### PR TITLE
Match getopt signature to posix standard

### DIFF
--- a/src/ddsrt/include/getopt.h.in
+++ b/src/ddsrt/include/getopt.h.in
@@ -19,6 +19,6 @@ DDS_EXPORT extern int optind;
 DDS_EXPORT extern int optopt;
 DDS_EXPORT extern char *optarg;
 
-DDS_EXPORT int getopt(int argc, char **argv, const char *opts);
+DDS_EXPORT int getopt(int argc, char *const argv[], const char *opts);
 
 #endif /* GETOPT_H */

--- a/src/ddsrt/src/getopt.c
+++ b/src/ddsrt/src/getopt.c
@@ -37,7 +37,7 @@ char *optarg;
 int
 getopt(
     int argc,
-    char **argv,
+    char *const argv[],
     const char *opts)
 {
     static int sp = 1;


### PR DESCRIPTION
This came up when I was trying to cross-compile on Mac:
```
colcon build --cmake-args "-DCMAKE_TOOLCHAIN_FILE=$PWD/cmake/Win.cmake" --packages-select cyclonedds --cmake-clean-cache --cmake-args " -DBUILD_TESTING=OFF"

Starting >>> cyclonedds
--- stderr: cyclonedds                              
In file included from /opt/ros/master/src/eclipse-cyclonedds/cyclonedds/src/tools/pubsub/pubsub.c:33:
In file included from /opt/ros/master/src/eclipse-cyclonedds/cyclonedds/src/tools/pubsub/common.h:15:
In file included from /opt/ros/master/src/eclipse-cyclonedds/cyclonedds/src/core/ddsc/include/dds/dds.h:38:
In file included from /opt/ros/master/src/eclipse-cyclonedds/cyclonedds/src/ddsrt/include/dds/ddsrt/time.h:26:
In file included from /opt/ros/master/src/eclipse-cyclonedds/cyclonedds/src/ddsrt/include/dds/ddsrt/types.h:23:
In file included from /opt/ros/master/src/eclipse-cyclonedds/cyclonedds/src/ddsrt/include/dds/ddsrt/types/posix.h:20:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/include/unistd.h:509:6: error: conflicting types for 'getopt'
int      getopt(int, char * const [], const char *) __DARWIN_ALIAS(getopt);
         ^
/opt/ros/master/build/cyclonedds/src/ddsrt/include/getopt.h:22:16: note: previous declaration is here
DDS_EXPORT int getopt(int argc, char **argv, const char *opts);
               ^
1 error generated.
gmake[2]: *** [src/tools/pubsub/CMakeFiles/pubsub.dir/build.make:63: src/tools/pubsub/CMakeFiles/pubsub.dir/pubsub.c.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:625: src/tools/pubsub/CMakeFiles/pubsub.dir/all] Error 2
gmake: *** [Makefile:152: all] Error 2
---
Failed   <<< cyclonedds	[ Exited with code 2 ]

Summary: 0 packages finished [17.3s]
  1 package failed: cyclonedds
  1 package had stderr output: cyclonedds
```
Signed-off-by: Dan Rose <dan@digilabs.io>
