### PR TITLE
Update security handshake when optional fields of handshake tokens are missing

### DIFF
--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -262,7 +262,7 @@ The default value is: "".
 
 
 #### //CycloneDDS/Domain/DDSSecurity/Authentication
-Children: [IdentityCA](#cycloneddsdomainddssecurityauthenticationidentityca), [IdentityCertificate](#cycloneddsdomainddssecurityauthenticationidentitycertificate), [Library](#cycloneddsdomainddssecurityauthenticationlibrary), [Password](#cycloneddsdomainddssecurityauthenticationpassword), [PrivateKey](#cycloneddsdomainddssecurityauthenticationprivatekey), [TrustedCADirectory](#cycloneddsdomainddssecurityauthenticationtrustedcadirectory)
+Children: [IdentityCA](#cycloneddsdomainddssecurityauthenticationidentityca), [IdentityCertificate](#cycloneddsdomainddssecurityauthenticationidentitycertificate), [IncludeOptionalFields](#cycloneddsdomainddssecurityauthenticationincludeoptionalfields), [Library](#cycloneddsdomainddssecurityauthenticationlibrary), [Password](#cycloneddsdomainddssecurityauthenticationpassword), [PrivateKey](#cycloneddsdomainddssecurityauthenticationprivatekey), [TrustedCADirectory](#cycloneddsdomainddssecurityauthenticationtrustedcadirectory)
 
 
 This element configures the Authentication plugin of the DDS Security
@@ -309,6 +309,18 @@ Examples:
 MIIDjjCCAnYCCQDCEu9...6rmT87dhTo=<br>
 
 -----END CERTIFICATE-----</IdentityCertificate>
+
+
+##### //CycloneDDS/Domain/DDSSecurity/Authentication/IncludeOptionalFields
+Boolean
+
+The authentication handshake tokens may contain optional fields to be
+included for finding interoperability problems.
+
+If this parameter is set to true the optional fields are included in the
+handshake token exchange.
+
+The default value is: "false".
 
 
 ##### //CycloneDDS/Domain/DDSSecurity/Authentication/Library

--- a/etc/cyclonedds.rnc
+++ b/etc/cyclonedds.rnc
@@ -268,6 +268,16 @@ MIIDjjCCAnYCCQDCEu9...6rmT87dhTo=<br>
             text
           }
           & [ a:documentation [ xml:lang="en" """
+<p>The authentication handshake tokens may contain optional fields to be
+included for finding interoperability problems.
+
+If this parameter is set to true the optional fields are included in the
+handshake token exchange.</p><p>The default value is:
+&quot;false&quot;.</p>""" ] ]
+          element IncludeOptionalFields {
+            xsd:boolean
+          }?
+          & [ a:documentation [ xml:lang="en" """
 <p>This element specifies the library to be loaded as the DDS Security
 Access Control plugin.</p>""" ] ]
           element Library {

--- a/etc/cyclonedds.xsd
+++ b/etc/cyclonedds.xsd
@@ -327,6 +327,7 @@ specification.&lt;/p&gt;</xs:documentation>
       <xs:all>
         <xs:element ref="config:IdentityCA"/>
         <xs:element ref="config:IdentityCertificate"/>
+        <xs:element minOccurs="0" ref="config:IncludeOptionalFields"/>
         <xs:element minOccurs="0" name="Library">
           <xs:annotation>
             <xs:documentation>
@@ -417,6 +418,17 @@ public key.&lt;/p&gt;
 MIIDjjCCAnYCCQDCEu9...6rmT87dhTo=&lt;br&gt;
 
 -----END CERTIFICATE-----&lt;/IdentityCertificate&gt;&lt;/p&gt;</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="IncludeOptionalFields" type="xs:boolean">
+    <xs:annotation>
+      <xs:documentation>
+&lt;p&gt;The authentication handshake tokens may contain optional fields to be
+included for finding interoperability problems.
+
+If this parameter is set to true the optional fields are included in the
+handshake token exchange.&lt;/p&gt;&lt;p&gt;The default value is:
+&amp;quot;false&amp;quot;.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="Password" type="xs:string">

--- a/src/core/ddsi/include/dds/ddsi/ddsi_domaingv.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_domaingv.h
@@ -330,6 +330,7 @@ struct ddsi_domaingv {
 #ifdef DDSI_INCLUDE_SECURITY
   struct dds_security_context *security_context;
   struct ddsi_hsadmin *hsadmin;
+  bool handshake_include_optional;
 #endif
 
 };

--- a/src/core/ddsi/include/dds/ddsi/q_config.h
+++ b/src/core/ddsi/include/dds/ddsi/q_config.h
@@ -174,6 +174,7 @@ typedef struct authentication_properties_type{
   char *private_key;
   char *password;
   char *trusted_ca_dir;
+  bool include_optional_fields;
 } authentication_properties_type;
 
 typedef struct access_control_properties_type{

--- a/src/core/ddsi/include/dds/ddsi/q_config.h
+++ b/src/core/ddsi/include/dds/ddsi/q_config.h
@@ -174,7 +174,7 @@ typedef struct authentication_properties_type{
   char *private_key;
   char *password;
   char *trusted_ca_dir;
-  bool include_optional_fields;
+  int include_optional_fields;
 } authentication_properties_type;
 
 typedef struct access_control_properties_type{

--- a/src/core/ddsi/src/ddsi_security_omg.c
+++ b/src/core/ddsi/src/ddsi_security_omg.c
@@ -736,7 +736,7 @@ void q_omg_security_init (struct ddsi_domaingv *gv)
   gv->security_context = sc;
 
   if (gv->config.omg_security_configuration)
-    gv->handshake_include_optional = gv->config.omg_security_configuration->cfg.authentication_properties.include_optional_fields;
+    gv->handshake_include_optional = gv->config.omg_security_configuration->cfg.authentication_properties.include_optional_fields != 0;
   else
     gv->handshake_include_optional = false;
 

--- a/src/core/ddsi/src/ddsi_security_omg.c
+++ b/src/core/ddsi/src/ddsi_security_omg.c
@@ -735,6 +735,11 @@ void q_omg_security_init (struct ddsi_domaingv *gv)
   ddsrt_mutex_init (&sc->omg_security_lock);
   gv->security_context = sc;
 
+  if (gv->config.omg_security_configuration)
+    gv->handshake_include_optional = gv->config.omg_security_configuration->cfg.authentication_properties.include_optional_fields;
+  else
+    gv->handshake_include_optional = false;
+
   ddsi_handshake_admin_init(gv);
 }
 

--- a/src/core/ddsi/src/q_config.c
+++ b/src/core/ddsi/src/q_config.c
@@ -353,7 +353,9 @@ The value of the password property shall be interpreted as the Base64 encoding o
 If the password property is not present, then the value supplied in the private_key property must contain the unencrypted private key. </p>") },
   { LEAF ("TrustedCADirectory"), 1, "", RELOFF (config_omg_security_listelem, cfg.authentication_properties.trusted_ca_dir), 0, uf_string, ff_free, pf_string,
     BLURB("<p>Trusted CA Directory which contains trusted CA certificates as separated files.</p>") },
-
+  { LEAF ("IncludeOptionalFields"), 1, "false", RELOFF (config_omg_security_listelem, cfg.authentication_properties.include_optional_fields), 0, uf_boolean, 0, pf_boolean,
+    BLURB("<p>The authentication handshake tokens may contain optional fields to be included for finding interoperability problems.\n\
+If this parameter is set to true the optional fields are included in the handshake token exchange.</p>") },
   END_MARKER
 };
 

--- a/src/security/builtin_plugins/cryptographic/src/crypto_key_exchange.c
+++ b/src/security/builtin_plugins/cryptographic/src/crypto_key_exchange.c
@@ -78,18 +78,19 @@ static bool check_crypto_keymaterial(
 {
   bool status = false;
   uint32_t transform_kind = CRYPTO_TRANSFORM_KIND(keymat->transformation_kind);
-  uint32_t key_sz = CRYPTO_KEY_SIZE_BYTES(transform_kind);
 
   if (transform_kind != CRYPTO_TRANSFORMATION_KIND_NONE)
   {
-    status = (transform_kind <= CRYPTO_TRANSFORMATION_KIND_AES256_GCM &&
-        keymat->master_salt._length == key_sz && keymat->master_salt._buffer != NULL && check_not_data_empty(&keymat->master_salt) &&
-        keymat->master_sender_key._length == key_sz && keymat->master_sender_key._buffer != NULL && check_not_data_empty(&keymat->master_sender_key));
-
-    if (status && CRYPTO_TRANSFORM_ID(keymat->receiver_specific_key_id))
+    if (transform_kind <= CRYPTO_TRANSFORMATION_KIND_AES256_GCM)
     {
-      status = (keymat->master_receiver_specific_key._length == key_sz &&
-          keymat->master_receiver_specific_key._buffer != NULL && check_not_data_empty(&keymat->master_receiver_specific_key));
+      uint32_t key_sz = CRYPTO_KEY_SIZE_BYTES(transform_kind);
+      status = (keymat->master_salt._length == key_sz && keymat->master_salt._buffer != NULL && check_not_data_empty(&keymat->master_salt) &&
+                keymat->master_sender_key._length == key_sz && keymat->master_sender_key._buffer != NULL && check_not_data_empty(&keymat->master_sender_key));
+      if (status && CRYPTO_TRANSFORM_ID(keymat->receiver_specific_key_id))
+      {
+        status = (keymat->master_receiver_specific_key._length == key_sz &&
+                  keymat->master_receiver_specific_key._buffer != NULL && check_not_data_empty(&keymat->master_receiver_specific_key));
+      }
     }
   }
   else

--- a/src/security/builtin_plugins/cryptographic/src/crypto_key_factory.c
+++ b/src/security/builtin_plugins/cryptographic/src/crypto_key_factory.c
@@ -37,7 +37,9 @@
  */
 
 #define KXKEYCOOKIE "key exchange key"
+#define KXKEYCOOKIE_SIZE (sizeof(KXKEYCOOKIE) - 1)
 #define KXSALTCOOKIE "keyexchange salt"
+#define KXSALTCOOKIE_SIZE (sizeof(KXSALTCOOKIE) - 1)
 
 typedef struct dds_security_crypto_key_factory_impl
 {
@@ -89,8 +91,6 @@ calculate_kx_keys(
   unsigned char *kx_master_salt, *kx_master_sender_key;
   size_t shared_secret_size = get_secret_size_from_secret_handle(shared_secret);
   unsigned char hash[SHA256_DIGEST_LENGTH];
-  size_t KXKEYCOOKIE_SIZE = strlen(KXKEYCOOKIE);
-  size_t KXSALTCOOKIE_SIZE = strlen(KXSALTCOOKIE);
   size_t concatenated_bytes1_size = DDS_SECURITY_AUTHENTICATION_CHALLENGE_SIZE * 2 + KXSALTCOOKIE_SIZE;
   size_t concatenated_bytes2_size = DDS_SECURITY_AUTHENTICATION_CHALLENGE_SIZE * 2 + KXKEYCOOKIE_SIZE;
   DDS_Security_octet *concatenated_bytes1, *concatenated_bytes2;

--- a/src/security/builtin_plugins/cryptographic/src/crypto_utils.c
+++ b/src/security/builtin_plugins/cryptographic/src/crypto_utils.c
@@ -62,6 +62,7 @@ crypto_calculate_key_impl(
   memcpy(buffer, prefix, strlen(prefix));
   memcpy(&buffer[strlen(prefix)], master_salt, key_bytes);
   memcpy(&buffer[strlen(prefix) + key_bytes], &id, sizeof(id));
+
   if (HMAC(EVP_sha256(), master_key, (int)key_bytes, buffer, sz, md, NULL) == NULL)
   {
     DDS_Security_Exception_set_with_openssl_error(ex, DDS_CRYPTO_PLUGIN_CONTEXT, DDS_SECURITY_ERR_CIPHER_ERROR, 0, "HMAC failed: ");

--- a/src/security/core/include/dds/security/core/dds_security_utils.h
+++ b/src/security/core/include/dds/security/core/dds_security_utils.h
@@ -53,12 +53,12 @@ DDS_Security_BinaryProperty_free(
 DDS_EXPORT void
 DDS_Security_BinaryProperty_copy(
          DDS_Security_BinaryProperty_t *dst,
-         DDS_Security_BinaryProperty_t *src);
+         const DDS_Security_BinaryProperty_t *src);
 
 DDS_EXPORT bool
 DDS_Security_BinaryProperty_equal(
-         DDS_Security_BinaryProperty_t *pa,
-         DDS_Security_BinaryProperty_t *pb);
+         const DDS_Security_BinaryProperty_t *pa,
+         const DDS_Security_BinaryProperty_t *pb);
 
 DDS_EXPORT void
 DDS_Security_BinaryProperty_set_by_value(
@@ -111,12 +111,12 @@ DDS_Security_Property_deinit(
 DDS_EXPORT void
 DDS_Security_Property_copy(
          DDS_Security_Property_t *dst,
-         DDS_Security_Property_t *src);
+         const DDS_Security_Property_t *src);
 
 DDS_EXPORT bool
 DDS_Security_Property_equal(
-         DDS_Security_Property_t *pa,
-         DDS_Security_Property_t *pb);
+         const DDS_Security_Property_t *pa,
+         const DDS_Security_Property_t *pb);
 
 DDS_EXPORT char *
 DDS_Security_Property_get_value(

--- a/src/security/core/src/dds_security_utils.c
+++ b/src/security/core/src/dds_security_utils.c
@@ -63,7 +63,7 @@ DDS_Security_BinaryProperty_free(
 void
 DDS_Security_BinaryProperty_copy(
      DDS_Security_BinaryProperty_t *dst,
-     DDS_Security_BinaryProperty_t *src)
+     const DDS_Security_BinaryProperty_t *src)
 {
     dst->name = src->name ? ddsrt_strdup(src->name) : NULL;
     dst->propagate = src->propagate;
@@ -80,8 +80,8 @@ DDS_Security_BinaryProperty_copy(
 
 bool
 DDS_Security_BinaryProperty_equal(
-     DDS_Security_BinaryProperty_t *pa,
-     DDS_Security_BinaryProperty_t *pb)
+     const DDS_Security_BinaryProperty_t *pa,
+     const DDS_Security_BinaryProperty_t *pb)
 {
     uint32_t i;
 
@@ -248,7 +248,7 @@ DDS_Security_Property_deinit(
 void
 DDS_Security_Property_copy(
      DDS_Security_Property_t *dst,
-     DDS_Security_Property_t *src)
+     const DDS_Security_Property_t *src)
 {
     dst->name = src->name ? ddsrt_strdup(src->name) : NULL;
     dst->value = src->value ? ddsrt_strdup(src->value) : NULL;
@@ -257,8 +257,8 @@ DDS_Security_Property_copy(
 
 bool
 DDS_Security_Property_equal(
-     DDS_Security_Property_t *pa,
-     DDS_Security_Property_t *pb)
+     const DDS_Security_Property_t *pa,
+     const DDS_Security_Property_t *pb)
 {
     if (pa->name && pb->name) {
         if (strcmp(pa->name, pb->name) != 0) {


### PR DESCRIPTION
A number of fields of the handshake tokens that are exchanged are optional. In case these optional fields are missing these field should be constructed at the receiving side to correctly verify the signature present in the handshake token. This is handled by this PR.
Further the (de)serialization of the PropertyQoS parameter present in the p.data field of the handshake tokens is corrrected.
Also the generation of the shared key used for the exchange of the crypto tokens is updated to comply to the specification.