### PR TITLE
Rename ``nn_keyhash`` to ``ddsi_keyhash``

### DIFF
--- a/src/core/ddsc/src/dds_builtin.c
+++ b/src/core/ddsc/src/dds_builtin.c
@@ -176,7 +176,7 @@ static struct ddsi_tkmap_instance *dds__builtin_get_tkmap_entry (const struct dd
   struct dds_domain *domain = vdomain;
   struct ddsi_tkmap_instance *tk;
   struct ddsi_serdata *sd;
-  struct nn_keyhash kh;
+  struct ddsi_keyhash kh;
   memcpy (&kh, guid, sizeof (kh));
   /* any random builtin topic will do (provided it has a GUID for a key), because what matters is the "class" of the topic, not the actual topic; also, this is called early in the initialisation of the entity with this GUID, which simply causes serdata_from_keyhash to create a key-only serdata because the key lookup fails. */
   sd = ddsi_serdata_from_keyhash (domain->builtin_participant_topic, &kh);
@@ -191,7 +191,7 @@ struct ddsi_serdata *dds__builtin_make_sample (const struct entity_common *e, nn
   struct dds_domain *dom = e->gv->builtin_topic_interface->arg;
   struct ddsi_sertopic *topic = NULL;
   struct ddsi_serdata *serdata;
-  struct nn_keyhash keyhash;
+  struct ddsi_keyhash keyhash;
   switch (e->kind)
   {
     case EK_PARTICIPANT:

--- a/src/core/ddsc/src/dds_serdata_builtintopic.c
+++ b/src/core/ddsc/src/dds_serdata_builtintopic.c
@@ -126,7 +126,7 @@ static void from_entity_pwr (struct ddsi_serdata_builtintopic *d, const struct p
   assert (d->xqos.present & QP_TYPE_NAME);
 }
 
-static struct ddsi_serdata *ddsi_serdata_builtin_from_keyhash (const struct ddsi_sertopic *tpcmn, const nn_keyhash_t *keyhash)
+static struct ddsi_serdata *ddsi_serdata_builtin_from_keyhash (const struct ddsi_sertopic *tpcmn, const ddsi_keyhash_t *keyhash)
 {
   /* FIXME: not quite elegant to manage the creation of a serdata for a built-in topic via this function, but I also find it quite unelegant to let from_sample read straight from the underlying internal entity, and to_sample convert to the external format ... I could claim the internal entity is the "serialised form", but that forces wrapping it in a fragchain in one way or another, which, though possible, is also a bit lacking in elegance. */
   const struct ddsi_sertopic_builtintopic *tp = (const struct ddsi_sertopic_builtintopic *)tpcmn;

--- a/src/core/ddsi/CMakeLists.txt
+++ b/src/core/ddsi/CMakeLists.txt
@@ -98,6 +98,7 @@ PREPEND(hdrs_private_ddsi "${CMAKE_CURRENT_LIST_DIR}/include/dds/ddsi"
     ddsi_builtin_topic_if.h
     ddsi_rhc.h
     ddsi_guid.h
+    ddsi_keyhash.h
     ddsi_entity_index.h
     ddsi_deadline.h
     ddsi_deliver_locally.h

--- a/src/core/ddsi/include/dds/ddsi/ddsi_keyhash.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_keyhash.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright(c) 2020 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#ifndef DDSI_KEYHASH_H
+#define DDSI_KEYHASH_H
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+typedef struct ddsi_keyhash {
+  unsigned char value[16];
+} ddsi_keyhash_t;
+
+#if defined (__cplusplus)
+}
+#endif
+
+#endif

--- a/src/core/ddsi/include/dds/ddsi/ddsi_plist.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_plist.h
@@ -14,6 +14,7 @@
 
 #include "dds/ddsi/q_feature_check.h"
 #include "dds/ddsi/ddsi_xqos.h"
+#include "dds/ddsi/ddsi_keyhash.h"
 #include "dds/ddsi/ddsi_tran.h" /* FIXME: eliminate */
 
 #if defined (__cplusplus)
@@ -96,10 +97,6 @@ typedef struct nn_locators {
 typedef uint32_t nn_ipv4address_t;
 
 typedef uint32_t nn_port_t;
-
-typedef struct nn_keyhash {
-  unsigned char value[16];
-} nn_keyhash_t;
 
 #ifdef DDSI_INCLUDE_SECURITY
 typedef struct nn_tag {
@@ -218,7 +215,7 @@ typedef struct ddsi_plist {
   uint32_t builtin_endpoint_set;
   /* int type_max_size_serialized; */
   char *entity_name;
-  nn_keyhash_t keyhash;
+  ddsi_keyhash_t keyhash;
   uint32_t statusinfo;
   nn_prismtech_participant_version_info_t prismtech_participant_version_info;
   char *type_description;

--- a/src/core/ddsi/include/dds/ddsi/ddsi_serdata.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_serdata.h
@@ -160,7 +160,7 @@ struct ddsi_serdata_ops {
 
 #define DDSI_SERDATA_HAS_PRINT 1
 #define DDSI_SERDATA_HAS_FROM_SER_IOV 1
-#define DDSI_SERDATA_HAS_ADD_KEYHASH 1
+#define DDSI_SERDATA_HAS_GET_KEYHASH 1
 
 DDS_EXPORT void ddsi_serdata_init (struct ddsi_serdata *d, const struct ddsi_sertopic *tp, enum ddsi_serdata_kind kind);
 

--- a/src/core/ddsi/include/dds/ddsi/ddsi_serdata.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_serdata.h
@@ -15,13 +15,13 @@
 #include "dds/ddsrt/sockets.h"
 #include "dds/ddsi/q_time.h"
 #include "dds/ddsi/ddsi_sertopic.h"
+#include "dds/ddsi/ddsi_keyhash.h"
 
 #if defined (__cplusplus)
 extern "C" {
 #endif
 
 struct nn_rdata;
-struct nn_keyhash;
 
 enum ddsi_serdata_kind {
   SDK_EMPTY,
@@ -65,7 +65,7 @@ typedef struct ddsi_serdata * (*ddsi_serdata_from_ser_t) (const struct ddsi_sert
 typedef struct ddsi_serdata * (*ddsi_serdata_from_ser_iov_t) (const struct ddsi_sertopic *topic, enum ddsi_serdata_kind kind, ddsrt_msg_iovlen_t niov, const ddsrt_iovec_t *iov, size_t size);
 
 /* Construct a serdata from a keyhash (an SDK_KEY by definition) */
-typedef struct ddsi_serdata * (*ddsi_serdata_from_keyhash_t) (const struct ddsi_sertopic *topic, const struct nn_keyhash *keyhash);
+typedef struct ddsi_serdata * (*ddsi_serdata_from_keyhash_t) (const struct ddsi_sertopic *topic, const struct ddsi_keyhash *keyhash);
 
 /* Construct a serdata from an application sample
    - "kind" is KEY or DATA depending on the operation invoked by the application;
@@ -138,7 +138,7 @@ typedef size_t (*ddsi_serdata_print_t) (const struct ddsi_sertopic *topic, const
 /* Add keyhash (from serdata) to buffer (forcing md5 when necessary).
    - key needs to be set within serdata (can already be md5)
    - buf needs to be at least 16 bytes large */
-typedef void (*ddsi_serdata_get_keyhash_t) (const struct ddsi_serdata *d, struct nn_keyhash *buf, bool force_md5);
+typedef void (*ddsi_serdata_get_keyhash_t) (const struct ddsi_serdata *d, struct ddsi_keyhash *buf, bool force_md5);
 
 struct ddsi_serdata_ops {
   ddsi_serdata_eqkey_t eqkey;
@@ -187,7 +187,7 @@ DDS_EXPORT inline struct ddsi_serdata *ddsi_serdata_from_ser_iov (const struct d
   return topic->serdata_ops->from_ser_iov (topic, kind, niov, iov, size);
 }
 
-DDS_EXPORT inline struct ddsi_serdata *ddsi_serdata_from_keyhash (const struct ddsi_sertopic *topic, const struct nn_keyhash *keyhash) {
+DDS_EXPORT inline struct ddsi_serdata *ddsi_serdata_from_keyhash (const struct ddsi_sertopic *topic, const struct ddsi_keyhash *keyhash) {
   return topic->serdata_ops->from_keyhash (topic, keyhash);
 }
 
@@ -237,7 +237,7 @@ DDS_EXPORT inline bool ddsi_serdata_print_topicless (const struct ddsi_sertopic 
   }
 }
 
-DDS_EXPORT inline void ddsi_serdata_get_keyhash (const struct ddsi_serdata *d, struct nn_keyhash *buf, bool force_md5) {
+DDS_EXPORT inline void ddsi_serdata_get_keyhash (const struct ddsi_serdata *d, struct ddsi_keyhash *buf, bool force_md5) {
   d->ops->get_keyhash (d, buf, force_md5);
 }
 

--- a/src/core/ddsi/src/ddsi_plist.c
+++ b/src/core/ddsi/src/ddsi_plist.c
@@ -487,7 +487,7 @@ static size_t ser_generic_srcsize (const enum pserop * __restrict desc)
       case Xb: case Xbx2: SIMPLE (Xb, unsigned char); break;
       case XbCOND: SIMPLE (XbCOND, unsigned char); break;
       case XG: SIMPLE (XG, ddsi_guid_t); break;
-      case XK: SIMPLE (XK, nn_keyhash_t); break;
+      case XK: SIMPLE (XK, ddsi_keyhash_t); break;
       case XbPROP: SIMPLE (XbPROP, unsigned char); break;
       case XQ: SIMPLE (XQ, ddsi_octetseq_t); break;
       case Xopt: break;
@@ -531,7 +531,7 @@ static bool fini_generic_embeddable (void * __restrict dst, size_t * __restrict 
       case Xb: case Xbx2: SIMPLE (Xb, unsigned char); break;
       case XbCOND: SIMPLE (XbCOND, unsigned char); break;
       case XG: SIMPLE (XG, ddsi_guid_t); break;
-      case XK: SIMPLE (XK, nn_keyhash_t); break;
+      case XK: SIMPLE (XK, ddsi_keyhash_t); break;
       case XbPROP: SIMPLE (XbPROP, unsigned char); break;
       case XQ:
       {
@@ -564,7 +564,7 @@ static size_t pserop_memalign (enum pserop op)
     case XO: case XQ: return alignof (ddsi_octetseq_t);
     case XS: return alignof (char *);
     case XG: return alignof (ddsi_guid_t);
-    case XK: return alignof (nn_keyhash_t);
+    case XK: return alignof (ddsi_keyhash_t);
     case Xb: case Xbx2: return 1;
     case Xo: case Xox2: return 1;
     case XbCOND: case XbPROP: return 1;
@@ -705,7 +705,7 @@ static dds_return_t deser_generic_r (void * __restrict dst, size_t * __restrict 
         break;
       }
       case XK: { /* keyhash */
-        nn_keyhash_t * const x = deser_generic_dst (dst, dstoff, alignof (nn_keyhash_t));
+        ddsi_keyhash_t * const x = deser_generic_dst (dst, dstoff, alignof (ddsi_keyhash_t));
         if (dd->bufsz - *srcoff < sizeof (*x))
           goto fail;
         memcpy (x, dd->buf + *srcoff, sizeof (*x));
@@ -817,7 +817,7 @@ static void ser_generic_size_embeddable (size_t *dstoff, const void *src, size_t
       case Xb: case Xbx2: SIMPLE1 (Xb, unsigned char); break;
       case XbCOND: SIMPLE1 (XbCOND, unsigned char); break;
       case XG: SIMPLE1 (XG, ddsi_guid_t); break;
-      case XK: SIMPLE1 (XK, nn_keyhash_t); break;
+      case XK: SIMPLE1 (XK, ddsi_keyhash_t); break;
       case XbPROP: /* "propagate" boolean: when 'false'; no serialisation; no size; force early out */
                COMPLEX (XbPROP, unsigned char, if (! *x) return); break;
       case XQ: COMPLEX (XQ, ddsi_octetseq_t, {
@@ -973,7 +973,7 @@ static dds_return_t ser_generic_embeddable (char * const data, size_t *dstoff, c
         break;
       }
       case XK: { /* keyhash */
-        nn_keyhash_t const * const x = deser_generic_src (src, &srcoff, alignof (nn_keyhash_t));
+        ddsi_keyhash_t const * const x = deser_generic_src (src, &srcoff, alignof (ddsi_keyhash_t));
         char * const p = data + *dstoff;
         memcpy (p, x, sizeof (*x));
         *dstoff += sizeof (*x);
@@ -1055,7 +1055,7 @@ static dds_return_t unalias_generic (void * __restrict dst, size_t * __restrict 
       case XbCOND: SIMPLE (XbCOND, unsigned char); break;
       case XbPROP: SIMPLE (XbPROP, unsigned char); break;
       case XG: SIMPLE (XG, ddsi_guid_t); break;
-      case XK: SIMPLE (XK, nn_keyhash_t); break;
+      case XK: SIMPLE (XK, ddsi_keyhash_t); break;
       case XQ: COMPLEX (XQ, ddsi_octetseq_t, if (x->length) {
         const size_t elem_size = ser_generic_srcsize (desc + 1);
         if (gen_seq_aliased)
@@ -1149,7 +1149,7 @@ static dds_return_t valid_generic (const void *src, size_t srcoff, const enum ps
       case XbCOND: SIMPLE (XbCOND, unsigned char, *x == 0 || *x == 1); break;
       case XbPROP: SIMPLE (XbPROP, unsigned char, *x == 0 || *x == 1); break;
       case XG: TRIVIAL (XG, ddsi_guid_t); break;
-      case XK: TRIVIAL (XK, nn_keyhash_t); break;
+      case XK: TRIVIAL (XK, ddsi_keyhash_t); break;
       case XQ: COMPLEX (XQ, ddsi_octetseq_t, {
         if ((x->length == 0) != (x->value == NULL))
           return DDS_RETCODE_BAD_PARAMETER;
@@ -1213,7 +1213,7 @@ static bool equal_generic (const void *srcx, const void *srcy, size_t srcoff, co
         break;
       case XbPROP: TRIVIAL (XbPROP, unsigned char); break;
       case XG: SIMPLE (XG, ddsi_guid_t, memcmp (x, y, sizeof (*x)) == 0); break;
-      case XK: SIMPLE (XK, nn_keyhash_t, memcmp (x, y, sizeof (*x)) == 0); break;
+      case XK: SIMPLE (XK, ddsi_keyhash_t, memcmp (x, y, sizeof (*x)) == 0); break;
       case XQ: COMPLEX (XQ, ddsi_octetseq_t, {
         if (x->length != y->length)
           return false;
@@ -1393,7 +1393,7 @@ static bool print_generic1 (char * __restrict *buf, size_t * __restrict bufsize,
         break;
       }
       case XK: { /* keyhash */
-        nn_keyhash_t const * const x = deser_generic_src (src, &srcoff, alignof (nn_keyhash_t));
+        ddsi_keyhash_t const * const x = deser_generic_src (src, &srcoff, alignof (ddsi_keyhash_t));
         if (!prtf (buf, bufsize, "%s{%02x%02x%02x%02x:%02x%02x%02x%02x:%02x%02x%02x%02x:%02x%02x%02x%02x}", sep,
                    x->value[0], x->value[1], x->value[2], x->value[3], x->value[4], x->value[5], x->value[6], x->value[7],
                    x->value[8], x->value[9], x->value[10], x->value[11], x->value[12], x->value[13], x->value[14], x->value[15]))

--- a/src/core/ddsi/src/ddsi_serdata.c
+++ b/src/core/ddsi/src/ddsi_serdata.c
@@ -37,7 +37,7 @@ extern inline void ddsi_serdata_unref (struct ddsi_serdata *serdata);
 extern inline uint32_t ddsi_serdata_size (const struct ddsi_serdata *d);
 extern inline struct ddsi_serdata *ddsi_serdata_from_ser (const struct ddsi_sertopic *topic, enum ddsi_serdata_kind kind, const struct nn_rdata *fragchain, size_t size);
 extern inline struct ddsi_serdata *ddsi_serdata_from_ser_iov (const struct ddsi_sertopic *topic, enum ddsi_serdata_kind kind, ddsrt_msg_iovlen_t niov, const ddsrt_iovec_t *iov, size_t size);
-extern inline struct ddsi_serdata *ddsi_serdata_from_keyhash (const struct ddsi_sertopic *topic, const struct nn_keyhash *keyhash);
+extern inline struct ddsi_serdata *ddsi_serdata_from_keyhash (const struct ddsi_sertopic *topic, const struct ddsi_keyhash *keyhash);
 extern inline struct ddsi_serdata *ddsi_serdata_from_sample (const struct ddsi_sertopic *topic, enum ddsi_serdata_kind kind, const void *sample);
 extern inline struct ddsi_serdata *ddsi_serdata_to_topicless (const struct ddsi_serdata *d);
 extern inline void ddsi_serdata_to_ser (const struct ddsi_serdata *d, size_t off, size_t sz, void *buf);
@@ -48,4 +48,4 @@ extern inline bool ddsi_serdata_topicless_to_sample (const struct ddsi_sertopic 
 extern inline bool ddsi_serdata_eqkey (const struct ddsi_serdata *a, const struct ddsi_serdata *b);
 extern inline bool ddsi_serdata_print (const struct ddsi_serdata *d, char *buf, size_t size);
 extern inline bool ddsi_serdata_print_topicless (const struct ddsi_sertopic *topic, const struct ddsi_serdata *d, char *buf, size_t size);
-extern inline void ddsi_serdata_get_keyhash (const struct ddsi_serdata *d, struct nn_keyhash *buf, bool force_md5);
+extern inline void ddsi_serdata_get_keyhash (const struct ddsi_serdata *d, struct ddsi_keyhash *buf, bool force_md5);

--- a/src/core/ddsi/src/ddsi_serdata_default.c
+++ b/src/core/ddsi/src/ddsi_serdata_default.c
@@ -346,7 +346,7 @@ static struct ddsi_serdata *serdata_default_from_ser_iov_nokey (const struct dds
   return fix_serdata_default_nokey (d, tpcmn->serdata_basehash);
 }
 
-static struct ddsi_serdata *ddsi_serdata_from_keyhash_cdr (const struct ddsi_sertopic *tpcmn, const nn_keyhash_t *keyhash)
+static struct ddsi_serdata *ddsi_serdata_from_keyhash_cdr (const struct ddsi_sertopic *tpcmn, const ddsi_keyhash_t *keyhash)
 {
   /* FIXME: not quite sure this is correct, though a check against a specially hacked OpenSplice suggests it is */
   const struct ddsi_sertopic_default *tp = (const struct ddsi_sertopic_default *)tpcmn;
@@ -374,7 +374,7 @@ static struct ddsi_serdata *ddsi_serdata_from_keyhash_cdr (const struct ddsi_ser
   }
 }
 
-static struct ddsi_serdata *ddsi_serdata_from_keyhash_cdr_nokey (const struct ddsi_sertopic *tpcmn, const nn_keyhash_t *keyhash)
+static struct ddsi_serdata *ddsi_serdata_from_keyhash_cdr_nokey (const struct ddsi_sertopic *tpcmn, const ddsi_keyhash_t *keyhash)
 {
   const struct ddsi_sertopic_default *tp = (const struct ddsi_sertopic_default *)tpcmn;
   struct ddsi_serdata_default *d = serdata_default_new(tp, SDK_KEY);
@@ -700,7 +700,7 @@ static size_t serdata_default_print_raw (const struct ddsi_sertopic *sertopic_co
   return (size_t) snprintf (buf, size, "(blob)");
 }
 
-static void serdata_default_get_keyhash (const struct ddsi_serdata *serdata_common, struct nn_keyhash *buf, bool force_md5)
+static void serdata_default_get_keyhash (const struct ddsi_serdata *serdata_common, struct ddsi_keyhash *buf, bool force_md5)
 {
   const struct ddsi_serdata_default *d = (const struct ddsi_serdata_default *)serdata_common;
   assert(buf);

--- a/src/core/ddsi/src/q_ddsi_discovery.c
+++ b/src/core/ddsi/src/q_ddsi_discovery.c
@@ -1874,7 +1874,7 @@ int builtins_dqueue_handler (const struct nn_rsample_info *sampleinfo, const str
           break;
       }
       keyhash_payload.p_endpoint_guid.parameterid = pid;
-      keyhash_payload.p_endpoint_guid.length = sizeof (nn_keyhash_t);
+      keyhash_payload.p_endpoint_guid.length = sizeof (ddsi_keyhash_t);
       memcpy (keyhash_payload.kh, &qos.keyhash, sizeof (qos.keyhash));
       keyhash_payload.p_sentinel.parameterid = PID_SENTINEL;
       keyhash_payload.p_sentinel.length = 0;

--- a/src/core/ddsi/src/q_xmsg.c
+++ b/src/core/ddsi/src/q_xmsg.c
@@ -952,7 +952,7 @@ void nn_xmsg_addpar_keyhash (struct nn_xmsg *m, const struct ddsi_serdata *serda
   if (serdata->kind != SDK_EMPTY)
   {
     char *p = nn_xmsg_addpar (m, PID_KEYHASH, 16);
-    ddsi_serdata_get_keyhash(serdata, (struct nn_keyhash*)p, force_md5);
+    ddsi_serdata_get_keyhash(serdata, (struct ddsi_keyhash*)p, force_md5);
   }
 }
 


### PR DESCRIPTION
… and ``DDSI_SERDATA_HAS_ADD_KEYHASH`` to ``DDSI_SERDATA_HAS_GET_KEYHASH``. The renaming of the macro is fixup for a reviewing oversight in #361, the renaming of type is because any custom topic implementations need to use this type and I am trying to avoid polluting the name space. It is also for this reason that the definition of ``struct ddsi_keyhash`` moves to a separate file.