### PR TITLE
Add string functions used by security plugins to ddsrt

### DIFF
--- a/src/ddsrt/include/dds/ddsrt/string.h
+++ b/src/ddsrt/include/dds/ddsrt/string.h
@@ -176,6 +176,23 @@ ddsrt_strerror_r(
     char *buf,
     size_t buflen);
 
+/**
+ * @brief Replace substring of null terminated string
+ *
+ * @param[in]   str     Pointer to string
+ * @param[in]   srch    Character sequence to search for and replace
+ * @param[in]   subst   String to substitute character sequence with, or NULL to erase
+ * @param[in]   max     Maximum number of times to replace search, or 0 for unlimited
+ *
+ * @returns Pointer to newly allocated string with max occurrences of srch replaced, str if nothing changed, or NULL on failure
+ */
+DDS_EXPORT char *
+ddsrt_str_replace(
+    const char *str,
+    const char *srch,
+    const char *subst,
+    size_t max);
+
 #if defined (__cplusplus)
 }
 #endif

--- a/src/ddsrt/include/dds/ddsrt/string.h
+++ b/src/ddsrt/include/dds/ddsrt/string.h
@@ -179,19 +179,21 @@ ddsrt_strerror_r(
 /**
  * @brief Replace substring of null terminated string
  *
- * @param[in]   str     Pointer to string
- * @param[in]   srch    Character sequence to search for and replace
- * @param[in]   subst   String to substitute character sequence with, or NULL to erase
- * @param[in]   max     Maximum number of times to replace search, or 0 for unlimited
+ * @param[in]   str     pointer to string
+ * @param[in]   srch    non-empty string to replace
+ * @param[in]   subst   string to substitute character "srch" with
+ * @param[in]   max     maximum number of times to replace search, or 0 for unlimited
  *
- * @returns Pointer to newly allocated string with max occurrences of srch replaced, str if nothing changed, or NULL on failure
+ * @returns Pointer to newly allocated string with max occurrences of srch replaced, or
+ * NULL on allocation failure or if srch is an empty string.
  */
 DDS_EXPORT char *
 ddsrt_str_replace(
     const char *str,
     const char *srch,
     const char *subst,
-    size_t max);
+    size_t max)
+ddsrt_nonnull_all;
 
 #if defined (__cplusplus)
 }

--- a/src/ddsrt/include/dds/ddsrt/strtol.h
+++ b/src/ddsrt/include/dds/ddsrt/strtol.h
@@ -22,6 +22,19 @@ extern "C" {
 #endif
 
 /**
+ * @brief Convert a character to an integer value
+ *
+ * Translates the numeric value of the provided character. For characters in range
+ * '0' to '9' the returned integer value is 0-9. For the range 'a' to 'z' and 'A'
+ * to 'Z', the numeric return value is 10-36.
+ *
+ * @param[in] chr   The character
+ *
+ * @returns The integer value for the character, or -1 in case @chr cannot be translated to a numeric value
+ */
+DDS_EXPORT int32_t ddsrt_todigit(const int chr);
+
+/**
  * @brief Convert a string to a long long integer.
  *
  * Translate @str to a long long integer considering base, and sign. If @base

--- a/src/ddsrt/src/string.c
+++ b/src/ddsrt/src/string.c
@@ -15,6 +15,7 @@
 #include <string.h>
 
 #include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/misc.h"
 #include "dds/ddsrt/string.h"
 #include "dds/ddsrt/types.h"
 
@@ -182,6 +183,7 @@ ddsrt_str_replace(
     cur = tmp + lsrch;
   if (!(tmp = r = ddsrt_malloc(lstr + cnt * (lsubst - lsrch) + 1)))
     return NULL;
+  DDSRT_WARNING_MSVC_OFF(4996);
   while (cnt--)
   {
     cur = strstr(str, srch);
@@ -193,5 +195,6 @@ ddsrt_str_replace(
     str += offset + lsrch;
   }
   strcpy(tmp, str);
+  DDSRT_WARNING_MSVC_ON(4996);
   return r;
 }

--- a/src/ddsrt/src/string.c
+++ b/src/ddsrt/src/string.c
@@ -16,6 +16,7 @@
 
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/string.h"
+#include "dds/ddsrt/types.h"
 
 int
 ddsrt_strcasecmp(
@@ -161,4 +162,36 @@ ddsrt_strdup(
   assert(str != NULL);
 
   return ddsrt_memdup(str, strlen(str) + 1);
+}
+
+char *
+ddsrt_str_replace(
+    const char *str,
+    const char *srch,
+    const char *subst,
+    size_t max)
+{
+  char *r, *cur = (char *)str, *tmp;
+  size_t lstr, lsrch, lsubst, cnt, offset;
+
+  if (!str || !srch || !subst || !(lsrch = strlen(srch)))
+    return NULL;
+  lstr = strlen(str);
+  lsubst = strlen(subst);
+  for (cnt = 0; (cur < str + lstr) && (tmp = strstr(cur, srch)) && (max == 0 || cnt < max); cnt++)
+    cur = tmp + lsrch;
+  if (!(tmp = r = ddsrt_malloc(lstr + cnt * (lsubst - lsrch) + 1)))
+    return NULL;
+  while (cnt--)
+  {
+    cur = strstr(str, srch);
+    offset = (size_t)(cur - str);
+    strncpy(tmp, str, offset);
+    tmp += offset;
+    strcpy(tmp, subst);
+    tmp += lsubst;
+    str += offset + lsrch;
+  }
+  strcpy(tmp, str);
+  return r;
 }

--- a/src/ddsrt/src/strtol.c
+++ b/src/ddsrt/src/strtol.c
@@ -16,7 +16,7 @@
 
 #include "dds/ddsrt/strtol.h"
 
-static int ddsrt_todigit(const int chr)
+int32_t ddsrt_todigit(const int chr)
 {
   if (chr >= '0' && chr <= '9') {
     return chr - '0';

--- a/src/ddsrt/tests/string.c
+++ b/src/ddsrt/tests/string.c
@@ -69,11 +69,11 @@ CU_Theory((const char *s1, const char *s2, size_t n, eq_t e), ddsrt_strncasecmp,
 }
 
 CU_TheoryDataPoints(ddsrt_str_replace, basic) = {
-  CU_DataPoints(const char *,  "",  "a", "aaa",  "aaa",   "aaa", "aaa",   "a", "aa", NULL,  "a",  "a",    "acaca", "aacaacaa", "aaa"),
-  CU_DataPoints(const char *, "a",   "",   "a",    "a",     "a",  "aa", "aaa",  "a",  "a", NULL,  "b",        "a",       "aa",   "a"),
-  CU_DataPoints(const char *, "b",  "b",   "b",   "bb",    "bb",   "b",   "b",  "b",  "b",  "b", NULL,       "bb",        "b",    ""),
-  CU_DataPoints(size_t,         0,    0,     0,      1,       2,     0,     0,   10,    0,    0,    0,          0,          2,     0),
-  CU_DataPoints(const char *,  "", NULL, "bbb", "bbaa", "bbbba",  "ba",   "a", "bb", NULL, NULL, NULL, "bbcbbcbb",   "bcbcaa",    ""),
+  CU_DataPoints(const char *,  "",  "a", "aaa",  "aaa",   "aaa", "aaa",   "a", "aa",    "acaca", "aacaacaa", "aaa"),
+  CU_DataPoints(const char *, "a",   "",   "a",    "a",     "a",  "aa", "aaa",  "a",        "a",       "aa",   "a"),
+  CU_DataPoints(const char *, "b",  "b",   "b",   "bb",    "bb",   "b",   "b",  "b",       "bb",        "b",    ""),
+  CU_DataPoints(size_t,         0,    0,     0,      1,       2,     0,     0,   10,          0,          2,     0),
+  CU_DataPoints(const char *,  "", NULL, "bbb", "bbaa", "bbbba",  "ba",   "a", "bb", "bbcbbcbb",   "bcbcaa",    ""),
 };
 
 CU_Theory((const char *str, const char *srch, const char *subst, size_t max, const char * exp), ddsrt_str_replace, basic)

--- a/src/ddsrt/tests/string.c
+++ b/src/ddsrt/tests/string.c
@@ -12,6 +12,7 @@
 #include <string.h>
 
 #include "CUnit/Theory.h"
+#include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/string.h"
 
 typedef enum { eq, lt, gt } eq_t;
@@ -65,5 +66,28 @@ CU_Theory((const char *s1, const char *s2, size_t n, eq_t e), ddsrt_strncasecmp,
 {
   int r = ddsrt_strncasecmp(s1, s2, n);
   CU_ASSERT((e == eq && r == 0) || (e == lt && r < 0) || (e == gt && r > 0));
+}
+
+CU_TheoryDataPoints(ddsrt_str_replace, basic) = {
+  CU_DataPoints(const char *,  "",  "a", "aaa",  "aaa",   "aaa", "aaa",   "a", "aa", NULL,  "a",  "a",    "acaca", "aacaacaa", "aaa"),
+  CU_DataPoints(const char *, "a",   "",   "a",    "a",     "a",  "aa", "aaa",  "a",  "a", NULL,  "b",        "a",       "aa",   "a"),
+  CU_DataPoints(const char *, "b",  "b",   "b",   "bb",    "bb",   "b",   "b",  "b",  "b",  "b", NULL,       "bb",        "b",    ""),
+  CU_DataPoints(size_t,         0,    0,     0,      1,       2,     0,     0,   10,    0,    0,    0,          0,          2,     0),
+  CU_DataPoints(const char *,  "", NULL, "bbb", "bbaa", "bbbba",  "ba",   "a", "bb", NULL, NULL, NULL, "bbcbbcbb",   "bcbcaa",    ""),
+};
+
+CU_Theory((const char *str, const char *srch, const char *subst, size_t max, const char * exp), ddsrt_str_replace, basic)
+{
+  char * r = ddsrt_str_replace(str, srch, subst, max);
+  if (exp != NULL)
+  {
+    CU_ASSERT_FATAL(r != NULL);
+    CU_ASSERT(strcmp(r, exp) == 0);
+    ddsrt_free(r);
+  }
+  else
+  {
+    CU_ASSERT_FATAL(r == NULL);
+  }
 }
 


### PR DESCRIPTION
The implementation for the DDS Security Access Control plugin (my next PR) requires two additional string functions. This PR adds the ddsrt_str_replace function (including tests) and exports the existing function ddsrt_todigit.