### PR TITLE
Fix take with query condition and the curious case of a netmask without an address family

### DIFF
--- a/src/core/ddsc/src/dds_rhc.c
+++ b/src/core/ddsc/src/dds_rhc.c
@@ -1874,6 +1874,7 @@ static int dds_rhc_take_w_qminv
                 {
                   /* The filter didn't match, so free the deserialised copy. */
                   ddsi_sertopic_free_sample (rhc->topic, values[n], DDS_FREE_CONTENTS);
+                  psample = sample;
                 }
               }
               sample = sample1;

--- a/src/os/src/posix/os_platform_ifaddrs.c
+++ b/src/os/src/posix/os_platform_ifaddrs.c
@@ -43,6 +43,11 @@ copyaddr(os_ifaddrs_t **ifap, const struct ifaddrs *sys_ifa)
         {
             err = errno;
         }
+        /* Seen on macOS using OpenVPN: netmask without an address family,
+           in which case copy it from the interface address */
+        if (ifa->addr && ifa->netmask && ifa->netmask->sa_family == 0) {
+            ifa->netmask->sa_family = ifa->addr->sa_family;
+        }
     }
 
     if (err == 0) {


### PR DESCRIPTION
This pull request fixes the issue with taking some but not all samples from an instance using a query condition (#90). Test case added.

It also fixes an issue I ran into by accident where the netmask of an IPv4 interface returned by getifaddrs did not have the address family filled in. This was OpenVPN active on macOS, but I don't know all the cases where this could happen. So now the Unix version of os_getifaddrs just sets the address family of the netmask to that of the address if it wasn't already set.