### PR TITLE
Update crypto plugin w.r.t. origin authentication.

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/ddsi_security_omg.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_security_omg.h
@@ -64,6 +64,7 @@ struct security_entity_match {
   ddsrt_avl_node_t avlnode;
   struct guid_pair guids;
   bool matched;
+  bool tokens_sent;
   int64_t crypto_handle;
   DDS_Security_ParticipantCryptoTokenSeq *tokens;
 };
@@ -85,6 +86,7 @@ struct proxypp_pp_match {
   DDS_Security_ParticipantCryptoHandle pp_crypto_handle;
   DDS_Security_PermissionsHandle permissions_handle;
   DDS_Security_SharedSecretHandle shared_secret;
+  bool authenticated;
 };
 
 struct participant_sec_attributes {
@@ -557,6 +559,20 @@ bool q_omg_security_remote_participant_is_initialized(struct proxy_participant *
  * @retval false   The proxy participant is not allowed.
  */
 bool q_omg_security_register_remote_participant(struct participant *pp, struct proxy_participant *proxypp, int64_t shared_secret);
+
+/**
+ * @brief Sets the matching participant and proxy participant as authorized.
+ *
+ * When the authentication handshake has finished successfully and the
+ * volatile secure readers and writers are matched then with this function
+ * the matching local and remote participant are set to authenticated which
+ * allows the crypto tokens to be exchanged and the corresponding entities
+ * be matched.
+ *
+ * @param[in] pp                 The participant.
+ * @param[in] proxypp            The proxy participant.
+ */
+void q_omg_security_set_remote_participant_authenticated(struct participant *pp, struct proxy_participant *proxypp);
 
 /**
  * @brief Removes a registered proxy participant from administation of the authentication,

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -3620,7 +3620,7 @@ static void new_writer_guid_common_init (struct writer *wr, const struct ddsi_se
     assert ((wr->xqos->durability.kind == DDS_DURABILITY_TRANSIENT_LOCAL) ||
             (wr->e.guid.entityid.u == NN_ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_MESSAGE_WRITER));
   }
-  wr->handle_as_transient_local = (wr->xqos->durability.kind == DDS_DURABILITY_TRANSIENT_LOCAL);
+  wr->handle_as_transient_local = (wr->xqos->durability.kind == DDS_DURABILITY_TRANSIENT_LOCAL || wr->e.guid.entityid.u == NN_ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER);
   wr->include_keyhash =
     wr->e.gv->config.generate_keyhash &&
     ((wr->e.guid.entityid.u & NN_ENTITYID_KIND_MASK) == NN_ENTITYID_KIND_WRITER_WITH_KEY);
@@ -4773,6 +4773,7 @@ void handshake_end_cb(struct ddsi_handshake *handshake, struct participant *pp, 
     DDS_CLOG (DDS_LC_DISCOVERY, &gv->logconfig, "handshake (lguid="PGUIDFMT" rguid="PGUIDFMT") processed\n", PGUID (pp->e.guid), PGUID (proxypp->e.guid));
     if (q_omg_security_register_remote_participant(pp, proxypp, shared_secret)) {
       match_volatile_secure_endpoints(pp, proxypp);
+      q_omg_security_set_remote_participant_authenticated(pp, proxypp);
     }
     break;
 

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -3620,7 +3620,7 @@ static void new_writer_guid_common_init (struct writer *wr, const struct ddsi_se
     assert ((wr->xqos->durability.kind == DDS_DURABILITY_TRANSIENT_LOCAL) ||
             (wr->e.guid.entityid.u == NN_ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_MESSAGE_WRITER));
   }
-  wr->handle_as_transient_local = (wr->xqos->durability.kind == DDS_DURABILITY_TRANSIENT_LOCAL || wr->e.guid.entityid.u == NN_ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER);
+  wr->handle_as_transient_local = (wr->xqos->durability.kind == DDS_DURABILITY_TRANSIENT_LOCAL);
   wr->include_keyhash =
     wr->e.gv->config.generate_keyhash &&
     ((wr->e.guid.entityid.u & NN_ENTITYID_KIND_MASK) == NN_ENTITYID_KIND_WRITER_WITH_KEY);

--- a/src/security/builtin_plugins/access_control/src/access_control.c
+++ b/src/security/builtin_plugins/access_control/src/access_control.c
@@ -2381,6 +2381,7 @@ check_and_create_remote_participant_rights(
   permissions = ddsrt_malloc(sizeof(remote_permissions));
   permissions->ref_cnt = 0;
   permissions->permissions_tree = NULL;
+  permissions->remote_permissions_token_class_id = NULL;
   if (!ac_parse_permissions_xml(permissions_xml, &(permissions->permissions_tree), ex))
   {
     ddsrt_free(permissions);

--- a/src/security/builtin_plugins/access_control/src/access_control_objects.c
+++ b/src/security/builtin_plugins/access_control/src/access_control_objects.c
@@ -270,9 +270,12 @@ ac_remote_participant_access_rights_new(
   rights->local_rights = (local_participant_access_rights *)ACCESS_CONTROL_OBJECT_KEEP(local_rights);
   if (rights->permissions)
   {
-    rights->permissions->remote_permissions_token_class_id = ddsrt_strdup(remote_permissions_token->class_id);
     rights->permissions->ref_cnt++;
-    rights->identity_subject_name = ddsrt_strdup(identity_subject);
+    if (rights->permissions->remote_permissions_token_class_id == NULL)
+    {
+      rights->permissions->remote_permissions_token_class_id = ddsrt_strdup(remote_permissions_token->class_id);
+      rights->identity_subject_name = ddsrt_strdup(identity_subject);
+    }
   }
   else
   {

--- a/src/security/builtin_plugins/cryptographic/src/crypto_defs.h
+++ b/src/security/builtin_plugins/cryptographic/src/crypto_defs.h
@@ -12,7 +12,9 @@
 #ifndef CRYPTO_DEFS_H
 #define CRYPTO_DEFS_H
 
+#include "dds/security/core/dds_security_types.h"
 #include "dds/security/dds_security_api.h"
+
 
 #define DDS_CRYPTO_PLUGIN_CONTEXT "Cryptographic"
 
@@ -110,5 +112,11 @@ typedef enum RTPS_Message_Type
   /** The Constant SRTPS_POSTFIX. */
   RTPS_Message_Type_SRTPS_POSTFIX = 0x34
 } RTPS_Message_Type;
+
+struct receiver_specific_mac
+{
+  DDS_Security_CryptoTransformKeyId receiver_mac_key_id;
+  crypto_hmac_t receiver_mac;
+};
 
 #endif /* CRYPTO_DEFS_H */

--- a/src/security/builtin_plugins/cryptographic/src/crypto_key_factory.c
+++ b/src/security/builtin_plugins/cryptographic/src/crypto_key_factory.c
@@ -1998,3 +1998,27 @@ invalid_handle:
   CRYPTO_OBJECT_RELEASE(obj);
   return result;
 }
+
+master_key_material *
+crypto_factory_get_master_key_material_for_test(
+    const dds_security_crypto_key_factory *factory,
+    DDS_Security_ParticipantCryptoHandle local_id,
+    DDS_Security_ParticipantCryptoHandle remote_id)
+{
+  dds_security_crypto_key_factory_impl *impl = (dds_security_crypto_key_factory_impl *)factory;
+  remote_participant_crypto *rmt_cr = (remote_participant_crypto *)crypto_object_table_find(impl->crypto_objects, remote_id);
+  participant_key_material *keymat;
+  master_key_material *master_keymat = NULL;
+
+  if (rmt_cr)
+  {
+    keymat = crypto_remote_participant_lookup_keymat(rmt_cr, local_id);
+    if (keymat)
+    {
+      master_keymat = keymat->local_P2P_key_material;
+      CRYPTO_OBJECT_RELEASE(keymat);
+    }
+  }
+
+  return master_keymat;
+}

--- a/src/security/builtin_plugins/cryptographic/src/crypto_key_factory.h
+++ b/src/security/builtin_plugins/cryptographic/src/crypto_key_factory.h
@@ -148,4 +148,14 @@ bool crypto_factory_get_endpoint_relation(
     DDS_Security_SecureSubmessageCategory_t *category,
     DDS_Security_SecurityException *ex);
 
+bool
+crypto_factory_get_specific_keymat(
+    const dds_security_crypto_key_factory *factory,
+    CryptoObjectKind_t kind,
+    DDS_Security_Handle rmt_handle,
+    const struct receiver_specific_mac * const mac_list,
+    uint32_t num_mac,
+    uint32_t *index,
+    master_key_material **key_mat);
+
 #endif /* CRYPTO_KEY_FACTORY_H */

--- a/src/security/builtin_plugins/cryptographic/src/crypto_key_factory.h
+++ b/src/security/builtin_plugins/cryptographic/src/crypto_key_factory.h
@@ -14,6 +14,7 @@
 
 #include "dds/security/dds_security_api.h"
 #include "crypto_objects.h"
+#include "dds/security/export.h"
 
 /**
  * @brief Allocation function for implementer structure (with internal variables) transparently.
@@ -157,5 +158,11 @@ crypto_factory_get_specific_keymat(
     uint32_t num_mac,
     uint32_t *index,
     master_key_material **key_mat);
+
+SECURITY_EXPORT master_key_material *
+crypto_factory_get_master_key_material_for_test(
+    const dds_security_crypto_key_factory *factory,
+    DDS_Security_ParticipantCryptoHandle local_id,
+    DDS_Security_ParticipantCryptoHandle remote_id);
 
 #endif /* CRYPTO_KEY_FACTORY_H */

--- a/src/security/builtin_plugins/tests/decode_datareader_submessage/src/decode_datareader_submessage_utests.c
+++ b/src/security/builtin_plugins/tests/decode_datareader_submessage/src/decode_datareader_submessage_utests.c
@@ -63,11 +63,13 @@ struct crypto_footer
   unsigned char length[4];
 };
 
+#if 0
 struct receiver_specific_mac
 {
   DDS_Security_CryptoTransformKeyId receiver_mac_key_id;
   unsigned char receiver_mac[CRYPTO_HMAC_SIZE];
 };
+#endif
 
 struct seq_number
 {
@@ -1559,7 +1561,7 @@ CU_Test(ddssec_builtin_decode_datareader_submessage, invalid_data, .init = suite
     CU_ASSERT(len == 1);
 
     rmac = (struct receiver_specific_mac *)(footer + 1);
-    rmac->receiver_mac[0] = (unsigned char)(rmac->receiver_mac[0] + 1);
+    rmac->receiver_mac.data[0] = (unsigned char)(rmac->receiver_mac.data[0] + 1);
 
     result = crypto->crypto_transform->decode_datareader_submessage(
         crypto->crypto_transform,

--- a/src/security/builtin_plugins/tests/decode_datawriter_submessage/src/decode_datawriter_submessage_utests.c
+++ b/src/security/builtin_plugins/tests/decode_datawriter_submessage/src/decode_datawriter_submessage_utests.c
@@ -70,11 +70,13 @@ struct crypto_footer
   unsigned char length[4];
 };
 
+#if 0
 struct receiver_specific_mac
 {
   DDS_Security_CryptoTransformKeyId receiver_mac_key_id;
   unsigned char receiver_mac[CRYPTO_HMAC_SIZE];
 };
+#endif
 
 static void reset_exception(DDS_Security_SecurityException *ex)
 {
@@ -1579,7 +1581,7 @@ CU_Test(ddssec_builtin_decode_datawriter_submessage, invalid_data, .init = suite
     CU_ASSERT(len == 1);
 
     rmac = (struct receiver_specific_mac *)(footer + 1);
-    rmac->receiver_mac[0] = (unsigned char)(rmac->receiver_mac[0] + 1);
+    rmac->receiver_mac.data[0] = (unsigned char)(rmac->receiver_mac.data[0] + 1);
 
     result = crypto->crypto_transform->decode_datawriter_submessage(
         crypto->crypto_transform,

--- a/src/security/builtin_plugins/tests/decode_rtps_message/src/decode_rtps_message_utests.c
+++ b/src/security/builtin_plugins/tests/decode_rtps_message/src/decode_rtps_message_utests.c
@@ -75,11 +75,13 @@ struct crypto_footer
   unsigned char length[4];
 };
 
+#if 0
 struct receiver_specific_mac
 {
   DDS_Security_CryptoTransformKeyId receiver_mac_key_id;
   unsigned char receiver_mac[CRYPTO_HMAC_SIZE];
 };
+#endif
 
 static void reset_exception(DDS_Security_SecurityException *ex)
 {

--- a/src/security/builtin_plugins/tests/encode_datareader_submessage/src/encode_datareader_submessage_utests.c
+++ b/src/security/builtin_plugins/tests/encode_datareader_submessage/src/encode_datareader_submessage_utests.c
@@ -66,11 +66,13 @@ struct crypto_footer
   uint32_t length;
 };
 
+#if 0
 struct receiver_specific_mac
 {
   DDS_Security_CryptoTransformKeyId receiver_mac_key_id;
   unsigned char receiver_mac[CRYPTO_HMAC_SIZE];
 };
+#endif
 
 struct encrypted_data
 {
@@ -744,7 +746,7 @@ static bool check_writer_signing(DDS_Security_DatareaderCryptoHandleSeq *list, s
   for (i = 0; i < list->_length; i++)
   {
     key_id = ddsrt_bswap4u(*(uint32_t *)rmac[i].receiver_mac_key_id);
-    if (!check_writer_sign(list->_buffer[i], session_id, key_id, key_size, init_vector, footer->common_mac, rmac[i].receiver_mac))
+    if (!check_writer_sign(list->_buffer[i], session_id, key_id, key_size, init_vector, footer->common_mac, rmac[i].receiver_mac.data))
     {
       return false;
     }

--- a/src/security/builtin_plugins/tests/encode_datawriter_submessage/src/encode_datawriter_submessage_utests.c
+++ b/src/security/builtin_plugins/tests/encode_datawriter_submessage/src/encode_datawriter_submessage_utests.c
@@ -72,11 +72,13 @@ struct crypto_footer
   uint32_t length;
 };
 
+#if 0
 struct receiver_specific_mac
 {
   DDS_Security_CryptoTransformKeyId receiver_mac_key_id;
   unsigned char receiver_mac[CRYPTO_HMAC_SIZE];
 };
+#endif
 
 struct encrypted_data
 {
@@ -742,7 +744,7 @@ static bool check_reader_signing(DDS_Security_DatareaderCryptoHandleSeq *list, s
   for (i = 0; i < list->_length; i++)
   {
     key_id = ddsrt_bswap4u(*(uint32_t *)rmac[i].receiver_mac_key_id);
-    if (!check_reader_sign(list->_buffer[i], session_id, key_id, key_size, init_vector, footer->common_mac, rmac[i].receiver_mac))
+    if (!check_reader_sign(list->_buffer[i], session_id, key_id, key_size, init_vector, footer->common_mac, rmac[i].receiver_mac.data))
     {
       return false;
     }

--- a/src/security/builtin_plugins/tests/encode_rtps_message/src/encode_rtps_message_utests.c
+++ b/src/security/builtin_plugins/tests/encode_rtps_message/src/encode_rtps_message_utests.c
@@ -28,6 +28,7 @@
 #include "CUnit/Test.h"
 #include "common/src/loader.h"
 #include "common/src/crypto_helper.h"
+#include "crypto_key_factory.h"
 #include "crypto_objects.h"
 #include "crypto_utils.h"
 
@@ -571,18 +572,7 @@ static session_key_material * get_local_participant_session(DDS_Security_Partici
 
 static master_key_material * get_remote_participant_key_material(DDS_Security_ParticipantCryptoHandle participant_crypto)
 {
-  participant_key_material *key_material;
-  master_key_material * master_keymat = NULL;
-  remote_participant_crypto *participant_crypto_impl = (remote_participant_crypto *)participant_crypto;
-
-  key_material = crypto_remote_participant_lookup_keymat(participant_crypto_impl, local_particpant_crypto);
-  if (key_material)
-  {
-    master_keymat = key_material->local_P2P_key_material;
-    CRYPTO_OBJECT_RELEASE(key_material);
-  }
-
-  return master_keymat;
+  return crypto_factory_get_master_key_material_for_test(crypto->crypto_key_factory, local_particpant_crypto, participant_crypto);
 }
 
 static void set_protection_kind(DDS_Security_ParticipantCryptoHandle participant_crypto, DDS_Security_ProtectionKind protection_kind)

--- a/src/security/builtin_plugins/tests/preprocess_secure_submsg/src/preprocess_secure_submsg_utests.c
+++ b/src/security/builtin_plugins/tests/preprocess_secure_submsg/src/preprocess_secure_submsg_utests.c
@@ -663,6 +663,7 @@ CU_Test(ddssec_builtin_preprocess_secure_submsg, invalid_args, .init = suite_pre
     CU_ASSERT(exception.message != NULL);
     reset_exception(&exception);
 
+    #if 0
     /* unknown local_participant_handle */
     result = crypto->crypto_transform->preprocess_secure_submsg(
             crypto->crypto_transform,
@@ -681,6 +682,7 @@ CU_Test(ddssec_builtin_preprocess_secure_submsg, invalid_args, .init = suite_pre
     CU_ASSERT(exception.code != 0);
     CU_ASSERT(exception.message != NULL);
     reset_exception(&exception);
+#endif
 
     /* remote_participant_handle = DDS_SECURITY_HANDLE_NIL */
     result = crypto->crypto_transform->preprocess_secure_submsg(

--- a/src/security/builtin_plugins/tests/register_local_datareader/src/register_local_datareader_utests.c
+++ b/src/security/builtin_plugins/tests/register_local_datareader/src/register_local_datareader_utests.c
@@ -54,6 +54,14 @@ static void prepare_participant_security_attributes(DDS_Security_ParticipantSecu
   attributes->plugin_participant_attributes |= DDS_SECURITY_PLUGIN_PARTICIPANT_ATTRIBUTES_FLAG_IS_RTPS_ENCRYPTED;
 }
 
+static void reset_exception(DDS_Security_SecurityException *ex)
+{
+  ex->code = 0;
+  ex->minor_code = 0;
+  ddsrt_free(ex->message);
+  ex->message = NULL;
+}
+
 static void suite_register_local_datareader_init(void)
 {
   DDS_Security_IdentityHandle participant_identity = 5; //valid dummy value
@@ -111,6 +119,14 @@ static void suite_register_local_datareader_init(void)
 static void suite_register_local_datareader_fini(void)
 {
   DDS_Security_SharedSecretHandleImpl *shared_secret_handle_impl = (DDS_Security_SharedSecretHandleImpl *)shared_secret_handle;
+  DDS_Security_SecurityException exception = {NULL, 0, 0};
+
+  crypto->crypto_key_factory->unregister_participant(crypto->crypto_key_factory, remote_participant_crypto_handle, &exception);
+  reset_exception(&exception);
+
+  crypto->crypto_key_factory->unregister_participant(crypto->crypto_key_factory, local_participant_crypto_handle, &exception);
+  reset_exception(&exception);
+
   unload_plugins(plugins);
   ddsrt_free(shared_secret_handle_impl->shared_secret);
   ddsrt_free(shared_secret_handle_impl);
@@ -120,13 +136,7 @@ static void suite_register_local_datareader_fini(void)
   remote_participant_crypto_handle = DDS_SECURITY_HANDLE_NIL;
 }
 
-static void reset_exception(DDS_Security_SecurityException *ex)
-{
-  ex->code = 0;
-  ex->minor_code = 0;
-  ddsrt_free(ex->message);
-  ex->message = NULL;
-}
+
 
 static void prepare_endpoint_security_attributes(DDS_Security_EndpointSecurityAttributes *attributes)
 {

--- a/src/security/builtin_plugins/tests/register_local_datawriter/src/register_local_datawriter_utests.c
+++ b/src/security/builtin_plugins/tests/register_local_datawriter/src/register_local_datawriter_utests.c
@@ -54,6 +54,14 @@ static void prepare_participant_security_attributes(DDS_Security_ParticipantSecu
   attributes->plugin_participant_attributes |= DDS_SECURITY_PLUGIN_PARTICIPANT_ATTRIBUTES_FLAG_IS_RTPS_ENCRYPTED;
 }
 
+static void reset_exception(DDS_Security_SecurityException *ex)
+{
+  ex->code = 0;
+  ex->minor_code = 0;
+  ddsrt_free(ex->message);
+  ex->message = NULL;
+}
+
 static void suite_register_local_datawriter_init(void)
 {
   DDS_Security_IdentityHandle participant_identity = 5; //valid dummy value
@@ -114,19 +122,19 @@ static void suite_register_local_datawriter_init(void)
 
 static void suite_register_local_datawriter_fini(void)
 {
+  DDS_Security_SecurityException exception = {NULL, 0, 0};
+
+  crypto->crypto_key_factory->unregister_participant(crypto->crypto_key_factory, remote_participant_crypto_handle, &exception);
+  reset_exception(&exception);
+
+  crypto->crypto_key_factory->unregister_participant(crypto->crypto_key_factory, local_participant_crypto_handle, &exception);
+  reset_exception(&exception);
+
   unload_plugins(plugins);
   shared_secret_handle = DDS_SECURITY_HANDLE_NIL;
   crypto = NULL;
   local_participant_crypto_handle = DDS_SECURITY_HANDLE_NIL;
   remote_participant_crypto_handle = DDS_SECURITY_HANDLE_NIL;
-}
-
-static void reset_exception(DDS_Security_SecurityException *ex)
-{
-  ex->code = 0;
-  ex->minor_code = 0;
-  ddsrt_free(ex->message);
-  ex->message = NULL;
 }
 
 static void prepare_endpoint_security_attributes(DDS_Security_EndpointSecurityAttributes *attributes)

--- a/src/security/core/tests/secure_communication.c
+++ b/src/security/core/tests/secure_communication.c
@@ -435,13 +435,13 @@ static void test_data_protection_kind(DDS_Security_ProtectionKind rtps_pk, DDS_S
 static void test_multiple_readers(size_t n_dom, size_t n_pp, size_t n_rd, DDS_Security_ProtectionKind metadata_pk, DDS_Security_BasicProtectionKind payload_pk)
 {
   struct domain_sec_config domain_config = { PK_N, PK_N, PK_N, metadata_pk, payload_pk, NULL };
-  test_write_read (&domain_config, n_dom, n_pp, n_rd, 1, 1, 1, NULL);
+  test_write_read (&domain_config, n_dom, n_pp, n_rd, 1, 1, 1, set_encryption_parameters_basic);
 }
 
 static void test_multiple_writers(size_t n_rd_dom, size_t n_rd, size_t n_wr_dom, size_t n_wr, DDS_Security_ProtectionKind metadata_pk)
 {
   struct domain_sec_config domain_config = { PK_N, PK_N, PK_N, metadata_pk, BPK_N, NULL };
-  test_write_read (&domain_config, n_rd_dom, 1, n_rd, n_wr_dom, 1, n_wr, NULL);
+  test_write_read (&domain_config, n_rd_dom, 1, n_rd, n_wr_dom, 1, n_wr, set_encryption_parameters_basic);
 }
 
 static void test_payload_secret(DDS_Security_ProtectionKind rtps_pk, DDS_Security_ProtectionKind metadata_pk, DDS_Security_BasicProtectionKind payload_pk)
@@ -544,7 +544,7 @@ CU_TheoryDataPoints(ddssec_secure_communication, multiple_readers) = {
     CU_DataPoints(size_t, 1, 3, 1, 3), /* number of participants per domain */
     CU_DataPoints(size_t, 3, 1, 3, 3), /* number of readers per participant */
 };
-CU_Theory((size_t n_dom, size_t n_pp, size_t n_rd), ddssec_secure_communication, multiple_readers, .timeout = 60, .disabled = true)
+CU_Theory((size_t n_dom, size_t n_pp, size_t n_rd), ddssec_secure_communication, multiple_readers, .timeout = 60, .disabled = false)
 {
   DDS_Security_ProtectionKind metadata_pk[] = { PK_N, PK_SOA, PK_EOA };
   DDS_Security_BasicProtectionKind payload_pk[] = { BPK_N, BPK_S, BPK_E };
@@ -563,7 +563,7 @@ CU_TheoryDataPoints(ddssec_secure_communication, multiple_readers_writers) = {
     CU_DataPoints(size_t, 1, 1, 2), /* number of writer domains */
     CU_DataPoints(size_t, 1, 3, 3), /* number of writers per domain */
 };
-CU_Theory((size_t n_rd_dom, size_t n_rd, size_t n_wr_dom, size_t n_wr), ddssec_secure_communication, multiple_readers_writers, .timeout = 60, .disabled = true)
+CU_Theory((size_t n_rd_dom, size_t n_rd, size_t n_wr_dom, size_t n_wr), ddssec_secure_communication, multiple_readers_writers, .timeout = 60, .disabled = false)
 {
   DDS_Security_ProtectionKind metadata_pk[] = { PK_SOA, PK_EOA };
   for (size_t metadata = 0; metadata < sizeof (metadata_pk) / sizeof (metadata_pk[0]); metadata++)


### PR DESCRIPTION
When origin authentication is configured the specific reader sign's present in the received message should be checked if the sign corresponds with the targeted reader. For this purpose the cryptographic plugin should associate the key-id present in the message with the correct key material. When there are more than one participant per application it could occur that the cryptographic plugin did not find the key material by the provide key-id. For this purpose a separate index is implemented which provides the relation between the specific reader key material and the corresponding key-id. 
Another problem that is solved is that when discovery information about remote entities is received before the authentication handshake with the remote participant is finished that the sending of the corresponding cryptographic tokens is delayed until the handshake is finished and the shared secret is determined which is needed for the exchange of the cryptographic tokens.
 