### PR TITLE
macOS pre-10.13 support

### DIFF
--- a/src/ddsrt/src/time/darwin/time.c
+++ b/src/ddsrt/src/time/darwin/time.c
@@ -13,6 +13,9 @@
 #include <errno.h>
 #include <time.h>
 #include <sys/time.h>
+#if __APPLE__
+#include <AvailabilityMacros.h>
+#endif
 
 #if MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_12
 #include <mach/mach_time.h>

--- a/src/ddsrt/tests/log.c
+++ b/src/ddsrt/tests/log.c
@@ -16,6 +16,7 @@
 
 #ifdef __APPLE__
 #include <pthread.h>
+#include <AvailabilityMacros.h>
 #endif /* __APPLE__ */
 
 #include "CUnit/Test.h"
@@ -27,7 +28,19 @@
 #include "dds/ddsrt/threads.h"
 #include "dds/ddsrt/time.h"
 
-static FILE *fh = NULL;
+/* On macOS, fmemopen was introduced in version 10.13.  The hassle of providing
+   an alternative implementation of it just for running a few sanity checks on an
+   old version of macOS isn't worth the bother.
+
+   The CUnit.cmake boiler-plate generator doesn't recognize #ifdef'ing tests away
+   because it runs on the source rather than on the output of the C preprocessor
+   (a reasonable decision in itself).  Therefore, just skip the body of each test. */
+
+#if __APPLE__ && MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_13
+#define HAVE_FMEMOPEN 0
+#else
+#define HAVE_FMEMOPEN 1
+#endif
 
 #ifdef _WIN32
 #include <fcntl.h>
@@ -104,6 +117,9 @@ FILE *fmemopen(void *buf, size_t size, const char *mode)
 }
 #endif /* _WIN32 */
 
+#if HAVE_FMEMOPEN
+static FILE *fh = NULL;
+
 static void count(void *ptr, const dds_log_data_t *data)
 {
   (void)data;
@@ -114,6 +130,7 @@ static void copy(void *ptr, const dds_log_data_t *data)
 {
   *(char **)ptr = ddsrt_strdup(data->message);
 }
+#endif
 
 static void reset(void)
 {
@@ -125,14 +142,18 @@ static void reset(void)
 
 static void setup(void)
 {
+#if HAVE_FMEMOPEN
   fh = fmemopen(NULL, 1024, "wb+");
   CU_ASSERT_PTR_NOT_NULL_FATAL(fh);
+#endif
 }
 
 static void teardown(void)
 {
   reset();
+#if HAVE_FMEMOPEN
   (void)fclose(fh);
+#endif
 }
 
 /* By default only DDS_LC_FATAL and DDS_LC_ERROR are set. This means setting a
@@ -140,6 +161,7 @@ static void teardown(void)
    enabled. The message should end up in the log file. */
 CU_Test(dds_log, only_log_file, .init=setup, .fini=teardown)
 {
+#if HAVE_FMEMOPEN
   char buf[1024], *ptr;
   int cnt = 0;
   size_t nbytes;
@@ -157,6 +179,7 @@ CU_Test(dds_log, only_log_file, .init=setup, .fini=teardown)
   /* No trace categories are enabled by default, verify trace callback was
      not invoked. */
   CU_ASSERT_EQUAL(cnt, 0);
+#endif
 }
 
 /* Messages must be printed to the trace file if at least one trace category
@@ -164,6 +187,7 @@ CU_Test(dds_log, only_log_file, .init=setup, .fini=teardown)
    same as the log file. */
 CU_Test(dds_log, same_file, .init=setup, .fini=teardown)
 {
+#if HAVE_FMEMOPEN
   char buf[1024], *ptr;
   size_t nbytes;
 
@@ -182,6 +206,7 @@ CU_Test(dds_log, same_file, .init=setup, .fini=teardown)
      occur again. */
   ptr = strstr(ptr + 1, "foobar\n");
   CU_ASSERT_PTR_NULL(ptr);
+#endif
 }
 
 /* The sinks are considered to be the same only if the callback and userdata
@@ -189,6 +214,7 @@ CU_Test(dds_log, same_file, .init=setup, .fini=teardown)
    be called twice for log messages. */
 CU_Test(dds_log, same_sink_function, .fini=reset)
 {
+#if HAVE_FMEMOPEN
   int log_cnt = 0, trace_cnt = 0;
 
   dds_set_log_mask(DDS_LC_ALL);
@@ -197,10 +223,12 @@ CU_Test(dds_log, same_sink_function, .fini=reset)
   DDS_ERROR("foo%s\n", "bar");
   CU_ASSERT_EQUAL(log_cnt, 1);
   CU_ASSERT_EQUAL(trace_cnt, 1);
+#endif
 }
 
 CU_Test(dds_log, exact_same_sink, .fini=reset)
 {
+#if HAVE_FMEMOPEN
   int cnt = 0;
 
   dds_set_log_mask(DDS_LC_ALL);
@@ -208,6 +236,7 @@ CU_Test(dds_log, exact_same_sink, .fini=reset)
   dds_set_trace_sink(&count, &cnt);
   DDS_ERROR("foo%s\n", "bar");
   CU_ASSERT_EQUAL(cnt, 1);
+#endif
 }
 
 /* The log file must be restored if the sink is unregistered, verify the log
@@ -215,6 +244,7 @@ CU_Test(dds_log, exact_same_sink, .fini=reset)
    restored again when the sink is unregistered. */
 CU_Test(dds_log, no_sink, .init=setup, .fini=teardown)
 {
+#if HAVE_FMEMOPEN
   int ret;
   char buf[1024], *ptr = NULL;
   size_t cnt[2] = {0, 0};
@@ -267,6 +297,7 @@ CU_Test(dds_log, no_sink, .init=setup, .fini=teardown)
   buf[cnt[1]] = '\0';
   ptr = strstr(buf, "foobaz\n");
   CU_ASSERT_PTR_NOT_NULL_FATAL(ptr);
+#endif
 }
 
 /* A newline terminates the message. Until that a newline is encountered, the
@@ -274,6 +305,7 @@ CU_Test(dds_log, no_sink, .init=setup, .fini=teardown)
    NULL byte if it is flushed to a sink. */
 CU_Test(dds_log, newline_terminates, .fini=reset)
 {
+#if HAVE_FMEMOPEN
   char *msg = NULL;
 
   dds_set_log_sink(&copy, &msg);
@@ -285,11 +317,13 @@ CU_Test(dds_log, newline_terminates, .fini=reset)
   CU_ASSERT_PTR_NOT_NULL_FATAL(msg);
   CU_ASSERT(strcmp(msg, "foobarbaz\n") == 0);
   ddsrt_free(msg);
+#endif
 }
 
 /* Nothing must be written unless a category is enabled. */
 CU_Test(dds_log, disabled_categories_discarded, .fini=reset)
 {
+#if HAVE_FMEMOPEN
   char *msg = NULL;
   dds_set_log_sink(&copy, &msg);
   DDS_INFO("foobar\n");
@@ -299,9 +333,10 @@ CU_Test(dds_log, disabled_categories_discarded, .fini=reset)
   CU_ASSERT_PTR_NOT_NULL_FATAL(msg);
   CU_ASSERT(strcmp(msg, "foobar\n") == 0);
   ddsrt_free(msg);
+#endif
 }
 
-
+#if HAVE_FMEMOPEN
 static ddsrt_cond_t cond;
 static ddsrt_mutex_t mutex;
 
@@ -337,12 +372,14 @@ static uint32_t run(void *ptr)
 
   return 0;
 }
+#endif
 
 /* Log and trace sinks can be changed at runtime. However, the operation must
    be synchronous! Verify the dds_set_log_sink blocks while other threads
    reside in the log or trace sinks. */
 CU_Test(dds_log, synchronous_sink_changes, .fini=reset)
 {
+#if HAVE_FMEMOPEN
   struct arg arg;
   ddsrt_thread_t tid;
   ddsrt_threadattr_t tattr;
@@ -364,4 +401,5 @@ CU_Test(dds_log, synchronous_sink_changes, .fini=reset)
 
   CU_ASSERT(arg.before < arg.after);
   CU_ASSERT(arg.after < dds_time());
+#endif
 }


### PR DESCRIPTION
macOS 10.13 is the first version to provide fmemopen and so building Cyclone (with BUILD_TESTING enabled) fails on older versions. That's somewhat annoying given that ROS2 very much supports macOS 10.12 still. This PR simply turns the handful of logging tests that depend on it into no-ops on macOS 10.12 and older.

It also adds a missing ``#include <AvailabilityMacros.h>`` needed for properly detecting whether ``clock_gettime_nsec_np`` exists. That only affects macOS 10.11 and older.

This should fix https://github.com/ros2/ros2/pull/787#issuecomment-536115180