### PR TITLE
permissions checks

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/ddsi_security_omg.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_security_omg.h
@@ -768,15 +768,17 @@ bool q_omg_reader_is_submessage_protected(const struct reader *rd);
  * This function will check with the access control plugin if the remote reader
  * is allowed to communicate with this participant.
  *
- * @param[in] prd       The remote reader.
- * @param[in] domain_id The domain id.
- * @param[in] pp        The local participant.
+ * @param[in] prd         The remote reader.
+ * @param[in] domain_id   The domain id.
+ * @param[in] pp          The local participant.
+ * @param[out] relay_only The "relay_only" value returned by the access control
+ *                        operation check_remote_datareader()
  *
  * @returns bool
  * @retval true   The remote reader is allowed to communicate.
- * @retval false  Otherwise.
+ * @retval false  Otherwise; relay_only is unspecified.
  */
-bool q_omg_security_check_remote_reader_permissions(const struct proxy_reader *prd, uint32_t domain_id, struct participant *pp);
+bool q_omg_security_check_remote_reader_permissions(const struct proxy_reader *prd, uint32_t domain_id, struct participant *pp, bool *relay_only);
 
 /**
  * @brief Check it the local writer is allowed to communicate with the remote reader.
@@ -793,13 +795,15 @@ bool q_omg_security_check_remote_reader_permissions(const struct proxy_reader *p
  *
  * @param[in] wr              The local writer.
  * @param[in] prd             The remote reader.
+ * @param[in] relay_only      The "relay_only" returned by access control
+ *                            operation check_remote_datareader()
  * @param[out] crypto_handle  The crypto handle associated with the match.
  *
  * @returns bool
  * @retval true   The local writer and remote reader are allowed to communicate.
  * @retval false  Otherwise.
  */
-bool q_omg_security_match_remote_reader_enabled(struct writer *wr, struct proxy_reader *prd, int64_t *crypto_handle);
+bool q_omg_security_match_remote_reader_enabled(struct writer *wr, struct proxy_reader *prd, bool relay_only, int64_t *crypto_handle);
 
 /**
  * @brief Release the security information associated with the match between a writer and
@@ -1226,7 +1230,7 @@ inline bool q_omg_security_match_remote_writer_enabled(UNUSED_ARG(struct reader 
   return true;
 }
 
-inline bool q_omg_security_match_remote_reader_enabled(UNUSED_ARG(struct writer *wr), UNUSED_ARG(struct proxy_reader *prd), UNUSED_ARG(int64_t *crypto_handle))
+inline bool q_omg_security_match_remote_reader_enabled(UNUSED_ARG(struct writer *wr), UNUSED_ARG(struct proxy_reader *prd), UNUSED_ARG(bool relay_only), UNUSED_ARG(int64_t *crypto_handle))
 {
   return true;
 }
@@ -1274,7 +1278,7 @@ inline bool q_omg_reader_is_submessage_protected(UNUSED_ARG(const struct reader 
 }
 
 
-inline bool q_omg_security_check_remote_reader_permissions(UNUSED_ARG(const struct proxy_reader *prd), UNUSED_ARG(uint32_t domain_id), UNUSED_ARG(struct participant *pp))
+inline bool q_omg_security_check_remote_reader_permissions(UNUSED_ARG(const struct proxy_reader *prd), UNUSED_ARG(uint32_t domain_id), UNUSED_ARG(struct participant *pp), UNUSED_ARG(bool *relay_only))
 {
   return true;
 }

--- a/src/core/ddsi/src/ddsi_security_omg.c
+++ b/src/core/ddsi/src/ddsi_security_omg.c
@@ -1956,7 +1956,7 @@ bool q_omg_security_check_remote_writer_permissions(const struct proxy_writer *p
   {
     DDS_Security_PermissionsHandle permissions_handle;
 
-    if ((permissions_handle = get_permissions_handle(pp, pwr->c.proxypp)) != 0)
+    if ((permissions_handle = get_permissions_handle(pp, pwr->c.proxypp)) == 0)
     {
       GVTRACE("Secure remote writer "PGUIDFMT" proxypp does not have permissions handle yet\n", PGUID(pwr->e.guid));
       return false;
@@ -2180,7 +2180,7 @@ bool q_omg_security_check_remote_reader_permissions(const struct proxy_reader *p
   {
     DDS_Security_PermissionsHandle permissions_handle;
 
-    if ((permissions_handle = get_permissions_handle(pp, prd->c.proxypp)) != 0)
+    if ((permissions_handle = get_permissions_handle(pp, prd->c.proxypp)) == 0)
     {
       GVTRACE("Secure remote reader "PGUIDFMT" proxypp does not have permissions handle yet\n", PGUID(prd->e.guid));
       return false;

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -2767,6 +2767,7 @@ static void connect_writer_with_proxy_reader (struct writer *wr, struct proxy_re
   const int isb1 = (is_builtin_entityid (prd->e.guid.entityid, prd->c.vendor) != 0);
   dds_qos_policy_id_t reason;
   int64_t crypto_handle;
+  bool relay_only;
 
   DDSRT_UNUSED_ARG(tnow);
   if (isb0 != isb1)
@@ -2779,12 +2780,12 @@ static void connect_writer_with_proxy_reader (struct writer *wr, struct proxy_re
     return;
   }
 
-  if (!q_omg_security_check_remote_reader_permissions (prd, wr->e.gv->config.domainId, wr->c.pp))
+  if (!q_omg_security_check_remote_reader_permissions (prd, wr->e.gv->config.domainId, wr->c.pp, &relay_only))
   {
     EELOGDISC (&wr->e, "connect_writer_with_proxy_reader (wr "PGUIDFMT") with (prd "PGUIDFMT") not allowed by security\n",
                    PGUID (wr->e.guid), PGUID (prd->e.guid));
   }
-  else if (!q_omg_security_match_remote_reader_enabled (wr, prd, &crypto_handle))
+  else if (!q_omg_security_match_remote_reader_enabled (wr, prd, relay_only, &crypto_handle))
   {
     EELOGDISC (&wr->e, "connect_writer_with_proxy_reader (wr "PGUIDFMT") with (prd "PGUIDFMT") waiting for approval by security\n",
                      PGUID (wr->e.guid), PGUID (prd->e.guid));


### PR DESCRIPTION
This PR fixes two issues with the permissions checks:
* passing of the ``relay_only`` parameter to the access control ``check_remote_datareader`` operation;
* correct an inverted test for the availability of a permissions handle prior to invoking the access control plugin
It furthermore now forwards the ``relay_only`` setting to the crypto plugin.