### PR TITLE
Update Travis to use xcode 10.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,9 +67,9 @@ linux_clang: &linux_clang
   install:
     - pip install conan --upgrade --user
 
-osx_xcode10_1: &osx_xcode10_1
+osx_xcode10_2: &osx_xcode10_2
   os: osx
-  osx_image: xcode10.1
+  osx_image: xcode10.2
   compiler: clang
   addons:
     homebrew:
@@ -141,9 +141,9 @@ jobs:
       env: [ ARCH=x86_64, ASAN=address, BUILD_TYPE=Debug, GENERATOR="Unix Makefiles" ]
     - <<: *linux_clang
       env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, GENERATOR="Unix Makefiles" ]
-    - <<: *osx_xcode10_1
+    - <<: *osx_xcode10_2
       env: [ ARCH=x86_64, ASAN=address, BUILD_TYPE=Debug, GENERATOR="Unix Makefiles" ]
-    - <<: *osx_xcode10_1
+    - <<: *osx_xcode10_2
       env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, GENERATOR="Unix Makefiles" ]
     - <<: *windows_vs2017
       env: [ ARCH=x86, ASAN=none, BUILD_TYPE=Debug, GENERATOR="Visual Studio 15 2017" ]


### PR DESCRIPTION
This is the easiest way to solve the Travis image referencing a now too-old homebrew version.