### PR TITLE
Improvements to building against & using master/security-enabled/security-but-disabled versions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,26 @@ if(NOT ${PROJECT_NAME} STREQUAL "CycloneDDS")
   message(FATAL_ERROR "Top-level CMakeLists.txt was moved to the top-level directory.  Please run cmake on ${dir} instead of ${CMAKE_CURRENT_LIST_DIR}")
 endif()
 
+# Generate a header file listing compile-time options relevant to the API.  Define to
+# "1" if enabled so that the generated features.h ends up having either
+#
+# - #define DDS_HAS_SECURITY 1
+# or
+# - /* #undef DDS_HAS_SECURITY */
+#
+# which caters both for those who prefer #ifdef DDS_HAS_SECURITY and for those who prefer
+# #if DDS_HAS_SECURITY.
+if(ENABLE_SECURITY)
+  set(DDS_HAS_SECURITY "1")
+endif()
+if(ENABLE_LIFESPAN)
+  set(DDS_HAS_LIFESPAN "1")
+endif()
+if(ENABLE_DEADLINE_MISSED)
+  set(DDS_HAS_DEADLINE_MISSED "1")
+endif()
+configure_file(features.h.in "${CMAKE_CURRENT_BINARY_DIR}/core/include/dds/features.h")
+
 add_definitions(-DDDSI_INCLUDE_NETWORK_PARTITIONS -DDDSI_INCLUDE_SSM)
 
 # OpenSSL is huge, raising the RSS by 1MB or so, and moreover find_package(OpenSSL) causes

--- a/src/core/ddsc/include/dds/dds.h
+++ b/src/core/ddsc/include/dds/dds.h
@@ -739,8 +739,22 @@ dds_set_listener(dds_entity_t entity, const dds_listener_t * listener);
  *
  * @retval >0
  *             A valid participant handle.
+ * @retval DDS_RETCODE_NOT_ALLOWED_BY_SECURITY
+ *             An invalid DDS Security configuration was specified (whether
+ *             that be missing or incorrect entries, expired certificates,
+ *             or anything else related to the security settings and
+ *             implementation).
+ * @retval DDS_RETCODE_PRECONDITION_NOT_MET
+ *             Some security properties specified in the QoS, but the Cyclone
+ *             build does not include support for DDS Security.
+ * @retval DDS_RETCODE_OUT_OF_RESOURCES
+ *             Some resource limit (maximum participants, memory, handles,
+ *             &c.) prevented creation of the participant.
  * @retval DDS_RETCODE_ERROR
- *             An internal error has occurred.
+ *             The "CYCLONEDDS_URI" environment variable lists non-existent
+ *             or invalid configuration files, or contains invalid embedded
+ *             configuration items; or an unspecified internal error has
+ *             occurred.
  */
 DDS_EXPORT dds_entity_t
 dds_create_participant(

--- a/src/core/ddsc/include/dds/dds.h
+++ b/src/core/ddsc/include/dds/dds.h
@@ -25,6 +25,7 @@
 #endif
 
 #include "dds/export.h"
+#include "dds/features.h"
 
 /**
  * Handle to an entity. A valid entity handle will always have a positive

--- a/src/core/ddsc/include/dds/ddsc/dds_public_qos.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_public_qos.h
@@ -23,6 +23,11 @@
 #include "dds/export.h"
 #include "dds/ddsc/dds_public_qosdefs.h"
 
+/* Whether or not the "property list" QoS setting is supported in this version.  If it is,
+   the "dds.sec." properties are treated specially, preventing the accidental creation of
+   an non-secure participant by an implementation built without support for DDS Security. */
+#define DDS_HAS_PROPERTY_LIST_QOS 1
+
 #if defined (__cplusplus)
 extern "C" {
 #endif

--- a/src/core/ddsi/include/dds/ddsi/ddsi_security_omg.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_security_omg.h
@@ -184,11 +184,12 @@ bool q_omg_proxy_participant_is_secure(const struct proxy_participant *proxypp);
  * @param[in] pp         The participant to check if alloweed by security.
  * #param[in] domain_id  The domain_id
  *
- * @returns bool
- * @retval true   Participant is allowed
- * @retval false  Participant is not allowed
+ * @returns dds_return_t
+ * @retval DDS_RETCODE_OK   Participant is allowed
+ * @retval DDS_RETCODE_NOT_ALLOWED_BY_SECURITY
+ *                          Participant is not allowed
  */
-bool q_omg_security_check_create_participant(struct participant *pp, uint32_t domain_id);
+dds_return_t q_omg_security_check_create_participant(struct participant *pp, uint32_t domain_id);
 
 void q_omg_security_participant_set_initialized(struct participant *pp);
 

--- a/src/core/ddsi/include/dds/ddsi/ddsi_xqos.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_xqos.h
@@ -322,7 +322,9 @@ DDS_EXPORT void ddsi_xqos_addtomsg (struct nn_xmsg *m, const dds_qos_t *xqos, ui
 DDS_EXPORT void ddsi_xqos_log (uint32_t cat, const struct ddsrt_log_cfg *logcfg, const dds_qos_t *xqos);
 DDS_EXPORT size_t ddsi_xqos_print (char * __restrict buf, size_t bufsize, const dds_qos_t *xqos);
 DDS_EXPORT dds_qos_t *ddsi_xqos_dup (const dds_qos_t *src);
-DDS_EXPORT bool ddsi_xqos_has_prop (const dds_qos_t *xqos, const char *pname, bool startswith, bool check_non_empty);
+DDS_EXPORT bool ddsi_xqos_has_prop_prefix (const dds_qos_t *xqos, const char *nameprefix);
+DDS_EXPORT bool ddsi_xqos_find_prop (const dds_qos_t *xqos, const char *name, const char **value);
+
 #ifdef DDSI_INCLUDE_SECURITY
 struct omg_security_configuration_type;
 DDS_EXPORT void ddsi_xqos_mergein_security_config (dds_qos_t *xqos, const struct omg_security_configuration_type *cfg);

--- a/src/core/ddsi/src/ddsi_plist.c
+++ b/src/core/ddsi/src/ddsi_plist.c
@@ -3179,16 +3179,30 @@ dds_qos_t * ddsi_xqos_dup (const dds_qos_t *src)
   return dst;
 }
 
-bool ddsi_xqos_has_prop (const dds_qos_t *xqos, const char *pname, bool startswith, bool check_non_empty)
+bool ddsi_xqos_has_prop_prefix (const dds_qos_t *xqos, const char *nameprefix)
 {
   if (!(xqos->present & QP_PROPERTY_LIST))
     return false;
+  const size_t len = strlen (nameprefix);
+  for (uint32_t i = 0; i < xqos->property.value.n; i++)
+  {
+    if (strncmp (xqos->property.value.props[i].name, nameprefix, len) == 0)
+      return true;
+  }
+  return false;
+}
 
-  for (uint32_t i = 0; i < xqos->property.value.n; i++) {
-    if (startswith && (strncmp(xqos->property.value.props[i].name, pname, strlen(pname)) == 0)) {
-      return !check_non_empty || strlen(xqos->property.value.props[i].value) != 0;
-    } else if (!startswith && (strcmp(xqos->property.value.props[i].name, pname) == 0)) {
-      return !check_non_empty || strlen(xqos->property.value.props[i].value) != 0;
+bool ddsi_xqos_find_prop (const dds_qos_t *xqos, const char *name, const char **value)
+{
+  if (!(xqos->present & QP_PROPERTY_LIST))
+    return false;
+  for (uint32_t i = 0; i < xqos->property.value.n; i++)
+  {
+    if (strcmp (xqos->property.value.props[i].name, name) == 0)
+    {
+      if (value)
+        *value = xqos->property.value.props[i].value;
+      return true;
     }
   }
   return false;

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -966,7 +966,7 @@ dds_return_t new_participant_guid (ddsi_guid_t *ppguid, struct ddsi_domaingv *gv
   {
     /* disallow creating a participant with a security configuration if there is support for security
        has been left out */
-    ret = DDS_RETCODE_NOT_ALLOWED_BY_SECURITY;
+    ret = DDS_RETCODE_PRECONDITION_NOT_MET;
     goto not_allowed;
   }
 #endif

--- a/src/features.h.in
+++ b/src/features.h.in
@@ -1,0 +1,24 @@
+/*
+ * Copyright(c) 2020 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#ifndef _DDS_PUBLIC_FEATURES_H_
+#define _DDS_PUBLIC_FEATURES_H_
+
+/* Whether or not support for DDS Security is included */
+#cmakedefine DDS_HAS_SECURITY @DDS_HAS_SECURITY@
+
+/* Whether or not support for the lifespan QoS is included */
+#cmakedefine DDS_HAS_LIFESPAN @DDS_HAS_LIFESPAN@
+
+/* Whether or not support for generating "deadline missed" events is included */
+#cmakedefine DDS_HAS_DEADLINE_MISSED @DDS_HAS_DEADLINE_MISSED@
+
+#endif


### PR DESCRIPTION
This PR adds a two key features (+ a test):

* Define a ``DDS_HAS_PROPERTY_LIST_QOS`` macro (as discussed in https://github.com/ros2/rmw_cyclonedds/pull/123) to allow users of Cyclone to conditionally include support for setting the QoS properties needed for configuring security. This'll allow, e.g., the RMW the layer to cover both master & security.
* Refuse to create a participant if some "dds.sec." properties are set but support security is not included in the build.
* Add a test to check the behaviour of the above. It relies on the CI doing builds with/without security included (we do both), but I don't see how it can be verified otherwise.

The diff's a bit bigger than strictly necessary merely for the above:

* Some of the property checking code was an over-parametrised mess where two simple functions do the trick. That's bad in general but even more so in the context of checking whether security options are set.
* ``new_participant_guid`` had grown unwieldy over time and which gave a memory leak (if a rare setting was enabled) a chance to hide. A big reason was the huge gob of code for creating the built-in endpoints. A bit of refactoring helps.