### PR TITLE
Fixes prompted by running Clang's static analyzer and Coverity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,9 +68,9 @@ linux_clang: &linux_clang
   install:
     - pip install conan --upgrade --user
 
-osx_xcode10_2: &osx_xcode10_2
+osx_xcode10_3: &osx_xcode10_3
   os: osx
-  osx_image: xcode10.2
+  osx_image: xcode10.3
   compiler: clang
   addons:
     homebrew:
@@ -147,9 +147,9 @@ jobs:
       env: [ ARCH=x86_64, ASAN=address, BUILD_TYPE=Debug, SSL=YES, GENERATOR="Unix Makefiles" ]
     - <<: *linux_clang
       env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, SSL=YES, GENERATOR="Unix Makefiles" ]
-    - <<: *osx_xcode10_2
+    - <<: *osx_xcode10_3
       env: [ ARCH=x86_64, ASAN=address, BUILD_TYPE=Debug, SSL=YES, GENERATOR="Unix Makefiles" ]
-    - <<: *osx_xcode10_2
+    - <<: *osx_xcode10_3
       env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, SSL=YES, GENERATOR="Unix Makefiles" ]
     - <<: *windows_vs2017
       env: [ ARCH=x86, ASAN=none, BUILD_TYPE=Debug, SSL=YES, GENERATOR="Visual Studio 15 2017" ]

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
 cunit/2.1-3@bincrafters/stable
-OpenSSL/1.1.1a@conan/stable
+OpenSSL/1.1.1c@conan/stable
 
 [generators]
 cmake

--- a/src/core/ddsc/src/dds_domain.c
+++ b/src/core/ddsc/src/dds_domain.c
@@ -169,7 +169,6 @@ static dds_return_t dds_domain_init (dds_domain *domain, dds_domainid_t domain_i
   dds_entity_init_complete (&domain->m_entity);
   return DDS_RETCODE_OK;
 
-  rtps_stop (&domain->gv);
 fail_rtps_start:
   if (domain->gv.config.liveliness_monitoring && dds_global.threadmon_count == 1)
     ddsi_threadmon_stop (dds_global.threadmon);

--- a/src/core/ddsc/src/dds_reader.c
+++ b/src/core/ddsc/src/dds_reader.c
@@ -114,7 +114,6 @@ void dds_reader_data_available_cb (struct dds_reader *rd)
   if (lst->on_data_on_readers)
   {
     ddsrt_mutex_unlock (&rd->m_entity.m_observers_lock);
-
     ddsrt_mutex_lock (&sub->m_observers_lock);
     const uint32_t data_on_rds_enabled = (ddsrt_atomic_ld32 (&sub->m_status.m_status_and_mask) & (DDS_DATA_ON_READERS_STATUS << SAM_ENABLED_SHIFT));
     if (data_on_rds_enabled)
@@ -127,13 +126,13 @@ void dds_reader_data_available_cb (struct dds_reader *rd)
 
       lst->on_data_on_readers (sub->m_hdllink.hdl, lst->on_data_on_readers_arg);
 
-      ddsrt_mutex_lock (&rd->m_entity.m_observers_lock);
       ddsrt_mutex_lock (&sub->m_observers_lock);
       sub->m_cb_count--;
       sub->m_cb_pending_count--;
       ddsrt_cond_broadcast (&sub->m_observers_cond);
     }
     ddsrt_mutex_unlock (&sub->m_observers_lock);
+    ddsrt_mutex_lock (&rd->m_entity.m_observers_lock);
   }
   else if (rd->m_entity.m_listener.on_data_available)
   {

--- a/src/core/ddsc/src/dds_stream.c
+++ b/src/core/ddsc/src/dds_stream.c
@@ -1696,7 +1696,7 @@ static bool prtf_simple_array (char * __restrict *buf, size_t * __restrict bufsi
         else
         {
           if (i != 0)
-            cont = prtf (buf, bufsize, ",");
+            (void) prtf (buf, bufsize, ",");
           cont = prtf_simple (buf, bufsize, is, type);
           i++;
         }
@@ -1708,7 +1708,7 @@ static bool prtf_simple_array (char * __restrict *buf, size_t * __restrict bufsi
       for (size_t i = 0; cont && i < num; i++)
       {
         if (i != 0)
-          cont = prtf (buf, bufsize, ",");
+          (void) prtf (buf, bufsize, ",");
         cont = prtf_simple (buf, bufsize, is, type);
       }
       break;

--- a/src/core/ddsc/tests/entity_hierarchy.c
+++ b/src/core/ddsc/tests/entity_hierarchy.c
@@ -366,6 +366,7 @@ CU_Test(ddsc_entity_get_children, null, .init=hierarchy_init, .fini=hierarchy_fi
 /*************************************************************************************************/
 
 /*************************************************************************************************/
+#if SIZE_MAX > INT32_MAX
 CU_Test(ddsc_entity_get_children, invalid_size, .init=hierarchy_init, .fini=hierarchy_fini)
 {
     dds_return_t ret;
@@ -373,6 +374,7 @@ CU_Test(ddsc_entity_get_children, invalid_size, .init=hierarchy_init, .fini=hier
     ret = dds_get_children(g_participant, &child, SIZE_MAX);
     CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_BAD_PARAMETER);
 }
+#endif
 /*************************************************************************************************/
 
 /*************************************************************************************************/

--- a/src/core/ddsc/tests/instance_get_key.c
+++ b/src/core/ddsc/tests/instance_get_key.c
@@ -132,6 +132,7 @@ CU_Test(ddsc_instance_get_key, registered_instance, .init=setup, .fini=teardown)
     ret = dds_instance_get_key(writer, handle, &key_data);
 
     CU_ASSERT_PTR_NOT_NULL_FATAL(key_data.ip);
+    assert (key_data.ip != NULL); /* for the benefit of clang's static analyzer */
     CU_ASSERT_STRING_EQUAL_FATAL(key_data.ip, data.ip);
     CU_ASSERT_EQUAL_FATAL(key_data.port, data.port);
     CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
@@ -162,6 +163,7 @@ CU_Test(ddsc_instance_get_key, readcondition, .init=setup, .fini=teardown)
     ret = dds_instance_get_key(readcondition, handle, &key_data);
 
     CU_ASSERT_PTR_NOT_NULL_FATAL(key_data.ip);
+    assert (key_data.ip != NULL); /* for the benefit of clang's static analyzer */
     CU_ASSERT_STRING_EQUAL_FATAL(key_data.ip, data.ip);
     CU_ASSERT_EQUAL_FATAL(key_data.port, data.port);
     CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
@@ -192,6 +194,7 @@ CU_Test(ddsc_instance_get_key, querycondition, .init=setup, .fini=teardown)
     ret = dds_instance_get_key(querycondition, handle, &key_data);
 
     CU_ASSERT_PTR_NOT_NULL_FATAL(key_data.ip);
+    assert (key_data.ip != NULL); /* for the benefit of clang's static analyzer */
     CU_ASSERT_STRING_EQUAL_FATAL(key_data.ip, data.ip);
     CU_ASSERT_EQUAL_FATAL(key_data.port, data.port);
     CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);

--- a/src/core/ddsc/tests/listener.c
+++ b/src/core/ddsc/tests/listener.c
@@ -727,7 +727,9 @@ CU_Test(ddsc_listener, publication_matched, .init=init_triggering_test, .fini=fi
     CU_ASSERT_EQUAL_FATAL(publication_matched.last_subscription_handle, reader_hdl);
 
     /* Reset the trigger flags. */
+    ddsrt_mutex_lock(&g_mutex);
     cb_called = 0;
+    ddsrt_mutex_unlock(&g_mutex);
 
     /* Un-match the publication by deleting the reader. */
     dds_delete(g_reader);
@@ -789,7 +791,9 @@ CU_Test(ddsc_listener, subscription_matched, .init=init_triggering_test, .fini=f
     CU_ASSERT_EQUAL_FATAL(subscription_matched.last_publication_handle, writer_hdl);
 
     /* Reset the trigger flags. */
+    ddsrt_mutex_lock(&g_mutex);
     cb_called = 0;
+    ddsrt_mutex_unlock(&g_mutex);
 
     /* Un-match the subscription by deleting the writer. */
     dds_delete(g_writer);
@@ -903,8 +907,10 @@ CU_Test(ddsc_listener, data_available, .init=init_triggering_test, .fini=fini_tr
 
     /* Deleting the writer causes unregisters (or dispose+unregister), and those
        should trigger DATA_AVAILABLE as well */
+    ddsrt_mutex_lock(&g_mutex);
     cb_called = 0;
     cb_reader = 0;
+    ddsrt_mutex_unlock(&g_mutex);
     ret = dds_delete (g_writer);
     CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
     g_writer = 0;
@@ -942,8 +948,10 @@ CU_Test(ddsc_listener, data_available_delete_writer, .init=init_triggering_test,
     CU_ASSERT_EQUAL_FATAL(cb_reader, g_reader);
 
     /* Deleting the writer must trigger DATA_AVAILABLE as well */
+    ddsrt_mutex_lock(&g_mutex);
     cb_called = 0;
     cb_reader = 0;
+    ddsrt_mutex_unlock(&g_mutex);
     ret = dds_delete (g_writer);
     CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
     g_writer = 0;
@@ -991,8 +999,10 @@ CU_Test(ddsc_listener, data_available_delete_writer_disposed, .init=init_trigger
     } while (ret > 0);
 
     /* Deleting the writer should not trigger DATA_AVAILABLE with all instances empty & disposed */
+    ddsrt_mutex_lock(&g_mutex);
     cb_called = 0;
     cb_reader = 0;
+    ddsrt_mutex_unlock(&g_mutex);
     ret = dds_delete (g_writer);
     CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
     g_writer = 0;
@@ -1174,7 +1184,9 @@ CU_Test(ddsc_listener, liveliness_changed, .init=init_triggering_test, .fini=fin
     CU_ASSERT_EQUAL_FATAL(liveliness_changed.last_publication_handle, writer_hdl);
 
     /* Reset the trigger flags. */
+    ddsrt_mutex_lock(&g_mutex);
     cb_called = 0;
+    ddsrt_mutex_unlock(&g_mutex);
 
     /* Change liveliness again by deleting the writer. */
     dds_delete(g_writer);

--- a/src/core/ddsc/tests/participant.c
+++ b/src/core/ddsc/tests/participant.c
@@ -47,7 +47,8 @@ CU_Test(ddsc_participant, create_with_no_conf_no_env)
   dds_domainid_t domain_id;
   dds_domainid_t valid_domain=3;
 
-  ddsrt_unsetenv(DDS_PROJECT_NAME_NOSPACE_CAPS"_URI");
+  status = ddsrt_unsetenv(DDS_PROJECT_NAME_NOSPACE_CAPS"_URI");
+  CU_ASSERT_EQUAL_FATAL(status, DDS_RETCODE_OK);
 
   //valid specific domain value
   participant2 = dds_create_participant (valid_domain, NULL, NULL);

--- a/src/core/ddsi/include/dds/ddsi/q_entity.h
+++ b/src/core/ddsi/include/dds/ddsi/q_entity.h
@@ -91,7 +91,7 @@ struct wr_prd_match {
   seqno_t min_seq; /* smallest ack'd seq nr in subtree */
   seqno_t max_seq; /* sort-of highest ack'd seq nr in subtree (see augment function) */
   seqno_t seq; /* highest acknowledged seq nr */
-  int num_reliable_readers_where_seq_equals_max;
+  int32_t num_reliable_readers_where_seq_equals_max;
   ddsi_guid_t arbitrary_unacked_reader;
   nn_count_t next_acknack; /* next acceptable acknack sequence number */
   nn_count_t next_nackfrag; /* next acceptable nackfrag sequence number */
@@ -260,7 +260,7 @@ struct writer
   uint32_t whc_low, whc_high; /* watermarks for WHC in bytes (counting only unack'd data) */
   nn_etime_t t_rexmit_end; /* time of last 1->0 transition of "retransmitting" */
   nn_etime_t t_whc_high_upd; /* time "whc_high" was last updated for controlled ramp-up of throughput */
-  int num_reliable_readers; /* number of matching reliable PROXY readers */
+  int32_t num_reliable_readers; /* number of matching reliable PROXY readers */
   ddsrt_avl_tree_t readers; /* all matching PROXY readers, see struct wr_prd_match */
   ddsrt_avl_tree_t local_readers; /* all matching LOCAL readers, see struct wr_rd_match */
 #ifdef DDSI_INCLUDE_NETWORK_PARTITIONS
@@ -356,8 +356,8 @@ struct proxy_writer {
   struct entity_common e;
   struct proxy_endpoint_common c;
   ddsrt_avl_tree_t readers; /* matching LOCAL readers, see pwr_rd_match */
-  int n_reliable_readers; /* number of those that are reliable */
-  int n_readers_out_of_sync; /* number of those that require special handling (accepting historical data, waiting for historical data set to become complete) */
+  int32_t n_reliable_readers; /* number of those that are reliable */
+  int32_t n_readers_out_of_sync; /* number of those that require special handling (accepting historical data, waiting for historical data set to become complete) */
   seqno_t last_seq; /* highest known seq published by the writer, not last delivered */
   uint32_t last_fragnum; /* last known frag for last_seq, or ~0u if last_seq not partial */
   nn_count_t nackfragcount; /* last nackfrag seq number */

--- a/src/core/ddsi/src/ddsi_raweth.c
+++ b/src/core/ddsi/src/ddsi_raweth.c
@@ -211,7 +211,12 @@ static ddsi_tran_conn_t ddsi_raweth_create_conn (ddsi_tran_factory_t fact, uint3
     return NULL;
   }
 
-  uc = (ddsi_raweth_conn_t) ddsrt_malloc (sizeof (*uc));
+  if ((uc = (ddsi_raweth_conn_t) ddsrt_malloc (sizeof (*uc))) == NULL)
+  {
+    ddsrt_close(sock);
+    return NULL;
+  }
+
   memset (uc, 0, sizeof (*uc));
   uc->m_sock = sock;
   uc->m_ifindex = addr.sll_ifindex;
@@ -226,7 +231,7 @@ static ddsi_tran_conn_t ddsi_raweth_create_conn (ddsi_tran_factory_t fact, uint3
   uc->m_base.m_disable_multiplexing_fn = 0;
 
   DDS_CTRACE (&fact->gv->logconfig, "ddsi_raweth_create_conn %s socket %d port %u\n", mcast ? "multicast" : "unicast", uc->m_sock, uc->m_base.m_base.m_port);
-  return uc ? &uc->m_base : NULL;
+  return &uc->m_base;
 }
 
 static int isbroadcast(const nn_locator_t *loc)

--- a/src/core/ddsi/src/ddsi_tcp.c
+++ b/src/core/ddsi/src/ddsi_tcp.c
@@ -554,8 +554,9 @@ static ssize_t ddsi_tcp_conn_write (ddsi_tran_conn_t base, const nn_locator_t *d
 
   /* If not connected attempt to conect */
 
-  if ((conn->m_sock == DDSRT_INVALID_SOCKET) && ! conn->m_base.m_server)
+  if (conn->m_sock == DDSRT_INVALID_SOCKET)
   {
+    assert (!conn->m_base.m_server);
     ddsi_tcp_conn_connect (conn, &msg);
     if (conn->m_sock == DDSRT_INVALID_SOCKET)
     {

--- a/src/core/ddsi/src/ddsi_threadmon.c
+++ b/src/core/ddsi/src/ddsi_threadmon.c
@@ -265,7 +265,7 @@ void ddsi_threadmon_unregister_domain (struct ddsi_threadmon *sl, const struct q
     dummy.gv = gv;
     struct threadmon_domain *tmdom = ddsrt_hh_lookup (sl->domains, &dummy);
     assert (tmdom);
-    ddsrt_hh_remove (sl->domains, tmdom);
+    (void) ddsrt_hh_remove (sl->domains, tmdom);
     ddsrt_mutex_unlock (&sl->lock);
     ddsrt_free (tmdom);
   }

--- a/src/core/ddsi/src/q_config.c
+++ b/src/core/ddsi/src/q_config.c
@@ -1012,6 +1012,8 @@ static size_t cfg_note_vsnprintf (struct cfg_note_buf *bb, const char *fmt, va_l
   return 0;
 }
 
+static void cfg_note_snprintf (struct cfg_note_buf *bb, const char *fmt, ...) ddsrt_attribute_format ((printf, 2, 3));
+
 static void cfg_note_snprintf (struct cfg_note_buf *bb, const char *fmt, ...)
 {
   /* The reason the 2nd call to os_vsnprintf is here and not inside
@@ -1123,6 +1125,8 @@ static size_t cfg_note (struct cfgst *cfgst, uint32_t cat, size_t bsz, const cha
   return 0;
 }
 
+static void cfg_warning (struct cfgst *cfgst, const char *fmt, ...) ddsrt_attribute_format ((printf, 2, 3));
+
 static void cfg_warning (struct cfgst *cfgst, const char *fmt, ...)
 {
   va_list ap;
@@ -1133,6 +1137,8 @@ static void cfg_warning (struct cfgst *cfgst, const char *fmt, ...)
     va_end (ap);
   } while (bsz > 0);
 }
+
+static enum update_result cfg_error (struct cfgst *cfgst, const char *fmt, ...) ddsrt_attribute_format ((printf, 2, 3));
 
 static enum update_result cfg_error (struct cfgst *cfgst, const char *fmt, ...)
 {
@@ -1145,6 +1151,8 @@ static enum update_result cfg_error (struct cfgst *cfgst, const char *fmt, ...)
   } while (bsz > 0);
   return URES_ERROR;
 }
+
+static void cfg_logelem (struct cfgst *cfgst, uint32_t sources, const char *fmt, ...) ddsrt_attribute_format ((printf, 3, 4));
 
 static void cfg_logelem (struct cfgst *cfgst, uint32_t sources, const char *fmt, ...)
 {
@@ -1444,7 +1452,7 @@ static void pf_int64_unit (struct cfgst *cfgst, int64_t value, uint32_t sources,
     }
     assert (m > 0);
     assert (unit != NULL);
-    cfg_logelem (cfgst, sources, "%lld %s", value / m, unit);
+    cfg_logelem (cfgst, sources, "%"PRId64" %s", value / m, unit);
   }
 }
 

--- a/src/core/ddsi/src/q_ddsi_discovery.c
+++ b/src/core/ddsi/src/q_ddsi_discovery.c
@@ -21,6 +21,7 @@
 #include "dds/ddsrt/md5.h"
 #include "dds/ddsrt/sync.h"
 #include "dds/ddsrt/avl.h"
+#include "dds/ddsrt/string.h"
 #include "dds/ddsi/q_protocol.h"
 #include "dds/ddsi/q_rtps.h"
 #include "dds/ddsi/q_misc.h"
@@ -302,8 +303,8 @@ int spdp_write (struct participant *pp)
       ps.prismtech_participant_version_info.flags |= NN_PRISMTECH_FL_PARTICIPANT_IS_DDSI2;
     ddsrt_mutex_unlock (&pp->e.gv->privileged_pp_lock);
 
-    ddsrt_gethostname(node, sizeof(node)-1);
-    node[sizeof(node)-1] = '\0';
+    if (ddsrt_gethostname(node, sizeof(node)-1) < 0)
+      ddsrt_strlcpy (node, "unknown", sizeof (node));
     size = strlen(node) + strlen(DDS_VERSION) + strlen(DDS_HOST_NAME) + strlen(DDS_TARGET_NAME) + 4; /* + ///'\0' */
     ps.prismtech_participant_version_info.internals = ddsrt_malloc(size);
     (void) snprintf(ps.prismtech_participant_version_info.internals, size, "%s/%s/%s/%s", node, DDS_VERSION, DDS_HOST_NAME, DDS_TARGET_NAME);

--- a/src/core/ddsi/src/q_receive.c
+++ b/src/core/ddsi/src/q_receive.c
@@ -1071,7 +1071,7 @@ static void handle_Heartbeat_helper (struct pwr_rd_match * const wn, struct hand
     refseq = nn_reorder_next_seq (pwr->reorder) - 1;
   else
     refseq = nn_reorder_next_seq (wn->u.not_in_sync.reorder) - 1;
-    RSTTRACE (" "PGUIDFMT"@%"PRId64"%s", PGUID (wn->rd_guid), refseq, (wn->in_sync == PRMSS_SYNC) ? "(sync)" : (wn->in_sync == PRMSS_TLCATCHUP) ? "(tlcatchup)" : "");
+  RSTTRACE (" "PGUIDFMT"@%"PRId64"%s", PGUID (wn->rd_guid), refseq, (wn->in_sync == PRMSS_SYNC) ? "(sync)" : (wn->in_sync == PRMSS_TLCATCHUP) ? "(tlcatchup)" : "");
 
   /* Reschedule AckNack transmit if deemed appropriate; unreliable
      readers have acknack_xevent == NULL and can't do this.
@@ -2437,7 +2437,7 @@ static int handle_DataFrag (struct receiver_state *rst, nn_etime_t tnow, struct 
       payload_offset = submsg_offset + (unsigned) size;
 
     begin = (msg->fragmentStartingNum - 1) * msg->fragmentSize;
-    if (msg->fragmentSize * msg->fragmentsInSubmessage > ((unsigned char *) msg + size - datap)) {
+    if ((uint32_t) msg->fragmentSize * msg->fragmentsInSubmessage > (uint32_t) ((unsigned char *) msg + size - datap)) {
       /* this happens for the last fragment (which usually is short) --
          and is included here merely as a sanity check, because that
          would mean the computed endp1'd be larger than the sample

--- a/src/core/ddsi/src/q_transmit.c
+++ b/src/core/ddsi/src/q_transmit.c
@@ -163,7 +163,7 @@ struct nn_xmsg *writer_hbcontrol_create_heartbeat (struct writer *wr, const stru
   }
   else
   {
-    const int n_unacked = wr->num_reliable_readers - root_rdmatch (wr)->num_reliable_readers_where_seq_equals_max;
+    const int32_t n_unacked = wr->num_reliable_readers - root_rdmatch (wr)->num_reliable_readers_where_seq_equals_max;
     assert (n_unacked >= 0);
     if (n_unacked == 0)
       prd_guid = NULL;
@@ -182,7 +182,7 @@ struct nn_xmsg *writer_hbcontrol_create_heartbeat (struct writer *wr, const stru
     ETRACE (wr, "multicasting ");
   else
     ETRACE (wr, "unicasting to prd "PGUIDFMT" ", PGUID (*prd_guid));
-  ETRACE (wr, "(rel-prd %d seq-eq-max %d seq %"PRId64" maxseq %"PRId64")\n",
+  ETRACE (wr, "(rel-prd %"PRId32" seq-eq-max %"PRId32" seq %"PRId64" maxseq %"PRId64")\n",
           wr->num_reliable_readers,
           ddsrt_avl_is_empty (&wr->readers) ? -1 : root_rdmatch (wr)->num_reliable_readers_where_seq_equals_max,
           wr->seq,

--- a/src/ddsrt/src/cdtors.c
+++ b/src/ddsrt/src/cdtors.c
@@ -49,7 +49,13 @@ retry:
     ddsrt_atomic_or32(&init_status, INIT_STATUS_OK);
   } else {
     while (v > 1 && !(v & INIT_STATUS_OK)) {
+#ifndef __COVERITY__
+      /* This sleep makes Coverity warn about possibly sleeping while holding in a lock
+         in many places, all because just-in-time creation of a thread descriptor ends
+         up here.  Since sleeping is merely meant as a better alternative to spinning,
+         skip the sleep when being analyzed. */
       dds_sleepfor(10000000);
+#endif
       v = ddsrt_atomic_ld32(&init_status);
     }
     goto retry;

--- a/src/ddsrt/src/retcode.c
+++ b/src/ddsrt/src/retcode.c
@@ -10,6 +10,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
 #include "dds/ddsrt/retcode.h"
+#include "dds/ddsrt/static_assert.h"
 
 static const char *retcodes[] = {
   "Success",
@@ -45,6 +46,7 @@ const char *dds_strretcode (dds_return_t rc)
 {
   const dds_return_t nretcodes = (dds_return_t) (sizeof (retcodes) / sizeof (retcodes[0]));
   const dds_return_t nxretcodes = (dds_return_t) (sizeof (xretcodes) / sizeof (xretcodes[0]));
+  DDSRT_STATIC_ASSERT (DDS_XRETCODE_BASE < 0);
   /* Retcodes used to be positive, but return values from the API would be a negative
      and so there are/were/may be places outside the core library where dds_strretcode
      is called with a -N for N a API return value, so ... play it safe and use the
@@ -53,8 +55,8 @@ const char *dds_strretcode (dds_return_t rc)
     rc = -rc;
   if (rc >= 0 && rc < nretcodes)
     return retcodes[rc];
-  else if (rc >= DDS_XRETCODE_BASE && rc < DDS_XRETCODE_BASE + nxretcodes)
-    return xretcodes[rc - DDS_XRETCODE_BASE];
+  else if (rc >= (-DDS_XRETCODE_BASE) && rc < (-DDS_XRETCODE_BASE) + nxretcodes)
+    return xretcodes[rc - (-DDS_XRETCODE_BASE)];
   else
     return "Unknown return code";
 }

--- a/src/ddsrt/tests/environ.c
+++ b/src/ddsrt/tests/environ.c
@@ -10,6 +10,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
 #include <stdlib.h>
+#include <assert.h>
 
 #include "CUnit/Theory.h"
 #include "dds/ddsrt/environ.h"
@@ -49,11 +50,13 @@ CU_Test(ddsrt_environ, setenv)
   CU_ASSERT_EQUAL(rc, DDS_RETCODE_OK);
   ptr = getenv(name);
   CU_ASSERT_PTR_NOT_NULL(ptr);
+  assert (ptr != NULL); /* for the benefit of clang's static analyzer */
   CU_ASSERT_STRING_EQUAL(ptr, "bar");
   /* Ensure value is copied into the environment. */
   value[2] = 'z';
   ptr = getenv(name);
   CU_ASSERT_PTR_NOT_NULL(ptr);
+  assert (ptr != NULL); /* for the benefit of clang's static analyzer */
   CU_ASSERT_STRING_EQUAL(ptr, "bar");
   rc = ddsrt_setenv(name, "");
   CU_ASSERT_EQUAL(rc, DDS_RETCODE_OK);

--- a/src/ddsrt/tests/ifaddrs.c
+++ b/src/ddsrt/tests/ifaddrs.c
@@ -9,6 +9,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
+#include <assert.h>
 #include "dds/ddsrt/cdtors.h"
 #include "dds/ddsrt/ifaddrs.h"
 #include "dds/ddsrt/retcode.h"
@@ -73,6 +74,7 @@ CU_Test(ddsrt_getifaddrs, ipv4)
   CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
   for (ifa = ifa_root; ifa; ifa = ifa->next) {
     CU_ASSERT_PTR_NOT_EQUAL_FATAL(ifa->addr, NULL);
+    assert (ifa->addr != NULL); /* for the benefit of clang's static analyzer */
     CU_ASSERT_EQUAL(ifa->addr->sa_family, AF_INET);
     if (ifa->addr->sa_family == AF_INET) {
       if (ifa->flags & IFF_LOOPBACK) {
@@ -130,6 +132,7 @@ CU_Test(ddsrt_getifaddrs, ipv6)
     CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
     for (ifa = ifa_root; ifa; ifa = ifa->next) {
       CU_ASSERT_PTR_NOT_EQUAL_FATAL(ifa->addr, NULL);
+      assert (ifa->addr != NULL); /* for the benefit of clang's static analyzer */
       CU_ASSERT_EQUAL(ifa->addr->sa_family, AF_INET6);
       if (ifa->addr->sa_family == AF_INET6) {
         have_ipv6 = 1;
@@ -170,6 +173,7 @@ CU_Test(ddsrt_getifaddrs, ipv4_n_ipv6)
     CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
     for (ifa = ifa_root; ifa; ifa = ifa->next) {
       CU_ASSERT_PTR_NOT_EQUAL_FATAL(ifa->addr, NULL);
+      assert (ifa->addr != NULL); /* for the benefit of clang's static analyzer */
       CU_ASSERT(ifa->addr->sa_family == AF_INET ||
                 ifa->addr->sa_family == AF_INET6);
       if (ifa->addr->sa_family == AF_INET) {

--- a/src/ddsrt/tests/log.c
+++ b/src/ddsrt/tests/log.c
@@ -254,11 +254,8 @@ CU_Test(dds_log, no_sink, .init=setup, .fini=teardown)
   ptr = NULL;
   DDS_ERROR("foobaz\n");
   ret = fseek(fh, 0, SEEK_SET);
+  CU_ASSERT_EQUAL_FATAL(ret, 0);
   CU_ASSERT_PTR_NULL(ptr);
-  if (ptr != NULL) {
-    ddsrt_free(ptr);
-    ptr = NULL;
-  }
   buf[0]= '\0';
   cnt[1] = fread(buf, 1, sizeof(buf) - 1, fh);
 #ifdef _WIN32

--- a/src/ddsrt/tests/process_app.c
+++ b/src/ddsrt/tests/process_app.c
@@ -29,9 +29,13 @@ static int test_sleep(int argi, int argc, char **argv)
   argi++;
   if (argi < argc) {
     long long dorment;
-    ddsrt_strtoll(argv[argi], NULL, 0, &dorment);
-    printf(" Process: sleep %d seconds.\n", (int)dorment);
-    dds_sleepfor(DDS_SECS((int64_t)dorment));
+    if (ddsrt_strtoll(argv[argi], NULL, 0, &dorment) != DDS_RETCODE_OK || dorment < 0 || dorment > INT32_MAX) {
+      printf(" Process: invalid --sleep argument.\n");
+      return TEST_EXIT_WRONG_ARGS;
+    } else {
+      printf(" Process: sleep %d seconds.\n", (int)dorment);
+      dds_sleepfor(DDS_SECS((int64_t)dorment));
+    }
   } else {
     printf(" Process: no --sleep value.\n");
     return TEST_EXIT_WRONG_ARGS;

--- a/src/mpt/tests/qos/procs/ppud.c
+++ b/src/mpt/tests/qos/procs/ppud.c
@@ -355,7 +355,7 @@ MPT_ProcessEntry (rwud,
           size_t chkusz = 0;
           if (!qget (chk, &chkud, &chkusz))
             MPT_ASSERT (0, "Check QoS: no %s present\n", qname);
-          MPT_ASSERT (chkusz == expusz && (expusz == 0 || memcmp (chkud, expud, expusz) == 0),
+          MPT_ASSERT (chkusz == expusz && (expusz == 0 || (chkud != NULL && memcmp (chkud, expud, expusz) == 0)),
                       "Retrieved %s differs from group data just set (%zu/%s vs %zu/%s)\n", qname,
                       chkusz, chkud ? (char *) chkud : "(null)", expusz, expud ? (char *) expud : "(null)");
           dds_free (chkud);


### PR DESCRIPTION
What the title subjects: there are a few *serious* bugs, like an inconsistency in locking/unlocking in not-invoking a "data on readers" listener, but most of the them are pretty benign — but needed to be addressed nonetheless, in my view anyway.

This set of changes also has a pretty radical effect on number of issues reported by Coverity and brings the issue density down to more acceptable levels.

I've kept them as separate commits for the benefit of the reviewer, but I propose to squash all trivial ones prior to merging.