### PR TITLE
OpenSSL 1.0.2 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -148,6 +148,8 @@ jobs:
     - <<: *linux_gcc8
       env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Debug, SSL=YES, SECURITY=YES, LIFESPAN=YES, DEADLINE=YES, GENERATOR="Unix Makefiles" ]
     - <<: *linux_gcc8
+      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Debug, SSL=YES, SECURITY=YES, LIFESPAN=YES, DEADLINE=YES, GENERATOR="Unix Makefiles", CONANFILE=conanfile102.txt ]
+    - <<: *linux_gcc8
       env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, SSL=YES, SECURITY=YES, LIFESPAN=YES, DEADLINE=YES, GENERATOR="Unix Makefiles" ]
     - <<: *linux_gcc8
       env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Debug, SSL=NO, SECURITY=YES, LIFESPAN=NO, DEADLINE=NO, GENERATOR="Unix Makefiles" ]
@@ -167,7 +169,7 @@ jobs:
     - <<: *osx_xcode
       env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, SSL=YES, SECURITY=YES, LIFESPAN=YES, DEADLINE=YES, GENERATOR="Unix Makefiles" ]
     - <<: *windows_vs2017
-      env: [ ARCH=x86, ASAN=none, BUILD_TYPE=Debug, SSL=YES, SECURITY=YES, LIFESPAN=YES, DEADLINE=YES, GENERATOR="Visual Studio 15 2017" ]
+      env: [ ARCH=x86, ASAN=none, BUILD_TYPE=Debug, SSL=YES, SECURITY=YES, LIFESPAN=YES, DEADLINE=YES, GENERATOR="Visual Studio 15 2017", CONANFILE=conanfile102.txt ]
     - <<: *windows_vs2017
       env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Debug, SSL=YES, SECURITY=YES, LIFESPAN=YES, DEADLINE=YES, GENERATOR="Visual Studio 15 2017 Win64" ]
     - <<: *windows_vs2017
@@ -197,7 +199,7 @@ script:
   - INSTALLPREFIX="$(pwd)/install"
   - mkdir build
   - cd build
-  - conan install -b missing -s arch=${ARCH} -s build_type=${BUILD_TYPE} ..
+  - conan install -b missing -s arch=${ARCH} -s build_type=${BUILD_TYPE} ../${CONANFILE:-conanfile.txt}
   - which trang && BUILD_SCHEMA=1 || BUILD_SCHEMA=0
   - cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
           -DCMAKE_INSTALL_PREFIX=${INSTALLPREFIX}

--- a/conanfile102.txt
+++ b/conanfile102.txt
@@ -1,0 +1,6 @@
+[requires]
+cunit/2.1-3@bincrafters/stable
+OpenSSL/1.0.2@conan/stable
+
+[generators]
+cmake

--- a/src/ddsrt/include/dds/ddsrt/xmlparser.h
+++ b/src/ddsrt/include/dds/ddsrt/xmlparser.h
@@ -12,6 +12,7 @@
 #ifndef DDSRT_XMLPARSER_H
 #define DDSRT_XMLPARSER_H
 
+#include <stdio.h>
 #include <stdint.h>
 
 #include "dds/export.h"

--- a/src/security/builtin_plugins/access_control/CMakeLists.txt
+++ b/src/security/builtin_plugins/access_control/CMakeLists.txt
@@ -26,6 +26,7 @@ generate_export_header(
         EXPORT_FILE_NAME "${CMAKE_CURRENT_BINARY_DIR}/include/dds/security/export.h"
 )
 
+target_link_libraries(dds_security_ac PRIVATE security_openssl)
 target_link_libraries(dds_security_ac PUBLIC ddsc)
 target_link_libraries(dds_security_ac PUBLIC OpenSSL::SSL)
 if(CMAKE_GENERATOR MATCHES "Visual Studio")
@@ -36,6 +37,7 @@ target_include_directories(dds_security_ac
     PUBLIC
         "$<BUILD_INTERFACE:$<TARGET_PROPERTY:security_api,INTERFACE_INCLUDE_DIRECTORIES>>"
         "$<BUILD_INTERFACE:$<TARGET_PROPERTY:security_core,INTERFACE_INCLUDE_DIRECTORIES>>"
+        "$<BUILD_INTERFACE:$<TARGET_PROPERTY:security_openssl,INTERFACE_INCLUDE_DIRECTORIES>>"
         "$<BUILD_INTERFACE:$<TARGET_PROPERTY:ddsrt,INTERFACE_INCLUDE_DIRECTORIES>>"
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
 )

--- a/src/security/builtin_plugins/access_control/src/access_control_objects.h
+++ b/src/security/builtin_plugins/access_control/src/access_control_objects.h
@@ -12,10 +12,10 @@
 #ifndef ACCESS_CONTROL_OBJECTS_H
 #define ACCESS_CONTROL_OBJECTS_H
 
-#include <openssl/x509.h>
 #include "dds/ddsrt/atomics.h"
 #include "dds/ddsrt/types.h"
 #include "dds/security/dds_security_api.h"
+#include "dds/security/openssl_support.h"
 
 #define ACCESS_CONTROL_OBJECT(o)            ((AccessControlObject *)(o))
 #define ACCESS_CONTROL_OBJECT_HANDLE(o)     ((o) ? ACCESS_CONTROL_OBJECT(o)->handle : DDS_SECURITY_HANDLE_NIL)

--- a/src/security/builtin_plugins/access_control/src/access_control_parser.c
+++ b/src/security/builtin_plugins/access_control/src/access_control_parser.c
@@ -11,11 +11,7 @@
  */
 #include <assert.h>
 #include <string.h>
-#include <openssl/x509.h>
-#include <openssl/pkcs7.h>
-#include <openssl/pem.h>
-#include <openssl/bio.h>
-#include <openssl/err.h>
+
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/misc.h"
 #include "dds/ddsrt/string.h"

--- a/src/security/builtin_plugins/access_control/src/access_control_utils.c
+++ b/src/security/builtin_plugins/access_control/src/access_control_utils.c
@@ -14,11 +14,7 @@
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <openssl/x509.h>
-#include <openssl/pkcs7.h>
-#include <openssl/pem.h>
-#include <openssl/bio.h>
-#include <openssl/err.h>
+
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/misc.h"
 #include "dds/ddsrt/string.h"
@@ -26,6 +22,7 @@
 #include "dds/ddsrt/types.h"
 #include "dds/security/dds_security_api.h"
 #include "dds/security/core/dds_security_utils.h"
+#include "dds/security/openssl_support.h"
 #include "access_control_utils.h"
 
 #define SEQ_ERR -1

--- a/src/security/builtin_plugins/access_control/src/access_control_utils.h
+++ b/src/security/builtin_plugins/access_control/src/access_control_utils.h
@@ -12,10 +12,10 @@
 #ifndef ACCESS_CONTROL_UTILS_H
 #define ACCESS_CONTROL_UTILS_H
 
-#include <openssl/x509.h>
 #include "dds/ddsrt/types.h"
-#include "dds/security/dds_security_api.h"
 #include "dds/security/export.h"
+#include "dds/security/dds_security_api.h"
+#include "dds/security/openssl_support.h"
 
 #define DDS_ACCESS_CONTROL_PLUGIN_CONTEXT "Access Control"
 

--- a/src/security/builtin_plugins/authentication/CMakeLists.txt
+++ b/src/security/builtin_plugins/authentication/CMakeLists.txt
@@ -31,6 +31,7 @@ generate_export_header(
         EXPORT_FILE_NAME "${CMAKE_CURRENT_BINARY_DIR}/include/dds/security/export.h"
 )
 
+target_link_libraries(dds_security_auth PRIVATE security_openssl)
 target_link_libraries(dds_security_auth PUBLIC ddsc)
 target_link_libraries(dds_security_auth PUBLIC OpenSSL::SSL)
 if(CMAKE_GENERATOR MATCHES "Visual Studio")
@@ -41,6 +42,7 @@ target_include_directories(dds_security_auth
     PUBLIC
         "$<BUILD_INTERFACE:$<TARGET_PROPERTY:security_api,INTERFACE_INCLUDE_DIRECTORIES>>"
         "$<BUILD_INTERFACE:$<TARGET_PROPERTY:security_core,INTERFACE_INCLUDE_DIRECTORIES>>"
+        "$<BUILD_INTERFACE:$<TARGET_PROPERTY:security_openssl,INTERFACE_INCLUDE_DIRECTORIES>>"
         "$<BUILD_INTERFACE:$<TARGET_PROPERTY:ddsrt,INTERFACE_INCLUDE_DIRECTORIES>>"
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../../../core/ddsi/include>"

--- a/src/security/builtin_plugins/authentication/src/auth_utils.h
+++ b/src/security/builtin_plugins/authentication/src/auth_utils.h
@@ -13,6 +13,13 @@
 #ifndef AUTH_UTILS_H
 #define AUTH_UTILS_H
 
+#ifdef _WIN32
+/* supposedly WinSock2 must be included before openssl 1.0.2 headers otherwise winsock will be used */
+#include <WinSock2.h>
+#endif
+#include <openssl/x509.h>
+#include <openssl/evp.h>
+
 #include "dds/security/dds_security_api.h"
 #include "dds/ddsrt/time.h"
 

--- a/src/security/builtin_plugins/cryptographic/CMakeLists.txt
+++ b/src/security/builtin_plugins/cryptographic/CMakeLists.txt
@@ -29,6 +29,7 @@ generate_export_header(
         EXPORT_FILE_NAME "${CMAKE_CURRENT_BINARY_DIR}/include/dds/security/export.h"
 )
 
+target_link_libraries(dds_security_crypto PRIVATE security_openssl)
 target_link_libraries(dds_security_crypto PUBLIC ddsc)
 target_link_libraries(dds_security_crypto PUBLIC OpenSSL::SSL)
 if(CMAKE_GENERATOR MATCHES "Visual Studio")
@@ -40,6 +41,7 @@ target_include_directories(dds_security_crypto
     PUBLIC
         "$<BUILD_INTERFACE:$<TARGET_PROPERTY:security_api,INTERFACE_INCLUDE_DIRECTORIES>>"
         "$<BUILD_INTERFACE:$<TARGET_PROPERTY:security_core,INTERFACE_INCLUDE_DIRECTORIES>>"
+        "$<BUILD_INTERFACE:$<TARGET_PROPERTY:security_openssl,INTERFACE_INCLUDE_DIRECTORIES>>"
         "$<BUILD_INTERFACE:$<TARGET_PROPERTY:ddsrt,INTERFACE_INCLUDE_DIRECTORIES>>"
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../../../core/ddsi/include>"

--- a/src/security/builtin_plugins/cryptographic/src/crypto_cipher.c
+++ b/src/security/builtin_plugins/cryptographic/src/crypto_cipher.c
@@ -10,10 +10,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
 #include <assert.h>
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
+
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/types.h"
+#include "dds/security/openssl_support.h"
 #include "crypto_defs.h"
 #include "crypto_utils.h"
 #include "crypto_cipher.h"

--- a/src/security/builtin_plugins/cryptographic/src/crypto_key_factory.c
+++ b/src/security/builtin_plugins/cryptographic/src/crypto_key_factory.c
@@ -11,11 +11,7 @@
  */
 #include <assert.h>
 #include <string.h>
-#include <openssl/rand.h>
-#include <openssl/sha.h>
-#include <openssl/hmac.h>
-#include <openssl/bio.h>
-#include <openssl/err.h>
+
 #include "dds/ddsrt/atomics.h"
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/sync.h"
@@ -25,6 +21,7 @@
 #include "dds/security/core/dds_security_utils.h"
 #include "dds/security/core/dds_security_serialize.h"
 #include "dds/security/core/shared_secret.h"
+#include "dds/security/openssl_support.h"
 #include "crypto_defs.h"
 #include "crypto_utils.h"
 #include "crypto_cipher.h"

--- a/src/security/builtin_plugins/cryptographic/src/crypto_utils.c
+++ b/src/security/builtin_plugins/cryptographic/src/crypto_utils.c
@@ -11,16 +11,14 @@
  */
 #include <assert.h>
 #include <string.h>
-#include <openssl/bio.h>
-#include <openssl/err.h>
-#include <openssl/hmac.h>
-#include <openssl/rand.h>
+
 #include "dds/ddsrt/bswap.h"
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/string.h"
 #include "dds/ddsrt/types.h"
 #include "dds/security/dds_security_api.h"
 #include "dds/security/core/dds_security_utils.h"
+#include "dds/security/openssl_support.h"
 #include "crypto_defs.h"
 #include "crypto_utils.h"
 

--- a/src/security/builtin_plugins/tests/CMakeLists.txt
+++ b/src/security/builtin_plugins/tests/CMakeLists.txt
@@ -63,29 +63,22 @@ add_cunit_executable(cunit_security_plugins ${security_auth_test_sources} ${secu
 
 target_include_directories(
   cunit_security_plugins PRIVATE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../access_control/src/>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../cryptographic/src/>"
   "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src/include/>"
   "$<BUILD_INTERFACE:$<TARGET_PROPERTY:security_api,INTERFACE_INCLUDE_DIRECTORIES>>"
   "$<BUILD_INTERFACE:$<TARGET_PROPERTY:security_core,INTERFACE_INCLUDE_DIRECTORIES>>"
+  "$<BUILD_INTERFACE:$<TARGET_PROPERTY:security_openssl,INTERFACE_INCLUDE_DIRECTORIES>>"
   "$<BUILD_INTERFACE:$<TARGET_PROPERTY:ddsrt,INTERFACE_INCLUDE_DIRECTORIES>>"
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>"
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>"
 )
 target_link_libraries(cunit_security_plugins PRIVATE ddsc security_api dds_security_ac dds_security_crypto)
+target_link_libraries(cunit_security_plugins PRIVATE security_openssl)
 target_link_libraries(cunit_security_plugins PRIVATE OpenSSL::SSL)
 if(CMAKE_GENERATOR MATCHES "Visual Studio")
   set_target_properties(cunit_security_plugins PROPERTIES LINK_FLAGS "/ignore:4099")
 endif()
-
-target_include_directories(
-  cunit_security_plugins PRIVATE
-      "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../access_control/src/>"
-      "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../cryptographic/src/>"
-      "$<BUILD_INTERFACE:$<TARGET_PROPERTY:security_api,INTERFACE_INCLUDE_DIRECTORIES>>"
-      "$<BUILD_INTERFACE:$<TARGET_PROPERTY:security_core,INTERFACE_INCLUDE_DIRECTORIES>>"
-      "$<BUILD_INTERFACE:$<TARGET_PROPERTY:ddsrt,INTERFACE_INCLUDE_DIRECTORIES>>"
-      "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>"
-      "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>"
-)
 
 set(CUnit_builtin_plugins_tests_dir "${CMAKE_CURRENT_LIST_DIR}")
 set(CUnit_build_dir "${CMAKE_CURRENT_BINARY_DIR}")

--- a/src/security/builtin_plugins/tests/common/src/crypto_helper.c
+++ b/src/security/builtin_plugins/tests/common/src/crypto_helper.c
@@ -10,10 +10,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
 #include <assert.h>
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
-#include <openssl/bio.h>
-#include <openssl/err.h>
 
 #include "dds/ddsrt/bswap.h"
 #include "dds/ddsrt/endian.h"
@@ -25,6 +21,7 @@
 #include "dds/security/core/dds_security_serialize.h"
 #include "dds/security/core/dds_security_utils.h"
 #include "dds/security/core/shared_secret.h"
+#include "dds/security/openssl_support.h"
 #include "CUnit/CUnit.h"
 #include "CUnit/Test.h"
 #include "crypto_helper.h"

--- a/src/security/builtin_plugins/tests/common/src/handshake_helper.c
+++ b/src/security/builtin_plugins/tests/common/src/handshake_helper.c
@@ -9,31 +9,21 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
-#include "handshake_helper.h"
-#include "dds/security/core/dds_security_serialize.h"
-#include "dds/ddsrt/string.h"
-#include "dds/ddsrt/heap.h"
 #include <stdio.h>
 #include <string.h>
+#include <assert.h>
+
+#include "dds/ddsrt/string.h"
+#include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/environ.h"
-#include "CUnit/CUnit.h"
-#include "CUnit/Test.h"
-#include "assert.h"
 #include "dds/ddsrt/misc.h"
 #include "dds/security/core/shared_secret.h"
-
-#if OPENSSL_VERSION_NUMBER >= 0x1000200fL
-#define AUTH_INCLUDE_EC
-#include <openssl/ec.h>
-#include <dds/security/core/dds_security_utils.h>
-
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
-#define AUTH_INCLUDE_DH_ACCESSORS
-#endif
-#else
-#error "version not found"
-#endif
-
+#include "dds/security/openssl_support.h"
+#include "dds/security/core/dds_security_serialize.h"
+#include "dds/security/core/dds_security_utils.h"
+#include "CUnit/CUnit.h"
+#include "CUnit/Test.h"
+#include "handshake_helper.h"
 
 const BIGNUM *
 dh_get_public_key(

--- a/src/security/builtin_plugins/tests/common/src/handshake_helper.h
+++ b/src/security/builtin_plugins/tests/common/src/handshake_helper.h
@@ -15,15 +15,7 @@
 
 #include "dds/security/dds_security_api.h"
 #include "dds/security/core/dds_security_serialize.h"
-
-#include <openssl/bn.h>
-#include <openssl/asn1.h>
-#include <openssl/x509.h>
-#include <openssl/x509_vfy.h>
-#include <openssl/pem.h>
-#include <openssl/bio.h>
-#include <openssl/err.h>
-#include <openssl/evp.h>
+#include "dds/security/openssl_support.h"
 
 const BIGNUM *
 dh_get_public_key(

--- a/src/security/builtin_plugins/tests/create_local_datareader_crypto_tokens/src/create_local_datareader_crypto_tokens_utests.c
+++ b/src/security/builtin_plugins/tests/create_local_datareader_crypto_tokens/src/create_local_datareader_crypto_tokens_utests.c
@@ -9,11 +9,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
-#include <openssl/bio.h>
-#include <openssl/err.h>
-
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/string.h"
 #include "dds/ddsrt/types.h"
@@ -22,6 +17,7 @@
 #include "dds/security/core/dds_security_serialize.h"
 #include "dds/security/core/dds_security_utils.h"
 #include "dds/security/core/shared_secret.h"
+#include "dds/security/openssl_support.h"
 #include "CUnit/CUnit.h"
 #include "CUnit/Test.h"
 #include "common/src/loader.h"

--- a/src/security/builtin_plugins/tests/create_local_datawriter_crypto_tokens/src/create_local_datawriter_crypto_tokens_utests.c
+++ b/src/security/builtin_plugins/tests/create_local_datawriter_crypto_tokens/src/create_local_datawriter_crypto_tokens_utests.c
@@ -9,11 +9,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
-#include <openssl/bio.h>
-#include <openssl/err.h>
-
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/string.h"
 #include "dds/ddsrt/types.h"
@@ -22,6 +17,7 @@
 #include "dds/security/core/dds_security_serialize.h"
 #include "dds/security/core/dds_security_utils.h"
 #include "dds/security/core/shared_secret.h"
+#include "dds/security/openssl_support.h"
 #include "CUnit/CUnit.h"
 #include "CUnit/Test.h"
 #include "common/src/loader.h"

--- a/src/security/builtin_plugins/tests/create_local_participant_crypto_tokens/src/create_local_participant_crypto_tokens_utests.c
+++ b/src/security/builtin_plugins/tests/create_local_participant_crypto_tokens/src/create_local_participant_crypto_tokens_utests.c
@@ -9,11 +9,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
-#include <openssl/bio.h>
-#include <openssl/err.h>
-
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/string.h"
 #include "dds/ddsrt/types.h"
@@ -22,6 +17,7 @@
 #include "dds/security/core/dds_security_serialize.h"
 #include "dds/security/core/dds_security_utils.h"
 #include "dds/security/core/shared_secret.h"
+#include "dds/security/openssl_support.h"
 #include "CUnit/CUnit.h"
 #include "CUnit/Test.h"
 #include "common/src/loader.h"

--- a/src/security/builtin_plugins/tests/decode_datareader_submessage/src/decode_datareader_submessage_utests.c
+++ b/src/security/builtin_plugins/tests/decode_datareader_submessage/src/decode_datareader_submessage_utests.c
@@ -9,12 +9,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
-#include <assert.h>
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
-#include <openssl/bio.h>
-#include <openssl/err.h>
-
 #include "dds/ddsrt/bswap.h"
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/string.h"
@@ -24,6 +18,7 @@
 #include "dds/security/core/dds_security_serialize.h"
 #include "dds/security/core/dds_security_utils.h"
 #include "dds/security/core/shared_secret.h"
+#include "dds/security/openssl_support.h"
 #include "CUnit/CUnit.h"
 #include "CUnit/Test.h"
 #include "common/src/loader.h"

--- a/src/security/builtin_plugins/tests/decode_datawriter_submessage/src/decode_datawriter_submessage_utests.c
+++ b/src/security/builtin_plugins/tests/decode_datawriter_submessage/src/decode_datawriter_submessage_utests.c
@@ -10,10 +10,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
 #include <assert.h>
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
-#include <openssl/bio.h>
-#include <openssl/err.h>
 
 #include "dds/ddsrt/bswap.h"
 #include "dds/ddsrt/heap.h"
@@ -25,6 +21,7 @@
 #include "dds/security/core/dds_security_serialize.h"
 #include "dds/security/core/dds_security_utils.h"
 #include "dds/security/core/shared_secret.h"
+#include "dds/security/openssl_support.h"
 #include "CUnit/CUnit.h"
 #include "CUnit/Test.h"
 #include "common/src/loader.h"

--- a/src/security/builtin_plugins/tests/decode_rtps_message/src/decode_rtps_message_utests.c
+++ b/src/security/builtin_plugins/tests/decode_rtps_message/src/decode_rtps_message_utests.c
@@ -10,10 +10,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
 #include <assert.h>
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
-#include <openssl/bio.h>
-#include <openssl/err.h>
 
 #include "dds/ddsrt/bswap.h"
 #include "dds/ddsrt/endian.h"
@@ -25,6 +21,7 @@
 #include "dds/security/core/dds_security_serialize.h"
 #include "dds/security/core/dds_security_utils.h"
 #include "dds/security/core/shared_secret.h"
+#include "dds/security/openssl_support.h"
 #include "CUnit/CUnit.h"
 #include "CUnit/Test.h"
 #include "common/src/loader.h"

--- a/src/security/builtin_plugins/tests/decode_serialized_payload/src/decode_serialized_payload_utests.c
+++ b/src/security/builtin_plugins/tests/decode_serialized_payload/src/decode_serialized_payload_utests.c
@@ -11,11 +11,6 @@
  */
 #include <assert.h>
 
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
-#include <openssl/bio.h>
-#include <openssl/err.h>
-
 #include "dds/ddsrt/bswap.h"
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/string.h"
@@ -25,6 +20,7 @@
 #include "dds/security/core/dds_security_serialize.h"
 #include "dds/security/core/dds_security_utils.h"
 #include "dds/security/core/shared_secret.h"
+#include "dds/security/openssl_support.h"
 #include "CUnit/CUnit.h"
 #include "CUnit/Test.h"
 #include "common/src/loader.h"

--- a/src/security/builtin_plugins/tests/encode_datareader_submessage/src/encode_datareader_submessage_utests.c
+++ b/src/security/builtin_plugins/tests/encode_datareader_submessage/src/encode_datareader_submessage_utests.c
@@ -10,10 +10,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
 #include <assert.h>
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
-#include <openssl/bio.h>
-#include <openssl/err.h>
 
 #include "dds/ddsrt/bswap.h"
 #include "dds/ddsrt/endian.h"
@@ -25,6 +21,7 @@
 #include "dds/security/core/dds_security_serialize.h"
 #include "dds/security/core/dds_security_utils.h"
 #include "dds/security/core/shared_secret.h"
+#include "dds/security/openssl_support.h"
 #include "CUnit/CUnit.h"
 #include "CUnit/Test.h"
 #include "common/src/loader.h"

--- a/src/security/builtin_plugins/tests/encode_datawriter_submessage/src/encode_datawriter_submessage_utests.c
+++ b/src/security/builtin_plugins/tests/encode_datawriter_submessage/src/encode_datawriter_submessage_utests.c
@@ -10,10 +10,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
 #include <assert.h>
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
-#include <openssl/bio.h>
-#include <openssl/err.h>
 
 #include "dds/ddsrt/bswap.h"
 #include "dds/ddsrt/endian.h"
@@ -25,6 +21,7 @@
 #include "dds/security/core/dds_security_serialize.h"
 #include "dds/security/core/dds_security_utils.h"
 #include "dds/security/core/shared_secret.h"
+#include "dds/security/openssl_support.h"
 #include "CUnit/CUnit.h"
 #include "CUnit/Test.h"
 #include "common/src/loader.h"

--- a/src/security/builtin_plugins/tests/encode_rtps_message/src/encode_rtps_message_utests.c
+++ b/src/security/builtin_plugins/tests/encode_rtps_message/src/encode_rtps_message_utests.c
@@ -10,10 +10,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
 #include <assert.h>
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
-#include <openssl/bio.h>
-#include <openssl/err.h>
 
 #include "dds/ddsrt/bswap.h"
 #include "dds/ddsrt/heap.h"
@@ -24,6 +20,7 @@
 #include "dds/security/core/dds_security_serialize.h"
 #include "dds/security/core/dds_security_utils.h"
 #include "dds/security/core/shared_secret.h"
+#include "dds/security/openssl_support.h"
 #include "CUnit/CUnit.h"
 #include "CUnit/Test.h"
 #include "common/src/loader.h"

--- a/src/security/builtin_plugins/tests/encode_serialized_payload/src/encode_serialized_payload_utests.c
+++ b/src/security/builtin_plugins/tests/encode_serialized_payload/src/encode_serialized_payload_utests.c
@@ -10,10 +10,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
 #include <assert.h>
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
-#include <openssl/bio.h>
-#include <openssl/err.h>
 
 #include "dds/ddsrt/bswap.h"
 #include "dds/ddsrt/heap.h"
@@ -24,6 +20,7 @@
 #include "dds/security/core/dds_security_serialize.h"
 #include "dds/security/core/dds_security_utils.h"
 #include "dds/security/core/shared_secret.h"
+#include "dds/security/openssl_support.h"
 #include "CUnit/CUnit.h"
 #include "CUnit/Test.h"
 #include "common/src/loader.h"

--- a/src/security/builtin_plugins/tests/get_authenticated_peer_credential_token/src/get_authenticated_peer_credential_token_utests.c
+++ b/src/security/builtin_plugins/tests/get_authenticated_peer_credential_token/src/get_authenticated_peer_credential_token_utests.c
@@ -10,32 +10,23 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
 
-/* CUnit includes. */
-
-#include "CUnit/CUnit.h"
-#include "CUnit/Test.h"
-#include "assert.h"
-/* Test helper includes. */
-#include "common/src/loader.h"
-#include "common/src/handshake_helper.h"
-
-#include "dds/security/dds_security_api.h"
-#include <openssl/opensslv.h>
-#include <openssl/sha.h>
-#include <openssl/x509.h>
-#include <openssl/pem.h>
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
 
 #include "dds/ddsrt/string.h"
 #include "dds/ddsrt/heap.h"
-#include <stdio.h>
-#include <string.h>
 #include "dds/ddsrt/environ.h"
-
 #include "dds/ddsrt/bswap.h"
 #include "dds/ddsrt/misc.h"
-#include "dds/security/core/dds_security_serialize.h"
 #include "dds/security/dds_security_api.h"
+#include "dds/security/core/dds_security_serialize.h"
 #include "dds/security/core/dds_security_utils.h"
+#include "dds/security/openssl_support.h"
+#include "CUnit/CUnit.h"
+#include "CUnit/Test.h"
+#include "common/src/loader.h"
+#include "common/src/handshake_helper.h"
 
 #define HANDSHAKE_SIGNATURE_SIZE 6
 
@@ -884,6 +875,7 @@ release_remote_identities(void)
 CU_Init(ddssec_builtin_get_authenticated_peer_credential)
 {
     int result = 0;
+    dds_openssl_init ();
 
     /* Only need the authentication plugin. */
     g_plugins = load_plugins(NULL   /* Access Control */,

--- a/src/security/builtin_plugins/tests/get_permissions_credential_token/src/get_permissions_credential_token_utests.c
+++ b/src/security/builtin_plugins/tests/get_permissions_credential_token/src/get_permissions_credential_token_utests.c
@@ -11,10 +11,6 @@
  */
 #include <assert.h>
 #include <string.h>
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
-#include <openssl/bio.h>
-#include <openssl/err.h>
 
 #include "dds/ddsrt/environ.h"
 #include "dds/ddsrt/heap.h"
@@ -23,6 +19,7 @@
 #include "dds/ddsrt/types.h"
 #include "dds/security/dds_security_api.h"
 #include "dds/security/core/dds_security_utils.h"
+#include "dds/security/openssl_support.h"
 #include "CUnit/CUnit.h"
 #include "CUnit/Test.h"
 #include "common/src/loader.h"

--- a/src/security/builtin_plugins/tests/get_permissions_token/src/get_permissions_token_utests.c
+++ b/src/security/builtin_plugins/tests/get_permissions_token/src/get_permissions_token_utests.c
@@ -10,10 +10,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
 #include <assert.h>
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
-#include <openssl/bio.h>
-#include <openssl/err.h>
 
 #include "dds/ddsrt/environ.h"
 #include "dds/ddsrt/heap.h"
@@ -22,6 +18,7 @@
 #include "dds/ddsrt/types.h"
 #include "dds/security/dds_security_api.h"
 #include "dds/security/core/dds_security_utils.h"
+#include "dds/security/openssl_support.h"
 #include "CUnit/CUnit.h"
 #include "CUnit/Test.h"
 #include "common/src/loader.h"

--- a/src/security/builtin_plugins/tests/get_xxx_sec_attributes/src/get_xxx_sec_attributes_utests.c
+++ b/src/security/builtin_plugins/tests/get_xxx_sec_attributes/src/get_xxx_sec_attributes_utests.c
@@ -10,10 +10,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
 #include <assert.h>
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
-#include <openssl/bio.h>
-#include <openssl/err.h>
 
 #include "dds/ddsrt/environ.h"
 #include "dds/ddsrt/heap.h"
@@ -22,6 +18,7 @@
 #include "dds/ddsrt/types.h"
 #include "dds/security/dds_security_api.h"
 #include "dds/security/core/dds_security_utils.h"
+#include "dds/security/openssl_support.h"
 #include "CUnit/CUnit.h"
 #include "CUnit/Test.h"
 #include "common/src/loader.h"

--- a/src/security/builtin_plugins/tests/listeners_access_control/src/listeners_access_control_utests.c
+++ b/src/security/builtin_plugins/tests/listeners_access_control/src/listeners_access_control_utests.c
@@ -10,12 +10,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
 #include <assert.h>
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
-#include <openssl/bio.h>
-#include <openssl/err.h>
-#include <openssl/pkcs7.h>
-#include <openssl/pem.h>
 
 #include "dds/ddsrt/environ.h"
 #include "dds/ddsrt/heap.h"
@@ -25,18 +19,11 @@
 #include "dds/ddsrt/types.h"
 #include "dds/security/dds_security_api.h"
 #include "dds/security/core/dds_security_utils.h"
+#include "dds/security/openssl_support.h"
 #include "CUnit/CUnit.h"
 #include "CUnit/Test.h"
 #include "common/src/loader.h"
 #include "config_env.h"
-
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L && OPENSSL_VERSION_NUMBER < 0x10100000L
-#define REMOVE_THREAD_STATE() ERR_remove_thread_state(NULL);
-#elif OPENSSL_VERSION_NUMBER < 0x10000000L
-#define REMOVE_THREAD_STATE() ERR_remove_state(0);
-#else
-#define REMOVE_THREAD_STATE()
-#endif
 
 static const char *ACCESS_PERMISSIONS_TOKEN_ID = "DDS:Access:Permissions:1.0";
 static const char *AUTH_PROTOCOL_CLASS_ID = "DDS:Auth:PKI-DH:1.0";
@@ -549,8 +536,7 @@ CU_Init(ddssec_builtin_listeners_access_control)
   } else {
     set_path_to_etc_dir();
     set_path_build_dir();
-    OpenSSL_add_all_algorithms();
-    ERR_load_crypto_strings();
+    dds_openssl_init ();
   }
 
   return res;
@@ -560,11 +546,6 @@ CU_Clean(ddssec_builtin_listeners_access_control)
 {
   unload_plugins(plugins);
   ddsrt_free(g_path_to_etc_dir);
-  EVP_cleanup();
-  CRYPTO_cleanup_all_ex_data();
-  REMOVE_THREAD_STATE();
-  ERR_free_strings();
-
   return 0;
 }
 

--- a/src/security/builtin_plugins/tests/preprocess_secure_submsg/src/preprocess_secure_submsg_utests.c
+++ b/src/security/builtin_plugins/tests/preprocess_secure_submsg/src/preprocess_secure_submsg_utests.c
@@ -9,11 +9,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
-#include <openssl/bio.h>
-#include <openssl/err.h>
-
 #include "dds/ddsrt/bswap.h"
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/string.h"
@@ -23,6 +18,7 @@
 #include "dds/security/core/dds_security_serialize.h"
 #include "dds/security/core/dds_security_utils.h"
 #include "dds/security/core/shared_secret.h"
+#include "dds/security/openssl_support.h"
 #include "CUnit/CUnit.h"
 #include "CUnit/Test.h"
 #include "common/src/loader.h"

--- a/src/security/builtin_plugins/tests/process_handshake/src/process_handshake_utests.c
+++ b/src/security/builtin_plugins/tests/process_handshake/src/process_handshake_utests.c
@@ -1,36 +1,20 @@
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
 
-
-/* CUnit includes. */
-#include "common/src/handshake_helper.h"
-
-/* Test helper includes. */
-#include "common/src/loader.h"
-
-/* Private header include */
-#include "dds/security/dds_security_api.h"
-#include "dds/security/core/dds_security_serialize.h"
-#include "dds/security/core/dds_security_utils.h"
-#include "dds/security/dds_security_api.h"
 #include "dds/ddsrt/bswap.h"
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/string.h"
-#include <stdio.h>
-#include <string.h>
 #include "dds/ddsrt/environ.h"
+#include "dds/security/dds_security_api.h"
+#include "dds/security/core/dds_security_serialize.h"
+#include "dds/security/core/dds_security_utils.h"
+#include "dds/security/openssl_support.h"
+#include "common/src/handshake_helper.h"
+#include "common/src/loader.h"
 #include "CUnit/CUnit.h"
 #include "CUnit/Test.h"
-#include "assert.h"
-
-#include <openssl/opensslv.h>
-#include <openssl/sha.h>
-#include <openssl/x509.h>
-#include <openssl/pem.h>
-#include <config_env.h>
-
-
-#include "dds/security/core/dds_security_serialize.h"
-#include "dds/security/dds_security_api.h"
-#include "dds/security/core/dds_security_utils.h"
+#include "config_env.h"
 
 #define HANDSHAKE_SIGNATURE_SIZE 6
 
@@ -1003,6 +987,7 @@ release_remote_identities(void)
 CU_Init(ddssec_builtin_process_handshake)
 {
     int result = 0;
+    dds_openssl_init ();
 
     /* Only need the authentication plugin. */
     plugins = load_plugins(NULL   /* Access Control */,

--- a/src/security/builtin_plugins/tests/register_local_datareader/src/register_local_datareader_utests.c
+++ b/src/security/builtin_plugins/tests/register_local_datareader/src/register_local_datareader_utests.c
@@ -11,11 +11,6 @@
  */
 #include <assert.h>
 
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
-#include <openssl/bio.h>
-#include <openssl/err.h>
-
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/string.h"
 #include "dds/ddsrt/types.h"
@@ -24,6 +19,7 @@
 #include "dds/security/core/dds_security_serialize.h"
 #include "dds/security/core/dds_security_utils.h"
 #include "dds/security/core/shared_secret.h"
+#include "dds/security/openssl_support.h"
 #include "CUnit/CUnit.h"
 #include "CUnit/Test.h"
 #include "common/src/loader.h"

--- a/src/security/builtin_plugins/tests/register_local_datawriter/src/register_local_datawriter_utests.c
+++ b/src/security/builtin_plugins/tests/register_local_datawriter/src/register_local_datawriter_utests.c
@@ -11,11 +11,6 @@
  */
 #include <assert.h>
 
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
-#include <openssl/bio.h>
-#include <openssl/err.h>
-
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/string.h"
 #include "dds/ddsrt/types.h"
@@ -24,6 +19,7 @@
 #include "dds/security/core/dds_security_serialize.h"
 #include "dds/security/core/dds_security_utils.h"
 #include "dds/security/core/shared_secret.h"
+#include "dds/security/openssl_support.h"
 #include "CUnit/CUnit.h"
 #include "CUnit/Test.h"
 #include "common/src/loader.h"

--- a/src/security/builtin_plugins/tests/register_local_participant/src/register_local_participant_utests.c
+++ b/src/security/builtin_plugins/tests/register_local_participant/src/register_local_participant_utests.c
@@ -11,11 +11,6 @@
  */
 #include <assert.h>
 
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
-#include <openssl/bio.h>
-#include <openssl/err.h>
-
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/string.h"
 #include "dds/ddsrt/types.h"
@@ -24,6 +19,7 @@
 #include "dds/security/core/dds_security_serialize.h"
 #include "dds/security/core/dds_security_utils.h"
 #include "dds/security/core/shared_secret.h"
+#include "dds/security/openssl_support.h"
 #include "CUnit/CUnit.h"
 #include "CUnit/Test.h"
 #include "common/src/loader.h"

--- a/src/security/builtin_plugins/tests/register_matched_remote_datareader/src/register_matched_remote_datareader_utests.c
+++ b/src/security/builtin_plugins/tests/register_matched_remote_datareader/src/register_matched_remote_datareader_utests.c
@@ -11,11 +11,6 @@
  */
 #include <assert.h>
 
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
-#include <openssl/bio.h>
-#include <openssl/err.h>
-
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/string.h"
 #include "dds/ddsrt/types.h"
@@ -24,6 +19,7 @@
 #include "dds/security/core/dds_security_serialize.h"
 #include "dds/security/core/dds_security_utils.h"
 #include "dds/security/core/shared_secret.h"
+#include "dds/security/openssl_support.h"
 #include "CUnit/CUnit.h"
 #include "CUnit/Test.h"
 #include "common/src/loader.h"

--- a/src/security/builtin_plugins/tests/register_matched_remote_datawriter/src/register_matched_remote_datawriter_utests.c
+++ b/src/security/builtin_plugins/tests/register_matched_remote_datawriter/src/register_matched_remote_datawriter_utests.c
@@ -11,11 +11,6 @@
  */
 #include <assert.h>
 
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
-#include <openssl/bio.h>
-#include <openssl/err.h>
-
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/string.h"
 #include "dds/ddsrt/types.h"
@@ -24,6 +19,7 @@
 #include "dds/security/core/dds_security_serialize.h"
 #include "dds/security/core/dds_security_utils.h"
 #include "dds/security/core/shared_secret.h"
+#include "dds/security/openssl_support.h"
 #include "CUnit/CUnit.h"
 #include "CUnit/Test.h"
 #include "common/src/loader.h"

--- a/src/security/builtin_plugins/tests/register_matched_remote_participant/src/register_matched_remote_participant_utests.c
+++ b/src/security/builtin_plugins/tests/register_matched_remote_participant/src/register_matched_remote_participant_utests.c
@@ -9,11 +9,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
-#include <openssl/bio.h>
-#include <openssl/err.h>
-
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/string.h"
 #include "dds/ddsrt/types.h"
@@ -22,6 +17,7 @@
 #include "dds/security/core/dds_security_serialize.h"
 #include "dds/security/core/dds_security_utils.h"
 #include "dds/security/core/shared_secret.h"
+#include "dds/security/openssl_support.h"
 #include "CUnit/CUnit.h"
 #include "CUnit/Test.h"
 #include "common/src/loader.h"

--- a/src/security/builtin_plugins/tests/set_remote_datareader_crypto_tokens/src/set_remote_datareader_crypto_tokens_utests.c
+++ b/src/security/builtin_plugins/tests/set_remote_datareader_crypto_tokens/src/set_remote_datareader_crypto_tokens_utests.c
@@ -9,11 +9,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
-#include <openssl/bio.h>
-#include <openssl/err.h>
-
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/string.h"
 #include "dds/ddsrt/types.h"
@@ -22,6 +17,7 @@
 #include "dds/security/core/dds_security_serialize.h"
 #include "dds/security/core/dds_security_utils.h"
 #include "dds/security/core/shared_secret.h"
+#include "dds/security/openssl_support.h"
 #include "CUnit/CUnit.h"
 #include "CUnit/Test.h"
 #include "common/src/loader.h"

--- a/src/security/builtin_plugins/tests/set_remote_datawriter_crypto_tokens/src/set_remote_datawriter_crypto_tokens_utests.c
+++ b/src/security/builtin_plugins/tests/set_remote_datawriter_crypto_tokens/src/set_remote_datawriter_crypto_tokens_utests.c
@@ -9,11 +9,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
-#include <openssl/bio.h>
-#include <openssl/err.h>
-
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/string.h"
 #include "dds/ddsrt/types.h"
@@ -22,6 +17,7 @@
 #include "dds/security/core/dds_security_serialize.h"
 #include "dds/security/core/dds_security_utils.h"
 #include "dds/security/core/shared_secret.h"
+#include "dds/security/openssl_support.h"
 #include "CUnit/CUnit.h"
 #include "CUnit/Test.h"
 #include "common/src/loader.h"

--- a/src/security/builtin_plugins/tests/set_remote_participant_crypto_tokens/src/set_remote_participant_crypto_tokens_utests.c
+++ b/src/security/builtin_plugins/tests/set_remote_participant_crypto_tokens/src/set_remote_participant_crypto_tokens_utests.c
@@ -9,11 +9,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
-#include <openssl/bio.h>
-#include <openssl/err.h>
-
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/string.h"
 #include "dds/ddsrt/types.h"
@@ -22,6 +17,7 @@
 #include "dds/security/core/dds_security_serialize.h"
 #include "dds/security/core/dds_security_utils.h"
 #include "dds/security/core/shared_secret.h"
+#include "dds/security/openssl_support.h"
 #include "CUnit/CUnit.h"
 #include "CUnit/Test.h"
 #include "common/src/loader.h"

--- a/src/security/builtin_plugins/tests/validate_begin_handshake_reply/src/validate_begin_handshake_reply_utests.c
+++ b/src/security/builtin_plugins/tests/validate_begin_handshake_reply/src/validate_begin_handshake_reply_utests.c
@@ -1,35 +1,19 @@
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
 
-
-
-
-/* CUnit includes. */
-
-
-/* Test helper includes. */
-#include "common/src/loader.h"
-#include "config_env.h"
-
-/* Private header include */
-#include <openssl/opensslv.h>
-#include <openssl/sha.h>
-#include <openssl/x509.h>
-#include <openssl/pem.h>
-#include <openssl/asn1.h>
-#include <openssl/err.h>
-
-#include "dds/security/dds_security_api.h"
+#include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/string.h"
+#include "dds/ddsrt/bswap.h"
+#include "dds/ddsrt/environ.h"
 #include "dds/security/core/dds_security_serialize.h"
 #include "dds/security/core/dds_security_utils.h"
 #include "dds/security/dds_security_api.h"
-#include "dds/ddsrt/heap.h"
-#include "dds/ddsrt/string.h"
-#include <stdio.h>
-#include <string.h>
-#include "dds/ddsrt/bswap.h"
-#include "dds/ddsrt/environ.h"
+#include "dds/security/openssl_support.h"
 #include "CUnit/CUnit.h"
 #include "CUnit/Test.h"
-#include "assert.h"
+#include "common/src/loader.h"
+#include "config_env.h"
 
 static const char * AUTH_PROTOCOL_CLASS_ID          = "DDS:Auth:PKI-DH:1.0";
 static const char * PERM_ACCESS_CLASS_ID            = "DDS:Access:Permissions:1.0";

--- a/src/security/builtin_plugins/tests/validate_begin_handshake_request/src/validate_begin_handshake_request_utests.c
+++ b/src/security/builtin_plugins/tests/validate_begin_handshake_request/src/validate_begin_handshake_request_utests.c
@@ -22,6 +22,10 @@
 
 /* Private header include */
 
+#ifdef _WIN32
+/* supposedly WinSock2 must be included before openssl 1.0.2 headers otherwise winsock will be used */
+#include <WinSock2.h>
+#endif
 #include <openssl/opensslv.h>
 
 static const char * AUTH_PROTOCOL_CLASS_ID          = "DDS:Auth:PKI-DH:1.0";

--- a/src/security/builtin_plugins/tests/validate_local_identity/src/validate_local_identity_utests.c
+++ b/src/security/builtin_plugins/tests/validate_local_identity/src/validate_local_identity_utests.c
@@ -16,7 +16,8 @@
 
 
 #include "dds/security/dds_security_api.h"
-#include <openssl/opensslv.h>
+#include "dds/security/openssl_support.h"
+
 #include <dds/ddsrt/heap.h>
 #include <dds/ddsrt/string.h>
 #include <config_env.h>

--- a/src/security/builtin_plugins/tests/validate_local_permissions/src/validate_local_permissions_utests.c
+++ b/src/security/builtin_plugins/tests/validate_local_permissions/src/validate_local_permissions_utests.c
@@ -10,10 +10,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
 #include <assert.h>
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
-#include <openssl/bio.h>
-#include <openssl/err.h>
 
 #include "dds/ddsrt/environ.h"
 #include "dds/ddsrt/heap.h"
@@ -22,6 +18,7 @@
 #include "dds/ddsrt/types.h"
 #include "dds/security/dds_security_api.h"
 #include "dds/security/core/dds_security_utils.h"
+#include "dds/security/openssl_support.h"
 #include "CUnit/CUnit.h"
 #include "CUnit/Test.h"
 #include "common/src/loader.h"

--- a/src/security/builtin_plugins/tests/validate_remote_permissions/src/validate_remote_permissions_utests.c
+++ b/src/security/builtin_plugins/tests/validate_remote_permissions/src/validate_remote_permissions_utests.c
@@ -10,10 +10,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
 #include <assert.h>
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
-#include <openssl/bio.h>
-#include <openssl/err.h>
 
 #include "dds/ddsrt/environ.h"
 #include "dds/ddsrt/heap.h"
@@ -22,6 +18,7 @@
 #include "dds/ddsrt/types.h"
 #include "dds/security/dds_security_api.h"
 #include "dds/security/core/dds_security_utils.h"
+#include "dds/security/openssl_support.h"
 #include "CUnit/CUnit.h"
 #include "CUnit/Test.h"
 #include "common/src/loader.h"

--- a/src/security/core/include/dds/security/core/dds_security_utils.h
+++ b/src/security/core/include/dds/security/core/dds_security_utils.h
@@ -17,6 +17,7 @@
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdbool.h>
+
 #include "dds/export.h"
 #include "dds/ddsrt/strtol.h"
 #include "dds/ddsrt/time.h"
@@ -279,17 +280,6 @@ DDS_Security_Exception_set(
          int minor_code,
          const char *fmt,
          ...);
-
-
-#ifdef DDSI_INCLUDE_SSL
-DDS_EXPORT void
-DDS_Security_Exception_set_with_openssl_error(
-         DDS_Security_SecurityException *ex,
-         const char *context,
-         int code,
-         int minor_code,
-         const char *fmt);
-#endif
 
 DDS_EXPORT void
 DDS_Security_Exception_reset(

--- a/src/security/core/src/dds_security_utils.c
+++ b/src/security/core/src/dds_security_utils.c
@@ -13,19 +13,14 @@
 #include <assert.h>
 #include <string.h>
 #include <stdarg.h>
+#include <stdlib.h>
 #include <stdio.h>
+
+#include "dds/ddsrt/string.h"
+#include "dds/ddsrt/misc.h"
 #include "dds/security/dds_security_api.h"
 #include "dds/security/core/dds_security_utils.h"
 #include "dds/ddsrt/heap.h"
-#include "stdlib.h"
-#include "stdarg.h"
-#include "dds/ddsrt/string.h"
-#include "dds/ddsrt/misc.h"
-
-#ifdef DDSI_INCLUDE_SSL
-#include <openssl/bio.h>
-#include <openssl/err.h>
-#endif
 
 DDS_Security_BinaryProperty_t *
 DDS_Security_BinaryProperty_alloc (void)
@@ -804,40 +799,6 @@ void DDS_Security_Exception_set (DDS_Security_SecurityException *ex, const char 
   DDS_Security_Exception_vset (ex, context, code, minor_code, fmt, args1);
   va_end(args1);
 }
-
-#ifdef DDSI_INCLUDE_SSL
-DDS_EXPORT void
-DDS_Security_Exception_set_with_openssl_error(
-    DDS_Security_SecurityException *ex,
-    const char *context,
-    int code,
-    int minor_code,
-    const char *error_area)
-{
-    BIO *bio;
-    assert(context);
-    assert(error_area);
-    assert(ex);
-    DDSRT_UNUSED_ARG(context);
-
-    if ((bio = BIO_new(BIO_s_mem()))) {
-        ERR_print_errors(bio);
-        char *buf = NULL;
-        size_t len = (size_t)BIO_get_mem_data(bio, &buf);
-        size_t exception_msg_len = len + strlen(error_area) + 1;
-        char *str = ddsrt_malloc(exception_msg_len);
-        ddsrt_strlcpy(str, error_area, exception_msg_len);
-        memcpy(str + strlen(error_area), buf, len);
-        str[exception_msg_len - 1] = '\0';
-        ex->message = str;
-        ex->code = code;
-        ex->minor_code = minor_code;
-        BIO_free(bio);
-    } else {
-        DDS_Security_Exception_set(ex, context, code, minor_code, "BIO_new failed");
-    }
-}
-#endif
 
 void
 DDS_Security_Exception_reset(

--- a/src/security/core/tests/CMakeLists.txt
+++ b/src/security/core/tests/CMakeLists.txt
@@ -102,6 +102,12 @@ target_include_directories(
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../../core/ddsi/include>"
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../../core/ddsc/src>"
  )
+if(ENABLE_SSL)
+  target_include_directories(
+    cunit_security_core PRIVATE
+      "$<BUILD_INTERFACE:$<TARGET_PROPERTY:security_openssl,INTERFACE_INCLUDE_DIRECTORIES>>"
+  )
+endif()
 
 set(common_etc_dir "${CMAKE_CURRENT_SOURCE_DIR}/common/etc")
 set(plugin_wrapper_lib_dir "${CMAKE_CURRENT_BINARY_DIR}")
@@ -111,5 +117,6 @@ target_link_libraries(cunit_security_core PRIVATE ddsc security_api SecurityCore
 if(ENABLE_SSL)
   target_link_libraries(cunit_security_core PRIVATE dds_security_auth dds_security_ac dds_security_crypto dds_security_access_control_wrapper dds_security_authentication_wrapper dds_security_cryptography_wrapper)
   target_link_libraries(cunit_security_core PRIVATE OpenSSL::SSL)
+  target_link_libraries(cunit_security_core PRIVATE security_openssl)
 endif()
 target_include_directories(cunit_security_core PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")

--- a/src/security/core/tests/common/cert_utils.c
+++ b/src/security/core/tests/common/cert_utils.c
@@ -12,15 +12,10 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <openssl/asn1.h>
-#include <openssl/bio.h>
-#include <openssl/conf.h>
-#include <openssl/err.h>
-#include <openssl/pem.h>
-#include <openssl/x509.h>
 
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/string.h"
+#include "dds/security/openssl_support.h"
 #include "CUnit/Test.h"
 #include "cert_utils.h"
 

--- a/src/security/core/tests/common/security_config_test_utils.c
+++ b/src/security/core/tests/common/security_config_test_utils.c
@@ -12,12 +12,6 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <openssl/asn1.h>
-#include <openssl/bio.h>
-#include <openssl/conf.h>
-#include <openssl/err.h>
-#include <openssl/pem.h>
-#include <openssl/x509.h>
 
 #include "CUnit/Test.h"
 #include "dds/dds.h"
@@ -26,6 +20,7 @@
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/string.h"
 #include "dds/ddsrt/io.h"
+#include "dds/security/openssl_support.h"
 #include "common/config_env.h"
 #include "common/test_utils.h"
 #include "security_config_test_utils.h"
@@ -160,6 +155,8 @@ static char * get_xml_datetime(dds_time_t t, char * buf, size_t len)
 
 static char * smime_sign(char * ca_cert_path, char * ca_priv_key_path, const char * data)
 {
+  dds_openssl_init ();
+
   // Read CA certificate
   BIO *ca_cert_bio = BIO_new (BIO_s_file ());
   if (BIO_read_filename (ca_cert_bio, ca_cert_path) <= 0)

--- a/src/security/openssl/CMakeLists.txt
+++ b/src/security/openssl/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2006 to 2019 ADLINK Technology Limited and others
+# Copyright(c) 2020 ADLINK Technology Limited and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at
@@ -9,14 +9,13 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
-cmake_minimum_required(VERSION 3.7)
 
-if(ENABLE_SECURITY)
-  add_subdirectory(api)
-  add_subdirectory(core)
+add_library(security_openssl INTERFACE)
 
-  if(ENABLE_SSL)
-    add_subdirectory(openssl)
-    add_subdirectory(builtin_plugins)
-  endif()
-endif()
+target_sources(security_openssl INTERFACE
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/openssl_support.c")
+
+target_include_directories(
+  security_openssl INTERFACE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+)

--- a/src/security/openssl/include/dds/security/openssl_support.h
+++ b/src/security/openssl/include/dds/security/openssl_support.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright(c) 2020 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+#ifndef DDS_OPENSSL_SUPPORT_H
+#define DDS_OPENSSL_SUPPORT_H
+
+#include "dds/security/dds_security_api_types.h"
+
+/* There's OpenSSL 1.1.x and there's OpenSSL 1.0.2 and the difference is like
+   night and day: 1.1.0 deprecated all the initialization and cleanup routines
+   and so any library can link with OpenSSL and use it safely without breaking
+   the application code or some other library in the same process.
+
+   OpenSSL 1.0.2h deprecated the cleanup functions such as EVP_cleanup because
+   calling the initialisation functions multiple times was survivable, but an
+   premature invocation of the cleanup functions deadly. It still has the per-
+   thread error state that one ought to clean up, but that firstly requires
+   keeping track of which threads make OpenSSL calls, and secondly we do
+   perform OpenSSL calls on the applications main-thread and so cleaning up
+   might interfere with the application code.
+
+   Compatibility with 1.0.2 exists merely as a courtesy to those who insist on
+   using it with that problematic piece of code. We only initialise it, and we
+   don't clean up thread state. If Cyclone DDS is the only part of the process
+   that uses OpenSSL, it should be ok (just some some minor leaks at the end),
+   if the application code or another library also uses it, it'll probably be
+   fine too. */
+
+#ifdef _WIN32
+/* WinSock2 must be included before openssl 1.0.2 headers otherwise winsock will be used */
+#include <WinSock2.h>
+#endif
+
+#include <openssl/opensslv.h>
+#include <openssl/opensslconf.h>
+#include <openssl/asn1.h>
+#include <openssl/bio.h>
+#include <openssl/conf.h>
+
+#if OPENSSL_VERSION_NUMBER >= 0x1000200fL
+#define AUTH_INCLUDE_EC
+#include <openssl/ec.h>
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#define AUTH_INCLUDE_DH_ACCESSORS
+#endif
+#else
+#error "OpenSSL version is not supported"
+#endif
+
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+#include <openssl/rand.h>
+#include <openssl/sha.h>
+#include <openssl/pem.h>
+#include <openssl/pkcs7.h>
+#include <openssl/x509.h>
+#include <openssl/x509v3.h>
+#include <openssl/x509_vfy.h>
+
+void dds_openssl_init (void);
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+/* 1.1.0 has it as a supported API. 1.0.2 has it in practice and since that has been
+   obsolete for ages, chances are that we can safely use it */
+struct tm *OPENSSL_gmtime(const time_t *timer, struct tm *result);
+#endif
+
+void DDS_Security_Exception_set_with_openssl_error (DDS_Security_SecurityException *ex, const char *context, int code, int minor_code, const char *error_area);
+
+#endif

--- a/src/security/openssl/src/openssl_support.c
+++ b/src/security/openssl/src/openssl_support.c
@@ -1,0 +1,127 @@
+/*
+ * Copyright(c) 2020 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include <string.h>
+#include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/sync.h"
+#include "dds/ddsrt/misc.h"
+#include "dds/ddsrt/string.h"
+#include "dds/ddsrt/threads.h"
+#include "dds/ddsrt/atomics.h"
+#include "dds/security/core/dds_security_utils.h"
+#include "dds/security/openssl_support.h"
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+static unsigned long ssl_id (void)
+{
+  return (unsigned long) ddsrt_gettid ();
+}
+
+typedef struct CRYPTO_dynlock_value {
+  ddsrt_mutex_t m_mutex;
+} CRYPTO_dynlock_value;
+
+CRYPTO_dynlock_value *dds_openssl102_ssl_locks = NULL;
+
+static void ssl_dynlock_lock (int mode, CRYPTO_dynlock_value *lock, const char *file, int line)
+{
+  (void) file;
+  (void) line;
+  if (mode & CRYPTO_LOCK)
+    ddsrt_mutex_lock (&lock->m_mutex);
+  else
+    ddsrt_mutex_unlock (&lock->m_mutex);
+}
+
+static void ssl_lock (int mode, int n, const char *file, int line)
+{
+  ssl_dynlock_lock (mode, &dds_openssl102_ssl_locks[n], file, line);
+}
+
+static CRYPTO_dynlock_value *ssl_dynlock_create (const char *file, int line)
+{
+  (void) file;
+  (void) line;
+  CRYPTO_dynlock_value *val = ddsrt_malloc (sizeof (*val));
+  ddsrt_mutex_init (&val->m_mutex);
+  return val;
+}
+
+static void ssl_dynlock_destroy (CRYPTO_dynlock_value *lock, const char *file, int line)
+{
+  (void) file;
+  (void) line;
+  ddsrt_mutex_destroy (&lock->m_mutex);
+  ddsrt_free (lock);
+}
+
+void dds_openssl_init (void)
+{
+  // This is terribly fragile and broken-by-design, but with OpenSSL sometimes
+  // linked dynamically and sometimes linked statically, with Windows and Unix
+  // in the mix, this appears to be the compromise that makes it work reliably
+  // enough ...
+  if (CRYPTO_get_id_callback () == 0)
+  {
+    CRYPTO_set_id_callback (ssl_id);
+    CRYPTO_set_locking_callback (ssl_lock);
+    CRYPTO_set_dynlock_create_callback (ssl_dynlock_create);
+    CRYPTO_set_dynlock_lock_callback (ssl_dynlock_lock);
+    CRYPTO_set_dynlock_destroy_callback (ssl_dynlock_destroy);
+
+    if (dds_openssl102_ssl_locks == NULL)
+    {
+      const int locks = CRYPTO_num_locks ();
+      assert (locks >= 0);
+      dds_openssl102_ssl_locks = ddsrt_malloc (sizeof (CRYPTO_dynlock_value) * (size_t) locks);
+      for (int i = 0; i < locks; i++)
+        ddsrt_mutex_init (&dds_openssl102_ssl_locks[i].m_mutex);
+    }
+
+    OpenSSL_add_all_algorithms ();
+    OpenSSL_add_all_ciphers ();
+    OpenSSL_add_all_digests ();
+    ERR_load_BIO_strings ();
+    ERR_load_crypto_strings ();
+  }
+}
+#else
+void dds_openssl_init (void)
+{
+  // nothing needed for OpenSSL 1.1.0 and later
+}
+#endif
+
+void DDS_Security_Exception_set_with_openssl_error (DDS_Security_SecurityException *ex, const char *context, int code, int minor_code, const char *error_area)
+{
+  BIO *bio;
+  assert (context);
+  assert (error_area);
+  assert (ex);
+  DDSRT_UNUSED_ARG (context);
+
+  if ((bio = BIO_new (BIO_s_mem ()))) {
+    ERR_print_errors (bio);
+    char *buf = NULL;
+    size_t len = (size_t) BIO_get_mem_data (bio, &buf);
+    size_t exception_msg_len = len + strlen (error_area) + 1;
+    char *str = ddsrt_malloc (exception_msg_len);
+    ddsrt_strlcpy (str, error_area, exception_msg_len);
+    memcpy (str + strlen (error_area), buf, len);
+    str[exception_msg_len - 1] = '\0';
+    ex->message = str;
+    ex->code = code;
+    ex->minor_code = minor_code;
+    BIO_free (bio);
+  } else {
+    DDS_Security_Exception_set (ex, context, code, minor_code, "BIO_new failed");
+  }
+}


### PR DESCRIPTION
This addresses a number of issues with building Cyclone DDS including
DDS Security while using OpenSSL 1.0.2. Compatibility with 1.0.2 is a
courtesy towards those who are unable to move to 1.1.x or later because
of other libraries (like ROS2 was still using 1.0.2 on Windows yesterday).

* On Windows, one must include Winsock2.h prior to including the OpenSSL
  header files, or it'll pull in incompatible definitions from Winsock.h
  and that breaks some of the files.

* OpenSSL 1.0.2 requires initializing the library (or more particular,
  loading all the required algorithms) but this is no longer needed in
  OpenSSL 1.1.x. It ends up being needed in a few places and having tons
  of essentially dead initialization code lying around is unpleasant.
  Hence this has been consolidated in a single function and protected
  with ddsrt_once().

* One ought to undo the above initialization on 1.0.2g and older, but it
  is impossible to know whether that can safely be done from a library.
  This is also the reason OpenSSL deprecated all the initialization and
  cleanup interfaces. So if one insists on trying it with such an old
  version, let there be some leaks.

* Thread state cleanup is sort-of required prior 1.1.0, but that suffers
  from the same problems; we'd have to do per-thread cleanup code for
  OpenSSL for any thread that could call into it (which is pretty much
  any thread). So once again, people should just use 1.1.0 or newer.

* There are some interfaces added in 1.1.0 that we use, but a few small
  workarounds those can be made to work on 1.0.2 as well. These also
  were replicated in a number of places and consolidated by this commit.
