### PR TITLE
Fix string literal under cpp compiler

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/q_rtps.h
+++ b/src/core/ddsi/include/dds/ddsi/q_rtps.h
@@ -27,7 +27,7 @@ typedef int64_t seqno_t;
 
 #define PGUIDPREFIX(gp) (gp).u[0], (gp).u[1], (gp).u[2]
 #define PGUID(g) PGUIDPREFIX ((g).prefix), (g).entityid.u
-#define PGUIDFMT "%"PRIx32":%"PRIx32":%"PRIx32":%"PRIx32
+#define PGUIDFMT "%" PRIx32 ":%" PRIx32 ":%" PRIx32 ":%" PRIx32
 
 /* predefined entity ids; here viewed as an unsigned int, on the
    network as four bytes corresponding to the integer in network byte


### PR DESCRIPTION
PGUIDFMT creates invalid C++ code.

In file included from /opt/ros/master/src/ros2/rmw_cyclonedds/rmw_cyclonedds_cpp/src/serdata.cpp:23:
In file included from /opt/ros/master/install/include/dds/ddsi/q_radmin.h:17:
In file included from /opt/ros/master/install/include/dds/ddsi/ddsi_tran.h:19:
In file included from /opt/ros/master/install/include/dds/ddsi/q_protocol.h:19:
/opt/ros/master/install/include/dds/ddsi/q_rtps.h:30:21: error: invalid suffix on literal; C++11 requires a space between literal and identifier [-Wreserved-user-defined-literal]
#define PGUIDFMT "%"PRIx32":%"PRIx32":%"PRIx32":%"PRIx32
                    ^
                     
/opt/ros/master/install/include/dds/ddsi/q_rtps.h:30:31: error: invalid suffix on literal; C++11 requires a space between literal and identifier [-Wreserved-user-defined-literal]
#define PGUIDFMT "%"PRIx32":%"PRIx32":%"PRIx32":%"PRIx32
