### PR TITLE
Stop threads doing handshake processing earlier

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/ddsi_handshake.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_handshake.h
@@ -169,6 +169,13 @@ struct ddsi_handshake * ddsi_handshake_find(struct participant *pp, struct proxy
 void ddsi_handshake_admin_init(struct ddsi_domaingv *gv);
 
 /**
+* @brief Stop handshake background processing.
+*
+* @param[in] gv         The global parameters
+*/
+void ddsi_handshake_admin_stop(struct ddsi_domaingv *gv);
+
+/**
  * @brief Deinitialze the handshake administration.
  *
  * @param[in] gv         The global parameters

--- a/src/core/ddsi/include/dds/ddsi/ddsi_security_omg.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_security_omg.h
@@ -1102,6 +1102,8 @@ dds_return_t q_omg_security_load( struct dds_security_context *security_context,
 
 void q_omg_security_init( struct ddsi_domaingv *gv );
 
+void q_omg_security_stop (struct ddsi_domaingv *gv);
+
 void q_omg_security_deinit( struct ddsi_domaingv *gv );
 
 bool q_omg_is_security_loaded(  struct dds_security_context *sc );
@@ -1394,10 +1396,6 @@ inline dds_return_t q_omg_security_load( UNUSED_ARG( struct dds_security_context
 {
   return DDS_RETCODE_ERROR;
 }
-
-inline void q_omg_security_init( UNUSED_ARG( struct dds_security_context *sc) ) {}
-
-inline void q_omg_security_deinit( UNUSED_ARG( struct dds_security_context *sc) ) {}
 
 inline bool q_omg_is_security_loaded(  UNUSED_ARG( struct dds_security_context *sc )) { return false; }
 

--- a/src/core/ddsi/src/ddsi_security_omg.c
+++ b/src/core/ddsi/src/ddsi_security_omg.c
@@ -623,6 +623,11 @@ static void release_plugins (dds_security_context *sc)
   sc->crypto_context = NULL;
 }
 
+void q_omg_security_stop (struct ddsi_domaingv *gv)
+{
+  ddsi_handshake_admin_stop(gv);
+}
+
 void q_omg_security_deinit (struct ddsi_domaingv *gv)
 {
   dds_security_context *sc = gv->security_context;

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -1518,12 +1518,12 @@ err_unicast_sockets:
   ddsrt_hh_free (gv->sertopics);
   ddsrt_mutex_destroy (&gv->sertopics_lock);
 #ifdef DDSI_INCLUDE_SECURITY
+  q_omg_security_stop (gv); // should be a no-op as it starts lazily
+  q_omg_security_deinit (gv);
   ddsi_xqos_fini (&gv->builtin_stateless_xqos_wr);
   ddsi_xqos_fini (&gv->builtin_stateless_xqos_rd);
   ddsi_xqos_fini (&gv->builtin_volatile_xqos_wr);
   ddsi_xqos_fini (&gv->builtin_volatile_xqos_rd);
-
-  q_omg_security_deinit (gv);
 #endif
   ddsi_xqos_fini (&gv->builtin_endpoint_xqos_wr);
   ddsi_xqos_fini (&gv->builtin_endpoint_xqos_rd);
@@ -1749,6 +1749,12 @@ void rtps_stop (struct ddsi_domaingv *gv)
     thread_state_asleep (ts1);
   }
 
+  /* Stop background (handshake) processing in security implementation,
+     do this only once we know no new events will be coming in. */
+#if DDSI_INCLUDE_SECURITY
+  q_omg_security_stop (gv);
+#endif
+
   /* Wait until all participants are really gone => by then we can be
      certain that no new GC requests will be added, short of what we
      do here */
@@ -1854,7 +1860,6 @@ void rtps_fini (struct ddsi_domaingv *gv)
   }
 
   ddsi_tkmap_free (gv->m_tkmap);
-
   entity_index_free (gv->entity_index);
   gv->entity_index = NULL;
   deleted_participants_admin_free (gv->deleted_participants);
@@ -1873,12 +1878,11 @@ void rtps_fini (struct ddsi_domaingv *gv)
   ddsrt_mutex_destroy (&gv->sertopics_lock);
 
 #ifdef DDSI_INCLUDE_SECURITY
+  q_omg_security_deinit (gv);
   ddsi_xqos_fini (&gv->builtin_stateless_xqos_wr);
   ddsi_xqos_fini (&gv->builtin_stateless_xqos_rd);
   ddsi_xqos_fini (&gv->builtin_volatile_xqos_wr);
   ddsi_xqos_fini (&gv->builtin_volatile_xqos_rd);
-
-  q_omg_security_deinit (gv);
 #endif
   ddsi_xqos_fini (&gv->builtin_endpoint_xqos_wr);
   ddsi_xqos_fini (&gv->builtin_endpoint_xqos_rd);


### PR DESCRIPTION
In particular before the state they depend on gets torn down.

Signed-off-by: Erik Boasson <eb@ilities.com>