### PR TITLE
Add support for musl libc

### DIFF
--- a/src/core/ddsi/src/sysdeps.c
+++ b/src/core/ddsi/src/sysdeps.c
@@ -18,7 +18,7 @@
 #include "dds/ddsi/q_log.h"
 #include "dds/ddsi/sysdeps.h"
 
-#if DDSRT_WITH_FREERTOS || !(defined __APPLE__ || defined __linux) || (__GNUC__ > 0 && (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) < 40100)
+#if DDSRT_WITH_FREERTOS || !(defined __APPLE__ || (defined __linux && (defined __GLIBC__ || defined __UCLIBC__))) || (__GNUC__ > 0 && (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) < 40100)
 void log_stacktrace (const struct ddsrt_log_cfg *logcfg, const char *name, ddsrt_thread_t tid)
 {
   DDSRT_UNUSED_ARG (name);


### PR DESCRIPTION
This PR adds (at least partial) support for [musl libc](https://www.musl-libc.org/). It basically entails:
* Disabling support for `log_stacktrace` on Linux except when glibc or μClibc is used.
* Switching from `pthread_getname_np` to `prctl` to retrieve the name of the calling thread.

The work is loosely based on a patch by @mauropasse (issue #383).