### PR TITLE
Prepare .travis.yml for Coverity Scan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,41 @@
 language: c
 
-# Platform descriptions
-# NOTE: These can be used in creating the build matrix by making use of the
-#       anchor/alias YAML features.
+# Coverity Scan can be configured through Travis addons, but this allows for
+# more control over the build instructions and does not require the addition
+# of a coverity_scan branch in the repository. travisci_build_coverity_scan.sh
+# does more checks before it decides to download Coverity (around 500M), but
+# these instructions assume Coverity Scan is not installed if the directory
+# does not exist and expects the download to fail if the token is incorrect.
+# Coverity Scan quota are not checked as the Coverity enabled build must only
+# run from cron.
+install_coverity: &install_coverity
+  if [ -n "${COVERITY_SCAN}" ]; then
+    COVERITY_DIR="/tmp/coverity-scan-analysis";
+    COVERITY_ARCHIVE="/tmp/cov-analysis-${COV_PLATFORM}.tgz";
+    test ! -d "${COVERITY_DIR}" &&
+      mkdir -p "${COVERITY_DIR}" &&
+      curl -f -s -F project="${TRAVIS_REPO_SLUG}"
+                 -F token="${COVERITY_SCAN_TOKEN}"
+                 -o "${COVERITY_ARCHIVE}"
+                 "https://scan.coverity.com/download/cxx/${COV_PLATFORM}" &&
+      tar -xzf "${COVERITY_ARCHIVE}" -C "${COVERITY_DIR}";
+    COVERITY_ANALYSIS=$(find "${COVERITY_DIR}" -type d -name "cov-analysis*");
+    eval "export PATH=\"${PATH}:${COVERITY_ANALYSIS}/bin\"";
+    eval "export SCAN_BUILD=\"cov-build --dir cov-int\"";
+    cov-configure --comptype ${COV_COMPTYPE} --compiler ${CC} --template;
+  fi
+
+submit_to_coverity_scan: &submit_to_coverity_scan
+  if [ -n "${COVERITY_SCAN}" ]; then
+    tar -czf analysis-results.tgz cov-int &&
+    curl -f -v -F project="${TRAVIS_REPO_SLUG}"
+               -F token="${COVERITY_SCAN_TOKEN}"
+               -F file=@analysis-results.tgz
+               -F version=$(git rev-parse --short HEAD)
+               -F description="Travis CI build"
+               "https://scan.coverity.com/builds";
+  fi
+
 linux_gcc8: &linux_gcc8
   os: linux
   dist: xenial
@@ -12,6 +45,13 @@ linux_gcc8: &linux_gcc8
       update: true
       sources: [ ubuntu-toolchain-r-test ]
       packages: [ gcc-8 g++-8 ]
+  before_install:
+    - eval "export CC=gcc-8"
+    - eval "export CXX=g++-8"
+    - eval "export COV_COMPTYPE=gcc COV_PLATFORM=linux64"
+  install:
+    - *install_coverity
+    - pip install conan --upgrade --user
 
 linux_clang: &linux_clang
   os: linux
@@ -20,6 +60,12 @@ linux_clang: &linux_clang
   addons:
     apt:
       update: true
+  before_install:
+    - eval "export CC=clang"
+    - eval "export CXX=clang++"
+    - eval "export COV_COMPTYPE=clang COV_PLATFORM=linux64"
+  install:
+    - pip install conan --upgrade --user
 
 osx_xcode10_1: &osx_xcode10_1
   os: osx
@@ -29,86 +75,86 @@ osx_xcode10_1: &osx_xcode10_1
     homebrew:
       packages:
       - pyenv-virtualenv
+  before_install:
+    - eval "export CC=clang"
+    - eval "export CXX=clang++"
+    - eval "export COV_COMPTYPE=clang COV_PLATFORM=macOSX"
+  install:
+    - eval "$(pyenv init -)"
+    - pyenv virtualenv conan
+    - pyenv rehash
+    - pyenv activate conan
+    - pip install conan --upgrade
 
 windows_vs2017: &windows_vs2017
   os: windows
+  # Conan will automatically determine the best compiler for a given platform
+  # based on educated guesses. The first check is based on the CC and CXX
+  # environment variables, the second (on Windows) is to check if Microsoft
+  # Visual Studio is installed. On Travis CC and CXX are set to gcc on
+  # Microsoft Windows targets as well, this has the undesired effect that MSVC
+  # is not detected, unsetting CC and CXX solves that problem.
+  #
+  #
+  # !!! IMPORTANT !!!
+  #
+  # Microsoft Windows instances freeze at "install:" if secure environment
+  # variables are used. There is no option to export secrets only for
+  # specified platforms. The "filter_secrets: false" option is used to disable
+  # the filter for Microsoft Windows instances. This is not an issue if the
+  # secret is removed from the environment at the earliest opportunity, before
+  # risk of exposure, as secrets are always removed from the environment for
+  # pull requests and are still filtered when exported to the environment. The
+  # secret of course will not be available for Microsoft Windows builds, but
+  # for Coverity Scan, that is fine.
+  filter_secrets: false
+  before_install:
+    - eval "unset COVERITY_SCAN_TOKEN"
+    - eval "unset CC"
+    - eval "unset CXX"
+    - eval "export COV_COMPTYPE=msvc COV_PLATFORM=win64"
+    - JAVA_HOME=$(find "/c/Program Files/Android/jdk/" -name "*openjdk*" | sort | head -n 1)
+    - export JAVA_HOME
+    - export PATH="${PATH}:${JAVA_HOME}/bin"
+  # Windows targets in Travis are still very much in beta and Python is not yet
+  # available and installation of Python through Chocolaty does not work well.
+  # The real fix is to wait until Python and pip are both available on the
+  # target. Until then download Conan from the official website and simply add
+  # the extracted folder to the path.
+  install:
+    - choco install innoextract
+    - choco install maven --ignore-dependencies
+    - wget -q https://dl.bintray.com/conan/installers/conan-win-64_1_10_0.exe
+    - innoextract conan-win-64_1_10_0.exe
+    - eval "export PATH=\"$(pwd)/app/conan:${PATH}\""
 
-matrix:
+jobs:
   include:
     - <<: *linux_gcc8
-      env: [ BUILD_TYPE=Debug, C_COMPILER=gcc-8, CXX_COMPILER=g++-8, USE_SANITIZER=none ]
+      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Debug, GENERATOR="Unix Makefiles", COVERITY_SCAN=true ]
+      if: type = cron
     - <<: *linux_gcc8
-      env: [ BUILD_TYPE=Release, C_COMPILER=gcc-8, CXX_COMPILER=g++-8, USE_SANITIZER=none ]
+      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Debug, GENERATOR="Unix Makefiles" ]
+    - <<: *linux_gcc8
+      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, GENERATOR="Unix Makefiles" ]
     - <<: *linux_clang
-      env: [ BUILD_TYPE=Debug, C_COMPILER=clang, CXX_COMPILER=clang++, USE_SANITIZER=address ]
+      env: [ ARCH=x86_64, ASAN=address, BUILD_TYPE=Debug, GENERATOR="Unix Makefiles" ]
     - <<: *linux_clang
-      env: [ BUILD_TYPE=Release, C_COMPILER=clang, CXX_COMPILER=clang++, USE_SANITIZER=none ]
+      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, GENERATOR="Unix Makefiles" ]
     - <<: *osx_xcode10_1
-      env: [ BUILD_TYPE=Debug, C_COMPILER=clang, CXX_COMPILER=clang++, USE_SANITIZER=address ]
+      env: [ ARCH=x86_64, ASAN=address, BUILD_TYPE=Debug, GENERATOR="Unix Makefiles" ]
     - <<: *osx_xcode10_1
-      env: [ BUILD_TYPE=Release, C_COMPILER=clang, CXX_COMPILER=clang++, USE_SANITIZER=none ]
+      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, GENERATOR="Unix Makefiles" ]
     - <<: *windows_vs2017
-      env: [ ARCH=x86, BUILD_TYPE=Debug, GENERATOR="Visual Studio 15 2017" ]
+      env: [ ARCH=x86, ASAN=none, BUILD_TYPE=Debug, GENERATOR="Visual Studio 15 2017" ]
     - <<: *windows_vs2017
-      env: [ ARCH=x86_64, BUILD_TYPE=Debug, GENERATOR="Visual Studio 15 2017" ]
+      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Debug, GENERATOR="Visual Studio 15 2017 Win64" ]
     - <<: *windows_vs2017
-      env: [ ARCH=x86_64, BUILD_TYPE=Release, GENERATOR="Visual Studio 15 2017" ]
-
-# Conan will automatically determine the best compiler for a given platform
-# based on educated guesses. The first check is based on the CC and CXX
-# environment variables, the second (on Windows) is to check if Microsoft
-# Visual Studio is installed. On Travis CC and CXX are set to gcc on Microsoft
-# Windows targets as well, this has the undesired effect that MSVC is not
-# detected, unsetting CC and CXX solves that problem.
-before_install:
-  - if [ "${TRAVIS_OS_NAME}" = "windows" ]; then
-      eval "unset CC";
-      eval "unset CXX";
-      JAVA_HOME=$(find "/c/Program Files/Android/jdk/" -name "*openjdk*" | sort | head -n 1);
-      export JAVA_HOME;
-      export PATH="${PATH}:${JAVA_HOME}/bin";
-    else
-      eval "export CC=${C_COMPILER}";
-      eval "export CXX=${CXX_COMPILER}";
-    fi
-
-# Windows targets in Travis are still very much in beta and Python is not yet
-# available and installation of Python through Chocolaty does not work well.
-# The real fix is to wait until Python and pip are both available on the
-# target. Until then download Conan from the official website and simply add
-# the extracted folder to the path.
-install:
-  - if [ "${TRAVIS_OS_NAME}" = "windows" ]; then
-      choco install innoextract;
-      choco install maven --ignore-dependencies;
-      wget -q https://dl.bintray.com/conan/installers/conan-win-64_1_10_0.exe;
-      innoextract conan-win-64_1_10_0.exe;
-      eval "export PATH=\"$(pwd)/app/conan:${PATH}\"";
-    elif [ "${TRAVIS_OS_NAME}" = "osx" ]; then
-      eval "$(pyenv init -)";
-      pyenv virtualenv conan;
-      pyenv rehash;
-      pyenv activate conan;
-      pip install conan --upgrade;
-    else
-      pip install conan --upgrade --user;
-    fi
-  - conan profile new default --detect
+      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, GENERATOR="Visual Studio 15 2017 Win64" ]
 
 before_script:
+  - conan profile new default --detect
   - conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan
-  - conan profile get settings.arch default
-  - if [ -z "${ARCH}" ]; then
-      eval "export ARCH=\"$(conan profile get settings.arch default)\"";
-    fi
-  - if [ "${TRAVIS_OS_NAME}" = "windows" ]; then
-      GENERATOR_ARCH=$(if [ "${ARCH}" = "x86_64" ]; then echo " Win64"; fi);
-      eval "export GENERATOR=\"${GENERATOR}${GENERATOR_ARCH}\"";
-      eval "export USE_SANITIZER=none";
-    else
-      eval "export GENERATOR=\"Unix Makefiles\"";
-    fi
-  - export
 
 script:
   - mkdir build
@@ -116,12 +162,12 @@ script:
   - conan install -b missing -s arch=${ARCH} -s build_type=${BUILD_TYPE} ..
   - cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
           -DCMAKE_INSTALL_PREFIX=$(pwd)/install
-          -DUSE_SANITIZER=${USE_SANITIZER}
+          -DUSE_SANITIZER=${ASAN}
           -DBUILD_TESTING=on
           -G "${GENERATOR}" ../src
-  - cmake --build . --config ${BUILD_TYPE} --target install
+  - ${SCAN_BUILD} cmake --build . --config ${BUILD_TYPE} --target install
   - CYCLONEDDS_URI='<CycloneDDS><DDSI2E><Internal><EnableExpensiveChecks>all</EnableExpensiveChecks></Internal></DDSI2E></CycloneDDS>' ctest -T test -C ${BUILD_TYPE}
-  - if [ "${USE_SANITIZER}" != "none" ]; then
+  - if [ "${ASAN}" != "none" ]; then
       CMAKE_LINKER_FLAGS="-DCMAKE_LINKER_FLAGS=-fsanitize=${USE_SANITIZER}";
       CMAKE_C_FLAGS="-DCMAKE_C_FLAGS=-fsanitize=${USE_SANITIZER}";
     fi
@@ -132,4 +178,8 @@ script:
           ${CMAKE_LINKER_FLAGS}
           -G "${GENERATOR}" ..
   - cmake --build . --config ${BUILD_TYPE}
+  - cd "${TRAVIS_BUILD_DIR}/build"
+
+#after_success:
+#  - *submit_to_coverity_scan
 


### PR DESCRIPTION
I took the liberty of implementing support for Coverity Scan after researching how to best add support for it in order to review pull request #176 by ThijsSassen and because he had some difficulties getting everything to work and keep Windows builds intact. I also reorganized the file a bit so that less if-statements are needed throughout the file, these are based on some of ThijsSassen's ideas about restructuring `.travis.yml` in pull request #184, but I like to think I improved on them :wink:.

The Coverity job will only run from if started from cron, so we don't go over quota. My suggestion would be to run it on a weekly base or something. We would also need to add a **hidden environment variable** named `COVERITY_SCAN_TOKEN` with the proper value. To do so, we will need to register the project with Coverity Scan, I think we'd need the help of @eclipsewebmaster. I'll look up what information is required to open a request.

These changes simplify the `.travis.yml` quite a bit, and since the added job doesn't yet run, they're safe to pull. For now, I simply removed the email notification from the fields posted to Coverity Scan, but I have no idea if that works. I'll be sure to test that too. If it's not allowed to leave out the email notification field, we'll have to think about where to send the email. My suggestion would be to use `cyclonedds-dev@eclipse.org` if that's allowed, or maybe the Eclipse Foundation prescribes a certain email address to use in these scenarios. Of course simply specifying a *black hole email address* is also an option.