### PR TITLE
Retention of samples in keep-last WHC + running ddsperf on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -216,6 +216,9 @@ script:
         ;;
     esac
   - CYCLONEDDS_URI='<CycloneDDS><Domain><Internal><EnableExpensiveChecks>all</EnableExpensiveChecks><LivelinessMonitoring>true</LivelinessMonitoring></Internal><Tracing><Verbosity>config</Verbosity><OutputFile>stderr</OutputFile></Tracing></Domain></CycloneDDS>' ctest -j 4 --output-on-failure -T test -E '^CUnit_ddsrt_random_default_random$' -C ${BUILD_TYPE}
+  - if [ "${ASAN}" = "none" ]; then
+      ${SHELL} ../src/tools/ddsperf/sanity.bash;
+    fi
   - if [ "${ASAN}" != "none" ]; then
       CMAKE_LINKER_FLAGS="-DCMAKE_LINKER_FLAGS=-fsanitize=${USE_SANITIZER}";
       CMAKE_C_FLAGS="-DCMAKE_C_FLAGS=-fsanitize=${USE_SANITIZER}";

--- a/src/core/ddsc/src/dds_whc.c
+++ b/src/core/ddsc/src/dds_whc.c
@@ -1311,7 +1311,7 @@ static int whc_default_insert (struct whc *whc_generic, seqno_t max_drop_seq, se
         newn->idxnode = idxn;
         newn->idxnode_pos = idxn->headidx;
 
-        if (oldn && (whc->wrinfo.hdepth > 0 || oldn->seq <= max_drop_seq) && whc->wrinfo.tldepth > 0)
+        if (oldn && (whc->wrinfo.hdepth > 0 || oldn->seq <= max_drop_seq) && (!whc->wrinfo.is_transient_local || whc->wrinfo.tldepth > 0))
         {
           TRACE (" prune whcn %p", (void *)oldn);
           assert (oldn != whc->maxseq_node || whc->wrinfo.has_deadline);

--- a/src/core/ddsi/src/ddsi_ipaddr.c
+++ b/src/core/ddsi/src/ddsi_ipaddr.c
@@ -13,6 +13,7 @@
 #include <string.h>
 
 #include "dds/ddsrt/endian.h"
+#include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/log.h"
 #include "dds/ddsrt/sockets.h"
 #include "dds/ddsi/ddsi_ipaddr.h"
@@ -103,6 +104,7 @@ enum ddsi_locator_from_string_result ddsi_ipaddr_from_string (ddsi_tran_factory_
           return AFSR_UNKNOWN;
       }
       memcpy(&tmpaddr, &hent->addrs[0], sizeof(hent->addrs[0]));
+      ddsrt_free (hent);
 #else
       return AFSR_INVALID;
 #endif

--- a/src/core/ddsi/src/ddsi_tcp.c
+++ b/src/core/ddsi/src/ddsi_tcp.c
@@ -699,6 +699,7 @@ static bool ddsi_tcp_supports (const struct ddsi_tran_factory *fact_cmn, int32_t
 
 static int ddsi_tcp_locator (struct ddsi_tran_factory *fact_cmn, ddsi_tran_base_t base, nn_locator_t *loc)
 {
+  loc->tran = fact_cmn;
   loc->kind = fact_cmn->m_kind;
   memcpy(loc->address, base->gv->extloc.address, sizeof(loc->address));
   loc->port = base->m_port;

--- a/src/tools/ddsperf/cputime.c
+++ b/src/tools/ddsperf/cputime.c
@@ -184,6 +184,11 @@ bool record_cputime (struct record_cputime_state *state, const char *prefix, dds
   return print_cputime (&state->s, prefix, false, true);
 }
 
+double record_cputime_read_rss (const struct record_cputime_state *state)
+{
+  return state->s.maxrss;
+}
+
 struct record_cputime_state *record_cputime_new (dds_entity_t wr)
 {
   ddsrt_thread_list_id_t tids[100];
@@ -249,6 +254,12 @@ bool record_cputime (struct record_cputime_state *state, const char *prefix, dds
   (void) state;
   (void) prefix;
   (void) tnow;
+}
+
+double record_cputime_read_rss (const struct record_cputime_state *state)
+{
+  (void) state;
+  return 0.0.
 }
 
 struct record_cputime_state *record_cputime_new (dds_entity_t wr)

--- a/src/tools/ddsperf/cputime.h
+++ b/src/tools/ddsperf/cputime.h
@@ -19,6 +19,7 @@ struct record_cputime_state;
 struct record_cputime_state *record_cputime_new (dds_entity_t wr);
 void record_cputime_free (struct record_cputime_state *state);
 bool record_cputime (struct record_cputime_state *state, const char *prefix, dds_time_t tnow);
+double record_cputime_read_rss (const struct record_cputime_state *state);
 bool print_cputime (const struct CPUStats *s, const char *prefix, bool print_host, bool is_fresh);
 
 #endif

--- a/src/tools/ddsperf/sanity.bash
+++ b/src/tools/ddsperf/sanity.bash
@@ -1,0 +1,23 @@
+exitcode=0
+# RSS/samples/roundtrip numbers are based on experimentation on Travis
+bin/ddsperf -L -D10 -n10 -Qminmatch:2 -Qrss:10% -Qrss:0.5 -Qsamples:300000 -Qroundtrips:3000 sub ping & ddsperf_pids=$!
+bin/ddsperf -L -D10 -n10 -Qminmatch:2 -Qrss:10% -Qrss:0.5 pub & ddsperf_pids="$ddsperf_pids $!"
+sleep 11
+for pid in $ddsperf_pids ; do
+    if kill -0 $pid 2>/dev/null ; then
+        echo "killing process $pid"
+        kill -9 $pid
+        exitcode=2
+    fi
+    wait $pid
+    x=$?
+    if [[ $x -gt $exitcode ]] ; then
+        exitcode=$x
+    fi
+done
+if [[ $exitcode -gt 0 ]] ; then
+    echo "** FAILED **"
+else
+    echo "** OK **"
+fi
+exit $exitcode


### PR DESCRIPTION
This PR fixes an accidental change in the retention of samples in a keep-last WHC introduced in commit 231cb8c. It also adds running a simple combined throughput and roundtrip sanity check using ``ddsperf`` on CI builds. This sanity check runs for 10s and fails if:
* the two processes don't discover each other in time;
* RSS grows by more than a set amount (10% + 0.5MB from initial to final, determined by experimentation) — better tests are needed, but at the data rates involved this should catch some real memory growth;
* sample rate is less than 30kS/s (because timing on Travis is really problematic, I've seen its once-per-seconds time stamps jump from for 2s straight to 9s ...);
* number of round trips is less than 3k.

Trying the "MonitorPort" setting I chanced upon two small independent issues, those are fixes as well.