### PR TITLE
Added property policy.

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/q_plist.h
+++ b/src/core/ddsi/include/dds/ddsi/q_plist.h
@@ -243,6 +243,9 @@ struct nn_rdata;
 DDS_EXPORT unsigned char *nn_plist_quickscan (struct nn_rsample_info *dest, const struct nn_rmsg *rmsg, const nn_plist_src_t *src);
 DDS_EXPORT const unsigned char *nn_plist_findparam_native_unchecked (const void *src, nn_parameterid_t pid);
 
+DDS_EXPORT void nn_free_property_policy (dds_property_qospolicy_t *property);
+DDS_EXPORT void nn_duplicate_property (dds_property_t *dest, const dds_property_t *src);
+
 #if defined (__cplusplus)
 }
 #endif

--- a/src/core/ddsi/include/dds/ddsi/q_xqos.h
+++ b/src/core/ddsi/include/dds/ddsi/q_xqos.h
@@ -32,6 +32,37 @@ typedef ddsi_octetseq_t dds_userdata_qospolicy_t;
 typedef ddsi_octetseq_t dds_topicdata_qospolicy_t;
 typedef ddsi_octetseq_t dds_groupdata_qospolicy_t;
 
+typedef struct dds_property {
+  char *name;
+  char *value;
+  /* The propagate boolean will not be send over the wire.
+   * When the value is 'false', the complete struct shouldn't be send. */
+  bool propagate;
+} dds_property_t;
+
+typedef struct dds_propertyseq {
+  uint32_t n;
+  dds_property_t *props;
+} dds_propertyseq_t;
+
+typedef struct dds_binaryproperty {
+  char *name;
+  ddsi_octetseq_t value;
+  /* The propagate boolean will not be send over the wire.
+   * When the value is 'false', the complete struct shouldn't be send. */
+  bool propagate;
+} dds_binaryproperty_t;
+
+typedef struct dds_binarypropertyseq {
+  uint32_t n;
+  dds_binaryproperty_t *props;
+} dds_binarypropertyseq_t;
+
+typedef struct dds_property_qospolicy {
+  dds_propertyseq_t value;
+  dds_binarypropertyseq_t binary_value;
+} dds_property_qospolicy_t;
+
 typedef struct dds_durability_qospolicy {
   dds_durability_kind_t kind;
 } dds_durability_qospolicy_t;
@@ -212,6 +243,7 @@ typedef struct dds_ignorelocal_qospolicy {
 #define QP_PRISMTECH_SUBSCRIPTION_KEYS       ((uint64_t)1 << 25)
 #define QP_PRISMTECH_ENTITY_FACTORY          ((uint64_t)1 << 27)
 #define QP_CYCLONE_IGNORELOCAL               ((uint64_t)1 << 30)
+#define QP_PROPERTY_LIST                     ((uint64_t)1 << 31)
 
 /* Partition QoS is not RxO according to the specification (DDS 1.2,
    section 7.1.3), but communication will not take place unless it
@@ -263,6 +295,7 @@ struct dds_qos {
   /*x xR*/dds_subscription_keys_qospolicy_t subscription_keys;
   /*x xR*/dds_reader_lifespan_qospolicy_t reader_lifespan;
   /* x  */dds_ignorelocal_qospolicy_t ignorelocal;
+  /*xxx */dds_property_qospolicy_t property;
 };
 
 struct nn_xmsg;


### PR DESCRIPTION
Add property policy to QoS and parameter list.

While it isn't currently used yet, this will be used by various other components of security.

The property policy has to be (de)serialized as part of the parameter list of a message. There is already generic code for that for other message parameters. However, that is for relatively simple structures.

The property policy is somewhat more elaborate. In short, it contains two sequences of structures ({name,string,propagate bool} and {name,buf,propagate bool}), which isn't supported by the generic (de)serialization. The other complication is the propagation boolean. First, it's not present on the wire. Second, when the value is 'false', then the complete struct should not be present on the wire either.

To support this, the generic parameter handling is extended.
* A XbPROP is added to the pserop to identify the propagation boolean within structures.
* The generic parameter handling functions are extended to be able to handle XbPROP.
* A propagate_generic function is added to check a struct if it contains the XbPROP boolean and what the value is.
* Various property_policy functions (like deser, unalias, etc) are added.
* Various struct_seq functions (like deser, unalias, etc) are added to support the property_policy functions. These functions expect a pserop array that represents the specific struct.
* dds_property_desc and dds_binaryproperty_desc pserop arrays are added to be used with the struct_seq functions.
* ser_generic() has been split up so that the data part can be used in ser_struct_seq().
* Few generic parameter handling functions now update the given offset, which makes using them in the struct_seq functions easier.
* Because the propagation boolean is not sent over the wire, the mem size of the struct on the wire is smaller than the one in memory. This means that the sequence buffer can not be aliased, but has to be specifically allocated. The contents, however, can be aliased. Because of this, a specific copy function for the property policy had to be created to make sure that the copy also has it's own sequence buffer. Otherwise, the fini and unaliase functions won't properly work.
* PID_PROPERTY_LIST is added to the piddesc piddesc_omg array that contains the parameter handling information. The specific property functions are referenced to make sure they're used instead of the generic ones.

I've tested it manually, please see the attached patch file for that.
[test.patch.txt](https://github.com/eclipse-cyclonedds/cyclonedds/files/3590524/test.patch.txt)