### PR TITLE
move options above where they're used to generate features.h header

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,9 @@ endif()
 #
 # which caters both for those who prefer #ifdef DDS_HAS_SECURITY and for those who prefer
 # #if DDS_HAS_SECURITY.
+option(ENABLE_SECURITY "Enable OMG DDS Security support" ON)
+option(ENABLE_LIFESPAN "Enable Lifespan QoS support" ON)
+option(ENABLE_DEADLINE_MISSED "Enable Deadline Missed QoS support" ON)
 if(ENABLE_SECURITY)
   set(DDS_HAS_SECURITY "1")
 endif()
@@ -62,19 +65,16 @@ if(ENABLE_SSL)
 endif()
 
 # Support the OMG DDS Security within ddsc adds quite a bit of code.
-option(ENABLE_SECURITY "Enable OMG DDS Security support" ON)
 if(NOT ENABLE_SECURITY)
   message(STATUS "Building without OMG DDS Security support")
 else()
   add_definitions(-DDDSI_INCLUDE_SECURITY)
 endif()
 
-option(ENABLE_LIFESPAN "Enable Lifespan QoS support" ON)
 if(ENABLE_LIFESPAN)
   add_definitions(-DDDSI_INCLUDE_LIFESPAN)
 endif()
 
-option(ENABLE_DEADLINE_MISSED "Enable Deadline Missed QoS support" ON)
 if(ENABLE_DEADLINE_MISSED)
   add_definitions(-DDDSI_INCLUDE_DEADLINE_MISSED)
 endif()


### PR DESCRIPTION
When trying to use DDS_SECURITY through rmw_cyclonedds_cpp I get the following error:
```
Security was requested but the Cyclone DDS being used does not have security support enabled. Recompile Cyclone DDS with the '-DENABLE_SECURITY=ON' CMake option
``` 
It seems to come from the fact that this condition evaluates to false:
https://github.com/ros2/rmw_cyclonedds/blob/f95c4960eadb4094c2aa296056d27b6664600b5e/rmw_cyclonedds_cpp/src/rmw_node.cpp#L83-L85

This PR moves the definition of the options before their value is checked to fill the `features.h` file, this way the default value is taken into account when the CMake option is not passed explicitly to CMake.

An alternative is to move the block 
https://github.com/eclipse-cyclonedds/cyclonedds/blob/8029274fec8a5bf45f87e86dfac5bb85d817182b/src/CMakeLists.txt#L28-L37

after all the options have been defined



cc @kyrofa @SidFaber