### PR TITLE
fixup following rename SYSDEPS to OS_MSGHDR_FLAGS

### DIFF
--- a/src/core/ddsi/src/ddsi_raweth.c
+++ b/src/core/ddsi/src/ddsi_raweth.c
@@ -100,7 +100,7 @@ static ssize_t ddsi_raweth_conn_read (ddsi_tran_conn_t conn, unsigned char * buf
 
     /* Check for udp packet truncation */
     if ((((size_t) ret) > len)
-#if SYSDEPS_MSGHDR_FLAGS
+#if OS_MSGHDR_FLAGS
         || (msghdr.msg_flags & MSG_TRUNC)
 #endif
         )

--- a/src/core/ddsi/src/ddsi_tcp.c
+++ b/src/core/ddsi/src/ddsi_tcp.c
@@ -555,7 +555,7 @@ static ssize_t ddsi_tcp_conn_write (ddsi_tran_conn_t base, const nn_locator_t *d
   set_msghdr_iov (&msg, (os_iovec_t *) iov, niov);
   msg.msg_name = &dstaddr;
   msg.msg_namelen = (socklen_t) os_sockaddr_get_size((os_sockaddr *) &dstaddr);
-#if SYSDEPS_MSGHDR_FLAGS
+#if OS_MSGHDR_FLAGS
   msg.msg_flags = (int) flags;
 #endif
   len = iovlen_sum (niov, iov);

--- a/src/core/ddsi/src/ddsi_udp.c
+++ b/src/core/ddsi/src/ddsi_udp.c
@@ -85,7 +85,7 @@ static ssize_t ddsi_udp_conn_read (ddsi_tran_conn_t conn, unsigned char * buf, s
 
     /* Check for udp packet truncation */
     if ((((size_t) ret) > len)
-#if SYSDEPS_MSGHDR_FLAGS
+#if OS_MSGHDR_FLAGS
         || (msghdr.msg_flags & MSG_TRUNC)
 #endif
         )
@@ -130,7 +130,7 @@ static ssize_t ddsi_udp_conn_write (ddsi_tran_conn_t conn, const nn_locator_t *d
   msg.msg_accrights = NULL;
   msg.msg_accrightslen = 0;
 #endif
-#if SYSDEPS_MSGHDR_FLAGS
+#if OS_MSGHDR_FLAGS
   msg.msg_flags = (int) flags;
 #else
   OS_UNUSED_ARG(flags);


### PR DESCRIPTION
The name change from SYSDEPS_MSGHDR_FLAGS to OS_MSGHDR_FLAGS missed the uses of the macro, with the result that datagram truncation on reception does not result in warning (but in the default configuration, truncation cannot occur); and that the message flags are undefined on sending datagrams, but judging by the man page, the likelihood of this causing problems is also small in practice.