### PR TITLE
Lifespan QoS implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -142,33 +142,33 @@ windows_vs2017: &windows_vs2017
 jobs:
   include:
     - <<: *linux_gcc8
-      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Debug, SSL=YES, GENERATOR="Unix Makefiles", COVERITY_SCAN=true ]
+      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Debug, SSL=YES, LIFESPAN=YES, GENERATOR="Unix Makefiles", COVERITY_SCAN=true ]
       if: type = cron
     - <<: *linux_gcc8
-      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Debug, SSL=YES, GENERATOR="Unix Makefiles" ]
+      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Debug, SSL=YES, LIFESPAN=YES, GENERATOR="Unix Makefiles" ]
     - <<: *linux_gcc8
-      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, SSL=YES, GENERATOR="Unix Makefiles" ]
+      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, SSL=YES, LIFESPAN=YES, GENERATOR="Unix Makefiles" ]
     - <<: *linux_gcc8
-      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Debug, SSL=NO, GENERATOR="Unix Makefiles" ]
+      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Debug, SSL=NO, LIFESPAN=NO, GENERATOR="Unix Makefiles" ]
     - <<: *linux_clang
-      env: [ ARCH=x86_64, ASAN=address, BUILD_TYPE=Debug, SSL=YES, GENERATOR="Unix Makefiles" ]
+      env: [ ARCH=x86_64, ASAN=address, BUILD_TYPE=Debug, SSL=YES, LIFESPAN=YES, GENERATOR="Unix Makefiles" ]
     - <<: *linux_clang
-      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, SSL=YES, GENERATOR="Unix Makefiles" ]
+      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, SSL=YES, LIFESPAN=YES, GENERATOR="Unix Makefiles" ]
     - <<: *osx_xcode9
-      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, SSL=NO, GENERATOR="Unix Makefiles" ]
+      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, SSL=NO, LIFESPAN=YES, GENERATOR="Unix Makefiles" ]
       if: type = cron
     - <<: *osx_xcode
-      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, SSL=NO, GENERATOR="Unix Makefiles", MACOSX_DEPLOYMENT_TARGET=10.12 ]
+      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, SSL=NO, LIFESPAN=YES, GENERATOR="Unix Makefiles", MACOSX_DEPLOYMENT_TARGET=10.12 ]
     - <<: *osx_xcode
-      env: [ ARCH=x86_64, ASAN=address, BUILD_TYPE=Debug, SSL=YES, GENERATOR="Unix Makefiles" ]
+      env: [ ARCH=x86_64, ASAN=address, BUILD_TYPE=Debug, SSL=YES, LIFESPAN=YES, GENERATOR="Unix Makefiles" ]
     - <<: *osx_xcode
-      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, SSL=YES, GENERATOR="Unix Makefiles" ]
+      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, SSL=YES, LIFESPAN=YES, GENERATOR="Unix Makefiles" ]
     - <<: *windows_vs2017
-      env: [ ARCH=x86, ASAN=none, BUILD_TYPE=Debug, SSL=YES, GENERATOR="Visual Studio 15 2017" ]
+      env: [ ARCH=x86, ASAN=none, BUILD_TYPE=Debug, SSL=YES, LIFESPAN=YES, GENERATOR="Visual Studio 15 2017" ]
     - <<: *windows_vs2017
-      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Debug, SSL=YES, GENERATOR="Visual Studio 15 2017 Win64" ]
+      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Debug, SSL=YES, LIFESPAN=YES, GENERATOR="Visual Studio 15 2017 Win64" ]
     - <<: *windows_vs2017
-      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, SSL=YES, GENERATOR="Visual Studio 15 2017 Win64" ]
+      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, SSL=YES, LIFESPAN=YES, GENERATOR="Visual Studio 15 2017 Win64" ]
 
 before_script:
   - conan profile new default --detect
@@ -199,6 +199,7 @@ script:
           -DCMAKE_INSTALL_PREFIX=${INSTALLPREFIX}
           -DUSE_SANITIZER=${ASAN}
           -DENABLE_SSL=${SSL}
+          -DENABLE_LIFESPAN=${LIFESPAN}
           -DBUILD_TESTING=on
           -DWERROR=on
           -G "${GENERATOR}" ..

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -27,6 +27,11 @@ endif()
 
 add_definitions(-DDDSI_INCLUDE_NETWORK_PARTITIONS -DDDSI_INCLUDE_SSM)
 
+option(ENABLE_LIFESPAN "Enable Lifespan QoS support" ON)
+if(ENABLE_LIFESPAN)
+  add_definitions(-DDDSI_INCLUDE_LIFESPAN)
+endif()
+
 # OpenSSL is huge, raising the RSS by 1MB or so, and moreover find_package(OpenSSL) causes
 # trouble on some older CMake versions that otherwise work fine, so provide an option to avoid
 # all OpenSSL related things.

--- a/src/core/ddsc/src/dds__rhc_default.h
+++ b/src/core/ddsc/src/dds__rhc_default.h
@@ -20,9 +20,12 @@ struct dds_rhc;
 struct dds_reader;
 struct ddsi_sertopic;
 struct q_globals;
+struct dds_rhc_default;
+struct rhc_sample;
 
 DDS_EXPORT struct dds_rhc *dds_rhc_default_new_xchecks (dds_reader *reader, struct q_globals *gv, const struct ddsi_sertopic *topic, bool xchecks);
 DDS_EXPORT struct dds_rhc *dds_rhc_default_new (struct dds_reader *reader, const struct ddsi_sertopic *topic);
+DDS_EXPORT nn_mtime_t dds_rhc_default_sample_expired_cb(void *hc, nn_mtime_t tnow);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsc/src/dds_whc_builtintopic.c
+++ b/src/core/ddsc/src/dds_whc_builtintopic.c
@@ -143,11 +143,12 @@ static void bwhc_get_state (const struct whc *whc, struct whc_state *st)
   st->unacked_bytes = 0;
 }
 
-static int bwhc_insert (struct whc *whc, seqno_t max_drop_seq, seqno_t seq, struct nn_plist *plist, struct ddsi_serdata *serdata, struct ddsi_tkmap_instance *tk)
+static int bwhc_insert (struct whc *whc, seqno_t max_drop_seq, seqno_t seq, nn_mtime_t exp, struct nn_plist *plist, struct ddsi_serdata *serdata, struct ddsi_tkmap_instance *tk)
 {
   (void)whc;
   (void)max_drop_seq;
   (void)seq;
+  (void)exp;
   (void)serdata;
   (void)tk;
   if (plist)

--- a/src/core/ddsc/src/dds_write.c
+++ b/src/core/ddsc/src/dds_write.c
@@ -99,7 +99,7 @@ static dds_return_t deliver_locally (struct writer *wr, struct ddsi_serdata *pay
     {
       dds_duration_t max_block_ms = wr->xqos->reliability.max_blocking_time;
       struct ddsi_writer_info pwr_info;
-      ddsi_make_writer_info (&pwr_info, &wr->e, wr->xqos);
+      ddsi_make_writer_info (&pwr_info, &wr->e, wr->xqos, payload->statusinfo);
       for (uint32_t i = 0; rdary[i]; i++) {
         DDS_CTRACE (&wr->e.gv->logconfig, "reader "PGUIDFMT"\n", PGUID (rdary[i]->e.guid));
         if ((ret = try_store (rdary[i]->rhc, &pwr_info, payload, tk, &max_block_ms)) != DDS_RETCODE_OK)
@@ -124,7 +124,7 @@ static dds_return_t deliver_locally (struct writer *wr, struct ddsi_serdata *pay
     const struct entity_index *gh = wr->e.gv->entity_index;
     dds_duration_t max_block_ms = wr->xqos->reliability.max_blocking_time;
     ddsrt_mutex_unlock (&wr->rdary.rdary_lock);
-    ddsi_make_writer_info (&wrinfo, &wr->e, wr->xqos);
+    ddsi_make_writer_info (&wrinfo, &wr->e, wr->xqos, payload->statusinfo);
     ddsrt_mutex_lock (&wr->e.lock);
     for (m = ddsrt_avl_iter_first (&wr_local_readers_treedef, &wr->local_readers, &it); m != NULL; m = ddsrt_avl_iter_next (&it))
     {

--- a/src/core/ddsc/src/dds_writer.c
+++ b/src/core/ddsc/src/dds_writer.c
@@ -218,9 +218,23 @@ static dds_return_t dds_writer_delete (dds_entity *e)
   return DDS_RETCODE_OK;
 }
 
+static dds_return_t validate_writer_qos (const dds_qos_t *wqos)
+{
+#ifndef DDSI_INCLUDE_LIFESPAN
+  if (wqos != NULL && (wqos->present & QP_LIFESPAN) && wqos->lifespan.duration != DDS_INFINITY)
+    return DDS_RETCODE_BAD_PARAMETER;
+#else
+  DDSRT_UNUSED_ARG (wqos);
+#endif
+  return DDS_RETCODE_OK;
+}
+
 static dds_return_t dds_writer_qos_set (dds_entity *e, const dds_qos_t *qos, bool enabled)
 {
   /* note: e->m_qos is still the old one to allow for failure here */
+  dds_return_t ret;
+  if ((ret = validate_writer_qos(qos)) != DDS_RETCODE_OK)
+    return ret;
   if (enabled)
   {
     struct writer *wr;
@@ -320,7 +334,8 @@ dds_entity_t dds_create_writer (dds_entity_t participant_or_publisher, dds_entit
     nn_xqos_mergein_missing (wqos, tp->m_entity.m_qos, ~(uint64_t)0);
   nn_xqos_mergein_missing (wqos, &pub->m_entity.m_domain->gv.default_xqos_wr, ~(uint64_t)0);
 
-  if ((rc = nn_xqos_valid (&pub->m_entity.m_domain->gv.logconfig, wqos)) < 0)
+  if ((rc = nn_xqos_valid (&pub->m_entity.m_domain->gv.logconfig, wqos)) < 0 ||
+      (rc = validate_writer_qos(wqos)) != DDS_RETCODE_OK)
   {
     dds_delete_qos(wqos);
     goto err_bad_qos;

--- a/src/core/ddsc/tests/CMakeLists.txt
+++ b/src/core/ddsc/tests/CMakeLists.txt
@@ -55,6 +55,10 @@ set(ddsc_test_sources
     "write_various_types.c"
     "writer.c")
 
+if(ENABLE_LIFESPAN)
+  list(APPEND ddsc_test_sources "lifespan.c")
+endif()
+
 add_cunit_executable(cunit_ddsc ${ddsc_test_sources})
 target_include_directories(
   cunit_ddsc PRIVATE

--- a/src/core/ddsc/tests/lifespan.c
+++ b/src/core/ddsc/tests/lifespan.c
@@ -1,0 +1,164 @@
+/*
+ * Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include <assert.h>
+#include <limits.h>
+
+#include "dds/dds.h"
+#include "CUnit/Theory.h"
+#include "Space.h"
+
+#include "dds/ddsrt/process.h"
+#include "dds/ddsrt/threads.h"
+#include "dds/ddsi/ddsi_entity_index.h"
+#include "dds/ddsi/q_entity.h"
+#include "dds/ddsi/q_whc.h"
+#include "dds__entity.h"
+
+static dds_entity_t g_participant = 0;
+static dds_entity_t g_subscriber  = 0;
+static dds_entity_t g_publisher   = 0;
+static dds_entity_t g_topic       = 0;
+static dds_entity_t g_reader      = 0;
+static dds_entity_t g_writer      = 0;
+static dds_entity_t g_waitset     = 0;
+static dds_entity_t g_rcond       = 0;
+static dds_entity_t g_qcond       = 0;
+
+static char*
+create_topic_name(const char *prefix, char *name, size_t size)
+{
+    /* Get semi random g_topic name. */
+    ddsrt_pid_t pid = ddsrt_getpid();
+    ddsrt_tid_t tid = ddsrt_gettid();
+    (void) snprintf(name, size, "%s_pid%"PRIdPID"_tid%"PRIdTID"", prefix, pid, tid);
+    return name;
+}
+
+static void lifespan_init(void)
+{
+  dds_attach_t triggered;
+  dds_return_t ret;
+  char name[100];
+  dds_qos_t *qos;
+
+  qos = dds_create_qos();
+  CU_ASSERT_PTR_NOT_NULL_FATAL(qos);
+
+  g_participant = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL, NULL);
+  CU_ASSERT_FATAL(g_participant > 0);
+
+  g_subscriber = dds_create_subscriber(g_participant, NULL, NULL);
+  CU_ASSERT_FATAL(g_subscriber > 0);
+
+  g_publisher = dds_create_publisher(g_participant, NULL, NULL);
+  CU_ASSERT_FATAL(g_publisher > 0);
+
+  g_waitset = dds_create_waitset(g_participant);
+  CU_ASSERT_FATAL(g_waitset > 0);
+
+  g_topic = dds_create_topic(g_participant, &Space_Type1_desc, create_topic_name("ddsc_qos_lifespan_test", name, sizeof name), NULL, NULL);
+  CU_ASSERT_FATAL(g_topic > 0);
+
+  dds_qset_history(qos, DDS_HISTORY_KEEP_ALL, DDS_LENGTH_UNLIMITED);
+  dds_qset_durability(qos, DDS_DURABILITY_TRANSIENT_LOCAL);
+  dds_qset_reliability(qos, DDS_RELIABILITY_RELIABLE, DDS_INFINITY);
+  g_writer = dds_create_writer(g_publisher, g_topic, qos, NULL);
+  CU_ASSERT_FATAL(g_writer > 0);
+  g_reader = dds_create_reader(g_subscriber, g_topic, qos, NULL);
+  CU_ASSERT_FATAL(g_reader > 0);
+
+  /* Sync g_reader to g_writer. */
+  ret = dds_set_status_mask(g_reader, DDS_SUBSCRIPTION_MATCHED_STATUS);
+  CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+  ret = dds_waitset_attach(g_waitset, g_reader, g_reader);
+  CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+  ret = dds_waitset_wait(g_waitset, &triggered, 1, DDS_SECS(1));
+  CU_ASSERT_EQUAL_FATAL(ret, 1);
+  CU_ASSERT_EQUAL_FATAL(g_reader, (dds_entity_t)(intptr_t)triggered);
+  ret = dds_waitset_detach(g_waitset, g_reader);
+  CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+
+  /* Sync g_writer to g_reader. */
+  ret = dds_set_status_mask(g_writer, DDS_PUBLICATION_MATCHED_STATUS);
+  CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+  ret = dds_waitset_attach(g_waitset, g_writer, g_writer);
+  CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+  ret = dds_waitset_wait(g_waitset, &triggered, 1, DDS_SECS(1));
+  CU_ASSERT_EQUAL_FATAL(ret, 1);
+  CU_ASSERT_EQUAL_FATAL(g_writer, (dds_entity_t)(intptr_t)triggered);
+  ret = dds_waitset_detach(g_waitset, g_writer);
+  CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+
+  dds_delete_qos(qos);
+}
+
+static void lifespan_fini(void)
+{
+  dds_delete(g_rcond);
+  dds_delete(g_qcond);
+  dds_delete(g_reader);
+  dds_delete(g_writer);
+  dds_delete(g_subscriber);
+  dds_delete(g_publisher);
+  dds_delete(g_waitset);
+  dds_delete(g_topic);
+  dds_delete(g_participant);
+}
+
+static void check_whc_state(dds_entity_t writer, seqno_t exp_min, seqno_t exp_max)
+{
+  struct dds_entity *wr_entity;
+  struct writer *wr;
+  struct whc_state whcst;
+  CU_ASSERT_EQUAL_FATAL(dds_entity_pin(writer, &wr_entity), 0);
+  thread_state_awake(lookup_thread_state(), &wr_entity->m_domain->gv);
+  wr = entidx_lookup_writer_guid(wr_entity->m_domain->gv.entity_index, &wr_entity->m_guid);
+  CU_ASSERT_FATAL(wr != NULL);
+  assert(wr != NULL); /* for Clang's static analyzer */
+  whc_get_state(wr->whc, &whcst);
+  thread_state_asleep(lookup_thread_state());
+  dds_entity_unpin(wr_entity);
+
+  CU_ASSERT_EQUAL_FATAL (whcst.min_seq, exp_min);
+  CU_ASSERT_EQUAL_FATAL (whcst.max_seq, exp_max);
+}
+
+CU_Test(ddsc_lifespan, basic, .init=lifespan_init, .fini=lifespan_fini)
+{
+  Space_Type1 sample = { 0, 0, 0 };
+  dds_return_t ret;
+  dds_duration_t exp = DDS_MSECS(500);
+  dds_qos_t *qos;
+
+  qos = dds_create_qos();
+  CU_ASSERT_PTR_NOT_NULL_FATAL(qos);
+
+  /* Write with default qos: lifespan inifinite */
+  ret = dds_write (g_writer, &sample);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
+  check_whc_state(g_writer, 1, 1);
+
+  dds_sleepfor (2 * exp);
+  check_whc_state(g_writer, 1, 1);
+
+  dds_qset_lifespan(qos, exp);
+  ret = dds_set_qos(g_writer, qos);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
+  ret = dds_write (g_writer, &sample);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
+  check_whc_state(g_writer, 2, 2);
+
+  dds_sleepfor (2 * exp);
+  check_whc_state(g_writer, -1, -1);
+
+  dds_delete_qos(qos);
+}

--- a/src/core/ddsi/CMakeLists.txt
+++ b/src/core/ddsi/CMakeLists.txt
@@ -59,6 +59,9 @@ PREPEND(srcs_ddsi "${CMAKE_CURRENT_LIST_DIR}/src"
     q_freelist.c
     sysdeps.c
 )
+if(ENABLE_LIFESPAN)
+  list(APPEND srcs_ddsi "${CMAKE_CURRENT_LIST_DIR}/src/ddsi_lifespan.c")
+endif()
 
 # The includes should reside close to the code. As long as that's not the case,
 # pull them in from this CMakeLists.txt.
@@ -119,6 +122,9 @@ PREPEND(hdrs_private_ddsi "${CMAKE_CURRENT_LIST_DIR}/include/dds/ddsi"
     q_xqos.h
     sysdeps.h
 )
+if(ENABLE_LIFESPAN)
+  list(APPEND hdrs_private_ddsi "${CMAKE_CURRENT_LIST_DIR}/include/dds/ddsi/ddsi_lifespan.h")
+endif()
 
 target_sources(ddsc
   PRIVATE ${srcs_ddsi} ${hdrs_private_ddsi})

--- a/src/core/ddsi/include/dds/ddsi/ddsi_lifespan.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_lifespan.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright(c) 2006 to 2019 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#ifndef DDSI_LIFESPAN_H
+#define DDSI_LIFESPAN_H
+
+#include "dds/ddsrt/fibheap.h"
+#include "dds/ddsi/q_time.h"
+#include "dds/ddsi/q_globals.h"
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+typedef nn_mtime_t (*sample_expired_cb_t)(void *hc, nn_mtime_t tnow);
+
+struct lifespan_adm {
+  ddsrt_fibheap_t ls_exp_heap;              /* heap for sample expiration (lifespan) */
+  struct xevent *evt;                       /* xevent that triggers for sample with earliest expiration */
+  sample_expired_cb_t sample_expired_cb;    /* callback for expired sample; this cb can use lifespan_next_expired_locked to get next expired sample */
+  size_t fh_offset;                         /* offset of lifespan_adm element in whc or rhc */
+  size_t fhn_offset;                        /* offset of lifespan_fhnode element in whc or rhc node (sample) */
+};
+
+struct lifespan_fhnode {
+  ddsrt_fibheap_node_t heapnode;
+  nn_mtime_t t_expire;
+};
+
+DDS_EXPORT void lifespan_init (const struct q_globals *gv, struct lifespan_adm *lifespan_adm, size_t fh_offset, size_t fh_node_offset, sample_expired_cb_t sample_expired_cb);
+DDS_EXPORT void lifespan_fini (const struct lifespan_adm *lifespan_adm);
+DDS_EXPORT nn_mtime_t lifespan_next_expired_locked (const struct lifespan_adm *lifespan_adm, nn_mtime_t tnow, void **sample);
+DDS_EXPORT void lifespan_register_sample_real (struct lifespan_adm *lifespan_adm, struct lifespan_fhnode *node);
+DDS_EXPORT void lifespan_unregister_sample_real (struct lifespan_adm *lifespan_adm, struct lifespan_fhnode *node);
+
+inline void lifespan_register_sample_locked (struct lifespan_adm *lifespan_adm, struct lifespan_fhnode *node)
+{
+  if (node->t_expire.v != T_NEVER)
+    lifespan_register_sample_real (lifespan_adm, node);
+}
+
+inline void lifespan_unregister_sample_locked (struct lifespan_adm *lifespan_adm, struct lifespan_fhnode *node)
+{
+  if (node->t_expire.v != T_NEVER)
+    lifespan_unregister_sample_real (lifespan_adm, node);
+}
+
+#if defined (__cplusplus)
+}
+#endif
+
+#endif /* DDSI_LIFESPAN_H */
+

--- a/src/core/ddsi/include/dds/ddsi/ddsi_rhc.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_rhc.h
@@ -21,6 +21,7 @@
 /* DDS_EXPORT inline i.c.w. __attributes__((visibility...)) and some compilers: */
 #include "dds/ddsrt/attributes.h"
 #include "dds/ddsi/ddsi_guid.h"
+#include "dds/ddsi/q_time.h"
 
 #if defined (__cplusplus)
 extern "C" {
@@ -38,6 +39,9 @@ struct ddsi_writer_info
   bool auto_dispose;
   int32_t ownership_strength;
   uint64_t iid;
+#ifdef DDSI_INCLUDE_LIFESPAN
+  nn_mtime_t lifespan_exp;
+#endif
 };
 
 typedef void (*ddsi_rhc_free_t) (struct ddsi_rhc *rhc);

--- a/src/core/ddsi/include/dds/ddsi/q_entity.h
+++ b/src/core/ddsi/include/dds/ddsi/q_entity.h
@@ -696,7 +696,7 @@ void rebuild_or_clear_writer_addrsets(struct q_globals *gv, int rebuild);
 void local_reader_ary_setfastpath_ok (struct local_reader_ary *x, bool fastpath_ok);
 
 struct ddsi_writer_info;
-DDS_EXPORT void ddsi_make_writer_info(struct ddsi_writer_info *wrinfo, const struct entity_common *e, const struct dds_qos *xqos);
+DDS_EXPORT void ddsi_make_writer_info(struct ddsi_writer_info *wrinfo, const struct entity_common *e, const struct dds_qos *xqos, uint32_t statusinfo);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsi/include/dds/ddsi/q_time.h
+++ b/src/core/ddsi/include/dds/ddsi/q_time.h
@@ -46,6 +46,9 @@ typedef struct {
   int64_t v;
 } nn_etime_t;
 
+#define NN_MTIME_NEVER ((nn_mtime_t) { T_NEVER })
+#define NN_WCTIME_NEVER ((nn_wctime_t) { T_NEVER })
+#define NN_ETIME_NEVER ((nn_etime_t) { T_NEVER })
 #define NN_WCTIME_INVALID ((nn_wctime_t) { INT64_MIN })
 
 int valid_ddsi_timestamp (ddsi_time_t t);

--- a/src/core/ddsi/include/dds/ddsi/q_whc.h
+++ b/src/core/ddsi/include/dds/ddsi/q_whc.h
@@ -13,6 +13,7 @@
 #define Q_WHC_H
 
 #include <stddef.h>
+#include "dds/ddsi/q_time.h"
 
 #if defined (__cplusplus)
 extern "C" {
@@ -72,7 +73,7 @@ typedef void (*whc_free_t)(struct whc *whc);
    reliable readers that have not acknowledged all data */
 /* max_drop_seq must go soon, it's way too ugly. */
 /* plist may be NULL or ddsrt_malloc'd, WHC takes ownership of plist */
-typedef int (*whc_insert_t)(struct whc *whc, seqno_t max_drop_seq, seqno_t seq, struct nn_plist *plist, struct ddsi_serdata *serdata, struct ddsi_tkmap_instance *tk);
+typedef int (*whc_insert_t)(struct whc *whc, seqno_t max_drop_seq, seqno_t seq, nn_mtime_t exp, struct nn_plist *plist, struct ddsi_serdata *serdata, struct ddsi_tkmap_instance *tk);
 typedef uint32_t (*whc_downgrade_to_volatile_t)(struct whc *whc, struct whc_state *st);
 typedef uint32_t (*whc_remove_acked_messages_t)(struct whc *whc, seqno_t max_drop_seq, struct whc_state *whcst, struct whc_node **deferred_free_list);
 typedef void (*whc_free_deferred_free_list_t)(struct whc *whc, struct whc_node *deferred_free_list);
@@ -120,8 +121,8 @@ inline bool whc_sample_iter_borrow_next (struct whc_sample_iter *it, struct whc_
 inline void whc_free (struct whc *whc) {
   whc->ops->free (whc);
 }
-inline int whc_insert (struct whc *whc, seqno_t max_drop_seq, seqno_t seq, struct nn_plist *plist, struct ddsi_serdata *serdata, struct ddsi_tkmap_instance *tk) {
-  return whc->ops->insert (whc, max_drop_seq, seq, plist, serdata, tk);
+inline int whc_insert (struct whc *whc, seqno_t max_drop_seq, seqno_t seq, nn_mtime_t exp, struct nn_plist *plist, struct ddsi_serdata *serdata, struct ddsi_tkmap_instance *tk) {
+  return whc->ops->insert (whc, max_drop_seq, seq, exp, plist, serdata, tk);
 }
 inline unsigned whc_downgrade_to_volatile (struct whc *whc, struct whc_state *st) {
   return whc->ops->downgrade_to_volatile (whc, st);

--- a/src/core/ddsi/include/dds/ddsi/q_xevent.h
+++ b/src/core/ddsi/include/dds/ddsi/q_xevent.h
@@ -12,6 +12,9 @@
 #ifndef NN_XEVENT_H
 #define NN_XEVENT_H
 
+#include "dds/ddsrt/retcode.h"
+#include "dds/ddsi/ddsi_guid.h"
+
 #if defined (__cplusplus)
 extern "C" {
 #endif
@@ -30,6 +33,7 @@ struct xevent;
 struct xeventq;
 struct proxy_writer;
 struct proxy_reader;
+struct nn_xmsg;
 
 struct xeventq *xeventq_new
 (
@@ -55,6 +59,7 @@ DDS_EXPORT int qxev_msg_rexmit_wrlock_held (struct xeventq *evq, struct nn_xmsg 
 
 /* All of the following lock EVQ for the duration of the operation */
 DDS_EXPORT void delete_xevent (struct xevent *ev);
+DDS_EXPORT void delete_xevent_callback (struct xevent *ev);
 DDS_EXPORT int resched_xevent_if_earlier (struct xevent *ev, nn_mtime_t tsched);
 
 DDS_EXPORT struct xevent *qxev_heartbeat (struct xeventq *evq, nn_mtime_t tsched, const ddsi_guid_t *wr_guid);

--- a/src/core/ddsi/src/ddsi_lifespan.c
+++ b/src/core/ddsi/src/ddsi_lifespan.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright(c) 2006 to 2019 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include <stddef.h>
+#include <stdlib.h>
+#include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/fibheap.h"
+#include "dds/ddsi/ddsi_lifespan.h"
+#include "dds/ddsi/q_time.h"
+#include "dds/ddsi/q_xevent.h"
+
+static int compare_lifespan_texp (const void *va, const void *vb)
+{
+  const struct lifespan_fhnode *a = va;
+  const struct lifespan_fhnode *b = vb;
+  return (a->t_expire.v == b->t_expire.v) ? 0 : (a->t_expire.v < b->t_expire.v) ? -1 : 1;
+}
+
+const ddsrt_fibheap_def_t lifespan_fhdef = DDSRT_FIBHEAPDEF_INITIALIZER(offsetof (struct lifespan_fhnode, heapnode), compare_lifespan_texp);
+
+static void lifespan_rhc_node_exp (struct xevent *xev, void *varg, nn_mtime_t tnow)
+{
+  struct lifespan_adm * const lifespan_adm = varg;
+  nn_mtime_t next_valid = lifespan_adm->sample_expired_cb((char *)lifespan_adm - lifespan_adm->fh_offset, tnow);
+  resched_xevent_if_earlier (xev, next_valid);
+}
+
+
+/* Gets the sample from the fibheap in lifespan admin that was expired first. If no more
+ * expired samples exist in the fibheap, the expiry time (nn_mtime_t) for the next sample to
+ * expire is returned. If the fibheap contains no more samples, NN_MTIME_NEVER is returned */
+nn_mtime_t lifespan_next_expired_locked (const struct lifespan_adm *lifespan_adm, nn_mtime_t tnow, void **sample)
+{
+  struct lifespan_fhnode *node;
+  if ((node = ddsrt_fibheap_min(&lifespan_fhdef, &lifespan_adm->ls_exp_heap)) != NULL && node->t_expire.v <= tnow.v)
+  {
+    *sample = (char *)node - lifespan_adm->fhn_offset;
+    return (nn_mtime_t) { 0 };
+  }
+  *sample = NULL;
+  return (node != NULL) ? node->t_expire : NN_MTIME_NEVER;
+}
+
+void lifespan_init (const struct q_globals *gv, struct lifespan_adm *lifespan_adm, size_t fh_offset, size_t fh_node_offset, sample_expired_cb_t sample_expired_cb)
+{
+  ddsrt_fibheap_init (&lifespan_fhdef, &lifespan_adm->ls_exp_heap);
+  lifespan_adm->evt = qxev_callback (gv->xevents, NN_MTIME_NEVER, lifespan_rhc_node_exp, lifespan_adm);
+  lifespan_adm->sample_expired_cb = sample_expired_cb;
+  lifespan_adm->fh_offset = fh_offset;
+  lifespan_adm->fhn_offset = fh_node_offset;
+}
+
+void lifespan_fini (const struct lifespan_adm *lifespan_adm)
+{
+  assert (ddsrt_fibheap_min (&lifespan_fhdef, &lifespan_adm->ls_exp_heap) == NULL);
+  delete_xevent_callback (lifespan_adm->evt);
+}
+
+extern inline void lifespan_register_sample_locked (struct lifespan_adm *lifespan_adm, struct lifespan_fhnode *node);
+
+void lifespan_register_sample_real (struct lifespan_adm *lifespan_adm, struct lifespan_fhnode *node)
+{
+  ddsrt_fibheap_insert(&lifespan_fhdef, &lifespan_adm->ls_exp_heap, node);
+  resched_xevent_if_earlier (lifespan_adm->evt, node->t_expire);
+}
+
+extern inline void lifespan_unregister_sample_locked (struct lifespan_adm *lifespan_adm, struct lifespan_fhnode *node);
+
+void lifespan_unregister_sample_real (struct lifespan_adm *lifespan_adm, struct lifespan_fhnode *node)
+{
+  /* Updating the scheduled event with the new shortest expiry
+   * is not required, because the event will be rescheduled when
+   * this removed node expires. Only remove the node from the
+   * lifespan heap */
+  ddsrt_fibheap_delete(&lifespan_fhdef, &lifespan_adm->ls_exp_heap, node);
+}

--- a/src/core/ddsi/src/q_ddsi_discovery.c
+++ b/src/core/ddsi/src/q_ddsi_discovery.c
@@ -1245,11 +1245,10 @@ static void handle_SEDP_alive (const struct receiver_state *rst, seqno_t seq, nn
     GVLOGDISC (" known%s", vendor_is_cloud (vendorid) ? "-DS" : "");
     if (vendor_is_cloud (vendorid) && pp->implicitly_created && memcmp(&pp->privileged_pp_guid.prefix, src_guid_prefix, sizeof(pp->privileged_pp_guid.prefix)) != 0)
     {
-      nn_etime_t never = { T_NEVER };
       GVLOGDISC (" "PGUIDFMT" attach-to-DS "PGUIDFMT, PGUID(pp->e.guid), PGUIDPREFIX(*src_guid_prefix), pp->privileged_pp_guid.entityid.u);
       ddsrt_mutex_lock (&pp->e.lock);
       pp->privileged_pp_guid.prefix = *src_guid_prefix;
-      lease_set_expiry(pp->lease, never);
+      lease_set_expiry(pp->lease, NN_ETIME_NEVER);
       ddsrt_mutex_unlock (&pp->e.lock);
     }
     GVLOGDISC ("\n");

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -761,7 +761,7 @@ static void wait_for_receive_threads (struct q_globals *gv)
   }
   if (trigev)
   {
-    delete_xevent (trigev);
+    delete_xevent_callback (trigev);
   }
 }
 

--- a/src/core/ddsi/src/q_receive.c
+++ b/src/core/ddsi/src/q_receive.c
@@ -1950,7 +1950,7 @@ static int deliver_user_data (const struct nn_rsample_info *sampleinfo, const st
   /* FIXME: should it be 0, local wall clock time or INVALID? */
   const nn_wctime_t tstamp = (sampleinfo->timestamp.v != NN_WCTIME_INVALID.v) ? sampleinfo->timestamp : ((nn_wctime_t) {0});
   struct ddsi_writer_info wrinfo;
-  ddsi_make_writer_info (&wrinfo, &pwr->e, pwr->c.xqos);
+  ddsi_make_writer_info (&wrinfo, &pwr->e, pwr->c.xqos, statusinfo);
 
   if (rdguid == NULL)
   {

--- a/src/core/ddsi/src/q_whc.c
+++ b/src/core/ddsi/src/q_whc.c
@@ -21,7 +21,7 @@ extern inline void whc_return_sample (struct whc *whc, struct whc_borrowed_sampl
 extern inline void whc_sample_iter_init (const struct whc *whc, struct whc_sample_iter *it);
 extern inline bool whc_sample_iter_borrow_next (struct whc_sample_iter *it, struct whc_borrowed_sample *sample);
 extern inline void whc_free (struct whc *whc);
-extern int whc_insert (struct whc *whc, seqno_t max_drop_seq, seqno_t seq, struct nn_plist *plist, struct ddsi_serdata *serdata, struct ddsi_tkmap_instance *tk);
+extern int whc_insert (struct whc *whc, seqno_t max_drop_seq, seqno_t seq, nn_mtime_t exp, struct nn_plist *plist, struct ddsi_serdata *serdata, struct ddsi_tkmap_instance *tk);
 extern unsigned whc_downgrade_to_volatile (struct whc *whc, struct whc_state *st);
 extern unsigned whc_remove_acked_messages (struct whc *whc, seqno_t max_drop_seq, struct whc_state *whcst, struct whc_node **deferred_free_list);
 extern void whc_free_deferred_free_list (struct whc *whc, struct whc_node *deferred_free_list);

--- a/src/core/ddsi/src/q_xevent.c
+++ b/src/core/ddsi/src/q_xevent.c
@@ -94,6 +94,7 @@ struct xevent
     struct {
       void (*cb) (struct xevent *ev, void *arg, nn_mtime_t tnow);
       void *arg;
+      bool executing;
     } callback;
   } u;
 };
@@ -232,7 +233,7 @@ static void add_to_non_timed_xmit_list (struct xeventq *evq, struct xevent_nt *e
   if (ev->kind == XEVK_MSG_REXMIT)
     remember_msg (evq, ev);
 
-  ddsrt_cond_signal (&evq->cond);
+  ddsrt_cond_broadcast (&evq->cond);
 }
 
 static struct xevent_nt *getnext_from_non_timed_xmit_list  (struct xeventq *evq)
@@ -316,6 +317,7 @@ void delete_xevent (struct xevent *ev)
 {
   struct xeventq *evq = ev->evq;
   ddsrt_mutex_lock (&evq->lock);
+  assert (ev->kind != XEVK_CALLBACK || ev->u.callback.executing);
   /* Can delete it only once, no matter how we implement it internally */
   assert (ev->tsched.v != TSCHED_DELETE);
   assert (TSCHED_DELETE < ev->tsched.v);
@@ -331,27 +333,44 @@ void delete_xevent (struct xevent *ev)
   }
   /* TSCHED_DELETE is absolute minimum time, so chances are we need to
      wake up the thread.  The superfluous signal is harmless. */
-  ddsrt_cond_signal (&evq->cond);
+  ddsrt_cond_broadcast (&evq->cond);
   ddsrt_mutex_unlock (&evq->lock);
+}
+
+void delete_xevent_callback (struct xevent *ev)
+{
+  struct xeventq *evq = ev->evq;
+  assert (ev->kind == XEVK_CALLBACK);
+  ddsrt_mutex_lock (&evq->lock);
+  if (ev->tsched.v != T_NEVER)
+  {
+    assert (ev->tsched.v != TSCHED_DELETE);
+    ddsrt_fibheap_delete (&evq_xevents_fhdef, &evq->xevents, ev);
+    ev->tsched.v = TSCHED_DELETE;
+  }
+  while (ev->u.callback.executing)
+    ddsrt_cond_wait (&evq->cond, &evq->lock);
+  ddsrt_mutex_unlock (&evq->lock);
+  free_xevent (evq, ev);
 }
 
 int resched_xevent_if_earlier (struct xevent *ev, nn_mtime_t tsched)
 {
   struct xeventq *evq = ev->evq;
   int is_resched;
+  if (tsched.v == T_NEVER)
+    return 0;
   ddsrt_mutex_lock (&evq->lock);
-  assert (tsched.v != TSCHED_DELETE);
   /* If you want to delete it, you to say so by calling the right
      function. Don't want to reschedule an event marked for deletion,
      but with TSCHED_DELETE = MIN_INT64, tsched >= ev->tsched is
      guaranteed to be false. */
-  assert (tsched.v > TSCHED_DELETE);
+  assert (tsched.v != TSCHED_DELETE);
   if (tsched.v >= ev->tsched.v)
     is_resched = 0;
   else
   {
     nn_mtime_t tbefore = earliest_in_xeventq (evq);
-    assert (tsched.v != T_NEVER);
     if (ev->tsched.v != T_NEVER)
     {
       ev->tsched = tsched;
@@ -364,7 +383,7 @@ int resched_xevent_if_earlier (struct xevent *ev, nn_mtime_t tsched)
     }
     is_resched = 1;
     if (tsched.v < tbefore.v)
-      ddsrt_cond_signal (&evq->cond);
+      ddsrt_cond_broadcast (&evq->cond);
   }
   ddsrt_mutex_unlock (&evq->lock);
   return is_resched;
@@ -406,13 +425,7 @@ static nn_mtime_t earliest_in_xeventq (struct xeventq *evq)
 {
   struct xevent *min;
   ASSERT_MUTEX_HELD (&evq->lock);
-  if ((min = ddsrt_fibheap_min (&evq_xevents_fhdef, &evq->xevents)) != NULL)
-    return min->tsched;
-  else
-  {
-    nn_mtime_t r = { T_NEVER };
-    return r;
-  }
+  return ((min = ddsrt_fibheap_min (&evq_xevents_fhdef, &evq->xevents)) != NULL) ? min->tsched : NN_MTIME_NEVER;
 }
 
 static void qxev_insert (struct xevent *ev)
@@ -426,7 +439,7 @@ static void qxev_insert (struct xevent *ev)
     nn_mtime_t tbefore = earliest_in_xeventq (evq);
     ddsrt_fibheap_insert (&evq_xevents_fhdef, &evq->xevents, ev);
     if (ev->tsched.v < tbefore.v)
-      ddsrt_cond_signal (&evq->cond);
+      ddsrt_cond_broadcast (&evq->cond);
   }
 }
 
@@ -502,7 +515,7 @@ void xeventq_stop (struct xeventq *evq)
   assert (evq->ts != NULL);
   ddsrt_mutex_lock (&evq->lock);
   evq->terminate = 1;
-  ddsrt_cond_signal (&evq->cond);
+  ddsrt_cond_broadcast (&evq->cond);
   ddsrt_mutex_unlock (&evq->lock);
   join_thread (evq->ts);
   evq->ts = NULL;
@@ -513,22 +526,7 @@ void xeventq_free (struct xeventq *evq)
   struct xevent *ev;
   assert (evq->ts == NULL);
   while ((ev = ddsrt_fibheap_extract_min (&evq_xevents_fhdef, &evq->xevents)) != NULL)
-  {
-    if (ev->tsched.v == TSCHED_DELETE || ev->kind != XEVK_CALLBACK)
-      free_xevent (evq, ev);
-    else
-    {
-      ev->tsched.v = T_NEVER;
-      ev->u.callback.cb (ev, ev->u.callback.arg, ev->tsched);
-      if (ev->tsched.v != TSCHED_DELETE)
-      {
-        union { void *v; void (*f) (struct xevent *ev, void *arg, nn_mtime_t tnow); } fp;
-        fp.f = ev->u.callback.cb;
-        DDS_CWARNING (&evq->gv->logconfig, "xeventq_free: callback %p did not schedule deletion as required, deleting event anyway\n", fp.v);
-        delete_xevent (ev);
-      }
-    }
-  }
+    free_xevent (evq, ev);
 
   {
     struct nn_xpack *xp = nn_xpack_new (evq->tev_conn, evq->auxiliary_bandwidth_limit, false);
@@ -1137,27 +1135,46 @@ static void handle_xevk_delete_writer (UNUSED_ARG (struct nn_xpack *xp), struct 
 
 static void handle_individual_xevent (struct thread_state1 * const ts1, struct xevent *xev, struct nn_xpack *xp, nn_mtime_t tnow)
 {
-  switch (xev->kind)
+  struct xeventq *xevq = xev->evq;
+  /* We relinquish the lock while processing the event, but require it
+     held for administrative work. */
+  ASSERT_MUTEX_HELD (&xevq->lock);
+  if (xev->kind == XEVK_CALLBACK)
   {
-    case XEVK_HEARTBEAT:
-      handle_xevk_heartbeat (xp, xev, tnow);
-      break;
-    case XEVK_ACKNACK:
-      handle_xevk_acknack (xp, xev, tnow);
-      break;
-    case XEVK_SPDP:
-      handle_xevk_spdp (xp, xev, tnow);
-      break;
-    case XEVK_PMD_UPDATE:
-      handle_xevk_pmd_update (ts1, xp, xev, tnow);
-      break;
-    case XEVK_DELETE_WRITER:
-      handle_xevk_delete_writer (xp, xev, tnow);
-      break;
-    case XEVK_CALLBACK:
-      xev->u.callback.cb (xev, xev->u.callback.arg, tnow);
-      break;
+    xev->u.callback.executing = true;
+    ddsrt_mutex_unlock (&xevq->lock);
+    xev->u.callback.cb (xev, xev->u.callback.arg, tnow);
+    ddsrt_mutex_lock (&xevq->lock);
+    xev->u.callback.executing = false;
+    ddsrt_cond_broadcast (&xevq->cond);
   }
+  else
+  {
+    ddsrt_mutex_unlock (&xevq->lock);
+    switch (xev->kind)
+    {
+      case XEVK_HEARTBEAT:
+        handle_xevk_heartbeat (xp, xev, tnow);
+        break;
+      case XEVK_ACKNACK:
+        handle_xevk_acknack (xp, xev, tnow);
+        break;
+      case XEVK_SPDP:
+        handle_xevk_spdp (xp, xev, tnow);
+        break;
+      case XEVK_PMD_UPDATE:
+        handle_xevk_pmd_update (ts1, xp, xev, tnow);
+        break;
+      case XEVK_DELETE_WRITER:
+        handle_xevk_delete_writer (xp, xev, tnow);
+        break;
+      case XEVK_CALLBACK:
+        assert (0);
+        break;
+    }
+    ddsrt_mutex_lock (&xevq->lock);
+  }
+  ASSERT_MUTEX_HELD (&xevq->lock);
 }
 
 static void handle_individual_xevent_nt (struct xevent_nt *xev, struct nn_xpack *xp)
@@ -1181,20 +1198,8 @@ static void handle_timed_xevent (struct thread_state1 * const ts1, struct xevent
 {
    /* This function handles the individual xevent irrespective of
       whether it is a "timed" or "non-timed" xevent */
-  struct xeventq *xevq = xev->evq;
-
-  /* We relinquish the lock while processing the event, but require it
-     held for administrative work. */
-  ASSERT_MUTEX_HELD (&xevq->lock);
-
-  assert (xev->evq == xevq);
   assert (xev->tsched.v != TSCHED_DELETE);
-
-  ddsrt_mutex_unlock (&xevq->lock);
   handle_individual_xevent (ts1, xev, xp, tnow /* monotonic */);
-  ddsrt_mutex_lock (&xevq->lock);
-
-  ASSERT_MUTEX_HELD (&xevq->lock);
 }
 
 static void handle_nontimed_xevent (struct xevent_nt *xev, struct nn_xpack *xp)
@@ -1517,6 +1522,7 @@ struct xevent *qxev_callback (struct xeventq *evq, nn_mtime_t tsched, void (*cb)
   ev = qxev_common (evq, tsched, XEVK_CALLBACK);
   ev->u.callback.cb = cb;
   ev->u.callback.arg = arg;
+  ev->u.callback.executing = false;
   qxev_insert (ev);
   ddsrt_mutex_unlock (&evq->lock);
   return ev;

--- a/src/mpt/tests/qos/procs/rw.c
+++ b/src/mpt/tests/qos/procs/rw.c
@@ -93,7 +93,11 @@ static void setqos (dds_qos_t *q, size_t i, bool isrd, bool create)
   dds_qset_history (q, (dds_history_kind_t) ((i + 1) % 2), (int32_t) (i + 1));
   dds_qset_resource_limits (q, (int32_t) i + 3, (int32_t) i + 2, (int32_t) i + 1);
   dds_qset_presentation (q, (dds_presentation_access_scope_kind_t) ((psi + 1) % 3), 1, 1);
+#ifdef DDSI_INCLUDE_LIFESPAN
   dds_qset_lifespan (q, INT64_C (23456789012345678) + (int32_t) i);
+#else
+  dds_qset_lifespan (q, DDS_INFINITY);
+#endif
   dds_qset_deadline (q, INT64_C (67890123456789012) + (int32_t) i);
   dds_qset_latency_budget (q, INT64_C (45678901234567890) + (int32_t) i);
   dds_qset_ownership (q, (dds_ownership_kind_t) ((i + 1) % 2));


### PR DESCRIPTION
This PR enables specifying a duration for data to be valid when writing samples. After this duration, samples are dropped from the reader and writer history cache. See section 2.2.3.16 of the DDS specification for more details on this QoS. 

The expiration of samples in the reader history cache is calculated based on the reception timestamp of the sample and uses the monotonic clock. As a result, the current implementation does not rely on clock synchronisation between reader and writer. There may be reasons to change this behavior in future and use the source timestamp instead.