### PR TITLE
Drop IDLC when building with colcon

### DIFF
--- a/colcon.pkg
+++ b/colcon.pkg
@@ -1,0 +1,3 @@
+{
+  "cmake-args": [ "-DBUILD_IDLC=OFF" ]
+}

--- a/package.xml
+++ b/package.xml
@@ -12,8 +12,6 @@
     <url type="repository">https://github.com/eclipse-cyclonedds/cyclonedds</url>
 
     <buildtool_depend>cmake</buildtool_depend>
-    <buildtool_depend>java</buildtool_depend>
-    <buildtool_depend>maven</buildtool_depend>
     <depend>openssl</depend>
     <test_depend>libcunit-dev</test_depend>
     <doc_depend>python3-sphinx</doc_depend>


### PR DESCRIPTION
This will eliminate two large dependencies when building CycloneDDS with colcon for ROS 2, which doesn't appear to need the IDLC.

@rotu FYI