### PR TITLE
Disable line buffering in Throughput examples on Windows

### DIFF
--- a/src/examples/throughput/publisher.c
+++ b/src/examples/throughput/publisher.c
@@ -46,7 +46,9 @@ int main (int argc, char **argv)
   dds_entity_t writer;
   ThroughputModule_DataType sample;
 
+#if !defined(_WIN32)
   setvbuf (stdout, NULL, _IOLBF, 0);
+#endif
 
   if (parse_args(argc, argv, &payloadSize, &burstInterval, &burstSize, &timeOut, &partitionName) == EXIT_FAILURE) {
     return EXIT_FAILURE;

--- a/src/examples/throughput/subscriber.c
+++ b/src/examples/throughput/subscriber.c
@@ -75,7 +75,9 @@ int main (int argc, char **argv)
   dds_entity_t participant;
   dds_entity_t reader;
 
+#if !defined(_WIN32)
   setvbuf (stdout, NULL, _IOLBF, 0);
+#endif
 
   if (parse_args(argc, argv, &maxCycles, &partitionName) == EXIT_FAILURE)
   {


### PR DESCRIPTION
The *setvbuf* call causes the Throughput example to crash on Windows. As line buffered output isn't supported on that platform anyway, I disabled compilation of it there entirely.