### PR TITLE
Check that domain + port mapping yields valid results

### DIFF
--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -261,7 +261,7 @@ The default value is: "250".
 ##### //CycloneDDS/Domain/Discovery/Ports/MulticastDataOffset
 Integer
 
-This element specifies the port number for multicast meta traffic (refer
+This element specifies the port number for multicast data traffic (refer
 to the DDSI 2.1 specification, section 9.6.1, constant d2).
 
 The default value is: "1".
@@ -289,7 +289,7 @@ The default value is: "2".
 ##### //CycloneDDS/Domain/Discovery/Ports/UnicastDataOffset
 Integer
 
-This element specifies the port number for unicast meta traffic (refer to
+This element specifies the port number for unicast data traffic (refer to
 the DDSI 2.1 specification, section 9.6.1, constant d3).
 
 The default value is: "11".

--- a/etc/cyclonedds.rnc
+++ b/etc/cyclonedds.rnc
@@ -203,7 +203,7 @@ constant DG).</p><p>The default value is: &quot;250&quot;.</p>""" ] ]
             xsd:integer
           }?
           & [ a:documentation [ xml:lang="en" """
-<p>This element specifies the port number for multicast meta traffic
+<p>This element specifies the port number for multicast data traffic
 (refer to the DDSI 2.1 specification, section 9.6.1, constant
 d2).</p><p>The default value is: &quot;1&quot;.</p>""" ] ]
           element MulticastDataOffset {
@@ -225,7 +225,7 @@ section 9.6.1, constant PG).</p><p>The default value is:
             xsd:integer
           }?
           & [ a:documentation [ xml:lang="en" """
-<p>This element specifies the port number for unicast meta traffic (refer
+<p>This element specifies the port number for unicast data traffic (refer
 to the DDSI 2.1 specification, section 9.6.1, constant d3).</p><p>The
 default value is: &quot;11&quot;.</p>""" ] ]
           element UnicastDataOffset {

--- a/etc/cyclonedds.xsd
+++ b/etc/cyclonedds.xsd
@@ -313,7 +313,7 @@ constant DG).&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;250&amp;quot;.&l
   <xs:element name="MulticastDataOffset" type="xs:integer">
     <xs:annotation>
       <xs:documentation>
-&lt;p&gt;This element specifies the port number for multicast meta traffic
+&lt;p&gt;This element specifies the port number for multicast data traffic
 (refer to the DDSI 2.1 specification, section 9.6.1, constant
 d2).&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;1&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
@@ -338,7 +338,7 @@ section 9.6.1, constant PG).&lt;/p&gt;&lt;p&gt;The default value is:
   <xs:element name="UnicastDataOffset" type="xs:integer">
     <xs:annotation>
       <xs:documentation>
-&lt;p&gt;This element specifies the port number for unicast meta traffic (refer
+&lt;p&gt;This element specifies the port number for unicast data traffic (refer
 to the DDSI 2.1 specification, section 9.6.1, constant d3).&lt;/p&gt;&lt;p&gt;The
 default value is: &amp;quot;11&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>

--- a/src/core/ddsi/CMakeLists.txt
+++ b/src/core/ddsi/CMakeLists.txt
@@ -18,6 +18,7 @@ PREPEND(srcs_ddsi "${CMAKE_CURRENT_LIST_DIR}/src"
     ddsi_raweth.c
     ddsi_ipaddr.c
     ddsi_mcgroup.c
+    ddsi_portmapping.c
     ddsi_serdata.c
     ddsi_serdata_default.c
     ddsi_sertopic.c
@@ -69,6 +70,7 @@ PREPEND(hdrs_private_ddsi "${CMAKE_CURRENT_LIST_DIR}/include/dds/ddsi"
     ddsi_ipaddr.h
     ddsi_mcgroup.h
     ddsi_plist_generic.h
+    ddsi_portmapping.h
     ddsi_serdata.h
     ddsi_sertopic.h
     ddsi_serdata_default.h

--- a/src/core/ddsi/include/dds/ddsi/ddsi_portmapping.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_portmapping.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright(c) 2019 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#ifndef DDSI_PORTMAPPING_H
+#define DDSI_PORTMAPPING_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+enum ddsi_port {
+  DDSI_PORT_MULTI_DISC,
+  DDSI_PORT_MULTI_DATA,
+  DDSI_PORT_UNI_DISC,
+  DDSI_PORT_UNI_DATA
+};
+
+struct ddsi_portmapping {
+  uint32_t base;
+  uint32_t dg;
+  uint32_t pg;
+  uint32_t d0;
+  uint32_t d1;
+  uint32_t d2;
+  uint32_t d3;
+};
+
+bool ddsi_valid_portmapping (const struct ddsi_portmapping *map, uint32_t domain_id, int32_t participant_index, char *msg, size_t msgsize);
+uint32_t ddsi_get_port (const struct ddsi_portmapping *map, enum ddsi_port which, uint32_t domain_id, int32_t participant_index);
+
+#if defined (__cplusplus)
+}
+#endif
+
+#endif /* DDSI_PORTMAPPING_H */

--- a/src/core/ddsi/include/dds/ddsi/ddsi_tran.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_tran.h
@@ -61,7 +61,7 @@ typedef void (*ddsi_tran_peer_locator_fn_t) (ddsi_tran_conn_t, nn_locator_t *);
 typedef void (*ddsi_tran_disable_multiplexing_fn_t) (ddsi_tran_conn_t);
 typedef ddsi_tran_conn_t (*ddsi_tran_accept_fn_t) (ddsi_tran_listener_t);
 typedef ddsi_tran_conn_t (*ddsi_tran_create_conn_fn_t) (ddsi_tran_factory_t fact, uint32_t, ddsi_tran_qos_t);
-typedef ddsi_tran_listener_t (*ddsi_tran_create_listener_fn_t) (ddsi_tran_factory_t fact, int port, ddsi_tran_qos_t);
+typedef ddsi_tran_listener_t (*ddsi_tran_create_listener_fn_t) (ddsi_tran_factory_t fact, uint32_t port, ddsi_tran_qos_t);
 typedef void (*ddsi_tran_release_conn_fn_t) (ddsi_tran_conn_t);
 typedef void (*ddsi_tran_close_conn_fn_t) (ddsi_tran_conn_t);
 typedef void (*ddsi_tran_unblock_listener_fn_t) (ddsi_tran_listener_t);
@@ -70,6 +70,7 @@ typedef int (*ddsi_tran_join_mc_fn_t) (ddsi_tran_conn_t, const nn_locator_t *src
 typedef int (*ddsi_tran_leave_mc_fn_t) (ddsi_tran_conn_t, const nn_locator_t *srcip, const nn_locator_t *mcip, const struct nn_interface *interf);
 typedef int (*ddsi_is_mcaddr_fn_t) (ddsi_tran_factory_t tran, const nn_locator_t *loc);
 typedef int (*ddsi_is_ssm_mcaddr_fn_t) (ddsi_tran_factory_t tran, const nn_locator_t *loc);
+typedef int (*ddsi_is_valid_port_fn_t) (ddsi_tran_factory_t tran, uint32_t port);
 
 enum ddsi_nearby_address_result {
   DNAR_DISTANT,
@@ -172,7 +173,8 @@ struct ddsi_tran_factory
   ddsi_locator_from_string_fn_t m_locator_from_string_fn;
   ddsi_locator_to_string_fn_t m_locator_to_string_fn;
   ddsi_enumerate_interfaces_fn_t m_enumerate_interfaces_fn;
-  
+  ddsi_is_valid_port_fn_t m_is_valid_port_fn;
+
   /* Data */
 
   int32_t m_kind;
@@ -205,10 +207,17 @@ void ddsi_factory_conn_init (const struct ddsi_tran_factory *factory, ddsi_tran_
 inline bool ddsi_factory_supports (const struct ddsi_tran_factory *factory, int32_t kind) {
   return factory->m_supports_fn (factory, kind);
 }
+inline int ddsi_is_valid_port (ddsi_tran_factory_t factory, uint32_t port) {
+  return factory->m_is_valid_port_fn (factory, port);
+}
 inline ddsi_tran_conn_t ddsi_factory_create_conn (ddsi_tran_factory_t factory, uint32_t port, ddsi_tran_qos_t qos) {
+  if (!ddsi_is_valid_port (factory, port))
+    return NULL;
   return factory->m_create_conn_fn (factory, port, qos);
 }
-inline ddsi_tran_listener_t ddsi_factory_create_listener (ddsi_tran_factory_t factory, int port, ddsi_tran_qos_t qos) {
+inline ddsi_tran_listener_t ddsi_factory_create_listener (ddsi_tran_factory_t factory, uint32_t port, ddsi_tran_qos_t qos) {
+  if (!ddsi_is_valid_port (factory, port))
+    return NULL;
   return factory->m_create_listener_fn (factory, port, qos);
 }
 

--- a/src/core/ddsi/include/dds/ddsi/q_config.h
+++ b/src/core/ddsi/include/dds/ddsi/q_config.h
@@ -21,12 +21,6 @@
 extern "C" {
 #endif
 
-/* FIXME: should eventually move to abstraction layer */
-typedef enum q__schedPrioClass {
-  Q__SCHED_PRIO_RELATIVE,
-  Q__SCHED_PRIO_ABSOLUTE
-} q__schedPrioClass;
-
 enum nn_standards_conformance {
   NN_SC_PEDANTIC,
   NN_SC_STRICT,
@@ -52,14 +46,6 @@ enum boolean_default {
   BOOLDEF_DEFAULT,
   BOOLDEF_FALSE,
   BOOLDEF_TRUE
-};
-
-enum durability_cdr
-{
-  DUR_CDR_LE,
-  DUR_CDR_BE,
-  DUR_CDR_SERVER,
-  DUR_CDR_CLIENT
 };
 
 #define PARTICIPANT_INDEX_AUTO -1

--- a/src/core/ddsi/include/dds/ddsi/q_config.h
+++ b/src/core/ddsi/include/dds/ddsi/q_config.h
@@ -16,6 +16,7 @@
 #include "dds/ddsi/q_thread.h"
 #include "dds/ddsi/q_xqos.h"
 #include "dds/ddsi/q_feature_check.h"
+#include "dds/ddsi/ddsi_portmapping.h"
 
 #if defined (__cplusplus)
 extern "C" {
@@ -198,7 +199,6 @@ struct config
   uint32_t domainId;
   int participantIndex;
   int maxAutoParticipantIndex;
-  uint32_t port_base;
   char *spdpMulticastAddressString;
   char *defaultMulticastAddressString;
   char *assumeMulticastCapable;
@@ -321,12 +321,7 @@ struct config
   enum many_sockets_mode many_sockets_mode;
   int assume_rti_has_pmd_endpoints;
 
-  uint32_t port_dg;
-  uint32_t port_pg;
-  uint32_t port_d0;
-  uint32_t port_d1;
-  uint32_t port_d2;
-  uint32_t port_d3;
+  struct ddsi_portmapping ports;
 
   int monitor_port;
 

--- a/src/core/ddsi/include/dds/ddsi/q_debmon.h
+++ b/src/core/ddsi/include/dds/ddsi/q_debmon.h
@@ -20,7 +20,7 @@ struct debug_monitor;
 typedef int (*debug_monitor_cpf_t) (ddsi_tran_conn_t conn, const char *fmt, ...);
 typedef int (*debug_monitor_plugin_t) (ddsi_tran_conn_t conn, debug_monitor_cpf_t cpf, void *arg);
 
-struct debug_monitor *new_debug_monitor (struct q_globals *gv, int port);
+struct debug_monitor *new_debug_monitor (struct q_globals *gv, int32_t port);
 void add_debug_monitor_plugin (struct debug_monitor *dm, debug_monitor_plugin_t fn, void *arg);
 void free_debug_monitor (struct debug_monitor *dm);
 

--- a/src/core/ddsi/src/ddsi_portmapping.c
+++ b/src/core/ddsi/src/ddsi_portmapping.c
@@ -1,0 +1,126 @@
+/*
+ * Copyright(c) 2019 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include <assert.h>
+#include "dds/ddsi/ddsi_portmapping.h"
+#include "dds/ddsi/q_config.h"
+
+static bool get_port_int (uint32_t *port, const struct ddsi_portmapping *map, enum ddsi_port which, uint32_t domain_id, int32_t participant_index, char *str_if_overflow, size_t strsize)
+{
+  uint32_t off = UINT32_MAX, ppidx = UINT32_MAX;
+
+  assert (domain_id != UINT32_MAX);
+  assert (participant_index >= 0 || participant_index == PARTICIPANT_INDEX_NONE);
+
+  switch (which)
+  {
+    case DDSI_PORT_MULTI_DISC:
+      off = map->d0;
+      /* multicast port numbers are not affected by participant index */
+      ppidx = 0;
+      break;
+    case DDSI_PORT_MULTI_DATA:
+      off = map->d2;
+      /* multicast port numbers are not affected by participant index */
+      ppidx = 0;
+      break;
+    case DDSI_PORT_UNI_DISC:
+      if (participant_index == PARTICIPANT_INDEX_NONE)
+      {
+        /* participant index "none" means unicast ports get chosen by the transport */
+        *port = 0;
+        return true;
+      }
+      off = map->d1;
+      ppidx = (uint32_t) participant_index;
+      break;
+    case DDSI_PORT_UNI_DATA:
+      if (participant_index == PARTICIPANT_INDEX_NONE)
+      {
+        /* participant index "none" means unicast ports get chosen by the transport */
+        *port = 0;
+        return true;
+      }
+      off = map->d3;
+      ppidx = (uint32_t) participant_index;
+      break;
+  }
+
+  const uint64_t a = (uint64_t) map->dg * domain_id;
+  const uint64_t b = map->base + (uint64_t) map->pg * ppidx + off;
+
+  /* For the mapping to be valid, the port number must be in range of an unsigned 32 bit integer and must
+     not be 0 (as that is used for indicating a random port should be selected by the transport).  The
+     transports may limit this further, but at least we won't have to worry about overflow anymore. */
+  *port = (uint32_t) (a + b);
+  if (a <= UINT32_MAX && b <= UINT32_MAX - a && *port > 0)
+    return true;
+  else
+  {
+    /* a, b < 2^64 ~ 18e18; 2^32 <= a + b < 2^65 ~ 36e18
+       2^32 ~ 4e9, so it can easily be split into (a+b) `div` 1e9 and (a+b) `mod` 1e9
+       and then the most-significant part is guaranteed to be > 0 */
+    const uint32_t billion = 1000000000;
+    const uint32_t y = (uint32_t) (a % billion) + (uint32_t) (b % billion);
+    const uint64_t x = (a / billion) + (b / billion) + (y / billion);
+    snprintf (str_if_overflow, strsize, "%"PRIu64"%09"PRIu32, x, y % billion);
+    return false;
+  }
+}
+
+static const char *portname (enum ddsi_port which)
+{
+  const char *n = "?";
+  switch (which)
+  {
+    case DDSI_PORT_MULTI_DISC: n = "multicast discovery"; break;
+    case DDSI_PORT_MULTI_DATA: n = "multicast data"; break;
+    case DDSI_PORT_UNI_DISC: n = "unicast discovery"; break;
+    case DDSI_PORT_UNI_DATA: n = "unicast data"; break;
+  }
+  return n;
+}
+
+bool ddsi_valid_portmapping (const struct ddsi_portmapping *map, uint32_t domain_id, int32_t participant_index, char *msg, size_t msgsize)
+{
+  DDSRT_STATIC_ASSERT (DDSI_PORT_MULTI_DISC >= 0 &&
+                       DDSI_PORT_MULTI_DISC + 1 == DDSI_PORT_MULTI_DATA &&
+                       DDSI_PORT_MULTI_DATA + 1 == DDSI_PORT_UNI_DISC &&
+                       DDSI_PORT_UNI_DISC + 1 == DDSI_PORT_UNI_DATA &&
+                       DDSI_PORT_UNI_DATA >= 0);
+  uint32_t dummy_port;
+  char str[32];
+  bool ok = true;
+  enum ddsi_port which = DDSI_PORT_MULTI_DISC;
+  int n = snprintf (msg, msgsize, "port number(s) of out range:");
+  size_t pos = (n >= 0 && (size_t) n <= msgsize) ? (size_t) n : msgsize;
+  do {
+    if (!get_port_int (&dummy_port, map, which, domain_id, participant_index, str, sizeof (str)))
+    {
+      n = snprintf (msg + pos, msgsize - pos, "%s %s %s", ok ? "" : ",", portname (which), str);
+      if (n >= 0 && (size_t) n <= msgsize - pos)
+        pos += (size_t) n;
+      ok = false;
+    }
+  } while (which++ != DDSI_PORT_UNI_DATA);
+  return ok;
+}
+
+uint32_t ddsi_get_port (const struct ddsi_portmapping *map, enum ddsi_port which, uint32_t domain_id, int32_t participant_index)
+{
+  /* Not supposed to come here if port mapping is invalid */
+  uint32_t port;
+  char str[32];
+  bool ok = get_port_int (&port, map, which, domain_id, participant_index, str, sizeof (str));
+  assert (ok);
+  (void) ok;
+  return port;
+}

--- a/src/core/ddsi/src/ddsi_raweth.c
+++ b/src/core/ddsi/src/ddsi_raweth.c
@@ -356,6 +356,12 @@ static int ddsi_raweth_enumerate_interfaces (ddsi_tran_factory_t fact, enum tran
   return ddsrt_getifaddrs(ifs, afs);
 }
 
+static int ddsi_raweth_is_valid_port (ddsi_tran_factory_t fact, uint32_t port)
+{
+  (void) fact;
+  return (port >= 1 && port <= 65535);
+}
+
 int ddsi_raweth_init (struct q_globals *gv)
 {
   struct ddsi_tran_factory *fact = ddsrt_malloc (sizeof (*fact));
@@ -377,6 +383,7 @@ int ddsi_raweth_init (struct q_globals *gv)
   fact->m_locator_from_string_fn = ddsi_raweth_address_from_string;
   fact->m_locator_to_string_fn = ddsi_raweth_to_string;
   fact->m_enumerate_interfaces_fn = ddsi_raweth_enumerate_interfaces;
+  fact->m_is_valid_port_fn = ddsi_raweth_is_valid_port;
   ddsi_factory_add (gv, fact);
   GVLOG (DDS_LC_CONFIG, "raweth initialized\n");
   return 0;

--- a/src/core/ddsi/src/ddsi_tcp.c
+++ b/src/core/ddsi/src/ddsi_tcp.c
@@ -856,7 +856,7 @@ static ddsi_tcp_conn_t ddsi_tcp_new_conn (struct ddsi_tran_factory_tcp *fact, dd
   return conn;
 }
 
-static ddsi_tran_listener_t ddsi_tcp_create_listener (ddsi_tran_factory_t fact, int port, ddsi_tran_qos_t qos)
+static ddsi_tran_listener_t ddsi_tcp_create_listener (ddsi_tran_factory_t fact, uint32_t port, ddsi_tran_qos_t qos)
 {
   char buff[DDSI_LOCSTRLEN];
   ddsrt_socket_t sock;
@@ -1055,6 +1055,12 @@ static enum ddsi_nearby_address_result ddsi_tcp_is_nearby_address (ddsi_tran_fac
   return ddsi_ipaddr_is_nearby_address(tran, loc, ownloc, ninterf, interf);
 }
 
+static int ddsi_tcp_is_valid_port (ddsi_tran_factory_t fact, uint32_t port)
+{
+  (void) fact;
+  return (port <= 65535);
+}
+
 int ddsi_tcp_init (struct q_globals *gv)
 {
   struct ddsi_tran_factory_tcp *fact = ddsrt_malloc (sizeof (*fact));
@@ -1079,6 +1085,7 @@ int ddsi_tcp_init (struct q_globals *gv)
   fact->fact.m_is_mcaddr_fn = ddsi_tcp_is_mcaddr;
   fact->fact.m_is_ssm_mcaddr_fn = ddsi_tcp_is_ssm_mcaddr;
   fact->fact.m_is_nearby_address_fn = ddsi_tcp_is_nearby_address;
+  fact->fact.m_is_valid_port_fn = ddsi_tcp_is_valid_port;
   ddsi_factory_add (gv, &fact->fact);
 
 #if DDSRT_HAVE_IPV6

--- a/src/core/ddsi/src/ddsi_tran.c
+++ b/src/core/ddsi/src/ddsi_tran.c
@@ -23,8 +23,9 @@
 
 extern inline uint32_t ddsi_conn_type (ddsi_tran_conn_t conn);
 extern inline uint32_t ddsi_conn_port (ddsi_tran_conn_t conn);
-extern inline ddsi_tran_listener_t ddsi_factory_create_listener (ddsi_tran_factory_t factory, int port, ddsi_tran_qos_t qos);
+extern inline ddsi_tran_listener_t ddsi_factory_create_listener (ddsi_tran_factory_t factory, uint32_t port, ddsi_tran_qos_t qos);
 extern inline bool ddsi_factory_supports (const struct ddsi_tran_factory *factory, int32_t kind);
+extern inline int ddsi_is_valid_port (ddsi_tran_factory_t factory, uint32_t port);
 extern inline ddsrt_socket_t ddsi_conn_handle (ddsi_tran_conn_t conn);
 extern inline int ddsi_conn_locator (ddsi_tran_conn_t conn, nn_locator_t * loc);
 extern inline ddsrt_socket_t ddsi_tran_handle (ddsi_tran_base_t base);

--- a/src/core/ddsi/src/ddsi_udp.c
+++ b/src/core/ddsi/src/ddsi_udp.c
@@ -466,6 +466,12 @@ static void ddsi_udp_fini (ddsi_tran_factory_t fact)
   ddsrt_free (fact);
 }
 
+static int ddsi_udp_is_valid_port (ddsi_tran_factory_t fact, uint32_t port)
+{
+  (void) fact;
+  return (port <= 65535);
+}
+
 int ddsi_udp_init (struct q_globals *gv)
 {
   struct ddsi_tran_factory *fact = ddsrt_malloc (sizeof (*fact));
@@ -489,6 +495,7 @@ int ddsi_udp_init (struct q_globals *gv)
   fact->m_locator_from_string_fn = ddsi_udp_address_from_string;
   fact->m_locator_to_string_fn = ddsi_udp_locator_to_string;
   fact->m_enumerate_interfaces_fn = ddsi_eth_enumerate_interfaces;
+  fact->m_is_valid_port_fn = ddsi_udp_is_valid_port;
 #if DDSRT_HAVE_IPV6
   if (gv->config.transport_selector == TRANS_UDP6)
   {

--- a/src/core/ddsi/src/q_addrset.c
+++ b/src/core/ddsi/src/q_addrset.c
@@ -103,25 +103,22 @@ static int add_addresses_to_addrset_1 (const struct q_globals *gv, struct addrse
     if (!ddsi_is_mcaddr (gv, &loc))
     {
       assert (gv->config.maxAutoParticipantIndex >= 0);
-      for (uint32_t i = 0; i <= (uint32_t) gv->config.maxAutoParticipantIndex; i++)
+      for (int32_t i = 0; i <= gv->config.maxAutoParticipantIndex; i++)
       {
-        uint32_t port = gv->config.port_base + gv->config.port_dg * gv->config.domainId + i * gv->config.port_pg + gv->config.port_d1;
-        loc.port = (unsigned) port;
+        loc.port = ddsi_get_port (&gv->config.ports, DDSI_PORT_UNI_DISC, gv->config.domainId, i);
         if (i == 0)
           GVLOG (DDS_LC_CONFIG, "%s", ddsi_locator_to_string(gv, buf, sizeof(buf), &loc));
         else
-          GVLOG (DDS_LC_CONFIG, ", :%"PRIu32, port);
+          GVLOG (DDS_LC_CONFIG, ", :%"PRIu32, loc.port);
         add_to_addrset (gv, as, &loc);
       }
     }
     else
     {
-      uint32_t port;
       if (port_mode == -1)
-        port = gv->config.port_base + gv->config.port_dg * gv->config.domainId + gv->config.port_d0;
+        loc.port = ddsi_get_port (&gv->config.ports, DDSI_PORT_MULTI_DISC, gv->config.domainId, 0);
       else
-        port = (uint32_t) port_mode;
-      loc.port = (unsigned) port;
+        loc.port = (uint32_t) port_mode;
       GVLOG (DDS_LC_CONFIG, "%s", ddsi_locator_to_string(gv, buf, sizeof(buf), &loc));
       add_to_addrset (gv, as, &loc);
     }

--- a/src/core/ddsi/src/q_config.c
+++ b/src/core/ddsi/src/q_config.c
@@ -166,7 +166,6 @@ DUPF(uint32);
 DU(natint);
 DU(natint_255);
 DUPF(participantIndex);
-DU(port);
 DU(dyn_port);
 DUPF(memsize);
 DU(duration_inf);
@@ -610,20 +609,20 @@ static const struct cfgelem sizing_cfgelems[] = {
 };
 
 static const struct cfgelem discovery_ports_cfgelems[] = {
-  { LEAF("Base"), 1, "7400", ABSOFF(port_base), 0, uf_port, 0, pf_uint,
+  { LEAF("Base"), 1, "7400", ABSOFF(ports.base), 0, uf_uint, 0, pf_uint,
     BLURB("<p>This element specifies the base port number (refer to the DDSI 2.1 specification, section 9.6.1, constant PB).</p>") },
-  { LEAF("DomainGain"), 1, "250", ABSOFF(port_dg), 0, uf_uint, 0, pf_uint,
+  { LEAF("DomainGain"), 1, "250", ABSOFF(ports.dg), 0, uf_uint, 0, pf_uint,
     BLURB("<p>This element specifies the domain gain, relating domain ids to sets of port numbers (refer to the DDSI 2.1 specification, section 9.6.1, constant DG).</p>") },
-  { LEAF("ParticipantGain"), 1, "2", ABSOFF(port_pg), 0, uf_uint, 0, pf_uint,
+  { LEAF("ParticipantGain"), 1, "2", ABSOFF(ports.pg), 0, uf_uint, 0, pf_uint,
     BLURB("<p>This element specifies the participant gain, relating p0, articipant index to sets of port numbers (refer to the DDSI 2.1 specification, section 9.6.1, constant PG).</p>") },
-  { LEAF("MulticastMetaOffset"), 1, "0", ABSOFF(port_d0), 0, uf_uint, 0, pf_uint,
+  { LEAF("MulticastMetaOffset"), 1, "0", ABSOFF(ports.d0), 0, uf_uint, 0, pf_uint,
     BLURB("<p>This element specifies the port number for multicast meta traffic (refer to the DDSI 2.1 specification, section 9.6.1, constant d0).</p>") },
-  { LEAF("UnicastMetaOffset"), 1, "10", ABSOFF(port_d1), 0, uf_uint, 0, pf_uint,
+  { LEAF("UnicastMetaOffset"), 1, "10", ABSOFF(ports.d1), 0, uf_uint, 0, pf_uint,
     BLURB("<p>This element specifies the port number for unicast meta traffic (refer to the DDSI 2.1 specification, section 9.6.1, constant d1).</p>") },
-  { LEAF("MulticastDataOffset"), 1, "1", ABSOFF(port_d2), 0, uf_uint, 0, pf_uint,
-    BLURB("<p>This element specifies the port number for multicast meta traffic (refer to the DDSI 2.1 specification, section 9.6.1, constant d2).</p>") },
-  { LEAF("UnicastDataOffset"), 1, "11", ABSOFF(port_d3), 0, uf_uint, 0, pf_uint,
-    BLURB("<p>This element specifies the port number for unicast meta traffic (refer to the DDSI 2.1 specification, section 9.6.1, constant d3).</p>") },
+  { LEAF("MulticastDataOffset"), 1, "1", ABSOFF(ports.d2), 0, uf_uint, 0, pf_uint,
+    BLURB("<p>This element specifies the port number for multicast data traffic (refer to the DDSI 2.1 specification, section 9.6.1, constant d2).</p>") },
+  { LEAF("UnicastDataOffset"), 1, "11", ABSOFF(ports.d3), 0, uf_uint, 0, pf_uint,
+    BLURB("<p>This element specifies the port number for unicast data traffic (refer to the DDSI 2.1 specification, section 9.6.1, constant d3).</p>") },
   END_MARKER
 };
 
@@ -1883,32 +1882,21 @@ static enum update_result uf_natint_255(struct cfgst *cfgst, void *parent, struc
 
 static enum update_result uf_uint (struct cfgst *cfgst, void *parent, struct cfgelem const * const cfgelem, UNUSED_ARG (int first), const char *value)
 {
-  unsigned * const elem = cfg_address (cfgst, parent, cfgelem);
+  uint32_t * const elem = cfg_address (cfgst, parent, cfgelem);
   char *endptr;
   unsigned long v = strtoul (value, &endptr, 10);
   if (*value == 0 || *endptr != 0)
     return cfg_error (cfgst, "%s: not a decimal integer", value);
-  if (v != (unsigned) v)
+  if (v != (uint32_t) v)
     return cfg_error (cfgst, "%s: value out of range", value);
-  *elem = (unsigned) v;
+  *elem = (uint32_t) v;
   return URES_SUCCESS;
 }
 
 static void pf_uint (struct cfgst *cfgst, void *parent, struct cfgelem const * const cfgelem, uint32_t sources)
 {
-  unsigned const * const p = cfg_address (cfgst, parent, cfgelem);
+  uint32_t const * const p = cfg_address (cfgst, parent, cfgelem);
   cfg_logelem (cfgst, sources, "%u", *p);
-}
-
-static enum update_result uf_port(struct cfgst *cfgst, void *parent, struct cfgelem const * const cfgelem, int first, const char *value)
-{
-  int *elem = cfg_address (cfgst, parent, cfgelem);
-  if (uf_uint (cfgst, parent, cfgelem, first, value) != URES_SUCCESS)
-    return URES_ERROR;
-  else if (*elem < 1 || *elem > 65535)
-    return cfg_error (cfgst, "%s: out of range", value);
-  else
-    return URES_SUCCESS;
 }
 
 static enum update_result uf_duration_gen (struct cfgst *cfgst, void *parent, struct cfgelem const * const cfgelem, const char *value, int64_t def_mult, int64_t min_ns, int64_t max_ns)

--- a/src/core/ddsi/src/q_debmon.c
+++ b/src/core/ddsi/src/q_debmon.c
@@ -346,10 +346,11 @@ static uint32_t debmon_main (void *vdm)
   return 0;
 }
 
-struct debug_monitor *new_debug_monitor (struct q_globals *gv, int port)
+struct debug_monitor *new_debug_monitor (struct q_globals *gv, int32_t port)
 {
   struct debug_monitor *dm;
 
+  /* negative port number means the feature is disabled */
   if (gv->config.monitor_port < 0)
     return NULL;
 
@@ -362,7 +363,14 @@ struct debug_monitor *new_debug_monitor (struct q_globals *gv, int port)
   dm->plugins = NULL;
   if ((dm->tran_factory = ddsi_factory_find (gv, "tcp")) == NULL)
     dm->tran_factory = ddsi_factory_find (gv, "tcp6");
-  dm->servsock = ddsi_factory_create_listener (dm->tran_factory, port, NULL);
+
+  if (!ddsi_is_valid_port (dm->tran_factory, (uint32_t) port))
+  {
+    GVERROR ("debug monitor port number %"PRId32" is invalid\n", port);
+    goto err_invalid_port;
+  }
+
+  dm->servsock = ddsi_factory_create_listener (dm->tran_factory, (uint32_t) port, NULL);
   if (dm->servsock == NULL)
   {
     GVWARNING ("debmon: can't create socket\n");
@@ -389,6 +397,7 @@ err_listen:
   ddsrt_mutex_destroy(&dm->lock);
   ddsi_listener_free(dm->servsock);
 err_servsock:
+err_invalid_port:
   ddsrt_free(dm);
   return NULL;
 }

--- a/src/ddsrt/include/dds/ddsrt/bswap.h
+++ b/src/ddsrt/include/dds/ddsrt/bswap.h
@@ -85,3 +85,4 @@ inline int64_t ddsrt_bswap8 (int64_t x)
 #endif
 
 #endif /* DDSRT_BSWAP_H */
+

--- a/src/tools/ddsperf/ddsperf.c
+++ b/src/tools/ddsperf/ddsperf.c
@@ -53,7 +53,9 @@ enum topicsel {
   KS,   /* KeyedSeq type: seq#, key, sequence-of-octet */
   K32,  /* Keyed32  type: seq#, key, array-of-24-octet (sizeof = 32) */
   K256, /* Keyed256 type: seq#, key, array-of-248-octet (sizeof = 256) */
-  OU    /* OneULong type: seq# */
+  OU,   /* OneULong type: seq# */
+  UK16, /* Unkeyed16, type: seq#, array-of-12-octet (sizeof = 16) */
+  UK1024/* Unkeyed1024, type: seq#, array-of-1020-octet (sizeof = 1024) */
 };
 
 enum submode {
@@ -317,6 +319,8 @@ union data {
   Keyed32 k32;
   Keyed256 k256;
   OneULong ou;
+  Unkeyed16 uk16;
+  Unkeyed1024 uk1024;
 };
 
 static void verrorx (int exitcode, const char *fmt, va_list ap)
@@ -528,6 +532,14 @@ static void *init_sample (union data *data, uint32_t seq)
       break;
     case OU:
       data->ou.seq = seq;
+      break;
+    case UK16:
+      data->uk16.seq = seq;
+      memset (data->uk16.baggage, 0xee, sizeof (data->uk16.baggage));
+      break;
+    case UK1024:
+      data->uk1024.seq = seq;
+      memset (data->uk1024.baggage, 0xee, sizeof (data->uk1024.baggage));
       break;
   }
   return baggage;
@@ -791,10 +803,12 @@ static uint32_t topic_payload_size (enum topicsel tp, uint32_t bgsize)
   uint32_t size = 0;
   switch (tp)
   {
-    case KS:   size = 12 + bgsize; break;
-    case K32:  size = 32; break;
-    case K256: size = 256; break;
-    case OU:   size = 4; break;
+    case KS:     size = 12 + bgsize; break;
+    case K32:    size = 32; break;
+    case K256:   size = 256; break;
+    case OU:     size = 4; break;
+    case UK16:   size = 16; break;
+    case UK1024: size = 1024; break;
   }
   return size;
 }
@@ -814,13 +828,15 @@ static bool process_data (dds_entity_t rd, struct subthread_arg *arg)
       uint32_t seq = 0, keyval = 0, size = 0;
       switch (topicsel)
       {
-        case KS:   {
-          KeyedSeq *d = (KeyedSeq *) mseq[i]; keyval = d->keyval; seq = d->seq; size = topic_payload_size (topicsel, d->baggage._length);
+        case KS: {
+          KeyedSeq *d = mseq[i]; keyval = d->keyval; seq = d->seq; size = topic_payload_size (topicsel, d->baggage._length);
           break;
         }
-        case K32:  { Keyed32 *d  = (Keyed32 *)  mseq[i]; keyval = d->keyval; seq = d->seq; size = topic_payload_size (topicsel, 0); } break;
-        case K256: { Keyed256 *d = (Keyed256 *) mseq[i]; keyval = d->keyval; seq = d->seq; size = topic_payload_size (topicsel, 0); } break;
-        case OU:   { OneULong *d = (OneULong *) mseq[i]; keyval = 0;         seq = d->seq; size = topic_payload_size (topicsel, 0); } break;
+        case K32:    { Keyed32 *d     = mseq[i]; keyval = d->keyval; seq = d->seq; size = topic_payload_size (topicsel, 0); } break;
+        case K256:   { Keyed256 *d    = mseq[i]; keyval = d->keyval; seq = d->seq; size = topic_payload_size (topicsel, 0); } break;
+        case OU:     { OneULong *d    = mseq[i]; keyval = 0;         seq = d->seq; size = topic_payload_size (topicsel, 0); } break;
+        case UK16:   { Unkeyed16 *d   = mseq[i]; keyval = 0;         seq = d->seq; size = topic_payload_size (topicsel, 0); } break;
+        case UK1024: { Unkeyed1024 *d = mseq[i]; keyval = 0;         seq = d->seq; size = topic_payload_size (topicsel, 0); } break;
       }
       (void) check_eseq (&eseq_admin, seq, keyval, size, iseq[i].publication_handle);
       if (iseq[i].source_timestamp & 1)
@@ -1883,6 +1899,8 @@ int main (int argc, char *argv[])
         else if (strcmp (optarg, "K32") == 0) topicsel = K32;
         else if (strcmp (optarg, "K256") == 0) topicsel = K256;
         else if (strcmp (optarg, "OU") == 0) topicsel = OU;
+        else if (strcmp (optarg, "UK16") == 0) topicsel = UK16;
+        else if (strcmp (optarg, "UK1024") == 0) topicsel = UK1024;
         else error3 ("%s: unknown topic\n", optarg);
         break;
       case 'M': maxwait = atof (optarg); if (maxwait <= 0) maxwait = HUGE_VAL; break;
@@ -1970,10 +1988,12 @@ int main (int argc, char *argv[])
     const dds_topic_descriptor_t *tp_desc = NULL;
     switch (topicsel)
     {
-      case KS:   tp_suf = "KS";   tp_desc = &KeyedSeq_desc; break;
-      case K32:  tp_suf = "K32";  tp_desc = &Keyed32_desc;  break;
-      case K256: tp_suf = "K256"; tp_desc = &Keyed256_desc; break;
-      case OU:   tp_suf = "OU";   tp_desc = &OneULong_desc; break;
+      case KS:     tp_suf = "KS";     tp_desc = &KeyedSeq_desc; break;
+      case K32:    tp_suf = "K32";    tp_desc = &Keyed32_desc;  break;
+      case K256:   tp_suf = "K256";   tp_desc = &Keyed256_desc; break;
+      case OU:     tp_suf = "OU";     tp_desc = &OneULong_desc; break;
+      case UK16:   tp_suf = "UK16";   tp_desc = &Unkeyed16_desc; break;
+      case UK1024: tp_suf = "UK1024"; tp_desc = &Unkeyed1024_desc; break;
     }
     snprintf (tpname_data, sizeof (tpname_data), "DDSPerf%cData%s", reliable ? 'R' : 'U', tp_suf);
     snprintf (tpname_ping, sizeof (tpname_ping), "DDSPerf%cPing%s", reliable ? 'R' : 'U', tp_suf);

--- a/src/tools/ddsperf/ddsperf.c
+++ b/src/tools/ddsperf/ddsperf.c
@@ -1675,7 +1675,7 @@ struct multiplier {
 
 static const struct multiplier frequency_units[] = {
   { "Hz", 1 },
-  { "kHz", 1024 },
+  { "kHz", 1000 },
   { NULL, 0 }
 };
 

--- a/src/tools/ddsperf/ddsperf_types.idl
+++ b/src/tools/ddsperf/ddsperf_types.idl
@@ -4,6 +4,20 @@ struct OneULong
 };
 #pragma keylist OneULong
 
+struct Unkeyed16
+{
+  unsigned long seq;
+  octet baggage[12];
+};
+#pragma keylist Unkeyed16
+
+struct Unkeyed1024
+{
+  unsigned long seq;
+  octet baggage[1020];
+};
+#pragma keylist Unkeyed1024
+
 struct Keyed32
 {
   unsigned long seq;

--- a/src/tools/pubsub/pubsub.c
+++ b/src/tools/pubsub/pubsub.c
@@ -292,7 +292,7 @@ static char *expand_env(const char *name, char op, const char *alt) {
         else {
             char *altx = expand_envvars(alt);
             error_exit("%s: %s\n", name, altx);
-            dds_free(altx);
+            //dds_free(altx);
             return NULL;
         }
     case '+':
@@ -2103,6 +2103,7 @@ static int get_metadata(char **metadata, char **typename, char **keylist, const 
     return 1;
 }
 
+#if 0
 static dds_entity_t find_topic(dds_entity_t dpFindTopic, const char *name, const dds_duration_t *timeout) {
     dds_entity_t tp;
     (void)timeout;
@@ -2157,6 +2158,7 @@ static dds_entity_t find_topic(dds_entity_t dpFindTopic, const char *name, const
 
     return tp;
 }
+#endif
 
 static void set_systemid_env(void) {
 //    TODO Determine encoding of dds_instance_handle_t, and see what sort of value can be extracted from it, if any
@@ -2678,7 +2680,9 @@ int main(int argc, char *argv[]) {
         case OU:   spec[i].tp = new_topic(spec[i].topicname, ts_OneULong, qos); break;
         case ARB:
             // TODO ARB type support
+#if 1
             error_exit("Currently doesn't support ARB type\n");
+#else
             if (spec[i].metadata == NULL) {
                 if (!(spec[i].tp = find_topic(dp, spec[i].topicname, &spec[i].findtopic_timeout)))
                     error_exit("topic %s not found\n", spec[i].topicname);
@@ -2691,6 +2695,7 @@ int main(int argc, char *argv[]) {
 //                dds_topic_descriptor_delete((dds_topic_descriptor_t*) ts);
             }
 //            spec[i].rd.tgtp = spec[i].wr.tgtp = tgnew(spec[i].tp, printtype);
+#endif
             break;
         }
         assert(spec[i].tp);


### PR DESCRIPTION
This pull request improves the checking of the port numbers that come out of the combination of the domain id, participant index and the port mapping parameters.

The old behavior was to truncate the resulting port numbers to 16 bits and letting "something" happen. This proposes computing them in unsigned 32-bit arithmetic and verifying that they meet the requirements of the transport. Thus, a new transport is not bound to the limitations of UDP/IP.

When the numbers are invalid, it tries to give a better messages than https://github.com/ros2/rmw_cyclonedds/issues/61 (although part of the problem there appears to be that the ROS2 python code doesn't deal with these problems gracefully either).

There are some typing issues in the existing code where ``unsigned`` is assumed to be equivalent to an ``uint32_t``. In practice, this is true for all platforms we currently support, and I think this is not the right pull-request to fix all of those.

Furthermore, there is still some very old code involved in creating the sockets and setting the options (i.e., ``make_socket``) with some magic numbers for errors. I do intend to clean those up at least to the point where the usual return codes are used. Then it will be straightforward to properly notify the user if the selected port numbers can't be used because they are in the restricted range (below 1024 non-root users on Unix).

I'd be interested in what you all think. One thing I believe I should change is to avoid wrap-around of port numbers (e.g., a domain id of 1649267417 with the default mapping would result in a multicast discovery port of 1234, and that might be a bit surprising ...).