### PR TITLE
IDL-compiler: Support for topic keys

### DIFF
--- a/src/ddsts/include/dds/ddsts/typetree.h
+++ b/src/ddsts/include/dds/ddsts/typetree.h
@@ -53,7 +53,7 @@
 
 #define DDSTS_TYPES                    ((1L<<(26+1))-1L)
 #define DDSTS_TYPE_OF(O)               ((O)->type.flags & DDSTS_TYPES)
-#define DDSTS_IS_TYPE(O,T)             (DDSTS_TYPE_OF(O) == (T))
+#define DDSTS_IS_TYPE(O,T)             ((DDSTS_TYPE_OF(O) & (T)) != 0)
 #define DDSTS_IS_DEFINITION(O)         ((DDSTS_DEFINITIONS & (O)->type.flags) != 0)
 
 #define DDSTS_UNBOUND                  (1L<<27)
@@ -109,6 +109,11 @@ struct ddsts_typespec {
   ddsts_type_t *next;       /* pointer to the next sibling */
   void (*free_func)(ddsts_type_t*);
 };
+
+typedef struct {
+  ddsts_type_t *first;     /* pointer to the first element */
+  ddsts_type_t **ref_end;  /* pointer to the pointer where a next element can be appended */
+} ddsts_type_list_t;
 
 /* Base type specification (base_type_spec) */
 typedef struct {
@@ -261,7 +266,7 @@ ddsts_create_map(ddsts_type_t *key_type, ddsts_type_t *value_type, unsigned long
 typedef struct ddsts_module ddsts_module_t;
 struct ddsts_module {
   ddsts_typespec_t type;
-  ddsts_type_t *members;
+  ddsts_type_list_t members;
   ddsts_module_t *previous; /* to previous open of this module, if present */
 };
 
@@ -322,11 +327,18 @@ ddsts_create_struct_forward_dcl(ddsts_identifier_t name, ddsts_type_t **result);
 
 /* Struct declaration (struct_def)
  */
+typedef struct ddsts_struct_key ddsts_struct_key_t;
 typedef struct {
   ddsts_typespec_t type;
   ddsts_type_t *super; /* used for extended struct type definition */
-  ddsts_type_t *members;
+  ddsts_type_list_t members;
+  ddsts_struct_key_t *keys;
 } ddsts_struct_t;
+ 
+struct ddsts_struct_key {
+  ddsts_type_t *member;
+  ddsts_struct_key_t *next;
+};
 
 /**
  * @brief Creates a ddsts_struct_t with no members.
@@ -344,15 +356,30 @@ ddsts_create_struct(ddsts_identifier_t name, ddsts_type_t **result);
 /**
  * @brief Adds a member at the end of the members of a ddsts_struct_t struct.
  *
- * @param[inout] module  A non-NULL pointer to a ddsts_struct_t struct.
- * @param[in]    member  A non-NULL pointer to a member type that is not owned
- *                       yet. If the function returns success, the member type
- *                       will be owned by the struct.
+ * @param[inout] struct_def  A non-NULL pointer to a ddsts_struct_t struct.
+ * @param[in]    member      A non-NULL pointer to a member type that is not
+ *                           owned yet. If the function returns success, the
+ *                           member type will be owned by the struct.
  *
  * @returns A dds_retcode_t indicating success or failure.
  */
 DDS_EXPORT dds_retcode_t
 ddsts_struct_add_member(ddsts_type_t *struct_def, ddsts_type_t *member);
+
+/**
+ * @brief Adds a key at the end of the keys of a ddsts_struct_t struct.
+ *
+ * @param[inout] struct_def  A non-NULL pointer to a ddsts_struct_t struct.
+ * @param[in]    member      A non-NULL pointer to a member type that
+ *                           belongs to the struct.
+ *
+ * @returns A dds_retcode_t indicating success or failure. On success a
+ * struct ddsts_struct_key_t pointing to the member will be added to the
+ * keys of struct_def. DDS_RETCODE_ERROR is returned when the member is
+ * already included as a key.
+ */
+DDS_EXPORT dds_retcode_t
+ddsts_struct_add_key(ddsts_type_t *struct_def, ddsts_type_t *member);
 
 /* Declaration
  */

--- a/src/ddsts/src/typetree.c
+++ b/src/ddsts/src/typetree.c
@@ -20,7 +20,7 @@
 void ddsts_free_literal(ddsts_literal_t *literal)
 {
   if (literal->flags == DDSTS_STRING || literal->flags == DDSTS_WIDE_STRING) {
-    ddsrt_free((void*)literal->value.str);
+    ddsrt_free(literal->value.str);
   }
 }
 
@@ -71,8 +71,8 @@ static void init_type(ddsts_type_t *type, void (*free_func)(ddsts_type_t*), ddst
 
 static void free_type(ddsts_type_t *type)
 {
-  ddsrt_free((void*)type->type.name);
-  ddsrt_free((void*)type);
+  ddsrt_free(type->type.name);
+  ddsrt_free(type);
 }
 
 /* ddsts_base_type_t */
@@ -214,7 +214,7 @@ dds_retcode_t ddsts_create_map(ddsts_type_t *key_type, ddsts_type_t *value_type,
 
 static void free_module(ddsts_type_t *type)
 {
-  free_children(type->module.members);
+  free_children(type->module.members.first);
   free_type(type);
 }
 
@@ -225,7 +225,8 @@ dds_retcode_t ddsts_create_module(ddsts_identifier_t name, ddsts_type_t **result
     return DDS_RETCODE_OUT_OF_RESOURCES;
   }
   init_type(type, free_module, DDSTS_MODULE, name);
-  type->module.members = NULL;
+  type->module.members.first = NULL;
+  type->module.members.ref_end = &type->module.members.first;
   type->module.previous = NULL;
   *result = type;
   return DDS_RETCODE_OK;
@@ -235,18 +236,15 @@ dds_retcode_t ddsts_module_add_member(ddsts_type_t *module, ddsts_type_t *member
 {
   if (module != NULL) {
     member->type.parent = module;
-    ddsts_type_t **ref_child = &module->module.members;
-    while (*ref_child != 0) {
-      ref_child = &(*ref_child)->type.next;
-    }
-    *ref_child = member;
+    *module->module.members.ref_end = member;
+    module->module.members.ref_end = &member->type.next;
 
     /* if the member is a module, find previous open of this module, if any */
     if (DDSTS_IS_TYPE(member, DDSTS_MODULE)) {
       ddsts_module_t *parent_module;
       for (parent_module = &module->module; parent_module != NULL; parent_module = parent_module->previous) {
         ddsts_type_t *child;
-        for (child = parent_module->members; child != NULL; child = child->type.next) {
+        for (child = parent_module->members.first; child != NULL; child = child->type.next) {
           if (DDSTS_IS_TYPE(child, DDSTS_MODULE) && strcmp(child->type.name, member->type.name) == 0 && child != member) {
             member->module.previous = &child->module;
           }
@@ -262,12 +260,12 @@ dds_retcode_t ddsts_module_add_member(ddsts_type_t *module, ddsts_type_t *member
       ddsts_module_t *parent_module;
       for (parent_module = &module->module; parent_module != NULL; parent_module = parent_module->previous) {
         ddsts_type_t *child;
-	    for (child = parent_module->members; child != NULL; child = child->type.next) {
-		  if (DDSTS_IS_TYPE(child, DDSTS_FORWARD_STRUCT) && strcmp(child->type.name, member->type.name) == 0) {
-		    child->forward.definition = member;
-		  }
-	    }
-	  }
+        for (child = parent_module->members.first; child != NULL; child = child->type.next) {
+          if (DDSTS_IS_TYPE(child, DDSTS_FORWARD_STRUCT) && strcmp(child->type.name, member->type.name) == 0) {
+            child->forward.definition = member;
+          }
+        }
+      }
     }
   }
   return DDS_RETCODE_OK;
@@ -296,7 +294,13 @@ dds_retcode_t ddsts_create_struct_forward_dcl(ddsts_identifier_t name, ddsts_typ
 
 static void free_struct(ddsts_type_t *type)
 {
-  free_children(type->struct_def.members);
+  ddsts_struct_key_t *key = type->struct_def.keys;
+  while (key != NULL) {
+    ddsts_struct_key_t *next = key->next;
+    ddsrt_free(key);
+    key = next;
+  }
+  free_children(type->struct_def.members.first);
   free_type(type);
 }
 
@@ -307,8 +311,10 @@ dds_retcode_t ddsts_create_struct(ddsts_identifier_t name, ddsts_type_t **result
     return DDS_RETCODE_OUT_OF_RESOURCES;
   }
   init_type(type, free_struct, DDSTS_STRUCT, name);
-  type->struct_def.members = NULL;
+  type->struct_def.members.first = NULL;
+  type->struct_def.members.ref_end = &type->struct_def.members.first;
   type->struct_def.super = NULL;
+  type->struct_def.keys = NULL;
   *result = type;
   return DDS_RETCODE_OK;
 }
@@ -317,12 +323,28 @@ dds_retcode_t ddsts_struct_add_member(ddsts_type_t *struct_def, ddsts_type_t *me
 {
   if (struct_def != NULL) {
     member->type.parent = struct_def;
-    ddsts_type_t **ref_child = &struct_def->struct_def.members;
-    while (*ref_child != 0) {
-      ref_child = &(*ref_child)->type.next;
-    }
-    *ref_child = member;
+    *struct_def->struct_def.members.ref_end = member;
+    struct_def->struct_def.members.ref_end = &member->type.next;
   }
+  return DDS_RETCODE_OK;
+}
+
+dds_retcode_t ddsts_struct_add_key(ddsts_type_t *struct_def, ddsts_type_t *member)
+{
+  /* We traverse the list to the end and check if 'member' is already included */
+  ddsts_struct_key_t **ref_key = &struct_def->struct_def.keys;
+  while (*ref_key != NULL) {
+    if ((*ref_key)->member == member) {
+      return DDS_RETCODE_ERROR;
+    }
+    ref_key = &(*ref_key)->next;
+  }
+  (*ref_key) = (ddsts_struct_key_t*)ddsrt_malloc(sizeof(ddsts_struct_key_t));
+  if (*ref_key == NULL) {
+    return DDS_RETCODE_OUT_OF_RESOURCES;
+  }
+  (*ref_key)->member = member;
+  (*ref_key)->next = NULL;
   return DDS_RETCODE_OK;
 }
 

--- a/src/tools/idlc/src/idl.l
+++ b/src/tools/idlc/src/idl.l
@@ -48,6 +48,8 @@ int yyerror(YYLTYPE *yylloc, yyscan_t yyscanner, ddsts_context_t *context, char 
 %x COMMENT
 %x INSTRING
 %x INWSTRING
+%x NOWS
+%x DIRECTIVE
 
 %option noyywrap
 %option nounistd
@@ -56,7 +58,6 @@ int yyerror(YYLTYPE *yylloc, yyscan_t yyscanner, ddsts_context_t *context, char 
 %option reentrant
 %option bison-bridge
 %option bison-locations
-%option never-interactive
 
 number                    [1-9][0-9]*
 octal_number              0[0-7]*
@@ -66,20 +67,21 @@ identifier                [a-zA-Z_][a-zA-Z0-9_]*
 
 %%
 
-[ \t\r]                   { }
-[\n]                      { }
+<INITIAL,NOWS>[ \t\r]     { BEGIN(INITIAL); }
+<INITIAL,NOWS>[\n]        { BEGIN(INITIAL); }
 
-"/*"                      { BEGIN(MULTILINE_COMMENT); }
+<INITIAL,NOWS>"/*"        { BEGIN(MULTILINE_COMMENT); }
 <MULTILINE_COMMENT>.      { }
 <MULTILINE_COMMENT>"\n"   { }
 <MULTILINE_COMMENT>"*/"   { BEGIN(INITIAL); }
 
-"//"                      { BEGIN(COMMENT); }
-<COMMENT>"\n"             { BEGIN(INITIAL); }
+<INITIAL,NOWS>"//"        { BEGIN(COMMENT); }
 <COMMENT>.                { }
+<COMMENT>"\n"             { BEGIN(INITIAL); }
 
 
-{integer_literal}         {
+<INITIAL,NOWS>{integer_literal} {
+                            BEGIN(INITIAL);
                             yylval->literal.flags = DDSTS_ULONGLONG;
                             /* strtoll recognizes if the value is dec, oct or hex if base is zero */
                             dds_retcode_t retcode = ddsrt_strtoull(yytext, NULL, 0, &yylval->literal.value.ullng);
@@ -89,7 +91,7 @@ identifier                [a-zA-Z_][a-zA-Z0-9_]*
                             return DDSTS_INTEGER_LITERAL_TOKEN;
                           }
 
-{identifier}              {
+<INITIAL>{identifier}     {
                             int token_number;
                             if (ddsts_parser_token_matches_keyword(yytext, &token_number)) {
                               return token_number;
@@ -98,12 +100,58 @@ identifier                [a-zA-Z_][a-zA-Z0-9_]*
                             if (yylval->identifier == NULL) {
                               yyerror(yylloc_param, yyscanner, context, "Could not copy identifier");
                             }
+                            BEGIN(NOWS);
                             return DDSTS_IDENTIFIER_TOKEN;
                           }
 
-"::"                      { return DDSTS_COLON_COLON_TOKEN; }
+<INITIAL>"::"             {
+                            BEGIN(NOWS);
+                            return DDSTS_COLON_COLON_TOKEN;
+                          }
 
-.                         { return yytext[0]; }
+<NOWS>{identifier}        {
+                            int token_number;
+                            if (ddsts_parser_token_matches_keyword(yytext, &token_number)) {
+                              return token_number;
+                            }
+                            yylval->identifier = yytext;
+                            if (yylval->identifier == NULL) {
+                              yyerror(yylloc_param, yyscanner, context, "Could not copy identifier");
+                            }
+                            return DDSTS_NOWS_IDENTIFIER_TOKEN;
+                          }
+
+<NOWS>"::"                {
+                            return DDSTS_NOWS_COLON_COLON_TOKEN;
+                          }
+
+
+<INITIAL>"@"              {
+                            BEGIN(NOWS);
+                            return DDSTS_AT_TOKEN;
+                          }
+
+<INITIAL,NOWS>.           {
+                            BEGIN(INITIAL);
+                            return yytext[0];
+                          }
+
+<INITIAL,NOWS>"#pragma"   {
+                            BEGIN(DIRECTIVE);
+                            return DDSTS_PRAGMA_TOKEN;
+                          }
+<DIRECTIVE>[ \t]          { }
+<DIRECTIVE>{identifier}   {
+                            yylval->identifier = yytext;
+                            if (yylval->identifier == NULL) {
+                              yyerror(yylloc_param, yyscanner, context, "Could not copy identifier");
+                            }
+                            return DDSTS_IDENTIFIER_TOKEN;
+                          }
+<DIRECTIVE>[\n]           {
+                            BEGIN(INITIAL);
+                            return DDSTS_END_DIRECTIVE_TOKEN;
+                          }
 
 %%
 

--- a/src/tools/idlc/src/idl.y
+++ b/src/tools/idlc/src/idl.y
@@ -71,6 +71,7 @@ int illegal_identifier(const char *token);
 
 %token <identifier>
   DDSTS_IDENTIFIER_TOKEN
+  DDSTS_NOWS_IDENTIFIER_TOKEN
 
 %token <literal>
   DDSTS_INTEGER_LITERAL_TOKEN
@@ -110,6 +111,7 @@ int illegal_identifier(const char *token);
 
 %type <scoped_name>
   scoped_name
+  nows_scoped_name
 
 %destructor { ddsts_free_scoped_name($$); } <scoped_name>
 
@@ -124,6 +126,7 @@ int illegal_identifier(const char *token);
 %type <identifier>
   simple_declarator
   identifier
+  nows_identifier
 
 /* keywords */
 %token DDSTS_MODULE_TOKEN "module"
@@ -166,8 +169,15 @@ int illegal_identifier(const char *token);
 %token DDSTS_UINT32_TOKEN "uint32"
 %token DDSTS_UINT64_TOKEN "uint64"
 
-%token DDSTS_COLON_COLON_TOKEN "::"
+%token DDSTS_COLON_COLON_TOKEN
+%token DDSTS_NOWS_COLON_COLON_TOKEN
+%token DDSTS_AT_TOKEN "@"
+
+%token DDSTS_PRAGMA_TOKEN "#pragma"
+%token DDSTS_END_DIRECTIVE_TOKEN
+
 %token DDSTS_END_TOKEN 0 "end of file"
+
 
 %%
 
@@ -187,6 +197,7 @@ definitions:
 definition:
     module_dcl ';'
   | type_dcl ';'
+  | pragma
   ;
 
 module_dcl:
@@ -206,13 +217,34 @@ scoped_name:
           YYABORT;
         }
       }
-  | "::" identifier
+  | DDSTS_COLON_COLON_TOKEN nows_identifier
       {
         if (!ddsts_new_scoped_name(context, 0, true, $2, &($$))) {
           YYABORT;
         }
       }
-  | scoped_name "::" identifier
+  | scoped_name DDSTS_NOWS_COLON_COLON_TOKEN nows_identifier
+      {
+        if (!ddsts_new_scoped_name(context, $1, false, $3, &($$))) {
+          YYABORT;
+        }
+      }
+  ;
+
+nows_scoped_name:
+    nows_identifier
+      {
+        if (!ddsts_new_scoped_name(context, 0, false, $1, &($$))) {
+          YYABORT;
+        }
+      }
+  | DDSTS_NOWS_COLON_COLON_TOKEN nows_identifier
+      {
+        if (!ddsts_new_scoped_name(context, 0, true, $2, &($$))) {
+          YYABORT;
+        }
+      }
+  | nows_scoped_name DDSTS_NOWS_COLON_COLON_TOKEN nows_identifier
       {
         if (!ddsts_new_scoped_name(context, $1, false, $3, &($$))) {
           YYABORT;
@@ -398,13 +430,22 @@ members:
   ;
 
 member:
-    type_spec
+    annotation_appls type_spec
+      {
+        if (!ddsts_add_struct_member(context, &($2))) {
+          YYABORT;
+        }
+      }
+    declarators ';'
+      { ddsts_struct_member_close(context); }
+  | type_spec
       {
         if (!ddsts_add_struct_member(context, &($1))) {
           YYABORT;
         }
       }
     declarators ';'
+      { ddsts_struct_member_close(context); }
 /* Embedded struct extension: */
   | struct_def { ddsts_add_struct_member(context, &($1)); }
     declarators ';'
@@ -420,8 +461,7 @@ struct_forward_dcl:
       };
 
 array_declarator:
-    identifier
-    fixed_array_sizes
+    identifier fixed_array_sizes
       {
         if (!ddsts_add_declarator(context, $1)) {
           YYABORT;
@@ -450,7 +490,8 @@ declarators:
   | declarator
   ;
 
-declarator: simple_declarator
+declarator:
+    simple_declarator
       {
         if (!ddsts_add_declarator(context, $1)) {
           YYABORT;
@@ -525,8 +566,63 @@ type_spec: template_type_spec ;
 declarator: array_declarator ;
 
 
+/* From Building Block Annotations (minimal for support of @key): */
+
+annotation_appls:
+    annotation_appl annotation_appls
+  | annotation_appl
+  ;
+
+annotation_appl:
+    "@" nows_scoped_name
+    {
+      if (!ddsts_add_annotation(context, $2)) {
+        YYABORT;
+      }
+    }
+  ;
+
+/* Backward compatability #pragma */
+
+pragma:
+    "#pragma"
+      { ddsts_pragma_open(context); }
+    pragma_arg_list DDSTS_END_DIRECTIVE_TOKEN
+      {
+        if (!ddsts_pragma_close(context)) {
+          YYABORT;
+        }
+      }
+  ;
+
+pragma_arg_list:
+    identifier
+      {
+        if (!ddsts_pragma_add_identifier(context, $1)) {
+          YYABORT;
+        }
+      }
+    pragma_arg_list
+  |
+  ;
+
 identifier:
     DDSTS_IDENTIFIER_TOKEN
+      {
+        size_t offset = 0;
+        if ($1[0] == '_') {
+          offset = 1;
+        }
+        else if (illegal_identifier($1) != 0) {
+          yyerror(&yylloc, scanner, context, "Identifier collides with a keyword");
+        }
+        if (!ddsts_context_copy_identifier(context, $1 + offset, &($$))) {
+          YYABORT;
+        }
+      };
+
+nows_identifier:
+    DDSTS_NOWS_IDENTIFIER_TOKEN
       {
         size_t offset = 0;
         if ($1[0] == '_') {

--- a/src/tools/idlc/src/parser.c
+++ b/src/tools/idlc/src/parser.c
@@ -25,7 +25,7 @@
 #define YY_TYPEDEF_YY_SCANNER_T
 typedef void* yyscan_t;
 
-#define YY_NO_UNISTD_H 1 /* to surpress #include <unistd.h> */
+#define YY_NO_UNISTD_H 1 /* to suppress #include <unistd.h> */
 
 #include "parser.h"
 #include "idl.parser.h"
@@ -56,10 +56,10 @@ DDSRT_WARNING_MSVC_ON(4996);
   ddsts_parser_lex_init(&scanner);
   ddsts_parser_set_in(fh, scanner);
   int parse_result = ddsts_parser_parse(scanner, context);
-  if (parse_result == 0) {
+  dds_retcode_t rc = parse_result == 2 ? DDS_RETCODE_OUT_OF_RESOURCES : ddsts_context_get_retcode(context);
+  if (rc == DDS_RETCODE_OK) {
     *ref_root_type = ddsts_context_take_root_type(context);
   }
-  dds_retcode_t rc = parse_result == 2 ? DDS_RETCODE_OUT_OF_RESOURCES : ddsts_context_get_retcode(context) ;
   ddsts_free_context(context);
   ddsts_parser_lex_destroy(scanner);
   (void)fclose(fh);
@@ -82,10 +82,10 @@ dds_retcode_t ddsts_idl_parse_string(const char *str, ddsts_type_t **ref_root_ty
   ddsts_parser_lex_init(&scanner);
   ddsts_parser__scan_string(str, scanner);
   int parse_result = ddsts_parser_parse(scanner, context);
-  if (parse_result == 0) {
+  dds_retcode_t rc = parse_result == 2 ? DDS_RETCODE_OUT_OF_RESOURCES : ddsts_context_get_retcode(context);
+  if (rc == DDS_RETCODE_OK) {
     *ref_root_type = ddsts_context_take_root_type(context);
   }
-  dds_retcode_t rc = parse_result == 2 ? DDS_RETCODE_OUT_OF_RESOURCES : ddsts_context_get_retcode(context) ;
   ddsts_free_context(context);
   ddsts_parser_lex_destroy(scanner);
 

--- a/src/tools/idlc/src/tt_create.c
+++ b/src/tools/idlc/src/tt_create.c
@@ -10,11 +10,13 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
 #include <stdio.h>
+#include <stdbool.h>
 #include <assert.h>
 #include <string.h>
 #include "dds/ddsrt/retcode.h"
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/string.h"
+#include "dds/ddsrt/misc.h"
 #include "dds/ddsrt/log.h"
 #include "dds/ddsts/typetree.h"
 #include "tt_create.h"
@@ -26,12 +28,33 @@ struct array_size {
   array_size_t *next;
 };
 
+typedef struct annotation annotation_t;
+struct annotation {
+  ddsts_scoped_name_t *scoped_name;
+  annotation_t *next;
+};
+
+typedef struct annotations_stack annotations_stack_t;
+struct annotations_stack {
+  annotation_t *annotations;
+  annotations_stack_t *deeper;
+};
+
+typedef struct pragma_arg pragma_arg_t;
+struct pragma_arg {
+  ddsts_identifier_t arg;
+  pragma_arg_t *next;
+};
+
 struct ddsts_context {
   ddsts_type_t *root_type;
   ddsts_type_t *cur_type;
   ddsts_type_t *type_for_declarator;
   array_size_t *array_sizes;
+  annotations_stack_t *annotations_stack;
+  pragma_arg_t *pragma_args;
   dds_retcode_t retcode;
+  bool semantic_error;
   ddsts_identifier_t dangling_identifier;
 };
 
@@ -189,10 +212,10 @@ static bool resolve_scoped_name(ddsts_context_t *context, ddsts_scoped_name_t *s
     for (cur_scoped_name = scoped_name; cur_scoped_name != NULL && found_type != NULL; cur_scoped_name = cur_scoped_name->next) {
       ddsts_type_t *child = NULL;
       if (DDSTS_IS_TYPE(found_type, DDSTS_MODULE)) {
-        child = found_type->module.members;
+        child = found_type->module.members.first;
       }
       else if (DDSTS_IS_TYPE(found_type, DDSTS_STRUCT)) {
-        child = found_type->struct_def.members;
+        child = found_type->struct_def.members.first;
       }
       found_type = NULL;
       for (; child != NULL; child = child->type.next) {
@@ -217,23 +240,37 @@ extern void ddsts_free_scoped_name(ddsts_scoped_name_t *scoped_name)
 {
   while (scoped_name != NULL) {
     ddsts_scoped_name_t *next = scoped_name->next;
-    ddsrt_free((void*)scoped_name->name);
-    ddsrt_free((void*)scoped_name);
+    ddsrt_free(scoped_name->name);
+    ddsrt_free(scoped_name);
     scoped_name = next;
   }
 }
 
 extern bool ddsts_get_type_from_scoped_name(ddsts_context_t *context, ddsts_scoped_name_t *scoped_name, ddsts_type_t **result)
 {
-  ddsts_type_t *definition;
-  resolve_scoped_name(context, scoped_name, &definition);
-  ddsts_free_scoped_name(scoped_name);
-  if (definition == NULL) {
-    /* Create a Boolean type, just to prevent a NULL pointer */
-    return ddsts_new_base_type(context, DDSTS_BOOLEAN, result);
+  ddsts_type_t *definition = NULL;
+  if (!resolve_scoped_name(context, scoped_name, &definition)) {
+    ddsts_free_scoped_name(scoped_name);
+    return false;
   }
+  ddsts_free_scoped_name(scoped_name);
   *result = definition;
   return true;
+}
+
+static void scoped_name_dds_error(ddsts_scoped_name_t *scoped_name)
+{
+  if (scoped_name == NULL) {
+    return;
+  }
+  bool collon = scoped_name->top;
+  for (; scoped_name != NULL; scoped_name = scoped_name->next) {
+    if (collon) {
+      DDS_ERROR("::");
+    }
+    DDS_ERROR("%s", scoped_name->name);
+    collon = true;
+  }
 }
 
 static bool new_module_definition(ddsts_context_t *context, ddsts_identifier_t name, ddsts_type_t *parent, ddsts_type_t **result)
@@ -252,6 +289,27 @@ static bool new_module_definition(ddsts_context_t *context, ddsts_identifier_t n
   return true;
 }
 
+static bool context_push_annotations_stack(ddsts_context_t *context)
+{
+  annotations_stack_t *annotations_stack = (annotations_stack_t*)ddsrt_malloc(sizeof(annotations_stack_t));
+  if (annotations_stack == NULL) {
+    return false;
+  }
+  annotations_stack->annotations = NULL;
+  annotations_stack->deeper = context->annotations_stack;
+  context->annotations_stack = annotations_stack;
+  return true;
+}
+
+static void context_pop_annotations_stack(ddsts_context_t *context)
+{
+  assert(context->annotations_stack != NULL);
+  annotations_stack_t *annotations_stack = context->annotations_stack;
+  context->annotations_stack = annotations_stack->deeper;
+  assert(annotations_stack->annotations == NULL);
+  ddsrt_free(annotations_stack);
+}
+
 extern ddsts_context_t* ddsts_create_context()
 {
   ddsts_context_t *context = (ddsts_context_t*)ddsrt_malloc(sizeof(ddsts_context_t));
@@ -268,7 +326,15 @@ extern ddsts_context_t* ddsts_create_context()
   context->cur_type = context->root_type;
   context->type_for_declarator = NULL;
   context->array_sizes = NULL;
+  context->annotations_stack = NULL;
+  if (!context_push_annotations_stack(context)) {
+    ddsts_free_type(module);
+    ddsrt_free(context);
+    return NULL;
+  }
+  context->pragma_args = NULL;
   context->retcode = DDS_RETCODE_ERROR;
+  context->semantic_error = false;
   return context;
 }
 
@@ -289,9 +355,34 @@ static void ddsts_context_free_array_sizes(ddsts_context_t *context)
 {
   while (context->array_sizes != NULL) {
     array_size_t *next = context->array_sizes->next;
-    ddsrt_free((void*)context->array_sizes);
+    ddsrt_free(context->array_sizes);
     context->array_sizes = next;
   }
+}
+
+static void context_free_pragma_args(ddsts_context_t *context)
+{
+  pragma_arg_t *pragma_arg = context->pragma_args;
+  while (pragma_arg != NULL) {
+    pragma_arg_t *next = pragma_arg->next;
+    ddsrt_free(pragma_arg->arg);
+    ddsrt_free(pragma_arg);
+    pragma_arg = next;
+  }
+  context->pragma_args = NULL;
+}
+
+static void context_free_annotations(ddsts_context_t *context)
+{
+  assert(context->annotations_stack != NULL);
+  annotation_t *annotation = context->annotations_stack->annotations;
+  while (annotation != NULL) {
+    annotation_t *next = annotation->next;
+    ddsts_free_scoped_name(annotation->scoped_name);
+    ddsrt_free(annotation);
+    annotation = next;
+  }
+  context->annotations_stack->annotations = NULL;
 }
 
 static void ddsts_context_close_member(ddsts_context_t *context)
@@ -308,6 +399,11 @@ extern void ddsts_free_context(ddsts_context_t *context)
   assert(context != NULL);
   ddsts_context_close_member(context);
   ddsts_free_type(context->root_type);
+  while (context->annotations_stack != NULL) {
+    context_free_annotations(context);
+    context_pop_annotations_stack(context);
+  }
+  context_free_pragma_args(context);
   ddsrt_free(context->dangling_identifier);
   ddsrt_free(context);
 }
@@ -384,6 +480,9 @@ extern bool ddsts_add_struct_open(ddsts_context_t *context, ddsts_identifier_t n
     ddsts_struct_add_member(context->cur_type, new_struct);
   }
   context->cur_type = new_struct;
+  if (!context_push_annotations_stack(context)) {
+    return false;
+  }
   return true;
 }
 
@@ -422,12 +521,18 @@ extern bool ddsts_add_struct_member(ddsts_context_t *context, ddsts_type_t **ref
   return true;
 }
 
+extern void ddsts_struct_member_close(ddsts_context_t *context)
+{
+  context_free_annotations(context);
+}
+
 extern void ddsts_struct_close(ddsts_context_t *context, ddsts_type_t **result)
 {
   assert(cur_scope_is_definition_type(context, DDSTS_STRUCT));
   ddsts_context_close_member(context);
   *result = context->cur_type;
   context->cur_type = context->cur_type->type.parent;
+  context_pop_annotations_stack(context);
 }
 
 extern void ddsts_struct_empty_close(ddsts_context_t *context, ddsts_type_t **result)
@@ -456,14 +561,50 @@ static ddsts_type_t *create_array_type(array_size_t *array_size, ddsts_type_t *t
   return array;
 }
 
+static bool keyable_type(ddsts_type_t *type)
+{
+  bool is_array = false;
+  while (type != NULL && DDSTS_IS_TYPE(type, DDSTS_ARRAY)) {
+    type = type->array.element_type;
+    is_array = true;
+  }
+  if (type == NULL) {
+    return false;
+  }
+  if (   DDSTS_IS_TYPE(type,
+                       DDSTS_SHORT | DDSTS_LONG | DDSTS_LONGLONG |
+                       DDSTS_USHORT | DDSTS_ULONG | DDSTS_ULONGLONG |
+                       DDSTS_CHAR | DDSTS_BOOLEAN | DDSTS_OCTET |
+                       DDSTS_INT8 | DDSTS_UINT8 |
+                       DDSTS_FLOAT | DDSTS_DOUBLE)
+      || (DDSTS_IS_TYPE(type, DDSTS_STRING) && !is_array)) {
+    return true;
+  }
+  if (DDSTS_IS_TYPE(type, DDSTS_STRUCT)) {
+    if (type->struct_def.keys == NULL) {
+      /* All fields should be keyable */
+      for (ddsts_type_t *member = type->struct_def.members.first; member != NULL; member = member->type.next) {
+        if (DDSTS_IS_TYPE(member, DDSTS_DECLARATION)) {
+          if (!keyable_type(member->declaration.decl_type)) {
+            return false;
+          }
+        }
+      }
+    }
+    return true;
+  }
+  return false;
+}
+
 extern bool ddsts_add_declarator(ddsts_context_t *context, ddsts_identifier_t name)
 {
   assert(context != NULL);
   assert(context->dangling_identifier == name);
   if (DDSTS_IS_TYPE(context->cur_type, DDSTS_STRUCT)) {
     assert(context->type_for_declarator != NULL);
-    ddsts_type_t *decl;
-    dds_retcode_t rc = ddsts_create_declaration(name, NULL, &decl);
+    ddsts_type_t *decl = NULL;
+    dds_retcode_t rc;
+    rc = ddsts_create_declaration(name, NULL, &decl);
     if (rc != DDS_RETCODE_OK) {
       ddsts_context_free_array_sizes(context);
       context->retcode = rc;
@@ -480,6 +621,37 @@ extern bool ddsts_add_declarator(ddsts_context_t *context, ddsts_identifier_t na
     ddsts_context_free_array_sizes(context);
     ddsts_declaration_set_type(decl, type);
     ddsts_struct_add_member(context->cur_type, decl);
+    /* Process annotations */
+    assert(context->annotations_stack != NULL);
+    for (annotation_t *annotation = context->annotations_stack->annotations; annotation != NULL; annotation = annotation->next) {
+      if (   annotation->scoped_name != NULL
+          && !annotation->scoped_name->top
+          && strcmp(annotation->scoped_name->name, "key") == 0
+          && annotation->scoped_name->next == NULL) {
+        if (keyable_type(type)) {
+          rc = ddsts_struct_add_key(context->cur_type, decl);
+          if (rc == DDS_RETCODE_ERROR) {
+            DDS_ERROR("Field '%s' already defined as key\n", name);
+            context->semantic_error = true;
+          }
+          else if (rc != DDS_RETCODE_OK) {
+            ddsts_context_free_array_sizes(context);
+            context->retcode = rc;
+            return false;
+          }
+        }
+        else {
+          DDS_ERROR("Type of '%s' is not valid for key\n", name);
+          context->semantic_error = true;
+        }
+      }
+      else {
+        DDS_ERROR("Unsupported annotation '");
+        scoped_name_dds_error(annotation->scoped_name);
+        DDS_ERROR("' is ignored\n");
+      }
+    }
+
     return true;
   }
   assert(false);
@@ -504,9 +676,145 @@ extern bool ddsts_add_array_size(ddsts_context_t *context, ddsts_literal_t *valu
   return true;
 }
 
+bool ddsts_add_annotation(ddsts_context_t *context, ddsts_scoped_name_t *scoped_name)
+{
+  assert(context != NULL);
+  assert(context->annotations_stack != NULL);
+
+  annotation_t **ref_annotation = &context->annotations_stack->annotations;
+  while (*ref_annotation != NULL) {
+    ref_annotation = &(*ref_annotation)->next;
+  }
+  (*ref_annotation) = (annotation_t*)ddsrt_malloc(sizeof(annotation_t));
+  if ((*ref_annotation) == NULL) {
+    context->retcode = DDS_RETCODE_OUT_OF_RESOURCES;
+    return false;
+  }
+  context->dangling_identifier = NULL;
+  (*ref_annotation)->scoped_name = scoped_name;
+  (*ref_annotation)->next = NULL;
+  return true;
+}
+
+void ddsts_pragma_open(ddsts_context_t *context)
+{
+  assert(context != NULL);
+  assert(context->pragma_args == NULL);
+  DDSRT_UNUSED_ARG(context);
+}
+
+bool ddsts_pragma_add_identifier(ddsts_context_t *context, ddsts_identifier_t name)
+{
+  assert(context != NULL);
+  assert(context->dangling_identifier == name);
+
+  pragma_arg_t **ref_pragma_arg = &context->pragma_args;
+  while (*ref_pragma_arg != NULL) {
+    ref_pragma_arg = &(*ref_pragma_arg)->next;
+  }
+  (*ref_pragma_arg) = (pragma_arg_t*)ddsrt_malloc(sizeof(pragma_arg_t));
+  if ((*ref_pragma_arg) == NULL) {
+    context->retcode = DDS_RETCODE_OUT_OF_RESOURCES;
+    return false;
+  }
+  context->dangling_identifier = NULL;
+  (*ref_pragma_arg)->arg = name;
+  (*ref_pragma_arg)->next = NULL;
+  return true;
+}
+
+bool ddsts_pragma_close(ddsts_context_t *context)
+{
+  assert(context != NULL);
+  assert(context->cur_type != NULL);
+
+  pragma_arg_t *pragma_arg = context->pragma_args;
+  if (pragma_arg == NULL) {
+    DDS_ERROR("Empty pragma is ignored\n");
+  }
+  else if (strcmp(pragma_arg->arg, "keylist") == 0) {
+    pragma_arg = pragma_arg->next;
+
+    if (pragma_arg == NULL) {
+      DDS_ERROR("Expect struct name after keylist pragma\n");
+      context->semantic_error = true;
+      context_free_pragma_args(context);
+      return true;
+    }
+
+    /* Find struct in currect context */
+    ddsts_type_t *member = NULL;
+    if (DDSTS_IS_TYPE(context->cur_type, DDSTS_MODULE)) {
+      member = context->cur_type->module.members.first;
+    }
+    else if (DDSTS_IS_TYPE(context->cur_type, DDSTS_STRUCT)) {
+      member = context->cur_type->struct_def.members.first;
+    }
+    ddsts_type_t *struct_def = NULL;
+    for (; member != NULL; member = member->type.next) {
+      if (DDSTS_IS_TYPE(member, DDSTS_STRUCT) && strcmp(pragma_arg->arg, member->type.name) == 0) {
+        struct_def = member;
+        break;
+      }
+    }
+    if (struct_def == NULL) {
+      DDS_ERROR("Struct '%s' for keylist pragma is undefined here\n", pragma_arg->arg);
+      context->semantic_error = true;
+      context_free_pragma_args(context);
+      return true;
+    }
+    /* The '@key' and '#pragma keylist' may not be mixed */
+    if (struct_def->struct_def.keys != NULL) {
+      DDS_ERROR("Cannot use keylist pragma for struct '%s' in combination with @key annotation\n", pragma_arg->arg);
+      context->semantic_error = true;
+      context_free_pragma_args(context);
+      return true;
+    }
+
+    for (pragma_arg = pragma_arg->next; pragma_arg != NULL; pragma_arg = pragma_arg->next) {
+      /* Find declarator in struct */
+      ddsts_type_t *declaration = NULL;
+      for (ddsts_type_t *member = struct_def->struct_def.members.first; member != NULL && declaration == NULL; member = member->type.next) {
+        if (DDSTS_IS_TYPE(member, DDSTS_DECLARATION) && strcmp(member->type.name, pragma_arg->arg) == 0) {
+          declaration = member;
+          break;
+        }
+      }
+      if (declaration == NULL) {
+        DDS_ERROR("Member '%s' in struct '%s' for keylist pragma is undefined\n", pragma_arg->arg, struct_def->type.name);
+        context->semantic_error = true;
+      }
+      else if (keyable_type(declaration->declaration.decl_type)) {
+        dds_retcode_t rc = ddsts_struct_add_key(struct_def, declaration);
+        if (rc == DDS_RETCODE_ERROR) {
+          DDS_ERROR("Field '%s' already defined as key\n", pragma_arg->arg);
+          context->semantic_error = true;
+        }
+        else if (rc != DDS_RETCODE_OK) {
+          context->retcode = rc;
+          context_free_pragma_args(context);
+          return false;
+        }
+      }
+      else {
+        DDS_ERROR("Type of '%s' is not valid for key\n", pragma_arg->arg);
+        context->semantic_error = true;
+      }
+    }
+  }
+  else {
+    DDS_WARNING("Unknown pragma '%s' is ignored\n", pragma_arg->arg);
+    context_free_pragma_args(context);
+    return true;
+  }
+
+  context_free_pragma_args(context);
+  return true;
+}
+
 extern void ddsts_accept(ddsts_context_t *context)
 {
   assert(context != NULL);
-  context->retcode = DDS_RETCODE_OK;
+  context->retcode = context->semantic_error ? DDS_RETCODE_ERROR : DDS_RETCODE_OK;
 }
 

--- a/src/tools/idlc/src/tt_create.h
+++ b/src/tools/idlc/src/tt_create.h
@@ -50,12 +50,19 @@ bool ddsts_add_struct_forward(ddsts_context_t *context, ddsts_identifier_t name)
 bool ddsts_add_struct_open(ddsts_context_t *context, ddsts_identifier_t name);
 bool ddsts_add_struct_extension_open(ddsts_context_t *context, ddsts_identifier_t name, ddsts_scoped_name_t *scoped_name);
 bool ddsts_add_struct_member(ddsts_context_t *context, ddsts_type_t **ref_type);
+void ddsts_struct_member_close(ddsts_context_t *context);
 void ddsts_struct_close(ddsts_context_t *context, ddsts_type_t **result);
 void ddsts_struct_empty_close(ddsts_context_t *context, ddsts_type_t **result);
 
 bool ddsts_add_declarator(ddsts_context_t *context, ddsts_identifier_t name);
 
 bool ddsts_add_array_size(ddsts_context_t *context, ddsts_literal_t *value);
+
+bool ddsts_add_annotation(ddsts_context_t *context, ddsts_scoped_name_t* scoped_name);
+
+void ddsts_pragma_open(ddsts_context_t *context);
+bool ddsts_pragma_add_identifier(ddsts_context_t *context, ddsts_identifier_t name);
+bool ddsts_pragma_close(ddsts_context_t *context);
 
 void ddsts_accept(ddsts_context_t *context);
 

--- a/src/tools/idlc/tests/parser.c
+++ b/src/tools/idlc/tests/parser.c
@@ -30,12 +30,13 @@ static void test_basic_type(const char *idl, ddsts_flags_t flags)
   CU_ASSERT(ddsts_idl_parse_string(idl, &root_type) == DDS_RETCODE_OK);
   CU_ASSERT(test_type(root_type, DDSTS_MODULE, NULL, NULL, true));
   CU_ASSERT(root_type->module.previous == NULL);
-    ddsts_type_t *struct_s = root_type->module.members;
+    ddsts_type_t *struct_s = root_type->module.members.first;
     CU_ASSERT(test_type(struct_s, DDSTS_STRUCT, "s", root_type, true));
-      ddsts_type_t *decl_c = struct_s->struct_def.members;
+      ddsts_type_t *decl_c = struct_s->struct_def.members.first;
       CU_ASSERT(test_type(decl_c, DDSTS_DECLARATION, "c", struct_s, true));
         ddsts_type_t *char_type = decl_c->declaration.decl_type;
         CU_ASSERT(test_type(char_type, flags, NULL, decl_c, true));
+      CU_ASSERT(struct_s->struct_def.keys == NULL);
   ddsts_free_type(root_type);
 }
 
@@ -70,15 +71,16 @@ CU_Test(parser, one_module1)
   CU_ASSERT(ddsts_idl_parse_string("module a{ struct s{char c;};};", &root_type) == DDS_RETCODE_OK);
   CU_ASSERT(test_type(root_type, DDSTS_MODULE, NULL, NULL, true));
   CU_ASSERT(root_type->module.previous == NULL);
-    ddsts_type_t *module_a = root_type->module.members;
+    ddsts_type_t *module_a = root_type->module.members.first;
     CU_ASSERT(test_type(module_a, DDSTS_MODULE, "a", root_type, true));
     CU_ASSERT(module_a->module.previous == NULL);
-      ddsts_type_t *struct_s = module_a->module.members;
+      ddsts_type_t *struct_s = module_a->module.members.first;
       CU_ASSERT(test_type(struct_s, DDSTS_STRUCT, "s", module_a, true));
-        ddsts_type_t *decl_c = struct_s->struct_def.members;
+        ddsts_type_t *decl_c = struct_s->struct_def.members.first;
         CU_ASSERT(test_type(decl_c, DDSTS_DECLARATION, "c", struct_s, true));
           ddsts_type_t *char_type = decl_c->declaration.decl_type;
           CU_ASSERT(test_type(char_type, DDSTS_CHAR, NULL, decl_c, true));
+        CU_ASSERT(struct_s->struct_def.keys == NULL);
   ddsts_free_type(root_type);
 }
 
@@ -88,27 +90,29 @@ CU_Test(parser, reopen_module)
   CU_ASSERT(ddsts_idl_parse_string("module a{ struct s{char c;};}; module a { struct t{char x;};};", &root_type) == DDS_RETCODE_OK);
   CU_ASSERT(test_type(root_type, DDSTS_MODULE, NULL, NULL, true));
   CU_ASSERT(root_type->module.previous == NULL);
-    ddsts_type_t *module_a = root_type->module.members;
+    ddsts_type_t *module_a = root_type->module.members.first;
     CU_ASSERT(test_type(module_a, DDSTS_MODULE, "a", root_type, false));
     CU_ASSERT(module_a->module.previous == NULL);
     {
-      ddsts_type_t *struct_s = module_a->module.members;
+      ddsts_type_t *struct_s = module_a->module.members.first;
       CU_ASSERT(test_type(struct_s, DDSTS_STRUCT, "s", module_a, true));
-        ddsts_type_t *decl_c = struct_s->struct_def.members;
+        ddsts_type_t *decl_c = struct_s->struct_def.members.first;
         CU_ASSERT(test_type(decl_c, DDSTS_DECLARATION, "c", struct_s, true));
           ddsts_type_t *char_type = decl_c->declaration.decl_type;
           CU_ASSERT(test_type(char_type, DDSTS_CHAR, NULL, decl_c, true));
+        CU_ASSERT(struct_s->struct_def.keys == NULL);
     }
     ddsts_type_t *module_a2 = module_a->type.next;
     CU_ASSERT(test_type(module_a2, DDSTS_MODULE, "a", root_type, true));
     CU_ASSERT(module_a2->module.previous == &module_a->module);
     {
-      ddsts_type_t *struct_t = module_a2->module.members;
+      ddsts_type_t *struct_t = module_a2->module.members.first;
       CU_ASSERT(test_type(struct_t, DDSTS_STRUCT, "t", module_a2, true));
-        ddsts_type_t *decl_x = struct_t->struct_def.members;
+        ddsts_type_t *decl_x = struct_t->struct_def.members.first;
         CU_ASSERT(test_type(decl_x, DDSTS_DECLARATION, "x", struct_t, true));
           ddsts_type_t *char_type = decl_x->declaration.decl_type;
           CU_ASSERT(test_type(char_type, DDSTS_CHAR, NULL, decl_x, true));
+        CU_ASSERT(struct_t->struct_def.keys == NULL);
     }
   ddsts_free_type(root_type);
 }
@@ -119,12 +123,12 @@ CU_Test(parser, scoped_name)
   CU_ASSERT(ddsts_idl_parse_string("module a{ struct s{char c;};}; module b { struct t{a::s x;};};", &root_type) == DDS_RETCODE_OK);
   CU_ASSERT(test_type(root_type, DDSTS_MODULE, NULL, NULL, true));
   CU_ASSERT(root_type->module.previous == NULL);
-    ddsts_type_t *module_a = root_type->module.members;
+    ddsts_type_t *module_a = root_type->module.members.first;
     CU_ASSERT(test_type(module_a, DDSTS_MODULE, "a", root_type, false));
     CU_ASSERT(module_a->module.previous == NULL);
-      ddsts_type_t *struct_s = module_a->module.members;
+      ddsts_type_t *struct_s = module_a->module.members.first;
       CU_ASSERT(test_type(struct_s, DDSTS_STRUCT, "s", module_a, true));
-        ddsts_type_t *decl_c = struct_s->struct_def.members;
+        ddsts_type_t *decl_c = struct_s->struct_def.members.first;
         CU_ASSERT(test_type(decl_c, DDSTS_DECLARATION, "c", struct_s, true));
           ddsts_type_t *char_type = decl_c->declaration.decl_type;
           CU_ASSERT(test_type(char_type, DDSTS_CHAR, NULL, decl_c, true));
@@ -132,9 +136,9 @@ CU_Test(parser, scoped_name)
     CU_ASSERT(test_type(module_b, DDSTS_MODULE, "b", root_type, true));
     CU_ASSERT(module_b->module.previous == NULL);
     {
-      ddsts_type_t *struct_t = module_b->module.members;
+      ddsts_type_t *struct_t = module_b->module.members.first;
       CU_ASSERT(test_type(struct_t, DDSTS_STRUCT, "t", module_b, true));
-        ddsts_type_t *decl_x = struct_t->struct_def.members;
+        ddsts_type_t *decl_x = struct_t->struct_def.members.first;
         CU_ASSERT(test_type(decl_x, DDSTS_DECLARATION, "x", struct_t, true));
           ddsts_type_t *x_type = decl_x->declaration.decl_type;
           CU_ASSERT(x_type == struct_s);
@@ -148,15 +152,16 @@ CU_Test(parser, comma)
   CU_ASSERT(ddsts_idl_parse_string("struct s{char a, b;};", &root_type) == DDS_RETCODE_OK);
   CU_ASSERT(test_type(root_type, DDSTS_MODULE, NULL, NULL, true));
   CU_ASSERT(root_type->module.previous == NULL);
-    ddsts_type_t *struct_s = root_type->module.members;
+    ddsts_type_t *struct_s = root_type->module.members.first;
     CU_ASSERT(test_type(struct_s, DDSTS_STRUCT, "s", root_type, true));
-      ddsts_type_t *decl_a = struct_s->struct_def.members;
+      ddsts_type_t *decl_a = struct_s->struct_def.members.first;
       CU_ASSERT(test_type(decl_a, DDSTS_DECLARATION, "a", struct_s, false));
         ddsts_type_t *char_type = decl_a->declaration.decl_type;
         CU_ASSERT(test_type(char_type, DDSTS_CHAR, NULL, decl_a, true));
       ddsts_type_t *decl_b = decl_a->type.next;
       CU_ASSERT(test_type(decl_b, DDSTS_DECLARATION, "b", struct_s, true));
         CU_ASSERT(decl_b->declaration.decl_type == char_type);
+      CU_ASSERT(struct_s->struct_def.keys == NULL);
   ddsts_free_type(root_type);
 }
 
@@ -166,9 +171,9 @@ CU_Test(parser, types)
   CU_ASSERT(ddsts_idl_parse_string("struct s{sequence<char> us; sequence<char,8> bs; string ust; string<7> bst; wstring uwst; wstring<6> bwst; fixed<5,3> fp; map<short,char> um; map<short,char,5> bm;};", &root_type) == DDS_RETCODE_OK);
   CU_ASSERT(test_type(root_type, DDSTS_MODULE, NULL, NULL, true));
   CU_ASSERT(root_type->module.previous == NULL);
-    ddsts_type_t *struct_s = root_type->module.members;
+    ddsts_type_t *struct_s = root_type->module.members.first;
     CU_ASSERT(test_type(struct_s, DDSTS_STRUCT, "s", root_type, true));
-      ddsts_type_t *decl = struct_s->struct_def.members;
+      ddsts_type_t *decl = struct_s->struct_def.members.first;
       CU_ASSERT(test_type(decl, DDSTS_DECLARATION, "us", struct_s, false));
         ddsts_type_t *s_type = decl->declaration.decl_type;
         CU_ASSERT(test_type(s_type, DDSTS_SEQUENCE, NULL, decl, true));
@@ -213,7 +218,7 @@ CU_Test(parser, types)
         s_type = decl->declaration.decl_type;
         CU_ASSERT(test_type(s_type, DDSTS_FIXED_PT, NULL, decl, true));
         CU_ASSERT(s_type->fixed_pt.digits == 5);
-        CU_ASSERT(s_type->fixed_pt.fraction_digits == 3); 
+        CU_ASSERT(s_type->fixed_pt.fraction_digits == 3);
       decl = decl->type.next;
       CU_ASSERT(test_type(decl, DDSTS_DECLARATION, "um", struct_s, false));
         s_type = decl->declaration.decl_type;
@@ -243,9 +248,9 @@ CU_Test(parser, array)
   CU_ASSERT(ddsts_idl_parse_string("struct s{short a[3], b[4][5]; sequence<char> s[6];};", &root_type) == DDS_RETCODE_OK);
   CU_ASSERT(test_type(root_type, DDSTS_MODULE, NULL, NULL, true));
   CU_ASSERT(root_type->module.previous == NULL);
-    ddsts_type_t *struct_s = root_type->module.members;
+    ddsts_type_t *struct_s = root_type->module.members.first;
     CU_ASSERT(test_type(struct_s, DDSTS_STRUCT, "s", root_type, true));
-      ddsts_type_t *decl = struct_s->struct_def.members;
+      ddsts_type_t *decl = struct_s->struct_def.members.first;
       CU_ASSERT(test_type(decl, DDSTS_DECLARATION, "a", struct_s, false));
         ddsts_type_t *a_type = decl->declaration.decl_type;
         CU_ASSERT(test_type(a_type, DDSTS_ARRAY, NULL, decl, true));
@@ -271,7 +276,74 @@ CU_Test(parser, array)
           CU_ASSERT(test_type(elem_type, DDSTS_SEQUENCE, NULL, s_type, true));
             elem_type2 = elem_type->sequence.element_type;
             CU_ASSERT(test_type(elem_type2, DDSTS_CHAR, NULL, elem_type, true));
+      CU_ASSERT(struct_s->struct_def.keys == NULL);
   ddsts_free_type(root_type);
+}
+
+static void test_topic_keys(const char *idl, const char *keystr)
+{
+  ddsts_type_t *root_type = NULL;
+  CU_ASSERT(ddsts_idl_parse_string(idl, &root_type) == DDS_RETCODE_OK);
+  CU_ASSERT(test_type(root_type, DDSTS_MODULE, NULL, NULL, true));
+  CU_ASSERT(root_type->module.previous == NULL);
+    ddsts_type_t *struct_s = root_type->module.members.first;
+    CU_ASSERT(test_type(struct_s, DDSTS_STRUCT, "s", root_type, true));
+      ddsts_type_t *decl_a = struct_s->struct_def.members.first;
+      CU_ASSERT(test_type(decl_a, DDSTS_DECLARATION, "a", struct_s, false));
+        ddsts_type_t *char_type = decl_a->declaration.decl_type;
+        CU_ASSERT(test_type(char_type, DDSTS_CHAR, NULL, decl_a, true));
+      ddsts_type_t *decl_b = decl_a->type.next;
+      CU_ASSERT(test_type(decl_b, DDSTS_DECLARATION, "b", struct_s, true));
+        char_type = decl_b->declaration.decl_type;
+        CU_ASSERT(decl_b->declaration.decl_type == char_type);
+      ddsts_struct_key_t *keys = struct_s->struct_def.keys;
+      for (; *keystr != '\0'; keystr++, keys = keys->next)
+      {
+        CU_ASSERT_FATAL(keys != NULL);
+        CU_ASSERT(*keystr != 'a' || keys->member == decl_a);
+        CU_ASSERT(*keystr != 'b' || keys->member == decl_b);
+      }
+      CU_ASSERT(keys == NULL);
+  ddsts_free_type(root_type);
+}
+
+CU_Test(parser, topic_keys)
+{
+  test_topic_keys("struct s{ @key char a; char b;};", "a");
+  test_topic_keys("struct s{ char a; @key char b;};", "b");
+  test_topic_keys("struct s{ @key char a; @key char b;};", "ab");
+  test_topic_keys("struct s{ @key char a, b;};", "ab");
+  test_topic_keys("struct s{ char a; char b;};\n#pragma keylist s a\n", "a");
+  test_topic_keys("struct s{ char a; char b;};\n#pragma keylist s a b\n", "ab");
+  test_topic_keys("struct s{ char a; char b;};\n#pragma keylist s b a\n", "ba");
+  ddsts_type_t *root_type = NULL;
+  CU_ASSERT(ddsts_idl_parse_string("module a{ struct s{char c;};}; module b { struct t{@key ::a::s x;};};", &root_type) == DDS_RETCODE_OK);
+  CU_ASSERT(test_type(root_type, DDSTS_MODULE, NULL, NULL, true));
+    ddsts_type_t *module_a = root_type->module.members.first;
+    CU_ASSERT(test_type(module_a, DDSTS_MODULE, "a", root_type, false));
+    ddsts_type_t *module_b = module_a->type.next;
+    CU_ASSERT(test_type(module_b, DDSTS_MODULE, "b", root_type, true));
+      ddsts_type_t *struct_t = module_b->module.members.first;
+      CU_ASSERT(test_type(struct_t, DDSTS_STRUCT, "t", module_b, true));
+      CU_ASSERT(struct_t->struct_def.keys != NULL);
+      CU_ASSERT(struct_t->struct_def.keys->member != NULL);
+      CU_ASSERT(strcmp(struct_t->struct_def.keys->member->type.name, "x") == 0);
+  ddsts_free_type(root_type);
+  root_type = NULL;
+  CU_ASSERT(ddsts_idl_parse_string("struct s{@key struct{char x;} a;};", &root_type) == DDS_RETCODE_OK);
+  /* verify that the @key is applied to 'a' and not to 'x': */
+  CU_ASSERT(test_type(root_type, DDSTS_MODULE, NULL, NULL, true));
+    ddsts_type_t *struct_s = root_type->module.members.first;
+    CU_ASSERT(test_type(struct_s, DDSTS_STRUCT, "s", root_type, true));
+      ddsts_type_t *anno_struct = struct_s->struct_def.members.first;
+      CU_ASSERT(test_type(anno_struct, DDSTS_STRUCT, NULL, struct_s, false));
+      CU_ASSERT(anno_struct->struct_def.keys == NULL);
+      ddsts_type_t *decl_a = anno_struct->type.next;
+      CU_ASSERT(test_type(decl_a, DDSTS_DECLARATION, "a", struct_s, true));
+    CU_ASSERT(struct_s->struct_def.keys != NULL);
+    CU_ASSERT(struct_s->struct_def.keys->member == decl_a);
+  ddsts_free_type(root_type);
+  
 }
 
 CU_Test(parser, errors)
@@ -288,6 +360,7 @@ CU_Test(parser, errors)
   CU_ASSERT(root_type == NULL);
   CU_ASSERT(ddsts_idl_parse_string("struct s{char a[3][4];};", &root_type) == DDS_RETCODE_OK);
   ddsts_free_type(root_type);
+  root_type = NULL;
   CU_ASSERT(ddsts_idl_parse_string("struct s{char a[3][4];}", &root_type) == DDS_RETCODE_ERROR);
   CU_ASSERT(root_type == NULL);
   CU_ASSERT(ddsts_idl_parse_string("struct s{char a[3][4];", &root_type) == DDS_RETCODE_ERROR);
@@ -326,5 +399,23 @@ CU_Test(parser, errors)
   CU_ASSERT(ddsts_idl_parse_string("struct s{map<char,char!> m;};", &root_type) == DDS_RETCODE_ERROR);
   CU_ASSERT(ddsts_idl_parse_string("struct s{map<char,!char> m;};", &root_type) == DDS_RETCODE_ERROR);
   CU_ASSERT(ddsts_idl_parse_string("struct s{map<char!,char> m;};", &root_type) == DDS_RETCODE_ERROR);
+  CU_ASSERT(ddsts_idl_parse_string("struct s{@key string a[4];};", &root_type) == DDS_RETCODE_ERROR);
+  CU_ASSERT(ddsts_idl_parse_string("struct s{@key sequence<char> a;};", &root_type) == DDS_RETCODE_ERROR);
+  CU_ASSERT(ddsts_idl_parse_string("struct s{@key struct{sequence<char> cs;} a;};", &root_type) == DDS_RETCODE_ERROR);
+  CU_ASSERT(ddsts_idl_parse_string("struct s{@key @key char c;};", &root_type) == DDS_RETCODE_ERROR);
+  CU_ASSERT(ddsts_idl_parse_string("struct s{char c;};\n#pragma keylis\n", &root_type) == DDS_RETCODE_OK);
+  ddsts_free_type(root_type);
+  root_type = NULL;
+  CU_ASSERT(ddsts_idl_parse_string("struct s{char c;};\n#pragma keylist\n", &root_type) == DDS_RETCODE_ERROR);
+  CU_ASSERT(ddsts_idl_parse_string("struct s{char c;};\n#pragma keylist v\n", &root_type) == DDS_RETCODE_ERROR);
+  CU_ASSERT(ddsts_idl_parse_string("struct s{char c;};\n#pragma keylist s\n", &root_type) == DDS_RETCODE_OK);
+  ddsts_free_type(root_type);
+  root_type = NULL;
+  CU_ASSERT(ddsts_idl_parse_string("struct s{char c;};\n#pragma keylist s v\n", &root_type) == DDS_RETCODE_ERROR);
+  CU_ASSERT(ddsts_idl_parse_string("struct s{char c;};\n#pragma keylist s c c\n", &root_type) == DDS_RETCODE_ERROR);
+  CU_ASSERT(ddsts_idl_parse_string("struct s{@key char c; char d;};\n#pragma keylist s d\n", &root_type) == DDS_RETCODE_ERROR);
+  CU_ASSERT(ddsts_idl_parse_string("module a{ struct s{char c;};}; module b { struct t{@ key a::s x;};};", &root_type) == DDS_RETCODE_ERROR);
+  CU_ASSERT(ddsts_idl_parse_string("module a{ struct s{char c;};}; module b { struct t{@key a ::s x;};};", &root_type) == DDS_RETCODE_ERROR);
+  CU_ASSERT(ddsts_idl_parse_string("module a{ struct s{char c;};}; module b { struct t{@key a:: s x;};};", &root_type) == DDS_RETCODE_ERROR);
 }
 


### PR DESCRIPTION
This commit adds support for topic keys, which are needed for a minimal implementation of the C99 back-end.

Both '@key' as the '#pragma keylist' method for defining topic keys are supported. It is possible to define an inline struct as a key. If some of its members are defined as keys, only those members actually are keys. If non of its members are defined as keys, all members are considered to be keys. The keys are stored with the structure as a linked list with pointers to the member declarations of the struct. The tests have been extended to cover the topic keys.

The grammar has been adapted such that no spaces are allowed between identifiers and the '@' and '::' symbols. This is needed to parse a member declaration such as '@key ::a::s x;' correctly.

Signed-off-by: Frans Faase <frans.faase@adlinktech.com>