### PR TITLE
Link with pthread

### DIFF
--- a/src/tools/ddsls/CMakeLists.txt
+++ b/src/tools/ddsls/CMakeLists.txt
@@ -10,7 +10,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
 add_executable(ddsls ddsls.c)
-target_link_libraries(ddsls ddsc)
+target_link_libraries(ddsls ddsc pthread)
 
 install(
   TARGETS ddsls

--- a/src/tools/ddsls/CMakeLists.txt
+++ b/src/tools/ddsls/CMakeLists.txt
@@ -10,7 +10,14 @@
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
 add_executable(ddsls ddsls.c)
-target_link_libraries(ddsls ddsc pthread)
+
+if(NOT WITH_FREERTOS)
+  set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+  find_package(Threads REQUIRED)
+  target_link_libraries(ddsls PUBLIC ddsc Threads::Threads)
+elseif()
+  target_link_libraries(ddsls ddsc)
+endif()
 
 install(
   TARGETS ddsls

--- a/src/tools/ddsperf/CMakeLists.txt
+++ b/src/tools/ddsperf/CMakeLists.txt
@@ -12,7 +12,7 @@
 
 idlc_generate(ddsperf_types ddsperf_types.idl)
 add_executable(ddsperf ddsperf.c cputime.c cputime.h netload.c netload.h)
-target_link_libraries(ddsperf ddsperf_types ddsc)
+target_link_libraries(ddsperf ddsperf_types ddsc pthread)
 
 if(WIN32)
   target_compile_definitions(ddsperf PRIVATE _CRT_SECURE_NO_WARNINGS)

--- a/src/tools/ddsperf/CMakeLists.txt
+++ b/src/tools/ddsperf/CMakeLists.txt
@@ -12,7 +12,14 @@
 
 idlc_generate(ddsperf_types ddsperf_types.idl)
 add_executable(ddsperf ddsperf.c cputime.c cputime.h netload.c netload.h)
-target_link_libraries(ddsperf ddsperf_types ddsc pthread)
+
+if(NOT WITH_FREERTOS)
+  set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+  find_package(Threads REQUIRED)
+  target_link_libraries(ddsperf ddsperf_types ddsc Threads::Threads)
+elseif()
+  target_link_libraries(ddsperf ddsperf_types ddsc)
+endif()
 
 if(WIN32)
   target_compile_definitions(ddsperf PRIVATE _CRT_SECURE_NO_WARNINGS)

--- a/src/tools/pubsub/CMakeLists.txt
+++ b/src/tools/pubsub/CMakeLists.txt
@@ -10,7 +10,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
 add_executable(pubsub pubsub.c common.c testtype.c porting.c)
-target_link_libraries(pubsub ddsc)
+target_link_libraries(pubsub ddsc pthread)
 
 if(WIN32)
   target_compile_definitions(pubsub PRIVATE _CRT_SECURE_NO_WARNINGS)

--- a/src/tools/pubsub/CMakeLists.txt
+++ b/src/tools/pubsub/CMakeLists.txt
@@ -10,7 +10,14 @@
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
 add_executable(pubsub pubsub.c common.c testtype.c porting.c)
-target_link_libraries(pubsub ddsc pthread)
+
+if(NOT WITH_FREERTOS)
+  set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+  find_package(Threads REQUIRED)
+  target_link_libraries(pubsub ddsc Threads::Threads)
+elseif()
+  target_link_libraries(pubsub ddsc)
+endif()
 
 if(WIN32)
   target_compile_definitions(pubsub PRIVATE _CRT_SECURE_NO_WARNINGS)


### PR DESCRIPTION
This PR fixes the issue of undefined references when trying to cross-compile for RaspberryPi

```
--- stderr: cyclonedds                                                                                                                                                                                             
You have called ADD_LIBRARY for library ddsc without any source files. This typically indicates a problem with your CMakeLists.txt file
CMake Warning:
  Manually-specified variables were not used by the project:

    THIRDPARTY


/root/sysroot/lib/arm-linux-gnueabihf/libpthread.so.0: undefined reference to `__libc_dl_error_tsd@GLIBC_PRIVATE'
collect2: error: ld returned 1 exit status
make[2]: *** [bin/ddsls] Error 1
make[1]: *** [src/tools/ddsls/CMakeFiles/ddsls.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
/root/sysroot/lib/arm-linux-gnueabihf/libpthread.so.0: undefined reference to `__libc_dl_error_tsd@GLIBC_PRIVATE'
collect2: error: ld returned 1 exit status
make[2]: *** [bin/pubsub] Error 1
make[1]: *** [src/tools/pubsub/CMakeFiles/pubsub.dir/all] Error 2
make: *** [all] Error 2
```
