### PR TITLE
Remove temporally stored crypto handles and tokens after entities are…

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/ddsi_domaingv.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_domaingv.h
@@ -329,7 +329,6 @@ struct ddsi_domaingv {
   /* security globals */
 #ifdef DDSI_INCLUDE_SECURITY
   struct dds_security_context *security_context;
-  struct dds_security_match_index *security_matches;
   struct ddsi_hsadmin *hsadmin;
 #endif
 

--- a/src/core/ddsi/include/dds/ddsi/ddsi_security_omg.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_security_omg.h
@@ -55,24 +55,10 @@ typedef struct nn_msg_sec_info {
   int64_t dst_pp_handle;
 } nn_msg_sec_info_t;
 
-struct guid_pair {
-  ddsi_guid_t src;
-  ddsi_guid_t dst;
-};
 
-struct security_entity_match {
-  ddsrt_avl_node_t avlnode;
-  struct guid_pair guids;
-  bool matched;
-  bool tokens_sent;
-  int64_t crypto_handle;
-  DDS_Security_ParticipantCryptoTokenSeq *tokens;
-};
 
-struct dds_security_match_index {
-  ddsrt_mutex_t lock;
-  ddsrt_avl_tree_t matches;
-};
+
+
 
 struct pp_proxypp_match {
   ddsrt_avl_node_t avlnode;
@@ -740,6 +726,15 @@ void q_omg_security_deregister_remote_writer_match(const struct ddsi_domaingv *g
 void q_omg_security_set_remote_writer_crypto_tokens(struct reader *rd, const ddsi_guid_t *pwr_guid, const nn_dataholderseq_t *tokens);
 
 /**
+ * @brief Release all the security resources associated with the remote writer.
+ *
+ * Cleanup security resource associated with the remote writer.
+ *
+ * @param[in] pwr       The remote writer.
+ */
+void q_omg_security_deregister_remote_writer(const struct proxy_writer *pwr);
+
+/**
  * @brief Set security information, depending on plist and proxy participant,
  * into the given proxy reader.
  *
@@ -849,6 +844,15 @@ void q_omg_security_deregister_remote_reader_match(const struct ddsi_domaingv *g
  * @param[in] tokens    The crypto token received from the remote reader for the writer.
  */
 void q_omg_security_set_remote_reader_crypto_tokens(struct writer *wr, const ddsi_guid_t *prd_guid, const nn_dataholderseq_t *tokens);
+
+/**
+ * @brief Release all the security resources associated with the remote reader.
+ *
+ * Cleanup security resource associated with the remote reader.
+ *
+ * @param[in] prd       The remote reader.
+ */
+void q_omg_security_deregister_remote_reader(const struct proxy_reader *prd);
 
 /**
  * @brief Encode RTPS message.

--- a/src/core/ddsi/include/dds/ddsi/ddsi_security_omg.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_security_omg.h
@@ -1108,7 +1108,9 @@ void q_omg_security_init( struct ddsi_domaingv *gv );
 
 void q_omg_security_stop (struct ddsi_domaingv *gv);
 
-void q_omg_security_deinit( struct ddsi_domaingv *gv );
+void q_omg_security_deinit (struct dds_security_context *sc );
+
+void q_omg_security_free (struct ddsi_domaingv *gv);
 
 bool q_omg_is_security_loaded(  struct dds_security_context *sc );
 

--- a/src/core/ddsi/src/ddsi_security_omg.c
+++ b/src/core/ddsi/src/ddsi_security_omg.c
@@ -415,20 +415,6 @@ static void pending_match_expiry_cb(struct xevent *xev, void *varg, ddsrt_mtime_
   ddsrt_mutex_unlock(&index->lock);
 }
 
-static void inc_guid(ddsi_guid_t *guid)
-{
-  guid->entityid.u++;
-  if (guid->entityid.u == 0)
-  {
-    for (int i = 2; i >= 0; i++)
-    {
-      guid->prefix.u[i]++;
-      if (guid->prefix.u[i] != 0)
-        break;
-    }
-  }
-}
-
 static void clear_pending_matches_by_local_guid(dds_security_context *sc, struct pending_match_index *index, const ddsi_guid_t *local_guid)
 {
   struct pending_match *match;
@@ -443,8 +429,7 @@ static void clear_pending_matches_by_local_guid(dds_security_context *sc, struct
       ddsrt_avl_delete(&pending_match_index_treedef, &index->pending_matches, match);
       if (match->expiry.v != DDS_NEVER)
         ddsrt_fibheap_delete(&pending_match_expiry_fhdef, &index->expiry_timers, match);
-      inc_guid(&match->guids.remote_guid);
-      next = ddsrt_avl_lookup_succ_eq(&pending_match_index_treedef, &index->pending_matches, &match->guids);
+      next = ddsrt_avl_lookup_succ(&pending_match_index_treedef, &index->pending_matches, &match->guids);
       unregister_and_free_pending_match(sc, match);
     }
     match = next;

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -5649,6 +5649,9 @@ static void gc_delete_proxy_writer (struct gcreq *gcreq)
   local_reader_ary_fini (&pwr->rdary);
   if (pwr->c.xqos->liveliness.lease_duration != DDS_INFINITY)
     lease_free (pwr->lease);
+#ifdef DDSI_INCLUDE_SECURITY
+  q_omg_security_deregister_remote_writer(pwr);
+#endif
   proxy_endpoint_common_fini (&pwr->e, &pwr->c);
   nn_defrag_free (pwr->defrag);
   nn_reorder_free (pwr->reorder);
@@ -5885,6 +5888,9 @@ static void gc_delete_proxy_reader (struct gcreq *gcreq)
     writer_drop_connection (&m->wr_guid, prd);
     free_prd_wr_match (m);
   }
+#ifdef DDSI_INCLUDE_SECURITY
+  q_omg_security_deregister_remote_reader(prd);
+#endif
   proxy_endpoint_common_fini (&prd->e, &prd->c);
   ddsrt_free (prd);
 }

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -1199,8 +1199,6 @@ int rtps_init (struct ddsi_domaingv *gv)
    * the entities (see DDS Security spec chapter 8.8.8.1). */
   add_property_to_xqos(&gv->builtin_volatile_xqos_rd, "dds.sec.builtin_endpoint_name", "BuiltinParticipantVolatileMessageSecureReader");
   add_property_to_xqos(&gv->builtin_volatile_xqos_wr, "dds.sec.builtin_endpoint_name", "BuiltinParticipantVolatileMessageSecureWriter");
-
-//  q_omg_security_init(gv);
 #endif
 
   ddsrt_mutex_init (&gv->sertopics_lock);

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -1200,7 +1200,7 @@ int rtps_init (struct ddsi_domaingv *gv)
   add_property_to_xqos(&gv->builtin_volatile_xqos_rd, "dds.sec.builtin_endpoint_name", "BuiltinParticipantVolatileMessageSecureReader");
   add_property_to_xqos(&gv->builtin_volatile_xqos_wr, "dds.sec.builtin_endpoint_name", "BuiltinParticipantVolatileMessageSecureWriter");
 
-  q_omg_security_init(gv);
+//  q_omg_security_init(gv);
 #endif
 
   ddsrt_mutex_init (&gv->sertopics_lock);
@@ -1470,6 +1470,10 @@ int rtps_init (struct ddsi_domaingv *gv)
 #endif
   );
 
+#ifdef DDSI_INCLUDE_SECURITY
+  q_omg_security_init(gv);
+#endif
+
   gv->as_disc = new_addrset ();
   if (gv->config.allowMulticast & AMC_SPDP)
     add_to_addrset (gv, gv->as_disc, &gv->loc_spdp_mc);
@@ -1559,7 +1563,8 @@ err_unicast_sockets:
   ddsrt_mutex_destroy (&gv->sertopics_lock);
 #ifdef DDSI_INCLUDE_SECURITY
   q_omg_security_stop (gv); // should be a no-op as it starts lazily
-  q_omg_security_deinit (gv);
+  q_omg_security_deinit(gv->security_context);
+  q_omg_security_free (gv);
   ddsi_xqos_fini (&gv->builtin_stateless_xqos_wr);
   ddsi_xqos_fini (&gv->builtin_stateless_xqos_rd);
   ddsi_xqos_fini (&gv->builtin_volatile_xqos_wr);
@@ -1835,6 +1840,10 @@ void rtps_fini (struct ddsi_domaingv *gv)
   nn_dqueue_free (gv->user_dqueue);
 #endif
 
+#ifdef DDSI_INCLUDE_SECURITY
+  q_omg_security_deinit (gv->security_context);
+#endif
+
   xeventq_free (gv->xevents);
 
   if (gv->config.xpack_send_async)
@@ -1918,7 +1927,7 @@ void rtps_fini (struct ddsi_domaingv *gv)
   ddsrt_mutex_destroy (&gv->sertopics_lock);
 
 #ifdef DDSI_INCLUDE_SECURITY
-  q_omg_security_deinit (gv);
+  q_omg_security_free (gv);
   ddsi_xqos_fini (&gv->builtin_stateless_xqos_wr);
   ddsi_xqos_fini (&gv->builtin_stateless_xqos_rd);
   ddsi_xqos_fini (&gv->builtin_volatile_xqos_wr);


### PR DESCRIPTION
Before local and remote entities can be matched the entities have to be registered which the cryptographic plugin which returns a corresponding handle and the corresponding cryptographic tokens have to be received from the remote entity. It can be that the cryptographic tokens have been received from the remote entity before the corresponding discovery information arrives in that case the received tokens must be cached. At moment the match is made either when receiving the token or the discovery information the temporally cached security information should be released.