### PR TITLE
Drop macOS 10.12 build from Travis CI cron job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,19 +84,6 @@ osx_xcode: &osx_xcode
   install:
     - python3 -m pip install conan --upgrade --user
 
-osx_xcode9: &osx_xcode9
-  <<: *osx_xcode
-  osx_image: xcode9
-  addons:
-    homebrew:
-      packages: [ python3, trang ]
-      # Homebrew must be updated before packages can be installed on outdated
-      # macOS images. The update process unfortunately takes a VERY long time
-      # and can even cause Travis to terminate the build. Travis caching is
-      # used to ensure Homebrew is kept up-to-date and build times are kept to
-      # a minimum.
-      update: true
-
 windows_vs2017: &windows_vs2017
   os: windows
   # Conan will automatically determine the best compiler for a given platform
@@ -159,9 +146,6 @@ jobs:
       env: [ ARCH=x86_64, ASAN=address, BUILD_TYPE=Debug, SSL=YES, SECURITY=NO, LIFESPAN=YES, DEADLINE=YES, GENERATOR="Unix Makefiles" ]
     - <<: *linux_clang
       env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, SSL=YES, SECURITY=YES, LIFESPAN=YES, DEADLINE=YES, GENERATOR="Unix Makefiles" ]
-    - <<: *osx_xcode9
-      env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, SSL=NO, SECURITY=YES, LIFESPAN=YES, DEADLINE=YES, GENERATOR="Unix Makefiles" ]
-      if: type = cron
     - <<: *osx_xcode
       env: [ ARCH=x86_64, ASAN=none, BUILD_TYPE=Release, SSL=NO, SECURITY=YES, LIFESPAN=YES, DEADLINE=YES, GENERATOR="Unix Makefiles", MACOSX_DEPLOYMENT_TARGET=10.12 ]
     - <<: *osx_xcode


### PR DESCRIPTION
The macOS 10.12 build was put in because of ROS2 "Dashing" specified
10.12 as the supported version, but Eloquent and later specify
10.14. The relevance of this is no longer there because of Foxy. The
build itself took an inordinate amount of time with lots of warnings
about the platform being deprecated.

Signed-off-by: Erik Boasson <eb@ilities.com>