### PR TITLE
Limit caching of WHC nodes, xmsg, serdata; OOB write fix & ddsperf updates

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/q_bitset.h
+++ b/src/core/ddsi/include/dds/ddsi/q_bitset.h
@@ -49,6 +49,7 @@ inline void nn_bitset_one (uint32_t numbits, uint32_t *bits)
   memset (bits, 0xff, 4 * ((numbits + 31) / 32));
 
   /* clear bits "accidentally" set */
+  if ((numbits % 32) != 0)
   {
     const uint32_t k = numbits / 32;
     const uint32_t n = numbits % 32;

--- a/src/core/ddsi/include/dds/ddsi/q_freelist.h
+++ b/src/core/ddsi/include/dds/ddsi/q_freelist.h
@@ -19,7 +19,7 @@
 extern "C" {
 #endif
 
-#define FREELIST_SIMPLE 1
+#define FREELIST_NONE 1
 #define FREELIST_ATOMIC_LIFO 2
 #define FREELIST_DOUBLE 3
 
@@ -33,7 +33,13 @@ extern "C" {
 #endif
 #endif
 
-#if FREELIST_TYPE == FREELIST_ATOMIC_LIFO
+#if FREELIST_TYPE == FREELIST_NONE
+
+struct nn_freelist {
+  char dummy;
+};
+
+#elif FREELIST_TYPE == FREELIST_ATOMIC_LIFO
 
 struct nn_freelist {
   ddsrt_atomic_lifo_t x;

--- a/src/core/ddsi/src/q_freelist.c
+++ b/src/core/ddsi/src/q_freelist.c
@@ -18,7 +18,37 @@
 #include "dds/ddsrt/threads.h"
 #include "dds/ddsi/q_freelist.h"
 
-#if FREELIST_TYPE == FREELIST_ATOMIC_LIFO
+#if FREELIST_TYPE == FREELIST_NONE
+
+void nn_freelist_init (struct nn_freelist *fl, uint32_t max, off_t linkoff)
+{
+  (void) fl; (void) max; (void) linkoff;
+}
+
+void nn_freelist_fini (struct nn_freelist *fl, void (*free) (void *elem))
+{
+  (void) fl; (void) free;
+}
+
+bool nn_freelist_push (struct nn_freelist *fl, void *elem)
+{
+  (void) fl; (void) elem;
+  return false;
+}
+
+void *nn_freelist_pushmany (struct nn_freelist *fl, void *first, void *last, uint32_t n)
+{
+  (void) fl; (void) first; (void) last; (void) n;
+  return first;
+}
+
+void *nn_freelist_pop (struct nn_freelist *fl)
+{
+  (void) fl;
+  return NULL;
+}
+
+#elif FREELIST_TYPE == FREELIST_ATOMIC_LIFO
 
 void nn_freelist_init (struct nn_freelist *fl, uint32_t max, off_t linkoff)
 {

--- a/src/tools/ddsperf/ddsperf.c
+++ b/src/tools/ddsperf/ddsperf.c
@@ -1493,7 +1493,7 @@ static int string_int_map_lookup (const struct string_int_map_elem *elems, const
   for (size_t i = 0; elems[i].name; i++)
   {
     if (strcmp (elems[i].name, str) == 0)
-      return elems[match].value;
+      return elems[i].value;
     else if (len >= 3 && strlen (elems[i].name) >= 3 && strncmp (elems[i].name, str, len) == 0)
     {
       if (match == SIZE_MAX)

--- a/src/tools/ddsperf/ddsperf.c
+++ b/src/tools/ddsperf/ddsperf.c
@@ -1298,7 +1298,7 @@ static void print_stats (dds_time_t tstart, dds_time_t tnow, dds_time_t tprev)
     if (nrecv > 0)
     {
       printf ("%s ntot %"PRIu64" delta: %"PRIu64" lost %"PRIu64" rate %.2f Mb/s\n",
-              prefix, tot_nrecv, nrecv, nlost, (double) nrecv_bytes * 8 / 1e6 / (1e9 * (double) (tnow - tprev)));
+              prefix, tot_nrecv, nrecv, nlost, (double) nrecv_bytes * 8 * 1e3 / (double) (tnow - tprev));
     }
   }
 


### PR DESCRIPTION
This pull request is a jumble of a few important things ... in order of decreasing importance:
* It fixes an out-of-bounds write in filling a bitset with all 1s, in case the number of 1s to be written is a multiple of 32. The case can occur when NACKing very large fragmented messages.
* It sets much more reasonable limits on the caching of WHC nodes, serdata (serialised data) and xmsg (message fragments): it limits the size of the cacheable ones, it reduces the number of entries that may be cached and it caches WHC nodes in a single cache for all WHCs, rather than having one per WHC. The maximum sizes of the caches is now quite reasonable (a few MB). Changing a single define will disable the caching altogether.
* DDSPerf gained 50% (median), 90% and 99% percentiles as well as a fix for calculating the bit rate in a throughput test.