### PR TITLE
Clean up representation of discovery messages

### DIFF
--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -451,7 +451,7 @@ The default value is: "dds_security_crypto".
 
 
 ### //CycloneDDS/Domain/Discovery
-Children: [DSGracePeriod](#cycloneddsdomaindiscoverydsgraceperiod), [DefaultMulticastAddress](#cycloneddsdomaindiscoverydefaultmulticastaddress), [EnableTopicDiscovery](#cycloneddsdomaindiscoveryenabletopicdiscovery), [ExternalDomainId](#cycloneddsdomaindiscoveryexternaldomainid), [MaxAutoParticipantIndex](#cycloneddsdomaindiscoverymaxautoparticipantindex), [ParticipantIndex](#cycloneddsdomaindiscoveryparticipantindex), [Peers](#cycloneddsdomaindiscoverypeers), [Ports](#cycloneddsdomaindiscoveryports), [SPDPInterval](#cycloneddsdomaindiscoveryspdpinterval), [SPDPMulticastAddress](#cycloneddsdomaindiscoveryspdpmulticastaddress), [Tag](#cycloneddsdomaindiscoverytag)
+Children: [DSGracePeriod](#cycloneddsdomaindiscoverydsgraceperiod), [DefaultMulticastAddress](#cycloneddsdomaindiscoverydefaultmulticastaddress), [ExternalDomainId](#cycloneddsdomaindiscoveryexternaldomainid), [MaxAutoParticipantIndex](#cycloneddsdomaindiscoverymaxautoparticipantindex), [ParticipantIndex](#cycloneddsdomaindiscoveryparticipantindex), [Peers](#cycloneddsdomaindiscoverypeers), [Ports](#cycloneddsdomaindiscoveryports), [SPDPInterval](#cycloneddsdomaindiscoveryspdpinterval), [SPDPMulticastAddress](#cycloneddsdomaindiscoveryspdpmulticastaddress), [Tag](#cycloneddsdomaindiscoverytag)
 
 
 The Discovery element allows specifying various parameters related to the
@@ -480,14 +480,6 @@ other than participant discovery packets. It defaults to
 Discovery/SPDPMulticastAddress.
 
 The default value is: "auto".
-
-
-#### //CycloneDDS/Domain/Discovery/EnableTopicDiscovery
-Boolean
-
-Do not use.
-
-The default value is: "true".
 
 
 #### //CycloneDDS/Domain/Discovery/ExternalDomainId

--- a/etc/cyclonedds.rnc
+++ b/etc/cyclonedds.rnc
@@ -407,11 +407,6 @@ Discovery/SPDPMulticastAddress.</p><p>The default value is:
           text
         }?
         & [ a:documentation [ xml:lang="en" """
-<p>Do not use.</p><p>The default value is: &quot;true&quot;.</p>""" ] ]
-        element EnableTopicDiscovery {
-          xsd:boolean
-        }?
-        & [ a:documentation [ xml:lang="en" """
 <p>An override for the domain id, to be used in discovery and for
 determining the port number mapping. This allows creating multiple
 domains in a single process while making them appear as a single domain

--- a/etc/cyclonedds.xsd
+++ b/etc/cyclonedds.xsd
@@ -522,7 +522,6 @@ the discovery of peers.&lt;/p&gt;</xs:documentation>
       <xs:all>
         <xs:element minOccurs="0" ref="config:DSGracePeriod"/>
         <xs:element minOccurs="0" ref="config:DefaultMulticastAddress"/>
-        <xs:element minOccurs="0" ref="config:EnableTopicDiscovery"/>
         <xs:element minOccurs="0" ref="config:ExternalDomainId"/>
         <xs:element minOccurs="0" ref="config:MaxAutoParticipantIndex"/>
         <xs:element minOccurs="0" ref="config:ParticipantIndex"/>
@@ -554,12 +553,6 @@ day.&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;30 s&amp;quot;.&lt;/p&gt;
 other than participant discovery packets. It defaults to
 Discovery/SPDPMulticastAddress.&lt;/p&gt;&lt;p&gt;The default value is:
 &amp;quot;auto&amp;quot;.&lt;/p&gt;</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="EnableTopicDiscovery" type="xs:boolean">
-    <xs:annotation>
-      <xs:documentation>
-&lt;p&gt;Do not use.&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;true&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="ExternalDomainId" type="xs:string">

--- a/src/core/ddsi/CMakeLists.txt
+++ b/src/core/ddsi/CMakeLists.txt
@@ -24,8 +24,12 @@ PREPEND(srcs_ddsi "${CMAKE_CURRENT_LIST_DIR}/src"
     ddsi_handshake.c
     ddsi_serdata.c
     ddsi_serdata_default.c
+    ddsi_serdata_pserop.c
+    ddsi_serdata_plist.c
     ddsi_sertopic.c
     ddsi_sertopic_default.c
+    ddsi_sertopic_pserop.c
+    ddsi_sertopic_plist.c
     ddsi_iid.c
     ddsi_tkmap.c
     ddsi_vendor.c
@@ -91,6 +95,8 @@ PREPEND(hdrs_private_ddsi "${CMAKE_CURRENT_LIST_DIR}/include/dds/ddsi"
     ddsi_serdata.h
     ddsi_sertopic.h
     ddsi_serdata_default.h
+    ddsi_serdata_pserop.h
+    ddsi_serdata_plist.h
     ddsi_iid.h
     ddsi_tkmap.h
     ddsi_vendor.h

--- a/src/core/ddsi/include/dds/ddsi/ddsi_domaingv.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_domaingv.h
@@ -294,8 +294,18 @@ struct ddsi_domaingv {
      transmit queue*/
   struct serdatapool *serpool;
   struct nn_xmsgpool *xmsgpool;
-  struct ddsi_sertopic *plist_topic; /* used for all discovery data */
-  struct ddsi_sertopic *rawcdr_topic; /* used for participant message data */
+  struct ddsi_sertopic *spdp_topic; /* key = participant GUID */
+  struct ddsi_sertopic *sedp_reader_topic; /* key = endpoint GUID */
+  struct ddsi_sertopic *sedp_writer_topic; /* key = endpoint GUID */
+  struct ddsi_sertopic *pmd_topic; /* participant message data */
+#ifdef DDSI_INCLUDE_SECURITY
+  struct ddsi_sertopic *spdp_secure_topic; /* key = participant GUID */
+  struct ddsi_sertopic *sedp_reader_secure_topic; /* key = endpoint GUID */
+  struct ddsi_sertopic *sedp_writer_secure_topic; /* key = endpoint GUID */
+  struct ddsi_sertopic *pmd_secure_topic; /* participant message data */
+  struct ddsi_sertopic *pgm_stateless_topic; /* participant generic message */
+  struct ddsi_sertopic *pgm_volatile_topic; /* participant generic message */
+#endif
 
   ddsrt_mutex_t sendq_lock;
   ddsrt_cond_t sendq_cond;

--- a/src/core/ddsi/include/dds/ddsi/ddsi_plist.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_plist.h
@@ -311,7 +311,7 @@ struct nn_rsample_info;
 struct nn_rdata;
 
 DDS_EXPORT unsigned char *ddsi_plist_quickscan (struct nn_rsample_info *dest, const struct nn_rmsg *rmsg, const ddsi_plist_src_t *src);
-DDS_EXPORT const unsigned char *ddsi_plist_findparam_native_unchecked (const void *src, nn_parameterid_t pid);
+DDS_EXPORT dds_return_t ddsi_plist_findparam_checking (const void *buf, size_t bufsz, uint16_t encoding, nn_parameterid_t needle, void **needlep, size_t *needlesz);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsi/include/dds/ddsi/ddsi_plist_generic.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_plist_generic.h
@@ -19,6 +19,7 @@
 #include "dds/export.h"
 
 #include "dds/ddsrt/attributes.h"
+#include "dds/ddsrt/retcode.h"
 
 #if defined (__cplusplus)
 extern "C" {
@@ -48,9 +49,11 @@ enum pserop {
 DDS_EXPORT void plist_fini_generic (void * __restrict dst, const enum pserop *desc, bool aliased);
 DDS_EXPORT dds_return_t plist_deser_generic (void * __restrict dst, const void * __restrict src, size_t srcsize, bool bswap, const enum pserop * __restrict desc);
 DDS_EXPORT dds_return_t plist_ser_generic (void **dst, size_t *dstsize, const void *src, const enum pserop * __restrict desc);
+DDS_EXPORT dds_return_t plist_ser_generic_be (void **dst, size_t *dstsize, const void *src, const enum pserop * __restrict desc);
 DDS_EXPORT dds_return_t plist_unalias_generic (void * __restrict dst, const enum pserop * __restrict desc);
 DDS_EXPORT bool plist_equal_generic (const void *srcx, const void *srcy, const enum pserop * __restrict desc);
 DDS_EXPORT size_t plist_memsize_generic (const enum pserop * __restrict desc);
+DDS_EXPORT size_t plist_print_generic (char * __restrict buf, size_t bufsize, const void * __restrict src, const enum pserop * __restrict desc);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsi/include/dds/ddsi/ddsi_pmd.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_pmd.h
@@ -12,7 +12,12 @@
 #ifndef DDSI_PMD_H
 #define DDSI_PMD_H
 
+#include <stdint.h>
 #include "dds/ddsrt/time.h"
+#include "dds/ddsi/ddsi_serdata.h"
+#include "dds/ddsi/ddsi_plist_generic.h"
+#include "dds/ddsi/ddsi_guid.h"
+#include "dds/ddsi/ddsi_xqos.h"
 
 #if defined (__cplusplus)
 extern "C" {
@@ -25,9 +30,20 @@ struct nn_xpack;
 struct participant;
 struct receiver_state;
 
+typedef struct ParticipantMessageData {
+  ddsi_guid_prefix_t participantGuidPrefix;
+  uint32_t kind; /* really 4 octets */
+  ddsi_octetseq_t value;
+} ParticipantMessageData_t;
+
+extern const enum pserop participant_message_data_ops[];
+extern size_t participant_message_data_nops;
+extern const enum pserop participant_message_data_ops_key[];
+extern size_t participant_message_data_nops_key;
+
 void write_pmd_message_guid (struct ddsi_domaingv * const gv, struct ddsi_guid *pp_guid, unsigned pmd_kind);
 void write_pmd_message (struct thread_state1 * const ts1, struct nn_xpack *xp, struct participant *pp, unsigned pmd_kind);
-void handle_pmd_message (const struct receiver_state *rst, ddsrt_wctime_t timestamp, uint32_t statusinfo, const void *vdata, uint32_t len);
+void handle_pmd_message (const struct receiver_state *rst, struct ddsi_serdata *sample_common);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsi/include/dds/ddsi/ddsi_security_exchange.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_security_exchange.h
@@ -29,8 +29,8 @@ extern "C" {
 #define GMCLASSID_SECURITY_DATAREADER_CRYPTO_TOKENS     "dds.sec.datareader_crypto_tokens"
 
 bool write_auth_handshake_message(const struct participant *pp, const struct proxy_participant *proxypp, nn_dataholderseq_t *mdata, bool request, const nn_message_identity_t *related_message_id);
-void handle_auth_handshake_message(const struct receiver_state *rst, ddsi_entityid_t wr_entity_id, ddsrt_wctime_t timestamp,  unsigned statusinfo, const void *vdata, size_t len);
-void handle_crypto_exchange_message(const struct receiver_state *rst, ddsi_entityid_t wr_entity_id, ddsrt_wctime_t timestamp, unsigned statusinfo, const void *vdata, unsigned len);
+void handle_auth_handshake_message(const struct receiver_state *rst, ddsi_entityid_t wr_entity_id, struct ddsi_serdata *sample);
+void handle_crypto_exchange_message(const struct receiver_state *rst, struct ddsi_serdata *sample);
 void auth_get_serialized_participant_data(struct participant *pp, ddsi_octetseq_t *seq);
 bool write_crypto_participant_tokens(const struct participant *pp, const struct proxy_participant *proxypp, const nn_dataholderseq_t *tokens);
 bool write_crypto_writer_tokens(const struct writer *wr, const struct proxy_reader *prd, const nn_dataholderseq_t *tokens);

--- a/src/core/ddsi/include/dds/ddsi/ddsi_security_msg.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_security_msg.h
@@ -95,6 +95,7 @@ nn_participant_generic_message_serialize(
    size_t *len);
 
 DDS_EXPORT extern const enum pserop pserop_participant_generic_message[];
+DDS_EXPORT extern const size_t pserop_participant_generic_message_nops;
 
 DDS_EXPORT int
 volatile_secure_data_filter(

--- a/src/core/ddsi/include/dds/ddsi/ddsi_serdata_default.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_serdata_default.h
@@ -18,6 +18,7 @@
 #include "dds/ddsrt/avl.h"
 #include "dds/ddsi/ddsi_serdata.h"
 #include "dds/ddsi/ddsi_sertopic.h"
+#include "dds/ddsi/ddsi_plist_generic.h"
 
 #include "dds/dds.h"
 
@@ -136,8 +137,6 @@ extern DDS_EXPORT const struct ddsi_sertopic_ops ddsi_sertopic_ops_default;
 
 extern DDS_EXPORT const struct ddsi_serdata_ops ddsi_serdata_ops_cdr;
 extern DDS_EXPORT const struct ddsi_serdata_ops ddsi_serdata_ops_cdr_nokey;
-extern DDS_EXPORT const struct ddsi_serdata_ops ddsi_serdata_ops_plist;
-extern DDS_EXPORT const struct ddsi_serdata_ops ddsi_serdata_ops_rawcdr;
 
 struct serdatapool * ddsi_serdatapool_new (void);
 void ddsi_serdatapool_free (struct serdatapool * pool);

--- a/src/core/ddsi/include/dds/ddsi/ddsi_serdata_plist.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_serdata_plist.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#ifndef DDSI_SERDATA_PLIST_H
+#define DDSI_SERDATA_PLIST_H
+
+#include "dds/ddsi/q_protocol.h" /* for nn_parameterid_t */
+#include "dds/ddsi/ddsi_keyhash.h"
+#include "dds/ddsi/ddsi_serdata.h"
+#include "dds/ddsi/ddsi_sertopic.h"
+
+#include "dds/dds.h"
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+/* There is an alignment requirement on the raw data (it must be at
+   offset mod 8 for the conversion to/from a dds_stream to work).
+   So we define two types: one without any additional padding, and
+   one where the appropriate amount of padding is inserted */
+#define DDSI_SERDATA_PLIST_PREPAD     \
+  struct ddsi_serdata c;              \
+  uint32_t pos;                       \
+  uint32_t size;                      \
+  nn_vendorid_t vendorid;             \
+  nn_protocol_version_t protoversion; \
+  ddsi_keyhash_t keyhash
+#define DDSI_SERDATA_PLIST_POSTPAD    \
+  uint16_t identifier;                \
+  uint16_t options;                   \
+  char data[]
+
+struct ddsi_serdata_plist_unpadded {
+  DDSI_SERDATA_PLIST_PREPAD;
+  DDSI_SERDATA_PLIST_POSTPAD;
+};
+
+#ifdef __GNUC__
+#define DDSI_SERDATA_PLIST_PAD(n) ((n) % 8)
+#else
+#define DDSI_SERDATA_PLIST_PAD(n) (n)
+#endif
+
+struct ddsi_serdata_plist {
+  DDSI_SERDATA_PLIST_PREPAD;
+  char pad[DDSI_SERDATA_PLIST_PAD (8 - (offsetof (struct ddsi_serdata_plist_unpadded, data) % 8))];
+  DDSI_SERDATA_PLIST_POSTPAD;
+};
+
+#undef DDSI_SERDATA_PLIST_PAD
+#undef DDSI_SERDATA_PLIST_POSTPAD
+#undef DDSI_SERDATA_PLIST_PREPAD
+
+struct ddsi_sertopic_plist {
+  struct ddsi_sertopic c;
+  uint16_t native_encoding_identifier; /* PL_CDR_(LE|BE) */
+  nn_parameterid_t keyparam;
+};
+
+extern DDS_EXPORT const struct ddsi_sertopic_ops ddsi_sertopic_ops_plist;
+extern DDS_EXPORT const struct ddsi_serdata_ops ddsi_serdata_ops_plist;
+
+#if defined (__cplusplus)
+}
+#endif
+
+#endif

--- a/src/core/ddsi/include/dds/ddsi/ddsi_serdata_pserop.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_serdata_pserop.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#ifndef DDSI_SERDATA_PSEROP_H
+#define DDSI_SERDATA_PSEROP_H
+
+#include "dds/ddsi/ddsi_serdata.h"
+#include "dds/ddsi/ddsi_sertopic.h"
+#include "dds/ddsi/ddsi_plist_generic.h"
+
+#include "dds/dds.h"
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+/* There is an alignment requirement on the raw data (it must be at
+   offset mod 8 for the conversion to/from a dds_stream to work).
+   So we define two types: one without any additional padding, and
+   one where the appropriate amount of padding is inserted */
+#define DDSI_SERDATA_PSEROP_PREPAD    \
+  struct ddsi_serdata c;              \
+  void *sample;                       \
+  bool keyless; /*cached from topic*/ \
+  uint32_t pos;                       \
+  uint32_t size
+#define DDSI_SERDATA_PSEROP_POSTPAD   \
+  uint16_t identifier;                \
+  uint16_t options;                   \
+  char data[]
+
+struct ddsi_serdata_pserop_unpadded {
+  DDSI_SERDATA_PSEROP_PREPAD;
+  DDSI_SERDATA_PSEROP_POSTPAD;
+};
+
+#ifdef __GNUC__
+#define DDSI_SERDATA_PSEROP_PAD(n) ((n) % 8)
+#else
+#define DDSI_SERDATA_PSEROP_PAD(n) (n)
+#endif
+
+struct ddsi_serdata_pserop {
+  DDSI_SERDATA_PSEROP_PREPAD;
+  char pad[DDSI_SERDATA_PSEROP_PAD (8 - (offsetof (struct ddsi_serdata_pserop_unpadded, data) % 8))];
+  DDSI_SERDATA_PSEROP_POSTPAD;
+};
+
+#undef DDSI_SERDATA_PSEROP_PAD
+#undef DDSI_SERDATA_PSEROP_POSTPAD
+#undef DDSI_SERDATA_PSEROP_PREPAD
+
+struct ddsi_sertopic_pserop {
+  struct ddsi_sertopic c;
+  uint16_t native_encoding_identifier; /* CDR_(LE|BE) */
+  size_t memsize;
+  size_t nops;
+  const enum pserop *ops;
+  size_t nops_key;
+  const enum pserop *ops_key; /* NULL <=> no key; != NULL <=> 16-byte key at offset 0 */
+};
+
+extern DDS_EXPORT const struct ddsi_sertopic_ops ddsi_sertopic_ops_pserop;
+extern DDS_EXPORT const struct ddsi_serdata_ops ddsi_serdata_ops_pserop;
+
+#if defined (__cplusplus)
+}
+#endif
+
+#endif

--- a/src/core/ddsi/include/dds/ddsi/q_config.h
+++ b/src/core/ddsi/include/dds/ddsi/q_config.h
@@ -261,8 +261,6 @@ struct config
 
   unsigned delivery_queue_maxsamples;
 
-  int do_topic_discovery;
-
   uint32_t max_msg_size;
   uint32_t fragment_size;
 

--- a/src/core/ddsi/include/dds/ddsi/q_ddsi_discovery.h
+++ b/src/core/ddsi/include/dds/ddsi/q_ddsi_discovery.h
@@ -25,7 +25,11 @@ struct nn_rsample_info;
 struct nn_rdata;
 struct ddsi_plist;
 
-void get_participant_builtin_topic_data(const struct participant *pp, struct nn_xmsg *mpayload, bool be);
+struct participant_builtin_topic_data_locators {
+  struct nn_locators_one def_uni_loc_one, def_multi_loc_one, meta_uni_loc_one, meta_multi_loc_one;
+};
+
+void get_participant_builtin_topic_data (const struct participant *pp, ddsi_plist_t *dst, struct participant_builtin_topic_data_locators *locs);
 
 int spdp_write (struct participant *pp);
 int spdp_dispose_unregister (struct participant *pp);
@@ -34,8 +38,6 @@ int sedp_write_writer (struct writer *wr);
 int sedp_write_reader (struct reader *rd);
 int sedp_dispose_unregister_writer (struct writer *wr);
 int sedp_dispose_unregister_reader (struct reader *rd);
-
-int sedp_write_topic (struct participant *pp, const struct ddsi_plist *datap);
 
 int builtins_dqueue_handler (const struct nn_rsample_info *sampleinfo, const struct nn_rdata *fragchain, const ddsi_guid_t *rdguid, void *qarg);
 

--- a/src/core/ddsi/include/dds/ddsi/q_entity.h
+++ b/src/core/ddsi/include/dds/ddsi/q_entity.h
@@ -291,7 +291,7 @@ struct writer
   struct addrset *ssm_as;
 #endif
   uint32_t alive_vclock; /* virtual clock counting transitions between alive/not-alive */
-  const struct ddsi_sertopic * topic; /* topic, but may be NULL for built-ins */
+  const struct ddsi_sertopic * topic; /* topic */
   struct addrset *as; /* set of addresses to publish to */
   struct addrset *as_group; /* alternate case, used for SPDP, when using Cloud with multiple bootstrap locators */
   struct xevent *heartbeat_xevent; /* timed event for "periodically" publishing heartbeats when unack'd data present, NULL <=> unreliable */
@@ -350,7 +350,7 @@ struct reader
 #ifdef DDSI_INCLUDE_NETWORK_PARTITIONS
   struct addrset *as;
 #endif
-  const struct ddsi_sertopic * topic; /* topic is NULL for built-in readers */
+  const struct ddsi_sertopic * topic; /* topic */
   uint32_t num_writers; /* total number of matching PROXY writers */
   ddsrt_avl_tree_t writers; /* all matching PROXY writers, see struct rd_pwr_match */
   ddsrt_avl_tree_t local_writers; /* all matching LOCAL writers, see struct rd_wr_match */

--- a/src/core/ddsi/include/dds/ddsi/q_protocol.h
+++ b/src/core/ddsi/include/dds/ddsi/q_protocol.h
@@ -203,7 +203,7 @@ typedef uint16_t nn_parameterid_t; /* spec says short */
 typedef struct nn_parameter {
   nn_parameterid_t parameterid;
   uint16_t length; /* spec says signed short */
-  /* char value[]; O! how I long for C99 */
+  /* char value[] */
 } nn_parameter_t;
 
 typedef struct Data_DataFrag_common {
@@ -318,18 +318,10 @@ typedef union Submessage {
   NackFrag_t nackfrag;
 } Submessage_t;
 
-DDSRT_WARNING_MSVC_OFF(4200)
-typedef struct ParticipantMessageData {
-  ddsi_guid_prefix_t participantGuidPrefix;
-  uint32_t kind; /* really 4 octets */
-  uint32_t length;
-  char value[];
-} ParticipantMessageData_t;
-DDSRT_WARNING_MSVC_ON(4200)
 #define PARTICIPANT_MESSAGE_DATA_KIND_UNKNOWN 0x0u
 #define PARTICIPANT_MESSAGE_DATA_KIND_AUTOMATIC_LIVELINESS_UPDATE 0x1u
 #define PARTICIPANT_MESSAGE_DATA_KIND_MANUAL_LIVELINESS_UPDATE 0x2u
-#define PARTICIPANT_MESSAGE_DATA_VENDER_SPECIFIC_KIND_FLAG 0x8000000u
+#define PARTICIPANT_MESSAGE_DATA_VENDOR_SPECIFIC_KIND_FLAG 0x8000000u
 
 #define PID_VENDORSPECIFIC_FLAG 0x8000u
 #define PID_UNRECOGNIZED_INCOMPATIBLE_FLAG 0x4000u

--- a/src/core/ddsi/src/ddsi_entity_index.c
+++ b/src/core/ddsi/src/ddsi_entity_index.c
@@ -70,20 +70,6 @@ static int entity_guid_eq_wrapper (const void *a, const void *b)
   return entity_guid_eq (a, b);
 }
 
-static int all_entities_compare_isbuiltin (const struct entity_common *e, nn_vendorid_t vendor)
-{
-  const unsigned char *guid_bytes = (const unsigned char *) &e->guid;
-  if (guid_bytes[0] != 0 && guid_bytes[0] != 0xff)
-    return is_builtin_endpoint (e->guid.entityid, vendor);
-  else
-  {
-    for (size_t i = 1; i < sizeof (e->guid); i++)
-      if (guid_bytes[i] != guid_bytes[0])
-        return is_builtin_endpoint (e->guid.entityid, vendor) && !is_local_orphan_endpoint (e);
-    return 0;
-  }
-}
-
 static int all_entities_compare (const void *va, const void *vb)
 {
   const struct entity_common *a = va;
@@ -104,28 +90,20 @@ static int all_entities_compare (const void *va, const void *vb)
     case EK_WRITER: {
       const struct writer *wra = va;
       const struct writer *wrb = vb;
-      if (!all_entities_compare_isbuiltin (a, NN_VENDORID_ECLIPSE)) {
-        assert ((wra->xqos->present & QP_TOPIC_NAME) && wra->xqos->topic_name);
-        tp_a = wra->xqos->topic_name;
-      }
-      if (!all_entities_compare_isbuiltin (b, NN_VENDORID_ECLIPSE)) {
-        assert ((wrb->xqos->present & QP_TOPIC_NAME) && wrb->xqos->topic_name);
-        tp_b = wrb->xqos->topic_name;
-      }
+      assert ((wra->xqos->present & QP_TOPIC_NAME) && wra->xqos->topic_name);
+      assert ((wrb->xqos->present & QP_TOPIC_NAME) && wrb->xqos->topic_name);
+      tp_a = wra->xqos->topic_name;
+      tp_b = wrb->xqos->topic_name;
       break;
     }
 
     case EK_READER: {
       const struct reader *rda = va;
       const struct reader *rdb = vb;
-      if (!all_entities_compare_isbuiltin (a, NN_VENDORID_ECLIPSE)) {
-        assert ((rda->xqos->present & QP_TOPIC_NAME) && rda->xqos->topic_name);
-        tp_a = rda->xqos->topic_name;
-      }
-      if (!all_entities_compare_isbuiltin (b, NN_VENDORID_ECLIPSE)) {
-        assert ((rdb->xqos->present & QP_TOPIC_NAME) && rdb->xqos->topic_name);
-        tp_b = rdb->xqos->topic_name;
-      }
+      assert ((rda->xqos->present & QP_TOPIC_NAME) && rda->xqos->topic_name);
+      assert ((rdb->xqos->present & QP_TOPIC_NAME) && rdb->xqos->topic_name);
+      tp_a = rda->xqos->topic_name;
+      tp_b = rdb->xqos->topic_name;
       break;
     }
 
@@ -133,14 +111,11 @@ static int all_entities_compare (const void *va, const void *vb)
     case EK_PROXY_READER: {
       const struct generic_proxy_endpoint *ga = va;
       const struct generic_proxy_endpoint *gb = vb;
-      if (!all_entities_compare_isbuiltin (a, ga->c.vendor)) {
-        assert ((ga->c.xqos->present & QP_TOPIC_NAME) && ga->c.xqos->topic_name);
+      /* built-in reader/writer proxies don't have topic name set */
+      if (ga->c.xqos->present & QP_TOPIC_NAME)
         tp_a = ga->c.xqos->topic_name;
-      }
-      if (!all_entities_compare_isbuiltin (b, gb->c.vendor)) {
-        assert ((gb->c.xqos->present & QP_TOPIC_NAME) && gb->c.xqos->topic_name);
+      if (gb->c.xqos->present & QP_TOPIC_NAME)
         tp_b = gb->c.xqos->topic_name;
-      }
       break;
     }
   }

--- a/src/core/ddsi/src/ddsi_security_msg.c
+++ b/src/core/ddsi/src/ddsi_security_msg.c
@@ -25,7 +25,6 @@
 #include "dds/ddsi/ddsi_plist.h"
 #include "dds/security/core/dds_security_utils.h"
 
-
 const enum pserop pserop_participant_generic_message[] =
 {
   /* nn_participant_generic_message */
@@ -47,7 +46,7 @@ const enum pserop pserop_participant_generic_message[] =
   XSTOP,
   XSTOP                /* end                                            */
 };
-
+const size_t pserop_participant_generic_message_nops = sizeof (pserop_participant_generic_message) / sizeof (pserop_participant_generic_message[0]);
 
 static void
 alias_simple_sequence(ddsi_octetseq_t *dst, const ddsi_octetseq_t *src, size_t elem_size)

--- a/src/core/ddsi/src/ddsi_serdata_default.c
+++ b/src/core/ddsi/src/ddsi_serdata_default.c
@@ -461,92 +461,6 @@ static struct ddsi_serdata *serdata_default_from_sample_cdr_nokey (const struct 
   return fix_serdata_default_nokey (d, tpcmn->serdata_basehash);
 }
 
-static struct ddsi_serdata *serdata_default_from_sample_plist (const struct ddsi_sertopic *tpcmn, enum ddsi_serdata_kind kind, const void *vsample)
-{
-  /* Currently restricted to DDSI discovery data (XTypes will need a rethink of the default representation and that may result in discovery data being moved to that new representation), and that means: keys are either GUIDs or an unbounded string for topics, for which MD5 is acceptable. Furthermore, these things don't get written very often, so scanning the parameter list to get the key value out is good enough for now. And at least it keeps the DDSI discovery data writing out of the internals of the sample representation */
-  const struct ddsi_sertopic_default *tp = (const struct ddsi_sertopic_default *)tpcmn;
-  const struct ddsi_plist_sample *sample = vsample;
-  struct ddsi_serdata_default *d = serdata_default_new(tp, kind);
-  if (d == NULL)
-    return NULL;
-  serdata_default_append_blob (&d, 1, sample->size, sample->blob);
-  const unsigned char *rawkey = ddsi_plist_findparam_native_unchecked (sample->blob, sample->keyparam);
-#ifndef NDEBUG
-  size_t keysize;
-#endif
-  assert(rawkey);
-  switch (sample->keyparam)
-  {
-    case PID_PARTICIPANT_GUID:
-    case PID_ENDPOINT_GUID:
-    case PID_GROUP_GUID:
-      d->keyhash.m_set = 1;
-      d->keyhash.m_iskey = 1;
-      d->keyhash.m_keysize = sizeof(d->keyhash.m_hash);
-      memcpy (d->keyhash.m_hash, rawkey, 16);
-#ifndef NDEBUG
-      keysize = 16;
-#endif
-      break;
-
-    case PID_TOPIC_NAME: {
-      const char *topic_name = (const char *) (rawkey + sizeof(uint32_t));
-      uint32_t topic_name_sz;
-      uint32_t topic_name_sz_BE;
-      ddsrt_md5_state_t md5st;
-      ddsrt_md5_byte_t digest[16];
-      topic_name_sz = (uint32_t) strlen (topic_name) + 1;
-      topic_name_sz_BE = ddsrt_toBE4u (topic_name_sz);
-      d->keyhash.m_set = 1;
-      d->keyhash.m_iskey = 0;
-      d->keyhash.m_keysize = sizeof(d->keyhash.m_hash);
-      ddsrt_md5_init (&md5st);
-      ddsrt_md5_append (&md5st, (const ddsrt_md5_byte_t *) &topic_name_sz_BE, sizeof (topic_name_sz_BE));
-      ddsrt_md5_append (&md5st, (const ddsrt_md5_byte_t *) topic_name, topic_name_sz);
-      ddsrt_md5_finish (&md5st, digest);
-      memcpy (d->keyhash.m_hash, digest, 16);
-#ifndef NDEBUG
-      keysize = sizeof (uint32_t) + topic_name_sz;
-#endif
-      break;
-    }
-
-    default:
-      abort();
-  }
-
-  /* if it is supposed to be just a key, rawkey must be be the first field and followed only by a sentinel */
-  assert (kind != SDK_KEY || rawkey == (const unsigned char *)sample->blob + sizeof (nn_parameter_t));
-  assert (kind != SDK_KEY || sample->size == sizeof (nn_parameter_t) + alignup_size (keysize, 4) + sizeof (nn_parameter_t));
-  return fix_serdata_default (d, tp->c.serdata_basehash);
-}
-
-static struct ddsi_serdata *serdata_default_from_sample_rawcdr (const struct ddsi_sertopic *tpcmn, enum ddsi_serdata_kind kind, const void *vsample)
-{
-  /* Currently restricted to DDSI discovery data (XTypes will need a rethink of the default representation and that may result in discovery data being moved to that new representation), and that means: keys are either GUIDs or an unbounded string for topics, for which MD5 is acceptable. Furthermore, these things don't get written very often, so scanning the parameter list to get the key value out is good enough for now. And at least it keeps the DDSI discovery data writing out of the internals of the sample representation */
-  const struct ddsi_sertopic_default *tp = (const struct ddsi_sertopic_default *)tpcmn;
-  const struct ddsi_rawcdr_sample *sample = vsample;
-  struct ddsi_serdata_default *d = serdata_default_new(tp, kind);
-  if (d == NULL)
-    return NULL;
-  assert (sample->keysize <= 16);
-  serdata_default_append_blob (&d, 1, sample->size, sample->blob);
-  serdata_default_append_aligned (&d, 0, 4);
-  d->keyhash.m_set = 1;
-  d->keyhash.m_iskey = 1;
-  if (sample->keysize == 0)
-  {
-    d->keyhash.m_keysize = 0;
-    return fix_serdata_default_nokey (d, tp->c.serdata_basehash);
-  }
-  else
-  {
-    memcpy (&d->keyhash.m_hash, sample->key, sample->keysize);
-    d->keyhash.m_keysize = (unsigned)sample->keysize & 0x1f;
-    return fix_serdata_default (d, tp->c.serdata_basehash);
-  }
-}
-
 static struct ddsi_serdata *serdata_default_to_topicless (const struct ddsi_serdata *serdata_common)
 {
   const struct ddsi_serdata_default *d = (const struct ddsi_serdata_default *)serdata_common;
@@ -669,37 +583,6 @@ static size_t serdata_default_print_cdr (const struct ddsi_sertopic *sertopic_co
     return dds_stream_print_sample (&is, tp, buf, size);
 }
 
-static size_t serdata_default_print_plist (const struct ddsi_sertopic *sertopic_common, const struct ddsi_serdata *serdata_common, char *buf, size_t size)
-{
-  const struct ddsi_serdata_default *d = (const struct ddsi_serdata_default *)serdata_common;
-  const struct ddsi_sertopic_default *tp = (const struct ddsi_sertopic_default *)sertopic_common;
-  ddsi_plist_src_t src;
-  ddsi_plist_t tmp;
-  src.buf = (const unsigned char *) d->data;
-  src.bufsz = d->pos;
-  src.encoding = d->hdr.identifier;
-  src.factory = tp->c.gv->m_factory;
-  src.logconfig = &tp->c.gv->logconfig;
-  src.protocol_version.major = RTPS_MAJOR;
-  src.protocol_version.minor = RTPS_MINOR;
-  src.strict = false;
-  src.vendorid = NN_VENDORID_ECLIPSE;
-  if (ddsi_plist_init_frommsg (&tmp, NULL, ~(uint64_t)0, ~(uint64_t)0, &src) < 0)
-    return (size_t) snprintf (buf, size, "(unparseable-plist)");
-  else
-  {
-    size_t ret = ddsi_plist_print (buf, size, &tmp);
-    ddsi_plist_fini (&tmp);
-    return ret;
-  }
-}
-
-static size_t serdata_default_print_raw (const struct ddsi_sertopic *sertopic_common, const struct ddsi_serdata *serdata_common, char *buf, size_t size)
-{
-  (void)sertopic_common; (void)serdata_common;
-  return (size_t) snprintf (buf, size, "(blob)");
-}
-
 static void serdata_default_get_keyhash (const struct ddsi_serdata *serdata_common, struct ddsi_keyhash *buf, bool force_md5)
 {
   const struct ddsi_serdata_default *d = (const struct ddsi_serdata_default *)serdata_common;
@@ -751,41 +634,5 @@ const struct ddsi_serdata_ops ddsi_serdata_ops_cdr_nokey = {
   .to_topicless = serdata_default_to_topicless,
   .topicless_to_sample = serdata_default_topicless_to_sample_cdr_nokey,
   .print = serdata_default_print_cdr,
-  .get_keyhash = serdata_default_get_keyhash
-};
-
-const struct ddsi_serdata_ops ddsi_serdata_ops_plist = {
-  .get_size = serdata_default_get_size,
-  .eqkey = serdata_default_eqkey,
-  .free = serdata_default_free,
-  .from_ser = serdata_default_from_ser,
-  .from_ser_iov = serdata_default_from_ser_iov,
-  .from_keyhash = 0,
-  .from_sample = serdata_default_from_sample_plist,
-  .to_ser = serdata_default_to_ser,
-  .to_sample = 0,
-  .to_ser_ref = serdata_default_to_ser_ref,
-  .to_ser_unref = serdata_default_to_ser_unref,
-  .to_topicless = serdata_default_to_topicless,
-  .topicless_to_sample = 0,
-  .print = serdata_default_print_plist,
-  .get_keyhash = serdata_default_get_keyhash
-};
-
-const struct ddsi_serdata_ops ddsi_serdata_ops_rawcdr = {
-  .get_size = serdata_default_get_size,
-  .eqkey = serdata_default_eqkey,
-  .free = serdata_default_free,
-  .from_ser = serdata_default_from_ser,
-  .from_ser_iov = serdata_default_from_ser_iov,
-  .from_keyhash = 0,
-  .from_sample = serdata_default_from_sample_rawcdr,
-  .to_ser = serdata_default_to_ser,
-  .to_sample = 0,
-  .to_ser_ref = serdata_default_to_ser_ref,
-  .to_ser_unref = serdata_default_to_ser_unref,
-  .to_topicless = serdata_default_to_topicless,
-  .topicless_to_sample = 0,
-  .print = serdata_default_print_raw,
   .get_keyhash = serdata_default_get_keyhash
 };

--- a/src/core/ddsi/src/ddsi_serdata_plist.c
+++ b/src/core/ddsi/src/ddsi_serdata_plist.c
@@ -1,0 +1,303 @@
+/*
+ * Copyright(c) 2020 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include <stdlib.h>
+#include <ctype.h>
+#include <assert.h>
+#include <string.h>
+
+#include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/log.h"
+#include "dds/ddsrt/md5.h"
+#include "dds/ddsrt/mh3.h"
+#include "dds/ddsi/q_bswap.h"
+#include "dds/ddsi/q_config.h"
+#include "dds/ddsi/q_freelist.h"
+#include "dds/ddsi/ddsi_tkmap.h"
+#include "dds/ddsi/ddsi_cdrstream.h"
+#include "dds/ddsi/q_radmin.h"
+#include "dds/ddsi/ddsi_domaingv.h"
+#include "dds/ddsi/ddsi_serdata_plist.h"
+#include "dds/ddsi/q_xmsg.h"
+
+static uint32_t serdata_plist_get_size (const struct ddsi_serdata *dcmn)
+{
+  const struct ddsi_serdata_plist *d = (const struct ddsi_serdata_plist *) dcmn;
+  return 4 + d->pos; // FIXME: +4 for CDR header should be eliminated
+}
+
+static bool serdata_plist_eqkey (const struct ddsi_serdata *acmn, const struct ddsi_serdata *bcmn)
+{
+  const struct ddsi_serdata_plist *a = (const struct ddsi_serdata_plist *) acmn;
+  const struct ddsi_serdata_plist *b = (const struct ddsi_serdata_plist *) bcmn;
+  return memcmp (&a->keyhash, &b->keyhash, sizeof (a->keyhash)) == 0;
+}
+
+static void serdata_plist_free (struct ddsi_serdata *dcmn)
+{
+  struct ddsi_serdata_plist *d = (struct ddsi_serdata_plist *) dcmn;
+  ddsrt_free (d);
+}
+
+static struct ddsi_serdata_plist *serdata_plist_new (const struct ddsi_sertopic_plist *tp, enum ddsi_serdata_kind kind, size_t size, const void *cdr_header)
+{
+  /* FIXME: check whether this really is the correct maximum: offsets are relative
+     to the CDR header, but there are also some places that use a serdata as-if it
+     were a stream, and those use offsets (m_index) relative to the start of the
+     serdata */
+  if (size < 4 || size > UINT32_MAX - offsetof (struct ddsi_serdata_plist, identifier))
+    return NULL;
+  struct ddsi_serdata_plist *d = ddsrt_malloc (sizeof (*d) + size);
+  if (d == NULL)
+    return NULL;
+  ddsi_serdata_init (&d->c, &tp->c, kind);
+  d->pos = 0;
+  d->size = (uint32_t) size;
+  // FIXME: vendorid/protoversion are not available when creating a serdata
+  // these should be overruled by the one creating the serdata
+  d->vendorid = NN_VENDORID_UNKNOWN;
+  d->protoversion.major = RTPS_MAJOR;
+  d->protoversion.minor = RTPS_MINOR;
+  const uint16_t *hdrsrc = cdr_header;
+  d->identifier = hdrsrc[0];
+  d->options = hdrsrc[1];
+  if (d->identifier != PL_CDR_LE && d->identifier != PL_CDR_BE)
+  {
+    ddsrt_free (d);
+    return NULL;
+  }
+  return d;
+}
+
+static struct ddsi_serdata *serdata_plist_fix (const struct ddsi_sertopic_plist *tp, struct ddsi_serdata_plist *d)
+{
+  assert (tp->keyparam != PID_SENTINEL);
+  void *needlep;
+  size_t needlesz;
+  if (ddsi_plist_findparam_checking (d->data, d->pos, d->identifier, tp->keyparam, &needlep, &needlesz) != DDS_RETCODE_OK)
+  {
+    ddsrt_free (d);
+    return NULL;
+  }
+  assert (needlep);
+  if (needlesz != sizeof (d->keyhash))
+  {
+    ddsrt_free (d);
+    return NULL;
+  }
+  memcpy (&d->keyhash, needlep, 16);
+  d->c.hash = ddsrt_mh3 (&d->keyhash, sizeof (d->keyhash), 0) ^ tp->c.serdata_basehash;
+  return &d->c;
+}
+
+static struct ddsi_serdata *serdata_plist_from_ser (const struct ddsi_sertopic *tpcmn, enum ddsi_serdata_kind kind, const struct nn_rdata *fragchain, size_t size)
+{
+  const struct ddsi_sertopic_plist *tp = (const struct ddsi_sertopic_plist *) tpcmn;
+  struct ddsi_serdata_plist *d = serdata_plist_new (tp, kind, size, NN_RMSG_PAYLOADOFF (fragchain->rmsg, NN_RDATA_PAYLOAD_OFF (fragchain)));
+  uint32_t off = 4; /* must skip the CDR header */
+  assert (fragchain->min == 0);
+  assert (fragchain->maxp1 >= off); /* CDR header must be in first fragment */
+  while (fragchain)
+  {
+    assert (fragchain->min <= off);
+    assert (fragchain->maxp1 <= size);
+    if (fragchain->maxp1 > off)
+    {
+      /* only copy if this fragment adds data */
+      const unsigned char *payload = NN_RMSG_PAYLOADOFF (fragchain->rmsg, NN_RDATA_PAYLOAD_OFF (fragchain));
+      uint32_t n = fragchain->maxp1 - off;
+      memcpy (d->data + d->pos, payload + off - fragchain->min, n);
+      d->pos += n;
+      off = fragchain->maxp1;
+    }
+    fragchain = fragchain->nextfrag;
+  }
+  return serdata_plist_fix (tp, d);
+}
+
+static struct ddsi_serdata *serdata_plist_from_ser_iov (const struct ddsi_sertopic *tpcmn, enum ddsi_serdata_kind kind, ddsrt_msg_iovlen_t niov, const ddsrt_iovec_t *iov, size_t size)
+{
+  const struct ddsi_sertopic_plist *tp = (const struct ddsi_sertopic_plist *) tpcmn;
+  assert (niov >= 1);
+  struct ddsi_serdata_plist *d = serdata_plist_new (tp, kind, size, iov[0].iov_base);
+  memcpy (d->data + d->pos, (const char *) iov[0].iov_base + 4, iov[0].iov_len - 4);
+  d->pos += (uint32_t) iov[0].iov_len - 4;
+  for (ddsrt_msg_iovlen_t i = 1; i < niov; i++)
+  {
+    memcpy (d->data + d->pos, (const char *) iov[i].iov_base, iov[i].iov_len);
+    d->pos += (uint32_t) iov[i].iov_len;
+  }
+  return serdata_plist_fix (tp, d);
+}
+
+static struct ddsi_serdata *serdata_plist_from_keyhash (const struct ddsi_sertopic *tpcmn, const ddsi_keyhash_t *keyhash)
+{
+  const struct ddsi_sertopic_plist *tp = (const struct ddsi_sertopic_plist *) tpcmn;
+  const struct { uint16_t identifier, options; nn_parameter_t par; ddsi_keyhash_t kh; } in = {
+    .identifier = CDR_BE,
+    .options = 0,
+    .par = {
+      .parameterid = ddsrt_toBE2u (tp->keyparam),
+      .length = sizeof (*keyhash)
+    },
+    *keyhash
+  };
+  const ddsrt_iovec_t iov = { .iov_base = (void *) &in, .iov_len = sizeof (in) };
+  return serdata_plist_from_ser_iov (tpcmn, SDK_KEY, 1, &iov, sizeof (in) - 4);
+}
+
+static bool serdata_plist_topicless_to_sample (const struct ddsi_sertopic *topic_common, const struct ddsi_serdata *serdata_common, void *sample, void **bufptr, void *buflim)
+{
+  const struct ddsi_serdata_plist *d = (const struct ddsi_serdata_plist *)serdata_common;
+  const struct ddsi_sertopic_plist *tp = (const struct ddsi_sertopic_plist *) topic_common;
+  struct ddsi_domaingv * const gv = tp->c.gv;
+  if (bufptr) abort(); else { (void)buflim; } /* FIXME: haven't implemented that bit yet! */
+  ddsi_plist_src_t src = {
+    .buf = (const unsigned char *) d->data,
+    .bufsz = d->pos,
+    .encoding = d->identifier,
+    .factory = gv->m_factory,
+    .logconfig = &gv->logconfig,
+    .protocol_version = d->protoversion,
+    .strict = NN_STRICT_P (gv->config),
+    .vendorid = d->vendorid
+  };
+  const dds_return_t rc = ddsi_plist_init_frommsg (sample, NULL, ~(uint64_t)0, ~(uint64_t)0, &src);
+  // FIXME: need a more informative return type
+  if (rc != DDS_RETCODE_OK && rc != DDS_RETCODE_UNSUPPORTED)
+    GVWARNING ("SPDP (vendor %u.%u): invalid qos/parameters\n", src.vendorid.id[0], src.vendorid.id[1]);
+  return (rc == DDS_RETCODE_OK);
+}
+
+static bool serdata_plist_to_sample (const struct ddsi_serdata *serdata_common, void *sample, void **bufptr, void *buflim)
+{
+  /* the "plist" topics only differ in the parameter that is used as the key value */
+  return serdata_plist_topicless_to_sample (serdata_common->topic, serdata_common, sample, bufptr, buflim);
+}
+
+static void serdata_plist_to_ser (const struct ddsi_serdata *serdata_common, size_t off, size_t sz, void *buf)
+{
+  const struct ddsi_serdata_plist *d = (const struct ddsi_serdata_plist *)serdata_common;
+  memcpy (buf, (char *) &d->identifier + off, sz);
+}
+
+static struct ddsi_serdata *serdata_plist_to_ser_ref (const struct ddsi_serdata *serdata_common, size_t off, size_t sz, ddsrt_iovec_t *ref)
+{
+  const struct ddsi_serdata_plist *d = (const struct ddsi_serdata_plist *)serdata_common;
+  ref->iov_base = (char *) &d->identifier + off;
+  ref->iov_len = (ddsrt_iov_len_t) sz;
+  return ddsi_serdata_ref (serdata_common);
+}
+
+static void serdata_plist_to_ser_unref (struct ddsi_serdata *serdata_common, const ddsrt_iovec_t *ref)
+{
+  (void) ref;
+  ddsi_serdata_unref (serdata_common);
+}
+
+static struct ddsi_serdata *serdata_plist_from_sample (const struct ddsi_sertopic *tpcmn, enum ddsi_serdata_kind kind, const void *sample)
+{
+  const struct ddsi_sertopic_plist *tp = (const struct ddsi_sertopic_plist *)tpcmn;
+  const struct { uint16_t identifier, options; } header = { tp->native_encoding_identifier, 0 };
+  const ddsi_guid_t nullguid = { .prefix = { .u = { 0,0,0 } }, .entityid = { .u = 0 } };
+
+  // FIXME: key must not require byteswapping (GUIDs are ok)
+  // FIXME: rework plist stuff so it doesn't need an nn_xmsg
+  struct nn_xmsg *mpayload = nn_xmsg_new (tp->c.gv->xmsgpool, &nullguid, NULL, 0, NN_XMSG_KIND_DATA);
+  memcpy (nn_xmsg_append (mpayload, NULL, 4), &header, 4);
+  ddsi_plist_addtomsg (mpayload, sample, ~(uint64_t)0, ~(uint64_t)0);
+  nn_xmsg_addpar_sentinel (mpayload);
+
+  size_t sz;
+  unsigned char *blob = nn_xmsg_payload (&sz, mpayload);
+#ifndef NDEBUG
+  void *needle;
+  size_t needlesz;
+  assert (ddsi_plist_findparam_checking (blob + 4, sz, header.identifier, tp->keyparam, &needle, &needlesz) == DDS_RETCODE_OK);
+  assert (needle && needlesz == 16);
+#endif
+  ddsrt_iovec_t iov = { .iov_base = blob, .iov_len = (ddsrt_iov_len_t) sz };
+  struct ddsi_serdata *d = serdata_plist_from_ser_iov (tpcmn, kind, 1, &iov, sz - 4);
+  nn_xmsg_free (mpayload);
+
+  /* we know the vendor when we construct a serdata from a sample */
+  struct ddsi_serdata_plist *d_plist = (struct ddsi_serdata_plist *) d;
+  d_plist->vendorid = NN_VENDORID_ECLIPSE;
+  return d;
+}
+
+static struct ddsi_serdata *serdata_plist_to_topicless (const struct ddsi_serdata *serdata_common)
+{
+  const struct ddsi_serdata_plist *d = (const struct ddsi_serdata_plist *) serdata_common;
+  const struct ddsi_sertopic_plist *tp = (const struct ddsi_sertopic_plist *) d->c.topic;
+  ddsrt_iovec_t iov = { .iov_base = (char *) &d->identifier, .iov_len = 4 + d->pos };
+  struct ddsi_serdata *dcmn_tl = serdata_plist_from_ser_iov (&tp->c, SDK_KEY, 1, &iov, d->pos);
+  assert (dcmn_tl != NULL);
+  dcmn_tl->topic = NULL;
+  return dcmn_tl;
+}
+
+static void serdata_plist_get_keyhash (const struct ddsi_serdata *serdata_common, struct ddsi_keyhash *buf, bool force_md5)
+{
+  const struct ddsi_serdata_plist *d = (const struct ddsi_serdata_plist *)serdata_common;
+  if (!force_md5)
+    memcpy (buf, &d->keyhash, 16);
+  else
+  {
+    ddsrt_md5_state_t md5st;
+    ddsrt_md5_init (&md5st);
+    ddsrt_md5_append (&md5st, (ddsrt_md5_byte_t *) &d->keyhash, 16);
+    ddsrt_md5_finish (&md5st, (ddsrt_md5_byte_t *) buf->value);
+  }
+}
+
+static size_t serdata_plist_print_plist (const struct ddsi_sertopic *sertopic_common, const struct ddsi_serdata *serdata_common, char *buf, size_t size)
+{
+  const struct ddsi_serdata_plist *d = (const struct ddsi_serdata_plist *) serdata_common;
+  const struct ddsi_sertopic_plist *tp = (const struct ddsi_sertopic_plist *) sertopic_common;
+  ddsi_plist_src_t src = {
+    .buf = (const unsigned char *) d->data,
+    .bufsz = d->pos,
+    .encoding = d->identifier,
+    .factory = tp->c.gv->m_factory,
+    .logconfig = &tp->c.gv->logconfig,
+    .protocol_version = d->protoversion,
+    .strict = false,
+    .vendorid = d->vendorid
+  };
+  ddsi_plist_t tmp;
+  if (ddsi_plist_init_frommsg (&tmp, NULL, ~(uint64_t)0, ~(uint64_t)0, &src) < 0)
+    return (size_t) snprintf (buf, size, "(unparseable-plist)");
+  else
+  {
+    size_t ret = ddsi_plist_print (buf, size, &tmp);
+    ddsi_plist_fini (&tmp);
+    return ret;
+  }
+}
+
+const struct ddsi_serdata_ops ddsi_serdata_ops_plist = {
+  .get_size = serdata_plist_get_size,
+  .eqkey = serdata_plist_eqkey,
+  .free = serdata_plist_free,
+  .from_ser = serdata_plist_from_ser,
+  .from_ser_iov = serdata_plist_from_ser_iov,
+  .from_keyhash = serdata_plist_from_keyhash,
+  .from_sample = serdata_plist_from_sample,
+  .to_ser = serdata_plist_to_ser,
+  .to_sample = serdata_plist_to_sample,
+  .to_ser_ref = serdata_plist_to_ser_ref,
+  .to_ser_unref = serdata_plist_to_ser_unref,
+  .to_topicless = serdata_plist_to_topicless,
+  .topicless_to_sample = serdata_plist_topicless_to_sample,
+  .print = serdata_plist_print_plist,
+  .get_keyhash = serdata_plist_get_keyhash
+};

--- a/src/core/ddsi/src/ddsi_serdata_pserop.c
+++ b/src/core/ddsi/src/ddsi_serdata_pserop.c
@@ -1,0 +1,297 @@
+/*
+ * Copyright(c) 2020 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include <stdlib.h>
+#include <ctype.h>
+#include <assert.h>
+#include <string.h>
+
+#include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/log.h"
+#include "dds/ddsrt/md5.h"
+#include "dds/ddsrt/mh3.h"
+#include "dds/ddsi/q_bswap.h"
+#include "dds/ddsi/q_config.h"
+#include "dds/ddsi/q_freelist.h"
+#include "dds/ddsi/ddsi_tkmap.h"
+#include "dds/ddsi/ddsi_cdrstream.h"
+#include "dds/ddsi/q_radmin.h"
+#include "dds/ddsi/ddsi_domaingv.h"
+#include "dds/ddsi/ddsi_serdata_pserop.h"
+
+static uint32_t serdata_pserop_get_size (const struct ddsi_serdata *dcmn)
+{
+  const struct ddsi_serdata_pserop *d = (const struct ddsi_serdata_pserop *) dcmn;
+  return 4 + d->pos; // FIXME: +4 for CDR header should be eliminated
+}
+
+static bool serdata_pserop_eqkey (const struct ddsi_serdata *acmn, const struct ddsi_serdata *bcmn)
+{
+  const struct ddsi_serdata_pserop *a = (const struct ddsi_serdata_pserop *) acmn;
+  const struct ddsi_serdata_pserop *b = (const struct ddsi_serdata_pserop *) bcmn;
+  if (a->keyless != b->keyless)
+    return false;
+  else if (a->keyless)
+    return true;
+  else
+    return memcmp (a->sample, b->sample, 16) == 0;
+}
+
+static void serdata_pserop_free (struct ddsi_serdata *dcmn)
+{
+  struct ddsi_serdata_pserop *d = (struct ddsi_serdata_pserop *) dcmn;
+  const struct ddsi_sertopic_pserop *tp = (const struct ddsi_sertopic_pserop *) d->c.topic;
+  if (d->c.kind == SDK_DATA)
+    plist_fini_generic (d->sample, tp->ops, true);
+  if (d->sample)
+    ddsrt_free (d->sample);
+  ddsrt_free (d);
+}
+
+static struct ddsi_serdata_pserop *serdata_pserop_new (const struct ddsi_sertopic_pserop *tp, enum ddsi_serdata_kind kind, size_t size, const void *cdr_header)
+{
+  /* FIXME: check whether this really is the correct maximum: offsets are relative
+     to the CDR header, but there are also some places that use a serdata as-if it
+     were a stream, and those use offsets (m_index) relative to the start of the
+     serdata */
+  assert (kind != SDK_EMPTY);
+  if (size < 4 || size > UINT32_MAX - offsetof (struct ddsi_serdata_pserop, identifier))
+    return NULL;
+  struct ddsi_serdata_pserop *d = ddsrt_malloc (sizeof (*d) + size);
+  if (d == NULL)
+    return NULL;
+  ddsi_serdata_init (&d->c, &tp->c, kind);
+  d->keyless = (tp->ops_key == NULL);
+  d->pos = 0;
+  d->size = (uint32_t) size;
+  const uint16_t *hdrsrc = cdr_header;
+  d->identifier = hdrsrc[0];
+  d->options = hdrsrc[1];
+  assert (d->identifier == CDR_LE || d->identifier == CDR_BE);
+  if (kind == SDK_KEY && d->keyless)
+    d->sample = NULL;
+  else if ((d->sample = ddsrt_malloc ((kind == SDK_DATA) ? tp->memsize : 16)) == NULL)
+  {
+    ddsrt_free (d);
+    return NULL;
+  }
+  return d;
+}
+
+static struct ddsi_serdata *serdata_pserop_fix (const struct ddsi_sertopic_pserop *tp, struct ddsi_serdata_pserop *d)
+{
+  const bool needs_bswap = (d->identifier != tp->native_encoding_identifier);
+  const enum pserop *ops = (d->c.kind == SDK_DATA) ? tp->ops : tp->ops_key;
+  d->c.hash = tp->c.serdata_basehash;
+  if (ops != NULL)
+  {
+    assert (d->pos >= 16 && tp->memsize >= 16);
+    if (plist_deser_generic (d->sample, d->data, d->pos, needs_bswap, (d->c.kind == SDK_DATA) ? tp->ops : tp->ops_key) < 0)
+    {
+      ddsrt_free (d->sample);
+      ddsrt_free (d);
+      return NULL;
+    }
+    if (tp->ops_key)
+    {
+      assert (d->pos >= 16 && tp->memsize >= 16);
+      d->c.hash ^= ddsrt_mh3 (d->sample, 16, 0);
+    }
+  }
+  return &d->c;
+}
+
+static struct ddsi_serdata *serdata_pserop_from_ser (const struct ddsi_sertopic *tpcmn, enum ddsi_serdata_kind kind, const struct nn_rdata *fragchain, size_t size)
+{
+  const struct ddsi_sertopic_pserop *tp = (const struct ddsi_sertopic_pserop *)tpcmn;
+  struct ddsi_serdata_pserop *d = serdata_pserop_new (tp, kind, size, NN_RMSG_PAYLOADOFF (fragchain->rmsg, NN_RDATA_PAYLOAD_OFF (fragchain)));
+  uint32_t off = 4; /* must skip the CDR header */
+  assert (fragchain->min == 0);
+  assert (fragchain->maxp1 >= off); /* CDR header must be in first fragment */
+  while (fragchain)
+  {
+    assert (fragchain->min <= off);
+    assert (fragchain->maxp1 <= size);
+    if (fragchain->maxp1 > off)
+    {
+      /* only copy if this fragment adds data */
+      const unsigned char *payload = NN_RMSG_PAYLOADOFF (fragchain->rmsg, NN_RDATA_PAYLOAD_OFF (fragchain));
+      uint32_t n = fragchain->maxp1 - off;
+      memcpy (d->data + d->pos, payload + off - fragchain->min, n);
+      d->pos += n;
+      off = fragchain->maxp1;
+    }
+    fragchain = fragchain->nextfrag;
+  }
+  return serdata_pserop_fix (tp, d);
+}
+
+static struct ddsi_serdata *serdata_pserop_from_ser_iov (const struct ddsi_sertopic *tpcmn, enum ddsi_serdata_kind kind, ddsrt_msg_iovlen_t niov, const ddsrt_iovec_t *iov, size_t size)
+{
+  const struct ddsi_sertopic_pserop *tp = (const struct ddsi_sertopic_pserop *)tpcmn;
+  assert (niov >= 1);
+  struct ddsi_serdata_pserop *d = serdata_pserop_new (tp, kind, size, iov[0].iov_base);
+  const uint16_t *hdrsrc = (uint16_t *) iov[0].iov_base;
+  d->identifier = hdrsrc[0];
+  d->options = hdrsrc[1];
+  assert (d->identifier == CDR_LE || d->identifier == CDR_BE);
+  memcpy (d->data + d->pos, (const char *) iov[0].iov_base + 4, iov[0].iov_len - 4);
+  d->pos += (uint32_t) iov[0].iov_len - 4;
+  for (ddsrt_msg_iovlen_t i = 1; i < niov; i++)
+  {
+    memcpy (d->data + d->pos, (const char *) iov[i].iov_base, iov[i].iov_len);
+    d->pos += (uint32_t) iov[i].iov_len;
+  }
+  return serdata_pserop_fix (tp, d);
+}
+
+static struct ddsi_serdata *serdata_pserop_from_keyhash (const struct ddsi_sertopic *tpcmn, const ddsi_keyhash_t *keyhash)
+{
+  const struct { uint16_t identifier, options; ddsi_keyhash_t kh; } in = { CDR_BE, 0, *keyhash };
+  const ddsrt_iovec_t iov = { .iov_base = (void *) &in, .iov_len = sizeof (in) };
+  return serdata_pserop_from_ser_iov (tpcmn, SDK_KEY, 1, &iov, sizeof (in) - 4);
+}
+
+static bool serdata_pserop_to_sample (const struct ddsi_serdata *serdata_common, void *sample, void **bufptr, void *buflim)
+{
+  const struct ddsi_serdata_pserop *d = (const struct ddsi_serdata_pserop *)serdata_common;
+  const struct ddsi_sertopic_pserop *tp = (const struct ddsi_sertopic_pserop *) d->c.topic;
+  if (bufptr) abort(); else { (void)buflim; } /* FIXME: haven't implemented that bit yet! */
+  if (d->c.kind == SDK_KEY)
+    memcpy (sample, d->sample, 16);
+  else
+  {
+    dds_return_t x;
+    x = plist_deser_generic (sample, d->data, d->pos, d->identifier != tp->native_encoding_identifier, tp->ops);
+    plist_unalias_generic (sample, tp->ops);
+    assert (x >= 0);
+    (void) x;
+  }
+  return true; /* FIXME: can't conversion to sample fail? */
+}
+
+static void serdata_pserop_to_ser (const struct ddsi_serdata *serdata_common, size_t off, size_t sz, void *buf)
+{
+  const struct ddsi_serdata_pserop *d = (const struct ddsi_serdata_pserop *)serdata_common;
+  memcpy (buf, (char *) &d->identifier + off, sz);
+}
+
+static struct ddsi_serdata *serdata_pserop_to_ser_ref (const struct ddsi_serdata *serdata_common, size_t off, size_t sz, ddsrt_iovec_t *ref)
+{
+  const struct ddsi_serdata_pserop *d = (const struct ddsi_serdata_pserop *)serdata_common;
+  ref->iov_base = (char *) &d->identifier + off;
+  ref->iov_len = (ddsrt_iov_len_t) sz;
+  return ddsi_serdata_ref (serdata_common);
+}
+
+static void serdata_pserop_to_ser_unref (struct ddsi_serdata *serdata_common, const ddsrt_iovec_t *ref)
+{
+  (void) ref;
+  ddsi_serdata_unref (serdata_common);
+}
+
+static struct ddsi_serdata *serdata_pserop_from_sample (const struct ddsi_sertopic *tpcmn, enum ddsi_serdata_kind kind, const void *sample)
+{
+  const struct ddsi_sertopic_pserop *tp = (const struct ddsi_sertopic_pserop *)tpcmn;
+  const struct { uint16_t identifier, options; } header = { tp->native_encoding_identifier, 0 };
+  if (kind == SDK_KEY && tp->ops_key == NULL)
+    return serdata_pserop_fix (tp, serdata_pserop_new (tp, kind, 0, &header));
+  else
+  {
+    void *data;
+    size_t size;
+    if (plist_ser_generic (&data, &size, sample, (kind == SDK_DATA) ? tp->ops : tp->ops_key) < 0)
+      return NULL;
+    const size_t size4 = (size + 3) & ~(size_t)3;
+    struct ddsi_serdata_pserop *d = serdata_pserop_new (tp, kind, size4, &header);
+    assert (tp->ops_key == NULL || (size >= 16 && tp->memsize >= 16));
+    memcpy (d->data, data, size);
+    memset (d->data + size, 0, size4 - size);
+    d->pos = (uint32_t) size;
+    ddsrt_free (data); // FIXME: shouldn't allocate twice & copy
+    // FIXME: and then this silly thing deserialises it immediately again -- perhaps it should be a bit lazier
+    return serdata_pserop_fix (tp, d);
+  }
+}
+
+static struct ddsi_serdata *serdata_pserop_to_topicless (const struct ddsi_serdata *serdata_common)
+{
+  const struct ddsi_serdata_pserop *d = (const struct ddsi_serdata_pserop *)serdata_common;
+  const struct ddsi_sertopic_pserop *tp = (const struct ddsi_sertopic_pserop *)d->c.topic;
+  ddsrt_iovec_t iov = { .iov_base = (char *) &d->identifier, .iov_len = (ddsrt_iov_len_t) (4 + d->pos) };
+  struct ddsi_serdata *dcmn_tl = serdata_pserop_from_ser_iov (&tp->c, SDK_KEY, 1, &iov, iov.iov_len);
+  assert (dcmn_tl != NULL);
+  dcmn_tl->topic = NULL;
+  return dcmn_tl;
+}
+
+static bool serdata_pserop_topicless_to_sample (const struct ddsi_sertopic *topic_common, const struct ddsi_serdata *serdata_common, void *sample, void **bufptr, void *buflim)
+{
+  const struct ddsi_serdata_pserop *d = (const struct ddsi_serdata_pserop *)serdata_common;
+  const struct ddsi_sertopic_pserop *tp = (const struct ddsi_sertopic_pserop *)topic_common;
+  if (bufptr) abort(); else { (void)buflim; } /* FIXME: haven't implemented that bit yet! */
+  if (tp->ops_key)
+    memcpy (sample, d->sample, 16);
+  return true;
+}
+
+static void serdata_pserop_get_keyhash (const struct ddsi_serdata *serdata_common, struct ddsi_keyhash *buf, bool force_md5)
+{
+  const struct ddsi_serdata_pserop *d = (const struct ddsi_serdata_pserop *)serdata_common;
+  const struct ddsi_sertopic_pserop *tp = (const struct ddsi_sertopic_pserop *)d->c.topic;
+  if (tp->ops_key == NULL)
+    memset (buf, 0, 16);
+  else
+  {
+    /* need big-endian representation for key hash, so be lazy & re-serialize
+       (and yes, it costs another malloc ...); note that key at offset 0 implies
+       ops_key is a prefix of ops */
+    void *be;
+    size_t besize;
+    (void) plist_ser_generic_be (&be, &besize, d->sample, tp->ops_key);
+    assert (besize == 16); /* that's the deal with keys for now */
+    if (!force_md5)
+      memcpy (buf, be, 16);
+    else
+    {
+      ddsrt_md5_state_t md5st;
+      ddsrt_md5_init (&md5st);
+      ddsrt_md5_append (&md5st, (ddsrt_md5_byte_t *) be, 16);
+      ddsrt_md5_finish (&md5st, (ddsrt_md5_byte_t *) buf->value);
+    }
+    ddsrt_free (be);
+  }
+}
+
+static size_t serdata_pserop_print_pserop (const struct ddsi_sertopic *sertopic_common, const struct ddsi_serdata *serdata_common, char *buf, size_t size)
+{
+  const struct ddsi_serdata_pserop *d = (const struct ddsi_serdata_pserop *)serdata_common;
+  const struct ddsi_sertopic_pserop *tp = (const struct ddsi_sertopic_pserop *)sertopic_common;
+  return plist_print_generic (buf, size, d->sample, tp->ops);
+}
+
+const struct ddsi_serdata_ops ddsi_serdata_ops_pserop = {
+  .get_size = serdata_pserop_get_size,
+  .eqkey = serdata_pserop_eqkey,
+  .free = serdata_pserop_free,
+  .from_ser = serdata_pserop_from_ser,
+  .from_ser_iov = serdata_pserop_from_ser_iov,
+  .from_keyhash = serdata_pserop_from_keyhash,
+  .from_sample = serdata_pserop_from_sample,
+  .to_ser = serdata_pserop_to_ser,
+  .to_sample = serdata_pserop_to_sample,
+  .to_ser_ref = serdata_pserop_to_ser_ref,
+  .to_ser_unref = serdata_pserop_to_ser_unref,
+  .to_topicless = serdata_pserop_to_topicless,
+  .topicless_to_sample = serdata_pserop_topicless_to_sample,
+  .print = serdata_pserop_print_pserop,
+  .get_keyhash = serdata_pserop_get_keyhash
+};

--- a/src/core/ddsi/src/ddsi_sertopic_plist.c
+++ b/src/core/ddsi/src/ddsi_sertopic_plist.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright(c) 2020 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include <stddef.h>
+#include <ctype.h>
+#include <assert.h>
+#include <string.h>
+
+#include "dds/ddsrt/mh3.h"
+#include "dds/ddsrt/heap.h"
+#include "dds/ddsi/ddsi_plist.h"
+#include "dds/ddsi/ddsi_sertopic.h"
+#include "dds/ddsi/ddsi_serdata_plist.h"
+
+static bool sertopic_plist_equal (const struct ddsi_sertopic *acmn, const struct ddsi_sertopic *bcmn)
+{
+  const struct ddsi_sertopic_plist *a = (struct ddsi_sertopic_plist *) acmn;
+  const struct ddsi_sertopic_plist *b = (struct ddsi_sertopic_plist *) bcmn;
+  if (a->native_encoding_identifier != b->native_encoding_identifier)
+    return false;
+  if (a->keyparam != b->keyparam)
+    return false;
+  return true;
+}
+
+static uint32_t sertopic_plist_hash (const struct ddsi_sertopic *tpcmn)
+{
+  const struct ddsi_sertopic_plist *tp = (struct ddsi_sertopic_plist *) tpcmn;
+  uint32_t h = 0;
+  h = ddsrt_mh3 (&tp->native_encoding_identifier, sizeof (tp->native_encoding_identifier), h);
+  h = ddsrt_mh3 (&tp->keyparam, sizeof (tp->keyparam), h);
+  return h;
+}
+
+static void sertopic_plist_free (struct ddsi_sertopic *tpcmn)
+{
+  struct ddsi_sertopic_plist *tp = (struct ddsi_sertopic_plist *) tpcmn;
+  ddsi_sertopic_fini (&tp->c);
+  ddsrt_free (tp);
+}
+
+static void sertopic_plist_zero_samples (const struct ddsi_sertopic *sertopic_common, void *sample, size_t count)
+{
+  (void) sertopic_common;
+  ddsi_plist_t *xs = sample;
+  for (size_t i = 0; i < count; i++)
+    ddsi_plist_init_empty (&xs[i]);
+}
+
+static void sertopic_plist_realloc_samples (void **ptrs, const struct ddsi_sertopic *sertopic_common, void *old, size_t oldcount, size_t count)
+{
+  (void) sertopic_common;
+  ddsi_plist_t *new = (oldcount == count) ? old : dds_realloc (old, count * sizeof (ddsi_plist_t));
+  if (new)
+  {
+    for (size_t i = count; i < oldcount; i++)
+      ddsi_plist_init_empty (&new[i]);
+    for (size_t i = 0; i < count; i++)
+      ptrs[i] = &new[i];
+  }
+}
+
+static void sertopic_plist_free_samples (const struct ddsi_sertopic *sertopic_common, void **ptrs, size_t count, dds_free_op_t op)
+{
+  (void) sertopic_common;
+  if (count > 0)
+  {
+#ifndef NDEBUG
+    for (size_t i = 0, off = 0; i < count; i++, off += sizeof (ddsi_plist_t))
+      assert ((char *)ptrs[i] == (char *)ptrs[0] + off);
+#endif
+    ddsi_plist_t *xs = ptrs[0];
+    for (size_t i = 0; i < count; i++)
+      ddsi_plist_fini (&xs[i]);
+    if (op & DDS_FREE_ALL_BIT)
+      dds_free (ptrs[0]);
+  }
+}
+
+const struct ddsi_sertopic_ops ddsi_sertopic_ops_plist = {
+  .equal = sertopic_plist_equal,
+  .hash = sertopic_plist_hash,
+  .free = sertopic_plist_free,
+  .zero_samples = sertopic_plist_zero_samples,
+  .realloc_samples = sertopic_plist_realloc_samples,
+  .free_samples = sertopic_plist_free_samples
+};

--- a/src/core/ddsi/src/ddsi_sertopic_pserop.c
+++ b/src/core/ddsi/src/ddsi_sertopic_pserop.c
@@ -1,0 +1,118 @@
+/*
+ * Copyright(c) 2020 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include <stddef.h>
+#include <ctype.h>
+#include <assert.h>
+#include <string.h>
+
+#include "dds/ddsrt/md5.h"
+#include "dds/ddsrt/mh3.h"
+#include "dds/ddsrt/heap.h"
+#include "dds/ddsi/q_bswap.h"
+#include "dds/ddsi/q_config.h"
+#include "dds/ddsi/q_freelist.h"
+#include "dds/ddsi/ddsi_plist_generic.h"
+#include "dds/ddsi/ddsi_sertopic.h"
+#include "dds/ddsi/ddsi_serdata_pserop.h"
+
+static bool sertopic_pserop_equal (const struct ddsi_sertopic *acmn, const struct ddsi_sertopic *bcmn)
+{
+  const struct ddsi_sertopic_pserop *a = (struct ddsi_sertopic_pserop *) acmn;
+  const struct ddsi_sertopic_pserop *b = (struct ddsi_sertopic_pserop *) bcmn;
+  if (a->native_encoding_identifier != b->native_encoding_identifier)
+    return false;
+  if (a->memsize != b->memsize)
+    return false;
+  if (a->nops != b->nops)
+    return false;
+  assert (a->nops > 0);
+  if (memcmp (a->ops, b->ops, a->nops * sizeof (*a->ops)) != 0)
+    return false;
+  if (a->nops_key != b->nops_key)
+    return false;
+  if (a->ops_key && memcmp (a->ops_key, b->ops_key, a->nops_key * sizeof (*a->ops_key)) != 0)
+    return false;
+  return true;
+}
+
+static uint32_t sertopic_pserop_hash (const struct ddsi_sertopic *tpcmn)
+{
+  const struct ddsi_sertopic_pserop *tp = (struct ddsi_sertopic_pserop *) tpcmn;
+  uint32_t h = 0;
+  h = ddsrt_mh3 (&tp->native_encoding_identifier, sizeof (tp->native_encoding_identifier), h);
+  h = ddsrt_mh3 (&tp->memsize, sizeof (tp->memsize), h);
+  h = ddsrt_mh3 (&tp->nops, sizeof (tp->nops), h);
+  h = ddsrt_mh3 (tp->ops, tp->nops * sizeof (*tp->ops), h);
+  h = ddsrt_mh3 (&tp->nops_key, sizeof (tp->nops_key), h);
+  if (tp->ops_key)
+    h = ddsrt_mh3 (tp->ops_key, tp->nops_key * sizeof (*tp->ops_key), h);
+  return h;
+}
+
+static void sertopic_pserop_free (struct ddsi_sertopic *tpcmn)
+{
+  struct ddsi_sertopic_pserop *tp = (struct ddsi_sertopic_pserop *) tpcmn;
+  ddsi_sertopic_fini (&tp->c);
+  ddsrt_free (tp);
+}
+
+static void sertopic_pserop_zero_samples (const struct ddsi_sertopic *sertopic_common, void *sample, size_t count)
+{
+  const struct ddsi_sertopic_pserop *tp = (const struct ddsi_sertopic_pserop *)sertopic_common;
+  memset (sample, 0, tp->memsize * count);
+}
+
+static void sertopic_pserop_realloc_samples (void **ptrs, const struct ddsi_sertopic *sertopic_common, void *old, size_t oldcount, size_t count)
+{
+  const struct ddsi_sertopic_pserop *tp = (const struct ddsi_sertopic_pserop *)sertopic_common;
+  const size_t size = tp->memsize;
+  char *new = (oldcount == count) ? old : dds_realloc (old, size * count);
+  if (new && count > oldcount)
+    memset (new + size * oldcount, 0, size * (count - oldcount));
+  for (size_t i = 0; i < count; i++)
+  {
+    void *ptr = (char *) new + i * size;
+    ptrs[i] = ptr;
+  }
+}
+
+static void sertopic_pserop_free_samples (const struct ddsi_sertopic *sertopic_common, void **ptrs, size_t count, dds_free_op_t op)
+{
+  if (count > 0)
+  {
+    const struct ddsi_sertopic_pserop *tp = (const struct ddsi_sertopic_pserop *)sertopic_common;
+    const size_t size = tp->memsize;
+#ifndef NDEBUG
+    for (size_t i = 0, off = 0; i < count; i++, off += size)
+      assert ((char *)ptrs[i] == (char *)ptrs[0] + off);
+#endif
+    char *ptr = ptrs[0];
+    for (size_t i = 0; i < count; i++)
+    {
+      plist_fini_generic (ptr, tp->ops, false);
+      ptr += size;
+    }
+    if (op & DDS_FREE_ALL_BIT)
+    {
+      dds_free (ptrs[0]);
+    }
+  }
+}
+
+const struct ddsi_sertopic_ops ddsi_sertopic_ops_pserop = {
+  .equal = sertopic_pserop_equal,
+  .hash = sertopic_pserop_hash,
+  .free = sertopic_pserop_free,
+  .zero_samples = sertopic_pserop_zero_samples,
+  .realloc_samples = sertopic_pserop_realloc_samples,
+  .free_samples = sertopic_pserop_free_samples
+};

--- a/src/core/ddsi/src/q_config.c
+++ b/src/core/ddsi/src/q_config.c
@@ -863,8 +863,6 @@ static const struct cfgelem discovery_cfgelems[] = {
     BLURB("<p>This element specifies the interval between spontaneous transmissions of participant discovery packets.</p>") },
   { LEAF("DefaultMulticastAddress"), 1, "auto", ABSOFF(defaultMulticastAddressString), 0, uf_networkAddress, 0, pf_networkAddress,
     BLURB("<p>This element specifies the default multicast address for all traffic other than participant discovery packets. It defaults to Discovery/SPDPMulticastAddress.</p>") },
-  { LEAF("EnableTopicDiscovery"), 1, "true", ABSOFF(do_topic_discovery), 0, uf_boolean, 0, pf_boolean,
-    BLURB("<p>Do not use.</p>") },
   { GROUP("Ports", discovery_ports_cfgelems),
     BLURB("<p>The Ports element allows specifying various parameters related to the port numbers used for discovery. These all have default values specified by the DDSI 2.1 specification and rarely need to be changed.</p>") },
   END_MARKER

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -563,7 +563,7 @@ static void add_security_builtin_endpoints(struct participant *pp, ddsi_guid_t *
 
     subguid->entityid = to_entityid (NN_ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_WRITER);
     wrinfo = whc_make_wrinfo (NULL, &gv->builtin_endpoint_xqos_wr);
-    new_writer_guid (NULL, subguid, group_guid, pp, NULL, &gv->builtin_endpoint_xqos_wr, whc_new(gv, wrinfo), NULL, NULL);
+    new_writer_guid (NULL, subguid, group_guid, pp, gv->spdp_secure_topic, &gv->builtin_endpoint_xqos_wr, whc_new(gv, wrinfo), NULL, NULL);
     whc_free_wrinfo (wrinfo);
     /* But we need the as_disc address set for SPDP, because we need to
        send it to everyone regardless of the existence of readers. */
@@ -572,28 +572,28 @@ static void add_security_builtin_endpoints(struct participant *pp, ddsi_guid_t *
 
     subguid->entityid = to_entityid (NN_ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_MESSAGE_WRITER);
     wrinfo = whc_make_wrinfo (NULL, &gv->builtin_stateless_xqos_wr);
-    new_writer_guid (NULL, subguid, group_guid, pp, NULL, &gv->builtin_stateless_xqos_wr, whc_new(gv, wrinfo), NULL, NULL);
+    new_writer_guid (NULL, subguid, group_guid, pp, gv->pgm_stateless_topic, &gv->builtin_stateless_xqos_wr, whc_new(gv, wrinfo), NULL, NULL);
     whc_free_wrinfo (wrinfo);
     pp->bes |= NN_BUILTIN_ENDPOINT_PARTICIPANT_STATELESS_MESSAGE_ANNOUNCER;
 
     subguid->entityid = to_entityid (NN_ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER);
     wrinfo = whc_make_wrinfo (NULL, &gv->builtin_volatile_xqos_wr);
-    new_writer_guid (NULL, subguid, group_guid, pp, NULL, &gv->builtin_volatile_xqos_wr, whc_new(gv, wrinfo), NULL, NULL);
+    new_writer_guid (NULL, subguid, group_guid, pp, gv->pgm_volatile_topic, &gv->builtin_volatile_xqos_wr, whc_new(gv, wrinfo), NULL, NULL);
     whc_free_wrinfo (wrinfo);
     pp->bes |= NN_BUILTIN_ENDPOINT_PARTICIPANT_VOLATILE_SECURE_ANNOUNCER;
 
     wrinfo = whc_make_wrinfo (NULL, &gv->builtin_endpoint_xqos_wr);
 
     subguid->entityid = to_entityid (NN_ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER);
-    new_writer_guid (NULL, subguid, group_guid, pp, NULL, &gv->builtin_endpoint_xqos_wr, whc_new(gv, wrinfo), NULL, NULL);
+    new_writer_guid (NULL, subguid, group_guid, pp, gv->pmd_secure_topic, &gv->builtin_endpoint_xqos_wr, whc_new(gv, wrinfo), NULL, NULL);
     pp->bes |= NN_BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_SECURE_ANNOUNCER;
 
     subguid->entityid = to_entityid (NN_ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER);
-    new_writer_guid (NULL, subguid, group_guid, pp, NULL, &gv->builtin_endpoint_xqos_wr, whc_new(gv, wrinfo), NULL, NULL);
+    new_writer_guid (NULL, subguid, group_guid, pp, gv->sedp_writer_secure_topic, &gv->builtin_endpoint_xqos_wr, whc_new(gv, wrinfo), NULL, NULL);
     pp->bes |= NN_BUILTIN_ENDPOINT_PUBLICATION_MESSAGE_SECURE_ANNOUNCER;
 
     subguid->entityid = to_entityid (NN_ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER);
-    new_writer_guid (NULL, subguid, group_guid, pp, NULL, &gv->builtin_endpoint_xqos_wr, whc_new(gv, wrinfo), NULL, NULL);
+    new_writer_guid (NULL, subguid, group_guid, pp, gv->sedp_reader_secure_topic, &gv->builtin_endpoint_xqos_wr, whc_new(gv, wrinfo), NULL, NULL);
     pp->bes |= NN_BUILTIN_ENDPOINT_SUBSCRIPTION_MESSAGE_SECURE_ANNOUNCER;
 
     whc_free_wrinfo (wrinfo);
@@ -602,11 +602,11 @@ static void add_security_builtin_endpoints(struct participant *pp, ddsi_guid_t *
   if (add_readers)
   {
     subguid->entityid = to_entityid (NN_ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER);
-    new_reader_guid (NULL, subguid, group_guid, pp, NULL, &gv->builtin_endpoint_xqos_rd, NULL, NULL, NULL);
+    new_reader_guid (NULL, subguid, group_guid, pp, gv->sedp_reader_secure_topic, &gv->builtin_endpoint_xqos_rd, NULL, NULL, NULL);
     pp->bes |= NN_BUILTIN_ENDPOINT_SUBSCRIPTION_MESSAGE_SECURE_DETECTOR;
 
     subguid->entityid = to_entityid (NN_ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_READER);
-    new_reader_guid (NULL, subguid, group_guid, pp, NULL, &gv->builtin_endpoint_xqos_rd, NULL, NULL, NULL);
+    new_reader_guid (NULL, subguid, group_guid, pp, gv->sedp_writer_secure_topic, &gv->builtin_endpoint_xqos_rd, NULL, NULL, NULL);
     pp->bes |= NN_BUILTIN_ENDPOINT_PUBLICATION_MESSAGE_SECURE_DETECTOR;
   }
 
@@ -615,19 +615,19 @@ static void add_security_builtin_endpoints(struct participant *pp, ddsi_guid_t *
    * besmode flag setting, because all participant do require authentication.
    */
   subguid->entityid = to_entityid (NN_ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_READER);
-  new_reader_guid (NULL, subguid, group_guid, pp, NULL, &gv->builtin_endpoint_xqos_rd, NULL, NULL, NULL);
+  new_reader_guid (NULL, subguid, group_guid, pp, gv->spdp_secure_topic, &gv->builtin_endpoint_xqos_rd, NULL, NULL, NULL);
   pp->bes |= NN_DISC_BUILTIN_ENDPOINT_PARTICIPANT_SECURE_DETECTOR;
 
   subguid->entityid = to_entityid (NN_ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_READER);
-  new_reader_guid (NULL, subguid, group_guid, pp, NULL, &gv->builtin_volatile_xqos_rd, NULL, NULL, NULL);
+  new_reader_guid (NULL, subguid, group_guid, pp, gv->pgm_volatile_topic, &gv->builtin_volatile_xqos_rd, NULL, NULL, NULL);
   pp->bes |= NN_BUILTIN_ENDPOINT_PARTICIPANT_VOLATILE_SECURE_DETECTOR;
 
   subguid->entityid = to_entityid (NN_ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_MESSAGE_READER);
-  new_reader_guid (NULL, subguid, group_guid, pp, NULL, &gv->builtin_stateless_xqos_rd, NULL, NULL, NULL);
+  new_reader_guid (NULL, subguid, group_guid, pp, gv->pgm_stateless_topic, &gv->builtin_stateless_xqos_rd, NULL, NULL, NULL);
   pp->bes |= NN_BUILTIN_ENDPOINT_PARTICIPANT_STATELESS_MESSAGE_DETECTOR;
 
   subguid->entityid = to_entityid (NN_ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER);
-  new_reader_guid (NULL, subguid, group_guid, pp, NULL, &gv->builtin_endpoint_xqos_rd, NULL, NULL, NULL);
+  new_reader_guid (NULL, subguid, group_guid, pp, gv->pmd_secure_topic, &gv->builtin_endpoint_xqos_rd, NULL, NULL, NULL);
   pp->bes |= NN_BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_SECURE_DETECTOR;
 }
 #endif
@@ -640,24 +640,17 @@ static void add_builtin_endpoints(struct participant *pp, ddsi_guid_t *subguid, 
 
     /* SEDP writers: */
     subguid->entityid = to_entityid (NN_ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_WRITER);
-    new_writer_guid (NULL, subguid, group_guid, pp, NULL, &gv->builtin_endpoint_xqos_wr, whc_new(gv, wrinfo), NULL, NULL);
+    new_writer_guid (NULL, subguid, group_guid, pp, gv->sedp_reader_topic, &gv->builtin_endpoint_xqos_wr, whc_new(gv, wrinfo), NULL, NULL);
     pp->bes |= NN_DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_ANNOUNCER;
 
     subguid->entityid = to_entityid (NN_ENTITYID_SEDP_BUILTIN_PUBLICATIONS_WRITER);
-    new_writer_guid (NULL, subguid, group_guid, pp, NULL, &gv->builtin_endpoint_xqos_wr, whc_new(gv, wrinfo), NULL, NULL);
+    new_writer_guid (NULL, subguid, group_guid, pp, gv->sedp_writer_topic, &gv->builtin_endpoint_xqos_wr, whc_new(gv, wrinfo), NULL, NULL);
     pp->bes |= NN_DISC_BUILTIN_ENDPOINT_PUBLICATION_ANNOUNCER;
 
     /* PMD writer: */
     subguid->entityid = to_entityid (NN_ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_WRITER);
-    new_writer_guid (NULL, subguid, group_guid, pp, NULL, &gv->builtin_endpoint_xqos_wr, whc_new(gv, wrinfo), NULL, NULL);
+    new_writer_guid (NULL, subguid, group_guid, pp, gv->pmd_topic, &gv->builtin_endpoint_xqos_wr, whc_new(gv, wrinfo), NULL, NULL);
     pp->bes |= NN_BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_WRITER;
-
-    if (gv->config.do_topic_discovery)
-    {
-      subguid->entityid = to_entityid (NN_ENTITYID_SEDP_BUILTIN_TOPIC_WRITER);
-      new_writer_guid (NULL, subguid, group_guid, pp, NULL, &gv->builtin_endpoint_xqos_wr, whc_new(gv, wrinfo), NULL, NULL);
-      pp->bes |= NN_DISC_BUILTIN_ENDPOINT_TOPIC_ANNOUNCER;
-    }
 
     whc_free_wrinfo (wrinfo);
   }
@@ -666,19 +659,19 @@ static void add_builtin_endpoints(struct participant *pp, ddsi_guid_t *subguid, 
   if (add_readers)
   {
     subguid->entityid = to_entityid (NN_ENTITYID_SPDP_BUILTIN_PARTICIPANT_READER);
-    new_reader_guid (NULL, subguid, group_guid, pp, NULL, &gv->spdp_endpoint_xqos, NULL, NULL, NULL);
+    new_reader_guid (NULL, subguid, group_guid, pp, gv->spdp_topic, &gv->spdp_endpoint_xqos, NULL, NULL, NULL);
     pp->bes |= NN_DISC_BUILTIN_ENDPOINT_PARTICIPANT_DETECTOR;
 
     subguid->entityid = to_entityid (NN_ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_READER);
-    new_reader_guid (NULL, subguid, group_guid, pp, NULL, &gv->builtin_endpoint_xqos_rd, NULL, NULL, NULL);
+    new_reader_guid (NULL, subguid, group_guid, pp, gv->sedp_reader_topic, &gv->builtin_endpoint_xqos_rd, NULL, NULL, NULL);
     pp->bes |= NN_DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_DETECTOR;
 
     subguid->entityid = to_entityid (NN_ENTITYID_SEDP_BUILTIN_PUBLICATIONS_READER);
-    new_reader_guid (NULL, subguid, group_guid, pp, NULL, &gv->builtin_endpoint_xqos_rd, NULL, NULL, NULL);
+    new_reader_guid (NULL, subguid, group_guid, pp, gv->sedp_writer_topic, &gv->builtin_endpoint_xqos_rd, NULL, NULL, NULL);
     pp->bes |= NN_DISC_BUILTIN_ENDPOINT_PUBLICATION_DETECTOR;
 
     subguid->entityid = to_entityid (NN_ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_READER);
-    new_reader_guid (NULL, subguid, group_guid, pp, NULL, &gv->builtin_endpoint_xqos_rd, NULL, NULL, NULL);
+    new_reader_guid (NULL, subguid, group_guid, pp, gv->pmd_topic, &gv->builtin_endpoint_xqos_rd, NULL, NULL, NULL);
     pp->bes |= NN_BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_READER;
   }
 
@@ -1001,7 +994,7 @@ dds_return_t new_participant_guid (ddsi_guid_t *ppguid, struct ddsi_domaingv *gv
   {
     subguid.entityid = to_entityid (NN_ENTITYID_SPDP_BUILTIN_PARTICIPANT_WRITER);
     wrinfo = whc_make_wrinfo (NULL, &gv->spdp_endpoint_xqos);
-    new_writer_guid (NULL, &subguid, &group_guid, pp, NULL, &gv->spdp_endpoint_xqos, whc_new(gv, wrinfo), NULL, NULL);
+    new_writer_guid (NULL, &subguid, &group_guid, pp, gv->spdp_topic, &gv->spdp_endpoint_xqos, whc_new(gv, wrinfo), NULL, NULL);
     whc_free_wrinfo (wrinfo);
     /* But we need the as_disc address set for SPDP, because we need to
        send it to everyone regardless of the existence of readers. */
@@ -2590,9 +2583,6 @@ already_matched:
   return;
 }
 
-
-
-
 static void proxy_reader_add_connection (struct proxy_reader *prd, struct writer *wr, int64_t crypto_handle)
 {
   struct prd_wr_match *m = ddsrt_malloc (sizeof (*m));
@@ -2615,7 +2605,6 @@ static void proxy_reader_add_connection (struct proxy_reader *prd, struct writer
   }
   else
   {
-    assert (wr->topic || is_builtin_endpoint (wr->e.guid.entityid, NN_VENDORID_ECLIPSE));
     ELOGDISC (prd, "  proxy_reader_add_connection(wr "PGUIDFMT" prd "PGUIDFMT")\n",
               PGUID (wr->e.guid), PGUID (prd->e.guid));
     ddsrt_avl_insert_ipath (&prd_writers_treedef, &prd->writers, m, &path);
@@ -2920,7 +2909,6 @@ static void connect_writer_with_proxy_reader_wrapper (struct entity_common *vwr,
   struct proxy_reader *prd = (struct proxy_reader *) vprd;
   assert (wr->e.kind == EK_WRITER);
   assert (prd->e.kind == EK_PROXY_READER);
-  assert (is_builtin_endpoint (wr->e.guid.entityid, NN_VENDORID_ECLIPSE) == is_builtin_endpoint (prd->e.guid.entityid, prd->c.vendor));
   connect_writer_with_proxy_reader (wr, prd, tnow);
 }
 
@@ -2930,7 +2918,6 @@ static void connect_proxy_writer_with_reader_wrapper (struct entity_common *vpwr
   struct reader *rd = (struct reader *) vrd;
   assert (pwr->e.kind == EK_PROXY_WRITER);
   assert (rd->e.kind == EK_READER);
-  assert (is_builtin_endpoint (rd->e.guid.entityid, NN_VENDORID_ECLIPSE) == is_builtin_endpoint (pwr->e.guid.entityid, pwr->c.vendor));
   connect_proxy_writer_with_reader (pwr, rd, tnow);
 }
 
@@ -2940,8 +2927,6 @@ static void connect_writer_with_reader_wrapper (struct entity_common *vwr, struc
   struct reader *rd = (struct reader *) vrd;
   assert (wr->e.kind == EK_WRITER);
   assert (rd->e.kind == EK_READER);
-  assert (!is_builtin_endpoint (wr->e.guid.entityid, NN_VENDORID_ECLIPSE) || is_local_orphan_endpoint (&wr->e));
-  assert (!is_builtin_endpoint (rd->e.guid.entityid, NN_VENDORID_ECLIPSE));
   connect_writer_with_reader (wr, rd, tnow);
 }
 
@@ -3234,7 +3219,7 @@ static void new_reader_writer_common (const struct ddsrt_log_cfg *logcfg, const 
 {
   const char *partition = "(default)";
   const char *partition_suffix = "";
-  assert (is_builtin_entityid (guid->entityid, NN_VENDORID_ECLIPSE) ? (topic == NULL) : (topic != NULL));
+  assert (topic != NULL);
   if (is_builtin_entityid (guid->entityid, NN_VENDORID_ECLIPSE))
   {
     /* continue printing it as not being in a partition, the actual
@@ -3252,8 +3237,8 @@ static void new_reader_writer_common (const struct ddsrt_log_cfg *logcfg, const 
             is_writer_entityid (guid->entityid) ? "writer" : "reader",
             PGUID (*guid),
             partition, partition_suffix,
-            topic ? topic->name : "(null)",
-            topic ? topic->type_name : "(null)");
+            topic->name,
+            topic->type_name);
 }
 
 static void endpoint_common_init (struct entity_common *e, struct endpoint_common *c, struct ddsi_domaingv *gv, enum entity_kind kind, const struct ddsi_guid *guid, const struct ddsi_guid *group_guid, struct participant *pp, bool onlylocal)
@@ -3282,12 +3267,12 @@ static void endpoint_common_fini (struct entity_common *e, struct endpoint_commo
 
 static int set_topic_type_name (dds_qos_t *xqos, const struct ddsi_sertopic * topic)
 {
-  if (!(xqos->present & QP_TYPE_NAME) && topic)
+  if (!(xqos->present & QP_TYPE_NAME))
   {
     xqos->present |= QP_TYPE_NAME;
     xqos->type_name = ddsrt_strdup (topic->type_name);
   }
-  if (!(xqos->present & QP_TOPIC_NAME) && topic)
+  if (!(xqos->present & QP_TOPIC_NAME))
   {
     xqos->present |= QP_TOPIC_NAME;
     xqos->topic_name = ddsrt_strdup (topic->name);
@@ -3754,7 +3739,7 @@ static dds_return_t new_writer_guid (struct writer **wr_out, const struct ddsi_g
    delete_participant won't interfere with our ability to address
    the participant */
 
-  const bool onlylocal = topic && builtintopic_is_builtintopic (pp->e.gv->builtin_topic_interface, topic);
+  const bool onlylocal = builtintopic_is_builtintopic (pp->e.gv->builtin_topic_interface, topic);
   endpoint_common_init (&wr->e, &wr->c, pp->e.gv, EK_WRITER, guid, group_guid, pp, onlylocal);
   new_writer_guid_common_init(wr, topic, xqos, whc, status_cb, status_entity);
 
@@ -4241,7 +4226,7 @@ static dds_return_t new_reader_guid
   if (rd_out)
     *rd_out = rd;
 
-  const bool onlylocal = topic && builtintopic_is_builtintopic (pp->e.gv->builtin_topic_interface, topic);
+  const bool onlylocal = builtintopic_is_builtintopic (pp->e.gv->builtin_topic_interface, topic);
   endpoint_common_init (&rd->e, &rd->c, pp->e.gv, EK_READER, guid, group_guid, pp, onlylocal);
 
   /* Copy QoS, merging in defaults */

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -50,6 +50,7 @@
 #include "dds/ddsi/q_debmon.h"
 #include "dds/ddsi/q_init.h"
 #include "dds/ddsi/ddsi_threadmon.h"
+#include "dds/ddsi/ddsi_pmd.h"
 
 #include "dds/ddsi/ddsi_tran.h"
 #include "dds/ddsi/ddsi_udp.h"
@@ -57,6 +58,8 @@
 #include "dds/ddsi/ddsi_raweth.h"
 #include "dds/ddsi/ddsi_mcgroup.h"
 #include "dds/ddsi/ddsi_serdata_default.h"
+#include "dds/ddsi/ddsi_serdata_pserop.h"
+#include "dds/ddsi/ddsi_serdata_plist.h"
 #include "dds/ddsi/ddsi_security_omg.h"
 
 #include "dds/ddsi/ddsi_tkmap.h"
@@ -788,38 +791,75 @@ static void wait_for_receive_threads (struct ddsi_domaingv *gv)
   }
 }
 
-static struct ddsi_sertopic *make_special_topic (const char *name, struct serdatapool *serpool, uint16_t enc_id, const struct ddsi_serdata_ops *ops)
+static struct ddsi_sertopic *make_special_topic_pserop (const char *name, const char *typename, size_t memsize, size_t nops, const enum pserop *ops, size_t nops_key, const enum pserop *ops_key)
 {
-  /* FIXME: two things (at least)
-     - it claims there is a key, but the underlying type description is missing
-       that only works as long as it ends up comparing the keyhash field ...
-       the keyhash field should be eliminated; but this can simply be moved over to an alternate
-       topic class, it need not use the "default" one, that's mere expediency
-     - initialising/freeing them here, in this manner, is not very clean
-       it should be moved to somewhere in the topic implementation
-       (kinda natural if they stop being "default" ones) */
-  struct ddsi_sertopic_default *st = ddsrt_malloc (sizeof (*st));
+  struct ddsi_sertopic_pserop *st = ddsrt_malloc (sizeof (*st));
   memset (st, 0, sizeof (*st));
-  ddsi_sertopic_init (&st->c, name, name, &ddsi_sertopic_ops_default, ops, false);
-  st->native_encoding_identifier = enc_id;
-  st->serpool = serpool;
+  ddsi_sertopic_init (&st->c, name, typename, &ddsi_sertopic_ops_pserop, &ddsi_serdata_ops_pserop, nops_key == 0);
+  st->native_encoding_identifier = (DDSRT_ENDIAN == DDSRT_LITTLE_ENDIAN) ? CDR_LE : CDR_BE;
+  st->memsize = memsize;
+  st->nops = nops;
+  st->ops = ops;
+  st->nops_key = nops_key;
+  st->ops_key = ops_key;
+  return (struct ddsi_sertopic *) st;
+}
+
+static struct ddsi_sertopic *make_special_topic_plist (const char *name, const char *typename, nn_parameterid_t keyparam)
+{
+  struct ddsi_sertopic_plist *st = ddsrt_malloc (sizeof (*st));
+  memset (st, 0, sizeof (*st));
+  ddsi_sertopic_init (&st->c, name, typename, &ddsi_sertopic_ops_plist, &ddsi_serdata_ops_plist, false);
+  st->native_encoding_identifier = (DDSRT_ENDIAN == DDSRT_LITTLE_ENDIAN) ? PL_CDR_LE : PL_CDR_BE;
+  st->keyparam = keyparam;
   return (struct ddsi_sertopic *) st;
 }
 
 static void free_special_topics (struct ddsi_domaingv *gv)
 {
-  ddsi_sertopic_unref (gv->plist_topic);
-  ddsi_sertopic_unref (gv->rawcdr_topic);
+#ifdef DDSI_INCLUDE_SECURITY
+  ddsi_sertopic_unref (gv->pgm_volatile_topic);
+  ddsi_sertopic_unref (gv->pgm_stateless_topic);
+  ddsi_sertopic_unref (gv->pmd_secure_topic);
+  ddsi_sertopic_unref (gv->spdp_secure_topic);
+  ddsi_sertopic_unref (gv->sedp_reader_secure_topic);
+  ddsi_sertopic_unref (gv->sedp_writer_secure_topic);
+#endif
+  ddsi_sertopic_unref (gv->pmd_topic);
+  ddsi_sertopic_unref (gv->spdp_topic);
+  ddsi_sertopic_unref (gv->sedp_reader_topic);
+  ddsi_sertopic_unref (gv->sedp_writer_topic);
 }
 
 static void make_special_topics (struct ddsi_domaingv *gv)
 {
-  gv->plist_topic = make_special_topic ("plist", gv->serpool, DDSRT_ENDIAN == DDSRT_LITTLE_ENDIAN ? PL_CDR_LE : PL_CDR_BE, &ddsi_serdata_ops_plist);
-  gv->rawcdr_topic = make_special_topic ("rawcdr", gv->serpool, DDSRT_ENDIAN == DDSRT_LITTLE_ENDIAN ? CDR_LE : CDR_BE, &ddsi_serdata_ops_rawcdr);
+  gv->spdp_topic = make_special_topic_plist ("DCPSParticipant", "ParticipantBuiltinTopicData", PID_PARTICIPANT_GUID);
+  gv->sedp_reader_topic = make_special_topic_plist ("DCPSSubscription", "SubscriptionBuiltinTopicData", PID_ENDPOINT_GUID);
+  gv->sedp_writer_topic = make_special_topic_plist ("DCPSPublication", "PublicationBuiltinTopicData", PID_ENDPOINT_GUID);
+  gv->pmd_topic = make_special_topic_pserop ("DCPSParticipantMessage", "ParticipantMessageData", sizeof (ParticipantMessageData_t), participant_message_data_nops, participant_message_data_ops, participant_message_data_nops_key, participant_message_data_ops_key);
+
+#ifdef DDSI_INCLUDE_SECURITY
+  gv->spdp_secure_topic = make_special_topic_plist ("DCPSParticipantsSecure", "ParticipantBuiltinTopicDataSecure", PID_PARTICIPANT_GUID);
+  gv->sedp_reader_secure_topic = make_special_topic_plist ("DCPSSubscriptionsSecure", "SubscriptionBuiltinTopicDataSecure", PID_ENDPOINT_GUID);
+  gv->sedp_writer_secure_topic = make_special_topic_plist ("DCPSPublicationsSecure", "PublicationBuiltinTopicDataSecure", PID_ENDPOINT_GUID);
+  gv->pmd_secure_topic = make_special_topic_pserop ("DCPSParticipantMessageSecure", "ParticipantMessageDataSecure", sizeof (ParticipantMessageData_t), participant_message_data_nops, participant_message_data_ops, participant_message_data_nops_key, participant_message_data_ops_key);
+  gv->pgm_stateless_topic = make_special_topic_pserop ("DCPSParticipantStatelessMessage", "ParticipantStatelessMessage", sizeof (nn_participant_generic_message_t), pserop_participant_generic_message_nops, pserop_participant_generic_message, 0, NULL);
+  gv->pgm_volatile_topic = make_special_topic_pserop ("DCPSParticipantVolatileMessageSecure", "ParticipantVolatileMessageSecure", sizeof (nn_participant_generic_message_t), pserop_participant_generic_message_nops, pserop_participant_generic_message, 0, NULL);
+#endif
 
   ddsrt_mutex_lock (&gv->sertopics_lock);
-  ddsi_sertopic_register_locked (gv, gv->plist_topic);
-  ddsi_sertopic_register_locked (gv, gv->rawcdr_topic);
+  ddsi_sertopic_register_locked (gv, gv->spdp_topic);
+  ddsi_sertopic_register_locked (gv, gv->sedp_reader_topic);
+  ddsi_sertopic_register_locked (gv, gv->sedp_writer_topic);
+  ddsi_sertopic_register_locked (gv, gv->pmd_topic);
+#ifdef DDSI_INCLUDE_SECURITY
+  ddsi_sertopic_register_locked (gv, gv->spdp_secure_topic);
+  ddsi_sertopic_register_locked (gv, gv->sedp_reader_secure_topic);
+  ddsi_sertopic_register_locked (gv, gv->sedp_writer_secure_topic);
+  ddsi_sertopic_register_locked (gv, gv->pmd_secure_topic);
+  ddsi_sertopic_register_locked (gv, gv->pgm_stateless_topic);
+  ddsi_sertopic_register_locked (gv, gv->pgm_volatile_topic);
+#endif
   ddsrt_mutex_unlock (&gv->sertopics_lock);
 
   /* register increments refcount (which is reasonable), but at some point

--- a/src/core/ddsi/src/q_receive.c
+++ b/src/core/ddsi/src/q_receive.c
@@ -1976,7 +1976,7 @@ static struct ddsi_serdata *remote_make_sample (struct ddsi_tkmap_instance **tk,
       GVTRACE ("data(application, vendor %u.%u): "PGUIDFMT" #%"PRId64": ST%x %s/%s:%s%s",
                sampleinfo->rst->vendor.id[0], sampleinfo->rst->vendor.id[1],
                PGUID (guid), sampleinfo->seq, statusinfo, topic->name, topic->type_name,
-               tmp, res < sizeof (tmp) ? "" : "(trunc)");
+               tmp, res < sizeof (tmp) - 1 ? "" : "(trunc)");
     }
   }
   return sample;

--- a/src/core/ddsi/src/q_transmit.c
+++ b/src/core/ddsi/src/q_transmit.c
@@ -966,8 +966,6 @@ static int insert_sample_in_whc (struct writer *wr, seqno_t seq, struct ddsi_pli
   {
     char ppbuf[1024];
     int tmp;
-    const char *tname = wr->topic ? wr->topic->name : "(null)";
-    const char *ttname = wr->topic ? wr->topic->type_name : "(null)";
     ppbuf[0] = '\0';
     tmp = sizeof (ppbuf) - 1;
     if (wr->e.gv->logconfig.c.mask & DDS_LC_CONTENT)
@@ -975,7 +973,7 @@ static int insert_sample_in_whc (struct writer *wr, seqno_t seq, struct ddsi_pli
     ETRACE (wr, "write_sample "PGUIDFMT" #%"PRId64, PGUID (wr->e.guid), seq);
     if (plist != 0 && (plist->present & PP_COHERENT_SET))
       ETRACE (wr, " C#%"PRId64"", fromSN (plist->coherent_set_seqno));
-    ETRACE (wr, ": ST%"PRIu32" %s/%s:%s%s\n", serdata->statusinfo, tname, ttname, ppbuf, tmp < (int) sizeof (ppbuf) ? "" : " (trunc)");
+    ETRACE (wr, ": ST%"PRIu32" %s/%s:%s%s\n", serdata->statusinfo, wr->topic->name, wr->topic->type_name, ppbuf, tmp < (int) sizeof (ppbuf) ? "" : " (trunc)");
   }
 
   assert (wr->reliable || have_reliable_subs (wr) == 0);
@@ -1235,13 +1233,11 @@ static int write_sample_eot (struct thread_state1 * const ts1, struct nn_xpack *
   {
     char ppbuf[1024];
     int tmp;
-    const char *tname = wr->topic ? wr->topic->name : "(null)";
-    const char *ttname = wr->topic ? wr->topic->type_name : "(null)";
     ppbuf[0] = '\0';
     tmp = sizeof (ppbuf) - 1;
     GVWARNING ("dropping oversize (%"PRIu32" > %"PRIu32") sample from local writer "PGUIDFMT" %s/%s:%s%s\n",
                ddsi_serdata_size (serdata), gv->config.max_sample_size,
-               PGUID (wr->e.guid), tname, ttname, ppbuf,
+               PGUID (wr->e.guid), wr->topic->name, wr->topic->type_name, ppbuf,
                tmp < (int) sizeof (ppbuf) ? "" : " (trunc)");
     r = DDS_RETCODE_BAD_PARAMETER;
     goto drop;

--- a/src/core/ddsi/src/q_xevent.c
+++ b/src/core/ddsi/src/q_xevent.c
@@ -1099,15 +1099,9 @@ static bool resend_spdp_sample_by_guid_key (struct writer *wr, const ddsi_guid_t
   ddsi_plist_init_empty (&ps);
   ps.present |= PP_PARTICIPANT_GUID;
   ps.participant_guid = *guid;
-  struct nn_xmsg *mpayload = nn_xmsg_new (gv->xmsgpool, guid, wr->c.pp, 0, NN_XMSG_KIND_DATA);
-  ddsi_plist_addtomsg (mpayload, &ps, ~(uint64_t)0, ~(uint64_t)0);
-  nn_xmsg_addpar_sentinel (mpayload);
+  struct ddsi_serdata *sd = ddsi_serdata_from_sample (gv->spdp_topic, SDK_KEY, &ps);
   ddsi_plist_fini (&ps);
-  struct ddsi_plist_sample plist_sample;
-  nn_xmsg_payload_to_plistsample (&plist_sample, PID_PARTICIPANT_GUID, mpayload);
-  struct ddsi_serdata *sd = ddsi_serdata_from_sample (gv->plist_topic, SDK_KEY, &plist_sample);
   struct whc_borrowed_sample sample;
-  nn_xmsg_free (mpayload);
 
   ddsrt_mutex_lock (&wr->e.lock);
   sample_found = whc_borrow_sample_key (wr->whc, sd, &sample);


### PR DESCRIPTION
This (massive-ish) PR was triggered by looking at the increased reliance on a decade-old hack in handling the extra messages mandated by security, accompanied by the nagging feeling that even before this recent increase, the hack had been allowed to linger around for too long anyway.

* Remove the "plist" and "rawcdr" abuse of the "serdata_default" sample representation.
* Introduce a new "plist" topic type and a new "pserop" topic type. The former represents parameter lists as used in discovery, the second arbitrary samples using the serialiser in ddsi_plist.c.
* Introduce sertopics for each of the built-in "topics" used by the DDSI discovery protocol using the two new topic types, and reference these in the readers/writers used in discovery.
* Construct and deconstruct the discovery message by using the conversion routines for these sample types, rather than fiddling with, e.g., the baroque interface for adding parameter lists to messages.
* As a consequence, it introduces standardized logging of received and transmitted discovery data and eliminates the annoying "(null)/(null)" and "(blob)" descriptions in the trace.
* Limits the dumping of octet sequences in discovery data to the first 100 bytes to make the embedded certificates and permissions documents (somewhat) manageable.
* Eliminates the (many) null pointer checks on reader/writer topics.
* Fixes the printing of nested sequences in discovery data (not used before) and the formatting of GUIDs.

Various interfaces remain unchanged and so while this removes cruft from the core code, it moves some of it into the conversion routines for the new topic types.

It also now allocates some memory when processing incoming discovery data, whereas before it had no need to do so.  Allowing for aliasing of data in the new sertopics and adding a way to initialize these specific types on the stack (both minor changes) suffices for eliminating those allocations.

Comments, anyone? This is quite a big change to code that plays a role in message validation and in vendor-specific message interpretation (to work around quirks of various implementations) so it is quite important to have look it over carefully.