### PR TITLE
Rewrite QoS/parameter list handling

### DIFF
--- a/src/core/ddsc/CMakeLists.txt
+++ b/src/core/ddsc/CMakeLists.txt
@@ -24,6 +24,7 @@ PREPEND(srcs_ddsc "${CMAKE_CURRENT_LIST_DIR}/src"
     dds_qos.c
     dds_handles.c
     dds_entity.c
+    dds_matched.c
     dds_querycond.c
     dds_topic.c
     dds_listener.c

--- a/src/core/ddsc/include/dds/dds.h
+++ b/src/core/ddsc/include/dds/dds.h
@@ -3061,6 +3061,140 @@ dds_triggered(dds_entity_t entity);
 DDS_EXPORT dds_entity_t
 dds_get_topic(dds_entity_t entity);
 
+/**
+ * @brief Get instance handles of the data readers matching a writer
+ *
+ * This operation fills the provided array with the instance handles
+ * of the data readers that match the writer.  On successful output,
+ * the number of entries of "rds" set is the minimum of the return
+ * value and the value of "nrds".
+ *
+ * @param[in] writer   The writer.
+ * @param[in] rds      The array to be filled.
+ * @param[in] nrds     The size of the rds array, at most the first
+ *             nrds entries will be filled.  rds = NULL and nrds = 0
+ *             is a valid way of determining the number of matched
+ *             readers, but inefficient compared to relying on the
+ *             matched publication status.
+ *
+ * @returns A dds_return_t indicating the number of matched readers
+ *             or failure.  The return value may be larger than nrds
+ *             if there are more matching readers than the array can
+ *             hold.
+ *
+ * @retval >=0
+ *             The number of matching readers.
+ * @retval DDS_RETCODE_BAD_PARAMETER
+ *             The entity parameter is not valid or rds = NULL and
+ *             nrds > 0.
+ * @retval DDS_RETCODE_ILLEGAL_OPERATION
+ *             The operation is invoked on an inappropriate object.
+ */
+DDS_EXPORT dds_return_t
+dds_get_matched_subscriptions (
+  dds_entity_t writer,
+  dds_instance_handle_t *rds,
+  size_t nrds);
+
+/**
+ * @brief Get a description of a reader matched with the provided
+ * writer
+ *
+ * This operation looks up the reader instance handle in the set of
+ * readers matched with the specified writer, returning a freshly
+ * allocated sample of the DCPSSubscription built-in topic if found,
+ * and NULL if not.  The caller is responsible for freeing the
+ * memory allocated.
+ *
+ * This operation is similar to performing a read of the given
+ * instance handle on a reader of the DCPSSubscription built-in
+ * topic, but this operation additionally filters on whether the
+ * reader is matched by the provided writer.
+ *
+ * @param[in] writer   The writer.
+ * @param[in] ih       The instance handle of a reader.
+ *
+ * @returns A newly allocated sample containing the information on the
+ *             reader, or a NULL pointer for any kind of failure.
+ *
+ * @retval != NULL
+ *             The requested data
+ * @retval NULL
+ *             The writer is not valid or ih is not an instance handle
+ *             of a matched reader.
+ */
+DDS_EXPORT dds_builtintopic_endpoint_t *
+dds_get_matched_subscription_data (
+  dds_entity_t writer,
+  dds_instance_handle_t ih);
+
+/**
+ * @brief Get instance handles of the data writers matching a reader
+ *
+ * This operation fills the provided array with the instance handles
+ * of the data writers that match the reader.  On successful output,
+ * the number of entries of "wrs" set is the minimum of the return
+ * value and the value of "nwrs".
+ *
+ * @param[in] reader   The reader.
+ * @param[in] wrs      The array to be filled.
+ * @param[in] nwrs     The size of the wrs array, at most the first
+ *             nwrs entries will be filled.  wrs = NULL and wrds = 0
+ *             is a valid way of determining the number of matched
+ *             readers, but inefficient compared to relying on the
+ *             matched publication status.
+ *
+ * @returns A dds_return_t indicating the number of matched writers
+ *             or failure.  The return value may be larger than nwrs
+ *             if there are more matching writers than the array can
+ *             hold.
+ *
+ * @retval >=0
+ *             The number of matching writers.
+ * @retval DDS_RETCODE_BAD_PARAMETER
+ *             The entity parameter is not valid or wrs = NULL and
+ *             nwrs > 0.
+ * @retval DDS_RETCODE_ILLEGAL_OPERATION
+ *             The operation is invoked on an inappropriate object.
+ */
+DDS_EXPORT dds_return_t
+dds_get_matched_publications (
+  dds_entity_t reader,
+  dds_instance_handle_t *wrs,
+  size_t nwrs);
+
+/**
+ * @brief Get a description of a writer matched with the provided
+ * reader
+ *
+ * This operation looks up the writer instance handle in the set of
+ * writers matched with the specified reader, returning a freshly
+ * allocated sample of the DCPSPublication built-in topic if found,
+ * and NULL if not.  The caller is responsible for freeing the
+ * memory allocated.
+ *
+ * This operation is similar to performing a read of the given
+ * instance handle on a reader of the DCPSPublication built-in
+ * topic, but this operation additionally filters on whether the
+ * writer is matched by the provided reader.
+ *
+ * @param[in] reader   The reader.
+ * @param[in] ih       The instance handle of a writer.
+ *
+ * @returns A newly allocated sample containing the information on the
+ *             writer, or a NULL pointer for any kind of failure.
+ *
+ * @retval != NULL
+ *             The requested data
+ * @retval NULL
+ *             The reader is not valid or ih is not an instance handle
+ *             of a matched writer.
+ */
+DDS_EXPORT dds_builtintopic_endpoint_t *
+dds_get_matched_publication_data (
+  dds_entity_t reader,
+  dds_instance_handle_t ih);
+
 #if defined (__cplusplus)
 }
 #endif

--- a/src/core/ddsc/include/dds/ddsc/dds_public_qos.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_public_qos.h
@@ -374,7 +374,8 @@ dds_qset_durability_service (
  * @param[in,out] qos - Pointer to a dds_qos_t structure that will store the policy
  * @param[in] ignore - True if readers and writers owned by the same participant should be ignored
  */
-DDS_EXPORT void dds_qset_ignorelocal (
+DDS_EXPORT void
+dds_qset_ignorelocal (
   dds_qos_t * __restrict qos,
   dds_ignorelocal_kind_t ignore);
 

--- a/src/core/ddsc/src/dds_entity.c
+++ b/src/core/ddsc/src/dds_entity.c
@@ -20,6 +20,7 @@
 #include "dds__reader.h"
 #include "dds__listener.h"
 #include "dds/version.h"
+#include "dds/ddsi/q_xqos.h"
 
 extern inline dds_entity *dds_entity_from_handle_link (struct dds_handle_link *hdllink);
 extern inline bool dds_entity_is_enabled (const dds_entity *e);
@@ -354,7 +355,8 @@ dds_return_t dds_get_qos (dds_entity_t entity, dds_qos_t *qos)
   else
   {
     dds_reset_qos (qos);
-    ret = dds_copy_qos (qos, e->m_qos);
+    nn_xqos_mergein_missing (qos, e->m_qos, ~(QP_TOPIC_NAME | QP_TYPE_NAME));
+    ret = DDS_RETCODE_OK;
   }
   dds_entity_unlock(e);
   return ret;

--- a/src/core/ddsc/src/dds_matched.c
+++ b/src/core/ddsc/src/dds_matched.c
@@ -1,0 +1,220 @@
+/*
+ * Copyright(c) 2019 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include <assert.h>
+#include <string.h>
+
+#include "dds/dds.h"
+#include "dds/version.h"
+#include "dds/ddsi/q_config.h"
+#include "dds/ddsi/q_globals.h"
+#include "dds/ddsi/q_entity.h"
+#include "dds/ddsi/q_thread.h"
+#include "dds/ddsi/q_bswap.h"
+#include "dds__writer.h"
+#include "dds__reader.h"
+#include "dds__qos.h"
+#include "dds__topic.h"
+
+dds_return_t dds_get_matched_subscriptions (dds_entity_t writer, dds_instance_handle_t *rds, size_t nrds)
+{
+  dds_writer *wr;
+  dds_return_t rc;
+  if (rds == NULL && nrds > 0)
+    return DDS_RETCODE_BAD_PARAMETER;
+  if ((rc = dds_writer_lock (writer, &wr)) != DDS_RETCODE_OK)
+    return rc;
+  else
+  {
+    const int32_t nrds_max = (nrds > INT32_MAX) ? INT32_MAX : (int32_t) nrds;
+    int32_t nrds_act = 0;
+    ddsrt_avl_iter_t it;
+    /* FIXME: this ought not be so tightly coupled to the lower layer */
+    thread_state_awake (lookup_thread_state ());
+    ddsrt_mutex_lock (&wr->m_wr->e.lock);
+    for (const struct wr_prd_match *m = ddsrt_avl_iter_first (&wr_readers_treedef, &wr->m_wr->readers, &it);
+         m != NULL;
+         m = ddsrt_avl_iter_next (&it))
+    {
+      struct proxy_reader *prd;
+      if ((prd = ephash_lookup_proxy_reader_guid (&m->prd_guid)) != NULL)
+      {
+        if (nrds_act < nrds_max)
+          rds[nrds_act] = prd->e.iid;
+        nrds_act++;
+      }
+    }
+    for (const struct wr_rd_match *m = ddsrt_avl_iter_first (&wr_local_readers_treedef, &wr->m_wr->local_readers, &it);
+         m != NULL;
+         m = ddsrt_avl_iter_next (&it))
+    {
+      struct reader *rd;
+      if ((rd = ephash_lookup_reader_guid (&m->rd_guid)) != NULL)
+      {
+        if (nrds_act < nrds_max)
+          rds[nrds_act] = rd->e.iid;
+        nrds_act++;
+      }
+    }
+    ddsrt_mutex_unlock (&wr->m_wr->e.lock);
+    thread_state_asleep (lookup_thread_state ());
+    dds_writer_unlock (wr);
+    return nrds_act;
+  }
+}
+
+dds_return_t dds_get_matched_publications (dds_entity_t reader, dds_instance_handle_t *wrs, size_t nwrs)
+{
+  dds_reader *rd;
+  dds_return_t rc;
+  if (wrs == NULL && nwrs > 0)
+    return DDS_RETCODE_BAD_PARAMETER;
+  if ((rc = dds_reader_lock (reader, &rd)) != DDS_RETCODE_OK)
+    return rc;
+  else
+  {
+    const int32_t nwrs_max = (nwrs > INT32_MAX) ? INT32_MAX : (int32_t) nwrs;
+    int32_t nwrs_act = 0;
+    ddsrt_avl_iter_t it;
+    /* FIXME: this ought not be so tightly coupled to the lower layer */
+    thread_state_awake (lookup_thread_state ());
+    ddsrt_mutex_lock (&rd->m_rd->e.lock);
+    for (const struct rd_pwr_match *m = ddsrt_avl_iter_first (&rd_writers_treedef, &rd->m_rd->writers, &it);
+         m != NULL;
+         m = ddsrt_avl_iter_next (&it))
+    {
+      struct proxy_writer *pwr;
+      if ((pwr = ephash_lookup_proxy_writer_guid (&m->pwr_guid)) != NULL)
+      {
+        if (nwrs_act < nwrs_max)
+          wrs[nwrs_act] = pwr->e.iid;
+        nwrs_act++;
+      }
+    }
+    for (const struct rd_wr_match *m = ddsrt_avl_iter_first (&rd_local_writers_treedef, &rd->m_rd->local_writers, &it);
+         m != NULL;
+         m = ddsrt_avl_iter_next (&it))
+    {
+      struct writer *wr;
+      if ((wr = ephash_lookup_writer_guid (&m->wr_guid)) != NULL)
+      {
+        if (nwrs_act < nwrs_max)
+          wrs[nwrs_act] = wr->e.iid;
+        nwrs_act++;
+      }
+    }
+    ddsrt_mutex_unlock (&rd->m_rd->e.lock);
+    thread_state_asleep (lookup_thread_state ());
+    dds_reader_unlock (rd);
+    return nwrs_act;
+  }
+}
+
+static dds_builtintopic_endpoint_t *make_builtintopic_endpoint (const nn_guid_t *guid, const nn_guid_t *ppguid, dds_instance_handle_t ppiid, const dds_qos_t *qos)
+{
+  dds_builtintopic_endpoint_t *ep;
+  nn_guid_t tmp;
+  ep = dds_alloc (sizeof (*ep));
+  tmp = nn_hton_guid (*guid);
+  memcpy (&ep->key, &tmp, sizeof (ep->key));
+  ep->participant_instance_handle = ppiid;
+  tmp = nn_hton_guid (*ppguid);
+  memcpy (&ep->participant_key, &tmp, sizeof (ep->participant_key));
+  ep->qos = dds_create_qos ();
+  nn_xqos_mergein_missing (ep->qos, qos, ~(QP_TOPIC_NAME | QP_TYPE_NAME));
+  ep->topic_name = dds_string_dup (qos->topic_name);
+  ep->type_name = dds_string_dup (qos->type_name);
+  return ep;
+}
+
+dds_builtintopic_endpoint_t *dds_get_matched_subscription_data (dds_entity_t writer, dds_instance_handle_t ih)
+{
+  dds_writer *wr;
+  dds_return_t rc;
+  if ((rc = dds_writer_lock (writer, &wr)) != DDS_RETCODE_OK)
+    return NULL;
+  else
+  {
+    dds_builtintopic_endpoint_t *ret = NULL;
+    ddsrt_avl_iter_t it;
+    /* FIXME: this ought not be so tightly coupled to the lower layer, and not be so inefficient besides */
+    thread_state_awake (lookup_thread_state ());
+    ddsrt_mutex_lock (&wr->m_wr->e.lock);
+    for (const struct wr_prd_match *m = ddsrt_avl_iter_first (&wr_readers_treedef, &wr->m_wr->readers, &it);
+         m != NULL && ret == NULL;
+         m = ddsrt_avl_iter_next (&it))
+    {
+      struct proxy_reader *prd;
+      if ((prd = ephash_lookup_proxy_reader_guid (&m->prd_guid)) != NULL)
+      {
+        if (prd->e.iid == ih)
+          ret = make_builtintopic_endpoint (&prd->e.guid, &prd->c.proxypp->e.guid, prd->c.proxypp->e.iid, prd->c.xqos);
+      }
+    }
+    for (const struct wr_rd_match *m = ddsrt_avl_iter_first (&wr_local_readers_treedef, &wr->m_wr->local_readers, &it);
+         m != NULL && ret == NULL;
+         m = ddsrt_avl_iter_next (&it))
+    {
+      struct reader *rd;
+      if ((rd = ephash_lookup_reader_guid (&m->rd_guid)) != NULL)
+      {
+        if (rd->e.iid == ih)
+          ret = make_builtintopic_endpoint (&rd->e.guid, &rd->c.pp->e.guid, rd->c.pp->e.iid, rd->xqos);
+      }
+    }
+    ddsrt_mutex_unlock (&wr->m_wr->e.lock);
+    thread_state_asleep (lookup_thread_state ());
+    dds_writer_unlock (wr);
+    return ret;
+  }
+}
+
+dds_builtintopic_endpoint_t *dds_get_matched_publication_data (dds_entity_t reader, dds_instance_handle_t ih)
+{
+  dds_reader *rd;
+  dds_return_t rc;
+  if ((rc = dds_reader_lock (reader, &rd)) != DDS_RETCODE_OK)
+    return NULL;
+  else
+  {
+    dds_builtintopic_endpoint_t *ret = NULL;
+    ddsrt_avl_iter_t it;
+    /* FIXME: this ought not be so tightly coupled to the lower layer, and not be so inefficient besides */
+    thread_state_awake (lookup_thread_state ());
+    ddsrt_mutex_lock (&rd->m_rd->e.lock);
+    for (const struct rd_pwr_match *m = ddsrt_avl_iter_first (&rd_writers_treedef, &rd->m_rd->writers, &it);
+         m != NULL && ret == NULL;
+         m = ddsrt_avl_iter_next (&it))
+    {
+      struct proxy_writer *pwr;
+      if ((pwr = ephash_lookup_proxy_writer_guid (&m->pwr_guid)) != NULL)
+      {
+        if (pwr->e.iid == ih)
+          ret = make_builtintopic_endpoint (&pwr->e.guid, &pwr->c.proxypp->e.guid, pwr->c.proxypp->e.iid, pwr->c.xqos);
+      }
+    }
+    for (const struct rd_wr_match *m = ddsrt_avl_iter_first (&rd_local_writers_treedef, &rd->m_rd->local_writers, &it);
+         m != NULL && ret == NULL;
+         m = ddsrt_avl_iter_next (&it))
+    {
+      struct writer *wr;
+      if ((wr = ephash_lookup_writer_guid (&m->wr_guid)) != NULL)
+      {
+        if (wr->e.iid == ih)
+          ret = make_builtintopic_endpoint (&wr->e.guid, &wr->c.pp->e.guid, wr->c.pp->e.iid, wr->xqos);
+      }
+    }
+    ddsrt_mutex_unlock (&rd->m_rd->e.lock);
+    thread_state_asleep (lookup_thread_state ());
+    dds_reader_unlock (rd);
+    return ret;
+  }
+}

--- a/src/core/ddsc/src/dds_reader.c
+++ b/src/core/ddsc/src/dds_reader.c
@@ -81,18 +81,9 @@ static dds_return_t dds_reader_qos_validate (const dds_qos_t *qos, bool enabled)
 
 static dds_return_t dds_reader_qos_validate (const dds_qos_t *qos, bool enabled)
 {
-  if (!dds_qos_validate_common (qos))
-    return DDS_RETCODE_ERROR;
-  if ((qos->present & QP_USER_DATA) && !validate_octetseq (&qos->user_data))
-    return DDS_RETCODE_INCONSISTENT_POLICY;
-  if ((qos->present & QP_PRISMTECH_READER_DATA_LIFECYCLE) && validate_reader_data_lifecycle (&qos->reader_data_lifecycle) < 0)
-    return DDS_RETCODE_INCONSISTENT_POLICY;
-  if ((qos->present & QP_TIME_BASED_FILTER) && validate_duration (qos->time_based_filter.minimum_separation) < 0)
-    return DDS_RETCODE_INCONSISTENT_POLICY;
-  if ((qos->present & QP_HISTORY) && (qos->present & QP_RESOURCE_LIMITS) && validate_history_and_resource_limits (&qos->history, &qos->resource_limits) < 0)
-    return DDS_RETCODE_INCONSISTENT_POLICY;
-  if ((qos->present & QP_TIME_BASED_FILTER) && (qos->present & QP_DEADLINE) && !validate_deadline_and_timebased_filter (qos->deadline.deadline, qos->time_based_filter.minimum_separation))
-    return DDS_RETCODE_INCONSISTENT_POLICY;
+  dds_return_t ret;
+  if ((ret = nn_xqos_valid (qos)) < 0)
+    return ret;
   return (enabled ? dds_qos_validate_mutable_common (qos) : DDS_RETCODE_OK);
 }
 
@@ -372,20 +363,15 @@ dds_entity_t dds_create_reader (dds_entity_t participant_or_subscriber, dds_enti
 
   /* Merge qos from topic and subscriber, dds_copy_qos only fails when it is passed a null
      argument, but that isn't the case here */
+#define DDS_QOSMASK_READER (QP_USER_DATA | QP_DURABILITY | QP_DEADLINE | QP_LATENCY_BUDGET | QP_OWNERSHIP | QP_LIVELINESS | QP_TIME_BASED_FILTER | QP_RELIABILITY | QP_DESTINATION_ORDER | QP_HISTORY | QP_RESOURCE_LIMITS | QP_PRISMTECH_READER_DATA_LIFECYCLE | QP_CYCLONE_IGNORELOCAL)
   rqos = dds_create_qos ();
   if (qos)
-    (void) dds_copy_qos (rqos, qos);
-
+    nn_xqos_mergein_missing (rqos, qos, DDS_QOSMASK_READER);
   if (sub->m_entity.m_qos)
-    dds_merge_qos (rqos, sub->m_entity.m_qos);
-
+    nn_xqos_mergein_missing (rqos, sub->m_entity.m_qos, ~(uint64_t)0);
   if (tp->m_entity.m_qos)
-  {
-    dds_merge_qos (rqos, tp->m_entity.m_qos);
-    /* reset the following qos policies if set during topic qos merge as they aren't applicable for reader */
-    rqos->present &= ~(QP_DURABILITY_SERVICE | QP_TRANSPORT_PRIORITY | QP_LIFESPAN);
-  }
-  nn_xqos_mergein_missing (rqos, &gv.default_xqos_rd);
+    nn_xqos_mergein_missing (rqos, tp->m_entity.m_qos, ~(uint64_t)0);
+  nn_xqos_mergein_missing (rqos, &gv.default_xqos_rd, ~(uint64_t)0);
 
   if ((ret = dds_reader_qos_validate (rqos, false)) != DDS_RETCODE_OK)
   {
@@ -397,7 +383,7 @@ dds_entity_t dds_create_reader (dds_entity_t participant_or_subscriber, dds_enti
   /* Additional checks required for built-in topics: we don't want to
      run into a resource limit on a built-in topic, it is a needless
      complication */
-  if (internal_topic && !dds__validate_builtin_reader_qos (topic, qos))
+  if (internal_topic && !dds__validate_builtin_reader_qos (topic, rqos))
   {
     dds_delete_qos (rqos);
     reader = DDS_RETCODE_INCONSISTENT_POLICY;

--- a/src/core/ddsc/src/dds_serdata_builtintopic.c
+++ b/src/core/ddsc/src/dds_serdata_builtintopic.c
@@ -19,6 +19,7 @@
 #include "dds/ddsi/q_bswap.h"
 #include "dds/ddsi/q_config.h"
 #include "dds/ddsi/q_freelist.h"
+#include "dds/ddsi/q_plist.h"
 #include "dds__stream.h"
 #include "dds__serdata_builtintopic.h"
 #include "dds/ddsi/ddsi_tkmap.h"
@@ -193,7 +194,7 @@ static dds_qos_t *dds_qos_from_xqos_reuse (dds_qos_t *old, const dds_qos_t *src)
     old = ddsrt_malloc (sizeof (*old));
     nn_xqos_init_empty (old);
     old->present |= QP_TOPIC_NAME | QP_TYPE_NAME;
-    nn_xqos_mergein_missing (old, src);
+    nn_xqos_mergein_missing (old, src, ~(uint64_t)0);
     old->present &= ~(QP_TOPIC_NAME | QP_TYPE_NAME);
   }
   else
@@ -201,7 +202,7 @@ static dds_qos_t *dds_qos_from_xqos_reuse (dds_qos_t *old, const dds_qos_t *src)
     nn_xqos_fini (old);
     nn_xqos_init_empty (old);
     old->present |= QP_TOPIC_NAME | QP_TYPE_NAME;
-    nn_xqos_mergein_missing (old, src);
+    nn_xqos_mergein_missing (old, src, ~(uint64_t)0);
     old->present &= ~(QP_TOPIC_NAME | QP_TYPE_NAME);
   }
   return old;

--- a/src/core/ddsc/tests/reader.c
+++ b/src/core/ddsc/tests/reader.c
@@ -241,7 +241,7 @@ CU_Test(ddsc_reader_create, invalid_qos_participant, .init=reader_init, .fini=re
     dds_qset_reader_data_lifecycle(qos, DDS_SECS(-1), DDS_SECS(-1));
     DDSRT_WARNING_MSVC_ON(28020);
     rdr = dds_create_reader(g_participant, g_topic, qos, NULL);
-    CU_ASSERT_EQUAL_FATAL(rdr, DDS_RETCODE_INCONSISTENT_POLICY);
+    CU_ASSERT_EQUAL_FATAL(rdr, DDS_RETCODE_BAD_PARAMETER);
     dds_delete_qos(qos);
 }
 /*************************************************************************************************/
@@ -256,7 +256,7 @@ CU_Test(ddsc_reader_create, invalid_qos_subscriber, .init=reader_init, .fini=rea
     dds_qset_reader_data_lifecycle(qos, DDS_SECS(-1), DDS_SECS(-1));
     DDSRT_WARNING_MSVC_ON(28020);
     rdr = dds_create_reader(g_subscriber, g_topic, qos, NULL);
-    CU_ASSERT_EQUAL_FATAL(rdr, DDS_RETCODE_INCONSISTENT_POLICY);
+    CU_ASSERT_EQUAL_FATAL(rdr, DDS_RETCODE_BAD_PARAMETER);
     dds_delete_qos(qos);
 }
 /*************************************************************************************************/

--- a/src/core/ddsc/tests/subscriber.c
+++ b/src/core/ddsc/tests/subscriber.c
@@ -91,7 +91,7 @@ CU_Test(ddsc_subscriber, create) {
   sqos = dds_create_qos();
   dds_qset_presentation(sqos, 123, 1, 1); /* Set invalid presentation policy */
   subscriber = dds_create_subscriber(participant, sqos, NULL);
-  CU_ASSERT_EQUAL_FATAL(subscriber, DDS_RETCODE_INCONSISTENT_POLICY);
+  CU_ASSERT_EQUAL_FATAL(subscriber, DDS_RETCODE_BAD_PARAMETER);
   dds_delete_qos(sqos);
 
   /*** Verify listener parameter ***/

--- a/src/core/ddsc/tests/topic.c
+++ b/src/core/ddsc/tests/topic.c
@@ -105,7 +105,7 @@ CU_Test(ddsc_topic_create, invalid_qos, .init=ddsc_topic_init, .fini=ddsc_topic_
     dds_entity_t topic;
     dds_qos_t *qos = dds_create_qos();
     DDSRT_WARNING_MSVC_OFF(28020); /* Disable SAL warning on intentional misuse of the API */
-    dds_qset_lifespan(qos, DDS_SECS(-1));
+    dds_qset_resource_limits(qos, 1, 1, 2);
     DDSRT_WARNING_MSVC_OFF(28020);
     topic = dds_create_topic(g_participant, &RoundTripModule_DataType_desc, "inconsistent", qos, NULL);
     CU_ASSERT_EQUAL_FATAL(topic, DDS_RETCODE_INCONSISTENT_POLICY);
@@ -417,7 +417,7 @@ CU_Test(ddsc_topic_set_qos, inconsistent, .init=ddsc_topic_init, .fini=ddsc_topi
     dds_qset_lifespan(g_qos, DDS_SECS(-1));
     DDSRT_WARNING_MSVC_ON(28020);
     ret = dds_set_qos(g_topicRtmDataType, g_qos);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_INCONSISTENT_POLICY);
+    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_BAD_PARAMETER);
 }
 /*************************************************************************************************/
 

--- a/src/core/ddsi/include/dds/ddsi/ddsi_serdata_default.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_serdata_default.h
@@ -13,7 +13,7 @@
 #define DDSI_SERDATA_DEFAULT_H
 
 #include "dds/ddsrt/endian.h"
-#include "dds/ddsi/q_plist.h" /* for nn_prismtech_writer_info */
+#include "dds/ddsi/q_protocol.h" /* for nn_parameterid_t */
 #include "dds/ddsi/q_freelist.h"
 #include "dds/ddsrt/avl.h"
 #include "dds/ddsi/ddsi_serdata.h"

--- a/src/core/ddsi/include/dds/ddsi/q_plist.h
+++ b/src/core/ddsi/include/dds/ddsi/q_plist.h
@@ -46,22 +46,16 @@ extern "C" {
 #define PP_STATUSINFO                           ((uint64_t)1 << 22)
 #define PP_ORIGINAL_WRITER_INFO                 ((uint64_t)1 << 23)
 #define PP_ENDPOINT_GUID                        ((uint64_t)1 << 24)
-#define PP_PRISMTECH_WRITER_INFO                ((uint64_t)1 << 25)
 #define PP_PRISMTECH_PARTICIPANT_VERSION_INFO   ((uint64_t)1 << 26)
 #define PP_PRISMTECH_NODE_NAME                  ((uint64_t)1 << 27)
 #define PP_PRISMTECH_EXEC_NAME                  ((uint64_t)1 << 28)
 #define PP_PRISMTECH_PROCESS_ID                 ((uint64_t)1 << 29)
-#define PP_PRISMTECH_SERVICE_TYPE               ((uint64_t)1 << 30)
-#define PP_PRISMTECH_WATCHDOG_SCHEDULING        ((uint64_t)1 << 31)
-#define PP_PRISMTECH_LISTENER_SCHEDULING        ((uint64_t)1 << 32)
 #define PP_PRISMTECH_BUILTIN_ENDPOINT_SET       ((uint64_t)1 << 33)
 #define PP_PRISMTECH_TYPE_DESCRIPTION           ((uint64_t)1 << 34)
 #define PP_COHERENT_SET                         ((uint64_t)1 << 37)
-#define PP_PRISMTECH_EOTINFO                    ((uint64_t)1 << 38)
 #ifdef DDSI_INCLUDE_SSM
 #define PP_READER_FAVOURS_SSM                   ((uint64_t)1 << 39)
 #endif
-#define PP_RTI_TYPECODE                         ((uint64_t)1 << 40)
 /* Security extensions. */
 #define PP_IDENTITY_TOKEN                       ((uint64_t)1 << 41)
 #define PP_PERMISSIONS_TOKEN                    ((uint64_t)1 << 42)
@@ -93,14 +87,14 @@ struct nn_locators_one {
 };
 
 typedef struct nn_locators {
-  int n;
+  uint32_t n;
   struct nn_locators_one *first;
   struct nn_locators_one *last;
 } nn_locators_t;
 
-typedef unsigned nn_ipv4address_t;
+typedef uint32_t nn_ipv4address_t;
 
-typedef unsigned nn_port_t;
+typedef uint32_t nn_port_t;
 
 typedef struct nn_keyhash {
   unsigned char value[16];
@@ -109,15 +103,15 @@ typedef struct nn_keyhash {
 
 #ifdef DDSI_INCLUDE_SSM
 typedef struct nn_reader_favours_ssm {
-  unsigned state; /* default is false */
+  uint32_t state; /* default is false */
 } nn_reader_favours_ssm_t;
 #endif
 
 typedef struct nn_prismtech_participant_version_info
 {
-  unsigned version;
-  unsigned flags;
-  unsigned unused[3];
+  uint32_t version;
+  uint32_t flags;
+  uint32_t unused[3];
   char *internals;
 } nn_prismtech_participant_version_info_t;
 
@@ -126,16 +120,9 @@ typedef struct nn_prismtech_eotgroup_tid {
   uint32_t transactionId;
 } nn_prismtech_eotgroup_tid_t;
 
-typedef struct nn_prismtech_eotinfo {
-  uint32_t transactionId;
-  uint32_t n;
-  nn_prismtech_eotgroup_tid_t *tids;
-} nn_prismtech_eotinfo_t;
-
 typedef struct nn_plist {
   uint64_t present;
   uint64_t aliased;
-  int unalias_needs_bswap;
 
   dds_qos_t qos;
 
@@ -150,7 +137,7 @@ typedef struct nn_plist {
 
   unsigned char expects_inline_qos;
   nn_count_t participant_manual_liveliness_count;
-  unsigned participant_builtin_endpoints;
+  uint32_t participant_builtin_endpoints;
   dds_duration_t participant_lease_duration;
   /* nn_content_filter_property_t content_filter_property; */
   nn_guid_t participant_guid;
@@ -160,21 +147,18 @@ typedef struct nn_plist {
   nn_entityid_t participant_entityid;
   nn_entityid_t group_entityid;
 #endif
-  unsigned builtin_endpoint_set;
-  unsigned prismtech_builtin_endpoint_set;
+  uint32_t builtin_endpoint_set;
+  uint32_t prismtech_builtin_endpoint_set;
   /* int type_max_size_serialized; */
   char *entity_name;
   nn_keyhash_t keyhash;
-  unsigned statusinfo;
+  uint32_t statusinfo;
   nn_prismtech_participant_version_info_t prismtech_participant_version_info;
   char *node_name;
   char *exec_name;
-  unsigned char is_service;
-  unsigned service_type;
-  unsigned process_id;
+  uint32_t process_id;
   char *type_description;
   nn_sequence_number_t coherent_set_seqno;
-  nn_prismtech_eotinfo_t eotinfo;
 #ifdef DDSI_INCLUDE_SSM
   nn_reader_favours_ssm_t reader_favours_ssm;
 #endif
@@ -192,8 +176,9 @@ typedef struct nn_plist_src {
   size_t bufsz;
 } nn_plist_src_t;
 
+void nn_plist_init_tables (void);
 DDS_EXPORT void nn_plist_init_empty (nn_plist_t *dest);
-DDS_EXPORT void nn_plist_mergein_missing (nn_plist_t *a, const nn_plist_t *b);
+DDS_EXPORT void nn_plist_mergein_missing (nn_plist_t *a, const nn_plist_t *b, uint64_t pmask, uint64_t qmask);
 DDS_EXPORT void nn_plist_copy (nn_plist_t *dst, const nn_plist_t *src);
 DDS_EXPORT nn_plist_t *nn_plist_dup (const nn_plist_t *src);
 
@@ -234,6 +219,9 @@ DDS_EXPORT nn_plist_t *nn_plist_dup (const nn_plist_t *src);
  * @retval DDS_RETCODE_OK
  *               All parameters valid (or ignored), dest and *nextafterplist have been set
  *               accordingly.
+ * @retval DDS_INCONSISTENT_POLICY
+ *               All individual settings are valid, but there are inconsistencies between
+ *               dependent settings.
  * @retval DDS_RETCODE_BAD_PARAMETER
  *               Input contained invalid data; dest is cleared, *nextafterplist is NULL.
  * @retval DDS_RETCODE_UNSUPPORTED
@@ -244,20 +232,6 @@ DDS_EXPORT dds_return_t nn_plist_init_frommsg (nn_plist_t *dest, char **nextafte
 DDS_EXPORT void nn_plist_fini (nn_plist_t *ps);
 DDS_EXPORT void nn_plist_addtomsg (struct nn_xmsg *m, const nn_plist_t *ps, uint64_t pwanted, uint64_t qwanted);
 DDS_EXPORT void nn_plist_init_default_participant (nn_plist_t *plist);
-
-DDS_EXPORT dds_return_t validate_history_qospolicy (const dds_history_qospolicy_t *q);
-DDS_EXPORT dds_return_t validate_durability_qospolicy (const dds_durability_qospolicy_t *q);
-DDS_EXPORT dds_return_t validate_resource_limits_qospolicy (const dds_resource_limits_qospolicy_t *q);
-DDS_EXPORT dds_return_t validate_history_and_resource_limits (const dds_history_qospolicy_t *qh, const dds_resource_limits_qospolicy_t *qr);
-DDS_EXPORT dds_return_t validate_durability_service_qospolicy (const dds_durability_service_qospolicy_t *q);
-DDS_EXPORT dds_return_t validate_liveliness_qospolicy (const dds_liveliness_qospolicy_t *q);
-DDS_EXPORT dds_return_t validate_destination_order_qospolicy (const dds_destination_order_qospolicy_t *q);
-DDS_EXPORT dds_return_t validate_ownership_qospolicy (const dds_ownership_qospolicy_t *q);
-DDS_EXPORT dds_return_t validate_ownership_strength_qospolicy (const dds_ownership_strength_qospolicy_t *q);
-DDS_EXPORT dds_return_t validate_presentation_qospolicy (const dds_presentation_qospolicy_t *q);
-DDS_EXPORT dds_return_t validate_transport_priority_qospolicy (const dds_transport_priority_qospolicy_t *q);
-DDS_EXPORT dds_return_t validate_reader_data_lifecycle (const dds_reader_data_lifecycle_qospolicy_t *q);
-DDS_EXPORT dds_return_t validate_duration (const dds_duration_t d);
 
 struct nn_rmsg;
 struct nn_rsample_info;

--- a/src/core/ddsi/include/dds/ddsi/q_protocol.h
+++ b/src/core/ddsi/include/dds/ddsi/q_protocol.h
@@ -390,14 +390,6 @@ typedef struct ParticipantMessageData {
 #define PID_IDENTITY_TOKEN                      0x1001u
 #define PID_PERMISSIONS_TOKEN                   0x1002u
 
-#define PID_RTI_TYPECODE                        (PID_VENDORSPECIFIC_FLAG | 0x4u)
-
-#ifdef DDSI_INCLUDE_SSM
-/* To indicate whether a reader favours the use of SSM.  Iff the
-   reader favours SSM, it will use SSM if available. */
-#define PID_READER_FAVOURS_SSM                  0x72u
-#endif
-
 #ifdef DDSI_INCLUDE_SSM
 /* To indicate whether a reader favours the use of SSM.  Iff the
    reader favours SSM, it will use SSM if available. */

--- a/src/core/ddsi/include/dds/ddsi/q_qosmatch.h
+++ b/src/core/ddsi/include/dds/ddsi/q_qosmatch.h
@@ -20,8 +20,14 @@ struct dds_qos;
 
 int partitions_match_p (const struct dds_qos *a, const struct dds_qos *b);
 
-/* Returns -1 on success, or QoS id of first mismatch (>=0) */
+/* perform reader/writer QoS (and topic name, type name, partition) matching;
+   mask can be used to exclude some of these (including topic name and type
+   name, so be careful!)
 
+   reason will be set to the policy id of one of the mismatching QoS, or to
+   DDS_INVALID_QOS_POLICY_ID if there is no mismatch or if the mismatch is
+   in topic or type name (those are not really QoS and don't have a policy id) */
+bool qos_match_mask_p (const dds_qos_t *rd, const dds_qos_t *wr, uint64_t mask, dds_qos_policy_id_t *reason) ddsrt_nonnull_all;
 bool qos_match_p (const struct dds_qos *rd, const struct dds_qos *wr, dds_qos_policy_id_t *reason) ddsrt_nonnull ((1, 2));
 
 #if defined (__cplusplus)

--- a/src/core/ddsi/include/dds/ddsi/q_xmsg.h
+++ b/src/core/ddsi/include/dds/ddsi/q_xmsg.h
@@ -28,8 +28,6 @@ struct proxy_reader;
 struct proxy_writer;
 
 struct nn_prismtech_participant_version_info;
-struct nn_prismtech_writer_info;
-struct nn_prismtech_eotinfo;
 struct nn_xmsgpool;
 struct nn_xmsg_data;
 struct nn_xmsg;
@@ -139,7 +137,6 @@ void nn_xmsg_addpar_reader_data_lifecycle (struct nn_xmsg *m, nn_parameterid_t p
 void nn_xmsg_addpar_liveliness (struct nn_xmsg *m, nn_parameterid_t pid, const dds_liveliness_qospolicy_t *rq);
 
 void nn_xmsg_addpar_parvinfo (struct nn_xmsg *m, nn_parameterid_t pid, const struct nn_prismtech_participant_version_info *pvi);
-void nn_xmsg_addpar_eotinfo (struct nn_xmsg *m, nn_parameterid_t pid, const struct nn_prismtech_eotinfo *txnid);
 void nn_xmsg_addpar_sentinel (struct nn_xmsg *m);
 int nn_xmsg_addpar_sentinel_ifparam (struct nn_xmsg *m);
 

--- a/src/core/ddsi/include/dds/ddsi/q_xqos.h
+++ b/src/core/ddsi/include/dds/ddsi/q_xqos.h
@@ -211,7 +211,6 @@ typedef struct dds_ignorelocal_qospolicy {
 #define QP_PRISMTECH_READER_LIFESPAN         ((uint64_t)1 << 24)
 #define QP_PRISMTECH_SUBSCRIPTION_KEYS       ((uint64_t)1 << 25)
 #define QP_PRISMTECH_ENTITY_FACTORY          ((uint64_t)1 << 27)
-#define QP_RTI_TYPECODE                      ((uint64_t)1 << 29)
 #define QP_CYCLONE_IGNORELOCAL               ((uint64_t)1 << 30)
 
 /* Partition QoS is not RxO according to the specification (DDS 1.2,
@@ -264,8 +263,6 @@ struct dds_qos {
   /*x xR*/dds_subscription_keys_qospolicy_t subscription_keys;
   /*x xR*/dds_reader_lifespan_qospolicy_t reader_lifespan;
   /* x  */dds_ignorelocal_qospolicy_t ignorelocal;
-
-  /*   X*/ddsi_octetseq_t rti_typecode;
 };
 
 struct nn_xmsg;
@@ -280,7 +277,8 @@ DDS_EXPORT void nn_xqos_init_default_topic (dds_qos_t *xqos);
 DDS_EXPORT void nn_xqos_copy (dds_qos_t *dst, const dds_qos_t *src);
 DDS_EXPORT void nn_xqos_unalias (dds_qos_t *xqos);
 DDS_EXPORT void nn_xqos_fini (dds_qos_t *xqos);
-DDS_EXPORT void nn_xqos_mergein_missing (dds_qos_t *a, const dds_qos_t *b);
+DDS_EXPORT dds_return_t nn_xqos_valid (const dds_qos_t *xqos);
+DDS_EXPORT void nn_xqos_mergein_missing (dds_qos_t *a, const dds_qos_t *b, uint64_t mask);
 DDS_EXPORT uint64_t nn_xqos_delta (const dds_qos_t *a, const dds_qos_t *b, uint64_t mask);
 DDS_EXPORT void nn_xqos_addtomsg (struct nn_xmsg *m, const dds_qos_t *xqos, uint64_t wanted);
 DDS_EXPORT void nn_log_xqos (uint32_t cat, const dds_qos_t *xqos);

--- a/src/core/ddsi/src/q_ddsi_discovery.c
+++ b/src/core/ddsi/src/q_ddsi_discovery.c
@@ -1085,7 +1085,7 @@ static struct proxy_participant *implicitly_create_proxypp (const nn_guid_t *ppg
       tmp_plist = *privpp->plist;
       tmp_plist.present = PP_PARTICIPANT_GUID | PP_PRISMTECH_PARTICIPANT_VERSION_INFO;
       tmp_plist.participant_guid = *ppguid;
-      nn_plist_mergein_missing (&pp_plist, &tmp_plist);
+      nn_plist_mergein_missing (&pp_plist, &tmp_plist, ~(uint64_t)0, ~(uint64_t)0);
       ddsrt_mutex_unlock (&privpp->e.lock);
 
       pp_plist.prismtech_participant_version_info.flags &= ~NN_PRISMTECH_FL_PARTICIPANT_IS_DDSI2;
@@ -1146,11 +1146,11 @@ static void handle_SEDP_alive (const struct receiver_state *rst, nn_plist_t *dat
   xqos = &datap->qos;
   is_writer = is_writer_entityid (datap->endpoint_guid.entityid);
   if (!is_writer)
-    nn_xqos_mergein_missing (xqos, &gv.default_xqos_rd);
+    nn_xqos_mergein_missing (xqos, &gv.default_xqos_rd, ~(uint64_t)0);
   else if (vendor_is_eclipse_or_prismtech(vendorid))
-    nn_xqos_mergein_missing (xqos, &gv.default_xqos_wr);
+    nn_xqos_mergein_missing (xqos, &gv.default_xqos_wr, ~(uint64_t)0);
   else
-    nn_xqos_mergein_missing (xqos, &gv.default_xqos_wr_nad);
+    nn_xqos_mergein_missing (xqos, &gv.default_xqos_wr_nad, ~(uint64_t)0);
 
   /* After copy + merge, should have at least the ones present in the
      input.  Also verify reliability and durability are present,
@@ -1434,8 +1434,7 @@ int sedp_write_cm_participant (struct participant *pp, int alive)
   {
     nn_plist_addtomsg (mpayload, pp->plist,
                        PP_PRISMTECH_NODE_NAME | PP_PRISMTECH_EXEC_NAME | PP_PRISMTECH_PROCESS_ID |
-                       PP_PRISMTECH_WATCHDOG_SCHEDULING | PP_PRISMTECH_LISTENER_SCHEDULING |
-                       PP_PRISMTECH_SERVICE_TYPE | PP_ENTITY_NAME,
+                       PP_ENTITY_NAME,
                        QP_PRISMTECH_ENTITY_FACTORY);
   }
   nn_xmsg_addpar_sentinel (mpayload);

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -457,7 +457,7 @@ dds_return_t new_participant_guid (const nn_guid_t *ppguid, unsigned flags, cons
   pp->lease_duration = config.lease_duration;
   pp->plist = ddsrt_malloc (sizeof (*pp->plist));
   nn_plist_copy (pp->plist, plist);
-  nn_plist_mergein_missing (pp->plist, &gv.default_plist_pp);
+  nn_plist_mergein_missing (pp->plist, &gv.default_plist_pp, ~(uint64_t)0, ~(uint64_t)0);
 
   if (dds_get_log_mask() & DDS_LC_DISCOVERY)
   {
@@ -2684,7 +2684,7 @@ static void new_writer_guid_common_init (struct writer *wr, const struct ddsi_se
 
   wr->xqos = ddsrt_malloc (sizeof (*wr->xqos));
   nn_xqos_copy (wr->xqos, xqos);
-  nn_xqos_mergein_missing (wr->xqos, &gv.default_xqos_wr);
+  nn_xqos_mergein_missing (wr->xqos, &gv.default_xqos_wr, ~(uint64_t)0);
   assert (wr->xqos->aliased == 0);
   set_topic_type_name (wr->xqos, topic);
 
@@ -3222,7 +3222,7 @@ static dds_return_t new_reader_guid
   /* Copy QoS, merging in defaults */
   rd->xqos = ddsrt_malloc (sizeof (*rd->xqos));
   nn_xqos_copy (rd->xqos, xqos);
-  nn_xqos_mergein_missing (rd->xqos, &gv.default_xqos_rd);
+  nn_xqos_mergein_missing (rd->xqos, &gv.default_xqos_rd, ~(uint64_t)0);
   assert (rd->xqos->aliased == 0);
   set_topic_type_name (rd->xqos, topic);
 
@@ -3660,7 +3660,7 @@ int update_proxy_participant_plist_locked (struct proxy_participant *proxypp, co
   nn_plist_t *new_plist;
 
   new_plist = nn_plist_dup (datap);
-  nn_plist_mergein_missing (new_plist, proxypp->plist);
+  nn_plist_mergein_missing (new_plist, proxypp->plist, ~(uint64_t)0, ~(uint64_t)0);
   nn_plist_fini (proxypp->plist);
   ddsrt_free (proxypp->plist);
   proxypp->plist = new_plist;
@@ -3694,8 +3694,7 @@ int update_proxy_participant_plist (struct proxy_participant *proxypp, const str
       tmp = *datap;
       tmp.present &=
         PP_PRISMTECH_NODE_NAME | PP_PRISMTECH_EXEC_NAME | PP_PRISMTECH_PROCESS_ID |
-        PP_PRISMTECH_WATCHDOG_SCHEDULING | PP_PRISMTECH_LISTENER_SCHEDULING |
-        PP_PRISMTECH_SERVICE_TYPE | PP_ENTITY_NAME;
+        PP_ENTITY_NAME;
       tmp.qos.present &= QP_PRISMTECH_ENTITY_FACTORY;
       update_proxy_participant_plist_locked (proxypp, &tmp, source, timestamp);
       break;
@@ -3993,7 +3992,7 @@ int new_proxy_group (const struct nn_guid *guid, const char *name, const struct 
       DDS_LOG(DDS_LC_DISCOVERY, "new_proxy_group("PGUIDFMT"): setting name (%s) and qos\n", PGUID (*guid), name);
       pgroup->name = ddsrt_strdup (name);
       pgroup->xqos = nn_xqos_dup (xqos);
-      nn_xqos_mergein_missing (pgroup->xqos, is_sub ? &gv.default_xqos_sub : &gv.default_xqos_pub);
+      nn_xqos_mergein_missing (pgroup->xqos, is_sub ? &gv.default_xqos_sub : &gv.default_xqos_pub, ~(uint64_t)0);
     }
   out:
     ddsrt_mutex_unlock (&proxypp->e.lock);

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -850,10 +850,11 @@ int rtps_init (void)
   uint32_t port_data_uc = 0;
   bool mc_available = true;
 
+  gv.tstart = now ();    /* wall clock time, used in logs */
+
   ddsi_plugin_init ();
   ddsi_iid_init ();
-
-  gv.tstart = now ();    /* wall clock time, used in logs */
+  nn_plist_init_tables ();
 
   gv.disc_conn_uc = NULL;
   gv.data_conn_uc = NULL;

--- a/src/core/ddsi/src/q_receive.c
+++ b/src/core/ddsi/src/q_receive.c
@@ -1952,7 +1952,7 @@ static int deliver_user_data (const struct nn_rsample_info *sampleinfo, const st
     src.encoding = (msg->smhdr.flags & SMFLAG_ENDIANNESS) ? PL_CDR_LE : PL_CDR_BE;
     src.buf = NN_RMSG_PAYLOADOFF (fragchain->rmsg, qos_offset);
     src.bufsz = NN_RDATA_PAYLOAD_OFF (fragchain) - qos_offset;
-    if ((plist_ret = nn_plist_init_frommsg (&qos, NULL, PP_STATUSINFO | PP_KEYHASH | PP_COHERENT_SET | PP_PRISMTECH_EOTINFO, 0, &src)) < 0)
+    if ((plist_ret = nn_plist_init_frommsg (&qos, NULL, PP_STATUSINFO | PP_KEYHASH | PP_COHERENT_SET, 0, &src)) < 0)
     {
       if (plist_ret != DDS_RETCODE_UNSUPPORTED)
         DDS_WARNING ("data(application, vendor %u.%u): "PGUIDFMT" #%"PRId64": invalid inline qos\n",
@@ -1980,9 +1980,7 @@ static int deliver_user_data (const struct nn_rsample_info *sampleinfo, const st
   }
 
   /* Generate the DDS_SampleInfo (which is faked to some extent
-     because we don't actually have a data reader); also note that
-     the PRISMTECH_WRITER_INFO thing is completely meaningless to
-     us */
+     because we don't actually have a data reader) */
   struct ddsi_tkmap_instance * tk;
   if ((tk = ddsi_tkmap_lookup_instance_ref(payload)) != NULL)
   {

--- a/src/core/ddsi/src/q_xmsg.c
+++ b/src/core/ddsi/src/q_xmsg.c
@@ -1029,19 +1029,6 @@ void nn_xmsg_addpar_parvinfo (struct nn_xmsg *m, nn_parameterid_t pid, const str
   memcpy(ps->contents, pvi->internals, slen);
 }
 
-void nn_xmsg_addpar_eotinfo (struct nn_xmsg *m, nn_parameterid_t pid, const struct nn_prismtech_eotinfo *txnid)
-{
-  uint32_t *pu, i;
-  pu = nn_xmsg_addpar (m, pid, 2 * sizeof (uint32_t) + txnid->n * sizeof (txnid->tids[0]));
-  pu[0] = txnid->transactionId;
-  pu[1] = txnid->n;
-  for (i = 0; i < txnid->n; i++)
-  {
-    pu[2*i + 2] = toBE4u (txnid->tids[i].writer_entityid.u);
-    pu[2*i + 3] = txnid->tids[i].transactionId;
-  }
-}
-
 /* XMSG_CHAIN ----------------------------------------------------------
 
    Xpacks refer to xmsgs and need to release these after having been

--- a/src/core/xtests/rhc_torture/rhc_torture.c
+++ b/src/core/xtests/rhc_torture/rhc_torture.c
@@ -147,7 +147,7 @@ static struct proxy_writer *mkwr (bool auto_dispose)
   wr_iid = ddsi_iid_gen ();
   memset (pwr, 0, sizeof (*pwr));
   nn_xqos_init_empty (xqos);
-  nn_xqos_mergein_missing (xqos, &gv.default_xqos_wr);
+  nn_xqos_mergein_missing (xqos, &gv.default_xqos_wr, ~(uint64_t)0);
   xqos->ownership_strength.value = 0;
   xqos->writer_data_lifecycle.autodispose_unregistered_instances = auto_dispose;
   pwr->e.iid = wr_iid;
@@ -170,7 +170,7 @@ static struct rhc *mkrhc (dds_reader *rd, dds_history_kind_t hk, int32_t hdepth,
   rqos.history.kind = hk;
   rqos.history.depth = hdepth;
   rqos.destination_order.kind = dok;
-  nn_xqos_mergein_missing (&rqos, &gv.default_xqos_rd);
+  nn_xqos_mergein_missing (&rqos, &gv.default_xqos_rd, ~(uint64_t)0);
   thread_state_awake (lookup_thread_state ());
   rhc = dds_rhc_new (rd, mdtopic);
   dds_rhc_set_qos(rhc, &rqos);

--- a/src/ddsrt/include/dds/ddsrt/attributes.h
+++ b/src/ddsrt/include/dds/ddsrt/attributes.h
@@ -105,4 +105,10 @@
 # define ddsrt_attribute_assume_aligned(params)
 #endif
 
+#if ddsrt_has_attribute(packed)
+# define ddsrt_attribute_packed __attribute__ ((__packed__))
+#else
+# define ddsrt_attribute_packed
+#endif
+
 #endif /* DDSRT_ATTRIBUTES_H */

--- a/src/mpt/tests/qosmatch/CMakeLists.txt
+++ b/src/mpt/tests/qosmatch/CMakeLists.txt
@@ -9,11 +9,15 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
-cmake_minimum_required(VERSION 3.7)
+include(${MPT_CMAKE})
 
-if(MPT_ENABLE_SELFTEST)
-  add_subdirectory(self)
-endif()
+set(sources
+    "procs/rw.c"
+    "qosmatch.c")
 
-add_subdirectory(basic)
-add_subdirectory(qosmatch)
+add_compile_options("-I${PROJECT_SOURCE_DIR}/core/ddsi/include")
+add_mpt_executable(mpt_qosmatch ${sources})
+
+idlc_generate(mpt_qosmatch_rwdata_lib "procs/rwdata.idl")
+target_link_libraries(mpt_qosmatch PRIVATE mpt_qosmatch_rwdata_lib)
+

--- a/src/mpt/tests/qosmatch/procs/rw.c
+++ b/src/mpt/tests/qosmatch/procs/rw.c
@@ -1,0 +1,376 @@
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+
+#include "mpt/mpt.h"
+
+#include "dds/dds.h"
+#include "rwdata.h"
+
+#include "dds/ddsrt/time.h"
+#include "dds/ddsrt/process.h"
+#include "dds/ddsrt/sockets.h"
+#include "dds/ddsrt/heap.h"
+
+#include "dds/ddsi/q_xqos.h"
+
+#define NPUB 10
+#define NWR_PUB 2
+
+void rw_init (void)
+{
+}
+
+void rw_fini (void)
+{
+}
+
+static void setqos (dds_qos_t *q, size_t i, bool isrd, bool create)
+{
+  size_t psi = i - (i % NWR_PUB);
+  /* Participant, publisher & topic get created with i == 0,
+     so make sure those have some crazy data set.  The writers
+     should inherit the topic and group data, but the user data
+     should be updated for each writer */
+  if (create)
+  {
+    if (psi == 1)
+    {
+      dds_qset_userdata (q, NULL, 0);
+      dds_qset_topicdata (q, NULL, 0);
+      dds_qset_groupdata (q, NULL, 0);
+    }
+    else
+    {
+      char buf[20];
+      snprintf (buf, sizeof (buf), "ud%zu%c", i, isrd ? 'r' : 'w');
+      dds_qset_userdata (q, buf, strlen (buf));
+      snprintf (buf, sizeof (buf), "td%zu", i);
+      dds_qset_topicdata (q, buf, strlen (buf));
+      snprintf (buf, sizeof (buf), "gd%zu", psi);
+      dds_qset_groupdata (q, buf, strlen (buf));
+    }
+  }
+  else
+  {
+    if (psi == 1)
+    {
+      dds_qset_userdata (q, NULL, 0);
+      dds_qset_topicdata (q, NULL, 0);
+      dds_qset_groupdata (q, NULL, 0);
+    }
+    else
+    {
+      char buf[20];
+      snprintf (buf, sizeof (buf), "ud%zu%c", i, isrd ? 'r' : 'w');
+      dds_qset_userdata (q, buf, strlen (buf));
+      snprintf (buf, sizeof (buf), "td%zu", (size_t) 0);
+      dds_qset_topicdata (q, buf, strlen (buf));
+      snprintf (buf, sizeof (buf), "gd%zu", psi);
+      dds_qset_groupdata (q, buf, strlen (buf));
+    }
+  }
+
+  /* Cyclone's accepting unimplemented QoS settings is a bug, but it does allow
+     us to feed it all kinds of nonsense and see whether discovery manages it */
+
+  /* this makes topic transient-local, keep-last 1 */
+  dds_qset_durability (q, (dds_durability_kind_t) ((i + 1) % 4));
+  dds_qset_history (q, (dds_history_kind_t) ((i + 1) % 2), (int32_t) (i + 1));
+  dds_qset_resource_limits (q, (int32_t) i + 3, (int32_t) i + 2, (int32_t) i + 1);
+  dds_qset_presentation (q, (dds_presentation_access_scope_kind_t) ((psi + 1) % 3), 1, 1);
+  dds_qset_lifespan (q, INT64_C (23456789012345678) + (int32_t) i);
+  dds_qset_deadline (q, INT64_C (67890123456789012) + (int32_t) i);
+  dds_qset_latency_budget (q, INT64_C (45678901234567890) + (int32_t) i);
+  dds_qset_ownership (q, (dds_ownership_kind_t) ((i + 1) % 2));
+  dds_qset_ownership_strength (q, 0x12345670 + (int32_t) i);
+  dds_qset_liveliness (q, (dds_liveliness_kind_t) ((i + i) % 2), INT64_C (456789012345678901) + (int32_t) i);
+  dds_qset_time_based_filter (q, INT64_C (34567890123456789) + (int32_t) i); /* must be <= deadline */
+  if (psi == 0)
+    dds_qset_partition1 (q, "p");
+  else if (psi == 1)
+    dds_qset_partition (q, 0, NULL);
+  else
+  {
+    char **ps = ddsrt_malloc (psi * sizeof (*ps));
+    for (size_t j = 0; j < psi; j++)
+    {
+      const size_t n = 40;
+      ps[j] = ddsrt_malloc (n);
+      snprintf (ps[j], n, "p%zu_%zu", psi, isrd ? (psi-j-1) : j);
+    }
+    dds_qset_partition (q, (uint32_t) psi, (const char **) ps);
+    for (size_t j = 0; j < psi; j++)
+      ddsrt_free (ps[j]);
+    ddsrt_free (ps);
+  }
+  dds_qset_reliability (q, (dds_reliability_kind_t) ((i + 1) % 2), INT64_C (890123456789012345) + (int32_t) i);
+  dds_qset_transport_priority (q, 0x23456701 + (int32_t) i);
+  dds_qset_destination_order (q, (dds_destination_order_kind_t) ((i + 1) % 2));
+  dds_qset_writer_data_lifecycle (q, ((i + 1) % 2) != 0);
+  dds_qset_reader_data_lifecycle (q, INT64_C (41234567890123456) + (int32_t) i, INT64_C (912345678901234567) + (int32_t) i);
+  dds_qset_durability_service (q, INT64_C (123456789012345678) + (int32_t) i, (dds_history_kind_t) ((i + 1) % 2), (int32_t) (i + 1), (int32_t) i + 3, (int32_t) i + 2, (int32_t) i + 1);
+}
+
+static bool pubsub_qos_eq_h (const dds_qos_t *a, dds_entity_t ent)
+{
+  dds_qos_t *b = dds_create_qos ();
+  dds_get_qos (ent, b);
+  /* internal interface is more luxurious that a simple compare for equality, and
+     using that here saves us a ton of code */
+  uint64_t delta = nn_xqos_delta (a, b, QP_GROUP_DATA | QP_PRESENTATION | QP_PARTITION);
+  if (delta)
+  {
+    DDS_LOG (DDS_LC_ERROR, "pub/sub: delta = %"PRIx64"\n", delta);
+    nn_log_xqos (DDS_LC_ERROR, a); DDS_LOG (DDS_LC_ERROR, "\n");
+    nn_log_xqos (DDS_LC_ERROR, b); DDS_LOG (DDS_LC_ERROR, "\n");
+  }
+  dds_delete_qos (b);
+  return delta == 0;
+}
+
+static uint64_t reader_qos_delta (const dds_qos_t *a, const dds_qos_t *b)
+{
+  return nn_xqos_delta (a, b, QP_USER_DATA | QP_TOPIC_DATA | QP_GROUP_DATA | QP_DURABILITY | QP_HISTORY | QP_RESOURCE_LIMITS | QP_PRESENTATION | QP_DEADLINE | QP_LATENCY_BUDGET | QP_OWNERSHIP | QP_LIVELINESS | QP_TIME_BASED_FILTER | QP_PARTITION | QP_RELIABILITY | QP_DESTINATION_ORDER | QP_PRISMTECH_READER_DATA_LIFECYCLE);
+}
+
+static bool reader_qos_eq_h (const dds_qos_t *a, dds_entity_t ent)
+{
+  dds_qos_t *b = dds_create_qos ();
+  dds_get_qos (ent, b);
+  uint64_t delta = reader_qos_delta (a, b);
+  if (delta)
+  {
+    DDS_LOG (DDS_LC_ERROR, "reader: delta = %"PRIx64"\n", delta);
+    nn_log_xqos (DDS_LC_ERROR, a); DDS_LOG (DDS_LC_ERROR, "\n");
+    nn_log_xqos (DDS_LC_ERROR, b); DDS_LOG (DDS_LC_ERROR, "\n");
+  }
+  dds_delete_qos (b);
+  return delta == 0;
+}
+
+static uint64_t writer_qos_delta (const dds_qos_t *a, const dds_qos_t *b)
+{
+  return nn_xqos_delta (a, b, QP_USER_DATA | QP_TOPIC_DATA | QP_GROUP_DATA | QP_DURABILITY | QP_HISTORY | QP_RESOURCE_LIMITS | QP_PRESENTATION | QP_LIFESPAN | QP_DEADLINE | QP_LATENCY_BUDGET | QP_OWNERSHIP | QP_OWNERSHIP_STRENGTH | QP_LIVELINESS | QP_PARTITION | QP_RELIABILITY | QP_DESTINATION_ORDER | QP_PRISMTECH_WRITER_DATA_LIFECYCLE);
+}
+
+static bool writer_qos_eq_h (const dds_qos_t *a, dds_entity_t ent)
+{
+  dds_qos_t *b = dds_create_qos ();
+  dds_get_qos (ent, b);
+  uint64_t delta = writer_qos_delta (a, b);
+  if (delta)
+  {
+    DDS_LOG (DDS_LC_ERROR, "writer: delta = %"PRIx64"\n", delta);
+    nn_log_xqos (DDS_LC_ERROR, a); DDS_LOG (DDS_LC_ERROR, "\n");
+    nn_log_xqos (DDS_LC_ERROR, b); DDS_LOG (DDS_LC_ERROR, "\n");
+  }
+  dds_delete_qos (b);
+  return delta == 0;
+}
+
+MPT_ProcessEntry (rw_publisher,
+                  MPT_Args (dds_domainid_t domainid,
+                            const char *topic_name))
+{
+  dds_entity_t dp;
+  dds_entity_t tp;
+  dds_entity_t pub[NPUB];
+  dds_entity_t wr[NPUB][NWR_PUB];
+  bool chk[NPUB][NWR_PUB] = { { false } };
+  dds_return_t rc;
+  dds_qos_t *qos;
+  int id = (int) ddsrt_getpid ();
+
+  printf ("=== [Publisher(%d)] Start(%d) ...\n", id, (int) domainid);
+
+  qos = dds_create_qos ();
+  setqos (qos, 0, false, true);
+  dp = dds_create_participant (domainid, NULL, NULL);
+  MPT_ASSERT_FATAL_GT (dp, 0, "Could not create participant: %s\n", dds_strretcode (dp));
+
+  tp = dds_create_topic (dp, &RWData_Msg_desc, topic_name, qos, NULL);
+  MPT_ASSERT_FATAL_GT (tp, 0, "Could not create topic: %s\n", dds_strretcode (tp));
+
+  for (size_t i = 0; i < NPUB; i++)
+  {
+    setqos (qos, i * NWR_PUB, false, true);
+    pub[i] = dds_create_publisher (dp, qos, NULL);
+    MPT_ASSERT_FATAL_GT (pub[i], 0, "Could not create publisher %zu: %s\n", i, dds_strretcode (pub[i]));
+    for (size_t j = 0; j < NWR_PUB; j++)
+    {
+      setqos (qos, i * NWR_PUB + j, false, true);
+      wr[i][j] = dds_create_writer (pub[i], tp, qos, NULL);
+      MPT_ASSERT_FATAL_GT (wr[i][j], 0, "Could not create writer %zu %zu: %s\n", i, j, dds_strretcode (wr[i][j]));
+    }
+  }
+
+  for (size_t i = 0; i < NPUB; i++)
+  {
+    setqos (qos, i * NWR_PUB, false, false);
+    MPT_ASSERT (pubsub_qos_eq_h (qos, pub[i]), "publisher %zu QoS mismatch\n", i);
+    for (size_t j = 0; j < NWR_PUB; j++)
+    {
+      setqos (qos, i * NWR_PUB + j, false, false);
+      MPT_ASSERT (writer_qos_eq_h (qos, wr[i][j]), "writer %zu %zu QoS mismatch\n", i, j);
+    }
+  }
+
+  /* Each writer should match exactly one reader */
+  uint32_t nchk = 0;
+  while (nchk != NPUB * NWR_PUB)
+  {
+    for (size_t i = 0; i < NPUB; i++)
+    {
+      for (size_t j = 0; j < NWR_PUB; j++)
+      {
+        if (chk[i][j])
+          continue;
+        dds_instance_handle_t ih;
+        dds_builtintopic_endpoint_t *ep;
+        rc = dds_get_matched_subscriptions (wr[i][j], &ih, 1);
+        MPT_ASSERT (rc == 0 || rc == 1, "Unexpected return from get_matched_subscriptions for writer %zu %zu: %s\n",
+                    i, j, dds_strretcode (rc));
+        if (rc == 1)
+        {
+          ep = dds_get_matched_subscription_data (wr[i][j], ih);
+          MPT_ASSERT (ep != NULL, "Failed to retrieve matched subscription data for writer %zu %zu\n", i, j);
+          setqos (qos, i * NWR_PUB + j, true, false);
+          uint64_t delta = reader_qos_delta (qos, ep->qos);
+          if (delta)
+          {
+            DDS_LOG (DDS_LC_ERROR, "matched reader: delta = %"PRIx64"\n", delta);
+            nn_log_xqos (DDS_LC_ERROR, qos); DDS_LOG (DDS_LC_ERROR, "\n");
+            nn_log_xqos (DDS_LC_ERROR, ep->qos); DDS_LOG (DDS_LC_ERROR, "\n");
+          }
+          MPT_ASSERT (delta == 0, "writer %zu %zu matched reader QoS mismatch\n", i, j);
+          dds_delete_qos (ep->qos);
+          dds_free (ep->topic_name);
+          dds_free (ep->type_name);
+          dds_free (ep);
+          chk[i][j] = true;
+          nchk++;
+        }
+      }
+    }
+    dds_sleepfor (DDS_MSECS (100));
+  }
+
+  /* Wait until subscribers terminate */
+  while (true)
+  {
+    for (size_t i = 0; i < NPUB; i++)
+    {
+      for (size_t j = 0; j < NWR_PUB; j++)
+      {
+        dds_publication_matched_status_t st;
+        rc = dds_get_publication_matched_status (wr[i][j], &st);
+        MPT_ASSERT_FATAL_EQ (rc, DDS_RETCODE_OK, "dds_get_matched_publication_status failed for writer %zu %zu: %s\n",
+                             i, j, dds_strretcode (rc));
+        if (st.current_count)
+          goto have_matches;
+      }
+    }
+    break;
+  have_matches:
+    ;
+  }
+
+  dds_delete_qos (qos);
+  rc = dds_delete (dp);
+  MPT_ASSERT_EQ (rc, DDS_RETCODE_OK, "teardown failed\n");
+  printf ("=== [Publisher(%d)] Done\n", id);
+}
+
+MPT_ProcessEntry (rw_subscriber,
+                  MPT_Args (dds_domainid_t domainid,
+                            const char *topic_name))
+{
+  dds_entity_t dp;
+  dds_entity_t tp;
+  dds_entity_t sub[NPUB];
+  dds_entity_t rd[NPUB][NWR_PUB];
+  bool chk[NPUB][NWR_PUB] = { { false } };
+  dds_return_t rc;
+  dds_qos_t *qos;
+  int id = (int) ddsrt_getpid ();
+
+  printf ("=== [Subscriber(%d)] Start(%d) ...\n", id, (int) domainid);
+
+  qos = dds_create_qos ();
+  setqos (qos, 0, true, true);
+  dp = dds_create_participant (domainid, NULL, NULL);
+  MPT_ASSERT_FATAL_GT (dp, 0, "Could not create participant: %s\n", dds_strretcode (dp));
+
+  tp = dds_create_topic (dp, &RWData_Msg_desc, topic_name, qos, NULL);
+  MPT_ASSERT_FATAL_GT (tp, 0, "Could not create topic: %s\n", dds_strretcode (tp));
+
+  for (size_t i = 0; i < NPUB; i++)
+  {
+    setqos (qos, i * NWR_PUB, true, true);
+    sub[i] = dds_create_subscriber (dp, qos, NULL);
+    MPT_ASSERT_FATAL_GT (sub[i], 0, "Could not create subscriber %zu: %s\n", i, dds_strretcode (sub[i]));
+    for (size_t j = 0; j < NWR_PUB; j++)
+    {
+      setqos (qos, i * NWR_PUB + j, true, true);
+      rd[i][j] = dds_create_reader (sub[i], tp, qos, NULL);
+      MPT_ASSERT_FATAL_GT (rd[i][j], 0, "Could not create reader %zu %zu: %s\n", i, j, dds_strretcode (rd[i][j]));
+    }
+  }
+
+  for (size_t i = 0; i < NPUB; i++)
+  {
+    setqos (qos, i * NWR_PUB, true, false);
+    MPT_ASSERT (pubsub_qos_eq_h (qos, sub[i]), "subscriber %zu QoS mismatch\n", i);
+    for (size_t j = 0; j < NWR_PUB; j++)
+    {
+      setqos (qos, i * NWR_PUB + j, true, false);
+      MPT_ASSERT (reader_qos_eq_h (qos, rd[i][j]), "reader %zu %zu QoS mismatch\n", i, j);
+    }
+  }
+
+  /* Each writer should match exactly one reader */
+  uint32_t nchk = 0;
+  while (nchk != NPUB * NWR_PUB)
+  {
+    for (size_t i = 0; i < NPUB; i++)
+    {
+      for (size_t j = 0; j < NWR_PUB; j++)
+      {
+        if (chk[i][j])
+          continue;
+        dds_instance_handle_t ih;
+        dds_builtintopic_endpoint_t *ep;
+        rc = dds_get_matched_publications (rd[i][j], &ih, 1);
+        MPT_ASSERT (rc == 0 || rc == 1, "Unexpected return from get_matched_publications for writer %zu %zu: %s\n",
+                    i, j, dds_strretcode (rc));
+        if (rc == 1)
+        {
+          ep = dds_get_matched_publication_data (rd[i][j], ih);
+          MPT_ASSERT (ep != NULL, "Failed to retrieve matched publication data for writer %zu %zu\n", i, j);
+          setqos (qos, i * NWR_PUB + j, false, false);
+          uint64_t delta = writer_qos_delta (qos, ep->qos);
+          if (delta)
+          {
+            DDS_LOG (DDS_LC_ERROR, "matched writer: delta = %"PRIx64"\n", delta);
+            nn_log_xqos (DDS_LC_ERROR, qos); DDS_LOG (DDS_LC_ERROR, "\n");
+            nn_log_xqos (DDS_LC_ERROR, ep->qos); DDS_LOG (DDS_LC_ERROR, "\n");
+          }
+          MPT_ASSERT (delta == 0, "reader %zu %zu matched writer QoS mismatch\n", i, j);
+          dds_delete_qos (ep->qos);
+          dds_free (ep->topic_name);
+          dds_free (ep->type_name);
+          dds_free (ep);
+          chk[i][j] = true;
+          nchk++;
+        }
+      }
+    }
+    dds_sleepfor (DDS_MSECS (100));
+  }
+
+  dds_delete_qos (qos);
+  rc = dds_delete (dp);
+  MPT_ASSERT_EQ (rc, DDS_RETCODE_OK, "teardown failed\n");
+  printf ("=== [Subscriber(%d)] Done\n", id);
+}

--- a/src/mpt/tests/qosmatch/procs/rw.h
+++ b/src/mpt/tests/qosmatch/procs/rw.h
@@ -9,19 +9,33 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
-#ifndef _DDS_QOS_H_
-#define _DDS_QOS_H_
 
-#include "dds__entity.h"
-#include "dds/ddsi/q_xqos.h"
+#ifndef MPT_QOSMATCH_PROCS_RW_H
+#define MPT_QOSMATCH_PROCS_RW_H
+
+#include <stdio.h>
+#include <string.h>
+
+#include "dds/dds.h"
+#include "mpt/mpt.h"
 
 #if defined (__cplusplus)
 extern "C" {
 #endif
 
-dds_return_t dds_qos_validate_mutable_common (const dds_qos_t *qos);
+void rw_init (void);
+void rw_fini (void);
+
+MPT_ProcessEntry (rw_publisher,
+                  MPT_Args (dds_domainid_t domainid,
+                            const char *topic_name));
+
+MPT_ProcessEntry (rw_subscriber,
+                  MPT_Args (dds_domainid_t domainid,
+                            const char *topic_name));
 
 #if defined (__cplusplus)
 }
 #endif
+
 #endif

--- a/src/mpt/tests/qosmatch/procs/rwdata.idl
+++ b/src/mpt/tests/qosmatch/procs/rwdata.idl
@@ -1,0 +1,8 @@
+module RWData
+{
+  struct Msg
+  {
+    long k;
+  };
+  #pragma keylist Msg k
+};

--- a/src/mpt/tests/qosmatch/qosmatch.c
+++ b/src/mpt/tests/qosmatch/qosmatch.c
@@ -1,0 +1,20 @@
+#include "mpt/mpt.h"
+#include "procs/rw.h"
+
+
+/*
+ * Tests to check communication between multiple publisher(s) and subscriber(s).
+ */
+
+
+/*
+ * The publisher expects 2 publication matched.
+ * The subscribers expect 1 sample each.
+ */
+#define TEST_PUB_ARGS MPT_ArgValues(DDS_DOMAIN_DEFAULT, "multi_qosmatch")
+#define TEST_SUB_ARGS MPT_ArgValues(DDS_DOMAIN_DEFAULT, "multi_qosmatch")
+MPT_TestProcess(qosmatch, qosmatch, pub, rw_publisher,  TEST_PUB_ARGS);
+MPT_TestProcess(qosmatch, qosmatch, sub, rw_subscriber, TEST_SUB_ARGS);
+MPT_Test(qosmatch, qosmatch, .init=rw_init, .fini=rw_fini);
+#undef TEST_SUB_ARGS
+#undef TEST_PUB_ARGS


### PR DESCRIPTION
Deserializing and validating parameter lists was done with a huge amount of code in a gigantic switch statement, and most of it of the copy-paste variety. Validation code was also hand-written, with separate implementations for validating QoS passed in by the application and QoS received over the network (even though it really is the same thing).

Serialization was spread over multiple places (xmsg_addpar_... and a bunch of macro + special cases in q_plist.c). Comparing two QoS objects to see if they are the same was yet-another hand-written bit of code. All-in-all rather prone to develop small discrepancies, and rather large as well.

This PR is a rewrite of all that, it now relies on a bunch of tables defining the known parameters, their types and where they reside in the internal representation, a set of generic functions for the various operations + special cases for the ones that really don't fit.

A fair bit of testing is done by a new multi-process test that creates all sorts of silly QoS values with the simple object of checking whether they go through the system unchanged. What I haven't been able to test is the byte swapping, because of a lack of big-endian machines, but to the best of my knowledge it has all the byteswaps in there (and now there are _far_ fewer then there used to be, as most of the parameters go through a single deserializer).

(This builds on #191)