### PR TITLE
Add security tests and fix some bugs in security implementation

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/ddsi_security_omg.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_security_omg.h
@@ -109,8 +109,8 @@ struct reader_sec_attributes {
   bool plugin_attr;
 };
 
-struct dds_security_authentication *q_omg_participant_get_authentication(const struct participant *pp);
-
+DDS_EXPORT struct dds_security_access_control *q_omg_participant_get_access_control(const struct participant *pp);
+DDS_EXPORT struct dds_security_authentication *q_omg_participant_get_authentication(const struct participant *pp);
 DDS_EXPORT struct dds_security_cryptography *q_omg_participant_get_cryptography(const struct participant *pp);
 
 void q_omg_vlog_exception(const struct ddsrt_log_cfg *lc, uint32_t cat, DDS_Security_SecurityException *exception, const char *file, uint32_t line, const char *func, const char *fmt, va_list ap);

--- a/src/core/ddsi/src/ddsi_security_omg.c
+++ b/src/core/ddsi/src/ddsi_security_omg.c
@@ -1396,12 +1396,18 @@ static bool is_topic_discovery_protected(DDS_Security_PermissionsHandle permissi
 {
   DDS_Security_TopicSecurityAttributes attributes = {0,0,0,0};
   DDS_Security_SecurityException exception = DDS_SECURITY_EXCEPTION_INIT;
+  bool result = false;
 
   if (access_control->get_topic_sec_attributes(access_control, permission_handle, topic_name, &attributes, &exception))
-    return attributes.is_discovery_protected;
+  {
+    result = attributes.is_discovery_protected;
+    access_control->return_topic_sec_attributes(access_control, &attributes, &exception);
+  }
   else
+  {
     DDS_Security_Exception_reset(&exception);
-  return false;
+  }
+  return result;
 }
 
 static void handle_not_allowed(

--- a/src/core/ddsi/src/ddsi_security_omg.c
+++ b/src/core/ddsi/src/ddsi_security_omg.c
@@ -837,7 +837,7 @@ static bool delete_pp_by_handle (DDS_Security_Handle handle, expired_pp_check_fn
   {
     if (q_omg_participant_is_secure (pp) && expired_pp_check_fn (pp, handle))
     {
-      delete_participant (gv, &pp->e.guid);
+      (void) delete_participant (gv, &pp->e.guid);
       result = true;
     }
   }

--- a/src/core/ddsi/src/ddsi_security_omg.c
+++ b/src/core/ddsi/src/ddsi_security_omg.c
@@ -284,10 +284,24 @@ static struct dds_security_context * q_omg_security_get_secure_context(const str
   return NULL;
 }
 
+struct dds_security_access_control *q_omg_participant_get_access_control(const struct participant *pp)
+{
+  if (pp && pp->e.gv->security_context && q_omg_is_security_loaded(pp->e.gv->security_context))
+    return pp->e.gv->security_context->access_control_context;
+  return NULL;
+}
+
 struct dds_security_authentication *q_omg_participant_get_authentication(const struct participant *pp)
 {
   if (pp && pp->e.gv->security_context && q_omg_is_security_loaded(pp->e.gv->security_context))
     return pp->e.gv->security_context->authentication_context;
+  return NULL;
+}
+
+struct dds_security_cryptography *q_omg_participant_get_cryptography(const struct participant *pp)
+{
+  if (pp && pp->e.gv->security_context && q_omg_is_security_loaded(pp->e.gv->security_context))
+    return pp->e.gv->security_context->crypto_context;
   return NULL;
 }
 
@@ -703,13 +717,6 @@ get_first_matched_proxypp_crypto_handle(struct participant_sec_attributes *attr)
   ddsrt_mutex_unlock(&attr->lock);
 
   return handle;
-}
-
-struct dds_security_cryptography *q_omg_participant_get_cryptography(const struct participant *pp)
-{
-  if (pp && pp->e.gv->security_context && q_omg_is_security_loaded(pp->e.gv->security_context))
-    return pp->e.gv->security_context->crypto_context;
-  return NULL;
 }
 
 bool q_omg_is_security_loaded (dds_security_context *sc)

--- a/src/core/ddsi/src/ddsi_security_omg.c
+++ b/src/core/ddsi/src/ddsi_security_omg.c
@@ -1464,7 +1464,7 @@ bool q_omg_security_check_create_writer(struct participant *pp, uint32_t domain_
 
   result = sc->access_control_context->check_create_datawriter(sc->access_control_context, pp->sec_attr->permissions_handle, (DDS_Security_DomainId)domain_id, topic_name, &security_qos, &partitions, NULL, &exception);
   if (!result)
-    handle_not_allowed(pp->e.gv, pp->sec_attr->permissions_handle, sc->access_control_context, &exception, topic_name, "Local topic permission denied");
+    handle_not_allowed(pp->e.gv, pp->sec_attr->permissions_handle, sc->access_control_context, &exception, topic_name, "Writer is not permitted");
 
   q_omg_shallow_free_security_qos(&security_qos);
   g_omg_shallow_free_StringSeq(&partitions.name);
@@ -3335,7 +3335,7 @@ static bool decode_payload (const struct ddsi_domaingv *gv, struct nn_rsample_in
   if (!q_omg_security_decode_serialized_payload (sampleinfo->pwr, payloadp, *payloadsz, &dst_buf, &dst_len))
   {
     GVTRACE ("decode_payload: failed to decrypt data from "PGUIDFMT"\n", PGUID (sampleinfo->pwr->e.guid));
-    return true;
+    return false;
   }
 
   /* Expect result to always fit into the original buffer. */

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -1308,14 +1308,19 @@ dds_return_t delete_participant (struct ddsi_domaingv *gv, const struct ddsi_gui
 {
   struct participant *pp;
   GVLOGDISC ("delete_participant("PGUIDFMT")\n", PGUID (*ppguid));
+  ddsrt_mutex_lock (&gv->lock);
   if ((pp = entidx_lookup_participant_guid (gv->entity_index, ppguid)) == NULL)
+  {
+    ddsrt_mutex_unlock (&gv->lock);
     return DDS_RETCODE_BAD_PARAMETER;
+  }
   builtintopic_write (gv->builtin_topic_interface, &pp->e, ddsrt_time_wallclock(), false);
   remember_deleted_participant_guid (gv->deleted_participants, &pp->e.guid);
 #ifdef DDSI_INCLUDE_SECURITY
   disconnect_participant_secure (pp);
 #endif
   entidx_remove_participant_guid (gv->entity_index, pp);
+  ddsrt_mutex_unlock (&gv->lock);
   gcreq_participant (pp);
   return 0;
 }

--- a/src/security/core/tests/CMakeLists.txt
+++ b/src/security/core/tests/CMakeLists.txt
@@ -79,6 +79,7 @@ if(ENABLE_SSL)
     "authentication.c"
     "access_control.c"
     "config.c"
+    "crypto.c"
     "handshake.c"
     "plugin_loading.c"
     "secure_communication.c"

--- a/src/security/core/tests/access_control.c
+++ b/src/security/core/tests/access_control.c
@@ -837,50 +837,6 @@ CU_Test(ddssec_access_control, readwrite_protection, .timeout=60)
               }
 }
 
-/* Test that all attributes and token retrieved from the access control plugin
-   are correctly returned. */
-CU_Test(ddssec_access_control, check_returns)
-{
-  char topic_name[100];
-  create_topic_name ("ddssec_access_control_", g_topic_nr++, topic_name, sizeof (topic_name));
-
-  char *ca, *id1, *id2, *id1_subj, *id2_subj;
-  ca = generate_ca ("ca1", TEST_IDENTITY_CA1_PRIVATE_KEY, 0, 3600);
-  id1 = generate_identity (ca, TEST_IDENTITY_CA1_PRIVATE_KEY, "id1", TEST_IDENTITY1_PRIVATE_KEY, 0, 3600, &id1_subj);
-  id2 = generate_identity (ca, TEST_IDENTITY_CA1_PRIVATE_KEY, "id2", TEST_IDENTITY1_PRIVATE_KEY, 0, 3600, &id2_subj);
-
-  char * grants[] = {
-    get_permissions_default_grant ("id1", id1_subj, topic_name),
-    get_permissions_default_grant ("id2", id2_subj, topic_name) };
-  char * perm_config = get_permissions_config (grants, 2, true);
-
-  char * gov_topic_rule = get_governance_topic_rule (NULL, true, true, true, true, PK_E, BPK_E);
-  char * gov_config = get_governance_config (false, true, PK_E, PK_E, PK_E, gov_topic_rule, true);
-  const char * def_perm_ca = PF_F COMMON_ETC_PATH("default_permissions_ca.pem");
-
-  access_control_init (
-      2,
-      (const char *[]) { id1, id2 },
-      (const char *[]) { TEST_IDENTITY1_PRIVATE_KEY, TEST_IDENTITY1_PRIVATE_KEY },
-      (const char *[]) { ca, ca },
-      (bool []) { false, false },
-      (const char *[]) { "init_test_access_control_check_returns", "init_test_access_control_wrapped" },
-      (const char *[]) { "finalize_test_access_control_check_returns", "finalize_test_access_control_wrapped" },
-      (bool []) { true, true }, (const char *[]) { gov_config, gov_config },
-      (bool []) { true, true }, (const char *[]) { perm_config, perm_config },
-      (bool []) { true, true }, (const char *[]) { def_perm_ca, def_perm_ca });
-
-  dds_entity_t pub, sub, pub_tp, sub_tp, wr, rd;
-  rd_wr_init (g_participant[0], &pub, &pub_tp, &wr, g_participant[1], &sub, &sub_tp, &rd, topic_name);
-  sync_writer_to_readers (g_participant[0], wr, 1, DDS_SECS (1));
-  sync_reader_to_writers (g_participant[1], rd, 1, DDS_SECS (1));
-
-  struct dds_security_access_control_impl * ac_context = get_access_control_context (g_participant[0]);
-  CU_ASSERT_FATAL (check_returns (ac_context));
-
-  access_control_fini (2, (void * []) { gov_config, gov_topic_rule, grants[0], grants[1], perm_config, ca, id1_subj, id2_subj, id1, id2 }, 10);
-}
-
 /* Check that communication for a topic that is allowed in the permissions config
    keeps working in case the publisher also creates a writer for a non-allowed topic */
 CU_Test(ddssec_access_control, denied_topic)

--- a/src/security/core/tests/access_control.c
+++ b/src/security/core/tests/access_control.c
@@ -297,12 +297,7 @@ CU_Test(ddssec_access_control, permissions_expiry_multiple, .timeout=20)
       id, pk, ca_list, exp_fail, NULL, NULL,
       incl_el, gov, incl_el, perm_conf, incl_el, perm_ca);
 
-  dds_qos_t * qos = dds_create_qos ();
-  CU_ASSERT_FATAL (qos != NULL);
-  dds_qset_history (qos, DDS_HISTORY_KEEP_ALL, -1);
-  dds_qset_durability (qos, DDS_DURABILITY_TRANSIENT_LOCAL);
-  dds_qset_reliability (qos, DDS_RELIABILITY_RELIABLE, DDS_INFINITY);
-
+  dds_qos_t * qos = get_default_test_qos ();
   dds_entity_t rd[N_RD];
   for (int i = 0; i < N_RD; i++)
   {
@@ -312,7 +307,7 @@ CU_Test(ddssec_access_control, permissions_expiry_multiple, .timeout=20)
     CU_ASSERT_FATAL (sub_tp > 0);
     rd[i] = dds_create_reader (sub, sub_tp, qos, NULL);
     CU_ASSERT_FATAL (rd[i] > 0);
-    dds_set_status_mask (rd[i], DDS_DATA_AVAILABLE_STATUS);
+    dds_set_status_mask (rd[i], DDS_SUBSCRIPTION_MATCHED_STATUS);
   }
 
   dds_entity_t wr[N_WR];
@@ -328,6 +323,11 @@ CU_Test(ddssec_access_control, permissions_expiry_multiple, .timeout=20)
     sync_writer_to_readers (g_participant[i + N_RD], wr[i], N_RD, DDS_SECS(2));
   }
   dds_delete_qos (qos);
+  for (int i = 0; i < N_RD; i++)
+  {
+    sync_reader_to_writers (g_participant[i], rd[i], N_WR, DDS_SECS (2));
+    dds_set_status_mask (rd[i], DDS_DATA_AVAILABLE_STATUS);
+  }
 
   SecurityCoreTests_Type1 sample = { 1, 1 };
   SecurityCoreTests_Type1 rd_sample;

--- a/src/security/core/tests/authentication.c
+++ b/src/security/core/tests/authentication.c
@@ -183,7 +183,9 @@ CU_TheoryDataPoints(ddssec_authentication, id_ca_certs) = {
 };
 #undef FM_CA
 #undef FM_INVK
-
+/* Test the security handshake result in test-cases using identity CA's that match and do not
+   match (i.e. a different CA that was not used for creating the identity) the identities used
+   in the participants security configuration. */
 CU_Theory((const char * test_descr, const char * id2, const char *key2, const char *ca2,
     bool exp_fail_pp1, bool exp_fail_pp2,
     bool exp_fail_local, const char * fail_local_msg,
@@ -218,6 +220,8 @@ CU_TheoryDataPoints(ddssec_authentication, trusted_ca_dir) = {
     CU_DataPoints(const char *, "",    ".",   "/nonexisting", NULL),
     CU_DataPoints(bool,         false, false, true,           false)
 };
+/* Test correct and incorrect values for the trusted CA directory in the
+   authentication plugin configuration */
 CU_Theory((const char * ca_dir, bool exp_fail), ddssec_authentication, trusted_ca_dir)
 {
   print_test_msg ("Testing custom CA dir: %s\n", ca_dir);
@@ -259,6 +263,9 @@ CU_TheoryDataPoints(ddssec_authentication, expired_cert) = {
     CU_DataPoints(uint32_t,  1,     0,     0,     0,     1,     0,     1,     10000 ),  /* write/read data during x ms */
     CU_DataPoints(bool,      false, false, false, false, false, false, false, true  ),  /* expect read data failure */
 };
+/* Test the security handshake result and check communication for scenarios using
+   valid identities, identities that are expired and identities that are not yet valid.
+   A test case using an identity that expires during the test is also included. */
 CU_Theory(
   (const char * test_descr, int32_t ca_not_before, int32_t ca_not_after,
     int32_t id1_not_before, int32_t id1_not_after, bool id1_local_fail,
@@ -300,7 +307,10 @@ CU_Theory(
 #undef H
 #undef M
 
-
+/* Test communication for a non-secure participant with a secure participant that
+   allows unauthenticated nodes in its governance configuration. Samples for a secured
+   topic should not be received by a reader in the non-secure participant; samples for
+   a non-secure topic should. */
 CU_Test(ddssec_authentication, unauthenticated_pp)
 {
   char topic_name_secure[100];

--- a/src/security/core/tests/authentication.c
+++ b/src/security/core/tests/authentication.c
@@ -101,15 +101,8 @@ static void authentication_init(
   if (perm_config == NULL)
     perm_config = DEF_PERM_CONF;
 
-  struct kvp governance_vars[] = {
-    { "DISCOVERY_PROTECTION_KIND", "NONE", 1 },
-    { "LIVELINESS_PROTECTION_KIND", "NONE", 1 },
-    { "RTPS_PROTECTION_KIND", "NONE", 1 },
-    { "METADATA_PROTECTION_KIND", "NONE", 1 },
-    { "DATA_PROTECTION_KIND", "NONE", 1 },
-    { NULL, NULL, 0 }
-  };
-  char * gov_config_signed = get_governance_config (governance_vars, true);
+  char * gov_topic_rule = get_governance_topic_rule ("*", false, false, true, true, "NONE", "NONE");
+  char * gov_config_signed = get_governance_config (false, false, NULL, NULL, NULL, gov_topic_rule, true);
 
   struct kvp config_vars1[] = {
     { "TEST_IDENTITY_CERTIFICATE", id1_cert, 1 },
@@ -143,6 +136,7 @@ static void authentication_init(
   CU_ASSERT_EQUAL_FATAL (exp_pp2_fail, g_participant2 <= 0);
 
   ddsrt_free (gov_config_signed);
+  ddsrt_free (gov_topic_rule);
   ddsrt_free (conf1);
   ddsrt_free (conf2);
 }

--- a/src/security/core/tests/authentication.c
+++ b/src/security/core/tests/authentication.c
@@ -34,7 +34,6 @@
 #include "common/security_config_test_utils.h"
 #include "common/test_identity.h"
 #include "common/cert_utils.h"
-#include "common/security_config_test_utils.h"
 
 #define ID1 TEST_IDENTITY1_CERTIFICATE
 #define ID1K TEST_IDENTITY1_PRIVATE_KEY

--- a/src/security/core/tests/authentication.c
+++ b/src/security/core/tests/authentication.c
@@ -263,10 +263,9 @@ CU_Theory(
   id2 = generate_identity (ca, CA1K, "id2", ID1K, id2_not_before, id2_not_after, &id2_subj);
   dds_sleepfor (DDS_MSECS (delay));
 
-  dds_time_t now = dds_time ();
   char * grants[] = {
-    get_permissions_grant ("id1", id1_subj, NULL, now - DDS_SECS(D(1)), now + DDS_SECS(D(1)), NULL, NULL, NULL),
-    get_permissions_grant ("id2", id2_subj, NULL, now - DDS_SECS(D(1)), now + DDS_SECS(D(1)), NULL, NULL, NULL) };
+    get_permissions_default_grant ("id1", id1_subj, topic_name),
+    get_permissions_default_grant ("id2", id2_subj, topic_name) };
   char * perm_config = get_permissions_config (grants, 2, true);
   authentication_init (id1, ID1K, ca, id2, ID1K, ca, NULL, perm_config, id1_local_fail, id2_local_fail);
   validate_handshake (DDS_DOMAINID1, id1_local_fail, NULL, NULL, NULL, DDS_SECS(2));

--- a/src/security/core/tests/common/access_control_wrapper.c
+++ b/src/security/core/tests/common/access_control_wrapper.c
@@ -12,6 +12,7 @@
 #include <string.h>
 #include <stdio.h>
 #include "dds/dds.h"
+#include "dds/ddsrt/circlist.h"
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/sync.h"
 #include "dds/ddsrt/string.h"
@@ -27,7 +28,8 @@ enum ac_plugin_mode {
   PLUGIN_MODE_ALL_OK,
   PLUGIN_MODE_WRAPPED,
   PLUGIN_MODE_NOT_ALLOWED,
-  PLUGIN_MODE_MISSING_FUNC
+  PLUGIN_MODE_MISSING_FUNC,
+  PLUGIN_MODE_CHECK_RETURNS,
 };
 
 enum ac_plugin_not_allowed {
@@ -56,6 +58,12 @@ enum ac_plugin_not_allowed {
 #define NOT_ALLOWED_REMOTE_READER_RELAY_ONLY      (1u << NOT_ALLOWED_ID_REMOTE_READER_RELAY_ONLY)
 #define NOT_ALLOWED_REMOTE_PERM                   (1u << NOT_ALLOWED_ID_REMOTE_PERM)
 
+struct returns_log_data {
+  struct ddsrt_circlist_elem e;
+  void * obj;
+};
+
+
 /**
  * Implementation structure for storing encapsulated members of the instance
  * while giving only the interface definition to user
@@ -65,7 +73,74 @@ struct dds_security_access_control_impl {
   dds_security_access_control *instance;
   enum ac_plugin_mode mode;
   uint32_t not_allowed_mask;
+  ddsrt_mutex_t returns_log_lock;
+  struct ddsrt_circlist returns_log;
+  bool invalid_return;
 };
+
+
+static void init_returns_log(struct dds_security_access_control_impl *impl)
+{
+  ddsrt_mutex_init (&impl->returns_log_lock);
+  ddsrt_circlist_init (&impl->returns_log);
+}
+
+static void fini_returns_log(struct dds_security_access_control_impl *impl)
+{
+  ddsrt_mutex_lock (&impl->returns_log_lock);
+  while (!ddsrt_circlist_isempty (&impl->returns_log))
+  {
+    struct ddsrt_circlist_elem *list_elem = ddsrt_circlist_oldest (&impl->returns_log);
+    ddsrt_circlist_remove (&impl->returns_log, list_elem);
+    ddsrt_free (list_elem);
+  }
+  ddsrt_mutex_unlock (&impl->returns_log_lock);
+  ddsrt_mutex_destroy (&impl->returns_log_lock);
+}
+
+static void register_return_obj (struct dds_security_access_control_impl * impl, void * obj)
+{
+  assert(impl->mode == PLUGIN_MODE_CHECK_RETURNS);
+  ddsrt_mutex_lock (&impl->returns_log_lock);
+  struct returns_log_data * attr_data = ddsrt_malloc (sizeof (*attr_data));
+  attr_data->obj = obj;
+  ddsrt_circlist_append(&impl->returns_log, &attr_data->e);
+  printf("log obj %p\n", obj);
+  ddsrt_mutex_unlock (&impl->returns_log_lock);
+}
+
+static void unregister_return_obj (struct dds_security_access_control_impl * impl, void * obj)
+{
+  assert(impl->mode == PLUGIN_MODE_CHECK_RETURNS);
+  ddsrt_mutex_lock (&impl->returns_log_lock);
+  struct ddsrt_circlist_elem *elem0 = ddsrt_circlist_oldest (&impl->returns_log), *elem = elem0;
+  while (elem != NULL)
+  {
+    struct returns_log_data *data = DDSRT_FROM_CIRCLIST (struct returns_log_data, e, elem);
+    if (data->obj == obj)
+    {
+      ddsrt_circlist_remove (&impl->returns_log, elem);
+      ddsrt_mutex_unlock (&impl->returns_log_lock);
+      ddsrt_free (elem);
+      printf("return obj %p\n", obj);
+      return;
+    }
+    elem = elem->next;
+    if (elem == elem0)
+      break;
+  }
+  impl->invalid_return = true;
+  ddsrt_mutex_unlock (&impl->returns_log_lock);
+}
+
+bool check_returns (struct dds_security_access_control_impl * impl)
+{
+  assert(impl->mode == PLUGIN_MODE_CHECK_RETURNS);
+  ddsrt_mutex_lock (&impl->returns_log_lock);
+  bool result = impl->invalid_return || !ddsrt_circlist_isempty (&impl->returns_log);
+  ddsrt_mutex_unlock (&impl->returns_log_lock);
+  return result;
+}
 
 static DDS_Security_PermissionsHandle validate_local_permissions(
     dds_security_access_control *instance,
@@ -87,7 +162,13 @@ static DDS_Security_PermissionsHandle validate_local_permissions(
       }
       /* fall through */
     case PLUGIN_MODE_WRAPPED:
-      return impl->instance->validate_local_permissions(impl->instance, auth_plugin, identity, domain_id, participant_qos, ex);
+    case PLUGIN_MODE_CHECK_RETURNS:
+    {
+      DDS_Security_PermissionsHandle handle = impl->instance->validate_local_permissions(impl->instance, auth_plugin, identity, domain_id, participant_qos, ex);
+      if (impl->mode == PLUGIN_MODE_CHECK_RETURNS)
+          register_return_obj (impl, (void *) handle);
+      return handle;
+    }
 
     default:
       return 1;
@@ -115,8 +196,14 @@ static DDS_Security_PermissionsHandle validate_remote_permissions(
       }
       /* fall through */
     case PLUGIN_MODE_WRAPPED:
-      return impl->instance->validate_remote_permissions(impl->instance, auth_plugin, local_identity_handle, remote_identity_handle,
+    case PLUGIN_MODE_CHECK_RETURNS:
+    {
+      DDS_Security_PermissionsHandle handle = impl->instance->validate_remote_permissions(impl->instance, auth_plugin, local_identity_handle, remote_identity_handle,
         remote_permissions_token, remote_credential_token, ex);
+      if (impl->mode == PLUGIN_MODE_CHECK_RETURNS)
+          register_return_obj (impl, (void *) handle);
+      return handle;
+    }
 
     default:
       return 0;
@@ -142,6 +229,7 @@ static DDS_Security_boolean check_create_participant(
       }
       /* fall through */
     case PLUGIN_MODE_WRAPPED:
+    case PLUGIN_MODE_CHECK_RETURNS:
       return impl->instance->check_create_participant(impl->instance, permissions_handle, domain_id, participant_qos, ex);
 
     default:
@@ -174,6 +262,7 @@ static DDS_Security_boolean check_create_datawriter(
       }
       /* fall through */
     case PLUGIN_MODE_WRAPPED:
+    case PLUGIN_MODE_CHECK_RETURNS:
       return impl->instance->check_create_datawriter(impl->instance, permissions_handle, domain_id, topic_name, writer_qos, partition, data_tag, ex);
 
     default:
@@ -203,6 +292,7 @@ static DDS_Security_boolean check_create_datareader(
       }
       /* fall through */
     case PLUGIN_MODE_WRAPPED:
+    case PLUGIN_MODE_CHECK_RETURNS:
       return impl->instance->check_create_datareader(impl->instance, permissions_handle, domain_id, topic_name, reader_qos, partition, data_tag, ex);
 
     default:
@@ -230,6 +320,7 @@ static DDS_Security_boolean check_create_topic(
       }
       /* fall through */
     case PLUGIN_MODE_WRAPPED:
+    case PLUGIN_MODE_CHECK_RETURNS:
       return impl->instance->check_create_topic(impl->instance, permissions_handle, domain_id, topic_name, qos, ex);
 
     default:
@@ -249,6 +340,7 @@ static DDS_Security_boolean check_local_datawriter_register_instance(
   {
     case PLUGIN_MODE_WRAPPED:
     case PLUGIN_MODE_NOT_ALLOWED:
+    case PLUGIN_MODE_CHECK_RETURNS:
       return impl->instance->check_local_datawriter_register_instance(impl->instance, permissions_handle, writer, key, ex);
 
     default:
@@ -268,6 +360,7 @@ static DDS_Security_boolean check_local_datawriter_dispose_instance(
   {
     case PLUGIN_MODE_WRAPPED:
     case PLUGIN_MODE_NOT_ALLOWED:
+    case PLUGIN_MODE_CHECK_RETURNS:
       return impl->instance->check_local_datawriter_dispose_instance(impl->instance, permissions_handle, writer, key, ex);
 
     default:
@@ -294,6 +387,7 @@ static DDS_Security_boolean check_remote_participant(
       }
       /* fall through */
     case PLUGIN_MODE_WRAPPED:
+    case PLUGIN_MODE_CHECK_RETURNS:
       return impl->instance->check_remote_participant(impl->instance, permissions_handle, domain_id, participant_data, ex);
 
     default:
@@ -320,6 +414,7 @@ static DDS_Security_boolean check_remote_datawriter(
       }
       /* fall through */
     case PLUGIN_MODE_WRAPPED:
+    case PLUGIN_MODE_CHECK_RETURNS:
       return impl->instance->check_remote_datawriter(impl->instance, permissions_handle, domain_id, publication_data, ex);
 
     default:
@@ -350,6 +445,7 @@ static DDS_Security_boolean check_remote_datareader(
       }
       /* fall through */
     case PLUGIN_MODE_WRAPPED:
+    case PLUGIN_MODE_CHECK_RETURNS:
     {
       bool ret;
       if ((ret = impl->instance->check_remote_datareader(impl->instance, permissions_handle, domain_id, subscription_data, relay_only, ex)))
@@ -389,6 +485,7 @@ static DDS_Security_boolean check_remote_topic(
       }
       /* fall through */
     case PLUGIN_MODE_WRAPPED:
+    case PLUGIN_MODE_CHECK_RETURNS:
       return impl->instance->check_remote_topic(impl->instance, permissions_handle, domain_id, topic_data, ex);
 
     default:
@@ -409,6 +506,7 @@ static DDS_Security_boolean check_local_datawriter_match(
   {
     case PLUGIN_MODE_WRAPPED:
     case PLUGIN_MODE_NOT_ALLOWED:
+    case PLUGIN_MODE_CHECK_RETURNS:
       return impl->instance->check_local_datawriter_match(impl->instance, writer_permissions_handle, reader_permissions_handle, publication_data, subscription_data, ex);
 
     default:
@@ -429,6 +527,7 @@ static DDS_Security_boolean check_local_datareader_match(
   {
     case PLUGIN_MODE_WRAPPED:
     case PLUGIN_MODE_NOT_ALLOWED:
+    case PLUGIN_MODE_CHECK_RETURNS:
       return impl->instance->check_local_datareader_match(impl->instance, reader_permissions_handle, writer_permissions_handle, subscription_data, publication_data, ex);
 
     default:
@@ -450,6 +549,7 @@ static DDS_Security_boolean check_remote_datawriter_register_instance(
   {
     case PLUGIN_MODE_WRAPPED:
     case PLUGIN_MODE_NOT_ALLOWED:
+    case PLUGIN_MODE_CHECK_RETURNS:
       return impl->instance->check_remote_datawriter_register_instance(impl->instance, permissions_handle, reader, publication_handle, key, instance_handle, ex);
 
     default:
@@ -470,6 +570,7 @@ static DDS_Security_boolean check_remote_datawriter_dispose_instance(
   {
     case PLUGIN_MODE_WRAPPED:
     case PLUGIN_MODE_NOT_ALLOWED:
+    case PLUGIN_MODE_CHECK_RETURNS:
       return impl->instance->check_remote_datawriter_dispose_instance(impl->instance, permissions_handle, reader, publication_handle, key, ex);
 
     default:
@@ -486,6 +587,9 @@ static DDS_Security_boolean get_permissions_token(
   struct dds_security_access_control_impl *impl = (struct dds_security_access_control_impl *)instance;
   switch (impl->mode)
   {
+    case PLUGIN_MODE_CHECK_RETURNS:
+      register_return_obj (impl, (void*) permissions_token);
+      /* fall through */
     case PLUGIN_MODE_WRAPPED:
     case PLUGIN_MODE_NOT_ALLOWED:
       return impl->instance->get_permissions_token(impl->instance, permissions_token, handle, ex);
@@ -506,6 +610,9 @@ static DDS_Security_boolean get_permissions_credential_token(
   struct dds_security_access_control_impl *impl = (struct dds_security_access_control_impl *)instance;
   switch (impl->mode)
   {
+    case PLUGIN_MODE_CHECK_RETURNS:
+      register_return_obj (impl, (void*) permissions_credential_token);
+      /* fall through */
     case PLUGIN_MODE_WRAPPED:
     case PLUGIN_MODE_NOT_ALLOWED:
       return impl->instance->get_permissions_credential_token(impl->instance, permissions_credential_token, handle, ex);
@@ -525,6 +632,7 @@ static DDS_Security_boolean set_listener(
   {
     case PLUGIN_MODE_WRAPPED:
     case PLUGIN_MODE_NOT_ALLOWED:
+    case PLUGIN_MODE_CHECK_RETURNS:
       return impl->instance->set_listener (impl->instance, listener, ex);
 
     default:
@@ -540,6 +648,9 @@ static DDS_Security_boolean return_permissions_token(
   struct dds_security_access_control_impl *impl = (struct dds_security_access_control_impl *)instance;
   switch (impl->mode)
   {
+    case PLUGIN_MODE_CHECK_RETURNS:
+      unregister_return_obj (impl, (void*) token);
+      /* fall through */
     case PLUGIN_MODE_WRAPPED:
     case PLUGIN_MODE_NOT_ALLOWED:
       return impl->instance->return_permissions_token (impl->instance, token, ex);
@@ -558,6 +669,9 @@ static DDS_Security_boolean return_permissions_credential_token(
   struct dds_security_access_control_impl *impl = (struct dds_security_access_control_impl *)instance;
   switch (impl->mode)
   {
+    case PLUGIN_MODE_CHECK_RETURNS:
+      unregister_return_obj (impl, (void*) permissions_credential_token);
+      /* fall through */
     case PLUGIN_MODE_WRAPPED:
     case PLUGIN_MODE_NOT_ALLOWED:
       return impl->instance->return_permissions_credential_token(impl->instance, permissions_credential_token, ex);
@@ -576,6 +690,9 @@ static DDS_Security_boolean get_participant_sec_attributes(
   struct dds_security_access_control_impl *impl = (struct dds_security_access_control_impl *)instance;
   switch (impl->mode)
   {
+    case PLUGIN_MODE_CHECK_RETURNS:
+      register_return_obj (impl, (void*) attributes);
+      /* fall through */
     case PLUGIN_MODE_WRAPPED:
     case PLUGIN_MODE_NOT_ALLOWED:
       return impl->instance->get_participant_sec_attributes(impl->instance, permissions_handle, attributes, ex);
@@ -595,6 +712,9 @@ static DDS_Security_boolean get_topic_sec_attributes(
   struct dds_security_access_control_impl *impl = (struct dds_security_access_control_impl *)instance;
   switch (impl->mode)
   {
+    case PLUGIN_MODE_CHECK_RETURNS:
+      register_return_obj (impl, (void*) attributes);
+      /* fall through */
     case PLUGIN_MODE_WRAPPED:
     case PLUGIN_MODE_NOT_ALLOWED:
       return impl->instance->get_topic_sec_attributes(impl->instance, permissions_handle, topic_name, attributes, ex);
@@ -616,6 +736,9 @@ static DDS_Security_boolean get_datawriter_sec_attributes(
   struct dds_security_access_control_impl *impl = (struct dds_security_access_control_impl *)instance;
   switch (impl->mode)
   {
+    case PLUGIN_MODE_CHECK_RETURNS:
+      register_return_obj (impl, (void*) attributes);
+      /* fall through */
     case PLUGIN_MODE_WRAPPED:
     case PLUGIN_MODE_NOT_ALLOWED:
       return impl->instance->get_datawriter_sec_attributes(impl->instance, permissions_handle, topic_name, partition, data_tag, attributes, ex);
@@ -637,6 +760,9 @@ static DDS_Security_boolean get_datareader_sec_attributes(
   struct dds_security_access_control_impl *impl = (struct dds_security_access_control_impl *)instance;
   switch (impl->mode)
   {
+    case PLUGIN_MODE_CHECK_RETURNS:
+      register_return_obj (impl, (void*) attributes);
+      /* fall through */
     case PLUGIN_MODE_WRAPPED:
     case PLUGIN_MODE_NOT_ALLOWED:
       return impl->instance->get_datareader_sec_attributes(impl->instance, permissions_handle, topic_name, partition, data_tag, attributes, ex);
@@ -654,6 +780,9 @@ static DDS_Security_boolean return_participant_sec_attributes(
   struct dds_security_access_control_impl *impl = (struct dds_security_access_control_impl *)instance;
   switch (impl->mode)
   {
+    case PLUGIN_MODE_CHECK_RETURNS:
+      unregister_return_obj (impl, (void*) attributes);
+      /* fall through */
     case PLUGIN_MODE_WRAPPED:
     case PLUGIN_MODE_NOT_ALLOWED:
       return impl->instance->return_participant_sec_attributes(impl->instance, attributes, ex);
@@ -671,6 +800,9 @@ static DDS_Security_boolean return_topic_sec_attributes(
   struct dds_security_access_control_impl *impl = (struct dds_security_access_control_impl *)instance;
   switch (impl->mode)
   {
+    case PLUGIN_MODE_CHECK_RETURNS:
+      unregister_return_obj (impl, (void*) attributes);
+      /* fall through */
     case PLUGIN_MODE_WRAPPED:
     case PLUGIN_MODE_NOT_ALLOWED:
       return impl->instance->return_topic_sec_attributes(impl->instance, attributes, ex);
@@ -688,6 +820,9 @@ static DDS_Security_boolean return_datawriter_sec_attributes(
   struct dds_security_access_control_impl *impl = (struct dds_security_access_control_impl *)instance;
   switch (impl->mode)
   {
+    case PLUGIN_MODE_CHECK_RETURNS:
+      unregister_return_obj (impl, (void*) attributes);
+      /* fall through */
     case PLUGIN_MODE_WRAPPED:
     case PLUGIN_MODE_NOT_ALLOWED:
       return impl->instance->return_datawriter_sec_attributes(impl->instance, attributes, ex);
@@ -705,6 +840,9 @@ static DDS_Security_boolean return_datareader_sec_attributes(
   struct dds_security_access_control_impl *impl = (struct dds_security_access_control_impl *)instance;
   switch (impl->mode)
   {
+    case PLUGIN_MODE_CHECK_RETURNS:
+      unregister_return_obj (impl, (void*) attributes);
+      /* fall through */
     case PLUGIN_MODE_WRAPPED:
     case PLUGIN_MODE_NOT_ALLOWED:
       return impl->instance->return_datareader_sec_attributes(impl->instance, attributes, ex);
@@ -722,6 +860,9 @@ static DDS_Security_boolean return_permissions_handle(
   struct dds_security_access_control_impl *impl = (struct dds_security_access_control_impl *)instance;
   switch (impl->mode)
   {
+    case PLUGIN_MODE_CHECK_RETURNS:
+      unregister_return_obj (impl, (void*) permissions_handle);
+      /* fall through */
     case PLUGIN_MODE_WRAPPED:
     case PLUGIN_MODE_NOT_ALLOWED:
       return impl->instance->return_permissions_handle(impl->instance, permissions_handle, ex);
@@ -861,5 +1002,24 @@ int finalize_test_access_control_not_allowed(void *context)
 {
   struct dds_security_access_control_impl* impl = (struct dds_security_access_control_impl*) context;
   assert(impl->mode == PLUGIN_MODE_NOT_ALLOWED);
+  return finalize_test_access_control_common(impl, true);
+}
+
+int init_test_access_control_check_returns(const char *argument, void **context, struct ddsi_domaingv *gv)
+{
+  struct dds_security_access_control_impl *impl = init_test_access_control_common(argument, true, gv);
+  if (!impl)
+    return DDS_SECURITY_FAILED;
+  impl->mode = PLUGIN_MODE_CHECK_RETURNS;
+  init_returns_log (impl);
+  *context = impl;
+  return DDS_SECURITY_SUCCESS;
+}
+
+int finalize_test_access_control_check_returns(void *context)
+{
+  struct dds_security_access_control_impl* impl = (struct dds_security_access_control_impl*) context;
+  assert(impl->mode == PLUGIN_MODE_CHECK_RETURNS);
+  fini_returns_log (impl);
   return finalize_test_access_control_common(impl, true);
 }

--- a/src/security/core/tests/common/access_control_wrapper.h
+++ b/src/security/core/tests/common/access_control_wrapper.h
@@ -20,6 +20,10 @@
    mode. This prefix is used to exclude built-in topics from being disallowed. */
 #define AC_WRAPPER_TOPIC_PREFIX "ddssec_access_control_"
 
+struct dds_security_access_control_impl;
+
+SECURITY_EXPORT bool check_returns (struct dds_security_access_control_impl * impl);
+
 /* Init in all-ok mode: all functions return success without calling the actual plugin */
 SECURITY_EXPORT int init_test_access_control_all_ok(const char *argument, void **context, struct ddsi_domaingv *gv);
 SECURITY_EXPORT int finalize_test_access_control_all_ok(void *context);
@@ -48,5 +52,10 @@ INIT_NOT_ALLOWED_DECL(remote_reader_relay_only)
 INIT_NOT_ALLOWED_DECL(remote_permissions_not_allowed)
 
 SECURITY_EXPORT int finalize_test_access_control_not_allowed(void *context);
+
+/* Init in attribute get and return logging mode */
+SECURITY_EXPORT int init_test_access_control_check_returns(const char *argument, void **context, struct ddsi_domaingv *gv);
+SECURITY_EXPORT int finalize_test_access_control_check_returns(void *context);
+
 
 #endif /* SECURITY_CORE_TEST_ACCESS_CONTROL_WRAPPER_H_ */

--- a/src/security/core/tests/common/access_control_wrapper.h
+++ b/src/security/core/tests/common/access_control_wrapper.h
@@ -22,8 +22,6 @@
 
 struct dds_security_access_control_impl;
 
-SECURITY_EXPORT bool check_returns (struct dds_security_access_control_impl * impl);
-
 /* Init in all-ok mode: all functions return success without calling the actual plugin */
 SECURITY_EXPORT int init_test_access_control_all_ok(const char *argument, void **context, struct ddsi_domaingv *gv);
 SECURITY_EXPORT int finalize_test_access_control_all_ok(void *context);
@@ -52,10 +50,5 @@ INIT_NOT_ALLOWED_DECL(remote_reader_relay_only)
 INIT_NOT_ALLOWED_DECL(remote_permissions_not_allowed)
 
 SECURITY_EXPORT int finalize_test_access_control_not_allowed(void *context);
-
-/* Init in attribute get and return logging mode */
-SECURITY_EXPORT int init_test_access_control_check_returns(const char *argument, void **context, struct ddsi_domaingv *gv);
-SECURITY_EXPORT int finalize_test_access_control_check_returns(void *context);
-
 
 #endif /* SECURITY_CORE_TEST_ACCESS_CONTROL_WRAPPER_H_ */

--- a/src/security/core/tests/common/access_control_wrapper.h
+++ b/src/security/core/tests/common/access_control_wrapper.h
@@ -37,14 +37,15 @@ SECURITY_EXPORT int finalize_test_access_control_wrapped(void *context);
 
 INIT_NOT_ALLOWED_DECL(local_participant_not_allowed)
 INIT_NOT_ALLOWED_DECL(local_topic_not_allowed)
-INIT_NOT_ALLOWED_DECL(local_publishing_not_allowed)
-INIT_NOT_ALLOWED_DECL(local_subscribing_not_allowed)
-INIT_NOT_ALLOWED_DECL(remote_permissions_invalidate)
+INIT_NOT_ALLOWED_DECL(local_writer_not_allowed)
+INIT_NOT_ALLOWED_DECL(local_reader_not_allowed)
+INIT_NOT_ALLOWED_DECL(local_permissions_not_allowed)
 INIT_NOT_ALLOWED_DECL(remote_participant_not_allowed)
 INIT_NOT_ALLOWED_DECL(remote_topic_not_allowed)
 INIT_NOT_ALLOWED_DECL(remote_writer_not_allowed)
 INIT_NOT_ALLOWED_DECL(remote_reader_not_allowed)
 INIT_NOT_ALLOWED_DECL(remote_reader_relay_only)
+INIT_NOT_ALLOWED_DECL(remote_permissions_not_allowed)
 
 SECURITY_EXPORT int finalize_test_access_control_not_allowed(void *context);
 

--- a/src/security/core/tests/common/cryptography_wrapper.c
+++ b/src/security/core/tests/common/cryptography_wrapper.c
@@ -13,6 +13,7 @@
 #include <stdio.h>
 #include "CUnit/Test.h"
 #include "dds/dds.h"
+#include "dds/ddsrt/circlist.h"
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/sync.h"
 #include "dds/ddsrt/string.h"
@@ -22,13 +23,17 @@
 #include "dds/security/core/dds_security_utils.h"
 #include "cryptography_wrapper.h"
 
-int init_crypto(const char *argument, void **context, struct ddsi_domaingv *gv);
-int finalize_crypto(void *context);
+#define CRYPTO_TOKEN_CLASS_ID "DDS:Crypto:AES_GCM_GMAC"
+#define CRYPTO_TOKEN_PROPERTY_NAME "dds.cryp.keymat"
+
+int32_t init_crypto(const char *argument, void **context, struct ddsi_domaingv *gv);
+int32_t finalize_crypto(void *context);
 
 enum crypto_plugin_mode {
   PLUGIN_MODE_ALL_OK,
   PLUGIN_MODE_MISSING_FUNC,
-  PLUGIN_MODE_WRAPPED
+  PLUGIN_MODE_WRAPPED,
+  PLUGIN_MODE_TOKEN_LOG
 };
 
 struct dds_security_crypto_key_exchange_impl {
@@ -67,9 +72,13 @@ struct dds_security_cryptography_impl {
   const char * groupdata_secret;
   const char * ep_secret;
   const char * encrypted_secret;
+  ddsrt_mutex_t token_data_lock;
+  struct ddsrt_circlist token_data_list;
 };
 
 static DDS_Security_ParticipantCryptoHandle g_local_participant_handle = 0;
+static ddsrt_once_t lock_inited = DDSRT_ONCE_INIT;
+static ddsrt_mutex_t g_print_token_lock;
 
 void set_protection_kinds(
   struct dds_security_cryptography_impl * impl,
@@ -107,6 +116,144 @@ void set_entity_data_secret(struct dds_security_cryptography_impl * impl, const 
   impl->pp_secret = pp_secret;
   impl->groupdata_secret = groupdata_secret;
   impl->ep_secret = ep_secret;
+}
+
+static bool check_crypto_tokens(const DDS_Security_DataHolderSeq *tokens)
+{
+    bool result = true;
+
+    if (tokens->_length == 0 || tokens->_buffer == NULL)
+      return false;
+
+    for (uint32_t i = 0; result && (i < tokens->_length); i++)
+    {
+      result = (tokens->_buffer[i].class_id != NULL &&
+        strcmp(CRYPTO_TOKEN_CLASS_ID, tokens->_buffer[i].class_id) == 0 &&
+        tokens->_buffer[i].binary_properties._length == 1 &&
+        tokens->_buffer[i].binary_properties._buffer != NULL &&
+        tokens->_buffer[i].binary_properties._buffer[0].name != NULL &&
+        strcmp(CRYPTO_TOKEN_PROPERTY_NAME, tokens->_buffer[i].binary_properties._buffer[0].name) == 0 &&
+        tokens->_buffer[i].binary_properties._buffer[0].value._length > 0 &&
+        tokens->_buffer[i].binary_properties._buffer[0].value._buffer != NULL);
+    }
+    return result;
+}
+
+const char *get_crypto_token_type_str (enum crypto_tokens_type type)
+{
+  switch (type)
+  {
+  case LOCAL_PARTICIPANT_TOKENS: return "LOCAL_PARTICIPANT_TOKENS";
+  case LOCAL_WRITER_TOKENS: return "LOCAL_WRITER_TOKENS";
+  case LOCAL_READER_TOKENS: return "LOCAL_READER_TOKENS";
+  case REMOTE_PARTICIPANT_TOKENS: return "REMOTE_PARTICIPANT_TOKENS";
+  case REMOTE_WRITER_TOKENS: return "REMOTE_WRITER_TOKENS";
+  case REMOTE_READER_TOKENS: return "REMOTE_READER_TOKENS";
+  default: assert (0); return "";
+  }
+}
+
+static void print_tokens (enum crypto_tokens_type type, const DDS_Security_ParticipantCryptoHandle lch, const DDS_Security_ParticipantCryptoHandle rch,
+    const DDS_Security_ParticipantCryptoTokenSeq *tokens)
+{
+  ddsrt_mutex_lock (&g_print_token_lock);
+  printf ("Token type %s, local %"PRIx64" / remote %"PRIx64", count: %u\n", get_crypto_token_type_str (type), lch, rch, tokens->_length);
+  for (uint32_t i = 0; i < tokens->_length; i++)
+  {
+    printf ("- token: ");
+    for (uint32_t j = 0; j < tokens->_buffer[i].binary_properties._buffer[0].value._length && j < 32; j++)
+      printf ("%02x", tokens->_buffer[i].binary_properties._buffer[0].value._buffer[j]);
+    printf ("\n");
+  }
+  printf ("\n");
+  ddsrt_mutex_unlock (&g_print_token_lock);
+}
+
+static void add_tokens (struct ddsrt_circlist *list, enum crypto_tokens_type type,
+    const DDS_Security_ParticipantCryptoHandle lch, const DDS_Security_ParticipantCryptoHandle rch,
+    const DDS_Security_ParticipantCryptoTokenSeq *tokens)
+{
+  struct crypto_token_data *token_data = ddsrt_malloc (sizeof (*token_data));
+  token_data->type = type;
+  token_data->local_handle = lch;
+  token_data->remote_handle = rch;
+  token_data->n_tokens = tokens->_length;
+  assert (tokens->_length <= CRYPTO_TOKEN_MAXLEN);
+  for (uint32_t i = 0; i < tokens->_length; i++)
+  {
+    size_t len = tokens->_buffer[i].binary_properties._buffer[0].value._length;
+    assert (len <= CRYPTO_TOKEN_SIZE);
+    memcpy (token_data->data[i], tokens->_buffer[i].binary_properties._buffer[0].value._buffer, len);
+    token_data->data_len[i] = len;
+  }
+  ddsrt_circlist_append(list, &token_data->e);
+}
+
+static void store_tokens (struct dds_security_crypto_key_exchange_impl *impl, enum crypto_tokens_type type, const DDS_Security_ParticipantCryptoHandle lch,
+    const DDS_Security_ParticipantCryptoHandle rch, const DDS_Security_ParticipantCryptoTokenSeq *tokens)
+{
+  if (!check_crypto_tokens ((const DDS_Security_DataHolderSeq *) tokens))
+  {
+    printf ("%d ERROR\n", type);
+    return;
+  }
+
+  ddsrt_mutex_lock (&impl->parent->token_data_lock);
+  add_tokens (&impl->parent->token_data_list, type, lch, rch, tokens);
+  ddsrt_mutex_unlock (&impl->parent->token_data_lock);
+
+  print_tokens (type, lch, rch, tokens);
+}
+
+struct ddsrt_circlist * get_crypto_tokens (struct dds_security_cryptography_impl * impl)
+{
+  struct ddsrt_circlist *tokens = ddsrt_malloc (sizeof (*tokens));
+  ddsrt_circlist_init (tokens);
+
+  ddsrt_mutex_lock (&impl->token_data_lock);
+  struct ddsrt_circlist_elem *elem0 = ddsrt_circlist_oldest (&impl->token_data_list), *elem = elem0;
+  while (elem != NULL)
+  {
+    struct crypto_token_data *elem_data = DDSRT_FROM_CIRCLIST (struct crypto_token_data, e, elem);
+    struct crypto_token_data *token_data = ddsrt_malloc (sizeof (*token_data));
+    memcpy (token_data, elem_data, sizeof (*token_data));
+    ddsrt_circlist_append (tokens, &token_data->e);
+    elem = elem->next;
+    if (elem == elem0)
+      break;
+  }
+  ddsrt_mutex_unlock (&impl->token_data_lock);
+
+  return tokens;
+}
+
+struct crypto_token_data * find_crypto_token (struct dds_security_cryptography_impl * impl, enum crypto_tokens_type type, unsigned char * data, size_t data_len)
+{
+  assert (data_len <= CRYPTO_TOKEN_SIZE);
+  ddsrt_mutex_lock (&impl->token_data_lock);
+  struct ddsrt_circlist_elem *elem0 = ddsrt_circlist_oldest (&impl->token_data_list), *elem = elem0;
+  while (elem != NULL)
+  {
+    struct crypto_token_data *elem_data = DDSRT_FROM_CIRCLIST (struct crypto_token_data, e, elem);
+    if (elem_data->type == type)
+    {
+      for (uint32_t i = 0; i < elem_data->n_tokens; i++)
+      {
+        size_t len = elem_data->data_len[i];
+        assert (len <= CRYPTO_TOKEN_SIZE);
+        if (!memcmp (data, elem_data->data[i], data_len < len ? data_len : len))
+        {
+          ddsrt_mutex_unlock (&impl->token_data_lock);
+          return elem_data;
+        }
+      }
+    }
+    elem = elem->next;
+    if (elem == elem0)
+      break;
+  }
+  ddsrt_mutex_unlock (&impl->token_data_lock);
+  return NULL;
 }
 
 static unsigned char * find_buffer_match(const unsigned char *input, size_t input_len, const unsigned char *match, size_t match_len)
@@ -171,8 +318,14 @@ static DDS_Security_boolean create_local_participant_crypto_tokens(
   switch (impl->parent->mode)
   {
     case PLUGIN_MODE_WRAPPED:
-      return impl->instance->create_local_participant_crypto_tokens (impl->instance, local_participant_crypto_tokens,
+    case PLUGIN_MODE_TOKEN_LOG:
+    {
+      DDS_Security_boolean ret = impl->instance->create_local_participant_crypto_tokens (impl->instance, local_participant_crypto_tokens,
         local_participant_crypto, remote_participant_crypto, ex);
+      if (ret && impl->parent->mode == PLUGIN_MODE_TOKEN_LOG)
+        store_tokens (impl, LOCAL_PARTICIPANT_TOKENS, local_participant_crypto, remote_participant_crypto, local_participant_crypto_tokens);
+      return ret;
+    }
     default:
       return true;
   }
@@ -189,8 +342,14 @@ static DDS_Security_boolean set_remote_participant_crypto_tokens(
   switch (impl->parent->mode)
   {
     case PLUGIN_MODE_WRAPPED:
-      return impl->instance->set_remote_participant_crypto_tokens (impl->instance, check_handle (local_participant_crypto),
+    case PLUGIN_MODE_TOKEN_LOG:
+    {
+      DDS_Security_boolean ret = impl->instance->set_remote_participant_crypto_tokens (impl->instance, check_handle (local_participant_crypto),
         check_handle (remote_participant_crypto), remote_participant_tokens, ex);
+      if (ret && impl->parent->mode == PLUGIN_MODE_TOKEN_LOG)
+        store_tokens (impl, REMOTE_PARTICIPANT_TOKENS, local_participant_crypto, remote_participant_crypto, remote_participant_tokens);
+      return ret;
+    }
     default:
       return true;
   }
@@ -207,8 +366,14 @@ static DDS_Security_boolean create_local_datawriter_crypto_tokens(
   switch (impl->parent->mode)
   {
     case PLUGIN_MODE_WRAPPED:
-      return impl->instance->create_local_datawriter_crypto_tokens (impl->instance, local_datawriter_crypto_tokens,
+    case PLUGIN_MODE_TOKEN_LOG:
+    {
+      DDS_Security_boolean ret = impl->instance->create_local_datawriter_crypto_tokens (impl->instance, local_datawriter_crypto_tokens,
         check_handle (local_datawriter_crypto), check_handle (remote_datareader_crypto), ex);
+      if (ret && impl->parent->mode == PLUGIN_MODE_TOKEN_LOG)
+        store_tokens (impl, LOCAL_WRITER_TOKENS, local_datawriter_crypto, remote_datareader_crypto, local_datawriter_crypto_tokens);
+      return ret;
+    }
     default:
       return true;
   }
@@ -225,8 +390,14 @@ static DDS_Security_boolean set_remote_datawriter_crypto_tokens(
   switch (impl->parent->mode)
   {
     case PLUGIN_MODE_WRAPPED:
-      return impl->instance->set_remote_datawriter_crypto_tokens (impl->instance, check_handle (local_datareader_crypto),
+    case PLUGIN_MODE_TOKEN_LOG:
+    {
+      DDS_Security_boolean ret = impl->instance->set_remote_datawriter_crypto_tokens (impl->instance, check_handle (local_datareader_crypto),
         check_handle (remote_datawriter_crypto), remote_datawriter_tokens, ex);
+      if (ret && impl->parent->mode == PLUGIN_MODE_TOKEN_LOG)
+        store_tokens (impl, REMOTE_WRITER_TOKENS, local_datareader_crypto, remote_datawriter_crypto, remote_datawriter_tokens);
+      return ret;
+    }
     default:
       return true;
   }
@@ -243,8 +414,14 @@ static DDS_Security_boolean create_local_datareader_crypto_tokens(
   switch (impl->parent->mode)
   {
     case PLUGIN_MODE_WRAPPED:
-      return impl->instance->create_local_datareader_crypto_tokens (impl->instance, local_datareader_cryto_tokens,
+    case PLUGIN_MODE_TOKEN_LOG:
+    {
+      DDS_Security_boolean ret = impl->instance->create_local_datareader_crypto_tokens (impl->instance, local_datareader_cryto_tokens,
         check_handle (local_datareader_crypto), check_handle (remote_datawriter_crypto), ex);
+      if (ret && impl->parent->mode == PLUGIN_MODE_TOKEN_LOG)
+        store_tokens (impl, LOCAL_READER_TOKENS, local_datareader_crypto, remote_datawriter_crypto, local_datareader_cryto_tokens);
+      return ret;
+    }
     default:
       return true;
   }
@@ -261,8 +438,14 @@ static DDS_Security_boolean set_remote_datareader_crypto_tokens(
   switch (impl->parent->mode)
   {
     case PLUGIN_MODE_WRAPPED:
-      return impl->instance->set_remote_datareader_crypto_tokens (impl->instance, check_handle (local_datawriter_crypto),
+    case PLUGIN_MODE_TOKEN_LOG:
+    {
+      DDS_Security_boolean ret = impl->instance->set_remote_datareader_crypto_tokens (impl->instance, check_handle (local_datawriter_crypto),
         check_handle (remote_datareader_crypto), remote_datareader_tokens, ex);
+      if (ret && impl->parent->mode == PLUGIN_MODE_TOKEN_LOG)
+        store_tokens (impl, REMOTE_READER_TOKENS, local_datawriter_crypto, remote_datareader_crypto, remote_datareader_tokens);
+      return ret;
+    }
     default:
       return true;
   }
@@ -277,6 +460,7 @@ static DDS_Security_boolean return_crypto_tokens(
   switch (impl->parent->mode)
   {
     case PLUGIN_MODE_WRAPPED:
+    case PLUGIN_MODE_TOKEN_LOG:
       return impl->instance->return_crypto_tokens (impl->instance, crypto_tokens, ex);
     default:
       return true;
@@ -298,6 +482,7 @@ static DDS_Security_ParticipantCryptoHandle register_local_participant(
   switch (impl->parent->mode)
   {
     case PLUGIN_MODE_WRAPPED:
+    case PLUGIN_MODE_TOKEN_LOG:
       return check_handle (impl->instance->register_local_participant (impl->instance, check_handle (participant_identity),
         check_handle (participant_permissions), participant_properties, participant_security_attributes, ex));
     default:
@@ -317,6 +502,7 @@ static DDS_Security_ParticipantCryptoHandle register_matched_remote_participant(
   switch (impl->parent->mode)
   {
     case PLUGIN_MODE_WRAPPED:
+    case PLUGIN_MODE_TOKEN_LOG:
       return check_handle (impl->instance->register_matched_remote_participant (impl->instance, local_participant_crypto_handle,
         remote_participant_identity, remote_participant_permissions, shared_secret, ex));
     default:
@@ -335,6 +521,7 @@ static DDS_Security_DatawriterCryptoHandle register_local_datawriter(
   switch (impl->parent->mode)
   {
     case PLUGIN_MODE_WRAPPED:
+    case PLUGIN_MODE_TOKEN_LOG:
       return check_handle (impl->instance->register_local_datawriter (impl->instance, check_handle (participant_crypto),
         datawriter_properties, datawriter_security_attributes, ex));
     default:
@@ -354,6 +541,7 @@ static DDS_Security_DatareaderCryptoHandle register_matched_remote_datareader(
   switch (impl->parent->mode)
   {
     case PLUGIN_MODE_WRAPPED:
+    case PLUGIN_MODE_TOKEN_LOG:
       return check_handle (impl->instance->register_matched_remote_datareader (impl->instance, check_handle (local_datawriter_crypto_handle),
         check_handle (remote_participant_crypto), check_handle (shared_secret), relay_only, ex));
     default:
@@ -372,6 +560,7 @@ static DDS_Security_DatareaderCryptoHandle register_local_datareader(
   switch (impl->parent->mode)
   {
     case PLUGIN_MODE_WRAPPED:
+    case PLUGIN_MODE_TOKEN_LOG:
       return check_handle (impl->instance->register_local_datareader (impl->instance, check_handle (participant_crypto),
         datareader_properties, datareader_security_attributes, ex));
     default:
@@ -390,6 +579,7 @@ static DDS_Security_DatawriterCryptoHandle register_matched_remote_datawriter(
   switch (impl->parent->mode)
   {
     case PLUGIN_MODE_WRAPPED:
+    case PLUGIN_MODE_TOKEN_LOG:
       return check_handle (impl->instance->register_matched_remote_datawriter (impl->instance, check_handle (local_datareader_crypto_handle),
         check_handle (remote_participant_crypt), shared_secret, ex));
     default:
@@ -406,6 +596,7 @@ static DDS_Security_boolean unregister_participant(
   switch (impl->parent->mode)
   {
     case PLUGIN_MODE_WRAPPED:
+    case PLUGIN_MODE_TOKEN_LOG:
       return impl->instance->unregister_participant (impl->instance, check_handle (participant_crypto_handle), ex);
     default:
       return true;
@@ -421,6 +612,7 @@ static DDS_Security_boolean unregister_datawriter(
   switch (impl->parent->mode)
   {
     case PLUGIN_MODE_WRAPPED:
+    case PLUGIN_MODE_TOKEN_LOG:
       return impl->instance->unregister_datawriter (impl->instance, check_handle (datawriter_crypto_handle), ex);
     default:
       return true;
@@ -436,6 +628,7 @@ static DDS_Security_boolean unregister_datareader(
   switch (impl->parent->mode)
   {
     case PLUGIN_MODE_WRAPPED:
+    case PLUGIN_MODE_TOKEN_LOG:
       return impl->instance->unregister_datareader (impl->instance, check_handle (datareader_crypto_handle), ex);
     default:
       return true;
@@ -457,6 +650,7 @@ static DDS_Security_boolean encode_serialized_payload(
   switch (impl->parent->mode)
   {
     case PLUGIN_MODE_WRAPPED:
+    case PLUGIN_MODE_TOKEN_LOG:
     {
       if (!impl->instance->encode_serialized_payload (impl->instance, encoded_buffer,
           extra_inline_qos, plain_buffer, check_handle (sending_datawriter_crypto), ex))
@@ -511,6 +705,7 @@ static DDS_Security_boolean encode_datawriter_submessage(
   switch (impl->parent->mode)
   {
     case PLUGIN_MODE_WRAPPED:
+    case PLUGIN_MODE_TOKEN_LOG:
       if (!impl->instance->encode_datawriter_submessage (impl->instance, encoded_rtps_submessage,
         plain_rtps_submessage, check_handle (sending_datawriter_crypto), receiving_datareader_crypto_list, receiving_datareader_crypto_list_index, ex))
         return false;
@@ -558,6 +753,7 @@ static DDS_Security_boolean encode_datareader_submessage(
   switch (impl->parent->mode)
   {
     case PLUGIN_MODE_WRAPPED:
+    case PLUGIN_MODE_TOKEN_LOG:
       if (!impl->instance->encode_datareader_submessage (impl->instance, encoded_rtps_submessage,
         plain_rtps_submessage, check_handle (sending_datareader_crypto), receiving_datawriter_crypto_list, ex))
         return false;
@@ -580,6 +776,7 @@ static DDS_Security_boolean encode_rtps_message(
   switch (impl->parent->mode)
   {
     case PLUGIN_MODE_WRAPPED:
+    case PLUGIN_MODE_TOKEN_LOG:
       if (!impl->instance->encode_rtps_message (impl->instance, encoded_rtps_message,
           plain_rtps_message, check_handle (sending_participant_crypto), receiving_participant_crypto_list, receiving_participant_crypto_list_index, ex))
         return false;
@@ -611,6 +808,7 @@ static DDS_Security_boolean decode_rtps_message(
   switch (impl->parent->mode)
   {
     case PLUGIN_MODE_WRAPPED:
+    case PLUGIN_MODE_TOKEN_LOG:
       return impl->instance->decode_rtps_message (impl->instance, plain_buffer, encoded_buffer,
           check_handle (receiving_participant_crypto), check_handle (sending_participant_crypto), ex);
     default:
@@ -632,6 +830,7 @@ static DDS_Security_boolean preprocess_secure_submsg(
   switch (impl->parent->mode)
   {
     case PLUGIN_MODE_WRAPPED:
+    case PLUGIN_MODE_TOKEN_LOG:
       return impl->instance->preprocess_secure_submsg (impl->instance, datawriter_crypto, datareader_crypto,
         secure_submessage_category, encoded_rtps_submessage, check_handle (receiving_participant_crypto), check_handle (sending_participant_crypto), ex);
     default:
@@ -651,6 +850,7 @@ static DDS_Security_boolean decode_datawriter_submessage(
   switch (impl->parent->mode)
   {
     case PLUGIN_MODE_WRAPPED:
+    case PLUGIN_MODE_TOKEN_LOG:
       return impl->instance->decode_datawriter_submessage (impl->instance, plain_rtps_submessage,
           encoded_rtps_submessage, check_handle (receiving_datareader_crypto), check_handle (sending_datawriter_crypto), ex);
     default:
@@ -670,6 +870,7 @@ static DDS_Security_boolean decode_datareader_submessage(
   switch (impl->parent->mode)
   {
     case PLUGIN_MODE_WRAPPED:
+    case PLUGIN_MODE_TOKEN_LOG:
       return impl->instance->decode_datareader_submessage (impl->instance, plain_rtps_submessage,
           encoded_rtps_submessage, check_handle (receiving_datawriter_crypto), check_handle (sending_datareader_crypto), ex);
     default:
@@ -690,6 +891,7 @@ static DDS_Security_boolean decode_serialized_payload(
   switch (impl->parent->mode)
   {
     case PLUGIN_MODE_WRAPPED:
+    case PLUGIN_MODE_TOKEN_LOG:
       return impl->instance->decode_serialized_payload(impl->instance, plain_buffer, encoded_buffer,
           inline_qos, check_handle (receiving_datareader_crypto), check_handle (sending_datawriter_crypto), ex);
     default:
@@ -812,6 +1014,44 @@ int finalize_test_cryptography_wrapped(void *context)
 {
   struct dds_security_cryptography_impl* impl = (struct dds_security_cryptography_impl*) context;
   assert(impl->mode == PLUGIN_MODE_WRAPPED);
+  return finalize_test_cryptography_common(impl, true);
+}
+
+static void init_print_lock(void)
+{
+  ddsrt_mutex_init (&g_print_token_lock);
+}
+
+int32_t init_test_cryptography_store_tokens(const char *argument, void **context, struct ddsi_domaingv *gv)
+{
+  struct dds_security_cryptography_impl *impl = init_test_cryptography_common(argument, true, gv);
+  if (!impl)
+    return DDS_SECURITY_FAILED;
+  impl->mode = PLUGIN_MODE_TOKEN_LOG;
+  ddsrt_once (&lock_inited, &init_print_lock);
+  ddsrt_mutex_init (&impl->token_data_lock);
+  ddsrt_circlist_init (&impl->token_data_list);
+  *context = impl;
+  return DDS_SECURITY_SUCCESS;
+}
+
+int32_t finalize_test_cryptography_store_tokens(void *context)
+{
+  struct dds_security_cryptography_impl* impl = (struct dds_security_cryptography_impl*) context;
+  assert(impl->mode == PLUGIN_MODE_TOKEN_LOG);
+  ddsrt_mutex_lock (&impl->token_data_lock);
+  while (!ddsrt_circlist_isempty (&impl->token_data_list))
+  {
+    struct ddsrt_circlist_elem *list_elem = ddsrt_circlist_oldest (&impl->token_data_list);
+    struct crypto_token_data *token_data = DDSRT_FROM_CIRCLIST (struct crypto_token_data, e, list_elem);
+    ddsrt_circlist_remove (&impl->token_data_list, list_elem);
+    ddsrt_free (token_data);
+  }
+  ddsrt_mutex_unlock (&impl->token_data_lock);
+  ddsrt_mutex_destroy (&impl->token_data_lock);
+  /* don't detroy g_print_token_lock as this will result in multiple
+     calls to mutex_destroy for this lock in case of multiple domains */
+
   return finalize_test_cryptography_common(impl, true);
 }
 

--- a/src/security/core/tests/common/cryptography_wrapper.c
+++ b/src/security/core/tests/common/cryptography_wrapper.c
@@ -195,7 +195,7 @@ static void add_tokens (struct ddsrt_circlist *list, enum crypto_tokens_type typ
   token_data->local_handle = lch;
   token_data->remote_handle = rch;
   token_data->n_tokens = tokens->_length;
-  assert (tokens->_length <= CRYPTO_TOKEN_MAXLEN);
+  assert (tokens->_length <= CRYPTO_TOKEN_MAXCOUNT);
   for (uint32_t i = 0; i < tokens->_length; i++)
   {
     size_t len = tokens->_buffer[i].binary_properties._buffer[0].value._length;
@@ -235,16 +235,14 @@ struct ddsrt_circlist * get_crypto_tokens (struct dds_security_cryptography_impl
   }
 
   struct ddsrt_circlist_elem *elem0 = ddsrt_circlist_oldest (&impl->token_data_list), *elem = elem0;
-  while (elem != NULL)
+  do
   {
     struct crypto_token_data *elem_data = DDSRT_FROM_CIRCLIST (struct crypto_token_data, e, elem);
     struct crypto_token_data *token_data = ddsrt_malloc (sizeof (*token_data));
     memcpy (token_data, elem_data, sizeof (*token_data));
     ddsrt_circlist_append (tokens, &token_data->e);
     elem = elem->next;
-    if (elem == elem0)
-      break;
-  }
+  } while (elem != elem0);
   ddsrt_mutex_unlock (&impl->token_data_lock);
 
   return tokens;
@@ -260,7 +258,7 @@ struct crypto_token_data * find_crypto_token (struct dds_security_cryptography_i
     return NULL;
   }
   struct ddsrt_circlist_elem *elem0 = ddsrt_circlist_oldest (&impl->token_data_list), *elem = elem0;
-  while (elem != NULL)
+  do
   {
     struct crypto_token_data *elem_data = DDSRT_FROM_CIRCLIST (struct crypto_token_data, e, elem);
     if (elem_data->type == type)
@@ -277,9 +275,7 @@ struct crypto_token_data * find_crypto_token (struct dds_security_cryptography_i
       }
     }
     elem = elem->next;
-    if (elem == elem0)
-      break;
-  }
+  } while (elem != elem0);
   ddsrt_mutex_unlock (&impl->token_data_lock);
   return NULL;
 }
@@ -290,7 +286,7 @@ static void log_encode_decode (struct dds_security_cryptography_impl * impl, enu
   if (!ddsrt_circlist_isempty (&impl->encode_decode_log))
   {
     struct ddsrt_circlist_elem *elem0 = ddsrt_circlist_oldest (&impl->encode_decode_log), *elem = elem0;
-    while (elem != NULL)
+    do
     {
       struct crypto_encode_decode_data *data = DDSRT_FROM_CIRCLIST (struct crypto_encode_decode_data, e, elem);
       if (data->function == function && data->handle == handle)
@@ -300,9 +296,7 @@ static void log_encode_decode (struct dds_security_cryptography_impl * impl, enu
         return;
       }
       elem = elem->next;
-      if (elem == elem0)
-        break;
-    }
+    } while (elem != elem0);
   }
   /* add new entry */
   struct crypto_encode_decode_data *new_data = ddsrt_malloc (sizeof (*new_data));
@@ -319,7 +313,7 @@ struct crypto_encode_decode_data * get_encode_decode_log (struct dds_security_cr
   if (!ddsrt_circlist_isempty (&impl->encode_decode_log))
   {
     struct ddsrt_circlist_elem *elem0 = ddsrt_circlist_oldest (&impl->encode_decode_log), *elem = elem0;
-    while (elem != NULL)
+    do
     {
       struct crypto_encode_decode_data *data = DDSRT_FROM_CIRCLIST (struct crypto_encode_decode_data, e, elem);
       if (data->function == function && data->handle == handle)
@@ -330,9 +324,7 @@ struct crypto_encode_decode_data * get_encode_decode_log (struct dds_security_cr
         return result;
       }
       elem = elem->next;
-      if (elem == elem0)
-        break;
-    }
+    } while (elem != elem0);
   }
   ddsrt_mutex_unlock (&impl->encode_decode_log_lock);
   return NULL;

--- a/src/security/core/tests/common/cryptography_wrapper.h
+++ b/src/security/core/tests/common/cryptography_wrapper.h
@@ -62,15 +62,13 @@ SECURITY_EXPORT void set_protection_kinds(
   DDS_Security_ProtectionKind rtps_protection_kind,
   DDS_Security_ProtectionKind metadata_protection_kind,
   DDS_Security_BasicProtectionKind payload_protection_kind);
-
 SECURITY_EXPORT void set_encrypted_secret(struct dds_security_cryptography_impl * impl, const char * secret);
-
 SECURITY_EXPORT void set_disc_protection_kinds(
   struct dds_security_cryptography_impl * impl,
   DDS_Security_ProtectionKind disc_protection_kind,
   DDS_Security_ProtectionKind liveliness_protection_kind);
-
 SECURITY_EXPORT void set_entity_data_secret(struct dds_security_cryptography_impl * impl, const char * pp_secret, const char * groupdata_secret, const char * ep_secret);
+SECURITY_EXPORT void set_force_plain_data(struct dds_security_cryptography_impl * impl, DDS_Security_DatawriterCryptoHandle wr_handle, bool plain_rtps, bool plain_submsg, bool plain_payload);
 
 SECURITY_EXPORT const char *get_crypto_token_type_str (enum crypto_tokens_type type);
 SECURITY_EXPORT struct ddsrt_circlist * get_crypto_tokens (struct dds_security_cryptography_impl * impl);
@@ -92,5 +90,9 @@ SECURITY_EXPORT int finalize_test_cryptography_wrapped(void *context);
 /* Init in store-token mode (stores all exchanged security tokens) */
 SECURITY_EXPORT int32_t init_test_cryptography_store_tokens(const char *argument, void **context, struct ddsi_domaingv *gv);
 SECURITY_EXPORT int32_t finalize_test_cryptography_store_tokens(void *context);
+
+/* Init in plain-data mode (force plain data for payload, submsg and/or rtps) */
+SECURITY_EXPORT int init_test_cryptography_plain_data(const char *argument, void **context, struct ddsi_domaingv *gv);
+SECURITY_EXPORT int finalize_test_cryptography_plain_data(void *context);
 
 #endif /* SECURITY_CORE_TEST_CRYPTO_WRAPPER_H_ */

--- a/src/security/core/tests/common/cryptography_wrapper.h
+++ b/src/security/core/tests/common/cryptography_wrapper.h
@@ -18,7 +18,7 @@
 #include "dds/security/dds_security_api_defs.h"
 #include "dds/security/cryptography_wrapper_export.h"
 
-#define CRYPTO_TOKEN_MAXLEN 10
+#define CRYPTO_TOKEN_MAXCOUNT 10
 #define CRYPTO_TOKEN_SIZE 256
 
 struct dds_security_cryptography_impl;
@@ -39,8 +39,8 @@ struct crypto_token_data {
   DDS_Security_ParticipantCryptoHandle local_handle;
   DDS_Security_ParticipantCryptoHandle remote_handle;
   uint32_t n_tokens;
-  unsigned char data[CRYPTO_TOKEN_MAXLEN][CRYPTO_TOKEN_SIZE];
-  size_t data_len[CRYPTO_TOKEN_MAXLEN];
+  unsigned char data[CRYPTO_TOKEN_MAXCOUNT][CRYPTO_TOKEN_SIZE];
+  size_t data_len[CRYPTO_TOKEN_MAXCOUNT];
 };
 
 enum crypto_encode_decode_fn {

--- a/src/security/core/tests/common/cryptography_wrapper.h
+++ b/src/security/core/tests/common/cryptography_wrapper.h
@@ -43,6 +43,20 @@ struct crypto_token_data {
   size_t data_len[CRYPTO_TOKEN_MAXLEN];
 };
 
+enum crypto_encode_decode_fn {
+  ENCODE_DATAWRITER_SUBMESSAGE,
+  ENCODE_DATAREADER_SUBMESSAGE,
+  DECODE_DATAWRITER_SUBMESSAGE,
+  DECODE_DATAREADER_SUBMESSAGE
+};
+
+struct crypto_encode_decode_data {
+  struct ddsrt_circlist_elem e;
+  enum crypto_encode_decode_fn function;
+  DDS_Security_long_long handle;
+  uint32_t count;
+};
+
 SECURITY_EXPORT void set_protection_kinds(
   struct dds_security_cryptography_impl * impl,
   DDS_Security_ProtectionKind rtps_protection_kind,
@@ -61,6 +75,7 @@ SECURITY_EXPORT void set_entity_data_secret(struct dds_security_cryptography_imp
 SECURITY_EXPORT const char *get_crypto_token_type_str (enum crypto_tokens_type type);
 SECURITY_EXPORT struct ddsrt_circlist * get_crypto_tokens (struct dds_security_cryptography_impl * impl);
 SECURITY_EXPORT struct crypto_token_data * find_crypto_token (struct dds_security_cryptography_impl * impl, enum crypto_tokens_type type, unsigned char * data, size_t data_len);
+SECURITY_EXPORT struct crypto_encode_decode_data * get_encode_decode_log (struct dds_security_cryptography_impl * impl, enum crypto_encode_decode_fn function, DDS_Security_long_long handle);
 
 /* Init in all-ok mode: all functions return success without calling the actual plugin */
 SECURITY_EXPORT int init_test_cryptography_all_ok(const char *argument, void **context, struct ddsi_domaingv *gv);

--- a/src/security/core/tests/common/security_config_test_utils.c
+++ b/src/security/core/tests/common/security_config_test_utils.c
@@ -245,7 +245,7 @@ static void print_config_vars(struct kvp *vars)
 }
 
 char * get_governance_topic_rule(const char * topic_expr, bool discovery_protection, bool liveliness_protection,
-    bool read_ac, bool write_ac, const char * metadata_protection_kind, const char * data_protection_kind)
+    bool read_ac, bool write_ac, DDS_Security_ProtectionKind metadata_protection_kind, DDS_Security_BasicProtectionKind data_protection_kind)
 {
   struct kvp vars[] = {
     { "TOPIC_EXPRESSION", topic_expr != NULL ? topic_expr : "*", 1 },
@@ -253,23 +253,23 @@ char * get_governance_topic_rule(const char * topic_expr, bool discovery_protect
     { "ENABLE_LIVELINESS_PROTECTION", liveliness_protection ? "true" : "false", 1 },
     { "ENABLE_READ_AC", read_ac ? "true" : "false", 1 },
     { "ENABLE_WRITE_AC", write_ac ? "true" : "false", 1 },
-    { "METADATA_PROTECTION_KIND", metadata_protection_kind != NULL ? metadata_protection_kind : "NONE", 1 },
-    { "DATA_PROTECTION_KIND", data_protection_kind != NULL ? data_protection_kind : "NONE", 1 },
+    { "METADATA_PROTECTION_KIND", pk_to_str (metadata_protection_kind), 1 },
+    { "DATA_PROTECTION_KIND", bpk_to_str (data_protection_kind), 1 },
     { NULL, NULL, 0 }
   };
   return ddsrt_expand_vars (topic_rule, &expand_lookup_vars, vars);
 }
 
-char * get_governance_config (bool allow_unauth_pp, bool enable_join_ac, const char * discovery_protection_kind, const char * liveliness_protection_kind,
-    const char * rtps_protection_kind, const char * topic_rules, bool add_prefix)
+char * get_governance_config (bool allow_unauth_pp, bool enable_join_ac, DDS_Security_ProtectionKind discovery_protection_kind, DDS_Security_ProtectionKind liveliness_protection_kind,
+    DDS_Security_ProtectionKind rtps_protection_kind, const char * topic_rules, bool add_prefix)
 {
   struct kvp vars[] = {
     { "ALLOW_UNAUTH_PP", allow_unauth_pp ? "true" : "false", 1 },
     { "ENABLE_JOIN_AC", enable_join_ac ? "true" : "false", 1 },
-    { "DISCOVERY_PROTECTION_KIND", discovery_protection_kind != NULL ? discovery_protection_kind : "NONE", 1 },
-    { "LIVELINESS_PROTECTION_KIND", liveliness_protection_kind != NULL ? liveliness_protection_kind : "NONE", 1 },
-    { "RTPS_PROTECTION_KIND", rtps_protection_kind != NULL ? rtps_protection_kind : "NONE", 1 },
-    { "TOPIC_RULES", topic_rules != NULL ? topic_rules : get_governance_topic_rule (NULL, false, false, false, false, NULL, NULL), 1 },
+    { "DISCOVERY_PROTECTION_KIND", pk_to_str (discovery_protection_kind), 1 },
+    { "LIVELINESS_PROTECTION_KIND", pk_to_str (liveliness_protection_kind), 1 },
+    { "RTPS_PROTECTION_KIND", pk_to_str (rtps_protection_kind), 1 },
+    { "TOPIC_RULES", topic_rules != NULL ? topic_rules : get_governance_topic_rule (NULL, false, false, false, false, PK_N, BPK_N), 1 },
     { NULL, NULL, 0 }
   };
   char * config = ddsrt_expand_vars (governance_xml, &expand_lookup_vars, vars);

--- a/src/security/core/tests/common/security_config_test_utils.h
+++ b/src/security/core/tests/common/security_config_test_utils.h
@@ -25,14 +25,16 @@ const char * expand_lookup_vars (const char *name, void * data);
 const char * expand_lookup_vars_env (const char *name, void * data);
 int32_t expand_lookup_unmatched (const struct kvp * lookup_table);
 
-char * get_governance_topic_rule(const char * topic_expr, bool discovery_protection, bool liveliness_protection,
+char * get_governance_topic_rule (const char * topic_expr, bool discovery_protection, bool liveliness_protection,
     bool read_ac, bool write_ac, const char * metadata_protection_kind, const char * data_protection_kind);
-char * get_governance_config(bool allow_unauth_pp, bool enable_join_ac, const char * discovery_protection_kind, const char * liveliness_protection_kind,
+char * get_governance_config (bool allow_unauth_pp, bool enable_join_ac, const char * discovery_protection_kind, const char * liveliness_protection_kind,
     const char * rtps_protection_kind, const char * topic_rules, bool add_prefix);
 
-char * get_permissions_topic(const char * name);
-char * get_permissions_grant(const char * name, const char * subject, const char * domain_id,
-    dds_time_t not_before, dds_time_t not_after, const char * pub_topics, const char * sub_topics, const char * default_policy);
-char * get_permissions_config(char * grants[], size_t ngrants, bool add_prefix);
+char * get_permissions_rules (const char * domain_id, const char * allow_pub_topic, const char * allow_sub_topic,
+    const char * deny_pub_topic, const char * deny_sub_topic);
+char * get_permissions_grant (const char * grant_name, const char * subject_name, dds_time_t not_before, dds_time_t not_after,
+    const char * rules_xml, const char * default_policy);
+char * get_permissions_default_grant (const char * grant_name, const char * subject_name, const char * topic_name);
+char * get_permissions_config (char * grants[], size_t ngrants, bool add_prefix);
 
 #endif /* SECURITY_CORE_TEST_SECURITY_CONFIG_TEST_UTILS_H_ */

--- a/src/security/core/tests/common/security_config_test_utils.h
+++ b/src/security/core/tests/common/security_config_test_utils.h
@@ -25,7 +25,11 @@ const char * expand_lookup_vars (const char *name, void * data);
 const char * expand_lookup_vars_env (const char *name, void * data);
 int32_t expand_lookup_unmatched (const struct kvp * lookup_table);
 
-char * get_governance_config (struct kvp *config_vars, bool add_prefix);
+char * get_governance_topic_rule(const char * topic_expr, bool discovery_protection, bool liveliness_protection,
+    bool read_ac, bool write_ac, const char * metadata_protection_kind, const char * data_protection_kind);
+char * get_governance_config(bool allow_unauth_pp, bool enable_join_ac, const char * discovery_protection_kind, const char * liveliness_protection_kind,
+    const char * rtps_protection_kind, const char * topic_rules, bool add_prefix);
+
 char * get_permissions_topic(const char * name);
 char * get_permissions_grant(const char * name, const char * subject, const char * domain_id,
     dds_time_t not_before, dds_time_t not_after, const char * pub_topics, const char * sub_topics, const char * default_policy);

--- a/src/security/core/tests/common/security_config_test_utils.h
+++ b/src/security/core/tests/common/security_config_test_utils.h
@@ -26,9 +26,9 @@ const char * expand_lookup_vars_env (const char *name, void * data);
 int32_t expand_lookup_unmatched (const struct kvp * lookup_table);
 
 char * get_governance_topic_rule (const char * topic_expr, bool discovery_protection, bool liveliness_protection,
-    bool read_ac, bool write_ac, const char * metadata_protection_kind, const char * data_protection_kind);
-char * get_governance_config (bool allow_unauth_pp, bool enable_join_ac, const char * discovery_protection_kind, const char * liveliness_protection_kind,
-    const char * rtps_protection_kind, const char * topic_rules, bool add_prefix);
+    bool read_ac, bool write_ac, DDS_Security_ProtectionKind metadata_protection_kind, DDS_Security_BasicProtectionKind data_protection_kind);
+char * get_governance_config (bool allow_unauth_pp, bool enable_join_ac, DDS_Security_ProtectionKind discovery_protection_kind, DDS_Security_ProtectionKind liveliness_protection_kind,
+    DDS_Security_ProtectionKind rtps_protection_kind, const char * topic_rules, bool add_prefix);
 
 char * get_permissions_rules (const char * domain_id, const char * allow_pub_topic, const char * allow_sub_topic,
     const char * deny_pub_topic, const char * deny_sub_topic);

--- a/src/security/core/tests/common/test_utils.c
+++ b/src/security/core/tests/common/test_utils.c
@@ -38,6 +38,12 @@ int numRemote = 0;
 struct Handshake handshakeList[MAX_HANDSHAKES];
 int numHandshake = 0;
 
+const char * g_pk_none = "NONE";
+const char * g_pk_sign = "SIGN";
+const char * g_pk_encrypt = "ENCRYPT";
+const char * g_pk_sign_oa = "SIGN_WITH_ORIGIN_AUTHENTICATION";
+const char * g_pk_encrypt_oa = "ENCRYPT_WITH_ORIGIN_AUTHENTICATION";
+
 static char * get_validation_result_str (DDS_Security_ValidationResult_t result)
 {
   switch (result)
@@ -470,4 +476,30 @@ struct dds_security_cryptography_impl * get_crypto_context(dds_entity_t particip
   thread_state_asleep (lookup_thread_state ());
   dds_entity_unlock (pp_entity);
   return context;
+}
+
+const char * pk_to_str(DDS_Security_ProtectionKind pk)
+{
+  switch (pk)
+  {
+    case DDS_SECURITY_PROTECTION_KIND_NONE: return g_pk_none;
+    case DDS_SECURITY_PROTECTION_KIND_SIGN: return g_pk_sign;
+    case DDS_SECURITY_PROTECTION_KIND_ENCRYPT: return g_pk_encrypt;
+    case DDS_SECURITY_PROTECTION_KIND_SIGN_WITH_ORIGIN_AUTHENTICATION: return g_pk_sign_oa;
+    case DDS_SECURITY_PROTECTION_KIND_ENCRYPT_WITH_ORIGIN_AUTHENTICATION: return g_pk_encrypt_oa;
+  }
+  assert (false);
+  return NULL;
+}
+
+const char * bpk_to_str(DDS_Security_BasicProtectionKind bpk)
+{
+  switch (bpk)
+  {
+    case DDS_SECURITY_BASICPROTECTION_KIND_NONE: return g_pk_none;
+    case DDS_SECURITY_BASICPROTECTION_KIND_SIGN: return g_pk_sign;
+    case DDS_SECURITY_BASICPROTECTION_KIND_ENCRYPT: return g_pk_encrypt;
+  }
+  assert (false);
+  return NULL;
 }

--- a/src/security/core/tests/common/test_utils.c
+++ b/src/security/core/tests/common/test_utils.c
@@ -398,6 +398,16 @@ bool reader_wait_for_data (dds_entity_t pp, dds_entity_t rd, dds_duration_t dur)
   return ret > 0;
 }
 
+dds_qos_t * get_default_test_qos (void)
+{
+  dds_qos_t * qos = dds_create_qos ();
+  CU_ASSERT_FATAL (qos != NULL);
+  dds_qset_history (qos, DDS_HISTORY_KEEP_ALL, -1);
+  dds_qset_durability (qos, DDS_DURABILITY_TRANSIENT_LOCAL);
+  dds_qset_reliability (qos, DDS_RELIABILITY_RELIABLE, DDS_INFINITY);
+  return qos;
+}
+
 void rd_wr_init_fail(
     dds_entity_t pp_wr, dds_entity_t *pub, dds_entity_t *pub_tp, dds_entity_t *wr,
     dds_entity_t pp_rd, dds_entity_t *sub, dds_entity_t *sub_tp, dds_entity_t *rd,
@@ -405,12 +415,7 @@ void rd_wr_init_fail(
     bool exp_pubtp_fail, bool exp_wr_fail,
     bool exp_subtp_fail, bool exp_rd_fail)
 {
-  dds_qos_t * qos = dds_create_qos ();
-  CU_ASSERT_FATAL (qos != NULL);
-  dds_qset_history (qos, DDS_HISTORY_KEEP_ALL, -1);
-  dds_qset_durability (qos, DDS_DURABILITY_TRANSIENT_LOCAL);
-  dds_qset_reliability (qos, DDS_RELIABILITY_RELIABLE, DDS_INFINITY);
-
+  dds_qos_t * qos = get_default_test_qos ();
   *pub = dds_create_publisher (pp_wr, NULL, NULL);
   CU_ASSERT_FATAL (*pub > 0);
   *sub = dds_create_subscriber (pp_rd, NULL, NULL);

--- a/src/security/core/tests/common/test_utils.c
+++ b/src/security/core/tests/common/test_utils.c
@@ -538,3 +538,37 @@ const char * bpk_to_str(DDS_Security_BasicProtectionKind bpk)
   assert (false);
   return NULL;
 }
+
+DDS_Security_DatawriterCryptoHandle get_builtin_writer_crypto_handle(dds_entity_t participant, unsigned entityid)
+{
+  DDS_Security_DatawriterCryptoHandle crypto_handle;
+  struct dds_entity *pp_entity;
+  struct participant *pp;
+  struct writer *wr;
+  CU_ASSERT_EQUAL_FATAL(dds_entity_pin(participant, &pp_entity), 0);
+  thread_state_awake(lookup_thread_state(), &pp_entity->m_domain->gv);
+  pp = entidx_lookup_participant_guid(pp_entity->m_domain->gv.entity_index, &pp_entity->m_guid);
+  wr = get_builtin_writer(pp, entityid);
+  CU_ASSERT_FATAL(wr != NULL);
+  assert(wr != NULL); /* for Clang's static analyzer */
+  crypto_handle = wr->sec_attr->crypto_handle;
+  thread_state_asleep(lookup_thread_state());
+  dds_entity_unpin(pp_entity);
+  return crypto_handle;
+}
+
+DDS_Security_DatawriterCryptoHandle get_writer_crypto_handle(dds_entity_t writer)
+{
+  DDS_Security_DatawriterCryptoHandle crypto_handle;
+  struct dds_entity *wr_entity;
+  struct writer *wr;
+  CU_ASSERT_EQUAL_FATAL(dds_entity_pin(writer, &wr_entity), 0);
+  thread_state_awake(lookup_thread_state(), &wr_entity->m_domain->gv);
+  wr = entidx_lookup_writer_guid(wr_entity->m_domain->gv.entity_index, &wr_entity->m_guid);
+  CU_ASSERT_FATAL(wr != NULL);
+  assert(wr != NULL); /* for Clang's static analyzer */
+  crypto_handle = wr->sec_attr->crypto_handle;
+  thread_state_asleep(lookup_thread_state());
+  dds_entity_unpin(wr_entity);
+  return crypto_handle;
+}

--- a/src/security/core/tests/common/test_utils.h
+++ b/src/security/core/tests/common/test_utils.h
@@ -82,10 +82,16 @@ void rd_wr_init_fail (
     bool exp_pubtp_fail, bool exp_wr_fail,
     bool exp_subtp_fail, bool exp_rd_fail);
 void write_read_for (dds_entity_t wr, dds_entity_t pp_rd, dds_entity_t rd, dds_duration_t dur, bool exp_write_fail, bool exp_read_fail);
-struct dds_security_cryptography_impl * get_crypto_context (dds_entity_t participant);
 const char * pk_to_str (DDS_Security_ProtectionKind pk);
 const char * bpk_to_str (DDS_Security_BasicProtectionKind bpk);
 DDS_Security_DatawriterCryptoHandle get_builtin_writer_crypto_handle(dds_entity_t participant, unsigned entityid);
 DDS_Security_DatawriterCryptoHandle get_writer_crypto_handle(dds_entity_t writer);
+
+#define GET_SECURITY_PLUGIN_CONTEXT_DECL(name_) \
+  struct dds_security_##name_##_impl * get_##name_##_context(dds_entity_t participant);
+GET_SECURITY_PLUGIN_CONTEXT_DECL(access_control)
+GET_SECURITY_PLUGIN_CONTEXT_DECL(authentication)
+GET_SECURITY_PLUGIN_CONTEXT_DECL(cryptography)
+
 
 #endif /* SECURITY_CORE_TEST_UTILS_H_ */

--- a/src/security/core/tests/common/test_utils.h
+++ b/src/security/core/tests/common/test_utils.h
@@ -60,26 +60,27 @@ struct Handshake
 };
 
 void print_test_msg (const char *msg, ...);
-void validate_handshake(dds_domainid_t domain_id, bool exp_localid_fail, const char * exp_localid_msg, struct Handshake *hs_list[], int *nhs);
-void validate_handshake_nofail (dds_domainid_t domain_id);
-void handshake_list_fini(struct Handshake *hs_list, int nhs);
-char *create_topic_name(const char *prefix, uint32_t nr, char *name, size_t size);
-void sync_writer_to_readers(dds_entity_t pp_wr, dds_entity_t wr, uint32_t exp_count);
-void sync_reader_to_writers (dds_entity_t pp_rd, dds_entity_t rd, uint32_t exp_count);
-bool reader_wait_for_data(dds_entity_t pp, dds_entity_t rd, dds_duration_t dur);
-void rd_wr_init(
+void validate_handshake (dds_domainid_t domain_id, bool exp_localid_fail, const char * exp_localid_msg, struct Handshake *hs_list[], int *nhs, dds_duration_t timeout);
+void validate_handshake_nofail (dds_domainid_t domain_id, dds_duration_t timeout);
+void validate_handshake_result (struct Handshake *hs, bool exp_fail_hs_req, const char * fail_hs_req_msg, bool exp_fail_hs_reply, const char * fail_hs_reply_msg);
+void handshake_list_fini (struct Handshake *hs_list, int nhs);
+char *create_topic_name (const char *prefix, uint32_t nr, char *name, size_t size);
+void sync_writer_to_readers (dds_entity_t pp_wr, dds_entity_t wr, uint32_t exp_count, dds_duration_t timeout);
+void sync_reader_to_writers (dds_entity_t pp_rd, dds_entity_t rd, uint32_t exp_count, dds_duration_t timeout);
+bool reader_wait_for_data (dds_entity_t pp, dds_entity_t rd, dds_duration_t dur);
+void rd_wr_init (
     dds_entity_t pp_wr, dds_entity_t *pub, dds_entity_t *pub_tp, dds_entity_t *wr,
     dds_entity_t pp_rd, dds_entity_t *sub, dds_entity_t *sub_tp, dds_entity_t *rd,
     const char * topic_name);
-void rd_wr_init_fail(
+void rd_wr_init_fail (
     dds_entity_t pp_wr, dds_entity_t *pub, dds_entity_t *pub_tp, dds_entity_t *wr,
     dds_entity_t pp_rd, dds_entity_t *sub, dds_entity_t *sub_tp, dds_entity_t *rd,
     const char * topic_name,
     bool exp_pubtp_fail, bool exp_wr_fail,
     bool exp_subtp_fail, bool exp_rd_fail);
-void write_read_for(dds_entity_t wr, dds_entity_t pp_rd, dds_entity_t rd, dds_duration_t dur, bool exp_write_fail, bool exp_read_fail);
-struct dds_security_cryptography_impl * get_crypto_context(dds_entity_t participant);
-const char * pk_to_str(DDS_Security_ProtectionKind pk);
-const char * bpk_to_str(DDS_Security_BasicProtectionKind bpk);
+void write_read_for (dds_entity_t wr, dds_entity_t pp_rd, dds_entity_t rd, dds_duration_t dur, bool exp_write_fail, bool exp_read_fail);
+struct dds_security_cryptography_impl * get_crypto_context (dds_entity_t participant);
+const char * pk_to_str (DDS_Security_ProtectionKind pk);
+const char * bpk_to_str (DDS_Security_BasicProtectionKind bpk);
 
 #endif /* SECURITY_CORE_TEST_UTILS_H_ */

--- a/src/security/core/tests/common/test_utils.h
+++ b/src/security/core/tests/common/test_utils.h
@@ -17,6 +17,15 @@
 
 #include "dds/security/dds_security_api.h"
 
+#define PK_N DDS_SECURITY_PROTECTION_KIND_NONE
+#define PK_S DDS_SECURITY_PROTECTION_KIND_SIGN
+#define PK_SOA DDS_SECURITY_PROTECTION_KIND_SIGN_WITH_ORIGIN_AUTHENTICATION
+#define PK_E DDS_SECURITY_PROTECTION_KIND_ENCRYPT
+#define PK_EOA DDS_SECURITY_PROTECTION_KIND_ENCRYPT_WITH_ORIGIN_AUTHENTICATION
+#define BPK_N DDS_SECURITY_BASICPROTECTION_KIND_NONE
+#define BPK_S DDS_SECURITY_BASICPROTECTION_KIND_SIGN
+#define BPK_E DDS_SECURITY_BASICPROTECTION_KIND_ENCRYPT
+
 #define MAX_LOCAL_IDENTITIES 8
 #define MAX_REMOTE_IDENTITIES 8
 #define MAX_HANDSHAKES 32
@@ -70,5 +79,7 @@ void rd_wr_init_fail(
     bool exp_subtp_fail, bool exp_rd_fail);
 void write_read_for(dds_entity_t wr, dds_entity_t pp_rd, dds_entity_t rd, dds_duration_t dur, bool exp_write_fail, bool exp_read_fail);
 struct dds_security_cryptography_impl * get_crypto_context(dds_entity_t participant);
+const char * pk_to_str(DDS_Security_ProtectionKind pk);
+const char * bpk_to_str(DDS_Security_BasicProtectionKind bpk);
 
 #endif /* SECURITY_CORE_TEST_UTILS_H_ */

--- a/src/security/core/tests/common/test_utils.h
+++ b/src/security/core/tests/common/test_utils.h
@@ -71,6 +71,7 @@ char *create_topic_name (const char *prefix, uint32_t nr, char *name, size_t siz
 void sync_writer_to_readers (dds_entity_t pp_wr, dds_entity_t wr, uint32_t exp_count, dds_duration_t timeout);
 void sync_reader_to_writers (dds_entity_t pp_rd, dds_entity_t rd, uint32_t exp_count, dds_duration_t timeout);
 bool reader_wait_for_data (dds_entity_t pp, dds_entity_t rd, dds_duration_t dur);
+dds_qos_t * get_default_test_qos (void);
 void rd_wr_init (
     dds_entity_t pp_wr, dds_entity_t *pub, dds_entity_t *pub_tp, dds_entity_t *wr,
     dds_entity_t pp_rd, dds_entity_t *sub, dds_entity_t *sub_tp, dds_entity_t *rd,

--- a/src/security/core/tests/common/test_utils.h
+++ b/src/security/core/tests/common/test_utils.h
@@ -26,6 +26,9 @@
 #define BPK_S DDS_SECURITY_BASICPROTECTION_KIND_SIGN
 #define BPK_E DDS_SECURITY_BASICPROTECTION_KIND_ENCRYPT
 
+#define PF_F "file:"
+#define PF_D "data:,"
+
 #define MAX_LOCAL_IDENTITIES 8
 #define MAX_REMOTE_IDENTITIES 8
 #define MAX_HANDSHAKES 32
@@ -82,5 +85,7 @@ void write_read_for (dds_entity_t wr, dds_entity_t pp_rd, dds_entity_t rd, dds_d
 struct dds_security_cryptography_impl * get_crypto_context (dds_entity_t participant);
 const char * pk_to_str (DDS_Security_ProtectionKind pk);
 const char * bpk_to_str (DDS_Security_BasicProtectionKind bpk);
+DDS_Security_DatawriterCryptoHandle get_builtin_writer_crypto_handle(dds_entity_t participant, unsigned entityid);
+DDS_Security_DatawriterCryptoHandle get_writer_crypto_handle(dds_entity_t writer);
 
 #endif /* SECURITY_CORE_TEST_UTILS_H_ */

--- a/src/security/core/tests/common/test_utils.h
+++ b/src/security/core/tests/common/test_utils.h
@@ -69,5 +69,6 @@ void rd_wr_init_fail(
     bool exp_pubtp_fail, bool exp_wr_fail,
     bool exp_subtp_fail, bool exp_rd_fail);
 void write_read_for(dds_entity_t wr, dds_entity_t pp_rd, dds_entity_t rd, dds_duration_t dur, bool exp_write_fail, bool exp_read_fail);
+struct dds_security_cryptography_impl * get_crypto_context(dds_entity_t participant);
 
 #endif /* SECURITY_CORE_TEST_UTILS_H_ */

--- a/src/security/core/tests/crypto.c
+++ b/src/security/core/tests/crypto.c
@@ -1,0 +1,170 @@
+/*
+ * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include <stdlib.h>
+#include <assert.h>
+
+#include "dds/dds.h"
+#include "CUnit/Test.h"
+#include "CUnit/Theory.h"
+
+#include "dds/version.h"
+#include "dds/ddsrt/cdtors.h"
+#include "dds/ddsrt/environ.h"
+#include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/string.h"
+#include "dds/ddsi/q_config.h"
+#include "dds/ddsi/ddsi_domaingv.h"
+#include "dds/ddsi/q_misc.h"
+#include "dds/ddsi/ddsi_xqos.h"
+
+#include "dds/security/dds_security_api.h"
+
+#include "common/config_env.h"
+#include "common/cryptography_wrapper.h"
+#include "common/test_utils.h"
+#include "common/security_config_test_utils.h"
+#include "common/test_identity.h"
+#include "common/cert_utils.h"
+
+static const char *config =
+    "${CYCLONEDDS_URI}${CYCLONEDDS_URI:+,}"
+    "<Domain id=\"any\">"
+    "  <Discovery>"
+    "    <ExternalDomainId>0</ExternalDomainId>"
+    "    <Tag>\\${CYCLONEDDS_PID}</Tag>"
+    "  </Discovery>"
+    "  <DDSSecurity>"
+    "    <Authentication>"
+    "      <Library finalizeFunction=\"finalize_authentication\" initFunction=\"init_authentication\"/>"
+    "      <IdentityCertificate>data:,${TEST_IDENTITY_CERTIFICATE}</IdentityCertificate>"
+    "      <PrivateKey>data:,${TEST_IDENTITY_PRIVATE_KEY}</PrivateKey>"
+    "      <IdentityCA>data:,${TEST_IDENTITY_CA_CERTIFICATE}</IdentityCA>"
+    "    </Authentication>"
+    "    <AccessControl>"
+    "      <Library finalizeFunction=\"finalize_access_control\" initFunction=\"init_access_control\"/>"
+    "      <Governance><![CDATA[${GOVERNANCE_CONFIG}]]></Governance>"
+    "      <PermissionsCA>file:" COMMON_ETC_PATH("default_permissions_ca.pem") "</PermissionsCA>"
+    "      <Permissions><![CDATA[${PERMISSIONS_CONFIG}]]></Permissions>"
+    "    </AccessControl>"
+    "    <Cryptographic>"
+    "      <Library initFunction=\"${CRYPTO_INIT:-init_test_cryptography_wrapped}\" finalizeFunction=\"${CRYPTO_FINI:-finalize_test_cryptography_wrapped}\" path=\"" WRAPPERLIB_PATH("dds_security_cryptography_wrapper") "\"/>"
+    "    </Cryptographic>"
+    "  </DDSSecurity>"
+    "</Domain>";
+
+#define DDS_DOMAINID1 0
+#define DDS_DOMAINID2 1
+
+static dds_entity_t g_domain1;
+static dds_entity_t g_participant1;
+static dds_entity_t g_domain2;
+static dds_entity_t g_participant2;
+
+static uint32_t g_topic_nr = 0;
+
+static void init_domain_pp (dds_domainid_t domain_id, const char *id_cert, const char * id_key, const char * id_ca,
+    const char * gov_config, const char * perm_config, const char * crypto_init, const char * crypto_fini, dds_entity_t *domain, dds_entity_t *pp)
+{
+  struct kvp config_vars[] =
+  {
+    { "TEST_IDENTITY_CERTIFICATE", id_cert, 1 },
+    { "TEST_IDENTITY_PRIVATE_KEY", id_key, 1 },
+    { "TEST_IDENTITY_CA_CERTIFICATE", id_ca, 1 },
+    { "PERMISSIONS_CONFIG", perm_config, 1 },
+    { "GOVERNANCE_CONFIG", gov_config, 1 },
+    { "CRYPTO_INIT", crypto_init, 1 },
+    { "CRYPTO_FINI", crypto_fini, 1 },
+    { NULL, NULL, 0 }
+  };
+  char *conf = ddsrt_expand_vars_sh (config, &expand_lookup_vars_env, config_vars);
+  CU_ASSERT_EQUAL_FATAL (expand_lookup_unmatched (config_vars), 0);
+  *domain = dds_create_domain (domain_id, conf);
+  *pp = dds_create_participant (domain_id, NULL, NULL);
+  CU_ASSERT_FATAL (*pp > 0);
+  ddsrt_free (conf);
+}
+
+static void crypto_init (
+    const char * gov_config1, const char * perm_config1, const char * id_cert1, const char * id_key1, const char * crypto_init1, const char * crypto_fini1,
+    const char * gov_config2, const char * perm_config2, const char * id_cert2, const char * id_key2, const char * crypto_init2, const char * crypto_fini2,
+    const char * id_ca)
+{
+  init_domain_pp (DDS_DOMAINID1, id_cert1, id_key1, id_ca, gov_config1, perm_config1, crypto_init1, crypto_fini1, &g_domain1, &g_participant1);
+  init_domain_pp (DDS_DOMAINID2, id_cert2, id_key2, id_ca, gov_config2, perm_config2, crypto_init2, crypto_fini2, &g_domain2, &g_participant2);
+}
+
+static void crypto_fini (void * res[], size_t nres)
+{
+  CU_ASSERT_EQUAL_FATAL (dds_delete (g_domain1), DDS_RETCODE_OK);
+  CU_ASSERT_EQUAL_FATAL (dds_delete (g_domain2), DDS_RETCODE_OK);
+  if (res != NULL)
+  {
+    for (size_t i = 0; i < nres; i++)
+      ddsrt_free (res[i]);
+  }
+}
+
+CU_TheoryDataPoints(ddssec_crypto, inject_plain_data) = {
+    CU_DataPoints(const char *,
+    /*                                             */"payload encrypt",
+    /*                                              |     */"payload sign",
+    /*                                              |      |     */"submessage encrypt",
+    /*                                              |      |      |     */"submessage sign",
+    /*                                              |      |      |      |     */"rtps encrypt",
+    /*                                              |      |      |      |      |     */"rtps sign"),
+    CU_DataPoints(DDS_Security_BasicProtectionKind, BPK_E, BPK_S, BPK_N, BPK_N, BPK_N, BPK_N),  /* payload protection */
+    CU_DataPoints(DDS_Security_ProtectionKind,      PK_N,  PK_N,  PK_E,  PK_S,  PK_N,  PK_N),   /* submessage protection */
+    CU_DataPoints(DDS_Security_ProtectionKind,      PK_N,  PK_N,  PK_N,  PK_N,  PK_E,  PK_S),   /* rtps protection */
+};
+CU_Theory((const char * test_descr, DDS_Security_BasicProtectionKind payload_pk, DDS_Security_ProtectionKind submsg_pk, DDS_Security_ProtectionKind rtps_pk),
+  ddssec_crypto, inject_plain_data, .timeout=30)
+{
+  print_test_msg ("running test inject_plain_data: %s\n", test_descr);
+
+  char topic_name[100];
+  create_topic_name ("ddssec_crypto_", g_topic_nr++, topic_name, sizeof (topic_name));
+
+  char *ca, *id1, *id1_subj, *id2, *id2_subj;
+  ca = generate_ca ("ca1", TEST_IDENTITY_CA1_PRIVATE_KEY, 0, 3600);
+  id1 = generate_identity (ca, TEST_IDENTITY_CA1_PRIVATE_KEY, "id1", TEST_IDENTITY1_PRIVATE_KEY, 0, 3600, &id1_subj);
+  id2 = generate_identity (ca, TEST_IDENTITY_CA1_PRIVATE_KEY, "id2", TEST_IDENTITY1_PRIVATE_KEY, 0, 3600, &id2_subj);
+
+  char * grants[] = {
+      get_permissions_default_grant ("id1", id1_subj, topic_name),
+      get_permissions_default_grant ("id2", id2_subj, topic_name) };
+  char * perm_config = get_permissions_config (grants, 2, true);
+
+  char * gov_topic_rule = get_governance_topic_rule (topic_name, false, false, false, false, submsg_pk, payload_pk);
+  char * gov_config = get_governance_config (false, true, PK_N, PK_N, rtps_pk, gov_topic_rule, true);
+
+  crypto_init (
+    gov_config, perm_config, id1, TEST_IDENTITY1_PRIVATE_KEY, "init_test_cryptography_plain_data", "finalize_test_cryptography_plain_data",
+    gov_config, perm_config, id2, TEST_IDENTITY1_PRIVATE_KEY, "init_test_cryptography_wrapped", "finalize_test_cryptography_wrapped",
+    ca);
+
+  dds_entity_t pub, sub, pub_tp, sub_tp, wr, rd;
+  rd_wr_init (g_participant1, &pub, &pub_tp, &wr, g_participant2, &sub, &sub_tp, &rd, topic_name);
+
+  /* set forced plain data for payload/submsg/rtps */
+  DDS_Security_DatawriterCryptoHandle wr_handle = get_writer_crypto_handle (wr);
+  struct dds_security_cryptography_impl * crypto_impl = get_crypto_context (g_participant1);
+  set_force_plain_data (crypto_impl, wr_handle, rtps_pk != PK_N, submsg_pk != PK_N, payload_pk != BPK_N);
+
+  /* sync and write/take sample */
+  sync_writer_to_readers (g_participant1, wr, 1, DDS_SECS (2));
+  write_read_for (wr, g_participant2, rd, DDS_MSECS (10), false, true);
+
+  /* reset forced plain data */
+  set_force_plain_data (crypto_impl, wr_handle, false, false, false);
+
+  crypto_fini ((void * []) { gov_config, gov_topic_rule, grants[0], grants[1], perm_config, ca, id1_subj, id1, id2_subj, id2 }, 10);
+}

--- a/src/security/core/tests/crypto.c
+++ b/src/security/core/tests/crypto.c
@@ -156,7 +156,7 @@ CU_Theory((const char * test_descr, DDS_Security_BasicProtectionKind payload_pk,
 
   /* set forced plain data for payload/submsg/rtps */
   DDS_Security_DatawriterCryptoHandle wr_handle = get_writer_crypto_handle (wr);
-  struct dds_security_cryptography_impl * crypto_impl = get_crypto_context (g_participant1);
+  struct dds_security_cryptography_impl * crypto_impl = get_cryptography_context (g_participant1);
   set_force_plain_data (crypto_impl, wr_handle, rtps_pk != PK_N, submsg_pk != PK_N, payload_pk != BPK_N);
 
   /* sync and write/take sample */

--- a/src/security/core/tests/crypto.c
+++ b/src/security/core/tests/crypto.c
@@ -125,6 +125,10 @@ CU_TheoryDataPoints(ddssec_crypto, inject_plain_data) = {
     CU_DataPoints(DDS_Security_ProtectionKind,      PK_N,  PK_N,  PK_E,  PK_S,  PK_N,  PK_N),   /* submessage protection */
     CU_DataPoints(DDS_Security_ProtectionKind,      PK_N,  PK_N,  PK_N,  PK_N,  PK_E,  PK_S),   /* rtps protection */
 };
+/* This test validates that non-encrypted data will not be received by a reader that has protection
+   enabled for rtps/submsg/payload. The test uses a crypto plugin wrapper mode that force the plugin
+   to write plain data in the encoded output buffer to DDSI, ignoring the security attributes for the
+   reader and writer. */
 CU_Theory((const char * test_descr, DDS_Security_BasicProtectionKind payload_pk, DDS_Security_ProtectionKind submsg_pk, DDS_Security_ProtectionKind rtps_pk),
   ddssec_crypto, inject_plain_data, .timeout=30)
 {

--- a/src/security/core/tests/handshake.c
+++ b/src/security/core/tests/handshake.c
@@ -143,11 +143,11 @@ CU_Test(ddssec_handshake, check_tokens)
   write_read_for (g_wr, g_participant2, g_rd, DDS_MSECS (100), false, false);
 
   // Get subscriber and publisher crypto tokens
-  struct dds_security_cryptography_impl * crypto_context_pub = get_crypto_context (g_participant1);
+  struct dds_security_cryptography_impl * crypto_context_pub = get_cryptography_context (g_participant1);
   CU_ASSERT_FATAL (crypto_context_pub != NULL);
   struct ddsrt_circlist *pub_tokens = get_crypto_tokens (crypto_context_pub);
 
-  struct dds_security_cryptography_impl * crypto_context_sub = get_crypto_context (g_participant2);
+  struct dds_security_cryptography_impl * crypto_context_sub = get_cryptography_context (g_participant2);
   CU_ASSERT_FATAL (crypto_context_sub != NULL);
   struct ddsrt_circlist *sub_tokens = get_crypto_tokens (crypto_context_sub);
 

--- a/src/security/core/tests/handshake.c
+++ b/src/security/core/tests/handshake.c
@@ -107,11 +107,25 @@ static void handshake_fini(void)
 
 CU_Test(ddssec_handshake, happy_day)
 {
+  struct Handshake *hs_list;
+  int nhs;
+
   handshake_init (
     "init_test_authentication_wrapped", "finalize_test_authentication_wrapped",
     "init_test_cryptography_wrapped", "finalize_test_cryptography_wrapped");
-  validate_handshake_nofail (DDS_DOMAINID1);
-  validate_handshake_nofail (DDS_DOMAINID2);
+
+  validate_handshake (DDS_DOMAINID1, false, NULL, &hs_list, &nhs, DDS_SECS(2));
+  CU_ASSERT_EQUAL_FATAL (nhs, 1);
+  for (int n = 0; n < nhs; n++)
+    validate_handshake_result (&hs_list[n], false, NULL, false, NULL);
+  handshake_list_fini (hs_list, nhs);
+
+  validate_handshake (DDS_DOMAINID2, false, NULL, &hs_list, &nhs, DDS_SECS(2));
+  CU_ASSERT_EQUAL_FATAL (nhs, 1);
+  for (int n = 0; n < nhs; n++)
+    validate_handshake_result (&hs_list[n], false, NULL, false, NULL);
+  handshake_list_fini (hs_list, nhs);
+
   handshake_fini ();
 }
 
@@ -120,8 +134,8 @@ CU_Test(ddssec_handshake, check_tokens)
   handshake_init (
     "init_test_authentication_wrapped", "finalize_test_authentication_wrapped",
     "init_test_cryptography_store_tokens", "finalize_test_cryptography_store_tokens");
-  validate_handshake_nofail (DDS_DOMAINID1);
-  validate_handshake_nofail (DDS_DOMAINID2);
+  validate_handshake_nofail (DDS_DOMAINID1, DDS_SECS (2));
+  validate_handshake_nofail (DDS_DOMAINID2, DDS_SECS (2));
 
   char topic_name[100];
   create_topic_name("ddssec_authentication_", g_topic_nr++, topic_name, sizeof (topic_name));

--- a/src/security/core/tests/handshake.c
+++ b/src/security/core/tests/handshake.c
@@ -105,6 +105,8 @@ static void handshake_fini(void)
   CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
 }
 
+/* Happy-day test for the security handshake, that tests succesfull handshake for
+   two participants using the same typical security settings. */
 CU_Test(ddssec_handshake, happy_day)
 {
   struct Handshake *hs_list;
@@ -129,6 +131,9 @@ CU_Test(ddssec_handshake, happy_day)
   handshake_fini ();
 }
 
+/* This test checks that all tokens that are sent to a remote participant are received
+   correctly by that participant and the token-data stored in the remote participant
+   is equal to the data in the token that was sent. */
 CU_Test(ddssec_handshake, check_tokens)
 {
   handshake_init (

--- a/src/security/core/tests/secure_communication.c
+++ b/src/security/core/tests/secure_communication.c
@@ -154,8 +154,8 @@ static void test_init(const struct domain_sec_config * domain_config, size_t n_s
   assert (n_pub_domains < MAX_DOMAINS);
   assert (n_pub_participants < MAX_PARTICIPANTS);
 
-  char * gov_topic_rule = get_governance_topic_rule ("*", false, false, true, true, pk_to_str (domain_config->metadata_pk), bpk_to_str (domain_config->payload_pk));
-  char * gov_config_signed = get_governance_config (false, false, pk_to_str (domain_config->discovery_pk), pk_to_str (domain_config->liveliness_pk),
+  char * gov_topic_rule = get_governance_topic_rule ("*", true, true, true, true, pk_to_str (domain_config->metadata_pk), bpk_to_str (domain_config->payload_pk));
+  char * gov_config_signed = get_governance_config (false, true, pk_to_str (domain_config->discovery_pk), pk_to_str (domain_config->liveliness_pk),
     pk_to_str (domain_config->rtps_pk), gov_topic_rule, false);
 
   struct kvp config_vars[] = {

--- a/src/security/core/tests/secure_communication.c
+++ b/src/security/core/tests/secure_communication.c
@@ -119,7 +119,7 @@ static dds_entity_t create_pp (dds_domainid_t domain_id, const struct domain_sec
   dds_entity_t pp = dds_create_participant (domain_id, qos, NULL);
   CU_ASSERT_FATAL (pp > 0);
   dds_delete_qos (qos);
-  struct dds_security_cryptography_impl * crypto_context = get_crypto_context (pp);
+  struct dds_security_cryptography_impl * crypto_context = get_cryptography_context (pp);
   CU_ASSERT_FATAL (crypto_context != NULL);
   assert (set_crypto_params);
   set_crypto_params (crypto_context, domain_config);

--- a/src/security/core/tests/secure_communication.c
+++ b/src/security/core/tests/secure_communication.c
@@ -154,9 +154,8 @@ static void test_init(const struct domain_sec_config * domain_config, size_t n_s
   assert (n_pub_domains < MAX_DOMAINS);
   assert (n_pub_participants < MAX_PARTICIPANTS);
 
-  char * gov_topic_rule = get_governance_topic_rule ("*", true, true, true, true, pk_to_str (domain_config->metadata_pk), bpk_to_str (domain_config->payload_pk));
-  char * gov_config_signed = get_governance_config (false, true, pk_to_str (domain_config->discovery_pk), pk_to_str (domain_config->liveliness_pk),
-    pk_to_str (domain_config->rtps_pk), gov_topic_rule, false);
+  char * gov_topic_rule = get_governance_topic_rule ("*", true, true, true, true, domain_config->metadata_pk, domain_config->payload_pk);
+  char * gov_config_signed = get_governance_config (false, true, domain_config->discovery_pk, domain_config->liveliness_pk, domain_config->rtps_pk, gov_topic_rule, false);
 
   struct kvp config_vars[] = {
     { "GOVERNANCE_DATA", gov_config_signed, 1 },

--- a/src/security/core/tests/secure_communication.c
+++ b/src/security/core/tests/secure_communication.c
@@ -255,7 +255,7 @@ static void test_write_read(struct domain_sec_config *domain_config,
       for (size_t w = 0; w < n_writers; w++)
       {
         size_t wr_index = pp_index * n_writers + w;
-        sync_writer_to_readers (g_pub_participants[pp_index], writers[wr_index], (uint32_t)(n_sub_domains * n_sub_participants * n_readers));
+        sync_writer_to_readers (g_pub_participants[pp_index], writers[wr_index], (uint32_t)(n_sub_domains * n_sub_participants * n_readers), DDS_SECS(2));
         sample.id = (int32_t) wr_index;
         printf("writer %"PRId32" writing sample %d\n", writers[wr_index], sample.id);
         ret = dds_write (writers[wr_index], &sample);
@@ -366,7 +366,7 @@ static void test_payload_secret(DDS_Security_ProtectionKind rtps_pk, DDS_Securit
   create_eps (&writers, &writer_topics, 1, 1, 1, name, &SecurityCoreTests_Type2_desc, g_pub_participants, qos, &dds_create_writer, DDS_PUBLICATION_MATCHED_STATUS);
   create_eps (&readers, &reader_topics, 1, 1, 1, name, &SecurityCoreTests_Type2_desc, g_sub_participants, qos, &dds_create_reader, DDS_DATA_AVAILABLE_STATUS);
   dds_delete_qos (qos);
-  sync_writer_to_readers (g_pub_participants[0], writers[0], 1);
+  sync_writer_to_readers (g_pub_participants[0], writers[0], 1, DDS_SECS(2));
   ret = dds_write (writers[0], &sample);
   CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
 

--- a/src/security/core/tests/secure_communication.c
+++ b/src/security/core/tests/secure_communication.c
@@ -387,6 +387,8 @@ static void test_payload_secret(DDS_Security_ProtectionKind rtps_pk, DDS_Securit
   ddsrt_free (sample.text);
 }
 
+/* Test communication between 2 nodes for all combinations of RTPS, metadata (submsg)
+   and payload protection kinds using a single reader and writer */
 CU_Test(ddssec_secure_communication, protection_kinds, .timeout = 120)
 {
   DDS_Security_ProtectionKind rtps_pk[] = { PK_N, PK_S, PK_E };
@@ -404,6 +406,8 @@ CU_Test(ddssec_secure_communication, protection_kinds, .timeout = 120)
   }
 }
 
+/* Test communication between 2 nodes for all combinations of discovery and
+   liveliness protection kinds using a single reader and writer */
 CU_Test(ddssec_secure_communication, discovery_liveliness_protection, .timeout = 60)
 {
   DDS_Security_ProtectionKind discovery_pk[] = { PK_N, PK_S, PK_E };
@@ -417,6 +421,8 @@ CU_Test(ddssec_secure_communication, discovery_liveliness_protection, .timeout =
   }
 }
 
+/* Test that a specific character sequence from the plain data does not appear in
+   encrypted payload, submessage or rtps message when protection kind is ENCRYPT*/
 CU_Test(ddssec_secure_communication, check_encrypted_secret, .timeout = 60)
 {
   DDS_Security_ProtectionKind rtps_pk[] = { PK_N, PK_E, PK_EOA };
@@ -434,6 +440,8 @@ CU_Test(ddssec_secure_communication, check_encrypted_secret, .timeout = 60)
   }
 }
 
+/* Test communication with specific combinations payload and submsg protection
+   kinds for 1-3 domains, 1-3 participants per domain and 1-3 readers per participant */
 CU_TheoryDataPoints(ddssec_secure_communication, multiple_readers) = {
     CU_DataPoints(size_t, 1, 1, 1, 3), /* number of domains */
     CU_DataPoints(size_t, 1, 3, 1, 3), /* number of participants per domain */
@@ -452,6 +460,9 @@ CU_Theory((size_t n_dom, size_t n_pp, size_t n_rd), ddssec_secure_communication,
   }
 }
 
+/* Test communication with specific combinations payload and submsg protection
+   kinds for 1-2 domains, 1-3 participants per domain, 1-3 readers per participant
+   and 1-3 writers per participant */
 CU_TheoryDataPoints(ddssec_secure_communication, multiple_readers_writers) = {
     CU_DataPoints(size_t, 1, 1, 2), /* number of reader domains */
     CU_DataPoints(size_t, 1, 3, 3), /* number of readers per domain */


### PR DESCRIPTION
This PR adds a set of security tests and fixes a few bugs that were found when introducing these tests. 

The bugfixes in this PR:
- bb501ea The `decode_payload` function should return false in case encoded data is expected according to the security attributes and decoding fails
- 546a007 In `new_proxy_participant`, communication with a proxy participant should be set-up when there is any non-secured local participant. In case the remote participant allows unauthenticated participants in its security settings and advertises a non-secured topic, a reader of the local non-secure participant can read this data. This is fixed by adding the condition `!q_omg_participant_is_secure (pp)`. 
- b8a28dd Fix reader-writer synchronization in access control expiry_multiple test

New tests added (the test descriptions are also included as code comments):
- 93657cd / ad8dc89 Test discovery and liveliness protection by checking that `encode_datawriter_submessage` is called for `SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER` and `P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER` depending on the discovery and liveliness protection settings in security configuration. 
- 269aaa8 Testing handshake result for any combination of protection kind values for rtps, discovery, liveliness, metadata (submsg) and payload protection settings. In all cases that have an encoding mismatch, the security handshake is expect to fail. 
- dc2071f Test read/write access control by running test cases with different combinations of allow and deny rules for publishing and subscribing a topic, and check correct working of the default policy.
- 4708b76 Test that all attributes and tokens retrieved from the access control plugin are correctly returned.
- 12f2e9a Check that communication for a topic that is allowed in the permissions config keeps working in case the publisher also creates a writer for a non-allowed topic
- d67436c Test communication for a non-secure participant with a secure participant that allows unauthenticated nodes in its governance configuration. Samples for a secured topic should not be received by a reader in the non-secure participant; samples for a non-secure topic should.
- 9080154 Validate that non-encrypted data will not be received by a reader that has protection enabled for rtps/submsg/payload. The test uses a crypto plugin wrapper mode that force the plugin to write plain data in the encoded output buffer to DDSI, ignoring the security attributes for the reader and writer.
- ba25f98 Check that all tokens that are sent to a remote participant are received correctly by that participant and the token-data stored in the remote participant is equal to the data in the token that was sent. 
