### PR TITLE
Fix undefined behavior when hash function given null pointer

### DIFF
--- a/src/core/ddsi/src/ddsi_sertopic_default.c
+++ b/src/core/ddsi/src/ddsi_sertopic_default.c
@@ -56,7 +56,7 @@ static uint32_t sertopic_default_hash (const struct ddsi_sertopic *tpcmn)
 {
   const struct ddsi_sertopic_default *tp = (struct ddsi_sertopic_default *) tpcmn;
   uint32_t h = 0;
-  h = ddsrt_mh3 (&tp->native_encoding_identifier, sizeof (tp->native_encoding_identifier), 0);
+  h = ddsrt_mh3 (&tp->native_encoding_identifier, sizeof (tp->native_encoding_identifier), h);
   h = ddsrt_mh3 (&tp->type.m_size, sizeof (tp->type.m_size), h);
   h = ddsrt_mh3 (&tp->type.m_align, sizeof (tp->type.m_align), h);
   h = ddsrt_mh3 (&tp->type.m_flagset, sizeof (tp->type.m_flagset), h);

--- a/src/core/ddsi/src/ddsi_sertopic_default.c
+++ b/src/core/ddsi/src/ddsi_sertopic_default.c
@@ -38,11 +38,15 @@ static bool sertopic_default_equal (const struct ddsi_sertopic *acmn, const stru
     return false;
   if (a->type.m_nkeys != b->type.m_nkeys)
     return false;
-  if (memcmp (a->type.m_keys, b->type.m_keys, a->type.m_nkeys * sizeof (*a->type.m_keys)) != 0)
+  if (
+    (a->type.m_keys == NULL) != (b->type.m_keys == NULL) ||
+    memcmp (a->type.m_keys, b->type.m_keys, a->type.m_nkeys * sizeof (*a->type.m_keys)) != 0)
     return false;
   if (a->type.m_nops != b->type.m_nops)
     return false;
-  if (memcmp (a->type.m_ops, b->type.m_ops, a->type.m_nops * sizeof (*a->type.m_ops)) != 0)
+  if (
+    (a->type.m_ops == NULL) != (b->type.m_ops == NULL) ||
+    memcmp (a->type.m_ops, b->type.m_ops, a->type.m_nops * sizeof (*a->type.m_ops)) != 0)
     return false;
   assert (a->opt_size == b->opt_size);
   return true;

--- a/src/ddsrt/src/mh3.c
+++ b/src/ddsrt/src/mh3.c
@@ -25,38 +25,41 @@ uint32_t ddsrt_mh3 (const void *key, size_t len, uint32_t seed)
   const uint32_t c2 = 0x1b873593;
 
   uint32_t h1 = seed;
-  const uint32_t *blocks = (const uint32_t *) (data + nblocks * 4);
-  for (intptr_t i = -nblocks; i; i++)
-  {
-    uint32_t k1 = blocks[i];
 
-    k1 *= c1;
-    k1 = DDSRT_MH3_ROTL32 (k1, 15);
-    k1 *= c2;
+  if(len){
+    const uint32_t *blocks = (const uint32_t *) (data + nblocks * 4);
+    for (intptr_t i = -nblocks; i; i++)
+    {
+      uint32_t k1 = blocks[i];
 
-    h1 ^= k1;
-    h1 = DDSRT_MH3_ROTL32 (h1, 13);
-    h1 = h1 * 5 + 0xe6546b64;
-  }
-
-  const uint8_t *tail = data + nblocks * 4;
-  uint32_t k1 = 0;
-  switch (len & 3)
-  {
-    case 3:
-      k1 ^= (uint32_t) tail[2] << 16;
-      /* FALLS THROUGH */
-    case 2:
-      k1 ^= (uint32_t) tail[1] << 8;
-      /* FALLS THROUGH */
-    case 1:
-      k1 ^= (uint32_t) tail[0];
       k1 *= c1;
       k1 = DDSRT_MH3_ROTL32 (k1, 15);
       k1 *= c2;
+
       h1 ^= k1;
-      /* FALLS THROUGH */
-  };
+      h1 = DDSRT_MH3_ROTL32 (h1, 13);
+      h1 = h1 * 5 + 0xe6546b64;
+    }
+
+    const uint8_t *tail = data + nblocks * 4;
+    uint32_t k1 = 0;
+    switch (len & 3)
+    {
+      case 3:
+        k1 ^= (uint32_t) tail[2] << 16;
+        /* FALLS THROUGH */
+      case 2:
+        k1 ^= (uint32_t) tail[1] << 8;
+        /* FALLS THROUGH */
+      case 1:
+        k1 ^= (uint32_t) tail[0];
+        k1 *= c1;
+        k1 = DDSRT_MH3_ROTL32 (k1, 15);
+        k1 *= c2;
+        h1 ^= k1;
+        /* FALLS THROUGH */
+    }
+  }
 
   /* finalization */
   h1 ^= (uint32_t) len;


### PR DESCRIPTION
```
[test_subscriber-12] /opt/ros/master/src/eclipse-cyclonedds/cyclonedds/src/ddsrt/src/mh3.c:28:53: runtime error: applying zero offset to null pointer
[test_subscriber-12] SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /opt/ros/master/src/eclipse-cyclonedds/cyclonedds/src/ddsrt/src/mh3.c:28:53 in
Signed-off-by: Dan Rose <dan@digilabs.io>
```