### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/core/ddsc/src/dds_topic.c
+++ b/src/core/ddsc/src/dds_topic.c
@@ -170,10 +170,8 @@ static dds_return_t dds_topic_qos_set (dds_entity *e, const dds_qos_t *qos, bool
 {
   /* We never actually set the qos of a struct dds_topic and really shouldn't be here,
      but the code to check whether set_qos is supported uses the entity's qos_set
-     function as a proxy.  One of the weird things about the topic's set_qos is that
-     this is called with e == NULL.  */
+     function as a proxy.  */
   (void) e; (void) qos; (void) enabled;
-  assert (e == NULL);
   return DDS_RETCODE_OK;
 }
 

--- a/src/ddsrt/src/sync/posix/sync.c
+++ b/src/ddsrt/src/sync/posix/sync.c
@@ -109,8 +109,8 @@ ddsrt_cond_waituntil(
     return true;
   }
   if (abstime > 0) {
-    ts.tv_sec = abstime / DDS_NSECS_IN_SEC;
-    ts.tv_nsec = abstime % DDS_NSECS_IN_SEC;
+    ts.tv_sec = (time_t) (abstime / DDS_NSECS_IN_SEC);
+    ts.tv_nsec = (suseconds_t) (abstime % DDS_NSECS_IN_SEC);
   }
 
   switch (pthread_cond_timedwait(&cond->cond, &mutex->mutex, &ts)) {

--- a/src/ddsrt/src/time.c
+++ b/src/ddsrt/src/time.c
@@ -26,8 +26,8 @@ void dds_sleepfor(dds_duration_t n)
   struct timespec t, r;
 
   if (n >= 0) {
-    t.tv_sec = n / DDS_NSECS_IN_SEC;
-    t.tv_nsec = n % DDS_NSECS_IN_SEC;
+    t.tv_sec = (time_t) (n / DDS_NSECS_IN_SEC);
+    t.tv_nsec = (long) (n % DDS_NSECS_IN_SEC);
     while (nanosleep(&t, &r) == -1 && errno == EINTR) {
       t = r;
     }


### PR DESCRIPTION
This deals with 2, 3 or 5 warnings, depending on how you want to count them:
* Passing a null pointer to a function declared to not accept null pointers (only picked up by gcc 5.4, oddly enough), but where the actual implementation had no problems because in the one case where a null pointer was passed in, it was actually expected. Still, one look at the function and it was clear that I had made somewhat of a mess and that the warning could be addressed by cleaning up the mess.
* On 32-bit Linux casts for converting internal time representations into ``struct timeval`` and ``struct timespec``. I've simply added the casts to the types used to define fields in those types. The warnings were reported on 32-bit armhf builds but I have reproduced them on an x86 build, and confirmed that this changes fixes it.

I've had a quick look at adding a 32-bit build to Travis CI, but it appears Travis images don't include support for 32-bit builds. Hopefully later.