### PR TITLE
Add a colcon.pkg file to override the CMake package name

### DIFF
--- a/colcon.pkg
+++ b/colcon.pkg
@@ -1,0 +1,4 @@
+{
+    "name": "cyclonedds",
+    "type": "cmake"
+}

--- a/colcon.pkg
+++ b/colcon.pkg
@@ -1,4 +1,3 @@
 {
-    "name": "cyclonedds",
-    "type": "cmake"
+    "name": "cyclonedds"
 }


### PR DESCRIPTION
Without this file, colcon will take the project name from the CMakeLists.txt file, which is `CycloneDDS`. This name does not conform to the standard practices for a ROS package name, and should be lowercase (i.e. `cyclonedds`).

This `colcon.pkg` will make colcon detect the package dependencies using this name.

Alternatively, a `package.xml` could be added to this project, but that format is ROS-specific.

This will require that the recent change in atolab/rmw_cyclonedds#27 be reverted.