### PR TITLE
Allow BUILD_IDLC to be 'AUTO' based on Maven presence

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,11 +23,6 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
 
-# By default the Java-based components get built, but make it possible to disable that: if only the
-# core library is required, there's no need to build them, and that in turn eliminates the Maven and
-# JDK dependency.
-option(BUILD_IDLC "Build IDL preprocessor" ON)
-
 # By default don't treat warnings as errors, else anyone building it with a different compiler that
 # just happens to generate a warning, as well as anyone adding or modifying something and making a
 # small mistake would run into errors.  CI builds can be configured differently.
@@ -49,6 +44,12 @@ set(PROJECT_NAME_FULL "Eclipse Cyclone DDS")
 string(REPLACE " " "-" PROJECT_NAME_DASHED "${PROJECT_NAME_FULL}")
 string(TOUPPER ${PROJECT_NAME} PROJECT_NAME_CAPS)
 string(TOLOWER ${PROJECT_NAME} PROJECT_NAME_SMALL)
+
+# By default the Java-based components get built, but make it possible to disable that: if only the
+# core library is required, there's no need to build them, and that in turn eliminates the Maven and
+# JDK dependency.
+find_package(Maven 3.0 QUIET)
+option(BUILD_IDLC "Build IDL preprocessor" ${Maven_FOUND})
 
 set(CMAKE_C_STANDARD 99)
 if(CMAKE_SYSTEM_NAME STREQUAL "VxWorks")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,8 +48,11 @@ string(TOLOWER ${PROJECT_NAME} PROJECT_NAME_SMALL)
 # By default the Java-based components get built, but make it possible to disable that: if only the
 # core library is required, there's no need to build them, and that in turn eliminates the Maven and
 # JDK dependency.
-find_package(Maven 3.0 QUIET)
-option(BUILD_IDLC "Build IDL preprocessor" ${Maven_FOUND})
+option(BUILD_IDLC "Build IDL preprocessor" ON)
+if(BUILD_IDLC STREQUAL "AUTO")
+  find_package(Maven 3.0 QUIET)
+  set(BUILD_IDLC ${Maven_FOUND})
+endif()
 
 set(CMAKE_C_STANDARD 99)
 if(CMAKE_SYSTEM_NAME STREQUAL "VxWorks")

--- a/colcon.pkg
+++ b/colcon.pkg
@@ -1,0 +1,3 @@
+{
+  "cmake-args": [ "-DBUILD_IDLC=AUTO" ]
+}

--- a/colcon.pkg
+++ b/colcon.pkg
@@ -1,3 +1,0 @@
-{
-  "cmake-args": [ "-DBUILD_IDLC=OFF" ]
-}

--- a/package.xml
+++ b/package.xml
@@ -12,8 +12,6 @@
     <url type="repository">https://github.com/eclipse-cyclonedds/cyclonedds</url>
 
     <buildtool_depend>cmake</buildtool_depend>
-    <buildtool_depend>java</buildtool_depend>
-    <buildtool_depend>maven</buildtool_depend>
     <depend>openssl</depend>
     <test_depend>libcunit-dev</test_depend>
     <doc_depend>python3-sphinx</doc_depend>

--- a/package.xml
+++ b/package.xml
@@ -12,6 +12,8 @@
     <url type="repository">https://github.com/eclipse-cyclonedds/cyclonedds</url>
 
     <buildtool_depend>cmake</buildtool_depend>
+    <buildtool_depend>java</buildtool_depend>
+    <buildtool_depend>maven</buildtool_depend>
     <depend>openssl</depend>
     <test_depend>libcunit-dev</test_depend>
     <doc_depend>python3-sphinx</doc_depend>


### PR DESCRIPTION
~~This will modify the default behavior to select BUILD_IDLC based on whether Maven is discovered or not.~~

~~The behavior when `-DBUILD_IDLC` is specified on the command line remains unchanged - the build will maintain the current behavior of failing to configure if `BUILD_IDLC=ON` and Maven was later not found.~~

See [my comment below](#issuecomment-553667381) for an updated description of this change.

I had to move the logic several lines lower to appear after `CMAKE_MODULE_PATH` was set so that `find_package(Maven)` worked right.

This reverts (part of) #292.