### PR TITLE
Eliminate Clang static analyzer warnings in the security branch

### DIFF
--- a/src/security/builtin_plugins/access_control/src/access_control_parser.c
+++ b/src/security/builtin_plugins/access_control/src/access_control_parser.c
@@ -419,7 +419,7 @@ static DDS_Security_boolean validate_rules(const struct domain_rule *rule, DDS_S
     {
       /* Last but not least, check the domain ids (ex is set when there's a failure) */
       validate_domains(rule->domains->domain_id_set, ex);
-      if (!rule->topic_access_rules && rule->topic_access_rules->topic_rule)
+      if (!(rule->topic_access_rules && rule->topic_access_rules->topic_rule))
         DDS_Security_Exception_set(ex, DDS_ACCESS_CONTROL_PLUGIN_CONTEXT, DDS_SECURITY_ERR_IDENTITY_EMPTY_CODE, 0, "Found rule in Governance file without topic_access_rules");
       else
       {

--- a/src/security/builtin_plugins/authentication/src/authentication.c
+++ b/src/security/builtin_plugins/authentication/src/authentication.c
@@ -660,7 +660,7 @@ free_binary_properties(
     uint32_t length)
 {
     uint32_t i;
-
+    assert (seq);
     for (i = 0; i < length; i++) {
         ddsrt_free(seq[i].name);
         ddsrt_free(seq[i].value._buffer);

--- a/src/security/builtin_plugins/cryptographic/src/crypto_key_factory.c
+++ b/src/security/builtin_plugins/cryptographic/src/crypto_key_factory.c
@@ -1150,6 +1150,8 @@ crypto_factory_set_datawriter_crypto_tokens(
   endpoint_relation *relation;
   uint32_t key_id, i;
 
+  assert (num_key_mat > 0);
+
   remote_writer_crypto = (remote_datawriter_crypto *)crypto_object_table_find(impl->crypto_objects, remote_writer_handle);
   if (!remote_writer_crypto)
   {

--- a/src/security/builtin_plugins/tests/decode_serialized_payload/src/decode_serialized_payload_utests.c
+++ b/src/security/builtin_plugins/tests/decode_serialized_payload/src/decode_serialized_payload_utests.c
@@ -9,6 +9,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
+#include <assert.h>
+
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
 #include <openssl/bio.h>
@@ -218,6 +220,7 @@ static DDS_Security_DatawriterCryptoHandle register_local_datawriter(bool encryp
     printf("register_local_datawriter: %s\n", exception.message ? exception.message : "Error message missing");
   }
 
+  assert (writer_crypto != 0);
   return writer_crypto;
 }
 
@@ -239,6 +242,7 @@ static DDS_Security_DatawriterCryptoHandle register_remote_datawriter(DDS_Securi
     printf("register_matched_remote_datareader: %s\n", exception.message ? exception.message : "Error message missing");
   }
 
+  assert (writer_crypto != 0);
   return writer_crypto;
 }
 
@@ -839,6 +843,7 @@ CU_Test(ddssec_builtin_decode_serialized_payload, invalid_data, .init = suite_de
   }
 
   CU_ASSERT_FATAL(result);
+  assert(result); // for Clang's static analyzer
   CU_ASSERT(exception.code == 0);
   CU_ASSERT(exception.message == NULL);
 
@@ -846,6 +851,7 @@ CU_Test(ddssec_builtin_decode_serialized_payload, invalid_data, .init = suite_de
 
   result = split_encoded_data(encoded_buffer._buffer, encoded_buffer._length, &header, &contents, (uint32_t *) &length, &footer);
   CU_ASSERT_FATAL(result);
+  assert(result); // for Clang's static analyzer
 
   /* use incorrect transformation kind */
   {

--- a/src/security/builtin_plugins/tests/encode_datareader_submessage/src/encode_datareader_submessage_utests.c
+++ b/src/security/builtin_plugins/tests/encode_datareader_submessage/src/encode_datareader_submessage_utests.c
@@ -804,6 +804,7 @@ static void encode_datareader_submessage_not_signed(uint32_t transformation_kind
 
   reader_crypto = register_local_datareader(&datareader_security_attributes, &datareader_properties);
   CU_ASSERT_FATAL(reader_crypto != 0);
+  assert(reader_crypto != 0); // for Clang's static analyzer
 
   session_keys = get_datareader_session(reader_crypto);
 
@@ -829,6 +830,7 @@ static void encode_datareader_submessage_not_signed(uint32_t transformation_kind
   }
 
   CU_ASSERT_FATAL(result);
+  assert(result); // for Clang's static analyzer
   CU_ASSERT(exception.code == 0);
   CU_ASSERT(exception.message == NULL);
 
@@ -836,6 +838,7 @@ static void encode_datareader_submessage_not_signed(uint32_t transformation_kind
 
   result = check_encoded_data(&encoded_buffer, is_encrypted, &header, &footer, &data);
   CU_ASSERT_FATAL(result);
+  assert(result); // for Clang's static analyzer
 
   CU_ASSERT(header->transform_identifier.transformation_kind[3] == transformation_kind);
 
@@ -951,6 +954,7 @@ static void encode_datareader_submessage_sign(uint32_t transformation_kind)
 
   reader_crypto = register_local_datareader(&datareader_security_attributes, &datareader_properties);
   CU_ASSERT_FATAL(reader_crypto != 0);
+  assert(reader_crypto != 0); // for Clang's static analyzer
 
   session_keys = get_datareader_session(reader_crypto);
 
@@ -960,6 +964,7 @@ static void encode_datareader_submessage_sign(uint32_t transformation_kind)
   {
     writer_crypto = register_remote_datawriter(reader_crypto);
     CU_ASSERT_FATAL(writer_crypto != 0);
+    assert(writer_crypto != 0); // for Clang's static analyzer
     writer_list._buffer[i] = writer_crypto;
   }
 
@@ -980,6 +985,7 @@ static void encode_datareader_submessage_sign(uint32_t transformation_kind)
   }
 
   CU_ASSERT_FATAL(result);
+  assert(result); // for Clang's static analyzer
   CU_ASSERT(exception.code == 0);
   CU_ASSERT(exception.message == NULL);
 
@@ -988,6 +994,7 @@ static void encode_datareader_submessage_sign(uint32_t transformation_kind)
 
   result = check_encoded_data(&encoded_buffer, is_encrypted, &header, &footer, &data);
   CU_ASSERT_FATAL(result);
+  assert(result); // for Clang's static analyzer
 
   CU_ASSERT(header->transform_identifier.transformation_kind[3] == transformation_kind);
 

--- a/src/security/builtin_plugins/tests/encode_datawriter_submessage/src/encode_datawriter_submessage_utests.c
+++ b/src/security/builtin_plugins/tests/encode_datawriter_submessage/src/encode_datawriter_submessage_utests.c
@@ -810,11 +810,13 @@ static void encode_datawriter_submessage_not_signed(DDS_Security_CryptoTransform
 
   writer_crypto = register_local_datawriter(&datawriter_security_attributes, &datawriter_properties);
   CU_ASSERT_FATAL(writer_crypto != 0);
+  assert(writer_crypto != 0); // for Clang's static analyzer
 
   session_keys = get_datawriter_session(writer_crypto);
 
   reader_crypto = register_remote_datareader(writer_crypto);
   CU_ASSERT_FATAL(reader_crypto != 0);
+  assert(reader_crypto != 0); // for Clang's static analyzer
 
   reader_list._length = reader_list._maximum = 1;
   reader_list._buffer = DDS_Security_DatareaderCryptoHandleSeq_allocbuf(1);
@@ -837,6 +839,8 @@ static void encode_datawriter_submessage_not_signed(DDS_Security_CryptoTransform
   }
 
   CU_ASSERT_FATAL(result);
+  assert(result != 0); // for Clang's static analyzer
+
   CU_ASSERT(exception.code == 0);
   CU_ASSERT(exception.message == NULL);
 
@@ -844,6 +848,7 @@ static void encode_datawriter_submessage_not_signed(DDS_Security_CryptoTransform
 
   result = check_encoded_data(&encoded_buffer, is_encrypted, &header, &footer, &data);
   CU_ASSERT_FATAL(result);
+  assert(result); // for Clang's static analyzer
 
   CU_ASSERT(header->transform_identifier.transformation_kind[3] == transformation_kind);
 
@@ -961,6 +966,7 @@ static void encode_datawriter_submessage_sign(DDS_Security_CryptoTransformKind_E
 
   writer_crypto = register_local_datawriter(&datawriter_security_attributes, &datawriter_properties);
   CU_ASSERT_FATAL(writer_crypto != 0);
+  assert(writer_crypto != 0); // for Clang's static analyzer
 
   session_keys = get_datawriter_session(writer_crypto);
 
@@ -970,6 +976,7 @@ static void encode_datawriter_submessage_sign(DDS_Security_CryptoTransformKind_E
   {
     reader_crypto = register_remote_datareader(writer_crypto);
     CU_ASSERT_FATAL(reader_crypto != 0);
+    assert(reader_crypto != 0); // for Clang's static analyzer
     reader_list._buffer[i] = reader_crypto;
   }
   index = 0;
@@ -994,6 +1001,7 @@ static void encode_datawriter_submessage_sign(DDS_Security_CryptoTransformKind_E
     }
 
     CU_ASSERT_FATAL(result);
+    assert(result); // for Clang's static analyzer
     CU_ASSERT(exception.code == 0);
     CU_ASSERT(exception.message == NULL);
 
@@ -1003,6 +1011,7 @@ static void encode_datawriter_submessage_sign(DDS_Security_CryptoTransformKind_E
 
   result = check_encoded_data(&encoded_buffer, is_encrypted, &header, &footer, &data);
   CU_ASSERT_FATAL(result);
+  assert(result); // for Clang's static analyzer
 
   CU_ASSERT(header->transform_identifier.transformation_kind[3] == transformation_kind);
 

--- a/src/security/builtin_plugins/tests/encode_serialized_payload/src/encode_serialized_payload_utests.c
+++ b/src/security/builtin_plugins/tests/encode_serialized_payload/src/encode_serialized_payload_utests.c
@@ -566,6 +566,8 @@ static void encode_serialized_payload_check(uint32_t key_size, bool encrypted)
 
   writer_crypto = register_local_datawriter(encrypted);
   CU_ASSERT_FATAL(writer_crypto != 0);
+  assert(writer_crypto != 0); // for Clang's static analyzer
+
   CU_ASSERT(check_protection_kind(writer_crypto, encrypted ? DDS_SECURITY_BASICPROTECTION_KIND_ENCRYPT : DDS_SECURITY_BASICPROTECTION_KIND_SIGN));
 
   session_keys = get_datawriter_session(writer_crypto);
@@ -586,12 +588,14 @@ static void encode_serialized_payload_check(uint32_t key_size, bool encrypted)
     printf("[ERROR] encode_serialized_payload: %s\n", exception.message ? exception.message : "Error message missing");
   }
   CU_ASSERT_FATAL(result);
+  assert(result); // for Clang's static analyzer
   CU_ASSERT(exception.code == 0);
   CU_ASSERT(exception.message == NULL);
   reset_exception(&exception);
 
   result = split_encoded_data(encoded_buffer._buffer, encoded_buffer._length, &header, &encoded_payload, &footer, encrypted);
   CU_ASSERT_FATAL(result == true);
+  assert(result); // for Clang's static analyzer
   CU_ASSERT(check_payload_encoded(&encoded_payload, &plain_buffer, encrypted));
 
   session_id = ddsrt_fromBE4u(*(uint32_t *)header->session_id);

--- a/src/security/builtin_plugins/tests/get_authenticated_peer_credential_token/src/get_authenticated_peer_credential_token_utests.c
+++ b/src/security/builtin_plugins/tests/get_authenticated_peer_credential_token/src/get_authenticated_peer_credential_token_utests.c
@@ -1256,6 +1256,7 @@ fill_handshake_message_token(
 
         CU_ASSERT(hash1_from_request != NULL);
         CU_ASSERT(hash2_from_reply != NULL);
+        assert(hash1_from_request && hash2_from_reply); // for Clang's static analyzer
 
         set_binary_property_value(hash_c1, "hash_c1", hash1_from_request->value._buffer, hash1_from_request->value._length);
         set_binary_property_value(hash_c2, "hash_c2", hash2_from_reply->value._buffer, hash2_from_reply->value._length);
@@ -1382,6 +1383,7 @@ CU_Test(ddssec_builtin_get_authenticated_peer_credential,token_after_request )
                     &exception);
 
     CU_ASSERT_FATAL(result == DDS_SECURITY_VALIDATION_PENDING_HANDSHAKE_MESSAGE);
+    assert(result == DDS_SECURITY_VALIDATION_PENDING_HANDSHAKE_MESSAGE); // for Clang's static analyzer
 
     /* mock reply */
     dh1 = find_binary_property(&handshake_token_out, "dh1");
@@ -1414,6 +1416,7 @@ CU_Test(ddssec_builtin_get_authenticated_peer_credential,token_after_request )
                         handshake_handle,
                         &exception);
     CU_ASSERT_FATAL(result == DDS_SECURITY_VALIDATION_OK_FINAL_MESSAGE);
+    assert(result == DDS_SECURITY_VALIDATION_OK_FINAL_MESSAGE); // for Clang's static analyzer
 
     /*
      * Actual test.
@@ -1425,8 +1428,10 @@ CU_Test(ddssec_builtin_get_authenticated_peer_credential,token_after_request )
                         &exception);
 
     CU_ASSERT_TRUE (success);
+    assert(success); // for Clang's static analyzer
 
     CU_ASSERT_FATAL(credential_token.class_id != NULL);
+    assert(credential_token.class_id); // for Clang's static analyzer
     CU_ASSERT(strcmp(credential_token.class_id, AUTH_PROTOCOL_CLASS_ID) == 0);
     CU_ASSERT(credential_token.properties._length == 2);
     CU_ASSERT(credential_token.binary_properties._length == 0);
@@ -1434,12 +1439,14 @@ CU_Test(ddssec_builtin_get_authenticated_peer_credential,token_after_request )
     c_id = find_property(&credential_token, "c.id");
     CU_ASSERT_FATAL(c_id != NULL);
     CU_ASSERT_FATAL(c_id->value != NULL);
+    assert(c_id && c_id->value); // for Clang's static analyzer
     //printf("c_id->value: %s\n", c_id->value);
     CU_ASSERT(strcmp(c_id->value, REMOTE_IDENTITY_CERTIFICATE) == 0);
 
     c_perm = find_property(&credential_token, "c.perm");
     CU_ASSERT_FATAL(c_perm != NULL);
     CU_ASSERT_FATAL(c_perm->value != NULL);
+    assert(c_perm && c_perm->value); // for Clang's static analyzer
     //printf("c_perm->value: %s\n", c_perm->value);
     CU_ASSERT(strcmp(c_perm->value, PERMISSIONS_DOCUMENT) == 0);
 
@@ -1506,6 +1513,7 @@ CU_Test(ddssec_builtin_get_authenticated_peer_credential,token_after_reply )
                     &exception);
 
     CU_ASSERT_FATAL(result == DDS_SECURITY_VALIDATION_PENDING_HANDSHAKE_MESSAGE);
+    assert(result == DDS_SECURITY_VALIDATION_PENDING_HANDSHAKE_MESSAGE); // for Clang's static analyzer
 
     /* mock final */
     dh2 = find_binary_property(&handshake_token_out, "dh2");
@@ -1539,6 +1547,7 @@ CU_Test(ddssec_builtin_get_authenticated_peer_credential,token_after_reply )
                         &exception);
 
     CU_ASSERT_FATAL(result == DDS_SECURITY_VALIDATION_OK);
+    assert(result == DDS_SECURITY_VALIDATION_OK); // for Clang's static analyzer
 
     /*
      * Actual test.
@@ -1550,6 +1559,7 @@ CU_Test(ddssec_builtin_get_authenticated_peer_credential,token_after_reply )
                         &exception);
 
     CU_ASSERT_TRUE (success);
+    assert(success); // for Clang's static analyzer
 
     CU_ASSERT_FATAL(credential_token.class_id != NULL);
     CU_ASSERT(strcmp(credential_token.class_id, AUTH_PROTOCOL_CLASS_ID) == 0);
@@ -1559,12 +1569,14 @@ CU_Test(ddssec_builtin_get_authenticated_peer_credential,token_after_reply )
     c_id = find_property(&credential_token, "c.id");
     CU_ASSERT_FATAL(c_id != NULL);
     CU_ASSERT_FATAL(c_id->value != NULL);
+    assert(c_id && c_id->value); // for Clang's static analyzer
     //printf("c_id->value: %s\n", c_id->value);
     CU_ASSERT(strcmp(c_id->value, REMOTE_IDENTITY_CERTIFICATE) == 0);
 
     c_perm = find_property(&credential_token, "c.perm");
     CU_ASSERT_FATAL(c_perm != NULL);
     CU_ASSERT_FATAL(c_perm->value != NULL);
+    assert(c_perm && c_perm->value); // for Clang's static analyzer
     //printf("c_perm->value: %s\n", c_perm->value);
     CU_ASSERT(strcmp(c_perm->value, PERMISSIONS_DOCUMENT) == 0);
 
@@ -1581,6 +1593,7 @@ CU_Test(ddssec_builtin_get_authenticated_peer_credential,token_after_reply )
 
     success = g_auth->return_handshake_handle(g_auth, handshake_handle, &exception);
     CU_ASSERT_TRUE (success);
+    assert(success); // for Clang's static analyzer
 
     reset_exception(&exception);
 

--- a/src/security/builtin_plugins/tests/get_xxx_sec_attributes/src/get_xxx_sec_attributes_utests.c
+++ b/src/security/builtin_plugins/tests/get_xxx_sec_attributes/src/get_xxx_sec_attributes_utests.c
@@ -1279,7 +1279,7 @@ static void test_liveliness_discovery_reader_attr(
   DDS_Security_DataTagQosPolicy data_tag;
   DDS_Security_PartitionQosPolicy *partition = NULL;
   bool result;
-  return;
+
   CU_ASSERT_FATAL(access_control->get_datareader_sec_attributes != NULL);
 
   memset(&attr, 0, sizeof(attr));

--- a/src/security/builtin_plugins/tests/listeners_authentication/src/listeners_authentication_utests.c
+++ b/src/security/builtin_plugins/tests/listeners_authentication/src/listeners_authentication_utests.c
@@ -1724,7 +1724,8 @@ fill_handshake_message_token(
            set_binary_property_string(c_kagree_algo, "c.kagree_algox", "rubbish");
         }
 
-        CU_ASSERT(hash1_from_request != NULL);
+        CU_ASSERT_FATAL(hash1_from_request != NULL);
+        assert(hash1_from_request != NULL); // for Clang's static analyzer
 
         set_binary_property_value(hash_c1, "hash_c1", hash1_from_request->value._buffer, hash1_from_request->value._length);
 
@@ -1786,6 +1787,7 @@ fill_handshake_message_token(
             EVP_PKEY *private_key_x509;
             unsigned char *sign;
             size_t signlen;
+            DDS_Security_ValidationResult_t rc;
 
             const DDS_Security_BinaryProperty_t * binary_properties[ HANDSHAKE_SIGNATURE_SIZE ];
 
@@ -1802,10 +1804,14 @@ fill_handshake_message_token(
             binary_properties[4] = dh1;
             binary_properties[5] = hash_c1;
 
-            if (create_signature_for_test(private_key_x509, binary_properties, HANDSHAKE_SIGNATURE_SIZE , &sign, &signlen, &exception) != DDS_SECURITY_VALIDATION_OK)
+            rc = create_signature_for_test(private_key_x509, binary_properties, HANDSHAKE_SIGNATURE_SIZE , &sign, &signlen, &exception);
+            if (rc != DDS_SECURITY_VALIDATION_OK)
             {
                 printf("Exception: %s\n", exception.message);
             }
+            CU_ASSERT_FATAL (rc == DDS_SECURITY_VALIDATION_OK);
+            assert(rc == DDS_SECURITY_VALIDATION_OK); // for Clang's static analyzer
+          
             set_binary_property_value(signature, "signature", sign, (uint32_t)signlen);
 
             ddsrt_free(sign);
@@ -2008,8 +2014,10 @@ CU_Test(ddssec_builtin_listeners_auth, local_remote_set_before_validation)
     hash1_sent_in_request = find_binary_property(&handshake_token_out, "hash_c1");
 
     CU_ASSERT_FATAL(dh1 != NULL);
+    assert(dh1 != NULL); // for Clang's static analyzer
     CU_ASSERT_FATAL(dh1->value._length > 0);
     CU_ASSERT_FATAL(dh1->value._buffer != NULL);
+    assert(dh1->value._length > 0 && dh1->value._buffer != NULL); // for Clang's static analyzer
 
     dh1_pub_key.data = dh1->value._buffer;
     dh1_pub_key.length = dh1->value._length;

--- a/src/security/builtin_plugins/tests/process_handshake/src/process_handshake_utests.c
+++ b/src/security/builtin_plugins/tests/process_handshake/src/process_handshake_utests.c
@@ -1292,7 +1292,8 @@ fill_handshake_message_token(
            set_binary_property_string(c_kagree_algo, "c.kagree_algox", "rubbish");
         }
 
-        CU_ASSERT(hash1_from_request != NULL);
+        CU_ASSERT_FATAL(hash1_from_request != NULL);
+        assert(hash1_from_request != NULL); // for Clang's static analyzer
 
         set_binary_property_value(hash_c1, "hash_c1", hash1_from_request->value._buffer, hash1_from_request->value._length);
 
@@ -1587,8 +1588,10 @@ CU_Test(ddssec_builtin_process_handshake,happy_day_after_request )
     hash1_sentrequest = find_binary_property(&handshake_token_out, "hash_c1");
 
     CU_ASSERT_FATAL(dh1 != NULL);
+    assert(dh1 != NULL); // for Clang's static analyzer
     CU_ASSERT_FATAL(dh1->value._length > 0);
     CU_ASSERT_FATAL(dh1->value._buffer != NULL);
+    assert(dh1->value._length > 0 && dh1->value._buffer != NULL); // for Clang's static analyzer
 
     dh1_pub_key.data = dh1->value._buffer;
     dh1_pub_key.length = dh1->value._length;
@@ -1875,8 +1878,10 @@ CU_Test(ddssec_builtin_process_handshake,invalid_certificate )
     hash1_sentrequest = find_binary_property(&handshake_token_out, "hash_c1");
 
     CU_ASSERT_FATAL(dh1 != NULL);
+    assert(dh1 != NULL); // for Clang's static analyzer
     CU_ASSERT_FATAL(dh1->value._length > 0);
     CU_ASSERT_FATAL(dh1->value._buffer != NULL);
+    assert(dh1->value._length > 0 && dh1->value._buffer != NULL); // for Clang's static analyzer
 
     /* prepare reply */
     dh1_pub_key.data = dh1->value._buffer;
@@ -1959,8 +1964,10 @@ CU_Test(ddssec_builtin_process_handshake,invalid_dsign_algo )
     hash1_sentrequest = find_binary_property(&handshake_token_out, "hash_c1");
 
     CU_ASSERT_FATAL(dh1 != NULL);
+    assert(dh1 != NULL); // for Clang's static analyzer
     CU_ASSERT_FATAL(dh1->value._length > 0);
     CU_ASSERT_FATAL(dh1->value._buffer != NULL);
+    assert(dh1->value._length > 0 && dh1->value._buffer != NULL); // for Clang's static analyzer
 
     /* prepare reply */
     dh1_pub_key.data = dh1->value._buffer;
@@ -2037,8 +2044,10 @@ CU_Test(ddssec_builtin_process_handshake,invalid_kagree_algo )
     hash1_sentrequest = find_binary_property(&handshake_token_out, "hash_c1");
 
     CU_ASSERT_FATAL(dh1 != NULL);
+    assert (dh1 != NULL); // for Clang's static analyzer
     CU_ASSERT_FATAL(dh1->value._length > 0);
     CU_ASSERT_FATAL(dh1->value._buffer != NULL);
+    assert (dh1->value._length > 0 && dh1->value._buffer != NULL); // for Clang's static analyzer
 
     /* prepare reply */
     dh1_pub_key.data = dh1->value._buffer;
@@ -2114,8 +2123,10 @@ CU_Test(ddssec_builtin_process_handshake,invalid_diffie_hellman )
     hash1_sentrequest = find_binary_property(&handshake_token_out, "hash_c1");
 
     CU_ASSERT_FATAL(dh1 != NULL);
+    assert (dh1 != NULL); // for Clang's static analyzer
     CU_ASSERT_FATAL(dh1->value._length > 0);
     CU_ASSERT_FATAL(dh1->value._buffer != NULL);
+    assert (dh1->value._length > 0 && dh1->value._buffer != NULL); // for Clang's static analyzer
 
     /* prepare reply */
     fill_handshake_message_token(
@@ -2244,6 +2255,8 @@ CU_Test(ddssec_builtin_process_handshake,extended_certificate_check )
     if (result != DDS_SECURITY_VALIDATION_PENDING_HANDSHAKE_MESSAGE) {
         printf("begin_handshake_request failed: %s\n", exception.message ? exception.message : "Error message missing");
     }
+    CU_ASSERT_FATAL(result == DDS_SECURITY_VALIDATION_PENDING_HANDSHAKE_MESSAGE);
+    assert(result == DDS_SECURITY_VALIDATION_PENDING_HANDSHAKE_MESSAGE); // for Clang's static analyzer
 
     /* get challenge 1 from the message */
     challenge1_glb = find_binary_property(&handshake_token_out, "challenge1");
@@ -2254,8 +2267,10 @@ CU_Test(ddssec_builtin_process_handshake,extended_certificate_check )
     hash1_sentrequest = find_binary_property(&handshake_token_out, "hash_c1");
 
     CU_ASSERT_FATAL(dh1 != NULL);
+    assert(dh1 != NULL); // for Clang's static analyzer
     CU_ASSERT_FATAL(dh1->value._length > 0);
     CU_ASSERT_FATAL(dh1->value._buffer != NULL);
+    assert(dh1->value._length > 0 && dh1->value._buffer != NULL); // for Clang's static analyzer
 
     dh1_pub_key.data = dh1->value._buffer;
     dh1_pub_key.length = dh1->value._length;
@@ -2328,8 +2343,10 @@ CU_Test(ddssec_builtin_process_handshake,extended_certificate_check )
     hash1_sentrequest = find_binary_property(&handshake_token_out, "hash_c1");
 
     CU_ASSERT_FATAL(dh1 != NULL);
+    assert (dh1 != NULL); // for Clang's static analyzer
     CU_ASSERT_FATAL(dh1->value._length > 0);
     CU_ASSERT_FATAL(dh1->value._buffer != NULL);
+    assert (dh1->value._length > 0 && dh1->value._buffer != NULL); // for Clang's static analyzer
 
     dh1_pub_key.data = dh1->value._buffer;
     dh1_pub_key.length = dh1->value._length;
@@ -2397,8 +2414,10 @@ CU_Test(ddssec_builtin_process_handshake,extended_certificate_check )
     hash1_sentrequest = find_binary_property(&handshake_token_out, "hash_c1");
 
     CU_ASSERT_FATAL(dh1 != NULL);
+    assert (dh1 != NULL); // for Clang's static analyzer
     CU_ASSERT_FATAL(dh1->value._length > 0);
     CU_ASSERT_FATAL(dh1->value._buffer != NULL);
+    assert (dh1->value._length > 0 && dh1->value._buffer != NULL); // for Clang's static analyzer
 
     dh1_pub_key.data = dh1->value._buffer;
     dh1_pub_key.length = dh1->value._length;

--- a/src/security/builtin_plugins/tests/register_local_datareader/src/register_local_datareader_utests.c
+++ b/src/security/builtin_plugins/tests/register_local_datareader/src/register_local_datareader_utests.c
@@ -9,6 +9,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
+#include <assert.h>
+
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
 #include <openssl/bio.h>
@@ -166,6 +168,7 @@ CU_Test(ddssec_builtin_register_local_datareader, happy_day, .init = suite_regis
 
   /* A valid handle to be returned */
   CU_ASSERT(result != 0);
+  assert(result != 0); // for Clang's static analyzer
 
   CU_ASSERT(exception.code == DDS_SECURITY_ERR_OK_CODE);
 
@@ -220,6 +223,7 @@ CU_Test(ddssec_builtin_register_local_datareader, builtin_endpoint, .init = suit
   /* A valid handle to be returned */
   CU_ASSERT(result != 0);
   CU_ASSERT(exception.code == DDS_SECURITY_ERR_OK_CODE);
+  assert(result != 0); // for Clang's static analyzer
 
   /* NOTE: It would be better to check if the keys have been generated but there is no interface to get them from handle */
   reader_crypto = (local_datareader_crypto *)result;
@@ -268,8 +272,9 @@ CU_Test(ddssec_builtin_register_local_datareader, special_endpoint_name, .init =
     printf("register_local_datareader: %s\n", exception.message ? exception.message : "Error message missing");
 
   /* A valid handle to be returned */
-  CU_ASSERT(result != 0);
-  CU_ASSERT(exception.code == DDS_SECURITY_ERR_OK_CODE);
+  CU_ASSERT_FATAL(result != 0);
+  assert(result != 0); // for Clang's static analyzer
+  CU_ASSERT_FATAL(exception.code == DDS_SECURITY_ERR_OK_CODE);
   CU_ASSERT_FATAL(((local_datareader_crypto *)result)->is_builtin_participant_volatile_message_secure_reader);
   reset_exception(&exception);
   DDS_Security_PropertySeq_deinit(&datareader_properties);

--- a/src/security/builtin_plugins/tests/register_local_datawriter/src/register_local_datawriter_utests.c
+++ b/src/security/builtin_plugins/tests/register_local_datawriter/src/register_local_datawriter_utests.c
@@ -9,6 +9,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
+#include <assert.h>
+
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
 #include <openssl/bio.h>
@@ -172,6 +174,7 @@ CU_Test(ddssec_builtin_register_local_datawriter, happy_day, .init = suite_regis
   /* A valid handle to be returned */
   CU_ASSERT(result != 0);
   CU_ASSERT(exception.code == DDS_SECURITY_ERR_OK_CODE);
+  assert(result != 0); // for Clang's static analyzer
 
   /* NOTE: It would be better to check if the keys have been generated but there is no interface to get them from handle */
   writer_crypto = (local_datawriter_crypto *)result;
@@ -230,8 +233,9 @@ CU_Test(ddssec_builtin_register_local_datawriter, builtin_endpoint, .init = suit
     printf("register_local_datawriter: %s\n", exception.message ? exception.message : "Error message missing");
 
   /* A valid handle to be returned */
-  CU_ASSERT(result != 0);
-  CU_ASSERT(exception.code == DDS_SECURITY_ERR_OK_CODE);
+  CU_ASSERT_FATAL(result != 0);
+  CU_ASSERT_FATAL(exception.code == DDS_SECURITY_ERR_OK_CODE);
+  assert(result != 0); // for Clang's static analyzer
 
   /* NOTE: It would be better to check if the keys have been generated but there is no interface to get them from handle */
   writer_crypto = (local_datawriter_crypto *)result;
@@ -289,8 +293,9 @@ CU_Test(ddssec_builtin_register_local_datawriter, special_endpoint_name, .init =
     printf("register_local_datawriter: %s\n", exception.message ? exception.message : "Error message missing");
 
   /* A valid handle to be returned */
-  CU_ASSERT(result != 0);
-  CU_ASSERT(exception.code == DDS_SECURITY_ERR_OK_CODE);
+  CU_ASSERT_FATAL(result != 0);
+  CU_ASSERT_FATAL(exception.code == DDS_SECURITY_ERR_OK_CODE);
+  assert(result != 0); // for Clang's static analyzer
   CU_ASSERT_FATAL(((local_datawriter_crypto *)result)->is_builtin_participant_volatile_message_secure_writer);
 
   reset_exception(&exception);

--- a/src/security/builtin_plugins/tests/register_local_participant/src/register_local_participant_utests.c
+++ b/src/security/builtin_plugins/tests/register_local_participant/src/register_local_participant_utests.c
@@ -9,6 +9,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
+#include <assert.h>
+
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
 #include <openssl/bio.h>
@@ -146,6 +148,8 @@ CU_Test(ddssec_builtin_register_local_participant, empty_identity, .init = suite
     printf("register_local_participant: %s\n", exception.message ? exception.message : "Error message missing");
 
   CU_ASSERT(exception.code == DDS_SECURITY_ERR_IDENTITY_EMPTY_CODE);
+  CU_ASSERT_FATAL(exception.message != NULL);
+  assert(exception.message != NULL); // for Clang's static analyzer
   CU_ASSERT(!strcmp(exception.message, DDS_SECURITY_ERR_IDENTITY_EMPTY_MESSAGE));
   CU_ASSERT(result == 0);
 

--- a/src/security/builtin_plugins/tests/register_matched_remote_datareader/src/register_matched_remote_datareader_utests.c
+++ b/src/security/builtin_plugins/tests/register_matched_remote_datareader/src/register_matched_remote_datareader_utests.c
@@ -9,6 +9,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
+#include <assert.h>
+
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
 #include <openssl/bio.h>
@@ -200,8 +202,9 @@ CU_Test(ddssec_builtin_register_remote_datareader, happy_day, .init = suite_regi
     printf("register_remote_datareader: %s\n", exception.message ? exception.message : "Error message missing");
 
   /* A valid handle to be returned */
-  CU_ASSERT(result != 0);
-  CU_ASSERT(exception.code == DDS_SECURITY_ERR_OK_CODE);
+  CU_ASSERT_FATAL(result != 0);
+  CU_ASSERT_FATAL(exception.code == DDS_SECURITY_ERR_OK_CODE);
+  assert(result != 0); // for Clang's static analyzer
 
   /* NOTE: It would be better to check if the keys have been generated but there is no interface to get them from handle */
   reader_crypto = (remote_datareader_crypto *)result;
@@ -265,6 +268,7 @@ CU_Test(ddssec_builtin_register_remote_datareader, volatile_secure, .init = suit
 
   /* A valid handle to be returned */
   CU_ASSERT_FATAL(result != 0);
+  assert(result != 0); // for Clang's static analyzer
   CU_ASSERT_FATAL(((remote_datareader_crypto *)result)->is_builtin_participant_volatile_message_secure_reader);
   CU_ASSERT_FATAL(exception.code == DDS_SECURITY_ERR_OK_CODE);
   reset_exception(&exception);
@@ -293,7 +297,6 @@ CU_Test(ddssec_builtin_register_remote_datareader, with_origin_authentication, .
   /*set writer protection kind */
   writer_crypto = (local_datawriter_crypto *)local_writer_handle;
   writer_crypto->metadata_protectionKind = DDS_SECURITY_PROTECTION_KIND_ENCRYPT_WITH_ORIGIN_AUTHENTICATION;
-  writer_crypto = (local_datawriter_crypto *)local_writer_handle;
 
   /* Now call the function. */
   result = crypto->crypto_key_factory->register_matched_remote_datareader(
@@ -310,6 +313,7 @@ CU_Test(ddssec_builtin_register_remote_datareader, with_origin_authentication, .
   /* A valid handle to be returned */
   CU_ASSERT(result != 0);
   CU_ASSERT(exception.code == DDS_SECURITY_ERR_OK_CODE);
+  assert(result != 0); // for Clang's static analyzer
 
   /* NOTE: It would be better to check if the keys have been generated but there is no interface to get them from handle */
   reader_crypto = (remote_datareader_crypto *)result;

--- a/src/security/builtin_plugins/tests/register_matched_remote_datawriter/src/register_matched_remote_datawriter_utests.c
+++ b/src/security/builtin_plugins/tests/register_matched_remote_datawriter/src/register_matched_remote_datawriter_utests.c
@@ -9,6 +9,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
+#include <assert.h>
+
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
 #include <openssl/bio.h>
@@ -199,10 +201,12 @@ CU_Test(ddssec_builtin_register_remote_datawriter, happy_day, .init = suite_regi
   /* A valid handle to be returned */
   CU_ASSERT_FATAL(result != 0);
   CU_ASSERT_FATAL(exception.code == DDS_SECURITY_ERR_OK_CODE);
+  assert(result != 0); // for Clang's static analyzer
 
   /* NOTE: It would be better to check if the keys have been generated but there is no interface to get them from handle */
   writer_crypto = (remote_datawriter_crypto *)result;
   CU_ASSERT_FATAL(writer_crypto->reader2writer_key_material != NULL);
+  assert(writer_crypto->reader2writer_key_material != NULL); // for Clang's static analyzer
   CU_ASSERT(master_salt_not_empty(writer_crypto->reader2writer_key_material));
   CU_ASSERT(master_key_not_empty(writer_crypto->reader2writer_key_material));
   CU_ASSERT_FATAL(writer_crypto->reader2writer_key_material->receiver_specific_key_id == 0);
@@ -254,6 +258,7 @@ CU_Test(ddssec_builtin_register_remote_datawriter, volatile_secure, .init = suit
 
   /* A valid handle to be returned */
   CU_ASSERT_FATAL(result != 0);
+  assert(result != 0); // for Clang's static analyzer
   CU_ASSERT_FATAL(((remote_datawriter_crypto *)result)->is_builtin_participant_volatile_message_secure_writer);
   CU_ASSERT_FATAL(exception.code == DDS_SECURITY_ERR_OK_CODE);
   reset_exception(&exception);
@@ -282,7 +287,6 @@ CU_Test(ddssec_builtin_register_remote_datawriter, with_origin_authentication, .
   /*set reader protection kind */
   reader_crypto = (local_datareader_crypto *)local_reader_handle;
   reader_crypto->metadata_protectionKind = DDS_SECURITY_PROTECTION_KIND_ENCRYPT_WITH_ORIGIN_AUTHENTICATION;
-  reader_crypto = (local_datareader_crypto *)local_reader_handle;
   /* Now call the function. */
 
   result = crypto->crypto_key_factory->register_matched_remote_datawriter(
@@ -296,12 +300,14 @@ CU_Test(ddssec_builtin_register_remote_datawriter, with_origin_authentication, .
     printf("register_remote_datawriter: %s\n", exception.message ? exception.message : "Error message missing");
 
   /* A valid handle to be returned */
-  CU_ASSERT(result != 0);
-  CU_ASSERT(exception.code == DDS_SECURITY_ERR_OK_CODE);
+  CU_ASSERT_FATAL(result != 0);
+  CU_ASSERT_FATAL(exception.code == DDS_SECURITY_ERR_OK_CODE);
+  assert(result != 0); // for Clang's static analyzer
 
   /* NOTE: It would be better to check if the keys have been generated but there is no interface to get them from handle */
   writer_crypto = (remote_datawriter_crypto *)result;
   CU_ASSERT_FATAL(writer_crypto->reader2writer_key_material != NULL);
+  assert(writer_crypto->reader2writer_key_material != NULL); // for Clang's static analyzer
   CU_ASSERT(master_salt_not_empty(writer_crypto->reader2writer_key_material));
   CU_ASSERT(master_key_not_empty(writer_crypto->reader2writer_key_material));
   CU_ASSERT_FATAL(writer_crypto->reader2writer_key_material->receiver_specific_key_id != 0);

--- a/src/security/builtin_plugins/tests/validate_begin_handshake_reply/src/validate_begin_handshake_reply_utests.c
+++ b/src/security/builtin_plugins/tests/validate_begin_handshake_reply/src/validate_begin_handshake_reply_utests.c
@@ -1586,6 +1586,7 @@ CU_Test(ddssec_builtin_validate_begin_handshake_reply,invalid_participant_data ,
 
     property = find_binary_property(&handshake_token_in, "c.pdata");
     CU_ASSERT_FATAL(property != NULL);
+    assert(property != NULL); // for Clang's static analyzer
 
     ddsrt_free(property->name);
     property->name = ddsrt_strdup("c.pdatax");
@@ -1835,17 +1836,18 @@ CU_Test(ddssec_builtin_validate_begin_handshake_reply,invalid_challenge ,  .init
     CU_ASSERT_FATAL (remote_identity_handle2 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (auth->begin_handshake_reply != NULL);
 
-  fill_handshake_message_token_default(&handshake_token_in, remote_participant_data2, challenge2->value._buffer, challenge2->value._length);
+    fill_handshake_message_token_default(&handshake_token_in, remote_participant_data2, challenge2->value._buffer, challenge2->value._length);
 
-  result = auth->begin_handshake_reply(
-    auth,
-    &handshake_handle,
-    &handshake_token_out,
-    &handshake_token_in,
-    remote_identity_handle1,
-    local_identity_handle,
-    &serialized_participant_data,
-    &exception);
+    result = auth->begin_handshake_reply(
+      auth,
+      &handshake_handle,
+      &handshake_token_out,
+      &handshake_token_in,
+      remote_identity_handle1,
+      local_identity_handle,
+      &serialized_participant_data,
+      &exception);
+    CU_ASSERT_FATAL (result == DDS_SECURITY_VALIDATION_PENDING_HANDSHAKE_MESSAGE);
 
     handshake_message_deinit(&handshake_token_in);
     handshake_message_deinit(&handshake_token_out);

--- a/src/security/builtin_plugins/tests/validate_local_identity/src/validate_local_identity_utests.c
+++ b/src/security/builtin_plugins/tests/validate_local_identity/src/validate_local_identity_utests.c
@@ -1133,6 +1133,7 @@ CU_Test(ddssec_builtin_validate_local_identity,missing_certificate_property)
     CU_ASSERT (result != DDS_SECURITY_VALIDATION_OK);
     CU_ASSERT (exception.minor_code != 0);
     CU_ASSERT_FATAL (exception.message != NULL);
+    assert(exception.message != NULL); // for Clang's static analyzer
     CU_ASSERT(strcmp(exception.message, "validate_local_identity: missing property 'dds.sec.auth.identity_certificate'") == 0);
 
     dds_security_property_deinit(&participant_qos.property.value);
@@ -1189,6 +1190,7 @@ CU_Test(ddssec_builtin_validate_local_identity,missing_ca_property)
     CU_ASSERT (result != DDS_SECURITY_VALIDATION_OK);
     CU_ASSERT (exception.minor_code != 0);
     CU_ASSERT_FATAL (exception.message != NULL);
+    assert(exception.message != NULL); // for Clang's static analyzer
     CU_ASSERT(strcmp(exception.message, "validate_local_identity: missing property 'dds.sec.auth.identity_ca'") == 0);
 
     dds_security_property_deinit(&participant_qos.property.value);
@@ -1240,6 +1242,7 @@ CU_Test(ddssec_builtin_validate_local_identity,missing_private_key_property)
     CU_ASSERT (result != DDS_SECURITY_VALIDATION_OK);
     CU_ASSERT (exception.minor_code != 0);
     CU_ASSERT_FATAL (exception.message != NULL);
+    assert(exception.message != NULL); // for Clang's static analyzer
     CU_ASSERT(strcmp(exception.message, "validate_local_identity: missing property 'dds.sec.auth.private_key'") == 0);
 
     dds_security_property_deinit(&participant_qos.property.value);

--- a/src/security/builtin_plugins/tests/validate_local_permissions/src/validate_local_permissions_utests.c
+++ b/src/security/builtin_plugins/tests/validate_local_permissions/src/validate_local_permissions_utests.c
@@ -605,6 +605,7 @@ static DDS_Security_long test_corrupted_signature(bool corrupt_permissions, bool
   /* Just some (hardcoded) sanity checks. */
   CU_ASSERT_FATAL(prop != NULL);
   CU_ASSERT_FATAL(prop->value != NULL);
+  assert(prop && prop->value); // for Clang's static analyzer
   len = strlen(prop->value);
   CU_ASSERT_FATAL(len > 2250);
 

--- a/src/security/builtin_plugins/tests/validate_remote_permissions/src/validate_remote_permissions_utests.c
+++ b/src/security/builtin_plugins/tests/validate_remote_permissions/src/validate_remote_permissions_utests.c
@@ -277,6 +277,7 @@ static void corrupt_permission_signature(DDS_Security_AuthenticatedPeerCredentia
   /* It is expected that the permissions are available in a fixed location. */
   CU_ASSERT_FATAL(token != NULL);
   CU_ASSERT_FATAL(token->properties._buffer != NULL);
+  assert(token->properties._buffer != NULL); // for Clang's static analyzer
   CU_ASSERT_FATAL(token->properties._length == 2);
   CU_ASSERT_FATAL(token->properties._buffer[1].name != NULL);
   CU_ASSERT_FATAL(token->properties._buffer[1].value != NULL);
@@ -285,6 +286,7 @@ static void corrupt_permission_signature(DDS_Security_AuthenticatedPeerCredentia
   /* Corrupt a byte somewhere in the signature. */
   permissions = token->properties._buffer[1].value;
   CU_ASSERT_FATAL(permissions != NULL);
+  assert(permissions != NULL); // for Clang's static analyzer
   len = strlen(permissions);
   CU_ASSERT_FATAL(len > 100);
   permissions[len - 75]--;

--- a/src/security/core/tests/plugin_loading/plugin_mock/authentication_finalize_error/mock_authentication.c
+++ b/src/security/core/tests/plugin_loading/plugin_mock/authentication_finalize_error/mock_authentication.c
@@ -15,6 +15,7 @@
 #include "dds/ddsrt/misc.h"
 #include "mock_authentication.h"
 #include <stdio.h>
+#include <assert.h>
 #include <string.h>
 #include <stdbool.h>
 
@@ -71,6 +72,11 @@ DDS_Security_ValidationResult_t validate_local_identity(
       identity_certificate = participant_qos->property.value._buffer[i].value;
     }
   }
+
+  /* for Clang's static analyzer */
+  assert(identity_certificate != NULL);
+  assert(identity_ca != NULL);
+  assert(private_key != NULL);
 
   if( strcmp(identity_certificate, test_identity_certificate) != 0){
 

--- a/src/security/core/tests/plugin_loading/plugin_mock/authentication_missing_function/mock_authentication.c
+++ b/src/security/core/tests/plugin_loading/plugin_mock/authentication_missing_function/mock_authentication.c
@@ -13,6 +13,7 @@
 #include "dds/ddsrt/misc.h"
 #include "mock_authentication.h"
 #include <stdio.h>
+#include <assert.h>
 #include <string.h>
 #include <stdbool.h>
 
@@ -72,6 +73,11 @@ DDS_Security_ValidationResult_t validate_local_identity(
       identity_certificate = participant_qos->property.value._buffer[i].value;
     }
   }
+
+  /* for Clang's static analyzer */
+  assert(identity_certificate != NULL);
+  assert(identity_ca != NULL);
+  assert(private_key != NULL);
 
   if( strcmp(identity_certificate, test_identity_certificate) != 0){
 


### PR DESCRIPTION
This is mostly adding ``aasert``s in test code. In the plugins it is the removal of a few unused variables and a fix for an incorrect check validating the topic access rules specification in a governance file.