### PR TITLE
Do not rewrite secure messages in retransmit queue

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/q_xmsg.h
+++ b/src/core/ddsi/include/dds/ddsi/q_xmsg.h
@@ -43,7 +43,8 @@ struct nn_xmsg_marker {
 enum nn_xmsg_kind {
   NN_XMSG_KIND_CONTROL,
   NN_XMSG_KIND_DATA,
-  NN_XMSG_KIND_DATA_REXMIT
+  NN_XMSG_KIND_DATA_REXMIT,
+  NN_XMSG_KIND_DATA_REXMIT_NOMERGE
 };
 
 /* XMSGPOOL */


### PR DESCRIPTION
Messages to be retransmitted spend some time on a transmit queue, and are subject to the rewriting of the destination information to reduce the number of outgoing copies.   -evidently, altering the message header does not sit well with encryption and/or authentication of messages.

The way the rewriting works is that the offset of the "reader entity id" in the DATA submessage is saved on message construction (the GUID prefix is at a fixed location), so that it can be read and possibly zero'd out later. The crypto transformations move the message around and it so happens that it can end up pointing to the key id in the encoded message.  Zeroing that one out leads to uninterpretable messages.

This commit adds a message/event kind to distinguish between retransmit that may and retransmit that may not be merged (and thus rewritten) and gets used when the crypto plugin is invoked to transform a message.

Signed-off-by: Erik Boasson <eb@ilities.com>