### PR TITLE
Report per-thread CPU usage in ddsperf

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Eclipse Cyclone DDS
 
-Eclipse Cyclone DDS is by far the most performant and robust DDS implementation available on the
-market. Moreover, Cyclone DDS is developed completely in the open as an Eclipse IoT project
+Eclipse Cyclone DDS is a very performant and robust open-source DDS implementation.  Cyclone DDS is developed completely in the open as an Eclipse IoT project
 (see [eclipse-cyclone-dds](https://projects.eclipse.org/projects/iot.cyclonedds)).
+
+* [Getting Started](#getting-started)
+* [Performance](#performance)
+* [Configuration](#configuration)
 
 # Getting Started
 
@@ -106,7 +109,76 @@ also need to add switches to select the architecture and build type, e.g., ``con
 arch=x86_64 -s build_type=Debug ..`` This will automatically download and/or build CUnit (and, at
 the moment, OpenSSL).
 
-## Configuration
+## Documentation
+
+The documentation is still rather limited, and at the moment only available in the sources (in the
+form of restructured text files in ``docs`` and Doxygen comments in the header files), or as
+a
+[PDF](https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/assets/pdf/CycloneDDS-0.1.0.pdf). The
+intent is to automate the process of building the documentation and have them available in more
+convenient formats and in the usual locations.
+
+## Building and Running the Roundtrip Example
+
+We will show you how to build and run an example program that measures latency.  The examples are
+built automatically when you build Cyclone DDS, so you don't need to follow these steps to be able
+to run the program, it is merely to illustrate the process.
+
+    $ cd cyclonedds/examples/roundtrip
+    $ mkdir build
+    $ cd build
+    $ cmake ..
+    $ make
+    
+On one terminal start the application that will be responding to pings:
+
+    $ ./RoundtripPong
+
+On another terminal, start the application that will be sending the pings:
+    
+    $ ./RoundtripPing 0 0 0 
+    # payloadSize: 0 | numSamples: 0 | timeOut: 0
+    # Waiting for startup jitter to stabilise
+    # Warm up complete.
+    # Latency measurements (in us)
+    #             Latency [us]                                   Write-access time [us]       Read-access time [us]
+    # Seconds     Count   median      min      99%      max      Count   median      min      Count   median      min
+        1     28065       17       16       23       87      28065        8        6      28065        1        0
+        2     28115       17       16       23       46      28115        8        6      28115        1        0
+        3     28381       17       16       22       46      28381        8        6      28381        1        0
+        4     27928       17       16       24      127      27928        8        6      27928        1        0
+        5     28427       17       16       20       47      28427        8        6      28427        1        0
+        6     27685       17       16       26       51      27685        8        6      27685        1        0
+        7     28391       17       16       23       47      28391        8        6      28391        1        0
+        8     27938       17       16       24       63      27938        8        6      27938        1        0
+        9     28242       17       16       24      132      28242        8        6      28242        1        0
+       10     28075       17       16       23       46      28075        8        6      28075        1        0
+
+The numbers above were measured on Mac running a 4.2 GHz Intel Core i7 on December 12th 2018.  From
+these numbers you can see how the roundtrip is very stable and the minimal latency is now down to 17
+micro-seconds (used to be 25 micro-seconds) on this HW.
+
+# Performance
+
+Reliable message throughput is over 1MS/s for very small samples and is roughly 90% of GbE with 100
+byte samples, and latency is about 30us when measured using [ddsperf](src/tools/ddsperf) between two
+Intel(R) Xeon(R) CPU E3-1270 V2 @ 3.50GHz (that's 2012 hardware ...) running Ubuntu 16.04, with the
+executables built on Ubuntu 18.04 using gcc 7.4.0 for a default (i.e., "RelWithDebInfo") build.
+
+<img src="https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/assets/performance/20190730/throughput-async-listener-rate.png" alt="Throughput" height="400"><img src="https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/assets/performance/20190730/latency-sync-listener.png" alt="Throughput" height="400">
+
+This is with the subscriber in listener mode, using asynchronous delivery for the throughput
+test. The configuration is a marginally tweaked out-of-the-box configuration: an increased maximum
+message size and fragment size, and an increased high-water mark for the reliability window on the
+writer side. For details, see the [scripts](examples/perfscript) directory,
+the
+[environment details](https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/assets/performance/20190730/config.txt) and
+the
+[throughput](https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/assets/performance/20190730/sub.log) and
+[latency](https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/assets/performance/20190730/ping.log) data
+underlying the graphs.  These also include CPU usage ([thoughput](https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/assets/performance/20190730/throughput-async-listener-cpu.png) and [latency](https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/assets/performance/20190730/latency-sync-listener-bwcpu.png)) and [memory usage](https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/assets/performance/20190730/throughput-async-listener-memory.png).
+
+# Configuration
 
 The out-of-the-box configuration should usually be fine, but there are a great many options that can
 be tweaked by creating an XML file with the desired settings and defining the ``CYCLONEDDS_URI`` to
@@ -160,73 +232,6 @@ This example shows a few things:
 The configurator tool ``cycloneddsconf`` can help in discovering the settings, as can the config
 dump.  Background information on configuring Cyclone DDS can be
 found [here](https://docs/manual/config.rst).
-
-## Documentation
-
-The documentation is still rather limited, and at the moment only available in the sources (in the
-form of restructured text files in ``docs`` and Doxygen comments in the header files), or as
-a
-[PDF](https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/assets/pdf/CycloneDDS-0.1.0.pdf). The
-intent is to automate the process of building the documentation and have them available in more
-convenient formats and in the usual locations.
-
-## Performance
-
-Median small message throughput measured using the Throughput example between two Intel(R) Xeon(R)
-CPU E3-1270 V2 @ 3.50GHz (that's 2012 hardware ...) running Linux 3.8.13-rt14.20.el6rt.x86_64,
-connected via a quiet GbE and when using gcc-6.2.0 for a default (i.e., "RelWithDebInfo") build is:
-
-<img src="https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/assets/performance/throughput-polling.png" alt="Throughput" height="400">
-
-This is with the subscriber in polling mode. Listener mode is marginally slower; using a waitset the
-message rate for minimal size messages drops to 600k sample/s in synchronous delivery mode and about
-750k samples/s in asynchronous delivery mode. The configuration is an out-of-the-box configuration,
-tweaked only to increase the high-water mark for the reliability window on the writer side. For
-details, see the scripts in the ``performance`` directory and
-the
-[data](https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/assets/performance/throughput.txt).
-
-There is some data on roundtrip latency below.
-
-## Building and Running the Roundtrip Example
-
-We will show you how to build and run an example program that measures latency.  The examples are
-built automatically when you build Cyclone DDS, so you don't need to follow these steps to be able
-to run the program, it is merely to illustrate the process.
-
-    $ cd cyclonedds/examples/roundtrip
-    $ mkdir build
-    $ cd build
-    $ cmake ..
-    $ make
-    
-On one terminal start the application that will be responding to pings:
-
-    $ ./RoundtripPong
-
-On another terminal, start the application that will be sending the pings:
-    
-    $ ./RoundtripPing 0 0 0 
-    # payloadSize: 0 | numSamples: 0 | timeOut: 0
-    # Waiting for startup jitter to stabilise
-    # Warm up complete.
-    # Round trip measurements (in us)
-    #             Round trip time [us]                           Write-access time [us]       Read-access time [us]
-    # Seconds     Count   median      min      99%      max      Count   median      min      Count   median      min
-        1     28065       17       16       23       87      28065        8        6      28065        1        0
-        2     28115       17       16       23       46      28115        8        6      28115        1        0
-        3     28381       17       16       22       46      28381        8        6      28381        1        0
-        4     27928       17       16       24      127      27928        8        6      27928        1        0
-        5     28427       17       16       20       47      28427        8        6      28427        1        0
-        6     27685       17       16       26       51      27685        8        6      27685        1        0
-        7     28391       17       16       23       47      28391        8        6      28391        1        0
-        8     27938       17       16       24       63      27938        8        6      27938        1        0
-        9     28242       17       16       24      132      28242        8        6      28242        1        0
-       10     28075       17       16       23       46      28075        8        6      28075        1        0
-
-The numbers above were measured on Mac running a 4.2 GHz Intel Core i7 on December 12th 2018.  From
-these numbers you can see how the roundtrip is very stable and the minimal latency is now down to 17
-micro-seconds (used to be 25 micro-seconds) on this HW.
 
 # Trademarks
 

--- a/examples/perfscript/latency-test
+++ b/examples/perfscript/latency-test
@@ -5,11 +5,11 @@ bandwidth=1e9
 remotedir="$PWD"
 provision=false
 asynclist="sync async"
-modelist="listener polling waitset"
+modelist="listener waitset"
 sizelist="0 20 50 100 200 500 1000 2000 5000 10000 20000 50000 100000 200000 500000 1000000"
 timeout=30
 loopback=true
-resultdir="throughput-result"
+resultdir="latency-result"
 
 usage () {
     cat >&2 <<EOF
@@ -32,15 +32,14 @@ OPTIONS
   -l LOOPBACK  enable/disable multicast loopback (true/false, default: $loopback)
   -o DIR       store results in dir (default: $resultdir)
 
-Local host runs "ddsperf" in subscriber mode, first remote runs it publisher
-mode, further remotes also run subcribers.  It assumes these are available in
-DIR/bin.  It also assumes that ssh user@remote works without requiring a
-password.
+Local host runs ddsperf in ping mode, remotes run pong.  It assumes these are
+available in DIR/bin.  It also assumes that ssh user@remote works without
+requiring a password.
 EOF
     exit 1
 }
 
-while getopts "i:b:d:pa:m:s:t:o:l:" opt ; do
+while getopts "i:d:pa:m:s:t:o:l:" opt ; do
     case $opt in
         i) nwif="$OPTARG" ;;
         b) case "$OPTARG" in
@@ -61,8 +60,6 @@ while getopts "i:b:d:pa:m:s:t:o:l:" opt ; do
 done
 shift $((OPTIND-1))
 if [ $# -lt 1 ] ; then usage ; fi
-pubremote=$1
-shift
 
 cfg=cdds-simple.xml
 cat >$cfg <<EOF
@@ -109,7 +106,7 @@ topic=KS
 [ -z "$sizelist" ] && topic=OU
 
 export CYCLONEDDS_URI=file://$PWD/$cfg
-for r in $pubremote "$@" ; do
+for r in "$@" ; do
     scp $cfg $r:$remotedir || { echo "failed to copy $cfg to $remote:$PWD" >&2 ; exit 1 ; }
 done
 
@@ -122,46 +119,35 @@ for async_mode in $asynclist ; do
     export async
     for sub_mode in $modelist ; do
         echo "======== ASYNC $async MODE $sub_mode ========="
+
         
-        cat > run-publisher.tmp <<EOF
+        cat > run-pong.tmp <<EOF
 export CYCLONEDDS_URI=file://$remotedir/$cfg
 export async=$async
 cd $remotedir
-for size in ${sizelist:-0} ; do
-  echo "size \$size"
-  bin/ddsperf -D $timeout -T $topic pub size \$size > pub.log
-  sleep 5
-done
-wait
-EOF
-        scp run-publisher.tmp $pubremote:$remotedir || { echo "failed to copy $cfg to $remote:$PWD" >&2 ; exit 2 ; }
-        killremotesubs=""
-        if [ $# -gt 0 ] ; then
-            cat > run-subscriber.tmp <<EOF
-export CYCLONEDDS_URI=file://$remotedir/$cfg
-export async=$async
-cd $remotedir
-nohup bin/ddsperf -T $topic sub $sub_mode > /dev/null &
+nohup bin/ddsperf -T $topic pong $sub_mode > /dev/null &
 echo \$!
 EOF
-            for r in "$@" ; do
-                scp run-subscriber.tmp $r:$remotedir
-                rsubpid=`ssh $r ". $remotedir/run-subscriber.tmp"`
-                killremotesubs="$killremotesubs ssh $r kill -9 $rsubpid &"
-            done
-        fi
+        killpongs=""
+        for r in "$@" ; do
+            scp run-pong.tmp $r:$remotedir
+            rpongpid=`ssh $r ". $remotedir/run-pong.tmp"`
+            killpongs="$killpongs ssh $r kill -9 $rpongpid &"
+        done
 
         outdir=$resultdir/$async_mode-$sub_mode
         mkdir $outdir
 
-        bin/ddsperf -d $nwif:$bandwidth -c -T $topic sub $sub_mode > $outdir/sub.log & spid=$!
-        tail -f $outdir/sub.log & xpid=$!
-        ssh $pubremote ". $remotedir/run-publisher.tmp"
-        kill $spid
-        eval $killremotesubs
+        touch $outdir/ping.log
+        tail -f $outdir/ping.log & xpid=$!
+        for size in ${sizelist:-0} ; do
+            echo "size $size"
+            bin/ddsperf -d $nwif:$bandwidth -c -D $timeout -T $topic ping size $size $sub_mode >> $outdir/ping.log
+            sleep 5
+        done
+        eval $killpongs
         sleep 1
         kill $xpid
         wait
-        scp $pubremote:$remotedir/pub.log $outdir
     done
 done

--- a/examples/perfscript/latency-test-extract
+++ b/examples/perfscript/latency-test-extract
@@ -9,16 +9,18 @@ my %res = ();
 my %meas;
 while (<>) {
   next unless s/^\[\d+\] \d+\.\d+\s+//;
-  if (/^size (\d+) .* rate (\d+\.\d+)\s*kS\/s\s+(\d+\.\d+)\s*Mb\/s/) {
+  if (s/^[^\@:]+:\d+\s+size (\d+) //) {
     # size is always the first line of an output block
     # ddsperf doesn't print CPU loads, RSS, bandwidth if it is zero
     my %tmp = %meas;
     push @{$res{$meas{size}}}, \%tmp if %meas;
-    %meas = (size => $1, rate => $2, cookedbw => $3,
+    %meas = (size => $1,
              rawxmitbw => 0, rawrecvbw => 0,
              subrss => 0, pubrss => 0,
              subcpu => 0, subrecv => 0,
              pubcpu => 0, pubrecv => 0);
+    $meas{$1} = $2 while s/^(mean|min|max|\d+%)\s+(\d+\.\d+)us\s*//;
+    die unless /cnt \d+$/;
   } elsif (s/^(\@[^:]+:\d+\s+)?rss:(\d+\.\d+)([kM])B//) {
     my $side = defined $1 ? "pub" : "sub";
     $meas{"${side}rss"}  = $2 / ($3 eq "k" ? 1024.0 : 1);
@@ -32,12 +34,16 @@ while (<>) {
 push @{$res{$meas{size}}}, \%meas if %meas;
 die "no data found" unless keys %res > 0;
 
-print "#size rate cookedbw rawxmitbw rawrecvbw pubrss subrss pubcpu pubrecv subcpu subrecv\n";
+print "#size mean min 50% 90% 99% max rawxmitbw rawrecvbw pubrss subrss pubcpu pubrecv subcpu subrecv\n";
 my @sizes = sort { $a <=> $b } keys %res;
 for my $sz (@sizes) {
   my $ms = $res{$sz};
-  my $rate = median ("rate", $ms);
-  my $cookedbw = median ("cookedbw", $ms);
+  my $min = min ("min", $ms);
+  my $max = max ("max", $ms);
+  my $mean = mean ("mean", $ms); # roughly same number of roundtrips, so not too far off
+  my $median = max ("50%", $ms); # also not quite correct ...
+  my $p90 = max ("90%", $ms);
+  my $p99 = max ("99%", $ms);
   my $rawxmitbw = median ("rawxmitbw", $ms);
   my $rawrecvbw = median ("rawrecvbw", $ms);
   my $pubrss = max ("pubrss", $ms);
@@ -46,7 +52,7 @@ for my $sz (@sizes) {
   my $pubrecv = median ("pubrecv", $ms);
   my $subcpu = median ("subcpu", $ms);
   my $subrecv = median ("subrecv", $ms);
-  print "$sz $rate $cookedbw $rawxmitbw $rawrecvbw $pubrss $subrss $pubcpu $pubrecv $subcpu $subrecv\n";
+  print "$sz $mean $min $median $p90 $p99 $max $rawxmitbw $rawrecvbw $pubrss $subrss $pubcpu $pubrecv $subcpu $subrecv\n";
 }
 
 sub cpuload {
@@ -63,6 +69,19 @@ sub max {
   my $v;
   for (extract (@_)) { $v = $_ unless defined $v; $v = $_ if $_ > $v; }
   return $v;
+}
+
+sub min {
+  my $v;
+  for (extract (@_)) { $v = $_ unless defined $v; $v = $_ if $_ < $v; }
+  return $v;
+}
+
+sub mean {
+  my $v = 0;
+  my @xs = extract (@_);
+  $v += $_ for @xs;
+  return $v / @xs;
 }
 
 sub median {

--- a/examples/perfscript/latency-test-plot
+++ b/examples/perfscript/latency-test-plot
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+`dirname $0`/latency-test-extract "$@" > data.txt
+gnuplot <<\EOF
+set term pngcairo size 1024,768
+set output "latency-sync-listener.png"
+set st d lp
+set st li 1 lw 2
+set st li 2 lw 2
+set st li 3 lw 2
+set st li 4 lw 2
+set st li 5 lw 2
+
+set multiplot
+set logscale xy
+set title "Latency"
+set ylabel "[us]"
+set grid xtics ytics mytics
+set xlabel "payload size [bytes]"
+p "data.txt" u 1:3 ti "min", "" u 1:4 ti "median", "" u 1:5 ti "90%", "" u 1:6 ti "99%", "" u 1:7 ti "max"
+unset logscale y
+unset xlabel
+unset ylabel
+unset title
+set grid nomytics
+set origin .1, .43
+set size .55, .5
+clear
+p [10:1000]  "data.txt" u 1:3 ti "min", "" u 1:4 ti "median", "" u 1:5 ti "90%", "" u 1:6 ti "99%", "" u 1:7 ti "max"
+unset multiplot
+
+unset origin
+unset size
+
+unset logscale
+set logscale x
+set output "latency-sync-listener-bwcpu.png"
+set title "Latency: network bandwidth and CPU usage"
+set y2tics
+set ylabel "[Mbps]"
+set y2label "CPU [%]"
+set xlabel "payload size [bytes]"
+set key at graph 1, 0.7
+p "data.txt" u 1:(10*$8) ti "GbE transmit bandwidth (left)", "" u 1:(10*$9) ti "GbE receive bandwidth (left)", "" u 1:13 axes x1y2 ti "ping CPU (right)", "" u 1:15 axes x1y2 ti "pong CPU (right)"
+
+EOF

--- a/examples/perfscript/throughput-test-plot
+++ b/examples/perfscript/throughput-test-plot
@@ -1,14 +1,55 @@
 #!/bin/bash
 
-`dirname $0`/throughput-test-extract > data.txt
+`dirname $0`/throughput-test-extract "$@" > data.txt
 gnuplot <<\EOF
-set term png size 1024,768
-set output "throughput-polling.png"
-set st d l
-set title "Throughput (polling with 1ms sleeps)"
-set ylabel "M sample/s"
-set y2label "Mbps"
-set y2tics
+set term pngcairo size 1024,768
+set output "throughput-async-listener-rate.png"
+set st d lp
+set st li 1 lw 2
+set st li 2 lw 2
+set st li 3 lw 2
+
+set multiplot
+set logscale xyy2
+set title "Throughput"
+set ylabel "[Mbps]"
+set ytics (100,200,300,400,500,600,700,800,900,1000)
+set grid xtics ytics mytics
 set xlabel "payload size [bytes]"
-p "data.txt" i 5 u 1:($2/1e6) ti "rate [M sample/s]", "" i 5 u 1:3 axes x1y2 ti "app bandwidth [Mbps]", "" i 5 u 1:4 axes x1y2 ti "GbE bandwidth [Mbps]"
+# sample rate in data.txt is in kS/s
+# GbE bandwidth in data.txt is in %, so 100% => 1000 Mbps
+set key at graph 1, 0.9
+p "data.txt" u 1:3 ti "payload", "" u 1:(10*$5) ti "GbE bandwidth"
+set ytics auto
+set key default
+
+unset xlabel
+unset title
+set grid nomytics
+set ylabel "[M sample/s]"
+set origin .3, .1
+set size .6, .6
+clear
+p "data.txt" u 1:($2/1e3) ti "rate"
+unset multiplot
+
+unset origin
+unset size
+
+unset logscale
+set logscale x
+set output "throughput-async-listener-memory.png"
+set title "Throughput: memory"
+set ylabel "RSS [MB]"
+set xlabel "payload size [bytes]"
+p "data.txt" u 1:6 ti "publisher", "" u 1:7 ti "subscriber"
+
+unset logscale
+set logscale x
+set output "throughput-async-listener-cpu.png"
+set title "Throughput: CPU"
+set ylabel "CPU [%]"
+set xlabel "payload size [bytes]"
+p "data.txt" u 1:8 ti "publisher (pub thread)", "" u 1:9 ti "publisher (recvUC thread)", "" u 1:10 ti "subscriber (dq.user thread)", "" u 1:11 ti "subscriber (recvUC thread)"
+
 EOF

--- a/src/core/ddsc/src/dds_read.c
+++ b/src/core/ddsc/src/dds_read.c
@@ -84,7 +84,10 @@ static dds_return_t dds_read_impl (bool take, dds_entity_t reader_or_condition, 
       if (rd->m_loan)
       {
         if (rd->m_loan_size >= maxs)
-          buf[0] = rd->m_loan;
+        {
+          /* This ensures buf is properly initialized */
+          ddsi_sertopic_realloc_samples (buf, rd->m_topic->m_stopic, rd->m_loan, rd->m_loan_size, rd->m_loan_size);
+        }
         else
         {
           ddsi_sertopic_realloc_samples (buf, rd->m_topic->m_stopic, rd->m_loan, rd->m_loan_size, maxs);

--- a/src/core/ddsc/src/dds_sertopic_builtintopic.c
+++ b/src/core/ddsc/src/dds_sertopic_builtintopic.c
@@ -93,7 +93,7 @@ static void sertopic_builtin_realloc_samples (void **ptrs, const struct ddsi_ser
 {
   const struct ddsi_sertopic_builtintopic *tp = (const struct ddsi_sertopic_builtintopic *)sertopic_common;
   const size_t size = get_size (tp->type);
-  char *new = dds_realloc (old, size * count);
+  char *new = (oldcount == count) ? old : dds_realloc (old, size * count);
   if (new && count > oldcount)
     memset (new + size * oldcount, 0, size * (count - oldcount));
   for (size_t i = 0; i < count; i++)

--- a/src/core/ddsi/src/ddsi_sertopic_default.c
+++ b/src/core/ddsi/src/ddsi_sertopic_default.c
@@ -42,7 +42,7 @@ static void sertopic_default_realloc_samples (void **ptrs, const struct ddsi_ser
 {
   const struct ddsi_sertopic_default *tp = (const struct ddsi_sertopic_default *)sertopic_common;
   const size_t size = tp->type->m_size;
-  char *new = dds_realloc (old, size * count);
+  char *new = (oldcount == count) ? old : dds_realloc (old, size * count);
   if (new && count > oldcount)
     memset (new + size * oldcount, 0, size * (count - oldcount));
   for (size_t i = 0; i < count; i++)

--- a/src/ddsrt/CMakeLists.txt
+++ b/src/ddsrt/CMakeLists.txt
@@ -147,7 +147,7 @@ list(APPEND sources
 # network stack. In order to mix-and-match various compilers, architectures,
 # operating systems, etc input from the build system is required.
 foreach(feature atomics cdtors environ heap ifaddrs random rusage
-                sockets string sync threads time md5 process)
+                sockets string sync threads time md5 process netstat)
   if(EXISTS "${include_path}/dds/ddsrt/${feature}.h")
     list(APPEND headers "${include_path}/dds/ddsrt/${feature}.h")
     file(GLOB_RECURSE

--- a/src/ddsrt/cmake/netstat.c
+++ b/src/ddsrt/cmake/netstat.c
@@ -1,0 +1,18 @@
+/*
+ * Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include "dds/ddsrt/netstat.h"
+
+#if DDSRT_HAVE_NETSTAT
+# error "cmake_HAVE_NETSTAT=true"
+#else
+# error "cmake_HAVE_NETSTAT=false"
+#endif

--- a/src/ddsrt/include/dds/ddsrt/netstat.h
+++ b/src/ddsrt/include/dds/ddsrt/netstat.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright(c) 2019 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#ifndef DDSRT_NETSTAT_H
+#define DDSRT_NETSTAT_H
+
+#include <stdint.h>
+
+#include "dds/export.h"
+#include "dds/ddsrt/retcode.h"
+
+#if defined (__linux) || defined (__APPLE__) || defined (_WIN32)
+#define DDSRT_HAVE_NETSTAT (1)
+#else
+#define DDSRT_HAVE_NETSTAT (0)
+#endif
+
+#if DDSRT_HAVE_NETSTAT
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+struct ddsrt_netstat {
+  uint64_t ipkt;
+  uint64_t opkt;
+  uint64_t ibytes;
+  uint64_t obytes;
+};
+
+/**
+ * @brief Platform dependent control structure for network statistics
+ */
+struct ddsrt_netstat_control;
+
+/**
+ * @brief Prepare for gathering network statistics for specified interface.
+ */
+DDS_EXPORT dds_return_t
+ddsrt_netstat_new (
+  struct ddsrt_netstat_control **control,
+  const char *device);
+
+/**
+ * @brief Release resources for gathering network statistics.
+ */
+DDS_EXPORT dds_return_t
+ddsrt_netstat_free (
+  struct ddsrt_netstat_control *control);
+
+/**
+ * @brief Get network statistics.
+ */
+DDS_EXPORT dds_return_t
+ddsrt_netstat_get (
+  struct ddsrt_netstat_control *control,
+  struct ddsrt_netstat *stats);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* DDSRT_HAVE_NETSTAT */
+
+#endif /* DDSRT_NETSTAT_H */

--- a/src/ddsrt/include/dds/ddsrt/rusage.h
+++ b/src/ddsrt/include/dds/ddsrt/rusage.h
@@ -22,12 +22,15 @@
 # else
 #   define DDSRT_HAVE_RUSAGE 0
 #endif
-#else
+#elif defined (_WIN32) || defined (__linux) || defined (__APPLE__)
 # define DDSRT_HAVE_RUSAGE 1
+#else
+# define DDSRT_HAVE_RUSAGE 0
 #endif
 
 #include "dds/ddsrt/time.h"
 #include "dds/ddsrt/retcode.h"
+#include "dds/ddsrt/threads.h"
 
 #if defined (__cplusplus)
 extern "C" {
@@ -43,8 +46,10 @@ typedef struct {
   size_t nivcsw; /* Involuntary context switches. Not maintained on Windows. */
 } ddsrt_rusage_t;
 
-#define DDSRT_RUSAGE_SELF (0)
-#define DDSRT_RUSAGE_THREAD (1)
+enum ddsrt_getrusage_who {
+  DDSRT_RUSAGE_SELF,
+  DDSRT_RUSAGE_THREAD
+};
 
 /**
  * @brief Get resource usage for the current thread or process.
@@ -61,7 +66,26 @@ typedef struct {
  * @retval DDS_RETCODE_ERROR
  *             An unidentified error occurred.
  */
-DDS_EXPORT dds_return_t ddsrt_getrusage(int who, ddsrt_rusage_t *usage);
+DDS_EXPORT dds_return_t ddsrt_getrusage(enum ddsrt_getrusage_who who, ddsrt_rusage_t *usage);
+
+#if DDSRT_HAVE_THREAD_LIST
+/**
+ * @brief Get resource usage for some thread.
+ *
+ * @param[in]  tid    id of the thread of to get the resource usage for
+ * @param[in]  usage  Structure where resource usage is returned.
+ *
+ * @returns A dds_return_t indicating success or failure.
+ *
+ * @retval DDS_RETCODE_OK
+ *             Resource usage successfully returned in @usage.
+ * @retval DDS_RETCODE_OUT_OF_RESOURCES
+ *             There were not enough resources to get resource usage.
+ * @retval DDS_RETCODE_ERROR
+ *             An unidentified error occurred.
+ */
+DDS_EXPORT dds_return_t ddsrt_getrusage_anythread (ddsrt_thread_list_id_t tid, ddsrt_rusage_t * __restrict usage);
+#endif
 
 #if defined (__cplusplus)
 }

--- a/src/ddsrt/include/dds/ddsrt/threads.h
+++ b/src/ddsrt/include/dds/ddsrt/threads.h
@@ -214,6 +214,53 @@ ddsrt_thread_setname(
   const char *__restrict name);
 #endif
 
+#if DDSRT_HAVE_THREAD_LIST
+/**
+ * @brief Get a list of threads in the calling process
+ *
+ * @param[out]  tids    Array of size elements to be filled with thread
+ *                      identifiers, may be NULL if size is 0
+ * @param[in]   size    The size of the tids array; 0 is allowed
+ *
+ * @returns A dds_return_t indicating the number of threads in the process
+ * or an error code on failure.
+ *
+ * @retval > 0
+ *             Number of threads in the process, may be larger than size
+ *             tids[0 .. (return - 1)] are valid
+ * @retval DDS_RETCODE_ERROR
+ *             Something went wrong, contents of tids is undefined
+ * @retval DDS_RETCODE_UNSUPPORTED
+ *             Not supported on the platform
+ */
+DDS_EXPORT dds_return_t ddsrt_thread_list (ddsrt_thread_list_id_t * __restrict tids, size_t size);
+
+/**
+ * @brief Get the name of the specified thread (in the calling process)
+ *
+ * @param[in]   tid     Thread identifier for which the name is sought
+ * @param[out]  name    Filled with the thread name (or a synthesized one)
+ *                      on successful return; name is silently truncated
+ *                      if the actual name is longer than name can hold;
+ *                      always 0-terminated if size > 0
+ * @param[in]   size    Number of bytes of name that may be assigned, size
+ *                      is 0 is allowed, though somewhat useless
+ *
+ * @returns A dds_return_t indicating success or failure.
+ *
+ * @retval DDS_RETCODE_OK
+ *             Possibly truncated name is returned as a null-terminated
+ *             string in name (provided size > 0).
+ * @retval DDS_RETCODE_NOT_FOUND
+ *             Thread not found; the contents of name is unchanged
+ * @retval DDS_RETCODE_ERROR
+ *             Unspecified failure, the contents of name is undefined
+ * @retval DDS_RETCODE_UNSUPPORTED
+ *             Not supported on the platform
+ */
+DDS_EXPORT dds_return_t ddsrt_thread_getname_anythread (ddsrt_thread_list_id_t tid, char *__restrict name, size_t size);
+#endif
+
 /**
  * @brief Push cleanup handler onto the cleanup stack
  *

--- a/src/ddsrt/include/dds/ddsrt/threads/freertos.h
+++ b/src/ddsrt/include/dds/ddsrt/threads/freertos.h
@@ -16,6 +16,7 @@
 #include <task.h>
 
 #define DDSRT_HAVE_THREAD_SETNAME (0)
+#define DDSRT_HAVE_THREAD_LIST (0)
 
 #if defined(__cplusplus)
 extern "C" {

--- a/src/ddsrt/include/dds/ddsrt/threads/posix.h
+++ b/src/ddsrt/include/dds/ddsrt/threads/posix.h
@@ -19,6 +19,11 @@
 #else
 #define DDSRT_HAVE_THREAD_SETNAME (1)
 #endif
+#if defined (__linux) || defined (__APPLE__)
+#define DDSRT_HAVE_THREAD_LIST (1)
+#else
+#define DDSRT_HAVE_THREAD_LIST (0)
+#endif
 
 #if defined (__cplusplus)
 extern "C" {
@@ -27,6 +32,7 @@ extern "C" {
 #if defined(__linux)
 typedef long int ddsrt_tid_t;
 #define PRIdTID "ld"
+typedef long int ddsrt_thread_list_id_t;
 /* __linux */
 #elif defined(__FreeBSD__) && (__FreeBSD_version >= 900031)
 /* FreeBSD >= 9.0 */
@@ -38,6 +44,8 @@ typedef int ddsrt_tid_t;
 /* macOS X >= 10.6 */
 typedef uint64_t ddsrt_tid_t;
 #define PRIdTID PRIu64
+/* ddsrt_thread_list_id_t is actually a mach_port_t */
+typedef uint32_t ddsrt_thread_list_id_t;
 /* __APPLE__ */
 #elif defined(__VXWORKS__)
 /* TODO: Verify taskIdSelf is the right function to use on VxWorks */

--- a/src/ddsrt/include/dds/ddsrt/threads/windows.h
+++ b/src/ddsrt/include/dds/ddsrt/threads/windows.h
@@ -15,6 +15,7 @@
 #include "dds/ddsrt/types.h"
 
 #define DDSRT_HAVE_THREAD_SETNAME (1)
+#define DDSRT_HAVE_THREAD_LIST (1)
 
 #if defined (__cplusplus)
 extern "C" {
@@ -27,6 +28,8 @@ typedef struct {
 
 typedef DWORD ddsrt_tid_t;
 #define PRIdTID "u"
+
+typedef HANDLE ddsrt_thread_list_id_t;
 
 #if defined (__cplusplus)
 }

--- a/src/ddsrt/src/netstat/darwin/netstat.c
+++ b/src/ddsrt/src/netstat/darwin/netstat.c
@@ -1,0 +1,130 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <sys/param.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/socket.h>
+#include <sys/sysctl.h>
+#include <net/if.h>
+#include <net/if_var.h>
+#include <net/if_types.h>
+#include <net/if.h>
+#include <net/if_mib.h>
+#include <errno.h>
+
+#include <dds/ddsrt/heap.h>
+#include <dds/ddsrt/string.h>
+#include <dds/ddsrt/netstat.h>
+
+struct ddsrt_netstat_control {
+  char *name;
+  int cached_row;
+};
+
+static dds_return_t ddsrt_netstat_get_int (struct ddsrt_netstat_control *control, struct ddsrt_netstat *stats)
+{
+  int name[6];
+  size_t len;
+  int count;
+  struct ifmibdata ifmd;
+
+  if (control->cached_row > 0)
+  {
+    name[0] = CTL_NET;
+    name[1] = PF_LINK;
+    name[2] = NETLINK_GENERIC;
+    name[3] = IFMIB_IFDATA;
+    name[4] = control->cached_row;
+    name[5] = IFDATA_GENERAL;
+    len = sizeof (ifmd);
+    if (sysctl (name, 6, &ifmd, &len, NULL, 0) != 0)
+      control->cached_row = 0;
+    else if (strcmp (ifmd.ifmd_name, control->name) != 0)
+      control->cached_row = 0;
+  }
+
+  if (control->cached_row == 0)
+  {
+    name[0] = CTL_NET;
+    name[1] = PF_LINK;
+    name[2] = NETLINK_GENERIC;
+    name[3] = IFMIB_SYSTEM;
+    name[4] = IFMIB_IFCOUNT;
+    len = sizeof (count);
+    if (sysctl (name, 5, &count, &len, NULL, 0) != 0)
+      goto error;
+    for (int row = 1; row <= count; row++)
+    {
+      name[0] = CTL_NET;
+      name[1] = PF_LINK;
+      name[2] = NETLINK_GENERIC;
+      name[3] = IFMIB_IFDATA;
+      name[4] = row;
+      name[5] = IFDATA_GENERAL;
+      len = sizeof (ifmd);
+      if (sysctl (name, 6, &ifmd, &len, NULL, 0) != 0)
+      {
+        if (errno != ENOENT)
+          goto error;
+      }
+      else if (strcmp (control->name, ifmd.ifmd_name) == 0)
+      {
+        control->cached_row = row;
+        break;
+      }
+    }
+  }
+
+  if (control->cached_row == 0)
+    return DDS_RETCODE_NOT_FOUND;
+  else
+  {
+    stats->ipkt = ifmd.ifmd_data.ifi_ipackets;
+    stats->opkt = ifmd.ifmd_data.ifi_opackets;
+    stats->ibytes = ifmd.ifmd_data.ifi_ibytes;
+    stats->obytes = ifmd.ifmd_data.ifi_obytes;
+    return DDS_RETCODE_OK;
+  }
+
+ error:
+  control->cached_row = -1;
+  return DDS_RETCODE_ERROR;
+}
+
+dds_return_t ddsrt_netstat_new (struct ddsrt_netstat_control **control, const char *device)
+{
+  struct ddsrt_netstat_control *c = ddsrt_malloc (sizeof (*c));
+  struct ddsrt_netstat dummy;
+  c->name = ddsrt_strdup (device);
+  c->cached_row = 0;
+  if (ddsrt_netstat_get_int (c, &dummy) != DDS_RETCODE_OK)
+  {
+    ddsrt_free (c->name);
+    ddsrt_free (c);
+    *control = NULL;
+    return DDS_RETCODE_ERROR;
+  }
+  else
+  {
+    *control = c;
+    return DDS_RETCODE_OK;
+  }
+}
+
+dds_return_t ddsrt_netstat_free (struct ddsrt_netstat_control *control)
+{
+  ddsrt_free (control->name);
+  ddsrt_free (control);
+  return DDS_RETCODE_OK;
+}
+
+dds_return_t ddsrt_netstat_get (struct ddsrt_netstat_control *control, struct ddsrt_netstat *stats)
+{
+  if (control->cached_row < 0)
+    return DDS_RETCODE_ERROR;
+  else
+    return ddsrt_netstat_get_int (control, stats);
+}

--- a/src/ddsrt/src/netstat/linux/netstat.c
+++ b/src/ddsrt/src/netstat/linux/netstat.c
@@ -1,0 +1,146 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+
+#include <dds/ddsrt/heap.h>
+#include <dds/ddsrt/string.h>
+#include <dds/ddsrt/netstat.h>
+
+struct ddsrt_netstat_control {
+  char *name;
+};
+
+dds_return_t ddsrt_netstat_get (struct ddsrt_netstat_control *control, struct ddsrt_netstat *stats)
+{
+  FILE *fp;
+  char save[256];
+  int c;
+  size_t np;
+  int field = 0;
+  if ((fp = fopen ("/proc/net/dev", "r")) == NULL)
+    return DDS_RETCODE_ERROR;
+  /* expected format: 2 header lines, then on each line, white space/interface
+     name/colon and then numbers. Received bytes is 1st data field, transmitted
+     bytes is 9th.
+
+     SKIP_HEADER_1 skips up to and including the first newline; then SKIP_TO_EOL
+     skips up to and including the second newline, so the first line that gets
+     interpreted is the third.
+   */
+  dds_return_t res = DDS_RETCODE_NOT_FOUND;
+  enum { SKIP_HEADER_1, SKIP_WHITE, READ_NAME, SKIP_TO_EOL, READ_SEP, READ_INT } state = SKIP_HEADER_1;
+  np = 0;
+  while (res == DDS_RETCODE_NOT_FOUND && (c = fgetc (fp)) != EOF) {
+    switch (state) {
+      case SKIP_HEADER_1:
+        if (c == '\n') {
+          state = SKIP_TO_EOL;
+        }
+        break;
+      case SKIP_WHITE:
+        if (c != ' ' && c != '\t') {
+          save[np++] = (char) c;
+          state = READ_NAME;
+        }
+        break;
+      case READ_NAME:
+        if (c == ':') {
+          save[np] = 0;
+          np = 0;
+          if (strcmp (save, control->name) != 0)
+            state = SKIP_TO_EOL;
+          else
+            state = READ_SEP;
+        } else if (np < sizeof (save) - 1) {
+          save[np++] = (char) c;
+        }
+        break;
+      case SKIP_TO_EOL:
+        if (c == '\n') {
+          state = SKIP_WHITE;
+        }
+        break;
+      case READ_SEP:
+        if (c == '\n')
+        {
+          /* unexpected end of line */
+          res = DDS_RETCODE_ERROR;
+        }
+        else if (c >= '0' && c <= '9')
+        {
+          field++;
+          save[np++] = (char) c;
+          state = READ_INT;
+        }
+        break;
+      case READ_INT:
+        if (c >= '0' && c <= '9')
+        {
+          if (np == sizeof (save) - 1)
+          {
+            res = DDS_RETCODE_ERROR;
+            break;
+          }
+          save[np++] = (char) c;
+        }
+        else
+        {
+          save[np] = 0;
+          np = 0;
+          if (field == 1 || field == 2 || field == 9 || field == 10)
+          {
+            int pos;
+            uint64_t val;
+            if (sscanf (save, "%"SCNu64"%n", &val, &pos) != 1 || save[pos] != 0)
+              res = DDS_RETCODE_ERROR;
+            else
+            {
+              switch (field)
+              {
+                case  1: stats->ibytes = val; break;
+                case  2: stats->ipkt   = val; break;
+                case  9: stats->obytes = val; break;
+                case 10: stats->opkt   = val; res = DDS_RETCODE_OK; break;
+              }
+            }
+          }
+          if (c == '\n' && res != DDS_RETCODE_OK)
+          {
+            /* newline before all expected fields have been read */
+            res = DDS_RETCODE_ERROR;
+          }
+          state = READ_SEP;
+        }
+        break;
+    }
+  }
+  fclose (fp);
+  return res;
+}
+
+dds_return_t ddsrt_netstat_new (struct ddsrt_netstat_control **control, const char *device)
+{
+  struct ddsrt_netstat_control *c = ddsrt_malloc (sizeof (*c));
+  struct ddsrt_netstat dummy;
+  c->name = ddsrt_strdup (device);
+  if (ddsrt_netstat_get (c, &dummy) != DDS_RETCODE_OK)
+  {
+    ddsrt_free (c->name);
+    ddsrt_free (c);
+    *control = NULL;
+    return DDS_RETCODE_ERROR;
+  }
+  else
+  {
+    *control = c;
+    return DDS_RETCODE_OK;
+  }
+}
+
+dds_return_t ddsrt_netstat_free (struct ddsrt_netstat_control *control)
+{
+  ddsrt_free (control->name);
+  ddsrt_free (control);
+  return DDS_RETCODE_OK;
+}

--- a/src/ddsrt/src/netstat/windows/netstat.c
+++ b/src/ddsrt/src/netstat/windows/netstat.c
@@ -1,0 +1,115 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <Windows.h>
+
+#include <ws2def.h>
+#include <ws2ipdef.h>
+#include <iphlpapi.h>
+
+#include <dds/ddsrt/heap.h>
+#include <dds/ddsrt/string.h>
+#include <dds/ddsrt/netstat.h>
+
+struct ddsrt_netstat_control {
+  wchar_t *name;
+  bool errored;
+  bool have_index;
+  NET_IFINDEX index;
+};
+
+static void copy_data (struct ddsrt_netstat *dst, const MIB_IF_ROW2 *src)
+{
+  dst->ipkt = src->InUcastPkts + src->InNUcastPkts;
+  dst->opkt = src->OutUcastPkts + src->OutNUcastPkts;
+  dst->ibytes = src->InOctets;
+  dst->obytes = src->OutOctets;
+}
+
+static bool is_desired_interface (const struct ddsrt_netstat_control *control, const MIB_IF_ROW2 *info)
+{
+  return wcscmp (control->name, info->Description) == 0 || wcscmp (control->name, info->Alias) == 0;
+}
+
+static dds_return_t ddsrt_netstat_get_int (struct ddsrt_netstat_control *control, struct ddsrt_netstat *stats)
+{
+  if (control->errored)
+    return DDS_RETCODE_ERROR;
+
+  if (control->have_index)
+  {
+    MIB_IF_ROW2 info;
+    memset (&info, 0, sizeof (info));
+    info.InterfaceIndex = control->index;
+    if (GetIfEntry2 (&info) != NO_ERROR || !is_desired_interface (control, &info))
+      control->have_index = false;
+    else
+    {
+      copy_data (stats, &info);
+      return DDS_RETCODE_OK;
+    }
+  }
+
+  MIB_IF_TABLE2 *table;
+  if (GetIfTable2 (&table) != NO_ERROR)
+    goto error;
+  control->have_index = false;
+  for (ULONG row = 0; row < table->NumEntries; row++)
+  {
+    if (is_desired_interface (control, &table->Table[row]))
+    {
+      control->index = table->Table[row].InterfaceIndex;
+      control->have_index = true;
+      copy_data (stats, &table->Table[row]);
+      break;
+    }
+  }
+  FreeMibTable (table);
+  return control->have_index ? DDS_RETCODE_OK : DDS_RETCODE_NOT_FOUND;
+
+ error:
+  control->errored = true;
+  return DDS_RETCODE_ERROR;
+}
+
+dds_return_t ddsrt_netstat_new (struct ddsrt_netstat_control **control, const char *device)
+{
+  struct ddsrt_netstat_control *c = ddsrt_malloc (sizeof (*c));
+  struct ddsrt_netstat dummy;
+  size_t name_size = strlen (device) + 1;
+  c->name = ddsrt_malloc (name_size * sizeof (*c->name));
+  size_t cnt = 0;
+  mbstowcs_s (&cnt, c->name, name_size, device, _TRUNCATE);
+  c->have_index = false;
+  c->errored = false;
+  c->index = 0;
+  if (ddsrt_netstat_get_int (c, &dummy) != DDS_RETCODE_OK)
+  {
+    ddsrt_free (c->name);
+    ddsrt_free (c);
+    *control = NULL;
+    return DDS_RETCODE_ERROR;
+  }
+  else
+  {
+    *control = c;
+    return DDS_RETCODE_OK;
+  }
+}
+
+dds_return_t ddsrt_netstat_free (struct ddsrt_netstat_control *control)
+{
+  ddsrt_free (control->name);
+  ddsrt_free (control);
+  return DDS_RETCODE_OK;
+}
+
+dds_return_t ddsrt_netstat_get (struct ddsrt_netstat_control *control, struct ddsrt_netstat *stats)
+{
+  return ddsrt_netstat_get_int (control, stats);
+}

--- a/src/ddsrt/src/rusage/freertos/rusage.c
+++ b/src/ddsrt/src/rusage/freertos/rusage.c
@@ -78,8 +78,18 @@ rusage_thread(ddsrt_rusage_t *usage)
   return DDS_RETCODE_OK;
 }
 
+#if ! DDSRT_HAVE_THREAD_LIST
+static
+#endif
 dds_return_t
-ddsrt_getrusage(int who, ddsrt_rusage_t *usage)
+ddsrt_getrusage_anythread(ddsrt_thread_list_id_t tid, ddsrt_rusage_t *__restrict usage)
+{
+  assert(usage != NULL);
+  return rusage_thread(tid, usage);
+}
+
+dds_return_t
+ddsrt_getrusage(enum ddsrt_getrusage_who who, ddsrt_rusage_t *usage)
 {
   dds_return_t rc;
 
@@ -87,7 +97,7 @@ ddsrt_getrusage(int who, ddsrt_rusage_t *usage)
   assert(usage != NULL);
 
   if (who == DDSRT_RUSAGE_THREAD) {
-    rc = rusage_thread(usage);
+    rc = rusage_thread_anythread(xTaskGetCurrentTaskHandle(), usage);
   } else {
     rc = rusage_self(usage);
   }

--- a/src/ddsrt/src/rusage/posix/rusage.c
+++ b/src/ddsrt/src/rusage/posix/rusage.c
@@ -15,87 +15,212 @@
 #include <string.h>
 #include <sys/resource.h>
 
-#if defined(__APPLE__)
+#include "dds/ddsrt/rusage.h"
+
+#if defined __linux
+#include <stdio.h>
+#include <dirent.h>
+
+dds_return_t
+ddsrt_getrusage_anythread (
+  ddsrt_thread_list_id_t tid,
+  ddsrt_rusage_t * __restrict usage)
+{
+  /* Linux' man pages happily state that the second field is the process/task name
+     in parentheses, and that %s is the correct scanf conversion.  As it turns out
+     the process name itself can contain spaces and parentheses ... so %s is not a
+     good choice for the general case.  The others are spec'd as a character or a
+     number, which suggests the correct procedure is to have the 2nd field start at
+     the first ( and end at the last ) ...
+
+     RSS is per-process, so no point in populating that one
+     field 14, 15: utime, stime (field 1 is first)
+
+     Voluntary and involuntary context switches can be found in .../status, but
+     not in stat; and .../status does not give the time.  Crazy.  */
+  const double hz = (double) sysconf (_SC_CLK_TCK);
+  char file[100];
+  FILE *fp;
+  int pos;
+  pos = snprintf (file, sizeof (file), "/proc/self/task/%lu/stat", (unsigned long) tid);
+  if (pos < 0 || pos >= (int) sizeof (file))
+    return DDS_RETCODE_ERROR;
+  if ((fp = fopen (file, "r")) == NULL)
+    return DDS_RETCODE_NOT_FOUND;
+  /* max 2 64-bit ints plus some whitespace; need 1 extra for detecting something
+     went wrong and we ended up gobbling up garbage; 64 will do */
+  char save[64];
+  size_t savepos = 0;
+  int prevc, c;
+  int field = 1;
+  for (prevc = 0; (c = fgetc (fp)) != EOF; prevc = c)
+  {
+    if (field == 1)
+    {
+      if (c == '(')
+        field = 2;
+    }
+    else if (field >= 2)
+    {
+      /* each close paren resets the field counter to 3 (the first is common,
+         further ones are rare and occur only if the thread name contains a
+         closing parenthesis), as well as the save space for fields 14 & 15
+         that we care about. */
+      if (c == ')')
+      {
+        field = 2;
+        savepos = 0;
+      }
+      else
+      {
+        /* next field on transition of whitespace to non-whitespace */
+        if (c != ' ' && prevc == ' ')
+          field++;
+        /* save fields 14 & 15 while continuing scanning to EOF on the off-chance
+           that 14&15 initially appear to be in what ultimately turns out to be
+           task name */
+        if (field == 14 || field == 15)
+        {
+          if (savepos < sizeof (save) - 1)
+            save[savepos++] = (char) c;
+        }
+      }
+    }
+  }
+  fclose (fp);
+  assert (savepos < sizeof (save));
+  save[savepos] = 0;
+  if (savepos == sizeof (save) - 1)
+    return DDS_RETCODE_ERROR;
+  /* it's really integer, but the conversion from an unknown HZ value is much
+     less tricky in floating-point */
+  double user, sys;
+  if (sscanf (save, "%lf %lf%n", &user, &sys, &pos) != 2 || (save[pos] != 0 && save[pos] != ' '))
+    return DDS_RETCODE_ERROR;
+  usage->utime = (dds_time_t) (1e9 * user / hz);
+  usage->stime = (dds_time_t) (1e9 * sys / hz);
+  usage->idrss = 0;
+  usage->maxrss = 0;
+  usage->nvcsw = 0;
+  usage->nivcsw = 0;
+
+  pos = snprintf (file, sizeof (file), "/proc/self/task/%lu/status", (unsigned long) tid);
+  if (pos < 0 || pos >= (int) sizeof (file))
+    return DDS_RETCODE_ERROR;
+  if ((fp = fopen (file, "r")) == NULL)
+    return DDS_RETCODE_NOT_FOUND;
+  enum { ERROR, READ_HEADING, SKIP_TO_EOL, READ_VCSW, READ_IVCSW } state = READ_HEADING;
+  savepos = 0;
+  while (state != ERROR && (c = fgetc (fp)) != EOF)
+  {
+    switch (state)
+    {
+      case READ_HEADING:
+        if (savepos < sizeof (save) - 1)
+          save[savepos++] = (char) c;
+        if (c == ':')
+        {
+          save[savepos] = 0;
+          savepos = 0;
+          if (strcmp (save, "voluntary_ctxt_switches:") == 0)
+            state = READ_VCSW;
+          else if (strcmp (save, "nonvoluntary_ctxt_switches:") == 0)
+            state = READ_IVCSW;
+          else
+            state = SKIP_TO_EOL;
+        }
+        break;
+      case SKIP_TO_EOL:
+        if (c == '\n')
+          state = READ_HEADING;
+        break;
+      case READ_VCSW:
+      case READ_IVCSW:
+        if (fscanf (fp, "%zu", (state == READ_VCSW) ? &usage->nvcsw : &usage->nivcsw) != 1)
+          state = ERROR;
+        else
+          state = SKIP_TO_EOL;
+        break;
+      case ERROR:
+        break;
+    }
+  }
+  fclose (fp);
+  return (state == ERROR) ? DDS_RETCODE_ERROR : DDS_RETCODE_OK;
+}
+
+dds_return_t
+ddsrt_getrusage (enum ddsrt_getrusage_who who, ddsrt_rusage_t *usage)
+{
+  struct rusage buf;
+
+  assert (who == DDSRT_RUSAGE_SELF || who == DDSRT_RUSAGE_THREAD);
+  assert (usage != NULL);
+
+  memset (&buf, 0, sizeof(buf));
+  if (getrusage ((who == DDSRT_RUSAGE_SELF) ? RUSAGE_SELF : RUSAGE_THREAD, &buf) == -1)
+    return DDS_RETCODE_ERROR;
+
+  usage->utime = (buf.ru_utime.tv_sec * DDS_NSECS_IN_SEC) + (buf.ru_utime.tv_usec * DDS_NSECS_IN_USEC);
+  usage->stime = (buf.ru_stime.tv_sec * DDS_NSECS_IN_SEC) + (buf.ru_stime.tv_usec * DDS_NSECS_IN_USEC);
+  usage->maxrss = 1024 * (size_t) buf.ru_maxrss;
+  usage->idrss = (size_t) buf.ru_idrss;
+  usage->nvcsw = (size_t) buf.ru_nvcsw;
+  usage->nivcsw = (size_t) buf.ru_nivcsw;
+  return DDS_RETCODE_OK;
+}
+#elif defined (__APPLE__)
 #include <mach/mach_init.h>
 #include <mach/mach_port.h>
 #include <mach/thread_act.h>
-#endif
-
-#include "dds/ddsrt/rusage.h"
 
 dds_return_t
-ddsrt_getrusage(int who, ddsrt_rusage_t *usage)
+ddsrt_getrusage_anythread (
+  ddsrt_thread_list_id_t tid,
+  ddsrt_rusage_t * __restrict usage)
 {
-  int err = 0;
+  mach_msg_type_number_t cnt;
+  thread_basic_info_data_t info;
+  cnt = THREAD_BASIC_INFO_COUNT;
+  if (thread_info ((mach_port_t) tid, THREAD_BASIC_INFO, (thread_info_t) &info, &cnt) != KERN_SUCCESS)
+    return DDS_RETCODE_ERROR;
+
+  /* Don't see an (easy) way to get context switch counts */
+  usage->utime = info.user_time.seconds * DDS_NSECS_IN_SEC + info.user_time.microseconds * DDS_NSECS_IN_USEC;
+  usage->stime = info.system_time.seconds * DDS_NSECS_IN_SEC + info.system_time.microseconds * DDS_NSECS_IN_USEC;
+  usage->idrss = 0;
+  usage->maxrss = 0;
+  usage->nivcsw = 0;
+  usage->nvcsw = 0;
+  return DDS_RETCODE_OK;
+}
+
+dds_return_t
+ddsrt_getrusage (enum ddsrt_getrusage_who who, ddsrt_rusage_t *usage)
+{
   struct rusage buf;
   dds_return_t rc;
 
-  assert(who == DDSRT_RUSAGE_SELF || who == DDSRT_RUSAGE_THREAD);
-  assert(usage != NULL);
+  assert (usage != NULL);
 
-  memset(&buf, 0, sizeof(buf));
+  memset (&buf, 0, sizeof(buf));
+  if (getrusage (RUSAGE_SELF, &buf) == -1)
+    return DDS_RETCODE_ERROR;
 
-#if defined(__linux)
-  if ((who == DDSRT_RUSAGE_SELF && getrusage(RUSAGE_SELF, &buf) == -1) ||
-      (who == DDSRT_RUSAGE_THREAD && getrusage(RUSAGE_THREAD, &buf) == -1))
-  {
-    err = errno;
-  } else {
-    buf.ru_maxrss *= 1024;
+  switch (who) {
+    case DDSRT_RUSAGE_THREAD:
+      if ((rc = ddsrt_getrusage_anythread (pthread_mach_thread_np (pthread_self()), usage)) < 0)
+        return rc;
+      break;
+    case DDSRT_RUSAGE_SELF:
+      usage->utime = (buf.ru_utime.tv_sec * DDS_NSECS_IN_SEC) + (buf.ru_utime.tv_usec * DDS_NSECS_IN_USEC);
+      usage->stime = (buf.ru_stime.tv_sec * DDS_NSECS_IN_SEC) + (buf.ru_stime.tv_usec * DDS_NSECS_IN_USEC);
+      usage->nvcsw = (size_t) buf.ru_nvcsw;
+      usage->nivcsw = (size_t) buf.ru_nivcsw;
+      break;
   }
-#else
-  if (getrusage(RUSAGE_SELF, &buf) == -1) {
-    err = errno;
-  } else if (who == DDSRT_RUSAGE_THREAD) {
-    memset(&buf.ru_utime, 0, sizeof(buf.ru_utime));
-    memset(&buf.ru_stime, 0, sizeof(buf.ru_stime));
-    buf.ru_nvcsw = 0;
-    buf.ru_nivcsw = 0;
-
-#if defined(__APPLE__)
-    kern_return_t ret;
-    mach_port_t thr;
-    mach_msg_type_number_t cnt;
-    thread_basic_info_data_t info;
-
-    thr = mach_thread_self();
-    assert(thr != MACH_PORT_DEAD);
-    if (thr == MACH_PORT_NULL) {
-      /* Resource shortage prevented reception of send right. */
-      err = ENOMEM;
-    } else {
-      cnt = THREAD_BASIC_INFO_COUNT;
-      ret = thread_info(
-        thr, THREAD_BASIC_INFO, (thread_info_t)&info, &cnt);
-      assert(ret != KERN_INVALID_ARGUMENT);
-      /* Assume MIG_ARRAY_TOO_LARGE will not happen. */
-      buf.ru_utime.tv_sec = info.user_time.seconds;
-      buf.ru_utime.tv_usec = info.user_time.microseconds;
-      buf.ru_stime.tv_sec = info.system_time.seconds;
-      buf.ru_stime.tv_usec = info.system_time.microseconds;
-      mach_port_deallocate(mach_task_self(), thr);
-    }
-#endif /* __APPLE__ */
-  }
-#endif /* __linux */
-
-  if (err == 0) {
-    rc = DDS_RETCODE_OK;
-    usage->utime =
-      (buf.ru_utime.tv_sec * DDS_NSECS_IN_SEC) +
-      (buf.ru_utime.tv_usec * DDS_NSECS_IN_USEC);
-    usage->stime =
-      (buf.ru_stime.tv_sec * DDS_NSECS_IN_SEC) +
-      (buf.ru_stime.tv_usec * DDS_NSECS_IN_USEC);
-    usage->maxrss = (size_t)buf.ru_maxrss;
-    usage->idrss = (size_t)buf.ru_idrss;
-    usage->nvcsw = (size_t)buf.ru_nvcsw;
-    usage->nivcsw = (size_t)buf.ru_nivcsw;
-  } else if (err == ENOMEM) {
-    rc = DDS_RETCODE_OUT_OF_RESOURCES;
-  } else {
-    rc = DDS_RETCODE_ERROR;
-  }
-
-  return rc;
+  usage->maxrss = (size_t) buf.ru_maxrss;
+  usage->idrss = (size_t) buf.ru_idrss;
+  return DDS_RETCODE_OK;
 }
+#endif

--- a/src/ddsrt/src/rusage/windows/rusage.c
+++ b/src/ddsrt/src/rusage/windows/rusage.c
@@ -18,36 +18,60 @@
 #include <psapi.h>
 
 dds_time_t
-filetime_to_time(const FILETIME *ft)
+filetime_to_time (const FILETIME *ft)
 {
     /* FILETIME structures express times in 100-nanosecond time units. */
-    return ((ft->dwHighDateTime << 31) + (ft->dwLowDateTime)) * 100;
+    return (dds_time_t) ((((uint64_t) ft->dwHighDateTime << 31) + (ft->dwLowDateTime)) * 100);
 }
 
 dds_return_t
-ddsrt_getrusage(int who, ddsrt_rusage_t *usage)
+ddsrt_getrusage_anythread (ddsrt_thread_list_id_t tid, ddsrt_rusage_t * __restrict usage)
 {
     FILETIME stime, utime, ctime, etime;
-    PROCESS_MEMORY_COUNTERS pmctrs;
 
-    assert(who == DDSRT_RUSAGE_SELF || who == DDSRT_RUSAGE_THREAD);
-    assert(usage != NULL);
+    assert (usage != NULL);
 
     /* Memory counters are per process, but populate them if thread resource
        usage is requested to keep in sync with Linux. */
-    if ((!GetProcessMemoryInfo(GetCurrentProcess(), &pmctrs, sizeof(pmctrs)))
-     || (who == DDSRT_RUSAGE_SELF &&
-         !GetProcessTimes(GetCurrentProcess(), &ctime, &etime, &stime, &utime))
-     || (who == DDSRT_RUSAGE_THREAD &&
-         !GetThreadTimes(GetCurrentThread(), &ctime, &etime, &stime, &utime)))
-    {
-        return GetLastError();
-    }
+    if (!GetThreadTimes (tid, &ctime, &etime, &stime, &utime))
+      return DDS_RETCODE_ERROR;
 
-    memset(usage, 0, sizeof(*usage));
-    usage->stime = filetime_to_time(&stime);
-    usage->utime = filetime_to_time(&utime);
-    usage->maxrss = pmctrs.PeakWorkingSetSize;
-
+    memset (usage, 0, sizeof (*usage));
+    usage->stime = filetime_to_time (&stime);
+    usage->utime = filetime_to_time (&utime);
     return DDS_RETCODE_OK;
 }
+
+dds_return_t
+ddsrt_getrusage (enum ddsrt_getrusage_who who, ddsrt_rusage_t *usage)
+{
+    PROCESS_MEMORY_COUNTERS pmctrs;
+
+    assert (who == DDSRT_RUSAGE_SELF || who == DDSRT_RUSAGE_THREAD);
+    assert (usage != NULL);
+
+    /* Memory counters are per process, but populate them if thread resource
+       usage is requested to keep in sync with Linux. */
+    if (!GetProcessMemoryInfo (GetCurrentProcess (), &pmctrs, sizeof (pmctrs)))
+      return DDS_RETCODE_ERROR;
+
+    if (who == DDSRT_RUSAGE_THREAD)
+    {
+      dds_return_t rc;
+      if ((rc = ddsrt_getrusage_anythread (GetCurrentThread (), usage)) < 0)
+        return rc;
+    }
+    else
+    {
+      FILETIME stime, utime, ctime, etime;
+      if (!GetProcessTimes (GetCurrentProcess (), &ctime, &etime, &stime, &utime))
+        return DDS_RETCODE_ERROR;
+      memset(usage, 0, sizeof(*usage));
+      usage->stime = filetime_to_time(&stime);
+      usage->utime = filetime_to_time(&utime);
+    }
+
+    usage->maxrss = pmctrs.PeakWorkingSetSize;
+    return DDS_RETCODE_OK;
+}
+

--- a/src/ddsrt/src/threads/posix/threads.c
+++ b/src/ddsrt/src/threads/posix/threads.c
@@ -30,6 +30,7 @@
 #include "dds/ddsrt/string.h"
 #include "dds/ddsrt/threads_priv.h"
 #include "dds/ddsrt/types.h"
+#include "dds/ddsrt/static_assert.h"
 
 typedef struct {
   char *name;
@@ -39,9 +40,14 @@ typedef struct {
 
 #if defined(__linux)
 #include <sys/syscall.h>
+#include <dirent.h>
 #define MAXTHREADNAMESIZE (15) /* 16 bytes including null-terminating byte. */
 #elif defined(__APPLE__)
+#include <mach/mach_init.h>
 #include <mach/thread_info.h> /* MAXTHREADNAMESIZE */
+#include <mach/task.h>
+#include <mach/task_info.h>
+#include <mach/vm_map.h>
 #elif defined(__sun)
 #define MAXTHREADNAMESIZE (31)
 #elif defined(__FreeBSD__)
@@ -363,7 +369,7 @@ ddsrt_thread_join(ddsrt_thread_t thread, uint32_t *thread_result)
 
   if ((err = pthread_join (thread.v, &vthread_result)) != 0)
   {
-    DDS_TRACE ("pthread_join(0x%"PRIxMAX") failed with error %d\n", (uintmax_t)((uintptr_t)thread.v), err);
+    DDS_ERROR ("pthread_join(0x%"PRIxMAX") failed with error %d\n", (uintmax_t)((uintptr_t)thread.v), err);
     return DDS_RETCODE_ERROR;
   }
 
@@ -371,6 +377,104 @@ ddsrt_thread_join(ddsrt_thread_t thread, uint32_t *thread_result)
     *thread_result = (uint32_t) ((uintptr_t) vthread_result);
   return DDS_RETCODE_OK;
 }
+
+#if defined __linux
+dds_return_t
+ddsrt_thread_list (
+  ddsrt_thread_list_id_t * __restrict tids,
+  size_t size)
+{
+  DIR *dir;
+  struct dirent *de;
+  if ((dir = opendir ("/proc/self/task")) == NULL)
+    return DDS_RETCODE_ERROR;
+  dds_return_t n = 0;
+  while ((de = readdir (dir)) != NULL)
+  {
+    if (de->d_name[0] == '.' && (de->d_name[1] == 0 || (de->d_name[1] == '.' && de->d_name[2] == 0)))
+      continue;
+    int pos;
+    long tid;
+    if (sscanf (de->d_name, "%ld%n", &tid, &pos) != 1 || de->d_name[pos] != 0)
+    {
+      n = DDS_RETCODE_ERROR;
+      break;
+    }
+    if ((size_t) n < size)
+      tids[n] = (ddsrt_thread_list_id_t) tid;
+    n++;
+  }
+  closedir (dir);
+  /* If there were no threads, something must've gone badly wrong */
+  return (n == 0) ? DDS_RETCODE_ERROR : n;
+}
+
+dds_return_t
+ddsrt_thread_getname_anythread (
+  ddsrt_thread_list_id_t tid,
+  char *__restrict name,
+  size_t size)
+{
+  char file[100];
+  FILE *fp;
+  int pos;
+  pos = snprintf (file, sizeof (file), "/proc/self/task/%lu/stat", (unsigned long) tid);
+  if (pos < 0 || pos >= (int) sizeof (file))
+    return DDS_RETCODE_ERROR;
+  if ((fp = fopen (file, "r")) == NULL)
+    return DDS_RETCODE_NOT_FOUND;
+  int c;
+  size_t namelen = 0, namepos = 0;
+  while ((c = fgetc (fp)) != EOF)
+    if (c == '(')
+      break;
+  while ((c = fgetc (fp)) != EOF)
+  {
+    if (c == ')')
+      namelen = namepos;
+    if (namepos + 1 < size)
+      name[namepos++] = (char) c;
+  }
+  fclose (fp);
+  assert (size == 0 || namelen < size);
+  if (size > 0)
+    name[namelen] = 0;
+  return DDS_RETCODE_OK;
+}
+#elif defined __APPLE__
+DDSRT_STATIC_ASSERT (sizeof (ddsrt_thread_list_id_t) == sizeof (mach_port_t));
+
+dds_return_t
+ddsrt_thread_list (
+  ddsrt_thread_list_id_t * __restrict tids,
+  size_t size)
+{
+  thread_act_array_t tasks;
+  mach_msg_type_number_t count;
+  if (task_threads (mach_task_self (), &tasks, &count) != KERN_SUCCESS)
+    return DDS_RETCODE_ERROR;
+  for (mach_msg_type_number_t i = 0; i < count && (size_t) i < size; i++)
+    tids[i] = (ddsrt_thread_list_id_t) tasks[i];
+  vm_deallocate (mach_task_self (), (vm_address_t) tasks, count * sizeof (thread_act_t));
+  return (dds_return_t) count;
+}
+
+dds_return_t
+ddsrt_thread_getname_anythread (
+  ddsrt_thread_list_id_t tid,
+  char *__restrict name,
+  size_t size)
+{
+  if (size > 0)
+  {
+    pthread_t pt = pthread_from_mach_thread_np ((mach_port_t) tid);
+    name[0] = '\0';
+    if (pt == NULL || pthread_getname_np (pt, name, size) != 0 || name[0] == 0)
+      snprintf (name, size, "task%"PRIu64, (uint64_t) tid);
+  }
+  return DDS_RETCODE_OK;
+}
+#endif
 
 
 static pthread_key_t thread_cleanup_key;

--- a/src/tools/ddsperf/CMakeLists.txt
+++ b/src/tools/ddsperf/CMakeLists.txt
@@ -11,7 +11,7 @@
 #
 
 idlc_generate(ddsperf_types ddsperf_types.idl)
-add_executable(ddsperf ddsperf.c)
+add_executable(ddsperf ddsperf.c cputime.c cputime.h netload.c netload.h)
 target_link_libraries(ddsperf ddsperf_types ddsc)
 
 if(WIN32)

--- a/src/tools/ddsperf/cputime.c
+++ b/src/tools/ddsperf/cputime.c
@@ -1,0 +1,250 @@
+/*
+ * Copyright(c) 2019 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#define _ISOC99_SOURCE
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <assert.h>
+
+#include "dds/dds.h"
+
+#include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/process.h"
+#include "dds/ddsrt/sockets.h"
+#include "dds/ddsrt/threads.h"
+#include "dds/ddsrt/string.h"
+#include "dds/ddsrt/rusage.h"
+
+#include "cputime.h"
+#include "ddsperf_types.h"
+
+static void print (char *line, size_t sz, size_t *pos, const char *name, double du, double ds)
+{
+  if (*pos < sz)
+    *pos += (size_t) snprintf (line + *pos, sz - *pos, " %s:%.0f%%+%.0f%%", name, 100.0 * du, 100.0 * ds);
+}
+
+bool print_cputime (const struct CPUStats *s, const char *prefix, bool print_host, bool is_fresh)
+{
+  if (!s->some_above)
+    return false;
+  else
+  {
+    char line[512];
+    size_t pos = 0;
+    assert (is_fresh || !print_host);
+    pos += (size_t) snprintf (line + pos, sizeof (line) - pos, "%s", prefix);
+    if (!is_fresh)
+      pos += (size_t) snprintf (line + pos, sizeof (line) - pos, " (stale)");
+    if (print_host)
+    {
+      int n = (int) strlen (s->hostname);
+      if (n > 100) n = 100;
+      pos += (size_t) snprintf (line + pos, sizeof (line) - pos, " @%*.*s:%"PRId32, n, n, s->hostname, s->pid);
+    }
+    if (s->maxrss > 1048576)
+      pos += (size_t) snprintf (line + pos, sizeof (line) - pos, " rss:%.1fMB", s->maxrss / 1048576.0);
+    else if (s->maxrss > 1024)
+      pos += (size_t) snprintf (line + pos, sizeof (line) - pos, " rss:%.0fkB", s->maxrss / 1024.0);
+    else {
+      /* non-sensical value -- presumably maxrss is not available */
+    }
+    const size_t init_pos = pos;
+    for (uint32_t i = 0; i < s->cpu._length; i++)
+    {
+      struct CPUStatThread * const thr = &s->cpu._buffer[i];
+      print (line, sizeof (line), &pos, thr->name, thr->u_pct / 100.0, thr->s_pct / 100.0);
+    }
+    if (pos > init_pos)
+      puts (line);
+    return true;
+  }
+}
+
+#if DDSRT_HAVE_RUSAGE && DDSRT_HAVE_THREAD_LIST
+
+struct record_cputime_state_thr {
+  ddsrt_thread_list_id_t tid;
+  char name[32];
+  double ut, st;
+};
+
+struct record_cputime_state {
+  bool supported;
+  dds_time_t tprev;
+  size_t nthreads;
+  struct record_cputime_state_thr *threads;
+  dds_entity_t wr;
+  struct CPUStats s;
+};
+
+static void update (double *ut_old, double *st_old, double dt, double ut_new, double st_new, double *du, double *ds)
+{
+  *du = (ut_new - *ut_old) / dt;
+  *ds = (st_new - *st_old) / dt;
+  *ut_old = ut_new;
+  *st_old = st_new;
+}
+
+static bool above_threshold (double *max, double *du_skip, double *ds_skip, double du, double ds)
+{
+  if (*max < du) *max = du;
+  if (*max < ds) *max = ds;
+  if (du >= 0.005 || ds >= 0.005)
+    return true;
+  else if (du_skip == NULL || ds_skip == NULL)
+    return false;
+  else
+  {
+    *du_skip += du;
+    *ds_skip += ds;
+    return false;
+  }
+}
+
+bool record_cputime (struct record_cputime_state *state, const char *prefix, dds_time_t tnow)
+{
+  if (state == NULL)
+    return false;
+
+  ddsrt_rusage_t usage;
+  if (ddsrt_getrusage (DDSRT_RUSAGE_SELF, &usage) < 0)
+    usage.maxrss = 0;
+  double max = 0;
+  double du_skip = 0.0, ds_skip = 0.0;
+  const double dt = (double) (tnow - state->tprev) / 1e9;
+  bool some_above = false;
+
+  state->s.maxrss = (double) usage.maxrss;
+  state->s.cpu._length = 0;
+  for (size_t i = 0; i < state->nthreads; i++)
+  {
+    struct record_cputime_state_thr * const thr = &state->threads[i];
+    if (ddsrt_getrusage_anythread (thr->tid, &usage) < 0)
+      continue;
+
+    const double ut = (double) usage.utime / 1e9;
+    const double st = (double) usage.stime / 1e9;
+    double du, ds;
+    update (&thr->ut, &thr->st, dt, ut, st, &du, &ds);
+    if (above_threshold (&max, &du_skip, &ds_skip, du, ds))
+    {
+      some_above = true;
+      /* Thread names are often set by thread itself immediately after creation,
+         and so it depends on the scheduling whether there is still a default
+         name or the name we are interested in.  Lazily retrieving the name the
+         first time the thread pops up in the CPU usage works around the timing
+         problem. */
+      if (thr->name[0] == 0)
+      {
+        if (ddsrt_thread_getname_anythread (thr->tid, thr->name, sizeof (thr->name)) < 0)
+        {
+          du_skip += du;
+          ds_skip += ds;
+          continue;
+        }
+      }
+
+      struct CPUStatThread * const x = &state->s.cpu._buffer[state->s.cpu._length++];
+      x->name = thr->name;
+      x->u_pct = (int) (100.0 * du + 0.5);
+      x->s_pct = (int) (100.0 * ds + 0.5);
+    }
+  }
+  if (above_threshold (&max, NULL, NULL, du_skip, ds_skip))
+  {
+    struct CPUStatThread * const x = &state->s.cpu._buffer[state->s.cpu._length++];
+    some_above = true;
+    x->name = "others";
+    x->u_pct = (int) (100.0 * du_skip + 0.5);
+    x->s_pct = (int) (100.0 * ds_skip + 0.5);
+  }
+  state->tprev = tnow;
+  state->s.some_above = some_above;
+  dds_write (state->wr, &state->s);
+  return print_cputime (&state->s, prefix, false, true);
+}
+
+struct record_cputime_state *record_cputime_new (dds_entity_t wr)
+{
+  ddsrt_thread_list_id_t tids[100];
+  dds_return_t n;
+  if ((n = ddsrt_thread_list (tids, sizeof (tids) / sizeof (tids[0]))) <= 0)
+    return NULL;
+  else if (n > (dds_return_t) (sizeof (tids) / sizeof (tids[0])))
+  {
+    fprintf (stderr, "way more threads than expected\n");
+    return NULL;
+  }
+
+  struct record_cputime_state *state = malloc (sizeof (*state));
+  state->tprev = dds_time ();
+  state->wr = wr;
+  state->threads = malloc ((size_t) n * sizeof (*state->threads));
+  state->nthreads = 0;
+  for (int32_t i = 0; i < n; i++)
+  {
+    struct record_cputime_state_thr * const thr = &state->threads[state->nthreads];
+    ddsrt_rusage_t usage;
+    if (ddsrt_getrusage_anythread (tids[i], &usage) < 0)
+      continue;
+    thr->tid = tids[i];
+    thr->name[0] = 0;
+    thr->ut = (double) usage.utime / 1e9;
+    thr->st = (double) usage.stime / 1e9;
+    state->nthreads++;
+  }
+
+  char hostname[128];
+  if (ddsrt_gethostname (hostname, sizeof (hostname)) != DDS_RETCODE_OK)
+    strcpy (hostname, "?");
+  state->s.hostname = ddsrt_strdup (hostname);
+  state->s.pid = (uint32_t) ddsrt_getpid ();
+  state->s.cpu._length = 0;
+  state->s.cpu._maximum = (uint32_t) state->nthreads;
+  state->s.cpu._buffer = malloc (state->s.cpu._maximum * sizeof (*state->s.cpu._buffer));
+  state->s.cpu._release = false;
+  return state;
+}
+
+void record_cputime_free (struct record_cputime_state *state)
+{
+  if (state)
+  {
+    free (state->threads);
+    ddsrt_free (state->s.hostname);
+    /* we alias thread names in state->s->cpu._buffer, so no need to free */
+    free (state->s.cpu._buffer);
+    free (state);
+  }
+}
+
+#else
+
+bool record_cputime (struct record_cputime_state *state, const char *prefix, dds_time_t tnow)
+{
+  (void) state;
+  (void) prefix;
+  (void) tnow;
+}
+
+struct record_cputime_state *record_cputime_new (dds_entity_t wr)
+{
+  (void) wr;
+}
+
+void record_cputime_free (struct record_cputime_state *state)
+{
+  (void) state;
+}
+
+#endif

--- a/src/tools/ddsperf/cputime.h
+++ b/src/tools/ddsperf/cputime.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright(c) 2019 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#ifndef CPUTIME_H
+#define CPUTIME_H
+
+#include "ddsperf_types.h"
+
+struct record_cputime_state;
+
+struct record_cputime_state *record_cputime_new (dds_entity_t wr);
+void record_cputime_free (struct record_cputime_state *state);
+bool record_cputime (struct record_cputime_state *state, const char *prefix, dds_time_t tnow);
+bool print_cputime (const struct CPUStats *s, const char *prefix, bool print_host, bool is_fresh);
+
+#endif

--- a/src/tools/ddsperf/ddsperf_types.idl
+++ b/src/tools/ddsperf/ddsperf_types.idl
@@ -27,3 +27,20 @@ struct KeyedSeq
   sequence<octet> baggage;
 };
 #pragma keylist KeyedSeq keyval
+
+struct CPUStatThread
+{
+  string name;
+  long u_pct;
+  long s_pct;
+};
+
+struct CPUStats
+{
+  string hostname;
+  unsigned long pid;
+  double maxrss;
+  boolean some_above;
+  sequence<CPUStatThread> cpu;
+};
+#pragma keylist CPUStats hostname pid

--- a/src/tools/ddsperf/netload.h
+++ b/src/tools/ddsperf/netload.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright(c) 2019 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#ifndef NETLOAD_H
+#define NETLOAD_H
+
+#include <dds/dds.h>
+
+struct record_netload_state;
+
+void record_netload (struct record_netload_state *st, const char *prefix, dds_time_t tnow);
+struct record_netload_state *record_netload_new (const char *dev, double bw);
+void record_netload_free (struct record_netload_state *st);
+
+#endif


### PR DESCRIPTION
Along with the other statistics, print user and system CPU usage for all
threads in "ddsperf" where at least one of the two is at least 0.5%.
Currently only for macOS and Linux, because those are the only ones I
can test.

Signed-off-by: Erik Boasson <eb@ilities.com>