### PR TITLE
DDS_FATAL, atomic64, iid init, ddsrt attributes

### DIFF
--- a/src/core/ddsc/src/dds_domain.c
+++ b/src/core/ddsc/src/dds_domain.c
@@ -51,7 +51,6 @@ static const ddsrt_avl_treedef_t dds_domaintree_def = DDSRT_AVL_TREEDEF_INITIALI
 static dds_return_t dds_domain_init (dds_domain *domain, dds_domainid_t domain_id, const char *config)
 {
   dds_return_t ret = DDS_RETCODE_OK;
-  char * uri = NULL;
   uint32_t len;
   dds_entity_t domain_handle;
 
@@ -90,7 +89,7 @@ static dds_return_t dds_domain_init (dds_domain *domain, dds_domainid_t domain_i
   domain->cfgst = config_init (config, &domain->gv.config, domain_id);
   if (domain->cfgst == NULL)
   {
-    DDS_ILOG (DDS_LC_CONFIG, domain_id, "Failed to parse configuration XML file %s\n", uri);
+    DDS_ILOG (DDS_LC_CONFIG, domain_id, "Failed to parse configuration\n");
     ret = DDS_RETCODE_ERROR;
     goto fail_config;
   }

--- a/src/core/ddsi/include/dds/ddsi/ddsi_iid.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_iid.h
@@ -21,12 +21,7 @@ extern "C" {
 #endif
 
 struct ddsi_iid {
-#if DDSRT_ATOMIC64_SUPPORT
   ddsrt_atomic_uint64_t counter;
-#else
-  ddsrt_mutex_t lock;
-  uint64_t counter;
-#endif
   uint32_t key[4];
 };
 

--- a/src/core/ddsi/src/q_debmon.c
+++ b/src/core/ddsi/src/q_debmon.c
@@ -195,7 +195,7 @@ static int print_participants (struct thread_state1 * const ts1, struct q_global
                   whcst.min_seq, whcst.max_seq, whcst.unacked_bytes,
                   w->throttling ? " THROTTLING" : "",
                   w->whc_low, w->whc_high,
-                  w->seq, READ_SEQ_XMIT(w), w->cs_seq);
+                  w->seq, writer_read_seq_xmit (w), w->cs_seq);
         if (w->reliable)
         {
           x += cpf (conn, "    hb %"PRIu32" ackhb %"PRId64" hb %"PRId64" wr %"PRId64" sched %"PRId64" #rel %"PRId32"\n",

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -110,6 +110,9 @@ extern inline bool builtintopic_is_builtintopic (const struct ddsi_builtin_topic
 extern inline struct ddsi_tkmap_instance *builtintopic_get_tkmap_entry (const struct ddsi_builtin_topic_interface *btif, const struct ddsi_guid *guid);
 extern inline void builtintopic_write (const struct ddsi_builtin_topic_interface *btif, const struct entity_common *e, nn_wctime_t timestamp, bool alive);
 
+extern inline seqno_t writer_read_seq_xmit (const struct writer *wr);
+extern inline void writer_update_seq_xmit (struct writer *wr, seqno_t nv);
+
 static int compare_guid (const void *va, const void *vb)
 {
   return memcmp (va, vb, sizeof (ddsi_guid_t));
@@ -2726,7 +2729,7 @@ static void new_writer_guid_common_init (struct writer *wr, const struct ddsi_se
   ddsrt_cond_init (&wr->throttle_cond);
   wr->seq = 0;
   wr->cs_seq = 0;
-  INIT_SEQ_XMIT(wr, 0);
+  ddsrt_atomic_st64 (&wr->seq_xmit, (uint64_t) 0);
   wr->hbcount = 0;
   wr->state = WRST_OPERATIONAL;
   wr->hbfragcount = 0;

--- a/src/core/ddsi/src/q_receive.c
+++ b/src/core/ddsi/src/q_receive.c
@@ -568,7 +568,7 @@ static void force_heartbeat_to_peer (struct writer *wr, const struct whc_state *
 static seqno_t grow_gap_to_next_seq (const struct writer *wr, seqno_t seq)
 {
   seqno_t next_seq = whc_next_seq (wr->whc, seq - 1);
-  seqno_t seq_xmit = READ_SEQ_XMIT(wr);
+  seqno_t seq_xmit = writer_read_seq_xmit (wr);
   if (next_seq == MAX_SEQ_NUMBER) /* no next sample */
     return seq_xmit + 1;
   else if (next_seq > seq_xmit)  /* next is beyond last actually transmitted */
@@ -849,7 +849,7 @@ static int handle_AckNack (struct receiver_state *rst, nn_etime_t tnow, const Ac
      that issue; if it has, then the timing is terribly unlucky, but
      a future request'll fix it. */
   enqueued = 1;
-  seq_xmit = READ_SEQ_XMIT(wr);
+  seq_xmit = writer_read_seq_xmit (wr);
   const bool gap_for_already_acked = vendor_is_eclipse (rst->vendor) && prd->c.xqos->durability.kind == DDS_DURABILITY_VOLATILE && seqbase <= rn->seq;
   const seqno_t min_seq_to_rexmit = gap_for_already_acked ? rn->seq + 1 : 0;
   for (uint32_t i = 0; i < numbits && seqbase + i <= seq_xmit && enqueued; i++)
@@ -1473,7 +1473,7 @@ static int handle_NackFrag (struct receiver_state *rst, nn_etime_t tnow, const N
       qxev_msg (wr->evq, m);
     }
   }
-  if (seq < READ_SEQ_XMIT(wr))
+  if (seq < writer_read_seq_xmit (wr))
   {
     /* Not everything was retransmitted yet, so force a heartbeat out
        to give the reader a chance to nack the rest and make sure

--- a/src/core/ddsi/src/q_thread.c
+++ b/src/core/ddsi/src/q_thread.c
@@ -251,10 +251,7 @@ static struct thread_state1 *init_thread_state (const char *tname, const struct 
   ts = &thread_states.ts[cand];
   ddsrt_atomic_stvoidp (&ts->gv, (struct q_globals *) gv);
   assert (vtime_asleep_p (ddsrt_atomic_ld32 (&ts->vtime)));
-  DDSRT_WARNING_MSVC_OFF(4996);
-  strncpy (ts->name, tname, sizeof (ts->name));
-  DDSRT_WARNING_MSVC_ON(4996);
-  ts->name[sizeof (ts->name) - 1] = 0;
+  ddsrt_strlcpy (ts->name, tname, sizeof (ts->name));
   ts->state = state;
 
   return ts;

--- a/src/core/ddsi/src/q_transmit.c
+++ b/src/core/ddsi/src/q_transmit.c
@@ -307,7 +307,7 @@ struct nn_xmsg *writer_hbcontrol_piggyback (struct writer *wr, const struct whc_
             (hbc->tsched.v == T_NEVER) ? INFINITY : (double) (hbc->tsched.v - tnow.v) / 1e9,
             ddsrt_avl_is_empty (&wr->readers) ? -1 : root_rdmatch (wr)->min_seq,
             ddsrt_avl_is_empty (&wr->readers) || root_rdmatch (wr)->all_have_replied_to_hb ? "" : "!",
-            whcst->max_seq, READ_SEQ_XMIT(wr));
+            whcst->max_seq, writer_read_seq_xmit (wr));
   }
 
   return msg;
@@ -354,7 +354,7 @@ void add_Heartbeat (struct nn_xmsg *msg, struct writer *wr, const struct whc_sta
     seqno_t seq_xmit;
     min = whcst->min_seq;
     max = wr->seq;
-    seq_xmit = READ_SEQ_XMIT(wr);
+    seq_xmit = writer_read_seq_xmit (wr);
     assert (min <= max);
     /* Informing readers of samples that haven't even been transmitted makes little sense,
        but for transient-local data, we let the first heartbeat determine the time at which
@@ -1125,7 +1125,7 @@ static int write_sample_eot (struct thread_state1 * const ts1, struct nn_xpack *
 
       (Note that no network destination is very nearly the same as no
       matching proxy readers.  The exception is the SPDP writer.) */
-    UPDATE_SEQ_XMIT_LOCKED (wr, seq);
+    writer_update_seq_xmit (wr, seq);
     ddsrt_mutex_unlock (&wr->e.lock);
     if (plist != NULL)
     {

--- a/src/core/ddsi/src/q_xevent.c
+++ b/src/core/ddsi/src/q_xevent.c
@@ -622,7 +622,7 @@ static void handle_xevk_heartbeat (struct nn_xpack *xp, struct xevent *ev, nn_mt
            (t_next.v == T_NEVER) ? INFINITY : (double)(t_next.v - tnow.v) / 1e9,
            ddsrt_avl_is_empty (&wr->readers) ? (seqno_t) -1 : ((struct wr_prd_match *) ddsrt_avl_root_non_empty (&wr_readers_treedef, &wr->readers))->min_seq,
            ddsrt_avl_is_empty (&wr->readers) || ((struct wr_prd_match *) ddsrt_avl_root_non_empty (&wr_readers_treedef, &wr->readers))->all_have_replied_to_hb ? "" : "!",
-           whcst.max_seq, READ_SEQ_XMIT(wr));
+           whcst.max_seq, writer_read_seq_xmit (wr));
   resched_xevent_if_earlier (ev, t_next);
   wr->hbcontrol.tsched = t_next;
   ddsrt_mutex_unlock (&wr->e.lock);

--- a/src/core/ddsi/src/q_xmsg.c
+++ b/src/core/ddsi/src/q_xmsg.c
@@ -868,7 +868,7 @@ static void nn_xmsg_chain_release (struct q_globals *gv, struct nn_xmsg_chain *c
         assert (m->kindspecific.data.wrseq != 0);
         wrguid = m->kindspecific.data.wrguid;
         if ((wr = ephash_lookup_writer_guid (gv->guid_hash, &m->kindspecific.data.wrguid)) != NULL)
-          UPDATE_SEQ_XMIT_UNLOCKED(wr, m->kindspecific.data.wrseq);
+          writer_update_seq_xmit (wr, m->kindspecific.data.wrseq);
       }
     }
 

--- a/src/ddsrt/include/dds/ddsrt/attributes.h
+++ b/src/ddsrt/include/dds/ddsrt/attributes.h
@@ -12,13 +12,13 @@
 #ifndef DDSRT_ATTRIBUTES_H
 #define DDSRT_ATTRIBUTES_H
 
-#if __clang__
+#if __GNUC__
 # define ddsrt_gnuc (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 #else
 # define ddsrt_gnuc (0)
 #endif
 
-#if __GNUC__
+#if __clang__
 # define ddsrt_clang (__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__)
 #else
 # define ddsrt_clang (0)

--- a/src/ddsrt/include/dds/ddsrt/retcode.h
+++ b/src/ddsrt/include/dds/ddsrt/retcode.h
@@ -28,20 +28,20 @@ typedef int32_t dds_return_t;
  * @name DDS_Error_Type
  * @{
  */
-#define DDS_RETCODE_OK                   0 /**< Success */
-#define DDS_RETCODE_ERROR                -1 /**< Non specific error */
-#define DDS_RETCODE_UNSUPPORTED          -2 /**< Feature unsupported */
-#define DDS_RETCODE_BAD_PARAMETER        -3 /**< Bad parameter value */
-#define DDS_RETCODE_PRECONDITION_NOT_MET -4 /**< Precondition for operation not met */
-#define DDS_RETCODE_OUT_OF_RESOURCES     -5 /**< When an operation fails because of a lack of resources */
-#define DDS_RETCODE_NOT_ENABLED          -6 /**< When a configurable feature is not enabled */
-#define DDS_RETCODE_IMMUTABLE_POLICY     -7 /**< When an attempt is made to modify an immutable policy */
-#define DDS_RETCODE_INCONSISTENT_POLICY  -8 /**< When a policy is used with inconsistent values */
-#define DDS_RETCODE_ALREADY_DELETED      -9 /**< When an attempt is made to delete something more than once */
-#define DDS_RETCODE_TIMEOUT              -10 /**< When a timeout has occurred */
-#define DDS_RETCODE_NO_DATA              -11 /**< When expected data is not provided */
-#define DDS_RETCODE_ILLEGAL_OPERATION    -12 /**< When a function is called when it should not be */
-#define DDS_RETCODE_NOT_ALLOWED_BY_SECURITY -13 /**< When credentials are not enough to use the function */
+#define DDS_RETCODE_OK                   (0) /**< Success */
+#define DDS_RETCODE_ERROR                (-1) /**< Non specific error */
+#define DDS_RETCODE_UNSUPPORTED          (-2) /**< Feature unsupported */
+#define DDS_RETCODE_BAD_PARAMETER        (-3) /**< Bad parameter value */
+#define DDS_RETCODE_PRECONDITION_NOT_MET (-4) /**< Precondition for operation not met */
+#define DDS_RETCODE_OUT_OF_RESOURCES     (-5) /**< When an operation fails because of a lack of resources */
+#define DDS_RETCODE_NOT_ENABLED          (-6) /**< When a configurable feature is not enabled */
+#define DDS_RETCODE_IMMUTABLE_POLICY     (-7) /**< When an attempt is made to modify an immutable policy */
+#define DDS_RETCODE_INCONSISTENT_POLICY  (-8) /**< When a policy is used with inconsistent values */
+#define DDS_RETCODE_ALREADY_DELETED      (-9) /**< When an attempt is made to delete something more than once */
+#define DDS_RETCODE_TIMEOUT              (-10) /**< When a timeout has occurred */
+#define DDS_RETCODE_NO_DATA              (-11) /**< When expected data is not provided */
+#define DDS_RETCODE_ILLEGAL_OPERATION    (-12) /**< When a function is called when it should not be */
+#define DDS_RETCODE_NOT_ALLOWED_BY_SECURITY (-13) /**< When credentials are not enough to use the function */
 
 
 /* Extended return codes are not in the DDS specification and are meant

--- a/src/ddsrt/src/log.c
+++ b/src/ddsrt/src/log.c
@@ -64,7 +64,7 @@ static void default_sink (void *ptr, const dds_log_data_t *data)
 
 static struct ddsrt_log_cfg_impl logconfig = {
   .c = {
-    .mask = DDS_LC_ERROR | DDS_LC_WARNING,
+    .mask = DDS_LC_ERROR | DDS_LC_WARNING | DDS_LC_FATAL,
     .tracemask = 0,
     .domid = UINT32_MAX
   },

--- a/src/ddsrt/src/retcode.c
+++ b/src/ddsrt/src/retcode.c
@@ -30,6 +30,7 @@ static const char *retcodes[] = {
 };
 
 static const char *xretcodes[] = {
+  "Unknown return code",
   "Operation in progress",
   "Try again",
   "Interrupted",
@@ -50,7 +51,11 @@ const char *dds_strretcode (dds_return_t rc)
   /* Retcodes used to be positive, but return values from the API would be a negative
      and so there are/were/may be places outside the core library where dds_strretcode
      is called with a -N for N a API return value, so ... play it safe and use the
-     magnitude */
+     magnitude.  Specially handle INT32_MIN to avoid undefined behaviour on integer
+     overflow. */
+  if (rc == INT32_MIN)
+    return xretcodes[0];
+
   if (rc < 0)
     rc = -rc;
   if (rc >= 0 && rc < nretcodes)
@@ -58,5 +63,5 @@ const char *dds_strretcode (dds_return_t rc)
   else if (rc >= (-DDS_XRETCODE_BASE) && rc < (-DDS_XRETCODE_BASE) + nxretcodes)
     return xretcodes[rc - (-DDS_XRETCODE_BASE)];
   else
-    return "Unknown return code";
+    return xretcodes[0];
 }

--- a/src/ddsrt/tests/CMakeLists.txt
+++ b/src/ddsrt/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ list(APPEND sources
   "string.c"
   "log.c"
   "random.c"
+  "retcode.c"
   "strlcpy.c"
   "socket.c"
   "select.c")

--- a/src/ddsrt/tests/retcode.c
+++ b/src/ddsrt/tests/retcode.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include <string.h>
+
+#include "CUnit/Theory.h"
+#include "dds/ddsrt/retcode.h"
+
+CU_TheoryDataPoints(ddsrt_retcode, unknown) = {
+  CU_DataPoints(dds_return_t,
+                DDS_RETCODE_NOT_ALLOWED_BY_SECURITY-1,
+                -(DDS_RETCODE_NOT_ALLOWED_BY_SECURITY-1),
+                DDS_XRETCODE_BASE,
+                -DDS_XRETCODE_BASE,
+                DDS_RETCODE_NOT_FOUND-1,
+                -(DDS_RETCODE_NOT_FOUND-1),
+                INT32_MAX,
+                -INT32_MAX,
+                INT32_MIN)
+};
+
+CU_Theory((dds_return_t ret), ddsrt_retcode, unknown)
+{
+  CU_ASSERT_STRING_EQUAL(dds_strretcode(ret), "Unknown return code");
+}
+
+CU_TheoryDataPoints(ddsrt_retcode, spotchecks) = {
+  CU_DataPoints(dds_return_t,
+                DDS_RETCODE_OK,
+                -DDS_RETCODE_OK,
+                DDS_RETCODE_NOT_ALLOWED_BY_SECURITY,
+                -DDS_RETCODE_NOT_ALLOWED_BY_SECURITY,
+                DDS_RETCODE_IN_PROGRESS,
+                -DDS_RETCODE_IN_PROGRESS,
+                DDS_RETCODE_NOT_FOUND,
+                -DDS_RETCODE_NOT_FOUND),
+  CU_DataPoints(const char *,
+                "Success",
+                "Success",
+                "Not Allowed By Security",
+                "Not Allowed By Security",
+                "Operation in progress",
+                "Operation in progress",
+                "Not found",
+                "Not found")
+};
+
+CU_Theory((dds_return_t ret, const char *exp), ddsrt_retcode, spotchecks)
+{
+  CU_ASSERT_STRING_EQUAL(dds_strretcode(ret), exp);
+}


### PR DESCRIPTION
This PR addresses the various sub-issues reported in #270:

* DDS_FATAL not aborting in the default configuration;
* Proper initialisation of the instance id generator;
* Removal of code variants for platforms that do not support 64-bit atomic operations, now that ``ddsrt`` emulates them;
* Defining ``ddsrt_clang`` and ``ddsrt_gnuc`` to the version numbers of clang respectively gcc, rather than the reverse ...

There is now a test for DDS_FATAL aborting, but that one only actually tests on Linux and macOS because of the vagaries of testing for abnormal program termination.