### PR TITLE
Remove from ddsrt dynlib and filesystem when building FreeRTOS

### DIFF
--- a/src/core/ddsc/src/dds_rhc.c
+++ b/src/core/ddsc/src/dds_rhc.c
@@ -20,10 +20,10 @@ extern inline void dds_rhc_unregister_wr (struct dds_rhc * __restrict rhc, const
 extern inline void dds_rhc_relinquish_ownership (struct dds_rhc * __restrict rhc, const uint64_t wr_iid);
 extern inline void dds_rhc_set_qos (struct dds_rhc *rhc, const struct dds_qos *qos);
 extern inline void dds_rhc_free (struct dds_rhc *rhc);
-extern inline int dds_rhc_read (struct dds_rhc *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, struct dds_readcond *cond);
-extern inline int dds_rhc_take (struct dds_rhc *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, struct dds_readcond *cond);
-extern inline int dds_rhc_readcdr (struct dds_rhc *rhc, bool lock, struct ddsi_serdata **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle);
-extern inline int dds_rhc_takecdr (struct dds_rhc *rhc, bool lock, struct ddsi_serdata **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle);
+extern inline int32_t dds_rhc_read (struct dds_rhc *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, struct dds_readcond *cond);
+extern inline int32_t dds_rhc_take (struct dds_rhc *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, struct dds_readcond *cond);
+extern inline int32_t dds_rhc_readcdr (struct dds_rhc *rhc, bool lock, struct ddsi_serdata **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle);
+extern inline int32_t dds_rhc_takecdr (struct dds_rhc *rhc, bool lock, struct ddsi_serdata **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle);
 extern inline bool dds_rhc_add_readcondition (struct dds_rhc *rhc, struct dds_readcond *cond);
 extern inline void dds_rhc_remove_readcondition (struct dds_rhc *rhc, struct dds_readcond *cond);
 extern inline uint32_t dds_rhc_lock_samples (struct dds_rhc *rhc);

--- a/src/ddsrt/CMakeLists.txt
+++ b/src/ddsrt/CMakeLists.txt
@@ -118,7 +118,6 @@ list(APPEND headers
   "${include_path}/dds/ddsrt/mh3.h"
   "${include_path}/dds/ddsrt/io.h"
   "${include_path}/dds/ddsrt/process.h"
-  "${include_path}/dds/ddsrt/dynlib.h"
   "${include_path}/dds/ddsrt/strtod.h"
   "${include_path}/dds/ddsrt/strtol.h"
   "${include_path}/dds/ddsrt/types.h"

--- a/src/ddsrt/cmake/dynlib.c
+++ b/src/ddsrt/cmake/dynlib.c
@@ -1,0 +1,18 @@
+/*
+ * Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include "dds/ddsrt/dynlib.h"
+
+#if DDSRT_HAVE_DYNLIB
+# error "cmake_HAVE_DYNLIB=true"
+#else
+# error "cmake_HAVE_DYNLIB=false"
+#endif

--- a/src/ddsrt/cmake/filesystem.c
+++ b/src/ddsrt/cmake/filesystem.c
@@ -1,0 +1,18 @@
+/*
+ * Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include "dds/ddsrt/filesystem.h"
+
+#if DDSRT_HAVE_FILESYSTEM
+# error "cmake_HAVE_FILESYSTEM=true"
+#else
+# error "cmake_HAVE_FILESYSTEM=false"
+#endif

--- a/src/ddsrt/include/dds/ddsrt/dynlib.h
+++ b/src/ddsrt/include/dds/ddsrt/dynlib.h
@@ -18,6 +18,14 @@
 #include "dds/ddsrt/retcode.h"
 #include "dds/ddsrt/attributes.h"
 
+#if !DDSRT_WITH_FREERTOS
+#define DDSRT_HAVE_DYNLIB (1)
+#else
+#define DDSRT_HAVE_DYNLIB (0)
+#endif
+
+#if DDSRT_HAVE_DYNLIB
+
 #if defined (__cplusplus)
 extern "C" {
 #endif
@@ -139,5 +147,7 @@ ddsrt_dlerror(
 #if defined (__cplusplus)
 }
 #endif
+
+#endif /* DDSRT_HAVE_DYNLIB */
 
 #endif /* DDSRT_LIBRARY_H */

--- a/src/ddsrt/include/dds/ddsrt/filesystem.h
+++ b/src/ddsrt/include/dds/ddsrt/filesystem.h
@@ -19,6 +19,14 @@
 #include "dds/ddsrt/retcode.h"
 #include "dds/ddsrt/time.h"
 
+#if !DDSRT_WITH_FREERTOS
+#define DDSRT_HAVE_FILESYSTEM (1)
+#else
+#define DDSRT_HAVE_FILESYSTEM (0)
+#endif
+
+#if DDSRT_HAVE_FILESYSTEM
+
 #if _WIN32
 #include "dds/ddsrt/filesystem/windows.h"
 #else
@@ -119,5 +127,7 @@ DDS_EXPORT const char* ddsrt_file_sep(void);
 #if defined (__cplusplus)
 }
 #endif
+
+#endif // DDRT_HAVE_FILESYSTEM
 
 #endif // FILESYSTEM_H


### PR DESCRIPTION
The dynlib and filesystem functions are currently not supported on FreeRTOS. The FreeRTOS dependencies are removed from ddsrt.