### PR TITLE
Prevent time-out in handshake

### DIFF
--- a/src/core/ddsi/src/ddsi_handshake.c
+++ b/src/core/ddsi/src/ddsi_handshake.c
@@ -91,7 +91,6 @@ struct ddsi_handshake
   DDS_Security_AuthRequestMessageToken *remote_auth_request_token;
   DDS_Security_OctetSeq pdata;
   int64_t shared_secret;
-  int handled_handshake_message;
 };
 
 struct ddsi_hsadmin {
@@ -1139,7 +1138,6 @@ void ddsi_handshake_handle_message(struct ddsi_handshake *handshake, const struc
     DDS_Security_DataHolder_deinit(&handshake->handshake_message_in_token);
     q_omg_security_dataholder_copyout(&handshake->handshake_message_in_token, &msg->message_data.tags[0]);
     memcpy(&handshake->handshake_message_in_id, &msg->message_identity, sizeof(handshake->handshake_message_in_id));
-    handshake->handled_handshake_message = 0;
     dds_security_fsm_dispatch(handshake->fsm, event, false);
     ddsrt_mutex_unlock(&handshake->lock);
   }

--- a/src/core/ddsi/src/ddsi_handshake.c
+++ b/src/core/ddsi/src/ddsi_handshake.c
@@ -553,7 +553,15 @@ static void func_validate_remote_identity(struct dds_security_fsm *fsm, void *ar
    * to be send.
    */
   if (handshake->local_auth_request_token.class_id && strlen(handshake->local_auth_request_token.class_id) != 0)
+  {
+    /* A short sleep to give the remote node some time for matching the
+       BuiltinParticipantStatelessMessageWriter, so that it won't drop the
+       sample we're sending (that would result in a time-out and the
+       handshake taking 1s longer than required) */
+    dds_sleepfor (DDS_MSECS(10));
+    HSTRACE("FSM: validate_remote_identity: send_handshake_message AUTH_REQUEST\n");
     (void)send_handshake_message(handshake, &handshake->local_auth_request_token, pp, proxypp, 1);
+  }
 
 validation_failed:
 ident_token_missing:


### PR DESCRIPTION
The security handshake is started when a node receives an SPDP message. The SPDP receiver will reply with an SPDP, followed by a `dds.sec.auth_request`. Because the initial SPDP sender will receive the `auth_request` immediately after (or even before) the SPDP reply message, that node may not have finished (or not even started) matching the remote writers and therefore it drops the `auth_request` message. This results in a time-out in the handshake process, and the `auth_request` has to be re-send. To avoid this, a short (rather arbitrarily chosen, based on local testing) sleep is introduced before the `auth_request` message is sent.
