### PR TITLE
Restore SEDP tracing

### DIFF
--- a/src/core/ddsi/src/q_ddsi_discovery.c
+++ b/src/core/ddsi/src/q_ddsi_discovery.c
@@ -1368,6 +1368,8 @@ static void handle_SEDP (const struct receiver_state *rst, seqno_t seq, struct d
   ddsi_plist_t decoded_data;
   if (ddsi_serdata_to_sample (serdata, &decoded_data, NULL, NULL))
   {
+    struct ddsi_domaingv * const gv = rst->gv;
+    GVLOGDISC ("SEDP ST%x", serdata->statusinfo);
     switch (serdata->statusinfo & (NN_STATUSINFO_DISPOSE | NN_STATUSINFO_UNREGISTER))
     {
       case 0:

--- a/src/core/ddsi/src/q_ddsi_discovery.c
+++ b/src/core/ddsi/src/q_ddsi_discovery.c
@@ -1162,9 +1162,7 @@ static void handle_SEDP_alive (const struct receiver_state *rst, seqno_t seq, dd
 #endif
 
   assert (datap);
-
-  if (!(datap->present & PP_ENDPOINT_GUID))
-    E (" no guid?\n", err);
+  assert (datap->present & PP_ENDPOINT_GUID);
   GVLOGDISC (" "PGUIDFMT, PGUID (datap->endpoint_guid));
 
   ppguid.prefix = datap->endpoint_guid.prefix;
@@ -1350,11 +1348,7 @@ static void handle_SEDP_dead (const struct receiver_state *rst, ddsi_plist_t *da
 {
   struct ddsi_domaingv * const gv = rst->gv;
   int res;
-  if (!(datap->present & PP_ENDPOINT_GUID))
-  {
-    GVLOGDISC (" no guid?\n");
-    return;
-  }
+  assert (datap->present & PP_ENDPOINT_GUID);
   GVLOGDISC (" "PGUIDFMT, PGUID (datap->endpoint_guid));
   if (is_writer_entityid (datap->endpoint_guid.entityid))
     res = delete_proxy_writer (gv, &datap->endpoint_guid, timestamp, 0);


### PR DESCRIPTION
I messed up in 4f3cbf7a1cea74ad7f9216923c008016598dd3ce and dropped the "SEDP ST%x" marker from the trace. This adds it back in.

It also removes a check for the presence of an endpoint GUID in the parameter list, because that check is now done as part of the conversion to a sample.