### PR TITLE
Avoid stale topic pointers (#207) and some "collateral damage"

### DIFF
--- a/src/core/ddsc/include/dds/dds.h
+++ b/src/core/ddsc/include/dds/dds.h
@@ -51,17 +51,6 @@ extern "C" {
 
 struct ddsi_serdata;
 
-/**
- * @brief Returns the default domain identifier.
- *
- * The default domain identifier can be configured in the configuration file
- * or be set through an evironment variable ({DDSC_PROJECT_NAME_NOSPACE_CAPS}_DOMAIN).
- *
- * @returns Default domain identifier
- */
-DDS_EXPORT dds_domainid_t dds_domain_default (void);
-
-
 #define DDS_MIN_PSEUDO_HANDLE ((dds_entity_t) 0x7fff0000)
 
 /* @defgroup builtintopic_constants Convenience constants for referring to builtin topics

--- a/src/core/ddsi/include/dds/ddsi/q_entity.h
+++ b/src/core/ddsi/include/dds/ddsi/q_entity.h
@@ -345,7 +345,6 @@ struct proxy_endpoint_common
   struct proxy_endpoint_common *next_ep; /* next \ endpoint belonging to this proxy participant */
   struct proxy_endpoint_common *prev_ep; /* prev / -- this is in arbitrary ordering */
   struct dds_qos *xqos; /* proxy endpoint QoS lives here; FIXME: local ones should have it moved to common as well */
-  struct ddsi_sertopic * topic; /* topic may be NULL: for built-ins, but also for never-yet matched proxies (so we don't have to know the topic; when we match, we certainly do know) */
   struct addrset *as; /* address set to use for communicating with this endpoint */
   nn_guid_t group_guid; /* 0:0:0:0 if not available */
   nn_vendorid_t vendor; /* cached from proxypp->vendor */

--- a/src/core/ddsi/include/dds/ddsi/q_globals.h
+++ b/src/core/ddsi/include/dds/ddsi/q_globals.h
@@ -158,7 +158,7 @@ struct q_globals {
 
   /* GUID to be used in next call to new_participant; also protected
      by privileged_pp_lock */
-  struct nn_guid next_ppguid;
+  struct nn_guid ppguid_base;
 
   /* number of up, non-loopback, IPv4/IPv6 interfaces, the index of
      the selected/preferred one, and the discovered interfaces. */

--- a/src/core/ddsi/src/q_ddsi_discovery.c
+++ b/src/core/ddsi/src/q_ddsi_discovery.c
@@ -1643,7 +1643,6 @@ int builtins_dqueue_handler (const struct nn_rsample_info *sampleinfo, const str
 
   /* Built-ins still do their own deserialization (SPDP <=> pwr ==
      NULL)). */
-  assert (pwr == NULL || pwr->c.topic == NULL);
   if (statusinfo == 0)
   {
     if (datasz == 0 || !(data_smhdr_flags & DATA_FLAG_DATAFLAG))

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -686,18 +686,14 @@ dds_return_t new_participant_guid (const nn_guid_t *ppguid, struct q_globals *gv
 
 dds_return_t new_participant (nn_guid_t *p_ppguid, struct q_globals *gv, unsigned flags, const nn_plist_t *plist)
 {
-  nn_guid_t ppguid;
-
-  ddsrt_mutex_lock (&gv->privileged_pp_lock);
-  ppguid = gv->next_ppguid;
-  if (gv->next_ppguid.prefix.u[2]++ == ~0u)
-  {
-    ddsrt_mutex_unlock (&gv->privileged_pp_lock);
-    return DDS_RETCODE_OUT_OF_RESOURCES;
-  }
-  ddsrt_mutex_unlock (&gv->privileged_pp_lock);
-  *p_ppguid = ppguid;
-
+  union { uint64_t u64; uint32_t u32[2]; } u;
+  u.u32[0] = gv->ppguid_base.prefix.u[1];
+  u.u32[1] = gv->ppguid_base.prefix.u[2];
+  u.u64 += ddsi_iid_gen ();
+  p_ppguid->prefix.u[0] = gv->ppguid_base.prefix.u[0];
+  p_ppguid->prefix.u[1] = u.u32[0];
+  p_ppguid->prefix.u[2] = u.u32[1];
+  p_ppguid->entityid.u = NN_ENTITYID_PARTICIPANT;
   return new_participant_guid (p_ppguid, gv, flags, plist);
 }
 

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -1875,7 +1875,7 @@ static void proxy_writer_add_connection (struct proxy_writer *pwr, struct reader
     /* builtins really don't care about multiple copies or anything */
     m->in_sync = PRMSS_SYNC;
   }
-  else if (!pwr->have_seen_heartbeat)
+  else if (!pwr->have_seen_heartbeat || !rd->handle_as_transient_local)
   {
     /* Proxy writer hasn't seen a heartbeat yet: means we have no
        clue from what sequence number to start accepting data, nor
@@ -1903,14 +1903,6 @@ static void proxy_writer_add_connection (struct proxy_writer *pwr, struct reader
     else
       m->in_sync = PRMSS_SYNC;
     m->u.not_in_sync.end_of_tl_seq = MAX_SEQ_NUMBER;
-  }
-  else if (!rd->handle_as_transient_local)
-  {
-    /* volatile reader, writer has seen a heartbeat: it's in sync
-       (there is a risk of it getting some historical data: that
-       happens to be cached in the writer's reorder admin at this
-       point) */
-    m->in_sync = PRMSS_SYNC;
   }
   else
   {

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -1037,11 +1037,39 @@ int rtps_init (struct q_globals *gv)
   ddsrt_mutex_init (&gv->privileged_pp_lock);
   gv->privileged_pp = NULL;
 
-  /* Template PP guid -- protected by privileged_pp_lock for simplicity */
-  gv->next_ppguid.prefix.u[0] = locator_to_hopefully_unique_uint32 (&gv->ownloc);
-  gv->next_ppguid.prefix.u[1] = (unsigned) ddsrt_getpid ();
-  gv->next_ppguid.prefix.u[2] = 1;
-  gv->next_ppguid.entityid.u = NN_ENTITYID_PARTICIPANT;
+  /* Base participant GUID.  IID initialisation should be from a really good random
+     generator and yield almost-unique numbers, and with a fallback of using process
+     id, timestamp and a counter, so incorporating that should do a lot to construct
+     a pseudo-random ID.  (The assumption here is that feeding pseudo-random data in
+     MD5 will not change the randomness ...)  Mix in the network configuration to
+     make machines with very reproducible boot sequences and low-resolution clocks
+     distinguishable.
+
+     This base is kept constant, prefix.u[1] and prefix.u[2] are then treated as a
+     64-bit unsigned integer to which we add IIDs to generate a hopping sequence
+     that won't repeat in the lifetime of the process.  Seems like it ought to work
+     to keep the risks of collisions low. */
+  {
+    uint64_t iid = toBE8u (ddsi_iid_gen ());
+    ddsrt_md5_state_t st;
+    ddsrt_md5_byte_t digest[16];
+    ddsrt_md5_init (&st);
+    ddsrt_md5_append (&st, (const ddsrt_md5_byte_t *) &iid, sizeof (iid));
+    for (int i = 0; i < gv->n_interfaces; i++)
+    {
+      const struct nn_interface *intf = &gv->interfaces[i];
+      ddsrt_md5_append (&st, (const ddsrt_md5_byte_t *) &intf->loc.kind, sizeof (intf->loc.kind));
+      ddsrt_md5_append (&st, (const ddsrt_md5_byte_t *) intf->loc.address, sizeof (intf->loc.address));
+    }
+    ddsrt_md5_finish (&st, digest);
+    /* DDSI 2.2 requires the first two bytes of the GUID to be set to the vendor
+       code -- a terrible waste of entropy ... */
+    gv->ppguid_base.prefix.s[0] = NN_VENDORID_ECLIPSE.id[0];
+    gv->ppguid_base.prefix.s[1] = NN_VENDORID_ECLIPSE.id[1];
+    DDSRT_STATIC_ASSERT (sizeof (gv->ppguid_base.prefix.s) > 2 && sizeof (gv->ppguid_base.prefix.s) - 2 <= sizeof (digest));
+    memcpy (&gv->ppguid_base.prefix.s[2], digest, sizeof (gv->ppguid_base.prefix.s) - 2);
+    gv->ppguid_base.entityid.u = NN_ENTITYID_PARTICIPANT;
+  }
 
   ddsrt_mutex_init (&gv->lock);
   ddsrt_mutex_init (&gv->spdp_lock);

--- a/src/core/ddsi/src/q_receive.c
+++ b/src/core/ddsi/src/q_receive.c
@@ -1732,16 +1732,10 @@ static struct ddsi_serdata *get_serdata (struct ddsi_sertopic const * const topi
   return sd;
 }
 
-static struct ddsi_serdata *extract_sample_from_data
-(
-  const struct nn_rsample_info *sampleinfo, unsigned char data_smhdr_flags,
-  const nn_plist_t *qos, const struct nn_rdata *fragchain, unsigned statusinfo,
-  nn_wctime_t tstamp, struct ddsi_sertopic const * const topic
-)
+static struct ddsi_serdata *new_sample_from_data (struct ddsi_tkmap_instance **tk1, struct q_globals *gv, const struct nn_rsample_info *sampleinfo, unsigned char data_smhdr_flags, const nn_plist_t *qos, const struct nn_rdata *fragchain, unsigned statusinfo, nn_wctime_t tstamp, struct ddsi_sertopic const * const topic)
 {
-  static const nn_guid_t null_guid = {{{0,0,0,0,0,0,0,0,0,0,0,0}},{0}};
   const char *failmsg = NULL;
-  struct ddsi_serdata * sample = NULL;
+  struct ddsi_serdata *sample = NULL;
 
   if (statusinfo == 0)
   {
@@ -1749,8 +1743,11 @@ static struct ddsi_serdata *extract_sample_from_data
     if (!(data_smhdr_flags & DATA_FLAG_DATAFLAG) || sampleinfo->size == 0)
     {
       const struct proxy_writer *pwr = sampleinfo->pwr;
-      nn_guid_t guid = pwr ? pwr->e.guid : null_guid; /* can't be null _yet_, but that might change some day */
-      DDS_CTRACE (&sampleinfo->rst->gv->logconfig,
+      nn_guid_t guid;
+      /* pwr can't currently be null, but that might change some day, and this being
+         an error path, it doesn't hurt to survive that */
+      if (pwr) guid = pwr->e.guid; else memset (&guid, 0, sizeof (guid));
+      DDS_CTRACE (&gv->logconfig,
                   "data(application, vendor %u.%u): "PGUIDFMT" #%"PRId64": write without proper payload (data_smhdr_flags 0x%x size %"PRIu32")\n",
                   sampleinfo->rst->vendor.id[0], sampleinfo->rst->vendor.id[1],
                   PGUID (guid), sampleinfo->seq,
@@ -1778,7 +1775,7 @@ static struct ddsi_serdata *extract_sample_from_data
   {
     /* RTI always tries to make us survive on the keyhash. RTI must
        mend its ways. */
-    if (NN_STRICT_P (sampleinfo->rst->gv->config))
+    if (NN_STRICT_P (gv->config))
       failmsg = "no content";
     else if (!(qos->present & PP_KEYHASH))
       failmsg = "qos present but without keyhash";
@@ -1798,15 +1795,30 @@ static struct ddsi_serdata *extract_sample_from_data
   {
     /* No message => error out */
     const struct proxy_writer *pwr = sampleinfo->pwr;
-    nn_guid_t guid = pwr ? pwr->e.guid : null_guid; /* can't be null _yet_, but that might change some day */
-    DDS_CWARNING (&sampleinfo->rst->gv->logconfig,
+    nn_guid_t guid;
+    if (pwr) guid = pwr->e.guid; else memset (&guid, 0, sizeof (guid));
+    DDS_CWARNING (&gv->logconfig,
                   "data(application, vendor %u.%u): "PGUIDFMT" #%"PRId64": deserialization %s/%s failed (%s)\n",
                   sampleinfo->rst->vendor.id[0], sampleinfo->rst->vendor.id[1],
                   PGUID (guid), sampleinfo->seq,
                   topic->name, topic->type_name,
                   failmsg ? failmsg : "for reasons unknown");
   }
+  else
+  {
+    if ((*tk1 = ddsi_tkmap_lookup_instance_ref (gv->m_tkmap, sample)) == NULL)
+    {
+      ddsi_serdata_unref (sample);
+      sample = NULL;
+    }
+  }
   return sample;
+}
+
+static void free_sample_after_store (struct q_globals *gv, struct ddsi_serdata *sample, struct ddsi_tkmap_instance *tk)
+{
+  ddsi_tkmap_instance_unref (gv->m_tkmap, tk);
+  ddsi_serdata_unref (sample);
 }
 
 unsigned char normalize_data_datafrag_flags (const SubmessageHeader_t *smhdr)
@@ -1830,17 +1842,36 @@ unsigned char normalize_data_datafrag_flags (const SubmessageHeader_t *smhdr)
   }
 }
 
+static struct reader *proxy_writer_first_in_sync_reader (struct proxy_writer *pwr, ddsrt_avl_iter_t *it)
+{
+  struct pwr_rd_match *m;
+  struct reader *rd;
+  for (m = ddsrt_avl_iter_first (&pwr_readers_treedef, &pwr->readers, it); m != NULL; m = ddsrt_avl_iter_next (it))
+    if (m->in_sync == PRMSS_SYNC && (rd = ephash_lookup_reader_guid (pwr->e.gv->guid_hash, &m->rd_guid)) != NULL)
+      return rd;
+  return NULL;
+}
+
+static struct reader *proxy_writer_next_in_sync_reader (struct proxy_writer *pwr, ddsrt_avl_iter_t *it)
+{
+  struct pwr_rd_match *m;
+  struct reader *rd;
+  for (m = ddsrt_avl_iter_next (it); m != NULL; m = ddsrt_avl_iter_next (it))
+    if (m->in_sync == PRMSS_SYNC && (rd = ephash_lookup_reader_guid (pwr->e.gv->guid_hash, &m->rd_guid)) != NULL)
+      return rd;
+  return NULL;
+}
+
 static int deliver_user_data (const struct nn_rsample_info *sampleinfo, const struct nn_rdata *fragchain, const nn_guid_t *rdguid, int pwr_locked)
 {
   struct receiver_state const * const rst = sampleinfo->rst;
+  struct q_globals * const gv = rst->gv;
   struct proxy_writer * const pwr = sampleinfo->pwr;
-  struct ddsi_sertopic const * const topic = pwr->c.topic;
   unsigned statusinfo;
   Data_DataFrag_common_t *msg;
   unsigned char data_smhdr_flags;
   nn_plist_t qos;
   int need_keyhash;
-  struct ddsi_serdata * payload;
 
   if (pwr->ddsi2direct_cb)
   {
@@ -1848,22 +1879,11 @@ static int deliver_user_data (const struct nn_rsample_info *sampleinfo, const st
     return 0;
   }
 
-  /* NOTE: pwr->e.lock need not be held for correct processing (though
-     it may be useful to hold it for maintaining order all the way to
-     v_groupWrite): guid is constant, set_vmsg_header() explains about
-     the qos issue (and will have to deal with that); and
-     pwr->groupset takes care of itself.  FIXME: groupset may be
-     taking care of itself, but it is currently doing so in an
-     annoyingly simplistic manner ...  */
-
   /* FIXME: fragments are now handled by copying the message to
      freshly malloced memory (see defragment()) ... that'll have to
      change eventually */
   assert (fragchain->min == 0);
   assert (!is_builtin_entityid (pwr->e.guid.entityid, pwr->c.vendor));
-  /* Can only get here if at some point readers existed => topic can't
-     still be NULL, even if there are no readers at the moment */
-  assert (topic != NULL);
 
   /* Luckily, the Data header (up to inline QoS) is a prefix of the
      DataFrag header, so for the fixed-position things that we're
@@ -1899,13 +1919,13 @@ static int deliver_user_data (const struct nn_rsample_info *sampleinfo, const st
     src.encoding = (msg->smhdr.flags & SMFLAG_ENDIANNESS) ? PL_CDR_LE : PL_CDR_BE;
     src.buf = NN_RMSG_PAYLOADOFF (fragchain->rmsg, qos_offset);
     src.bufsz = NN_RDATA_PAYLOAD_OFF (fragchain) - qos_offset;
-    src.strict = NN_STRICT_P (rst->gv->config);
-    src.factory = rst->gv->m_factory;
-    src.logconfig = &rst->gv->logconfig;
+    src.strict = NN_STRICT_P (gv->config);
+    src.factory = gv->m_factory;
+    src.logconfig = &gv->logconfig;
     if ((plist_ret = nn_plist_init_frommsg (&qos, NULL, PP_STATUSINFO | PP_KEYHASH | PP_COHERENT_SET, 0, &src)) < 0)
     {
       if (plist_ret != DDS_RETCODE_UNSUPPORTED)
-        DDS_CWARNING (&sampleinfo->rst->gv->logconfig,
+        DDS_CWARNING (&gv->logconfig,
                       "data(application, vendor %u.%u): "PGUIDFMT" #%"PRId64": invalid inline qos\n",
                       src.vendorid.id[0], src.vendorid.id[1], PGUID (pwr->e.guid), sampleinfo->seq);
       return 0;
@@ -1913,67 +1933,54 @@ static int deliver_user_data (const struct nn_rsample_info *sampleinfo, const st
     statusinfo = (qos.present & PP_STATUSINFO) ? qos.statusinfo : 0;
   }
 
-  /* Note: deserializing done potentially many times for a historical
-     data sample (once per reader that cares about that data).  For
-     now, this is accepted as sufficiently abnormal behaviour to not
-     worry about it. */
-  {
-    nn_wctime_t tstamp;
-    if (sampleinfo->timestamp.v != NN_WCTIME_INVALID.v)
-      tstamp = sampleinfo->timestamp;
-    else
-      tstamp.v = 0;
-    payload = extract_sample_from_data (sampleinfo, data_smhdr_flags, &qos, fragchain, statusinfo, tstamp, topic);
-  }
-  if (payload == NULL)
-  {
-    goto no_payload;
-  }
+  /* FIXME: should it be 0, local wall clock time or INVALID? */
+  const nn_wctime_t tstamp = (sampleinfo->timestamp.v != NN_WCTIME_INVALID.v) ? sampleinfo->timestamp : ((nn_wctime_t) {0});
+  struct proxy_writer_info pwr_info;
+  make_proxy_writer_info (&pwr_info, &pwr->e, pwr->c.xqos);
 
-  /* Generate the DDS_SampleInfo (which is faked to some extent
-     because we don't actually have a data reader) */
-  struct ddsi_tkmap_instance *tk;
-  if ((tk = ddsi_tkmap_lookup_instance_ref (pwr->e.gv->m_tkmap, payload)) != NULL)
+  if (rdguid == NULL)
   {
-    struct proxy_writer_info pwr_info;
-    make_proxy_writer_info (&pwr_info, &pwr->e, pwr->c.xqos);
+    ETRACE (pwr, " %"PRId64"=>EVERYONE\n", sampleinfo->seq);
 
-    if (rdguid == NULL)
+    /* FIXME: Retry loop, for re-delivery of rejected reliable samples. Is a
+       temporary hack till throttling back of writer is implemented (with late
+       acknowledgement of sample and nack). */
+  retry:
+    ddsrt_mutex_lock (&pwr->rdary.rdary_lock);
+    if (pwr->rdary.fastpath_ok)
     {
-      ETRACE (pwr, " %"PRId64"=>EVERYONE\n", sampleinfo->seq);
-
-      /* FIXME: pwr->rdary is an array of pointers to attached
-       readers.  There's only one thread delivering data for the
-       proxy writer (as long as there is only one receive thread),
-       so could get away with not locking at all, and doing safe
-       updates + GC of rdary instead.  */
-
-      /* Retry loop, for re-delivery of rejected reliable samples. Is a
-       temporary hack till throttling back of writer is implemented
-       (with late acknowledgement of sample and nack). */
-    retry:
-
-      ddsrt_mutex_lock (&pwr->rdary.rdary_lock);
-      if (pwr->rdary.fastpath_ok)
+      struct reader ** const rdary = pwr->rdary.rdary;
+      if (rdary[0])
       {
-        struct reader ** const rdary = pwr->rdary.rdary;
-        for (uint32_t i = 0; rdary[i]; i++)
+        struct ddsi_serdata *payload;
+        struct ddsi_tkmap_instance *tk;
+        if ((payload = new_sample_from_data (&tk, gv, sampleinfo, data_smhdr_flags, &qos, fragchain, statusinfo, tstamp, rdary[0]->topic)) != NULL)
         {
-          ETRACE (pwr, "reader "PGUIDFMT"\n", PGUID (rdary[i]->e.guid));
-          if (!rhc_store (rdary[i]->rhc, &pwr_info, payload, tk))
-          {
-            if (pwr_locked) ddsrt_mutex_unlock (&pwr->e.lock);
-            ddsrt_mutex_unlock (&pwr->rdary.rdary_lock);
-            dds_sleepfor (DDS_MSECS (10));
-            if (pwr_locked) ddsrt_mutex_lock (&pwr->e.lock);
-            goto retry;
-          }
+          uint32_t i = 0;
+          do {
+            ETRACE (pwr, "reader "PGUIDFMT"\n", PGUID (rdary[i]->e.guid));
+            if (!rhc_store (rdary[i]->rhc, &pwr_info, payload, tk))
+            {
+              if (pwr_locked) ddsrt_mutex_unlock (&pwr->e.lock);
+              ddsrt_mutex_unlock (&pwr->rdary.rdary_lock);
+              /* It is painful to drop the sample, but there is no guarantee that the readers
+                 will still be there after unlocking; indeed, it is even possible that the
+                 topic definition got replaced in the meantime.  Fortunately, this is in
+                 the midst of a FIXME for many other reasons. */
+              free_sample_after_store (gv, payload, tk);
+              dds_sleepfor (DDS_MSECS (10));
+              if (pwr_locked) ddsrt_mutex_lock (&pwr->e.lock);
+              goto retry;
+            }
+          } while (rdary[++i]);
+          free_sample_after_store (gv, payload, tk);
         }
-        ddsrt_mutex_unlock (&pwr->rdary.rdary_lock);
       }
-      else
-      {
-        /* When deleting, pwr is no longer accessible via the hash
+      ddsrt_mutex_unlock (&pwr->rdary.rdary_lock);
+    }
+    else
+    {
+      /* When deleting, pwr is no longer accessible via the hash
          tables, and consequently, a reader may be deleted without
          it being possible to remove it from rdary. The primary
          reason rdary exists is to avoid locking the proxy writer
@@ -1981,39 +1988,58 @@ static int deliver_user_data (const struct nn_rsample_info *sampleinfo, const st
          we fall back to using the GUIDs so that we can deliver all
          samples we received from it. As writer being deleted any
          reliable samples that are rejected are simply discarded. */
-        ddsrt_avl_iter_t it;
-        struct pwr_rd_match *m;
-        ddsrt_mutex_unlock (&pwr->rdary.rdary_lock);
-        if (!pwr_locked) ddsrt_mutex_lock (&pwr->e.lock);
-        for (m = ddsrt_avl_iter_first (&pwr_readers_treedef, &pwr->readers, &it); m != NULL; m = ddsrt_avl_iter_next (&it))
+      ddsrt_avl_iter_t it;
+      struct reader *rd;
+      ddsrt_mutex_unlock (&pwr->rdary.rdary_lock);
+      if (!pwr_locked) ddsrt_mutex_lock (&pwr->e.lock);
+      if ((rd = proxy_writer_first_in_sync_reader (pwr, &it)) != NULL)
+      {
+        struct ddsi_serdata *payload;
+        struct ddsi_tkmap_instance *tk;
+        if ((payload = new_sample_from_data (&tk, gv, sampleinfo, data_smhdr_flags, &qos, fragchain, statusinfo, tstamp, rd->topic)) != NULL)
         {
-          struct reader *rd;
-          if ((rd = ephash_lookup_reader_guid (pwr->e.gv->guid_hash, &m->rd_guid)) != NULL && m->in_sync == PRMSS_SYNC)
-          {
+          do {
             ETRACE (pwr, "reader-via-guid "PGUIDFMT"\n", PGUID (rd->e.guid));
             (void) rhc_store (rd->rhc, &pwr_info, payload, tk);
+            rd = proxy_writer_next_in_sync_reader (pwr, &it);
+          } while (rd != NULL);
+          free_sample_after_store (gv, payload, tk);
+        }
+      }
+      if (!pwr_locked) ddsrt_mutex_unlock (&pwr->e.lock);
+    }
+
+    ddsrt_atomic_st32 (&pwr->next_deliv_seq_lowword, (uint32_t) (sampleinfo->seq + 1));
+  }
+  else
+  {
+    struct reader *rd = ephash_lookup_reader_guid (gv->guid_hash, rdguid);
+    ETRACE (pwr, " %"PRId64"=>"PGUIDFMT"%s\n", sampleinfo->seq, PGUID (*rdguid), rd ? "" : "?");
+    if (rd != NULL)
+    {
+      struct ddsi_serdata *payload;
+      struct ddsi_tkmap_instance *tk;
+      if ((payload = new_sample_from_data (&tk, gv, sampleinfo, data_smhdr_flags, &qos, fragchain, statusinfo, tstamp, rd->topic)) != NULL)
+      {
+        /* FIXME: why look up rd,pwr again? Their states remains valid while the thread stays
+           "awake" (although a delete can be initiated), and blocking like this is a stopgap
+           anyway -- quite possibly to abort once either is deleted */
+        while (!rhc_store (rd->rhc, &pwr_info, payload, tk))
+        {
+          if (pwr_locked) ddsrt_mutex_unlock (&pwr->e.lock);
+          dds_sleepfor (DDS_MSECS (1));
+          if (pwr_locked) ddsrt_mutex_lock (&pwr->e.lock);
+          if (ephash_lookup_reader_guid (gv->guid_hash, rdguid) == NULL ||
+              ephash_lookup_proxy_writer_guid (gv->guid_hash, &pwr->e.guid) == NULL)
+          {
+            /* give up when reader or proxy writer no longer accessible */
+            break;
           }
         }
-        if (!pwr_locked) ddsrt_mutex_unlock (&pwr->e.lock);
-      }
-
-      ddsrt_atomic_st32 (&pwr->next_deliv_seq_lowword, (uint32_t) (sampleinfo->seq + 1));
-    }
-    else
-    {
-      struct reader *rd = ephash_lookup_reader_guid (pwr->e.gv->guid_hash, rdguid);
-      ETRACE (pwr, " %"PRId64"=>"PGUIDFMT"%s\n", sampleinfo->seq, PGUID (*rdguid), rd ? "" : "?");
-      while (rd && ! rhc_store (rd->rhc, &pwr_info, payload, tk) && ephash_lookup_proxy_writer_guid (pwr->e.gv->guid_hash, &pwr->e.guid))
-      {
-        if (pwr_locked) ddsrt_mutex_unlock (&pwr->e.lock);
-        dds_sleepfor (DDS_MSECS (1));
-        if (pwr_locked) ddsrt_mutex_lock (&pwr->e.lock);
+        free_sample_after_store (gv, payload, tk);
       }
     }
-    ddsi_tkmap_instance_unref (pwr->e.gv->m_tkmap, tk);
   }
-  ddsi_serdata_unref (payload);
- no_payload:
   nn_plist_fini (&qos);
   return 0;
 }
@@ -2301,8 +2327,8 @@ static void drop_oversize (struct receiver_state *rst, struct nn_rmsg *rmsg, con
 
     if (gap_was_valuable)
     {
-      const char *tname = pwr->c.topic ? pwr->c.topic->name : "(null)";
-      const char *ttname = pwr->c.topic ? pwr->c.topic->type_name : "(null)";
+      const char *tname = (pwr->c.xqos->present & QP_TOPIC_NAME) ? pwr->c.xqos->topic_name : "(null)";
+      const char *ttname = (pwr->c.xqos->present & QP_TYPE_NAME) ? pwr->c.xqos->type_name : "(null)";
       DDS_CWARNING (&rst->gv->logconfig, "dropping oversize (%"PRIu32" > %"PRIu32") sample %"PRId64" from remote writer "PGUIDFMT" %s/%s\n",
                     sampleinfo->size, rst->gv->config.max_sample_size, sampleinfo->seq,
                     PGUIDPREFIX (rst->src_guid_prefix), msg->writerId.u,

--- a/src/ddsrt/src/random.c
+++ b/src/ddsrt/src/random.c
@@ -61,6 +61,7 @@
 #include "dds/ddsrt/sync.h"
 #include "dds/ddsrt/time.h"
 #include "dds/ddsrt/process.h"
+#include "dds/ddsrt/atomics.h"
 #include "dds/ddsrt/static_assert.h"
 
 #define N DDSRT_MT19937_N
@@ -186,13 +187,15 @@ void ddsrt_random_init (void)
   ddsrt_prng_seed_t seed;
   if (!ddsrt_prng_makeseed (&seed))
   {
+    static ddsrt_atomic_uint32_t counter = DDSRT_ATOMIC_UINT32_INIT (0);
     /* Poor man's initialisation */
-    DDSRT_STATIC_ASSERT (sizeof (seed.key) / sizeof (seed.key[0]) >= 3);
+    DDSRT_STATIC_ASSERT (sizeof (seed.key) / sizeof (seed.key[0]) >= 4);
     memset (&seed, 0, sizeof (seed));
     dds_time_t now = dds_time ();
     seed.key[0] = (uint32_t) ddsrt_getpid ();
     seed.key[1] = (uint32_t) ((uint64_t) now >> 32);
     seed.key[2] = (uint32_t) now;
+    seed.key[3] = ddsrt_atomic_inc32_ov (&counter);
   }
   ddsrt_prng_init (&default_prng, &seed);
   ddsrt_mutex_init (&default_prng_lock);

--- a/src/mpt/mpt/include/mpt/mpt.h
+++ b/src/mpt/mpt/include/mpt/mpt.h
@@ -111,45 +111,45 @@ MPT_TestFiniDeclaration(suite, test)                              \
  * Test asserts.
  * Printing is supported eg MPT_ASSERT_EQ(a, b, "foo: %s", bar")
  */
-#define MPT_ASSERT(cond, ...)   MPT__ASSERT__(cond, MPT_FATAL_NO, __VA_ARGS__)
+#define MPT_ASSERT(cond, ...)   MPT__ASSERT__((cond), MPT_FATAL_NO, __VA_ARGS__)
 
 #define MPT_ASSERT_FAIL(...)    MPT_ASSERT(0, __VA_ARGS__)
 
-#define MPT_ASSERT_EQ(value, expected, ...)  MPT_ASSERT((value == expected), __VA_ARGS__)
-#define MPT_ASSERT_NEQ(value, expected, ...) MPT_ASSERT((value != expected), __VA_ARGS__)
-#define MPT_ASSERT_LEQ(value, expected, ...) MPT_ASSERT((value <= expected), __VA_ARGS__)
-#define MPT_ASSERT_GEQ(value, expected, ...) MPT_ASSERT((value >= expected), __VA_ARGS__)
-#define MPT_ASSERT_LT(value, expected, ...)  MPT_ASSERT((value  < expected), __VA_ARGS__)
-#define MPT_ASSERT_GT(value, expected, ...)  MPT_ASSERT((value  > expected), __VA_ARGS__)
+#define MPT_ASSERT_EQ(value, expected, ...)  MPT_ASSERT(((value) == (expected)), __VA_ARGS__)
+#define MPT_ASSERT_NEQ(value, expected, ...) MPT_ASSERT(((value) != (expected)), __VA_ARGS__)
+#define MPT_ASSERT_LEQ(value, expected, ...) MPT_ASSERT(((value) <= (expected)), __VA_ARGS__)
+#define MPT_ASSERT_GEQ(value, expected, ...) MPT_ASSERT(((value) >= (expected)), __VA_ARGS__)
+#define MPT_ASSERT_LT(value, expected, ...)  MPT_ASSERT(((value)  < (expected)), __VA_ARGS__)
+#define MPT_ASSERT_GT(value, expected, ...)  MPT_ASSERT(((value)  > (expected)), __VA_ARGS__)
 
-#define MPT_ASSERT_NULL(value, ...)     MPT_ASSERT((value == NULL), __VA_ARGS__)
-#define MPT_ASSERT_NOT_NULL(value, ...) MPT_ASSERT((value != NULL), __VA_ARGS__)
+#define MPT_ASSERT_NULL(value, ...)     MPT_ASSERT(((value) == NULL), __VA_ARGS__)
+#define MPT_ASSERT_NOT_NULL(value, ...) MPT_ASSERT(((value) != NULL), __VA_ARGS__)
 
-#define MPT_ASSERT_STR_EQ(value, expected, ...)  MPT_ASSERT((MPT_STRCMP(value, expected, 1) == 0), __VA_ARGS__)
-#define MPT_ASSERT_STR_NEQ(value, expected, ...) MPT_ASSERT((MPT_STRCMP(value, expected, 0) != 0), __VA_ARGS__)
-#define MPT_ASSERT_STR_EMPTY(value, ...)         MPT_ASSERT((MPT_STRLEN(value, 1) == 0), __VA_ARGS__)
-#define MPT_ASSERT_STR_NOT_EMPTY(value, ...)     MPT_ASSERT((MPT_STRLEN(value, 0)  > 0), __VA_ARGS__)
+#define MPT_ASSERT_STR_EQ(value, expected, ...)  MPT_ASSERT((MPT_STRCMP((value), (expected), 1) == 0), __VA_ARGS__)
+#define MPT_ASSERT_STR_NEQ(value, expected, ...) MPT_ASSERT((MPT_STRCMP((value), (expected), 0) != 0), __VA_ARGS__)
+#define MPT_ASSERT_STR_EMPTY(value, ...)         MPT_ASSERT((MPT_STRLEN((value), 1) == 0), __VA_ARGS__)
+#define MPT_ASSERT_STR_NOT_EMPTY(value, ...)     MPT_ASSERT((MPT_STRLEN((value), 0)  > 0), __VA_ARGS__)
 
 
 /* Fatal just means that control is returned to the parent function. */
-#define MPT_ASSERT_FATAL(cond, ...)   MPT__ASSERT__(cond, MPT_FATAL_YES, __VA_ARGS__)
+#define MPT_ASSERT_FATAL(cond, ...)   MPT__ASSERT__((cond), MPT_FATAL_YES, __VA_ARGS__)
 
 #define MPT_ASSERT_FATAL_FAIL(...)    MPT_ASSERT_FATAL(0, __VA_ARGS__)
 
-#define MPT_ASSERT_FATAL_EQ(value, expected, ...)  MPT_ASSERT_FATAL((value == expected), __VA_ARGS__)
-#define MPT_ASSERT_FATAL_NEQ(value, expected, ...) MPT_ASSERT_FATAL((value != expected), __VA_ARGS__)
-#define MPT_ASSERT_FATAL_LEQ(value, expected, ...) MPT_ASSERT_FATAL((value <= expected), __VA_ARGS__)
-#define MPT_ASSERT_FATAL_GEQ(value, expected, ...) MPT_ASSERT_FATAL((value >= expected), __VA_ARGS__)
-#define MPT_ASSERT_FATAL_LT(value, expected, ...)  MPT_ASSERT_FATAL((value  < expected), __VA_ARGS__)
-#define MPT_ASSERT_FATAL_GT(value, expected, ...)  MPT_ASSERT_FATAL((value  > expected), __VA_ARGS__)
+#define MPT_ASSERT_FATAL_EQ(value, expected, ...)  MPT_ASSERT_FATAL(((value) == (expected)), __VA_ARGS__)
+#define MPT_ASSERT_FATAL_NEQ(value, expected, ...) MPT_ASSERT_FATAL(((value) != (expected)), __VA_ARGS__)
+#define MPT_ASSERT_FATAL_LEQ(value, expected, ...) MPT_ASSERT_FATAL(((value) <= (expected)), __VA_ARGS__)
+#define MPT_ASSERT_FATAL_GEQ(value, expected, ...) MPT_ASSERT_FATAL(((value) >= (expected)), __VA_ARGS__)
+#define MPT_ASSERT_FATAL_LT(value, expected, ...)  MPT_ASSERT_FATAL(((value)  < (expected)), __VA_ARGS__)
+#define MPT_ASSERT_FATAL_GT(value, expected, ...)  MPT_ASSERT_FATAL(((value)  > (expected)), __VA_ARGS__)
 
-#define MPT_ASSERT_FATAL_NULL(value, ...)     MPT_ASSERT_FATAL((value == NULL), __VA_ARGS__)
-#define MPT_ASSERT_FATAL_NOT_NULL(value, ...) MPT_ASSERT_FATAL((value != NULL), __VA_ARGS__)
+#define MPT_ASSERT_FATAL_NULL(value, ...)     MPT_ASSERT_FATAL(((value) == NULL), __VA_ARGS__)
+#define MPT_ASSERT_FATAL_NOT_NULL(value, ...) MPT_ASSERT_FATAL(((value) != NULL), __VA_ARGS__)
 
-#define MPT_ASSERT_FATAL_STR_EQ(value, expected, ...)  MPT_ASSERT_FATAL((MPT_STRCMP(value, expected, 1) == 0), __VA_ARGS__)
-#define MPT_ASSERT_FATAL_STR_NEQ(value, expected, ...) MPT_ASSERT_FATAL((MPT_STRCMP(value, expected, 0) != 0), __VA_ARGS__)
-#define MPT_ASSERT_FATAL_STR_EMPTY(value, ...)         MPT_ASSERT_FATAL((MPT_STRLEN(value, 1) == 0), __VA_ARGS__)
-#define MPT_ASSERT_FATAL_STR_NOT_EMPTY(value, ...)     MPT_ASSERT_FATAL((MPT_STRLEN(value, 0)  > 0), __VA_ARGS__)
+#define MPT_ASSERT_FATAL_STR_EQ(value, expected, ...)  MPT_ASSERT_FATAL((MPT_STRCMP((value), (expected), 1) == 0), __VA_ARGS__)
+#define MPT_ASSERT_FATAL_STR_NEQ(value, expected, ...) MPT_ASSERT_FATAL((MPT_STRCMP((value), (expected), 0) != 0), __VA_ARGS__)
+#define MPT_ASSERT_FATAL_STR_EMPTY(value, ...)         MPT_ASSERT_FATAL((MPT_STRLEN((value), 1) == 0), __VA_ARGS__)
+#define MPT_ASSERT_FATAL_STR_NOT_EMPTY(value, ...)     MPT_ASSERT_FATAL((MPT_STRLEN((value), 0)  > 0), __VA_ARGS__)
 
 
 /* Helpful function to check for patterns in log callbacks. */

--- a/src/mpt/tests/disc/CMakeLists.txt
+++ b/src/mpt/tests/disc/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
+# Copyright(c) 2006 to 2019 ADLINK Technology Limited and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at
@@ -9,12 +9,10 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
-cmake_minimum_required(VERSION 3.7)
+include(${MPT_CMAKE})
 
-if(MPT_ENABLE_SELFTEST)
-  add_subdirectory(self)
-endif()
-
-add_subdirectory(basic)
-add_subdirectory(qos)
-add_subdirectory(disc)
+add_mpt_executable(mpt_discstress
+    "procs/createwriter.c"
+    "discstress.c")
+idlc_generate(mpt_discstress_discstressdata_lib "procs/createwriterdata.idl")
+target_link_libraries(mpt_discstress PRIVATE mpt_discstress_discstressdata_lib)

--- a/src/mpt/tests/disc/discstress.c
+++ b/src/mpt/tests/disc/discstress.c
@@ -1,0 +1,10 @@
+#include "mpt/mpt.h"
+#include "procs/createwriter.h"
+
+#define TEST_PUB_ARGS MPT_ArgValues(DDS_DOMAIN_DEFAULT, "discstress_createwriter")
+#define TEST_SUB_ARGS MPT_ArgValues(DDS_DOMAIN_DEFAULT, "discstress_createwriter")
+MPT_TestProcess(discstress, createwriter, pub, createwriter_publisher,  TEST_PUB_ARGS);
+MPT_TestProcess(discstress, createwriter, sub, createwriter_subscriber, TEST_SUB_ARGS);
+MPT_Test(discstress, createwriter, .init=createwriter_init, .fini=createwriter_fini);
+#undef TEST_SUB_ARGS
+#undef TEST_PUB_ARGS

--- a/src/mpt/tests/disc/procs/createwriter.c
+++ b/src/mpt/tests/disc/procs/createwriter.c
@@ -1,0 +1,412 @@
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <stdlib.h>
+
+#include "mpt/mpt.h"
+
+#include "dds/dds.h"
+
+#include "dds/ddsrt/time.h"
+#include "dds/ddsrt/strtol.h"
+#include "dds/ddsrt/process.h"
+#include "dds/ddsrt/environ.h"
+#include "dds/ddsrt/cdtors.h"
+#include "dds/ddsrt/sync.h"
+#include "dds/ddsrt/hopscotch.h"
+
+#include "createwriter.h"
+#include "createwriterdata.h"
+
+void createwriter_init (void)
+{
+}
+
+void createwriter_fini (void)
+{
+}
+
+#define N_WRITERS 3
+#define N_READERS 4
+#define N_ROUNDS 100
+#define DEPTH 7
+
+static dds_return_t get_matched_count_writers (uint32_t *count, dds_entity_t writers[N_WRITERS])
+{
+  *count = 0;
+  for (int i = 0; i < N_WRITERS; i++)
+  {
+    dds_publication_matched_status_t st;
+    dds_return_t rc = dds_get_publication_matched_status (writers[i], &st);
+    if (rc != 0)
+      return rc;
+    *count += st.current_count;
+  }
+  return 0;
+}
+
+static dds_return_t get_matched_count_readers (uint32_t *count, dds_entity_t readers[N_READERS])
+{
+  *count = 0;
+  for (int i = 0; i < N_READERS; i++)
+  {
+    dds_subscription_matched_status_t st;
+    dds_return_t rc = dds_get_subscription_matched_status (readers[i], &st);
+    if (rc != 0)
+      return rc;
+    *count += st.current_count;
+  }
+  return 0;
+}
+
+MPT_ProcessEntry (createwriter_publisher,
+                  MPT_Args (dds_domainid_t domainid,
+                            const char *topic_name))
+{
+  dds_entity_t participant;
+  dds_entity_t topic;
+  dds_entity_t writers[N_WRITERS];
+  dds_return_t rc;
+  dds_qos_t *qos;
+  int id = (int) ddsrt_getpid ();
+
+  printf ("=== [Publisher(%d)] Start(%d) ...\n", id, domainid);
+
+  qos = dds_create_qos ();
+  dds_qset_durability (qos, DDS_DURABILITY_VOLATILE);
+  dds_qset_history (qos, DDS_HISTORY_KEEP_LAST, DEPTH);
+  dds_qset_reliability (qos, DDS_RELIABILITY_RELIABLE, DDS_SECS (10));
+
+  participant = dds_create_participant (domainid, NULL, NULL);
+  MPT_ASSERT_FATAL_GT (participant, 0, "Could not create participant: %s\n", dds_strretcode(participant));
+
+  topic = dds_create_topic (participant, &DiscStress_CreateWriter_Msg_desc, topic_name, qos, NULL);
+  MPT_ASSERT_FATAL_GT (topic, 0, "Could not create topic: %s\n", dds_strretcode(topic));
+
+  for (int i = 0; i < N_WRITERS; i++)
+  {
+    writers[i] = dds_create_writer (participant, topic, qos, NULL);
+    MPT_ASSERT_FATAL_GT (writers[i], 0, "Could not create writer: %s\n", dds_strretcode (writers[i]));
+  }
+
+  /* At some point in time, all remote readers will be known, and will consequently be matched
+     immediately on creation of the writer.  That means it expects ACKs from all those readers, and
+     that in turn means they should go into their "linger" state until all samples they wrote have
+     been acknowledged (or the timeout occurs - but it shouldn't in a quiescent setup with a pretty
+     reliable transport like a local loopback).  So other than waiting for some readers to show up
+     at all, there's no need to look at matching events or to use anything other than volatile,
+     provided the readers accept an initial short sequence in the first batch.  */
+  printf ("=== [Publisher(%d)] Publishing while waiting for some reader ...\n", id);
+  fflush (stdout);
+  uint32_t seq = 0;
+  int32_t round = -1;
+  uint32_t wrseq = 0;
+  bool matched = false;
+  while (round < N_ROUNDS)
+  {
+    if (matched)
+      round++;
+    else
+    {
+      uint32_t mc;
+      rc = get_matched_count_writers (&mc, writers);
+      MPT_ASSERT_FATAL_EQ (rc, 0, "Could not get publication matched status: %s\n", dds_strretcode (rc));
+      matched = (mc == N_READERS * N_WRITERS);
+      if (matched)
+      {
+        printf ("=== [Publisher(%d)] All readers found; continuing at [%"PRIu32",%"PRIu32"] for %d rounds\n",
+                id, wrseq * N_WRITERS + 1, (wrseq + 1) * N_WRITERS, N_ROUNDS);
+        fflush (stdout);
+      }
+    }
+
+    for (uint32_t i = 0; i < N_WRITERS; i++)
+    {
+      for (uint32_t j = 0; j < DEPTH; j++)
+      {
+        /* Note: +1 makes wrseq equal to the writer entity id */
+        DiscStress_CreateWriter_Msg m = {
+          .round = round, .wrseq = wrseq * N_WRITERS + i + 1, .wridx = i, .histidx = j, .seq = seq
+        };
+        rc = dds_write (writers[i], &m);
+        MPT_ASSERT_FATAL_EQ (rc, 0, "Could not write data: %s\n", dds_strretcode (rc));
+        seq++;
+      }
+    }
+
+    /* Delete, then create writer: this should result in the other process processing alternating
+       deletes and creates, and consequently, all readers should always have at least some matching
+       writers.
+
+       Round 0 is the first round where all readers have been matched with writer 0 */
+    for (int i = 0; i < N_WRITERS; i++)
+    {
+      rc = dds_delete (writers[i]);
+      MPT_ASSERT_FATAL_EQ (rc, 0, "Could not delete writer: %s\n", dds_strretcode (rc));
+      writers[i] = dds_create_writer (participant, topic, qos, NULL);
+      MPT_ASSERT_FATAL_GT (writers[i], 0, "Could not create writer: %s\n", dds_strretcode (writers[i]));
+    }
+
+    wrseq++;
+  }
+
+  rc = dds_delete (participant);
+  MPT_ASSERT_EQ (rc, DDS_RETCODE_OK, "Teardown failed\n");
+  dds_delete_qos (qos);
+  printf ("=== [Publisher(%d)] Done\n", id);
+}
+
+struct wrinfo {
+  uint32_t rdid;
+  uint32_t wrid;
+  dds_instance_handle_t wr_iid;
+  bool last_not_alive;
+  uint32_t seen;
+};
+
+static uint32_t wrinfo_hash (const void *va)
+{
+  const struct wrinfo *a = va;
+  return (uint32_t) (((a->rdid + UINT64_C (16292676669999574021)) *
+                      (a->wrid + UINT64_C (10242350189706880077))) >> 32);
+}
+
+static int wrinfo_eq (const void *va, const void *vb)
+{
+  const struct wrinfo *a = va;
+  const struct wrinfo *b = vb;
+  return a->rdid == b->rdid && a->wrid == b->wrid;
+}
+
+#define LOGDEPTH 30
+#define LOGLINE 200
+
+static void dumplog (char logbuf[LOGDEPTH][LOGLINE], int *logidx)
+{
+  if (logbuf[*logidx][0])
+    for (int i = 0; i < LOGDEPTH; i++)
+      fputs (logbuf[i], stdout);
+  for (int i = 0; i < *logidx; i++)
+    fputs (logbuf[i], stdout);
+  for (int i = 0; i < LOGDEPTH; i++)
+    logbuf[i][0] = 0;
+  *logidx = 0;
+}
+
+/*
+ * The DiscStress_CreateWriter subscriber.
+ * It waits for sample(s) and checks the content.
+ */
+MPT_ProcessEntry(createwriter_subscriber,
+                 MPT_Args(dds_domainid_t domainid,
+                          const char *topic_name))
+{
+  dds_entity_t participant;
+  dds_entity_t topic;
+  dds_entity_t readers[N_READERS];
+  dds_return_t rc;
+  dds_qos_t *qos;
+  int id = (int) ddsrt_getpid ();
+
+  printf ("--- [Subscriber(%d)] Start(%d) ...\n", id, domainid);
+
+  qos = dds_create_qos ();
+  dds_qset_durability (qos, DDS_DURABILITY_VOLATILE);
+  dds_qset_history (qos, DDS_HISTORY_KEEP_LAST, DEPTH);
+  dds_qset_reliability (qos, DDS_RELIABILITY_RELIABLE, DDS_SECS (10));
+
+  participant = dds_create_participant (domainid, NULL, NULL);
+  MPT_ASSERT_FATAL_GT (participant, 0, "Could not create participant: %s\n", dds_strretcode(participant));
+
+  topic = dds_create_topic (participant, &DiscStress_CreateWriter_Msg_desc, topic_name, qos, NULL);
+  MPT_ASSERT_FATAL_GT (topic, 0, "Could not create topic: %s\n", dds_strretcode(topic));
+
+  /* Keep all history on the reader: then we should see DEPTH samples from each writer, except,
+     perhaps, the very first time */
+  dds_qset_history (qos, DDS_HISTORY_KEEP_ALL, 0);
+  for (int i = 0; i < N_READERS; i++)
+  {
+    readers[i] = dds_create_reader (participant, topic, qos, NULL);
+    MPT_ASSERT_FATAL_GT (readers[i], 0, "Could not create reader: %s\n", dds_strretcode (readers[i]));
+  }
+
+  printf ("--- [Subscriber(%d)] Waiting for some writer to match ...\n", id);
+  fflush (stdout);
+
+  /* Wait until we have matching writers */
+  dds_entity_t ws = dds_create_waitset (participant);
+  MPT_ASSERT_FATAL_GT (ws, 0, "Could not create waitset: %s\n", dds_strretcode (ws));
+  for (int i = 0; i < N_READERS; i++)
+  {
+    rc = dds_set_status_mask (readers[i], DDS_SUBSCRIPTION_MATCHED_STATUS);
+    MPT_ASSERT_FATAL_EQ (rc, 0, "Could not set subscription matched mask: %s\n", dds_strretcode (rc));
+    rc = dds_waitset_attach (ws, readers[i], i);
+    MPT_ASSERT_FATAL_EQ (rc, 0, "Could not attach reader to waitset: %s\n", dds_strretcode (rc));
+  }
+
+  {
+    uint32_t mc;
+    do {
+      rc = get_matched_count_readers (&mc, readers);
+      MPT_ASSERT_FATAL_EQ (rc, 0, "Could not get subscription matched status: %s\n", dds_strretcode (rc));
+    } while (mc < N_READERS * N_WRITERS && (rc = dds_waitset_wait (ws, NULL, 0, DDS_INFINITY)) >= 0);
+    MPT_ASSERT_FATAL_GEQ (rc, 0, "Wait for writers failed: %s\n", dds_strretcode (rc));
+  }
+
+  /* Add DATA_AVAILABLE event; of course it would be easier to simply set it to desired value, but
+     this is more fun */
+  for (int i = 0; i < N_READERS; i++)
+  {
+    uint32_t mask;
+    rc = dds_get_status_mask (readers[i], &mask);
+    MPT_ASSERT_FATAL_EQ (rc, 0, "Could not get status mask: %s\n", dds_strretcode (rc));
+    MPT_ASSERT_FATAL ((mask & DDS_SUBSCRIPTION_MATCHED_STATUS) != 0, "Retrieved status mask doesn't have MATCHED set\n");
+    mask |= DDS_DATA_AVAILABLE_STATUS;
+    rc = dds_set_status_mask (readers[i], mask);
+    MPT_ASSERT_FATAL_EQ (rc, 0, "Could not add data available status: %s\n", dds_strretcode (rc));
+  }
+
+  /* Loop while we have some matching writers */
+  printf ("--- [Subscriber(%d)] Checking data ...\n", id);
+  fflush (stdout);
+  struct ddsrt_hh *wrinfo = ddsrt_hh_new (1, wrinfo_hash, wrinfo_eq);
+  dds_entity_t xreader = 0;
+  bool matched = true;
+  char logbuf[N_READERS][LOGDEPTH][LOGLINE] = {{ "" }};
+  int logidx[N_READERS] = { 0 };
+  while (matched)
+  {
+    dds_attach_t xs[N_READERS];
+
+    {
+      uint32_t mc;
+      rc = get_matched_count_readers (&mc, readers);
+      MPT_ASSERT_FATAL_EQ (rc, 0, "Could not get subscription matched status: %s\n", dds_strretcode (rc));
+      matched = (mc > 0);
+    }
+
+    /* Losing all matched writers will result in a transition to NO_WRITERS, and so in a DATA_AVAILABLE
+       state, but the unregistering happens before the match count is updated.  I'm not sure it makes to
+       make those atomic; I also don't think it is very elegant to do a final NO_WRITERS message with
+       that was already signalled as no longer matching in a listener.
+
+
+       Given that situation, waiting for data available, taking everything and immediately checking
+       the subscription matched status doesn't guarantee in observing the absence of matched writers.
+       Hence enabling the SUBSCRIPTION_MATCHED status on the readers, so that the actual removal will
+       also trigger the waitset.
+
+       The current_count == 0 case is so we do one final take after deciding to stop, just in case the
+       unregisters & state change happened in between taking and checking the number of matched writers. */
+    int32_t nxs = dds_waitset_wait (ws, xs, N_READERS, matched ? DDS_SECS (12) : 0);
+    MPT_ASSERT_FATAL_GEQ (nxs, 0, "Waiting for data failed: %s\n", dds_strretcode (nxs));
+    if (nxs == 0 && matched)
+    {
+      printf ("--- [Subscriber(%d)] Unexpected timeout\n", id);
+      for (int i = 0; i < N_READERS; i++)
+      {
+        dds_subscription_matched_status_t st;
+        rc = dds_get_subscription_matched_status (readers[i], &st);
+        MPT_ASSERT_FATAL_EQ (rc, 0, "Could not get subscription matched status: %s\n", dds_strretcode (rc));
+        printf ("--- [Subscriber(%d)] reader %d current_count %"PRIu32"\n", id, i, st.current_count);
+      }
+      fflush (stdout);
+      MPT_ASSERT_FATAL (0, "Timed out\n");
+    }
+
+#define READ_LEN 3
+    for (int32_t i = 0; i < nxs; i++)
+    {
+      void *raw[READ_LEN] = { NULL };
+      dds_sample_info_t si[READ_LEN];
+      int32_t n;
+      while ((n = dds_take (readers[xs[i]], raw, si, READ_LEN, READ_LEN)) > 0)
+      {
+        for (int32_t j = 0; j < n; j++)
+        {
+          DiscStress_CreateWriter_Msg const * const s = raw[j];
+          if (si[j].valid_data && s->round >= 0)
+          {
+            /* Cyclone always sets the key value, other fields are 0 for invalid data */
+            struct wrinfo wri_key = { .wrid = s->wrseq, .rdid = (uint32_t) xs[i] };
+            struct wrinfo *wri;
+
+            MPT_ASSERT_FATAL_LT (s->wridx, N_WRITERS, "Writer id out of range (%"PRIu32" %"PRIu32"\n)", s->wrseq, s->wridx);
+
+#define XASSERT(cond, ...) do { if (!(cond)) { \
+dumplog (logbuf[xs[i]], &logidx[xs[i]]); \
+MPT_ASSERT (0, __VA_ARGS__); \
+} } while (0)
+#define XASSERT_FATAL(cond, ...) do { if (!(cond)) { \
+dumplog (logbuf[xs[i]], &logidx[xs[i]]); \
+MPT_ASSERT_FATAL (0, __VA_ARGS__); \
+} } while (0)
+
+            if ((wri = ddsrt_hh_lookup (wrinfo, &wri_key)) == NULL)
+            {
+              wri = malloc (sizeof (*wri));
+              *wri = wri_key;
+              rc = ddsrt_hh_add (wrinfo, wri);
+              MPT_ASSERT_FATAL_NEQ (rc, 0, "Both wrinfo lookup and add failed\n");
+            }
+
+            snprintf (logbuf[xs[i]][logidx[xs[i]]], sizeof (logbuf[xs[i]][logidx[xs[i]]]),
+                      "%"PRId32": %"PRId32".%"PRIu32" %"PRIu32".%"PRIu32" iid %"PRIx64" new %"PRIx64" st %c%c seq %"PRIu32" seen %"PRIu32"\n",
+                      (uint32_t) xs[i], s->round, s->wrseq, s->wridx, s->histidx, wri->wr_iid, si[j].publication_handle,
+                      (si[j].instance_state == DDS_IST_ALIVE) ? 'A' : (si[j].instance_state == DDS_IST_NOT_ALIVE_DISPOSED) ? 'D' : 'U',
+                      si[j].valid_data ? 'v' : 'i', s->seq, wri->seen);
+            if (++logidx[xs[i]] == LOGDEPTH)
+              logidx[xs[i]] = 0;
+
+            XASSERT (wri->wr_iid == 0 || wri->wr_iid == si[j].publication_handle, "Mismatch between wrid and publication handle");
+
+            XASSERT_FATAL (s->histidx < DEPTH, "depth_idx out of range");
+            XASSERT ((wri->seen & (1u << s->histidx)) == 0, "Duplicate sample\n");
+            if (s->histidx > 0)
+              XASSERT ((wri->seen & (1u << (s->histidx - 1))) != 0, "Out of order sample (1)\n");
+            XASSERT (wri->seen < (1u << s->histidx), "Out of order sample (2)\n");
+            wri->wr_iid = si[j].publication_handle;
+            wri->seen |= 1u << s->histidx;
+          }
+        }
+        rc = dds_return_loan (readers[xs[i]], raw, n);
+        MPT_ASSERT_FATAL_EQ (rc, 0, "Could not return loan: %s\n", dds_strretcode (rc));
+
+        /* Flip-flop between create & deleting a reader to ensure matching activity on the proxy
+           writers, as that, too should occasionally push the delivery out of the fast path */
+        if (xreader)
+        {
+          rc = dds_delete (xreader);
+          MPT_ASSERT_FATAL_EQ (rc, 0, "Error on deleting extra reader: %s\n", dds_strretcode (rc));
+          xreader = 0;
+        }
+        else
+        {
+          xreader = dds_create_reader (participant, topic, qos, NULL);
+          MPT_ASSERT_FATAL_GT (xreader, 0, "Could not create extra reader: %s\n", dds_strretcode (xreader));
+        }
+      }
+      MPT_ASSERT_FATAL_EQ (rc, 0, "Error on reading: %s\n", dds_strretcode (rc));
+    }
+  }
+
+  rc = dds_delete (participant);
+  MPT_ASSERT_EQ (rc, DDS_RETCODE_OK, "Teardown failed\n");
+  dds_delete_qos (qos);
+
+  struct ddsrt_hh_iter it;
+  uint32_t nwri = 0;
+  for (struct wrinfo *wri = ddsrt_hh_iter_first (wrinfo, &it); wri; wri = ddsrt_hh_iter_next (&it))
+  {
+    nwri++;
+    if (wri->seen != (1u << DEPTH) - 1)
+    {
+      MPT_ASSERT (0, "Some data missing at end (rd %d wr %d seen %"PRIx32")\n", wri->rdid, wri->wrid, wri->seen);
+    }
+    /* simple iteration won't touch an object pointer twice */
+    free (wri);
+  }
+  ddsrt_hh_free (wrinfo);
+  MPT_ASSERT (nwri >= (N_ROUNDS / 3) * N_READERS * N_WRITERS, "Less data received than expected\n");
+  printf ("--- [Subscriber(%d)] Done after %"PRIu32" sets\n", id, nwri / (N_READERS * N_WRITERS));
+}

--- a/src/mpt/tests/disc/procs/createwriter.h
+++ b/src/mpt/tests/disc/procs/createwriter.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright(c) 2019 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+#ifndef MPT_DISCSTRESS_PROCS_CREATEWRITER_H
+#define MPT_DISCSTRESS_PROCS_CREATEWRITER_H
+
+#include <stdio.h>
+#include <string.h>
+
+#include "dds/dds.h"
+#include "mpt/mpt.h"
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+void createwriter_init(void);
+void createwriter_fini(void);
+
+MPT_ProcessEntry(createwriter_publisher,
+                 MPT_Args(dds_domainid_t domainid,
+                          const char *topic_name));
+
+MPT_ProcessEntry(createwriter_subscriber,
+                 MPT_Args(dds_domainid_t domainid,
+                          const char *topic_name));
+
+#if defined (__cplusplus)
+}
+#endif
+
+#endif /* MPT_DISCSTRESS_PROCS_CREATEWRITER_H */

--- a/src/mpt/tests/disc/procs/createwriterdata.idl
+++ b/src/mpt/tests/disc/procs/createwriterdata.idl
@@ -1,0 +1,12 @@
+module DiscStress {
+  module CreateWriter {
+    struct Msg {
+      long round;
+      unsigned long wrseq;
+      unsigned long wridx;
+      unsigned long histidx;
+      unsigned long seq;
+    };
+#pragma keylist Msg
+  };
+};


### PR DESCRIPTION
This pull request fixes #207 by eliminating the cached topic pointers. Although I suggested there to reset the topic pointer in the proxy entity when the last match disappeared, correctly handling the various edge cases with asynchronous delivery is a bit of a pain. Fortunately, it so happens that the need for those pointers disappeared over the years and so the problem can also simply be avoided. (This realisation of course only came _after_ going through said pain ...)

Eliminating the pointers requires some changes to the structure of the function that delivers the data to the readers. An attempt at writing a test that hits all paths (which is not so easy because one of them is a rarely used fall-back one during matching) turned into one that looks more like a stress test for (writer) discovery and delivery of all samples written by each volatile writer to all pre-existing readers, complicated by having the lifetime of each writer likely shorter than the time needed for discovery.

That test in turn unearthed two other issues:
* One with delivery of the first sample(s) written to all readers (at least one reader would always get them, but not necessarily all readers).
* One where the possible race between matching and unmatching a reader with a proxy writer could lead to decrementing that reader's match count by more than 1 by a single unmatch event. (The matching work can happen in parallel, which was accounted for in the data structures used by the DDSI part, but not in raising a ``SUBSCRIPTION_MATCHED`` event.)

Both are addressed in this PR.

Another detail that surfaced by good fortune — before doing much harm, that is — is that a process that created a participant (initialising the library), deleted it (de-initialising the library) and then created another participant (re-initialising the library) would end up with the second participant getting the same GUID as the first.

Changing the GUID generation without making them DDSI 2.2 compliant is a bit silly, but as DDSI 2.2 requires the first two bytes to be set to the vendor id, a tweaked version of the old procedure won't do because it would be far too likely to lead to collisions. Thus, this PR introduces a new one that combines an MD5'd version of an instance id (which is pseudo-random anyway) with the network configuration of the machine to obtain a base GUID, then adds a unique instance id to that for each participant created in the process. The unproven idea being that this approximates a random 80-bit starting point for a pseudo-random hopping sequence using 64-bits.

The initialisation of the random generator that is used for the instance id sequence is in principle based on a good system-source of randomness (i.e., /dev/urandom), but with a fall-back relying on process id and time stamp. To that a global counter has now been added, so that subsequent initialisations within the same process and with the same time stamp will still be different. (Some embedded machines have low-resolution clocks.)

Then there are two more commits:
* removal of the redundant prototype of ``dds_domain_default`` as noted by @martinbremmer in a comment on on #223;
* properly parenthesising the macro arguments in MPT_ASSERT & friends.

(@k0ekk0ek I can split this PR if you wish: the GUID and random generator stuff has nothing to do with the topic pointers, they are only combined in a single PR because one thing led to another and they ended up on the same branch.)