### PR TITLE
Add macOS 10.12 / Xcode 9 build on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,18 +74,36 @@ osx_xcode10_3: &osx_xcode10_3
   compiler: clang
   addons:
     homebrew:
-      packages:
-      - pyenv-virtualenv
+      packages: [ python3 ]
   before_install:
     - eval "export CC=clang"
     - eval "export CXX=clang++"
     - eval "export COV_COMPTYPE=clang COV_PLATFORM=macOSX"
+    - eval "export PATH=\"${PATH}:$(python3 -m site --user-base)/bin\""
   install:
-    - eval "$(pyenv init -)"
-    - pyenv virtualenv conan
-    - pyenv rehash
-    - pyenv activate conan
-    - pip install conan --upgrade
+    - pip3 install conan --upgrade --user
+
+osx_xcode9: &osx_xcode9
+  <<: *osx_xcode10_3
+  osx_image: xcode9
+  cache:
+    directories:
+      - $HOME/Library/Caches/Homebrew
+      - /usr/local/Homebrew
+  addons:
+    homebrew:
+      packages: [ python3 ]
+      # Homebrew must be updated before packages can be installed on outdated
+      # macOS images. The update process unfortunately takes a VERY long time
+      # and can even cause Travis to terminate the build. Travis caching is
+      # used to ensure Homebrew is kept up-to-date and build times are kept to
+      # a minimum.
+      update: true
+  before_cache:
+    - brew cleanup
+    - find /usr/local/Homebrew -type d -name .git |
+      xargs -I {} dirname {} |
+      xargs -I {} git --git-dir={}/.git --work-tree={} clean -f -d -x
 
 windows_vs2017: &windows_vs2017
   os: windows
@@ -147,6 +165,8 @@ jobs:
       env: [ ARCH=x86_64, ASAN=address, BUILD_TYPE=Debug, SSL=YES, GENERATOR="Unix Makefiles" ]
     - <<: *linux_clang
       env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, SSL=YES, GENERATOR="Unix Makefiles" ]
+    - <<: *osx_xcode9
+      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, SSL=NO, GENERATOR="Unix Makefiles" ]
     - <<: *osx_xcode10_3
       env: [ ARCH=x86_64, ASAN=address, BUILD_TYPE=Debug, SSL=YES, GENERATOR="Unix Makefiles" ]
     - <<: *osx_xcode10_3


### PR DESCRIPTION
This PR adds a macOS 10.12 / Xcode 9 build to Travis. What's different from the other macOS builds is that *caching* is enabled and Homebrew is automatically updated. It'll take much longer for the initial build to complete, but build time should be reasonable afterwards (+2m in comparison to other macOS builds, or rather, still quicker than Windows :sweat_smile:). Automatic updates and caching have not been enabled for the more recent macOS builds because they have a negative impact (cause by the automatic updates).

Please consider pulling these changes.