### PR TITLE
Cyclone configuration as string

### DIFF
--- a/src/core/ddsc/include/dds/dds.h
+++ b/src/core/ddsc/include/dds/dds.h
@@ -726,7 +726,7 @@ dds_set_listener(dds_entity_t entity, const dds_listener_t * listener);
  * If no configuration file exists, the default domain is configured as 0.
  *
  *
- * @param[in]  domain The domain in which to create the participant (can be DDS_DOMAIN_DEFAULT). Valid values for domain id are between 0 and 230. DDS_DOMAIN_DEFAULT is for using the domain in the configuration.
+ * @param[in]  domain The domain in which to create the participant (can be DDS_DOMAIN_DEFAULT). DDS_DOMAIN_DEFAULT is for using the domain in the configuration.
  * @param[in]  qos The QoS to set on the new participant (can be NULL).
  * @param[in]  listener Any listener functions associated with the new participant (can be NULL).
 
@@ -742,6 +742,33 @@ dds_create_participant(
   const dds_domainid_t domain,
   const dds_qos_t *qos,
   const dds_listener_t *listener);
+
+/**
+ * @brief Creates a domain with a given configuration
+ *
+ * To explicitly create a domain based on a configuration passed as a string.
+ * Normally, the domain is created implicitly on the first call to
+ * dds_create_particiant based on the configuration specified throught
+ * the environment. This function allows to by-pass this behaviour.
+ *
+ *
+ * @param[in]  domain The domain to be created. DEFAULT_DOMAIN is not allowed.
+ * @param[in]  config A configuration string containing file names and/or XML fragments representing the configuration.
+ *
+ * @returns A return code
+ *
+ * @retval DDS_RETCODE_OK
+ *             The domain with the domain identifier has been created from
+ *             given configuration string.
+ * @retval DDS_RETCODE_BAD_PARAMETER
+ *             Illegal value for domain id or the configfile parameter is NULL.
+ * @retval DDS_PRECONDITION_NOT_MET
+ *             The domain already existed and cannot be created again.
+ * @retval DDS_RETCODE_ERROR
+ *             An internal error has occurred.
+ */
+DDS_EXPORT dds_return_t
+dds_create_domain(const dds_domainid_t domain, const char *config);
 
 /**
  * @brief Get entity parent.

--- a/src/core/ddsc/src/dds__domain.h
+++ b/src/core/ddsc/src/dds__domain.h
@@ -18,7 +18,7 @@
 extern "C" {
 #endif
 
-DDS_EXPORT dds_return_t dds_domain_create (dds_domain **domain_out, dds_domainid_t id);
+DDS_EXPORT dds_return_t dds_domain_create_internal (dds_domain **domain_out, dds_domainid_t id, bool use_existing, const char *config) ddsrt_nonnull((1,4));
 DDS_EXPORT dds_domain *dds_domain_find_locked (dds_domainid_t id);
 
 #if defined (__cplusplus)

--- a/src/core/ddsc/src/dds_handles.c
+++ b/src/core/ddsc/src/dds_handles.c
@@ -172,8 +172,8 @@ int32_t dds_handle_delete (struct dds_handle_link *link)
   {
     assert (cf & HDL_FLAG_CLOSING);
     assert (cf & HDL_FLAG_CLOSED);
+    assert ((cf & HDL_REFCOUNT_MASK) == 0u);
   }
-  assert ((cf & HDL_REFCOUNT_MASK) == 0u);
   assert ((cf & HDL_PINCOUNT_MASK) == 1u);
 #endif
   ddsrt_mutex_lock (&handles.lock);

--- a/src/core/ddsc/src/dds_participant.c
+++ b/src/core/ddsc/src/dds_participant.c
@@ -12,11 +12,13 @@
 #include <assert.h>
 
 #include "dds/ddsrt/cdtors.h"
+#include "dds/ddsrt/environ.h"
 #include "dds/ddsi/q_entity.h"
 #include "dds/ddsi/q_thread.h"
 #include "dds/ddsi/q_config.h"
 #include "dds/ddsi/q_plist.h"
 #include "dds/ddsi/q_globals.h"
+#include "dds/version.h"
 #include "dds__init.h"
 #include "dds__domain.h"
 #include "dds__participant.h"
@@ -82,12 +84,15 @@ dds_entity_t dds_create_participant (const dds_domainid_t domain, const dds_qos_
   dds_participant * pp;
   nn_plist_t plist;
   dds_qos_t *new_qos = NULL;
+  char *config = "";
 
   /* Make sure DDS instance is initialized. */
   if ((ret = dds_init ()) < 0)
     goto err_dds_init;
 
-  if ((ret = dds_domain_create (&dom, domain)) < 0)
+  (void) ddsrt_getenv (DDS_PROJECT_NAME_NOSPACE_CAPS"_URI", &config);
+
+  if ((ret = dds_domain_create_internal (&dom, domain, true, config)) < 0)
     goto err_domain_create;
 
   new_qos = dds_create_qos ();

--- a/src/core/ddsc/tests/config.c
+++ b/src/core/ddsc/tests/config.c
@@ -75,3 +75,46 @@ CU_Test(ddsc_config, simple_udp, .init = ddsrt_init, .fini = ddsrt_fini) {
 
     dds_delete(participant);
 }
+
+CU_Test(ddsc_config, user_config, .init = ddsrt_init, .fini = ddsrt_fini) {
+
+    CU_ASSERT_FATAL(dds_create_domain(1,
+         "<"DDS_PROJECT_NAME"><Domain><Id>any</Id></Domain>"
+           "<DDSI2E><Internal><MaxParticipants>2</MaxParticipants></Internal></DDSI2E>"
+         "</"DDS_PROJECT_NAME">") == DDS_RETCODE_OK);
+
+    dds_entity_t participant_1;
+    dds_entity_t participant_2;
+    dds_entity_t participant_3;
+
+    participant_1 = dds_create_participant(1, NULL, NULL);
+
+    CU_ASSERT_FATAL(participant_1 > 0);
+
+    participant_2 = dds_create_participant(1, NULL, NULL);
+
+    CU_ASSERT_FATAL(participant_2 > 0);
+
+    participant_3 = dds_create_participant(1, NULL, NULL);
+
+    CU_ASSERT(participant_3 <= 0);
+
+    dds_delete(participant_3);
+    dds_delete(participant_2);
+    dds_delete(participant_1);
+}
+
+CU_Test(ddsc_config, incorrect_config, .init = ddsrt_init, .fini = ddsrt_fini) {
+
+    CU_ASSERT_FATAL(dds_create_domain(1, NULL) == DDS_RETCODE_BAD_PARAMETER);
+    CU_ASSERT_FATAL(dds_create_domain(1, "<CycloneDDS incorrect XML") != DDS_RETCODE_OK);
+    CU_ASSERT_FATAL(dds_create_domain(DDS_DOMAIN_DEFAULT,
+         "<"DDS_PROJECT_NAME"><Domain><Id>any</Id></Domain>"
+           "<DDSI2E><Internal><MaxParticipants>2</MaxParticipants></Internal></DDSI2E>"
+         "</"DDS_PROJECT_NAME">") == DDS_RETCODE_BAD_PARAMETER);
+    CU_ASSERT_FATAL(dds_create_domain(2,
+         "<"DDS_PROJECT_NAME"><Domain><Id>any</Id></Domain>"
+           "<DDSI2E><Internal><MaxParticipants>2</MaxParticipants></Internal></DDSI2E>"
+         "</"DDS_PROJECT_NAME">") == DDS_RETCODE_OK);
+    CU_ASSERT_FATAL(dds_create_domain(2, "") == DDS_RETCODE_PRECONDITION_NOT_MET);
+}

--- a/src/core/ddsi/include/dds/ddsi/q_config.h
+++ b/src/core/ddsi/include/dds/ddsi/q_config.h
@@ -393,7 +393,7 @@ struct config
 
 struct cfgst;
 
-struct cfgst *config_init (const char *configfile, struct config *cfg, uint32_t domid);
+struct cfgst *config_init (const char *config, struct config *cfg, uint32_t domid) ddsrt_nonnull((1,2));
 void config_print_cfgst (struct cfgst *cfgst, const struct ddsrt_log_cfg *logcfg);
 void config_free_source_info (struct cfgst *cfgst);
 void config_fini (struct cfgst *cfgst);


### PR DESCRIPTION
For targets that do not support ddsrt_setenv and ddsrt_getenv, an alternative method is needed to supply an application specific configuration. One way to implement this, is to add a function for creating a domain with a string arguments, which needs to be called before any call to dds_create_participant for given domain identifier.
    
The function dds_create_domain has been added, which has as arguments a domain identifier and a configuration string. In case the string starts with '<' it is parsed as XML fragment for the configuration, otherwise it is taken as the name of the file containing the configuration. (This is similar to how the value of the environment variable is treated.)
    
Two tests have been added. One limits the number of participants to two and verifies that creating a third participant fails. The other tests checks incorrect calls to dds_create_domain.
    
An assert in dds_handle_delete has been weakened.


Signed-off-by: Frans Faase <frans.faase@adlinktech.com>