### PR TITLE
Do not assume string in algo binary property

### DIFF
--- a/src/security/builtin_plugins/authentication/src/authentication.c
+++ b/src/security/builtin_plugins/authentication/src/authentication.c
@@ -529,8 +529,10 @@ static bool str_octseq_equal (const char *str, const DDS_Security_OctetSeq *bins
   for (i = 0; str[i] && i < binstr->_length; i++)
     if ((unsigned char) str[i] != binstr->_buffer[i])
       return false;
-  /* allow zero-termination in binstr */
-  return (str[i] == 0 && (i == binstr->_length || binstr->_buffer[i] == 0));
+  /* allow zero-termination in binstr, but disallow anything other than a single \0 */
+  return (str[i] == 0 &&
+          (i == binstr->_length ||
+           (i+1 == binstr->_length && binstr->_buffer[i] == 0)));
 }
 
 static AuthenticationAlgoKind_t get_dsign_algo_from_octseq(const DDS_Security_OctetSeq *name)


### PR DESCRIPTION
Interpretation of the c.dsign_algo and c.kagree_algo properties must not
assume the binary property to be a null-terminated string.

Signed-off-by: Erik Boasson <eb@ilities.com>