### PR TITLE
Odds and ends

### DIFF
--- a/src/core/ddsc/src/dds_builtin.c
+++ b/src/core/ddsc/src/dds_builtin.c
@@ -370,7 +370,8 @@ dds__builtin_write(
     _In_ nn_wctime_t timestamp,
     _In_ bool alive)
 {
-    dds_entity_t topic;
+    /* initialize to avoid compiler warning ultimately caused by C's horrible type system */
+    dds_entity_t topic = 0;
     switch (type)
     {
         case DSBT_PARTICIPANT:
@@ -383,6 +384,7 @@ dds__builtin_write(
             topic = DDS_BUILTIN_TOPIC_DCPSSUBSCRIPTION;
             break;
     }
+    assert(topic != 0);
     (void)dds__builtin_write_int(topic, guid, timestamp.v, alive);
 }
 

--- a/src/core/ddsc/src/dds_entity.c
+++ b/src/core/ddsc/src/dds_entity.c
@@ -560,7 +560,7 @@ dds_get_qos(
 {
     dds_entity *e;
     dds__retcode_t rc;
-    dds_return_t ret = DDS_RETCODE_OK;
+    dds_return_t ret;
 
     if (qos == NULL) {
         DDS_ERROR("Argument qos is NULL\n");
@@ -574,11 +574,10 @@ dds_get_qos(
         goto fail;
     }
     if (e->m_deriver.set_qos) {
-        rc = dds_copy_qos(qos, e->m_qos);
+        ret = dds_copy_qos(qos, e->m_qos);
     } else {
-        rc = DDS_RETCODE_ILLEGAL_OPERATION;
         DDS_ERROR("QoS cannot be set on this entity\n");
-        ret = DDS_ERRNO(rc);
+        ret = DDS_ERRNO(DDS_RETCODE_ILLEGAL_OPERATION);
     }
     dds_entity_unlock(e);
 fail:

--- a/src/core/ddsc/src/dds_reader.c
+++ b/src/core/ddsc/src/dds_reader.c
@@ -325,14 +325,12 @@ dds_reader_status_cb(
             /* There's a deletion or closing going on. */
         }
     } else if (rc == DDS_RETCODE_NO_DATA) {
-        /* Nobody was interested through a listener (NO_DATA == NO_CALL): set the status. */
+        /* Nobody was interested through a listener (NO_DATA == NO_CALL): set the status, consider successful. */
         dds_entity_status_set(entity, data->status);
         /* Notify possible interested observers. */
         dds_entity_status_signal(entity);
-        rc = DDS_RETCODE_OK;
     } else if (rc == DDS_RETCODE_ALREADY_DELETED) {
-        /* An entity up the hierarchy is being deleted. */
-        rc = DDS_RETCODE_OK;
+        /* An entity up the hierarchy is being deleted, consider successful. */
     } else {
         /* Something went wrong up the hierarchy. */
     }

--- a/src/core/ddsc/src/dds_rhc.c
+++ b/src/core/ddsc/src/dds_rhc.c
@@ -367,6 +367,7 @@ static void remove_inst_from_nonempty_list (struct rhc *rhc, struct rhc_instance
 #ifndef NDEBUG
   {
     const struct rhc_instance *x = rhc->nonempty_instances;
+    assert (x);
     do { if (x == inst) break; x = x->next; } while (x != rhc->nonempty_instances);
     assert (x == inst);
   }
@@ -2132,7 +2133,7 @@ void dds_rhc_add_readcondition (dds_readcond * cond)
 
   DDS_TRACE("add_readcondition(%p, %x, %x, %x) => %p qminv %x ; rhc %u conds\n",
     (void *) rhc, cond->m_sample_states, cond->m_view_states,
-    cond->m_instance_states, cond, cond->m_qminv, rhc->nconds);
+    cond->m_instance_states, (void *) cond, cond->m_qminv, rhc->nconds);
 
   os_mutexUnlock (&rhc->conds_lock);
   os_mutexUnlock (&rhc->lock);

--- a/src/core/ddsc/src/dds_topic.c
+++ b/src/core/ddsc/src/dds_topic.c
@@ -130,14 +130,12 @@ dds_topic_status_cb(
             dds_topic_unlock(topic);
         }
     } else if (rc == DDS_RETCODE_NO_DATA) {
-        /* Nobody was interested through a listener (NO_DATA == NO_CALL): set the status. */
+        /* Nobody was interested through a listener (NO_DATA == NO_CALL): set the status; consider it successful. */
         dds_entity_status_set((dds_entity*)topic, DDS_INCONSISTENT_TOPIC_STATUS);
         /* Notify possible interested observers. */
         dds_entity_status_signal((dds_entity*)topic);
-        rc = DDS_RETCODE_OK;
     } else if (rc == DDS_RETCODE_ALREADY_DELETED) {
-        /* An entity up the hierarchy is being deleted. */
-        rc = DDS_RETCODE_OK;
+        /* An entity up the hierarchy is being deleted; consider it successful. */
     } else {
         /* Something went wrong up the hierarchy. */
     }
@@ -318,7 +316,7 @@ static bool dupdef_qos_ok(const dds_qos_t *qos, const struct ddsi_sertopic *st)
 
 static bool sertopic_equivalent (const struct ddsi_sertopic *a, const struct ddsi_sertopic *b)
 {
-  printf ("sertopic_equivalent %p %p (%s %s; %u %u; %p %p; %p %p)\n", a, b, a->name_typename, b->name_typename, a->serdata_basehash, b->serdata_basehash, a->ops, b->ops, a->serdata_ops, b->serdata_ops);
+  printf ("sertopic_equivalent %p %p (%s %s; %u %u; %p %p; %p %p)\n", (void*)a, (void*)b, a->name_typename, b->name_typename, a->serdata_basehash, b->serdata_basehash, (void *)a->ops, (void *)b->ops, (void *)a->serdata_ops, (void *)b->serdata_ops);
 
   if (strcmp (a->name_typename, b->name_typename) != 0)
     return false;

--- a/src/core/ddsc/src/dds_writer.c
+++ b/src/core/ddsc/src/dds_writer.c
@@ -170,14 +170,12 @@ dds_writer_status_cb(
             /* There's a deletion or closing going on. */
         }
     } else if (rc == DDS_RETCODE_NO_DATA) {
-        /* Nobody was interested through a listener (NO_DATA == NO_CALL): set the status. */
+        /* Nobody was interested through a listener (NO_DATA == NO_CALL): set the status; consider it successful. */
         dds_entity_status_set(entity, data->status);
         /* Notify possible interested observers. */
         dds_entity_status_signal(entity);
-        rc = DDS_RETCODE_OK;
     } else if (rc == DDS_RETCODE_ALREADY_DELETED) {
-        /* An entity up the hierarchy is being deleted. */
-        rc = DDS_RETCODE_OK;
+        /* An entity up the hierarchy is being deleted; consider it successful. */
     } else {
         /* Something went wrong up the hierarchy. */
     }
@@ -395,12 +393,6 @@ static struct whc *make_whc(const dds_qos_t *qos)
   } else {
     tldepth = 0;
   }
-  if (hdepth == 0 && tldepth == 0)
-  {
-    /* no index at all - so no need to bother with startup mode */
-    startup_mode = 0;
-  }
-
   return whc_new (handle_as_transient_local, hdepth, tldepth);
 }
 

--- a/src/core/ddsi/include/ddsi/ddsi_tkmap.h
+++ b/src/core/ddsi/include/ddsi/ddsi_tkmap.h
@@ -26,7 +26,6 @@ struct dds_topic;
 struct ddsi_tkmap_instance
 {
   struct ddsi_serdata * m_sample;
-  struct ddsi_tkmap * m_map;
   uint64_t m_iid;
   os_atomic_uint32_t m_refc;
 };

--- a/src/core/ddsi/include/ddsi/q_entity.h
+++ b/src/core/ddsi/include/ddsi/q_entity.h
@@ -328,7 +328,7 @@ struct proxy_endpoint_common
   struct proxy_endpoint_common *next_ep; /* next \ endpoint belonging to this proxy participant */
   struct proxy_endpoint_common *prev_ep; /* prev / -- this is in arbitrary ordering */
   struct nn_xqos *xqos; /* proxy endpoint QoS lives here; FIXME: local ones should have it moved to common as well */
-  const struct ddsi_sertopic * topic; /* topic may be NULL: for built-ins, but also for never-yet matched proxies (so we don't have to know the topic; when we match, we certainly do know) */
+  struct ddsi_sertopic * topic; /* topic may be NULL: for built-ins, but also for never-yet matched proxies (so we don't have to know the topic; when we match, we certainly do know) */
   struct addrset *as; /* address set to use for communicating with this endpoint */
   nn_guid_t group_guid; /* 0:0:0:0 if not available */
   nn_vendorid_t vendor; /* cached from proxypp->vendor */

--- a/src/core/ddsi/include/ddsi/q_error.h
+++ b/src/core/ddsi/include/ddsi/q_error.h
@@ -22,5 +22,6 @@
 #define ERR_BUSY                -8
 #define ERR_NO_ADDRESS          -9
 #define ERR_TIMEOUT             -10
+#define ERR_INCOMPATIBLE        -11
 
 #endif /* NN_ERROR_H */

--- a/src/core/ddsi/include/ddsi/q_protocol.h
+++ b/src/core/ddsi/include/ddsi/q_protocol.h
@@ -156,6 +156,11 @@ typedef struct Header {
   nn_guid_prefix_t guid_prefix;
 } Header_t;
 #define NN_PROTOCOLID_INITIALIZER {{ 'R','T','P','S' }}
+#if PLATFORM_IS_LITTLE_ENDIAN
+#define NN_PROTOCOLID_AS_UINT32 (((uint32_t)'R' << 0) | ((uint32_t)'T' << 8) | ((uint32_t)'P' << 16) | ((uint32_t)'S' << 24))
+#else
+#define NN_PROTOCOLID_AS_UINT32 (((uint32_t)'R' << 24) | ((uint32_t)'T' << 16) | ((uint32_t)'P' << 8) | ((uint32_t)'S' << 0))
+#endif
 #define NN_PROTOCOL_VERSION_INITIALIZER { RTPS_MAJOR, RTPS_MINOR }
 #define NN_VENDORID_INITIALIER MY_VENDOR_ID
 #define NN_HEADER_INITIALIZER { NN_PROTOCOLID_INITIALIZER, NN_PROTOCOL_VERSION_INITIALIZER, NN_VENDORID_INITIALIER, NN_GUID_PREFIX_UNKNOWN_INITIALIZER }

--- a/src/core/ddsi/src/ddsi_ipaddr.c
+++ b/src/core/ddsi/src/ddsi_ipaddr.c
@@ -38,7 +38,7 @@ int ddsi_ipaddr_compare (const os_sockaddr *const sa1, const os_sockaddr *const 
         sin1 = (os_sockaddr_in *)sa1;
         sin2 = (os_sockaddr_in *)sa2;
         sz = sizeof(sin1->sin_addr);
-        eq = memcmp(&sin1->sin_addr, &sin2->sin_addr, sizeof(sz));
+        eq = memcmp(&sin1->sin_addr, &sin2->sin_addr, sz);
         break;
       }
       default: {

--- a/src/core/ddsi/src/ddsi_serdata_builtin.c
+++ b/src/core/ddsi/src/ddsi_serdata_builtin.c
@@ -133,7 +133,7 @@ struct ddsi_serdata *ddsi_serdata_builtin_from_keyhash (const struct ddsi_sertop
   const struct entity_common *entity = ephash_lookup_guid_untyped ((const nn_guid_t *) keyhash->value);
   struct ddsi_serdata_builtin *d = serdata_builtin_new(tp, entity ? SDK_DATA : SDK_KEY);
   memcpy (&d->key, keyhash->value, sizeof (d->key));
-  if (d->c.kind == SDK_DATA)
+  if (entity)
   {
     switch (entity->kind)
     {

--- a/src/core/ddsi/src/ddsi_serdata_default.c
+++ b/src/core/ddsi/src/ddsi_serdata_default.c
@@ -167,6 +167,12 @@ static struct ddsi_serdata *fix_serdata_default(struct ddsi_serdata_default *d, 
   return &d->c;
 }
 
+static struct ddsi_serdata *fix_serdata_default_nokey(struct ddsi_serdata_default *d, uint32_t basehash)
+{
+  d->c.hash = basehash;
+  return &d->c;
+}
+
 static uint32_t serdata_default_get_size(const struct ddsi_serdata *dcmn)
 {
   const struct ddsi_serdata_default *d = (const struct ddsi_serdata_default *) dcmn;
@@ -240,7 +246,7 @@ static struct ddsi_serdata_default *serdata_default_new(const struct ddsi_sertop
 }
 
 /* Construct a serdata from a fragchain received over the network */
-static struct ddsi_serdata *serdata_default_from_ser (const struct ddsi_sertopic *tpcmn, enum ddsi_serdata_kind kind, const struct nn_rdata *fragchain, size_t size)
+static struct ddsi_serdata_default *serdata_default_from_ser_common (const struct ddsi_sertopic *tpcmn, enum ddsi_serdata_kind kind, const struct nn_rdata *fragchain, size_t size)
 {
   const struct ddsi_sertopic_default *tp = (const struct ddsi_sertopic_default *)tpcmn;
   struct ddsi_serdata_default *d = serdata_default_new(tp, kind);
@@ -270,7 +276,17 @@ static struct ddsi_serdata *serdata_default_from_ser (const struct ddsi_sertopic
   dds_stream_t is;
   dds_stream_from_serdata_default (&is, d);
   dds_stream_read_keyhash (&is, &d->keyhash, (const dds_topic_descriptor_t *)tp->type, kind == SDK_KEY);
-  return fix_serdata_default (d, tp->c.serdata_basehash);
+  return d;
+}
+
+static struct ddsi_serdata *serdata_default_from_ser (const struct ddsi_sertopic *tpcmn, enum ddsi_serdata_kind kind, const struct nn_rdata *fragchain, size_t size)
+{
+  return fix_serdata_default (serdata_default_from_ser_common (tpcmn, kind, fragchain, size), tpcmn->serdata_basehash);
+}
+
+static struct ddsi_serdata *serdata_default_from_ser_nokey (const struct ddsi_sertopic *tpcmn, enum ddsi_serdata_kind kind, const struct nn_rdata *fragchain, size_t size)
+{
+  return fix_serdata_default_nokey (serdata_default_from_ser_common (tpcmn, kind, fragchain, size), tpcmn->serdata_basehash);
 }
 
 struct ddsi_serdata *ddsi_serdata_from_keyhash_cdr (const struct ddsi_sertopic *tpcmn, const nn_keyhash_t *keyhash)
@@ -301,11 +317,10 @@ struct ddsi_serdata *ddsi_serdata_from_keyhash_cdr_nokey (const struct ddsi_sert
   (void)keyhash;
   d->keyhash.m_set = 1;
   d->keyhash.m_iskey = 1;
-  d->c.hash = tp->c.serdata_basehash;
-  return (struct ddsi_serdata *)d;
+  return fix_serdata_default_nokey(d, tp->c.serdata_basehash);
 }
 
-static struct ddsi_serdata *serdata_default_from_sample_cdr (const struct ddsi_sertopic *tpcmn, enum ddsi_serdata_kind kind, const void *sample)
+static struct ddsi_serdata_default *serdata_default_from_sample_cdr_common (const struct ddsi_sertopic *tpcmn, enum ddsi_serdata_kind kind, const void *sample)
 {
   const struct ddsi_sertopic_default *tp = (const struct ddsi_sertopic_default *)tpcmn;
   struct ddsi_serdata_default *d = serdata_default_new(tp, kind);
@@ -324,7 +339,17 @@ static struct ddsi_serdata *serdata_default_from_sample_cdr (const struct ddsi_s
       break;
   }
   dds_stream_add_to_serdata_default (&os, &d);
-  return fix_serdata_default (d, tp->c.serdata_basehash);
+  return d;
+}
+
+static struct ddsi_serdata *serdata_default_from_sample_cdr (const struct ddsi_sertopic *tpcmn, enum ddsi_serdata_kind kind, const void *sample)
+{
+  return fix_serdata_default (serdata_default_from_sample_cdr_common (tpcmn, kind, sample), tpcmn->serdata_basehash);
+}
+
+static struct ddsi_serdata *serdata_default_from_sample_cdr_nokey (const struct ddsi_sertopic *tpcmn, enum ddsi_serdata_kind kind, const void *sample)
+{
+  return fix_serdata_default_nokey (serdata_default_from_sample_cdr_common (tpcmn, kind, sample), tpcmn->serdata_basehash);
 }
 
 static struct ddsi_serdata *serdata_default_from_sample_plist (const struct ddsi_sertopic *tpcmn, enum ddsi_serdata_kind kind, const void *vsample)
@@ -391,9 +416,13 @@ static struct ddsi_serdata *serdata_default_from_sample_rawcdr (const struct dds
   serdata_default_append_blob (&d, 1, sample->size, sample->blob);
   d->keyhash.m_set = 1;
   d->keyhash.m_iskey = 1;
-  if (sample->keysize > 0)
+  if (sample->keysize == 0)
+    return fix_serdata_default_nokey (d, tp->c.serdata_basehash);
+  else
+  {
     memcpy (&d->keyhash.m_hash, sample->key, sample->keysize);
-  return fix_serdata_default (d, tp->c.serdata_basehash);
+    return fix_serdata_default (d, tp->c.serdata_basehash);
+  }
 }
 
 static struct ddsi_serdata *serdata_default_to_topicless (const struct ddsi_serdata *serdata_common)
@@ -518,9 +547,9 @@ const struct ddsi_serdata_ops ddsi_serdata_ops_cdr_nokey = {
   .get_size = serdata_default_get_size,
   .eqkey = serdata_default_eqkey_nokey,
   .free = serdata_default_free,
-  .from_ser = serdata_default_from_ser,
+  .from_ser = serdata_default_from_ser_nokey,
   .from_keyhash = ddsi_serdata_from_keyhash_cdr_nokey,
-  .from_sample = serdata_default_from_sample_cdr,
+  .from_sample = serdata_default_from_sample_cdr_nokey,
   .to_ser = serdata_default_to_ser,
   .to_sample = serdata_default_to_sample_cdr,
   .to_ser_ref = serdata_default_to_ser_ref,

--- a/src/core/ddsi/src/ddsi_serdata_default.c
+++ b/src/core/ddsi/src/ddsi_serdata_default.c
@@ -370,7 +370,7 @@ static struct ddsi_serdata *serdata_default_from_sample_plist (const struct ddsi
     case PID_GROUP_GUID:
       d->keyhash.m_set = 1;
       d->keyhash.m_iskey = 1;
-      memcpy (&d->keyhash.m_hash, rawkey, 16);
+      memcpy (d->keyhash.m_hash, rawkey, 16);
 #ifndef NDEBUG
       keysize = 16;
 #endif
@@ -383,13 +383,14 @@ static struct ddsi_serdata *serdata_default_from_sample_plist (const struct ddsi
       md5_state_t md5st;
       md5_byte_t digest[16];
       topic_name_sz = (uint32_t) strlen (topic_name) + 1;
+      topic_name_sz_BE = toBE4u (topic_name_sz);
       d->keyhash.m_set = 1;
       d->keyhash.m_iskey = 0;
       md5_init (&md5st);
       md5_append (&md5st, (const md5_byte_t *) &topic_name_sz_BE, sizeof (topic_name_sz_BE));
       md5_append (&md5st, (const md5_byte_t *) topic_name, topic_name_sz);
       md5_finish (&md5st, digest);
-      memcpy (&d->keyhash.m_hash, digest, 16);
+      memcpy (d->keyhash.m_hash, digest, 16);
 #ifndef NDEBUG
       keysize = sizeof (uint32_t) + topic_name_sz;
 #endif

--- a/src/core/ddsi/src/ddsi_serdata_default.c
+++ b/src/core/ddsi/src/ddsi_serdata_default.c
@@ -60,7 +60,7 @@ static void serdata_free_wrap (void *elem)
 
 void ddsi_serdatapool_free (struct serdatapool * pool)
 {
-  DDS_TRACE("ddsi_serdatapool_free(%p)\n", pool);
+  DDS_TRACE("ddsi_serdatapool_free(%p)\n", (void *) pool);
   nn_freelist_fini (&pool->freelist, serdata_free_wrap);
   os_free (pool);
 }

--- a/src/core/ddsi/src/ddsi_sertopic_builtin.c
+++ b/src/core/ddsi/src/ddsi_sertopic_builtin.c
@@ -114,7 +114,7 @@ static void sertopic_builtin_free_samples (const struct ddsi_sertopic *sertopic_
 #endif
     if (op & DDS_FREE_CONTENTS_BIT)
     {
-      void (*f) (void *);
+      void (*f) (void *) = 0;
       char *ptr = ptrs[0];
       switch (tp->type)
       {
@@ -126,6 +126,7 @@ static void sertopic_builtin_free_samples (const struct ddsi_sertopic *sertopic_
           f = free_endpoint;
           break;
       }
+      assert (f != 0);
       for (size_t i = 0; i < count; i++)
       {
         f (ptr);

--- a/src/core/ddsi/src/ddsi_tcp.c
+++ b/src/core/ddsi/src/ddsi_tcp.c
@@ -73,7 +73,7 @@ typedef struct ddsi_tcp_listener
 }
 * ddsi_tcp_listener_t;
 
-static int ddsi_tcp_cmp_conn (const ddsi_tcp_conn_t c1, const ddsi_tcp_conn_t c2)
+static int ddsi_tcp_cmp_conn (const struct ddsi_tcp_conn *c1, const struct ddsi_tcp_conn *c2)
 {
   const os_sockaddr *a1s = (os_sockaddr *)&c1->m_peer_addr;
   const os_sockaddr *a2s = (os_sockaddr *)&c2->m_peer_addr;
@@ -82,6 +82,11 @@ static int ddsi_tcp_cmp_conn (const ddsi_tcp_conn_t c1, const ddsi_tcp_conn_t c2
   else if (c1->m_peer_port != c2->m_peer_port)
     return (c1->m_peer_port < c2->m_peer_port) ? -1 : 1;
   return ddsi_ipaddr_compare (a1s, a2s);
+}
+
+static int ddsi_tcp_cmp_conn_wrap (const void *a, const void *b)
+{
+  return ddsi_tcp_cmp_conn (a, b);
 }
 
 typedef struct ddsi_tcp_node
@@ -95,7 +100,7 @@ static const ut_avlTreedef_t ddsi_tcp_treedef = UT_AVL_TREEDEF_INITIALIZER_INDKE
 (
   offsetof (struct ddsi_tcp_node, m_avlnode),
   offsetof (struct ddsi_tcp_node, m_conn),
-  ddsi_tcp_cmp_conn,
+  ddsi_tcp_cmp_conn_wrap,
   0
 );
 

--- a/src/core/ddsi/src/ddsi_tkmap.c
+++ b/src/core/ddsi/src/ddsi_tkmap.c
@@ -189,7 +189,6 @@ retry:
       return NULL;
 
     tk->m_sample = ddsi_serdata_to_topicless (sd);
-    tk->m_map = map;
     os_atomic_st32 (&tk->m_refc, 1);
     tk->m_iid = ddsi_iid_gen ();
     if (!ut_chhAdd (map->m_hh, tk))
@@ -235,7 +234,7 @@ void ddsi_tkmap_instance_unref (_In_ struct ddsi_tkmap_instance * tk)
   } while (!os_atomic_cas32(&tk->m_refc, old, new));
   if (new == REFC_DELETE)
   {
-    struct ddsi_tkmap *map = tk->m_map;
+    struct ddsi_tkmap *map = gv.m_tkmap;
 
     /* Remove from hash table */
     int removed = ut_chhRemove(map->m_hh, tk);

--- a/src/core/ddsi/src/ddsi_tkmap.c
+++ b/src/core/ddsi/src/ddsi_tkmap.c
@@ -202,7 +202,7 @@ retry:
 
   if (tk && rd)
   {
-    DDS_TRACE("tk=%p iid=%"PRIx64" ", &tk, tk->m_iid);
+    DDS_TRACE("tk=%p iid=%"PRIx64" ", (void *) &tk, tk->m_iid);
   }
   return tk;
 }

--- a/src/core/ddsi/src/q_ddsi_discovery.c
+++ b/src/core/ddsi/src/q_ddsi_discovery.c
@@ -799,14 +799,16 @@ static void handle_SPDP (const struct receiver_state *rst, nn_wctime_t timestamp
     nn_plist_t decoded_data;
     nn_plist_src_t src;
     int interesting = 0;
+    int plist_ret;
     src.protocol_version = rst->protocol_version;
     src.vendorid = rst->vendor;
     src.encoding = data->identifier;
     src.buf = (unsigned char *) data + 4;
     src.bufsz = len - 4;
-    if (nn_plist_init_frommsg (&decoded_data, NULL, ~(uint64_t)0, ~(uint64_t)0, &src) < 0)
+    if ((plist_ret = nn_plist_init_frommsg (&decoded_data, NULL, ~(uint64_t)0, ~(uint64_t)0, &src)) < 0)
     {
-      DDS_WARNING("SPDP (vendor %u.%u): invalid qos/parameters\n", src.vendorid.id[0], src.vendorid.id[1]);
+      if (plist_ret != ERR_INCOMPATIBLE)
+        DDS_WARNING("SPDP (vendor %u.%u): invalid qos/parameters\n", src.vendorid.id[0], src.vendorid.id[1]);
       return;
     }
 
@@ -1340,14 +1342,16 @@ static void handle_SEDP (const struct receiver_state *rst, nn_wctime_t timestamp
   {
     nn_plist_t decoded_data;
     nn_plist_src_t src;
+    int plist_ret;
     src.protocol_version = rst->protocol_version;
     src.vendorid = rst->vendor;
     src.encoding = data->identifier;
     src.buf = (unsigned char *) data + 4;
     src.bufsz = len - 4;
-    if (nn_plist_init_frommsg (&decoded_data, NULL, ~(uint64_t)0, ~(uint64_t)0, &src) < 0)
+    if ((plist_ret = nn_plist_init_frommsg (&decoded_data, NULL, ~(uint64_t)0, ~(uint64_t)0, &src)) < 0)
     {
-      DDS_WARNING("SEDP (vendor %u.%u): invalid qos/parameters\n", src.vendorid.id[0], src.vendorid.id[1]);
+      if (plist_ret != ERR_INCOMPATIBLE)
+        DDS_WARNING("SEDP (vendor %u.%u): invalid qos/parameters\n", src.vendorid.id[0], src.vendorid.id[1]);
       return;
     }
 
@@ -1466,14 +1470,16 @@ static void handle_SEDP_CM (const struct receiver_state *rst, nn_entityid_t wr_e
   {
     nn_plist_t decoded_data;
     nn_plist_src_t src;
+    int plist_ret;
     src.protocol_version = rst->protocol_version;
     src.vendorid = rst->vendor;
     src.encoding = data->identifier;
     src.buf = (unsigned char *) data + 4;
     src.bufsz = len - 4;
-    if (nn_plist_init_frommsg (&decoded_data, NULL, ~(uint64_t)0, ~(uint64_t)0, &src) < 0)
+    if ((plist_ret = nn_plist_init_frommsg (&decoded_data, NULL, ~(uint64_t)0, ~(uint64_t)0, &src)) < 0)
     {
-      DDS_WARNING("SEDP_CM (vendor %u.%u): invalid qos/parameters\n", src.vendorid.id[0], src.vendorid.id[1]);
+      if (plist_ret != ERR_INCOMPATIBLE)
+        DDS_WARNING("SEDP_CM (vendor %u.%u): invalid qos/parameters\n", src.vendorid.id[0], src.vendorid.id[1]);
       return;
     }
 
@@ -1626,14 +1632,16 @@ static void handle_SEDP_GROUP (const struct receiver_state *rst, nn_wctime_t tim
   {
     nn_plist_t decoded_data;
     nn_plist_src_t src;
+    int plist_ret;
     src.protocol_version = rst->protocol_version;
     src.vendorid = rst->vendor;
     src.encoding = data->identifier;
     src.buf = (unsigned char *) data + 4;
     src.bufsz = len - 4;
-    if (nn_plist_init_frommsg (&decoded_data, NULL, ~(uint64_t)0, ~(uint64_t)0, &src) < 0)
+    if ((plist_ret = nn_plist_init_frommsg (&decoded_data, NULL, ~(uint64_t)0, ~(uint64_t)0, &src)) < 0)
     {
-      DDS_WARNING("SEDP_GROUP (vendor %u.%u): invalid qos/parameters\n", src.vendorid.id[0], src.vendorid.id[1]);
+      if (plist_ret != ERR_INCOMPATIBLE)
+        DDS_WARNING("SEDP_GROUP (vendor %u.%u): invalid qos/parameters\n", src.vendorid.id[0], src.vendorid.id[1]);
       return;
     }
 
@@ -1747,15 +1755,17 @@ int builtins_dqueue_handler (const struct nn_rsample_info *sampleinfo, const str
   {
     nn_plist_src_t src;
     size_t qos_offset = NN_RDATA_SUBMSG_OFF (fragchain) + offsetof (Data_DataFrag_common_t, octetsToInlineQos) + sizeof (msg->octetsToInlineQos) + msg->octetsToInlineQos;
+    int plist_ret;
     src.protocol_version = sampleinfo->rst->protocol_version;
     src.vendorid = sampleinfo->rst->vendor;
     src.encoding = (msg->smhdr.flags & SMFLAG_ENDIANNESS) ? PL_CDR_LE : PL_CDR_BE;
     src.buf = NN_RMSG_PAYLOADOFF (fragchain->rmsg, qos_offset);
     src.bufsz = NN_RDATA_PAYLOAD_OFF (fragchain) - qos_offset;
-    if (nn_plist_init_frommsg (&qos, NULL, PP_STATUSINFO | PP_KEYHASH, 0, &src) < 0)
+    if ((plist_ret = nn_plist_init_frommsg (&qos, NULL, PP_STATUSINFO | PP_KEYHASH, 0, &src)) < 0)
     {
-      DDS_WARNING("data(builtin, vendor %u.%u): %x:%x:%x:%x #%"PRId64": invalid inline qos\n",
-                   src.vendorid.id[0], src.vendorid.id[1], PGUID (srcguid), sampleinfo->seq);
+      if (plist_ret != ERR_INCOMPATIBLE)
+        DDS_WARNING("data(builtin, vendor %u.%u): %x:%x:%x:%x #%"PRId64": invalid inline qos\n",
+                    src.vendorid.id[0], src.vendorid.id[1], PGUID (srcguid), sampleinfo->seq);
       goto done_upd_deliv;
     }
     /* Complex qos bit also gets set when statusinfo bits other than

--- a/src/core/ddsi/src/q_ddsi_discovery.c
+++ b/src/core/ddsi/src/q_ddsi_discovery.c
@@ -520,9 +520,6 @@ static int handle_SPDP_alive (const struct receiver_state *rst, nn_wctime_t time
   nn_duration_t lease_duration;
   unsigned custom_flags = 0;
 
-  if (!(dds_get_log_mask() & DDS_LC_DISCOVERY))
-    DDS_LOG(DDS_LC_DISCOVERY, "SPDP ST0");
-
   if (!(datap->present & PP_PARTICIPANT_GUID) || !(datap->present & PP_BUILTIN_ENDPOINT_SET))
   {
     DDS_WARNING("data (SPDP, vendor %u.%u): no/invalid payload\n", rst->vendor.id[0], rst->vendor.id[1]);
@@ -565,8 +562,6 @@ static int handle_SPDP_alive (const struct receiver_state *rst, nn_wctime_t time
         prismtech_builtin_endpoint_set |= NN_DISC_BUILTIN_ENDPOINT_CM_PUBLISHER_WRITER | NN_DISC_BUILTIN_ENDPOINT_CM_SUBSCRIBER_WRITER;
   }
 
-  DDS_LOG(DDS_LC_DISCOVERY, " %x:%x:%x:%x", PGUID (datap->participant_guid));
-
   /* Local SPDP packets may be looped back, and that may include ones
      currently being deleted.  The first thing that happens when
      deleting a participant is removing it from the hash table, and
@@ -575,7 +570,7 @@ static int handle_SPDP_alive (const struct receiver_state *rst, nn_wctime_t time
 
   if (is_deleted_participant_guid (&datap->participant_guid, DPG_REMOTE))
   {
-    DDS_LOG(DDS_LC_DISCOVERY, " (recently deleted)");
+    DDS_LOG(DDS_LC_TRACE, "SPDP ST0 %x:%x:%x:%x (recently deleted)", PGUID (datap->participant_guid));
     return 1;
   }
 
@@ -585,7 +580,7 @@ static int handle_SPDP_alive (const struct receiver_state *rst, nn_wctime_t time
       islocal = 1;
     if (islocal)
     {
-      DDS_LOG(DDS_LC_DISCOVERY, " (local %d)", islocal);
+      DDS_LOG(DDS_LC_TRACE, "SPDP ST0 %x:%x:%x:%x (local %d)", islocal, PGUID (datap->participant_guid));
       return 0;
     }
   }
@@ -596,7 +591,7 @@ static int handle_SPDP_alive (const struct receiver_state *rst, nn_wctime_t time
        are even skipping the automatic lease renewal.  Therefore do it
        regardless of
        config.arrival_of_data_asserts_pp_and_ep_liveliness. */
-    DDS_LOG(DDS_LC_DISCOVERY, " (known)");
+    DDS_LOG(DDS_LC_TRACE, "SPDP ST0 %x:%x:%x:%x (known)", PGUID (datap->participant_guid));
     lease_renew (os_atomic_ldvoidp (&proxypp->lease), now_et ());
     os_mutexLock (&proxypp->e.lock);
     if (proxypp->implicitly_created)
@@ -609,7 +604,7 @@ static int handle_SPDP_alive (const struct receiver_state *rst, nn_wctime_t time
     return 0;
   }
 
-  DDS_LOG(DDS_LC_DISCOVERY, " bes %x ptbes %x NEW", builtin_endpoint_set, prismtech_builtin_endpoint_set);
+  DDS_LOG(DDS_LC_DISCOVERY, "SPDP ST0 %x:%x:%x:%x bes %x ptbes %x NEW", PGUID (datap->participant_guid), builtin_endpoint_set, prismtech_builtin_endpoint_set);
 
   if (datap->present & PP_PARTICIPANT_LEASE_DURATION)
   {

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -1351,16 +1351,16 @@ static void writer_drop_connection (const struct nn_guid * wr_guid, const struct
       rebuild_writer_addrset (wr);
       remove_acked_messages (wr, &whcst, &deferred_free_list);
       wr->num_reliable_readers -= m->is_reliable;
-      if (wr->status_cb)
-      {
-        status_cb_data_t data;
-        data.status = DDS_PUBLICATION_MATCHED_STATUS;
-        data.add = false;
-        data.handle = prd->e.iid;
-        (wr->status_cb) (wr->status_cb_entity, &data);
-      }
     }
     os_mutexUnlock (&wr->e.lock);
+    if (m != NULL && wr->status_cb)
+    {
+      status_cb_data_t data;
+      data.status = DDS_PUBLICATION_MATCHED_STATUS;
+      data.add = false;
+      data.handle = prd->e.iid;
+      (wr->status_cb) (wr->status_cb_entity, &data);
+    }
     whc_free_deferred_free_list (wr->whc, deferred_free_list);
     free_wr_prd_match (m);
   }
@@ -1380,7 +1380,8 @@ static void writer_drop_local_connection (const struct nn_guid *wr_guid, struct 
       ut_avlDelete (&wr_local_readers_treedef, &wr->local_readers, m);
     }
     local_reader_ary_remove (&wr->rdary, rd);
-    if (wr->status_cb)
+    os_mutexUnlock (&wr->e.lock);
+    if (m != NULL && wr->status_cb)
     {
       status_cb_data_t data;
       data.status = DDS_PUBLICATION_MATCHED_STATUS;
@@ -1388,7 +1389,6 @@ static void writer_drop_local_connection (const struct nn_guid *wr_guid, struct 
       data.handle = rd->e.iid;
       (wr->status_cb) (wr->status_cb_entity, &data);
     }
-    os_mutexUnlock (&wr->e.lock);
     free_wr_rd_match (m);
   }
 }

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -1795,7 +1795,7 @@ static void proxy_writer_add_connection (struct proxy_writer *pwr, struct reader
     goto already_matched;
 
   if (pwr->c.topic == NULL && rd->topic)
-    pwr->c.topic = rd->topic;
+    pwr->c.topic = ddsi_sertopic_ref (rd->topic);
   if (pwr->ddsi2direct_cb == 0 && rd->ddsi2direct_cb != 0)
   {
     pwr->ddsi2direct_cb = rd->ddsi2direct_cb;
@@ -1910,7 +1910,7 @@ static void proxy_reader_add_connection (struct proxy_reader *prd, struct writer
   m->wr_guid = wr->e.guid;
   os_mutexLock (&prd->e.lock);
   if (prd->c.topic == NULL)
-    prd->c.topic = wr->topic;
+    prd->c.topic = ddsi_sertopic_ref (wr->topic);
   if (ut_avlLookupIPath (&prd_writers_treedef, &prd->writers, &wr->e.guid, &path))
   {
     DDS_LOG(DDS_LC_DISCOVERY, "  proxy_reader_add_connection(wr %x:%x:%x:%x prd %x:%x:%x:%x) - already connected\n",
@@ -4055,6 +4055,7 @@ static void proxy_endpoint_common_fini (struct entity_common *e, struct proxy_en
 {
   unref_proxy_participant (c->proxypp, c);
 
+  ddsi_sertopic_unref (c->topic);
   nn_xqos_fini (c->xqos);
   os_free (c->xqos);
   unref_addrset (c->as);

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -1039,7 +1039,7 @@ static void rebuild_make_covered(int8_t **covered, const struct writer *wr, int 
   struct wr_prd_match *m;
   ut_avlIter_t it;
   int rdidx, i, j;
-  int8_t *cov = os_malloc((size_t) *nreaders * (size_t) nlocs * sizeof (*covered));
+  int8_t *cov = os_malloc((size_t) *nreaders * (size_t) nlocs * sizeof (*cov));
   for (i = 0; i < *nreaders * nlocs; i++)
     cov[i] = -1;
   rdidx = 0;

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -240,24 +240,28 @@ void local_reader_ary_setinvalid (struct local_reader_ary *x)
 
 static void write_builtin_topic_any (const struct entity_common *e, nn_wctime_t timestamp, bool alive, nn_vendorid_t vendorid, struct ddsi_tkmap_instance *tk)
 {
-  enum ddsi_sertopic_builtin_type type;
-  switch (e->kind)
-  {
-    case EK_PARTICIPANT:
-    case EK_PROXY_PARTICIPANT:
-      type = DSBT_PARTICIPANT;
-      break;
-    case EK_READER:
-    case EK_PROXY_READER:
-      type = DSBT_READER;
-      break;
-    case EK_WRITER:
-    case EK_PROXY_WRITER:
-      type = DSBT_WRITER;
-      break;
-  }
   if (!(e->onlylocal || is_builtin_endpoint(e->guid.entityid, vendorid)))
+  {
+    /* initialize to avoid gcc warning ultimately caused by C's horrible type system */
+    enum ddsi_sertopic_builtin_type type = DSBT_PARTICIPANT;
+    switch (e->kind)
+    {
+      case EK_PARTICIPANT:
+      case EK_PROXY_PARTICIPANT:
+        type = DSBT_PARTICIPANT;
+        break;
+      case EK_READER:
+      case EK_PROXY_READER:
+        type = DSBT_READER;
+        break;
+      case EK_WRITER:
+      case EK_PROXY_WRITER:
+        type = DSBT_WRITER;
+        break;
+    }
+    assert(type != DSBT_PARTICIPANT || (e->kind == EK_PARTICIPANT || e->kind == EK_PROXY_PARTICIPANT));
     ddsi_plugin.builtin_write (type, &e->guid, timestamp, alive);
+  }
   /* tkmap instance only needs to be kept around until the first write of a built-in topic (if none ever happens, it needn't be kept at all): afterward, the WHC of the local built-in topic writer will keep the entry alive. FIXME: the SPDP/SEPD ones currently use default sertopics instead of builtin sertopics, and so use different mappings and different instnace ids. No-one ever sees those ids, so it doesn't matter, but it would nicer if it could actually be the same one.  FIXME: it would also be nicer if the local built-in topics and the SPDP/SEDP writers were the same, but I want the locally created endpoints visible in the built-in topics as well, and those don't exist in the discovery writers ... */
   if (tk)
     ddsi_tkmap_instance_unref (tk);

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -1280,6 +1280,7 @@ void rebuild_or_clear_writer_addrsets(int rebuild)
   }
   os_rwlockUnlock (&gv.qoslock);
   ephash_enum_writer_fini (&est);
+  unref_addrset(empty);
   DDS_LOG(DDS_LC_DISCOVERY, "rebuild_or_delete_writer_addrsets(%d) done\n", rebuild);
 }
 

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -1343,7 +1343,7 @@ err_mc_conn:
   if (gv.pcap_fp)
     os_mutexDestroy (&gv.pcap_lock);
   if (gv.disc_conn_uc != gv.disc_conn_mc)
-    ddsi_conn_free (gv.data_conn_uc);
+    ddsi_conn_free (gv.disc_conn_uc);
   if (gv.data_conn_uc != gv.disc_conn_uc)
     ddsi_conn_free (gv.data_conn_uc);
   free_group_membership(gv.mship);

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -1381,6 +1381,8 @@ err_unicast_sockets:
   (ddsi_plugin.fini_fn) ();
 #ifdef DDSI_INCLUDE_NETWORK_PARTITIONS
 err_network_partition_addrset:
+  for (struct config_networkpartition_listelem *np = config.networkPartitions; np; np = np->next)
+    unref_addrset (np->as);
 #endif
 err_set_ext_address:
   while (gv.recvips)
@@ -1614,6 +1616,10 @@ void rtps_term (void)
     fclose (gv.pcap_fp);
   }
 
+#ifdef DDSI_INCLUDE_NETWORK_PARTITIONS
+  for (struct config_networkpartition_listelem *np = config.networkPartitions; np; np = np->next)
+    unref_addrset (np->as);
+#endif
   unref_addrset (gv.as_disc);
   unref_addrset (gv.as_disc_group);
 

--- a/src/core/ddsi/src/q_plist.c
+++ b/src/core/ddsi/src/q_plist.c
@@ -3477,7 +3477,7 @@ void nn_xqos_fini (nn_xqos_t *xqos)
     else
     {
       /* until proper message buffers arrive */
-      DDS_LOG(DDS_LC_PLIST, "NN_XQOS_FINI free %p\n", xqos->partition.strs);
+      DDS_LOG(DDS_LC_PLIST, "NN_XQOS_FINI free %p\n", (void *) xqos->partition.strs);
       os_free (xqos->partition.strs);
     }
   }
@@ -3488,7 +3488,7 @@ void nn_xqos_fini (nn_xqos_t *xqos)
     else
     {
       /* until proper message buffers arrive */
-      DDS_LOG(DDS_LC_PLIST, "NN_XQOS_FINI free %p\n", xqos->subscription_keys.key_list.strs);
+      DDS_LOG(DDS_LC_PLIST, "NN_XQOS_FINI free %p\n", (void *) xqos->subscription_keys.key_list.strs);
       os_free (xqos->subscription_keys.key_list.strs);
     }
   }

--- a/src/core/ddsi/src/q_plist.c
+++ b/src/core/ddsi/src/q_plist.c
@@ -2779,18 +2779,18 @@ static int init_one_parameter
          one implemented, and fail it if it isn't. I know all RFPs say
          to be tolerant in what is accepted, but that is where the
          bugs & the buffer overflows originate! */
-      if (pid & PID_UNRECOGNIZED_INCOMPATIBLE_FLAG)
+      if (pid & PID_UNRECOGNIZED_INCOMPATIBLE_FLAG) {
         dest->present |= PP_INCOMPATIBLE;
-      else if (pid & PID_VENDORSPECIFIC_FLAG)
+        return ERR_INCOMPATIBLE;
+      } else if (pid & PID_VENDORSPECIFIC_FLAG) {
         return 0;
-      else if (!protocol_version_is_newer (dd->protocol_version) && NN_STRICT_P)
-      {
+      } else if (!protocol_version_is_newer (dd->protocol_version) && NN_STRICT_P) {
         DDS_TRACE("plist/init_one_parameter[pid=%u,mode=STRICT,proto=%u.%u]: undefined paramter id\n",
                 pid, dd->protocol_version.major, dd->protocol_version.minor);
         return ERR_INVALID;
-      }
-      else
+      } else {
         return 0;
+      }
   }
 
   assert (0);

--- a/src/core/ddsi/src/q_receive.c
+++ b/src/core/ddsi/src/q_receive.c
@@ -2703,7 +2703,7 @@ static int handle_submsg_sequence
 
     if (submsg + submsg_size > end)
     {
-      DDS_TRACE(" BREAK (%u %"PRIuSIZE": %p %u)\n", (unsigned) (submsg - msg), submsg_size, msg, (unsigned) len);
+      DDS_TRACE(" BREAK (%u %"PRIuSIZE": %p %u)\n", (unsigned) (submsg - msg), submsg_size, (void *) msg, (unsigned) len);
       break;
     }
 
@@ -2909,7 +2909,7 @@ static int handle_submsg_sequence
   {
     state = "parse:shortmsg";
     state_smkind = SMID_PAD;
-    DDS_TRACE("short (size %"PRIuSIZE" exp %p act %p)", submsg_size, submsg, end);
+    DDS_TRACE("short (size %"PRIuSIZE" exp %p act %p)", submsg_size, (void *) submsg, (void *) end);
     goto malformed;
   }
   return 0;
@@ -3319,7 +3319,7 @@ void trigger_recv_threads (void)
         break;
       }
       case RTM_MANY: {
-        DDS_TRACE("trigger_recv_threads: %d many %p\n", i, gv.recv_threads[i].arg.u.many.ws);
+        DDS_TRACE("trigger_recv_threads: %d many %p\n", i, (void *) gv.recv_threads[i].arg.u.many.ws);
         os_sockWaitsetTrigger (gv.recv_threads[i].arg.u.many.ws);
         break;
       }

--- a/src/core/ddsi/src/q_receive.c
+++ b/src/core/ddsi/src/q_receive.c
@@ -2115,14 +2115,17 @@ static void deliver_user_data_synchronously (struct nn_rsample_chain *sc)
 static void clean_defrag (struct proxy_writer *pwr)
 {
   seqno_t seq = nn_reorder_next_seq (pwr->reorder);
-  struct pwr_rd_match *wn;
-  for (wn = ut_avlFindMin (&pwr_readers_treedef, &pwr->readers); wn != NULL; wn = ut_avlFindSucc (&pwr_readers_treedef, &pwr->readers, wn))
+  if (pwr->n_readers_out_of_sync > 0)
   {
-    if (wn->in_sync == PRMSS_OUT_OF_SYNC)
+    struct pwr_rd_match *wn;
+    for (wn = ut_avlFindMin (&pwr_readers_treedef, &pwr->readers); wn != NULL; wn = ut_avlFindSucc (&pwr_readers_treedef, &pwr->readers, wn))
     {
-      seqno_t seq1 = nn_reorder_next_seq (wn->u.not_in_sync.reorder);
-      if (seq1 < seq)
-        seq = seq1;
+      if (wn->in_sync == PRMSS_OUT_OF_SYNC)
+      {
+        seqno_t seq1 = nn_reorder_next_seq (wn->u.not_in_sync.reorder);
+        if (seq1 < seq)
+          seq = seq1;
+      }
     }
   }
   nn_defrag_notegap (pwr->defrag, 1, seq);

--- a/src/core/ddsi/src/q_xmsg.c
+++ b/src/core/ddsi/src/q_xmsg.c
@@ -256,7 +256,7 @@ static void nn_xmsg_realfree_wrap (void *elem)
 void nn_xmsgpool_free (struct nn_xmsgpool *pool)
 {
   nn_freelist_fini (&pool->freelist, nn_xmsg_realfree_wrap);
-  DDS_TRACE("xmsgpool_free(%p)\n", pool);
+  DDS_TRACE("xmsgpool_free(%p)\n", (void *)pool);
   os_free (pool);
 }
 

--- a/src/examples/throughput/publisher.c
+++ b/src/examples/throughput/publisher.c
@@ -207,7 +207,7 @@ static dds_return_t wait_for_reader(dds_entity_t writer, dds_entity_t participan
   DDS_ERR_CHECK (waitset, DDS_CHECK_REPORT | DDS_CHECK_EXIT);
 
   ret = dds_waitset_attach(waitset, writer, (dds_attach_t)NULL);
-  DDS_ERR_CHECK (waitset, DDS_CHECK_REPORT | DDS_CHECK_EXIT);
+  DDS_ERR_CHECK (ret, DDS_CHECK_REPORT | DDS_CHECK_EXIT);
 
   ret = dds_waitset_wait(waitset, NULL, 0, DDS_SECS(30));
   DDS_ERR_CHECK (ret, DDS_CHECK_REPORT | DDS_CHECK_EXIT);

--- a/src/os/include/os/os_atomics_gcc.h
+++ b/src/os/include/os/os_atomics_gcc.h
@@ -331,6 +331,11 @@ VDDS_INLINE int os_atomic_casvoidp (volatile os_atomic_voidp_t *x, void *exp, vo
 VDDS_INLINE void os_atomic_fence (void) {
   __sync_synchronize ();
 }
+VDDS_INLINE void os_atomic_fence_ldld (void) {
+#if !(defined __i386__ || defined __x86_64__ || defined _M_IX86 || defined _M_X64)
+  __sync_synchronize ();
+#endif
+}
 VDDS_INLINE void os_atomic_fence_acq (void) {
   os_atomic_fence ();
 }

--- a/src/os/include/os/os_atomics_solaris.h
+++ b/src/os/include/os/os_atomics_solaris.h
@@ -231,6 +231,9 @@ VDDS_INLINE void os_atomic_fence (void) {
   membar_exit ();
   membar_enter ();
 }
+VDDS_INLINE void os_atomic_fence_ldld (void) {
+  membar_enter ();
+}
 VDDS_INLINE void os_atomic_fence_acq (void) {
   membar_enter ();
 }

--- a/src/os/include/os/os_atomics_win32.h
+++ b/src/os/include/os/os_atomics_win32.h
@@ -416,6 +416,11 @@ OS_ATOMIC_API_INLINE void os_atomic_fence (void) {
   InterlockedExchange (&tmp, 0);
 #pragma warning (pop)
 }
+OS_ATOMIC_API_INLINE void os_atomic_fence_ldld (void) {
+#if !(defined _M_IX86 || defined _M_X64)
+  os_atomic_fence ();
+#endif
+}
 OS_ATOMIC_API_INLINE void os_atomic_fence_acq (void) {
   os_atomic_fence ();
 }

--- a/src/os/src/os_log.c
+++ b/src/os/src/os_log.c
@@ -188,7 +188,7 @@ dds_set_log_mask(_In_ uint32_t cats)
 static void print_header(char *str)
 {
     int cnt;
-    char *tid, buf[MAX_TID_LEN] = { 0 };
+    char *tid, buf[MAX_TID_LEN+1] = { 0 };
     static const char fmt[] = "%10u.%06d/%*.*s:";
     os_time tv;
     unsigned sec;

--- a/src/os/src/os_socket.c
+++ b/src/os/src/os_socket.c
@@ -142,7 +142,7 @@ static int os_sockaddr_compare(
                 sin1 = (os_sockaddr_in *)sa1;
                 sin2 = (os_sockaddr_in *)sa2;
                 sz = sizeof(sin1->sin_addr);
-                eq = memcmp(&sin1->sin_addr, &sin2->sin_addr, sizeof(sz));
+                eq = memcmp(&sin1->sin_addr, &sin2->sin_addr, sz);
             }
                 break;
         }

--- a/src/os/src/snippets/code/os_posix_thread.c
+++ b/src/os/src/snippets/code/os_posix_thread.c
@@ -155,8 +155,6 @@ os_startRoutineWrapper (
     os_threadContext *context = threadContext;
     uintptr_t resultValue;
 
-    resultValue = 0;
-
 #if !defined(__VXWORKS__) && !defined(__APPLE__) && !defined(__sun)
     prctl(PR_SET_NAME, context->threadName);
 #endif

--- a/src/tools/pubsub/pubsub.c
+++ b/src/tools/pubsub/pubsub.c
@@ -805,7 +805,6 @@ static void print_sampleinfo(dds_time_t *tstart, dds_time_t tnow, const dds_samp
     relt = tnow - *tstart;
 //    instancehandle_to_id(&ihSystemId, &ihLocalId, si->instance_handle);
 //    instancehandle_to_id(&phSystemId, &phLocalId, si->publication_handle);
-    sep = "";
     if (print_metadata & PM_PID) {
         n += printf ("%d", pid);
     }
@@ -826,7 +825,6 @@ static void print_sampleinfo(dds_time_t *tstart, dds_time_t tnow, const dds_samp
     sep = " : ";
     if (print_metadata & PM_STIME) {
         n += printf ("%s%lld.%09lld", n > 0 ? sep : "", (si->source_timestamp/DDS_NSECS_IN_SEC), (si->source_timestamp%DDS_NSECS_IN_SEC));
-        sep = " ";
     }
     sep = " : ";
     if (print_metadata & PM_DGEN) {
@@ -843,7 +841,6 @@ static void print_sampleinfo(dds_time_t *tstart, dds_time_t tnow, const dds_samp
     sep = " : ";
     if (print_metadata & PM_STATE) {
         n += printf ("%s%c%c%c", n > 0 ? sep : "", isc, ssc, vsc);
-        sep = " ";
     }
     if (n > 0) {
         printf(" : ");
@@ -1895,9 +1892,9 @@ static uint32_t subthread(void *vspec) {
     case MODE_ZEROLOAD:
         break;
     case MODE_PRINT:
-        rc = dds_waitset_detach(ws, rdcondA);
+        dds_waitset_detach(ws, rdcondA);
         dds_delete(rdcondA);
-        rc = dds_waitset_detach(ws, rdcondD);
+        dds_waitset_detach(ws, rdcondD);
         dds_delete(rdcondD);
         break;
     case MODE_CHECK:
@@ -1952,9 +1949,8 @@ static uint32_t autotermthread(void *varg __attribute__((unused))) {
         tnow = dds_time();
     }
 
-    rc = dds_waitset_detach(ws, termcond);
-    rc = dds_delete(ws);
-
+    dds_waitset_detach(ws, termcond);
+    dds_delete(ws);
     return 0;
 }
 

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -21,6 +21,10 @@ target_link_libraries(util PUBLIC OSAPI)
 target_include_directories(util PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>" "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/exports/>"
                                         "$<INSTALL_INTERFACE:${INSTALL_PREFIX}/include/>" "$<INSTALL_INTERFACE:${INSTALL_PREFIX}/exports/>")
 
+if(${CMAKE_C_COMPILER_ID} STREQUAL "SunPro")
+  add_definitions(-KPIC)
+endif()
+
 # TODO: improve test inclusion.
 if((BUILD_TESTING) AND ((NOT DEFINED MSVC_VERSION) OR (MSVC_VERSION GREATER "1800")))
   add_subdirectory(tests)

--- a/src/util/include/util/ut_avl.h
+++ b/src/util/include/util/ut_avl.h
@@ -190,7 +190,6 @@ typedef struct ut_avlTreedef {
     size_t avlnodeoffset;
     size_t keyoffset;
     union {
-        int (*cmp) ();
         ut_avlCompare_t comparekk;
         ut_avlCompare_r_t comparekk_r;
     } u;
@@ -239,14 +238,14 @@ typedef struct ut_avlCIter {
 } ut_avlCIter_t;
 
 /* avlnodeoffset and keyoffset must both be in [0,2**31-1] */
-#define UT_AVL_TREEDEF_INITIALIZER(avlnodeoffset, keyoffset, comparekk, augment) { (avlnodeoffset), (keyoffset), { (int (*) ()) (comparekk) }, (augment), 0, 0 }
-#define UT_AVL_TREEDEF_INITIALIZER_INDKEY(avlnodeoffset, keyoffset, comparekk, augment) { (avlnodeoffset), (keyoffset), { (int (*) ()) (comparekk) }, (augment), UT_AVL_TREEDEF_FLAG_INDKEY, 0 }
-#define UT_AVL_TREEDEF_INITIALIZER_ALLOWDUPS(avlnodeoffset, keyoffset, comparekk, augment) { (avlnodeoffset), (keyoffset), { (int (*) ()) (comparekk) }, (augment), UT_AVL_TREEDEF_FLAG_ALLOWDUPS, 0 }
-#define UT_AVL_TREEDEF_INITIALIZER_INDKEY_ALLOWDUPS(avlnodeoffset, keyoffset, comparekk, augment) { (avlnodeoffset), (keyoffset), { (int (*) ()) (comparekk) }, (augment), UT_AVL_TREEDEF_FLAG_INDKEY|UT_AVL_TREEDEF_FLAG_ALLOWDUPS, 0 }
-#define UT_AVL_TREEDEF_INITIALIZER_R(avlnodeoffset, keyoffset, comparekk, cmparg, augment) { (avlnodeoffset), (keyoffset), { (int (*) ()) (comparekk) }, (augment), UT_AVL_TREEDEF_FLAG_R, (cmparg) }
-#define UT_AVL_TREEDEF_INITIALIZER_INDKEY_R(avlnodeoffset, keyoffset, comparekk, cmparg, augment) { (avlnodeoffset), (keyoffset), { (int (*) ()) (comparekk) }, (augment), UT_AVL_TREEDEF_FLAG_INDKEY|UT_AVL_TREEDEF_FLAG_R, (cmparg) }
-#define UT_AVL_TREEDEF_INITIALIZER_R_ALLOWDUPS(avlnodeoffset, keyoffset, comparekk, cmparg, augment) { (avlnodeoffset), (keyoffset), { (int (*) ()) (comparekk) }, (augment), UT_AVL_TREEDEF_FLAG_R|UT_AVL_TREEDEF_FLAG_ALLOWDUPS, (cmparg) }
-#define UT_AVL_TREEDEF_INITIALIZER_INDKEY_R_ALLOWDUPS(avlnodeoffset, keyoffset, comparekk, cmparg, augment) { (avlnodeoffset), (keyoffset), { (int (*) ()) (comparekk) }, (augment), UT_AVL_TREEDEF_FLAG_INDKEY|UT_AVL_TREEDEF_FLAG_R|UT_AVL_TREEDEF_FLAG_ALLOWDUPS, (cmparg) }
+#define UT_AVL_TREEDEF_INITIALIZER(avlnodeoffset, keyoffset, comparekk_, augment) { (avlnodeoffset), (keyoffset), { .comparekk = (comparekk_) }, (augment), 0, 0 }
+#define UT_AVL_TREEDEF_INITIALIZER_INDKEY(avlnodeoffset, keyoffset, comparekk_, augment) { (avlnodeoffset), (keyoffset), { .comparekk = (comparekk_) }, (augment), UT_AVL_TREEDEF_FLAG_INDKEY, 0 }
+#define UT_AVL_TREEDEF_INITIALIZER_ALLOWDUPS(avlnodeoffset, keyoffset, comparekk_, augment) { (avlnodeoffset), (keyoffset), { .comparekk = (comparekk_) }, (augment), UT_AVL_TREEDEF_FLAG_ALLOWDUPS, 0 }
+#define UT_AVL_TREEDEF_INITIALIZER_INDKEY_ALLOWDUPS(avlnodeoffset, keyoffset, comparekk_, augment) { (avlnodeoffset), (keyoffset), { .comparekk = (comparekk_) }, (augment), UT_AVL_TREEDEF_FLAG_INDKEY|UT_AVL_TREEDEF_FLAG_ALLOWDUPS, 0 }
+#define UT_AVL_TREEDEF_INITIALIZER_R(avlnodeoffset, keyoffset, comparekk_, cmparg, augment) { (avlnodeoffset), (keyoffset), { .comparekk_r = (comparekk_) }, (augment), UT_AVL_TREEDEF_FLAG_R, (cmparg) }
+#define UT_AVL_TREEDEF_INITIALIZER_INDKEY_R(avlnodeoffset, keyoffset, comparekk_, cmparg, augment) { (avlnodeoffset), (keyoffset), { .comparekk_r = (comparekk_) }, (augment), UT_AVL_TREEDEF_FLAG_INDKEY|UT_AVL_TREEDEF_FLAG_R, (cmparg) }
+#define UT_AVL_TREEDEF_INITIALIZER_R_ALLOWDUPS(avlnodeoffset, keyoffset, comparekk_, cmparg, augment) { (avlnodeoffset), (keyoffset), { .comparekk_r = (comparekk_) }, (augment), UT_AVL_TREEDEF_FLAG_R|UT_AVL_TREEDEF_FLAG_ALLOWDUPS, (cmparg) }
+#define UT_AVL_TREEDEF_INITIALIZER_INDKEY_R_ALLOWDUPS(avlnodeoffset, keyoffset, comparekk_, cmparg, augment) { (avlnodeoffset), (keyoffset), { .comparekk_r = (comparekk_) }, (augment), UT_AVL_TREEDEF_FLAG_INDKEY|UT_AVL_TREEDEF_FLAG_R|UT_AVL_TREEDEF_FLAG_ALLOWDUPS, (cmparg) }
 
 /* Not maintaining # nodes */
 


### PR DESCRIPTION
Various small fixes:

- a fix for deadlock on unmatching a reader while in ``dds_write`` (#41) — there are arguments against this fix, as there is no guarantee that an application will never observe an unmatch event before the corresponding match event, but that it is quite unlikely in practice, and certainly still better than a deadlock ...
- proxy readers/writers referred to topic definitions by just storing a pointer, but those topics can be freed ... so now it is refcounted (it may be better to erase the topic definition instead of retaining it, but that's for some other time)
- use the correct size in comparing IPv4 addresses — on a 64-bit machine it would compare too many bytes (curiously enough, it nonetheless worked)
- consistent use of ``_nokey`` functions for keyless topics, I am pretty sure there was a discrepancy in the hash value generation but even if there wasn't a discrepancy, it was wasting time
- fixes for (fortunately mostly harmless) use of uninitialised memory
- fix for a memory leak of the address sets for network partitions
- fix for an oversized memory allocation in calculating the set of addresses to use to get data to all matched readers
- handling of "incompatible if unrecognized" flag in parameter list decoding (#79)
- code refactoring for the benefit of static analysis
- tracing cleanup by increasing the buffer size for the thread name by 1
- tracing cleanup for SPDP handling: if the "discovery" tracing is enabled, but not all tracing, then it would continue collecting some data in the trace buffer until that buffer filled up
- fix for building on Solaris (-KPIC is needed also for code in the util directory)
- addition of a load-load barrier function, and use in the lookup function of the concurrent hash table (on an intel one doesn't need a L-L barrier and the expensive ``mfence`` instruction that was there is rather expensive)
- ``cleanup_defrag`` did an unnecessary scan of all readers in the vast majority of cases
- calling ``memset`` when allocating a new sample struct in the RHC is a significant overhead (5% or so)
- removal of no-longer useful backreference from ``tkmap_instance`` to ``tkmap``
