### PR TITLE
Define NOMINMAX to suppress windows.h min/max macros

### DIFF
--- a/src/ddsrt/include/dds/ddsrt/types/windows.h
+++ b/src/ddsrt/include/dds/ddsrt/types/windows.h
@@ -16,6 +16,10 @@
 #define WIN32_LEAN_AND_MEAN
 #endif
 
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+
 #include <windows.h>
 #include <VersionHelpers.h>
 #include <stdint.h>


### PR DESCRIPTION
Signed-off-by: Dan Rose <dan@digilabs.io>
