### PR TITLE
Fallback to zip installer for non Linux/Windows builds

### DIFF
--- a/cmake/Modules/Packaging.cmake
+++ b/cmake/Modules/Packaging.cmake
@@ -140,6 +140,9 @@ elseif(CMAKE_SYSTEM_NAME MATCHES "Linux")
     # Generic tgz package
     set(CPACK_GENERATOR "TGZ;${CPACK_GENERATOR}" CACHE STRING "List of package generators")
   endif()
+else()
+    # Fallback to zip package
+    set(CPACK_GENERATOR "ZIP;${CPACK_GENERATOR}" CACHE STRING "List of package generators")
 endif()
 
 # This must always be last!


### PR DESCRIPTION
When building an installer for a non Windows/Linux target i.e. FreeRTOS a CPACK error occurs due to missing generator setting. This PR adds a fallback to zip for these situations. 