### PR TITLE
Some minor things from issues and restoring OpenIndiana support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -127,7 +127,7 @@ script:
           -DBUILD_TESTING=on
           -G "${GENERATOR}" ../src
   - cmake --build . --config ${BUILD_TYPE} --target install
-  - ctest -T test -C ${BUILD_TYPE}
+  - CYCLONEDDS_URI='<CycloneDDS><DDSI2E><Internal><EnableExpensiveChecks>all</EnableExpensiveChecks></Internal></DDSI2E></CycloneDDS>' ctest -T test -C ${BUILD_TYPE}
   - if [ "${USE_SANITIZER}" != "none" ]; then
       CMAKE_LINKER_FLAGS="-DCMAKE_LINKER_FLAGS=-fsanitize=${USE_SANITIZER}";
       CMAKE_C_FLAGS="-DCMAKE_C_FLAGS=-fsanitize=${USE_SANITIZER}";

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,13 +37,14 @@ build_script:
   - cd build
   - conan install -s arch=%ARCH% -s build_type=%CONFIGURATION% ..
   - cmake -DBUILD_TESTING=on -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DCMAKE_INSTALL_PREFIX=%CD%/install -G "%GENERATOR%" ../src
-  - cmake --build . --config %CONFIGURATION% --target install
+  - cmake --build . --config %CONFIGURATION% --target install -- /maxcpucount
   - cd install/share/CycloneDDS/examples/helloworld
   - mkdir build
   - cd build
   - cmake -DCMAKE_BUILD_TYPE=%CONFIGURATION% -G "%GENERATOR%" ..
-  - cmake --build . --config %CONFIGURATION%
+  - cmake --build . --config %CONFIGURATION% -- /maxcpucount
   - cd ../../../../../..
 
 test_script:
+  - set "CYCLONEDDS_URI=<CycloneDDS><DDSI2E><Internal><EnableExpensiveChecks>all</EnableExpensiveChecks></Internal></DDSI2E></CycloneDDS>"
   - ctest --test-action test --build-config %CONFIGURATION%

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,7 +53,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL "VxWorks")
 endif()
 
 if(${CMAKE_C_COMPILER_ID} STREQUAL "SunPro")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m64 -xc99 -D__restrict=restrict")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m64 -xc99 -D__restrict=restrict -D__deprecated__=")
+  set(CMAKE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} -m64")
 endif()
 
 # Conan

--- a/src/core/ddsc/src/dds_publisher.c
+++ b/src/core/ddsc/src/dds_publisher.c
@@ -11,6 +11,7 @@
  */
 #include <assert.h>
 #include <string.h>
+#include "dds/ddsrt/misc.h"
 #include "dds__listener.h"
 #include "dds__qos.h"
 #include "dds__err.h"

--- a/src/core/ddsc/src/dds_rhc.c
+++ b/src/core/ddsc/src/dds_rhc.c
@@ -2625,6 +2625,9 @@ int dds_rhc_takecdr
 #define CHECK_MAX_CONDS 64
 static int rhc_check_counts_locked (struct rhc *rhc, bool check_conds, bool check_qcmask)
 {
+  if (!(config.enabled_xchecks & DDS_XCHECK_RHC))
+    return 1;
+
   const uint32_t ncheck = rhc->nconds < CHECK_MAX_CONDS ? rhc->nconds : CHECK_MAX_CONDS;
   unsigned n_instances = 0, n_nonempty_instances = 0;
   unsigned n_not_alive_disposed = 0, n_not_alive_no_writers = 0, n_new = 0;

--- a/src/core/ddsc/src/dds_rhc.c
+++ b/src/core/ddsc/src/dds_rhc.c
@@ -11,6 +11,7 @@
  */
 #include <assert.h>
 #include <string.h>
+#include <limits.h>
 
 #if HAVE_VALGRIND && ! defined (NDEBUG)
 #include <memcheck.h>

--- a/src/core/ddsc/src/dds_whc.c
+++ b/src/core/ddsc/src/dds_whc.c
@@ -258,6 +258,7 @@ static void check_whc (const struct whc_impl *whc)
   assert (whc->maxseq_node == whc_findmax_procedurally (whc));
 
 #if !defined(NDEBUG)
+  if (config.enabled_xchecks & DDS_XCHECK_WHC)
   {
     struct whc_intvnode *firstintv;
     struct whc_node *cur;

--- a/src/core/ddsc/src/dds_whc.c
+++ b/src/core/ddsc/src/dds_whc.c
@@ -15,6 +15,7 @@
 
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/sync.h"
+#include "dds/ddsrt/misc.h"
 #include "dds/ddsi/ddsi_serdata.h"
 #include "dds/ddsi/q_unused.h"
 #include "dds/ddsi/q_config.h"

--- a/src/core/ddsi/include/dds/ddsi/q_config.h
+++ b/src/core/ddsi/include/dds/ddsi/q_config.h
@@ -218,10 +218,15 @@ struct ssl_min_version {
 };
 #endif
 
+/* Expensive checks (compiled in when NDEBUG not defined, enabled only if flag set in xchecks) */
+#define DDS_XCHECK_WHC 1u
+#define DDS_XCHECK_RHC 2u
+
 struct config
 {
   int valid;
   uint32_t enabled_logcats;
+  uint32_t enabled_xchecks;
   char *servicename;
   char *pcap_file;
 

--- a/src/core/ddsi/include/dds/ddsi/q_protocol.h
+++ b/src/core/ddsi/include/dds/ddsi/q_protocol.h
@@ -130,8 +130,10 @@ typedef struct Header {
 } Header_t;
 #if DDSRT_ENDIAN == DDSRT_LITTLE_ENDIAN
 #define NN_PROTOCOLID_AS_UINT32 (((uint32_t)'R' << 0) | ((uint32_t)'T' << 8) | ((uint32_t)'P' << 16) | ((uint32_t)'S' << 24))
-#else
+#elif DDSRT_ENDIAN == DDSRT_BIG_ENDIAN
 #define NN_PROTOCOLID_AS_UINT32 (((uint32_t)'R' << 24) | ((uint32_t)'T' << 16) | ((uint32_t)'P' << 8) | ((uint32_t)'S' << 0))
+#else
+#error "DDSRT_ENDIAN neither LITTLE nor BIG"
 #endif
 #define RTPS_MESSAGE_HEADER_SIZE (sizeof (Header_t))
 

--- a/src/core/ddsi/src/ddsi_ssl.c
+++ b/src/core/ddsi/src/ddsi_ssl.c
@@ -13,6 +13,7 @@
 #include "dds/ddsi/ddsi_ssl.h"
 #include "dds/ddsi/q_config.h"
 #include "dds/ddsrt/log.h"
+#include "dds/ddsrt/misc.h"
 
 #ifdef DDSI_INCLUDE_SSL
 

--- a/src/core/ddsi/src/ddsi_udp.c
+++ b/src/core/ddsi/src/ddsi_udp.c
@@ -14,6 +14,7 @@
 #include "dds/ddsrt/atomics.h"
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/log.h"
+#include "dds/ddsrt/misc.h"
 #include "dds/ddsrt/sockets.h"
 #include "ddsi_eth.h"
 #include "dds/ddsi/ddsi_tran.h"

--- a/src/core/ddsi/src/q_addrset.c
+++ b/src/core/ddsi/src/q_addrset.c
@@ -16,6 +16,7 @@
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/log.h"
 #include "dds/ddsrt/string.h"
+#include "dds/ddsrt/misc.h"
 #include "dds/util/ut_avl.h"
 #include "dds/ddsi/q_log.h"
 #include "dds/ddsi/q_misc.h"

--- a/src/core/ddsi/src/q_config.c
+++ b/src/core/ddsi/src/q_config.c
@@ -21,6 +21,7 @@
 #include "dds/ddsrt/log.h"
 #include "dds/ddsrt/string.h"
 #include "dds/ddsrt/strtod.h"
+#include "dds/ddsrt/misc.h"
 #include "dds/ddsi/q_config.h"
 #include "dds/ddsi/q_log.h"
 #include "dds/util/ut_avl.h"

--- a/src/core/ddsi/src/q_debmon.c
+++ b/src/core/ddsi/src/q_debmon.c
@@ -16,6 +16,7 @@
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/log.h"
 #include "dds/ddsrt/sync.h"
+#include "dds/ddsrt/misc.h"
 
 #include "dds/util/ut_avl.h"
 

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -18,6 +18,7 @@
 #include "dds/ddsrt/sockets.h"
 #include "dds/ddsrt/string.h"
 #include "dds/ddsrt/sync.h"
+#include "dds/ddsrt/misc.h"
 
 #include "dds/ddsi/q_entity.h"
 #include "dds/ddsi/q_config.h"

--- a/src/core/ddsi/src/q_ephash.c
+++ b/src/core/ddsi/src/q_ephash.c
@@ -13,6 +13,8 @@
 #include <assert.h>
 
 #include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/misc.h"
+
 #include "dds/util/ut_hopscotch.h"
 #include "dds/ddsi/q_ephash.h"
 #include "dds/ddsi/q_config.h"

--- a/src/core/ddsi/src/q_freelist.c
+++ b/src/core/ddsi/src/q_freelist.c
@@ -12,6 +12,7 @@
 #include <stddef.h>
 
 #include "dds/ddsrt/atomics.h"
+#include "dds/ddsrt/misc.h"
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/sync.h"
 #include "dds/ddsrt/threads.h"

--- a/src/core/ddsi/src/q_nwif.c
+++ b/src/core/ddsi/src/q_nwif.c
@@ -544,9 +544,7 @@ int find_own_ip (const char *requested_address)
       quality = q;
     }
 
-    /* FIXME: HACK HACK */
-    //ddsi_ipaddr_to_loc(&gv.interfaces[gv.n_interfaces].loc, &tmpip, gv.m_factory->m_kind);
-    if (ifa->addr->sa_family == AF_INET || ifa->addr->sa_family == AF_INET6)
+    if (ifa->addr->sa_family == AF_INET && ifa->netmask)
     {
       ddsi_ipaddr_to_loc(&gv.interfaces[gv.n_interfaces].netmask, ifa->netmask, gv.m_factory->m_kind);
     }

--- a/src/core/ddsi/src/q_thread.c
+++ b/src/core/ddsi/src/q_thread.c
@@ -19,6 +19,7 @@
 #include "dds/ddsrt/string.h"
 #include "dds/ddsrt/sync.h"
 #include "dds/ddsrt/threads.h"
+#include "dds/ddsrt/misc.h"
 
 #include "dds/ddsi/q_thread.h"
 #include "dds/ddsi/q_servicelease.h"

--- a/src/core/ddsi/src/sysdeps.c
+++ b/src/core/ddsi/src/sysdeps.c
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 
 #include "dds/ddsrt/atomics.h"
+#include "dds/ddsrt/misc.h"
 
 #include "dds/ddsi/q_error.h"
 #include "dds/ddsi/q_log.h"

--- a/src/ddsrt/include/dds/ddsrt/attributes.h
+++ b/src/ddsrt/include/dds/ddsrt/attributes.h
@@ -24,6 +24,10 @@
 # define ddsrt_clang (0)
 #endif
 
+#ifdef __SUNPRO_C
+# define __attribute__(x)
+#endif
+
 #if defined(__has_attribute)
 # define ddsrt_has_attribute(params) __has_attribute(params)
 #elif ddsrt_gnuc

--- a/src/ddsrt/include/dds/ddsrt/endian.h
+++ b/src/ddsrt/include/dds/ddsrt/endian.h
@@ -32,6 +32,13 @@ extern "C" {
 #   elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #     define DDSRT_ENDIAN DDSRT_LITTLE_ENDIAN
 #   endif
+# elif defined(__sun)
+#   include <sys/isa_defs.h>
+#   if defined(_BIG_ENDIAN)
+#     define DDSRT_ENDIAN DDSRT_BIG_ENDIAN
+#   elif defined(_LITTLE_ENDIAN)
+#     define DDSRT_ENDIAN DDSRT_LITTLE_ENDIAN
+#   endif
 # endif
 #endif /* _WIN32 */
 

--- a/src/ddsrt/src/sockets/posix/socket.c
+++ b/src/ddsrt/src/sockets/posix/socket.c
@@ -23,6 +23,9 @@
 #endif /* __VXWORKS__ */
 #include <sys/types.h>
 #include <sys/socket.h>
+#ifdef __sun
+#include <fcntl.h>
+#endif
 
 #ifdef __APPLE__
 #include <sys/sockio.h>

--- a/src/examples/helloworld/publisher.c
+++ b/src/examples/helloworld/publisher.c
@@ -31,6 +31,7 @@ int main (int argc, char ** argv)
     DDS_FATAL("dds_create_write: %s\n", dds_strretcode(-writer));
 
   printf("=== [Publisher]  Waiting for a reader to be discovered ...\n");
+  fflush (stdout);
 
   rc = dds_set_status_mask(writer, DDS_PUBLICATION_MATCHED_STATUS);
   if (rc != DDS_RETCODE_OK)
@@ -52,6 +53,7 @@ int main (int argc, char ** argv)
 
   printf ("=== [Publisher]  Writing : ");
   printf ("Message (%d, %s)\n", msg.userID, msg.message);
+  fflush (stdout);
 
   rc = dds_write (writer, &msg);
   if (rc != DDS_RETCODE_OK)

--- a/src/examples/helloworld/subscriber.c
+++ b/src/examples/helloworld/subscriber.c
@@ -40,6 +40,7 @@ int main (int argc, char ** argv)
   dds_delete_qos(qos);
 
   printf ("\n=== [Subscriber] Waiting for a sample ...\n");
+  fflush (stdout);
 
   /* Initialize sample buffer, by pointing the void pointer within
    * the buffer array to a valid sample memory location. */
@@ -61,6 +62,7 @@ int main (int argc, char ** argv)
       msg = (HelloWorldData_Msg*) samples[0];
       printf ("=== [Subscriber] Received : ");
       printf ("Message (%d, %s)\n", msg->userID, msg->message);
+      fflush (stdout);
       break;
     }
     else

--- a/src/examples/roundtrip/ping.c
+++ b/src/examples/roundtrip/ping.c
@@ -193,6 +193,7 @@ static void data_available(dds_entity_t rd, void *arg)
              readAccess.count,
              exampleGetMedianFromTimeStats (&readAccess),
              readAccess.min);
+      fflush (stdout);
 
       exampleResetTimeStats (&roundTrip);
       exampleResetTimeStats (&writeAccess);
@@ -282,11 +283,10 @@ int main (int argc, char *argv[])
   }
   prepare_dds(&writer, &reader, &readCond, listener);
 
-  setvbuf(stdout, NULL, _IONBF, 0);
-
   if (argc - argidx == 1 && strcmp (argv[argidx], "quit") == 0)
   {
     printf ("Sending termination request.\n");
+    fflush (stdout);
     /* pong uses a waitset which is triggered by instance disposal, and
       quits when it fires. */
     dds_sleepfor (DDS_SECS (1));
@@ -325,6 +325,7 @@ int main (int argc, char *argv[])
   if (invalidargs || (argc - argidx == 1 && (strcmp (argv[argidx], "-h") == 0 || strcmp (argv[argidx], "--help") == 0)))
     usage();
   printf ("# payloadSize: %" PRIu32 " | numSamples: %" PRIu64 " | timeOut: %" PRIi64 "\n\n", payloadSize, numSamples, timeOut);
+  fflush (stdout);
 
   pub_data.payload._length = payloadSize;
   pub_data.payload._buffer = payloadSize ? dds_alloc (payloadSize) : NULL;
@@ -337,6 +338,7 @@ int main (int argc, char *argv[])
 
   startTime = dds_time ();
   printf ("# Waiting for startup jitter to stabilise\n");
+  fflush (stdout);
   /* Write a sample that pong can send back */
   while (!dds_triggered (waitSet) && difference < DDS_SECS(5))
   {
@@ -358,11 +360,10 @@ int main (int argc, char *argv[])
   {
     warmUp = false;
     printf("# Warm up complete.\n\n");
-
     printf("# Latency measurements (in us)\n");
     printf("#             Latency [us]                                   Write-access time [us]       Read-access time [us]\n");
     printf("# Seconds     Count   median      min      99%%      max      Count   median      min      Count   median      min\n");
-
+    fflush (stdout);
   }
 
   exampleResetTimeStats (&roundTrip);
@@ -403,6 +404,7 @@ int main (int argc, char *argv[])
       exampleGetMedianFromTimeStats (&readAccessOverall),
       readAccessOverall.min
     );
+    fflush (stdout);
   }
 
 done:

--- a/src/examples/roundtrip/ping.c
+++ b/src/examples/roundtrip/ping.c
@@ -375,7 +375,7 @@ int main (int argc, char *argv[])
   if (status < 0)
     DDS_FATAL("dds_write_ts: %s\n", dds_strretcode(-status));
   postWriteTime = dds_time ();
-  for (i = 0; !dds_triggered (waitSet) && (!numSamples || i < numSamples); i++)
+  for (i = 0; !dds_triggered (waitSet) && (!numSamples || i < numSamples) && !(timeOut && elapsed >= timeOut); i++)
   {
     status = dds_waitset_wait (waitSet, wsresults, wsresultsize, waitTimeout);
     if (status < 0)

--- a/src/examples/throughput/publisher.c
+++ b/src/examples/throughput/publisher.c
@@ -47,10 +47,6 @@ int main (int argc, char **argv)
   dds_return_t rc;
   ThroughputModule_DataType sample;
 
-#if !defined(_WIN32)
-  setvbuf (stdout, NULL, _IOLBF, 0);
-#endif
-
   if (parse_args(argc, argv, &payloadSize, &burstInterval, &burstSize, &timeOut, &partitionName) == EXIT_FAILURE) {
     return EXIT_FAILURE;
   }
@@ -60,6 +56,7 @@ int main (int argc, char **argv)
   /* Wait until have a reader */
   if (wait_for_reader(writer, participant) == 0) {
     printf ("=== [Publisher]  Did not discover a reader.\n");
+    fflush (stdout);
     rc = dds_delete (participant);
     if (rc < 0)
       DDS_FATAL("dds_delete: %s\n", dds_strretcode(-rc));
@@ -131,6 +128,7 @@ static int parse_args(
 
   printf ("payloadSize: %u bytes burstInterval: %u ms burstSize: %u timeOut: %u seconds partitionName: %s\n",
     *payloadSize, *burstInterval, *burstSize, *timeOut, *partitionName);
+  fflush (stdout);
 
   return result;
 }
@@ -182,6 +180,7 @@ static dds_entity_t prepare_dds(dds_entity_t *writer, const char *partitionName)
 static dds_return_t wait_for_reader(dds_entity_t writer, dds_entity_t participant)
 {
   printf ("\n=== [Publisher]  Waiting for a reader ...\n");
+  fflush (stdout);
 
   dds_return_t rc;
   dds_entity_t waitset;
@@ -224,6 +223,7 @@ static void start_writing(
     unsigned int burstCount = 0;
 
     printf ("=== [Publisher]  Writing samples...\n");
+    fflush (stdout);
 
     while (!done && !timedOut)
     {
@@ -277,14 +277,8 @@ static void start_writing(
     }
     dds_write_flush (writer);
 
-    if (done)
-    {
-      printf ("=== [Publisher]  Terminated, %llu samples written.\n", (unsigned long long) sample->count);
-    }
-    else
-    {
-      printf ("=== [Publisher]  Timed out, %llu samples written.\n", (unsigned long long) sample->count);
-    }
+    printf ("=== [Publisher]  %s, %llu samples written.\n", done ? "Terminated" : "Timed out", (unsigned long long) sample->count);
+    fflush (stdout);
   }
 }
 

--- a/src/examples/throughput/subscriber.c
+++ b/src/examples/throughput/subscriber.c
@@ -75,20 +75,18 @@ int main (int argc, char **argv)
   dds_entity_t participant;
   dds_entity_t reader;
 
-#if !defined(_WIN32)
-  setvbuf (stdout, NULL, _IOLBF, 0);
-#endif
-
   if (parse_args(argc, argv, &maxCycles, &partitionName) == EXIT_FAILURE)
   {
     return EXIT_FAILURE;
   }
 
   printf ("Cycles: %llu | PollingDelay: %ld | Partition: %s\n", maxCycles, pollingDelay, partitionName);
+  fflush (stdout);
 
   participant = prepare_dds(&reader, partitionName);
 
   printf ("=== [Subscriber] Waiting for samples...\n");
+  fflush (stdout);
 
   /* Process samples until Ctrl-C is pressed or until maxCycles */
   /* has been reached (0 = infinite) */
@@ -280,6 +278,7 @@ static void process_samples(dds_entity_t reader, unsigned long long maxCycles)
                 deltaTime, payloadSize, total_samples, total_bytes, outOfOrder,
                 (deltaTime != 0.0) ? ((double)(total_samples - prev_samples) / deltaTime) : 0,
                 (deltaTime != 0.0) ? ((double)((total_bytes - prev_bytes) / BYTES_PER_SEC_TO_MEGABITS_PER_SEC) / deltaTime) : 0);
+        fflush (stdout);
         cycles++;
         prev_time = time_now;
         prev_bytes = total_bytes;
@@ -300,6 +299,7 @@ static void process_samples(dds_entity_t reader, unsigned long long maxCycles)
   printf ("Out of order: %llu samples\n", outOfOrder);
   printf ("Average transfer rate: %.2lf samples/s, ", (double)total_samples / deltaTime);
   printf ("%.2lf Mbit/s\n", (double)(total_bytes / BYTES_PER_SEC_TO_MEGABITS_PER_SEC) / deltaTime);
+  fflush (stdout);
 }
 
 static dds_entity_t prepare_dds(dds_entity_t *reader, const char *partitionName)

--- a/src/util/include/dds/util/ut_xmlparser.h
+++ b/src/util/include/dds/util/ut_xmlparser.h
@@ -38,6 +38,7 @@ extern "C" {
 
     DDS_EXPORT struct ut_xmlpState *ut_xmlpNewFile (FILE *fp, void *varg, const struct ut_xmlpCallbacks *cb);
     DDS_EXPORT struct ut_xmlpState *ut_xmlpNewString (const char *string, void *varg, const struct ut_xmlpCallbacks *cb);
+    DDS_EXPORT void ut_xmlpSetRequireEOF (struct ut_xmlpState *st, int require_eof);
     DDS_EXPORT void ut_xmlpFree (struct ut_xmlpState *st);
     DDS_EXPORT int ut_xmlpParse (struct ut_xmlpState *st);
 

--- a/src/util/include/dds/util/ut_xmlparser.h
+++ b/src/util/include/dds/util/ut_xmlparser.h
@@ -39,6 +39,7 @@ extern "C" {
     DDS_EXPORT struct ut_xmlpState *ut_xmlpNewFile (FILE *fp, void *varg, const struct ut_xmlpCallbacks *cb);
     DDS_EXPORT struct ut_xmlpState *ut_xmlpNewString (const char *string, void *varg, const struct ut_xmlpCallbacks *cb);
     DDS_EXPORT void ut_xmlpSetRequireEOF (struct ut_xmlpState *st, int require_eof);
+    DDS_EXPORT size_t ut_xmlpGetBufpos (const struct ut_xmlpState *st);
     DDS_EXPORT void ut_xmlpFree (struct ut_xmlpState *st);
     DDS_EXPORT int ut_xmlpParse (struct ut_xmlpState *st);
 

--- a/src/util/src/ut_xmlparser.c
+++ b/src/util/src/ut_xmlparser.c
@@ -49,6 +49,7 @@ struct ut_xmlpState {
     size_t tpescp; /* still escape sequences in tpescp .. tpp */
     int nest; /* current nesting level */
     void *varg; /* user argument to callback functions */
+    int require_eof; /* if false, junk may follow top-level closing tag */
     struct ut_xmlpCallbacks cb; /* user-supplied callbacks (or stubs) */
 };
 
@@ -107,6 +108,7 @@ static void ut_xmlpNewCommon (struct ut_xmlpState *st)
     st->peekpayload = NULL;
     st->nest = 0;
     st->error = 0;
+    st->require_eof = 1;
 }
 
 static void ut_xmlpNewSetCB (struct ut_xmlpState *st, void *varg, const struct ut_xmlpCallbacks *cb)
@@ -144,6 +146,11 @@ struct ut_xmlpState *ut_xmlpNewString (const char *string, void *varg, const str
     ut_xmlpNewCommon (st);
     ut_xmlpNewSetCB (st, varg, cb);
     return st;
+}
+
+void ut_xmlpSetRequireEOF (struct ut_xmlpState *st, int require_eof)
+{
+    st->require_eof = require_eof;
 }
 
 void ut_xmlpFree (struct ut_xmlpState *st)
@@ -697,7 +704,7 @@ int ut_xmlpParse (struct ut_xmlpState *st)
         return 0;
     } else {
         int ret = parse_element (st, 0);
-        if (ret < 0 || next_token (st, NULL) == TOK_EOF) {
+        if (ret < 0|| !st->require_eof || next_token (st, NULL) == TOK_EOF ) {
             return ret;
         } else {
             return -1;

--- a/src/util/src/ut_xmlparser.c
+++ b/src/util/src/ut_xmlparser.c
@@ -153,6 +153,11 @@ void ut_xmlpSetRequireEOF (struct ut_xmlpState *st, int require_eof)
     st->require_eof = require_eof;
 }
 
+size_t ut_xmlpGetBufpos (const struct ut_xmlpState *st)
+{
+    return st->cbufp;
+}
+
 void ut_xmlpFree (struct ut_xmlpState *st)
 {
     if (st->fp != NULL) {


### PR DESCRIPTION
This PR adds a few small things:

- timeout parameter in ``RoundtripPing`` (#126)
- flushing of output in all examples (#133)
- reducing the cost of enabling assertions (#125) — there's an option for enabling them (Internal/EnableExpensiveChecks), this is used in the CI runs
- IPv6 support on Windows — this was broken because of erroneously requiring a netmask
- a small enhancement in configuration handling, allowing CYCLONEDDS_URI to include XML fragments so you can configure things without having to set a file
- restore building on OpenIndiana