### PR TITLE
Fix double delivery of historical data and add DATA_AVAILABLE on deleting writer

### DIFF
--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -4111,12 +4111,13 @@ int new_proxy_writer (const struct nn_guid *ppguid, const struct nn_guid *guid, 
   } else {
     pwr->deliver_synchronously = 0;
   }
-  pwr->have_seen_heartbeat = 0;
+  /* Pretend we have seen a heartbeat if the proxy writer is a best-effort one */
+  isreliable = (pwr->c.xqos->reliability.kind != NN_BEST_EFFORT_RELIABILITY_QOS);
+  pwr->have_seen_heartbeat = !isreliable;
   pwr->local_matching_inprogress = 1;
 #ifdef DDSI_INCLUDE_SSM
   pwr->supports_ssm = (addrset_contains_ssm (as) && config.allowMulticast & AMC_SSM) ? 1 : 0;
 #endif
-  isreliable = (pwr->c.xqos->reliability.kind != NN_BEST_EFFORT_RELIABILITY_QOS);
 
   /* Only assert PP lease on receipt of data if enabled (duh) and the proxy participant is a
      "real" participant, rather than the thing we use for endpoints discovered via the DS */


### PR DESCRIPTION
This PR addresses #146 and #148. The fix for #146 is not ideal in that it somewhat delays the reception of the first sample compared to what it did before, but that's definitely less bad than delivering data twice or dropping some data when the reader and writer both use a KEEP_ALL history setting (see the commit message for details).

I suspect there are some possible improvements, but those would really be limited to small improvements in start-up behaviour and in some cases where a single process has a mix of best-effort and reliable readers all matching the same reliable writer.