### PR TITLE
Various improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -166,8 +166,18 @@ script:
           -DBUILD_TESTING=on
           -DWERROR=on
           -G "${GENERATOR}" ..
-  - ${SCAN_BUILD} cmake --build . --config ${BUILD_TYPE} --target install
-  - CYCLONEDDS_URI='<CycloneDDS><DDSI2E><Internal><EnableExpensiveChecks>all</EnableExpensiveChecks></Internal></DDSI2E></CycloneDDS>' ctest -T test -C ${BUILD_TYPE}
+  - case "${GENERATOR}" in
+      "Unix Makefiles")
+        ${SCAN_BUILD} cmake --build . --config ${BUILD_TYPE} --target install -- -j 4
+        ;;
+      "Visual Studio "*)
+        ${SCAN_BUILD} cmake --build . --config ${BUILD_TYPE} --target install -- -nologo -verbosity:minimal -maxcpucount -p:CL_MPCount=2
+        ;;
+      *)
+        ${SCAN_BUILD} cmake --build . --config ${BUILD_TYPE} --target install
+        ;;
+    esac
+  - CYCLONEDDS_URI='<CycloneDDS><DDSI2E><Internal><EnableExpensiveChecks>all</EnableExpensiveChecks></Internal></DDSI2E></CycloneDDS>' ctest -j 4 --output-on-failure -T test -C ${BUILD_TYPE}
   - if [ "${ASAN}" != "none" ]; then
       CMAKE_LINKER_FLAGS="-DCMAKE_LINKER_FLAGS=-fsanitize=${USE_SANITIZER}";
       CMAKE_C_FLAGS="-DCMAKE_C_FLAGS=-fsanitize=${USE_SANITIZER}";

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ This example shows a few things:
   the address or the interface name).  Proper use of multiple network interfaces simultaneously will
   come, but is not there yet.
 * ``AllowMulticast`` configures the circumstances under which multicast will be used.  If the
-  selected interface doesn't support it, it obviously wonn't be used (``false``); but if it does
+  selected interface doesn't support it, it obviously won't be used (``false``); but if it does
   support it, the type of the network adapter determines the default value.  For a wired network, it
   will use multicast for initial discovery as well as for data when there are multiple peers that
   the data needs to go to (``true``); but on a WiFi network it will use it only for initial
@@ -225,13 +225,13 @@ This example shows a few things:
   the size of the UDP payload), and the size of the fragments into which very large samples get
   split (which needs to be "a bit" less).  Large values such as these typically improve performance
   over the (current) default values.
-* ``WhcHigh`` determines when the sender will wait for acknolwedgements from the readers because it
+* ``WhcHigh`` determines when the sender will wait for acknowledgements from the readers because it
   has buffered too much unacknowledged data.  There is some auto-tuning, the (current) default value
   is a bit small to get really high throughput.
 
 The configurator tool ``cycloneddsconf`` can help in discovering the settings, as can the config
 dump.  Background information on configuring Cyclone DDS can be
-found [here](https://docs/manual/config.rst).
+found [here](docs/manual/config.rst).
 
 # Trademarks
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,14 +37,14 @@ build_script:
   - cd build
   - conan install -s arch=%ARCH% -s build_type=%CONFIGURATION% ..
   - cmake -DBUILD_TESTING=on -DWERROR=ON -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DCMAKE_INSTALL_PREFIX=%CD%/install -G "%GENERATOR%" ..
-  - cmake --build . --config %CONFIGURATION% --target install -- /maxcpucount
+  - cmake --build . --config %CONFIGURATION% --target install -- /nologo /verbosity:minimal /maxcpucount /p:CL_MPCount=2
   - cd install/share/CycloneDDS/examples/helloworld
   - mkdir build
   - cd build
   - cmake -DCMAKE_BUILD_TYPE=%CONFIGURATION% -G "%GENERATOR%" ..
-  - cmake --build . --config %CONFIGURATION% -- /maxcpucount
+  - cmake --build . --config %CONFIGURATION% -- /nologo /verbosity:minimal /maxcpucount /p:CL_MPCount=2
   - cd ../../../../../..
 
 test_script:
   - set "CYCLONEDDS_URI=<CycloneDDS><DDSI2E><Internal><EnableExpensiveChecks>all</EnableExpensiveChecks></Internal></DDSI2E></CycloneDDS>"
-  - ctest --test-action test --build-config %CONFIGURATION%
+  - ctest --output-on-failure --parallel 4 --test-action test --build-config %CONFIGURATION%

--- a/src/core/ddsi/include/dds/ddsi/q_bswap.h
+++ b/src/core/ddsi/include/dds/ddsi/q_bswap.h
@@ -95,10 +95,10 @@ nn_entityid_t nn_ntoh_entityid (nn_entityid_t e);
 nn_guid_t nn_hton_guid (nn_guid_t g);
 nn_guid_t nn_ntoh_guid (nn_guid_t g);
 
-void bswap_sequence_number_set_hdr (nn_sequence_number_set_t *snset);
-void bswap_sequence_number_set_bitmap (nn_sequence_number_set_t *snset);
-void bswap_fragment_number_set_hdr (nn_fragment_number_set_t *fnset);
-void bswap_fragment_number_set_bitmap (nn_fragment_number_set_t *fnset);
+void bswap_sequence_number_set_hdr (nn_sequence_number_set_header_t *snset);
+void bswap_sequence_number_set_bitmap (nn_sequence_number_set_header_t *snset, uint32_t *bits);
+void bswap_fragment_number_set_hdr (nn_fragment_number_set_header_t *fnset);
+void bswap_fragment_number_set_bitmap (nn_fragment_number_set_header_t *fnset, uint32_t *bits);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsi/include/dds/ddsi/q_radmin.h
+++ b/src/core/ddsi/include/dds/ddsi/q_radmin.h
@@ -217,7 +217,7 @@ int nn_defrag_nackmap (struct nn_defrag *defrag, seqno_t seq, uint32_t maxfragnu
 
 struct nn_reorder *nn_reorder_new (enum nn_reorder_mode mode, uint32_t max_samples);
 void nn_reorder_free (struct nn_reorder *r);
-struct nn_rsample *nn_reorder_rsample_dup (struct nn_rmsg *rmsg, struct nn_rsample *rsampleiv);
+struct nn_rsample *nn_reorder_rsample_dup_first (struct nn_rmsg *rmsg, struct nn_rsample *rsampleiv);
 struct nn_rdata *nn_rsample_fragchain (struct nn_rsample *rsample);
 nn_reorder_result_t nn_reorder_rsample (struct nn_rsample_chain *sc, struct nn_reorder *reorder, struct nn_rsample *rsampleiv, int *refcount_adjust, int delivery_queue_full_p);
 nn_reorder_result_t nn_reorder_gap (struct nn_rsample_chain *sc, struct nn_reorder *reorder, struct nn_rdata *rdata, seqno_t min, seqno_t maxp1, int *refcount_adjust);

--- a/src/core/ddsi/src/q_bswap.c
+++ b/src/core/ddsi/src/q_bswap.c
@@ -53,28 +53,28 @@ nn_guid_t nn_ntoh_guid (nn_guid_t g)
   return g;
 }
 
-void bswap_sequence_number_set_hdr (nn_sequence_number_set_t *snset)
+void bswap_sequence_number_set_hdr (nn_sequence_number_set_header_t *snset)
 {
   bswapSN (&snset->bitmap_base);
   snset->numbits = bswap4u (snset->numbits);
 }
 
-void bswap_sequence_number_set_bitmap (nn_sequence_number_set_t *snset)
+void bswap_sequence_number_set_bitmap (nn_sequence_number_set_header_t *snset, uint32_t *bits)
 {
   const uint32_t n = (snset->numbits + 31) / 32;
   for (uint32_t i = 0; i < n; i++)
-    snset->bits[i] = bswap4u (snset->bits[i]);
+    bits[i] = bswap4u (bits[i]);
 }
 
-void bswap_fragment_number_set_hdr (nn_fragment_number_set_t *fnset)
+void bswap_fragment_number_set_hdr (nn_fragment_number_set_header_t *fnset)
 {
   fnset->bitmap_base = bswap4u (fnset->bitmap_base);
   fnset->numbits = bswap4u (fnset->numbits);
 }
 
-void bswap_fragment_number_set_bitmap (nn_fragment_number_set_t *fnset)
+void bswap_fragment_number_set_bitmap (nn_fragment_number_set_header_t *fnset, uint32_t *bits)
 {
   const uint32_t n = (fnset->numbits + 31) / 32;
   for (uint32_t i = 0; i < n; i++)
-    fnset->bits[i] = bswap4u (fnset->bits[i]);
+    bits[i] = bswap4u (bits[i]);
 }

--- a/src/core/ddsi/src/q_radmin.c
+++ b/src/core/ddsi/src/q_radmin.c
@@ -1726,7 +1726,7 @@ static int reorder_try_append_and_discard (struct nn_reorder *reorder, struct nn
   }
 }
 
-struct nn_rsample *nn_reorder_rsample_dup (struct nn_rmsg *rmsg, struct nn_rsample *rsampleiv)
+struct nn_rsample *nn_reorder_rsample_dup_first (struct nn_rmsg *rmsg, struct nn_rsample *rsampleiv)
 {
   /* Duplicates the rsampleiv without updating any reference counts:
      that is left to the caller, as they do not need to be updated if
@@ -1738,7 +1738,6 @@ struct nn_rsample *nn_reorder_rsample_dup (struct nn_rmsg *rmsg, struct nn_rsamp
      rsampleiv. */
   struct nn_rsample *rsampleiv_new;
   struct nn_rsample_chain_elem *sce;
-  assert (rsample_is_singleton (&rsampleiv->u.reorder));
 #ifndef NDEBUG
   {
     struct nn_rdata *d = rsampleiv->u.reorder.sc.first->fragchain;
@@ -1754,7 +1753,9 @@ struct nn_rsample *nn_reorder_rsample_dup (struct nn_rmsg *rmsg, struct nn_rsamp
   sce->fragchain = rsampleiv->u.reorder.sc.first->fragchain;
   sce->next = NULL;
   sce->sampleinfo = rsampleiv->u.reorder.sc.first->sampleinfo;
-  *rsampleiv_new = *rsampleiv;
+  rsampleiv_new->u.reorder.min = rsampleiv->u.reorder.min;
+  rsampleiv_new->u.reorder.maxp1 = rsampleiv_new->u.reorder.min + 1;
+  rsampleiv_new->u.reorder.n_samples = 1;
   rsampleiv_new->u.reorder.sc.first = rsampleiv_new->u.reorder.sc.last = sce;
   return rsampleiv_new;
 }

--- a/src/core/ddsi/src/q_receive.c
+++ b/src/core/ddsi/src/q_receive.c
@@ -2201,8 +2201,10 @@ static void handle_regular (struct receiver_state *rst, nn_etime_t tnow, struct 
         nn_reorder_result_t rres2;
         if (wn->in_sync == PRMSS_SYNC)
           continue;
+        /* only need to get a copy of the first sample, because that's the one
+           that triggered delivery */
         if (!reuse_rsample_dup)
-          rsample_dup = nn_reorder_rsample_dup (rmsg, rsample);
+          rsample_dup = nn_reorder_rsample_dup_first (rmsg, rsample);
         rres2 = nn_reorder_rsample (&sc, wn->u.not_in_sync.reorder, rsample_dup, &refc_adjust, nn_dqueue_is_full (pwr->dqueue));
         switch (rres2)
         {

--- a/src/ddsrt/src/sockets/posix/socket.c
+++ b/src/ddsrt/src/sockets/posix/socket.c
@@ -466,6 +466,7 @@ send_error_to_retcode(int errnum)
 {
   switch (errnum) {
     case EACCES:
+    case EPERM:
       return DDS_RETCODE_NOT_ALLOWED;
     case EAGAIN:
 #if EAGAIN != EWOULDBLOCK

--- a/src/mpt/tests/qos/procs/ppud.c
+++ b/src/mpt/tests/qos/procs/ppud.c
@@ -28,25 +28,28 @@
 void ppud_init (void) { }
 void ppud_fini (void) { }
 
-static const char *exp_ud[] = {
-  "a", "bc", "def", ""
-};
-
 MPT_ProcessEntry (ppud,
                   MPT_Args (dds_domainid_t domainid,
-                            bool active,
+                            bool master,
                             unsigned ncycles))
 {
+#define prefix "ppuserdata:"
+  static const char *exp_ud[] = {
+    prefix "a", prefix "bc", prefix "def", prefix ""
+  };
+  const char *expud = master ? prefix "X" : prefix;
+  size_t expusz = strlen (expud);
   dds_entity_t dp, rd, ws;
   dds_instance_handle_t dpih;
   dds_return_t rc;
   dds_qos_t *qos;
   int id = (int) ddsrt_getpid ();
 
-  printf ("=== [Check(%d)] active=%d ncycles=%u Start(%d) ...\n", id, active, ncycles, (int) domainid);
+  printf ("=== [Check(%d)] master=%d ncycles=%u Start(%d) ...\n", id, master, ncycles, (int) domainid);
 
   qos = dds_create_qos ();
   dds_qset_history (qos, DDS_HISTORY_KEEP_ALL, 0);
+  dds_qset_userdata (qos, expud, expusz);
   dp = dds_create_participant (domainid, qos, NULL);
   MPT_ASSERT_FATAL_GT (dp, 0, "Could not create participant: %s\n", dds_strretcode (dp));
   rc = dds_get_instance_handle (dp, &dpih);
@@ -61,7 +64,7 @@ MPT_ProcessEntry (ppud,
   MPT_ASSERT_FATAL_EQ (rc, 0, "Could not attach reader to waitset: %s\n", dds_strretcode (rc));
 
   bool done = false;
-  bool first = true;
+  bool synced = !master;
   unsigned exp_index = 0;
   unsigned exp_cycle = 0;
   while (!done)
@@ -84,83 +87,88 @@ MPT_ProcessEntry (ppud,
         void *ud = NULL;
         size_t usz = 0;
         if (!dds_qget_userdata (sample->qos, &ud, &usz))
-          printf ("%d: user data not set in QoS\n", id);
-        if (first && usz == 0)
+          MPT_ASSERT (0, "%d: user data not set in QoS\n", id);
+        if (ud == NULL || strncmp (ud, prefix, sizeof (prefix) - 1) != 0)
         {
-          dds_qset_userdata (qos, "X", 1);
-          rc = dds_set_qos (dp, qos);
-          MPT_ASSERT_EQ (rc, DDS_RETCODE_OK, "Set QoS failed: %s\n", dds_strretcode (rc));
+          /* presumably another process */
+        }
+        else if (!synced && strcmp (ud, expud) != 0)
+        {
+          /* slave hasn't discovered us yet */
+        }
+        else if (synced && master && strcmp (ud, prefix "X") == 0 && exp_index == 1 && exp_cycle == 0)
+        {
+          /* FIXME: don't want no stutter of the initial sample ... */
         }
         else
         {
-          const char *exp = exp_ud[exp_index];
-          if (first && strcmp (ud, "X") == 0)
-            exp = "X";
-          const size_t expsz = strlen (exp);
-          bool eq = (usz == expsz && (usz == 0 || memcmp (ud, exp, usz) == 0));
-          //printf ("%d: expected %u %zu/%s received %zu/%s\n",
-          //        id, exp_index, expsz, exp, usz, ud ? (char *) ud : "(null)");
-          MPT_ASSERT (eq, "User data mismatch: expected %u %zu/%s received %zu/%s\n",
-                      exp_index, expsz, exp, usz, ud ? (char *) ud : "(null)");
-          if (strcmp (exp, "X") != 0 && ++exp_index == sizeof (exp_ud) / sizeof (exp_ud[0]))
+          synced = true;
+          if (master)
           {
-            exp_index = 0;
-            exp_cycle++;
-          }
+            bool eq = (usz == expusz && (usz == 0 || memcmp (ud, expud, usz) == 0));
+            printf ("%d: expected %u %zu/%s received %zu/%s\n",
+                    id, exp_index, expusz, expud, usz, ud ? (char *) ud : "(null)");
+            MPT_ASSERT (eq, "user data mismatch: expected %u %zu/%s received %zu/%s\n",
+                        exp_index, expusz, expud ? expud : "(null)", usz, ud ? (char *) ud : "(null)");
+            if (++exp_index == sizeof (exp_ud) / sizeof (exp_ud[0]))
+            {
+              exp_index = 0;
+              exp_cycle++;
+            }
 
-          if (active && exp_cycle == ncycles)
-            done = true;
+            if (exp_cycle == ncycles)
+              done = true;
+
+            expud = exp_ud[exp_index];
+            expusz = strlen (expud);
+          }
           else
           {
-            const void *newud;
-            size_t newusz;
-            if (!active)
-            {
-              /* Set user data to the same value in response */
-              newud = ud; newusz = usz;
-              dds_qset_userdata (qos, ud, usz);
-            }
-            else /* Set next agreed value */
-            {
-              newud = exp_ud[exp_index]; newusz = strlen (exp_ud[exp_index]);
-              dds_qset_userdata (qos, newud, newusz);
-            }
-
-            rc = dds_set_qos (dp, qos);
-            MPT_ASSERT_EQ (rc, DDS_RETCODE_OK, "Set QoS failed: %s\n", dds_strretcode (rc));
-
-            dds_qos_t *chk = dds_create_qos ();
-            rc = dds_get_qos (dp, chk);
-            MPT_ASSERT_EQ (rc, DDS_RETCODE_OK, "Get QoS failed: %s\n", dds_strretcode (rc));
-
-            void *chkud = NULL;
-            size_t chkusz = 0;
-            if (!dds_qget_userdata (chk, &chkud, &chkusz))
-              MPT_ASSERT (0, "Check QoS: no user data present\n");
-            MPT_ASSERT (chkusz == newusz && (newusz == 0 || memcmp (chkud, newud, newusz) == 0),
-                        "Retrieved user data differs from user data just set (%zu/%s vs %zu/%s)\n",
-                        chkusz, chkud ? (char *) chkud : "(null)", newusz, newud ? (char *) newud : "(null)");
-            dds_free (chkud);
-            dds_delete_qos (chk);
-            first = false;
+            printf ("%d: slave: received %zu/%s\n", id, usz, ud ? (char *) ud : "(null)");
+            expud = ud;
+            expusz = usz;
           }
+
+          dds_qset_userdata (qos, expud, expusz);
+          rc = dds_set_qos (dp, qos);
+          MPT_ASSERT_EQ (rc, DDS_RETCODE_OK, "Set QoS failed: %s\n", dds_strretcode (rc));
+
+          dds_qos_t *chk = dds_create_qos ();
+          rc = dds_get_qos (dp, chk);
+          MPT_ASSERT_EQ (rc, DDS_RETCODE_OK, "Get QoS failed: %s\n", dds_strretcode (rc));
+
+          void *chkud = NULL;
+          size_t chkusz = 0;
+          if (!dds_qget_userdata (chk, &chkud, &chkusz))
+            MPT_ASSERT (0, "Check QoS: no user data present\n");
+          MPT_ASSERT (chkusz == expusz && (expusz == 0 || memcmp (chkud, expud, expusz) == 0),
+                      "Retrieved user data differs from user data just set (%zu/%s vs %zu/%s)\n",
+                      chkusz, chkud ? (char *) chkud : "(null)", expusz, expud ? (char *) expud : "(null)");
+          dds_free (chkud);
+          dds_delete_qos (chk);
         }
         dds_free (ud);
       }
     }
     MPT_ASSERT_FATAL_EQ (n, 0, "Read failed: %s\n", dds_strretcode (n));
     dds_return_loan (rd, &raw, 1);
+    fflush (stdout);
   }
   dds_delete_qos (qos);
   rc = dds_delete (dp);
   MPT_ASSERT_EQ (rc, DDS_RETCODE_OK, "teardown failed\n");
   printf ("=== [Check(%d)] Done\n", id);
+#undef prefix
 }
+
+static const char *exp_rwud[] = {
+  "a", "bc", "def", ""
+};
 
 MPT_ProcessEntry (rwud,
                   MPT_Args (dds_domainid_t domainid,
                             const char *topic_name,
-                            bool active,
+                            bool master,
                             unsigned ncycles,
                             enum rwud which))
 {
@@ -168,12 +176,15 @@ MPT_ProcessEntry (rwud,
   void (*qset) (dds_qos_t * __restrict qos, const void *value, size_t sz) = 0;
   const char *qname = "UNDEFINED";
 
-  dds_entity_t dp, tp, ep, rdep, qent = 0, ws;
+  dds_entity_t dp, tp, ep, grp, rdep, qent = 0, ws;
   dds_return_t rc;
   dds_qos_t *qos;
   int id = (int) ddsrt_getpid ();
 
-  printf ("=== [Check(%d)] active=%d ncycles=%u Start(%d) ...\n", id, active, ncycles, (int) domainid);
+  const char *expud = master ? "X" : "";
+  size_t expusz = strlen (expud);
+
+  printf ("=== [Check(%d)] master=%d ncycles=%u Start(%d) ...\n", id, master, ncycles, (int) domainid);
 
   qos = dds_create_qos ();
   dds_qset_history (qos, DDS_HISTORY_KEEP_ALL, 0);
@@ -181,18 +192,22 @@ MPT_ProcessEntry (rwud,
   MPT_ASSERT_FATAL_GT (dp, 0, "Could not create participant: %s\n", dds_strretcode (dp));
   tp = dds_create_topic (dp, &RWData_Msg_desc, topic_name, qos, NULL);
   MPT_ASSERT_FATAL_GT (tp, 0, "Could not create topic: %s\n", dds_strretcode (tp));
-  if (active)
+  if (master)
   {
     rdep = dds_create_reader (dp, DDS_BUILTIN_TOPIC_DCPSSUBSCRIPTION, qos, NULL);
     MPT_ASSERT_FATAL_GT (rdep, 0, "Could not create DCPSSubscription reader: %s\n", dds_strretcode (rdep));
-    ep = dds_create_writer (dp, tp, qos, NULL);
+    grp = dds_create_publisher (dp, qos, NULL);
+    MPT_ASSERT_FATAL_GT (grp, 0, "Could not create publisher: %s\n", dds_strretcode (grp));
+    ep = dds_create_writer (grp, tp, qos, NULL);
     MPT_ASSERT_FATAL_GT (ep, 0, "Could not create writer: %s\n", dds_strretcode (ep));
   }
   else
   {
     rdep = dds_create_reader (dp, DDS_BUILTIN_TOPIC_DCPSPUBLICATION, qos, NULL);
     MPT_ASSERT_FATAL_GT (rdep, 0, "Could not create DCPSPublication reader: %s\n", dds_strretcode (rdep));
-    ep = dds_create_reader (dp, tp, qos, NULL);
+    grp = dds_create_subscriber (dp, qos, NULL);
+    MPT_ASSERT_FATAL_GT (grp, 0, "Could not create subscriber: %s\n", dds_strretcode (grp));
+    ep = dds_create_reader (grp, tp, qos, NULL);
     MPT_ASSERT_FATAL_GT (ep, 0, "Could not create reader: %s\n", dds_strretcode (ep));
   }
   rc = dds_set_status_mask (rdep, DDS_DATA_AVAILABLE_STATUS);
@@ -214,7 +229,7 @@ MPT_ProcessEntry (rwud,
       qget = dds_qget_groupdata;
       qset = dds_qset_groupdata;
       qname = "group data";
-      qent = dds_get_parent (ep);
+      qent = grp;
       MPT_ASSERT_FATAL_GT (qent, 0, "Could not get pub/sub from wr/rd: %s\n", dds_strretcode (qent));
       break;
     case RWUD_TOPICDATA:
@@ -225,10 +240,18 @@ MPT_ProcessEntry (rwud,
       break;
   }
 
+  if (master)
+  {
+    qset (qos, expud, expusz);
+    rc = dds_set_qos (qent, qos);
+    MPT_ASSERT_EQ (rc, DDS_RETCODE_OK, "Set QoS failed: %s\n", dds_strretcode (rc));
+  }
+
   bool done = false;
-  bool first = true;
+  bool synced = !master;
   unsigned exp_index = 0;
   unsigned exp_cycle = 0;
+  dds_instance_handle_t peer = 0;
   while (!done)
   {
     rc = dds_waitset_wait (ws, NULL, 0, DDS_INFINITY);
@@ -240,81 +263,76 @@ MPT_ProcessEntry (rwud,
     while ((n = dds_take (rdep, &raw, &si, 1, 1)) == 1)
     {
       const dds_builtintopic_endpoint_t *sample = raw;
-      if (si.instance_state != DDS_IST_ALIVE)
+      if (si.instance_state != DDS_IST_ALIVE && si.instance_handle == peer)
         done = true;
-      else if (!si.valid_data || strcmp (sample->topic_name, topic_name) != 0)
+      else if (!si.valid_data)
+        continue;
+      else if ((peer && si.instance_handle != peer) || strcmp (sample->topic_name, topic_name) != 0)
         continue;
       else
       {
         void *ud = NULL;
         size_t usz = 0;
         if (!qget (sample->qos, &ud, &usz))
-          printf ("%d: group data not set in QoS\n", id);
-        if (first && usz == 0)
+          MPT_ASSERT (0, "%d: %s not set in QoS\n", id, qname);
+        else if (!synced && (ud == NULL || strcmp (ud, expud) != 0))
         {
-          qset (qos, "X", 1);
-          rc = dds_set_qos (qent, qos);
-          MPT_ASSERT_EQ (rc, DDS_RETCODE_OK, "Set QoS failed: %s\n", dds_strretcode (rc));
+          /* slave hasn't discovered us yet */
         }
         else
         {
-          const char *exp = exp_ud[exp_index];
-          if (first && strcmp (ud, "X") == 0)
-            exp = "X";
-          const size_t expsz = first ? 1 : strlen (exp);
-          bool eq = (usz == expsz && (usz == 0 || memcmp (ud, exp, usz) == 0));
-          //printf ("%d: expected %u %zu/%s received %zu/%s\n",
-          //        id, exp_index, expsz, exp, usz, ud ? (char *) ud : "(null)");
-          MPT_ASSERT (eq, "%s mismatch: expected %u %zu/%s received %zu/%s\n",
-                      qname, exp_index, expsz, exp, usz, ud ? (char *) ud : "(null)");
-          if (strcmp (exp, "X") != 0 && ++exp_index == sizeof (exp_ud) / sizeof (exp_ud[0]))
+          peer = si.instance_handle;
+          synced = true;
+          if (master)
           {
-            exp_index = 0;
-            exp_cycle++;
-          }
+            bool eq = (usz == expusz && (usz == 0 || memcmp (ud, expud, usz) == 0));
+            printf ("%d: expected %u %zu/%s received %zu/%s\n",
+                    id, exp_index, expusz, expud, usz, ud ? (char *) ud : "(null)");
+            MPT_ASSERT (eq, "%s mismatch: expected %u %zu/%s received %zu/%s\n",
+                        qname, exp_index, expusz, expud ? expud : "(null)", usz, ud ? (char *) ud : "(null)");
+            if (++exp_index == sizeof (exp_rwud) / sizeof (exp_rwud[0]))
+            {
+              exp_index = 0;
+              exp_cycle++;
+            }
 
-          if (active && exp_cycle == ncycles)
-            done = true;
+            if (exp_cycle == ncycles)
+              done = true;
+
+            expud = exp_rwud[exp_index];
+            expusz = strlen (expud);
+          }
           else
           {
-            const void *newud;
-            size_t newusz;
-            if (!active)
-            {
-              /* Set group data to the same value in response */
-              newud = ud; newusz = usz;
-              qset (qos, ud, usz);
-            }
-            else /* Set next agreed value */
-            {
-              newud = exp_ud[exp_index]; newusz = strlen (exp_ud[exp_index]);
-              qset (qos, newud, newusz);
-            }
-
-            rc = dds_set_qos (qent, qos);
-            MPT_ASSERT_EQ (rc, DDS_RETCODE_OK, "Set QoS failed: %s\n", dds_strretcode (rc));
-
-            dds_qos_t *chk = dds_create_qos ();
-            rc = dds_get_qos (ep, chk);
-            MPT_ASSERT_EQ (rc, DDS_RETCODE_OK, "Get QoS failed: %s\n", dds_strretcode (rc));
-
-            void *chkud = NULL;
-            size_t chkusz = 0;
-            if (!qget (chk, &chkud, &chkusz))
-              MPT_ASSERT (0, "Check QoS: no %s present\n", qname);
-            MPT_ASSERT (chkusz == newusz && (newusz == 0 || memcmp (chkud, newud, newusz) == 0),
-                        "Retrieved %s differs from group data just set (%zu/%s vs %zu/%s)\n", qname,
-                        chkusz, chkud ? (char *) chkud : "(null)", newusz, newud ? (char *) newud : "(null)");
-            dds_free (chkud);
-            dds_delete_qos (chk);
-            first = false;
+            printf ("%d: slave: received %zu/%s\n", id, usz, ud ? (char *) ud : "(null)");
+            expud = ud;
+            expusz = usz;
           }
+
+          qset (qos, expud, expusz);
+          rc = dds_set_qos (qent, qos);
+          MPT_ASSERT_EQ (rc, DDS_RETCODE_OK, "Set QoS failed: %s\n", dds_strretcode (rc));
+
+          dds_qos_t *chk = dds_create_qos ();
+          rc = dds_get_qos (ep, chk);
+          MPT_ASSERT_EQ (rc, DDS_RETCODE_OK, "Get QoS failed: %s\n", dds_strretcode (rc));
+
+          void *chkud = NULL;
+          size_t chkusz = 0;
+          if (!qget (chk, &chkud, &chkusz))
+            MPT_ASSERT (0, "Check QoS: no %s present\n", qname);
+          MPT_ASSERT (chkusz == expusz && (expusz == 0 || memcmp (chkud, expud, expusz) == 0),
+                      "Retrieved %s differs from group data just set (%zu/%s vs %zu/%s)\n", qname,
+                      chkusz, chkud ? (char *) chkud : "(null)", expusz, expud ? (char *) expud : "(null)");
+          dds_free (chkud);
+          dds_delete_qos (chk);
         }
         dds_free (ud);
       }
     }
     MPT_ASSERT_FATAL_EQ (n, 0, "Read failed: %s\n", dds_strretcode (n));
     dds_return_loan (rdep, &raw, 1);
+    fflush (stdout);
   }
   dds_delete_qos (qos);
   rc = dds_delete (dp);

--- a/src/mpt/tests/qos/procs/ppud.h
+++ b/src/mpt/tests/qos/procs/ppud.h
@@ -34,13 +34,13 @@ enum rwud {
 
 MPT_ProcessEntry (ppud,
                   MPT_Args (dds_domainid_t domainid,
-                            bool active,
+                            bool master,
                             unsigned ncycles));
 
 MPT_ProcessEntry (rwud,
                   MPT_Args (dds_domainid_t domainid,
                             const char *topic_name,
-                            bool active,
+                            bool master,
                             unsigned ncycles,
                             enum rwud which));
 

--- a/src/tools/ddsperf/ddsperf_types.idl
+++ b/src/tools/ddsperf/ddsperf_types.idl
@@ -40,6 +40,8 @@ struct CPUStats
   string hostname;
   unsigned long pid;
   double maxrss;
+  unsigned long vcsw;
+  unsigned long ivcsw;
   boolean some_above;
   sequence<CPUStatThread> cpu;
 };


### PR DESCRIPTION
* Small improvements to DDSPerf (default settings, allowing units in size specification, context switches)

And some small improvements made while adding multi-domain work. As these are completely independent fixes:

* Faster builds on CI by parallelizing the building and testing
* Reduced likelihood of ddsrt_select_timeout test failure (#212)
* Fixes an assertion in the receive path introduced by #165 
* Improved robustness of the multi-process QoS change tests
* Conform to C99 rules for flexible array members
* Ignore EPERM on sendmsg that sometimes happens because of firewalls