### PR TITLE
Fixed build error on FreeRTOS

### DIFF
--- a/src/tools/ddsperf/cputime.c
+++ b/src/tools/ddsperf/cputime.c
@@ -259,7 +259,7 @@ bool record_cputime (struct record_cputime_state *state, const char *prefix, dds
 double record_cputime_read_rss (const struct record_cputime_state *state)
 {
   (void) state;
-  return 0.0.
+  return 0.0;
 }
 
 struct record_cputime_state *record_cputime_new (dds_entity_t wr)


### PR DESCRIPTION
recent change in ddsperf causes a build error on freeRTOS.