### PR TITLE
remove unused atomic pointer operations

### DIFF
--- a/src/ddsrt/include/dds/ddsrt/atomics/arm.h
+++ b/src/ddsrt/include/dds/ddsrt/atomics/arm.h
@@ -76,23 +76,11 @@ inline uint32_t ddsrt_atomic_add32_nv (volatile ddsrt_atomic_uint32_t *x, uint32
                 : "r1");
    return result;
 }
-inline uintptr_t ddsrt_atomic_addptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-    return ddsrt_atomic_add32_nv ((volatile ddsrt_atomic_uint32_t *) x, v);
-}
-inline void *ddsrt_atomic_addvoidp_nv (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
-    return (void *) ddsrt_atomic_addptr_nv ((volatile ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
-}
 inline void ddsrt_atomic_add32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
     (void) ddsrt_atomic_add32_nv (x, v);
 }
 inline uint32_t ddsrt_atomic_add32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
     return ddsrt_atomic_add32_nv (x, v) - v;
-}
-inline void ddsrt_atomic_addptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-    (void) ddsrt_atomic_addptr_nv (x, v);
-}
-inline void ddsrt_atomic_addvoidp (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
-    (void) ddsrt_atomic_addvoidp_nv (x, v);
 }
 
 /* SUB */
@@ -100,20 +88,8 @@ inline void ddsrt_atomic_addvoidp (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v
 inline uint32_t ddsrt_atomic_sub32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
     return ddsrt_atomic_add32_nv (x, -v);
 }
-inline uintptr_t ddsrt_atomic_subptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-    return ddsrt_atomic_addptr_nv (x, -v);
-}
-inline void *ddsrt_atomic_subvoidp_nv (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
-    return ddsrt_atomic_addvoidp_nv (x, -v);
-}
 inline void ddsrt_atomic_sub32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
     ddsrt_atomic_add32 (x, -v);
-}
-inline void ddsrt_atomic_subptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-    ddsrt_atomic_subptr (x, -v);
-}
-inline void ddsrt_atomic_subvoidp (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
-    ddsrt_atomic_subvoidp (x, -v);
 }
 
 /* INC */
@@ -124,14 +100,8 @@ inline uint32_t ddsrt_atomic_inc32_ov (volatile ddsrt_atomic_uint32_t *x) {
 inline uint32_t ddsrt_atomic_inc32_nv (volatile ddsrt_atomic_uint32_t *x) {
     return ddsrt_atomic_add32_nv (x, 1);
 }
-inline uintptr_t ddsrt_atomic_incptr_nv (volatile ddsrt_atomic_uintptr_t *x) {
-    return ddsrt_atomic_addptr_nv (x, 1);
-}
 inline void ddsrt_atomic_inc32 (volatile ddsrt_atomic_uint32_t *x) {
     (void) ddsrt_atomic_inc32_nv (x);
-}
-inline void ddsrt_atomic_incptr (volatile ddsrt_atomic_uintptr_t *x) {
-    (void) ddsrt_atomic_incptr_nv (x);
 }
 
 /* DEC */
@@ -142,14 +112,8 @@ inline uint32_t ddsrt_atomic_dec32_ov (volatile ddsrt_atomic_uint32_t *x) {
 inline uint32_t ddsrt_atomic_dec32_nv (volatile ddsrt_atomic_uint32_t *x) {
     return ddsrt_atomic_sub32_nv (x, 1);
 }
-inline uintptr_t ddsrt_atomic_decptr_nv (volatile ddsrt_atomic_uintptr_t *x) {
-    return ddsrt_atomic_subptr_nv (x, 1);
-}
 inline void ddsrt_atomic_dec32 (volatile ddsrt_atomic_uint32_t *x) {
     (void) ddsrt_atomic_dec32_nv (x);
-}
-inline void ddsrt_atomic_decptr (volatile ddsrt_atomic_uintptr_t *x) {
-    (void) ddsrt_atomic_decptr_nv (x);
 }
 
 /* AND */
@@ -159,26 +123,13 @@ inline uint32_t ddsrt_atomic_and32_ov (volatile ddsrt_atomic_uint32_t *x, uint32
     do { oldval = x->v; newval = oldval & v; } while (!ddsrt_atomic_cas32 (x, oldval, newval));
     return oldval;
 }
-inline uintptr_t ddsrt_atomic_andptr_ov (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-    uintptr_t oldval, newval;
-    do { oldval = x->v; newval = oldval & v; } while (!ddsrt_atomic_casptr (x, oldval, newval));
-    return oldval;
-}
 inline uint32_t ddsrt_atomic_and32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
     uint32_t oldval, newval;
     do { oldval = x->v; newval = oldval & v; } while (!ddsrt_atomic_cas32 (x, oldval, newval));
     return newval;
 }
-inline uintptr_t ddsrt_atomic_andptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-    uintptr_t oldval, newval;
-    do { oldval = x->v; newval = oldval & v; } while (!ddsrt_atomic_casptr (x, oldval, newval));
-    return newval;
-}
 inline void ddsrt_atomic_and32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
     (void) ddsrt_atomic_and32_nv (x, v);
-}
-inline void ddsrt_atomic_andptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-    (void) ddsrt_atomic_andptr_nv (x, v);
 }
 
 /* OR */
@@ -188,26 +139,13 @@ inline uint32_t ddsrt_atomic_or32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_
     do { oldval = x->v; newval = oldval | v; } while (!ddsrt_atomic_cas32 (x, oldval, newval));
     return oldval;
 }
-inline uintptr_t ddsrt_atomic_orptr_ov (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-    uintptr_t oldval, newval;
-    do { oldval = x->v; newval = oldval | v; } while (!ddsrt_atomic_casptr (x, oldval, newval));
-    return oldval;
-}
 inline uint32_t ddsrt_atomic_or32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
     uint32_t oldval, newval;
     do { oldval = x->v; newval = oldval | v; } while (!ddsrt_atomic_cas32 (x, oldval, newval));
     return newval;
 }
-inline uintptr_t ddsrt_atomic_orptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-    uintptr_t oldval, newval;
-    do { oldval = x->v; newval = oldval | v; } while (!ddsrt_atomic_casptr (x, oldval, newval));
-    return newval;
-}
 inline void ddsrt_atomic_or32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
     (void) ddsrt_atomic_or32_nv (x, v);
-}
-inline void ddsrt_atomic_orptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-    (void) ddsrt_atomic_orptr_nv (x, v);
 }
 
 /* FENCES */

--- a/src/ddsrt/include/dds/ddsrt/atomics/gcc.h
+++ b/src/ddsrt/include/dds/ddsrt/atomics/gcc.h
@@ -82,9 +82,6 @@ inline void ddsrt_atomic_inc64 (volatile ddsrt_atomic_uint64_t *x) {
   __sync_fetch_and_add (&x->v, 1);
 }
 #endif
-inline void ddsrt_atomic_incptr (volatile ddsrt_atomic_uintptr_t *x) {
-  __sync_fetch_and_add (&x->v, 1);
-}
 inline uint32_t ddsrt_atomic_inc32_ov (volatile ddsrt_atomic_uint32_t *x) {
   return __sync_fetch_and_add (&x->v, 1);
 }
@@ -96,9 +93,6 @@ inline uint64_t ddsrt_atomic_inc64_nv (volatile ddsrt_atomic_uint64_t *x) {
   return __sync_add_and_fetch (&x->v, 1);
 }
 #endif
-inline uintptr_t ddsrt_atomic_incptr_nv (volatile ddsrt_atomic_uintptr_t *x) {
-  return __sync_add_and_fetch (&x->v, 1);
-}
 
 /* DEC */
 
@@ -110,9 +104,6 @@ inline void ddsrt_atomic_dec64 (volatile ddsrt_atomic_uint64_t *x) {
   __sync_fetch_and_sub (&x->v, 1);
 }
 #endif
-inline void ddsrt_atomic_decptr (volatile ddsrt_atomic_uintptr_t *x) {
-  __sync_fetch_and_sub (&x->v, 1);
-}
 inline uint32_t ddsrt_atomic_dec32_nv (volatile ddsrt_atomic_uint32_t *x) {
   return __sync_sub_and_fetch (&x->v, 1);
 }
@@ -121,9 +112,6 @@ inline uint64_t ddsrt_atomic_dec64_nv (volatile ddsrt_atomic_uint64_t *x) {
   return __sync_sub_and_fetch (&x->v, 1);
 }
 #endif
-inline uintptr_t ddsrt_atomic_decptr_nv (volatile ddsrt_atomic_uintptr_t *x) {
-  return __sync_sub_and_fetch (&x->v, 1);
-}
 inline uint32_t ddsrt_atomic_dec32_ov (volatile ddsrt_atomic_uint32_t *x) {
   return __sync_fetch_and_sub (&x->v, 1);
 }
@@ -132,9 +120,6 @@ inline uint64_t ddsrt_atomic_dec64_ov (volatile ddsrt_atomic_uint64_t *x) {
   return __sync_fetch_and_sub (&x->v, 1);
 }
 #endif
-inline uintptr_t ddsrt_atomic_decptr_ov (volatile ddsrt_atomic_uintptr_t *x) {
-  return __sync_fetch_and_sub (&x->v, 1);
-}
 
 /* ADD */
 
@@ -146,12 +131,6 @@ inline void ddsrt_atomic_add64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
   __sync_fetch_and_add (&x->v, v);
 }
 #endif
-inline void ddsrt_atomic_addptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  __sync_fetch_and_add (&x->v, v);
-}
-inline void ddsrt_atomic_addvoidp (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
-  ddsrt_atomic_addptr ((volatile ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
-}
 inline uint32_t ddsrt_atomic_add32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
   return __sync_fetch_and_add (&x->v, v);
 }
@@ -163,12 +142,6 @@ inline uint64_t ddsrt_atomic_add64_nv (volatile ddsrt_atomic_uint64_t *x, uint64
   return __sync_add_and_fetch (&x->v, v);
 }
 #endif
-inline uintptr_t ddsrt_atomic_addptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  return __sync_add_and_fetch (&x->v, v);
-}
-inline void *ddsrt_atomic_addvoidp_nv (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
-  return (void *) ddsrt_atomic_addptr_nv ((volatile ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
-}
 
 /* SUB */
 
@@ -180,12 +153,6 @@ inline void ddsrt_atomic_sub64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
   __sync_fetch_and_sub (&x->v, v);
 }
 #endif
-inline void ddsrt_atomic_subptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  __sync_fetch_and_sub (&x->v, v);
-}
-inline void ddsrt_atomic_subvoidp (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
-  ddsrt_atomic_subptr ((volatile ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
-}
 inline uint32_t ddsrt_atomic_sub32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
   return __sync_fetch_and_sub (&x->v, v);
 }
@@ -197,12 +164,6 @@ inline uint64_t ddsrt_atomic_sub64_nv (volatile ddsrt_atomic_uint64_t *x, uint64
   return __sync_sub_and_fetch (&x->v, v);
 }
 #endif
-inline uintptr_t ddsrt_atomic_subptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  return __sync_sub_and_fetch (&x->v, v);
-}
-inline void *ddsrt_atomic_subvoidp_nv (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
-  return (void *) ddsrt_atomic_subptr_nv ((volatile ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
-}
 
 /* AND */
 
@@ -214,9 +175,6 @@ inline void ddsrt_atomic_and64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
   __sync_fetch_and_and (&x->v, v);
 }
 #endif
-inline void ddsrt_atomic_andptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  __sync_fetch_and_and (&x->v, v);
-}
 inline uint32_t ddsrt_atomic_and32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
   return __sync_fetch_and_and (&x->v, v);
 }
@@ -225,9 +183,6 @@ inline uint64_t ddsrt_atomic_and64_ov (volatile ddsrt_atomic_uint64_t *x, uint64
   return __sync_fetch_and_and (&x->v, v);
 }
 #endif
-inline uintptr_t ddsrt_atomic_andptr_ov (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  return __sync_fetch_and_and (&x->v, v);
-}
 inline uint32_t ddsrt_atomic_and32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
   return __sync_and_and_fetch (&x->v, v);
 }
@@ -236,9 +191,6 @@ inline uint64_t ddsrt_atomic_and64_nv (volatile ddsrt_atomic_uint64_t *x, uint64
   return __sync_and_and_fetch (&x->v, v);
 }
 #endif
-inline uintptr_t ddsrt_atomic_andptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  return __sync_and_and_fetch (&x->v, v);
-}
 
 /* OR */
 
@@ -250,9 +202,6 @@ inline void ddsrt_atomic_or64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
   __sync_fetch_and_or (&x->v, v);
 }
 #endif
-inline void ddsrt_atomic_orptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  __sync_fetch_and_or (&x->v, v);
-}
 inline uint32_t ddsrt_atomic_or32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
   return __sync_fetch_and_or (&x->v, v);
 }
@@ -261,9 +210,6 @@ inline uint64_t ddsrt_atomic_or64_ov (volatile ddsrt_atomic_uint64_t *x, uint64_
   return __sync_fetch_and_or (&x->v, v);
 }
 #endif
-inline uintptr_t ddsrt_atomic_orptr_ov (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  return __sync_fetch_and_or (&x->v, v);
-}
 inline uint32_t ddsrt_atomic_or32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
   return __sync_or_and_fetch (&x->v, v);
 }
@@ -272,9 +218,6 @@ inline uint64_t ddsrt_atomic_or64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_
   return __sync_or_and_fetch (&x->v, v);
 }
 #endif
-inline uintptr_t ddsrt_atomic_orptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  return __sync_or_and_fetch (&x->v, v);
-}
 
 /* CAS */
 

--- a/src/ddsrt/include/dds/ddsrt/atomics/msvc.h
+++ b/src/ddsrt/include/dds/ddsrt/atomics/msvc.h
@@ -73,9 +73,6 @@ inline void ddsrt_atomic_inc64 (volatile ddsrt_atomic_uint64_t *x) {
   DDSRT_ATOMIC_OP64 (InterlockedIncrement, &x->v);
 }
 #endif
-inline void ddsrt_atomic_incptr (volatile ddsrt_atomic_uintptr_t *x) {
-  DDSRT_ATOMIC_PTROP (InterlockedIncrement, &x->v);
-}
 inline uint32_t ddsrt_atomic_inc32_ov (volatile ddsrt_atomic_uint32_t *x) {
   return DDSRT_ATOMIC_OP32 (InterlockedIncrement, &x->v) - 1;
 }
@@ -87,9 +84,6 @@ inline uint64_t ddsrt_atomic_inc64_nv (volatile ddsrt_atomic_uint64_t *x) {
   return DDSRT_ATOMIC_OP64 (InterlockedIncrement, &x->v);
 }
 #endif
-inline uintptr_t ddsrt_atomic_incptr_nv (volatile ddsrt_atomic_uintptr_t *x) {
-  return DDSRT_ATOMIC_PTROP (InterlockedIncrement, &x->v);
-}
 
 /* DEC */
 
@@ -101,9 +95,6 @@ inline void ddsrt_atomic_dec64 (volatile ddsrt_atomic_uint64_t *x) {
   DDSRT_ATOMIC_OP64 (InterlockedDecrement, &x->v);
 }
 #endif
-inline void ddsrt_atomic_decptr (volatile ddsrt_atomic_uintptr_t *x) {
-  DDSRT_ATOMIC_PTROP (InterlockedDecrement, &x->v);
-}
 inline uint32_t ddsrt_atomic_dec32_nv (volatile ddsrt_atomic_uint32_t *x) {
   return DDSRT_ATOMIC_OP32 (InterlockedDecrement, &x->v);
 }
@@ -112,9 +103,6 @@ inline uint64_t ddsrt_atomic_dec64_nv (volatile ddsrt_atomic_uint64_t *x) {
   return DDSRT_ATOMIC_OP64 (InterlockedDecrement, &x->v);
 }
 #endif
-inline uintptr_t ddsrt_atomic_decptr_nv (volatile ddsrt_atomic_uintptr_t *x) {
-  return DDSRT_ATOMIC_PTROP (InterlockedDecrement, &x->v);
-}
 inline uint32_t ddsrt_atomic_dec32_ov (volatile ddsrt_atomic_uint32_t *x) {
   return DDSRT_ATOMIC_OP32 (InterlockedDecrement, &x->v) + 1;
 }
@@ -123,9 +111,6 @@ inline uint64_t ddsrt_atomic_dec64_ov (volatile ddsrt_atomic_uint64_t *x) {
   return DDSRT_ATOMIC_OP64 (InterlockedDecrement, &x->v) + 1;
 }
 #endif
-inline uintptr_t ddsrt_atomic_decptr_ov (volatile ddsrt_atomic_uintptr_t *x) {
-  return DDSRT_ATOMIC_PTROP (InterlockedDecrement, &x->v) + 1;
-}
 
 /* ADD */
 
@@ -137,12 +122,6 @@ inline void ddsrt_atomic_add64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
   DDSRT_ATOMIC_OP64 (InterlockedExchangeAdd, &x->v, v);
 }
 #endif
-inline void ddsrt_atomic_addptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  DDSRT_ATOMIC_PTROP (InterlockedExchangeAdd, &x->v, v);
-}
-inline void ddsrt_atomic_addvoidp (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
-  ddsrt_atomic_addptr ((volatile ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
-}
 inline uint32_t ddsrt_atomic_add32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
   return DDSRT_ATOMIC_OP32 (InterlockedExchangeAdd, &x->v, v);
 }
@@ -154,12 +133,6 @@ inline uint64_t ddsrt_atomic_add64_nv (volatile ddsrt_atomic_uint64_t *x, uint64
   return DDSRT_ATOMIC_OP64 (InterlockedExchangeAdd, &x->v, v) + v;
 }
 #endif
-inline uintptr_t ddsrt_atomic_addptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  return DDSRT_ATOMIC_PTROP (InterlockedExchangeAdd, &x->v, v) + v;
-}
-inline void *ddsrt_atomic_addvoidp_nv (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
-  return (void *) ddsrt_atomic_addptr_nv ((volatile ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
-}
 
 /* SUB */
 
@@ -177,15 +150,6 @@ inline void ddsrt_atomic_sub64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
   DDSRT_WARNING_MSVC_ON(4146)
 }
 #endif
-inline void ddsrt_atomic_subptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  /* disable unary minus applied to unsigned type, result still unsigned */
-  DDSRT_WARNING_MSVC_OFF(4146)
-  DDSRT_ATOMIC_PTROP (InterlockedExchangeAdd, &x->v, -v);
-  DDSRT_WARNING_MSVC_ON(4146)
-}
-inline void ddsrt_atomic_subvoidp (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
-  ddsrt_atomic_subptr ((volatile ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
-}
 inline uint32_t ddsrt_atomic_sub32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
   /* disable unary minus applied to unsigned type, result still unsigned */
   DDSRT_WARNING_MSVC_OFF(4146)
@@ -206,15 +170,6 @@ inline uint64_t ddsrt_atomic_sub64_nv (volatile ddsrt_atomic_uint64_t *x, uint64
   DDSRT_WARNING_MSVC_ON(4146)
 }
 #endif
-inline uintptr_t ddsrt_atomic_subptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  /* disable unary minus applied to unsigned type, result still unsigned */
-  DDSRT_WARNING_MSVC_OFF(4146)
-  return DDSRT_ATOMIC_PTROP (InterlockedExchangeAdd, &x->v, -v) - v;
-  DDSRT_WARNING_MSVC_ON(4146)
-}
-inline void *ddsrt_atomic_subvoidp_nv (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
-  return (void *) ddsrt_atomic_subptr_nv ((volatile ddsrt_atomic_uintptr_t *) x, (uintptr_t) v);
-}
 
 /* AND */
 
@@ -226,9 +181,6 @@ inline void ddsrt_atomic_and64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
   DDSRT_ATOMIC_OP64 (InterlockedAnd, &x->v, v);
 }
 #endif
-inline void ddsrt_atomic_andptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  DDSRT_ATOMIC_PTROP (InterlockedAnd, &x->v, v);
-}
 inline uint32_t ddsrt_atomic_and32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
   return DDSRT_ATOMIC_OP32 (InterlockedAnd, &x->v, v);
 }
@@ -237,9 +189,6 @@ inline uint64_t ddsrt_atomic_and64_ov (volatile ddsrt_atomic_uint64_t *x, uint64
   return DDSRT_ATOMIC_OP64 (InterlockedAnd, &x->v, v);
 }
 #endif
-inline uintptr_t ddsrt_atomic_andptr_ov (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  return DDSRT_ATOMIC_PTROP (InterlockedAnd, &x->v, v);
-}
 inline uint32_t ddsrt_atomic_and32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
   return DDSRT_ATOMIC_OP32 (InterlockedAnd, &x->v, v) & v;
 }
@@ -248,9 +197,6 @@ inline uint64_t ddsrt_atomic_and64_nv (volatile ddsrt_atomic_uint64_t *x, uint64
   return DDSRT_ATOMIC_OP64 (InterlockedAnd, &x->v, v) & v;
 }
 #endif
-inline uintptr_t ddsrt_atomic_andptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  return DDSRT_ATOMIC_PTROP (InterlockedAnd, &x->v, v) & v;
-}
 
 /* OR */
 
@@ -262,9 +208,6 @@ inline void ddsrt_atomic_or64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
   DDSRT_ATOMIC_OP64 (InterlockedOr, &x->v, v);
 }
 #endif
-inline void ddsrt_atomic_orptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  DDSRT_ATOMIC_PTROP (InterlockedOr, &x->v, v);
-}
 inline uint32_t ddsrt_atomic_or32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
   return DDSRT_ATOMIC_OP32 (InterlockedOr, &x->v, v);
 }
@@ -273,9 +216,6 @@ inline uint64_t ddsrt_atomic_or64_ov (volatile ddsrt_atomic_uint64_t *x, uint64_
   return DDSRT_ATOMIC_OP64 (InterlockedOr, &x->v, v);
 }
 #endif
-inline uintptr_t ddsrt_atomic_orptr_ov (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  return DDSRT_ATOMIC_PTROP (InterlockedOr, &x->v, v);
-}
 inline uint32_t ddsrt_atomic_or32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
   return DDSRT_ATOMIC_OP32 (InterlockedOr, &x->v, v) | v;
 }
@@ -284,9 +224,6 @@ inline uint64_t ddsrt_atomic_or64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_
   return DDSRT_ATOMIC_OP64 (InterlockedOr, &x->v, v) | v;
 }
 #endif
-inline uintptr_t ddsrt_atomic_orptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  return DDSRT_ATOMIC_PTROP (InterlockedOr, &x->v, v) | v;
-}
 
 /* FENCES */
 

--- a/src/ddsrt/include/dds/ddsrt/atomics/sun.h
+++ b/src/ddsrt/include/dds/ddsrt/atomics/sun.h
@@ -37,9 +37,6 @@ inline void ddsrt_atomic_inc32 (volatile ddsrt_atomic_uint32_t *x) {
 inline void ddsrt_atomic_inc64 (volatile ddsrt_atomic_uint64_t *x) {
   atomic_inc_64 (&x->v);
 }
-inline void ddsrt_atomic_incptr (volatile ddsrt_atomic_uintptr_t *x) {
-  atomic_inc_ulong (&x->v);
-}
 inline uint32_t ddsrt_atomic_inc32_ov (volatile ddsrt_atomic_uint32_t *x) {
   uint32_t oldval, newval;
   do { oldval = x->v; newval = oldval + 1; } while (atomic_cas_32 (&x->v, oldval, newval) != oldval);
@@ -51,9 +48,6 @@ inline uint32_t ddsrt_atomic_inc32_nv (volatile ddsrt_atomic_uint32_t *x) {
 inline uint64_t ddsrt_atomic_inc64_nv (volatile ddsrt_atomic_uint64_t *x) {
   return atomic_inc_64_nv (&x->v);
 }
-inline uintptr_t ddsrt_atomic_incptr_nv (volatile ddsrt_atomic_uintptr_t *x) {
-  return atomic_inc_ulong_nv (&x->v);
-}
 
 /* DEC */
 
@@ -63,17 +57,11 @@ inline void ddsrt_atomic_dec32 (volatile ddsrt_atomic_uint32_t *x) {
 inline void ddsrt_atomic_dec64 (volatile ddsrt_atomic_uint64_t *x) {
   atomic_dec_64 (&x->v);
 }
-inline void ddsrt_atomic_decptr (volatile ddsrt_atomic_uintptr_t *x) {
-  atomic_dec_ulong (&x->v);
-}
 inline uint32_t ddsrt_atomic_dec32_nv (volatile ddsrt_atomic_uint32_t *x) {
   return atomic_dec_32_nv (&x->v);
 }
 inline uint64_t ddsrt_atomic_dec64_nv (volatile ddsrt_atomic_uint64_t *x) {
   return atomic_dec_64_nv (&x->v);
-}
-inline uintptr_t ddsrt_atomic_decptr_nv (volatile ddsrt_atomic_uintptr_t *x) {
-  return atomic_dec_ulong_nv (&x->v);
 }
 inline uint32_t ddsrt_atomic_dec32_ov (volatile ddsrt_atomic_uint32_t *x) {
   uint32_t oldval, newval;
@@ -82,11 +70,6 @@ inline uint32_t ddsrt_atomic_dec32_ov (volatile ddsrt_atomic_uint32_t *x) {
 }
 inline uint64_t ddsrt_atomic_dec64_ov (volatile ddsrt_atomic_uint64_t *x) {
   uint64_t oldval, newval;
-  do { oldval = x->v; newval = oldval - 1; } while (atomic_cas_64 (&x->v, oldval, newval) != oldval);
-  return oldval;
-}
-inline uintptr_t ddsrt_atomic_decptr_ov (volatile ddsrt_atomic_uintptr_t *x) {
-  uintptr_t oldval, newval;
   do { oldval = x->v; newval = oldval - 1; } while (atomic_cas_64 (&x->v, oldval, newval) != oldval);
   return oldval;
 }
@@ -99,12 +82,6 @@ inline void ddsrt_atomic_add32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
 inline void ddsrt_atomic_add64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
   atomic_add_64 (&x->v, v);
 }
-inline void ddsrt_atomic_addptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  atomic_add_long (&x->v, v);
-}
-inline void ddsrt_atomic_addvoidp (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
-  atomic_add_ptr (&x->v, v);
-}
 inline uint32_t ddsrt_atomic_add32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
   return atomic_add_32_nv (&x->v, v) - v;
 }
@@ -113,12 +90,6 @@ inline uint32_t ddsrt_atomic_add32_nv (volatile ddsrt_atomic_uint32_t *x, uint32
 }
 inline uint64_t ddsrt_atomic_add64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
   return atomic_add_64_nv (&x->v, v);
-}
-inline uintptr_t ddsrt_atomic_addptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  return atomic_add_long_nv (&x->v, v);
-}
-inline void *ddsrt_atomic_addvoidp_nv (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
-  return atomic_add_ptr_nv (&x->v, v);
 }
 
 /* SUB */
@@ -129,12 +100,6 @@ inline void ddsrt_atomic_sub32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
 inline void ddsrt_atomic_sub64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
   atomic_add_64 (&x->v, -v);
 }
-inline void ddsrt_atomic_subptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  atomic_add_long (&x->v, -v);
-}
-inline void ddsrt_atomic_subvoidp (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
-  atomic_add_ptr (&x->v, -v);
-}
 inline uint32_t ddsrt_atomic_sub32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
   return atomic_add_32_nv (&x->v, -v) + v;
 }
@@ -144,12 +109,6 @@ inline uint32_t ddsrt_atomic_sub32_nv (volatile ddsrt_atomic_uint32_t *x, uint32
 inline uint64_t ddsrt_atomic_sub64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
   return atomic_add_64_nv (&x->v, -v);
 }
-inline uintptr_t ddsrt_atomic_subptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  return atomic_add_long_nv (&x->v, -v);
-}
-inline void *ddsrt_atomic_subvoidp_nv (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v) {
-  return atomic_add_ptr_nv (&x->v, -v);
-}
 
 /* AND */
 
@@ -158,9 +117,6 @@ inline void ddsrt_atomic_and32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
 }
 inline void ddsrt_atomic_and64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
   atomic_and_64 (&x->v, v);
-}
-inline void ddsrt_atomic_andptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  atomic_and_ulong (&x->v, v);
 }
 inline uint32_t ddsrt_atomic_and32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
   uint32_t oldval, newval;
@@ -172,19 +128,11 @@ inline uint64_t ddsrt_atomic_and64_ov (volatile ddsrt_atomic_uint64_t *x, uint64
   do { oldval = x->v; newval = oldval & v; } while (atomic_cas_64 (&x->v, oldval, newval) != oldval);
   return oldval;
 }
-inline uintptr_t ddsrt_atomic_andptr_ov (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  uintptr_t oldval, newval;
-  do { oldval = x->v; newval = oldval & v; } while (atomic_cas_ulong (&x->v, oldval, newval) != oldval);
-  return oldval;
-}
 inline uint32_t ddsrt_atomic_and32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
   return atomic_and_32_nv (&x->v, v);
 }
 inline uint64_t ddsrt_atomic_and64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
   return atomic_and_64_nv (&x->v, v);
-}
-inline uintptr_t ddsrt_atomic_andptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  return atomic_and_ulong_nv (&x->v, v);
 }
 
 /* OR */
@@ -194,9 +142,6 @@ inline void ddsrt_atomic_or32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
 }
 inline void ddsrt_atomic_or64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
   atomic_or_64 (&x->v, v);
-}
-inline void ddsrt_atomic_orptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  atomic_or_ulong (&x->v, v);
 }
 inline uint32_t ddsrt_atomic_or32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
   uint32_t oldval, newval;
@@ -208,19 +153,11 @@ inline uint64_t ddsrt_atomic_or64_ov (volatile ddsrt_atomic_uint64_t *x, uint64_
   do { oldval = x->v; newval = oldval | v; } while (atomic_cas_64 (&x->v, oldval, newval) != oldval);
   return oldval;
 }
-inline uintptr_t ddsrt_atomic_orptr_ov (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  uintptr_t oldval, newval;
-  do { oldval = x->v; newval = oldval | v; } while (atomic_cas_ulong (&x->v, oldval, newval) != oldval);
-  return oldval;
-}
 inline uint32_t ddsrt_atomic_or32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v) {
   return atomic_or_32_nv (&x->v, v);
 }
 inline uint64_t ddsrt_atomic_or64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v) {
   return atomic_or_64_nv (&x->v, v);
-}
-inline uintptr_t ddsrt_atomic_orptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v) {
-  return atomic_or_ulong_nv (&x->v, v);
 }
 
 /* CAS */

--- a/src/ddsrt/src/atomics.c
+++ b/src/ddsrt/src/atomics.c
@@ -29,89 +29,70 @@ extern inline void ddsrt_atomic_inc32 (volatile ddsrt_atomic_uint32_t *x);
 #if DDSRT_HAVE_ATOMIC64
 extern inline void ddsrt_atomic_inc64 (volatile ddsrt_atomic_uint64_t *x);
 #endif
-extern inline void ddsrt_atomic_incptr (volatile ddsrt_atomic_uintptr_t *x);
 extern inline uint32_t ddsrt_atomic_inc32_ov (volatile ddsrt_atomic_uint32_t *x);
 extern inline uint32_t ddsrt_atomic_inc32_nv (volatile ddsrt_atomic_uint32_t *x);
 #if DDSRT_HAVE_ATOMIC64
 extern inline uint64_t ddsrt_atomic_inc64_nv (volatile ddsrt_atomic_uint64_t *x);
 #endif
-extern inline uintptr_t ddsrt_atomic_incptr_nv (volatile ddsrt_atomic_uintptr_t *x);
 /* DEC */
 extern inline void ddsrt_atomic_dec32 (volatile ddsrt_atomic_uint32_t *x);
 #if DDSRT_HAVE_ATOMIC64
 extern inline void ddsrt_atomic_dec64 (volatile ddsrt_atomic_uint64_t *x);
 #endif
-extern inline void ddsrt_atomic_decptr (volatile ddsrt_atomic_uintptr_t *x);
 extern inline uint32_t ddsrt_atomic_dec32_nv (volatile ddsrt_atomic_uint32_t *x);
 #if DDSRT_HAVE_ATOMIC64
 extern inline uint64_t ddsrt_atomic_dec64_nv (volatile ddsrt_atomic_uint64_t *x);
 #endif
-extern inline uintptr_t ddsrt_atomic_decptr_nv (volatile ddsrt_atomic_uintptr_t *x);
 extern inline uint32_t ddsrt_atomic_dec32_ov (volatile ddsrt_atomic_uint32_t *x);
 #if DDSRT_HAVE_ATOMIC64
 extern inline uint64_t ddsrt_atomic_dec64_ov (volatile ddsrt_atomic_uint64_t *x);
 #endif
-extern inline uintptr_t ddsrt_atomic_decptr_ov (volatile ddsrt_atomic_uintptr_t *x);
 /* ADD */
 extern inline void ddsrt_atomic_add32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v);
 #if DDSRT_HAVE_ATOMIC64
 extern inline void ddsrt_atomic_add64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
 #endif
-extern inline void ddsrt_atomic_addptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v);
-extern inline void ddsrt_atomic_addvoidp (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v);
 extern inline uint32_t ddsrt_atomic_add32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v);
 extern inline uint32_t ddsrt_atomic_add32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v);
 #if DDSRT_HAVE_ATOMIC64
 extern inline uint64_t ddsrt_atomic_add64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
 #endif
-extern inline uintptr_t ddsrt_atomic_addptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v);
-extern inline void *ddsrt_atomic_addvoidp_nv (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v);
 /* SUB */
 extern inline void ddsrt_atomic_sub32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v);
 #if DDSRT_HAVE_ATOMIC64
 extern inline void ddsrt_atomic_sub64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
 #endif
-extern inline void ddsrt_atomic_subptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v);
-extern inline void ddsrt_atomic_subvoidp (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v);
 extern inline uint32_t ddsrt_atomic_sub32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v);
 extern inline uint32_t ddsrt_atomic_sub32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v);
 #if DDSRT_HAVE_ATOMIC64
 extern inline uint64_t ddsrt_atomic_sub64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
 #endif
-extern inline uintptr_t ddsrt_atomic_subptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v);
-extern inline void *ddsrt_atomic_subvoidp_nv (volatile ddsrt_atomic_voidp_t *x, ptrdiff_t v);
 /* AND */
 extern inline void ddsrt_atomic_and32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v);
 #if DDSRT_HAVE_ATOMIC64
 extern inline void ddsrt_atomic_and64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
 #endif
-extern inline void ddsrt_atomic_andptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v);
 extern inline uint32_t ddsrt_atomic_and32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v);
 #if DDSRT_HAVE_ATOMIC64
 extern inline uint64_t ddsrt_atomic_and64_ov (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
 #endif
-extern inline uintptr_t ddsrt_atomic_andptr_ov (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v);
 extern inline uint32_t ddsrt_atomic_and32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v);
 #if DDSRT_HAVE_ATOMIC64
 extern inline uint64_t ddsrt_atomic_and64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
 #endif
-extern inline uintptr_t ddsrt_atomic_andptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v);
 /* OR */
 extern inline void ddsrt_atomic_or32 (volatile ddsrt_atomic_uint32_t *x, uint32_t v);
 #if DDSRT_HAVE_ATOMIC64
 extern inline void ddsrt_atomic_or64 (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
 #endif
-extern inline void ddsrt_atomic_orptr (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v);
 extern inline uint32_t ddsrt_atomic_or32_ov (volatile ddsrt_atomic_uint32_t *x, uint32_t v);
 #if DDSRT_HAVE_ATOMIC64
 extern inline uint64_t ddsrt_atomic_or64_ov (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
 #endif
-extern inline uintptr_t ddsrt_atomic_orptr_ov (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v);
 extern inline uint32_t ddsrt_atomic_or32_nv (volatile ddsrt_atomic_uint32_t *x, uint32_t v);
 #if DDSRT_HAVE_ATOMIC64
 extern inline uint64_t ddsrt_atomic_or64_nv (volatile ddsrt_atomic_uint64_t *x, uint64_t v);
 #endif
-extern inline uintptr_t ddsrt_atomic_orptr_nv (volatile ddsrt_atomic_uintptr_t *x, uintptr_t v);
 /* CAS */
 extern inline int ddsrt_atomic_cas32 (volatile ddsrt_atomic_uint32_t *x, uint32_t exp, uint32_t des);
 #if DDSRT_HAVE_ATOMIC64

--- a/src/ddsrt/tests/atomics.c
+++ b/src/ddsrt/tests/atomics.c
@@ -106,11 +106,8 @@ CU_Test(ddsrt_atomics, increment)
 #if DDSRT_HAVE_ATOMIC64
   volatile ddsrt_atomic_uint64_t uint64 = DDSRT_ATOMIC_UINT64_INIT(0);
 #endif
-  volatile ddsrt_atomic_uintptr_t uintptr = DDSRT_ATOMIC_UINTPTR_INIT(0);
   _osuint32 = 0;
   _osuint64 = 0;
-  _osaddress = 0;
-  _osvoidp = (uintptr_t *)0;
 
   /* Test os_inc32 */
   ddsrt_atomic_inc32 (&uint32);
@@ -122,10 +119,6 @@ CU_Test(ddsrt_atomics, increment)
   CU_ASSERT (ddsrt_atomic_ld64 (&uint64) == 1);
 #endif
 
-  /* Test os_incptr */
-  ddsrt_atomic_incptr (&uintptr);
-  CU_ASSERT (ddsrt_atomic_ldptr (&uintptr) == 1);
-
   /* Test ddsrt_atomic_inc32_nv */
   ddsrt_atomic_st32 (&uint32, _osuint32);
   CU_ASSERT (ddsrt_atomic_inc32_nv (&uint32) == 1);
@@ -135,10 +128,6 @@ CU_Test(ddsrt_atomics, increment)
   ddsrt_atomic_st64 (&uint64, _osuint64);
   CU_ASSERT (ddsrt_atomic_inc64_nv (&uint64) == 1);
 #endif
-
-  /* Test ddsrt_atomic_incptr_nv */
-  ddsrt_atomic_stptr (&uintptr, _osaddress);
-  CU_ASSERT (ddsrt_atomic_incptr_nv(&uintptr) == 1);
 }
 
 CU_Test(ddsrt_atomics, decrement)
@@ -147,11 +136,8 @@ CU_Test(ddsrt_atomics, decrement)
 #if DDSRT_HAVE_ATOMIC64
   volatile ddsrt_atomic_uint64_t uint64 = DDSRT_ATOMIC_UINT64_INIT(1);
 #endif
-  volatile ddsrt_atomic_uintptr_t uintptr = DDSRT_ATOMIC_UINTPTR_INIT(1);
   _osuint32 = 1;
   _osuint64 = 1;
-  _osaddress = 1;
-  _osvoidp = (uintptr_t *)1;
 
   /* Test ddsrt_atomic_dec32 */
   ddsrt_atomic_dec32 (&uint32);
@@ -163,10 +149,6 @@ CU_Test(ddsrt_atomics, decrement)
   CU_ASSERT (ddsrt_atomic_ld64 (&uint64) == 0);
 #endif
 
-  /* Test ddsrt_atomic_decptr */
-  ddsrt_atomic_decptr (&uintptr);
-  CU_ASSERT (ddsrt_atomic_ldptr (&uintptr) == 0);
-
   /* Test ddsrt_atomic_dec32_nv */
   ddsrt_atomic_st32 (&uint32, _osuint32);
   CU_ASSERT (ddsrt_atomic_dec32_nv (&uint32) == 0);
@@ -176,10 +158,6 @@ CU_Test(ddsrt_atomics, decrement)
   ddsrt_atomic_st64 (&uint64, _osuint64);
   CU_ASSERT (ddsrt_atomic_dec64_nv (&uint64) == 0);
 #endif
-
-  /* Test ddsrt_atomic_decptr_nv */
-  ddsrt_atomic_stptr (&uintptr, _osaddress);
-  CU_ASSERT (ddsrt_atomic_decptr_nv(&uintptr) == 0);
 }
 
 CU_Test(ddsrt_atomics, add)
@@ -188,12 +166,8 @@ CU_Test(ddsrt_atomics, add)
 #if DDSRT_HAVE_ATOMIC64
   volatile ddsrt_atomic_uint64_t uint64 = DDSRT_ATOMIC_UINT64_INIT(1);
 #endif
-  volatile ddsrt_atomic_uintptr_t uintptr = DDSRT_ATOMIC_UINTPTR_INIT(1);
-  volatile ddsrt_atomic_voidp_t uintvoidp = DDSRT_ATOMIC_VOIDP_INIT((uintptr_t)1);
   _osuint32 = 2;
   _osuint64 = 2;
-  _osaddress = 2;
-  _ptrdiff = 2;
 
   /* Test ddsrt_atomic_add32 */
   ddsrt_atomic_add32 (&uint32, _osuint32);
@@ -205,14 +179,6 @@ CU_Test(ddsrt_atomics, add)
   CU_ASSERT (ddsrt_atomic_ld64 (&uint64) == 3);
 #endif
 
-  /* Test ddsrt_atomic_addptr */
-  ddsrt_atomic_addptr (&uintptr, _osaddress);
-  CU_ASSERT (ddsrt_atomic_ldptr (&uintptr) == 3);
-
-  /* Test ddsrt_atomic_addvoidp */
-  ddsrt_atomic_addvoidp (&uintvoidp, _ptrdiff);
-  CU_ASSERT (ddsrt_atomic_ldvoidp (&uintvoidp) == (uintptr_t*)3);
-
   /* Test ddsrt_atomic_add32_nv */
   ddsrt_atomic_st32 (&uint32, 1);
   CU_ASSERT (ddsrt_atomic_add32_nv (&uint32, _osuint32) == 3);
@@ -222,14 +188,6 @@ CU_Test(ddsrt_atomics, add)
   ddsrt_atomic_st64 (&uint64, 1);
   CU_ASSERT (ddsrt_atomic_add64_nv (&uint64, _osuint64) == 3);
 #endif
-
-  /* Test ddsrt_atomic_addptr_nv */
-  ddsrt_atomic_stptr (&uintptr, 1);
-  CU_ASSERT (ddsrt_atomic_addptr_nv (&uintptr, _osaddress) == 3);
-
-  /* Test ddsrt_atomic_addvoidp_nv */
-  ddsrt_atomic_stvoidp (&uintvoidp, (uintptr_t*)1);
-  CU_ASSERT (ddsrt_atomic_addvoidp_nv (&uintvoidp, _ptrdiff) == (uintptr_t*)3);
 }
 
 CU_Test(ddsrt_atomics, subtract)
@@ -238,12 +196,8 @@ CU_Test(ddsrt_atomics, subtract)
 #if DDSRT_HAVE_ATOMIC64
   volatile ddsrt_atomic_uint64_t uint64 = DDSRT_ATOMIC_UINT64_INIT(5);
 #endif
-  volatile ddsrt_atomic_uintptr_t uintptr = DDSRT_ATOMIC_UINTPTR_INIT(5);
-  volatile ddsrt_atomic_voidp_t uintvoidp = DDSRT_ATOMIC_VOIDP_INIT((uintptr_t)5);
   _osuint32 = 2;
   _osuint64 = 2;
-  _osaddress = 2;
-  _ptrdiff = 2;
 
   /* Test ddsrt_atomic_sub32 */
   ddsrt_atomic_sub32 (&uint32, _osuint32);
@@ -255,14 +209,6 @@ CU_Test(ddsrt_atomics, subtract)
   CU_ASSERT (ddsrt_atomic_ld64 (&uint64) == 3);
 #endif
 
-  /* Test ddsrt_atomic_subptr */
-  ddsrt_atomic_subptr (&uintptr, _osaddress);
-  CU_ASSERT (ddsrt_atomic_ldptr (&uintptr) == 3);
-
-  /* Test ddsrt_atomic_subvoidp */
-  ddsrt_atomic_subvoidp (&uintvoidp, _ptrdiff);
-  CU_ASSERT (ddsrt_atomic_ldvoidp (&uintvoidp) == (uintptr_t*)3);
-
   /* Test ddsrt_atomic_sub32_nv */
   ddsrt_atomic_st32 (&uint32, 5);
   CU_ASSERT (ddsrt_atomic_sub32_nv (&uint32, _osuint32) == 3);
@@ -272,14 +218,6 @@ CU_Test(ddsrt_atomics, subtract)
   ddsrt_atomic_st64 (&uint64, 5);
   CU_ASSERT (ddsrt_atomic_sub64_nv (&uint64, _osuint64) == 3);
 #endif
-
-  /* Test ddsrt_atomic_subptr_nv */
-  ddsrt_atomic_stptr (&uintptr, 5);
-  CU_ASSERT (ddsrt_atomic_subptr_nv (&uintptr, _osaddress) == 3);
-
-  /* Test ddsrt_atomic_subvoidp_nv */
-  ddsrt_atomic_stvoidp (&uintvoidp, (uintptr_t*)5);
-  CU_ASSERT (ddsrt_atomic_subvoidp_nv (&uintvoidp, _ptrdiff) == (void *)3);
 }
 
 CU_Test(ddsrt_atomics, and)
@@ -295,10 +233,8 @@ CU_Test(ddsrt_atomics, and)
 #if DDSRT_HAVE_ATOMIC64
   volatile ddsrt_atomic_uint64_t uint64 = DDSRT_ATOMIC_UINT64_INIT(150);
 #endif
-  volatile ddsrt_atomic_uintptr_t uintptr = DDSRT_ATOMIC_UINTPTR_INIT(150);
   _osuint32 = 500;
   _osuint64 = 500;
-  _osaddress = 500;
 
   /* Test ddsrt_atomic_and32 */
   ddsrt_atomic_and32 (&uint32, _osuint32);
@@ -310,10 +246,6 @@ CU_Test(ddsrt_atomics, and)
   CU_ASSERT (ddsrt_atomic_ld64 (&uint64) == 148);
 #endif
 
-  /* Test ddsrt_atomic_andptr */
-  ddsrt_atomic_andptr (&uintptr, _osaddress);
-  CU_ASSERT (ddsrt_atomic_ldptr (&uintptr) == 148);
-
   /* Test ddsrt_atomic_and32_ov */
   CU_ASSERT (ddsrt_atomic_and32_ov (&uint32, _osuint32) == 148);
 
@@ -322,9 +254,6 @@ CU_Test(ddsrt_atomics, and)
   CU_ASSERT (ddsrt_atomic_and64_ov (&uint64, _osuint64) == 148);
 #endif
 
-  /* Test ddsrt_atomic_andptr_ov */
-  CU_ASSERT (ddsrt_atomic_andptr_ov (&uintptr, _osaddress) == 148);
-
   /* Test ddsrt_atomic_and32_nv */
   CU_ASSERT (ddsrt_atomic_and32_nv (&uint32, _osuint32) == 148);
 
@@ -332,9 +261,6 @@ CU_Test(ddsrt_atomics, and)
 #if DDSRT_HAVE_ATOMIC64
   CU_ASSERT (ddsrt_atomic_and64_nv (&uint64, _osuint64) == 148);
  #endif
-
-  /* Test ddsrt_atomic_andptr_nv */
-  CU_ASSERT (ddsrt_atomic_andptr_nv (&uintptr, _osaddress) == 148);
 }
 
 CU_Test(ddsrt_atomics, or)
@@ -350,10 +276,8 @@ CU_Test(ddsrt_atomics, or)
 #if DDSRT_HAVE_ATOMIC64
   volatile ddsrt_atomic_uint64_t uint64 = DDSRT_ATOMIC_UINT64_INIT(150);
 #endif
-  volatile ddsrt_atomic_uintptr_t uintptr = DDSRT_ATOMIC_UINTPTR_INIT(150);
   _osuint32 = 500;
   _osuint64 = 500;
-  _osaddress = 500;
 
   /* Test ddsrt_atomic_or32 */
   ddsrt_atomic_or32 (&uint32, _osuint32);
@@ -365,10 +289,6 @@ CU_Test(ddsrt_atomics, or)
   CU_ASSERT (ddsrt_atomic_ld64 (&uint64) == 502);
 #endif
 
-  /* Test ddsrt_atomic_orptr */
-  ddsrt_atomic_orptr (&uintptr, _osaddress);
-  CU_ASSERT (ddsrt_atomic_ldptr (&uintptr) == 502);
-
   /* Test ddsrt_atomic_or32_ov */
   CU_ASSERT (ddsrt_atomic_or32_ov (&uint32, _osuint32) == 502);
 
@@ -377,9 +297,6 @@ CU_Test(ddsrt_atomics, or)
   CU_ASSERT (ddsrt_atomic_or64_ov (&uint64, _osuint64) == 502);
 #endif
 
-  /* Test ddsrt_atomic_orptr_ov */
-  CU_ASSERT (ddsrt_atomic_orptr_ov (&uintptr, _osaddress) == 502);
-
   /* Test ddsrt_atomic_or32_nv */
   CU_ASSERT (ddsrt_atomic_or32_nv (&uint32, _osuint32) == 502);
 
@@ -387,7 +304,4 @@ CU_Test(ddsrt_atomics, or)
 #if DDSRT_HAVE_ATOMIC64
   CU_ASSERT (ddsrt_atomic_or64_nv (&uint64, _osuint64) == 502);
 #endif
-
-  /* Test ddsrt_atomic_orptr_nv */
-  CU_ASSERT (ddsrt_atomic_orptr_nv (&uintptr, _osaddress) == 502);
 }


### PR DESCRIPTION
This PR removes unused atomic pointer operations (add, sub, and, or).

See issue #515 for more discussion.