### PR TITLE
Preparatory work for implementing autopurge on RHC

### DIFF
--- a/src/core/ddsc/include/dds/dds.h
+++ b/src/core/ddsc/include/dds/dds.h
@@ -2741,6 +2741,53 @@ dds_take_mask_wl(
   uint32_t maxs,
   uint32_t mask);
 
+#define DDS_HAS_READCDR 1
+/**
+ * @brief Access the collection of serialized data values (of same type) and
+ *        sample info from the data reader, readcondition or querycondition.
+ *
+ * This call accesses the serialized data from the data reader, readcondition or
+ * querycondition and makes it available to the application. The serialized data
+ * is made available through \ref ddsi_serdata structures. Returned samples are
+ * marked as READ.
+ *
+ * Return value provides information about the number of samples read, which will
+ * be <= maxs. Based on the count, the buffer will contain serialized data to be
+ * read only when valid_data bit in sample info structure is set.
+ * The buffer required for data values, could be allocated explicitly or can
+ * use the memory from data reader to prevent copy. In the latter case, buffer and
+ * sample_info should be returned back, once it is no longer using the data.
+ *
+ * @param[in]  reader_or_condition Reader, readcondition or querycondition entity.
+ * @param[out] buf An array of pointers to \ref ddsi_serdata structures that contain
+ *                 the serialized data. The pointers can be NULL.
+ * @param[in]  maxs Maximum number of samples to read.
+ * @param[out] si Pointer to an array of \ref dds_sample_info_t returned for each data value.
+ * @param[in]  mask Filter the data based on dds_sample_state_t|dds_view_state_t|dds_instance_state_t.
+ *
+ * @returns A dds_return_t with the number of samples read or an error code.
+ *
+ * @retval >=0
+ *             Number of samples read.
+ * @retval DDS_RETCODE_ERROR
+ *             An internal error has occurred.
+ * @retval DDS_RETCODE_BAD_PARAMETER
+ *             One of the given arguments is not valid.
+ * @retval DDS_RETCODE_ILLEGAL_OPERATION
+ *             The operation is invoked on an inappropriate object.
+ * @retval DDS_RETCODE_ALREADY_DELETED
+ *             The entity has already been deleted.
+ * @retval DDS_RETCODE_PRECONDITION_NOT_MET
+ *             The precondition for this operation is not met.
+ */
+DDS_EXPORT dds_return_t
+dds_readcdr(
+  dds_entity_t reader_or_condition,
+  struct ddsi_serdata **buf,
+  uint32_t maxs,
+  dds_sample_info_t *si,
+  uint32_t mask);
+
 /**
  * @brief Access the collection of serialized data values (of same type) and
  *        sample info from the data reader, readcondition or querycondition.

--- a/src/core/ddsc/include/dds/ddsc/dds_public_impl.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_public_impl.h
@@ -225,6 +225,13 @@ enum dds_stream_typecode_subtype {
 #define DDS_OP_FLAG_KEY 0x01 /* key field: applicable to {1,2,4,8}BY, STR, BST, ARR-of-{1,2,4,8}BY */
 #define DDS_OP_FLAG_DEF 0x02 /* union has a default case (for DDS_OP_ADR | DDS_OP_TYPE_UNI) */
 
+/* For a union: (1) the discriminator may be a key field; (2) there may be a default value;
+   and (3) the discriminator can be an integral type (or enumerated - here treated as equivalent).
+   What it can't be is a floating-point type. So DEF and FP need never be set at the same time.
+   There are only a few flag bits, so saving one is not such a bad idea. */
+#define DDS_OP_FLAG_FP  0x02 /* floating-point: applicable to {4,8}BY and arrays, sequences of them */
+#define DDS_OP_FLAG_SGN 0x04 /* signed: applicable to {1,2,4,8}BY and arrays, sequences of them */
+
 /**
  * Description : Enable or disable write batching. Overrides default configuration
  * setting for write batching (Internal/WriteBatch).

--- a/src/core/ddsc/include/dds/ddsc/dds_rhc.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_rhc.h
@@ -27,9 +27,8 @@ struct dds_reader;
 struct ddsi_tkmap;
 
 typedef dds_return_t (*dds_rhc_associate_t) (struct dds_rhc *rhc, struct dds_reader *reader, const struct ddsi_sertopic *topic, struct ddsi_tkmap *tkmap);
-typedef int (*dds_rhc_read_t) (struct dds_rhc *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, struct dds_readcond *cond);
-typedef int (*dds_rhc_take_t) (struct dds_rhc *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, struct dds_readcond *cond);
-typedef int (*dds_rhc_takecdr_t) (struct dds_rhc *rhc, bool lock, struct ddsi_serdata **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle);
+typedef int32_t (*dds_rhc_read_take_t) (struct dds_rhc *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, struct dds_readcond *cond);
+typedef int32_t (*dds_rhc_read_take_cdr_t) (struct dds_rhc *rhc, bool lock, struct ddsi_serdata **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle);
 
 typedef bool (*dds_rhc_add_readcondition_t) (struct dds_rhc *rhc, struct dds_readcond *cond);
 typedef void (*dds_rhc_remove_readcondition_t) (struct dds_rhc *rhc, struct dds_readcond *cond);
@@ -40,9 +39,9 @@ struct dds_rhc_ops {
   /* A copy of DDSI rhc ops comes first so we can use either interface without
      additional indirections */
   struct ddsi_rhc_ops rhc_ops;
-  dds_rhc_read_t read;
-  dds_rhc_take_t take;
-  dds_rhc_takecdr_t takecdr;
+  dds_rhc_read_take_t read;
+  dds_rhc_read_take_t take;
+  dds_rhc_read_take_cdr_t takecdr;
   dds_rhc_add_readcondition_t add_readcondition;
   dds_rhc_remove_readcondition_t remove_readcondition;
   dds_rhc_lock_samples_t lock_samples;
@@ -76,13 +75,13 @@ DDS_EXPORT inline void dds_rhc_set_qos (struct dds_rhc *rhc, const struct dds_qo
 DDS_EXPORT inline void dds_rhc_free (struct dds_rhc *rhc) {
   rhc->common.ops->rhc_ops.free (&rhc->common.rhc);
 }
-DDS_EXPORT inline int dds_rhc_read (struct dds_rhc *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, struct dds_readcond *cond) {
+DDS_EXPORT inline int32_t dds_rhc_read (struct dds_rhc *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, struct dds_readcond *cond) {
   return (rhc->common.ops->read) (rhc, lock, values, info_seq, max_samples, mask, handle, cond);
 }
-DDS_EXPORT inline int dds_rhc_take (struct dds_rhc *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, struct dds_readcond *cond) {
+DDS_EXPORT inline int32_t dds_rhc_take (struct dds_rhc *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, struct dds_readcond *cond) {
   return rhc->common.ops->take (rhc, lock, values, info_seq, max_samples, mask, handle, cond);
 }
-DDS_EXPORT inline int dds_rhc_takecdr (struct dds_rhc *rhc, bool lock, struct ddsi_serdata **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle) {
+DDS_EXPORT inline int32_t dds_rhc_takecdr (struct dds_rhc *rhc, bool lock, struct ddsi_serdata **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle) {
   return rhc->common.ops->takecdr (rhc, lock, values, info_seq, max_samples, sample_states, view_states, instance_states, handle);
 }
 DDS_EXPORT inline bool dds_rhc_add_readcondition (struct dds_rhc *rhc, struct dds_readcond *cond) {

--- a/src/core/ddsc/include/dds/ddsc/dds_rhc.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_rhc.h
@@ -41,6 +41,7 @@ struct dds_rhc_ops {
   struct ddsi_rhc_ops rhc_ops;
   dds_rhc_read_take_t read;
   dds_rhc_read_take_t take;
+  dds_rhc_read_take_cdr_t readcdr;
   dds_rhc_read_take_cdr_t takecdr;
   dds_rhc_add_readcondition_t add_readcondition;
   dds_rhc_remove_readcondition_t remove_readcondition;
@@ -80,6 +81,9 @@ DDS_EXPORT inline int32_t dds_rhc_read (struct dds_rhc *rhc, bool lock, void **v
 }
 DDS_EXPORT inline int32_t dds_rhc_take (struct dds_rhc *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, struct dds_readcond *cond) {
   return rhc->common.ops->take (rhc, lock, values, info_seq, max_samples, mask, handle, cond);
+}
+DDS_EXPORT inline int32_t dds_rhc_readcdr (struct dds_rhc *rhc, bool lock, struct ddsi_serdata **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle) {
+  return rhc->common.ops->readcdr (rhc, lock, values, info_seq, max_samples, sample_states, view_states, instance_states, handle);
 }
 DDS_EXPORT inline int32_t dds_rhc_takecdr (struct dds_rhc *rhc, bool lock, struct ddsi_serdata **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle) {
   return rhc->common.ops->takecdr (rhc, lock, values, info_seq, max_samples, sample_states, view_states, instance_states, handle);

--- a/src/core/ddsc/src/dds_builtin.c
+++ b/src/core/ddsc/src/dds_builtin.c
@@ -15,6 +15,7 @@
 #include "dds/ddsi/q_entity.h"
 #include "dds/ddsi/q_thread.h"
 #include "dds/ddsi/q_config.h"
+#include "dds/ddsi/q_bswap.h"
 #include "dds/ddsi/ddsi_domaingv.h"
 #include "dds/ddsi/ddsi_plist.h"
 #include "dds__init.h"
@@ -180,10 +181,13 @@ static struct ddsi_tkmap_instance *dds__builtin_get_tkmap_entry (const struct dd
   struct dds_domain *domain = vdomain;
   struct ddsi_tkmap_instance *tk;
   struct ddsi_serdata *sd;
-  struct nn_keyhash kh;
-  memcpy (&kh, guid, sizeof (kh));
-  /* any random builtin topic will do (provided it has a GUID for a key), because what matters is the "class" of the topic, not the actual topic; also, this is called early in the initialisation of the entity with this GUID, which simply causes serdata_from_keyhash to create a key-only serdata because the key lookup fails. */
-  sd = ddsi_serdata_from_keyhash (domain->builtin_participant_topic, &kh);
+  union { ddsi_guid_t guid; nn_keyhash_t keyhash; } x;
+  x.guid = nn_hton_guid (*guid);
+  /* any random builtin topic will do (provided it has a GUID for a key), because what matters is the "class"
+     of the topic, not the actual topic; also, this is called early in the initialisation of the entity with
+     this GUID, which simply causes serdata_from_keyhash to create a key-only serdata because the key lookup
+     fails. */
+  sd = ddsi_serdata_from_keyhash (domain->builtin_participant_topic, &x.keyhash);
   tk = ddsi_tkmap_find (domain->gv.m_tkmap, sd, true);
   ddsi_serdata_unref (sd);
   return tk;
@@ -195,7 +199,7 @@ struct ddsi_serdata *dds__builtin_make_sample (const struct entity_common *e, dd
   struct dds_domain *dom = e->gv->builtin_topic_interface->arg;
   struct ddsi_sertopic *topic = NULL;
   struct ddsi_serdata *serdata;
-  struct nn_keyhash keyhash;
+  union { ddsi_guid_t guid; nn_keyhash_t keyhash; } x;
   switch (e->kind)
   {
     case EK_PARTICIPANT:
@@ -212,8 +216,8 @@ struct ddsi_serdata *dds__builtin_make_sample (const struct entity_common *e, dd
       break;
   }
   assert (topic != NULL);
-  memcpy (&keyhash, &e->guid, sizeof (keyhash));
-  serdata = ddsi_serdata_from_keyhash (topic, &keyhash);
+  x.guid = nn_hton_guid (e->guid);
+  serdata = ddsi_serdata_from_keyhash (topic, &x.keyhash);
   serdata->timestamp = timestamp;
   serdata->statusinfo = alive ? 0 : NN_STATUSINFO_DISPOSE | NN_STATUSINFO_UNREGISTER;
   return serdata;

--- a/src/core/ddsc/src/dds_rhc.c
+++ b/src/core/ddsc/src/dds_rhc.c
@@ -22,6 +22,7 @@ extern inline void dds_rhc_set_qos (struct dds_rhc *rhc, const struct dds_qos *q
 extern inline void dds_rhc_free (struct dds_rhc *rhc);
 extern inline int dds_rhc_read (struct dds_rhc *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, struct dds_readcond *cond);
 extern inline int dds_rhc_take (struct dds_rhc *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, struct dds_readcond *cond);
+extern inline int dds_rhc_readcdr (struct dds_rhc *rhc, bool lock, struct ddsi_serdata **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle);
 extern inline int dds_rhc_takecdr (struct dds_rhc *rhc, bool lock, struct ddsi_serdata **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle);
 extern inline bool dds_rhc_add_readcondition (struct dds_rhc *rhc, struct dds_readcond *cond);
 extern inline void dds_rhc_remove_readcondition (struct dds_rhc *rhc, struct dds_readcond *cond);

--- a/src/core/ddsc/src/dds_rhc_default.c
+++ b/src/core/ddsc/src/dds_rhc_default.c
@@ -695,7 +695,7 @@ static void inst_clear_invsample_if_exists (struct dds_rhc_default *rhc, struct 
     inst_clear_invsample (rhc, inst, trig_qc);
 }
 
-static void inst_set_invsample (struct dds_rhc_default *rhc, struct rhc_instance *inst, struct trigger_info_qcond *trig_qc, bool *nda)
+static void inst_set_invsample (struct dds_rhc_default *rhc, struct rhc_instance *inst, struct trigger_info_qcond *trig_qc, bool * __restrict nda)
 {
   if (inst->inv_exists && !inst->inv_isread)
   {
@@ -842,7 +842,7 @@ static bool trigger_info_differs (const struct dds_rhc_default *rhc, const struc
             trig_qc->dec_sample_read != trig_qc->inc_sample_read);
 }
 
-static bool add_sample (struct dds_rhc_default *rhc, struct rhc_instance *inst, const struct ddsi_writer_info *wrinfo, const struct ddsi_serdata *sample, status_cb_data_t *cb_data, struct trigger_info_qcond *trig_qc)
+static bool add_sample (struct dds_rhc_default *rhc, struct rhc_instance *inst, const struct ddsi_writer_info *wrinfo, const struct ddsi_serdata *sample, status_cb_data_t *cb_data, struct trigger_info_qcond *trig_qc, bool * __restrict nda)
 {
   struct rhc_sample *s;
 
@@ -936,6 +936,7 @@ static bool add_sample (struct dds_rhc_default *rhc, struct rhc_instance *inst, 
 
   trig_qc->inc_conds_sample = s->conds;
   inst->latest = s;
+  *nda = true;
   return true;
 }
 
@@ -1033,7 +1034,7 @@ static void drop_instance_noupdate_no_writers (struct dds_rhc_default *__restric
   *instptr = NULL;
 }
 
-static void dds_rhc_register (struct dds_rhc_default *rhc, struct rhc_instance *inst, uint64_t wr_iid, bool autodispose, bool iid_update)
+static void dds_rhc_register (struct dds_rhc_default *rhc, struct rhc_instance *inst, uint64_t wr_iid, bool autodispose, bool iid_update, bool * __restrict nda)
 {
   const uint64_t inst_wr_iid = inst->wr_iid_islive ? inst->wr_iid : 0;
 
@@ -1054,10 +1055,8 @@ static void dds_rhc_register (struct dds_rhc_default *rhc, struct rhc_instance *
        else. */
     TRACE ("cached");
     assert (inst->wrcount > 0);
-    return;
   }
-
-  if (inst->wrcount == 0)
+  else if (inst->wrcount == 0)
   {
     /* Currently no writers at all */
     assert (!inst->wr_iid_islive);
@@ -1075,6 +1074,7 @@ static void dds_rhc_register (struct dds_rhc_default *rhc, struct rhc_instance *
 
     if (!inst_is_empty (inst) && !inst->isdisposed)
       rhc->n_not_alive_no_writers--;
+    *nda = true;
   }
   else if (inst_wr_iid == 0 && inst->wrcount == 1)
   {
@@ -1136,6 +1136,7 @@ static void dds_rhc_register (struct dds_rhc_default *rhc, struct rhc_instance *
       inst->wrcount++;
       if (autodispose)
         inst->autodispose = 1;
+      *nda = true;
     }
     else
     {
@@ -1181,7 +1182,7 @@ static void account_for_nonempty_to_empty_transition (struct dds_rhc_default *__
   }
 }
 
-static int rhc_unregister_isreg_w_sideeffects (struct dds_rhc_default *rhc, const struct rhc_instance *inst, uint64_t wr_iid)
+static int rhc_unregister_delete_registration (struct dds_rhc_default *rhc, const struct rhc_instance *inst, uint64_t wr_iid)
 {
   /* Returns 1 if last registration just disappeared */
   if (inst->wrcount == 0)
@@ -1225,9 +1226,8 @@ static int rhc_unregister_isreg_w_sideeffects (struct dds_rhc_default *rhc, cons
   }
 }
 
-static int rhc_unregister_updateinst (struct dds_rhc_default *rhc, struct rhc_instance **instptr, const struct ddsi_writer_info * __restrict wrinfo, ddsrt_wctime_t tstamp, struct trigger_info_qcond *trig_qc, bool *nda)
+static int rhc_unregister_updateinst (struct dds_rhc_default *rhc, struct rhc_instance *inst, const struct ddsi_writer_info * __restrict wrinfo, ddsrt_wctime_t tstamp, struct trigger_info_qcond *trig_qc, bool * __restrict nda)
 {
-  struct rhc_instance * const inst = *instptr;
   assert (inst->wrcount > 0);
   if (wrinfo->auto_dispose)
     inst->autodispose = 1;
@@ -1273,6 +1273,7 @@ static int rhc_unregister_updateinst (struct dds_rhc_default *rhc, struct rhc_in
           inst->isdisposed = 1;
           rhc->n_not_alive_disposed++;
         }
+        *nda = true;
       }
       inst->wr_iid_islive = 0;
       return 0;
@@ -1297,34 +1298,27 @@ static int rhc_unregister_updateinst (struct dds_rhc_default *rhc, struct rhc_in
       }
       account_for_empty_to_nonempty_transition (rhc, inst);
       inst->wr_iid_islive = 0;
+      *nda = true;
       return 0;
     }
   }
 }
 
-static bool dds_rhc_unregister (struct dds_rhc_default *rhc, struct rhc_instance **instptr, const struct ddsi_writer_info * __restrict wrinfo, ddsrt_wctime_t tstamp, struct trigger_info_post *post, struct trigger_info_qcond *trig_qc)
+static void dds_rhc_unregister (struct dds_rhc_default *rhc, struct rhc_instance *inst, const struct ddsi_writer_info * __restrict wrinfo, ddsrt_wctime_t tstamp, struct trigger_info_post *post, struct trigger_info_qcond *trig_qc, bool * __restrict nda)
 {
-  struct rhc_instance * const inst = *instptr;
-  bool notify_data_available = false;
-
-  /* 'post' always gets set; instance may have been freed upon return. */
+  /* 'post' always gets set */
   TRACE (" unregister:");
-  if (!rhc_unregister_isreg_w_sideeffects (rhc, inst, wrinfo->iid))
-  {
+  if (!rhc_unregister_delete_registration (rhc, inst, wrinfo->iid)) {
     /* other registrations remain */
     get_trigger_info_cmn (&post->c, inst);
-  }
-  else if (rhc_unregister_updateinst (rhc, instptr, wrinfo, tstamp, trig_qc, &notify_data_available))
-  {
+  } else if (rhc_unregister_updateinst (rhc, inst, wrinfo, tstamp, trig_qc, nda)) {
     /* instance dropped */
     init_trigger_info_cmn_nonmatch (&post->c);
-  }
-  else
-  {
+  } else {
     /* no writers remain, but instance not empty */
     get_trigger_info_cmn (&post->c, inst);
   }
-  return notify_data_available;
+  TRACE (" nda=%d\n", *nda);
 }
 
 static struct rhc_instance *alloc_new_instance (struct dds_rhc_default *rhc, const struct ddsi_writer_info *wrinfo, struct ddsi_serdata *serdata, struct ddsi_tkmap_instance *tk)
@@ -1336,7 +1330,7 @@ static struct rhc_instance *alloc_new_instance (struct dds_rhc_default *rhc, con
   memset (inst, 0, sizeof (*inst));
   inst->iid = tk->m_iid;
   inst->tk = tk;
-  inst->wrcount = (serdata->statusinfo & NN_STATUSINFO_UNREGISTER) ? 0 : 1;
+  inst->wrcount = 1;
   inst->isdisposed = (serdata->statusinfo & NN_STATUSINFO_DISPOSE) != 0;
   inst->autodispose = wrinfo->auto_dispose;
   inst->deadline_reg = 0;
@@ -1362,7 +1356,7 @@ static struct rhc_instance *alloc_new_instance (struct dds_rhc_default *rhc, con
   return inst;
 }
 
-static rhc_store_result_t rhc_store_new_instance (struct rhc_instance **out_inst, struct dds_rhc_default *rhc, const struct ddsi_writer_info *wrinfo, struct ddsi_serdata *sample, struct ddsi_tkmap_instance *tk, const bool has_data, status_cb_data_t *cb_data, struct trigger_info_post *post, struct trigger_info_qcond *trig_qc)
+static rhc_store_result_t rhc_store_new_instance (struct rhc_instance **out_inst, struct dds_rhc_default *rhc, const struct ddsi_writer_info *wrinfo, struct ddsi_serdata *sample, struct ddsi_tkmap_instance *tk, const bool has_data, status_cb_data_t *cb_data, struct trigger_info_qcond *trig_qc, bool * __restrict nda)
 {
   struct rhc_instance *inst;
   int ret;
@@ -1400,7 +1394,7 @@ static rhc_store_result_t rhc_store_new_instance (struct rhc_instance **out_inst
   inst = alloc_new_instance (rhc, wrinfo, sample, tk);
   if (has_data)
   {
-    if (!add_sample (rhc, inst, wrinfo, sample, cb_data, trig_qc))
+    if (!add_sample (rhc, inst, wrinfo, sample, cb_data, trig_qc, nda))
     {
       free_empty_instance (inst, rhc);
       return RHC_REJECTED;
@@ -1408,10 +1402,8 @@ static rhc_store_result_t rhc_store_new_instance (struct rhc_instance **out_inst
   }
   else
   {
-    if (inst->isdisposed) {
-      bool nda_dummy = false;
-      inst_set_invsample (rhc, inst, trig_qc, &nda_dummy);
-    }
+    if (inst->isdisposed)
+      inst_set_invsample (rhc, inst, trig_qc, nda);
   }
 
   account_for_empty_to_nonempty_transition (rhc, inst);
@@ -1420,7 +1412,6 @@ static rhc_store_result_t rhc_store_new_instance (struct rhc_instance **out_inst
   (void) ret;
   rhc->n_instances++;
   rhc->n_new++;
-  get_trigger_info_cmn (&post->c, inst);
 
   *out_inst = inst;
   return RHC_STORED;
@@ -1462,6 +1453,43 @@ static void postprocess_instance_update (struct dds_rhc_default * __restrict rhc
     update_conditions_locked (rhc, true, pre, post, trig_qc, *instptr, triggers, ntriggers);
 
   assert (rhc_check_counts_locked (rhc, true, true));
+}
+
+static void update_viewstate_and_disposedness (struct dds_rhc_default * __restrict rhc, struct rhc_instance * __restrict inst, bool has_data, bool not_alive, bool is_dispose, bool * __restrict nda)
+{
+  /* Sample arriving for a NOT_ALIVE instance => view state NEW */
+  if (has_data && not_alive)
+  {
+    TRACE (" notalive->alive");
+    inst->isnew = 1;
+    *nda = true;
+  }
+
+  /* Desired effect on instance state and disposed_gen:
+       op     DISPOSED    NOT_DISPOSED
+       W      ND;gen++    ND
+       D      D           D
+       WD     D;gen++     D
+     Simplest way is to toggle istate when it is currently DISPOSED
+     and the operation is WD. */
+  if (has_data && inst->isdisposed)
+  {
+    TRACE (" disposed->notdisposed");
+    inst->disposed_gen++;
+    if (!is_dispose)
+      inst->isdisposed = 0;
+    *nda = true;
+  }
+  if (is_dispose)
+  {
+    bool wasdisposed = inst->isdisposed;
+    if (!inst->isdisposed)
+    {
+      inst->isdisposed = 1;
+      *nda = true;
+    }
+    TRACE (" dispose(%d)", !wasdisposed);
+  }
 }
 
 /*
@@ -1521,14 +1549,12 @@ static bool dds_rhc_default_store (struct ddsi_rhc * __restrict rhc_common, cons
     }
     else
     {
-      TRACE (" new instance");
-      stored = rhc_store_new_instance (&inst, rhc, wrinfo, sample, tk, has_data, &cb_data, &post, &trig_qc);
+      TRACE (" new instance\n");
+      stored = rhc_store_new_instance (&inst, rhc, wrinfo, sample, tk, has_data, &cb_data, &trig_qc, &notify_data_available);
       if (stored != RHC_STORED)
-      {
         goto error_or_nochange;
-      }
+
       init_trigger_info_cmn_nonmatch (&pre.c);
-      notify_data_available = true;
     }
   }
   else if (!inst_accepts_sample (rhc, inst, wrinfo, sample, has_data))
@@ -1542,25 +1568,13 @@ static bool dds_rhc_default_store (struct ddsi_rhc * __restrict rhc_common, cons
 
     get_trigger_info_pre (&pre, inst);
     if (has_data || is_dispose)
-    {
-      dds_rhc_register (rhc, inst, wr_iid, wrinfo->auto_dispose, false);
-    }
-    if (statusinfo & NN_STATUSINFO_UNREGISTER)
-    {
-      if (dds_rhc_unregister (rhc, &inst, wrinfo, sample->timestamp, &post, &trig_qc))
-        notify_data_available = true;
-    }
-    else
-    {
-      get_trigger_info_cmn (&post.c, inst);
-    }
-    /* notify sample lost */
+      dds_rhc_register (rhc, inst, wr_iid, wrinfo->auto_dispose, false, &notify_data_available);
 
+    /* notify sample lost */
     cb_data.raw_status_id = (int) DDS_SAMPLE_LOST_STATUS_ID;
     cb_data.extra = 0;
     cb_data.handle = 0;
     cb_data.add = true;
-    goto error_or_nochange;
   }
   else
   {
@@ -1579,7 +1593,6 @@ static bool dds_rhc_default_store (struct ddsi_rhc * __restrict rhc_common, cons
       const bool old_isdisposed = inst->isdisposed;
       const bool old_isnew = inst->isnew;
       const bool was_empty = inst_is_empty (inst);
-      int inst_became_disposed = 0;
 
       /* Not just an unregister, so a write and/or a dispose (possibly
          combined with an unregister).  Write & dispose create a
@@ -1589,66 +1602,29 @@ static bool dds_rhc_default_store (struct ddsi_rhc * __restrict rhc_common, cons
          (i.e., out-of-memory), abort the operation and hope that the
          caller can still notify the application.  */
 
-      dds_rhc_register (rhc, inst, wr_iid, wrinfo->auto_dispose, true);
+      dds_rhc_register (rhc, inst, wr_iid, wrinfo->auto_dispose, true, &notify_data_available);
+      update_viewstate_and_disposedness (rhc, inst, has_data, not_alive, is_dispose, &notify_data_available);
 
-      /* Sample arriving for a NOT_ALIVE instance => view state NEW */
-      if (has_data && not_alive)
-      {
-        TRACE (" notalive->alive");
-        inst->isnew = 1;
-      }
-
-      /* Desired effect on instance state and disposed_gen:
-         op     DISPOSED    NOT_DISPOSED
-         W      ND;gen++    ND
-         D      D           D
-         WD     D;gen++     D
-         Simplest way is to toggle istate when it is currently DISPOSED
-         and the operation is WD. */
-      if (has_data && inst->isdisposed)
-      {
-        TRACE (" disposed->notdisposed");
-        inst->isdisposed = 0;
-        inst->disposed_gen++;
-      }
-      if (is_dispose)
-      {
-        inst->isdisposed = 1;
-        inst_became_disposed = !old_isdisposed;
-        TRACE (" dispose(%d)", inst_became_disposed);
-      }
-
-      /* Only need to add a sample to the history if the input actually
-         is a sample. */
+      /* Only need to add a sample to the history if the input actually is a sample. */
       if (has_data)
       {
         TRACE (" add_sample");
-        if (!add_sample (rhc, inst, wrinfo, sample, &cb_data, &trig_qc))
+        if (!add_sample (rhc, inst, wrinfo, sample, &cb_data, &trig_qc, &notify_data_available))
         {
-          TRACE ("(reject)");
+          TRACE ("(reject)\n");
           stored = RHC_REJECTED;
 
           /* FIXME: fix the bad rejection handling, probably put back in a proper rollback, until then a band-aid like this will have to do: */
           inst->isnew = old_isnew;
           if (old_isdisposed)
-          {
             inst->disposed_gen--;
-            if (!inst->isdisposed)
-            {
-              inst->isdisposed = 1;
-            }
-          }
-          else if (inst->isdisposed)
-          {
-            inst->isdisposed = 0;
-          }
+          inst->isdisposed = old_isdisposed;
           goto error_or_nochange;
         }
-        notify_data_available = true;
       }
 
       /* If instance became disposed, add an invalid sample if there are no samples left */
-      if (inst_became_disposed && (inst->latest == NULL || inst->latest->isread))
+      if ((bool) inst->isdisposed > old_isdisposed && (inst->latest == NULL || inst->latest->isread))
         inst_set_invsample (rhc, inst, &trig_qc, &notify_data_available);
 
       update_inst (inst, wrinfo, true, sample->timestamp);
@@ -1658,7 +1634,7 @@ static bool dds_rhc_default_store (struct ddsi_rhc * __restrict rhc_common, cons
          guaranteed that we end up with a non-empty instance: for
          example, if the instance was disposed & empty, nothing
          changes. */
-      if (inst->latest || inst_became_disposed)
+      if (inst->latest || (bool) inst->isdisposed > old_isdisposed)
       {
         if (was_empty)
           account_for_empty_to_nonempty_transition (rhc, inst);
@@ -1672,29 +1648,30 @@ static bool dds_rhc_default_store (struct ddsi_rhc * __restrict rhc_common, cons
       }
     }
 
+    TRACE(" nda=%d\n", notify_data_available);
     assert (rhc_check_counts_locked (rhc, false, false));
+  }
 
-    if (statusinfo & NN_STATUSINFO_UNREGISTER)
-    {
-      /* Either a pure unregister, or the instance rejected the sample
-         because of time stamps, content filter, or something else.  If
-         the writer unregisters the instance, I think we should ignore
-         the acceptance filters and process it anyway.
+  if (statusinfo & NN_STATUSINFO_UNREGISTER)
+  {
+    /* Either a pure unregister, or the instance rejected the sample
+       because of time stamps, content filter, or something else.  If
+       the writer unregisters the instance, I think we should ignore
+       the acceptance filters and process it anyway.
 
-         It is a bit unclear what
+       It is a bit unclear what
 
-           write_w_timestamp(x,1) ; unregister_w_timestamp(x,0)
+         write_w_timestamp(x,1) ; unregister_w_timestamp(x,0)
 
-         actually means if BY_SOURCE ordering is selected: does that
-         mean an application reading "x" after the write and reading it
-         again after the unregister will see a change in the
-         no_writers_generation field? */
-      dds_rhc_unregister (rhc, &inst, wrinfo, sample->timestamp, &post, &trig_qc);
-    }
-    else
-    {
-      get_trigger_info_cmn (&post.c, inst);
-    }
+       actually means if BY_SOURCE ordering is selected: does that
+       mean an application reading "x" after the write and reading it
+       again after the unregister will see a change in the
+       no_writers_generation field? */
+    dds_rhc_unregister (rhc, inst, wrinfo, sample->timestamp, &post, &trig_qc, &notify_data_available);
+  }
+  else
+  {
+    get_trigger_info_cmn (&post.c, inst);
   }
 
   postprocess_instance_update (rhc, &inst, &pre, &post, &trig_qc, triggers, &ntriggers);
@@ -1736,7 +1713,6 @@ static void dds_rhc_default_unregister_wr (struct ddsi_rhc * __restrict rhc_comm
   struct rhc_instance *inst;
   struct ddsrt_hh_iter iter;
   const uint64_t wr_iid = wrinfo->iid;
-  const bool auto_dispose = wrinfo->auto_dispose;
   size_t ntriggers = SIZE_MAX;
 
   ddsrt_mutex_lock (&rhc->lock);
@@ -1751,47 +1727,16 @@ static void dds_rhc_default_unregister_wr (struct ddsi_rhc * __restrict rhc_comm
       struct trigger_info_qcond trig_qc;
       get_trigger_info_pre (&pre, inst);
       init_trigger_info_qcond (&trig_qc);
-
       TRACE ("  %"PRIx64":", inst->iid);
-
-      assert (inst->wrcount > 0);
-      if (auto_dispose && !inst->isdisposed)
-      {
-        notify_data_available = true;
-        inst->isdisposed = 1;
-
-        /* Set invalid sample for disposing it (unregister may also set it for unregistering) */
-        if (inst->latest && !inst->latest->isread)
-        {
-          assert (!inst->inv_exists);
-          rhc->n_not_alive_disposed++;
-        }
-        else
-        {
-          const bool was_empty = inst_is_empty (inst);
-          inst_set_invsample (rhc, inst, &trig_qc, &notify_data_available);
-          if (was_empty)
-            account_for_empty_to_nonempty_transition (rhc, inst);
-          else
-            rhc->n_not_alive_disposed++;
-        }
-      }
-
-      (void) dds_rhc_unregister (rhc, &inst, wrinfo, inst->tstamp, &post, &trig_qc);
-
+      dds_rhc_unregister (rhc, inst, wrinfo, inst->tstamp, &post, &trig_qc, &notify_data_available);
       postprocess_instance_update (rhc, &inst, &pre, &post, &trig_qc, NULL, &ntriggers);
       TRACE ("\n");
     }
   }
-  TRACE (")\n");
-
   ddsrt_mutex_unlock (&rhc->lock);
 
-  if (rhc->reader)
-  {
-    if (notify_data_available)
-      dds_reader_data_available_cb (rhc->reader);
-  }
+  if (rhc->reader && notify_data_available)
+    dds_reader_data_available_cb (rhc->reader);
 }
 
 static void dds_rhc_default_relinquish_ownership (struct ddsi_rhc * __restrict rhc_common, const uint64_t wr_iid)
@@ -2044,7 +1989,6 @@ static int32_t read_w_qminv_inst (struct dds_rhc_default * const __restrict rhc,
         to_sample (sample->sample, values + n, 0, 0);
         if (!sample->isread)
         {
-          TRACE ("s");
           read_sample_update_conditions (rhc, &pre, &post, &trig_qc, inst, sample->conds, false);
           sample->isread = true;
           inst->nvread++;
@@ -2063,7 +2007,6 @@ static int32_t read_w_qminv_inst (struct dds_rhc_default * const __restrict rhc,
     to_invsample (rhc->topic, inst->tk->m_sample, values + n, 0, 0);
     if (!inst->inv_isread)
     {
-      TRACE ("i");
       read_sample_update_conditions (rhc, &pre, &post, &trig_qc, inst, inst->conds, false);
       inst->inv_isread = 1;
       rhc->n_invread++;

--- a/src/core/ddsc/src/dds_rhc_default.c
+++ b/src/core/ddsc/src/dds_rhc_default.c
@@ -363,79 +363,7 @@ struct trigger_info_post {
   struct trigger_info_cmn c;
 };
 
-static void dds_rhc_default_free (struct dds_rhc_default *rhc);
-static bool dds_rhc_default_store (struct dds_rhc_default * __restrict rhc, const struct ddsi_writer_info * __restrict wrinfo, struct ddsi_serdata * __restrict sample, struct ddsi_tkmap_instance * __restrict tk);
-static void dds_rhc_default_unregister_wr (struct dds_rhc_default * __restrict rhc, const struct ddsi_writer_info * __restrict wrinfo);
-static void dds_rhc_default_relinquish_ownership (struct dds_rhc_default * __restrict rhc, const uint64_t wr_iid);
-static void dds_rhc_default_set_qos (struct dds_rhc_default *rhc, const struct dds_qos *qos);
-static int32_t dds_rhc_default_read (struct dds_rhc_default *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, dds_readcond *cond);
-static int32_t dds_rhc_default_take (struct dds_rhc_default *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, dds_readcond *cond);
-static int32_t dds_rhc_default_readcdr (struct dds_rhc_default *rhc, bool lock, struct ddsi_serdata ** values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle);
-static int32_t dds_rhc_default_takecdr (struct dds_rhc_default *rhc, bool lock, struct ddsi_serdata ** values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle);
-static bool dds_rhc_default_add_readcondition (struct dds_rhc_default *rhc, dds_readcond *cond);
-static void dds_rhc_default_remove_readcondition (struct dds_rhc_default *rhc, dds_readcond *cond);
-static uint32_t dds_rhc_default_lock_samples (struct dds_rhc_default *rhc);
-
-static void dds_rhc_default_free_wrap (struct ddsi_rhc *rhc) {
-  dds_rhc_default_free ((struct dds_rhc_default *) rhc);
-}
-static bool dds_rhc_default_store_wrap (struct ddsi_rhc * __restrict rhc, const struct ddsi_writer_info * __restrict wrinfo, struct ddsi_serdata * __restrict sample, struct ddsi_tkmap_instance * __restrict tk) {
-  return dds_rhc_default_store ((struct dds_rhc_default *) rhc, wrinfo, sample, tk);
-}
-static void dds_rhc_default_unregister_wr_wrap (struct ddsi_rhc * __restrict rhc, const struct ddsi_writer_info * __restrict wrinfo) {
-  dds_rhc_default_unregister_wr ((struct dds_rhc_default *) rhc, wrinfo);
-}
-static void dds_rhc_default_relinquish_ownership_wrap (struct ddsi_rhc * __restrict rhc, const uint64_t wr_iid) {
-  dds_rhc_default_relinquish_ownership ((struct dds_rhc_default *) rhc, wr_iid);
-}
-static void dds_rhc_default_set_qos_wrap (struct ddsi_rhc *rhc, const struct dds_qos *qos) {
-  dds_rhc_default_set_qos ((struct dds_rhc_default *) rhc, qos);
-}
-static int32_t dds_rhc_default_read_wrap (struct dds_rhc *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, dds_readcond *cond) {
-  return dds_rhc_default_read ((struct dds_rhc_default *) rhc, lock, values, info_seq, max_samples, mask, handle, cond);
-}
-static int32_t dds_rhc_default_take_wrap (struct dds_rhc *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, dds_readcond *cond) {
-  return dds_rhc_default_take ((struct dds_rhc_default *) rhc, lock, values, info_seq, max_samples, mask, handle, cond);
-}
-static int32_t dds_rhc_default_readcdr_wrap (struct dds_rhc *rhc, bool lock, struct ddsi_serdata **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle) {
-  return dds_rhc_default_readcdr ((struct dds_rhc_default *) rhc, lock, values, info_seq, max_samples, sample_states, view_states, instance_states, handle);
-}
-static int32_t dds_rhc_default_takecdr_wrap (struct dds_rhc *rhc, bool lock, struct ddsi_serdata **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle) {
-  return dds_rhc_default_takecdr ((struct dds_rhc_default *) rhc, lock, values, info_seq, max_samples, sample_states, view_states, instance_states, handle);
-}
-static bool dds_rhc_default_add_readcondition_wrap (struct dds_rhc *rhc, dds_readcond *cond) {
-  return dds_rhc_default_add_readcondition ((struct dds_rhc_default *) rhc, cond);
-}
-static void dds_rhc_default_remove_readcondition_wrap (struct dds_rhc *rhc, dds_readcond *cond) {
-  dds_rhc_default_remove_readcondition ((struct dds_rhc_default *) rhc, cond);
-}
-static uint32_t dds_rhc_default_lock_samples_wrap (struct dds_rhc *rhc) {
-  return dds_rhc_default_lock_samples ((struct dds_rhc_default *) rhc);
-}
-static dds_return_t dds_rhc_default_associate (struct dds_rhc *rhc, dds_reader *reader, const struct ddsi_sertopic *topic, struct ddsi_tkmap *tkmap)
-{
-  /* ignored out of laziness */
-  (void) rhc; (void) reader; (void) topic; (void) tkmap;
-  return DDS_RETCODE_OK;
-}
-
-static const struct dds_rhc_ops dds_rhc_default_ops = {
-  .rhc_ops = {
-    .store = dds_rhc_default_store_wrap,
-    .unregister_wr = dds_rhc_default_unregister_wr_wrap,
-    .relinquish_ownership = dds_rhc_default_relinquish_ownership_wrap,
-    .set_qos = dds_rhc_default_set_qos_wrap,
-    .free = dds_rhc_default_free_wrap
-  },
-  .read = dds_rhc_default_read_wrap,
-  .take = dds_rhc_default_take_wrap,
-  .readcdr = dds_rhc_default_readcdr_wrap,
-  .takecdr = dds_rhc_default_takecdr_wrap,
-  .add_readcondition = dds_rhc_default_add_readcondition_wrap,
-  .remove_readcondition = dds_rhc_default_remove_readcondition_wrap,
-  .lock_samples = dds_rhc_default_lock_samples_wrap,
-  .associate = dds_rhc_default_associate
-};
+static const struct dds_rhc_ops dds_rhc_default_ops;
 
 static uint32_t qmask_of_sample (const struct rhc_sample *s)
 {
@@ -675,8 +603,16 @@ struct dds_rhc *dds_rhc_default_new (dds_reader *reader, const struct ddsi_serto
   return dds_rhc_default_new_xchecks (reader, &reader->m_entity.m_domain->gv, topic, (reader->m_entity.m_domain->gv.config.enabled_xchecks & DDS_XCHECK_RHC) != 0);
 }
 
-static void dds_rhc_default_set_qos (struct dds_rhc_default * rhc, const dds_qos_t * qos)
+static dds_return_t dds_rhc_default_associate (struct dds_rhc *rhc, dds_reader *reader, const struct ddsi_sertopic *topic, struct ddsi_tkmap *tkmap)
 {
+  /* ignored out of laziness */
+  (void) rhc; (void) reader; (void) topic; (void) tkmap;
+  return DDS_RETCODE_OK;
+}
+
+static void dds_rhc_default_set_qos (struct ddsi_rhc *rhc_common, const dds_qos_t * qos)
+{
+  struct dds_rhc_default * const rhc = (struct dds_rhc_default *) rhc_common;
   /* Set read related QoS */
 
   rhc->max_samples = qos->resource_limits.max_samples;
@@ -822,8 +758,9 @@ static void free_instance_rhc_free (struct rhc_instance *inst, struct dds_rhc_de
   free_empty_instance(inst, rhc);
 }
 
-static uint32_t dds_rhc_default_lock_samples (struct dds_rhc_default *rhc)
+static uint32_t dds_rhc_default_lock_samples (struct dds_rhc *rhc_common)
 {
+  struct dds_rhc_default * const rhc = (struct dds_rhc_default *) rhc_common;
   uint32_t no;
   ddsrt_mutex_lock (&rhc->lock);
   no = rhc->n_vsamples + rhc->n_invsamples;
@@ -839,8 +776,9 @@ static void free_instance_rhc_free_wrap (void *vnode, void *varg)
   free_instance_rhc_free (vnode, varg);
 }
 
-static void dds_rhc_default_free (struct dds_rhc_default *rhc)
+static void dds_rhc_default_free (struct ddsi_rhc *rhc_common)
 {
+  struct dds_rhc_default *rhc = (struct dds_rhc_default *) rhc_common;
 #ifdef DDSI_INCLUDE_LIFESPAN
   dds_rhc_default_sample_expired_cb (rhc, DDSRT_MTIME_NEVER);
   lifespan_fini (&rhc->lifespan);
@@ -1464,8 +1402,9 @@ static rhc_store_result_t rhc_store_new_instance (struct rhc_instance **out_inst
   delivered (true unless a reliable sample rejected).
 */
 
-static bool dds_rhc_default_store (struct dds_rhc_default * __restrict rhc, const struct ddsi_writer_info * __restrict wrinfo, struct ddsi_serdata * __restrict sample, struct ddsi_tkmap_instance * __restrict tk)
+static bool dds_rhc_default_store (struct ddsi_rhc * __restrict rhc_common, const struct ddsi_writer_info * __restrict wrinfo, struct ddsi_serdata * __restrict sample, struct ddsi_tkmap_instance * __restrict tk)
 {
+  struct dds_rhc_default * const __restrict rhc = (struct dds_rhc_default * __restrict) rhc_common;
   const uint64_t wr_iid = wrinfo->iid;
   const uint32_t statusinfo = sample->statusinfo;
   const bool has_data = (sample->kind == SDK_DATA);
@@ -1740,7 +1679,7 @@ error_or_nochange:
   return delivered;
 }
 
-static void dds_rhc_default_unregister_wr (struct dds_rhc_default * __restrict rhc, const struct ddsi_writer_info * __restrict wrinfo)
+static void dds_rhc_default_unregister_wr (struct ddsi_rhc * __restrict rhc_common, const struct ddsi_writer_info * __restrict wrinfo)
 {
   /* Only to be called when writer with ID WR_IID has died.
 
@@ -1757,6 +1696,7 @@ static void dds_rhc_default_unregister_wr (struct dds_rhc_default * __restrict r
      need to get two IIDs: the one visible to the application in the
      built-in topics and in get_instance_handle, and one used internally
      for tracking registrations and unregistrations. */
+  struct dds_rhc_default * __restrict const rhc = (struct dds_rhc_default * __restrict) rhc_common;
   bool notify_data_available = false;
   struct rhc_instance *inst;
   struct ddsrt_hh_iter iter;
@@ -1825,8 +1765,9 @@ static void dds_rhc_default_unregister_wr (struct dds_rhc_default * __restrict r
   }
 }
 
-static void dds_rhc_default_relinquish_ownership (struct dds_rhc_default * __restrict rhc, const uint64_t wr_iid)
+static void dds_rhc_default_relinquish_ownership (struct ddsi_rhc * __restrict rhc_common, const uint64_t wr_iid)
 {
+  struct dds_rhc_default * __restrict const rhc = (struct dds_rhc_default * __restrict) rhc_common;
   struct rhc_instance *inst;
   struct ddsrt_hh_iter iter;
   ddsrt_mutex_lock (&rhc->lock);
@@ -2393,12 +2334,13 @@ static bool cond_is_sample_state_dependent (const struct dds_readcond *cond)
   }
 }
 
-static bool dds_rhc_default_add_readcondition (struct dds_rhc_default *rhc, dds_readcond *cond)
+static bool dds_rhc_default_add_readcondition (struct dds_rhc *rhc_common, dds_readcond *cond)
 {
   /* On the assumption that a readcondition will be attached to a
      waitset for nearly all of its life, we keep track of all
      readconditions on a reader in one set, without distinguishing
      between those attached to a waitset or not. */
+  struct dds_rhc_default * const rhc = (struct dds_rhc_default *) rhc_common;
   struct ddsrt_hh_iter it;
 
   assert ((dds_entity_kind (&cond->m_entity) == DDS_KIND_COND_READ && cond->m_query.m_filter == 0) ||
@@ -2498,8 +2440,9 @@ static bool dds_rhc_default_add_readcondition (struct dds_rhc_default *rhc, dds_
   return true;
 }
 
-static void dds_rhc_default_remove_readcondition (struct dds_rhc_default *rhc, dds_readcond *cond)
+static void dds_rhc_default_remove_readcondition (struct dds_rhc *rhc_common, dds_readcond *cond)
 {
+  struct dds_rhc_default * const rhc = (struct dds_rhc_default *) rhc_common;
   dds_readcond **ptr;
   ddsrt_mutex_lock (&rhc->lock);
   ptr = &rhc->conds;
@@ -2727,26 +2670,30 @@ static bool update_conditions_locked (struct dds_rhc_default *rhc, bool called_f
  ******  READ/TAKE  ******
  *************************/
 
-static int32_t dds_rhc_default_read (struct dds_rhc_default *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, dds_readcond *cond)
+static int32_t dds_rhc_default_read (struct dds_rhc *rhc_common, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, dds_readcond *cond)
 {
+  struct dds_rhc_default * const rhc = (struct dds_rhc_default *) rhc_common;
   uint32_t qminv = qmask_from_mask_n_cond (mask, cond);
   return dds_rhc_read_w_qminv (rhc, lock, values, info_seq, max_samples, qminv, handle, cond);
 }
 
-static int32_t dds_rhc_default_take (struct dds_rhc_default *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, dds_readcond *cond)
+static int32_t dds_rhc_default_take (struct dds_rhc *rhc_common, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, dds_readcond *cond)
 {
+  struct dds_rhc_default * const rhc = (struct dds_rhc_default *) rhc_common;
   uint32_t qminv = qmask_from_mask_n_cond(mask, cond);
   return dds_rhc_take_w_qminv (rhc, lock, values, info_seq, max_samples, qminv, handle, cond);
 }
 
-static int32_t dds_rhc_default_readcdr (struct dds_rhc_default *rhc, bool lock, struct ddsi_serdata ** values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle)
+static int32_t dds_rhc_default_readcdr (struct dds_rhc *rhc_common, bool lock, struct ddsi_serdata ** values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle)
 {
+  struct dds_rhc_default * const rhc = (struct dds_rhc_default *) rhc_common;
   uint32_t qminv = qmask_from_dcpsquery (sample_states, view_states, instance_states);
   return dds_rhc_readcdr_w_qminv (rhc, lock, values, info_seq, max_samples, qminv, handle, NULL);
 }
 
-static int32_t dds_rhc_default_takecdr (struct dds_rhc_default *rhc, bool lock, struct ddsi_serdata ** values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle)
+static int32_t dds_rhc_default_takecdr (struct dds_rhc *rhc_common, bool lock, struct ddsi_serdata ** values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle)
 {
+  struct dds_rhc_default * const rhc = (struct dds_rhc_default *) rhc_common;
   uint32_t qminv = qmask_from_dcpsquery (sample_states, view_states, instance_states);
   return dds_rhc_takecdr_w_qminv (rhc, lock, values, info_seq, max_samples, qminv, handle, NULL);
 }
@@ -2924,3 +2871,21 @@ static int rhc_check_counts_locked (struct dds_rhc_default *rhc, bool check_cond
 }
 #undef CHECK_MAX_CONDS
 #endif
+
+static const struct dds_rhc_ops dds_rhc_default_ops = {
+  .rhc_ops = {
+    .store = dds_rhc_default_store,
+    .unregister_wr = dds_rhc_default_unregister_wr,
+    .relinquish_ownership = dds_rhc_default_relinquish_ownership,
+    .set_qos = dds_rhc_default_set_qos,
+    .free = dds_rhc_default_free
+  },
+  .read = dds_rhc_default_read,
+  .take = dds_rhc_default_take,
+  .readcdr = dds_rhc_default_readcdr,
+  .takecdr = dds_rhc_default_takecdr,
+  .add_readcondition = dds_rhc_default_add_readcondition,
+  .remove_readcondition = dds_rhc_default_remove_readcondition,
+  .lock_samples = dds_rhc_default_lock_samples,
+  .associate = dds_rhc_default_associate
+};

--- a/src/core/ddsc/src/dds_rhc_default.c
+++ b/src/core/ddsc/src/dds_rhc_default.c
@@ -270,6 +270,7 @@ struct rhc_instance {
   unsigned wr_iid_islive : 1;  /* whether wr_iid is of a live writer */
   unsigned inv_exists : 1;     /* whether or not state change occurred since last sample (i.e., must return invalid sample) */
   unsigned inv_isread : 1;     /* whether or not that state change has been read before */
+  unsigned deadline_reg : 1;   /* whether or not registered for a deadline (== isdisposed, except store() defers updates) */
   uint32_t disposed_gen;       /* bloody generation counters - worst invention of mankind */
   uint32_t no_writers_gen;     /* __/ */
   int32_t strength;            /* "current" ownership strength */
@@ -713,7 +714,7 @@ static void free_empty_instance (struct rhc_instance *inst, struct dds_rhc_defau
   assert (inst_is_empty (inst));
   ddsi_tkmap_instance_unref (rhc->tkmap, inst->tk);
 #ifdef DDSI_INCLUDE_DEADLINE_MISSED
-  if (!inst->isdisposed)
+  if (inst->deadline_reg)
     deadline_unregister_instance_locked (&rhc->deadline, &inst->deadline);
 #endif
   ddsrt_free (inst);
@@ -917,11 +918,6 @@ static bool add_sample (struct dds_rhc_default *rhc, struct rhc_instance *inst, 
   s->inst = inst;
   s->lifespan.t_expire = wrinfo->lifespan_exp;
   lifespan_register_sample_locked (&rhc->lifespan, &s->lifespan);
-#endif
-#ifdef DDSI_INCLUDE_DEADLINE_MISSED
-  /* Only renew the deadline missed counter in case the sample is actually stored in the rhc */
-  if (!inst->isdisposed)
-    deadline_renew_instance_locked (&rhc->deadline, &inst->deadline);
 #endif
 
   s->conds = 0;
@@ -1264,8 +1260,7 @@ static int rhc_unregister_updateinst (struct dds_rhc_default *rhc, struct rhc_in
     else if (inst->isdisposed)
     {
       /* No content left, no registrations left, so drop */
-      TRACE (",#0,empty,disposed,drop");
-      drop_instance_noupdate_no_writers (rhc, instptr);
+      TRACE (",#0,empty,nowriters,disposed");
       return 1;
     }
     else
@@ -1318,6 +1313,7 @@ static struct rhc_instance *alloc_new_instance (struct dds_rhc_default *rhc, con
   inst->tk = tk;
   inst->wrcount = (serdata->statusinfo & NN_STATUSINFO_UNREGISTER) ? 0 : 1;
   inst->isdisposed = (serdata->statusinfo & NN_STATUSINFO_DISPOSE) != 0;
+  inst->deadline_reg = 0;
   inst->isnew = 1;
   inst->a_sample_free = 1;
   inst->conds = 0;
@@ -1337,12 +1333,6 @@ static struct rhc_instance *alloc_new_instance (struct dds_rhc_default *rhc, con
         inst->conds |= c->m_query.m_qcmask;
     }
   }
-
-#ifdef DDSI_INCLUDE_DEADLINE_MISSED
-  if (!inst->isdisposed)
-    deadline_register_instance_locked (&rhc->deadline, &inst->deadline, ddsrt_time_monotonic ());
-#endif
-
   return inst;
 }
 
@@ -1410,6 +1400,44 @@ static rhc_store_result_t rhc_store_new_instance (struct rhc_instance **out_inst
   return RHC_STORED;
 }
 
+static void postprocess_instance_update (struct dds_rhc_default * __restrict rhc, struct rhc_instance * __restrict * __restrict instptr, const struct trigger_info_pre *pre, const struct trigger_info_post *post, struct trigger_info_qcond *trig_qc, dds_entity *triggers[], size_t *ntriggers)
+{
+  {
+    struct rhc_instance *inst = *instptr;
+
+#ifdef DDSI_INCLUDE_DEADLINE_MISSED
+    if (inst->isdisposed)
+    {
+      if (inst->deadline_reg)
+      {
+        inst->deadline_reg = 0;
+        deadline_unregister_instance_locked (&rhc->deadline, &inst->deadline);
+      }
+    }
+    else
+    {
+      if (inst->deadline_reg)
+        deadline_renew_instance_locked (&rhc->deadline, &inst->deadline);
+      else
+      {
+        deadline_register_instance_locked (&rhc->deadline, &inst->deadline, ddsrt_time_monotonic ());
+        inst->deadline_reg = 1;
+      }
+    }
+#endif
+
+    if (inst_is_empty (inst) && inst->wrcount == 0)
+    {
+      drop_instance_noupdate_no_writers (rhc, instptr);
+    }
+  }
+
+  if (trigger_info_differs (rhc, pre, post, trig_qc))
+    update_conditions_locked (rhc, true, pre, post, trig_qc, *instptr, triggers, ntriggers);
+
+  assert (rhc_check_counts_locked (rhc, true, true));
+}
+
 /*
   dds_rhc_store: DDSI up call into read cache to store new sample. Returns whether sample
   delivered (true unless a reliable sample rejected).
@@ -1429,22 +1457,25 @@ static bool dds_rhc_default_store (struct ddsi_rhc * __restrict rhc_common, cons
   struct trigger_info_qcond trig_qc;
   rhc_store_result_t stored;
   status_cb_data_t cb_data;   /* Callback data for reader status callback */
-  bool delivered = true;
-  bool notify_data_available = false;
+  bool notify_data_available;
+  dds_entity *triggers[MAX_FAST_TRIGGERS];
+  size_t ntriggers;
 
-  TRACE ("rhc_store(%"PRIx64",%"PRIx64" si %x has_data %d:", tk->m_iid, wr_iid, statusinfo, has_data);
+  TRACE ("rhc_store %"PRIx64",%"PRIx64" si %x has_data %d:", tk->m_iid, wr_iid, statusinfo, has_data);
   if (!has_data && statusinfo == 0)
   {
     /* Write with nothing but a key -- I guess that would be a
        register, which we do implicitly. (Currently DDSI2 won't allow
        it through anyway.) */
-    TRACE (" ignore explicit register)\n");
-    return delivered;
+    TRACE (" ignore explicit register\n");
+    return true;
   }
 
+  notify_data_available = false;
   dummy_instance.iid = tk->m_iid;
   stored = RHC_FILTERED;
   cb_data.raw_status_id = -1;
+  ntriggers = 0;
 
   init_trigger_info_qcond (&trig_qc);
 
@@ -1459,7 +1490,7 @@ static bool dds_rhc_default_store (struct ddsi_rhc * __restrict rhc_common, cons
      */
     if (!has_data && !is_dispose)
     {
-      TRACE (" disp/unreg on unknown instance");
+      TRACE (" unreg on unknown instance\n");
       goto error_or_nochange;
     }
     else
@@ -1481,7 +1512,7 @@ static bool dds_rhc_default_store (struct ddsi_rhc * __restrict rhc_common, cons
        will raise a SAMPLE_REJECTED, and indicate that the system should
        kill itself.)  Not letting instances go to ALIVE or NEW based on
        a rejected sample - (no one knows, it seemed) */
-    TRACE (" instance rejects sample");
+    TRACE (" instance rejects sample\n");
 
     get_trigger_info_pre (&pre, inst);
     if (has_data || is_dispose)
@@ -1553,19 +1584,11 @@ static bool dds_rhc_default_store (struct ddsi_rhc * __restrict rhc_common, cons
         TRACE (" disposed->notdisposed");
         inst->isdisposed = 0;
         inst->disposed_gen++;
-#ifdef DDSI_INCLUDE_DEADLINE_MISSED
-        if (!is_dispose)
-          deadline_register_instance_locked (&rhc->deadline, &inst->deadline, ddsrt_time_monotonic ());
-#endif
       }
       if (is_dispose)
       {
         inst->isdisposed = 1;
         inst_became_disposed = !old_isdisposed;
-#ifdef DDSI_INCLUDE_DEADLINE_MISSED
-        if (inst_became_disposed)
-          deadline_unregister_instance_locked (&rhc->deadline, &inst->deadline);
-#endif
         TRACE (" dispose(%d)", inst_became_disposed);
       }
 
@@ -1587,17 +1610,11 @@ static bool dds_rhc_default_store (struct ddsi_rhc * __restrict rhc_common, cons
             if (!inst->isdisposed)
             {
               inst->isdisposed = 1;
-#ifdef DDSI_INCLUDE_DEADLINE_MISSED
-              deadline_unregister_instance_locked (&rhc->deadline, &inst->deadline);
-#endif
             }
           }
           else if (inst->isdisposed)
           {
             inst->isdisposed = 0;
-#ifdef DDSI_INCLUDE_DEADLINE_MISSED
-            deadline_register_instance_locked (&rhc->deadline, &inst->deadline, ddsrt_time_monotonic ());
-#endif
           }
           goto error_or_nochange;
         }
@@ -1654,15 +1671,9 @@ static bool dds_rhc_default_store (struct ddsi_rhc * __restrict rhc_common, cons
     }
   }
 
-  TRACE (")\n");
+  postprocess_instance_update (rhc, &inst, &pre, &post, &trig_qc, triggers, &ntriggers);
 
-  dds_entity *triggers[MAX_FAST_TRIGGERS];
-  size_t ntriggers = 0;
-  if (trigger_info_differs (rhc, &pre, &post, &trig_qc))
-    update_conditions_locked (rhc, true, &pre, &post, &trig_qc, inst, triggers, &ntriggers);
-
-  assert (rhc_check_counts_locked (rhc, true, true));
-
+error_or_nochange:
   ddsrt_mutex_unlock (&rhc->lock);
 
   if (rhc->reader)
@@ -1671,25 +1682,10 @@ static bool dds_rhc_default_store (struct ddsi_rhc * __restrict rhc_common, cons
       dds_reader_data_available_cb (rhc->reader);
     for (size_t i = 0; i < ntriggers; i++)
       dds_entity_status_signal (triggers[i], 0);
+    if (cb_data.raw_status_id >= 0)
+      dds_reader_status_cb (&rhc->reader->m_entity, &cb_data);
   }
-
-  return delivered;
-
-error_or_nochange:
-
-  if (rhc->reliable && (stored == RHC_REJECTED))
-  {
-    delivered = false;
-  }
-
-  ddsrt_mutex_unlock (&rhc->lock);
-  TRACE (")\n");
-
-  /* Make any reader status callback */
-
-  if (cb_data.raw_status_id >= 0 && rhc->reader)
-    dds_reader_status_cb (&rhc->reader->m_entity, &cb_data);
-  return delivered;
+  return !(rhc->reliable && stored == RHC_REJECTED);
 }
 
 static void dds_rhc_default_unregister_wr (struct ddsi_rhc * __restrict rhc_common, const struct ddsi_writer_info * __restrict wrinfo)
@@ -1736,9 +1732,6 @@ static void dds_rhc_default_unregister_wr (struct ddsi_rhc * __restrict rhc_comm
       if (auto_dispose && !inst->isdisposed)
       {
         inst->isdisposed = 1;
-#ifdef DDSI_INCLUDE_DEADLINE_MISSED
-        deadline_unregister_instance_locked (&rhc->deadline, &inst->deadline);
-#endif
 
         /* Set invalid sample for disposing it (unregister may also set it for unregistering) */
         if (inst->latest)
@@ -1759,12 +1752,8 @@ static void dds_rhc_default_unregister_wr (struct ddsi_rhc * __restrict rhc_comm
 
       (void) dds_rhc_unregister (rhc, &inst, wrinfo, inst->tstamp, &post, &trig_qc);
 
+      postprocess_instance_update (rhc, &inst, &pre, &post, &trig_qc, NULL, &ntriggers);
       TRACE ("\n");
-
-      notify_data_available = true;
-      if (trigger_info_differs (rhc, &pre, &post, &trig_qc))
-        update_conditions_locked (rhc, true, &pre, &post, &trig_qc, inst, NULL, &ntriggers);
-      assert (rhc_check_counts_locked (rhc, true, false));
     }
   }
   TRACE (")\n");

--- a/src/core/ddsc/src/dds_rhc_default.c
+++ b/src/core/ddsc/src/dds_rhc_default.c
@@ -1648,7 +1648,7 @@ static bool dds_rhc_default_store (struct ddsi_rhc * __restrict rhc_common, cons
       }
 
       /* If instance became disposed, add an invalid sample if there are no samples left */
-      if (inst_became_disposed && inst->latest == NULL)
+      if (inst_became_disposed && (inst->latest == NULL || inst->latest->isread))
         inst_set_invsample (rhc, inst, &trig_qc, &notify_data_available);
 
       update_inst (inst, wrinfo, true, sample->timestamp);

--- a/src/core/ddsc/tests/deadline.c
+++ b/src/core/ddsc/tests/deadline.c
@@ -125,6 +125,7 @@ static void deadline_init(void)
   dds_qset_history(g_qos, DDS_HISTORY_KEEP_ALL, DDS_LENGTH_UNLIMITED);
   dds_qset_durability(g_qos, DDS_DURABILITY_TRANSIENT_LOCAL);
   dds_qset_reliability(g_qos, DDS_RELIABILITY_RELIABLE, DDS_INFINITY);
+  dds_qset_writer_data_lifecycle(g_qos, false);
 }
 
 static void deadline_fini(void)
@@ -422,7 +423,10 @@ CU_Theory((int32_t n_inst, uint8_t unreg_nth, uint8_t dispose_nth), ddsc_deadlin
         n_dispose++;
       }
     }
-    n_alive = n_inst - n_dispose - n_unreg;
+    /* FIXME: should unregistered instances cause deadline expirations? I do think so
+       and that is what it actually implemented
+       if they shouldn't: n_alive = n_inst - n_dispose - n_unreg */
+    n_alive = n_inst - n_dispose;
 
     /* Sleep deadline_dur + 50% and check missed deadline count */
     sleepfor(3 * deadline_dur / 2);

--- a/src/core/ddsc/tests/listener.c
+++ b/src/core/ddsc/tests/listener.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -9,1254 +9,1249 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
+#include <stdlib.h>
+
 #include "dds/dds.h"
-
-#include "dds/ddsrt/cdtors.h"
 #include "dds/ddsrt/misc.h"
-#include "dds/ddsrt/process.h"
 #include "dds/ddsrt/sync.h"
-#include "dds/ddsrt/threads.h"
-
+#include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/string.h"
+#include "dds/ddsrt/environ.h"
 #include "test_common.h"
 
-/****************************************************************************
- * TODO: Add DDS_INCONSISTENT_TOPIC_STATUS test
- * TODO: Add DDS_OFFERED/REQUESTED_DEADLINE_MISSED_STATUS test
- * TODO: Add DDS_LIVELINESS_LOST_STATUS test
- * TODO: Check DDS_REQUESTED_INCOMPATIBLE_QOS_STATUS intermittent fail (total_count != 1)
- ****************************************************************************/
+static ddsrt_mutex_t g_mutex;
+static ddsrt_cond_t g_cond;
+static uint32_t cb_called;
+static dds_entity_t cb_topic, cb_writer, cb_reader, cb_subscriber;
 
-/****************************************************************************
- * Convenience test macros.
- ****************************************************************************/
+#define DEFINE_STATUS_CALLBACK(name, NAME, kind) \
+  static dds_##name##_status_t cb_##name##_status; \
+  static void name##_cb (dds_entity_t kind, const dds_##name##_status_t status, void *arg) \
+  { \
+    (void) arg; \
+    ddsrt_mutex_lock (&g_mutex); \
+    cb_##kind = kind; \
+    cb_##name##_status = status; \
+    cb_called |= DDS_##NAME##_STATUS; \
+    ddsrt_cond_broadcast (&g_cond); \
+    ddsrt_mutex_unlock (&g_mutex); \
+  }
+
+DEFINE_STATUS_CALLBACK (inconsistent_topic, INCONSISTENT_TOPIC, topic)
+DEFINE_STATUS_CALLBACK (liveliness_changed, LIVELINESS_CHANGED, reader)
+DEFINE_STATUS_CALLBACK (liveliness_lost, LIVELINESS_LOST, writer)
+DEFINE_STATUS_CALLBACK (offered_deadline_missed, OFFERED_DEADLINE_MISSED, writer)
+DEFINE_STATUS_CALLBACK (offered_incompatible_qos, OFFERED_INCOMPATIBLE_QOS, writer)
+DEFINE_STATUS_CALLBACK (publication_matched, PUBLICATION_MATCHED, writer)
+DEFINE_STATUS_CALLBACK (requested_deadline_missed, REQUESTED_DEADLINE_MISSED, reader)
+DEFINE_STATUS_CALLBACK (requested_incompatible_qos, REQUESTED_INCOMPATIBLE_QOS, reader)
+DEFINE_STATUS_CALLBACK (sample_lost, SAMPLE_LOST, reader)
+DEFINE_STATUS_CALLBACK (sample_rejected, SAMPLE_REJECTED, reader)
+DEFINE_STATUS_CALLBACK (subscription_matched, SUBSCRIPTION_MATCHED, reader)
+
+static void data_on_readers_cb (dds_entity_t subscriber, void *arg)
+{
+  (void) arg;
+  ddsrt_mutex_lock (&g_mutex);
+  cb_subscriber = subscriber;
+  cb_called |= DDS_DATA_ON_READERS_STATUS;
+  ddsrt_cond_broadcast (&g_cond);
+  ddsrt_mutex_unlock (&g_mutex);
+}
+
+static void data_available_cb (dds_entity_t reader, void *arg)
+{
+  (void)arg;
+  ddsrt_mutex_lock (&g_mutex);
+  cb_reader = reader;
+  cb_called |= DDS_DATA_AVAILABLE_STATUS;
+  ddsrt_cond_broadcast (&g_cond);
+  ddsrt_mutex_unlock (&g_mutex);
+}
+
+static void dummy_data_on_readers_cb (dds_entity_t subscriber, void *arg)
+{
+  (void)subscriber;
+  (void)arg;
+}
+
+static void dummy_data_available_cb (dds_entity_t reader, void *arg)
+{
+  (void)reader;
+  (void)arg;
+}
+
+static void dummy_subscription_matched_cb (dds_entity_t reader, const dds_subscription_matched_status_t status, void *arg)
+{
+  (void)reader;
+  (void)status;
+  (void)arg;
+}
+
+static void dummy_liveliness_changed_cb (dds_entity_t reader, const dds_liveliness_changed_status_t status, void *arg)
+{
+  (void)reader;
+  (void)status;
+  (void)arg;
+}
+
+static void dummy_cb (void)
+{
+  // Used as a listener function in checking merging of listeners,
+  // and for that purpose, casting it to whatever function type is
+  // required is ok.  It is not supposed to ever be called.
+  abort ();
+}
+
+#undef DEFINE_STATUS_CALLBACK
+
+/**************************************************
+ ****                                          ****
+ ****  create/delete/get/set/copy/merge/reset  ****
+ ****                                          ****
+ **************************************************/
+
+static void set_all_const (dds_listener_t *l, void (*c) (void))
+{
+  dds_lset_data_available (l, (dds_on_data_available_fn) c);
+  dds_lset_data_on_readers (l, (dds_on_data_on_readers_fn) c);
+  dds_lset_inconsistent_topic (l, (dds_on_inconsistent_topic_fn) c);
+  dds_lset_liveliness_changed (l, (dds_on_liveliness_changed_fn) c);
+  dds_lset_liveliness_lost (l, (dds_on_liveliness_lost_fn) c);
+  dds_lset_offered_deadline_missed (l, (dds_on_offered_deadline_missed_fn) c);
+  dds_lset_offered_incompatible_qos (l, (dds_on_offered_incompatible_qos_fn) c);
+  dds_lset_publication_matched (l, (dds_on_publication_matched_fn) c);
+  dds_lset_requested_deadline_missed (l, (dds_on_requested_deadline_missed_fn) c);
+  dds_lset_requested_incompatible_qos (l, (dds_on_requested_incompatible_qos_fn) c);
+  dds_lset_sample_lost (l, (dds_on_sample_lost_fn) c);
+  dds_lset_sample_rejected (l, (dds_on_sample_rejected_fn) c);
+  dds_lset_subscription_matched (l, (dds_on_subscription_matched_fn) c);
+}
+
+static void set_all (dds_listener_t *l)
+{
+  dds_lset_data_available (l, data_available_cb);
+  dds_lset_data_on_readers (l, data_on_readers_cb);
+  dds_lset_inconsistent_topic (l, inconsistent_topic_cb);
+  dds_lset_liveliness_changed (l, liveliness_changed_cb);
+  dds_lset_liveliness_lost (l, liveliness_lost_cb);
+  dds_lset_offered_deadline_missed (l, offered_deadline_missed_cb);
+  dds_lset_offered_incompatible_qos (l, offered_incompatible_qos_cb);
+  dds_lset_publication_matched (l, publication_matched_cb);
+  dds_lset_requested_deadline_missed (l, requested_deadline_missed_cb);
+  dds_lset_requested_incompatible_qos (l, requested_incompatible_qos_cb);
+  dds_lset_sample_lost (l, sample_lost_cb);
+  dds_lset_sample_rejected (l, sample_rejected_cb);
+  dds_lset_subscription_matched (l, subscription_matched_cb);
+}
+
 #define ASSERT_CALLBACK_EQUAL(fntype, listener, expected) \
-    do { \
-        dds_on_##fntype##_fn cb; \
-        dds_lget_##fntype(listener, &cb); \
-        CU_ASSERT_EQUAL(cb, expected); \
-    } while (0)
+  do { \
+    dds_on_##fntype##_fn cb; \
+    dds_lget_##fntype(listener, &cb); \
+    CU_ASSERT_EQUAL(cb, expected); \
+  } while (0)
 
-#define STR(fntype) #fntype##_cb
-
-#define TEST_GET_SET(listener, fntype, cb) \
-    do { \
-        dds_on_##fntype##_fn dummy = NULL; \
-        /* Initially expect DDS_LUNSET on a newly created listener */ \
-        ASSERT_CALLBACK_EQUAL(fntype, listener, DDS_LUNSET); \
-        /* Using listener or callback NULL, shouldn't crash and be noop */ \
-        dds_lset_##fntype(NULL, NULL); \
-        dds_lget_##fntype(NULL, NULL); \
-        dds_lget_##fntype(listener, NULL); \
-        dds_lget_##fntype(NULL, &dummy);  \
-        CU_ASSERT_EQUAL_FATAL(dummy, NULL); \
-        /* Set to NULL, get to confirm it succeeds */ \
-        dds_lset_##fntype(listener, NULL); \
-        ASSERT_CALLBACK_EQUAL(fntype, listener, NULL); \
-        /* Set to a proper cb method, get to confirm it succeeds */ \
-        dds_lset_##fntype(listener, cb); \
-        ASSERT_CALLBACK_EQUAL(fntype, listener, cb); \
-    } while (0)
-
-
-
-/****************************************************************************
- * Test globals.
- ****************************************************************************/
-static dds_entity_t    g_participant = 0;
-static dds_entity_t    g_subscriber  = 0;
-static dds_entity_t    g_publisher   = 0;
-static dds_entity_t    g_topic       = 0;
-static dds_entity_t    g_writer      = 0;
-static dds_entity_t    g_reader      = 0;
-
-static dds_listener_t *g_listener = NULL;
-static dds_qos_t      *g_qos = NULL;
-static ddsrt_mutex_t   g_mutex;
-static ddsrt_cond_t    g_cond;
-
-
-
-/****************************************************************************
- * Callback stuff.
- ****************************************************************************/
-static uint32_t        cb_called     = 0;
-static dds_entity_t    cb_topic      = 0;
-static dds_entity_t    cb_writer     = 0;
-static dds_entity_t    cb_reader     = 0;
-static dds_entity_t    cb_subscriber = 0;
-
-static dds_inconsistent_topic_status_t          cb_inconsistent_topic_status;
-static dds_liveliness_lost_status_t             cb_liveliness_lost_status;
-static dds_offered_deadline_missed_status_t     cb_offered_deadline_missed_status;
-static dds_offered_incompatible_qos_status_t    cb_offered_incompatible_qos_status;
-static dds_sample_lost_status_t                 cb_sample_lost_status;
-static dds_sample_rejected_status_t             cb_sample_rejected_status;
-static dds_liveliness_changed_status_t          cb_liveliness_changed_status;
-static dds_requested_deadline_missed_status_t   cb_requested_deadline_missed_status;
-static dds_requested_incompatible_qos_status_t  cb_requested_incompatible_qos_status;
-static dds_publication_matched_status_t         cb_publication_matched_status;
-static dds_subscription_matched_status_t        cb_subscription_matched_status;
-
-
-static void
-inconsistent_topic_cb(
-        dds_entity_t topic,
-        const dds_inconsistent_topic_status_t status, void* arg)
+static void check_all_const (const dds_listener_t *l, void (*c) (void))
 {
-    (void)arg;
-    ddsrt_mutex_lock(&g_mutex);
-    cb_topic = topic;
-    cb_inconsistent_topic_status = status;
-    cb_called |= DDS_INCONSISTENT_TOPIC_STATUS;
-    ddsrt_cond_broadcast(&g_cond);
-    ddsrt_mutex_unlock(&g_mutex);
+  ASSERT_CALLBACK_EQUAL (data_available, l, (dds_on_data_available_fn) c);
+  ASSERT_CALLBACK_EQUAL (data_on_readers, l, (dds_on_data_on_readers_fn) c);
+  ASSERT_CALLBACK_EQUAL (inconsistent_topic, l, (dds_on_inconsistent_topic_fn) c);
+  ASSERT_CALLBACK_EQUAL (liveliness_changed, l, (dds_on_liveliness_changed_fn) c);
+  ASSERT_CALLBACK_EQUAL (liveliness_lost, l, (dds_on_liveliness_lost_fn) c);
+  ASSERT_CALLBACK_EQUAL (offered_deadline_missed, l, (dds_on_offered_deadline_missed_fn) c);
+  ASSERT_CALLBACK_EQUAL (offered_incompatible_qos, l, (dds_on_offered_incompatible_qos_fn) c);
+  ASSERT_CALLBACK_EQUAL (publication_matched, l, (dds_on_publication_matched_fn) c);
+  ASSERT_CALLBACK_EQUAL (requested_deadline_missed, l, (dds_on_requested_deadline_missed_fn) c);
+  ASSERT_CALLBACK_EQUAL (requested_incompatible_qos, l, (dds_on_requested_incompatible_qos_fn) c);
+  ASSERT_CALLBACK_EQUAL (sample_lost, l, (dds_on_sample_lost_fn) c);
+  ASSERT_CALLBACK_EQUAL (sample_rejected, l, (dds_on_sample_rejected_fn) c);
+  ASSERT_CALLBACK_EQUAL (subscription_matched, l, (dds_on_subscription_matched_fn) c);
 }
 
-static void
-liveliness_lost_cb(
-        dds_entity_t writer,
-        const dds_liveliness_lost_status_t status,
-        void* arg)
+static void check_all (const dds_listener_t *l)
 {
-    (void)arg;
-    ddsrt_mutex_lock(&g_mutex);
-    cb_writer = writer;
-    cb_liveliness_lost_status = status;
-    cb_called |= DDS_LIVELINESS_LOST_STATUS;
-    ddsrt_cond_broadcast(&g_cond);
-    ddsrt_mutex_unlock(&g_mutex);
+  ASSERT_CALLBACK_EQUAL (data_available, l, data_available_cb);
+  ASSERT_CALLBACK_EQUAL (data_on_readers, l, data_on_readers_cb);
+  ASSERT_CALLBACK_EQUAL (inconsistent_topic, l, inconsistent_topic_cb);
+  ASSERT_CALLBACK_EQUAL (liveliness_changed, l, liveliness_changed_cb);
+  ASSERT_CALLBACK_EQUAL (liveliness_lost, l, liveliness_lost_cb);
+  ASSERT_CALLBACK_EQUAL (offered_deadline_missed, l, offered_deadline_missed_cb);
+  ASSERT_CALLBACK_EQUAL (offered_incompatible_qos, l, offered_incompatible_qos_cb);
+  ASSERT_CALLBACK_EQUAL (publication_matched, l, publication_matched_cb);
+  ASSERT_CALLBACK_EQUAL (requested_deadline_missed, l, requested_deadline_missed_cb);
+  ASSERT_CALLBACK_EQUAL (requested_incompatible_qos, l, requested_incompatible_qos_cb);
+  ASSERT_CALLBACK_EQUAL (sample_lost, l, sample_lost_cb);
+  ASSERT_CALLBACK_EQUAL (sample_rejected, l, sample_rejected_cb);
+  ASSERT_CALLBACK_EQUAL (subscription_matched, l, subscription_matched_cb);
 }
 
-static void
-offered_deadline_missed_cb(
-        dds_entity_t writer,
-        const dds_offered_deadline_missed_status_t status,
-        void* arg)
+CU_Test (ddsc_listener, create_and_delete)
 {
-    (void)arg;
-    ddsrt_mutex_lock(&g_mutex);
-    cb_writer = writer;
-    cb_offered_deadline_missed_status = status;
-    cb_called |= DDS_OFFERED_DEADLINE_MISSED_STATUS;
-    ddsrt_cond_broadcast(&g_cond);
-    ddsrt_mutex_unlock(&g_mutex);
+  dds_listener_t *listener = dds_create_listener (NULL);
+  CU_ASSERT_PTR_NOT_NULL_FATAL (listener);
+  check_all_const (listener, 0);
+  dds_delete_listener (listener);
+
+  // check delete_listeners handles a null pointer gracefully
+  dds_delete_listener (NULL);
 }
 
-static void
-offered_incompatible_qos_cb(
-        dds_entity_t writer,
-        const dds_offered_incompatible_qos_status_t status,
-        void* arg)
+CU_Test (ddsc_listener, reset)
 {
-    (void)arg;
-    ddsrt_mutex_lock(&g_mutex);
-    cb_writer = writer;
-    cb_offered_incompatible_qos_status = status;
-    cb_called |= DDS_OFFERED_INCOMPATIBLE_QOS_STATUS;
-    ddsrt_cond_broadcast(&g_cond);
-    ddsrt_mutex_unlock(&g_mutex);
+  dds_listener_t *listener = dds_create_listener (NULL);
+  CU_ASSERT_PTR_NOT_NULL_FATAL (listener);
+
+  set_all (listener);
+
+  // all callbacks should revert to default after reset
+  dds_reset_listener (listener);
+  check_all_const (listener, 0);
+  dds_delete_listener (listener);
+
+  // check reset_listeners handles a null pointer gracefully
+  dds_reset_listener (NULL);
 }
 
-static void
-data_on_readers_cb(
-        dds_entity_t subscriber,
-        void* arg)
+CU_Test (ddsc_listener, copy)
 {
-    (void)arg;
-    ddsrt_mutex_lock(&g_mutex);
-    cb_subscriber = subscriber;
-    cb_called |= DDS_DATA_ON_READERS_STATUS;
-    ddsrt_cond_broadcast(&g_cond);
-    ddsrt_mutex_unlock(&g_mutex);
+  dds_listener_t *listener1 = dds_create_listener (NULL);
+  CU_ASSERT_PTR_NOT_NULL_FATAL (listener1);
+  set_all (listener1);
+
+  dds_listener_t *listener2 = dds_create_listener (NULL);
+  CU_ASSERT_PTR_NOT_NULL_FATAL (listener2);
+  dds_copy_listener (listener2, listener1);
+  check_all (listener2);
+
+  // Calling copy with NULL should not crash and be noops
+  dds_copy_listener (listener2, NULL);
+  dds_copy_listener (NULL, listener1);
+  dds_copy_listener (NULL, NULL);
+
+  dds_delete_listener (listener1);
+  dds_delete_listener (listener2);
 }
 
-static void
-sample_lost_cb(
-        dds_entity_t reader,
-        const dds_sample_lost_status_t status,
-        void* arg)
+CU_Test (ddsc_listener, merge)
 {
-    (void)arg;
-    ddsrt_mutex_lock(&g_mutex);
-    cb_reader = reader;
-    cb_sample_lost_status = status;
-    cb_called |= DDS_SAMPLE_LOST_STATUS;
-    ddsrt_cond_broadcast(&g_cond);
-    ddsrt_mutex_unlock(&g_mutex);
-}
+  dds_listener_t *listener1 = dds_create_listener (NULL);
+  CU_ASSERT_PTR_NOT_NULL_FATAL (listener1);
+  set_all (listener1);
 
-static void
-data_available_cb(
-        dds_entity_t reader,
-        void* arg)
-{
-    (void)arg;
-    ddsrt_mutex_lock(&g_mutex);
-    cb_reader = reader;
-    cb_called |= DDS_DATA_AVAILABLE_STATUS;
-    ddsrt_cond_broadcast(&g_cond);
-    ddsrt_mutex_unlock(&g_mutex);
-}
+  // Merging listener1 into empty listener2 be like a copy
+  dds_listener_t *listener2 = dds_create_listener (NULL);
+  CU_ASSERT_PTR_NOT_NULL_FATAL (listener2);
+  dds_merge_listener (listener2, listener1);
+  check_all (listener2);
 
-static void
-sample_rejected_cb(
-        dds_entity_t reader,
-        const dds_sample_rejected_status_t status,
-        void* arg)
-{
-    (void)arg;
-    ddsrt_mutex_lock(&g_mutex);
-    cb_reader = reader;
-    cb_sample_rejected_status = status;
-    cb_called |= DDS_SAMPLE_REJECTED_STATUS;
-    ddsrt_cond_broadcast(&g_cond);
-    ddsrt_mutex_unlock(&g_mutex);
-}
+  // Merging listener into a full listener2 should not overwrite anything
+  set_all_const (listener2, dummy_cb);
+  dds_merge_listener (listener2, listener1);
+  check_all_const (listener2, dummy_cb);
 
-static void
-liveliness_changed_cb(
-        dds_entity_t reader,
-        const dds_liveliness_changed_status_t status,
-        void* arg)
-{
-    (void)arg;
-    ddsrt_mutex_lock(&g_mutex);
-    cb_reader = reader;
-    cb_liveliness_changed_status = status;
-    cb_called |= DDS_LIVELINESS_CHANGED_STATUS;
-    ddsrt_cond_broadcast(&g_cond);
-    ddsrt_mutex_unlock(&g_mutex);
-}
+  // Using NULLs shouldn't crash and be noops
+  dds_merge_listener (listener2, NULL);
+  dds_merge_listener (NULL, listener1);
+  dds_merge_listener (NULL, NULL);
 
-static void
-requested_deadline_missed_cb(
-        dds_entity_t reader,
-        const dds_requested_deadline_missed_status_t status,
-        void* arg)
-{
-    (void)arg;
-    ddsrt_mutex_lock(&g_mutex);
-    cb_reader = reader;
-    cb_requested_deadline_missed_status = status;
-    cb_called |= DDS_REQUESTED_DEADLINE_MISSED_STATUS;
-    ddsrt_cond_broadcast(&g_cond);
-    ddsrt_mutex_unlock(&g_mutex);
-}
-
-static void
-requested_incompatible_qos_cb(
-        dds_entity_t reader,
-        const dds_requested_incompatible_qos_status_t status,
-        void* arg)
-{
-    (void)arg;
-    ddsrt_mutex_lock(&g_mutex);
-    cb_reader = reader;
-    cb_requested_incompatible_qos_status = status;
-    cb_called |= DDS_REQUESTED_INCOMPATIBLE_QOS_STATUS;
-    ddsrt_cond_broadcast(&g_cond);
-    ddsrt_mutex_unlock(&g_mutex);
-}
-
-static void
-publication_matched_cb(
-        dds_entity_t writer,
-        const dds_publication_matched_status_t status,
-        void* arg)
-{
-    (void)arg;
-    ddsrt_mutex_lock(&g_mutex);
-    cb_writer = writer;
-    cb_publication_matched_status = status;
-    cb_called |= DDS_PUBLICATION_MATCHED_STATUS;
-    ddsrt_cond_broadcast(&g_cond);
-    ddsrt_mutex_unlock(&g_mutex);
-}
-
-static void
-subscription_matched_cb(
-        dds_entity_t reader,
-        const dds_subscription_matched_status_t status,
-        void* arg)
-{
-    (void)arg;
-    ddsrt_mutex_lock(&g_mutex);
-    cb_reader = reader;
-    cb_subscription_matched_status = status;
-    cb_called |= DDS_SUBSCRIPTION_MATCHED_STATUS;
-    ddsrt_cond_broadcast(&g_cond);
-    ddsrt_mutex_unlock(&g_mutex);
-}
-
-static void
-callback_dummy(void)
-{
-}
-
-static uint32_t
-waitfor_cb(uint32_t expected)
-{
-    dds_time_t timeout = 5 * DDS_NSECS_IN_SEC;
-    bool signalled = true;
-    ddsrt_mutex_lock(&g_mutex);
-    while (((cb_called & expected) != expected) && (signalled)) {
-        signalled = ddsrt_cond_waitfor(&g_cond, &g_mutex, timeout);
-    }
-    ddsrt_mutex_unlock(&g_mutex);
-    return cb_called;
-}
-
-
-
-/****************************************************************************
- * Test initializations and teardowns.
- ****************************************************************************/
-
-static void
-init_triggering_base(void)
-{
-    char name[100];
-
-    ddsrt_init();
-
-    ddsrt_mutex_init(&g_mutex);
-    ddsrt_cond_init(&g_cond);
-
-    g_participant = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL, NULL);
-    CU_ASSERT_FATAL(g_participant > 0);
-
-    g_subscriber = dds_create_subscriber(g_participant, NULL, NULL);
-    CU_ASSERT_FATAL(g_subscriber > 0);
-
-    g_publisher = dds_create_publisher(g_participant, NULL, NULL);
-    CU_ASSERT_FATAL(g_publisher > 0);
-
-    g_topic = dds_create_topic(g_participant, &RoundTripModule_DataType_desc, create_unique_topic_name("ddsc_listener_test", name, 100), NULL, NULL);
-    CU_ASSERT_FATAL(g_topic > 0);
-
-    g_listener = dds_create_listener(NULL);
-    CU_ASSERT_PTR_NOT_NULL_FATAL(g_listener);
-
-    g_qos = dds_create_qos();
-    CU_ASSERT_PTR_NOT_NULL_FATAL(g_qos);
-    dds_qset_reliability(g_qos, DDS_RELIABILITY_RELIABLE, DDS_SECS(1));
-    dds_qset_history(g_qos, DDS_HISTORY_KEEP_ALL, 0);
-
-    cb_called = 0;
-}
-
-static void
-init_triggering_test(void)
-{
-    uint32_t triggered;
-
-    /* Initialize base. */
-    init_triggering_base();
-
-    /* Set QoS Policies that'll help us test various status callbacks. */
-    dds_qset_destination_order(g_qos, DDS_DESTINATIONORDER_BY_SOURCE_TIMESTAMP);
-    dds_qset_reliability(g_qos, DDS_RELIABILITY_BEST_EFFORT, DDS_MSECS(100));
-    dds_qset_resource_limits(g_qos, 1, 1, 1);
-
-    /* Use these to be sure reader and writer know each other. */
-    dds_lset_publication_matched(g_listener, publication_matched_cb);
-    dds_lset_subscription_matched(g_listener, subscription_matched_cb);
-    dds_lset_liveliness_changed(g_listener, liveliness_changed_cb);
-
-    /* Create reader and writer with proper listeners. */
-    g_writer = dds_create_writer(g_publisher, g_topic, g_qos, g_listener);
-    CU_ASSERT(g_writer > 0);
-    g_reader = dds_create_reader(g_subscriber, g_topic, g_qos, g_listener);
-    CU_ASSERT(g_reader > 0);
-
-    /* Sync. */
-    triggered = waitfor_cb(DDS_PUBLICATION_MATCHED_STATUS | DDS_SUBSCRIPTION_MATCHED_STATUS | DDS_LIVELINESS_CHANGED_STATUS);
-    CU_ASSERT_EQUAL_FATAL(triggered & DDS_LIVELINESS_CHANGED_STATUS,    DDS_LIVELINESS_CHANGED_STATUS);
-    CU_ASSERT_EQUAL_FATAL(triggered & DDS_PUBLICATION_MATCHED_STATUS,   DDS_PUBLICATION_MATCHED_STATUS);
-    CU_ASSERT_EQUAL_FATAL(triggered & DDS_SUBSCRIPTION_MATCHED_STATUS,  DDS_SUBSCRIPTION_MATCHED_STATUS);
-}
-
-static void
-fini_triggering_base(void)
-{
-    dds_delete_qos(g_qos);
-    dds_delete_listener(g_listener);
-    dds_delete(g_participant);
-    ddsrt_cond_destroy(&g_cond);
-    ddsrt_mutex_destroy(&g_mutex);
-    ddsrt_fini();
-}
-
-static void
-fini_triggering_test(void)
-{
-    dds_delete(g_reader);
-    if (g_writer)
-      dds_delete(g_writer);
-    fini_triggering_base();
-}
-
-
-/****************************************************************************
- * API tests
- ****************************************************************************/
-CU_Test(ddsc_listener, create_and_delete)
-{
-    /* Verify create doesn't return null */
-    dds_listener_t *listener;
-    listener = dds_create_listener(NULL);
-    CU_ASSERT_PTR_NOT_NULL_FATAL(listener);
-
-    /* Check default cb's are set */
-    ASSERT_CALLBACK_EQUAL(inconsistent_topic, listener, DDS_LUNSET);
-    ASSERT_CALLBACK_EQUAL(liveliness_lost, listener, DDS_LUNSET);
-    ASSERT_CALLBACK_EQUAL(offered_deadline_missed, listener, DDS_LUNSET);
-    ASSERT_CALLBACK_EQUAL(offered_incompatible_qos, listener, DDS_LUNSET);
-    ASSERT_CALLBACK_EQUAL(data_on_readers, listener, DDS_LUNSET);
-    ASSERT_CALLBACK_EQUAL(sample_lost, listener, DDS_LUNSET);
-    ASSERT_CALLBACK_EQUAL(sample_rejected, listener, DDS_LUNSET);
-    ASSERT_CALLBACK_EQUAL(liveliness_changed, listener, DDS_LUNSET);
-    ASSERT_CALLBACK_EQUAL(requested_deadline_missed, listener, DDS_LUNSET);
-    ASSERT_CALLBACK_EQUAL(requested_incompatible_qos, listener, DDS_LUNSET);
-    ASSERT_CALLBACK_EQUAL(publication_matched, listener, DDS_LUNSET);
-    ASSERT_CALLBACK_EQUAL(subscription_matched, listener, DDS_LUNSET);
-    ASSERT_CALLBACK_EQUAL(data_available, listener, DDS_LUNSET);
-
-    dds_delete_listener(listener);
-    DDSRT_WARNING_MSVC_OFF(6387); /* Disable SAL warning on intentional misuse of the API */
-    dds_delete_listener(NULL);
-    DDSRT_WARNING_MSVC_ON(6387);
-}
-
-CU_Test(ddsc_listener, reset)
-{
-    dds_listener_t *listener;
-    listener = dds_create_listener(NULL);
-    CU_ASSERT_PTR_NOT_NULL_FATAL(listener);
-
-    /* Set a listener cb to a non-default value */
-    dds_lset_data_available(listener, NULL);
-    ASSERT_CALLBACK_EQUAL(data_available, listener, NULL);
-
-    /* Listener cb should revert to default after reset */
-    dds_reset_listener(listener);
-    ASSERT_CALLBACK_EQUAL(data_available, listener, DDS_LUNSET);
-
-    /* Resetting a NULL listener should not crash */
-    dds_reset_listener(NULL);
-
-    dds_delete_listener(listener);
-}
-
-CU_Test(ddsc_listener, copy)
-{
-    dds_listener_t *listener1 = NULL, *listener2 = NULL;
-    listener1 = dds_create_listener(NULL);
-    listener2 = dds_create_listener(NULL);
-    CU_ASSERT_PTR_NOT_NULL_FATAL(listener1);
-    CU_ASSERT_PTR_NOT_NULL_FATAL(listener2);
-
-    /* Set some listener1 callbacks to non-default values */
-    dds_lset_data_available(listener1, NULL);
-    dds_lset_sample_lost(listener1, sample_lost_cb);
-    ASSERT_CALLBACK_EQUAL(data_available, listener1, NULL);
-    ASSERT_CALLBACK_EQUAL(sample_lost, listener1, sample_lost_cb);
-    ASSERT_CALLBACK_EQUAL(data_available, listener2, DDS_LUNSET);
-    ASSERT_CALLBACK_EQUAL(sample_lost, listener2, DDS_LUNSET);
-
-    /* Cb's should be copied to listener2 */
-    dds_copy_listener(listener2, listener1);
-    ASSERT_CALLBACK_EQUAL(data_available, listener1, NULL);
-    ASSERT_CALLBACK_EQUAL(data_available, listener2, NULL);
-    ASSERT_CALLBACK_EQUAL(sample_lost, listener1, sample_lost_cb);
-    ASSERT_CALLBACK_EQUAL(sample_lost, listener2, sample_lost_cb);
-
-    /* Calling copy with NULL should not crash and be noops. */
-    DDSRT_WARNING_MSVC_OFF(6387); /* Disable SAL warning on intentional misuse of the API */
-    dds_copy_listener(listener2, NULL);
-    dds_copy_listener(NULL, listener1);
-    dds_copy_listener(NULL, NULL);
-    DDSRT_WARNING_MSVC_ON(6387);
-
-    dds_delete_listener(listener1);
-    dds_delete_listener(listener2);
-}
-
-CU_Test(ddsc_listener, merge)
-{
-    dds_listener_t *listener1 = NULL, *listener2 = NULL;
-    listener1 = dds_create_listener(NULL);
-    listener2 = dds_create_listener(NULL);
-    CU_ASSERT_PTR_NOT_NULL_FATAL(listener1);
-    CU_ASSERT_PTR_NOT_NULL_FATAL(listener2);
-
-    /* Set all listener1 callbacks to non-default values */
-    dds_lset_inconsistent_topic         (listener1, inconsistent_topic_cb);
-    dds_lset_liveliness_lost            (listener1, liveliness_lost_cb);
-    dds_lset_offered_deadline_missed    (listener1, offered_deadline_missed_cb);
-    dds_lset_offered_incompatible_qos   (listener1, offered_incompatible_qos_cb);
-    dds_lset_data_on_readers            (listener1, data_on_readers_cb);
-    dds_lset_sample_lost                (listener1, sample_lost_cb);
-    dds_lset_data_available             (listener1, data_available_cb);
-    dds_lset_sample_rejected            (listener1, sample_rejected_cb);
-    dds_lset_liveliness_changed         (listener1, liveliness_changed_cb);
-    dds_lset_requested_deadline_missed  (listener1, requested_deadline_missed_cb);
-    dds_lset_requested_incompatible_qos (listener1, requested_incompatible_qos_cb);
-    dds_lset_publication_matched        (listener1, publication_matched_cb);
-    dds_lset_subscription_matched       (listener1, subscription_matched_cb);
-
-    /* Merging listener1 into empty listener2 should act a bit like a copy. */
-    dds_merge_listener(listener2, listener1);
-    ASSERT_CALLBACK_EQUAL(inconsistent_topic,           listener2, inconsistent_topic_cb);
-    ASSERT_CALLBACK_EQUAL(liveliness_lost,              listener2, liveliness_lost_cb);
-    ASSERT_CALLBACK_EQUAL(offered_deadline_missed,      listener2, offered_deadline_missed_cb);
-    ASSERT_CALLBACK_EQUAL(offered_incompatible_qos,     listener2, offered_incompatible_qos_cb);
-    ASSERT_CALLBACK_EQUAL(data_on_readers,              listener2, data_on_readers_cb);
-    ASSERT_CALLBACK_EQUAL(sample_lost,                  listener2, sample_lost_cb);
-    ASSERT_CALLBACK_EQUAL(data_available,               listener2, data_available_cb);
-    ASSERT_CALLBACK_EQUAL(sample_rejected,              listener2, sample_rejected_cb);
-    ASSERT_CALLBACK_EQUAL(liveliness_changed,           listener2, liveliness_changed_cb);
-    ASSERT_CALLBACK_EQUAL(requested_deadline_missed,    listener2, requested_deadline_missed_cb);
-    ASSERT_CALLBACK_EQUAL(requested_incompatible_qos,   listener2, requested_incompatible_qos_cb);
-    ASSERT_CALLBACK_EQUAL(publication_matched,          listener2, publication_matched_cb);
-    ASSERT_CALLBACK_EQUAL(subscription_matched,         listener2, subscription_matched_cb);
-
-    /* Merging listener into a full listener2 should act as a noop. */
-    dds_lset_inconsistent_topic         (listener2, (dds_on_inconsistent_topic_fn)callback_dummy);
-    dds_lset_liveliness_lost            (listener2, (dds_on_liveliness_lost_fn)callback_dummy);
-    dds_lset_offered_deadline_missed    (listener2, (dds_on_offered_deadline_missed_fn)callback_dummy);
-    dds_lset_offered_incompatible_qos   (listener2, (dds_on_offered_incompatible_qos_fn)callback_dummy);
-    dds_lset_data_on_readers            (listener2, (dds_on_data_on_readers_fn)callback_dummy);
-    dds_lset_sample_lost                (listener2, (dds_on_sample_lost_fn)callback_dummy);
-    dds_lset_data_available             (listener2, (dds_on_data_available_fn)callback_dummy);
-    dds_lset_sample_rejected            (listener2, (dds_on_sample_rejected_fn)callback_dummy);
-    dds_lset_liveliness_changed         (listener2, (dds_on_liveliness_changed_fn)callback_dummy);
-    dds_lset_requested_deadline_missed  (listener2, (dds_on_requested_deadline_missed_fn)callback_dummy);
-    dds_lset_requested_incompatible_qos (listener2, (dds_on_requested_incompatible_qos_fn)callback_dummy);
-    dds_lset_publication_matched        (listener2, (dds_on_publication_matched_fn)callback_dummy);
-    dds_lset_subscription_matched       (listener2, (dds_on_subscription_matched_fn)callback_dummy);
-    dds_merge_listener(listener2, listener1);
-    ASSERT_CALLBACK_EQUAL(inconsistent_topic,           listener2, (dds_on_inconsistent_topic_fn)callback_dummy);
-    ASSERT_CALLBACK_EQUAL(liveliness_lost,              listener2, (dds_on_liveliness_lost_fn)callback_dummy);
-    ASSERT_CALLBACK_EQUAL(offered_deadline_missed,      listener2, (dds_on_offered_deadline_missed_fn)callback_dummy);
-    ASSERT_CALLBACK_EQUAL(offered_incompatible_qos,     listener2, (dds_on_offered_incompatible_qos_fn)callback_dummy);
-    ASSERT_CALLBACK_EQUAL(data_on_readers,              listener2, (dds_on_data_on_readers_fn)callback_dummy);
-    ASSERT_CALLBACK_EQUAL(sample_lost,                  listener2, (dds_on_sample_lost_fn)callback_dummy);
-    ASSERT_CALLBACK_EQUAL(data_available,               listener2, (dds_on_data_available_fn)callback_dummy);
-    ASSERT_CALLBACK_EQUAL(sample_rejected,              listener2, (dds_on_sample_rejected_fn)callback_dummy);
-    ASSERT_CALLBACK_EQUAL(liveliness_changed,           listener2, (dds_on_liveliness_changed_fn)callback_dummy);
-    ASSERT_CALLBACK_EQUAL(requested_deadline_missed,    listener2, (dds_on_requested_deadline_missed_fn)callback_dummy);
-    ASSERT_CALLBACK_EQUAL(requested_incompatible_qos,   listener2, (dds_on_requested_incompatible_qos_fn)callback_dummy);
-    ASSERT_CALLBACK_EQUAL(publication_matched,          listener2, (dds_on_publication_matched_fn)callback_dummy);
-    ASSERT_CALLBACK_EQUAL(subscription_matched,         listener2, (dds_on_subscription_matched_fn)callback_dummy);
-
-    /* Using NULLs shouldn't crash and be noops. */
-    dds_merge_listener(listener2, NULL);
-    dds_merge_listener(NULL, listener1);
-    dds_merge_listener(NULL, NULL);
-
-    dds_delete_listener(listener1);
-    dds_delete_listener(listener2);
+  dds_delete_listener (listener1);
+  dds_delete_listener (listener2);
 }
 
 CU_Test(ddsc_listener, getters_setters)
 {
-    /* test all individual cb get/set methods */
-    dds_listener_t *listener = dds_create_listener(NULL);
-    CU_ASSERT_PTR_NOT_NULL_FATAL(listener);
+  // test all individual cb get/set methods
+  dds_listener_t *listener = dds_create_listener (NULL);
+  CU_ASSERT_PTR_NOT_NULL_FATAL (listener);
 
-    DDSRT_WARNING_MSVC_OFF(6387); /* Disable SAL warning on intentional misuse of the API */ \
-    TEST_GET_SET(listener, inconsistent_topic, inconsistent_topic_cb);
-    TEST_GET_SET(listener, liveliness_lost, liveliness_lost_cb);
-    TEST_GET_SET(listener, offered_deadline_missed, offered_deadline_missed_cb);
-    TEST_GET_SET(listener, offered_incompatible_qos, offered_incompatible_qos_cb);
-    TEST_GET_SET(listener, data_on_readers, data_on_readers_cb);
-    TEST_GET_SET(listener, sample_lost, sample_lost_cb);
-    TEST_GET_SET(listener, sample_rejected, sample_rejected_cb);
-    TEST_GET_SET(listener, liveliness_changed, liveliness_changed_cb);
-    TEST_GET_SET(listener, requested_deadline_missed, requested_deadline_missed_cb);
-    TEST_GET_SET(listener, requested_incompatible_qos, requested_incompatible_qos_cb);
-    TEST_GET_SET(listener, publication_matched, publication_matched_cb);
-    TEST_GET_SET(listener, subscription_matched, subscription_matched_cb);
-    TEST_GET_SET(listener, data_available, data_available_cb);
-    DDSRT_WARNING_MSVC_ON(6387);
+#define TEST_GET_SET(listener, fntype, cb) \
+  do { \
+    dds_on_##fntype##_fn dummy = NULL; \
+    /* Initially expect DDS_LUNSET on a newly created listener */ \
+    ASSERT_CALLBACK_EQUAL (fntype, listener, 0); \
+    /* Using listener or callback NULL, shouldn't crash and be noop */ \
+    dds_lset_##fntype (NULL, NULL); \
+    dds_lget_##fntype (NULL, NULL); \
+    dds_lget_##fntype (listener, NULL); \
+    dds_lget_##fntype (NULL, &dummy);  \
+    CU_ASSERT_EQUAL_FATAL (dummy, NULL); \
+    /* Set to NULL, get to confirm it succeeds */ \
+    dds_lset_##fntype (listener, NULL); \
+    ASSERT_CALLBACK_EQUAL (fntype, listener, NULL); \
+    /* Set to a proper cb method, get to confirm it succeeds */ \
+    dds_lset_##fntype (listener, cb); \
+    ASSERT_CALLBACK_EQUAL (fntype, listener, cb); \
+  } while (0)
+  TEST_GET_SET (listener, data_available, data_available_cb);
+  TEST_GET_SET (listener, data_on_readers, data_on_readers_cb);
+  TEST_GET_SET (listener, inconsistent_topic, inconsistent_topic_cb);
+  TEST_GET_SET (listener, liveliness_changed, liveliness_changed_cb);
+  TEST_GET_SET (listener, liveliness_lost, liveliness_lost_cb);
+  TEST_GET_SET (listener, offered_deadline_missed, offered_deadline_missed_cb);
+  TEST_GET_SET (listener, offered_incompatible_qos, offered_incompatible_qos_cb);
+  TEST_GET_SET (listener, publication_matched, publication_matched_cb);
+  TEST_GET_SET (listener, requested_deadline_missed, requested_deadline_missed_cb);
+  TEST_GET_SET (listener, requested_incompatible_qos, requested_incompatible_qos_cb);
+  TEST_GET_SET (listener, sample_lost, sample_lost_cb);
+  TEST_GET_SET (listener, sample_rejected, sample_rejected_cb);
+  TEST_GET_SET (listener, subscription_matched, subscription_matched_cb);
+#undef TEST_GET_SET
 
-    dds_delete_listener(listener);
+  dds_delete_listener (listener);
 }
 
+#undef ASSERT_CALLBACK_EQUAL
 
+/**************************************************
+ ****                                          ****
+ ****  programmable listener checker           ****
+ ****                                          ****
+ **************************************************/
 
-/****************************************************************************
- * Triggering tests
- ****************************************************************************/
-CU_Test(ddsc_listener, propagation, .init=init_triggering_base, .fini=fini_triggering_base)
+// These had better match the corresponding type definitions!
+// n   uint32_t ...count
+// c   int32_t  ...count_change
+// I            instance handle of a data instance
+// P   uint32_t QoS policy ID
+// E            instance handle of an entity
+// R            sample_rejected_status_kind
+static const struct {
+  size_t size;                   // size of status struct
+  const char *desc;              // description of status struct
+  uint32_t mask;                 // status mask, bit in "cb_called"
+  const dds_entity_t *cb_entity; // which cb_... entity to look at
+  const void *cb_status;         // cb_..._status to look at
+} lldesc[] = {
+  { 0, NULL, DDS_DATA_AVAILABLE_STATUS, &cb_reader, NULL }, // data available
+  { 0, NULL, DDS_DATA_ON_READERS_STATUS, &cb_subscriber, NULL }, // data on readers
+  { sizeof (dds_inconsistent_topic_status_t), "nc", DDS_INCONSISTENT_TOPIC_STATUS, &cb_topic, &cb_inconsistent_topic_status },
+  { sizeof (dds_liveliness_changed_status_t), "nnccE", DDS_LIVELINESS_CHANGED_STATUS, &cb_reader, &cb_liveliness_changed_status },
+  { sizeof (dds_liveliness_lost_status_t), "nc", DDS_LIVELINESS_LOST_STATUS, &cb_writer, &cb_liveliness_lost_status },
+  { sizeof (dds_offered_deadline_missed_status_t), "ncI", DDS_OFFERED_DEADLINE_MISSED_STATUS, &cb_writer, &cb_offered_deadline_missed_status },
+  { sizeof (dds_offered_incompatible_qos_status_t), "ncP", DDS_OFFERED_INCOMPATIBLE_QOS_STATUS, &cb_writer, &cb_offered_incompatible_qos_status },
+  { sizeof (dds_publication_matched_status_t), "ncncE", DDS_PUBLICATION_MATCHED_STATUS, &cb_writer, &cb_publication_matched_status },
+  { sizeof (dds_requested_deadline_missed_status_t), "ncI", DDS_REQUESTED_DEADLINE_MISSED_STATUS, &cb_reader, &cb_requested_deadline_missed_status },
+  { sizeof (dds_requested_incompatible_qos_status_t), "ncP", DDS_REQUESTED_INCOMPATIBLE_QOS_STATUS, &cb_reader, &cb_requested_incompatible_qos_status },
+  { sizeof (dds_sample_lost_status_t), "nc", DDS_SAMPLE_LOST_STATUS, &cb_reader, &cb_sample_lost_status },
+  { sizeof (dds_sample_rejected_status_t), "ncRI", DDS_SAMPLE_REJECTED_STATUS, &cb_reader, &cb_sample_rejected_status },
+  { sizeof (dds_subscription_matched_status_t), "ncncE", DDS_SUBSCRIPTION_MATCHED_STATUS, &cb_reader, &cb_subscription_matched_status }
+};
+
+static const void *advance (const void *status, size_t *off, char code)
 {
-    dds_listener_t *listener_par = NULL;
-    dds_listener_t *listener_pub = NULL;
-    dds_listener_t *listener_sub = NULL;
-    uint32_t triggered;
+#define alignof(type_) offsetof (struct { char c; type_ d; }, d)
+  size_t align = 1, size = 1;
+  switch (code)
+  {
+    case 'n': case 'c': case 'P':
+      align = alignof (uint32_t); size = sizeof (uint32_t);
+      break;
+    case 'E': case 'I':
+      align = alignof (dds_instance_handle_t); size = sizeof (dds_instance_handle_t);
+      break;
+    case 'R':
+      align = alignof (dds_sample_rejected_status_kind); size = sizeof (dds_sample_rejected_status_kind);
+      break;
+    default:
+      abort ();
+  }
+#undef alignof
+  *off = (*off + align - 1) & ~(align - 1);
+  const void *p = (const char *) status + *off;
+  *off += size;
+  return p;
+}
+
+static void get_status (int ll, dds_entity_t ent, void *status)
+{
+  dds_return_t ret;
+  switch (ll)
+  {
+    case 2: ret = dds_get_inconsistent_topic_status (ent, status); break;
+    case 3: ret = dds_get_liveliness_changed_status (ent, status); break;
+    case 4: ret = dds_get_liveliness_lost_status (ent, status); break;
+    case 5: ret = dds_get_offered_deadline_missed_status (ent, status); break;
+    case 6: ret = dds_get_offered_incompatible_qos_status (ent, status); break;
+    case 7: ret = dds_get_publication_matched_status (ent, status); break;
+    case 8: ret = dds_get_requested_deadline_missed_status (ent, status); break;
+    case 9: ret = dds_get_requested_incompatible_qos_status (ent, status); break;
+    case 10: ret = dds_get_sample_lost_status (ent, status); break;
+    case 11: ret = dds_get_sample_rejected_status (ent, status); break;
+    case 12: ret = dds_get_subscription_matched_status (ent, status); break;
+    default: abort ();
+  }
+  CU_ASSERT_FATAL (ret == 0);
+}
+
+static void assert_status_change_fields_are_0 (int ll, dds_entity_t ent)
+{
+  if (lldesc[ll].desc)
+  {
+    const char *d = lldesc[ll].desc;
+    void *status = malloc (lldesc[ll].size);
+    get_status (ll, ent, status);
+    size_t off = 0;
+    while (*d)
+    {
+      const uint32_t *p = advance (status, &off, *d);
+      if (*d == 'c')
+        CU_ASSERT_FATAL (*p == 0);
+      d++;
+    }
+    assert (off <= lldesc[ll].size);
+    free (status);
+  }
+}
+
+static int getentity (const char *tok, bool *isbang, bool *ishash)
+{
+  static const char *known = "PRWrstwxy";
+  const char *p;
+  if (isbang)
+    *isbang = false;
+  if (ishash)
+    *ishash = false;
+  if ((p = strchr (known, *tok)) == NULL)
+    return -1;
+  int ent = (int) (p - known);
+  if (*++tok == 0)
+    return ent;
+  if (*tok == '\'')
+  {
+    ent += (int) strlen (known);
+    tok++;
+  }
+  while (*tok == '!' || *tok == '#')
+  {
+    if (strchr (known + 3, *p) == NULL)
+      return -1; // only readers, writers
+    if (*tok == '!' && isbang)
+      *isbang = true;
+    else if (*tok == '#' && ishash)
+      *ishash = true;
+    tok++;
+  }
+  return (*tok == 0) ? ent : -1;
+}
+
+static int getlistener (const char *tok, bool *isbang)
+{
+  // note: sort order is on full name (so sample rejected precedes subscription matched)
+  static const char *ls[] = {
+    "da", "dor", "it", "lc", "ll", "odm", "oiq", "pm", "rdm", "riq", "sl", "sr", "sm"
+  };
+  if (isbang)
+    *isbang = false;
+  for (size_t i = 0; i < sizeof (ls) / sizeof (*ls); i++)
+  {
+    size_t n = strlen (ls[i]);
+    if (strncmp (tok, ls[i], n) == 0 && (tok[n] == 0 || tok[n+1] == ','))
+    {
+      if (isbang)
+        *isbang = (tok[n] == '!');
+      return (int) i;
+    }
+  }
+  return -1;
+}
+
+struct ents {
+  dds_entity_t es[2 * 9];
+  dds_entity_t tps[2];
+  dds_entity_t doms[2];
+  dds_instance_handle_t esi[2 * 9];
+  // built-in topic readers for cross-referencing instance handles
+  dds_entity_t pubrd[2];
+  dds_entity_t subrd[2];
+};
+
+static void make_participant (struct ents *es, const char *topicname, int ent, const dds_qos_t *qos, dds_listener_t *list)
+{
+  const dds_domainid_t domid = (ent < 9) ? 0 : 1;
+  char *conf = ddsrt_expand_envvars ("${CYCLONEDDS_URI}${CYCLONEDDS_URI:+,}<Discovery><ExternalDomainId>0</ExternalDomainId></Discovery>", domid);
+  printf ("create domain %"PRIu32, domid);
+  fflush (stdout);
+  es->doms[domid] = dds_create_domain (domid, conf);
+  CU_ASSERT_FATAL (es->doms[domid] > 0);
+  ddsrt_free (conf);
+  printf (" create participant P%s", (ent < 9) ? "" : "'");
+  fflush (stdout);
+  es->es[ent] = dds_create_participant (domid, NULL, list);
+  CU_ASSERT_FATAL (es->es[ent] > 0);
+  es->tps[domid] = dds_create_topic (es->es[ent], &Space_Type1_desc, topicname, qos, NULL);
+  CU_ASSERT_FATAL (es->tps[domid] > 0);
+
+  // Create the built-in topic readers with a dummy listener to avoid any event (data available comes to mind)
+  // from propagating to the normal data available listener, in case it has been set on the participant.
+  //
+  // - dummy_cb aborts when it is invoked, but all reader-related listeners that can possibly trigger are set
+  //   separately (incompatible qos, deadline missed, sample lost and sample rejected are all impossible by
+  //   construction)
+  // - regarding data_on_readers: Cyclone handles listeners installed on an ancestor by *inheriting* them,
+  //   rather than by walking up ancestor chain. Setting data_on_readers on the reader therefore overrides the
+  //   listener set on the subscriber. It is a nice feature!
+  dds_listener_t *dummylist = dds_create_listener (NULL);
+  set_all_const (dummylist, dummy_cb);
+  dds_lset_data_available (dummylist, dummy_data_available_cb);
+  dds_lset_data_on_readers (dummylist, dummy_data_on_readers_cb);
+  dds_lset_subscription_matched (dummylist, dummy_subscription_matched_cb);
+  dds_lset_liveliness_changed (dummylist, dummy_liveliness_changed_cb);
+  es->pubrd[domid] = dds_create_reader (es->es[ent], DDS_BUILTIN_TOPIC_DCPSPUBLICATION, NULL, dummylist);
+  CU_ASSERT_FATAL (es->pubrd[domid] > 0);
+  es->subrd[domid] = dds_create_reader (es->es[ent], DDS_BUILTIN_TOPIC_DCPSSUBSCRIPTION, NULL, dummylist);
+  CU_ASSERT_FATAL (es->subrd[domid] > 0);
+  dds_delete_listener (dummylist);
+  printf ("pubrd %"PRId32" subrd %"PRId32" sub %"PRId32"\n", es->pubrd[domid], es->subrd[domid], dds_get_parent (es->pubrd[domid]));
+}
+
+static void make_entity1 (struct ents *es, const char *topicname, int ent, bool isbang, bool ishash, const dds_qos_t *qos, dds_qos_t *rwqos, dds_listener_t *list)
+{
+  dds_return_t ret;
+  switch (ent)
+  {
+    case 0: case 9:
+      make_participant (es, topicname, ent, qos, list);
+      break;
+    case 1: case 10:
+      if (es->es[ent-1] == 0)
+      {
+        printf ("[");
+        make_entity1 (es, topicname, ent-1, false, false, qos, rwqos, NULL);
+        printf ("] ");
+      }
+      printf ("create subscriber R%s", (ent < 9) ? "" : "'");
+      fflush (stdout);
+      es->es[ent] = dds_create_subscriber (es->es[ent-1], NULL, list);
+      break;
+    case 2: case 11:
+      if (es->es[ent-2] == 0)
+      {
+        printf ("[");
+        make_entity1 (es, topicname, ent-2, false, false, qos, rwqos, NULL);
+        printf ("] ");
+      }
+      printf ("create publisher W%s", (ent < 9) ? "" : "'");
+      fflush (stdout);
+      es->es[ent] = dds_create_publisher (es->es[ent-2], NULL, list);
+      break;
+    case 3: case 4: case 5: case 12: case 13: case 14:
+      if (es->es[ent < 9 ? 1 : 10] == 0)
+      {
+        printf ("[");
+        make_entity1 (es, topicname, ent < 9 ? 1 : 10, false, false, qos, rwqos, NULL);
+        printf ("] ");
+      }
+      printf ("create %s reader %c%s", isbang ? "best-effort" : "reliable", 'r' + (ent < 9 ? ent-3 : ent-12), (ent < 9) ? "" : "'");
+      fflush (stdout);
+      dds_reset_qos (rwqos);
+      if (isbang)
+        dds_qset_reliability (rwqos, DDS_RELIABILITY_BEST_EFFORT, DDS_MSECS (100));
+      if (ishash)
+        dds_qset_resource_limits (rwqos, 1, DDS_LENGTH_UNLIMITED, DDS_LENGTH_UNLIMITED);
+      es->es[ent] = dds_create_reader (es->es[ent < 9 ? 1 : 10], es->tps[ent < 9 ? 0 : 1], rwqos, list);
+      break;
+    case 6: case 7: case 8: case 15: case 16: case 17:
+      if (es->es[ent < 9 ? 2 : 11] == 0)
+      {
+        printf ("[");
+        make_entity1 (es, topicname, ent < 9 ? 2 : 11, false, false, qos, rwqos, NULL);
+        printf ("] ");
+      }
+      printf ("create %s writer %c%s", isbang ? "best-effort" : "reliable", 'w' + (ent < 9 ? ent-6 : ent-15), (ent < 9) ? "" : "'");
+      fflush (stdout);
+      dds_reset_qos (rwqos);
+      if (isbang)
+        dds_qset_reliability (rwqos, DDS_RELIABILITY_BEST_EFFORT, DDS_MSECS (100));
+      if (ishash)
+        dds_qset_resource_limits (rwqos, 1, DDS_LENGTH_UNLIMITED, DDS_LENGTH_UNLIMITED);
+      es->es[ent] = dds_create_writer (es->es[ent < 9 ? 2 : 11], es->tps[ent < 9 ? 0 : 1], rwqos, list);
+      break;
+    default:
+      abort ();
+  }
+  printf (" = %"PRId32, es->es[ent]);
+  fflush (stdout);
+  CU_ASSERT_FATAL (es->es[ent] > 0);
+  ret = dds_get_instance_handle (es->es[ent], &es->esi[ent]);
+  //printf (" %"PRIx64, es->esi[ent]);
+  //fflush (stdout);
+  CU_ASSERT_FATAL (ret == 0);
+}
+
+static void make_entity (struct ents *es, const char *topicname, int ent, bool isbang, bool ishash, const dds_qos_t *qos, dds_qos_t *rwqos, dds_listener_t *list)
+{
+  make_entity1 (es, topicname, ent, isbang, ishash, qos, rwqos, list);
+  printf ("\n");
+}
+
+static char *strsep_noempty (char **cursor, const char *sep)
+{
+  char *tok;
+  while ((tok = ddsrt_strsep (cursor, sep)) != NULL && *tok == 0) { }
+  return tok;
+}
+
+static dds_instance_handle_t lookup_insthandle (const struct ents *es, int ent, int ent1)
+{
+  // if both are in the same domain, it's easy
+  if (ent / 9 == ent1 / 9)
+    return es->esi[ent1];
+  else
+  {
+    // if they aren't ... find GUID from instance handle in the one domain,
+    // then find instance handle for GUID in the other
+    dds_entity_t rd1 = 0, rd2 = 0;
+    switch (ent1)
+    {
+      case  3: case  4: case  5: rd1 = es->subrd[0]; rd2 = es->subrd[1]; break;
+      case 12: case 13: case 14: rd1 = es->subrd[1]; rd2 = es->subrd[0]; break;
+      case  6: case  7: case  8: rd1 = es->pubrd[0]; rd2 = es->pubrd[1]; break;
+      case 15: case 16: case 17: rd1 = es->pubrd[1]; rd2 = es->pubrd[0]; break;
+      default: abort ();
+    }
+
     dds_return_t ret;
-    RoundTripModule_DataType sample;
-    memset (&sample, 0, sizeof (sample));
-
-    /* Let participant be interested in data. */
-    listener_par = dds_create_listener(NULL);
-    CU_ASSERT_PTR_NOT_NULL_FATAL(listener_par);
-    dds_lset_data_on_readers(listener_par, data_on_readers_cb);
-    ret = dds_set_listener(g_participant, listener_par);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    dds_delete_listener(listener_par);
-
-    /* Let publisher be interested in publication matched. */
-    listener_pub = dds_create_listener(NULL);
-    CU_ASSERT_PTR_NOT_NULL_FATAL(listener_pub);
-    dds_lset_publication_matched(listener_pub, publication_matched_cb);
-    ret = dds_set_listener(g_publisher, listener_pub);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    dds_delete_listener(listener_pub);
-
-    /* Let subscriber be interested in subscription matched. */
-    listener_sub = dds_create_listener(NULL);
-    CU_ASSERT_PTR_NOT_NULL_FATAL(listener_pub);
-    dds_lset_subscription_matched(listener_sub, subscription_matched_cb);
-    ret = dds_set_listener(g_subscriber, listener_sub);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    dds_delete_listener(listener_sub);
-
-    /* Create reader and writer without listeners. */
-    g_reader = dds_create_reader(g_subscriber, g_topic, g_qos, NULL);
-    CU_ASSERT_FATAL(g_reader > 0);
-    g_writer = dds_create_writer(g_publisher, g_topic, g_qos, NULL);
-    CU_ASSERT_FATAL(g_writer > 0);
-
-    /* Publication and Subscription should be matched. */
-    triggered = waitfor_cb(DDS_PUBLICATION_MATCHED_STATUS | DDS_SUBSCRIPTION_MATCHED_STATUS);
-    CU_ASSERT_EQUAL_FATAL(triggered & DDS_SUBSCRIPTION_MATCHED_STATUS, DDS_SUBSCRIPTION_MATCHED_STATUS);
-    CU_ASSERT_EQUAL_FATAL(triggered & DDS_PUBLICATION_MATCHED_STATUS,  DDS_PUBLICATION_MATCHED_STATUS);
-    CU_ASSERT_EQUAL_FATAL(cb_writer, g_writer);
-    CU_ASSERT_EQUAL_FATAL(cb_reader, g_reader);
-
-    /* Write sample. */
-    ret = dds_write(g_writer, &sample);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-
-    /* Data on readers should be triggered with the right status. */
-    triggered = waitfor_cb(DDS_DATA_ON_READERS_STATUS);
-    CU_ASSERT_EQUAL_FATAL(triggered & DDS_DATA_ON_READERS_STATUS, DDS_DATA_ON_READERS_STATUS);
-    CU_ASSERT_EQUAL_FATAL(cb_subscriber, g_subscriber);
-    CU_ASSERT_NOT_EQUAL_FATAL(triggered & DDS_DATA_AVAILABLE_STATUS, DDS_DATA_AVAILABLE_STATUS);
-
-    dds_delete(g_writer);
-    dds_delete(g_reader);
+    dds_builtintopic_endpoint_t keysample;
+    //printf ("(in %"PRId32" %"PRIx64" -> ", rd1, es->esi[ent1]);
+    //fflush (stdout);
+    ret = dds_instance_get_key (rd1, es->esi[ent1], &keysample);
+    CU_ASSERT_FATAL (ret == 0);
+    // In principle, only key fields are set in sample returned by get_key;
+    // in the case of a built-in topic that is extended to the participant
+    // key. The qos and topic/type names should not be set, and there is no
+    // (therefore) memory allocated for the sample.
+    CU_ASSERT_FATAL (keysample.qos == NULL);
+    CU_ASSERT_FATAL (keysample.topic_name == NULL);
+    CU_ASSERT_FATAL (keysample.type_name == NULL);
+    //for (size_t j = 0; j < sizeof (keysample.key.v); j++)
+    //  printf ("%s%02x", (j > 0 && j % 4 == 0) ? ":" : "", keysample.key.v[j]);
+    const dds_instance_handle_t ih = dds_lookup_instance (rd2, &keysample);
+    CU_ASSERT_FATAL (ih != 0);
+    //printf (" -> %"PRIx64")", ih);
+    //fflush (stdout);
+    return ih;
+  }
 }
 
-
-CU_Test(ddsc_listener, matched, .init=init_triggering_base, .fini=fini_triggering_base)
+static void checkstatus (int ll, const struct ents *es, int ent, const char *args, const void *status)
 {
-    uint32_t triggered;
-
-    /* We will basically do the same as the 'normal' init_triggering_test() and
-     * fini_triggering_test() calls. It's just that we do it in a different
-     * order and use the participant iso subscriber and publisher. */
-
-    /* We are interested in matched notifications. */
-    dds_lset_publication_matched(g_listener, publication_matched_cb);
-    dds_lset_subscription_matched(g_listener, subscription_matched_cb);
-
-    /* Create reader and writer with proper listeners.
-     * The creation order is deliberately different from publication_matched and subscription_matched. */
-    g_reader = dds_create_reader(g_participant, g_topic, g_qos, g_listener);
-    CU_ASSERT_FATAL(g_reader > 0);
-    g_writer = dds_create_writer(g_participant, g_topic, g_qos, g_listener);
-    CU_ASSERT_FATAL(g_writer > 0);
-
-    /* Both matched should be triggered on the right entities. */
-    triggered = waitfor_cb(DDS_PUBLICATION_MATCHED_STATUS | DDS_SUBSCRIPTION_MATCHED_STATUS);
-    CU_ASSERT_EQUAL_FATAL(triggered & DDS_SUBSCRIPTION_MATCHED_STATUS, DDS_SUBSCRIPTION_MATCHED_STATUS);
-    CU_ASSERT_EQUAL_FATAL(triggered & DDS_PUBLICATION_MATCHED_STATUS,  DDS_PUBLICATION_MATCHED_STATUS);
-    CU_ASSERT_EQUAL_FATAL(cb_writer, g_writer);
-    CU_ASSERT_EQUAL_FATAL(cb_reader, g_reader);
-
-    dds_delete(g_writer);
-    dds_delete(g_reader);
+  DDSRT_WARNING_MSVC_OFF(4996); // use of sscanf triggers a warning
+  if (*args == 0)
+    return;
+  if (*args++ != '(')
+    abort ();
+  assert (lldesc[ll].desc != NULL);
+  const char *d = lldesc[ll].desc;
+  const char *sep = "(";
+  size_t off = 0;
+  while (*d)
+  {
+    const void *p = advance (status, &off, *d);
+    char str[32];
+    unsigned u;
+    int i, pos = -1;
+    switch (*d)
+    {
+      case 'n':
+        if (sscanf (args, "%u%n", &u, &pos) != 1 || (args[pos] != ',' && args[pos] != ')'))
+          abort ();
+        printf ("%s%"PRIu32" %u", sep, *(uint32_t *)p, u); fflush (stdout);
+        CU_ASSERT_FATAL (*(uint32_t *)p == u);
+        break;
+      case 'c':
+        if (sscanf (args, "%d%n", &i, &pos) != 1 || (args[pos] != ',' && args[pos] != ')'))
+          abort ();
+        printf ("%s%"PRId32" %d", sep, *(int32_t *)p, i); fflush (stdout);
+        CU_ASSERT_FATAL (*(int32_t *)p == i);
+        break;
+      case 'P': // policy id: currently fixed at reliability
+        pos = -1; // not actually consuming an argument
+        printf ("%s%"PRIu32" %d", sep, *(uint32_t *)p, (int) DDS_RELIABILITY_QOS_POLICY_ID); fflush (stdout);
+        CU_ASSERT_FATAL (*(uint32_t *)p == (uint32_t) DDS_RELIABILITY_QOS_POLICY_ID);
+        break;
+      case 'R':
+        if (sscanf (args, "%31[^,)]%n", str, &pos) != 1 || (args[pos] != ',' && args[pos] != ')'))
+          abort ();
+        if (strcmp (str, "i") == 0)
+          i = (int) DDS_REJECTED_BY_INSTANCES_LIMIT;
+        else if (strcmp (str, "s") == 0)
+          i = (int) DDS_REJECTED_BY_SAMPLES_LIMIT;
+        else if (strcmp (str, "spi") == 0)
+          i = (int) DDS_REJECTED_BY_SAMPLES_PER_INSTANCE_LIMIT;
+        else
+          abort ();
+        printf ("%s%d %d", sep, (int) *(dds_sample_rejected_status_kind *)p, i); fflush (stdout);
+        CU_ASSERT_FATAL (*(dds_sample_rejected_status_kind *)p == (dds_sample_rejected_status_kind) i);
+        break;
+      case 'I': // instance handle is too complicated
+        pos = -1; // not actually consuming an argument
+        break;
+      case 'E': {
+        int ent1 = -1;
+        dds_instance_handle_t esi1 = 0;
+        if (sscanf (args, "%31[^,)]%n", str, &pos) != 1 || (args[pos] != ',' && args[pos] != ')'))
+          abort ();
+        if (strcmp (str, "*") != 0 && (ent1 = getentity (str, NULL, NULL)) < 0)
+          abort ();
+        if (ent1 != -1)
+          esi1 = lookup_insthandle (es, ent, ent1);
+        printf ("%s%"PRIx64" %"PRIx64, sep, *(dds_instance_handle_t *)p, esi1); fflush (stdout);
+        CU_ASSERT_FATAL (ent1 == -1 || *(dds_instance_handle_t *)p == esi1);
+        break;
+      }
+      default: abort ();
+    }
+    args += pos + 1;
+    sep = ", ";
+    d++;
+  }
+  printf (")");
+  assert (*args == 0);
+  assert (off <= lldesc[ll].size);
+  DDSRT_WARNING_MSVC_ON(4996);
 }
 
-CU_Test(ddsc_listener, publication_matched, .init=init_triggering_test, .fini=fini_triggering_test)
+/** @brief run a "test" consisting of a sequence of simplish operations
+ *
+ * This operation takes a test description, really a program in a bizarre syntax, and executes it.  Any failures,
+ * be it because of error codes coming out of the Cyclone calls or expected values being wrong cause it to fail
+ * the test via CU_ASSERT_FATAL. While it is doing this, it outputs the test steps to stdout including some
+ * actual values. An invalid program is mostly reported by calling abort(). It is geared towards checking for
+ * listener invocations and the effects on statuses.
+ *
+ * Entities in play:
+ *
+ * - participants:   P      P'
+ * - subscribers:    R      R'
+ * - publishers:     W      W'
+ * - readers:        r s t  r' s' t'
+ * - writers:        w x y  w' x' y'
+ *
+ * The unprimed ones exist in domain 0, the primed ones in domain 1 (but configured such that it talks to
+ * domain 0), so that network-related listener invocations can be checked as well.
+ *
+ * The first mention of an entity creates it as well as its ancestors.  Implicitly created ancestors always have
+ * standard QoS and have no listeners. There is one topic that is created implicitly when the participant is
+ * created.
+ *
+ * Standard QoS is: default + reliable (100ms), by-source-timestamp, keep-all.
+ * The QoS of a reader/writer can be altered at the first mention of it by suffixing its name with "!" and/or "#"
+ * (the apostrophe is part of the name, so w#! or r'! are valid). Those suffixes are ignored if the entity
+ * already exists.
+ *
+ * A program consists of a sequence of operations separated by whitespace, ';' or '/' (there is no meaning to the
+ * separators, they exist to allow visual grouping):
+ *
+ * PROGRAM     ::= (OP (\s+|[/;])*)*
+ *
+ * OP          ::= (LISTENER)* ENTITY-NAME
+ *                       if entity ENTITY-NAME does not exist:
+ *                         creates the entity with the given listeners installed
+ *                       else
+ *                         changes the entity's listeners to the specified ones
+ *                       (see above for the valid ENTITY-NAMEs)
+ *               | -ENTITY-NAME
+ *                       deletes the specified entity
+ *               | WRITE-LIKE[fail][@DT] KEY <entity name>
+ *                       writes/disposes/unregisters key KEY (an integer), if "fail" is appended, the
+ *                       expectation is that it fails with a timeout, if @DT is appended, the timestamp is the
+ *                       start time of the test + <dt>s rather than the current time; DT is a floating-point
+ *                       number
+ *               | READ-LIKE[(A,B))] <entity name>
+ *                       reads/takes at most 10 samples, counting the number of valid and invalid samples seen
+ *                       and checking it against A and B if given
+ *               | ?LISTENER[(ARGS)] <entity name>
+ *                       waits until the specified listener has been invoked on <entity name> using a flag set
+ *                       by the listener function, resets the flag and verifies that neither the entity status
+ *                       bit nor the "change" fields in the various statuses were set
+ *                       ARGS is used to check the status argument most recently passed to the listener:
+ *                         it        (A,B) verifies count and change match A and B, policy matches RELIABILITY
+ *                         lc        (A,B,C,D,E) verifies that alive and not-alive counts match A and B, that
+ *                                   alive and not-alive changes match C and D and that the last handle matches
+ *                                   E if an entity name (ignored if E = "*")
+ *                         ll        (A,B) verifies count and change match A and B
+ *                         odm       (A,B) verifies count and change match A and B, last handle is ignored
+ *                         oiq       (A,B) verifies that total count and change match A and B and that the
+ *                                   mismatching QoS is reliability (the only one that can for now)
+ *                         pm        (A,B,C,D,E) verifies that total count and change match A and B, that
+ *                                   current count and change match C and D and that the last handle matches E
+ *                                   if an entity name (ignored if E = "*")
+ *                         rdm       see odm
+ *                         riq       see oiq
+ *                         sl        (A,B) verifies that total count and change match A and B
+ *                         sr        (A,B,C) verifies total count and change match A and B, and that the reason
+ *                                   matches C (one of "s" for samples, "i" for instances, "spi" for samples
+ *                                   per instance)
+ *                         sm        see pm
+ *               | ?!LISTENER
+ *                       (not listener) tests that LISTENER has not been invoked since last reset
+ *               | sleep D
+ *                       delay program execution for D s (D is a floating-point number)
+ * WRITE-LIKE  ::= wr    write
+ *               | wrdisp  write-dispose
+ *               | disp  dispose
+ *               | unreg unregister
+ * READ-LIKE   ::= read  dds_read (so any state)
+ *               | take  dds_take (so any state)
+ * LISTENER    ::= da    data available (acts on a reader)
+ *               | dor   data on readers (acts on a subcsriber)
+ *               | it    incompatible topic (acts on a topic)
+ *               | lc    liveliness changed (acts on a reader)
+ *               | ll    liveliness lost (acts on a writer)
+ *               | odm   offered deadline missed (acts on a writer)
+ *               | oiq   offered incompatible QoS (acts on a writer)
+ *               | pm    publication matched (acts on a writer)
+ *               | rdm   requested deadline missed (acts on a reader)
+ *               | riq   requested incompatible QoS (acts on a reader)
+ *               | sl    sample lost (acts on a reader)
+ *               | sr    sample rejected (acts on a reader)
+ *               | sm    subscription matched (acts on a reader)
+ *
+ * All entities share the listeners with their global state. Only the latest invocation is visible.
+ *
+ * @param[in]  ops  Program to execute.
+ */
+static void dotest (const char *ops)
 {
-    dds_publication_matched_status_t publication_matched;
-    dds_instance_handle_t reader_hdl;
-    dds_return_t ret;
-    uint32_t triggered;
-    uint32_t status;
+  DDSRT_WARNING_MSVC_OFF(4996); // use of sscanf triggers a warning
+  static const char *sep = " /;\n\t\r\v";
+  char *opscopy = ddsrt_strdup (ops), *cursor = opscopy, *tok;
+  struct ents es;
+  dds_return_t ret;
+  Space_Type1 sample;
+  char topicname[100];
+  dds_qos_t *qos = dds_create_qos (), *rwqos = dds_create_qos ();
+  dds_listener_t *list = dds_create_listener (NULL);
+  const dds_time_t tref = dds_time ();
+  CU_ASSERT_FATAL (qos != NULL);
+  CU_ASSERT_FATAL (rwqos != NULL);
+  CU_ASSERT_FATAL (list != NULL);
+  dds_qset_reliability (qos, DDS_RELIABILITY_RELIABLE, DDS_MSECS (100));
+  dds_qset_destination_order (qos, DDS_DESTINATIONORDER_BY_SOURCE_TIMESTAMP);
+  dds_qset_history (qos, DDS_HISTORY_KEEP_ALL, 0);
+  memset (&es, 0, sizeof (es));
+  memset (&sample, 0, sizeof (sample));
 
-    /* Get reader handle that should be part of the status. */
-    ret = dds_get_instance_handle(g_reader, &reader_hdl);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+  ddsrt_mutex_init (&g_mutex);
+  ddsrt_cond_init (&g_cond);
+  ddsrt_mutex_lock (&g_mutex);
+  cb_called = 0;
+  ddsrt_mutex_unlock (&g_mutex);
 
-    /* Publication matched should be triggered with the right status. */
-    triggered = waitfor_cb(DDS_PUBLICATION_MATCHED_STATUS);
-    CU_ASSERT_EQUAL_FATAL(triggered & DDS_PUBLICATION_MATCHED_STATUS, DDS_PUBLICATION_MATCHED_STATUS);
-    CU_ASSERT_EQUAL_FATAL(cb_writer, g_writer);
-    CU_ASSERT_EQUAL_FATAL(cb_publication_matched_status.current_count, 1);
-    CU_ASSERT_EQUAL_FATAL(cb_publication_matched_status.current_count_change, 1);
-    CU_ASSERT_EQUAL_FATAL(cb_publication_matched_status.total_count, 1);
-    CU_ASSERT_EQUAL_FATAL(cb_publication_matched_status.total_count_change, 1);
-    CU_ASSERT_EQUAL_FATAL(cb_publication_matched_status.last_subscription_handle, reader_hdl);
+  create_unique_topic_name ("ddsc_listener_test", topicname, 100);
+  printf ("dotest: %s\n", ops);
+  printf ("topic: %s\n", topicname);
+  while ((tok = strsep_noempty (&cursor, sep)) != NULL)
+  {
+    int ent, ll;
+    bool isbang, ishash;
+    if ((ent = getentity (tok, &isbang, &ishash)) >= 0)
+    {
+      make_entity (&es, topicname, ent, isbang, ishash, qos, rwqos, NULL);
+    }
+    else if (*tok == '-' && (ent = getentity (tok + 1, NULL, NULL)) >= 0)
+    {
+      // delete deliberately leaves the instance handle in place for checking
+      // the publication/subscription handle in subscription matched/publication
+      // matched for a lost match
+      printf ("delete %"PRId32"\n", es.es[ent]);
+      ret = dds_delete (es.es[ent]);
+      CU_ASSERT_FATAL (ret == 0);
+      es.es[ent] = 0;
+    }
+    else if ((ll = getlistener (tok, &isbang)) >= 0)
+    {
+      printf ("set listener:");
+      dds_reset_listener (list);
+      do {
+        printf (" %s", tok);
+        switch (ll)
+        {
+          case 0: dds_lset_data_available (list, isbang ? 0 : data_available_cb); break;
+          case 1: dds_lset_data_on_readers (list, isbang ? 0 : data_on_readers_cb); break;
+          case 2: dds_lset_inconsistent_topic (list, isbang ? 0: inconsistent_topic_cb); break;
+          case 3: dds_lset_liveliness_changed (list, isbang ? 0 : liveliness_changed_cb); break;
+          case 4: dds_lset_liveliness_lost (list, isbang ? 0 : liveliness_lost_cb); break;
+          case 5: dds_lset_offered_deadline_missed (list, isbang ? 0 : offered_deadline_missed_cb); break;
+          case 6: dds_lset_offered_incompatible_qos (list, isbang ? 0 : offered_incompatible_qos_cb); break;
+          case 7: dds_lset_publication_matched (list, isbang ? 0 : publication_matched_cb); break;
+          case 8: dds_lset_requested_deadline_missed (list, isbang ? 0 : requested_deadline_missed_cb); break;
+          case 9: dds_lset_requested_incompatible_qos (list, isbang ? 0 : requested_incompatible_qos_cb); break;
+          case 10: dds_lset_sample_lost (list, isbang ? 0 : sample_lost_cb); break;
+          case 11: dds_lset_sample_rejected (list, isbang ? 0 : sample_rejected_cb); break;
+          case 12: dds_lset_subscription_matched (list, isbang ? 0 : subscription_matched_cb); break;
+          default: abort ();
+        }
+      } while ((tok = strsep_noempty (&cursor, sep)) != NULL && (ll = getlistener (tok, &isbang)) >= 0);
+      if (tok == NULL || (ent = getentity (tok, &isbang, &ishash)) < 0)
+        abort ();
+      if (es.es[ent] == 0)
+      {
+        printf (" for ");
+        make_entity (&es, topicname, ent, isbang, ishash, qos, rwqos, list);
+      }
+      else
+      {
+        dds_listener_t *tmplist = dds_create_listener (NULL);
+        CU_ASSERT_FATAL (tmplist != NULL);
+        ret = dds_get_listener (es.es[ent], tmplist);
+        CU_ASSERT_FATAL (ret == 0);
+        dds_merge_listener (list, tmplist);
+        dds_delete_listener (tmplist);
+        printf (" on entity %"PRId32"\n", es.es[ent]);
+        ret = dds_set_listener (es.es[ent], list);
+        CU_ASSERT_FATAL (ret == 0);
+      }
+    }
+    else if (strncmp (tok, "wr", 2) == 0 || strncmp (tok, "disp", 4) == 0 || strncmp (tok, "unreg", 5) == 0)
+    {
+      dds_return_t (*fn) (dds_entity_t wr, const void *sample, dds_time_t ts) = 0;
+      double dt = 0.0;
+      dds_time_t ts = dds_time ();
+      char *cmd = tok;
+      bool expectfail = false;
+      int off, pos, key;
+      if ((tok = strsep_noempty (&cursor, sep)) == NULL)
+        abort ();
+      if (sscanf (tok, "%d%n", &key, &pos) != 1 || tok[pos] != 0)
+        abort ();
+      if ((tok = strsep_noempty (&cursor, sep)) == NULL || (ent = getentity (tok, &isbang, &ishash)) < 0)
+        abort ();
+      if (es.es[ent] == 0)
+        make_entity (&es, topicname, ent, isbang, ishash, qos, rwqos, NULL);
+      switch (cmd[0])
+      {
+        case 'w':
+          if (strncmp (cmd + 2, "disp", 4) == 0) {
+            off = 6; fn = dds_writedispose_ts;
+          } else {
+            off = 2; fn = dds_write_ts;
+          }
+          break;
+        case 'd': off = 4; fn = dds_dispose_ts; break;
+        case 'u': off = 5; fn = dds_unregister_instance_ts; break;
+        default: abort ();
+      }
+      if (strncmp (cmd + off, "fail", 4) == 0)
+      {
+        expectfail = true;
+        off += 4;
+      }
+      if (cmd[off] == '@')
+      {
+        if (sscanf (cmd + off, "@%lf%n", &dt, &pos) != 1 || cmd[off + pos] != 0)
+          abort ();
+        ts = tref + (dds_time_t) (dt * 1e9);
+      }
+      sample.long_1 = key;
+      printf ("entity %"PRId32": %*.*s@%"PRId64".%09"PRId64" %d\n", es.es[ent], off, off, cmd, ts / DDS_NSECS_IN_SEC, ts % DDS_NSECS_IN_SEC, key);
+      ret = fn (es.es[ent], &sample, ts);
+      if (expectfail) {
+        CU_ASSERT_FATAL (ret == DDS_RETCODE_TIMEOUT);
+      } else {
+        CU_ASSERT_FATAL (ret == 0);
+      }
+    }
+    else if (strncmp (tok, "take", 4) == 0 || strncmp(tok, "read", 4) == 0)
+    {
+      char *args = (tok[4] ? tok + 4 : NULL);
+      int exp_nvalid = -1, exp_ninvalid = -1, pos;
+      dds_return_t (*fn) (dds_entity_t, void **buf, dds_sample_info_t *, size_t, uint32_t);
+      fn = (strncmp (tok, "take", 4) == 0) ? dds_take : dds_read;
+      assert (args == NULL || *args == '(');
+      if (args && (sscanf (args, "(%d,%d)%n", &exp_nvalid, &exp_ninvalid, &pos) != 2 || args[pos] != 0))
+        abort ();
+      if ((tok = strsep_noempty (&cursor, sep)) == NULL || (ent = getentity (tok, &isbang, &ishash)) < 0)
+        abort ();
+      if (es.es[ent] == 0)
+        make_entity (&es, topicname, ent, isbang, ishash, qos, rwqos, NULL);
+      printf ("entity %"PRId32": %s", es.es[ent], (fn == dds_take) ? "take" : "read");
+      fflush (stdout);
+      void *raw[10] = { NULL };
+      dds_sample_info_t si[10];
+      const uint32_t maxs = (uint32_t) (sizeof (raw) / sizeof (raw[0]));
+      int count[2] = { 0, 0 };
+      ret = fn (es.es[ent], raw, si, maxs, maxs);
+      CU_ASSERT_FATAL (ret >= 0);
+      for (int32_t i = 0; i < ret; i++)
+        count[si[i].valid_data]++;
+      ret = dds_return_loan (es.es[ent], raw, ret);
+      CU_ASSERT_FATAL (ret == 0);
+      printf (" valid %d %d invalid %d %d\n", count[1], exp_nvalid, count[0], exp_ninvalid);
+      if (exp_nvalid >= 0)
+        CU_ASSERT_FATAL (count[1] == exp_nvalid);
+      if (exp_ninvalid >= 0)
+        CU_ASSERT_FATAL (count[0] == exp_ninvalid);
+    }
+    else if (tok[0] == '?')
+    {
+      const bool expectclear = (tok[1] == '!');
+      const char *llname = tok + (expectclear ? 2 : 1);
+      char *checkargs;
+      if ((checkargs = strchr (llname, '(')) != NULL)
+        *checkargs = 0; // clear so getlistener groks the input
+      if ((ll = getlistener (llname, NULL)) < 0)
+        abort ();
+      if (expectclear)
+      {
+        printf ("listener %s: check not called", llname);
+        fflush (stdout);
+        ddsrt_mutex_lock (&g_mutex);
+        printf (" cb_called %"PRIx32" %s\n", cb_called, (cb_called & lldesc[ll].mask) == 0 ? "ok" : "fail");
+        CU_ASSERT_FATAL ((cb_called & lldesc[ll].mask) == 0);
+        ddsrt_mutex_unlock (&g_mutex);
+      }
+      else
+      {
+        bool signalled = true;
+        uint32_t status;
+        if ((tok = strsep_noempty (&cursor, sep)) == NULL || (ent = getentity (tok, &isbang, &ishash)) < 0)
+          abort ();
+        if (es.es[ent] == 0)
+          make_entity (&es, topicname, ent, isbang, ishash, qos, rwqos, NULL);
+        if ((size_t) ll >= sizeof (lldesc) / sizeof (*lldesc))
+          abort ();
+        printf ("listener %s: check called for entity %"PRId32, llname, es.es[ent]);
+        fflush (stdout);
+        ddsrt_mutex_lock (&g_mutex);
+        while ((cb_called & lldesc[ll].mask) == 0 && signalled)
+          signalled = ddsrt_cond_waitfor (&g_cond, &g_mutex, DDS_SECS (5));
+        printf (" cb_called %"PRIx32" (%s)", cb_called, (cb_called & lldesc[ll].mask) != 0 ? "ok" : "fail");
+        fflush (stdout);
+        CU_ASSERT_FATAL ((cb_called & lldesc[ll].mask) != 0);
+        printf (" cb_entity %"PRId32" %"PRId32" (%s)", *lldesc[ll].cb_entity, es.es[ent], (*lldesc[ll].cb_entity == es.es[ent]) ? "ok" : "fail");
+        fflush (stdout);
+        CU_ASSERT_FATAL (*lldesc[ll].cb_entity == es.es[ent]);
+        if (!(es.doms[0] && es.doms[1]))
+        {
+          // FIXME: two domains: listener invocation happens on another thread and we can observe non-0 "change" fields
+          // they get updated, listener gets invoked, then they get reset -- pretty sure it is allowed by the spec, but
+          // not quite elegant
+          assert_status_change_fields_are_0 (ll, es.es[ent]);
+        }
+        if (checkargs && lldesc[ll].cb_status)
+        {
+          *checkargs = '('; // restore ( so checkargs function gets a more sensible input
+          checkstatus (ll, &es, ent, checkargs, lldesc[ll].cb_status);
+        }
+        printf ("\n");
+        cb_called &= ~lldesc[ll].mask;
+        ddsrt_mutex_unlock (&g_mutex);
+        ret = dds_get_status_changes (es.es[ent], &status);
+        CU_ASSERT_FATAL (ret == 0);
+        CU_ASSERT_FATAL ((status & lldesc[ll].mask) == 0);
+      }
+    }
+    else if (strcmp (tok, "sleep") == 0)
+    {
+      if ((tok = strsep_noempty (&cursor, sep)) == NULL)
+        abort ();
+      double d; int pos;
+      if (sscanf (tok, "%lf%n", &d, &pos) != 1 || tok[pos] != 0)
+        abort ();
+      printf ("sleep %fs\n", d);
+      dds_sleepfor ((dds_duration_t) (d * 1e9));
+    }
+    else
+    {
+      printf ("tok '%s': unrecognized\n", tok);
+      abort ();
+    }
+  }
 
-    /* The listener should have swallowed the status. */
-    ret = dds_read_status(g_writer, &status, DDS_PUBLICATION_MATCHED_STATUS);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    CU_ASSERT_EQUAL_FATAL(status, 0);
-
-    /* The listener should have reset the count_change. */
-    ret = dds_get_publication_matched_status(g_writer, &publication_matched);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    CU_ASSERT_EQUAL_FATAL(publication_matched.current_count,        1);
-    CU_ASSERT_EQUAL_FATAL(publication_matched.current_count_change, 0);
-    CU_ASSERT_EQUAL_FATAL(publication_matched.total_count,          1);
-    CU_ASSERT_EQUAL_FATAL(publication_matched.total_count_change,   0);
-    CU_ASSERT_EQUAL_FATAL(publication_matched.last_subscription_handle, reader_hdl);
-
-    /* Reset the trigger flags. */
-    ddsrt_mutex_lock(&g_mutex);
-    cb_called = 0;
-    ddsrt_mutex_unlock(&g_mutex);
-
-    /* Un-match the publication by deleting the reader. */
-    dds_delete(g_reader);
-
-    /* Publication matched should be triggered with the right status. */
-    triggered = waitfor_cb(DDS_PUBLICATION_MATCHED_STATUS);
-    CU_ASSERT_EQUAL_FATAL(triggered & DDS_PUBLICATION_MATCHED_STATUS, DDS_PUBLICATION_MATCHED_STATUS);
-    CU_ASSERT_EQUAL_FATAL(cb_writer, g_writer);
-    CU_ASSERT_EQUAL_FATAL(cb_publication_matched_status.current_count, 0);
-    CU_ASSERT_EQUAL_FATAL(cb_publication_matched_status.current_count_change, -1);
-    CU_ASSERT_EQUAL_FATAL(cb_publication_matched_status.total_count, 1);
-    CU_ASSERT_EQUAL_FATAL(cb_publication_matched_status.total_count_change, 0);
-    CU_ASSERT_EQUAL_FATAL(cb_publication_matched_status.last_subscription_handle, reader_hdl);
-
-    /* The listener should have reset the count_change. */
-    ret = dds_get_publication_matched_status(g_writer, &publication_matched);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    CU_ASSERT_EQUAL_FATAL(publication_matched.current_count,        0);
-    CU_ASSERT_EQUAL_FATAL(publication_matched.current_count_change, 0);
-    CU_ASSERT_EQUAL_FATAL(publication_matched.total_count,          1);
-    CU_ASSERT_EQUAL_FATAL(publication_matched.total_count_change,   0);
-    CU_ASSERT_EQUAL_FATAL(publication_matched.last_subscription_handle, reader_hdl);
+  dds_delete_listener (list);
+  dds_delete_qos (rwqos);
+  dds_delete_qos (qos);
+  // prevent any listeners from being invoked so we can safely delete the
+  // mutex and the condition variable -- must do this going down the
+  // hierarchy, or listeners may remain set through inheritance
+  for (size_t i = 0; i < sizeof (es.es) / sizeof (es.es[0]); i++)
+  {
+    if (es.es[i])
+    {
+      ret = dds_set_listener (es.es[i], NULL);
+      CU_ASSERT_FATAL (ret == 0);
+    }
+  }
+  ddsrt_mutex_destroy (&g_mutex);
+  ddsrt_cond_destroy (&g_cond);
+  for (size_t i = 0; i < sizeof (es.doms) / sizeof (es.doms[0]); i++)
+  {
+    if (es.doms[i])
+    {
+      ret = dds_delete (es.doms[i]);
+      CU_ASSERT_FATAL (ret == 0);
+    }
+  }
+  ddsrt_free (opscopy);
+  DDSRT_WARNING_MSVC_ON(4996);
 }
 
-CU_Test(ddsc_listener, subscription_matched, .init=init_triggering_test, .fini=fini_triggering_test)
+/**************************************************
+ ****                                          ****
+ ****  listener invocation checks              ****
+ ****                                          ****
+ **************************************************/
+
+CU_Test (ddsc_listener, propagation)
 {
-    dds_subscription_matched_status_t subscription_matched;
-    dds_instance_handle_t writer_hdl;
-    dds_return_t ret;
-    uint32_t triggered;
-    uint32_t status;
-
-    /* Get writer handle that should be part of the status. */
-    ret = dds_get_instance_handle(g_writer, &writer_hdl);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-
-    /* Subscription matched should be triggered with the right status. */
-    triggered = waitfor_cb(DDS_SUBSCRIPTION_MATCHED_STATUS);
-    CU_ASSERT_EQUAL_FATAL(triggered & DDS_SUBSCRIPTION_MATCHED_STATUS, DDS_SUBSCRIPTION_MATCHED_STATUS);
-    CU_ASSERT_EQUAL_FATAL(cb_reader, g_reader);
-    CU_ASSERT_EQUAL_FATAL(cb_subscription_matched_status.current_count, 1);
-    CU_ASSERT_EQUAL_FATAL(cb_subscription_matched_status.current_count_change, 1);
-    CU_ASSERT_EQUAL_FATAL(cb_subscription_matched_status.total_count, 1);
-    CU_ASSERT_EQUAL_FATAL(cb_subscription_matched_status.total_count_change, 1);
-    CU_ASSERT_EQUAL_FATAL(cb_subscription_matched_status.last_publication_handle, writer_hdl);
-
-    /* The listener should have swallowed the status. */
-    ret = dds_read_status(g_reader, &status, DDS_SUBSCRIPTION_MATCHED_STATUS);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    CU_ASSERT_EQUAL_FATAL(status, 0);
-
-    /* The listener should have reset the count_change. */
-    ret = dds_get_subscription_matched_status(g_reader, &subscription_matched);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    CU_ASSERT_EQUAL_FATAL(subscription_matched.current_count, 1);
-    CU_ASSERT_EQUAL_FATAL(subscription_matched.current_count_change, 0);
-    CU_ASSERT_EQUAL_FATAL(subscription_matched.total_count, 1);
-    CU_ASSERT_EQUAL_FATAL(subscription_matched.total_count_change, 0);
-    CU_ASSERT_EQUAL_FATAL(subscription_matched.last_publication_handle, writer_hdl);
-
-    /* Reset the trigger flags. */
-    ddsrt_mutex_lock(&g_mutex);
-    cb_called = 0;
-    ddsrt_mutex_unlock(&g_mutex);
-
-    /* Un-match the subscription by deleting the writer. */
-    dds_delete(g_writer);
-
-    /* Subscription matched should be triggered with the right status. */
-    triggered = waitfor_cb(DDS_SUBSCRIPTION_MATCHED_STATUS);
-    CU_ASSERT_EQUAL_FATAL(triggered & DDS_SUBSCRIPTION_MATCHED_STATUS, DDS_SUBSCRIPTION_MATCHED_STATUS);
-    CU_ASSERT_EQUAL_FATAL(cb_reader, g_reader);
-    CU_ASSERT_EQUAL_FATAL(cb_subscription_matched_status.current_count, 0);
-    CU_ASSERT_EQUAL_FATAL(cb_subscription_matched_status.current_count_change, -1);
-    CU_ASSERT_EQUAL_FATAL(cb_subscription_matched_status.total_count, 1);
-    CU_ASSERT_EQUAL_FATAL(cb_subscription_matched_status.total_count_change, 0);
-    CU_ASSERT_EQUAL_FATAL(cb_subscription_matched_status.last_publication_handle, writer_hdl);
-
-    /* The listener should have reset the count_change. */
-    ret = dds_get_subscription_matched_status(g_reader, &subscription_matched);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    CU_ASSERT_EQUAL_FATAL(subscription_matched.current_count, 0);
-    CU_ASSERT_EQUAL_FATAL(subscription_matched.current_count_change, 0);
-    CU_ASSERT_EQUAL_FATAL(subscription_matched.total_count, 1);
-    CU_ASSERT_EQUAL_FATAL(subscription_matched.total_count_change, 0);
-    CU_ASSERT_EQUAL_FATAL(subscription_matched.last_publication_handle, writer_hdl);
+  // data-on-readers set on a participant at creation time must not trigger for
+  // the readers for DCPSPublication and DCPSSubscription: those events must be
+  // invisible for the test logic to work reliably. Installing a dummy listener
+  // for it on the reader should prevent that from happening
+  dotest ("da dor lc sm P ; ?!dor ?!da ?!sm ?!lc");
+  // writing data should trigger data-available unless data-on-readers is set
+  dotest ("da lc sm P ; r ; wr 0 w ; ?da r ?sm r ?lc r");
+  dotest ("da dor lc sm P ; r ; wr 0 w ; ?!da ; ?dor R ?sm r ?lc r");
+  // setting listeners after entity creation should work, too
+  dotest ("P W R ; dor P pm W sm R ; r w ; ?sm r ?pm w ; wr 0 w ; ?dor R ; ?!da");
 }
 
-CU_Test(ddsc_listener, incompatible_qos, .init=init_triggering_base, .fini=fini_triggering_base)
+CU_Test (ddsc_listener, matched)
 {
-    dds_offered_incompatible_qos_status_t offered_incompatible_qos;
-    dds_requested_incompatible_qos_status_t requested_incompatible_qos;
-    dds_return_t ret;
-    uint32_t triggered;
-    uint32_t status;
-
-    /* We are interested in incompatible qos notifications. */
-    dds_lset_offered_incompatible_qos(g_listener, offered_incompatible_qos_cb);
-    dds_lset_requested_incompatible_qos(g_listener, requested_incompatible_qos_cb);
-
-    /* Create reader and writer with proper listeners.
-     * But create reader with persistent durability to get incompatible qos. */
-    g_writer = dds_create_writer(g_participant, g_topic, g_qos, g_listener);
-    CU_ASSERT_FATAL(g_writer > 0);
-    dds_qset_durability (g_qos, DDS_DURABILITY_PERSISTENT);
-    g_reader = dds_create_reader(g_participant, g_topic, g_qos, g_listener);
-    CU_ASSERT_FATAL(g_reader > 0);
-
-    /* Incompatible QoS should be triggered with the right status. */
-    triggered = waitfor_cb(DDS_OFFERED_INCOMPATIBLE_QOS_STATUS | DDS_REQUESTED_INCOMPATIBLE_QOS_STATUS);
-    CU_ASSERT_EQUAL_FATAL(triggered & DDS_OFFERED_INCOMPATIBLE_QOS_STATUS, DDS_OFFERED_INCOMPATIBLE_QOS_STATUS);
-    CU_ASSERT_EQUAL_FATAL(triggered & DDS_REQUESTED_INCOMPATIBLE_QOS_STATUS, DDS_REQUESTED_INCOMPATIBLE_QOS_STATUS);
-    CU_ASSERT_EQUAL_FATAL(cb_reader, g_reader);
-    CU_ASSERT_EQUAL_FATAL(cb_writer, g_writer);
-    CU_ASSERT_EQUAL_FATAL(cb_offered_incompatible_qos_status.total_count, 1);
-    CU_ASSERT_EQUAL_FATAL(cb_offered_incompatible_qos_status.total_count_change, 1);
-    CU_ASSERT_EQUAL_FATAL(cb_offered_incompatible_qos_status.last_policy_id, DDS_DURABILITY_QOS_POLICY_ID);
-    CU_ASSERT_EQUAL_FATAL(cb_requested_incompatible_qos_status.total_count, 1);
-    CU_ASSERT_EQUAL_FATAL(cb_requested_incompatible_qos_status.total_count_change, 1);
-    CU_ASSERT_EQUAL_FATAL(cb_requested_incompatible_qos_status.last_policy_id, DDS_DURABILITY_QOS_POLICY_ID);
-
-    /* The listener should have swallowed the status. */
-    ret = dds_read_status(g_writer, &status, DDS_OFFERED_INCOMPATIBLE_QOS_STATUS);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    CU_ASSERT_EQUAL_FATAL(status, 0);
-    ret = dds_read_status(g_reader, &status, DDS_REQUESTED_INCOMPATIBLE_QOS_STATUS);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    CU_ASSERT_EQUAL_FATAL(status, 0);
-
-    /* The listener should have reset the count_change. */
-    ret = dds_get_offered_incompatible_qos_status(g_writer, &offered_incompatible_qos);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    ret = dds_get_requested_incompatible_qos_status(g_reader, &requested_incompatible_qos);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    CU_ASSERT_EQUAL_FATAL(offered_incompatible_qos.total_count, 1);
-    CU_ASSERT_EQUAL_FATAL(offered_incompatible_qos.total_count_change, 0);
-    CU_ASSERT_EQUAL_FATAL(offered_incompatible_qos.last_policy_id, DDS_DURABILITY_QOS_POLICY_ID);
-    CU_ASSERT_EQUAL_FATAL(requested_incompatible_qos.total_count, 1);
-    CU_ASSERT_EQUAL_FATAL(requested_incompatible_qos.total_count_change, 0);
-    CU_ASSERT_EQUAL_FATAL(requested_incompatible_qos.last_policy_id, DDS_DURABILITY_QOS_POLICY_ID);
-
-    dds_delete(g_writer);
-    dds_delete(g_reader);
+  // publication & subscription matched must both trigger; note: reader/writer matching inside
+  // a process is synchronous, no need to check everywhere
+  dotest ("sm r pm w ?pm w ?sm r");
+  // across the network it should work just as well (matching happens on different threads for
+  // remote & local entity creation, so it is meaningfully different test)
+  dotest ("sm r pm w' ?pm w' ?sm r");
 }
 
-CU_Test(ddsc_listener, data_available, .init=init_triggering_test, .fini=fini_triggering_test)
+CU_Test (ddsc_listener, publication_matched)
 {
-    dds_return_t ret;
-    uint32_t triggered;
-    uint32_t status;
-    RoundTripModule_DataType sample;
-    memset (&sample, 0, sizeof (sample));
+  // regardless of order of creation, the writer should see one reader come & then go
+  dotest ("sm r pm w ; ?pm(1,1,1,1,r) w ?sm r ; -r ; ?pm(1,0,0,-1,r) w");
+  dotest ("pm w sm r ; ?pm(1,1,1,1,r) w ?sm r ; -r ; ?pm(1,0,0,-1,r) w");
 
-    /* We are interested in data available notifications. */
-    dds_lset_data_available(g_listener, data_available_cb);
-    ret = dds_set_listener(g_reader, g_listener);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+  // regardless of order of creation, the writer should see one reader come & then go, also
+  // when a second reader introduced
+  dotest ("sm r pm w ; ?pm(1,1,1,1,r) w ?sm r ; t ?pm(2,1,2,1,t) w ; -r ; ?pm(2,0,1,-1,r) w");
+  dotest ("pm w sm r ; ?pm(1,1,1,1,r) w ?sm r ; t ?pm(2,1,2,1,t) w ; -t ; ?pm(2,0,1,-1,t) w");
 
-    /* Write sample. */
-    ret = dds_write(g_writer, &sample);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+  // same with 2 domains
+  dotest ("sm r pm w' ; ?pm(1,1,1,1,r) w' ?sm r ; -r ; ?pm(1,0,0,-1,r) w'");
+  dotest ("pm w sm r' ; ?pm(1,1,1,1,r') w ?sm r' ; -r' ; ?pm(1,0,0,-1,r') w");
 
-    /* Data available should be triggered with the right status. */
-    triggered = waitfor_cb(DDS_DATA_AVAILABLE_STATUS);
-    CU_ASSERT_EQUAL_FATAL(triggered & DDS_DATA_AVAILABLE_STATUS, DDS_DATA_AVAILABLE_STATUS);
-    CU_ASSERT_EQUAL_FATAL(cb_reader, g_reader);
-
-    /* The listener should have swallowed the status. */
-    ret = dds_read_status(g_subscriber, &status, DDS_DATA_ON_READERS_STATUS);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    CU_ASSERT_EQUAL_FATAL(status, 0);
-    ret = dds_read_status(g_reader, &status, DDS_DATA_AVAILABLE_STATUS);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    CU_ASSERT_EQUAL_FATAL(status, 0);
-
-    /* Deleting the writer causes unregisters (or dispose+unregister), and those
-       should trigger DATA_AVAILABLE as well */
-    ddsrt_mutex_lock(&g_mutex);
-    cb_called = 0;
-    cb_reader = 0;
-    ddsrt_mutex_unlock(&g_mutex);
-    ret = dds_delete (g_writer);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    g_writer = 0;
-    triggered = waitfor_cb(DDS_DATA_AVAILABLE_STATUS);
-    CU_ASSERT_EQUAL_FATAL(triggered & DDS_DATA_AVAILABLE_STATUS, DDS_DATA_AVAILABLE_STATUS);
-    CU_ASSERT_EQUAL_FATAL(cb_reader, g_reader);
-
-    /* The listener should have swallowed the status. */
-    ret = dds_read_status(g_subscriber, &status, DDS_DATA_ON_READERS_STATUS);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    CU_ASSERT_EQUAL_FATAL(status, 0);
-    ret = dds_read_status(g_reader, &status, DDS_DATA_AVAILABLE_STATUS);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    CU_ASSERT_EQUAL_FATAL(status, 0);
+  dotest ("sm r pm w' ; ?pm(1,1,1,1,r) w' ?sm r ; t ?pm(2,1,2,1,t) w' ; -r ; ?pm(2,0,1,-1,r) w'");
+  dotest ("pm w sm r' ; ?pm(1,1,1,1,r') w ?sm r' ; t ?pm(2,1,2,1,t) w ; -t ; ?pm(2,0,1,-1,t) w");
+  dotest ("sm r pm w' ; ?pm(1,1,1,1,r) w' ?sm r ; t' ?pm(2,1,2,1,t') w' ; -r ; ?pm(2,0,1,-1,r) w'");
+  dotest ("pm w sm r' ; ?pm(1,1,1,1,r') w ?sm r' ; t' ?pm(2,1,2,1,t') w ; -t' ; ?pm(2,0,1,-1,t') w");
 }
 
-CU_Test(ddsc_listener, data_available_delete_writer, .init=init_triggering_test, .fini=fini_triggering_test)
+CU_Test (ddsc_listener, subscription_matched)
 {
-    dds_return_t ret;
-    uint32_t triggered;
-    uint32_t status;
-    RoundTripModule_DataType sample;
-    memset (&sample, 0, sizeof (sample));
+  // regardless of order of creation, the reader should see one writer come & then go
+  dotest ("sm r pm w ; ?pm w ?sm(1,1,1,1,w) r ; -w ; ?sm(1,0,0,-1,w) r");
+  dotest ("pm w sm r ; ?pm w ?sm(1,1,1,1,w) r ; -w ; ?sm(1,0,0,-1,w) r");
 
-    /* We are interested in data available notifications. */
-    dds_lset_data_available(g_listener, data_available_cb);
-    ret = dds_set_listener(g_reader, g_listener);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+  // regardless of order of creation, the reader should see one writer come & then go, also
+  // when a second writer is introduced
+  dotest ("sm r pm w ; ?pm w ?sm(1,1,1,1,w) r ; x ?sm(2,1,2,1,x) r ; -w ; ?sm(2,0,1,-1,w) r");
+  dotest ("pm w sm r ; ?pm w ?sm(1,1,1,1,w) r ; x ?sm(2,1,2,1,x) r ; -x ; ?sm(2,0,1,-1,x) r");
 
-    /* Write sample, wait for the listener to swallow the status. */
-    ret = dds_write(g_writer, &sample);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    triggered = waitfor_cb(DDS_DATA_AVAILABLE_STATUS);
-    CU_ASSERT_EQUAL_FATAL(triggered & DDS_DATA_AVAILABLE_STATUS, DDS_DATA_AVAILABLE_STATUS);
-    CU_ASSERT_EQUAL_FATAL(cb_reader, g_reader);
+  // same with 2 domains
+  dotest ("sm r pm w' ; ?pm w' ?sm(1,1,1,1,w') r ; -w' ; ?sm(1,0,0,-1,w') r");
+  dotest ("pm w sm r' ; ?pm w ?sm(1,1,1,1,w) r' ; -w ; ?sm(1,0,0,-1,w) r'");
 
-    /* Deleting the writer must trigger DATA_AVAILABLE as well */
-    ddsrt_mutex_lock(&g_mutex);
-    cb_called = 0;
-    cb_reader = 0;
-    ddsrt_mutex_unlock(&g_mutex);
-    ret = dds_delete (g_writer);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    g_writer = 0;
-    triggered = waitfor_cb(DDS_DATA_AVAILABLE_STATUS);
-    CU_ASSERT_EQUAL_FATAL(triggered & DDS_DATA_AVAILABLE_STATUS, DDS_DATA_AVAILABLE_STATUS);
-    CU_ASSERT_EQUAL_FATAL(cb_reader, g_reader);
-
-    /* The listener should have swallowed the status. */
-    ret = dds_read_status(g_subscriber, &status, DDS_DATA_ON_READERS_STATUS);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    CU_ASSERT_EQUAL_FATAL(status, 0);
-    ret = dds_read_status(g_reader, &status, DDS_DATA_AVAILABLE_STATUS);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    CU_ASSERT_EQUAL_FATAL(status, 0);
+  dotest ("sm r pm w' ; ?pm w' ?sm(1,1,1,1,w') r ; x ?sm(2,1,2,1,x) r ; -w' ; ?sm(2,0,1,-1,w') r");
+  dotest ("pm w sm r' ; ?pm w ?sm(1,1,1,1,w) r' ; x ?sm(2,1,2,1,x) r' ; -x ; ?sm(2,0,1,-1,x) r'");
+  dotest ("sm r pm w' ; ?pm w' ?sm(1,1,1,1,w') r ; x' ?sm(2,1,2,1,x') r ; -w' ; ?sm(2,0,1,-1,w') r");
+  dotest ("pm w sm r' ; ?pm w ?sm(1,1,1,1,w) r' ; x' ?sm(2,1,2,1,x') r' ; -x' ; ?sm(2,0,1,-1,x') r'");
 }
 
-CU_Test(ddsc_listener, data_available_delete_writer_disposed, .init=init_triggering_test, .fini=fini_triggering_test)
+CU_Test (ddsc_listener, incompatible_qos)
 {
-    dds_return_t ret;
-    uint32_t triggered;
-    uint32_t status;
-    RoundTripModule_DataType sample;
-    memset (&sample, 0, sizeof (sample));
-
-    /* We are interested in data available notifications. */
-    dds_lset_data_available(g_listener, data_available_cb);
-    ret = dds_set_listener(g_reader, g_listener);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-
-    /* Write & dispose sample and take it so that the instance is empty & disposed.  Then deleting
-       the writer should silently drop the instance. */
-    ret = dds_write(g_writer, &sample);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    ret = dds_dispose(g_writer, &sample);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    triggered = waitfor_cb(DDS_DATA_AVAILABLE_STATUS);
-    CU_ASSERT_EQUAL_FATAL(triggered & DDS_DATA_AVAILABLE_STATUS, DDS_DATA_AVAILABLE_STATUS);
-    CU_ASSERT_EQUAL_FATAL(cb_reader, g_reader);
-
-    /* Take all data so that the instance becomes empty & disposed */
-    do {
-      void *sampleptr = &sample;
-      dds_sample_info_t info;
-      ret = dds_take (g_reader, &sampleptr, &info, 1, 1);
-    } while (ret > 0);
-
-    /* Deleting the writer should not trigger DATA_AVAILABLE with all instances empty & disposed */
-    ddsrt_mutex_lock(&g_mutex);
-    cb_called = 0;
-    cb_reader = 0;
-    ddsrt_mutex_unlock(&g_mutex);
-    ret = dds_delete (g_writer);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    g_writer = 0;
-    ddsrt_mutex_lock(&g_mutex);
-    CU_ASSERT_EQUAL_FATAL(cb_called & DDS_DATA_AVAILABLE_STATUS_ID, 0);
-    ddsrt_mutex_unlock(&g_mutex);
-
-    /* The listener should have swallowed the status. */
-    ret = dds_read_status(g_subscriber, &status, DDS_DATA_ON_READERS_STATUS);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    CU_ASSERT_EQUAL_FATAL(status, 0);
-    ret = dds_read_status(g_reader, &status, DDS_DATA_AVAILABLE_STATUS);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    CU_ASSERT_EQUAL_FATAL(status, 0);
+  // best-effort writer & reliable reader: both must trigger incompatible QoS event
+  dotest ("oiq w! riq r ; ?oiq(1,1) w ?riq(1,1) r");
+  dotest ("riq r oiq w! ; ?oiq(1,1) w ?riq(1,1) r");
 }
 
-CU_Test(ddsc_listener, data_on_readers, .init=init_triggering_test, .fini=fini_triggering_test)
+CU_Test (ddsc_listener, data_available)
 {
-    dds_return_t ret;
-    uint32_t triggered;
-    uint32_t status;
-    RoundTripModule_DataType sample;
-    memset (&sample, 0, sizeof (sample));
-
-    /* We are interested in data available notifications. */
-    dds_lset_data_on_readers(g_listener, data_on_readers_cb);
-    ret = dds_set_listener(g_subscriber, g_listener);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-
-    /* Setting data available notifications should not 'sabotage' the on_readers call. */
-    dds_lset_data_available(g_listener, data_available_cb);
-    ret = dds_set_listener(g_reader, g_listener);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-
-    /* Write sample. */
-    ret = dds_write(g_writer, &sample);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-
-    /* Data on readers should be triggered with the right status. */
-    triggered = waitfor_cb(DDS_DATA_ON_READERS_STATUS);
-    CU_ASSERT_EQUAL_FATAL(triggered & DDS_DATA_ON_READERS_STATUS, DDS_DATA_ON_READERS_STATUS);
-    CU_ASSERT_EQUAL_FATAL(cb_subscriber, g_subscriber);
-    CU_ASSERT_NOT_EQUAL_FATAL(triggered & DDS_DATA_AVAILABLE_STATUS, DDS_DATA_AVAILABLE_STATUS);
-
-    /* The listener should have swallowed the status. */
-    ret = dds_read_status(g_subscriber, &status, DDS_DATA_ON_READERS_STATUS);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    CU_ASSERT_EQUAL_FATAL(status, 0);
-    ret = dds_read_status(g_reader, &status, DDS_DATA_AVAILABLE_STATUS);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    CU_ASSERT_EQUAL_FATAL(status, 0);
+  // data available on reader
+  dotest ("da sm r pm w ?pm w ?sm r wr 0 w ?da r ?!dor");
+  // data available set on subscriber
+  dotest ("da R sm r pm w ?pm w ?sm r wr 0 w ?da r ?!dor");
+  // data available set on participant
+  dotest ("da P sm r pm w ?pm w ?sm r wr 0 w ?da r ?!dor");
 }
 
-
-CU_Test(ddsc_listener, sample_lost, .init=init_triggering_test, .fini=fini_triggering_test)
+CU_Test (ddsc_listener, data_available_delete_writer)
 {
-    dds_sample_lost_status_t sample_lost;
-    dds_return_t ret;
-    uint32_t triggered;
-    dds_time_t the_past;
-    uint32_t status;
-    RoundTripModule_DataType sample;
-    memset (&sample, 0, sizeof (sample));
-
-    /* Get a time that should be historic on all platforms.*/
-    the_past = dds_time() - 1000000;
-
-    /* We are interested in sample lost notifications. */
-    dds_lset_sample_lost(g_listener, sample_lost_cb);
-    ret = dds_set_listener(g_reader, g_listener);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-
-    /* Write first sample with current timestamp. */
-    ret = dds_write_ts(g_writer, &sample, dds_time());
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-
-    /* Write second sample with older timestamp. */
-    ret = dds_write_ts(g_writer, &sample, the_past);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-
-    /* Sample lost should be triggered with the right status. */
-    triggered = waitfor_cb(DDS_SAMPLE_LOST_STATUS);
-    CU_ASSERT_EQUAL_FATAL(triggered & DDS_SAMPLE_LOST_STATUS, DDS_SAMPLE_LOST_STATUS);
-    CU_ASSERT_EQUAL_FATAL(cb_reader, g_reader);
-    CU_ASSERT_EQUAL_FATAL(cb_sample_lost_status.total_count, 1);
-    CU_ASSERT_EQUAL_FATAL(cb_sample_lost_status.total_count_change, 1);
-
-    /* The listener should have swallowed the status. */
-    ret = dds_read_status(g_reader, &status, DDS_SAMPLE_LOST_STATUS);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    CU_ASSERT_EQUAL_FATAL(status, 0);
-
-    /* The listener should have reset the count_change. */
-    ret = dds_get_sample_lost_status(g_reader, &sample_lost);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    CU_ASSERT_EQUAL_FATAL(sample_lost.total_count, 1);
-    CU_ASSERT_EQUAL_FATAL(sample_lost.total_count_change, 0);
+  // unmatching a writer that didn't read anything has no visible effect on RHC
+  // subscription-matched event is generated synchronously, so "?sm r" doesn't
+  // really add anything (it'd be different if there are two domain instances)
+  dotest ("da sm r w ; -w ?sm r ?!da ; take(0,0) r");
+  // after writing: auto-dispose should always trigger data available, an invalid
+  // sample needs to show up if there isn't an unread sample to use instead
+  dotest ("da r w ; wr 0 w ?da r ; -w ?da r ; take(1,0) r");
+  dotest ("da r w ; wr 0 w ?da r ; read(1,0) r ; -w ?da r ; take(1,1) r");
+  dotest ("da r w ; wr 0 w ?da r ; take(1,0) r ; -w ?da r ; take(0,1) r");
+  // same with two writers (no point in doing this also with two domains)
+  dotest ("da r w x ; -w ?!da -x ?!da ; take(0,0) r");
+  dotest ("da r w x ; wr 0 w ?da r ; -x ?!da ; -w ?da r ; take(1,0) r");
+  dotest ("da r w x ; wr 0 w ?da r ; -w ?da r ; take(1,0) r ; -x ?!da ; take(0,0) r");
+  dotest ("da r w x ; wr 0 w wr 0 x ?da r ; -w ?!da ; take(2,0) r ; -x ?da r ; take(0,1) r");
+  dotest ("da r w x ; wr 0 w wr 0 x ?da r ; read(2,0) r ; -w ?!da -x ?da r ; take(2,1) r");
+  dotest ("da r w x ; wr 0 w wr 0 x ?da r ; read(2,0) r ; -x ?!da -w ?da r ; take(2,1) r");
+  dotest ("da r w x ; wr 0 w read(1,0) r ; wr 0 x ?da r ; -w ?!da -x ?da r ; take(2,0) r");
+  dotest ("da r w x ; wr 0 w read(1,0) r ; wr 0 x ?da r ; -x ?!da -w ?da r ; take(2,0) r");
+  dotest ("da r w x ; wr 0 w read(1,0) r ; wr 0 x ?da r ; read(2,0) r ; -w ?!da -x ?da r ; take(2,1) r");
+  dotest ("da r w x ; wr 0 w read(1,0) r ; wr 0 x ?da r ; read(2,0) r ; -x ?!da -w ?da r ; take(2,1) r");
+  dotest ("da r w x ; wr 0 w wr 0 x ?da r ; take(2,0) r ; -w ?!da -x ?da r ; take(0,1) r");
+  dotest ("da r w x ; wr 0 w wr 0 x ?da r ; take(2,0) r ; -x ?!da -w ?da r ; take(0,1) r");
 }
 
-CU_Test(ddsc_listener, sample_rejected, .init=init_triggering_test, .fini=fini_triggering_test)
+CU_Test (ddsc_listener, data_available_delete_writer_disposed)
 {
-    dds_sample_rejected_status_t sample_rejected;
-    dds_return_t ret;
-    uint32_t triggered;
-    uint32_t status;
-    RoundTripModule_DataType sample;
-    memset (&sample, 0, sizeof (sample));
+  // same as data_available_delete_writer, but now with the instance disposed first
+  dotest ("da r w ; wr 0 w disp 0 w ?da r ; -w ?!da");
+  dotest ("da r w ; wr 0 w disp 0 w ?da r ; read(1,0) r ; -w ?!da");
+  dotest ("da r w ; wr 0 w disp 0 w ?da r ; take(1,0) r ; -w ?!da");
 
-    /* We are interested in sample rejected notifications. */
-    dds_lset_sample_rejected(g_listener, sample_rejected_cb);
-    ret = dds_set_listener(g_reader, g_listener);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+  dotest ("da r w x ; wr 0 w ?da r ; read(1,0) r ; disp 0 w ?da r ; read(1,1) r ; -w ?!da -x ?!da");
+  dotest ("da r w x ; wr 0 w ?da r ; take(1,0) r ; disp 0 w ?da r ; take(0,1) r ; -w ?!da -x ?!da");
+  dotest ("da r w x ; wr 0 w ?da r ; read(1,0) r ; disp 0 w ?da r ; read(1,1) r ; -x ?!da -w ?!da");
+  dotest ("da r w x ; wr 0 w ?da r ; take(1,0) r ; disp 0 w ?da r ; take(0,1) r ; -x ?!da -w ?!da");
 
-    /* Write more than resource limits set by the reader. */
-    ret = dds_write(g_writer, &sample);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    ret = dds_write(g_writer, &sample);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    ret = dds_write(g_writer, &sample);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-
-    /* Sample lost should be triggered with the right status. */
-    triggered = waitfor_cb(DDS_SAMPLE_REJECTED_STATUS);
-    CU_ASSERT_EQUAL_FATAL(triggered & DDS_SAMPLE_REJECTED_STATUS, DDS_SAMPLE_REJECTED_STATUS);
-    CU_ASSERT_EQUAL_FATAL(cb_reader, g_reader);
-    CU_ASSERT_EQUAL_FATAL(cb_sample_rejected_status.total_count, 2);
-    CU_ASSERT_EQUAL_FATAL(cb_sample_rejected_status.total_count_change, 1);
-    CU_ASSERT_EQUAL_FATAL(cb_sample_rejected_status.last_reason, DDS_REJECTED_BY_SAMPLES_LIMIT);
-
-    /* The listener should have swallowed the status. */
-    ret = dds_read_status(g_reader, &status, DDS_SAMPLE_REJECTED_STATUS);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    CU_ASSERT_EQUAL_FATAL(status, 0);
-
-    /* The listener should have reset the count_change. */
-    ret = dds_get_sample_rejected_status(g_reader, &sample_rejected);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    CU_ASSERT_EQUAL_FATAL(sample_rejected.total_count, 2);
-    CU_ASSERT_EQUAL_FATAL(sample_rejected.total_count_change, 0);
-    CU_ASSERT_EQUAL_FATAL(cb_sample_rejected_status.last_reason, DDS_REJECTED_BY_SAMPLES_LIMIT);
+  dotest ("da r w x ; wr 0 w ?da r ; read(1,0) r ; disp 0 x ?da r ; read(1,1) r ; -w ?!da -x ?!da");
+  dotest ("da r w x ; wr 0 w ?da r ; take(1,0) r ; disp 0 x ?da r ; take(0,1) r ; -w ?!da -x ?!da");
+  dotest ("da r w x ; wr 0 w ?da r ; read(1,0) r ; disp 0 x ?da r ; read(1,1) r ; -x ?!da -w ?!da");
+  dotest ("da r w x ; wr 0 w ?da r ; take(1,0) r ; disp 0 x ?da r ; take(0,1) r ; -x ?!da -w ?!da");
 }
 
-CU_Test(ddsc_listener, liveliness_changed, .init=init_triggering_test, .fini=fini_triggering_base)
+CU_Test (ddsc_listener, data_on_readers)
 {
-    dds_liveliness_changed_status_t liveliness_changed;
-    dds_instance_handle_t writer_hdl;
-    dds_return_t ret;
-    uint32_t triggered;
-    uint32_t status;
-
-    /* The init_triggering_test_byliveliness set our interest in liveliness. */
-
-    /* Get writer handle that should be part of the status. */
-    ret = dds_get_instance_handle(g_writer, &writer_hdl);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-
-    /* Liveliness changed should be triggered with the right status. */
-    triggered = waitfor_cb(DDS_LIVELINESS_CHANGED_STATUS);
-    CU_ASSERT_EQUAL_FATAL(triggered & DDS_LIVELINESS_CHANGED_STATUS,  DDS_LIVELINESS_CHANGED_STATUS);
-    CU_ASSERT_EQUAL_FATAL(cb_reader, g_reader);
-    CU_ASSERT_EQUAL_FATAL(cb_liveliness_changed_status.alive_count, 1);
-    CU_ASSERT_EQUAL_FATAL(cb_liveliness_changed_status.alive_count_change, 1);
-    CU_ASSERT_EQUAL_FATAL(cb_liveliness_changed_status.not_alive_count, 0);
-    CU_ASSERT_EQUAL_FATAL(cb_liveliness_changed_status.not_alive_count_change, 0);
-    CU_ASSERT_EQUAL_FATAL(cb_liveliness_changed_status.last_publication_handle, writer_hdl);
-
-    /* The listener should have swallowed the status. */
-    ret = dds_read_status(g_reader, &status, DDS_LIVELINESS_CHANGED_STATUS);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    CU_ASSERT_EQUAL_FATAL(status, 0);
-
-    /* The listener should have reset the count_change. */
-    ret = dds_get_liveliness_changed_status(g_reader, &liveliness_changed);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    CU_ASSERT_EQUAL_FATAL(liveliness_changed.alive_count, 1);
-    CU_ASSERT_EQUAL_FATAL(liveliness_changed.alive_count_change, 0);
-    CU_ASSERT_EQUAL_FATAL(liveliness_changed.not_alive_count, 0);
-    CU_ASSERT_EQUAL_FATAL(liveliness_changed.not_alive_count_change, 0);
-    CU_ASSERT_EQUAL_FATAL(liveliness_changed.last_publication_handle, writer_hdl);
-
-    /* Reset the trigger flags. */
-    ddsrt_mutex_lock(&g_mutex);
-    cb_called = 0;
-    ddsrt_mutex_unlock(&g_mutex);
-
-    /* Change liveliness again by deleting the writer. */
-    dds_delete(g_writer);
-
-    /* Liveliness changed should be triggered with the right status. */
-    triggered = waitfor_cb(DDS_LIVELINESS_CHANGED_STATUS);
-    CU_ASSERT_EQUAL_FATAL(triggered & DDS_LIVELINESS_CHANGED_STATUS,  DDS_LIVELINESS_CHANGED_STATUS);
-    CU_ASSERT_EQUAL_FATAL(cb_reader, g_reader);
-    CU_ASSERT_EQUAL_FATAL(cb_liveliness_changed_status.alive_count, 0);
-    CU_ASSERT_EQUAL_FATAL(cb_liveliness_changed_status.alive_count_change, -1);
-    CU_ASSERT_EQUAL_FATAL(cb_liveliness_changed_status.not_alive_count, 0);
-    CU_ASSERT_EQUAL_FATAL(cb_liveliness_changed_status.not_alive_count_change, 0);
-    CU_ASSERT_EQUAL_FATAL(cb_liveliness_changed_status.last_publication_handle, writer_hdl);
-
-    /* The listener should have reset the count_change. */
-    ret = dds_get_liveliness_changed_status(g_reader, &liveliness_changed);
-    CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-    CU_ASSERT_EQUAL_FATAL(liveliness_changed.alive_count, 0);
-    CU_ASSERT_EQUAL_FATAL(liveliness_changed.alive_count_change, 0);
-    CU_ASSERT_EQUAL_FATAL(liveliness_changed.not_alive_count, 0);
-    CU_ASSERT_EQUAL_FATAL(liveliness_changed.not_alive_count_change, 0);
-    CU_ASSERT_EQUAL_FATAL(liveliness_changed.last_publication_handle, writer_hdl);
+  // data on readers wins from data available
+  dotest ("dor R da r ; wr 0 w ; ?dor R ?!da");
+  dotest ("dor P da r ; wr 0 w ; ?dor R ?!da");
 }
 
-#if 0
-/* This is basically the same as the Lite test, but inconsistent topic is not triggered.
- * That is actually what I would expect, because the code doesn't seem to be the way
- * to go to test for inconsistent topic. */
-Test(ddsc_listener, inconsistent_topic, .init=init_triggering_base, .fini=fini_triggering_base)
+CU_Test (ddsc_listener, sample_lost)
 {
-    dds_entity_t wr_topic;
-    dds_entity_t rd_topic;
-    dds_entity_t writer;
-    dds_entity_t reader;
-    uint32_t triggered;
-
-    os_osInit();
-
-    ddsrt_mutex_init(&g_mutex);
-    ddsrt_cond_init(&g_cond);
-
-    g_qos = dds_create_qos();
-    cr_assert_not_null(g_qos, "Failed to create prerequisite g_qos");
-
-    g_listener = dds_create_listener(NULL);
-    cr_assert_not_null(g_listener, "Failed to create prerequisite g_listener");
-
-    g_participant = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL, NULL);
-    cr_assert_gt(g_participant, 0, "Failed to create prerequisite g_participant");
-
-    /* We are interested in inconsistent topics. */
-    dds_lset_inconsistent_topic(g_listener, inconsistent_topic_cb);
-
-    wr_topic = dds_create_topic(g_participant, &RoundTripModule_DataType_desc, "WRITER_TOPIC", NULL, g_listener);
-    cr_assert_gt(g_topic, 0, "Failed to create prerequisite wr_topic");
-
-    rd_topic = dds_create_topic(g_participant, &RoundTripModule_DataType_desc, "READER_TOPIC", NULL, g_listener);
-    cr_assert_gt(g_topic, 0, "Failed to create prerequisite rd_topic");
-
-    /* Create reader and writer. */
-    writer = dds_create_writer(g_participant, g_topic, NULL, NULL);
-    cr_assert_gt(writer, 0, "Failed to create prerequisite writer");
-    dds_qset_reliability (g_qos, DDS_RELIABILITY_RELIABLE, DDS_SECS (1));
-    dds_qset_history (g_qos, DDS_HISTORY_KEEP_ALL, 0);
-    reader = dds_create_reader(g_subscriber, g_topic, g_qos, NULL);
-    cr_assert_gt(reader, 0, "Failed to create prerequisite reader");
-
-    /* Inconsistent topic should be triggered with the right status. */
-    triggered = waitfor_cb(DDS_INCONSISTENT_TOPIC_STATUS);
-    cr_assert_eq(triggered & DDS_INCONSISTENT_TOPIC_STATUS,  DDS_INCONSISTENT_TOPIC_STATUS, "DDS_INCONSISTENT_TOPIC_STATUS not triggered");
-
-    dds_delete(reader);
-    dds_delete(writer);
-    dds_delete(rd_topic);
-    dds_delete(wr_topic);
-    dds_delete(g_participant);
-
-    dds_delete_listener(g_listener);
-    dds_delete_qos(g_qos);
+  // FIXME: figure out what really constitutes a "lost sample"
+  dotest ("sl r ; wr@0 0 w ?!sl ; wr@-1 0 w ?sl(1,1) r");
 }
-#endif
 
+CU_Test (ddsc_listener, sample_rejected)
+{
+  // FIXME: rejection counts with retries?
+  // reliable: expect timeout on the write when max samples has been reached
+  // invalid samples don't count towards resource limits, so dispose should
+  // not be blocked
+  dotest ("sr r# ; wr 0 w wrfail 0 w wrfail 0 w ; ?sr r");
+  dotest ("sr r# ; wr 0 w wrfail 0 w ; read(1,0) r ; disp 0 w ; read(1,1) r ; ?sr r");
+
+  // best-effort: writes should succeed despite not delivering the data adding
+  // the data in the RHC, also check number of samples rejected
+  dotest ("sr r#! ; wr 0 w! wr 0 w wr 0 w ; ?sr(2,1,s) r");
+  dotest ("sr r#! ; wr 0 w! wr 0 w ; read(1,0) r ; disp 0 w ; read(1,1) r ; ?sr(1,1,s) r");
+}
+
+CU_Test (ddsc_listener, liveliness_changed)
+{
+  // liveliness changed should trigger along with matching
+  dotest ("pm w lc sm r ; ?pm w ?sm r ; ?lc(1,0,1,0,w) r ; -w ; ?lc(0,0,-1,0,w) r");
+  dotest ("pm w lc sm r' ; ?pm w ?sm r' ; ?lc(1,0,1,0,w) r' ; -w ; ?lc(0,0,-1,0,w) r'");
+}

--- a/src/core/ddsc/tests/listener.c
+++ b/src/core/ddsc/tests/listener.c
@@ -997,9 +997,9 @@ CU_Test(ddsc_listener, data_available_delete_writer_disposed, .init=init_trigger
     ret = dds_delete (g_writer);
     CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
     g_writer = 0;
-    triggered = waitfor_cb(DDS_DATA_AVAILABLE_STATUS);
-    CU_ASSERT_EQUAL_FATAL(triggered & DDS_DATA_AVAILABLE_STATUS, DDS_DATA_AVAILABLE_STATUS);
-    CU_ASSERT_EQUAL_FATAL(cb_reader, g_reader);
+    ddsrt_mutex_lock(&g_mutex);
+    CU_ASSERT_EQUAL_FATAL(cb_called & DDS_DATA_AVAILABLE_STATUS_ID, 0);
+    ddsrt_mutex_unlock(&g_mutex);
 
     /* The listener should have swallowed the status. */
     ret = dds_read_status(g_subscriber, &status, DDS_DATA_ON_READERS_STATUS);

--- a/src/core/ddsc/tests/reader_iterator.c
+++ b/src/core/ddsc/tests/reader_iterator.c
@@ -55,7 +55,7 @@
 #define MAX_SAMPLES                 21
 
 #define RDR_NOT_READ_CNT            11
-#define RDR_INV_READ_CNT             1
+#define RDR_INV_READ_CNT             2
 int rdr_expected_long_2[RDR_NOT_READ_CNT] = { 0, 1, 2, 6, 7, 9, 11, 13, 14, 16, 19 };
 
 /* Because we only read one sample at a time, only the first sample of an instance

--- a/src/core/ddsi/src/ddsi_cdrstream.c
+++ b/src/core/ddsi/src/ddsi_cdrstream.c
@@ -1990,14 +1990,42 @@ static size_t isprint_runlen (const unsigned char *s, size_t n)
   return m;
 }
 
-static bool prtf_simple (char * __restrict *buf, size_t * __restrict bufsize, dds_istream_t * __restrict is, enum dds_stream_typecode type)
+static bool prtf_simple (char * __restrict *buf, size_t * __restrict bufsize, dds_istream_t * __restrict is, enum dds_stream_typecode type, unsigned flags)
 {
   switch (type)
   {
-    case DDS_OP_VAL_1BY: return prtf (buf, bufsize, "%"PRIu8, dds_is_get1 (is));
-    case DDS_OP_VAL_2BY: return prtf (buf, bufsize, "%"PRIu16, dds_is_get2 (is));
-    case DDS_OP_VAL_4BY: return prtf (buf, bufsize, "%"PRIu32, dds_is_get4 (is));
-    case DDS_OP_VAL_8BY: return prtf (buf, bufsize, "%"PRIu64, dds_is_get8 (is));
+    case DDS_OP_VAL_1BY: {
+      const union { int8_t s; uint8_t u; } x = { .u = dds_is_get1 (is) };
+      if (flags & DDS_OP_FLAG_SGN)
+        return prtf (buf, bufsize, "%"PRId8, x.s);
+      else
+        return prtf (buf, bufsize, "%"PRIu8, x.u);
+    }
+    case DDS_OP_VAL_2BY: {
+      const union { int16_t s; uint16_t u; } x = { .u = dds_is_get2 (is) };
+      if (flags & DDS_OP_FLAG_SGN)
+        return prtf (buf, bufsize, "%"PRId16, x.s);
+      else
+        return prtf (buf, bufsize, "%"PRIu16, x.u);
+    }
+    case DDS_OP_VAL_4BY: {
+      const union { int32_t s; uint32_t u; float f; } x = { .u = dds_is_get4 (is) };
+      if (flags & DDS_OP_FLAG_FP)
+        return prtf (buf, bufsize, "%g", x.f);
+      else if (flags & DDS_OP_FLAG_SGN)
+        return prtf (buf, bufsize, "%"PRId32, x.s);
+      else
+        return prtf (buf, bufsize, "%"PRIu32, x.u);
+    }
+    case DDS_OP_VAL_8BY: {
+      const union { int64_t s; uint64_t u; double f; } x = { .u = dds_is_get8 (is) };
+      if (flags & DDS_OP_FLAG_FP)
+        return prtf (buf, bufsize, "%g", x.f);
+      else if (flags & DDS_OP_FLAG_SGN)
+        return prtf (buf, bufsize, "%"PRId64, x.s);
+      else
+        return prtf (buf, bufsize, "%"PRIu64, x.u);
+    }
     case DDS_OP_VAL_STR: case DDS_OP_VAL_BST: return prtf_str (buf, bufsize, is);
     case DDS_OP_VAL_ARR: case DDS_OP_VAL_SEQ: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU:
       abort ();
@@ -2005,7 +2033,7 @@ static bool prtf_simple (char * __restrict *buf, size_t * __restrict bufsize, dd
   return false;
 }
 
-static bool prtf_simple_array (char * __restrict *buf, size_t * __restrict bufsize, dds_istream_t * __restrict is, uint32_t num, enum dds_stream_typecode type)
+static bool prtf_simple_array (char * __restrict *buf, size_t * __restrict bufsize, dds_istream_t * __restrict is, uint32_t num, enum dds_stream_typecode type, unsigned flags)
 {
   bool cont = prtf (buf, bufsize, "{");
   switch (type)
@@ -2028,7 +2056,7 @@ static bool prtf_simple_array (char * __restrict *buf, size_t * __restrict bufsi
         {
           if (i != 0)
             (void) prtf (buf, bufsize, ",");
-          cont = prtf_simple (buf, bufsize, is, type);
+          cont = prtf_simple (buf, bufsize, is, type, flags);
           i++;
         }
       }
@@ -2040,7 +2068,7 @@ static bool prtf_simple_array (char * __restrict *buf, size_t * __restrict bufsi
       {
         if (i != 0)
           (void) prtf (buf, bufsize, ",");
-        cont = prtf_simple (buf, bufsize, is, type);
+        cont = prtf_simple (buf, bufsize, is, type, flags);
       }
       break;
     default:
@@ -2065,10 +2093,10 @@ static const uint32_t *prtf_seq (char * __restrict *buf, size_t *bufsize, dds_is
   switch (subtype)
   {
     case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY:
-      (void) prtf_simple_array (buf, bufsize, is, num, subtype);
+      (void) prtf_simple_array (buf, bufsize, is, num, subtype, DDS_OP_FLAGS (insn));
       return ops + 2;
     case DDS_OP_VAL_STR: case DDS_OP_VAL_BST:
-      (void) prtf_simple_array (buf, bufsize, is, num, subtype);
+      (void) prtf_simple_array (buf, bufsize, is, num, subtype, DDS_OP_FLAGS (insn));
       return ops + (subtype == DDS_OP_VAL_STR ? 2 : 3);
     case DDS_OP_VAL_SEQ: case DDS_OP_VAL_ARR: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU: {
       const uint32_t jmp = DDS_OP_ADR_JMP (ops[3]);
@@ -2093,10 +2121,10 @@ static const uint32_t *prtf_arr (char * __restrict *buf, size_t *bufsize, dds_is
   switch (subtype)
   {
     case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY:
-      (void) prtf_simple_array (buf, bufsize, is, num, subtype);
+      (void) prtf_simple_array (buf, bufsize, is, num, subtype, DDS_OP_FLAGS (insn));
       return ops + 3;
     case DDS_OP_VAL_STR: case DDS_OP_VAL_BST:
-      (void) prtf_simple_array (buf, bufsize, is, num, subtype);
+      (void) prtf_simple_array (buf, bufsize, is, num, subtype, DDS_OP_FLAGS (insn));
       return ops + (subtype == DDS_OP_VAL_STR ? 3 : 5);
     case DDS_OP_VAL_SEQ: case DDS_OP_VAL_ARR: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU: {
       const uint32_t *jsr_ops = ops + DDS_OP_ADR_JSR (ops[3]);
@@ -2127,7 +2155,7 @@ static const uint32_t *prtf_uni (char * __restrict *buf, size_t *bufsize, dds_is
     {
       case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY:
       case DDS_OP_VAL_STR: case DDS_OP_VAL_BST:
-        (void) prtf_simple (buf, bufsize, is, valtype);
+        (void) prtf_simple (buf, bufsize, is, valtype, DDS_OP_FLAGS (jeq_op[0]));
         break;
       case DDS_OP_VAL_SEQ: case DDS_OP_VAL_ARR: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU:
         (void) dds_stream_print_sample1 (buf, bufsize, is, jeq_op + DDS_OP_ADR_JSR (jeq_op[0]), valtype == DDS_OP_VAL_STU);
@@ -2156,11 +2184,11 @@ static bool dds_stream_print_sample1 (char * __restrict *buf, size_t * __restric
         {
           case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY:
           case DDS_OP_VAL_STR:
-            cont = prtf_simple (buf, bufsize, is, DDS_OP_TYPE (insn));
+            cont = prtf_simple (buf, bufsize, is, DDS_OP_TYPE (insn), DDS_OP_FLAGS (insn));
             ops += 2;
             break;
           case DDS_OP_VAL_BST:
-            cont = prtf_simple (buf, bufsize, is, DDS_OP_TYPE (insn));
+            cont = prtf_simple (buf, bufsize, is, DDS_OP_TYPE (insn), DDS_OP_FLAGS (insn));
             ops += 3;
             break;
           case DDS_OP_VAL_SEQ:
@@ -2212,10 +2240,10 @@ size_t dds_stream_print_key (dds_istream_t * __restrict is, const struct ddsi_se
     {
       case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY:
       case DDS_OP_VAL_STR: case DDS_OP_VAL_BST:
-        cont = prtf_simple (&buf, &bufsize, is, DDS_OP_TYPE (*op));
+        cont = prtf_simple (&buf, &bufsize, is, DDS_OP_TYPE (*op), DDS_OP_FLAGS (*op));
         break;
       case DDS_OP_VAL_ARR:
-        cont = prtf_simple_array (&buf, &bufsize, is, op[2], DDS_OP_SUBTYPE (*op));
+        cont = prtf_simple_array (&buf, &bufsize, is, op[2], DDS_OP_SUBTYPE (*op), DDS_OP_FLAGS (*op));
         break;
       case DDS_OP_VAL_SEQ: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU:
         abort ();

--- a/src/core/xtests/rhc_torture/rhc_torture.c
+++ b/src/core/xtests/rhc_torture/rhc_torture.c
@@ -894,6 +894,7 @@ int main (int argc, char **argv)
   uint32_t states_seen[2 * 2 * 3][2] = {{ 0 }};
   unsigned seed = 0;
   bool print = false;
+  int xchecks = 1;
   int first = 0, count = 10000;
 
   ddsrt_mutex_init (&wait_gc_cycle_lock);
@@ -909,9 +910,20 @@ int main (int argc, char **argv)
     count = atoi (argv[3]);
   if (argc > 4)
     print = (atoi (argv[4]) != 0);
+  if (argc > 5)
+    xchecks = atoi (argv[4]);
 
-  printf ("prng seed %u first %d count %d print %d\n", seed, first, count, print);
+  printf ("prng seed %u first %d count %d print %d xchecks %d\n", seed, first, count, print, xchecks);
   ddsrt_prng_init_simple (&prng, seed);
+
+  if (xchecks != 0)
+  {
+    struct ddsi_domaingv *gv = get_gv (pp);
+    if (xchecks > 0)
+      gv->config.enabled_xchecks = ~0u;
+    else
+      gv->config.enabled_xchecks = 0u;
+  }
 
   memset (rres_mseq, 0, sizeof (rres_mseq));
   for (size_t i = 0; i < sizeof (rres_iseq) / sizeof(rres_iseq[0]); i++)

--- a/src/core/xtests/rhc_torture/rhc_torture.c
+++ b/src/core/xtests/rhc_torture/rhc_torture.c
@@ -935,6 +935,7 @@ int main (int argc, char **argv)
       printf ("************* 0 *************\n");
     struct dds_rhc *rhc = mkrhc (gv, NULL, DDS_HISTORY_KEEP_LAST, 1, DDS_DESTINATIONORDER_BY_SOURCE_TIMESTAMP);
     struct proxy_writer *wr0 = mkwr (gv, 1);
+    struct proxy_writer *wr1 = mkwr (gv, 1);
     uint64_t iid0, iid1, iid_t;
     iid0 = store (tkmap, rhc, wr0, mksample (0, 0), print, false);
     iid1 = store (tkmap, rhc, wr0, mksample (1, NN_STATUSINFO_DISPOSE), print, false);
@@ -944,17 +945,38 @@ int main (int argc, char **argv)
       { 0, 0, 0, 0, 0, 0, 0, 0 }
     };
     rdall (rhc, c0, print, states_seen);
-    iid_t = store (tkmap, rhc, wr0, mkkeysample (0, NN_STATUSINFO_UNREGISTER), print, false);
+    /* write instance 0 with 2nd writer to have 2 live writers */
+    iid_t = store (tkmap, rhc, wr1, mksample (0, 0), print, false);
     assert (iid_t == iid0);
-    (void)iid0;
-    (void)iid_t;
     const struct check c1[] = {
-      { "ROU", iid0, wr0->e.iid, 0,0, 1, 0,1 },
-      { "NOU", iid0, 0, 0,0, 0, 0,0 },
+      { "NOA", iid0, wr1->e.iid, 0,0, 1, 0,3 },
       { "ROD", iid1, wr0->e.iid, 0,0, 1, 1,2 },
       { 0, 0, 0, 0, 0, 0, 0, 0 }
     };
     rdall (rhc, c1, print, states_seen);
+    /* unregister instance 0 with wr0 - autodispose, but 2nd writer keeps it alive, no visible change */
+    iid_t = store (tkmap, rhc, wr0, mkkeysample (0, NN_STATUSINFO_UNREGISTER), print, false);
+    assert (iid_t == iid0);
+    const struct check c2[] = {
+      { "ROA", iid0, wr1->e.iid, 0,0, 1, 0,3 },
+      { "ROD", iid1, wr0->e.iid, 0,0, 1, 1,2 },
+      { 0, 0, 0, 0, 0, 0, 0, 0 }
+    };
+    rdall (rhc, c2, print, states_seen);
+    /* unregistering instance 0 again should be a no-op because wr0 no longer has it registered */
+    iid_t = store (tkmap, rhc, wr0, mkkeysample (0, NN_STATUSINFO_UNREGISTER), print, false);
+    assert (iid_t == iid0);
+    rdall (rhc, c2, print, states_seen);
+    /* unregistering instance 0 with wr1 - autodispose, no live writers -> dispose */
+    iid_t = store (tkmap, rhc, wr1, mkkeysample (0, NN_STATUSINFO_UNREGISTER), print, false);
+    assert (iid_t == iid0);
+    const struct check c3[] = {
+      { "ROD", iid0, wr1->e.iid, 0,0, 1, 0,3 },
+      { "NOD", iid0, 0, 0,0, 0, 0,0 },
+      { "ROD", iid1, wr0->e.iid, 0,0, 1, 1,2 },
+      { 0, 0, 0, 0, 0, 0, 0, 0 }
+    };
+    rdall (rhc, c3, print, states_seen);
     thread_state_awake_domain_ok (lookup_thread_state ());
     struct ddsi_writer_info wr0_info;
     wr0_info.auto_dispose = wr0->c.xqos->writer_data_lifecycle.autodispose_unregistered_instances;
@@ -966,16 +988,18 @@ int main (int argc, char **argv)
 #endif
     dds_rhc_unregister_wr (rhc, &wr0_info);
     thread_state_asleep (lookup_thread_state ());
-    const struct check c2[] = {
-      { "ROU", iid0, wr0->e.iid, 0,0, 1, 0,1 },
-      { "ROU", iid0, 0, 0,0, 0, 0,0 },
+    const struct check c4[] = {
+      { "ROD", iid0, wr1->e.iid, 0,0, 1, 0,3 },
+      { "ROD", iid0, 0, 0,0, 0, 0,0 },
       { "ROD", iid1, wr0->e.iid, 0,0, 1, 1,2 },
-      { "NOD", iid1, 0, 0,0, 0, 1,0 },
+      // { "NOD", iid1, 0, 0,0, 0, 1,0 }, doesn't exist because it is already disposed
       { 0, 0, 0, 0, 0, 0, 0, 0 }
     };
-    tkall (rhc, c2, print, states_seen);
+    tkall (rhc, c4, print, states_seen);
     frhc (rhc);
     fwr (wr0);
+    fwr (wr1);
+    (void)iid_t;
   }
 
   if (1 >= first)

--- a/src/idlc/src/org/eclipse/cyclonedds/generator/BasicType.java
+++ b/src/idlc/src/org/eclipse/cyclonedds/generator/BasicType.java
@@ -20,15 +20,15 @@ public class BasicType extends AbstractType
   {
     BOOLEAN ("bool", "DDS_OP_TYPE_BOO", "DDS_OP_SUBTYPE_BOO", Alignment.BOOL, "Boolean"),
     OCTET ("uint8_t", "DDS_OP_TYPE_1BY", "DDS_OP_SUBTYPE_1BY", Alignment.ONE, "Octet"),
-    CHAR ("char", "DDS_OP_TYPE_1BY", "DDS_OP_SUBTYPE_1BY", Alignment.ONE, "Char"),
-    SHORT ("int16_t", "DDS_OP_TYPE_2BY", "DDS_OP_SUBTYPE_2BY", Alignment.TWO, "Short"),
+    CHAR ("char", "DDS_OP_TYPE_1BY | DDS_OP_FLAG_SGN", "DDS_OP_SUBTYPE_1BY | DDS_OP_FLAG_SGN", Alignment.ONE, "Char"),
+    SHORT ("int16_t", "DDS_OP_TYPE_2BY | DDS_OP_FLAG_SGN", "DDS_OP_SUBTYPE_2BY | DDS_OP_FLAG_SGN", Alignment.TWO, "Short"),
     USHORT ("uint16_t", "DDS_OP_TYPE_2BY", "DDS_OP_SUBTYPE_2BY", Alignment.TWO, "UShort"),
-    LONG ("int32_t", "DDS_OP_TYPE_4BY", "DDS_OP_SUBTYPE_4BY", Alignment.FOUR, "Long"),
+    LONG ("int32_t", "DDS_OP_TYPE_4BY | DDS_OP_FLAG_SGN", "DDS_OP_SUBTYPE_4BY | DDS_OP_FLAG_SGN", Alignment.FOUR, "Long"),
     ULONG ("uint32_t", "DDS_OP_TYPE_4BY", "DDS_OP_SUBTYPE_4BY", Alignment.FOUR, "ULong"),
-    LONGLONG ("int64_t", "DDS_OP_TYPE_8BY", "DDS_OP_SUBTYPE_8BY", Alignment.EIGHT, "LongLong"),
+    LONGLONG ("int64_t", "DDS_OP_TYPE_8BY | DDS_OP_FLAG_SGN", "DDS_OP_SUBTYPE_8BY | DDS_OP_FLAG_SGN", Alignment.EIGHT, "LongLong"),
     ULONGLONG ("uint64_t", "DDS_OP_TYPE_8BY", "DDS_OP_SUBTYPE_8BY", Alignment.EIGHT, "ULongLong"),
-    FLOAT ("float", "DDS_OP_TYPE_4BY", "DDS_OP_SUBTYPE_4BY", Alignment.FOUR, "Float"),
-    DOUBLE ("double", "DDS_OP_TYPE_8BY", "DDS_OP_SUBTYPE_8BY", Alignment.EIGHT, "Double"),
+    FLOAT ("float", "DDS_OP_TYPE_4BY | DDS_OP_FLAG_FP", "DDS_OP_SUBTYPE_4BY | DDS_OP_FLAG_FP", Alignment.FOUR, "Float"),
+    DOUBLE ("double", "DDS_OP_TYPE_8BY | DDS_OP_FLAG_FP", "DDS_OP_SUBTYPE_8BY | DDS_OP_FLAG_FP", Alignment.EIGHT, "Double"),
     STRING ("char *", "DDS_OP_TYPE_STR", "DDS_OP_SUBTYPE_STR", Alignment.PTR, "String");
 
     public final String cType;


### PR DESCRIPTION
With apologies for the mass of this PR ... and even with that it is still only preparation for I really meant to do because the bit of refactoring I started doing with an aim to reduce the number of points that would be affected by implementing "autopurge" for instances in the no writers and in the disposed states turned up some other things.

There are many commits, I believe I managed to get all of them to work, even though they were mostly reconstructed based on the final form. If anyone feels like reviewing anything, I'd suggest looking at the individual commits.

* The first 4 commits are the same as #499, rebased to current master.
* "Null instance pointer ..." avoids passing what is effectively a dangling pointer. The dangling pointer did not get dereferenced, but I found it quite unwise as it was.
* "Track deadline registrations ..." uses a dedicated flag to track in the instances to track whether it is currently registered in the deadline administration and uses this to perform all updates at the end updating an instance, instead of spread out through the code.
* "Auto-dispose ..." is a slight change in auto-dispose behaviour, instead of treating an unregister as a dispose, it now atomically transitions a NO_WRITERS instance to a DISPOSED one (also fits better with the name: "auto-dispose *unregistered* instances", instead of "auto-dispose on unregister").
* "Always add invalid sample ...": it turns out there were a few cases where an invalid sample wasn't generated when it should have been.
* "Refactor" is some of the refactoring in the title, shouldn't affect the behaviour other than some tiny changes in tracing output (those traces remain unworthy of recommendation as reading material anyway).
* "Standard byte order ...": a small clean up to try not to break expectations.
* "Implement "from_sample" ...": that function didn't exist by mistake, causing `dds_lookup_instance` on a built-in topic to crash.
* "Rework listener tests" manages to leave the number of lines of the test file very nearly unchanged while vastly increasing the number of tests by replacing tons of boilerplate by an inscrutable and hacked-together DSL with an interpreter. I'm not sure it is an improvement, but it did help me find missing data available notifications, missing invalid samples and a missing "from_sample" function, so it certainly has been a valuable exercise.