### PR TITLE
Update FindMaven for Travis/Windows

### DIFF
--- a/src/cmake/modules/FindMaven.cmake
+++ b/src/cmake/modules/FindMaven.cmake
@@ -18,8 +18,13 @@ if(DEFINED ENV{M2_HOME})
 endif()
 
 # Chocolatey installs packages under C:\ProgramData\chocolatey.
-if(ENV{ProgramData} AND IS_DIRECTORY "$ENV{ProgramData}/chocolatey/bin")
-  list(APPEND _mvn_paths "$ENV{ProgramData}/chocolatey/bin")
+if(NOT "$ENV{ProgramData}" STREQUAL "")
+  if(IS_DIRECTORY "$ENV{ProgramData}/chocolatey/bin")
+    list(APPEND _mvn_paths "$ENV{ProgramData}/chocolatey/bin")
+  endif()
+  if(IS_DIRECTORY "$ENV{ProgramData}/chocolatey/bin")
+    list(APPEND _dirs "$ENV{ProgramData}/chocolatey/lib/maven")
+  endif()
 endif()
 
 # Maven documentation mentions intalling maven under C:\Program Files on


### PR DESCRIPTION
It appears the Chocolately maven package now installs in different
location (or some shims that used to be installed no longer are).
Because the Travis build uses bash instead of cmd/powershell it doesn't
properly pick up M2_HOME.  This commits adds the new location.

Signed-off-by: Erik Boasson <eb@ilities.com>