### PR TITLE
Make really short liveliness settings work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -215,7 +215,7 @@ script:
         ${SCAN_BUILD} cmake --build . --config ${BUILD_TYPE} --target install
         ;;
     esac
-  - CYCLONEDDS_URI='<CycloneDDS><Domain><Internal><EnableExpensiveChecks>all</EnableExpensiveChecks></Internal><Tracing><Verbosity>config</Verbosity><OutputFile>stderr</OutputFile></Tracing></Domain></CycloneDDS>' ctest -j 4 --output-on-failure -T test -E '^CUnit_ddsrt_random_default_random$' -C ${BUILD_TYPE}
+  - CYCLONEDDS_URI='<CycloneDDS><Domain><Internal><EnableExpensiveChecks>all</EnableExpensiveChecks><LivelinessMonitoring>true</LivelinessMonitoring></Internal><Tracing><Verbosity>config</Verbosity><OutputFile>stderr</OutputFile></Tracing></Domain></CycloneDDS>' ctest -j 4 --output-on-failure -T test -E '^CUnit_ddsrt_random_default_random$' -C ${BUILD_TYPE}
   - if [ "${ASAN}" != "none" ]; then
       CMAKE_LINKER_FLAGS="-DCMAKE_LINKER_FLAGS=-fsanitize=${USE_SANITIZER}";
       CMAKE_C_FLAGS="-DCMAKE_C_FLAGS=-fsanitize=${USE_SANITIZER}";

--- a/src/core/ddsc/src/dds__writer.h
+++ b/src/core/ddsc/src/dds__writer.h
@@ -23,6 +23,7 @@ DEFINE_ENTITY_LOCK_UNLOCK(inline, dds_writer, DDS_KIND_WRITER)
 struct status_cb_data;
 
 void dds_writer_status_cb (void *entity, const struct status_cb_data * data);
+dds_return_t dds__writer_wait_for_acks (struct dds_writer *wr, dds_time_t abstimeout);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsc/src/dds_publisher.c
+++ b/src/core/ddsc/src/dds_publisher.c
@@ -15,6 +15,7 @@
 #include "dds__listener.h"
 #include "dds__participant.h"
 #include "dds__publisher.h"
+#include "dds__writer.h"
 #include "dds__qos.h"
 #include "dds/ddsi/ddsi_iid.h"
 #include "dds/ddsi/q_entity.h"
@@ -94,10 +95,33 @@ dds_return_t dds_resume (dds_entity_t publisher)
 
 dds_return_t dds_wait_for_acks (dds_entity_t publisher_or_writer, dds_duration_t timeout)
 {
+  dds_return_t ret;
+  dds_entity *p_or_w_ent;
+
   if (timeout < 0)
     return DDS_RETCODE_BAD_PARAMETER;
-  static const dds_entity_kind_t kinds[] = { DDS_KIND_WRITER, DDS_KIND_PUBLISHER };
-  return dds_generic_unimplemented_operation_manykinds (publisher_or_writer, sizeof (kinds) / sizeof (kinds[0]), kinds);
+
+  if ((ret = dds_entity_pin (publisher_or_writer, &p_or_w_ent)) < 0)
+    return ret;
+
+  const dds_time_t tnow = dds_time ();
+  const dds_time_t abstimeout = (DDS_INFINITY - timeout <= tnow) ? DDS_NEVER : (tnow + timeout);
+  switch (dds_entity_kind (p_or_w_ent))
+  {
+    case DDS_KIND_PUBLISHER:
+      /* FIXME: wait_for_acks on all writers of the same publisher */
+      dds_entity_unpin (p_or_w_ent);
+      return DDS_RETCODE_UNSUPPORTED;
+
+    case DDS_KIND_WRITER:
+      ret = dds__writer_wait_for_acks ((struct dds_writer *) p_or_w_ent, abstimeout);
+      dds_entity_unpin (p_or_w_ent);
+      return ret;
+
+    default:
+      dds_entity_unpin (p_or_w_ent);
+      return DDS_RETCODE_ILLEGAL_OPERATION;
+  }
 }
 
 dds_return_t dds_publisher_begin_coherent (dds_entity_t publisher)

--- a/src/core/ddsc/src/dds_writer.c
+++ b/src/core/ddsc/src/dds_writer.c
@@ -379,6 +379,16 @@ dds_entity_t dds_get_publisher (dds_entity_t writer)
   }
 }
 
+dds_return_t dds__writer_wait_for_acks (struct dds_writer *wr, dds_time_t abstimeout)
+{
+  /* during lifetime of the writer m_wr is constant, it is only during deletion that it
+     gets erased at some point */
+  if (wr->m_wr == NULL)
+    return DDS_RETCODE_OK;
+  else
+    return writer_wait_for_acks (wr->m_wr, abstimeout);
+}
+
 DDS_GET_STATUS(writer, publication_matched, PUBLICATION_MATCHED, total_count_change, current_count_change)
 DDS_GET_STATUS(writer, liveliness_lost, LIVELINESS_LOST, total_count_change)
 DDS_GET_STATUS(writer, offered_deadline_missed, OFFERED_DEADLINE_MISSED, total_count_change)

--- a/src/core/ddsc/tests/unsupported.c
+++ b/src/core/ddsc/tests/unsupported.c
@@ -84,21 +84,6 @@ CU_Test(ddsc_unsupported, dds_begin_end_coherent, .init = setup, .fini = teardow
     }
 }
 
-CU_Test(ddsc_unsupported, dds_wait_for_acks, .init = setup, .fini = teardown)
-{
-    dds_return_t result;
-    static struct index_result pars[] = {
-        {PUB, DDS_RETCODE_UNSUPPORTED},
-        {WRI, DDS_RETCODE_UNSUPPORTED},
-        {BAD, DDS_RETCODE_BAD_PARAMETER}
-    };
-
-    for (size_t i=0; i < sizeof (pars) / sizeof (pars[0]);i++) {
-        result = dds_wait_for_acks(e[pars[i].index], 0);
-        CU_ASSERT_EQUAL(result, pars[i].exp_res);
-    }
-}
-
 CU_Test(ddsc_unsupported, dds_suspend_resume, .init = setup, .fini = teardown)
 {
     dds_return_t result;

--- a/src/core/ddsi/include/dds/ddsi/q_entity.h
+++ b/src/core/ddsi/include/dds/ddsi/q_entity.h
@@ -240,7 +240,7 @@ struct writer
   struct endpoint_common c;
   status_cb_t status_cb;
   void * status_cb_entity;
-  ddsrt_cond_t throttle_cond; /* used to trigger a transmit thread blocked in throttle_writer() */
+  ddsrt_cond_t throttle_cond; /* used to trigger a transmit thread blocked in throttle_writer() or wait_for_acks() */
   seqno_t seq; /* last sequence number (transmitted seqs are 1 ... seq) */
   seqno_t cs_seq; /* 1st seq in coherent set (or 0) */
   seq_xmit_t seq_xmit; /* last sequence number actually transmitted */
@@ -605,6 +605,7 @@ seqno_t writer_max_drop_seq (const struct writer *wr);
 int writer_must_have_hb_scheduled (const struct writer *wr, const struct whc_state *whcst);
 void writer_set_retransmitting (struct writer *wr);
 void writer_clear_retransmitting (struct writer *wr);
+dds_return_t writer_wait_for_acks (struct writer *wr, dds_time_t abstimeout);
 
 dds_return_t unblock_throttled_writer (struct q_globals *gv, const struct ddsi_guid *guid);
 dds_return_t delete_writer (struct q_globals *gv, const struct ddsi_guid *guid);

--- a/src/core/ddsi/include/dds/ddsi/q_entity.h
+++ b/src/core/ddsi/include/dds/ddsi/q_entity.h
@@ -676,7 +676,6 @@ void update_proxy_writer (struct proxy_writer *pwr, seqno_t seq, struct addrset 
 
 void proxy_writer_set_alive_may_unlock (struct proxy_writer *pwr, bool notify);
 int proxy_writer_set_notalive (struct proxy_writer *pwr, bool notify);
-void proxy_writer_set_notalive_guid (struct q_globals *gv, const struct ddsi_guid *pwrguid, bool notify);
 
 int new_proxy_group (const struct ddsi_guid *guid, const char *name, const struct dds_qos *xqos, nn_wctime_t timestamp);
 

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -4510,20 +4510,6 @@ int proxy_writer_set_notalive (struct proxy_writer *pwr, bool notify)
   return DDS_RETCODE_OK;
 }
 
-void proxy_writer_set_notalive_guid (struct q_globals *gv, const struct ddsi_guid *pwrguid, bool notify)
-{
-  struct proxy_writer *pwr;
-  if ((pwr = entidx_lookup_proxy_writer_guid (gv->entity_index, pwrguid)) == NULL)
-    GVLOGDISC (" "PGUIDFMT"?\n", PGUID (*pwrguid));
-  else
-  {
-    GVLOGDISC ("proxy_writer_set_notalive_guid ("PGUIDFMT")", PGUID (*pwrguid));
-    if (proxy_writer_set_notalive (pwr, notify) == DDS_RETCODE_PRECONDITION_NOT_MET)
-      GVLOGDISC (" pwr was not alive");
-    GVLOGDISC ("\n");
-  }
-}
-
 /* PROXY-READER ----------------------------------------------------- */
 
 int new_proxy_reader (struct q_globals *gv, const struct ddsi_guid *ppguid, const struct ddsi_guid *guid, struct addrset *as, const nn_plist_t *plist, nn_wctime_t timestamp, seqno_t seq

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -4478,8 +4478,13 @@ void proxy_writer_set_alive_may_unlock (struct proxy_writer *pwr, bool notify)
   ddsrt_mutex_lock (&pwr->c.proxypp->e.lock);
   pwr->alive = true;
   pwr->alive_vclock++;
-  if (pwr->c.xqos->liveliness.lease_duration != T_NEVER && pwr->c.xqos->liveliness.kind != DDS_LIVELINESS_MANUAL_BY_TOPIC)
-    proxy_participant_add_pwr_lease_locked (pwr->c.proxypp, pwr);
+  if (pwr->c.xqos->liveliness.lease_duration != T_NEVER)
+  {
+    if (pwr->c.xqos->liveliness.kind != DDS_LIVELINESS_MANUAL_BY_TOPIC)
+      proxy_participant_add_pwr_lease_locked (pwr->c.proxypp, pwr);
+    else
+      lease_set_expiry (pwr->lease, add_duration_to_etime (now_et (), pwr->lease->tdur));
+  }
   ddsrt_mutex_unlock (&pwr->c.proxypp->e.lock);
 
   if (notify)

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -3845,13 +3845,15 @@ void new_proxy_participant (struct q_globals *gv, const struct ddsi_guid *ppguid
     nn_plist_fini (&plist_rd);
   }
 
+  /* write DCPSParticipant topic before the lease can expire */
+  builtintopic_write (gv->builtin_topic_interface, &proxypp->e, timestamp, true);
+
   /* Register lease for auto liveliness, but be careful not to accidentally re-register
      DDSI2's lease, as we may have become dependent on DDSI2 any time after
      entidx_insert_proxy_participant_guid even if privileged_pp_guid was NULL originally */
   ddsrt_mutex_lock (&proxypp->e.lock);
   if (proxypp->owns_lease)
     lease_register (ddsrt_atomic_ldvoidp (&proxypp->minl_auto));
-  builtintopic_write (gv->builtin_topic_interface, &proxypp->e, timestamp, true);
   ddsrt_mutex_unlock (&proxypp->e.lock);
 }
 

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -957,7 +957,7 @@ int rtps_init (struct q_globals *gv)
   {
     if (!gv->interfaces[gv->selected_interface].mc_capable)
     {
-      GVWARNING ("selected interface is not multicast-capable: disabling multicast\n");
+      GVWARNING ("selected interface \"%s\" is not multicast-capable: disabling multicast\n", gv->interfaces[gv->selected_interface].name);
       gv->config.allowMulticast = AMC_FALSE;
       /* ensure discovery can work: firstly, that the process will be reachable on a "well-known" port
          number, and secondly, that the local interface's IP address gets added to the discovery

--- a/src/core/ddsi/src/q_lease.c
+++ b/src/core/ddsi/src/q_lease.c
@@ -281,7 +281,7 @@ int64_t check_and_handle_lease_expiration (struct q_globals *gv, nn_etime_t tnow
         delete_proxy_participant_by_guid (gv, &g, now(), 1);
         break;
       case EK_PROXY_WRITER:
-        proxy_writer_set_notalive_guid (gv, &g, true);
+        proxy_writer_set_notalive ((struct proxy_writer *) l->entity, true);
         break;
       case EK_PARTICIPANT:
       case EK_READER:


### PR DESCRIPTION
This PR was caused by pondering the wisdom of #368: is it wise to rewrite a lease duration of 0 received via discovery in some specific case? There are solid arguments against it:
* Endpoint matching takes lease durations into account, so rewriting it can result in two endpoints no longer matching;
* There is a valid argument in favour of supporting (and even optimising) lease_duration = 0, which is that it effectively eliminates the distinction between the "alive" and "not-alive-no-writers" states in an instance. That in turn affects eventual consistency-after-reconnect.

The problem intended to be addressed #368 being a very narrow one and the wisdom being doubtful, a wiser approach is to make sure a writer lease duration of 0 is handled correctly. Testing a automatic one is next to impossible (because it forces infinitely fast updates of the participants liveliness) so instead some checks in manual mode seemed to be in order.

This PR thus introduces such a test and some more-or-less related changes:

* A proxy-writer lease expiry during the creation of the proxy writer object could result in the proxy-writer not being marked "not alive" because the object might not yet be accessible via the GUID. Using the entity pointer that's embedded in the lease instead of looking it up via the GUID (retrieved using that pointer!) solves the problem.
* A manual-by-topic proxy writer did transition correctly to not-alive after expiry of the deadline, and did correctly transition back to alive on the receipt of a sample. However, it did not restart the deadline and so would then stay alive indefinitely.
* I found it sensible to use ``dds_wait_for_acks`` in the test code, so it now works for writers. The intent is that it can also be called on a publisher, where it would mean to wait on all the publishers writers in parallel, but that I haven't implemented yet. (Also, the testing is rather minimal ...)
* I suddenly realised that the warning ``selected interface is not multicast-capable: disabling multicast`` would be much improved if the name of the selected interface were to be included ...