### PR TITLE
Unable to run CycloneDDS because of locale issue in Windows.

### DIFF
--- a/src/ddsrt/src/ifaddrs/windows/ifaddrs.c
+++ b/src/ddsrt/src/ifaddrs/windows/ifaddrs.c
@@ -189,10 +189,14 @@ copyaddr(
   if ((ifa = ddsrt_calloc_s(1, sizeof(*ifa))) == NULL) {
     err = DDS_RETCODE_OUT_OF_RESOURCES;
   } else {
+    size_t namelen = wcslen(iface->FriendlyName);
     ifa->flags = getflags(iface);
     ifa->type = guess_iftype(iface);
     ifa->addr = ddsrt_memdup(sa, sz);
-    (void)ddsrt_asprintf(&ifa->name, "%wS", iface->FriendlyName);
+    ifa->name = ddsrt_malloc(namelen + 1);
+    if (ifa->name != NULL) {
+      wcstombs(ifa->name, iface->FriendlyName, namelen);
+    }
     if (ifa->addr == NULL || ifa->name == NULL) {
       err = DDS_RETCODE_OUT_OF_RESOURCES;
     } else if (ifa->addr->sa_family == AF_INET6) {


### PR DESCRIPTION
The problem is about CycloneDDS running on Windows.
`ddsrt_asprintf` will not malloc memory for `ifa->name` while `iface->FriendlyName` is not English.
(In my case, `iface->FriendlyName` is traditional Chinese.)
This will cause CycloneDDS unable to work because `ifa->name == NULL`.
Therefore, I allocate the memory first and then call `wcstombs` to transform wide char into char.