### PR TITLE
Add DOMAIN_ID, DOMAIN_TAG to config, discovery

### DIFF
--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -101,7 +101,7 @@ The default value is: "lax".
 
 
 ### //CycloneDDS/Domain/Discovery
-Children: [DSGracePeriod](#cycloneddsdomaindiscoverydsgraceperiod), [DefaultMulticastAddress](#cycloneddsdomaindiscoverydefaultmulticastaddress), [EnableTopicDiscovery](#cycloneddsdomaindiscoveryenabletopicdiscovery), [MaxAutoParticipantIndex](#cycloneddsdomaindiscoverymaxautoparticipantindex), [ParticipantIndex](#cycloneddsdomaindiscoveryparticipantindex), [Peers](#cycloneddsdomaindiscoverypeers), [Ports](#cycloneddsdomaindiscoveryports), [SPDPInterval](#cycloneddsdomaindiscoveryspdpinterval), [SPDPMulticastAddress](#cycloneddsdomaindiscoveryspdpmulticastaddress)
+Children: [DSGracePeriod](#cycloneddsdomaindiscoverydsgraceperiod), [DefaultMulticastAddress](#cycloneddsdomaindiscoverydefaultmulticastaddress), [EnableTopicDiscovery](#cycloneddsdomaindiscoveryenabletopicdiscovery), [ExternalDomainId](#cycloneddsdomaindiscoveryexternaldomainid), [MaxAutoParticipantIndex](#cycloneddsdomaindiscoverymaxautoparticipantindex), [ParticipantIndex](#cycloneddsdomaindiscoveryparticipantindex), [Peers](#cycloneddsdomaindiscoverypeers), [Ports](#cycloneddsdomaindiscoveryports), [SPDPInterval](#cycloneddsdomaindiscoveryspdpinterval), [SPDPMulticastAddress](#cycloneddsdomaindiscoveryspdpmulticastaddress), [Tag](#cycloneddsdomaindiscoverytag)
 
 
 The Discovery element allows specifying various parameters related to the
@@ -138,6 +138,17 @@ Boolean
 Do not use.
 
 The default value is: "true".
+
+
+#### //CycloneDDS/Domain/Discovery/ExternalDomainId
+Text
+
+An override for the domain id, to be used in discovery and for
+determining the port number mapping. This allows creating multiple
+domains in a single process while making them appear as a single domain
+on the network. The value "default" disables the override.
+
+The default value is: "default".
 
 
 #### //CycloneDDS/Domain/Discovery/MaxAutoParticipantIndex
@@ -326,6 +337,15 @@ ff02::ffff:239.255.0.1, which is a non-standardised link-local multicast
 address.
 
 The default value is: "239.255.0.1".
+
+
+#### //CycloneDDS/Domain/Discovery/Tag
+Text
+
+String extension for domain id that remote participants must match to be
+discovered.
+
+The default value is: "".
 
 
 ### //CycloneDDS/Domain/General

--- a/etc/cyclonedds.rnc
+++ b/etc/cyclonedds.rnc
@@ -111,6 +111,15 @@ Discovery/SPDPMulticastAddress.</p><p>The default value is:
           xsd:boolean
         }?
         & [ a:documentation [ xml:lang="en" """
+<p>An override for the domain id, to be used in discovery and for
+determining the port number mapping. This allows creating multiple
+domains in a single process while making them appear as a single domain
+on the network. The value "default" disables the override.</p><p>The
+default value is: &quot;default&quot;.</p>""" ] ]
+        element ExternalDomainId {
+          text
+        }?
+        & [ a:documentation [ xml:lang="en" """
 <p>This element specifies the maximum DDSI participant index selected by
 this instance of the Cyclone DDS service if the
 Discovery/ParticipantIndex is "auto".</p><p>The default value is:
@@ -255,6 +264,12 @@ default is the (standardised) 239.255.0.1, in IPv6 mode it becomes
 ff02::ffff:239.255.0.1, which is a non-standardised link-local multicast
 address.</p><p>The default value is: &quot;239.255.0.1&quot;.</p>""" ] ]
         element SPDPMulticastAddress {
+          text
+        }?
+        & [ a:documentation [ xml:lang="en" """
+<p>String extension for domain id that remote participants must match to
+be discovered.</p><p>The default value is: &quot;&quot;.</p>""" ] ]
+        element Tag {
           text
         }?
       }?

--- a/etc/cyclonedds.xsd
+++ b/etc/cyclonedds.xsd
@@ -157,12 +157,14 @@ the discovery of peers.&lt;/p&gt;</xs:documentation>
         <xs:element minOccurs="0" ref="config:DSGracePeriod"/>
         <xs:element minOccurs="0" ref="config:DefaultMulticastAddress"/>
         <xs:element minOccurs="0" ref="config:EnableTopicDiscovery"/>
+        <xs:element minOccurs="0" ref="config:ExternalDomainId"/>
         <xs:element minOccurs="0" ref="config:MaxAutoParticipantIndex"/>
         <xs:element minOccurs="0" ref="config:ParticipantIndex"/>
         <xs:element minOccurs="0" ref="config:Peers"/>
         <xs:element minOccurs="0" ref="config:Ports"/>
         <xs:element minOccurs="0" ref="config:SPDPInterval"/>
         <xs:element minOccurs="0" ref="config:SPDPMulticastAddress"/>
+        <xs:element minOccurs="0" ref="config:Tag"/>
       </xs:all>
     </xs:complexType>
   </xs:element>
@@ -192,6 +194,16 @@ Discovery/SPDPMulticastAddress.&lt;/p&gt;&lt;p&gt;The default value is:
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;Do not use.&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;true&amp;quot;.&lt;/p&gt;</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="ExternalDomainId" type="xs:string">
+    <xs:annotation>
+      <xs:documentation>
+&lt;p&gt;An override for the domain id, to be used in discovery and for
+determining the port number mapping. This allows creating multiple
+domains in a single process while making them appear as a single domain
+on the network. The value "default" disables the override.&lt;/p&gt;&lt;p&gt;The
+default value is: &amp;quot;default&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="MaxAutoParticipantIndex" type="xs:integer">
@@ -369,6 +381,13 @@ destination for the participant discovery packets. In IPv4 mode the
 default is the (standardised) 239.255.0.1, in IPv6 mode it becomes
 ff02::ffff:239.255.0.1, which is a non-standardised link-local multicast
 address.&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;239.255.0.1&amp;quot;.&lt;/p&gt;</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="Tag" type="xs:string">
+    <xs:annotation>
+      <xs:documentation>
+&lt;p&gt;String extension for domain id that remote participants must match to
+be discovered.&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="General">

--- a/src/core/ddsi/include/dds/ddsi/ddsi_portmapping.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_portmapping.h
@@ -37,8 +37,10 @@ struct ddsi_portmapping {
   uint32_t d3;
 };
 
-bool ddsi_valid_portmapping (const struct ddsi_portmapping *map, uint32_t domain_id, int32_t participant_index, char *msg, size_t msgsize);
-uint32_t ddsi_get_port (const struct ddsi_portmapping *map, enum ddsi_port which, uint32_t domain_id, int32_t participant_index);
+struct config;
+
+bool ddsi_valid_portmapping (const struct config *config, int32_t participant_index, char *msg, size_t msgsize);
+uint32_t ddsi_get_port (const struct config *config, enum ddsi_port which, int32_t participant_index);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsi/include/dds/ddsi/q_config.h
+++ b/src/core/ddsi/include/dds/ddsi/q_config.h
@@ -196,6 +196,8 @@ struct config
   int dontRoute;
   int enableMulticastLoopback;
   uint32_t domainId;
+  struct config_maybe_uint32 extDomainId; // domain id advertised in discovery
+  char *domainTag;
   int participantIndex;
   int maxAutoParticipantIndex;
   char *spdpMulticastAddressString;

--- a/src/core/ddsi/include/dds/ddsi/q_plist.h
+++ b/src/core/ddsi/include/dds/ddsi/q_plist.h
@@ -59,6 +59,8 @@ extern "C" {
 /* Security extensions. */
 #define PP_IDENTITY_TOKEN                       ((uint64_t)1 << 41)
 #define PP_PERMISSIONS_TOKEN                    ((uint64_t)1 << 42)
+#define PP_DOMAIN_ID                            ((uint64_t)1 << 43)
+#define PP_DOMAIN_TAG                           ((uint64_t)1 << 44)
 /* Set for unrecognized parameters that are in the reserved space or
    in our own vendor-specific space that have the
    PID_UNRECOGNIZED_INCOMPATIBLE_FLAG set (see DDSI 2.1 9.6.2.2.1) */
@@ -162,6 +164,8 @@ typedef struct nn_plist {
 #ifdef DDSI_INCLUDE_SSM
   nn_reader_favours_ssm_t reader_favours_ssm;
 #endif
+  uint32_t domain_id;
+  char *domain_tag;
 } nn_plist_t;
 
 

--- a/src/core/ddsi/include/dds/ddsi/q_protocol.h
+++ b/src/core/ddsi/include/dds/ddsi/q_protocol.h
@@ -330,6 +330,8 @@ DDSRT_WARNING_MSVC_ON(4200)
 
 #define PID_PAD                                 0x0u
 #define PID_SENTINEL                            0x1u
+#define PID_DOMAIN_ID                           0xfu
+#define PID_DOMAIN_TAG                          (0x14u | PID_UNRECOGNIZED_INCOMPATIBLE_FLAG)
 #define PID_USER_DATA                           0x2cu
 #define PID_TOPIC_NAME                          0x5u
 #define PID_TYPE_NAME                           0x7u

--- a/src/core/ddsi/src/ddsi_portmapping.c
+++ b/src/core/ddsi/src/ddsi_portmapping.c
@@ -89,7 +89,7 @@ static const char *portname (enum ddsi_port which)
   return n;
 }
 
-bool ddsi_valid_portmapping (const struct ddsi_portmapping *map, uint32_t domain_id, int32_t participant_index, char *msg, size_t msgsize)
+bool ddsi_valid_portmapping (const struct config *config, int32_t participant_index, char *msg, size_t msgsize)
 {
   DDSRT_STATIC_ASSERT (DDSI_PORT_MULTI_DISC >= 0 &&
                        DDSI_PORT_MULTI_DISC + 1 == DDSI_PORT_MULTI_DATA &&
@@ -103,7 +103,7 @@ bool ddsi_valid_portmapping (const struct ddsi_portmapping *map, uint32_t domain
   int n = snprintf (msg, msgsize, "port number(s) of out range:");
   size_t pos = (n >= 0 && (size_t) n <= msgsize) ? (size_t) n : msgsize;
   do {
-    if (!get_port_int (&dummy_port, map, which, domain_id, participant_index, str, sizeof (str)))
+    if (!get_port_int (&dummy_port, &config->ports, which, config->extDomainId.value, participant_index, str, sizeof (str)))
     {
       n = snprintf (msg + pos, msgsize - pos, "%s %s %s", ok ? "" : ",", portname (which), str);
       if (n >= 0 && (size_t) n <= msgsize - pos)
@@ -114,12 +114,12 @@ bool ddsi_valid_portmapping (const struct ddsi_portmapping *map, uint32_t domain
   return ok;
 }
 
-uint32_t ddsi_get_port (const struct ddsi_portmapping *map, enum ddsi_port which, uint32_t domain_id, int32_t participant_index)
+uint32_t ddsi_get_port (const struct config *config, enum ddsi_port which, int32_t participant_index)
 {
   /* Not supposed to come here if port mapping is invalid */
   uint32_t port;
   char str[32];
-  bool ok = get_port_int (&port, map, which, domain_id, participant_index, str, sizeof (str));
+  bool ok = get_port_int (&port, &config->ports, which, config->extDomainId.value, participant_index, str, sizeof (str));
   assert (ok);
   (void) ok;
   return port;

--- a/src/core/ddsi/src/q_addrset.c
+++ b/src/core/ddsi/src/q_addrset.c
@@ -105,7 +105,7 @@ static int add_addresses_to_addrset_1 (const struct q_globals *gv, struct addrse
       assert (gv->config.maxAutoParticipantIndex >= 0);
       for (int32_t i = 0; i <= gv->config.maxAutoParticipantIndex; i++)
       {
-        loc.port = ddsi_get_port (&gv->config.ports, DDSI_PORT_UNI_DISC, gv->config.domainId, i);
+        loc.port = ddsi_get_port (&gv->config, DDSI_PORT_UNI_DISC, i);
         if (i == 0)
           GVLOG (DDS_LC_CONFIG, "%s", ddsi_locator_to_string(gv, buf, sizeof(buf), &loc));
         else
@@ -116,7 +116,7 @@ static int add_addresses_to_addrset_1 (const struct q_globals *gv, struct addrse
     else
     {
       if (port_mode == -1)
-        loc.port = ddsi_get_port (&gv->config.ports, DDSI_PORT_MULTI_DISC, gv->config.domainId, 0);
+        loc.port = ddsi_get_port (&gv->config, DDSI_PORT_MULTI_DISC, 0);
       else
         loc.port = (uint32_t) port_mode;
       GVLOG (DDS_LC_CONFIG, "%s", ddsi_locator_to_string(gv, buf, sizeof(buf), &loc));

--- a/src/core/ddsi/src/q_config.c
+++ b/src/core/ddsi/src/q_config.c
@@ -697,6 +697,10 @@ static const struct cfgelem discovery_peers_cfgelems[] = {
 };
 
 static const struct cfgelem discovery_cfgelems[] = {
+  { LEAF("Tag"), 0, "", ABSOFF(domainTag), 0, uf_string, ff_free, pf_string,
+    BLURB("<p>String extension for domain id that remote participants must match to be discovered.</p>") },
+  { LEAF ("ExternalDomainId"), 1, "default", ABSOFF (extDomainId), 0, uf_maybe_int32, 0, pf_maybe_int32,
+    BLURB("<p>An override for the domain id, to be used in discovery and for determining the port number mapping. This allows creating multiple domains in a single process while making them appear as a single domain on the network.  The value \"default\" disables the override.</p>") },
   { LEAF("DSGracePeriod"), 1, "30 s", ABSOFF(ds_grace_period), 0, uf_duration_inf, 0, pf_duration,
     BLURB("<p>This setting controls for how long endpoints discovered via a Cloud discovery service will survive after the discovery service disappeared, allowing reconnect without loss of data when the discovery service restarts (or another instance takes over).</p>") },
   { GROUP("Peers", discovery_peers_cfgelems),

--- a/src/core/ddsi/src/q_ddsi_discovery.c
+++ b/src/core/ddsi/src/q_ddsi_discovery.c
@@ -216,12 +216,25 @@ int spdp_write (struct participant *pp)
 
   nn_plist_init_empty (&ps);
   ps.present |= PP_PARTICIPANT_GUID | PP_BUILTIN_ENDPOINT_SET |
-    PP_PROTOCOL_VERSION | PP_VENDORID | PP_PARTICIPANT_LEASE_DURATION;
+    PP_PROTOCOL_VERSION | PP_VENDORID | PP_PARTICIPANT_LEASE_DURATION |
+    PP_DOMAIN_ID;
   ps.participant_guid = pp->e.guid;
   ps.builtin_endpoint_set = pp->bes;
   ps.protocol_version.major = RTPS_MAJOR;
   ps.protocol_version.minor = RTPS_MINOR;
   ps.vendorid = NN_VENDORID_ECLIPSE;
+  ps.domain_id = pp->e.gv->config.extDomainId.value;
+  /* Be sure not to send a DOMAIN_TAG when it is the default (an empty)
+     string: it is an "incompatible-if-unrecognized" parameter, and so
+     implementations that don't understand the parameter will refuse to
+     discover us, and so sending the default would break backwards
+     compatibility. */
+  if (strcmp (pp->e.gv->config.domainTag, "") != 0)
+  {
+    ps.present |= PP_DOMAIN_TAG;
+    ps.aliased |= PP_DOMAIN_TAG;
+    ps.domain_tag = pp->e.gv->config.domainTag;
+  }
   if (pp->prismtech_bes)
   {
     ps.present |= PP_PRISMTECH_BUILTIN_ENDPOINT_SET;
@@ -519,6 +532,18 @@ static int handle_SPDP_alive (const struct receiver_state *rst, seqno_t seq, nn_
   ddsi_guid_t privileged_pp_guid;
   dds_duration_t lease_duration;
   unsigned custom_flags = 0;
+
+  /* If advertised domain id or domain tag doesn't match, ignore the message.  Do this first to
+     minimize the impact such messages have. */
+  {
+    const uint32_t domain_id = (datap->present & PP_DOMAIN_ID) ? datap->domain_id : gv->config.extDomainId.value;
+    const char *domain_tag = (datap->present & PP_DOMAIN_TAG) ? datap->domain_tag : "";
+    if (domain_id != gv->config.extDomainId.value || strcmp (domain_tag, gv->config.domainTag) != 0)
+    {
+      GVTRACE ("ignore remote participant in mismatching domain %"PRIu32" tag \"%s\"\n", domain_id, domain_tag);
+      return 0;
+    }
+  }
 
   if (!(datap->present & PP_PARTICIPANT_GUID) || !(datap->present & PP_BUILTIN_ENDPOINT_SET))
   {

--- a/src/core/ddsi/src/q_plist.c
+++ b/src/core/ddsi/src/q_plist.c
@@ -1173,6 +1173,8 @@ static const struct piddesc piddesc_omg[] = {
 #ifdef DDSI_INCLUDE_SSM
   PPV (READER_FAVOURS_SSM,                  reader_favours_ssm, Xu),
 #endif
+  PP  (DOMAIN_ID,                           domain_id, Xu),
+  PP  (DOMAIN_TAG,                          domain_tag, XS),
   { PID_STATUSINFO, PDF_FUNCTION, PP_STATUSINFO, "STATUSINFO",
     offsetof (struct nn_plist, statusinfo), membersize (struct nn_plist, statusinfo),
     { .f = { .deser = deser_statusinfo, .ser = ser_statusinfo } }, 0 },
@@ -1318,8 +1320,8 @@ static const struct piddesc_index piddesc_vendor_index[] = {
 /* List of entries that require unalias, fini processing;
    initialized by nn_plist_init_tables; will assert when
    table too small or too large */
-static const struct piddesc *piddesc_unalias[19];
-static const struct piddesc *piddesc_fini[19];
+static const struct piddesc *piddesc_unalias[20];
+static const struct piddesc *piddesc_fini[20];
 static ddsrt_once_t table_init_control = DDSRT_ONCE_INIT;
 
 static nn_parameterid_t pid_without_flags (nn_parameterid_t pid)
@@ -2098,13 +2100,7 @@ static dds_return_t init_one_parameter (nn_plist_t *plist, nn_ipaddress_params_t
     return return_unrecognized_pid (plist, pid);
   assert (pid_without_flags (pid) == pid_without_flags (entry->pid));
   if (pid != entry->pid)
-  {
-    DDS_CERROR (logcfg, "error processing parameter list (vendor %u.%u, version %u.%u): pid %"PRIx16" mapped to pid %"PRIx16"\n",
-                dd->vendorid.id[0], dd->vendorid.id[1],
-                dd->protocol_version.major, dd->protocol_version.minor,
-                pid, entry->pid);
     return return_unrecognized_pid (plist, pid);
-  }
   assert (pid != PID_PAD);
 
   struct flagset flagset;


### PR DESCRIPTION
This commits adds support for the DOMAIN_ID and DOMAIN_TAG parameters in
participant discovery, allowing multiple domains to share a port
number (a feature introduced in DDSI 2.3).  The tag can be configured
via Discovery/Tag.

This commit also introduces a setting Discovery/ExternalDomainId that
makes it possible to override the domain id on the network, both in what
is advertised in the DOMAIN_ID discovery parameter and in the
calculation of port numbers.  This way a single process can create two
independent domains that talk via the network, which is on occassion
useful in writing tests.

Signed-off-by: Erik Boasson <eb@ilities.com>