### PR TITLE
Fix use-after-free via (proxy)pp min lease pointer

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/q_entity.h
+++ b/src/core/ddsi/include/dds/ddsi/q_entity.h
@@ -231,7 +231,7 @@ struct participant
   int32_t builtin_refc; /* number of built-in endpoints in this participant [refc_lock] */
   int builtins_deleted; /* whether deletion of built-in endpoints has been initiated [refc_lock] */
   ddsrt_fibheap_t ldur_auto_wr; /* Heap that contains lease duration for writers with automatic liveliness in this participant */
-  ddsrt_atomic_voidp_t minl_man; /* lease object for shortest manual-by-participant liveliness writer's lease */
+  ddsrt_atomic_voidp_t minl_man; /* clone of min(leaseheap_man) */
   ddsrt_fibheap_t leaseheap_man; /* keeps leases for this participant's writers (with liveliness manual-by-participant) */
 #ifdef DDSI_INCLUDE_SECURITY
   struct participant_sec_attributes *sec_attr;
@@ -369,9 +369,9 @@ struct proxy_participant
   unsigned bes; /* built-in endpoint set */
   ddsi_guid_t privileged_pp_guid; /* if this PP depends on another PP for its SEDP writing */
   struct ddsi_plist *plist; /* settings/QoS for this participant */
-  ddsrt_atomic_voidp_t minl_auto; /* lease object for shortest automatic liveliness pwr's lease (includes this proxypp's lease) */
+  ddsrt_atomic_voidp_t minl_auto; /* clone of min(leaseheap_auto) */
   ddsrt_fibheap_t leaseheap_auto; /* keeps leases for this proxypp and leases for pwrs (with liveliness automatic) */
-  ddsrt_atomic_voidp_t minl_man; /* lease object for shortest manual-by-participant liveliness pwr's lease */
+  ddsrt_atomic_voidp_t minl_man; /* clone of min(leaseheap_man) */
   ddsrt_fibheap_t leaseheap_man; /* keeps leases for this proxypp and leases for pwrs (with liveliness manual-by-participant) */
   struct lease *lease; /* lease for this proxypp */
   struct addrset *as_default; /* default address set to use for user data traffic */


### PR DESCRIPTION
This changes the handling of the removal of the lease of a manual
liveliness (proxy) writer from the (proxy) participant, such that the
invariant maintained for the "min lease" objects in the (proxy)
participant changes from: a clone of some lease with the minimum
duration, to: a clone of the lease that is returned by the
ddsrt_fibheap_min operation on the lease heap.

This fixes a use-after-free of the entity pointed to by the cloned lease
object in a scenario where the shortest lease duration is used by
multiple writers and the removal of a lease from the heap shuffles the
remaining entries around.  For example (before this change):

1. initial situation: three writers w1, w2 and w3 with equal lease
   durations:
   - pp.heap = w1.lease : w2.lease w3.lease
   - pp.minl = clone of w1.lease

2. delete w2:
   - assuming deleting w2.lease from the heap moves w3.lease to the
     front (only guarantee is that there are no smaller keys in the heap
     than that of the entry returned by minimum operation)
   - min(pp.heap) = w1.lease != w2.lease
     thus: pp.minl unchanged, pp.minl.entity = w1
   - pp.heap = w3.lease : w1.lease

3. delete w1:
   - min(pp.heap) = w3.lease != w1.lease,
     thus: pp.minl unchanged, pp.minl.entity = w1
   - pp.heap = w3
   - free w1
   - now pp.minl.entity has a dangling pointer, touched on deleting
     the (proxy) particpant or on lease expiry.

With this chamge, pp.minl is updated in step 2 to be a clone of w3.lease
because the lease returned by min(pp.heap) changes.  This ensures that
in step 3 there is no dangling pointer and no use-after-free.

Signed-off-by: Erik Boasson <eb@ilities.com>