### PR TITLE
Add throughput figures to README and scripting used to generate it

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,24 @@ Assuming that **git** is also available on your machine then, simply do:
     $ make install
 
 At this point you are ready to use **cyclonedds** for your next DDS project!
- 
+
+
+## Performance
+
+Median small message throughput measured using the Throughput example between two Intel(R) Xeon(R)
+CPU E3-1270 V2 @ 3.50GHz (that's 2012 hardware ...) running Linux 3.8.13-rt14.20.el6rt.x86_64,
+connected via a quiet GbE and when using gcc-6.2.0 for a RelWithDebInfo build is:
+
+![Throughput](https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/assets/performance/throughput-polling.png)
+
+This is with the subscriber in polling mode. Listener mode is marginally slower; using a waitset the
+message rate for minimal size messages drops to 600k sample/s in synchronous delivery mode and about
+750k samples/s in asynchronous delivery mode. The configuration is an out-of-the-box configuration,
+tweaked only to increase the high-water mark for the reliability window on the writer side. For
+details, see the scripts in the ``performance`` directory and the [data](https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/assets/performance/throughput.txt).
+
+There is some data on roundtrip latency below.
+
 
 ## Examples
 Now that you have built and installed **cyclonecdds** it is time to experiment with some examples.
@@ -63,7 +80,7 @@ On another terminal, start the application that will be sending the ping.
        10     28075       17       16       23       46      28075        8        6      28075        1        0
 
            
-The number above were measure on Mac running a 4,2 GHz Intel Core i7 on December 12th 2018. From these number you can see how the roundtrip is incredibly stable and the minimal latency is now down to  17 micro-seconds (used to be 25 micro-seconds) on this HW.
+The number above were measure on Mac running a 4,2 GHz Intel Core i7 on December 12th 2018. From these number you can see how the roundtrip is incredibly stable and the minimal latency is now down to 17 micro-seconds (used to be 25 micro-seconds) on this HW.
 
 ## Documentation
 The Cyclone DDS documentation is available [here](http://cdds.io/docs).

--- a/performance/ethload
+++ b/performance/ethload
@@ -1,0 +1,48 @@
+#!/usr/bin/perl -w
+
+use strict;
+use bignum;
+use Time::HiRes qw (time);
+
+if (@ARGV != 2) {
+  print STDERR "usage: $0 device {100|1000}\n";
+  exit 1;
+}
+
+my $devname = $ARGV[0];
+my $speed = $ARGV[1] * 1e6;
+
+$| = 1;
+my ($lt, $t, $lrecv, $lxmit);
+while (1) {
+  open FH, "< /proc/net/dev" or die "can't open /proc/net/dev";
+  $t = time;
+  my $info = undef;
+  while (<FH>) {
+    chomp;
+    if (s/^\s+$devname\s*:\s*//) {
+      $info = $_;
+      last;
+    }
+  }
+  close FH;
+  die "can't locate info for $devname" unless defined $info;
+
+  my @info = split ' ', $info;
+  my $recv = $info[0] + 0;
+  my $xmit = $info[8] + 0;
+
+  if (defined $lt) {
+    my $dr = $recv - $lrecv;
+    my $dx = $xmit - $lxmit;
+    my $dt = $t - $lt;
+    my $ur = 100 * (8 * $dr) / ($dt * $speed);
+    my $xr = 100 * (8 * $dx) / ($dt * $speed);
+    printf "r %5.1f x %5.1f (%8d %8d)\n", $ur, $xr, $dr, $dx;
+  }
+
+  $lt = $t;
+  $lrecv = $recv;
+  $lxmit = $xmit;
+  sleep 1;
+}

--- a/performance/throughput-test
+++ b/performance/throughput-test
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+if [ $# -ne 1 ] ; then
+    echo >&2 <<EOF
+usage: $0 user@remote
+
+It assumes various things:
+- ssh user@remote succeeds without a password
+- network device to use is em2 (otherwise, change the config)
+- it assumes it is run from the build directory (actually, it verifies this)
+- it assumes ThroughputPublisher can be found in exactly the same place on the remote
+- probably some other things as well ... use with care.
+EOF
+    exit 1
+fi
+remote=$1
+dir=`dirname $0`
+ethload=$dir/ethload
+
+cfg=cdds-simple.xml
+cat >$cfg <<EOF
+<CycloneDDS>
+  <Domain>
+    <Id>17</Id>
+  </Domain>
+  <DDSI2E>
+    <General>
+      <NetworkInterfaceAddress>em2</NetworkInterfaceAddress>
+    </General>
+    <Internal>
+      <Watermarks>
+        <WhcHigh>500kB</WhcHigh>
+      </Watermarks>
+      <SynchronousDeliveryPriorityThreshold>${ASYNC:-0}</SynchronousDeliveryPriorityThreshold>
+    </Internal>
+  </DDSI2E>
+</CycloneDDS>
+EOF
+
+if [ ! -x bin/ThroughputPublisher -o ! -x bin/ThroughputSubscriber -o ! -x $ethload ] ; then
+    echo "some check for existence of a file failed on the local machine" >&2
+    exit 1
+fi
+
+mkdir throughput-result || { echo "failed to create throughput-result directory" >&2 ; exit 1 ; }
+
+export CYCLONEDDS_URI=file://$PWD/$cfg
+scp $cfg $remote:$PWD || { echo "failed to copy $cfg to $remote:$PWD" >&2 ; exit 1 ; }
+
+for async in 0 1 ; do
+    for mode in -1 0 1 ; do
+        echo "======== ASYNC $async MODE $mode ========="
+        cat > run-publisher.tmp <<EOF
+export CYCLONEDDS_URI=$CYCLONEDDS_URI
+export ASYNC=$async
+cd $PWD
+rm -f pub-top.log
+for size in 0 16 32 64 128 256 ; do
+  echo "size \$size"
+  bin/ThroughputPublisher \$size > pub.log & ppid=\$!
+  top -b -d1 -p \$ppid >> pub-top.log & tpid=\$!
+  sleep 20
+  kill \$tpid
+  kill -2 \$ppid
+  wait \$ppid
+  sleep 5
+done
+wait
+EOF
+        scp run-publisher.tmp $remote:$PWD || { echo "failed to copy $cfg to $remote:$PWD" >&2 ; exit 2 ; }
+
+        export ASYNC=$async
+
+        outdir=throughput-result/data-async$async-mode$mode
+        mkdir $outdir
+
+        rm -f sub-top.log
+        $ethload em2 1000 > $outdir/sub-ethload.log & lpid=$!
+        bin/ThroughputSubscriber 0 $mode > $outdir/sub.log & spid=$!
+        top -b -d1 -p $spid >> $outdir/sub-top.log & tpid=$!
+        tail -f $outdir/sub.log & xpid=$!
+        ssh $remote ". $PWD/run-publisher.tmp"
+        kill $tpid
+        kill -2 $spid
+        sleep 1
+        kill $lpid $xpid
+        wait
+        scp $remote:$PWD/{pub-top.log,pub.log} $outdir
+    done
+done

--- a/performance/throughput-test-extract
+++ b/performance/throughput-test-extract
@@ -1,0 +1,60 @@
+#!/usr/bin/perl -w
+
+use strict;
+
+my @dirs = ("async0-mode-1", "async0-mode0", "async0-mode1",
+            "async1-mode-1", "async1-mode0", "async1-mode1");
+
+my $dataset = 0;
+my $basedir = "throughput-result";
+for my $dir (@dirs) {
+  my @loads = ();
+  
+  {
+    open LH, "< $basedir/data-$dir/sub-ethload.log" or die "can't open $basedir/data-$dir/sub-ethload.log";
+    my @curload = ();
+    while (<LH>) {
+      die unless /^r +([0-9.]+).*\( *(\d+)/;
+      push @curload, $2 if $1 > 20;
+      if (@curload && $1 < 20) {
+        push @loads, median (@curload);
+        @curload = ();
+      }
+    }
+    push @loads, median (@curload) if @curload;
+    close LH;
+  }
+  
+  open FH, "< $basedir/data-$dir/sub.log" or die "can't open $basedir/data-$dir/sub.log";
+  print "\n\n" if $dataset++;
+  print "# mode $dir\n";
+  print "# payloadsize rate[samples/s] appl.bandwidth[Mb/s] raw.bandwidth[Mb/s]\n";
+  my $psz;
+  my @rate = ();
+  while (<FH>) {
+    next unless /Payload size: ([0-9]+).*Transfer rate: ([0-9.]+)/;
+    my $psz_cur = $1; my $rate_cur = $2;
+    $psz = $psz_cur unless defined $psz;
+    if ($psz != $psz_cur) {
+      # this is a bit yucky: scan the ethload for the next set of substantially-above-zero numbers
+      # where "substantially-above-zero" is defined as > 20%, cos that seems to work fine on a
+      # quiescent network
+      my $load = shift @loads;
+      my $rate = median (@rate);
+      printf "%d %f %f %f\n", $psz, $rate, $rate * (8 + $psz) / 125e3, $load / 125e3;
+      @rate = ();
+    }
+    $psz = $psz_cur;
+    push @rate, ($rate_cur + 0.0);
+  }
+  my $load = shift @loads;
+  my $rate = median (@rate);
+  printf "%d %f %f %f\n", $psz, $rate, $rate * (8 + $psz) / 125e3, $load / 125e3;
+  close FH;
+}
+
+sub median {
+  my @xs = sort { $a <=> $b } @_;
+  return (@xs % 2) ? $xs[(@xs - 1) / 2] : ($xs[@xs/2 - 1] + $xs[@xs/2]) / 2;
+}
+

--- a/performance/throughput-test-plot
+++ b/performance/throughput-test-plot
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+`dirname $0`/throughput-test-extract > data.txt
+gnuplot <<\EOF
+set term png size 1024,768
+set output "throughput-polling.png"
+set st d l
+set title "Throughput (polling with 1ms sleeps)"
+set ylabel "M sample/s"
+set y2label "Mbps"
+set y2tics
+set xlabel "payload size [bytes]"
+p "data.txt" i 5 u 1:($2/1e6) ti "rate [M sample/s]", "" i 5 u 1:3 axes x1y2 ti "app bandwidth [Mbps]", "" i 5 u 1:4 axes x1y2 ti "GbE bandwidth [Mbps]"
+EOF


### PR DESCRIPTION
For a long time, the only performance figures available on were some roundtrip figures over loopback. This PR adds small message throughput (8 bytes to 256 bytes) over GbE between a pair of reasonable machines (from 2012 ...) results to the README, as well as the scripts used to generate them.