### PR TITLE
Encoding preparations

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/ddsi_security_omg.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_security_omg.h
@@ -152,7 +152,7 @@ unsigned determine_publication_writer(const struct writer *wr);
  * @retval false  The proxy participant may not be deleted by this writer.
  */
 bool
-allow_proxy_participant_deletion(
+is_proxy_participant_deletion_allowed(
   struct q_globals * const gv,
   const struct ddsi_guid *guid,
   const ddsi_entityid_t pwr_entityid);
@@ -461,6 +461,35 @@ decode_rtps_message(
   struct nn_rbufpool *rbpool,
   bool isstream);
 
+/**
+ * @brief Send the RTPS message securely.
+ *
+ * @param[in]     conn          Connection to use.
+ * @param[in]     dst           Possible destination information.
+ * @param[in]     niov          Number of io vectors.
+ * @param[in]     iov           Array of io vectors.
+ * @param[in]     flags         Connection write flags.
+ * @param[in,out] msg_len       Submessage containing length.
+ * @param[in]     dst_one       Is there only one specific destination?
+ * @param[in]     sec_info      Security information for handles.
+ * @param[in]     conn_write_cb Function to call to do the actual writing.
+ *
+ * @returns ssize_t
+ * @retval negative/zero    Something went wrong.
+ * @retval positive         Secure writing succeeded.
+ */
+ssize_t
+secure_conn_write(
+    ddsi_tran_conn_t conn,
+    const nn_locator_t *dst,
+    size_t niov,
+    const ddsrt_iovec_t *iov,
+    uint32_t flags,
+    MsgLen_t *msg_len,
+    bool dst_one,
+    nn_msg_sec_info_t *sec_info,
+    ddsi_tran_write_fn_t conn_write_cb);
+
 #else /* DDSI_INCLUDE_SECURITY */
 
 #include "dds/ddsi/q_unused.h"
@@ -493,7 +522,7 @@ determine_publication_writer(
 }
 
 inline bool
-allow_proxy_participant_deletion(
+is_proxy_participant_deletion_allowed(
   UNUSED_ARG(struct q_globals * const gv),
   UNUSED_ARG(const struct ddsi_guid *guid),
   UNUSED_ARG(const ddsi_entityid_t pwr_entityid))

--- a/src/core/ddsi/include/dds/ddsi/ddsi_security_omg.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_security_omg.h
@@ -107,7 +107,131 @@ unsigned determine_publication_writer(const struct writer *wr);
  * @retval true   The proxy participant may be deleted.
  * @retval false  The proxy participant may not be deleted by this writer.
  */
-bool allow_proxy_participant_deletion(struct q_globals * const gv, const struct ddsi_guid *guid, const ddsi_entityid_t pwr_entityid);
+bool
+allow_proxy_participant_deletion(
+  struct q_globals * const gv,
+  const struct ddsi_guid *guid,
+  const ddsi_entityid_t pwr_entityid);
+
+/**
+ * @brief Set security information, depending on plist, into the given
+ * proxy participant.
+ *
+ * @param[in] proxypp  Proxy participant to set security info on.
+ * @param[in] plist    Paramater list, possibly contains security info.
+ */
+void
+set_proxy_participant_security_info(
+  struct proxy_participant *proxypp,
+  const nn_plist_t *plist);
+
+/**
+ * @brief Set security information, depending on plist and proxy participant,
+ * into the given proxy reader.
+ *
+ * @param[in] prd      Proxy reader to set security info on.
+ * @param[in] plist    Paramater list, possibly contains security info.
+ */
+void
+set_proxy_reader_security_info(
+  struct proxy_reader *prd,
+  const nn_plist_t *plist);
+
+/**
+ * @brief Set security information, depending on plist and proxy participant,
+ * into the given proxy writer.
+ *
+ * @param[in] pwr      Proxy writer to set security info on.
+ * @param[in] plist    Paramater list, possibly contains security info.
+ */
+void
+set_proxy_writer_security_info(
+  struct proxy_writer *pwr,
+  const nn_plist_t *plist);
+
+/**
+ * @brief Encode payload when necessary.
+ *
+ * When encoding is necessary, *buf will be allocated and the vec contents
+ * will change to point to that buffer.
+ * It is expected that the vec contents is always aliased.
+ *
+ * If no encoding is necessary, nothing changes.
+ *
+ * encoding(    not needed) -> return( true), vec(untouched), buf(NULL)
+ * encoding(needed&success) -> return( true), vec( buf(new))
+ * encoding(needed&failure) -> return(false), vec(untouched), buf(NULL)
+ *
+ * @param[in]     wr   Writer that writes the payload.
+ * @param[in,out] vec  An iovec that contains the payload.
+ * @param[out]    buf  Buffer to contain the encoded payload.
+ *
+ * @returns bool
+ * @retval true   Encoding succeeded or not necessary. Either way, vec
+ *                contains the payload that should be send.
+ * @retval false  Encoding was necessary, but failed.
+ */
+bool
+encode_payload(
+  struct writer *wr,
+  ddsrt_iovec_t *vec,
+  unsigned char **buf);
+
+/**
+ * @brief Decode the payload of a Data submessage.
+ *
+ * When decoding is necessary, the payloadp memory will be replaced
+ * by the decoded payload. This means that the original submessage
+ * now contains payload that can be deserialized.
+ *
+ * If no decoding is necessary, nothing changes.
+ *
+ * @param[in]     gv          Global information.
+ * @param[in]     sampleinfo  Sample information.
+ * @param[in,out] payloadp    Pointer to payload memory.
+ * @param[in]     payloadsz   Size of payload.
+ * @param[in,out] submsg_len  Size of submessage.
+ *
+ * @returns bool
+ * @retval true   Decoding succeeded or not necessary. Either way, payloadp
+ *                contains the data that should be deserialized.
+ * @retval false  Decoding was necessary, but failed.
+ */
+bool
+decode_Data(
+  const struct q_globals *gv,
+  struct nn_rsample_info *sampleinfo,
+  unsigned char *payloadp,
+  uint32_t payloadsz,
+  size_t *submsg_len);
+
+/**
+ * @brief Decode the payload of a DataFrag submessage.
+ *
+ * When decoding is necessary, the payloadp memory will be replaced
+ * by the decoded payload. This means that the original submessage
+ * now contains payload that can be deserialized.
+ *
+ * If no decoding is necessary, nothing changes.
+ *
+ * @param[in]     gv          Global information.
+ * @param[in]     sampleinfo  Sample information.
+ * @param[in,out] payloadp    Pointer to payload memory.
+ * @param[in]     payloadsz   Size of payload.
+ * @param[in,out] submsg_len  Size of submessage.
+ *
+ * @returns bool
+ * @retval true   Decoding succeeded or not necessary. Either way, payloadp
+ *                contains the data that should be deserialized.
+ * @retval false  Decoding was necessary, but failed.
+ */
+bool
+decode_DataFrag(
+  const struct q_globals *gv,
+  struct nn_rsample_info *sampleinfo,
+  unsigned char *payloadp,
+  uint32_t payloadsz,
+  size_t *submsg_len);
 
 #else /* DDSI_INCLUDE_SECURITY */
 
@@ -139,6 +263,50 @@ allow_proxy_participant_deletion(
   UNUSED_ARG(struct q_globals * const gv),
   UNUSED_ARG(const struct ddsi_guid *guid),
   UNUSED_ARG(const ddsi_entityid_t pwr_entityid))
+{
+  return true;
+}
+
+inline void
+set_proxy_participant_security_info(
+  UNUSED_ARG(struct proxy_participant *prd),
+  UNUSED_ARG(const nn_plist_t *plist))
+{
+}
+
+inline void
+set_proxy_reader_security_info(
+  UNUSED_ARG(struct proxy_reader *prd),
+  UNUSED_ARG(const nn_plist_t *plist))
+{
+}
+
+inline void
+set_proxy_writer_security_info(
+  UNUSED_ARG(struct proxy_writer *pwr),
+  UNUSED_ARG(const nn_plist_t *plist))
+{
+}
+
+
+inline bool
+decode_Data(
+  UNUSED_ARG(const struct q_globals *gv),
+  UNUSED_ARG(struct nn_rsample_info *sampleinfo),
+  UNUSED_ARG(unsigned char *payloadp),
+  UNUSED_ARG(uint32_t payloadsz),
+  UNUSED_ARG(size_t *submsg_len))
+{
+  return true;
+}
+
+inline bool
+decode_DataFrag(
+  UNUSED_ARG(const struct q_globals *gv),
+  UNUSED_ARG(struct nn_rsample_info *sampleinfo),
+  UNUSED_ARG(unsigned char *payloadp),
+  UNUSED_ARG(uint32_t payloadsz),
+  UNUSED_ARG(size_t *submsg_len))
 {
   return true;
 }

--- a/src/core/ddsi/include/dds/ddsi/q_entity.h
+++ b/src/core/ddsi/include/dds/ddsi/q_entity.h
@@ -345,6 +345,9 @@ struct proxy_endpoint_common
   ddsi_guid_t group_guid; /* 0:0:0:0 if not available */
   nn_vendorid_t vendor; /* cached from proxypp->vendor */
   seqno_t seq; /* sequence number of most recent SEDP message */
+#ifdef DDSI_INCLUDE_SECURITY
+  nn_security_info_t security_info;
+#endif
 };
 
 struct proxy_writer {
@@ -371,9 +374,6 @@ struct proxy_writer {
   struct local_reader_ary rdary; /* LOCAL readers for fast-pathing; if not fast-pathed, fall back to scanning local_readers */
   ddsi2direct_directread_cb_t ddsi2direct_cb;
   void *ddsi2direct_cbarg;
-#ifdef DDSI_INCLUDE_SECURITY
-  nn_security_info_t security_info;
-#endif
 };
 
 struct proxy_reader {
@@ -385,9 +385,6 @@ struct proxy_reader {
   unsigned favours_ssm: 1; /* iff 1, this proxy reader favours SSM when available */
 #endif
   ddsrt_avl_tree_t writers; /* matching LOCAL writers */
-#ifdef DDSI_INCLUDE_SECURITY
-  nn_security_info_t security_info;
-#endif
 };
 
 extern const ddsrt_avl_treedef_t wr_readers_treedef;

--- a/src/core/ddsi/include/dds/ddsi/q_entity.h
+++ b/src/core/ddsi/include/dds/ddsi/q_entity.h
@@ -16,6 +16,7 @@
 #include "dds/ddsrt/avl.h"
 #include "dds/ddsrt/sync.h"
 #include "dds/ddsi/q_rtps.h"
+#include "dds/ddsi/q_plist.h"
 #include "dds/ddsi/q_protocol.h"
 #include "dds/ddsi/q_lat_estim.h"
 #include "dds/ddsi/q_ephash.h"
@@ -314,6 +315,9 @@ struct proxy_participant
   unsigned proxypp_have_spdp: 1;
   unsigned proxypp_have_cm: 1;
   unsigned owns_lease: 1;
+#ifdef DDSI_INCLUDE_SECURITY
+  nn_security_info_t security_info;
+#endif
 };
 
 /* Representing proxy subscriber & publishers as "groups": until DDSI2
@@ -367,6 +371,9 @@ struct proxy_writer {
   struct local_reader_ary rdary; /* LOCAL readers for fast-pathing; if not fast-pathed, fall back to scanning local_readers */
   ddsi2direct_directread_cb_t ddsi2direct_cb;
   void *ddsi2direct_cbarg;
+#ifdef DDSI_INCLUDE_SECURITY
+  nn_security_info_t security_info;
+#endif
 };
 
 struct proxy_reader {
@@ -378,6 +385,9 @@ struct proxy_reader {
   unsigned favours_ssm: 1; /* iff 1, this proxy reader favours SSM when available */
 #endif
   ddsrt_avl_tree_t writers; /* matching LOCAL writers */
+#ifdef DDSI_INCLUDE_SECURITY
+  nn_security_info_t security_info;
+#endif
 };
 
 extern const ddsrt_avl_treedef_t wr_readers_treedef;

--- a/src/core/ddsi/include/dds/ddsi/q_protocol.h
+++ b/src/core/ddsi/include/dds/ddsi/q_protocol.h
@@ -162,6 +162,10 @@ typedef enum SubmessageKind {
   SMID_HEARTBEAT_FRAG = 0x13,
   SMID_DATA = 0x15,
   SMID_DATA_FRAG = 0x16,
+  /* security-specific sub messages */
+  SMID_SEC_BODY = 0x30,
+  SMID_SEC_PREFIX = 0x31,
+  SMID_SEC_POSTFIX = 0x32,
   /* vendor-specific sub messages (0x80 .. 0xff) */
   SMID_PT_INFO_CONTAINER = 0x80,
   SMID_PT_MSG_LEN = 0x81,

--- a/src/core/ddsi/include/dds/ddsi/q_protocol.h
+++ b/src/core/ddsi/include/dds/ddsi/q_protocol.h
@@ -166,6 +166,8 @@ typedef enum SubmessageKind {
   SMID_SEC_BODY = 0x30,
   SMID_SEC_PREFIX = 0x31,
   SMID_SEC_POSTFIX = 0x32,
+  SMID_SRTPS_PREFIX = 0x33,
+  SMID_SRTPS_POSTFIX = 0x34,
   /* vendor-specific sub messages (0x80 .. 0xff) */
   SMID_PT_INFO_CONTAINER = 0x80,
   SMID_PT_MSG_LEN = 0x81,

--- a/src/core/ddsi/include/dds/ddsi/q_radmin.h
+++ b/src/core/ddsi/include/dds/ddsi/q_radmin.h
@@ -102,10 +102,11 @@ struct nn_rmsg {
 #define NN_RMSG_PAYLOADOFF(m, o) (NN_RMSG_PAYLOAD (m) + (o))
 
 struct receiver_state {
-  ddsi_guid_prefix_t src_guid_prefix;       /* 12 */
-  ddsi_guid_prefix_t dst_guid_prefix;       /* 12 */
+  ddsi_guid_prefix_t src_guid_prefix;     /* 12 */
+  ddsi_guid_prefix_t dst_guid_prefix;     /* 12 */
   struct addrset *reply_locators;         /* 4/8 */
-  int forme;                              /* 4 */
+  uint32_t forme:1;                       /* 4 */
+  uint32_t rtps_encoded:1;                /* - */
   nn_vendorid_t vendor;                   /* 2 */
   nn_protocol_version_t protocol_version; /* 2 => 44/48 */
   ddsi_tran_conn_t conn;                  /* Connection for request */

--- a/src/core/ddsi/include/dds/ddsi/q_xevent.h
+++ b/src/core/ddsi/include/dds/ddsi/q_xevent.h
@@ -46,8 +46,8 @@ DDS_EXPORT dds_return_t xeventq_start (struct xeventq *evq, const char *name); /
 DDS_EXPORT void xeventq_stop (struct xeventq *evq);
 
 DDS_EXPORT void qxev_msg (struct xeventq *evq, struct nn_xmsg *msg);
-DDS_EXPORT void qxev_pwr_entityid (struct proxy_writer * pwr, ddsi_guid_prefix_t * id);
-DDS_EXPORT void qxev_prd_entityid (struct proxy_reader * prd, ddsi_guid_prefix_t * id);
+DDS_EXPORT void qxev_pwr_entityid (struct proxy_writer * pwr, const ddsi_guid_t *guid);
+DDS_EXPORT void qxev_prd_entityid (struct proxy_reader * prd, const ddsi_guid_t *guid);
 
 /* Returns 1 if queued, 0 otherwise (no point in returning the
    event, you can't do anything with it anyway) */

--- a/src/core/ddsi/include/dds/ddsi/q_xmsg.h
+++ b/src/core/ddsi/include/dds/ddsi/q_xmsg.h
@@ -26,6 +26,7 @@ struct ddsi_serdata;
 struct addrset;
 struct proxy_reader;
 struct proxy_writer;
+struct writer;
 
 struct nn_prismtech_participant_version_info;
 struct nn_xmsgpool;
@@ -114,7 +115,7 @@ void nn_xmsg_guid_seq_fragid (const struct nn_xmsg *m, ddsi_guid_t *wrguid, seqn
 void *nn_xmsg_submsg_from_marker (struct nn_xmsg *msg, struct nn_xmsg_marker marker);
 void *nn_xmsg_append (struct nn_xmsg *m, struct nn_xmsg_marker *marker, size_t sz);
 void nn_xmsg_shrink (struct nn_xmsg *m, struct nn_xmsg_marker marker, size_t sz);
-void nn_xmsg_serdata (struct nn_xmsg *m, struct ddsi_serdata *serdata, size_t off, size_t len);
+void nn_xmsg_serdata (struct nn_xmsg *m, struct ddsi_serdata *serdata, size_t off, size_t len, struct writer *wr);
 void nn_xmsg_submsg_setnext (struct nn_xmsg *msg, struct nn_xmsg_marker marker);
 void nn_xmsg_submsg_init (struct nn_xmsg *msg, struct nn_xmsg_marker marker, SubmessageKind_t smkind);
 void nn_xmsg_add_timestamp (struct nn_xmsg *m, nn_wctime_t t);

--- a/src/core/ddsi/include/dds/ddsi/q_xmsg.h
+++ b/src/core/ddsi/include/dds/ddsi/q_xmsg.h
@@ -27,6 +27,7 @@ struct addrset;
 struct proxy_reader;
 struct proxy_writer;
 struct writer;
+struct participant;
 
 struct nn_prismtech_participant_version_info;
 struct nn_xmsgpool;
@@ -55,10 +56,10 @@ void nn_xmsgpool_free (struct nn_xmsgpool *pool);
 /* To allocate a new xmsg from the pool; if expected_size is NOT
    exceeded, no reallocs will be performed, else the address of the
    xmsg may change because of reallocing when appending to it. */
-struct nn_xmsg *nn_xmsg_new (struct nn_xmsgpool *pool, const ddsi_guid_prefix_t *src_guid_prefix, size_t expected_size, enum nn_xmsg_kind kind);
+struct nn_xmsg *nn_xmsg_new (struct nn_xmsgpool *pool, const ddsi_guid_t *src_guid, struct participant *pp, size_t expected_size, enum nn_xmsg_kind kind);
 
 /* For sending to a particular destination (participant) */
-void nn_xmsg_setdst1 (struct nn_xmsg *m, const ddsi_guid_prefix_t *gp, const nn_locator_t *addr);
+void nn_xmsg_setdst1 (struct q_globals *gv, struct nn_xmsg *m, const ddsi_guid_prefix_t *gp, const nn_locator_t *addr);
 bool nn_xmsg_getdst1prefix (struct nn_xmsg *m, ddsi_guid_prefix_t *gp);
 
 /* For sending to a particular proxy reader; this is a convenience

--- a/src/core/ddsi/include/dds/ddsi/q_xmsg.h
+++ b/src/core/ddsi/include/dds/ddsi/q_xmsg.h
@@ -59,6 +59,7 @@ struct nn_xmsg *nn_xmsg_new (struct nn_xmsgpool *pool, const ddsi_guid_prefix_t 
 
 /* For sending to a particular destination (participant) */
 void nn_xmsg_setdst1 (struct nn_xmsg *m, const ddsi_guid_prefix_t *gp, const nn_locator_t *addr);
+bool nn_xmsg_getdst1prefix (struct nn_xmsg *m, ddsi_guid_prefix_t *gp);
 
 /* For sending to a particular proxy reader; this is a convenience
    routine that extracts a suitable address from the proxy reader's
@@ -116,6 +117,12 @@ void *nn_xmsg_submsg_from_marker (struct nn_xmsg *msg, struct nn_xmsg_marker mar
 void *nn_xmsg_append (struct nn_xmsg *m, struct nn_xmsg_marker *marker, size_t sz);
 void nn_xmsg_shrink (struct nn_xmsg *m, struct nn_xmsg_marker marker, size_t sz);
 void nn_xmsg_serdata (struct nn_xmsg *m, struct ddsi_serdata *serdata, size_t off, size_t len, struct writer *wr);
+#ifdef DDSI_INCLUDE_SECURITY
+size_t nn_xmsg_submsg_size (struct nn_xmsg *msg, struct nn_xmsg_marker marker);
+void nn_xmsg_submsg_remove (struct nn_xmsg *msg, struct nn_xmsg_marker sm_marker);
+void nn_xmsg_submsg_replace (struct nn_xmsg *msg, struct nn_xmsg_marker sm_marker, unsigned char *new_submsg, size_t new_len);
+void nn_xmsg_submsg_append_refd_payload (struct nn_xmsg *msg, struct nn_xmsg_marker sm_marker);
+#endif
 void nn_xmsg_submsg_setnext (struct nn_xmsg *msg, struct nn_xmsg_marker marker);
 void nn_xmsg_submsg_init (struct nn_xmsg *msg, struct nn_xmsg_marker marker, SubmessageKind_t smkind);
 void nn_xmsg_add_timestamp (struct nn_xmsg *m, nn_wctime_t t);

--- a/src/core/ddsi/src/ddsi_security_omg.c
+++ b/src/core/ddsi/src/ddsi_security_omg.c
@@ -680,8 +680,6 @@ encode_datareader_submsg(
         unsigned int   src_len;
         unsigned char *dst_buf;
         unsigned int   dst_len;
-        ddsi_guid_prefix_t dst_guid_prefix;
-        ddsi_guid_prefix_t *dst = NULL;
 
         /* Make one blob of the current sub-message by appending the serialized payload. */
         nn_xmsg_submsg_append_refd_payload(msg, sm_marker);
@@ -690,13 +688,8 @@ encode_datareader_submsg(
         src_buf = (unsigned char*)nn_xmsg_submsg_from_marker(msg, sm_marker);
         src_len = (unsigned int)nn_xmsg_submsg_size(msg, sm_marker);
 
-        if (nn_xmsg_getdst1prefix(msg, &dst_guid_prefix))
-        {
-          dst = &dst_guid_prefix;
-        }
-
         /* Do the actual encryption. */
-        if (q_omg_security_encode_datareader_submessage(rd, dst, src_buf, src_len, &dst_buf, &dst_len))
+        if (q_omg_security_encode_datareader_submessage(rd, &(pwr->e.guid.prefix), src_buf, src_len, &dst_buf, &dst_len))
         {
           /* Replace the old sub-message with the new encoded one(s). */
           nn_xmsg_submsg_replace(msg, sm_marker, dst_buf, dst_len);

--- a/src/core/ddsi/src/ddsi_security_omg.c
+++ b/src/core/ddsi/src/ddsi_security_omg.c
@@ -14,9 +14,60 @@
 #include <string.h>
 
 #include "dds/ddsrt/misc.h"
+#include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/string.h"
 
 #include "dds/ddsi/q_unused.h"
+#include "dds/ddsi/q_radmin.h"
 #include "dds/ddsi/ddsi_security_omg.h"
+#include "dds/ddsi/ddsi_sertopic.h"
+
+static bool
+q_omg_writer_is_payload_protected(
+  const struct writer *wr);
+
+static bool endpoint_is_DCPSParticipantSecure(const ddsi_guid_t *guid)
+{
+  return ((guid->entityid.u == NN_ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_WRITER) ||
+          (guid->entityid.u == NN_ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_READER) );
+}
+
+static bool endpoint_is_DCPSPublicationsSecure(const ddsi_guid_t *guid)
+{
+  return ((guid->entityid.u == NN_ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER) ||
+          (guid->entityid.u == NN_ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_READER) );
+}
+
+static bool endpoint_is_DCPSSubscriptionsSecure(const ddsi_guid_t *guid)
+{
+  return ((guid->entityid.u == NN_ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER) ||
+          (guid->entityid.u == NN_ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER) );
+}
+
+static bool endpoint_is_DCPSParticipantStatelessMessage(const ddsi_guid_t *guid)
+{
+  return ((guid->entityid.u == NN_ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_MESSAGE_WRITER) ||
+          (guid->entityid.u == NN_ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_MESSAGE_READER) );
+}
+
+static bool endpoint_is_DCPSParticipantMessageSecure(const ddsi_guid_t *guid)
+{
+  return ((guid->entityid.u == NN_ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER) ||
+          (guid->entityid.u == NN_ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER) );
+}
+
+static bool endpoint_is_DCPSParticipantVolatileMessageSecure(const ddsi_guid_t *guid)
+{
+#if 1
+  /* TODO: volatile endpoint. */
+  DDSRT_UNUSED_ARG(guid);
+  return false;
+#else
+  return ((guid->entityid.u == NN_ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER) ||
+          (guid->entityid.u == NN_ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_READER) );
+#endif
+}
+
 
 bool
 q_omg_participant_is_secure(
@@ -54,9 +105,18 @@ q_omg_get_writer_security_info(
   assert(info);
   /* TODO: Register local writer. */
   DDSRT_UNUSED_ARG(wr);
+
   info->plugin_security_attributes = 0;
-  info->security_attributes = 0;
-  return false;
+  if (q_omg_writer_is_payload_protected(wr))
+  {
+    info->security_attributes = NN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_VALID|
+                                NN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_PAYLOAD_PROTECTED;
+  }
+  else
+  {
+    info->security_attributes = 0;
+  }
+  return true;
 }
 
 bool
@@ -130,19 +190,351 @@ allow_proxy_participant_deletion(
   return (!q_omg_proxyparticipant_is_authenticated(proxypp));
 }
 
+void
+set_proxy_participant_security_info(
+  struct proxy_participant *proxypp,
+  const nn_plist_t *plist)
+{
+  assert(proxypp);
+  assert(plist);
+  if (plist->present & PP_PARTICIPANT_SECURITY_INFO) {
+    proxypp->security_info.security_attributes = plist->participant_security_info.security_attributes;
+    proxypp->security_info.plugin_security_attributes = plist->participant_security_info.plugin_security_attributes;
+  } else {
+    proxypp->security_info.security_attributes = 0;
+    proxypp->security_info.plugin_security_attributes = 0;
+  }
+}
+
+static void
+q_omg_get_proxy_endpoint_security_info(
+  const struct entity_common *entity,
+  nn_security_info_t *proxypp_sec_info,
+  const nn_plist_t *plist,
+  nn_security_info_t *info)
+{
+  bool proxypp_info_available;
+
+  proxypp_info_available = (proxypp_sec_info->security_attributes != 0) ||
+                           (proxypp_sec_info->plugin_security_attributes != 0);
+
+  /*
+   * If Security info is present, use that.
+   * Otherwise, use the specified values for the secure builtin endpoints.
+   *      (Table 20 – EndpointSecurityAttributes for all "Builtin Security Endpoints")
+   * Otherwise, reset.
+   */
+  if (plist->present & PP_ENDPOINT_SECURITY_INFO)
+  {
+    info->security_attributes = plist->endpoint_security_info.security_attributes;
+    info->plugin_security_attributes = plist->endpoint_security_info.plugin_security_attributes;
+  }
+  else if (endpoint_is_DCPSParticipantSecure(&(entity->guid)) ||
+           endpoint_is_DCPSPublicationsSecure(&(entity->guid)) ||
+           endpoint_is_DCPSSubscriptionsSecure(&(entity->guid)) )
+  {
+    info->plugin_security_attributes = NN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_VALID;
+    info->security_attributes = NN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_VALID;
+    if (proxypp_info_available)
+    {
+      if (proxypp_sec_info->security_attributes & NN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_DISCOVERY_PROTECTED)
+      {
+        info->security_attributes |= NN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_PROTECTED;
+      }
+      if (proxypp_sec_info->plugin_security_attributes & NN_PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_DISCOVERY_ENCRYPTED)
+      {
+        info->plugin_security_attributes |= NN_PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ENCRYPTED;
+      }
+      if (proxypp_sec_info->plugin_security_attributes & NN_PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_DISCOVERY_AUTHENTICATED)
+      {
+        info->plugin_security_attributes |= NN_PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ORIGIN_AUTHENTICATED;
+      }
+    }
+    else
+    {
+      /* No participant info: assume hardcoded OpenSplice V6.10.0 values. */
+      info->security_attributes |= NN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_PROTECTED;
+      info->plugin_security_attributes |= NN_PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ENCRYPTED;
+    }
+  }
+  else if (endpoint_is_DCPSParticipantMessageSecure(&(entity->guid)))
+  {
+    info->plugin_security_attributes = NN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_VALID;
+    info->security_attributes = NN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_VALID;
+    if (proxypp_info_available)
+    {
+      if (proxypp_sec_info->security_attributes & NN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_LIVELINESS_PROTECTED)
+      {
+        info->security_attributes |= NN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_PROTECTED;
+      }
+      if (proxypp_sec_info->plugin_security_attributes & NN_PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_LIVELINESS_ENCRYPTED)
+      {
+        info->plugin_security_attributes |= NN_PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ENCRYPTED;
+      }
+      if (proxypp_sec_info->plugin_security_attributes & NN_PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_LIVELINESS_AUTHENTICATED)
+      {
+        info->plugin_security_attributes |= NN_PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ORIGIN_AUTHENTICATED;
+      }
+    }
+    else
+    {
+      /* No participant info: assume hardcoded OpenSplice V6.10.0 values. */
+      info->security_attributes |= NN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_PROTECTED;
+      info->plugin_security_attributes |= NN_PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ENCRYPTED;
+    }
+  }
+  else if (endpoint_is_DCPSParticipantStatelessMessage(&(entity->guid)))
+  {
+    info->security_attributes = NN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_VALID;
+    info->plugin_security_attributes = 0;
+  }
+  else if (endpoint_is_DCPSParticipantVolatileMessageSecure(&(entity->guid)))
+  {
+    info->security_attributes = NN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_VALID |
+                                NN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_PROTECTED;
+    info->plugin_security_attributes = 0;
+  }
+  else
+  {
+    info->security_attributes = 0;
+    info->plugin_security_attributes = 0;
+  }
+}
+
+void
+set_proxy_reader_security_info(
+  struct proxy_reader *prd,
+  const nn_plist_t *plist)
+{
+  assert(prd);
+  q_omg_get_proxy_endpoint_security_info(&(prd->e),
+                                         &(prd->c.proxypp->security_info),
+                                         plist,
+                                         &(prd->security_info));
+}
+
+void
+set_proxy_writer_security_info(
+  struct proxy_writer *pwr,
+  const nn_plist_t *plist)
+{
+  assert(pwr);
+  q_omg_get_proxy_endpoint_security_info(&(pwr->e),
+                                         &(pwr->c.proxypp->security_info),
+                                         plist,
+                                         &(pwr->security_info));
+}
+
+static bool
+q_omg_security_encode_serialized_payload(
+  const struct writer *wr,
+  const unsigned char *src_buf,
+  const unsigned int   src_len,
+  unsigned char     **dst_buf,
+  unsigned int       *dst_len)
+{
+  /* TODO: Use proper keys to actually encode (need key-exchange). */
+  DDSRT_UNUSED_ARG(wr);
+  DDSRT_UNUSED_ARG(src_buf);
+  DDSRT_UNUSED_ARG(src_len);
+  DDSRT_UNUSED_ARG(dst_buf);
+  DDSRT_UNUSED_ARG(dst_len);
+  return false;
+}
+
+static bool
+q_omg_security_decode_serialized_payload(
+  struct proxy_writer *pwr,
+  const unsigned char *src_buf,
+  const unsigned int   src_len,
+  unsigned char     **dst_buf,
+  unsigned int       *dst_len)
+{
+  /* TODO: Use proper keys to actually decode (need key-exchange). */
+  DDSRT_UNUSED_ARG(pwr);
+  DDSRT_UNUSED_ARG(src_buf);
+  DDSRT_UNUSED_ARG(src_len);
+  DDSRT_UNUSED_ARG(dst_buf);
+  DDSRT_UNUSED_ARG(dst_len);
+  return false;
+}
+
+static bool
+q_omg_writer_is_payload_protected(
+  const struct writer *wr)
+{
+  /* TODO: Local registration. */
+  DDSRT_UNUSED_ARG(wr);
+  return false;
+}
+
+bool
+encode_payload(
+  struct writer *wr,
+  ddsrt_iovec_t *vec,
+  unsigned char **buf)
+{
+  bool ok = true;
+  *buf = NULL;
+  if (q_omg_writer_is_payload_protected(wr))
+  {
+    /* Encrypt the data. */
+    unsigned char *enc_buf;
+    unsigned int   enc_len;
+    ok = q_omg_security_encode_serialized_payload(
+                    wr,
+                    vec->iov_base,
+                    (unsigned int)vec->iov_len,
+                    &enc_buf,
+                    &enc_len);
+    if (ok)
+    {
+      /* Replace the iov buffer, which should always be aliased. */
+      vec->iov_base = (char *)enc_buf;
+      vec->iov_len = enc_len;
+      /* Remember the pointer to be able to free the memory. */
+      *buf = enc_buf;
+    }
+  }
+  return ok;
+}
+
+
+static bool
+decode_payload(
+  const struct q_globals *gv,
+  struct nn_rsample_info *sampleinfo,
+  unsigned char *payloadp,
+  uint32_t *payloadsz,
+  size_t *submsg_len)
+{
+  bool ok = true;
+
+  assert(payloadp);
+  assert(payloadsz);
+  assert(*payloadsz);
+  assert(submsg_len);
+  assert(sampleinfo);
+
+  if (sampleinfo->pwr == NULL)
+  {
+    /* No specified proxy writer means no encoding. */
+    return true;
+  }
+
+  /* Only decode when the attributes tell us so. */
+  if ((sampleinfo->pwr->security_info.security_attributes & NN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_PAYLOAD_PROTECTED)
+                                                         == NN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_PAYLOAD_PROTECTED)
+  {
+    unsigned char *dst_buf = NULL;
+    unsigned int   dst_len = 0;
+
+    /* Decrypt the payload. */
+    if (q_omg_security_decode_serialized_payload(sampleinfo->pwr, payloadp, *payloadsz, &dst_buf, &dst_len))
+    {
+      /* Expect result to always fit into the original buffer. */
+      assert(*payloadsz >= dst_len);
+
+      /* Reduce submessage and payload lengths. */
+      *submsg_len -= (*payloadsz - dst_len);
+      *payloadsz   = dst_len;
+
+      /* Replace the encrypted payload with the decrypted. */
+      memcpy(payloadp, dst_buf, dst_len);
+      ddsrt_free(dst_buf);
+    }
+    else
+    {
+      GVWARNING("decode_payload: failed to decrypt data from "PGUIDFMT"", PGUID (sampleinfo->pwr->e.guid));
+      ok = false;
+    }
+  }
+
+  return ok;
+}
+
+bool
+decode_Data(
+  const struct q_globals *gv,
+  struct nn_rsample_info *sampleinfo,
+  unsigned char *payloadp,
+  uint32_t payloadsz,
+  size_t *submsg_len)
+{
+  int ok = true;
+  /* Only decode when there's actual data. */
+  if (payloadp && (payloadsz > 0))
+  {
+    ok = decode_payload(gv, sampleinfo, payloadp, &payloadsz, submsg_len);
+    if (ok)
+    {
+      /* It's possible that the payload size (and thus the sample size) has been reduced. */
+      sampleinfo->size = payloadsz;
+    }
+  }
+  return ok;
+}
+
+bool
+decode_DataFrag(
+  const struct q_globals *gv,
+  struct nn_rsample_info *sampleinfo,
+  unsigned char *payloadp,
+  uint32_t payloadsz,
+  size_t *submsg_len)
+{
+  int ok = true;
+  /* Only decode when there's actual data. */
+  if (payloadp && (payloadsz > 0))
+  {
+    ok = decode_payload(gv, sampleinfo, payloadp, &payloadsz, submsg_len);
+    /* Do not touch the sampleinfo->size in contradiction to decode_Data() (it has been calculated differently). */
+  }
+  return ok;
+}
 
 #else /* DDSI_INCLUDE_SECURITY */
 
 #include "dds/ddsi/ddsi_security_omg.h"
 
-extern inline bool q_omg_participant_is_secure(UNUSED_ARG(const struct participant *pp));
+extern inline bool q_omg_participant_is_secure(
+  UNUSED_ARG(const struct participant *pp));
 
-extern inline unsigned determine_subscription_writer(UNUSED_ARG(const struct reader *rd));
-extern inline unsigned determine_publication_writer(UNUSED_ARG(const struct writer *wr));
+extern inline unsigned determine_subscription_writer(
+  UNUSED_ARG(const struct reader *rd));
+
+extern inline unsigned determine_publication_writer(
+  UNUSED_ARG(const struct writer *wr));
 
 extern inline bool allow_proxy_participant_deletion(
   UNUSED_ARG(struct q_globals * const gv),
   UNUSED_ARG(const struct ddsi_guid *guid),
   UNUSED_ARG(const ddsi_entityid_t pwr_entityid));
+
+extern inline void set_proxy_participant_security_info(
+  UNUSED_ARG(struct proxy_participant *prd),
+  UNUSED_ARG(const nn_plist_t *plist));
+
+extern inline void set_proxy_reader_security_info(
+  UNUSED_ARG(struct proxy_reader *prd),
+  UNUSED_ARG(const nn_plist_t *plist));
+
+extern inline void set_proxy_writer_security_info(
+  UNUSED_ARG(struct proxy_writer *pwr),
+  UNUSED_ARG(const nn_plist_t *plist));
+
+extern inline bool decode_Data(
+  UNUSED_ARG(const struct q_globals *gv),
+  UNUSED_ARG(struct nn_rsample_info *sampleinfo),
+  UNUSED_ARG(unsigned char *payloadp),
+  UNUSED_ARG(uint32_t payloadsz),
+  UNUSED_ARG(size_t *submsg_len));
+
+extern inline bool decode_DataFrag(
+  UNUSED_ARG(const struct q_globals *gv),
+  UNUSED_ARG(struct nn_rsample_info *sampleinfo),
+  UNUSED_ARG(unsigned char *payloadp),
+  UNUSED_ARG(uint32_t payloadsz),
+  UNUSED_ARG(size_t *submsg_len));
 
 #endif /* DDSI_INCLUDE_SECURITY */

--- a/src/core/ddsi/src/ddsi_security_omg.c
+++ b/src/core/ddsi/src/ddsi_security_omg.c
@@ -15,12 +15,14 @@
 
 #include "dds/ddsrt/misc.h"
 #include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/bswap.h"
 #include "dds/ddsrt/string.h"
+#include "dds/ddsrt/process.h"
 
 #include "dds/ddsi/q_unused.h"
-#include "dds/ddsi/q_radmin.h"
 #include "dds/ddsi/ddsi_security_omg.h"
 #include "dds/ddsi/ddsi_sertopic.h"
+
 
 static bool
 q_omg_writer_is_payload_protected(
@@ -68,6 +70,11 @@ static bool endpoint_is_DCPSParticipantVolatileMessageSecure(const ddsi_guid_t *
 #endif
 }
 
+static bool
+q_omg_security_enabled()
+{
+  return true;
+}
 
 bool
 q_omg_participant_is_secure(
@@ -75,7 +82,7 @@ q_omg_participant_is_secure(
 {
   /* TODO: Register local participant. */
   DDSRT_UNUSED_ARG(pp);
-  return false;
+  return true;
 }
 
 static bool
@@ -310,7 +317,7 @@ set_proxy_reader_security_info(
   q_omg_get_proxy_endpoint_security_info(&(prd->e),
                                          &(prd->c.proxypp->security_info),
                                          plist,
-                                         &(prd->security_info));
+                                         &(prd->c.security_info));
 }
 
 void
@@ -322,7 +329,65 @@ set_proxy_writer_security_info(
   q_omg_get_proxy_endpoint_security_info(&(pwr->e),
                                          &(pwr->c.proxypp->security_info),
                                          plist,
-                                         &(pwr->security_info));
+                                         &(pwr->c.security_info));
+}
+
+
+static bool
+q_omg_security_encode_datareader_submessage(
+  struct reader            *rd,
+  const ddsi_guid_prefix_t *dst_prefix,
+  const unsigned char      *src_buf,
+  const unsigned int        src_len,
+  unsigned char           **dst_buf,
+  unsigned int             *dst_len)
+{
+  /* TODO: Use proper keys to actually encode (need key-exchange). */
+  DDSRT_UNUSED_ARG(rd);
+  DDSRT_UNUSED_ARG(dst_prefix);
+  DDSRT_UNUSED_ARG(src_buf);
+  DDSRT_UNUSED_ARG(src_len);
+  DDSRT_UNUSED_ARG(dst_buf);
+  DDSRT_UNUSED_ARG(dst_len);
+  return false;
+}
+
+static bool
+q_omg_security_encode_datawriter_submessage(
+  struct writer            *wr,
+  const ddsi_guid_prefix_t *dst_prefix,
+  const unsigned char      *src_buf,
+  const unsigned int        src_len,
+  unsigned char           **dst_buf,
+  unsigned int             *dst_len)
+{
+  /* TODO: Use proper keys to actually encode (need key-exchange). */
+  DDSRT_UNUSED_ARG(wr);
+  DDSRT_UNUSED_ARG(dst_prefix);
+  DDSRT_UNUSED_ARG(src_buf);
+  DDSRT_UNUSED_ARG(src_len);
+  DDSRT_UNUSED_ARG(dst_buf);
+  DDSRT_UNUSED_ARG(dst_len);
+  return false;
+}
+
+static bool
+q_omg_security_decode_submessage(
+  const ddsi_guid_prefix_t* const src_prefix,
+  const ddsi_guid_prefix_t* const dst_prefix,
+  const unsigned char   *src_buf,
+  const unsigned int     src_len,
+  unsigned char        **dst_buf,
+  unsigned int          *dst_len)
+{
+  /* TODO: Use proper keys to actually decode (need key-exchange). */
+  DDSRT_UNUSED_ARG(src_prefix);
+  DDSRT_UNUSED_ARG(dst_prefix);
+  DDSRT_UNUSED_ARG(src_buf);
+  DDSRT_UNUSED_ARG(src_len);
+  DDSRT_UNUSED_ARG(dst_buf);
+  DDSRT_UNUSED_ARG(dst_len);
+  return false;
 }
 
 static bool
@@ -365,6 +430,24 @@ q_omg_writer_is_payload_protected(
 {
   /* TODO: Local registration. */
   DDSRT_UNUSED_ARG(wr);
+  return false;
+}
+
+static bool
+q_omg_writer_is_submessage_protected(
+  struct writer *wr)
+{
+  /* TODO: Local registration. */
+  DDSRT_UNUSED_ARG(wr);
+  return false;
+}
+
+static bool
+q_omg_reader_is_submessage_protected(
+  struct reader *rd)
+{
+  /* TODO: Local registration. */
+  DDSRT_UNUSED_ARG(rd);
   return false;
 }
 
@@ -423,8 +506,8 @@ decode_payload(
   }
 
   /* Only decode when the attributes tell us so. */
-  if ((sampleinfo->pwr->security_info.security_attributes & NN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_PAYLOAD_PROTECTED)
-                                                         == NN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_PAYLOAD_PROTECTED)
+  if ((sampleinfo->pwr->c.security_info.security_attributes & NN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_PAYLOAD_PROTECTED)
+                                                           == NN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_PAYLOAD_PROTECTED)
   {
     unsigned char *dst_buf = NULL;
     unsigned int   dst_len = 0;
@@ -493,6 +576,302 @@ decode_DataFrag(
   return ok;
 }
 
+
+void
+encode_datareader_submsg(
+  struct nn_xmsg *msg,
+  struct nn_xmsg_marker sm_marker,
+  struct proxy_writer *pwr,
+  const struct ddsi_guid *rd_guid)
+{
+  /* Only encode when needed. */
+  if (q_omg_security_enabled())
+  {
+    struct reader *rd = ephash_lookup_reader_guid(pwr->e.gv->guid_hash, rd_guid);
+    if (rd)
+    {
+      if (q_omg_reader_is_submessage_protected(rd))
+      {
+        unsigned char *src_buf;
+        unsigned int   src_len;
+        unsigned char *dst_buf;
+        unsigned int   dst_len;
+        ddsi_guid_prefix_t dst_guid_prefix;
+        ddsi_guid_prefix_t *dst = NULL;
+
+        /* Make one blob of the current sub-message by appending the serialized payload. */
+        nn_xmsg_submsg_append_refd_payload(msg, sm_marker);
+
+        /* Get the sub-message buffer. */
+        src_buf = (unsigned char*)nn_xmsg_submsg_from_marker(msg, sm_marker);
+        src_len = (unsigned int)nn_xmsg_submsg_size(msg, sm_marker);
+
+        if (nn_xmsg_getdst1prefix(msg, &dst_guid_prefix))
+        {
+          dst = &dst_guid_prefix;
+        }
+
+        /* Do the actual encryption. */
+        if (q_omg_security_encode_datareader_submessage(rd, dst, src_buf, src_len, &dst_buf, &dst_len))
+        {
+          /* Replace the old sub-message with the new encoded one(s). */
+          nn_xmsg_submsg_replace(msg, sm_marker, dst_buf, dst_len);
+          ddsrt_free(dst_buf);
+        }
+        else
+        {
+          /* The sub-message should have been encoded, which failed.
+           * Remove it to prevent it from being send. */
+          nn_xmsg_submsg_remove(msg, sm_marker);
+        }
+      }
+    }
+  }
+}
+
+
+void
+encode_datawriter_submsg(
+  struct nn_xmsg *msg,
+  struct nn_xmsg_marker sm_marker,
+  struct writer *wr)
+{
+  /* Only encode when needed. */
+  if (q_omg_security_enabled())
+  {
+    if (q_omg_writer_is_submessage_protected(wr))
+    {
+      unsigned char *src_buf;
+      unsigned int   src_len;
+      unsigned char *dst_buf;
+      unsigned int   dst_len;
+      ddsi_guid_prefix_t dst_guid_prefix;
+      ddsi_guid_prefix_t *dst = NULL;
+
+      /* Make one blob of the current sub-message by appending the serialized payload. */
+      nn_xmsg_submsg_append_refd_payload(msg, sm_marker);
+
+      /* Get the sub-message buffer. */
+      src_buf = (unsigned char*)nn_xmsg_submsg_from_marker(msg, sm_marker);
+      src_len = (unsigned int)nn_xmsg_submsg_size(msg, sm_marker);
+
+      if (nn_xmsg_getdst1prefix(msg, &dst_guid_prefix))
+      {
+        dst = &dst_guid_prefix;
+      }
+
+      /* Do the actual encryption. */
+      if (q_omg_security_encode_datawriter_submessage(wr, dst, src_buf, src_len, &dst_buf, &dst_len))
+      {
+        /* Replace the old sub-message with the new encoded one(s). */
+        nn_xmsg_submsg_replace(msg, sm_marker, dst_buf, dst_len);
+        ddsrt_free(dst_buf);
+      }
+      else
+      {
+        /* The sub-message should have been encoded, which failed.
+         * Remove it to prevent it from being send. */
+        nn_xmsg_submsg_remove(msg, sm_marker);
+      }
+    }
+  }
+}
+
+
+
+bool
+validate_msg_decoding(
+  const struct entity_common *e,
+  const struct proxy_endpoint_common *c,
+  struct proxy_participant *proxypp,
+  struct receiver_state *rst,
+  SubmessageKind_t prev_smid)
+{
+  assert(e);
+  assert(c);
+  assert(proxypp);
+  assert(rst);
+
+  /* If this endpoint is expected to have submessages protected, it means that the
+   * previous submessage id (prev_smid) has to be SMID_SEC_PREFIX. That caused the
+   * protected submessage to be copied into the current RTPS message as a clear
+   * submessage, which we are currently handling.
+   * However, we have to check if the prev_smid is actually SMID_SEC_PREFIX, otherwise
+   * a rascal can inject data as just a clear submessage. */
+  if ((c->security_info.security_attributes & NN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_PROTECTED)
+                                           == NN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_PROTECTED)
+  {
+    if (prev_smid != SMID_SEC_PREFIX)
+    {
+      return false;
+    }
+  }
+
+  /* Use e, proxypp and rst for RTPS checks. */
+  (void)e;
+  (void)rst;
+  (void)proxypp;
+
+  return true;
+}
+
+static int
+validate_submsg(struct q_globals *gv, unsigned char smid, unsigned char *submsg, unsigned char * const end, int byteswap)
+{
+  int result = -1;
+  if ((submsg + RTPS_SUBMESSAGE_HEADER_SIZE) <= end)
+  {
+    SubmessageHeader_t *hdr = (SubmessageHeader_t*)submsg;
+    if ((smid == 0 /* don't care */) || (hdr->submessageId == smid))
+    {
+      unsigned short size = hdr->octetsToNextHeader;
+      if (byteswap)
+      {
+         size = ddsrt_bswap2u(size);
+      }
+      result = (int)size + (int)RTPS_SUBMESSAGE_HEADER_SIZE;
+      if ((submsg + result) > end)
+      {
+        result = -1;
+      }
+    }
+    else
+    {
+      GVWARNING("Unexpected submsg 0x%02x (0x%02x expected)", hdr->submessageId, smid);
+    }
+  }
+  else
+  {
+    GVWARNING("Submsg 0x%02x does not fit message", smid);
+  }
+  return result;
+}
+
+
+static int
+padding_submsg(struct q_globals *gv, unsigned char *start, unsigned char *end, int byteswap)
+{
+  SubmessageHeader_t *padding = (SubmessageHeader_t*)start;
+  size_t size = (size_t)(end - start);
+  int result = -1;
+
+  assert(start <= end);
+
+  if (size > sizeof(SubmessageHeader_t))
+  {
+    result = (int)size;
+    padding->submessageId = SMID_PAD;
+    padding->flags = (byteswap ? !(DDSRT_ENDIAN == DDSRT_LITTLE_ENDIAN) : (DDSRT_ENDIAN == DDSRT_LITTLE_ENDIAN));
+    padding->octetsToNextHeader = (unsigned short)(size - sizeof(SubmessageHeader_t));
+    if (byteswap)
+    {
+      padding->octetsToNextHeader = ddsrt_bswap2u(padding->octetsToNextHeader);
+    }
+  }
+  else
+  {
+    GVWARNING("Padding submessage doesn't fit");
+  }
+  return result;
+}
+
+int
+decode_SecPrefix(
+  struct receiver_state *rst,
+  unsigned char *submsg,
+  size_t submsg_size,
+  unsigned char * const msg_end,
+  const ddsi_guid_prefix_t * const src_prefix,
+  const ddsi_guid_prefix_t * const dst_prefix,
+  int byteswap)
+{
+  int result = -1;
+  int totalsize = (int)submsg_size;
+  unsigned char *body_submsg;
+  unsigned char *prefix_submsg;
+  unsigned char *postfix_submsg;
+  SubmessageHeader_t *hdr = (SubmessageHeader_t*)submsg;
+  uint8_t flags = hdr->flags;
+
+  if (byteswap)
+  {
+    if ((DDSRT_ENDIAN == DDSRT_LITTLE_ENDIAN))
+      hdr->flags |= 0x01;
+    else
+      hdr->flags &= 0xFE;
+  }
+
+  /* First sub-message is the SEC_PREFIX. */
+  prefix_submsg = submsg;
+
+  /* Next sub-message is SEC_BODY when encrypted or the original submessage when only signed. */
+  body_submsg = submsg + submsg_size;
+  result = validate_submsg(rst->gv, 0 /* don't care smid */, body_submsg, msg_end, byteswap);
+  if (result > 0)
+  {
+    totalsize += result;
+
+    /* Third sub-message should be the SEC_POSTFIX. */
+    postfix_submsg = submsg + totalsize;
+    result = validate_submsg(rst->gv, SMID_SEC_POSTFIX, postfix_submsg, msg_end, byteswap);
+    if (result > 0)
+    {
+      bool decoded;
+      unsigned char *dst_buf;
+      unsigned int   dst_len;
+
+      totalsize += result;
+
+      /* Decode all three submessages. */
+      decoded = q_omg_security_decode_submessage(src_prefix, dst_prefix, submsg, (unsigned int)totalsize, &dst_buf, &dst_len);
+      if (decoded && dst_buf)
+      {
+        /*
+         * The 'normal' submessage sequence handling will continue after the
+         * given security SEC_PREFIX.
+         */
+        if (*body_submsg == SMID_SEC_BODY)
+        {
+          /*
+           * Copy the decoded buffer into the original message, replacing (part
+           * of) SEC_BODY.
+           *
+           * By replacing the SEC_BODY with the decoded submessage, everything
+           * can continue as if there was never an encoded submessage.
+           */
+          assert((int)dst_len <= ((int)totalsize - (int)submsg_size));
+          memcpy(body_submsg, dst_buf, dst_len);
+
+          /* Remainder of SEC_BODY & SEC_POSTFIX should be padded to keep the submsg sequence going. */
+          result = padding_submsg(rst->gv, body_submsg + dst_len, prefix_submsg + totalsize, byteswap);
+        }
+        else
+        {
+          /*
+           * When only signed, then the submessage is already available and
+           * SMID_SEC_POSTFIX will be ignored.
+           * So, we don't really have to do anything.
+           */
+        }
+        ddsrt_free(dst_buf);
+      }
+      else
+      {
+        /*
+         * Decoding or signing failed.
+         *
+         * Replace the security submessages with padding. This also removes a plain
+         * submessage when a signature check failed.
+         */
+        result = padding_submsg(rst->gv, body_submsg, prefix_submsg + totalsize, byteswap);
+      }
+    }
+  }
+  /* Restore flags. */
+  hdr->flags = flags;
+  return result;
+}
+
 #else /* DDSI_INCLUDE_SECURITY */
 
 #include "dds/ddsi/ddsi_security_omg.h"
@@ -536,5 +915,32 @@ extern inline bool decode_DataFrag(
   UNUSED_ARG(unsigned char *payloadp),
   UNUSED_ARG(uint32_t payloadsz),
   UNUSED_ARG(size_t *submsg_len));
+
+extern inline void encode_datareader_submsg(
+  UNUSED_ARG(struct nn_xmsg *msg),
+  UNUSED_ARG(struct nn_xmsg_marker sm_marker),
+  UNUSED_ARG(struct proxy_writer *pwr),
+  UNUSED_ARG(const struct ddsi_guid *rd_guid));
+
+extern inline void encode_datawriter_submsg(
+  UNUSED_ARG(struct nn_xmsg *msg),
+  UNUSED_ARG(struct nn_xmsg_marker sm_marker),
+  UNUSED_ARG(struct writer *wr));
+
+extern inline bool validate_msg_decoding(
+  UNUSED_ARG(const struct entity_common *e),
+  UNUSED_ARG(const struct proxy_endpoint_common *c),
+  UNUSED_ARG(struct proxy_participant *proxypp),
+  UNUSED_ARG(struct receiver_state *rst),
+  UNUSED_ARG(SubmessageKind_t prev_smid));
+
+extern inline int decode_SecPrefix(
+  UNUSED_ARG(struct receiver_state *rst),
+  UNUSED_ARG(unsigned char *submsg),
+  UNUSED_ARG(size_t submsg_size),
+  UNUSED_ARG(unsigned char * const msg_end),
+  UNUSED_ARG(const ddsi_guid_prefix_t * const src_prefix),
+  UNUSED_ARG(const ddsi_guid_prefix_t * const dst_prefix),
+  UNUSED_ARG(int byteswap));
 
 #endif /* DDSI_INCLUDE_SECURITY */

--- a/src/core/ddsi/src/q_ddsi_discovery.c
+++ b/src/core/ddsi/src/q_ddsi_discovery.c
@@ -437,7 +437,7 @@ static int handle_SPDP_dead (const struct receiver_state *rst, ddsi_entityid_t p
     guid = datap->participant_guid;
     GVLOGDISC (" %"PRIx32":%"PRIx32":%"PRIx32":%"PRIx32, PGUID (guid));
     assert (guid.entityid.u == NN_ENTITYID_PARTICIPANT);
-    if (allow_proxy_participant_deletion(gv, &guid, pwr_entityid))
+    if (is_proxy_participant_deletion_allowed(gv, &guid, pwr_entityid))
     {
       if (delete_proxy_participant_by_guid (gv, &guid, timestamp, 0) < 0)
       {

--- a/src/core/ddsi/src/q_ddsi_discovery.c
+++ b/src/core/ddsi/src/q_ddsi_discovery.c
@@ -213,7 +213,7 @@ int spdp_write (struct participant *pp)
      terribly important, the msg will grow as needed, address space is
      essentially meaningless because we only use the message to
      construct the payload. */
-  mpayload = nn_xmsg_new (pp->e.gv->xmsgpool, &pp->e.guid.prefix, 0, NN_XMSG_KIND_DATA);
+  mpayload = nn_xmsg_new (pp->e.gv->xmsgpool, &pp->e.guid, NULL, 0, NN_XMSG_KIND_DATA);
 
   nn_plist_init_empty (&ps);
   ps.present |= PP_PARTICIPANT_GUID | PP_BUILTIN_ENDPOINT_SET |
@@ -343,7 +343,7 @@ static int spdp_dispose_unregister_with_wr (struct participant *pp, unsigned ent
     return 0;
   }
 
-  mpayload = nn_xmsg_new (pp->e.gv->xmsgpool, &pp->e.guid.prefix, 0, NN_XMSG_KIND_DATA);
+  mpayload = nn_xmsg_new (pp->e.gv->xmsgpool, &pp->e.guid, NULL, 0, NN_XMSG_KIND_DATA);
   nn_plist_init_empty (&ps);
   ps.present |= PP_PARTICIPANT_GUID;
   ps.participant_guid = pp->e.guid;
@@ -999,7 +999,7 @@ static int sedp_write_endpoint
      the QoS and other settings. So the header fields aren't really
      important, except that they need to be set to reasonable things
      or it'll crash */
-  mpayload = nn_xmsg_new (gv->xmsgpool, &wr->e.guid.prefix, 0, NN_XMSG_KIND_DATA);
+  mpayload = nn_xmsg_new (gv->xmsgpool, &wr->e.guid, NULL, 0, NN_XMSG_KIND_DATA);
   nn_plist_addtomsg (mpayload, &ps, ~(uint64_t)0, ~(uint64_t)0);
   if (xqos) nn_xqos_addtomsg (mpayload, xqos, qosdiff);
   nn_xmsg_addpar_sentinel (mpayload);
@@ -1467,7 +1467,7 @@ int sedp_write_topic (struct participant *pp, const struct nn_plist *datap)
 
   sedp_wr = get_sedp_writer (pp, NN_ENTITYID_SEDP_BUILTIN_TOPIC_WRITER);
 
-  mpayload = nn_xmsg_new (sedp_wr->e.gv->xmsgpool, &sedp_wr->e.guid.prefix, 0, NN_XMSG_KIND_DATA);
+  mpayload = nn_xmsg_new (sedp_wr->e.gv->xmsgpool, &sedp_wr->e.guid, NULL, 0, NN_XMSG_KIND_DATA);
   delta = nn_xqos_delta (&datap->qos, &sedp_wr->e.gv->default_xqos_tp, ~(uint64_t)0);
   if (sedp_wr->e.gv->config.explicitly_publish_qos_set_to_default)
     delta |= ~QP_UNRECOGNIZED_INCOMPATIBLE_MASK;
@@ -1505,7 +1505,7 @@ int sedp_write_cm_participant (struct participant *pp, int alive)
    the QoS and other settings. So the header fields aren't really
    important, except that they need to be set to reasonable things
    or it'll crash */
-  mpayload = nn_xmsg_new (sedp_wr->e.gv->xmsgpool, &sedp_wr->e.guid.prefix, 0, NN_XMSG_KIND_DATA);
+  mpayload = nn_xmsg_new (sedp_wr->e.gv->xmsgpool, &sedp_wr->e.guid, NULL, 0, NN_XMSG_KIND_DATA);
   nn_plist_init_empty (&ps);
   ps.present = PP_PARTICIPANT_GUID;
   ps.participant_guid = pp->e.guid;

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -2119,7 +2119,7 @@ static void proxy_writer_add_connection (struct proxy_writer *pwr, struct reader
   ddsrt_avl_insert_ipath (&pwr_readers_treedef, &pwr->readers, m, &path);
   local_reader_ary_insert(&pwr->rdary, rd);
   ddsrt_mutex_unlock (&pwr->e.lock);
-  qxev_pwr_entityid (pwr, &rd->e.guid.prefix);
+  qxev_pwr_entityid (pwr, &rd->e.guid);
 
   ELOGDISC (pwr, "\n");
 
@@ -2163,7 +2163,7 @@ static void proxy_reader_add_connection (struct proxy_reader *prd, struct writer
               PGUID (wr->e.guid), PGUID (prd->e.guid));
     ddsrt_avl_insert_ipath (&prd_writers_treedef, &prd->writers, m, &path);
     ddsrt_mutex_unlock (&prd->e.lock);
-    qxev_prd_entityid (prd, &wr->e.guid.prefix);
+    qxev_prd_entityid (prd, &wr->e.guid);
   }
 }
 
@@ -4446,7 +4446,7 @@ void update_proxy_writer (struct proxy_writer *pwr, seqno_t seq, struct addrset 
         rd = ephash_lookup_reader_guid (pwr->e.gv->guid_hash, &m->rd_guid);
         if (rd)
         {
-          qxev_pwr_entityid (pwr, &rd->e.guid.prefix);
+          qxev_pwr_entityid (pwr, &rd->e.guid);
         }
         m = ddsrt_avl_iter_next (&iter);
       }
@@ -4503,7 +4503,7 @@ void update_proxy_reader (struct proxy_reader *prd, seqno_t seq, struct addrset 
           ddsrt_mutex_lock (&wr->e.lock);
           rebuild_writer_addrset (wr);
           ddsrt_mutex_unlock (&wr->e.lock);
-          qxev_prd_entityid (prd, &wr->e.guid.prefix);
+          qxev_prd_entityid (prd, &wr->e.guid);
         }
         wrguid = guid_next;
         ddsrt_mutex_lock (&prd->e.lock);

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -3974,6 +3974,8 @@ void new_proxy_participant
   nn_xqos_mergein_missing (&proxypp->plist->qos, &gv->default_plist_pp.qos, ~(uint64_t)0);
   ddsrt_avl_init (&proxypp_groups_treedef, &proxypp->groups);
 
+  set_proxy_participant_security_info(proxypp, plist);
+
   if (custom_flags & CF_INC_KERNEL_SEQUENCE_NUMBERS)
     proxypp->kernel_sequence_numbers = 1;
   else
@@ -4394,6 +4396,8 @@ int new_proxy_writer (struct q_globals *gv, const struct ddsi_guid *ppguid, cons
   pwr->ddsi2direct_cb = 0;
   pwr->ddsi2direct_cbarg = 0;
 
+  set_proxy_writer_security_info(pwr, plist);
+
   local_reader_ary_init (&pwr->rdary);
 
   /* locking the entity prevents matching while the built-in topic hasn't been published yet */
@@ -4581,6 +4585,8 @@ int new_proxy_reader (struct q_globals *gv, const struct ddsi_guid *ppguid, cons
   prd->favours_ssm = (favours_ssm && gv->config.allowMulticast & AMC_SSM) ? 1 : 0;
 #endif
   prd->is_fict_trans_reader = 0;
+
+  set_proxy_reader_security_info(prd, plist);
 
   ddsrt_avl_init (&prd_writers_treedef, &prd->writers);
 

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -4291,6 +4291,11 @@ static void proxy_endpoint_common_init (struct entity_common *e, struct proxy_en
   else
     memset (&c->group_guid, 0, sizeof (c->group_guid));
 
+#ifdef DDSI_INCLUDE_SECURITY
+  c->security_info.security_attributes = 0;
+  c->security_info.plugin_security_attributes = 0;
+#endif
+
   ref_proxy_participant (proxypp, c);
 }
 

--- a/src/core/ddsi/src/q_transmit.c
+++ b/src/core/ddsi/src/q_transmit.c
@@ -448,9 +448,9 @@ static dds_return_t create_fragment_message_simple (struct writer *wr, seqno_t s
 
 #if TEST_KEYHASH
   if (serdata->kind != SDK_KEY || !wr->include_keyhash)
-    nn_xmsg_serdata (*pmsg, serdata, 0, ddsi_serdata_size (serdata));
+    nn_xmsg_serdata (*pmsg, serdata, 0, ddsi_serdata_size (serdata), wr);
 #else
-  nn_xmsg_serdata (*pmsg, serdata, 0, ddsi_serdata_size (serdata));
+  nn_xmsg_serdata (*pmsg, serdata, 0, ddsi_serdata_size (serdata), wr);
 #endif
   nn_xmsg_submsg_setnext (*pmsg, sm_marker);
   return 0;
@@ -618,7 +618,7 @@ dds_return_t create_fragment_message (struct writer *wr, seqno_t seq, const stru
     }
   }
 
-  nn_xmsg_serdata (*pmsg, serdata, fragstart, fraglen);
+  nn_xmsg_serdata (*pmsg, serdata, fragstart, fraglen, wr);
   nn_xmsg_submsg_setnext (*pmsg, sm_marker);
 #if 0
   GVTRACE ("queue data%s "PGUIDFMT" #%lld/%u[%u..%u)\n",

--- a/src/core/ddsi/src/q_transmit.c
+++ b/src/core/ddsi/src/q_transmit.c
@@ -141,7 +141,7 @@ struct nn_xmsg *writer_hbcontrol_create_heartbeat (struct writer *wr, const stru
   assert (wr->reliable);
   assert (hbansreq >= 0);
 
-  if ((msg = nn_xmsg_new (gv->xmsgpool, &wr->e.guid.prefix, sizeof (InfoTS_t) + sizeof (Heartbeat_t), NN_XMSG_KIND_CONTROL)) == NULL)
+  if ((msg = nn_xmsg_new (gv->xmsgpool, &wr->e.guid, wr->c.pp, sizeof (InfoTS_t) + sizeof (Heartbeat_t), NN_XMSG_KIND_CONTROL)) == NULL)
     /* out of memory at worst slows down traffic */
     return NULL;
 
@@ -420,7 +420,7 @@ static dds_return_t create_fragment_message_simple (struct writer *wr, seqno_t s
   ASSERT_MUTEX_HELD (&wr->e.lock);
 
   /* INFO_TS: 12 bytes, Data_t: 24 bytes, expected inline QoS: 32 => should be single chunk */
-  if ((*pmsg = nn_xmsg_new (gv->xmsgpool, &wr->e.guid.prefix, sizeof (InfoTimestamp_t) + sizeof (Data_t) + expected_inline_qos_size, NN_XMSG_KIND_DATA)) == NULL)
+  if ((*pmsg = nn_xmsg_new (gv->xmsgpool, &wr->e.guid, wr->c.pp, sizeof (InfoTimestamp_t) + sizeof (Data_t) + expected_inline_qos_size, NN_XMSG_KIND_DATA)) == NULL)
     return DDS_RETCODE_OUT_OF_RESOURCES;
 
 #ifdef DDSI_INCLUDE_NETWORK_PARTITIONS
@@ -506,7 +506,7 @@ dds_return_t create_fragment_message (struct writer *wr, seqno_t seq, const stru
   fragging = (gv->config.fragment_size < size);
 
   /* INFO_TS: 12 bytes, DataFrag_t: 36 bytes, expected inline QoS: 32 => should be single chunk */
-  if ((*pmsg = nn_xmsg_new (gv->xmsgpool, &wr->e.guid.prefix, sizeof (InfoTimestamp_t) + sizeof (DataFrag_t) + expected_inline_qos_size, xmsg_kind)) == NULL)
+  if ((*pmsg = nn_xmsg_new (gv->xmsgpool, &wr->e.guid, wr->c.pp, sizeof (InfoTimestamp_t) + sizeof (DataFrag_t) + expected_inline_qos_size, xmsg_kind)) == NULL)
     return DDS_RETCODE_OUT_OF_RESOURCES;
 
 #ifdef DDSI_INCLUDE_NETWORK_PARTITIONS
@@ -653,7 +653,7 @@ static void create_HeartbeatFrag (struct writer *wr, seqno_t seq, unsigned fragn
   struct nn_xmsg_marker sm_marker;
   HeartbeatFrag_t *hbf;
   ASSERT_MUTEX_HELD (&wr->e.lock);
-  if ((*pmsg = nn_xmsg_new (gv->xmsgpool, &wr->e.guid.prefix, sizeof (HeartbeatFrag_t), NN_XMSG_KIND_CONTROL)) == NULL)
+  if ((*pmsg = nn_xmsg_new (gv->xmsgpool, &wr->e.guid, wr->c.pp, sizeof (HeartbeatFrag_t), NN_XMSG_KIND_CONTROL)) == NULL)
     return; /* ignore out-of-memory: HeartbeatFrag is only advisory anyway */
 #ifdef DDSI_INCLUDE_NETWORK_PARTITIONS
   nn_xmsg_setencoderid (*pmsg, wr->partition_id);


### PR DESCRIPTION
This pull request does not actually introduce encoding and decoding. But it will introduce DDSI preparations to support that.

It's divided into three* commits to separate the three different encoding/decoding 'layers': payload, sub-message and RTPS message.

\* The fourth commit is just removing a redundant function call.

**Payload**
For this, the security attributes have to be send during the discovery to know if the writer has encoded the payload or not.

When data is send: refd_payload_iov is used and normally points to the 'normal' sample. When encoding is necessary, it'll point to a new buffer (refd_payload_encoded) causing the encoded payload to be used automatically.

When (fragmented) data is received, the sub-message header is extracted. Then the payload is decoded when necessary. That'll replace the original encoded payload within the sub-message. Now the complete receive stack can continue normally. Small problem is that the byteswap bit was part of the encoded payload, meaning that it can only be set after the decoding.

**Sub-message**
The plugin API forces that encoding the submessage has to be with a single buffer. This means that the payload has to be explicitly copied right after the submessage header (normally it's just the next iov element). The encoded submessage will replace the original one. This way, the send sequence can continue normally.

When receiving a submessage, it'll be decoded when necessary. Again, it'll replace the original encoded submessage so that the rest of the code can remain the same. 
Small caveat though. When handling the submessage, the code has to make sure that it was actually encoded previously, otherwise someone can inject clear submessages.

**RTPS message**
This has basically the same issues as the sub-message encoding and decoding. Only even more iov buffers when sending. Also, it needs participant keys iso reader/writer keys.

**Testing**
This has been tested manually by this [testpatch.txt](https://github.com/eclipse-cyclonedds/cyclonedds/files/3864416/testpatch.txt) patch that'll mock encryption and then run the mpt_basic tests.