### PR TITLE
Prepare for 0.6.0 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,11 +2,27 @@
 Changelog for Eclipse Cyclone DDS
 =================================
 
-`Unreleased <https://github.com/eclipse-cyclonedds/cyclonedds/compare/0.5.1...master>`_
+`Unreleased <https://github.com/eclipse-cyclonedds/cyclonedds/compare/0.6.0...master>`_
 ---------------------------------------------------------------------------------------
+
+`V0.6.0 (2020-05-21) <https://github.com/eclipse-cyclonedds/cyclonedds/compare/V0.5.0...0.6.0>`_
+-----------------------------------------------------------------------------------------------
+
+* Support for mixed-language programming by supporting multiple (de)serializers for a single topic in a single process. This way, a program that consists of, say, C and C++ can use a different representation of the data in C than in C++. Before, all readers/writers in the process would be forced to use the same representation (or perform an additional copy). Currently C is still the only natively supported language, but one can use an evolving-but-reasonable-stable interface to implement different mappings.
+* Improved QoS support: full support for deadline, lifespan and liveliness. The first is for generating notifications when a configured instance update rate is not achieved, the second for automatically removing stale samples, the third for different modes of monitoring the liveliness of peers.
+* Improved scalability in matching readers and writers. Before it used to try matching a new local or remote reader or writer with all known local & remote entities, now only with the right group with the correct topic name.
+* Improved tracing: discovery data is now printed properly and user samples have more type information allowing floating-point and signed numbers to be traced in a more readable form.
+* Extension of platform support
+  * Known to work on FreeBSD, CheriBSD
+  * Known to work with the musl C library
+* Windows-specific changes
+  * Fixes multicasts to addresses also used by non-Cyclone processes (caused by accidentally linking with an old sockets library)
+  * Correct handling of non-English network interface names
 
 `0.5.1 (2020-03-11) <https://github.com/eclipse-cyclonedds/cyclonedds/compare/V0.5.0...0.5.1>`_
 -----------------------------------------------------------------------------------------------
+
+An interim tag for the benefit of ROS2
 
 * Enable QOS features: liveliness, lifespan, deadline
 * Fix issues on Windows where multicast data was not received

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
 cmake_minimum_required(VERSION 3.7)
-project(CycloneDDS VERSION 0.5.0)
+project(CycloneDDS VERSION 0.6.0)
 
 # Set a default build type if none was specified
 set(default_build_type "RelWithDebInfo")

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Eclipse Cyclone DDS
 
 Eclipse Cyclone DDS is a very performant and robust open-source DDS implementation.  Cyclone DDS is developed completely in the open as an Eclipse IoT project
-(see [eclipse-cyclone-dds](https://projects.eclipse.org/projects/iot.cyclonedds)).
+(see [eclipse-cyclone-dds](https://projects.eclipse.org/projects/iot.cyclonedds)) with a growing list of [adopters](https://iot.eclipse.org/adopters/?#iot.cyclonedds) (if you're one of them, please add your [logo](https://github.com/EclipseFdn/iot.eclipse.org/issues/new?template=adopter_request.md)).  It is a tier-1 middleware for the Robot Operating System [ROS 2](https://index.ros.org/doc/ros2/).
 
 * [Getting Started](#getting-started)
 * [Performance](#performance)
@@ -11,8 +11,7 @@ Eclipse Cyclone DDS is a very performant and robust open-source DDS implementati
 
 ## Building Eclipse Cyclone DDS
 
-In order to build Cyclone DDS you need a Linux, Mac or Windows 10 machine (or, with some caveats, an
-OpenIndiana one or a Solaris 2.6 one) with the following installed on your host:
+In order to build Cyclone DDS you need a Linux, Mac or Windows 10 machine (or, with some caveats, a *BSD, OpenIndiana or a Solaris 2.6 one) with the following installed on your host:
 
   * C compiler (most commonly GCC on Linux, Visual Studio on Windows, Xcode on macOS);
   * GIT version control system;
@@ -28,11 +27,11 @@ installed, and the rest should already be there.  On Windows, installing chocola
 install git cmake openjdk maven`` should get you a long way.  On macOS, ``brew install maven cmake``
 and downloading and installing the JDK is easiest.
 
-The Java-based components are the preprocessor and a configurator tool.  The run-time
+The only Java-based component is the IDL preprocessor.  The run-time
 libraries are pure C code, so there is no need to have Java available on "target"
 machines.  If desired, it is possible to do a build without Java or Maven installed by
 defining ``BUILD_IDLC=NO``, but that effectively only gets you the core library.  For the
-current [ROS2 RMW layer](https://github.com/ros2/rmw_cyclonedds), that is sufficient.
+current [ROS 2 RMW layer](https://github.com/ros2/rmw_cyclonedds), that is sufficient.
 
 To obtain Eclipse Cyclone DDS, do
 
@@ -250,3 +249,5 @@ Background information on configuring Cyclone DDS can be found
 * "Eclipse Cyclone DDS" and "Cyclone DDS" are trademarks of the Eclipse Foundation.
 
 * "DDS" is a trademark of the Object Management Group, Inc.
+
+* "ROS" is a trademark of Open Source Robotics Foundation, Inc.

--- a/cmake/Modules/FindSphinx.cmake
+++ b/cmake/Modules/FindSphinx.cmake
@@ -319,7 +319,7 @@ function(sphinx_add_docs _target)
   endif()
 
   add_custom_target(
-    ${_target}
+    ${_target} ALL
     COMMAND ${SPHINX_BUILD_EXECUTABLE}
               -b ${_builder}
               -d "${CMAKE_CURRENT_BINARY_DIR}/${_target}.cache/_doctrees"

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -46,11 +46,11 @@ if(BUILD_DOCS)
     docs
     BREATHE_PROJECTS ddsc_api_docs
     BUILDER html
-    SOURCE_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+    SOURCE_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/manual")
   add_dependencies(docs options_doc)
 
   install(
-    DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+    DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/docs"
     DESTINATION "${CMAKE_INSTALL_DOCDIR}/manual"
     COMPONENT dev)
 endif()

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>cyclonedds</name>
-    <version>0.5.1</version>
+    <version>0.6.0</version>
     <description>Eclipse Cyclone DDS is a very performant and robust open-source DDS implementation. Cyclone DDS is developed completely in the open as an Eclipse IoT project.</description>
     <maintainer email="cyclonedds-dev@eclipse.org">Eclipse Foundation, Inc.</maintainer>
     <license>Eclipse Public License 2.0</license>


### PR DESCRIPTION
It's only really minor stuff.

After this has been merged, I'll put a 0.6.0rc1 tag on it and create a releases/0.6.x branch for ROS2 to reference in the upcoming Foxy release.