### PR TITLE
Correct length of encrypted submessage body

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/ddsi_security_omg.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_security_omg.h
@@ -625,27 +625,6 @@ int64_t q_omg_security_get_remote_participant_handle(struct proxy_participant *p
 void q_omg_security_set_participant_crypto_tokens(struct participant *pp, struct proxy_participant *proxypp, const nn_dataholderseq_t *tokens);
 
 /**
- * @brief Set security information, depending on plist and proxy participant,
- * into the given proxy writer.
- *
- * @param[in] pwr      Proxy writer to set security info on.
- * @param[in] plist    Paramater list, possibly contains security info.
- */
-void set_proxy_writer_security_info(struct proxy_writer *pwr, const ddsi_plist_t *plist);
-
-/**
- * @brief Determine the security settings associated with the remote writer.
- *
- * From the security information contained in the parameter list from the remote writer
- * the corresponding security settings are determined and returned in the info parameter.
- *
- * @param[in] pwr       The remote writer.
- * @param[in] plist     The parameter list from the remote writer.
- * @param[out] info     The security settings associated with the remote writer.
- */
-void q_omg_get_proxy_writer_security_info(struct proxy_writer *pwr, const ddsi_plist_t *plist, nn_security_info_t *info);
-
-/**
  * @brief Check if the writer has the is_discovery_protected flag set
  *
  * @param[in] wr        The local writer.
@@ -740,27 +719,6 @@ void q_omg_security_deregister_remote_writer_match(const struct ddsi_domaingv *g
 void q_omg_security_set_remote_writer_crypto_tokens(struct reader *rd, const ddsi_guid_t *pwr_guid, const nn_dataholderseq_t *tokens);
 
 /**
- * @brief Set security information, depending on plist and proxy participant,
- * into the given proxy reader.
- *
- * @param[in] prd      Proxy reader to set security info on.
- * @param[in] plist    Paramater list, possibly contains security info.
- */
-void set_proxy_reader_security_info(struct proxy_reader *prd, const ddsi_plist_t *plist);
-
-/**
- * @brief Determine the security settings associated with the remote reader.
- *
- * From the security information contained in the parameter list from the remote reader
- * the corresponding security settings are determined and returned in the info parameter.
- *
- * @param[in] prd       The remote reader.
- * @param[in] plist     The parameter list from the remote reader.
- * @param[out] info     The security settings associated with the remote reader.
- */
-void q_omg_get_proxy_reader_security_info(struct proxy_reader *prd, const ddsi_plist_t *plist, nn_security_info_t *info);
-
-/**
  * @brief Check if the reader has the is_discovery_protected flag set
  *
  * @param[in] rd        The local reader.
@@ -796,6 +754,18 @@ bool q_omg_reader_is_submessage_protected(const struct reader *rd);
  * @retval false  Otherwise; relay_only is unspecified.
  */
 bool q_omg_security_check_remote_reader_permissions(const struct proxy_reader *prd, uint32_t domain_id, struct participant *pp, bool *relay_only);
+
+
+/**
+ * @brief Set security information, depending on plist and proxy participant,
+ * into the given proxy endpoint.
+ *
+ * @param[in] entity            The endpoint common attributes.
+ * @param[in] proxypp_sec_info  The security info of the proxy participant
+ * @param[in] plist             Paramater list which may contain security info.
+ * @param[in] info              The proxy endpoint security info to be set.
+ */
+void q_omg_get_proxy_endpoint_security_info(const struct entity_common *entity, nn_security_info_t *proxypp_sec_info, const ddsi_plist_t *plist, nn_security_info_t *info);
 
 /**
  * @brief Check it the local writer is allowed to communicate with the remote reader.

--- a/src/core/ddsi/include/dds/ddsi/q_entity.h
+++ b/src/core/ddsi/include/dds/ddsi/q_entity.h
@@ -455,9 +455,6 @@ struct proxy_writer {
   ddsi2direct_directread_cb_t ddsi2direct_cb;
   void *ddsi2direct_cbarg;
   struct lease *lease;
-#ifdef DDSI_INCLUDE_SECURITY
-  nn_security_info_t security_info;
-#endif
 };
 
 
@@ -473,9 +470,6 @@ struct proxy_reader {
 #endif
   ddsrt_avl_tree_t writers; /* matching LOCAL writers */
   filter_fn_t filter;
-#ifdef DDSI_INCLUDE_SECURITY
-  nn_security_info_t security_info;
-#endif
 };
 
 DDS_EXPORT extern const ddsrt_avl_treedef_t wr_readers_treedef;

--- a/src/core/ddsi/src/ddsi_security_omg.c
+++ b/src/core/ddsi/src/ddsi_security_omg.c
@@ -1926,7 +1926,7 @@ bool q_omg_security_check_remote_writer_permissions(const struct proxy_writer *p
     }
   }
 
-  if (SECURITY_INFO_IS_WRITE_PROTECTED(pwr->security_info))
+  if (SECURITY_INFO_IS_WRITE_PROTECTED(pwr->c.security_info))
   {
     DDS_Security_PermissionsHandle permissions_handle;
 
@@ -1937,7 +1937,7 @@ bool q_omg_security_check_remote_writer_permissions(const struct proxy_writer *p
     }
     else
     {
-      q_omg_shallow_copy_PublicationBuiltinTopicDataSecure(&publication_data, &pwr->e.guid, pwr->c.xqos, &pwr->security_info);
+      q_omg_shallow_copy_PublicationBuiltinTopicDataSecure(&publication_data, &pwr->e.guid, pwr->c.xqos, &pwr->c.security_info);
       ok = sc->access_control_context->check_remote_datawriter(sc->access_control_context, permissions_handle, (int)domain_id, &publication_data, &exception);
       q_omg_shallow_free_PublicationBuiltinTopicDataSecure(&publication_data);
       if (!ok)
@@ -2067,11 +2067,11 @@ bool q_omg_security_match_remote_writer_enabled(struct reader *rd, struct proxy_
    * q_omg_participant_allow_unauthenticated() returns FALSE there.
    */
   (void)q_omg_get_reader_security_info(rd, &info);
-  if (!SECURITY_INFO_COMPATIBLE(pwr->security_info, info, NN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_VALID))
+  if (!SECURITY_INFO_COMPATIBLE(pwr->c.security_info, info, NN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_VALID))
   {
     GVWARNING("match_remote_writer "PGUIDFMT" with reader "PGUIDFMT" security_attributes mismatch: 0x%08x.0x%08x - 0x%08x.0x%08x\n",
                 PGUID(pwr->e.guid), PGUID(rd->e.guid),
-                pwr->security_info.security_attributes, pwr->security_info.plugin_security_attributes,
+                pwr->c.security_info.security_attributes, pwr->c.security_info.plugin_security_attributes,
                 info.security_attributes, info.plugin_security_attributes);
     return false;
   }
@@ -2092,11 +2092,11 @@ bool q_omg_security_match_remote_writer_enabled(struct reader *rd, struct proxy_
    * the valid flag is 0. To be able to support these product, assume
    * that the attributes are the same. If there is actually a mismatch,
    * communication will fail at a later moment anyway. */
-  if (!SECURITY_ATTR_IS_VALID(pwr->security_info.security_attributes)) {
-    pwr->security_info.security_attributes = info.security_attributes;
+  if (!SECURITY_ATTR_IS_VALID(pwr->c.security_info.security_attributes)) {
+    pwr->c.security_info.security_attributes = info.security_attributes;
   }
-  if (!SECURITY_ATTR_IS_VALID(pwr->security_info.plugin_security_attributes)) {
-    pwr->security_info.plugin_security_attributes = info.plugin_security_attributes;
+  if (!SECURITY_ATTR_IS_VALID(pwr->c.security_info.plugin_security_attributes)) {
+    pwr->c.security_info.plugin_security_attributes = info.plugin_security_attributes;
   }
 
   return q_omg_security_register_remote_writer_match(pwr, rd, crypto_handle);
@@ -2148,7 +2148,7 @@ bool q_omg_security_check_remote_reader_permissions(const struct proxy_reader *p
     }
   }
 
-  if (SECURITY_INFO_IS_READ_PROTECTED(prd->security_info))
+  if (SECURITY_INFO_IS_READ_PROTECTED(prd->c.security_info))
   {
     DDS_Security_PermissionsHandle permissions_handle;
 
@@ -2162,7 +2162,7 @@ bool q_omg_security_check_remote_reader_permissions(const struct proxy_reader *p
       DDS_Security_SubscriptionBuiltinTopicDataSecure subscription_data;
       DDS_Security_boolean sec_relay_only;
 
-      q_omg_shallow_copy_SubscriptionBuiltinTopicDataSecure(&subscription_data, &prd->e.guid, prd->c.xqos, &prd->security_info);
+      q_omg_shallow_copy_SubscriptionBuiltinTopicDataSecure(&subscription_data, &prd->e.guid, prd->c.xqos, &prd->c.security_info);
       ok = sc->access_control_context->check_remote_datareader(sc->access_control_context, permissions_handle, (int)domain_id, &subscription_data, &sec_relay_only, &exception);
       q_omg_shallow_free_SubscriptionBuiltinTopicDataSecure(&subscription_data);
       if (ok)
@@ -2180,10 +2180,13 @@ bool q_omg_security_check_remote_reader_permissions(const struct proxy_reader *p
   return ok;
 }
 
-static void q_omg_get_proxy_endpoint_security_info(const struct entity_common *entity, nn_security_info_t *proxypp_sec_info, const ddsi_plist_t *plist, nn_security_info_t *info)
+void q_omg_get_proxy_endpoint_security_info(const struct entity_common *entity, nn_security_info_t *proxypp_sec_info, const ddsi_plist_t *plist, nn_security_info_t *info)
 {
   const bool proxypp_info_available =
     (proxypp_sec_info->security_attributes != 0 || proxypp_sec_info->plugin_security_attributes != 0);
+
+  info->security_attributes = 0;
+  info->plugin_security_attributes = 0;
 
   /*
    * If Security info is present, use that.
@@ -2251,34 +2254,6 @@ static void q_omg_get_proxy_endpoint_security_info(const struct entity_common *e
       NN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_VALID | NN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_PROTECTED;
     info->plugin_security_attributes = 0;
   }
-  else
-  {
-    info->security_attributes = 0;
-    info->plugin_security_attributes = 0;
-  }
-}
-
-void q_omg_get_proxy_reader_security_info(struct proxy_reader *prd, const ddsi_plist_t *plist, nn_security_info_t *info)
-{
-  q_omg_get_proxy_endpoint_security_info(&(prd->e), &(prd->c.proxypp->security_info), plist, info);
-}
-
-void set_proxy_reader_security_info(struct proxy_reader *prd, const ddsi_plist_t *plist)
-{
-  assert (prd);
-  q_omg_get_proxy_endpoint_security_info (&prd->e, &prd->c.proxypp->security_info, plist, &prd->c.security_info);
-}
-
-
-void q_omg_get_proxy_writer_security_info(struct proxy_writer *pwr, const ddsi_plist_t *plist, nn_security_info_t *info)
-{
-  q_omg_get_proxy_endpoint_security_info(&(pwr->e), &(pwr->c.proxypp->security_info), plist, info);
-}
-
-void set_proxy_writer_security_info(struct proxy_writer *pwr, const ddsi_plist_t *plist)
-{
-  assert (pwr);
-  q_omg_get_proxy_endpoint_security_info (&pwr->e, &pwr->c.proxypp->security_info, plist, &pwr->c.security_info);
 }
 
 void q_omg_security_deregister_remote_reader_match(const struct ddsi_domaingv *gv, const ddsi_guid_t *wr_guid, struct wr_prd_match *m)
@@ -2417,11 +2392,11 @@ bool q_omg_security_match_remote_reader_enabled(struct writer *wr, struct proxy_
    * q_omg_participant_allow_unauthenticated() returns FALSE there.
    */
   (void)q_omg_get_writer_security_info(wr, &info);
-  if (!SECURITY_INFO_COMPATIBLE(prd->security_info, info, NN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_VALID))
+  if (!SECURITY_INFO_COMPATIBLE(prd->c.security_info, info, NN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_VALID))
   {
     GVWARNING("match_remote_reader "PGUIDFMT" with writer "PGUIDFMT" security_attributes mismatch: 0x%08x.0x%08x - 0x%08x.0x%08x\n",
         PGUID(prd->e.guid), PGUID(wr->e.guid),
-        prd->security_info.security_attributes, prd->security_info.plugin_security_attributes,
+        prd->c.security_info.security_attributes, prd->c.security_info.plugin_security_attributes,
         info.security_attributes, info.plugin_security_attributes);
     return false;
   }
@@ -2442,11 +2417,11 @@ bool q_omg_security_match_remote_reader_enabled(struct writer *wr, struct proxy_
    * the valid flag is 0. To be able to support these product, assume
    * that the attributes are the same. If there is actually a mismatch,
    * communication will fail at a later moment anyway. */
-  if (!SECURITY_ATTR_IS_VALID(prd->security_info.security_attributes)) {
-    prd->security_info.security_attributes = info.security_attributes;
+  if (!SECURITY_ATTR_IS_VALID(prd->c.security_info.security_attributes)) {
+    prd->c.security_info.security_attributes = info.security_attributes;
   }
-  if (!SECURITY_ATTR_IS_VALID(prd->security_info.plugin_security_attributes)) {
-    prd->security_info.plugin_security_attributes = info.plugin_security_attributes;
+  if (!SECURITY_ATTR_IS_VALID(prd->c.security_info.plugin_security_attributes)) {
+    prd->c.security_info.plugin_security_attributes = info.plugin_security_attributes;
   }
 
   return q_omg_security_register_remote_reader_match(prd, wr, crypto_handle, relay_only);

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -4475,9 +4475,6 @@ dds_return_t delete_reader (struct ddsi_domaingv *gv, const struct ddsi_guid *gu
   GVLOGDISC ("delete_reader_guid(guid "PGUIDFMT") ...\n", PGUID (*guid));
   builtintopic_write (rd->e.gv->builtin_topic_interface, &rd->e, ddsrt_time_wallclock(), false);
   entidx_remove_reader_guid (gv->entity_index, rd);
-#ifdef DDSI_INCLUDE_SECURITY
-  q_omg_security_deregister_reader(rd);
-#endif
   gcreq_reader (rd);
   return 0;
 }
@@ -5369,8 +5366,7 @@ static int proxy_endpoint_common_init (struct entity_common *e, struct proxy_end
     memset (&c->group_guid, 0, sizeof (c->group_guid));
 
 #ifdef DDSI_INCLUDE_SECURITY
-  c->security_info.security_attributes = 0;
-  c->security_info.plugin_security_attributes = 0;
+  q_omg_get_proxy_endpoint_security_info(e, &proxypp->security_info, plist, &c->security_info);
 #endif
 
   if ((ret = ref_proxy_participant (proxypp, c)) != DDS_RETCODE_OK)
@@ -5515,11 +5511,6 @@ int new_proxy_writer (struct ddsi_domaingv *gv, const struct ddsi_guid *ppguid, 
   pwr->evq = evq;
   pwr->ddsi2direct_cb = 0;
   pwr->ddsi2direct_cbarg = 0;
-
-#ifdef DDSI_INCLUDE_SECURITY
-  set_proxy_writer_security_info(pwr, plist);
-  q_omg_get_proxy_writer_security_info(pwr, plist, &(pwr->security_info));
-#endif
 
   local_reader_ary_init (&pwr->rdary);
 
@@ -5798,14 +5789,9 @@ int new_proxy_reader (struct ddsi_domaingv *gv, const struct ddsi_guid *ppguid, 
 #endif
   prd->is_fict_trans_reader = 0;
 
-#ifdef DDSI_INCLUDE_SECURITY
-  set_proxy_reader_security_info(prd, plist);
-#endif
-
   ddsrt_avl_init (&prd_writers_treedef, &prd->writers);
 
 #ifdef DDSI_INCLUDE_SECURITY
-  q_omg_get_proxy_reader_security_info(prd, plist, &(prd->security_info));
   if (prd->e.guid.entityid.u == NN_ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_READER)
     prd->filter = volatile_secure_data_filter;
   else

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -4052,9 +4052,7 @@ dds_return_t delete_writer_nolinger (struct ddsi_domaingv *gv, const struct ddsi
     return DDS_RETCODE_BAD_PARAMETER;
   }
   GVLOGDISC ("delete_writer_nolinger(guid "PGUIDFMT") ...\n", PGUID (*guid));
-#ifdef DDSI_INCLUDE_SECURITY
-  q_omg_security_deregister_writer(wr);
-#endif
+
   ddsrt_mutex_lock (&wr->e.lock);
   delete_writer_nolinger_locked (wr);
   ddsrt_mutex_unlock (&wr->e.lock);


### PR DESCRIPTION
When a sub-message is encrypted the length of the resulting sec_body sub-message is set to 4 bytes higher than the actual encrypted payload. Although this does not provide a problem because the length field octet sequence is correct it is better to correct this.
Further for the proxy reader and proxy writer the security_info element present in the entity common is used.