### PR TITLE
Prevent participant creation with unknown domain id.

### DIFF
--- a/src/core/ddsc/include/dds/dds.h
+++ b/src/core/ddsc/include/dds/dds.h
@@ -51,17 +51,6 @@ extern "C" {
 
 struct ddsi_serdata;
 
-/**
- * @brief Returns the default domain identifier.
- *
- * The default domain identifier can be configured in the configuration file
- * or be set through an evironment variable ({DDSC_PROJECT_NAME_NOSPACE_CAPS}_DOMAIN).
- *
- * @returns Default domain identifier
- */
-DDS_EXPORT dds_domainid_t dds_domain_default (void);
-
-
 #define DDS_MIN_PSEUDO_HANDLE ((dds_entity_t) 0x7fff0000)
 
 /* @defgroup builtintopic_constants Convenience constants for referring to builtin topics

--- a/src/core/ddsc/src/dds_domain.c
+++ b/src/core/ddsc/src/dds_domain.c
@@ -73,7 +73,7 @@ static dds_return_t dds_domain_init (dds_domain *domain, dds_domainid_t domain_i
         enough) */
 
   (void) ddsrt_getenv ("CYCLONEDDS_URI", &uri);
-  domain->cfgst = config_init (uri, &domain->gv.config, domain_id);
+  domain->cfgst = config_init (uri, &domain->gv.config, (domain_id == DDS_DOMAIN_DEFAULT) ? UINT32_MAX : domain_id);
   if (domain->cfgst == NULL)
   {
     DDS_ILOG (DDS_LC_CONFIG, domain_id, "Failed to parse configuration XML file %s\n", uri);

--- a/src/core/ddsc/tests/participant.c
+++ b/src/core/ddsc/tests/participant.c
@@ -75,7 +75,7 @@ CU_Test(ddsc_participant, create_multiple_domains)
   dds_return_t status;
   dds_domainid_t domain_id;
 
-  ddsrt_setenv("CYCLONEDDS_URI", "<Tracing><Verbosity>finest</><OutputFile>multi-domain-1.log</></>");
+  ddsrt_setenv(DDS_PROJECT_NAME_NOSPACE_CAPS"_URI", "<Tracing><Verbosity>finest</><OutputFile>multi-domain-1.log</></>");
 
   //valid specific domain value
   participant1 = dds_create_participant (1, NULL, NULL);
@@ -84,7 +84,7 @@ CU_Test(ddsc_participant, create_multiple_domains)
   CU_ASSERT_EQUAL_FATAL(status, DDS_RETCODE_OK);
   CU_ASSERT_EQUAL_FATAL(domain_id, 1);
 
-  ddsrt_setenv("CYCLONEDDS_URI", "<Tracing><Verbosity>finest</><OutputFile>multi-domain-2.log</></>");
+  ddsrt_setenv(DDS_PROJECT_NAME_NOSPACE_CAPS"_URI", "<Tracing><Verbosity>finest</><OutputFile>multi-domain-2.log</></>");
 
   //DDS_DOMAIN_DEFAULT from user
   participant2 = dds_create_participant (2, NULL, NULL);
@@ -341,4 +341,21 @@ CU_Test(ddsc_participant_lookup, deleted) {
   CU_ASSERT_FATAL(participants[0] == participant);
 
   dds_delete (participant);
+}
+
+
+/* Test for creating a participant with domain id not mentioned in config  */
+CU_Test(ddsc_participant, create_with_invalid_domain)
+{
+  dds_entity_t participant;
+
+  ddsrt_setenv(DDS_PROJECT_NAME_NOSPACE_CAPS"_URI", "<Domain id=\"3\"/>");
+
+  // invalid specific domain value
+  participant = dds_create_participant (2, NULL, NULL);
+
+  ddsrt_unsetenv(DDS_PROJECT_NAME_NOSPACE_CAPS"_URI");
+
+  // it should have failed
+  CU_ASSERT_FATAL(participant <= 0);
 }


### PR DESCRIPTION
Consider the situation where a configuration mentions only specific domain(s) (non-any).
The creation of a participant with a different domain id (non-default) should fail, but doesn't.

This pull request fixes that.

p.s. Also removed the redundant dds_domain_default() function declaration from dds.h (https://github.com/eclipse-cyclonedds/cyclonedds/pull/223#issuecomment-523519153).