### PR TITLE
Do not reset dds_sample_rejected_status_t::last_reason when getting status

### DIFF
--- a/src/core/ddsc/src/dds_reader.c
+++ b/src/core/ddsc/src/dds_reader.c
@@ -561,7 +561,7 @@ DDSRT_STATIC_ASSERT ((int) DDS_NOT_REJECTED == 0);
 
 DDS_GET_STATUS (reader, subscription_matched,       SUBSCRIPTION_MATCHED,       total_count_change, current_count_change)
 DDS_GET_STATUS (reader, liveliness_changed,         LIVELINESS_CHANGED,         alive_count_change, not_alive_count_change)
-DDS_GET_STATUS (reader, sample_rejected,            SAMPLE_REJECTED,            total_count_change, last_reason)
+DDS_GET_STATUS (reader, sample_rejected,            SAMPLE_REJECTED,            total_count_change)
 DDS_GET_STATUS (reader, sample_lost,                SAMPLE_LOST,                total_count_change)
 DDS_GET_STATUS (reader, requested_deadline_missed,  REQUESTED_DEADLINE_MISSED,  total_count_change)
 DDS_GET_STATUS (reader, requested_incompatible_qos, REQUESTED_INCOMPATIBLE_QOS, total_count_change)

--- a/src/core/ddsc/tests/entity_status.c
+++ b/src/core/ddsc/tests/entity_status.c
@@ -145,6 +145,15 @@ CU_Test(ddsc_entity_status, publication_matched, .init=init_entity_status, .fini
     CU_ASSERT_EQUAL_FATAL(publication_matched.total_count_change,   1);
     CU_ASSERT_EQUAL_FATAL(publication_matched.last_subscription_handle, reader_i_hdl);
 
+    /* Second call should reset the changed count. */
+    ret = dds_get_publication_matched_status(wri, &publication_matched);
+    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+    CU_ASSERT_EQUAL_FATAL(publication_matched.current_count,        1);
+    CU_ASSERT_EQUAL_FATAL(publication_matched.current_count_change, 0);
+    CU_ASSERT_EQUAL_FATAL(publication_matched.total_count,          1);
+    CU_ASSERT_EQUAL_FATAL(publication_matched.total_count_change,   0);
+    CU_ASSERT_EQUAL_FATAL(publication_matched.last_subscription_handle, reader_i_hdl);
+
     /* Getting the status should have reset the trigger,
      * meaning that the wait should timeout. */
     ret = dds_waitset_wait(waitSetwr, wsresults, wsresultsize, shortTimeout);
@@ -162,6 +171,15 @@ CU_Test(ddsc_entity_status, publication_matched, .init=init_entity_status, .fini
     CU_ASSERT_EQUAL_FATAL(publication_matched.current_count_change, -1);
     CU_ASSERT_EQUAL_FATAL(publication_matched.total_count,           1);
     CU_ASSERT_EQUAL_FATAL(publication_matched.total_count_change,    0);
+    CU_ASSERT_EQUAL_FATAL(publication_matched.last_subscription_handle, reader_i_hdl);
+
+    /* Second call should reset the changed count. */
+    ret = dds_get_publication_matched_status(wri, &publication_matched);
+    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+    CU_ASSERT_EQUAL_FATAL(publication_matched.current_count,        0);
+    CU_ASSERT_EQUAL_FATAL(publication_matched.current_count_change, 0);
+    CU_ASSERT_EQUAL_FATAL(publication_matched.total_count,          1);
+    CU_ASSERT_EQUAL_FATAL(publication_matched.total_count_change,   0);
     CU_ASSERT_EQUAL_FATAL(publication_matched.last_subscription_handle, reader_i_hdl);
 }
 
@@ -182,6 +200,15 @@ CU_Test(ddsc_entity_status, subscription_matched, .init=init_entity_status, .fin
     CU_ASSERT_EQUAL_FATAL(subscription_matched.total_count_change,   1);
     CU_ASSERT_EQUAL_FATAL(subscription_matched.last_publication_handle, writer_i_hdl);
 
+    /* Second call should reset the changed count. */
+    ret = dds_get_subscription_matched_status(rea, &subscription_matched);
+    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+    CU_ASSERT_EQUAL_FATAL(subscription_matched.current_count,        1);
+    CU_ASSERT_EQUAL_FATAL(subscription_matched.current_count_change, 0);
+    CU_ASSERT_EQUAL_FATAL(subscription_matched.total_count,          1);
+    CU_ASSERT_EQUAL_FATAL(subscription_matched.total_count_change,   0);
+    CU_ASSERT_EQUAL_FATAL(subscription_matched.last_publication_handle, writer_i_hdl);
+
     /* Getting the status should have reset the trigger,
      * meaning that the wait should timeout. */
     ret = dds_waitset_wait(waitSetrd, wsresults, wsresultsize, shortTimeout);
@@ -199,6 +226,15 @@ CU_Test(ddsc_entity_status, subscription_matched, .init=init_entity_status, .fin
     CU_ASSERT_EQUAL_FATAL(subscription_matched.current_count_change, -1);
     CU_ASSERT_EQUAL_FATAL(subscription_matched.total_count,           1);
     CU_ASSERT_EQUAL_FATAL(subscription_matched.total_count_change,    0);
+    CU_ASSERT_EQUAL_FATAL(subscription_matched.last_publication_handle, writer_i_hdl);
+
+    /* Second call should reset the changed count. */
+    ret = dds_get_subscription_matched_status(rea, &subscription_matched);
+    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+    CU_ASSERT_EQUAL_FATAL(subscription_matched.current_count,        0);
+    CU_ASSERT_EQUAL_FATAL(subscription_matched.current_count_change, 0);
+    CU_ASSERT_EQUAL_FATAL(subscription_matched.total_count,          1);
+    CU_ASSERT_EQUAL_FATAL(subscription_matched.total_count_change,   0);
     CU_ASSERT_EQUAL_FATAL(subscription_matched.last_publication_handle, writer_i_hdl);
 }
 
@@ -238,6 +274,13 @@ CU_Test(ddsc_entity, incompatible_qos, .init=init_entity_status, .fini=fini_enti
     CU_ASSERT_EQUAL_FATAL(req_incompatible_qos.total_count_change,    1);
     CU_ASSERT_EQUAL_FATAL(req_incompatible_qos.last_policy_id, DDS_DURABILITY_QOS_POLICY_ID);
 
+    /* Second call should reset the changed count. */
+    ret = dds_get_requested_incompatible_qos_status (reader2, &req_incompatible_qos);
+    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+    CU_ASSERT_EQUAL_FATAL(req_incompatible_qos.total_count,           1);
+    CU_ASSERT_EQUAL_FATAL(req_incompatible_qos.total_count_change,    0);
+    CU_ASSERT_EQUAL_FATAL(req_incompatible_qos.last_policy_id, DDS_DURABILITY_QOS_POLICY_ID);
+
     /*Getting the status should have reset the trigger, waitset should timeout */
     ret = dds_waitset_wait(waitSetrd, wsresults, wsresultsize, shortTimeout);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -249,6 +292,13 @@ CU_Test(ddsc_entity, incompatible_qos, .init=init_entity_status, .fini=fini_enti
     CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
     CU_ASSERT_EQUAL_FATAL(off_incompatible_qos.total_count,           1);
     CU_ASSERT_EQUAL_FATAL(off_incompatible_qos.total_count_change,    1);
+    CU_ASSERT_EQUAL_FATAL(off_incompatible_qos.last_policy_id, DDS_DURABILITY_QOS_POLICY_ID);
+
+    /* Second call should reset the changed count. */
+    ret = dds_get_offered_incompatible_qos_status (wri, &off_incompatible_qos);
+    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+    CU_ASSERT_EQUAL_FATAL(off_incompatible_qos.total_count,           1);
+    CU_ASSERT_EQUAL_FATAL(off_incompatible_qos.total_count_change,    0);
     CU_ASSERT_EQUAL_FATAL(off_incompatible_qos.last_policy_id, DDS_DURABILITY_QOS_POLICY_ID);
 
     /*Getting the status should have reset the trigger, waitset should timeout */
@@ -285,6 +335,15 @@ CU_Test(ddsc_entity, liveliness_changed, .init=init_entity_status, .fini=fini_en
     CU_ASSERT_EQUAL_FATAL(liveliness_changed.not_alive_count_change,0);
     CU_ASSERT_EQUAL_FATAL(liveliness_changed.last_publication_handle, writer_i_hdl);
 
+    /* Second call should reset the changed count. */
+    ret = dds_get_liveliness_changed_status (rea, &liveliness_changed);
+    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+    CU_ASSERT_EQUAL_FATAL(liveliness_changed.alive_count,           1);
+    CU_ASSERT_EQUAL_FATAL(liveliness_changed.alive_count_change,    0);
+    CU_ASSERT_EQUAL_FATAL(liveliness_changed.not_alive_count,       0);
+    CU_ASSERT_EQUAL_FATAL(liveliness_changed.not_alive_count_change,0);
+    CU_ASSERT_EQUAL_FATAL(liveliness_changed.last_publication_handle, writer_i_hdl);
+
     /*Getting the status should have reset the trigger, waitset should timeout */
     ret = dds_waitset_wait(waitSetrd, wsresults, wsresultsize, shortTimeout);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -304,6 +363,15 @@ CU_Test(ddsc_entity, liveliness_changed, .init=init_entity_status, .fini=fini_en
     CU_ASSERT_EQUAL_FATAL(liveliness_changed.alive_count_change,    0);
     CU_ASSERT_EQUAL_FATAL(liveliness_changed.not_alive_count,       1);
     CU_ASSERT_EQUAL_FATAL(liveliness_changed.not_alive_count_change,1);
+    CU_ASSERT_EQUAL_FATAL(liveliness_changed.last_publication_handle, writer_i_hdl);
+
+    /* Second call should reset the changed count. */
+    ret = dds_get_liveliness_changed_status (rea, &liveliness_changed);
+    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+    CU_ASSERT_EQUAL_FATAL(liveliness_changed.alive_count,           0);
+    CU_ASSERT_EQUAL_FATAL(liveliness_changed.alive_count_change,    0);
+    CU_ASSERT_EQUAL_FATAL(liveliness_changed.not_alive_count,       1);
+    CU_ASSERT_EQUAL_FATAL(liveliness_changed.not_alive_count_change,0);
     CU_ASSERT_EQUAL_FATAL(liveliness_changed.last_publication_handle, writer_i_hdl);
 }
 
@@ -344,6 +412,13 @@ CU_Test(ddsc_entity, sample_rejected, .init=init_entity_status, .fini=fini_entit
     CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
     CU_ASSERT_EQUAL_FATAL(sample_rejected.total_count,        4);
     CU_ASSERT_EQUAL_FATAL(sample_rejected.total_count_change, 4);
+    CU_ASSERT_EQUAL_FATAL(sample_rejected.last_reason, DDS_REJECTED_BY_SAMPLES_LIMIT);
+
+    /* Second call should reset the changed count. */
+    ret = dds_get_sample_rejected_status (rea, &sample_rejected);
+    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+    CU_ASSERT_EQUAL_FATAL(sample_rejected.total_count,        4);
+    CU_ASSERT_EQUAL_FATAL(sample_rejected.total_count_change, 0);
     CU_ASSERT_EQUAL_FATAL(sample_rejected.last_reason, DDS_REJECTED_BY_SAMPLES_LIMIT);
 
     /*Getting the status should have reset the trigger, waitset should timeout */
@@ -433,8 +508,14 @@ CU_Test(ddsc_entity, sample_lost, .init=init_entity_status, .fini=fini_entity_st
     CU_ASSERT_EQUAL_FATAL(ret, (dds_return_t)wsresultsize);
     ret = dds_get_sample_lost_status (rea, &sample_lost);
     CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    CU_ASSERT_EQUAL_FATAL(sample_lost.total_count,          1);
+    CU_ASSERT_EQUAL_FATAL(sample_lost.total_count,        1);
     CU_ASSERT_EQUAL_FATAL(sample_lost.total_count_change, 1);
+
+    /* Second call should reset the changed count. */
+    ret = dds_get_sample_lost_status (rea, &sample_lost);
+    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+    CU_ASSERT_EQUAL_FATAL(sample_lost.total_count,        1);
+    CU_ASSERT_EQUAL_FATAL(sample_lost.total_count_change, 0);
 
     /*Getting the status should have reset the trigger, waitset should timeout */
     ret = dds_waitset_wait(waitSetrd, wsresults, wsresultsize, shortTimeout);

--- a/src/core/ddsc/tests/listener.c
+++ b/src/core/ddsc/tests/listener.c
@@ -692,6 +692,7 @@ CU_Test(ddsc_listener, matched, .init=init_triggering_base, .fini=fini_triggerin
 
 CU_Test(ddsc_listener, publication_matched, .init=init_triggering_test, .fini=fini_triggering_test)
 {
+    dds_publication_matched_status_t publication_matched;
     dds_instance_handle_t reader_hdl;
     dds_return_t ret;
     uint32_t triggered;
@@ -716,6 +717,15 @@ CU_Test(ddsc_listener, publication_matched, .init=init_triggering_test, .fini=fi
     CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
     CU_ASSERT_EQUAL_FATAL(status, 0);
 
+    /* The listener should have reset the count_change. */
+    ret = dds_get_publication_matched_status(g_writer, &publication_matched);
+    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+    CU_ASSERT_EQUAL_FATAL(publication_matched.current_count,        1);
+    CU_ASSERT_EQUAL_FATAL(publication_matched.current_count_change, 0);
+    CU_ASSERT_EQUAL_FATAL(publication_matched.total_count,          1);
+    CU_ASSERT_EQUAL_FATAL(publication_matched.total_count_change,   0);
+    CU_ASSERT_EQUAL_FATAL(publication_matched.last_subscription_handle, reader_hdl);
+
     /* Reset the trigger flags. */
     cb_called = 0;
 
@@ -731,10 +741,20 @@ CU_Test(ddsc_listener, publication_matched, .init=init_triggering_test, .fini=fi
     CU_ASSERT_EQUAL_FATAL(cb_publication_matched_status.total_count, 1);
     CU_ASSERT_EQUAL_FATAL(cb_publication_matched_status.total_count_change, 0);
     CU_ASSERT_EQUAL_FATAL(cb_publication_matched_status.last_subscription_handle, reader_hdl);
+
+    /* The listener should have reset the count_change. */
+    ret = dds_get_publication_matched_status(g_writer, &publication_matched);
+    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+    CU_ASSERT_EQUAL_FATAL(publication_matched.current_count,        0);
+    CU_ASSERT_EQUAL_FATAL(publication_matched.current_count_change, 0);
+    CU_ASSERT_EQUAL_FATAL(publication_matched.total_count,          1);
+    CU_ASSERT_EQUAL_FATAL(publication_matched.total_count_change,   0);
+    CU_ASSERT_EQUAL_FATAL(publication_matched.last_subscription_handle, reader_hdl);
 }
 
 CU_Test(ddsc_listener, subscription_matched, .init=init_triggering_test, .fini=fini_triggering_test)
 {
+    dds_subscription_matched_status_t subscription_matched;
     dds_instance_handle_t writer_hdl;
     dds_return_t ret;
     uint32_t triggered;
@@ -759,6 +779,15 @@ CU_Test(ddsc_listener, subscription_matched, .init=init_triggering_test, .fini=f
     CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
     CU_ASSERT_EQUAL_FATAL(status, 0);
 
+    /* The listener should have reset the count_change. */
+    ret = dds_get_subscription_matched_status(g_reader, &subscription_matched);
+    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+    CU_ASSERT_EQUAL_FATAL(subscription_matched.current_count, 1);
+    CU_ASSERT_EQUAL_FATAL(subscription_matched.current_count_change, 0);
+    CU_ASSERT_EQUAL_FATAL(subscription_matched.total_count, 1);
+    CU_ASSERT_EQUAL_FATAL(subscription_matched.total_count_change, 0);
+    CU_ASSERT_EQUAL_FATAL(subscription_matched.last_publication_handle, writer_hdl);
+
     /* Reset the trigger flags. */
     cb_called = 0;
 
@@ -774,10 +803,21 @@ CU_Test(ddsc_listener, subscription_matched, .init=init_triggering_test, .fini=f
     CU_ASSERT_EQUAL_FATAL(cb_subscription_matched_status.total_count, 1);
     CU_ASSERT_EQUAL_FATAL(cb_subscription_matched_status.total_count_change, 0);
     CU_ASSERT_EQUAL_FATAL(cb_subscription_matched_status.last_publication_handle, writer_hdl);
+
+    /* The listener should have reset the count_change. */
+    ret = dds_get_subscription_matched_status(g_reader, &subscription_matched);
+    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+    CU_ASSERT_EQUAL_FATAL(subscription_matched.current_count, 0);
+    CU_ASSERT_EQUAL_FATAL(subscription_matched.current_count_change, 0);
+    CU_ASSERT_EQUAL_FATAL(subscription_matched.total_count, 1);
+    CU_ASSERT_EQUAL_FATAL(subscription_matched.total_count_change, 0);
+    CU_ASSERT_EQUAL_FATAL(subscription_matched.last_publication_handle, writer_hdl);
 }
 
 CU_Test(ddsc_listener, incompatible_qos, .init=init_triggering_base, .fini=fini_triggering_base)
 {
+    dds_offered_incompatible_qos_status_t offered_incompatible_qos;
+    dds_requested_incompatible_qos_status_t requested_incompatible_qos;
     dds_return_t ret;
     uint32_t triggered;
     uint32_t status;
@@ -814,6 +854,18 @@ CU_Test(ddsc_listener, incompatible_qos, .init=init_triggering_base, .fini=fini_
     ret = dds_read_status(g_reader, &status, DDS_REQUESTED_INCOMPATIBLE_QOS_STATUS);
     CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
     CU_ASSERT_EQUAL_FATAL(status, 0);
+
+    /* The listener should have reset the count_change. */
+    ret = dds_get_offered_incompatible_qos_status(g_writer, &offered_incompatible_qos);
+    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+    ret = dds_get_requested_incompatible_qos_status(g_reader, &requested_incompatible_qos);
+    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+    CU_ASSERT_EQUAL_FATAL(offered_incompatible_qos.total_count, 1);
+    CU_ASSERT_EQUAL_FATAL(offered_incompatible_qos.total_count_change, 0);
+    CU_ASSERT_EQUAL_FATAL(offered_incompatible_qos.last_policy_id, DDS_DURABILITY_QOS_POLICY_ID);
+    CU_ASSERT_EQUAL_FATAL(requested_incompatible_qos.total_count, 1);
+    CU_ASSERT_EQUAL_FATAL(requested_incompatible_qos.total_count_change, 0);
+    CU_ASSERT_EQUAL_FATAL(requested_incompatible_qos.last_policy_id, DDS_DURABILITY_QOS_POLICY_ID);
 
     dds_delete(g_writer);
     dds_delete(g_reader);
@@ -997,6 +1049,7 @@ CU_Test(ddsc_listener, data_on_readers, .init=init_triggering_test, .fini=fini_t
 
 CU_Test(ddsc_listener, sample_lost, .init=init_triggering_test, .fini=fini_triggering_test)
 {
+    dds_sample_lost_status_t sample_lost;
     dds_return_t ret;
     uint32_t triggered;
     dds_time_t the_past;
@@ -1031,10 +1084,17 @@ CU_Test(ddsc_listener, sample_lost, .init=init_triggering_test, .fini=fini_trigg
     ret = dds_read_status(g_reader, &status, DDS_SAMPLE_LOST_STATUS);
     CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
     CU_ASSERT_EQUAL_FATAL(status, 0);
+
+    /* The listener should have reset the count_change. */
+    ret = dds_get_sample_lost_status(g_reader, &sample_lost);
+    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+    CU_ASSERT_EQUAL_FATAL(sample_lost.total_count, 1);
+    CU_ASSERT_EQUAL_FATAL(sample_lost.total_count_change, 0);
 }
 
 CU_Test(ddsc_listener, sample_rejected, .init=init_triggering_test, .fini=fini_triggering_test)
 {
+    dds_sample_rejected_status_t sample_rejected;
     dds_return_t ret;
     uint32_t triggered;
     uint32_t status;
@@ -1060,15 +1120,24 @@ CU_Test(ddsc_listener, sample_rejected, .init=init_triggering_test, .fini=fini_t
     CU_ASSERT_EQUAL_FATAL(cb_reader, g_reader);
     CU_ASSERT_EQUAL_FATAL(cb_sample_rejected_status.total_count, 2);
     CU_ASSERT_EQUAL_FATAL(cb_sample_rejected_status.total_count_change, 1);
+    CU_ASSERT_EQUAL_FATAL(cb_sample_rejected_status.last_reason, DDS_REJECTED_BY_SAMPLES_LIMIT);
 
     /* The listener should have swallowed the status. */
     ret = dds_read_status(g_reader, &status, DDS_SAMPLE_REJECTED_STATUS);
     CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
     CU_ASSERT_EQUAL_FATAL(status, 0);
+
+    /* The listener should have reset the count_change. */
+    ret = dds_get_sample_rejected_status(g_reader, &sample_rejected);
+    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+    CU_ASSERT_EQUAL_FATAL(sample_rejected.total_count, 2);
+    CU_ASSERT_EQUAL_FATAL(sample_rejected.total_count_change, 0);
+    CU_ASSERT_EQUAL_FATAL(cb_sample_rejected_status.last_reason, DDS_REJECTED_BY_SAMPLES_LIMIT);
 }
 
 CU_Test(ddsc_listener, liveliness_changed, .init=init_triggering_test, .fini=fini_triggering_base)
 {
+    dds_liveliness_changed_status_t liveliness_changed;
     dds_instance_handle_t writer_hdl;
     dds_return_t ret;
     uint32_t triggered;
@@ -1095,6 +1164,15 @@ CU_Test(ddsc_listener, liveliness_changed, .init=init_triggering_test, .fini=fin
     CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
     CU_ASSERT_EQUAL_FATAL(status, 0);
 
+    /* The listener should have reset the count_change. */
+    ret = dds_get_liveliness_changed_status(g_reader, &liveliness_changed);
+    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+    CU_ASSERT_EQUAL_FATAL(liveliness_changed.alive_count, 1);
+    CU_ASSERT_EQUAL_FATAL(liveliness_changed.alive_count_change, 0);
+    CU_ASSERT_EQUAL_FATAL(liveliness_changed.not_alive_count, 0);
+    CU_ASSERT_EQUAL_FATAL(liveliness_changed.not_alive_count_change, 0);
+    CU_ASSERT_EQUAL_FATAL(liveliness_changed.last_publication_handle, writer_hdl);
+
     /* Reset the trigger flags. */
     cb_called = 0;
 
@@ -1110,6 +1188,15 @@ CU_Test(ddsc_listener, liveliness_changed, .init=init_triggering_test, .fini=fin
     CU_ASSERT_EQUAL_FATAL(cb_liveliness_changed_status.not_alive_count, 1);
     CU_ASSERT_EQUAL_FATAL(cb_liveliness_changed_status.not_alive_count_change, 1);
     CU_ASSERT_EQUAL_FATAL(cb_liveliness_changed_status.last_publication_handle, writer_hdl);
+
+    /* The listener should have reset the count_change. */
+    ret = dds_get_liveliness_changed_status(g_reader, &liveliness_changed);
+    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+    CU_ASSERT_EQUAL_FATAL(liveliness_changed.alive_count, 0);
+    CU_ASSERT_EQUAL_FATAL(liveliness_changed.alive_count_change, 0);
+    CU_ASSERT_EQUAL_FATAL(liveliness_changed.not_alive_count, 1);
+    CU_ASSERT_EQUAL_FATAL(liveliness_changed.not_alive_count_change, 0);
+    CU_ASSERT_EQUAL_FATAL(liveliness_changed.last_publication_handle, writer_hdl);
 }
 
 #if 0


### PR DESCRIPTION
Getting a status should reset its ```change_count``` variables. But only those.
Calling ```dds_get_sample_rejected_status()``` would cause the ```last_reason``` variable to be reset as well. This reset has been removed.

This ```change_count``` reset is also applicable for listener triggers. But the listener already left the ```last_reason``` alone when resetting ```dds_sample_rejected_status_t```.

Tests were added.