### PR TITLE
Improve multicast defaults

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/q_config.h
+++ b/src/core/ddsi/include/dds/ddsi/q_config.h
@@ -184,7 +184,7 @@ struct prune_deleted_ppant {
   int enforce_delay;
 };
 
-/* allow multicast bits: */
+/* allow multicast bits (default depends on network type): */
 #define AMC_FALSE 0u
 #define AMC_SPDP 1u
 #define AMC_ASM 2u
@@ -194,6 +194,7 @@ struct prune_deleted_ppant {
 #else
 #define AMC_TRUE (AMC_SPDP | AMC_ASM)
 #endif
+#define AMC_DEFAULT 0x80000000u
 
 /* FIXME: this should be fully dynamic ... but this is easier for a quick hack */
 enum transport_selector {

--- a/src/core/ddsi/include/dds/ddsi/q_nwif.h
+++ b/src/core/ddsi/include/dds/ddsi/q_nwif.h
@@ -28,6 +28,7 @@ struct nn_interface {
   nn_locator_t netmask;
   uint32_t if_index;
   unsigned mc_capable: 1;
+  unsigned mc_flaky: 1;
   unsigned point_to_point: 1;
   char *name;
 };

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -936,7 +936,24 @@ int rtps_init (void)
       config.participantIndex = PARTICIPANT_INDEX_AUTO;
       mc_available = false;
     }
+    else if (config.allowMulticast & AMC_DEFAULT)
+    {
+      /* default is dependent on network interface type: if multicast is believed to be flaky,
+         use multicast only for SPDP packets */
+      assert ((config.allowMulticast & ~AMC_DEFAULT) == 0);
+      if (gv.interfaces[gv.selected_interface].mc_flaky)
+      {
+        config.allowMulticast = AMC_SPDP;
+        DDS_LOG(DDS_LC_CONFIG, "presumed flaky multicast, use for SPDP only\n");
+      }
+      else
+      {
+        DDS_LOG(DDS_LC_CONFIG, "presumed robust multicast support, use for everything\n");
+        config.allowMulticast = AMC_TRUE;
+      }
+    }
   }
+  assert ((config.allowMulticast & AMC_DEFAULT) == 0);
   if (set_recvips () < 0)
     goto err_set_recvips;
   if (set_spdp_address () < 0)

--- a/src/core/ddsi/src/q_nwif.c
+++ b/src/core/ddsi/src/q_nwif.c
@@ -485,6 +485,18 @@ int find_own_ip (const char *requested_address)
       continue;
     }
 
+    switch (ifa->type)
+    {
+      case DDSRT_IFTYPE_WIFI:
+        DDS_LOG(DDS_LC_CONFIG, " wireless");
+        break;
+      case DDSRT_IFTYPE_WIRED:
+        DDS_LOG(DDS_LC_CONFIG, " wired");
+        break;
+      case DDSRT_IFTYPE_UNKNOWN:
+        break;
+    }
+
 #if defined(__linux) && !LWIP_SOCKET
     if (ifa->addr->sa_family == AF_PACKET)
     {
@@ -571,6 +583,7 @@ int find_own_ip (const char *requested_address)
       memset(&gv.interfaces[gv.n_interfaces].netmask.address, 0, sizeof(gv.interfaces[gv.n_interfaces].netmask.address));
     }
     gv.interfaces[gv.n_interfaces].mc_capable = ((ifa->flags & IFF_MULTICAST) != 0);
+    gv.interfaces[gv.n_interfaces].mc_flaky = ((ifa->type == DDSRT_IFTYPE_WIFI) != 0);
     gv.interfaces[gv.n_interfaces].point_to_point = ((ifa->flags & IFF_POINTOPOINT) != 0);
     gv.interfaces[gv.n_interfaces].if_index = ifa->index;
     gv.interfaces[gv.n_interfaces].name = ddsrt_strdup (if_name);

--- a/src/ddsrt/include/dds/ddsrt/ifaddrs.h
+++ b/src/ddsrt/include/dds/ddsrt/ifaddrs.h
@@ -18,11 +18,18 @@
 extern "C" {
 #endif
 
+enum ddsrt_iftype {
+  DDSRT_IFTYPE_UNKNOWN,
+  DDSRT_IFTYPE_WIRED,
+  DDSRT_IFTYPE_WIFI
+};
+
 struct ddsrt_ifaddrs {
   struct ddsrt_ifaddrs *next;
   char *name;
   uint32_t index;
   uint32_t flags;
+  enum ddsrt_iftype type;
   struct sockaddr *addr;
   struct sockaddr *netmask;
   struct sockaddr *broadaddr;

--- a/src/ddsrt/src/ifaddrs/lwip/ifaddrs.c
+++ b/src/ddsrt/src/ifaddrs/lwip/ifaddrs.c
@@ -95,6 +95,7 @@ copyaddr(
   } else {
     ifa->flags = getflags(netif, addr);
     ifa->index = netif->num;
+    ifa->type = DDSRT_IFTYPE_UNKNOWN;
 
     if (IP_IS_V4(addr)) {
       static const size_t sz = sizeof(struct sockaddr_in);

--- a/src/ddsrt/src/ifaddrs/windows/ifaddrs.c
+++ b/src/ddsrt/src/ifaddrs/windows/ifaddrs.c
@@ -152,6 +152,21 @@ getflags(const PIP_ADAPTER_ADDRESSES iface)
   return flags;
 }
 
+static enum ddsrt_iftype
+guess_iftype (const PIP_ADAPTER_ADDRESSES iface)
+{
+  switch (iface->IfType) {
+    case IF_TYPE_IEEE80211:
+      return DDSRT_IFTYPE_WIFI;
+    case IF_TYPE_ETHERNET_CSMACD:
+    case IF_TYPE_IEEE1394:
+    case IF_TYPE_ISO88025_TOKENRING:
+      return DDSRT_IFTYPE_WIRED;
+    default:
+      return DDSRT_IFTYPE_UNKNOWN;
+  }
+}
+
 static int
 copyaddr(
   ddsrt_ifaddrs_t **ifap,
@@ -175,6 +190,7 @@ copyaddr(
     err = DDS_RETCODE_OUT_OF_RESOURCES;
   } else {
     ifa->flags = getflags(iface);
+    ifa->type = guess_iftype(iface);
     ifa->addr = ddsrt_memdup(sa, sz);
     (void)ddsrt_asprintf(&ifa->name, "%wS", iface->FriendlyName);
     if (ifa->addr == NULL || ifa->name == NULL) {


### PR DESCRIPTION
This PR changes two defaults related to the use of multicast:

* It checks the kernel's information on the network interface to determine whether the chosen interface is a WiFi or any other type. On a WiFi network the use of multicast is (by default) restricted to participant discovery only.
WiFi pretends to be like an Ethernet, but the reliability of multicast is dramatically lower. As far as I know, pretty much any interference will cause packet loss, and often the loss comes in bursts. Experience is that behaviour on a WiFi is much, much better when avoiding multicast except for that one purpose.
* The second is to not assume that a retransmit request is likely to be followed in very short order by retransmit requests from other nodes, and that therefore the retransmits should not be multicast by default.

I've managed to check the WiFi/wired detection on macOS and Linux (though only with straightforwad network configuration). The code it uses on Windows seems like it ought to be correct, but it would be much appreciated if someone with a Windows box could give it a try.

The other commit is just a slight lenthening of a timeout in a test and the removal of a fixed port number. Those are the only two obvious things that may have caused the intermittent failure of the "select timeout" test (#212).