### PR TITLE
Fix some typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ the
 the
 [throughput](https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/assets/performance/20190730/sub.log) and
 [latency](https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/assets/performance/20190730/ping.log) data
-underlying the graphs.  These also include CPU usage ([thoughput](https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/assets/performance/20190730/throughput-async-listener-cpu.png) and [latency](https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/assets/performance/20190730/latency-sync-listener-bwcpu.png)) and [memory usage](https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/assets/performance/20190730/throughput-async-listener-memory.png).
+underlying the graphs.  These also include CPU usage ([throughput](https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/assets/performance/20190730/throughput-async-listener-cpu.png) and [latency](https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/assets/performance/20190730/latency-sync-listener-bwcpu.png)) and [memory usage](https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/assets/performance/20190730/throughput-async-listener-memory.png).
 
 # Configuration
 

--- a/docs/dev/debugging.md
+++ b/docs/dev/debugging.md
@@ -56,7 +56,7 @@ su - travis
 5. Install The [Conan C/C++ Package Manager](https://conan.io).
 
  ```
-$ pip intall conan --upgrade --user
+$ pip install conan --upgrade --user
 $ conan user
 ```
 

--- a/docs/dev/logging.md
+++ b/docs/dev/logging.md
@@ -66,7 +66,7 @@ priority member that is passed to the handler consists of the priority,
 e.g. error, info, etc and (if it's a trace message) the category.
 
 To be specific. The last four bits of the 32-bit integer contain the priority.
-The other bits implicity indicate it's a trace message and are reserved to
+The other bits implicitly indicate it's a trace message and are reserved to
 specify the category to which a message belongs.
 
 ```C
@@ -89,7 +89,7 @@ the internal log and trace functions depends on it. The user is strongly
 discouraged to enable all categories and filter messages in the registered
 handler, because of the performance impact!
 
-> Tests have shown performance to decrease by roughly 5% if the descision on
+> Tests have shown performance to decrease by roughly 5% if the decision on
 > whether or not to write the message is done outside the function. The reason
 > obviously not being the *if*-statement, but the creation of the stack frame.
 
@@ -143,7 +143,7 @@ that can print to the native log api offered by a target. e.g.
  * Use the name of the parameter as it appears in the documentation for that 
    language binding to reference a parameter where applicable.
  * Use the same formatting style as other messages in the same module.
-   * e.g. use "could not ..." or "failed to ..." consitently.
+   * e.g. use "could not ..." or "failed to ..." consistently.
  * Avoid duplicate reports as much as possible. 
    e.g. if a problem is reported in a lower layer, do not report it again when 
    the error is propagated.
@@ -173,7 +173,7 @@ that can print to the native log api offered by a target. e.g.
 
 * Cyclone assumes files can always be written. For a number of supported
   targets, e.g. FreeRTOS and VxWorks, this is often not the case. Also,
-  filling the memory with log files is proably undesirable.
+  filling the memory with log files is probably undesirable.
 
 * Cyclone (except for DDSI) does not support log categories to selectively
   enable/disable messages that the user is interested in. Causing trace logs

--- a/docs/dev/modules.md
+++ b/docs/dev/modules.md
@@ -1,7 +1,7 @@
 # Eclipse Cyclone DDS Module Layout
 
 Cyclone DDS is made up of multiple modules, each of which provides a certain
-set of functionality, either private, public or a combination therof. Since
+set of functionality, either private, public or a combination thereof. Since
 Cyclone DDS is a middleware product, the api is of course the most visible
 interface. Cyclone DDS uses the *dds* (not followed by an underscore) prefix
 to avoid name collisions with other code.
@@ -32,7 +32,7 @@ but does offer a neat way to separate features logically.
 > restructuring of the runtime module. The two will be merged in the not too
 > distant future.
 
-All modules are exported seperately, for convenience. e.g. the *ddsrt* module
+All modules are exported separately, for convenience. e.g. the *ddsrt* module
 offers target agnostic interfaces to create and manage threads and
 synchronization primitives, retrieve resource usage, system time, etc.
 However, all symbols not referenced by including *dds.h* or prefixed with
@@ -54,12 +54,12 @@ the target supports IPv6 addresses.
 
 
 ### Feature discovery
-Discovery of target features at compile time is lagely dynamic. Various target
+Discovery of target features at compile time is largely dynamic. Various target
 specific predefined macros determine if a feature is supported and which
 implementation is built. This is on purpose, to avoid a target specific
 include directory and an abundance of configuration header files and works
 well for most use cases. Of course, there are exceptions where the preprocessor
-requires some hints to make the right the descision. e.g. when the lwIP TCP/IP
+requires some hints to make the right decision. e.g. when the lwIP TCP/IP
 stack should be used as opposed to the native stack. The build system is
 responsible for the availability of the proper macros at compile time.
 
@@ -82,10 +82,10 @@ target architecture specific implementation.
 #### Network stack
 General purpose operating systems like Microsoft Windows and Linux come with
 a network stack, as does VxWorks. FreeRTOS, however, does not and requires a
-seperate TCP/IP stack, which is often part of the Board Support Package (BSP).
+separate TCP/IP stack, which is often part of the Board Support Package (BSP).
 But separate stacks can be used on Microsoft Windows and Linux too. e.g. the
 network stack in Tizen RT is based on lwIP, but the platform uses the Linux
-kernel. Wheter or not lwIP must be used cannot be determined automatically and
+kernel. Whether or not lwIP must be used cannot be determined automatically and
 the build system must hint which implementation is to be used.
 
 
@@ -158,7 +158,7 @@ directory.
 
 ### Development guidelines
 * Be pragmatic. Use ifdefs (only) where it makes sense. Do not ifdef if target
-  implementations are completely different. Add a seperate implementation. If
+  implementations are completely different. Add a separate implementation. If
   there are only minor differences, as is typically the case between unices,
   use an ifdef.
 * Header and source files are not prefixed. Instead they reside in a directory

--- a/docs/manual/GettingStartedGuide/helloworld_indepth.rst
+++ b/docs/manual/GettingStartedGuide/helloworld_indepth.rst
@@ -377,7 +377,7 @@ can be done to properly connect readers and writers:
 
   The use of these events will be outside the scope of this example
 
-* Poll for the publication/subscription matches statusses
+* Poll for the publication/subscription matches statuses
 
   * The Subscriber should poll for a subscription matched status to be set
   * The Publisher should poll for a publication matched status to be set

--- a/docs/manual/config.rst
+++ b/docs/manual/config.rst
@@ -106,7 +106,7 @@ from its WHC when it fills up too far, and allows readers to always receive all 
 complication exists in the case of unresponsive readers, readers that do not respond to
 a Heartbeat at all, or that for some reason fail to receive some samples despite
 resending it.  The specification leaves the way these get treated unspecified.  The
-default beahviour of Eclipse Cyclone DDS is to never consider readers unresponsive, but it can
+default behaviour of Eclipse Cyclone DDS is to never consider readers unresponsive, but it can
 be configured to consider them so after a certain length of time has passed at which
 point the participant containing the reader is undiscovered.
 
@@ -214,7 +214,7 @@ settings.
 Proxies have the same natural hierarchy that ‘normal’ DDSI entities have: each proxy
 endpoint is owned by some proxy participant, and once the proxy participant is deleted,
 all of its proxy endpoints are deleted as well.  Participants assert their liveliness
-periodically (called *automic* liveliness in the DCPS specification and the only mode
+periodically (called *automatic* liveliness in the DCPS specification and the only mode
 currently supported by Eclipse Cyclone DDS), and when nothing has been heard from a participant
 for the lease duration published by that participant in its SPDP message, the lease
 becomes expired triggering a clean-up.
@@ -807,7 +807,7 @@ size of the second to ``Internal/SecondaryReorderMaxSamples``.
 In between the receive thread and the delivery threads sit queues, of which the maximum
 size is controlled by the ``Internal/DeliveryQueueMaxSamples`` setting.  Generally there
 is no need for these queues to be very large (unless one has very small samples in very
-large messaegs), their primary function is to smooth out the processing when batches of
+large messages), their primary function is to smooth out the processing when batches of
 samples become available at once, for example following a retransmission.
 
 When any of these receive buffers hit their size limit and it concerns application data,

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -64,7 +64,7 @@ One of: false, true, single, none, many
 This option specifies whether a network socket will be created for each
 domain participant on a host. The specification seems to assume that each
 participant has a unique address, and setting this option will ensure
-this to be the case. This is not the defeault.
+this to be the case. This is not the default.
 
 Disabling it slightly improves performance and reduces network traffic
 somewhat. It also causes the set of port numbers needed by Cyclone DDS to
@@ -290,7 +290,7 @@ The default value is: "0".
 ##### //CycloneDDS/Domain/Discovery/Ports/ParticipantGain
 Integer
 
-This element specifies the participant gain, relating p0, articipant
+This element specifies the participant gain, relating p0, participant
 index to sets of port numbers (refer to the DDSI 2.1 specification,
 section 9.6.1, constant PG).
 
@@ -696,8 +696,8 @@ Attributes: [max](#cycloneddsdomaininternalheartbeatintervalmax), [min](#cyclone
 
 Number-with-unit
 
-This elemnents allows configuring the base interval for sending writer
-heartbeats and the bounds within it can vary.
+This element allows configuring the base interval for sending writer
+heartbeats and the bounds within which it can vary.
 
 Valid values are finite durations with an explicit unit or the keyword
 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.
@@ -1246,8 +1246,8 @@ transport. Enabling write batching causes multiple small write operations
 to be aggregated within the write cache into a single larger write. This
 gives greater throughput at the expense of latency. Currently there is no
 mechanism for the write cache to automatically flush itself, so that if
-write batching is enabled, the application may havee to use the
-dds_write_flush function to ensure thta all samples are written.
+write batching is enabled, the application may have to use the
+dds_write_flush function to ensure that all samples are written.
 
 The default value is: "false".
 
@@ -1784,7 +1784,7 @@ Text
 
 This option specifies the file to which received and sent packets will be
 logged in the "pcap" format suitable for analysis using common networking
-tools, such as WireShark. IP and UDP headers are ficitious, in particular
+tools, such as WireShark. IP and UDP headers are fictitious, in particular
 the destination address of received packets. The TTL may be used to
 distinguish between sent and received packets: it is 255 for sent packets
 and 128 for received ones. Currently IPv4 only.

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -1784,10 +1784,10 @@ Text
 
 This option specifies the file to which received and sent packets will be
 logged in the "pcap" format suitable for analysis using common networking
-tools, such as WireShark. IP and UDP headers are fictitious, in particular
-the destination address of received packets. The TTL may be used to
-distinguish between sent and received packets: it is 255 for sent packets
-and 128 for received ones. Currently IPv4 only.
+tools, such as WireShark. IP and UDP headers are fictitious, in
+particular the destination address of received packets. The TTL may be
+used to distinguish between sent and received packets: it is 255 for sent
+packets and 128 for received ones. Currently IPv4 only.
 
 The default value is: "".
 

--- a/etc/cyclonedds.rnc
+++ b/etc/cyclonedds.rnc
@@ -44,7 +44,7 @@ will help.</p><p>The default value is: &quot;false&quot;.</p>""" ] ]
 <p>This option specifies whether a network socket will be created for
 each domain participant on a host. The specification seems to assume that
 each participant has a unique address, and setting this option will
-ensure this to be the case. This is not the defeault.</p>
+ensure this to be the case. This is not the default.</p>
 
 <p>Disabling it slightly improves performance and reduces network traffic
 somewhat. It also causes the set of port numbers needed by Cyclone DDS to
@@ -226,7 +226,7 @@ d0).</p><p>The default value is: &quot;0&quot;.</p>""" ] ]
             xsd:integer
           }?
           & [ a:documentation [ xml:lang="en" """
-<p>This element specifies the participant gain, relating p0, articipant
+<p>This element specifies the participant gain, relating p0, participant
 index to sets of port numbers (refer to the DDSI 2.1 specification,
 section 9.6.1, constant PG).</p><p>The default value is:
 &quot;2&quot;.</p>""" ] ]
@@ -567,8 +567,8 @@ keys.</p><p>The default value is: &quot;false&quot;.</p>""" ] ]
           xsd:boolean
         }?
         & [ a:documentation [ xml:lang="en" """
-<p>This elemnents allows configuring the base interval for sending writer
-heartbeats and the bounds within it can vary.</p>
+<p>This element allows configuring the base interval for sending writer
+heartbeats and the bounds within which it can vary.</p>
 
 <p>Valid values are finite durations with an explicit unit or the keyword
 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr,
@@ -1008,8 +1008,8 @@ transport. Enabling write batching causes multiple small write operations
 to be aggregated within the write cache into a single larger write. This
 gives greater throughput at the expense of latency. Currently there is no
 mechanism for the write cache to automatically flush itself, so that if
-write batching is enabled, the application may havee to use the
-dds_write_flush function to ensure thta all samples are
+write batching is enabled, the application may have to use the
+dds_write_flush function to ensure that all samples are
 written.</p><p>The default value is: &quot;false&quot;.</p>""" ] ]
         element WriteBatch {
           xsd:boolean
@@ -1430,8 +1430,8 @@ or Tracing/EnabledCategory settings.</p><p>The default value is:
         & [ a:documentation [ xml:lang="en" """
 <p>This option specifies the file to which received and sent packets will
 be logged in the "pcap" format suitable for analysis using common
-networking tools, such as WireShark. IP and UDP headers are ficitious, in
-particular the destination address of received packets. The TTL may be
+networking tools, such as WireShark. IP and UDP headers are fictitious,
+in particular the destination address of received packets. The TTL may be
 used to distinguish between sent and received packets: it is 255 for sent
 packets and 128 for received ones. Currently IPv4 only.</p><p>The default
 value is: &quot;&quot;.</p>""" ] ]

--- a/etc/cyclonedds.xsd
+++ b/etc/cyclonedds.xsd
@@ -94,7 +94,7 @@ will help.&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;false&amp;quot;.&lt
 &lt;p&gt;This option specifies whether a network socket will be created for
 each domain participant on a host. The specification seems to assume that
 each participant has a unique address, and setting this option will
-ensure this to be the case. This is not the defeault.&lt;/p&gt;
+ensure this to be the case. This is not the default.&lt;/p&gt;
 
 &lt;p&gt;Disabling it slightly improves performance and reduces network traffic
 somewhat. It also causes the set of port numbers needed by Cyclone DDS to
@@ -341,7 +341,7 @@ d0).&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;0&amp;quot;.&lt;/p&gt;</x
   <xs:element name="ParticipantGain" type="xs:integer">
     <xs:annotation>
       <xs:documentation>
-&lt;p&gt;This element specifies the participant gain, relating p0, articipant
+&lt;p&gt;This element specifies the participant gain, relating p0, participant
 index to sets of port numbers (refer to the DDSI 2.1 specification,
 section 9.6.1, constant PG).&lt;/p&gt;&lt;p&gt;The default value is:
 &amp;quot;2&amp;quot;.&lt;/p&gt;</xs:documentation>
@@ -816,8 +816,8 @@ keys.&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;false&amp;quot;.&lt;/p&g
   <xs:element name="HeartbeatInterval">
     <xs:annotation>
       <xs:documentation>
-&lt;p&gt;This elemnents allows configuring the base interval for sending writer
-heartbeats and the bounds within it can vary.&lt;/p&gt;
+&lt;p&gt;This element allows configuring the base interval for sending writer
+heartbeats and the bounds within which it can vary.&lt;/p&gt;
 
 &lt;p&gt;Valid values are finite durations with an explicit unit or the keyword
 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr,
@@ -1354,8 +1354,8 @@ transport. Enabling write batching causes multiple small write operations
 to be aggregated within the write cache into a single larger write. This
 gives greater throughput at the expense of latency. Currently there is no
 mechanism for the write cache to automatically flush itself, so that if
-write batching is enabled, the application may havee to use the
-dds_write_flush function to ensure thta all samples are
+write batching is enabled, the application may have to use the
+dds_write_flush function to ensure that all samples are
 written.&lt;/p&gt;&lt;p&gt;The default value is: &amp;quot;false&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
@@ -1935,8 +1935,8 @@ or Tracing/EnabledCategory settings.&lt;/p&gt;&lt;p&gt;The default value is:
       <xs:documentation>
 &lt;p&gt;This option specifies the file to which received and sent packets will
 be logged in the "pcap" format suitable for analysis using common
-networking tools, such as WireShark. IP and UDP headers are ficitious, in
-particular the destination address of received packets. The TTL may be
+networking tools, such as WireShark. IP and UDP headers are fictitious,
+in particular the destination address of received packets. The TTL may be
 used to distinguish between sent and received packets: it is 255 for sent
 packets and 128 for received ones. Currently IPv4 only.&lt;/p&gt;&lt;p&gt;The default
 value is: &amp;quot;&amp;quot;.&lt;/p&gt;</xs:documentation>

--- a/src/core/ddsi/src/q_config.c
+++ b/src/core/ddsi/src/q_config.c
@@ -413,7 +413,7 @@ static const struct cfgelem compatibility_cfgelems[] = {
     BLURB("<p>This element specifies whether QoS settings set to default values are explicitly published in the discovery protocol. Implementations are to use the default value for QoS settings not published, which allows a significant reduction of the amount of data that needs to be exchanged for the discovery protocol, but this requires all implementations to adhere to the default values specified by the specifications.</p>\n\
 <p>When interoperability is required with an implementation that does not follow the specifications in this regard, setting this option to true will help.</p>") },
   { LEAF ("ManySocketsMode"), 1, "single", ABSOFF (many_sockets_mode), 0, uf_many_sockets_mode, 0, pf_many_sockets_mode,
-    BLURB("<p>This option specifies whether a network socket will be created for each domain participant on a host. The specification seems to assume that each participant has a unique address, and setting this option will ensure this to be the case. This is not the defeault.</p>\n\
+    BLURB("<p>This option specifies whether a network socket will be created for each domain participant on a host. The specification seems to assume that each participant has a unique address, and setting this option will ensure this to be the case. This is not the default.</p>\n\
 <p>Disabling it slightly improves performance and reduces network traffic somewhat. It also causes the set of port numbers needed by DDSI2E to become predictable, which may be useful for firewall and NAT configuration.</p>") },
   { LEAF("AssumeRtiHasPmdEndpoints"), 1, "false", ABSOFF(assume_rti_has_pmd_endpoints), 0, uf_boolean, 0, pf_boolean,
     BLURB("<p>This option assumes ParticipantMessageData endpoints required by the liveliness protocol are present in RTI participants even when not properly advertised by the participant discovery protocol.</p>") },
@@ -525,7 +525,7 @@ static const struct cfgelem internal_cfgelems[] = {
     BLURB("<p>This setting determines the size of the time window in which a NACK of some sample is ignored because a retransmit of that sample has been multicasted too recently. This setting has no effect on unicasted retransmits.</p>\n\
 <p>See also Internal/RetransmitMerging.</p>") },
   { LEAF_W_ATTRS("HeartbeatInterval", heartbeat_interval_attrs), 1, "100 ms", ABSOFF(const_hb_intv_sched), 0, uf_duration_inf, 0, pf_duration,
-    BLURB("<p>This elemnents allows configuring the base interval for sending writer heartbeats and the bounds within it can vary.</p>") },
+    BLURB("<p>This element allows configuring the base interval for sending writer heartbeats and the bounds within which it can vary.</p>") },
   { LEAF("MaxQueuedRexmitBytes"), 1, "50 kB", ABSOFF(max_queued_rexmit_bytes), 0, uf_memsize, 0, pf_memsize,
     BLURB("<p>This setting limits the maximum number of bytes queued for retransmission. The default value of 0 is unlimited unless an AuxiliaryBandwidthLimit has been set, in which case it becomes NackDelay * AuxiliaryBandwidthLimit. It must be large enough to contain the largest sample that may need to be retransmitted.</p>") },
   { LEAF("MaxQueuedRexmitMessages"), 1, "200", ABSOFF(max_queued_rexmit_msgs), 0, uf_uint, 0, pf_uint,
@@ -566,7 +566,7 @@ static const struct cfgelem internal_cfgelems[] = {
   { LEAF("MaxSampleSize"), 1, "2147483647 B", ABSOFF(max_sample_size), 0, uf_memsize, 0, pf_memsize,
     BLURB("<p>This setting controls the maximum (CDR) serialised size of samples that DDSI2E will forward in either direction. Samples larger than this are discarded with a warning.</p>") },
   { LEAF("WriteBatch"), 1, "false", ABSOFF(whc_batch), 0, uf_boolean, 0, pf_boolean,
-    BLURB("<p>This element enables the batching of write operations. By default each write operation writes through the write cache and out onto the transport. Enabling write batching causes multiple small write operations to be aggregated within the write cache into a single larger write. This gives greater throughput at the expense of latency. Currently there is no mechanism for the write cache to automatically flush itself, so that if write batching is enabled, the application may havee to use the dds_write_flush function to ensure thta all samples are written.</p>") },
+    BLURB("<p>This element enables the batching of write operations. By default each write operation writes through the write cache and out onto the transport. Enabling write batching causes multiple small write operations to be aggregated within the write cache into a single larger write. This gives greater throughput at the expense of latency. Currently there is no mechanism for the write cache to automatically flush itself, so that if write batching is enabled, the application may have to use the dds_write_flush function to ensure that all samples are written.</p>") },
   { LEAF_W_ATTRS("LivelinessMonitoring", liveliness_monitoring_attrs), 1, "false", ABSOFF(liveliness_monitoring), 0, uf_boolean, 0, pf_boolean,
     BLURB("<p>This element controls whether or not implementation should internally monitor its own liveliness. If liveliness monitoring is enabled, stack traces can be dumped automatically when some thread appears to have stopped making progress.</p>") },
   { LEAF("MonitorPort"), 1, "-1", ABSOFF(monitor_port), 0, uf_int, 0, pf_int,
@@ -611,7 +611,7 @@ static const struct cfgelem discovery_ports_cfgelems[] = {
   { LEAF("DomainGain"), 1, "250", ABSOFF(ports.dg), 0, uf_uint, 0, pf_uint,
     BLURB("<p>This element specifies the domain gain, relating domain ids to sets of port numbers (refer to the DDSI 2.1 specification, section 9.6.1, constant DG).</p>") },
   { LEAF("ParticipantGain"), 1, "2", ABSOFF(ports.pg), 0, uf_uint, 0, pf_uint,
-    BLURB("<p>This element specifies the participant gain, relating p0, articipant index to sets of port numbers (refer to the DDSI 2.1 specification, section 9.6.1, constant PG).</p>") },
+    BLURB("<p>This element specifies the participant gain, relating p0, participant index to sets of port numbers (refer to the DDSI 2.1 specification, section 9.6.1, constant PG).</p>") },
   { LEAF("MulticastMetaOffset"), 1, "0", ABSOFF(ports.d0), 0, uf_uint, 0, pf_uint,
     BLURB("<p>This element specifies the port number for multicast meta traffic (refer to the DDSI 2.1 specification, section 9.6.1, constant d0).</p>") },
   { LEAF("UnicastMetaOffset"), 1, "10", ABSOFF(ports.d1), 0, uf_uint, 0, pf_uint,
@@ -759,7 +759,7 @@ static const struct cfgelem tracing_cfgelems[] = {
   { LEAF("AppendToFile"), 1, "false", ABSOFF(tracingAppendToFile), 0, uf_boolean, 0, pf_boolean,
     BLURB("<p>This option specifies whether the output is to be appended to an existing log file. The default is to create a new log file each time, which is generally the best option if a detailed log is generated.</p>") },
   { LEAF("PacketCaptureFile"), 1, "", ABSOFF(pcap_file), 0, uf_string, ff_free, pf_string,
-    BLURB("<p>This option specifies the file to which received and sent packets will be logged in the \"pcap\" format suitable for analysis using common networking tools, such as WireShark. IP and UDP headers are ficitious, in particular the destination address of received packets. The TTL may be used to distinguish between sent and received packets: it is 255 for sent packets and 128 for received ones. Currently IPv4 only.</p>") },
+    BLURB("<p>This option specifies the file to which received and sent packets will be logged in the \"pcap\" format suitable for analysis using common networking tools, such as WireShark. IP and UDP headers are fictitious, in particular the destination address of received packets. The TTL may be used to distinguish between sent and received packets: it is 255 for sent packets and 128 for received ones. Currently IPv4 only.</p>") },
   END_MARKER
 };
 

--- a/src/idlc/src/org/eclipse/cyclonedds/compilers/IdlcCmdOptions.java
+++ b/src/idlc/src/org/eclipse/cyclonedds/compilers/IdlcCmdOptions.java
@@ -36,7 +36,7 @@ public class IdlcCmdOptions extends CmdOptions
     io.println ("   -nostamp         Do not timestamp generated code");
     io.println ("   -lax             Skip over structs containing unsupported datatypes");
     io.println ("   -quiet           Suppress console output other than error messages (default)");
-    io.println ("   -verbose         Enable console ouptut other than error messages");
+    io.println ("   -verbose         Enable console output other than error messages");
     io.println ("   -map_wide        Map the unsupported wchar and wstring types to char and string");
     io.println ("   -map_longdouble  Map the unsupported long double type to double");
   }


### PR DESCRIPTION
In files:
- README.md
- docs/dev/{modules,logging,debugging}.md
- docs/manual/{config,options,GettingStartedGuide/helloworld_indepth}.rst
- src/idlc/src/org/eclipse/cyclonedds/compilers/IdlcCmdOptions.java
