### PR TITLE
Hook-up preprocessor to IDL compiler

### DIFF
--- a/src/ddsrt/include/dds/ddsrt/io.h
+++ b/src/ddsrt/include/dds/ddsrt/io.h
@@ -25,6 +25,15 @@ extern "C" {
  * @brief Write a formatted string to a newly allocated buffer.
  */
 DDS_EXPORT int
+ddsrt_vasprintf(
+  char **strp,
+  const char *fmt,
+  va_list ap);
+
+/**
+ * @brief Write a formatted string to a newly allocated buffer.
+ */
+DDS_EXPORT int
 ddsrt_asprintf(
   char **strp,
   const char *fmt,

--- a/src/ddsrt/include/dds/ddsrt/retcode.h
+++ b/src/ddsrt/include/dds/ddsrt/retcode.h
@@ -77,6 +77,8 @@ typedef int32_t dds_return_t;
 #define DDS_RETCODE_OUT_OF_RANGE        DDS_XRETCODE(9)
 /** Not found */
 #define DDS_RETCODE_NOT_FOUND           DDS_XRETCODE(10)
+/** Syntax error */
+#define DDS_RETCODE_BAD_SYNTAX          DDS_XRETCODE(11)
 /**
  * @}
  */

--- a/src/ddsrt/src/io.c
+++ b/src/ddsrt/src/io.c
@@ -52,6 +52,40 @@ ddsrt_asprintf(
   return ret;
 }
 
+int
+ddsrt_vasprintf(
+  char **strp,
+  const char *fmt,
+  va_list ap)
+{
+  int ret;
+  unsigned int len;
+  char buf[1] = { '\0' };
+  char *str = NULL;
+  va_list ap2;
+
+  assert(strp != NULL);
+  assert(fmt != NULL);
+
+  va_copy(ap2, ap); /* va_list cannot be reused */
+
+  if ((ret = vsnprintf(buf, sizeof(buf), fmt, ap)) >= 0) {
+    len = (unsigned int)ret;
+    if ((str = ddsrt_malloc(len + 1)) == NULL) {
+      ret = -1;
+    } else if ((ret = vsnprintf(str, len + 1, fmt, ap2)) >= 0) {
+      assert(((unsigned int)ret) == len);
+      *strp = str;
+    } else {
+      ddsrt_free(str);
+    }
+  }
+
+  va_end(ap2);
+
+  return ret;
+}
+
 #if defined(_MSC_VER) && (_MSC_VER < 1900)
 int
 snprintf(

--- a/src/tools/idlc/CMakeLists.txt
+++ b/src/tools/idlc/CMakeLists.txt
@@ -52,8 +52,6 @@ elseif(CMAKE_C_COMPILER_ID MATCHES "GNU" OR
     "${idl_y_c}" PROPERTIES COMPILE_FLAGS "${parser_cflags}")
 endif()
 
-set(source_dir "${CMAKE_CURRENT_SOURCE_DIR}/src")
-
 add_library(idlc-lib STATIC
     "src/idl.c"
     "src/tt_create.c"
@@ -69,5 +67,4 @@ target_link_libraries(idlc-lib PUBLIC ddsc)
 target_link_libraries(idlc-lib PUBLIC ddsts)
 
 add_executable(idlc "src/main.c")
-target_link_libraries(idlc PRIVATE idlc-lib)
-
+target_link_libraries(idlc PRIVATE idlc-lib idlpp)

--- a/src/tools/idlc/src/idl.l
+++ b/src/tools/idlc/src/idl.l
@@ -25,14 +25,15 @@
 #include "idl.y.h"
 %}
 
-%x MULTILINE_COMMENT
 %x COMMENT
-%x NO_WS
 %x DIRECTIVE
 %x LINE
 %x PRAGMA
-%x DATA_TYPE
+%x KEYLIST
 %x KEY
+%x NOOP
+%x SPACE
+%x SCOPED_NAME
 
 %option noyywrap
 %option nounistd
@@ -44,6 +45,7 @@
 %option bison-bridge
 %option bison-locations
 %option yylineno
+%option stack
 
 %{
 #define YY_USER_ACTION \
@@ -65,28 +67,71 @@ string_literal            \"([^\n\\\"]|\\.)*\"
 identifier                [a-zA-Z_][a-zA-Z0-9_]*
 
 %%
+  /* yy_push_state and yy_pop_state are reserved for COMMENTs. propably better
+     implemented without stack(?) */
+<*>"/*"               { yymore(); yy_push_state(COMMENT, yyscanner); }
+<COMMENT>[^*\n]       { yymore(); }
+<COMMENT>"*"+[^*/\n]  { yymore(); }
+<COMMENT>[\n]         { yymore(); return '\n'; }
+<COMMENT>"*/"         {           yy_pop_state(yyscanner); }
 
-<INITIAL>^[ \t]*#[ \t]* {
+<*>"//"+[^\n]* {
+    /* FIXME: add support for RTI //@ directives like //@key, which are
+              compiler directives and not idl language constructs */
+  }
+
+<*>[\n] {
+    /* preprocessor pushes input to the lexer, but the preprocessor writes a
+       stream of bytes, not tokens. Storing the entire stream in memory before
+       tokenization is rather inefficient, therefore the write function keeps
+       track of newlines. lines can safely be discarded from the input buffer
+       after tokenization. however, the lexer quits once the buffer is empty.
+       to ensure all input is tokenized, the lexer signals the write function
+       after a line has been tokenized so that the end of the buffer is never
+       reached before the end of the stream */
+    /* preprocessor takes care of line-continuation sequences */
+    switch (YY_START) {
+      case DIRECTIVE:
+      case KEYLIST:
+        yyerror(yylloc, parser, "invalid compiler directive");
+        yyterminate();
+      case KEY:
+        ddsts_pragma_close(parser->context);
+        break;
+      default:
+        break;
+    }
+
+    BEGIN(INITIAL);
+    return '\n';
+  }
+
+<INITIAL>^[ \t]*# {
+    /* compiler directives like #line and #pragma are processed by the lexer
+       as they are not idl language constructs */
     BEGIN(DIRECTIVE);
-    /* do not emit token */
   }
 
-<DIRECTIVE>line {
-    /* #line directives are processed entirely by the scanner as they are
-       compiler directives, not idl language constructs, and the parser is
-       location agnostic */
-    BEGIN(LINE);
-    /* do not emit token */
+<DIRECTIVE>{identifier} {
+    if (strcmp(yytext, "line") == 0) {
+      BEGIN(LINE);
+    } else if (strcmp(yytext, "pragma") == 0) {
+      BEGIN(PRAGMA);
+    } else {
+      /* include directives have been handled by the preprocessor */
+      yyerror(yylloc, parser, "unsupported compiler directive '%s'", yytext);
+      yyterminate();
+    }
   }
 
-<LINE>[ \t]+{decimal_number}([ \t]+{string_literal})?[ \t]* {
+<LINE>{decimal_number}([ \t]+{string_literal})? {
     char *str, *dquot = NULL;
     long long ln;
 
     (void)ddsrt_strtoll(yytext, &dquot, 10, &ln);
     assert(dquot != yytext); /* require at least one digit in input */
     while (*dquot == ' ' || *dquot == '\t') {
-      dquot++; /* ignore whitespace */
+      dquot++; /* ignore white space */
     }
     if (*dquot == '"') {
       char *fn = NULL;
@@ -104,10 +149,12 @@ identifier                [a-zA-Z_][a-zA-Z0-9_]*
       if (fn == NULL) {
         idl_file_t *file;
         if ((file = ddsrt_malloc(sizeof(*file))) == NULL) {
-          yyerror(yylloc, parser, context, yyscanner, "Out of memory");
+          yyerror(yylloc, parser, "memory exhausted");
+          yyterminate();
         } else if ((fn = ddsrt_strndup(str, len)) == NULL) {
           ddsrt_free(file);
-          yyerror(yylloc, parser, context, yyscanner, "Out of memory");
+          yyerror(yylloc, parser, "memory exhausted");
+          yyterminate();
         }
         file->next = parser->files;
         file->name = fn;
@@ -117,140 +164,263 @@ identifier                [a-zA-Z_][a-zA-Z0-9_]*
     }
     yylloc->last_line = yylineno = (int)ln;
     yylloc->last_column = yycolumn = 1;
-    /* do not emit token */
+    BEGIN(SPACE);
   }
 
-<LINE>[^[:space:]] {
-    yyerror(yylloc, parser, context, yyscanner, "Malformed #line directive");
-  }
-
-<DIRECTIVE>pragma([ \t]+keylist)? {
-    /* #pragma directives are processed by the scanner, knowledge of specific
-       directives must only be propagated to the parser if idl language
-       constructs are impacted, as is the case for e.g. #pragma keylist */
-    char *dir;
-
-    BEGIN(PRAGMA);
-    /* ignore pragma directive */
-    dir = yytext + strlen("pragma");
-    if (*dir != '\0') {
-      int tok = -1;
-      /* fixup location before everything but pragma is reverted */
-      yycolumn -= (yyleng - 6);
-      yylloc->last_column = yycolumn;
-
-      while (*dir == ' ' || *dir == '\t') {
-        dir++; /* ignore whitespace */
-      }
-      /* emit pragma token if directive must be propagated to the parser */
-      if (strcmp(dir, "keylist") == 0) {
-        tok = IDL_T_PRAGMA;
-      }
-
-      yyless(6);
-
-      if (tok != -1) {
-        return tok;
-      }
+<PRAGMA>{identifier} {
+    /* compatability with OpenSplice. See OpenSplice_IDLPreProcGuide.pdf for
+       grammar specification. */
+    if (strcmp(yytext, "keylist") == 0) {
+      BEGIN(KEYLIST);
+    } else {
+      /* unsupported pragma directives are ignored */
+      yywarning(yylloc, parser, "unsupported pragma '%s'", yytext);
+      BEGIN(NOOP);
     }
-    /* do not emit token */
   }
 
-<PRAGMA>keylist {
-    BEGIN(DATA_TYPE);
-    return IDL_T_KEYLIST;
-  }
+<KEYLIST>{identifier} {
+    char *ident = NULL;
 
-<DATA_TYPE>{identifier} {
-    BEGIN(KEY);
-    if ((yylval->str = ddsrt_strdup(yytext)) == NULL) {
-      yyerror(yylloc, parser, context, yyscanner, "Could not copy identifier");
+    ddsts_pragma_open(parser->context);
+    if ((ident = ddsrt_strdup(yytext)) != NULL &&
+        (ddsts_pragma_add_identifier(parser->context, ident)))
+    {
+      BEGIN(KEY);
+    } else {
+      ddsrt_free(ident);
+      yyerror(yylloc, parser, "memory exhausted");
+      yyterminate();
     }
-    return IDL_T_DATA_TYPE;
   }
 
 <KEY>{identifier} {
-    if ((yylval->str = ddsrt_strdup(yytext)) == NULL) {
-      yyerror(yylloc, parser, context, yyscanner, "Could not copy identifier");
+    char *ident = NULL;
+    if ((ident = ddsrt_strdup(yytext)) == NULL ||
+       !(ddsts_pragma_add_identifier(parser->context, ident)))
+    {
+      ddsrt_free(ident);
+      yyerror(yylloc, parser, "memory exhausted");
+      yyterminate();
     }
-    return IDL_T_KEY;
   }
 
-<DATA_TYPE,KEY>[^[:space:]] {
-    yyerror(yylloc, parser, context, yyscanner, "Malformed #pragma keylist directive");
+<INITIAL,SCOPED_NAME>{identifier}(::)? {
+    /* grammer for IDL (>=4.0) is incorrect (or at least ambiguous). blanks,
+       horizontal and vertical tabs, newlines, form feeds, and comments
+       (collective, "white space") are ignored except as they serve to
+       separate tokens. the specification does not clearly state if white
+       space may occur between "::" and adjacent identifiers to form a
+       "scoped_name". the same is true for the "annotation_appl". in C++ "::"
+       is an operator and white space is therefore allowed, in IDL it is not.
+       this did not use to be a problem, but with the addition of annotations
+       it became possible to have two adjacent scoped names. many compilers
+       (probably) implement just the standardized annotations. the pragmatic
+       approach is to forbid use of white space in annotations, which works
+       for standardized annotations like "@key" and allow use of white space
+       for scoped names elsewhere. to implement this feature the parser must
+       know whether or not white space occurred between an identifier and the
+       scope operator. however, white space cannot be communicated to the
+       the parser (the grammer would explode) and an introducing an extra
+       identifier class is not an option (same reason). to work around this
+       problem, the lexer communicates different types of scope operators
+       used by the parser to implement a specialized "scoped_name" version
+       just for annotations. */
+    int tok;
+    char *ident;
+    size_t len = yyleng;
+
+    if (len > 2 && yytext[len-2] == ':' && yytext[len-1] == ':') {
+      /* fixup location before :: is reverted */
+      yycolumn -= 2;
+      yylloc->last_column = yycolumn;
+      len -= 2;
+      BEGIN(SCOPED_NAME);
+      yyless((int)len);
+    } else {
+      BEGIN(INITIAL);
+    }
+
+    if ((ident = ddsrt_strndup(yytext, len)) == NULL) {
+      yyerror(yylloc, parser, "memory exhausted");
+      yyterminate();
+    } else if ((tok = yystrtok(ident, 0)) != -1) {
+      ddsrt_free(ident);
+      BEGIN(INITIAL);
+      return tok;
+    }
+
+    yylval->identifier = ident;
+    return IDL_T_IDENTIFIER;
   }
 
-<PRAGMA>[^[:space:]] {
-    yyerror(yylloc, parser, context, yyscanner, "Unkown #pragma directive");
+<INITIAL,SCOPED_NAME>(::)({identifier})? {
+    /* see reason for optional identifier above */
+    int tok;
+    size_t len = yyleng;
+
+    if (len == 2) {
+      tok = ((YY_START) == SCOPED_NAME) ? IDL_T_SCOPE_L : IDL_T_SCOPE;
+      BEGIN(INITIAL);
+    } else {
+      assert(len > 2);
+      /* fixup location before identifier is reverted */
+      yycolumn -= (int)(len - 2);
+      yylloc->last_column = yycolumn;
+      tok = ((YY_START) == SCOPED_NAME) ? IDL_T_SCOPE_LR : IDL_T_SCOPE_R;
+      BEGIN(SCOPED_NAME);
+      yyless(2);
+    }
+
+    return tok;
   }
 
+@(::|{identifier}) {
+    /* see reason for mandatory :: or identifier above */
+    /* fixup location before :: or identifier is reverted */
+    yycolumn -= (yyleng - 1);
+    yylloc->last_column = yycolumn;
+    yyless(1);
+    return IDL_T_AT;
+  }
 
-<INITIAL,NO_WS>[ \t\r]    { BEGIN(INITIAL); }
+{integer_literal} {
+    unsigned long long ullng;
 
-<INITIAL,NO_WS>"/*"       { BEGIN(MULTILINE_COMMENT); }
-<MULTILINE_COMMENT>.      { }
-<MULTILINE_COMMENT>\n     { }
-<MULTILINE_COMMENT>"*/"   { BEGIN(INITIAL); }
+    /* strtoll recognizes if the value is dec, oct or hex if base is zero */
+    if (ddsrt_strtoull(yytext, NULL, 0, &ullng) != DDS_RETCODE_OK) {
+      idl_yyerror(yylloc, parser, "integer value %s out-of-range", yytext);
+      yyterminate();
+    }
 
-<INITIAL,NO_WS>"//"       { BEGIN(COMMENT); }
-<COMMENT>.                { }
+    yylval->literal.flags = DDSTS_ULONGLONG;
+    yylval->literal.value.ullng = ullng;
+    return IDL_T_INTEGER_LITERAL;
+  }
 
+<*>[ \t]+ {
+    /* ignore white space, except in SCOPED_NAME */
+    switch (YY_START) {
+      case SCOPED_NAME:
+        BEGIN(INITIAL);
+        /* fall through */
+      default:
+        break;
+    }
+  }
 
-<INITIAL,NO_WS>{integer_literal} {
-                            BEGIN(INITIAL);
-                            yylval->literal.flags = DDSTS_ULONGLONG;
-                            /* strtoll recognizes if the value is dec, oct or hex if base is zero */
-                            dds_return_t retcode = ddsrt_strtoull(yytext, NULL, 0, &yylval->literal.value.ullng);
-                            if (retcode != DDS_RETCODE_OK) {
-                              idl_yyerror(yylloc_param, parser, context, yyscanner, "Integer value invalid");
-                            }
-                            return IDL_T_INTEGER_LITERAL;
-                          }
+<*>. {
+    switch (YY_START) {
+      case DIRECTIVE:
+      case LINE:
+      case PRAGMA:
+      case KEYLIST:
+      case KEY:
+      case SPACE:
+        yyerror(yylloc, parser, "invalid symbol in compiler directive");
+        yyterminate();
+        /* never reached */
+      case NOOP:
+        /* ignore everything up to newline */
+        break;
+      default:
+        break;
+    }
 
-<INITIAL>{identifier}     {
-                            int tok;
-                            if ((tok = idl_yystrtok(yytext)) != -1) {
-                              return tok;
-                            }
-                            yylval->identifier = yytext;
-                            BEGIN(NO_WS);
-                            return IDL_T_IDENTIFIER;
-                          }
-
-<INITIAL>"::"             {
-                            BEGIN(NO_WS);
-                            return IDL_T_COLON_COLON;
-                          }
-
-<NO_WS>{identifier}       {
-                            int tok;
-                            if ((tok = idl_yystrtok(yytext)) != -1) {
-                              return tok;
-                            }
-                            yylval->identifier = yytext;
-                            if (yylval->identifier == NULL) {
-                              idl_yyerror(yylloc_param, parser, context, yyscanner, "Could not copy identifier");
-                            }
-                            return IDL_T_NOWS_IDENTIFIER;
-                          }
-
-<NO_WS>"::"               {
-                            return IDL_T_NOWS_COLON_COLON;
-                          }
-
-
-<INITIAL>"@"              {
-                            BEGIN(NO_WS);
-                            return '@';
-                          }
-
-<*>[ \t]+ { /* ignore whitespace */ }
-<*>\n { BEGIN(INITIAL); }
-
-<INITIAL,NO_WS>.          {
-                            BEGIN(INITIAL);
-                            return yytext[0];
-                          }
+    return yytext[0];
+  }
 
 %%
 
+#define CHUNK (4096)
+
+int idl_puts(idl_parser_t *parser, const char *str, size_t len)
+{
+  dds_return_t rc = 0;
+  struct yyguts_t *yyg; /* required for YY_CURRENT_BUFFER */
+  YY_BUFFER_STATE yybuf;
+
+  assert(parser != NULL);
+  assert(parser->yylstate != NULL);
+
+  yyg = (struct yyguts_t *)parser->yylstate;
+  /* YY_CURRENT_BUFFER macro is used so that the yy_buffer_state struct does
+     not have to be defined in order to define the idl_parser struct */
+  yybuf = YY_CURRENT_BUFFER;
+
+  /* tokenize to free up space */
+  if ((parser->buffer.size - parser->buffer.used) <= len &&
+      (parser->buffer.lines) > 1)
+  {
+    while (parser->buffer.lines > 1 && (rc = idl_scan(parser)) == 1) { /* scan */ }
+
+    if (rc != 1) {
+      assert(rc != DDS_RETCODE_OK);
+      ddsts_context_set_retcode(parser->context, rc);
+      return -1;
+    }
+
+    /* move non-tokenized data to start of buffer, but only if yy_more_flag is
+       not set to avoid corruption of buffer state */
+    if (yyg->yy_more_flag != 1) {
+      size_t cnt, off;
+      off = yyg->yy_c_buf_p - yybuf->yy_ch_buf;
+      assert(off != 0);
+      cnt = parser->buffer.used - off;
+      memmove(parser->buffer.data, parser->buffer.data + off, parser->buffer.used - off);
+      parser->buffer.used = cnt;
+      parser->buffer.data[cnt + 0] = '\0';
+      parser->buffer.data[cnt + 1] = '\0';
+      /* update yybuf and yyscan */
+      yybuf->yy_n_chars = yybuf->yy_buf_size = (int)cnt;
+      yyg->yy_c_buf_p = yybuf->yy_ch_buf;
+    }
+  }
+
+  /* expand buffer if necessary */
+  if ((parser->buffer.size - parser->buffer.used) <= len) {
+    size_t size = parser->buffer.size + (((len / CHUNK) + 1) * CHUNK);
+    char *buf = ddsrt_realloc(parser->buffer.data, size + 2 /* '\0' + '\0' */);
+    if (buf == NULL) {
+      ddsts_context_set_retcode(parser->context, DDS_RETCODE_OUT_OF_RESOURCES);
+      return -1;
+    }
+    /* update input buffer */
+    parser->buffer.data = buf;
+    parser->buffer.size = size;
+    if (yybuf != NULL) {
+      /* update yybuf and yyscan */
+      yyg->yy_c_buf_p = buf + (yyg->yy_c_buf_p - yybuf->yy_ch_buf);
+      yybuf->yy_buf_pos = buf + (yybuf->yy_buf_pos - yybuf->yy_ch_buf);
+      yybuf->yy_ch_buf = parser->buffer.data;
+    }
+  }
+
+  /* write to buffer */
+  memcpy(parser->buffer.data + parser->buffer.used, str, len);
+  parser->buffer.used += len;
+  assert(parser->buffer.used <= parser->buffer.size);
+  parser->buffer.data[parser->buffer.used + 0] = '\0';
+  parser->buffer.data[parser->buffer.used + 1] = '\0';
+  /* buffer must exist and contain data */
+  if (yybuf == NULL) {
+    yybuf = yy_scan_buffer(parser->buffer.data, parser->buffer.used + 2, yyg);
+    if (yybuf == NULL) {
+      ddsts_context_set_retcode(parser->context, DDS_RETCODE_OUT_OF_RESOURCES);
+      return -1;
+    }
+    yyset_lineno(1, yyg);
+    yyset_column(1, yyg);
+  } else {
+    yybuf->yy_n_chars = yybuf->yy_buf_size = (int)parser->buffer.used;
+  }
+
+  /* keep track of lines */
+  for (const char *ptr = str; *ptr != '\0'; ptr++) {
+    if (*ptr == '\n') {
+      parser->buffer.lines++;
+    }
+  }
+
+  return (int)len;
+}

--- a/src/tools/idlc/src/idl.y
+++ b/src/tools/idlc/src/idl.y
@@ -25,29 +25,17 @@
 %code provides {
 #include <stdarg.h>
 
-#define YYSTYPE IDL_YYSTYPE
-#define YYLTYPE IDL_YYLTYPE
-
-typedef struct YYLTYPE {
-  char *first_file;
-  int first_line;
-  int first_column;
-  char *last_file;
-  int last_line;
-  int last_column;
-} YYLTYPE;
-
 #define YY_DECL \
-  int idl_yylex(YYSTYPE *yylval_param, YYLTYPE *yylloc_param, idl_parser_t *parser, ddsts_context_t *context, yyscan_t yyscanner)
+  int idl_yylex(YYSTYPE *yylval_param, YYLTYPE *yylloc_param, idl_parser_t *parser, yyscan_t yyscanner)
 
 extern YY_DECL;
 
 #define yyerror idl_yyerror
-int idl_yyerror(YYLTYPE *yylloc, idl_parser_t *parser, ddsts_context_t *context, yyscan_t, char *fmt, ...);
-
-int idl_yystrtok(const char *str);
-
-int idl_yystritok(const char *str);
+void idl_yyerror(YYLTYPE *yylloc, idl_parser_t *parser, const char *fmt, ...);
+#define yywarning idl_yywarning
+void idl_yywarning(YYLTYPE *yylloc, idl_parser_t *parser, const char *fmt, ...);
+#define yystrtok idl_yystrtok
+int idl_yystrtok(const char *str, bool nc);
 }
 
 %code requires {
@@ -56,8 +44,13 @@ int idl_yystritok(const char *str);
 
 /* Make yytoknum available */
 #define YYPRINT(A,B,C) YYUSE(A)
-/* Use YYLTYPE definition above */
+/* Use YYLTYPE definition below */
 #define IDL_YYLTYPE_IS_DECLARED
+
+#define YYSTYPE IDL_YYSTYPE
+#define YYLTYPE IDL_YYLTYPE
+
+typedef struct idl_location YYLTYPE;
 
 #define YYLLOC_DEFAULT(Cur, Rhs, N) \
   do { \
@@ -91,21 +84,18 @@ int idl_yystritok(const char *str);
   ddsts_literal_t literal;
   ddsts_identifier_t identifier;
   ddsts_scoped_name_t *scoped_name;
-  char *str;
 }
 
 %define api.pure full
 %define api.prefix {idl_yy}
+%define api.push-pull push
 %define parse.trace
 
 %locations
 
 %param { idl_parser_t *parser }
-%param { ddsts_context_t *context }
-%param { yyscan_t scanner }
 %initial-action { YYLLOC_INITIAL(@$, parser->files ? parser->files->name : NULL); }
 
-%destructor { ddsrt_free($$); } <str>
 
 %token-table
 
@@ -154,7 +144,7 @@ int idl_yystritok(const char *str);
 
 %type <scoped_name>
   scoped_name
-  nows_scoped_name
+  at_scoped_name
 
 %destructor { ddsts_free_scoped_name($$); } <scoped_name>
 
@@ -168,14 +158,15 @@ int idl_yystritok(const char *str);
 %type <identifier>
   simple_declarator
   identifier
-  nows_identifier
 
-/* compiler directives */
-%token IDL_T_PRAGMA "#pragma"
-/* #pragma keylist is implemented for compatibility with OpenSplice */
-%token IDL_T_KEYLIST "keylist"
-%token <str> IDL_T_DATA_TYPE
-%token <str> IDL_T_KEY
+/* standardized annotations */
+%token IDL_T_AT "@"
+
+/* scope operators, see idl.l for details */
+%token IDL_T_SCOPE
+%token IDL_T_SCOPE_L
+%token IDL_T_SCOPE_R
+%token IDL_T_SCOPE_LR
 
 /* keywords */
 %token IDL_T_MODULE "module"
@@ -218,8 +209,7 @@ int idl_yystritok(const char *str);
 %token IDL_T_UINT32 "uint32"
 %token IDL_T_UINT64 "uint64"
 
-%token IDL_T_COLON_COLON
-%token IDL_T_NOWS_COLON_COLON
+%token IDL_T_DOUBLE_COLON "::"
 
 %token IDL_T_END 0 "end of file"
 
@@ -230,7 +220,7 @@ int idl_yystritok(const char *str);
 
 specification:
     definitions IDL_T_END
-    { ddsts_accept(context); YYACCEPT; }
+    { ddsts_accept(parser->context); YYACCEPT; }
   ;
 
 definitions:
@@ -241,56 +231,62 @@ definitions:
 definition:
     module_dcl ';'
   | type_dcl ';'
-  | pragma
   ;
 
 module_dcl:
     "module" identifier
       {
-        if (!ddsts_module_open(context, $2)) {
+        if (!ddsts_module_open(parser->context, $2)) {
           YYABORT;
         }
       }
     '{' definitions '}'
-      { ddsts_module_close(context); };
+      { ddsts_module_close(parser->context); };
 
-scoped_name:
+at_scoped_name:
     identifier
       {
-        if (!ddsts_new_scoped_name(context, 0, false, $1, &($$))) {
+        if (!ddsts_new_scoped_name(parser->context, 0, false, $1, &($$))) {
           YYABORT;
         }
       }
-  | IDL_T_COLON_COLON nows_identifier
+  | IDL_T_SCOPE_R identifier
       {
-        if (!ddsts_new_scoped_name(context, 0, true, $2, &($$))) {
+        if (!ddsts_new_scoped_name(parser->context, 0, true, $2, &($$))) {
           YYABORT;
         }
       }
-  | scoped_name IDL_T_NOWS_COLON_COLON nows_identifier
+  | at_scoped_name IDL_T_SCOPE_LR identifier
       {
-        if (!ddsts_new_scoped_name(context, $1, false, $3, &($$))) {
+        if (!ddsts_new_scoped_name(parser->context, $1, false, $3, &($$))) {
           YYABORT;
         }
       }
   ;
 
-nows_scoped_name:
-    nows_identifier
+scope:
+    IDL_T_SCOPE
+  | IDL_T_SCOPE_L
+  | IDL_T_SCOPE_R
+  | IDL_T_SCOPE_LR
+  ;
+
+scoped_name:
+    identifier
       {
-        if (!ddsts_new_scoped_name(context, 0, false, $1, &($$))) {
+        if (!ddsts_new_scoped_name(parser->context, 0, false, $1, &($$))) {
           YYABORT;
         }
       }
-  | IDL_T_COLON_COLON nows_identifier
+  | scope identifier
       {
-        if (!ddsts_new_scoped_name(context, 0, true, $2, &($$))) {
+        if (!ddsts_new_scoped_name(parser->context, 0, true, $2, &($$))) {
           YYABORT;
         }
       }
-  | nows_scoped_name IDL_T_NOWS_COLON_COLON nows_identifier
+  | scoped_name scope identifier
       {
-        if (!ddsts_new_scoped_name(context, $1, false, $3, &($$))) {
+        if (!ddsts_new_scoped_name(parser->context, $1, false, $3, &($$))) {
           YYABORT;
         }
       }
@@ -319,13 +315,13 @@ type_spec:
 simple_type_spec:
     base_type_spec
       {
-        if (!ddsts_new_base_type(context, $1, &($$))) {
+        if (!ddsts_new_base_type(parser->context, $1, &($$))) {
           YYABORT;
         }
       }
   | scoped_name
       {
-        if (!ddsts_get_type_from_scoped_name(context, $1, &($$))) {
+        if (!ddsts_get_type_from_scoped_name(parser->context, $1, &($$))) {
           YYABORT;
         }
       }
@@ -386,13 +382,13 @@ template_type_spec:
 sequence_type:
     "sequence" '<' type_spec ',' positive_int_const '>'
       {
-        if (!ddsts_new_sequence(context, $3, &($5), &($$))) {
+        if (!ddsts_new_sequence(parser->context, $3, &($5), &($$))) {
           YYABORT;
         }
       }
   | "sequence" '<' type_spec '>'
       {
-        if (!ddsts_new_sequence_unbound(context, $3, &($$))) {
+        if (!ddsts_new_sequence_unbound(parser->context, $3, &($$))) {
           YYABORT;
         }
       }
@@ -401,13 +397,13 @@ sequence_type:
 string_type:
     "string" '<' positive_int_const '>'
       {
-        if (!ddsts_new_string(context, &($3), &($$))) {
+        if (!ddsts_new_string(parser->context, &($3), &($$))) {
           YYABORT;
         }
       }
   | "string"
       {
-        if (!ddsts_new_string_unbound(context, &($$))) {
+        if (!ddsts_new_string_unbound(parser->context, &($$))) {
           YYABORT;
         }
       }
@@ -416,13 +412,13 @@ string_type:
 wide_string_type:
     "wstring" '<' positive_int_const '>'
       {
-        if (!ddsts_new_wide_string(context, &($3), &($$))) {
+        if (!ddsts_new_wide_string(parser->context, &($3), &($$))) {
           YYABORT;
         }
       }
   | "wstring"
       {
-        if (!ddsts_new_wide_string_unbound(context, &($$))) {
+        if (!ddsts_new_wide_string_unbound(parser->context, &($$))) {
           YYABORT;
         }
       }
@@ -431,7 +427,7 @@ wide_string_type:
 fixed_pt_type:
     "fixed" '<' positive_int_const ',' positive_int_const '>'
       {
-        if (!ddsts_new_fixed_pt(context, &($3), &($5), &($$))) {
+        if (!ddsts_new_fixed_pt(parser->context, &($3), &($5), &($$))) {
           YYABORT;
         }
       }
@@ -441,12 +437,12 @@ fixed_pt_type:
 struct_type:
     "struct" '{'
       {
-        if (!ddsts_add_struct_open(context, NULL)) {
+        if (!ddsts_add_struct_open(parser->context, NULL)) {
           YYABORT;
         }
       }
     members '}'
-      { ddsts_struct_close(context, &($$)); }
+      { ddsts_struct_close(parser->context, &($$)); }
   ;
 
 constr_type_dcl:
@@ -462,12 +458,12 @@ struct_dcl:
 struct_def:
     "struct" identifier '{'
       {
-        if (!ddsts_add_struct_open(context, $2)) {
+        if (!ddsts_add_struct_open(parser->context, $2)) {
           YYABORT;
         }
       }
     members '}'
-      { ddsts_struct_close(context, &($$)); }
+      { ddsts_struct_close(parser->context, &($$)); }
   ;
 members:
     member members
@@ -477,29 +473,29 @@ members:
 member:
     annotation_appls type_spec
       {
-        if (!ddsts_add_struct_member(context, &($2))) {
+        if (!ddsts_add_struct_member(parser->context, &($2))) {
           YYABORT;
         }
       }
     declarators ';'
-      { ddsts_struct_member_close(context); }
+      { ddsts_struct_member_close(parser->context); }
   | type_spec
       {
-        if (!ddsts_add_struct_member(context, &($1))) {
+        if (!ddsts_add_struct_member(parser->context, &($1))) {
           YYABORT;
         }
       }
     declarators ';'
-      { ddsts_struct_member_close(context); }
+      { ddsts_struct_member_close(parser->context); }
 /* Embedded struct extension: */
-  | struct_def { ddsts_add_struct_member(context, &($1)); }
+  | struct_def { ddsts_add_struct_member(parser->context, &($1)); }
     declarators ';'
   ;
 
 struct_forward_dcl:
     "struct" identifier
       {
-        if (!ddsts_add_struct_forward(context, $2)) {
+        if (!ddsts_add_struct_forward(parser->context, $2)) {
           YYABORT;
         }
       };
@@ -512,18 +508,18 @@ union_dcl:
 union_def:
     "union" identifier
        {
-         if (!ddsts_add_union_open(context, $2)) {
+         if (!ddsts_add_union_open(parser->context, $2)) {
            YYABORT ;
          }
        }
     "switch" '(' switch_type_spec ')'
        {
-         if (!ddsts_union_set_switch_type(context, $6)) {
+         if (!ddsts_union_set_switch_type(parser->context, $6)) {
            YYABORT ;
          }
        }
     '{' switch_body '}'
-       { ddsts_union_close(context); }
+       { ddsts_union_close(parser->context); }
   ;
 switch_type_spec:
     integer_type
@@ -531,7 +527,7 @@ switch_type_spec:
   | boolean_type
   | scoped_name
       {
-        if (!ddsts_get_base_type_from_scoped_name(context, $1, &($$))) {
+        if (!ddsts_get_base_type_from_scoped_name(parser->context, $1, &($$))) {
           YYABORT;
         }
       }
@@ -555,13 +551,13 @@ case_labels:
 case_label:
     "case" const_expr ':'
       {
-        if (!ddsts_union_add_case_label(context, &($2))) {
+        if (!ddsts_union_add_case_label(parser->context, &($2))) {
           YYABORT;
         }
       }
   | "default" ':'
       {
-        if (!ddsts_union_add_case_default(context)) {
+        if (!ddsts_union_add_case_default(parser->context)) {
           YYABORT;
         }
       }
@@ -570,7 +566,7 @@ case_label:
 element_spec:
     type_spec
       {
-        if (!ddsts_union_add_element(context, &($1))) {
+        if (!ddsts_union_add_element(parser->context, &($1))) {
           YYABORT;
         }
       }
@@ -580,7 +576,7 @@ element_spec:
 union_forward_dcl:
     "union" identifier
       {
-        if (!ddsts_add_union_forward(context, $2)) {
+        if (!ddsts_add_union_forward(parser->context, $2)) {
           YYABORT;
         }
       }
@@ -589,7 +585,7 @@ union_forward_dcl:
 array_declarator:
     identifier fixed_array_sizes
       {
-        if (!ddsts_add_declarator(context, $1)) {
+        if (!ddsts_add_declarator(parser->context, $1)) {
           YYABORT;
         }
       }
@@ -603,7 +599,7 @@ fixed_array_sizes:
 fixed_array_size:
     '[' positive_int_const ']'
       {
-        if (!ddsts_add_array_size(context, &($2))) {
+        if (!ddsts_add_array_size(parser->context, &($2))) {
           YYABORT;
         }
       }
@@ -619,7 +615,7 @@ declarators:
 declarator:
     simple_declarator
       {
-        if (!ddsts_add_declarator(context, $1)) {
+        if (!ddsts_add_declarator(parser->context, $1)) {
           YYABORT;
         }
       };
@@ -629,20 +625,20 @@ declarator:
 struct_def:
     "struct" identifier ':' scoped_name '{'
       {
-        if (!ddsts_add_struct_extension_open(context, $2, $4)) {
+        if (!ddsts_add_struct_extension_open(parser->context, $2, $4)) {
           YYABORT;
         }
       }
     members '}'
-      { ddsts_struct_close(context, &($$)); }
+      { ddsts_struct_close(parser->context, &($$)); }
   | "struct" identifier '{'
       {
-        if (!ddsts_add_struct_open(context, $2)) {
+        if (!ddsts_add_struct_open(parser->context, $2)) {
           YYABORT;
         }
       }
     '}'
-      { ddsts_struct_empty_close(context, &($$)); }
+      { ddsts_struct_empty_close(parser->context, &($$)); }
   ;
 
 template_type_spec:
@@ -652,13 +648,13 @@ template_type_spec:
 map_type:
     "map" '<' type_spec ',' type_spec ',' positive_int_const '>'
       {
-        if (!ddsts_new_map(context, $3, $5, &($7), &($$))) {
+        if (!ddsts_new_map(parser->context, $3, $5, &($7), &($$))) {
           YYABORT;
         }
       }
   | "map" '<' type_spec ',' type_spec '>'
       {
-        if (!ddsts_new_map_unbound(context, $3, $5, &($$))) {
+        if (!ddsts_new_map_unbound(parser->context, $3, $5, &($$))) {
           YYABORT;
         }
       }
@@ -700,96 +696,82 @@ annotation_appls:
   ;
 
 annotation_appl:
-    '@' nows_scoped_name
+    "@" at_scoped_name
     {
-      if (!ddsts_add_annotation(context, $2)) {
+      if (!ddsts_add_annotation(parser->context, $2)) {
         YYABORT;
       }
     }
   ;
 
-/* Compatability with OpenSplice. See OpenSplice_IDLPreProcGuide.pdf for
-   grammar specification. */
-
-pragma:
-    "#pragma" "keylist" IDL_T_DATA_TYPE
-    {
-      ddsts_pragma_open(context);
-      if(!ddsts_pragma_add_identifier(context, $3)) {
-        YYABORT;
-      }
-    }
-    keys
-    {
-      ddsts_pragma_close(context);
-    } ;
-
-keys:
-  | keys IDL_T_KEY
-    {
-      if (!ddsts_pragma_add_identifier(context, $2)) {
-        YYABORT;
-      }
-    } ;
-
 identifier:
     IDL_T_IDENTIFIER
       {
-        size_t offset = 0;
+        size_t off = 0;
         if ($1[0] == '_') {
-          offset = 1;
-        } else if (idl_yystritok($1) != -1) {
-          yyerror(&yylloc, parser, context, scanner, "Identifier collides with a keyword");
+          off = 1;
+        } else if (yystrtok($1, 1) != -1) {
+          yyerror(&yylloc, parser, "identifier '%s' collides with a keyword", $1);
           YYABORT;
         }
-        if (!ddsts_context_copy_identifier(context, $1 + offset, &($$))) {
-          YYABORT;
-        }
-      };
-
-nows_identifier:
-    IDL_T_NOWS_IDENTIFIER
-      {
-        size_t offset = 0;
-        if ($1[0] == '_') {
-          offset = 1;
-        } else if (idl_yystritok($1) != -1) {
-          yyerror(&yylloc, parser, context, scanner, "Identifier collides with a keyword");
-          YYABORT;
-        }
-        if (!ddsts_context_copy_identifier(context, $1 + offset, &($$))) {
+        if (!ddsts_context_copy_identifier(parser->context, $1 + off, &($$))) {
           YYABORT;
         }
       };
 
 %%
 
-int idl_yyerror(
-  YYLTYPE *yylloc, idl_parser_t *parser, ddsts_context_t *context, yyscan_t yyscanner, char *fmt, ...)
+void idl_yyerror(
+  YYLTYPE *yylloc, idl_parser_t *parser, const char *fmt, ...)
 {
+  dds_return_t rc;
   va_list ap;
 
   DDSRT_UNUSED_ARG(parser);
-  DDSRT_UNUSED_ARG(context);
-  DDSRT_UNUSED_ARG(yyscanner);
+  rc = ddsts_context_get_retcode(parser->context);
+  if (rc == DDS_RETCODE_OK) {
+    if (strcmp(fmt, "memory exhausted") == 0) {
+      ddsts_context_set_retcode(parser->context, DDS_RETCODE_OUT_OF_RESOURCES);
+    } else {
+      ddsts_context_set_retcode(parser->context, DDS_RETCODE_BAD_SYNTAX);
+    }
+  }
+
   fprintf(stderr, "%s at %d.%d: ", yylloc->first_file, yylloc->first_line, yylloc->first_column);
   va_start(ap, fmt);
   vfprintf(stderr, fmt, ap);
   va_end(ap);
   fprintf(stderr, "\n");
-  return 0;
 }
 
-int idl_yystritok(const char *str)
+void idl_yywarning(
+  YYLTYPE *yylloc, idl_parser_t *parser, const char *fmt, ...)
+{
+  va_list ap;
+
+  assert(yylloc != NULL);
+  (void)parser;
+  assert(fmt != NULL);
+
+  fprintf(stderr, "%s at %d.%d: ", yylloc->first_file, yylloc->first_line, yylloc->first_column);
+  va_start(ap, fmt);
+  vfprintf(stderr, fmt, ap);
+  va_end(ap);
+  fprintf(stderr, "\n");
+}
+
+int idl_yystrtok(const char *str, bool nc)
 {
   size_t i, n;
+  int(*cmp)(const char *s1, const char *s2, size_t n);
 
   assert(str != NULL);
 
+  cmp = (nc ? &ddsrt_strncasecmp : strncmp);
   for (i = 0, n = strlen(str); i < YYNTOKENS; i++) {
     if (yytname[i] != 0
         && yytname[i][    0] == '"'
-        && ddsrt_strncasecmp(yytname[i] + 1, str, n) == 0
+        && cmp(yytname[i] + 1, str, n) == 0
         && yytname[i][n + 1] == '"'
         && yytname[i][n + 2] == '\0') {
       return yytoknum[i];
@@ -798,23 +780,3 @@ int idl_yystritok(const char *str)
 
   return -1;
 }
-
-int idl_yystrtok(const char *str)
-{
-  size_t i, n;
-
-  assert(str != NULL);
-
-  for (i = 0, n = strlen(str); i < YYNTOKENS; i++) {
-    if (yytname[i] != 0
-        && yytname[i][    0] == '"'
-        && strncmp(yytname[i] + 1, str, n) == 0
-        && yytname[i][n + 1] == '"'
-        && yytname[i][n + 2] == 0) {
-      return yytoknum[i];
-    }
-  }
-
-  return -1;
-}
-

--- a/src/tools/idlc/src/main.c
+++ b/src/tools/idlc/src/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2019 ADLINK Technology Limited and others
+ * Copyright(c) 2019 Jeroen Koekkoek
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -10,14 +10,230 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
 #include <assert.h>
+#include <errno.h>
+#include <getopt.h>
+#include <limits.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdbool.h>
+#include <string.h>
 
+#include "dds/version.h"
+#include "dds/ddsrt/attributes.h"
+#include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/io.h"
 #include "dds/ddsrt/log.h"
+#include "dds/ddsrt/string.h"
 #include "dds/ddsts/typetree.h"
+#include "dds/ddsrt/misc.h"
+
 #include "idl.h"
+#include "mcpp_lib.h"
+#include "mcpp_out.h"
 #include "gen_c99.h"
+
+#define IDLC_PREPROCESS (1<<0)
+#define IDLC_COMPILE (1<<1)
+#define IDLC_DEBUG_PREPROCESSOR (1<<2)
+#define IDLC_DEBUG_PARSER (1<<3)
+
+typedef struct {
+  char *file; /* path of input file or "-" for STDIN */
+  char *lang;
+  int flags; /* preprocess and/or compile */
+  /* (emulated) command line options for mcpp */
+  int argc;
+  char **argv;
+} idlc_options_t;
+
+/* mcpp does not accept userdata */
+static idlc_options_t opts;
+static idl_parser_t *parser = NULL;
+static ddsts_type_t *root = NULL;
+
+static int idlc_putc(int chr, OUTDEST od);
+static int idlc_puts(const char *str, OUTDEST od)
+  ddsrt_nonnull((1));
+static int idlc_printf(OUTDEST od, const char *str, ...)
+  ddsrt_nonnull((2))
+  ddsrt_attribute_format((printf, 2, 3));
+static dds_return_t idlc_parse(void);
+
+static int idlc_putc(int chr, OUTDEST od)
+{
+  int ret = 1;
+  char str[2] = { (char)chr, '\0' };
+
+  switch (od) {
+  case OUT:
+    if (!(opts.flags & IDLC_COMPILE)) {
+      ret = printf("%c", chr);
+    } else {
+      assert(parser != NULL);
+      ret = idl_puts(parser, str, 1);
+    }
+    break;
+  case ERR:
+    DDS_ERROR("%c", chr);
+    break;
+  case DBG:
+    if (opts.flags & IDLC_DEBUG_PREPROCESSOR) {
+      ret = fprintf(stderr, "%c", chr);
+    }
+    break;
+  default:
+    assert(0);
+    break;
+  }
+
+  return ret < 0 ? -1 : ret;
+}
+
+static int idlc_puts(const char *str, OUTDEST od)
+{
+  int ret;
+  size_t len = strlen(str);
+
+  assert(str != NULL);
+  assert(len <= INT_MAX);
+  ret = (int)len;
+
+  switch (od) {
+  case OUT:
+    if (!(opts.flags & IDLC_COMPILE)) {
+      ret = printf("%s", str);
+    } else {
+      assert(parser != NULL);
+      ret = idl_puts(parser, str, len);
+    }
+    break;
+  case ERR:
+    DDS_ERROR("%s", str);
+    break;
+  case DBG:
+    if (opts.flags & IDLC_DEBUG_PREPROCESSOR) {
+      ret = fprintf(stderr, "%s", str);
+    }
+    break;
+  default:
+    assert(0);
+    break;
+  }
+
+  return ret < 0 ? -1 : ret;
+}
+
+static int idlc_printf(OUTDEST od, const char *fmt, ...)
+{
+  int ret = -1;
+  char *str = NULL;
+  int len;
+  va_list ap;
+
+  assert(fmt != NULL);
+
+  va_start(ap, fmt);
+  if ((len = ddsrt_vasprintf(&str, fmt, ap)) < 0) { /* FIXME: optimize */
+    ddsts_context_set_retcode(parser->context, DDS_RETCODE_OUT_OF_RESOURCES);
+    return -1;
+  }
+  va_end(ap);
+
+  switch (od) {
+  case OUT:
+    if (!(opts.flags & IDLC_COMPILE)) {
+      ret = printf("%s", str);
+    } else {
+      assert(parser != NULL);
+      ret = idl_puts(parser, str, (size_t)len);
+    }
+    break;
+  case ERR:
+    DDS_ERROR("%s", str);
+    break;
+  case DBG:
+    if (opts.flags & IDLC_DEBUG_PREPROCESSOR) {
+      ret = fprintf(stderr, "%s", str);
+    }
+    break;
+  default:
+    assert(0);
+    break;
+  }
+
+  ddsrt_free(str);
+
+  return ret < 0 ? -1 : ret;
+}
+
+dds_return_t idlc_parse(void)
+{
+  dds_return_t rc = DDS_RETCODE_OK;
+
+  if(opts.flags & IDLC_COMPILE) {
+    if ((parser = idl_create_parser()) == NULL) {
+      return DDS_RETCODE_OUT_OF_RESOURCES;
+    }
+  }
+
+  if (opts.flags & IDLC_PREPROCESS) {
+    mcpp_set_out_func(&idlc_putc, &idlc_puts, &idlc_printf);
+    if (mcpp_lib_main(opts.argc, opts.argv) == 0) {
+      assert(!(opts.flags & IDLC_COMPILE) ||
+             ddsts_context_get_retcode(parser->context) == DDS_RETCODE_OK);
+    } else if (opts.flags & IDLC_COMPILE) {
+      assert(ddsts_context_get_retcode(parser->context) != DDS_RETCODE_OK);
+      rc = ddsts_context_get_retcode(parser->context);
+    }
+  } else {
+    FILE *fin;
+    char buf[1024];
+    size_t nrd;
+    int nwr;
+
+    if (strcmp(opts.file, "-") == 0) {
+      fin = stdin;
+    } else {
+      DDSRT_WARNING_MSVC_OFF(4996)
+      fin = fopen(opts.file, "rb");
+      DDSRT_WARNING_MSVC_ON(4996)
+    }
+
+    if (fin == NULL) {
+      switch (errno) {
+        case ENOMEM:
+          rc = DDS_RETCODE_OUT_OF_RESOURCES;
+          break;
+        default:
+          rc = DDS_RETCODE_ERROR;
+          break;
+      }
+    } else {
+      while ((nrd = fread(buf, sizeof(buf), 1, fin)) > 0) {
+        if ((nwr = idl_puts(parser, buf, nrd)) == -1) {
+          rc = ddsts_context_get_retcode(parser->context);
+          assert(rc != DDS_RETCODE_OK);
+        }
+        assert(nrd == (size_t)nwr);
+      }
+    }
+
+    if (fin != stdin) {
+      fclose(fin);
+    }
+  }
+
+  if (rc == DDS_RETCODE_OK && (opts.flags & IDLC_COMPILE)) {
+    rc = idl_scan(parser);
+    if (rc == DDS_RETCODE_OK) {
+      root = ddsts_context_take_root_type(parser->context);
+    }
+  }
+
+  idl_destroy_parser(parser);
+
+  return rc;
+}
 
 static void
 usage(const char *prog)
@@ -25,22 +241,127 @@ usage(const char *prog)
   fprintf(stderr, "Usage: %s FILE\n", prog);
 }
 
-int
-main(int argc, char *argv[])
+static void
+help(const char *prog)
 {
-  if (argc != 2) {
-    usage(argv[0]);
-    return EXIT_FAILURE;
+  static const char fmt[] =
+"Usage: %s [OPTIONS] FILE\n"
+"Options:\n"
+"  -d <component>       Display debug information for <component>(s)\n"
+"                       Comma separate or use more than one -d option to\n"
+"                       specify multiple components\n"
+"                       Components: preprocessor, parser\n"
+"  -D <macro>[=value]   Define <macro> to <value> (default:1)\n"
+"  -E                   Preprocess only\n"
+"  -h                   Display available options\n"
+"  -I <directory>       Add <directory> to include search list\n"
+"  -l <language>        Compile representation for <language>\n"
+"  -S                   Compile only\n"
+"  -v                   Display version information\n";
+
+  printf(fmt, prog);
+}
+
+static void
+version(const char *prog)
+{
+  printf("%s (Eclipse Cyclone DDS) %s\n", prog, DDS_VERSION);
+}
+
+int main(int argc, char *argv[])
+{
+  int opt;
+  char *prog = argv[0];
+  dds_return_t rc;
+
+  /* determine basename */
+  for (char *sep = argv[0]; *sep; sep++) {
+    if (*sep == '/' || *sep == '\\') {
+      prog = sep + 1;
+    }
   }
 
-  ddsts_type_t *root_type = NULL;
-  if (idl_parse_file(argv[1], &root_type) != DDS_RETCODE_OK) {
-    return EXIT_FAILURE;
+  opts.file = "-"; /* default to STDIN */
+  opts.flags = IDLC_PREPROCESS | IDLC_COMPILE;
+  opts.lang = "c";
+  opts.argc = 0;
+  opts.argv = ddsrt_calloc((unsigned int)argc + 6, sizeof(char *));
+  if (opts.argv == NULL) {
+    return -1;
   }
 
-  ddsts_generate_C99(argv[1], root_type);
+  opts.argv[opts.argc++] = argv[0];
+  opts.argv[opts.argc++] = "-C"; /* keep comments */
+  opts.argv[opts.argc++] = "-I-"; /* unset system include directories */
+  opts.argv[opts.argc++] = "-k"; /* keep white space as is */
+  opts.argv[opts.argc++] = "-N"; /* unset predefined macros */
+  /* FIXME: mcpp option -K embeds macro notifications into comments to allow
+            reconstruction of the original source position from the
+            preprocessed output */
 
-  ddsts_free_type(root_type);
+  /* parse command line options */
+  while ((opt = getopt(argc, argv, "Cd:D:EhI:l:Sv")) != -1) {
+    switch (opt) {
+      case 'd':
+        {
+          char *tok, *str = optarg;
+          while ((tok = ddsrt_strsep(&str, ",")) != NULL) {
+            if (ddsrt_strcasecmp(tok, "preprocessor") == 0) {
+              opts.flags |= IDLC_DEBUG_PREPROCESSOR;
+            } else if (ddsrt_strcasecmp(tok, "parser") == 0) {
+              opts.flags |= IDLC_DEBUG_PARSER;
+            }
+          }
+        }
+        break;
+      case 'D':
+        opts.argv[opts.argc++] = "-D";
+        opts.argv[opts.argc++] = optarg;
+        break;
+      case 'E':
+        opts.flags &= ~IDLC_COMPILE;
+        opts.flags |= IDLC_PREPROCESS;
+        break;
+      case 'h':
+        help(prog);
+        exit(0);
+      case 'I':
+        opts.argv[opts.argc++] = "-I";
+        opts.argv[opts.argc++] = optarg;
+        break;
+      case 'l':
+        opts.lang = optarg;
+        break;
+      case 'S':
+        opts.flags &= ~IDLC_PREPROCESS;
+        opts.flags |= IDLC_COMPILE;
+        break;
+      case 'v':
+        version(prog);
+        exit(0);
+      case '?':
+        usage(prog);
+        exit(1);
+    }
+  }
+
+  if (optind == argc) { /* default to STDIN */
+    assert(opts.file != NULL);
+    assert(strcmp(opts.file, "-") == 0);
+  } else {
+    opts.file = argv[optind];
+  }
+
+  opts.argv[opts.argc++] = opts.file;
+
+  if ((rc = idlc_parse()) == DDS_RETCODE_OK && (opts.flags & IDLC_COMPILE)) {
+    assert(root != NULL);
+    assert(ddsrt_strcasecmp(opts.lang, "c") == 0);
+    ddsts_generate_C99(opts.file, root);
+    ddsts_free_type(root);
+  }
+
+  ddsrt_free(opts.argv);
 
   return EXIT_SUCCESS;
 }

--- a/src/tools/idlc/src/tt_create.h
+++ b/src/tools/idlc/src/tt_create.h
@@ -23,6 +23,7 @@ typedef struct ddsts_context ddsts_context_t;
 ddsts_context_t* ddsts_create_context(void);
 void ddsts_context_error(ddsts_context_t *context, int line, int column, const char *msg);
 void ddsts_context_set_error_func(ddsts_context_t *context, void (*error)(int line, int column, const char *msg));
+void ddsts_context_set_retcode(ddsts_context_t *context, dds_return_t retcode);
 dds_return_t ddsts_context_get_retcode(ddsts_context_t* context);
 ddsts_type_t* ddsts_context_take_root_type(ddsts_context_t *context);
 void ddsts_free_context(ddsts_context_t* context);

--- a/src/tools/idlc/tests/gen_C99.c
+++ b/src/tools/idlc/tests/gen_C99.c
@@ -21,7 +21,7 @@
 static bool test_parse_gen_C99(const char *input, const char *str)
 {
   ddsts_type_t *root_type = NULL;
-  if (idl_parse_string(input, &root_type) != DDS_RETCODE_OK) {
+  if (idl_parse(input, &root_type) != DDS_RETCODE_OK) {
     return false;
   }
 
@@ -41,7 +41,7 @@ static bool test_parse_gen_C99(const char *input, const char *str)
 static bool test_parse_gen_C99_descr(const char *input, const char *name, const char *align, const char *flags)
 {
   ddsts_type_t *root_type = NULL;
-  if (idl_parse_string(input, &root_type) != DDS_RETCODE_OK) {
+  if (idl_parse(input, &root_type) != DDS_RETCODE_OK) {
     return false;
   }
 

--- a/src/tools/idlc/tests/parser.c
+++ b/src/tools/idlc/tests/parser.c
@@ -27,7 +27,7 @@ static bool test_type(ddsts_type_t *type, ddsts_flags_t flags, const char *name,
 static void test_basic_type(const char *idl, ddsts_flags_t flags)
 {
   ddsts_type_t *root_type = NULL;
-  CU_ASSERT(idl_parse_string(idl, &root_type) == DDS_RETCODE_OK);
+  CU_ASSERT(idl_parse(idl, &root_type) == DDS_RETCODE_OK);
   CU_ASSERT(test_type(root_type, DDSTS_MODULE, NULL, NULL, true));
   CU_ASSERT(root_type->module.previous == NULL);
     ddsts_type_t *struct_s = root_type->module.members.first;
@@ -68,7 +68,7 @@ CU_Test(parser, basic_types)
 CU_Test(parser, one_module1)
 {
   ddsts_type_t *root_type = NULL;
-  CU_ASSERT(idl_parse_string("module a{ struct s{char c;};};", &root_type) == DDS_RETCODE_OK);
+  CU_ASSERT(idl_parse("module a{ struct s{char c;};};", &root_type) == DDS_RETCODE_OK);
   CU_ASSERT(test_type(root_type, DDSTS_MODULE, NULL, NULL, true));
   CU_ASSERT(root_type->module.previous == NULL);
     ddsts_type_t *module_a = root_type->module.members.first;
@@ -87,7 +87,7 @@ CU_Test(parser, one_module1)
 CU_Test(parser, reopen_module)
 {
   ddsts_type_t *root_type = NULL;
-  CU_ASSERT(idl_parse_string("module a{ struct s{char c;};}; module a { struct t{char x;};};", &root_type) == DDS_RETCODE_OK);
+  CU_ASSERT(idl_parse("module a{ struct s{char c;};}; module a { struct t{char x;};};", &root_type) == DDS_RETCODE_OK);
   CU_ASSERT(test_type(root_type, DDSTS_MODULE, NULL, NULL, true));
   CU_ASSERT(root_type->module.previous == NULL);
     ddsts_type_t *module_a = root_type->module.members.first;
@@ -120,7 +120,7 @@ CU_Test(parser, reopen_module)
 CU_Test(parser, scoped_name)
 {
   ddsts_type_t *root_type = NULL;
-  CU_ASSERT(idl_parse_string("module a{ struct s{char c;};}; module b { struct t{a::s x;};};", &root_type) == DDS_RETCODE_OK);
+  CU_ASSERT(idl_parse("module a{ struct s{char c;};}; module b { struct t{a::s x;};};", &root_type) == DDS_RETCODE_OK);
   CU_ASSERT(test_type(root_type, DDSTS_MODULE, NULL, NULL, true));
   CU_ASSERT(root_type->module.previous == NULL);
     ddsts_type_t *module_a = root_type->module.members.first;
@@ -149,7 +149,7 @@ CU_Test(parser, scoped_name)
 CU_Test(parser, comma)
 {
   ddsts_type_t *root_type = NULL;
-  CU_ASSERT(idl_parse_string("struct s{char a, b;};", &root_type) == DDS_RETCODE_OK);
+  CU_ASSERT(idl_parse("struct s{char a, b;};", &root_type) == DDS_RETCODE_OK);
   CU_ASSERT(test_type(root_type, DDSTS_MODULE, NULL, NULL, true));
   CU_ASSERT(root_type->module.previous == NULL);
     ddsts_type_t *struct_s = root_type->module.members.first;
@@ -168,7 +168,7 @@ CU_Test(parser, comma)
 CU_Test(parser, types)
 {
   ddsts_type_t *root_type = NULL;
-  CU_ASSERT(idl_parse_string("struct s{sequence<char> us; sequence<char,8> bs; string ust; string<7> bst; wstring uwst; wstring<6> bwst; fixed<5,3> fp; map<short,char> um; map<short,char,5> bm;};", &root_type) == DDS_RETCODE_OK);
+  CU_ASSERT(idl_parse("struct s{sequence<char> us; sequence<char,8> bs; string ust; string<7> bst; wstring uwst; wstring<6> bwst; fixed<5,3> fp; map<short,char> um; map<short,char,5> bm;};", &root_type) == DDS_RETCODE_OK);
   CU_ASSERT(test_type(root_type, DDSTS_MODULE, NULL, NULL, true));
   CU_ASSERT(root_type->module.previous == NULL);
     ddsts_type_t *struct_s = root_type->module.members.first;
@@ -245,7 +245,7 @@ CU_Test(parser, types)
 CU_Test(parser, union)
 {
   ddsts_type_t *root_type = NULL;
-  CU_ASSERT_FATAL(idl_parse_string("union a switch(short) { case 0: short b; case 1: case 4: octet c; default: char d; };", &root_type) == DDS_RETCODE_OK);
+  CU_ASSERT_FATAL(idl_parse("union a switch(short) { case 0: short b; case 1: case 4: octet c; default: char d; };", &root_type) == DDS_RETCODE_OK);
   CU_ASSERT(test_type(root_type, DDSTS_MODULE, NULL, NULL, true));
   CU_ASSERT(root_type->module.previous == NULL);
     ddsts_type_t *union_s = root_type->module.members.first;
@@ -283,7 +283,7 @@ CU_Test(parser, union)
         case_type = union_case->declaration.decl_type;
         CU_ASSERT(test_type(case_type, DDSTS_CHAR, NULL, union_case, true));
   ddsts_free_type(root_type);
-  CU_ASSERT_FATAL(idl_parse_string("union u switch(short) { case 0: short b;}; struct s{u a;};", &root_type) == DDS_RETCODE_OK);
+  CU_ASSERT_FATAL(idl_parse("union u switch(short) { case 0: short b;}; struct s{u a;};", &root_type) == DDS_RETCODE_OK);
   CU_ASSERT(test_type(root_type, DDSTS_MODULE, NULL, NULL, true));
   CU_ASSERT(root_type->module.previous == NULL);
     ddsts_type_t *union_u = root_type->module.members.first;
@@ -311,7 +311,7 @@ CU_Test(parser, union)
 CU_Test(parser, array)
 {
   ddsts_type_t *root_type = NULL;
-  CU_ASSERT(idl_parse_string("struct s{short a[3], b[4][5]; sequence<char> s[6];};", &root_type) == DDS_RETCODE_OK);
+  CU_ASSERT(idl_parse("struct s{short a[3], b[4][5]; sequence<char> s[6];};", &root_type) == DDS_RETCODE_OK);
   CU_ASSERT(test_type(root_type, DDSTS_MODULE, NULL, NULL, true));
   CU_ASSERT(root_type->module.previous == NULL);
     ddsts_type_t *struct_s = root_type->module.members.first;
@@ -349,7 +349,7 @@ CU_Test(parser, array)
 static void test_topic_keys(const char *idl, const char *keystr)
 {
   ddsts_type_t *root_type = NULL;
-  CU_ASSERT(idl_parse_string(idl, &root_type) == DDS_RETCODE_OK);
+  CU_ASSERT(idl_parse(idl, &root_type) == DDS_RETCODE_OK);
   CU_ASSERT(test_type(root_type, DDSTS_MODULE, NULL, NULL, true));
   CU_ASSERT(root_type->module.previous == NULL);
     ddsts_type_t *struct_s = root_type->module.members.first;
@@ -383,7 +383,7 @@ CU_Test(parser, topic_keys)
   test_topic_keys("struct s{ char a; char b;};\n#pragma keylist s a b\n", "ab");
   test_topic_keys("struct s{ char a; char b;};\n#pragma keylist s b a\n", "ba");
   ddsts_type_t *root_type = NULL;
-  CU_ASSERT(idl_parse_string("module a{ struct s{char c;};}; module b { struct t{@key ::a::s x;};};", &root_type) == DDS_RETCODE_OK);
+  CU_ASSERT(idl_parse("module a{ struct s{char c;};}; module b { struct t{@key ::a::s x;};};", &root_type) == DDS_RETCODE_OK);
   CU_ASSERT(test_type(root_type, DDSTS_MODULE, NULL, NULL, true));
     ddsts_type_t *module_a = root_type->module.members.first;
     CU_ASSERT(test_type(module_a, DDSTS_MODULE, "a", root_type, false));
@@ -396,7 +396,7 @@ CU_Test(parser, topic_keys)
       CU_ASSERT(strcmp(struct_t->struct_def.keys->member->type.name, "x") == 0);
   ddsts_free_type(root_type);
   root_type = NULL;
-  CU_ASSERT(idl_parse_string("struct s{@key struct{char x;} a;};", &root_type) == DDS_RETCODE_OK);
+  CU_ASSERT(idl_parse("struct s{@key struct{char x;} a;};", &root_type) == DDS_RETCODE_OK);
   /* verify that the @key is applied to 'a' and not to 'x': */
   CU_ASSERT(test_type(root_type, DDSTS_MODULE, NULL, NULL, true));
     ddsts_type_t *struct_s = root_type->module.members.first;
@@ -415,109 +415,109 @@ CU_Test(parser, errors)
 {
   /* The purpose of these tests is also to verify that all memory is freed correctly */
   ddsts_type_t *root_type = NULL;
-  CU_ASSERT(idl_parse_string(NULL, &root_type) == DDS_RETCODE_BAD_PARAMETER);
   CU_ASSERT(root_type == NULL);
-  CU_ASSERT(idl_parse_string("xyz", NULL) == DDS_RETCODE_BAD_PARAMETER);
+  CU_ASSERT(idl_parse("xyz", &root_type) == DDS_RETCODE_BAD_SYNTAX);
   CU_ASSERT(root_type == NULL);
-  CU_ASSERT(idl_parse_string(NULL, NULL) == DDS_RETCODE_BAD_PARAMETER);
-  CU_ASSERT(root_type == NULL);
-  CU_ASSERT(idl_parse_string("xyz", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(root_type == NULL);
-  CU_ASSERT(idl_parse_string("struct s{char a[3][4];};", &root_type) == DDS_RETCODE_OK);
+  CU_ASSERT(idl_parse("struct s{char a[3][4];};", &root_type) == DDS_RETCODE_OK);
   ddsts_free_type(root_type);
   root_type = NULL;
-  CU_ASSERT(idl_parse_string("struct s{char a[3][4];}", &root_type) == DDS_RETCODE_ERROR);
+  CU_ASSERT(idl_parse("struct s{char a[3][4];}", &root_type) == DDS_RETCODE_BAD_SYNTAX);
   CU_ASSERT(root_type == NULL);
-  CU_ASSERT(idl_parse_string("struct s{char a[3][4];", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{char a[3][4]", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{char a[3][4", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{char a[3][", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{char a[3]", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{char a[3", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{char a[", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{char a;", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{char", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{sequence<char> seqa;}", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{sequence<char> seqa", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{sequence<char>", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{sequence<char", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{sequence<", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{sequence", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{map<char,char> m;}", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{map<char,char> m;", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{map<char,char> m", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{map<char,char> ", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{map<char,char", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{map<char,", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{map<char", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{map<", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{map", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{map<char,char> m;};!", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{map<char,char> m;}!;", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{map<char,char> m;!};", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{map<char,char> m!;};", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{map<char,char> !m;};", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{map<char,char>! m;};", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{map<char,char!> m;};", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{map<char,!char> m;};", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{map<char!,char> m;};", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct v{char c;};struct s{v", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct v{char c;};struct s{sequence<v>", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct v{char c;};struct s{sequence<v", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct v{char c;};struct s{map<v,v", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("union u switch(short) { case 1: char v; case 2: case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("union u switch(short) { case 1: char v; case 2: case 4: short s; default: long x;!}", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("union u switch(short) { case 1: char v; case 2: case 4: short s; default: long x!;}", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("union u switch(short) { case 1: char v; case 2: case 4: short s; default: long !x;}", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("union u switch(short) { case 1: char v; case 2: case 4: short s; default: lo!ng x;}", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("union u switch(short) { case 1: char v; case 2: case 4: short s; default:! long x;}", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("union u switch(short) { case 1: char v; case 2: case 4: short s; default!: long x;}", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("union u switch(short) { case 1: char v; case 2: case 4: short s; defa!ult: long x;}", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("union u switch(short) { case 1: char v; case 2: case 4: short s;! default: long x;}", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("union u switch(short) { case 1: char v; case 2: case 4: short s!; default: long x;}", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("union u switch(short) { case 1: char v; case 2: case 4: short! s; default: long x;}", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("union u switch(short) { case 1: char v; case 2: case 4:! short s; default: long x;}", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("union u switch(short) { case 1: char v; case 2: case! 4: short s; default: long x;}", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("union u switch(short) { case 1: char v; case 2:! case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("union u switch(short) { case 1: char v; case 2!: case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("union u switch(short) { case 1: char v; case! 2: case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("union u switch(short) { case 1: char v;! case 2: case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("union u switch(short) { case 1: char v!; case 2: case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("union u switch(short) { case 1: char! v; case 2: case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("union u switch(short) { case 1:! char v; case 2: case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("union u switch(short) { case 1!: char v; case 2: case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("union u switch(short) { case! 1: char v; case 2: case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("union u switch(short) {! case 1: char v; case 2: case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("union u switch(short)! { case 1: char v; case 2: case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("union u switch(short!) { case 1: char v; case 2: case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("union u switch(sh!ort) { case 1: char v; case 2: case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("union u switch(!short) { case 1: char v; case 2: case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("union u switch!(short) { case 1: char v; case 2: case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("union u sw!itch(short) { case 1: char v; case 2: case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("union u! switch(short) { case 1: char v; case 2: case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("union! u switch(short) { case 1: char v; case 2: case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("union u switch(short) { case 1: char v; case 4: case 1: short s; default: long x;};", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{@key string a[4];};", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{@key sequence<char> a;};", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{@key struct{sequence<char> cs;} a;};", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{@key @key char c;};", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{char c;};\n#pragma keylis\n", &root_type) == DDS_RETCODE_OK);
+  CU_ASSERT(idl_parse("struct s{char a[3][4];", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct s{char a[3][4]", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct s{char a[3][4", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct s{char a[3][", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct s{char a[3]", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct s{char a[3", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct s{char a[", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct s{char a;", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct s{char", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct s{sequence<char> seqa;}", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct s{sequence<char> seqa", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct s{sequence<char>", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct s{sequence<char", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct s{sequence<", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct s{sequence", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct s{", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct s", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct s{map<char,char> m;}", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct s{map<char,char> m;", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct s{map<char,char> m", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct s{map<char,char> ", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct s{map<char,char", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct s{map<char,", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct s{map<char", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct s{map<", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct s{map", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct s{map<char,char> m;};!", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct s{map<char,char> m;}!;", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct s{map<char,char> m;!};", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct s{map<char,char> m!;};", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct s{map<char,char> !m;};", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct s{map<char,char>! m;};", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct s{map<char,char!> m;};", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct s{map<char,!char> m;};", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct s{map<char!,char> m;};", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct v{char c;};struct s{v", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct v{char c;};struct s{sequence<v>", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct v{char c;};struct s{sequence<v", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct v{char c;};struct s{map<v,v", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("union u switch(short) { case 1: char v; case 2: case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("union u switch(short) { case 1: char v; case 2: case 4: short s; default: long x;!}", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("union u switch(short) { case 1: char v; case 2: case 4: short s; default: long x!;}", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("union u switch(short) { case 1: char v; case 2: case 4: short s; default: long !x;}", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("union u switch(short) { case 1: char v; case 2: case 4: short s; default: lo!ng x;}", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("union u switch(short) { case 1: char v; case 2: case 4: short s; default:! long x;}", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("union u switch(short) { case 1: char v; case 2: case 4: short s; default!: long x;}", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("union u switch(short) { case 1: char v; case 2: case 4: short s; defa!ult: long x;}", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("union u switch(short) { case 1: char v; case 2: case 4: short s;! default: long x;}", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("union u switch(short) { case 1: char v; case 2: case 4: short s!; default: long x;}", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("union u switch(short) { case 1: char v; case 2: case 4: short! s; default: long x;}", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("union u switch(short) { case 1: char v; case 2: case 4:! short s; default: long x;}", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("union u switch(short) { case 1: char v; case 2: case! 4: short s; default: long x;}", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("union u switch(short) { case 1: char v; case 2:! case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("union u switch(short) { case 1: char v; case 2!: case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("union u switch(short) { case 1: char v; case! 2: case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("union u switch(short) { case 1: char v;! case 2: case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("union u switch(short) { case 1: char v!; case 2: case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("union u switch(short) { case 1: char! v; case 2: case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("union u switch(short) { case 1:! char v; case 2: case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("union u switch(short) { case 1!: char v; case 2: case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("union u switch(short) { case! 1: char v; case 2: case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("union u switch(short) {! case 1: char v; case 2: case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("union u switch(short)! { case 1: char v; case 2: case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("union u switch(short!) { case 1: char v; case 2: case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("union u switch(sh!ort) { case 1: char v; case 2: case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("union u switch(!short) { case 1: char v; case 2: case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("union u switch!(short) { case 1: char v; case 2: case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("union u sw!itch(short) { case 1: char v; case 2: case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("union u! switch(short) { case 1: char v; case 2: case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("union! u switch(short) { case 1: char v; case 2: case 4: short s; default: long x;}", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("union u switch(short) { case 1: char v; case 4: case 1: short s; default: long x;};", &root_type) == DDS_RETCODE_ERROR);
+  CU_ASSERT(idl_parse("struct s{@key string a[4];};", &root_type) == DDS_RETCODE_ERROR);
+  CU_ASSERT(idl_parse("struct s{@key sequence<char> a;};", &root_type) == DDS_RETCODE_ERROR);
+  CU_ASSERT(idl_parse("struct s{@key struct{sequence<char> cs;} a;};", &root_type) == DDS_RETCODE_ERROR);
+  CU_ASSERT(idl_parse("struct s{@key @key char c;};", &root_type) == DDS_RETCODE_ERROR);
+  /* Unsupported pragma directives are ignored */
+  CU_ASSERT(idl_parse("struct s{char c;};\n#pragma keylis\n", &root_type) == DDS_RETCODE_OK);
   ddsts_free_type(root_type);
   root_type = NULL;
-  CU_ASSERT(idl_parse_string("struct s{char c;};\n#pragma keylist\n", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{char c;};\n#pragma keylist v\n", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{char c;};\n#pragma keylist s\n", &root_type) == DDS_RETCODE_OK);
+  CU_ASSERT(idl_parse("struct s{char c;};\n#pragma keylist\n", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("struct s{char c;};\n#pragma keylist v\n", &root_type) == DDS_RETCODE_ERROR);
+  CU_ASSERT(idl_parse("struct s{char c;};\n#pragma keylist s\n", &root_type) == DDS_RETCODE_OK);
   ddsts_free_type(root_type);
   root_type = NULL;
-  CU_ASSERT(idl_parse_string("struct s{char c;};\n#pragma keylist s v\n", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{char c;};\n#pragma keylist s c c\n", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct s{@key char c; char d;};\n#pragma keylist s d\n", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("module a{ struct s{char c;};}; module b { struct t{@ key a::s x;};};", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("module a{ struct s{char c;};}; module b { struct t{@key a ::s x;};};", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("module a{ struct s{char c;};}; module b { struct t{@key a:: s x;};};", &root_type) == DDS_RETCODE_ERROR);
-  CU_ASSERT(idl_parse_string("struct v;struct s{v a;};struct v{char x;};", &root_type) == DDS_RETCODE_ERROR);
+  CU_ASSERT(idl_parse("struct s{char c;};\n#pragma keylist s v\n", &root_type) == DDS_RETCODE_ERROR);
+  CU_ASSERT(idl_parse("struct s{char c;};\n#pragma keylist s c c\n", &root_type) == DDS_RETCODE_ERROR);
+  CU_ASSERT(idl_parse("struct s{@key char c; char d;};\n#pragma keylist s d\n", &root_type) == DDS_RETCODE_ERROR);
+  CU_ASSERT(idl_parse("module a{ struct s{char c;};}; module b { struct t{@ key a::s x;};};", &root_type) == DDS_RETCODE_BAD_SYNTAX);
+  CU_ASSERT(idl_parse("module a{ struct s{char c;};}; module b { struct t{@key a ::s x;};};", &root_type) == DDS_RETCODE_OK);
+  ddsts_free_type(root_type);
+  root_type = NULL;
+  CU_ASSERT(idl_parse("module a{ struct s{char c;};}; module b { struct t{@key a:: s x;};};", &root_type) == DDS_RETCODE_OK);
+  ddsts_free_type(root_type);
+  root_type = NULL;
+  CU_ASSERT(idl_parse("struct v;struct s{v a;};struct v{char x;};", &root_type) == DDS_RETCODE_ERROR);
 }
 

--- a/src/tools/idlpp/src/internal.H
+++ b/src/tools/idlpp/src/internal.H
@@ -366,7 +366,7 @@ extern int      in_define;          /* In #define line              */
 extern int      in_getarg;          /* Collecting arguments of macro*/
 extern int      in_include;         /* In #include line             */
 extern int      in_if;              /* In #if and non-skipped expr. */
-ssize_t         macro_line;         /* Line number of macro call    */
+extern ssize_t  macro_line;         /* Line number of macro call    */
 extern char *   macro_name;         /* Currently expanding macro    */
 extern int      openum;             /* Number of operator or punct. */
 extern IFINFO *     ifptr;          /* -> current ifstack item      */


### PR DESCRIPTION
This PR ties the preprocessor to the IDL compiler created by @FransFaase to make it at least a somewhat usable tool (it actually works :wink:).

To do so I added `ddsrt_vasprintf` and added the `DDS_RETCODE_BAD_SYNTAX` return code to `ddsrt`. Apart from that I fixed handling of `@key` and annotations in general and moved handling of compiler directives (just `#pragma keylist` for now) to the right location.

While there's still much ground to cover, all the basics are now in place and all-in-all this marks the first actual working version of `idlc`.

@eboasson, if you can find the time, please skim the changes before I merge them into the `xtypes` branch.