### PR TITLE
Remove address sanitizer from project build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,25 +170,23 @@ if(${CMAKE_GENERATOR} STREQUAL "Xcode")
   set (CMAKE_XCODE_ATTRIBUTE_GCC_WARN_ABOUT_MISSING_PROTOTYPES YES)
 endif()
 
-# Make it easy to enable one of Clang's/gcc's analyzers, and default to using
-# the address sanitizer for ordinary debug builds; gcc is giving some grief on
-# Travis, so don't enable it for gcc by default
-if(NOT USE_SANITIZER)
-  if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug" AND
-      NOT ("${CMAKE_GENERATOR}" STREQUAL "Xcode") AND
-      ("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang"
-        OR "${CMAKE_C_COMPILER_ID}" STREQUAL "AppleClang"))
-    message(STATUS "Enabling address sanitizer; set USE_SANITIZER=none to prevent this")
-    set(USE_SANITIZER address)
-  else()
-    set(USE_SANITIZER none)
+
+# Make it easy to enable Clang's/gcc's analyzers
+set(USE_SANITIZER "" CACHE STRING "Sanitizers to enable on the build.")
+foreach(san "${USE_SANITIZER}")
+  message(STATUS "Enabling sanitizer: '${san}'")
+
+  if("${san}" STREQUAL address)
+    add_compile_options(-fno-omit-frame-pointer)
+    link_libraries(-fno-omit-frame-pointer)
   endif()
-endif()
-if(NOT ("${USE_SANITIZER}" STREQUAL "none"))
-  message(STATUS "Sanitizer set to ${USE_SANITIZER}")
-  add_compile_options(-fno-omit-frame-pointer -fsanitize=${USE_SANITIZER})
-  link_libraries(-fno-omit-frame-pointer -fsanitize=${USE_SANITIZER})
-endif()
+
+  if(NOT("${san}" STREQUAL "none"))
+    add_compile_options("-fsanitize=${san}")
+    link_libraries("-fsanitize=${san}")
+  endif()
+endforeach()
+
 
 include(GNUInstallDirs)
 include(AnalyzeBuild)


### PR DESCRIPTION
1. Don't automatically enable asan on Debug builds.
~~2. Remove asan logic in the library build process.~~
3. Retain existing asan behavior in the CI builds.

The correct way to hook up address sanitizer depends on the eventual application using it and whether CycloneDDS is statically or dynamically linked.
Doing it improperly results in runtime crashes like:
```
    [ERROR] [1582664129.049907842] [rcl]: Error getting RMW implementation identifier / RMW implementation not installed (expected identifier of 'rmw_cyclonedds_cpp'), with error message 'failed to load shared library of rmw implementation. Exception: Cannot load library: /opt/ros/master/install/lib/libddsc.so.0: undefined symbol: __asan_option_detect_stack_use_after_return, at /opt/ros/master/src/ros2/rmw_implementation/rmw_implementation/src/functions.cpp:69', exiting with 1.
  >>>
```

Signed-off-by: Dan Rose <dan@digilabs.io>
