### PR TITLE
Move md5 from DDSI to DDSRT

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -52,6 +52,8 @@ include(ddsc/CMakeLists.txt)
 
 target_link_libraries(ddsc PRIVATE util)
 target_link_libraries(ddsc PRIVATE ddsrt)
+target_compile_definitions(
+  ddsc PUBLIC $<BUILD_INTERFACE:$<TARGET_PROPERTY:ddsrt,INTERFACE_COMPILE_DEFINITIONS>>)
 target_include_directories(
   ddsc PUBLIC $<BUILD_INTERFACE:$<TARGET_PROPERTY:ddsrt,INTERFACE_INCLUDE_DIRECTORIES>>)
 

--- a/src/core/ddsc/src/dds_key.c
+++ b/src/core/ddsc/src/dds_key.c
@@ -11,11 +11,12 @@
  */
 #include <assert.h>
 #include <string.h>
+
+#include "dds/ddsrt/md5.h"
 #include "dds__key.h"
 #include "dds__stream.h"
 #include "dds/ddsi/ddsi_serdata.h"
 #include "dds/ddsi/q_bswap.h"
-#include "dds/ddsi/q_md5.h"
 
 #ifndef NDEBUG
 static bool keyhash_is_reset(const dds_key_hash_t *kh)
@@ -112,14 +113,14 @@ void dds_key_gen (const dds_topic_descriptor_t * const desc, dds_key_hash_t * kh
   else
   {
     dds_stream_t os;
-    md5_state_t md5st;
+    ddsrt_md5_state_t md5st;
     kh->m_iskey = 0;
     dds_stream_init(&os, 64);
     os.m_endian = 0;
     dds_key_gen_stream (desc, &os, sample);
-    md5_init (&md5st);
-    md5_append (&md5st, os.m_buffer.p8, os.m_index);
-    md5_finish (&md5st, (unsigned char *) kh->m_hash);
+    ddsrt_md5_init (&md5st);
+    ddsrt_md5_append (&md5st, os.m_buffer.p8, os.m_index);
+    ddsrt_md5_finish (&md5st, (unsigned char *) kh->m_hash);
     dds_stream_fini (&os);
   }
 }

--- a/src/core/ddsc/src/dds_serdata_builtintopic.c
+++ b/src/core/ddsc/src/dds_serdata_builtintopic.c
@@ -15,7 +15,7 @@
 #include <string.h>
 
 #include "dds/ddsrt/heap.h"
-#include "dds/ddsi/q_md5.h"
+#include "dds/ddsrt/md5.h"
 #include "dds/ddsi/q_bswap.h"
 #include "dds/ddsi/q_config.h"
 #include "dds/ddsi/q_freelist.h"

--- a/src/core/ddsc/src/dds_sertopic_builtintopic.c
+++ b/src/core/ddsc/src/dds_sertopic_builtintopic.c
@@ -16,7 +16,7 @@
 
 #include "dds/dds.h"
 #include "dds/ddsrt/heap.h"
-#include "dds/ddsi/q_md5.h"
+#include "dds/ddsrt/md5.h"
 #include "dds/ddsi/q_bswap.h"
 #include "dds/ddsi/q_config.h"
 #include "dds/ddsi/q_freelist.h"

--- a/src/core/ddsc/src/dds_stream.c
+++ b/src/core/ddsc/src/dds_stream.c
@@ -11,18 +11,18 @@
  */
 #include <assert.h>
 #include <string.h>
+
+#include "dds/ddsrt/endian.h"
+#include "dds/ddsrt/md5.h"
 #include "dds/ddsi/q_bswap.h"
 #include "dds/ddsi/q_config.h"
 #include "dds__stream.h"
 #include "dds__key.h"
 #include "dds__alloc.h"
-#include "dds/ddsi/q_md5.h"
-#include "dds/ddsrt/endian.h"
 
 //#define OP_DEBUG_READ 1
 //#define OP_DEBUG_WRITE 1
 //#define OP_DEBUG_KEY 1
-
 
 #if defined OP_DEBUG_WRITE || defined OP_DEBUG_READ || defined OP_DEBUG_KEY
 static const char * stream_op_type[11] =
@@ -1612,14 +1612,14 @@ void dds_stream_read_keyhash
   else
   {
     dds_stream_t os;
-    md5_state_t md5st;
+    ddsrt_md5_state_t md5st;
     kh->m_iskey = 0;
     dds_stream_init (&os, 0);
     os.m_endian = 0;
     dds_stream_extract_key (is, &os, desc->m_ops, just_key);
-    md5_init (&md5st);
-    md5_append (&md5st, os.m_buffer.p8, os.m_index);
-    md5_finish (&md5st, (unsigned char *) kh->m_hash);
+    ddsrt_md5_init (&md5st);
+    ddsrt_md5_append (&md5st, os.m_buffer.p8, os.m_index);
+    ddsrt_md5_finish (&md5st, (unsigned char *) kh->m_hash);
     dds_stream_fini (&os);
   }
 }

--- a/src/core/ddsc/src/dds_write.c
+++ b/src/core/ddsc/src/dds_write.c
@@ -185,10 +185,10 @@ dds_return_t dds_write_impl (dds_writer *wr, const void * data, dds_time_t tstam
     if (!config.whc_batch)
       nn_xpack_send (wr->m_xp, false);
     ret = DDS_RETCODE_OK;
-  } else if (w_rc == ERR_TIMEOUT) {
+  } else if (w_rc == Q_ERR_TIMEOUT) {
     DDS_ERROR ("The writer could not deliver data on time, probably due to a reader resources being full\n");
     ret = DDS_ERRNO (DDS_RETCODE_TIMEOUT);
-  } else if (w_rc == ERR_INVALID_DATA) {
+  } else if (w_rc == Q_ERR_INVALID_DATA) {
     DDS_ERROR ("Invalid data provided\n");
     ret = DDS_ERRNO (DDS_RETCODE_ERROR);
   } else {
@@ -224,10 +224,10 @@ dds_return_t dds_writecdr_impl_lowlevel (struct writer *ddsi_wr, struct nn_xpack
     if (!config.whc_batch && xp != NULL)
       nn_xpack_send (xp, false);
     ret = DDS_RETCODE_OK;
-  } else if (w_rc == ERR_TIMEOUT) {
+  } else if (w_rc == Q_ERR_TIMEOUT) {
     DDS_ERROR ("The writer could not deliver data on time, probably due to a reader resources being full\n");
     ret = DDS_ERRNO(DDS_RETCODE_TIMEOUT);
-  } else if (w_rc == ERR_INVALID_DATA) {
+  } else if (w_rc == Q_ERR_INVALID_DATA) {
     DDS_ERROR ("Invalid data provided\n");
     ret = DDS_ERRNO (DDS_RETCODE_ERROR);
   } else {

--- a/src/core/ddsi/CMakeLists.txt
+++ b/src/core/ddsi/CMakeLists.txt
@@ -39,7 +39,6 @@ PREPEND(srcs_ddsi "${CMAKE_CURRENT_LIST_DIR}/src"
     q_init.c
     q_lat_estim.c
     q_lease.c
-    q_md5.c
     q_misc.c
     q_nwif.c
     q_pcap.c
@@ -97,7 +96,6 @@ PREPEND(hdrs_private_ddsi "${CMAKE_CURRENT_LIST_DIR}/include/dds/ddsi"
     q_lat_estim.h
     q_lease.h
     q_log.h
-    q_md5.h
     q_misc.h
     q_nwif.h
     q_pcap.h

--- a/src/core/ddsi/include/dds/ddsi/ddsi_tran.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_tran.h
@@ -26,6 +26,12 @@
 
 #define DDSI_TRAN_ON_CONNECT 0x0001
 
+#if DDSRT_HAVE_IPV6 == 1
+# define DDSI_LOCATORSTRLEN INET6_ADDRSTRLEN_EXTENDED
+#else
+# define DDSI_LOCATORSTRLEN INET_ADDRSTRLEN_EXTENDED
+#endif
+
 /* Core types */
 
 typedef struct ddsi_tran_base * ddsi_tran_base_t;

--- a/src/core/ddsi/include/dds/ddsi/q_bitset.h
+++ b/src/core/ddsi/include/dds/ddsi/q_bitset.h
@@ -13,41 +13,42 @@
 #define NN_BITSET_H
 
 #include <assert.h>
+#include <stdint.h>
 #include <string.h>
 
 #include "dds/ddsi/q_unused.h"
 
-inline int nn_bitset_isset (unsigned numbits, const unsigned *bits, unsigned idx)
+inline int nn_bitset_isset (uint32_t numbits, const uint32_t *bits, uint32_t idx)
 {
-  return idx < numbits && (bits[idx/32] & (1u << (31 - (idx%32))));
+  return idx < numbits && (bits[idx/32] & (UINT32_C(1) << (31 - (idx%32))));
 }
 
-inline void nn_bitset_set (UNUSED_ARG_NDEBUG (unsigned numbits), unsigned *bits, unsigned idx)
-{
-  assert (idx < numbits);
-  bits[idx/32] |= 1u << (31 - (idx%32));
-}
-
-inline void nn_bitset_clear (UNUSED_ARG_NDEBUG (unsigned numbits), unsigned *bits, unsigned idx)
+inline void nn_bitset_set (UNUSED_ARG_NDEBUG (uint32_t numbits), uint32_t *bits, uint32_t idx)
 {
   assert (idx < numbits);
-  bits[idx/32] &= ~(1u << (31 - (idx%32)));
+  bits[idx/32] |= UINT32_C(1) << (31 - (idx%32));
 }
 
-inline void nn_bitset_zero (unsigned numbits, unsigned *bits)
+inline void nn_bitset_clear (UNUSED_ARG_NDEBUG (uint32_t numbits), uint32_t *bits, uint32_t idx)
+{
+  assert (idx < numbits);
+  bits[idx/32] &= ~(UINT32_C(1) << (31 - (idx%32)));
+}
+
+inline void nn_bitset_zero (uint32_t numbits, uint32_t *bits)
 {
   memset (bits, 0, 4 * ((numbits + 31) / 32));
 }
 
-inline void nn_bitset_one (unsigned numbits, unsigned *bits)
+inline void nn_bitset_one (uint32_t numbits, uint32_t *bits)
 {
   memset (bits, 0xff, 4 * ((numbits + 31) / 32));
 
   /* clear bits "accidentally" set */
   {
-    const unsigned k = numbits / 32;
-    const unsigned n = numbits % 32;
-    bits[k] &= ~(~0u >> n);
+    const uint32_t k = numbits / 32;
+    const uint32_t n = numbits % 32;
+    bits[k] &= ~(~UINT32_C(0) >> n);
   }
 }
 

--- a/src/core/ddsi/include/dds/ddsi/q_error.h
+++ b/src/core/ddsi/include/dds/ddsi/q_error.h
@@ -12,16 +12,16 @@
 #ifndef NN_ERROR_H
 #define NN_ERROR_H
 
-#define ERR_UNSPECIFIED         -1
-#define ERR_INVALID             -2
-#define ERR_OUT_OF_MEMORY       -3
-#define ERR_ENTITY_EXISTS       -4
-#define ERR_UNKNOWN_ENTITY      -5
-#define ERR_OUT_OF_IDS          -6
-#define ERR_INVALID_DATA        -7
-#define ERR_BUSY                -8
-#define ERR_NO_ADDRESS          -9
-#define ERR_TIMEOUT             -10
-#define ERR_INCOMPATIBLE        -11
+#define Q_ERR_UNSPECIFIED       -1
+#define Q_ERR_INVALID           -2
+#define Q_ERR_OUT_OF_MEMORY     -3
+#define Q_ERR_ENTITY_EXISTS     -4
+#define Q_ERR_UNKNOWN_ENTITY    -5
+#define Q_ERR_OUT_OF_IDS        -6
+#define Q_ERR_INVALID_DATA      -7
+#define Q_ERR_BUSY              -8
+#define Q_ERR_NO_ADDRESS        -9
+#define Q_ERR_TIMEOUT           -10
+#define Q_ERR_INCOMPATIBLE      -11
 
 #endif /* NN_ERROR_H */

--- a/src/core/ddsi/include/dds/ddsi/q_time.h
+++ b/src/core/ddsi/include/dds/ddsi/q_time.h
@@ -53,9 +53,9 @@ int valid_ddsi_timestamp (nn_ddsi_time_t t);
 DDS_EXPORT nn_wctime_t now (void);       /* wall clock time */
 DDS_EXPORT nn_mtime_t now_mt (void);     /* monotonic time */
 DDS_EXPORT nn_etime_t now_et (void);     /* elapsed time */
-DDS_EXPORT void mtime_to_sec_usec (int * __restrict sec, int * __restrict usec, nn_mtime_t t);
-DDS_EXPORT void wctime_to_sec_usec (int * __restrict sec, int * __restrict usec, nn_wctime_t t);
-DDS_EXPORT void etime_to_sec_usec (int * __restrict sec, int * __restrict usec, nn_etime_t t);
+DDS_EXPORT void mtime_to_sec_usec (int32_t * __restrict sec, int32_t * __restrict usec, nn_mtime_t t);
+DDS_EXPORT void wctime_to_sec_usec (int32_t * __restrict sec, int32_t * __restrict usec, nn_wctime_t t);
+DDS_EXPORT void etime_to_sec_usec (int32_t * __restrict sec, int32_t * __restrict usec, nn_etime_t t);
 DDS_EXPORT nn_mtime_t mtime_round_up (nn_mtime_t t, int64_t round);
 DDS_EXPORT nn_mtime_t add_duration_to_mtime (nn_mtime_t t, int64_t d);
 DDS_EXPORT nn_wctime_t add_duration_to_wctime (nn_wctime_t t, int64_t d);

--- a/src/core/ddsi/src/ddsi_ipaddr.c
+++ b/src/core/ddsi/src/ddsi_ipaddr.c
@@ -131,7 +131,7 @@ char *ddsi_ipaddr_to_string (ddsi_tran_factory_t tran, char *dst, size_t sizeof_
       if (with_port) {
         pos = strlen (dst);
         assert(pos <= sizeof_dst);
-        snprintf (dst + pos, sizeof_dst - pos, ":%d", loc->port);
+        snprintf (dst + pos, sizeof_dst - pos, ":%"PRIu32, loc->port);
       }
       break;
 #if DDSRT_HAVE_IPV6
@@ -141,7 +141,7 @@ char *ddsi_ipaddr_to_string (ddsi_tran_factory_t tran, char *dst, size_t sizeof_
       pos = strlen (dst);
       if (with_port) {
         assert(pos <= sizeof_dst);
-        snprintf (dst + pos, sizeof_dst - pos, "]:%u", loc->port);
+        snprintf (dst + pos, sizeof_dst - pos, "]:%"PRIu32, loc->port);
       } else {
         snprintf (dst + pos, sizeof_dst - pos, "]");
       }

--- a/src/core/ddsi/src/ddsi_serdata.c
+++ b/src/core/ddsi/src/ddsi_serdata.c
@@ -14,7 +14,7 @@
 #include <assert.h>
 #include <string.h>
 
-#include "dds/ddsi/q_md5.h"
+#include "dds/ddsrt/md5.h"
 #include "dds/ddsi/q_bswap.h"
 #include "dds/ddsi/q_config.h"
 #include "dds/ddsi/q_freelist.h"

--- a/src/core/ddsi/src/ddsi_serdata_default.c
+++ b/src/core/ddsi/src/ddsi_serdata_default.c
@@ -16,7 +16,7 @@
 
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/log.h"
-#include "dds/ddsi/q_md5.h"
+#include "dds/ddsrt/md5.h"
 #include "dds/ddsi/q_bswap.h"
 #include "dds/ddsi/q_config.h"
 #include "dds/ddsi/q_freelist.h"
@@ -377,16 +377,16 @@ static struct ddsi_serdata *serdata_default_from_sample_plist (const struct ddsi
       const char *topic_name = (const char *) (rawkey + sizeof(uint32_t));
       uint32_t topic_name_sz;
       uint32_t topic_name_sz_BE;
-      md5_state_t md5st;
-      md5_byte_t digest[16];
+      ddsrt_md5_state_t md5st;
+      ddsrt_md5_byte_t digest[16];
       topic_name_sz = (uint32_t) strlen (topic_name) + 1;
       topic_name_sz_BE = toBE4u (topic_name_sz);
       d->keyhash.m_set = 1;
       d->keyhash.m_iskey = 0;
-      md5_init (&md5st);
-      md5_append (&md5st, (const md5_byte_t *) &topic_name_sz_BE, sizeof (topic_name_sz_BE));
-      md5_append (&md5st, (const md5_byte_t *) topic_name, topic_name_sz);
-      md5_finish (&md5st, digest);
+      ddsrt_md5_init (&md5st);
+      ddsrt_md5_append (&md5st, (const ddsrt_md5_byte_t *) &topic_name_sz_BE, sizeof (topic_name_sz_BE));
+      ddsrt_md5_append (&md5st, (const ddsrt_md5_byte_t *) topic_name, topic_name_sz);
+      ddsrt_md5_finish (&md5st, digest);
       memcpy (d->keyhash.m_hash, digest, 16);
 #ifndef NDEBUG
       keysize = sizeof (uint32_t) + topic_name_sz;

--- a/src/core/ddsi/src/ddsi_sertopic.c
+++ b/src/core/ddsi/src/ddsi_sertopic.c
@@ -15,13 +15,12 @@
 #include <string.h>
 
 #include "dds/ddsrt/heap.h"
-#include "dds/ddsi/q_md5.h"
+#include "dds/ddsrt/md5.h"
 #include "dds/ddsi/q_bswap.h"
 #include "dds/ddsi/q_config.h"
 #include "dds/ddsi/q_freelist.h"
 #include "dds/ddsi/ddsi_sertopic.h"
 #include "dds/ddsi/ddsi_serdata.h"
-#include "dds/ddsi/q_md5.h"
 
 struct ddsi_sertopic *ddsi_sertopic_ref (const struct ddsi_sertopic *sertopic_const)
 {
@@ -48,13 +47,13 @@ void ddsi_sertopic_unref (struct ddsi_sertopic *sertopic)
 
 uint32_t ddsi_sertopic_compute_serdata_basehash (const struct ddsi_serdata_ops *ops)
 {
-  md5_state_t md5st;
-  md5_byte_t digest[16];
+  ddsrt_md5_state_t md5st;
+  ddsrt_md5_byte_t digest[16];
   uint32_t res;
-  md5_init (&md5st);
-  md5_append (&md5st, (const md5_byte_t *) &ops, sizeof (ops));
-  md5_append (&md5st, (const md5_byte_t *) ops, sizeof (*ops));
-  md5_finish (&md5st, digest);
+  ddsrt_md5_init (&md5st);
+  ddsrt_md5_append (&md5st, (const ddsrt_md5_byte_t *) &ops, sizeof (ops));
+  ddsrt_md5_append (&md5st, (const ddsrt_md5_byte_t *) ops, sizeof (*ops));
+  ddsrt_md5_finish (&md5st, digest);
   memcpy (&res, digest, sizeof (res));
   return res;
 }

--- a/src/core/ddsi/src/ddsi_sertopic_default.c
+++ b/src/core/ddsi/src/ddsi_sertopic_default.c
@@ -14,7 +14,7 @@
 #include <assert.h>
 #include <string.h>
 
-#include "dds/ddsi/q_md5.h"
+#include "dds/ddsrt/md5.h"
 #include "dds/ddsi/q_bswap.h"
 #include "dds/ddsi/q_config.h"
 #include "dds/ddsi/q_freelist.h"

--- a/src/core/ddsi/src/ddsi_tcp.c
+++ b/src/core/ddsi/src/ddsi_tcp.c
@@ -390,7 +390,7 @@ static ssize_t ddsi_tcp_conn_read (ddsi_tran_conn_t conn, unsigned char * buf, s
 {
   dds_retcode_t rc;
   ddsi_tcp_conn_t tcp = (ddsi_tcp_conn_t) conn;
-  ssize_t (*rd) (ddsi_tcp_conn_t, void *, size_t, int * err) = ddsi_tcp_conn_read_plain;
+  ssize_t (*rd) (ddsi_tcp_conn_t, void *, size_t, dds_retcode_t * err) = ddsi_tcp_conn_read_plain;
   size_t pos = 0;
   ssize_t n;
 
@@ -467,7 +467,7 @@ static ssize_t ddsi_tcp_conn_write_ssl (ddsi_tcp_conn_t conn, const void * buf, 
 
 static ssize_t ddsi_tcp_block_write
 (
-  ssize_t (*wr) (ddsi_tcp_conn_t, const void *, size_t, int *),
+  ssize_t (*wr) (ddsi_tcp_conn_t, const void *, size_t, dds_retcode_t *),
   ddsi_tcp_conn_t conn,
   const void * buf,
   size_t sz
@@ -654,7 +654,7 @@ static ssize_t ddsi_tcp_conn_write (ddsi_tran_conn_t base, const nn_locator_t *d
 
   if (piecewise)
   {
-    ssize_t (*wr) (ddsi_tcp_conn_t, const void *, size_t, int *) = ddsi_tcp_conn_write_plain;
+    ssize_t (*wr) (ddsi_tcp_conn_t, const void *, size_t, dds_retcode_t *) = ddsi_tcp_conn_write_plain;
     int i = 0;
 #ifdef DDSI_INCLUDE_SSL
     if (ddsi_tcp_ssl_plugin.write)

--- a/src/core/ddsi/src/ddsi_udp.c
+++ b/src/core/ddsi/src/ddsi_udp.c
@@ -490,7 +490,7 @@ static char *ddsi_udp_locator_to_string (ddsi_tran_factory_t tran, char *dst, si
       pos += (size_t)cnt;
     }
     if (with_port && pos < sizeof_dst) {
-      snprintf (dst + pos, sizeof_dst - pos, ":%d", loc->port);
+      snprintf (dst + pos, sizeof_dst - pos, ":%"PRIu32, loc->port);
     }
     return dst;
   }

--- a/src/core/ddsi/src/q_bitset_inlines.c
+++ b/src/core/ddsi/src/q_bitset_inlines.c
@@ -11,9 +11,9 @@
  */
 #include "dds/ddsi/q_bitset.h"
 
-extern inline int nn_bitset_isset (unsigned numbits, const unsigned *bits, unsigned idx);
-extern inline void nn_bitset_set (unsigned numbits, unsigned *bits, unsigned idx);
-extern inline void nn_bitset_clear (unsigned numbits, unsigned *bits, unsigned idx);
-extern inline void nn_bitset_zero (unsigned numbits, unsigned *bits);
-extern inline void nn_bitset_one (unsigned numbits, unsigned *bits);
+extern inline int nn_bitset_isset (uint32_t numbits, const uint32_t *bits, uint32_t idx);
+extern inline void nn_bitset_set (uint32_t numbits, uint32_t *bits, uint32_t idx);
+extern inline void nn_bitset_clear (uint32_t numbits, uint32_t *bits, uint32_t idx);
+extern inline void nn_bitset_zero (uint32_t numbits, uint32_t *bits);
+extern inline void nn_bitset_one (uint32_t numbits, uint32_t *bits);
 

--- a/src/core/ddsi/src/q_config.c
+++ b/src/core/ddsi/src/q_config.c
@@ -116,7 +116,7 @@ static const uint32_t xcheck_codes[] = {
 
 /* We want the tracing/verbosity settings to be fixed while parsing
 the configuration, so we update this variable instead. */
-static unsigned enabled_logcats;
+static uint32_t enabled_logcats;
 
 static int cfgst_node_cmp(const void *va, const void *vb);
 static const ut_avlTreedef_t cfgst_found_treedef =
@@ -1827,7 +1827,7 @@ static int uf_maybe_int32(struct cfgst *cfgst, void *parent, struct cfgelem cons
         elem->isdefault = 1;
         elem->value = 0;
         return 1;
-    } else if ( sscanf(value, "%d%n", &elem->value, &pos) == 1 && value[pos] == 0 ) {
+    } else if ( sscanf(value, "%"PRId32"%n", &elem->value, &pos) == 1 && value[pos] == 0 ) {
         elem->isdefault = 0;
         return 1;
     } else {
@@ -1971,7 +1971,7 @@ static int uf_domainId(struct cfgst *cfgst, void *parent, struct cfgelem const *
     elem->isdefault = 1;
     elem->value = 0;
     return 1;
-  } else if (sscanf(value, "%d%n", &elem->value, &pos) == 1 && value[pos] == 0 && elem->value >= 0 && elem->value <= 230) {
+  } else if (sscanf(value, "%"PRId32"%n", &elem->value, &pos) == 1 && value[pos] == 0 && elem->value >= 0 && elem->value <= 230) {
     elem->isdefault = 0;
     return 1;
   } else {

--- a/src/core/ddsi/src/q_ddsi_discovery.c
+++ b/src/core/ddsi/src/q_ddsi_discovery.c
@@ -799,7 +799,7 @@ static void handle_SPDP (const struct receiver_state *rst, nn_wctime_t timestamp
     src.bufsz = len - 4;
     if ((plist_ret = nn_plist_init_frommsg (&decoded_data, NULL, ~(uint64_t)0, ~(uint64_t)0, &src)) < 0)
     {
-      if (plist_ret != ERR_INCOMPATIBLE)
+      if (plist_ret != Q_ERR_INCOMPATIBLE)
         DDS_WARNING("SPDP (vendor %u.%u): invalid qos/parameters\n", src.vendorid.id[0], src.vendorid.id[1]);
       return;
     }
@@ -1341,7 +1341,7 @@ static void handle_SEDP (const struct receiver_state *rst, nn_wctime_t timestamp
     src.bufsz = len - 4;
     if ((plist_ret = nn_plist_init_frommsg (&decoded_data, NULL, ~(uint64_t)0, ~(uint64_t)0, &src)) < 0)
     {
-      if (plist_ret != ERR_INCOMPATIBLE)
+      if (plist_ret != Q_ERR_INCOMPATIBLE)
         DDS_WARNING("SEDP (vendor %u.%u): invalid qos/parameters\n", src.vendorid.id[0], src.vendorid.id[1]);
       return;
     }
@@ -1469,7 +1469,7 @@ static void handle_SEDP_CM (const struct receiver_state *rst, nn_entityid_t wr_e
     src.bufsz = len - 4;
     if ((plist_ret = nn_plist_init_frommsg (&decoded_data, NULL, ~(uint64_t)0, ~(uint64_t)0, &src)) < 0)
     {
-      if (plist_ret != ERR_INCOMPATIBLE)
+      if (plist_ret != Q_ERR_INCOMPATIBLE)
         DDS_WARNING("SEDP_CM (vendor %u.%u): invalid qos/parameters\n", src.vendorid.id[0], src.vendorid.id[1]);
       return;
     }
@@ -1631,7 +1631,7 @@ static void handle_SEDP_GROUP (const struct receiver_state *rst, nn_wctime_t tim
     src.bufsz = len - 4;
     if ((plist_ret = nn_plist_init_frommsg (&decoded_data, NULL, ~(uint64_t)0, ~(uint64_t)0, &src)) < 0)
     {
-      if (plist_ret != ERR_INCOMPATIBLE)
+      if (plist_ret != Q_ERR_INCOMPATIBLE)
         DDS_WARNING("SEDP_GROUP (vendor %u.%u): invalid qos/parameters\n", src.vendorid.id[0], src.vendorid.id[1]);
       return;
     }
@@ -1754,7 +1754,7 @@ int builtins_dqueue_handler (const struct nn_rsample_info *sampleinfo, const str
     src.bufsz = NN_RDATA_PAYLOAD_OFF (fragchain) - qos_offset;
     if ((plist_ret = nn_plist_init_frommsg (&qos, NULL, PP_STATUSINFO | PP_KEYHASH, 0, &src)) < 0)
     {
-      if (plist_ret != ERR_INCOMPATIBLE)
+      if (plist_ret != Q_ERR_INCOMPATIBLE)
         DDS_WARNING("data(builtin, vendor %u.%u): %x:%x:%x:%x #%"PRId64": invalid inline qos\n",
                     src.vendorid.id[0], src.vendorid.id[1], PGUID (srcguid), sampleinfo->seq);
       goto done_upd_deliv;

--- a/src/core/ddsi/src/q_ddsi_discovery.c
+++ b/src/core/ddsi/src/q_ddsi_discovery.c
@@ -18,6 +18,7 @@
 #include "dds/version.h"
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/log.h"
+#include "dds/ddsrt/md5.h"
 #include "dds/ddsrt/sync.h"
 #include "dds/util/ut_avl.h"
 #include "dds/ddsi/q_protocol.h"
@@ -30,6 +31,7 @@
 #include "dds/ddsi/q_xevent.h"
 #include "dds/ddsi/q_addrset.h"
 #include "dds/ddsi/q_ddsi_discovery.h"
+
 #include "dds/ddsi/q_radmin.h"
 #include "dds/ddsi/q_ephash.h"
 #include "dds/ddsi/q_entity.h"
@@ -40,7 +42,6 @@
 #include "dds/ddsi/q_lease.h"
 #include "dds/ddsi/q_error.h"
 #include "dds/ddsi/ddsi_serdata_default.h"
-#include "dds/ddsi/q_md5.h"
 #include "dds/ddsi/q_feature_check.h"
 
 static int get_locator (nn_locator_t *loc, const nn_locators_t *locs, int uc_same_subnet)

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -13,6 +13,7 @@
 #include <stddef.h>
 
 #include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/md5.h"
 #include "dds/ddsrt/process.h"
 #include "dds/ddsrt/time.h"
 #include "dds/ddsrt/string.h"
@@ -21,7 +22,6 @@
 #include "dds/util/ut_avl.h"
 #include "dds/util/ut_thread_pool.h"
 
-#include "dds/ddsi/q_md5.h"
 #include "dds/ddsi/q_protocol.h"
 #include "dds/ddsi/q_rtps.h"
 #include "dds/ddsi/q_misc.h"

--- a/src/core/ddsi/src/q_lease.c
+++ b/src/core/ddsi/src/q_lease.c
@@ -164,14 +164,14 @@ void lease_renew (struct lease *l, nn_etime_t tnowE)
 
   if (did_update && (dds_get_log_mask() & DDS_LC_TRACE))
   {
-    int tsec, tusec;
+    int32_t tsec, tusec;
     DDS_TRACE(" L(");
     if (l->entity->guid.entityid.u == NN_ENTITYID_PARTICIPANT)
       DDS_TRACE(":%x", l->entity->guid.entityid.u);
     else
       DDS_TRACE("%x:%x:%x:%x", PGUID (l->entity->guid));
     etime_to_sec_usec (&tsec, &tusec, tend_new);
-    DDS_TRACE(" %d.%06d)", tsec, tusec);
+    DDS_TRACE(" %"PRId32".%06"PRId32")", tsec, tusec);
   }
 }
 

--- a/src/core/ddsi/src/q_misc.c
+++ b/src/core/ddsi/src/q_misc.c
@@ -12,8 +12,9 @@
 #include <string.h>
 
 #include "dds/ddsi/q_misc.h"
+
+#include "dds/ddsrt/md5.h"
 #include "dds/ddsi/q_bswap.h"
-#include "dds/ddsi/q_md5.h"
 
 extern inline seqno_t fromSN (const nn_sequence_number_t sn);
 extern inline nn_sequence_number_t toSN (seqno_t n);

--- a/src/core/ddsi/src/q_nwif.c
+++ b/src/core/ddsi/src/q_nwif.c
@@ -39,7 +39,7 @@ static void print_sockerror (const char *msg)
 
 unsigned locator_to_hopefully_unique_uint32 (const nn_locator_t *src)
 {
-  unsigned id;
+  unsigned id = 0;
   if (src->kind == NN_LOCATOR_KIND_UDPv4 || src->kind == NN_LOCATOR_KIND_TCPv4)
     memcpy (&id, src->address + 12, sizeof (id));
   else
@@ -93,7 +93,7 @@ static void set_socket_nodelay (ddsrt_socket_t sock)
 static int set_rcvbuf (ddsrt_socket_t socket)
 {
   uint32_t ReceiveBufferSize;
-  uint32_t optlen = (uint32_t) sizeof (ReceiveBufferSize);
+  socklen_t optlen = (socklen_t) sizeof (ReceiveBufferSize);
   uint32_t socket_min_rcvbuf_size;
   if (config.socket_min_rcvbuf_size.isdefault)
     socket_min_rcvbuf_size = 1048576;
@@ -137,7 +137,7 @@ static int set_rcvbuf (ddsrt_socket_t socket)
 static int set_sndbuf (ddsrt_socket_t socket)
 {
   unsigned SendBufferSize;
-  uint32_t optlen = (uint32_t) sizeof(SendBufferSize);
+  socklen_t optlen = (socklen_t) sizeof(SendBufferSize);
   if (ddsrt_getsockopt(socket, SOL_SOCKET, SO_SNDBUF,(char *)&SendBufferSize, &optlen) != DDS_RETCODE_OK)
   {
     print_sockerror ("get SO_SNDBUF");

--- a/src/core/ddsi/src/q_nwif.c
+++ b/src/core/ddsi/src/q_nwif.c
@@ -17,15 +17,16 @@
 
 #include "dds/ddsrt/ifaddrs.h"
 #include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/md5.h"
 #include "dds/ddsrt/string.h"
 #include "dds/ddsrt/sockets.h"
 
 #include "dds/ddsi/q_log.h"
 #include "dds/ddsi/q_nwif.h"
+
 #include "dds/ddsi/q_globals.h"
 #include "dds/ddsi/q_config.h"
 #include "dds/ddsi/q_unused.h"
-#include "dds/ddsi/q_md5.h"
 #include "dds/ddsi/q_misc.h"
 #include "dds/ddsi/q_addrset.h" /* unspec locator */
 #include "dds/ddsi/q_feature_check.h"
@@ -45,11 +46,11 @@ unsigned locator_to_hopefully_unique_uint32 (const nn_locator_t *src)
   else
   {
 #if DDSRT_HAVE_IPV6
-    md5_state_t st;
-    md5_byte_t digest[16];
-    md5_init (&st);
-    md5_append (&st, (const md5_byte_t *) ((const struct sockaddr_in6 *) src)->sin6_addr.s6_addr, 16);
-    md5_finish (&st, digest);
+    ddsrt_md5_state_t st;
+    ddsrt_md5_byte_t digest[16];
+    ddsrt_md5_init (&st);
+    ddsrt_md5_append (&st, (const ddsrt_md5_byte_t *) ((const struct sockaddr_in6 *) src)->sin6_addr.s6_addr, 16);
+    ddsrt_md5_finish (&st, digest);
     memcpy (&id, digest, sizeof (id));
 #else
     DDS_FATAL("IPv6 unavailable\n");

--- a/src/core/ddsi/src/q_plist.c
+++ b/src/core/ddsi/src/q_plist.c
@@ -92,18 +92,18 @@ static int validate_string (const struct dd *dd, size_t *len)
   if (dd->bufsz < sizeof (struct cdrstring))
   {
     DDS_TRACE("plist/validate_string: buffer too small (header)\n");
-    return ERR_INVALID;
+    return Q_ERR_INVALID;
   }
   *len = dd->bswap ? bswap4u (x->length) : x->length;
   if (*len < 1 || *len > dd->bufsz - offsetof (struct cdrstring, contents))
   {
     DDS_TRACE("plist/validate_string: length %" PRIuSIZE " out of range\n", *len);
-    return ERR_INVALID;
+    return Q_ERR_INVALID;
   }
   if (x->contents[*len-1] != 0)
   {
     DDS_TRACE("plist/validate_string: terminator missing\n");
-    return ERR_INVALID;
+    return Q_ERR_INVALID;
   }
   return 0;
 }
@@ -142,10 +142,10 @@ static int validate_octetseq (const struct dd *dd, size_t *len)
 {
   const struct cdroctetseq *x = (const struct cdroctetseq *) dd->buf;
   if (dd->bufsz < offsetof (struct cdroctetseq, value))
-    return ERR_INVALID;
+    return Q_ERR_INVALID;
   *len = dd->bswap ? bswap4u (x->len) : x->len;
   if (*len > dd->bufsz - offsetof (struct cdroctetseq, value))
-    return ERR_INVALID;
+    return Q_ERR_INVALID;
   return 0;
 }
 
@@ -193,7 +193,7 @@ static int validate_stringseq (const struct dd *dd)
   if (dd->bufsz < sizeof (int))
   {
     DDS_TRACE("plist/validate_stringseq: buffer too small (header)\n");
-    return ERR_INVALID;
+    return Q_ERR_INVALID;
   }
   memcpy (&n, seq, sizeof (n));
   if (dd->bswap)
@@ -202,7 +202,7 @@ static int validate_stringseq (const struct dd *dd)
   if (n < 0)
   {
     DDS_TRACE("plist/validate_stringseq: length %d out of range\n", n);
-    return ERR_INVALID;
+    return Q_ERR_INVALID;
   }
   else if (n == 0)
   {
@@ -226,7 +226,7 @@ static int validate_stringseq (const struct dd *dd)
     if (i < n)
     {
       DDS_TRACE("plist/validate_stringseq: buffer too small (contents)\n");
-      return ERR_INVALID;
+      return Q_ERR_INVALID;
     }
   }
   /* Should I worry about junk between the last string & the end of
@@ -248,7 +248,7 @@ static int alias_stringseq (nn_stringseq_t *strseq, const struct dd *dd)
   if (dd->bufsz < sizeof (int))
   {
     DDS_TRACE("plist/alias_stringseq: buffer too small (header)\n");
-    return ERR_INVALID;
+    return Q_ERR_INVALID;
   }
   memcpy (&strseq->n, seq, sizeof (strseq->n));
   if (dd->bswap)
@@ -257,7 +257,7 @@ static int alias_stringseq (nn_stringseq_t *strseq, const struct dd *dd)
   if (strseq->n >= UINT_MAX / sizeof(*strs))
   {
     DDS_TRACE("plist/alias_stringseq: length %u out of range\n", strseq->n);
-    return ERR_INVALID;
+    return Q_ERR_INVALID;
   }
   else if (strseq->n == 0)
   {
@@ -284,7 +284,7 @@ static int alias_stringseq (nn_stringseq_t *strseq, const struct dd *dd)
     if (i != strseq->n)
     {
       DDS_TRACE("plist/validate_stringseq: buffer too small (contents)\n");
-      result = ERR_INVALID;
+      result = Q_ERR_INVALID;
       goto fail;
     }
     strseq->strs = strs;
@@ -535,7 +535,7 @@ static int validate_time (const nn_ddsi_time_t *t)
   else
   {
     DDS_TRACE("plist/validate_time: invalid timestamp (%08x.%08x)\n", t->seconds, t->fraction);
-    return ERR_INVALID;
+    return Q_ERR_INVALID;
   }
 }
 
@@ -555,7 +555,7 @@ static int do_duration (nn_duration_t *q, uint64_t *present, uint64_t fl, const 
   if (dd->bufsz < sizeof (*q))
   {
     DDS_TRACE("plist/do_duration: buffer too small\n");
-    return ERR_INVALID;
+    return Q_ERR_INVALID;
   }
   memcpy (q, dd->buf, sizeof (*q));
   if (dd->bswap)
@@ -582,7 +582,7 @@ int validate_durability_qospolicy (const nn_durability_qospolicy_t *q)
       break;
     default:
       DDS_TRACE("plist/validate_durability_qospolicy: invalid kind (%d)\n", (int) q->kind);
-      return ERR_INVALID;
+      return Q_ERR_INVALID;
   }
   return 0;
 }
@@ -614,7 +614,7 @@ int validate_history_qospolicy (const nn_history_qospolicy_t *q)
       break;
     default:
       DDS_TRACE("plist/validate_history_qospolicy: invalid kind (%d)\n", (int) q->kind);
-      return ERR_INVALID;
+      return Q_ERR_INVALID;
   }
   /* Accept all values for depth if kind = ALL */
   if (q->kind == NN_KEEP_LAST_HISTORY_QOS)
@@ -622,7 +622,7 @@ int validate_history_qospolicy (const nn_history_qospolicy_t *q)
     if (q->depth < 1)
     {
       DDS_TRACE("plist/validate_history_qospolicy: invalid depth (%d)\n", (int) q->depth);
-      return ERR_INVALID;
+      return Q_ERR_INVALID;
     }
   }
   return 0;
@@ -649,17 +649,17 @@ int validate_resource_limits_qospolicy (const nn_resource_limits_qospolicy_t *q)
   if (q->max_samples < 1 && q->max_samples != unlimited)
   {
     DDS_TRACE("plist/validate_resource_limits_qospolicy: max_samples invalid (%d)\n", (int) q->max_samples);
-    return ERR_INVALID;
+    return Q_ERR_INVALID;
   }
   if (q->max_instances < 1 && q->max_instances != unlimited)
   {
     DDS_TRACE("plist/validate_resource_limits_qospolicy: max_instances invalid (%d)\n", (int) q->max_instances);
-    return ERR_INVALID;
+    return Q_ERR_INVALID;
   }
   if (q->max_samples_per_instance < 1 && q->max_samples_per_instance != unlimited)
   {
     DDS_TRACE("plist/validate_resource_limits_qospolicy: max_samples_per_instance invalid (%d)\n", (int) q->max_samples_per_instance);
-    return ERR_INVALID;
+    return Q_ERR_INVALID;
   }
   if (q->max_samples != unlimited && q->max_samples_per_instance != unlimited)
   {
@@ -668,7 +668,7 @@ int validate_resource_limits_qospolicy (const nn_resource_limits_qospolicy_t *q)
     if (q->max_samples < q->max_samples_per_instance)
     {
       DDS_TRACE("plist/validate_resource_limits_qospolicy: max_samples (%d) and max_samples_per_instance (%d) incompatible\n", (int) q->max_samples, (int) q->max_samples_per_instance);
-      return ERR_INVALID;
+      return Q_ERR_INVALID;
     }
   }
   return 0;
@@ -695,7 +695,7 @@ int validate_history_and_resource_limits (const nn_history_qospolicy_t *qh, cons
       if (qr->max_samples_per_instance != unlimited)
       {
         DDS_TRACE("plist/validate_history_and_resource_limits: max_samples_per_instance (%d) incompatible with KEEP_ALL policy\n", (int) qr->max_samples_per_instance);
-        return ERR_INVALID;
+        return Q_ERR_INVALID;
       }
 #endif
       break;
@@ -703,7 +703,7 @@ int validate_history_and_resource_limits (const nn_history_qospolicy_t *qh, cons
       if (qr->max_samples_per_instance != unlimited && qh->depth > qr->max_samples_per_instance)
       {
         DDS_TRACE("plist/validate_history_and_resource_limits: depth (%d) and max_samples_per_instance (%d) incompatible with KEEP_LAST policy\n", (int) qh->depth, (int) qr->max_samples_per_instance);
-        return ERR_INVALID;
+        return Q_ERR_INVALID;
       }
       break;
   }
@@ -766,7 +766,7 @@ int validate_liveliness_qospolicy (const nn_liveliness_qospolicy_t *q)
       return res;
     default:
       DDS_TRACE("plist/validate_liveliness_qospolicy: invalid kind (%d)\n", (int) q->kind);
-      return ERR_INVALID;
+      return Q_ERR_INVALID;
   }
 }
 
@@ -794,7 +794,7 @@ static int validate_xform_reliability_qospolicy (nn_reliability_qospolicy_t *qds
         return res;
       default:
         DDS_TRACE("plist/validate_xform_reliability_qospolicy[pedantic]: invalid kind (%d)\n", (int) qext->kind);
-        return ERR_INVALID;
+        return Q_ERR_INVALID;
     }
   }
   else
@@ -811,7 +811,7 @@ static int validate_xform_reliability_qospolicy (nn_reliability_qospolicy_t *qds
         return res;
       default:
         DDS_TRACE("plist/validate_xform_reliability_qospolicy[!pedantic]: invalid kind (%d)\n", (int) qext->kind);
-        return ERR_INVALID;
+        return Q_ERR_INVALID;
     }
   }
 }
@@ -830,7 +830,7 @@ int validate_destination_order_qospolicy (const nn_destination_order_qospolicy_t
       return 0;
     default:
       DDS_TRACE("plist/validate_destination_order_qospolicy: invalid kind (%d)\n", (int) q->kind);
-      return ERR_INVALID;
+      return Q_ERR_INVALID;
   }
 }
 
@@ -848,7 +848,7 @@ int validate_ownership_qospolicy (const nn_ownership_qospolicy_t *q)
       return 0;
     default:
       DDS_TRACE("plist/validate_ownership_qospolicy: invalid kind (%d)\n", (int) q->kind);
-      return ERR_INVALID;
+      return Q_ERR_INVALID;
   }
 }
 
@@ -877,18 +877,18 @@ int validate_presentation_qospolicy (const nn_presentation_qospolicy_t *q)
       break;
     default:
       DDS_TRACE("plist/validate_presentation_qospolicy: invalid access_scope (%d)\n", (int) q->access_scope);
-      return ERR_INVALID;
+      return Q_ERR_INVALID;
   }
   /* Bools must be 0 or 1, i.e., only the lsb may be set */
   if (q->coherent_access & ~1)
   {
     DDS_TRACE("plist/validate_presentation_qospolicy: coherent_access invalid (%d)\n", (int) q->coherent_access);
-    return ERR_INVALID;
+    return Q_ERR_INVALID;
   }
   if (q->ordered_access & ~1)
   {
     DDS_TRACE("plist/validate_presentation_qospolicy: ordered_access invalid (%d)\n", (int) q->ordered_access);
-    return ERR_INVALID;
+    return Q_ERR_INVALID;
   }
   /* coherent_access & ordered_access are a bit irrelevant for
      instance presentation qos, but it appears as if their values are
@@ -964,7 +964,7 @@ static int do_locator
   if (dd->bufsz < sizeof (loc))
   {
     DDS_TRACE("plist/do_locator: buffer too small\n");
-    return ERR_INVALID;
+    return Q_ERR_INVALID;
   }
   memcpy (&loc, dd->buf, sizeof (loc));
   if (dd->bswap)
@@ -979,12 +979,12 @@ static int do_locator
       if (loc.port <= 0 || loc.port > 65535)
       {
         DDS_TRACE("plist/do_locator[kind=IPv4]: invalid port (%d)\n", (int) loc.port);
-        return ERR_INVALID;
+        return Q_ERR_INVALID;
       }
       if (!locator_address_prefix12_zero (&loc))
       {
         DDS_TRACE("plist/do_locator[kind=IPv4]: junk in address prefix\n");
-        return ERR_INVALID;
+        return Q_ERR_INVALID;
       }
       break;
     case NN_LOCATOR_KIND_UDPv6:
@@ -992,7 +992,7 @@ static int do_locator
       if (loc.port <= 0 || loc.port > 65535)
       {
         DDS_TRACE("plist/do_locator[kind=IPv6]: invalid port (%d)\n", (int) loc.port);
-        return ERR_INVALID;
+        return Q_ERR_INVALID;
       }
       break;
     case NN_LOCATOR_KIND_UDPv4MCGEN: {
@@ -1002,12 +1002,12 @@ static int do_locator
       if (loc.port <= 0 || loc.port > 65536)
       {
         DDS_TRACE("plist/do_locator[kind=IPv4MCGEN]: invalid port (%d)\n", (int) loc.port);
-        return ERR_INVALID;
+        return Q_ERR_INVALID;
       }
       if ((int)x->base + x->count >= 28 || x->count == 0 || x->idx >= x->count)
       {
         DDS_TRACE("plist/do_locator[kind=IPv4MCGEN]: invalid base/count/idx (%u,%u,%u)\n", x->base, x->count, x->idx);
-        return ERR_INVALID;
+        return Q_ERR_INVALID;
       }
       break;
     }
@@ -1015,12 +1015,12 @@ static int do_locator
       if (!locator_address_zero (&loc))
       {
         DDS_TRACE("plist/do_locator[kind=INVALID]: junk in address\n");
-        return ERR_INVALID;
+        return Q_ERR_INVALID;
       }
       if (loc.port != 0)
       {
         DDS_TRACE("plist/do_locator[kind=INVALID]: junk in port\n");
-        return ERR_INVALID;
+        return Q_ERR_INVALID;
       }
       /* silently dropped correctly formatted "invalid" locators. */
       return 0;
@@ -1029,7 +1029,7 @@ static int do_locator
       return 0;
     default:
       DDS_TRACE("plist/do_locator: invalid kind (%d)\n", (int) loc.kind);
-      return NN_PEDANTIC_P ? ERR_INVALID : 0;
+      return NN_PEDANTIC_P ? Q_ERR_INVALID : 0;
   }
   return add_locator (ls, present, wanted, fl, &loc);
 }
@@ -1052,7 +1052,7 @@ static int do_ipv4address (nn_plist_t *dest, nn_ipaddress_params_tmp_t *dest_tmp
   if (dd->bufsz < sizeof (*a))
   {
     DDS_TRACE("plist/do_ipv4address: buffer too small\n");
-    return ERR_INVALID;
+    return Q_ERR_INVALID;
   }
   switch (fl_tmp)
   {
@@ -1122,7 +1122,7 @@ static int do_port (nn_plist_t *dest, nn_ipaddress_params_tmp_t *dest_tmp, uint6
   if (dd->bufsz < sizeof (*p))
   {
     DDS_TRACE("plist/do_port: buffer too small\n");
-    return ERR_INVALID;
+    return Q_ERR_INVALID;
   }
   switch (fl_tmp)
   {
@@ -1156,7 +1156,7 @@ static int do_port (nn_plist_t *dest, nn_ipaddress_params_tmp_t *dest_tmp, uint6
   if (*p <= 0 || *p > 65535)
   {
     DDS_TRACE("plist/do_port: invalid port (%d)\n", (int) *p);
-    return ERR_INVALID;
+    return Q_ERR_INVALID;
   }
   dest_tmp->present |= fl_tmp;
   if ((dest_tmp->present & (fl_tmp | fl1_tmp)) == (fl_tmp | fl1_tmp))
@@ -1185,7 +1185,7 @@ static int valid_participant_guid (const nn_guid_t *g, UNUSED_ARG (const struct 
     else
     {
       DDS_TRACE("plist/valid_participant_guid: prefix is 0 but entityid is not (%u)\n", g->entityid.u);
-      return ERR_INVALID;
+      return Q_ERR_INVALID;
     }
   }
   else if (g->entityid.u == NN_ENTITYID_PARTICIPANT)
@@ -1195,7 +1195,7 @@ static int valid_participant_guid (const nn_guid_t *g, UNUSED_ARG (const struct 
   else
   {
     DDS_TRACE("plist/valid_participant_guid: entityid not a participant entityid (%u)\n", g->entityid.u);
-    return ERR_INVALID;
+    return Q_ERR_INVALID;
   }
 }
 
@@ -1209,7 +1209,7 @@ static int valid_group_guid (const nn_guid_t *g, UNUSED_ARG (const struct dd *dd
     else
     {
       DDS_TRACE("plist/valid_group_guid: prefix is 0 but entityid is not (%u)\n", g->entityid.u);
-      return ERR_INVALID;
+      return Q_ERR_INVALID;
     }
   }
   else if (g->entityid.u != 0)
@@ -1220,7 +1220,7 @@ static int valid_group_guid (const nn_guid_t *g, UNUSED_ARG (const struct dd *dd
   else
   {
     DDS_TRACE("plist/valid_group_guid: entityid is 0\n");
-    return ERR_INVALID;
+    return Q_ERR_INVALID;
   }
 }
 
@@ -1234,7 +1234,7 @@ static int valid_endpoint_guid (const nn_guid_t *g, const struct dd *dd)
     else
     {
       DDS_TRACE("plist/valid_endpoint_guid: prefix is 0 but entityid is not (%x)\n", g->entityid.u);
-      return ERR_INVALID;
+      return Q_ERR_INVALID;
     }
   }
   switch (g->entityid.u & NN_ENTITYID_SOURCE_MASK)
@@ -1255,7 +1255,7 @@ static int valid_endpoint_guid (const nn_guid_t *g, const struct dd *dd)
             DDS_TRACE("plist/valid_endpoint_guid[src=USER,proto=%u.%u]: invalid kind (%x)\n",
                     dd->protocol_version.major, dd->protocol_version.minor,
                     g->entityid.u & NN_ENTITYID_KIND_MASK);
-            return ERR_INVALID;
+            return Q_ERR_INVALID;
           }
       }
     case NN_ENTITYID_SOURCE_BUILTIN:
@@ -1279,7 +1279,7 @@ static int valid_endpoint_guid (const nn_guid_t *g, const struct dd *dd)
           {
             DDS_TRACE("plist/valid_endpoint_guid[src=BUILTIN,proto=%u.%u]: invalid entityid (%x)\n",
                     dd->protocol_version.major, dd->protocol_version.minor, g->entityid.u);
-            return ERR_INVALID;
+            return Q_ERR_INVALID;
           }
       }
     case NN_ENTITYID_SOURCE_VENDOR:
@@ -1309,7 +1309,7 @@ static int valid_endpoint_guid (const nn_guid_t *g, const struct dd *dd)
       }
     default:
       DDS_TRACE("plist/valid_endpoint_guid: invalid source (%x)\n", g->entityid.u);
-      return ERR_INVALID;
+      return Q_ERR_INVALID;
   }
 }
 
@@ -1318,7 +1318,7 @@ static int do_guid (nn_guid_t *dst, uint64_t *present, uint64_t fl, int (*valid)
   if (dd->bufsz < sizeof (*dst))
   {
     DDS_TRACE("plist/do_guid: buffer too small\n");
-    return ERR_INVALID;
+    return Q_ERR_INVALID;
   }
   memcpy (dst, dd->buf, sizeof (*dst));
   *dst = nn_ntoh_guid (*dst);
@@ -1334,7 +1334,7 @@ static int do_guid (nn_guid_t *dst, uint64_t *present, uint64_t fl, int (*valid)
     }
     else
     {
-      return ERR_INVALID;
+      return Q_ERR_INVALID;
     }
   }
   *present |= fl;
@@ -1358,7 +1358,7 @@ static int do_prismtech_participant_version_info (nn_prismtech_participant_versi
   else if (dd->bufsz < NN_PRISMTECH_PARTICIPANT_VERSION_INFO_FIXED_CDRSIZE)
   {
     DDS_TRACE("plist/do_prismtech_participant_version_info[pid=PRISMTECH_PARTICIPANT_VERSION_INFO]: buffer too small\n");
-    return ERR_INVALID;
+    return Q_ERR_INVALID;
   }
   else
   {
@@ -1393,13 +1393,13 @@ static int do_subscription_keys_qospolicy (nn_subscription_keys_qospolicy_t *q, 
   if (dd->bufsz < 4)
   {
     DDS_TRACE("plist/do_subscription_keys: buffer too small\n");
-    return ERR_INVALID;
+    return Q_ERR_INVALID;
   }
   q->use_key_list = (unsigned char) dd->buf[0];
   if (q->use_key_list != 0 && q->use_key_list != 1)
   {
     DDS_TRACE("plist/do_subscription_keys: invalid use_key_list (%d)\n", (int) q->use_key_list);
-    return ERR_INVALID;
+    return Q_ERR_INVALID;
   }
   dd1 = *dd;
   dd1.buf += 4;
@@ -1423,7 +1423,7 @@ static int do_reader_lifespan_qospolicy (nn_reader_lifespan_qospolicy_t *q, uint
   if (dd->bufsz < sizeof (*q))
   {
     DDS_TRACE("plist/do_reader_lifespan: buffer too small\n");
-    return ERR_INVALID;
+    return Q_ERR_INVALID;
   }
   *q = *((nn_reader_lifespan_qospolicy_t *) dd->buf);
   if (dd->bswap)
@@ -1431,7 +1431,7 @@ static int do_reader_lifespan_qospolicy (nn_reader_lifespan_qospolicy_t *q, uint
   if (q->use_lifespan != 0 && q->use_lifespan != 1)
   {
     DDS_TRACE("plist/do_reader_lifespan: invalid use_lifespan (%d)\n", (int) q->use_lifespan);
-    return ERR_INVALID;
+    return Q_ERR_INVALID;
   }
   if ((res = validate_duration (&q->duration)) >= 0)
     *present |= fl;
@@ -1443,13 +1443,13 @@ static int do_entity_factory_qospolicy (nn_entity_factory_qospolicy_t *q, uint64
   if (dd->bufsz < sizeof (*q))
   {
     DDS_TRACE("plist/do_entity_factory: buffer too small\n");
-    return ERR_INVALID;
+    return Q_ERR_INVALID;
   }
   q->autoenable_created_entities = dd->buf[0];
   if (q->autoenable_created_entities != 0 && q->autoenable_created_entities != 1)
   {
     DDS_TRACE("plist/do_entity_factory: invalid autoenable_created_entities (%d)\n", (int) q->autoenable_created_entities);
-    return ERR_INVALID;
+    return Q_ERR_INVALID;
   }
   *present |= fl;
   return 0;
@@ -1461,17 +1461,17 @@ int validate_reader_data_lifecycle (const nn_reader_data_lifecycle_qospolicy_t *
       validate_duration (&q->autopurge_disposed_samples_delay) < 0)
   {
     DDS_TRACE("plist/init_one_parameter[pid=PRISMTECH_READER_DATA_LIFECYCLE]: invalid autopurge_nowriter_sample_delay or autopurge_disposed_samples_delay\n");
-    return ERR_INVALID;
+    return Q_ERR_INVALID;
   }
   if (q->autopurge_dispose_all != 0 && q->autopurge_dispose_all != 1)
   {
     DDS_TRACE("plist/init_one_parameter[pid=PRISMTECH_READER_DATA_LIFECYCLE]: invalid autopurge_dispose_all\n");
-    return ERR_INVALID;
+    return Q_ERR_INVALID;
   }
   if (q->enable_invalid_samples != 0 && q->enable_invalid_samples != 1)
   {
     DDS_TRACE("plist/init_one_parameter[pid=PRISMTECH_READER_DATA_LIFECYCLE]: invalid enable_invalid_samples\n");
-    return ERR_INVALID;
+    return Q_ERR_INVALID;
   }
   /* Don't check consistency between enable_invalid_samples and invalid_samples_mode (yet) */
   switch (q->invalid_sample_visibility)
@@ -1482,7 +1482,7 @@ int validate_reader_data_lifecycle (const nn_reader_data_lifecycle_qospolicy_t *
       break;
     default:
       DDS_TRACE("plist/init_one_parameter[pid=PRISMTECH_READER_DATA_LIFECYCLE]: invalid invalid_sample_visibility\n");
-      return ERR_INVALID;
+      return Q_ERR_INVALID;
   }
   return 0;
 }
@@ -1535,7 +1535,7 @@ static int init_one_parameter
     if (dd->bufsz < sizeof (nn_##name_##_qospolicy_t))                  \
     {                                                                   \
       DDS_TRACE("plist/init_one_parameter[pid=%s]: buffer too small\n", #NAME_); \
-      return ERR_INVALID;                                               \
+      return Q_ERR_INVALID;                                             \
     }                                                                   \
     else                                                                \
     {                                                                   \
@@ -1562,7 +1562,7 @@ static int init_one_parameter
       if (dd->bufsz < sizeof (nn_durability_service_qospolicy_t))
       {
         DDS_TRACE("plist/init_one_parameter[pid=DURABILITY_SERVICE]: buffer too small\n");
-        return ERR_INVALID;
+        return Q_ERR_INVALID;
       }
       else
       {
@@ -1589,7 +1589,7 @@ static int init_one_parameter
       if (dd->bufsz < sizeof (nn_external_reliability_qospolicy_t))
       {
         DDS_TRACE("plist/init_one_parameter[pid=RELIABILITY]: buffer too small\n");
-        return ERR_INVALID;
+        return Q_ERR_INVALID;
       }
       else
       {
@@ -1640,7 +1640,7 @@ static int init_one_parameter
         else
         {
           DDS_TRACE("plist/init_one_parameter[pid=PRISMTECH_READER_DATA_LIFECYCLE]: buffer too small\n");
-          ret = ERR_INVALID;
+          ret = Q_ERR_INVALID;
         }
         if (ret >= 0)
           dest->qos.present |= QP_PRISMTECH_READER_DATA_LIFECYCLE;
@@ -1655,7 +1655,7 @@ static int init_one_parameter
         if (dd->bufsz < 1)
         {
           DDS_TRACE("plist/init_one_parameter[pid=PRISMTECH_WRITER_DATA_LIFECYCLE]: buffer too small\n");
-          return ERR_INVALID;
+          return Q_ERR_INVALID;
         }
         else if (dd->bufsz < sizeof (*q))
         {
@@ -1676,13 +1676,13 @@ static int init_one_parameter
         if (q->autodispose_unregistered_instances & ~1)
         {
           DDS_TRACE("plist/init_one_parameter[pid=PRISMTECH_WRITER_DATA_LIFECYCLE]: invalid autodispose_unregistered_instances (%d)\n", (int) q->autodispose_unregistered_instances);
-          return ERR_INVALID;
+          return Q_ERR_INVALID;
         }
         if (validate_duration (&q->autounregister_instance_delay) < 0 ||
             validate_duration (&q->autopurge_suspended_samples_delay) < 0)
         {
           DDS_TRACE("plist/init_one_parameter[pid=PRISMTECH_WRITER_DATA_LIFECYCLE]: invalid autounregister_instance_delay or autopurge_suspended_samples_delay\n");
-          return ERR_INVALID;
+          return Q_ERR_INVALID;
         }
         dest->qos.present |= QP_PRISMTECH_WRITER_DATA_LIFECYCLE;
         return 0;
@@ -1694,7 +1694,7 @@ static int init_one_parameter
       else if (dd->bufsz < sizeof (dest->qos.relaxed_qos_matching))
       {
         DDS_TRACE("plist/init_one_parameter[pid=PRISMTECH_RELAXED_QOS_MATCHING]: buffer too small\n");
-        return ERR_INVALID;
+        return Q_ERR_INVALID;
       }
       else
       {
@@ -1703,7 +1703,7 @@ static int init_one_parameter
         if (rqm->value != 0 && rqm->value != 1)
         {
           DDS_TRACE("plist/init_one_parameter[pid=PRISMTECH_RELAXED_QOS_MATCHING]: invalid\n");
-          return ERR_INVALID;
+          return Q_ERR_INVALID;
         }
         dest->qos.present |= QP_PRISMTECH_RELAXED_QOS_MATCHING;
         return 0;
@@ -1715,7 +1715,7 @@ static int init_one_parameter
       else if (dd->bufsz < sizeof (dest->qos.synchronous_endpoint))
       {
         DDS_TRACE("plist/init_one_parameter[pid=PRISMTECH_SYNCHRONOUS_ENDPOINT]: buffer too small\n");
-        return ERR_INVALID;
+        return Q_ERR_INVALID;
       }
       else
       {
@@ -1724,7 +1724,7 @@ static int init_one_parameter
         if (q->value != 0 && q->value != 1)
         {
           DDS_TRACE("plist/init_one_parameter[pid=PRISMTECH_SYNCHRONOUS_ENDPOINT]: invalid value for synchronous flag\n");
-          return ERR_INVALID;
+          return Q_ERR_INVALID;
         }
         dest->qos.present |= QP_PRISMTECH_SYNCHRONOUS_ENDPOINT;
         return 0;
@@ -1735,7 +1735,7 @@ static int init_one_parameter
       if (dd->bufsz < sizeof (nn_protocol_version_t))
       {
         DDS_TRACE("plist/init_one_parameter[pid=PROTOCOL_VERSION]: buffer too small\n");
-        return ERR_INVALID;
+        return Q_ERR_INVALID;
       }
       memcpy (&dest->protocol_version, dd->buf, sizeof (dest->protocol_version));
       if (NN_STRICT_P &&
@@ -1748,14 +1748,14 @@ static int init_one_parameter
         DDS_TRACE("plist/init_one_parameter[pid=PROTOCOL_VERSION,mode=STRICT]: version (%u.%u) mismatch with message (%u.%u)\n",
                 dest->protocol_version.major, dest->protocol_version.minor,
                 dd->protocol_version.major, dd->protocol_version.minor);
-        return ERR_INVALID;
+        return Q_ERR_INVALID;
       }
       dest->present |= PP_PROTOCOL_VERSION;
       return 0;
 
     case PID_VENDORID:
       if (dd->bufsz < sizeof (nn_vendorid_t))
-        return ERR_INVALID;
+        return Q_ERR_INVALID;
       memcpy (&dest->vendorid, dd->buf, sizeof (dest->vendorid));
       if (NN_STRICT_P &&
           (dest->vendorid.id[0] != dd->vendorid.id[0] ||
@@ -1764,7 +1764,7 @@ static int init_one_parameter
         /* see PROTOCOL_VERSION */
         DDS_TRACE("plist/init_one_parameter[pid=VENDORID,mode=STRICT]: vendor (%u.%u) mismatch with message (%u.%u)\n",
                 dest->vendorid.id[0], dest->vendorid.id[1], dd->vendorid.id[0], dd->vendorid.id[1]);
-        return ERR_INVALID;
+        return Q_ERR_INVALID;
       }
       dest->present |= PP_VENDORID;
       return 0;
@@ -1808,7 +1808,7 @@ static int init_one_parameter
       if (dd->bufsz < sizeof (dest->expects_inline_qos))
       {
         DDS_TRACE("plist/init_one_parameter[pid=EXPECTS_INLINE_QOS]: buffer too small\n");
-        return ERR_INVALID;
+        return Q_ERR_INVALID;
       }
       dest->expects_inline_qos = dd->buf[0];
       /* boolean: only lsb may be set */
@@ -1816,7 +1816,7 @@ static int init_one_parameter
       {
         DDS_TRACE("plist/init_one_parameter[pid=EXPECTS_INLINE_QOS]: invalid expects_inline_qos (%d)\n",
                 (int) dest->expects_inline_qos);
-        return ERR_INVALID;
+        return Q_ERR_INVALID;
       }
       dest->present |= PP_EXPECTS_INLINE_QOS;
       return 0;
@@ -1828,7 +1828,7 @@ static int init_one_parameter
       if (dd->bufsz < sizeof (dest->participant_manual_liveliness_count))
       {
         DDS_TRACE("plist/init_one_parameter[pid=PARTICIPANT_MANUAL_LIVELINESS_COUNT]: buffer too small\n");
-        return ERR_INVALID;
+        return Q_ERR_INVALID;
       }
       memcpy (&dest->participant_manual_liveliness_count, dd->buf, sizeof (dest->participant_manual_liveliness_count));
       if (dd->bswap)
@@ -1862,7 +1862,7 @@ static int init_one_parameter
       if (dd->bufsz < sizeof (dest->builtin_endpoint_set))
       {
         DDS_TRACE("plist/init_one_parameter[pid=BUILTIN_ENDPOINT_SET(%u)]: buffer too small\n", pid);
-        return ERR_INVALID;
+        return Q_ERR_INVALID;
       }
       memcpy (&dest->builtin_endpoint_set, dd->buf, sizeof (dest->builtin_endpoint_set));
       if (dd->bswap)
@@ -1887,7 +1887,7 @@ static int init_one_parameter
       {
         DDS_TRACE("plist/init_one_parameter[pid=BUILTIN_ENDPOINT_SET(%u),mode=STRICT,proto=%u.%u]: invalid set (0x%x)\n",
                 pid, dd->protocol_version.major, dd->protocol_version.minor, dest->builtin_endpoint_set);
-        return ERR_INVALID;
+        return Q_ERR_INVALID;
       }
       dest->present |= PP_BUILTIN_ENDPOINT_SET;
       return 0;
@@ -1898,7 +1898,7 @@ static int init_one_parameter
       else if (dd->bufsz < sizeof (dest->prismtech_builtin_endpoint_set))
       {
         DDS_TRACE("plist/init_one_parameter[pid=PRISMTECH_BUILTIN_ENDPOINT_SET(%u)]: buffer too small\n", pid);
-        return ERR_INVALID;
+        return Q_ERR_INVALID;
       }
       else
       {
@@ -1921,7 +1921,7 @@ static int init_one_parameter
       if (dd->bufsz < sizeof (dest->keyhash))
       {
         DDS_TRACE("plist/init_one_parameter[pid=KEYHASH]: buffer too small\n");
-        return ERR_INVALID;
+        return Q_ERR_INVALID;
       }
       memcpy (&dest->keyhash, dd->buf, sizeof (dest->keyhash));
       dest->present |= PP_KEYHASH;
@@ -1931,7 +1931,7 @@ static int init_one_parameter
       if (dd->bufsz < sizeof (dest->statusinfo))
       {
         DDS_TRACE("plist/init_one_parameter[pid=STATUSINFO]: buffer too small\n");
-        return ERR_INVALID;
+        return Q_ERR_INVALID;
       }
       memcpy (&dest->statusinfo, dd->buf, sizeof (dest->statusinfo));
       dest->statusinfo = fromBE4u (dest->statusinfo);
@@ -1942,7 +1942,7 @@ static int init_one_parameter
            may use them in this version of the specification */
         DDS_TRACE("plist/init_one_parameter[pid=STATUSINFO,mode=STRICT,proto=%u.%u]: invalid statusinfo (0x%x)\n",
                 dd->protocol_version.major, dd->protocol_version.minor, dest->statusinfo);
-        return ERR_INVALID;
+        return Q_ERR_INVALID;
       }
       /* Clear all bits we don't understand, then add the extended bits if present */
       dest->statusinfo &= NN_STATUSINFO_STANDARDIZED;
@@ -1962,7 +1962,7 @@ static int init_one_parameter
       if (dd->bufsz < sizeof (dest->coherent_set_seqno))
       {
         DDS_TRACE("plist/init_one_parameter[pid=COHERENT_SET]: buffer too small\n");
-        return ERR_INVALID;
+        return Q_ERR_INVALID;
       }
       else
       {
@@ -1978,7 +1978,7 @@ static int init_one_parameter
         if (seqno <= 0 && seqno != NN_SEQUENCE_NUMBER_UNKNOWN)
         {
           DDS_TRACE("plist/init_one_parameter[pid=COHERENT_SET]: invalid sequence number (%" PRId64 ")\n", seqno);
-          return ERR_INVALID;
+          return Q_ERR_INVALID;
         }
         dest->present |= PP_COHERENT_SET;
         return 0;
@@ -1999,7 +1999,7 @@ static int init_one_parameter
            ignore it. */
         DDS_TRACE("plist/init_one_parameter[pid=ENDPOINT_GUID,mode=PEDANTIC,proto=%u.%u]: undefined pid\n",
                 dd->protocol_version.major, dd->protocol_version.minor);
-        return ERR_INVALID;
+        return Q_ERR_INVALID;
       }
       return do_guid (&dest->endpoint_guid, &dest->present, PP_ENDPOINT_GUID, valid_endpoint_guid, dd);
 
@@ -2056,7 +2056,7 @@ static int init_one_parameter
       if (dd->bufsz < sizeof (dest->service_type))
       {
         DDS_TRACE("plist/init_one_parameter[pid=PRISMTECH_SERVICE_TYPE]: buffer too small\n");
-        return ERR_INVALID;
+        return Q_ERR_INVALID;
       }
       memcpy (&dest->service_type, dd->buf, sizeof (dest->service_type));
       if (dd->bswap)
@@ -2070,7 +2070,7 @@ static int init_one_parameter
       if (dd->bufsz < sizeof (dest->process_id))
       {
         DDS_TRACE("plist/init_one_parameter[pid=PRISMTECH_PROCESS_ID]: buffer too small\n");
-        return ERR_INVALID;
+        return Q_ERR_INVALID;
       }
       memcpy (&dest->process_id, dd->buf, sizeof (dest->process_id));
       if (dd->bswap)
@@ -2089,7 +2089,7 @@ static int init_one_parameter
       else if (dd->bufsz < 2*sizeof (uint32_t))
       {
         DDS_TRACE("plist/init_one_parameter[pid=PRISMTECH_EOTINFO]: buffer too small (1)\n");
-        return ERR_INVALID;
+        return Q_ERR_INVALID;
       }
       else
       {
@@ -2105,7 +2105,7 @@ static int init_one_parameter
         if (q->n > (dd->bufsz - 2*sizeof (uint32_t)) / sizeof (nn_prismtech_eotgroup_tid_t))
         {
           DDS_TRACE("plist/init_one_parameter[pid=PRISMTECH_EOTINFO]: buffer too small (2)\n");
-          return ERR_INVALID;
+          return Q_ERR_INVALID;
         }
         if (q->n == 0)
           q->tids = NULL;
@@ -2134,7 +2134,7 @@ static int init_one_parameter
       if (dd->bufsz < sizeof (dest->reader_favours_ssm))
       {
         DDS_TRACE("plist/init_one_parameter[pid=READER_FAVOURS_SSM]: buffer too small\n");
-        return ERR_INVALID;
+        return Q_ERR_INVALID;
       }
       else
       {
@@ -2174,13 +2174,13 @@ static int init_one_parameter
          bugs & the buffer overflows originate! */
       if (pid & PID_UNRECOGNIZED_INCOMPATIBLE_FLAG) {
         dest->present |= PP_INCOMPATIBLE;
-        return ERR_INCOMPATIBLE;
+        return Q_ERR_INCOMPATIBLE;
       } else if (pid & PID_VENDORSPECIFIC_FLAG) {
         return 0;
       } else if (!protocol_version_is_newer (dd->protocol_version) && NN_STRICT_P) {
         DDS_TRACE("plist/init_one_parameter[pid=%u,mode=STRICT,proto=%u.%u]: undefined paramter id\n",
                 pid, dd->protocol_version.major, dd->protocol_version.minor);
-        return ERR_INVALID;
+        return Q_ERR_INVALID;
       } else {
         return 0;
       }
@@ -2188,7 +2188,7 @@ static int init_one_parameter
 
   assert (0);
   DDS_TRACE("plist/init_one_parameter: can't happen\n");
-  return ERR_INVALID;
+  return Q_ERR_INVALID;
 }
 
 static void default_resource_limits (nn_resource_limits_qospolicy_t *q)
@@ -2404,7 +2404,7 @@ int nn_plist_init_frommsg
     default:
       DDS_WARNING ("plist(vendor %u.%u): unknown encoding (%d)\n",
                    src->vendorid.id[0], src->vendorid.id[1], src->encoding);
-      return ERR_INVALID;
+      return Q_ERR_INVALID;
   }
   nn_plist_init_empty (dest);
   dest->unalias_needs_bswap = dd.bswap;
@@ -2431,7 +2431,7 @@ int nn_plist_init_frommsg
       if ((res = final_validation (dest, src->protocol_version, src->vendorid)) < 0)
       {
         nn_plist_fini (dest);
-        return ERR_INVALID;
+        return Q_ERR_INVALID;
       }
       else
       {
@@ -2446,14 +2446,14 @@ int nn_plist_init_frommsg
       DDS_WARNING("plist(vendor %u.%u): parameter length %u out of bounds\n",
                   src->vendorid.id[0], src->vendorid.id[1], length);
       nn_plist_fini (dest);
-      return ERR_INVALID;
+      return Q_ERR_INVALID;
     }
     if ((length % 4) != 0) /* DDSI 9.4.2.11 */
     {
       DDS_WARNING("plist(vendor %u.%u): parameter length %u mod 4 != 0\n",
                   src->vendorid.id[0], src->vendorid.id[1], length);
       nn_plist_fini (dest);
-      return ERR_INVALID;
+      return Q_ERR_INVALID;
     }
 
     if (dds_get_log_mask() & DDS_LC_PLIST)
@@ -2479,7 +2479,7 @@ int nn_plist_init_frommsg
   DDS_WARNING("plist(vendor %u.%u): invalid parameter list: sentinel missing\n",
               src->vendorid.id[0], src->vendorid.id[1]);
   nn_plist_fini (dest);
-  return ERR_INVALID;
+  return Q_ERR_INVALID;
 }
 
 const unsigned char *nn_plist_findparam_native_unchecked (const void *src, nn_parameterid_t pid)

--- a/src/core/ddsi/src/q_receive.c
+++ b/src/core/ddsi/src/q_receive.c
@@ -15,11 +15,11 @@
 #include <stddef.h>
 
 #include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/log.h"
+#include "dds/ddsrt/md5.h"
 #include "dds/ddsrt/sync.h"
 #include "dds/ddsrt/string.h"
-#include "dds/ddsrt/log.h"
 
-#include "dds/ddsi/q_md5.h"
 #include "dds/util/ut_avl.h"
 #include "dds__stream.h"
 #include "dds/ddsi/q_protocol.h"
@@ -44,6 +44,7 @@
 #include "dds/ddsi/q_entity.h"
 #include "dds/ddsi/q_xmsg.h"
 #include "dds/ddsi/q_receive.h"
+
 #include "dds/ddsi/q_transmit.h"
 #include "dds/ddsi/q_globals.h"
 #include "dds/ddsi/q_static_assert.h"

--- a/src/core/ddsi/src/q_security.c
+++ b/src/core/ddsi/src/q_security.c
@@ -1657,7 +1657,7 @@ static os_ssize_t q_security_sendmsg
   char stbuf[2048], *buf;
   size_t sz, data_size;
   uint32_t sz32, data_size32;
-  ssize_t ret = ERR_UNSPECIFIED;
+  ssize_t ret = Q_ERR_UNSPECIFIED;
   PT_InfoContainer_t * securityHeader;
   unsigned i;
 

--- a/src/core/ddsi/src/q_servicelease.c
+++ b/src/core/ddsi/src/q_servicelease.c
@@ -217,7 +217,7 @@ int nn_servicelease_start_renewing (struct nn_servicelease *sl)
 
  fail_thread:
   sl->keepgoing = -1;
-  return ERR_UNSPECIFIED;
+  return Q_ERR_UNSPECIFIED;
 }
 
 void nn_servicelease_statechange_barrier (struct nn_servicelease *sl)

--- a/src/core/ddsi/src/q_sockwaitset.c
+++ b/src/core/ddsi/src/q_sockwaitset.c
@@ -831,7 +831,7 @@ void os_sockWaitsetRemove (os_sockWaitset ws, ddsi_tran_conn_t conn)
 
 os_sockWaitsetCtx os_sockWaitsetWait (os_sockWaitset ws)
 {
-  int n = -1;
+  int32_t n = -1;
   unsigned u;
   int fdmax;
   fd_set * rdset = NULL;

--- a/src/core/ddsi/src/q_thread.c
+++ b/src/core/ddsi/src/q_thread.c
@@ -301,7 +301,7 @@ int join_thread (struct thread_state1 *ts1)
   if (ddsrt_thread_join (ts1->extTid, NULL) == DDS_RETCODE_OK)
     ret = 0;
   else
-    ret = ERR_UNSPECIFIED;
+    ret = Q_ERR_UNSPECIFIED;
   assert (vtime_asleep_p (ts1->vtime));
   reap_thread_state (ts1, 1);
   return ret;

--- a/src/core/ddsi/src/q_time.c
+++ b/src/core/ddsi/src/q_time.c
@@ -51,23 +51,23 @@ nn_etime_t now_et (void)
   return t;
 }
 
-static void time_to_sec_usec (int * __restrict sec, int * __restrict usec, int64_t t)
+static void time_to_sec_usec (int32_t * __restrict sec, int32_t * __restrict usec, int64_t t)
 {
-  *sec = (int) (t / T_SECOND);
-  *usec = (int) (t % T_SECOND) / 1000;
+  *sec = (int32_t) (t / T_SECOND);
+  *usec = (int32_t) (t % T_SECOND) / 1000;
 }
 
-void mtime_to_sec_usec (int * __restrict sec, int * __restrict usec, nn_mtime_t t)
-{
-  time_to_sec_usec (sec, usec, t.v);
-}
-
-void wctime_to_sec_usec (int * __restrict sec, int * __restrict usec, nn_wctime_t t)
+void mtime_to_sec_usec (int32_t * __restrict sec, int32_t * __restrict usec, nn_mtime_t t)
 {
   time_to_sec_usec (sec, usec, t.v);
 }
 
-void etime_to_sec_usec (int * __restrict sec, int * __restrict usec, nn_etime_t t)
+void wctime_to_sec_usec (int32_t * __restrict sec, int32_t * __restrict usec, nn_wctime_t t)
+{
+  time_to_sec_usec (sec, usec, t.v);
+}
+
+void etime_to_sec_usec (int32_t * __restrict sec, int32_t * __restrict usec, nn_etime_t t)
 {
   time_to_sec_usec (sec, usec, t.v);
 }

--- a/src/core/ddsi/src/q_transmit.c
+++ b/src/core/ddsi/src/q_transmit.c
@@ -424,7 +424,7 @@ static int create_fragment_message_simple (struct writer *wr, seqno_t seq, struc
   ASSERT_MUTEX_HELD (&wr->e.lock);
 
   if ((*pmsg = nn_xmsg_new (gv.xmsgpool, &wr->e.guid.prefix, sizeof (InfoTimestamp_t) + sizeof (Data_t) + expected_inline_qos_size, NN_XMSG_KIND_DATA)) == NULL)
-    return ERR_OUT_OF_MEMORY;
+    return Q_ERR_OUT_OF_MEMORY;
 
 #ifdef DDSI_INCLUDE_NETWORK_PARTITIONS
   /* use the partition_id from the writer to select the proper encoder */
@@ -503,13 +503,13 @@ int create_fragment_message (struct writer *wr, seqno_t seq, const struct nn_pli
        an non-existent fragment, which a malicious (or buggy) remote
        reader can trigger.  So we return an error instead of asserting
        as we used to. */
-    return ERR_INVALID;
+    return Q_ERR_INVALID;
   }
 
   fragging = (config.fragment_size < size);
 
   if ((*pmsg = nn_xmsg_new (gv.xmsgpool, &wr->e.guid.prefix, sizeof (InfoTimestamp_t) + sizeof (DataFrag_t) + expected_inline_qos_size, xmsg_kind)) == NULL)
-    return ERR_OUT_OF_MEMORY;
+    return Q_ERR_OUT_OF_MEMORY;
 
 #ifdef DDSI_INCLUDE_NETWORK_PARTITIONS
   /* use the partition_id from the writer to select the proper encoder */
@@ -522,7 +522,7 @@ int create_fragment_message (struct writer *wr, seqno_t seq, const struct nn_pli
     {
       nn_xmsg_free (*pmsg);
       *pmsg = NULL;
-      return ERR_NO_ADDRESS;
+      return Q_ERR_NO_ADDRESS;
     }
     /* retransmits: latency budget doesn't apply */
   }
@@ -1050,7 +1050,7 @@ static int write_sample_eot (struct nn_xpack *xp, struct writer *wr, struct nn_p
                  ddsi_serdata_size (serdata), config.max_sample_size,
                  PGUID (wr->e.guid), tname, ttname, ppbuf,
                  tmp < (int) sizeof (ppbuf) ? "" : " (trunc)");
-    r = ERR_INVALID_DATA;
+    r = Q_ERR_INVALID_DATA;
     goto drop;
   }
 
@@ -1082,7 +1082,7 @@ static int write_sample_eot (struct nn_xpack *xp, struct writer *wr, struct nn_p
       if (ores == DDS_RETCODE_TIMEOUT)
       {
         ddsrt_mutex_unlock (&wr->e.lock);
-        r = ERR_TIMEOUT;
+        r = Q_ERR_TIMEOUT;
         goto drop;
       }
     }

--- a/src/core/ddsi/src/q_xevent.c
+++ b/src/core/ddsi/src/q_xevent.c
@@ -521,7 +521,7 @@ int xeventq_start (struct xeventq *evq, const char *name)
   {
     ddsrt_free (evqname);
   }
-  return (evq->ts == NULL) ? ERR_UNSPECIFIED : 0;
+  return (evq->ts == NULL) ? Q_ERR_UNSPECIFIED : 0;
 }
 
 void xeventq_stop (struct xeventq *evq)

--- a/src/core/ddsi/src/q_xmsg.c
+++ b/src/core/ddsi/src/q_xmsg.c
@@ -591,7 +591,7 @@ int nn_xmsg_setdstPRD (struct nn_xmsg *m, const struct proxy_reader *prd)
   else
   {
     DDS_WARNING("nn_xmsg_setdstPRD: no address for %x:%x:%x:%x", PGUID (prd->e.guid));
-    return ERR_NO_ADDRESS;
+    return Q_ERR_NO_ADDRESS;
   }
 }
 
@@ -604,7 +604,7 @@ int nn_xmsg_setdstPWR (struct nn_xmsg *m, const struct proxy_writer *pwr)
     return 0;
   }
   DDS_WARNING("nn_xmsg_setdstPRD: no address for %x:%x:%x:%x", PGUID (pwr->e.guid));
-  return ERR_NO_ADDRESS;
+  return Q_ERR_NO_ADDRESS;
 }
 
 void nn_xmsg_setdstN (struct nn_xmsg *m, struct addrset *as, struct addrset *as_group)

--- a/src/core/xtests/rhc_torture.c
+++ b/src/core/xtests/rhc_torture.c
@@ -265,7 +265,7 @@ static void print_seq (int n, const dds_sample_info_t *iseq, const RhcTypes_T *m
     char buf[64];
     assert(si->instance_handle);
     assert(si->publication_handle);
-    printf ("[%2d] %c%c%c %16"PRIx64" %16"PRIx64" %4d %4d %2d %2d %2d %2"PRId32,
+    printf ("[%2d] %c%c%c %16"PRIx64" %16"PRIx64" %4"PRIu32" %4"PRIu32" %2"PRIu32" %2"PRIu32" %2"PRIu32" %2"PRId32,
             i, si2ss(si), si2vs(si), si2is(si),
             si->instance_handle, si->publication_handle,
             si->disposed_generation_count, si->no_writers_generation_count,

--- a/src/ddsrt/CMakeLists.txt
+++ b/src/ddsrt/CMakeLists.txt
@@ -89,7 +89,7 @@ list(APPEND sources
 # network stack. In order to mix-and-match various compilers, architectures,
 # operating systems, etc input from the build system is required.
 foreach(feature atomics cdtors environ heap ifaddrs random rusage
-                sockets string sync threads time)
+                sockets string sync threads time md5)
   if(EXISTS "${include_path}/dds/ddsrt/${feature}.h")
     list(APPEND headers "${include_path}/dds/ddsrt/${feature}.h")
     file(GLOB

--- a/src/ddsrt/include/dds/ddsrt/md5.h
+++ b/src/ddsrt/include/dds/ddsrt/md5.h
@@ -59,8 +59,8 @@
   1999-05-03 lpd Original version.
  */
 
-#ifndef md5_INCLUDED
-#  define md5_INCLUDED
+#ifndef DDSRT_MD5_H
+#define DDSRT_MD5_H
 
 #include <stddef.h>
 
@@ -74,15 +74,15 @@
  * efficiently on either one than if ARCH_IS_BIG_ENDIAN is defined.
  */
 
-typedef unsigned char md5_byte_t; /* 8-bit byte */
-typedef unsigned int md5_word_t; /* 32-bit word */
+typedef unsigned char ddsrt_md5_byte_t; /* 8-bit byte */
+typedef unsigned int ddsrt_md5_word_t; /* 32-bit word */
 
 /* Define the state of the MD5 Algorithm. */
-typedef struct md5_state_s {
-    md5_word_t count[2];        /* message length in bits, lsw first */
-    md5_word_t abcd[4];         /* digest buffer */
-    md5_byte_t buf[64];         /* accumulate block */
-} md5_state_t;
+typedef struct ddsrt_md5_state_s {
+    ddsrt_md5_word_t count[2];        /* message length in bits, lsw first */
+    ddsrt_md5_word_t abcd[4];         /* digest buffer */
+    ddsrt_md5_byte_t buf[64];         /* accumulate block */
+} ddsrt_md5_state_t;
 
 #ifdef __cplusplus
 extern "C"
@@ -90,16 +90,16 @@ extern "C"
 #endif
 
 /* Initialize the algorithm. */
-void md5_init(md5_state_t *pms);
+void ddsrt_md5_init(ddsrt_md5_state_t *pms);
 
 /* Append a string to the message. */
-void md5_append(md5_state_t *pms, const md5_byte_t *data, unsigned nbytes);
+void ddsrt_md5_append(ddsrt_md5_state_t *pms, const ddsrt_md5_byte_t *data, unsigned nbytes);
 
 /* Finish the message and return the digest. */
-void md5_finish(md5_state_t *pms, md5_byte_t digest[16]);
+void ddsrt_md5_finish(ddsrt_md5_state_t *pms, ddsrt_md5_byte_t digest[16]);
 
 #ifdef __cplusplus
 }  /* end extern "C" */
 #endif
 
-#endif /* md5_INCLUDED */
+#endif /* DDSRT_MD5_H */

--- a/src/ddsrt/include/dds/ddsrt/misc.h
+++ b/src/ddsrt/include/dds/ddsrt/misc.h
@@ -20,7 +20,7 @@ extern "C" {
 
 #if defined(__GNUC__) && ((__GNUC__ * 100) + __GNUC_MINOR__) >= 402
 # define DDSRT_GNUC_STR(s) #s
-# define DDSRT_GNUC_JOINSTR(x,y) DDSRT_GNUC_DIAG_STR(x ## y)
+# define DDSRT_GNUC_JOINSTR(x,y) DDSRT_GNUC_STR(x ## y)
 # define DDSRT_GNUC_DO_PRAGMA(x) _Pragma (#x)
 # define DDSRT_GNUC_PRAGMA(x) DDSRT_GNUC_DO_PRAGMA(GCC diagnostic x)
 # if ((__GNUC__ * 100) + __GNUC_MINOR__) >= 406

--- a/src/ddsrt/include/dds/ddsrt/sockets.h
+++ b/src/ddsrt/include/dds/ddsrt/sockets.h
@@ -8,11 +8,13 @@
 #include "dds/ddsrt/attributes.h"
 #include "dds/ddsrt/retcode.h"
 #include "dds/ddsrt/time.h"
-#if !defined(_WIN32)
-#include "dds/ddsrt/sockets/posix.h"
-#else
+#if _WIN32
 #include "dds/ddsrt/sockets/windows.h"
+#else
+#include "dds/ddsrt/sockets/posix.h"
 #endif
+
+#define INET_ADDRSTRLEN_EXTENDED (INET_ADDRSTRLEN + 6) /* ":12345" */
 
 #if DDSRT_HAVE_IPV6
 #define INET6_ADDRSTRLEN_EXTENDED (INET6_ADDRSTRLEN + 8) /* "[]:12345" */

--- a/src/examples/helloworld/publisher.c
+++ b/src/examples/helloworld/publisher.c
@@ -52,7 +52,7 @@ int main (int argc, char ** argv)
   msg.message = "Hello World";
 
   printf ("=== [Publisher]  Writing : ");
-  printf ("Message (%d, %s)\n", msg.userID, msg.message);
+  printf ("Message (%"PRId32", %s)\n", msg.userID, msg.message);
   fflush (stdout);
 
   rc = dds_write (writer, &msg);

--- a/src/examples/helloworld/subscriber.c
+++ b/src/examples/helloworld/subscriber.c
@@ -61,7 +61,7 @@ int main (int argc, char ** argv)
       /* Print Message. */
       msg = (HelloWorldData_Msg*) samples[0];
       printf ("=== [Subscriber] Received : ");
-      printf ("Message (%d, %s)\n", msg->userID, msg->message);
+      printf ("Message (%"PRId32", %s)\n", msg->userID, msg->message);
       fflush (stdout);
       break;
     }

--- a/src/examples/throughput/publisher.c
+++ b/src/examples/throughput/publisher.c
@@ -126,7 +126,7 @@ static int parse_args(
     *partitionName = argv[5]; /* The name of the partition */
   }
 
-  printf ("payloadSize: %u bytes burstInterval: %u ms burstSize: %u timeOut: %u seconds partitionName: %s\n",
+  printf ("payloadSize: %"PRIu32" bytes burstInterval: %u ms burstSize: %"PRId32" timeOut: %u seconds partitionName: %s\n",
     *payloadSize, *burstInterval, *burstSize, *timeOut, *partitionName);
   fflush (stdout);
 

--- a/src/tools/ddsls/ddsls.c
+++ b/src/tools/ddsls/ddsls.c
@@ -150,17 +150,17 @@ void qp_resource_limits_1 (FILE *fp, int32_t max_samples, int32_t max_instances,
   if (max_samples == DDS_LENGTH_UNLIMITED)
     fprintf (fp, "unlimited");
   else
-    fprintf (fp, "%d", max_samples);
+    fprintf (fp, "%"PRId32, max_samples);
   fprintf (fp, ", max_instances = ");
   if (max_instances == DDS_LENGTH_UNLIMITED)
     fprintf (fp, "unlimited");
   else
-    fprintf (fp, "%d", max_instances);
+    fprintf (fp, "%"PRId32, max_instances);
   fprintf (fp, ", max_samples_per_instance = ");
   if (max_samples_per_instance == DDS_LENGTH_UNLIMITED)
     fprintf (fp, "unlimited\n");
   else
-    fprintf (fp, "%d\n", max_samples_per_instance);
+    fprintf (fp, "%"PRId32"\n", max_samples_per_instance);
 }
 
 void qp_resource_limits (const dds_qos_t *q, FILE *fp)

--- a/src/tools/pubsub/common.c
+++ b/src/tools/pubsub/common.c
@@ -705,7 +705,7 @@ static int one_resource_limit(int32_t *val, const char **arg) {
         *val = DDS_LENGTH_UNLIMITED;
         (*arg) += 3;
         return 1;
-    } else if (sscanf(*arg, "%d%n", val, &pos) == 1) {
+    } else if (sscanf(*arg, "%"PRId32"%n", val, &pos) == 1) {
         (*arg) += pos;
         return 1;
     } else {
@@ -957,7 +957,7 @@ bool dds_err_check (dds_return_t err, unsigned flags, const char * where)
     if (flags & (DDS_CHECK_REPORT | DDS_CHECK_FAIL))
     {
       char msg[DDS_ERR_MSG_MAX];
-      (void) snprintf (msg, DDS_ERR_MSG_MAX, "Error %d:M%d:%s", dds_err_file_id(err), dds_err_line(err), dds_err_str(err));
+      (void) snprintf (msg, DDS_ERR_MSG_MAX, "Error %"PRId32":M%"PRId32":%s", dds_err_file_id(err), dds_err_line(err), dds_err_str(err));
       if (flags & DDS_CHECK_REPORT)
       {
         printf ("%s: %s\n", where, msg);

--- a/src/tools/pubsub/pubsub.c
+++ b/src/tools/pubsub/pubsub.c
@@ -45,7 +45,7 @@
 //#define NUMSTR "0123456789"
 //#define HOSTNAMESTR "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-." NUMSTR
 
-typedef int (*write_oper_t) (dds_entity_t wr, const void *d, const dds_time_t ts);
+typedef dds_return_t (*write_oper_t) (dds_entity_t wr, const void *d, const dds_time_t ts);
 
 enum topicsel { UNSPEC, KS, K32, K64, K128, K256, OU, ARB };
 enum readermode { MODE_PRINT, MODE_CHECK, MODE_ZEROLOAD, MODE_DUMP, MODE_NONE };
@@ -860,11 +860,11 @@ static void print_K(dds_time_t *tstart, dds_time_t tnow, dds_entity_t rd, const 
     print_sampleinfo(tstart, tnow, si, tag);
     if (si->valid_data) {
         if(printmode == TGPM_MULTILINE) {
-            printf ("{\n%*.*s.seq = %u,\n%*.*s.keyval = %d }\n", 4, 4, "", seq, 4, 4, "", keyval);
+            printf ("{\n%*.*s.seq = %"PRIu32",\n%*.*s.keyval = %"PRId32" }\n", 4, 4, "", seq, 4, 4, "", keyval);
         } else if(printmode == TGPM_DENSE) {
-            printf ("{%u,%d}\n", seq, keyval);
+            printf ("{%"PRIu32",%"PRId32"}\n", seq, keyval);
         } else {
-            printf ("{ .seq = %u, .keyval = %d }\n", seq, keyval);
+            printf ("{ .seq = %"PRIu32", .keyval = %"PRId32" }\n", seq, keyval);
         }
     } else {
         /* May not look at mseq->_buffer[i] but want the key value
@@ -877,11 +877,11 @@ static void print_K(dds_time_t *tstart, dds_time_t tnow, dds_entity_t rd, const 
         int32_t d_key;
         if ((result = getkeyval(rd, &d_key, si->instance_handle)) == DDS_RETCODE_OK) {
             if(printmode == TGPM_MULTILINE) {
-                printf ("{\n%*.*s.seq = NA,\n%*.*s.keyval = %d }\n", 4, 4, "", 4, 4, "", keyval);
+                printf ("{\n%*.*s.seq = NA,\n%*.*s.keyval = %"PRId32" }\n", 4, 4, "", 4, 4, "", keyval);
             } else if(printmode == TGPM_DENSE) {
-                printf ("{NA,%d}\n", keyval);
+                printf ("{NA,%"PRId32"}\n", keyval);
             } else {
-                printf ("{ .seq = NA, .keyval = %d }\n", keyval);
+                printf ("{ .seq = NA, .keyval = %"PRId32" }\n", keyval);
             }
         } else
             printf ("get_key_value: error (%s)\n", dds_err_str(result));
@@ -930,11 +930,11 @@ static void print_seq_OU(dds_time_t *tstart, dds_time_t tnow, dds_entity_t rd __
         print_sampleinfo(tstart, tnow, si, tag);
         if (si->valid_data) {
             if(printmode == TGPM_MULTILINE) {
-                printf ("{\n%*.*s.seq = %u }\n", 4, 4, "", mseq[i]->seq);
+                printf ("{\n%*.*s.seq = %"PRIu32" }\n", 4, 4, "", mseq[i]->seq);
             } else if(printmode == TGPM_DENSE) {
-                printf ("{%u}\n", mseq[i]->seq);
+                printf ("{%"PRIu32"}\n", mseq[i]->seq);
             } else {
-                printf ("{ .seq = %u }\n", mseq[i]->seq);
+                printf ("{ .seq = %"PRIu32" }\n", mseq[i]->seq);
             }
         } else {
             printf ("NA\n");
@@ -1109,7 +1109,7 @@ static void wr_on_publication_matched(dds_entity_t wr __attribute__((unused)), c
     }
 }
 
-static int register_instance_wrapper(dds_entity_t wr, const void *d, const dds_time_t tstamp) {
+static dds_return_t register_instance_wrapper(dds_entity_t wr, const void *d, const dds_time_t tstamp) {
     dds_instance_handle_t handle;
     (void)tstamp;
     return dds_register_instance(wr, &handle, d);
@@ -1795,7 +1795,7 @@ static uint32_t subthread(void *vspec) {
                     rc = dds_get_subscription_matched_status(rd, &status);
                     error_report(rc, "dds_get_subscription_matched_status failed");
                     if (rc == DDS_RETCODE_OK) {
-                        printf("[pre-read: subscription-matched: total=(%"PRIu32" change %d) current=(%"PRIu32" change %d) handle=%"PRIu64"]\n",
+                        printf("[pre-read: subscription-matched: total=(%"PRIu32" change %"PRId32") current=(%"PRIu32" change %"PRId32") handle=%"PRIu64"]\n",
                                 status.total_count, status.total_count_change,
                                 status.current_count,
                                 status.current_count_change,

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -25,6 +25,10 @@ generate_export_header(
 
 # util must NOT link with ddsrt to avoid duplicate symbols in ddsc!
 # ddsrt include directories are required though.
+target_compile_definitions(
+  util
+  PUBLIC
+    $<BUILD_INTERFACE:$<TARGET_PROPERTY:ddsrt,INTERFACE_COMPILE_DEFINITIONS>>)
 target_include_directories(
   util
   PUBLIC


### PR DESCRIPTION
While trying to build for my [FreeRTOS + lwIP Simulator](https://github.com/k0ekk0ek/FreeRTOS-lwIP-Sim) I got linker errors about the *md5_* prefixed functions being exported by lwIP too. Since we might want to use platform native crypto functions at some point, e.g. on Windows, I chose to move them to ddsrt and prefix them accordingly.