### PR TITLE
Fix building tests on macOS 10.12

### DIFF
--- a/src/ddsrt/src/time/darwin/time.c
+++ b/src/ddsrt/src/time/darwin/time.c
@@ -13,11 +13,9 @@
 #include <errno.h>
 #include <time.h>
 #include <sys/time.h>
-#if __APPLE__
 #include <AvailabilityMacros.h>
-#endif
 
-#if MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_12
+#if !(defined MAC_OS_X_VERSION_10_12 && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12)
 #include <mach/mach_time.h>
 #endif
 
@@ -25,7 +23,7 @@
 
 dds_time_t dds_time(void)
 {
-#if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12
+#if defined MAC_OS_X_VERSION_10_12 && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12
   return (int64_t) clock_gettime_nsec_np (CLOCK_REALTIME);
 #else
   struct timeval tv;
@@ -36,7 +34,7 @@ dds_time_t dds_time(void)
 
 dds_time_t ddsrt_time_monotonic(void)
 {
-#if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12
+#if defined MAC_OS_X_VERSION_10_12 && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12
   return (int64_t) clock_gettime_nsec_np (CLOCK_UPTIME_RAW);
 #else
   static mach_timebase_info_data_t timeInfo;
@@ -65,7 +63,7 @@ dds_time_t ddsrt_time_monotonic(void)
 
 dds_time_t ddsrt_time_elapsed(void)
 {
-#if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12
+#if defined MAC_OS_X_VERSION_10_12 && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12
   return (int64_t) clock_gettime_nsec_np (CLOCK_MONOTONIC_RAW);
 #else
   /* Elapsed time clock not (yet) supported on this platform. */

--- a/src/ddsrt/tests/log.c
+++ b/src/ddsrt/tests/log.c
@@ -36,7 +36,7 @@
    because it runs on the source rather than on the output of the C preprocessor
    (a reasonable decision in itself).  Therefore, just skip the body of each test. */
 
-#if __APPLE__ && MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_13
+#if __APPLE__ && !(defined MAC_OS_X_VERSION_10_13 && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_13)
 #define HAVE_FMEMOPEN 0
 #else
 #define HAVE_FMEMOPEN 1


### PR DESCRIPTION
* Clang 9 does not yet define MAC_OS_X_VERSION_10_13

  Which breaks the test for macOS versions older than 10.13 when
  building on an older system.

Signed-off-by: Erik Boasson <eb@ilities.com>