### PR TITLE
WIP: Switch atomic operations to __atomic functions

### DIFF
--- a/src/ddsrt/include/dds/ddsrt/atomics.h
+++ b/src/ddsrt/include/dds/ddsrt/atomics.h
@@ -65,23 +65,23 @@ typedef ddsrt_atomic_uintptr_t ddsrt_atomic_voidp_t;
    the form of a different implementation where it is used, or as an emulation using a mutex in
    ddsrt.  It seems that the places where they'd be used end up adding a mutex, so an emulation in
    ddsrt while being able to check whether it is supported by hardware is a sensible approach.  */
-DDS_EXPORT uint64_t ddsrt_atomic_ld64 (const volatile ddsrt_atomic_uint64_t *x);
-DDS_EXPORT void ddsrt_atomic_st64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
-DDS_EXPORT void ddsrt_atomic_inc64 (volatile ddsrt_atomic_uint64_t *x);
-DDS_EXPORT uint64_t ddsrt_atomic_inc64_nv (volatile ddsrt_atomic_uint64_t *x);
-DDS_EXPORT void ddsrt_atomic_dec64 (volatile ddsrt_atomic_uint64_t *x);
-DDS_EXPORT uint64_t ddsrt_atomic_dec64_nv (volatile ddsrt_atomic_uint64_t *x);
-DDS_EXPORT void ddsrt_atomic_add64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
-DDS_EXPORT uint64_t ddsrt_atomic_add64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
-DDS_EXPORT void ddsrt_atomic_sub64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
-DDS_EXPORT uint64_t ddsrt_atomic_sub64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
-DDS_EXPORT void ddsrt_atomic_and64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
-DDS_EXPORT uint64_t ddsrt_atomic_and64_ov (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
-DDS_EXPORT uint64_t ddsrt_atomic_and64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
-DDS_EXPORT void ddsrt_atomic_or64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
-DDS_EXPORT uint64_t ddsrt_atomic_or64_ov (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
-DDS_EXPORT uint64_t ddsrt_atomic_or64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
-DDS_EXPORT int ddsrt_atomic_cas64 (volatile ddsrt_atomic_uint64_t *x, uint64_t exp, uint64_t des);
+DDS_EXPORT uint64_t ddsrt_atomic_ld64 (const ddsrt_atomic_uint64_t *x);
+DDS_EXPORT void ddsrt_atomic_st64 (ddsrt_atomic_uint64_t *x, uint64_t v);
+DDS_EXPORT void ddsrt_atomic_inc64 (ddsrt_atomic_uint64_t *x);
+DDS_EXPORT uint64_t ddsrt_atomic_inc64_nv (ddsrt_atomic_uint64_t *x);
+DDS_EXPORT void ddsrt_atomic_dec64 (ddsrt_atomic_uint64_t *x);
+DDS_EXPORT uint64_t ddsrt_atomic_dec64_nv (ddsrt_atomic_uint64_t *x);
+DDS_EXPORT void ddsrt_atomic_add64 (ddsrt_atomic_uint64_t *x, uint64_t v);
+DDS_EXPORT uint64_t ddsrt_atomic_add64_nv (ddsrt_atomic_uint64_t *x, uint64_t v);
+DDS_EXPORT void ddsrt_atomic_sub64 (ddsrt_atomic_uint64_t *x, uint64_t v);
+DDS_EXPORT uint64_t ddsrt_atomic_sub64_nv (ddsrt_atomic_uint64_t *x, uint64_t v);
+DDS_EXPORT void ddsrt_atomic_and64 (ddsrt_atomic_uint64_t *x, uint64_t v);
+DDS_EXPORT uint64_t ddsrt_atomic_and64_ov (ddsrt_atomic_uint64_t *x, uint64_t v);
+DDS_EXPORT uint64_t ddsrt_atomic_and64_nv (ddsrt_atomic_uint64_t *x, uint64_t v);
+DDS_EXPORT void ddsrt_atomic_or64 (ddsrt_atomic_uint64_t *x, uint64_t v);
+DDS_EXPORT uint64_t ddsrt_atomic_or64_ov (ddsrt_atomic_uint64_t *x, uint64_t v);
+DDS_EXPORT uint64_t ddsrt_atomic_or64_nv (ddsrt_atomic_uint64_t *x, uint64_t v);
+DDS_EXPORT int ddsrt_atomic_cas64 (ddsrt_atomic_uint64_t *x, uint64_t exp, uint64_t des);
 #endif
 
 void ddsrt_atomics_init (void);

--- a/src/ddsrt/include/dds/ddsrt/atomics/arm.h
+++ b/src/ddsrt/include/dds/ddsrt/atomics/arm.h
@@ -29,17 +29,17 @@ extern "C" {
 
 /* LD, ST */
 
-inline uint32_t ddsrt_atomic_ld32 (const volatile ddsrt_atomic_uint32_t *x) { return x->v; }
-inline uintptr_t ddsrt_atomic_ldptr (const volatile ddsrt_atomic_uintptr_t *x) { return x->v; }
-inline void *ddsrt_atomic_ldvoidp (const volatile ddsrt_atomic_voidp_t *x) { return (void *) ddsrt_atomic_ldptr (x); }
+inline uint32_t ddsrt_atomic_ld32 (const ddsrt_atomic_uint32_t *x) { return x->v; }
+inline uintptr_t ddsrt_atomic_ldptr (const ddsrt_atomic_uintptr_t *x) { return x->v; }
+inline void *ddsrt_atomic_ldvoidp (const ddsrt_atomic_voidp_t *x) { return (void *) ddsrt_atomic_ldptr (x); }
 
-inline void ddsrt_atomic_st32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) { x->v = v; }
-inline void ddsrt_atomic_stptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) { x->v = v; }
-inline void ddsrt_atomic_stvoidp (volatile ddsrt_atomic_voidp_t *x, void *v) { ddsrt_atomic_stptr (x, (uintptr_t) v); }
+inline void ddsrt_atomic_st32 (ddsrt_atomic_uint32_t *x, uint32_t v) { x->v = v; }
+inline void ddsrt_atomic_stptr (ddsrt_atomic_uintptr_t *x, uintptr_t v) { x->v = v; }
+inline void ddsrt_atomic_stvoidp (ddsrt_atomic_voidp_t *x, void *v) { ddsrt_atomic_stptr (x, (uintptr_t) v); }
 
 /* CAS */
 
-inline int ddsrt_atomic_cas32 (volatile ddsrt_atomic_uint32_t *x, uint32_t exp, uint32_t des) {
+inline int ddsrt_atomic_cas32 (ddsrt_atomic_uint32_t *x, uint32_t exp, uint32_t des) {
     register int result;
     asm volatile ("ldrex    r0, [%1]\n\t"      /*exclusive load of ptr */
                   "cmp      r0,  %2\n\t"       /*compare the oldval == *ptr */
@@ -55,16 +55,16 @@ inline int ddsrt_atomic_cas32 (volatile ddsrt_atomic_uint32_t *x, uint32_t exp, 
                   : "r0");
     return result == 0;
 }
-inline int ddsrt_atomic_casptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t exp, uintptr_t des) {
-    return ddsrt_atomic_cas32 ((volatile ddsrt_atomic_uint32_t *) x, exp, des);
+inline int ddsrt_atomic_casptr (ddsrt_atomic_uintptr_t *x, uintptr_t exp, uintptr_t des) {
+    return ddsrt_atomic_cas32 ((ddsrt_atomic_uint32_t *) x, exp, des);
 }
-inline int ddsrt_atomic_casvoidp (volatile ddsrt_atomic_voidp_t *x, void *exp, void *des) {
-    return ddsrt_atomic_casptr ((volatile ddsrt_atomic_uintptr_t *) x, (uintptr_t) exp, (uintptr_t) des);
+inline int ddsrt_atomic_casvoidp (ddsrt_atomic_voidp_t *x, void *exp, void *des) {
+    return ddsrt_atomic_casptr ((ddsrt_atomic_uintptr_t *) x, (uintptr_t) exp, (uintptr_t) des);
 }
 
 /* ADD */
 
-inline uint32_t ddsrt_atomic_add32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline uint32_t ddsrt_atomic_add32_nv (ddsrt_atomic_uint32_t *x, uint32_t v) {
   register unsigned int result;
   asm volatile ("1: ldrex  %0,  [%1]\n\t"
                 "add       %0,   %0,  %2\n\t"
@@ -76,137 +76,137 @@ inline uint32_t ddsrt_atomic_add32_nv (volatile ddsrt_atomic_uint32_t *x, uint32
                 : "r1");
    return result;
 }
-inline uintptr_t ddsrt_atomic_addptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-    return ddsrt_atomic_add32_nv ((volatile ddsrt_atomic_uint32_t *) x, v);
+inline uintptr_t ddsrt_atomic_addptr_nv (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+    return ddsrt_atomic_add32_nv ((ddsrt_atomic_uint32_t *) x, v);
 }
-inline void *ddsrt_atomic_addvoidp_nv (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
-    return (void *) ddsrt_atomic_addptr_nv ((volatile ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
+inline void *ddsrt_atomic_addvoidp_nv (ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
+    return (void *) ddsrt_atomic_addptr_nv ((ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
 }
-inline void ddsrt_atomic_add32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline void ddsrt_atomic_add32 (ddsrt_atomic_uint32_t *x, uint32_t v) {
     (void) ddsrt_atomic_add32_nv (x, v);
 }
-inline uint32_t ddsrt_atomic_add32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline uint32_t ddsrt_atomic_add32_ov (ddsrt_atomic_uint32_t *x, uint32_t v) {
     return ddsrt_atomic_add32_nv (x, v) - v;
 }
-inline void ddsrt_atomic_addptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline void ddsrt_atomic_addptr (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
     (void) ddsrt_atomic_addptr_nv (x, v);
 }
-inline void ddsrt_atomic_addvoidp (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
+inline void ddsrt_atomic_addvoidp (ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
     (void) ddsrt_atomic_addvoidp_nv (x, v);
 }
 
 /* SUB */
 
-inline uint32_t ddsrt_atomic_sub32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline uint32_t ddsrt_atomic_sub32_nv (ddsrt_atomic_uint32_t *x, uint32_t v) {
     return ddsrt_atomic_add32_nv (x, -v);
 }
-inline uintptr_t ddsrt_atomic_subptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline uintptr_t ddsrt_atomic_subptr_nv (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
     return ddsrt_atomic_addptr_nv (x, -v);
 }
-inline void *ddsrt_atomic_subvoidp_nv (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
+inline void *ddsrt_atomic_subvoidp_nv (ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
     return ddsrt_atomic_addvoidp_nv (x, -v);
 }
-inline void ddsrt_atomic_sub32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline void ddsrt_atomic_sub32 (ddsrt_atomic_uint32_t *x, uint32_t v) {
     ddsrt_atomic_add32 (x, -v);
 }
-inline void ddsrt_atomic_subptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline void ddsrt_atomic_subptr (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
     ddsrt_atomic_subptr (x, -v);
 }
-inline void ddsrt_atomic_subvoidp (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
+inline void ddsrt_atomic_subvoidp (ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
     ddsrt_atomic_subvoidp (x, -v);
 }
 
 /* INC */
 
-inline uint32_t ddsrt_atomic_inc32_ov (volatile ddsrt_atomic_uint32_t *x) {
+inline uint32_t ddsrt_atomic_inc32_ov (ddsrt_atomic_uint32_t *x) {
     return ddsrt_atomic_add32_nv (x, 1) - 1;
 }
-inline uint32_t ddsrt_atomic_inc32_nv (volatile ddsrt_atomic_uint32_t *x) {
+inline uint32_t ddsrt_atomic_inc32_nv (ddsrt_atomic_uint32_t *x) {
     return ddsrt_atomic_add32_nv (x, 1);
 }
-inline uintptr_t ddsrt_atomic_incptr_nv (volatile ddsrt_atomic_uintptr_t *x) {
+inline uintptr_t ddsrt_atomic_incptr_nv (ddsrt_atomic_uintptr_t *x) {
     return ddsrt_atomic_addptr_nv (x, 1);
 }
-inline void ddsrt_atomic_inc32 (volatile ddsrt_atomic_uint32_t *x) {
+inline void ddsrt_atomic_inc32 (ddsrt_atomic_uint32_t *x) {
     (void) ddsrt_atomic_inc32_nv (x);
 }
-inline void ddsrt_atomic_incptr (volatile ddsrt_atomic_uintptr_t *x) {
+inline void ddsrt_atomic_incptr (ddsrt_atomic_uintptr_t *x) {
     (void) ddsrt_atomic_incptr_nv (x);
 }
 
 /* DEC */
 
-inline uint32_t ddsrt_atomic_dec32_ov (volatile ddsrt_atomic_uint32_t *x) {
+inline uint32_t ddsrt_atomic_dec32_ov (ddsrt_atomic_uint32_t *x) {
     return ddsrt_atomic_sub32_nv (x, 1) + 1;
 }
-inline uint32_t ddsrt_atomic_dec32_nv (volatile ddsrt_atomic_uint32_t *x) {
+inline uint32_t ddsrt_atomic_dec32_nv (ddsrt_atomic_uint32_t *x) {
     return ddsrt_atomic_sub32_nv (x, 1);
 }
-inline uintptr_t ddsrt_atomic_decptr_nv (volatile ddsrt_atomic_uintptr_t *x) {
+inline uintptr_t ddsrt_atomic_decptr_nv (ddsrt_atomic_uintptr_t *x) {
     return ddsrt_atomic_subptr_nv (x, 1);
 }
-inline void ddsrt_atomic_dec32 (volatile ddsrt_atomic_uint32_t *x) {
+inline void ddsrt_atomic_dec32 (ddsrt_atomic_uint32_t *x) {
     (void) ddsrt_atomic_dec32_nv (x);
 }
-inline void ddsrt_atomic_decptr (volatile ddsrt_atomic_uintptr_t *x) {
+inline void ddsrt_atomic_decptr (ddsrt_atomic_uintptr_t *x) {
     (void) ddsrt_atomic_decptr_nv (x);
 }
 
 /* AND */
 
-inline uint32_t ddsrt_atomic_and32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline uint32_t ddsrt_atomic_and32_ov (ddsrt_atomic_uint32_t *x, uint32_t v) {
     uint32_t oldval, newval;
     do { oldval = x->v; newval = oldval & v; } while (!ddsrt_atomic_cas32 (x, oldval, newval));
     return oldval;
 }
-inline uintptr_t ddsrt_atomic_andptr_ov (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline uintptr_t ddsrt_atomic_andptr_ov (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
     uintptr_t oldval, newval;
     do { oldval = x->v; newval = oldval & v; } while (!ddsrt_atomic_casptr (x, oldval, newval));
     return oldval;
 }
-inline uint32_t ddsrt_atomic_and32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline uint32_t ddsrt_atomic_and32_nv (ddsrt_atomic_uint32_t *x, uint32_t v) {
     uint32_t oldval, newval;
     do { oldval = x->v; newval = oldval & v; } while (!ddsrt_atomic_cas32 (x, oldval, newval));
     return newval;
 }
-inline uintptr_t ddsrt_atomic_andptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline uintptr_t ddsrt_atomic_andptr_nv (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
     uintptr_t oldval, newval;
     do { oldval = x->v; newval = oldval & v; } while (!ddsrt_atomic_casptr (x, oldval, newval));
     return newval;
 }
-inline void ddsrt_atomic_and32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline void ddsrt_atomic_and32 (ddsrt_atomic_uint32_t *x, uint32_t v) {
     (void) ddsrt_atomic_and32_nv (x, v);
 }
-inline void ddsrt_atomic_andptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline void ddsrt_atomic_andptr (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
     (void) ddsrt_atomic_andptr_nv (x, v);
 }
 
 /* OR */
 
-inline uint32_t ddsrt_atomic_or32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline uint32_t ddsrt_atomic_or32_ov (ddsrt_atomic_uint32_t *x, uint32_t v) {
     uint32_t oldval, newval;
     do { oldval = x->v; newval = oldval | v; } while (!ddsrt_atomic_cas32 (x, oldval, newval));
     return oldval;
 }
-inline uintptr_t ddsrt_atomic_orptr_ov (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline uintptr_t ddsrt_atomic_orptr_ov (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
     uintptr_t oldval, newval;
     do { oldval = x->v; newval = oldval | v; } while (!ddsrt_atomic_casptr (x, oldval, newval));
     return oldval;
 }
-inline uint32_t ddsrt_atomic_or32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline uint32_t ddsrt_atomic_or32_nv (ddsrt_atomic_uint32_t *x, uint32_t v) {
     uint32_t oldval, newval;
     do { oldval = x->v; newval = oldval | v; } while (!ddsrt_atomic_cas32 (x, oldval, newval));
     return newval;
 }
-inline uintptr_t ddsrt_atomic_orptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline uintptr_t ddsrt_atomic_orptr_nv (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
     uintptr_t oldval, newval;
     do { oldval = x->v; newval = oldval | v; } while (!ddsrt_atomic_casptr (x, oldval, newval));
     return newval;
 }
-inline void ddsrt_atomic_or32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline void ddsrt_atomic_or32 (ddsrt_atomic_uint32_t *x, uint32_t v) {
     (void) ddsrt_atomic_or32_nv (x, v);
 }
-inline void ddsrt_atomic_orptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline void ddsrt_atomic_orptr (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
     (void) ddsrt_atomic_orptr_nv (x, v);
 }
 

--- a/src/ddsrt/include/dds/ddsrt/atomics/gcc.h
+++ b/src/ddsrt/include/dds/ddsrt/atomics/gcc.h
@@ -29,42 +29,42 @@ extern "C" {
 ddsrt_attribute_no_sanitize (("thread"))
 inline uint32_t ddsrt_atomic_ld32(const ddsrt_atomic_uint32_t *x)
 {
-  return x->v;
+  return __atomic_load_n(&x->v, __ATOMIC_SEQ_CST);
 }
 #if DDSRT_HAVE_ATOMIC64
 ddsrt_attribute_no_sanitize (("thread"))
 inline uint64_t ddsrt_atomic_ld64(const ddsrt_atomic_uint64_t *x)
 {
-  return x->v;
+  return __atomic_load_n(&x->v, __ATOMIC_SEQ_CST);
 }
 #endif
 ddsrt_attribute_no_sanitize (("thread"))
 inline uintptr_t ddsrt_atomic_ldptr(const ddsrt_atomic_uintptr_t *x)
 {
-  return x->v;
+  return __atomic_load_n(&x->v, __ATOMIC_SEQ_CST);
 }
 ddsrt_attribute_no_sanitize (("thread"))
 inline void *ddsrt_atomic_ldvoidp(const ddsrt_atomic_voidp_t *x)
 {
-  return (void *) ddsrt_atomic_ldptr(x);
+  return (void *) __atomic_load_n(&x->v, __ATOMIC_SEQ_CST);
 }
 
 ddsrt_attribute_no_sanitize (("thread"))
 inline void ddsrt_atomic_st32(ddsrt_atomic_uint32_t *x, uint32_t v)
 {
-  x->v = v;
+  __atomic_store_n(&x->v, v, __ATOMIC_SEQ_CST);
 }
 #if DDSRT_HAVE_ATOMIC64
 ddsrt_attribute_no_sanitize (("thread"))
 inline void ddsrt_atomic_st64(ddsrt_atomic_uint64_t *x, uint64_t v)
 {
-  x->v = v;
+  __atomic_store_n(&x->v, v, __ATOMIC_SEQ_CST);
 }
 #endif
 ddsrt_attribute_no_sanitize (("thread"))
 inline void ddsrt_atomic_stptr(ddsrt_atomic_uintptr_t *x, uintptr_t v)
 {
-  x->v = v;
+  __atomic_store_n(&x->v, v, __ATOMIC_SEQ_CST);
 }
 ddsrt_attribute_no_sanitize (("thread"))
 inline void ddsrt_atomic_stvoidp(ddsrt_atomic_voidp_t *x, void *v)
@@ -75,96 +75,96 @@ inline void ddsrt_atomic_stvoidp(ddsrt_atomic_voidp_t *x, void *v)
 /* INC */
 
 inline void ddsrt_atomic_inc32(ddsrt_atomic_uint32_t *x) {
-  __sync_fetch_and_add (&x->v, 1);
+  __atomic_fetch_add(&x->v, 1, __ATOMIC_SEQ_CST);
 }
 #if DDSRT_HAVE_ATOMIC64
 inline void ddsrt_atomic_inc64 (ddsrt_atomic_uint64_t *x) {
-  __sync_fetch_and_add (&x->v, 1);
+  __atomic_fetch_add(&x->v, 1, __ATOMIC_SEQ_CST);
 }
 #endif
 inline void ddsrt_atomic_incptr (ddsrt_atomic_uintptr_t *x) {
-  __sync_fetch_and_add (&x->v, 1);
+  __atomic_fetch_add(&x->v, 1, __ATOMIC_SEQ_CST);
 }
 inline uint32_t ddsrt_atomic_inc32_ov (ddsrt_atomic_uint32_t *x) {
-  return __sync_fetch_and_add (&x->v, 1);
+  return __atomic_fetch_add(&x->v, 1, __ATOMIC_SEQ_CST);
 }
 inline uint32_t ddsrt_atomic_inc32_nv (ddsrt_atomic_uint32_t *x) {
-  return __sync_add_and_fetch (&x->v, 1);
+  return __atomic_add_fetch(&x->v, 1, __ATOMIC_SEQ_CST);
 }
 #if DDSRT_HAVE_ATOMIC64
 inline uint64_t ddsrt_atomic_inc64_nv (ddsrt_atomic_uint64_t *x) {
-  return __sync_add_and_fetch (&x->v, 1);
+  return __atomic_add_fetch(&x->v, 1, __ATOMIC_SEQ_CST);
 }
 #endif
 inline uintptr_t ddsrt_atomic_incptr_nv (ddsrt_atomic_uintptr_t *x) {
-  return __sync_add_and_fetch (&x->v, 1);
+  return __atomic_add_fetch(&x->v, 1, __ATOMIC_SEQ_CST);
 }
 
 /* DEC */
 
 inline void ddsrt_atomic_dec32 (ddsrt_atomic_uint32_t *x) {
-  __sync_fetch_and_sub (&x->v, 1);
+  __atomic_fetch_sub(&x->v, 1, __ATOMIC_SEQ_CST);
 }
 #if DDSRT_HAVE_ATOMIC64
 inline void ddsrt_atomic_dec64 (ddsrt_atomic_uint64_t *x) {
-  __sync_fetch_and_sub (&x->v, 1);
+  __atomic_fetch_sub(&x->v, 1, __ATOMIC_SEQ_CST);
 }
 #endif
 inline void ddsrt_atomic_decptr (ddsrt_atomic_uintptr_t *x) {
-  __sync_fetch_and_sub (&x->v, 1);
+  __atomic_fetch_sub(&x->v, 1, __ATOMIC_SEQ_CST);
 }
 inline uint32_t ddsrt_atomic_dec32_nv (ddsrt_atomic_uint32_t *x) {
-  return __sync_sub_and_fetch (&x->v, 1);
+  return __atomic_sub_fetch(&x->v, 1, __ATOMIC_SEQ_CST);
 }
 #if DDSRT_HAVE_ATOMIC64
 inline uint64_t ddsrt_atomic_dec64_nv (ddsrt_atomic_uint64_t *x) {
-  return __sync_sub_and_fetch (&x->v, 1);
+  return __atomic_sub_fetch(&x->v, 1, __ATOMIC_SEQ_CST);
 }
 #endif
 inline uintptr_t ddsrt_atomic_decptr_nv (ddsrt_atomic_uintptr_t *x) {
-  return __sync_sub_and_fetch (&x->v, 1);
+  return __atomic_sub_fetch(&x->v, 1, __ATOMIC_SEQ_CST);
 }
 inline uint32_t ddsrt_atomic_dec32_ov (ddsrt_atomic_uint32_t *x) {
-  return __sync_fetch_and_sub (&x->v, 1);
+  return __atomic_sub_fetch(&x->v, 1, __ATOMIC_SEQ_CST);
 }
 #if DDSRT_HAVE_ATOMIC64
 inline uint64_t ddsrt_atomic_dec64_ov (ddsrt_atomic_uint64_t *x) {
-  return __sync_fetch_and_sub (&x->v, 1);
+  return __atomic_sub_fetch(&x->v, 1, __ATOMIC_SEQ_CST);
 }
 #endif
 inline uintptr_t ddsrt_atomic_decptr_ov (ddsrt_atomic_uintptr_t *x) {
-  return __sync_fetch_and_sub (&x->v, 1);
+  return __atomic_fetch_sub(&x->v, 1, __ATOMIC_SEQ_CST);
 }
 
 /* ADD */
 
 inline void ddsrt_atomic_add32 (ddsrt_atomic_uint32_t *x, uint32_t v) {
-  __sync_fetch_and_add (&x->v, v);
+  __atomic_fetch_add(&x->v, v, __ATOMIC_SEQ_CST);
 }
 #if DDSRT_HAVE_ATOMIC64
 inline void ddsrt_atomic_add64 (ddsrt_atomic_uint64_t *x, uint64_t v) {
-  __sync_fetch_and_add (&x->v, v);
+  __atomic_fetch_add(&x->v, v, __ATOMIC_SEQ_CST);
 }
 #endif
 inline void ddsrt_atomic_addptr (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  __sync_fetch_and_add (&x->v, v);
+  __atomic_fetch_add(&x->v, v, __ATOMIC_SEQ_CST);
 }
 inline void ddsrt_atomic_addvoidp (ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
   ddsrt_atomic_addptr ((ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
 }
 inline uint32_t ddsrt_atomic_add32_ov (ddsrt_atomic_uint32_t *x, uint32_t v) {
-  return __sync_fetch_and_add (&x->v, v);
+  return __atomic_fetch_add(&x->v, v, __ATOMIC_SEQ_CST);
 }
 inline uint32_t ddsrt_atomic_add32_nv (ddsrt_atomic_uint32_t *x, uint32_t v) {
-  return __sync_add_and_fetch (&x->v, v);
+  return __atomic_add_fetch(&x->v, v, __ATOMIC_SEQ_CST);
 }
 #if DDSRT_HAVE_ATOMIC64
 inline uint64_t ddsrt_atomic_add64_nv (ddsrt_atomic_uint64_t *x, uint64_t v) {
-  return __sync_add_and_fetch (&x->v, v);
+  return __atomic_add_fetch(&x->v, v, __ATOMIC_SEQ_CST);
 }
 #endif
 inline uintptr_t ddsrt_atomic_addptr_nv (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  return __sync_add_and_fetch (&x->v, v);
+  return __atomic_add_fetch(&x->v, v, __ATOMIC_SEQ_CST);
 }
 inline void *ddsrt_atomic_addvoidp_nv (ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
   return (void *) ddsrt_atomic_addptr_nv ((ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
@@ -173,32 +173,32 @@ inline void *ddsrt_atomic_addvoidp_nv (ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
 /* SUB */
 
 inline void ddsrt_atomic_sub32 (ddsrt_atomic_uint32_t *x, uint32_t v) {
-  __sync_fetch_and_sub (&x->v, v);
+  __atomic_fetch_sub(&x->v, v, __ATOMIC_SEQ_CST);
 }
 #if DDSRT_HAVE_ATOMIC64
 inline void ddsrt_atomic_sub64 (ddsrt_atomic_uint64_t *x, uint64_t v) {
-  __sync_fetch_and_sub (&x->v, v);
+  __atomic_fetch_sub(&x->v, v, __ATOMIC_SEQ_CST);
 }
 #endif
 inline void ddsrt_atomic_subptr (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  __sync_fetch_and_sub (&x->v, v);
+  __atomic_fetch_sub(&x->v, v, __ATOMIC_SEQ_CST);
 }
 inline void ddsrt_atomic_subvoidp (ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
   ddsrt_atomic_subptr ((ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
 }
 inline uint32_t ddsrt_atomic_sub32_ov (ddsrt_atomic_uint32_t *x, uint32_t v) {
-  return __sync_fetch_and_sub (&x->v, v);
+  return __atomic_fetch_sub(&x->v, v, __ATOMIC_SEQ_CST);
 }
 inline uint32_t ddsrt_atomic_sub32_nv (ddsrt_atomic_uint32_t *x, uint32_t v) {
-  return __sync_sub_and_fetch (&x->v, v);
+  return __atomic_sub_fetch(&x->v, v, __ATOMIC_SEQ_CST);
 }
 #if DDSRT_HAVE_ATOMIC64
 inline uint64_t ddsrt_atomic_sub64_nv (ddsrt_atomic_uint64_t *x, uint64_t v) {
-  return __sync_sub_and_fetch (&x->v, v);
+  return __atomic_sub_fetch(&x->v, v, __ATOMIC_SEQ_CST);
 }
 #endif
 inline uintptr_t ddsrt_atomic_subptr_nv (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  return __sync_sub_and_fetch (&x->v, v);
+  return __atomic_sub_fetch(&x->v, v, __ATOMIC_SEQ_CST);
 }
 inline void *ddsrt_atomic_subvoidp_nv (ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
   return (void *) ddsrt_atomic_subptr_nv ((ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
@@ -207,90 +207,89 @@ inline void *ddsrt_atomic_subvoidp_nv (ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
 /* AND */
 
 inline void ddsrt_atomic_and32 (ddsrt_atomic_uint32_t *x, uint32_t v) {
-  __sync_fetch_and_and (&x->v, v);
+  __atomic_fetch_and(&x->v, v, __ATOMIC_SEQ_CST);
 }
 #if DDSRT_HAVE_ATOMIC64
 inline void ddsrt_atomic_and64 (ddsrt_atomic_uint64_t *x, uint64_t v) {
-  __sync_fetch_and_and (&x->v, v);
+  __atomic_fetch_and(&x->v, v, __ATOMIC_SEQ_CST);
 }
 #endif
 inline void ddsrt_atomic_andptr (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  __sync_fetch_and_and (&x->v, v);
+  __atomic_fetch_and(&x->v, v, __ATOMIC_SEQ_CST);
 }
 inline uint32_t ddsrt_atomic_and32_ov (ddsrt_atomic_uint32_t *x, uint32_t v) {
-  return __sync_fetch_and_and (&x->v, v);
+  return __atomic_fetch_and(&x->v, v, __ATOMIC_SEQ_CST);
 }
 #if DDSRT_HAVE_ATOMIC64
 inline uint64_t ddsrt_atomic_and64_ov (ddsrt_atomic_uint64_t *x, uint64_t v) {
-  return __sync_fetch_and_and (&x->v, v);
+  return __atomic_fetch_and(&x->v, v, __ATOMIC_SEQ_CST);
 }
 #endif
 inline uintptr_t ddsrt_atomic_andptr_ov (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  return __sync_fetch_and_and (&x->v, v);
+  return __atomic_fetch_and(&x->v, v, __ATOMIC_SEQ_CST);
 }
 inline uint32_t ddsrt_atomic_and32_nv (ddsrt_atomic_uint32_t *x, uint32_t v) {
-  return __sync_and_and_fetch (&x->v, v);
+  return __atomic_and_fetch(&x->v, v, __ATOMIC_SEQ_CST);
 }
 #if DDSRT_HAVE_ATOMIC64
 inline uint64_t ddsrt_atomic_and64_nv (ddsrt_atomic_uint64_t *x, uint64_t v) {
-  return __sync_and_and_fetch (&x->v, v);
+  return __atomic_and_fetch(&x->v, v, __ATOMIC_SEQ_CST);
 }
 #endif
 inline uintptr_t ddsrt_atomic_andptr_nv (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  return __sync_and_and_fetch (&x->v, v);
+  return __atomic_and_fetch (&x->v, v, __ATOMIC_SEQ_CST);
 }
 
 /* OR */
 
 inline void ddsrt_atomic_or32 (ddsrt_atomic_uint32_t *x, uint32_t v) {
-  __sync_fetch_and_or (&x->v, v);
+  __atomic_fetch_or (&x->v, v, __ATOMIC_SEQ_CST);
 }
 #if DDSRT_HAVE_ATOMIC64
 inline void ddsrt_atomic_or64 (ddsrt_atomic_uint64_t *x, uint64_t v) {
-  __sync_fetch_and_or (&x->v, v);
+  __atomic_fetch_or (&x->v, v, __ATOMIC_SEQ_CST);
 }
 #endif
 inline void ddsrt_atomic_orptr (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  __sync_fetch_and_or (&x->v, v);
+  __atomic_fetch_or (&x->v, v, __ATOMIC_SEQ_CST);
 }
 inline uint32_t ddsrt_atomic_or32_ov (ddsrt_atomic_uint32_t *x, uint32_t v) {
-  return __sync_fetch_and_or (&x->v, v);
+  return __atomic_fetch_or (&x->v, v, __ATOMIC_SEQ_CST);
 }
 #if DDSRT_HAVE_ATOMIC64
 inline uint64_t ddsrt_atomic_or64_ov (ddsrt_atomic_uint64_t *x, uint64_t v) {
-  return __sync_fetch_and_or (&x->v, v);
+  return __atomic_fetch_or (&x->v, v, __ATOMIC_SEQ_CST);
 }
 #endif
 inline uintptr_t ddsrt_atomic_orptr_ov (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  return __sync_fetch_and_or (&x->v, v);
+  return __atomic_fetch_or (&x->v, v, __ATOMIC_SEQ_CST);
 }
 inline uint32_t ddsrt_atomic_or32_nv (ddsrt_atomic_uint32_t *x, uint32_t v) {
-  return __sync_or_and_fetch (&x->v, v);
+  return __atomic_or_fetch (&x->v, v, __ATOMIC_SEQ_CST);
 }
 #if DDSRT_HAVE_ATOMIC64
 inline uint64_t ddsrt_atomic_or64_nv (ddsrt_atomic_uint64_t *x, uint64_t v) {
-  return __sync_or_and_fetch (&x->v, v);
+  return __atomic_or_fetch (&x->v, v, __ATOMIC_SEQ_CST);
 }
 #endif
 inline uintptr_t ddsrt_atomic_orptr_nv (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  return __sync_or_and_fetch (&x->v, v);
+  return __atomic_or_fetch (&x->v, v, __ATOMIC_SEQ_CST);
 }
 
 /* CAS */
-
-inline int ddsrt_atomic_cas32 (ddsrt_atomic_uint32_t *x, uint32_t exp, uint32_t des) {
-  return __sync_bool_compare_and_swap (&x->v, exp, des);
+inline bool ddsrt_atomic_cas32 (ddsrt_atomic_uint32_t *x, uint32_t exp, uint32_t des) {
+  return __atomic_compare_exchange_n(&x->v, &exp, des, false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
 }
 #if DDSRT_HAVE_ATOMIC64
-inline int ddsrt_atomic_cas64 (ddsrt_atomic_uint64_t *x, uint64_t exp, uint64_t des) {
-  return __sync_bool_compare_and_swap (&x->v, exp, des);
+inline bool ddsrt_atomic_cas64 (ddsrt_atomic_uint64_t *x, uint64_t exp, uint64_t des) {
+  return __atomic_compare_exchange_n (&x->v, &exp, des, false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
 }
 #endif
-inline int ddsrt_atomic_casptr (ddsrt_atomic_uintptr_t *x, uintptr_t exp, uintptr_t des) {
-  return __sync_bool_compare_and_swap (&x->v, exp, des);
+inline bool ddsrt_atomic_casptr (ddsrt_atomic_uintptr_t *x, uintptr_t exp, uintptr_t des) {
+  return __atomic_compare_exchange_n (&x->v, &exp, des, false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
 }
-inline int ddsrt_atomic_casvoidp (ddsrt_atomic_voidp_t *x, void *exp, void *des) {
-  return ddsrt_atomic_casptr (x, (uintptr_t) exp, (uintptr_t) des);
+inline bool ddsrt_atomic_casvoidp (ddsrt_atomic_voidp_t *x, void *exp, void *des) {
+  return __atomic_compare_exchange_n ((void **)(&x->v), &exp, des, false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
 }
 #if DDSRT_HAVE_ATOMIC_LIFO
 #if DDSRT_HAVE_ATOMIC64
@@ -319,21 +318,21 @@ inline int ddsrt_atomic_casvoidp2 (ddsrt_atomic_uintptr2_t *x, uintptr_t a0, uin
 /* FENCES */
 
 inline void ddsrt_atomic_fence (void) {
-  __sync_synchronize ();
+  __atomic_thread_fence (__ATOMIC_SEQ_CST);
 }
 inline void ddsrt_atomic_fence_ldld (void) {
 #if !(defined __i386__ || defined __x86_64__ || defined _M_IX86 || defined _M_X64)
-  __sync_synchronize ();
+  __atomic_thread_fence (__ATOMIC_SEQ_CST);
 #endif
 }
 inline void ddsrt_atomic_fence_stst (void) {
 #if !(defined __i386__ || defined __x86_64__ || defined _M_IX86 || defined _M_X64)
-  __sync_synchronize ();
+  __sync_synchronize (__ATOMIC_SEQ_CST);
 #endif
 }
 inline void ddsrt_atomic_fence_acq (void) {
 #if !(defined __i386__ || defined __x86_64__ || defined _M_IX86 || defined _M_X64)
-  ddsrt_atomic_fence ();
+  ddsrt_atomic_fence (__ATOMIC_SEQ_CST);
 #else
   asm volatile ("" ::: "memory");
 #endif

--- a/src/ddsrt/include/dds/ddsrt/atomics/gcc.h
+++ b/src/ddsrt/include/dds/ddsrt/atomics/gcc.h
@@ -27,269 +27,269 @@ extern "C" {
 /* LD, ST */
 
 ddsrt_attribute_no_sanitize (("thread"))
-inline uint32_t ddsrt_atomic_ld32(const volatile ddsrt_atomic_uint32_t *x)
+inline uint32_t ddsrt_atomic_ld32(const ddsrt_atomic_uint32_t *x)
 {
   return x->v;
 }
 #if DDSRT_HAVE_ATOMIC64
 ddsrt_attribute_no_sanitize (("thread"))
-inline uint64_t ddsrt_atomic_ld64(const volatile ddsrt_atomic_uint64_t *x)
+inline uint64_t ddsrt_atomic_ld64(const ddsrt_atomic_uint64_t *x)
 {
   return x->v;
 }
 #endif
 ddsrt_attribute_no_sanitize (("thread"))
-inline uintptr_t ddsrt_atomic_ldptr(const volatile ddsrt_atomic_uintptr_t *x)
+inline uintptr_t ddsrt_atomic_ldptr(const ddsrt_atomic_uintptr_t *x)
 {
   return x->v;
 }
 ddsrt_attribute_no_sanitize (("thread"))
-inline void *ddsrt_atomic_ldvoidp(const volatile ddsrt_atomic_voidp_t *x)
+inline void *ddsrt_atomic_ldvoidp(const ddsrt_atomic_voidp_t *x)
 {
   return (void *) ddsrt_atomic_ldptr(x);
 }
 
 ddsrt_attribute_no_sanitize (("thread"))
-inline void ddsrt_atomic_st32(volatile ddsrt_atomic_uint32_t *x, uint32_t v)
+inline void ddsrt_atomic_st32(ddsrt_atomic_uint32_t *x, uint32_t v)
 {
   x->v = v;
 }
 #if DDSRT_HAVE_ATOMIC64
 ddsrt_attribute_no_sanitize (("thread"))
-inline void ddsrt_atomic_st64(volatile ddsrt_atomic_uint64_t *x, uint64_t v)
+inline void ddsrt_atomic_st64(ddsrt_atomic_uint64_t *x, uint64_t v)
 {
   x->v = v;
 }
 #endif
 ddsrt_attribute_no_sanitize (("thread"))
-inline void ddsrt_atomic_stptr(volatile ddsrt_atomic_uintptr_t *x, uintptr_t v)
+inline void ddsrt_atomic_stptr(ddsrt_atomic_uintptr_t *x, uintptr_t v)
 {
   x->v = v;
 }
 ddsrt_attribute_no_sanitize (("thread"))
-inline void ddsrt_atomic_stvoidp(volatile ddsrt_atomic_voidp_t *x, void *v)
+inline void ddsrt_atomic_stvoidp(ddsrt_atomic_voidp_t *x, void *v)
 {
   ddsrt_atomic_stptr(x, (uintptr_t)v);
 }
 
 /* INC */
 
-inline void ddsrt_atomic_inc32(volatile ddsrt_atomic_uint32_t *x) {
+inline void ddsrt_atomic_inc32(ddsrt_atomic_uint32_t *x) {
   __sync_fetch_and_add (&x->v, 1);
 }
 #if DDSRT_HAVE_ATOMIC64
-inline void ddsrt_atomic_inc64 (volatile ddsrt_atomic_uint64_t *x) {
+inline void ddsrt_atomic_inc64 (ddsrt_atomic_uint64_t *x) {
   __sync_fetch_and_add (&x->v, 1);
 }
 #endif
-inline void ddsrt_atomic_incptr (volatile ddsrt_atomic_uintptr_t *x) {
+inline void ddsrt_atomic_incptr (ddsrt_atomic_uintptr_t *x) {
   __sync_fetch_and_add (&x->v, 1);
 }
-inline uint32_t ddsrt_atomic_inc32_ov (volatile ddsrt_atomic_uint32_t *x) {
+inline uint32_t ddsrt_atomic_inc32_ov (ddsrt_atomic_uint32_t *x) {
   return __sync_fetch_and_add (&x->v, 1);
 }
-inline uint32_t ddsrt_atomic_inc32_nv (volatile ddsrt_atomic_uint32_t *x) {
+inline uint32_t ddsrt_atomic_inc32_nv (ddsrt_atomic_uint32_t *x) {
   return __sync_add_and_fetch (&x->v, 1);
 }
 #if DDSRT_HAVE_ATOMIC64
-inline uint64_t ddsrt_atomic_inc64_nv (volatile ddsrt_atomic_uint64_t *x) {
+inline uint64_t ddsrt_atomic_inc64_nv (ddsrt_atomic_uint64_t *x) {
   return __sync_add_and_fetch (&x->v, 1);
 }
 #endif
-inline uintptr_t ddsrt_atomic_incptr_nv (volatile ddsrt_atomic_uintptr_t *x) {
+inline uintptr_t ddsrt_atomic_incptr_nv (ddsrt_atomic_uintptr_t *x) {
   return __sync_add_and_fetch (&x->v, 1);
 }
 
 /* DEC */
 
-inline void ddsrt_atomic_dec32 (volatile ddsrt_atomic_uint32_t *x) {
+inline void ddsrt_atomic_dec32 (ddsrt_atomic_uint32_t *x) {
   __sync_fetch_and_sub (&x->v, 1);
 }
 #if DDSRT_HAVE_ATOMIC64
-inline void ddsrt_atomic_dec64 (volatile ddsrt_atomic_uint64_t *x) {
+inline void ddsrt_atomic_dec64 (ddsrt_atomic_uint64_t *x) {
   __sync_fetch_and_sub (&x->v, 1);
 }
 #endif
-inline void ddsrt_atomic_decptr (volatile ddsrt_atomic_uintptr_t *x) {
+inline void ddsrt_atomic_decptr (ddsrt_atomic_uintptr_t *x) {
   __sync_fetch_and_sub (&x->v, 1);
 }
-inline uint32_t ddsrt_atomic_dec32_nv (volatile ddsrt_atomic_uint32_t *x) {
+inline uint32_t ddsrt_atomic_dec32_nv (ddsrt_atomic_uint32_t *x) {
   return __sync_sub_and_fetch (&x->v, 1);
 }
 #if DDSRT_HAVE_ATOMIC64
-inline uint64_t ddsrt_atomic_dec64_nv (volatile ddsrt_atomic_uint64_t *x) {
+inline uint64_t ddsrt_atomic_dec64_nv (ddsrt_atomic_uint64_t *x) {
   return __sync_sub_and_fetch (&x->v, 1);
 }
 #endif
-inline uintptr_t ddsrt_atomic_decptr_nv (volatile ddsrt_atomic_uintptr_t *x) {
+inline uintptr_t ddsrt_atomic_decptr_nv (ddsrt_atomic_uintptr_t *x) {
   return __sync_sub_and_fetch (&x->v, 1);
 }
-inline uint32_t ddsrt_atomic_dec32_ov (volatile ddsrt_atomic_uint32_t *x) {
+inline uint32_t ddsrt_atomic_dec32_ov (ddsrt_atomic_uint32_t *x) {
   return __sync_fetch_and_sub (&x->v, 1);
 }
 #if DDSRT_HAVE_ATOMIC64
-inline uint64_t ddsrt_atomic_dec64_ov (volatile ddsrt_atomic_uint64_t *x) {
+inline uint64_t ddsrt_atomic_dec64_ov (ddsrt_atomic_uint64_t *x) {
   return __sync_fetch_and_sub (&x->v, 1);
 }
 #endif
-inline uintptr_t ddsrt_atomic_decptr_ov (volatile ddsrt_atomic_uintptr_t *x) {
+inline uintptr_t ddsrt_atomic_decptr_ov (ddsrt_atomic_uintptr_t *x) {
   return __sync_fetch_and_sub (&x->v, 1);
 }
 
 /* ADD */
 
-inline void ddsrt_atomic_add32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline void ddsrt_atomic_add32 (ddsrt_atomic_uint32_t *x, uint32_t v) {
   __sync_fetch_and_add (&x->v, v);
 }
 #if DDSRT_HAVE_ATOMIC64
-inline void ddsrt_atomic_add64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
+inline void ddsrt_atomic_add64 (ddsrt_atomic_uint64_t *x, uint64_t v) {
   __sync_fetch_and_add (&x->v, v);
 }
 #endif
-inline void ddsrt_atomic_addptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline void ddsrt_atomic_addptr (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
   __sync_fetch_and_add (&x->v, v);
 }
-inline void ddsrt_atomic_addvoidp (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
-  ddsrt_atomic_addptr ((volatile ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
+inline void ddsrt_atomic_addvoidp (ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
+  ddsrt_atomic_addptr ((ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
 }
-inline uint32_t ddsrt_atomic_add32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline uint32_t ddsrt_atomic_add32_ov (ddsrt_atomic_uint32_t *x, uint32_t v) {
   return __sync_fetch_and_add (&x->v, v);
 }
-inline uint32_t ddsrt_atomic_add32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline uint32_t ddsrt_atomic_add32_nv (ddsrt_atomic_uint32_t *x, uint32_t v) {
   return __sync_add_and_fetch (&x->v, v);
 }
 #if DDSRT_HAVE_ATOMIC64
-inline uint64_t ddsrt_atomic_add64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
+inline uint64_t ddsrt_atomic_add64_nv (ddsrt_atomic_uint64_t *x, uint64_t v) {
   return __sync_add_and_fetch (&x->v, v);
 }
 #endif
-inline uintptr_t ddsrt_atomic_addptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline uintptr_t ddsrt_atomic_addptr_nv (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
   return __sync_add_and_fetch (&x->v, v);
 }
-inline void *ddsrt_atomic_addvoidp_nv (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
-  return (void *) ddsrt_atomic_addptr_nv ((volatile ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
+inline void *ddsrt_atomic_addvoidp_nv (ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
+  return (void *) ddsrt_atomic_addptr_nv ((ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
 }
 
 /* SUB */
 
-inline void ddsrt_atomic_sub32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline void ddsrt_atomic_sub32 (ddsrt_atomic_uint32_t *x, uint32_t v) {
   __sync_fetch_and_sub (&x->v, v);
 }
 #if DDSRT_HAVE_ATOMIC64
-inline void ddsrt_atomic_sub64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
+inline void ddsrt_atomic_sub64 (ddsrt_atomic_uint64_t *x, uint64_t v) {
   __sync_fetch_and_sub (&x->v, v);
 }
 #endif
-inline void ddsrt_atomic_subptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline void ddsrt_atomic_subptr (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
   __sync_fetch_and_sub (&x->v, v);
 }
-inline void ddsrt_atomic_subvoidp (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
-  ddsrt_atomic_subptr ((volatile ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
+inline void ddsrt_atomic_subvoidp (ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
+  ddsrt_atomic_subptr ((ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
 }
-inline uint32_t ddsrt_atomic_sub32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline uint32_t ddsrt_atomic_sub32_ov (ddsrt_atomic_uint32_t *x, uint32_t v) {
   return __sync_fetch_and_sub (&x->v, v);
 }
-inline uint32_t ddsrt_atomic_sub32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline uint32_t ddsrt_atomic_sub32_nv (ddsrt_atomic_uint32_t *x, uint32_t v) {
   return __sync_sub_and_fetch (&x->v, v);
 }
 #if DDSRT_HAVE_ATOMIC64
-inline uint64_t ddsrt_atomic_sub64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
+inline uint64_t ddsrt_atomic_sub64_nv (ddsrt_atomic_uint64_t *x, uint64_t v) {
   return __sync_sub_and_fetch (&x->v, v);
 }
 #endif
-inline uintptr_t ddsrt_atomic_subptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline uintptr_t ddsrt_atomic_subptr_nv (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
   return __sync_sub_and_fetch (&x->v, v);
 }
-inline void *ddsrt_atomic_subvoidp_nv (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
-  return (void *) ddsrt_atomic_subptr_nv ((volatile ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
+inline void *ddsrt_atomic_subvoidp_nv (ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
+  return (void *) ddsrt_atomic_subptr_nv ((ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
 }
 
 /* AND */
 
-inline void ddsrt_atomic_and32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline void ddsrt_atomic_and32 (ddsrt_atomic_uint32_t *x, uint32_t v) {
   __sync_fetch_and_and (&x->v, v);
 }
 #if DDSRT_HAVE_ATOMIC64
-inline void ddsrt_atomic_and64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
+inline void ddsrt_atomic_and64 (ddsrt_atomic_uint64_t *x, uint64_t v) {
   __sync_fetch_and_and (&x->v, v);
 }
 #endif
-inline void ddsrt_atomic_andptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline void ddsrt_atomic_andptr (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
   __sync_fetch_and_and (&x->v, v);
 }
-inline uint32_t ddsrt_atomic_and32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline uint32_t ddsrt_atomic_and32_ov (ddsrt_atomic_uint32_t *x, uint32_t v) {
   return __sync_fetch_and_and (&x->v, v);
 }
 #if DDSRT_HAVE_ATOMIC64
-inline uint64_t ddsrt_atomic_and64_ov (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
+inline uint64_t ddsrt_atomic_and64_ov (ddsrt_atomic_uint64_t *x, uint64_t v) {
   return __sync_fetch_and_and (&x->v, v);
 }
 #endif
-inline uintptr_t ddsrt_atomic_andptr_ov (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline uintptr_t ddsrt_atomic_andptr_ov (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
   return __sync_fetch_and_and (&x->v, v);
 }
-inline uint32_t ddsrt_atomic_and32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline uint32_t ddsrt_atomic_and32_nv (ddsrt_atomic_uint32_t *x, uint32_t v) {
   return __sync_and_and_fetch (&x->v, v);
 }
 #if DDSRT_HAVE_ATOMIC64
-inline uint64_t ddsrt_atomic_and64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
+inline uint64_t ddsrt_atomic_and64_nv (ddsrt_atomic_uint64_t *x, uint64_t v) {
   return __sync_and_and_fetch (&x->v, v);
 }
 #endif
-inline uintptr_t ddsrt_atomic_andptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline uintptr_t ddsrt_atomic_andptr_nv (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
   return __sync_and_and_fetch (&x->v, v);
 }
 
 /* OR */
 
-inline void ddsrt_atomic_or32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline void ddsrt_atomic_or32 (ddsrt_atomic_uint32_t *x, uint32_t v) {
   __sync_fetch_and_or (&x->v, v);
 }
 #if DDSRT_HAVE_ATOMIC64
-inline void ddsrt_atomic_or64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
+inline void ddsrt_atomic_or64 (ddsrt_atomic_uint64_t *x, uint64_t v) {
   __sync_fetch_and_or (&x->v, v);
 }
 #endif
-inline void ddsrt_atomic_orptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline void ddsrt_atomic_orptr (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
   __sync_fetch_and_or (&x->v, v);
 }
-inline uint32_t ddsrt_atomic_or32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline uint32_t ddsrt_atomic_or32_ov (ddsrt_atomic_uint32_t *x, uint32_t v) {
   return __sync_fetch_and_or (&x->v, v);
 }
 #if DDSRT_HAVE_ATOMIC64
-inline uint64_t ddsrt_atomic_or64_ov (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
+inline uint64_t ddsrt_atomic_or64_ov (ddsrt_atomic_uint64_t *x, uint64_t v) {
   return __sync_fetch_and_or (&x->v, v);
 }
 #endif
-inline uintptr_t ddsrt_atomic_orptr_ov (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline uintptr_t ddsrt_atomic_orptr_ov (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
   return __sync_fetch_and_or (&x->v, v);
 }
-inline uint32_t ddsrt_atomic_or32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline uint32_t ddsrt_atomic_or32_nv (ddsrt_atomic_uint32_t *x, uint32_t v) {
   return __sync_or_and_fetch (&x->v, v);
 }
 #if DDSRT_HAVE_ATOMIC64
-inline uint64_t ddsrt_atomic_or64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
+inline uint64_t ddsrt_atomic_or64_nv (ddsrt_atomic_uint64_t *x, uint64_t v) {
   return __sync_or_and_fetch (&x->v, v);
 }
 #endif
-inline uintptr_t ddsrt_atomic_orptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline uintptr_t ddsrt_atomic_orptr_nv (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
   return __sync_or_and_fetch (&x->v, v);
 }
 
 /* CAS */
 
-inline int ddsrt_atomic_cas32 (volatile ddsrt_atomic_uint32_t *x, uint32_t exp, uint32_t des) {
+inline int ddsrt_atomic_cas32 (ddsrt_atomic_uint32_t *x, uint32_t exp, uint32_t des) {
   return __sync_bool_compare_and_swap (&x->v, exp, des);
 }
 #if DDSRT_HAVE_ATOMIC64
-inline int ddsrt_atomic_cas64 (volatile ddsrt_atomic_uint64_t *x, uint64_t exp, uint64_t des) {
+inline int ddsrt_atomic_cas64 (ddsrt_atomic_uint64_t *x, uint64_t exp, uint64_t des) {
   return __sync_bool_compare_and_swap (&x->v, exp, des);
 }
 #endif
-inline int ddsrt_atomic_casptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t exp, uintptr_t des) {
+inline int ddsrt_atomic_casptr (ddsrt_atomic_uintptr_t *x, uintptr_t exp, uintptr_t des) {
   return __sync_bool_compare_and_swap (&x->v, exp, des);
 }
-inline int ddsrt_atomic_casvoidp (volatile ddsrt_atomic_voidp_t *x, void *exp, void *des) {
+inline int ddsrt_atomic_casvoidp (ddsrt_atomic_voidp_t *x, void *exp, void *des) {
   return ddsrt_atomic_casptr (x, (uintptr_t) exp, (uintptr_t) des);
 }
 #if DDSRT_HAVE_ATOMIC_LIFO
@@ -308,7 +308,7 @@ DDS_EXPORT void ddsrt_atomic_lifo_push(ddsrt_atomic_lifo_t *head, void *elem, si
 DDS_EXPORT void *ddsrt_atomic_lifo_pop(ddsrt_atomic_lifo_t *head, size_t linkoff);
 DDS_EXPORT void ddsrt_atomic_lifo_pushmany(ddsrt_atomic_lifo_t *head, void *first, void *last, size_t linkoff);
 
-inline int ddsrt_atomic_casvoidp2 (volatile ddsrt_atomic_uintptr2_t *x, uintptr_t a0, uintptr_t b0, uintptr_t a1, uintptr_t b1) {
+inline int ddsrt_atomic_casvoidp2 (ddsrt_atomic_uintptr2_t *x, uintptr_t a0, uintptr_t b0, uintptr_t a1, uintptr_t b1) {
   ddsrt_atomic_uintptr2_t o, n;
   o.s.a = a0; o.s.b = b0;
   n.s.a = a1; n.s.b = b1;

--- a/src/ddsrt/include/dds/ddsrt/atomics/msvc.h
+++ b/src/ddsrt/include/dds/ddsrt/atomics/msvc.h
@@ -32,259 +32,259 @@ extern "C" {
 
 /* LD, ST */
 
-inline uint32_t ddsrt_atomic_ld32 (const volatile ddsrt_atomic_uint32_t *x) { return x->v; }
+inline uint32_t ddsrt_atomic_ld32 (const ddsrt_atomic_uint32_t *x) { return x->v; }
 #if DDSRT_HAVE_ATOMIC64
-inline uint64_t ddsrt_atomic_ld64 (const volatile ddsrt_atomic_uint64_t *x) { return x->v; }
+inline uint64_t ddsrt_atomic_ld64 (const ddsrt_atomic_uint64_t *x) { return x->v; }
 #endif
-inline uintptr_t ddsrt_atomic_ldptr (const volatile ddsrt_atomic_uintptr_t *x) { return x->v; }
-inline void *ddsrt_atomic_ldvoidp (const volatile ddsrt_atomic_voidp_t *x) { return (void *) ddsrt_atomic_ldptr (x); }
+inline uintptr_t ddsrt_atomic_ldptr (const ddsrt_atomic_uintptr_t *x) { return x->v; }
+inline void *ddsrt_atomic_ldvoidp (const ddsrt_atomic_voidp_t *x) { return (void *) ddsrt_atomic_ldptr (x); }
 
-inline void ddsrt_atomic_st32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) { x->v = v; }
+inline void ddsrt_atomic_st32 (ddsrt_atomic_uint32_t *x, uint32_t v) { x->v = v; }
 #if DDSRT_HAVE_ATOMIC64
-inline void ddsrt_atomic_st64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) { x->v = v; }
+inline void ddsrt_atomic_st64 (ddsrt_atomic_uint64_t *x, uint64_t v) { x->v = v; }
 #endif
-inline void ddsrt_atomic_stptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) { x->v = v; }
-inline void ddsrt_atomic_stvoidp (volatile ddsrt_atomic_voidp_t *x, void *v) { ddsrt_atomic_stptr (x, (uintptr_t) v); }
+inline void ddsrt_atomic_stptr (ddsrt_atomic_uintptr_t *x, uintptr_t v) { x->v = v; }
+inline void ddsrt_atomic_stvoidp (ddsrt_atomic_voidp_t *x, void *v) { ddsrt_atomic_stptr (x, (uintptr_t) v); }
 
 /* CAS */
 
-inline int ddsrt_atomic_cas32 (volatile ddsrt_atomic_uint32_t *x, uint32_t exp, uint32_t des) {
+inline int ddsrt_atomic_cas32 (ddsrt_atomic_uint32_t *x, uint32_t exp, uint32_t des) {
   return DDSRT_ATOMIC_OP32 (InterlockedCompareExchange, &x->v, des, exp) == exp;
 }
 #if DDSRT_HAVE_ATOMIC64
-inline int ddsrt_atomic_cas64 (volatile ddsrt_atomic_uint64_t *x, uint64_t exp, uint64_t des) {
+inline int ddsrt_atomic_cas64 (ddsrt_atomic_uint64_t *x, uint64_t exp, uint64_t des) {
   return DDSRT_ATOMIC_OP64 (InterlockedCompareExchange, &x->v, des, exp) == exp;
 }
 #endif
-inline int ddsrt_atomic_casptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t exp, uintptr_t des) {
+inline int ddsrt_atomic_casptr (ddsrt_atomic_uintptr_t *x, uintptr_t exp, uintptr_t des) {
   return DDSRT_ATOMIC_PTROP (InterlockedCompareExchange, &x->v, des, exp) == exp;
 }
-inline int ddsrt_atomic_casvoidp (volatile ddsrt_atomic_voidp_t *x, void *exp, void *des) {
-  return ddsrt_atomic_casptr ((volatile ddsrt_atomic_uintptr_t *) x, (uintptr_t) exp, (uintptr_t) des);
+inline int ddsrt_atomic_casvoidp (ddsrt_atomic_voidp_t *x, void *exp, void *des) {
+  return ddsrt_atomic_casptr ((ddsrt_atomic_uintptr_t *) x, (uintptr_t) exp, (uintptr_t) des);
 }
 
 /* INC */
 
-inline void ddsrt_atomic_inc32 (volatile ddsrt_atomic_uint32_t *x) {
+inline void ddsrt_atomic_inc32 (ddsrt_atomic_uint32_t *x) {
   DDSRT_ATOMIC_OP32 (InterlockedIncrement, &x->v);
 }
 #if DDSRT_HAVE_ATOMIC64
-inline void ddsrt_atomic_inc64 (volatile ddsrt_atomic_uint64_t *x) {
+inline void ddsrt_atomic_inc64 (ddsrt_atomic_uint64_t *x) {
   DDSRT_ATOMIC_OP64 (InterlockedIncrement, &x->v);
 }
 #endif
-inline void ddsrt_atomic_incptr (volatile ddsrt_atomic_uintptr_t *x) {
+inline void ddsrt_atomic_incptr (ddsrt_atomic_uintptr_t *x) {
   DDSRT_ATOMIC_PTROP (InterlockedIncrement, &x->v);
 }
-inline uint32_t ddsrt_atomic_inc32_ov (volatile ddsrt_atomic_uint32_t *x) {
+inline uint32_t ddsrt_atomic_inc32_ov (ddsrt_atomic_uint32_t *x) {
   return DDSRT_ATOMIC_OP32 (InterlockedIncrement, &x->v) - 1;
 }
-inline uint32_t ddsrt_atomic_inc32_nv (volatile ddsrt_atomic_uint32_t *x) {
+inline uint32_t ddsrt_atomic_inc32_nv (ddsrt_atomic_uint32_t *x) {
   return DDSRT_ATOMIC_OP32 (InterlockedIncrement, &x->v);
 }
 #if DDSRT_HAVE_ATOMIC64
-inline uint64_t ddsrt_atomic_inc64_nv (volatile ddsrt_atomic_uint64_t *x) {
+inline uint64_t ddsrt_atomic_inc64_nv (ddsrt_atomic_uint64_t *x) {
   return DDSRT_ATOMIC_OP64 (InterlockedIncrement, &x->v);
 }
 #endif
-inline uintptr_t ddsrt_atomic_incptr_nv (volatile ddsrt_atomic_uintptr_t *x) {
+inline uintptr_t ddsrt_atomic_incptr_nv (ddsrt_atomic_uintptr_t *x) {
   return DDSRT_ATOMIC_PTROP (InterlockedIncrement, &x->v);
 }
 
 /* DEC */
 
-inline void ddsrt_atomic_dec32 (volatile ddsrt_atomic_uint32_t *x) {
+inline void ddsrt_atomic_dec32 (ddsrt_atomic_uint32_t *x) {
   DDSRT_ATOMIC_OP32 (InterlockedDecrement, &x->v);
 }
 #if DDSRT_HAVE_ATOMIC64
-inline void ddsrt_atomic_dec64 (volatile ddsrt_atomic_uint64_t *x) {
+inline void ddsrt_atomic_dec64 (ddsrt_atomic_uint64_t *x) {
   DDSRT_ATOMIC_OP64 (InterlockedDecrement, &x->v);
 }
 #endif
-inline void ddsrt_atomic_decptr (volatile ddsrt_atomic_uintptr_t *x) {
+inline void ddsrt_atomic_decptr (ddsrt_atomic_uintptr_t *x) {
   DDSRT_ATOMIC_PTROP (InterlockedDecrement, &x->v);
 }
-inline uint32_t ddsrt_atomic_dec32_nv (volatile ddsrt_atomic_uint32_t *x) {
+inline uint32_t ddsrt_atomic_dec32_nv (ddsrt_atomic_uint32_t *x) {
   return DDSRT_ATOMIC_OP32 (InterlockedDecrement, &x->v);
 }
 #if DDSRT_HAVE_ATOMIC64
-inline uint64_t ddsrt_atomic_dec64_nv (volatile ddsrt_atomic_uint64_t *x) {
+inline uint64_t ddsrt_atomic_dec64_nv (ddsrt_atomic_uint64_t *x) {
   return DDSRT_ATOMIC_OP64 (InterlockedDecrement, &x->v);
 }
 #endif
-inline uintptr_t ddsrt_atomic_decptr_nv (volatile ddsrt_atomic_uintptr_t *x) {
+inline uintptr_t ddsrt_atomic_decptr_nv (ddsrt_atomic_uintptr_t *x) {
   return DDSRT_ATOMIC_PTROP (InterlockedDecrement, &x->v);
 }
-inline uint32_t ddsrt_atomic_dec32_ov (volatile ddsrt_atomic_uint32_t *x) {
+inline uint32_t ddsrt_atomic_dec32_ov (ddsrt_atomic_uint32_t *x) {
   return DDSRT_ATOMIC_OP32 (InterlockedDecrement, &x->v) + 1;
 }
 #if DDSRT_HAVE_ATOMIC64
-inline uint64_t ddsrt_atomic_dec64_ov (volatile ddsrt_atomic_uint64_t *x) {
+inline uint64_t ddsrt_atomic_dec64_ov (ddsrt_atomic_uint64_t *x) {
   return DDSRT_ATOMIC_OP64 (InterlockedDecrement, &x->v) + 1;
 }
 #endif
-inline uintptr_t ddsrt_atomic_decptr_ov (volatile ddsrt_atomic_uintptr_t *x) {
+inline uintptr_t ddsrt_atomic_decptr_ov (ddsrt_atomic_uintptr_t *x) {
   return DDSRT_ATOMIC_PTROP (InterlockedDecrement, &x->v) + 1;
 }
 
 /* ADD */
 
-inline void ddsrt_atomic_add32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline void ddsrt_atomic_add32 (ddsrt_atomic_uint32_t *x, uint32_t v) {
   DDSRT_ATOMIC_OP32 (InterlockedExchangeAdd, &x->v, v);
 }
 #if DDSRT_HAVE_ATOMIC64
-inline void ddsrt_atomic_add64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
+inline void ddsrt_atomic_add64 (ddsrt_atomic_uint64_t *x, uint64_t v) {
   DDSRT_ATOMIC_OP64 (InterlockedExchangeAdd, &x->v, v);
 }
 #endif
-inline void ddsrt_atomic_addptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline void ddsrt_atomic_addptr (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
   DDSRT_ATOMIC_PTROP (InterlockedExchangeAdd, &x->v, v);
 }
-inline void ddsrt_atomic_addvoidp (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
-  ddsrt_atomic_addptr ((volatile ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
+inline void ddsrt_atomic_addvoidp (ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
+  ddsrt_atomic_addptr ((ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
 }
-inline uint32_t ddsrt_atomic_add32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline uint32_t ddsrt_atomic_add32_ov (ddsrt_atomic_uint32_t *x, uint32_t v) {
   return DDSRT_ATOMIC_OP32 (InterlockedExchangeAdd, &x->v, v);
 }
-inline uint32_t ddsrt_atomic_add32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline uint32_t ddsrt_atomic_add32_nv (ddsrt_atomic_uint32_t *x, uint32_t v) {
   return DDSRT_ATOMIC_OP32 (InterlockedExchangeAdd, &x->v, v) + v;
 }
 #if DDSRT_HAVE_ATOMIC64
-inline uint64_t ddsrt_atomic_add64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
+inline uint64_t ddsrt_atomic_add64_nv (ddsrt_atomic_uint64_t *x, uint64_t v) {
   return DDSRT_ATOMIC_OP64 (InterlockedExchangeAdd, &x->v, v) + v;
 }
 #endif
-inline uintptr_t ddsrt_atomic_addptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline uintptr_t ddsrt_atomic_addptr_nv (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
   return DDSRT_ATOMIC_PTROP (InterlockedExchangeAdd, &x->v, v) + v;
 }
-inline void *ddsrt_atomic_addvoidp_nv (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
-  return (void *) ddsrt_atomic_addptr_nv ((volatile ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
+inline void *ddsrt_atomic_addvoidp_nv (ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
+  return (void *) ddsrt_atomic_addptr_nv ((ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
 }
 
 /* SUB */
 
-inline void ddsrt_atomic_sub32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline void ddsrt_atomic_sub32 (ddsrt_atomic_uint32_t *x, uint32_t v) {
   /* disable unary minus applied to unsigned type, result still unsigned */
   DDSRT_WARNING_MSVC_OFF(4146)
   DDSRT_ATOMIC_OP32 (InterlockedExchangeAdd, &x->v, -v);
   DDSRT_WARNING_MSVC_ON(4146)
 }
 #if DDSRT_HAVE_ATOMIC64
-inline void ddsrt_atomic_sub64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
+inline void ddsrt_atomic_sub64 (ddsrt_atomic_uint64_t *x, uint64_t v) {
   /* disable unary minus applied to unsigned type, result still unsigned */
   DDSRT_WARNING_MSVC_OFF(4146)
   DDSRT_ATOMIC_OP64 (InterlockedExchangeAdd, &x->v, -v);
   DDSRT_WARNING_MSVC_ON(4146)
 }
 #endif
-inline void ddsrt_atomic_subptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline void ddsrt_atomic_subptr (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
   /* disable unary minus applied to unsigned type, result still unsigned */
   DDSRT_WARNING_MSVC_OFF(4146)
   DDSRT_ATOMIC_PTROP (InterlockedExchangeAdd, &x->v, -v);
   DDSRT_WARNING_MSVC_ON(4146)
 }
-inline void ddsrt_atomic_subvoidp (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
-  ddsrt_atomic_subptr ((volatile ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
+inline void ddsrt_atomic_subvoidp (ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
+  ddsrt_atomic_subptr ((ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
 }
-inline uint32_t ddsrt_atomic_sub32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline uint32_t ddsrt_atomic_sub32_ov (ddsrt_atomic_uint32_t *x, uint32_t v) {
   /* disable unary minus applied to unsigned type, result still unsigned */
   DDSRT_WARNING_MSVC_OFF(4146)
   return DDSRT_ATOMIC_OP32 (InterlockedExchangeAdd, &x->v, -v);
   DDSRT_WARNING_MSVC_ON(4146)
 }
-inline uint32_t ddsrt_atomic_sub32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline uint32_t ddsrt_atomic_sub32_nv (ddsrt_atomic_uint32_t *x, uint32_t v) {
   /* disable unary minus applied to unsigned type, result still unsigned */
   DDSRT_WARNING_MSVC_OFF(4146)
   return DDSRT_ATOMIC_OP32 (InterlockedExchangeAdd, &x->v, -v) - v;
   DDSRT_WARNING_MSVC_ON(4146)
 }
 #if DDSRT_HAVE_ATOMIC64
-inline uint64_t ddsrt_atomic_sub64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
+inline uint64_t ddsrt_atomic_sub64_nv (ddsrt_atomic_uint64_t *x, uint64_t v) {
   /* disable unary minus applied to unsigned type, result still unsigned */
   DDSRT_WARNING_MSVC_OFF(4146)
   return DDSRT_ATOMIC_OP64 (InterlockedExchangeAdd, &x->v, -v) - v;
   DDSRT_WARNING_MSVC_ON(4146)
 }
 #endif
-inline uintptr_t ddsrt_atomic_subptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline uintptr_t ddsrt_atomic_subptr_nv (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
   /* disable unary minus applied to unsigned type, result still unsigned */
   DDSRT_WARNING_MSVC_OFF(4146)
   return DDSRT_ATOMIC_PTROP (InterlockedExchangeAdd, &x->v, -v) - v;
   DDSRT_WARNING_MSVC_ON(4146)
 }
-inline void *ddsrt_atomic_subvoidp_nv (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
-  return (void *) ddsrt_atomic_subptr_nv ((volatile ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
+inline void *ddsrt_atomic_subvoidp_nv (ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
+  return (void *) ddsrt_atomic_subptr_nv ((ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
 }
 
 /* AND */
 
-inline void ddsrt_atomic_and32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline void ddsrt_atomic_and32 (ddsrt_atomic_uint32_t *x, uint32_t v) {
   DDSRT_ATOMIC_OP32 (InterlockedAnd, &x->v, v);
 }
 #if DDSRT_HAVE_ATOMIC64
-inline void ddsrt_atomic_and64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
+inline void ddsrt_atomic_and64 (ddsrt_atomic_uint64_t *x, uint64_t v) {
   DDSRT_ATOMIC_OP64 (InterlockedAnd, &x->v, v);
 }
 #endif
-inline void ddsrt_atomic_andptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline void ddsrt_atomic_andptr (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
   DDSRT_ATOMIC_PTROP (InterlockedAnd, &x->v, v);
 }
-inline uint32_t ddsrt_atomic_and32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline uint32_t ddsrt_atomic_and32_ov (ddsrt_atomic_uint32_t *x, uint32_t v) {
   return DDSRT_ATOMIC_OP32 (InterlockedAnd, &x->v, v);
 }
 #if DDSRT_HAVE_ATOMIC64
-inline uint64_t ddsrt_atomic_and64_ov (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
+inline uint64_t ddsrt_atomic_and64_ov (ddsrt_atomic_uint64_t *x, uint64_t v) {
   return DDSRT_ATOMIC_OP64 (InterlockedAnd, &x->v, v);
 }
 #endif
-inline uintptr_t ddsrt_atomic_andptr_ov (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline uintptr_t ddsrt_atomic_andptr_ov (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
   return DDSRT_ATOMIC_PTROP (InterlockedAnd, &x->v, v);
 }
-inline uint32_t ddsrt_atomic_and32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline uint32_t ddsrt_atomic_and32_nv (ddsrt_atomic_uint32_t *x, uint32_t v) {
   return DDSRT_ATOMIC_OP32 (InterlockedAnd, &x->v, v) & v;
 }
 #if DDSRT_HAVE_ATOMIC64
-inline uint64_t ddsrt_atomic_and64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
+inline uint64_t ddsrt_atomic_and64_nv (ddsrt_atomic_uint64_t *x, uint64_t v) {
   return DDSRT_ATOMIC_OP64 (InterlockedAnd, &x->v, v) & v;
 }
 #endif
-inline uintptr_t ddsrt_atomic_andptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline uintptr_t ddsrt_atomic_andptr_nv (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
   return DDSRT_ATOMIC_PTROP (InterlockedAnd, &x->v, v) & v;
 }
 
 /* OR */
 
-inline void ddsrt_atomic_or32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline void ddsrt_atomic_or32 (ddsrt_atomic_uint32_t *x, uint32_t v) {
   DDSRT_ATOMIC_OP32 (InterlockedOr, &x->v, v);
 }
 #if DDSRT_HAVE_ATOMIC64
-inline void ddsrt_atomic_or64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
+inline void ddsrt_atomic_or64 (ddsrt_atomic_uint64_t *x, uint64_t v) {
   DDSRT_ATOMIC_OP64 (InterlockedOr, &x->v, v);
 }
 #endif
-inline void ddsrt_atomic_orptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline void ddsrt_atomic_orptr (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
   DDSRT_ATOMIC_PTROP (InterlockedOr, &x->v, v);
 }
-inline uint32_t ddsrt_atomic_or32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline uint32_t ddsrt_atomic_or32_ov (ddsrt_atomic_uint32_t *x, uint32_t v) {
   return DDSRT_ATOMIC_OP32 (InterlockedOr, &x->v, v);
 }
 #if DDSRT_HAVE_ATOMIC64
-inline uint64_t ddsrt_atomic_or64_ov (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
+inline uint64_t ddsrt_atomic_or64_ov (ddsrt_atomic_uint64_t *x, uint64_t v) {
   return DDSRT_ATOMIC_OP64 (InterlockedOr, &x->v, v);
 }
 #endif
-inline uintptr_t ddsrt_atomic_orptr_ov (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline uintptr_t ddsrt_atomic_orptr_ov (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
   return DDSRT_ATOMIC_PTROP (InterlockedOr, &x->v, v);
 }
-inline uint32_t ddsrt_atomic_or32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline uint32_t ddsrt_atomic_or32_nv (ddsrt_atomic_uint32_t *x, uint32_t v) {
   return DDSRT_ATOMIC_OP32 (InterlockedOr, &x->v, v) | v;
 }
 #if DDSRT_HAVE_ATOMIC64
-inline uint64_t ddsrt_atomic_or64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
+inline uint64_t ddsrt_atomic_or64_nv (ddsrt_atomic_uint64_t *x, uint64_t v) {
   return DDSRT_ATOMIC_OP64 (InterlockedOr, &x->v, v) | v;
 }
 #endif
-inline uintptr_t ddsrt_atomic_orptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline uintptr_t ddsrt_atomic_orptr_nv (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
   return DDSRT_ATOMIC_PTROP (InterlockedOr, &x->v, v) | v;
 }
 

--- a/src/ddsrt/include/dds/ddsrt/atomics/sun.h
+++ b/src/ddsrt/include/dds/ddsrt/atomics/sun.h
@@ -19,73 +19,73 @@ extern "C" {
 
 /* LD, ST */
 
-inline uint32_t ddsrt_atomic_ld32 (const volatile ddsrt_atomic_uint32_t *x) { return x->v; }
-inline uint64_t ddsrt_atomic_ld64 (const volatile ddsrt_atomic_uint64_t *x) { return x->v; }
-inline uintptr_t ddsrt_atomic_ldptr (const volatile ddsrt_atomic_uintptr_t *x) { return x->v; }
-inline void *ddsrt_atomic_ldvoidp (const volatile ddsrt_atomic_voidp_t *x) { return (void *) ddsrt_atomic_ldptr (x); }
+inline uint32_t ddsrt_atomic_ld32 (const ddsrt_atomic_uint32_t *x) { return x->v; }
+inline uint64_t ddsrt_atomic_ld64 (const ddsrt_atomic_uint64_t *x) { return x->v; }
+inline uintptr_t ddsrt_atomic_ldptr (const ddsrt_atomic_uintptr_t *x) { return x->v; }
+inline void *ddsrt_atomic_ldvoidp (const ddsrt_atomic_voidp_t *x) { return (void *) ddsrt_atomic_ldptr (x); }
 
-inline void ddsrt_atomic_st32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) { x->v = v; }
-inline void ddsrt_atomic_st64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) { x->v = v; }
-inline void ddsrt_atomic_stptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) { x->v = v; }
-inline void ddsrt_atomic_stvoidp (volatile ddsrt_atomic_voidp_t *x, void *v) { ddsrt_atomic_stptr (x, (uintptr_t) v); }
+inline void ddsrt_atomic_st32 (ddsrt_atomic_uint32_t *x, uint32_t v) { x->v = v; }
+inline void ddsrt_atomic_st64 (ddsrt_atomic_uint64_t *x, uint64_t v) { x->v = v; }
+inline void ddsrt_atomic_stptr (ddsrt_atomic_uintptr_t *x, uintptr_t v) { x->v = v; }
+inline void ddsrt_atomic_stvoidp (ddsrt_atomic_voidp_t *x, void *v) { ddsrt_atomic_stptr (x, (uintptr_t) v); }
 
 /* INC */
 
-inline void ddsrt_atomic_inc32 (volatile ddsrt_atomic_uint32_t *x) {
+inline void ddsrt_atomic_inc32 (ddsrt_atomic_uint32_t *x) {
   atomic_inc_32 (&x->v);
 }
-inline void ddsrt_atomic_inc64 (volatile ddsrt_atomic_uint64_t *x) {
+inline void ddsrt_atomic_inc64 (ddsrt_atomic_uint64_t *x) {
   atomic_inc_64 (&x->v);
 }
-inline void ddsrt_atomic_incptr (volatile ddsrt_atomic_uintptr_t *x) {
+inline void ddsrt_atomic_incptr (ddsrt_atomic_uintptr_t *x) {
   atomic_inc_ulong (&x->v);
 }
-inline uint32_t ddsrt_atomic_inc32_ov (volatile ddsrt_atomic_uint32_t *x) {
+inline uint32_t ddsrt_atomic_inc32_ov (ddsrt_atomic_uint32_t *x) {
   uint32_t oldval, newval;
   do { oldval = x->v; newval = oldval + 1; } while (atomic_cas_32 (&x->v, oldval, newval) != oldval);
   return oldval;
 }
-inline uint32_t ddsrt_atomic_inc32_nv (volatile ddsrt_atomic_uint32_t *x) {
+inline uint32_t ddsrt_atomic_inc32_nv (ddsrt_atomic_uint32_t *x) {
   return atomic_inc_32_nv (&x->v);
 }
-inline uint64_t ddsrt_atomic_inc64_nv (volatile ddsrt_atomic_uint64_t *x) {
+inline uint64_t ddsrt_atomic_inc64_nv (ddsrt_atomic_uint64_t *x) {
   return atomic_inc_64_nv (&x->v);
 }
-inline uintptr_t ddsrt_atomic_incptr_nv (volatile ddsrt_atomic_uintptr_t *x) {
+inline uintptr_t ddsrt_atomic_incptr_nv (ddsrt_atomic_uintptr_t *x) {
   return atomic_inc_ulong_nv (&x->v);
 }
 
 /* DEC */
 
-inline void ddsrt_atomic_dec32 (volatile ddsrt_atomic_uint32_t *x) {
+inline void ddsrt_atomic_dec32 (ddsrt_atomic_uint32_t *x) {
   atomic_dec_32 (&x->v);
 }
-inline void ddsrt_atomic_dec64 (volatile ddsrt_atomic_uint64_t *x) {
+inline void ddsrt_atomic_dec64 (ddsrt_atomic_uint64_t *x) {
   atomic_dec_64 (&x->v);
 }
-inline void ddsrt_atomic_decptr (volatile ddsrt_atomic_uintptr_t *x) {
+inline void ddsrt_atomic_decptr (ddsrt_atomic_uintptr_t *x) {
   atomic_dec_ulong (&x->v);
 }
-inline uint32_t ddsrt_atomic_dec32_nv (volatile ddsrt_atomic_uint32_t *x) {
+inline uint32_t ddsrt_atomic_dec32_nv (ddsrt_atomic_uint32_t *x) {
   return atomic_dec_32_nv (&x->v);
 }
-inline uint64_t ddsrt_atomic_dec64_nv (volatile ddsrt_atomic_uint64_t *x) {
+inline uint64_t ddsrt_atomic_dec64_nv (ddsrt_atomic_uint64_t *x) {
   return atomic_dec_64_nv (&x->v);
 }
-inline uintptr_t ddsrt_atomic_decptr_nv (volatile ddsrt_atomic_uintptr_t *x) {
+inline uintptr_t ddsrt_atomic_decptr_nv (ddsrt_atomic_uintptr_t *x) {
   return atomic_dec_ulong_nv (&x->v);
 }
-inline uint32_t ddsrt_atomic_dec32_ov (volatile ddsrt_atomic_uint32_t *x) {
+inline uint32_t ddsrt_atomic_dec32_ov (ddsrt_atomic_uint32_t *x) {
   uint32_t oldval, newval;
   do { oldval = x->v; newval = oldval - 1; } while (atomic_cas_32 (&x->v, oldval, newval) != oldval);
   return oldval;
 }
-inline uint64_t ddsrt_atomic_dec64_ov (volatile ddsrt_atomic_uint64_t *x) {
+inline uint64_t ddsrt_atomic_dec64_ov (ddsrt_atomic_uint64_t *x) {
   uint64_t oldval, newval;
   do { oldval = x->v; newval = oldval - 1; } while (atomic_cas_64 (&x->v, oldval, newval) != oldval);
   return oldval;
 }
-inline uintptr_t ddsrt_atomic_decptr_ov (volatile ddsrt_atomic_uintptr_t *x) {
+inline uintptr_t ddsrt_atomic_decptr_ov (ddsrt_atomic_uintptr_t *x) {
   uintptr_t oldval, newval;
   do { oldval = x->v; newval = oldval - 1; } while (atomic_cas_64 (&x->v, oldval, newval) != oldval);
   return oldval;
@@ -93,148 +93,148 @@ inline uintptr_t ddsrt_atomic_decptr_ov (volatile ddsrt_atomic_uintptr_t *x) {
 
 /* ADD */
 
-inline void ddsrt_atomic_add32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline void ddsrt_atomic_add32 (ddsrt_atomic_uint32_t *x, uint32_t v) {
   atomic_add_32 (&x->v, v);
 }
-inline void ddsrt_atomic_add64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
+inline void ddsrt_atomic_add64 (ddsrt_atomic_uint64_t *x, uint64_t v) {
   atomic_add_64 (&x->v, v);
 }
-inline void ddsrt_atomic_addptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline void ddsrt_atomic_addptr (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
   atomic_add_long (&x->v, v);
 }
-inline void ddsrt_atomic_addvoidp (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
+inline void ddsrt_atomic_addvoidp (ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
   atomic_add_ptr (&x->v, v);
 }
-inline uint32_t ddsrt_atomic_add32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline uint32_t ddsrt_atomic_add32_ov (ddsrt_atomic_uint32_t *x, uint32_t v) {
   return atomic_add_32_nv (&x->v, v) - v;
 }
-inline uint32_t ddsrt_atomic_add32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline uint32_t ddsrt_atomic_add32_nv (ddsrt_atomic_uint32_t *x, uint32_t v) {
   return atomic_add_32_nv (&x->v, v);
 }
-inline uint64_t ddsrt_atomic_add64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
+inline uint64_t ddsrt_atomic_add64_nv (ddsrt_atomic_uint64_t *x, uint64_t v) {
   return atomic_add_64_nv (&x->v, v);
 }
-inline uintptr_t ddsrt_atomic_addptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline uintptr_t ddsrt_atomic_addptr_nv (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
   return atomic_add_long_nv (&x->v, v);
 }
-inline void *ddsrt_atomic_addvoidp_nv (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
+inline void *ddsrt_atomic_addvoidp_nv (ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
   return atomic_add_ptr_nv (&x->v, v);
 }
 
 /* SUB */
 
-inline void ddsrt_atomic_sub32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline void ddsrt_atomic_sub32 (ddsrt_atomic_uint32_t *x, uint32_t v) {
   atomic_add_32 (&x->v, -v);
 }
-inline void ddsrt_atomic_sub64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
+inline void ddsrt_atomic_sub64 (ddsrt_atomic_uint64_t *x, uint64_t v) {
   atomic_add_64 (&x->v, -v);
 }
-inline void ddsrt_atomic_subptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline void ddsrt_atomic_subptr (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
   atomic_add_long (&x->v, -v);
 }
-inline void ddsrt_atomic_subvoidp (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
+inline void ddsrt_atomic_subvoidp (ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
   atomic_add_ptr (&x->v, -v);
 }
-inline uint32_t ddsrt_atomic_sub32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline uint32_t ddsrt_atomic_sub32_ov (ddsrt_atomic_uint32_t *x, uint32_t v) {
   return atomic_add_32_nv (&x->v, -v) + v;
 }
-inline uint32_t ddsrt_atomic_sub32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline uint32_t ddsrt_atomic_sub32_nv (ddsrt_atomic_uint32_t *x, uint32_t v) {
   return atomic_add_32_nv (&x->v, -v);
 }
-inline uint64_t ddsrt_atomic_sub64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
+inline uint64_t ddsrt_atomic_sub64_nv (ddsrt_atomic_uint64_t *x, uint64_t v) {
   return atomic_add_64_nv (&x->v, -v);
 }
-inline uintptr_t ddsrt_atomic_subptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline uintptr_t ddsrt_atomic_subptr_nv (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
   return atomic_add_long_nv (&x->v, -v);
 }
-inline void *ddsrt_atomic_subvoidp_nv (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
+inline void *ddsrt_atomic_subvoidp_nv (ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
   return atomic_add_ptr_nv (&x->v, -v);
 }
 
 /* AND */
 
-inline void ddsrt_atomic_and32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline void ddsrt_atomic_and32 (ddsrt_atomic_uint32_t *x, uint32_t v) {
   atomic_and_32 (&x->v, v);
 }
-inline void ddsrt_atomic_and64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
+inline void ddsrt_atomic_and64 (ddsrt_atomic_uint64_t *x, uint64_t v) {
   atomic_and_64 (&x->v, v);
 }
-inline void ddsrt_atomic_andptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline void ddsrt_atomic_andptr (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
   atomic_and_ulong (&x->v, v);
 }
-inline uint32_t ddsrt_atomic_and32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline uint32_t ddsrt_atomic_and32_ov (ddsrt_atomic_uint32_t *x, uint32_t v) {
   uint32_t oldval, newval;
   do { oldval = x->v; newval = oldval & v; } while (atomic_cas_32 (&x->v, oldval, newval) != oldval);
   return oldval;
 }
-inline uint64_t ddsrt_atomic_and64_ov (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
+inline uint64_t ddsrt_atomic_and64_ov (ddsrt_atomic_uint64_t *x, uint64_t v) {
   uint64_t oldval, newval;
   do { oldval = x->v; newval = oldval & v; } while (atomic_cas_64 (&x->v, oldval, newval) != oldval);
   return oldval;
 }
-inline uintptr_t ddsrt_atomic_andptr_ov (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline uintptr_t ddsrt_atomic_andptr_ov (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
   uintptr_t oldval, newval;
   do { oldval = x->v; newval = oldval & v; } while (atomic_cas_ulong (&x->v, oldval, newval) != oldval);
   return oldval;
 }
-inline uint32_t ddsrt_atomic_and32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline uint32_t ddsrt_atomic_and32_nv (ddsrt_atomic_uint32_t *x, uint32_t v) {
   return atomic_and_32_nv (&x->v, v);
 }
-inline uint64_t ddsrt_atomic_and64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
+inline uint64_t ddsrt_atomic_and64_nv (ddsrt_atomic_uint64_t *x, uint64_t v) {
   return atomic_and_64_nv (&x->v, v);
 }
-inline uintptr_t ddsrt_atomic_andptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline uintptr_t ddsrt_atomic_andptr_nv (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
   return atomic_and_ulong_nv (&x->v, v);
 }
 
 /* OR */
 
-inline void ddsrt_atomic_or32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline void ddsrt_atomic_or32 (ddsrt_atomic_uint32_t *x, uint32_t v) {
   atomic_or_32 (&x->v, v);
 }
-inline void ddsrt_atomic_or64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
+inline void ddsrt_atomic_or64 (ddsrt_atomic_uint64_t *x, uint64_t v) {
   atomic_or_64 (&x->v, v);
 }
-inline void ddsrt_atomic_orptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline void ddsrt_atomic_orptr (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
   atomic_or_ulong (&x->v, v);
 }
-inline uint32_t ddsrt_atomic_or32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline uint32_t ddsrt_atomic_or32_ov (ddsrt_atomic_uint32_t *x, uint32_t v) {
   uint32_t oldval, newval;
   do { oldval = x->v; newval = oldval | v; } while (atomic_cas_32 (&x->v, oldval, newval) != oldval);
   return oldval;
 }
-inline uint64_t ddsrt_atomic_or64_ov (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
+inline uint64_t ddsrt_atomic_or64_ov (ddsrt_atomic_uint64_t *x, uint64_t v) {
   uint64_t oldval, newval;
   do { oldval = x->v; newval = oldval | v; } while (atomic_cas_64 (&x->v, oldval, newval) != oldval);
   return oldval;
 }
-inline uintptr_t ddsrt_atomic_orptr_ov (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline uintptr_t ddsrt_atomic_orptr_ov (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
   uintptr_t oldval, newval;
   do { oldval = x->v; newval = oldval | v; } while (atomic_cas_ulong (&x->v, oldval, newval) != oldval);
   return oldval;
 }
-inline uint32_t ddsrt_atomic_or32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
+inline uint32_t ddsrt_atomic_or32_nv (ddsrt_atomic_uint32_t *x, uint32_t v) {
   return atomic_or_32_nv (&x->v, v);
 }
-inline uint64_t ddsrt_atomic_or64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
+inline uint64_t ddsrt_atomic_or64_nv (ddsrt_atomic_uint64_t *x, uint64_t v) {
   return atomic_or_64_nv (&x->v, v);
 }
-inline uintptr_t ddsrt_atomic_orptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
+inline uintptr_t ddsrt_atomic_orptr_nv (ddsrt_atomic_uintptr_t *x, uintptr_t v) {
   return atomic_or_ulong_nv (&x->v, v);
 }
 
 /* CAS */
 
-inline int ddsrt_atomic_cas32 (volatile ddsrt_atomic_uint32_t *x, uint32_t exp, uint32_t des) {
+inline int ddsrt_atomic_cas32 (ddsrt_atomic_uint32_t *x, uint32_t exp, uint32_t des) {
   return atomic_cas_32 (&x->v, exp, des) == exp;
 }
-inline int ddsrt_atomic_cas64 (volatile ddsrt_atomic_uint64_t *x, uint64_t exp, uint64_t des) {
+inline int ddsrt_atomic_cas64 (ddsrt_atomic_uint64_t *x, uint64_t exp, uint64_t des) {
   return atomic_cas_64 (&x->v, exp, des) == exp;
 }
-inline int ddsrt_atomic_casptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t exp, uintptr_t des) {
+inline int ddsrt_atomic_casptr (ddsrt_atomic_uintptr_t *x, uintptr_t exp, uintptr_t des) {
   return atomic_cas_ulong (&x->v, exp, des) == exp;
 }
-inline int ddsrt_atomic_casvoidp (volatile ddsrt_atomic_voidp_t *x, void *exp, void *des) {
+inline int ddsrt_atomic_casvoidp (ddsrt_atomic_voidp_t *x, void *exp, void *des) {
   return atomic_cas_ptr (&x->v, exp, des) == exp;
 }
 

--- a/src/ddsrt/src/atomics.c
+++ b/src/ddsrt/src/atomics.c
@@ -12,115 +12,115 @@
 #include "dds/ddsrt/atomics.h"
 
 /* LD, ST */
-extern inline uint32_t ddsrt_atomic_ld32 (const volatile ddsrt_atomic_uint32_t *x);
+extern inline uint32_t ddsrt_atomic_ld32 (const ddsrt_atomic_uint32_t *x);
 #if DDSRT_HAVE_ATOMIC64
-extern inline uint64_t ddsrt_atomic_ld64 (const volatile ddsrt_atomic_uint64_t *x);
+extern inline uint64_t ddsrt_atomic_ld64 (const ddsrt_atomic_uint64_t *x);
 #endif
-extern inline uintptr_t ddsrt_atomic_ldptr (const volatile ddsrt_atomic_uintptr_t *x);
-extern inline void *ddsrt_atomic_ldvoidp (const volatile ddsrt_atomic_voidp_t *x);
-extern inline void ddsrt_atomic_st32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v);
+extern inline uintptr_t ddsrt_atomic_ldptr (const ddsrt_atomic_uintptr_t *x);
+extern inline void *ddsrt_atomic_ldvoidp (const ddsrt_atomic_voidp_t *x);
+extern inline void ddsrt_atomic_st32 (ddsrt_atomic_uint32_t *x, uint32_t v);
 #if DDSRT_HAVE_ATOMIC64
-extern inline void ddsrt_atomic_st64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
+extern inline void ddsrt_atomic_st64 (ddsrt_atomic_uint64_t *x, uint64_t v);
 #endif
-extern inline void ddsrt_atomic_stptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v);
-extern inline void ddsrt_atomic_stvoidp (volatile ddsrt_atomic_voidp_t *x, void *v);
+extern inline void ddsrt_atomic_stptr (ddsrt_atomic_uintptr_t *x, uintptr_t v);
+extern inline void ddsrt_atomic_stvoidp (ddsrt_atomic_voidp_t *x, void *v);
 /* INC */
-extern inline void ddsrt_atomic_inc32 (volatile ddsrt_atomic_uint32_t *x);
+extern inline void ddsrt_atomic_inc32 (ddsrt_atomic_uint32_t *x);
 #if DDSRT_HAVE_ATOMIC64
-extern inline void ddsrt_atomic_inc64 (volatile ddsrt_atomic_uint64_t *x);
+extern inline void ddsrt_atomic_inc64 (ddsrt_atomic_uint64_t *x);
 #endif
-extern inline void ddsrt_atomic_incptr (volatile ddsrt_atomic_uintptr_t *x);
-extern inline uint32_t ddsrt_atomic_inc32_ov (volatile ddsrt_atomic_uint32_t *x);
-extern inline uint32_t ddsrt_atomic_inc32_nv (volatile ddsrt_atomic_uint32_t *x);
+extern inline void ddsrt_atomic_incptr (ddsrt_atomic_uintptr_t *x);
+extern inline uint32_t ddsrt_atomic_inc32_ov (ddsrt_atomic_uint32_t *x);
+extern inline uint32_t ddsrt_atomic_inc32_nv (ddsrt_atomic_uint32_t *x);
 #if DDSRT_HAVE_ATOMIC64
-extern inline uint64_t ddsrt_atomic_inc64_nv (volatile ddsrt_atomic_uint64_t *x);
+extern inline uint64_t ddsrt_atomic_inc64_nv (ddsrt_atomic_uint64_t *x);
 #endif
-extern inline uintptr_t ddsrt_atomic_incptr_nv (volatile ddsrt_atomic_uintptr_t *x);
+extern inline uintptr_t ddsrt_atomic_incptr_nv (ddsrt_atomic_uintptr_t *x);
 /* DEC */
-extern inline void ddsrt_atomic_dec32 (volatile ddsrt_atomic_uint32_t *x);
+extern inline void ddsrt_atomic_dec32 (ddsrt_atomic_uint32_t *x);
 #if DDSRT_HAVE_ATOMIC64
-extern inline void ddsrt_atomic_dec64 (volatile ddsrt_atomic_uint64_t *x);
+extern inline void ddsrt_atomic_dec64 (ddsrt_atomic_uint64_t *x);
 #endif
-extern inline void ddsrt_atomic_decptr (volatile ddsrt_atomic_uintptr_t *x);
-extern inline uint32_t ddsrt_atomic_dec32_nv (volatile ddsrt_atomic_uint32_t *x);
+extern inline void ddsrt_atomic_decptr (ddsrt_atomic_uintptr_t *x);
+extern inline uint32_t ddsrt_atomic_dec32_nv (ddsrt_atomic_uint32_t *x);
 #if DDSRT_HAVE_ATOMIC64
-extern inline uint64_t ddsrt_atomic_dec64_nv (volatile ddsrt_atomic_uint64_t *x);
+extern inline uint64_t ddsrt_atomic_dec64_nv (ddsrt_atomic_uint64_t *x);
 #endif
-extern inline uintptr_t ddsrt_atomic_decptr_nv (volatile ddsrt_atomic_uintptr_t *x);
-extern inline uint32_t ddsrt_atomic_dec32_ov (volatile ddsrt_atomic_uint32_t *x);
+extern inline uintptr_t ddsrt_atomic_decptr_nv (ddsrt_atomic_uintptr_t *x);
+extern inline uint32_t ddsrt_atomic_dec32_ov (ddsrt_atomic_uint32_t *x);
 #if DDSRT_HAVE_ATOMIC64
-extern inline uint64_t ddsrt_atomic_dec64_ov (volatile ddsrt_atomic_uint64_t *x);
+extern inline uint64_t ddsrt_atomic_dec64_ov (ddsrt_atomic_uint64_t *x);
 #endif
-extern inline uintptr_t ddsrt_atomic_decptr_ov (volatile ddsrt_atomic_uintptr_t *x);
+extern inline uintptr_t ddsrt_atomic_decptr_ov (ddsrt_atomic_uintptr_t *x);
 /* ADD */
-extern inline void ddsrt_atomic_add32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v);
+extern inline void ddsrt_atomic_add32 (ddsrt_atomic_uint32_t *x, uint32_t v);
 #if DDSRT_HAVE_ATOMIC64
-extern inline void ddsrt_atomic_add64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
+extern inline void ddsrt_atomic_add64 (ddsrt_atomic_uint64_t *x, uint64_t v);
 #endif
-extern inline void ddsrt_atomic_addptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v);
-extern inline void ddsrt_atomic_addvoidp (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v);
-extern inline uint32_t ddsrt_atomic_add32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v);
-extern inline uint32_t ddsrt_atomic_add32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v);
+extern inline void ddsrt_atomic_addptr (ddsrt_atomic_uintptr_t *x, uintptr_t v);
+extern inline void ddsrt_atomic_addvoidp (ddsrt_atomic_voidp_t *x, ptrdiff_t v);
+extern inline uint32_t ddsrt_atomic_add32_ov (ddsrt_atomic_uint32_t *x, uint32_t v);
+extern inline uint32_t ddsrt_atomic_add32_nv (ddsrt_atomic_uint32_t *x, uint32_t v);
 #if DDSRT_HAVE_ATOMIC64
-extern inline uint64_t ddsrt_atomic_add64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
+extern inline uint64_t ddsrt_atomic_add64_nv (ddsrt_atomic_uint64_t *x, uint64_t v);
 #endif
-extern inline uintptr_t ddsrt_atomic_addptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v);
-extern inline void *ddsrt_atomic_addvoidp_nv (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v);
+extern inline uintptr_t ddsrt_atomic_addptr_nv (ddsrt_atomic_uintptr_t *x, uintptr_t v);
+extern inline void *ddsrt_atomic_addvoidp_nv (ddsrt_atomic_voidp_t *x, ptrdiff_t v);
 /* SUB */
-extern inline void ddsrt_atomic_sub32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v);
+extern inline void ddsrt_atomic_sub32 (ddsrt_atomic_uint32_t *x, uint32_t v);
 #if DDSRT_HAVE_ATOMIC64
-extern inline void ddsrt_atomic_sub64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
+extern inline void ddsrt_atomic_sub64 (ddsrt_atomic_uint64_t *x, uint64_t v);
 #endif
-extern inline void ddsrt_atomic_subptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v);
-extern inline void ddsrt_atomic_subvoidp (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v);
-extern inline uint32_t ddsrt_atomic_sub32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v);
-extern inline uint32_t ddsrt_atomic_sub32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v);
+extern inline void ddsrt_atomic_subptr (ddsrt_atomic_uintptr_t *x, uintptr_t v);
+
+extern inline uint32_t ddsrt_atomic_sub32_ov (ddsrt_atomic_uint32_t *x, uint32_t v);
+extern inline uint32_t ddsrt_atomic_sub32_nv (ddsrt_atomic_uint32_t *x, uint32_t v);
 #if DDSRT_HAVE_ATOMIC64
-extern inline uint64_t ddsrt_atomic_sub64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
+extern inline uint64_t ddsrt_atomic_sub64_nv (ddsrt_atomic_uint64_t *x, uint64_t v);
 #endif
-extern inline uintptr_t ddsrt_atomic_subptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v);
-extern inline void *ddsrt_atomic_subvoidp_nv (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v);
+extern inline uintptr_t ddsrt_atomic_subptr_nv (ddsrt_atomic_uintptr_t *x, uintptr_t v);
+extern inline void *ddsrt_atomic_subvoidp_nv (ddsrt_atomic_voidp_t *x, ptrdiff_t v);
 /* AND */
-extern inline void ddsrt_atomic_and32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v);
+extern inline void ddsrt_atomic_and32 (ddsrt_atomic_uint32_t *x, uint32_t v);
 #if DDSRT_HAVE_ATOMIC64
-extern inline void ddsrt_atomic_and64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
+extern inline void ddsrt_atomic_and64 (ddsrt_atomic_uint64_t *x, uint64_t v);
 #endif
-extern inline void ddsrt_atomic_andptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v);
-extern inline uint32_t ddsrt_atomic_and32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v);
+extern inline void ddsrt_atomic_andptr (ddsrt_atomic_uintptr_t *x, uintptr_t v);
+extern inline uint32_t ddsrt_atomic_and32_ov (ddsrt_atomic_uint32_t *x, uint32_t v);
 #if DDSRT_HAVE_ATOMIC64
-extern inline uint64_t ddsrt_atomic_and64_ov (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
+extern inline uint64_t ddsrt_atomic_and64_ov (ddsrt_atomic_uint64_t *x, uint64_t v);
 #endif
-extern inline uintptr_t ddsrt_atomic_andptr_ov (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v);
-extern inline uint32_t ddsrt_atomic_and32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v);
+extern inline uintptr_t ddsrt_atomic_andptr_ov (ddsrt_atomic_uintptr_t *x, uintptr_t v);
+extern inline uint32_t ddsrt_atomic_and32_nv (ddsrt_atomic_uint32_t *x, uint32_t v);
 #if DDSRT_HAVE_ATOMIC64
-extern inline uint64_t ddsrt_atomic_and64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
+extern inline uint64_t ddsrt_atomic_and64_nv (ddsrt_atomic_uint64_t *x, uint64_t v);
 #endif
-extern inline uintptr_t ddsrt_atomic_andptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v);
+extern inline uintptr_t ddsrt_atomic_andptr_nv (ddsrt_atomic_uintptr_t *x, uintptr_t v);
 /* OR */
-extern inline void ddsrt_atomic_or32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v);
+extern inline void ddsrt_atomic_or32 (ddsrt_atomic_uint32_t *x, uint32_t v);
 #if DDSRT_HAVE_ATOMIC64
-extern inline void ddsrt_atomic_or64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
+extern inline void ddsrt_atomic_or64 (ddsrt_atomic_uint64_t *x, uint64_t v);
 #endif
-extern inline void ddsrt_atomic_orptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v);
-extern inline uint32_t ddsrt_atomic_or32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v);
+extern inline void ddsrt_atomic_orptr (ddsrt_atomic_uintptr_t *x, uintptr_t v);
+extern inline uint32_t ddsrt_atomic_or32_ov (ddsrt_atomic_uint32_t *x, uint32_t v);
 #if DDSRT_HAVE_ATOMIC64
-extern inline uint64_t ddsrt_atomic_or64_ov (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
+extern inline uint64_t ddsrt_atomic_or64_ov (ddsrt_atomic_uint64_t *x, uint64_t v);
 #endif
-extern inline uintptr_t ddsrt_atomic_orptr_ov (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v);
-extern inline uint32_t ddsrt_atomic_or32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v);
+extern inline uintptr_t ddsrt_atomic_orptr_ov (ddsrt_atomic_uintptr_t *x, uintptr_t v);
+extern inline uint32_t ddsrt_atomic_or32_nv (ddsrt_atomic_uint32_t *x, uint32_t v);
 #if DDSRT_HAVE_ATOMIC64
-extern inline uint64_t ddsrt_atomic_or64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
+extern inline uint64_t ddsrt_atomic_or64_nv (ddsrt_atomic_uint64_t *x, uint64_t v);
 #endif
-extern inline uintptr_t ddsrt_atomic_orptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v);
+extern inline uintptr_t ddsrt_atomic_orptr_nv (ddsrt_atomic_uintptr_t *x, uintptr_t v);
 /* CAS */
-extern inline int ddsrt_atomic_cas32 (volatile ddsrt_atomic_uint32_t *x, uint32_t exp, uint32_t des);
+extern inline int ddsrt_atomic_cas32 (ddsrt_atomic_uint32_t *x, uint32_t exp, uint32_t des);
 #if DDSRT_HAVE_ATOMIC64
-extern inline int ddsrt_atomic_cas64 (volatile ddsrt_atomic_uint64_t *x, uint64_t exp, uint64_t des);
+extern inline int ddsrt_atomic_cas64 (ddsrt_atomic_uint64_t *x, uint64_t exp, uint64_t des);
 #endif
-extern inline int ddsrt_atomic_casptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t exp, uintptr_t des);
-extern inline int ddsrt_atomic_casvoidp (volatile ddsrt_atomic_voidp_t *x, void *exp, void *des);
+extern inline int ddsrt_atomic_casptr (ddsrt_atomic_uintptr_t *x, uintptr_t exp, uintptr_t des);
+extern inline int ddsrt_atomic_casvoidp (ddsrt_atomic_voidp_t *x, void *exp, void *des);
 #if DDSRT_HAVE_ATOMIC_LIFO
-extern inline int ddsrt_atomic_casvoidp2 (volatile ddsrt_atomic_uintptr2_t *x, uintptr_t a0, uintptr_t b0, uintptr_t a1, uintptr_t b1);
+extern inline int ddsrt_atomic_casvoidp2 (ddsrt_atomic_uintptr2_t *x, uintptr_t a0, uintptr_t b0, uintptr_t a1, uintptr_t b1);
 #endif
 /* FENCES */
 extern inline void ddsrt_atomic_fence (void);
@@ -218,14 +218,14 @@ void ddsrt_atomics_init (void) { }
 void ddsrt_atomics_fini (void) { }
 #endif
 
-static uint32_t atomic64_lock_index (const volatile ddsrt_atomic_uint64_t *x)
+static uint32_t atomic64_lock_index (const ddsrt_atomic_uint64_t *x)
 {
   const uint32_t u = (uint16_t) ((uintptr_t) x >> 3);
   const uint32_t v = u * 0xb4817365;
   return v >> (32 - N_MUTEXES_LG2);
 }
 
-int ddsrt_atomic_cas64 (volatile ddsrt_atomic_uint64_t *x, uint64_t exp, uint64_t des)
+int ddsrt_atomic_cas64 (ddsrt_atomic_uint64_t *x, uint64_t exp, uint64_t des)
 {
   const uint32_t idx = atomic64_lock_index (x);
   ddsrt_mutex_lock (&mutexes[idx]);
@@ -243,8 +243,8 @@ int ddsrt_atomic_cas64 (volatile ddsrt_atomic_uint64_t *x, uint64_t exp, uint64_
 }
 
 #define DDSRT_FAKE_ATOMIC64(name, oper, ret) \
-  uint64_t ddsrt_atomic_##name##64_##ret (volatile ddsrt_atomic_uint64_t *x, uint64_t v); \
-  uint64_t ddsrt_atomic_##name##64_##ret (volatile ddsrt_atomic_uint64_t *x, uint64_t v) \
+  uint64_t ddsrt_atomic_##name##64_##ret (ddsrt_atomic_uint64_t *x, uint64_t v); \
+  uint64_t ddsrt_atomic_##name##64_##ret (ddsrt_atomic_uint64_t *x, uint64_t v) \
   { \
     const uint64_t idx = atomic64_lock_index (x); \
     ddsrt_mutex_lock (&mutexes[idx]); \
@@ -257,11 +257,11 @@ int ddsrt_atomic_cas64 (volatile ddsrt_atomic_uint64_t *x, uint64_t exp, uint64_
 #define DDSRT_FAKE_ATOMIC64_TRIPLET(name, oper) \
   DDSRT_FAKE_ATOMIC64(name, oper, nv) \
   DDSRT_FAKE_ATOMIC64(name, oper, ov) \
-  void ddsrt_atomic_##name##64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) { \
+  void ddsrt_atomic_##name##64 (ddsrt_atomic_uint64_t *x, uint64_t v) { \
     (void) ddsrt_atomic_##name##64_ov (x, v); \
   }
 
-uint64_t ddsrt_atomic_ld64 (const volatile ddsrt_atomic_uint64_t *x)
+uint64_t ddsrt_atomic_ld64 (const ddsrt_atomic_uint64_t *x)
 {
   const uint32_t idx = atomic64_lock_index (x);
   ddsrt_mutex_lock (&mutexes[idx]);
@@ -270,7 +270,7 @@ uint64_t ddsrt_atomic_ld64 (const volatile ddsrt_atomic_uint64_t *x)
   return v;
 }
 
-void ddsrt_atomic_st64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v)
+void ddsrt_atomic_st64 (ddsrt_atomic_uint64_t *x, uint64_t v)
 {
   const uint32_t idx = atomic64_lock_index (x);
   ddsrt_mutex_lock (&mutexes[idx]);
@@ -283,16 +283,16 @@ DDSRT_FAKE_ATOMIC64_TRIPLET(sub, -)
 DDSRT_FAKE_ATOMIC64_TRIPLET(or,  |)
 DDSRT_FAKE_ATOMIC64_TRIPLET(and, &)
 
-void ddsrt_atomic_inc64 (volatile ddsrt_atomic_uint64_t *x) {
+void ddsrt_atomic_inc64 (ddsrt_atomic_uint64_t *x) {
   ddsrt_atomic_add64 (x, 1);
 }
-uint64_t ddsrt_atomic_inc64_nv (volatile ddsrt_atomic_uint64_t *x) {
+uint64_t ddsrt_atomic_inc64_nv (ddsrt_atomic_uint64_t *x) {
   return ddsrt_atomic_add64_nv (x, 1);
 }
-void ddsrt_atomic_dec64 (volatile ddsrt_atomic_uint64_t *x) {
+void ddsrt_atomic_dec64 (ddsrt_atomic_uint64_t *x) {
   ddsrt_atomic_sub64 (x, 1);
 }
-uint64_t ddsrt_atomic_dec64_nv (volatile ddsrt_atomic_uint64_t *x) {
+uint64_t ddsrt_atomic_dec64_nv (ddsrt_atomic_uint64_t *x) {
   return ddsrt_atomic_sub64_nv (x, 1);
 }
 
@@ -306,7 +306,7 @@ uint64_t ddsrt_atomic_dec64_nv (volatile ddsrt_atomic_uint64_t *x) {
 #define DDSRT_FAKE_SYNC(name, size, oper, ret)                          \
   unsigned __sync_##name##_##size (volatile unsigned *x, unsigned v) \
   {                                                                     \
-    const uint32_t idx = atomic64_lock_index ((const volatile ddsrt_atomic_uint64_t *) x); \
+    const uint32_t idx = atomic64_lock_index ((const ddsrt_atomic_uint64_t *) x); \
     ddsrt_mutex_lock (&mutexes[idx]);                                   \
     const uint32_t ov = *x;                                             \
     const uint32_t nv = ov oper v;                                      \
@@ -325,7 +325,7 @@ DDSRT_FAKE_SYNC_PAIR (and, 4, &)
 
 bool __sync_bool_compare_and_swap_4 (volatile unsigned *x, unsigned exp, unsigned des)
 {
-  const uint32_t idx = atomic64_lock_index ((const volatile ddsrt_atomic_uint64_t *) x);
+  const uint32_t idx = atomic64_lock_index ((const ddsrt_atomic_uint64_t *) x);
   ddsrt_mutex_lock (&mutexes[idx]);
   if (*x == exp)
   {

--- a/src/ddsrt/src/atomics.c
+++ b/src/ddsrt/src/atomics.c
@@ -113,12 +113,12 @@ extern inline uint64_t ddsrt_atomic_or64_nv (ddsrt_atomic_uint64_t *x, uint64_t 
 #endif
 extern inline uintptr_t ddsrt_atomic_orptr_nv (ddsrt_atomic_uintptr_t *x, uintptr_t v);
 /* CAS */
-extern inline int ddsrt_atomic_cas32 (ddsrt_atomic_uint32_t *x, uint32_t exp, uint32_t des);
+extern inline bool ddsrt_atomic_cas32 (ddsrt_atomic_uint32_t *x, uint32_t exp, uint32_t des);
 #if DDSRT_HAVE_ATOMIC64
-extern inline int ddsrt_atomic_cas64 (ddsrt_atomic_uint64_t *x, uint64_t exp, uint64_t des);
+extern inline bool ddsrt_atomic_cas64 (ddsrt_atomic_uint64_t *x, uint64_t exp, uint64_t des);
 #endif
-extern inline int ddsrt_atomic_casptr (ddsrt_atomic_uintptr_t *x, uintptr_t exp, uintptr_t des);
-extern inline int ddsrt_atomic_casvoidp (ddsrt_atomic_voidp_t *x, void *exp, void *des);
+extern inline bool ddsrt_atomic_casptr (ddsrt_atomic_uintptr_t *x, uintptr_t exp, uintptr_t des);
+extern inline bool ddsrt_atomic_casvoidp (ddsrt_atomic_voidp_t *x, void *exp, void *des);
 #if DDSRT_HAVE_ATOMIC_LIFO
 extern inline int ddsrt_atomic_casvoidp2 (ddsrt_atomic_uintptr2_t *x, uintptr_t a0, uintptr_t b0, uintptr_t a1, uintptr_t b1);
 #endif

--- a/src/ddsrt/tests/atomics.c
+++ b/src/ddsrt/tests/atomics.c
@@ -20,12 +20,12 @@ void * _osvoidp = (uintptr_t *)0;
 
 CU_Test(ddsrt_atomics, load_store)
 {
-  volatile ddsrt_atomic_uint32_t uint32 = DDSRT_ATOMIC_UINT32_INIT(5);
+  ddsrt_atomic_uint32_t uint32 = DDSRT_ATOMIC_UINT32_INIT(5);
 #if DDSRT_HAVE_ATOMIC64
-  volatile ddsrt_atomic_uint64_t uint64 = DDSRT_ATOMIC_UINT64_INIT(5);
+  ddsrt_atomic_uint64_t uint64 = DDSRT_ATOMIC_UINT64_INIT(5);
 #endif
-  volatile ddsrt_atomic_uintptr_t uintptr = DDSRT_ATOMIC_UINTPTR_INIT(5);
-  volatile ddsrt_atomic_voidp_t voidp = DDSRT_ATOMIC_VOIDP_INIT((uintptr_t)5);
+  ddsrt_atomic_uintptr_t uintptr = DDSRT_ATOMIC_UINTPTR_INIT(5);
+  ddsrt_atomic_voidp_t voidp = DDSRT_ATOMIC_VOIDP_INIT((uintptr_t)5);
 
   /* Test uint32 LD-ST */
   CU_ASSERT (ddsrt_atomic_ld32 (&uint32) == 5); /* Returns contents of uint32 */
@@ -53,12 +53,12 @@ CU_Test(ddsrt_atomics, load_store)
 CU_Test(ddsrt_atomics, compare_and_swap)
 {
   /* Compare and Swap if (ptr == expected) { ptr = newval; } */
-  volatile ddsrt_atomic_uint32_t uint32 = DDSRT_ATOMIC_UINT32_INIT(0);
+  ddsrt_atomic_uint32_t uint32 = DDSRT_ATOMIC_UINT32_INIT(0);
 #if DDSRT_HAVE_ATOMIC64
-  volatile ddsrt_atomic_uint64_t uint64 = DDSRT_ATOMIC_UINT64_INIT(0);
+  ddsrt_atomic_uint64_t uint64 = DDSRT_ATOMIC_UINT64_INIT(0);
 #endif
-  volatile ddsrt_atomic_uintptr_t uintptr = DDSRT_ATOMIC_UINTPTR_INIT(0);
-  volatile ddsrt_atomic_voidp_t uintvoidp = DDSRT_ATOMIC_VOIDP_INIT((uintptr_t)0);
+  ddsrt_atomic_uintptr_t uintptr = DDSRT_ATOMIC_UINTPTR_INIT(0);
+  ddsrt_atomic_voidp_t uintvoidp = DDSRT_ATOMIC_VOIDP_INIT((uintptr_t)0);
   _osuint32 = 1;
   _osuint64 = 1;
   _osaddress = 1;
@@ -102,11 +102,11 @@ CU_Test(ddsrt_atomics, compare_and_swap)
 
 CU_Test(ddsrt_atomics, increment)
 {
-  volatile ddsrt_atomic_uint32_t uint32 = DDSRT_ATOMIC_UINT32_INIT(0);
+  ddsrt_atomic_uint32_t uint32 = DDSRT_ATOMIC_UINT32_INIT(0);
 #if DDSRT_HAVE_ATOMIC64
-  volatile ddsrt_atomic_uint64_t uint64 = DDSRT_ATOMIC_UINT64_INIT(0);
+  ddsrt_atomic_uint64_t uint64 = DDSRT_ATOMIC_UINT64_INIT(0);
 #endif
-  volatile ddsrt_atomic_uintptr_t uintptr = DDSRT_ATOMIC_UINTPTR_INIT(0);
+  ddsrt_atomic_uintptr_t uintptr = DDSRT_ATOMIC_UINTPTR_INIT(0);
   _osuint32 = 0;
   _osuint64 = 0;
   _osaddress = 0;
@@ -143,11 +143,11 @@ CU_Test(ddsrt_atomics, increment)
 
 CU_Test(ddsrt_atomics, decrement)
 {
-  volatile ddsrt_atomic_uint32_t uint32 = DDSRT_ATOMIC_UINT32_INIT(1);
+  ddsrt_atomic_uint32_t uint32 = DDSRT_ATOMIC_UINT32_INIT(1);
 #if DDSRT_HAVE_ATOMIC64
-  volatile ddsrt_atomic_uint64_t uint64 = DDSRT_ATOMIC_UINT64_INIT(1);
+  ddsrt_atomic_uint64_t uint64 = DDSRT_ATOMIC_UINT64_INIT(1);
 #endif
-  volatile ddsrt_atomic_uintptr_t uintptr = DDSRT_ATOMIC_UINTPTR_INIT(1);
+  ddsrt_atomic_uintptr_t uintptr = DDSRT_ATOMIC_UINTPTR_INIT(1);
   _osuint32 = 1;
   _osuint64 = 1;
   _osaddress = 1;
@@ -184,12 +184,12 @@ CU_Test(ddsrt_atomics, decrement)
 
 CU_Test(ddsrt_atomics, add)
 {
-  volatile ddsrt_atomic_uint32_t uint32 = DDSRT_ATOMIC_UINT32_INIT(1);
+  ddsrt_atomic_uint32_t uint32 = DDSRT_ATOMIC_UINT32_INIT(1);
 #if DDSRT_HAVE_ATOMIC64
-  volatile ddsrt_atomic_uint64_t uint64 = DDSRT_ATOMIC_UINT64_INIT(1);
+  ddsrt_atomic_uint64_t uint64 = DDSRT_ATOMIC_UINT64_INIT(1);
 #endif
-  volatile ddsrt_atomic_uintptr_t uintptr = DDSRT_ATOMIC_UINTPTR_INIT(1);
-  volatile ddsrt_atomic_voidp_t uintvoidp = DDSRT_ATOMIC_VOIDP_INIT((uintptr_t)1);
+  ddsrt_atomic_uintptr_t uintptr = DDSRT_ATOMIC_UINTPTR_INIT(1);
+  ddsrt_atomic_voidp_t uintvoidp = DDSRT_ATOMIC_VOIDP_INIT((uintptr_t)1);
   _osuint32 = 2;
   _osuint64 = 2;
   _osaddress = 2;
@@ -234,12 +234,12 @@ CU_Test(ddsrt_atomics, add)
 
 CU_Test(ddsrt_atomics, subtract)
 {
-  volatile ddsrt_atomic_uint32_t uint32 = DDSRT_ATOMIC_UINT32_INIT(5);
+  ddsrt_atomic_uint32_t uint32 = DDSRT_ATOMIC_UINT32_INIT(5);
 #if DDSRT_HAVE_ATOMIC64
-  volatile ddsrt_atomic_uint64_t uint64 = DDSRT_ATOMIC_UINT64_INIT(5);
+  ddsrt_atomic_uint64_t uint64 = DDSRT_ATOMIC_UINT64_INIT(5);
 #endif
-  volatile ddsrt_atomic_uintptr_t uintptr = DDSRT_ATOMIC_UINTPTR_INIT(5);
-  volatile ddsrt_atomic_voidp_t uintvoidp = DDSRT_ATOMIC_VOIDP_INIT((uintptr_t)5);
+  ddsrt_atomic_uintptr_t uintptr = DDSRT_ATOMIC_UINTPTR_INIT(5);
+  ddsrt_atomic_voidp_t uintvoidp = DDSRT_ATOMIC_VOIDP_INIT((uintptr_t)5);
   _osuint32 = 2;
   _osuint64 = 2;
   _osaddress = 2;
@@ -291,11 +291,11 @@ CU_Test(ddsrt_atomics, and)
 
      148  010010100 */
 
-  volatile ddsrt_atomic_uint32_t uint32 = DDSRT_ATOMIC_UINT32_INIT(150);
+  ddsrt_atomic_uint32_t uint32 = DDSRT_ATOMIC_UINT32_INIT(150);
 #if DDSRT_HAVE_ATOMIC64
-  volatile ddsrt_atomic_uint64_t uint64 = DDSRT_ATOMIC_UINT64_INIT(150);
+  ddsrt_atomic_uint64_t uint64 = DDSRT_ATOMIC_UINT64_INIT(150);
 #endif
-  volatile ddsrt_atomic_uintptr_t uintptr = DDSRT_ATOMIC_UINTPTR_INIT(150);
+  ddsrt_atomic_uintptr_t uintptr = DDSRT_ATOMIC_UINTPTR_INIT(150);
   _osuint32 = 500;
   _osuint64 = 500;
   _osaddress = 500;
@@ -346,11 +346,11 @@ CU_Test(ddsrt_atomics, or)
 
      502  111110110 */
 
-  volatile ddsrt_atomic_uint32_t uint32 = DDSRT_ATOMIC_UINT32_INIT(150);
+  ddsrt_atomic_uint32_t uint32 = DDSRT_ATOMIC_UINT32_INIT(150);
 #if DDSRT_HAVE_ATOMIC64
-  volatile ddsrt_atomic_uint64_t uint64 = DDSRT_ATOMIC_UINT64_INIT(150);
+  ddsrt_atomic_uint64_t uint64 = DDSRT_ATOMIC_UINT64_INIT(150);
 #endif
-  volatile ddsrt_atomic_uintptr_t uintptr = DDSRT_ATOMIC_UINTPTR_INIT(150);
+  ddsrt_atomic_uintptr_t uintptr = DDSRT_ATOMIC_UINTPTR_INIT(150);
   _osuint32 = 500;
   _osuint64 = 500;
   _osaddress = 500;


### PR DESCRIPTION
1. Make atomic load and store operations actually atomic
2. Switch definitions to use `__atomic_...` functions instead of legacy `__sync_...` functions.
3. Clean up function signatures.
 
Fix #409