### PR TITLE
Fixed coverity issues

### DIFF
--- a/src/core/ddsc/src/dds_instance.c
+++ b/src/core/ddsc/src/dds_instance.c
@@ -113,7 +113,7 @@ dds_return_t dds_unregister_instance_ts (dds_entity_t writer, const void *data, 
     return ret;
 
   if (wr->m_entity.m_qos)
-    dds_qget_writer_data_lifecycle (wr->m_entity.m_qos, &autodispose);
+    (void) dds_qget_writer_data_lifecycle (wr->m_entity.m_qos, &autodispose);
 
   thread_state_awake (ts1, &wr->m_entity.m_domain->gv);
   if (autodispose)
@@ -140,7 +140,7 @@ dds_return_t dds_unregister_instance_ih_ts (dds_entity_t writer, dds_instance_ha
     return ret;
 
   if (wr->m_entity.m_qos)
-    dds_qget_writer_data_lifecycle (wr->m_entity.m_qos, &autodispose);
+    (void) dds_qget_writer_data_lifecycle (wr->m_entity.m_qos, &autodispose);
 
   thread_state_awake (ts1, &wr->m_entity.m_domain->gv);
   if (autodispose)

--- a/src/core/ddsc/src/dds_reader.c
+++ b/src/core/ddsc/src/dds_reader.c
@@ -150,6 +150,7 @@ void dds_reader_data_available_cb (struct dds_reader *rd)
 
   rd->m_entity.m_cb_count--;
   rd->m_entity.m_cb_pending_count--;
+
   ddsrt_cond_broadcast (&rd->m_entity.m_observers_cond);
   ddsrt_mutex_unlock (&rd->m_entity.m_observers_lock);
 }
@@ -448,7 +449,7 @@ err_tp_lock:
     (void) dds_delete (subscriber);
 err_sub_lock:
   if (internal_topic)
-    dds_delete (t);
+    (void) dds_delete (t);
   return reader;
 }
 

--- a/src/core/ddsc/src/dds_rhc_default.c
+++ b/src/core/ddsc/src/dds_rhc_default.c
@@ -1110,7 +1110,7 @@ static int rhc_unregister_isreg_w_sideeffects (struct dds_rhc_default *rhc, cons
     if (inst->wrcount == 2 && inst->wr_iid_islive && inst->wr_iid != wr_iid)
     {
       TRACE (",delreg(remain)");
-      lwregs_delete (&rhc->registrations, inst->iid, inst->wr_iid);
+      (void) lwregs_delete (&rhc->registrations, inst->iid, inst->wr_iid);
     }
     return 1;
   }
@@ -1627,7 +1627,7 @@ static void dds_rhc_default_unregister_wr (struct dds_rhc_default * __restrict r
         }
       }
 
-      dds_rhc_unregister (rhc, inst, wrinfo, inst->tstamp, &post, &trig_qc);
+      (void) dds_rhc_unregister (rhc, inst, wrinfo, inst->tstamp, &post, &trig_qc);
 
       TRACE ("\n");
 

--- a/src/core/ddsi/include/dds/ddsi/q_radmin.h
+++ b/src/core/ddsi/include/dds/ddsi/q_radmin.h
@@ -98,7 +98,7 @@ struct nn_rmsg {
 
   struct nn_rmsg_chunk chunk;
 };
-#define NN_RMSG_PAYLOAD(m) ((unsigned char *) (&(m)->chunk + 1))
+#define NN_RMSG_PAYLOAD(m) ((unsigned char *) (m + 1))
 #define NN_RMSG_PAYLOADOFF(m, o) (NN_RMSG_PAYLOAD (m) + (o))
 
 struct receiver_state {

--- a/src/core/ddsi/src/ddsi_ipaddr.c
+++ b/src/core/ddsi/src/ddsi_ipaddr.c
@@ -123,7 +123,7 @@ char *ddsi_ipaddr_to_string (ddsi_tran_factory_t tran, char *dst, size_t sizeof_
   (void)tran;
   assert (sizeof_dst > 1);
   if (loc->kind == NN_LOCATOR_KIND_INVALID)
-    snprintf (dst, sizeof_dst, "(invalid)");
+    (void) snprintf (dst, sizeof_dst, "(invalid)");
   else
   {
     struct sockaddr_storage src;

--- a/src/core/ddsi/src/ddsi_mcgroup.c
+++ b/src/core/ddsi/src/ddsi_mcgroup.c
@@ -148,7 +148,7 @@ static char *make_joinleave_msg (char *buf, size_t bufsz, ddsi_tran_conn_t conn,
     (void) snprintf (interfstr, sizeof (interfstr), "(default)");
   n = err ? snprintf (buf, bufsz, "error %d in ", err) : 0;
   if ((size_t) n  < bufsz)
-    snprintf (buf + n, bufsz - (size_t) n, "%s conn %p for (%s, %s) interface %s", join ? "join" : "leave", (void *) conn, mcstr, srcstr, interfstr);
+    (void) snprintf (buf + n, bufsz - (size_t) n, "%s conn %p for (%s, %s) interface %s", join ? "join" : "leave", (void *) conn, mcstr, srcstr, interfstr);
   return buf;
 }
 

--- a/src/core/ddsi/src/ddsi_raweth.c
+++ b/src/core/ddsi/src/ddsi_raweth.c
@@ -42,13 +42,13 @@ static char *ddsi_raweth_to_string (ddsi_tran_factory_t tran, char *dst, size_t 
 {
   (void)tran;
   if (with_port)
-    snprintf(dst, sizeof_dst, "[%02x:%02x:%02x:%02x:%02x:%02x]:%u",
-             loc->address[10], loc->address[11], loc->address[12],
-             loc->address[13], loc->address[14], loc->address[15], loc->port);
+    (void) snprintf(dst, sizeof_dst, "[%02x:%02x:%02x:%02x:%02x:%02x]:%u",
+                    loc->address[10], loc->address[11], loc->address[12],
+                    loc->address[13], loc->address[14], loc->address[15], loc->port);
   else
-    snprintf(dst, sizeof_dst, "[%02x:%02x:%02x:%02x:%02x:%02x]",
-             loc->address[10], loc->address[11], loc->address[12],
-             loc->address[13], loc->address[14], loc->address[15]);
+    (void) snprintf(dst, sizeof_dst, "[%02x:%02x:%02x:%02x:%02x:%02x]",
+                    loc->address[10], loc->address[11], loc->address[12],
+                    loc->address[13], loc->address[14], loc->address[15]);
   return dst;
 }
 
@@ -94,9 +94,9 @@ static ssize_t ddsi_raweth_conn_read (ddsi_tran_conn_t conn, unsigned char * buf
         )
     {
       char addrbuf[DDSI_LOCSTRLEN];
-      snprintf(addrbuf, sizeof(addrbuf), "[%02x:%02x:%02x:%02x:%02x:%02x]:%u",
-               src.sll_addr[0], src.sll_addr[1], src.sll_addr[2],
-               src.sll_addr[3], src.sll_addr[4], src.sll_addr[5], ntohs(src.sll_protocol));
+      (void) snprintf(addrbuf, sizeof(addrbuf), "[%02x:%02x:%02x:%02x:%02x:%02x]:%u",
+                      src.sll_addr[0], src.sll_addr[1], src.sll_addr[2],
+                      src.sll_addr[3], src.sll_addr[4], src.sll_addr[5], ntohs(src.sll_protocol));
       DDS_CWARNING(&conn->m_base.gv->logconfig, "%s => %d truncated to %d\n", addrbuf, (int)ret, (int)len);
     }
   }

--- a/src/core/ddsi/src/ddsi_tran.c
+++ b/src/core/ddsi/src/ddsi_tran.c
@@ -285,7 +285,7 @@ char *ddsi_locator_to_string (const struct q_globals *gv, char *dst, size_t size
     if (0 < pos && (size_t)pos < sizeof_dst)
       (void) tran->m_locator_to_string_fn (tran, dst + (size_t)pos, sizeof_dst - (size_t)pos, loc, 1);
   } else {
-    snprintf (dst, sizeof_dst, "invalid/0:0");
+    (void) snprintf (dst, sizeof_dst, "invalid/0:0");
   }
   return dst;
 }
@@ -298,7 +298,7 @@ char *ddsi_locator_to_string_no_port (const struct q_globals *gv, char *dst, siz
     if (0 < pos && (size_t)pos < sizeof_dst)
       (void) tran->m_locator_to_string_fn (tran, dst + (size_t)pos, sizeof_dst - (size_t)pos, loc, 0);
   } else {
-    snprintf (dst, sizeof_dst, "invalid/0");
+    (void) snprintf (dst, sizeof_dst, "invalid/0");
   }
   return dst;
 }

--- a/src/core/ddsi/src/ddsi_udp.c
+++ b/src/core/ddsi/src/ddsi_udp.c
@@ -454,7 +454,7 @@ static char *ddsi_udp_locator_to_string (ddsi_tran_factory_t tran, char *dst, si
       pos += (size_t)cnt;
     }
     if (with_port && pos < sizeof_dst) {
-      snprintf (dst + pos, sizeof_dst - pos, ":%"PRIu32, loc->port);
+      (void) snprintf (dst + pos, sizeof_dst - pos, ":%"PRIu32, loc->port);
     }
     return dst;
   }

--- a/src/core/ddsi/src/q_config.c
+++ b/src/core/ddsi/src/q_config.c
@@ -1161,7 +1161,7 @@ static int64_t lookup_multiplier (struct cfgst *cfgst, const struct unit *unitta
          always allow 0 to be specified without a unit */
       return 1;
     } else if (def_mult == 0 && err_on_unrecognised) {
-      cfg_error (cfgst, "%s: unit is required", value);
+      (void) cfg_error (cfgst, "%s: unit is required", value);
       return 0;
     } else {
       cfg_warning (cfgst, "%s: use of default unit is deprecated", value);
@@ -1174,7 +1174,7 @@ static int64_t lookup_multiplier (struct cfgst *cfgst, const struct unit *unitta
       if (strcmp(unittab[i].name, value + unit_pos) == 0)
         return unittab[i].multiplier;
     if (err_on_unrecognised)
-      cfg_error(cfgst, "%s: unrecognised unit", value + unit_pos);
+      (void) cfg_error(cfgst, "%s: unrecognised unit", value + unit_pos);
     return 0;
   }
 }
@@ -2078,7 +2078,7 @@ static int set_default (struct cfgst *cfgst, void *parent, struct cfgelem const 
   enum update_result res;
   if (cfgelem->defvalue == NULL)
   {
-    cfg_error (cfgst, "element missing in configuration");
+    (void) cfg_error (cfgst, "element missing in configuration");
     return 0;
   }
   res = do_update (cfgst, cfgelem->update, parent, cfgelem, cfgelem->defvalue, 0);
@@ -2408,7 +2408,7 @@ static int proc_elem_open (void *varg, UNUSED_ARG (uintptr_t parentinfo), UNUSED
       cfg_subelem = partial_match;
     else
     {
-      cfg_error (cfgst, "%s: unknown element", name);
+      (void) cfg_error (cfgst, "%s: unknown element", name);
       cfgst_push (cfgst, 0, NULL, NULL);
       return 0;
     }
@@ -2522,7 +2522,7 @@ static int proc_attr (void *varg, UNUSED_ARG (uintptr_t eleminfo), const char *n
     return proc_update_cfgelem (cfgst, cfg_attr, value, true);
   else
   {
-    cfg_error (cfgst, "%s: unknown attribute", name);
+    (void) cfg_error (cfgst, "%s: unknown attribute", name);
     return 0;
   }
 }
@@ -2539,7 +2539,7 @@ static int proc_elem_data (void *varg, UNUSED_ARG (uintptr_t eleminfo), const ch
     return proc_update_cfgelem (cfgst, cfgelem, value, isattr);
   else
   {
-    cfg_error (cfgst, "%s: no data expected", value);
+    (void) cfg_error (cfgst, "%s: no data expected", value);
     return 0;
   }
 }
@@ -2566,7 +2566,7 @@ static int proc_elem_close (void *varg, UNUSED_ARG (uintptr_t eleminfo), int lin
 static void proc_error (void *varg, const char *msg, int line)
 {
   struct cfgst * const cfgst = varg;
-  cfg_error (cfgst, "parser error %s at line %d", msg, line);
+  (void) cfg_error (cfgst, "parser error %s at line %d", msg, line);
 }
 
 static int cfgst_node_cmp (const void *va, const void *vb)
@@ -2728,7 +2728,7 @@ struct cfgst *config_init (const char *config, struct config *cfg, uint32_t domi
       qx = ddsrt_xmlp_new_string (tok, cfgst, &cb);
       ddsrt_xmlp_set_options (qx, DDSRT_XMLP_ANONYMOUS_CLOSE_TAG | DDSRT_XMLP_MISSING_CLOSE_AS_EOF);
       fp = NULL;
-      snprintf (env_input, sizeof (env_input), "CYCLONEDDS_URI+%u", (unsigned) (tok - copy));
+      (void) snprintf (env_input, sizeof (env_input), "CYCLONEDDS_URI+%u", (unsigned) (tok - copy));
       cfgst->input = env_input;
       cfgst->line = 1;
     }
@@ -2913,7 +2913,7 @@ static char *get_partition_search_pattern (const char *partition, const char *to
 {
   size_t sz = strlen (partition) + strlen (topic) + 2;
   char *pt = ddsrt_malloc (sz);
-  snprintf (pt, sz, "%s.%s", partition, topic);
+  (void) snprintf (pt, sz, "%s.%s", partition, topic);
   return pt;
 }
 

--- a/src/core/ddsi/src/q_ddsi_discovery.c
+++ b/src/core/ddsi/src/q_ddsi_discovery.c
@@ -304,7 +304,7 @@ int spdp_write (struct participant *pp)
     ddsrt_mutex_unlock (&pp->e.gv->privileged_pp_lock);
 
     if (ddsrt_gethostname(node, sizeof(node)-1) < 0)
-      ddsrt_strlcpy (node, "unknown", sizeof (node));
+      (void) ddsrt_strlcpy (node, "unknown", sizeof (node));
     size = strlen(node) + strlen(DDS_VERSION) + strlen(DDS_HOST_NAME) + strlen(DDS_TARGET_NAME) + 4; /* + ///'\0' */
     ps.prismtech_participant_version_info.internals = ddsrt_malloc(size);
     (void) snprintf(ps.prismtech_participant_version_info.internals, size, "%s/%s/%s/%s", node, DDS_VERSION, DDS_HOST_NAME, DDS_TARGET_NAME);
@@ -400,7 +400,7 @@ static void respond_to_spdp (const struct q_globals *gv, const ddsi_guid_t *dest
     GVTRACE (" %"PRId64, delay);
     if (!pp->e.gv->config.unicast_response_to_spdp_messages)
       /* pp can't reach gc_delete_participant => can safely reschedule */
-      resched_xevent_if_earlier (pp->spdp_xevent, tsched);
+      (void) resched_xevent_if_earlier (pp->spdp_xevent, tsched);
     else
       qxev_spdp (gv->xevents, tsched, &pp->e.guid, dest_proxypp_guid);
   }

--- a/src/core/ddsi/src/q_debmon.c
+++ b/src/core/ddsi/src/q_debmon.c
@@ -381,7 +381,7 @@ struct debug_monitor *new_debug_monitor (struct q_globals *gv, int port)
   if (ddsi_listener_listen (dm->servsock) < 0)
     goto err_listen;
   dm->stop = 0;
-  create_thread (&dm->servts, gv, "debmon", debmon_main, dm);
+  (void) create_thread (&dm->servts, gv, "debmon", debmon_main, dm);
   return dm;
 
 err_listen:

--- a/src/core/ddsi/src/q_debmon.c
+++ b/src/core/ddsi/src/q_debmon.c
@@ -381,7 +381,8 @@ struct debug_monitor *new_debug_monitor (struct q_globals *gv, int port)
   if (ddsi_listener_listen (dm->servsock) < 0)
     goto err_listen;
   dm->stop = 0;
-  (void) create_thread (&dm->servts, gv, "debmon", debmon_main, dm);
+  if (create_thread (&dm->servts, gv, "debmon", debmon_main, dm) != DDS_RETCODE_OK)
+    goto err_listen;
   return dm;
 
 err_listen:

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -1698,7 +1698,7 @@ static void writer_add_connection (struct writer *wr, struct proxy_reader *prd)
       if (tnext.v < wr->hbcontrol.tsched.v)
       {
         wr->hbcontrol.tsched = tnext;
-        resched_xevent_if_earlier (wr->heartbeat_xevent, tnext);
+        (void) resched_xevent_if_earlier (wr->heartbeat_xevent, tnext);
       }
       ddsrt_mutex_unlock (&wr->e.lock);
     }
@@ -1807,7 +1807,7 @@ static void reader_add_connection (struct reader *rd, struct proxy_writer *pwr, 
       /* FIXME: for now, assume that the ports match for datasock_mc --
        't would be better to dynamically create and destroy sockets on
        an as needed basis. */
-      ddsi_join_mc (rd->e.gv, rd->e.gv->mship, rd->e.gv->data_conn_mc, &m->ssm_src_loc, &m->ssm_mc_loc);
+      (void) ddsi_join_mc (rd->e.gv, rd->e.gv->mship, rd->e.gv->data_conn_mc, &m->ssm_src_loc, &m->ssm_mc_loc);
     }
     else
     {
@@ -2931,7 +2931,7 @@ static dds_return_t new_writer_guid (struct writer **wr_out, const struct ddsi_g
   if (wr->lease_duration != T_NEVER)
   {
     nn_mtime_t tsched = { 0 };
-    resched_xevent_if_earlier (pp->pmd_update_xevent, tsched);
+    (void) resched_xevent_if_earlier (pp->pmd_update_xevent, tsched);
   }
 
   return 0;
@@ -3770,7 +3770,7 @@ int update_proxy_participant_plist_locked (struct proxy_participant *proxypp, se
   switch (source)
   {
     case UPD_PROXYPP_SPDP:
-      update_qos_locked (&proxypp->e, &proxypp->plist->qos, &new_plist->qos, timestamp);
+      (void) update_qos_locked (&proxypp->e, &proxypp->plist->qos, &new_plist->qos, timestamp);
       nn_plist_fini (new_plist);
       ddsrt_free (new_plist);
       proxypp->proxypp_have_spdp = 1;
@@ -4181,7 +4181,7 @@ void update_proxy_writer (struct proxy_writer *pwr, seqno_t seq, struct addrset 
       }
     }
 
-    update_qos_locked (&pwr->e, pwr->c.xqos, xqos, timestamp);
+    (void) update_qos_locked (&pwr->e, pwr->c.xqos, xqos, timestamp);
   }
   ddsrt_mutex_unlock (&pwr->e.lock);
 }
@@ -4239,7 +4239,7 @@ void update_proxy_reader (struct proxy_reader *prd, seqno_t seq, struct addrset 
       }
     }
 
-    update_qos_locked (&prd->e, prd->c.xqos, xqos, timestamp);
+    (void) update_qos_locked (&prd->e, prd->c.xqos, xqos, timestamp);
   }
   ddsrt_mutex_unlock (&prd->e.lock);
 }

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -1807,7 +1807,9 @@ static void reader_add_connection (struct reader *rd, struct proxy_writer *pwr, 
       /* FIXME: for now, assume that the ports match for datasock_mc --
        't would be better to dynamically create and destroy sockets on
        an as needed basis. */
-      (void) ddsi_join_mc (rd->e.gv, rd->e.gv->mship, rd->e.gv->data_conn_mc, &m->ssm_src_loc, &m->ssm_mc_loc);
+      int ret = ddsi_join_mc (rd->e.gv, rd->e.gv->mship, rd->e.gv->data_conn_mc, &m->ssm_src_loc, &m->ssm_mc_loc);
+      if (ret < 0)
+        ELOGDISC (rd, "  unable to join\n");
     }
     else
     {

--- a/src/core/ddsi/src/q_gc.c
+++ b/src/core/ddsi/src/q_gc.c
@@ -133,7 +133,7 @@ static uint32_t gcreq_queue_thread (struct gcreq_queue *q)
         } else {
           to = delay;
         }
-        ddsrt_cond_waitfor (&q->cond, &q->lock, to);
+        (void) ddsrt_cond_waitfor (&q->cond, &q->lock, to);
       }
       if (q->first)
       {

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -1403,7 +1403,8 @@ int rtps_start (struct q_globals *gv)
   }
   if (gv->listener)
   {
-    (void) create_thread (&gv->listen_ts, gv, "listen", (uint32_t (*) (void *)) listen_thread, gv->listener);
+    if (create_thread (&gv->listen_ts, gv, "listen", (uint32_t (*) (void *)) listen_thread, gv->listener) != DDS_RETCODE_OK)
+      GVERROR ("rtps_start: can't create listener thread\n");
     /* FIXME: error handling */
   }
   if (gv->config.monitor_port >= 0)

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -701,7 +701,7 @@ static void wait_for_receive_threads_helper (struct xevent *xev, void *varg, nn_
   if (arg->count++ == arg->gv->config.recv_thread_stop_maxretries)
     abort ();
   trigger_recv_threads (arg->gv);
-  resched_xevent_if_earlier (xev, add_duration_to_mtime (tnow, T_SECOND));
+  (void) resched_xevent_if_earlier (xev, add_duration_to_mtime (tnow, T_SECOND));
 }
 
 static void wait_for_receive_threads (struct q_globals *gv)
@@ -1403,7 +1403,7 @@ int rtps_start (struct q_globals *gv)
   }
   if (gv->listener)
   {
-    create_thread (&gv->listen_ts, gv, "listen", (uint32_t (*) (void *)) listen_thread, gv->listener);
+    (void) create_thread (&gv->listen_ts, gv, "listen", (uint32_t (*) (void *)) listen_thread, gv->listener);
     /* FIXME: error handling */
   }
   if (gv->config.monitor_port >= 0)

--- a/src/core/ddsi/src/q_lease.c
+++ b/src/core/ddsi/src/q_lease.c
@@ -263,13 +263,13 @@ int64_t check_and_handle_lease_expiration (struct q_globals *gv, nn_etime_t tnow
         delete_writer_nolinger (gv, &g);
         break;
       case EK_PROXY_WRITER:
-        delete_proxy_writer (gv, &g, now(), 1);
+        (void) delete_proxy_writer (gv, &g, now(), 1);
         break;
       case EK_READER:
         delete_reader (gv, &g);
         break;
       case EK_PROXY_READER:
-        delete_proxy_reader (gv, &g, now(), 1);
+        (void) delete_proxy_reader (gv, &g, now(), 1);
         break;
     }
 

--- a/src/core/ddsi/src/q_nwif.c
+++ b/src/core/ddsi/src/q_nwif.c
@@ -464,11 +464,11 @@ int find_own_ip (struct q_globals *gv, const char *requested_address)
     char if_name[sizeof (last_if_name)];
     int q = 0;
 
-    ddsrt_strlcpy(if_name, ifa->name, sizeof(if_name));
+    (void) ddsrt_strlcpy(if_name, ifa->name, sizeof(if_name));
 
     if (strcmp (if_name, last_if_name))
       GVLOG (DDS_LC_CONFIG, "%s%s", sep, if_name);
-    ddsrt_strlcpy(last_if_name, if_name, sizeof(last_if_name));
+    (void) ddsrt_strlcpy(last_if_name, if_name, sizeof(last_if_name));
 
     /* interface must be up */
     if ((ifa->flags & IFF_UP) == 0) {

--- a/src/core/ddsi/src/q_pcap.c
+++ b/src/core/ddsi/src/q_pcap.c
@@ -96,7 +96,7 @@ FILE *new_pcap_file (const struct ddsrt_log_cfg *logcfg, const char *name)
   hdr.sigfigs = 0;
   hdr.snaplen = 65535;
   hdr.network = LINKTYPE_RAW;
-  fwrite (&hdr, sizeof (hdr), 1, fp);
+  (void) fwrite (&hdr, sizeof (hdr), 1, fp);
 
   return fp;
   DDSRT_WARNING_MSVC_ON(4996);
@@ -109,7 +109,7 @@ static void write_data (FILE *fp, const ddsrt_msghdr_t *msghdr, size_t sz)
   {
     size_t m1 = msghdr->msg_iov[i].iov_len;
     size_t m = (n + m1 <= sz) ? m1 : sz - n;
-    fwrite (msghdr->msg_iov[i].iov_base, m, 1, fp);
+    (void) fwrite (msghdr->msg_iov[i].iov_base, m, 1, fp);
     n += m;
   }
   assert (n == sz);
@@ -142,20 +142,20 @@ void write_pcap_received (struct q_globals *gv, nn_wctime_t tstamp, const struct
     ddsrt_mutex_lock (&gv->pcap_lock);
     wctime_to_sec_usec (&pcap_hdr.ts_sec, &pcap_hdr.ts_usec, tstamp);
     pcap_hdr.incl_len = pcap_hdr.orig_len = (uint32_t) sz_iud;
-    fwrite (&pcap_hdr, sizeof (pcap_hdr), 1, gv->pcap_fp);
+    (void) fwrite (&pcap_hdr, sizeof (pcap_hdr), 1, gv->pcap_fp);
     u.ipv4_hdr = ipv4_hdr_template;
     u.ipv4_hdr.totallength = ddsrt_toBE2u ((unsigned short) sz_iud);
     u.ipv4_hdr.ttl = 128;
     u.ipv4_hdr.srcip = ((struct sockaddr_in*) src)->sin_addr.s_addr;
     u.ipv4_hdr.dstip = ((struct sockaddr_in*) dst)->sin_addr.s_addr;
     u.ipv4_hdr.checksum = calc_ipv4_checksum (u.x);
-    fwrite (&u.ipv4_hdr, sizeof (u.ipv4_hdr), 1, gv->pcap_fp);
+    (void) fwrite (&u.ipv4_hdr, sizeof (u.ipv4_hdr), 1, gv->pcap_fp);
     udp_hdr.srcport = ((struct sockaddr_in*) src)->sin_port;
     udp_hdr.dstport = ((struct sockaddr_in*) dst)->sin_port;
     udp_hdr.length = ddsrt_toBE2u ((unsigned short) sz_ud);
     udp_hdr.checksum = 0; /* don't have to compute a checksum for UDPv4 */
-    fwrite (&udp_hdr, sizeof (udp_hdr), 1, gv->pcap_fp);
-    fwrite (buf, sz, 1, gv->pcap_fp);
+    (void) fwrite (&udp_hdr, sizeof (udp_hdr), 1, gv->pcap_fp);
+    (void) fwrite (buf, sz, 1, gv->pcap_fp);
     ddsrt_mutex_unlock (&gv->pcap_lock);
   }
 }
@@ -175,19 +175,19 @@ void write_pcap_sent (struct q_globals *gv, nn_wctime_t tstamp, const struct soc
     ddsrt_mutex_lock (&gv->pcap_lock);
     wctime_to_sec_usec (&pcap_hdr.ts_sec, &pcap_hdr.ts_usec, tstamp);
     pcap_hdr.incl_len = pcap_hdr.orig_len = (uint32_t) sz_iud;
-    fwrite (&pcap_hdr, sizeof (pcap_hdr), 1, gv->pcap_fp);
+    (void) fwrite (&pcap_hdr, sizeof (pcap_hdr), 1, gv->pcap_fp);
     u.ipv4_hdr = ipv4_hdr_template;
     u.ipv4_hdr.totallength = ddsrt_toBE2u ((unsigned short) sz_iud);
     u.ipv4_hdr.ttl = 255;
     u.ipv4_hdr.srcip = ((struct sockaddr_in*) src)->sin_addr.s_addr;
     u.ipv4_hdr.dstip = ((struct sockaddr_in*) hdr->msg_name)->sin_addr.s_addr;
     u.ipv4_hdr.checksum = calc_ipv4_checksum (u.x);
-    fwrite (&u.ipv4_hdr, sizeof (u.ipv4_hdr), 1, gv->pcap_fp);
+    (void) fwrite (&u.ipv4_hdr, sizeof (u.ipv4_hdr), 1, gv->pcap_fp);
     udp_hdr.srcport = ((struct sockaddr_in*) src)->sin_port;
     udp_hdr.dstport = ((struct sockaddr_in*) hdr->msg_name)->sin_port;
     udp_hdr.length = ddsrt_toBE2u ((unsigned short) sz_ud);
     udp_hdr.checksum = 0; /* don't have to compute a checksum for UDPv4 */
-    fwrite (&udp_hdr, sizeof (udp_hdr), 1, gv->pcap_fp);
+    (void) fwrite (&udp_hdr, sizeof (udp_hdr), 1, gv->pcap_fp);
     write_data (gv->pcap_fp, hdr, sz);
     ddsrt_mutex_unlock (&gv->pcap_lock);
   }

--- a/src/core/ddsi/src/q_radmin.c
+++ b/src/core/ddsi/src/q_radmin.c
@@ -2535,7 +2535,7 @@ struct nn_dqueue *nn_dqueue_new (const char *name, const struct q_globals *gv, u
   thrnamesz = 3 + strlen (name) + 1;
   if ((thrname = ddsrt_malloc (thrnamesz)) == NULL)
     goto fail_thrname;
-  snprintf (thrname, thrnamesz, "dq.%s", name);
+  (void) snprintf (thrname, thrnamesz, "dq.%s", name);
   if (create_thread (&q->ts, gv, thrname, (uint32_t (*) (void *)) dqueue_thread, q) != DDS_RETCODE_OK)
     goto fail_thread;
   ddsrt_free (thrname);
@@ -2648,7 +2648,7 @@ void nn_dqueue_enqueue1 (struct nn_dqueue *q, const ddsi_guid_t *rdguid, struct 
   ddsrt_atomic_add32 (&q->nof_samples, 1 + (uint32_t) rres);
   if (nn_dqueue_enqueue_bubble_locked (q, b))
     ddsrt_cond_broadcast (&q->cond);
-  nn_dqueue_enqueue_locked (q, sc);
+  (void) nn_dqueue_enqueue_locked (q, sc);
   ddsrt_mutex_unlock (&q->lock);
 }
 

--- a/src/core/ddsi/src/q_receive.c
+++ b/src/core/ddsi/src/q_receive.c
@@ -2891,6 +2891,9 @@ static bool do_packet (struct thread_state1 * const ts1, struct q_globals *gv, d
   {
     return false;
   }
+
+  assert(sizeof(struct nn_rmsg) == offsetof(struct nn_rmsg, chunk) + sizeof(struct nn_rmsg_chunk));
+
   buff = (unsigned char *) NN_RMSG_PAYLOAD (rmsg);
   hdr = (Header_t*) buff;
 

--- a/src/core/ddsi/src/q_receive.c
+++ b/src/core/ddsi/src/q_receive.c
@@ -1346,7 +1346,7 @@ static int handle_HeartbeatFrag (struct receiver_state *rst, UNUSED_ARG(nn_etime
            samples we no longer care about) */
         int64_t delay = rst->gv->config.nack_delay;
         RSTTRACE ("/nackfrag");
-        resched_xevent_if_earlier (m->acknack_xevent, add_duration_to_mtime (now_mt(), delay));
+        (void) resched_xevent_if_earlier (m->acknack_xevent, add_duration_to_mtime (now_mt(), delay));
       }
     }
   }
@@ -2896,7 +2896,7 @@ static bool do_packet (struct thread_state1 * const ts1, struct q_globals *gv, d
 
   if (conn->m_stream)
   {
-    MsgLen_t * ml = (MsgLen_t*) (buff + RTPS_MESSAGE_HEADER_SIZE);
+    MsgLen_t * ml = (MsgLen_t*) (hdr + 1);
 
     /*
       Read in packet header to get size of packet in MsgLen_t, then read in

--- a/src/core/ddsi/src/q_sockwaitset.c
+++ b/src/core/ddsi/src/q_sockwaitset.c
@@ -704,8 +704,8 @@ void os_sockWaitsetFree (os_sockWaitset ws)
   closesocket (ws->pipe[0]);
   closesocket (ws->pipe[1]);
 #elif !defined(LWIP_SOCKET)
-  close (ws->pipe[0]);
-  close (ws->pipe[1]);
+  (void) close (ws->pipe[0]);
+  (void) close (ws->pipe[1]);
 #endif
 #if defined(__VXWORKS__) && defined(__RTP__)
   pipeDevDelete ((char*) &nameBuf, 0);

--- a/src/core/ddsi/src/q_thread.c
+++ b/src/core/ddsi/src/q_thread.c
@@ -251,7 +251,7 @@ static struct thread_state1 *init_thread_state (const char *tname, const struct 
   ts = &thread_states.ts[cand];
   ddsrt_atomic_stvoidp (&ts->gv, (struct q_globals *) gv);
   assert (vtime_asleep_p (ddsrt_atomic_ld32 (&ts->vtime)));
-  ddsrt_strlcpy (ts->name, tname, sizeof (ts->name));
+  (void) ddsrt_strlcpy (ts->name, tname, sizeof (ts->name));
   ts->state = state;
 
   return ts;

--- a/src/core/ddsi/src/q_transmit.c
+++ b/src/core/ddsi/src/q_transmit.c
@@ -120,7 +120,7 @@ void writer_hbcontrol_note_asyncwrite (struct writer *wr, nn_mtime_t tnow)
        least one unacked msg if there are reliable readers, so must
        have a heartbeat scheduled.  Do so now */
     hbc->tsched = tnext;
-    resched_xevent_if_earlier (wr->heartbeat_xevent, tnext);
+    (void) resched_xevent_if_earlier (wr->heartbeat_xevent, tnext);
   }
 }
 

--- a/src/core/ddsi/src/q_xevent.c
+++ b/src/core/ddsi/src/q_xevent.c
@@ -623,7 +623,7 @@ static void handle_xevk_heartbeat (struct nn_xpack *xp, struct xevent *ev, nn_mt
            ddsrt_avl_is_empty (&wr->readers) ? (seqno_t) -1 : ((struct wr_prd_match *) ddsrt_avl_root_non_empty (&wr_readers_treedef, &wr->readers))->min_seq,
            ddsrt_avl_is_empty (&wr->readers) || ((struct wr_prd_match *) ddsrt_avl_root_non_empty (&wr_readers_treedef, &wr->readers))->all_have_replied_to_hb ? "" : "!",
            whcst.max_seq, writer_read_seq_xmit (wr));
-  resched_xevent_if_earlier (ev, t_next);
+  (void) resched_xevent_if_earlier (ev, t_next);
   wr->hbcontrol.tsched = t_next;
   ddsrt_mutex_unlock (&wr->e.lock);
 
@@ -895,7 +895,7 @@ static void handle_xevk_acknack (UNUSED_ARG (struct nn_xpack *xp), struct xevent
          HEARTBEAT, I've seen too many cases of not sending an NACK
          because the writing side got confused ...  Better to recover
          eventually. */
-      resched_xevent_if_earlier (ev, add_duration_to_mtime (tnow, gv->config.auto_resched_nack_delay));
+      (void) resched_xevent_if_earlier (ev, add_duration_to_mtime (tnow, gv->config.auto_resched_nack_delay));
     }
     GVTRACE ("send acknack(rd "PGUIDFMT" -> pwr "PGUIDFMT")\n",
              PGUID (ev->u.acknack.rd_guid), PGUID (ev->u.acknack.pwr_guid));
@@ -921,7 +921,7 @@ static void handle_xevk_acknack (UNUSED_ARG (struct nn_xpack *xp), struct xevent
       intv = 5;
     else
       intv = 10;
-    resched_xevent_if_earlier (ev, add_duration_to_mtime (tnow, intv * T_SECOND));
+    (void) resched_xevent_if_earlier (ev, add_duration_to_mtime (tnow, intv * T_SECOND));
   }
   ddsrt_mutex_unlock (&pwr->e.lock);
 
@@ -934,7 +934,7 @@ static void handle_xevk_acknack (UNUSED_ARG (struct nn_xpack *xp), struct xevent
  outofmem:
   /* What to do if out of memory?  Crash or burn? */
   ddsrt_mutex_unlock (&pwr->e.lock);
-  resched_xevent_if_earlier (ev, add_duration_to_mtime (tnow, 100 * T_MILLISECOND));
+  (void) resched_xevent_if_earlier (ev, add_duration_to_mtime (tnow, 100 * T_MILLISECOND));
 }
 
 static bool resend_spdp_sample_by_guid_key (struct writer *wr, const ddsi_guid_t *guid, struct proxy_reader *prd)
@@ -1059,7 +1059,7 @@ static void handle_xevk_spdp (UNUSED_ARG (struct nn_xpack *xp), struct xevent *e
                PGUID (pp->e.guid),
                PGUIDPREFIX (ev->u.spdp.dest_proxypp_guid_prefix), NN_ENTITYID_SPDP_BUILTIN_PARTICIPANT_READER,
                (double)(tnext.v - tnow.v) / 1e9);
-      resched_xevent_if_earlier (ev, tnext);
+      (void) resched_xevent_if_earlier (ev, tnext);
     }
   }
   else
@@ -1086,7 +1086,7 @@ static void handle_xevk_spdp (UNUSED_ARG (struct nn_xpack *xp), struct xevent *e
              PGUID (pp->e.guid),
              PGUIDPREFIX (ev->u.spdp.dest_proxypp_guid_prefix), NN_ENTITYID_SPDP_BUILTIN_PARTICIPANT_READER,
              (double)(tnext.v - tnow.v) / 1e9);
-    resched_xevent_if_earlier (ev, tnext);
+    (void) resched_xevent_if_earlier (ev, tnext);
   }
 }
 
@@ -1168,7 +1168,7 @@ static void handle_xevk_pmd_update (struct thread_state1 * const ts1, struct nn_
     GVTRACE ("resched pmd("PGUIDFMT"): %gs\n", PGUID (pp->e.guid), (double)(tnext.v - tnow.v) / 1e9);
   }
 
-  resched_xevent_if_earlier (ev, tnext);
+  (void) resched_xevent_if_earlier (ev, tnext);
   ddsrt_mutex_unlock (&pp->e.lock);
 }
 

--- a/src/core/ddsi/src/q_xmsg.c
+++ b/src/core/ddsi/src/q_xmsg.c
@@ -1217,7 +1217,8 @@ void nn_xpack_sendq_init (struct q_globals *gv)
 
 void nn_xpack_sendq_start (struct q_globals *gv)
 {
-  (void) create_thread (&gv->sendq_ts, gv, "sendq", nn_xpack_sendq_thread, NULL);
+  if (create_thread (&gv->sendq_ts, gv, "sendq", nn_xpack_sendq_thread, NULL) != DDS_RETCODE_OK)
+    GVERROR ("nn_xpack_sendq_start: can't create nn_xpack_sendq_thread\n");
 }
 
 void nn_xpack_sendq_stop (struct q_globals *gv)

--- a/src/core/ddsi/src/q_xmsg.c
+++ b/src/core/ddsi/src/q_xmsg.c
@@ -1188,7 +1188,7 @@ static uint32_t nn_xpack_sendq_thread (void *vgv)
     struct nn_xpack *xp;
     if ((xp = gv->sendq_head) == NULL)
     {
-      ddsrt_cond_waitfor (&gv->sendq_cond, &gv->sendq_lock, 1000000);
+      (void) ddsrt_cond_waitfor (&gv->sendq_cond, &gv->sendq_lock, 1000000);
     }
     else
     {
@@ -1217,7 +1217,7 @@ void nn_xpack_sendq_init (struct q_globals *gv)
 
 void nn_xpack_sendq_start (struct q_globals *gv)
 {
-  create_thread (&gv->sendq_ts, gv, "sendq", nn_xpack_sendq_thread, NULL);
+  (void) create_thread (&gv->sendq_ts, gv, "sendq", nn_xpack_sendq_thread, NULL);
 }
 
 void nn_xpack_sendq_stop (struct q_globals *gv)

--- a/src/core/xtests/rhc_torture/rhc_torture.c
+++ b/src/core/xtests/rhc_torture/rhc_torture.c
@@ -70,7 +70,7 @@ static char *print_tstamp (char *buf, size_t sz, dds_time_t t)
   if (d / 1000000000 != 0)
     pos += (size_t) snprintf (buf + pos, sz - pos, "%+ds", (int) (d / 1000000000));
   if (d % 1000000000 != 0)
-    snprintf (buf + pos, sz - pos, "%+dns", (int) (d % 1000000000));
+	(void) snprintf (buf + pos, sz - pos, "%+dns", (int) (d % 1000000000));
   return buf;
 }
 
@@ -439,7 +439,7 @@ static void print_condmask (char *buf, size_t bufsz, const dds_readcond *cond)
       pos += (size_t) snprintf (buf + pos, bufsz - pos, "%sALIVE | DISPOSED", sep);
       break;
   }
-  snprintf (buf + pos, bufsz - pos, "]");
+  (void) snprintf (buf + pos, bufsz - pos, "]");
 }
 
 static void rdcond (struct dds_rhc *rhc, dds_readcond *cond, const struct check *chk, int max, bool print, uint32_t states_seen[STATIC_ARRAY_DIM 2*2*3][2])

--- a/src/ddsrt/src/expand_envvars.c
+++ b/src/ddsrt/src/expand_envvars.c
@@ -42,10 +42,10 @@ static char *expand_env (const char *name, char op, const char *alt, expand_fn e
     if ((ret = ddsrt_getenv (name, &env)) == DDS_RETCODE_OK) {
         /* ok */
     } else if (strcmp (name, "$") == 0 || strcmp (name, "CYCLONEDDS_PID") == 0) {
-        snprintf (idstr, sizeof (idstr), "%"PRIdPID, ddsrt_getpid ());
+        (void) snprintf (idstr, sizeof (idstr), "%"PRIdPID, ddsrt_getpid ());
         env = idstr;
     } else if (strcmp (name, "CYCLONEDDS_DOMAIN_ID") == 0 && domid != UINT32_MAX) {
-        snprintf (idstr, sizeof (idstr), "%"PRIu32, domid);
+        (void) snprintf (idstr, sizeof (idstr), "%"PRIu32, domid);
         env = idstr;
     }
 

--- a/src/ddsrt/src/ifaddrs/posix/ifaddrs.c
+++ b/src/ddsrt/src/ifaddrs/posix/ifaddrs.c
@@ -94,7 +94,7 @@ static enum ddsrt_iftype guess_iftype (const struct ifaddrs *sys_ifa)
   struct ifmediareq ifmr;
   enum ddsrt_iftype type;
   memset (&ifmr, 0, sizeof (ifmr));
-  ddsrt_strlcpy (ifmr.ifm_name, sys_ifa->ifa_name, sizeof (ifmr.ifm_name));
+  (void) ddsrt_strlcpy (ifmr.ifm_name, sys_ifa->ifa_name, sizeof (ifmr.ifm_name));
   if (ioctl (sock, SIOCGIFMEDIA, (caddr_t) &ifmr) < 0)
   {
     type = DDSRT_IFTYPE_UNKNOWN;

--- a/src/ddsrt/src/log.c
+++ b/src/ddsrt/src/log.c
@@ -54,7 +54,7 @@ static void default_sink (void *ptr, const dds_log_data_t *data)
 {
   if (ptr)
   {
-    fwrite (data->message - data->hdrsize, 1, data->hdrsize + data->size + 1, (FILE *) ptr);
+    (void) fwrite (data->message - data->hdrsize, 1, data->hdrsize + data->size + 1, (FILE *) ptr);
     fflush ((FILE *) ptr);
   }
 }

--- a/src/ddsrt/src/process/posix/process.c
+++ b/src/ddsrt/src/process/posix/process.c
@@ -203,8 +203,8 @@ ddsrt_proc_create(
     if (write(exec_fds[1], &exec_err, sizeof(int)) < (ssize_t)sizeof(int)) {
       DDS_ERROR("Could not write proc error pipe.\n");
     }
-    close(exec_fds[1]);
-    close(exec_fds[0]);
+    (void) close(exec_fds[1]);
+    (void) close(exec_fds[0]);
     ddsrt_free(exec_argv);
     _exit(1);
   }
@@ -214,7 +214,7 @@ ddsrt_proc_create(
 
     /* Get execv result. */
     rv = DDS_RETCODE_ERROR;
-    close(exec_fds[1]);
+    (void) close(exec_fds[1]);
     nr = read(exec_fds[0], &exec_err, sizeof(int));
     if (nr == 0) {
       /* Pipe closed by successful execv. */
@@ -228,14 +228,14 @@ ddsrt_proc_create(
         rv = DDS_RETCODE_NOT_ALLOWED;
       }
     }
-    close(exec_fds[0]);
+    (void) close(exec_fds[0]);
 
     if (rv == DDS_RETCODE_OK) {
       /* Remember child pid. */
       *pid = spawn;
     } else {
       /* Remove the failed fork pid from the system list. */
-      waitpid(spawn, NULL, 0);
+      (void) waitpid(spawn, NULL, 0);
     }
   }
 
@@ -244,8 +244,8 @@ ddsrt_proc_create(
 
 fail_fork:
 fail_fctl:
-  close(exec_fds[0]);
-  close(exec_fds[1]);
+  (void) close(exec_fds[0]);
+  (void) close(exec_fds[1]);
 fail_pipe:
   ddsrt_free(exec_argv);
   return rv;

--- a/src/ddsrt/src/rusage/posix/rusage.c
+++ b/src/ddsrt/src/rusage/posix/rusage.c
@@ -109,7 +109,7 @@ ddsrt_getrusage_anythread (
     return DDS_RETCODE_ERROR;
   if ((fp = fopen (file, "r")) == NULL)
     return DDS_RETCODE_NOT_FOUND;
-  enum { ERROR, READ_HEADING, SKIP_TO_EOL, READ_VCSW, READ_IVCSW } state = READ_HEADING;
+  enum { ERROR = 1, READ_HEADING, SKIP_TO_EOL, READ_VCSW, READ_IVCSW } state = READ_HEADING;
   savepos = 0;
   while (state != ERROR && (c = fgetc (fp)) != EOF)
   {

--- a/src/ddsrt/src/threads/posix/threads.c
+++ b/src/ddsrt/src/threads/posix/threads.c
@@ -126,7 +126,7 @@ ddsrt_thread_setname(const char *__restrict name)
   /* Thread names are limited to 16 bytes on Linux. ERANGE is returned if the
      name exceeds the limit, so silently truncate. */
   char buf[MAXTHREADNAMESIZE + 1] = "";
-  ddsrt_strlcpy(buf, name, sizeof(buf));
+  (void)ddsrt_strlcpy(buf, name, sizeof(buf));
   (void)pthread_setname_np(pthread_self(), name);
 #elif defined(__APPLE__)
   (void)pthread_setname_np(name);

--- a/src/ddsrt/src/threads/windows/threads.c
+++ b/src/ddsrt/src/threads/windows/threads.c
@@ -313,7 +313,7 @@ ddsrt_thread_setname(
     }
 #pragma warning(pop)
   }
-  ddsrt_strlcpy (thread_name, name, sizeof (thread_name));
+  (void)ddsrt_strlcpy (thread_name, name, sizeof (thread_name));
 }
 
 dds_return_t

--- a/src/ddsrt/src/xmlparser.c
+++ b/src/ddsrt/src/xmlparser.c
@@ -459,10 +459,10 @@ static int next_token_tag_withoutclose (struct ddsrt_xmlp_state *st, char **payl
     } else {
         int tok = TOK_OPEN_TAG;
         /* pre: peek_char(st) == '<' */
-        next_char (st);
+        (void) next_char (st);
         if (peek_char (st) == '/') {
             tok = TOK_CLOSE_TAG;
-            next_char (st);
+            (void) next_char (st);
         }
         /* we only do tag names that are identifiers */
         if (peek_char (st) == '>' && (st->options & DDSRT_XMLP_ANONYMOUS_CLOSE_TAG)) {
@@ -501,7 +501,7 @@ static int skip_comment (struct ddsrt_xmlp_state *st)
         return 0;
     }
     while (peek_char (st) != TOK_EOF && (peek_char (st) != '-' || !peek_chars (st, "-->", 0))) {
-        next_char (st);
+        (void) next_char (st);
     }
     if (peek_chars (st, "-->", 1)) {
         return 1;
@@ -514,7 +514,7 @@ static void processing_instruction (struct ddsrt_xmlp_state *st, const char *end
 {
     /* just after <?; skip everything up to and include ?> */
     while (peek_char (st) != TOK_EOF && !peek_chars (st, end, 1)) {
-        next_char (st);
+        (void) next_char (st);
     }
 }
 
@@ -551,7 +551,7 @@ static int next_token (struct ddsrt_xmlp_state *st, char **payload)
         st->prevline = st->line;
         do {
             while (qq_isspace (peek_char (st))) {
-                next_char (st);
+                (void) next_char (st);
             }
         } while ((cmt = skip_comment (st)) > 0);
         if (cmt == TOK_ERROR) {

--- a/src/ddsrt/tests/log.c
+++ b/src/ddsrt/tests/log.c
@@ -435,13 +435,13 @@ static void abort_handler (int sig)
 static void abort_log (void *arg, const dds_log_data_t *info)
 {
   (void) arg;
-  ddsrt_strlcpy (abort_message, info->message, sizeof (abort_message));
+  (void) ddsrt_strlcpy (abort_message, info->message, sizeof (abort_message));
 }
 
 static void abort_trace (void *arg, const dds_log_data_t *info)
 {
   (void) arg;
-  ddsrt_strlcpy (abort_message_trace, info->message, sizeof (abort_message_trace));
+  (void) ddsrt_strlcpy (abort_message_trace, info->message, sizeof (abort_message_trace));
 }
 
 CU_TheoryDataPoints(dds_log, fatal_aborts) = {

--- a/src/ddsrt/tests/socket.c
+++ b/src/ddsrt/tests/socket.c
@@ -157,7 +157,7 @@ CU_Test(ddsrt_sockets, gethostname)
 
   sysbuf[0] = '\0';
 #if LWIP_SOCKET
-  ddsrt_strlcpy(sysbuf, "localhost", sizeof(sysbuf));
+  (void) ddsrt_strlcpy(sysbuf, "localhost", sizeof(sysbuf));
 #else
   int ret = gethostname(sysbuf, sizeof(sysbuf));
   CU_ASSERT_EQUAL(ret, 0);

--- a/src/tools/ddsls/ddsls.c
+++ b/src/tools/ddsls/ddsls.c
@@ -27,9 +27,9 @@
 static char *qp_duration_str (char *buf, size_t bufsz, dds_duration_t d)
 {
   if (d == DDS_INFINITY)
-    snprintf (buf, bufsz, "infinite");
+    (void) snprintf (buf, bufsz, "infinite");
   else
-    snprintf (buf, bufsz, "%u.%09u", (unsigned)(d / DDS_NSECS_IN_SEC), (unsigned)(d % DDS_NSECS_IN_SEC));
+    (void) snprintf (buf, bufsz, "%u.%09u", (unsigned)(d / DDS_NSECS_IN_SEC), (unsigned)(d % DDS_NSECS_IN_SEC));
   return buf;
 }
 
@@ -443,9 +443,9 @@ static void print_dcps_participant (FILE *fp, dds_entity_t pp)
         qp_qos (data->qos, fp);
       }
     }
-    dds_return_loan (rd, ptrs, n);
+    (void) dds_return_loan (rd, ptrs, n);
   }
-  dds_delete (rd);
+  (void) dds_delete (rd);
 }
 
 static void print_dcps_endpoint (FILE *fp, dds_entity_t pp, const char *type, dds_entity_t topic)
@@ -472,9 +472,9 @@ static void print_dcps_endpoint (FILE *fp, dds_entity_t pp, const char *type, dd
         qp_qos (data->qos,fp);
       }
     }
-    dds_return_loan (rd, ptrs, n);
+    (void) dds_return_loan (rd, ptrs, n);
   }
-  dds_delete (rd);
+  (void) dds_delete (rd);
 }
 
 static void print_dcps_subscription (FILE *fp, dds_entity_t pp)

--- a/src/tools/ddsperf/cputime.c
+++ b/src/tools/ddsperf/cputime.c
@@ -180,7 +180,7 @@ bool record_cputime (struct record_cputime_state *state, const char *prefix, dds
   }
   state->tprev = tnow;
   state->s.some_above = some_above;
-  dds_write (state->wr, &state->s);
+  (void) dds_write (state->wr, &state->s);
   return print_cputime (&state->s, prefix, false, true);
 }
 

--- a/src/tools/ddsperf/ddsperf.c
+++ b/src/tools/ddsperf/ddsperf.c
@@ -1865,7 +1865,7 @@ int main (int argc, char *argv[])
       case 'd': {
         char *col;
         int pos;
-        ddsrt_strlcpy (netload_if, optarg, sizeof (netload_if));
+        (void) ddsrt_strlcpy (netload_if, optarg, sizeof (netload_if));
         if ((col = strrchr (netload_if, ':')) == NULL || col == netload_if ||
             (sscanf (col+1, "%lf%n", &netload_bw, &pos) != 1 || (col+1)[pos] != 0))
           error3 ("-d%s: expected DEVICE:BANDWIDTH\n", optarg);

--- a/src/tools/pubsub/pubsub.c
+++ b/src/tools/pubsub/pubsub.c
@@ -280,7 +280,7 @@ static char *expand_envvars(const char *src0);
 // FIXME: This is the same as the expand function in util. Merge.
 static char *expand_env(const char *name, char op, const char *alt) {
     char *env = NULL;
-    ddsrt_getenv(name, &env);
+    (void) ddsrt_getenv(name, &env);
     switch (op) {
     case 0:
         return dds_string_dup(env ? env : "");
@@ -1427,7 +1427,7 @@ static char *pub_do_nonarb(const struct writerspec *spec, uint32_t *seq) {
         case 'Q': {
             dds_qos_t *qos = dds_create_qos ();
             setqos_from_args (DDS_KIND_PARTICIPANT, qos, 1, (const char **) &arg);
-            dds_set_qos (dp, qos);
+            (void) dds_set_qos (dp, qos);
             dds_delete_qos (qos);
             break;
           }
@@ -2058,8 +2058,8 @@ static uint32_t autotermthread(void *varg __attribute__((unused))) {
         tnow = dds_time();
     }
 
-    dds_waitset_detach(ws, termcond);
-    dds_delete(ws);
+    (void) dds_waitset_detach(ws, termcond);
+    (void) dds_delete(ws);
     return 0;
 }
 

--- a/src/tools/pubsub/pubsub.c
+++ b/src/tools/pubsub/pubsub.c
@@ -266,162 +266,6 @@ Use \"\" for default partition.\n",
     exit (1);
 }
 
-static void expand_append(char **dst, size_t *sz,size_t *pos, char c) {
-    if (*pos == *sz) {
-        *sz += 1024;
-        *dst = dds_realloc(*dst, *sz);
-    }
-    (*dst)[*pos] = c;
-    (*pos)++;
-}
-
-static char *expand_envvars(const char *src0);
-
-// FIXME: This is the same as the expand function in util. Merge.
-static char *expand_env(const char *name, char op, const char *alt) {
-    char *env = NULL;
-    (void) ddsrt_getenv(name, &env);
-    switch (op) {
-    case 0:
-        return dds_string_dup(env ? env : "");
-    case '-':
-        return env ? dds_string_dup(env) : expand_envvars(alt);
-    case '?':
-        if (env)
-            return dds_string_dup(env);
-        else {
-            char *altx = expand_envvars(alt);
-            error_exit("%s: %s\n", name, altx);
-            dds_free(altx);
-            return NULL;
-        }
-    case '+':
-        return env ? expand_envvars(alt) : dds_string_dup("");
-    default:
-        exit(2);
-    }
-}
-
-static char *expand_envbrace(const char **src) {
-    const char *start = *src + 1;
-    char *name, *x;
-    assert(**src == '{');
-    (*src)++;
-    while (**src && **src != ':' && **src != '}')
-        (*src)++;
-    if (**src == 0)
-        goto err;
-
-    name = dds_alloc((size_t) (*src - start) + 1);
-    memcpy(name, start, (size_t) (*src - start));
-    name[*src - start] = 0;
-    if (**src == '}') {
-        (*src)++;
-        x = expand_env(name, 0, NULL);
-        dds_free(name);
-        return x;
-    } else {
-        const char *altstart;
-        char *alt;
-        char op;
-        assert(**src == ':');
-        (*src)++;
-
-        switch (**src) {
-        case '-': case '+': case '?':
-            op = **src;
-            (*src)++;
-            break;
-        default:
-            goto err;
-        }
-
-        altstart = *src;
-        while (**src && **src != '}') {
-            if (**src == '\\') {
-                (*src)++;
-                if (**src == 0)
-                goto err;
-            }
-            (*src)++;
-        }
-        if (**src == 0)
-            goto err;
-        assert(**src == '}');
-        alt = dds_alloc((size_t) (*src - altstart) + 1);
-        memcpy(alt, altstart, (size_t) (*src - altstart));
-        alt[*src - altstart] = 0;
-        (*src)++;
-        x = expand_env(name, op, alt);
-        dds_free(alt);
-        dds_free(name);
-        return x;
-    }
-
-    err:
-        error_exit("%*.*s: invalid expansion\n", (int) (*src - start), (int) (*src - start), start);
-    return NULL;
-}
-
-static char *expand_envsimple(const char **src) {
-    const char *start = *src;
-    char *name, *x;
-    while (**src && (isalnum((unsigned char)**src) || **src == '_'))
-        (*src)++;
-    assert(*src > start);
-    name = dds_alloc((size_t) (*src - start) + 1);
-    memcpy(name, start, (size_t) (*src - start));
-    name[*src - start] = 0;
-    x = expand_env(name, 0, NULL);
-    dds_free(name);
-    return x;
-}
-
-static char *expand_envchar(const char **src) {
-    char name[2];
-    assert(**src);
-    name[0] = **src;
-    name[1] = 0;
-    (*src)++;
-    return expand_env(name, 0, NULL);
-}
-
-static char *expand_envvars(const char *src0) {
-    /* Expands $X, ${X}, ${X:-Y}, ${X:+Y}, ${X:?Y} forms */
-    const char *src = src0;
-    size_t sz = strlen(src) + 1, pos = 0;
-    char *dst = dds_alloc(sz);
-    while (*src) {
-        if (*src == '\\') {
-            src++;
-            if (*src == 0)
-                error_exit("%s: incomplete escape at end of string\n", src0);
-            expand_append(&dst, &sz, &pos, *src++);
-        } else if (*src == '$') {
-            char *x, *xp;
-            src++;
-            if (*src == 0) {
-                error_exit("%s: incomplete variable expansion at end of string\n", src0);
-                return NULL;
-            } else if (*src == '{') {
-                x = expand_envbrace(&src);
-            } else if (isalnum((unsigned char)*src) || *src == '_') {
-                x = expand_envsimple(&src);
-            } else {
-                x = expand_envchar(&src);
-            }
-            xp = x;
-            while (*xp)
-                expand_append(&dst, &sz, &pos, *xp++);
-            dds_free(x);
-        } else {
-            expand_append(&dst, &sz, &pos, *src++);
-        }
-    }
-    expand_append(&dst, &sz, &pos, 0);
-    return dst;
-}
-
 static unsigned split_partitions(const char ***p_ps, char **p_bufcopy, const char *buf) {
     const char *b;
     const char **ps;
@@ -432,7 +276,7 @@ static unsigned split_partitions(const char ***p_ps, char **p_bufcopy, const cha
         nps += (*b == ',');
     }
     ps = dds_alloc(nps * sizeof(*ps));
-    bufcopy = expand_envvars(buf);
+    bufcopy = ddsrt_expand_envvars_sh(buf, 0);
     i = 0; bc = bufcopy;
     while (1) {
         ps[i++] = bc;
@@ -2646,7 +2490,7 @@ int main(int argc, char *argv[]) {
     {
         char **ps = (char **) dds_alloc(sizeof(char *) * (uint32_t)(argc - optind));
         for (i = 0; i < (unsigned) (argc - optind); i++)
-            ps[i] = expand_envvars(argv[(unsigned) optind + i]);
+            ps[i] = ddsrt_expand_envvars_sh(argv[(unsigned) optind + i], 0);
         if (want_reader) {
             qos = dds_create_qos();
             setqos_from_args(DDS_KIND_SUBSCRIBER, qos, nqsubscriber, qsubscriber);
@@ -2704,7 +2548,7 @@ int main(int argc, char *argv[]) {
             fprintf (stderr,"C99 API doesn't support the creation of content filtered topic.\n");
             spec[i].cftp = spec[i].tp;
 //            TODO Content Filtered Topic support
-//            char name[40], *expr = expand_envvars(spec[i].cftp_expr);
+//            char name[40], *expr = expand_envvars_sh(spec[i].cftp_exp, 0);
 //            DDS_StringSeq *params = DDS_StringSeq__alloc();
 //            snprintf (name, sizeof (name), "cft%u", i);
 //            if ((spec[i].cftp = DDS_DomainParticipant_create_contentfilteredtopic(dp, name, spec[i].tp, expr, params)) == NULL)


### PR DESCRIPTION
- Fixed a lot of 'unchecked return value' issues.
- Fixed 'illegal address computation' issue in do_packet() function by using pointer arithmetic i.s.o. using offsets.
- Allocate array of samples from heap i.s.o. using local variable on stack in throughput/subscriber example.

Travis job with compiler 'clang Xcode: xcode9 C' is failing, but that is a known problem.