### PR TITLE
Make header files more C++ friendly (and fix a few compiler warnings in ddsperf)

### DIFF
--- a/src/core/ddsc/src/dds__guardcond.h
+++ b/src/core/ddsc/src/dds__guardcond.h
@@ -14,10 +14,18 @@
 
 #include "dds__entity.h"
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 dds_guardcond*
 dds_create_guardcond(
         dds_participant *pp);
 
 DEFINE_ENTITY_LOCK_UNLOCK(inline, dds_guardcond, DDS_KIND_COND_GUARD)
+
+#if defined (__cplusplus)
+}
+#endif
 
 #endif

--- a/src/core/ddsc/src/dds__readcond.h
+++ b/src/core/ddsc/src/dds__readcond.h
@@ -14,11 +14,19 @@
 
 #include "dds__entity.h"
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 dds_readcond *
 dds_create_readcond(
   dds_reader *rd,
   dds_entity_kind_t kind,
   uint32_t mask,
   dds_querycondition_filter_fn filter);
+
+#if defined (__cplusplus)
+}
+#endif
 
 #endif

--- a/src/core/ddsc/src/dds__serdata_builtintopic.h
+++ b/src/core/ddsc/src/dds__serdata_builtintopic.h
@@ -16,6 +16,10 @@
 #include "dds/ddsi/ddsi_serdata.h"
 #include "dds/ddsi/ddsi_sertopic.h"
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 struct ddsi_serdata_builtintopic {
   struct ddsi_serdata c;
   nn_guid_t key;
@@ -38,5 +42,9 @@ extern const struct ddsi_sertopic_ops ddsi_sertopic_ops_builtintopic;
 extern const struct ddsi_serdata_ops ddsi_serdata_ops_builtintopic;
 
 struct ddsi_sertopic *new_sertopic_builtintopic (enum ddsi_sertopic_builtintopic_type type, const char *name, const char *typename);
+
+#if defined (__cplusplus)
+}
+#endif
 
 #endif

--- a/src/core/ddsc/src/dds_init.c
+++ b/src/core/ddsc/src/dds_init.c
@@ -30,6 +30,7 @@
 #include "dds/ddsi/q_entity.h"
 #include "dds/ddsi/q_config.h"
 #include "dds/ddsi/q_gc.h"
+#include "dds/ddsi/q_globals.h"
 #include "dds/version.h"
 
 #define DOMAIN_ID_MIN 0

--- a/src/core/ddsc/src/dds_instance.c
+++ b/src/core/ddsc/src/dds_instance.c
@@ -22,7 +22,7 @@
 #include "dds/ddsi/ddsi_serdata.h"
 #include "dds/ddsi/q_entity.h"
 #include "dds/ddsi/q_thread.h"
-
+#include "dds/ddsi/q_globals.h"
 
 dds_return_t
 dds_writedispose(

--- a/src/core/ddsc/src/dds_read.c
+++ b/src/core/ddsc/src/dds_read.c
@@ -19,6 +19,7 @@
 #include "dds/ddsi/q_thread.h"
 #include "dds/ddsi/q_ephash.h"
 #include "dds/ddsi/q_entity.h"
+#include "dds/ddsi/q_globals.h"
 #include "dds/ddsi/ddsi_sertopic.h"
 
 static dds_retcode_t dds_read_lock (dds_entity_t hdl, dds_reader **reader, dds_readcond **condition, bool only_reader)

--- a/src/core/ddsc/src/dds_reader.c
+++ b/src/core/ddsc/src/dds_reader.c
@@ -23,6 +23,7 @@
 #include "dds__topic.h"
 #include "dds/ddsi/q_entity.h"
 #include "dds/ddsi/q_thread.h"
+#include "dds/ddsi/q_globals.h"
 #include "dds__builtin.h"
 #include "dds/ddsi/ddsi_sertopic.h"
 

--- a/src/core/ddsc/src/dds_serdata_builtintopic.c
+++ b/src/core/ddsc/src/dds_serdata_builtintopic.c
@@ -91,7 +91,7 @@ static void set_topic_type_from_sertopic (struct ddsi_serdata_builtintopic *d, c
   }
   if (!(d->xqos.present & QP_TYPE_NAME))
   {
-    d->xqos.type_name = dds_string_dup (tp->typename);
+    d->xqos.type_name = dds_string_dup (tp->type_name);
     d->xqos.present |= QP_TYPE_NAME;
   }
 }

--- a/src/core/ddsc/src/dds_sertopic_builtintopic.c
+++ b/src/core/ddsc/src/dds_sertopic_builtintopic.c
@@ -21,6 +21,7 @@
 #include "dds/ddsi/q_config.h"
 #include "dds/ddsi/q_freelist.h"
 #include "dds/ddsi/ddsi_sertopic.h"
+#include "dds/ddsi/ddsi_iid.h"
 #include "dds__serdata_builtintopic.h"
 
 /* FIXME: sertopic /= ddstopic so a lot of stuff needs to be moved here from dds_topic.c and the free function needs to be implemented properly */
@@ -30,10 +31,10 @@ struct ddsi_sertopic *new_sertopic_builtintopic (enum ddsi_sertopic_builtintopic
   struct ddsi_sertopic_builtintopic *tp = ddsrt_malloc (sizeof (*tp));
   tp->c.iid = ddsi_iid_gen();
   tp->c.name = dds_string_dup (name);
-  tp->c.typename = dds_string_dup (typename);
-  const size_t name_typename_size = strlen (tp->c.name) + 1 + strlen (tp->c.typename) + 1;
-  tp->c.name_typename = dds_alloc (name_typename_size);
-  snprintf (tp->c.name_typename, name_typename_size, "%s/%s", tp->c.name, tp->c.typename);
+  tp->c.type_name = dds_string_dup (typename);
+  const size_t name_typename_size = strlen (tp->c.name) + 1 + strlen (tp->c.type_name) + 1;
+  tp->c.name_type_name = dds_alloc (name_typename_size);
+  snprintf (tp->c.name_type_name, name_typename_size, "%s/%s", tp->c.name, tp->c.type_name);
   tp->c.ops = &ddsi_sertopic_ops_builtintopic;
   tp->c.serdata_ops = &ddsi_serdata_ops_builtintopic;
   tp->c.serdata_basehash = ddsi_sertopic_compute_serdata_basehash (tp->c.serdata_ops);

--- a/src/core/ddsc/src/dds_topic.c
+++ b/src/core/ddsc/src/dds_topic.c
@@ -35,7 +35,7 @@ DECL_ENTITY_LOCK_UNLOCK(extern inline, dds_topic)
 const ddsrt_avl_treedef_t dds_topictree_def = DDSRT_AVL_TREEDEF_INITIALIZER_INDKEY
 (
   offsetof (struct ddsi_sertopic, avlnode),
-  offsetof (struct ddsi_sertopic, name_typename),
+  offsetof (struct ddsi_sertopic, name_type_name),
   (int (*) (const void *, const void *)) strcmp,
   0
 );
@@ -285,7 +285,7 @@ static bool dupdef_qos_ok(const dds_qos_t *qos, const struct ddsi_sertopic *st)
 
 static bool sertopic_equivalent (const struct ddsi_sertopic *a, const struct ddsi_sertopic *b)
 {
-  if (strcmp (a->name_typename, b->name_typename) != 0)
+  if (strcmp (a->name_type_name, b->name_type_name) != 0)
     return false;
   if (a->serdata_basehash != b->serdata_basehash)
     return false;
@@ -447,9 +447,9 @@ dds_create_topic(
     st->c.iid = ddsi_iid_gen ();
     st->c.status_cb = dds_topic_status_cb;
     st->c.status_cb_entity = NULL; /* set by dds_create_topic_arbitrary */
-    st->c.name_typename = key;
+    st->c.name_type_name = key;
     st->c.name = dds_string_dup (name);
-    st->c.typename = dds_string_dup (typename);
+    st->c.type_name = dds_string_dup (typename);
     st->c.ops = &ddsi_sertopic_ops_default;
     st->c.serdata_ops = desc->m_nkeys ? &ddsi_serdata_ops_cdr : &ddsi_serdata_ops_cdr_nokey;
     st->c.serdata_basehash = ddsi_sertopic_compute_serdata_basehash (st->c.serdata_ops);
@@ -471,7 +471,7 @@ dds_create_topic(
 
     /* Set Topic meta data (for SEDP publication) */
     plist.qos.topic_name = dds_string_dup (st->c.name);
-    plist.qos.type_name = dds_string_dup (st->c.typename);
+    plist.qos.type_name = dds_string_dup (st->c.type_name);
     plist.qos.present |= (QP_TOPIC_NAME | QP_TYPE_NAME);
     if (desc->m_meta) {
         plist.type_description = dds_string_dup (desc->m_meta);
@@ -643,7 +643,7 @@ dds_get_type_name(
         ret = DDS_ERRNO(rc);
         goto fail;
     }
-    (void)snprintf(name, size, "%s", t->m_stopic->typename);
+    (void)snprintf(name, size, "%s", t->m_stopic->type_name);
     dds_topic_unlock(t);
     ret = DDS_RETCODE_OK;
 fail:

--- a/src/core/ddsc/src/dds_whc.c
+++ b/src/core/ddsc/src/dds_whc.c
@@ -27,6 +27,7 @@
 #include "dds/ddsi/q_time.h"
 #include "dds/ddsi/q_rtps.h"
 #include "dds/ddsi/q_freelist.h"
+#include "dds/ddsi/q_globals.h"
 
 #define USE_EHH 0
 

--- a/src/core/ddsc/src/dds_writer.c
+++ b/src/core/ddsc/src/dds_writer.c
@@ -14,6 +14,7 @@
 #include "dds/dds.h"
 #include "dds/version.h"
 #include "dds/ddsi/q_config.h"
+#include "dds/ddsi/q_globals.h"
 #include "dds/ddsi/q_entity.h"
 #include "dds/ddsi/q_thread.h"
 #include "dds/ddsi/q_xmsg.h"

--- a/src/core/ddsi/include/dds/ddsi/ddsi_ipaddr.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_ipaddr.h
@@ -14,11 +14,19 @@
 
 #include "dds/ddsi/ddsi_tran.h"
 
-enum ddsi_nearby_address_result ddsi_ipaddr_is_nearby_address (ddsi_tran_factory_t tran, const nn_locator_t *loc, size_t ninterf, const struct nn_interface interf[]);
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+enum ddsi_nearby_address_result ddsi_ipaddr_is_nearby_address (ddsi_tran_factory_t tran, const nn_locator_t *loc, size_t ninterf, const struct nn_interface *interf);
 enum ddsi_locator_from_string_result ddsi_ipaddr_from_string (ddsi_tran_factory_t tran, nn_locator_t *loc, const char *str, int32_t kind);
 int ddsi_ipaddr_compare (const struct sockaddr *const sa1, const struct sockaddr *const sa2);
 char *ddsi_ipaddr_to_string (ddsi_tran_factory_t tran, char *dst, size_t sizeof_dst, const nn_locator_t *loc, int with_port);
 void ddsi_ipaddr_to_loc (nn_locator_t *dst, const struct sockaddr *src, int32_t kind);
 void ddsi_ipaddr_from_loc (struct sockaddr_storage *dst, const nn_locator_t *src);
+
+#if defined (__cplusplus)
+}
+#endif
 
 #endif

--- a/src/core/ddsi/include/dds/ddsi/ddsi_mcgroup.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_mcgroup.h
@@ -14,6 +14,10 @@
 
 #include "dds/ddsi/ddsi_tran.h"
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 struct nn_group_membership;
 
 struct nn_group_membership *new_group_membership (void);
@@ -22,5 +26,9 @@ int ddsi_join_mc (ddsi_tran_conn_t conn, const nn_locator_t *srcip, const nn_loc
 int ddsi_leave_mc (ddsi_tran_conn_t conn, const nn_locator_t *srcip, const nn_locator_t *mcip);
 void ddsi_transfer_group_membership (ddsi_tran_conn_t conn, ddsi_tran_conn_t newconn);
 int ddsi_rejoin_transferred_mcgroups (ddsi_tran_conn_t conn);
+
+#if defined (__cplusplus)
+}
+#endif
 
 #endif

--- a/src/core/ddsi/include/dds/ddsi/ddsi_raweth.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_raweth.h
@@ -12,6 +12,14 @@
 #ifndef DDSI_RAWETH_H
 #define DDSI_RAWETH_H
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 int ddsi_raweth_init (void);
+
+#if defined (__cplusplus)
+}
+#endif
 
 #endif

--- a/src/core/ddsi/include/dds/ddsi/ddsi_rhc_plugin.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_rhc_plugin.h
@@ -12,6 +12,10 @@
 #ifndef DDSI_RHC_PLUGIN_H
 #define DDSI_RHC_PLUGIN_H
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 struct rhc;
 struct nn_xqos;
 struct ddsi_tkmap_instance;
@@ -41,5 +45,9 @@ struct ddsi_rhc_plugin
 };
 
 DDS_EXPORT void make_proxy_writer_info(struct proxy_writer_info *pwr_info, const struct entity_common *e, const struct nn_xqos *xqos);
+
+#if defined (__cplusplus)
+}
+#endif
 
 #endif

--- a/src/core/ddsi/include/dds/ddsi/ddsi_serdata_default.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_serdata_default.h
@@ -22,6 +22,10 @@
 #include "dds/dds.h"
 #include "dds__topic.h"
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 #if DDSRT_ENDIAN == DDSRT_LITTLE_ENDIAN
 #define CDR_BE 0x0000
 #define CDR_LE 0x0100
@@ -124,5 +128,9 @@ extern DDS_EXPORT const struct ddsi_serdata_ops ddsi_serdata_ops_rawcdr;
 
 struct serdatapool * ddsi_serdatapool_new (void);
 void ddsi_serdatapool_free (struct serdatapool * pool);
+
+#if defined (__cplusplus)
+}
+#endif
 
 #endif

--- a/src/core/ddsi/include/dds/ddsi/ddsi_sertopic.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_sertopic.h
@@ -16,6 +16,10 @@
 #include "dds/ddsrt/avl.h"
 #include "dds/ddsc/dds_public_alloc.h"
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 struct ddsi_serdata;
 struct ddsi_serdata_ops;
 
@@ -29,9 +33,9 @@ struct ddsi_sertopic {
   const struct ddsi_sertopic_ops *ops;
   const struct ddsi_serdata_ops *serdata_ops;
   uint32_t serdata_basehash;
-  char *name_typename;
+  char *name_type_name;
   char *name;
-  char *typename;
+  char *type_name;
   uint64_t iid;
   ddsrt_atomic_uint32_t refc; /* counts refs from entities, not from data */
 
@@ -39,12 +43,14 @@ struct ddsi_sertopic {
   struct dds_topic * status_cb_entity;
 };
 
+/* Called when the refcount dropped to zero */
 typedef void (*ddsi_sertopic_deinit_t) (struct ddsi_sertopic *tp);
 
-/* Release any memory allocated by ddsi_sertopic_to_sample */
+/* Zero out a sample, used for generating samples from just a key value and in cleaning up
+   after dds_return_loan */
 typedef void (*ddsi_sertopic_zero_samples_t) (const struct ddsi_sertopic *d, void *samples, size_t count);
 
-/* Release any memory allocated by ddsi_sertopic_to_sample */
+/* (Re)allocate an array of samples, used in growing loaned sample arrays in dds_read */
 typedef void (*ddsi_sertopic_realloc_samples_t) (void **ptrs, const struct ddsi_sertopic *d, void *old, size_t oldcount, size_t count);
 
 /* Release any memory allocated by ddsi_sertopic_to_sample (also undo sertopic_alloc_sample if "op" so requests) */
@@ -85,5 +91,9 @@ DDS_EXPORT inline void *ddsi_sertopic_alloc_sample (const struct ddsi_sertopic *
 DDS_EXPORT inline void ddsi_sertopic_free_sample (const struct ddsi_sertopic *tp, void *sample, dds_free_op_t op) {
   ddsi_sertopic_free_samples (tp, &sample, 1, op);
 }
+
+#if defined (__cplusplus)
+}
+#endif
 
 #endif

--- a/src/core/ddsi/include/dds/ddsi/ddsi_ssl.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_ssl.h
@@ -20,8 +20,16 @@
 #endif
 #include <openssl/ssl.h>
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 struct ddsi_ssl_plugins;
 void ddsi_ssl_config_plugin (struct ddsi_ssl_plugins *plugin);
+
+#if defined (__cplusplus)
+}
+#endif
 
 #endif
 #endif

--- a/src/core/ddsi/include/dds/ddsi/ddsi_tcp.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_tcp.h
@@ -18,6 +18,10 @@
 
 #include "dds/ddsi/ddsi_ssl.h"
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 struct ddsi_ssl_plugins
 {
   bool (*init) (void);
@@ -31,8 +35,20 @@ struct ddsi_ssl_plugins
   SSL * (*accept) (BIO *bio, ddsrt_socket_t *sock);
 };
 
+#if defined (__cplusplus)
+}
+#endif
+
+#endif
+
+#if defined (__cplusplus)
+extern "C" {
 #endif
 
 int ddsi_tcp_init (void);
+
+#if defined (__cplusplus)
+}
+#endif
 
 #endif

--- a/src/core/ddsi/include/dds/ddsi/ddsi_tran.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_tran.h
@@ -14,8 +14,15 @@
 
 /* DDSI Transport module */
 
-#include "dds/ddsi/q_globals.h"
+#include "dds/ddsrt/ifaddrs.h"
+#include "dds/ddsrt/atomics.h"
 #include "dds/ddsi/q_protocol.h"
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+struct nn_interface;
 
 /* Types supporting handles */
 
@@ -69,7 +76,7 @@ enum ddsi_nearby_address_result {
   DNAR_SAME
 };
 
-typedef enum ddsi_nearby_address_result (*ddsi_is_nearby_address_fn_t) (ddsi_tran_factory_t tran, const nn_locator_t *loc, size_t ninterf, const struct nn_interface interf[]);
+typedef enum ddsi_nearby_address_result (*ddsi_is_nearby_address_fn_t) (ddsi_tran_factory_t tran, const nn_locator_t *loc, size_t ninterf, const struct nn_interface *interf);
 
 enum ddsi_locator_from_string_result {
   AFSR_OK,      /* conversion succeeded */
@@ -239,7 +246,7 @@ void ddsi_conn_transfer_group_membership (ddsi_tran_conn_t conn, ddsi_tran_conn_
 int ddsi_conn_rejoin_transferred_mcgroups (ddsi_tran_conn_t conn);
 int ddsi_is_mcaddr (const nn_locator_t *loc);
 int ddsi_is_ssm_mcaddr (const nn_locator_t *loc);
-enum ddsi_nearby_address_result ddsi_is_nearby_address (const nn_locator_t *loc, size_t ninterf, const struct nn_interface interf[]);
+enum ddsi_nearby_address_result ddsi_is_nearby_address (const nn_locator_t *loc, size_t ninterf, const struct nn_interface *interf);
 
 enum ddsi_locator_from_string_result ddsi_locator_from_string (nn_locator_t *loc, const char *str);
 
@@ -270,5 +277,9 @@ inline ddsi_tran_conn_t ddsi_listener_accept (ddsi_tran_listener_t listener) {
 }
 void ddsi_listener_unblock (ddsi_tran_listener_t listener);
 void ddsi_listener_free (ddsi_tran_listener_t listener);
+
+#if defined (__cplusplus)
+}
+#endif
 
 #endif

--- a/src/core/ddsi/include/dds/ddsi/ddsi_udp.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_udp.h
@@ -12,6 +12,14 @@
 #ifndef _DDSI_UDP_H_
 #define _DDSI_UDP_H_
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 int ddsi_udp_init (void);
+
+#if defined (__cplusplus)
+}
+#endif
 
 #endif

--- a/src/core/ddsi/include/dds/ddsi/q_bitset.h
+++ b/src/core/ddsi/include/dds/ddsi/q_bitset.h
@@ -18,6 +18,10 @@
 
 #include "dds/ddsi/q_unused.h"
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 inline int nn_bitset_isset (uint32_t numbits, const uint32_t *bits, uint32_t idx)
 {
   return idx < numbits && (bits[idx/32] & (UINT32_C(1) << (31 - (idx%32))));
@@ -51,5 +55,9 @@ inline void nn_bitset_one (uint32_t numbits, uint32_t *bits)
     bits[k] &= ~(~UINT32_C(0) >> n);
   }
 }
+
+#if defined (__cplusplus)
+}
+#endif
 
 #endif /* NN_BITSET_H */

--- a/src/core/ddsi/include/dds/ddsi/q_bswap.h
+++ b/src/core/ddsi/include/dds/ddsi/q_bswap.h
@@ -19,6 +19,10 @@
 #include "dds/ddsi/q_rtps.h" /* for nn_guid_t, nn_guid_prefix_t */
 #include "dds/ddsi/q_protocol.h" /* for nn_sequence_number_t */
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 inline uint16_t bswap2u (uint16_t x)
 {
   return (uint16_t) ((x >> 8) | (x << 8));
@@ -82,10 +86,6 @@ inline void bswapSN (nn_sequence_number_t *sn)
 #define fromBE4u(x) (x)
 #define fromBE8(x) (x)
 #define fromBE8u(x) (x)
-#endif
-
-#if defined (__cplusplus)
-extern "C" {
 #endif
 
 nn_guid_prefix_t nn_hton_guid_prefix (nn_guid_prefix_t p);

--- a/src/core/ddsi/include/dds/ddsi/q_debmon.h
+++ b/src/core/ddsi/include/dds/ddsi/q_debmon.h
@@ -12,6 +12,10 @@
 #ifndef Q_DEBMON_H
 #define Q_DEBMON_H
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 struct debug_monitor;
 typedef int (*debug_monitor_cpf_t) (ddsi_tran_conn_t conn, const char *fmt, ...);
 typedef int (*debug_monitor_plugin_t) (ddsi_tran_conn_t conn, debug_monitor_cpf_t cpf, void *arg);
@@ -20,4 +24,8 @@ struct debug_monitor *new_debug_monitor (int port);
 void add_debug_monitor_plugin (struct debug_monitor *dm, debug_monitor_plugin_t fn, void *arg);
 void free_debug_monitor (struct debug_monitor *dm);
 
-#endif /* defined(__ospli_osplo__q_debmon__) */
+#if defined (__cplusplus)
+}
+#endif
+
+#endif

--- a/src/core/ddsi/include/dds/ddsi/q_entity.h
+++ b/src/core/ddsi/include/dds/ddsi/q_entity.h
@@ -14,6 +14,7 @@
 
 #include "dds/ddsrt/atomics.h"
 #include "dds/ddsrt/avl.h"
+#include "dds/ddsrt/sync.h"
 #include "dds/ddsi/q_rtps.h"
 #include "dds/ddsi/q_protocol.h"
 #include "dds/ddsi/q_lat_estim.h"
@@ -32,11 +33,14 @@ struct xevent;
 struct nn_reorder;
 struct nn_defrag;
 struct nn_dqueue;
+struct nn_rsample_info;
+struct nn_rdata;
 struct addrset;
 struct ddsi_sertopic;
 struct whc;
 struct nn_xqos;
 struct nn_plist;
+struct lease;
 
 struct proxy_group;
 struct proxy_endpoint_common;
@@ -159,7 +163,7 @@ struct participant
   unsigned bes; /* built-in endpoint set */
   unsigned prismtech_bes; /* prismtech-specific extension of built-in endpoints set */
   unsigned is_ddsi2_pp: 1; /* true for the "federation leader", the ddsi2 participant itself in OSPL; FIXME: probably should use this for broker mode as well ... */
-  nn_plist_t *plist; /* settings/QoS for this participant */
+  struct nn_plist *plist; /* settings/QoS for this participant */
   struct xevent *spdp_xevent; /* timed event for periodically publishing SPDP */
   struct xevent *pmd_update_xevent; /* timed event for periodically publishing ParticipantMessageData */
   nn_locator_t m_locator;
@@ -294,7 +298,7 @@ struct proxy_participant
   unsigned bes; /* built-in endpoint set */
   unsigned prismtech_bes; /* prismtech-specific extension of built-in endpoints set */
   nn_guid_t privileged_pp_guid; /* if this PP depends on another PP for its SEDP writing */
-  nn_plist_t *plist; /* settings/QoS for this participant */
+  struct nn_plist *plist; /* settings/QoS for this participant */
   ddsrt_atomic_voidp_t lease; /* lease object for this participant, for automatic leases */
   struct addrset *as_default; /* default address set to use for user data traffic */
   struct addrset *as_meta; /* default address set to use for discovery traffic */

--- a/src/core/ddsi/include/dds/ddsi/q_freelist.h
+++ b/src/core/ddsi/include/dds/ddsi/q_freelist.h
@@ -15,6 +15,10 @@
 #include "dds/ddsrt/atomics.h"
 #include "dds/ddsrt/sync.h"
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 #define FREELIST_SIMPLE 1
 #define FREELIST_ATOMIC_LIFO 2
 #define FREELIST_DOUBLE 3
@@ -73,5 +77,9 @@ void nn_freelist_fini (struct nn_freelist *fl, void (*free) (void *elem));
 bool nn_freelist_push (struct nn_freelist *fl, void *elem);
 void *nn_freelist_pushmany (struct nn_freelist *fl, void *first, void *last, uint32_t n);
 void *nn_freelist_pop (struct nn_freelist *fl);
+
+#if defined (__cplusplus)
+}
+#endif
 
 #endif /* NN_FREELIST_H */

--- a/src/core/ddsi/include/dds/ddsi/q_init.h
+++ b/src/core/ddsi/include/dds/ddsi/q_init.h
@@ -12,7 +12,15 @@
 #ifndef Q_INIT_H
 #define Q_INIT_H
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 int create_multicast_sockets(void);
 int joinleave_spdp_defmcip (int dojoin);
+
+#if defined (__cplusplus)
+}
+#endif
 
 #endif

--- a/src/core/ddsi/include/dds/ddsi/q_inverse_uint32_set.h
+++ b/src/core/ddsi/include/dds/ddsi/q_inverse_uint32_set.h
@@ -14,6 +14,10 @@
 
 #include "dds/ddsrt/avl.h"
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 struct inverse_uint32_set_node {
   ddsrt_avl_node_t avlnode;
   uint32_t min, max;
@@ -28,5 +32,9 @@ void inverse_uint32_set_init(struct inverse_uint32_set *set, uint32_t min, uint3
 void inverse_uint32_set_fini(struct inverse_uint32_set *set);
 int inverse_uint32_set_alloc(uint32_t * const id, struct inverse_uint32_set *set);
 void inverse_uint32_set_free(struct inverse_uint32_set *set, uint32_t id);
+
+#if defined (__cplusplus)
+}
+#endif
 
 #endif

--- a/src/core/ddsi/include/dds/ddsi/q_radmin.h
+++ b/src/core/ddsi/include/dds/ddsi/q_radmin.h
@@ -14,7 +14,6 @@
 
 #include "dds/ddsrt/atomics.h"
 #include "dds/ddsrt/threads.h"
-#include "dds/ddsi/q_rtps.h"
 #include "dds/ddsi/ddsi_tran.h"
 
 #if defined (__cplusplus)

--- a/src/core/ddsi/include/dds/ddsi/q_xmsg.h
+++ b/src/core/ddsi/include/dds/ddsi/q_xmsg.h
@@ -29,6 +29,7 @@ struct proxy_writer;
 
 struct nn_prismtech_participant_version_info;
 struct nn_prismtech_writer_info;
+struct nn_prismtech_eotinfo;
 struct nn_xmsgpool;
 struct nn_xmsg_data;
 struct nn_xmsg;

--- a/src/core/ddsi/src/ddsi_eth.h
+++ b/src/core/ddsi/src/ddsi_eth.h
@@ -14,6 +14,14 @@
 
 #include "dds/ddsi/ddsi_tran.h"
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 int ddsi_eth_enumerate_interfaces(ddsi_tran_factory_t fact, ddsrt_ifaddrs_t **ifs);
+
+#if defined (__cplusplus)
+}
+#endif
 
 #endif /* DDSI_ETH_H */

--- a/src/core/ddsi/src/ddsi_ipaddr.c
+++ b/src/core/ddsi/src/ddsi_ipaddr.c
@@ -18,6 +18,7 @@
 #include "dds/ddsi/ddsi_ipaddr.h"
 #include "dds/ddsi/q_nwif.h"
 #include "dds/ddsi/q_config.h"
+#include "dds/ddsi/q_globals.h"
 
 int ddsi_ipaddr_compare (const struct sockaddr *const sa1, const struct sockaddr *const sa2)
 {

--- a/src/core/ddsi/src/ddsi_mcgroup.c
+++ b/src/core/ddsi/src/ddsi_mcgroup.c
@@ -20,6 +20,7 @@
 #include "dds/ddsi/ddsi_mcgroup.h"
 #include "dds/ddsi/q_config.h"
 #include "dds/ddsi/q_log.h"
+#include "dds/ddsi/q_globals.h"
 #include "dds/ddsrt/avl.h"
 
 struct nn_group_membership_node {

--- a/src/core/ddsi/src/ddsi_raweth.c
+++ b/src/core/ddsi/src/ddsi_raweth.c
@@ -18,6 +18,7 @@
 #include "dds/ddsi/q_log.h"
 #include "dds/ddsi/q_error.h"
 #include "dds/ddsi/q_pcap.h"
+#include "dds/ddsi/q_globals.h"
 #include "dds/ddsrt/atomics.h"
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/log.h"

--- a/src/core/ddsi/src/ddsi_serdata_default.c
+++ b/src/core/ddsi/src/ddsi_serdata_default.c
@@ -24,6 +24,7 @@
 #include "dds/ddsi/ddsi_tkmap.h"
 #include "dds__stream.h"
 #include "dds/ddsi/q_radmin.h"
+#include "dds/ddsi/q_globals.h"
 #include "dds/ddsi/ddsi_serdata_default.h"
 
 #define MAX_POOL_SIZE 16384

--- a/src/core/ddsi/src/ddsi_sertopic.c
+++ b/src/core/ddsi/src/ddsi_sertopic.c
@@ -37,9 +37,9 @@ void ddsi_sertopic_unref (struct ddsi_sertopic *sertopic)
     if (ddsrt_atomic_dec32_ov (&sertopic->refc) == 1)
     {
       ddsi_sertopic_deinit (sertopic);
-      ddsrt_free (sertopic->name_typename);
+      ddsrt_free (sertopic->name_type_name);
       ddsrt_free (sertopic->name);
-      ddsrt_free (sertopic->typename);
+      ddsrt_free (sertopic->type_name);
       ddsrt_free (sertopic);
     }
   }

--- a/src/core/ddsi/src/ddsi_tcp.c
+++ b/src/core/ddsi/src/ddsi_tcp.c
@@ -25,6 +25,7 @@
 #include "dds/ddsi/q_config.h"
 #include "dds/ddsi/q_log.h"
 #include "dds/ddsi/q_entity.h"
+#include "dds/ddsi/q_globals.h"
 
 #define INVALID_PORT (~0u)
 

--- a/src/core/ddsi/src/ddsi_tran.c
+++ b/src/core/ddsi/src/ddsi_tran.c
@@ -19,6 +19,7 @@
 #include "dds/ddsi/ddsi_tran.h"
 #include "dds/ddsi/q_config.h"
 #include "dds/ddsi/q_log.h"
+#include "dds/ddsi/q_globals.h"
 
 static ddsi_tran_factory_t ddsi_tran_factories = NULL;
 

--- a/src/core/ddsi/src/ddsi_udp.c
+++ b/src/core/ddsi/src/ddsi_udp.c
@@ -25,6 +25,7 @@
 #include "dds/ddsi/q_config.h"
 #include "dds/ddsi/q_log.h"
 #include "dds/ddsi/q_pcap.h"
+#include "dds/ddsi/q_globals.h"
 
 extern void ddsi_factory_conn_init (ddsi_tran_factory_t factory, ddsi_tran_conn_t conn);
 

--- a/src/core/ddsi/src/q_debmon.c
+++ b/src/core/ddsi/src/q_debmon.c
@@ -121,7 +121,7 @@ static int print_any_endpoint_common (ddsi_tran_conn_t conn, const char *label, 
     if (xqos->partition.n > 1) cpf (conn, "}");
     x += cpf (conn, ".%s/%s",
               topic && topic->name ? topic->name : (xqos->present & QP_TOPIC_NAME) ? xqos->topic_name : "(null)",
-              topic && topic->typename ? topic->typename : (xqos->present & QP_TYPE_NAME) ? xqos->type_name : "(null)");
+              topic && topic->type_name ? topic->type_name : (xqos->present & QP_TYPE_NAME) ? xqos->type_name : "(null)");
   }
   cpf (conn, "\n");
   return x;

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -2383,7 +2383,7 @@ static void new_reader_writer_common (const struct nn_guid *guid, const struct d
           PGUID (*guid),
           partition, partition_suffix,
           topic ? topic->name : "(null)",
-          topic ? topic->typename : "(null)");
+          topic ? topic->type_name : "(null)");
 }
 
 static void endpoint_common_init (struct entity_common *e, struct endpoint_common *c, enum entity_kind kind, const struct nn_guid *guid, const struct nn_guid *group_guid, struct participant *pp)
@@ -2415,7 +2415,7 @@ static int set_topic_type_name (nn_xqos_t *xqos, const struct ddsi_sertopic * to
   if (!(xqos->present & QP_TYPE_NAME) && topic)
   {
     xqos->present |= QP_TYPE_NAME;
-    xqos->type_name = ddsrt_strdup (topic->typename);
+    xqos->type_name = ddsrt_strdup (topic->type_name);
   }
   if (!(xqos->present & QP_TOPIC_NAME) && topic)
   {
@@ -2881,7 +2881,7 @@ struct local_orphan_writer *new_local_orphan_writer (nn_entityid_t entityid, str
   struct writer *wr;
   nn_mtime_t tnow = now_mt ();
 
-  DDS_LOG(DDS_LC_DISCOVERY, "new_local_orphan_writer(%s/%s)\n", topic->name, topic->typename);
+  DDS_LOG(DDS_LC_DISCOVERY, "new_local_orphan_writer(%s/%s)\n", topic->name, topic->type_name);
   lowr = ddsrt_malloc (sizeof (*lowr));
   wr = &lowr->wr;
 

--- a/src/core/ddsi/src/q_plist.c
+++ b/src/core/ddsi/src/q_plist.c
@@ -28,6 +28,7 @@
 #include "dds/ddsi/q_xmsg.h"
 
 #include "dds/ddsi/q_config.h"
+#include "dds/ddsi/q_globals.h"
 #include "dds/ddsi/q_protocol.h" /* for NN_STATUSINFO_... */
 #include "dds/ddsi/q_radmin.h" /* for nn_plist_quickscan */
 #include "dds/ddsi/q_static_assert.h"

--- a/src/core/ddsi/src/q_receive.c
+++ b/src/core/ddsi/src/q_receive.c
@@ -1885,7 +1885,7 @@ static struct ddsi_serdata *extract_sample_from_data
       "data(application, vendor %u.%u): %x:%x:%x:%x #%"PRId64": deserialization %s/%s failed (%s)\n",
       sampleinfo->rst->vendor.id[0], sampleinfo->rst->vendor.id[1],
       PGUID (guid), sampleinfo->seq,
-      topic->name, topic->typename,
+      topic->name, topic->type_name,
       failmsg ? failmsg : "for reasons unknown"
     );
   }
@@ -2388,7 +2388,7 @@ static void drop_oversize (struct receiver_state *rst, struct nn_rmsg *rmsg, con
     if (gap_was_valuable)
     {
       const char *tname = pwr->c.topic ? pwr->c.topic->name : "(null)";
-      const char *ttname = pwr->c.topic ? pwr->c.topic->typename : "(null)";
+      const char *ttname = pwr->c.topic ? pwr->c.topic->type_name : "(null)";
       DDS_WARNING ("dropping oversize (%u > %u) sample %"PRId64" from remote writer %x:%x:%x:%x %s/%s\n",
                    sampleinfo->size, config.max_sample_size, sampleinfo->seq,
                    PGUIDPREFIX (rst->src_guid_prefix), msg->writerId.u,

--- a/src/core/ddsi/src/q_transmit.c
+++ b/src/core/ddsi/src/q_transmit.c
@@ -868,7 +868,7 @@ static int insert_sample_in_whc (struct writer *wr, seqno_t seq, struct nn_plist
     char ppbuf[1024];
     int tmp;
     const char *tname = wr->topic ? wr->topic->name : "(null)";
-    const char *ttname = wr->topic ? wr->topic->typename : "(null)";
+    const char *ttname = wr->topic ? wr->topic->type_name : "(null)";
     ppbuf[0] = '\0';
     tmp = sizeof (ppbuf) - 1;
     DDS_TRACE("write_sample %x:%x:%x:%x #%"PRId64"", PGUID (wr->e.guid), seq);
@@ -1043,7 +1043,7 @@ static int write_sample_eot (struct thread_state1 * const ts1, struct nn_xpack *
     char ppbuf[1024];
     int tmp;
     const char *tname = wr->topic ? wr->topic->name : "(null)";
-    const char *ttname = wr->topic ? wr->topic->typename : "(null)";
+    const char *ttname = wr->topic ? wr->topic->type_name : "(null)";
     ppbuf[0] = '\0';
     tmp = sizeof (ppbuf) - 1;
     DDS_WARNING ("dropping oversize (%u > %u) sample from local writer %x:%x:%x:%x %s/%s:%s%s\n",

--- a/src/ddsrt/include/dds/ddsrt/atomics/arm.h
+++ b/src/ddsrt/include/dds/ddsrt/atomics/arm.h
@@ -12,6 +12,10 @@
 #ifndef DDSRT_ATOMICS_ARM_H
 #define DDSRT_ATOMICS_ARM_H
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 #if !defined(__arm__)
 #define __arm__
 #endif
@@ -209,5 +213,8 @@ inline void ddsrt_atomic_fence_rel (void) {
     ddsrt_atomic_fence ();
 }
 
-#endif /* DDSRT_ATOMICS_ARM_H */
+#if defined (__cplusplus)
+}
+#endif
 
+#endif /* DDSRT_ATOMICS_ARM_H */

--- a/src/ddsrt/include/dds/ddsrt/atomics/gcc.h
+++ b/src/ddsrt/include/dds/ddsrt/atomics/gcc.h
@@ -14,6 +14,10 @@
 
 #include "dds/ddsrt/misc.h"
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 #if ( DDSRT_HAVE_ATOMIC64 && __GCC_HAVE_SYNC_COMPARE_AND_SWAP_16) || \
     (!DDSRT_HAVE_ATOMIC64 && __GCC_HAVE_SYNC_COMPARE_AND_SWAP_8)
 # define DDSRT_HAVE_ATOMIC_LIFO 1
@@ -287,5 +291,8 @@ inline void ddsrt_atomic_fence_rel (void) {
   ddsrt_atomic_fence ();
 }
 
-#endif /* DDSRT_ATOMICS_GCC_H */
+#if defined (__cplusplus)
+}
+#endif
 
+#endif /* DDSRT_ATOMICS_GCC_H */

--- a/src/ddsrt/include/dds/ddsrt/atomics/msvc.h
+++ b/src/ddsrt/include/dds/ddsrt/atomics/msvc.h
@@ -14,6 +14,10 @@
 
 #include "dds/ddsrt/misc.h"
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 /* x86 has supported 64-bit CAS for a long time, so Windows ought to
    provide all the interlocked operations for 64-bit operands on x86
    platforms, but it doesn't. */
@@ -295,5 +299,8 @@ inline void ddsrt_atomic_fence_rel (void) {
 
 #undef DDSRT_ATOMIC_PTROP
 
-#endif /* DDSRT_ATOMICS_MSVC_H */
+#if defined (__cplusplus)
+}
+#endif
 
+#endif /* DDSRT_ATOMICS_MSVC_H */

--- a/src/ddsrt/include/dds/ddsrt/atomics/sun.h
+++ b/src/ddsrt/include/dds/ddsrt/atomics/sun.h
@@ -11,6 +11,10 @@
  */
 #include <atomic.h>
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 #define DDSRT_ATOMIC64_SUPPORT 1
 
 /* LD, ST */
@@ -239,3 +243,6 @@ inline void ddsrt_atomic_fence_rel (void) {
   membar_exit ();
 }
 
+#if defined (__cplusplus)
+}
+#endif

--- a/src/ddsrt/include/dds/ddsrt/cdtors.h
+++ b/src/ddsrt/include/dds/ddsrt/cdtors.h
@@ -15,10 +15,18 @@
 #include "dds/export.h"
 #include "dds/ddsrt/sync.h"
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 DDS_EXPORT void ddsrt_init(void);
 
 DDS_EXPORT void ddsrt_fini(void);
 
 DDS_EXPORT ddsrt_mutex_t *ddsrt_get_singleton_mutex(void);
+
+#if defined (__cplusplus)
+}
+#endif
 
 #endif /* DDSRT_CDTORS_H */

--- a/src/ddsrt/include/dds/ddsrt/md5.h
+++ b/src/ddsrt/include/dds/ddsrt/md5.h
@@ -63,6 +63,7 @@
 #define DDSRT_MD5_H
 
 #include <stddef.h>
+#include "dds/export.h"
 
 /*
  * This package supports both compile-time and run-time determination of CPU
@@ -90,13 +91,13 @@ extern "C"
 #endif
 
 /* Initialize the algorithm. */
-void ddsrt_md5_init(ddsrt_md5_state_t *pms);
+DDS_EXPORT void ddsrt_md5_init(ddsrt_md5_state_t *pms);
 
 /* Append a string to the message. */
-void ddsrt_md5_append(ddsrt_md5_state_t *pms, const ddsrt_md5_byte_t *data, unsigned nbytes);
+DDS_EXPORT void ddsrt_md5_append(ddsrt_md5_state_t *pms, const ddsrt_md5_byte_t *data, unsigned nbytes);
 
 /* Finish the message and return the digest. */
-void ddsrt_md5_finish(ddsrt_md5_state_t *pms, ddsrt_md5_byte_t digest[16]);
+DDS_EXPORT void ddsrt_md5_finish(ddsrt_md5_state_t *pms, ddsrt_md5_byte_t digest[16]);
 
 #ifdef __cplusplus
 }  /* end extern "C" */

--- a/src/ddsrt/include/dds/ddsrt/retcode.h
+++ b/src/ddsrt/include/dds/ddsrt/retcode.h
@@ -5,6 +5,10 @@
 
 #include "dds/export.h"
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 typedef int32_t dds_retcode_t;
 
 /*
@@ -85,5 +89,9 @@ typedef int32_t dds_retcode_t;
  * @returns  String corresponding to the error value
  */
 DDS_EXPORT const char *dds_strretcode(dds_retcode_t ret);
+
+#if defined (__cplusplus)
+}
+#endif
 
 #endif /* DDS_RETCODE_H */

--- a/src/ddsrt/include/dds/ddsrt/rusage.h
+++ b/src/ddsrt/include/dds/ddsrt/rusage.h
@@ -17,6 +17,10 @@
 #include "dds/ddsrt/time.h"
 #include "dds/ddsrt/retcode.h"
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 typedef struct {
   dds_time_t utime; /* User CPU time used. */
   dds_time_t stime; /* System CPU time used. */
@@ -46,5 +50,9 @@ typedef struct {
  *             An unidentified error occurred.
  */
 DDS_EXPORT dds_retcode_t ddsrt_getrusage(int who, ddsrt_rusage_t *usage);
+
+#if defined (__cplusplus)
+}
+#endif
 
 #endif /* DDSRT_RUSAGE_H */

--- a/src/ddsrt/include/dds/ddsrt/sockets.h
+++ b/src/ddsrt/include/dds/ddsrt/sockets.h
@@ -14,6 +14,10 @@
 #include "dds/ddsrt/sockets/posix.h"
 #endif
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 #define INET_ADDRSTRLEN_EXTENDED (INET_ADDRSTRLEN + 6) /* ":12345" */
 
 #if DDSRT_HAVE_IPV6
@@ -259,6 +263,10 @@ ddsrt_gethostbyname(
   const char *name,
   int af,
   ddsrt_hostent_t **hentp);
+#endif
+
+#if defined (__cplusplus)
+}
 #endif
 
 #endif /* DDSRT_SOCKETS_H */

--- a/src/ddsrt/include/dds/ddsrt/strtod.h
+++ b/src/ddsrt/include/dds/ddsrt/strtod.h
@@ -22,6 +22,10 @@
 #include "dds/export.h"
 #include "dds/ddsrt/retcode.h"
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 /**
  * @brief Convert a string to a double precision floating point number.
  *
@@ -71,5 +75,9 @@ ddsrt_dtostr(double src, char *str, size_t size);
  */
 DDS_EXPORT int
 ddsrt_ftostr(float src, char *str, size_t size);
+
+#if defined (__cplusplus)
+}
+#endif
 
 #endif /* DDSRT_STRTOD_H */

--- a/src/tools/ddsperf/ddsperf.c
+++ b/src/tools/ddsperf/ddsperf.c
@@ -664,7 +664,7 @@ static dds_instance_handle_t get_pphandle_for_pubhandle (dds_instance_handle_t p
   dds_sample_info_t info;
   if ((n = dds_read_instance (rd_publications, &msg, &info, 1, 1, pubhandle)) < 0)
     error2 ("dds_read_instance(rd_publications, %"PRIx64") failed: %d\n", pubhandle, (int) n);
-  else if (n == 0 || !info.valid_data)
+  if (n == 0 || !info.valid_data)
   {
     printf ("get_pong_writer: publication handle %"PRIx64" not found\n", pubhandle);
     fflush (stdout);
@@ -772,7 +772,7 @@ static bool process_data (dds_entity_t rd, struct subthread_arg *arg)
   {
     if (iseq[i].valid_data)
     {
-      uint32_t seq, keyval, size;
+      uint32_t seq = 0, keyval = 0, size = 0;
       switch (topicsel)
       {
         case KS:   { KeyedSeq *d = (KeyedSeq *) mseq[i]; keyval = d->keyval; seq = d->seq; size = 12 + d->baggage._length; } break;
@@ -783,7 +783,7 @@ static bool process_data (dds_entity_t rd, struct subthread_arg *arg)
       (void) check_eseq (&eseq_admin, seq, keyval, size, iseq[i].publication_handle);
       if (iseq[i].source_timestamp & 1)
       {
-        dds_entity_t wr_pong = 0;
+        dds_entity_t wr_pong;
         if ((wr_pong = get_pong_writer (iseq[i].publication_handle)) != 0)
         {
           dds_return_t rc;


### PR DESCRIPTION
This PR makes it possible to include the bits required for implementing custom sample representations and serialisation from C++ code:
* by solving a clash between a struct member and a C++ keyword,
* by removing "q_globals.h" from the set of header files that get included transitively (because of a C/C++ compatibility issue, but also because it shouldn't get included for this), and
* by adding a few #ifdef __cplusplus / extern "C" thingummies (actually, it adds these throughout).

The compilation warnings in "ddsperf" were all false positives, so that's not too bad.