### PR TITLE
Improvements to dds_read_instance, the addition of dds_readcdr of nicer printing of samples

### DIFF
--- a/src/core/ddsc/include/dds/dds.h
+++ b/src/core/ddsc/include/dds/dds.h
@@ -2717,6 +2717,53 @@ dds_take_mask_wl(
   uint32_t maxs,
   uint32_t mask);
 
+#define DDS_HAS_READCDR 1
+/**
+ * @brief Access the collection of serialized data values (of same type) and
+ *        sample info from the data reader, readcondition or querycondition.
+ *
+ * This call accesses the serialized data from the data reader, readcondition or
+ * querycondition and makes it available to the application. The serialized data
+ * is made available through \ref ddsi_serdata structures. Returned samples are
+ * marked as READ.
+ *
+ * Return value provides information about the number of samples read, which will
+ * be <= maxs. Based on the count, the buffer will contain serialized data to be
+ * read only when valid_data bit in sample info structure is set.
+ * The buffer required for data values, could be allocated explicitly or can
+ * use the memory from data reader to prevent copy. In the latter case, buffer and
+ * sample_info should be returned back, once it is no longer using the data.
+ *
+ * @param[in]  reader_or_condition Reader, readcondition or querycondition entity.
+ * @param[out] buf An array of pointers to \ref ddsi_serdata structures that contain
+ *                 the serialized data. The pointers can be NULL.
+ * @param[in]  maxs Maximum number of samples to read.
+ * @param[out] si Pointer to an array of \ref dds_sample_info_t returned for each data value.
+ * @param[in]  mask Filter the data based on dds_sample_state_t|dds_view_state_t|dds_instance_state_t.
+ *
+ * @returns A dds_return_t with the number of samples read or an error code.
+ *
+ * @retval >=0
+ *             Number of samples read.
+ * @retval DDS_RETCODE_ERROR
+ *             An internal error has occurred.
+ * @retval DDS_RETCODE_BAD_PARAMETER
+ *             One of the given arguments is not valid.
+ * @retval DDS_RETCODE_ILLEGAL_OPERATION
+ *             The operation is invoked on an inappropriate object.
+ * @retval DDS_RETCODE_ALREADY_DELETED
+ *             The entity has already been deleted.
+ * @retval DDS_RETCODE_PRECONDITION_NOT_MET
+ *             The precondition for this operation is not met.
+ */
+DDS_EXPORT dds_return_t
+dds_readcdr(
+  dds_entity_t reader_or_condition,
+  struct ddsi_serdata **buf,
+  uint32_t maxs,
+  dds_sample_info_t *si,
+  uint32_t mask);
+
 /**
  * @brief Access the collection of serialized data values (of same type) and
  *        sample info from the data reader, readcondition or querycondition.

--- a/src/core/ddsc/include/dds/ddsc/dds_public_impl.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_public_impl.h
@@ -225,6 +225,13 @@ enum dds_stream_typecode_subtype {
 #define DDS_OP_FLAG_KEY 0x01 /* key field: applicable to {1,2,4,8}BY, STR, BST, ARR-of-{1,2,4,8}BY */
 #define DDS_OP_FLAG_DEF 0x02 /* union has a default case (for DDS_OP_ADR | DDS_OP_TYPE_UNI) */
 
+/* For a union: (1) the discriminator may be a key field; (2) there may be a default value;
+   and (3) the discriminator can be an integral type (or enumerated - here treated as equivalent).
+   What it can't be is a floating-point type. So DEF and FP need never be set at the same time.
+   There are only a few flag bits, so saving one is not such a bad idea. */
+#define DDS_OP_FLAG_FP  0x02 /* floating-point: applicable to {4,8}BY and arrays, sequences of them */
+#define DDS_OP_FLAG_SGN 0x04 /* signed: applicable to {1,2,4,8}BY and arrays, sequences of them */
+
 /**
  * Description : Enable or disable write batching. Overrides default configuration
  * setting for write batching (Internal/WriteBatch).

--- a/src/core/ddsc/include/dds/ddsc/dds_rhc.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_rhc.h
@@ -27,9 +27,8 @@ struct dds_reader;
 struct ddsi_tkmap;
 
 typedef dds_return_t (*dds_rhc_associate_t) (struct dds_rhc *rhc, struct dds_reader *reader, const struct ddsi_sertopic *topic, struct ddsi_tkmap *tkmap);
-typedef int (*dds_rhc_read_t) (struct dds_rhc *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, struct dds_readcond *cond);
-typedef int (*dds_rhc_take_t) (struct dds_rhc *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, struct dds_readcond *cond);
-typedef int (*dds_rhc_takecdr_t) (struct dds_rhc *rhc, bool lock, struct ddsi_serdata **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle);
+typedef int32_t (*dds_rhc_read_take_t) (struct dds_rhc *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, struct dds_readcond *cond);
+typedef int32_t (*dds_rhc_read_take_cdr_t) (struct dds_rhc *rhc, bool lock, struct ddsi_serdata **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle);
 
 typedef bool (*dds_rhc_add_readcondition_t) (struct dds_rhc *rhc, struct dds_readcond *cond);
 typedef void (*dds_rhc_remove_readcondition_t) (struct dds_rhc *rhc, struct dds_readcond *cond);
@@ -40,9 +39,9 @@ struct dds_rhc_ops {
   /* A copy of DDSI rhc ops comes first so we can use either interface without
      additional indirections */
   struct ddsi_rhc_ops rhc_ops;
-  dds_rhc_read_t read;
-  dds_rhc_take_t take;
-  dds_rhc_takecdr_t takecdr;
+  dds_rhc_read_take_t read;
+  dds_rhc_read_take_t take;
+  dds_rhc_read_take_cdr_t takecdr;
   dds_rhc_add_readcondition_t add_readcondition;
   dds_rhc_remove_readcondition_t remove_readcondition;
   dds_rhc_lock_samples_t lock_samples;
@@ -76,13 +75,13 @@ DDS_EXPORT inline void dds_rhc_set_qos (struct dds_rhc *rhc, const struct dds_qo
 DDS_EXPORT inline void dds_rhc_free (struct dds_rhc *rhc) {
   rhc->common.ops->rhc_ops.free (&rhc->common.rhc);
 }
-DDS_EXPORT inline int dds_rhc_read (struct dds_rhc *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, struct dds_readcond *cond) {
+DDS_EXPORT inline int32_t dds_rhc_read (struct dds_rhc *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, struct dds_readcond *cond) {
   return (rhc->common.ops->read) (rhc, lock, values, info_seq, max_samples, mask, handle, cond);
 }
-DDS_EXPORT inline int dds_rhc_take (struct dds_rhc *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, struct dds_readcond *cond) {
+DDS_EXPORT inline int32_t dds_rhc_take (struct dds_rhc *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, struct dds_readcond *cond) {
   return rhc->common.ops->take (rhc, lock, values, info_seq, max_samples, mask, handle, cond);
 }
-DDS_EXPORT inline int dds_rhc_takecdr (struct dds_rhc *rhc, bool lock, struct ddsi_serdata **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle) {
+DDS_EXPORT inline int32_t dds_rhc_takecdr (struct dds_rhc *rhc, bool lock, struct ddsi_serdata **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle) {
   return rhc->common.ops->takecdr (rhc, lock, values, info_seq, max_samples, sample_states, view_states, instance_states, handle);
 }
 DDS_EXPORT inline bool dds_rhc_add_readcondition (struct dds_rhc *rhc, struct dds_readcond *cond) {

--- a/src/core/ddsc/include/dds/ddsc/dds_rhc.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_rhc.h
@@ -41,6 +41,7 @@ struct dds_rhc_ops {
   struct ddsi_rhc_ops rhc_ops;
   dds_rhc_read_take_t read;
   dds_rhc_read_take_t take;
+  dds_rhc_read_take_cdr_t readcdr;
   dds_rhc_read_take_cdr_t takecdr;
   dds_rhc_add_readcondition_t add_readcondition;
   dds_rhc_remove_readcondition_t remove_readcondition;
@@ -80,6 +81,9 @@ DDS_EXPORT inline int32_t dds_rhc_read (struct dds_rhc *rhc, bool lock, void **v
 }
 DDS_EXPORT inline int32_t dds_rhc_take (struct dds_rhc *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, struct dds_readcond *cond) {
   return rhc->common.ops->take (rhc, lock, values, info_seq, max_samples, mask, handle, cond);
+}
+DDS_EXPORT inline int32_t dds_rhc_readcdr (struct dds_rhc *rhc, bool lock, struct ddsi_serdata **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle) {
+  return rhc->common.ops->readcdr (rhc, lock, values, info_seq, max_samples, sample_states, view_states, instance_states, handle);
 }
 DDS_EXPORT inline int32_t dds_rhc_takecdr (struct dds_rhc *rhc, bool lock, struct ddsi_serdata **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle) {
   return rhc->common.ops->takecdr (rhc, lock, values, info_seq, max_samples, sample_states, view_states, instance_states, handle);

--- a/src/core/ddsc/src/dds_rhc.c
+++ b/src/core/ddsc/src/dds_rhc.c
@@ -22,6 +22,7 @@ extern inline void dds_rhc_set_qos (struct dds_rhc *rhc, const struct dds_qos *q
 extern inline void dds_rhc_free (struct dds_rhc *rhc);
 extern inline int dds_rhc_read (struct dds_rhc *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, struct dds_readcond *cond);
 extern inline int dds_rhc_take (struct dds_rhc *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, struct dds_readcond *cond);
+extern inline int dds_rhc_readcdr (struct dds_rhc *rhc, bool lock, struct ddsi_serdata **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle);
 extern inline int dds_rhc_takecdr (struct dds_rhc *rhc, bool lock, struct ddsi_serdata **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle);
 extern inline bool dds_rhc_add_readcondition (struct dds_rhc *rhc, struct dds_readcond *cond);
 extern inline void dds_rhc_remove_readcondition (struct dds_rhc *rhc, struct dds_readcond *cond);

--- a/src/core/ddsc/src/dds_rhc_default.c
+++ b/src/core/ddsc/src/dds_rhc_default.c
@@ -363,79 +363,7 @@ struct trigger_info_post {
   struct trigger_info_cmn c;
 };
 
-static void dds_rhc_default_free (struct dds_rhc_default *rhc);
-static bool dds_rhc_default_store (struct dds_rhc_default * __restrict rhc, const struct ddsi_writer_info * __restrict wrinfo, struct ddsi_serdata * __restrict sample, struct ddsi_tkmap_instance * __restrict tk);
-static void dds_rhc_default_unregister_wr (struct dds_rhc_default * __restrict rhc, const struct ddsi_writer_info * __restrict wrinfo);
-static void dds_rhc_default_relinquish_ownership (struct dds_rhc_default * __restrict rhc, const uint64_t wr_iid);
-static void dds_rhc_default_set_qos (struct dds_rhc_default *rhc, const struct dds_qos *qos);
-static int32_t dds_rhc_default_read (struct dds_rhc_default *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, dds_readcond *cond);
-static int32_t dds_rhc_default_take (struct dds_rhc_default *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, dds_readcond *cond);
-static int32_t dds_rhc_default_readcdr (struct dds_rhc_default *rhc, bool lock, struct ddsi_serdata ** values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle);
-static int32_t dds_rhc_default_takecdr (struct dds_rhc_default *rhc, bool lock, struct ddsi_serdata ** values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle);
-static bool dds_rhc_default_add_readcondition (struct dds_rhc_default *rhc, dds_readcond *cond);
-static void dds_rhc_default_remove_readcondition (struct dds_rhc_default *rhc, dds_readcond *cond);
-static uint32_t dds_rhc_default_lock_samples (struct dds_rhc_default *rhc);
-
-static void dds_rhc_default_free_wrap (struct ddsi_rhc *rhc) {
-  dds_rhc_default_free ((struct dds_rhc_default *) rhc);
-}
-static bool dds_rhc_default_store_wrap (struct ddsi_rhc * __restrict rhc, const struct ddsi_writer_info * __restrict wrinfo, struct ddsi_serdata * __restrict sample, struct ddsi_tkmap_instance * __restrict tk) {
-  return dds_rhc_default_store ((struct dds_rhc_default *) rhc, wrinfo, sample, tk);
-}
-static void dds_rhc_default_unregister_wr_wrap (struct ddsi_rhc * __restrict rhc, const struct ddsi_writer_info * __restrict wrinfo) {
-  dds_rhc_default_unregister_wr ((struct dds_rhc_default *) rhc, wrinfo);
-}
-static void dds_rhc_default_relinquish_ownership_wrap (struct ddsi_rhc * __restrict rhc, const uint64_t wr_iid) {
-  dds_rhc_default_relinquish_ownership ((struct dds_rhc_default *) rhc, wr_iid);
-}
-static void dds_rhc_default_set_qos_wrap (struct ddsi_rhc *rhc, const struct dds_qos *qos) {
-  dds_rhc_default_set_qos ((struct dds_rhc_default *) rhc, qos);
-}
-static int32_t dds_rhc_default_read_wrap (struct dds_rhc *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, dds_readcond *cond) {
-  return dds_rhc_default_read ((struct dds_rhc_default *) rhc, lock, values, info_seq, max_samples, mask, handle, cond);
-}
-static int32_t dds_rhc_default_take_wrap (struct dds_rhc *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, dds_readcond *cond) {
-  return dds_rhc_default_take ((struct dds_rhc_default *) rhc, lock, values, info_seq, max_samples, mask, handle, cond);
-}
-static int32_t dds_rhc_default_readcdr_wrap (struct dds_rhc *rhc, bool lock, struct ddsi_serdata **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle) {
-  return dds_rhc_default_readcdr ((struct dds_rhc_default *) rhc, lock, values, info_seq, max_samples, sample_states, view_states, instance_states, handle);
-}
-static int32_t dds_rhc_default_takecdr_wrap (struct dds_rhc *rhc, bool lock, struct ddsi_serdata **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle) {
-  return dds_rhc_default_takecdr ((struct dds_rhc_default *) rhc, lock, values, info_seq, max_samples, sample_states, view_states, instance_states, handle);
-}
-static bool dds_rhc_default_add_readcondition_wrap (struct dds_rhc *rhc, dds_readcond *cond) {
-  return dds_rhc_default_add_readcondition ((struct dds_rhc_default *) rhc, cond);
-}
-static void dds_rhc_default_remove_readcondition_wrap (struct dds_rhc *rhc, dds_readcond *cond) {
-  dds_rhc_default_remove_readcondition ((struct dds_rhc_default *) rhc, cond);
-}
-static uint32_t dds_rhc_default_lock_samples_wrap (struct dds_rhc *rhc) {
-  return dds_rhc_default_lock_samples ((struct dds_rhc_default *) rhc);
-}
-static dds_return_t dds_rhc_default_associate (struct dds_rhc *rhc, dds_reader *reader, const struct ddsi_sertopic *topic, struct ddsi_tkmap *tkmap)
-{
-  /* ignored out of laziness */
-  (void) rhc; (void) reader; (void) topic; (void) tkmap;
-  return DDS_RETCODE_OK;
-}
-
-static const struct dds_rhc_ops dds_rhc_default_ops = {
-  .rhc_ops = {
-    .store = dds_rhc_default_store_wrap,
-    .unregister_wr = dds_rhc_default_unregister_wr_wrap,
-    .relinquish_ownership = dds_rhc_default_relinquish_ownership_wrap,
-    .set_qos = dds_rhc_default_set_qos_wrap,
-    .free = dds_rhc_default_free_wrap
-  },
-  .read = dds_rhc_default_read_wrap,
-  .take = dds_rhc_default_take_wrap,
-  .readcdr = dds_rhc_default_readcdr_wrap,
-  .takecdr = dds_rhc_default_takecdr_wrap,
-  .add_readcondition = dds_rhc_default_add_readcondition_wrap,
-  .remove_readcondition = dds_rhc_default_remove_readcondition_wrap,
-  .lock_samples = dds_rhc_default_lock_samples_wrap,
-  .associate = dds_rhc_default_associate
-};
+static const struct dds_rhc_ops dds_rhc_default_ops;
 
 static uint32_t qmask_of_sample (const struct rhc_sample *s)
 {
@@ -675,8 +603,16 @@ struct dds_rhc *dds_rhc_default_new (dds_reader *reader, const struct ddsi_serto
   return dds_rhc_default_new_xchecks (reader, &reader->m_entity.m_domain->gv, topic, (reader->m_entity.m_domain->gv.config.enabled_xchecks & DDS_XCHECK_RHC) != 0);
 }
 
-static void dds_rhc_default_set_qos (struct dds_rhc_default * rhc, const dds_qos_t * qos)
+static dds_return_t dds_rhc_default_associate (struct dds_rhc *rhc, dds_reader *reader, const struct ddsi_sertopic *topic, struct ddsi_tkmap *tkmap)
 {
+  /* ignored out of laziness */
+  (void) rhc; (void) reader; (void) topic; (void) tkmap;
+  return DDS_RETCODE_OK;
+}
+
+static void dds_rhc_default_set_qos (struct ddsi_rhc *rhc_common, const dds_qos_t * qos)
+{
+  struct dds_rhc_default * const rhc = (struct dds_rhc_default *) rhc_common;
   /* Set read related QoS */
 
   rhc->max_samples = qos->resource_limits.max_samples;
@@ -822,8 +758,9 @@ static void free_instance_rhc_free (struct rhc_instance *inst, struct dds_rhc_de
   free_empty_instance(inst, rhc);
 }
 
-static uint32_t dds_rhc_default_lock_samples (struct dds_rhc_default *rhc)
+static uint32_t dds_rhc_default_lock_samples (struct dds_rhc *rhc_common)
 {
+  struct dds_rhc_default * const rhc = (struct dds_rhc_default *) rhc_common;
   uint32_t no;
   ddsrt_mutex_lock (&rhc->lock);
   no = rhc->n_vsamples + rhc->n_invsamples;
@@ -839,8 +776,9 @@ static void free_instance_rhc_free_wrap (void *vnode, void *varg)
   free_instance_rhc_free (vnode, varg);
 }
 
-static void dds_rhc_default_free (struct dds_rhc_default *rhc)
+static void dds_rhc_default_free (struct ddsi_rhc *rhc_common)
 {
+  struct dds_rhc_default *rhc = (struct dds_rhc_default *) rhc_common;
 #ifdef DDSI_INCLUDE_LIFESPAN
   dds_rhc_default_sample_expired_cb (rhc, DDSRT_MTIME_NEVER);
   lifespan_fini (&rhc->lifespan);
@@ -1464,8 +1402,9 @@ static rhc_store_result_t rhc_store_new_instance (struct rhc_instance **out_inst
   delivered (true unless a reliable sample rejected).
 */
 
-static bool dds_rhc_default_store (struct dds_rhc_default * __restrict rhc, const struct ddsi_writer_info * __restrict wrinfo, struct ddsi_serdata * __restrict sample, struct ddsi_tkmap_instance * __restrict tk)
+static bool dds_rhc_default_store (struct ddsi_rhc * __restrict rhc_common, const struct ddsi_writer_info * __restrict wrinfo, struct ddsi_serdata * __restrict sample, struct ddsi_tkmap_instance * __restrict tk)
 {
+  struct dds_rhc_default * const __restrict rhc = (struct dds_rhc_default * __restrict) rhc_common;
   const uint64_t wr_iid = wrinfo->iid;
   const uint32_t statusinfo = sample->statusinfo;
   const bool has_data = (sample->kind == SDK_DATA);
@@ -1740,7 +1679,7 @@ error_or_nochange:
   return delivered;
 }
 
-static void dds_rhc_default_unregister_wr (struct dds_rhc_default * __restrict rhc, const struct ddsi_writer_info * __restrict wrinfo)
+static void dds_rhc_default_unregister_wr (struct ddsi_rhc * __restrict rhc_common, const struct ddsi_writer_info * __restrict wrinfo)
 {
   /* Only to be called when writer with ID WR_IID has died.
 
@@ -1757,6 +1696,7 @@ static void dds_rhc_default_unregister_wr (struct dds_rhc_default * __restrict r
      need to get two IIDs: the one visible to the application in the
      built-in topics and in get_instance_handle, and one used internally
      for tracking registrations and unregistrations. */
+  struct dds_rhc_default * __restrict const rhc = (struct dds_rhc_default * __restrict) rhc_common;
   bool notify_data_available = false;
   struct rhc_instance *inst;
   struct ddsrt_hh_iter iter;
@@ -1825,8 +1765,9 @@ static void dds_rhc_default_unregister_wr (struct dds_rhc_default * __restrict r
   }
 }
 
-static void dds_rhc_default_relinquish_ownership (struct dds_rhc_default * __restrict rhc, const uint64_t wr_iid)
+static void dds_rhc_default_relinquish_ownership (struct ddsi_rhc * __restrict rhc_common, const uint64_t wr_iid)
 {
+  struct dds_rhc_default * __restrict const rhc = (struct dds_rhc_default * __restrict) rhc_common;
   struct rhc_instance *inst;
   struct ddsrt_hh_iter iter;
   ddsrt_mutex_lock (&rhc->lock);
@@ -2393,12 +2334,13 @@ static bool cond_is_sample_state_dependent (const struct dds_readcond *cond)
   }
 }
 
-static bool dds_rhc_default_add_readcondition (struct dds_rhc_default *rhc, dds_readcond *cond)
+static bool dds_rhc_default_add_readcondition (struct dds_rhc *rhc_common, dds_readcond *cond)
 {
   /* On the assumption that a readcondition will be attached to a
      waitset for nearly all of its life, we keep track of all
      readconditions on a reader in one set, without distinguishing
      between those attached to a waitset or not. */
+  struct dds_rhc_default * const rhc = (struct dds_rhc_default *) rhc_common;
   struct ddsrt_hh_iter it;
 
   assert ((dds_entity_kind (&cond->m_entity) == DDS_KIND_COND_READ && cond->m_query.m_filter == 0) ||
@@ -2498,8 +2440,9 @@ static bool dds_rhc_default_add_readcondition (struct dds_rhc_default *rhc, dds_
   return true;
 }
 
-static void dds_rhc_default_remove_readcondition (struct dds_rhc_default *rhc, dds_readcond *cond)
+static void dds_rhc_default_remove_readcondition (struct dds_rhc *rhc_common, dds_readcond *cond)
 {
+  struct dds_rhc_default * const rhc = (struct dds_rhc_default *) rhc_common;
   dds_readcond **ptr;
   ddsrt_mutex_lock (&rhc->lock);
   ptr = &rhc->conds;
@@ -2727,26 +2670,30 @@ static bool update_conditions_locked (struct dds_rhc_default *rhc, bool called_f
  ******  READ/TAKE  ******
  *************************/
 
-static int32_t dds_rhc_default_read (struct dds_rhc_default *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, dds_readcond *cond)
+static int32_t dds_rhc_default_read (struct dds_rhc *rhc_common, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, dds_readcond *cond)
 {
+  struct dds_rhc_default * const rhc = (struct dds_rhc_default *) rhc_common;
   uint32_t qminv = qmask_from_mask_n_cond (mask, cond);
   return dds_rhc_read_w_qminv (rhc, lock, values, info_seq, max_samples, qminv, handle, cond);
 }
 
-static int32_t dds_rhc_default_take (struct dds_rhc_default *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, dds_readcond *cond)
+static int32_t dds_rhc_default_take (struct dds_rhc *rhc_common, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, dds_readcond *cond)
 {
+  struct dds_rhc_default * const rhc = (struct dds_rhc_default *) rhc_common;
   uint32_t qminv = qmask_from_mask_n_cond(mask, cond);
   return dds_rhc_take_w_qminv (rhc, lock, values, info_seq, max_samples, qminv, handle, cond);
 }
 
-static int32_t dds_rhc_default_readcdr (struct dds_rhc_default *rhc, bool lock, struct ddsi_serdata ** values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle)
+static int32_t dds_rhc_default_readcdr (struct dds_rhc *rhc_common, bool lock, struct ddsi_serdata ** values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle)
 {
+  struct dds_rhc_default * const rhc = (struct dds_rhc_default *) rhc_common;
   uint32_t qminv = qmask_from_dcpsquery (sample_states, view_states, instance_states);
   return dds_rhc_readcdr_w_qminv (rhc, lock, values, info_seq, max_samples, qminv, handle, NULL);
 }
 
-static int32_t dds_rhc_default_takecdr (struct dds_rhc_default *rhc, bool lock, struct ddsi_serdata ** values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle)
+static int32_t dds_rhc_default_takecdr (struct dds_rhc *rhc_common, bool lock, struct ddsi_serdata ** values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle)
 {
+  struct dds_rhc_default * const rhc = (struct dds_rhc_default *) rhc_common;
   uint32_t qminv = qmask_from_dcpsquery (sample_states, view_states, instance_states);
   return dds_rhc_takecdr_w_qminv (rhc, lock, values, info_seq, max_samples, qminv, handle, NULL);
 }
@@ -2924,3 +2871,21 @@ static int rhc_check_counts_locked (struct dds_rhc_default *rhc, bool check_cond
 }
 #undef CHECK_MAX_CONDS
 #endif
+
+static const struct dds_rhc_ops dds_rhc_default_ops = {
+  .rhc_ops = {
+    .store = dds_rhc_default_store,
+    .unregister_wr = dds_rhc_default_unregister_wr,
+    .relinquish_ownership = dds_rhc_default_relinquish_ownership,
+    .set_qos = dds_rhc_default_set_qos,
+    .free = dds_rhc_default_free
+  },
+  .read = dds_rhc_default_read,
+  .take = dds_rhc_default_take,
+  .readcdr = dds_rhc_default_readcdr,
+  .takecdr = dds_rhc_default_takecdr,
+  .add_readcondition = dds_rhc_default_add_readcondition,
+  .remove_readcondition = dds_rhc_default_remove_readcondition,
+  .lock_samples = dds_rhc_default_lock_samples,
+  .associate = dds_rhc_default_associate
+};

--- a/src/core/ddsi/src/ddsi_cdrstream.c
+++ b/src/core/ddsi/src/ddsi_cdrstream.c
@@ -1990,14 +1990,42 @@ static size_t isprint_runlen (const unsigned char *s, size_t n)
   return m;
 }
 
-static bool prtf_simple (char * __restrict *buf, size_t * __restrict bufsize, dds_istream_t * __restrict is, enum dds_stream_typecode type)
+static bool prtf_simple (char * __restrict *buf, size_t * __restrict bufsize, dds_istream_t * __restrict is, enum dds_stream_typecode type, unsigned flags)
 {
   switch (type)
   {
-    case DDS_OP_VAL_1BY: return prtf (buf, bufsize, "%"PRIu8, dds_is_get1 (is));
-    case DDS_OP_VAL_2BY: return prtf (buf, bufsize, "%"PRIu16, dds_is_get2 (is));
-    case DDS_OP_VAL_4BY: return prtf (buf, bufsize, "%"PRIu32, dds_is_get4 (is));
-    case DDS_OP_VAL_8BY: return prtf (buf, bufsize, "%"PRIu64, dds_is_get8 (is));
+    case DDS_OP_VAL_1BY: {
+      const union { int8_t s; uint8_t u; } x = { .u = dds_is_get1 (is) };
+      if (flags & DDS_OP_FLAG_SGN)
+        return prtf (buf, bufsize, "%"PRId8, x.s);
+      else
+        return prtf (buf, bufsize, "%"PRIu8, x.u);
+    }
+    case DDS_OP_VAL_2BY: {
+      const union { int16_t s; uint16_t u; } x = { .u = dds_is_get2 (is) };
+      if (flags & DDS_OP_FLAG_SGN)
+        return prtf (buf, bufsize, "%"PRId16, x.s);
+      else
+        return prtf (buf, bufsize, "%"PRIu16, x.u);
+    }
+    case DDS_OP_VAL_4BY: {
+      const union { int32_t s; uint32_t u; float f; } x = { .u = dds_is_get4 (is) };
+      if (flags & DDS_OP_FLAG_FP)
+        return prtf (buf, bufsize, "%g", x.f);
+      else if (flags & DDS_OP_FLAG_SGN)
+        return prtf (buf, bufsize, "%"PRId32, x.s);
+      else
+        return prtf (buf, bufsize, "%"PRIu32, x.u);
+    }
+    case DDS_OP_VAL_8BY: {
+      const union { int64_t s; uint64_t u; double f; } x = { .u = dds_is_get8 (is) };
+      if (flags & DDS_OP_FLAG_FP)
+        return prtf (buf, bufsize, "%g", x.f);
+      else if (flags & DDS_OP_FLAG_SGN)
+        return prtf (buf, bufsize, "%"PRId64, x.s);
+      else
+        return prtf (buf, bufsize, "%"PRIu64, x.u);
+    }
     case DDS_OP_VAL_STR: case DDS_OP_VAL_BST: return prtf_str (buf, bufsize, is);
     case DDS_OP_VAL_ARR: case DDS_OP_VAL_SEQ: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU:
       abort ();
@@ -2005,7 +2033,7 @@ static bool prtf_simple (char * __restrict *buf, size_t * __restrict bufsize, dd
   return false;
 }
 
-static bool prtf_simple_array (char * __restrict *buf, size_t * __restrict bufsize, dds_istream_t * __restrict is, uint32_t num, enum dds_stream_typecode type)
+static bool prtf_simple_array (char * __restrict *buf, size_t * __restrict bufsize, dds_istream_t * __restrict is, uint32_t num, enum dds_stream_typecode type, unsigned flags)
 {
   bool cont = prtf (buf, bufsize, "{");
   switch (type)
@@ -2028,7 +2056,7 @@ static bool prtf_simple_array (char * __restrict *buf, size_t * __restrict bufsi
         {
           if (i != 0)
             (void) prtf (buf, bufsize, ",");
-          cont = prtf_simple (buf, bufsize, is, type);
+          cont = prtf_simple (buf, bufsize, is, type, flags);
           i++;
         }
       }
@@ -2040,7 +2068,7 @@ static bool prtf_simple_array (char * __restrict *buf, size_t * __restrict bufsi
       {
         if (i != 0)
           (void) prtf (buf, bufsize, ",");
-        cont = prtf_simple (buf, bufsize, is, type);
+        cont = prtf_simple (buf, bufsize, is, type, flags);
       }
       break;
     default:
@@ -2065,10 +2093,10 @@ static const uint32_t *prtf_seq (char * __restrict *buf, size_t *bufsize, dds_is
   switch (subtype)
   {
     case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY:
-      (void) prtf_simple_array (buf, bufsize, is, num, subtype);
+      (void) prtf_simple_array (buf, bufsize, is, num, subtype, DDS_OP_FLAGS (insn));
       return ops + 2;
     case DDS_OP_VAL_STR: case DDS_OP_VAL_BST:
-      (void) prtf_simple_array (buf, bufsize, is, num, subtype);
+      (void) prtf_simple_array (buf, bufsize, is, num, subtype, DDS_OP_FLAGS (insn));
       return ops + (subtype == DDS_OP_VAL_STR ? 2 : 3);
     case DDS_OP_VAL_SEQ: case DDS_OP_VAL_ARR: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU: {
       const uint32_t jmp = DDS_OP_ADR_JMP (ops[3]);
@@ -2093,10 +2121,10 @@ static const uint32_t *prtf_arr (char * __restrict *buf, size_t *bufsize, dds_is
   switch (subtype)
   {
     case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY:
-      (void) prtf_simple_array (buf, bufsize, is, num, subtype);
+      (void) prtf_simple_array (buf, bufsize, is, num, subtype, DDS_OP_FLAGS (insn));
       return ops + 3;
     case DDS_OP_VAL_STR: case DDS_OP_VAL_BST:
-      (void) prtf_simple_array (buf, bufsize, is, num, subtype);
+      (void) prtf_simple_array (buf, bufsize, is, num, subtype, DDS_OP_FLAGS (insn));
       return ops + (subtype == DDS_OP_VAL_STR ? 3 : 5);
     case DDS_OP_VAL_SEQ: case DDS_OP_VAL_ARR: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU: {
       const uint32_t *jsr_ops = ops + DDS_OP_ADR_JSR (ops[3]);
@@ -2127,7 +2155,7 @@ static const uint32_t *prtf_uni (char * __restrict *buf, size_t *bufsize, dds_is
     {
       case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY:
       case DDS_OP_VAL_STR: case DDS_OP_VAL_BST:
-        (void) prtf_simple (buf, bufsize, is, valtype);
+        (void) prtf_simple (buf, bufsize, is, valtype, DDS_OP_FLAGS (jeq_op[0]));
         break;
       case DDS_OP_VAL_SEQ: case DDS_OP_VAL_ARR: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU:
         (void) dds_stream_print_sample1 (buf, bufsize, is, jeq_op + DDS_OP_ADR_JSR (jeq_op[0]), valtype == DDS_OP_VAL_STU);
@@ -2156,11 +2184,11 @@ static bool dds_stream_print_sample1 (char * __restrict *buf, size_t * __restric
         {
           case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY:
           case DDS_OP_VAL_STR:
-            cont = prtf_simple (buf, bufsize, is, DDS_OP_TYPE (insn));
+            cont = prtf_simple (buf, bufsize, is, DDS_OP_TYPE (insn), DDS_OP_FLAGS (insn));
             ops += 2;
             break;
           case DDS_OP_VAL_BST:
-            cont = prtf_simple (buf, bufsize, is, DDS_OP_TYPE (insn));
+            cont = prtf_simple (buf, bufsize, is, DDS_OP_TYPE (insn), DDS_OP_FLAGS (insn));
             ops += 3;
             break;
           case DDS_OP_VAL_SEQ:
@@ -2212,10 +2240,10 @@ size_t dds_stream_print_key (dds_istream_t * __restrict is, const struct ddsi_se
     {
       case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY:
       case DDS_OP_VAL_STR: case DDS_OP_VAL_BST:
-        cont = prtf_simple (&buf, &bufsize, is, DDS_OP_TYPE (*op));
+        cont = prtf_simple (&buf, &bufsize, is, DDS_OP_TYPE (*op), DDS_OP_FLAGS (*op));
         break;
       case DDS_OP_VAL_ARR:
-        cont = prtf_simple_array (&buf, &bufsize, is, op[2], DDS_OP_SUBTYPE (*op));
+        cont = prtf_simple_array (&buf, &bufsize, is, op[2], DDS_OP_SUBTYPE (*op), DDS_OP_FLAGS (*op));
         break;
       case DDS_OP_VAL_SEQ: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU:
         abort ();

--- a/src/idlc/src/org/eclipse/cyclonedds/generator/BasicType.java
+++ b/src/idlc/src/org/eclipse/cyclonedds/generator/BasicType.java
@@ -20,15 +20,15 @@ public class BasicType extends AbstractType
   {
     BOOLEAN ("bool", "DDS_OP_TYPE_BOO", "DDS_OP_SUBTYPE_BOO", Alignment.BOOL, "Boolean"),
     OCTET ("uint8_t", "DDS_OP_TYPE_1BY", "DDS_OP_SUBTYPE_1BY", Alignment.ONE, "Octet"),
-    CHAR ("char", "DDS_OP_TYPE_1BY", "DDS_OP_SUBTYPE_1BY", Alignment.ONE, "Char"),
-    SHORT ("int16_t", "DDS_OP_TYPE_2BY", "DDS_OP_SUBTYPE_2BY", Alignment.TWO, "Short"),
+    CHAR ("char", "DDS_OP_TYPE_1BY | DDS_OP_FLAG_SGN", "DDS_OP_SUBTYPE_1BY | DDS_OP_FLAG_SGN", Alignment.ONE, "Char"),
+    SHORT ("int16_t", "DDS_OP_TYPE_2BY | DDS_OP_FLAG_SGN", "DDS_OP_SUBTYPE_2BY | DDS_OP_FLAG_SGN", Alignment.TWO, "Short"),
     USHORT ("uint16_t", "DDS_OP_TYPE_2BY", "DDS_OP_SUBTYPE_2BY", Alignment.TWO, "UShort"),
-    LONG ("int32_t", "DDS_OP_TYPE_4BY", "DDS_OP_SUBTYPE_4BY", Alignment.FOUR, "Long"),
+    LONG ("int32_t", "DDS_OP_TYPE_4BY | DDS_OP_FLAG_SGN", "DDS_OP_SUBTYPE_4BY | DDS_OP_FLAG_SGN", Alignment.FOUR, "Long"),
     ULONG ("uint32_t", "DDS_OP_TYPE_4BY", "DDS_OP_SUBTYPE_4BY", Alignment.FOUR, "ULong"),
-    LONGLONG ("int64_t", "DDS_OP_TYPE_8BY", "DDS_OP_SUBTYPE_8BY", Alignment.EIGHT, "LongLong"),
+    LONGLONG ("int64_t", "DDS_OP_TYPE_8BY | DDS_OP_FLAG_SGN", "DDS_OP_SUBTYPE_8BY | DDS_OP_FLAG_SGN", Alignment.EIGHT, "LongLong"),
     ULONGLONG ("uint64_t", "DDS_OP_TYPE_8BY", "DDS_OP_SUBTYPE_8BY", Alignment.EIGHT, "ULongLong"),
-    FLOAT ("float", "DDS_OP_TYPE_4BY", "DDS_OP_SUBTYPE_4BY", Alignment.FOUR, "Float"),
-    DOUBLE ("double", "DDS_OP_TYPE_8BY", "DDS_OP_SUBTYPE_8BY", Alignment.EIGHT, "Double"),
+    FLOAT ("float", "DDS_OP_TYPE_4BY | DDS_OP_FLAG_FP", "DDS_OP_SUBTYPE_4BY | DDS_OP_FLAG_FP", Alignment.FOUR, "Float"),
+    DOUBLE ("double", "DDS_OP_TYPE_8BY | DDS_OP_FLAG_FP", "DDS_OP_SUBTYPE_8BY | DDS_OP_FLAG_FP", Alignment.EIGHT, "Double"),
     STRING ("char *", "DDS_OP_TYPE_STR", "DDS_OP_SUBTYPE_STR", Alignment.PTR, "String");
 
     public final String cType;


### PR DESCRIPTION
* dds_read_instance had an unspeakably bad implementation (I plead innocent despite git blame showing my name):
  * dds_read_impl did an entirely superfluous check to see whether the instance handle was known globally, and as there is no efficient global instance handle lookup that meant a scan of all known instance handles
  * the RHC implementation is built around a hashing instance handles, but instead of using a hash lookup it scanned all instances
  And so what should have been a pretty efficient lookup ended up being *two* linear scans of key values ... This PR fixes that by dropping the superfluous first scan and replacing the second by a hash table lookup.
* The code for reading/taking samples is somewhat complicated. I've refactored it a bit and in the process also removed the duplicate implementation in `dds_takecdr`. That interface is not quite a stable, backwards-compatible interface, but it has proved very useful on multiple occasions and I believe deserves to stay. But then the absence of a `dds_readcdr` companion is starting to grate. With the refactoring, adding the latter is a trivial thing. Once again: it's an evolving interface, so think before you decide to rely on it.
* A layer of wrapper functions that did nothing more than casting the RHC pointer from the generic `dds_rhc` to the specific `dds_rhc_default` got removed as well. Those were just noise.
* The trace optionally contains the sample contents in a readable form, but the IDL preprocessor erased so much type information that it became impossible to tell whether, e.g., a 4 byte object was originally an enumerated type, a 32-bit signed integer, a 32-bit unsigned integer, or a 32-bit floating-point number. The enums coming out as numbers is no big deal, but signed integers, and especially floating-point numbers, being printed as unsigned decimal numbers is quite annoying. So despite my reluctance to touch IDLC, this changes its output to set flags for signed and floating-point numbers. These flags only affect the printing. No requirement to regenerate anything.