### PR TITLE
macOS 10.12 Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,6 +87,33 @@ osx_xcode10_3: &osx_xcode10_3
     - pyenv activate conan
     - pip install conan --upgrade
 
+# macOS 10.12 / Xcode 9 is the macOS platform for ROS2, and hence quite important.  Travis
+# supports it, but the homebrew version on that image is outdated, and updating it takes
+# forever.  Well, not quite forever, but much longer than building CMake from source.
+#
+# make -k install || true installs into /usr/local while ignoring any errors.  The first
+# is so CMake for Cyclone finds it without any complications; the second is because it
+# can't install into /usr/local/doc.
+#
+# It also means we have to do without conan -- but currently the build dependencies on
+# macOS are still simple enough to get away with that.
+osx_xcode9: &osx_xcode9
+  os: osx
+  osx_image: xcode9
+  compiler: clang
+  before_install:
+    - eval "export CC=clang"
+    - eval "export CXX=clang++"
+    - eval "export COV_COMPTYPE=clang COV_PLATFORM=macOSX"
+    - wget http://downloads.sourceforge.net/project/cunit/CUnit/2.1-2/CUnit-2.1-2-src.tar.bz2
+    - tar -xvjpf CUnit-2.1-2-src.tar.bz2
+    - cd CUnit-2.1-2
+    - ./configure
+    - make
+    - make -k install || true
+    - cd ..
+    - rm -rf CUnit-2.1-2
+
 windows_vs2017: &windows_vs2017
   os: windows
   # Conan will automatically determine the best compiler for a given platform
@@ -133,34 +160,38 @@ windows_vs2017: &windows_vs2017
 jobs:
   include:
     - <<: *linux_gcc8
-      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Debug, SSL=YES, GENERATOR="Unix Makefiles", COVERITY_SCAN=true ]
+      env: [ ARCH=x86_64, CONAN=true, ASAN=none, BUILD_TYPE=Debug, SSL=YES, GENERATOR="Unix Makefiles", COVERITY_SCAN=true ]
       if: type = cron
     - <<: *linux_gcc8
-      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Debug, SSL=YES, GENERATOR="Unix Makefiles" ]
+      env: [ ARCH=x86_64, CONAN=true, ASAN=none, BUILD_TYPE=Debug, SSL=YES, GENERATOR="Unix Makefiles" ]
     - <<: *linux_gcc8
-      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, SSL=YES, GENERATOR="Unix Makefiles" ]
+      env: [ ARCH=x86_64, CONAN=true, ASAN=none, BUILD_TYPE=Release, SSL=YES, GENERATOR="Unix Makefiles" ]
     - <<: *linux_gcc8
-      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Debug, SSL=NO, GENERATOR="Unix Makefiles" ]
+      env: [ ARCH=x86_64, CONAN=true, ASAN=none, BUILD_TYPE=Debug, SSL=NO, GENERATOR="Unix Makefiles" ]
     - <<: *linux_gcc8
-      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, SSL=YES, GENERATOR="Unix Makefiles" ]
+      env: [ ARCH=x86_64, CONAN=true, ASAN=none, BUILD_TYPE=Release, SSL=YES, GENERATOR="Unix Makefiles" ]
     - <<: *linux_clang
-      env: [ ARCH=x86_64, ASAN=address, BUILD_TYPE=Debug, SSL=YES, GENERATOR="Unix Makefiles" ]
+      env: [ ARCH=x86_64, CONAN=true, ASAN=address, BUILD_TYPE=Debug, SSL=YES, GENERATOR="Unix Makefiles" ]
     - <<: *linux_clang
-      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, SSL=YES, GENERATOR="Unix Makefiles" ]
+      env: [ ARCH=x86_64, CONAN=true, ASAN=none, BUILD_TYPE=Release, SSL=YES, GENERATOR="Unix Makefiles" ]
     - <<: *osx_xcode10_3
-      env: [ ARCH=x86_64, ASAN=address, BUILD_TYPE=Debug, SSL=YES, GENERATOR="Unix Makefiles" ]
+      env: [ ARCH=x86_64, CONAN=true, ASAN=address, BUILD_TYPE=Debug, SSL=YES, GENERATOR="Unix Makefiles" ]
     - <<: *osx_xcode10_3
-      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, SSL=YES, GENERATOR="Unix Makefiles" ]
+      env: [ ARCH=x86_64, CONAN=true, ASAN=none, BUILD_TYPE=Release, SSL=YES, GENERATOR="Unix Makefiles" ]
+    - <<: *osx_xcode9
+      env: [ ARCH=x86_64, CONAN=false, ASAN=none, BUILD_TYPE=Release, SSL=NO, GENERATOR="Unix Makefiles" ]
     - <<: *windows_vs2017
-      env: [ ARCH=x86, ASAN=none, BUILD_TYPE=Debug, SSL=YES, GENERATOR="Visual Studio 15 2017" ]
+      env: [ ARCH=x86, CONAN=true, ASAN=none, BUILD_TYPE=Debug, SSL=YES, GENERATOR="Visual Studio 15 2017" ]
     - <<: *windows_vs2017
-      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Debug, SSL=YES, GENERATOR="Visual Studio 15 2017 Win64" ]
+      env: [ ARCH=x86_64, CONAN=true, ASAN=none, BUILD_TYPE=Debug, SSL=YES, GENERATOR="Visual Studio 15 2017 Win64" ]
     - <<: *windows_vs2017
-      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, SSL=YES, GENERATOR="Visual Studio 15 2017 Win64" ]
+      env: [ ARCH=x86_64, CONAN=true, ASAN=none, BUILD_TYPE=Release, SSL=YES, GENERATOR="Visual Studio 15 2017 Win64" ]
 
 before_script:
-  - conan profile new default --detect
-  - conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan
+  - if $CONAN ; then
+      conan profile new default --detect ;
+      conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan ;
+    fi
 
 # Notes on test settings:
 # - CYCLONEDDS_URI:
@@ -181,7 +212,7 @@ before_script:
 script:
   - mkdir build
   - cd build
-  - conan install -b missing -s arch=${ARCH} -s build_type=${BUILD_TYPE} ..
+  - if $CONAN ; then conan install -b missing -s arch=${ARCH} -s build_type=${BUILD_TYPE} .. ; fi
   - cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
           -DCMAKE_INSTALL_PREFIX=$(pwd)/install
           -DUSE_SANITIZER=${ASAN}

--- a/src/ddsrt/src/time/darwin/time.c
+++ b/src/ddsrt/src/time/darwin/time.c
@@ -13,11 +13,9 @@
 #include <errno.h>
 #include <time.h>
 #include <sys/time.h>
-#if __APPLE__
 #include <AvailabilityMacros.h>
-#endif
 
-#if MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_12
+#if !(defined MAC_OS_X_VERSION_10_12 && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12)
 #include <mach/mach_time.h>
 #endif
 
@@ -25,7 +23,7 @@
 
 dds_time_t dds_time(void)
 {
-#if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12
+#if defined MAC_OS_X_VERSION_10_12 && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12
   return (int64_t) clock_gettime_nsec_np (CLOCK_REALTIME);
 #else
   struct timeval tv;
@@ -36,7 +34,7 @@ dds_time_t dds_time(void)
 
 dds_time_t ddsrt_time_monotonic(void)
 {
-#if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12
+#if defined MAC_OS_X_VERSION_10_12 && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12
   return (int64_t) clock_gettime_nsec_np (CLOCK_UPTIME_RAW);
 #else
   static mach_timebase_info_data_t timeInfo;
@@ -65,7 +63,7 @@ dds_time_t ddsrt_time_monotonic(void)
 
 dds_time_t ddsrt_time_elapsed(void)
 {
-#if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12
+#if defined MAC_OS_X_VERSION_10_12 && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12
   return (int64_t) clock_gettime_nsec_np (CLOCK_MONOTONIC_RAW);
 #else
   /* Elapsed time clock not (yet) supported on this platform. */

--- a/src/ddsrt/tests/log.c
+++ b/src/ddsrt/tests/log.c
@@ -36,7 +36,7 @@
    because it runs on the source rather than on the output of the C preprocessor
    (a reasonable decision in itself).  Therefore, just skip the body of each test. */
 
-#if __APPLE__ && MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_13
+#if __APPLE__ && !(defined MAC_OS_X_VERSION_10_13 && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_13)
 #define HAVE_FMEMOPEN 0
 #else
 #define HAVE_FMEMOPEN 1


### PR DESCRIPTION
This PR is the part of #265 removed by reducing it to just the code changes needed for building the tests on macOS 10.12. That was done to be able to merge the code changes and make progress on automated ROS2 mac builds, without importing an arguably "overly pragmatic" approach to the CI builds.

Copy-paste from the relevant comment by @k0ekk0ek on #265:

> I don't like the chosen solution. I'd much prefer that you'd install Conan and install CUnit using that. I feel taking the quick route with things like this is a slippery slope (one more exception to cover and no guarantee that each build target has Conan). An installer exists for Windows, but does not for macOS. The Homebrew installation on the xcode9 images is probably too old? Do you happen to know if Python is available on the image? If so, doing a shallow git clone of the Conan repo and setting the path could be a way to go...

Hopefully a clean solution will be possible, but it looks like it may take some time to get there. For the time being I'm putting this icky, hacky solution in its own PR so that it doesn't get lost.