### PR TITLE
Change QoS and listener operations naming to bring them in line with the rest of the API

### DIFF
--- a/src/core/ddsc/include/ddsc/dds_public_listener.h
+++ b/src/core/ddsc/include/ddsc/dds_public_listener.h
@@ -63,21 +63,25 @@ typedef struct c_listener dds_listener_t;
  * @return Returns a pointer to the allocated memory for dds_listener_t structure.
  */
 _Ret_notnull_
-DDS_EXPORT dds_listener_t* dds_listener_create (_In_opt_ void* arg);
+DDS_EXPORT dds_listener_t* dds_create_listener (_In_opt_ void* arg);
+_Ret_notnull_
+DDS_DEPRECATED_EXPORT dds_listener_t* dds_listener_create (_In_opt_ void* arg);
 
 /**
  * @brief Delete the memory allocated to listener structure
  *
  * @param[in] listener pointer to the listener struct to delete
  */
-DDS_EXPORT void dds_listener_delete (_In_ _Post_invalid_ dds_listener_t * __restrict listener);
+DDS_EXPORT void dds_delete_listener (_In_ _Post_invalid_ dds_listener_t * __restrict listener);
+DDS_DEPRECATED_EXPORT void dds_listener_delete (_In_ _Post_invalid_ dds_listener_t * __restrict listener);
 
 /**
  * @brief Reset the listener structure contents to ::DDS_LUNSET
  *
  * @param[in,out] listener pointer to the listener struct to reset
  */
-DDS_EXPORT void dds_listener_reset (_Out_ dds_listener_t * __restrict listener);
+DDS_EXPORT void dds_reset_listener (_Out_ dds_listener_t * __restrict listener);
+DDS_DEPRECATED_EXPORT void dds_listener_reset (_Out_ dds_listener_t * __restrict listener);
 
 /**
  * @brief Copy the listener callbacks from source to destination
@@ -85,7 +89,8 @@ DDS_EXPORT void dds_listener_reset (_Out_ dds_listener_t * __restrict listener);
  * @param[in,out] dst The pointer to the destination listener structure, where the content is to copied
  * @param[in] src The pointer to the source listener structure to be copied
  */
-DDS_EXPORT void dds_listener_copy (_Out_ dds_listener_t * __restrict dst, _In_ const dds_listener_t * __restrict src);
+DDS_EXPORT void dds_copy_listener (_Out_ dds_listener_t * __restrict dst, _In_ const dds_listener_t * __restrict src);
+DDS_DEPRECATED_EXPORT void dds_listener_copy (_Out_ dds_listener_t * __restrict dst, _In_ const dds_listener_t * __restrict src);
 
 /**
  * @brief Copy the listener callbacks from source to destination, unless already set
@@ -96,7 +101,8 @@ DDS_EXPORT void dds_listener_copy (_Out_ dds_listener_t * __restrict dst, _In_ c
  * @param[in,out] dst The pointer to the destination listener structure, where the content is merged
  * @param[in] src The pointer to the source listener structure to be copied
  */
-DDS_EXPORT void dds_listener_merge (_Inout_ dds_listener_t * __restrict dst, _In_ const dds_listener_t * __restrict src);
+DDS_EXPORT void dds_merge_listener (_Inout_ dds_listener_t * __restrict dst, _In_ const dds_listener_t * __restrict src);
+DDS_DEPRECATED_EXPORT void dds_listener_merge (_Inout_ dds_listener_t * __restrict dst, _In_ const dds_listener_t * __restrict src);
 
 
 /************************************************************************************************

--- a/src/core/ddsc/include/ddsc/dds_public_qos.h
+++ b/src/core/ddsc/include/ddsc/dds_public_qos.h
@@ -144,6 +144,9 @@ dds_presentation_access_scope_kind_t;
  */
 _Ret_notnull_
 DDS_EXPORT
+dds_qos_t * dds_create_qos (void);
+_Ret_notnull_
+DDS_DEPRECATED_EXPORT
 dds_qos_t * dds_qos_create (void);
 
 /**
@@ -152,6 +155,10 @@ dds_qos_t * dds_qos_create (void);
  * @param[in] qos - Pointer to dds_qos_t structure
  */
 DDS_EXPORT
+void dds_delete_qos (
+    _In_ _Post_invalid_ dds_qos_t * __restrict qos
+);
+DDS_DEPRECATED_EXPORT
 void dds_qos_delete (
     _In_ _Post_invalid_ dds_qos_t * __restrict qos
 );
@@ -161,7 +168,10 @@ void dds_qos_delete (
  *
  * @param[in,out] qos - Pointer to the dds_qos_t structure
  */
-DDS_EXPORT
+DDS_EXPORT void
+dds_reset_qos(
+    _Out_ dds_qos_t * __restrict qos);
+DDS_DEPRECATED_EXPORT
 void dds_qos_reset (
     _Out_ dds_qos_t * __restrict qos
 );
@@ -175,6 +185,11 @@ void dds_qos_reset (
  * @returns - Return-code indicating success or failure
  */
 DDS_EXPORT
+dds_return_t dds_copy_qos (
+    _Out_ dds_qos_t * __restrict dst,
+    _In_ const dds_qos_t * __restrict src
+);
+DDS_DEPRECATED_EXPORT
 dds_return_t dds_qos_copy (
     _Out_ dds_qos_t * __restrict dst,
     _In_ const dds_qos_t * __restrict src
@@ -189,6 +204,12 @@ dds_return_t dds_qos_copy (
  * @param[in] src - Pointer to the source qos structure
  */
 DDS_EXPORT
+void dds_merge_qos
+(
+    _Inout_ dds_qos_t * __restrict dst,
+    _In_ const dds_qos_t * __restrict src
+);
+DDS_DEPRECATED_EXPORT
 void dds_qos_merge
 (
     _Inout_ dds_qos_t * __restrict dst,

--- a/src/core/ddsc/src/dds_builtin.c
+++ b/src/core/ddsc/src/dds_builtin.c
@@ -152,12 +152,12 @@ dds__create_builtin_publisher(
     dds_qos_t *qos;
     const char *partition = "__BUILT-IN PARTITION__";
 
-    qos = dds_qos_create();
+    qos = dds_create_qos();
     dds_qset_partition(qos, 1, &partition);
 
     pub = dds_create_publisher(participant, qos, NULL);
 
-    dds_qos_delete(qos);
+    dds_delete_qos(qos);
 
     return pub;
 }
@@ -170,12 +170,12 @@ dds__create_builtin_subscriber(
     dds_qos_t *qos;
     const char *partition = "__BUILT-IN PARTITION__";
 
-    qos = dds_qos_create();
+    qos = dds_create_qos();
     dds_qset_partition(qos, 1, &partition);
 
     /* Create builtin-subscriber */
     sub = dds__create_subscriber_l(participant, qos, NULL);
-    dds_qos_delete(qos);
+    dds_delete_qos(qos);
 
     return sub;
 }
@@ -191,11 +191,11 @@ dds__create_builtin_writer(
         if (top > 0) {
             dds_qos_t *qos;
             // TODO: set builtin qos
-            qos = dds_qos_create();
+            qos = dds_create_qos();
             dds_qset_durability(qos, DDS_DURABILITY_TRANSIENT_LOCAL);
             dds_qset_reliability(qos, DDS_RELIABILITY_RELIABLE, DDS_MSECS(100));
             wr = dds_create_writer(pub, top, qos, NULL);
-            dds_qos_delete(qos);
+            dds_delete_qos(qos);
             (void)dds_delete(top);
         } else {
             wr = top;
@@ -323,12 +323,12 @@ dds__get_builtin_topic(
             DDS_REPORT_FLUSH(0);
             DDS_REPORT_STACK();
 
-            tqos = dds_qos_create();
+            tqos = dds_create_qos();
             dds_qset_durability(tqos, DDS_DURABILITY_TRANSIENT_LOCAL);
             dds_qset_presentation(tqos, DDS_PRESENTATION_TOPIC, false, false);
             dds_qset_reliability(tqos, DDS_RELIABILITY_RELIABLE, DDS_MSECS(100));
             ret = dds_create_topic(participant, desc, name, tqos, NULL);
-            dds_qos_delete(tqos);
+            dds_delete_qos(tqos);
         }
 
     } else {

--- a/src/core/ddsc/src/dds_entity.c
+++ b/src/core/ddsc/src/dds_entity.c
@@ -432,7 +432,7 @@ dds_delete_impl(
 
     if (ret == DDS_RETCODE_OK) {
         /* Destroy last few things. */
-        dds_qos_delete (e->m_qos);
+        dds_delete_qos (e->m_qos);
         os_condDestroy (&e->m_cond);
         os_mutexDestroy (&e->m_mutex);
         os_mutexDestroy (&e->m_observers_lock);
@@ -573,7 +573,7 @@ dds_get_qos(
         goto fail;
     }
     if (e->m_deriver.set_qos) {
-        rc = dds_qos_copy(qos, e->m_qos);
+        rc = dds_copy_qos(qos, e->m_qos);
     } else {
         rc = DDS_RETCODE_ILLEGAL_OPERATION;
         ret = DDS_ERRNO(rc, "QoS cannot be set on this entity");
@@ -609,9 +609,9 @@ dds_set_qos(
             if (ret == DDS_RETCODE_OK) {
                 /* Remember this QoS. */
                 if (e->m_qos == NULL) {
-                    e->m_qos = dds_qos_create();
+                    e->m_qos = dds_create_qos();
                 }
-                rc = dds_qos_copy(e->m_qos, qos);
+                rc = dds_copy_qos(e->m_qos, qos);
                 ret = DDS_ERRNO(rc, "QoS cannot be set on this entity");
             }
             dds_entity_unlock(e);

--- a/src/core/ddsc/src/dds_entity.c
+++ b/src/core/ddsc/src/dds_entity.c
@@ -260,9 +260,9 @@ dds_entity_init(
     }
 
     if (listener) {
-        dds_listener_copy(&e->m_listener, listener);
+        dds_copy_listener(&e->m_listener, listener);
     } else {
-        dds_listener_reset(&e->m_listener);
+        dds_reset_listener(&e->m_listener);
     }
 
     e->m_hdllink = NULL;
@@ -332,7 +332,7 @@ dds_delete_impl(
 
     ut_handle_close(e->m_hdl, e->m_hdllink);
     e->m_status_enable = 0;
-    dds_listener_reset(&e->m_listener);
+    dds_reset_listener(&e->m_listener);
     e->m_trigger |= DDS_DELETING_STATUS;
 
     dds_entity_unlock(e);
@@ -643,7 +643,7 @@ dds_get_listener(
         rc = dds_entity_lock(entity, DDS_KIND_DONTCARE, &e);
         if (rc == DDS_RETCODE_OK) {
             dds_entity_cb_wait(e);
-            dds_listener_copy (listener, &e->m_listener);
+            dds_copy_listener (listener, &e->m_listener);
             dds_entity_unlock(e);
         } else {
               ret = DDS_ERRNO(rc, "Error occurred on locking entity");
@@ -676,9 +676,9 @@ dds_set_listener(
     }
     dds_entity_cb_wait(e);
     if (listener) {
-        dds_listener_copy(&e->m_listener, listener);
+        dds_copy_listener(&e->m_listener, listener);
     } else {
-        dds_listener_reset(&e->m_listener);
+        dds_reset_listener(&e->m_listener);
     }
     dds_entity_unlock(e);
 fail:

--- a/src/core/ddsc/src/dds_listener.c
+++ b/src/core/ddsc/src/dds_listener.c
@@ -18,25 +18,37 @@
 
 _Ret_notnull_
 dds_listener_t*
-dds_listener_create(_In_opt_ void* arg)
+dds_create_listener(_In_opt_ void* arg)
 {
     c_listener_t *l = dds_alloc(sizeof(*l));
-    dds_listener_reset(l);
+    dds_reset_listener(l);
     l->arg = arg;
     return l;
 }
 
+_Ret_notnull_
+dds_listener_t*
+dds_listener_create(_In_opt_ void* arg)
+{
+    return dds_create_listener(arg);
+}
+
 void
-dds_listener_delete(_In_ _Post_invalid_ dds_listener_t * __restrict listener)
+dds_delete_listener(_In_ _Post_invalid_ dds_listener_t * __restrict listener)
 {
     if (listener) {
         dds_free(listener);
     }
 }
 
+void
+dds_listener_delete(_In_ _Post_invalid_ dds_listener_t * __restrict listener)
+{
+    dds_delete_listener(listener);
+}
 
 void
-dds_listener_reset(_Out_ dds_listener_t * __restrict listener)
+dds_reset_listener(_Out_ dds_listener_t * __restrict listener)
 {
     if (listener) {
         c_listener_t *l = listener;
@@ -59,7 +71,13 @@ dds_listener_reset(_Out_ dds_listener_t * __restrict listener)
 }
 
 void
-dds_listener_copy(_Out_ dds_listener_t * __restrict dst, _In_ const dds_listener_t * __restrict src)
+dds_listener_reset(_Out_ dds_listener_t * __restrict listener)
+{
+    dds_reset_listener(listener);
+}
+
+void
+dds_copy_listener(_Out_ dds_listener_t * __restrict dst, _In_ const dds_listener_t * __restrict src)
 {
     const c_listener_t *srcl = src;
     c_listener_t *dstl = dst;
@@ -89,7 +107,13 @@ dds_listener_copy(_Out_ dds_listener_t * __restrict dst, _In_ const dds_listener
 }
 
 void
-dds_listener_merge (_Inout_ dds_listener_t * __restrict dst, _In_ const dds_listener_t * __restrict src)
+dds_listener_copy(_Out_ dds_listener_t * __restrict dst, _In_ const dds_listener_t * __restrict src)
+{
+    dds_copy_listener(dst, src);
+}
+
+void
+dds_merge_listener (_Inout_ dds_listener_t * __restrict dst, _In_ const dds_listener_t * __restrict src)
 {
     const c_listener_t *srcl = src;
     c_listener_t *dstl = dst;
@@ -141,6 +165,12 @@ dds_listener_merge (_Inout_ dds_listener_t * __restrict dst, _In_ const dds_list
     if (dstl->on_subscription_matched == DDS_LUNSET) {
         dstl->on_subscription_matched = srcl->on_subscription_matched;
     }
+}
+
+void
+dds_listener_merge (_Inout_ dds_listener_t * __restrict dst, _In_ const dds_listener_t * __restrict src)
+{
+    dds_merge_listener(dst, src);
 }
 
 /************************************************************************************************

--- a/src/core/ddsc/src/dds_participant.c
+++ b/src/core/ddsc/src/dds_participant.c
@@ -170,18 +170,18 @@ dds_create_participant(
             e = (dds_entity_t)ret;
             goto fail_qos_validation;
         }
-        new_qos = dds_qos_create ();
+        new_qos = dds_create_qos ();
         /* Only returns failure when one of the qos args is NULL, which
          * is not the case here. */
-        (void)dds_qos_copy(new_qos, qos);
+        (void)dds_copy_qos(new_qos, qos);
     } else {
         /* Use default qos. */
-        new_qos = dds_qos_create ();
+        new_qos = dds_create_qos ();
     }
 
     /* Translate qos */
     nn_plist_init_empty(&plist);
-    dds_qos_merge (&plist.qos, new_qos);
+    dds_merge_qos (&plist.qos, new_qos);
 
     thr = lookup_thread_state ();
     asleep = !vtime_awake_p (thr->vtime);
@@ -225,7 +225,7 @@ dds_create_participant(
 fail_entity_init:
     dds_free(pp);
 fail_new_participant:
-    dds_qos_delete(new_qos);
+    dds_delete_qos(new_qos);
 fail_qos_validation:
 fail_domain_check:
     DDS_REPORT_FLUSH(true);

--- a/src/core/ddsc/src/dds_publisher.c
+++ b/src/core/ddsc/src/dds_publisher.c
@@ -112,10 +112,10 @@ dds_create_publisher(
             hdl = ret;
             goto qos_err;
         }
-        new_qos = dds_qos_create ();
+        new_qos = dds_create_qos ();
         /* Only returns failure when one of the qos args is NULL, which
          * is not the case here. */
-        (void)dds_qos_copy(new_qos, qos);
+        (void)dds_copy_qos(new_qos, qos);
     }
 
     /* Create publisher */

--- a/src/core/ddsc/src/dds_qos.c
+++ b/src/core/ddsc/src/dds_qos.c
@@ -194,15 +194,21 @@ dds_qos_init_defaults (
 }
 
 _Ret_notnull_
-dds_qos_t * dds_qos_create (void)
+dds_qos_t * dds_create_qos (void)
 {
     dds_qos_t *qos = dds_alloc (sizeof (dds_qos_t));
     dds_qos_init_defaults (qos);
     return qos;
 }
 
+_Ret_notnull_
+dds_qos_t * dds_qos_create (void)
+{
+    return dds_create_qos ();
+}
+
 void
-dds_qos_reset(
+dds_reset_qos(
     _Out_ dds_qos_t * __restrict qos)
 {
     if (qos) {
@@ -214,17 +220,31 @@ dds_qos_reset(
 }
 
 void
-dds_qos_delete(
+dds_qos_reset(
+    _Out_ dds_qos_t * __restrict qos)
+{
+    dds_reset_qos (qos);
+}
+
+void
+dds_delete_qos(
     _In_ _Post_invalid_ dds_qos_t * __restrict qos)
 {
     if (qos) {
-        dds_qos_reset(qos);
+        dds_reset_qos(qos);
         dds_free(qos);
     }
 }
 
+void
+dds_qos_delete(
+    _In_ _Post_invalid_ dds_qos_t * __restrict qos)
+{
+    dds_delete_qos (qos);
+}
+
 dds_return_t
-dds_qos_copy (
+dds_copy_qos (
     _Out_ dds_qos_t * __restrict dst,
     _In_ const dds_qos_t * __restrict src)
 {
@@ -238,7 +258,15 @@ dds_qos_copy (
     return DDS_RETCODE_OK;
 }
 
-void dds_qos_merge (
+dds_return_t
+dds_qos_copy (
+    _Out_ dds_qos_t * __restrict dst,
+    _In_ const dds_qos_t * __restrict src)
+{
+    return dds_copy_qos (dst, src);
+}
+
+void dds_merge_qos (
     _Inout_ dds_qos_t * __restrict dst,
     _In_ const dds_qos_t * __restrict src)
 {
@@ -252,6 +280,13 @@ void dds_qos_merge (
     }
     /* Copy qos from source to destination unless already set */
     nn_xqos_mergein_missing (dst, src);
+}
+
+void dds_qos_merge (
+    _Inout_ dds_qos_t * __restrict dst,
+    _In_ const dds_qos_t * __restrict src)
+{
+    dds_merge_qos (dst, src);
 }
 
 bool dds_qos_equal (

--- a/src/core/ddsc/src/dds_reader.c
+++ b/src/core/ddsc/src/dds_reader.c
@@ -399,19 +399,19 @@ dds_create_reader(
     assert (sub->m_domain == tp->m_domain);
 
     /* Merge qos from topic and subscriber */
-    rqos = dds_qos_create ();
+    rqos = dds_create_qos ();
     if (qos) {
         /* Only returns failure when one of the qos args is NULL, which
          * is not the case here. */
-        (void)dds_qos_copy(rqos, qos);
+        (void)dds_copy_qos(rqos, qos);
     }
 
     if(sub->m_qos){
-        dds_qos_merge (rqos, sub->m_qos);
+        dds_merge_qos (rqos, sub->m_qos);
     }
 
     if (tp->m_qos) {
-        dds_qos_merge (rqos, tp->m_qos);
+        dds_merge_qos (rqos, tp->m_qos);
 
         /* reset the following qos policies if set during topic qos merge as they aren't applicable for reader */
         rqos->present &= ~(QP_DURABILITY_SERVICE | QP_TRANSPORT_PRIORITY | QP_LIFESPAN);
@@ -420,7 +420,7 @@ dds_create_reader(
 
     ret = dds_reader_qos_validate (rqos, false);
     if (ret != 0) {
-        dds_qos_delete(rqos);
+        dds_delete_qos(rqos);
         reader = ret;
         goto err_bad_qos;
     }

--- a/src/core/ddsc/src/dds_subscriber.c
+++ b/src/core/ddsc/src/dds_subscriber.c
@@ -125,10 +125,10 @@ dds__create_subscriber_l(
         if ((ret = dds__subscriber_qos_validate(qos, false)) != DDS_RETCODE_OK) {
             goto err_param;
         }
-        new_qos = dds_qos_create();
+        new_qos = dds_create_qos();
         /* Only returns failure when one of the qos args is NULL, which
          * is not the case here. */
-        (void)dds_qos_copy(new_qos, qos);
+        (void)dds_copy_qos(new_qos, qos);
     } else {
         new_qos = NULL;
     }

--- a/src/core/ddsc/src/dds_topic.c
+++ b/src/core/ddsc/src/dds_topic.c
@@ -398,10 +398,10 @@ dds_create_topic(
         strcat (key, typename);
 
         if (qos) {
-            new_qos = dds_qos_create();
+            new_qos = dds_create_qos();
             /* Only returns failure when one of the qos args is NULL, which
              * is not the case here. */
-            (void)dds_qos_copy(new_qos, qos);
+            (void)dds_copy_qos(new_qos, qos);
         }
 
         /* Create topic */
@@ -445,7 +445,7 @@ dds_create_topic(
 
         nn_plist_init_empty (&plist);
         if (new_qos) {
-            dds_qos_merge (&plist.qos, new_qos);
+            dds_merge_qos (&plist.qos, new_qos);
         }
 
         /* Set Topic meta data (for SEDP publication) */

--- a/src/core/ddsc/src/dds_writer.c
+++ b/src/core/ddsc/src/dds_writer.c
@@ -448,26 +448,26 @@ dds_create_writer(
     assert(pub->m_domain == tp->m_domain);
 
     /* Merge Topic & Publisher qos */
-    wqos = dds_qos_create();
+    wqos = dds_create_qos();
     if (qos) {
         /* Only returns failure when one of the qos args is NULL, which
          * is not the case here. */
-        (void)dds_qos_copy(wqos, qos);
+        (void)dds_copy_qos(wqos, qos);
     }
 
     if (pub->m_qos) {
-        dds_qos_merge(wqos, pub->m_qos);
+        dds_merge_qos(wqos, pub->m_qos);
     }
 
     if (tp->m_qos) {
         /* merge topic qos data to writer qos */
-        dds_qos_merge(wqos, tp->m_qos);
+        dds_merge_qos(wqos, tp->m_qos);
     }
     nn_xqos_mergein_missing(wqos, &gv.default_xqos_wr);
 
     ret = dds_writer_qos_validate(wqos, false);
     if (ret != 0) {
-        dds_qos_delete(wqos);
+        dds_delete_qos(wqos);
         writer = ret;
         goto err_bad_qos;
     }

--- a/src/core/ddsc/tests/builtin_topics.c
+++ b/src/core/ddsc/tests/builtin_topics.c
@@ -58,7 +58,7 @@ static dds_qos_t *g_qos = NULL;
 static void
 qos_init(void)
 {
-    g_qos = dds_qos_create();
+    g_qos = dds_create_qos();
     cr_assert_not_null(g_qos);
 
     g_pol_userdata.value._buffer = dds_alloc(strlen(c_userdata) + 1);
@@ -137,7 +137,7 @@ qos_init(void)
 static void
 qos_fini(void)
 {
-    dds_qos_delete(g_qos);
+    dds_delete_qos(g_qos);
     dds_free(g_pol_userdata.value._buffer);
     dds_free(g_pol_groupdata.value._buffer);
     dds_free(g_pol_topicdata.value._buffer);
@@ -196,7 +196,7 @@ check_default_qos_of_builtin_entity(dds_entity_t entity)
   char **partitions;
   uint32_t plen;
 
-  dds_qos_t *qos = dds_qos_create();
+  dds_qos_t *qos = dds_create_qos();
   cr_assert_not_null(qos);
 
   ret = dds_get_qos(entity, qos);
@@ -249,7 +249,7 @@ check_default_qos_of_builtin_entity(dds_entity_t entity)
       }
       dds_free(partitions);
   }
-  dds_qos_delete(qos);
+  dds_delete_qos(qos);
 }
 
 static dds_entity_t builtin_topic_handles[10];

--- a/src/core/ddsc/tests/dispose.c
+++ b/src/core/ddsc/tests/dispose.c
@@ -62,7 +62,7 @@ static void
 disposing_init(void)
 {
     Space_Type1 sample = { 0, 0, 0 };
-    dds_qos_t *qos = dds_qos_create ();
+    dds_qos_t *qos = dds_create_qos ();
     dds_attach_t triggered;
     dds_return_t ret;
     char name[100];
@@ -132,7 +132,7 @@ disposing_init(void)
     g_present = dds_time();
     g_past    = g_present - DDS_SECS(1);
 
-    dds_qos_delete(qos);
+    dds_delete_qos(qos);
 }
 
 static void

--- a/src/core/ddsc/tests/entity_api.c
+++ b/src/core/ddsc/tests/entity_api.c
@@ -72,7 +72,7 @@ Test(ddsc_entity, enable, .init = create_entity, .fini = delete_entity)
 void entity_qos_get_set(dds_entity_t e, const char* info)
 {
     dds_return_t status;
-    dds_qos_t *qos = dds_qos_create();
+    dds_qos_t *qos = dds_create_qos();
 
     /* Get QoS. */
     status = dds_get_qos (e, qos);
@@ -81,13 +81,13 @@ void entity_qos_get_set(dds_entity_t e, const char* info)
     status = dds_set_qos (e, qos); /* Doesn't change anything, so no need to forbid. But we return NOT_SUPPORTED anyway for now*/
     cr_assert_status_eq(status, DDS_RETCODE_UNSUPPORTED, "dds_set_qos(entity, qos) %s", info);
 
-    dds_qos_delete(qos);
+    dds_delete_qos(qos);
 }
 
 Test(ddsc_entity, qos, .init = create_entity, .fini = delete_entity)
 {
     dds_return_t status;
-    dds_qos_t *qos = dds_qos_create();
+    dds_qos_t *qos = dds_create_qos();
 
     /* Don't check inconsistent and immutable policies. That's a job
      * for the specific entity children, not for the generic part. */
@@ -119,7 +119,7 @@ Test(ddsc_entity, qos, .init = create_entity, .fini = delete_entity)
     }
 
     /* Delete qos. */
-    dds_qos_delete(qos);
+    dds_delete_qos(qos);
 }
 
 Test(ddsc_entity, listener, .init = create_entity, .fini = delete_entity)

--- a/src/core/ddsc/tests/entity_api.c
+++ b/src/core/ddsc/tests/entity_api.c
@@ -125,8 +125,8 @@ Test(ddsc_entity, qos, .init = create_entity, .fini = delete_entity)
 Test(ddsc_entity, listener, .init = create_entity, .fini = delete_entity)
 {
     dds_return_t status;
-    dds_listener_t *l1 = dds_listener_create(NULL);
-    dds_listener_t *l2 = dds_listener_create(NULL);
+    dds_listener_t *l1 = dds_create_listener(NULL);
+    dds_listener_t *l2 = dds_create_listener(NULL);
     void *cb1;
     void *cb2;
 

--- a/src/core/ddsc/tests/entity_status.c
+++ b/src/core/ddsc/tests/entity_status.c
@@ -71,7 +71,7 @@ init_entity_status(void)
     top = dds_create_topic(participant, &RoundTripModule_DataType_desc, create_topic_name("ddsc_status_test", topicName, 100), NULL, NULL);
     cr_assert_gt(top, 0, "Failed to create prerequisite topic");
 
-    qos = dds_qos_create();
+    qos = dds_create_qos();
     cr_assert_not_null(qos, "Failed to create prerequisite qos");
     dds_qset_resource_limits (qos, resource_limits.max_samples, resource_limits.max_instances, resource_limits.max_samples_per_instance);
     dds_qset_reliability(qos, DDS_RELIABILITY_BEST_EFFORT, DDS_MSECS(100));
@@ -113,7 +113,7 @@ fini_entity_status(void)
     dds_delete(wri);
     dds_delete(publisher);
     dds_delete(rea);
-    dds_qos_delete(qos);
+    dds_delete_qos(qos);
     dds_delete(top);
     dds_delete(subscriber);
     dds_delete(participant);

--- a/src/core/ddsc/tests/listener.c
+++ b/src/core/ddsc/tests/listener.c
@@ -344,7 +344,7 @@ init_triggering_base(void)
     g_listener = dds_listener_create(NULL);
     cr_assert_not_null(g_listener, "Failed to create prerequisite g_listener");
 
-    g_qos = dds_qos_create();
+    g_qos = dds_create_qos();
     cr_assert_not_null(g_qos, "Failed to create prerequisite g_qos");
     dds_qset_reliability(g_qos, DDS_RELIABILITY_RELIABLE, DDS_SECS(1));
     dds_qset_history(g_qos, DDS_HISTORY_KEEP_ALL, 0);
@@ -384,7 +384,7 @@ init_triggering_test(void)
 static void
 fini_triggering_base(void)
 {
-    dds_qos_delete(g_qos);
+    dds_delete_qos(g_qos);
     dds_listener_delete(g_listener);
     dds_delete(g_participant);
     os_condDestroy(&g_cond);
@@ -1019,7 +1019,7 @@ Test(ddsc_listener, inconsistent_topic, .init=init_triggering_base, .fini=fini_t
     os_mutexInit(&g_mutex);
     os_condInit(&g_cond, &g_mutex);
 
-    g_qos = dds_qos_create();
+    g_qos = dds_create_qos();
     cr_assert_not_null(g_qos, "Failed to create prerequisite g_qos");
 
     g_listener = dds_listener_create(NULL);
@@ -1056,7 +1056,7 @@ Test(ddsc_listener, inconsistent_topic, .init=init_triggering_base, .fini=fini_t
     dds_delete(g_participant);
 
     dds_listener_delete(g_listener);
-    dds_qos_delete(g_qos);
+    dds_delete_qos(g_qos);
 }
 #endif
 #endif

--- a/src/core/ddsc/tests/listener.c
+++ b/src/core/ddsc/tests/listener.c
@@ -341,7 +341,7 @@ init_triggering_base(void)
     g_topic = dds_create_topic(g_participant, &RoundTripModule_DataType_desc, create_topic_name("ddsc_listener_test", name, 100), NULL, NULL);
     cr_assert_gt(g_topic, 0, "Failed to create prerequisite g_topic");
 
-    g_listener = dds_listener_create(NULL);
+    g_listener = dds_create_listener(NULL);
     cr_assert_not_null(g_listener, "Failed to create prerequisite g_listener");
 
     g_qos = dds_create_qos();
@@ -385,7 +385,7 @@ static void
 fini_triggering_base(void)
 {
     dds_delete_qos(g_qos);
-    dds_listener_delete(g_listener);
+    dds_delete_listener(g_listener);
     dds_delete(g_participant);
     os_condDestroy(&g_cond);
     os_mutexDestroy(&g_mutex);
@@ -410,7 +410,7 @@ Test(ddsc_listener, create_and_delete)
 {
     /* Verify create doesn't return null */
     dds_listener_t *listener;
-    listener = dds_listener_create(NULL);
+    listener = dds_create_listener(NULL);
     cr_assert_not_null(listener);
 
     /* Check default cb's are set */
@@ -428,16 +428,16 @@ Test(ddsc_listener, create_and_delete)
     ASSERT_CALLBACK_EQUAL(subscription_matched, listener, DDS_LUNSET);
     ASSERT_CALLBACK_EQUAL(data_available, listener, DDS_LUNSET);
 
-    dds_listener_delete(listener);
+    dds_delete_listener(listener);
     OS_WARNING_MSVC_OFF(6387); /* Disable SAL warning on intentional misuse of the API */
-    dds_listener_delete(NULL);
+    dds_delete_listener(NULL);
     OS_WARNING_MSVC_ON(6387);
 }
 
 Test(ddsc_listener, reset)
 {
     dds_listener_t *listener;
-    listener = dds_listener_create(NULL);
+    listener = dds_create_listener(NULL);
     cr_assert_not_null(listener);
 
     /* Set a listener cb to a non-default value */
@@ -445,20 +445,20 @@ Test(ddsc_listener, reset)
     ASSERT_CALLBACK_EQUAL(data_available, listener, NULL);
 
     /* Listener cb should revert to default after reset */
-    dds_listener_reset(listener);
+    dds_reset_listener(listener);
     ASSERT_CALLBACK_EQUAL(data_available, listener, DDS_LUNSET);
 
     /* Resetting a NULL listener should not crash */
-    dds_listener_reset(NULL);
+    dds_reset_listener(NULL);
 
-    dds_listener_delete(listener);
+    dds_delete_listener(listener);
 }
 
 Test(ddsc_listener, copy)
 {
     dds_listener_t *listener1 = NULL, *listener2 = NULL;
-    listener1 = dds_listener_create(NULL);
-    listener2 = dds_listener_create(NULL);
+    listener1 = dds_create_listener(NULL);
+    listener2 = dds_create_listener(NULL);
     cr_assert_not_null(listener1);
     cr_assert_not_null(listener2);
 
@@ -471,7 +471,7 @@ Test(ddsc_listener, copy)
     ASSERT_CALLBACK_EQUAL(sample_lost, listener2, DDS_LUNSET);
 
     /* Cb's should be copied to listener2 */
-    dds_listener_copy(listener2, listener1);
+    dds_copy_listener(listener2, listener1);
     ASSERT_CALLBACK_EQUAL(data_available, listener1, NULL);
     ASSERT_CALLBACK_EQUAL(data_available, listener2, NULL);
     ASSERT_CALLBACK_EQUAL(sample_lost, listener1, sample_lost_cb);
@@ -479,20 +479,20 @@ Test(ddsc_listener, copy)
 
     /* Calling copy with NULL should not crash and be noops. */
     OS_WARNING_MSVC_OFF(6387); /* Disable SAL warning on intentional misuse of the API */
-    dds_listener_copy(listener2, NULL);
-    dds_listener_copy(NULL, listener1);
-    dds_listener_copy(NULL, NULL);
+    dds_copy_listener(listener2, NULL);
+    dds_copy_listener(NULL, listener1);
+    dds_copy_listener(NULL, NULL);
     OS_WARNING_MSVC_ON(6387);
 
-    dds_listener_delete(listener1);
-    dds_listener_delete(listener2);
+    dds_delete_listener(listener1);
+    dds_delete_listener(listener2);
 }
 
 Test(ddsc_listener, merge)
 {
     dds_listener_t *listener1 = NULL, *listener2 = NULL;
-    listener1 = dds_listener_create(NULL);
-    listener2 = dds_listener_create(NULL);
+    listener1 = dds_create_listener(NULL);
+    listener2 = dds_create_listener(NULL);
     cr_assert_not_null(listener1);
     cr_assert_not_null(listener2);
 
@@ -512,7 +512,7 @@ Test(ddsc_listener, merge)
     dds_lset_subscription_matched       (listener1, subscription_matched_cb);
 
     /* Merging listener1 into empty listener2 should act a bit like a copy. */
-    dds_listener_merge(listener2, listener1);
+    dds_merge_listener(listener2, listener1);
     ASSERT_CALLBACK_EQUAL(inconsistent_topic,           listener2, inconsistent_topic_cb);
     ASSERT_CALLBACK_EQUAL(liveliness_lost,              listener2, liveliness_lost_cb);
     ASSERT_CALLBACK_EQUAL(offered_deadline_missed,      listener2, offered_deadline_missed_cb);
@@ -541,7 +541,7 @@ Test(ddsc_listener, merge)
     dds_lset_requested_incompatible_qos (listener2, (dds_on_requested_incompatible_qos_fn)callback_dummy);
     dds_lset_publication_matched        (listener2, (dds_on_publication_matched_fn)callback_dummy);
     dds_lset_subscription_matched       (listener2, (dds_on_subscription_matched_fn)callback_dummy);
-    dds_listener_merge(listener2, listener1);
+    dds_merge_listener(listener2, listener1);
     ASSERT_CALLBACK_EQUAL(inconsistent_topic,           listener2, (dds_on_inconsistent_topic_fn)callback_dummy);
     ASSERT_CALLBACK_EQUAL(liveliness_lost,              listener2, (dds_on_liveliness_lost_fn)callback_dummy);
     ASSERT_CALLBACK_EQUAL(offered_deadline_missed,      listener2, (dds_on_offered_deadline_missed_fn)callback_dummy);
@@ -557,18 +557,18 @@ Test(ddsc_listener, merge)
     ASSERT_CALLBACK_EQUAL(subscription_matched,         listener2, (dds_on_subscription_matched_fn)callback_dummy);
 
     /* Using NULLs shouldn't crash and be noops. */
-    dds_listener_merge(listener2, NULL);
-    dds_listener_merge(NULL, listener1);
-    dds_listener_merge(NULL, NULL);
+    dds_merge_listener(listener2, NULL);
+    dds_merge_listener(NULL, listener1);
+    dds_merge_listener(NULL, NULL);
 
-    dds_listener_delete(listener1);
-    dds_listener_delete(listener2);
+    dds_delete_listener(listener1);
+    dds_delete_listener(listener2);
 }
 
 Test(ddsc_listener, getters_setters)
 {
     /* test all individual cb get/set methods */
-    dds_listener_t *listener = dds_listener_create(NULL);
+    dds_listener_t *listener = dds_create_listener(NULL);
     cr_assert_not_null(listener);
 
     OS_WARNING_MSVC_OFF(6387); /* Disable SAL warning on intentional misuse of the API */ \
@@ -587,7 +587,7 @@ Test(ddsc_listener, getters_setters)
     TEST_GET_SET(listener, data_available, data_available_cb);
     OS_WARNING_MSVC_ON(6387);
 
-    dds_listener_delete(listener);
+    dds_delete_listener(listener);
 }
 
 
@@ -606,28 +606,28 @@ Test(ddsc_listener, propagation, .init=init_triggering_base, .fini=fini_triggeri
     memset (&sample, 0, sizeof (sample));
 
     /* Let participant be interested in data. */
-    listener_par = dds_listener_create(NULL);
+    listener_par = dds_create_listener(NULL);
     cr_assert_not_null(listener_par, "Failed to create prerequisite listener_par");
     dds_lset_data_on_readers(listener_par, data_on_readers_cb);
     ret = dds_set_listener(g_participant, listener_par);
     cr_assert_eq(ret, DDS_RETCODE_OK, "Failed to set prerequisite listener_par");
-    dds_listener_delete(listener_par);
+    dds_delete_listener(listener_par);
 
     /* Let publisher be interested in publication matched. */
-    listener_pub = dds_listener_create(NULL);
+    listener_pub = dds_create_listener(NULL);
     cr_assert_not_null(listener_pub, "Failed to create prerequisite listener_pub");
     dds_lset_publication_matched(listener_pub, publication_matched_cb);
     ret = dds_set_listener(g_publisher, listener_pub);
     cr_assert_eq(ret, DDS_RETCODE_OK, "Failed to set prerequisite listener_pub");
-    dds_listener_delete(listener_pub);
+    dds_delete_listener(listener_pub);
 
     /* Let subscriber be interested in subscription matched. */
-    listener_sub = dds_listener_create(NULL);
+    listener_sub = dds_create_listener(NULL);
     cr_assert_not_null(listener_pub, "Failed to create prerequisite listener_sub");
     dds_lset_subscription_matched(listener_sub, subscription_matched_cb);
     ret = dds_set_listener(g_subscriber, listener_sub);
     cr_assert_eq(ret, DDS_RETCODE_OK, "Failed to set prerequisite listener_sub");
-    dds_listener_delete(listener_sub);
+    dds_delete_listener(listener_sub);
 
     /* Create reader and writer without listeners. */
     g_reader = dds_create_reader(g_subscriber, g_topic, g_qos, NULL);
@@ -1022,7 +1022,7 @@ Test(ddsc_listener, inconsistent_topic, .init=init_triggering_base, .fini=fini_t
     g_qos = dds_create_qos();
     cr_assert_not_null(g_qos, "Failed to create prerequisite g_qos");
 
-    g_listener = dds_listener_create(NULL);
+    g_listener = dds_create_listener(NULL);
     cr_assert_not_null(g_listener, "Failed to create prerequisite g_listener");
 
     g_participant = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL, NULL);
@@ -1055,7 +1055,7 @@ Test(ddsc_listener, inconsistent_topic, .init=init_triggering_base, .fini=fini_t
     dds_delete(wr_topic);
     dds_delete(g_participant);
 
-    dds_listener_delete(g_listener);
+    dds_delete_listener(g_listener);
     dds_delete_qos(g_qos);
 }
 #endif

--- a/src/core/ddsc/tests/publisher.c
+++ b/src/core/ddsc/tests/publisher.c
@@ -95,13 +95,13 @@ Test(ddsc_publisher, create)
 #endif
 
   /* Use listener(NULL) */
-  listener = dds_listener_create(NULL);
-  cr_assert_neq(listener, NULL, "dds_listener_create(NULL)");
+  listener = dds_create_listener(NULL);
+  cr_assert_neq(listener, NULL, "dds_create_listener(NULL)");
   publisher = dds_create_publisher(participant, NULL, listener);
   cr_assert_gt(publisher, 0, "dds_create_publisher(participant,NULL,listener(NULL))");
   dds_delete(publisher);
 
-  dds_listener_reset(listener);
+  dds_reset_listener(listener);
 
   /* Use listener for data_available */
   dds_lset_data_available(listener, NULL);
@@ -109,7 +109,7 @@ Test(ddsc_publisher, create)
   cr_assert_gt(publisher, 0, "dds_create_publisher(participant,NULL,listener) with dds_lset_data_available(listener, NULL)");
   dds_delete(publisher);
 
-  dds_listener_reset(listener);
+  dds_reset_listener(listener);
 
   /* Use DDS_LUNSET for data_available */
   dds_lset_data_available(listener, DDS_LUNSET);
@@ -117,7 +117,7 @@ Test(ddsc_publisher, create)
   cr_assert_gt(publisher, 0, "dds_create_publisher(participant,NULL,listener) with dds_lset_data_available(listener, DDS_LUNSET)");
   dds_delete(publisher);
 
-  dds_listener_reset(listener);
+  dds_reset_listener(listener);
 
   /* Use callback for data_available */
   dds_lset_data_available(listener, data_available_cb);
@@ -131,7 +131,7 @@ Test(ddsc_publisher, create)
   cr_assert_gt(publisher, 0, "dds_create_publisher(participant,qos,listener) with dds_lset_data_available(listener, data_available_cb)");
   dds_delete(publisher);
 
-  dds_listener_delete(listener);
+  dds_delete_listener(listener);
   dds_delete_qos(qos);
   dds_delete (participant);
 }

--- a/src/core/ddsc/tests/publisher.c
+++ b/src/core/ddsc/tests/publisher.c
@@ -58,8 +58,8 @@ Test(ddsc_publisher, create)
   dds_delete(publisher);
 
   /* Create a non-null qos */
-  qos = dds_qos_create();
-  cr_assert_neq(qos, NULL, "dds_qos_create()");
+  qos = dds_create_qos();
+  cr_assert_neq(qos, NULL, "dds_create_qos()");
 
   /* Use qos without partition; in that case the default partition should be used */
   publisher = dds_create_publisher(participant, qos, NULL);
@@ -132,7 +132,7 @@ Test(ddsc_publisher, create)
   dds_delete(publisher);
 
   dds_listener_delete(listener);
-  dds_qos_delete(qos);
+  dds_delete_qos(qos);
   dds_delete (participant);
 }
 

--- a/src/core/ddsc/tests/qos.c
+++ b/src/core/ddsc/tests/qos.c
@@ -168,7 +168,7 @@ static dds_qos_t *g_qos = NULL;
 static void
 qos_init(void)
 {
-    g_qos = dds_qos_create();
+    g_qos = dds_create_qos();
     cr_assert_not_null(g_qos);
 
     g_pol_userdata.value = (void*)c_userdata;
@@ -234,7 +234,7 @@ qos_init(void)
 static void
 qos_fini(void)
 {
-    dds_qos_delete(g_qos);
+    dds_delete_qos(g_qos);
 }
 
 /****************************************************************************

--- a/src/core/ddsc/tests/querycondition.c
+++ b/src/core/ddsc/tests/querycondition.c
@@ -90,7 +90,7 @@ static void
 querycondition_init(void)
 {
     Space_Type1 sample = { 0, 0, 0 };
-    dds_qos_t *qos = dds_qos_create ();
+    dds_qos_t *qos = dds_create_qos ();
     dds_attach_t triggered;
     dds_return_t ret;
     char name[100];
@@ -198,7 +198,7 @@ querycondition_init(void)
         }
     }
 
-    dds_qos_delete(qos);
+    dds_delete_qos(qos);
 }
 
 static void

--- a/src/core/ddsc/tests/read_instance.c
+++ b/src/core/ddsc/tests/read_instance.c
@@ -94,7 +94,7 @@ read_instance_init(void)
     char name[100];
     dds_qos_t *qos;
 
-    qos = dds_qos_create();
+    qos = dds_create_qos();
     cr_assert_not_null(qos, "Failed to create prerequisite qos");
 
     g_participant = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL, NULL);
@@ -256,7 +256,7 @@ read_instance_init(void)
     g_hdl_valid = dds_instance_lookup(g_reader, &sample);
     cr_assert_neq(g_hdl_valid, DDS_HANDLE_NIL, "Failed prerequisite dds_instance_lookup");
 
-    dds_qos_delete(qos);
+    dds_delete_qos(qos);
 }
 
 static void

--- a/src/core/ddsc/tests/readcondition.c
+++ b/src/core/ddsc/tests/readcondition.c
@@ -83,7 +83,7 @@ static void
 readcondition_init(void)
 {
     Space_Type1 sample = { 0, 0, 0 };
-    dds_qos_t *qos = dds_qos_create ();
+    dds_qos_t *qos = dds_create_qos ();
     dds_attach_t triggered;
     dds_return_t ret;
     char name[100];
@@ -191,7 +191,7 @@ readcondition_init(void)
         }
     }
 
-    dds_qos_delete(qos);
+    dds_delete_qos(qos);
 }
 
 static void

--- a/src/core/ddsc/tests/reader.c
+++ b/src/core/ddsc/tests/reader.c
@@ -89,7 +89,7 @@ reader_init(void)
     dds_return_t ret;
     char name[100];
 
-    g_qos = dds_qos_create();
+    g_qos = dds_create_qos();
     g_listener = dds_listener_create(NULL);
 
     g_participant = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL, NULL);
@@ -205,7 +205,7 @@ reader_init(void)
 static void
 reader_fini(void)
 {
-    dds_qos_delete(g_qos);
+    dds_delete_qos(g_qos);
     dds_listener_delete(g_listener);
     dds_delete(g_reader);
     dds_delete(g_writer);
@@ -249,14 +249,14 @@ Theory((dds_entity_t *ent, dds_qos_t **qos, dds_listener_t **listener), ddsc_rea
 Test(ddsc_reader_create, invalid_qos_participant, .init=reader_init, .fini=reader_fini)
 {
     dds_entity_t rdr;
-    dds_qos_t *qos = dds_qos_create();
+    dds_qos_t *qos = dds_create_qos();
     /* Set invalid reader data lifecycle policy */
     OS_WARNING_MSVC_OFF(28020); /* Disable SAL warning on intentional misuse of the API */
     dds_qset_reader_data_lifecycle(qos, DDS_SECS(-1), DDS_SECS(-1));
     OS_WARNING_MSVC_ON(28020);
     rdr = dds_create_reader(g_participant, g_topic, qos, NULL);
     cr_assert_eq(dds_err_nr(rdr), DDS_RETCODE_INCONSISTENT_POLICY, "returned %d", dds_err_nr(rdr));
-    dds_qos_delete(qos);
+    dds_delete_qos(qos);
 }
 /*************************************************************************************************/
 
@@ -264,14 +264,14 @@ Test(ddsc_reader_create, invalid_qos_participant, .init=reader_init, .fini=reade
 Test(ddsc_reader_create, invalid_qos_subscriber, .init=reader_init, .fini=reader_fini)
 {
     dds_entity_t rdr;
-    dds_qos_t *qos = dds_qos_create();
+    dds_qos_t *qos = dds_create_qos();
     /* Set invalid reader data lifecycle policy */
     OS_WARNING_MSVC_OFF(28020); /* Disable SAL warning on intentional misuse of the API */
     dds_qset_reader_data_lifecycle(qos, DDS_SECS(-1), DDS_SECS(-1));
     OS_WARNING_MSVC_ON(28020);
     rdr = dds_create_reader(g_subscriber, g_topic, qos, NULL);
     cr_assert_eq(dds_err_nr(rdr), DDS_RETCODE_INCONSISTENT_POLICY, "returned %d", dds_err_nr(rdr));
-    dds_qos_delete(qos);
+    dds_delete_qos(qos);
 }
 /*************************************************************************************************/
 
@@ -2506,7 +2506,7 @@ Test(ddsc_take_mask, take_instance_last_sample)
     char name[100];
 
     /* We need other readers/writers/data to force the crash. */
-    g_qos = dds_qos_create();
+    g_qos = dds_create_qos();
     dds_qset_history(g_qos, DDS_HISTORY_KEEP_ALL, DDS_LENGTH_UNLIMITED);
     g_participant = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL, NULL);
     cr_assert_gt(g_participant, 0, "Failed to create prerequisite g_participant");
@@ -2606,7 +2606,7 @@ Test(ddsc_take_mask, take_instance_last_sample)
     dds_delete(g_waitset);
     dds_delete(g_topic);
     dds_delete(g_participant);
-    dds_qos_delete(g_qos);
+    dds_delete_qos(g_qos);
 }
 /*************************************************************************************************/
 

--- a/src/core/ddsc/tests/reader.c
+++ b/src/core/ddsc/tests/reader.c
@@ -90,7 +90,7 @@ reader_init(void)
     char name[100];
 
     g_qos = dds_create_qos();
-    g_listener = dds_listener_create(NULL);
+    g_listener = dds_create_listener(NULL);
 
     g_participant = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL, NULL);
     cr_assert_gt(g_participant, 0, "Failed to create prerequisite g_participant");
@@ -206,7 +206,7 @@ static void
 reader_fini(void)
 {
     dds_delete_qos(g_qos);
-    dds_listener_delete(g_listener);
+    dds_delete_listener(g_listener);
     dds_delete(g_reader);
     dds_delete(g_writer);
     dds_delete(g_waitset);

--- a/src/core/ddsc/tests/reader_iterator.c
+++ b/src/core/ddsc/tests/reader_iterator.c
@@ -131,7 +131,7 @@ reader_iterator_init(void)
     char name[100];
     dds_qos_t *qos;
 
-    qos = dds_qos_create();
+    qos = dds_create_qos();
     cr_assert_not_null(qos, "Failed to create prerequisite qos");
 
     g_participant = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL, NULL);
@@ -308,7 +308,7 @@ reader_iterator_init(void)
      *    |    6   |   20   |   40   |     read | old | no_writers |
      */
 
-    dds_qos_delete(qos);
+    dds_delete_qos(qos);
 }
 
 static void

--- a/src/core/ddsc/tests/register.c
+++ b/src/core/ddsc/tests/register.c
@@ -54,7 +54,7 @@ static void
 registering_init(void)
 {
     Space_Type1 sample = { 0, 0, 0 };
-    dds_qos_t *qos = dds_qos_create ();
+    dds_qos_t *qos = dds_create_qos ();
     dds_attach_t triggered;
     dds_return_t ret;
     char name[100];
@@ -123,7 +123,7 @@ registering_init(void)
     g_present = dds_time();
     g_past    = g_present - DDS_SECS(1);
 
-    dds_qos_delete(qos);
+    dds_delete_qos(qos);
 }
 
 static void

--- a/src/core/ddsc/tests/subscriber.c
+++ b/src/core/ddsc/tests/subscriber.c
@@ -97,25 +97,25 @@ Test(ddsc_subscriber, create) {
 
   /*** Verify listener parameter ***/
 
-  listener = dds_listener_create(NULL); /* Use defaults (all listeners unset) */
+  listener = dds_create_listener(NULL); /* Use defaults (all listeners unset) */
   subscriber = dds_create_subscriber(participant, NULL, listener);
   cr_assert_gt(subscriber, 0, "dds_create_subscriber: unset listeners");
   dds_delete(subscriber);
-  dds_listener_delete(listener);
+  dds_delete_listener(listener);
 
-  listener = dds_listener_create(NULL);
+  listener = dds_create_listener(NULL);
   dds_lset_data_available(listener, &on_data_available); /* Set on_data_available listener */
   subscriber = dds_create_subscriber(participant, NULL, listener);
   cr_assert_gt(subscriber, 0, "dds_create_subscriber: on_data_available listener");
   dds_delete(subscriber);
-  dds_listener_delete(listener);
+  dds_delete_listener(listener);
 
-  listener = dds_listener_create(NULL);
+  listener = dds_create_listener(NULL);
   dds_lset_publication_matched(listener, &on_publication_matched); /* Set on_publication_matched listener (ignored, not applicable for subscriber) */
   subscriber = dds_create_subscriber(participant, NULL, listener);
   cr_assert_gt(subscriber, 0, "dds_create_subscriber: on_publication_matched listener");
   dds_delete(subscriber);
-  dds_listener_delete(listener);
+  dds_delete_listener(listener);
 
   dds_delete(participant);
 }

--- a/src/core/ddsc/tests/subscriber.c
+++ b/src/core/ddsc/tests/subscriber.c
@@ -76,24 +76,24 @@ Test(ddsc_subscriber, create) {
 
   /*** Verify qos parameter ***/
 
-  sqos = dds_qos_create(); /* Use defaults (no user-defined policies) */
+  sqos = dds_create_qos(); /* Use defaults (no user-defined policies) */
   subscriber = dds_create_subscriber(participant, sqos, NULL);
   cr_assert_gt(subscriber, 0, "dds_create_subscriber: default QoS parameter");
   dds_delete(subscriber);
-  dds_qos_delete(sqos);
+  dds_delete_qos(sqos);
 
-  sqos = dds_qos_create();
+  sqos = dds_create_qos();
   dds_qset_destination_order(sqos, 3); /* Set invalid dest. order (ignored, not applicable for subscriber) */
   subscriber = dds_create_subscriber(participant, sqos, NULL);
   cr_assert_gt(subscriber, 0, "dds_create_subscriber: invalid non-applicable QoS parameter");
   dds_delete(subscriber);
-  dds_qos_delete(sqos);
+  dds_delete_qos(sqos);
 
-  sqos = dds_qos_create();
+  sqos = dds_create_qos();
   dds_qset_presentation(sqos, 123, 1, 1); /* Set invalid presentation policy */
   subscriber = dds_create_subscriber(participant, sqos, NULL);
   cr_assert_eq(dds_err_nr(subscriber), DDS_RETCODE_INCONSISTENT_POLICY, "dds_create_subscriber: invalid presentation access_scope QoS parameter");
-  dds_qos_delete(sqos);
+  dds_delete_qos(sqos);
 
   /*** Verify listener parameter ***/
 

--- a/src/core/ddsc/tests/take_instance.c
+++ b/src/core/ddsc/tests/take_instance.c
@@ -94,7 +94,7 @@ take_instance_init(void)
     char name[100];
     dds_qos_t *qos;
 
-    qos = dds_qos_create();
+    qos = dds_create_qos();
     cr_assert_not_null(qos, "Failed to create prerequisite qos");
 
     g_participant = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL, NULL);
@@ -256,7 +256,7 @@ take_instance_init(void)
     g_hdl_valid = dds_instance_lookup(g_reader, &sample);
     cr_assert_neq(g_hdl_valid, DDS_HANDLE_NIL, "Failed prerequisite dds_instance_lookup");
 
-    dds_qos_delete(qos);
+    dds_delete_qos(qos);
 }
 
 static void

--- a/src/core/ddsc/tests/topic.c
+++ b/src/core/ddsc/tests/topic.c
@@ -61,7 +61,7 @@ ddsc_topic_init(void)
     cr_assert_gt(g_topicRtmDataType, 0, "Failed to create prerequisite g_topicRtmDataType");
 
     g_qos = dds_create_qos();
-    g_listener = dds_listener_create(NULL);
+    g_listener = dds_create_listener(NULL);
 }
 
 
@@ -69,7 +69,7 @@ static void
 ddsc_topic_fini(void)
 {
     dds_delete_qos(g_qos);
-    dds_listener_delete(g_listener);
+    dds_delete_listener(g_listener);
     dds_delete(g_topicRtmDataType);
     dds_delete(g_topicRtmAddress);
     dds_delete(g_participant);

--- a/src/core/ddsc/tests/topic.c
+++ b/src/core/ddsc/tests/topic.c
@@ -60,7 +60,7 @@ ddsc_topic_init(void)
     g_topicRtmDataType = dds_create_topic(g_participant, &RoundTripModule_DataType_desc, g_topicRtmDataTypeName, NULL, NULL);
     cr_assert_gt(g_topicRtmDataType, 0, "Failed to create prerequisite g_topicRtmDataType");
 
-    g_qos = dds_qos_create();
+    g_qos = dds_create_qos();
     g_listener = dds_listener_create(NULL);
 }
 
@@ -68,7 +68,7 @@ ddsc_topic_init(void)
 static void
 ddsc_topic_fini(void)
 {
-    dds_qos_delete(g_qos);
+    dds_delete_qos(g_qos);
     dds_listener_delete(g_listener);
     dds_delete(g_topicRtmDataType);
     dds_delete(g_topicRtmAddress);
@@ -102,13 +102,13 @@ Theory((char *name, dds_qos_t **qos, dds_listener_t **listener), ddsc_topic_crea
 Test(ddsc_topic_create, invalid_qos, .init=ddsc_topic_init, .fini=ddsc_topic_fini)
 {
     dds_entity_t topic;
-    dds_qos_t *qos = dds_qos_create();
+    dds_qos_t *qos = dds_create_qos();
     OS_WARNING_MSVC_OFF(28020); /* Disable SAL warning on intentional misuse of the API */
     dds_qset_lifespan(qos, DDS_SECS(-1));
     OS_WARNING_MSVC_OFF(28020);
     topic = dds_create_topic(g_participant, &RoundTripModule_DataType_desc, "inconsistent", qos, NULL);
     cr_assert_eq(dds_err_nr(topic), DDS_RETCODE_INCONSISTENT_POLICY, "returned %s", dds_err_str(topic));
-    dds_qos_delete(qos);
+    dds_delete_qos(qos);
 }
 /*************************************************************************************************/
 

--- a/src/core/ddsc/tests/transientlocal.c
+++ b/src/core/ddsc/tests/transientlocal.c
@@ -39,7 +39,7 @@ Test(ddsc_transient_local, late_joiner)
     }
 
     /* Use transient local with reliable. */
-    qos = dds_qos_create();
+    qos = dds_create_qos();
     dds_qset_durability(qos, DDS_DURABILITY_TRANSIENT_LOCAL);
     dds_qset_reliability(qos, DDS_RELIABILITY_RELIABLE, DDS_INFINITY);
 
@@ -101,5 +101,5 @@ Test(ddsc_transient_local, late_joiner)
     cr_assert_eq(ret, 4, "# read %d, expected 4", ret);
 
     dds_delete(par);
-    dds_qos_delete(qos);
+    dds_delete_qos(qos);
 }

--- a/src/core/ddsc/tests/unregister.c
+++ b/src/core/ddsc/tests/unregister.c
@@ -54,7 +54,7 @@ static void
 unregistering_init(void)
 {
     Space_Type1 sample = { 0, 0, 0 };
-    dds_qos_t *qos = dds_qos_create ();
+    dds_qos_t *qos = dds_create_qos ();
     dds_attach_t triggered;
     dds_return_t ret;
     char name[100];
@@ -123,7 +123,7 @@ unregistering_init(void)
     g_present = dds_time();
     g_past    = g_present - DDS_SECS(1);
 
-    dds_qos_delete(qos);
+    dds_delete_qos(qos);
 }
 
 static void

--- a/src/core/ddsc/tests/unsupported.c
+++ b/src/core/ddsc/tests/unsupported.c
@@ -175,8 +175,8 @@ ParameterizedTest(struct index_result *par, ddsc_unsupported, dds_set_qos, .init
     dds_return_t result;
     dds_qos_t *qos;
 
-    qos = dds_qos_create();
+    qos = dds_create_qos();
     result = dds_set_qos(e[par->index], qos);
     cr_expect_eq(dds_err_nr(result), par->exp_res, "Unexpected return code %d \"%s\" (expected %d \"%s\") from dds_set_qos(%s, qos): (%d)", dds_err_nr(result), dds_err_str(result), par->exp_res, dds_err_str(-par->exp_res), entity_kind_str(e[par->index]), result);
-    dds_qos_delete(qos);
+    dds_delete_qos(qos);
 }

--- a/src/examples/helloworld/subscriber.c
+++ b/src/examples/helloworld/subscriber.c
@@ -30,11 +30,11 @@ int main (int argc, char ** argv)
     DDS_ERR_CHECK (topic, DDS_CHECK_REPORT | DDS_CHECK_EXIT);
 
     /* Create a reliable Reader. */
-    qos = dds_qos_create ();
+    qos = dds_create_qos ();
     dds_qset_reliability (qos, DDS_RELIABILITY_RELIABLE, DDS_SECS (10));
     reader = dds_create_reader (participant, topic, qos, NULL);
     DDS_ERR_CHECK (reader, DDS_CHECK_REPORT | DDS_CHECK_EXIT);
-    dds_qos_delete(qos);
+    dds_delete_qos(qos);
 
     printf ("\n=== [Subscriber] Waiting for a sample ...\n");
 

--- a/src/examples/roundtrip/ping.c
+++ b/src/examples/roundtrip/ping.c
@@ -274,7 +274,7 @@ int main (int argc, char *argv[])
 
   if (use_listener)
   {
-    listener = dds_listener_create(NULL);
+    listener = dds_create_listener(NULL);
     dds_lset_data_available(listener, data_available);
   }
   prepare_dds(&writer, &reader, &readCond, listener);

--- a/src/examples/roundtrip/ping.c
+++ b/src/examples/roundtrip/ping.c
@@ -442,35 +442,35 @@ static dds_entity_t prepare_dds(dds_entity_t *wr, dds_entity_t *rd, dds_entity_t
   DDS_ERR_CHECK (topic, DDS_CHECK_REPORT | DDS_CHECK_EXIT);
 
   /* A DDS_Publisher is created on the domain participant. */
-  pubQos = dds_qos_create ();
+  pubQos = dds_create_qos ();
   dds_qset_partition (pubQos, 1, pubPartitions);
 
   publisher = dds_create_publisher (participant, pubQos, NULL);
   DDS_ERR_CHECK (publisher, DDS_CHECK_REPORT | DDS_CHECK_EXIT);
-  dds_qos_delete (pubQos);
+  dds_delete_qos (pubQos);
 
   /* A DDS_DataWriter is created on the Publisher & Topic with a modified Qos. */
-  dwQos = dds_qos_create ();
+  dwQos = dds_create_qos ();
   dds_qset_reliability (dwQos, DDS_RELIABILITY_RELIABLE, DDS_SECS (10));
   dds_qset_writer_data_lifecycle (dwQos, false);
   *wr = dds_create_writer (publisher, topic, dwQos, NULL);
   DDS_ERR_CHECK (*wr, DDS_CHECK_REPORT | DDS_CHECK_EXIT);
-  dds_qos_delete (dwQos);
+  dds_delete_qos (dwQos);
 
   /* A DDS_Subscriber is created on the domain participant. */
-  subQos = dds_qos_create ();
+  subQos = dds_create_qos ();
 
   dds_qset_partition (subQos, 1, subPartitions);
 
   subscriber = dds_create_subscriber (participant, subQos, NULL);
   DDS_ERR_CHECK (subscriber, DDS_CHECK_REPORT | DDS_CHECK_EXIT);
-  dds_qos_delete (subQos);
+  dds_delete_qos (subQos);
   /* A DDS_DataReader is created on the Subscriber & Topic with a modified QoS. */
-  drQos = dds_qos_create ();
+  drQos = dds_create_qos ();
   dds_qset_reliability (drQos, DDS_RELIABILITY_RELIABLE, DDS_SECS(10));
   *rd = dds_create_reader (subscriber, topic, drQos, listener);
   DDS_ERR_CHECK (*rd, DDS_CHECK_REPORT | DDS_CHECK_EXIT);
-  dds_qos_delete (drQos);
+  dds_delete_qos (drQos);
 
   waitSet = dds_create_waitset (participant);
   if (listener == NULL) {

--- a/src/examples/roundtrip/pong.c
+++ b/src/examples/roundtrip/pong.c
@@ -105,7 +105,7 @@ int main (int argc, char *argv[])
 
   if (use_listener)
   {
-    listener = dds_listener_create(NULL);
+    listener = dds_create_listener(NULL);
     dds_lset_data_available(listener, data_available);
   }
 

--- a/src/examples/roundtrip/pong.c
+++ b/src/examples/roundtrip/pong.c
@@ -164,38 +164,38 @@ static dds_entity_t prepare_dds(dds_entity_t *writer, dds_entity_t *reader, dds_
 
   /* A DDS Publisher is created on the domain participant. */
 
-  qos = dds_qos_create ();
+  qos = dds_create_qos ();
   dds_qset_partition (qos, 1, pubPartitions);
 
   publisher = dds_create_publisher (participant, qos, NULL);
   DDS_ERR_CHECK (publisher, DDS_CHECK_REPORT | DDS_CHECK_EXIT);
-  dds_qos_delete (qos);
+  dds_delete_qos (qos);
 
   /* A DDS DataWriter is created on the Publisher & Topic with a modififed Qos. */
 
-  qos = dds_qos_create ();
+  qos = dds_create_qos ();
   dds_qset_reliability (qos, DDS_RELIABILITY_RELIABLE, DDS_SECS(10));
   dds_qset_writer_data_lifecycle (qos, false);
   *writer = dds_create_writer (publisher, topic, qos, NULL);
   DDS_ERR_CHECK (*writer, DDS_CHECK_REPORT | DDS_CHECK_EXIT);
-  dds_qos_delete (qos);
+  dds_delete_qos (qos);
 
   /* A DDS Subscriber is created on the domain participant. */
 
-  qos = dds_qos_create ();
+  qos = dds_create_qos ();
   dds_qset_partition (qos, 1, subPartitions);
 
   subscriber = dds_create_subscriber (participant, qos, NULL);
   DDS_ERR_CHECK (subscriber, DDS_CHECK_REPORT | DDS_CHECK_EXIT);
-  dds_qos_delete (qos);
+  dds_delete_qos (qos);
 
   /* A DDS DataReader is created on the Subscriber & Topic with a modified QoS. */
 
-  qos = dds_qos_create ();
+  qos = dds_create_qos ();
   dds_qset_reliability (qos, DDS_RELIABILITY_RELIABLE, DDS_SECS(10));
   *reader = dds_create_reader (subscriber, topic, qos, listener);
   DDS_ERR_CHECK (*reader, DDS_CHECK_REPORT | DDS_CHECK_EXIT);
-  dds_qos_delete (qos);
+  dds_delete_qos (qos);
 
   waitSet = dds_create_waitset (participant);
   if (listener == NULL) {

--- a/src/examples/throughput/publisher.c
+++ b/src/examples/throughput/publisher.c
@@ -171,21 +171,21 @@ static dds_entity_t prepare_dds(dds_entity_t *writer, const char *partitionName)
   DDS_ERR_CHECK (topic, DDS_CHECK_REPORT | DDS_CHECK_EXIT);
 
   /* A publisher is created on the domain participant. */
-  pubQos = dds_qos_create ();
+  pubQos = dds_create_qos ();
   pubParts[0] = partitionName;
   dds_qset_partition (pubQos, 1, pubParts);
   publisher = dds_create_publisher (participant, pubQos, NULL);
   DDS_ERR_CHECK (publisher, DDS_CHECK_REPORT | DDS_CHECK_EXIT);
-  dds_qos_delete (pubQos);
+  dds_delete_qos (pubQos);
 
   /* A DataWriter is created on the publisher. */
-  dwQos = dds_qos_create ();
+  dwQos = dds_create_qos ();
   dds_qset_reliability (dwQos, DDS_RELIABILITY_RELIABLE, DDS_SECS (10));
   dds_qset_history (dwQos, DDS_HISTORY_KEEP_ALL, 0);
   dds_qset_resource_limits (dwQos, MAX_SAMPLES, DDS_LENGTH_UNLIMITED, DDS_LENGTH_UNLIMITED);
   *writer = dds_create_writer (publisher, topic, dwQos, NULL);
   DDS_ERR_CHECK (*writer, DDS_CHECK_REPORT | DDS_CHECK_EXIT);
-  dds_qos_delete (dwQos);
+  dds_delete_qos (dwQos);
 
   /* Enable write batching */
   dds_write_set_batch (true);

--- a/src/examples/throughput/subscriber.c
+++ b/src/examples/throughput/subscriber.c
@@ -374,7 +374,7 @@ static dds_entity_t prepare_dds(dds_entity_t *reader, const char *partitionName)
   dds_qset_history (drQos, DDS_HISTORY_KEEP_ALL, 0);
   dds_qset_resource_limits (drQos, maxSamples, DDS_LENGTH_UNLIMITED, DDS_LENGTH_UNLIMITED);
 
-  rd_listener = dds_listener_create(NULL);
+  rd_listener = dds_create_listener(NULL);
   dds_lset_data_available(rd_listener, data_available_handler);
 
   /* A Read Condition is created which is triggered when data is available to read */
@@ -401,7 +401,7 @@ static dds_entity_t prepare_dds(dds_entity_t *reader, const char *partitionName)
   *reader = dds_create_reader (subscriber, topic, drQos, rd_listener);
   DDS_ERR_CHECK (*reader, DDS_CHECK_REPORT | DDS_CHECK_EXIT);
   dds_delete_qos (drQos);
-  dds_listener_delete(rd_listener);
+  dds_delete_listener(rd_listener);
 
   return participant;
 }

--- a/src/examples/throughput/subscriber.c
+++ b/src/examples/throughput/subscriber.c
@@ -347,8 +347,8 @@ static dds_entity_t prepare_dds(dds_entity_t *reader, const char *partitionName)
 
   int32_t maxSamples = 400;
   const char *subParts[1];
-  dds_qos_t *subQos = dds_qos_create ();
-  dds_qos_t *drQos = dds_qos_create ();
+  dds_qos_t *subQos = dds_create_qos ();
+  dds_qos_t *drQos = dds_create_qos ();
 
   /* A Participant is created for the default domain. */
 
@@ -366,7 +366,7 @@ static dds_entity_t prepare_dds(dds_entity_t *reader, const char *partitionName)
   dds_qset_partition (subQos, 1, subParts);
   subscriber = dds_create_subscriber (participant, subQos, NULL);
   DDS_ERR_CHECK (subscriber, DDS_CHECK_REPORT | DDS_CHECK_EXIT);
-  dds_qos_delete (subQos);
+  dds_delete_qos (subQos);
 
   /* A Reader is created on the Subscriber & Topic with a modified Qos. */
 
@@ -400,7 +400,7 @@ static dds_entity_t prepare_dds(dds_entity_t *reader, const char *partitionName)
 
   *reader = dds_create_reader (subscriber, topic, drQos, rd_listener);
   DDS_ERR_CHECK (*reader, DDS_CHECK_REPORT | DDS_CHECK_EXIT);
-  dds_qos_delete (drQos);
+  dds_delete_qos (drQos);
   dds_listener_delete(rd_listener);
 
   return participant;

--- a/src/tools/pubsub/common.c
+++ b/src/tools/pubsub/common.c
@@ -257,13 +257,13 @@ int change_publisher_partitions(dds_entity_t pub, unsigned npartitions, const ch
     dds_qos_t *qos;
     dds_return_t rc;
 
-    qos = dds_qos_create();
+    qos = dds_create_qos();
     rc = dds_get_qos(pub, qos);
     if (rc == DDS_SUCCESS) {
         dds_qset_partition(qos, npartitions, partitions);
         rc = dds_set_qos(pub, qos);
     }
-    dds_qos_delete(qos);
+    dds_delete_qos(qos);
     return rc;
 }
 
@@ -271,25 +271,25 @@ int change_subscriber_partitions(dds_entity_t sub, unsigned npartitions, const c
     dds_qos_t *qos;
     dds_return_t rc;
 
-    qos = dds_qos_create();
+    qos = dds_create_qos();
     rc = dds_get_qos(sub, qos);
     if (rc == DDS_SUCCESS) {
         dds_qset_partition(qos, npartitions, partitions);
         rc = dds_set_qos(sub, qos);
     }
-    dds_qos_delete(qos);
+    dds_delete_qos(qos);
     return rc;
 }
 
 static dds_qos_t *get_topic_qos(dds_entity_t tp) {
-    dds_qos_t *tQos = dds_qos_create();
+    dds_qos_t *tQos = dds_create_qos();
     dds_return_t rc = dds_get_qos(tp, tQos);
     error_abort(rc, "dds_qos_get_topic_qos");
     return tQos;
 }
 
 dds_qos_t *new_tqos(void) {
-    dds_qos_t *q = dds_qos_create();
+    dds_qos_t *q = dds_create_qos();
 
     /* Not all defaults are those of DCPS: */
     dds_qset_reliability(q, DDS_RELIABILITY_RELIABLE, DDS_SECS(1));
@@ -299,21 +299,21 @@ dds_qos_t *new_tqos(void) {
 
 dds_qos_t *new_rdqos(dds_entity_t tp) {
     dds_qos_t *tQos = get_topic_qos(tp);
-    dds_qos_t *qos = dds_qos_create();
+    dds_qos_t *qos = dds_create_qos();
 
-    dds_return_t rc = dds_qos_copy(qos, tQos);
-    error_abort(rc ,"new_rdqos: dds_qos_copy");
-    dds_qos_delete(tQos);
+    dds_return_t rc = dds_copy_qos(qos, tQos);
+    error_abort(rc ,"new_rdqos: dds_copy_qos");
+    dds_delete_qos(tQos);
     return qos;
 }
 
 dds_qos_t *new_wrqos(dds_entity_t tp) {
     dds_qos_t *tQos = get_topic_qos(tp);
-    dds_qos_t *qos = dds_qos_create();
+    dds_qos_t *qos = dds_create_qos();
 
-    dds_return_t rc = dds_qos_copy(qos, tQos);
-    error_abort(rc ,"new_wrqos: dds_qos_copy");
-    dds_qos_delete(tQos);
+    dds_return_t rc = dds_copy_qos(qos, tQos);
+    error_abort(rc ,"new_wrqos: dds_copy_qos");
+    dds_delete_qos(tQos);
 
     /* Not all defaults are those of DCPS: */
     dds_qset_writer_data_lifecycle(qos, false);
@@ -329,7 +329,7 @@ dds_entity_t new_topic(const char *name, const dds_topic_descriptor_t *topicDesc
 dds_entity_t new_publisher(dds_qos_t *q, unsigned npartitions, const char **partitions) {
     dds_qos_t *pQos;
     if (q == NULL) {
-        pQos = dds_qos_create();
+        pQos = dds_create_qos();
     } else {
         pQos = q;
     }
@@ -337,14 +337,14 @@ dds_entity_t new_publisher(dds_qos_t *q, unsigned npartitions, const char **part
     dds_entity_t pub = dds_create_publisher(dp, pQos, NULL);
     error_abort(pub, "new_publisher: dds_create_publisher");
     if (q == NULL)
-        dds_qos_delete(pQos);
+        dds_delete_qos(pQos);
     return pub;
 }
 
 dds_entity_t new_subscriber(dds_qos_t *q, unsigned npartitions, const char **partitions) {
     dds_qos_t *sQos;
     if (q == NULL) {
-        sQos = dds_qos_create();
+        sQos = dds_create_qos();
     } else {
         sQos = q;
     }
@@ -352,7 +352,7 @@ dds_entity_t new_subscriber(dds_qos_t *q, unsigned npartitions, const char **par
     dds_entity_t sub = dds_create_subscriber(dp, sQos, NULL);
     error_abort(sub, "new_subscriber: dds_create_subscriber");
     if (q == NULL)
-        dds_qos_delete(sQos);
+        dds_delete_qos(sQos);
     return sub;
 }
 

--- a/src/tools/pubsub/pubsub.c
+++ b/src/tools/pubsub/pubsub.c
@@ -2159,8 +2159,8 @@ static void set_print_mode(const char *modestr) {
 int MAIN(int argc, char *argv[]) {
     dds_entity_t sub = 0;
     dds_entity_t pub = 0;
-    dds_listener_t *rdlistener = dds_listener_create(NULL);
-    dds_listener_t *wrlistener = dds_listener_create(NULL);
+    dds_listener_t *rdlistener = dds_create_listener(NULL);
+    dds_listener_t *wrlistener = dds_create_listener(NULL);
 
     dds_qos_t *qos;
     const char **qtopic = (const char **) dds_alloc(sizeof(char *) * (unsigned)argc);
@@ -2764,8 +2764,8 @@ int MAIN(int argc, char *argv[]) {
         }
     }
 
-    dds_listener_delete(wrlistener);
-    dds_listener_delete(rdlistener);
+    dds_delete_listener(wrlistener);
+    dds_delete_listener(rdlistener);
 
     dds_free((char **) qtopic);
     dds_free((char **) qpublisher);

--- a/src/tools/pubsub/pubsub.c
+++ b/src/tools/pubsub/pubsub.c
@@ -797,39 +797,55 @@ static void print_sampleinfo(dds_time_t *tstart, dds_time_t tnow, const dds_samp
     char isc = si2isc(si), ssc = si2ssc(si), vsc = si2vsc(si);
     const char *sep;
     int n = 0;
-    if (*tstart == 0)
+    if (*tstart == 0) {
         *tstart = tnow;
+    }
     relt = tnow - *tstart;
 //    instancehandle_to_id(&ihSystemId, &ihLocalId, si->instance_handle);
 //    instancehandle_to_id(&phSystemId, &phLocalId, si->publication_handle);
     sep = "";
-    if (print_metadata & PM_PID)
+    if (print_metadata & PM_PID) {
         n += printf ("%d", pid);
-    if (print_metadata & PM_TOPIC)
+    }
+    if (print_metadata & PM_TOPIC) {
         n += printf ("%s", tag);
-    if (print_metadata & PM_TIME)
+    }
+    if (print_metadata & PM_TIME) {
         n += printf ("%s%lld.%09lld", n > 0 ? " " : "", (relt / DDS_NSECS_IN_SEC), (relt % DDS_NSECS_IN_SEC));
+    }
     sep = " : ";
-    if (print_metadata & PM_PHANDLE)
-        n += printf ("%s%" PRIu64, n > 0 ? sep : "", si->publication_handle), sep = " ";
-    if (print_metadata & PM_IHANDLE)
+    if (print_metadata & PM_PHANDLE) {
+        n += printf ("%s%" PRIu64, n > 0 ? sep : "", si->publication_handle);
+        sep = " ";
+    }
+    if (print_metadata & PM_IHANDLE) {
         n += printf ("%s%" PRIu64, n > 0 ? sep : "", si->instance_handle);
+    }
     sep = " : ";
-    if (print_metadata & PM_STIME)
-        n += printf ("%s%lld.%09lld", n > 0 ? sep : "", (si->source_timestamp/DDS_NSECS_IN_SEC), (si->source_timestamp%DDS_NSECS_IN_SEC)), sep = " ";
+    if (print_metadata & PM_STIME) {
+        n += printf ("%s%lld.%09lld", n > 0 ? sep : "", (si->source_timestamp/DDS_NSECS_IN_SEC), (si->source_timestamp%DDS_NSECS_IN_SEC));
+        sep = " ";
+    }
     sep = " : ";
-    if (print_metadata & PM_DGEN)
-        n += printf ("%s%"PRIu32, n > 0 ? sep : "", si->disposed_generation_count), sep = " ";
-    if (print_metadata & PM_NWGEN)
+    if (print_metadata & PM_DGEN) {
+        n += printf ("%s%"PRIu32, n > 0 ? sep : "", si->disposed_generation_count);
+        sep = " ";
+    }
+    if (print_metadata & PM_NWGEN) {
         n += printf ("%s%"PRIu32, n > 0 ? sep : "", si->no_writers_generation_count);
+    }
     sep = " : ";
-    if (print_metadata & PM_RANKS)
+    if (print_metadata & PM_RANKS) {
         n += printf ("%s%"PRIu32" %"PRIu32" %"PRIu32, n > 0 ? sep : "", si->sample_rank, si->generation_rank, si->absolute_generation_rank);
+    }
     sep = " : ";
-    if (print_metadata & PM_STATE)
-        n += printf ("%s%c%c%c", n > 0 ? sep : "", isc, ssc, vsc), sep = " ";
-    if (n > 0)
+    if (print_metadata & PM_STATE) {
+        n += printf ("%s%c%c%c", n > 0 ? sep : "", isc, ssc, vsc);
+        sep = " ";
+    }
+    if (n > 0) {
         printf(" : ");
+    }
 }
 
 static void print_K(dds_time_t *tstart, dds_time_t tnow, dds_entity_t rd, const char *tag, const dds_sample_info_t *si, int32_t keyval, uint32_t seq, int (*getkeyval) (dds_entity_t rd, int32_t *key, dds_instance_handle_t ih)) {
@@ -1489,9 +1505,9 @@ static uint32_t pubthread(void *vwrspecs) {
             char *tmp = nextspec + strlen(nextspec);
             while (tmp > nextspec && isspace((unsigned char)tmp[-1]))
                 *--tmp = 0;
-            if ((sscanf(nextspec, "+%d%n", &cnt, &pos) == 1 && nextspec[pos] == 0) || (cnt = 1, strcmp(nextspec, "+") == 0)) {
+            if ((sscanf(nextspec, "+%d%n", &cnt, &pos) == 1 && nextspec[pos] == 0) || ((void)(cnt = 1), strcmp(nextspec, "+") == 0)) {
                 while (cnt--) cursor = cursor->next;
-            } else if ((sscanf(nextspec, "-%d%n", &cnt, &pos) == 1 && nextspec[pos] == 0) || (cnt = 1, strcmp(nextspec, "-") == 0)) {
+            } else if ((sscanf(nextspec, "-%d%n", &cnt, &pos) == 1 && nextspec[pos] == 0) || ((void)(cnt = 1), strcmp(nextspec, "-") == 0)) {
                 while (cnt--) cursor = cursor->prev;
             } else if (sscanf(nextspec, "%d%n", &cnt, &pos) == 1 && nextspec[pos] == 0) {
                 cursor = wrspecs; while (cnt--) cursor = cursor->next;
@@ -2091,10 +2107,11 @@ static void set_print_mode(const char *modestr) {
     char *copy = dds_string_dup(modestr), *cursor = copy, *tok;
     while ((tok = os_strsep(&cursor, ",")) != NULL) {
         int enable;
-        if (strncmp(tok, "no", 2) == 0)
-            enable = 0, tok += 2;
-        else
+        if (strncmp(tok, "no", 2) == 0) {
+            enable = 0; tok += 2;
+        } else {
             enable = 1;
+        }
         if (strcmp(tok, "type") == 0)
             printtype = enable;
         else if (strcmp(tok, "dense") == 0)
@@ -2304,27 +2321,27 @@ int MAIN(int argc, char *argv[]) {
             break;
         case 'm':
             spec[specidx].rd.polling = 0;
-            if (strcmp(os_get_optarg(), "0") == 0)
+            if (strcmp(os_get_optarg(), "0") == 0) {
                 spec[specidx].rd.mode = MODE_NONE;
-            else if (strcmp(os_get_optarg(), "p") == 0)
+            } else if (strcmp(os_get_optarg(), "p") == 0) {
                 spec[specidx].rd.mode = MODE_PRINT;
-            else if (strcmp(os_get_optarg(), "pp") == 0)
-                spec[specidx].rd.mode = MODE_PRINT, spec[specidx].rd.polling = 1;
-            else if (strcmp(os_get_optarg(), "c") == 0)
+            } else if (strcmp(os_get_optarg(), "pp") == 0) {
+                spec[specidx].rd.mode = MODE_PRINT; spec[specidx].rd.polling = 1;
+            } else if (strcmp(os_get_optarg(), "c") == 0) {
                 spec[specidx].rd.mode = MODE_CHECK;
-            else if (sscanf(os_get_optarg(), "c:%u%n", &nkeyvals, &pos) == 1 && os_get_optarg()[pos] == 0)
+            } else if (sscanf(os_get_optarg(), "c:%u%n", &nkeyvals, &pos) == 1 && os_get_optarg()[pos] == 0) {
                 spec[specidx].rd.mode = MODE_CHECK;
-            else if (strcmp(os_get_optarg(), "cp") == 0)
-                spec[specidx].rd.mode = MODE_CHECK, spec[specidx].rd.polling = 1;
-            else if (sscanf(os_get_optarg(), "cp:%u%n", &nkeyvals, &pos) == 1 && os_get_optarg()[pos] == 0)
-                spec[specidx].rd.mode = MODE_CHECK, spec[specidx].rd.polling = 1;
-            else if (strcmp(os_get_optarg(), "z") == 0)
+            } else if (strcmp(os_get_optarg(), "cp") == 0) {
+                spec[specidx].rd.mode = MODE_CHECK; spec[specidx].rd.polling = 1;
+            } else if (sscanf(os_get_optarg(), "cp:%u%n", &nkeyvals, &pos) == 1 && os_get_optarg()[pos] == 0) {
+                spec[specidx].rd.mode = MODE_CHECK; spec[specidx].rd.polling = 1;
+            } else if (strcmp(os_get_optarg(), "z") == 0) {
                 spec[specidx].rd.mode = MODE_ZEROLOAD;
-            else if (strcmp(os_get_optarg(), "d") == 0)
+            } else if (strcmp(os_get_optarg(), "d") == 0) {
                 spec[specidx].rd.mode = MODE_DUMP;
-            else if (strcmp(os_get_optarg(), "dp") == 0)
-                spec[specidx].rd.mode = MODE_DUMP, spec[specidx].rd.polling = 1;
-            else {
+            } else if (strcmp(os_get_optarg(), "dp") == 0) {
+                spec[specidx].rd.mode = MODE_DUMP; spec[specidx].rd.polling = 1;
+            } else {
                 fprintf (stderr, "-m %s: invalid mode\n", os_get_optarg());
                 exit(2);
             }

--- a/src/tools/pubsub/pubsub.c
+++ b/src/tools/pubsub/pubsub.c
@@ -1589,7 +1589,7 @@ static int check_eseq(struct eseq_admin *ea, unsigned seq, unsigned keyval, cons
 //static int subscriber_needs_access(dds_entity_t sub) {
 //    dds_qos_t *qos;
 //    int x;
-//    if ((qos = dds_qos_create()) == NULL)
+//    if ((qos = dds_create_qos()) == NULL)
 //        return DDS_RETCODE_OUT_OF_RESOURCES;
 //    dds_qos_get(sub, qos);
 //    if (qos == NULL)
@@ -2534,16 +2534,16 @@ int MAIN(int argc, char *argv[]) {
         for (i = 0; i < (unsigned) (argc - os_get_optind()); i++)
             ps[i] = expand_envvars(argv[(unsigned) os_get_optind() + i]);
         if (want_reader) {
-            qos = dds_qos_create();
+            qos = dds_create_qos();
             setqos_from_args(DDS_KIND_SUBSCRIBER, qos, nqsubscriber, qsubscriber);
             sub = new_subscriber(qos, (unsigned) (argc - os_get_optind()), (const char **) ps);
-            dds_qos_delete(qos);
+            dds_delete_qos(qos);
         }
         if (want_writer) {
-            qos = dds_qos_create();
+            qos = dds_create_qos();
             setqos_from_args(DDS_KIND_PUBLISHER, qos, nqpublisher, qpublisher);
             pub = new_publisher(qos, (unsigned) (argc - os_get_optind()), (const char **) ps);
-            dds_qos_delete(qos);
+            dds_delete_qos(qos);
         }
         for (i = 0; i < (unsigned) (argc - os_get_optind()); i++)
             dds_free(ps[i]);
@@ -2582,7 +2582,7 @@ int MAIN(int argc, char *argv[]) {
         assert(spec[i].tp);
 //        assert(spec[i].rd.topicsel != ARB || spec[i].rd.tgtp != NULL);
 //        assert(spec[i].wr.topicsel != ARB || spec[i].wr.tgtp != NULL);
-        dds_qos_delete(qos);
+        dds_delete_qos(qos);
 
         if (spec[i].cftp_expr == NULL)
             spec[i].cftp = spec[i].tp;
@@ -2604,7 +2604,7 @@ int MAIN(int argc, char *argv[]) {
             setqos_from_args(DDS_KIND_READER, qos, nqreader, qreader);
             spec[i].rd.rd = new_datareader_listener(sub, spec[i].cftp, qos, rdlistener);
             spec[i].rd.sub = sub;
-            dds_qos_delete(qos);
+            dds_delete_qos(qos);
         }
 
         if (spec[i].wr.mode != WRM_NONE) {
@@ -2616,7 +2616,7 @@ int MAIN(int argc, char *argv[]) {
                 spec[i].wr.dupwr = dds_create_writer(pub, spec[i].tp, qos, NULL);
                 error_abort(spec[i].wr.dupwr, "dds_writer_create failed");
             }
-            dds_qos_delete(qos);
+            dds_delete_qos(qos);
         }
     }
 


### PR DESCRIPTION
This pull request changes the names of the QoS and listener operations to bring them in line with the rest of the API (that is named like operation _ type, e.g., dds_create_qos). Functions with the old names are still available as deprecated exports, causing compilation warnings from gcc, clang and, I presume, Microsoft's compiler.