### PR TITLE
Fix for crash in ddsi_serdata_from_keyhash

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/q_rtps.h
+++ b/src/core/ddsi/include/dds/ddsi/q_rtps.h
@@ -76,6 +76,7 @@ struct cfgst;
 int rtps_config_prep (struct cfgst *cfgst);
 int rtps_config_open (void);
 int rtps_init (void);
+int rtps_start (void);
 void ddsi_plugin_init (void);
 void rtps_stop (void);
 void rtps_fini (void);

--- a/src/core/ddsi/src/q_thread.c
+++ b/src/core/ddsi/src/q_thread.c
@@ -172,6 +172,7 @@ static uint32_t create_thread_wrapper (void *ptr)
 {
   uint32_t ret;
   struct thread_context *ctx = ptr;
+  DDS_TRACE ("started new thread %"PRIdTID": %s\n", ddsrt_gettid (), ctx->self->name);
   ctx->self->tid = ddsrt_thread_self ();
   ret = ctx->f (ctx->arg);
   ddsrt_free (ctx);
@@ -272,7 +273,6 @@ struct thread_state1 *create_thread (const char *name, uint32_t (*f) (void *arg)
     DDS_FATAL("create_thread: %s: ddsrt_thread_create failed\n", name);
     goto fatal;
   }
-  DDS_TRACE("started new thread %"PRIdTID" : %s\n", ddsrt_gettid(), name);
   ts1->extTid = tid; /* overwrite the temporary value with the correct external one */
   ddsrt_mutex_unlock (&thread_states.lock);
   return ts1;


### PR DESCRIPTION
This PR fixes #138, and cleans up two minor other issues as well: possible error messages on shutdown from the (optional) "debmon" thread, and an incorrect thread id in the trace when a new thread is created. 