### PR TITLE
Liveliness local readers

### DIFF
--- a/src/core/ddsc/src/dds_reader.c
+++ b/src/core/ddsc/src/dds_reader.c
@@ -254,9 +254,8 @@ void dds_reader_status_cb (void *ventity, const status_cb_data_t *data)
                            LIVELINESS_CHANGED_REMOVE_NOT_ALIVE < LIVELINESS_CHANGED_REMOVE_ALIVE &&
                            LIVELINESS_CHANGED_REMOVE_ALIVE < LIVELINESS_CHANGED_ALIVE_TO_NOT_ALIVE &&
                            LIVELINESS_CHANGED_ALIVE_TO_NOT_ALIVE < LIVELINESS_CHANGED_NOT_ALIVE_TO_ALIVE &&
-                           LIVELINESS_CHANGED_NOT_ALIVE_TO_ALIVE < LIVELINESS_CHANGED_TWITCH &&
-                           (uint32_t) LIVELINESS_CHANGED_TWITCH < UINT32_MAX);
-      assert (data->extra <= (uint32_t) LIVELINESS_CHANGED_TWITCH);
+                           (uint32_t) LIVELINESS_CHANGED_NOT_ALIVE_TO_ALIVE < UINT32_MAX);
+      assert (data->extra <= (uint32_t) LIVELINESS_CHANGED_NOT_ALIVE_TO_ALIVE);
       switch ((enum liveliness_changed_data_extra) data->extra)
       {
         case LIVELINESS_CHANGED_ADD_ALIVE:
@@ -286,8 +285,6 @@ void dds_reader_status_cb (void *ventity, const status_cb_data_t *data)
           st->not_alive_count_change--;
           st->alive_count++;
           st->alive_count_change++;
-          break;
-        case LIVELINESS_CHANGED_TWITCH:
           break;
       }
       st->last_publication_handle = data->handle;

--- a/src/core/ddsi/src/ddsi_pmd.c
+++ b/src/core/ddsi/src/ddsi_pmd.c
@@ -49,12 +49,17 @@ static void debug_print_rawdata (const struct q_globals *gv, const char *msg, co
 void write_pmd_message_guid (struct q_globals * const gv, struct ddsi_guid *pp_guid, unsigned pmd_kind)
 {
   struct thread_state1 * const ts1 = lookup_thread_state ();
+  struct lease *lease;
   thread_state_awake (ts1, gv);
   struct participant *pp = entidx_lookup_participant_guid (gv->entity_index, pp_guid);
   if (pp == NULL)
     GVTRACE ("write_pmd_message("PGUIDFMT") - builtin pmd writer not found\n", PGUID (*pp_guid));
   else
+  {
+    if ((lease = ddsrt_atomic_ldvoidp (&pp->minl_man)) != NULL)
+      lease_renew (lease, now_et());
     write_pmd_message (ts1, NULL, pp, pmd_kind);
+  }
   thread_state_asleep (ts1);
 }
 

--- a/src/core/ddsi/src/q_receive.c
+++ b/src/core/ddsi/src/q_receive.c
@@ -1121,7 +1121,8 @@ static int handle_Heartbeat (struct receiver_state *rst, nn_etime_t tnow, struct
   dst.prefix = rst->dst_guid_prefix;
   dst.entityid = msg->readerId;
 
-  RSTTRACE ("HEARTBEAT(%s#%"PRId32":%"PRId64"..%"PRId64" ", msg->smhdr.flags & HEARTBEAT_FLAG_FINAL ? "F" : "", msg->count, firstseq, lastseq);
+  RSTTRACE ("HEARTBEAT(%s%s#%"PRId32":%"PRId64"..%"PRId64" ", msg->smhdr.flags & HEARTBEAT_FLAG_FINAL ? "F" : "",
+    msg->smhdr.flags & HEARTBEAT_FLAG_LIVELINESS ? "L" : "", msg->count, firstseq, lastseq);
 
   if (!rst->forme)
   {
@@ -1139,7 +1140,7 @@ static int handle_Heartbeat (struct receiver_state *rst, nn_etime_t tnow, struct
   RSTTRACE (PGUIDFMT" -> "PGUIDFMT":", PGUID (src), PGUID (dst));
   ddsrt_mutex_lock (&pwr->e.lock);
   if (msg->smhdr.flags & HEARTBEAT_FLAG_LIVELINESS &&
-      pwr->c.xqos->liveliness.kind == DDS_LIVELINESS_MANUAL_BY_TOPIC &&
+      pwr->c.xqos->liveliness.kind != DDS_LIVELINESS_AUTOMATIC &&
       pwr->c.xqos->liveliness.lease_duration != T_NEVER)
   {
     if ((lease = ddsrt_atomic_ldvoidp (&pwr->c.proxypp->minl_man)) != NULL)

--- a/src/tools/decode-trace
+++ b/src/tools/decode-trace
@@ -36,6 +36,7 @@ for (@showopts) {
 my $topfmt = "%${topcolwidth}.${topcolwidth}s";
 my $guidre = "[0-9a-f]+(?::[0-9a-f]+){3}";
 my $gidre = "[0-9a-f]+(?::[0-9a-f]+){2}";
+my $leasere = "(?:L\\((?:[a-z]+ )?[0-9a-f:]+\\s+[0-9.]+\\)\\s*)+";
 my %opstr = ("00" => "R  ", "01" => "W  ", # index by $stinfo.$dflag
              "10" => " D ", "11" => "WD ",
              "20" => "  U", "21" => "W U",
@@ -258,7 +259,7 @@ while(<>) {
   # decent proxy for that.
   #
   # FIXME: find a way of dealing with decimal representation ...
-  if (/: ACKNACK\(F?#\d+:(\d+)\/(\d+):[01]* (?:L\([0-9a-f:]+\s+[0-9.]+\)\s*)?([0-9a-f]+(?::[0-9a-f]+){2}:[234]c7) -\> ([0-9a-f]+(?::[0-9a-f]+){2}:[234]c2) .*?(happy-now)?/) {
+  if (/: ACKNACK\(F?#\d+:(\d+)\/(\d+):[01]* (?:$leasere)?([0-9a-f]+(?::[0-9a-f]+){2}:[234]c7) -\> ([0-9a-f]+(?::[0-9a-f]+){2}:[234]c2) .*?(happy-now)?/) {
     if (defined $5 || ($1 > 1 && $2 == 0 && version_at_least(6,6,4))) {
       # happy-now should be enough, but historically DDSI2 advertised only data present in the WHC,
       # which caused happy-now to not show up if the historical data ended on an unregister, because
@@ -266,7 +267,7 @@ while(<>) {
       # last one written (that is, unregistered) (fixed in 6.6.4)
       check_disccomplete("A", $3);
     }
-  } elsif (/: HEARTBEAT\(F?#\d+:(\d+)\.\.(\d+)\s+(?:L\([0-9a-f:]+\s+[0-9.]+\)\s*)?([0-9a-f]+(?::[0-9a-f]+){2}:[234]c2)/) {
+  } elsif (/: HEARTBEAT\(F?L?#\d+:(\d+)\.\.(\d+)\s+(?:$leasere)?([0-9a-f]+(?::[0-9a-f]+){2}:[234]c2)/) {
     check_disccomplete("H", $3);
     # if there is no data and final is set there might be no ACK
     check_disccomplete("B", $3) if $2 < $1;
@@ -745,7 +746,7 @@ while(<>) {
         if $nlost > 0 && $shows{rematch};
       delete $prd->{matches}->{$wrguid}->{seqp1del};
     }
-  } elsif (/ACKNACK\(F?#\d+:(\d+)\/\d+:([01]*) (?:L\(:1c1 [0-9.]+\) )?($guidre) -> ($guidre)(\??)/o) {
+  } elsif (/ACKNACK\(F?#\d+:(\d+)\/\d+:([01]*) (?:$leasere)?($guidre) -> ($guidre)(\??)/o) {
     my $seqp1 = $1; my $nackset = $2; my $prdguid = hexify($3); my $wrguid = hexify($4); my $wrknown = ($5 eq "");
     my $wr = $wr{$wrguid};
     my $cnt = ($nackset =~ y/1//);
@@ -904,7 +905,7 @@ while(<>) {
         }
       }
     }
-  } elsif (/HEARTBEAT\(F?#\d+:(\d+)\.\.(\d+) ($guidre)/o) {
+  } elsif (/HEARTBEAT\(F?L?#\d+:(\d+)\.\.(\d+) ($guidre)/o) {
     my $prdguid = hexify($3);
     (my $ppguid = $prdguid) =~ s/:[0-9a-f]+$/:1c1/;
     $proxypp{$ppguid}->{non_spdp_seen} = 1 if exists $proxypp{$ppguid} && !defined $proxypp{$ppguid}->{tdel};
@@ -1475,7 +1476,7 @@ not necessarily the 4th field in, say, AWK):
 EOT
     ;
   exit 1;
-  return; 
+  return;
 }
 
 sub fmtblurb {


### PR DESCRIPTION
This PR adds support for liveliness QoS when using local readers. The implementation for (liveliness) expiration of writers used here is similar to that used with proxy writers, and it also supports the three liveliness kinds (1) automatic, which is trivial when using a local reader and writer, (2) manual-by-participant and (3) manual-by-topic.

In addition, these changes and fixes are included:
- Fixed a bug in heartbeat handling in the reader: for manual-by-participant writers the lease was not updated on reception of a heartbeat message with liveliness flag set. This is fixed and a test-case is added.
- Include the liveliness flag in a heartbeat message to the trace 
- Trace all lease renewals, including liveliness leases
- Replaced liveliness changed state 'twitch' by 2 subsequent calls to the status callback
- Added a test for liveliness duration 0 and 1ns (for both local and remote readers)