### PR TITLE
Implement dds_contains and some minor renames

### DIFF
--- a/src/core/ddsc/include/ddsc/dds.h
+++ b/src/core/ddsc/include/ddsc/dds.h
@@ -3326,7 +3326,9 @@ dds_get_topic(
  * @retval DDS_RETCODE_BAD_PARAMETER
  *             Entity or parent parameter is not a valid parameter.
  * @retval DDS_RETCODE_ILLEGAL_OPERATION
- *             The combination of entity and parent is not legal
+ *             The combination of entity and parent is not legal.
+ * @retval DDS_RETCODE_ALREADY_DELETED
+ *             Either entity or parent is already deleted.
  */
 DDS_EXPORT dds_entity_t
 dds_contains (

--- a/src/core/ddsc/include/ddsc/dds.h
+++ b/src/core/ddsc/include/ddsc/dds.h
@@ -2083,7 +2083,7 @@ dds_waitset_get_entities(
  * @param[in]  waitset  The waitset to attach the given entity to.
  * @param[in]  entity   The entity to attach.
  * @param[in]  x        Blob that will be supplied when the waitset wait is
- *                      triggerd by the given entity.
+ *                      triggered by the given entity.
  *
  * @returns A dds_return_t indicating success or failure.
  *

--- a/src/core/ddsc/include/ddsc/dds.h
+++ b/src/core/ddsc/include/ddsc/dds.h
@@ -3162,7 +3162,6 @@ DDS_DEPRECATED_EXPORT dds_instance_handle_t
 dds_instance_lookup (
         dds_entity_t entity,
         const void *data);
-
 /**
  * @brief This operation takes an instance handle and return a key-value corresponding to it.
  *
@@ -3304,6 +3303,35 @@ _Pre_satisfies_(entity & DDS_ENTITY_KIND_MASK)
 DDS_EXPORT dds_entity_t
 dds_get_topic(
         _In_ dds_entity_t entity);
+
+
+/**
+ * @brief Check if entity is contained or observed by the parent
+ *
+ * Check if the @p entity is contained by the @p parent entity, e.g. does a
+ * writer belong to the specified publisher, or is the @p entity observed by
+ * the @p parent entity, e.g. is an entity observed by the specified waitset.
+ *
+ * @param[in] parent The parent entity.
+ * @param[in] entity The entity.
+ *
+ * @returns The entity handle if parent contains the entity, DDS_ENTITY_NIL if
+ *          both the entities and their combination is valid but the parent
+ *          did not contain the entity, or an error if the input is invalid.
+ *
+ * @retval > 0
+ *             entity is contained in parent.
+ * @retval DDS_ENTITY_NIL
+ *             Entity is not contained in parent.
+ * @retval DDS_RETCODE_BAD_PARAMETER
+ *             Entity or parent parameter is not a valid parameter.
+ * @retval DDS_RETCODE_ILLEGAL_OPERATION
+ *             The combination of entity and parent is not legal
+ */
+DDS_EXPORT dds_entity_t
+dds_contains (
+        _In_  dds_entity_t parent,
+        _In_  dds_entity_t entity);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsc/include/ddsc/dds_public_impl.h
+++ b/src/core/ddsc/include/ddsc/dds_public_impl.h
@@ -98,9 +98,11 @@ dds_topic_descriptor_t;
 #define DDS_ENTITY_NIL 0
 
 #define DDS_ENTITY_KIND_MASK (0x7F000000) /* Should be same as UT_HANDLE_KIND_MASK. */
+#define DDS_IS_ENTITY_KIND(entity) \
+    ((entity) > 0 && ((entity) & DDS_ENTITY_KIND_MASK) != 0)
 typedef enum dds_entity_kind
 {
-  DDS_KIND_DONTCARE    = 0x00000000,
+  DDS_KIND_ANY         = 0x00000000,
   DDS_KIND_TOPIC       = 0x01000000,
   DDS_KIND_PARTICIPANT = 0x02000000,
   DDS_KIND_READER      = 0x03000000,

--- a/src/core/ddsc/src/dds__entity.h
+++ b/src/core/ddsc/src/dds__entity.h
@@ -75,7 +75,7 @@ inline dds_entity_kind_t dds_entity_kind (const dds_entity *e) {
 }
 
 inline dds_entity_kind_t dds_entity_kind_from_handle (dds_entity_t hdl) {
-  return (hdl > 0) ? (dds_entity_kind_t) (hdl & DDS_ENTITY_KIND_MASK) : DDS_KIND_DONTCARE;
+  return (hdl > 0) ? (dds_entity_kind_t) (hdl & DDS_ENTITY_KIND_MASK) : DDS_KIND_ANY;
 }
 
 void dds_entity_status_signal (dds_entity *e);
@@ -83,7 +83,7 @@ void dds_entity_status_signal (dds_entity *e);
 void dds_entity_invoke_listener (const dds_entity *entity, enum dds_status_id which, const void *vst);
 
 _Check_return_ dds__retcode_t
-dds_valid_hdl(
+dds_is_entity(
         _In_ dds_entity_t hdl,
         _In_ dds_entity_kind_t kind);
 

--- a/src/core/ddsc/src/dds_entity.c
+++ b/src/core/ddsc/src/dds_entity.c
@@ -54,7 +54,7 @@ static void dds_set_explicit (dds_entity_t entity)
 {
   dds_entity *e;
   dds__retcode_t rc;
-  if ((rc = dds_entity_lock (entity, DDS_KIND_DONTCARE, &e)) == DDS_RETCODE_OK)
+  if ((rc = dds_entity_lock (entity, DDS_KIND_ANY, &e)) == DDS_RETCODE_OK)
   {
     e->m_flags &= ~DDS_ENTITY_IMPLICIT;
     dds_entity_unlock (e);
@@ -288,7 +288,7 @@ dds_entity_t dds_get_parent (dds_entity_t entity)
 {
   dds_entity *e;
   dds__retcode_t rc;
-  if ((rc = dds_entity_lock (entity, DDS_KIND_DONTCARE, &e)) != DDS_RETCODE_OK)
+  if ((rc = dds_entity_lock (entity, DDS_KIND_ANY, &e)) != DDS_RETCODE_OK)
     return DDS_ERRNO (rc);
   else
   {
@@ -310,7 +310,7 @@ dds_entity_t dds_get_participant (dds_entity_t entity)
 {
   dds_entity *e;
   dds__retcode_t rc;
-  if ((rc = dds_entity_lock (entity, DDS_KIND_DONTCARE, &e)) != DDS_RETCODE_OK)
+  if ((rc = dds_entity_lock (entity, DDS_KIND_ANY, &e)) != DDS_RETCODE_OK)
     return DDS_ERRNO (rc);
   else
   {
@@ -330,7 +330,7 @@ dds_return_t dds_get_children (dds_entity_t entity, dds_entity_t *children, size
   if (children == NULL && size != 0)
     return DDS_ERRNO (DDS_RETCODE_BAD_PARAMETER);
 
-  if ((rc = dds_entity_lock (entity, DDS_KIND_DONTCARE, &e)) != DDS_RETCODE_OK)
+  if ((rc = dds_entity_lock (entity, DDS_KIND_ANY, &e)) != DDS_RETCODE_OK)
     return DDS_ERRNO (rc);
   else
   {
@@ -360,7 +360,7 @@ dds_return_t dds_get_qos (dds_entity_t entity, dds_qos_t *qos)
   if (qos == NULL)
     return DDS_ERRNO (DDS_RETCODE_BAD_PARAMETER);
 
-  if ((rc = dds_entity_lock (entity, DDS_KIND_DONTCARE, &e)) != DDS_RETCODE_OK)
+  if ((rc = dds_entity_lock (entity, DDS_KIND_ANY, &e)) != DDS_RETCODE_OK)
     return DDS_ERRNO (rc);
 
   if (e->m_deriver.set_qos == 0)
@@ -383,7 +383,7 @@ dds_return_t dds_set_qos (dds_entity_t entity, const dds_qos_t *qos)
   if (qos == NULL)
     return DDS_ERRNO (DDS_RETCODE_BAD_PARAMETER);
 
-  if ((rc = dds_entity_lock (entity, DDS_KIND_DONTCARE, &e)) != DDS_RETCODE_OK)
+  if ((rc = dds_entity_lock (entity, DDS_KIND_ANY, &e)) != DDS_RETCODE_OK)
     return DDS_ERRNO (rc);
 
   if (e->m_deriver.set_qos == 0)
@@ -409,7 +409,7 @@ dds_return_t dds_get_listener (dds_entity_t entity, dds_listener_t *listener)
   dds__retcode_t rc;
 
   if (listener != NULL) {
-    rc = dds_entity_lock(entity, DDS_KIND_DONTCARE, &e);
+    rc = dds_entity_lock(entity, DDS_KIND_ANY, &e);
     if (rc == DDS_RETCODE_OK) {
       os_mutexLock (&e->m_observers_lock);
       dds_copy_listener (listener, &e->m_listener);
@@ -543,7 +543,7 @@ static void pushdown_listener (dds_entity_t entity)
   for (int i = 0; i < ncs; i++)
   {
     dds_entity *e;
-    if (dds_entity_lock (cs[i], DDS_KIND_DONTCARE, &e) == DDS_RETCODE_OK)
+    if (dds_entity_lock (cs[i], DDS_KIND_ANY, &e) == DDS_RETCODE_OK)
     {
       dds_listener_t tmp;
       os_mutexLock (&e->m_observers_lock);
@@ -564,7 +564,7 @@ dds_return_t dds_set_listener (dds_entity_t entity, const dds_listener_t *listen
   dds_entity *e, *x;
   dds__retcode_t rc;
 
-  if ((rc = dds_entity_lock (entity, DDS_KIND_DONTCARE, &e)) != DDS_RETCODE_OK)
+  if ((rc = dds_entity_lock (entity, DDS_KIND_ANY, &e)) != DDS_RETCODE_OK)
     return DDS_ERRNO (rc);
 
   os_mutexLock (&e->m_observers_lock);
@@ -595,7 +595,7 @@ dds_return_t dds_enable (dds_entity_t entity)
   dds_entity *e;
   dds__retcode_t rc;
 
-  if ((rc = dds_entity_lock(entity, DDS_KIND_DONTCARE, &e)) != DDS_RETCODE_OK)
+  if ((rc = dds_entity_lock(entity, DDS_KIND_ANY, &e)) != DDS_RETCODE_OK)
     return DDS_ERRNO (rc);
 
   if ((e->m_flags & DDS_ENTITY_ENABLED) == 0)
@@ -617,7 +617,7 @@ dds_return_t dds_get_status_changes (dds_entity_t entity, uint32_t *status)
   if (status == NULL)
     return DDS_ERRNO (DDS_RETCODE_BAD_PARAMETER);
 
-  if ((rc = dds_entity_lock (entity, DDS_KIND_DONTCARE, &e)) != DDS_RETCODE_OK)
+  if ((rc = dds_entity_lock (entity, DDS_KIND_ANY, &e)) != DDS_RETCODE_OK)
     return DDS_ERRNO (rc);
 
   if (e->m_deriver.validate_status == 0)
@@ -642,7 +642,7 @@ dds_return_t dds_get_status_mask (dds_entity_t entity, uint32_t *mask)
   if (mask == NULL)
     return DDS_ERRNO (DDS_RETCODE_BAD_PARAMETER);
 
-  if ((rc = dds_entity_lock (entity, DDS_KIND_DONTCARE, &e)) != DDS_RETCODE_OK)
+  if ((rc = dds_entity_lock (entity, DDS_KIND_ANY, &e)) != DDS_RETCODE_OK)
     return DDS_ERRNO (rc);
 
   if (e->m_deriver.validate_status == 0)
@@ -669,7 +669,7 @@ dds_return_t dds_set_status_mask (dds_entity_t entity, uint32_t mask)
   dds__retcode_t rc;
   dds_return_t ret;
 
-  if ((rc = dds_entity_lock (entity, DDS_KIND_DONTCARE, &e)) != DDS_RETCODE_OK)
+  if ((rc = dds_entity_lock (entity, DDS_KIND_ANY, &e)) != DDS_RETCODE_OK)
     return DDS_ERRNO (rc);
 
   if (e->m_deriver.validate_status == 0)
@@ -701,7 +701,7 @@ static dds_return_t dds_readtake_status (dds_entity_t entity, uint32_t *status, 
   if (status == NULL)
     return DDS_ERRNO (DDS_RETCODE_BAD_PARAMETER);
 
-  if ((rc = dds_entity_lock (entity, DDS_KIND_DONTCARE, &e)) != DDS_RETCODE_OK)
+  if ((rc = dds_entity_lock (entity, DDS_KIND_ANY, &e)) != DDS_RETCODE_OK)
     return DDS_ERRNO (rc);
 
   if (e->m_deriver.validate_status == 0)
@@ -737,7 +737,7 @@ dds_return_t dds_get_domainid (dds_entity_t entity, dds_domainid_t *id)
   if (id == NULL)
     return DDS_ERRNO (DDS_RETCODE_BAD_PARAMETER);
 
-  if ((rc = dds_entity_lock (entity, DDS_KIND_DONTCARE, &e)) != DDS_RETCODE_OK)
+  if ((rc = dds_entity_lock (entity, DDS_KIND_ANY, &e)) != DDS_RETCODE_OK)
     return DDS_ERRNO (rc);
 
   *id = e->m_domainid;
@@ -754,7 +754,7 @@ dds_return_t dds_get_instance_handle (dds_entity_t entity, dds_instance_handle_t
   if (ihdl == NULL)
     return DDS_ERRNO (DDS_RETCODE_BAD_PARAMETER);
 
-  if ((rc = dds_entity_lock (entity, DDS_KIND_DONTCARE, &e)) != DDS_RETCODE_OK)
+  if ((rc = dds_entity_lock (entity, DDS_KIND_ANY, &e)) != DDS_RETCODE_OK)
     return DDS_ERRNO (rc);
 
   if (e->m_deriver.get_instance_hdl)
@@ -766,7 +766,7 @@ dds_return_t dds_get_instance_handle (dds_entity_t entity, dds_instance_handle_t
 }
 
 
-dds__retcode_t dds_valid_hdl (dds_entity_t hdl, dds_entity_kind_t kind)
+dds__retcode_t dds_is_entity (dds_entity_t hdl, dds_entity_kind_t kind)
 {
   ut_handle_t utr;
   if ((utr = ut_handle_status (hdl, NULL, (int32_t) kind)) == UT_HANDLE_OK)
@@ -855,7 +855,7 @@ dds_return_t dds_triggered (dds_entity_t entity)
   dds_return_t ret;
   dds__retcode_t rc;
 
-  if ((rc = dds_entity_lock(entity, DDS_KIND_DONTCARE, &e)) != DDS_RETCODE_OK)
+  if ((rc = dds_entity_lock(entity, DDS_KIND_ANY, &e)) != DDS_RETCODE_OK)
     return DDS_ERRNO (rc);
   os_mutexLock (&e->m_observers_lock);
   ret = (e->m_trigger != 0);
@@ -898,7 +898,7 @@ dds__retcode_t dds_entity_observer_register (dds_entity_t observed, dds_entity_t
   dds__retcode_t rc;
   dds_entity *e;
   assert (cb);
-  if ((rc = dds_entity_lock (observed, DDS_KIND_DONTCARE, &e)) != DDS_RETCODE_OK)
+  if ((rc = dds_entity_lock (observed, DDS_KIND_ANY, &e)) != DDS_RETCODE_OK)
     return rc;
   rc = dds_entity_observer_register_nl (e, observer, cb);
   dds_entity_unlock (e);
@@ -937,7 +937,7 @@ dds__retcode_t dds_entity_observer_unregister (dds_entity_t observed, dds_entity
 {
   dds__retcode_t rc;
   dds_entity *e;
-  if ((rc = dds_entity_lock (observed, DDS_KIND_DONTCARE, &e)) != DDS_RETCODE_OK)
+  if ((rc = dds_entity_lock (observed, DDS_KIND_ANY, &e)) != DDS_RETCODE_OK)
     return rc;
   rc = dds_entity_observer_unregister_nl (e, observer);
   dds_entity_unlock (e);
@@ -987,7 +987,7 @@ dds_entity_t dds_get_topic (dds_entity_t entity)
   dds_entity_t hdl;
   dds_entity *e;
 
-  if ((rc = dds_entity_lock (entity, DDS_KIND_DONTCARE, &e)) != DDS_RETCODE_OK)
+  if ((rc = dds_entity_lock (entity, DDS_KIND_ANY, &e)) != DDS_RETCODE_OK)
     return DDS_ERRNO (rc);
   switch (dds_entity_kind (e))
   {
@@ -1049,7 +1049,10 @@ dds_contains(
         return DDS_ERRNO(DDS_RETCODE_BAD_PARAMETER);
     } else if ((entity & DDS_ENTITY_KIND_MASK) == DDS_KIND_PARTICIPANT) {
         return DDS_ERRNO(DDS_RETCODE_ILLEGAL_OPERATION);
+    } else if ((rc = dds_is_entity(parent, DDS_KIND_ANY)) != DDS_RETCODE_OK) {
+        return DDS_ERRNO(rc);
     }
+
     switch (dds_entity_kind_from_handle (parent)) {
         case DDS_KIND_PARTICIPANT:
             hdl = dds_get_participant (entity);
@@ -1061,14 +1064,16 @@ dds_contains(
             hdl = dds_get_subscriber (entity);
             break;
         case DDS_KIND_READER:
-            if (!(entity & (DDS_KIND_COND_READ | DDS_KIND_COND_QUERY))) {
+            if ((entity & DDS_ENTITY_KIND_MASK) != DDS_KIND_COND_READ &&
+                (entity & DDS_ENTITY_KIND_MASK) != DDS_KIND_COND_QUERY)
+            {
                 return DDS_ERRNO(DDS_RETCODE_ILLEGAL_OPERATION);
             } else {
                 hdl = dds_get_parent (entity);
             }
             break;
         case DDS_KIND_WAITSET:
-            rc = dds_entity_lock (entity, DDS_KIND_DONTCARE, &e);
+            rc = dds_entity_lock (entity, DDS_KIND_ANY, &e);
             if (rc != DDS_RETCODE_OK) {
                 return DDS_ERRNO(rc);
             } else if (in_observer_list_p (e, parent)) {

--- a/src/core/ddsc/src/dds_guardcond.c
+++ b/src/core/ddsc/src/dds_guardcond.c
@@ -43,7 +43,7 @@ dds_return_t dds_set_guardcondition (dds_entity_t condition, bool triggered)
   dds__retcode_t rc;
 
   if ((rc = dds_guardcond_lock (condition, &gcond)) != DDS_RETCODE_OK)
-    return DDS_ERRNO (dds_valid_hdl (condition, DDS_KIND_COND_GUARD));
+    return DDS_ERRNO (dds_is_entity (condition, DDS_KIND_COND_GUARD));
   else
   {
     os_mutexLock (&gcond->m_entity.m_observers_lock);
@@ -67,7 +67,7 @@ dds_return_t dds_read_guardcondition (dds_entity_t condition, bool *triggered)
 
   *triggered = false;
   if ((rc = dds_guardcond_lock (condition, &gcond)) != DDS_RETCODE_OK)
-    return DDS_ERRNO (dds_valid_hdl (condition, DDS_KIND_COND_GUARD));
+    return DDS_ERRNO (dds_is_entity (condition, DDS_KIND_COND_GUARD));
   else
   {
     os_mutexLock (&gcond->m_entity.m_observers_lock);
@@ -88,7 +88,7 @@ dds_return_t dds_take_guardcondition (dds_entity_t condition, bool *triggered)
 
   *triggered = false;
   if ((rc = dds_guardcond_lock (condition, &gcond)) != DDS_RETCODE_OK)
-    return DDS_ERRNO (dds_valid_hdl (condition, DDS_KIND_COND_GUARD));
+    return DDS_ERRNO (dds_is_entity (condition, DDS_KIND_COND_GUARD));
   else
   {
     os_mutexLock (&gcond->m_entity.m_observers_lock);

--- a/src/core/ddsc/src/dds_read.c
+++ b/src/core/ddsc/src/dds_read.c
@@ -25,7 +25,7 @@ static dds__retcode_t dds_read_lock (dds_entity_t hdl, dds_reader **reader, dds_
 {
   dds__retcode_t rc;
   dds_entity *entity, *parent_entity;
-  if ((rc = dds_entity_lock (hdl, DDS_KIND_DONTCARE, &entity)) != DDS_RETCODE_OK)
+  if ((rc = dds_entity_lock (hdl, DDS_KIND_ANY, &entity)) != DDS_RETCODE_OK)
   {
     return rc;
   }

--- a/src/core/ddsc/src/dds_readcond.c
+++ b/src/core/ddsc/src/dds_readcond.c
@@ -80,7 +80,7 @@ dds_entity_t dds_get_datareader (dds_entity_t condition)
         hdl = dds_get_parent(condition);
     } else {
         DDS_ERROR("Argument condition is not valid\n");
-        hdl = DDS_ERRNO(dds_valid_hdl(condition, DDS_KIND_COND_READ));
+        hdl = DDS_ERRNO(dds_is_entity(condition, DDS_KIND_COND_READ));
     }
 
     return hdl;
@@ -94,12 +94,12 @@ dds_return_t dds_get_mask (dds_entity_t condition, uint32_t *mask)
   if (mask == NULL)
     return DDS_ERRNO (DDS_RETCODE_BAD_PARAMETER);
 
-  if ((rc = dds_entity_lock (condition, DDS_KIND_DONTCARE, &entity)) != DDS_RETCODE_OK)
+  if ((rc = dds_entity_lock (condition, DDS_KIND_ANY, &entity)) != DDS_RETCODE_OK)
     return DDS_ERRNO (rc);
   else if (dds_entity_kind (entity) != DDS_KIND_COND_READ && dds_entity_kind (entity) != DDS_KIND_COND_QUERY)
   {
     dds_entity_unlock (entity);
-    return DDS_ERRNO (dds_valid_hdl (condition, DDS_KIND_COND_READ));
+    return DDS_ERRNO (dds_is_entity (condition, DDS_KIND_COND_READ));
   }
   else
   {

--- a/src/core/ddsc/src/dds_reader.c
+++ b/src/core/ddsc/src/dds_reader.c
@@ -606,7 +606,7 @@ dds_entity_t dds_get_subscriber (dds_entity_t entity)
   else
   {
     DDS_ERROR ("Provided entity is not a reader nor a condition\n");
-    hdl = DDS_ERRNO (dds_valid_hdl (entity, DDS_KIND_READER));
+    hdl = DDS_ERRNO (dds_is_entity (entity, DDS_KIND_READER));
   }
 
   return hdl;

--- a/src/core/ddsc/src/dds_waitset.c
+++ b/src/core/ddsc/src/dds_waitset.c
@@ -346,7 +346,7 @@ dds_waitset_attach(
     rc = dds_waitset_lock(waitset, &ws);
     if (rc == DDS_RETCODE_OK) {
         if (waitset != entity) {
-            rc = dds_entity_lock(entity, DDS_KIND_DONTCARE, &e);
+            rc = dds_entity_lock(entity, DDS_KIND_ANY, &e);
             if (rc != DDS_RETCODE_OK) {
                 e = NULL;
             }

--- a/src/core/ddsc/src/dds_writer.c
+++ b/src/core/ddsc/src/dds_writer.c
@@ -518,7 +518,7 @@ dds_get_publisher(
 {
     dds_entity_t hdl = DDS_RETCODE_OK;
 
-    hdl = dds_valid_hdl(writer, DDS_KIND_WRITER);
+    hdl = dds_is_entity(writer, DDS_KIND_WRITER);
     if(hdl != DDS_RETCODE_OK){
         DDS_ERROR("Provided handle is not writer kind, so it is not valid\n");
         hdl = DDS_ERRNO(hdl);

--- a/src/core/ddsc/tests/CMakeLists.txt
+++ b/src/core/ddsc/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set(ddsc_test_sources
     "config.c"
     "dispose.c"
     "entity_api.c"
+    "entity_contains.c"
     "entity_hierarchy.c"
     "entity_status.c"
     "err.c"

--- a/src/core/ddsc/tests/entity_contains.c
+++ b/src/core/ddsc/tests/entity_contains.c
@@ -1,0 +1,202 @@
+/*
+ * Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include "ddsc/dds.h"
+#include "CUnit/Test.h"
+#include "CUnit/Theory.h"
+#include "os/os.h"
+
+#include "RoundTrip.h"
+
+static dds_entity_t participant = DDS_ENTITY_NIL;
+static dds_entity_t topic = DDS_ENTITY_NIL;
+static dds_entity_t publisher = DDS_ENTITY_NIL;
+static dds_entity_t subscriber =DDS_ENTITY_NIL;
+static dds_entity_t writer = DDS_ENTITY_NIL;
+static dds_entity_t reader = DDS_ENTITY_NIL;
+static dds_entity_t waitset = DDS_ENTITY_NIL;
+static dds_entity_t publisher2 = DDS_ENTITY_NIL;
+static dds_entity_t subscriber2 =DDS_ENTITY_NIL;
+static dds_entity_t writer2 = DDS_ENTITY_NIL;
+static dds_entity_t reader2 = DDS_ENTITY_NIL;
+static dds_entity_t readcond = DDS_ENTITY_NIL;
+static dds_entity_t querycond = DDS_ENTITY_NIL;
+
+/* Dummy query condition callback. */
+static bool
+accept_all(const void * sample)
+{
+    (void)sample;
+    return true;
+}
+
+static dds_entity_t result;
+
+static void
+setup(void)
+{
+    participant = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL, NULL);
+    CU_ASSERT_FATAL(participant > 0);
+    topic = dds_create_topic(participant, &RoundTripModule_DataType_desc, "RoundTrip", NULL, NULL);
+    CU_ASSERT_FATAL(topic > 0);
+    publisher = dds_create_publisher(participant, NULL, NULL);
+    CU_ASSERT_FATAL(publisher > 0);
+    subscriber = dds_create_subscriber(participant, NULL, NULL);
+    CU_ASSERT_FATAL(subscriber > 0);
+    writer = dds_create_writer(publisher, topic, NULL, NULL);
+    CU_ASSERT_FATAL(writer > 0);
+    reader = dds_create_reader(subscriber, topic, NULL, NULL);
+    CU_ASSERT_FATAL(reader > 0);
+    uint32_t mask = DDS_ANY_SAMPLE_STATE | DDS_ANY_VIEW_STATE | DDS_ANY_INSTANCE_STATE;
+    readcond = dds_create_readcondition(reader, mask);
+    CU_ASSERT_FATAL(readcond > 0);
+    querycond = dds_create_querycondition(reader, mask, accept_all);
+    CU_ASSERT_FATAL(querycond > 0);
+    publisher2 = dds_create_publisher(participant, NULL, NULL);
+    CU_ASSERT_FATAL(publisher2 > 0);
+    subscriber2 = dds_create_subscriber(participant, NULL, NULL);
+    CU_ASSERT_FATAL(subscriber2 > 0);
+    writer2 = dds_create_writer(publisher2, topic, NULL, NULL);
+    CU_ASSERT_FATAL(writer2 > 0);
+    reader2 = dds_create_reader(subscriber2, topic, NULL, NULL);
+    CU_ASSERT_FATAL(reader2 > 0);
+    waitset = dds_create_waitset(participant);
+    CU_ASSERT_FATAL(waitset > 0);
+    result = dds_waitset_attach(waitset, subscriber2, subscriber2);
+    CU_ASSERT_EQUAL_FATAL(result, DDS_RETCODE_OK)
+    result = dds_waitset_attach(waitset, reader2, reader2);
+    CU_ASSERT_EQUAL_FATAL(result, DDS_RETCODE_OK);
+    result = dds_waitset_attach(waitset, publisher2, publisher2);
+    CU_ASSERT_EQUAL_FATAL(result, DDS_RETCODE_OK)
+    result = dds_waitset_attach(waitset, writer2, writer2);
+    CU_ASSERT_EQUAL_FATAL(result, DDS_RETCODE_OK);
+}
+
+static void
+teardown(void)
+{
+    dds_delete(reader);
+    dds_delete(reader2);
+    dds_delete(writer);
+    dds_delete(writer2);
+    dds_delete(publisher);
+    dds_delete(subscriber);
+    dds_delete(subscriber2);
+    dds_delete(topic);
+    dds_delete(waitset);
+    dds_delete(participant);
+}
+
+CU_Test(ddsc_Contains, bad_parent)
+{
+    dds_entity_t participant, publisher;
+    dds_entity_t entity;
+    participant = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL, NULL);
+    CU_ASSERT_FATAL (participant > 0);
+    publisher = dds_create_publisher (participant, NULL, NULL);
+    CU_ASSERT_FATAL (publisher > 0);
+
+    entity = dds_contains(-DDS_RETCODE_ERROR, publisher);
+    CU_ASSERT(entity < 0);
+    CU_ASSERT_EQUAL(dds_err_nr(entity), DDS_RETCODE_BAD_PARAMETER);
+    entity = dds_contains(DDS_ENTITY_NIL, publisher);
+    CU_ASSERT(entity < 0);
+    CU_ASSERT_EQUAL(dds_err_nr(entity), DDS_RETCODE_BAD_PARAMETER);
+
+    dds_delete(publisher);
+    dds_delete(participant);
+}
+
+CU_Test(ddsc_Contains, bad_child, .init=setup, .fini= teardown)
+{
+    dds_entity_t participant, publisher;
+    dds_entity_t entity;
+    participant = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL, NULL);
+    CU_ASSERT_FATAL (participant > 0);
+    publisher = dds_create_publisher (participant, NULL, NULL);
+    CU_ASSERT_FATAL (publisher > 0);
+
+    entity = dds_contains (participant, -DDS_RETCODE_ERROR);
+    CU_ASSERT(entity < 0);
+    CU_ASSERT_EQUAL (dds_err_nr(entity), DDS_RETCODE_BAD_PARAMETER);
+    entity = dds_contains (participant, DDS_ENTITY_NIL);
+    CU_ASSERT (entity < 0);
+    CU_ASSERT_EQUAL (dds_err_nr(entity), DDS_RETCODE_BAD_PARAMETER);
+    entity = dds_contains (participant, participant);
+    CU_ASSERT (entity < 0);
+    CU_ASSERT_EQUAL (dds_err_nr(entity), DDS_RETCODE_ILLEGAL_OPERATION);
+}
+
+CU_Test(ddsc_Contains, deleted_parent)
+{
+    dds_entity_t entity;
+    dds_entity_t participant, publisher;
+    participant = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL, NULL);
+    CU_ASSERT_FATAL (participant > 0);
+    publisher = dds_create_publisher(participant, NULL, NULL);
+    CU_ASSERT_FATAL (participant > 0);
+
+    dds_delete (participant);
+
+    entity = dds_contains (participant, publisher);
+    CU_ASSERT_FATAL (entity < 0);
+    CU_ASSERT_EQUAL_FATAL (dds_err_nr (entity), DDS_RETCODE_BAD_PARAMETER);
+
+    dds_delete (publisher);
+}
+
+CU_Test(ddsc_Contains, deleted_child)
+{
+    dds_entity_t entity;
+    dds_entity_t participant, publisher;
+    participant = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL, NULL);
+    CU_ASSERT_FATAL (participant > 0);
+    publisher = dds_create_publisher(participant, NULL, NULL);
+    CU_ASSERT_FATAL (participant > 0);
+
+    dds_delete (publisher);
+
+    entity = dds_contains (participant, publisher);
+    CU_ASSERT_FATAL (entity < 0);
+    CU_ASSERT_EQUAL_FATAL (dds_err_nr (entity), DDS_RETCODE_ALREADY_DELETED);
+
+    dds_delete (participant);
+}
+
+CU_TheoryDataPoints(ddsc_Contains, illegal_condition_combinations) = {
+    CU_DataPoints(dds_entity_t*, &readcond, &readcond, &querycond, &querycond, &readcond, &readcond, &readcond, &readcond, &readcond, &readcond, &querycond, &querycond, &querycond, &querycond, &querycond, &querycond, &publisher, &subscriber, &publisher, &subscriber, &reader, &writer, &subscriber, &publisher, &topic, &participant,),
+    CU_DataPoints(dds_entity_t*, &readcond, &querycond, &querycond, &readcond, &reader, &writer, &subscriber, &publisher, &topic, &participant, &reader, &writer, &subscriber, &publisher, &topic, &participant, &reader, &writer, &reader2, &writer2, &participant, &participant, &participant, &participant, &participant, &participant)
+};
+CU_Theory((dds_entity_t *parent_entity, dds_entity_t *child_entity), ddsc_Contains, illegal_condition_combinations, .init=setup, .fini=teardown)
+{
+    dds_entity_t res_entity = dds_contains(*parent_entity, *child_entity);
+    CU_ASSERT_EQUAL_FATAL(dds_err_nr(res_entity), DDS_RETCODE_ILLEGAL_OPERATION);
+}
+
+CU_TheoryDataPoints(ddsc_Contains, basic_cases) = {
+    CU_DataPoints(dds_entity_t*, &participant, &participant, &participant, &participant, &participant, &participant, &subscriber, &subscriber, &subscriber, &publisher, &waitset, &waitset, &waitset, &waitset),
+    CU_DataPoints(dds_entity_t*, &subscriber, &publisher, &writer, &reader, &readcond, &querycond, &reader, &readcond, &querycond, &writer, &reader2, &writer2, &subscriber2, &publisher2)
+};
+CU_Theory((dds_entity_t *parent_entity, dds_entity_t *child_entity), ddsc_Contains, basic_cases, .init=setup, .fini= teardown)
+{
+    dds_entity_t res_entity = dds_contains(*parent_entity, *child_entity);
+    CU_ASSERT_EQUAL_FATAL(res_entity, *child_entity);
+}
+
+CU_TheoryDataPoints(ddsc_Contains, wrong_cases) = {
+    CU_DataPoints(dds_entity_t*, &waitset, &waitset, &waitset, &waitset, &subscriber, &subscriber2, &publisher2, &publisher, &subscriber2, &reader2),
+    CU_DataPoints(dds_entity_t*, &reader, &writer, &publisher, &subscriber, &reader2, &reader, &writer, &writer2, &readcond, &readcond)
+};
+CU_Theory((dds_entity_t *parent_entity, dds_entity_t *child_entity), ddsc_Contains, wrong_cases, .init=setup, .fini= teardown)
+{
+    dds_entity_t res_entity = dds_contains(*parent_entity, *child_entity);
+    CU_ASSERT_EQUAL_FATAL(res_entity, DDS_ENTITY_NIL);
+}

--- a/src/core/ddsc/tests/entity_contains.c
+++ b/src/core/ddsc/tests/entity_contains.c
@@ -10,99 +10,18 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
 #include "ddsc/dds.h"
-#include "CUnit/Test.h"
 #include "CUnit/Theory.h"
-#include "os/os.h"
 
 #include "RoundTrip.h"
 
-static dds_entity_t participant = DDS_ENTITY_NIL;
-static dds_entity_t topic = DDS_ENTITY_NIL;
-static dds_entity_t publisher = DDS_ENTITY_NIL;
-static dds_entity_t subscriber =DDS_ENTITY_NIL;
-static dds_entity_t writer = DDS_ENTITY_NIL;
-static dds_entity_t reader = DDS_ENTITY_NIL;
-static dds_entity_t waitset = DDS_ENTITY_NIL;
-static dds_entity_t publisher2 = DDS_ENTITY_NIL;
-static dds_entity_t subscriber2 =DDS_ENTITY_NIL;
-static dds_entity_t writer2 = DDS_ENTITY_NIL;
-static dds_entity_t reader2 = DDS_ENTITY_NIL;
-static dds_entity_t readcond = DDS_ENTITY_NIL;
-static dds_entity_t querycond = DDS_ENTITY_NIL;
-
-/* Dummy query condition callback. */
-static bool
-accept_all(const void * sample)
-{
-    (void)sample;
-    return true;
-}
-
-static dds_entity_t result;
-
-static void
-setup(void)
-{
-    participant = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL, NULL);
-    CU_ASSERT_FATAL(participant > 0);
-    topic = dds_create_topic(participant, &RoundTripModule_DataType_desc, "RoundTrip", NULL, NULL);
-    CU_ASSERT_FATAL(topic > 0);
-    publisher = dds_create_publisher(participant, NULL, NULL);
-    CU_ASSERT_FATAL(publisher > 0);
-    subscriber = dds_create_subscriber(participant, NULL, NULL);
-    CU_ASSERT_FATAL(subscriber > 0);
-    writer = dds_create_writer(publisher, topic, NULL, NULL);
-    CU_ASSERT_FATAL(writer > 0);
-    reader = dds_create_reader(subscriber, topic, NULL, NULL);
-    CU_ASSERT_FATAL(reader > 0);
-    uint32_t mask = DDS_ANY_SAMPLE_STATE | DDS_ANY_VIEW_STATE | DDS_ANY_INSTANCE_STATE;
-    readcond = dds_create_readcondition(reader, mask);
-    CU_ASSERT_FATAL(readcond > 0);
-    querycond = dds_create_querycondition(reader, mask, accept_all);
-    CU_ASSERT_FATAL(querycond > 0);
-    publisher2 = dds_create_publisher(participant, NULL, NULL);
-    CU_ASSERT_FATAL(publisher2 > 0);
-    subscriber2 = dds_create_subscriber(participant, NULL, NULL);
-    CU_ASSERT_FATAL(subscriber2 > 0);
-    writer2 = dds_create_writer(publisher2, topic, NULL, NULL);
-    CU_ASSERT_FATAL(writer2 > 0);
-    reader2 = dds_create_reader(subscriber2, topic, NULL, NULL);
-    CU_ASSERT_FATAL(reader2 > 0);
-    waitset = dds_create_waitset(participant);
-    CU_ASSERT_FATAL(waitset > 0);
-    result = dds_waitset_attach(waitset, subscriber2, subscriber2);
-    CU_ASSERT_EQUAL_FATAL(result, DDS_RETCODE_OK)
-    result = dds_waitset_attach(waitset, reader2, reader2);
-    CU_ASSERT_EQUAL_FATAL(result, DDS_RETCODE_OK);
-    result = dds_waitset_attach(waitset, publisher2, publisher2);
-    CU_ASSERT_EQUAL_FATAL(result, DDS_RETCODE_OK)
-    result = dds_waitset_attach(waitset, writer2, writer2);
-    CU_ASSERT_EQUAL_FATAL(result, DDS_RETCODE_OK);
-}
-
-static void
-teardown(void)
-{
-    dds_delete(reader);
-    dds_delete(reader2);
-    dds_delete(writer);
-    dds_delete(writer2);
-    dds_delete(publisher);
-    dds_delete(subscriber);
-    dds_delete(subscriber2);
-    dds_delete(topic);
-    dds_delete(waitset);
-    dds_delete(participant);
-}
-
-CU_Test(ddsc_Contains, bad_parent)
+CU_Test(ddsc_contains, bad_parent)
 {
     dds_entity_t participant, publisher;
     dds_entity_t entity;
     participant = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL, NULL);
-    CU_ASSERT_FATAL (participant > 0);
-    publisher = dds_create_publisher (participant, NULL, NULL);
-    CU_ASSERT_FATAL (publisher > 0);
+    CU_ASSERT_FATAL(participant > 0);
+    publisher = dds_create_publisher(participant, NULL, NULL);
+    CU_ASSERT_FATAL(publisher > 0);
 
     entity = dds_contains(-DDS_RETCODE_ERROR, publisher);
     CU_ASSERT(entity < 0);
@@ -115,88 +34,215 @@ CU_Test(ddsc_Contains, bad_parent)
     dds_delete(participant);
 }
 
-CU_Test(ddsc_Contains, bad_child, .init=setup, .fini= teardown)
+CU_Test(ddsc_contains, bad_child)
 {
     dds_entity_t participant, publisher;
     dds_entity_t entity;
     participant = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL, NULL);
-    CU_ASSERT_FATAL (participant > 0);
-    publisher = dds_create_publisher (participant, NULL, NULL);
-    CU_ASSERT_FATAL (publisher > 0);
+    CU_ASSERT_FATAL(participant > 0);
+    publisher = dds_create_publisher(participant, NULL, NULL);
+    CU_ASSERT_FATAL(publisher > 0);
 
-    entity = dds_contains (participant, -DDS_RETCODE_ERROR);
+    entity = dds_contains(participant, -DDS_RETCODE_ERROR);
     CU_ASSERT(entity < 0);
-    CU_ASSERT_EQUAL (dds_err_nr(entity), DDS_RETCODE_BAD_PARAMETER);
-    entity = dds_contains (participant, DDS_ENTITY_NIL);
+    CU_ASSERT_EQUAL(dds_err_nr(entity), DDS_RETCODE_BAD_PARAMETER);
+    entity = dds_contains(participant, DDS_ENTITY_NIL);
     CU_ASSERT (entity < 0);
-    CU_ASSERT_EQUAL (dds_err_nr(entity), DDS_RETCODE_BAD_PARAMETER);
-    entity = dds_contains (participant, participant);
+    CU_ASSERT_EQUAL(dds_err_nr(entity), DDS_RETCODE_BAD_PARAMETER);
+    entity = dds_contains(participant, participant);
     CU_ASSERT (entity < 0);
-    CU_ASSERT_EQUAL (dds_err_nr(entity), DDS_RETCODE_ILLEGAL_OPERATION);
+    CU_ASSERT_EQUAL(dds_err_nr(entity), DDS_RETCODE_ILLEGAL_OPERATION);
 }
 
-CU_Test(ddsc_Contains, deleted_parent)
+CU_Test(ddsc_contains, already_deleted)
 {
-    dds_entity_t entity;
-    dds_entity_t participant, publisher;
+    dds_entity_t entity, participant, publisher, subscriber, waitset;
+    dds_return_t result;
+
     participant = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL, NULL);
-    CU_ASSERT_FATAL (participant > 0);
+    CU_ASSERT_FATAL(participant > 0);
     publisher = dds_create_publisher(participant, NULL, NULL);
-    CU_ASSERT_FATAL (participant > 0);
+    CU_ASSERT_FATAL(publisher > 0);
+    subscriber = dds_create_subscriber(participant, NULL, NULL);
+    CU_ASSERT_FATAL(subscriber > 0);
+    waitset = dds_create_waitset(participant);
+    CU_ASSERT_FATAL(waitset > 0);
 
-    dds_delete (participant);
+    /* Test with a deleted child entity first to verify already deleted is
+       returned when only the child entity is deleted. */
+    result = dds_delete(publisher);
+    CU_ASSERT_EQUAL_FATAL(result, DDS_RETCODE_OK);
 
-    entity = dds_contains (participant, publisher);
-    CU_ASSERT_FATAL (entity < 0);
-    CU_ASSERT_EQUAL_FATAL (dds_err_nr (entity), DDS_RETCODE_BAD_PARAMETER);
+    entity = dds_contains(participant, publisher);
+    CU_ASSERT(entity < 0);
+    CU_ASSERT_EQUAL(dds_err_nr(entity), DDS_RETCODE_ALREADY_DELETED);
 
-    dds_delete (publisher);
+    /* Test with a deleted parent entity, but not a direct parent, to verify
+       already deleted is returned when the parent entity is deleted. */
+    result = dds_delete(waitset);
+    CU_ASSERT_EQUAL_FATAL(result, DDS_RETCODE_OK);
+
+    entity = dds_contains(waitset, subscriber);
+    CU_ASSERT(entity < 0);
+    CU_ASSERT_EQUAL(dds_err_nr(entity), DDS_RETCODE_ALREADY_DELETED);
+
+    dds_delete(subscriber);
+    dds_delete(participant);
 }
 
-CU_Test(ddsc_Contains, deleted_child)
+/* Dummy query condition callback. */
+static bool
+accept_all(const void * sample)
 {
-    dds_entity_t entity;
-    dds_entity_t participant, publisher;
-    participant = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL, NULL);
-    CU_ASSERT_FATAL (participant > 0);
-    publisher = dds_create_publisher(participant, NULL, NULL);
-    CU_ASSERT_FATAL (participant > 0);
-
-    dds_delete (publisher);
-
-    entity = dds_contains (participant, publisher);
-    CU_ASSERT_FATAL (entity < 0);
-    CU_ASSERT_EQUAL_FATAL (dds_err_nr (entity), DDS_RETCODE_ALREADY_DELETED);
-
-    dds_delete (participant);
+    (void)sample;
+    return true;
 }
 
-CU_TheoryDataPoints(ddsc_Contains, illegal_condition_combinations) = {
-    CU_DataPoints(dds_entity_t*, &readcond, &readcond, &querycond, &querycond, &readcond, &readcond, &readcond, &readcond, &readcond, &readcond, &querycond, &querycond, &querycond, &querycond, &querycond, &querycond, &publisher, &subscriber, &publisher, &subscriber, &reader, &writer, &subscriber, &publisher, &topic, &participant,),
-    CU_DataPoints(dds_entity_t*, &readcond, &querycond, &querycond, &readcond, &reader, &writer, &subscriber, &publisher, &topic, &participant, &reader, &writer, &subscriber, &publisher, &topic, &participant, &reader, &writer, &reader2, &writer2, &participant, &participant, &participant, &participant, &participant, &participant)
+static uint32_t mask = DDS_ANY_SAMPLE_STATE | DDS_ANY_VIEW_STATE | DDS_ANY_INSTANCE_STATE;
+
+static dds_entity_t par = DDS_ENTITY_NIL;
+static dds_entity_t top = DDS_ENTITY_NIL;
+static dds_entity_t pub = DDS_ENTITY_NIL;
+static dds_entity_t pub2 = DDS_ENTITY_NIL;
+static dds_entity_t wtr = DDS_ENTITY_NIL;
+static dds_entity_t wtr2 = DDS_ENTITY_NIL;
+static dds_entity_t sub = DDS_ENTITY_NIL;
+static dds_entity_t sub2 = DDS_ENTITY_NIL;
+static dds_entity_t rdr = DDS_ENTITY_NIL;
+static dds_entity_t rdr2 = DDS_ENTITY_NIL;
+static dds_entity_t ws = DDS_ENTITY_NIL;
+static dds_entity_t rc = DDS_ENTITY_NIL;
+static dds_entity_t qc = DDS_ENTITY_NIL;
+
+/**
+ * The tree of types created will look like this.
+ *
+ *  - participant
+ *     - publisher
+ *        - writer
+ *     - publisher2
+ *        - writer2
+ *     - subscriber
+ *        - reader
+ *           - read condition
+ *           - query condition
+ *     - subscriber2
+ *        - reader2
+ *     - waitset
+ */
+
+static void
+setup(void)
+{
+    dds_return_t ret;
+
+    par = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL, NULL);
+    CU_ASSERT_FATAL(par > 0);
+    top = dds_create_topic(par, &RoundTripModule_DataType_desc, "RoundTrip", NULL, NULL);
+    CU_ASSERT_FATAL(top > 0);
+
+    pub = dds_create_publisher(par, NULL, NULL);
+    CU_ASSERT_FATAL(pub > 0);
+    pub2 = dds_create_publisher(par, NULL, NULL);
+    CU_ASSERT_FATAL(pub2 > 0);
+    wtr = dds_create_writer(pub, top, NULL, NULL);
+    CU_ASSERT_FATAL(wtr > 0);
+    wtr2 = dds_create_writer(pub2, top, NULL, NULL);
+    CU_ASSERT_FATAL(wtr2 > 0);
+
+    sub = dds_create_subscriber(par, NULL, NULL);
+    CU_ASSERT_FATAL(sub > 0);
+    sub2 = dds_create_subscriber(par, NULL, NULL);
+    CU_ASSERT_FATAL(sub2 > 0);
+    rdr = dds_create_reader(sub, top, NULL, NULL);
+    CU_ASSERT_FATAL(rdr > 0);
+    rdr2 = dds_create_reader(sub2, top, NULL, NULL);
+    CU_ASSERT_FATAL(rdr2 > 0);
+    rc = dds_create_readcondition(rdr, mask);
+    CU_ASSERT_FATAL(rc > 0);
+    qc = dds_create_querycondition(rdr, mask, accept_all);
+    CU_ASSERT_FATAL(qc > 0);
+
+    ws = dds_create_waitset(par);
+    CU_ASSERT_FATAL(ws > 0);
+    ret = dds_waitset_attach(ws, pub, pub);
+    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+    ret = dds_waitset_attach(ws, wtr, wtr);
+    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+    ret = dds_waitset_attach(ws, sub, sub);
+    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+    ret = dds_waitset_attach(ws, rdr, rdr);
+    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+    ret = dds_waitset_attach(ws, rc, rc);
+    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+    ret = dds_waitset_attach(ws, qc, qc);
+    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+}
+
+static void
+teardown(void)
+{
+    dds_waitset_detach(ws, qc);
+    dds_waitset_detach(ws, rc);
+    dds_waitset_detach(ws, rdr);
+    dds_waitset_detach(ws, sub);
+    dds_waitset_detach(ws, wtr);
+    dds_waitset_detach(ws, pub);
+    dds_delete(par);
+}
+
+/* Verify the function returns illegal operation for all invalid combinations
+   of parent and child entity. */
+CU_TheoryDataPoints(ddsc_contains, bad_combos) = {
+    CU_DataPoints(dds_entity_t*, &rc,  &qc,   &qc,   &rc,  &wtr, &pub,
+                                 &rdr, &rdr2, &wtr, &pub,
+                                 &sub, &sub2, &pub,
+                                 &wtr, &wtr2, &rdr, &sub,
+                                 &pub, &pub2, &sub),
+    CU_DataPoints(dds_entity_t*, &rc,  &rc,   &qc,   &qc,  &rc,   &rc,
+                                 &rdr, &rdr,  &rdr, &rdr,
+                                 &sub, &sub,  &sub,
+                                 &wtr, &wtr,  &wtr, &wtr,
+                                 &pub, &pub,  &pub)
 };
-CU_Theory((dds_entity_t *parent_entity, dds_entity_t *child_entity), ddsc_Contains, illegal_condition_combinations, .init=setup, .fini=teardown)
+
+CU_Theory((dds_entity_t *parent, dds_entity_t *entity), ddsc_contains, bad_combos, .init=setup, .fini=teardown)
 {
-    dds_entity_t res_entity = dds_contains(*parent_entity, *child_entity);
-    CU_ASSERT_EQUAL_FATAL(dds_err_nr(res_entity), DDS_RETCODE_ILLEGAL_OPERATION);
+    dds_entity_t result = dds_contains(*parent, *entity);
+    CU_ASSERT(result < 0);
+    CU_ASSERT_EQUAL(dds_err_nr(result), DDS_RETCODE_ILLEGAL_OPERATION);
 }
 
-CU_TheoryDataPoints(ddsc_Contains, basic_cases) = {
-    CU_DataPoints(dds_entity_t*, &participant, &participant, &participant, &participant, &participant, &participant, &subscriber, &subscriber, &subscriber, &publisher, &waitset, &waitset, &waitset, &waitset),
-    CU_DataPoints(dds_entity_t*, &subscriber, &publisher, &writer, &reader, &readcond, &querycond, &reader, &readcond, &querycond, &writer, &reader2, &writer2, &subscriber2, &publisher2)
+/* Verify an entity can be found throughout the entire tree. e.g. a read
+   condition can be found in the reader, subscriber and participant. */
+CU_TheoryDataPoints(ddsc_contains, happy_days) = {
+    CU_DataPoints(dds_entity_t*, &rdr, &sub, &par, &ws,
+                                 &sub, &par,
+                                 &par,
+                                 &pub, &par,
+                                 &par),
+    CU_DataPoints(dds_entity_t*, &rc,  &rc,  &rc, &rc,
+                                 &rdr, &rdr,
+                                 &sub,
+                                 &wtr, &wtr,
+                                 &pub)
 };
-CU_Theory((dds_entity_t *parent_entity, dds_entity_t *child_entity), ddsc_Contains, basic_cases, .init=setup, .fini= teardown)
+
+CU_Theory((dds_entity_t *parent, dds_entity_t *entity), ddsc_contains, happy_days, .init=setup, .fini= teardown)
 {
-    dds_entity_t res_entity = dds_contains(*parent_entity, *child_entity);
-    CU_ASSERT_EQUAL_FATAL(res_entity, *child_entity);
+    dds_entity_t result = dds_contains(*parent, *entity);
+    CU_ASSERT_EQUAL(result, *entity);
 }
 
-CU_TheoryDataPoints(ddsc_Contains, wrong_cases) = {
-    CU_DataPoints(dds_entity_t*, &waitset, &waitset, &waitset, &waitset, &subscriber, &subscriber2, &publisher2, &publisher, &subscriber2, &reader2),
-    CU_DataPoints(dds_entity_t*, &reader, &writer, &publisher, &subscriber, &reader2, &reader, &writer, &writer2, &readcond, &readcond)
+/* Verify that when an entity cannot be found DDS_ENTITY_NIL is returned when
+   the input entities and their combination is valid. */
+CU_TheoryDataPoints(ddsc_contains, unhappy_days) = {
+    CU_DataPoints(dds_entity_t*, &rdr2, &rdr2, &sub2, &pub2, &ws),
+    CU_DataPoints(dds_entity_t*, &rc,   &qc,   &rdr,  &wtr,  &rdr2)
 };
-CU_Theory((dds_entity_t *parent_entity, dds_entity_t *child_entity), ddsc_Contains, wrong_cases, .init=setup, .fini= teardown)
+
+CU_Theory((dds_entity_t *parent, dds_entity_t *entity), ddsc_contains, unhappy_days, .init=setup, .fini= teardown)
 {
-    dds_entity_t res_entity = dds_contains(*parent_entity, *child_entity);
-    CU_ASSERT_EQUAL_FATAL(res_entity, DDS_ENTITY_NIL);
+    dds_entity_t result = dds_contains(*parent, *entity);
+    CU_ASSERT_EQUAL(result, DDS_ENTITY_NIL);
 }

--- a/src/tools/pubsub/common.c
+++ b/src/tools/pubsub/common.c
@@ -384,7 +384,7 @@ static void inapplicable_qos(dds_entity_kind_t qt, const char *n) {
     case DDS_KIND_SUBSCRIBER: en = "subscriber"; break;
     case DDS_KIND_WRITER: en = "writer"; break;
     case DDS_KIND_READER: en = "reader"; break;
-    case DDS_KIND_DONTCARE: en = "dontcare"; break;
+    case DDS_KIND_ANY: en = "any"; break;
     case DDS_KIND_PARTICIPANT: en = "participant"; break;
     case DDS_KIND_COND_READ: en = "cond read"; break;
     case DDS_KIND_COND_QUERY: en = "cond query"; break;


### PR DESCRIPTION
This pull request implements dds_contains and a bunch of test cases to verify correct operation.

Apart from that it adds a macro called DDS_IS_ENTITY_KIND to use in dds functions. The macro first tests if the value is greater than zero and, if true, tests if the value binary and DDS_ENTITY_KIND_MASK is greater than zero. This intention of this macro is to quickly test if a value looks like it is a valid entity handle.

I've also opted to rename DDS_KIND_DONTCARE to DDS_KIND_ANY to better represent the intention and because it's shorter and to rename dds_valid_hdl to dds_is_entity to better represent the intent.

This pull request builds on work initiated by @FirasSahliADLinktech, but I found that his implementation tested too much and, at the same time, not enough. Apart from that there was a bug in his implementation that caused already deleted parent entities to slip through. Of course it's not really that big of a deal, but still. Oh and the check in the switch when the parent was a reader wasn't correct. I took credit for the addition of DDS_IS_ENTITY_KIND only because I actually implemented it.

Please consider pulling these changes.