### PR TITLE
start using the DDSI vendor id code for the Eclipse Foundation

### DIFF
--- a/src/core/ddsi/CMakeLists.txt
+++ b/src/core/ddsi/CMakeLists.txt
@@ -25,6 +25,7 @@ PREPEND(srcs_ddsi "${CMAKE_CURRENT_LIST_DIR}/src"
     ddsi_rhc_plugin.c
     ddsi_iid.c
     ddsi_tkmap.c
+    ddsi_vendor.c
     q_addrset.c
     q_bitset_inlines.c
     q_bswap.c
@@ -77,6 +78,7 @@ PREPEND(hdrs_private_ddsi "${CMAKE_CURRENT_LIST_DIR}/include/ddsi"
     ddsi_rhc_plugin.h
     ddsi_iid.h
     ddsi_tkmap.h
+    ddsi_vendor.h
     probes-constants.h
     q_addrset.h
     q_bitset.h

--- a/src/core/ddsi/include/ddsi/ddsi_vendor.h
+++ b/src/core/ddsi/include/ddsi/ddsi_vendor.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright(c) 2019 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#ifndef DDSI_VENDOR_H
+#define DDSI_VENDOR_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef struct {
+  uint8_t id[2];
+} nn_vendorid_t;
+
+/* All existing vendor codes have the major part equal to 1 (and this will probably be true for a long, long time) */
+#define NN_VENDORID_MINOR_RTI                0x01
+#define NN_VENDORID_MINOR_PRISMTECH_OSPL     0x02
+#define NN_VENDORID_MINOR_OCI                0x03
+#define NN_VENDORID_MINOR_MILSOFT            0x04
+#define NN_VENDORID_MINOR_KONGSBERG          0x05
+#define NN_VENDORID_MINOR_TWINOAKS           0x06
+#define NN_VENDORID_MINOR_LAKOTA             0x07
+#define NN_VENDORID_MINOR_ICOUP              0x08
+#define NN_VENDORID_MINOR_ETRI               0x09
+#define NN_VENDORID_MINOR_RTI_MICRO          0x0a
+#define NN_VENDORID_MINOR_PRISMTECH_JAVA     0x0b
+#define NN_VENDORID_MINOR_PRISMTECH_GATEWAY  0x0c
+#define NN_VENDORID_MINOR_PRISMTECH_LITE     0x0d
+#define NN_VENDORID_MINOR_TECHNICOLOR        0x0e
+#define NN_VENDORID_MINOR_EPROSIMA           0x0f
+#define NN_VENDORID_MINOR_ECLIPSE            0x10
+#define NN_VENDORID_MINOR_PRISMTECH_CLOUD    0x20
+
+#define NN_VENDORID_UNKNOWN ((nn_vendorid_t) {{ 0x00, 0x00 }})
+#define NN_VENDORID_ECLIPSE ((nn_vendorid_t) {{ 0x01, 0x10 }})
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+inline bool vendor_equals (nn_vendorid_t a, nn_vendorid_t b) {
+  return ((a.id[0] << 8) | a.id[1]) == ((b.id[0] << 8) | b.id[1]);
+}
+inline bool vendor_is_eclipse (nn_vendorid_t vendor) {
+  return vendor_equals (vendor, NN_VENDORID_ECLIPSE);
+}
+inline bool vendor_is_rti (nn_vendorid_t vendor) {
+  return vendor_equals (vendor, (nn_vendorid_t) { 0x01, NN_VENDORID_MINOR_RTI });
+}
+inline bool vendor_is_opensplice (nn_vendorid_t vendor) {
+  return vendor_equals (vendor, (nn_vendorid_t) { 0x01, NN_VENDORID_MINOR_PRISMTECH_OSPL });
+}
+inline bool vendor_is_twinoaks (nn_vendorid_t vendor) {
+  return vendor_equals (vendor, (nn_vendorid_t) { 0x01, NN_VENDORID_MINOR_TWINOAKS });
+}
+inline bool vendor_is_cloud (nn_vendorid_t vendor) {
+  return vendor_equals (vendor, (nn_vendorid_t) { 0x01, NN_VENDORID_MINOR_PRISMTECH_CLOUD });
+}
+inline bool vendor_is_eclipse_or_opensplice (nn_vendorid_t vendor) {
+  return vendor_is_eclipse (vendor) | vendor_is_opensplice (vendor);
+}
+inline bool vendor_is_prismtech (nn_vendorid_t vendor) {
+  return (vendor_equals (vendor, (nn_vendorid_t) { 0x01, NN_VENDORID_MINOR_PRISMTECH_OSPL }) ||
+          vendor_equals (vendor, (nn_vendorid_t) { 0x01, NN_VENDORID_MINOR_PRISMTECH_LITE }) ||
+          vendor_equals (vendor, (nn_vendorid_t) { 0x01, NN_VENDORID_MINOR_PRISMTECH_GATEWAY }) ||
+          vendor_equals (vendor, (nn_vendorid_t) { 0x01, NN_VENDORID_MINOR_PRISMTECH_JAVA }) ||
+          vendor_equals (vendor, (nn_vendorid_t) { 0x01, NN_VENDORID_MINOR_PRISMTECH_CLOUD }));
+}
+inline bool vendor_is_eclipse_or_prismtech (nn_vendorid_t vendor) {
+  return vendor_is_eclipse (vendor) || vendor_is_prismtech (vendor);
+}
+
+#if defined (__cplusplus)
+}
+#endif
+
+#endif /* DDSI_VENDOR_H */

--- a/src/core/ddsi/include/ddsi/q_misc.h
+++ b/src/core/ddsi/include/ddsi/q_misc.h
@@ -18,26 +18,24 @@
 extern "C" {
 #endif
 
-struct nn_guid;
+inline seqno_t fromSN (const nn_sequence_number_t sn) {
+  return ((seqno_t) sn.high << 32) | sn.low;
+}
 
-int vendor_is_lite (nn_vendorid_t vendor);
-int vendor_is_opensplice (nn_vendorid_t vid);
-int vendor_is_rti (nn_vendorid_t vendor);
-int vendor_is_twinoaks (nn_vendorid_t vendor);
-int vendor_is_prismtech (nn_vendorid_t vendor);
-int vendor_is_cloud (nn_vendorid_t vendor);
-int is_own_vendor (nn_vendorid_t vendor);
+inline nn_sequence_number_t toSN (seqno_t n) {
+  nn_sequence_number_t x;
+  x.high = (int) (n >> 32);
+  x.low = (unsigned) n;
+  return x;
+}
+
 unsigned char normalize_data_datafrag_flags (const SubmessageHeader_t *smhdr, int datafrag_as_data);
-
-seqno_t fromSN (const nn_sequence_number_t sn);
-nn_sequence_number_t toSN (seqno_t);
 
 #ifdef DDSI_INCLUDE_NETWORK_PARTITIONS
 int WildcardOverlap(char * p1, char * p2);
 #endif
 
 int ddsi2_patmatch (const char *pat, const char *str);
-
 
 uint32_t crc32_calc (const void *buf, size_t length);
 

--- a/src/core/ddsi/include/ddsi/q_protocol.h
+++ b/src/core/ddsi/include/ddsi/q_protocol.h
@@ -123,27 +123,6 @@ struct cdrstring {
 #define NN_LOCATOR_KIND_UDPv4MCGEN 0x4fff0000
 #define NN_LOCATOR_PORT_INVALID 0
 
-#define NN_VENDORID_UNKNOWN                {{ 0x00, 0x00 }}
-#define NN_VENDORID_RTI                    {{ 0x01, 0x01 }}
-#define NN_VENDORID_PRISMTECH_OSPL         {{ 0x01, 0x02 }}
-#define NN_VENDORID_OCI                    {{ 0x01, 0x03 }}
-#define NN_VENDORID_MILSOFT                {{ 0x01, 0x04 }}
-#define NN_VENDORID_KONGSBERG              {{ 0x01, 0x05 }}
-#define NN_VENDORID_TWINOAKS               {{ 0x01, 0x06 }}
-#define NN_VENDORID_LAKOTA                 {{ 0x01, 0x07 }}
-#define NN_VENDORID_ICOUP                  {{ 0x01, 0x08 }}
-#define NN_VENDORID_ETRI                   {{ 0x01, 0x09 }}
-#define NN_VENDORID_RTI_MICRO              {{ 0x01, 0x0a }}
-#define NN_VENDORID_PRISMTECH_JAVA         {{ 0x01, 0x0b }}
-#define NN_VENDORID_PRISMTECH_GATEWAY      {{ 0x01, 0x0c }}
-#define NN_VENDORID_PRISMTECH_LITE         {{ 0x01, 0x0d }}
-#define NN_VENDORID_TECHNICOLOR            {{ 0x01, 0x0e }}
-#define NN_VENDORID_EPROSIMA               {{ 0x01, 0x0f }}
-#define NN_VENDORID_PRISMTECH_CLOUD        {{ 0x01, 0x20 }}
-#define NN_VENDORID_ECLIPSE_CYCLONEDDS     {{ 0x01, 0x0d }} // Since CYCLONEDDS has no owner yet, it uses the same VENDORID as LITE
-
-#define MY_VENDOR_ID NN_VENDORID_ECLIPSE_CYCLONEDDS
-
 /* Only one specific version is grokked */
 #define RTPS_MAJOR 2
 #define RTPS_MINOR 1
@@ -155,15 +134,11 @@ typedef struct Header {
   nn_vendorid_t vendorid;
   nn_guid_prefix_t guid_prefix;
 } Header_t;
-#define NN_PROTOCOLID_INITIALIZER {{ 'R','T','P','S' }}
 #if PLATFORM_IS_LITTLE_ENDIAN
 #define NN_PROTOCOLID_AS_UINT32 (((uint32_t)'R' << 0) | ((uint32_t)'T' << 8) | ((uint32_t)'P' << 16) | ((uint32_t)'S' << 24))
 #else
 #define NN_PROTOCOLID_AS_UINT32 (((uint32_t)'R' << 24) | ((uint32_t)'T' << 16) | ((uint32_t)'P' << 8) | ((uint32_t)'S' << 0))
 #endif
-#define NN_PROTOCOL_VERSION_INITIALIZER { RTPS_MAJOR, RTPS_MINOR }
-#define NN_VENDORID_INITIALIER MY_VENDOR_ID
-#define NN_HEADER_INITIALIZER { NN_PROTOCOLID_INITIALIZER, NN_PROTOCOL_VERSION_INITIALIZER, NN_VENDORID_INITIALIER, NN_GUID_PREFIX_UNKNOWN_INITIALIZER }
 #define RTPS_MESSAGE_HEADER_SIZE (sizeof (Header_t))
 
 typedef struct SubmessageHeader {

--- a/src/core/ddsi/include/ddsi/q_rtps.h
+++ b/src/core/ddsi/include/ddsi/q_rtps.h
@@ -13,16 +13,14 @@
 #define NN_RTPS_H
 
 #include "os/os_defs.h"
+#include "ddsi/ddsi_vendor.h"
 
 #if defined (__cplusplus)
 extern "C" {
 #endif
 
 typedef struct {
-  unsigned char id[2];
-} nn_vendorid_t;
-typedef struct {
-  unsigned char major, minor;
+  uint8_t major, minor;
 } nn_protocol_version_t;
 typedef union nn_guid_prefix {
   unsigned char s[12];

--- a/src/core/ddsi/src/ddsi_vendor.c
+++ b/src/core/ddsi/src/ddsi_vendor.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright(c) 2019 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include <string.h>
+
+#include "ddsi/ddsi_vendor.h"
+
+extern inline bool vendor_equals (nn_vendorid_t a, nn_vendorid_t b);
+extern inline bool vendor_is_rti (nn_vendorid_t vendor);
+extern inline bool vendor_is_twinoaks (nn_vendorid_t vendor);
+extern inline bool vendor_is_prismtech (nn_vendorid_t vendor);
+extern inline bool vendor_is_opensplice (nn_vendorid_t vendor);
+extern inline bool vendor_is_cloud (nn_vendorid_t vendor);
+extern inline bool vendor_is_eclipse (nn_vendorid_t vendor);
+extern inline bool vendor_is_eclipse_or_opensplice (nn_vendorid_t vendor);
+extern inline bool vendor_is_eclipse_or_prismtech (nn_vendorid_t vendor);

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -1499,7 +1499,6 @@ void rtps_stop (void)
   }
 
   {
-    const nn_vendorid_t ownvendorid = MY_VENDOR_ID;
     struct ephash_enum_writer est_wr;
     struct ephash_enum_reader est_rd;
     struct ephash_enum_participant est_pp;
@@ -1515,7 +1514,7 @@ void rtps_stop (void)
     ephash_enum_writer_init (&est_wr);
     while ((wr = ephash_enum_writer_next (&est_wr)) != NULL)
     {
-      if (!is_builtin_entityid (wr->e.guid.entityid, ownvendorid))
+      if (!is_builtin_entityid (wr->e.guid.entityid, NN_VENDORID_ECLIPSE))
         delete_writer_nolinger (&wr->e.guid);
     }
     ephash_enum_writer_fini (&est_wr);
@@ -1523,7 +1522,7 @@ void rtps_stop (void)
     ephash_enum_reader_init (&est_rd);
     while ((rd = ephash_enum_reader_next (&est_rd)) != NULL)
     {
-      if (!is_builtin_entityid (rd->e.guid.entityid, ownvendorid))
+      if (!is_builtin_entityid (rd->e.guid.entityid, NN_VENDORID_ECLIPSE))
         (void)delete_reader (&rd->e.guid);
     }
     ephash_enum_reader_fini (&est_rd);

--- a/src/core/ddsi/src/q_misc.c
+++ b/src/core/ddsi/src/q_misc.c
@@ -15,71 +15,8 @@
 #include "ddsi/q_bswap.h"
 #include "ddsi/q_md5.h"
 
-int vendor_is_rti (nn_vendorid_t vendor)
-{
-  const nn_vendorid_t rti = NN_VENDORID_RTI;
-  return vendor.id[0] == rti.id[0] && vendor.id[1] == rti.id[1];
-}
-
-int vendor_is_twinoaks (nn_vendorid_t vendor)
-{
-  const nn_vendorid_t twinoaks = NN_VENDORID_TWINOAKS;
-  return vendor.id[0] == twinoaks.id[0] && vendor.id[1] == twinoaks.id[1];
-}
-
-int vendor_is_cloud (nn_vendorid_t vendor)
-{
-  const nn_vendorid_t cloud = NN_VENDORID_PRISMTECH_CLOUD;
-  return vendor.id[0] == cloud.id[0] && vendor.id[1] == cloud.id[1];
-}
-
-int vendor_is_prismtech (nn_vendorid_t vid)
-{
-  const nn_vendorid_t pt1 = NN_VENDORID_PRISMTECH_OSPL;
-  const nn_vendorid_t pt2 = NN_VENDORID_PRISMTECH_LITE;
-  const nn_vendorid_t pt3 = NN_VENDORID_PRISMTECH_GATEWAY;
-  const nn_vendorid_t pt4 = NN_VENDORID_PRISMTECH_JAVA;
-  const nn_vendorid_t pt5 = NN_VENDORID_PRISMTECH_CLOUD;
-  const nn_vendorid_t pt6 = NN_VENDORID_ECLIPSE_CYCLONEDDS;
-
-  return
-    (vid.id[0] == pt1.id[0]) &&
-    ((vid.id[1] == pt1.id[1]) || (vid.id[1] == pt2.id[1])
-     || (vid.id[1] == pt3.id[1]) || (vid.id[1] == pt4.id[1])
-     || (vid.id[1] == pt5.id[1]) || (vid.id[1] == pt6.id[1]));
-}
-
-int vendor_is_opensplice (nn_vendorid_t vid)
-{
-  const nn_vendorid_t pt1 = NN_VENDORID_PRISMTECH_OSPL;
-  return (vid.id[0] == pt1.id[0] && vid.id[1] == pt1.id[1]);
-}
-
-int vendor_is_lite (nn_vendorid_t vid)
-{
-  const nn_vendorid_t pt1 = NN_VENDORID_PRISMTECH_LITE;
-  return (vid.id[0] == pt1.id[0] && vid.id[1] == pt1.id[1]);
-}
-
-int is_own_vendor (nn_vendorid_t vendor)
-{
-  const nn_vendorid_t ownid = MY_VENDOR_ID;
-  return vendor.id[0] == ownid.id[0] && vendor.id[1] == ownid.id[1];
-}
-
-
-seqno_t fromSN (const nn_sequence_number_t sn)
-{
-  return ((seqno_t) sn.high << 32) | sn.low;
-}
-
-nn_sequence_number_t toSN (seqno_t n)
-{
-  nn_sequence_number_t x;
-  x.high = (int) (n >> 32);
-  x.low = (unsigned) n;
-  return x;
-}
+extern inline seqno_t fromSN (const nn_sequence_number_t sn);
+extern inline nn_sequence_number_t toSN (seqno_t n);
 
 #ifdef DDSI_INCLUDE_NETWORK_PARTITIONS
 int WildcardOverlap(char * p1, char * p2)

--- a/src/core/ddsi/src/q_receive.c
+++ b/src/core/ddsi/src/q_receive.c
@@ -2837,7 +2837,7 @@ static int handle_submsg_sequence
         break;
 
       case SMID_PT_INFO_CONTAINER:
-        if (is_own_vendor (rst->vendor) || vendor_is_lite(rst->vendor))
+        if (vendor_is_eclipse_or_prismtech (rst->vendor))
         {
           state = "parse:pt_info_container";
           DDS_TRACE("PT_INFO_CONTAINER(");
@@ -2898,7 +2898,7 @@ static int handle_submsg_sequence
                rst->protocol_version.minor < RTPS_MINOR_MINIMUM))
             goto malformed;
         }
-        else if (is_own_vendor (rst->vendor))
+        else if (vendor_is_eclipse (rst->vendor))
         {
           /* One wouldn't expect undefined stuff from ourselves,
              except that we need to be up- and backwards compatible

--- a/src/core/ddsi/src/q_transmit.c
+++ b/src/core/ddsi/src/q_transmit.c
@@ -953,13 +953,10 @@ static os_result throttle_writer (struct nn_xpack *xp, struct writer *wr)
   whc_get_state(wr->whc, &whcst);
 
   {
-#ifndef NDEBUG
-    nn_vendorid_t ownvendorid = MY_VENDOR_ID;
-#endif
     ASSERT_MUTEX_HELD (&wr->e.lock);
     assert (wr->throttling == 0);
     assert (vtime_awake_p (lookup_thread_state ()->vtime));
-    assert (!is_builtin_entityid(wr->e.guid.entityid, ownvendorid));
+    assert (!is_builtin_entityid(wr->e.guid.entityid, NN_VENDORID_ECLIPSE));
   }
 
   DDS_LOG(DDS_LC_THROTTLE, "writer %x:%x:%x:%x waiting for whc to shrink below low-water mark (whc %"PRIuSIZE" low=%u high=%u)\n", PGUID (wr->e.guid), whcst.unacked_bytes, wr->whc_low, wr->whc_high);

--- a/src/core/ddsi/src/q_xmsg.c
+++ b/src/core/ddsi/src/q_xmsg.c
@@ -288,7 +288,6 @@ static void nn_xmsg_reinit (struct nn_xmsg *m, enum nn_xmsg_kind kind)
 
 static struct nn_xmsg *nn_xmsg_allocnew (struct nn_xmsgpool *pool, size_t expected_size, enum nn_xmsg_kind kind)
 {
-  const nn_vendorid_t myvendorid = MY_VENDOR_ID;
   struct nn_xmsg *m;
   struct nn_xmsg_data *d;
 
@@ -312,7 +311,7 @@ static struct nn_xmsg *nn_xmsg_allocnew (struct nn_xmsgpool *pool, size_t expect
   d->src.unused = 0;
   d->src.version.major = RTPS_MAJOR;
   d->src.version.minor = RTPS_MINOR;
-  d->src.vendorid = myvendorid;
+  d->src.vendorid = NN_VENDORID_ECLIPSE;
   d->dst.smhdr.submessageId = SMID_INFO_DST;
   d->dst.smhdr.flags = (PLATFORM_IS_LITTLE_ENDIAN ? SMFLAG_ENDIANNESS : 0);
   d->dst.smhdr.octetsToNextHeader = sizeof (d->dst.guid_prefix);
@@ -1239,7 +1238,6 @@ static void nn_xpack_reinit (struct nn_xpack *xp)
 
 struct nn_xpack * nn_xpack_new (ddsi_tran_conn_t conn, uint32_t bw_limit, bool async_mode)
 {
-  const nn_vendorid_t myvendorid = MY_VENDOR_ID;
   struct nn_xpack *xp;
 
   /* Disallow setting async_mode if not configured to enable async mode: this way we
@@ -1257,7 +1255,7 @@ struct nn_xpack * nn_xpack_new (ddsi_tran_conn_t conn, uint32_t bw_limit, bool a
   xp->hdr.protocol.id[3] = 'S';
   xp->hdr.version.major = RTPS_MAJOR;
   xp->hdr.version.minor = RTPS_MINOR;
-  xp->hdr.vendorid = myvendorid;
+  xp->hdr.vendorid = NN_VENDORID_ECLIPSE;
 
   /* MSG_LEN first sub message for stream based connections */
 


### PR DESCRIPTION
This PR changes the vendor code used by the DDSI stack to that assigned to the Eclipse Foundation for Cyclone DDS.