### PR TITLE
fix read of uninitialized program name in dds_init

### DIFF
--- a/src/core/ddsc/src/dds_init.c
+++ b/src/core/ddsc/src/dds_init.c
@@ -44,7 +44,7 @@ dds_init(dds_domainid_t domain)
 {
   dds_return_t ret = DDS_RETCODE_OK;
   const char * uri;
-  char progname[50];
+  char progname[50] = "UNKNOWN"; /* FIXME: once retrieving process names is back in */
   char hostname[64];
   uint32_t len;
   os_mutex *init_mutex;


### PR DESCRIPTION
dds_init generates an entity name for the participant derived from the
process name and process id, but the name is currently uninitialised
(temporarily so, caused by a recent update to the OS abstraction layer).

Signed-off-by: Erik Boasson <eb@ilities.com>