### PR TITLE
the "tracing" category in the configuration should only affect the "trace" sink and leave the "log" sink alone

### DIFF
--- a/src/core/ddsc/src/dds_init.c
+++ b/src/core/ddsc/src/dds_init.c
@@ -77,7 +77,7 @@ dds_init(dds_domainid_t domain)
   dds_cfgst = config_init (uri);
   if (dds_cfgst == NULL)
   {
-    DDS_ERROR("Failed to parse configuration XML file %s\n", uri);
+    DDS_LOG(DDS_LC_CONFIG, "Failed to parse configuration XML file %s\n", uri);
     ret = DDS_ERRNO(DDS_RETCODE_ERROR);
     goto fail_config;
   }
@@ -109,7 +109,7 @@ dds_init(dds_domainid_t domain)
 
   if (rtps_config_prep(dds_cfgst) != 0)
   {
-    DDS_ERROR("Failed to configure RTPS\n");
+    DDS_LOG(DDS_LC_CONFIG, "Failed to configure RTPS\n");
     ret = DDS_ERRNO(DDS_RETCODE_ERROR);
     goto fail_rtps_config;
   }
@@ -132,7 +132,7 @@ dds_init(dds_domainid_t domain)
 
   if (rtps_init() < 0)
   {
-    DDS_ERROR("Failed to initialize RTPS\n");
+    DDS_LOG(DDS_LC_CONFIG, "Failed to initialize RTPS\n");
     ret = DDS_ERRNO(DDS_RETCODE_ERROR);
     goto fail_rtps_init;
   }

--- a/src/core/ddsc/src/dds_stream.c
+++ b/src/core/ddsc/src/dds_stream.c
@@ -163,7 +163,7 @@ size_t dds_stream_check_optimize (_In_ const dds_topic_descriptor_t * desc)
   dds_sample_free_contents (sample, desc->m_ops);
   dds_free (sample);
   dds_stream_fini (&os);
-  DDS_INFO("Marshalling for type: %s is%s optimised\n", desc->m_typename, size ? "" : " not");
+  DDS_TRACE("Marshalling for type: %s is%s optimised\n", desc->m_typename, size ? "" : " not");
   return size;
 }
 

--- a/src/core/ddsi/src/ddsi_raweth.c
+++ b/src/core/ddsi/src/ddsi_raweth.c
@@ -242,7 +242,7 @@ static ddsi_tran_conn_t ddsi_raweth_create_conn (uint32_t port, ddsi_tran_qos_t 
   uc->m_base.m_write_fn = ddsi_raweth_conn_write;
   uc->m_base.m_disable_multiplexing_fn = 0;
 
-  DDS_INFO("ddsi_raweth_create_conn %s socket %d port %u\n", mcast ? "multicast" : "unicast", uc->m_sock, uc->m_base.m_base.m_port);
+  DDS_TRACE("ddsi_raweth_create_conn %s socket %d port %u\n", mcast ? "multicast" : "unicast", uc->m_sock, uc->m_base.m_base.m_port);
   return uc ? &uc->m_base : NULL;
 }
 
@@ -294,7 +294,7 @@ static int ddsi_raweth_leave_mc (ddsi_tran_conn_t conn, const nn_locator_t *srcl
 static void ddsi_raweth_release_conn (ddsi_tran_conn_t conn)
 {
   ddsi_raweth_conn_t uc = (ddsi_raweth_conn_t) conn;
-  DDS_INFO
+  DDS_TRACE
   (
     "ddsi_raweth_release_conn %s socket %d port %d\n",
     conn->m_base.m_multicast ? "multicast" : "unicast",
@@ -359,7 +359,7 @@ static void ddsi_raweth_deinit(void)
   if (os_atomic_dec32_nv(&init_g) == 0) {
     if (ddsi_raweth_config_g.mship)
       free_group_membership(ddsi_raweth_config_g.mship);
-    DDS_LOG(DDS_LC_INFO | DDS_LC_CONFIG, "raweth de-initialized\n");
+    DDS_LOG(DDS_LC_CONFIG, "raweth de-initialized\n");
   }
 }
 
@@ -396,7 +396,7 @@ int ddsi_raweth_init (void)
 
     ddsi_raweth_config_g.mship = new_group_membership();
 
-    DDS_LOG(DDS_LC_INFO | DDS_LC_CONFIG, "raweth initialized\n");
+    DDS_LOG(DDS_LC_CONFIG, "raweth initialized\n");
   }
   return 0;
 }

--- a/src/core/ddsi/src/ddsi_udp.c
+++ b/src/core/ddsi/src/ddsi_udp.c
@@ -273,7 +273,7 @@ static ddsi_tran_conn_t ddsi_udp_create_conn
     uc->m_base.m_write_fn = ddsi_udp_conn_write;
     uc->m_base.m_disable_multiplexing_fn = ddsi_udp_disable_multiplexing;
 
-    DDS_INFO
+    DDS_TRACE
     (
       "ddsi_udp_create_conn %s socket %"PRIsock" port %u\n",
       mcast ? "multicast" : "unicast",
@@ -396,7 +396,7 @@ static int ddsi_udp_leave_mc (ddsi_tran_conn_t conn, const nn_locator_t *srcloc,
 static void ddsi_udp_release_conn (ddsi_tran_conn_t conn)
 {
   ddsi_udp_conn_t uc = (ddsi_udp_conn_t) conn;
-  DDS_INFO
+  DDS_TRACE
   (
     "ddsi_udp_release_conn %s socket %"PRIsock" port %u\n",
     conn->m_base.m_multicast ? "multicast" : "unicast",
@@ -415,7 +415,7 @@ void ddsi_udp_fini (void)
     if(os_atomic_dec32_nv (&ddsi_udp_init_g) == 0) {
         free_group_membership(ddsi_udp_config_g.mship);
         memset (&ddsi_udp_factory_g, 0, sizeof (ddsi_udp_factory_g));
-        DDS_LOG(DDS_LC_INFO | DDS_LC_CONFIG, "udp finalized\n");
+        DDS_LOG(DDS_LC_CONFIG, "udp finalized\n");
     }
 }
 
@@ -505,7 +505,7 @@ static void ddsi_udp_deinit(void)
   if (os_atomic_dec32_nv(&ddsi_udp_init_g) == 0) {
     if (ddsi_udp_config_g.mship)
       free_group_membership(ddsi_udp_config_g.mship);
-    DDS_LOG(DDS_LC_INFO | DDS_LC_CONFIG, "udp de-initialized\n");
+    DDS_LOG(DDS_LC_CONFIG, "udp de-initialized\n");
   }
 }
 
@@ -550,7 +550,7 @@ int ddsi_udp_init (void)
 
     ddsi_factory_add (&ddsi_udp_factory_g);
 
-    DDS_LOG(DDS_LC_INFO | DDS_LC_CONFIG, "udp initialized\n");
+    DDS_LOG(DDS_LC_CONFIG, "udp initialized\n");
   }
   return 0;
 }

--- a/src/core/ddsi/src/q_config.c
+++ b/src/core/ddsi/src/q_config.c
@@ -2851,7 +2851,7 @@ struct cfgst * config_init
                 case Q_CIPHER_NULL:
                     /* nop */
                     if ( s->key && strlen(s->key) > 0 ) {
-                        DDS_ERROR("config: DDSI2Service/Security/SecurityProfile[@cipherkey]: %s: cipher key not required\n", s->key);
+                        DDS_INFO("config: DDSI2Service/Security/SecurityProfile[@cipherkey]: %s: cipher key not required\n", s->key);
                     }
                     break;
 

--- a/src/core/ddsi/src/q_ddsi_discovery.c
+++ b/src/core/ddsi/src/q_ddsi_discovery.c
@@ -538,7 +538,7 @@ static int handle_SPDP_alive (const struct receiver_state *rst, nn_wctime_t time
            NN_BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_WRITER)) &&
       config.assume_rti_has_pmd_endpoints)
   {
-    DDS_WARNING("data (SPDP, vendor %u.%u): assuming unadvertised PMD endpoints do exist\n",
+    DDS_LOG(DDS_LC_DISCOVERY, "data (SPDP, vendor %u.%u): assuming unadvertised PMD endpoints do exist\n",
                  rst->vendor.id[0], rst->vendor.id[1]);
     builtin_endpoint_set |=
       NN_BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_READER |
@@ -1837,9 +1837,9 @@ int builtins_dqueue_handler (const struct nn_rsample_info *sampleinfo, const str
           pid = PID_ENDPOINT_GUID;
           break;
         default:
-          DDS_WARNING("data(builtin, vendor %u.%u): %x:%x:%x:%x #%"PRId64": mapping keyhash to ENDPOINT_GUID",
-                       sampleinfo->rst->vendor.id[0], sampleinfo->rst->vendor.id[1],
-                       PGUID (srcguid), sampleinfo->seq);
+          DDS_LOG(DDS_LC_DISCOVERY, "data(builtin, vendor %u.%u): %x:%x:%x:%x #%"PRId64": mapping keyhash to ENDPOINT_GUID",
+                  sampleinfo->rst->vendor.id[0], sampleinfo->rst->vendor.id[1],
+                  PGUID (srcguid), sampleinfo->seq);
           pid = PID_ENDPOINT_GUID;
           break;
       }
@@ -1882,9 +1882,9 @@ int builtins_dqueue_handler (const struct nn_rsample_info *sampleinfo, const str
       handle_SEDP_GROUP (sampleinfo->rst, timestamp, statusinfo, datap, datasz);
       break;
     default:
-      DDS_WARNING ("data(builtin, vendor %u.%u): %x:%x:%x:%x #%"PRId64": not handled\n",
-                   sampleinfo->rst->vendor.id[0], sampleinfo->rst->vendor.id[1],
-                   PGUID (srcguid), sampleinfo->seq);
+      DDS_LOG (DDS_LC_DISCOVERY, "data(builtin, vendor %u.%u): %x:%x:%x:%x #%"PRId64": not handled\n",
+               sampleinfo->rst->vendor.id[0], sampleinfo->rst->vendor.id[1],
+               PGUID (srcguid), sampleinfo->seq);
       break;
   }
 

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -2753,7 +2753,7 @@ static void new_writer_guid_common_init (struct writer *wr, const struct ddsi_se
   if (wr->xqos->liveliness.kind != NN_AUTOMATIC_LIVELINESS_QOS ||
       nn_from_ddsi_duration (wr->xqos->liveliness.lease_duration) != T_NEVER)
   {
-    DDS_LOG(DDS_LC_INFO | DDS_LC_DISCOVERY, "writer %x:%x:%x:%x: incorrectly treating it as of automatic liveliness kind with lease duration = inf (%d, %"PRId64")\n", PGUID (wr->e.guid), (int) wr->xqos->liveliness.kind, nn_from_ddsi_duration (wr->xqos->liveliness.lease_duration));
+    DDS_LOG(DDS_LC_DISCOVERY, "writer %x:%x:%x:%x: incorrectly treating it as of automatic liveliness kind with lease duration = inf (%d, %"PRId64")\n", PGUID (wr->e.guid), (int) wr->xqos->liveliness.kind, nn_from_ddsi_duration (wr->xqos->liveliness.lease_duration));
   }
   wr->lease_duration = T_NEVER; /* FIXME */
 
@@ -3237,7 +3237,7 @@ static struct reader * new_reader_guid
   if (rd->xqos->liveliness.kind != NN_AUTOMATIC_LIVELINESS_QOS ||
       nn_from_ddsi_duration (rd->xqos->liveliness.lease_duration) != T_NEVER)
   {
-    DDS_LOG(DDS_LC_INFO | DDS_LC_DISCOVERY, "reader %x:%x:%x:%x: incorrectly treating it as of automatic liveliness kind with lease duration = inf (%d, %"PRId64")\n", PGUID (rd->e.guid), (int) rd->xqos->liveliness.kind, nn_from_ddsi_duration (rd->xqos->liveliness.lease_duration));
+    DDS_LOG(DDS_LC_DISCOVERY, "reader %x:%x:%x:%x: incorrectly treating it as of automatic liveliness kind with lease duration = inf (%d, %"PRId64")\n", PGUID (rd->e.guid), (int) rd->xqos->liveliness.kind, nn_from_ddsi_duration (rd->xqos->liveliness.lease_duration));
   }
 
 #ifdef DDSI_INCLUDE_NETWORK_PARTITIONS

--- a/src/core/ddsi/src/q_plist.c
+++ b/src/core/ddsi/src/q_plist.c
@@ -1866,9 +1866,8 @@ static int do_guid (nn_guid_t *dst, uint64_t *present, uint64_t fl, int (*valid)
     if (fl == PP_PARTICIPANT_GUID && vendor_is_twinoaks (dd->vendorid) &&
         dst->entityid.u == 0 && ! NN_STRICT_P)
     {
-      DDS_WARNING("plist(vendor %u.%u): rewriting invalid participant guid %x:%x:%x:%x\n",
-                  dd->vendorid.id[0], dd->vendorid.id[1],
-                  dst->prefix.u[0], dst->prefix.u[1], dst->prefix.u[2], dst->entityid.u);
+      DDS_LOG(DDS_LC_DISCOVERY, "plist(vendor %u.%u): rewriting invalid participant guid %x:%x:%x:%x\n",
+              dd->vendorid.id[0], dd->vendorid.id[1], PGUID (*dst));
       dst->entityid.u = NN_ENTITYID_PARTICIPANT;
     }
     else

--- a/src/core/ddsi/src/q_receive.c
+++ b/src/core/ddsi/src/q_receive.c
@@ -799,18 +799,9 @@ static int handle_AckNack (struct receiver_state *rst, nn_etime_t tnow, const Ac
     nn_wctime_t tstamp_now = now ();
     nn_wctime_t tstamp_msg = nn_wctime_from_ddsi_time (timestamp);
     nn_lat_estim_update (&rn->hb_to_ack_latency, tstamp_now.v - tstamp_msg.v);
-    if ((dds_get_log_mask() & (DDS_LC_TRACE | DDS_LC_INFO)) &&
-        tstamp_now.v > rn->hb_to_ack_latency_tlastlog.v + 10 * T_SECOND)
+    if ((dds_get_log_mask() & DDS_LC_TRACE) && tstamp_now.v > rn->hb_to_ack_latency_tlastlog.v + 10 * T_SECOND)
     {
-      if (dds_get_log_mask() & DDS_LC_TRACE)
-        nn_lat_estim_log (DDS_LC_TRACE, NULL, &rn->hb_to_ack_latency);
-      else if (dds_get_log_mask() & DDS_LC_INFO)
-      {
-        char tagbuf[2*(4*8+3) + 4 + 1];
-        (void) snprintf (tagbuf, sizeof (tagbuf), "%x:%x:%x:%x -> %x:%x:%x:%x", PGUID (src), PGUID (dst));
-        if (nn_lat_estim_log (DDS_LC_INFO, tagbuf, &rn->hb_to_ack_latency))
-          DDS_LOG(DDS_LC_INFO, "\n");
-      }
+      nn_lat_estim_log (DDS_LC_TRACE, NULL, &rn->hb_to_ack_latency);
       rn->hb_to_ack_latency_tlastlog = tstamp_now;
     }
   }
@@ -856,7 +847,7 @@ static int handle_AckNack (struct receiver_state *rst, nn_etime_t tnow, const Ac
       rn->seq = wr->seq;
     }
     ut_avlAugmentUpdate (&wr_readers_treedef, rn);
-    DDS_WARNING("writer %x:%x:%x:%x considering reader %x:%x:%x:%x responsive again\n", PGUID (wr->e.guid), PGUID (rn->prd_guid));
+    DDS_LOG(DDS_LC_THROTTLE, "writer %x:%x:%x:%x considering reader %x:%x:%x:%x responsive again\n", PGUID (wr->e.guid), PGUID (rn->prd_guid));
   }
 
   /* Second, the NACK bits (literally, that is). To do so, attempt to

--- a/src/core/ddsi/src/q_servicelease.c
+++ b/src/core/ddsi/src/q_servicelease.c
@@ -116,7 +116,7 @@ static uint32_t lease_renewal_thread (struct nn_servicelease *sl)
               msg = "failed to make progress";
             else
               msg = "once again made progress";
-            DDS_WARNING("thread %s %s\n", name ? name : "(anon)", msg);
+            DDS_INFO("thread %s %s\n", name ? name : "(anon)", msg);
             sl->av_ary[i].alive = (char) alive;
           }
         }

--- a/src/core/ddsi/src/q_thread.c
+++ b/src/core/ddsi/src/q_thread.c
@@ -135,7 +135,7 @@ lookup_thread_state(
                 os_osInit();
                 ts1->extTid = tid;
                 ts1->tid = tid;
-                DDS_LOG(DDS_LC_INFO, "started application thread %s\n", tname);
+                DDS_LOG(DDS_LC_TRACE, "started application thread %s\n", tname);
                 os_threadCleanupPush(&cleanup_thread_state, NULL);
             }
             os_mutexUnlock(&thread_states.lock);
@@ -275,7 +275,7 @@ struct thread_state1 *create_thread (_In_z_ const char *name, _In_ uint32_t (*f)
     DDS_FATAL("create_thread: %s: os_threadCreate failed\n", name);
     goto fatal;
   }
-  DDS_LOG(DDS_LC_INFO, "started new thread 0x%"PRIxMAX" : %s\n", os_threadIdToInteger (tid), name);
+  DDS_LOG(DDS_LC_TRACE, "started new thread 0x%"PRIxMAX" : %s\n", os_threadIdToInteger (tid), name);
   ts1->extTid = tid; /* overwrite the temporary value with the correct external one */
   os_mutexUnlock (&thread_states.lock);
   return ts1;

--- a/src/os/include/os/posix/os_platform_socket.h
+++ b/src/os/include/os/posix/os_platform_socket.h
@@ -64,6 +64,7 @@ extern "C" {
 #define os_sockENETUNREACH  ENETUNREACH /* Network is unreachable */
 #define os_sockENOBUFS      ENOBUFS     /* No buffer space available */
 #define os_sockECONNRESET   ECONNRESET  /* Connection reset by peer */
+#define os_sockEPIPE        EPIPE       /* Connection reset by peer */
 
     typedef int os_socket; /* signed */
     #define PRIsock "d"

--- a/src/os/src/os_log.c
+++ b/src/os/src/os_log.c
@@ -146,6 +146,7 @@ void dds_set_log_file(_In_ FILE *file)
     if (sinks[LOG].funcs[SET] == default_sink) {
         sinks[LOG].ptr = sinks[LOG].out;
     }
+    set_active_log_sinks();
     unlock_sink();
 }
 
@@ -156,6 +157,7 @@ void dds_set_trace_file(_In_ FILE *file)
     if (sinks[TRACE].funcs[SET] == default_sink) {
         sinks[TRACE].ptr = sinks[TRACE].out;
     }
+    set_active_log_sinks();
     unlock_sink();
 }
 

--- a/src/os/tests/log.c
+++ b/src/os/tests/log.c
@@ -350,10 +350,6 @@ CU_Test(dds_log, synchronous_sink_changes)
     os_mutexLock(&mutex);
     dds_set_log_sink(&block, &arg);
     os_threadAttrInit(&tattr);
-#ifdef __APPLE__
-    tattr.schedPriority = sched_get_priority_min(SCHED_OTHER);
-#endif /* __APPLE__ */
-
     res = os_threadCreate(&tid, "foobar", &tattr, &run, &arg);
     CU_ASSERT_EQUAL_FATAL(res, os_resultSuccess);
     os_condWait(&cond, &mutex);

--- a/src/os/tests/thread.c
+++ b/src/os/tests/thread.c
@@ -70,11 +70,6 @@ uint32_t threadMemory_thread (_In_opt_ void *args)
     returnval = os_threadMemMalloc (3, 100);
     CU_ASSERT (returnval != NULL);
 
-    /* Check os_threadMemMalloc with fail result for child thread for index already in use */
-    printf("Starting os_threadMemMalloc_004\n");
-    returnval = os_threadMemMalloc (3, 100);
-    CU_ASSERT (returnval == NULL);
-
     /* Check os_threadMemGet for child thread and non allocated index */
     printf("Starting os_threadMemGet_003\n");
     returnval = os_threadMemGet (OS_THREAD_WARNING);
@@ -637,24 +632,6 @@ CU_Test(os_thread, memmalloc)
     printf ("Starting os_thread_memmalloc_001\n");
     returnval = os_threadMemMalloc (3, 100);
     CU_ASSERT (returnval != NULL);
-
-    /* Check os_threadMemMalloc with fail result for main thread
-       for index already in use */
-    printf ("Starting os_thread_memmalloc_002\n");
-    returnval = os_threadMemMalloc (3, 100);
-    CU_ASSERT (returnval == NULL);
-
-    /* Check os_threadMemMalloc with fail result for main thread
-       for index < 0 */
-    printf ("Starting os_thread_memmalloc_003\n");
-    returnval = os_threadMemMalloc (-1, 100);
-    CU_ASSERT (returnval == NULL);
-
-    /* Check os_threadMemMalloc with fail result for main thread
-       for index >= OS_THREAD_MEM_ARRAY_SIZE */
-    printf ("Starting os_thread_memmalloc_004\n");
-    returnval = os_threadMemMalloc (OS_THREAD_MEM_ARRAY_SIZE, 100);
-    CU_ASSERT (returnval == NULL);
 
     printf ("Ending tc_thread_memmalloc\n");
 }


### PR DESCRIPTION
Fixing that produces a lot of noise on stderr because of inappropriate use of the "info" category in various place and, on macOS, because of a rather stupid way of messing with thread scheduling priorities even when none have been specified explicitly in the configuration.

Signed-off-by: Erik Boasson <eb@ilities.com>