### PR TITLE
Fix plist topics mishap

### DIFF
--- a/src/core/ddsi/src/q_ddsi_discovery.c
+++ b/src/core/ddsi/src/q_ddsi_discovery.c
@@ -1534,6 +1534,13 @@ int builtins_dqueue_handler (const struct nn_rsample_info *sampleinfo, const str
                PGUID (srcguid), sampleinfo->seq);
     goto done_upd_deliv;
   }
+  if (d == NULL)
+  {
+    GVLOG (DDS_LC_DISCOVERY | DDS_LC_WARNING, "data(builtin, vendor %u.%u): "PGUIDFMT" #%"PRId64": deserialization failed\n",
+           sampleinfo->rst->vendor.id[0], sampleinfo->rst->vendor.id[1],
+           PGUID (srcguid), sampleinfo->seq);
+    goto done_upd_deliv;
+  }
 
   d->timestamp = (sampleinfo->timestamp.v != DDSRT_WCTIME_INVALID.v) ? sampleinfo->timestamp : ddsrt_time_wallclock ();
   d->statusinfo = statusinfo;

--- a/src/core/ddsi/src/q_ddsi_discovery.c
+++ b/src/core/ddsi/src/q_ddsi_discovery.c
@@ -638,16 +638,12 @@ static int handle_SPDP_alive (const struct receiver_state *rst, seqno_t seq, dds
     }
   }
 
-  const bool is_secure = (datap->builtin_endpoint_set & NN_DISC_BUILTIN_ENDPOINT_PARTICIPANT_SECURE_ANNOUNCER) != 0;
+  const bool is_secure = ((datap->builtin_endpoint_set & NN_DISC_BUILTIN_ENDPOINT_PARTICIPANT_SECURE_ANNOUNCER) != 0 &&
+                          (datap->present & PP_IDENTITY_TOKEN));
   /* Make sure we don't create any security builtin endpoint when it's considered unsecure. */
   if (!is_secure)
     builtin_endpoint_set &= NN_BES_MASK_NON_SECURITY;
   GVLOGDISC ("SPDP ST0 "PGUIDFMT" bes %x%s NEW", PGUID (datap->participant_guid), builtin_endpoint_set, is_secure ? " (secure)" : "");
-  if (is_secure && !(datap->present & PP_IDENTITY_TOKEN))
-  {
-    GVLOGDISC (" identity token missing\n");
-    return 0;
-  }
 
   if (datap->present & PP_PARTICIPANT_LEASE_DURATION)
   {

--- a/src/security/core/CMakeLists.txt
+++ b/src/security/core/CMakeLists.txt
@@ -45,7 +45,7 @@ target_include_directories(security_core
         "$<BUILD_INTERFACE:$<TARGET_PROPERTY:ddsc,INTERFACE_INCLUDE_DIRECTORIES>>"
 )
 
-if(BUILD_TESTING)
+if(BUILD_TESTING AND BUILD_IDLC)
   add_subdirectory(tests)
 endif()
 


### PR DESCRIPTION
This PR fixes some issues with the new discovery data ("plist" topics) discovered on interoperating with some other DDS implementations:

* The interpretation of a keyhash as if it were a valid sample was wrong in various ways: inconsistent endianness, incorrect encoding identifier and a missing sentinel.  As Cyclone follows the spec and always provides a well-formed payload, the problem only surfaces when interoperating with implementations that expect the recipient to make do with a keyhash.
* Various paths failed to check for failure causing potential null pointer dereferences.
* There exist implementations that advertise security-related built-endpoints regardless of whether the participant has security configured.  Therefore, the test whether security is enabled for the participant cannot simply be the presence of such an endpoint, because the absence of an IDENTITY_TOKEN in the data is then considered an error. This PR simply changes the check to requiring the presence of the endpoint and the presence of the IDENTITY_TOKEN.

Mea culpa.