### PR TITLE
add RPATH for compiled tools to find the libddsc.so

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -155,6 +155,11 @@ endif()
 include(FileIDs)
 include(GNUInstallDirs)
 include(AnalyzeBuild)
+if(APPLE)
+  set(CMAKE_INSTALL_RPATH "@loader_path/../${CMAKE_INSTALL_LIBDIR}")
+else()
+  set(CMAKE_INSTALL_RPATH "$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
+endif()
 # Include Coverage before CTest so that COVERAGE_COMMAND can be modified
 # in the Coverage module should that ever be necessary.
 include(Coverage)

--- a/src/tools/ddsls/CMakeLists.txt
+++ b/src/tools/ddsls/CMakeLists.txt
@@ -11,11 +11,6 @@
 #
 add_executable(ddsls ddsls.c)
 target_link_libraries(ddsls ddsc)
-if(APPLE)
-  set_target_properties(ddsls PROPERTIES INSTALL_RPATH "@loader_path/../lib")
-else()
-  set_target_properties(ddsls PROPERTIES INSTALL_RPATH "$ORIGIN/../lib")
-endif()
 
 install(
   TARGETS ddsls

--- a/src/tools/ddsls/CMakeLists.txt
+++ b/src/tools/ddsls/CMakeLists.txt
@@ -11,6 +11,11 @@
 #
 add_executable(ddsls ddsls.c)
 target_link_libraries(ddsls ddsc)
+if(APPLE)
+  set_target_properties(ddsls PROPERTIES INSTALL_RPATH "@loader_path/../lib")
+else()
+  set_target_properties(ddsls PROPERTIES INSTALL_RPATH "$ORIGIN/../lib")
+endif()
 
 install(
   TARGETS ddsls

--- a/src/tools/pubsub/CMakeLists.txt
+++ b/src/tools/pubsub/CMakeLists.txt
@@ -11,11 +11,6 @@
 #
 add_executable(pubsub pubsub.c common.c testtype.c porting.c)
 target_link_libraries(pubsub ddsc)
-if(APPLE)
-  set_target_properties(pubsub PROPERTIES INSTALL_RPATH "@loader_path/../lib")
-else()
-  set_target_properties(pubsub PROPERTIES INSTALL_RPATH "$ORIGIN/../lib")
-endif()
 
 if(WIN32)
   target_compile_definitions(pubsub PRIVATE _CRT_SECURE_NO_WARNINGS)

--- a/src/tools/pubsub/CMakeLists.txt
+++ b/src/tools/pubsub/CMakeLists.txt
@@ -11,6 +11,12 @@
 #
 add_executable(pubsub pubsub.c common.c testtype.c porting.c)
 target_link_libraries(pubsub ddsc)
+if(APPLE)
+  set_target_properties(pubsub PROPERTIES INSTALL_RPATH "@loader_path/../lib")
+else()
+  set_target_properties(pubsub PROPERTIES INSTALL_RPATH "$ORIGIN/../lib")
+endif()
+
 if(WIN32)
   target_compile_definitions(pubsub PRIVATE _CRT_SECURE_NO_WARNINGS)
 endif()


### PR DESCRIPTION
When assigning CMAKE_INSTALL_PREFIX into non-default path, e.g. /opt/CycloneDDS. 

```bash
$> cmake -Bbuild -H./src -DCMAKE_INSTALL_PREFIX=/opt/CyclineDDS 
$> sudo cmake --build build --target install 
```
Since libddsc.so is not the default library searching path in this situation, e.g. /opt/CycloneDDS/lib.
Those compiled tools like `ddsls` and `pubsub` are failed to find libddsc.so. 
Add relative rpath "$ORIGIN/../lib" for these targets to fix this problem. 