### PR TITLE
Added property policy.

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/q_plist.h
+++ b/src/core/ddsi/include/dds/ddsi/q_plist.h
@@ -243,6 +243,9 @@ struct nn_rdata;
 DDS_EXPORT unsigned char *nn_plist_quickscan (struct nn_rsample_info *dest, const struct nn_rmsg *rmsg, const nn_plist_src_t *src);
 DDS_EXPORT const unsigned char *nn_plist_findparam_native_unchecked (const void *src, nn_parameterid_t pid);
 
+DDS_EXPORT void nn_free_property_policy (dds_property_qospolicy_t *property);
+DDS_EXPORT void nn_duplicate_property (dds_property_t *dest, const dds_property_t *src);
+
 #if defined (__cplusplus)
 }
 #endif

--- a/src/core/ddsi/include/dds/ddsi/q_plist.h
+++ b/src/core/ddsi/include/dds/ddsi/q_plist.h
@@ -243,9 +243,6 @@ struct nn_rdata;
 DDS_EXPORT unsigned char *nn_plist_quickscan (struct nn_rsample_info *dest, const struct nn_rmsg *rmsg, const nn_plist_src_t *src);
 DDS_EXPORT const unsigned char *nn_plist_findparam_native_unchecked (const void *src, nn_parameterid_t pid);
 
-DDS_EXPORT void nn_free_property_policy (dds_property_qospolicy_t *property);
-DDS_EXPORT void nn_duplicate_property (dds_property_t *dest, const dds_property_t *src);
-
 #if defined (__cplusplus)
 }
 #endif

--- a/src/core/ddsi/include/dds/ddsi/q_xqos.h
+++ b/src/core/ddsi/include/dds/ddsi/q_xqos.h
@@ -35,7 +35,8 @@ typedef ddsi_octetseq_t dds_groupdata_qospolicy_t;
 typedef struct dds_property {
   /* The propagate boolean will not be send over the wire.
    * When the value is 'false', the complete struct shouldn't be send.
-   * It has to be the first variable within the structure. */
+   * It has to be the first variable within the structure because it
+   * is mapped to XbPROP in the serialiser. */
   unsigned char propagate;
   char *name;
   char *value;
@@ -49,7 +50,8 @@ typedef struct dds_propertyseq {
 typedef struct dds_binaryproperty {
   /* The propagate boolean will not be send over the wire.
    * When the value is 'false', the complete struct shouldn't be send.
-   * It has to be the first variable within the structure. */
+   * It has to be the first variable within the structure because it
+   * is mapped to XbPROP in the serialiser. */
   unsigned char propagate;
   char *name;
   ddsi_octetseq_t value;

--- a/src/core/ddsi/include/dds/ddsi/q_xqos.h
+++ b/src/core/ddsi/include/dds/ddsi/q_xqos.h
@@ -32,6 +32,39 @@ typedef ddsi_octetseq_t dds_userdata_qospolicy_t;
 typedef ddsi_octetseq_t dds_topicdata_qospolicy_t;
 typedef ddsi_octetseq_t dds_groupdata_qospolicy_t;
 
+typedef struct dds_property {
+  /* The propagate boolean will not be send over the wire.
+   * When the value is 'false', the complete struct shouldn't be send.
+   * It has to be the first variable within the structure. */
+  unsigned char propagate;
+  char *name;
+  char *value;
+} dds_property_t;
+
+typedef struct dds_propertyseq {
+  uint32_t n;
+  dds_property_t *props;
+} dds_propertyseq_t;
+
+typedef struct dds_binaryproperty {
+  /* The propagate boolean will not be send over the wire.
+   * When the value is 'false', the complete struct shouldn't be send.
+   * It has to be the first variable within the structure. */
+  unsigned char propagate;
+  char *name;
+  ddsi_octetseq_t value;
+} dds_binaryproperty_t;
+
+typedef struct dds_binarypropertyseq {
+  uint32_t n;
+  dds_binaryproperty_t *props;
+} dds_binarypropertyseq_t;
+
+typedef struct dds_property_qospolicy {
+  dds_propertyseq_t value;
+  dds_binarypropertyseq_t binary_value;
+} dds_property_qospolicy_t;
+
 typedef struct dds_durability_qospolicy {
   dds_durability_kind_t kind;
 } dds_durability_qospolicy_t;
@@ -212,6 +245,7 @@ typedef struct dds_ignorelocal_qospolicy {
 #define QP_PRISMTECH_SUBSCRIPTION_KEYS       ((uint64_t)1 << 25)
 #define QP_PRISMTECH_ENTITY_FACTORY          ((uint64_t)1 << 27)
 #define QP_CYCLONE_IGNORELOCAL               ((uint64_t)1 << 30)
+#define QP_PROPERTY_LIST                     ((uint64_t)1 << 31)
 
 /* Partition QoS is not RxO according to the specification (DDS 1.2,
    section 7.1.3), but communication will not take place unless it
@@ -263,6 +297,7 @@ struct dds_qos {
   /*x xR*/dds_subscription_keys_qospolicy_t subscription_keys;
   /*x xR*/dds_reader_lifespan_qospolicy_t reader_lifespan;
   /* x  */dds_ignorelocal_qospolicy_t ignorelocal;
+  /*xxx */dds_property_qospolicy_t property;
 };
 
 struct nn_xmsg;

--- a/src/core/ddsi/src/ddsi_serdata_default.c
+++ b/src/core/ddsi/src/ddsi_serdata_default.c
@@ -453,6 +453,7 @@ static struct ddsi_serdata *serdata_default_from_sample_plist (const struct ddsi
 #ifndef NDEBUG
   size_t keysize;
 #endif
+  assert(rawkey);
   switch (sample->keyparam)
   {
     case PID_PARTICIPANT_GUID:


### PR DESCRIPTION
Add property policy to QoS and parameter list.

While it isn't currently used yet, this will be used by various other components of security.

A previous PR was created regarding the property policy: #250.
Because of the comments and specifically the (non-nested) sequences handling prototype, it was easier for me to just create a new PR.

The property policy has to be (de)serialized as part of the parameter list of a message. There is already generic code for that for other message parameters. However, that is for relatively simple structures.

The property policy is somewhat more elaborate. In short, it contains two sequences of structures ({name,string,propagate bool} and {name,buf,propagate bool}), which already isn't supported by the generic (de)serialization. The other complication is the propagation boolean. First, it's not present the wire. Second, when the value is 'false', then the complete struct should not be present on the wire either.

To support this, the generic parameter handling is extended.
* A XbPROP is added to the pserop to identify the propagation boolean within structures.
* A XQ is added to the pserop to identify a (non-octet, non-nested) sequence (replacing the XZ string sequence).
* The generic parameter handling functions are extended to be able to handle XbPROP and XQ.
* Some generic parameter handling functions are split into an 'entry' function and a 'partial' function.
* PID_PROPERTY_LIST is added to the piddesc piddesc_omg array that contains the parameter handling information.


This is done in 3 commits:
1. Unused length opcode has been removed.
2. The plist handling has been extended with the sequence and propagate boolean handling.
3. The property policy types and handling has been added.

I've tested it manually, please see the attached patch file for that.
[prop_test.patch.txt](https://github.com/eclipse-cyclonedds/cyclonedds/files/3617110/prop_test.patch.txt)