### PR TITLE
Support docker build for cyclonedds

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# It is assumed that this script is called from the root of the project
+WORKSPACE=$(pwd)
+echo "WORKSPACE is $WORKSPACE"
+
+CYCLONEDDS_INSTALL_PREFIX=$WORKSPACE/build/install/
+
+rm -rf build/
+mkdir build
+cd build
+cmake -DCMAKE_INSTALL_PREFIX=$CYCLONEDDS_INSTALL_PREFIX -DBUILD_IDLC=ON ..
+cmake --build .
+cmake --build . --target install

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,9 +6,46 @@ WORKSPACE=$(pwd)
 echo "WORKSPACE is $WORKSPACE"
 
 CYCLONEDDS_INSTALL_PREFIX=$WORKSPACE/build/install/
+CLEAN_BUILD=false
 
-rm -rf build/
-mkdir build
+usage() {
+	echo ""
+	echo "Helper script to build cyclonedds"
+	echo "Usage : "
+	echo "<workspace>/scripts/build.sh [options]"
+	echo "Supported options are "
+	echo "clean 		: remove build folder (Default : keep build folder)"
+	echo ""
+}
+
+parse_args() {
+	for arg in "$@"
+	do
+		case $arg in
+		    -h | --help)
+			usage
+			exit 0
+			;;
+			clean)
+			CLEAN_BUILD=true
+			;;
+			*)
+			echo "ERROR : unknown parameter $arg"
+			usage
+			exit 1
+			;;
+		esac
+	done
+}
+
+parse_args $@
+
+if [ $CLEAN_BUILD == true ]
+then
+    rm -rf build/
+fi
+
+mkdir -p build
 cd build
 cmake -DCMAKE_INSTALL_PREFIX=$CYCLONEDDS_INSTALL_PREFIX -DBUILD_IDLC=ON ..
 cmake --build .

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,15 @@
 #!/bin/bash
+
+# Copyright(c) 2020 Prasanna Bhat
+
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 set -e
 
 # It is assumed that this script is called from the root of the project

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:bionic
+
+# Dependencies required to build cyclonedds
+RUN apt update && apt install -y \
+        cmake \
+        default-jdk \
+        maven \
+        g++
+

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -1,3 +1,13 @@
+# Copyright(c) 2020 Prasanna Bhat
+
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 FROM ubuntu:bionic
 
 # Dependencies required to build cyclonedds

--- a/scripts/docker/DockerfileCycloneDds
+++ b/scripts/docker/DockerfileCycloneDds
@@ -5,4 +5,4 @@ ADD . /cyclonedds
 
 WORKDIR /cyclonedds
 
-RUN ./scripts/build.sh
+RUN ./scripts/build.sh clean

--- a/scripts/docker/DockerfileCycloneDds
+++ b/scripts/docker/DockerfileCycloneDds
@@ -1,0 +1,8 @@
+# Build a docker image with pre-built cyclonedds core & examples
+FROM ubuntu:cyclonedds
+
+ADD . /cyclonedds
+
+WORKDIR /cyclonedds
+
+RUN ./scripts/build.sh

--- a/scripts/docker/DockerfileCycloneDds
+++ b/scripts/docker/DockerfileCycloneDds
@@ -1,3 +1,13 @@
+# Copyright(c) 2020 Prasanna Bhat
+
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 # Build a docker image with pre-built cyclonedds core & examples
 FROM ubuntu:cyclonedds
 

--- a/scripts/docker/README.md
+++ b/scripts/docker/README.md
@@ -1,7 +1,7 @@
 # Overview
 
 This contains helper scripts to build & run cyclonedds core & example applications in docker.  
-Additionally you can also build a docker image with pre-built cyclonedds examples. This could be useful in quikly trying the examples (both IPC & network communication).
+Additionally you can also build a docker image with pre-built cyclonedds examples. This could be useful in quickly trying the examples (both IPC & network communication).
 
 # Bulid docker image 
 There are two docker images you can build.  
@@ -27,7 +27,8 @@ The following images are supported.
 `ubuntu` : Same as **ubuntu:cyclonedds** , mentioned above.  
 `cyclonedds` : Same as **cyclonedds:latest**, mentioned above.  
 You can run the script with `-h` option to display usage information.  
-- Build cyclonedds core & examples (if you are using **ubuntu:cyclonedds**)
+**NOTE** : *cyclonedds:latest* depends on image *ubuntu:cyclonedds*. You need to build *ubuntu:cyclonedds* first, if you want to use *cyclonedds:latest*.  
+- Build cyclonedds core & examples (if you are using **ubuntu:cyclonedds**)  
 Use the helper script `./scripts/docker/build_cyclonedds.sh` to build using the currently checked out revision.  
 **NOTE** : You need to run this script from the root of the project.
 
@@ -39,14 +40,17 @@ Once you have built the cyclonedds , you are ready to run the examples inside do
 Let's do that !  
   
 ## Run examples inside the same container (uses IPC)  
-- Launch docker container, from the root of the project
-`docker run --name cyclonedds -it -v $(pwd):/cyclonedds --workdir /cyclonedds cyclonedds:latest /bin/bash`
-This will open terminal connected to docker @ root of the project.  
+- Launch docker container, from the root of the project  
+
+```
+docker run --name cyclonedds -it --workdir /cyclonedds/build/bin cyclonedds:latest /bin/bash
+```
+This will open terminal connected to docker @ bin of the project, which contains sample applications.
 It will look something like this
 ```
-root@22ff409a33e1:/cyclonedds# 
+root@22ff409a33e1:/cyclonedds/build/bin# 
 ```
-- Navigate to `/build/bin` to run the example applications.
+- From here you can run the example applications.
 - To run another terminal , connected to same docker container, use the following command.
 ```
 docker exec -it cyclonedds /bin/bash
@@ -57,7 +61,7 @@ Run the partner example here. This will establish communication over IPC channel
 ## Run examples in different containers (uses docker networking)
 - Follow the same steps as in the previous section , instead connecting to existing docker container create a new docker container.
 e.g.  
-`docker run --name cyclonedds1 -it -v $(pwd):/cyclonedds --workdir /cyclonedds cyclonedds:latest /bin/bash`  
+`docker run --name cyclonedds1 -it --workdir /cyclonedds/build/bin cyclonedds:latest /bin/bash`  
 **NOTE** : You need to run this script from the root of the project.  
 At this point you can inspect the traffic using wireshark.  
 Open docker network interface (`docker0` on my system) in wireshark.  

--- a/scripts/docker/README.md
+++ b/scripts/docker/README.md
@@ -1,0 +1,7 @@
+# Overview
+
+This contains helper scripts (Linux) to
+- Build docker image (this contains the dependencies of cyclonedds build & can be used to build cyclonedds)
+- Build docker image with pre-built cyclonedds (can be used for quick testing)
+
+

--- a/scripts/docker/README.md
+++ b/scripts/docker/README.md
@@ -1,7 +1,67 @@
 # Overview
 
-This contains helper scripts (Linux) to
-- Build docker image (this contains the dependencies of cyclonedds build & can be used to build cyclonedds)
-- Build docker image with pre-built cyclonedds (can be used for quick testing)
+This contains helper scripts to build & run cyclonedds core & example applications in docker.  
+Additionally you can also build a docker image with pre-built cyclonedds examples. This could be useful in quikly trying the examples (both IPC & network communication).
+
+# Bulid docker image 
+There are two docker images you can build.  
+- **ubuntu:cyclonedds** : ubuntu bionic based image that contains dependencies to build cyclonedds. 
+- **cyclonedds:latest** : ubuntu bionic based image with pre-built cyclonedds core & applications (based on the checked out revision).
+
+## How to build the images
+
+### Pre-requisites
+- Linux machine (native / runnin inside VM)
+- Docker (I have tested with 19.03.8, however past versions also would work, as there is no specific dependency)
+
+### Steps
+
+You can use the helper script `./scripts/docker/build_docker_image.sh` to build the docker images.
+
+- Navigate to root of the project.
+- Run the script with -h to display usage.
+```
+./scripts/docker/build_docker_image.sh [images]
+```
+The following images are supported.  
+`ubuntu` : Same as **ubuntu:cyclonedds** , mentioned above.  
+`cyclonedds` : Same as **cyclonedds:latest**, mentioned above.  
+You can run the script with `-h` option to display usage information.  
+- Build cyclonedds core & examples (if you are using **ubuntu:cyclonedds**)
+Use the helper script `./scripts/docker/build_cyclonedds.sh` to build using the currently checked out revision.  
+**NOTE** : You need to run this script from the root of the project.
+
+# Run cyclonedds examples in docker
+You can use either of the above docker images to run the examples.  
+If you use **ubuntu:cyclonedds**, you need to build cyclonedds inside container to build examples.
+Once you have built the cyclonedds , you are ready to run the examples inside docker container.  
+  
+Let's do that !  
+  
+## Run examples inside the same container (uses IPC)  
+- Launch docker container, from the root of the project
+`docker run --name cyclonedds -it -v $(pwd):/cyclonedds --workdir /cyclonedds cyclonedds:latest /bin/bash`
+This will open terminal connected to docker @ root of the project.  
+It will look something like this
+```
+root@22ff409a33e1:/cyclonedds# 
+```
+- Navigate to `/build/bin` to run the example applications.
+- To run another terminal , connected to same docker container, use the following command.
+```
+docker exec -it cyclonedds /bin/bash
+```
+Run the partner example here. This will establish communication over IPC channel.
+
+
+## Run examples in different containers (uses docker networking)
+- Follow the same steps as in the previous section , instead connecting to existing docker container create a new docker container.
+e.g.  
+`docker run --name cyclonedds1 -it -v $(pwd):/cyclonedds --workdir /cyclonedds cyclonedds:latest /bin/bash`  
+**NOTE** : You need to run this script from the root of the project.  
+At this point you can inspect the traffic using wireshark.  
+Open docker network interface (`docker0` on my system) in wireshark.  
+Good news is that wireshark has RTPS dissector.
+
 
 

--- a/scripts/docker/build_cyclonedds.sh
+++ b/scripts/docker/build_cyclonedds.sh
@@ -9,7 +9,7 @@ CONTAINER_NAME="cyclonedds"
 
 echo "WORKSPACE is $WORKSPACE"
 
-docker run -it --rm -v $WORKSPACE/:/cyclonedds --workdir /cyclonedds $IMAGE_NAME /bin/bash -c "./scripts/build.sh"
+docker run -it --rm -v $WORKSPACE/:/cyclonedds --workdir /cyclonedds $IMAGE_NAME /bin/bash -c "./scripts/build.sh clean"
 # Launch the docker after build
 docker run --name $CONTAINER_NAME -it -v $WORKSPACE/:/cyclonedds --workdir /cyclonedds $IMAGE_NAME /bin/bash
 # If you want to connect to the above docker to run cyclonedds examples (multiple apps in separate terminals) , use the below command

--- a/scripts/docker/build_cyclonedds.sh
+++ b/scripts/docker/build_cyclonedds.sh
@@ -13,4 +13,4 @@ docker run -it --rm -v $WORKSPACE/:/cyclonedds --workdir /cyclonedds $IMAGE_NAME
 # Launch the docker after build
 docker run --name $CONTAINER_NAME -it -v $WORKSPACE/:/cyclonedds --workdir /cyclonedds $IMAGE_NAME /bin/bash
 # If you want to connect to the above docker to run cyclonedds examples (multiple apps in separate terminals) , use the below command
-docker exec -it cyclonedds /bin/bash
+# docker exec -it cyclonedds /bin/bash

--- a/scripts/docker/build_cyclonedds.sh
+++ b/scripts/docker/build_cyclonedds.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+# It is assumed that this script is run from root of the project
+WORKSPACE=$(pwd)
+IMAGE_NAME="ubuntu:cyclonedds"
+CONTAINER_NAME="cyclonedds"
+
+echo "WORKSPACE is $WORKSPACE"
+
+docker run -it --rm -v $WORKSPACE/:/cyclonedds --workdir /cyclonedds $IMAGE_NAME /bin/bash -c "./scripts/build.sh"
+# Launch the docker after build
+docker run --name $CONTAINER_NAME -it -v $WORKSPACE/:/cyclonedds --workdir /cyclonedds $IMAGE_NAME /bin/bash
+# If you want to connect to the above docker to run cyclonedds examples (multiple apps in separate terminals) , use the below command
+docker exec -it cyclonedds /bin/bash

--- a/scripts/docker/build_cyclonedds.sh
+++ b/scripts/docker/build_cyclonedds.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+# Copyright(c) 2020 Prasanna Bhat
+
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 set -e
 
 # It is assumed that this script is run from root of the project

--- a/scripts/docker/build_docker_image.sh
+++ b/scripts/docker/build_docker_image.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+set -e 
+
+BUILD_UBUNTU=false
+BUILD_CYCLONEDDS=false
+
+usage() {
+	echo ""
+	echo "Helper script to build docker images for cyclonedds"
+	echo "Usage : "
+	echo "<workspace>/scripts/docker/build_docker_image.sh [images]"
+	echo "Supported images are "
+	echo "ubuntu 		: ubuntu based image to build cyclone dds. Contains dependencies to build cyclonedds."
+	echo "cyclonedds	: pre-built cyclonedds core libs & example applications. Can be quickly used to test cyclonedds apps."
+	echo ""
+}
+
+parse_args() {
+	for arg in "$@"
+	do
+		case $arg in
+		    -h | --help)
+			usage
+			exit 0
+			;;
+			ubuntu)
+			BUILD_UBUNTU=true
+			;;
+			cyclonedds)
+			BUILD_CYCLONEDDS=true
+			;;
+			*)
+			echo "ERROR : unknown parameter $arg"
+			usage
+			exit 1
+			;;
+		esac
+	done
+}
+
+
+
+if [ "$#" -eq 0 ] 
+then
+	echo "Supply at least one argument"
+	echo "Run with -h/--help for usage"
+	exit 1
+fi
+parse_args $@
+
+
+DOCKERFILE_DIR="$(dirname "$(readlink -fm "$0")")"
+WORKSPACE="$(dirname "$(dirname "${DOCKERFILE_DIR}")")"
+echo "WORKSPACE is $WORKSPACE"
+cd "$WORKSPACE"
+
+if [ $BUILD_UBUNTU == true ]
+then
+	UBUNTU_IMAGE="ubuntu:cyclonedds"
+	docker build --file "${DOCKERFILE_DIR}/Dockerfile" . --tag "${UBUNTU_IMAGE}"
+fi
+
+if [ $BUILD_CYCLONEDDS == true ]
+then
+	CYCLONEDDS_IMAGE="cyclonedds:latest"
+	docker build --file "${DOCKERFILE_DIR}/DockerfileCycloneDds" . --tag "${CYCLONEDDS_IMAGE}"
+fi
+
+
+
+

--- a/scripts/docker/build_docker_image.sh
+++ b/scripts/docker/build_docker_image.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+# Copyright(c) 2020 Prasanna Bhat
+
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 set -e 
 
 BUILD_UBUNTU=false


### PR DESCRIPTION
Dockerfile & dockerbuild scripts added, which enable building & testing cyclonedds in docker containers.
With dockers both IPC & network based use cases can be tested in the same machine

