### PR TITLE
Increased time-out for the ddsrt_thread_create_and_join test. 

### DIFF
--- a/src/ddsrt/tests/thread.c
+++ b/src/ddsrt/tests/thread.c
@@ -115,7 +115,7 @@ CU_TheoryDataPoints(ddsrt_thread, create_and_join) = {
                                30303,                 40404)
 };
 
-CU_Theory((ddsrt_sched_t sched, int32_t *prio, uint32_t exp), ddsrt_thread, create_and_join)
+CU_Theory((ddsrt_sched_t sched, int32_t *prio, uint32_t exp), ddsrt_thread, create_and_join, .timeout=60)
 {
   int skip = 0;
   uint32_t res = 50505;


### PR DESCRIPTION
This test runs on Travis Windows x86 often for up to 4-6 seconds. In case of busy build machines it may exceed the time-out of 10 seconds (because of testing with lowest thread priority), so I've increased the time-out to 60s. 

Signed-off-by: Dennis Potman <dennis.potman@adlinktech.com>