### PR TITLE
Update macOS images on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,9 +68,9 @@ linux_clang: &linux_clang
   install:
     - pip install conan --upgrade --user
 
-osx_xcode10_3: &osx_xcode10_3
+osx_xcode: &osx_xcode
   os: osx
-  osx_image: xcode10.3
+  osx_image: xcode11.1
   compiler: clang
   addons:
     homebrew:
@@ -84,7 +84,7 @@ osx_xcode10_3: &osx_xcode10_3
     - python3 -m pip install conan --upgrade --user
 
 osx_xcode9: &osx_xcode9
-  <<: *osx_xcode10_3
+  <<: *osx_xcode
   osx_image: xcode9
   cache:
     directories:
@@ -165,9 +165,9 @@ jobs:
       env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, SSL=YES, GENERATOR="Unix Makefiles" ]
     - <<: *osx_xcode9
       env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, SSL=NO, GENERATOR="Unix Makefiles" ]
-    - <<: *osx_xcode10_3
+    - <<: *osx_xcode
       env: [ ARCH=x86_64, ASAN=address, BUILD_TYPE=Debug, SSL=YES, GENERATOR="Unix Makefiles" ]
-    - <<: *osx_xcode10_3
+    - <<: *osx_xcode
       env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, SSL=YES, GENERATOR="Unix Makefiles" ]
     - <<: *windows_vs2017
       env: [ ARCH=x86, ASAN=none, BUILD_TYPE=Debug, SSL=YES, GENERATOR="Visual Studio 15 2017" ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,10 +86,6 @@ osx_xcode: &osx_xcode
 osx_xcode9: &osx_xcode9
   <<: *osx_xcode
   osx_image: xcode9
-  cache:
-    directories:
-      - $HOME/Library/Caches/Homebrew
-      - /usr/local/Homebrew
   addons:
     homebrew:
       packages: [ python3 ]
@@ -99,11 +95,6 @@ osx_xcode9: &osx_xcode9
       # used to ensure Homebrew is kept up-to-date and build times are kept to
       # a minimum.
       update: true
-  before_cache:
-    - brew cleanup
-    - find /usr/local/Homebrew -type d -name .git |
-      xargs -I {} dirname {} |
-      xargs -I {} git --git-dir={}/.git --work-tree={} clean -f -d -x
 
 windows_vs2017: &windows_vs2017
   os: windows
@@ -165,6 +156,9 @@ jobs:
       env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, SSL=YES, GENERATOR="Unix Makefiles" ]
     - <<: *osx_xcode9
       env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, SSL=NO, GENERATOR="Unix Makefiles" ]
+      if: type = cron
+    - <<: *osx_xcode
+      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, SSL=NO, GENERATOR="Unix Makefiles", MACOSX_DEPLOYMENT_TARGET=10.12 ]
     - <<: *osx_xcode
       env: [ ARCH=x86_64, ASAN=address, BUILD_TYPE=Debug, SSL=YES, GENERATOR="Unix Makefiles" ]
     - <<: *osx_xcode

--- a/src/mpt/tests/qos/procs/rw.c
+++ b/src/mpt/tests/qos/procs/rw.c
@@ -302,8 +302,6 @@ MPT_ProcessEntry (rw_publisher,
                              i, j, dds_strretcode (rc));
         if (st.current_count)
         {
-          printf ("%zu %zu: %d\n", i, j, (int) st.current_count);
-          fflush (stdout);
           goto have_matches;
         }
       }


### PR DESCRIPTION
This updates the macOS builds:

1. The regular builds get upgraded from the Xcode 10.3 image to the Xcode 11.1 one. Shortly after Xcode 11 got released, builds on the Xcode 10.3 image starting taking forever, and moving to a newer image speeds things up again.
2. The Xcode 9 / macOS 10.12 build is replaced by a build targetting macOS 10.12. Targetting an earlier version is different from building on it in two ways. Firstly, in what macros are defined (in particular macOS version macros). Secondly, in that the tests run on the later version.
3. The cron job should now periodically build on Xcode 9 / macOS 10.12

This should make the PR builds less flaky and much faster.

(The other commit is just something I noticed. Sometimes that tests prints 100s of thousands of identical lines of no value while one side waits for the other to stop.)