### PR TITLE
Add config options to decrease ACK rates

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -15,14 +15,17 @@ if(PERL_FOUND)
       options.md cyclonedds.rnc
     COMMAND
       ${PERL_EXECUTABLE} -w "${CMAKE_CURRENT_SOURCE_DIR}/makernc.pl" "${CMAKE_CURRENT_SOURCE_DIR}/../src/core/ddsi/src/q_config.c" options.md cyclonedds.rnc
+    DEPENDS
+      "${CMAKE_CURRENT_SOURCE_DIR}/makernc.pl"
+      "${CMAKE_CURRENT_SOURCE_DIR}/../src/core/ddsi/src/q_config.c")
+  add_custom_target(
+    options_doc ALL
     COMMAND
       ${PERL_EXECUTABLE} -w "${CMAKE_CURRENT_SOURCE_DIR}/compare.pl" options.md "${CMAKE_CURRENT_SOURCE_DIR}/manual/options.md"
     COMMAND
       ${PERL_EXECUTABLE} -w "${CMAKE_CURRENT_SOURCE_DIR}/compare.pl" cyclonedds.rnc "${CMAKE_CURRENT_SOURCE_DIR}/../etc/cyclonedds.rnc"
     DEPENDS
-      "${CMAKE_CURRENT_SOURCE_DIR}/makernc.pl"
-      "${CMAKE_CURRENT_SOURCE_DIR}/../src/core/ddsi/src/q_config.c")
-  add_custom_target(options_doc ALL DEPENDS "options.md" "cyclonedds.rnc")
+      "options.md" "cyclonedds.rnc")
 
   find_package(Java COMPONENTS Runtime)
   if(JAVA_FOUND AND EXISTS "${TRANG_PATH}" OR EXISTS "$ENV{TRANG}")
@@ -35,13 +38,16 @@ if(PERL_FOUND)
         cyclonedds.xsd
       COMMAND
         ${Java_JAVA_EXECUTABLE} -jar "${TRANG_PATH}" -I rnc -O xsd cyclonedds.rnc cyclonedds.xsd
+      DEPENDS
+        "cyclonedds.rnc")
+    add_custom_target(
+      options_xsd ALL
       COMMAND
         ${PERL_EXECUTABLE} -w "${CMAKE_CURRENT_SOURCE_DIR}/compare.pl" cyclonedds.xsd "${CMAKE_CURRENT_SOURCE_DIR}/../etc/cyclonedds.xsd"
       DEPENDS
-        "cyclonedds.rnc")
-    add_custom_target(options_xsd ALL DEPENDS "cyclonedds.xsd")
+        "cyclonedds.xsd")
   else()
-    message(STATUS "Java or not trang not found: not converting/checking RNC to XSD")
+    message(STATUS "Java or trang not found: not converting/checking RNC to XSD")
   endif()
 else()
   message(STATUS "perl not found: not generating/checking options documentation and RNC")

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -554,7 +554,7 @@ The default value is: "default".
 
 
 ### //CycloneDDS/Domain/Internal
-Children: [AccelerateRexmitBlockSize](#cycloneddsdomaininternalacceleraterexmitblocksize), [AssumeMulticastCapable](#cycloneddsdomaininternalassumemulticastcapable), [AutoReschedNackDelay](#cycloneddsdomaininternalautoreschednackdelay), [BuiltinEndpointSet](#cycloneddsdomaininternalbuiltinendpointset), [ControlTopic](#cycloneddsdomaininternalcontroltopic), [DDSI2DirectMaxThreads](#cycloneddsdomaininternalddsi2directmaxthreads), [DefragReliableMaxSamples](#cycloneddsdomaininternaldefragreliablemaxsamples), [DefragUnreliableMaxSamples](#cycloneddsdomaininternaldefragunreliablemaxsamples), [DeliveryQueueMaxSamples](#cycloneddsdomaininternaldeliveryqueuemaxsamples), [EnableExpensiveChecks](#cycloneddsdomaininternalenableexpensivechecks), [GenerateKeyhash](#cycloneddsdomaininternalgeneratekeyhash), [HeartbeatInterval](#cycloneddsdomaininternalheartbeatinterval), [LateAckMode](#cycloneddsdomaininternallateackmode), [LeaseDuration](#cycloneddsdomaininternalleaseduration), [LivelinessMonitoring](#cycloneddsdomaininternallivelinessmonitoring), [MaxParticipants](#cycloneddsdomaininternalmaxparticipants), [MaxQueuedRexmitBytes](#cycloneddsdomaininternalmaxqueuedrexmitbytes), [MaxQueuedRexmitMessages](#cycloneddsdomaininternalmaxqueuedrexmitmessages), [MaxSampleSize](#cycloneddsdomaininternalmaxsamplesize), [MeasureHbToAckLatency](#cycloneddsdomaininternalmeasurehbtoacklatency), [MinimumSocketReceiveBufferSize](#cycloneddsdomaininternalminimumsocketreceivebuffersize), [MinimumSocketSendBufferSize](#cycloneddsdomaininternalminimumsocketsendbuffersize), [MonitorPort](#cycloneddsdomaininternalmonitorport), [MultipleReceiveThreads](#cycloneddsdomaininternalmultiplereceivethreads), [NackDelay](#cycloneddsdomaininternalnackdelay), [PreEmptiveAckDelay](#cycloneddsdomaininternalpreemptiveackdelay), [PrimaryReorderMaxSamples](#cycloneddsdomaininternalprimaryreordermaxsamples), [PrioritizeRetransmit](#cycloneddsdomaininternalprioritizeretransmit), [RediscoveryBlacklistDuration](#cycloneddsdomaininternalrediscoveryblacklistduration), [RetransmitMerging](#cycloneddsdomaininternalretransmitmerging), [RetransmitMergingPeriod](#cycloneddsdomaininternalretransmitmergingperiod), [RetryOnRejectBestEffort](#cycloneddsdomaininternalretryonrejectbesteffort), [SPDPResponseMaxDelay](#cycloneddsdomaininternalspdpresponsemaxdelay), [ScheduleTimeRounding](#cycloneddsdomaininternalscheduletimerounding), [SecondaryReorderMaxSamples](#cycloneddsdomaininternalsecondaryreordermaxsamples), [SendAsync](#cycloneddsdomaininternalsendasync), [SquashParticipants](#cycloneddsdomaininternalsquashparticipants), [SynchronousDeliveryLatencyBound](#cycloneddsdomaininternalsynchronousdeliverylatencybound), [SynchronousDeliveryPriorityThreshold](#cycloneddsdomaininternalsynchronousdeliveryprioritythreshold), [Test](#cycloneddsdomaininternaltest), [UnicastResponseToSPDPMessages](#cycloneddsdomaininternalunicastresponsetospdpmessages), [UseMulticastIfMreqn](#cycloneddsdomaininternalusemulticastifmreqn), [Watermarks](#cycloneddsdomaininternalwatermarks), [WriteBatch](#cycloneddsdomaininternalwritebatch), [WriterLingerDuration](#cycloneddsdomaininternalwriterlingerduration)
+Children: [AccelerateRexmitBlockSize](#cycloneddsdomaininternalacceleraterexmitblocksize), [AckDelay](#cycloneddsdomaininternalackdelay), [AckSuppression](#cycloneddsdomaininternalacksuppression), [AssumeMulticastCapable](#cycloneddsdomaininternalassumemulticastcapable), [AutoReschedNackDelay](#cycloneddsdomaininternalautoreschednackdelay), [BuiltinEndpointSet](#cycloneddsdomaininternalbuiltinendpointset), [ControlTopic](#cycloneddsdomaininternalcontroltopic), [DDSI2DirectMaxThreads](#cycloneddsdomaininternalddsi2directmaxthreads), [DefragReliableMaxSamples](#cycloneddsdomaininternaldefragreliablemaxsamples), [DefragUnreliableMaxSamples](#cycloneddsdomaininternaldefragunreliablemaxsamples), [DeliveryQueueMaxSamples](#cycloneddsdomaininternaldeliveryqueuemaxsamples), [DisablePmdReader](#cycloneddsdomaininternaldisablepmdreader), [EnableExpensiveChecks](#cycloneddsdomaininternalenableexpensivechecks), [GenerateKeyhash](#cycloneddsdomaininternalgeneratekeyhash), [HeartbeatInterval](#cycloneddsdomaininternalheartbeatinterval), [LateAckMode](#cycloneddsdomaininternallateackmode), [LeaseDuration](#cycloneddsdomaininternalleaseduration), [LivelinessMonitoring](#cycloneddsdomaininternallivelinessmonitoring), [MaxParticipants](#cycloneddsdomaininternalmaxparticipants), [MaxQueuedRexmitBytes](#cycloneddsdomaininternalmaxqueuedrexmitbytes), [MaxQueuedRexmitMessages](#cycloneddsdomaininternalmaxqueuedrexmitmessages), [MaxSampleSize](#cycloneddsdomaininternalmaxsamplesize), [MeasureHbToAckLatency](#cycloneddsdomaininternalmeasurehbtoacklatency), [MinimumSocketReceiveBufferSize](#cycloneddsdomaininternalminimumsocketreceivebuffersize), [MinimumSocketSendBufferSize](#cycloneddsdomaininternalminimumsocketsendbuffersize), [MonitorPort](#cycloneddsdomaininternalmonitorport), [MultipleReceiveThreads](#cycloneddsdomaininternalmultiplereceivethreads), [NackDelay](#cycloneddsdomaininternalnackdelay), [PreEmptiveAckDelay](#cycloneddsdomaininternalpreemptiveackdelay), [PrimaryReorderMaxSamples](#cycloneddsdomaininternalprimaryreordermaxsamples), [PrioritizeRetransmit](#cycloneddsdomaininternalprioritizeretransmit), [RediscoveryBlacklistDuration](#cycloneddsdomaininternalrediscoveryblacklistduration), [RetransmitMerging](#cycloneddsdomaininternalretransmitmerging), [RetransmitMergingPeriod](#cycloneddsdomaininternalretransmitmergingperiod), [RetryOnRejectBestEffort](#cycloneddsdomaininternalretryonrejectbesteffort), [SPDPResponseMaxDelay](#cycloneddsdomaininternalspdpresponsemaxdelay), [ScheduleTimeRounding](#cycloneddsdomaininternalscheduletimerounding), [SecondaryReorderMaxSamples](#cycloneddsdomaininternalsecondaryreordermaxsamples), [SendAsync](#cycloneddsdomaininternalsendasync), [SquashParticipants](#cycloneddsdomaininternalsquashparticipants), [SynchronousDeliveryLatencyBound](#cycloneddsdomaininternalsynchronousdeliverylatencybound), [SynchronousDeliveryPriorityThreshold](#cycloneddsdomaininternalsynchronousdeliveryprioritythreshold), [Test](#cycloneddsdomaininternaltest), [UnicastResponseToSPDPMessages](#cycloneddsdomaininternalunicastresponsetospdpmessages), [UseMulticastIfMreqn](#cycloneddsdomaininternalusemulticastifmreqn), [Watermarks](#cycloneddsdomaininternalwatermarks), [WriteBatch](#cycloneddsdomaininternalwritebatch), [WriterLingerDuration](#cycloneddsdomaininternalwriterlingerduration)
 
 
 The Internal elements deal with a variety of settings that evolving and
@@ -572,6 +572,39 @@ this many samples retransmitted when they NACK something, even if some of
 these samples have sequence numbers outside the set covered by the NACK.
 
 The default value is: "0".
+
+
+#### //CycloneDDS/Domain/Internal/AckDelay
+Attributes: [randomize](#cycloneddsdomaininternalackdelayrandomize)
+
+Number-with-unit
+
+This element controls the delay for answering a heartbeat that requests
+an ACK
+
+The unit must be specified explicitly. Recognised units: ns, us, ms, s,
+min, hr, day.
+
+The default value is: "0 ms".
+
+
+#### //CycloneDDS/Domain/Internal/AckDelay[@randomize]
+Boolean
+
+Randomize acknowledgement delays using a value between 0 - AckDelay
+
+The default value is: "false".
+
+
+#### //CycloneDDS/Domain/Internal/AckSuppression
+Boolean
+
+This element controls whether a reliable writer requests ACKs. When
+enabled, matching readers will send ACKs at a rate of 50% of the maximum
+interval for periodic heartbeats, to ensure samples can be removed from
+the writer history.
+
+The default value is: "false".
 
 
 #### //CycloneDDS/Domain/Internal/AssumeMulticastCapable
@@ -662,6 +695,18 @@ samples. Once a delivery queue is full, incoming samples destined for
 that queue are dropped until space becomes available again.
 
 The default value is: "256".
+
+
+#### //CycloneDDS/Domain/Internal/DisablePmdReader
+Boolean
+
+This element controls whether a ParticipantMessageData reader is created
+for DDSI liveliness protocol, effectively also disabling writers which
+get created upon reader discovery. PMD writers are reliable and may cause
+spikes in ACK traffic when adding a participant. Note liveliness still
+works by deriving it from other traffic.
+
+The default value is: "false".
 
 
 #### //CycloneDDS/Domain/Internal/EnableExpensiveChecks

--- a/etc/cyclonedds.rnc
+++ b/etc/cyclonedds.rnc
@@ -469,6 +469,29 @@ the NACK.</p><p>The default value is: &quot;0&quot;.</p>""" ] ]
           xsd:integer
         }?
         & [ a:documentation [ xml:lang="en" """
+<p>This element controls the delay for answering a heartbeat that
+requests an ACK</p>
+
+<p>The unit must be specified explicitly. Recognised units: ns, us, ms,
+s, min, hr, day.</p><p>The default value is: &quot;0 ms&quot;.</p>""" ] ]
+        element AckDelay {
+          [ a:documentation [ xml:lang="en" """
+<p>Randomize acknowledgement delays using a value between 0 -
+AckDelay</p><p>The default value is: &quot;false&quot;.</p>""" ] ]
+          attribute randomize {
+            xsd:boolean
+          }?
+          & duration
+        }?
+        & [ a:documentation [ xml:lang="en" """
+<p>This element controls whether a reliable writer requests ACKs. When
+enabled, matching readers will send ACKs at a rate of 50% of the maximum
+interval for periodic heartbeats, to ensure samples can be removed from
+the writer history.</p><p>The default value is: &quot;false&quot;.</p>""" ] ]
+        element AckSuppression {
+          xsd:boolean
+        }?
+        & [ a:documentation [ xml:lang="en" """
 <p>This element controls which network interfaces are assumed to be
 capable of multicasting even when the interface flags returned by the
 operating system state it is not (this provides a workaround for some
@@ -546,6 +569,16 @@ that queue are dropped until space becomes available again.</p><p>The
 default value is: &quot;256&quot;.</p>""" ] ]
         element DeliveryQueueMaxSamples {
           xsd:integer
+        }?
+        & [ a:documentation [ xml:lang="en" """
+<p>This element controls whether a ParticipantMessageData reader is
+created for DDSI liveliness protocol, effectively also disabling writers
+which get created upon reader discovery. PMD writers are reliable and may
+cause spikes in ACK traffic when adding a participant. Note liveliness
+still works by deriving it from other traffic.</p><p>The default value
+is: &quot;false&quot;.</p>""" ] ]
+        element DisablePmdReader {
+          xsd:boolean
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element enables expensive checks in builds with assertions

--- a/etc/cyclonedds.xsd
+++ b/etc/cyclonedds.xsd
@@ -636,6 +636,8 @@ reserved. This includes renaming or moving options.&lt;/p&gt;</xs:documentation>
     <xs:complexType>
       <xs:all>
         <xs:element minOccurs="0" ref="config:AccelerateRexmitBlockSize"/>
+        <xs:element minOccurs="0" ref="config:AckDelay"/>
+        <xs:element minOccurs="0" ref="config:AckSuppression"/>
         <xs:element minOccurs="0" ref="config:AssumeMulticastCapable"/>
         <xs:element minOccurs="0" ref="config:AutoReschedNackDelay"/>
         <xs:element minOccurs="0" ref="config:BuiltinEndpointSet"/>
@@ -644,6 +646,7 @@ reserved. This includes renaming or moving options.&lt;/p&gt;</xs:documentation>
         <xs:element minOccurs="0" ref="config:DefragReliableMaxSamples"/>
         <xs:element minOccurs="0" ref="config:DefragUnreliableMaxSamples"/>
         <xs:element minOccurs="0" ref="config:DeliveryQueueMaxSamples"/>
+        <xs:element minOccurs="0" ref="config:DisablePmdReader"/>
         <xs:element minOccurs="0" ref="config:EnableExpensiveChecks"/>
         <xs:element minOccurs="0" ref="config:GenerateKeyhash"/>
         <xs:element minOccurs="0" ref="config:HeartbeatInterval"/>
@@ -690,6 +693,38 @@ reserved. This includes renaming or moving options.&lt;/p&gt;</xs:documentation>
 get this many samples retransmitted when they NACK something, even if
 some of these samples have sequence numbers outside the set covered by
 the NACK.&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;0&amp;quot;.&lt;/p&gt;</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="AckDelay">
+    <xs:annotation>
+      <xs:documentation>
+&lt;p&gt;This element controls the delay for answering a heartbeat that
+requests an ACK&lt;/p&gt;
+
+&lt;p&gt;The unit must be specified explicitly. Recognised units: ns, us, ms,
+s, min, hr, day.&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;0 ms&amp;quot;.&lt;/p&gt;</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="config:duration">
+          <xs:attribute name="randomize" type="xs:boolean">
+            <xs:annotation>
+              <xs:documentation>
+&lt;p&gt;Randomize acknowledgement delays using a value between 0 -
+AckDelay&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;false&amp;quot;.&lt;/p&gt;</xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="AckSuppression" type="xs:boolean">
+    <xs:annotation>
+      <xs:documentation>
+&lt;p&gt;This element controls whether a reliable writer requests ACKs. When
+enabled, matching readers will send ACKs at a rate of 50% of the maximum
+interval for periodic heartbeats, to ensure samples can be removed from
+the writer history.&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;false&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="AssumeMulticastCapable" type="xs:string">
@@ -785,6 +820,17 @@ value is: &amp;quot;4&amp;quot;.&lt;/p&gt;</xs:documentation>
 in samples. Once a delivery queue is full, incoming samples destined for
 that queue are dropped until space becomes available again.&lt;/p&gt;&lt;p&gt;The
 default value is: &amp;quot;256&amp;quot;.&lt;/p&gt;</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="DisablePmdReader" type="xs:boolean">
+    <xs:annotation>
+      <xs:documentation>
+&lt;p&gt;This element controls whether a ParticipantMessageData reader is
+created for DDSI liveliness protocol, effectively also disabling writers
+which get created upon reader discovery. PMD writers are reliable and may
+cause spikes in ACK traffic when adding a participant. Note liveliness
+still works by deriving it from other traffic.&lt;/p&gt;&lt;p&gt;The default value
+is: &amp;quot;false&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="EnableExpensiveChecks">

--- a/src/core/ddsi/include/dds/ddsi/q_config.h
+++ b/src/core/ddsi/include/dds/ddsi/q_config.h
@@ -282,6 +282,8 @@ struct config
   int unicast_response_to_spdp_messages;
   int synchronous_delivery_priority_threshold;
   int64_t synchronous_delivery_latency_bound;
+  int disable_pmd_reader;
+  int ack_suppression;
 
   /* Write cache */
 
@@ -302,6 +304,8 @@ struct config
   uint32_t socket_min_sndbuf_size;
   int64_t nack_delay;
   int64_t preemptive_ack_delay;
+  int64_t ack_delay;
+  int ackdelay_randomize;
   int64_t schedule_time_rounding;
   int64_t auto_resched_nack_delay;
   int64_t ds_grace_period;

--- a/src/core/ddsi/include/dds/ddsi/q_misc.h
+++ b/src/core/ddsi/include/dds/ddsi/q_misc.h
@@ -37,6 +37,8 @@ int WildcardOverlap(char * p1, char * p2);
 
 int ddsi2_patmatch (const char *pat, const char *str);
 
+int64_t pseudo_random_delay (const ddsi_guid_t *x, const ddsi_guid_t *y, nn_mtime_t tnow, int64_t max_ms);
+
 #if defined (__cplusplus)
 }
 #endif

--- a/src/core/ddsi/src/q_config.c
+++ b/src/core/ddsi/src/q_config.c
@@ -485,6 +485,12 @@ static const struct cfgelem multiple_recv_threads_attrs[] = {
   END_MARKER
 };
 
+static const struct cfgelem ackdelay_attrs[] = {
+    { ATTR("randomize"), 1, "false", ABSOFF(ackdelay_randomize), 0, uf_boolean, 0, pf_boolean,
+      BLURB("<p>Randomize acknowledgement delays using a value between 0 - AckDelay</p>") },
+    END_MARKER
+};
+
 static const struct cfgelem unsupp_cfgelems[] = {
   { MOVED("MaxMessageSize", "CycloneDDS/General/MaxMessageSize") },
   { MOVED("FragmentSize", "CycloneDDS/General/FragmentSize") },
@@ -504,6 +510,12 @@ static const struct cfgelem unsupp_cfgelems[] = {
 <li><i>writers</i>: all participants have the writers, but just one has the readers;</li>\n\
 <li><i>minimal</i>: only one participant has built-in endpoints.</li></ul>\n\
 <p>The default is <i>writers</i>, as this is thought to be compliant and reasonably efficient. <i>Minimal</i> may or may not be compliant but is most efficient, and <i>full</i> is inefficient but certain to be compliant. See also Internal/ConservativeBuiltinReaderStartup.</p>") },
+  { LEAF("DisablePmdReader"), 1, "false", ABSOFF(disable_pmd_reader), 0, uf_boolean, 0, pf_boolean,
+    BLURB("<p>This element controls whether a ParticipantMessageData reader is created for DDSI liveliness protocol, effectively also disabling writers which get created upon reader discovery. PMD writers are reliable and may cause spikes in ACK traffic when adding a participant. Note liveliness still works by deriving it from other traffic.</p>") },
+  { LEAF("AckSuppression"), 1, "false", ABSOFF(ack_suppression), 0, uf_boolean, 0, pf_boolean,
+    BLURB("<p>This element controls whether a reliable writer requests ACKs. When enabled, matching readers will send ACKs at a rate of 50% of the maximum interval for periodic heartbeats, to ensure samples can be removed from the writer history.</p>") },
+  { LEAF_W_ATTRS("AckDelay", ackdelay_attrs), 1, "0 ms", ABSOFF(ack_delay), 0, uf_duration_ms_1hr, 0, pf_duration,
+    BLURB("<p>This element controls the delay for answering a heartbeat that requests an ACK</p>") },
   { LEAF("MeasureHbToAckLatency"), 1, "false", ABSOFF(meas_hb_to_ack_latency), 0, uf_boolean, 0, pf_boolean,
     BLURB("<p>This element enables heartbeat-to-ack latency among DDSI2E services by prepending timestamps to Heartbeat and AckNack messages and calculating round trip times. This is non-standard behaviour. The measured latencies are quite noisy and are currently not used anywhere.</p>") },
   { LEAF("UnicastResponseToSPDPMessages"), 1, "true", ABSOFF(unicast_response_to_spdp_messages), 0, uf_boolean, 0, pf_boolean,

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -747,9 +747,12 @@ dds_return_t new_participant_guid (const ddsi_guid_t *ppguid, struct ddsi_domain
     new_reader_guid (NULL, &subguid, &group_guid, pp, NULL, &gv->builtin_endpoint_xqos_rd, NULL, NULL, NULL);
     pp->bes |= NN_DISC_BUILTIN_ENDPOINT_PUBLICATION_DETECTOR;
 
-    subguid.entityid = to_entityid (NN_ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_READER);
-    new_reader_guid (NULL, &subguid, &group_guid, pp, NULL, &gv->builtin_endpoint_xqos_rd, NULL, NULL, NULL);
-    pp->bes |= NN_BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_READER;
+    if (!gv->config.disable_pmd_reader)
+    {
+      subguid.entityid = to_entityid (NN_ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_READER);
+      new_reader_guid (NULL, &subguid, &group_guid, pp, NULL, &gv->builtin_endpoint_xqos_rd, NULL, NULL, NULL);
+      pp->bes |= NN_BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_READER;
+    }
   }
 
   /* If the participant doesn't have the full set of builtin writers

--- a/src/core/ddsi/src/q_misc.c
+++ b/src/core/ddsi/src/q_misc.c
@@ -89,3 +89,32 @@ int ddsi2_patmatch (const char *pat, const char *str)
   }
   return *str == 0;
 }
+
+int64_t pseudo_random_delay (const ddsi_guid_t *x, const ddsi_guid_t *y, nn_mtime_t tnow, int64_t max_ms)
+{
+  /* You know, an ordinary random generator would be even better, but
+     the C library doesn't have a reentrant one and I don't feel like
+     integrating, say, the Mersenne Twister right now. */
+  static const uint64_t cs[] = {
+    UINT64_C (15385148050874689571),
+    UINT64_C (17503036526311582379),
+    UINT64_C (11075621958654396447),
+    UINT64_C ( 9748227842331024047),
+    UINT64_C (14689485562394710107),
+    UINT64_C (17256284993973210745),
+    UINT64_C ( 9288286355086959209),
+    UINT64_C (17718429552426935775),
+    UINT64_C (10054290541876311021),
+    UINT64_C (13417933704571658407)
+  };
+  uint32_t a = x->prefix.u[0], b = x->prefix.u[1], c = x->prefix.u[2], d = x->entityid.u;
+  uint32_t e = y->prefix.u[0], f = y->prefix.u[1], g = y->prefix.u[2], h = y->entityid.u;
+  uint32_t i = (uint32_t) ((uint64_t) tnow.v >> 32), j = (uint32_t) tnow.v;
+  uint64_t m = 0;
+  m += (a + cs[0]) * (b + cs[1]);
+  m += (c + cs[2]) * (d + cs[3]);
+  m += (e + cs[4]) * (f + cs[5]);
+  m += (g + cs[6]) * (h + cs[7]);
+  m += (i + cs[8]) * (j + cs[9]);
+  return (int64_t) (m >> 32) * max_ms / 4295;
+}

--- a/src/core/ddsi/src/q_receive.c
+++ b/src/core/ddsi/src/q_receive.c
@@ -1087,7 +1087,12 @@ static void handle_Heartbeat_helper (struct pwr_rd_match * const wn, struct hand
     }
     else if (!(msg->smhdr.flags & HEARTBEAT_FLAG_FINAL))
     {
-      tsched = arg->tnow_mt;
+      RSTTRACE ("/ACK");
+      int64_t delay = rst->gv->config.ackdelay_randomize ? \
+          pseudo_random_delay(&(pwr->e.guid), &(wn->rd_guid), arg->tnow_mt, rst->gv->config.ack_delay / 1000000) : rst->gv->config.ack_delay;
+      tsched.v = arg->tnow_mt.v + delay;
+      if (delay > 0)
+        RSTTRACE ("d");
     }
     if (resched_xevent_if_earlier (wn->acknack_xevent, tsched))
     {


### PR DESCRIPTION
A number of config options have been added for tweaking the protocol between reliable readers/writers to decrease ACK rates.
- Disable ParticipantMessageData readers (which trigger creation of matching writers) to disable periodical liveliness messages and associated ACK traffic. Liveliness is still derived indirectly from other traffic.
- Option for ACK suppression that makes reliable writers send heartbeats with ACK requests only if neccesary eg. to clean up writer-history cache (suppressing ACKs when 'all is well').
- Option for (randomized) ACK delay to prevent all relevant readers from responding to ACK requests at the same time causing spikes on the network.

All options are by default turned off so unless explicitly configured the default behaviour is unchanged.