### PR TITLE
Added participant mismatch tests.

### DIFF
--- a/src/core/ddsc/tests/reader.c
+++ b/src/core/ddsc/tests/reader.c
@@ -288,7 +288,39 @@ CU_Test(ddsc_reader_create, wrong_participant, .init=reader_init, .fini=reader_f
 }
 /*************************************************************************************************/
 
+/*************************************************************************************************/
+CU_Test(ddsc_reader_create, participant_mismatch)
+{
+    dds_entity_t par1 = 0;
+    dds_entity_t par2 = 0;
+    dds_entity_t sub1 = 0;
+    dds_entity_t top2 = 0;
+    dds_entity_t reader = 0;
+    char name[100];
 
+    par1 = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL, NULL);
+    CU_ASSERT_FATAL(par1 > 0);
+    par2 = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL, NULL);
+    CU_ASSERT_FATAL(par2 > 0);
+
+    sub1 = dds_create_subscriber(par1, NULL, NULL);
+    CU_ASSERT_FATAL(sub1 > 0);
+
+    top2 = dds_create_topic(par2, &Space_Type1_desc, create_topic_name("ddsc_reader_participant_mismatch", name, sizeof name), NULL, NULL);
+    CU_ASSERT_FATAL(top2 > 0);
+
+    /* Create reader with participant mismatch. */
+    reader = dds_create_reader(sub1, top2, NULL, NULL);
+
+    /* Expect the creation to have failed. */
+    CU_ASSERT_FATAL(reader <= 0);
+
+    dds_delete(top2);
+    dds_delete(sub1);
+    dds_delete(par2);
+    dds_delete(par1);
+}
+/*************************************************************************************************/
 
 
 

--- a/src/core/ddsc/tests/writer.c
+++ b/src/core/ddsc/tests/writer.c
@@ -116,3 +116,27 @@ CU_Test(ddsc_create_writer, deleted_topic, .init = setup, .fini = teardown)
     writer = dds_create_writer(publisher, topic, NULL, NULL);
     CU_ASSERT_EQUAL_FATAL(writer, DDS_RETCODE_BAD_PARAMETER);
 }
+
+
+CU_Test(ddsc_create_writer, participant_mismatch, .init = setup, .fini = teardown)
+{
+    dds_entity_t l_par = 0;
+    dds_entity_t l_pub = 0;
+
+    /* The call to setup() created the global topic. */
+
+    /* Create publisher on local participant. */
+    l_par = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL, NULL);
+    CU_ASSERT_FATAL(l_par > 0);
+    l_pub = dds_create_publisher(l_par, NULL, NULL);
+    CU_ASSERT_FATAL(l_pub > 0);
+
+    /* Create writer with local publisher and global topic. */
+    writer = dds_create_writer(l_pub, topic, NULL, NULL);
+
+    /* Expect the creation to have failed. */
+    CU_ASSERT_FATAL(writer <= 0);
+
+    dds_delete(l_pub);
+    dds_delete(l_par);
+}


### PR DESCRIPTION
It was possible to create a writer with publisher(participant1) and topic(participant2). See for more information #190, where a test was provided that indicated the problem.

The problem should have been fixed with #246.

This pull request will introduce (as requested) the test of #190 to see if it is actually fixed (which it is).