### PR TITLE
Avoid race causing thread-state pointer aliasing

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/q_thread.h
+++ b/src/core/ddsi/include/dds/ddsi/q_thread.h
@@ -50,6 +50,8 @@ typedef int32_t svtime_t; /* signed version */
 
 enum thread_state {
   THREAD_STATE_ZERO, /* known to be dead */
+  THREAD_STATE_STOPPED, /* internal thread, stopped-but-not-reaped */
+  THREAD_STATE_INIT, /* internal thread, initializing */
   THREAD_STATE_LAZILY_CREATED, /* lazily created in response because an application used it. Reclaimed if the thread terminates, but not considered an error if all of Cyclone is shutdown while this thread hasn't terminated yet */
   THREAD_STATE_ALIVE /* known to be alive - for Cyclone internal threads */
 };
@@ -67,13 +69,34 @@ struct ddsrt_log_cfg;
  *
  * gv is constant for internal threads, i.e., for threads with state = ALIVE
  * gv is non-NULL for internal threads except thread liveliness monitoring
+ *
+ * Q_THREAD_DEBUG enables some really costly debugging stuff that may not be fully
+ * portable (I used it once, might as well keep it)
  */
+#define Q_THREAD_DEBUG 0
+#if Q_THREAD_DEBUG
+#define Q_THREAD_NSTACKS 20
+#define Q_THREAD_STACKDEPTH 10
+#define Q_THREAD_BASE_DEBUG \
+  void *stks[Q_THREAD_NSTACKS][Q_THREAD_STACKDEPTH]; \
+  int stks_depth[Q_THREAD_NSTACKS]; \
+  int stks_idx;
+
+struct thread_state1;
+void thread_vtime_trace (struct thread_state1 *ts1);
+#else /* Q_THREAD_DEBUG */
+#define Q_THREAD_BASE_DEBUG
+#define thread_vtime_trace(ts1) do { } while (0)
+#endif /* Q_THREAD_DEBUG */
+
 #define THREAD_BASE                             \
   ddsrt_atomic_uint32_t vtime;                  \
-  ddsrt_atomic_voidp_t gv;                      \
   enum thread_state state;                      \
+  ddsrt_atomic_voidp_t gv;                      \
   ddsrt_thread_t tid;                           \
-  ddsrt_thread_t extTid;                        \
+  uint32_t (*f) (void *arg);                    \
+  void *f_arg;                                  \
+  Q_THREAD_BASE_DEBUG /* note: no semicolon! */ \
   char name[24] /* note: no semicolon! */
 
 struct thread_state_base {
@@ -107,8 +130,6 @@ DDS_EXPORT dds_return_t create_thread (struct thread_state1 **ts, const struct d
 DDS_EXPORT struct thread_state1 *lookup_thread_state_real (void);
 DDS_EXPORT dds_return_t join_thread (struct thread_state1 *ts1);
 DDS_EXPORT void log_stack_traces (const struct ddsrt_log_cfg *logcfg, const struct ddsi_domaingv *gv);
-DDS_EXPORT void reset_thread_state (struct thread_state1 *ts1);
-DDS_EXPORT int thread_exists (const char *name);
 
 DDS_EXPORT inline struct thread_state1 *lookup_thread_state (void) {
   struct thread_state1 *ts1 = tsd_thread_state;
@@ -154,6 +175,7 @@ DDS_EXPORT inline void thread_state_asleep (struct thread_state1 *ts1)
   assert (vtime_awake_p (vt));
   /* nested calls a rare and an extra fence doesn't break things */
   ddsrt_atomic_fence_rel ();
+  thread_vtime_trace (ts1);
   if ((vt & VTIME_NEST_MASK) == 1)
     vt += (1u << VTIME_TIME_SHIFT) - 1u;
   else
@@ -167,6 +189,7 @@ DDS_EXPORT inline void thread_state_awake (struct thread_state1 *ts1, const stru
   assert ((vt & VTIME_NEST_MASK) < VTIME_NEST_MASK);
   assert (gv != NULL);
   assert (ts1->state != THREAD_STATE_ALIVE || gv == ddsrt_atomic_ldvoidp (&ts1->gv));
+  thread_vtime_trace (ts1);
   ddsrt_atomic_stvoidp (&ts1->gv, (struct ddsi_domaingv *) gv);
   ddsrt_atomic_fence_stst ();
   ddsrt_atomic_st32 (&ts1->vtime, vt + 1u);
@@ -179,6 +202,7 @@ DDS_EXPORT inline void thread_state_awake_domain_ok (struct thread_state1 *ts1)
   vtime_t vt = ddsrt_atomic_ld32 (&ts1->vtime);
   assert ((vt & VTIME_NEST_MASK) < VTIME_NEST_MASK);
   assert (ddsrt_atomic_ldvoidp (&ts1->gv) != NULL);
+  thread_vtime_trace (ts1);
   ddsrt_atomic_st32 (&ts1->vtime, vt + 1u);
   /* nested calls a rare and an extra fence doesn't break things */
   ddsrt_atomic_fence_acq ();
@@ -196,6 +220,7 @@ DDS_EXPORT inline void thread_state_awake_to_awake_no_nest (struct thread_state1
   vtime_t vt = ddsrt_atomic_ld32 (&ts1->vtime);
   assert ((vt & VTIME_NEST_MASK) == 1);
   ddsrt_atomic_fence_rel ();
+  thread_vtime_trace (ts1);
   ddsrt_atomic_st32 (&ts1->vtime, vt + (1u << VTIME_TIME_SHIFT));
   ddsrt_atomic_fence_acq ();
 }


### PR DESCRIPTION
The thread_states array resets the "state" to ZERO on thread termination
to indicate that the slot was unused, but it leaves the thread id
unchanged because some platforms don't have a defined value that will
never be used as a thread id.  A consequence is that a newly created
thread may result in multiple slots containing their own thread id, but
generally there will only be one that is not in state ZERO.

However, the code for create_thread used to set the state to ALIVE prior
to creating the thread, and so if the events get scheduled like:

1. thread A: X.state = ALIVE
2. create new thread B, storing tid in X.tid
3. thread A: Y.state = ALIVE
4. new thread B: lookup self (and cache pointer)
5. create new thread C, storing tid in Y.tid
6. new thread C: lookup self (and cache pointer)

Then B will observe two slots in the ALIVE state, with X.tid certain to
match and Y.tid undefined (and hence possibly matching).  It may
therefore pick Y.  C will (in this schedule) of course always choose Y.
They cache the pointer and never look at X and Y again, except for
updating their virtual clocks.

These virtual clocks are updated non-atomically (by design it is private
to the thread) and so if both B & C use Y they can end up racing each
other in updating the virtual clock and cause the nesting level of the
"awake" state controlling garbage collection to get stuck (or wrap
around, or do other horrible things).  The consequence can be anything,
from a somewhat benign variant where GC effectively stops and some
operations (deleting readers and writers and shutting down) block
forever, to use-after-free and the undefined behaviour that implies.

This commit avoids looking up the slot in the newly created threads,
instead passing the correct address in the argument.  It also adds an
intermediate state INIT that serves to reserve the slot until the new
thread is actually running.  It does make the look-up safe (if one were
to do it), and as it is essentially free and gives more insight in the
state of the system when viewed from a debugger, it appears a useful
addition.

(https://github.com/ros2/rmw_cyclonedds/issues/104)

Signed-off-by: Erik Boasson <eb@ilities.com>