### PR TITLE
Possible assert when ddsi socket write fails.

### DIFF
--- a/src/core/ddsi/src/ddsi_raweth.c
+++ b/src/core/ddsi/src/ddsi_raweth.c
@@ -160,7 +160,7 @@ static ssize_t ddsi_raweth_conn_write (ddsi_tran_conn_t conn, const nn_locator_t
   {
     DDS_ERROR("ddsi_raweth_conn_write failed with retcode %d", rc);
   }
-  return ret;
+  return (rc == DDS_RETCODE_OK ? ret : -1);
 }
 
 static ddsrt_socket_t ddsi_raweth_conn_handle (ddsi_tran_base_t base)

--- a/src/core/ddsi/src/ddsi_tcp.c
+++ b/src/core/ddsi/src/ddsi_tcp.c
@@ -530,7 +530,7 @@ static ssize_t ddsi_tcp_conn_write (ddsi_tran_conn_t base, const nn_locator_t *d
   char msgbuf[4096]; /* stack buffer for merging smallish writes without requiring allocations */
   ddsrt_iovec_t iovec; /* iovec used for msgbuf */
 #endif
-  ssize_t ret;
+  ssize_t ret = -1;
   size_t len;
   ddsi_tcp_conn_t conn;
   int piecewise;

--- a/src/core/ddsi/src/ddsi_udp.c
+++ b/src/core/ddsi/src/ddsi_udp.c
@@ -169,7 +169,7 @@ static ssize_t ddsi_udp_conn_write (ddsi_tran_conn_t conn, const nn_locator_t *d
   {
     DDS_ERROR("ddsi_udp_conn_write failed with retcode %d", rc);
   }
-  return ret;
+  return (rc == DDS_RETCODE_OK ? ret : -1);
 }
 
 static void ddsi_udp_disable_multiplexing (ddsi_tran_conn_t base)

--- a/src/core/ddsi/src/ddsi_udp.c
+++ b/src/core/ddsi/src/ddsi_udp.c
@@ -117,7 +117,7 @@ static void set_msghdr_iov (ddsrt_msghdr_t *mhdr, ddsrt_iovec_t *iov, size_t iov
 static ssize_t ddsi_udp_conn_write (ddsi_tran_conn_t conn, const nn_locator_t *dst, size_t niov, const ddsrt_iovec_t *iov, uint32_t flags)
 {
   dds_retcode_t rc;
-  ssize_t ret;
+  ssize_t ret = -1;
   unsigned retry = 2;
   int sendflags = 0;
   ddsrt_msghdr_t msg;


### PR DESCRIPTION
The pull request #124 was a major overhaul of the operating system abstraction layer.
One small change within that pull request was a syntax change of the socket send functions.

Previously, the 'nr of written bytes' variable contained an error value when the send failed. Now, however, that value is not touched when the ddsrt socket send fails. But the DDSI write still expected it to contain an error value when the send failed.

Now, the DDSI write(s) dependent on the ddsrt socket return value when the send failed, instead of the 'nr of written bytes'.

NB. The socket recv usages don't have this issue.