### PR TITLE
Interoperability: keyless topics and malformed ACKNACK from FastRTPS

### DIFF
--- a/src/core/ddsc/src/dds_sertopic_builtintopic.c
+++ b/src/core/ddsc/src/dds_sertopic_builtintopic.c
@@ -29,16 +29,7 @@
 struct ddsi_sertopic *new_sertopic_builtintopic (enum ddsi_sertopic_builtintopic_type type, const char *name, const char *typename, struct q_globals *gv)
 {
   struct ddsi_sertopic_builtintopic *tp = ddsrt_malloc (sizeof (*tp));
-  tp->c.iid = ddsi_iid_gen();
-  tp->c.name = dds_string_dup (name);
-  tp->c.type_name = dds_string_dup (typename);
-  const size_t name_typename_size = strlen (tp->c.name) + 1 + strlen (tp->c.type_name) + 1;
-  tp->c.name_type_name = dds_alloc (name_typename_size);
-  snprintf (tp->c.name_type_name, name_typename_size, "%s/%s", tp->c.name, tp->c.type_name);
-  tp->c.ops = &ddsi_sertopic_ops_builtintopic;
-  tp->c.serdata_ops = &ddsi_serdata_ops_builtintopic;
-  tp->c.serdata_basehash = ddsi_sertopic_compute_serdata_basehash (tp->c.serdata_ops);
-  ddsrt_atomic_st32 (&tp->c.refc, 1);
+  ddsi_sertopic_init (&tp->c, name, typename, &ddsi_sertopic_ops_builtintopic, &ddsi_serdata_ops_builtintopic, false);
   tp->type = type;
   tp->gv = gv;
   return &tp->c;
@@ -46,9 +37,7 @@ struct ddsi_sertopic *new_sertopic_builtintopic (enum ddsi_sertopic_builtintopic
 
 static void sertopic_builtin_free (struct ddsi_sertopic *tp)
 {
-  ddsrt_free (tp->name_type_name);
-  ddsrt_free (tp->name);
-  ddsrt_free (tp->type_name);
+  ddsi_sertopic_fini (tp);
   ddsrt_free (tp);
 }
 

--- a/src/core/ddsi/include/dds/ddsi/ddsi_sertopic.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_sertopic.h
@@ -22,22 +22,31 @@ extern "C" {
 
 struct ddsi_serdata;
 struct ddsi_serdata_ops;
-
-struct dds_topic;
-typedef void (*topic_cb_t) (struct dds_topic * topic);
-
 struct ddsi_sertopic_ops;
 
 struct ddsi_sertopic {
   const struct ddsi_sertopic_ops *ops;
   const struct ddsi_serdata_ops *serdata_ops;
   uint32_t serdata_basehash;
+  bool topickind_no_key;
   char *name_type_name;
   char *name;
   char *type_name;
   uint64_t iid;
   ddsrt_atomic_uint32_t refc; /* counts refs from entities, not from data */
 };
+
+/* The old and the new happen to have the same memory layout on a 64-bit machine
+   and so any user that memset's the ddsi_sertopic to 0 before filling out the
+   required fields gets unchanged behaviour.  32-bit machines have a different
+   layout and no such luck.
+
+   There are presumably very few users of this type outside Cyclone DDS itself,
+   but the ROS2 RMW implementation does use it -- indeed, it prompted the change.
+   This define makes it possible to have a single version of the source that is
+   compatible with the old and the new definition, even if it is only partially
+   binary compatible. */
+#define DDSI_SERTOPIC_HAS_TOPICKIND_NO_KEY 1
 
 /* Called when the refcount dropped to zero */
 typedef void (*ddsi_sertopic_free_t) (struct ddsi_sertopic *tp);
@@ -59,6 +68,9 @@ struct ddsi_sertopic_ops {
   ddsi_sertopic_free_samples_t free_samples;
 };
 
+DDS_EXPORT void ddsi_sertopic_init (struct ddsi_sertopic *tp, const char *name, const char *type_name, const struct ddsi_sertopic_ops *sertopic_ops, const struct ddsi_serdata_ops *serdata_ops, bool topickind_no_key);
+DDS_EXPORT void ddsi_sertopic_init_anon (struct ddsi_sertopic *tp, const struct ddsi_sertopic_ops *sertopic_ops, const struct ddsi_serdata_ops *serdata_ops, bool topickind_no_key);
+DDS_EXPORT void ddsi_sertopic_fini (struct ddsi_sertopic *tp);
 DDS_EXPORT struct ddsi_sertopic *ddsi_sertopic_ref (const struct ddsi_sertopic *tp);
 DDS_EXPORT void ddsi_sertopic_unref (struct ddsi_sertopic *tp);
 DDS_EXPORT uint32_t ddsi_sertopic_compute_serdata_basehash (const struct ddsi_serdata_ops *ops);

--- a/src/core/ddsi/include/dds/ddsi/ddsi_vendor.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_vendor.h
@@ -60,6 +60,9 @@ inline bool vendor_is_opensplice (nn_vendorid_t vendor) {
 inline bool vendor_is_twinoaks (nn_vendorid_t vendor) {
   return vendor_equals (vendor, (nn_vendorid_t) {{ 0x01, NN_VENDORID_MINOR_TWINOAKS }});
 }
+inline bool vendor_is_eprosima (nn_vendorid_t vendor) {
+  return vendor_equals (vendor, (nn_vendorid_t) {{ 0x01, NN_VENDORID_MINOR_EPROSIMA }});
+}
 inline bool vendor_is_cloud (nn_vendorid_t vendor) {
   return vendor_equals (vendor, (nn_vendorid_t) {{ 0x01, NN_VENDORID_MINOR_PRISMTECH_CLOUD }});
 }

--- a/src/core/ddsi/include/dds/ddsi/q_entity.h
+++ b/src/core/ddsi/include/dds/ddsi/q_entity.h
@@ -410,6 +410,7 @@ int is_builtin_endpoint (nn_entityid_t id, nn_vendorid_t vendorid);
 bool is_local_orphan_endpoint (const struct entity_common *e);
 int is_writer_entityid (nn_entityid_t id);
 int is_reader_entityid (nn_entityid_t id);
+int is_keyed_endpoint_entityid (nn_entityid_t id);
 nn_vendorid_t get_entity_vendorid (const struct entity_common *e);
 
 /* Interface for glue code between the OpenSplice kernel and the DDSI

--- a/src/core/ddsi/src/ddsi_sertopic_default.c
+++ b/src/core/ddsi/src/ddsi_sertopic_default.c
@@ -22,13 +22,9 @@
 #include "dds/ddsi/ddsi_sertopic.h"
 #include "dds/ddsi/ddsi_serdata_default.h"
 
-/* FIXME: sertopic /= ddstopic so a lot of stuff needs to be moved here from dds_topic.c and the free function needs to be implemented properly */
-
 static void sertopic_default_free (struct ddsi_sertopic *tp)
 {
-  ddsrt_free (tp->name_type_name);
-  ddsrt_free (tp->name);
-  ddsrt_free (tp->type_name);
+  ddsi_sertopic_fini (tp);
   ddsrt_free (tp);
 }
 

--- a/src/core/ddsi/src/ddsi_vendor.c
+++ b/src/core/ddsi/src/ddsi_vendor.c
@@ -16,6 +16,7 @@
 extern inline bool vendor_equals (nn_vendorid_t a, nn_vendorid_t b);
 extern inline bool vendor_is_rti (nn_vendorid_t vendor);
 extern inline bool vendor_is_twinoaks (nn_vendorid_t vendor);
+extern inline bool vendor_is_eprosima (nn_vendorid_t vendor);
 extern inline bool vendor_is_prismtech (nn_vendorid_t vendor);
 extern inline bool vendor_is_opensplice (nn_vendorid_t vendor);
 extern inline bool vendor_is_cloud (nn_vendorid_t vendor);

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -744,15 +744,11 @@ static struct ddsi_sertopic *make_special_topic (struct serdatapool *serpool, ui
        (kinda natural if they stop being "default" ones) */
   struct ddsi_sertopic_default *st = ddsrt_malloc (sizeof (*st));
   memset (st, 0, sizeof (*st));
-  ddsrt_atomic_st32 (&st->c.refc, 1);
-  st->c.ops = &ddsi_sertopic_ops_default;
-  st->c.serdata_ops = ops;
-  st->c.serdata_basehash = ddsi_sertopic_compute_serdata_basehash (st->c.serdata_ops);
-  st->c.iid = ddsi_iid_gen ();
+  ddsi_sertopic_init_anon (&st->c, &ddsi_sertopic_ops_default, ops, false);
   st->native_encoding_identifier = enc_id;
   st->serpool = serpool;
   st->nkeys = 1;
-  return (struct ddsi_sertopic *)st;
+  return (struct ddsi_sertopic *) st;
 }
 
 static void make_special_topics (struct q_globals *gv)


### PR DESCRIPTION
This pull request addresses to issues: the trivial one is that FastRTPS generates malformed pre-"emptive" ACKNACK messages where it sets the base sequence number to 0 (which is explicitly forbidden by the standard).

The less-trivial one is that it changes Cyclone to use the "NO_KEY" variants of readers and writers, submitting to the tyranny of the majority in the name of interoperability, even though it is actually incorrect.

## For the gory details

DDSI-RTPS has two distinct types of readers and writers: those of the “WITH_KEY” kind, and those of the “NO_KEY” kind. Nothing is explicitly defined as to how DCPS readers and writers should be mapped to these, although table 8.2 suggests something:

>Enumeration used to distinguish whether a Topic has defined some fields within to be used as the ‘key’ that identifies data-instances within the Topic. See the DDS specification for more details on keys.
> The following values are reserved by the protocol:
> ``NO_KEY``
> ``WITH_KEY``

but then the specification continues to define behavioural differences between the two — I suppose it is a good thing the two are treated differently, else there really would be no point in having both! — for example:

> 8.2.9.1.3 Transition T3
> This transition is triggered by the act of disposing a data-object previously written with the DDS DataWriter ‘the_dds_writer.’ The DataWriter::dispose() operation takes as parameter the InstanceHandle_t ‘handle’ used to differentiate among different data-objects.
> This operation has no effect if the topicKind==NO_KEY.

and 8.2.9.1.4, the same for “unregister”.

Furthermore, it states in 8.4.4, “The Behavior of a Writer with respect to each matched Reader”:

> Both RTPS Writer and Reader must have the same value of the topicKind attribute. This is because they both relate to the same DDS Topic, which will either be WITH_KEY or NO_KEY.

That seems clear enough. However, the DCPS specification — which is after all the governing specification that defines the application-visible behaviour and for which DDSI-RTPS is merely a supporting implementation — states, in 2.1.1.2.2

> If no key is provided, the data set associated with the Topic is restricted to a single instance.

Nowhere does it even suggest that this single instance can’t be disposed or unregistered — or that tracking of registrations is not supposed to be possible.

Therefore, although the DDSI-RTPS specification has this “NO_KEY” that is very suggestively described, the only correct implementation from DDS perspective is to always use the “WITH_KEY” variant. And lest one think the distinction is really not very relevant: consider a transient or persistent topic with no key fields (and thus a single instance). The only way to remove this data from the transient/persistent is by disposing it, so there is good reason to require “WITH_KEY”.

Unfortunately, pretty much all implementations get this wrong … and that creates a compatibility issue for Cyclone. Reality therefore is that Cyclone will have to conform.