### PR TITLE
64-bit alignment in serialised data

### DIFF
--- a/src/core/ddsc/src/dds_stream.c
+++ b/src/core/ddsc/src/dds_stream.c
@@ -1614,6 +1614,8 @@ void dds_stream_extract_keyhash (dds_istream_t * __restrict is, dds_keyhash_t * 
  **
  *******************************************************************************************/
 
+DDSRT_STATIC_ASSERT ((offsetof (struct ddsi_serdata_default, data) % 8) == 0);
+
 void dds_istream_from_serdata_default (dds_istream_t * __restrict s, const struct ddsi_serdata_default * __restrict d)
 {
   s->m_buffer = (const unsigned char *) d;


### PR DESCRIPTION
The payload in a struct serdata_default is assumed to be at a 64-bit
offset for conversion to/from a dds_{i,o}stream_t and getting padding
calculations in the serialised representation correct.  The definition
did not guarantee this and got it wrong on a 32-bit release build.

This commit computes the required padding at compile time and at
verifies the assumption holds where it matters.