### PR TITLE
Add CMake command list_join

### DIFF
--- a/cmake/Modules/ListJoin.cmake
+++ b/cmake/Modules/ListJoin.cmake
@@ -1,0 +1,37 @@
+#
+# Copyright(c) 2019 Jeroen Koekkoek <jeroen@koekkoek.nl>
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+
+if(__LIST_JOIN__)
+  return()
+endif()
+set(__LIST_JOIN__ TRUE)
+
+# list(JOIN ...) was added in CMake 3.12 (3.7 is currently required)
+function(LIST_JOIN _list _glue _var)
+  set(_str "")
+  list(LENGTH ${_list} _len)
+
+  if(_len GREATER 0)
+    set(_cnt 0)
+    math(EXPR _max ${_len}-1)
+    list(GET ${_list} 0 _str)
+    if(_len GREATER 1)
+      foreach(_cnt RANGE 1 ${_max})
+        list(GET ${_list} ${_cnt} _elm)
+        set(_str "${_str}${_glue}${_elm}")
+      endforeach()
+    endif()
+  endif()
+
+  set(${_var} "${_str}" PARENT_SCOPE)
+endfunction()
+

--- a/src/tools/idlc/CMakeLists.txt
+++ b/src/tools/idlc/CMakeLists.txt
@@ -9,6 +9,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
+include(ListJoin)
 
 if(BUILD_TESTING)
   add_subdirectory(tests)
@@ -45,8 +46,8 @@ elseif(CMAKE_C_COMPILER_ID MATCHES "GNU" OR
                    "-Wno-documentation"
                    "-Wno-missing-prototypes")
   set(parser_cflags "-Wno-sign-conversion")
-  list(JOIN lexer_cflags " " lexer_cflags)
-  list(JOIN parser_cflags " " parser_cflags)
+  list_join(lexer_cflags " " lexer_cflags)
+  list_join(parser_cflags " " parser_cflags)
   set_source_files_properties(
     "${lexer_path}" PROPERTIES COMPILE_FLAGS "${lexer_cflags}")
   set_source_files_properties(


### PR DESCRIPTION
The native `list(JOIN ...)` was added to CMake in version 3.12, which is a bit to
recent for most distributions. I've verified this works with version 3.7 and that it behaves in the same way the newer native method does. The idea is that the module be removed once all Linux distributions ship versions of CMake that don't need this workaround.

Thanks to @FransFaase for reporting via personal email (GitHub issues preferred for future reports, PRs would be even better :wink:).