### PR TITLE
Using GUIDs in the API

### DIFF
--- a/src/core/ddsc/include/dds/dds.h
+++ b/src/core/ddsc/include/dds/dds.h
@@ -186,17 +186,21 @@ typedef struct dds_builtintopic_guid
 }
 dds_builtintopic_guid_t;
 
+/* "dds_builtintopic_guid_t" is a bit of a weird name for what everyone just calls a GUID,
+   so let us try and switch to using the more logical one */
+typedef struct dds_builtintopic_guid dds_guid_t;
+
 typedef struct dds_builtintopic_participant
 {
-  dds_builtintopic_guid_t key;
+  dds_guid_t key;
   dds_qos_t *qos;
 }
 dds_builtintopic_participant_t;
 
 typedef struct dds_builtintopic_endpoint
 {
-  dds_builtintopic_guid_t key;
-  dds_builtintopic_guid_t participant_key;
+  dds_guid_t key;
+  dds_guid_t participant_key;
   dds_instance_handle_t participant_instance_handle;
   char *topic_name;
   char *type_name;

--- a/src/core/ddsc/include/dds/dds.h
+++ b/src/core/ddsc/include/dds/dds.h
@@ -418,6 +418,26 @@ dds_get_mask(dds_entity_t condition, uint32_t *mask);
 DDS_EXPORT dds_return_t
 dds_get_instance_handle(dds_entity_t entity, dds_instance_handle_t *ihdl);
 
+/**
+ * @brief Returns the GUID that represents the entity in the network,
+ * and therefore only supports participants, readers and writers.
+ *
+ * @param[in]   entity  Entity of which to get the instance handle.
+ * @param[out]  guid    Where to store the GUID.
+ *
+ * @returns A dds_return_t indicating success or failure.
+ *
+ * @retval DDS_RETCODE_OK
+ *             Success.
+ * @retval DDS_RETCODE_ILLEGAL_OPERATION
+ *             The operation is invoked on an inappropriate object.
+ * @retval DDS_RETCODE_ERROR
+ *             An internal error has occurred.
+ */
+/* TODO: Check list of return codes is complete. */
+DDS_EXPORT dds_return_t
+dds_get_guid (dds_entity_t entity, dds_guid_t *guid);
+
 /*
   All entities have a set of "status conditions" (following the DCPS
   spec), read peeks, take reads & resets (analogously to read & take

--- a/src/core/ddsc/src/dds_serdata_builtintopic.c
+++ b/src/core/ddsc/src/dds_serdata_builtintopic.c
@@ -175,7 +175,7 @@ static struct ddsi_serdata *serdata_builtin_to_topicless (const struct ddsi_serd
   return ddsi_serdata_ref (serdata_common);
 }
 
-static void convkey (dds_builtintopic_guid_t *key, const ddsi_guid_t *guid)
+static void convkey (dds_guid_t *key, const ddsi_guid_t *guid)
 {
   ddsi_guid_t tmp;
   tmp = nn_hton_guid (*guid);

--- a/src/core/ddsc/tests/entity_api.c
+++ b/src/core/ddsc/tests/entity_api.c
@@ -255,6 +255,28 @@ CU_Test(ddsc_entity, status, .init = create_entity, .fini = delete_entity)
     CU_ASSERT_EQUAL_FATAL(status1, DDS_RETCODE_OK);
 }
 
+CU_Test(ddsc_entity, guid, .init = create_entity, .fini = delete_entity)
+{
+    dds_return_t status;
+    dds_guid_t guid, zero;
+    memset(&zero, 0, sizeof(zero));
+
+    /* Don't check actual handle contents. That's a job
+     * for the specific entity children, not for the generic part. */
+
+    /* Check getting Handle with bad parameters. */
+    status = dds_get_guid (0, NULL);
+    CU_ASSERT_EQUAL_FATAL(status, DDS_RETCODE_BAD_PARAMETER);
+    status = dds_get_guid (entity, NULL);
+    CU_ASSERT_EQUAL_FATAL(status, DDS_RETCODE_BAD_PARAMETER);
+    status = dds_get_guid (0, &guid);
+    CU_ASSERT_EQUAL_FATAL(status, DDS_RETCODE_BAD_PARAMETER);
+
+    /* Get Instance Handle, which should not be 0 for a participant. */
+    status = dds_get_guid (entity, &guid);
+    CU_ASSERT_EQUAL_FATAL(status, DDS_RETCODE_OK);
+    CU_ASSERT_FATAL(memcmp(&guid, &zero, sizeof(guid)) != 0);
+}
 
 CU_Test(ddsc_entity, instance_handle, .init = create_entity, .fini = delete_entity)
 {

--- a/src/tools/ddsls/ddsls.c
+++ b/src/tools/ddsls/ddsls.c
@@ -385,7 +385,7 @@ static void qp_qos (const dds_qos_t *q, FILE *fp)
   qp_group_data (q, fp);
 }
 
-static void print_key(FILE *fp, const char *label, const dds_builtintopic_guid_t *key)
+static void print_key(FILE *fp, const char *label, const dds_guid_t *key)
 {
   fprintf(fp, "%s", label);
   for(size_t j = 0; j < sizeof (key->v); j++) {

--- a/src/tools/ddsperf/ddsperf.c
+++ b/src/tools/ddsperf/ddsperf.c
@@ -283,7 +283,7 @@ struct ppant {
   ddsrt_avl_node_t avlnode;     /* embedded AVL node for handle index */
   ddsrt_fibheap_node_t fhnode;  /* prio queue for timeout handling */
   dds_instance_handle_t handle; /* participant instance handle */
-  dds_builtintopic_guid_t guid; /* participant GUID */
+  dds_guid_t guid;              /* participant GUID */
   char *hostname;               /* hostname is taken from user_data QoS */
   uint32_t pid;                 /* pid is also taken from user_data QoS */
   dds_time_t tdisc;             /* time at which it was discovered */
@@ -357,7 +357,7 @@ static void error3 (const char *fmt, ...)
   verrorx (3, fmt, ap);
 }
 
-static char *make_guidstr (struct guidstr *buf, const dds_builtintopic_guid_t *guid)
+static char *make_guidstr (struct guidstr *buf, const dds_guid_t *guid)
 {
   snprintf (buf->str, sizeof (buf->str), "%02x%02x%02x%02x_%02x%02x%02x%02x_%02x%02x%02x%02x_%02x%02x%02x%02x",
             guid->v[0], guid->v[1], guid->v[2], guid->v[3],


### PR DESCRIPTION
Adds ``dds_guid_t`` as a less confusing alias for ``dds_builtintopic_guid_t``. It is alias to retain backwards compatibility. All uses in the sources of Cyclone have been updated.

Adds ``dds_get_guid`` to retrieve the GUID of an participant, reader or writer (the only entities visible in the discovery). This is *much* more convenient (and more efficient) than something like:
```
dds_entity_t x = dds_create_reader(h, matching_builtin_topic, NULL, NULL);
dds_sample_info_t si;
void *raw = NULL;
dds_instance_handle_t ih;
dds_get_instance_handle(h, &ih);
int32_t n;
dds_read_instance(x, &raw, &si, 1, 1, ih);
(e.g. dds_builtintopic_participant_t *)s = raw;
guid = &s->key;
dds_return_loan(x, &raw, 1);
dds_delete(x);
```