### PR TITLE
Don't pass null to memcmp

### DIFF
--- a/src/core/ddsi/src/ddsi_sertopic_default.c
+++ b/src/core/ddsi/src/ddsi_sertopic_default.c
@@ -38,11 +38,15 @@ static bool sertopic_default_equal (const struct ddsi_sertopic *acmn, const stru
     return false;
   if (a->type.m_nkeys != b->type.m_nkeys)
     return false;
-  if (memcmp (a->type.m_keys, b->type.m_keys, a->type.m_nkeys * sizeof (*a->type.m_keys)) != 0)
+  if (
+    (a->type.m_keys == NULL) != (b->type.m_keys == NULL) ||
+    memcmp (a->type.m_keys, b->type.m_keys, a->type.m_nkeys * sizeof (*a->type.m_keys)) != 0)
     return false;
   if (a->type.m_nops != b->type.m_nops)
     return false;
-  if (memcmp (a->type.m_ops, b->type.m_ops, a->type.m_nops * sizeof (*a->type.m_ops)) != 0)
+  if (
+    (a->type.m_ops == NULL) != (b->type.m_ops == NULL) ||
+    memcmp (a->type.m_ops, b->type.m_ops, a->type.m_nops * sizeof (*a->type.m_ops)) != 0)
     return false;
   assert (a->opt_size == b->opt_size);
   return true;

--- a/src/core/ddsi/src/ddsi_sertopic_default.c
+++ b/src/core/ddsi/src/ddsi_sertopic_default.c
@@ -39,13 +39,13 @@ static bool sertopic_default_equal (const struct ddsi_sertopic *acmn, const stru
   if (a->type.m_nkeys != b->type.m_nkeys)
     return false;
   if (
-    (a->type.m_keys == NULL) != (b->type.m_keys == NULL) ||
+    (a->type.m_nkeys > 0) &&
     memcmp (a->type.m_keys, b->type.m_keys, a->type.m_nkeys * sizeof (*a->type.m_keys)) != 0)
     return false;
   if (a->type.m_nops != b->type.m_nops)
     return false;
   if (
-    (a->type.m_ops == NULL) != (b->type.m_ops == NULL) ||
+    (a->type.m_nops > 0) &&
     memcmp (a->type.m_ops, b->type.m_ops, a->type.m_nops * sizeof (*a->type.m_ops)) != 0)
     return false;
   assert (a->opt_size == b->opt_size);


### PR DESCRIPTION
```
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /opt/ros/master/src/ros2/rmw_cyclonedds/rmw_cyclonedds_cpp/include/rmw_cyclonedds_cpp/serdes.hpp:135:3 in
/opt/ros/master/src/eclipse-cyclonedds/cyclonedds/src/core/ddsi/src/ddsi_sertopic_default.c:41:15: runtime error: null pointer passed as argument 1, which is declared to never be null
/usr/include/string.h:64:33: note: nonnull attribute specified here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /opt/ros/master/src/eclipse-cyclonedds/cyclonedds/src/core/ddsi/src/ddsi_sertopic_default.c:41:15 in
/opt/ros/master/src/eclipse-cyclonedds/cyclonedds/src/core/ddsi/src/ddsi_sertopic_default.c:41:31: runtime error: null pointer passed as argument 2, which is declared to never be null
/usr/include/string.h:64:33: note: nonnull attribute specified here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /opt/ros/master/src/eclipse-cyclonedds/cyclonedds/src/core/ddsi/src/ddsi_sertopic_default.c:41:31 in
/opt/ros/master/src/eclipse-cyclonedds/cyclonedds/src/core/ddsi/src/ddsi_sertopic_default.c:45:15: runtime error: null pointer passed as argument 1, which is declared to never be null
/usr/include/string.h:64:33: note: nonnull attribute specified here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /opt/ros/master/src/eclipse-cyclonedds/cyclonedds/src/core/ddsi/src/ddsi_sertopic_default.c:45:15 in
/opt/ros/master/src/eclipse-cyclonedds/cyclonedds/src/core/ddsi/src/ddsi_sertopic_default.c:45:30: runtime error: null pointer passed as argument 2, which is declared to never be null
/usr/include/string.h:64:33: note: nonnull attribute specified here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /opt/ros/master/src/eclipse-cyclonedds/cyclonedds/src/core/ddsi/src/ddsi_sertopic_default.c:45:30 in
```
Signed-off-by: Dan Rose <dan@digilabs.io>
