### PR TITLE
Fixed assert when calling dds_unregister_instance_ih_ts()

### DIFF
--- a/src/core/ddsc/src/dds_instance.c
+++ b/src/core/ddsc/src/dds_instance.c
@@ -241,12 +241,11 @@ dds_unregister_instance_ih_ts(
     if (wr->m_entity.m_qos) {
         dds_qget_writer_data_lifecycle (wr->m_entity.m_qos, &autodispose);
     }
+    thread_state_awake (ts1);
     if (autodispose) {
         dds_instance_remove (wr->m_topic, NULL, handle);
         action |= DDS_WR_DISPOSE_BIT;
     }
-
-    thread_state_awake (ts1);
     tk = ddsi_tkmap_find_by_id (gv.m_tkmap, handle);
     if (tk) {
         struct ddsi_sertopic *tp = wr->m_topic->m_stopic;

--- a/src/core/ddsc/tests/unregister.c
+++ b/src/core/ddsc/tests/unregister.c
@@ -610,6 +610,37 @@ CU_Test(ddsc_unregister_instance_ih_ts, unregistering_past_sample, .init=unregis
 /*************************************************************************************************/
 
 /*************************************************************************************************/
+CU_Test(ddsc_unregister_instance_ih_ts, unregistering_instance)
+{
+    Space_Type1 testData = { 0, 22, 22 };
+    dds_instance_handle_t ih = 0;
+    dds_return_t ret;
+    char name[100];
+
+    /* Create a writer that WILL automatically dispose unregistered samples. */
+    g_participant = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL, NULL);
+    CU_ASSERT_FATAL(g_participant > 0);
+    g_topic = dds_create_topic(g_participant, &Space_Type1_desc, create_topic_name("ddsc_unregistering_instance_test", name, 100), NULL, NULL);
+    CU_ASSERT_FATAL(g_topic > 0);
+    g_writer = dds_create_writer(g_participant, g_topic, NULL, NULL);
+    CU_ASSERT_FATAL(g_writer > 0);
+
+    /* Register the instance. */
+    ret = dds_register_instance(g_writer, &ih, &testData);
+    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+    CU_ASSERT_NOT_EQUAL_FATAL(ih, DDS_HANDLE_NIL);
+
+    /* Unregister the instance. */
+    ret = dds_unregister_instance_ih_ts(g_writer, ih, dds_time());
+    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+
+    dds_delete(g_writer);
+    dds_delete(g_topic);
+    dds_delete(g_participant);
+}
+/*************************************************************************************************/
+
+/*************************************************************************************************/
 CU_Test(ddsc_unregister_instance, dispose_unregistered_sample, .init=unregistering_init, .fini=unregistering_fini)
 {
     dds_entity_t writer;


### PR DESCRIPTION
Imagine autodispose is switched on. If you then call dds_unregister_instance_ih_ts() (or dds_unregister_instance_ih), the following assert will be triggered:
https://github.com/eclipse-cyclonedds/cyclonedds/blob/master/src/core/ddsi/src/ddsi_tkmap.c#L128
```
#0  0x00007ffff6148428 in __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:54
#1  0x00007ffff614a02a in __GI_abort () at abort.c:89
#2  0x00007ffff6140bd7 in __assert_fail_base (fmt=<optimized out>, assertion=assertion@entry=0x7ffff7640c20 <.str> "thread_is_awake ()",
    file=file@entry=0x7ffff7640c60 <.str.1> "/home/martinb/lite2/lite/cyclonedds/src/core/ddsi/src/ddsi_tkmap.c", line=line@entry=128,
    function=function@entry=0x7ffff7640d60 <__PRETTY_FUNCTION__.ddsi_tkmap_find_by_id> "struct ddsi_tkmap_instance *ddsi_tkmap_find_by_id(struct ddsi_tkmap *, uint64_t)") at assert.c:92
#3  0x00007ffff6140c82 in __GI___assert_fail (assertion=0x7ffff7640c20 <.str> "thread_is_awake ()", file=0x7ffff7640c60 <.str.1> "/home/martinb/lite2/lite/cyclonedds/src/core/ddsi/src/ddsi_tkmap.c", line=128,
    function=0x7ffff7640d60 <__PRETTY_FUNCTION__.ddsi_tkmap_find_by_id> "struct ddsi_tkmap_instance *ddsi_tkmap_find_by_id(struct ddsi_tkmap *, uint64_t)") at assert.c:101
#4  0x00007ffff7455baf in ddsi_tkmap_find_by_id (map=0x608000010020, iid=12295004035598266004) at /home/martinb/lite2/lite/cyclonedds/src/core/ddsi/src/ddsi_tkmap.c:128
#5  0x00007ffff75be1b2 in dds_instance_remove (topic=0x6160000a1780, data=0x0, handle=12295004035598266004) at /home/martinb/lite2/lite/cyclonedds/src/core/ddsc/src/dds_instance.c:73
#6  0x00007ffff75bdeb6 in dds_unregister_instance_ih_ts (writer=1025374452, handle=12295004035598266004, timestamp=1558957698276541683) at /home/martinb/lite2/lite/cyclonedds/src/core/ddsc/src/dds_instance.c:245
#7  0x00007ffff75bdb51 in dds_unregister_instance_ih (writer=1025374452, handle=12295004035598266004) at /home/martinb/lite2/lite/cyclonedds/src/core/ddsc/src/dds_instance.c:176
```

This is solved by moving the thread_state_awake() call to be in front of the dds_instance_remove() call.

Note: dds_unregister_instance_ts() already has the thread_state_awake() before dds_instance_remove().