### PR TITLE
Fixed build issue when using dds_err_nr()

### DIFF
--- a/src/core/ddsc/include/dds/ddsc/dds_public_error.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_public_error.h
@@ -39,7 +39,7 @@ extern "C" {
 /* Error code handling functions */
 
 /** Macro to extract error number */
-#define dds_err_nr(e) (e))
+#define dds_err_nr(e) (e)
 
 /** Macro to extract line number */
 #define dds_err_line(e) (0)


### PR DESCRIPTION
The dds_err_nr() macro contains a redundant closing parentheses, causing build problems when used. This has been removed.