### PR TITLE
#213 - Allow readconditions and queryconditions as valid entities for…

### DIFF
--- a/src/core/ddsc/include/dds/dds.h
+++ b/src/core/ddsc/include/dds/dds.h
@@ -2939,7 +2939,7 @@ dds_instance_lookup(dds_entity_t entity, const void *data);
 /**
  * @brief This operation takes an instance handle and return a key-value corresponding to it.
  *
- * @param[in]  entity Reader or writer entity.
+ * @param[in]  entity Reader, writer, readcondition or querycondition entity.
  * @param[in]  inst   Instance handle.
  * @param[out] data   pointer to an instance, to which the key ID corresponding to the instance handle will be
  *    returned, the sample in the instance should be ignored.

--- a/src/core/ddsc/src/dds__types.h
+++ b/src/core/ddsc/src/dds__types.h
@@ -173,8 +173,9 @@ dds_return_t dds_entity_deriver_dummy_delete (struct dds_entity *e);
 dds_return_t dds_entity_deriver_dummy_set_qos (struct dds_entity *e, const dds_qos_t *qos, bool enabled);
 dds_return_t dds_entity_deriver_dummy_validate_status (uint32_t mask);
 
+
 inline dds_return_t dds_entity_deriver_close (struct dds_entity *e) {
-  return dds_entity_deriver_table[e->m_kind]->close (e);
+  return (dds_entity_deriver_table[e->m_kind]->close) (e);
 }
 inline dds_return_t dds_entity_deriver_delete (struct dds_entity *e) {
   return dds_entity_deriver_table[e->m_kind]->delete (e);

--- a/src/core/ddsc/src/dds__whc.h
+++ b/src/core/ddsc/src/dds__whc.h
@@ -18,7 +18,7 @@
 extern "C" {
 #endif
 
-struct whc *whc_new (int is_transient_local, unsigned hdepth, unsigned tldepth);
+struct whc *whc_new (int is_transient_local, uint32_t hdepth, uint32_t tldepth);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsc/src/dds_instance.c
+++ b/src/core/ddsc/src/dds_instance.c
@@ -284,23 +284,27 @@ dds_return_t dds_instance_get_key (dds_entity_t entity, dds_instance_handle_t ih
   dds_return_t ret;
   const dds_topic *topic;
   struct ddsi_tkmap_instance *tk;
-  dds_entity *w_or_r;
+  dds_entity *e;
 
   if (data == NULL)
     return DDS_RETCODE_BAD_PARAMETER;
 
-  if ((ret = dds_entity_lock (entity, DDS_KIND_DONTCARE, &w_or_r)) < 0)
+  if ((ret = dds_entity_lock (entity, DDS_KIND_DONTCARE, &e)) < 0)
     return ret;
-  switch (dds_entity_kind (w_or_r))
+  switch (dds_entity_kind (e))
   {
     case DDS_KIND_WRITER:
-      topic = ((dds_writer *) w_or_r)->m_topic;
+      topic = ((dds_writer *) e)->m_topic;
       break;
     case DDS_KIND_READER:
-      topic = ((dds_reader *) w_or_r)->m_topic;
+      topic = ((dds_reader *) e)->m_topic;
+      break;
+    case DDS_KIND_COND_READ:
+    case DDS_KIND_COND_QUERY:
+      topic = ((dds_reader *) e->m_parent)->m_topic;
       break;
     default:
-      dds_entity_unlock (w_or_r);
+      dds_entity_unlock (e);
       return DDS_RETCODE_ILLEGAL_OPERATION;
   }
 
@@ -315,6 +319,6 @@ dds_return_t dds_instance_get_key (dds_entity_t entity, dds_instance_handle_t ih
     ret = DDS_RETCODE_OK;
   }
   thread_state_asleep (ts1);
-  dds_entity_unlock (w_or_r);
+  dds_entity_unlock (e);
   return ret;
 }

--- a/src/core/ddsi/include/dds/ddsi/q_whc.h
+++ b/src/core/ddsi/include/dds/ddsi/q_whc.h
@@ -73,8 +73,8 @@ typedef void (*whc_free_t)(struct whc *whc);
 /* max_drop_seq must go soon, it's way too ugly. */
 /* plist may be NULL or ddsrt_malloc'd, WHC takes ownership of plist */
 typedef int (*whc_insert_t)(struct whc *whc, seqno_t max_drop_seq, seqno_t seq, struct nn_plist *plist, struct ddsi_serdata *serdata, struct ddsi_tkmap_instance *tk);
-typedef unsigned (*whc_downgrade_to_volatile_t)(struct whc *whc, struct whc_state *st);
-typedef unsigned (*whc_remove_acked_messages_t)(struct whc *whc, seqno_t max_drop_seq, struct whc_state *whcst, struct whc_node **deferred_free_list);
+typedef uint32_t (*whc_downgrade_to_volatile_t)(struct whc *whc, struct whc_state *st);
+typedef uint32_t (*whc_remove_acked_messages_t)(struct whc *whc, seqno_t max_drop_seq, struct whc_state *whcst, struct whc_node **deferred_free_list);
 typedef void (*whc_free_deferred_free_list_t)(struct whc *whc, struct whc_node *deferred_free_list);
 
 struct whc_ops {

--- a/src/core/ddsi/src/q_lease.c
+++ b/src/core/ddsi/src/q_lease.c
@@ -295,7 +295,7 @@ static void debug_print_rawdata (const char *msg, const void *data, size_t len)
   DDS_TRACE(">");
 }
 
-void handle_PMD (UNUSED_ARG (const struct receiver_state *rst), nn_wctime_t timestamp, unsigned statusinfo, const void *vdata, uint32_t len)
+void handle_PMD (UNUSED_ARG (const struct receiver_state *rst), nn_wctime_t timestamp, uint32_t statusinfo, const void *vdata, uint32_t len)
 {
   const struct CDRHeader *data = vdata; /* built-ins not deserialized (yet) */
   const int bswap = (data->identifier == CDR_LE) ^ (DDSRT_ENDIAN == DDSRT_LITTLE_ENDIAN);

--- a/src/core/ddsi/src/q_plist.c
+++ b/src/core/ddsi/src/q_plist.c
@@ -1106,7 +1106,11 @@ struct piddesc_index {
    Sizes are such that the highest PID (without flags) in
    table are the last entry in the array.  Checked by
    nn_plist_init_tables. */
+#ifdef DDSI_INCLUDE_SSM
 static const struct piddesc *piddesc_omg_index[115];
+#else
+static const struct piddesc *piddesc_omg_index[114];
+#endif
 static const struct piddesc *piddesc_eclipse_index[19];
 static const struct piddesc *piddesc_prismtech_index[19];
 

--- a/src/ddsrt/src/ifaddrs/lwip/ifaddrs.c
+++ b/src/ddsrt/src/ifaddrs/lwip/ifaddrs.c
@@ -67,13 +67,13 @@ sockaddr_from_ip_addr(
   }
 }
 
-static dds_retcode_t
+static dds_return_t
 copyaddr(
   ddsrt_ifaddrs_t **ifap,
   const struct netif *netif,
   const ip_addr_t *addr)
 {
-  dds_retcode_t rc = DDS_RETCODE_OK;
+  dds_return_t rc = DDS_RETCODE_OK;
   ddsrt_ifaddrs_t *ifa;
   struct sockaddr_storage sa;
 
@@ -122,12 +122,12 @@ copyaddr(
   return rc;
 }
 
-dds_retcode_t
+dds_return_t
 ddsrt_getifaddrs(
   ddsrt_ifaddrs_t **ifap,
   const int *afs)
 {
-  dds_retcode_t rc = DDS_RETCODE_OK;
+  dds_return_t rc = DDS_RETCODE_OK;
   int use_ip4, use_ip6;
   struct netif *netif;
   ddsrt_ifaddrs_t *ifa, *next_ifa, *root_ifa;

--- a/src/ddsrt/src/rusage/freertos/rusage.c
+++ b/src/ddsrt/src/rusage/freertos/rusage.c
@@ -29,10 +29,10 @@
 #error "Time base for run time stats is not defined"
 #endif
 
-static dds_retcode_t
+static dds_return_t
 rusage_self(ddsrt_rusage_t *usage)
 {
-  dds_retcode_t rc = DDS_RETCODE_OK;
+  dds_return_t rc = DDS_RETCODE_OK;
   dds_duration_t nsecs;
   UBaseType_t cnt, len;
   TaskStatus_t *states = NULL, *ptr;
@@ -65,7 +65,7 @@ rusage_self(ddsrt_rusage_t *usage)
   return rc;
 }
 
-static dds_retcode_t
+static dds_return_t
 rusage_thread(ddsrt_rusage_t *usage)
 {
   TaskStatus_t states;
@@ -78,10 +78,10 @@ rusage_thread(ddsrt_rusage_t *usage)
   return DDS_RETCODE_OK;
 }
 
-dds_retcode_t
+dds_return_t
 ddsrt_getrusage(int who, ddsrt_rusage_t *usage)
 {
-  dds_retcode_t rc;
+  dds_return_t rc;
 
   assert(who == DDSRT_RUSAGE_SELF || who == DDSRT_RUSAGE_THREAD);
   assert(usage != NULL);

--- a/src/ddsrt/src/sync/freertos/sync.c
+++ b/src/ddsrt/src/sync/freertos/sync.c
@@ -82,13 +82,13 @@ void ddsrt_mutex_unlock(ddsrt_mutex_t *mutex)
   }
 }
 
-static dds_retcode_t
+static dds_return_t
 cond_timedwait(
   ddsrt_cond_t *cond,
   ddsrt_mutex_t *mutex,
   dds_duration_t reltime)
 {
-  dds_retcode_t rc = DDS_RETCODE_OK;
+  dds_return_t rc = DDS_RETCODE_OK;
   dds_time_t abstime;
   TaskHandle_t task;
   TickType_t ticks = 0;
@@ -174,7 +174,7 @@ ddsrt_cond_waitfor(
   ddsrt_mutex_t *mutex,
   dds_duration_t reltime)
 {
-  dds_retcode_t rc;
+  dds_return_t rc;
 
   assert(cond != NULL);
   assert(mutex != NULL);
@@ -198,7 +198,7 @@ ddsrt_cond_waituntil(
   ddsrt_mutex_t *mutex,
   dds_time_t abstime)
 {
-  dds_retcode_t rc;
+  dds_return_t rc;
   dds_time_t time;
   dds_duration_t reltime;
 

--- a/src/ddsrt/src/threads/freertos/threads.c
+++ b/src/ddsrt/src/threads/freertos/threads.c
@@ -135,10 +135,10 @@ thread_context_find(TaskHandle_t task)
   return ctx;
 }
 
-static dds_retcode_t
+static dds_return_t
 thread_context_create(thread_context_t **ctxptr)
 {
-  dds_retcode_t rc = DDS_RETCODE_OK;
+  dds_return_t rc = DDS_RETCODE_OK;
   size_t len;
   thread_context_t *ctx = NULL, **ctxs = NULL;
 
@@ -172,10 +172,10 @@ thread_context_create(thread_context_t **ctxptr)
 
 #define thread_context_require() thread_context_acquire(NULL)
 
-static dds_retcode_t
+static dds_return_t
 thread_context_acquire(thread_context_t **ctxptr)
 {
-  dds_retcode_t rc = DDS_RETCODE_OK;
+  dds_return_t rc = DDS_RETCODE_OK;
   thread_context_t *ctx = thread_context;
 
   if (ctx == NULL) {
@@ -340,7 +340,7 @@ thread_start_routine(void *arg)
    the user to change it on a per-thread basis at runtime. */
 #define MIN_STACK_SIZE ((uint16_t)(configMINIMAL_STACK_SIZE * WORD_SIZE))
 
-dds_retcode_t
+dds_return_t
 ddsrt_thread_create(
   ddsrt_thread_t *thread,
   const char *name,
@@ -348,7 +348,7 @@ ddsrt_thread_create(
   ddsrt_thread_routine_t start_routine,
   void *arg)
 {
-  dds_retcode_t rc;
+  dds_return_t rc;
   TaskHandle_t task;
   UBaseType_t prio;
   uint16_t size = MIN_STACK_SIZE;
@@ -437,10 +437,10 @@ ddsrt_thread_fini(void)
   }
 }
 
-dds_retcode_t
+dds_return_t
 ddsrt_thread_join(ddsrt_thread_t thread, uint32_t *thread_result)
 {
-  dds_retcode_t rc;
+  dds_return_t rc;
   thread_context_t *ctx;
   eTaskState status;
 
@@ -502,10 +502,10 @@ ddsrt_thread_join(ddsrt_thread_t thread, uint32_t *thread_result)
   return rc;
 }
 
-dds_retcode_t
+dds_return_t
 ddsrt_thread_cleanup_push(void (*routine)(void *), void *arg)
 {
-  dds_retcode_t rc = DDS_RETCODE_OK;
+  dds_return_t rc = DDS_RETCODE_OK;
   thread_cleanup_t *tail = NULL;
   thread_context_t *ctx;
 
@@ -525,7 +525,7 @@ ddsrt_thread_cleanup_push(void (*routine)(void *), void *arg)
   return rc;
 }
 
-dds_retcode_t
+dds_return_t
 ddsrt_thread_cleanup_pop(int execute)
 {
   thread_cleanup_t *tail;


### PR DESCRIPTION
This pull requests adds the ability to use dds_instance_get_key() on readconditions and queryconditions. This is just for convenience and may lead to slightly less application code. Without this pull request dds_instance_get_key() can only be used on readers.

The pull requests consists of:

- A small modification in the logic to dds_instance_get_key() to handle readconditions and queryconditions
- A change in the description of this function to describe this new functionality
- Test cases that demonstrate that dds_instance_get_key() can be applied on readconditions and queryconditions.



Signed-off-by: TheFixer <thefixer@iteazz.com>