### PR TITLE
Locking issues

### DIFF
--- a/src/core/ddsc/include/dds/dds.h
+++ b/src/core/ddsc/include/dds/dds.h
@@ -79,7 +79,6 @@ DDS_EXPORT dds_domainid_t dds_domain_default (void);
 
 /** @name Communication Status definitions
   @{**/
-/** Another topic exists with the same name but with different characteristics. */
 typedef enum dds_status_id {
   DDS_INCONSISTENT_TOPIC_STATUS_ID,
   DDS_OFFERED_DEADLINE_MISSED_STATUS_ID,
@@ -94,8 +93,9 @@ typedef enum dds_status_id {
   DDS_LIVELINESS_CHANGED_STATUS_ID,
   DDS_PUBLICATION_MATCHED_STATUS_ID,
   DDS_SUBSCRIPTION_MATCHED_STATUS_ID
-}
-dds_status_id_t;
+} dds_status_id_t;
+
+/** Another topic exists with the same name but with different characteristics. */
 #define DDS_INCONSISTENT_TOPIC_STATUS          (1u << DDS_INCONSISTENT_TOPIC_STATUS_ID)
 /** The deadline that the writer has committed through its deadline QoS policy was not respected for a specific instance. */
 #define DDS_OFFERED_DEADLINE_MISSED_STATUS     (1u << DDS_OFFERED_DEADLINE_MISSED_STATUS_ID)

--- a/src/core/ddsc/include/dds/ddsc/dds_public_alloc.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_public_alloc.h
@@ -54,20 +54,6 @@ typedef struct dds_allocator
 }
 dds_allocator_t;
 
-DDS_EXPORT void dds_set_allocator (const dds_allocator_t * __restrict n, dds_allocator_t * __restrict o);
-
-typedef struct dds_aligned_allocator
-{
-  /* size is a multiple of align, align is a power of 2 no less than
-     the machine's page size, returned pointer MUST be aligned to at
-     least align. */
-  void * (*alloc) (size_t size, size_t align);
-  void (*free) (size_t size, void *ptr);
-}
-dds_aligned_allocator_t;
-
-DDS_EXPORT void dds_set_aligned_allocator (const dds_aligned_allocator_t * __restrict n, dds_aligned_allocator_t * __restrict o);
-
 DDS_EXPORT void * dds_alloc (size_t size);
 DDS_EXPORT void * dds_realloc (void * ptr, size_t size);
 DDS_EXPORT void * dds_realloc_zero (void * ptr, size_t size);

--- a/src/core/ddsc/include/dds/ddsc/dds_public_impl.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_public_impl.h
@@ -98,19 +98,18 @@ dds_topic_descriptor_t;
 
 typedef enum dds_entity_kind
 {
-  DDS_KIND_DONTCARE    = 0x00000000,
-  DDS_KIND_TOPIC       = 0x01000000,
-  DDS_KIND_PARTICIPANT = 0x02000000,
-  DDS_KIND_READER      = 0x03000000,
-  DDS_KIND_WRITER      = 0x04000000,
-  DDS_KIND_SUBSCRIBER  = 0x05000000,
-  DDS_KIND_PUBLISHER   = 0x06000000,
-  DDS_KIND_COND_READ   = 0x07000000,
-  DDS_KIND_COND_QUERY  = 0x08000000,
-  DDS_KIND_COND_GUARD  = 0x09000000,
-  DDS_KIND_WAITSET     = 0x0A000000
-}
-dds_entity_kind_t;
+  DDS_KIND_DONTCARE,
+  DDS_KIND_TOPIC,
+  DDS_KIND_PARTICIPANT,
+  DDS_KIND_READER,
+  DDS_KIND_WRITER,
+  DDS_KIND_SUBSCRIBER,
+  DDS_KIND_PUBLISHER,
+  DDS_KIND_COND_READ,
+  DDS_KIND_COND_QUERY,
+  DDS_KIND_COND_GUARD,
+  DDS_KIND_WAITSET
+} dds_entity_kind_t;
 
 /* Handles are opaque pointers to implementation types */
 typedef uint64_t dds_instance_handle_t;

--- a/src/core/ddsc/src/dds__entity.h
+++ b/src/core/ddsc/src/dds__entity.h
@@ -26,20 +26,22 @@ dds_entity_init(
   dds_entity_kind_t kind,
   dds_qos_t * qos,
   const dds_listener_t *listener,
-  uint32_t mask);
+  status_mask_t mask);
 
 DDS_EXPORT void
-dds_entity_add_ref(dds_entity *e);
+dds_entity_register_child (
+  dds_entity *parent,
+  dds_entity *child);
 
 DDS_EXPORT void
-dds_entity_add_ref_nolock(dds_entity *e);
+dds_entity_add_ref_locked(dds_entity *e);
 
 #define DEFINE_ENTITY_LOCK_UNLOCK(qualifier_, type_, kind_) \
   qualifier_ dds_return_t type_##_lock (dds_entity_t hdl, type_ **x) \
   { \
     dds_return_t rc; \
     dds_entity *e; \
-    if ((rc = dds_entity_lock (hdl, kind_, &e)) != DDS_RETCODE_OK) \
+    if ((rc = dds_entity_lock (hdl, kind_, &e)) < 0) \
       return rc; \
     *x = (type_ *) e; \
     return DDS_RETCODE_OK; \
@@ -61,30 +63,27 @@ DDS_EXPORT inline bool dds_entity_is_enabled (const dds_entity *e) {
   return (e->m_flags & DDS_ENTITY_ENABLED) != 0;
 }
 
-DDS_EXPORT void dds_entity_status_set (dds_entity *e, uint32_t t);
+DDS_EXPORT void dds_entity_status_set (dds_entity *e, status_mask_t t);
+DDS_EXPORT void dds_entity_trigger_set (dds_entity *e, uint32_t t);
 
-DDS_EXPORT inline void dds_entity_status_reset (dds_entity *e, uint32_t t) {
-  e->m_trigger &= ~t;
-}
-
-DDS_EXPORT inline bool dds_entity_status_match (const dds_entity *e, uint32_t t) {
-  return (e->m_trigger & t) != 0;
+DDS_EXPORT inline void dds_entity_status_reset (dds_entity *e, status_mask_t t) {
+  ddsrt_atomic_and32 (&e->m_status.m_status_and_mask, SAM_ENABLED_MASK | (status_mask_t) ~t);
 }
 
 DDS_EXPORT inline dds_entity_kind_t dds_entity_kind (const dds_entity *e) {
   return e->m_kind;
 }
 
-DDS_EXPORT void dds_entity_status_signal (dds_entity *e);
+DDS_EXPORT void dds_entity_status_signal (dds_entity *e, uint32_t status);
 
 DDS_EXPORT void dds_entity_invoke_listener (const dds_entity *entity, enum dds_status_id which, const void *vst);
 
 DDS_EXPORT dds_return_t
-dds_entity_claim (
+dds_entity_pin (
   dds_entity_t hdl,
   dds_entity **eptr);
 
-DDS_EXPORT void dds_entity_release (
+DDS_EXPORT void dds_entity_unpin (
   dds_entity *e);
 
 DDS_EXPORT dds_return_t
@@ -97,26 +96,16 @@ DDS_EXPORT void
 dds_entity_unlock(dds_entity *e);
 
 DDS_EXPORT dds_return_t
-dds_entity_observer_register_nl(
-  dds_entity *observed,
-  dds_entity_t observer,
-  dds_entity_callback cb);
-
-DDS_EXPORT dds_return_t
 dds_entity_observer_register(
-  dds_entity_t observed,
-  dds_entity_t observer,
-  dds_entity_callback cb);
-
-DDS_EXPORT dds_return_t
-dds_entity_observer_unregister_nl(
   dds_entity *observed,
-  dds_entity_t observer);
+  dds_entity *observer,
+  dds_entity_callback cb,
+  dds_entity_delete_callback delete_cb);
 
 DDS_EXPORT dds_return_t
 dds_entity_observer_unregister(
-  dds_entity_t observed,
-  dds_entity_t observer);
+  dds_entity *observed,
+  dds_entity *observer);
 
 DDS_EXPORT dds_return_t
 dds_delete_impl(

--- a/src/core/ddsc/src/dds__get_status.h
+++ b/src/core/ddsc/src/dds__get_status.h
@@ -29,7 +29,7 @@
   { \
     if (status) \
       *status = ent->m_##status_##_status; \
-    if (ent->m_entity.m_status_enable & DDS_##STATUS_##_STATUS) { \
+    if (ddsrt_atomic_ld32 (&ent->m_entity.m_status.m_status_and_mask) & (DDS_##STATUS_##_STATUS << SAM_ENABLED_SHIFT)) { \
       do { DDS_GET_STATUS_LOCKED_RESET_N (DDSRT_COUNT_ARGS (__VA_ARGS__), status_, __VA_ARGS__) } while (0); \
       dds_entity_status_reset (&ent->m_entity, DDS_##STATUS_##_STATUS); \
     } \

--- a/src/core/ddsc/src/dds__handles.h
+++ b/src/core/ddsc/src/dds__handles.h
@@ -145,13 +145,13 @@ dds_handle_delete(
  * Returns OK when succeeded.
  */
 DDS_EXPORT int32_t
-dds_handle_claim(
+dds_handle_pin(
         dds_handle_t hdl,
         struct dds_handle_link **entity);
 
 
 DDS_EXPORT void
-dds_handle_claim_inc(
+dds_handle_repin(
         struct dds_handle_link *link);
 
 
@@ -159,7 +159,7 @@ dds_handle_claim_inc(
  * The active claims count is decreased.
  */
 DDS_EXPORT void
-dds_handle_release(
+dds_handle_unpin(
         struct dds_handle_link *link);
 
 
@@ -176,6 +176,9 @@ DDS_EXPORT bool
 dds_handle_is_closed(
         struct dds_handle_link *link);
 
+
+DDS_EXPORT void dds_handle_add_ref (struct dds_handle_link *link);
+DDS_EXPORT bool dds_handle_drop_ref (struct dds_handle_link *link);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsc/src/dds__types.h
+++ b/src/core/ddsc/src/dds__types.h
@@ -39,12 +39,11 @@ struct dds_statuscond;
 struct ddsi_sertopic;
 struct rhc;
 
-/* Internal entity status flags */
-
-#define DDS_INTERNAL_STATUS_MASK     (0xFF000000u)
-
-#define DDS_WAITSET_TRIGGER_STATUS   (0x01000000u)
-#define DDS_DELETING_STATUS          (0x02000000u)
+typedef uint16_t status_mask_t;
+typedef ddsrt_atomic_uint32_t status_and_enabled_t;
+#define SAM_STATUS_MASK        0xffffu
+#define SAM_ENABLED_MASK   0xffff0000u
+#define SAM_ENABLED_SHIFT          16
 
 /* This can be used when polling for various states.
  * Obviously, it is encouraged to use condition variables and such. But
@@ -92,14 +91,12 @@ struct dds_listener {
 #define DDS_ENTITY_ENABLED      0x0001u
 #define DDS_ENTITY_IMPLICIT     0x0002u
 
-typedef struct dds_domain
-{
+typedef struct dds_domain {
   ddsrt_avl_node_t m_node;
   dds_domainid_t m_id;
   ddsrt_avl_tree_t m_topics;
   uint32_t m_refc;
-}
-dds_domain;
+} dds_domain;
 
 struct dds_entity;
 typedef struct dds_entity_deriver {
@@ -111,28 +108,28 @@ typedef struct dds_entity_deriver {
   dds_return_t (*validate_status)(uint32_t mask);
 } dds_entity_deriver;
 
-typedef void (*dds_entity_callback)(dds_entity_t observer, dds_entity_t observed, uint32_t status);
+typedef void (*dds_entity_callback)(struct dds_entity *observer, dds_entity_t observed, uint32_t status);
+typedef void (*dds_entity_delete_callback)(struct dds_entity *observer, dds_entity_t observed);
 
 typedef struct dds_entity_observer {
   dds_entity_callback m_cb;
-  dds_entity_t m_observer;
+  dds_entity_delete_callback m_delete_cb;
+  struct dds_entity *m_observer;
   struct dds_entity_observer *m_next;
 } dds_entity_observer;
 
 typedef struct dds_entity {
   struct dds_handle_link m_hdllink; /* handle is constant, cnt_flags private to dds_handle.c */
   dds_entity_kind_t m_kind;         /* constant */
-  dds_entity_deriver m_deriver;     /* constant; FIXME: no point in having function pointers embedded */
-  uint32_t m_refc;                  /* [m_mutex] */
   struct dds_entity *m_next;        /* [m_mutex] */
   struct dds_entity *m_parent;      /* constant */
-  struct dds_entity *m_children;    /* [m_mutex] */
+  ddsrt_avl_node_t m_avlnode_child; /* [m_mutex of m_parent] */
+  ddsrt_avl_tree_t m_children;      /* [m_mutex] tree on m_iid using m_avlnode_child */
   struct dds_entity *m_participant; /* constant */
   struct dds_domain *m_domain;      /* constant */
   dds_qos_t *m_qos;                 /* [m_mutex] */
-  dds_domainid_t m_domainid;        /* constant; FIXME: why? hardly ever used, m_domain should give that info, too */
-  nn_guid_t m_guid;                 /* ~ constant: FIXME: set during creation, but possibly after becoming visible */
-  dds_instance_handle_t m_iid;      /* ~ constant: FIXME: like GUID */
+  nn_guid_t m_guid;                 /* unique (if not 0) and constant; FIXME: set during creation, but possibly after becoming visible */
+  dds_instance_handle_t m_iid;      /* unique for all time, constant; FIXME: like GUID */
   uint32_t m_flags;                 /* [m_mutex] */
 
   /* Allowed:
@@ -145,47 +142,78 @@ typedef struct dds_entity {
   ddsrt_mutex_t m_mutex;
   ddsrt_cond_t m_cond;
 
-  ddsrt_mutex_t m_observers_lock;
+  union {
+    status_and_enabled_t m_status_and_mask; /* for most entities */
+    ddsrt_atomic_uint32_t m_trigger;        /* for conditions & waitsets */
+  } m_status;
+
+  ddsrt_mutex_t m_observers_lock;   /* locking parent->...->m_observers_lock while holding it is allowed */
   ddsrt_cond_t m_observers_cond;
-  dds_listener_t m_listener;
-  uint32_t m_trigger;
-  uint32_t m_status_enable;
-  uint32_t m_cb_count;
-  dds_entity_observer *m_observers;
-}
-dds_entity;
+  dds_listener_t m_listener;        /* [m_observers_lock] */
+  uint32_t m_cb_count;              /* [m_observers_lock] */
+  dds_entity_observer *m_observers; /* [m_observers_lock] */
+} dds_entity;
 
 extern const ddsrt_avl_treedef_t dds_topictree_def;
+extern const ddsrt_avl_treedef_t dds_entity_children_td;
 
-typedef struct dds_subscriber
-{
-  struct dds_entity m_entity;
+extern const struct dds_entity_deriver dds_entity_deriver_topic;
+extern const struct dds_entity_deriver dds_entity_deriver_participant;
+extern const struct dds_entity_deriver dds_entity_deriver_reader;
+extern const struct dds_entity_deriver dds_entity_deriver_writer;
+extern const struct dds_entity_deriver dds_entity_deriver_subscriber;
+extern const struct dds_entity_deriver dds_entity_deriver_publisher;
+extern const struct dds_entity_deriver dds_entity_deriver_readcondition;
+extern const struct dds_entity_deriver dds_entity_deriver_guardcondition;
+extern const struct dds_entity_deriver dds_entity_deriver_waitset;
+extern const struct dds_entity_deriver *dds_entity_deriver_table[];
+
+dds_return_t dds_entity_deriver_dummy_close (struct dds_entity *e);
+dds_return_t dds_entity_deriver_dummy_delete (struct dds_entity *e);
+dds_return_t dds_entity_deriver_dummy_set_qos (struct dds_entity *e, const dds_qos_t *qos, bool enabled);
+dds_return_t dds_entity_deriver_dummy_validate_status (uint32_t mask);
+
+inline dds_return_t dds_entity_deriver_close (struct dds_entity *e) {
+  return dds_entity_deriver_table[e->m_kind]->close (e);
 }
-dds_subscriber;
-
-typedef struct dds_publisher
-{
-  struct dds_entity m_entity;
+inline dds_return_t dds_entity_deriver_delete (struct dds_entity *e) {
+  return dds_entity_deriver_table[e->m_kind]->delete (e);
 }
-dds_publisher;
+inline dds_return_t dds_entity_deriver_set_qos (struct dds_entity *e, const dds_qos_t *qos, bool enabled) {
+  return dds_entity_deriver_table[e->m_kind]->set_qos (e, qos, enabled);
+}
+inline dds_return_t dds_entity_deriver_validate_status (struct dds_entity *e, uint32_t mask) {
+  return dds_entity_deriver_table[e->m_kind]->validate_status (mask);
+}
+inline bool dds_entity_supports_set_qos (struct dds_entity *e) {
+  return dds_entity_deriver_table[e->m_kind]->set_qos != dds_entity_deriver_dummy_set_qos;
+}
+inline bool dds_entity_supports_validate_status (struct dds_entity *e) {
+  return dds_entity_deriver_table[e->m_kind]->validate_status != dds_entity_deriver_dummy_validate_status;
+}
 
-typedef struct dds_participant
-{
+typedef struct dds_subscriber {
+  struct dds_entity m_entity;
+} dds_subscriber;
+
+typedef struct dds_publisher {
+  struct dds_entity m_entity;
+} dds_publisher;
+
+typedef struct dds_participant {
   struct dds_entity m_entity;
   struct dds_entity * m_dur_reader;
   struct dds_entity * m_dur_writer;
   dds_entity_t m_builtin_subscriber;
-}
-dds_participant;
+} dds_participant;
 
-typedef struct dds_reader
-{
+typedef struct dds_reader {
   struct dds_entity m_entity;
-  const struct dds_topic * m_topic;
-  struct reader * m_rd;
+  const struct dds_topic *m_topic;
+  struct reader *m_rd;
   bool m_data_on_readers;
   bool m_loan_out;
-  void * m_loan;
+  void *m_loan;
   uint32_t m_loan_size;
 
   /* Status metrics */
@@ -196,15 +224,13 @@ typedef struct dds_reader
   dds_requested_incompatible_qos_status_t m_requested_incompatible_qos_status;
   dds_sample_lost_status_t m_sample_lost_status;
   dds_subscription_matched_status_t m_subscription_matched_status;
-}
-dds_reader;
+} dds_reader;
 
-typedef struct dds_writer
-{
+typedef struct dds_writer {
   struct dds_entity m_entity;
-  const struct dds_topic * m_topic;
-  struct nn_xpack * m_xp;
-  struct writer * m_wr;
+  const struct dds_topic *m_topic;
+  struct nn_xpack *m_xp;
+  struct writer *m_wr;
   struct whc *m_whc; /* FIXME: ownership still with underlying DDSI writer (cos of DDSI built-in writers )*/
 
   /* Status metrics */
@@ -213,74 +239,62 @@ typedef struct dds_writer
   dds_offered_deadline_missed_status_t m_offered_deadline_missed_status;
   dds_offered_incompatible_qos_status_t m_offered_incompatible_qos_status;
   dds_publication_matched_status_t m_publication_matched_status;
-}
-dds_writer;
+} dds_writer;
 
 #ifndef DDS_TOPIC_INTERN_FILTER_FN_DEFINED
 #define DDS_TOPIC_INTERN_FILTER_FN_DEFINED
 typedef bool (*dds_topic_intern_filter_fn) (const void * sample, void *ctx);
 #endif
 
-typedef struct dds_topic
-{
+typedef struct dds_topic {
   struct dds_entity m_entity;
-  struct ddsi_sertopic * m_stopic;
+  struct ddsi_sertopic *m_stopic;
 
   dds_topic_intern_filter_fn filter_fn;
-  void * filter_ctx;
+  void *filter_ctx;
 
   /* Status metrics */
 
   dds_inconsistent_topic_status_t m_inconsistent_topic_status;
-}
-dds_topic;
+} dds_topic;
 
 typedef uint32_t dds_querycond_mask_t;
 
-typedef struct dds_readcond
-{
+typedef struct dds_readcond {
   dds_entity m_entity;
-  struct rhc * m_rhc;
+  struct rhc *m_rhc;
   uint32_t m_qminv;
   uint32_t m_sample_states;
   uint32_t m_view_states;
   uint32_t m_instance_states;
   nn_guid_t m_rd_guid;
-  struct dds_readcond * m_next;
-  struct
-  {
-      dds_querycondition_filter_fn m_filter;
-      dds_querycond_mask_t m_qcmask; /* condition mask in RHC*/
+  struct dds_readcond *m_next;
+  struct {
+    dds_querycondition_filter_fn m_filter;
+    dds_querycond_mask_t m_qcmask; /* condition mask in RHC*/
   } m_query;
-}
-dds_readcond;
+} dds_readcond;
 
-typedef struct dds_guardcond
-{
+typedef struct dds_guardcond {
   dds_entity m_entity;
-}
-dds_guardcond;
+} dds_guardcond;
 
-typedef struct dds_attachment
-{
-    dds_entity  *entity;
-    dds_attach_t arg;
-    struct dds_attachment* next;
-}
-dds_attachment;
+typedef struct dds_attachment {
+  dds_entity *entity;
+  dds_entity_t handle;
+  dds_attach_t arg;
+} dds_attachment;
 
-typedef struct dds_waitset
-{
+typedef struct dds_waitset {
   dds_entity m_entity;
-  dds_attachment *observed;
-  dds_attachment *triggered;
-}
-dds_waitset;
+  size_t nentities;         /* [m_entity.m_mutex] */
+  size_t ntriggered;        /* [m_entity.m_mutex] */
+  dds_attachment *entities; /* [m_entity.m_mutex] 0 .. ntriggered are triggred, ntriggred .. nentities are not */
+} dds_waitset;
 
 /* Globals */
 
-typedef struct dds_globals
-{
+typedef struct dds_globals {
   dds_domainid_t m_default_domain;
   int32_t m_init_count;
   void (*m_dur_reader) (struct dds_reader * reader, struct rhc * rhc);
@@ -289,8 +303,7 @@ typedef struct dds_globals
   void (*m_dur_fini) (void);
   ddsrt_avl_tree_t m_domains;
   ddsrt_mutex_t m_mutex;
-}
-dds_globals;
+} dds_globals;
 
 DDS_EXPORT extern dds_globals dds_global;
 

--- a/src/core/ddsc/src/dds_entity.c
+++ b/src/core/ddsc/src/dds_entity.c
@@ -26,23 +26,58 @@
 
 extern inline dds_entity *dds_entity_from_handle_link (struct dds_handle_link *hdllink);
 extern inline bool dds_entity_is_enabled (const dds_entity *e);
-extern inline void dds_entity_status_reset (dds_entity *e, uint32_t t);
-extern inline bool dds_entity_status_match (const dds_entity *e, uint32_t t);
+extern inline void dds_entity_status_reset (dds_entity *e, status_mask_t t);
 extern inline dds_entity_kind_t dds_entity_kind (const dds_entity *e);
 
-static void dds_entity_observers_signal (dds_entity *observed, uint32_t status);
-static void dds_entity_observers_delete (dds_entity *observed);
+const struct dds_entity_deriver *dds_entity_deriver_table[] = {
+  [DDS_KIND_TOPIC] = &dds_entity_deriver_topic,
+  [DDS_KIND_PARTICIPANT] = &dds_entity_deriver_participant,
+  [DDS_KIND_READER] = &dds_entity_deriver_reader,
+  [DDS_KIND_WRITER] = &dds_entity_deriver_writer,
+  [DDS_KIND_SUBSCRIBER] = &dds_entity_deriver_subscriber,
+  [DDS_KIND_PUBLISHER] = &dds_entity_deriver_publisher,
+  [DDS_KIND_COND_READ] = &dds_entity_deriver_readcondition,
+  [DDS_KIND_COND_QUERY] = &dds_entity_deriver_readcondition,
+  [DDS_KIND_COND_GUARD] = &dds_entity_deriver_guardcondition,
+  [DDS_KIND_WAITSET] = &dds_entity_deriver_waitset,
+};
 
-void dds_entity_add_ref_nolock (dds_entity *e)
-{
-  e->m_refc++;
+dds_return_t dds_entity_deriver_dummy_close (struct dds_entity *e) {
+  (void) e; return DDS_RETCODE_OK;
+}
+dds_return_t dds_entity_deriver_dummy_delete (struct dds_entity *e) {
+  (void) e; return DDS_RETCODE_OK;
+}
+dds_return_t dds_entity_deriver_dummy_set_qos (struct dds_entity *e, const dds_qos_t *qos, bool enabled) {
+  (void) e; (void) qos; (void) enabled; return DDS_RETCODE_ILLEGAL_OPERATION;
+}
+dds_return_t dds_entity_deriver_dummy_validate_status (uint32_t mask) {
+  (void) mask; return DDS_RETCODE_ILLEGAL_OPERATION;
 }
 
-void dds_entity_add_ref (dds_entity *e)
+extern inline dds_return_t dds_entity_deriver_close (struct dds_entity *e);
+extern inline dds_return_t dds_entity_deriver_delete (struct dds_entity *e);
+extern inline dds_return_t dds_entity_deriver_set_qos (struct dds_entity *e, const dds_qos_t *qos, bool enabled);
+extern inline dds_return_t dds_entity_deriver_validate_status (struct dds_entity *e, uint32_t mask);
+extern inline bool dds_entity_supports_set_qos (struct dds_entity *e);
+extern inline bool dds_entity_supports_validate_status (struct dds_entity *e);
+
+static int compare_instance_handle (const void *va, const void *vb)
 {
-  ddsrt_mutex_lock (&e->m_mutex);
-  dds_entity_add_ref_nolock (e);
-  ddsrt_mutex_unlock (&e->m_mutex);
+  const dds_instance_handle_t *a = va;
+  const dds_instance_handle_t *b = vb;
+  return (*a == *b) ? 0 : (*a < *b) ? -1 : 1;
+}
+
+const ddsrt_avl_treedef_t dds_entity_children_td = DDSRT_AVL_TREEDEF_INITIALIZER (offsetof (struct dds_entity, m_avlnode_child), offsetof (struct dds_entity, m_iid), compare_instance_handle, 0);
+
+static void dds_entity_observers_signal (dds_entity *observed, uint32_t status);
+static void dds_entity_observers_signal_delete (dds_entity *observed);
+static void dds_entity_observers_delete (dds_entity *observed);
+
+void dds_entity_add_ref_locked (dds_entity *e)
+{
+  dds_handle_add_ref (&e->m_hdllink);
 }
 
 dds_domain *dds__entity_domain (dds_entity *e)
@@ -50,41 +85,54 @@ dds_domain *dds__entity_domain (dds_entity *e)
   return e->m_domain;
 }
 
-static void dds_set_explicit (dds_entity_t entity)
-{
-  dds_entity *e;
-  dds_return_t rc;
-  if ((rc = dds_entity_lock (entity, DDS_KIND_DONTCARE, &e)) == DDS_RETCODE_OK)
-  {
-    e->m_flags &= ~DDS_ENTITY_IMPLICIT;
-    dds_entity_unlock (e);
-  }
-}
-
 static dds_entity *dds__nonself_parent (dds_entity *e)
 {
   return e->m_parent == e ? NULL : e->m_parent;
 }
 
-dds_entity_t dds_entity_init (dds_entity *e, dds_entity *parent, dds_entity_kind_t kind, dds_qos_t *qos, const dds_listener_t *listener, uint32_t mask)
+static bool entity_has_status (const dds_entity *e)
+{
+  switch (e->m_kind)
+  {
+    case DDS_KIND_TOPIC:
+    case DDS_KIND_READER:
+    case DDS_KIND_WRITER:
+    case DDS_KIND_PUBLISHER:
+    case DDS_KIND_SUBSCRIBER:
+    case DDS_KIND_PARTICIPANT:
+      return true;
+    case DDS_KIND_COND_READ:
+    case DDS_KIND_COND_QUERY:
+    case DDS_KIND_COND_GUARD:
+    case DDS_KIND_WAITSET:
+      break;
+    case DDS_KIND_DONTCARE:
+      abort ();
+      break;
+  }
+  return false;
+}
+
+dds_entity_t dds_entity_init (dds_entity *e, dds_entity *parent, dds_entity_kind_t kind, dds_qos_t *qos, const dds_listener_t *listener, status_mask_t mask)
 {
   dds_handle_t handle;
 
   assert ((kind == DDS_KIND_PARTICIPANT) == (parent == NULL));
   assert (e);
 
-  e->m_refc = 1;
   e->m_kind = kind;
   e->m_qos = qos;
   e->m_cb_count = 0;
   e->m_observers = NULL;
-  e->m_trigger = 0;
 
   /* TODO: CHAM-96: Implement dynamic enabling of entity. */
   e->m_flags |= DDS_ENTITY_ENABLED;
 
   /* set the status enable based on kind */
-  e->m_status_enable = mask | DDS_INTERNAL_STATUS_MASK;
+  if (entity_has_status (e))
+    ddsrt_atomic_st32 (&e->m_status.m_status_and_mask, (uint32_t) mask << SAM_ENABLED_SHIFT);
+  else
+    ddsrt_atomic_st32 (&e->m_status.m_trigger, 0);
 
   ddsrt_mutex_init (&e->m_mutex);
   ddsrt_mutex_init (&e->m_observers_lock);
@@ -95,10 +143,8 @@ dds_entity_t dds_entity_init (dds_entity *e, dds_entity *parent, dds_entity_kind
   {
     e->m_parent = parent;
     e->m_domain = parent->m_domain;
-    e->m_domainid = parent->m_domainid;
     e->m_participant = parent->m_participant;
-    e->m_next = parent->m_children;
-    parent->m_children = e;
+    ddsrt_avl_init (&dds_entity_children_td, &e->m_children);
   }
   else
   {
@@ -111,9 +157,9 @@ dds_entity_t dds_entity_init (dds_entity *e, dds_entity *parent, dds_entity_kind
     dds_merge_listener (&e->m_listener, listener);
   if (parent)
   {
-    ddsrt_mutex_lock (&e->m_observers_lock);
+    ddsrt_mutex_lock (&parent->m_observers_lock);
     dds_inherit_listener (&e->m_listener, &parent->m_listener);
-    ddsrt_mutex_unlock (&e->m_observers_lock);
+    ddsrt_mutex_unlock (&parent->m_observers_lock);
   }
 
   if ((handle = dds_handle_create (&e->m_hdllink)) <= 0)
@@ -123,16 +169,27 @@ dds_entity_t dds_entity_init (dds_entity *e, dds_entity *parent, dds_entity_kind
   return (dds_entity_t) handle;
 }
 
+void dds_entity_register_child (dds_entity *parent, dds_entity *child)
+{
+  assert (child->m_iid != 0);
+  assert (ddsrt_avl_lookup (&dds_entity_children_td, &parent->m_children, &child->m_iid) == NULL);
+  ddsrt_avl_insert (&dds_entity_children_td, &parent->m_children, child);
+}
+
 dds_return_t dds_delete (dds_entity_t entity)
 {
   return dds_delete_impl (entity, false);
 }
 
-static dds_entity *next_non_topic_child (dds_entity *remaining_children)
+static dds_entity *next_non_topic_child (ddsrt_avl_tree_t *remaining_children)
 {
-  while (remaining_children != NULL && dds_entity_kind (remaining_children) == DDS_KIND_TOPIC)
-    remaining_children = remaining_children->m_next;
-  return remaining_children;
+  ddsrt_avl_iter_t it;
+  for (dds_entity *e = ddsrt_avl_iter_first (&dds_entity_children_td, remaining_children, &it); e != NULL; e = ddsrt_avl_iter_next (&it))
+  {
+    if (dds_entity_kind (e) != DDS_KIND_TOPIC)
+      return e;
+  }
+  return NULL;
 }
 
 dds_return_t dds_delete_impl (dds_entity_t entity, bool keep_if_explicit)
@@ -140,45 +197,39 @@ dds_return_t dds_delete_impl (dds_entity_t entity, bool keep_if_explicit)
   dds_time_t timeout = DDS_SECS(10);
   dds_entity *e;
   dds_entity *child;
-  dds_entity *parent;
-  dds_entity *prev = NULL;
-  dds_entity *next = NULL;
   dds_return_t ret;
   dds_return_t rc;
 
-  rc = dds_entity_lock (entity, DDS_KIND_DONTCARE, &e);
-  if (rc != DDS_RETCODE_OK)
+  if ((rc = dds_entity_pin (entity, &e)) < 0)
   {
     DDS_TRACE ("dds_delete_impl: error on locking entity %"PRIu32" keep_if_explicit %d\n", entity, (int) keep_if_explicit);
     return rc;
   }
 
+  ddsrt_mutex_lock (&e->m_mutex);
   if (keep_if_explicit == true && (e->m_flags & DDS_ENTITY_IMPLICIT) == 0)
   {
-    dds_entity_unlock(e);
+    ddsrt_mutex_unlock (&e->m_mutex);
+    dds_entity_unpin (e);
     return DDS_RETCODE_OK;
   }
 
-  if (--e->m_refc != 0)
+  if (! dds_handle_drop_ref (&e->m_hdllink))
   {
-    dds_entity_unlock (e);
+    ddsrt_mutex_unlock (&e->m_mutex);
+    dds_entity_unpin (e);
     return DDS_RETCODE_OK;
   }
 
-  /* FIXME: "closing" the handle here means a listener invoked on X
-     can still discover that X has become inaccessible */
-  /* FIXME: RHC reads m_status_enable outside lock and might still
-     just invoke the listener */
-  dds_handle_close (&e->m_hdllink);
-  e->m_status_enable = 0;
+  ddsrt_mutex_lock (&e->m_observers_lock);
+  if (entity_has_status (e))
+    ddsrt_atomic_and32 (&e->m_status.m_status_and_mask, SAM_STATUS_MASK);
   dds_reset_listener (&e->m_listener);
-  e->m_trigger |= DDS_DELETING_STATUS;
-  dds_entity_unlock(e);
 
   /* Signal observers that this entity will be deleted and wait for
      all listeners to complete. */
-  ddsrt_mutex_lock (&e->m_observers_lock);
-  dds_entity_observers_signal (e, e->m_trigger);
+  ddsrt_mutex_unlock (&e->m_mutex);
+  dds_entity_observers_signal_delete (e);
   while (e->m_cb_count > 0)
     ddsrt_cond_wait (&e->m_observers_cond, &e->m_observers_lock);
   ddsrt_mutex_unlock (&e->m_observers_lock);
@@ -201,29 +252,27 @@ dds_return_t dds_delete_impl (dds_entity_t entity, bool keep_if_explicit)
    * To circumvent the problem. We ignore topics in the first loop.
    */
   ret = DDS_RETCODE_OK;
-  child = next_non_topic_child (e->m_children);
-  while (child != NULL && ret == DDS_RETCODE_OK)
+  ddsrt_mutex_lock (&e->m_mutex);
+  while ((child = next_non_topic_child (&e->m_children)) && ret == DDS_RETCODE_OK)
   {
-    next = next_non_topic_child (child->m_next);
-    /* This will probably delete the child entry from the current children's list */
-    ret = dds_delete (child->m_hdllink.hdl);
-    child = next;
+    dds_entity_t child_handle = child->m_hdllink.hdl;
+    ddsrt_mutex_unlock (&e->m_mutex);
+    ret = dds_delete (child_handle);
+    ddsrt_mutex_lock (&e->m_mutex);
   }
-  child = e->m_children;
-  while (child != NULL && ret == DDS_RETCODE_OK)
+  while ((child = ddsrt_avl_find_min (&dds_entity_children_td, &e->m_children)) != NULL && ret == DDS_RETCODE_OK)
   {
-    next = child->m_next;
     assert (dds_entity_kind (child) == DDS_KIND_TOPIC);
-    ret = dds_delete (child->m_hdllink.hdl);
-    child = next;
+    dds_entity_t child_handle = child->m_hdllink.hdl;
+    ddsrt_mutex_unlock (&e->m_mutex);
+    ret = dds_delete (child_handle);
+    ddsrt_mutex_lock (&e->m_mutex);
   }
-  if (ret == DDS_RETCODE_OK && e->m_deriver.close)
-  {
-    /* Close the entity. This can terminate threads or kick of
-     * other destroy stuff that takes a while. */
-    ret = e->m_deriver.close (e);
-  }
+  ddsrt_mutex_unlock (&e->m_mutex);
+  if (ret == DDS_RETCODE_OK)
+    ret = dds_entity_deriver_close (e);
 
+  dds_entity_unpin (e);
   if (ret == DDS_RETCODE_OK)
   {
     /* The dds_handle_delete will wait until the last active claim on that handle
@@ -239,26 +288,17 @@ dds_return_t dds_delete_impl (dds_entity_t entity, bool keep_if_explicit)
     dds_entity_observers_delete (e);
 
     /* Remove from parent */
+    dds_entity *parent;
     if ((parent = dds__nonself_parent(e)) != NULL)
     {
       ddsrt_mutex_lock (&parent->m_mutex);
-      child = parent->m_children;
-      while (child && child != e)
-      {
-        prev = child;
-        child = child->m_next;
-      }
-      assert (child != NULL);
-      if (prev)
-        prev->m_next = e->m_next;
-      else
-        parent->m_children = e->m_next;
+      assert (ddsrt_avl_lookup (&dds_entity_children_td, &parent->m_children, &e->m_iid) != NULL);
+      ddsrt_avl_delete (&dds_entity_children_td, &parent->m_children, e);
       ddsrt_mutex_unlock (&parent->m_mutex);
     }
 
     /* Do some specific deletion when needed. */
-    if (e->m_deriver.delete)
-      ret = e->m_deriver.delete(e);
+    ret = dds_entity_deriver_delete (e);
   }
 
   if (ret == DDS_RETCODE_OK)
@@ -288,8 +328,13 @@ dds_entity_t dds_get_parent (dds_entity_t entity)
       hdl = DDS_ENTITY_NIL;
     else
     {
+      dds_entity *x;
       hdl = parent->m_hdllink.hdl;
-      dds_set_explicit (hdl);
+      if (dds_entity_lock (hdl, DDS_KIND_DONTCARE, &x) == DDS_RETCODE_OK)
+      {
+        parent->m_flags &= ~DDS_ENTITY_IMPLICIT;
+        dds_entity_unlock (parent);
+      }
     }
     dds_entity_unlock (e);
     return hdl;
@@ -320,24 +365,43 @@ dds_return_t dds_get_children (dds_entity_t entity, dds_entity_t *children, size
   if (children == NULL && size != 0)
     return DDS_RETCODE_BAD_PARAMETER;
 
-  if ((rc = dds_entity_lock (entity, DDS_KIND_DONTCARE, &e)) != DDS_RETCODE_OK)
+  if ((rc = dds_entity_pin (entity, &e)) != DDS_RETCODE_OK)
     return rc;
   else
   {
-    dds_return_t n = 0;
-    dds_entity *iter = e->m_children;
-    while (iter)
+    /* FIXME: fix the implicit/explicit stuff so the set_explicit isn't needed; and then this can also be done with a regular iterator & without unlocking */
+    size_t n = 0;
+    dds_instance_handle_t last_iid = 0;
+    struct dds_entity *c;
+    ddsrt_mutex_lock (&e->m_mutex);
+    while ((c = ddsrt_avl_lookup_succ (&dds_entity_children_td, &e->m_children, &last_iid)) != NULL)
     {
-      if ((size_t) n < size)
+      last_iid = c->m_iid;
+      if (n < size)
       {
-        children[n] = iter->m_hdllink.hdl;
-        dds_set_explicit (iter->m_hdllink.hdl);
+        dds_entity *x;
+        /* Claim child handle to guarantee the child entity remains valid; as we unlock "e" only when we manage to claim the child, and the child has to remain in existence until we release it, "c" remains a valid pointer despite the unlocking. */
+        if (dds_entity_pin (c->m_hdllink.hdl, &x) == DDS_RETCODE_OK)
+        {
+          assert (x == c);
+          children[n] = c->m_hdllink.hdl;
+          ddsrt_mutex_unlock (&e->m_mutex);
+
+          ddsrt_mutex_lock (&c->m_mutex);
+          c->m_flags &= ~DDS_ENTITY_IMPLICIT;
+          ddsrt_mutex_unlock (&c->m_mutex);
+
+          ddsrt_mutex_lock (&e->m_mutex);
+          dds_entity_unpin (c);
+        }
       }
       n++;
-      iter = iter->m_next;
     }
-    dds_entity_unlock(e);
-    return n;
+    ddsrt_mutex_unlock (&e->m_mutex);
+    dds_entity_unpin (e);
+    /* there are fewer than INT32_MAX handles, so there can never be more entities */
+    assert (n <= INT32_MAX);
+    return (dds_return_t) n;
   }
 }
 
@@ -378,7 +442,7 @@ dds_return_t dds_get_qos (dds_entity_t entity, dds_qos_t *qos)
   if ((ret = dds_entity_lock (entity, DDS_KIND_DONTCARE, &e)) != DDS_RETCODE_OK)
     return ret;
 
-  if (e->m_deriver.set_qos == 0)
+  if (!dds_entity_supports_set_qos (e))
     ret = DDS_RETCODE_ILLEGAL_OPERATION;
   else
   {
@@ -417,7 +481,7 @@ static dds_return_t dds_set_qos_locked_impl (dds_entity *e, const dds_qos_t *qos
 
   if (ret != DDS_RETCODE_OK)
     dds_delete_qos (newqos);
-  else if ((ret = e->m_deriver.set_qos (e, newqos, e->m_flags & DDS_ENTITY_ENABLED)) != DDS_RETCODE_OK)
+  else if ((ret = dds_entity_deriver_set_qos (e, newqos, e->m_flags & DDS_ENTITY_ENABLED)) != DDS_RETCODE_OK)
     dds_delete_qos (newqos);
   else
   {
@@ -427,87 +491,90 @@ static dds_return_t dds_set_qos_locked_impl (dds_entity *e, const dds_qos_t *qos
   return ret;
 }
 
-static void pushdown_pubsub_qos (dds_entity_t entity)
+static void pushdown_pubsub_qos (dds_entity *e)
 {
-  dds_entity_t *cs = NULL;
-  int ncs, size = 0;
-  while ((ncs = dds_get_children (entity, cs, (size_t) size)) > size)
+  /* e claimed but no mutex held */
+  struct dds_entity *c;
+  dds_instance_handle_t last_iid = 0;
+  ddsrt_mutex_lock (&e->m_mutex);
+  while ((c = ddsrt_avl_lookup_succ (&dds_entity_children_td, &e->m_children, &last_iid)) != NULL)
   {
-    size = ncs;
-    cs = ddsrt_realloc (cs, (size_t) size * sizeof (*cs));
-  }
-  for (int i = 0; i < ncs; i++)
-  {
-    dds_entity *e;
-    if (dds_entity_lock (cs[i], DDS_KIND_DONTCARE, &e) == DDS_RETCODE_OK)
+    struct dds_entity *x;
+    last_iid = c->m_iid;
+    if (dds_entity_pin (c->m_hdllink.hdl, &x) == DDS_RETCODE_OK)
     {
-      if (dds_entity_kind (e) == DDS_KIND_READER || dds_entity_kind (e) == DDS_KIND_WRITER)
-      {
-        dds_entity *pe;
-        if (dds_entity_lock (entity, DDS_KIND_DONTCARE, &pe) == DDS_RETCODE_OK)
-        {
-          dds_set_qos_locked_impl (e, pe->m_qos, QP_GROUP_DATA | QP_PARTITION);
-          dds_entity_unlock (pe);
-        }
-      }
-      dds_entity_unlock (e);
+      assert (x == c);
+      assert (dds_entity_kind (c) == DDS_KIND_READER || dds_entity_kind (c) == DDS_KIND_WRITER);
+      /* see dds_get_children for why "c" remains valid despite unlocking m_mutex;
+         unlock e, lock c, relock e sequence is to avoid locking a child while holding the parent */
+      ddsrt_mutex_unlock (&e->m_mutex);
+
+      ddsrt_mutex_lock (&c->m_mutex);
+      ddsrt_mutex_lock (&e->m_mutex);
+      dds_set_qos_locked_impl (c, e->m_qos, QP_GROUP_DATA | QP_PARTITION);
+      ddsrt_mutex_unlock (&c->m_mutex);
+      dds_entity_unpin (c);
     }
   }
-  ddsrt_free (cs);
+  ddsrt_mutex_unlock (&e->m_mutex);
 }
 
-static void pushdown_topic_qos (dds_entity_t parent, dds_entity_t topic)
+static void pushdown_topic_qos (dds_entity *e, struct dds_entity *tp)
 {
-  dds_entity_t *cs = NULL;
-  int ncs, size = 0;
-  while ((ncs = dds_get_children (parent, cs, (size_t) size)) > size)
+  /* on input: both entities claimed but no mutexes held */
+  enum { NOP, PROP, CHANGE } todo;
+  switch (dds_entity_kind (e))
   {
-    size = ncs;
-    cs = ddsrt_realloc (cs, (size_t) size * sizeof (*cs));
-  }
-  for (int i = 0; i < ncs; i++)
-  {
-    dds_entity *e;
-    if (dds_entity_lock (cs[i], DDS_KIND_DONTCARE, &e) == DDS_RETCODE_OK)
-    {
-      enum { NOP, PROP, CHANGE } todo;
-      switch (dds_entity_kind (e))
-      {
-        case DDS_KIND_READER: {
-          dds_reader *rd = (dds_reader *) e;
-          todo = (rd->m_topic->m_entity.m_hdllink.hdl == topic) ? CHANGE : NOP;
-          break;
-        }
-        case DDS_KIND_WRITER: {
-          dds_writer *wr = (dds_writer *) e;
-          todo = (wr->m_topic->m_entity.m_hdllink.hdl == topic) ? CHANGE : NOP;
-          break;
-        case DDS_KIND_PUBLISHER:
-        case DDS_KIND_SUBSCRIBER:
-          todo = PROP;
-          break;
-        default:
-          todo = NOP;
-          break;
-        }
-      }
-      if (todo == CHANGE)
-      {
-        dds_topic *tp;
-        if (dds_topic_lock (topic, &tp) == DDS_RETCODE_OK)
-        {
-          dds_set_qos_locked_impl (e, tp->m_entity.m_qos, QP_TOPIC_DATA);
-          dds_topic_unlock (tp);
-        }
-      }
-      dds_entity_unlock (e);
-      if (todo == PROP)
-      {
-        pushdown_topic_qos (cs[i], topic);
-      }
+    case DDS_KIND_READER: {
+      dds_reader *rd = (dds_reader *) e;
+      todo = (&rd->m_topic->m_entity == tp) ? CHANGE : NOP;
+      break;
+    }
+    case DDS_KIND_WRITER: {
+      dds_writer *wr = (dds_writer *) e;
+      todo = (&wr->m_topic->m_entity == tp) ? CHANGE : NOP;
+      break;
+    }
+    default: {
+      todo = PROP;
+      break;
     }
   }
-  ddsrt_free (cs);
+  switch (todo)
+  {
+    case NOP:
+      break;
+    case CHANGE: {
+      /* may lock topic while holding reader/writer lock */
+      ddsrt_mutex_lock (&e->m_mutex);
+      ddsrt_mutex_lock (&tp->m_mutex);
+      dds_set_qos_locked_impl (e, tp->m_qos, QP_TOPIC_DATA);
+      ddsrt_mutex_unlock (&tp->m_mutex);
+      ddsrt_mutex_unlock (&e->m_mutex);
+      break;
+    }
+    case PROP: {
+      struct dds_entity *c;
+      dds_instance_handle_t last_iid = 0;
+      ddsrt_mutex_lock (&e->m_mutex);
+      while ((c = ddsrt_avl_lookup_succ (&dds_entity_children_td, &e->m_children, &last_iid)) != NULL)
+      {
+        struct dds_entity *x;
+        last_iid = c->m_iid;
+        if (dds_entity_pin (c->m_hdllink.hdl, &x) == DDS_RETCODE_OK)
+        {
+          assert (x == c);
+          /* see dds_get_children for why "c" remains valid despite unlocking m_mutex */
+          ddsrt_mutex_unlock (&e->m_mutex);
+          pushdown_topic_qos (c, tp);
+          ddsrt_mutex_lock (&e->m_mutex);
+          dds_entity_unpin (c);
+        }
+      }
+      ddsrt_mutex_unlock (&e->m_mutex);
+      break;
+    }
+  }
 }
 
 dds_return_t dds_set_qos (dds_entity_t entity, const dds_qos_t *qos)
@@ -516,34 +583,48 @@ dds_return_t dds_set_qos (dds_entity_t entity, const dds_qos_t *qos)
   dds_return_t ret;
   if (qos == NULL)
     return DDS_RETCODE_BAD_PARAMETER;
-  else if ((ret = dds_entity_lock (entity, DDS_KIND_DONTCARE, &e)) != DDS_RETCODE_OK)
+  if ((ret = dds_entity_pin (entity, &e)) < 0)
     return ret;
-  else
+
+  const dds_entity_kind_t kind = dds_entity_kind (e);
+  if (!dds_entity_supports_set_qos (e))
   {
-    const dds_entity_kind_t kind = dds_entity_kind (e);
-    dds_entity_t pphandle = e->m_participant->m_hdllink.hdl;
-    if (e->m_deriver.set_qos == 0)
-      ret = DDS_RETCODE_ILLEGAL_OPERATION;
-    else
-      ret = dds_set_qos_locked_impl (e, qos, entity_kind_qos_mask (kind));
-    dds_entity_unlock (e);
-    if (ret == DDS_RETCODE_OK)
-    {
-      switch (dds_entity_kind (e))
+    dds_entity_unpin (e);
+    return DDS_RETCODE_ILLEGAL_OPERATION;
+  }
+
+  ddsrt_mutex_lock (&e->m_mutex);
+  ret = dds_set_qos_locked_impl (e, qos, entity_kind_qos_mask (kind));
+  ddsrt_mutex_unlock (&e->m_mutex);
+  if (ret < 0)
+  {
+    dds_entity_unpin (e);
+    return ret;
+  }
+
+  switch (dds_entity_kind (e))
+  {
+    case DDS_KIND_TOPIC: {
+      dds_entity *pp;
+      if (dds_entity_pin (e->m_participant->m_hdllink.hdl, &pp) == DDS_RETCODE_OK)
       {
-        case DDS_KIND_TOPIC:
-          pushdown_topic_qos (pphandle, entity);
-          break;
-        case DDS_KIND_PUBLISHER:
-        case DDS_KIND_SUBSCRIBER:
-          pushdown_pubsub_qos (entity);
-          break;
-        default:
-          break;
+        pushdown_topic_qos (pp, e);
+        dds_entity_unpin (pp);
       }
+      break;
+    }
+    case DDS_KIND_PUBLISHER:
+    case DDS_KIND_SUBSCRIBER: {
+      pushdown_pubsub_qos (e);
+      break;
+    }
+    default: {
+      break;
     }
   }
-  return ret;
+
+  dds_entity_unpin (e);
+  return 0;
 }
 
 dds_return_t dds_get_listener (dds_entity_t entity, dds_listener_t *listener)
@@ -552,14 +633,14 @@ dds_return_t dds_get_listener (dds_entity_t entity, dds_listener_t *listener)
   dds_return_t ret;
   if (listener == NULL)
     return DDS_RETCODE_BAD_PARAMETER;
-  else if ((ret = dds_entity_lock (entity, DDS_KIND_DONTCARE, &e)) != DDS_RETCODE_OK)
+  else if ((ret = dds_entity_pin (entity, &e)) != DDS_RETCODE_OK)
     return ret;
   else
   {
     ddsrt_mutex_lock (&e->m_observers_lock);
     dds_copy_listener (listener, &e->m_listener);
     ddsrt_mutex_unlock (&e->m_observers_lock);
-    dds_entity_unlock(e);
+    dds_entity_unpin (e);
     return DDS_RETCODE_OK;
   }
 }
@@ -638,62 +719,70 @@ void dds_entity_invoke_listener (const dds_entity *entity, enum dds_status_id wh
 static void clear_status_with_listener (struct dds_entity *e)
 {
   const struct dds_listener *lst = &e->m_listener;
+  status_mask_t mask = 0;
   if (lst->on_inconsistent_topic)
-    e->m_trigger &= ~DDS_INCONSISTENT_TOPIC_STATUS;
+    mask |= DDS_INCONSISTENT_TOPIC_STATUS;
   if (lst->on_liveliness_lost)
-    e->m_trigger &= ~DDS_LIVELINESS_LOST_STATUS;
+    mask |= DDS_LIVELINESS_LOST_STATUS;
   if (lst->on_offered_deadline_missed)
-    e->m_trigger &= ~DDS_OFFERED_DEADLINE_MISSED_STATUS;
+    mask |= DDS_OFFERED_DEADLINE_MISSED_STATUS;
   if (lst->on_offered_deadline_missed_arg)
-    e->m_trigger &= ~DDS_OFFERED_DEADLINE_MISSED_STATUS;
+    mask |= DDS_OFFERED_DEADLINE_MISSED_STATUS;
   if (lst->on_offered_incompatible_qos)
-    e->m_trigger &= ~DDS_OFFERED_INCOMPATIBLE_QOS_STATUS;
+    mask |= DDS_OFFERED_INCOMPATIBLE_QOS_STATUS;
   if (lst->on_data_on_readers)
-    e->m_trigger &= ~DDS_DATA_ON_READERS_STATUS;
+    mask |= DDS_DATA_ON_READERS_STATUS;
   if (lst->on_sample_lost)
-    e->m_trigger &= ~DDS_SAMPLE_LOST_STATUS;
+    mask |= DDS_SAMPLE_LOST_STATUS;
   if (lst->on_data_available)
-    e->m_trigger &= ~DDS_DATA_AVAILABLE_STATUS;
+    mask |= DDS_DATA_AVAILABLE_STATUS;
   if (lst->on_sample_rejected)
-    e->m_trigger &= ~DDS_SAMPLE_REJECTED_STATUS;
+    mask |= DDS_SAMPLE_REJECTED_STATUS;
   if (lst->on_liveliness_changed)
-    e->m_trigger &= ~DDS_LIVELINESS_CHANGED_STATUS;
+    mask |= DDS_LIVELINESS_CHANGED_STATUS;
   if (lst->on_requested_deadline_missed)
-    e->m_trigger &= ~DDS_REQUESTED_DEADLINE_MISSED_STATUS;
+    mask |= DDS_REQUESTED_DEADLINE_MISSED_STATUS;
   if (lst->on_requested_incompatible_qos)
-    e->m_trigger &= ~DDS_REQUESTED_INCOMPATIBLE_QOS_STATUS;
+    mask |= DDS_REQUESTED_INCOMPATIBLE_QOS_STATUS;
   if (lst->on_publication_matched)
-    e->m_trigger &= ~DDS_PUBLICATION_MATCHED_STATUS;
+    mask |= DDS_PUBLICATION_MATCHED_STATUS;
   if (lst->on_subscription_matched)
-    e->m_trigger &= ~DDS_SUBSCRIPTION_MATCHED_STATUS;
+    mask |= DDS_SUBSCRIPTION_MATCHED_STATUS;
+  ddsrt_atomic_and32 (&e->m_status.m_status_and_mask, ~(uint32_t)mask);
 }
 
-static void pushdown_listener (dds_entity_t entity)
+static void pushdown_listener (dds_entity *e)
 {
-  dds_entity_t *cs = NULL;
-  int ncs, size = 0;
-  while ((ncs = dds_get_children (entity, cs, (size_t) size)) > size)
+  /* Note: e is claimed, no mutexes held */
+  struct dds_entity *c;
+  dds_instance_handle_t last_iid = 0;
+  ddsrt_mutex_lock (&e->m_mutex);
+  while ((c = ddsrt_avl_lookup_succ (&dds_entity_children_td, &e->m_children, &last_iid)) != NULL)
   {
-    size = ncs;
-    cs = ddsrt_realloc (cs, (size_t) size * sizeof (*cs));
-  }
-  for (int i = 0; i < ncs; i++)
-  {
-    dds_entity *e;
-    if (dds_entity_lock (cs[i], DDS_KIND_DONTCARE, &e) == DDS_RETCODE_OK)
+    struct dds_entity *x;
+    last_iid = c->m_iid;
+    if (dds_entity_pin (c->m_hdllink.hdl, &x) == DDS_RETCODE_OK)
     {
-      dds_listener_t tmp;
+      ddsrt_mutex_unlock (&e->m_mutex);
+
+      ddsrt_mutex_lock (&c->m_observers_lock);
+      while (c->m_cb_count > 0)
+        ddsrt_cond_wait (&c->m_observers_cond, &c->m_observers_lock);
+
       ddsrt_mutex_lock (&e->m_observers_lock);
-      while (e->m_cb_count > 0)
-        ddsrt_cond_wait (&e->m_observers_cond, &e->m_observers_lock);
-      dds_get_listener (entity, &tmp);
-      dds_override_inherited_listener (&e->m_listener, &tmp);
-      clear_status_with_listener (e);
+      dds_override_inherited_listener (&c->m_listener, &e->m_listener);
       ddsrt_mutex_unlock (&e->m_observers_lock);
-      dds_entity_unlock (e);
+
+      clear_status_with_listener (c);
+      ddsrt_mutex_unlock (&c->m_observers_lock);
+
+      pushdown_listener (c);
+
+      ddsrt_mutex_lock (&e->m_mutex);
+      dds_entity_unpin (c);
     }
   }
-  ddsrt_free (cs);
+  ddsrt_mutex_unlock (&e->m_mutex);
 }
 
 dds_return_t dds_set_listener (dds_entity_t entity, const dds_listener_t *listener)
@@ -701,7 +790,7 @@ dds_return_t dds_set_listener (dds_entity_t entity, const dds_listener_t *listen
   dds_entity *e, *x;
   dds_return_t rc;
 
-  if ((rc = dds_entity_claim (entity, &e)) != DDS_RETCODE_OK)
+  if ((rc = dds_entity_pin (entity, &e)) != DDS_RETCODE_OK)
     return rc;
 
   ddsrt_mutex_lock (&e->m_observers_lock);
@@ -718,12 +807,14 @@ dds_return_t dds_set_listener (dds_entity_t entity, const dds_listener_t *listen
   while (dds_entity_kind (x) != DDS_KIND_PARTICIPANT)
   {
     x = x->m_parent;
+    ddsrt_mutex_lock (&x->m_observers_lock);
     dds_inherit_listener (&e->m_listener, &x->m_listener);
+    ddsrt_mutex_unlock (&x->m_observers_lock);
   }
   clear_status_with_listener (e);
   ddsrt_mutex_unlock (&e->m_observers_lock);
-  dds_entity_release (e);
-  pushdown_listener (entity);
+  pushdown_listener (e);
+  dds_entity_unpin (e);
   return DDS_RETCODE_OK;
 }
 
@@ -756,13 +847,12 @@ dds_return_t dds_get_status_changes (dds_entity_t entity, uint32_t *status)
   if ((ret = dds_entity_lock (entity, DDS_KIND_DONTCARE, &e)) != DDS_RETCODE_OK)
     return ret;
 
-  if (e->m_deriver.validate_status == 0)
+  if (!dds_entity_supports_validate_status (e))
     ret = DDS_RETCODE_ILLEGAL_OPERATION;
   else
   {
-    ddsrt_mutex_lock (&e->m_observers_lock);
-    *status = e->m_trigger;
-    ddsrt_mutex_unlock (&e->m_observers_lock);
+    assert (entity_has_status (e));
+    *status = ddsrt_atomic_ld32 (&e->m_status.m_status_and_mask) & SAM_STATUS_MASK;
     ret = DDS_RETCODE_OK;
   }
   dds_entity_unlock(e);
@@ -777,19 +867,18 @@ dds_return_t dds_get_status_mask (dds_entity_t entity, uint32_t *mask)
   if (mask == NULL)
     return DDS_RETCODE_BAD_PARAMETER;
 
-  if ((ret = dds_entity_claim (entity, &e)) != DDS_RETCODE_OK)
+  if ((ret = dds_entity_pin (entity, &e)) != DDS_RETCODE_OK)
     return ret;
 
-  if (e->m_deriver.validate_status == 0)
+  if (!dds_entity_supports_validate_status (e))
     ret = DDS_RETCODE_ILLEGAL_OPERATION;
   else
   {
-    ddsrt_mutex_lock (&e->m_observers_lock);
-    *mask = (e->m_status_enable & ~DDS_INTERNAL_STATUS_MASK);
-    ddsrt_mutex_unlock (&e->m_observers_lock);
+    assert (entity_has_status (e));
+    *mask = ddsrt_atomic_ld32 (&e->m_status.m_status_and_mask) >> SAM_ENABLED_SHIFT;
     ret = DDS_RETCODE_OK;
   }
-  dds_entity_release(e);
+  dds_entity_unpin(e);
   return ret;
 }
 
@@ -803,30 +892,34 @@ dds_return_t dds_set_status_mask (dds_entity_t entity, uint32_t mask)
   dds_entity *e;
   dds_return_t ret;
 
-  if ((ret = dds_entity_claim (entity, &e)) != DDS_RETCODE_OK)
+  if ((mask & ~SAM_STATUS_MASK) != 0)
+    return DDS_RETCODE_BAD_PARAMETER;
+
+  if ((ret = dds_entity_pin (entity, &e)) != DDS_RETCODE_OK)
     return ret;
 
-  if (e->m_deriver.validate_status == 0)
-    ret = DDS_RETCODE_ILLEGAL_OPERATION;
-  else if ((ret = e->m_deriver.validate_status (mask)) == DDS_RETCODE_OK)
+  if ((ret = dds_entity_deriver_validate_status (e, mask)) == DDS_RETCODE_OK)
   {
+    assert (entity_has_status (e));
     ddsrt_mutex_lock (&e->m_observers_lock);
     while (e->m_cb_count > 0)
       ddsrt_cond_wait (&e->m_observers_cond, &e->m_observers_lock);
 
     /* Don't block internal status triggers. */
-    mask |= DDS_INTERNAL_STATUS_MASK;
-    e->m_status_enable = mask;
-    e->m_trigger &= mask;
+    uint32_t old, new;
+    do {
+      old = ddsrt_atomic_ld32 (&e->m_status.m_status_and_mask);
+      new = (mask << SAM_ENABLED_SHIFT) | (old & mask);
+    } while (!ddsrt_atomic_cas32 (&e->m_status.m_status_and_mask, old, new));
     ddsrt_mutex_unlock (&e->m_observers_lock);
   }
-  dds_entity_release (e);
+  dds_entity_unpin (e);
   return ret;
 }
 
 dds_return_t dds_set_enabled_status(dds_entity_t entity, uint32_t mask)
 {
-  return dds_set_status_mask( entity, mask);
+  return dds_set_status_mask (entity, mask);
 }
 
 static dds_return_t dds_readtake_status (dds_entity_t entity, uint32_t *status, uint32_t mask, bool reset)
@@ -836,19 +929,21 @@ static dds_return_t dds_readtake_status (dds_entity_t entity, uint32_t *status, 
 
   if (status == NULL)
     return DDS_RETCODE_BAD_PARAMETER;
+  if ((mask & ~SAM_STATUS_MASK) != 0)
+    return DDS_RETCODE_BAD_PARAMETER;
 
   if ((ret = dds_entity_lock (entity, DDS_KIND_DONTCARE, &e)) != DDS_RETCODE_OK)
     return ret;
 
-  if (e->m_deriver.validate_status == 0)
-    ret = DDS_RETCODE_ILLEGAL_OPERATION;
-  else if ((ret = e->m_deriver.validate_status (mask)) == DDS_RETCODE_OK)
+  if ((ret = dds_entity_deriver_validate_status (e, mask)) == DDS_RETCODE_OK)
   {
-    ddsrt_mutex_lock (&e->m_observers_lock);
-    *status = e->m_trigger & mask;
+    uint32_t s;
+    assert (entity_has_status (e));
     if (reset)
-      e->m_trigger &= ~mask;
-    ddsrt_mutex_unlock (&e->m_observers_lock);
+      s = ddsrt_atomic_and32_ov (&e->m_status.m_status_and_mask, ~mask) & mask;
+    else
+      s = ddsrt_atomic_ld32 (&e->m_status.m_status_and_mask) & mask;
+    *status = s;
   }
   dds_entity_unlock (e);
   return ret;
@@ -876,7 +971,7 @@ dds_return_t dds_get_domainid (dds_entity_t entity, dds_domainid_t *id)
   if ((rc = dds_entity_lock (entity, DDS_KIND_DONTCARE, &e)) != DDS_RETCODE_OK)
     return rc;
 
-  *id = e->m_domainid;
+  *id = e->m_domain->m_id;
   dds_entity_unlock(e);
   return DDS_RETCODE_OK;
 }
@@ -889,18 +984,18 @@ dds_return_t dds_get_instance_handle (dds_entity_t entity, dds_instance_handle_t
   if (ihdl == NULL)
     return DDS_RETCODE_BAD_PARAMETER;
 
-  if ((ret = dds_entity_claim (entity, &e)) != DDS_RETCODE_OK)
+  if ((ret = dds_entity_pin (entity, &e)) != DDS_RETCODE_OK)
     return ret;
   *ihdl = e->m_iid;
-  dds_entity_release(e);
+  dds_entity_unpin(e);
   return ret;
 }
 
-dds_return_t dds_entity_claim (dds_entity_t hdl, dds_entity **eptr)
+dds_return_t dds_entity_pin (dds_entity_t hdl, dds_entity **eptr)
 {
   dds_return_t hres;
   struct dds_handle_link *hdllink;
-  if ((hres = dds_handle_claim (hdl, &hdllink)) != DDS_RETCODE_OK)
+  if ((hres = dds_handle_pin (hdl, &hdllink)) < 0)
     return hres;
   else
   {
@@ -909,41 +1004,26 @@ dds_return_t dds_entity_claim (dds_entity_t hdl, dds_entity **eptr)
   }
 }
 
-void dds_entity_release (dds_entity *e)
+void dds_entity_unpin (dds_entity *e)
 {
-  dds_handle_release (&e->m_hdllink);
+  dds_handle_unpin (&e->m_hdllink);
 }
 
 dds_return_t dds_entity_lock (dds_entity_t hdl, dds_entity_kind_t kind, dds_entity **eptr)
 {
   dds_return_t hres;
   dds_entity *e;
-
-  /* When the given handle already contains an error, then return that
-   * same error to retain the original information. */
-  if ((hres = dds_entity_claim (hdl, &e)) != DDS_RETCODE_OK)
+  if ((hres = dds_entity_pin (hdl, &e)) < 0)
     return hres;
   else
   {
     if (dds_entity_kind (e) != kind && kind != DDS_KIND_DONTCARE)
     {
-      dds_handle_release (&e->m_hdllink);
+      dds_entity_unpin (e);
       return DDS_RETCODE_ILLEGAL_OPERATION;
     }
 
     ddsrt_mutex_lock (&e->m_mutex);
-    /* FIXME: The handle could have been closed while we were waiting for the mutex -- that should be handled differently!
-
-       For now, however, it is really important at two points in the logic:
-         (1) preventing creating new entities as children of a one that is currently being deleted, and
-         (2) preventing dds_delete_impl from doing anything once the entity is being deleted.
-
-       Without (1), it would be possible to add children while trying to delete them, without (2) you're looking at crashes. */
-    if (dds_handle_is_closed (&e->m_hdllink))
-    {
-      dds_entity_unlock (e);
-      return DDS_RETCODE_BAD_PARAMETER;
-    }
     *eptr = e;
     return DDS_RETCODE_OK;
   }
@@ -952,7 +1032,7 @@ dds_return_t dds_entity_lock (dds_entity_t hdl, dds_entity_kind_t kind, dds_enti
 void dds_entity_unlock (dds_entity *e)
 {
   ddsrt_mutex_unlock (&e->m_mutex);
-  dds_handle_release (&e->m_hdllink);
+  dds_handle_unpin (&e->m_hdllink);
 }
 
 dds_return_t dds_triggered (dds_entity_t entity)
@@ -960,16 +1040,17 @@ dds_return_t dds_triggered (dds_entity_t entity)
   dds_entity *e;
   dds_return_t ret;
 
-  if ((ret = dds_entity_lock(entity, DDS_KIND_DONTCARE, &e)) != DDS_RETCODE_OK)
+  if ((ret = dds_entity_lock (entity, DDS_KIND_DONTCARE, &e)) != DDS_RETCODE_OK)
     return ret;
-  ddsrt_mutex_lock (&e->m_observers_lock);
-  ret = (e->m_trigger != 0);
-  ddsrt_mutex_unlock (&e->m_observers_lock);
+  if (entity_has_status (e))
+    ret = ((ddsrt_atomic_ld32 (&e->m_status.m_status_and_mask) & SAM_STATUS_MASK) != 0);
+  else
+    ret = (ddsrt_atomic_ld32 (&e->m_status.m_trigger) != 0);
   dds_entity_unlock (e);
   return ret;
 }
 
-static bool in_observer_list_p (const struct dds_entity *observed, const dds_entity_t observer)
+static bool in_observer_list_p (const struct dds_entity *observed, const dds_entity *observer)
 {
   dds_entity_observer *cur;
   for (cur = observed->m_observers; cur != NULL; cur = cur->m_next)
@@ -978,7 +1059,7 @@ static bool in_observer_list_p (const struct dds_entity *observed, const dds_ent
   return false;
 }
 
-dds_return_t dds_entity_observer_register_nl (dds_entity *observed, dds_entity_t observer, dds_entity_callback cb)
+dds_return_t dds_entity_observer_register (dds_entity *observed, dds_entity *observer, dds_entity_callback cb, dds_entity_delete_callback delete_cb)
 {
   dds_return_t rc;
   assert (observed);
@@ -989,6 +1070,7 @@ dds_return_t dds_entity_observer_register_nl (dds_entity *observed, dds_entity_t
   {
     dds_entity_observer *o = ddsrt_malloc (sizeof (dds_entity_observer));
     o->m_cb = cb;
+    o->m_delete_cb = delete_cb;
     o->m_observer = observer;
     o->m_next = observed->m_observers;
     observed->m_observers = o;
@@ -998,19 +1080,7 @@ dds_return_t dds_entity_observer_register_nl (dds_entity *observed, dds_entity_t
   return rc;
 }
 
-dds_return_t dds_entity_observer_register (dds_entity_t observed, dds_entity_t observer, dds_entity_callback cb)
-{
-  dds_return_t rc;
-  dds_entity *e;
-  assert (cb);
-  if ((rc = dds_entity_lock (observed, DDS_KIND_DONTCARE, &e)) != DDS_RETCODE_OK)
-    return rc;
-  rc = dds_entity_observer_register_nl (e, observer, cb);
-  dds_entity_unlock (e);
-  return rc;
-}
-
-dds_return_t dds_entity_observer_unregister_nl (dds_entity *observed, dds_entity_t observer)
+dds_return_t dds_entity_observer_unregister (dds_entity *observed, dds_entity *observer)
 {
   dds_return_t rc;
   dds_entity_observer *prev, *idx;
@@ -1038,17 +1108,6 @@ dds_return_t dds_entity_observer_unregister_nl (dds_entity *observed, dds_entity
   return rc;
 }
 
-dds_return_t dds_entity_observer_unregister (dds_entity_t observed, dds_entity_t observer)
-{
-  dds_return_t rc;
-  dds_entity *e;
-  if ((rc = dds_entity_lock (observed, DDS_KIND_DONTCARE, &e)) != DDS_RETCODE_OK)
-    return rc;
-  rc = dds_entity_observer_unregister_nl (e, observer);
-  dds_entity_unlock (e);
-  return rc;
-}
-
 static void dds_entity_observers_delete (dds_entity *observed)
 {
   dds_entity_observer *idx;
@@ -1070,20 +1129,43 @@ static void dds_entity_observers_signal (dds_entity *observed, uint32_t status)
     idx->m_cb (idx->m_observer, observed->m_hdllink.hdl, status);
 }
 
-void dds_entity_status_signal (dds_entity *e)
+static void dds_entity_observers_signal_delete (dds_entity *observed)
+{
+  for (dds_entity_observer *idx = observed->m_observers; idx; idx = idx->m_next)
+    idx->m_delete_cb (idx->m_observer, observed->m_hdllink.hdl);
+}
+
+void dds_entity_status_signal (dds_entity *e, uint32_t status)
 {
   ddsrt_mutex_lock (&e->m_observers_lock);
-  dds_entity_observers_signal (e, e->m_trigger);
+  dds_entity_observers_signal (e, status);
   ddsrt_mutex_unlock (&e->m_observers_lock);
 }
 
-void dds_entity_status_set (dds_entity *e, uint32_t t)
+void dds_entity_status_set (dds_entity *e, status_mask_t status)
 {
-  if (!(e->m_trigger & t))
-  {
-    e->m_trigger |= e->m_status_enable & t;
-    dds_entity_observers_signal (e, e->m_trigger);
-  }
+  assert (entity_has_status (e));
+  uint32_t old, delta, new;
+  do {
+    old = ddsrt_atomic_ld32 (&e->m_status.m_status_and_mask);
+    delta = ((uint32_t) status & (old >> SAM_ENABLED_SHIFT));
+    if (delta == 0)
+      return;
+    new = old | delta;
+  } while (!ddsrt_atomic_cas32 (&e->m_status.m_status_and_mask, old, new));
+  if (delta)
+    dds_entity_observers_signal (e, status);
+}
+
+void dds_entity_trigger_set (dds_entity *e, uint32_t t)
+{
+  assert (! entity_has_status (e));
+  uint32_t oldst;
+  do {
+    oldst = ddsrt_atomic_ld32 (&e->m_status.m_trigger);
+  } while (!ddsrt_atomic_cas32 (&e->m_status.m_trigger, oldst, t));
+  if (oldst == 0 && t != 0)
+    dds_entity_observers_signal (e, t);
 }
 
 dds_entity_t dds_get_topic (dds_entity_t entity)
@@ -1126,7 +1208,7 @@ dds_return_t dds_generic_unimplemented_operation_manykinds (dds_entity_t handle,
 {
   dds_entity *e;
   dds_return_t ret;
-  if ((ret = dds_entity_claim (handle, &e)) != DDS_RETCODE_OK)
+  if ((ret = dds_entity_pin (handle, &e)) != DDS_RETCODE_OK)
     return ret;
   else
   {
@@ -1141,7 +1223,7 @@ dds_return_t dds_generic_unimplemented_operation_manykinds (dds_entity_t handle,
         break;
       }
     }
-    dds_entity_release (e);
+    dds_entity_unpin (e);
     return ret;
   }
 }

--- a/src/core/ddsc/src/dds_entity.c
+++ b/src/core/ddsc/src/dds_entity.c
@@ -889,14 +889,10 @@ dds_return_t dds_get_instance_handle (dds_entity_t entity, dds_instance_handle_t
   if (ihdl == NULL)
     return DDS_RETCODE_BAD_PARAMETER;
 
-  if ((ret = dds_entity_lock (entity, DDS_KIND_DONTCARE, &e)) != DDS_RETCODE_OK)
+  if ((ret = dds_entity_claim (entity, &e)) != DDS_RETCODE_OK)
     return ret;
-
-  if (e->m_deriver.get_instance_hdl)
-    ret = e->m_deriver.get_instance_hdl (e, ihdl);
-  else
-    ret = DDS_RETCODE_ILLEGAL_OPERATION;
-  dds_entity_unlock(e);
+  *ihdl = e->m_iid;
+  dds_entity_release(e);
   return ret;
 }
 

--- a/src/core/ddsc/src/dds_guardcond.c
+++ b/src/core/ddsc/src/dds_guardcond.c
@@ -14,6 +14,7 @@
 #include "dds__reader.h"
 #include "dds__guardcond.h"
 #include "dds__participant.h"
+#include "dds/ddsi/ddsi_iid.h"
 #include "dds/ddsi/q_ephash.h"
 #include "dds/ddsi/q_entity.h"
 #include "dds/ddsi/q_thread.h"
@@ -29,8 +30,9 @@ dds_entity_t dds_create_guardcondition (dds_entity_t participant)
     return rc;
   else
   {
-    dds_guardcond * gcond = dds_alloc (sizeof (*gcond));
+    dds_guardcond *gcond = dds_alloc (sizeof (*gcond));
     dds_entity_t hdl = dds_entity_init (&gcond->m_entity, &pp->m_entity, DDS_KIND_COND_GUARD, NULL, NULL, 0);
+    gcond->m_entity.m_iid = ddsi_iid_gen ();
     dds_participant_unlock (pp);
     return hdl;
   }

--- a/src/core/ddsc/src/dds_handles.c
+++ b/src/core/ddsc/src/dds_handles.c
@@ -28,7 +28,19 @@
 #define USE_CHH 0
 
 #define HDL_FLAG_CLOSED    (0x80000000u)
-#define HDL_COUNT_MASK     (0x00ffffffu)
+
+/* ref count: # outstanding references to this handle/object (not so sure it is
+   ideal to have a one-to-one mapping between the two, but that is what the rest
+   of the code assumes at the moment); so this limits one to having, e.g., no
+   more than 64k endpoints referencing the same topic */
+#define HDL_REFCOUNT_MASK  (0x0ffff000u)
+#define HDL_REFCOUNT_UNIT  (0x00001000u)
+#define HDL_REFCOUNT_SHIFT 12
+
+/* pin count: # concurrent operations, so allowing up to 4096 threads had better
+   be enough ... */
+#define HDL_PINCOUNT_MASK  (0x00000fffu)
+#define HDL_PINCOUNT_UNIT  (0x00000001u)
 
 /* Maximum number of handles is INT32_MAX - 1, but as the allocator relies on a
    random generator for finding a free one, the time spent in the dds_handle_create
@@ -105,7 +117,7 @@ static bool hhadd (struct ddsrt_hh *ht, void *elem) { return ddsrt_hh_add (ht, e
 #endif
 static dds_handle_t dds_handle_create_int (struct dds_handle_link *link)
 {
-  ddsrt_atomic_st32 (&link->cnt_flags, 0);
+  ddsrt_atomic_st32 (&link->cnt_flags, HDL_REFCOUNT_UNIT);
   do {
     do {
       link->hdl = (int32_t) (ddsrt_random () & INT32_MAX);
@@ -159,11 +171,12 @@ int32_t dds_handle_delete (struct dds_handle_link *link, dds_duration_t timeout)
 #endif
   assert (ddsrt_atomic_ld32 (&link->cnt_flags) & HDL_FLAG_CLOSED);
   ddsrt_mutex_lock (&handles.lock);
-  if ((ddsrt_atomic_ld32 (&link->cnt_flags) & HDL_COUNT_MASK) != 0)
+  if ((ddsrt_atomic_ld32 (&link->cnt_flags) & HDL_PINCOUNT_MASK) != 0)
   {
-    /* FIXME: */
+    /* FIXME: there is no sensible solution when this times out, so it must
+       never do that ... */
     const dds_time_t abstimeout = dds_time () + timeout;
-    while ((ddsrt_atomic_ld32 (&link->cnt_flags) & HDL_COUNT_MASK) != 0)
+    while ((ddsrt_atomic_ld32 (&link->cnt_flags) & HDL_PINCOUNT_MASK) != 0)
     {
       if (!ddsrt_cond_waituntil (&handles.cond, &handles.lock, abstimeout))
       {
@@ -188,7 +201,7 @@ int32_t dds_handle_delete (struct dds_handle_link *link, dds_duration_t timeout)
   return DDS_RETCODE_OK;
 }
 
-int32_t dds_handle_claim (dds_handle_t hdl, struct dds_handle_link **link)
+int32_t dds_handle_pin (dds_handle_t hdl, struct dds_handle_link **link)
 {
 #if USE_CHH
   struct thread_state1 * const ts1 = lookup_thread_state ();
@@ -196,7 +209,7 @@ int32_t dds_handle_claim (dds_handle_t hdl, struct dds_handle_link **link)
   struct dds_handle_link dummy = { .hdl = hdl };
   int32_t rc;
   /* it makes sense to check here for initialization: the first thing any operation
-     (other than create_participant) does is to call dds_handle_claim on the supplied
+     (other than create_participant) does is to call dds_handle_pin on the supplied
      entity, so checking here whether the library has been initialised helps avoid
      crashes if someone forgets to create a participant (or allows a program to
      continue after failing to create one).
@@ -228,7 +241,7 @@ int32_t dds_handle_claim (dds_handle_t hdl, struct dds_handle_link **link)
         rc = DDS_RETCODE_BAD_PARAMETER;
         break;
       }
-    } while (!ddsrt_atomic_cas32 (&(*link)->cnt_flags, cnt_flags, cnt_flags + 1));
+    } while (!ddsrt_atomic_cas32 (&(*link)->cnt_flags, cnt_flags, cnt_flags + HDL_PINCOUNT_UNIT));
   }
 #if USE_CHH
   thread_state_asleep (ts1);
@@ -238,21 +251,42 @@ int32_t dds_handle_claim (dds_handle_t hdl, struct dds_handle_link **link)
   return rc;
 }
 
-void dds_handle_claim_inc (struct dds_handle_link *link)
+void dds_handle_repin (struct dds_handle_link *link)
 {
+  DDSRT_STATIC_ASSERT (HDL_PINCOUNT_UNIT == 1);
   uint32_t x = ddsrt_atomic_inc32_nv (&link->cnt_flags);
   assert (!(x & HDL_FLAG_CLOSED));
   (void) x;
 }
 
-void dds_handle_release (struct dds_handle_link *link)
+void dds_handle_unpin (struct dds_handle_link *link)
 {
-  if (ddsrt_atomic_dec32_ov (&link->cnt_flags) == (HDL_FLAG_CLOSED | 1))
+  DDSRT_STATIC_ASSERT (HDL_PINCOUNT_UNIT == 1);
+  if ((ddsrt_atomic_dec32_ov (&link->cnt_flags) & (HDL_FLAG_CLOSED | HDL_PINCOUNT_MASK)) == (HDL_FLAG_CLOSED | HDL_PINCOUNT_UNIT))
   {
     ddsrt_mutex_lock (&handles.lock);
     ddsrt_cond_broadcast (&handles.cond);
     ddsrt_mutex_unlock (&handles.lock);
   }
+}
+
+void dds_handle_add_ref (struct dds_handle_link *link)
+{
+  ddsrt_atomic_add32 (&link->cnt_flags, HDL_REFCOUNT_UNIT);
+}
+
+bool dds_handle_drop_ref (struct dds_handle_link *link)
+{
+  assert ((ddsrt_atomic_ld32 (&link->cnt_flags) & HDL_REFCOUNT_MASK) != 0);
+  uint32_t old, new;
+  do {
+    old = ddsrt_atomic_ld32 (&link->cnt_flags);
+    if ((old & HDL_REFCOUNT_MASK) != HDL_REFCOUNT_UNIT)
+      new = old - HDL_REFCOUNT_UNIT;
+    else
+      new = (old - HDL_REFCOUNT_UNIT) | HDL_FLAG_CLOSED;
+  } while (!ddsrt_atomic_cas32 (&link->cnt_flags, old, new));
+  return (new & HDL_REFCOUNT_MASK) == 0;
 }
 
 bool dds_handle_is_closed (struct dds_handle_link *link)

--- a/src/core/ddsc/src/dds_instance.c
+++ b/src/core/ddsc/src/dds_instance.c
@@ -238,6 +238,9 @@ dds_return_t dds_dispose_ts (dds_entity_t writer, const void *data, dds_time_t t
   dds_return_t ret;
   dds_writer *wr;
 
+  if (data == NULL)
+    return DDS_RETCODE_BAD_PARAMETER;
+
   if ((ret = dds_writer_lock (writer, &wr)) != DDS_RETCODE_OK)
     return ret;
 

--- a/src/core/ddsc/src/dds_participant.c
+++ b/src/core/ddsc/src/dds_participant.c
@@ -64,14 +64,6 @@ static dds_return_t dds_participant_delete (dds_entity *e)
   return DDS_RETCODE_OK;
 }
 
-static dds_return_t dds_participant_instance_hdl (dds_entity *e, dds_instance_handle_t *i) ddsrt_nonnull_all;
-
-static dds_return_t dds_participant_instance_hdl (dds_entity *e, dds_instance_handle_t *i)
-{
-  *i = participant_instance_id (&e->m_guid);
-  return DDS_RETCODE_OK;
-}
-
 static dds_return_t dds_participant_qos_set (dds_entity *e, const dds_qos_t *qos, bool enabled)
 {
   /* note: e->m_qos is still the old one to allow for failure here */
@@ -134,11 +126,11 @@ dds_entity_t dds_create_participant (const dds_domainid_t domain, const dds_qos_
     goto err_entity_init;
 
   pp->m_entity.m_guid = guid;
+  pp->m_entity.m_iid = get_entity_instance_id (&guid);
   pp->m_entity.m_domain = dds_domain_create (dds_domain_default ());
   pp->m_entity.m_domainid = dds_domain_default ();
   pp->m_entity.m_deriver.delete = dds_participant_delete;
   pp->m_entity.m_deriver.set_qos = dds_participant_qos_set;
-  pp->m_entity.m_deriver.get_instance_hdl = dds_participant_instance_hdl;
   pp->m_entity.m_deriver.validate_status = dds_participant_status_validate;
   pp->m_builtin_subscriber = 0;
 

--- a/src/core/ddsc/src/dds_participant.c
+++ b/src/core/ddsc/src/dds_participant.c
@@ -84,6 +84,13 @@ static dds_return_t dds_participant_qos_set (dds_entity *e, const dds_qos_t *qos
   return DDS_RETCODE_OK;
 }
 
+const struct dds_entity_deriver dds_entity_deriver_participant = {
+  .close = dds_entity_deriver_dummy_close,
+  .delete = dds_participant_delete,
+  .set_qos = dds_participant_qos_set,
+  .validate_status = dds_participant_status_validate
+};
+
 dds_entity_t dds_create_participant (const dds_domainid_t domain, const dds_qos_t *qos, const dds_listener_t *listener)
 {
   dds_entity_t ret;
@@ -128,10 +135,6 @@ dds_entity_t dds_create_participant (const dds_domainid_t domain, const dds_qos_
   pp->m_entity.m_guid = guid;
   pp->m_entity.m_iid = get_entity_instance_id (&guid);
   pp->m_entity.m_domain = dds_domain_create (dds_domain_default ());
-  pp->m_entity.m_domainid = dds_domain_default ();
-  pp->m_entity.m_deriver.delete = dds_participant_delete;
-  pp->m_entity.m_deriver.set_qos = dds_participant_qos_set;
-  pp->m_entity.m_deriver.validate_status = dds_participant_status_validate;
   pp->m_builtin_subscriber = 0;
 
   /* Add participant to extent */
@@ -175,7 +178,7 @@ dds_entity_t dds_lookup_participant (dds_domainid_t domain_id, dds_entity_t *par
     ddsrt_mutex_lock (&dds_global.m_mutex);
     for (dds_entity *iter = dds_pp_head; iter; iter = iter->m_next)
     {
-      if (iter->m_domainid == domain_id)
+      if (iter->m_domain->m_id == domain_id)
       {
         if ((size_t) ret < size)
           participants[ret] = iter->m_hdllink.hdl;

--- a/src/core/ddsc/src/dds_publisher.c
+++ b/src/core/ddsc/src/dds_publisher.c
@@ -36,6 +36,13 @@ static dds_return_t dds_publisher_status_validate (uint32_t mask)
   return (mask & ~DDS_PUBLISHER_STATUS_MASK) ? DDS_RETCODE_BAD_PARAMETER : DDS_RETCODE_OK;
 }
 
+const struct dds_entity_deriver dds_entity_deriver_publisher = {
+  .close = dds_entity_deriver_dummy_close,
+  .delete = dds_entity_deriver_dummy_delete,
+  .set_qos = dds_publisher_qos_set,
+  .validate_status = dds_publisher_status_validate
+};
+
 dds_entity_t dds_create_publisher (dds_entity_t participant, const dds_qos_t *qos, const dds_listener_t *listener)
 {
   dds_participant *par;
@@ -62,8 +69,7 @@ dds_entity_t dds_create_publisher (dds_entity_t participant, const dds_qos_t *qo
   pub = dds_alloc (sizeof (*pub));
   hdl = dds_entity_init (&pub->m_entity, &par->m_entity, DDS_KIND_PUBLISHER, new_qos, listener, DDS_PUBLISHER_STATUS_MASK);
   pub->m_entity.m_iid = ddsi_iid_gen ();
-  pub->m_entity.m_deriver.set_qos = dds_publisher_qos_set;
-  pub->m_entity.m_deriver.validate_status = dds_publisher_status_validate;
+  dds_entity_register_child (&par->m_entity, &pub->m_entity);
   dds_participant_unlock (par);
   return hdl;
 }

--- a/src/core/ddsc/src/dds_publisher.c
+++ b/src/core/ddsc/src/dds_publisher.c
@@ -24,15 +24,6 @@ DECL_ENTITY_LOCK_UNLOCK (extern inline, dds_publisher)
 
 #define DDS_PUBLISHER_STATUS_MASK   (0u)
 
-static dds_return_t dds_publisher_instance_hdl (dds_entity *e, dds_instance_handle_t *i) ddsrt_nonnull_all;
-
-static dds_return_t dds_publisher_instance_hdl (dds_entity *e, dds_instance_handle_t *i)
-{
-  /* FIXME: Get/generate proper handle. */
-  (void) e; (void) i;
-  return DDS_RETCODE_UNSUPPORTED;
-}
-
 static dds_return_t dds_publisher_qos_set (dds_entity *e, const dds_qos_t *qos, bool enabled)
 {
   /* note: e->m_qos is still the old one to allow for failure here */
@@ -70,8 +61,8 @@ dds_entity_t dds_create_publisher (dds_entity_t participant, const dds_qos_t *qo
   }
   pub = dds_alloc (sizeof (*pub));
   hdl = dds_entity_init (&pub->m_entity, &par->m_entity, DDS_KIND_PUBLISHER, new_qos, listener, DDS_PUBLISHER_STATUS_MASK);
+  pub->m_entity.m_iid = ddsi_iid_gen ();
   pub->m_entity.m_deriver.set_qos = dds_publisher_qos_set;
-  pub->m_entity.m_deriver.get_instance_hdl = dds_publisher_instance_hdl;
   pub->m_entity.m_deriver.validate_status = dds_publisher_status_validate;
   dds_participant_unlock (par);
   return hdl;

--- a/src/core/ddsc/src/dds_qos.c
+++ b/src/core/ddsc/src/dds_qos.c
@@ -22,7 +22,7 @@ static void dds_qos_data_copy_in (ddsi_octetseq_t *data, const void * __restrict
   if (overwrite && data->value)
     ddsrt_free (data->value);
   data->length = (uint32_t) sz;
-  data->value = ddsrt_memdup (value, sz);
+  data->value = value ? ddsrt_memdup (value, sz) : NULL;
 }
 
 static bool dds_qos_data_copy_out (const ddsi_octetseq_t *data, void **value, size_t *sz)

--- a/src/core/ddsc/src/dds_querycond.c
+++ b/src/core/ddsc/src/dds_querycond.c
@@ -33,15 +33,8 @@ dds_entity_t dds_create_querycondition (dds_entity_t reader, uint32_t mask, dds_
     dds_entity_t hdl;
     dds_readcond *cond = dds_create_readcond (r, DDS_KIND_COND_QUERY, mask, filter);
     assert (cond);
-    const bool success = (cond->m_entity.m_deriver.delete != 0);
     dds_reader_unlock (r);
-    if (success)
-      hdl = cond->m_entity.m_hdllink.hdl;
-    else
-    {
-      dds_delete (cond->m_entity.m_hdllink.hdl);
-      hdl = DDS_RETCODE_OUT_OF_RESOURCES;
-    }
+    hdl = cond->m_entity.m_hdllink.hdl;
     return hdl;
   }
 }

--- a/src/core/ddsc/src/dds_read.c
+++ b/src/core/ddsc/src/dds_read.c
@@ -134,12 +134,11 @@ static dds_return_t dds_read_impl (bool take, dds_entity_t reader_or_condition, 
 
   /* read/take resets data available status -- must reset before reading because
      the actual writing is protected by RHC lock, not by rd->m_entity.m_lock */
-  ddsrt_mutex_lock (&rd->m_entity.m_observers_lock);
   dds_entity_status_reset (&rd->m_entity, DDS_DATA_AVAILABLE_STATUS);
+
   /* reset DATA_ON_READERS status on subscriber after successful read/take */
-  if (dds_entity_kind (rd->m_entity.m_parent) == DDS_KIND_SUBSCRIBER)
-    dds_entity_status_reset (rd->m_entity.m_parent, DDS_DATA_ON_READERS_STATUS);
-  ddsrt_mutex_unlock (&rd->m_entity.m_observers_lock);
+  assert (dds_entity_kind (rd->m_entity.m_parent) == DDS_KIND_SUBSCRIBER);
+  dds_entity_status_reset (rd->m_entity.m_parent, DDS_DATA_ON_READERS_STATUS);
 
   if (take)
     ret = dds_rhc_take (rd->m_rd->rhc, lock, buf, si, maxs, mask, hand, cond);
@@ -158,7 +157,7 @@ static dds_return_t dds_read_impl (bool take, dds_entity_t reader_or_condition, 
     if (nodata_cleanups & NC_RESET_BUF)
       buf[0] = NULL;
   }
-  dds_read_unlock(rd, cond);
+  dds_read_unlock (rd, cond);
   thread_state_asleep (ts1);
   return ret;
 
@@ -191,13 +190,12 @@ static dds_return_t dds_readcdr_impl (bool take, dds_entity_t reader_or_conditio
   if ((ret = dds_read_lock (reader_or_condition, &rd, &cond, false)) == DDS_RETCODE_OK)
   {
     /* read/take resets data available status -- must reset before reading because
-       the actual writing is protected by RHC lock, not by rd->m_entity.m_lock */
-    ddsrt_mutex_lock (&rd->m_entity.m_observers_lock);
+     the actual writing is protected by RHC lock, not by rd->m_entity.m_lock */
     dds_entity_status_reset (&rd->m_entity, DDS_DATA_AVAILABLE_STATUS);
+
     /* reset DATA_ON_READERS status on subscriber after successful read/take */
-    if (dds_entity_kind (rd->m_entity.m_parent) == DDS_KIND_SUBSCRIBER)
-      dds_entity_status_reset (rd->m_entity.m_parent, DDS_DATA_ON_READERS_STATUS);
-    ddsrt_mutex_unlock (&rd->m_entity.m_observers_lock);
+    assert (dds_entity_kind (rd->m_entity.m_parent) == DDS_KIND_SUBSCRIBER);
+    dds_entity_status_reset (rd->m_entity.m_parent, DDS_DATA_ON_READERS_STATUS);
 
     ret = dds_rhc_takecdr (rd->m_rd->rhc, lock, buf, si, maxs, mask & DDS_ANY_SAMPLE_STATE, mask & DDS_ANY_VIEW_STATE, mask & DDS_ANY_INSTANCE_STATE, hand);
     dds_read_unlock (rd, cond);

--- a/src/core/ddsc/src/dds_readcond.c
+++ b/src/core/ddsc/src/dds_readcond.c
@@ -14,6 +14,7 @@
 #include "dds__readcond.h"
 #include "dds__rhc.h"
 #include "dds__entity.h"
+#include "dds/ddsi/ddsi_iid.h"
 #include "dds/ddsi/q_ephash.h"
 #include "dds/ddsi/q_entity.h"
 #include "dds/ddsi/q_thread.h"
@@ -31,6 +32,7 @@ dds_readcond *dds_create_readcond (dds_reader *rd, dds_entity_kind_t kind, uint3
   dds_readcond *cond = dds_alloc (sizeof (*cond));
   assert ((kind == DDS_KIND_COND_READ && filter == 0) || (kind == DDS_KIND_COND_QUERY && filter != 0));
   (void) dds_entity_init (&cond->m_entity, &rd->m_entity, kind, NULL, NULL, 0);
+  cond->m_entity.m_iid = ddsi_iid_gen ();
   cond->m_entity.m_deriver.delete = dds_readcond_delete;
   cond->m_rhc = rd->m_rd->rhc;
   cond->m_sample_states = mask & DDS_ANY_SAMPLE_STATE;

--- a/src/core/ddsc/src/dds_reader.c
+++ b/src/core/ddsc/src/dds_reader.c
@@ -39,14 +39,6 @@ DECL_ENTITY_LOCK_UNLOCK (extern inline, dds_reader)
                          DDS_SAMPLE_LOST_STATUS                  |\
                          DDS_SUBSCRIPTION_MATCHED_STATUS)
 
-static dds_return_t dds_reader_instance_hdl (dds_entity *e, dds_instance_handle_t *i) ddsrt_nonnull_all;
-
-static dds_return_t dds_reader_instance_hdl (dds_entity *e, dds_instance_handle_t *i)
-{
-  *i = reader_instance_id (&e->m_guid);
-  return DDS_RETCODE_OK;
-}
-
 static dds_return_t dds_reader_close (dds_entity *e) ddsrt_nonnull_all;
 
 static dds_return_t dds_reader_close (dds_entity *e)
@@ -392,7 +384,6 @@ dds_entity_t dds_create_reader (dds_entity_t participant_or_subscriber, dds_enti
   rd->m_entity.m_deriver.delete = dds_reader_delete;
   rd->m_entity.m_deriver.set_qos = dds_reader_qos_set;
   rd->m_entity.m_deriver.validate_status = dds_reader_status_validate;
-  rd->m_entity.m_deriver.get_instance_hdl = dds_reader_instance_hdl;
 
   /* Extra claim of this reader to make sure that the delete waits until DDSI
      has deleted its reader as well. This can be known through the callback. */
@@ -407,6 +398,7 @@ dds_entity_t dds_create_reader (dds_entity_t participant_or_subscriber, dds_enti
   ddsrt_mutex_lock (&tp->m_entity.m_mutex);
   assert (ret == DDS_RETCODE_OK); /* FIXME: can be out-of-resources at the very least */
   thread_state_asleep (lookup_thread_state ());
+  rd->m_entity.m_iid = get_entity_instance_id (&rd->m_entity.m_guid);
 
   /* For persistent data register reader with durability */
   if (dds_global.m_dur_reader && (rd->m_entity.m_qos->durability.kind > DDS_DURABILITY_TRANSIENT_LOCAL)) {

--- a/src/core/ddsc/src/dds_rhc.c
+++ b/src/core/ddsc/src/dds_rhc.c
@@ -192,30 +192,33 @@ static int lwreg_equals (const void *va, const void *vb)
 
 static void lwregs_init (struct lwregs *rt)
 {
-  rt->regs = ddsrt_ehh_new (sizeof (struct lwreg), 1, lwreg_hash, lwreg_equals);
+  rt->regs = NULL;
 }
 
 static void lwregs_fini (struct lwregs *rt)
 {
-  ddsrt_ehh_free (rt->regs);
+  if (rt->regs)
+    ddsrt_ehh_free (rt->regs);
 }
 
 static int lwregs_contains (struct lwregs *rt, uint64_t iid, uint64_t wr_iid)
 {
   struct lwreg dummy = { .iid = iid, .wr_iid = wr_iid };
-  return ddsrt_ehh_lookup (rt->regs, &dummy) != NULL;
+  return rt->regs != NULL && ddsrt_ehh_lookup (rt->regs, &dummy) != NULL;
 }
 
 static int lwregs_add (struct lwregs *rt, uint64_t iid, uint64_t wr_iid)
 {
   struct lwreg dummy = { .iid = iid, .wr_iid = wr_iid };
+  if (rt->regs == NULL)
+    rt->regs = ddsrt_ehh_new (sizeof (struct lwreg), 1, lwreg_hash, lwreg_equals);
   return ddsrt_ehh_add (rt->regs, &dummy);
 }
 
 static int lwregs_delete (struct lwregs *rt, uint64_t iid, uint64_t wr_iid)
 {
   struct lwreg dummy = { .iid = iid, .wr_iid = wr_iid };
-  return ddsrt_ehh_remove (rt->regs, &dummy);
+  return rt->regs != NULL && ddsrt_ehh_remove (rt->regs, &dummy);
 }
 
 #if 0

--- a/src/core/ddsc/src/dds_sertopic_builtintopic.c
+++ b/src/core/ddsc/src/dds_sertopic_builtintopic.c
@@ -38,8 +38,6 @@ struct ddsi_sertopic *new_sertopic_builtintopic (enum ddsi_sertopic_builtintopic
   tp->c.ops = &ddsi_sertopic_ops_builtintopic;
   tp->c.serdata_ops = &ddsi_serdata_ops_builtintopic;
   tp->c.serdata_basehash = ddsi_sertopic_compute_serdata_basehash (tp->c.serdata_ops);
-  tp->c.status_cb = 0;
-  tp->c.status_cb_entity = NULL;
   ddsrt_atomic_st32 (&tp->c.refc, 1);
   tp->type = type;
   return &tp->c;

--- a/src/core/ddsc/src/dds_subscriber.c
+++ b/src/core/ddsc/src/dds_subscriber.c
@@ -23,15 +23,6 @@ DECL_ENTITY_LOCK_UNLOCK (extern inline, dds_subscriber)
 #define DDS_SUBSCRIBER_STATUS_MASK                               \
                         (DDS_DATA_ON_READERS_STATUS)
 
-static dds_return_t dds_subscriber_instance_hdl (dds_entity *e, dds_instance_handle_t *i) ddsrt_nonnull_all;
-
-static dds_return_t dds_subscriber_instance_hdl (dds_entity *e, dds_instance_handle_t *i)
-{
-  (void) e; (void) i;
-  /* FIXME: Get/generate proper handle. */
-  return DDS_RETCODE_UNSUPPORTED;
-}
-
 static dds_return_t dds_subscriber_qos_set (dds_entity *e, const dds_qos_t *qos, bool enabled)
 {
   /* note: e->m_qos is still the old one to allow for failure here */
@@ -64,9 +55,9 @@ dds_entity_t dds__create_subscriber_l (dds_participant *participant, const dds_q
 
   sub = dds_alloc (sizeof (*sub));
   subscriber = dds_entity_init (&sub->m_entity, &participant->m_entity, DDS_KIND_SUBSCRIBER, new_qos, listener, DDS_SUBSCRIBER_STATUS_MASK);
+  sub->m_entity.m_iid = ddsi_iid_gen ();
   sub->m_entity.m_deriver.set_qos = dds_subscriber_qos_set;
   sub->m_entity.m_deriver.validate_status = dds_subscriber_status_validate;
-  sub->m_entity.m_deriver.get_instance_hdl = dds_subscriber_instance_hdl;
   return subscriber;
 }
 

--- a/src/core/ddsc/src/dds_topic.c
+++ b/src/core/ddsc/src/dds_topic.c
@@ -271,6 +271,7 @@ dds_entity_t dds_create_topic_arbitrary (dds_entity_t participant, struct ddsi_s
     /* Create topic */
     top = dds_alloc (sizeof (*top));
     hdl = dds_entity_init (&top->m_entity, &par->m_entity, DDS_KIND_TOPIC, new_qos, listener, DDS_TOPIC_STATUS_MASK);
+    top->m_entity.m_iid = ddsi_iid_gen ();
     top->m_entity.m_deriver.delete = dds_topic_delete;
     top->m_entity.m_deriver.set_qos = dds_topic_qos_set;
     top->m_entity.m_deriver.validate_status = dds_topic_status_validate;

--- a/src/core/ddsc/src/dds_waitset.c
+++ b/src/core/ddsc/src/dds_waitset.c
@@ -22,126 +22,95 @@
 
 DEFINE_ENTITY_LOCK_UNLOCK (static, dds_waitset, DDS_KIND_WAITSET)
 
-static void dds_waitset_swap (dds_attachment **dst, dds_attachment **src, dds_attachment *prev, dds_attachment *idx)
+static bool is_triggered (struct dds_entity *e)
 {
-  /* Remove from source. */
-  if (prev == NULL)
-    *src = idx->next;
-  else
-    prev->next = idx->next;
-
-  /* Add to destination. */
-  idx->next = *dst;
-  *dst = idx;
+  bool t;
+  switch (e->m_kind)
+  {
+    case DDS_KIND_COND_READ:
+    case DDS_KIND_COND_QUERY:
+    case DDS_KIND_COND_GUARD:
+    case DDS_KIND_WAITSET:
+      t = ddsrt_atomic_ld32 (&e->m_status.m_trigger) != 0;
+      break;
+    default:
+      t = (ddsrt_atomic_ld32 (&e->m_status.m_status_and_mask) & SAM_STATUS_MASK) != 0;
+      break;
+  }
+  return t;
 }
 
 static dds_return_t dds_waitset_wait_impl (dds_entity_t waitset, dds_attach_t *xs, size_t nxs, dds_time_t abstimeout)
 {
   dds_waitset *ws;
   dds_return_t ret;
-  dds_attachment *idx;
-  dds_attachment *prev;
 
-  if (xs == NULL && nxs != 0)
-    return DDS_RETCODE_BAD_PARAMETER;
-  if (xs != NULL && nxs == 0)
+  if ((xs == NULL) != (nxs == 0))
     return DDS_RETCODE_BAD_PARAMETER;
 
   /* Locking the waitset here will delay a possible deletion until it is
    * unlocked. Even when the related mutex is unlocked by a conditioned wait. */
-  if ((ret = dds_waitset_lock (waitset, &ws)) != DDS_RETCODE_OK)
-    return ret;
+  {
+    dds_entity *ent;
+    if ((ret = dds_entity_pin (waitset, &ent)) != DDS_RETCODE_OK)
+      return ret;
+    if (dds_entity_kind (ent) != DDS_KIND_WAITSET)
+    {
+      dds_entity_unpin (ent);
+      return DDS_RETCODE_ILLEGAL_OPERATION;
+    }
+    ws = (dds_waitset *) ent;
+  }
 
   /* Move any previously but no longer triggering entities back to the observed list */
-  idx = ws->triggered;
-  prev = NULL;
-  while (idx != NULL)
+  ddsrt_mutex_lock (&ws->m_entity.m_mutex);
+  ws->ntriggered = 0;
+  for (size_t i = 0; i < ws->nentities; i++)
   {
-    dds_attachment *next = idx->next;
-    if (idx->entity->m_trigger == 0)
-      dds_waitset_swap (&ws->observed, &ws->triggered, prev, idx);
-    else
-      prev = idx;
-    idx = next;
-  }
-  /* Check if any of the observed entities are currently triggered, moving them
-     to the triggered list */
-  idx = ws->observed;
-  prev = NULL;
-  while (idx != NULL)
-  {
-    dds_attachment *next = idx->next;
-    if (idx->entity->m_trigger > 0)
-      dds_waitset_swap (&ws->triggered, &ws->observed, prev, idx);
-    else
-      prev = idx;
-    idx = next;
+    if (is_triggered (ws->entities[i].entity))
+    {
+      dds_attachment tmp = ws->entities[i];
+      ws->entities[i] = ws->entities[ws->ntriggered];
+      ws->entities[ws->ntriggered++] = tmp;
+    }
   }
 
   /* Only wait/keep waiting when we have something to observe and there aren't any triggers yet. */
-  while (ws->observed != NULL && ws->triggered == NULL)
+  while (ws->nentities > 0 && ws->ntriggered == 0)
     if (!ddsrt_cond_waituntil (&ws->m_entity.m_cond, &ws->m_entity.m_mutex, abstimeout))
       break;
 
-  /* Get number of triggered entities
-   *   - set attach array when needed
-   *   - swap them back to observed */
-  ret = 0;
-  idx = ws->triggered;
-  while (idx != NULL)
-  {
-    if ((uint32_t) ret < (uint32_t) nxs)
-      xs[ret] = idx->arg;
-    ret++;
-
-    /* The idx is always the first in triggered, so no prev. */
-    dds_attachment *next = idx->next;
-    dds_waitset_swap (&ws->observed, &ws->triggered, NULL, idx);
-    idx = next;
-  }
-  dds_waitset_unlock (ws);
+  ret = (int32_t) ws->ntriggered;
+  for (size_t i = 0; i < ws->ntriggered && i < nxs; i++)
+    xs[i] = ws->entities[i].arg;
+  ddsrt_mutex_unlock (&ws->m_entity.m_mutex);
+  dds_entity_unpin (&ws->m_entity);
   return ret;
-}
-
-static void dds_waitset_close_list (dds_attachment **list, dds_entity_t waitset)
-{
-  dds_attachment *idx = *list;
-  dds_attachment *next;
-  while (idx != NULL)
-  {
-    next = idx->next;
-    (void) dds_entity_observer_unregister (idx->entity->m_hdllink.hdl, waitset);
-    ddsrt_free (idx);
-    idx = next;
-  }
-  *list = NULL;
-}
-
-static bool dds_waitset_remove_from_list (dds_attachment **list, dds_entity_t observed)
-{
-  dds_attachment *idx, *prev;
-  for (idx = *list, prev = NULL; idx != NULL; prev = idx, idx = idx->next)
-    if (idx->entity->m_hdllink.hdl == observed)
-      break;
-  if (idx == NULL)
-    return false;
-
-  if (prev == NULL)
-    *list = idx->next;
-  else
-    prev->next = idx->next;
-  ddsrt_free (idx);
-  return true;
 }
 
 static dds_return_t dds_waitset_close (struct dds_entity *e)
 {
+  /* deep in the process of deleting the entity, so this is the only thread */
   dds_waitset *ws = (dds_waitset *) e;
-  dds_waitset_close_list (&ws->observed,  e->m_hdllink.hdl);
-  dds_waitset_close_list (&ws->triggered, e->m_hdllink.hdl);
-  ddsrt_cond_broadcast (&e->m_cond);
+  for (size_t i = 0; i < ws->nentities; i++)
+    (void) dds_entity_observer_unregister (ws->entities[i].entity, &ws->m_entity);
   return DDS_RETCODE_OK;
 }
+
+static dds_return_t dds_waitset_delete (struct dds_entity *e)
+{
+  /* deep in the process of deleting the entity, so this is the only thread */
+  dds_waitset *ws = (dds_waitset *) e;
+  ddsrt_free (ws->entities);
+  return DDS_RETCODE_OK;
+}
+
+const struct dds_entity_deriver dds_entity_deriver_waitset = {
+  .close = dds_waitset_close,
+  .delete = dds_waitset_delete,
+  .set_qos = dds_entity_deriver_dummy_set_qos,
+  .validate_status = dds_entity_deriver_dummy_validate_status
+};
 
 dds_entity_t dds_create_waitset (dds_entity_t participant)
 {
@@ -155,13 +124,13 @@ dds_entity_t dds_create_waitset (dds_entity_t participant)
   dds_waitset *waitset = dds_alloc (sizeof (*waitset));
   hdl = dds_entity_init (&waitset->m_entity, &par->m_entity, DDS_KIND_WAITSET, NULL, NULL, 0);
   waitset->m_entity.m_iid = ddsi_iid_gen ();
-  waitset->m_entity.m_deriver.close = dds_waitset_close;
-  waitset->observed = NULL;
-  waitset->triggered = NULL;
+  dds_entity_register_child (&par->m_entity, &waitset->m_entity);
+  waitset->nentities = 0;
+  waitset->ntriggered = 0;
+  waitset->entities = NULL;
   dds_participant_unlock (par);
   return hdl;
 }
-
 
 dds_return_t dds_waitset_get_entities (dds_entity_t waitset, dds_entity_t *entities, size_t size)
 {
@@ -171,62 +140,72 @@ dds_return_t dds_waitset_get_entities (dds_entity_t waitset, dds_entity_t *entit
   if ((ret = dds_waitset_lock (waitset, &ws)) != DDS_RETCODE_OK)
     return ret;
 
-  ret = 0;
-  for (dds_attachment *iter = ws->observed; iter != NULL; iter = iter->next)
+  if (entities != NULL)
   {
-    if ((size_t) ret < size && entities != NULL)
-      entities[ret] = iter->entity->m_hdllink.hdl;
-    ret++;
+    for (size_t i = 0; i < ws->nentities && i < size; i++)
+      entities[i] = ws->entities[i].handle;
   }
-  for (dds_attachment *iter = ws->triggered; iter != NULL; iter = iter->next)
-  {
-    if ((size_t) ret < size && entities != NULL)
-      entities[ret] = iter->entity->m_hdllink.hdl;
-    ret++;
-  }
-  dds_waitset_unlock(ws);
+  ret = (int32_t) ws->nentities;
+  dds_waitset_unlock (ws);
   return ret;
-}
-
-static void dds_waitset_move (dds_attachment **src, dds_attachment **dst, dds_entity_t entity)
-{
-  dds_attachment *idx, *prev;
-  for (idx = *src, prev = NULL; idx != NULL; prev = idx, idx = idx->next)
-    if (idx->entity->m_hdllink.hdl == entity)
-      break;
-  if (idx != NULL)
-  {
-    /* Swap idx from src to dst. */
-    dds_waitset_swap (dst, src, prev, idx);
-  }
 }
 
 static void dds_waitset_remove (dds_waitset *ws, dds_entity_t observed)
 {
-  if (!dds_waitset_remove_from_list (&ws->observed, observed))
-    (void) dds_waitset_remove_from_list (&ws->triggered, observed);
+  size_t i;
+  for (i = 0; i < ws->nentities; i++)
+    if (ws->entities[i].handle == observed)
+      break;
+  if (i < ws->nentities)
+  {
+    if (i < ws->ntriggered)
+    {
+      ws->entities[i] = ws->entities[--ws->ntriggered];
+      ws->entities[ws->ntriggered] = ws->entities[--ws->nentities];
+    }
+    else
+    {
+      ws->entities[i] = ws->entities[--ws->nentities];
+    }
+    return;
+  }
 }
 
 /* This is called when the observed entity signals a status change. */
-static void dds_waitset_observer (dds_entity_t observer, dds_entity_t observed, uint32_t status)
+static void dds_waitset_observer (dds_entity *ent, dds_entity_t observed, uint32_t status)
 {
-  dds_waitset *ws;
-  if (dds_waitset_lock (observer, &ws) == DDS_RETCODE_OK) {
-    if (status & DDS_DELETING_STATUS) {
-      /* Remove this observed entity, which is being deleted, from the waitset. */
-      dds_waitset_remove (ws, observed);
-      /* Our registration to this observed entity will be removed automatically. */
-    } else if (status != 0) {
-      /* Move observed entity to triggered list. */
-      dds_waitset_move (&ws->observed, &ws->triggered, observed);
-    } else {
-      /* Remove observed entity from triggered list (which it possibly resides in). */
-      dds_waitset_move (&ws->triggered, &ws->observed, observed);
-    }
-    /* Trigger waitset to wake up. */
-    ddsrt_cond_broadcast (&ws->m_entity.m_cond);
-    dds_waitset_unlock (ws);
+  assert (dds_entity_kind (ent) == DDS_KIND_WAITSET);
+  dds_waitset *ws = (dds_waitset *) ent;
+  (void) status;
+
+  ddsrt_mutex_lock (&ws->m_entity.m_mutex);
+  /* Move observed entity to triggered list. */
+  size_t i;
+  for (i = 0; i < ws->nentities; i++)
+    if (ws->entities[i].handle == observed)
+      break;
+  if (i < ws->nentities && i >= ws->ntriggered)
+  {
+    dds_attachment tmp = ws->entities[i];
+    ws->entities[i] = ws->entities[ws->ntriggered];
+    ws->entities[ws->ntriggered++] = tmp;
   }
+  /* Trigger waitset to wake up. */
+  ddsrt_cond_broadcast (&ws->m_entity.m_cond);
+  ddsrt_mutex_unlock (&ws->m_entity.m_mutex);
+}
+
+static void dds_waitset_delete_observer (dds_entity *ent, dds_entity_t observed)
+{
+  assert (dds_entity_kind (ent) == DDS_KIND_WAITSET);
+  dds_waitset *ws = (dds_waitset *) ent;
+  ddsrt_mutex_lock (&ws->m_entity.m_mutex);
+  /* Remove this observed entity, which is being deleted, from the waitset. */
+  dds_waitset_remove (ws, observed);
+  /* Our registration to this observed entity will be removed automatically. */
+  /* Trigger waitset to wake up. */
+  ddsrt_cond_broadcast (&ws->m_entity.m_cond);
+  ddsrt_mutex_unlock (&ws->m_entity.m_mutex);
 }
 
 dds_return_t dds_waitset_attach (dds_entity_t waitset, dds_entity_t entity, dds_attach_t x)
@@ -235,35 +214,35 @@ dds_return_t dds_waitset_attach (dds_entity_t waitset, dds_entity_t entity, dds_
   dds_waitset *ws;
   dds_return_t ret;
 
-  if ((ret = dds_waitset_lock (waitset, &ws)) != DDS_RETCODE_OK)
+  if ((ret = dds_waitset_lock (waitset, &ws)) < 0)
     return ret;
 
   if (waitset == entity)
     e = &ws->m_entity;
-  else if ((ret = dds_entity_lock (entity, DDS_KIND_DONTCARE, &e)) != DDS_RETCODE_OK)
-  {
-    ret = DDS_RETCODE_BAD_PARAMETER;
+  else if ((ret = dds_entity_pin (entity, &e)) < 0)
     goto err_waitset;
-  }
 
   /* This will fail if given entity is already attached (or deleted). */
-  if ((ret = dds_entity_observer_register_nl (e, waitset, dds_waitset_observer)) != DDS_RETCODE_OK)
+  if ((ret = dds_entity_observer_register (e, &ws->m_entity, dds_waitset_observer, dds_waitset_delete_observer)) != DDS_RETCODE_OK)
     goto err_entity;
 
-  dds_attachment *a = ddsrt_malloc (sizeof (*a));
-  a->arg = x;
-  a->entity = e;
-  if (e->m_trigger > 0) {
-    a->next = ws->triggered;
-    ws->triggered = a;
-  } else {
-    a->next = ws->observed;
-    ws->observed = a;
+  ws->entities = ddsrt_realloc (ws->entities, (ws->nentities + 1) * sizeof (*ws->entities));
+  ws->entities[ws->nentities].arg = x;
+  ws->entities[ws->nentities].entity = e;
+  ws->entities[ws->nentities].handle = e->m_hdllink.hdl;
+  ws->nentities++;
+  if (is_triggered (e))
+  {
+    const size_t i = ws->nentities - 1;
+    dds_attachment tmp = ws->entities[i];
+    ws->entities[i] = ws->entities[ws->ntriggered];
+    ws->entities[ws->ntriggered++] = tmp;
   }
+  ddsrt_cond_broadcast (&ws->m_entity.m_cond);
 
 err_entity:
   if (e != &ws->m_entity)
-    dds_entity_unlock (e);
+    dds_entity_unpin (e);
 err_waitset:
   dds_waitset_unlock (ws);
   return ret;
@@ -272,6 +251,7 @@ err_waitset:
 dds_return_t dds_waitset_detach (dds_entity_t waitset, dds_entity_t entity)
 {
   dds_waitset *ws;
+  dds_entity *e;
   dds_return_t ret;
 
   if ((ret = dds_waitset_lock (waitset, &ws)) != DDS_RETCODE_OK)
@@ -279,12 +259,19 @@ dds_return_t dds_waitset_detach (dds_entity_t waitset, dds_entity_t entity)
 
   /* Possibly fails when entity was not attached. */
   if (waitset == entity)
-    ret = dds_entity_observer_unregister_nl (&ws->m_entity, waitset);
+    ret = dds_entity_observer_unregister (&ws->m_entity, &ws->m_entity);
+  else if ((ret = dds_entity_pin (entity, &e)) < 0)
+    ; /* entity invalid */
   else
-    ret = dds_entity_observer_unregister (entity, waitset);
+  {
+    ret = dds_entity_observer_unregister (e, &ws->m_entity);
+    dds_entity_unpin (e);
+  }
 
   if (ret == DDS_RETCODE_OK)
+  {
     dds_waitset_remove (ws, entity);
+  }
   else
   {
     if (ret != DDS_RETCODE_PRECONDITION_NOT_MET)
@@ -296,7 +283,7 @@ dds_return_t dds_waitset_detach (dds_entity_t waitset, dds_entity_t entity)
 
 dds_return_t dds_waitset_wait_until (dds_entity_t waitset, dds_attach_t *xs, size_t nxs, dds_time_t abstimeout)
 {
-  return dds_waitset_wait_impl(waitset, xs, nxs, abstimeout);
+  return dds_waitset_wait_impl (waitset, xs, nxs, abstimeout);
 }
 
 dds_return_t dds_waitset_wait (dds_entity_t waitset, dds_attach_t *xs, size_t nxs, dds_duration_t reltimeout)
@@ -310,22 +297,21 @@ dds_return_t dds_waitset_wait (dds_entity_t waitset, dds_attach_t *xs, size_t nx
 
 dds_return_t dds_waitset_set_trigger (dds_entity_t waitset, bool trigger)
 {
-  dds_waitset *ws;
+  dds_entity *ent;
   dds_return_t rc;
 
-  if ((rc = dds_waitset_lock (waitset, &ws)) != DDS_RETCODE_OK)
+  if ((rc = dds_entity_pin (waitset, &ent)) != DDS_RETCODE_OK)
     return rc;
+  else if (dds_entity_kind (ent) != DDS_KIND_WAITSET)
+  {
+    dds_entity_unpin (ent);
+    return DDS_RETCODE_ILLEGAL_OPERATION;
+  }
 
-  ddsrt_mutex_unlock (&ws->m_entity.m_mutex);
+  ddsrt_mutex_lock (&ent->m_observers_lock);
+  dds_entity_trigger_set (ent, trigger);
+  ddsrt_mutex_unlock (&ent->m_observers_lock);
 
-  ddsrt_mutex_lock (&ws->m_entity.m_observers_lock);
-  if (trigger)
-    dds_entity_status_set (&ws->m_entity, DDS_WAITSET_TRIGGER_STATUS);
-  else
-    dds_entity_status_reset (&ws->m_entity, DDS_WAITSET_TRIGGER_STATUS);
-  ddsrt_mutex_unlock (&ws->m_entity.m_observers_lock);
-
-  ddsrt_mutex_lock (&ws->m_entity.m_mutex);
-  dds_waitset_unlock (ws);
+  dds_entity_unpin (ent);
   return DDS_RETCODE_OK;
 }

--- a/src/core/ddsc/src/dds_waitset.c
+++ b/src/core/ddsc/src/dds_waitset.c
@@ -18,6 +18,7 @@
 #include "dds__querycond.h"
 #include "dds__readcond.h"
 #include "dds__rhc.h"
+#include "dds/ddsi/ddsi_iid.h"
 
 DEFINE_ENTITY_LOCK_UNLOCK (static, dds_waitset, DDS_KIND_WAITSET)
 
@@ -153,6 +154,7 @@ dds_entity_t dds_create_waitset (dds_entity_t participant)
 
   dds_waitset *waitset = dds_alloc (sizeof (*waitset));
   hdl = dds_entity_init (&waitset->m_entity, &par->m_entity, DDS_KIND_WAITSET, NULL, NULL, 0);
+  waitset->m_entity.m_iid = ddsi_iid_gen ();
   waitset->m_entity.m_deriver.close = dds_waitset_close;
   waitset->observed = NULL;
   waitset->triggered = NULL;

--- a/src/core/ddsc/src/dds_whc.c
+++ b/src/core/ddsc/src/dds_whc.c
@@ -60,11 +60,7 @@ struct whc_idxnode {
   seqno_t prune_seq;
   struct ddsi_tkmap_instance *tk;
   uint32_t headidx;
-#if __STDC_VERSION__ >= 199901L
   struct whc_node *hist[];
-#else
-  struct whc_node *hist[1];
-#endif
 };
 
 #if USE_EHH

--- a/src/core/ddsc/src/dds_whc.c
+++ b/src/core/ddsc/src/dds_whc.c
@@ -366,11 +366,11 @@ struct whc *whc_new (int is_transient_local, uint32_t hdepth, uint32_t tldepth)
 #if USE_EHH
   whc->seq_hash = ddsrt_ehh_new (sizeof (struct whc_seq_entry), 32, whc_seq_entry_hash, whc_seq_entry_eq);
 #else
-  whc->seq_hash = ddsrt_hh_new (32, whc_node_hash, whc_node_eq);
+  whc->seq_hash = ddsrt_hh_new (1, whc_node_hash, whc_node_eq);
 #endif
 
   if (whc->idxdepth > 0)
-    whc->idx_hash = ddsrt_hh_new (32, whc_idxnode_hash_key, whc_idxnode_eq_key);
+    whc->idx_hash = ddsrt_hh_new (1, whc_idxnode_hash_key, whc_idxnode_eq_key);
   else
     whc->idx_hash = NULL;
 

--- a/src/core/ddsc/src/dds_writer.c
+++ b/src/core/ddsc/src/dds_writer.c
@@ -36,14 +36,6 @@ DECL_ENTITY_LOCK_UNLOCK (extern inline, dds_writer)
                          DDS_OFFERED_INCOMPATIBLE_QOS_STATUS     |\
                          DDS_PUBLICATION_MATCHED_STATUS)
 
-static dds_return_t dds_writer_instance_hdl (dds_entity *e, dds_instance_handle_t *i) ddsrt_nonnull_all;
-
-static dds_return_t dds_writer_instance_hdl (dds_entity *e, dds_instance_handle_t *i)
-{
-  *i = writer_instance_id(&e->m_guid);
-  return DDS_RETCODE_OK;
-}
-
 static dds_return_t dds_writer_status_validate (uint32_t mask)
 {
   return (mask & ~DDS_WRITER_STATUS_MASK) ? DDS_RETCODE_BAD_PARAMETER : DDS_RETCODE_OK;
@@ -305,7 +297,6 @@ dds_entity_t dds_create_writer (dds_entity_t participant_or_publisher, dds_entit
   wr->m_entity.m_deriver.delete = dds_writer_delete;
   wr->m_entity.m_deriver.set_qos = dds_writer_qos_set;
   wr->m_entity.m_deriver.validate_status = dds_writer_status_validate;
-  wr->m_entity.m_deriver.get_instance_hdl = dds_writer_instance_hdl;
   wr->m_whc = make_whc (wqos);
 
   /* Extra claim of this writer to make sure that the delete waits until DDSI
@@ -321,6 +312,7 @@ dds_entity_t dds_create_writer (dds_entity_t participant_or_publisher, dds_entit
   ddsrt_mutex_lock (&tp->m_entity.m_mutex);
   assert(rc == DDS_RETCODE_OK);
   thread_state_asleep (lookup_thread_state ());
+  wr->m_entity.m_iid = get_entity_instance_id (&wr->m_entity.m_guid);
   dds_topic_unlock (tp);
   dds_publisher_unlock (pub);
   return writer;

--- a/src/core/ddsc/tests/dispose.c
+++ b/src/core/ddsc/tests/dispose.c
@@ -560,7 +560,8 @@ CU_Theory((dds_entity_t *writer), ddsc_dispose, non_writers, .init=disposing_ini
 {
     dds_return_t ret;
     DDSRT_WARNING_MSVC_OFF(6387); /* Disable SAL warning on intentional misuse of the API */
-    ret = dds_dispose(*writer, NULL);
+    /* pass a non-null pointer that'll trigger a crash if it is read */
+    ret = dds_dispose(*writer, (void *) 1);
     DDSRT_WARNING_MSVC_ON(6387);
     CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_ILLEGAL_OPERATION);
 }
@@ -714,7 +715,8 @@ CU_Theory((dds_entity_t *writer), ddsc_dispose_ts, non_writers, .init=disposing_
 {
     dds_return_t ret;
     DDSRT_WARNING_MSVC_OFF(6387); /* Disable SAL warning on intentional misuse of the API */
-    ret = dds_dispose_ts(*writer, NULL, g_present);
+    /* pass a non-null pointer that'll trigger a crash if it is read */
+    ret = dds_dispose_ts(*writer, (void *) 1, g_present);
     DDSRT_WARNING_MSVC_ON(6387);
     CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_ILLEGAL_OPERATION);
 }

--- a/src/core/ddsc/tests/instance_get_key.c
+++ b/src/core/ddsc/tests/instance_get_key.c
@@ -63,7 +63,7 @@ CU_Test(ddsc_instance_get_key, bad_entity, .init=setup, .fini=teardown)
     dds_return_t ret;
 
     ret = dds_instance_get_key(participant, handle, &data);
-    CU_ASSERT_EQUAL(ret, DDS_RETCODE_BAD_PARAMETER);
+    CU_ASSERT_EQUAL(ret, DDS_RETCODE_ILLEGAL_OPERATION);
 }
 
 CU_Test(ddsc_instance_get_key, null_data, .init=setup, .fini=teardown)

--- a/src/core/ddsc/tests/unsupported.c
+++ b/src/core/ddsc/tests/unsupported.c
@@ -121,16 +121,19 @@ CU_Test(ddsc_unsupported, dds_get_instance_handle, .init = setup, .fini = teardo
     dds_return_t result;
     dds_instance_handle_t ih;
     static struct index_result pars[] = {
-        {TOP, DDS_RETCODE_ILLEGAL_OPERATION}, /* TODO: Shouldn't this be either supported or unsupported? */
-        {PUB, DDS_RETCODE_UNSUPPORTED},
-        {SUB, DDS_RETCODE_UNSUPPORTED},
-        {RCD, DDS_RETCODE_ILLEGAL_OPERATION},
+        {TOP, DDS_RETCODE_OK},
+        {PUB, DDS_RETCODE_OK},
+        {SUB, DDS_RETCODE_OK},
+        {RCD, DDS_RETCODE_OK},
         {BAD, DDS_RETCODE_BAD_PARAMETER}
     };
 
     for (size_t i=0; i < sizeof (pars) / sizeof (pars[0]);i++) {
         result = dds_get_instance_handle(e[pars[i].index], &ih);
         CU_ASSERT_EQUAL(result, pars[i].exp_res);
+        if (pars[i].exp_res == DDS_RETCODE_OK) {
+          CU_ASSERT(ih > 0);
+        }
     }
 }
 

--- a/src/core/ddsi/include/dds/ddsi/ddsi_serdata_default.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_serdata_default.h
@@ -66,7 +66,7 @@ struct ddsi_serdata_default {
      serdata is 8-byte aligned */
   char pad[8 - ((sizeof (struct ddsi_serdata) + 4) % 8)];
   struct CDRHeader hdr;
-  char data[1];
+  char data[];
 };
 
 struct dds_key_descriptor;

--- a/src/core/ddsi/include/dds/ddsi/ddsi_sertopic.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_sertopic.h
@@ -29,7 +29,6 @@ typedef void (*topic_cb_t) (struct dds_topic * topic);
 struct ddsi_sertopic_ops;
 
 struct ddsi_sertopic {
-  ddsrt_avl_node_t avlnode; /* index on name_typename */
   const struct ddsi_sertopic_ops *ops;
   const struct ddsi_serdata_ops *serdata_ops;
   uint32_t serdata_basehash;
@@ -38,9 +37,6 @@ struct ddsi_sertopic {
   char *type_name;
   uint64_t iid;
   ddsrt_atomic_uint32_t refc; /* counts refs from entities, not from data */
-
-  topic_cb_t status_cb;
-  struct dds_topic * status_cb_entity;
 };
 
 /* Called when the refcount dropped to zero */

--- a/src/core/ddsi/include/dds/ddsi/q_entity.h
+++ b/src/core/ddsi/include/dds/ddsi/q_entity.h
@@ -529,6 +529,7 @@ dds_return_t new_participant (struct nn_guid *ppguid, unsigned flags, const stru
 */
 dds_return_t delete_participant (const struct nn_guid *ppguid);
 void update_participant_plist (struct participant *pp, const struct nn_plist *plist);
+uint64_t get_entity_instance_id (const struct nn_guid *guid);
 
 /* To obtain the builtin writer to be used for publishing SPDP, SEDP,
    PMD stuff for PP and its endpoints, given the entityid.  If PP has
@@ -559,7 +560,6 @@ dds_return_t delete_writer_nolinger (const struct nn_guid *guid);
 dds_return_t delete_writer_nolinger_locked (struct writer *wr);
 
 dds_return_t delete_reader (const struct nn_guid *guid);
-uint64_t reader_instance_id (const struct nn_guid *guid);
 
 struct local_orphan_writer {
   struct writer wr;
@@ -593,7 +593,6 @@ void delete_local_orphan_writer (struct local_orphan_writer *wr);
 
 void new_proxy_participant (const struct nn_guid *guid, unsigned bes, unsigned prismtech_bes, const struct nn_guid *privileged_pp_guid, struct addrset *as_default, struct addrset *as_meta, const struct nn_plist *plist, dds_duration_t tlease_dur, nn_vendorid_t vendor, unsigned custom_flags, nn_wctime_t timestamp, seqno_t seq);
 int delete_proxy_participant_by_guid (const struct nn_guid * guid, nn_wctime_t timestamp, int isimplicit);
-uint64_t participant_instance_id (const struct nn_guid *guid);
 
 enum update_proxy_participant_source {
   UPD_PROXYPP_SPDP,
@@ -628,8 +627,6 @@ void update_proxy_writer (struct proxy_writer *pwr, struct addrset *as, const st
 
 int new_proxy_group (const struct nn_guid *guid, const char *name, const struct dds_qos *xqos, nn_wctime_t timestamp);
 void delete_proxy_group (const struct nn_guid *guid, nn_wctime_t timestamp, int isimplicit);
-
-uint64_t writer_instance_id (const struct nn_guid *guid);
 
 /* Call this to empty all address sets of all writers to stop all outgoing traffic, or to
    rebuild them all (which only makes sense after previously having emptied them all). */

--- a/src/core/ddsi/include/dds/ddsi/q_globals.h
+++ b/src/core/ddsi/include/dds/ddsi/q_globals.h
@@ -221,7 +221,7 @@ struct q_globals {
   struct thread_state1 *listen_ts;
 
   /* Flag cleared when stopping (receive threads). FIXME. */
-  int rtps_keepgoing;
+  ddsrt_atomic_uint32_t rtps_keepgoing;
 
   /* Start time of the DDSI2 service, for logging relative time stamps,
      should I ever so desire. */

--- a/src/core/ddsi/include/dds/ddsi/q_globals.h
+++ b/src/core/ddsi/include/dds/ddsi/q_globals.h
@@ -64,9 +64,6 @@ enum recvips_mode {
   RECVIPS_MODE_SOME             /* explicit list of interfaces; only one requiring recvips */
 };
 
-#define N_LEASE_LOCKS_LG2 4
-#define N_LEASE_LOCKS ((int) (1 << N_LEASE_LOCKS_LG2))
-
 enum recv_thread_mode {
   RTM_SINGLE,
   RTM_MANY
@@ -109,7 +106,6 @@ struct q_globals {
 
   /* Lease junk */
   ddsrt_mutex_t leaseheap_lock;
-  ddsrt_mutex_t lease_locks[N_LEASE_LOCKS];
   ddsrt_fibheap_t leaseheap;
 
   /* Transport factory */

--- a/src/core/ddsi/include/dds/ddsi/q_protocol.h
+++ b/src/core/ddsi/include/dds/ddsi/q_protocol.h
@@ -35,8 +35,8 @@ typedef struct {
 typedef struct nn_sequence_number_set {
   nn_sequence_number_t bitmap_base;
   uint32_t numbits;
-  uint32_t bits[1];
-} nn_sequence_number_set_t; /* Why strict C90? zero-length/flexible array members are far nicer */
+  uint32_t bits[];
+} nn_sequence_number_set_t;
 /* SequenceNumberSet size is base (2 words) + numbits (1 word) +
    bitmap ((numbits+31)/32 words), and this at 4 bytes/word */
 #define NN_SEQUENCE_NUMBER_SET_BITS_SIZE(numbits) ((unsigned) (4 * (((numbits) + 31) / 32)))
@@ -45,7 +45,7 @@ typedef unsigned nn_fragment_number_t;
 typedef struct nn_fragment_number_set {
   nn_fragment_number_t bitmap_base;
   uint32_t numbits;
-  uint32_t bits[1];
+  uint32_t bits[];
 } nn_fragment_number_set_t;
 /* FragmentNumberSet size is base (2 words) + numbits (1 word) +
    bitmap ((numbits+31)/32 words), and this at 4 bytes/word */
@@ -69,12 +69,6 @@ typedef struct nn_udpv4mcgen_address {
   uint8_t count;
   uint8_t idx; /* must be last: then sorting will put them consecutively */
 } nn_udpv4mcgen_address_t;
-
-
-struct cdrstring {
-  uint32_t length;
-  unsigned char contents[1]; /* C90 does not support flex. array members */
-};
 
 #define NN_STATUSINFO_DISPOSE      0x1u
 #define NN_STATUSINFO_UNREGISTER   0x2u
@@ -317,7 +311,7 @@ typedef struct ParticipantMessageData {
   nn_guid_prefix_t participantGuidPrefix;
   uint32_t kind; /* really 4 octets */
   uint32_t length;
-  char value[1 /* length */];
+  char value[];
 } ParticipantMessageData_t;
 #define PARTICIPANT_MESSAGE_DATA_KIND_UNKNOWN 0x0u
 #define PARTICIPANT_MESSAGE_DATA_KIND_AUTOMATIC_LIVELINESS_UPDATE 0x1u

--- a/src/core/ddsi/include/dds/ddsi/q_radmin.h
+++ b/src/core/ddsi/include/dds/ddsi/q_radmin.h
@@ -47,15 +47,15 @@ struct nn_rmsg_chunk {
      nn_rmsg_setsize after receiving a packet from the kernel and
      before processing it.  */
   uint32_t size;
-  union {
-    /* payload array stretched to whatever it really is */
-    unsigned char payload[1];
 
-    /* to ensure reasonable alignment of payload[] */
+  /* to ensure reasonable alignment of payload[] */
+  union {
     int64_t l;
     double d;
     void *p;
   } u;
+  /* payload array stretched to whatever it really is */
+  unsigned char payload[];
 };
 
 struct nn_rmsg {
@@ -95,7 +95,7 @@ struct nn_rmsg {
 
   struct nn_rmsg_chunk chunk;
 };
-#define NN_RMSG_PAYLOAD(m) ((m)->chunk.u.payload)
+#define NN_RMSG_PAYLOAD(m) ((m)->chunk.payload)
 #define NN_RMSG_PAYLOADOFF(m, o) (NN_RMSG_PAYLOAD (m) + (o))
 
 struct receiver_state {

--- a/src/core/ddsi/include/dds/ddsi/q_thread.h
+++ b/src/core/ddsi/include/dds/ddsi/q_thread.h
@@ -57,13 +57,14 @@ enum thread_state {
 struct logbuf;
 
 /*
- * watchdog indicates progress for the service lease liveliness mechsanism, while vtime
- * indicates progress for the Garbage collection purposes.
- *  vtime even : thread awake
- *  vtime odd  : thread asleep
+ * vtime indicates progress for the garbage collector and the liveliness monitoring.
+ *
+ * vtime is updated without using atomic operations: only the owning thread updates
+ * them, and the garbage collection mechanism and the liveliness monitoring only
+ * observe the value
  */
 #define THREAD_BASE                             \
-  volatile vtime_t vtime;                       \
+  ddsrt_atomic_uint32_t vtime;                  \
   ddsrt_thread_t tid;                           \
   ddsrt_thread_t extTid;                        \
   enum thread_state state;                      \
@@ -131,17 +132,21 @@ DDS_EXPORT inline bool vtime_gt (vtime_t vtime1, vtime_t vtime0)
 
 DDS_EXPORT inline bool thread_is_awake (void)
 {
-  return vtime_awake_p (lookup_thread_state ()->vtime);
+  struct thread_state1 *ts = lookup_thread_state ();
+  vtime_t vt = ddsrt_atomic_ld32 (&ts->vtime);
+  return vtime_awake_p (vt);
 }
 
 DDS_EXPORT inline bool thread_is_asleep (void)
 {
-  return vtime_asleep_p (lookup_thread_state ()->vtime);
+  struct thread_state1 *ts = lookup_thread_state ();
+  vtime_t vt = ddsrt_atomic_ld32 (&ts->vtime);
+  return vtime_asleep_p (vt);
 }
 
 DDS_EXPORT inline void thread_state_asleep (struct thread_state1 *ts1)
 {
-  vtime_t vt = ts1->vtime;
+  vtime_t vt = ddsrt_atomic_ld32 (&ts1->vtime);
   assert (vtime_awake_p (vt));
   /* nested calls a rare and an extra fence doesn't break things */
   ddsrt_atomic_fence_rel ();
@@ -149,24 +154,24 @@ DDS_EXPORT inline void thread_state_asleep (struct thread_state1 *ts1)
     vt += (1u << VTIME_TIME_SHIFT) - 1u;
   else
     vt -= 1u;
-  ts1->vtime = vt;
+  ddsrt_atomic_st32 (&ts1->vtime, vt);
 }
 
 DDS_EXPORT inline void thread_state_awake (struct thread_state1 *ts1)
 {
-  vtime_t vt = ts1->vtime;
+  vtime_t vt = ddsrt_atomic_ld32 (&ts1->vtime);
   assert ((vt & VTIME_NEST_MASK) < VTIME_NEST_MASK);
-  ts1->vtime = vt + 1u;
+  ddsrt_atomic_st32 (&ts1->vtime, vt + 1u);
   /* nested calls a rare and an extra fence doesn't break things */
   ddsrt_atomic_fence_acq ();
 }
 
 DDS_EXPORT inline void thread_state_awake_to_awake_no_nest (struct thread_state1 *ts1)
 {
-  vtime_t vt = ts1->vtime;
+  vtime_t vt = ddsrt_atomic_ld32 (&ts1->vtime);
   assert ((vt & VTIME_NEST_MASK) == 1);
   ddsrt_atomic_fence_rel ();
-  ts1->vtime = vt + (1u << VTIME_TIME_SHIFT);
+  ddsrt_atomic_st32 (&ts1->vtime, vt + (1u << VTIME_TIME_SHIFT));
   ddsrt_atomic_fence_acq ();
 }
 

--- a/src/core/ddsi/src/ddsi_tcp.c
+++ b/src/core/ddsi/src/ddsi_tcp.c
@@ -706,6 +706,7 @@ static ddsrt_socket_t ddsi_tcp_conn_handle (ddsi_tran_base_t base)
   return ((ddsi_tcp_conn_t) base)->m_sock;
 }
 
+ddsrt_attribute_no_sanitize (("thread"))
 static bool ddsi_tcp_supports (int32_t kind)
 {
   return kind == ddsi_tcp_factory_g.m_kind;
@@ -770,7 +771,7 @@ static ddsi_tran_conn_t ddsi_tcp_accept (ddsi_tran_listener_t listener)
     {
       rc = ddsrt_accept(tl->m_sock, NULL, NULL, &sock);
     }
-    if (! gv.rtps_keepgoing)
+    if (!ddsrt_atomic_ld32(&gv.rtps_keepgoing))
     {
       ddsi_tcp_sock_free (sock, NULL);
       return NULL;

--- a/src/core/ddsi/src/ddsi_threadmon.c
+++ b/src/core/ddsi/src/ddsi_threadmon.c
@@ -83,7 +83,7 @@ static uint32_t threadmon_thread (struct ddsi_threadmon *sl)
           n_unused++;
         else
         {
-          vtime_t vt = thread_states.ts[i].vtime;
+          vtime_t vt = ddsrt_atomic_ld32 (&thread_states.ts[i].vtime);
           bool alive = vtime_asleep_p (vt) || vtime_asleep_p (sl->av_ary[i].vt) || vtime_gt (vt, sl->av_ary[i].vt);
           n_alive += (unsigned) alive;
           DDS_TRACE(" %u(%s):%c:%"PRIx32"->%"PRIx32, i, thread_states.ts[i].name, alive ? 'a' : 'd', sl->av_ary[i].vt, vt);

--- a/src/core/ddsi/src/ddsi_tran.c
+++ b/src/core/ddsi/src/ddsi_tran.c
@@ -91,6 +91,7 @@ static ddsi_tran_factory_t ddsi_factory_find_with_len (const char * type, size_t
   return factory;
 }
 
+ddsrt_attribute_no_sanitize (("thread"))
 ddsi_tran_factory_t ddsi_factory_find_supported_kind (int32_t kind)
 {
   /* FIXME: MUST speed up */
@@ -124,7 +125,7 @@ void ddsi_conn_free (ddsi_tran_conn_t conn)
         for (uint32_t i = 0; i < gv.n_recv_threads; i++)
         {
           if (!gv.recv_threads[i].ts)
-            assert (!gv.rtps_keepgoing);
+            assert (!ddsrt_atomic_ld32 (&gv.rtps_keepgoing));
           else
           {
             switch (gv.recv_threads[i].arg.mode)

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -2063,19 +2063,12 @@ static void writer_qos_mismatch (struct writer * wr, dds_qos_policy_id_t reason)
 {
   /* When the reason is DDS_INVALID_QOS_POLICY_ID, it means that we compared
    * readers/writers from different topics: ignore that. */
-  if (reason != DDS_INVALID_QOS_POLICY_ID)
+  if (reason != DDS_INVALID_QOS_POLICY_ID && wr->status_cb)
   {
-    if (wr->topic->status_cb) {
-      /* Handle INCONSISTENT_TOPIC on topic */
-      (wr->topic->status_cb) (wr->topic->status_cb_entity);
-    }
-    if (wr->status_cb)
-    {
-      status_cb_data_t data;
-      data.raw_status_id = (int) DDS_OFFERED_INCOMPATIBLE_QOS_STATUS_ID;
-      data.extra = reason;
-      (wr->status_cb) (wr->status_cb_entity, &data);
-    }
+    status_cb_data_t data;
+    data.raw_status_id = (int) DDS_OFFERED_INCOMPATIBLE_QOS_STATUS_ID;
+    data.extra = reason;
+    (wr->status_cb) (wr->status_cb_entity, &data);
   }
 }
 
@@ -2083,20 +2076,12 @@ static void reader_qos_mismatch (struct reader * rd, dds_qos_policy_id_t reason)
 {
   /* When the reason is DDS_INVALID_QOS_POLICY_ID, it means that we compared
    * readers/writers from different topics: ignore that. */
-  if (reason != DDS_INVALID_QOS_POLICY_ID)
+  if (reason != DDS_INVALID_QOS_POLICY_ID && rd->status_cb)
   {
-    if (rd->topic->status_cb)
-    {
-      /* Handle INCONSISTENT_TOPIC on topic */
-      (rd->topic->status_cb) (rd->topic->status_cb_entity);
-    }
-    if (rd->status_cb)
-    {
-      status_cb_data_t data;
-      data.raw_status_id = (int) DDS_REQUESTED_INCOMPATIBLE_QOS_STATUS_ID;
-      data.extra = reason;
-      (rd->status_cb) (rd->status_cb_entity, &data);
-    }
+    status_cb_data_t data;
+    data.raw_status_id = (int) DDS_REQUESTED_INCOMPATIBLE_QOS_STATUS_ID;
+    data.extra = reason;
+    (rd->status_cb) (rd->status_cb_entity, &data);
   }
 }
 

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -3124,20 +3124,6 @@ dds_return_t delete_writer (const struct nn_guid *guid)
   return 0;
 }
 
-uint64_t writer_instance_id (const struct nn_guid *guid)
-{
-    struct entity_common *e;
-    e = (struct entity_common*)ephash_lookup_writer_guid(guid);
-    if (e) {
-        return e->iid;
-    }
-    e = (struct entity_common*)ephash_lookup_proxy_writer_guid(guid);
-    if (e) {
-        return e->iid;
-    }
-    return 0;
-}
-
 /* READER ----------------------------------------------------------- */
 
 #ifdef DDSI_INCLUDE_NETWORK_PARTITIONS
@@ -3462,20 +3448,6 @@ dds_return_t delete_reader (const struct nn_guid *guid)
   ephash_remove_reader_guid (rd);
   gcreq_reader (rd);
   return 0;
-}
-
-uint64_t reader_instance_id (const struct nn_guid *guid)
-{
-    struct entity_common *e;
-    e = (struct entity_common*)ephash_lookup_reader_guid(guid);
-    if (e) {
-        return e->iid;
-    }
-    e = (struct entity_common*)ephash_lookup_proxy_reader_guid(guid);
-    if (e) {
-        return e->iid;
-    }
-    return 0;
 }
 
 void update_reader_qos (struct reader *rd, const dds_qos_t *xqos)
@@ -3967,18 +3939,16 @@ int delete_proxy_participant_by_guid (const struct nn_guid * guid, nn_wctime_t t
   return 0;
 }
 
-uint64_t participant_instance_id (const struct nn_guid *guid)
+uint64_t get_entity_instance_id (const struct nn_guid *guid)
 {
-    struct entity_common *e;
-    e = (struct entity_common*)ephash_lookup_participant_guid(guid);
-    if (e) {
-        return e->iid;
-    }
-    e = (struct entity_common*)ephash_lookup_proxy_participant_guid(guid);
-    if (e) {
-        return e->iid;
-    }
-    return 0;
+  struct thread_state1 *ts1 = lookup_thread_state ();
+  struct entity_common *e;
+  uint64_t iid = 0;
+  thread_state_awake (ts1);
+  if ((e = ephash_lookup_guid_untyped (guid)) != NULL)
+    iid = e->iid;
+  thread_state_asleep (ts1);
+  return iid;
 }
 
 /* PROXY-GROUP --------------------------------------------------- */

--- a/src/core/ddsi/src/q_ephash.c
+++ b/src/core/ddsi/src/q_ephash.c
@@ -121,6 +121,7 @@ void *ephash_lookup_guid_untyped (const struct nn_guid *guid)
   /* FIXME: could (now) require guid to be first in entity_common; entity_common already is first in entity */
   struct entity_common e;
   e.guid = *guid;
+  assert (thread_is_awake ());
   return ddsrt_chh_lookup (gv.guid_hash->hash, &e);
 }
 

--- a/src/core/ddsi/src/q_gc.c
+++ b/src/core/ddsi/src/q_gc.c
@@ -44,7 +44,7 @@ static void threads_vtime_gather_for_wait (unsigned *nivs, struct idx_vtime *ivs
   uint32_t i, j;
   for (i = j = 0; i < thread_states.nthreads; i++)
   {
-    vtime_t vtime = thread_states.ts[i].vtime;
+    vtime_t vtime = ddsrt_atomic_ld32 (&thread_states.ts[i].vtime);
     if (vtime_awake_p (vtime))
     {
       ivs[j].idx = i;
@@ -63,7 +63,7 @@ static int threads_vtime_check (uint32_t *nivs, struct idx_vtime *ivs)
   while (i < *nivs)
   {
     uint32_t thridx = ivs[i].idx;
-    vtime_t vtime = thread_states.ts[thridx].vtime;
+    vtime_t vtime = ddsrt_atomic_ld32 (&thread_states.ts[thridx].vtime);
     assert (vtime_awake_p (ivs[i].vtime));
     if (!vtime_gt (vtime, ivs[i].vtime))
       ++i;

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -679,9 +679,9 @@ static void rtps_term_prep (void)
 {
   /* Stop all I/O */
   ddsrt_mutex_lock (&gv.lock);
-  if (gv.rtps_keepgoing)
+  if (ddsrt_atomic_ld32 (&gv.rtps_keepgoing))
   {
-    gv.rtps_keepgoing = 0; /* so threads will stop once they get round to checking */
+    ddsrt_atomic_st32 (&gv.rtps_keepgoing, 0); /* so threads will stop once they get round to checking */
     ddsrt_atomic_fence ();
     /* can't wake up throttle_writer, currently, but it'll check every few seconds */
     trigger_recv_threads ();
@@ -1252,7 +1252,7 @@ int rtps_init (void)
 
   gv.gcreq_queue = gcreq_queue_new ();
 
-  gv.rtps_keepgoing = 1;
+  ddsrt_atomic_st32 (&gv.rtps_keepgoing, 1);
   ddsrt_rwlock_init (&gv.qoslock);
 
   if (config.xpack_send_async)

--- a/src/core/ddsi/src/q_plist.c
+++ b/src/core/ddsi/src/q_plist.c
@@ -712,9 +712,9 @@ static dds_return_t unalias_generic (void * __restrict dst, size_t * __restrict 
     {
       case XSTOP:
         return 0;
-      case XO: COMPLEX (XO, ddsi_octetseq_t, x->value = ddsrt_memdup (x->value, x->length)); break;
-      case XS: COMPLEX (XS, char *, *x = ddsrt_strdup (*x)); break;
-      case XZ: COMPLEX (XZ, ddsi_stringseq_t, {
+      case XO: COMPLEX (XO, ddsi_octetseq_t, if (x->value) { x->value = ddsrt_memdup (x->value, x->length); }); break;
+      case XS: COMPLEX (XS, char *, if (*x) { *x = ddsrt_strdup (*x); }); break;
+      case XZ: COMPLEX (XZ, ddsi_stringseq_t, if (x->n) {
         x->strs = ddsrt_memdup (x->strs, x->n * sizeof (*x->strs));
         for (uint32_t i = 0; i < x->n; i++)
           x->strs[i] = ddsrt_strdup (x->strs[i]);

--- a/src/core/ddsi/src/q_receive.c
+++ b/src/core/ddsi/src/q_receive.c
@@ -3156,7 +3156,7 @@ uint32_t listen_thread (struct ddsi_tran_listener * listener)
 {
   ddsi_tran_conn_t conn;
 
-  while (gv.rtps_keepgoing)
+  while (ddsrt_atomic_ld32 (&gv.rtps_keepgoing))
   {
     /* Accept connection from listener */
 
@@ -3310,7 +3310,7 @@ uint32_t recv_thread (void *vrecv_thread_arg)
   nn_rbufpool_setowner (rbpool, ddsrt_thread_self ());
   if (waitset == NULL)
   {
-    while (gv.rtps_keepgoing)
+    while (ddsrt_atomic_ld32 (&gv.rtps_keepgoing))
     {
       LOG_THREAD_CPUTIME (next_thread_cputime);
       (void) do_packet (ts1, recv_thread_arg->u.single.conn, NULL, rbpool);
@@ -3343,7 +3343,7 @@ uint32_t recv_thread (void *vrecv_thread_arg)
       num_fixed += (unsigned)rc;
     }
 
-    while (gv.rtps_keepgoing)
+    while (ddsrt_atomic_ld32 (&gv.rtps_keepgoing))
     {
       int rebuildws;
       LOG_THREAD_CPUTIME (next_thread_cputime);

--- a/src/core/ddsi/src/q_sockwaitset.c
+++ b/src/core/ddsi/src/q_sockwaitset.c
@@ -118,7 +118,7 @@ os_sockWaitset os_sockWaitsetNew (void)
   ws->ctx.nevs = 0;
   ws->ctx.index = 0;
   ws->ctx.evs_sz = sz;
-  if ((ws->ctx.evs = malloc (ws->ctx.evs_sz * sizeof (*ws->ctx.evs))) == NULL)
+  if ((ws->ctx.evs = ddsrt_malloc (ws->ctx.evs_sz * sizeof (*ws->ctx.evs))) == NULL)
     goto fail_ctx_evs;
   if ((ws->kqueue = kqueue ()) == -1)
     goto fail_kqueue;

--- a/src/core/ddsi/src/q_transmit.c
+++ b/src/core/ddsi/src/q_transmit.c
@@ -968,7 +968,7 @@ static dds_return_t throttle_writer (struct thread_state1 * const ts1, struct nn
     whc_get_state (wr->whc, &whcst);
   }
 
-  while (gv.rtps_keepgoing && !writer_may_continue (wr, &whcst))
+  while (ddsrt_atomic_ld32 (&gv.rtps_keepgoing) && !writer_may_continue (wr, &whcst))
   {
     int64_t reltimeout;
     tnow = now_mt ();

--- a/src/core/ddsi/src/q_transmit.c
+++ b/src/core/ddsi/src/q_transmit.c
@@ -1103,6 +1103,22 @@ static int write_sample_eot (struct thread_state1 * const ts1, struct nn_xpack *
       ddsrt_free (plist);
     }
   }
+  else if (addrset_empty (wr->as) && (wr->as_group == NULL || addrset_empty (wr->as_group)))
+  {
+    /* No network destination, so no point in doing all the work involved
+       in going all the way.  We do have to record that we "transmitted"
+       this sample, or it might not be retransmitted on request.
+
+      (Note that no network destination is very nearly the same as no
+      matching proxy readers.  The exception is the SPDP writer.) */
+    UPDATE_SEQ_XMIT_LOCKED (wr, seq);
+    ddsrt_mutex_unlock (&wr->e.lock);
+    if (plist != NULL)
+    {
+      nn_plist_fini (plist);
+      ddsrt_free (plist);
+    }
+  }
   else
   {
     /* Note the subtlety of enqueueing with the lock held but

--- a/src/core/ddsi/src/q_xevent.c
+++ b/src/core/ddsi/src/q_xevent.c
@@ -542,9 +542,9 @@ void xeventq_free (struct xeventq *evq)
       handle_nontimed_xevent (getnext_from_non_timed_xmit_list (evq), xp);
     }
     ddsrt_mutex_unlock (&evq->lock);
-    thread_state_asleep (lookup_thread_state ());
     nn_xpack_send (xp, false);
     nn_xpack_free (xp);
+    thread_state_asleep (lookup_thread_state ());
   }
 
   assert (ddsrt_avl_is_empty (&evq->msg_xevents));

--- a/src/core/ddsi/src/q_xevent.c
+++ b/src/core/ddsi/src/q_xevent.c
@@ -597,8 +597,8 @@ static void handle_xevk_heartbeat (struct nn_xpack *xp, struct xevent *ev, nn_mt
     return;
   }
 
-  assert (wr->reliable);
   ddsrt_mutex_lock (&wr->e.lock);
+  assert (wr->reliable);
   whc_get_state(wr->whc, &whcst);
   if (!writer_must_have_hb_scheduled (wr, &whcst))
   {

--- a/src/core/ddsi/src/q_xmsg.c
+++ b/src/core/ddsi/src/q_xmsg.c
@@ -52,7 +52,7 @@ struct nn_xmsgpool {
 struct nn_xmsg_data {
   InfoSRC_t src;
   InfoDST_t dst;
-  char payload[1]; /* of size maxsz */
+  char payload[]; /* of size maxsz */
 };
 
 struct nn_xmsg_chain_elem {

--- a/src/core/xtests/rhc_torture/rhc_torture.c
+++ b/src/core/xtests/rhc_torture/rhc_torture.c
@@ -982,6 +982,7 @@ int main (int argc, char **argv)
   for (size_t i = 0; i < sizeof (rres_iseq) / sizeof (rres_iseq[0]); i++)
     RhcTypes_T_free (&rres_mseq[i], DDS_FREE_CONTENTS);
 
+  ddsi_sertopic_unref (mdtopic);
   dds_delete(pp);
   return 0;
 }

--- a/src/ddsrt/include/dds/ddsrt/atomics.h
+++ b/src/ddsrt/include/dds/ddsrt/atomics.h
@@ -59,6 +59,34 @@ typedef ddsrt_atomic_uintptr_t ddsrt_atomic_voidp_t;
 #error "Atomic operations are not supported"
 #endif
 
+#if ! DDSRT_HAVE_ATOMIC64
+/* 64-bit atomics are not supported by all hardware, but it would be a shame not to use them when
+   they are available.  That necessitates an alternative implementation when they are not, either in
+   the form of a different implementation where it is used, or as an emulation using a mutex in
+   ddsrt.  It seems that the places where they'd be used end up adding a mutex, so an emulation in
+   ddsrt while being able to check whether it is supported by hardware is a sensible approach.  */
+DDS_EXPORT uint64_t ddsrt_atomic_ld64 (const volatile ddsrt_atomic_uint64_t *x);
+DDS_EXPORT void ddsrt_atomic_st64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
+DDS_EXPORT void ddsrt_atomic_inc64 (volatile ddsrt_atomic_uint64_t *x);
+DDS_EXPORT uint64_t ddsrt_atomic_inc64_nv (volatile ddsrt_atomic_uint64_t *x);
+DDS_EXPORT void ddsrt_atomic_dec64 (volatile ddsrt_atomic_uint64_t *x);
+DDS_EXPORT uint64_t ddsrt_atomic_dec64_nv (volatile ddsrt_atomic_uint64_t *x);
+DDS_EXPORT void ddsrt_atomic_add64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
+DDS_EXPORT uint64_t ddsrt_atomic_add64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
+DDS_EXPORT void ddsrt_atomic_sub64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
+DDS_EXPORT uint64_t ddsrt_atomic_sub64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
+DDS_EXPORT void ddsrt_atomic_and64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
+DDS_EXPORT uint64_t ddsrt_atomic_and64_ov (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
+DDS_EXPORT uint64_t ddsrt_atomic_and64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
+DDS_EXPORT void ddsrt_atomic_or64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
+DDS_EXPORT uint64_t ddsrt_atomic_or64_ov (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
+DDS_EXPORT uint64_t ddsrt_atomic_or64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
+DDS_EXPORT int ddsrt_atomic_cas64 (volatile ddsrt_atomic_uint64_t *x, uint64_t exp, uint64_t des);
+#endif
+
+void ddsrt_atomics_init (void);
+void ddsrt_atomics_fini (void);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/src/ddsrt/include/dds/ddsrt/atomics/arm.h
+++ b/src/ddsrt/include/dds/ddsrt/atomics/arm.h
@@ -85,6 +85,9 @@ inline void *ddsrt_atomic_addvoidp_nv (volatile ddsrt_atomic_voidp_t *x, ptrdiff
 inline void ddsrt_atomic_add32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
     (void) ddsrt_atomic_add32_nv (x, v);
 }
+inline uint32_t ddsrt_atomic_add32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+    return ddsrt_atomic_add32_nv (x, v) - v;
+}
 inline void ddsrt_atomic_addptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
     (void) ddsrt_atomic_addptr_nv (x, v);
 }
@@ -115,6 +118,9 @@ inline void ddsrt_atomic_subvoidp (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v
 
 /* INC */
 
+inline uint32_t ddsrt_atomic_inc32_ov (volatile ddsrt_atomic_uint32_t *x) {
+    return ddsrt_atomic_add32_nv (x, 1) - 1;
+}
 inline uint32_t ddsrt_atomic_inc32_nv (volatile ddsrt_atomic_uint32_t *x) {
     return ddsrt_atomic_add32_nv (x, 1);
 }
@@ -130,6 +136,9 @@ inline void ddsrt_atomic_incptr (volatile ddsrt_atomic_uintptr_t *x) {
 
 /* DEC */
 
+inline uint32_t ddsrt_atomic_dec32_ov (volatile ddsrt_atomic_uint32_t *x) {
+    return ddsrt_atomic_sub32_nv (x, 1) + 1;
+}
 inline uint32_t ddsrt_atomic_dec32_nv (volatile ddsrt_atomic_uint32_t *x) {
     return ddsrt_atomic_sub32_nv (x, 1);
 }

--- a/src/ddsrt/include/dds/ddsrt/atomics/gcc.h
+++ b/src/ddsrt/include/dds/ddsrt/atomics/gcc.h
@@ -318,10 +318,18 @@ inline void ddsrt_atomic_fence_ldld (void) {
 #endif
 }
 inline void ddsrt_atomic_fence_acq (void) {
+#if !(defined __i386__ || defined __x86_64__ || defined _M_IX86 || defined _M_X64)
   ddsrt_atomic_fence ();
+#else
+  asm volatile ("" ::: "memory");
+#endif
 }
 inline void ddsrt_atomic_fence_rel (void) {
+#if !(defined __i386__ || defined __x86_64__ || defined _M_IX86 || defined _M_X64)
   ddsrt_atomic_fence ();
+#else
+  asm volatile ("" ::: "memory");
+#endif
 }
 
 #if defined (__cplusplus)

--- a/src/ddsrt/include/dds/ddsrt/atomics/gcc.h
+++ b/src/ddsrt/include/dds/ddsrt/atomics/gcc.h
@@ -85,6 +85,9 @@ inline void ddsrt_atomic_inc64 (volatile ddsrt_atomic_uint64_t *x) {
 inline void ddsrt_atomic_incptr (volatile ddsrt_atomic_uintptr_t *x) {
   __sync_fetch_and_add (&x->v, 1);
 }
+inline uint32_t ddsrt_atomic_inc32_ov (volatile ddsrt_atomic_uint32_t *x) {
+  return __sync_fetch_and_add (&x->v, 1);
+}
 inline uint32_t ddsrt_atomic_inc32_nv (volatile ddsrt_atomic_uint32_t *x) {
   return __sync_add_and_fetch (&x->v, 1);
 }
@@ -149,6 +152,9 @@ inline void ddsrt_atomic_addptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v
 inline void ddsrt_atomic_addvoidp (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
   ddsrt_atomic_addptr ((volatile ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
 }
+inline uint32_t ddsrt_atomic_add32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+  return __sync_fetch_and_add (&x->v, v);
+}
 inline uint32_t ddsrt_atomic_add32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
   return __sync_add_and_fetch (&x->v, v);
 }
@@ -179,6 +185,9 @@ inline void ddsrt_atomic_subptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v
 }
 inline void ddsrt_atomic_subvoidp (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
   ddsrt_atomic_subptr ((volatile ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
+}
+inline uint32_t ddsrt_atomic_sub32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+  return __sync_fetch_and_sub (&x->v, v);
 }
 inline uint32_t ddsrt_atomic_sub32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
   return __sync_sub_and_fetch (&x->v, v);

--- a/src/ddsrt/include/dds/ddsrt/atomics/gcc.h
+++ b/src/ddsrt/include/dds/ddsrt/atomics/gcc.h
@@ -13,6 +13,7 @@
 #define DDSRT_ATOMICS_GCC_H
 
 #include "dds/ddsrt/misc.h"
+#include "dds/ddsrt/attributes.h"
 
 #if defined (__cplusplus)
 extern "C" {
@@ -25,19 +26,51 @@ extern "C" {
 
 /* LD, ST */
 
-inline uint32_t ddsrt_atomic_ld32(const volatile ddsrt_atomic_uint32_t *x) { return x->v; }
+ddsrt_attribute_no_sanitize (("thread"))
+inline uint32_t ddsrt_atomic_ld32(const volatile ddsrt_atomic_uint32_t *x)
+{
+  return x->v;
+}
 #if DDSRT_HAVE_ATOMIC64
-inline uint64_t ddsrt_atomic_ld64(const volatile ddsrt_atomic_uint64_t *x) { return x->v; }
+ddsrt_attribute_no_sanitize (("thread"))
+inline uint64_t ddsrt_atomic_ld64(const volatile ddsrt_atomic_uint64_t *x)
+{
+  return x->v;
+}
 #endif
-inline uintptr_t ddsrt_atomic_ldptr(const volatile ddsrt_atomic_uintptr_t *x) { return x->v; }
-inline void *ddsrt_atomic_ldvoidp(const volatile ddsrt_atomic_voidp_t *x) { return (void *) ddsrt_atomic_ldptr(x); }
+ddsrt_attribute_no_sanitize (("thread"))
+inline uintptr_t ddsrt_atomic_ldptr(const volatile ddsrt_atomic_uintptr_t *x)
+{
+  return x->v;
+}
+ddsrt_attribute_no_sanitize (("thread"))
+inline void *ddsrt_atomic_ldvoidp(const volatile ddsrt_atomic_voidp_t *x)
+{
+  return (void *) ddsrt_atomic_ldptr(x);
+}
 
-inline void ddsrt_atomic_st32(volatile ddsrt_atomic_uint32_t *x, uint32_t v) { x->v = v; }
+ddsrt_attribute_no_sanitize (("thread"))
+inline void ddsrt_atomic_st32(volatile ddsrt_atomic_uint32_t *x, uint32_t v)
+{
+  x->v = v;
+}
 #if DDSRT_HAVE_ATOMIC64
-inline void ddsrt_atomic_st64(volatile ddsrt_atomic_uint64_t *x, uint64_t v) { x->v = v; }
+ddsrt_attribute_no_sanitize (("thread"))
+inline void ddsrt_atomic_st64(volatile ddsrt_atomic_uint64_t *x, uint64_t v)
+{
+  x->v = v;
+}
 #endif
-inline void ddsrt_atomic_stptr(volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) { x->v = v; }
-inline void ddsrt_atomic_stvoidp(volatile ddsrt_atomic_voidp_t *x, void *v) { ddsrt_atomic_stptr(x, (uintptr_t)v); }
+ddsrt_attribute_no_sanitize (("thread"))
+inline void ddsrt_atomic_stptr(volatile ddsrt_atomic_uintptr_t *x, uintptr_t v)
+{
+  x->v = v;
+}
+ddsrt_attribute_no_sanitize (("thread"))
+inline void ddsrt_atomic_stvoidp(volatile ddsrt_atomic_voidp_t *x, void *v)
+{
+  ddsrt_atomic_stptr(x, (uintptr_t)v);
+}
 
 /* INC */
 

--- a/src/ddsrt/include/dds/ddsrt/atomics/msvc.h
+++ b/src/ddsrt/include/dds/ddsrt/atomics/msvc.h
@@ -74,6 +74,9 @@ inline void ddsrt_atomic_inc64 (volatile ddsrt_atomic_uint64_t *x) {
 inline void ddsrt_atomic_incptr (volatile ddsrt_atomic_uintptr_t *x) {
   DDSRT_ATOMIC_PTROP (InterlockedIncrement) (&x->v);
 }
+inline uint32_t ddsrt_atomic_inc32_ov (volatile ddsrt_atomic_uint32_t *x) {
+  return InterlockedIncrement (&x->v) - 1;
+}
 inline uint32_t ddsrt_atomic_inc32_nv (volatile ddsrt_atomic_uint32_t *x) {
   return InterlockedIncrement (&x->v);
 }
@@ -138,6 +141,9 @@ inline void ddsrt_atomic_addptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v
 inline void ddsrt_atomic_addvoidp (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
   ddsrt_atomic_addptr ((volatile ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
 }
+inline uint32_t ddsrt_atomic_add32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+  return InterlockedExchangeAdd (&x->v, v);
+}
 inline uint32_t ddsrt_atomic_add32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
   return InterlockedExchangeAdd (&x->v, v) + v;
 }
@@ -177,6 +183,12 @@ inline void ddsrt_atomic_subptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v
 }
 inline void ddsrt_atomic_subvoidp (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
   ddsrt_atomic_subptr ((volatile ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
+}
+inline uint32_t ddsrt_atomic_sub32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+  /* disable unary minus applied to unsigned type, result still unsigned */
+  DDSRT_WARNING_MSVC_OFF(4146)
+  return InterlockedExchangeAdd (&x->v, -v);
+  DDSRT_WARNING_MSVC_ON(4146)
 }
 inline uint32_t ddsrt_atomic_sub32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
   /* disable unary minus applied to unsigned type, result still unsigned */

--- a/src/ddsrt/include/dds/ddsrt/atomics/sun.h
+++ b/src/ddsrt/include/dds/ddsrt/atomics/sun.h
@@ -40,6 +40,11 @@ inline void ddsrt_atomic_inc64 (volatile ddsrt_atomic_uint64_t *x) {
 inline void ddsrt_atomic_incptr (volatile ddsrt_atomic_uintptr_t *x) {
   atomic_inc_ulong (&x->v);
 }
+inline uint32_t ddsrt_atomic_inc32_ov (volatile ddsrt_atomic_uint32_t *x) {
+  uint32_t oldval, newval;
+  do { oldval = x->v; newval = oldval + 1; } while (atomic_cas_32 (&x->v, oldval, newval) != oldval);
+  return oldval;
+}
 inline uint32_t ddsrt_atomic_inc32_nv (volatile ddsrt_atomic_uint32_t *x) {
   return atomic_inc_32_nv (&x->v);
 }
@@ -100,6 +105,9 @@ inline void ddsrt_atomic_addptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v
 inline void ddsrt_atomic_addvoidp (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
   atomic_add_ptr (&x->v, v);
 }
+inline uint32_t ddsrt_atomic_add32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+  return atomic_add_32_nv (&x->v, v) - v;
+}
 inline uint32_t ddsrt_atomic_add32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
   return atomic_add_32_nv (&x->v, v);
 }
@@ -126,6 +134,9 @@ inline void ddsrt_atomic_subptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v
 }
 inline void ddsrt_atomic_subvoidp (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
   atomic_add_ptr (&x->v, -v);
+}
+inline uint32_t ddsrt_atomic_sub32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+  return atomic_add_32_nv (&x->v, -v) + v;
 }
 inline uint32_t ddsrt_atomic_sub32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
   return atomic_add_32_nv (&x->v, -v);

--- a/src/ddsrt/include/dds/ddsrt/attributes.h
+++ b/src/ddsrt/include/dds/ddsrt/attributes.h
@@ -111,4 +111,16 @@
 # define ddsrt_attribute_packed
 #endif
 
+#if ddsrt_has_attribute(no_sanitize)
+# define ddsrt_attribute_no_sanitize(params) __attribute__ ((__no_sanitize__ params))
+#else
+# define ddsrt_attribute_no_sanitize(params)
+#endif
+
+#if defined(__has_feature)
+# define ddsrt_has_feature_thread_sanitizer __has_feature(thread_sanitizer)
+#else
+# define ddsrt_has_feature_thread_sanitizer 0
+#endif
+
 #endif /* DDSRT_ATTRIBUTES_H */

--- a/src/ddsrt/include/dds/ddsrt/hopscotch.h
+++ b/src/ddsrt/include/dds/ddsrt/hopscotch.h
@@ -20,15 +20,6 @@
 extern "C" {
 #endif
 
-/* Concurrent version */
-struct ddsrt_chh;
-struct ddsrt_chh_bucket;
-struct ddsrt_chh_iter {
-  struct ddsrt_chh_bucket *bs;
-  uint32_t size;
-  uint32_t cursor;
-};
-
 /*
  * The hopscotch hash table is dependent on a proper functioning hash.
  * If the hash function generates a lot of hash collisions, then it will
@@ -54,15 +45,6 @@ typedef int (*ddsrt_hh_equals_fn) (const void *, const void *);
  */
 typedef void (*ddsrt_hh_buckets_gc_fn) (void *);
 
-DDS_EXPORT struct ddsrt_chh *ddsrt_chh_new (uint32_t init_size, ddsrt_hh_hash_fn hash, ddsrt_hh_equals_fn equals, ddsrt_hh_buckets_gc_fn gc_buckets);
-DDS_EXPORT void ddsrt_chh_free (struct ddsrt_chh * __restrict hh);
-DDS_EXPORT void *ddsrt_chh_lookup (struct ddsrt_chh * __restrict rt, const void * __restrict template);
-DDS_EXPORT int ddsrt_chh_add (struct ddsrt_chh * __restrict rt, const void * __restrict data);
-DDS_EXPORT int ddsrt_chh_remove (struct ddsrt_chh * __restrict rt, const void * __restrict template);
-DDS_EXPORT void ddsrt_chh_enum_unsafe (struct ddsrt_chh * __restrict rt, void (*f) (void *a, void *f_arg), void *f_arg); /* may delete a */
-void *ddsrt_chh_iter_first (struct ddsrt_chh * __restrict rt, struct ddsrt_chh_iter *it);
-void *ddsrt_chh_iter_next (struct ddsrt_chh_iter *it);
-
 /* Sequential version */
 struct ddsrt_hh;
 
@@ -80,6 +62,31 @@ DDS_EXPORT void ddsrt_hh_enum (struct ddsrt_hh * __restrict rt, void (*f) (void 
 DDS_EXPORT void *ddsrt_hh_iter_first (struct ddsrt_hh * __restrict rt, struct ddsrt_hh_iter * __restrict iter); /* may delete nodes */
 DDS_EXPORT void *ddsrt_hh_iter_next (struct ddsrt_hh_iter * __restrict iter);
 
+/* Concurrent version */
+struct ddsrt_chh;
+struct ddsrt_chh_bucket;
+
+#if ! ddsrt_has_feature_thread_sanitizer
+struct ddsrt_chh_iter {
+  struct ddsrt_chh_bucket *bs;
+  uint32_t size;
+  uint32_t cursor;
+};
+#else
+struct ddsrt_chh_iter {
+  struct ddsrt_chh *chh;
+  struct ddsrt_hh_iter it;
+};
+#endif
+
+DDS_EXPORT struct ddsrt_chh *ddsrt_chh_new (uint32_t init_size, ddsrt_hh_hash_fn hash, ddsrt_hh_equals_fn equals, ddsrt_hh_buckets_gc_fn gc_buckets);
+DDS_EXPORT void ddsrt_chh_free (struct ddsrt_chh * __restrict hh);
+DDS_EXPORT void *ddsrt_chh_lookup (struct ddsrt_chh * __restrict rt, const void * __restrict template);
+DDS_EXPORT int ddsrt_chh_add (struct ddsrt_chh * __restrict rt, const void * __restrict data);
+DDS_EXPORT int ddsrt_chh_remove (struct ddsrt_chh * __restrict rt, const void * __restrict template);
+DDS_EXPORT void ddsrt_chh_enum_unsafe (struct ddsrt_chh * __restrict rt, void (*f) (void *a, void *f_arg), void *f_arg); /* may delete a */
+DDS_EXPORT void *ddsrt_chh_iter_first (struct ddsrt_chh * __restrict rt, struct ddsrt_chh_iter *it);
+DDS_EXPORT void *ddsrt_chh_iter_next (struct ddsrt_chh_iter *it);
 /* Sequential version, embedded data */
 struct ddsrt_ehh;
 

--- a/src/ddsrt/src/atomics.c
+++ b/src/ddsrt/src/atomics.c
@@ -30,6 +30,7 @@ extern inline void ddsrt_atomic_inc32 (volatile ddsrt_atomic_uint32_t *x);
 extern inline void ddsrt_atomic_inc64 (volatile ddsrt_atomic_uint64_t *x);
 #endif
 extern inline void ddsrt_atomic_incptr (volatile ddsrt_atomic_uintptr_t *x);
+extern inline uint32_t ddsrt_atomic_inc32_ov (volatile ddsrt_atomic_uint32_t *x);
 extern inline uint32_t ddsrt_atomic_inc32_nv (volatile ddsrt_atomic_uint32_t *x);
 #if DDSRT_HAVE_ATOMIC64
 extern inline uint64_t ddsrt_atomic_inc64_nv (volatile ddsrt_atomic_uint64_t *x);
@@ -58,6 +59,7 @@ extern inline void ddsrt_atomic_add64 (volatile ddsrt_atomic_uint64_t *x, uint64
 #endif
 extern inline void ddsrt_atomic_addptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v);
 extern inline void ddsrt_atomic_addvoidp (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v);
+extern inline uint32_t ddsrt_atomic_add32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v);
 extern inline uint32_t ddsrt_atomic_add32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v);
 #if DDSRT_HAVE_ATOMIC64
 extern inline uint64_t ddsrt_atomic_add64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
@@ -71,6 +73,7 @@ extern inline void ddsrt_atomic_sub64 (volatile ddsrt_atomic_uint64_t *x, uint64
 #endif
 extern inline void ddsrt_atomic_subptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v);
 extern inline void ddsrt_atomic_subvoidp (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v);
+extern inline uint32_t ddsrt_atomic_sub32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v);
 extern inline uint32_t ddsrt_atomic_sub32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v);
 #if DDSRT_HAVE_ATOMIC64
 extern inline uint64_t ddsrt_atomic_sub64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v);

--- a/src/ddsrt/src/cdtors.c
+++ b/src/ddsrt/src/cdtors.c
@@ -43,6 +43,7 @@ retry:
     ddsrt_time_init();
 #endif
     ddsrt_random_init();
+    ddsrt_atomics_init();
     ddsrt_atomic_or32(&init_status, INIT_STATUS_OK);
   } else {
     while (v > 1 && !(v & INIT_STATUS_OK)) {
@@ -68,6 +69,7 @@ void ddsrt_fini (void)
   {
     ddsrt_mutex_destroy(&init_mutex);
     ddsrt_random_fini();
+    ddsrt_atomics_fini();
 #if _WIN32
     ddsrt_winsock_fini();
     ddsrt_time_fini();

--- a/src/ddsrt/src/hopscotch.c
+++ b/src/ddsrt/src/hopscotch.c
@@ -12,6 +12,7 @@
 #include <assert.h>
 #include <string.h>
 
+#include "dds/ddsrt/attributes.h"
 #include "dds/ddsrt/atomics.h"
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/sync.h"
@@ -22,7 +23,228 @@
 
 #define NOT_A_BUCKET (~(uint32_t)0)
 
+/************* SEQUENTIAL VERSION ***************/
+
+struct ddsrt_hh_bucket {
+  uint32_t hopinfo;
+  void *data;
+};
+
+struct ddsrt_hh {
+  uint32_t size; /* power of 2 */
+  struct ddsrt_hh_bucket *buckets;
+  ddsrt_hh_hash_fn hash;
+  ddsrt_hh_equals_fn equals;
+};
+
+static void ddsrt_hh_init (struct ddsrt_hh *rt, uint32_t init_size, ddsrt_hh_hash_fn hash, ddsrt_hh_equals_fn equals)
+{
+  uint32_t size = HH_HOP_RANGE;
+  uint32_t i;
+  while (size < init_size) {
+    size *= 2;
+  }
+  rt->hash = hash;
+  rt->equals = equals;
+  rt->size = size;
+  rt->buckets = ddsrt_malloc (size * sizeof (*rt->buckets));
+  for (i = 0; i < size; i++) {
+    rt->buckets[i].hopinfo = 0;
+    rt->buckets[i].data = NULL;
+  }
+}
+
+static void ddsrt_hh_fini (struct ddsrt_hh *rt)
+{
+  ddsrt_free (rt->buckets);
+}
+
+struct ddsrt_hh *ddsrt_hh_new (uint32_t init_size, ddsrt_hh_hash_fn hash, ddsrt_hh_equals_fn equals)
+{
+  struct ddsrt_hh *hh = ddsrt_malloc (sizeof (*hh));
+  ddsrt_hh_init (hh, init_size, hash, equals);
+  return hh;
+}
+
+void ddsrt_hh_free (struct ddsrt_hh * __restrict hh)
+{
+  ddsrt_hh_fini (hh);
+  ddsrt_free (hh);
+}
+
+static void *ddsrt_hh_lookup_internal (const struct ddsrt_hh *rt, const uint32_t bucket, const void *template)
+{
+  const uint32_t idxmask = rt->size - 1;
+  uint32_t hopinfo = rt->buckets[bucket].hopinfo;
+  uint32_t idx;
+  for (idx = 0; hopinfo != 0; hopinfo >>= 1, idx++) {
+    const uint32_t bidx = (bucket + idx) & idxmask;
+    void *data = rt->buckets[bidx].data;
+    if (data && rt->equals (data, template))
+      return data;
+  }
+  return NULL;
+}
+
+void *ddsrt_hh_lookup (const struct ddsrt_hh * __restrict rt, const void * __restrict template)
+{
+  const uint32_t hash = rt->hash (template);
+  const uint32_t idxmask = rt->size - 1;
+  const uint32_t bucket = hash & idxmask;
+  return ddsrt_hh_lookup_internal (rt, bucket, template);
+}
+
+static uint32_t ddsrt_hh_find_closer_free_bucket (struct ddsrt_hh *rt, uint32_t free_bucket, uint32_t *free_distance)
+{
+  const uint32_t idxmask = rt->size - 1;
+  uint32_t move_bucket, free_dist;
+  move_bucket = (free_bucket - (HH_HOP_RANGE - 1)) & idxmask;
+  for (free_dist = HH_HOP_RANGE - 1; free_dist > 0; free_dist--) {
+    uint32_t move_free_distance = NOT_A_BUCKET;
+    uint32_t mask = 1;
+    uint32_t i;
+    for (i = 0; i < free_dist; i++, mask <<= 1) {
+      if (mask & rt->buckets[move_bucket].hopinfo) {
+        move_free_distance = i;
+        break;
+      }
+    }
+    if (move_free_distance != NOT_A_BUCKET) {
+      uint32_t new_free_bucket = (move_bucket + move_free_distance) & idxmask;
+      rt->buckets[move_bucket].hopinfo |= 1u << free_dist;
+      rt->buckets[free_bucket].data = rt->buckets[new_free_bucket].data;
+      rt->buckets[new_free_bucket].data = NULL;
+      rt->buckets[move_bucket].hopinfo &= ~(1u << move_free_distance);
+      *free_distance -= free_dist - move_free_distance;
+      return new_free_bucket;
+    }
+    move_bucket = (move_bucket + 1) & idxmask;
+  }
+  return NOT_A_BUCKET;
+}
+
+static void ddsrt_hh_resize (struct ddsrt_hh *rt)
+{
+  struct ddsrt_hh_bucket *bs1;
+  uint32_t i, idxmask0, idxmask1;
+
+  bs1 = ddsrt_malloc (2 * rt->size * sizeof (*rt->buckets));
+
+  for (i = 0; i < 2 * rt->size; i++) {
+    bs1[i].hopinfo = 0;
+    bs1[i].data = NULL;
+  }
+  idxmask0 = rt->size - 1;
+  idxmask1 = 2 * rt->size - 1;
+  for (i = 0; i < rt->size; i++) {
+    void *data = rt->buckets[i].data;
+    if (data) {
+      const uint32_t hash = rt->hash (data);
+      const uint32_t old_start_bucket = hash & idxmask0;
+      const uint32_t new_start_bucket = hash & idxmask1;
+      const uint32_t dist = (i >= old_start_bucket) ? (i - old_start_bucket) : (rt->size + i - old_start_bucket);
+      const uint32_t newb = (new_start_bucket + dist) & idxmask1;
+      assert (dist < HH_HOP_RANGE);
+      bs1[new_start_bucket].hopinfo |= 1u << dist;
+      bs1[newb].data = data;
+    }
+  }
+
+  ddsrt_free (rt->buckets);
+  rt->size *= 2;
+  rt->buckets = bs1;
+}
+
+int ddsrt_hh_add (struct ddsrt_hh * __restrict rt, const void * __restrict data)
+{
+  const uint32_t hash = rt->hash (data);
+  const uint32_t idxmask = rt->size - 1;
+  const uint32_t start_bucket = hash & idxmask;
+  uint32_t free_distance, free_bucket;
+
+  if (ddsrt_hh_lookup_internal (rt, start_bucket, data)) {
+    return 0;
+  }
+
+  free_bucket = start_bucket;
+  for (free_distance = 0; free_distance < HH_ADD_RANGE; free_distance++) {
+    if (rt->buckets[free_bucket].data == NULL)
+      break;
+    free_bucket = (free_bucket + 1) & idxmask;
+  }
+  if (free_distance < HH_ADD_RANGE) {
+    do {
+      if (free_distance < HH_HOP_RANGE) {
+        assert ((uint32_t) free_bucket == ((start_bucket + free_distance) & idxmask));
+        rt->buckets[start_bucket].hopinfo |= 1u << free_distance;
+        rt->buckets[free_bucket].data = (void *) data;
+        return 1;
+      }
+      free_bucket = ddsrt_hh_find_closer_free_bucket (rt, free_bucket, &free_distance);
+      assert (free_bucket == NOT_A_BUCKET || free_bucket <= idxmask);
+    } while (free_bucket != NOT_A_BUCKET);
+  }
+
+  ddsrt_hh_resize (rt);
+  return ddsrt_hh_add (rt, data);
+}
+
+int ddsrt_hh_remove (struct ddsrt_hh * __restrict rt, const void * __restrict template)
+{
+  const uint32_t hash = rt->hash (template);
+  const uint32_t idxmask = rt->size - 1;
+  const uint32_t bucket = hash & idxmask;
+  uint32_t hopinfo;
+  uint32_t idx;
+  hopinfo = rt->buckets[bucket].hopinfo;
+  for (idx = 0; hopinfo != 0; hopinfo >>= 1, idx++) {
+    if (hopinfo & 1) {
+      const uint32_t bidx = (bucket + idx) & idxmask;
+      void *data = rt->buckets[bidx].data;
+      if (data && rt->equals (data, template)) {
+        rt->buckets[bidx].data = NULL;
+        rt->buckets[bucket].hopinfo &= ~(1u << idx);
+        return 1;
+      }
+    }
+  }
+  return 0;
+}
+
+void ddsrt_hh_enum (struct ddsrt_hh * __restrict rt, void (*f) (void *a, void *f_arg), void *f_arg)
+{
+  uint32_t i;
+  for (i = 0; i < rt->size; i++) {
+    void *data = rt->buckets[i].data;
+    if (data) {
+      f (data, f_arg);
+    }
+  }
+}
+
+void *ddsrt_hh_iter_first (struct ddsrt_hh * __restrict rt, struct ddsrt_hh_iter * __restrict iter)
+{
+  iter->hh = rt;
+  iter->cursor = 0;
+  return ddsrt_hh_iter_next (iter);
+}
+
+void *ddsrt_hh_iter_next (struct ddsrt_hh_iter * __restrict iter)
+{
+  struct ddsrt_hh *rt = iter->hh;
+  while (iter->cursor < rt->size) {
+    void *data = rt->buckets[iter->cursor].data;
+    iter->cursor++;
+    if (data) {
+      return data;
+    }
+  }
+  return NULL;
+}
+
 /********** CONCURRENT VERSION ************/
+
+#if ! ddsrt_has_feature_thread_sanitizer
 
 #define N_BACKING_LOCKS 32
 #define N_RESIZE_LOCKS 8
@@ -228,7 +450,7 @@ static void *ddsrt_chh_lookup_internal (struct ddsrt_chh_bucket_array const * co
 
 #define ddsrt_atomic_rmw32_nonatomic(var_, tmp_, expr_) do {                 \
         ddsrt_atomic_uint32_t *var__ = (var_);                               \
-        uint32_t tmp_ = ddsrt_atomic_ld32 (var__);                          \
+        uint32_t tmp_ = ddsrt_atomic_ld32 (var__);                           \
         ddsrt_atomic_st32 (var__, (expr_));                                  \
     } while (0)
 
@@ -467,224 +689,78 @@ void *ddsrt_chh_iter_first (struct ddsrt_chh * __restrict rt, struct ddsrt_chh_i
   return ddsrt_chh_iter_next (it);
 }
 
-/************* SEQUENTIAL VERSION ***************/
+#else
 
-struct ddsrt_hh_bucket {
-    uint32_t hopinfo;
-    void *data;
+struct ddsrt_chh {
+  ddsrt_mutex_t lock;
+  struct ddsrt_hh rt;
 };
 
-struct ddsrt_hh {
-    uint32_t size; /* power of 2 */
-    struct ddsrt_hh_bucket *buckets;
-    ddsrt_hh_hash_fn hash;
-    ddsrt_hh_equals_fn equals;
-};
-
-static void ddsrt_hh_init (struct ddsrt_hh *rt, uint32_t init_size, ddsrt_hh_hash_fn hash, ddsrt_hh_equals_fn equals)
+struct ddsrt_chh *ddsrt_chh_new (uint32_t init_size, ddsrt_hh_hash_fn hash, ddsrt_hh_equals_fn equals, ddsrt_hh_buckets_gc_fn gc)
 {
-    uint32_t size = HH_HOP_RANGE;
-    uint32_t i;
-    while (size < init_size) {
-        size *= 2;
-    }
-    rt->hash = hash;
-    rt->equals = equals;
-    rt->size = size;
-    rt->buckets = ddsrt_malloc (size * sizeof (*rt->buckets));
-    for (i = 0; i < size; i++) {
-        rt->buckets[i].hopinfo = 0;
-        rt->buckets[i].data = NULL;
-    }
+  struct ddsrt_chh *hh = ddsrt_malloc (sizeof (*hh));
+  (void) gc;
+  ddsrt_mutex_init (&hh->lock);
+  ddsrt_hh_init (&hh->rt, init_size, hash, equals);
+  return hh;
 }
 
-static void ddsrt_hh_fini (struct ddsrt_hh *rt)
+void ddsrt_chh_free (struct ddsrt_chh * __restrict hh)
 {
-    ddsrt_free (rt->buckets);
+  ddsrt_hh_fini (&hh->rt);
+  ddsrt_mutex_destroy (&hh->lock);
+  ddsrt_free (hh);
 }
 
-struct ddsrt_hh *ddsrt_hh_new (uint32_t init_size, ddsrt_hh_hash_fn hash, ddsrt_hh_equals_fn equals)
+void *ddsrt_chh_lookup (struct ddsrt_chh * __restrict hh, const void * __restrict template)
 {
-    struct ddsrt_hh *hh = ddsrt_malloc (sizeof (*hh));
-    ddsrt_hh_init (hh, init_size, hash, equals);
-    return hh;
+  ddsrt_mutex_lock (&hh->lock);
+  void *x = ddsrt_hh_lookup (&hh->rt, template);
+  ddsrt_mutex_unlock (&hh->lock);
+  return x;
 }
 
-void ddsrt_hh_free (struct ddsrt_hh * __restrict hh)
+int ddsrt_chh_add (struct ddsrt_chh * __restrict hh, const void * __restrict data)
 {
-    ddsrt_hh_fini (hh);
-    ddsrt_free (hh);
+  ddsrt_mutex_lock (&hh->lock);
+  int x = ddsrt_hh_add (&hh->rt, data);
+  ddsrt_mutex_unlock (&hh->lock);
+  return x;
 }
 
-static void *ddsrt_hh_lookup_internal (const struct ddsrt_hh *rt, const uint32_t bucket, const void *template)
+int ddsrt_chh_remove (struct ddsrt_chh * __restrict hh, const void * __restrict template)
 {
-    const uint32_t idxmask = rt->size - 1;
-    uint32_t hopinfo = rt->buckets[bucket].hopinfo;
-    uint32_t idx;
-    for (idx = 0; hopinfo != 0; hopinfo >>= 1, idx++) {
-        const uint32_t bidx = (bucket + idx) & idxmask;
-        void *data = rt->buckets[bidx].data;
-        if (data && rt->equals (data, template))
-            return data;
-    }
-    return NULL;
+  ddsrt_mutex_lock (&hh->lock);
+  int x = ddsrt_hh_remove (&hh->rt, template);
+  ddsrt_mutex_unlock (&hh->lock);
+  return x;
 }
 
-void *ddsrt_hh_lookup (const struct ddsrt_hh * __restrict rt, const void * __restrict template)
+void ddsrt_chh_enum_unsafe (struct ddsrt_chh * __restrict hh, void (*f) (void *a, void *f_arg), void *f_arg)
 {
-    const uint32_t hash = rt->hash (template);
-    const uint32_t idxmask = rt->size - 1;
-    const uint32_t bucket = hash & idxmask;
-    return ddsrt_hh_lookup_internal (rt, bucket, template);
+  ddsrt_mutex_lock (&hh->lock);
+  ddsrt_hh_enum (&hh->rt, f, f_arg);
+  ddsrt_mutex_unlock (&hh->lock);
 }
 
-static uint32_t ddsrt_hh_find_closer_free_bucket (struct ddsrt_hh *rt, uint32_t free_bucket, uint32_t *free_distance)
+void *ddsrt_chh_iter_first (struct ddsrt_chh * __restrict hh, struct ddsrt_chh_iter *it)
 {
-    const uint32_t idxmask = rt->size - 1;
-    uint32_t move_bucket, free_dist;
-    move_bucket = (free_bucket - (HH_HOP_RANGE - 1)) & idxmask;
-    for (free_dist = HH_HOP_RANGE - 1; free_dist > 0; free_dist--) {
-        uint32_t move_free_distance = NOT_A_BUCKET;
-        uint32_t mask = 1;
-        uint32_t i;
-        for (i = 0; i < free_dist; i++, mask <<= 1) {
-            if (mask & rt->buckets[move_bucket].hopinfo) {
-                move_free_distance = i;
-                break;
-            }
-        }
-        if (move_free_distance != NOT_A_BUCKET) {
-            uint32_t new_free_bucket = (move_bucket + move_free_distance) & idxmask;
-            rt->buckets[move_bucket].hopinfo |= 1u << free_dist;
-            rt->buckets[free_bucket].data = rt->buckets[new_free_bucket].data;
-            rt->buckets[new_free_bucket].data = NULL;
-            rt->buckets[move_bucket].hopinfo &= ~(1u << move_free_distance);
-            *free_distance -= free_dist - move_free_distance;
-            return new_free_bucket;
-        }
-        move_bucket = (move_bucket + 1) & idxmask;
-    }
-    return NOT_A_BUCKET;
+  ddsrt_mutex_lock (&hh->lock);
+  it->chh = hh;
+  void *x = ddsrt_hh_iter_first (&hh->rt, &it->it);
+  ddsrt_mutex_unlock (&hh->lock);
+  return x;
 }
 
-static void ddsrt_hh_resize (struct ddsrt_hh *rt)
+void *ddsrt_chh_iter_next (struct ddsrt_chh_iter *it)
 {
-    struct ddsrt_hh_bucket *bs1;
-    uint32_t i, idxmask0, idxmask1;
-
-    bs1 = ddsrt_malloc (2 * rt->size * sizeof (*rt->buckets));
-
-    for (i = 0; i < 2 * rt->size; i++) {
-        bs1[i].hopinfo = 0;
-        bs1[i].data = NULL;
-    }
-    idxmask0 = rt->size - 1;
-    idxmask1 = 2 * rt->size - 1;
-    for (i = 0; i < rt->size; i++) {
-        void *data = rt->buckets[i].data;
-        if (data) {
-            const uint32_t hash = rt->hash (data);
-            const uint32_t old_start_bucket = hash & idxmask0;
-            const uint32_t new_start_bucket = hash & idxmask1;
-            const uint32_t dist = (i >= old_start_bucket) ? (i - old_start_bucket) : (rt->size + i - old_start_bucket);
-            const uint32_t newb = (new_start_bucket + dist) & idxmask1;
-            assert (dist < HH_HOP_RANGE);
-            bs1[new_start_bucket].hopinfo |= 1u << dist;
-            bs1[newb].data = data;
-        }
-    }
-
-    ddsrt_free (rt->buckets);
-    rt->size *= 2;
-    rt->buckets = bs1;
+  ddsrt_mutex_lock (&it->chh->lock);
+  void *x = ddsrt_hh_iter_next (&it->it);
+  ddsrt_mutex_unlock (&it->chh->lock);
+  return x;
 }
 
-int ddsrt_hh_add (struct ddsrt_hh * __restrict rt, const void * __restrict data)
-{
-    const uint32_t hash = rt->hash (data);
-    const uint32_t idxmask = rt->size - 1;
-    const uint32_t start_bucket = hash & idxmask;
-    uint32_t free_distance, free_bucket;
-
-    if (ddsrt_hh_lookup_internal (rt, start_bucket, data)) {
-        return 0;
-    }
-
-    free_bucket = start_bucket;
-    for (free_distance = 0; free_distance < HH_ADD_RANGE; free_distance++) {
-        if (rt->buckets[free_bucket].data == NULL)
-            break;
-        free_bucket = (free_bucket + 1) & idxmask;
-    }
-    if (free_distance < HH_ADD_RANGE) {
-        do {
-            if (free_distance < HH_HOP_RANGE) {
-                assert ((uint32_t) free_bucket == ((start_bucket + free_distance) & idxmask));
-                rt->buckets[start_bucket].hopinfo |= 1u << free_distance;
-                rt->buckets[free_bucket].data = (void *) data;
-                return 1;
-            }
-            free_bucket = ddsrt_hh_find_closer_free_bucket (rt, free_bucket, &free_distance);
-            assert (free_bucket == NOT_A_BUCKET || free_bucket <= idxmask);
-        } while (free_bucket != NOT_A_BUCKET);
-    }
-
-    ddsrt_hh_resize (rt);
-    return ddsrt_hh_add (rt, data);
-}
-
-int ddsrt_hh_remove (struct ddsrt_hh * __restrict rt, const void * __restrict template)
-{
-    const uint32_t hash = rt->hash (template);
-    const uint32_t idxmask = rt->size - 1;
-    const uint32_t bucket = hash & idxmask;
-    uint32_t hopinfo;
-    uint32_t idx;
-    hopinfo = rt->buckets[bucket].hopinfo;
-    for (idx = 0; hopinfo != 0; hopinfo >>= 1, idx++) {
-        if (hopinfo & 1) {
-            const uint32_t bidx = (bucket + idx) & idxmask;
-            void *data = rt->buckets[bidx].data;
-            if (data && rt->equals (data, template)) {
-                rt->buckets[bidx].data = NULL;
-                rt->buckets[bucket].hopinfo &= ~(1u << idx);
-                return 1;
-            }
-        }
-    }
-    return 0;
-}
-
-void ddsrt_hh_enum (struct ddsrt_hh * __restrict rt, void (*f) (void *a, void *f_arg), void *f_arg)
-{
-    uint32_t i;
-    for (i = 0; i < rt->size; i++) {
-        void *data = rt->buckets[i].data;
-        if (data) {
-            f (data, f_arg);
-        }
-    }
-}
-
-void *ddsrt_hh_iter_first (struct ddsrt_hh * __restrict rt, struct ddsrt_hh_iter * __restrict iter)
-{
-    iter->hh = rt;
-    iter->cursor = 0;
-    return ddsrt_hh_iter_next (iter);
-}
-
-void *ddsrt_hh_iter_next (struct ddsrt_hh_iter * __restrict iter)
-{
-    struct ddsrt_hh *rt = iter->hh;
-    while (iter->cursor < rt->size) {
-        void *data = rt->buckets[iter->cursor].data;
-        iter->cursor++;
-        if (data) {
-            return data;
-        }
-    }
-    return NULL;
-}
+#endif
 
 /************* SEQUENTIAL VERSION WITH EMBEDDED DATA ***************/
 

--- a/src/mpt/tests/qos/ppuserdata.c
+++ b/src/mpt/tests/qos/ppuserdata.c
@@ -27,8 +27,8 @@ MPT_Test(qos, ppuserdata, .init=ppud_init, .fini=ppud_fini);
 /*
  * Checks whether reader/writer user_data QoS changes work.
  */
-#define TEST_A_ARGS MPT_ArgValues(DDS_DOMAIN_DEFAULT, "rwuserdata", true, 10)
-#define TEST_B_ARGS MPT_ArgValues(DDS_DOMAIN_DEFAULT, "rwuserdata", false, 0)
+#define TEST_A_ARGS MPT_ArgValues(DDS_DOMAIN_DEFAULT, "rwuserdata", true, 10, RWUD_USERDATA)
+#define TEST_B_ARGS MPT_ArgValues(DDS_DOMAIN_DEFAULT, "rwuserdata", false, 0, RWUD_USERDATA)
 MPT_TestProcess(qos, rwuserdata, a, rwud, TEST_A_ARGS);
 MPT_TestProcess(qos, rwuserdata, b, rwud, TEST_B_ARGS);
 MPT_Test(qos, rwuserdata, .init=ppud_init, .fini=ppud_fini);
@@ -38,10 +38,10 @@ MPT_Test(qos, rwuserdata, .init=ppud_init, .fini=ppud_fini);
 /*
  * Checks whether topic_data QoS changes become visible in reader/writer.
  */
-#define TEST_A_ARGS MPT_ArgValues(DDS_DOMAIN_DEFAULT, "rwtopicdata", true, 10)
-#define TEST_B_ARGS MPT_ArgValues(DDS_DOMAIN_DEFAULT, "rwtopicdata", false, 0)
-MPT_TestProcess(qos, rwtopicdata, a, rwtd, TEST_A_ARGS);
-MPT_TestProcess(qos, rwtopicdata, b, rwtd, TEST_B_ARGS);
+#define TEST_A_ARGS MPT_ArgValues(DDS_DOMAIN_DEFAULT, "rwtopicdata", true, 10, RWUD_TOPICDATA)
+#define TEST_B_ARGS MPT_ArgValues(DDS_DOMAIN_DEFAULT, "rwtopicdata", false, 0, RWUD_TOPICDATA)
+MPT_TestProcess(qos, rwtopicdata, a, rwud, TEST_A_ARGS);
+MPT_TestProcess(qos, rwtopicdata, b, rwud, TEST_B_ARGS);
 MPT_Test(qos, rwtopicdata, .init=ppud_init, .fini=ppud_fini);
 #undef TEST_A_ARGS
 #undef TEST_B_ARGS
@@ -49,10 +49,10 @@ MPT_Test(qos, rwtopicdata, .init=ppud_init, .fini=ppud_fini);
 /*
  * Checks whether group_data QoS changes become visible in reader/writer.
  */
-#define TEST_A_ARGS MPT_ArgValues(DDS_DOMAIN_DEFAULT, "rwgroupdata", true, 10)
-#define TEST_B_ARGS MPT_ArgValues(DDS_DOMAIN_DEFAULT, "rwgroupdata", false, 0)
-MPT_TestProcess(qos, rwgroupdata, a, rwgd, TEST_A_ARGS);
-MPT_TestProcess(qos, rwgroupdata, b, rwgd, TEST_B_ARGS);
+#define TEST_A_ARGS MPT_ArgValues(DDS_DOMAIN_DEFAULT, "rwgroupdata", true, 10, RWUD_GROUPDATA)
+#define TEST_B_ARGS MPT_ArgValues(DDS_DOMAIN_DEFAULT, "rwgroupdata", false, 0, RWUD_GROUPDATA)
+MPT_TestProcess(qos, rwgroupdata, a, rwud, TEST_A_ARGS);
+MPT_TestProcess(qos, rwgroupdata, b, rwud, TEST_B_ARGS);
 MPT_Test(qos, rwgroupdata, .init=ppud_init, .fini=ppud_fini);
 #undef TEST_A_ARGS
 #undef TEST_B_ARGS

--- a/src/mpt/tests/qos/procs/ppud.c
+++ b/src/mpt/tests/qos/procs/ppud.c
@@ -98,8 +98,8 @@ MPT_ProcessEntry (ppud,
             exp = "X";
           const size_t expsz = strlen (exp);
           bool eq = (usz == expsz && (usz == 0 || memcmp (ud, exp, usz) == 0));
-          printf ("%d: expected %u %zu/%s received %zu/%s\n",
-                  id, exp_index, expsz, exp, usz, ud ? (char *) ud : "(null)");
+          //printf ("%d: expected %u %zu/%s received %zu/%s\n",
+          //        id, exp_index, expsz, exp, usz, ud ? (char *) ud : "(null)");
           MPT_ASSERT (eq, "User data mismatch: expected %u %zu/%s received %zu/%s\n",
                       exp_index, expsz, exp, usz, ud ? (char *) ud : "(null)");
           if (strcmp (exp, "X") != 0 && ++exp_index == sizeof (exp_ud) / sizeof (exp_ud[0]))
@@ -235,8 +235,8 @@ MPT_ProcessEntry (rwud,
             exp = "X";
           const size_t expsz = first ? 1 : strlen (exp);
           bool eq = (usz == expsz && (usz == 0 || memcmp (ud, exp, usz) == 0));
-          printf ("%d: expected %u %zu/%s received %zu/%s\n",
-                  id, exp_index, expsz, exp, usz, ud ? (char *) ud : "(null)");
+          //printf ("%d: expected %u %zu/%s received %zu/%s\n",
+          //        id, exp_index, expsz, exp, usz, ud ? (char *) ud : "(null)");
           MPT_ASSERT (eq, "User data mismatch: expected %u %zu/%s received %zu/%s\n",
                       exp_index, expsz, exp, usz, ud ? (char *) ud : "(null)");
           if (strcmp (exp, "X") != 0 && ++exp_index == sizeof (exp_ud) / sizeof (exp_ud[0]))
@@ -372,8 +372,8 @@ MPT_ProcessEntry (rwtd,
             exp = "X";
           const size_t expsz = first ? 1 : strlen (exp);
           bool eq = (tsz == expsz && (tsz == 0 || memcmp (td, exp, tsz) == 0));
-          printf ("%d: expected %u %zu/%s received %zu/%s\n",
-                  id, exp_index, expsz, exp, tsz, td ? (char *) td : "(null)");
+          //printf ("%d: expected %u %zu/%s received %zu/%s\n",
+          //        id, exp_index, expsz, exp, tsz, td ? (char *) td : "(null)");
           MPT_ASSERT (eq, "Topic data mismatch: expected %u %zu/%s received %zu/%s\n",
                       exp_index, expsz, exp, tsz, td ? (char *) td : "(null)");
           if (strcmp (exp, "X") != 0 && ++exp_index == sizeof (exp_ud) / sizeof (exp_ud[0]))
@@ -511,8 +511,8 @@ MPT_ProcessEntry (rwgd,
             exp = "X";
           const size_t expsz = first ? 1 : strlen (exp);
           bool eq = (gsz == expsz && (gsz == 0 || memcmp (gd, exp, gsz) == 0));
-          printf ("%d: expected %u %zu/%s received %zu/%s\n",
-                  id, exp_index, expsz, exp, gsz, gd ? (char *) gd : "(null)");
+          //printf ("%d: expected %u %zu/%s received %zu/%s\n",
+          //        id, exp_index, expsz, exp, gsz, gd ? (char *) gd : "(null)");
           MPT_ASSERT (eq, "Group data mismatch: expected %u %zu/%s received %zu/%s\n",
                       exp_index, expsz, exp, gsz, gd ? (char *) gd : "(null)");
           if (strcmp (exp, "X") != 0 && ++exp_index == sizeof (exp_ud) / sizeof (exp_ud[0]))

--- a/src/mpt/tests/qos/procs/ppud.c
+++ b/src/mpt/tests/qos/procs/ppud.c
@@ -154,16 +154,21 @@ MPT_ProcessEntry (ppud,
   dds_delete_qos (qos);
   rc = dds_delete (dp);
   MPT_ASSERT_EQ (rc, DDS_RETCODE_OK, "teardown failed\n");
-  printf ("=== [Publisher(%d)] Done\n", id);
+  printf ("=== [Check(%d)] Done\n", id);
 }
 
 MPT_ProcessEntry (rwud,
                   MPT_Args (dds_domainid_t domainid,
                             const char *topic_name,
                             bool active,
-                            unsigned ncycles))
+                            unsigned ncycles,
+                            enum rwud which))
 {
-  dds_entity_t dp, tp, ep, rdep, ws;
+  bool (*qget) (const dds_qos_t * __restrict qos, void **value, size_t *sz) = 0;
+  void (*qset) (dds_qos_t * __restrict qos, const void *value, size_t sz) = 0;
+  const char *qname = "UNDEFINED";
+
+  dds_entity_t dp, tp, ep, rdep, qent = 0, ws;
   dds_return_t rc;
   dds_qos_t *qos;
   int id = (int) ddsrt_getpid ();
@@ -196,6 +201,29 @@ MPT_ProcessEntry (rwud,
   MPT_ASSERT_FATAL_GT (ws, 0, "Could not create waitset: %s\n", dds_strretcode (ws));
   rc = dds_waitset_attach (ws, rdep, 0);
   MPT_ASSERT_FATAL_EQ (rc, 0, "Could not attach built-in reader to waitset: %s\n", dds_strretcode (rc));
+
+  switch (which)
+  {
+    case RWUD_USERDATA:
+      qget = dds_qget_userdata;
+      qset = dds_qset_userdata;
+      qname = "user data";
+      qent = ep;
+      break;
+    case RWUD_GROUPDATA:
+      qget = dds_qget_groupdata;
+      qset = dds_qset_groupdata;
+      qname = "group data";
+      qent = dds_get_parent (ep);
+      MPT_ASSERT_FATAL_GT (qent, 0, "Could not get pub/sub from wr/rd: %s\n", dds_strretcode (qent));
+      break;
+    case RWUD_TOPICDATA:
+      qget = dds_qget_topicdata;
+      qset = dds_qset_topicdata;
+      qname = "topic data";
+      qent = tp;
+      break;
+  }
 
   bool done = false;
   bool first = true;
@@ -220,12 +248,12 @@ MPT_ProcessEntry (rwud,
       {
         void *ud = NULL;
         size_t usz = 0;
-        if (!dds_qget_userdata (sample->qos, &ud, &usz))
-          printf ("%d: user data not set in QoS\n", id);
+        if (!qget (sample->qos, &ud, &usz))
+          printf ("%d: group data not set in QoS\n", id);
         if (first && usz == 0)
         {
-          dds_qset_userdata (qos, "X", 1);
-          rc = dds_set_qos (ep, qos);
+          qset (qos, "X", 1);
+          rc = dds_set_qos (qent, qos);
           MPT_ASSERT_EQ (rc, DDS_RETCODE_OK, "Set QoS failed: %s\n", dds_strretcode (rc));
         }
         else
@@ -237,8 +265,8 @@ MPT_ProcessEntry (rwud,
           bool eq = (usz == expsz && (usz == 0 || memcmp (ud, exp, usz) == 0));
           //printf ("%d: expected %u %zu/%s received %zu/%s\n",
           //        id, exp_index, expsz, exp, usz, ud ? (char *) ud : "(null)");
-          MPT_ASSERT (eq, "User data mismatch: expected %u %zu/%s received %zu/%s\n",
-                      exp_index, expsz, exp, usz, ud ? (char *) ud : "(null)");
+          MPT_ASSERT (eq, "%s mismatch: expected %u %zu/%s received %zu/%s\n",
+                      qname, exp_index, expsz, exp, usz, ud ? (char *) ud : "(null)");
           if (strcmp (exp, "X") != 0 && ++exp_index == sizeof (exp_ud) / sizeof (exp_ud[0]))
           {
             exp_index = 0;
@@ -253,17 +281,17 @@ MPT_ProcessEntry (rwud,
             size_t newusz;
             if (!active)
             {
-              /* Set user data to the same value in response */
+              /* Set group data to the same value in response */
               newud = ud; newusz = usz;
-              dds_qset_userdata (qos, ud, usz);
+              qset (qos, ud, usz);
             }
             else /* Set next agreed value */
             {
               newud = exp_ud[exp_index]; newusz = strlen (exp_ud[exp_index]);
-              dds_qset_userdata (qos, newud, newusz);
+              qset (qos, newud, newusz);
             }
 
-            rc = dds_set_qos (ep, qos);
+            rc = dds_set_qos (qent, qos);
             MPT_ASSERT_EQ (rc, DDS_RETCODE_OK, "Set QoS failed: %s\n", dds_strretcode (rc));
 
             dds_qos_t *chk = dds_create_qos ();
@@ -272,10 +300,10 @@ MPT_ProcessEntry (rwud,
 
             void *chkud = NULL;
             size_t chkusz = 0;
-            if (!dds_qget_userdata (chk, &chkud, &chkusz))
-              MPT_ASSERT (0, "Check QoS: no user data present\n");
+            if (!qget (chk, &chkud, &chkusz))
+              MPT_ASSERT (0, "Check QoS: no %s present\n", qname);
             MPT_ASSERT (chkusz == newusz && (newusz == 0 || memcmp (chkud, newud, newusz) == 0),
-                        "Retrieved user data differs from user data just set (%zu/%s vs %zu/%s)\n",
+                        "Retrieved %s differs from group data just set (%zu/%s vs %zu/%s)\n", qname,
                         chkusz, chkud ? (char *) chkud : "(null)", newusz, newud ? (char *) newud : "(null)");
             dds_free (chkud);
             dds_delete_qos (chk);
@@ -291,281 +319,5 @@ MPT_ProcessEntry (rwud,
   dds_delete_qos (qos);
   rc = dds_delete (dp);
   MPT_ASSERT_EQ (rc, DDS_RETCODE_OK, "teardown failed\n");
-  printf ("=== [Publisher(%d)] Done\n", id);
-}
-
-MPT_ProcessEntry (rwtd,
-                  MPT_Args (dds_domainid_t domainid,
-                            const char *topic_name,
-                            bool active,
-                            unsigned ncycles))
-{
-  dds_entity_t dp, tp, ep, rdep, ws;
-  dds_return_t rc;
-  dds_qos_t *qos;
-  int id = (int) ddsrt_getpid ();
-
-  printf ("=== [Check(%d)] active=%d ncycles=%u Start(%d) ...\n", id, active, ncycles, (int) domainid);
-
-  qos = dds_create_qos ();
-  dds_qset_history (qos, DDS_HISTORY_KEEP_ALL, 0);
-  dp = dds_create_participant (domainid, NULL, NULL);
-  MPT_ASSERT_FATAL_GT (dp, 0, "Could not create participant: %s\n", dds_strretcode (dp));
-  tp = dds_create_topic (dp, &RWData_Msg_desc, topic_name, qos, NULL);
-  MPT_ASSERT_FATAL_GT (tp, 0, "Could not create topic: %s\n", dds_strretcode (tp));
-  if (active)
-  {
-    rdep = dds_create_reader (dp, DDS_BUILTIN_TOPIC_DCPSSUBSCRIPTION, qos, NULL);
-    MPT_ASSERT_FATAL_GT (rdep, 0, "Could not create DCPSSubscription reader: %s\n", dds_strretcode (rdep));
-    ep = dds_create_writer (dp, tp, qos, NULL);
-    MPT_ASSERT_FATAL_GT (ep, 0, "Could not create writer: %s\n", dds_strretcode (ep));
-  }
-  else
-  {
-    rdep = dds_create_reader (dp, DDS_BUILTIN_TOPIC_DCPSPUBLICATION, qos, NULL);
-    MPT_ASSERT_FATAL_GT (rdep, 0, "Could not create DCPSPublication reader: %s\n", dds_strretcode (rdep));
-    ep = dds_create_reader (dp, tp, qos, NULL);
-    MPT_ASSERT_FATAL_GT (ep, 0, "Could not create reader: %s\n", dds_strretcode (ep));
-  }
-  rc = dds_set_status_mask (rdep, DDS_DATA_AVAILABLE_STATUS);
-  MPT_ASSERT_FATAL_EQ (rc, 0, "Could not set status mask: %s\n", dds_strretcode (rc));
-  ws = dds_create_waitset (dp);
-  MPT_ASSERT_FATAL_GT (ws, 0, "Could not create waitset: %s\n", dds_strretcode (ws));
-  rc = dds_waitset_attach (ws, rdep, 0);
-  MPT_ASSERT_FATAL_EQ (rc, 0, "Could not attach built-in reader to waitset: %s\n", dds_strretcode (rc));
-
-  bool done = false;
-  bool first = true;
-  unsigned exp_index = 0;
-  unsigned exp_cycle = 0;
-  while (!done)
-  {
-    rc = dds_waitset_wait (ws, NULL, 0, DDS_INFINITY);
-    MPT_ASSERT_FATAL_GEQ (rc, 0, "Wait failed: %s\n", dds_strretcode (ws));
-
-    void *raw = NULL;
-    dds_sample_info_t si;
-    int32_t n;
-    while ((n = dds_take (rdep, &raw, &si, 1, 1)) == 1)
-    {
-      const dds_builtintopic_endpoint_t *sample = raw;
-      if (si.instance_state != DDS_IST_ALIVE)
-        done = true;
-      else if (!si.valid_data || strcmp (sample->topic_name, topic_name) != 0)
-        continue;
-      else
-      {
-        void *td = NULL;
-        size_t tsz = 0;
-        if (!dds_qget_topicdata (sample->qos, &td, &tsz))
-          printf ("%d: topic data not set in QoS\n", id);
-        if (first && tsz == 0)
-        {
-          dds_qset_topicdata (qos, "X", 1);
-          rc = dds_set_qos (tp, qos);
-          MPT_ASSERT_EQ (rc, DDS_RETCODE_OK, "Set QoS failed: %s\n", dds_strretcode (rc));
-        }
-        else
-        {
-          const char *exp = exp_ud[exp_index];
-          if (first && strcmp (td, "X") == 0)
-            exp = "X";
-          const size_t expsz = first ? 1 : strlen (exp);
-          bool eq = (tsz == expsz && (tsz == 0 || memcmp (td, exp, tsz) == 0));
-          //printf ("%d: expected %u %zu/%s received %zu/%s\n",
-          //        id, exp_index, expsz, exp, tsz, td ? (char *) td : "(null)");
-          MPT_ASSERT (eq, "Topic data mismatch: expected %u %zu/%s received %zu/%s\n",
-                      exp_index, expsz, exp, tsz, td ? (char *) td : "(null)");
-          if (strcmp (exp, "X") != 0 && ++exp_index == sizeof (exp_ud) / sizeof (exp_ud[0]))
-          {
-            exp_index = 0;
-            exp_cycle++;
-          }
-
-          if (active && exp_cycle == ncycles)
-            done = true;
-          else
-          {
-            const void *newtd;
-            size_t newtsz;
-            if (!active)
-            {
-              /* Set topic data to the same value in response */
-              newtd = td; newtsz = tsz;
-              dds_qset_topicdata (qos, td, tsz);
-            }
-            else /* Set next agreed value */
-            {
-              newtd = exp_ud[exp_index]; newtsz = strlen (exp_ud[exp_index]);
-              dds_qset_topicdata (qos, newtd, newtsz);
-            }
-
-            rc = dds_set_qos (tp, qos);
-            MPT_ASSERT_EQ (rc, DDS_RETCODE_OK, "Set QoS failed: %s\n", dds_strretcode (rc));
-
-            dds_qos_t *chk = dds_create_qos ();
-            rc = dds_get_qos (ep, chk);
-            MPT_ASSERT_EQ (rc, DDS_RETCODE_OK, "Get QoS failed: %s\n", dds_strretcode (rc));
-
-            void *chktd = NULL;
-            size_t chktsz = 0;
-            if (!dds_qget_topicdata (chk, &chktd, &chktsz))
-              MPT_ASSERT (0, "Check QoS: no topic data present\n");
-            MPT_ASSERT (chktsz == newtsz && (newtsz == 0 || memcmp (chktd, newtd, newtsz) == 0),
-                        "Retrieved topic data differs from topic data just set (%zu/%s vs %zu/%s)\n",
-                        chktsz, chktd ? (char *) chktd : "(null)", newtsz, newtd ? (char *) newtd : "(null)");
-            dds_free (chktd);
-            dds_delete_qos (chk);
-            first = false;
-          }
-        }
-        dds_free (td);
-      }
-    }
-    MPT_ASSERT_FATAL_EQ (n, 0, "Read failed: %s\n", dds_strretcode (n));
-    dds_return_loan (rdep, &raw, 1);
-  }
-  dds_delete_qos (qos);
-  rc = dds_delete (dp);
-  MPT_ASSERT_EQ (rc, DDS_RETCODE_OK, "teardown failed\n");
-  printf ("=== [Publisher(%d)] Done\n", id);
-}
-
-MPT_ProcessEntry (rwgd,
-                  MPT_Args (dds_domainid_t domainid,
-                            const char *topic_name,
-                            bool active,
-                            unsigned ncycles))
-{
-  dds_entity_t dp, tp, ep, rdep, grp, ws;
-  dds_return_t rc;
-  dds_qos_t *qos;
-  int id = (int) ddsrt_getpid ();
-
-  printf ("=== [Check(%d)] active=%d ncycles=%u Start(%d) ...\n", id, active, ncycles, (int) domainid);
-
-  qos = dds_create_qos ();
-  dds_qset_history (qos, DDS_HISTORY_KEEP_ALL, 0);
-  dp = dds_create_participant (domainid, NULL, NULL);
-  MPT_ASSERT_FATAL_GT (dp, 0, "Could not create participant: %s\n", dds_strretcode (dp));
-  tp = dds_create_topic (dp, &RWData_Msg_desc, topic_name, qos, NULL);
-  MPT_ASSERT_FATAL_GT (tp, 0, "Could not create topic: %s\n", dds_strretcode (tp));
-  if (active)
-  {
-    rdep = dds_create_reader (dp, DDS_BUILTIN_TOPIC_DCPSSUBSCRIPTION, qos, NULL);
-    MPT_ASSERT_FATAL_GT (rdep, 0, "Could not create DCPSSubscription reader: %s\n", dds_strretcode (rdep));
-    ep = dds_create_writer (dp, tp, qos, NULL);
-    MPT_ASSERT_FATAL_GT (ep, 0, "Could not create writer: %s\n", dds_strretcode (ep));
-  }
-  else
-  {
-    rdep = dds_create_reader (dp, DDS_BUILTIN_TOPIC_DCPSPUBLICATION, qos, NULL);
-    MPT_ASSERT_FATAL_GT (rdep, 0, "Could not create DCPSPublication reader: %s\n", dds_strretcode (rdep));
-    ep = dds_create_reader (dp, tp, qos, NULL);
-    MPT_ASSERT_FATAL_GT (ep, 0, "Could not create reader: %s\n", dds_strretcode (ep));
-  }
-  grp = dds_get_parent (ep);
-  MPT_ASSERT_FATAL_GT (grp, 0, "Could not get pub/sub from wr/rd: %s\n", dds_strretcode (grp));
-  rc = dds_set_status_mask (rdep, DDS_DATA_AVAILABLE_STATUS);
-  MPT_ASSERT_FATAL_EQ (rc, 0, "Could not set status mask: %s\n", dds_strretcode (rc));
-  ws = dds_create_waitset (dp);
-  MPT_ASSERT_FATAL_GT (ws, 0, "Could not create waitset: %s\n", dds_strretcode (ws));
-  rc = dds_waitset_attach (ws, rdep, 0);
-  MPT_ASSERT_FATAL_EQ (rc, 0, "Could not attach built-in reader to waitset: %s\n", dds_strretcode (rc));
-
-  bool done = false;
-  bool first = true;
-  unsigned exp_index = 0;
-  unsigned exp_cycle = 0;
-  while (!done)
-  {
-    rc = dds_waitset_wait (ws, NULL, 0, DDS_INFINITY);
-    MPT_ASSERT_FATAL_GEQ (rc, 0, "Wait failed: %s\n", dds_strretcode (ws));
-
-    void *raw = NULL;
-    dds_sample_info_t si;
-    int32_t n;
-    while ((n = dds_take (rdep, &raw, &si, 1, 1)) == 1)
-    {
-      const dds_builtintopic_endpoint_t *sample = raw;
-      if (si.instance_state != DDS_IST_ALIVE)
-        done = true;
-      else if (!si.valid_data || strcmp (sample->topic_name, topic_name) != 0)
-        continue;
-      else
-      {
-        void *gd = NULL;
-        size_t gsz = 0;
-        if (!dds_qget_groupdata (sample->qos, &gd, &gsz))
-          printf ("%d: group data not set in QoS\n", id);
-        if (first && gsz == 0)
-        {
-          dds_qset_groupdata (qos, "X", 1);
-          rc = dds_set_qos (grp, qos);
-          MPT_ASSERT_EQ (rc, DDS_RETCODE_OK, "Set QoS failed: %s\n", dds_strretcode (rc));
-        }
-        else
-        {
-          const char *exp = exp_ud[exp_index];
-          if (first && strcmp (gd, "X") == 0)
-            exp = "X";
-          const size_t expsz = first ? 1 : strlen (exp);
-          bool eq = (gsz == expsz && (gsz == 0 || memcmp (gd, exp, gsz) == 0));
-          //printf ("%d: expected %u %zu/%s received %zu/%s\n",
-          //        id, exp_index, expsz, exp, gsz, gd ? (char *) gd : "(null)");
-          MPT_ASSERT (eq, "Group data mismatch: expected %u %zu/%s received %zu/%s\n",
-                      exp_index, expsz, exp, gsz, gd ? (char *) gd : "(null)");
-          if (strcmp (exp, "X") != 0 && ++exp_index == sizeof (exp_ud) / sizeof (exp_ud[0]))
-          {
-            exp_index = 0;
-            exp_cycle++;
-          }
-
-          if (active && exp_cycle == ncycles)
-            done = true;
-          else
-          {
-            const void *newgd;
-            size_t newgsz;
-            if (!active)
-            {
-              /* Set group data to the same value in response */
-              newgd = gd; newgsz = gsz;
-              dds_qset_groupdata (qos, gd, gsz);
-            }
-            else /* Set next agreed value */
-            {
-              newgd = exp_ud[exp_index]; newgsz = strlen (exp_ud[exp_index]);
-              dds_qset_groupdata (qos, newgd, newgsz);
-            }
-
-            rc = dds_set_qos (grp, qos);
-            MPT_ASSERT_EQ (rc, DDS_RETCODE_OK, "Set QoS failed: %s\n", dds_strretcode (rc));
-
-            dds_qos_t *chk = dds_create_qos ();
-            rc = dds_get_qos (ep, chk);
-            MPT_ASSERT_EQ (rc, DDS_RETCODE_OK, "Get QoS failed: %s\n", dds_strretcode (rc));
-
-            void *chkgd = NULL;
-            size_t chkgsz = 0;
-            if (!dds_qget_groupdata (chk, &chkgd, &chkgsz))
-              MPT_ASSERT (0, "Check QoS: no group data present\n");
-            MPT_ASSERT (chkgsz == newgsz && (newgsz == 0 || memcmp (chkgd, newgd, newgsz) == 0),
-                        "Retrieved group data differs from group data just set (%zu/%s vs %zu/%s)\n",
-                        chkgsz, chkgd ? (char *) chkgd : "(null)", newgsz, newgd ? (char *) newgd : "(null)");
-            dds_free (chkgd);
-            dds_delete_qos (chk);
-            first = false;
-          }
-        }
-        dds_free (gd);
-      }
-    }
-    MPT_ASSERT_FATAL_EQ (n, 0, "Read failed: %s\n", dds_strretcode (n));
-    dds_return_loan (rdep, &raw, 1);
-  }
-  dds_delete_qos (qos);
-  rc = dds_delete (dp);
-  MPT_ASSERT_EQ (rc, DDS_RETCODE_OK, "teardown failed\n");
-  printf ("=== [Publisher(%d)] Done\n", id);
+  printf ("=== [Check(%d)] Done\n", id);
 }

--- a/src/mpt/tests/qos/procs/ppud.h
+++ b/src/mpt/tests/qos/procs/ppud.h
@@ -26,6 +26,12 @@ extern "C" {
 void ppud_init (void);
 void ppud_fini (void);
 
+enum rwud {
+  RWUD_USERDATA,
+  RWUD_GROUPDATA,
+  RWUD_TOPICDATA
+};
+
 MPT_ProcessEntry (ppud,
                   MPT_Args (dds_domainid_t domainid,
                             bool active,
@@ -35,19 +41,9 @@ MPT_ProcessEntry (rwud,
                   MPT_Args (dds_domainid_t domainid,
                             const char *topic_name,
                             bool active,
-                            unsigned ncycles));
+                            unsigned ncycles,
+                            enum rwud which));
 
-MPT_ProcessEntry (rwtd,
-                  MPT_Args (dds_domainid_t domainid,
-                            const char *topic_name,
-                            bool active,
-                            unsigned ncycles));
-
-MPT_ProcessEntry (rwgd,
-                  MPT_Args (dds_domainid_t domainid,
-                            const char *topic_name,
-                            bool active,
-                            unsigned ncycles));
 #if defined (__cplusplus)
 }
 #endif

--- a/src/tools/ddsperf/ddsperf.c
+++ b/src/tools/ddsperf/ddsperf.c
@@ -1886,7 +1886,7 @@ int main (int argc, char *argv[])
      have a reader or will never really be receiving data) */
   struct subthread_arg subarg_data, subarg_ping, subarg_pong;
   init_eseq_admin (&eseq_admin, nkeyvals);
-  subthread_arg_init (&subarg_data, rd_data, 100);
+  subthread_arg_init (&subarg_data, rd_data, 1000);
   subthread_arg_init (&subarg_ping, rd_ping, 100);
   subthread_arg_init (&subarg_pong, rd_pong, 100);
   uint32_t (*subthread_func) (void *arg) = 0;

--- a/src/tools/pubsub/common.c
+++ b/src/tools/pubsub/common.c
@@ -400,6 +400,7 @@ static void inapplicable_qos(dds_entity_kind_t qt, const char *n) {
 #define   get_qos_W(qt, q, n) ((qt == DDS_KIND_WRITER)                                                              ? q : (inapplicable_qos((qt), n), (dds_qos_t*)0))
 #define  get_qos_TW(qt, q, n) ((qt == DDS_KIND_TOPIC)     || (qt == DDS_KIND_WRITER)                                ? q : (inapplicable_qos((qt), n), (dds_qos_t*)0))
 #define  get_qos_RW(qt, q, n) ((qt == DDS_KIND_READER)    || (qt == DDS_KIND_WRITER)                                ? q : (inapplicable_qos((qt), n), (dds_qos_t*)0))
+#define  get_qos_MRW(qt, q, n) ((qt == DDS_KIND_READER) || (qt == DDS_KIND_WRITER) || (qt == DDS_KIND_PARTICIPANT)  ? q : (inapplicable_qos((qt), n), (dds_qos_t*)0))
 #define  get_qos_PS(qt, q, n) ((qt == DDS_KIND_PUBLISHER) || (qt == DDS_KIND_SUBSCRIBER)                            ? q : (inapplicable_qos((qt), n), (dds_qos_t*)0))
 #define get_qos_TRW(qt, q, n) ((qt == DDS_KIND_TOPIC)     || (qt == DDS_KIND_READER)     || (qt == DDS_KIND_WRITER) ? q : (inapplicable_qos((qt), n), (dds_qos_t*)0))
 
@@ -563,7 +564,7 @@ static void *unescape(const char *str, size_t *len) {
 }
 
 void qos_user_data(dds_entity_kind_t qt, dds_qos_t *q, const char *arg) {
-    dds_qos_t *qp = get_qos_RW(qt, q, "user_data");
+    dds_qos_t *qp = get_qos_MRW(qt, q, "user_data");
     size_t len;
     if (qp == NULL)
         return;

--- a/src/tools/pubsub/pubsub.c
+++ b/src/tools/pubsub/pubsub.c
@@ -567,7 +567,7 @@ static int read_value(char *command, int *key, struct tstamp_t *tstamp, char **a
                 return 1;
             }
             break;
-        case 'p': case 'S': case ':': {
+        case 'p': case 'S': case ':': case 'Q': {
             int i = 0;
             *command = (char) c;
             while ((c = getc(stdin)) != EOF && !isspace((unsigned char) c)) {
@@ -1424,6 +1424,13 @@ static char *pub_do_nonarb(const struct writerspec *spec, uint32_t *seq) {
                 dds_sleepfor(DDS_SECS(k));
             }
             break;
+        case 'Q': {
+            dds_qos_t *qos = dds_create_qos ();
+            setqos_from_args (DDS_KIND_PARTICIPANT, qos, 1, (const char **) &arg);
+            dds_set_qos (dp, qos);
+            dds_delete_qos (qos);
+            break;
+          }
         case 'Y': case 'B': case 'E': case 'W':
             non_data_operation(command, spec->wr);
             break;


### PR DESCRIPTION
The primary component of this PR is a rework of some of the locking of API-level DDS entities, because there were some functions (such as dds_get_children) that would acquire a child's entity lock while holding the parent's entity lock, whereas in most places that locks of multiple entities are held simultaneously, the opposite order is used.

With this PR, for those cases that descend down the entity hierarchy, the parent is now unlocked before the child is locked. It already was the case that a handle could be pinned (formerly called "claimed") which would keep the object in existence and this is now used strategically in more places. The problematic bit is iterating over all children, so that has been completely rewritten.

All entities now have an eternally unique ``dds_instance_handle_t`` (``iid`` for short), and children are in an AVL tree sorted on the ``iid``. Thus walking down the hierarchy can now be done by pinning the parent, finding the child with the next higher ``iid``, pinning that one, unlocking the parent, &c. This way, deleting the child being visible is impossible and deleting any other child is perfectly safe. Children added while scanning may or may not be included. For ``dds_get_children``, this is acceptable to me; for ``dds_set_qos`` and ``dds_set_listener`` the new value is set before the propagation begins and so new children would already have inherited from the new value and the operations are idempotent. So that is fine, too.

Another interesting area is the handling of topics between multiple participants: this is another area that had some locking issues (albeit with a different locks causing the problem). Previously it would do "something", with participant re-using another participant's topic entity. (That's bad.) Now, each participant will get its own topic entity while sharing the underlying type.

Status masks and condition trigger counts ended up using atomic operations. For events that have an associated status information, all operations happen inside the lock, but for data availability, protecting them with a mutex turned out to be a significant cost center. Fortunately, the uses are very limited, only requiring triggering waitsets on the raising of the status. The current model should not suffer from many spurious wakeups in ``dds_waitset_wait``.

Some additional changes: I played with the "undefined behaviour" sanitizer and made a few changes — the most pleasant thing is that now all the C89-style fake flexible struct members have been replaced by C99 real ones. Similarly, I played with thread sanitizer, but I have not yet figured out how to make it shut up about the GC mechanism. It keeps complaining "as if synchronized via sleep", which is indeed correct, but also a deliberate choice ...

The lease renewal for remote writers/participants is now lock-free. I believe I have done the change correctly ... that is actually how it was always meant to be. It shouldn't have become part of this PR, but one thing led to another ... For this, I apologize ...