### PR TITLE
A few fixes for issues signalled by Coverity

### DIFF
--- a/src/mpt/tests/qos/procs/rw.c
+++ b/src/mpt/tests/qos/procs/rw.c
@@ -328,13 +328,12 @@ MPT_ProcessEntry (rw_publisher,
 
 static void wait_for_done (dds_entity_t rd, const char *userdata)
 {
-  int32_t n;
   void *raw = NULL;
   dds_sample_info_t si;
   bool done = false;
   while (!done)
   {
-    while (!done && (n = dds_take (rd, &raw, &si, 1, 1)) == 1)
+    while (!done && dds_take (rd, &raw, &si, 1, 1) == 1)
     {
       const dds_builtintopic_participant_t *sample = raw;
       void *ud = NULL;

--- a/src/security/builtin_plugins/access_control/src/access_control.c
+++ b/src/security/builtin_plugins/access_control/src/access_control.c
@@ -508,7 +508,6 @@ check_remote_participant(dds_security_access_control *instance,
 {
   dds_security_access_control_impl *ac = (dds_security_access_control_impl *)instance;
   remote_participant_access_rights *remote_rights = NULL;
-  DDS_Security_boolean isValid = false;
   DDS_Security_ParticipantSecurityAttributes participantSecurityAttributes;
   DDS_Security_PermissionsHandle local_permissions_handle;
   DDS_Security_string class_id_remote_str;
@@ -530,7 +529,7 @@ check_remote_participant(dds_security_access_control *instance,
 
   /* The local rights pointer is actually the local permissions handle. */
   local_permissions_handle = ACCESS_CONTROL_OBJECT_HANDLE(remote_rights->local_rights);
-  if ((isValid = get_participant_sec_attributes(instance, local_permissions_handle, &participantSecurityAttributes, ex)) == false)
+  if (!get_participant_sec_attributes(instance, local_permissions_handle, &participantSecurityAttributes, ex))
     goto exit;
   if (participantSecurityAttributes.is_access_protected == false)
   {

--- a/src/security/builtin_plugins/tests/common/src/handshake_helper.c
+++ b/src/security/builtin_plugins/tests/common/src/handshake_helper.c
@@ -157,8 +157,7 @@ screate_asymmetrical_signature_for_test(
         goto err_sign;
     }
 
-    //*signature = ddsrt_malloc(sizeof(unsigned char) * (*signatureLen));
-    *signature = OPENSSL_malloc(*signatureLen);
+    *signature = ddsrt_malloc(*signatureLen);
     if (EVP_DigestSignFinal(mdctx, *signature, signatureLen) != 1) {
         char *msg = get_openssl_error_message_for_test();
         result = DDS_SECURITY_VALIDATION_FAILED;
@@ -550,14 +549,13 @@ create_asymmetrical_signature_for_test(
         goto err_sign;
     }
 
-    //*signature = os_malloc(sizeof(unsigned char) * (*signatureLen));
-    *signature = OPENSSL_malloc(*signatureLen);
+    *signature = ddsrt_malloc(*signatureLen);
     if (EVP_DigestSignFinal(mdctx, *signature, signatureLen) != 1) {
         char *msg = get_openssl_error_message_for_test();
         result = DDS_SECURITY_VALIDATION_FAILED;
         DDS_Security_Exception_set(ex, "Authentication", DDS_SECURITY_ERR_UNDEFINED_CODE, (int)result, "Failed to finalize signing context: %s", msg);
         ddsrt_free(msg);
-        ddsrt_free(signature);
+        ddsrt_free(*signature);
     }
 
     err_sign:

--- a/src/security/builtin_plugins/tests/create_local_datareader_crypto_tokens/src/create_local_datareader_crypto_tokens_utests.c
+++ b/src/security/builtin_plugins/tests/create_local_datareader_crypto_tokens/src/create_local_datareader_crypto_tokens_utests.c
@@ -347,8 +347,11 @@ CU_Test(ddssec_builtin_create_local_datareader_crypto_tokens, happy_day, .init =
   DDS_Security_DatawriterCryptoTokenSeq tokens;
 
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange != NULL);
+  assert(crypto->crypto_key_exchange != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange->create_local_datareader_crypto_tokens != NULL);
+  assert(crypto->crypto_key_exchange->create_local_datareader_crypto_tokens != 0);
 
   memset(&tokens, 0, sizeof(tokens));
 
@@ -395,8 +398,11 @@ CU_Test(ddssec_builtin_create_local_datareader_crypto_tokens, invalid_args, .ini
 
   /* Check if we actually have the validate_local_identity() function. */
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange != NULL);
+  assert(crypto->crypto_key_exchange != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange->create_local_datareader_crypto_tokens != NULL);
+  assert(crypto->crypto_key_exchange->create_local_datareader_crypto_tokens != 0);
 
   memset(&tokens, 0, sizeof(tokens));
 

--- a/src/security/builtin_plugins/tests/create_local_datawriter_crypto_tokens/src/create_local_datawriter_crypto_tokens_utests.c
+++ b/src/security/builtin_plugins/tests/create_local_datawriter_crypto_tokens/src/create_local_datawriter_crypto_tokens_utests.c
@@ -350,8 +350,11 @@ CU_Test(ddssec_builtin_create_local_datawriter_crypto_tokens, happy_day, .init =
   DDS_Security_DatawriterCryptoTokenSeq tokens;
 
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange != NULL);
+  assert(crypto->crypto_key_exchange != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange->create_local_datawriter_crypto_tokens != NULL);
+  assert(crypto->crypto_key_exchange->create_local_datawriter_crypto_tokens != 0);
 
   memset(&tokens, 0, sizeof(tokens));
 
@@ -398,8 +401,11 @@ CU_Test(ddssec_builtin_create_local_datawriter_crypto_tokens, invalid_args, .ini
 
   /* Check if we actually have the validate_local_identity() function. */
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange != NULL);
+  assert(crypto->crypto_key_exchange != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange->create_local_datawriter_crypto_tokens != NULL);
+  assert(crypto->crypto_key_exchange->create_local_datawriter_crypto_tokens != 0);
 
   memset(&tokens, 0, sizeof(tokens));
 

--- a/src/security/builtin_plugins/tests/create_local_participant_crypto_tokens/src/create_local_participant_crypto_tokens_utests.c
+++ b/src/security/builtin_plugins/tests/create_local_participant_crypto_tokens/src/create_local_participant_crypto_tokens_utests.c
@@ -210,8 +210,11 @@ CU_Test(ddssec_builtin_create_local_participant_crypto_tokens, happy_day, .init 
 
   /* Check if we actually have the validate_local_identity() function. */
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange != NULL);
+  assert(crypto->crypto_key_exchange != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange->create_local_participant_crypto_tokens != NULL);
+  assert(crypto->crypto_key_exchange->create_local_participant_crypto_tokens != 0);
 
   memset(&exception, 0, sizeof(DDS_Security_SecurityException));
   memset(&tokens, 0, sizeof(tokens));
@@ -260,8 +263,11 @@ CU_Test(ddssec_builtin_create_local_participant_crypto_tokens, invalid_args, .in
 
   /* Check if we actually have the validate_local_identity() function. */
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange != NULL);
+  assert(crypto->crypto_key_exchange != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange->create_local_participant_crypto_tokens != NULL);
+  assert(crypto->crypto_key_exchange->create_local_participant_crypto_tokens != 0);
 
   memset(&exception, 0, sizeof(DDS_Security_SecurityException));
   memset(&tokens, 0, sizeof(tokens));

--- a/src/security/builtin_plugins/tests/decode_datareader_submessage/src/decode_datareader_submessage_utests.c
+++ b/src/security/builtin_plugins/tests/decode_datareader_submessage/src/decode_datareader_submessage_utests.c
@@ -514,9 +514,13 @@ static void decode_datareader_submessage_not_signed(
   DDS_Security_PropertySeq datareader_properties;
 
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform != NULL);
+  assert(crypto->crypto_transform != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform->encode_datareader_submessage != NULL);
+  assert(crypto->crypto_transform->encode_datareader_submessage != 0);
   CU_ASSERT_FATAL(crypto->crypto_transform->decode_datareader_submessage != NULL);
+  assert(crypto->crypto_transform->decode_datareader_submessage != 0);
 
   initialize_data_submessage(&plain_buffer);
 
@@ -647,9 +651,13 @@ static void decode_datareader_submessage_signed(
   DDS_Security_PropertySeq datareader_properties;
 
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform != NULL);
+  assert(crypto->crypto_transform != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform->encode_datareader_submessage != NULL);
+  assert(crypto->crypto_transform->encode_datareader_submessage != 0);
   CU_ASSERT_FATAL(crypto->crypto_transform->decode_datareader_submessage != NULL);
+  assert(crypto->crypto_transform->decode_datareader_submessage != 0);
 
   initialize_data_submessage(&plain_buffer);
 
@@ -802,9 +810,13 @@ CU_Test(ddssec_builtin_decode_datareader_submessage, invalid_args, .init = suite
   DDS_Security_PropertySeq datareader_properties;
 
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform != NULL);
+  assert(crypto->crypto_transform != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform->encode_datareader_submessage != NULL);
+  assert(crypto->crypto_transform->encode_datareader_submessage != 0);
   CU_ASSERT_FATAL(crypto->crypto_transform->decode_datareader_submessage != NULL);
+  assert(crypto->crypto_transform->decode_datareader_submessage != 0);
 
   initialize_data_submessage(&plain_buffer);
 
@@ -1028,9 +1040,13 @@ CU_Test(ddssec_builtin_decode_datareader_submessage, invalid_data, .init = suite
   DDS_Security_PropertySeq datareader_properties;
 
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform != NULL);
+  assert(crypto->crypto_transform != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform->encode_datareader_submessage != NULL);
+  assert(crypto->crypto_transform->encode_datareader_submessage != 0);
   CU_ASSERT_FATAL(crypto->crypto_transform->decode_datareader_submessage != NULL);
+  assert(crypto->crypto_transform->decode_datareader_submessage != 0);
 
   initialize_data_submessage(&plain_buffer);
 
@@ -1617,9 +1633,13 @@ CU_Test(ddssec_builtin_decode_datareader_submessage, volatile_sec, .init = suite
   DDS_Security_OctetSeq decoded_buffer = {0, 0, NULL};
 
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform != NULL);
+  assert(crypto->crypto_transform != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform->encode_datareader_submessage != NULL);
+  assert(crypto->crypto_transform->encode_datareader_submessage != 0);
   CU_ASSERT_FATAL(crypto->crypto_transform->decode_datareader_submessage != NULL);
+  assert(crypto->crypto_transform->decode_datareader_submessage != 0);
 
   initialize_data_submessage(&plain_buffer);
 

--- a/src/security/builtin_plugins/tests/decode_datawriter_submessage/src/decode_datawriter_submessage_utests.c
+++ b/src/security/builtin_plugins/tests/decode_datawriter_submessage/src/decode_datawriter_submessage_utests.c
@@ -500,9 +500,13 @@ static void decode_datawriter_submessage_not_signed(DDS_Security_CryptoTransform
   DDS_Security_PropertySeq datareader_properties;
 
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform != NULL);
+  assert(crypto->crypto_transform != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform->encode_datawriter_submessage != NULL);
+  assert(crypto->crypto_transform->encode_datawriter_submessage != 0);
   CU_ASSERT_FATAL(crypto->crypto_transform->decode_datawriter_submessage != NULL);
+  assert(crypto->crypto_transform->decode_datawriter_submessage != 0);
 
   prepare_endpoint_security_attributes_and_properties(&datareader_security_attributes, &datareader_properties, transformation_kind, false);
   prepare_endpoint_security_attributes_and_properties(&datawriter_security_attributes, &datawriter_properties, transformation_kind, false);
@@ -633,9 +637,13 @@ static void decode_datawriter_submessage_signed(DDS_Security_CryptoTransformKind
   DDS_Security_PropertySeq datareader_properties;
 
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform != NULL);
+  assert(crypto->crypto_transform != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform->encode_datawriter_submessage != NULL);
+  assert(crypto->crypto_transform->encode_datawriter_submessage != 0);
   CU_ASSERT_FATAL(crypto->crypto_transform->decode_datawriter_submessage != NULL);
+  assert(crypto->crypto_transform->decode_datawriter_submessage != 0);
 
   prepare_endpoint_security_attributes_and_properties(&datareader_security_attributes, &datareader_properties, transformation_kind, true);
   prepare_endpoint_security_attributes_and_properties(&datawriter_security_attributes, &datawriter_properties, transformation_kind, true);
@@ -798,9 +806,13 @@ CU_Test(ddssec_builtin_decode_datawriter_submessage, invalid_args, .init = suite
   DDS_Security_PropertySeq datareader_properties;
 
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform != NULL);
+  assert(crypto->crypto_transform != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform->encode_datawriter_submessage != NULL);
+  assert(crypto->crypto_transform->encode_datawriter_submessage != 0);
   CU_ASSERT_FATAL(crypto->crypto_transform->decode_datawriter_submessage != NULL);
+  assert(crypto->crypto_transform->decode_datawriter_submessage != 0);
 
   prepare_endpoint_security_attributes_and_properties(&datareader_security_attributes, &datareader_properties, CRYPTO_TRANSFORMATION_KIND_AES256_GCM, true);
   prepare_endpoint_security_attributes_and_properties(&datawriter_security_attributes, &datawriter_properties, CRYPTO_TRANSFORMATION_KIND_AES256_GCM, true);
@@ -1048,9 +1060,13 @@ CU_Test(ddssec_builtin_decode_datawriter_submessage, invalid_data, .init = suite
   DDS_Security_PropertySeq datareader_properties;
 
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform != NULL);
+  assert(crypto->crypto_transform != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform->encode_datawriter_submessage != NULL);
+  assert(crypto->crypto_transform->encode_datawriter_submessage != 0);
   CU_ASSERT_FATAL(crypto->crypto_transform->decode_datawriter_submessage != NULL);
+  assert(crypto->crypto_transform->decode_datawriter_submessage != 0);
 
   prepare_endpoint_security_attributes_and_properties(&datareader_security_attributes, &datareader_properties, CRYPTO_TRANSFORMATION_KIND_AES256_GCM, true);
   prepare_endpoint_security_attributes_and_properties(&datawriter_security_attributes, &datawriter_properties, CRYPTO_TRANSFORMATION_KIND_AES256_GCM, true);
@@ -1640,9 +1656,13 @@ CU_Test(ddssec_builtin_decode_datawriter_submessage, volatile_sec, .init = suite
   DDS_Security_PropertySeq datareader_properties;
 
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform != NULL);
+  assert(crypto->crypto_transform != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform->encode_datawriter_submessage != NULL);
+  assert(crypto->crypto_transform->encode_datawriter_submessage != 0);
   CU_ASSERT_FATAL(crypto->crypto_transform->decode_datawriter_submessage != NULL);
+  assert(crypto->crypto_transform->decode_datawriter_submessage != 0);
 
   prepare_endpoint_security_attributes_and_properties(&datareader_security_attributes, NULL, CRYPTO_TRANSFORMATION_KIND_AES256_GCM, false);
   prepare_endpoint_security_attributes_and_properties(&datawriter_security_attributes, NULL, CRYPTO_TRANSFORMATION_KIND_AES256_GCM, false);

--- a/src/security/builtin_plugins/tests/decode_rtps_message/src/decode_rtps_message_utests.c
+++ b/src/security/builtin_plugins/tests/decode_rtps_message/src/decode_rtps_message_utests.c
@@ -456,9 +456,13 @@ static void decode_rtps_message_not_authenticated(DDS_Security_CryptoTransformKi
   DDS_Security_PropertySeq properties;
 
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform != NULL);
+  assert(crypto->crypto_transform != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform->encode_rtps_message != NULL);
+  assert(crypto->crypto_transform->encode_rtps_message != 0);
   CU_ASSERT_FATAL(crypto->crypto_transform->decode_rtps_message != NULL);
+  assert(crypto->crypto_transform->decode_rtps_message != 0);
 
   prepare_participant_security_attributes_and_properties(&attributes, &properties, transformation_kind, true);
   register_local_participants(&attributes, &properties);
@@ -580,9 +584,13 @@ static void decode_rtps_message_authenticated(DDS_Security_CryptoTransformKind_E
   int i, index;
 
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform != NULL);
+  assert(crypto->crypto_transform != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform->encode_rtps_message != NULL);
+  assert(crypto->crypto_transform->encode_rtps_message != 0);
   CU_ASSERT_FATAL(crypto->crypto_transform->decode_rtps_message != NULL);
+  assert(crypto->crypto_transform->decode_rtps_message != 0);
 
   prepare_participant_security_attributes_and_properties(&attributes, &properties, transformation_kind, true);
   register_local_participants(&attributes, &properties);
@@ -717,9 +725,13 @@ CU_Test(ddssec_builtin_decode_rtps_message, invalid_args, .init = suite_decode_r
   DDS_Security_PropertySeq properties;
 
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform != NULL);
+  assert(crypto->crypto_transform != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform->encode_rtps_message != NULL);
+  assert(crypto->crypto_transform->encode_rtps_message != 0);
   CU_ASSERT_FATAL(crypto->crypto_transform->decode_rtps_message != NULL);
+  assert(crypto->crypto_transform->decode_rtps_message != 0);
 
   prepare_participant_security_attributes_and_properties(&attributes, &properties, CRYPTO_TRANSFORMATION_KIND_AES256_GMAC, false);
   register_local_participants(&attributes, &properties);
@@ -925,9 +937,13 @@ CU_Test(ddssec_builtin_decode_rtps_message, invalid_data, .init = suite_decode_r
   DDS_Security_PropertySeq properties;
 
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform != NULL);
+  assert(crypto->crypto_transform != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform->encode_rtps_message != NULL);
+  assert(crypto->crypto_transform->encode_rtps_message != 0);
   CU_ASSERT_FATAL(crypto->crypto_transform->decode_rtps_message != NULL);
+  assert(crypto->crypto_transform->decode_rtps_message != 0);
 
   prepare_participant_security_attributes_and_properties(&attributes, &properties, CRYPTO_TRANSFORMATION_KIND_AES256_GMAC, false);
   register_local_participants(&attributes, &properties);

--- a/src/security/builtin_plugins/tests/decode_serialized_payload/src/decode_serialized_payload_utests.c
+++ b/src/security/builtin_plugins/tests/decode_serialized_payload/src/decode_serialized_payload_utests.c
@@ -405,7 +405,7 @@ static void suite_decode_serialized_payload_fini(void)
   deallocate_shared_secret();
 }
 
-static bool split_encoded_data(unsigned char *data, size_t size, struct crypto_header **header, unsigned char **contents, uint32_t *length, struct crypto_footer **footer)
+static bool split_encoded_data(unsigned char *data, size_t size, struct crypto_header **header, unsigned char **contents, size_t *length, struct crypto_footer **footer)
 {
   unsigned char *ptr;
 
@@ -845,7 +845,7 @@ CU_Test(ddssec_builtin_decode_serialized_payload, invalid_data, .init = suite_de
 
   reset_exception(&exception);
 
-  result = split_encoded_data(encoded_buffer._buffer, encoded_buffer._length, &header, &contents, (uint32_t *) &length, &footer);
+  result = split_encoded_data(encoded_buffer._buffer, encoded_buffer._length, &header, &contents, &length, &footer);
   CU_ASSERT_FATAL(result);
   assert(result); // for Clang's static analyzer
 

--- a/src/security/builtin_plugins/tests/decode_serialized_payload/src/decode_serialized_payload_utests.c
+++ b/src/security/builtin_plugins/tests/decode_serialized_payload/src/decode_serialized_payload_utests.c
@@ -570,8 +570,11 @@ CU_Test(ddssec_builtin_decode_serialized_payload, invalid_args, .init = suite_de
   size_t length;
 
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform != NULL);
+  assert(crypto->crypto_transform != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform->encode_serialized_payload != NULL);
+  assert(crypto->crypto_transform->encode_serialized_payload != 0);
 
   memset(&extra_inline_qos, 0, sizeof(extra_inline_qos));
   memset(&empty_buffer, 0, sizeof(empty_buffer));
@@ -795,8 +798,11 @@ CU_Test(ddssec_builtin_decode_serialized_payload, invalid_data, .init = suite_de
   unsigned char *contents = NULL;
 
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform != NULL);
+  assert(crypto->crypto_transform != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform->encode_serialized_payload != NULL);
+  assert(crypto->crypto_transform->encode_serialized_payload != 0);
 
   memset(&extra_inline_qos, 0, sizeof(extra_inline_qos));
 

--- a/src/security/builtin_plugins/tests/encode_datareader_submessage/src/encode_datareader_submessage_utests.c
+++ b/src/security/builtin_plugins/tests/encode_datareader_submessage/src/encode_datareader_submessage_utests.c
@@ -792,8 +792,11 @@ static void encode_datareader_submessage_not_signed(uint32_t transformation_kind
   bool is_encrypted;
 
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform != NULL);
+  assert(crypto->crypto_transform != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform->encode_datareader_submessage != NULL);
+  assert(crypto->crypto_transform->encode_datareader_submessage != 0);
 
   is_encrypted = (transformation_kind == CRYPTO_TRANSFORMATION_KIND_AES128_GCM || transformation_kind == CRYPTO_TRANSFORMATION_KIND_AES256_GCM);
 
@@ -935,8 +938,11 @@ static void encode_datareader_submessage_sign(uint32_t transformation_kind)
   bool is_encrypted;
 
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform != NULL);
+  assert(crypto->crypto_transform != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform->encode_datareader_submessage != NULL);
+  assert(crypto->crypto_transform->encode_datareader_submessage != 0);
 
   if (transformation_kind == CRYPTO_TRANSFORMATION_KIND_AES128_GCM || transformation_kind == CRYPTO_TRANSFORMATION_KIND_AES256_GCM)
   {
@@ -1088,8 +1094,11 @@ CU_Test(ddssec_builtin_encode_datareader_submessage, invalid_args, .init = suite
   DDS_Security_EndpointSecurityAttributes datareader_security_attributes;
 
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform != NULL);
+  assert(crypto->crypto_transform != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform->encode_datareader_submessage != NULL);
+  assert(crypto->crypto_transform->encode_datareader_submessage != 0);
 
   prepare_endpoint_security_attributes_and_properties(&datareader_security_attributes, &datareader_properties, CRYPTO_TRANSFORMATION_KIND_AES256_GCM, true);
 

--- a/src/security/builtin_plugins/tests/encode_datawriter_submessage/src/encode_datawriter_submessage_utests.c
+++ b/src/security/builtin_plugins/tests/encode_datawriter_submessage/src/encode_datawriter_submessage_utests.c
@@ -791,8 +791,11 @@ static void encode_datawriter_submessage_not_signed(DDS_Security_CryptoTransform
   bool is_encrypted;
 
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform != NULL);
+  assert(crypto->crypto_transform != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform->encode_datawriter_submessage != NULL);
+  assert(crypto->crypto_transform->encode_datawriter_submessage != 0);
 
   if (transformation_kind == CRYPTO_TRANSFORMATION_KIND_AES128_GCM || transformation_kind == CRYPTO_TRANSFORMATION_KIND_AES256_GCM)
   {
@@ -947,8 +950,11 @@ static void encode_datawriter_submessage_sign(DDS_Security_CryptoTransformKind_E
   bool is_encrypted;
 
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform != NULL);
+  assert(crypto->crypto_transform != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform->encode_datawriter_submessage != NULL);
+  assert(crypto->crypto_transform->encode_datawriter_submessage != 0);
 
   if (transformation_kind == CRYPTO_TRANSFORMATION_KIND_AES128_GCM || transformation_kind == CRYPTO_TRANSFORMATION_KIND_AES256_GCM)
   {
@@ -1107,8 +1113,11 @@ CU_Test(ddssec_builtin_encode_datawriter_submessage, invalid_args, .init = suite
   DDS_Security_EndpointSecurityAttributes datawriter_security_attributes;
 
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform != NULL);
+  assert(crypto->crypto_transform != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform->encode_datawriter_submessage != NULL);
+  assert(crypto->crypto_transform->encode_datawriter_submessage != 0);
 
   prepare_endpoint_security_attributes_and_properties(&datawriter_security_attributes, &datawriter_properties, CRYPTO_TRANSFORMATION_KIND_AES256_GCM, true);
 

--- a/src/security/builtin_plugins/tests/encode_rtps_message/src/encode_rtps_message_utests.c
+++ b/src/security/builtin_plugins/tests/encode_rtps_message/src/encode_rtps_message_utests.c
@@ -564,6 +564,7 @@ crypto_decrypt_data(
 static session_key_material * get_local_participant_session(DDS_Security_ParticipantCryptoHandle participant_crypto)
 {
   local_participant_crypto *participant_crypto_impl = (local_participant_crypto *)participant_crypto;
+  assert(participant_crypto_impl);
   return participant_crypto_impl->session;
 }
 
@@ -767,8 +768,11 @@ static void encode_rtps_message_not_authenticated(DDS_Security_CryptoTransformKi
   DDS_Security_PropertySeq properties;
 
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform != NULL);
+  assert(crypto->crypto_transform != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform->encode_rtps_message != NULL);
+  assert(crypto->crypto_transform->encode_rtps_message != 0);
 
   prepare_participant_security_attributes_and_properties(&attributes, &properties, transformation_kind, false);
 
@@ -904,8 +908,11 @@ static void encode_rtps_message_sign(DDS_Security_CryptoTransformKind_Enum trans
   size_t i;
 
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform != NULL);
+  assert(crypto->crypto_transform != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform->encode_rtps_message != NULL);
+  assert(crypto->crypto_transform->encode_rtps_message != 0);
 
   prepare_participant_security_attributes_and_properties(&attributes, &properties, transformation_kind, true);
 

--- a/src/security/builtin_plugins/tests/encode_serialized_payload/src/encode_serialized_payload_utests.c
+++ b/src/security/builtin_plugins/tests/encode_serialized_payload/src/encode_serialized_payload_utests.c
@@ -661,8 +661,11 @@ CU_Test(ddssec_builtin_encode_serialized_payload, invalid_args, .init = suite_en
   size_t length;
 
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform != NULL);
+  assert(crypto->crypto_transform != NULL);
   CU_ASSERT_FATAL(crypto->crypto_transform->encode_serialized_payload != NULL);
+  assert(crypto->crypto_transform->encode_serialized_payload != 0);
 
   writer_crypto = register_local_datawriter(true);
   CU_ASSERT_FATAL(writer_crypto != 0);

--- a/src/security/builtin_plugins/tests/get_permissions_credential_token/src/get_permissions_credential_token_utests.c
+++ b/src/security/builtin_plugins/tests/get_permissions_credential_token/src/get_permissions_credential_token_utests.c
@@ -382,7 +382,9 @@ CU_Test(ddssec_builtin_get_permissions_credential_token, happy_day, .init = suit
 
   /* Pre-requisites. */
   CU_ASSERT_FATAL(access_control != NULL);
+  assert(access_control != NULL);
   CU_ASSERT_FATAL(access_control->get_permissions_credential_token != NULL);
+  assert(access_control->get_permissions_credential_token != 0);
   memset(&exception, 0, sizeof(DDS_Security_SecurityException));
   memset(&token, 0, sizeof(token));
 
@@ -416,7 +418,9 @@ CU_Test(ddssec_builtin_get_permissions_credential_token, invalid_args, .init = s
 
   /* Pre-requisites. */
   CU_ASSERT_FATAL(access_control != NULL);
-  CU_ASSERT_FATAL(access_control->get_permissions_token != NULL);
+  assert(access_control != NULL);
+  CU_ASSERT_FATAL(access_control->get_permissions_credential_token != NULL);
+  assert(access_control->get_permissions_credential_token != 0);
   memset(&exception, 0, sizeof(DDS_Security_SecurityException));
   memset(&token, 0, sizeof(token));
 

--- a/src/security/builtin_plugins/tests/get_permissions_token/src/get_permissions_token_utests.c
+++ b/src/security/builtin_plugins/tests/get_permissions_token/src/get_permissions_token_utests.c
@@ -325,7 +325,9 @@ CU_Test(ddssec_builtin_get_permissions_token, happy_day, .init = suite_get_permi
 
   /* Pre-requisites. */
   CU_ASSERT_FATAL(access_control != NULL);
+  assert(access_control != NULL);
   CU_ASSERT_FATAL(access_control->get_permissions_token != NULL);
+  assert(access_control->get_permissions_token != 0);
   memset(&exception, 0, sizeof(DDS_Security_SecurityException));
   memset(&token, 0, sizeof(token));
 
@@ -359,7 +361,9 @@ CU_Test(ddssec_builtin_get_permissions_token, invalid_args, .init = suite_get_pe
 
   /* Pre-requisites. */
   CU_ASSERT_FATAL(access_control != NULL);
+  assert(access_control != NULL);
   CU_ASSERT_FATAL(access_control->get_permissions_token != NULL);
+  assert(access_control->get_permissions_token != 0);
   memset(&exception, 0, sizeof(DDS_Security_SecurityException));
   memset(&token, 0, sizeof(token));
 

--- a/src/security/builtin_plugins/tests/get_xxx_sec_attributes/src/get_xxx_sec_attributes_utests.c
+++ b/src/security/builtin_plugins/tests/get_xxx_sec_attributes/src/get_xxx_sec_attributes_utests.c
@@ -504,7 +504,9 @@ CU_Test(ddssec_builtin_get_xxx_sec_attributes, participant_happy_day, .init = su
   result = plugins_init();
   CU_ASSERT_FATAL(result);
   CU_ASSERT_FATAL(access_control != NULL);
+  assert(access_control != NULL);
   CU_ASSERT_FATAL(access_control->get_participant_sec_attributes != NULL);
+  assert(access_control->get_participant_sec_attributes != 0);
 
   result = create_local_identity(0, "Test_Governance_full.p7s");
   CU_ASSERT_FATAL(result);
@@ -563,7 +565,9 @@ CU_Test(ddssec_builtin_get_xxx_sec_attributes, datawriter_happy_day, .init = sui
   result = plugins_init();
   CU_ASSERT_FATAL(result);
   CU_ASSERT_FATAL(access_control != NULL);
+  assert(access_control != NULL);
   CU_ASSERT_FATAL(access_control->get_datawriter_sec_attributes != NULL);
+  assert(access_control->get_datawriter_sec_attributes != 0);
 
   result = create_local_identity(0, "Test_Governance_full.p7s");
   CU_ASSERT_FATAL(result);
@@ -612,7 +616,9 @@ CU_Test(ddssec_builtin_get_xxx_sec_attributes, datawriter_non_existing_topic, .i
   result = plugins_init();
   CU_ASSERT_FATAL(result);
   CU_ASSERT_FATAL(access_control != NULL);
+  assert(access_control != NULL);
   CU_ASSERT_FATAL(access_control->get_datawriter_sec_attributes != NULL);
+  assert(access_control->get_datawriter_sec_attributes != 0);
 
   /* use a different domain(30) to get non matching topic result */
   result = create_local_identity(30, "Test_Governance_full.p7s");
@@ -653,7 +659,9 @@ CU_Test(ddssec_builtin_get_xxx_sec_attributes, datareader_happy_day, .init = sui
   result = plugins_init();
   CU_ASSERT_FATAL(result);
   CU_ASSERT_FATAL(access_control != NULL);
+  assert(access_control != NULL);
   CU_ASSERT_FATAL(access_control->get_datareader_sec_attributes != NULL);
+  assert(access_control->get_datareader_sec_attributes != 0);
 
   result = create_local_identity(0, "Test_Governance_full.p7s");
   CU_ASSERT_FATAL(result);
@@ -702,7 +710,9 @@ CU_Test(ddssec_builtin_get_xxx_sec_attributes, datareader_non_existing_topic, .i
   result = plugins_init();
   CU_ASSERT_FATAL(result);
   CU_ASSERT_FATAL(access_control != NULL);
+  assert(access_control != NULL);
   CU_ASSERT_FATAL(access_control->get_datawriter_sec_attributes != NULL);
+  assert(access_control->get_datawriter_sec_attributes != 0);
 
   /* use a different domain (30) to get non matching topic result */
   result = create_local_identity(30, "Test_Governance_full.p7s");
@@ -741,7 +751,9 @@ CU_Test(ddssec_builtin_get_xxx_sec_attributes, participant_invalid_param, .init 
   result = plugins_init();
   CU_ASSERT_FATAL(result);
   CU_ASSERT_FATAL(access_control != NULL);
+  assert(access_control != NULL);
   CU_ASSERT_FATAL(access_control->get_participant_sec_attributes != NULL);
+  assert(access_control->get_participant_sec_attributes != 0);
 
   result = access_control->get_participant_sec_attributes(
       NULL,
@@ -797,7 +809,9 @@ CU_Test(ddssec_builtin_get_xxx_sec_attributes, datareader_invalid_param, .init =
   result = plugins_init();
   CU_ASSERT_FATAL(result);
   CU_ASSERT_FATAL(access_control != NULL);
+  assert(access_control != NULL);
   CU_ASSERT_FATAL(access_control->get_datareader_sec_attributes != NULL);
+  assert(access_control->get_datareader_sec_attributes != 0);
 
   memset(&attributes, 0, sizeof(attributes));
 
@@ -881,7 +895,9 @@ CU_Test(ddssec_builtin_get_xxx_sec_attributes, datawriter_invalid_param, .init =
   result = plugins_init();
   CU_ASSERT_FATAL(result);
   CU_ASSERT_FATAL(access_control != NULL);
+  assert(access_control != NULL);
   CU_ASSERT_FATAL(access_control->get_datawriter_sec_attributes != NULL);
+  assert(access_control->get_datawriter_sec_attributes != 0);
 
   memset(&attributes, 0, sizeof(attributes));
 
@@ -964,7 +980,9 @@ CU_Test(ddssec_builtin_get_xxx_sec_attributes, topic_happy_day, .init = suite_ge
   result = plugins_init();
   CU_ASSERT_FATAL(result);
   CU_ASSERT_FATAL(access_control != NULL);
+  assert(access_control != NULL);
   CU_ASSERT_FATAL(access_control->get_topic_sec_attributes != NULL);
+  assert(access_control->get_topic_sec_attributes != 0);
 
   result = create_local_identity(0, "Test_Governance_full.p7s");
   CU_ASSERT_FATAL(result);
@@ -1009,7 +1027,9 @@ CU_Test(ddssec_builtin_get_xxx_sec_attributes, topic_non_existing_topic, .init =
   result = plugins_init();
   CU_ASSERT_FATAL(result);
   CU_ASSERT_FATAL(access_control != NULL);
+  assert(access_control != NULL);
   CU_ASSERT_FATAL(access_control->get_topic_sec_attributes != NULL);
+  assert(access_control->get_topic_sec_attributes != 0);
 
   result = create_local_identity(30, "Test_Governance_full.p7s");
   CU_ASSERT_FATAL(result);
@@ -1049,7 +1069,9 @@ CU_Test(ddssec_builtin_get_xxx_sec_attributes, topic_invalid_param, .init = suit
   result = plugins_init();
   CU_ASSERT_FATAL(result);
   CU_ASSERT_FATAL(access_control != NULL);
+  assert(access_control != NULL);
   CU_ASSERT_FATAL(access_control->get_topic_sec_attributes != NULL);
+  assert(access_control->get_topic_sec_attributes != 0);
 
   result = create_local_identity(0, "Test_Governance_full.p7s");
   CU_ASSERT_FATAL(result);
@@ -1126,7 +1148,9 @@ CU_Test(ddssec_builtin_get_xxx_sec_attributes, participant_2nd_rule, .init = sui
   result = plugins_init();
   CU_ASSERT_FATAL(result);
   CU_ASSERT_FATAL(access_control != NULL);
+  assert(access_control != NULL);
   CU_ASSERT_FATAL(access_control->get_participant_sec_attributes != NULL);
+  assert(access_control->get_participant_sec_attributes != 0);
 
   result = create_local_identity(30, "Test_Governance_full.p7s");
   CU_ASSERT_FATAL(result);
@@ -1193,6 +1217,7 @@ static void test_liveliness_discovery_participant_attr(
   bool result;
 
   CU_ASSERT_FATAL(access_control->get_participant_sec_attributes != NULL);
+  assert(access_control->get_participant_sec_attributes != 0);
 
   memset(&attr, 0, sizeof(attr));
 
@@ -1233,6 +1258,7 @@ static void test_liveliness_discovery_writer_attr(
   bool result;
 
   CU_ASSERT_FATAL(access_control->get_datawriter_sec_attributes != NULL);
+  assert(access_control->get_datawriter_sec_attributes != 0);
 
   memset(&attr, 0, sizeof(attr));
 
@@ -1278,6 +1304,7 @@ static void test_liveliness_discovery_reader_attr(
   bool result;
 
   CU_ASSERT_FATAL(access_control->get_datareader_sec_attributes != NULL);
+  assert(access_control->get_datareader_sec_attributes != 0);
 
   memset(&attr, 0, sizeof(attr));
 

--- a/src/security/builtin_plugins/tests/listeners_access_control/src/listeners_access_control_utests.c
+++ b/src/security/builtin_plugins/tests/listeners_access_control/src/listeners_access_control_utests.c
@@ -587,10 +587,13 @@ CU_Test(ddssec_builtin_listeners_access_control, local_2secs)
   CU_ASSERT_FATAL(valid == DDS_SECURITY_ERR_OK_CODE);
 
   /* Check if we actually have validate_remote_permissions function. */
-  CU_ASSERT_FATAL(access_control != NULL);
   CU_ASSERT_FATAL(local_identity_handle != DDS_SECURITY_HANDLE_NIL);
+  CU_ASSERT_FATAL(access_control != NULL);
+  assert(access_control != NULL);
   CU_ASSERT_FATAL(access_control->validate_remote_permissions != NULL);
+  assert(access_control->validate_remote_permissions != 0);
   CU_ASSERT_FATAL(access_control->return_permissions_handle != NULL);
+  assert(access_control->return_permissions_handle != 0);
 
   fill_permissions_token(&permissions_token);
   r = fill_peer_credential_token(&credential_token, 1);

--- a/src/security/builtin_plugins/tests/listeners_authentication/src/listeners_authentication_utests.c
+++ b/src/security/builtin_plugins/tests/listeners_authentication/src/listeners_authentication_utests.c
@@ -1235,14 +1235,13 @@ create_asymmetrical_signature_for_test(
         goto err_sign;
     }
 
-    //*signature = ddsrt_malloc(sizeof(unsigned char) * (*signatureLen));
-    *signature = OPENSSL_malloc(*signatureLen);
+    *signature = ddsrt_malloc(*signatureLen);
     if (EVP_DigestSignFinal(mdctx, *signature, signatureLen) != 1) {
         char *msg = get_openssl_error_message_for_test();
         result = DDS_SECURITY_VALIDATION_FAILED;
         DDS_Security_Exception_set(ex, "Authentication", DDS_SECURITY_ERR_UNDEFINED_CODE, (int)result, "Failed to finalize signing context: %s", msg);
         ddsrt_free(msg);
-        ddsrt_free(signature);
+        ddsrt_free(*signature);
     }
 
 err_sign:
@@ -1777,12 +1776,13 @@ fill_handshake_message_token(
             {
                 printf("Exception: %s\n", exception.message);
             }
-            CU_ASSERT_FATAL (rc == DDS_SECURITY_VALIDATION_OK);
-            assert(rc == DDS_SECURITY_VALIDATION_OK); // for Clang's static analyzer
-
-            set_binary_property_value(signature, "signature", sign, (uint32_t)signlen);
-
-            ddsrt_free(sign);
+            else
+            {
+                CU_ASSERT_FATAL (rc == DDS_SECURITY_VALIDATION_OK);
+                assert(rc == DDS_SECURITY_VALIDATION_OK); // for Clang's static analyzer
+                set_binary_property_value(signature, "signature", sign, (uint32_t)signlen);
+                ddsrt_free(sign);
+            }
             EVP_PKEY_free(private_key_x509);
             BIO_free(bio);
         }
@@ -1865,9 +1865,11 @@ fill_handshake_message_token(
             {
                 printf("Exception: %s\n", exception.message);
             }
-            set_binary_property_value(signature, "signature", sign, (uint32_t)signlen);
-
-            ddsrt_free(sign);
+            else
+            {
+                set_binary_property_value(signature, "signature", sign, (uint32_t)signlen);
+                ddsrt_free(sign);
+            }
             EVP_PKEY_free(private_key_x509);
             BIO_free(bio);
         }

--- a/src/security/builtin_plugins/tests/listeners_authentication/src/listeners_authentication_utests.c
+++ b/src/security/builtin_plugins/tests/listeners_authentication/src/listeners_authentication_utests.c
@@ -1945,10 +1945,13 @@ CU_Test(ddssec_builtin_listeners_auth, local_remote_set_before_validation)
 
 
     /* Check if we actually have validate_remote_permissions function. */
-    CU_ASSERT_FATAL (access_control != NULL);
     CU_ASSERT_FATAL (local_identity_handle != DDS_SECURITY_HANDLE_NIL);
-    CU_ASSERT_FATAL (access_control->validate_remote_permissions != NULL);
-    CU_ASSERT_FATAL (access_control->return_permissions_handle != NULL);
+    CU_ASSERT_FATAL(access_control != NULL);
+    assert(access_control != NULL);
+    CU_ASSERT_FATAL(access_control->validate_remote_permissions != NULL);
+    assert(access_control->validate_remote_permissions != 0);
+    CU_ASSERT_FATAL(access_control->return_permissions_handle != NULL);
+    assert(access_control->return_permissions_handle != 0);
 
     fill_permissions_token(&permissions_token);
     r = fill_peer_credential_token(&credential_token);

--- a/src/security/builtin_plugins/tests/preprocess_secure_submsg/src/preprocess_secure_submsg_utests.c
+++ b/src/security/builtin_plugins/tests/preprocess_secure_submsg/src/preprocess_secure_submsg_utests.c
@@ -449,8 +449,11 @@ CU_Test(ddssec_builtin_preprocess_secure_submsg, writer_happy_day, .init = suite
     DDS_Security_OctetSeq message;
 
     CU_ASSERT_FATAL (crypto != NULL);
+    assert(crypto != NULL);
     CU_ASSERT_FATAL (crypto->crypto_transform != NULL);
+    assert(crypto->crypto_transform != NULL);
     CU_ASSERT_FATAL (crypto->crypto_transform->preprocess_secure_submsg != NULL);
+    assert(crypto->crypto_transform->preprocess_secure_submsg != 0);
 
     create_encoded_submsg(&message, writer_key_message.sender_key_id, writer_key_message.transformation_kind, VALID_SMID_SEC_PREFIX, false);
 
@@ -515,8 +518,11 @@ CU_Test(ddssec_builtin_preprocess_secure_submsg, reader_happy_day, .init = suite
     DDS_Security_OctetSeq message;
 
     CU_ASSERT_FATAL (crypto != NULL);
-    CU_ASSERT_FATAL (crypto ->crypto_transform!= NULL);
-    CU_ASSERT_FATAL (crypto ->crypto_transform->preprocess_secure_submsg != NULL);
+    assert(crypto != NULL);
+    CU_ASSERT_FATAL (crypto->crypto_transform != NULL);
+    assert(crypto->crypto_transform != NULL);
+    CU_ASSERT_FATAL (crypto->crypto_transform->preprocess_secure_submsg != NULL);
+    assert(crypto->crypto_transform->preprocess_secure_submsg != 0);
 
     create_encoded_submsg(&message, reader_key_message.sender_key_id, reader_key_message.transformation_kind, VALID_SMID_SEC_PREFIX, false);
 
@@ -578,8 +584,11 @@ CU_Test(ddssec_builtin_preprocess_secure_submsg, invalid_args, .init = suite_pre
     DDS_Security_OctetSeq message;
 
     CU_ASSERT_FATAL (crypto != NULL);
-    CU_ASSERT_FATAL (crypto ->crypto_transform!= NULL);
-    CU_ASSERT_FATAL (crypto ->crypto_transform->preprocess_secure_submsg != NULL);
+    assert(crypto != NULL);
+    CU_ASSERT_FATAL (crypto->crypto_transform != NULL);
+    assert(crypto->crypto_transform != NULL);
+    CU_ASSERT_FATAL (crypto->crypto_transform->preprocess_secure_submsg != NULL);
+    assert(crypto->crypto_transform->preprocess_secure_submsg != 0);
 
     create_encoded_submsg(&message, writer_key_message.sender_key_id, reader_key_message.transformation_kind, VALID_SMID_SEC_PREFIX, false);
 
@@ -731,8 +740,11 @@ CU_Test(ddssec_builtin_preprocess_secure_submsg, invalid_message, .init = suite_
     DDS_Security_OctetSeq message;
 
     CU_ASSERT_FATAL (crypto != NULL);
-    CU_ASSERT_FATAL (crypto ->crypto_transform!= NULL);
-    CU_ASSERT_FATAL (crypto ->crypto_transform->preprocess_secure_submsg != NULL);
+    assert(crypto != NULL);
+    CU_ASSERT_FATAL (crypto->crypto_transform != NULL);
+    assert(crypto->crypto_transform != NULL);
+    CU_ASSERT_FATAL (crypto->crypto_transform->preprocess_secure_submsg != NULL);
+    assert(crypto->crypto_transform->preprocess_secure_submsg != 0);
 
     /* unknown key id */
     create_encoded_submsg(&message, writer_key_payload.sender_key_id, writer_key_payload.transformation_kind, VALID_SMID_SEC_PREFIX, false);
@@ -826,8 +838,11 @@ CU_Test(ddssec_builtin_preprocess_secure_submsg, volatile_secure, .init = suite_
     DDS_Security_OctetSeq message;
 
     CU_ASSERT_FATAL (crypto != NULL);
+    assert(crypto != NULL);
     CU_ASSERT_FATAL (crypto->crypto_transform != NULL);
+    assert(crypto->crypto_transform != NULL);
     CU_ASSERT_FATAL (crypto->crypto_transform->preprocess_secure_submsg != NULL);
+    assert(crypto->crypto_transform->preprocess_secure_submsg != 0);
 
     datareader_properties._length = datareader_properties._maximum = 1;
     datareader_properties._buffer = DDS_Security_PropertySeq_allocbuf(1);

--- a/src/security/builtin_plugins/tests/process_handshake/src/process_handshake_utests.c
+++ b/src/security/builtin_plugins/tests/process_handshake/src/process_handshake_utests.c
@@ -1360,9 +1360,11 @@ fill_handshake_message_token(
             {
                 printf("Exception: %s\n", exception.message);
             }
-            set_binary_property_value(signature, "signature", sign, (uint32_t ) signlen);
-
-            ddsrt_free(sign);
+            else
+            {
+                set_binary_property_value(signature, "signature", sign, (uint32_t ) signlen);
+                ddsrt_free(sign);
+            }
             EVP_PKEY_free(private_key_x509);
             BIO_free(bio);
         }
@@ -1445,9 +1447,11 @@ fill_handshake_message_token(
             {
                 printf("Exception: %s\n", exception.message);
             }
-            set_binary_property_value(signature, "signature", sign, (uint32_t) signlen);
-
-            ddsrt_free(sign);
+            else
+            {
+                set_binary_property_value(signature, "signature", sign, (uint32_t) signlen);
+                ddsrt_free(sign);
+            }
             EVP_PKEY_free(private_key_x509);
             BIO_free(bio);
         }

--- a/src/security/builtin_plugins/tests/process_handshake/src/process_handshake_utests.c
+++ b/src/security/builtin_plugins/tests/process_handshake/src/process_handshake_utests.c
@@ -1510,13 +1510,13 @@ validate_handshake_token(
 
     if (!token->class_id || strcmp(token->class_id, class_id) != 0) {
         CU_FAIL("HandshakeMessageToken incorrect class_id");
-    } else if ((property = find_binary_property(token, "hash_c2")) == NULL) {
+    } else if (find_binary_property(token, "hash_c2") == NULL) {
          CU_FAIL("HandshakeMessageToken incorrect property 'hash_c2' not found");
-    } else if ((property = find_binary_property(token, "dh2")) == NULL) {
+    } else if (find_binary_property(token, "dh2") == NULL) {
         CU_FAIL("HandshakeMessageToken incorrect property 'dh2' not found");
-    } else if ((property = find_binary_property(token, "hash_c1")) == NULL) {
+    } else if (find_binary_property(token, "hash_c1") == NULL) {
         CU_FAIL("HandshakeMessageToken incorrect property 'hash_c1' not found");
-    } else if ((property = find_binary_property(token, "dh1")) == NULL) {
+    } else if (find_binary_property(token, "dh1") == NULL) {
         CU_FAIL("HandshakeMessageToken incorrect property 'dh1' not found");
     } else if ((property = find_binary_property(token, "challenge1")) == NULL) {
         CU_FAIL("HandshakeMessageToken incorrect property 'challenge1' not found");
@@ -1549,11 +1549,14 @@ CU_Test(ddssec_builtin_process_handshake,happy_day_after_request )
     struct octet_seq dh1_pub_key;
 
     CU_ASSERT_FATAL (auth != NULL);
+    assert(auth != NULL);
     CU_ASSERT_FATAL (local_identity_handle != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle1 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle2 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (auth->begin_handshake_request != NULL);
+    assert(auth->begin_handshake_request != 0);
     CU_ASSERT_FATAL (auth->process_handshake != NULL);
+    assert(auth->process_handshake != 0);
 
     result = auth->begin_handshake_request(
                     auth,
@@ -1837,11 +1840,14 @@ CU_Test(ddssec_builtin_process_handshake,invalid_certificate )
     DDS_Security_boolean success;
 
     CU_ASSERT_FATAL (auth != NULL);
+    assert(auth != NULL);
     CU_ASSERT_FATAL (local_identity_handle != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle1 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle2 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (auth->begin_handshake_request != NULL);
+    assert(auth->begin_handshake_request != 0);
     CU_ASSERT_FATAL (auth->process_handshake != NULL);
+    assert(auth->process_handshake != 0);
 
     result = auth->begin_handshake_request(
                    auth,
@@ -1923,11 +1929,14 @@ CU_Test(ddssec_builtin_process_handshake,invalid_dsign_algo )
     struct octet_seq dh1_pub_key;
 
     CU_ASSERT_FATAL (auth != NULL);
+    assert(auth != NULL);
     CU_ASSERT_FATAL (local_identity_handle != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle1 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle2 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (auth->begin_handshake_request != NULL);
+    assert(auth->begin_handshake_request != 0);
     CU_ASSERT_FATAL (auth->process_handshake != NULL);
+    assert(auth->process_handshake != 0);
 
     result = auth->begin_handshake_request(
                    auth,
@@ -2003,11 +2012,14 @@ CU_Test(ddssec_builtin_process_handshake,invalid_kagree_algo )
     struct octet_seq dh1_pub_key;
 
     CU_ASSERT_FATAL (auth != NULL);
+    assert(auth != NULL);
     CU_ASSERT_FATAL (local_identity_handle != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle1 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle2 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (auth->begin_handshake_request != NULL);
+    assert(auth->begin_handshake_request != 0);
     CU_ASSERT_FATAL (auth->process_handshake != NULL);
+    assert(auth->process_handshake != 0);
 
     result = auth->begin_handshake_request(
                    auth,
@@ -2082,11 +2094,14 @@ CU_Test(ddssec_builtin_process_handshake,invalid_diffie_hellman )
     const DDS_Security_BinaryProperty_t *dh1;
 
     CU_ASSERT_FATAL (auth != NULL);
+    assert(auth != NULL);
     CU_ASSERT_FATAL (local_identity_handle != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle1 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle2 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (auth->begin_handshake_request != NULL);
+    assert(auth->begin_handshake_request != 0);
     CU_ASSERT_FATAL (auth->process_handshake != NULL);
+    assert(auth->process_handshake != 0);
 
     result = auth->begin_handshake_request(
                    auth,
@@ -2155,10 +2170,12 @@ CU_Test(ddssec_builtin_process_handshake,return_handle)
     DDS_Security_boolean success;
 
     CU_ASSERT_FATAL (auth != NULL);
+    assert(auth != NULL);
     CU_ASSERT_FATAL (local_identity_handle != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle1 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle2 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (auth->begin_handshake_reply != NULL);
+    assert(auth->begin_handshake_reply != 0);
 
     fill_handshake_message_token_default(&handshake_token_in, remote_participant_data1, challenge1_predefined_glb->value._buffer, challenge1_predefined_glb->value._length);
 
@@ -2226,11 +2243,14 @@ CU_Test(ddssec_builtin_process_handshake,extended_certificate_check )
     CU_ASSERT_FATAL( !validate_remote_identities( remote_identity_trusted ) );
 
     CU_ASSERT_FATAL (auth != NULL);
+    assert(auth != NULL);
     CU_ASSERT_FATAL (local_identity_handle != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle1 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle2 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (auth->begin_handshake_request != NULL);
+    assert(auth->begin_handshake_request != 0);
     CU_ASSERT_FATAL (auth->process_handshake != NULL);
+    assert(auth->process_handshake != 0);
 
     result = auth->begin_handshake_request(
                     auth,
@@ -2304,11 +2324,14 @@ CU_Test(ddssec_builtin_process_handshake,extended_certificate_check )
     CU_ASSERT_FATAL( !validate_remote_identities( remote_identity_trusted_expired ) );
 
     CU_ASSERT_FATAL (auth != NULL);
+    assert(auth != NULL);
     CU_ASSERT_FATAL (local_identity_handle != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle1 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle2 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (auth->begin_handshake_request != NULL);
+    assert(auth->begin_handshake_request != 0);
     CU_ASSERT_FATAL (auth->process_handshake != NULL);
+    assert(auth->process_handshake != 0);
 
     result = auth->begin_handshake_request(
                     auth,
@@ -2375,11 +2398,14 @@ CU_Test(ddssec_builtin_process_handshake,extended_certificate_check )
     CU_ASSERT_FATAL( !validate_remote_identities( remote_identity_untrusted ) );
 
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (local_identity_handle != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle1 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle2 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (auth->begin_handshake_request != NULL);
+    assert (auth->begin_handshake_request != 0);
     CU_ASSERT_FATAL (auth->process_handshake != NULL);
+    assert (auth->process_handshake != 0);
 
     result = auth->begin_handshake_request(
                     auth,

--- a/src/security/builtin_plugins/tests/register_local_datareader/src/register_local_datareader_utests.c
+++ b/src/security/builtin_plugins/tests/register_local_datareader/src/register_local_datareader_utests.c
@@ -204,8 +204,11 @@ CU_Test(ddssec_builtin_register_local_datareader, builtin_endpoint, .init = suit
 
   /* Check if we actually have the function. */
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_factory != NULL);
+  assert(crypto->crypto_key_factory != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_factory->register_local_datareader != NULL);
+  assert(crypto->crypto_key_factory->register_local_datareader != 0);
 
   datareader_properties._buffer = DDS_Security_PropertySeq_allocbuf(1);
   datareader_properties._length = datareader_properties._maximum = 1;
@@ -255,8 +258,11 @@ CU_Test(ddssec_builtin_register_local_datareader, special_endpoint_name, .init =
 
   /* Check if we actually have the function. */
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_factory != NULL);
+  assert(crypto->crypto_key_factory != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_factory->register_local_datareader != NULL);
+  assert(crypto->crypto_key_factory->register_local_datareader != 0);
 
   /*set special endpoint name*/
   datareader_properties._buffer = DDS_Security_PropertySeq_allocbuf(1);
@@ -297,8 +303,11 @@ CU_Test(ddssec_builtin_register_local_datareader, invalid_participant, .init = s
 
   /* Check if we actually have the function. */
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_factory != NULL);
+  assert(crypto->crypto_key_factory != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_factory->register_local_datareader != NULL);
+  assert(crypto->crypto_key_factory->register_local_datareader != 0);
 
   memset(&exception, 0, sizeof(DDS_Security_SecurityException));
   memset(&datareader_properties, 0, sizeof(datareader_properties));

--- a/src/security/builtin_plugins/tests/register_local_datawriter/src/register_local_datawriter_utests.c
+++ b/src/security/builtin_plugins/tests/register_local_datawriter/src/register_local_datawriter_utests.c
@@ -154,8 +154,11 @@ CU_Test(ddssec_builtin_register_local_datawriter, happy_day, .init = suite_regis
 
   /* Check if we actually have the function. */
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_factory != NULL);
+  assert(crypto->crypto_key_factory != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_factory->register_local_datawriter != NULL);
+  assert(crypto->crypto_key_factory->register_local_datawriter != 0);
 
   memset(&exception, 0, sizeof(DDS_Security_SecurityException));
   memset(&datawriter_properties, 0, sizeof(datawriter_properties));
@@ -217,8 +220,11 @@ CU_Test(ddssec_builtin_register_local_datawriter, builtin_endpoint, .init = suit
 
   /* Check if we actually have the function. */
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_factory != NULL);
+  assert(crypto->crypto_key_factory != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_factory->register_local_datawriter != NULL);
+  assert(crypto->crypto_key_factory->register_local_datawriter != 0);
 
   datawriter_properties._buffer = DDS_Security_PropertySeq_allocbuf(1);
   datawriter_properties._length = datawriter_properties._maximum = 1;
@@ -276,8 +282,11 @@ CU_Test(ddssec_builtin_register_local_datawriter, special_endpoint_name, .init =
 
   /* Check if we actually have the function. */
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_factory != NULL);
+  assert(crypto->crypto_key_factory != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_factory->register_local_datawriter != NULL);
+  assert(crypto->crypto_key_factory->register_local_datawriter != 0);
 
   /*set special endpoint name*/
   datawriter_properties._buffer = DDS_Security_PropertySeq_allocbuf(1);
@@ -317,8 +326,11 @@ CU_Test(ddssec_builtin_register_local_datawriter, invalid_participant, .init = s
 
   /* Check if we actually have the function. */
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_factory != NULL);
+  assert(crypto->crypto_key_factory != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_factory->register_local_datawriter != NULL);
+  assert(crypto->crypto_key_factory->register_local_datawriter != 0);
 
   memset(&exception, 0, sizeof(DDS_Security_SecurityException));
   memset(&datawriter_properties, 0, sizeof(datawriter_properties));

--- a/src/security/builtin_plugins/tests/register_local_participant/src/register_local_participant_utests.c
+++ b/src/security/builtin_plugins/tests/register_local_participant/src/register_local_participant_utests.c
@@ -78,8 +78,11 @@ CU_Test(ddssec_builtin_register_local_participant, happy_day, .init = suite_regi
 
   /* Check if we actually have the validate_local_identity() function. */
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_factory != NULL);
+  assert(crypto->crypto_key_factory != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_factory->register_local_participant != NULL);
+  assert(crypto->crypto_key_factory->register_local_participant != 0);
 
   memset(&exception, 0, sizeof(DDS_Security_SecurityException));
   memset(&participant_properties, 0, sizeof(participant_properties));
@@ -125,8 +128,11 @@ CU_Test(ddssec_builtin_register_local_participant, empty_identity, .init = suite
 
   /* Check if we actually have the validate_local_identity() function. */
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_factory != NULL);
+  assert(crypto->crypto_key_factory != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_factory->register_local_participant != NULL);
+  assert(crypto->crypto_key_factory->register_local_participant != 0);
 
   memset(&exception, 0, sizeof(DDS_Security_SecurityException));
   memset(&participant_properties, 0, sizeof(participant_properties));

--- a/src/security/builtin_plugins/tests/register_matched_remote_datareader/src/register_matched_remote_datareader_utests.c
+++ b/src/security/builtin_plugins/tests/register_matched_remote_datareader/src/register_matched_remote_datareader_utests.c
@@ -179,8 +179,11 @@ CU_Test(ddssec_builtin_register_remote_datareader, happy_day, .init = suite_regi
 
   /* Check if we actually have the function. */
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_factory != NULL);
+  assert(crypto->crypto_key_factory != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_factory->register_matched_remote_datareader != NULL);
+  assert(crypto->crypto_key_factory->register_matched_remote_datareader != 0);
 
   register_local_regular();
 
@@ -286,8 +289,11 @@ CU_Test(ddssec_builtin_register_remote_datareader, with_origin_authentication, .
 
   /* Check if we actually have the function. */
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_factory != NULL);
+  assert(crypto->crypto_key_factory != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_factory->register_matched_remote_datareader != NULL);
+  assert(crypto->crypto_key_factory->register_matched_remote_datareader != 0);
   register_local_regular();
 
   /*set writer protection kind */
@@ -342,8 +348,11 @@ CU_Test(ddssec_builtin_register_remote_datareader, invalid_participant, .init = 
 
   /* Check if we actually have the function. */
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_factory != NULL);
+  assert(crypto->crypto_key_factory != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_factory->register_matched_remote_datareader != NULL);
+  assert(crypto->crypto_key_factory->register_matched_remote_datareader != 0);
 
   register_local_regular();
 
@@ -372,8 +381,11 @@ CU_Test(ddssec_builtin_register_remote_datareader, invalid_writer_properties, .i
 
   /* Check if we actually have the function. */
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_factory != NULL);
+  assert(crypto->crypto_key_factory != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_factory->register_matched_remote_datareader != NULL);
+  assert(crypto->crypto_key_factory->register_matched_remote_datareader != 0);
   register_local_regular();
 
   /* Now call the function. */

--- a/src/security/builtin_plugins/tests/register_matched_remote_datawriter/src/register_matched_remote_datawriter_utests.c
+++ b/src/security/builtin_plugins/tests/register_matched_remote_datawriter/src/register_matched_remote_datawriter_utests.c
@@ -276,8 +276,11 @@ CU_Test(ddssec_builtin_register_remote_datawriter, with_origin_authentication, .
 
   /* Check if we actually have the function. */
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_factory != NULL);
+  assert(crypto->crypto_key_factory != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_factory->register_matched_remote_datawriter != NULL);
+  assert(crypto->crypto_key_factory->register_matched_remote_datawriter != 0);
   register_local_regular();
 
   /*set reader protection kind */
@@ -330,8 +333,11 @@ CU_Test(ddssec_builtin_register_remote_datawriter, invalid_participant, .init = 
 
   /* Check if we actually have the function. */
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_factory != NULL);
+  assert(crypto->crypto_key_factory != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_factory->register_matched_remote_datawriter != NULL);
+  assert(crypto->crypto_key_factory->register_matched_remote_datawriter != 0);
   register_local_regular();
 
   /* Now call the function. */
@@ -358,8 +364,11 @@ CU_Test(ddssec_builtin_register_remote_datawriter, invalid_writer_properties, .i
 
   /* Check if we actually have the function. */
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_factory != NULL);
+  assert(crypto->crypto_key_factory != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_factory->register_matched_remote_datawriter != NULL);
+  assert(crypto->crypto_key_factory->register_matched_remote_datawriter != 0);
   register_local_regular();
 
   /* Now call the function. */

--- a/src/security/builtin_plugins/tests/set_remote_datareader_crypto_tokens/src/set_remote_datareader_crypto_tokens_utests.c
+++ b/src/security/builtin_plugins/tests/set_remote_datareader_crypto_tokens/src/set_remote_datareader_crypto_tokens_utests.c
@@ -351,8 +351,11 @@ CU_Test(ddssec_builtin_set_remote_datareader_crypto_tokens, happy_day, .init = s
   DDS_Security_DatawriterCryptoTokenSeq tokens;
 
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange != NULL);
+  assert(crypto->crypto_key_exchange != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange->set_remote_datareader_crypto_tokens != NULL);
+  assert(crypto->crypto_key_exchange->set_remote_datareader_crypto_tokens != 0);
 
   memset(&tokens, 0, sizeof(tokens));
 
@@ -385,8 +388,11 @@ CU_Test(ddssec_builtin_set_remote_datareader_crypto_tokens, single_token, .init 
   DDS_Security_DatawriterCryptoTokenSeq tokens;
 
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange != NULL);
+  assert(crypto->crypto_key_exchange != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange->set_remote_datareader_crypto_tokens != NULL);
+  assert(crypto->crypto_key_exchange->set_remote_datareader_crypto_tokens != NULL);
   memset(&tokens, 0, sizeof(tokens));
   create_reader_tokens(&tokens);
 
@@ -418,8 +424,11 @@ CU_Test(ddssec_builtin_set_remote_datareader_crypto_tokens, invalid_args, .init 
 
   /* Check if we actually have the validate_local_identity() function. */
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange != NULL);
+  assert(crypto->crypto_key_exchange != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange->set_remote_datareader_crypto_tokens != NULL);
+  assert(crypto->crypto_key_exchange->set_remote_datareader_crypto_tokens != 0);
 
   memset(&tokens, 0, sizeof(tokens));
 
@@ -517,8 +526,11 @@ CU_Test(ddssec_builtin_set_remote_datareader_crypto_tokens, invalid_tokens, .ini
   DDS_Security_DatawriterCryptoTokenSeq empty_tokens;
 
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange != NULL);
+  assert(crypto->crypto_key_exchange != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange->set_remote_datareader_crypto_tokens != NULL);
+  assert(crypto->crypto_key_exchange->set_remote_datareader_crypto_tokens != 0);
 
   memset(&tokens, 0, sizeof(tokens));
   memset(&empty_tokens, 0, sizeof(empty_tokens));
@@ -662,8 +674,11 @@ CU_Test(ddssec_builtin_set_remote_datareader_crypto_tokens, invalid_key_material
   DDS_Security_KeyMaterial_AES_GCM_GMAC keymat;
 
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange != NULL);
+  assert(crypto->crypto_key_exchange != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange->set_remote_datareader_crypto_tokens != NULL);
+  assert(crypto->crypto_key_exchange->set_remote_datareader_crypto_tokens != 0);
 
   memset(&tokens, 0, sizeof(tokens));
 

--- a/src/security/builtin_plugins/tests/set_remote_datawriter_crypto_tokens/src/set_remote_datawriter_crypto_tokens_utests.c
+++ b/src/security/builtin_plugins/tests/set_remote_datawriter_crypto_tokens/src/set_remote_datawriter_crypto_tokens_utests.c
@@ -345,8 +345,11 @@ CU_Test(ddssec_builtin_set_remote_datawriter_crypto_tokens, happy_day, .init = s
   DDS_Security_DatawriterCryptoTokenSeq tokens;
 
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange != NULL);
+  assert(crypto->crypto_key_exchange != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange->set_remote_datawriter_crypto_tokens != NULL);
+  assert(crypto->crypto_key_exchange->set_remote_datawriter_crypto_tokens != 0);
 
   memset(&tokens, 0, sizeof(tokens));
 
@@ -377,8 +380,11 @@ CU_Test(ddssec_builtin_set_remote_datawriter_crypto_tokens, single_token, .init 
   DDS_Security_DatawriterCryptoTokenSeq tokens;
 
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange != NULL);
+  assert(crypto->crypto_key_exchange != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange->set_remote_datawriter_crypto_tokens != NULL);
+  assert(crypto->crypto_key_exchange->set_remote_datawriter_crypto_tokens != 0);
   memset(&tokens, 0, sizeof(tokens));
   create_writer_tokens(&tokens, 1);
 
@@ -408,8 +414,11 @@ CU_Test(ddssec_builtin_set_remote_datawriter_crypto_tokens, invalid_args, .init 
 
   /* Check if we actually have the validate_local_identity() function. */
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange != NULL);
+  assert(crypto->crypto_key_exchange != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange->create_local_datawriter_crypto_tokens != NULL);
+  assert(crypto->crypto_key_exchange->create_local_datawriter_crypto_tokens != 0);
   memset(&tokens, 0, sizeof(tokens));
   create_writer_tokens(&tokens, 2);
 
@@ -503,8 +512,11 @@ CU_Test(ddssec_builtin_set_remote_datawriter_crypto_tokens, invalid_tokens, .ini
   DDS_Security_DatawriterCryptoTokenSeq empty_tokens;
 
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange != NULL);
+  assert(crypto->crypto_key_exchange != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange->set_remote_datawriter_crypto_tokens != NULL);
+  assert(crypto->crypto_key_exchange->set_remote_datawriter_crypto_tokens != 0);
 
   memset(&tokens, 0, sizeof(tokens));
   memset(&empty_tokens, 0, sizeof(empty_tokens));
@@ -713,8 +725,11 @@ CU_Test(ddssec_builtin_set_remote_datawriter_crypto_tokens, invalid_key_material
   DDS_Security_KeyMaterial_AES_GCM_GMAC keymat;
 
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange != NULL);
+  assert(crypto->crypto_key_exchange != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange->set_remote_datawriter_crypto_tokens != NULL);
+  assert(crypto->crypto_key_exchange->set_remote_datawriter_crypto_tokens != 0);
   memset(&tokens, 0, sizeof(tokens));
   create_writer_tokens_no_key_material(&tokens, 1);
 

--- a/src/security/builtin_plugins/tests/set_remote_participant_crypto_tokens/src/set_remote_participant_crypto_tokens_utests.c
+++ b/src/security/builtin_plugins/tests/set_remote_participant_crypto_tokens/src/set_remote_participant_crypto_tokens_utests.c
@@ -204,8 +204,11 @@ CU_Test(ddssec_builtin_set_remote_participant_crypto_tokens, happy_day, .init = 
 
   /* Check if we actually have the validate_local_identity() function. */
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange != NULL);
+  assert(crypto->crypto_key_exchange != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange->set_remote_participant_crypto_tokens != NULL);
+  assert(crypto->crypto_key_exchange->set_remote_participant_crypto_tokens != 0);
 
   memset(&exception, 0, sizeof(DDS_Security_SecurityException));
 
@@ -235,8 +238,11 @@ CU_Test(ddssec_builtin_set_remote_participant_crypto_tokens, invalid_args, .init
 
   /* Check if we actually have the validate_local_identity() function. */
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange != NULL);
+  assert(crypto->crypto_key_exchange != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange->create_local_participant_crypto_tokens != NULL);
+  assert(crypto->crypto_key_exchange->create_local_participant_crypto_tokens != 0);
 
   memset(&exception, 0, sizeof(DDS_Security_SecurityException));
   memset(&participant_properties, 0, sizeof(participant_properties));
@@ -329,8 +335,11 @@ CU_Test(ddssec_builtin_set_remote_participant_crypto_tokens, invalid_tokens, .in
 
   /* Check if we actually have the validate_local_identity() function. */
   CU_ASSERT_FATAL(crypto != NULL);
+  assert(crypto != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange != NULL);
+  assert(crypto->crypto_key_exchange != NULL);
   CU_ASSERT_FATAL(crypto->crypto_key_exchange->create_local_participant_crypto_tokens != NULL);
+  assert(crypto->crypto_key_exchange->create_local_participant_crypto_tokens != 0);
 
   memset(&exception, 0, sizeof(DDS_Security_SecurityException));
   memset(&participant_properties, 0, sizeof(participant_properties));

--- a/src/security/builtin_plugins/tests/validate_begin_handshake_reply/src/validate_begin_handshake_reply_utests.c
+++ b/src/security/builtin_plugins/tests/validate_begin_handshake_reply/src/validate_begin_handshake_reply_utests.c
@@ -1170,7 +1170,7 @@ validate_handshake_token(
         CU_FAIL("HandshakeMessageToken incorrect property 'c.id' not found");
     } else if (!valid_c_id_property(&identity_certificate[6], &property->value)) {
         CU_FAIL("HandshakeMessageToken incorrect property 'c.id' value is invalid");
-    } else if ((property = find_binary_property(token, "c.pdata")) == NULL) {
+    } else if (find_binary_property(token, "c.pdata") == NULL) {
         CU_FAIL("HandshakeMessageToken incorrect property 'c.pdata' not found");
     } else if ((property = find_binary_property(token, "c.dsign_algo")) == NULL) {
         CU_FAIL("HandshakeMessageToken incorrect property 'c.dsign_algo' not found");
@@ -1180,13 +1180,13 @@ validate_handshake_token(
         CU_FAIL("HandshakeMessageToken incorrect property 'c.kagree_algo' not found");
     } else if (!valid_string_value(AUTH_KAGREE_ALGO_RSA_NAME, &property->value)) {
         CU_FAIL("HandshakeMessageToken incorrect property 'c.kagree_algo' incorrect value");
-    } else if ((property = find_binary_property(token, "hash_c2")) == NULL) {
+    } else if (find_binary_property(token, "hash_c2") == NULL) {
          CU_FAIL("HandshakeMessageToken incorrect property 'hash_c2' not found");
-    } else if ((property = find_binary_property(token, "dh2")) == NULL) {
+    } else if (find_binary_property(token, "dh2") == NULL) {
         CU_FAIL("HandshakeMessageToken incorrect property 'dh2' not found");
-    } else if ((property = find_binary_property(token, "hash_c1")) == NULL) {
+    } else if (find_binary_property(token, "hash_c1") == NULL) {
         CU_FAIL("HandshakeMessageToken incorrect property 'hash_c1' not found");
-    } else if ((property = find_binary_property(token, "dh1")) == NULL) {
+    } else if (find_binary_property(token, "dh1") == NULL) {
         CU_FAIL("HandshakeMessageToken incorrect property 'dh1' not found");
     } else if ((property = find_binary_property(token, "challenge1")) == NULL) {
         CU_FAIL("HandshakeMessageToken incorrect property 'challenge1' not found");
@@ -1213,11 +1213,12 @@ CU_Test(ddssec_builtin_validate_begin_handshake_reply, happy_day,  .init = init_
     DDS_Security_boolean success;
 
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (local_identity_handle != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle1 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle2 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (auth->begin_handshake_reply != NULL);
-
+    assert (auth->begin_handshake_reply != 0);
 
     fill_handshake_message_token_default(&handshake_token_in, remote_participant_data1, challenge2->value._buffer, challenge2->value._length);
 
@@ -1264,10 +1265,12 @@ CU_Test(ddssec_builtin_validate_begin_handshake_reply,future_challenge,  .init =
     DDS_Security_boolean success;
 
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (local_identity_handle != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle1 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle2 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (auth->begin_handshake_reply != NULL);
+    assert (auth->begin_handshake_reply != NULL);
 
     fill_handshake_message_token_default(&handshake_token_in, remote_participant_data2, challenge2->value._buffer, challenge2->value._length);
 
@@ -1316,10 +1319,12 @@ CU_Test(ddssec_builtin_validate_begin_handshake_reply,invalid_arguments,  .init 
     DDS_Security_OctetSeq serdata = DDS_SECURITY_SEQUENCE_INIT;
 
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (local_identity_handle != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle1 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle2 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (auth->begin_handshake_reply != NULL);
+    assert (auth->begin_handshake_reply != 0);
 
     fill_handshake_message_token_default(&handshake_token_in, remote_participant_data1, challenge1->value._buffer, challenge1->value._length);
 
@@ -1462,10 +1467,12 @@ CU_Test(ddssec_builtin_validate_begin_handshake_reply,invalid_certificate,  .ini
     DDS_Security_SecurityException exception = {NULL, 0, 0};
 
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (local_identity_handle != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle1 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle2 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (auth->begin_handshake_reply != NULL);
+    assert (auth->begin_handshake_reply != 0);
 
     fill_handshake_message_token(
             &handshake_token_in, remote_participant_data1, unrelated_identity,
@@ -1531,10 +1538,12 @@ CU_Test(ddssec_builtin_validate_begin_handshake_reply,invalid_participant_data ,
     DDS_Security_BinaryProperty_t *property;
 
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (local_identity_handle != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle1 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle2 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (auth->begin_handshake_reply != NULL);
+    assert (auth->begin_handshake_reply != 0);
 
     fill_handshake_message_token(
             &handshake_token_in, remote_participant_data3, remote_identity_certificate,
@@ -1608,10 +1617,12 @@ CU_Test(ddssec_builtin_validate_begin_handshake_reply,invalid_dsign_algo ,  .ini
     DDS_Security_SecurityException exception = {NULL, 0, 0};
 
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (local_identity_handle != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle1 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle2 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (auth->begin_handshake_reply != NULL);
+    assert (auth->begin_handshake_reply != 0);
 
     fill_handshake_message_token(
             &handshake_token_in, remote_participant_data1, remote_identity_certificate,
@@ -1677,10 +1688,12 @@ CU_Test(ddssec_builtin_validate_begin_handshake_reply,invalid_kagree_algo ,  .in
     DDS_Security_SecurityException exception = {NULL, 0, 0};
 
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (local_identity_handle != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle1 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle2 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (auth->begin_handshake_reply != NULL);
+    assert (auth->begin_handshake_reply != 0);
 
     fill_handshake_message_token(
             &handshake_token_in, remote_participant_data1, remote_identity_certificate,
@@ -1746,10 +1759,12 @@ CU_Test(ddssec_builtin_validate_begin_handshake_reply,invalid_diffie_hellman ,  
     DDS_Security_SecurityException exception = {NULL, 0, 0};
 
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (local_identity_handle != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle1 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle2 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (auth->begin_handshake_reply != NULL);
+    assert (auth->begin_handshake_reply != 0);
 
     fill_handshake_message_token(
             &handshake_token_in, remote_participant_data1, remote_identity_certificate,
@@ -1815,10 +1830,12 @@ CU_Test(ddssec_builtin_validate_begin_handshake_reply,invalid_challenge ,  .init
     DDS_Security_SecurityException exception = {NULL, 0, 0};
 
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (local_identity_handle != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle1 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle2 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (auth->begin_handshake_reply != NULL);
+    assert (auth->begin_handshake_reply != 0);
 
     fill_handshake_message_token_default(&handshake_token_in, remote_participant_data2, challenge2->value._buffer, challenge2->value._length);
 
@@ -1904,10 +1921,12 @@ CU_Test(ddssec_builtin_validate_begin_handshake_reply,return_handle,  .init = in
     DDS_Security_boolean success;
 
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (local_identity_handle != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle1 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle2 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (auth->begin_handshake_reply != NULL);
+    assert (auth->begin_handshake_reply != 0);
 
     fill_handshake_message_token_default(&handshake_token_in, remote_participant_data1, challenge2->value._buffer, challenge2->value._length);
 
@@ -1969,11 +1988,12 @@ CU_Test(validate_begin_handshake_reply,extended_certificate_check,  .init = init
     CU_ASSERT_FATAL( !validate_remote_identities( remote_identity_trusted ) );
 
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (local_identity_handle != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle1 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle2 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (auth->begin_handshake_reply != NULL);
-
+    assert (auth->begin_handshake_reply != 0);
 
     fill_handshake_message_token(
                     &handshake_token_in, remote_participant_data1, remote_identity_trusted,
@@ -2018,11 +2038,12 @@ CU_Test(validate_begin_handshake_reply,extended_certificate_check,  .init = init
     CU_ASSERT_FATAL( !validate_remote_identities( remote_identity_untrusted ) );
 
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (local_identity_handle != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle1 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle2 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (auth->begin_handshake_reply != NULL);
-
+    assert (auth->begin_handshake_reply != 0);
 
     fill_handshake_message_token(
                     &handshake_token_in, remote_participant_data1, remote_identity_untrusted,
@@ -2057,11 +2078,12 @@ CU_Test(validate_begin_handshake_reply,extended_certificate_check,  .init = init
     CU_ASSERT_FATAL( !validate_remote_identities( remote_identity_trusted_expired ) );
 
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (local_identity_handle != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle1 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle2 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (auth->begin_handshake_reply != NULL);
-
+    assert (auth->begin_handshake_reply != 0);
 
     fill_handshake_message_token(
                     &handshake_token_in, remote_participant_data1, remote_identity_trusted_expired,

--- a/src/security/builtin_plugins/tests/validate_begin_handshake_request/src/validate_begin_handshake_request_utests.c
+++ b/src/security/builtin_plugins/tests/validate_begin_handshake_request/src/validate_begin_handshake_request_utests.c
@@ -543,7 +543,7 @@ validate_handshake_token(
         CU_FAIL("HandshakeMessageToken incorrect property 'c.id' not found");
     } else if (!valid_c_id_property(&identity_certificate[6], &property->value)) {
         CU_FAIL("HandshakeMessageToken incorrect property 'c.id' value is invalid");
-    } else if ((property = find_binary_property(token, "c.pdata")) == NULL) {
+    } else if (find_binary_property(token, "c.pdata") == NULL) {
         CU_FAIL("HandshakeMessageToken incorrect property 'c.pdata' not found");
     } else if ((property = find_binary_property(token, "c.dsign_algo")) == NULL) {
         CU_FAIL("HandshakeMessageToken incorrect property 'c.dsign_algo' not found");
@@ -553,9 +553,9 @@ validate_handshake_token(
         CU_FAIL("HandshakeMessageToken incorrect property 'c.kagree_algo' not found");
     } else if (!valid_string_value(AUTH_KAGREE_ALGO_ECDH_NAME, &property->value)) {
         CU_FAIL("HandshakeMessageToken incorrect property 'c.kagree_algo' incorrect value");
-    } else if ((property = find_binary_property(token, "hash_c1")) == NULL) {
+    } else if (find_binary_property(token, "hash_c1") == NULL) {
         CU_FAIL("HandshakeMessageToken incorrect property 'hash_c1' not found");
-    } else if ((property = find_binary_property(token, "dh1")) == NULL) {
+    } else if (find_binary_property(token, "dh1") == NULL) {
         CU_FAIL("HandshakeMessageToken incorrect property 'dh1' not found");
     } else if ((property = find_binary_property(token, "challenge1")) == NULL) {
         CU_FAIL("HandshakeMessageToken incorrect property 'challenge1' not found");
@@ -580,10 +580,12 @@ CU_Test(ddssec_builtin_validate_begin_handshake_request,happy_day_challenge)
     DDS_Security_boolean success;
 
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (local_identity_handle != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle1 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle2 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (auth->begin_handshake_request != NULL);
+    assert (auth->begin_handshake_request != 0);
 
     fill_local_participant_data(&local_participant_data, 82);
 
@@ -629,10 +631,12 @@ CU_Test(ddssec_builtin_validate_begin_handshake_request,happy_day_future_challen
     DDS_Security_boolean success;
 
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (local_identity_handle != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle1 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle2 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (auth->begin_handshake_request != NULL);
+    assert (auth->begin_handshake_request != 0);
 
     fill_local_participant_data(&local_participant_data, 82);
 
@@ -678,10 +682,12 @@ CU_Test(ddssec_builtin_validate_begin_handshake_request,invalid_arguments)
     DDS_Security_OctetSeq local_participant_data;
 
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (local_identity_handle != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle1 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle2 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (auth->begin_handshake_request != NULL);
+    assert (auth->begin_handshake_request != 0);
 
     fill_local_participant_data(&local_participant_data, 82);
 
@@ -783,10 +789,12 @@ CU_Test(ddssec_builtin_validate_begin_handshake_request,return_handle)
     DDS_Security_boolean success;
 
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (local_identity_handle != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle1 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (remote_identity_handle2 != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (auth->begin_handshake_request != NULL);
+    assert (auth->begin_handshake_request != 0);
 
     fill_local_participant_data(&local_participant_data, 82);
 

--- a/src/security/builtin_plugins/tests/validate_local_identity/src/validate_local_identity_utests.c
+++ b/src/security/builtin_plugins/tests/validate_local_identity/src/validate_local_identity_utests.c
@@ -570,7 +570,9 @@ CU_Test(ddssec_builtin_validate_local_identity,happy_day)
 
     /* Check if we actually have the validate_local_identity() function. */
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (auth->validate_local_identity != NULL);
+    assert (auth->validate_local_identity != 0);
 
     memset(&adjusted_participant_guid, 0, sizeof(adjusted_participant_guid));
     memcpy(&candidate_participant_guid.prefix, &prefix, sizeof(prefix));
@@ -675,7 +677,9 @@ CU_Test(ddssec_builtin_validate_local_identity,invalid_certificate)
 
     /* Check if we actually have the validate_local_identity() function. */
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (auth->validate_local_identity != NULL);
+    assert (auth->validate_local_identity != 0);
 
     memset(&adjusted_participant_guid, 0, sizeof(adjusted_participant_guid));
     memcpy(&candidate_participant_guid.prefix, &prefix, sizeof(prefix));
@@ -759,7 +763,9 @@ CU_Test(ddssec_builtin_validate_local_identity,invalid_root)
 
     /* Check if we actually have the validate_local_identity() function. */
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (auth->validate_local_identity != NULL);
+    assert (auth->validate_local_identity != 0);
 
     memset(&adjusted_participant_guid, 0, sizeof(adjusted_participant_guid));
     memcpy(&candidate_participant_guid.prefix, &prefix, sizeof(prefix));
@@ -839,7 +845,9 @@ CU_Test(ddssec_builtin_validate_local_identity,invalid_chain)
 
     /* Check if we actually have the validate_local_identity() function. */
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (auth->validate_local_identity != NULL);
+    assert (auth->validate_local_identity != 0);
 
     memset(&adjusted_participant_guid, 0, sizeof(adjusted_participant_guid));
     memcpy(&candidate_participant_guid.prefix, &prefix, sizeof(prefix));
@@ -921,7 +929,9 @@ CU_Test(ddssec_builtin_validate_local_identity,certificate_key_to_small)
 
     /* Check if we actually have the validate_local_identity() function. */
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (auth->validate_local_identity != NULL);
+    assert (auth->validate_local_identity != 0);
 
     memset(&adjusted_participant_guid, 0, sizeof(adjusted_participant_guid));
     memcpy(&candidate_participant_guid.prefix, &prefix, sizeof(prefix));
@@ -971,7 +981,9 @@ CU_Test(ddssec_builtin_validate_local_identity,invalid_private_key)
 
     /* Check if we actually have the validate_local_identity() function. */
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (auth->validate_local_identity != NULL);
+    assert (auth->validate_local_identity != 0);
 
     memset(&adjusted_participant_guid, 0, sizeof(adjusted_participant_guid));
     memcpy(&candidate_participant_guid.prefix, &prefix, sizeof(prefix));
@@ -1052,7 +1064,9 @@ CU_Test(ddssec_builtin_validate_local_identity,private_key_to_small)
 
     /* Check if we actually have the validate_local_identity() function. */
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (auth->validate_local_identity != NULL);
+    assert (auth->validate_local_identity != 0);
 
     memset(&adjusted_participant_guid, 0, sizeof(adjusted_participant_guid));
     memcpy(&candidate_participant_guid.prefix, &prefix, sizeof(prefix));
@@ -1101,7 +1115,9 @@ CU_Test(ddssec_builtin_validate_local_identity,missing_certificate_property)
 
     /* Check if we actually have the validate_local_identity() function. */
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (auth->validate_local_identity != NULL);
+    assert (auth->validate_local_identity != 0);
 
     memset(&adjusted_participant_guid, 0, sizeof(adjusted_participant_guid));
     memcpy(&candidate_participant_guid.prefix, &prefix, sizeof(prefix));
@@ -1158,7 +1174,9 @@ CU_Test(ddssec_builtin_validate_local_identity,missing_ca_property)
 
     /* Check if we actually have the validate_local_identity() function. */
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (auth->validate_local_identity != NULL);
+    assert (auth->validate_local_identity != 0);
 
     memset(&adjusted_participant_guid, 0, sizeof(adjusted_participant_guid));
     memcpy(&candidate_participant_guid.prefix, &prefix, sizeof(prefix));
@@ -1212,7 +1230,9 @@ CU_Test(ddssec_builtin_validate_local_identity,missing_private_key_property)
 
     /* Check if we actually have the validate_local_identity() function. */
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (auth->validate_local_identity != NULL);
+    assert (auth->validate_local_identity != 0);
 
     memset(&adjusted_participant_guid, 0, sizeof(adjusted_participant_guid));
     memcpy(&candidate_participant_guid.prefix, &prefix, sizeof(prefix));
@@ -1266,7 +1286,9 @@ CU_Test(ddssec_builtin_validate_local_identity,unsupported_certification_format)
 
     /* Check if we actually have the validate_local_identity() function. */
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (auth->validate_local_identity != NULL);
+    assert (auth->validate_local_identity != 0);
 
     len = strlen("uri:") + strlen(&identity_certificate[6]) + 1;
     cert = ddsrt_malloc(len);
@@ -1320,7 +1342,9 @@ CU_Test(ddssec_builtin_validate_local_identity,encrypted_key)
 
     /* Check if we actually have the validate_local_identity() function. */
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (auth->validate_local_identity != NULL);
+    assert (auth->validate_local_identity != 0);
 
     memset(&adjusted_participant_guid, 0, sizeof(adjusted_participant_guid));
     memcpy(&candidate_participant_guid.prefix, &prefix, sizeof(prefix));
@@ -1402,7 +1426,9 @@ CU_Test(ddssec_builtin_validate_local_identity,encrypted_key_no_password)
 
     /* Check if we actually have the validate_local_identity() function. */
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (auth->validate_local_identity != NULL);
+    assert (auth->validate_local_identity != 0);
 
     memset(&adjusted_participant_guid, 0, sizeof(adjusted_participant_guid));
     memcpy(&candidate_participant_guid.prefix, &prefix, sizeof(prefix));
@@ -1474,7 +1500,9 @@ CU_Test(ddssec_builtin_validate_local_identity,encrypted_key_invalid_password)
 
     /* Check if we actually have the validate_local_identity() function. */
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (auth->validate_local_identity != NULL);
+    assert (auth->validate_local_identity != 0);
 
     memset(&adjusted_participant_guid, 0, sizeof(adjusted_participant_guid));
     memcpy(&candidate_participant_guid.prefix, &prefix, sizeof(prefix));
@@ -1558,7 +1586,9 @@ CU_Test(ddssec_builtin_validate_local_identity,happy_day_eliptic)
 
     /* Check if we actually have the validate_local_identity() function. */
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (auth->validate_local_identity != NULL);
+    assert (auth->validate_local_identity != 0);
 
     memset(&adjusted_participant_guid, 0, sizeof(adjusted_participant_guid));
     memcpy(&candidate_participant_guid.prefix, &prefix, sizeof(prefix));
@@ -1660,7 +1690,9 @@ CU_Test(ddssec_builtin_validate_local_identity,encrypted_ec_key)
 
     /* Check if we actually have the validate_local_identity() function. */
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (auth->validate_local_identity != NULL);
+    assert (auth->validate_local_identity != 0);
 
     memset(&adjusted_participant_guid, 0, sizeof(adjusted_participant_guid));
     memcpy(&candidate_participant_guid.prefix, &prefix, sizeof(prefix));
@@ -1743,7 +1775,9 @@ CU_Test(ddssec_builtin_validate_local_identity,elliptic_unsupported_certificate)
 
     /* Check if we actually have the validate_local_identity() function. */
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (auth->validate_local_identity != NULL);
+    assert (auth->validate_local_identity != 0);
 
     memset(&adjusted_participant_guid, 0, sizeof(adjusted_participant_guid));
     memcpy(&candidate_participant_guid.prefix, &prefix, sizeof(prefix));
@@ -1795,7 +1829,9 @@ CU_Test(ddssec_builtin_validate_local_identity,elliptic_unsupported_private_key)
 
     /* Check if we actually have the validate_local_identity() function. */
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (auth->validate_local_identity != NULL);
+    assert (auth->validate_local_identity != 0);
 
     memset(&adjusted_participant_guid, 0, sizeof(adjusted_participant_guid));
     memcpy(&candidate_participant_guid.prefix, &prefix, sizeof(prefix));
@@ -1848,7 +1884,9 @@ CU_Test(ddssec_builtin_validate_local_identity,return_freed_handle)
 
     /* Check if we actually have the validate_local_identity() function. */
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (auth->validate_local_identity != NULL);
+    assert (auth->validate_local_identity != 0);
 
     memset(&adjusted_participant_guid, 0, sizeof(adjusted_participant_guid));
     memcpy(&candidate_participant_guid.prefix, &prefix, sizeof(prefix));
@@ -1921,7 +1959,9 @@ CU_Test(ddssec_builtin_validate_local_identity,no_file)
 
     /* Check if we actually have the validate_local_identity() function. */
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (auth->validate_local_identity != NULL);
+    assert (auth->validate_local_identity != 0);
 
     /* validate with file */
     memset(&adjusted_participant_guid, 0, sizeof(adjusted_participant_guid));
@@ -2036,7 +2076,9 @@ CU_Test(ddssec_builtin_validate_local_identity,with_extended_certificate_check)
 
     /* Check if we actually have the validate_local_identity() function. */
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (auth->validate_local_identity != NULL);
+    assert (auth->validate_local_identity != 0);
 
     memset(&adjusted_participant_guid, 0, sizeof(adjusted_participant_guid));
     memcpy(&candidate_participant_guid.prefix, &prefix, sizeof(prefix));

--- a/src/security/builtin_plugins/tests/validate_local_permissions/src/validate_local_permissions_utests.c
+++ b/src/security/builtin_plugins/tests/validate_local_permissions/src/validate_local_permissions_utests.c
@@ -258,7 +258,10 @@ static DDS_Security_IdentityHandle create_local_identity(DDS_Security_Qos *parti
   DDS_Security_GuidPrefix_t prefix = {0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xbb};
   DDS_Security_EntityId_t entityId = {{0xb0, 0xb1, 0xb2}, 0x1};
 
+  CU_ASSERT_FATAL(g_auth != NULL);
+  assert(g_auth != NULL);
   CU_ASSERT_FATAL(g_auth->validate_local_identity != NULL);
+  assert(g_auth->validate_local_identity != 0);
 
   memset(&local_participant_guid, 0, sizeof(local_participant_guid));
   memcpy(&candidate_participant_guid.prefix, &prefix, sizeof(prefix));
@@ -435,9 +438,13 @@ static DDS_Security_IdentityHandle test_setup(DDS_Security_Qos *participant_qos)
   if (g_plugins)
   {
     CU_ASSERT_FATAL(g_auth != NULL);
+    assert(g_auth != NULL);
     CU_ASSERT_FATAL(g_access_control != NULL);
+    assert(g_access_control != NULL);
     CU_ASSERT_FATAL(g_access_control->validate_local_permissions != NULL);
+    assert(g_access_control->validate_local_permissions != 0);
     CU_ASSERT_FATAL(g_access_control->return_permissions_handle != NULL);
+    assert(g_access_control->return_permissions_handle != 0);
 
     local_id_hdl = create_local_identity(participant_qos);
   }

--- a/src/security/builtin_plugins/tests/validate_remote_identity/src/validate_remote_identity_utests.c
+++ b/src/security/builtin_plugins/tests/validate_remote_identity/src/validate_remote_identity_utests.c
@@ -441,9 +441,11 @@ CU_Test(ddssec_builtin_validate_remote_identity,happy_day_nil_auth_req )
     DDS_Security_SecurityException exception = {NULL, 0, 0};
 
     /* Check if we actually have validate_local_identity function. */
-    CU_ASSERT (auth != NULL);
     CU_ASSERT (local_identity_handle != DDS_SECURITY_HANDLE_NIL);
-    CU_ASSERT (auth->validate_remote_identity != NULL);
+    CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
+    CU_ASSERT_FATAL (auth->validate_remote_identity != NULL);
+    assert (auth->validate_remote_identity != NULL);
 
     if (local_identity_handle == DDS_SECURITY_HANDLE_NIL) {
         return;
@@ -501,8 +503,11 @@ CU_Test(ddssec_builtin_validate_remote_identity,happy_day_with_auth_req )
 
     /* Check if we actually have validate_local_identity function. */
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (local_identity_handle != DDS_SECURITY_HANDLE_NIL);
+    CU_ASSERT_FATAL (auth != NULL);
     CU_ASSERT_FATAL (auth->validate_remote_identity != NULL);
+    assert (auth->validate_remote_identity != 0);
 
     initialize_identity_token(&remote_identity_token, RSA_2048_ALGORITHM_NAME, RSA_2048_ALGORITHM_NAME);
     fill_auth_request_token(&remote_auth_request_token);
@@ -553,8 +558,11 @@ CU_Test(ddssec_builtin_validate_remote_identity,invalid_parameters )
 
     /* Check if we actually have validate_local_identity function. */
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (local_identity_handle != DDS_SECURITY_HANDLE_NIL);
+    CU_ASSERT_FATAL (auth != NULL);
     CU_ASSERT_FATAL (auth->validate_remote_identity != NULL);
+    assert (auth->validate_remote_identity != 0);
 
     initialize_identity_token(&remote_identity_token, RSA_2048_ALGORITHM_NAME, RSA_2048_ALGORITHM_NAME);
     fill_auth_request_token(&remote_auth_request_token);
@@ -632,8 +640,11 @@ CU_Test(ddssec_builtin_validate_remote_identity,unknown_local_identity )
 
     /* Check if we actually have validate_local_identity function. */
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (local_identity_handle != DDS_SECURITY_HANDLE_NIL);
+    CU_ASSERT_FATAL (auth != NULL);
     CU_ASSERT_FATAL (auth->validate_remote_identity != NULL);
+    assert (auth->validate_remote_identity != 0);
 
     initialize_identity_token(&remote_identity_token, RSA_2048_ALGORITHM_NAME, RSA_2048_ALGORITHM_NAME);
     fill_auth_request_token(&remote_auth_request_token);
@@ -675,8 +686,11 @@ CU_Test(ddssec_builtin_validate_remote_identity,invalid_remote_identity_token )
 
     /* Check if we actually have validate_local_identity function. */
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (local_identity_handle != DDS_SECURITY_HANDLE_NIL);
+    CU_ASSERT_FATAL (auth != NULL);
     CU_ASSERT_FATAL (auth->validate_remote_identity != NULL);
+    assert (auth->validate_remote_identity != 0);
 
     initialize_identity_token(&remote_identity_token, RSA_2048_ALGORITHM_NAME, RSA_2048_ALGORITHM_NAME);
     fill_auth_request_token(&remote_auth_request_token);
@@ -746,8 +760,11 @@ CU_Test(ddssec_builtin_validate_remote_identity,invalid_auth_req_token )
 
     /* Check if we actually have validate_local_identity function. */
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (local_identity_handle != DDS_SECURITY_HANDLE_NIL);
+    CU_ASSERT_FATAL (auth != NULL);
     CU_ASSERT_FATAL (auth->validate_remote_identity != NULL);
+    assert (auth->validate_remote_identity != 0);
 
     initialize_identity_token(&remote_identity_token, RSA_2048_ALGORITHM_NAME, RSA_2048_ALGORITHM_NAME);
     fill_auth_request_token(&remote_auth_request_token);
@@ -996,8 +1013,11 @@ CU_Test(ddssec_builtin_validate_remote_identity,already_validated_same_token )
 
     /* Check if we actually have validate_local_identity function. */
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (local_identity_handle != DDS_SECURITY_HANDLE_NIL);
+    CU_ASSERT_FATAL (auth != NULL);
     CU_ASSERT_FATAL (auth->validate_remote_identity != NULL);
+    assert (auth->validate_remote_identity != 0);
 
     initialize_identity_token(&remote_identity_token, RSA_2048_ALGORITHM_NAME, RSA_2048_ALGORITHM_NAME);
     fill_auth_request_token(&remote_auth_request_token);
@@ -1072,8 +1092,10 @@ CU_Test(ddssec_builtin_validate_remote_identity,already_validated_different_toke
 
     /* Check if we actually have validate_local_identity function. */
     CU_ASSERT_FATAL (auth != NULL);
+    assert (auth != NULL);
     CU_ASSERT_FATAL (local_identity_handle != DDS_SECURITY_HANDLE_NIL);
     CU_ASSERT_FATAL (auth->validate_remote_identity != NULL);
+    assert (auth->validate_remote_identity != 0);
 
     initialize_identity_token(&remote_identity_token, RSA_2048_ALGORITHM_NAME, RSA_2048_ALGORITHM_NAME);
     fill_auth_request_token(&remote_auth_request_token);

--- a/src/security/builtin_plugins/tests/validate_remote_permissions/src/validate_remote_permissions_utests.c
+++ b/src/security/builtin_plugins/tests/validate_remote_permissions/src/validate_remote_permissions_utests.c
@@ -398,9 +398,12 @@ CU_Test(ddssec_builtin_validate_remote_permissions, valid_permissions, .init = s
 
   /* Check if we actually have validate_remote_permissions function. */
   CU_ASSERT_FATAL(access_control != NULL);
+  assert(access_control != NULL);
   CU_ASSERT_FATAL(local_identity_handle != DDS_SECURITY_HANDLE_NIL);
   CU_ASSERT_FATAL(access_control->validate_remote_permissions != NULL);
+  assert(access_control->validate_remote_permissions != 0);
   CU_ASSERT_FATAL(access_control->return_permissions_handle != NULL);
+  assert(access_control->return_permissions_handle != 0);
 
   fill_permissions_token(&permissions_token);
   r = fill_peer_credential_token(&credential_token, "Test_Permissions_ok.p7s");
@@ -437,9 +440,12 @@ CU_Test(ddssec_builtin_validate_remote_permissions, permissions_unknown_ca, .ini
 
   /* Check if we actually have validate_remote_permissions function. */
   CU_ASSERT_FATAL(access_control != NULL);
+  assert(access_control != NULL);
   CU_ASSERT_FATAL(local_identity_handle != DDS_SECURITY_HANDLE_NIL);
   CU_ASSERT_FATAL(access_control->validate_remote_permissions != NULL);
+  assert(access_control->validate_remote_permissions != 0);
   CU_ASSERT_FATAL(access_control->return_permissions_handle != NULL);
+  assert(access_control->return_permissions_handle != 0);
 
   fill_permissions_token(&permissions_token);
   r = fill_peer_credential_token(&credential_token, "Test_Permissions_unknown_ca.p7s");
@@ -489,9 +495,12 @@ CU_Test(ddssec_builtin_validate_remote_permissions, permissions_not_signed, .ini
 
   /* Check if we actually have validate_remote_permissions function. */
   CU_ASSERT_FATAL(access_control != NULL);
+  assert(access_control != NULL);
   CU_ASSERT_FATAL(local_identity_handle != DDS_SECURITY_HANDLE_NIL);
   CU_ASSERT_FATAL(access_control->validate_remote_permissions != NULL);
+  assert(access_control->validate_remote_permissions != 0);
   CU_ASSERT_FATAL(access_control->return_permissions_handle != NULL);
+  assert(access_control->return_permissions_handle != 0);
 
   fill_permissions_token(&permissions_token);
   r = fill_peer_credential_token(&credential_token, "Test_Permissions_not_signed.p7s");
@@ -540,9 +549,12 @@ CU_Test(ddssec_builtin_validate_remote_permissions, invalid_credential_token, .i
 
   /* Check if we actually have validate_remote_permissions function. */
   CU_ASSERT_FATAL(access_control != NULL);
+  assert(access_control != NULL);
   CU_ASSERT_FATAL(local_identity_handle != DDS_SECURITY_HANDLE_NIL);
   CU_ASSERT_FATAL(access_control->validate_remote_permissions != NULL);
+  assert(access_control->validate_remote_permissions != 0);
   CU_ASSERT_FATAL(access_control->return_permissions_handle != NULL);
+  assert(access_control->return_permissions_handle != 0);
 
   remote_identity_handle++;
 
@@ -811,9 +823,12 @@ CU_Test(ddssec_builtin_validate_remote_permissions, invalid_xml, .init = suite_v
 
   /* Check if we actually have validate_remote_permissions function. */
   CU_ASSERT_FATAL(access_control != NULL);
+  assert(access_control != NULL);
   CU_ASSERT_FATAL(local_identity_handle != DDS_SECURITY_HANDLE_NIL);
   CU_ASSERT_FATAL(access_control->validate_remote_permissions != NULL);
+  assert(access_control->validate_remote_permissions != 0);
   CU_ASSERT_FATAL(access_control->return_permissions_handle != NULL);
+  assert(access_control->return_permissions_handle != 0);
 
   fill_permissions_token(&permissions_token);
   //permissions_token.
@@ -854,9 +869,12 @@ CU_Test(ddssec_builtin_validate_remote_permissions, permissions_expired, .init =
 
   /* Check if we actually have validate_remote_permissions function. */
   CU_ASSERT_FATAL(access_control != NULL);
+  assert(access_control != NULL);
   CU_ASSERT_FATAL(local_identity_handle != DDS_SECURITY_HANDLE_NIL);
   CU_ASSERT_FATAL(access_control->validate_remote_permissions != NULL);
+  assert(access_control->validate_remote_permissions != 0);
   CU_ASSERT_FATAL(access_control->return_permissions_handle != NULL);
+  assert(access_control->return_permissions_handle != 0);
 
   fill_permissions_token(&permissions_token);
   r = fill_peer_credential_token(&credential_token, "Test_Permissions_expired.p7s");
@@ -892,9 +910,12 @@ CU_Test(ddssec_builtin_validate_remote_permissions, permissions_not_yet, .init =
 
   /* Check if we actually have validate_remote_permissions function. */
   CU_ASSERT_FATAL(access_control != NULL);
+  assert(access_control != NULL);
   CU_ASSERT_FATAL(local_identity_handle != DDS_SECURITY_HANDLE_NIL);
   CU_ASSERT_FATAL(access_control->validate_remote_permissions != NULL);
+  assert(access_control->validate_remote_permissions != 0);
   CU_ASSERT_FATAL(access_control->return_permissions_handle != NULL);
+  assert(access_control->return_permissions_handle != 0);
 
   fill_permissions_token(&permissions_token);
   r = fill_peer_credential_token(&credential_token, "Test_Permissions_notyet.p7s");
@@ -930,9 +951,12 @@ CU_Test(ddssec_builtin_validate_remote_permissions, permissions_unknown_subject_
 
   /* Check if we actually have validate_remote_permissions function. */
   CU_ASSERT_FATAL(access_control != NULL);
+  assert(access_control != NULL);
   CU_ASSERT_FATAL(local_identity_handle != DDS_SECURITY_HANDLE_NIL);
   CU_ASSERT_FATAL(access_control->validate_remote_permissions != NULL);
+  assert(access_control->validate_remote_permissions != 0);
   CU_ASSERT_FATAL(access_control->return_permissions_handle != NULL);
+  assert(access_control->return_permissions_handle != 0);
 
   fill_permissions_token(&permissions_token);
   r = fill_peer_credential_token(&credential_token, "Test_Permissions_unknown_subject.p7s");
@@ -993,9 +1017,12 @@ CU_Test(ddssec_builtin_validate_remote_permissions, permissions_different_subjec
 
   /* Check if we actually have validate_remote_permissions function. */
   CU_ASSERT_FATAL(access_control != NULL);
+  assert(access_control != NULL);
   CU_ASSERT_FATAL(local_identity_handle != DDS_SECURITY_HANDLE_NIL);
   CU_ASSERT_FATAL(access_control->validate_remote_permissions != NULL);
+  assert(access_control->validate_remote_permissions != 0);
   CU_ASSERT_FATAL(access_control->return_permissions_handle != NULL);
+  assert(access_control->return_permissions_handle != 0);
 
   fill_permissions_token(&permissions_token);
   r = fill_peer_credential_token(&credential_token, "Test_Permissions_different_subject_representation.p7s");
@@ -1031,9 +1058,12 @@ CU_Test(ddssec_builtin_validate_remote_permissions, corrupted_signature, .init =
 
   /* Check if we actually have validate_remote_permissions function. */
   CU_ASSERT_FATAL(access_control != NULL);
+  assert(access_control != NULL);
   CU_ASSERT_FATAL(local_identity_handle != DDS_SECURITY_HANDLE_NIL);
   CU_ASSERT_FATAL(access_control->validate_remote_permissions != NULL);
+  assert(access_control->validate_remote_permissions != 0);
   CU_ASSERT_FATAL(access_control->return_permissions_handle != NULL);
+  assert(access_control->return_permissions_handle != 0);
 
   fill_permissions_token(&permissions_token);
   //permissions_token.

--- a/src/security/core/src/dds_security_utils.c
+++ b/src/security/core/src/dds_security_utils.c
@@ -782,7 +782,7 @@ void DDS_Security_Exception_vset (DDS_Security_SecurityException *ex, const char
     }
   }
 
-  va_end(args1);
+  va_end(args2);
 
   ex->message = str;
   ex->code = code;

--- a/src/security/core/tests/common/authentication_wrapper.c
+++ b/src/security/core/tests/common/authentication_wrapper.c
@@ -74,6 +74,10 @@ static DDS_Security_ValidationResult_t test_validate_local_identity_all_ok(
       identity_certificate = participant_qos->property.value._buffer[i].value;
   }
 
+  assert(identity_certificate != NULL);
+  assert(identity_ca != NULL);
+  assert(private_key != NULL);
+
   if (strcmp(identity_certificate, test_identity_certificate))
   {
     printf("identity received=%s\n", identity_certificate);

--- a/src/security/core/tests/common/test_utils.c
+++ b/src/security/core/tests/common/test_utils.c
@@ -284,6 +284,7 @@ static void handle_validate_local_identity (dds_domainid_t domain_id, bool exp_l
       break;
   }
   CU_ASSERT_FATAL (msg != NULL);
+  assert (msg != NULL);
   CU_ASSERT_FATAL ((msg->result == DDS_SECURITY_VALIDATION_OK) != exp_localid_fail);
   if (exp_localid_fail && exp_localid_msg)
   {

--- a/src/tools/ddsperf/ddsperf.c
+++ b/src/tools/ddsperf/ddsperf.c
@@ -562,7 +562,7 @@ static uint32_t pubthread (void *varg)
 {
   int result;
   dds_instance_handle_t *ihs;
-  dds_time_t ntot = 0, tfirst, tfirst0;
+  dds_time_t ntot = 0, tfirst;
   union data data;
   uint64_t timeouts = 0;
   void *baggage = NULL;
@@ -584,7 +584,7 @@ static uint32_t pubthread (void *varg)
   }
   data.seq_keyval.keyval = 0;
 
-  tfirst0 = tfirst = dds_time();
+  tfirst = dds_time();
 
   uint32_t bi = 0;
   while (!ddsrt_atomic_ld32 (&termflag))
@@ -623,7 +623,7 @@ static uint32_t pubthread (void *varg)
       if (++bi == burstsize)
       {
         /* FIXME: should average rate over a short-ish period, rather than over the entire run */
-        while (((double) (ntot / burstsize) / ((double) (t - tfirst0) / 1e9 + 5e-3)) > pub_rate && !ddsrt_atomic_ld32 (&termflag))
+        while (((double) (ntot / burstsize) / ((double) (t - tfirst) / 1e9 + 5e-3)) > pub_rate && !ddsrt_atomic_ld32 (&termflag))
         {
           /* FIXME: flushing manually because batching is not yet implemented properly */
           dds_write_flush (wr_data);

--- a/src/tools/pubsub/pubsub.c
+++ b/src/tools/pubsub/pubsub.c
@@ -1980,7 +1980,7 @@ static char *read_line_from_textfile(FILE *fp) {
         str[n++] = (char)c;
     }
     if (c != EOF || n > 0) {
-        if (n == sz) str = dds_realloc(str, sz += 1);
+        if (n == sz) str = dds_realloc(str, sz + 1);
         str[n] = 0;
     } else if (ferror(fp)) {
         error_exit("error reading file, errno = %d\n", errno);


### PR DESCRIPTION
On most platforms they're pretty much harmless because the erroneous cases do not actually occur (the plug-ins are only called with a non-null plug-in instance pointer, `va_end` on many platforms doesn't actually do all that much, and all the others are error handling in test code), but that's no reason not to fix them.