### PR TITLE
Fix compilation errors for RMW build on Windows

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/ddsi_vendor.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_vendor.h
@@ -19,6 +19,7 @@ typedef struct {
   uint8_t id[2];
 } nn_vendorid_t;
 
+
 /* All existing vendor codes have the major part equal to 1 (and this will probably be true for a long, long time) */
 #define NN_VENDORID_MINOR_RTI                0x01
 #define NN_VENDORID_MINOR_PRISMTECH_OSPL     0x02
@@ -38,8 +39,15 @@ typedef struct {
 #define NN_VENDORID_MINOR_ECLIPSE            0x10
 #define NN_VENDORID_MINOR_PRISMTECH_CLOUD    0x20
 
-#define NN_VENDORID_UNKNOWN ((nn_vendorid_t) {{ 0x00, 0x00 }})
-#define NN_VENDORID_ECLIPSE ((nn_vendorid_t) {{ 0x01, 0x10 }})
+#if defined(_WIN32) && defined(__cplusplus)
+#define NN_VENDORID_CAST
+#define NN_VENDORID_UNKNOWN {{ 0x00, 0x00 }}
+#define NN_VENDORID_ECLIPSE {{ 0x01, 0x10 }}
+#else
+#define NN_VENDORID_CAST (nn_vendorid_t)
+#define NN_VENDORID_UNKNOWN (NN_VENDORID_CAST {{ 0x00, 0x00 }})
+#define NN_VENDORID_ECLIPSE (NN_VENDORID_CAST {{ 0x01, 0x10 }})
+#endif
 
 #if defined (__cplusplus)
 extern "C" {
@@ -52,29 +60,29 @@ inline bool vendor_is_eclipse (nn_vendorid_t vendor) {
   return vendor_equals (vendor, NN_VENDORID_ECLIPSE);
 }
 inline bool vendor_is_rti (nn_vendorid_t vendor) {
-  return vendor_equals (vendor, (nn_vendorid_t) {{ 0x01, NN_VENDORID_MINOR_RTI }});
+  return vendor_equals (vendor, NN_VENDORID_CAST {{ 0x01, NN_VENDORID_MINOR_RTI }});
 }
 inline bool vendor_is_opensplice (nn_vendorid_t vendor) {
-  return vendor_equals (vendor, (nn_vendorid_t) {{ 0x01, NN_VENDORID_MINOR_PRISMTECH_OSPL }});
+  return vendor_equals (vendor, NN_VENDORID_CAST {{ 0x01, NN_VENDORID_MINOR_PRISMTECH_OSPL }});
 }
 inline bool vendor_is_twinoaks (nn_vendorid_t vendor) {
-  return vendor_equals (vendor, (nn_vendorid_t) {{ 0x01, NN_VENDORID_MINOR_TWINOAKS }});
+  return vendor_equals (vendor, NN_VENDORID_CAST {{ 0x01, NN_VENDORID_MINOR_TWINOAKS }});
 }
 inline bool vendor_is_eprosima (nn_vendorid_t vendor) {
-  return vendor_equals (vendor, (nn_vendorid_t) {{ 0x01, NN_VENDORID_MINOR_EPROSIMA }});
+  return vendor_equals (vendor, NN_VENDORID_CAST {{ 0x01, NN_VENDORID_MINOR_EPROSIMA }});
 }
 inline bool vendor_is_cloud (nn_vendorid_t vendor) {
-  return vendor_equals (vendor, (nn_vendorid_t) {{ 0x01, NN_VENDORID_MINOR_PRISMTECH_CLOUD }});
+  return vendor_equals (vendor, NN_VENDORID_CAST {{ 0x01, NN_VENDORID_MINOR_PRISMTECH_CLOUD }});
 }
 inline bool vendor_is_eclipse_or_opensplice (nn_vendorid_t vendor) {
   return vendor_is_eclipse (vendor) | vendor_is_opensplice (vendor);
 }
 inline bool vendor_is_prismtech (nn_vendorid_t vendor) {
-  return (vendor_equals (vendor, (nn_vendorid_t) {{ 0x01, NN_VENDORID_MINOR_PRISMTECH_OSPL }}) ||
-          vendor_equals (vendor, (nn_vendorid_t) {{ 0x01, NN_VENDORID_MINOR_PRISMTECH_LITE }}) ||
-          vendor_equals (vendor, (nn_vendorid_t) {{ 0x01, NN_VENDORID_MINOR_PRISMTECH_GATEWAY }}) ||
-          vendor_equals (vendor, (nn_vendorid_t) {{ 0x01, NN_VENDORID_MINOR_PRISMTECH_JAVA }}) ||
-          vendor_equals (vendor, (nn_vendorid_t) {{ 0x01, NN_VENDORID_MINOR_PRISMTECH_CLOUD }}));
+  return (vendor_equals (vendor, NN_VENDORID_CAST {{ 0x01, NN_VENDORID_MINOR_PRISMTECH_OSPL }}) ||
+          vendor_equals (vendor, NN_VENDORID_CAST {{ 0x01, NN_VENDORID_MINOR_PRISMTECH_LITE }}) ||
+          vendor_equals (vendor, NN_VENDORID_CAST {{ 0x01, NN_VENDORID_MINOR_PRISMTECH_GATEWAY }}) ||
+          vendor_equals (vendor, NN_VENDORID_CAST {{ 0x01, NN_VENDORID_MINOR_PRISMTECH_JAVA }}) ||
+          vendor_equals (vendor, NN_VENDORID_CAST {{ 0x01, NN_VENDORID_MINOR_PRISMTECH_CLOUD }}));
 }
 inline bool vendor_is_eclipse_or_prismtech (nn_vendorid_t vendor) {
   return vendor_is_eclipse (vendor) || vendor_is_prismtech (vendor);

--- a/src/core/ddsi/include/dds/ddsi/ddsi_vendor.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_vendor.h
@@ -40,14 +40,14 @@ typedef struct {
 #define NN_VENDORID_MINOR_PRISMTECH_CLOUD    0x20
 
 #if defined(_WIN32) && defined(__cplusplus)
-#define NN_VENDORID_CAST
+#define NN_VENDORID(vendor) {{ 0x01, NN_VENDORID_MINOR_##vendor }}
 #define NN_VENDORID_UNKNOWN {{ 0x00, 0x00 }}
-#define NN_VENDORID_ECLIPSE {{ 0x01, 0x10 }}
 #else
-#define NN_VENDORID_CAST (nn_vendorid_t)
-#define NN_VENDORID_UNKNOWN (NN_VENDORID_CAST {{ 0x00, 0x00 }})
-#define NN_VENDORID_ECLIPSE (NN_VENDORID_CAST {{ 0x01, 0x10 }})
+#define NN_VENDORID(vendor) ((nn_vendorid_t) {{ 0x01, NN_VENDORID_MINOR_##vendor }})
+#define NN_VENDORID_UNKNOWN ((nn_vendorid_t) {{ 0x00, 0x00 }})
 #endif
+
+#define NN_VENDORID_ECLIPSE NN_VENDORID (ECLIPSE)
 
 #if defined (__cplusplus)
 extern "C" {
@@ -57,32 +57,32 @@ inline bool vendor_equals (nn_vendorid_t a, nn_vendorid_t b) {
   return ((a.id[0] << 8) | a.id[1]) == ((b.id[0] << 8) | b.id[1]);
 }
 inline bool vendor_is_eclipse (nn_vendorid_t vendor) {
-  return vendor_equals (vendor, NN_VENDORID_ECLIPSE);
+  return vendor_equals (vendor, NN_VENDORID (ECLIPSE));
 }
 inline bool vendor_is_rti (nn_vendorid_t vendor) {
-  return vendor_equals (vendor, NN_VENDORID_CAST {{ 0x01, NN_VENDORID_MINOR_RTI }});
+  return vendor_equals (vendor, NN_VENDORID (RTI));
 }
 inline bool vendor_is_opensplice (nn_vendorid_t vendor) {
-  return vendor_equals (vendor, NN_VENDORID_CAST {{ 0x01, NN_VENDORID_MINOR_PRISMTECH_OSPL }});
+  return vendor_equals (vendor, NN_VENDORID (PRISMTECH_OSPL));
 }
 inline bool vendor_is_twinoaks (nn_vendorid_t vendor) {
-  return vendor_equals (vendor, NN_VENDORID_CAST {{ 0x01, NN_VENDORID_MINOR_TWINOAKS }});
+  return vendor_equals (vendor, NN_VENDORID (TWINOAKS));
 }
 inline bool vendor_is_eprosima (nn_vendorid_t vendor) {
-  return vendor_equals (vendor, NN_VENDORID_CAST {{ 0x01, NN_VENDORID_MINOR_EPROSIMA }});
+  return vendor_equals (vendor, NN_VENDORID (EPROSIMA));
 }
 inline bool vendor_is_cloud (nn_vendorid_t vendor) {
-  return vendor_equals (vendor, NN_VENDORID_CAST {{ 0x01, NN_VENDORID_MINOR_PRISMTECH_CLOUD }});
+  return vendor_equals (vendor, NN_VENDORID (PRISMTECH_CLOUD));
 }
 inline bool vendor_is_eclipse_or_opensplice (nn_vendorid_t vendor) {
   return vendor_is_eclipse (vendor) | vendor_is_opensplice (vendor);
 }
 inline bool vendor_is_prismtech (nn_vendorid_t vendor) {
-  return (vendor_equals (vendor, NN_VENDORID_CAST {{ 0x01, NN_VENDORID_MINOR_PRISMTECH_OSPL }}) ||
-          vendor_equals (vendor, NN_VENDORID_CAST {{ 0x01, NN_VENDORID_MINOR_PRISMTECH_LITE }}) ||
-          vendor_equals (vendor, NN_VENDORID_CAST {{ 0x01, NN_VENDORID_MINOR_PRISMTECH_GATEWAY }}) ||
-          vendor_equals (vendor, NN_VENDORID_CAST {{ 0x01, NN_VENDORID_MINOR_PRISMTECH_JAVA }}) ||
-          vendor_equals (vendor, NN_VENDORID_CAST {{ 0x01, NN_VENDORID_MINOR_PRISMTECH_CLOUD }}));
+  return (vendor_equals (vendor, NN_VENDORID (PRISMTECH_OSPL)) ||
+          vendor_equals (vendor, NN_VENDORID (PRISMTECH_LITE)) ||
+          vendor_equals (vendor, NN_VENDORID (PRISMTECH_GATEWAY)) ||
+          vendor_equals (vendor, NN_VENDORID (PRISMTECH_JAVA)) ||
+          vendor_equals (vendor, NN_VENDORID (PRISMTECH_CLOUD)));
 }
 inline bool vendor_is_eclipse_or_prismtech (nn_vendorid_t vendor) {
   return vendor_is_eclipse (vendor) || vendor_is_prismtech (vendor);

--- a/src/core/ddsi/include/dds/ddsi/q_protocol.h
+++ b/src/core/ddsi/include/dds/ddsi/q_protocol.h
@@ -13,6 +13,7 @@
 #define NN_PROTOCOL_H
 
 #include "dds/ddsrt/endian.h"
+#include "dds/ddsrt/misc.h"
 #include "dds/ddsi/q_feature_check.h"
 
 #include "dds/ddsi/q_rtps.h"
@@ -223,6 +224,7 @@ typedef struct MsgLen {
   uint32_t length;
 } MsgLen_t;
 
+DDSRT_WARNING_MSVC_OFF(4200)
 typedef struct AckNack {
   SubmessageHeader_t smhdr;
   nn_entityid_t readerId;
@@ -231,10 +233,12 @@ typedef struct AckNack {
   uint32_t bits[];
   /* nn_count_t count; */
 } AckNack_t;
+DDSRT_WARNING_MSVC_ON(4200)
 #define ACKNACK_FLAG_FINAL 0x02u
 #define ACKNACK_SIZE(numbits) (offsetof (AckNack_t, bits) + NN_SEQUENCE_NUMBER_SET_BITS_SIZE (numbits) + 4)
 #define ACKNACK_SIZE_MAX ACKNACK_SIZE (256u)
 
+DDSRT_WARNING_MSVC_OFF(4200)
 typedef struct Gap {
   SubmessageHeader_t smhdr;
   nn_entityid_t readerId;
@@ -243,6 +247,7 @@ typedef struct Gap {
   nn_sequence_number_set_header_t gapList;
   uint32_t bits[];
 } Gap_t;
+DDSRT_WARNING_MSVC_ON(4200)
 #define GAP_SIZE(numbits) (offsetof (Gap_t, bits) + NN_SEQUENCE_NUMBER_SET_BITS_SIZE (numbits))
 #define GAP_SIZE_MAX GAP_SIZE (256u)
 
@@ -272,6 +277,7 @@ typedef struct HeartbeatFrag {
   nn_count_t count;
 } HeartbeatFrag_t;
 
+DDSRT_WARNING_MSVC_OFF(4200)
 typedef struct NackFrag {
   SubmessageHeader_t smhdr;
   nn_entityid_t readerId;
@@ -281,6 +287,7 @@ typedef struct NackFrag {
   uint32_t bits[];
   /* nn_count_t count; */
 } NackFrag_t;
+DDSRT_WARNING_MSVC_ON(4200)
 #define NACKFRAG_SIZE(numbits) (offsetof (NackFrag_t, bits) + NN_FRAGMENT_NUMBER_SET_BITS_SIZE (numbits) + 4)
 #define NACKFRAG_SIZE_MAX NACKFRAG_SIZE (256u)
 
@@ -305,12 +312,14 @@ typedef union Submessage {
   PT_InfoContainer_t pt_infocontainer;
 } Submessage_t;
 
+DDSRT_WARNING_MSVC_OFF(4200)
 typedef struct ParticipantMessageData {
   nn_guid_prefix_t participantGuidPrefix;
   uint32_t kind; /* really 4 octets */
   uint32_t length;
   char value[];
 } ParticipantMessageData_t;
+DDSRT_WARNING_MSVC_ON(4200)
 #define PARTICIPANT_MESSAGE_DATA_KIND_UNKNOWN 0x0u
 #define PARTICIPANT_MESSAGE_DATA_KIND_AUTOMATIC_LIVELINESS_UPDATE 0x1u
 #define PARTICIPANT_MESSAGE_DATA_KIND_MANUAL_LIVELINESS_UPDATE 0x2u

--- a/src/ddsrt/include/dds/ddsrt/atomics/msvc.h
+++ b/src/ddsrt/include/dds/ddsrt/atomics/msvc.h
@@ -23,9 +23,9 @@ extern "C" {
    platforms, but it doesn't. */
 
 #if DDSRT_HAVE_ATOMIC64
-#define DDSRT_ATOMIC_PTROP(name) name##64
+#define DDSRT_ATOMIC_PTROP(name, ...) name##64 ((volatile int64_t *) __VA_ARGS__)
 #else
-#define DDSRT_ATOMIC_PTROP(name) name
+#define DDSRT_ATOMIC_PTROP(name, ...) name ((volatile long *) __VA_ARGS__)
 #endif
 
 /* LD, ST */
@@ -47,15 +47,15 @@ inline void ddsrt_atomic_stvoidp (volatile ddsrt_atomic_voidp_t *x, void *v) { d
 /* CAS */
 
 inline int ddsrt_atomic_cas32 (volatile ddsrt_atomic_uint32_t *x, uint32_t exp, uint32_t des) {
-  return InterlockedCompareExchange (&x->v, des, exp) == exp;
+  return (uint32_t) InterlockedCompareExchange ((volatile long *) &x->v, des, exp) == exp;
 }
 #if DDSRT_HAVE_ATOMIC64
 inline int ddsrt_atomic_cas64 (volatile ddsrt_atomic_uint64_t *x, uint64_t exp, uint64_t des) {
-  return InterlockedCompareExchange64 (&x->v, des, exp) == exp;
+  return (uint64_t) InterlockedCompareExchange64 ((volatile int64_t *) &x->v, des, exp) == exp;
 }
 #endif
 inline int ddsrt_atomic_casptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t exp, uintptr_t des) {
-  return DDSRT_ATOMIC_PTROP (InterlockedCompareExchange) (&x->v, des, exp) == exp;
+  return (uintptr_t) DDSRT_ATOMIC_PTROP (InterlockedCompareExchange, &x->v, des, exp) == exp;
 }
 inline int ddsrt_atomic_casvoidp (volatile ddsrt_atomic_voidp_t *x, void *exp, void *des) {
   return ddsrt_atomic_casptr ((volatile ddsrt_atomic_uintptr_t *) x, (uintptr_t) exp, (uintptr_t) des);
@@ -64,96 +64,96 @@ inline int ddsrt_atomic_casvoidp (volatile ddsrt_atomic_voidp_t *x, void *exp, v
 /* INC */
 
 inline void ddsrt_atomic_inc32 (volatile ddsrt_atomic_uint32_t *x) {
-  InterlockedIncrement (&x->v);
+  InterlockedIncrement ((volatile long *) &x->v);
 }
 #if DDSRT_HAVE_ATOMIC64
 inline void ddsrt_atomic_inc64 (volatile ddsrt_atomic_uint64_t *x) {
-  InterlockedIncrement64 (&x->v);
+  InterlockedIncrement64 ((volatile int64_t *) &x->v);
 }
 #endif
 inline void ddsrt_atomic_incptr (volatile ddsrt_atomic_uintptr_t *x) {
-  DDSRT_ATOMIC_PTROP (InterlockedIncrement) (&x->v);
+  DDSRT_ATOMIC_PTROP (InterlockedIncrement, &x->v);
 }
 inline uint32_t ddsrt_atomic_inc32_ov (volatile ddsrt_atomic_uint32_t *x) {
-  return InterlockedIncrement (&x->v) - 1;
+  return InterlockedIncrement ((volatile long *) &x->v) - 1;
 }
 inline uint32_t ddsrt_atomic_inc32_nv (volatile ddsrt_atomic_uint32_t *x) {
-  return InterlockedIncrement (&x->v);
+  return InterlockedIncrement ((volatile long *) &x->v);
 }
 #if DDSRT_HAVE_ATOMIC64
 inline uint64_t ddsrt_atomic_inc64_nv (volatile ddsrt_atomic_uint64_t *x) {
-  return InterlockedIncrement64 (&x->v);
+  return InterlockedIncrement64 ((volatile int64_t *) &x->v);
 }
 #endif
 inline uintptr_t ddsrt_atomic_incptr_nv (volatile ddsrt_atomic_uintptr_t *x) {
-  return DDSRT_ATOMIC_PTROP (InterlockedIncrement) (&x->v);
+  return DDSRT_ATOMIC_PTROP (InterlockedIncrement, &x->v);
 }
 
 /* DEC */
 
 inline void ddsrt_atomic_dec32 (volatile ddsrt_atomic_uint32_t *x) {
-  InterlockedDecrement (&x->v);
+  InterlockedDecrement ((volatile long *) &x->v);
 }
 #if DDSRT_HAVE_ATOMIC64
 inline void ddsrt_atomic_dec64 (volatile ddsrt_atomic_uint64_t *x) {
-  InterlockedDecrement64 (&x->v);
+  InterlockedDecrement64 ((volatile int64_t *) &x->v);
 }
 #endif
 inline void ddsrt_atomic_decptr (volatile ddsrt_atomic_uintptr_t *x) {
-  DDSRT_ATOMIC_PTROP (InterlockedDecrement) (&x->v);
+  DDSRT_ATOMIC_PTROP (InterlockedDecrement, &x->v);
 }
 inline uint32_t ddsrt_atomic_dec32_nv (volatile ddsrt_atomic_uint32_t *x) {
-  return InterlockedDecrement (&x->v);
+  return InterlockedDecrement ((volatile long *) &x->v);
 }
 #if DDSRT_HAVE_ATOMIC64
 inline uint64_t ddsrt_atomic_dec64_nv (volatile ddsrt_atomic_uint64_t *x) {
-  return InterlockedDecrement64 (&x->v);
+  return InterlockedDecrement64 ((volatile int64_t *) &x->v);
 }
 #endif
 inline uintptr_t ddsrt_atomic_decptr_nv (volatile ddsrt_atomic_uintptr_t *x) {
-  return DDSRT_ATOMIC_PTROP (InterlockedDecrement) (&x->v);
+  return DDSRT_ATOMIC_PTROP (InterlockedDecrement, &x->v);
 }
 inline uint32_t ddsrt_atomic_dec32_ov (volatile ddsrt_atomic_uint32_t *x) {
-  return InterlockedDecrement (&x->v) + 1;
+  return InterlockedDecrement ((volatile long *) &x->v) + 1;
 }
 #if DDSRT_HAVE_ATOMIC64
 inline uint64_t ddsrt_atomic_dec64_ov (volatile ddsrt_atomic_uint64_t *x) {
-  return InterlockedDecrement64 (&x->v) + 1;
+  return InterlockedDecrement64 ((volatile int64_t *) &x->v) + 1;
 }
 #endif
 inline uintptr_t ddsrt_atomic_decptr_ov (volatile ddsrt_atomic_uintptr_t *x) {
-  return DDSRT_ATOMIC_PTROP (InterlockedDecrement) (&x->v) + 1;
+  return DDSRT_ATOMIC_PTROP (InterlockedDecrement, &x->v) + 1;
 }
 
 /* ADD */
 
 inline void ddsrt_atomic_add32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
-  InterlockedExchangeAdd (&x->v, v);
+  InterlockedExchangeAdd ((volatile long *) &x->v, v);
 }
 #if DDSRT_HAVE_ATOMIC64
 inline void ddsrt_atomic_add64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
-  InterlockedExchangeAdd64 (&x->v, v);
+  InterlockedExchangeAdd64 ((volatile int64_t *)&x->v, v);
 }
 #endif
 inline void ddsrt_atomic_addptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  DDSRT_ATOMIC_PTROP (InterlockedExchangeAdd) (&x->v, v);
+  DDSRT_ATOMIC_PTROP (InterlockedExchangeAdd, &x->v, v);
 }
 inline void ddsrt_atomic_addvoidp (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
   ddsrt_atomic_addptr ((volatile ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
 }
 inline uint32_t ddsrt_atomic_add32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
-  return InterlockedExchangeAdd (&x->v, v);
+  return InterlockedExchangeAdd ((volatile long *) &x->v, v);
 }
 inline uint32_t ddsrt_atomic_add32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
-  return InterlockedExchangeAdd (&x->v, v) + v;
+  return InterlockedExchangeAdd ((volatile long *) &x->v, v) + v;
 }
 #if DDSRT_HAVE_ATOMIC64
 inline uint64_t ddsrt_atomic_add64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
-  return InterlockedExchangeAdd64 (&x->v, v) + v;
+  return InterlockedExchangeAdd64 ((volatile int64_t *) &x->v, v) + v;
 }
 #endif
 inline uintptr_t ddsrt_atomic_addptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  return DDSRT_ATOMIC_PTROP (InterlockedExchangeAdd) (&x->v, v) + v;
+  return DDSRT_ATOMIC_PTROP (InterlockedExchangeAdd, &x->v, v) + v;
 }
 inline void *ddsrt_atomic_addvoidp_nv (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
   return (void *) ddsrt_atomic_addptr_nv ((volatile ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
@@ -164,21 +164,21 @@ inline void *ddsrt_atomic_addvoidp_nv (volatile ddsrt_atomic_voidp_t *x, ptrdiff
 inline void ddsrt_atomic_sub32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
   /* disable unary minus applied to unsigned type, result still unsigned */
   DDSRT_WARNING_MSVC_OFF(4146)
-  InterlockedExchangeAdd (&x->v, -v);
+  InterlockedExchangeAdd ((volatile long *) &x->v, -v);
   DDSRT_WARNING_MSVC_ON(4146)
 }
 #if DDSRT_HAVE_ATOMIC64
 inline void ddsrt_atomic_sub64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
   /* disable unary minus applied to unsigned type, result still unsigned */
   DDSRT_WARNING_MSVC_OFF(4146)
-  InterlockedExchangeAdd64 (&x->v, -v);
+  InterlockedExchangeAdd64 ((volatile int64_t *) &x->v, -v);
   DDSRT_WARNING_MSVC_ON(4146)
 }
 #endif
 inline void ddsrt_atomic_subptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
   /* disable unary minus applied to unsigned type, result still unsigned */
   DDSRT_WARNING_MSVC_OFF(4146)
-  DDSRT_ATOMIC_PTROP (InterlockedExchangeAdd) (&x->v, -v);
+  DDSRT_ATOMIC_PTROP (InterlockedExchangeAdd, &x->v, -v);
   DDSRT_WARNING_MSVC_ON(4146)
 }
 inline void ddsrt_atomic_subvoidp (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
@@ -187,27 +187,27 @@ inline void ddsrt_atomic_subvoidp (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v
 inline uint32_t ddsrt_atomic_sub32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
   /* disable unary minus applied to unsigned type, result still unsigned */
   DDSRT_WARNING_MSVC_OFF(4146)
-  return InterlockedExchangeAdd (&x->v, -v);
+  return InterlockedExchangeAdd ((volatile long *) &x->v, -v);
   DDSRT_WARNING_MSVC_ON(4146)
 }
 inline uint32_t ddsrt_atomic_sub32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
   /* disable unary minus applied to unsigned type, result still unsigned */
   DDSRT_WARNING_MSVC_OFF(4146)
-  return InterlockedExchangeAdd (&x->v, -v) - v;
+  return InterlockedExchangeAdd ((volatile long *) &x->v, -v) - v;
   DDSRT_WARNING_MSVC_ON(4146)
 }
 #if DDSRT_HAVE_ATOMIC64
 inline uint64_t ddsrt_atomic_sub64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
   /* disable unary minus applied to unsigned type, result still unsigned */
   DDSRT_WARNING_MSVC_OFF(4146)
-  return InterlockedExchangeAdd64 (&x->v, -v) - v;
+  return InterlockedExchangeAdd64 ((volatile int64_t *) &x->v, -v) - v;
   DDSRT_WARNING_MSVC_ON(4146)
 }
 #endif
 inline uintptr_t ddsrt_atomic_subptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
   /* disable unary minus applied to unsigned type, result still unsigned */
   DDSRT_WARNING_MSVC_OFF(4146)
-  return DDSRT_ATOMIC_PTROP (InterlockedExchangeAdd) (&x->v, -v) - v;
+  return DDSRT_ATOMIC_PTROP (InterlockedExchangeAdd, &x->v, -v) - v;
   DDSRT_WARNING_MSVC_ON(4146)
 }
 inline void *ddsrt_atomic_subvoidp_nv (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
@@ -217,73 +217,73 @@ inline void *ddsrt_atomic_subvoidp_nv (volatile ddsrt_atomic_voidp_t *x, ptrdiff
 /* AND */
 
 inline void ddsrt_atomic_and32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
-  InterlockedAnd (&x->v, v);
+  InterlockedAnd ((volatile long *) &x->v, v);
 }
 #if DDSRT_HAVE_ATOMIC64
 inline void ddsrt_atomic_and64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
-  InterlockedAnd64 (&x->v, v);
+  InterlockedAnd64 ((volatile int64_t *) &x->v, v);
 }
 #endif
 inline void ddsrt_atomic_andptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  DDSRT_ATOMIC_PTROP (InterlockedAnd) (&x->v, v);
+  DDSRT_ATOMIC_PTROP (InterlockedAnd, &x->v, v);
 }
 inline uint32_t ddsrt_atomic_and32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
-  return InterlockedAnd (&x->v, v);
+  return InterlockedAnd ((volatile long *) &x->v, v);
 }
 #if DDSRT_HAVE_ATOMIC64
 inline uint64_t ddsrt_atomic_and64_ov (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
-  return InterlockedAnd64 (&x->v, v);
+  return InterlockedAnd64 ((volatile int64_t *) &x->v, v);
 }
 #endif
 inline uintptr_t ddsrt_atomic_andptr_ov (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  return DDSRT_ATOMIC_PTROP (InterlockedAnd) (&x->v, v);
+  return DDSRT_ATOMIC_PTROP (InterlockedAnd, &x->v, v);
 }
 inline uint32_t ddsrt_atomic_and32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
-  return InterlockedAnd (&x->v, v) & v;
+  return InterlockedAnd ((volatile long *) &x->v, v) & v;
 }
 #if DDSRT_HAVE_ATOMIC64
 inline uint64_t ddsrt_atomic_and64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
-  return InterlockedAnd64 (&x->v, v) & v;
+  return InterlockedAnd64 ((volatile int64_t *) &x->v, v) & v;
 }
 #endif
 inline uintptr_t ddsrt_atomic_andptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  return DDSRT_ATOMIC_PTROP (InterlockedAnd) (&x->v, v) & v;
+  return DDSRT_ATOMIC_PTROP (InterlockedAnd, &x->v, v) & v;
 }
 
 /* OR */
 
 inline void ddsrt_atomic_or32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
-  InterlockedOr (&x->v, v);
+  InterlockedOr ((volatile long *) &x->v, v);
 }
 #if DDSRT_HAVE_ATOMIC64
 inline void ddsrt_atomic_or64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
-  InterlockedOr64 (&x->v, v);
+  InterlockedOr64 ((volatile int64_t *) &x->v, v);
 }
 #endif
 inline void ddsrt_atomic_orptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  DDSRT_ATOMIC_PTROP (InterlockedOr) (&x->v, v);
+  DDSRT_ATOMIC_PTROP (InterlockedOr, &x->v, v);
 }
 inline uint32_t ddsrt_atomic_or32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
-  return InterlockedOr (&x->v, v);
+  return InterlockedOr ((volatile long *) &x->v, v);
 }
 #if DDSRT_HAVE_ATOMIC64
 inline uint64_t ddsrt_atomic_or64_ov (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
-  return InterlockedOr64 (&x->v, v);
+  return InterlockedOr64 ((volatile int64_t *) &x->v, v);
 }
 #endif
 inline uintptr_t ddsrt_atomic_orptr_ov (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  return DDSRT_ATOMIC_PTROP (InterlockedOr) (&x->v, v);
+  return DDSRT_ATOMIC_PTROP (InterlockedOr, &x->v, v);
 }
 inline uint32_t ddsrt_atomic_or32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
-  return InterlockedOr (&x->v, v) | v;
+  return InterlockedOr ((volatile long *) &x->v, v) | v;
 }
 #if DDSRT_HAVE_ATOMIC64
 inline uint64_t ddsrt_atomic_or64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
-  return InterlockedOr64 (&x->v, v) | v;
+  return InterlockedOr64 ((volatile int64_t *) &x->v, v) | v;
 }
 #endif
 inline uintptr_t ddsrt_atomic_orptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  return DDSRT_ATOMIC_PTROP (InterlockedOr) (&x->v, v) | v;
+  return DDSRT_ATOMIC_PTROP (InterlockedOr, &x->v, v) | v;
 }
 
 /* FENCES */

--- a/src/ddsrt/include/dds/ddsrt/atomics/msvc.h
+++ b/src/ddsrt/include/dds/ddsrt/atomics/msvc.h
@@ -22,7 +22,9 @@ extern "C" {
    provide all the interlocked operations for 64-bit operands on x86
    platforms, but it doesn't. */
 
+#define DDSRT_ATOMIC_OP32(name, ...) name ((volatile long *) __VA_ARGS__)
 #if DDSRT_HAVE_ATOMIC64
+#define DDSRT_ATOMIC_OP64(name, ...) name ((volatile int64_t *) __VA_ARGS__)
 #define DDSRT_ATOMIC_PTROP(name, ...) name##64 ((volatile int64_t *) __VA_ARGS__)
 #else
 #define DDSRT_ATOMIC_PTROP(name, ...) name ((volatile long *) __VA_ARGS__)
@@ -47,15 +49,15 @@ inline void ddsrt_atomic_stvoidp (volatile ddsrt_atomic_voidp_t *x, void *v) { d
 /* CAS */
 
 inline int ddsrt_atomic_cas32 (volatile ddsrt_atomic_uint32_t *x, uint32_t exp, uint32_t des) {
-  return (uint32_t) InterlockedCompareExchange ((volatile long *) &x->v, des, exp) == exp;
+  return DDSRT_ATOMIC_OP32 (InterlockedCompareExchange, &x->v, des, exp) == exp;
 }
 #if DDSRT_HAVE_ATOMIC64
 inline int ddsrt_atomic_cas64 (volatile ddsrt_atomic_uint64_t *x, uint64_t exp, uint64_t des) {
-  return (uint64_t) InterlockedCompareExchange64 ((volatile int64_t *) &x->v, des, exp) == exp;
+  return DDSRT_ATOMIC_OP64 (InterlockedCompareExchange64, &x->v, des, exp) == exp;
 }
 #endif
 inline int ddsrt_atomic_casptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t exp, uintptr_t des) {
-  return (uintptr_t) DDSRT_ATOMIC_PTROP (InterlockedCompareExchange, &x->v, des, exp) == exp;
+  return DDSRT_ATOMIC_PTROP (InterlockedCompareExchange, &x->v, des, exp) == exp;
 }
 inline int ddsrt_atomic_casvoidp (volatile ddsrt_atomic_voidp_t *x, void *exp, void *des) {
   return ddsrt_atomic_casptr ((volatile ddsrt_atomic_uintptr_t *) x, (uintptr_t) exp, (uintptr_t) des);
@@ -64,25 +66,25 @@ inline int ddsrt_atomic_casvoidp (volatile ddsrt_atomic_voidp_t *x, void *exp, v
 /* INC */
 
 inline void ddsrt_atomic_inc32 (volatile ddsrt_atomic_uint32_t *x) {
-  InterlockedIncrement ((volatile long *) &x->v);
+  DDSRT_ATOMIC_OP32 (InterlockedIncrement, &x->v);
 }
 #if DDSRT_HAVE_ATOMIC64
 inline void ddsrt_atomic_inc64 (volatile ddsrt_atomic_uint64_t *x) {
-  InterlockedIncrement64 ((volatile int64_t *) &x->v);
+  DDSRT_ATOMIC_OP64 (InterlockedIncrement64, &x->v);
 }
 #endif
 inline void ddsrt_atomic_incptr (volatile ddsrt_atomic_uintptr_t *x) {
   DDSRT_ATOMIC_PTROP (InterlockedIncrement, &x->v);
 }
 inline uint32_t ddsrt_atomic_inc32_ov (volatile ddsrt_atomic_uint32_t *x) {
-  return InterlockedIncrement ((volatile long *) &x->v) - 1;
+  return DDSRT_ATOMIC_OP32 (InterlockedIncrement, &x->v) - 1;
 }
 inline uint32_t ddsrt_atomic_inc32_nv (volatile ddsrt_atomic_uint32_t *x) {
-  return InterlockedIncrement ((volatile long *) &x->v);
+  return DDSRT_ATOMIC_OP32 (InterlockedIncrement, &x->v);
 }
 #if DDSRT_HAVE_ATOMIC64
 inline uint64_t ddsrt_atomic_inc64_nv (volatile ddsrt_atomic_uint64_t *x) {
-  return InterlockedIncrement64 ((volatile int64_t *) &x->v);
+  return DDSRT_ATOMIC_OP64 (InterlockedIncrement64, &x->v);
 }
 #endif
 inline uintptr_t ddsrt_atomic_incptr_nv (volatile ddsrt_atomic_uintptr_t *x) {
@@ -92,33 +94,33 @@ inline uintptr_t ddsrt_atomic_incptr_nv (volatile ddsrt_atomic_uintptr_t *x) {
 /* DEC */
 
 inline void ddsrt_atomic_dec32 (volatile ddsrt_atomic_uint32_t *x) {
-  InterlockedDecrement ((volatile long *) &x->v);
+  DDSRT_ATOMIC_OP32 (InterlockedDecrement, &x->v);
 }
 #if DDSRT_HAVE_ATOMIC64
 inline void ddsrt_atomic_dec64 (volatile ddsrt_atomic_uint64_t *x) {
-  InterlockedDecrement64 ((volatile int64_t *) &x->v);
+  DDSRT_ATOMIC_OP64 (InterlockedDecrement64, &x->v);
 }
 #endif
 inline void ddsrt_atomic_decptr (volatile ddsrt_atomic_uintptr_t *x) {
   DDSRT_ATOMIC_PTROP (InterlockedDecrement, &x->v);
 }
 inline uint32_t ddsrt_atomic_dec32_nv (volatile ddsrt_atomic_uint32_t *x) {
-  return InterlockedDecrement ((volatile long *) &x->v);
+  return DDSRT_ATOMIC_OP32 (InterlockedDecrement, &x->v);
 }
 #if DDSRT_HAVE_ATOMIC64
 inline uint64_t ddsrt_atomic_dec64_nv (volatile ddsrt_atomic_uint64_t *x) {
-  return InterlockedDecrement64 ((volatile int64_t *) &x->v);
+  return DDSRT_ATOMIC_OP64 (InterlockedDecrement64, &x->v);
 }
 #endif
 inline uintptr_t ddsrt_atomic_decptr_nv (volatile ddsrt_atomic_uintptr_t *x) {
   return DDSRT_ATOMIC_PTROP (InterlockedDecrement, &x->v);
 }
 inline uint32_t ddsrt_atomic_dec32_ov (volatile ddsrt_atomic_uint32_t *x) {
-  return InterlockedDecrement ((volatile long *) &x->v) + 1;
+  return DDSRT_ATOMIC_OP32 (InterlockedDecrement, &x->v) + 1;
 }
 #if DDSRT_HAVE_ATOMIC64
 inline uint64_t ddsrt_atomic_dec64_ov (volatile ddsrt_atomic_uint64_t *x) {
-  return InterlockedDecrement64 ((volatile int64_t *) &x->v) + 1;
+  return DDSRT_ATOMIC_OP64 (InterlockedDecrement64, &x->v) + 1;
 }
 #endif
 inline uintptr_t ddsrt_atomic_decptr_ov (volatile ddsrt_atomic_uintptr_t *x) {
@@ -128,11 +130,11 @@ inline uintptr_t ddsrt_atomic_decptr_ov (volatile ddsrt_atomic_uintptr_t *x) {
 /* ADD */
 
 inline void ddsrt_atomic_add32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
-  InterlockedExchangeAdd ((volatile long *) &x->v, v);
+  DDSRT_ATOMIC_OP32 (InterlockedExchangeAdd, &x->v, v);
 }
 #if DDSRT_HAVE_ATOMIC64
 inline void ddsrt_atomic_add64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
-  InterlockedExchangeAdd64 ((volatile int64_t *)&x->v, v);
+  DDSRT_ATOMIC_OP64 (InterlockedExchangeAdd64, &x->v, v);
 }
 #endif
 inline void ddsrt_atomic_addptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
@@ -142,14 +144,14 @@ inline void ddsrt_atomic_addvoidp (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v
   ddsrt_atomic_addptr ((volatile ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
 }
 inline uint32_t ddsrt_atomic_add32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
-  return InterlockedExchangeAdd ((volatile long *) &x->v, v);
+  return DDSRT_ATOMIC_OP32 (InterlockedExchangeAdd, &x->v, v);
 }
 inline uint32_t ddsrt_atomic_add32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
-  return InterlockedExchangeAdd ((volatile long *) &x->v, v) + v;
+  return DDSRT_ATOMIC_OP32 (InterlockedExchangeAdd, &x->v, v) + v;
 }
 #if DDSRT_HAVE_ATOMIC64
 inline uint64_t ddsrt_atomic_add64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
-  return InterlockedExchangeAdd64 ((volatile int64_t *) &x->v, v) + v;
+  return DDSRT_ATOMIC_OP64 (InterlockedExchangeAdd64, &x->v, v) + v;
 }
 #endif
 inline uintptr_t ddsrt_atomic_addptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
@@ -164,14 +166,14 @@ inline void *ddsrt_atomic_addvoidp_nv (volatile ddsrt_atomic_voidp_t *x, ptrdiff
 inline void ddsrt_atomic_sub32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
   /* disable unary minus applied to unsigned type, result still unsigned */
   DDSRT_WARNING_MSVC_OFF(4146)
-  InterlockedExchangeAdd ((volatile long *) &x->v, -v);
+  DDSRT_ATOMIC_OP32 (InterlockedExchangeAdd, &x->v, -v);
   DDSRT_WARNING_MSVC_ON(4146)
 }
 #if DDSRT_HAVE_ATOMIC64
 inline void ddsrt_atomic_sub64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
   /* disable unary minus applied to unsigned type, result still unsigned */
   DDSRT_WARNING_MSVC_OFF(4146)
-  InterlockedExchangeAdd64 ((volatile int64_t *) &x->v, -v);
+  DDSRT_ATOMIC_OP64 (InterlockedExchangeAdd64, &x->v, -v);
   DDSRT_WARNING_MSVC_ON(4146)
 }
 #endif
@@ -187,20 +189,20 @@ inline void ddsrt_atomic_subvoidp (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v
 inline uint32_t ddsrt_atomic_sub32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
   /* disable unary minus applied to unsigned type, result still unsigned */
   DDSRT_WARNING_MSVC_OFF(4146)
-  return InterlockedExchangeAdd ((volatile long *) &x->v, -v);
+  return DDSRT_ATOMIC_OP32 (InterlockedExchangeAdd, &x->v, -v);
   DDSRT_WARNING_MSVC_ON(4146)
 }
 inline uint32_t ddsrt_atomic_sub32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
   /* disable unary minus applied to unsigned type, result still unsigned */
   DDSRT_WARNING_MSVC_OFF(4146)
-  return InterlockedExchangeAdd ((volatile long *) &x->v, -v) - v;
+  return DDSRT_ATOMIC_OP32 (InterlockedExchangeAdd, &x->v, -v) - v;
   DDSRT_WARNING_MSVC_ON(4146)
 }
 #if DDSRT_HAVE_ATOMIC64
 inline uint64_t ddsrt_atomic_sub64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
   /* disable unary minus applied to unsigned type, result still unsigned */
   DDSRT_WARNING_MSVC_OFF(4146)
-  return InterlockedExchangeAdd64 ((volatile int64_t *) &x->v, -v) - v;
+  return DDSRT_ATOMIC_OP64 (InterlockedExchangeAdd64, &x->v, -v) - v;
   DDSRT_WARNING_MSVC_ON(4146)
 }
 #endif
@@ -217,33 +219,33 @@ inline void *ddsrt_atomic_subvoidp_nv (volatile ddsrt_atomic_voidp_t *x, ptrdiff
 /* AND */
 
 inline void ddsrt_atomic_and32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
-  InterlockedAnd ((volatile long *) &x->v, v);
+  DDSRT_ATOMIC_OP32 (InterlockedAnd, &x->v, v);
 }
 #if DDSRT_HAVE_ATOMIC64
 inline void ddsrt_atomic_and64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
-  InterlockedAnd64 ((volatile int64_t *) &x->v, v);
+  DDSRT_ATOMIC_OP64 (InterlockedAnd64, &x->v, v);
 }
 #endif
 inline void ddsrt_atomic_andptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
   DDSRT_ATOMIC_PTROP (InterlockedAnd, &x->v, v);
 }
 inline uint32_t ddsrt_atomic_and32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
-  return InterlockedAnd ((volatile long *) &x->v, v);
+  return DDSRT_ATOMIC_OP32 (InterlockedAnd, &x->v, v);
 }
 #if DDSRT_HAVE_ATOMIC64
 inline uint64_t ddsrt_atomic_and64_ov (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
-  return InterlockedAnd64 ((volatile int64_t *) &x->v, v);
+  return DDSRT_ATOMIC_OP64 (InterlockedAnd64, &x->v, v);
 }
 #endif
 inline uintptr_t ddsrt_atomic_andptr_ov (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
   return DDSRT_ATOMIC_PTROP (InterlockedAnd, &x->v, v);
 }
 inline uint32_t ddsrt_atomic_and32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
-  return InterlockedAnd ((volatile long *) &x->v, v) & v;
+  return DDSRT_ATOMIC_OP32 (InterlockedAnd, &x->v, v) & v;
 }
 #if DDSRT_HAVE_ATOMIC64
 inline uint64_t ddsrt_atomic_and64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
-  return InterlockedAnd64 ((volatile int64_t *) &x->v, v) & v;
+  return DDSRT_ATOMIC_OP64 (InterlockedAnd64, &x->v, v) & v;
 }
 #endif
 inline uintptr_t ddsrt_atomic_andptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
@@ -253,33 +255,33 @@ inline uintptr_t ddsrt_atomic_andptr_nv (volatile ddsrt_atomic_uintptr_t *x, uin
 /* OR */
 
 inline void ddsrt_atomic_or32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
-  InterlockedOr ((volatile long *) &x->v, v);
+  DDSRT_ATOMIC_OP32 (InterlockedOr, &x->v, v);
 }
 #if DDSRT_HAVE_ATOMIC64
 inline void ddsrt_atomic_or64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
-  InterlockedOr64 ((volatile int64_t *) &x->v, v);
+  DDSRT_ATOMIC_OP64 (InterlockedOr64, &x->v, v);
 }
 #endif
 inline void ddsrt_atomic_orptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
   DDSRT_ATOMIC_PTROP (InterlockedOr, &x->v, v);
 }
 inline uint32_t ddsrt_atomic_or32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
-  return InterlockedOr ((volatile long *) &x->v, v);
+  return DDSRT_ATOMIC_OP32 (InterlockedOr, &x->v, v);
 }
 #if DDSRT_HAVE_ATOMIC64
 inline uint64_t ddsrt_atomic_or64_ov (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
-  return InterlockedOr64 ((volatile int64_t *) &x->v, v);
+  return DDSRT_ATOMIC_OP64 (InterlockedOr64, &x->v, v);
 }
 #endif
 inline uintptr_t ddsrt_atomic_orptr_ov (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
   return DDSRT_ATOMIC_PTROP (InterlockedOr, &x->v, v);
 }
 inline uint32_t ddsrt_atomic_or32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
-  return InterlockedOr ((volatile long *) &x->v, v) | v;
+  return DDSRT_ATOMIC_OP32 (InterlockedOr, &x->v, v) | v;
 }
 #if DDSRT_HAVE_ATOMIC64
 inline uint64_t ddsrt_atomic_or64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
-  return InterlockedOr64 ((volatile int64_t *) &x->v, v) | v;
+  return DDSRT_ATOMIC_OP64 (InterlockedOr64, &x->v, v) | v;
 }
 #endif
 inline uintptr_t ddsrt_atomic_orptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {

--- a/src/ddsrt/include/dds/ddsrt/atomics/msvc.h
+++ b/src/ddsrt/include/dds/ddsrt/atomics/msvc.h
@@ -24,7 +24,7 @@ extern "C" {
 
 #define DDSRT_ATOMIC_OP32(name, ...) name ((volatile long *) __VA_ARGS__)
 #if DDSRT_HAVE_ATOMIC64
-#define DDSRT_ATOMIC_OP64(name, ...) name ((volatile int64_t *) __VA_ARGS__)
+#define DDSRT_ATOMIC_OP64(name, ...) name##64 ((volatile int64_t *) __VA_ARGS__)
 #define DDSRT_ATOMIC_PTROP(name, ...) name##64 ((volatile int64_t *) __VA_ARGS__)
 #else
 #define DDSRT_ATOMIC_PTROP(name, ...) name ((volatile long *) __VA_ARGS__)
@@ -53,7 +53,7 @@ inline int ddsrt_atomic_cas32 (volatile ddsrt_atomic_uint32_t *x, uint32_t exp, 
 }
 #if DDSRT_HAVE_ATOMIC64
 inline int ddsrt_atomic_cas64 (volatile ddsrt_atomic_uint64_t *x, uint64_t exp, uint64_t des) {
-  return DDSRT_ATOMIC_OP64 (InterlockedCompareExchange64, &x->v, des, exp) == exp;
+  return DDSRT_ATOMIC_OP64 (InterlockedCompareExchange, &x->v, des, exp) == exp;
 }
 #endif
 inline int ddsrt_atomic_casptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t exp, uintptr_t des) {
@@ -70,7 +70,7 @@ inline void ddsrt_atomic_inc32 (volatile ddsrt_atomic_uint32_t *x) {
 }
 #if DDSRT_HAVE_ATOMIC64
 inline void ddsrt_atomic_inc64 (volatile ddsrt_atomic_uint64_t *x) {
-  DDSRT_ATOMIC_OP64 (InterlockedIncrement64, &x->v);
+  DDSRT_ATOMIC_OP64 (InterlockedIncrement, &x->v);
 }
 #endif
 inline void ddsrt_atomic_incptr (volatile ddsrt_atomic_uintptr_t *x) {
@@ -84,7 +84,7 @@ inline uint32_t ddsrt_atomic_inc32_nv (volatile ddsrt_atomic_uint32_t *x) {
 }
 #if DDSRT_HAVE_ATOMIC64
 inline uint64_t ddsrt_atomic_inc64_nv (volatile ddsrt_atomic_uint64_t *x) {
-  return DDSRT_ATOMIC_OP64 (InterlockedIncrement64, &x->v);
+  return DDSRT_ATOMIC_OP64 (InterlockedIncrement, &x->v);
 }
 #endif
 inline uintptr_t ddsrt_atomic_incptr_nv (volatile ddsrt_atomic_uintptr_t *x) {
@@ -98,7 +98,7 @@ inline void ddsrt_atomic_dec32 (volatile ddsrt_atomic_uint32_t *x) {
 }
 #if DDSRT_HAVE_ATOMIC64
 inline void ddsrt_atomic_dec64 (volatile ddsrt_atomic_uint64_t *x) {
-  DDSRT_ATOMIC_OP64 (InterlockedDecrement64, &x->v);
+  DDSRT_ATOMIC_OP64 (InterlockedDecrement, &x->v);
 }
 #endif
 inline void ddsrt_atomic_decptr (volatile ddsrt_atomic_uintptr_t *x) {
@@ -109,7 +109,7 @@ inline uint32_t ddsrt_atomic_dec32_nv (volatile ddsrt_atomic_uint32_t *x) {
 }
 #if DDSRT_HAVE_ATOMIC64
 inline uint64_t ddsrt_atomic_dec64_nv (volatile ddsrt_atomic_uint64_t *x) {
-  return DDSRT_ATOMIC_OP64 (InterlockedDecrement64, &x->v);
+  return DDSRT_ATOMIC_OP64 (InterlockedDecrement, &x->v);
 }
 #endif
 inline uintptr_t ddsrt_atomic_decptr_nv (volatile ddsrt_atomic_uintptr_t *x) {
@@ -120,7 +120,7 @@ inline uint32_t ddsrt_atomic_dec32_ov (volatile ddsrt_atomic_uint32_t *x) {
 }
 #if DDSRT_HAVE_ATOMIC64
 inline uint64_t ddsrt_atomic_dec64_ov (volatile ddsrt_atomic_uint64_t *x) {
-  return DDSRT_ATOMIC_OP64 (InterlockedDecrement64, &x->v) + 1;
+  return DDSRT_ATOMIC_OP64 (InterlockedDecrement, &x->v) + 1;
 }
 #endif
 inline uintptr_t ddsrt_atomic_decptr_ov (volatile ddsrt_atomic_uintptr_t *x) {
@@ -134,7 +134,7 @@ inline void ddsrt_atomic_add32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
 }
 #if DDSRT_HAVE_ATOMIC64
 inline void ddsrt_atomic_add64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
-  DDSRT_ATOMIC_OP64 (InterlockedExchangeAdd64, &x->v, v);
+  DDSRT_ATOMIC_OP64 (InterlockedExchangeAdd, &x->v, v);
 }
 #endif
 inline void ddsrt_atomic_addptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
@@ -151,7 +151,7 @@ inline uint32_t ddsrt_atomic_add32_nv (volatile ddsrt_atomic_uint32_t *x, uint32
 }
 #if DDSRT_HAVE_ATOMIC64
 inline uint64_t ddsrt_atomic_add64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
-  return DDSRT_ATOMIC_OP64 (InterlockedExchangeAdd64, &x->v, v) + v;
+  return DDSRT_ATOMIC_OP64 (InterlockedExchangeAdd, &x->v, v) + v;
 }
 #endif
 inline uintptr_t ddsrt_atomic_addptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
@@ -173,7 +173,7 @@ inline void ddsrt_atomic_sub32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
 inline void ddsrt_atomic_sub64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
   /* disable unary minus applied to unsigned type, result still unsigned */
   DDSRT_WARNING_MSVC_OFF(4146)
-  DDSRT_ATOMIC_OP64 (InterlockedExchangeAdd64, &x->v, -v);
+  DDSRT_ATOMIC_OP64 (InterlockedExchangeAdd, &x->v, -v);
   DDSRT_WARNING_MSVC_ON(4146)
 }
 #endif
@@ -202,7 +202,7 @@ inline uint32_t ddsrt_atomic_sub32_nv (volatile ddsrt_atomic_uint32_t *x, uint32
 inline uint64_t ddsrt_atomic_sub64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
   /* disable unary minus applied to unsigned type, result still unsigned */
   DDSRT_WARNING_MSVC_OFF(4146)
-  return DDSRT_ATOMIC_OP64 (InterlockedExchangeAdd64, &x->v, -v) - v;
+  return DDSRT_ATOMIC_OP64 (InterlockedExchangeAdd, &x->v, -v) - v;
   DDSRT_WARNING_MSVC_ON(4146)
 }
 #endif
@@ -223,7 +223,7 @@ inline void ddsrt_atomic_and32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
 }
 #if DDSRT_HAVE_ATOMIC64
 inline void ddsrt_atomic_and64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
-  DDSRT_ATOMIC_OP64 (InterlockedAnd64, &x->v, v);
+  DDSRT_ATOMIC_OP64 (InterlockedAnd, &x->v, v);
 }
 #endif
 inline void ddsrt_atomic_andptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
@@ -234,7 +234,7 @@ inline uint32_t ddsrt_atomic_and32_ov (volatile ddsrt_atomic_uint32_t *x, uint32
 }
 #if DDSRT_HAVE_ATOMIC64
 inline uint64_t ddsrt_atomic_and64_ov (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
-  return DDSRT_ATOMIC_OP64 (InterlockedAnd64, &x->v, v);
+  return DDSRT_ATOMIC_OP64 (InterlockedAnd, &x->v, v);
 }
 #endif
 inline uintptr_t ddsrt_atomic_andptr_ov (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
@@ -245,7 +245,7 @@ inline uint32_t ddsrt_atomic_and32_nv (volatile ddsrt_atomic_uint32_t *x, uint32
 }
 #if DDSRT_HAVE_ATOMIC64
 inline uint64_t ddsrt_atomic_and64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
-  return DDSRT_ATOMIC_OP64 (InterlockedAnd64, &x->v, v) & v;
+  return DDSRT_ATOMIC_OP64 (InterlockedAnd, &x->v, v) & v;
 }
 #endif
 inline uintptr_t ddsrt_atomic_andptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
@@ -259,7 +259,7 @@ inline void ddsrt_atomic_or32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
 }
 #if DDSRT_HAVE_ATOMIC64
 inline void ddsrt_atomic_or64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
-  DDSRT_ATOMIC_OP64 (InterlockedOr64, &x->v, v);
+  DDSRT_ATOMIC_OP64 (InterlockedOr, &x->v, v);
 }
 #endif
 inline void ddsrt_atomic_orptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
@@ -270,7 +270,7 @@ inline uint32_t ddsrt_atomic_or32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_
 }
 #if DDSRT_HAVE_ATOMIC64
 inline uint64_t ddsrt_atomic_or64_ov (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
-  return DDSRT_ATOMIC_OP64 (InterlockedOr64, &x->v, v);
+  return DDSRT_ATOMIC_OP64 (InterlockedOr, &x->v, v);
 }
 #endif
 inline uintptr_t ddsrt_atomic_orptr_ov (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
@@ -281,7 +281,7 @@ inline uint32_t ddsrt_atomic_or32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_
 }
 #if DDSRT_HAVE_ATOMIC64
 inline uint64_t ddsrt_atomic_or64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
-  return DDSRT_ATOMIC_OP64 (InterlockedOr64, &x->v, v) | v;
+  return DDSRT_ATOMIC_OP64 (InterlockedOr, &x->v, v) | v;
 }
 #endif
 inline uintptr_t ddsrt_atomic_orptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {

--- a/src/ddsrt/include/dds/ddsrt/sockets.h
+++ b/src/ddsrt/include/dds/ddsrt/sockets.h
@@ -12,6 +12,7 @@
 #include "dds/ddsrt/attributes.h"
 #include "dds/ddsrt/retcode.h"
 #include "dds/ddsrt/time.h"
+#include "dds/ddsrt/misc.h"
 #if _WIN32
 #include "dds/ddsrt/sockets/windows.h"
 #else
@@ -237,10 +238,12 @@ ddsrt_sockaddrtostr(
   const void *sa, char *buf, size_t size);
 
 #if DDSRT_HAVE_DNS
+DDSRT_WARNING_MSVC_OFF(4200)
 typedef struct {
   size_t naddrs;
   struct sockaddr_storage addrs[];
 } ddsrt_hostent_t;
+DDSRT_WARNING_MSVC_ON(4200)
 
 /**
  * @brief Lookup addresses for given host name.


### PR DESCRIPTION
With this PR the compilation errors are fixed that occur when compiling CycloneDDS headers as part of the ROS2 rmw_cyclonedds_cpp module on Windows (using the msvc C++ compiler). The errors are fixed by adding explicit casts when calling operations on atomics and using a different syntax for compound literals (because the c99 syntax is not supported in msvc in C++ mode). I also suppressed some warnings (msvc only) related to emtpy array declaration in structs.