### PR TITLE
Bump version number to 0.5 prior to release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
 cmake_minimum_required(VERSION 3.7)
-project(CycloneDDS VERSION 0.1.0)
+project(CycloneDDS VERSION 0.5.0)
 
 # Set a default build type if none was specified
 set(default_build_type "RelWithDebInfo")

--- a/docs/manual/config.rst
+++ b/docs/manual/config.rst
@@ -1110,21 +1110,3 @@ an endless loop.
 There is furthermore also a difference of interpretation of the meaning of the
 ‘autodispose_unregistered_instances’ QoS on the writer.  Eclipse Cyclone DDS aligns with
 OpenSplice.
-
-
-.. _`Compatibility issues with TwinOaks`:
-
-Compatibility issues with TwinOaks
-----------------------------------
-
-In the default configuration there should be no interoperability issues with TwinOaks CoreDX,
-although there is the aforementioned difference in interpretation of the meaning of the
-‘autodispose_unregistered_instances’ QoS on the writer.
-
-Interoperability with very old versions of CoreDX may require setting:
-
-+ ``Compatibility/ManySocketsMode``: *true*
-+ ``Compatibility/ExplicitlyPublishQosSetToDefault``: *true*
-
-The exact version number of CoreDX starting with which these settings are no longer needed is
-unknown, but it has certainly not been needed for several years.

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -94,7 +94,8 @@ if(BUILD_DOCS)
     "__attribute__="
     "__declspec(x)="
     "DDS_EXPORT="
-    "DDS_DEPRECATED_EXPORT=")
+    "DDS_DEPRECATED_EXPORT="
+    "DDSRT_STATIC_ASSERT(x)=")
   find_package(Doxygen REQUIRED)
   doxygen_add_docs(ddsc_api_docs "ddsc/include")
 endif()


### PR DESCRIPTION
I am trying to release a new version — long, long overdue! — and would have liked to do so in time for the ROS2 Eloquent release on the 22nd. Having been negligent in starting the release process in time for that, the least I can do is bump the version number and tag it as a release candidate.

Once the version number is bumped, there are no particular details that should prevent it from being releaseable as-is, but I do want to make sure the documentation is regenerated with the right version number and do a few more checks. I also still need to get approval from the Eclipse PMC to release.

This PR is therefore simply the first step, bumping the version number. (There is no -rc1 in it, CMake didn't like my attempt at adding that ...)

Signed-off-by: Erik Boasson <eb@ilities.com>