### PR TITLE
Add user data pointer to dds_entity

### DIFF
--- a/src/core/ddsc/include/dds/dds.h
+++ b/src/core/ddsc/include/dds/dds.h
@@ -715,6 +715,61 @@ DDS_EXPORT dds_return_t
 dds_set_listener(dds_entity_t entity, const dds_listener_t * listener);
 
 /*
+  Get or set user data pointer for an entity.
+*/
+
+/**
+ * @brief Get user data pointer.
+ *
+ * This operation allows access to the user data pointer of the entity.
+ *
+ * @param[in]  entity     Entity from which to get the user data pointer.
+ * @param[in]  user_data  Pointer to a pointer that will get the address
+ *                        of the user data that is stored with this entity.
+ *
+ * @returns A dds_return_t indicating success or failure.
+ *
+ * @retval DDS_RETCODE_OK
+ *             The user data pointer has been successfully retrieved from
+ *             the entity.
+ * @retval DDS_RETCODE_ERROR
+ *             An internal error has occurred.
+ * @retval DDS_RETCODE_BAD_PARAMETER
+ *             The user_data parameter is NULL or the entity parameter
+ *             is not a valid parameter
+ * @retval DDS_RETCODE_ALREADY_DELETED
+ *             The entity has already been deleted.
+ */
+DDS_EXPORT dds_return_t
+dds_get_user_data(dds_entity_t entity, void ** user_data);
+
+/**
+ * @brief Set user data pointer.
+ *
+ * This operation sets the user data pointer of the entity. The user-data
+ * pointer can e.g. be used to facilitate lookup functionality when implementing
+ * a language binding. The user-data pointer can act as a back-ref to the API
+ * object that is built on top of the C API.
+ *
+ * @param[in]  entity     Entity on which to set the user data pointer.
+ * @param[in]  user_data  Pointer to the user data that will be stored with
+ *                        this entity.
+ *
+ * @returns A dds_return_t indicating success or failure.
+ *
+ * @retval DDS_RETCODE_OK
+ *             The user data pointer has been successfully set.
+ * @retval DDS_RETCODE_ERROR
+ *             An internal error has occurred.
+ * @retval DDS_RETCODE_BAD_PARAMETER
+ *             The entity parameter is not a valid parameter.
+ * @retval DDS_RETCODE_ALREADY_DELETED
+ *             The entity has already been deleted.
+ */
+DDS_EXPORT dds_return_t
+dds_set_user_data(dds_entity_t entity, const void * user_data);
+
+/*
   Creation functions for various entities. Creating a subscriber or
   publisher is optional: if one creates a reader as a descendant of a
   participant, it is as if a subscriber is created specially for

--- a/src/core/ddsc/src/dds__types.h
+++ b/src/core/ddsc/src/dds__types.h
@@ -147,6 +147,7 @@ typedef struct dds_entity
   uint32_t m_status_enable;
   uint32_t m_cb_count;
   dds_entity_observer *m_observers;
+  void * m_user_data;
 
   struct ut_handlelink *m_hdllink;
 }

--- a/src/core/ddsc/src/dds_entity.c
+++ b/src/core/ddsc/src/dds_entity.c
@@ -1038,3 +1038,37 @@ const char *dds__entity_kind_str (dds_entity_t e)
     default:                    return "(INVALID_ENTITY)";
   }
 }
+
+dds_return_t dds_get_user_data (dds_entity_t entity, void ** user_data)
+{
+  dds_entity *e;
+  dds_retcode_t rc;
+
+  if (user_data == NULL) {
+    return DDS_ERRNO (DDS_RETCODE_BAD_PARAMETER);
+  }
+
+  if ((rc = dds_entity_lock (entity, DDS_KIND_DONTCARE, &e)) != DDS_RETCODE_OK) {
+    return DDS_ERRNO (rc);
+  }
+
+  *user_data = e->m_user_data;
+  dds_entity_unlock(e);
+
+  return DDS_RETCODE_OK;
+}
+
+dds_return_t dds_set_user_data (dds_entity_t entity, const void * user_data)
+{
+  dds_entity *e;
+  dds_retcode_t rc;
+
+  if ((rc = dds_entity_lock (entity, DDS_KIND_DONTCARE, &e)) != DDS_RETCODE_OK) {
+    return DDS_ERRNO (rc);
+  }
+
+  e->m_user_data = (void *)user_data;
+  dds_entity_unlock(e);
+
+  return DDS_RETCODE_OK;
+}

--- a/src/core/ddsc/tests/entity_api.c
+++ b/src/core/ddsc/tests/entity_api.c
@@ -257,6 +257,41 @@ CU_Test(ddsc_entity, status, .init = create_entity, .fini = delete_entity)
     cu_assert_status_eq(status1, DDS_RETCODE_OK);
 }
 
+CU_Test(ddsc_entity, user_data, .init = create_entity, .fini = delete_entity)
+{
+    dds_return_t status1;
+    void * user_data1 = NULL;
+    void * user_data2 = &user_data1;
+
+    /* Check getting user data with bad parameters. */
+    status1 = dds_get_user_data (0, NULL);
+    cu_assert_status_eq(status1, DDS_RETCODE_BAD_PARAMETER);
+    status1 = dds_get_user_data (entity, NULL);
+    cu_assert_status_eq(status1, DDS_RETCODE_BAD_PARAMETER);
+    status1 = dds_get_user_data (0, &user_data1);
+    cu_assert_status_eq(status1, DDS_RETCODE_BAD_PARAMETER);
+
+    /* Check setting user data with bad parameters. */
+    status1 = dds_set_user_data (0, NULL);
+    cu_assert_status_eq(status1, DDS_RETCODE_BAD_PARAMETER);
+    CU_ASSERT_EQUAL_FATAL(user_data1, NULL);
+
+    /* Check setting user data to user_data2 (address of user_data1) */
+    status1 = dds_set_user_data (entity, user_data2);
+    cu_assert_status_eq(status1, DDS_RETCODE_OK);
+
+    /* Get user data, which should be the address of user_data1 */
+    status1 = dds_get_user_data (entity, &user_data2);
+    cu_assert_status_eq(status1, DDS_RETCODE_OK);
+    CU_ASSERT_EQUAL_FATAL(user_data2, &user_data1);
+
+    /* Check setting user data to NULL */
+    status1 = dds_set_user_data (entity, NULL);
+    cu_assert_status_eq(status1, DDS_RETCODE_OK);
+    status1 = dds_get_user_data (entity, &user_data2);
+    cu_assert_status_eq(status1, DDS_RETCODE_OK);
+    CU_ASSERT_EQUAL_FATAL(user_data2, NULL);
+}
 
 CU_Test(ddsc_entity, instance_handle, .init = create_entity, .fini = delete_entity)
 {


### PR DESCRIPTION
To build API's (e.g. a C++11 API) on top op Cyclone's C99 API, bottom-up navigation is required, i.e. from a C99 handle to the corresponding C++ object. This is needed to facilitate things like listener-callbacks and lookup functionality (e.g. the get_subscriber call on the, which is supposed to return the Subscriber that used when creating a DataReader). This pull request adds a user_data pointer to the dds_entity type, so that a backref can be stored that points to the API object built on top of the C99 API.