### PR TITLE
Remove dependency on jdk8 Chocolatey package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,13 +77,6 @@ before_install:
 # The real fix is to wait until Python and pip are both available on the
 # target. Until then download Conan from the official website and simply add
 # the extracted folder to the path.
-#
-# Maven requires JAVA_HOME to be set (at least on Windows), but Windows targets
-# do not come with Java installed. For now it is installed through Chocolatey
-# as a dependency of Maven, hence JAVA_HOME is only available after the
-# package is installed. The problem is that the shell cannot be restarted and
-# the path is not fixed as it contains the version number. To workaround this
-# issue, JAVA_HOME is read from the registry and exported by this script.
 install:
   - if [ "${TRAVIS_OS_NAME}" = "windows" ]; then
       choco install innoextract;

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,9 @@ before_install:
   - if [ "${TRAVIS_OS_NAME}" = "windows" ]; then
       eval "unset CC";
       eval "unset CXX";
+      JAVA_HOME=$(find "/c/Program Files/Android/jdk/" -name "*openjdk*" | sort | head -n 1);
+      export JAVA_HOME;
+      export PATH="${PATH}:${JAVA_HOME}/bin";
     else
       eval "export CC=${C_COMPILER}";
       eval "export CXX=${CXX_COMPILER}";
@@ -83,13 +86,10 @@ before_install:
 # issue, JAVA_HOME is read from the registry and exported by this script.
 install:
   - if [ "${TRAVIS_OS_NAME}" = "windows" ]; then
-      choco install innoextract maven;
+      choco install innoextract;
+      choco install maven --ignore-dependencies;
       wget -q https://dl.bintray.com/conan/installers/conan-win-64_1_10_0.exe;
       innoextract conan-win-64_1_10_0.exe;
-      KEY='HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment';
-      VALUE='JAVA_HOME';
-      JAVA_HOME=$(REG QUERY "${KEY}" -v "${VALUE}" | sed -n 's/^.*JAVA_HOME \+[_A-Z]\+ \+//ip');
-      eval "export JAVA_HOME=\"${JAVA_HOME}\"";
       eval "export PATH=\"$(pwd)/app/conan:${PATH}\"";
     elif [ "${TRAVIS_OS_NAME}" = "osx" ]; then
       eval "$(pyenv init -)";


### PR DESCRIPTION
This pull request removes the dependency on the jdk8 Chocolatey package. The installation of jdk8 package failed because the archive wasn't/isn't available anymore. Luckily the Windows image has the Android SDK installed and OpenJDK 1.8 is available by default. Apart from fixing the issue with failing builds, it also shaves a couple of minutes from the build process and makes the `.travis.yml` a lot easier.

Please consider pulling these changes.