### PR TITLE
Added DDS Security XML configuration elements.

### DIFF
--- a/src/core/ddsc/tests/CMakeLists.txt
+++ b/src/core/ddsc/tests/CMakeLists.txt
@@ -54,7 +54,8 @@ set(ddsc_test_sources
 add_cunit_executable(cunit_ddsc ${ddsc_test_sources})
 target_include_directories(
   cunit_ddsc PRIVATE
-  "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src/include/>")
+  "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src/include/>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../ddsi/include/>")
 target_link_libraries(cunit_ddsc PRIVATE RoundTrip Space TypesArrayKey ddsc)
 
 # Setup environment for config-tests

--- a/src/core/ddsc/tests/config.c
+++ b/src/core/ddsc/tests/config.c
@@ -158,6 +158,12 @@ static bool patternmatch(const char* pattern, const char* string)
     }
 }
 
+/*
+ * The 'found' variable will contain flags related to the expected log
+ * messages that were received.
+ * Using flags will allow to show that when message isn't received,
+ * which one it was.
+ */
 static uint32_t found;
 static void logger(void *ptr, const dds_log_data_t *data)
 {
@@ -167,6 +173,33 @@ static void logger(void *ptr, const dds_log_data_t *data)
             found |= (uint32_t)(1 << i);
         }
     }
+}
+
+CU_Test(ddsc_config, security_non, .init = ddsrt_init, .fini = ddsrt_fini) {
+
+    /* There shouldn't be traces that mention security. */
+    const char *log_expected[] = {
+      "*Security*",
+      NULL
+    };
+
+    dds_entity_t participant;
+
+    /* Set up the trace sinks to detect the config parsing. */
+    dds_set_log_mask(DDS_LC_FATAL|DDS_LC_ERROR|DDS_LC_WARNING|DDS_LC_CONFIG);
+    dds_set_log_sink(&logger, (void*)log_expected);
+    dds_set_trace_sink(&logger, (void*)log_expected);
+
+    /* Create participant with an empty security element. */
+    found = 0;
+    ddsrt_setenv(URI_VARIABLE, "<Tracing><Verbosity>finest</></>");
+    participant = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL, NULL);
+    ddsrt_setenv(URI_VARIABLE, "");
+    CU_ASSERT_FATAL(participant > 0);
+    dds_delete(participant);
+
+    /* No security traces should have been provided. */
+    CU_ASSERT_FATAL(found == 0x0);
 }
 
 CU_Test(ddsc_config, security_empty, .init = ddsrt_init, .fini = ddsrt_fini) {
@@ -243,8 +276,6 @@ CU_Test(ddsc_config, security_missing, .init = ddsrt_init, .fini = ddsrt_fini) {
 
     dds_entity_t participant;
 
-    ddsrt_setenv(URI_VARIABLE, sec_config);
-
     /* Set up the trace sinks to detect the config parsing. */
     dds_set_log_mask(DDS_LC_FATAL|DDS_LC_ERROR|DDS_LC_WARNING|DDS_LC_CONFIG);
     dds_set_log_sink(&logger, (void*)log_expected);
@@ -265,7 +296,7 @@ CU_Test(ddsc_config, security_missing, .init = ddsrt_init, .fini = ddsrt_fini) {
 #endif
 }
 
-CU_Test(ddsc_config, security, .init = ddsrt_init, .fini = ddsrt_fini) {
+CU_Test(ddsc_config, security_all, .init = ddsrt_init, .fini = ddsrt_fini) {
 
     /* Expected traces when creating participant with the security elements. */
     const char *log_expected[] = {
@@ -280,7 +311,7 @@ CU_Test(ddsc_config, security, .init = ddsrt_init, .fini = ddsrt_fini) {
       "config: Domain/DDSSecurity/Authentication/IdentityCA/#text: testtext_IdentityCA_testtext*",
       "config: Domain/DDSSecurity/Authentication/PrivateKey/#text: testtext_PrivateKey_testtext*",
       "config: Domain/DDSSecurity/Authentication/Password/#text: testtext_Password_testtext*",
-      "config: Domain/DDSSecurity/Authentication/TrustedCADirectory/#text:*",
+      "config: Domain/DDSSecurity/Authentication/TrustedCADirectory/#text: testtext_Dir_testtext*",
       "config: Domain/DDSSecurity/AccessControl/Library/#text: dds_security_ac*",
       "config: Domain/DDSSecurity/AccessControl/Library[@path]: dds_security_ac*",
       "config: Domain/DDSSecurity/AccessControl/Library[@initFunction]: init_ac*",
@@ -293,7 +324,89 @@ CU_Test(ddsc_config, security, .init = ddsrt_init, .fini = ddsrt_fini) {
       "config: Domain/DDSSecurity/Cryptographic/Library[@initFunction]: init_crypto*",
       "config: Domain/DDSSecurity/Cryptographic/Library[@finalizeFunction]: finalize_crypto*",
       /* The config should have been parsed into the participant QoS. */
-      "PARTICIPANT * QOS={*property_list={value={{dds.sec.auth.identity_ca,testtext_IdentityCA_testtext,0},{dds.sec.auth.private_key,testtext_PrivateKey_testtext,0},{dds.sec.auth.identity_certificate,testtext_IdentityCertificate_testtext,0},{dds.sec.access.permissions_ca,file:Permissions_CA.pem,0},{dds.sec.access.governance,file:Governance.p7s,0},{dds.sec.access.permissions,file:Permissions.p7s,0},{dds.sec.auth.password,testtext_Password_testtext,0}}binary_value={}}*}*",
+      "PARTICIPANT * QOS={*property_list={value={{dds.sec.auth.identity_ca,testtext_IdentityCA_testtext,0},{dds.sec.auth.private_key,testtext_PrivateKey_testtext,0},{dds.sec.auth.identity_certificate,testtext_IdentityCertificate_testtext,0},{dds.sec.access.permissions_ca,file:Permissions_CA.pem,0},{dds.sec.access.governance,file:Governance.p7s,0},{dds.sec.access.permissions,file:Permissions.p7s,0},{dds.sec.auth.password,testtext_Password_testtext,0},{dds.sec.auth.trusted_ca_dir,testtext_Dir_testtext,0}}binary_value={}}*}*",
+#endif
+      NULL
+    };
+
+    const char *sec_config =
+      "<"DDS_PROJECT_NAME">"
+        "<Domain id=\"any\">"
+          "<Tracing><Verbosity>finest</></>"
+          "<DDSSecurity>"
+            "<Authentication>"
+              "<Library path=\"dds_security_auth\" initFunction=\"init_authentication\" finalizeFunction=\"finalize_authentication\" />"
+              "<IdentityCertificate>testtext_IdentityCertificate_testtext</IdentityCertificate>"
+              "<IdentityCA>testtext_IdentityCA_testtext</IdentityCA>"
+              "<PrivateKey>testtext_PrivateKey_testtext</PrivateKey>"
+              "<Password>testtext_Password_testtext</Password>"
+              "<TrustedCADirectory>testtext_Dir_testtext</TrustedCADirectory>"
+            "</Authentication>"
+            "<Cryptographic>"
+              "<Library path=\"dds_security_crypto\" initFunction=\"init_crypto\" finalizeFunction=\"finalize_crypto\"/>"
+            "</Cryptographic>"
+            "<AccessControl>"
+              "<Library path=\"dds_security_ac\" initFunction=\"init_ac\" finalizeFunction=\"finalize_ac\"/>"
+              "<Governance>file:Governance.p7s</Governance>"
+              "<PermissionsCA>file:Permissions_CA.pem</PermissionsCA>"
+              "<Permissions>file:Permissions.p7s</Permissions>"
+            "</AccessControl>"
+          "</DDSSecurity>"
+        "</Domain>"
+      "</"DDS_PROJECT_NAME">";
+
+
+    dds_entity_t participant;
+
+    /* Set up the trace sinks to detect the config parsing. */
+    dds_set_log_mask(DDS_LC_FATAL|DDS_LC_ERROR|DDS_LC_WARNING|DDS_LC_CONFIG);
+    dds_set_log_sink(&logger, (void*)log_expected);
+    dds_set_trace_sink(&logger, (void*)log_expected);
+
+    /* Create participant with security elements. */
+    found = 0;
+    ddsrt_setenv(URI_VARIABLE, sec_config);
+    participant = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL, NULL);
+    ddsrt_setenv(URI_VARIABLE, "");
+    dds_delete(participant);
+
+    /* All traces should have been provided. */
+#ifndef DDSI_INCLUDE_SECURITY
+    CU_ASSERT_FATAL(found == 0x1);
+#else
+    CU_ASSERT_FATAL(found == 0x1fffff);
+#endif
+}
+
+CU_Test(ddsc_config, security, .init = ddsrt_init, .fini = ddsrt_fini) {
+
+    /* Expected traces when creating participant with the security elements. */
+    const char *log_expected[] = {
+#ifndef DDSI_INCLUDE_SECURITY
+      "config: //CycloneDDS/Domain: DDSSecurity: unknown element*",
+#else
+      "config: Domain/DDSSecurity/Authentication/Library/#text: dds_security_auth*",
+      "config: Domain/DDSSecurity/Authentication/Library[@path]: dds_security_auth*",
+      "config: Domain/DDSSecurity/Authentication/Library[@initFunction]: init_authentication*",
+      "config: Domain/DDSSecurity/Authentication/Library[@finalizeFunction]: finalize_authentication*",
+      "config: Domain/DDSSecurity/Authentication/IdentityCertificate/#text: testtext_IdentityCertificate_testtext*",
+      "config: Domain/DDSSecurity/Authentication/IdentityCA/#text: testtext_IdentityCA_testtext*",
+      "config: Domain/DDSSecurity/Authentication/PrivateKey/#text: testtext_PrivateKey_testtext*",
+      "config: Domain/DDSSecurity/Authentication/Password/#text:  {}*",
+      "config: Domain/DDSSecurity/Authentication/TrustedCADirectory/#text:  {}*",
+      "config: Domain/DDSSecurity/AccessControl/Library/#text: dds_security_ac*",
+      "config: Domain/DDSSecurity/AccessControl/Library[@path]: dds_security_ac*",
+      "config: Domain/DDSSecurity/AccessControl/Library[@initFunction]: init_ac*",
+      "config: Domain/DDSSecurity/AccessControl/Library[@finalizeFunction]: finalize_ac*",
+      "config: Domain/DDSSecurity/AccessControl/PermissionsCA/#text: file:Permissions_CA.pem*",
+      "config: Domain/DDSSecurity/AccessControl/Governance/#text: file:Governance.p7s*",
+      "config: Domain/DDSSecurity/AccessControl/Permissions/#text: file:Permissions.p7s*",
+      "config: Domain/DDSSecurity/Cryptographic/Library/#text: dds_security_crypto*",
+      "config: Domain/DDSSecurity/Cryptographic/Library[@path]: dds_security_crypto*",
+      "config: Domain/DDSSecurity/Cryptographic/Library[@initFunction]: init_crypto*",
+      "config: Domain/DDSSecurity/Cryptographic/Library[@finalizeFunction]: finalize_crypto*",
+      /* The config should have been parsed into the participant QoS. */
+      "PARTICIPANT * QOS={*property_list={value={{dds.sec.auth.identity_ca,testtext_IdentityCA_testtext,0},{dds.sec.auth.private_key,testtext_PrivateKey_testtext,0},{dds.sec.auth.identity_certificate,testtext_IdentityCertificate_testtext,0},{dds.sec.access.permissions_ca,file:Permissions_CA.pem,0},{dds.sec.access.governance,file:Governance.p7s,0},{dds.sec.access.permissions,file:Permissions.p7s,0}}binary_value={}}*}*",
 #endif
       NULL
     };
@@ -306,7 +419,6 @@ CU_Test(ddsc_config, security, .init = ddsrt_init, .fini = ddsrt_fini) {
           "<IdentityCertificate>testtext_IdentityCertificate_testtext</IdentityCertificate>"
           "<IdentityCA>testtext_IdentityCA_testtext</IdentityCA>"
           "<PrivateKey>testtext_PrivateKey_testtext</PrivateKey>"
-          "<Password>testtext_Password_testtext</Password>"
         "</Authentication>"
           "<Cryptographic>"
             "<Library path=\"dds_security_crypto\" initFunction=\"init_crypto\" finalizeFunction=\"finalize_crypto\"/>"
@@ -322,7 +434,90 @@ CU_Test(ddsc_config, security, .init = ddsrt_init, .fini = ddsrt_fini) {
 
     dds_entity_t participant;
 
+    /* Set up the trace sinks to detect the config parsing. */
+    dds_set_log_mask(DDS_LC_FATAL|DDS_LC_ERROR|DDS_LC_WARNING|DDS_LC_CONFIG);
+    dds_set_log_sink(&logger, (void*)log_expected);
+    dds_set_trace_sink(&logger, (void*)log_expected);
+
+    /* Create participant with security elements. */
+    found = 0;
     ddsrt_setenv(URI_VARIABLE, sec_config);
+    participant = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL, NULL);
+    ddsrt_setenv(URI_VARIABLE, "");
+    dds_delete(participant);
+
+    /* All traces should have been provided. */
+#ifndef DDSI_INCLUDE_SECURITY
+    CU_ASSERT_FATAL(found == 0x1);
+#else
+    CU_ASSERT_FATAL(found == 0x1fffff);
+#endif
+}
+
+CU_Test(ddsc_config, security_deprecated, .init = ddsrt_init, .fini = ddsrt_fini) {
+
+    /* Expected traces when creating participant with the security elements. */
+    const char *log_expected[] = {
+#ifndef DDSI_INCLUDE_SECURITY
+      "config: //CycloneDDS/Domain: DDSSecurity: unknown element*",
+#else
+      "config: Domain/DDSSecurity/Authentication/Library/#text: dds_security_auth*",
+      "config: Domain/DDSSecurity/Authentication/Library[@path]: dds_security_auth*",
+      "config: Domain/DDSSecurity/Authentication/Library[@initFunction]: init_authentication*",
+      "config: Domain/DDSSecurity/Authentication/Library[@finalizeFunction]: finalize_authentication*",
+      "config: Domain/DDSSecurity/Authentication/IdentityCertificate/#text: testtext_IdentityCertificate_testtext*",
+      "config: Domain/DDSSecurity/Authentication/IdentityCA/#text: testtext_IdentityCA_testtext*",
+      "config: Domain/DDSSecurity/Authentication/PrivateKey/#text: testtext_PrivateKey_testtext*",
+      "config: Domain/DDSSecurity/Authentication/Password/#text: testtext_Password_testtext*",
+      "config: Domain/DDSSecurity/Authentication/TrustedCADirectory/#text: testtext_Dir_testtext*",
+      "config: Domain/DDSSecurity/AccessControl/Library/#text: dds_security_ac*",
+      "config: Domain/DDSSecurity/AccessControl/Library[@path]: dds_security_ac*",
+      "config: Domain/DDSSecurity/AccessControl/Library[@initFunction]: init_ac*",
+      "config: Domain/DDSSecurity/AccessControl/Library[@finalizeFunction]: finalize_ac*",
+      "config: Domain/DDSSecurity/AccessControl/PermissionsCA/#text: file:Permissions_CA.pem*",
+      "config: Domain/DDSSecurity/AccessControl/Governance/#text: file:Governance.p7s*",
+      "config: Domain/DDSSecurity/AccessControl/Permissions/#text: file:Permissions.p7s*",
+      "config: Domain/DDSSecurity/Cryptographic/Library/#text: dds_security_crypto*",
+      "config: Domain/DDSSecurity/Cryptographic/Library[@path]: dds_security_crypto*",
+      "config: Domain/DDSSecurity/Cryptographic/Library[@initFunction]: init_crypto*",
+      "config: Domain/DDSSecurity/Cryptographic/Library[@finalizeFunction]: finalize_crypto*",
+      /* The config should have been parsed into the participant QoS. */
+      "PARTICIPANT * QOS={*property_list={value={{dds.sec.auth.identity_ca,testtext_IdentityCA_testtext,0},{dds.sec.auth.private_key,testtext_PrivateKey_testtext,0},{dds.sec.auth.identity_certificate,testtext_IdentityCertificate_testtext,0},{dds.sec.access.permissions_ca,file:Permissions_CA.pem,0},{dds.sec.access.governance,file:Governance.p7s,0},{dds.sec.access.permissions,file:Permissions.p7s,0},{dds.sec.auth.password,testtext_Password_testtext,0},{dds.sec.auth.trusted_ca_dir,testtext_Dir_testtext,0}}binary_value={}}*}*",
+#endif
+      NULL
+    };
+
+    const char *sec_config =
+      "<"DDS_PROJECT_NAME">"
+        "<Domain>"
+          "<Id>any</Id>"
+        "</Domain>"
+        "<DDSI2E>"
+          "<DDSSecurity>"
+            "<Authentication>"
+              "<Library path=\"dds_security_auth\" initFunction=\"init_authentication\" finalizeFunction=\"finalize_authentication\" />"
+              "<IdentityCertificate>testtext_IdentityCertificate_testtext</IdentityCertificate>"
+              "<IdentityCA>testtext_IdentityCA_testtext</IdentityCA>"
+              "<PrivateKey>testtext_PrivateKey_testtext</PrivateKey>"
+              "<Password>testtext_Password_testtext</Password>"
+              "<TrustedCADirectory>testtext_Dir_testtext</TrustedCADirectory>"
+            "</Authentication>"
+            "<Cryptographic>"
+              "<Library path=\"dds_security_crypto\" initFunction=\"init_crypto\" finalizeFunction=\"finalize_crypto\"/>"
+            "</Cryptographic>"
+            "<AccessControl>"
+              "<Library path=\"dds_security_ac\" initFunction=\"init_ac\" finalizeFunction=\"finalize_ac\"/>"
+              "<Governance>file:Governance.p7s</Governance>"
+              "<PermissionsCA>file:Permissions_CA.pem</PermissionsCA>"
+              "<Permissions>file:Permissions.p7s</Permissions>"
+            "</AccessControl>"
+          "</DDSSecurity>"
+          "<Tracing><Verbosity>finest</></>"
+        "</DDSI2E>"
+      "</"DDS_PROJECT_NAME">";
+
+
+    dds_entity_t participant;
 
     /* Set up the trace sinks to detect the config parsing. */
     dds_set_log_mask(DDS_LC_FATAL|DDS_LC_ERROR|DDS_LC_WARNING|DDS_LC_CONFIG);

--- a/src/core/ddsc/tests/config.c
+++ b/src/core/ddsc/tests/config.c
@@ -19,6 +19,7 @@
 #include "dds/ddsrt/cdtors.h"
 #include "dds/ddsrt/environ.h"
 #include "dds/ddsrt/heap.h"
+#include "dds/ddsi/q_misc.h"
 
 #define FORCE_ENV
 
@@ -119,45 +120,6 @@ CU_Test(ddsc_config, incorrect_config, .init = ddsrt_init, .fini = ddsrt_fini) {
     CU_ASSERT_FATAL(dds_create_domain(2, "") == DDS_RETCODE_PRECONDITION_NOT_MET);
 }
 
-static bool patternmatch(const char* pattern, const char* string)
-{
-    char patterncharacter;
-
-    /* iterate over pattern string */
-    for (;;) {
-        patterncharacter = *pattern;
-        pattern++;
-        switch (patterncharacter) {
-        case '\0':
-            return (*string == '\0');
-        case '?':
-            if (*string == '\0') {
-                return false;
-            }
-            ++string;
-            break;
-        case '*':
-            if (*pattern == '\0'){
-                return true;
-            }
-            while (*string != '\0') {
-                if (patternmatch(pattern, string)) {
-                    return true;
-                }
-                ++string;
-            }
-            return false;
-            break;
-        default: /* Regular character */
-            if (*string != patterncharacter) {
-                return false;
-            }
-            string++;
-            break;
-        }
-    }
-}
-
 /*
  * The 'found' variable will contain flags related to the expected log
  * messages that were received.
@@ -169,7 +131,7 @@ static void logger(void *ptr, const dds_log_data_t *data)
 {
     char **expected = (char**)ptr;
     for (uint32_t i = 0; expected[i] != NULL; i++) {
-        if (patternmatch(expected[i], data->message)) {
+        if (ddsi2_patmatch(expected[i], data->message)) {
             found |= (uint32_t)(1 << i);
         }
     }

--- a/src/core/ddsi/include/dds/ddsi/q_config.h
+++ b/src/core/ddsi/include/dds/ddsi/q_config.h
@@ -210,6 +210,41 @@ enum many_sockets_mode {
   MSM_MANY_UNICAST
 };
 
+#ifdef DDSI_INCLUDE_SECURITY
+typedef struct plugin_library_properties_type{
+  char *library_path;
+  char *library_init;
+  char *library_finalize;
+} plugin_library_properties_type;
+
+typedef struct authentication_properties_type{
+  char *identity_certificate;
+  char *identity_ca;
+  char *private_key;
+  char *password;
+  char *trusted_ca_dir;
+} authentication_properties_type;
+
+typedef struct access_control_properties_type{
+  char *permissions;
+  char *permissions_ca;
+  char *governance;
+} access_control_properties_type;
+
+typedef struct omg_security_configuration_type {
+  authentication_properties_type authentication_properties;
+  access_control_properties_type access_control_properties;
+  plugin_library_properties_type authentication_plugin;
+  plugin_library_properties_type access_control_plugin;
+  plugin_library_properties_type cryptography_plugin;
+} omg_security_configuration_type;
+
+struct config_omg_security_listelem {
+  struct config_omg_security_listelem *next;
+  omg_security_configuration_type cfg;
+};
+#endif /* DDSI_INCLUDE_SECURITY */
+
 #ifdef DDSI_INCLUDE_SSL
 struct ssl_min_version {
   int major;
@@ -389,6 +424,10 @@ struct config
 
   int use_multicast_if_mreqn;
   struct prune_deleted_ppant prune_deleted_ppant;
+
+#ifdef DDSI_INCLUDE_SECURITY
+  struct config_omg_security_listelem *omg_security_configuration;
+#endif
 };
 
 struct cfgst;

--- a/src/core/ddsi/include/dds/ddsi/q_misc.h
+++ b/src/core/ddsi/include/dds/ddsi/q_misc.h
@@ -35,7 +35,7 @@ unsigned char normalize_data_datafrag_flags (const SubmessageHeader_t *smhdr);
 int WildcardOverlap(char * p1, char * p2);
 #endif
 
-int ddsi2_patmatch (const char *pat, const char *str);
+DDS_EXPORT int ddsi2_patmatch (const char *pat, const char *str);
 
 uint32_t crc32_calc (const void *buf, size_t length);
 

--- a/src/core/ddsi/include/dds/ddsi/q_xqos.h
+++ b/src/core/ddsi/include/dds/ddsi/q_xqos.h
@@ -321,6 +321,10 @@ DDS_EXPORT uint64_t nn_xqos_delta (const dds_qos_t *a, const dds_qos_t *b, uint6
 DDS_EXPORT void nn_xqos_addtomsg (struct nn_xmsg *m, const dds_qos_t *xqos, uint64_t wanted);
 DDS_EXPORT void nn_log_xqos (uint32_t cat, const struct ddsrt_log_cfg *logcfg, const dds_qos_t *xqos);
 DDS_EXPORT dds_qos_t *nn_xqos_dup (const dds_qos_t *src);
+#ifdef DDSI_INCLUDE_SECURITY
+struct omg_security_configuration_type;
+DDS_EXPORT void nn_xqos_mergein_security_config (dds_qos_t *xqos, const struct omg_security_configuration_type *cfg);
+#endif
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -519,65 +519,11 @@ dds_return_t new_participant_guid (const ddsi_guid_t *ppguid, struct q_globals *
 #ifdef DDSI_INCLUDE_SECURITY
   if (gv->config.omg_security_configuration)
   {
-    /* Add DDS Security configuration to the QoS as a Property policy,
-     * used by the security plugins to get their proper settings. */
-    omg_security_configuration_type *cfg = &(gv->config.omg_security_configuration->cfg);
-    dds_property_t *properties;
-    uint32_t idx;
-
-    /* No property should be present yet. */
-    assert(!(pp->plist->qos.present & QP_PROPERTY_LIST));
-
-    /* Prepare property. */
-    properties = ddsrt_malloc(8 /* max */ * sizeof (dds_property_t));
-    idx = 0;
-    properties[idx].name = ddsrt_strdup("dds.sec.auth.identity_ca");
-    properties[idx].value = ddsrt_strdup(cfg->authentication_properties.identity_ca);
-    properties[idx].propagate = false;
-    idx++;
-    properties[idx].name = ddsrt_strdup("dds.sec.auth.private_key");
-    properties[idx].value = ddsrt_strdup(cfg->authentication_properties.private_key);
-    properties[idx].propagate = false;
-    idx++;
-    properties[idx].name = ddsrt_strdup("dds.sec.auth.identity_certificate");
-    properties[idx].value = ddsrt_strdup(cfg->authentication_properties.identity_certificate);
-    properties[idx].propagate = false;
-    idx++;
-    properties[idx].name = ddsrt_strdup("dds.sec.access.permissions_ca");
-    properties[idx].value = ddsrt_strdup(cfg->access_control_properties.permissions_ca);
-    properties[idx].propagate = false;
-    idx++;
-    properties[idx].name = ddsrt_strdup("dds.sec.access.governance");
-    properties[idx].value = ddsrt_strdup(cfg->access_control_properties.governance);
-    properties[idx].propagate = false;
-    idx++;
-    properties[idx].name = ddsrt_strdup("dds.sec.access.permissions");
-    properties[idx].value = ddsrt_strdup(cfg->access_control_properties.permissions);
-    properties[idx].propagate = false;
-    idx++;
-    if (cfg->authentication_properties.password && (strlen(cfg->authentication_properties.password) != 0))
-    {
-      properties[idx].name = ddsrt_strdup("dds.sec.auth.password");
-      properties[idx].value = ddsrt_strdup(cfg->authentication_properties.password);
-      properties[idx].propagate = false;
-      idx++;
-    }
-    if (cfg->authentication_properties.trusted_ca_dir && (strlen(cfg->authentication_properties.trusted_ca_dir) != 0))
-    {
-      properties[idx].name = ddsrt_strdup("dds.sec.auth.trusted_ca_dir");
-      properties[idx].value = ddsrt_strdup(cfg->authentication_properties.trusted_ca_dir);
-      properties[idx].propagate = false;
-      idx++;
-    }
-
-    /* Add property. */
-    pp->plist->qos.present |= QP_PROPERTY_LIST;
-    pp->plist->qos.property.value.n = idx;
-    pp->plist->qos.property.value.props = properties;
-    pp->plist->qos.property.binary_value.n = 0;
-    pp->plist->qos.property.binary_value.props = NULL;
+    /* For security, configuration can be provided through the configuration.
+     * However, the specification (and the plugins) expect it to be in the QoS. */
+    nn_xqos_mergein_security_config(&(pp->plist->qos), &(gv->config.omg_security_configuration->cfg));
   }
-#endif /* DDSI_INCLUDE_SECURITY */
+#endif
 
   if (gv->logconfig.c.mask & DDS_LC_DISCOVERY)
   {


### PR DESCRIPTION
DDS Security needs to be configured. For this, the following XML elements are added to the cyclonedds XML configuration:
```
Domain/DDSSecurity/Authentication/Library/#text
Domain/DDSSecurity/Authentication/Library[@path]
Domain/DDSSecurity/Authentication/Library[@initFunction]
Domain/DDSSecurity/Authentication/Library[@finalizeFunction]
Domain/DDSSecurity/Authentication/IdentityCertificate/#text
Domain/DDSSecurity/Authentication/IdentityCA/#text
Domain/DDSSecurity/Authentication/PrivateKey/#text
Domain/DDSSecurity/Authentication/Password/#text
Domain/DDSSecurity/Authentication/TrustedCADirectory/#text
Domain/DDSSecurity/AccessControl/Library/#text
Domain/DDSSecurity/AccessControl/Library[@path]
Domain/DDSSecurity/AccessControl/Library[@initFunction]
Domain/DDSSecurity/AccessControl/Library[@finalizeFunction]
Domain/DDSSecurity/AccessControl/PermissionsCA/#text
Domain/DDSSecurity/AccessControl/Governance/#text
Domain/DDSSecurity/AccessControl/Permissions/#text
Domain/DDSSecurity/Cryptographic/Library/#text
Domain/DDSSecurity/Cryptographic/Library[@path]
Domain/DDSSecurity/Cryptographic/Library[@initFunction]
Domain/DDSSecurity/Cryptographic/Library[@finalizeFunction]
```

Detailed explanations of these elements have been added to q_config.c.

The configuration values are added to the Property policy of the internal QoS, so that the plugins can get their settings (in the near future) through 'normal' means.

Note, the DDS Security specification states that these configuration values should be part of the Property policy within the Participant QoS in the API. The Property policy is part of the internal QoS, but not part of the API yet. This API extension of the QoS is planned to be added in the (near) future. See also https://github.com/martinbremmer/cyclonedds/blob/mpt/docs/dev/dds_security_effort.md#Move-configuration