### PR TITLE
Allow building without a C++ compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
 cmake_minimum_required(VERSION 3.7)
-project(CycloneDDS VERSION 0.7.0)
+project(CycloneDDS VERSION 0.7.0 LANGUAGES C)
 
 # Set a default build type if none was specified
 set(default_build_type "RelWithDebInfo")

--- a/ports/freertos-posix/CMakeLists.txt
+++ b/ports/freertos-posix/CMakeLists.txt
@@ -10,7 +10,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
 cmake_minimum_required(VERSION 3.5)
-project(FreeRTOS-Sim VERSION 10.0.2.0)
+project(FreeRTOS-Sim VERSION 10.0.2.0 LANGUAGES C)
 
 include(GNUInstallDirs)
 


### PR DESCRIPTION
If you don't explicitly specify which languages you're using in the CMake project call, it defaults to C and CXX and will fail if it can't find a valid C++ compiler.

See the LANGUAGES section under https://cmake.org/cmake/help/latest/command/project.html#options.

Before:
https://travis-ci.com/github/eclipse-cyclonedds/cyclonedds/jobs/346028302#L612

After:
https://travis-ci.com/github/robinlinden/cyclonedds/jobs/346172916#L616