### PR TITLE
Don't link winsock1

### DIFF
--- a/src/ddsrt/CMakeLists.txt
+++ b/src/ddsrt/CMakeLists.txt
@@ -236,7 +236,7 @@ if(NOT WITH_FREERTOS)
 endif()
 
 if(WIN32)
-  target_link_libraries(ddsrt INTERFACE wsock32 ws2_32 iphlpapi bcrypt)
+  target_link_libraries(ddsrt INTERFACE ws2_32 iphlpapi bcrypt)
 elseif(UNIX)
   check_library_exists(c clock_gettime "" HAVE_CLOCK_GETTIME)
   if(NOT HAVE_CLOCK_GETTIME)


### PR DESCRIPTION
wsock32.lib is only needed for the legacy version of Winsock and is not needed with Winsock2 (the current version).
This appears to be a root cause of the multicast issue on Win10 and may allow us to reverse #404

Signed-off-by: Dan Rose <dan@digilabs.io>