### PR TITLE
Remove incorrect assert on thread ids in receive buffer management

### DIFF
--- a/src/core/ddsi/src/q_config.c
+++ b/src/core/ddsi/src/q_config.c
@@ -248,7 +248,7 @@ static const struct cfgelem general_cfgelems[] = {
 "<p>This element controls whether DDSI2E uses multicasts for data traffic.</p>\n\
 <p>It is a comma-separated list of some of the following keywords: \"spdp\", \"asm\", \"ssm\", or either of \"false\" or \"true\".</p>\n\
 <ul>\n\
-<li><i>spdp</i>: enables the use of ASM (any-source multicast) for participant discovery</li>\n\
+<li><i>spdp</i>: enables the use of ASM (any-source multicast) for participant discovery, joining the multicast group on the discovery socket, transmitting SPDP messages to this group, but never advertising nor using any multicast address in any discovery message, thus forcing unicast communications for all endpoint discovery and user data.</li>\n\
 <li><i>asm</i>: enables the use of ASM for all traffic (including SPDP)</li>\n\
 <li><i>ssm</i>: enables the use of SSM (source-specific multicast) for all non-SPDP traffic (if supported)</li>\n\
 </ul>\n\

--- a/src/core/ddsi/src/q_config.c
+++ b/src/core/ddsi/src/q_config.c
@@ -654,7 +654,7 @@ END_MARKER
 static const struct cfgelem sizing_cfgelems[] =
 {
     { LEAF("ReceiveBufferSize"), 1, "1 MiB", ABSOFF(rbuf_size), 0, uf_memsize, 0, pf_memsize,
-    "<p>This element sets the size of a single receive buffer. Many receive buffers may be needed. Their size must be greater than ReceiveBufferChunkSize by a modest amount.</p>" },
+    "<p>This element sets the size of a single receive buffer. Many receive buffers may be needed. The minimum workable size a little bit larger than Sizing/ReceiveBufferChunkSize, and the value used is taken as the configured value and the actual minimum workable size.</p>" },
     { LEAF("ReceiveBufferChunkSize"), 1, "128 KiB", ABSOFF(rmsg_chunk_size), 0, uf_memsize, 0, pf_memsize,
     "<p>This element specifies the size of one allocation unit in the receive buffer. Must be greater than the maximum packet size by a modest amount (too large packets are dropped). Each allocation is shrunk immediately after processing a message, or freed straightaway.</p>" },
     END_MARKER

--- a/src/core/ddsi/src/q_radmin.c
+++ b/src/core/ddsi/src/q_radmin.c
@@ -330,7 +330,13 @@ struct nn_rbufpool *nn_rbufpool_new (uint32_t rbuf_size, uint32_t max_rmsg_size)
   struct nn_rbufpool *rbp;
 
   assert (max_rmsg_size > 0);
-  assert (rbuf_size >= max_rmsg_size_w_hdr (max_rmsg_size));
+
+  /* raise rbuf_size to minimum possible considering max_rmsg_size, there is
+     no reason to bother the user with the small difference between the two
+     when he tries to configure things, and the crash is horrible when
+     rbuf_size is too small */
+  if (rbuf_size < max_rmsg_size_w_hdr (max_rmsg_size))
+    rbuf_size = max_rmsg_size_w_hdr (max_rmsg_size);
 
   if ((rbp = ddsrt_malloc (sizeof (*rbp))) == NULL)
     goto fail_rbp;

--- a/src/core/ddsi/src/q_receive.c
+++ b/src/core/ddsi/src/q_receive.c
@@ -2304,8 +2304,8 @@ static int handle_SPDP (const struct nn_rsample_info *sampleinfo, struct nn_rdat
   fragchain = nn_rsample_fragchain (rsample);
   if ((rres = nn_reorder_rsample (&sc, gv.spdp_reorder, rsample, &refc_adjust, nn_dqueue_is_full (gv.builtins_dqueue))) > 0)
     nn_dqueue_enqueue (gv.builtins_dqueue, &sc, rres);
-  ddsrt_mutex_unlock (&gv.spdp_lock);
   nn_fragchain_adjust_refcount (fragchain, refc_adjust);
+  ddsrt_mutex_unlock (&gv.spdp_lock);
   return 0;
 }
 
@@ -2342,8 +2342,8 @@ static void drop_oversize (struct receiver_state *rst, struct nn_rmsg *rmsg, con
     ddsrt_mutex_lock (&pwr->e.lock);
     wn = ut_avlLookup (&pwr_readers_treedef, &pwr->readers, &dst);
     gap_was_valuable = handle_one_gap (pwr, wn, sampleinfo->seq, sampleinfo->seq+1, gap, &refc_adjust);
-    ddsrt_mutex_unlock (&pwr->e.lock);
     nn_fragchain_adjust_refcount (gap, refc_adjust);
+    ddsrt_mutex_unlock (&pwr->e.lock);
 
     if (gap_was_valuable)
     {


### PR DESCRIPTION
This PR removes an incorrect assert on thread ids in receive buffer management that can trigger when multiple receive threads are used. After due deliberation, I am convinced that there is no actual problem, but I am also of the opinion that the entire receive buffering needs some TLC.

Also included are two small changes to the configuration info blurbs and a more graceful handling of a Sizing/ReceiveBufferSize that is set too small.