### PR TITLE
Build OpenSSL dependent parts only if present

### DIFF
--- a/src/security/CMakeLists.txt
+++ b/src/security/CMakeLists.txt
@@ -15,7 +15,7 @@ if(ENABLE_SECURITY)
   add_subdirectory(api)
   add_subdirectory(core)
 
-  if(ENABLE_SSL)
+  if(ENABLE_SSL AND OPENSSL_FOUND)
     add_subdirectory(openssl)
     add_subdirectory(builtin_plugins)
   endif()

--- a/src/security/core/tests/CMakeLists.txt
+++ b/src/security/core/tests/CMakeLists.txt
@@ -67,7 +67,7 @@ set(security_core_test_sources
     "security_utils.c"
 )
 
-if(ENABLE_SSL)
+if(ENABLE_SSL AND OPENSSL_FOUND)
   add_wrapper(access_control dds_security_ac)
   add_wrapper(authentication dds_security_auth)
   add_wrapper(cryptography dds_security_crypto)
@@ -102,7 +102,7 @@ target_include_directories(
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../../core/ddsi/include>"
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../../core/ddsc/src>"
  )
-if(ENABLE_SSL)
+if(ENABLE_SSL AND OPENSSL_FOUND)
   target_include_directories(
     cunit_security_core PRIVATE
       "$<BUILD_INTERFACE:$<TARGET_PROPERTY:security_openssl,INTERFACE_INCLUDE_DIRECTORIES>>"
@@ -114,7 +114,7 @@ set(plugin_wrapper_lib_dir "${CMAKE_CURRENT_BINARY_DIR}")
 configure_file("common/config_env.h.in" "common/config_env.h")
 
 target_link_libraries(cunit_security_core PRIVATE ddsc security_api SecurityCoreTests)
-if(ENABLE_SSL)
+if(ENABLE_SSL AND OPENSSL_FOUND)
   target_link_libraries(cunit_security_core PRIVATE dds_security_auth dds_security_ac dds_security_crypto dds_security_access_control_wrapper dds_security_authentication_wrapper dds_security_cryptography_wrapper)
   target_link_libraries(cunit_security_core PRIVATE OpenSSL::SSL)
   target_link_libraries(cunit_security_core PRIVATE security_openssl)


### PR DESCRIPTION
The case of building Cyclone DDS including support for DDS Security but without OpenSSL present while not having explicitly disabled it was overlooked and causes CMake errors.