### PR TITLE
Update security documentation

### DIFF
--- a/docs/manual/_static/example_governance.xml
+++ b/docs/manual/_static/example_governance.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding=\"utf-8\"?>
+<dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://www.omg.org/spec/DDS-SECURITY/20170901/omg_shared_ca_governance.xsd">
+  <domain_access_rules>
+    <domain_rule>
+      <domains>
+        <id_range>
+          <min>0</min>
+          <max>230</max>
+        </id_range>
+      </domains>
+      <allow_unauthenticated_participants>false</allow_unauthenticated_participants>
+      <enable_join_access_control>true</enable_join_access_control>
+      <discovery_protection_kind>NONE</discovery_protection_kind>
+      <liveliness_protection_kind>NONE</liveliness_protection_kind>
+      <rtps_protection_kind>NONE</rtps_protection_kind>
+      <topic_access_rules>
+        <topic_rule>
+          <topic_expression>*</topic_expression>
+          <enable_discovery_protection>true</enable_discovery_protection>
+          <enable_liveliness_protection>true</enable_liveliness_protection>
+          <enable_read_access_control>true</enable_read_access_control>
+          <enable_write_access_control>true</enable_write_access_control>
+          <metadata_protection_kind>SIGN</metadata_protection_kind>
+          <data_protection_kind>ENCRYPT</data_protection_kind>
+        </topic_rule>
+      </topic_access_rules>
+    </domain_rule>
+  </domain_access_rules>
+</dds>

--- a/docs/manual/_static/example_permissions.xml
+++ b/docs/manual/_static/example_permissions.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:noNamespaceSchemaLocation="https://www.omg.org/spec/DDS-SECURITY/20170901/omg_shared_ca_permissions.xsd">
+  <permissions>
+    <grant name="default_permissions">
+      <subject_name>emailAddress=alice@cycloneddssecurity.adlinktech.com,CN=Alice Example,O=Example Organization,OU=Organizational Unit Name,L=Locality Name,ST=OV,C=NL</subject_name>
+      <validity>
+        <!-- Format is CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] in GMT -->
+        <not_before>2020-01-01T01:00:00</not_before>
+        <not_after>2120-01-01T01:00:00</not_after>
+      </validity>
+      <allow_rule>
+        <domains>
+          <id_range>
+            <min>0</min>
+            <max>230</max>
+          </id_range>
+        </domains>
+        <publish>
+          <topics>
+            <topic>*</topic>
+          </topics>
+          <partitions>
+            <partition>*</partition>
+          </partitions>
+        </publish>
+        <subscribe>
+          <topics>
+            <topic>*</topic>
+          </topics>
+          <partitions>
+            <partition>*</partition>
+          </partitions>
+        </subscribe>
+      </allow_rule>
+      <default>DENY</default>
+    </grant>
+  </permissions>
+</dds>

--- a/docs/manual/_static/security_by_config.xml
+++ b/docs/manual/_static/security_by_config.xml
@@ -1,0 +1,19 @@
+<Domain id="any">
+  <DDSSecurity>
+    <Authentication>
+      <Library initFunction="init_authentication" finalizeFunction="finalize_authentication" path="dds_security_auth"/>
+      <IdentityCA>file:/path/to/example_id_ca_cert.pem</IdentityCA>
+      <IdentityCertificate>file:/path/to/example_alice_cert.pem</IdentityCertificate>
+      <PrivateKey>file:/path/to/example_alice_priv_key.pem</PrivateKey>
+    </Authentication>
+    <Cryptographic>
+      <Library initFunction="init_crypto" finalizeFunction="finalize_crypto" path="dds_security_crypto"/>
+    </Cryptographic>
+    <AccessControl>
+      <Library initFunction="init_access_control" finalizeFunction="finalize_access_control" path="dds_security_ac"/>
+      <PermissionsCA>file:/path/to/example_perm_ca_cert.pem</PermissionsCA>
+      <Governance>file:/path/to/example_governance.p7s</Governance>
+      <Permissions>file:/path/to/example_permissions.p7s</Permissions>
+    </AccessControl>
+  </DDSSecurity>
+</Domain>

--- a/docs/manual/_static/security_by_qos.c
+++ b/docs/manual/_static/security_by_qos.c
@@ -1,0 +1,21 @@
+dds_qos_t * qos = dds_create_qos();
+
+dds_qset_prop(qos, "dds.sec.auth.library.path", "dds_security_auth");
+dds_qset_prop(qos, "dds.sec.auth.library.init", "init_authentication");
+dds_qset_prop(qos, "dds.sec.auth.library.finalize", "finalize_authentication");
+dds_qset_prop(qos, "dds.sec.auth.identity_ca", "file:/path/to/example_id_ca_cert.pem");
+dds_qset_prop(qos, "dds.sec.auth.private_key", "file:/path/to/example_alice_priv_key.pem");
+dds_qset_prop(qos, "dds.sec.auth.identity_certificate", "file:/path/to/example_alice_cert.pem");
+
+dds_qset_prop(qos, "dds.sec.crypto.library.path", "dds_security_crypto");
+dds_qset_prop(qos, "dds.sec.crypto.library.init", "init_crypto");
+dds_qset_prop(qos, "dds.sec.crypto.library.finalize", "finalize_crypto");
+
+dds_qset_prop(qos, "dds.sec.access.library.path", "dds_security_ac");
+dds_qset_prop(qos, "dds.sec.access.library.init", "init_access_control");
+dds_qset_prop(qos, "dds.sec.access.library.finalize", "finalize_access_control");
+dds_qset_prop(qos, "dds.sec.access.permissions_ca", "file:/path/to/example_perm_ca_cert.pem");
+dds_qset_prop(qos, "dds.sec.access.governance", "file:/path/to/example_governance.p7s");
+dds_qset_prop(qos, "dds.sec.access.permissions", "file:/path/to/example_permissions.p7s");
+
+dds_entity_t participant = dds_create_participant(0, qos, NULL);

--- a/docs/manual/index.rst
+++ b/docs/manual/index.rst
@@ -21,6 +21,7 @@ Welcome to Eclipse Cyclone DDS's documentation!
    GettingStartedGuide/index
    ddsc
    config
+   security
 
 Indices and tables
 ==================

--- a/docs/manual/security.rst
+++ b/docs/manual/security.rst
@@ -42,9 +42,6 @@ authentication and Diffie-Hellman is used for key exchange. AccessControl use Pe
 signed by shared Certificate Authority. Cryptography uses AES-GCM (AES using Galois Counter Mode)
 for encryption and AES-GMAC for message authentication.
 
-The plugins are accessed by the DDSI2 service when DDS Security is enabled by supplying the
-security configuration within the XML configuration or Participant QoS.
-
 Security plugins are dynamically loaded where the locations are defined in CycloneDDS
 configuration or Participant QoS settings.
 
@@ -149,7 +146,7 @@ The configuration of DDS Security is split up into two parts.
 Plugins Configuration
 *********************
 
-CycloneDDS gets the security configuration from DDS2I XML configuration elements or from
+CycloneDDS gets the security configuration from XML configuration elements or from
 the participant QoS policies as stated in the DDS Security specification.
 
 This behavior allows applications to use DDS Security without recompiling the binaries.
@@ -188,10 +185,10 @@ file (prefixed with ``file:``).
 Optionally the private key could be protected by a password
 (``DDSSecurity/Authentication/Password``).
 
-Furthermore the CycloneDDS configuration allows to configure a directory containing additional
-identity CA's which are used to verify the identity certificates that are received by remote instances
-(``DDSSecurity/Authentication/TrustedCADirectory``). This option allows to use more than one identity
-CA throughout the system.
+Furthermore the CycloneDDS configuration allows configuring a directory containing additional
+identity CA's which are used to verify the identity certificates that are received from remote instances
+(``DDSSecurity/Authentication/TrustedCADirectory``). This option allows multiple identity
+CAs throughout the system.
 
 .. _`Access Control Properties`:
 
@@ -223,7 +220,7 @@ Access Control Configuration
 Access Control configuration consists of Governance document and Permissions document.
 Both governance and permissions files must be signed by the Permissions CA in S/MIME format.
 Participants use their own permissions CA to validate remote permissions. So, all permissions CA
-Certificates must be same for all participants.
+Certificates must be the same for all participants.
 
 The signed document should use S/MIME version 3.2 format as defined in IETF RFC 5761 using
 SignedData Content Type (section 2.4.2 of IETF RFC 5761) formatted as multipart/signed (section
@@ -235,8 +232,8 @@ Additionally the signer certificate should be be included within the signature.
 Governance Document
 ===================
 
-Governance document defines the security behavior of domains and topics. It is an XML document and
-its format is specified in OMG DDS Security Version 1.1 Section 9.4.1.2.3.
+The Governance document defines the security behavior of domains and topics. It is an XML document
+and its format is specified in OMG DDS Security Version 1.1 Section 9.4.1.2.3.
 
 This section describes the properties that can be specified in a permissions document. An example
 of a governance document is provided in `Create a signed governance document`_. The options
@@ -377,9 +374,8 @@ of a permissions document is provided in `Creating a signed permissions document
 Validity period
 ===============
 
-It is checked before creating participant; expired permissions document results with DDSI shutdown.
-Validity period is also checked during handshake with remote participant; expired remote
-permissions document prevents communications to be established.
+It is checked before creating participant. Validity period is also checked during handshake with
+remote participant; expired remote permissions document prevents communications to be established.
 
 
 Subject Name
@@ -447,15 +443,10 @@ resent.
 DDS Secure Discovery
 ********************
 
-Just like normal operation, DDSI will discover local and remote participants, topics, readers and
-writers. However, when DDS Security is enabled, it is more complex and will take a longer time
-(due to the handshaking that is required).
-
-With every new node in the system, the discovery takes exponentially longer. This can become a
-problem if the system contains a number of slow platforms or is large.
-
-The Security discovery performance can be increased quite a bit by using the DDSI
-Internal/SquashParticipants configuration.
+Just like normal operation, Cyclone DDS discovers remote participants, topics, readers and writers.
+However, when DDS Security is enabled, it is more complex and will take a longer time (due to the
+handshaking that is required). The effort to perform discovery grows quadratically in the number of
+nodes. This can become a problem if the system contains a number of slow platforms or is large.
 
 
 Proprietary builtin endpoints


### PR DESCRIPTION
An update for the security documentation that is part of the CycloneDDS manual:
- added openssl commands for creating a set of CA and identity certificates
- code fragment for setting security by qos and example of xml security config
- commands for signing governance and permissions documents using openssl