### PR TITLE
Writer throttling fixes + timeouts on Windows

### DIFF
--- a/src/core/ddsi/src/q_transmit.c
+++ b/src/core/ddsi/src/q_transmit.c
@@ -960,7 +960,7 @@ static os_result throttle_writer (struct nn_xpack *xp, struct writer *wr)
   }
 
   DDS_LOG(DDS_LC_THROTTLE, "writer %x:%x:%x:%x waiting for whc to shrink below low-water mark (whc %"PRIuSIZE" low=%u high=%u)\n", PGUID (wr->e.guid), whcst.unacked_bytes, wr->whc_low, wr->whc_high);
-  wr->throttling = 1;
+  wr->throttling++;
   wr->throttle_count++;
 
   /* Force any outstanding packet out: there will be a heartbeat
@@ -1000,7 +1000,7 @@ static os_result throttle_writer (struct nn_xpack *xp, struct writer *wr)
     }
   }
 
-  wr->throttling = 0;
+  wr->throttling--;
   if (wr->state != WRST_OPERATIONAL)
   {
     /* gc_delete_writer may be waiting */

--- a/src/core/ddsi/src/q_transmit.c
+++ b/src/core/ddsi/src/q_transmit.c
@@ -950,7 +950,7 @@ static os_result throttle_writer (struct nn_xpack *xp, struct writer *wr)
   nn_mtime_t tnow = now_mt ();
   const nn_mtime_t abstimeout = add_duration_to_mtime (tnow, nn_from_ddsi_duration (wr->xqos->reliability.max_blocking_time));
   struct whc_state whcst;
-  whc_get_state(wr->whc, &whcst);
+  whc_get_state (wr->whc, &whcst);
 
   {
     ASSERT_MUTEX_HELD (&wr->e.lock);
@@ -976,6 +976,7 @@ static os_result throttle_writer (struct nn_xpack *xp, struct writer *wr)
     }
     nn_xpack_send (xp, true);
     os_mutexLock (&wr->e.lock);
+    whc_get_state (wr->whc, &whcst);
   }
 
   while (gv.rtps_keepgoing && !writer_may_continue (wr, &whcst))

--- a/src/os/src/windows/os_platform_sync.c
+++ b/src/os/src/windows/os_platform_sync.c
@@ -97,7 +97,7 @@ os_result os_condTimedWait(os_cond *cond, os_mutex *mutex, const os_time *time)
     assert(cond != NULL);
     assert(mutex != NULL);
 
-    timems = time->tv_sec * 1000 + (time->tv_nsec + 999999999) / 1000000;
+    timems = time->tv_sec * 1000 + (time->tv_nsec + 999999) / 1000000;
     if (SleepConditionVariableSRW(&cond->cond, &mutex->lock, timems, 0)) {
         return os_resultSuccess;
     } else if (GetLastError() != ERROR_TIMEOUT) {


### PR DESCRIPTION
This PR fixes three separate problems:

* Incorrect conversion of timeouts in condition-variable waits to milliseconds on Windows, where instead of rounding upwards to the nearest millisecond, it is more like adding a second. The effect on the behaviour is surprisingly mild, but it does cause the observed periodic drops in throughput reported in #125.
* A missing re-calculation of the amount of unacknowledged data in the WHC (introduced in
https://github.com/eclipse-cyclonedds/cyclonedds/pull/31/commits/f2f436bde3cf225a6beaef8bb87ac24bec75b46c), which can result in an indefinite blocking waiting for an ACK that already arrived.
* A so-far only theoretical one, where multiple threads are using the same writer and all end up in the writer throttling path at the same time, and some never get unblocked.