### PR TITLE
Set project name via string literal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,17 +41,10 @@ FUNCTION(PREPEND var prefix)
    SET(${var} "${listVar}" PARENT_SCOPE)
 ENDFUNCTION(PREPEND)
 
-# Update the git submodules
-execute_process(COMMAND git submodule init
-                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-execute_process(COMMAND git submodule update
-                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-
 # Set module path before defining project so platform files will work.
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/Modules")
 set(CMAKE_PROJECT_NAME_FULL "Eclipse Cyclone DDS")
-set(PROJECT_NAME "CycloneDDS")
-project(${PROJECT_NAME} VERSION 0.1.0)
+project(CycloneDDS VERSION 0.1.0)
 
 # Set some convenience variants of the project-name
 string(REPLACE " " "-" CMAKE_PROJECT_NAME_DASHED "${CMAKE_PROJECT_NAME_FULL}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,9 +93,23 @@ endif()
 
 # Set reasonably strict warning options for clang, gcc, msvc
 # Enable coloured ouput if Ninja is used for building
-if("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_C_COMPILER_ID}" STREQUAL "AppleClang")
+if("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang" OR
+   "${CMAKE_C_COMPILER_ID}" STREQUAL "AppleClang")
   #message(STATUS clang)
-  add_compile_options(-Wall -Wextra -Wconversion -Wunused -Wmissing-prototypes)
+  set(wflags "-Wall"
+             "-Wextra"
+             "-Wconversion"
+             "-Wunused"
+             "-Wmissing-prototypes"
+             "-Winfinite-recursion"
+             "-Wassign-enum"
+             "-Wcomma"
+             "-Wmissing-prototypes"
+             "-Wdocumentation"
+             "-Wstrict-prototypes"
+             "-Wconditional-uninitialized"
+             "-Wshadow")
+  add_compile_options(${wflags})
   if(${WERROR})
     add_compile_options(-Werror)
   endif()

--- a/cmake/Modules/CUnit/include/CUnit/Test.h
+++ b/cmake/Modules/CUnit/include/CUnit/Test.h
@@ -48,16 +48,16 @@ typedef struct {
   void CU_TestProxyName(suite, test)(void);                \
                                                            \
   void CU_TestProxyName(suite, test)(void) {               \
-    cu_data_t data = CU_Fixture(__VA_ARGS__);              \
+    cu_data_t cu_data = CU_Fixture(__VA_ARGS__);           \
                                                            \
-    if (data.init != NULL) {                               \
-      data.init();                                         \
+    if (cu_data.init != NULL) {                            \
+      cu_data.init();                                      \
     }                                                      \
                                                            \
     CU_TestName(suite, test)();                            \
                                                            \
-    if (data.fini != NULL) {                               \
-      data.fini();                                         \
+    if (cu_data.fini != NULL) {                            \
+      cu_data.fini();                                      \
     }                                                      \
   }                                                        \
                                                            \

--- a/cmake/Modules/CUnit/include/CUnit/Theory.h
+++ b/cmake/Modules/CUnit/include/CUnit/Theory.h
@@ -47,19 +47,19 @@ extern "C" {
   void CU_TestProxyName(suite, test)(void);                               \
                                                                           \
   void CU_TestProxyName(suite, test)(void) {                              \
-    cu_data_t data = CU_Fixture(__VA_ARGS__);                             \
+    cu_data_t cu_data = CU_Fixture(__VA_ARGS__);                          \
     size_t i, n;                                                          \
                                                                           \
-    if (data.init != NULL) {                                              \
-      data.init();                                                        \
+    if (cu_data.init != NULL) {                                           \
+      cu_data.init();                                                     \
     }                                                                     \
                                                                           \
     for (i = 0, n = CU_TheoryDataPointsSize(suite, test); i < n; i++) {   \
       CU_TestName(suite, test) CU_TheoryDataPointsSlice(suite, test, i) ; \
     }                                                                     \
                                                                           \
-    if (data.fini != NULL) {                                              \
-      data.fini();                                                        \
+    if (cu_data.fini != NULL) {                                           \
+      cu_data.fini();                                                     \
     }                                                                     \
   }                                                                       \
                                                                           \

--- a/src/core/ddsc/tests/subscriber.c
+++ b/src/core/ddsc/tests/subscriber.c
@@ -10,6 +10,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
 #include "dds/dds.h"
+#include "dds/ddsrt/misc.h"
 
 #include <stdio.h>
 #include "CUnit/Test.h"
@@ -82,14 +83,18 @@ CU_Test(ddsc_subscriber, create) {
   dds_delete_qos(sqos);
 
   sqos = dds_create_qos();
+  DDSRT_WARNING_CLANG_OFF(assign-enum);
   dds_qset_destination_order(sqos, 3); /* Set invalid dest. order (ignored, not applicable for subscriber) */
+  DDSRT_WARNING_CLANG_ON(assign-enum);
   subscriber = dds_create_subscriber(participant, sqos, NULL);
   CU_ASSERT_FATAL(subscriber > 0);
   dds_delete(subscriber);
   dds_delete_qos(sqos);
 
   sqos = dds_create_qos();
+  DDSRT_WARNING_CLANG_OFF(assign-enum);
   dds_qset_presentation(sqos, 123, 1, 1); /* Set invalid presentation policy */
+  DDSRT_WARNING_CLANG_ON(assign-enum);
   subscriber = dds_create_subscriber(participant, sqos, NULL);
   CU_ASSERT_EQUAL_FATAL(subscriber, DDS_RETCODE_BAD_PARAMETER);
   dds_delete_qos(sqos);

--- a/src/ddsrt/include/dds/ddsrt/misc.h
+++ b/src/ddsrt/include/dds/ddsrt/misc.h
@@ -18,28 +18,44 @@
 extern "C" {
 #endif
 
-#if defined(__GNUC__) && ((__GNUC__ * 100) + __GNUC_MINOR__) >= 402
-# define DDSRT_GNUC_STR(s) #s
-# define DDSRT_GNUC_JOINSTR(x,y) DDSRT_GNUC_STR(x ## y)
-# define DDSRT_GNUC_DO_PRAGMA(x) _Pragma (#x)
-# define DDSRT_GNUC_PRAGMA(x) DDSRT_GNUC_DO_PRAGMA(GCC diagnostic x)
-# if ((__GNUC__ * 100) + __GNUC_MINOR__) >= 406
+#if defined(__clang__) || \
+    defined(__GNUC__) && ((__GNUC__ * 100) + __GNUC_MINOR__) >= 402
+# define DDSRT_STR(s) #s
+# define DDSRT_JOINSTR(x,y) DDSRT_STR(x ## y)
+# define DDSRT_DO_PRAGMA(x) _Pragma(#x)
+# define DDSRT_PRAGMA(x) DDSRT_DO_PRAGMA(GCC diagnostic x)
+
+# if defined(__clang__)
+#   define DDSRT_WARNING_CLANG_OFF(x) \
+      DDSRT_PRAGMA(push) \
+      DDSRT_PRAGMA(ignored DDSRT_JOINSTR(-W,x))
+#   define DDSRT_WARNING_CLANG_ON(x) \
+      DDSRT_PRAGMA(pop)
+# elif ((__GNUC__ * 100) + __GNUC_MINOR__) >= 406
 #   define DDSRT_WARNING_GNUC_OFF(x) \
-      DDSRT_GNUC_PRAGMA(push) \
-      DDSRT_GNUC_PRAGMA(ignored DDSRT_GNUC_JOINSTR(-W,x))
+      DDSRT_PRAGMA(push) \
+      DDSRT_PRAGMA(ignored DDSRT_JOINSTR(-W,x))
 #   define DDSRT_WARNING_GNUC_ON(x) \
-      DDSRT_GNUC_PRAGMA(pop)
+      DDSRT_PRAGMA(pop)
 # else
 #   define DDSRT_WARNING_GNUC_OFF(x) \
-      DDSRT_GNUC_PRAGMA(ignored DDSRT_GNUC_JOINSTR(-W,x))
+      DDSRT_PRAGMA(ignored DDSRT_JOINSTR(-W,x))
 #   define DDSRT_WARNING_GNUC_ON(x) \
-      DDSRT_GNUC_PRAGMA(warning DDSRT_GNUC_JOINSTR(-W,x))
+      DDSRT_PRAGMA(warning DDSRT_JOINSTR(-W,x))
 # endif
-#else
+#endif
+
+#if !defined(DDSRT_WARNING_CLANG_OFF) && \
+    !defined(DDSRT_WARNING_CLANG_ON)
+# define DDSRT_WARNING_CLANG_OFF(x)
+# define DDSRT_WARNING_CLANG_ON(x)
+#endif
+
+#if !defined(DDSRT_WARNING_GNUC_OFF) && \
+    !defined(DDSRT_WARNING_GNUC_ON)
 # define DDSRT_WARNING_GNUC_OFF(x)
 # define DDSRT_WARNING_GNUC_ON(x)
 #endif
-
 
 #if defined(_MSC_VER)
 # define DDSRT_WARNING_MSVC_OFF(x) \


### PR DESCRIPTION
This pull request sets the project name via a string literal so 3rd party tools can easily extract it. The fix was proposed by @dirk-thomas in PRs #235 and details about why were mentioned in #224. Apart from that this PR enables extra warnings for Clang builds and adds a `DDSRT_WARNING_CLANG_OFF` and a `DDSRT_WARNING_CLANG_ON` to disable and re-enable them as required in the code. e.g. for test cases that verify the api behaves correctly on bad parameters.

Please consider pulling these changes. Thanks!