### PR TITLE
Namespace the schema and add references in xml files — take 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ point to it.  E.g. (on Linux):
 
     $ cat cyclonedds.xml
     <?xml version="1.0" encoding="UTF-8" ?>
-    <CycloneDDS xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://github.com/eclipse-cyclonedds/cyclonedds/etc/cyclonedds.xsd">
+    <CycloneDDS <CycloneDDS xmlns="https://cdds.io/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://cdds.io/config https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/master/etc/cyclonedds.xsd">
     <CycloneDDS>
         <Domain id="any">
             <General>

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -8,5 +8,43 @@
 # http://www.eclipse.org/org/documents/edl-v10.php.
 #
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
-add_subdirectory(manual)
+include(FindPerl)
+if(PERL_FOUND)
+  add_custom_command(
+    OUTPUT
+      options.md cyclonedds.rnc
+    COMMAND
+      ${PERL_EXECUTABLE} -w "${CMAKE_CURRENT_SOURCE_DIR}/makernc.pl" "${CMAKE_CURRENT_SOURCE_DIR}/../src/core/ddsi/src/q_config.c" options.md cyclonedds.rnc
+    COMMAND
+      ${PERL_EXECUTABLE} -w "${CMAKE_CURRENT_SOURCE_DIR}/compare.pl" options.md "${CMAKE_CURRENT_SOURCE_DIR}/manual/options.md"
+    COMMAND
+      ${PERL_EXECUTABLE} -w "${CMAKE_CURRENT_SOURCE_DIR}/compare.pl" cyclonedds.rnc "${CMAKE_CURRENT_SOURCE_DIR}/../etc/cyclonedds.rnc"
+    DEPENDS
+      "${CMAKE_CURRENT_SOURCE_DIR}/makernc.pl"
+      "${CMAKE_CURRENT_SOURCE_DIR}/../src/core/ddsi/src/q_config.c")
+  add_custom_target(options_doc ALL DEPENDS "options.md" "cyclonedds.rnc")
 
+  find_package(Java COMPONENTS Runtime)
+  if(JAVA_FOUND AND EXISTS "${TRANG_PATH}" OR EXISTS "$ENV{TRANG}")
+    if(NOT EXISTS "${TRANG_PATH}" AND EXISTS "$ENV{TRANG}")
+      message(STATUS "Setting TRANG_PATH to $ENV{TRANG}")
+      set(TRANG_PATH "$ENV{TRANG}" CACHE FILEPATH "Location of 'trang' for converting XML schemas" FORCE)
+    endif()
+    add_custom_command(
+      OUTPUT
+        cyclonedds.xsd
+      COMMAND
+        ${Java_JAVA_EXECUTABLE} -jar "${TRANG_PATH}" -I rnc -O xsd cyclonedds.rnc cyclonedds.xsd
+      COMMAND
+        ${PERL_EXECUTABLE} -w "${CMAKE_CURRENT_SOURCE_DIR}/compare.pl" cyclonedds.xsd "${CMAKE_CURRENT_SOURCE_DIR}/../etc/cyclonedds.xsd"
+      DEPENDS
+        "cyclonedds.rnc")
+    add_custom_target(options_xsd ALL DEPENDS "cyclonedds.xsd")
+  else()
+    message(STATUS "Java or not trang not found: not converting/checking RNC to XSD")
+  endif()
+else()
+  message(STATUS "perl not found: not generating/checking options documentation and RNC")
+endif()
+
+add_subdirectory(manual)

--- a/docs/compare.pl
+++ b/docs/compare.pl
@@ -1,0 +1,8 @@
+open A, "< $ARGV[0]" or die "can't open $ARGV[0]";
+open B, "< $ARGV[1]" or die "can't open $ARGV[1]";
+while (defined ($a = <A>) && defined ($b = <B>)) {
+  $a =~ s/[\r\n]+$//s;
+  $b =~ s/[\r\n]+$//s;
+  exit 1 unless $a eq $b;
+}
+exit 0;

--- a/docs/makernc.pl
+++ b/docs/makernc.pl
@@ -495,7 +495,7 @@ sub read_config {
   my @stk = (); # stack of conditional nesting, for each: copy/discard/ignore
   open FH, "<", $input or die "can't open $input\n";
   while (<FH>) {
-    chomp;
+    s/[\r\n]+$//s;
 
     # ignore parts guarded by #if/#ifdef/#if!/#ifndef if $incl says so
     if (/^\s*\#\s*if(n?def|\s*!)?\s*([A-Za-z_][A-Za-z_0-9]*)\s*(?:\/(?:\/.*|\*.*?\*\/)\s*)?$/) {

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -672,6 +672,8 @@ The default value is: "false".
 
 
 #### //CycloneDDS/Domain/Internal/HeartbeatInterval
+Attributes: [max](#cycloneddsdomaininternalheartbeatintervalmax), [min](#cycloneddsdomaininternalheartbeatintervalmin), [minsched](#cycloneddsdomaininternalheartbeatintervalminsched)
+
 Number-with-unit
 
 This elemnents allows configuring the base interval for sending writer
@@ -681,6 +683,42 @@ Valid values are finite durations with an explicit unit or the keyword
 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.
 
 The default value is: "100 ms".
+
+
+#### //CycloneDDS/Domain/Internal/HeartbeatInterval[@max]
+Number-with-unit
+
+This attribute sets the maximum interval for periodic heartbeats.
+
+Valid values are finite durations with an explicit unit or the keyword
+'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.
+
+The default value is: "8 s".
+
+
+#### //CycloneDDS/Domain/Internal/HeartbeatInterval[@min]
+Number-with-unit
+
+This attribute sets the minimum interval that must have passed since the
+most recent heartbeat from a writer, before another asynchronous (not
+directly related to writing) will be sent.
+
+Valid values are finite durations with an explicit unit or the keyword
+'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.
+
+The default value is: "5 ms".
+
+
+#### //CycloneDDS/Domain/Internal/HeartbeatInterval[@minsched]
+Number-with-unit
+
+This attribute sets the minimum interval for periodic heartbeats. Other
+events may still cause heartbeats to go out.
+
+Valid values are finite durations with an explicit unit or the keyword
+'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.
+
+The default value is: "20 ms".
 
 
 #### //CycloneDDS/Domain/Internal/LateAckMode
@@ -704,6 +742,8 @@ The default value is: "10 s".
 
 
 #### //CycloneDDS/Domain/Internal/LivelinessMonitoring
+Attributes: [Interval](#cycloneddsdomaininternallivelinessmonitoringinterval), [StackTraces](#cycloneddsdomaininternallivelinessmonitoringstacktraces)
+
 Boolean
 
 This element controls whether or not implementation should internally
@@ -712,6 +752,28 @@ traces can be dumped automatically when some thread appears to have
 stopped making progress.
 
 The default value is: "false".
+
+
+#### //CycloneDDS/Domain/Internal/LivelinessMonitoring[@Interval]
+Number-with-unit
+
+This element controls the interval at which to check whether threads have
+been making progress.
+
+The unit must be specified explicitly. Recognised units: ns, us, ms, s,
+min, hr, day.
+
+The default value is: "1s".
+
+
+#### //CycloneDDS/Domain/Internal/LivelinessMonitoring[@StackTraces]
+Boolean
+
+This element controls whether or not to write stack traces to the Cyclone
+DDS trace when a thread fails to make progress (on select platforms
+only).
+
+The default value is: "true".
 
 
 #### //CycloneDDS/Domain/Internal/MaxParticipants
@@ -819,6 +881,8 @@ The default value is: "-1".
 
 
 #### //CycloneDDS/Domain/Internal/MultipleReceiveThreads
+Attributes: [maxretries](#cycloneddsdomaininternalmultiplereceivethreadsmaxretries)
+
 Boolean
 
 This element controls whether all traffic is handled by a single receive
@@ -828,6 +892,18 @@ connectionless transport (e.g., UDP) and ManySocketsMode not set to
 single (the default).
 
 The default value is: "true".
+
+
+#### //CycloneDDS/Domain/Internal/MultipleReceiveThreads[@maxretries]
+Integer
+
+Receive threads dedicated to a single socket can only be triggered for
+termination by sending a packet. Reception of any packet will do, so
+termination failure due to packet loss is exceedingly unlikely, but to
+eliminate all risks, it will retry as many times as specified by this
+attribute before aborting.
+
+The default value is: "4294967295".
 
 
 #### //CycloneDDS/Domain/Internal/NackDelay
@@ -880,6 +956,8 @@ The default value is: "true".
 
 
 #### //CycloneDDS/Domain/Internal/RediscoveryBlacklistDuration
+Attributes: [enforce](#cycloneddsdomaininternalrediscoveryblacklistdurationenforce)
+
 Number-with-unit
 
 This element controls for how long a remote participant that was
@@ -896,6 +974,18 @@ Valid values are finite durations with an explicit unit or the keyword
 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.
 
 The default value is: "10s".
+
+
+#### //CycloneDDS/Domain/Internal/RediscoveryBlacklistDuration[@enforce]
+Boolean
+
+This attribute controls whether the configured time during which recently
+deleted participants will not be rediscovered (i.e., "black listed") is
+enforced and following complete removal of the participant in Cyclone
+DDS, or whether it can be rediscovered earlier provided all traces of
+that participant have been removed already.
+
+The default value is: "false".
 
 
 #### //CycloneDDS/Domain/Internal/RetransmitMerging

--- a/etc/cyclonedds.rnc
+++ b/etc/cyclonedds.rnc
@@ -1,3 +1,4 @@
+default namespace = "https://cdds.io/config"
 namespace a = "http://relaxng.org/ns/compatibility/annotations/1.0"
 grammar {
   start =
@@ -558,7 +559,37 @@ heartbeats and the bounds within it can vary.</p>
 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr,
 day.</p><p>The default value is: &quot;100 ms&quot;.</p>""" ] ]
         element HeartbeatInterval {
-          duration_inf
+          [ a:documentation [ xml:lang="en" """
+<p>This attribute sets the maximum interval for periodic heartbeats.</p>
+
+<p>Valid values are finite durations with an explicit unit or the keyword
+'inf' for infinity. Recognised units: ns, us, ms, s, min, hr,
+day.</p><p>The default value is: &quot;8 s&quot;.</p>""" ] ]
+          attribute max {
+            duration_inf
+          }?
+          & [ a:documentation [ xml:lang="en" """
+<p>This attribute sets the minimum interval that must have passed since
+the most recent heartbeat from a writer, before another asynchronous (not
+directly related to writing) will be sent.</p>
+
+<p>Valid values are finite durations with an explicit unit or the keyword
+'inf' for infinity. Recognised units: ns, us, ms, s, min, hr,
+day.</p><p>The default value is: &quot;5 ms&quot;.</p>""" ] ]
+          attribute min {
+            duration_inf
+          }?
+          & [ a:documentation [ xml:lang="en" """
+<p>This attribute sets the minimum interval for periodic heartbeats.
+Other events may still cause heartbeats to go out.</p>
+
+<p>Valid values are finite durations with an explicit unit or the keyword
+'inf' for infinity. Recognised units: ns, us, ms, s, min, hr,
+day.</p><p>The default value is: &quot;20 ms&quot;.</p>""" ] ]
+          attribute minsched {
+            duration_inf
+          }?
+          & duration_inf
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>Ack a sample only when it has been delivered, instead of when
@@ -582,7 +613,23 @@ traces can be dumped automatically when some thread appears to have
 stopped making progress.</p><p>The default value is:
 &quot;false&quot;.</p>""" ] ]
         element LivelinessMonitoring {
-          xsd:boolean
+          [ a:documentation [ xml:lang="en" """
+<p>This element controls the interval at which to check whether threads
+have been making progress.</p>
+
+<p>The unit must be specified explicitly. Recognised units: ns, us, ms,
+s, min, hr, day.</p><p>The default value is: &quot;1s&quot;.</p>""" ] ]
+          attribute Interval {
+            duration
+          }?
+          & [ a:documentation [ xml:lang="en" """
+<p>This element controls whether or not to write stack traces to the
+Cyclone DDS trace when a thread fails to make progress (on select
+platforms only).</p><p>The default value is: &quot;true&quot;.</p>""" ] ]
+          attribute StackTraces {
+            xsd:boolean
+          }?
+          & xsd:boolean
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This elements configures the maximum number of DCPS domain
@@ -678,7 +725,17 @@ latency. Currently multiple receive threads are only used for
 connectionless transport (e.g., UDP) and ManySocketsMode not set to
 single (the default).</p><p>The default value is: &quot;true&quot;.</p>""" ] ]
         element MultipleReceiveThreads {
-          xsd:boolean
+          [ a:documentation [ xml:lang="en" """
+<p>Receive threads dedicated to a single socket can only be triggered for
+termination by sending a packet. Reception of any packet will do, so
+termination failure due to packet loss is exceedingly unlikely, but to
+eliminate all risks, it will retry as many times as specified by this
+attribute before aborting.</p><p>The default value is:
+&quot;4294967295&quot;.</p>""" ] ]
+          attribute maxretries {
+            xsd:integer
+          }?
+          & xsd:boolean
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This setting controls the delay between receipt of a HEARTBEAT
@@ -734,7 +791,17 @@ is therefore recommended to set it to at least several seconds.</p>
 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr,
 day.</p><p>The default value is: &quot;10s&quot;.</p>""" ] ]
         element RediscoveryBlacklistDuration {
-          duration_inf
+          [ a:documentation [ xml:lang="en" """
+<p>This attribute controls whether the configured time during which
+recently deleted participants will not be rediscovered (i.e., "black
+listed") is enforced and following complete removal of the participant in
+Cyclone DDS, or whether it can be rediscovered earlier provided all
+traces of that participant have been removed already.</p><p>The default
+value is: &quot;false&quot;.</p>""" ] ]
+          attribute enforce {
+            xsd:boolean
+          }?
+          & duration_inf
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This elements controls the addressing and timing of retransmits.

--- a/etc/cyclonedds.xsd
+++ b/etc/cyclonedds.xsd
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="https://cdds.io/config"
+           targetNamespace="https://cdds.io/config"
+           elementFormDefault="qualified">
   <xs:element name="CycloneDDS">
     <xs:annotation>
       <xs:documentation>

--- a/etc/cyclonedds.xsd
+++ b/etc/cyclonedds.xsd
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns="https://cdds.io/config"
-           targetNamespace="https://cdds.io/config"
-           elementFormDefault="qualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="https://cdds.io/config" xmlns:config="https://cdds.io/config">
   <xs:element name="CycloneDDS">
     <xs:annotation>
       <xs:documentation>
@@ -11,7 +7,7 @@ CycloneDDS configuration</xs:documentation>
     </xs:annotation>
     <xs:complexType>
       <xs:sequence>
-        <xs:element minOccurs="0" ref="Domain"/>
+        <xs:element minOccurs="0" ref="config:Domain"/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>
@@ -22,15 +18,15 @@ CycloneDDS configuration</xs:documentation>
     </xs:annotation>
     <xs:complexType>
       <xs:all>
-        <xs:element minOccurs="0" ref="Compatibility"/>
-        <xs:element minOccurs="0" ref="Discovery"/>
-        <xs:element minOccurs="0" ref="General"/>
-        <xs:element minOccurs="0" ref="Internal"/>
-        <xs:element minOccurs="0" ref="Partitioning"/>
-        <xs:element minOccurs="0" ref="SSL"/>
-        <xs:element minOccurs="0" ref="Sizing"/>
-        <xs:element minOccurs="0" ref="TCP"/>
-        <xs:element minOccurs="0" ref="ThreadPool"/>
+        <xs:element minOccurs="0" ref="config:Compatibility"/>
+        <xs:element minOccurs="0" ref="config:Discovery"/>
+        <xs:element minOccurs="0" ref="config:General"/>
+        <xs:element minOccurs="0" ref="config:Internal"/>
+        <xs:element minOccurs="0" ref="config:Partitioning"/>
+        <xs:element minOccurs="0" ref="config:SSL"/>
+        <xs:element minOccurs="0" ref="config:Sizing"/>
+        <xs:element minOccurs="0" ref="config:TCP"/>
+        <xs:element minOccurs="0" ref="config:ThreadPool"/>
         <xs:element minOccurs="0" name="Threads">
           <xs:annotation>
             <xs:documentation>
@@ -38,11 +34,11 @@ CycloneDDS configuration</xs:documentation>
           </xs:annotation>
           <xs:complexType>
             <xs:sequence>
-              <xs:element minOccurs="0" maxOccurs="unbounded" ref="Thread"/>
+              <xs:element minOccurs="0" maxOccurs="unbounded" ref="config:Thread"/>
             </xs:sequence>
           </xs:complexType>
         </xs:element>
-        <xs:element minOccurs="0" ref="Tracing"/>
+        <xs:element minOccurs="0" ref="config:Tracing"/>
       </xs:all>
       <xs:attribute name="Id">
         <xs:annotation>
@@ -61,10 +57,10 @@ to compatability with standards and with other DDSI implementations.&lt;/p&gt;</
     </xs:annotation>
     <xs:complexType>
       <xs:all>
-        <xs:element minOccurs="0" ref="AssumeRtiHasPmdEndpoints"/>
-        <xs:element minOccurs="0" ref="ExplicitlyPublishQosSetToDefault"/>
-        <xs:element minOccurs="0" ref="ManySocketsMode"/>
-        <xs:element minOccurs="0" ref="StandardsConformance"/>
+        <xs:element minOccurs="0" ref="config:AssumeRtiHasPmdEndpoints"/>
+        <xs:element minOccurs="0" ref="config:ExplicitlyPublishQosSetToDefault"/>
+        <xs:element minOccurs="0" ref="config:ManySocketsMode"/>
+        <xs:element minOccurs="0" ref="config:StandardsConformance"/>
       </xs:all>
     </xs:complexType>
   </xs:element>
@@ -158,19 +154,19 @@ the discovery of peers.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
     <xs:complexType>
       <xs:all>
-        <xs:element minOccurs="0" ref="DSGracePeriod"/>
-        <xs:element minOccurs="0" ref="DefaultMulticastAddress"/>
-        <xs:element minOccurs="0" ref="EnableTopicDiscovery"/>
-        <xs:element minOccurs="0" ref="MaxAutoParticipantIndex"/>
-        <xs:element minOccurs="0" ref="ParticipantIndex"/>
-        <xs:element minOccurs="0" ref="Peers"/>
-        <xs:element minOccurs="0" ref="Ports"/>
-        <xs:element minOccurs="0" ref="SPDPInterval"/>
-        <xs:element minOccurs="0" ref="SPDPMulticastAddress"/>
+        <xs:element minOccurs="0" ref="config:DSGracePeriod"/>
+        <xs:element minOccurs="0" ref="config:DefaultMulticastAddress"/>
+        <xs:element minOccurs="0" ref="config:EnableTopicDiscovery"/>
+        <xs:element minOccurs="0" ref="config:MaxAutoParticipantIndex"/>
+        <xs:element minOccurs="0" ref="config:ParticipantIndex"/>
+        <xs:element minOccurs="0" ref="config:Peers"/>
+        <xs:element minOccurs="0" ref="config:Ports"/>
+        <xs:element minOccurs="0" ref="config:SPDPInterval"/>
+        <xs:element minOccurs="0" ref="config:SPDPMulticastAddress"/>
       </xs:all>
     </xs:complexType>
   </xs:element>
-  <xs:element name="DSGracePeriod" type="duration_inf">
+  <xs:element name="DSGracePeriod" type="config:duration_inf">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This setting controls for how long endpoints discovered via a Cloud
@@ -242,8 +238,8 @@ second be option be used.&lt;/p&gt;&lt;p&gt;The default value is:
     </xs:annotation>
     <xs:complexType>
       <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="Group"/>
-        <xs:element ref="Peer"/>
+        <xs:element ref="config:Group"/>
+        <xs:element ref="config:Peer"/>
       </xs:choice>
     </xs:complexType>
   </xs:element>
@@ -256,7 +252,7 @@ succeeds.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
     <xs:complexType>
       <xs:sequence>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="Peer"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="config:Peer"/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>
@@ -288,13 +284,13 @@ by the DDSI 2.1 specification and rarely need to be changed.&lt;/p&gt;</xs:docum
     </xs:annotation>
     <xs:complexType>
       <xs:all>
-        <xs:element minOccurs="0" ref="Base"/>
-        <xs:element minOccurs="0" ref="DomainGain"/>
-        <xs:element minOccurs="0" ref="MulticastDataOffset"/>
-        <xs:element minOccurs="0" ref="MulticastMetaOffset"/>
-        <xs:element minOccurs="0" ref="ParticipantGain"/>
-        <xs:element minOccurs="0" ref="UnicastDataOffset"/>
-        <xs:element minOccurs="0" ref="UnicastMetaOffset"/>
+        <xs:element minOccurs="0" ref="config:Base"/>
+        <xs:element minOccurs="0" ref="config:DomainGain"/>
+        <xs:element minOccurs="0" ref="config:MulticastDataOffset"/>
+        <xs:element minOccurs="0" ref="config:MulticastMetaOffset"/>
+        <xs:element minOccurs="0" ref="config:ParticipantGain"/>
+        <xs:element minOccurs="0" ref="config:UnicastDataOffset"/>
+        <xs:element minOccurs="0" ref="config:UnicastMetaOffset"/>
       </xs:all>
     </xs:complexType>
   </xs:element>
@@ -355,7 +351,7 @@ to the DDSI 2.1 specification, section 9.6.1, constant d1).&lt;/p&gt;&lt;p&gt;Th
 default value is: &amp;quot;10&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="SPDPInterval" type="duration">
+  <xs:element name="SPDPInterval" type="config:duration">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element specifies the interval between spontaneous transmissions
@@ -383,19 +379,19 @@ settings.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
     <xs:complexType>
       <xs:all>
-        <xs:element minOccurs="0" ref="AllowMulticast"/>
-        <xs:element minOccurs="0" ref="DontRoute"/>
-        <xs:element minOccurs="0" ref="EnableMulticastLoopback"/>
-        <xs:element minOccurs="0" ref="ExternalNetworkAddress"/>
-        <xs:element minOccurs="0" ref="ExternalNetworkMask"/>
-        <xs:element minOccurs="0" ref="FragmentSize"/>
-        <xs:element minOccurs="0" ref="MaxMessageSize"/>
-        <xs:element minOccurs="0" ref="MulticastRecvNetworkInterfaceAddresses"/>
-        <xs:element minOccurs="0" ref="MulticastTimeToLive"/>
-        <xs:element minOccurs="0" ref="NetworkInterfaceAddress"/>
-        <xs:element minOccurs="0" ref="PreferMulticast"/>
-        <xs:element minOccurs="0" ref="Transport"/>
-        <xs:element minOccurs="0" ref="UseIPv6"/>
+        <xs:element minOccurs="0" ref="config:AllowMulticast"/>
+        <xs:element minOccurs="0" ref="config:DontRoute"/>
+        <xs:element minOccurs="0" ref="config:EnableMulticastLoopback"/>
+        <xs:element minOccurs="0" ref="config:ExternalNetworkAddress"/>
+        <xs:element minOccurs="0" ref="config:ExternalNetworkMask"/>
+        <xs:element minOccurs="0" ref="config:FragmentSize"/>
+        <xs:element minOccurs="0" ref="config:MaxMessageSize"/>
+        <xs:element minOccurs="0" ref="config:MulticastRecvNetworkInterfaceAddresses"/>
+        <xs:element minOccurs="0" ref="config:MulticastTimeToLive"/>
+        <xs:element minOccurs="0" ref="config:NetworkInterfaceAddress"/>
+        <xs:element minOccurs="0" ref="config:PreferMulticast"/>
+        <xs:element minOccurs="0" ref="config:Transport"/>
+        <xs:element minOccurs="0" ref="config:UseIPv6"/>
       </xs:all>
     </xs:complexType>
   </xs:element>
@@ -481,7 +477,7 @@ address. This option is IPv4-only.&lt;/p&gt;&lt;p&gt;The default value is:
 &amp;quot;0.0.0.0&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="FragmentSize" type="memsize">
+  <xs:element name="FragmentSize" type="config:memsize">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element specifies the size of DDSI sample fragments generated by
@@ -497,7 +493,7 @@ of which the size is at least the minimum of 1025 and FragmentSize.&lt;/p&gt;
 B&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="MaxMessageSize" type="memsize">
+  <xs:element name="MaxMessageSize" type="config:memsize">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element specifies the maximum size of the UDP payload that
@@ -620,51 +616,51 @@ reserved. This includes renaming or moving options.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
     <xs:complexType>
       <xs:all>
-        <xs:element minOccurs="0" ref="AccelerateRexmitBlockSize"/>
-        <xs:element minOccurs="0" ref="AssumeMulticastCapable"/>
-        <xs:element minOccurs="0" ref="AutoReschedNackDelay"/>
-        <xs:element minOccurs="0" ref="BuiltinEndpointSet"/>
-        <xs:element minOccurs="0" ref="ControlTopic"/>
-        <xs:element minOccurs="0" ref="DDSI2DirectMaxThreads"/>
-        <xs:element minOccurs="0" ref="DefragReliableMaxSamples"/>
-        <xs:element minOccurs="0" ref="DefragUnreliableMaxSamples"/>
-        <xs:element minOccurs="0" ref="DeliveryQueueMaxSamples"/>
-        <xs:element minOccurs="0" ref="EnableExpensiveChecks"/>
-        <xs:element minOccurs="0" ref="GenerateKeyhash"/>
-        <xs:element minOccurs="0" ref="HeartbeatInterval"/>
-        <xs:element minOccurs="0" ref="LateAckMode"/>
-        <xs:element minOccurs="0" ref="LeaseDuration"/>
-        <xs:element minOccurs="0" ref="LivelinessMonitoring"/>
-        <xs:element minOccurs="0" ref="MaxParticipants"/>
-        <xs:element minOccurs="0" ref="MaxQueuedRexmitBytes"/>
-        <xs:element minOccurs="0" ref="MaxQueuedRexmitMessages"/>
-        <xs:element minOccurs="0" ref="MaxSampleSize"/>
-        <xs:element minOccurs="0" ref="MeasureHbToAckLatency"/>
-        <xs:element minOccurs="0" ref="MinimumSocketReceiveBufferSize"/>
-        <xs:element minOccurs="0" ref="MinimumSocketSendBufferSize"/>
-        <xs:element minOccurs="0" ref="MonitorPort"/>
-        <xs:element minOccurs="0" ref="MultipleReceiveThreads"/>
-        <xs:element minOccurs="0" ref="NackDelay"/>
-        <xs:element minOccurs="0" ref="PreEmptiveAckDelay"/>
-        <xs:element minOccurs="0" ref="PrimaryReorderMaxSamples"/>
-        <xs:element minOccurs="0" ref="PrioritizeRetransmit"/>
-        <xs:element minOccurs="0" ref="RediscoveryBlacklistDuration"/>
-        <xs:element minOccurs="0" ref="RetransmitMerging"/>
-        <xs:element minOccurs="0" ref="RetransmitMergingPeriod"/>
-        <xs:element minOccurs="0" ref="RetryOnRejectBestEffort"/>
-        <xs:element minOccurs="0" ref="SPDPResponseMaxDelay"/>
-        <xs:element minOccurs="0" ref="ScheduleTimeRounding"/>
-        <xs:element minOccurs="0" ref="SecondaryReorderMaxSamples"/>
-        <xs:element minOccurs="0" ref="SendAsync"/>
-        <xs:element minOccurs="0" ref="SquashParticipants"/>
-        <xs:element minOccurs="0" ref="SynchronousDeliveryLatencyBound"/>
-        <xs:element minOccurs="0" ref="SynchronousDeliveryPriorityThreshold"/>
-        <xs:element minOccurs="0" ref="Test"/>
-        <xs:element minOccurs="0" ref="UnicastResponseToSPDPMessages"/>
-        <xs:element minOccurs="0" ref="UseMulticastIfMreqn"/>
-        <xs:element minOccurs="0" ref="Watermarks"/>
-        <xs:element minOccurs="0" ref="WriteBatch"/>
-        <xs:element minOccurs="0" ref="WriterLingerDuration"/>
+        <xs:element minOccurs="0" ref="config:AccelerateRexmitBlockSize"/>
+        <xs:element minOccurs="0" ref="config:AssumeMulticastCapable"/>
+        <xs:element minOccurs="0" ref="config:AutoReschedNackDelay"/>
+        <xs:element minOccurs="0" ref="config:BuiltinEndpointSet"/>
+        <xs:element minOccurs="0" ref="config:ControlTopic"/>
+        <xs:element minOccurs="0" ref="config:DDSI2DirectMaxThreads"/>
+        <xs:element minOccurs="0" ref="config:DefragReliableMaxSamples"/>
+        <xs:element minOccurs="0" ref="config:DefragUnreliableMaxSamples"/>
+        <xs:element minOccurs="0" ref="config:DeliveryQueueMaxSamples"/>
+        <xs:element minOccurs="0" ref="config:EnableExpensiveChecks"/>
+        <xs:element minOccurs="0" ref="config:GenerateKeyhash"/>
+        <xs:element minOccurs="0" ref="config:HeartbeatInterval"/>
+        <xs:element minOccurs="0" ref="config:LateAckMode"/>
+        <xs:element minOccurs="0" ref="config:LeaseDuration"/>
+        <xs:element minOccurs="0" ref="config:LivelinessMonitoring"/>
+        <xs:element minOccurs="0" ref="config:MaxParticipants"/>
+        <xs:element minOccurs="0" ref="config:MaxQueuedRexmitBytes"/>
+        <xs:element minOccurs="0" ref="config:MaxQueuedRexmitMessages"/>
+        <xs:element minOccurs="0" ref="config:MaxSampleSize"/>
+        <xs:element minOccurs="0" ref="config:MeasureHbToAckLatency"/>
+        <xs:element minOccurs="0" ref="config:MinimumSocketReceiveBufferSize"/>
+        <xs:element minOccurs="0" ref="config:MinimumSocketSendBufferSize"/>
+        <xs:element minOccurs="0" ref="config:MonitorPort"/>
+        <xs:element minOccurs="0" ref="config:MultipleReceiveThreads"/>
+        <xs:element minOccurs="0" ref="config:NackDelay"/>
+        <xs:element minOccurs="0" ref="config:PreEmptiveAckDelay"/>
+        <xs:element minOccurs="0" ref="config:PrimaryReorderMaxSamples"/>
+        <xs:element minOccurs="0" ref="config:PrioritizeRetransmit"/>
+        <xs:element minOccurs="0" ref="config:RediscoveryBlacklistDuration"/>
+        <xs:element minOccurs="0" ref="config:RetransmitMerging"/>
+        <xs:element minOccurs="0" ref="config:RetransmitMergingPeriod"/>
+        <xs:element minOccurs="0" ref="config:RetryOnRejectBestEffort"/>
+        <xs:element minOccurs="0" ref="config:SPDPResponseMaxDelay"/>
+        <xs:element minOccurs="0" ref="config:ScheduleTimeRounding"/>
+        <xs:element minOccurs="0" ref="config:SecondaryReorderMaxSamples"/>
+        <xs:element minOccurs="0" ref="config:SendAsync"/>
+        <xs:element minOccurs="0" ref="config:SquashParticipants"/>
+        <xs:element minOccurs="0" ref="config:SynchronousDeliveryLatencyBound"/>
+        <xs:element minOccurs="0" ref="config:SynchronousDeliveryPriorityThreshold"/>
+        <xs:element minOccurs="0" ref="config:Test"/>
+        <xs:element minOccurs="0" ref="config:UnicastResponseToSPDPMessages"/>
+        <xs:element minOccurs="0" ref="config:UseMulticastIfMreqn"/>
+        <xs:element minOccurs="0" ref="config:Watermarks"/>
+        <xs:element minOccurs="0" ref="config:WriteBatch"/>
+        <xs:element minOccurs="0" ref="config:WriterLingerDuration"/>
       </xs:all>
     </xs:complexType>
   </xs:element>
@@ -688,7 +684,7 @@ wildcards) against which the interface names are matched.&lt;/p&gt;&lt;p&gt;The
 default value is: &amp;quot;&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="AutoReschedNackDelay" type="duration_inf">
+  <xs:element name="AutoReschedNackDelay" type="config:duration_inf">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This setting controls the interval with which a reader will continue
@@ -798,7 +794,7 @@ checks.&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;&amp;quot;.&lt;/p&gt;<
 keys.&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;false&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="HeartbeatInterval" type="duration_inf">
+  <xs:element name="HeartbeatInterval">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This elemnents allows configuring the base interval for sending writer
@@ -808,6 +804,45 @@ heartbeats and the bounds within it can vary.&lt;/p&gt;
 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr,
 day.&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;100 ms&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="config:duration_inf">
+          <xs:attribute name="max" type="config:duration_inf">
+            <xs:annotation>
+              <xs:documentation>
+&lt;p&gt;This attribute sets the maximum interval for periodic heartbeats.&lt;/p&gt;
+
+&lt;p&gt;Valid values are finite durations with an explicit unit or the keyword
+'inf' for infinity. Recognised units: ns, us, ms, s, min, hr,
+day.&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;8 s&amp;quot;.&lt;/p&gt;</xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="min" type="config:duration_inf">
+            <xs:annotation>
+              <xs:documentation>
+&lt;p&gt;This attribute sets the minimum interval that must have passed since
+the most recent heartbeat from a writer, before another asynchronous (not
+directly related to writing) will be sent.&lt;/p&gt;
+
+&lt;p&gt;Valid values are finite durations with an explicit unit or the keyword
+'inf' for infinity. Recognised units: ns, us, ms, s, min, hr,
+day.&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;5 ms&amp;quot;.&lt;/p&gt;</xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="minsched" type="config:duration_inf">
+            <xs:annotation>
+              <xs:documentation>
+&lt;p&gt;This attribute sets the minimum interval for periodic heartbeats.
+Other events may still cause heartbeats to go out.&lt;/p&gt;
+
+&lt;p&gt;Valid values are finite durations with an explicit unit or the keyword
+'inf' for infinity. Recognised units: ns, us, ms, s, min, hr,
+day.&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;20 ms&amp;quot;.&lt;/p&gt;</xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
   </xs:element>
   <xs:element name="LateAckMode" type="xs:boolean">
     <xs:annotation>
@@ -817,7 +852,7 @@ committed to delivering it.&lt;/p&gt;&lt;p&gt;The default value is:
 &amp;quot;false&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="LeaseDuration" type="duration">
+  <xs:element name="LeaseDuration" type="config:duration">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This setting controls the default participant lease duration. &lt;p&gt;
@@ -826,7 +861,7 @@ committed to delivering it.&lt;/p&gt;&lt;p&gt;The default value is:
 s, min, hr, day.&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;10 s&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="LivelinessMonitoring" type="xs:boolean">
+  <xs:element name="LivelinessMonitoring">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element controls whether or not implementation should internally
@@ -835,6 +870,30 @@ traces can be dumped automatically when some thread appears to have
 stopped making progress.&lt;/p&gt;&lt;p&gt;The default value is:
 &amp;quot;false&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="xs:boolean">
+          <xs:attribute name="Interval" type="config:duration">
+            <xs:annotation>
+              <xs:documentation>
+&lt;p&gt;This element controls the interval at which to check whether threads
+have been making progress.&lt;/p&gt;
+
+&lt;p&gt;The unit must be specified explicitly. Recognised units: ns, us, ms,
+s, min, hr, day.&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;1s&amp;quot;.&lt;/p&gt;</xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="StackTraces" type="xs:boolean">
+            <xs:annotation>
+              <xs:documentation>
+&lt;p&gt;This element controls whether or not to write stack traces to the
+Cyclone DDS trace when a thread fails to make progress (on select
+platforms only).&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;true&amp;quot;.&lt;/p&gt;</xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
   </xs:element>
   <xs:element name="MaxParticipants" type="xs:integer">
     <xs:annotation>
@@ -844,7 +903,7 @@ participants this Cyclone DDS instance is willing to service. 0 is
 unlimited.&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;0&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="MaxQueuedRexmitBytes" type="memsize">
+  <xs:element name="MaxQueuedRexmitBytes" type="config:memsize">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This setting limits the maximum number of bytes queued for
@@ -866,7 +925,7 @@ kB&amp;quot;.&lt;/p&gt;</xs:documentation>
 retransmission.&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;200&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="MaxSampleSize" type="memsize">
+  <xs:element name="MaxSampleSize" type="config:memsize">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This setting controls the maximum (CDR) serialised size of samples
@@ -889,7 +948,7 @@ measured latencies are quite noisy and are currently not used
 anywhere.&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;false&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="MinimumSocketReceiveBufferSize" type="memsize">
+  <xs:element name="MinimumSocketReceiveBufferSize" type="config:memsize">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This setting controls the minimum size of socket receive buffers. The
@@ -908,7 +967,7 @@ a smaller buffer should that attempt fail.&lt;/p&gt;
 &amp;quot;default&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="MinimumSocketSendBufferSize" type="memsize">
+  <xs:element name="MinimumSocketSendBufferSize" type="config:memsize">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This setting controls the minimum size of socket send buffers. This
@@ -931,7 +990,7 @@ positive number is used as the TCP port number.&lt;/p&gt;&lt;p&gt;The default va
 is: &amp;quot;-1&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="MultipleReceiveThreads" type="xs:boolean">
+  <xs:element name="MultipleReceiveThreads">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element controls whether all traffic is handled by a single
@@ -940,8 +999,25 @@ latency. Currently multiple receive threads are only used for
 connectionless transport (e.g., UDP) and ManySocketsMode not set to
 single (the default).&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;true&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="xs:boolean">
+          <xs:attribute name="maxretries" type="xs:integer">
+            <xs:annotation>
+              <xs:documentation>
+&lt;p&gt;Receive threads dedicated to a single socket can only be triggered for
+termination by sending a packet. Reception of any packet will do, so
+termination failure due to packet loss is exceedingly unlikely, but to
+eliminate all risks, it will retry as many times as specified by this
+attribute before aborting.&lt;/p&gt;&lt;p&gt;The default value is:
+&amp;quot;4294967295&amp;quot;.&lt;/p&gt;</xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
   </xs:element>
-  <xs:element name="NackDelay" type="duration">
+  <xs:element name="NackDelay" type="config:duration">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This setting controls the delay between receipt of a HEARTBEAT
@@ -954,7 +1030,7 @@ that NACK will incorporate the latest information.&lt;/p&gt;
 s, min, hr, day.&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;10 ms&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="PreEmptiveAckDelay" type="duration">
+  <xs:element name="PreEmptiveAckDelay" type="config:duration">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This setting controls the delay between the discovering a remote
@@ -984,7 +1060,7 @@ data, speeding up recovery.&lt;/p&gt;&lt;p&gt;The default value is:
 &amp;quot;true&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="RediscoveryBlacklistDuration" type="duration_inf">
+  <xs:element name="RediscoveryBlacklistDuration">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element controls for how long a remote participant that was
@@ -1001,6 +1077,23 @@ is therefore recommended to set it to at least several seconds.&lt;/p&gt;
 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr,
 day.&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;10s&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="config:duration_inf">
+          <xs:attribute name="enforce" type="xs:boolean">
+            <xs:annotation>
+              <xs:documentation>
+&lt;p&gt;This attribute controls whether the configured time during which
+recently deleted participants will not be rediscovered (i.e., "black
+listed") is enforced and following complete removal of the participant in
+Cyclone DDS, or whether it can be rediscovered earlier provided all
+traces of that participant have been removed already.&lt;/p&gt;&lt;p&gt;The default
+value is: &amp;quot;false&amp;quot;.&lt;/p&gt;</xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
   </xs:element>
   <xs:element name="RetransmitMerging">
     <xs:annotation>
@@ -1029,7 +1122,7 @@ Internal/RetransmitMergingPeriod.&lt;/p&gt;&lt;p&gt;The default value is:
       </xs:restriction>
     </xs:simpleType>
   </xs:element>
-  <xs:element name="RetransmitMergingPeriod" type="duration">
+  <xs:element name="RetransmitMergingPeriod" type="config:duration">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This setting determines the size of the time window in which a NACK of
@@ -1051,7 +1144,7 @@ into the reader caches when resource limits are reached.&lt;/p&gt;&lt;p&gt;The
 default value is: &amp;quot;false&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="SPDPResponseMaxDelay" type="duration">
+  <xs:element name="SPDPResponseMaxDelay" type="config:duration">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;Maximum pseudo-random delay in milliseconds between discovering a
@@ -1061,7 +1154,7 @@ remote participant and responding to it.&lt;/p&gt;
 s, min, hr, day.&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;0 ms&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="ScheduleTimeRounding" type="duration">
+  <xs:element name="ScheduleTimeRounding" type="config:duration">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This setting allows the timing of scheduled events to be rounded up so
@@ -1103,7 +1196,7 @@ by setting Internal/BuiltinEndpointSet to "minimal" but with less loss of
 information).&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;false&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="SynchronousDeliveryLatencyBound" type="duration_inf">
+  <xs:element name="SynchronousDeliveryLatencyBound" type="config:duration_inf">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element controls whether samples sent by a writer with QoS
@@ -1137,7 +1230,7 @@ the expense of aggregate bandwidth.&lt;/p&gt;&lt;p&gt;The default value is:
     </xs:annotation>
     <xs:complexType>
       <xs:sequence>
-        <xs:element minOccurs="0" ref="XmitLossiness"/>
+        <xs:element minOccurs="0" ref="config:XmitLossiness"/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>
@@ -1171,10 +1264,10 @@ to &lt;i&gt;false&lt;/i&gt;.&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;t
     </xs:annotation>
     <xs:complexType>
       <xs:all>
-        <xs:element minOccurs="0" ref="WhcAdaptive"/>
-        <xs:element minOccurs="0" ref="WhcHigh"/>
-        <xs:element minOccurs="0" ref="WhcHighInit"/>
-        <xs:element minOccurs="0" ref="WhcLow"/>
+        <xs:element minOccurs="0" ref="config:WhcAdaptive"/>
+        <xs:element minOccurs="0" ref="config:WhcHigh"/>
+        <xs:element minOccurs="0" ref="config:WhcHighInit"/>
+        <xs:element minOccurs="0" ref="config:WhcLow"/>
       </xs:all>
     </xs:complexType>
   </xs:element>
@@ -1186,7 +1279,7 @@ mark to current traffic conditions, based on retransmit requests and
 transmit pressure.&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;true&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="WhcHigh" type="memsize">
+  <xs:element name="WhcHigh" type="config:memsize">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element sets the maximum allowed high-water mark for the Cyclone
@@ -1199,7 +1292,7 @@ this size.&lt;/p&gt;
 kB&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="WhcHighInit" type="memsize">
+  <xs:element name="WhcHighInit" type="config:memsize">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element sets the initial level of the high-water mark for the
@@ -1211,7 +1304,7 @@ Cyclone DDS WHCs, expressed in bytes.&lt;/p&gt;
 kB&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="WhcLow" type="memsize">
+  <xs:element name="WhcLow" type="config:memsize">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element sets the low-water mark for the Cyclone DDS WHCs,
@@ -1237,7 +1330,7 @@ dds_write_flush function to ensure thta all samples are
 written.&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;false&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="WriterLingerDuration" type="duration">
+  <xs:element name="WriterLingerDuration" type="config:duration">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This setting controls the maximum duration for which actual deletion
@@ -1257,9 +1350,9 @@ partitions.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
     <xs:complexType>
       <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="IgnoredPartitions"/>
-        <xs:element ref="NetworkPartitions"/>
-        <xs:element ref="PartitionMappings"/>
+        <xs:element ref="config:IgnoredPartitions"/>
+        <xs:element ref="config:NetworkPartitions"/>
+        <xs:element ref="config:PartitionMappings"/>
       </xs:choice>
     </xs:complexType>
   </xs:element>
@@ -1271,7 +1364,7 @@ combinations that are not distributed over the network.&lt;/p&gt;</xs:documentat
     </xs:annotation>
     <xs:complexType>
       <xs:sequence>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="IgnoredPartition"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="config:IgnoredPartition"/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>
@@ -1306,7 +1399,7 @@ partitions.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
     <xs:complexType>
       <xs:sequence>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="NetworkPartition"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="config:NetworkPartition"/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>
@@ -1351,7 +1444,7 @@ partition/topic combinations to Cyclone DDS network partitions.&lt;/p&gt;</xs:do
     </xs:annotation>
     <xs:complexType>
       <xs:sequence>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="PartitionMapping"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="config:PartitionMapping"/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>
@@ -1394,8 +1487,8 @@ SSL/TLS for DDSI over TCP.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
     <xs:complexType>
       <xs:all>
-        <xs:element minOccurs="0" ref="CertificateVerification"/>
-        <xs:element minOccurs="0" ref="Ciphers"/>
+        <xs:element minOccurs="0" ref="config:CertificateVerification"/>
+        <xs:element minOccurs="0" ref="config:Ciphers"/>
         <xs:element minOccurs="0" name="Enable" type="xs:boolean">
           <xs:annotation>
             <xs:documentation>
@@ -1403,12 +1496,12 @@ SSL/TLS for DDSI over TCP.&lt;/p&gt;</xs:documentation>
 &amp;quot;false&amp;quot;.&lt;/p&gt;</xs:documentation>
           </xs:annotation>
         </xs:element>
-        <xs:element minOccurs="0" ref="EntropyFile"/>
-        <xs:element minOccurs="0" ref="KeyPassphrase"/>
-        <xs:element minOccurs="0" ref="KeystoreFile"/>
-        <xs:element minOccurs="0" ref="MinimumTLSVersion"/>
-        <xs:element minOccurs="0" ref="SelfSignedCertificates"/>
-        <xs:element minOccurs="0" ref="VerifyClient"/>
+        <xs:element minOccurs="0" ref="config:EntropyFile"/>
+        <xs:element minOccurs="0" ref="config:KeyPassphrase"/>
+        <xs:element minOccurs="0" ref="config:KeystoreFile"/>
+        <xs:element minOccurs="0" ref="config:MinimumTLSVersion"/>
+        <xs:element minOccurs="0" ref="config:SelfSignedCertificates"/>
+        <xs:element minOccurs="0" ref="config:VerifyClient"/>
       </xs:all>
     </xs:complexType>
   </xs:element>
@@ -1477,12 +1570,12 @@ dealing with expected system sizes, buffer sizes, &amp;c.&lt;/p&gt;</xs:document
     </xs:annotation>
     <xs:complexType>
       <xs:all>
-        <xs:element minOccurs="0" ref="ReceiveBufferChunkSize"/>
-        <xs:element minOccurs="0" ref="ReceiveBufferSize"/>
+        <xs:element minOccurs="0" ref="config:ReceiveBufferChunkSize"/>
+        <xs:element minOccurs="0" ref="config:ReceiveBufferSize"/>
       </xs:all>
     </xs:complexType>
   </xs:element>
-  <xs:element name="ReceiveBufferChunkSize" type="memsize">
+  <xs:element name="ReceiveBufferChunkSize" type="config:memsize">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element specifies the size of one allocation unit in the receive
@@ -1496,7 +1589,7 @@ after processing a message, or freed straightaway.&lt;/p&gt;
 KiB&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="ReceiveBufferSize" type="memsize">
+  <xs:element name="ReceiveBufferSize" type="config:memsize">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element sets the size of a single receive buffer. Many receive
@@ -1518,7 +1611,7 @@ running DDSI over TCP.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
     <xs:complexType>
       <xs:all>
-        <xs:element minOccurs="0" ref="AlwaysUsePeeraddrForUnicast"/>
+        <xs:element minOccurs="0" ref="config:AlwaysUsePeeraddrForUnicast"/>
         <xs:element minOccurs="0" name="Enable">
           <xs:annotation>
             <xs:documentation>
@@ -1534,10 +1627,10 @@ General/Transport instead.&lt;/p&gt;&lt;p&gt;The default value is:
             </xs:restriction>
           </xs:simpleType>
         </xs:element>
-        <xs:element minOccurs="0" ref="NoDelay"/>
-        <xs:element minOccurs="0" ref="Port"/>
-        <xs:element minOccurs="0" ref="ReadTimeout"/>
-        <xs:element minOccurs="0" ref="WriteTimeout"/>
+        <xs:element minOccurs="0" ref="config:NoDelay"/>
+        <xs:element minOccurs="0" ref="config:Port"/>
+        <xs:element minOccurs="0" ref="config:ReadTimeout"/>
+        <xs:element minOccurs="0" ref="config:WriteTimeout"/>
       </xs:all>
     </xs:complexType>
   </xs:element>
@@ -1571,7 +1664,7 @@ by establishing connections to other services.&lt;/p&gt;&lt;p&gt;The default val
 is: &amp;quot;-1&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="ReadTimeout" type="duration">
+  <xs:element name="ReadTimeout" type="config:duration">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element specifies the timeout for blocking TCP read operations.
@@ -1581,7 +1674,7 @@ If this timeout expires then the connection is closed.&lt;/p&gt;
 s, min, hr, day.&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;2 s&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="WriteTimeout" type="duration">
+  <xs:element name="WriteTimeout" type="config:duration">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element specifies the timeout for blocking TCP write operations.
@@ -1607,7 +1700,7 @@ using a thread pool to send DDSI messages to multiple unicast addresses
 is: &amp;quot;false&amp;quot;.&lt;/p&gt;</xs:documentation>
           </xs:annotation>
         </xs:element>
-        <xs:element minOccurs="0" ref="ThreadMax"/>
+        <xs:element minOccurs="0" ref="config:ThreadMax"/>
         <xs:element minOccurs="0" name="Threads" type="xs:integer">
           <xs:annotation>
             <xs:documentation>
@@ -1632,8 +1725,8 @@ pool.&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;8&amp;quot;.&lt;/p&gt;</
     </xs:annotation>
     <xs:complexType>
       <xs:all>
-        <xs:element minOccurs="0" ref="Scheduling"/>
-        <xs:element minOccurs="0" ref="StackSize"/>
+        <xs:element minOccurs="0" ref="config:Scheduling"/>
+        <xs:element minOccurs="0" ref="config:StackSize"/>
       </xs:all>
       <xs:attribute name="Name" use="required">
         <xs:annotation>
@@ -1671,8 +1764,8 @@ discovery;&lt;/li&gt;
     </xs:annotation>
     <xs:complexType>
       <xs:all>
-        <xs:element minOccurs="0" ref="Class"/>
-        <xs:element minOccurs="0" ref="Priority"/>
+        <xs:element minOccurs="0" ref="config:Class"/>
+        <xs:element minOccurs="0" ref="config:Priority"/>
       </xs:all>
     </xs:complexType>
   </xs:element>
@@ -1704,7 +1797,7 @@ assign some of the privileged priorities.&lt;/p&gt;&lt;p&gt;The default value is
 &amp;quot;default&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="StackSize" type="memsize">
+  <xs:element name="StackSize" type="config:memsize">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element configures the stack size for this thread. The default
@@ -1726,11 +1819,11 @@ track the DDSI service during application development.&lt;/p&gt;</xs:documentati
     </xs:annotation>
     <xs:complexType>
       <xs:all>
-        <xs:element minOccurs="0" ref="AppendToFile"/>
-        <xs:element minOccurs="0" ref="Category"/>
-        <xs:element minOccurs="0" ref="OutputFile"/>
-        <xs:element minOccurs="0" ref="PacketCaptureFile"/>
-        <xs:element minOccurs="0" ref="Verbosity"/>
+        <xs:element minOccurs="0" ref="config:AppendToFile"/>
+        <xs:element minOccurs="0" ref="config:Category"/>
+        <xs:element minOccurs="0" ref="config:OutputFile"/>
+        <xs:element minOccurs="0" ref="config:PacketCaptureFile"/>
+        <xs:element minOccurs="0" ref="config:Verbosity"/>
       </xs:all>
     </xs:complexType>
   </xs:element>

--- a/src/core/ddsc/tests/config_simple_udp.xml
+++ b/src/core/ddsc/tests/config_simple_udp.xml
@@ -30,8 +30,8 @@
     </Tracing>
     <Internal>
       <MaxParticipants>${MAX_PARTICIPANTS}</MaxParticipants>
-      <HeartbeatInterval max="10 s"> 100 ms </HeartbeatInterval>
-      <RediscoveryBlacklistDuration></RediscoveryBlacklistDuration>
+      <HeartbeatInterval>100 ms</HeartbeatInterval>
+      <RediscoveryBlacklistDuration>10s</RediscoveryBlacklistDuration>
     </Internal>
   </Domain>
 </CycloneDDS>

--- a/src/core/ddsc/tests/config_simple_udp.xml
+++ b/src/core/ddsc/tests/config_simple_udp.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<?xml-model href="https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/master/etc/cyclonedds.xsd"
+        schematypens="http://www.w3.org/2001/XMLSchema" ?>
 <!--
   Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
 
@@ -10,7 +12,7 @@
 
   SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 -->
-<CycloneDDS>
+<CycloneDDS xmlns="https://cdds.io/config">
   <!-- Simple config-file for testing whether a config-file can be picked up
        correctly. -->
   <Domain id="3">

--- a/src/core/ddsi/src/q_config.c
+++ b/src/core/ddsi/src/q_config.c
@@ -830,6 +830,7 @@ static const struct cfgelem root_cfgelems[] = {
 };
 
 static const struct cfgelem root_cfgattrs[] = {
+  { ATTR("xmlns"), 0, "", 0, 0, 0, uf_nop, 0, pf_nop, NULL },
   { ATTR("xmlns:xsi"), 0, "", 0, 0, 0, uf_nop, 0, pf_nop, NULL },
   { ATTR("xsi:noNamespaceSchemaLocation"), 0, "", 0, 0, 0, uf_nop, 0, pf_nop, NULL },
   END_MARKER

--- a/src/core/ddsi/src/q_config.c
+++ b/src/core/ddsi/src/q_config.c
@@ -832,6 +832,7 @@ static const struct cfgelem root_cfgelems[] = {
 static const struct cfgelem root_cfgattrs[] = {
   { ATTR("xmlns"), 0, "", 0, 0, 0, uf_nop, 0, pf_nop, NULL },
   { ATTR("xmlns:xsi"), 0, "", 0, 0, 0, uf_nop, 0, pf_nop, NULL },
+  { ATTR("xsi:schemaLocation"), 0, "", 0, 0, 0, uf_nop, 0, pf_nop, NULL },
   { ATTR("xsi:noNamespaceSchemaLocation"), 0, "", 0, 0, 0, uf_nop, 0, pf_nop, NULL },
   END_MARKER
 };

--- a/src/mpt/tests/basic/etc/config_any.xml
+++ b/src/mpt/tests/basic/etc/config_any.xml
@@ -13,9 +13,7 @@
   SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 -->
 <CycloneDDS xmlns="https://cdds.io/config">
-  <Domain>
-    <Id>any</Id>
-  </Domain>
+  <Domain Id="any">
   <General>
     <AllowMulticast>true</AllowMulticast>
     <EnableMulticastLoopback>true</EnableMulticastLoopback>
@@ -27,4 +25,5 @@
     <Verbosity>finest</Verbosity>
     <OutputFile>ddsi_${MPT_PROCESS_NAME}.log</OutputFile>
   </Tracing-->
+  </Domain>
 </CycloneDDS>

--- a/src/mpt/tests/basic/etc/config_any.xml
+++ b/src/mpt/tests/basic/etc/config_any.xml
@@ -1,3 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<?xml-model href="https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/master/etc/cyclonedds.xsd"
+        schematypens="http://www.w3.org/2001/XMLSchema" ?>
 <!--
   Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
 
@@ -9,7 +12,7 @@
 
   SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 -->
-<CycloneDDS>
+<CycloneDDS xmlns="https://cdds.io/config">
   <Domain>
     <Id>any</Id>
   </Domain>

--- a/src/mpt/tests/basic/etc/config_specific.xml
+++ b/src/mpt/tests/basic/etc/config_specific.xml
@@ -13,9 +13,7 @@
   SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 -->
 <CycloneDDS xmlns="https://cdds.io/config">
-  <Domain>
-    <Id>${DOMAIN_ID}</Id>
-  </Domain>
+  <Domain Id="${DOMAIN_ID}">
   <General>
     <AllowMulticast>true</AllowMulticast>
     <EnableMulticastLoopback>true</EnableMulticastLoopback>
@@ -27,4 +25,5 @@
     <Verbosity>finest</Verbosity>
     <OutputFile>ddsi_${MPT_PROCESS_NAME}.log</OutputFile>
   </Tracing-->
+  </Domain>
 </CycloneDDS>

--- a/src/mpt/tests/basic/etc/config_specific.xml
+++ b/src/mpt/tests/basic/etc/config_specific.xml
@@ -1,3 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<?xml-model href="https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/master/etc/cyclonedds.xsd"
+        schematypens="http://www.w3.org/2001/XMLSchema" ?>
 <!--
   Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
 
@@ -9,7 +12,7 @@
 
   SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 -->
-<CycloneDDS>
+<CycloneDDS xmlns="https://cdds.io/config">
   <Domain>
     <Id>${DOMAIN_ID}</Id>
   </Domain>


### PR DESCRIPTION
This PR is a rebase of #282 extended with the generation of cyclonedds.xsd, cyclonedds.rnc and options.md fixed to include some attributes missing because of a bug in the generator script.

Even though these XSD, RNC and MD are mechanically generated, the files are committed in the repository, because the tools are not necessarily available everywhere and because it is nice to always have them at hand. Unfortunately, it means the committed copies can become out of date with respect to the sources.

To guard against this, this PR adds build code to generate what it can (and if perl is available, that is at least some), and fails the build if the committed files are out-of-sync. This should only ever happen when the configuration tables in ``q_config.c`` are changed, which is not all that often (fortunately).

Note that @rotu 's comment https://github.com/eclipse-cyclonedds/cyclonedds/pull/282#issuecomment-548866780 that it would be **much** better to generate the C source from a decent input form, rather than this fragile reading of the C code, is something I very much agree with. However, changing that means some real work, and I don't want to delay fixing the XSD because of it.

@rotu do you agree?