### PR TITLE
Do not require table to contain address if interface is down (Fixes #55)

### DIFF
--- a/src/core/ddsc/tests/read_instance.c
+++ b/src/core/ddsc/tests/read_instance.c
@@ -298,7 +298,7 @@ CU_Theory((dds_entity_t *ent, void **buf, dds_sample_info_t *si, size_t bufsz, u
         ret = dds_read_instance(*ent, buf, si, bufsz, maxs, g_hdl_valid);
         CU_ASSERT_EQUAL_FATAL(dds_err_nr(ret), DDS_RETCODE_BAD_PARAMETER);
     } else {
-        CU_PASS();
+        CU_PASS("Skipped");
     }
 }
 /*************************************************************************************************/
@@ -319,7 +319,7 @@ CU_Theory((dds_entity_t *ent, void **buf, dds_sample_info_t *si, uint32_t maxs),
         ret = dds_read_instance_wl(*ent, buf, si, maxs, g_hdl_valid);
         CU_ASSERT_EQUAL_FATAL(dds_err_nr(ret), DDS_RETCODE_BAD_PARAMETER);
     } else {
-        CU_PASS();
+        CU_PASS("Skipped");
     }
 }
 /*************************************************************************************************/
@@ -349,7 +349,7 @@ CU_Theory((dds_entity_t *ent, void **buf, dds_sample_info_t *si, size_t bufsz, u
         ret = dds_read_instance_mask(*ent, buf, si, bufsz, maxs, g_hdl_valid, mask);
         CU_ASSERT_EQUAL_FATAL(dds_err_nr(ret), DDS_RETCODE_BAD_PARAMETER);
     } else {
-        CU_PASS();
+        CU_PASS("Skipped");
     }
 }
 /*************************************************************************************************/

--- a/src/core/ddsc/tests/reader.c
+++ b/src/core/ddsc/tests/reader.c
@@ -306,7 +306,7 @@ CU_Theory((void **buf, dds_sample_info_t *si, size_t bufsz, uint32_t maxs), ddsc
         ret = dds_read(g_reader, buf, si, bufsz, maxs);
         CU_ASSERT_EQUAL_FATAL(dds_err_nr(ret), DDS_RETCODE_BAD_PARAMETER);
     } else {
-        CU_PASS();
+        CU_PASS("Skipped");
     }
 }
 /*************************************************************************************************/
@@ -540,7 +540,7 @@ CU_Theory((void **buf, dds_sample_info_t *si, size_t bufsz, uint32_t maxs), ddsc
         ret = dds_read_mask(g_reader, buf, si, bufsz, maxs, mask);
         CU_ASSERT_EQUAL_FATAL(dds_err_nr(ret), DDS_RETCODE_BAD_PARAMETER);
     } else {
-        CU_PASS();
+        CU_PASS("Skipped");
     }
 }
 /*************************************************************************************************/
@@ -1676,7 +1676,7 @@ CU_Theory((void **buf, dds_sample_info_t *si, size_t bufsz, uint32_t maxs), ddsc
         ret = dds_take(g_reader, buf, si, bufsz, maxs);
         CU_ASSERT_EQUAL_FATAL(dds_err_nr(ret), DDS_RETCODE_BAD_PARAMETER);
     } else {
-        CU_PASS();
+        CU_PASS("Skipped");
     }
 }
 /*************************************************************************************************/
@@ -1911,7 +1911,7 @@ CU_Theory((void **buf, dds_sample_info_t *si, size_t bufsz, uint32_t maxs), ddsc
         ret = dds_take_mask(g_reader, buf, si, bufsz, maxs, mask);
         CU_ASSERT_EQUAL(dds_err_nr(ret), DDS_RETCODE_BAD_PARAMETER);
     } else {
-        CU_PASS();
+        CU_PASS("Skipped");
     }
 }
 /*************************************************************************************************/

--- a/src/core/ddsc/tests/reader_iterator.c
+++ b/src/core/ddsc/tests/reader_iterator.c
@@ -405,7 +405,7 @@ CU_Theory((void **buf, dds_sample_info_t *si), ddsc_read_next, invalid_buffers, 
         ret = dds_read_next(g_reader, buf, si);
         CU_ASSERT_EQUAL_FATAL(dds_err_nr(ret), DDS_RETCODE_BAD_PARAMETER);
     } else {
-        CU_PASS();
+        CU_PASS("Skipped");
     }
 }
 /*************************************************************************************************/
@@ -521,7 +521,7 @@ CU_Theory((void **buf, dds_sample_info_t *si), ddsc_read_next_wl, invalid_buffer
         ret = dds_read_next_wl(g_reader, buf, si);
         CU_ASSERT_EQUAL_FATAL(dds_err_nr(ret), DDS_RETCODE_BAD_PARAMETER);
     } else {
-        CU_PASS();
+        CU_PASS("Skipped");
     }
 }
 /*************************************************************************************************/
@@ -631,7 +631,7 @@ CU_Theory((void **buf, dds_sample_info_t *si), ddsc_take_next, invalid_buffers, 
         ret = dds_take_next(g_reader, buf, si);
         CU_ASSERT_EQUAL_FATAL(dds_err_nr(ret), DDS_RETCODE_BAD_PARAMETER);
     } else {
-        CU_PASS();
+        CU_PASS("Skipped");
     }
 }
 /*************************************************************************************************/
@@ -743,7 +743,7 @@ CU_Theory((void **buf, dds_sample_info_t *si), ddsc_take_next_wl, invalid_buffer
         ret = dds_take_next_wl(g_reader, buf, si);
         CU_ASSERT_EQUAL_FATAL(dds_err_nr(ret), DDS_RETCODE_BAD_PARAMETER);
     } else {
-        CU_PASS();
+        CU_PASS("Skipped");
     }
 }
 /*************************************************************************************************/

--- a/src/core/ddsc/tests/take_instance.c
+++ b/src/core/ddsc/tests/take_instance.c
@@ -299,7 +299,7 @@ CU_Theory((dds_entity_t *ent, void **buf, dds_sample_info_t *si, size_t bufsz, u
         ret = dds_take_instance(*ent, buf, si, bufsz, maxs, g_hdl_valid);
         CU_ASSERT_EQUAL_FATAL(dds_err_nr(ret), DDS_RETCODE_BAD_PARAMETER);
     } else {
-        CU_PASS();
+        CU_PASS("Skipped");
     }
 }
 /*************************************************************************************************/
@@ -347,7 +347,7 @@ CU_Theory((dds_entity_t *ent, void **buf, dds_sample_info_t *si, size_t bufsz, u
         ret = dds_take_instance_mask(*ent, buf, si, bufsz, maxs, g_hdl_valid, mask);
         CU_ASSERT_EQUAL_FATAL(dds_err_nr(ret), DDS_RETCODE_BAD_PARAMETER);
     } else {
-        CU_PASS();
+        CU_PASS("Skipped");
     }
 }
 /*************************************************************************************************/


### PR DESCRIPTION
This pull request fixes issue #55 by not requiring the address to be in the address table if the interface is down. Apart from that it also fixes build warnings by passing a message to CU_PASS. The warnings were introduced by my previous pull request.