### PR TITLE
Update getting started guide to use new QoS function names

### DIFF
--- a/src/docs/GettingStartedGuide/helloworld_indepth.rst
+++ b/src/docs/GettingStartedGuide/helloworld_indepth.rst
@@ -261,10 +261,10 @@ a so called 'reliable' reader. Without going into details, the reader
 will be created like this
 ::
 
-    dds_qos_t *qos = dds_qos_create ();
+    dds_qos_t *qos = dds_create_qos ();
     dds_qset_reliability (qos, DDS_RELIABILITY_RELIABLE, DDS_SECS (10));
     reader = dds_create_reader (participant, topic, qos, NULL);
-    dds_qos_delete(qos);
+    dds_delete_qos(qos);
 
 We are almost able to read data. However, the read expects an
 array of pointers to valid memory locations. This means the


### PR DESCRIPTION
I missed the sources of the getting started guide when changing the names for the QoS and listener functions in #52.