### PR TITLE
Fix warning -Wimplicit-int-float-conversion

### DIFF
--- a/src/tools/pubsub/common.c
+++ b/src/tools/pubsub/common.c
@@ -583,7 +583,7 @@ int double_to_dds_duration(dds_duration_t *dd, double d) {
     if (d < 0)
         return -1;
     double nanosec = d * 1e9;
-    if(nanosec > INT64_MAX) {
+    if(nanosec > (double)INT64_MAX) {
         *dd = DDS_INFINITY;
     } else {
         *dd = (int64_t) nanosec;


### PR DESCRIPTION
```
/opt/ros/master/src/eclipse-cyclonedds/cyclonedds/src/tools/pubsub/common.c:586:28: warning: implicit conversion from 'long' to 'double' changes value from 9223372036854775807 to 9223372036854775808 [-Wimplicit-int-float-conversion]
    if(nanosec > nextafter(INT64_MAX, 0)) {
                 ~~~~~~~~~ ^~~~~~~~~
/usr/include/stdint.h:134:22: note: expanded from macro 'INT64_MAX'
# define INT64_MAX              (__INT64_C(9223372036854775807))
                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/stdint.h:116:24: note: expanded from macro '__INT64_C'
#  define __INT64_C(c)  c ## L
                        ^~~~~~
<scratch space>:345:1: note: expanded from here
9223372036854775807L
^~~~~~~~~~~~~~~~~~~~
1 warning generated.
```