### PR TITLE
Fixed missing-field-initializers clang-4 warnings.

### DIFF
--- a/src/core/ddsi/src/q_plist.c
+++ b/src/core/ddsi/src/q_plist.c
@@ -1268,7 +1268,7 @@ static void plist_or_xqos_fini (void * __restrict dst, size_t shift, uint64_t pm
   if (shift > 0)
   {
     dds_qos_t *qos = dst;
-    pfs = (struct flagset) { 0 };
+    pfs = (struct flagset) { NULL, NULL, 0 };
     qfs = (struct flagset) { .present = &qos->present, .aliased = &qos->aliased };
   }
   else
@@ -1310,7 +1310,7 @@ static void plist_or_xqos_unalias (void * __restrict dst, size_t shift)
   if (shift > 0)
   {
     dds_qos_t *qos = dst;
-    pfs = (struct flagset) { 0 };
+    pfs = (struct flagset) { NULL, NULL, 0 };
     qfs = (struct flagset) { .present = &qos->present, .aliased = &qos->aliased };
   }
   else
@@ -1354,9 +1354,9 @@ static void plist_or_xqos_mergein_missing (void * __restrict dst, const void * _
   {
     dds_qos_t *qos_dst = dst;
     const dds_qos_t *qos_src = src;
-    pfs_dst = (struct flagset) { 0 };
+    pfs_dst = (struct flagset) { NULL, NULL, 0 };
     qfs_dst = (struct flagset) { .present = &qos_dst->present, .aliased = &qos_dst->aliased };
-    pfs_src = (struct flagset) { 0 };
+    pfs_src = (struct flagset) { NULL, NULL, 0 };
     qfs_src = (struct flagset) { .present = (uint64_t *) &qos_src->present, .aliased = (uint64_t *) &qos_src->aliased };
   }
   else


### PR DESCRIPTION
Compiling with Clang 4.0.0 causes the following warnings:
```
/home/martinb/cyclone/cyclonedds/src/core/ddsi/src/q_plist.c:1271:32: warning: missing field 'aliased' initializer [-Wmissing-field-initializers]
    pfs = (struct flagset) { 0 };
                               ^
/home/martinb/cyclone/cyclonedds/src/core/ddsi/src/q_plist.c:1313:32: warning: missing field 'aliased' initializer [-Wmissing-field-initializers]
    pfs = (struct flagset) { 0 };
                               ^
/home/martinb/cyclone/cyclonedds/src/core/ddsi/src/q_plist.c:1357:36: warning: missing field 'aliased' initializer [-Wmissing-field-initializers]
    pfs_dst = (struct flagset) { 0 };
                                   ^
/home/martinb/cyclone/cyclonedds/src/core/ddsi/src/q_plist.c:1359:36: warning: missing field 'aliased' initializer [-Wmissing-field-initializers]
    pfs_src = (struct flagset) { 0 };
```

This is fixed.