### PR TITLE
Fix some unreliable STREQUAL calls in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,17 +170,17 @@ endif()
 # the address sanitizer for ordinary debug builds; gcc is giving some grief on
 # Travis, so don't enable it for gcc by default
 if(NOT USE_SANITIZER)
-  if(${CMAKE_BUILD_TYPE} STREQUAL "Debug" AND
-      NOT (${CMAKE_GENERATOR} STREQUAL "Xcode") AND
-      (${CMAKE_C_COMPILER_ID} STREQUAL "Clang"
-        OR ${CMAKE_C_COMPILER_ID} STREQUAL "AppleClang"))
+  if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug" AND
+      NOT ("${CMAKE_GENERATOR}" STREQUAL "Xcode") AND
+      ("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang"
+        OR "${CMAKE_C_COMPILER_ID}" STREQUAL "AppleClang"))
     message(STATUS "Enabling address sanitizer; set USE_SANITIZER=none to prevent this")
     set(USE_SANITIZER address)
   else()
     set(USE_SANITIZER none)
   endif()
 endif()
-if(NOT (${USE_SANITIZER} STREQUAL "none"))
+if(NOT ("${USE_SANITIZER}" STREQUAL "none"))
   message(STATUS "Sanitizer set to ${USE_SANITIZER}")
   add_compile_options(-fno-omit-frame-pointer -fsanitize=${USE_SANITIZER})
   link_libraries(-fno-omit-frame-pointer -fsanitize=${USE_SANITIZER})


### PR DESCRIPTION
These conditionals may fail if the variable they're checking isn't defined at all. Adding quotes makes the comparison against an empty string in this case, which avoids the syntax error.

Example failure:
```
CMake Error at CMakeLists.txt:173 (if):
  if given arguments:

    "STREQUAL" "Debug" "AND" "NOT" "(" "Visual Studio 16 2019" "STREQUAL" "Xcode" ")" "AND" "(" "MSVC" "STREQUAL" "Clang" "OR" "MSVC" "STREQUAL" "AppleClang" ")"

  Unknown arguments specified
```