### PR TITLE
Moved bswap functions to ddsrt

### DIFF
--- a/src/core/ddsc/src/dds_sertopic_builtintopic.c
+++ b/src/core/ddsc/src/dds_sertopic_builtintopic.c
@@ -17,7 +17,6 @@
 #include "dds/dds.h"
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/md5.h"
-#include "dds/ddsi/q_bswap.h"
 #include "dds/ddsi/q_config.h"
 #include "dds/ddsi/q_freelist.h"
 #include "dds/ddsi/ddsi_sertopic.h"

--- a/src/core/ddsc/src/dds_stream.c
+++ b/src/core/ddsc/src/dds_stream.c
@@ -175,17 +175,17 @@ static void dds_os_put1be (dds_ostreamBE_t * __restrict s, uint8_t v)
 
 static void dds_os_put2be (dds_ostreamBE_t * __restrict s, uint16_t v)
 {
-  dds_os_put2 (&s->x, toBE2u (v));
+  dds_os_put2 (&s->x, ddsrt_toBE2u (v));
 }
 
 static void dds_os_put4be (dds_ostreamBE_t * __restrict s, uint32_t v)
 {
-  dds_os_put4 (&s->x, toBE4u (v));
+  dds_os_put4 (&s->x, ddsrt_toBE4u (v));
 }
 
 static void dds_os_put8be (dds_ostreamBE_t * __restrict s, uint64_t v)
 {
-  dds_os_put8 (&s->x, toBE8u (v));
+  dds_os_put8 (&s->x, ddsrt_toBE8u (v));
 }
 
 static void dds_os_put_bytes (dds_ostream_t * __restrict s, const void * __restrict b, uint32_t l)
@@ -782,7 +782,7 @@ static bool normalize_uint16 (char * __restrict data, uint32_t * __restrict off,
   if ((*off = check_align_prim (*off, size, 1)) == UINT32_MAX)
     return false;
   if (bswap)
-    *((uint16_t *) (data + *off)) = bswap2u (*((uint16_t *) (data + *off)));
+    *((uint16_t *) (data + *off)) = ddsrt_bswap2u (*((uint16_t *) (data + *off)));
   (*off) += 2;
   return true;
 }
@@ -792,7 +792,7 @@ static bool normalize_uint32 (char * __restrict data, uint32_t * __restrict off,
   if ((*off = check_align_prim (*off, size, 2)) == UINT32_MAX)
     return false;
   if (bswap)
-    *((uint32_t *) (data + *off)) = bswap4u (*((uint32_t *) (data + *off)));
+    *((uint32_t *) (data + *off)) = ddsrt_bswap4u (*((uint32_t *) (data + *off)));
   (*off) += 4;
   return true;
 }
@@ -802,7 +802,7 @@ static bool read_and_normalize_uint32 (uint32_t * __restrict val, char * __restr
   if ((*off = check_align_prim (*off, size, 2)) == UINT32_MAX)
     return false;
   if (bswap)
-    *((uint32_t *) (data + *off)) = bswap4u (*((uint32_t *) (data + *off)));
+    *((uint32_t *) (data + *off)) = ddsrt_bswap4u (*((uint32_t *) (data + *off)));
   *val = *((uint32_t *) (data + *off));
   (*off) += 4;
   return true;
@@ -813,7 +813,7 @@ static bool normalize_uint64 (char * __restrict data, uint32_t * __restrict off,
   if ((*off = check_align_prim (*off, size, 3)) == UINT32_MAX)
     return false;
   if (bswap)
-    *((uint64_t *) (data + *off)) = bswap8u (*((uint64_t *) (data + *off)));
+    *((uint64_t *) (data + *off)) = ddsrt_bswap8u (*((uint64_t *) (data + *off)));
   (*off) += 8;
   return true;
 }
@@ -847,7 +847,7 @@ static bool normalize_primarray (char * __restrict data, uint32_t * __restrict o
       {
         uint16_t *xs = (uint16_t *) (data + *off);
         for (uint32_t i = 0; i < num; i++)
-          xs[i] = bswap2u (xs[i]);
+          xs[i] = ddsrt_bswap2u (xs[i]);
       }
       *off += 2 * num;
       return true;
@@ -858,7 +858,7 @@ static bool normalize_primarray (char * __restrict data, uint32_t * __restrict o
       {
         uint32_t *xs = (uint32_t *) (data + *off);
         for (uint32_t i = 0; i < num; i++)
-          xs[i] = bswap4u (xs[i]);
+          xs[i] = ddsrt_bswap4u (xs[i]);
       }
       *off += 4 * num;
       return true;
@@ -869,7 +869,7 @@ static bool normalize_primarray (char * __restrict data, uint32_t * __restrict o
       {
         uint64_t *xs = (uint64_t *) (data + *off);
         for (uint32_t i = 0; i < num; i++)
-          xs[i] = bswap8u (xs[i]);
+          xs[i] = ddsrt_bswap8u (xs[i]);
       }
       *off += 8 * num;
       return true;
@@ -956,7 +956,7 @@ static bool normalize_uni_disc (uint32_t * __restrict val, char * __restrict dat
       if ((*off = check_align_prim (*off, size, 1)) == UINT32_MAX)
         return false;
       if (bswap)
-        *((uint16_t *) (data + *off)) = bswap2u (*((uint16_t *) (data + *off)));
+        *((uint16_t *) (data + *off)) = ddsrt_bswap2u (*((uint16_t *) (data + *off)));
       *val = *((uint16_t *) (data + *off));
       (*off) += 2;
       return true;
@@ -964,7 +964,7 @@ static bool normalize_uni_disc (uint32_t * __restrict val, char * __restrict dat
       if ((*off = check_align_prim (*off, size, 2)) == UINT32_MAX)
         return false;
       if (bswap)
-        *((uint32_t *) (data + *off)) = bswap4u (*((uint32_t *) (data + *off)));
+        *((uint32_t *) (data + *off)) = ddsrt_bswap4u (*((uint32_t *) (data + *off)));
       *val = *((uint32_t *) (data + *off));
       (*off) += 4;
       return true;
@@ -1180,19 +1180,19 @@ static void dds_stream_swap_insitu (void * __restrict vbuf, uint32_t size, uint3
     case 2: {
       uint16_t *buf = vbuf;
       for (uint32_t i = 0; i < num; i++)
-        buf[i] = bswap2u (buf[i]);
+        buf[i] = ddsrt_bswap2u (buf[i]);
       break;
     }
     case 4: {
       uint32_t *buf = vbuf;
       for (uint32_t i = 0; i < num; i++)
-        buf[i] = bswap4u (buf[i]);
+        buf[i] = ddsrt_bswap4u (buf[i]);
       break;
     }
     case 8: {
       uint64_t *buf = vbuf;
       for (uint32_t i = 0; i < num; i++)
-        buf[i] = bswap8u (buf[i]);
+        buf[i] = ddsrt_bswap8u (buf[i]);
       break;
     }
   }
@@ -1294,21 +1294,21 @@ static void dds_stream_swap_copy (void * __restrict vdst, const void * __restric
       const uint16_t *src = vsrc;
       uint16_t *dst = vdst;
       for (uint32_t i = 0; i < num; i++)
-        dst[i] = bswap2u (src[i]);
+        dst[i] = ddsrt_bswap2u (src[i]);
       break;
     }
     case 4: {
       const uint32_t *src = vsrc;
       uint32_t *dst = vdst;
       for (uint32_t i = 0; i < num; i++)
-        dst[i] = bswap4u (src[i]);
+        dst[i] = ddsrt_bswap4u (src[i]);
       break;
     }
     case 8: {
       const uint64_t *src = vsrc;
       uint64_t *dst = vdst;
       for (uint32_t i = 0; i < num; i++)
-        dst[i] = bswap8u (src[i]);
+        dst[i] = ddsrt_bswap8u (src[i]);
       break;
     }
   }
@@ -1943,7 +1943,7 @@ void dds_ostream_add_to_serdata_default (dds_ostream_t * __restrict s, struct dd
   (*d) = (void *) s->m_buffer;
   (*d)->pos = (s->m_index - (uint32_t) offsetof (struct ddsi_serdata_default, data));
   (*d)->size = (s->m_size - (uint32_t) offsetof (struct ddsi_serdata_default, data));
-  (*d)->hdr.options = toBE2u ((uint16_t) pad);
+  (*d)->hdr.options = ddsrt_toBE2u ((uint16_t) pad);
 }
 
 void dds_ostreamBE_from_serdata_default (dds_ostreamBE_t * __restrict s, struct ddsi_serdata_default * __restrict d)
@@ -1966,5 +1966,5 @@ void dds_ostreamBE_add_to_serdata_default (dds_ostreamBE_t * __restrict s, struc
   (*d) = (void *) s->x.m_buffer;
   (*d)->pos = (s->x.m_index - (uint32_t) offsetof (struct ddsi_serdata_default, data));
   (*d)->size = (s->x.m_size - (uint32_t) offsetof (struct ddsi_serdata_default, data));
-  (*d)->hdr.options = toBE2u ((uint16_t) pad);
+  (*d)->hdr.options = ddsrt_toBE2u ((uint16_t) pad);
 }

--- a/src/core/ddsi/CMakeLists.txt
+++ b/src/core/ddsi/CMakeLists.txt
@@ -30,7 +30,6 @@ PREPEND(srcs_ddsi "${CMAKE_CURRENT_LIST_DIR}/src"
     q_addrset.c
     q_bitset_inlines.c
     q_bswap.c
-    q_bswap_inlines.c
     q_config.c
     q_ddsi_discovery.c
     q_debmon.c

--- a/src/core/ddsi/include/dds/ddsi/q_bswap.h
+++ b/src/core/ddsi/include/dds/ddsi/q_bswap.h
@@ -14,7 +14,7 @@
 
 #include <stdint.h>
 
-#include "dds/ddsrt/endian.h"
+#include "dds/ddsrt/bswap.h"
 #include "dds/ddsrt/misc.h"
 #include "dds/ddsi/q_rtps.h" /* for nn_guid_t, nn_guid_prefix_t */
 #include "dds/ddsi/q_protocol.h" /* for nn_sequence_number_t */
@@ -23,70 +23,11 @@
 extern "C" {
 #endif
 
-inline uint16_t bswap2u (uint16_t x)
-{
-  return (uint16_t) ((x >> 8) | (x << 8));
-}
-
-inline int16_t bswap2 (int16_t x)
-{
-  return (int16_t) bswap2u ((uint16_t) x);
-}
-
-inline uint32_t bswap4u (uint32_t x)
-{
-  return (x >> 24) | ((x >> 8) & 0xff00) | ((x << 8) & 0xff0000) | (x << 24);
-}
-
-inline int32_t bswap4 (int32_t x)
-{
-  return (int32_t) bswap4u ((uint32_t) x);
-}
-
-inline uint64_t bswap8u (uint64_t x)
-{
-  const uint32_t newhi = bswap4u ((uint32_t) x);
-  const uint32_t newlo = bswap4u ((uint32_t) (x >> 32));
-  return ((uint64_t) newhi << 32) | (uint64_t) newlo;
-}
-
-inline int64_t bswap8 (int64_t x)
-{
-  return (int64_t) bswap8u ((uint64_t) x);
-}
-
 inline void bswapSN (nn_sequence_number_t *sn)
 {
-  sn->high = bswap4 (sn->high);
-  sn->low = bswap4u (sn->low);
+  sn->high = ddsrt_bswap4 (sn->high);
+  sn->low = ddsrt_bswap4u (sn->low);
 }
-
-#if DDSRT_ENDIAN == DDSRT_LITTLE_ENDIAN
-#define toBE2(x) bswap2 (x)
-#define toBE2u(x) bswap2u (x)
-#define toBE4(x) bswap4 (x)
-#define toBE4u(x) bswap4u (x)
-#define toBE8(x) bswap8 (x)
-#define toBE8u(x) bswap8u (x)
-#define fromBE2(x) bswap2 (x)
-#define fromBE2u(x) bswap2u (x)
-#define fromBE4(x) bswap4 (x)
-#define fromBE4u(x) bswap4u (x)
-#define fromBE8(x) bswap8 (x)
-#define fromBE8u(x) bswap8u (x)
-#else
-#define toBE2u(x) (x)
-#define toBE4(x) (x)
-#define toBE4u(x) (x)
-#define toBE8(x) (x)
-#define toBE8u(x) (x)
-#define fromBE2(x) (x)
-#define fromBE2u(x) (x)
-#define fromBE4(x) (x)
-#define fromBE4u(x) (x)
-#define fromBE8(x) (x)
-#define fromBE8u(x) (x)
-#endif
 
 ddsi_guid_prefix_t nn_hton_guid_prefix (ddsi_guid_prefix_t p);
 ddsi_guid_prefix_t nn_ntoh_guid_prefix (ddsi_guid_prefix_t p);

--- a/src/core/ddsi/src/ddsi_serdata_default.c
+++ b/src/core/ddsi/src/ddsi_serdata_default.c
@@ -296,7 +296,7 @@ static struct ddsi_serdata_default *serdata_default_from_ser_common (const struc
 
   const bool needs_bswap = (d->hdr.identifier != NATIVE_ENCODING);
   d->hdr.identifier = NATIVE_ENCODING;
-  const uint32_t pad = fromBE2u (d->hdr.options) & 2;
+  const uint32_t pad = ddsrt_fromBE2u (d->hdr.options) & 2;
   if (d->pos < pad)
   {
     ddsi_serdata_unref (&d->c);
@@ -474,7 +474,7 @@ static struct ddsi_serdata *serdata_default_from_sample_plist (const struct ddsi
       ddsrt_md5_state_t md5st;
       ddsrt_md5_byte_t digest[16];
       topic_name_sz = (uint32_t) strlen (topic_name) + 1;
-      topic_name_sz_BE = toBE4u (topic_name_sz);
+      topic_name_sz_BE = ddsrt_toBE4u (topic_name_sz);
       d->keyhash.m_set = 1;
       d->keyhash.m_iskey = 0;
       ddsrt_md5_init (&md5st);

--- a/src/core/ddsi/src/q_bswap.c
+++ b/src/core/ddsi/src/q_bswap.c
@@ -11,6 +11,8 @@
  */
 #include "dds/ddsi/q_bswap.h"
 
+extern inline void bswapSN (nn_sequence_number_t *sn);
+
 ddsi_guid_prefix_t nn_hton_guid_prefix (ddsi_guid_prefix_t p)
 {
   int i;
@@ -78,3 +80,4 @@ void bswap_fragment_number_set_bitmap (nn_fragment_number_set_header_t *fnset, u
   for (uint32_t i = 0; i < n; i++)
     bits[i] = ddsrt_bswap4u (bits[i]);
 }
+

--- a/src/core/ddsi/src/q_bswap.c
+++ b/src/core/ddsi/src/q_bswap.c
@@ -15,7 +15,7 @@ ddsi_guid_prefix_t nn_hton_guid_prefix (ddsi_guid_prefix_t p)
 {
   int i;
   for (i = 0; i < 3; i++)
-    p.u[i] = toBE4u (p.u[i]);
+    p.u[i] = ddsrt_toBE4u (p.u[i]);
   return p;
 }
 
@@ -23,19 +23,19 @@ ddsi_guid_prefix_t nn_ntoh_guid_prefix (ddsi_guid_prefix_t p)
 {
   int i;
   for (i = 0; i < 3; i++)
-    p.u[i] = fromBE4u (p.u[i]);
+    p.u[i] = ddsrt_fromBE4u (p.u[i]);
   return p;
 }
 
 ddsi_entityid_t nn_hton_entityid (ddsi_entityid_t e)
 {
-  e.u = toBE4u (e.u);
+  e.u = ddsrt_toBE4u (e.u);
   return e;
 }
 
 ddsi_entityid_t nn_ntoh_entityid (ddsi_entityid_t e)
 {
-  e.u = fromBE4u (e.u);
+  e.u = ddsrt_fromBE4u (e.u);
   return e;
 }
 
@@ -56,25 +56,25 @@ ddsi_guid_t nn_ntoh_guid (ddsi_guid_t g)
 void bswap_sequence_number_set_hdr (nn_sequence_number_set_header_t *snset)
 {
   bswapSN (&snset->bitmap_base);
-  snset->numbits = bswap4u (snset->numbits);
+  snset->numbits = ddsrt_bswap4u (snset->numbits);
 }
 
 void bswap_sequence_number_set_bitmap (nn_sequence_number_set_header_t *snset, uint32_t *bits)
 {
   const uint32_t n = (snset->numbits + 31) / 32;
   for (uint32_t i = 0; i < n; i++)
-    bits[i] = bswap4u (bits[i]);
+    bits[i] = ddsrt_bswap4u (bits[i]);
 }
 
 void bswap_fragment_number_set_hdr (nn_fragment_number_set_header_t *fnset)
 {
-  fnset->bitmap_base = bswap4u (fnset->bitmap_base);
-  fnset->numbits = bswap4u (fnset->numbits);
+  fnset->bitmap_base = ddsrt_bswap4u (fnset->bitmap_base);
+  fnset->numbits = ddsrt_bswap4u (fnset->numbits);
 }
 
 void bswap_fragment_number_set_bitmap (nn_fragment_number_set_header_t *fnset, uint32_t *bits)
 {
   const uint32_t n = (fnset->numbits + 31) / 32;
   for (uint32_t i = 0; i < n; i++)
-    bits[i] = bswap4u (bits[i]);
+    bits[i] = ddsrt_bswap4u (bits[i]);
 }

--- a/src/core/ddsi/src/q_bswap_inlines.c
+++ b/src/core/ddsi/src/q_bswap_inlines.c
@@ -9,13 +9,13 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
+#include "dds/ddsrt/bswap.h"
 #include "dds/ddsi/q_bswap.h"
 
-extern inline uint16_t bswap2u (uint16_t x);
-extern inline uint32_t bswap4u (uint32_t x);
-extern inline uint64_t bswap8u (uint64_t x);
-extern inline int16_t bswap2 (int16_t x);
-extern inline int32_t bswap4 (int32_t x);
-extern inline int64_t bswap8 (int64_t x);
+extern inline uint16_t ddsrt_bswap2u (uint16_t x);
+extern inline uint32_t ddsrt_bswap4u (uint32_t x);
+extern inline uint64_t ddsrt_bswap8u (uint64_t x);
+extern inline int16_t ddsrt_bswap2 (int16_t x);
+extern inline int32_t ddsrt_bswap4 (int32_t x);
+extern inline int64_t ddsrt_bswap8 (int64_t x);
 extern inline void bswapSN (nn_sequence_number_t *sn);
-

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -1038,7 +1038,7 @@ int rtps_init (struct q_globals *gv)
      that won't repeat in the lifetime of the process.  Seems like it ought to work
      to keep the risks of collisions low. */
   {
-    uint64_t iid = toBE8u (ddsi_iid_gen ());
+    uint64_t iid = ddsrt_toBE8u (ddsi_iid_gen ());
     ddsrt_md5_state_t st;
     ddsrt_md5_byte_t digest[16];
     ddsrt_md5_init (&st);

--- a/src/core/ddsi/src/q_lease.c
+++ b/src/core/ddsi/src/q_lease.c
@@ -320,7 +320,7 @@ void handle_PMD (const struct receiver_state *rst, nn_wctime_t timestamp, uint32
         const ParticipantMessageData_t *pmd = (ParticipantMessageData_t *) (data + 1);
         ddsi_guid_prefix_t p = nn_ntoh_guid_prefix (pmd->participantGuidPrefix);
         uint32_t kind = ntohl (pmd->kind);
-        uint32_t length = bswap ? bswap4u (pmd->length) : pmd->length;
+        uint32_t length = bswap ? ddsrt_bswap4u (pmd->length) : pmd->length;
         RSTTRACE (" pp %"PRIx32":%"PRIx32":%"PRIx32" kind %u data %u", p.u[0], p.u[1], p.u[2], kind, length);
         if (len - sizeof (struct CDRHeader) - offsetof (ParticipantMessageData_t, value) < length)
           debug_print_rawdata (rst->gv, " SHORT2", pmd->value, len - sizeof (struct CDRHeader) - offsetof (ParticipantMessageData_t, value));

--- a/src/core/ddsi/src/q_pcap.c
+++ b/src/core/ddsi/src/q_pcap.c
@@ -144,7 +144,7 @@ void write_pcap_received (struct q_globals *gv, nn_wctime_t tstamp, const struct
     pcap_hdr.incl_len = pcap_hdr.orig_len = (uint32_t) sz_iud;
     fwrite (&pcap_hdr, sizeof (pcap_hdr), 1, gv->pcap_fp);
     u.ipv4_hdr = ipv4_hdr_template;
-    u.ipv4_hdr.totallength = toBE2u ((unsigned short) sz_iud);
+    u.ipv4_hdr.totallength = ddsrt_toBE2u ((unsigned short) sz_iud);
     u.ipv4_hdr.ttl = 128;
     u.ipv4_hdr.srcip = ((struct sockaddr_in*) src)->sin_addr.s_addr;
     u.ipv4_hdr.dstip = ((struct sockaddr_in*) dst)->sin_addr.s_addr;
@@ -152,7 +152,7 @@ void write_pcap_received (struct q_globals *gv, nn_wctime_t tstamp, const struct
     fwrite (&u.ipv4_hdr, sizeof (u.ipv4_hdr), 1, gv->pcap_fp);
     udp_hdr.srcport = ((struct sockaddr_in*) src)->sin_port;
     udp_hdr.dstport = ((struct sockaddr_in*) dst)->sin_port;
-    udp_hdr.length = toBE2u ((unsigned short) sz_ud);
+    udp_hdr.length = ddsrt_toBE2u ((unsigned short) sz_ud);
     udp_hdr.checksum = 0; /* don't have to compute a checksum for UDPv4 */
     fwrite (&udp_hdr, sizeof (udp_hdr), 1, gv->pcap_fp);
     fwrite (buf, sz, 1, gv->pcap_fp);
@@ -177,7 +177,7 @@ void write_pcap_sent (struct q_globals *gv, nn_wctime_t tstamp, const struct soc
     pcap_hdr.incl_len = pcap_hdr.orig_len = (uint32_t) sz_iud;
     fwrite (&pcap_hdr, sizeof (pcap_hdr), 1, gv->pcap_fp);
     u.ipv4_hdr = ipv4_hdr_template;
-    u.ipv4_hdr.totallength = toBE2u ((unsigned short) sz_iud);
+    u.ipv4_hdr.totallength = ddsrt_toBE2u ((unsigned short) sz_iud);
     u.ipv4_hdr.ttl = 255;
     u.ipv4_hdr.srcip = ((struct sockaddr_in*) src)->sin_addr.s_addr;
     u.ipv4_hdr.dstip = ((struct sockaddr_in*) hdr->msg_name)->sin_addr.s_addr;
@@ -185,7 +185,7 @@ void write_pcap_sent (struct q_globals *gv, nn_wctime_t tstamp, const struct soc
     fwrite (&u.ipv4_hdr, sizeof (u.ipv4_hdr), 1, gv->pcap_fp);
     udp_hdr.srcport = ((struct sockaddr_in*) src)->sin_port;
     udp_hdr.dstport = ((struct sockaddr_in*) hdr->msg_name)->sin_port;
-    udp_hdr.length = toBE2u ((unsigned short) sz_ud);
+    udp_hdr.length = ddsrt_toBE2u ((unsigned short) sz_ud);
     udp_hdr.checksum = 0; /* don't have to compute a checksum for UDPv4 */
     fwrite (&udp_hdr, sizeof (udp_hdr), 1, gv->pcap_fp);
     write_data (gv->pcap_fp, hdr, sz);

--- a/src/core/ddsi/src/q_receive.c
+++ b/src/core/ddsi/src/q_receive.c
@@ -145,7 +145,7 @@ static int valid_AckNack (const struct receiver_state *rst, AckNack_t *msg, size
   if (byteswap)
   {
     bswap_sequence_number_set_bitmap (&msg->readerSNState, msg->bits);
-    *count = bswap4 (*count);
+    *count = ddsrt_bswap4 (*count);
   }
   return 1;
 }
@@ -199,8 +199,8 @@ static int valid_InfoTS (InfoTS_t *msg, size_t size, int byteswap)
   {
     if (byteswap)
     {
-      msg->time.seconds = bswap4 (msg->time.seconds);
-      msg->time.fraction = bswap4u (msg->time.fraction);
+      msg->time.seconds = ddsrt_bswap4 (msg->time.seconds);
+      msg->time.fraction = ddsrt_bswap4u (msg->time.fraction);
     }
     return valid_ddsi_timestamp (msg->time);
   }
@@ -214,7 +214,7 @@ static int valid_Heartbeat (Heartbeat_t *msg, size_t size, int byteswap)
   {
     bswapSN (&msg->firstSN);
     bswapSN (&msg->lastSN);
-    msg->count = bswap4 (msg->count);
+    msg->count = ddsrt_bswap4 (msg->count);
   }
   msg->readerId = nn_ntoh_entityid (msg->readerId);
   msg->writerId = nn_ntoh_entityid (msg->writerId);
@@ -231,8 +231,8 @@ static int valid_HeartbeatFrag (HeartbeatFrag_t *msg, size_t size, int byteswap)
   if (byteswap)
   {
     bswapSN (&msg->writerSN);
-    msg->lastFragmentNum = bswap4u (msg->lastFragmentNum);
-    msg->count = bswap4 (msg->count);
+    msg->lastFragmentNum = ddsrt_bswap4u (msg->lastFragmentNum);
+    msg->count = ddsrt_bswap4 (msg->count);
   }
   msg->readerId = nn_ntoh_entityid (msg->readerId);
   msg->writerId = nn_ntoh_entityid (msg->writerId);
@@ -267,7 +267,7 @@ static int valid_NackFrag (NackFrag_t *msg, size_t size, int byteswap)
   if (byteswap)
   {
     bswap_fragment_number_set_bitmap (&msg->fragmentNumberState, msg->bits);
-    *count = bswap4 (*count);
+    *count = ddsrt_bswap4 (*count);
   }
   return 1;
 }
@@ -292,8 +292,8 @@ static int valid_Data (const struct receiver_state *rst, struct nn_rmsg *rmsg, D
     return 0;
   if (byteswap)
   {
-    msg->x.extraFlags = bswap2u (msg->x.extraFlags);
-    msg->x.octetsToInlineQos = bswap2u (msg->x.octetsToInlineQos);
+    msg->x.extraFlags = ddsrt_bswap2u (msg->x.extraFlags);
+    msg->x.octetsToInlineQos = ddsrt_bswap2u (msg->x.octetsToInlineQos);
     bswapSN (&msg->x.writerSN);
   }
   msg->x.readerId = nn_ntoh_entityid (msg->x.readerId);
@@ -400,13 +400,13 @@ static int valid_DataFrag (const struct receiver_state *rst, struct nn_rmsg *rms
 
   if (byteswap)
   {
-    msg->x.extraFlags = bswap2u (msg->x.extraFlags);
-    msg->x.octetsToInlineQos = bswap2u (msg->x.octetsToInlineQos);
+    msg->x.extraFlags = ddsrt_bswap2u (msg->x.extraFlags);
+    msg->x.octetsToInlineQos = ddsrt_bswap2u (msg->x.octetsToInlineQos);
     bswapSN (&msg->x.writerSN);
-    msg->fragmentStartingNum = bswap4u (msg->fragmentStartingNum);
-    msg->fragmentsInSubmessage = bswap2u (msg->fragmentsInSubmessage);
-    msg->fragmentSize = bswap2u (msg->fragmentSize);
-    msg->sampleSize = bswap4u (msg->sampleSize);
+    msg->fragmentStartingNum = ddsrt_bswap4u (msg->fragmentStartingNum);
+    msg->fragmentsInSubmessage = ddsrt_bswap2u (msg->fragmentsInSubmessage);
+    msg->fragmentSize = ddsrt_bswap2u (msg->fragmentSize);
+    msg->sampleSize = ddsrt_bswap4u (msg->sampleSize);
   }
   msg->x.readerId = nn_ntoh_entityid (msg->x.readerId);
   msg->x.writerId = nn_ntoh_entityid (msg->x.writerId);
@@ -2662,7 +2662,7 @@ static int handle_submsg_sequence
     }
     if (byteswap)
     {
-      sm->smhdr.octetsToNextHeader = bswap2u (sm->smhdr.octetsToNextHeader);
+      sm->smhdr.octetsToNextHeader = ddsrt_bswap2u (sm->smhdr.octetsToNextHeader);
     }
 
     octetsToNextHeader = sm->smhdr.octetsToNextHeader;
@@ -2929,7 +2929,7 @@ static bool do_packet (struct thread_state1 * const ts1, struct q_globals *gv, d
       }
       if (swap)
       {
-        ml->length = bswap4u (ml->length);
+        ml->length = ddsrt_bswap4u (ml->length);
       }
 
       if (ml->smhdr.submessageId != SMID_PT_MSG_LEN)

--- a/src/core/ddsi/src/q_xevent.c
+++ b/src/core/ddsi/src/q_xevent.c
@@ -1109,7 +1109,7 @@ static void write_pmd_message (struct thread_state1 * const ts1, struct nn_xpack
   }
 
   u.pmd.participantGuidPrefix = nn_hton_guid_prefix (pp->e.guid.prefix);
-  u.pmd.kind = toBE4u (pmd_kind);
+  u.pmd.kind = ddsrt_toBE4u (pmd_kind);
   u.pmd.length = PMD_DATA_LENGTH;
   memset (u.pmd.value, 0, u.pmd.length);
 

--- a/src/core/ddsi/src/q_xmsg.c
+++ b/src/core/ddsi/src/q_xmsg.c
@@ -786,7 +786,7 @@ void nn_xmsg_addpar_keyhash (struct nn_xmsg *m, const struct ddsi_serdata *serda
 static void nn_xmsg_addpar_BE4u (struct nn_xmsg *m, nn_parameterid_t pid, uint32_t x)
 {
   unsigned *p = nn_xmsg_addpar (m, pid, sizeof (x));
-  *p = toBE4u (x);
+  *p = ddsrt_toBE4u (x);
 }
 
 void nn_xmsg_addpar_statusinfo (struct nn_xmsg *m, unsigned statusinfo)
@@ -800,8 +800,8 @@ void nn_xmsg_addpar_statusinfo (struct nn_xmsg *m, unsigned statusinfo)
     assert ((statusinfo & ~NN_STATUSINFO_STANDARDIZED) == NN_STATUSINFO_OSPL_AUTO);
     if (statusinfo & NN_STATUSINFO_OSPL_AUTO)
       statusinfox |= NN_STATUSINFOX_OSPL_AUTO;
-    p[0] = toBE4u (statusinfo & NN_STATUSINFO_STANDARDIZED);
-    p[1] = toBE4u (statusinfox);
+    p[0] = ddsrt_toBE4u (statusinfo & NN_STATUSINFO_STANDARDIZED);
+    p[1] = ddsrt_toBE4u (statusinfox);
   }
 }
 

--- a/src/ddsrt/CMakeLists.txt
+++ b/src/ddsrt/CMakeLists.txt
@@ -116,6 +116,7 @@ list(APPEND headers
   "${include_path}/dds/ddsrt/static_assert.h")
 
 list(APPEND sources
+  "${source_path}/bswap.c"
   "${source_path}/io.c"
   "${source_path}/log.c"
   "${source_path}/retcode.c"

--- a/src/ddsrt/include/dds/ddsrt/bswap.h
+++ b/src/ddsrt/include/dds/ddsrt/bswap.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#ifndef DDSRT_BSWAP_H
+#define DDSRT_BSWAP_H
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "dds/ddsrt/endian.h"
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+inline uint16_t ddsrt_bswap2u (uint16_t x)
+{
+  return (uint16_t) ((x >> 8) | (x << 8));
+}
+
+inline int16_t ddsrt_bswap2 (int16_t x)
+{
+  return (int16_t) ddsrt_bswap2u ((uint16_t) x);
+}
+
+inline uint32_t ddsrt_bswap4u (uint32_t x)
+{
+  return (x >> 24) | ((x >> 8) & 0xff00) | ((x << 8) & 0xff0000) | (x << 24);
+}
+
+inline int32_t ddsrt_bswap4 (int32_t x)
+{
+  return (int32_t) ddsrt_bswap4u ((uint32_t) x);
+}
+
+inline uint64_t ddsrt_bswap8u (uint64_t x)
+{
+  const uint32_t newhi = ddsrt_bswap4u ((uint32_t) x);
+  const uint32_t newlo = ddsrt_bswap4u ((uint32_t) (x >> 32));
+  return ((uint64_t) newhi << 32) | (uint64_t) newlo;
+}
+
+inline int64_t ddsrt_bswap8 (int64_t x)
+{
+  return (int64_t) ddsrt_bswap8u ((uint64_t) x);
+}
+
+#if DDSRT_ENDIAN == DDSRT_LITTLE_ENDIAN
+#define ddsrt_toBE2(x) ddsrt_bswap2 (x)
+#define ddsrt_toBE2u(x) ddsrt_bswap2u (x)
+#define ddsrt_toBE4(x) ddsrt_bswap4 (x)
+#define ddsrt_toBE4u(x) ddsrt_bswap4u (x)
+#define ddsrt_toBE8(x) ddsrt_bswap8 (x)
+#define ddsrt_toBE8u(x) ddsrt_bswap8u (x)
+#define ddsrt_fromBE2(x) ddsrt_bswap2 (x)
+#define ddsrt_fromBE2u(x) ddsrt_bswap2u (x)
+#define ddsrt_fromBE4(x) ddsrt_bswap4 (x)
+#define ddsrt_fromBE4u(x) ddsrt_bswap4u (x)
+#define ddsrt_fromBE8(x) ddsrt_bswap8 (x)
+#define ddsrt_fromBE8u(x) ddsrt_bswap8u (x)
+#else
+#define ddsrt_toBE2u(x) (x)
+#define ddsrt_toBE4(x) (x)
+#define ddsrt_toBE4u(x) (x)
+#define ddsrt_toBE8(x) (x)
+#define ddsrt_toBE8u(x) (x)
+#define ddsrt_fromBE2(x) (x)
+#define ddsrt_fromBE2u(x) (x)
+#define ddsrt_fromBE4(x) (x)
+#define ddsrt_fromBE4u(x) (x)
+#define ddsrt_fromBE8(x) (x)
+#define ddsrt_fromBE8u(x) (x)
+#endif
+
+#if defined (__cplusplus)
+}
+#endif
+
+#endif /* DDSRT_BSWAP_H */

--- a/src/ddsrt/src/bswap.c
+++ b/src/ddsrt/src/bswap.c
@@ -10,7 +10,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
 #include "dds/ddsrt/bswap.h"
-#include "dds/ddsi/q_bswap.h"
 
 extern inline uint16_t ddsrt_bswap2u (uint16_t x);
 extern inline uint32_t ddsrt_bswap4u (uint32_t x);
@@ -18,4 +17,3 @@ extern inline uint64_t ddsrt_bswap8u (uint64_t x);
 extern inline int16_t ddsrt_bswap2 (int16_t x);
 extern inline int32_t ddsrt_bswap4 (int32_t x);
 extern inline int64_t ddsrt_bswap8 (int64_t x);
-extern inline void bswapSN (nn_sequence_number_t *sn);


### PR DESCRIPTION
Moved the byte swapping functions from ddsi to ddsrt so that
these can be re-used in e.g. the security plugins and tests.

Signed-off-by: Dennis Potman <dennis.potman@adlinktech.com>