### PR TITLE
Deal with OpenSSL in a DLL on Windows

### DIFF
--- a/cmake/Modules/FindOpenSSL.cmake
+++ b/cmake/Modules/FindOpenSSL.cmake
@@ -32,3 +32,11 @@ else()
   endif()
 endif()
 
+# OpenSSL DLL on Windows: use of BIO_s_fd and BIO_s_file (directly or indirectly) requires
+# the executable to incorporate OpenSSL applink.c.  CMake 18 adds support for handling
+# this as part of the OpenSSL package, but we can't require such a new CMake version.
+if(OPENSSL_FOUND AND EXISTS "${OPENSSL_INCLUDE_DIR}/openssl/applink.c")
+  set(CYCLONEDDS_OPENSSL_APPLINK "${OPENSSL_INCLUDE_DIR}/openssl/applink.c")
+else()
+  set(CYCLONEDDS_OPENSSL_APPLINK "")
+endif()

--- a/src/security/builtin_plugins/tests/CMakeLists.txt
+++ b/src/security/builtin_plugins/tests/CMakeLists.txt
@@ -59,7 +59,11 @@ set(security_crypto_test_sources
     "set_remote_participant_crypto_tokens/src/set_remote_participant_crypto_tokens_utests.c"
 )
 
-add_cunit_executable(cunit_security_plugins ${security_auth_test_sources} ${security_ac_test_sources} ${security_crypto_test_sources})
+add_cunit_executable(cunit_security_plugins
+  ${security_auth_test_sources}
+  ${security_ac_test_sources}
+  ${security_crypto_test_sources}
+  ${CYCLONEDDS_OPENSSL_APPLINK})
 
 target_include_directories(
   cunit_security_plugins PRIVATE

--- a/src/security/builtin_plugins/tests/CMakeLists.txt
+++ b/src/security/builtin_plugins/tests/CMakeLists.txt
@@ -65,6 +65,11 @@ add_cunit_executable(cunit_security_plugins
   ${security_crypto_test_sources}
   ${CYCLONEDDS_OPENSSL_APPLINK})
 
+# applink.c triggers the dreaded This function or variable may be unsafe
+if(NOT "${CYCLONEDDS_OPENSSL_APPLINK}" STREQUAL "")
+  set_source_files_properties("${CYCLONEDDS_OPENSSL_APPLINK}" PROPERTIES COMPILE_FLAGS "-D_CRT_SECURE_NO_WARNINGS")
+endif()
+
 target_include_directories(
   cunit_security_plugins PRIVATE
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../access_control/src/>"

--- a/src/security/builtin_plugins/tests/validate_begin_handshake_reply/src/validate_begin_handshake_reply_utests.c
+++ b/src/security/builtin_plugins/tests/validate_begin_handshake_reply/src/validate_begin_handshake_reply_utests.c
@@ -705,7 +705,7 @@ set_dh_public_key(
 
     *pubkey = ddsrt_malloc(*size);
     memcpy(*pubkey, buffer, *size);
-    ddsrt_free(buffer);
+    OPENSSL_free(buffer);
 
     ASN1_INTEGER_free(asn1int);
 

--- a/src/security/core/tests/CMakeLists.txt
+++ b/src/security/core/tests/CMakeLists.txt
@@ -84,6 +84,10 @@ if(ENABLE_SSL AND OPENSSL_FOUND)
     "plugin_loading.c"
     "secure_communication.c"
     ${CYCLONEDDS_OPENSSL_APPLINK})
+  # applink.c triggers the dreaded This function or variable may be unsafe
+  if(NOT "${CYCLONEDDS_OPENSSL_APPLINK}" STREQUAL "")
+    set_source_files_properties("${CYCLONEDDS_OPENSSL_APPLINK}" PROPERTIES COMPILE_FLAGS "-D_CRT_SECURE_NO_WARNINGS")
+  endif()
 endif()
 
 add_cunit_executable(cunit_security_core ${security_core_test_sources})

--- a/src/security/core/tests/CMakeLists.txt
+++ b/src/security/core/tests/CMakeLists.txt
@@ -83,7 +83,7 @@ if(ENABLE_SSL AND OPENSSL_FOUND)
     "handshake.c"
     "plugin_loading.c"
     "secure_communication.c"
-  )
+    ${CYCLONEDDS_OPENSSL_APPLINK})
 endif()
 
 add_cunit_executable(cunit_security_core ${security_core_test_sources})


### PR DESCRIPTION
OpenSSL doesn't support using BIOs of the "fd" or "file" type when it is built as a DLL and the executable didn't provide it with access to the executable's CRT. Requiring all applications that wish to use security to worry about this "applink.c" thing is too onerous a requirement.

* Check for the existence of "applink.c" in the OpenSSL include directory, adding it to the security tests if it exists.  This way, all of OpenSSL can be used by the tests.
* Include it in the security core and built-in plugin tests.  This way, the test code can use the entirety of OpenSSL.
* In the authentication and access-control plugins, load X509 and private keys from files by first reading them into a "mem" type BIO, then reading them from that BIO.
* Take care not to call ddsrt_free on OpenSSL-allocated memory, either by calling OPENSSL_free, or by allocating the memory using ddsrt_malloc and letting OpenSSL fill that buffer.

On my local setup this fixes https://github.com/ros2/rmw_cyclonedds/issues/201 and https://github.com/eclipse-cyclonedds/cyclonedds/pull/527#issuecomment-642210391 but it needs confirmation from a ROS2 CI run first.