### PR TITLE
Fix IPv6 link-local, "raw" Ethernet + some fallout

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/ddsi_ipaddr.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_ipaddr.h
@@ -19,7 +19,7 @@ extern "C" {
 #endif
 
 enum ddsi_nearby_address_result ddsi_ipaddr_is_nearby_address (const nn_locator_t *loc, const nn_locator_t *ownloc, size_t ninterf, const struct nn_interface *interf);
-enum ddsi_locator_from_string_result ddsi_ipaddr_from_string (ddsi_tran_factory_t tran, nn_locator_t *loc, const char *str, int32_t kind);
+enum ddsi_locator_from_string_result ddsi_ipaddr_from_string (const struct ddsi_tran_factory *tran, nn_locator_t *loc, const char *str, int32_t kind);
 int ddsi_ipaddr_compare (const struct sockaddr *const sa1, const struct sockaddr *const sa2);
 char *ddsi_ipaddr_to_string (char *dst, size_t sizeof_dst, const nn_locator_t *loc, int with_port);
 void ddsi_ipaddr_to_loc (const struct ddsi_tran_factory *tran, nn_locator_t *dst, const struct sockaddr *src, int32_t kind);

--- a/src/core/ddsi/include/dds/ddsi/ddsi_ssl.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_ssl.h
@@ -24,7 +24,19 @@
 extern "C" {
 #endif
 
-struct ddsi_ssl_plugins;
+struct ddsi_ssl_plugins
+{
+  bool (*init) (struct ddsi_domaingv *gv);
+  void (*fini) (void);
+  void (*ssl_free) (SSL *ssl);
+  void (*bio_vfree) (BIO *bio);
+  ssize_t (*read) (SSL *ssl, void *buf, size_t len, dds_return_t *err);
+  ssize_t (*write) (SSL *ssl, const void *msg, size_t len, dds_return_t *err);
+  SSL * (*connect) (const struct ddsi_domaingv *gv, ddsrt_socket_t sock);
+  BIO * (*listen) (ddsrt_socket_t sock);
+  SSL * (*accept) (const struct ddsi_domaingv *gv, BIO *bio, ddsrt_socket_t *sock);
+};
+
 void ddsi_ssl_config_plugin (struct ddsi_ssl_plugins *plugin);
 
 #if defined (__cplusplus)

--- a/src/core/ddsi/include/dds/ddsi/ddsi_tcp.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_tcp.h
@@ -14,38 +14,11 @@
 
 #include "dds/ddsi/ddsi_tran.h"
 
-#ifdef DDSI_INCLUDE_SSL
-
-#include "dds/ddsi/ddsi_ssl.h"
-
 #if defined (__cplusplus)
 extern "C" {
 #endif
 
-struct ddsi_ssl_plugins
-{
-  bool (*init) (struct ddsi_domaingv *gv);
-  void (*fini) (void);
-  void (*ssl_free) (SSL *ssl);
-  void (*bio_vfree) (BIO *bio);
-  ssize_t (*read) (SSL *ssl, void *buf, size_t len, dds_return_t *err);
-  ssize_t (*write) (SSL *ssl, const void *msg, size_t len, dds_return_t *err);
-  SSL * (*connect) (const struct ddsi_domaingv *gv, ddsrt_socket_t sock);
-  BIO * (*listen) (ddsrt_socket_t sock);
-  SSL * (*accept) (const struct ddsi_domaingv *gv, BIO *bio, ddsrt_socket_t *sock);
-};
-
-#if defined (__cplusplus)
-}
-#endif
-
-#endif /* DDSI_INCLUDE_SSL */
-
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
-int ddsi_tcp_init (struct ddsi_domaingv *gv);
+DDS_EXPORT int ddsi_tcp_init (struct ddsi_domaingv *gv);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsi/include/dds/ddsi/ddsi_tran.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_tran.h
@@ -68,9 +68,9 @@ typedef void (*ddsi_tran_unblock_listener_fn_t) (ddsi_tran_listener_t);
 typedef void (*ddsi_tran_release_listener_fn_t) (ddsi_tran_listener_t);
 typedef int (*ddsi_tran_join_mc_fn_t) (ddsi_tran_conn_t, const nn_locator_t *srcip, const nn_locator_t *mcip, const struct nn_interface *interf);
 typedef int (*ddsi_tran_leave_mc_fn_t) (ddsi_tran_conn_t, const nn_locator_t *srcip, const nn_locator_t *mcip, const struct nn_interface *interf);
-typedef int (*ddsi_is_mcaddr_fn_t) (ddsi_tran_factory_t tran, const nn_locator_t *loc);
-typedef int (*ddsi_is_ssm_mcaddr_fn_t) (ddsi_tran_factory_t tran, const nn_locator_t *loc);
-typedef int (*ddsi_is_valid_port_fn_t) (ddsi_tran_factory_t tran, uint32_t port);
+typedef int (*ddsi_is_mcaddr_fn_t) (const struct ddsi_tran_factory *tran, const nn_locator_t *loc);
+typedef int (*ddsi_is_ssm_mcaddr_fn_t) (const struct ddsi_tran_factory *tran, const nn_locator_t *loc);
+typedef int (*ddsi_is_valid_port_fn_t) (const struct ddsi_tran_factory *tran, uint32_t port);
 
 enum ddsi_nearby_address_result {
   DNAR_DISTANT,
@@ -87,7 +87,7 @@ enum ddsi_locator_from_string_result {
   AFSR_MISMATCH /* recognised format, but mismatch with expected (e.g., IPv4/IPv6) */
 };
 
-typedef enum ddsi_locator_from_string_result (*ddsi_locator_from_string_fn_t) (ddsi_tran_factory_t tran, nn_locator_t *loc, const char *str);
+typedef enum ddsi_locator_from_string_result (*ddsi_locator_from_string_fn_t) (const struct ddsi_tran_factory *tran, nn_locator_t *loc, const char *str);
 
 typedef char * (*ddsi_locator_to_string_fn_t) (char *dst, size_t sizeof_dst, const nn_locator_t *loc, int with_port);
 
@@ -211,7 +211,7 @@ void ddsi_factory_conn_init (const struct ddsi_tran_factory *factory, ddsi_tran_
 inline bool ddsi_factory_supports (const struct ddsi_tran_factory *factory, int32_t kind) {
   return factory->m_supports_fn (factory, kind);
 }
-inline int ddsi_is_valid_port (ddsi_tran_factory_t factory, uint32_t port) {
+inline int ddsi_is_valid_port (const struct ddsi_tran_factory *factory, uint32_t port) {
   return factory->m_is_valid_port_fn (factory, port);
 }
 inline dds_return_t ddsi_factory_create_conn (ddsi_tran_conn_t *conn, ddsi_tran_factory_t factory, uint32_t port, const struct ddsi_tran_qos *qos) {
@@ -234,10 +234,10 @@ inline ddsrt_socket_t ddsi_tran_handle (ddsi_tran_base_t base) {
 inline ddsrt_socket_t ddsi_conn_handle (ddsi_tran_conn_t conn) {
   return conn->m_base.m_handle_fn (&conn->m_base);
 }
-inline uint32_t ddsi_conn_type (ddsi_tran_conn_t conn) {
+inline uint32_t ddsi_conn_type (const struct ddsi_tran_conn *conn) {
   return conn->m_base.m_trantype;
 }
-inline uint32_t ddsi_conn_port (ddsi_tran_conn_t conn) {
+inline uint32_t ddsi_conn_port (const struct ddsi_tran_conn *conn) {
   return conn->m_base.m_port;
 }
 inline int ddsi_conn_locator (ddsi_tran_conn_t conn, nn_locator_t * loc) {

--- a/src/core/ddsi/include/dds/ddsi/ddsi_tran.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_tran.h
@@ -203,8 +203,8 @@ struct ddsi_tran_qos
 
 void ddsi_tran_factories_fini (struct ddsi_domaingv *gv);
 void ddsi_factory_add (struct ddsi_domaingv *gv, ddsi_tran_factory_t factory);
-void ddsi_factory_free (ddsi_tran_factory_t factory);
-ddsi_tran_factory_t ddsi_factory_find (const struct ddsi_domaingv *gv, const char * type);
+DDS_EXPORT void ddsi_factory_free (ddsi_tran_factory_t factory);
+DDS_EXPORT ddsi_tran_factory_t ddsi_factory_find (const struct ddsi_domaingv *gv, const char * type);
 ddsi_tran_factory_t ddsi_factory_find_supported_kind (const struct ddsi_domaingv *gv, int32_t kind);
 void ddsi_factory_conn_init (const struct ddsi_tran_factory *factory, ddsi_tran_conn_t conn);
 
@@ -261,7 +261,7 @@ int ddsi_is_mcaddr (const struct ddsi_domaingv *gv, const nn_locator_t *loc);
 int ddsi_is_ssm_mcaddr (const struct ddsi_domaingv *gv, const nn_locator_t *loc);
 enum ddsi_nearby_address_result ddsi_is_nearby_address (const nn_locator_t *loc, const nn_locator_t *ownloc, size_t ninterf, const struct nn_interface *interf);
 
-enum ddsi_locator_from_string_result ddsi_locator_from_string (const struct ddsi_domaingv *gv, nn_locator_t *loc, const char *str, ddsi_tran_factory_t default_factory);
+DDS_EXPORT enum ddsi_locator_from_string_result ddsi_locator_from_string (const struct ddsi_domaingv *gv, nn_locator_t *loc, const char *str, ddsi_tran_factory_t default_factory);
 
 /*  8 for transport/
     1 for [

--- a/src/core/ddsi/include/dds/ddsi/ddsi_udp.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_udp.h
@@ -24,7 +24,7 @@ typedef struct nn_udpv4mcgen_address {
   uint8_t idx; /* must be last: then sorting will put them consecutively */
 } nn_udpv4mcgen_address_t;
 
-int ddsi_udp_init (struct ddsi_domaingv *gv);
+DDS_EXPORT int ddsi_udp_init (struct ddsi_domaingv *gv);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsi/src/ddsi_ipaddr.c
+++ b/src/core/ddsi/src/ddsi_ipaddr.c
@@ -75,7 +75,7 @@ enum ddsi_nearby_address_result ddsi_ipaddr_is_nearby_address (const nn_locator_
   return DNAR_DISTANT;
 }
 
-enum ddsi_locator_from_string_result ddsi_ipaddr_from_string (ddsi_tran_factory_t tran, nn_locator_t *loc, const char *str, int32_t kind)
+enum ddsi_locator_from_string_result ddsi_ipaddr_from_string (const struct ddsi_tran_factory *tran, nn_locator_t *loc, const char *str, int32_t kind)
 {
   DDSRT_WARNING_MSVC_OFF(4996);
   char copy[264];

--- a/src/core/ddsi/src/ddsi_ipaddr.c
+++ b/src/core/ddsi/src/ddsi_ipaddr.c
@@ -77,6 +77,8 @@ enum ddsi_nearby_address_result ddsi_ipaddr_is_nearby_address (const nn_locator_
 
 enum ddsi_locator_from_string_result ddsi_ipaddr_from_string (ddsi_tran_factory_t tran, nn_locator_t *loc, const char *str, int32_t kind)
 {
+  DDSRT_WARNING_MSVC_OFF(4996);
+  char copy[264];
   int af = AF_INET;
   struct sockaddr_storage tmpaddr;
 
@@ -94,28 +96,101 @@ enum ddsi_locator_from_string_result ddsi_ipaddr_from_string (ddsi_tran_factory_
       return AFSR_MISMATCH;
   }
 
-  (void)tran;
-  if (ddsrt_sockaddrfromstr(af, str, (struct sockaddr *) &tmpaddr) != 0) {
-#if DDSRT_HAVE_DNS
-      /* Not a valid IP address. User may have specified a hostname instead. */
-      ddsrt_hostent_t *hent = NULL;
-      if (ddsrt_gethostbyname(str, af, &hent) != 0) {
-          return AFSR_UNKNOWN;
-      }
-      memcpy(&tmpaddr, &hent->addrs[0], sizeof(hent->addrs[0]));
-      ddsrt_free (hent);
-#else
+  // IPv6: we format numeric ones surrounded by brackets and we want to
+  // parse port numbers, so a copy is the most pragamatic approach. POSIX
+  // hostnames seem to be limited to 255 characters, add a port of max 5
+  // digits and a colon, and so 262 should be enough.  (Numerical addresses
+  // add a few other characters, but even so this ought to be plenty.)
+  const size_t len = strlen(str);
+  if (len == 0 || len >= sizeof(copy))
+    return AFSR_INVALID;
+  memcpy(copy, str, len + 1);
+  char *ipstr = copy;
+  char *portstr = strrchr(copy, ':');
+  if (af == AF_INET6 && portstr != strchr(copy, ':') && ipstr[0] != '[')
+  {
+    // IPv6 numerical addresses contain colons, so if there are multiple
+    // colons, we require disambiguation by enclosing the IP part in
+    // brackets and hence consider "portstr" only if the first character
+    // is '['
+    portstr = NULL;
+  }
+  uint16_t port = 0;
+  if (portstr) {
+    unsigned tmpport;
+    int pos;
+    if (sscanf (portstr + 1, "%u%n", &tmpport, &pos) == 1 && portstr[1 + pos] == 0)
+    {
+      if (tmpport < 1 || tmpport > 65535)
+        return AFSR_INVALID;
+      *portstr = 0;
+      port = (uint16_t) tmpport;
+    }
+    else if (af == AF_INET)
+    {
+      // no colons in IPv4 addresses
       return AFSR_INVALID;
+    }
+    else
+    {
+      // allow for IPv6 address embedding IPv4 ones, like ff02::ffff:239.255.0.1
+      portstr = NULL;
+    }
+  }
+
+#if DDSRT_HAVE_IPV6
+  if (af == AF_INET6)
+  {
+    if (copy[0] == '[') {
+      // strip brackets: last character before the port must be a ']',
+      // in the absence of a port, the last character in the string.
+      ipstr = copy + 1;
+      if (portstr == NULL) {
+        if (copy[len - 1] != ']')
+          return AFSR_INVALID;
+        copy[len - 1] = 0;
+      } else {
+        assert (portstr > copy);
+        if (portstr[-1] != ']')
+          return AFSR_INVALID;
+        portstr[-1] = 0;
+      }
+    }
+  }
+#endif
+
+  if (ddsrt_sockaddrfromstr(af, ipstr, (struct sockaddr *) &tmpaddr) != 0) {
+#if DDSRT_HAVE_DNS
+    /* Not a valid IP address. User may have specified a hostname instead. */
+    ddsrt_hostent_t *hent = NULL;
+    if (ddsrt_gethostbyname(ipstr, af, &hent) != 0) {
+      return AFSR_UNKNOWN;
+    }
+    memcpy(&tmpaddr, &hent->addrs[0], sizeof(hent->addrs[0]));
+    ddsrt_free (hent);
+#else
+    return AFSR_INVALID;
 #endif
   }
+  // patch in port (sin_port/sin6_port is undefined at this point and must always be set
+  // before calling ddsi_ipaddr_to_loc
   if (tmpaddr.ss_family != af) {
     return AFSR_MISMATCH;
+  } else if (af == AF_INET) {
+    struct sockaddr_in *x = (struct sockaddr_in *) &tmpaddr;
+    x->sin_port = htons (port);
+  } else {
+#if DDSRT_HAVE_IPV6
+    assert (af == AF_INET6);
+    struct sockaddr_in6 *x = (struct sockaddr_in6 *) &tmpaddr;
+    x->sin6_port = htons (port);
+#else
+    abort ();
+#endif
   }
   ddsi_ipaddr_to_loc (tran, loc, (struct sockaddr *)&tmpaddr, kind);
-  /* This is just an address, so there is no valid value for port, other than INVALID.
-     Without a guarantee that tmpaddr has port 0, best is to set it explicitly here */
-  loc->port = NN_LOCATOR_PORT_INVALID;
   return AFSR_OK;
+  DDSRT_WARNING_MSVC_ON(4996);
 }
 
 char *ddsi_ipaddr_to_string (char *dst, size_t sizeof_dst, const nn_locator_t *loc, int with_port)

--- a/src/core/ddsi/src/ddsi_ownip.c
+++ b/src/core/ddsi/src/ddsi_ownip.c
@@ -274,7 +274,7 @@ int find_own_ip (struct ddsi_domaingv *gv, const char *requested_address)
     if (i < gv->n_interfaces)
       selected_idx = i;
     else
-      GVERROR ("%s: does not match an available interface\n", gv->config.networkAddressString);
+      GVERROR ("%s: does not match an available interface supporting %s\n", gv->config.networkAddressString, gv->m_factory->m_typename);
   }
 
   if (selected_idx < 0)

--- a/src/core/ddsi/src/ddsi_raweth.c
+++ b/src/core/ddsi/src/ddsi_raweth.c
@@ -291,14 +291,14 @@ static void ddsi_raweth_release_conn (ddsi_tran_conn_t conn)
   ddsrt_free (conn);
 }
 
-static int ddsi_raweth_is_mcaddr (const ddsi_tran_factory_t tran, const nn_locator_t *loc)
+static int ddsi_raweth_is_mcaddr (const struct ddsi_tran_factory *tran, const nn_locator_t *loc)
 {
   (void) tran;
   assert (loc->kind == NN_LOCATOR_KIND_RAWETH);
   return (loc->address[10] & 1);
 }
 
-static int ddsi_raweth_is_ssm_mcaddr (const ddsi_tran_factory_t tran, const nn_locator_t *loc)
+static int ddsi_raweth_is_ssm_mcaddr (const struct ddsi_tran_factory *tran, const nn_locator_t *loc)
 {
   (void) tran;
   (void) loc;
@@ -314,7 +314,7 @@ static enum ddsi_nearby_address_result ddsi_raweth_is_nearby_address (const nn_l
   return DNAR_LOCAL;
 }
 
-static enum ddsi_locator_from_string_result ddsi_raweth_address_from_string (ddsi_tran_factory_t tran, nn_locator_t *loc, const char *str)
+static enum ddsi_locator_from_string_result ddsi_raweth_address_from_string (const struct ddsi_tran_factory *tran, nn_locator_t *loc, const char *str)
 {
   int i = 0;
   (void)tran;
@@ -356,7 +356,7 @@ static int ddsi_raweth_enumerate_interfaces (ddsi_tran_factory_t fact, enum tran
   return ddsrt_getifaddrs(ifs, afs);
 }
 
-static int ddsi_raweth_is_valid_port (ddsi_tran_factory_t fact, uint32_t port)
+static int ddsi_raweth_is_valid_port (const struct ddsi_tran_factory *fact, uint32_t port)
 {
   (void) fact;
   return (port >= 1 && port <= 65535);

--- a/src/core/ddsi/src/ddsi_tcp.c
+++ b/src/core/ddsi/src/ddsi_tcp.c
@@ -25,6 +25,7 @@
 #include "dds/ddsi/q_log.h"
 #include "dds/ddsi/q_entity.h"
 #include "dds/ddsi/ddsi_domaingv.h"
+#include "dds/ddsi/ddsi_ssl.h"
 
 #define INVALID_PORT (~0u)
 

--- a/src/core/ddsi/src/ddsi_tcp.c
+++ b/src/core/ddsi/src/ddsi_tcp.c
@@ -1114,19 +1114,19 @@ static void ddsi_tcp_release_factory (struct ddsi_tran_factory *fact_cmn)
   ddsrt_free (fact);
 }
 
-static enum ddsi_locator_from_string_result ddsi_tcp_address_from_string (ddsi_tran_factory_t fact, nn_locator_t *loc, const char *str)
+static enum ddsi_locator_from_string_result ddsi_tcp_address_from_string (const struct ddsi_tran_factory *fact, nn_locator_t *loc, const char *str)
 {
   return ddsi_ipaddr_from_string(fact, loc, str, fact->m_kind);
 }
 
-static int ddsi_tcp_is_mcaddr (const ddsi_tran_factory_t tran, const nn_locator_t *loc)
+static int ddsi_tcp_is_mcaddr (const struct ddsi_tran_factory *tran, const nn_locator_t *loc)
 {
   (void) tran;
   (void) loc;
   return 0;
 }
 
-static int ddsi_tcp_is_ssm_mcaddr (const ddsi_tran_factory_t tran, const nn_locator_t *loc)
+static int ddsi_tcp_is_ssm_mcaddr (const struct ddsi_tran_factory *tran, const nn_locator_t *loc)
 {
   (void) tran;
   (void) loc;
@@ -1138,7 +1138,7 @@ static enum ddsi_nearby_address_result ddsi_tcp_is_nearby_address (const nn_loca
   return ddsi_ipaddr_is_nearby_address(loc, ownloc, ninterf, interf);
 }
 
-static int ddsi_tcp_is_valid_port (ddsi_tran_factory_t fact, uint32_t port)
+static int ddsi_tcp_is_valid_port (const struct ddsi_tran_factory *fact, uint32_t port)
 {
   (void) fact;
   return (port <= 65535);

--- a/src/core/ddsi/src/ddsi_tran.c
+++ b/src/core/ddsi/src/ddsi_tran.c
@@ -22,11 +22,11 @@
 #include "dds/ddsi/q_log.h"
 #include "dds/ddsi/ddsi_domaingv.h"
 
-extern inline uint32_t ddsi_conn_type (ddsi_tran_conn_t conn);
-extern inline uint32_t ddsi_conn_port (ddsi_tran_conn_t conn);
+extern inline uint32_t ddsi_conn_type (const struct ddsi_tran_conn *conn);
+extern inline uint32_t ddsi_conn_port (const struct ddsi_tran_conn *conn);
 extern inline dds_return_t ddsi_factory_create_listener (ddsi_tran_listener_t *listener, ddsi_tran_factory_t factory, uint32_t port, const struct ddsi_tran_qos *qos);
 extern inline bool ddsi_factory_supports (const struct ddsi_tran_factory *factory, int32_t kind);
-extern inline int ddsi_is_valid_port (ddsi_tran_factory_t factory, uint32_t port);
+extern inline int ddsi_is_valid_port (const struct ddsi_tran_factory *factory, uint32_t port);
 extern inline ddsrt_socket_t ddsi_conn_handle (ddsi_tran_conn_t conn);
 extern inline int ddsi_conn_locator (ddsi_tran_conn_t conn, nn_locator_t * loc);
 extern inline ddsrt_socket_t ddsi_tran_handle (ddsi_tran_base_t base);

--- a/src/core/ddsi/src/ddsi_udp.c
+++ b/src/core/ddsi/src/ddsi_udp.c
@@ -658,7 +658,7 @@ static void ddsi_udp_release_conn (ddsi_tran_conn_t conn_cmn)
   ddsrt_free (conn_cmn);
 }
 
-static int ddsi_udp_is_mcaddr (const ddsi_tran_factory_t tran, const nn_locator_t *loc)
+static int ddsi_udp_is_mcaddr (const struct ddsi_tran_factory *tran, const nn_locator_t *loc)
 {
   (void) tran;
   switch (loc->kind)
@@ -684,7 +684,7 @@ static int ddsi_udp_is_mcaddr (const ddsi_tran_factory_t tran, const nn_locator_
 }
 
 #ifdef DDSI_INCLUDE_SSM
-static int ddsi_udp_is_ssm_mcaddr (const ddsi_tran_factory_t tran, const nn_locator_t *loc)
+static int ddsi_udp_is_ssm_mcaddr (const struct ddsi_tran_factory *tran, const nn_locator_t *loc)
 {
   (void) tran;
   switch (loc->kind)
@@ -706,7 +706,7 @@ static int ddsi_udp_is_ssm_mcaddr (const ddsi_tran_factory_t tran, const nn_loca
 }
 #endif
 
-static enum ddsi_locator_from_string_result mcgen_address_from_string (ddsi_tran_factory_t tran, nn_locator_t *loc, const char *str)
+static enum ddsi_locator_from_string_result mcgen_address_from_string (const struct ddsi_tran_factory *tran, nn_locator_t *loc, const char *str)
 {
   // check for UDPv4MCGEN string, be lazy and refuse to recognize as a MCGEN form if there's anything "wrong" with it
   DDSRT_WARNING_MSVC_OFF(4996);
@@ -755,7 +755,7 @@ static enum ddsi_locator_from_string_result mcgen_address_from_string (ddsi_tran
   DDSRT_WARNING_MSVC_ON(4996);
 }
 
-static enum ddsi_locator_from_string_result ddsi_udp_address_from_string (ddsi_tran_factory_t tran, nn_locator_t *loc, const char *str)
+static enum ddsi_locator_from_string_result ddsi_udp_address_from_string (const struct ddsi_tran_factory *tran, nn_locator_t *loc, const char *str)
 {
   if (tran->m_kind == TRANS_UDP && mcgen_address_from_string (tran, loc, str) == AFSR_OK)
     return AFSR_OK;
@@ -798,7 +798,7 @@ static void ddsi_udp_fini (ddsi_tran_factory_t fact)
   ddsrt_free (fact);
 }
 
-static int ddsi_udp_is_valid_port (ddsi_tran_factory_t fact, uint32_t port)
+static int ddsi_udp_is_valid_port (const struct ddsi_tran_factory *fact, uint32_t port)
 {
   (void) fact;
   return (port <= 65535);

--- a/src/core/ddsi/src/ddsi_udp.c
+++ b/src/core/ddsi/src/ddsi_udp.c
@@ -457,6 +457,11 @@ static dds_return_t ddsi_udp_create_conn (ddsi_tran_conn_t *conn_out, ddsi_tran_
       ipv6 = true;
       if (bind_to_any)
         socketname.a6.sin6_addr = ddsrt_in6addr_any;
+      if (IN6_IS_ADDR_LINKLOCAL (&socketname.a6.sin6_addr))
+      {
+        // A hack that only works if there is only a single interface in use
+        socketname.a6.sin6_scope_id = gv->interfaceNo;
+      }
       break;
 #endif
     default:

--- a/src/core/ddsi/src/q_addrset.c
+++ b/src/core/ddsi/src/q_addrset.c
@@ -44,86 +44,46 @@ static int compare_locators_vwrap (const void *va, const void *vb);
 static const ddsrt_avl_ctreedef_t addrset_treedef =
   DDSRT_AVL_CTREEDEF_INITIALIZER (offsetof (struct addrset_node, avlnode), offsetof (struct addrset_node, loc), compare_locators_vwrap, 0);
 
-static int add_addresses_to_addrset_1 (const struct ddsi_domaingv *gv, struct addrset *as, const char *ip, int port_mode, const char *msgtag, int req_mc, int mcgen_base, int mcgen_count, int mcgen_idx)
+static int add_addresses_to_addrset_1 (const struct ddsi_domaingv *gv, struct addrset *as, nn_locator_t *loc, int port_mode, const char *msgtag)
 {
   char buf[DDSI_LOCSTRLEN];
-  nn_locator_t loc;
+  int32_t maxidx;
 
-  switch (ddsi_locator_from_string(gv, &loc, ip, gv->m_factory))
+  // check whether port number, address type and mode make sense, and prepare the
+  // locator by patching the first port number to use if none is given
+  if (loc->port != NN_LOCATOR_PORT_INVALID)
   {
-    case AFSR_OK:
-      break;
-    case AFSR_INVALID:
-      GVERROR ("%s: %s: not a valid address\n", msgtag, ip);
+    if (port_mode >= 0 && loc->port != (uint32_t) port_mode)
+    {
+      GVERROR ("%s: %s: port mismatch (expecting no port or %d)\n", msgtag, ddsi_locator_to_string (buf, sizeof(buf), loc), port_mode);
       return -1;
-    case AFSR_UNKNOWN:
-      GVERROR ("%s: %s: unknown address\n", msgtag, ip);
-      return -1;
-    case AFSR_MISMATCH:
-      GVERROR ("%s: %s: address family mismatch\n", msgtag, ip);
-      return -1;
+    }
+    maxidx = 0;
   }
-
-  if (req_mc && !ddsi_is_mcaddr (gv, &loc))
+  else if (port_mode >= 0)
   {
-    GVERROR ("%s: %s: not a multicast address\n", msgtag, ip);
-    return -1;
+    loc->port = (uint32_t) port_mode;
+    maxidx = 0;
   }
-
-  if (mcgen_base == -1 && mcgen_count == -1 && mcgen_idx == -1)
-    ;
-  else if (loc.kind == NN_LOCATOR_KIND_UDPv4 && ddsi_is_mcaddr(gv, &loc) && mcgen_base >= 0 && mcgen_count > 0 && mcgen_base + mcgen_count < 28 && mcgen_idx >= 0 && mcgen_idx < mcgen_count)
+  else if (ddsi_is_mcaddr (gv, loc))
   {
-    nn_udpv4mcgen_address_t x;
-    memset(&x, 0, sizeof(x));
-    memcpy(&x.ipv4, loc.address + 12, 4);
-    x.base = (unsigned char) mcgen_base;
-    x.count = (unsigned char) mcgen_count;
-    x.idx = (unsigned char) mcgen_idx;
-    memset(loc.address, 0, sizeof(loc.address));
-    memcpy(loc.address, &x, sizeof(x));
-    loc.kind = NN_LOCATOR_KIND_UDPv4MCGEN;
+    loc->port = ddsi_get_port (&gv->config, DDSI_PORT_MULTI_DISC, 0);
+    maxidx = 0;
   }
   else
   {
-    GVERROR ("%s: %s,%d,%d,%d: IPv4 multicast address generator invalid or out of place\n",
-             msgtag, ip, mcgen_base, mcgen_count, mcgen_idx);
-    return -1;
+    loc->port = ddsi_get_port (&gv->config, DDSI_PORT_UNI_DISC, 0);
+    maxidx = gv->config.maxAutoParticipantIndex;
   }
 
-  if (port_mode >= 0)
+  GVLOG (DDS_LC_CONFIG, "%s: add %s", msgtag, ddsi_locator_to_string (buf, sizeof (buf), loc));
+  add_to_addrset (gv, as, loc);
+  for (int32_t i = 1; i < maxidx; i++)
   {
-    loc.port = (unsigned) port_mode;
-    GVLOG (DDS_LC_CONFIG, "%s: add %s", msgtag, ddsi_locator_to_string(buf, sizeof(buf), &loc));
-    add_to_addrset (gv, as, &loc);
+    loc->port = ddsi_get_port (&gv->config, DDSI_PORT_UNI_DISC, i);
+    GVLOG (DDS_LC_CONFIG, ", :%"PRIu32, loc->port);
+    add_to_addrset (gv, as, loc);
   }
-  else
-  {
-    GVLOG (DDS_LC_CONFIG, "%s: add ", msgtag);
-    if (!ddsi_is_mcaddr (gv, &loc))
-    {
-      assert (gv->config.maxAutoParticipantIndex >= 0);
-      for (int32_t i = 0; i <= gv->config.maxAutoParticipantIndex; i++)
-      {
-        loc.port = ddsi_get_port (&gv->config, DDSI_PORT_UNI_DISC, i);
-        if (i == 0)
-          GVLOG (DDS_LC_CONFIG, "%s", ddsi_locator_to_string(buf, sizeof(buf), &loc));
-        else
-          GVLOG (DDS_LC_CONFIG, ", :%"PRIu32, loc.port);
-        add_to_addrset (gv, as, &loc);
-      }
-    }
-    else
-    {
-      if (port_mode == -1)
-        loc.port = ddsi_get_port (&gv->config, DDSI_PORT_MULTI_DISC, 0);
-      else
-        loc.port = (uint32_t) port_mode;
-      GVLOG (DDS_LC_CONFIG, "%s", ddsi_locator_to_string(buf, sizeof(buf), &loc));
-      add_to_addrset (gv, as, &loc);
-    }
-  }
-
   GVLOG (DDS_LC_CONFIG, "\n");
   return 0;
 }
@@ -134,50 +94,43 @@ int add_addresses_to_addrset (const struct ddsi_domaingv *gv, struct addrset *as
      port_mode >= 0 => always set port to port_mode
   */
   DDSRT_WARNING_MSVC_OFF(4996);
-  char *addrs_copy, *ip, *cursor, *a;
+  char *addrs_copy, *cursor, *a;
   int retval = -1;
   addrs_copy = ddsrt_strdup (addrs);
-  ip = ddsrt_malloc (strlen (addrs) + 1);
   cursor = addrs_copy;
   while ((a = ddsrt_strsep (&cursor, ",")) != NULL)
   {
-    int port = 0, pos;
-    int mcgen_base = -1, mcgen_count = -1, mcgen_idx = -1;
-    if (gv->config.transport_selector == TRANS_UDP || gv->config.transport_selector == TRANS_TCP)
+    nn_locator_t loc;
+    char buf[DDSI_LOCSTRLEN];
+
+    switch (ddsi_locator_from_string (gv, &loc, a, gv->m_factory))
     {
-      if (port_mode == -1 && sscanf (a, "%[^:]:%d%n", ip, &port, &pos) == 2 && a[pos] == 0)
-        ; /* XYZ:PORT */
-      else if (sscanf (a, "%[^;];%d;%d;%d%n", ip, &mcgen_base, &mcgen_count, &mcgen_idx, &pos) == 4 && a[pos] == 0)
-        port = port_mode; /* XYZ;BASE;COUNT;IDX for IPv4 MC address generators */
-      else if (sscanf (a, "%[^:]%n", ip, &pos) == 1 && a[pos] == 0)
-        port = port_mode; /* XYZ */
-      else { /* XY:Z -- illegal, but conversion routine should flag it */
-        strcpy (ip, a);
-        port = 0;
-      }
-    }
-    else
-    {
-      if (port_mode == -1 && sscanf (a, "[%[^]]]:%d%n", ip, &port, &pos) == 2 && a[pos] == 0)
-        ; /* [XYZ]:PORT */
-      else if (sscanf (a, "[%[^]]]%n", ip, &pos) == 1 && a[pos] == 0)
-        port = port_mode; /* [XYZ] */
-      else { /* XYZ -- let conversion routines handle errors */
-        strcpy (ip, a);
-        port = 0;
-      }
+      case AFSR_OK:
+        break;
+      case AFSR_INVALID:
+        GVERROR ("%s: %s: not a valid address\n", msgtag, a);
+        goto error;
+      case AFSR_UNKNOWN:
+        GVERROR ("%s: %s: unknown address\n", msgtag, a);
+        goto error;
+      case AFSR_MISMATCH:
+        GVERROR ("%s: %s: address family mismatch\n", msgtag, a);
+        goto error;
     }
 
-    if ((port > 0 && port <= 65535) || (port_mode == -1 && port == -1)) {
-      if (add_addresses_to_addrset_1 (gv, as, ip, port, msgtag, req_mc, mcgen_base, mcgen_count, mcgen_idx) < 0)
-        goto error;
-    } else {
-      GVERROR ("%s: %s: port %d invalid\n", msgtag, a, port);
+    if (req_mc && !ddsi_is_mcaddr (gv, &loc))
+    {
+      GVERROR ("%s: %s: not a multicast address\n", msgtag, ddsi_locator_to_string_no_port (buf, sizeof(buf), &loc));
+      goto error;
+    }
+
+    if (add_addresses_to_addrset_1 (gv, as, &loc, port_mode, msgtag) < 0)
+    {
+      goto error;
     }
   }
   retval = 0;
  error:
-  ddsrt_free (ip);
   ddsrt_free (addrs_copy);
   return retval;
   DDSRT_WARNING_MSVC_ON(4996);

--- a/src/core/ddsi/src/q_config.c
+++ b/src/core/ddsi/src/q_config.c
@@ -1223,9 +1223,9 @@ static void pf_allow_multicast(struct cfgst *cfgst, void *parent, struct cfgelem
 {
   uint32_t *p = cfg_address (cfgst, parent, cfgelem);
   if (*p == AMC_DEFAULT)
-  {
     cfg_logelem (cfgst, sources, "default");
-  }
+  else if (*p == 0)
+    cfg_logelem (cfgst, sources, "false");
   else
   {
     do_print_uint32_bitset (cfgst, *p, sizeof (allow_multicast_codes) / sizeof (*allow_multicast_codes), allow_multicast_names, allow_multicast_codes, sources, "");

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -1525,6 +1525,14 @@ int rtps_init (struct ddsi_domaingv *gv)
     qxev_callback (gv->xevents, reset_deaf_mute_time, reset_deaf_mute, gv);
   return 0;
 
+#if 0
+#ifdef DDSI_INCLUDE_SECURITY
+err_post_omg_security_init:
+  q_omg_security_stop (gv); // should be a no-op as it starts lazily
+  q_omg_security_deinit(gv->security_context);
+  q_omg_security_free (gv);
+#endif
+#endif
 err_mc_conn:
   if (gv->xmit_conn)
     ddsi_conn_free (gv->xmit_conn);
@@ -1562,9 +1570,6 @@ err_unicast_sockets:
   ddsrt_hh_free (gv->sertopics);
   ddsrt_mutex_destroy (&gv->sertopics_lock);
 #ifdef DDSI_INCLUDE_SECURITY
-  q_omg_security_stop (gv); // should be a no-op as it starts lazily
-  q_omg_security_deinit(gv->security_context);
-  q_omg_security_free (gv);
   ddsi_xqos_fini (&gv->builtin_stateless_xqos_wr);
   ddsi_xqos_fini (&gv->builtin_stateless_xqos_rd);
   ddsi_xqos_fini (&gv->builtin_volatile_xqos_wr);

--- a/src/core/ddsi/tests/CMakeLists.txt
+++ b/src/core/ddsi/tests/CMakeLists.txt
@@ -12,6 +12,7 @@
 include(CUnit)
 
 set(ddsi_test_sources
+    "locators.c"
     "plist_generic.c"
     "plist.c"
     "mem_ser.h")

--- a/src/core/ddsi/tests/locators.c
+++ b/src/core/ddsi/tests/locators.c
@@ -1,0 +1,428 @@
+/*
+ * Copyright(c) 2020 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include <string.h>
+#include <assert.h>
+
+#include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/sockets.h"
+#include "dds/ddsi/ddsi_tran.h"
+#include "dds/ddsi/ddsi_domaingv.h"
+#include "dds/ddsi/ddsi_udp.h"
+#include "dds/ddsi/ddsi_tcp.h"
+#include "dds/ddsi/q_config.h"
+#include "dds/ddsi/q_rtps.h"
+#include "CUnit/Theory.h"
+
+static bool prefix_zero (const nn_locator_t *loc, size_t n)
+{
+  assert (n <= sizeof (loc->address));
+  for (size_t i = 0; i < n; i++)
+    if (loc->address[i] != 0)
+      return false;
+  return true;
+}
+
+static bool check_ipv4_address (const nn_locator_t *loc, const uint8_t x[4])
+{
+  return prefix_zero (loc, 12) && memcmp (loc->address + 12, x, 4) == 0;
+}
+
+static bool check_ipv64_address (const nn_locator_t *loc, const uint8_t x[4])
+{
+  return prefix_zero (loc, 10) && loc->address[10] == 0xff && loc->address[11] == 0xff && memcmp (loc->address + 12, x, 4) == 0;
+}
+
+static struct ddsi_tran_factory *init (struct ddsi_domaingv *gv, enum transport_selector tr)
+{
+  memset (gv, 0, sizeof (*gv));
+  gv->config.transport_selector = tr;
+  ddsi_udp_init (gv);
+  ddsi_tcp_init (gv);
+  switch (tr)
+  {
+    case TRANS_UDP: return ddsi_factory_find (gv, "udp");
+    case TRANS_TCP: return ddsi_factory_find (gv, "tcp");
+    case TRANS_UDP6: return ddsi_factory_find (gv, "udp6");
+    case TRANS_TCP6: return ddsi_factory_find (gv, "tcp6");
+    default: return NULL;
+  }
+}
+
+static void fini (struct ddsi_domaingv *gv)
+{
+  while (gv->ddsi_tran_factories)
+  {
+    struct ddsi_tran_factory *f = gv->ddsi_tran_factories;
+    gv->ddsi_tran_factories = f->m_factory;
+    ddsi_factory_free (f);
+  }
+}
+
+CU_Test (ddsi_locator_from_string, bogusproto)
+{
+  struct ddsi_domaingv gv;
+  struct ddsi_tran_factory * const fact = init (&gv, TRANS_UDP);
+  nn_locator_t loc;
+  enum ddsi_locator_from_string_result res;
+  res = ddsi_locator_from_string (&gv, &loc, "bogusproto/xyz", fact);
+  CU_ASSERT_FATAL (res == AFSR_UNKNOWN);
+  res = ddsi_locator_from_string (&gv, &loc, "bogusproto/xyz:1234", fact);
+  CU_ASSERT_FATAL (res == AFSR_UNKNOWN);
+  res = ddsi_locator_from_string (&gv, &loc, "bogusproto/1.2.3.4:1234", fact);
+  CU_ASSERT_FATAL (res == AFSR_UNKNOWN);
+  fini (&gv);
+}
+
+CU_TheoryDataPoints(ddsi_locator_from_string, ipv4_invalid) = {
+  CU_DataPoints(enum transport_selector, TRANS_UDP, TRANS_TCP)
+};
+
+CU_Theory ((enum transport_selector tr), ddsi_locator_from_string, ipv4_invalid)
+{
+  struct ddsi_domaingv gv;
+  struct ddsi_tran_factory * const fact = init (&gv, tr);
+  nn_locator_t loc;
+  enum ddsi_locator_from_string_result res;
+  char astr[40];
+  snprintf (astr, sizeof (astr), "%s/", fact->m_typename);
+  res = ddsi_locator_from_string (&gv, &loc, astr, fact);
+  CU_ASSERT_FATAL (res == AFSR_INVALID);
+  snprintf (astr, sizeof (astr), "%s/:", fact->m_typename);
+  res = ddsi_locator_from_string (&gv, &loc, astr, fact);
+  CU_ASSERT_FATAL (res == AFSR_INVALID);
+  snprintf (astr, sizeof (astr), "%s/1.2:", fact->m_typename);
+  res = ddsi_locator_from_string (&gv, &loc, astr, fact);
+  CU_ASSERT_FATAL (res == AFSR_INVALID);
+  snprintf (astr, sizeof (astr), "%s/1.2:99999", fact->m_typename);
+  res = ddsi_locator_from_string (&gv, &loc, astr, fact);
+  CU_ASSERT_FATAL (res == AFSR_INVALID);
+  // if DNS is supported, a hostname lookup is tried whenever parsing as a numerical address fails
+  // which means we may get UNKNOWN
+  snprintf (astr, sizeof (astr), "%s/:1234", fact->m_typename);
+  res = ddsi_locator_from_string (&gv, &loc, astr, fact);
+  CU_ASSERT_FATAL (res == AFSR_INVALID || res == AFSR_UNKNOWN);
+  snprintf (astr, sizeof (astr), "%s/[1.2.3.4]", fact->m_typename);
+  res = ddsi_locator_from_string (&gv, &loc, astr, fact);
+  CU_ASSERT_FATAL (res == AFSR_INVALID || res == AFSR_UNKNOWN);
+  snprintf (astr, sizeof (astr), "%s/[1.2.3.4]:1234", fact->m_typename);
+  res = ddsi_locator_from_string (&gv, &loc, astr, fact);
+  CU_ASSERT_FATAL (res == AFSR_INVALID || res == AFSR_UNKNOWN);
+  fini (&gv);
+}
+
+CU_TheoryDataPoints(ddsi_locator_from_string, ipv4) = {
+  CU_DataPoints(enum transport_selector, TRANS_UDP, TRANS_TCP)
+};
+
+CU_Theory ((enum transport_selector tr), ddsi_locator_from_string, ipv4)
+{
+  struct ddsi_domaingv gv;
+  struct ddsi_tran_factory * const fact = init (&gv, tr);
+  nn_locator_t loc;
+  enum ddsi_locator_from_string_result res;
+  char astr[40];
+
+#if DDSRT_HAVE_DNS
+  {
+    enum ddsi_locator_from_string_result exp;
+    struct sockaddr_in localhost;
+    ddsrt_hostent_t *hent = NULL;
+    if (ddsrt_gethostbyname ("localhost", AF_INET, &hent) != 0)
+      exp = AFSR_UNKNOWN;
+    else
+    {
+      CU_ASSERT_FATAL (hent->addrs[0].ss_family == AF_INET);
+      memcpy (&localhost, &hent->addrs[0], sizeof (localhost));
+      ddsrt_free (hent);
+      exp = AFSR_OK;
+    }
+    res = ddsi_locator_from_string (&gv, &loc, "localhost", fact);
+    CU_ASSERT_FATAL (res == exp);
+    if (res == AFSR_OK)
+    {
+      CU_ASSERT_FATAL (loc.kind == fact->m_kind);
+      CU_ASSERT_FATAL (loc.port == NN_LOCATOR_PORT_INVALID);
+      CU_ASSERT_FATAL (loc.tran == fact);
+      CU_ASSERT_FATAL (prefix_zero (&loc, 12) && memcmp (loc.address + 12, &localhost.sin_addr.s_addr, 4) == 0);
+    }
+    res = ddsi_locator_from_string (&gv, &loc, "localhost:1234", fact);
+    CU_ASSERT_FATAL (res == exp);
+    if (res == AFSR_OK)
+    {
+      CU_ASSERT_FATAL (loc.kind == fact->m_kind);
+      CU_ASSERT_FATAL (loc.port == 1234);
+      CU_ASSERT_FATAL (loc.tran == fact);
+      CU_ASSERT_FATAL (prefix_zero (&loc, 12) && memcmp (loc.address + 12, &localhost.sin_addr.s_addr, 4) == 0);
+    }
+  }
+#endif
+
+  res = ddsi_locator_from_string (&gv, &loc, "1.2.3.4", fact);
+  CU_ASSERT_FATAL (res == AFSR_OK);
+  CU_ASSERT_FATAL (loc.kind == fact->m_kind);
+  CU_ASSERT_FATAL (loc.port == NN_LOCATOR_PORT_INVALID);
+  CU_ASSERT_FATAL (loc.tran == fact);
+  CU_ASSERT_FATAL (check_ipv4_address (&loc, (uint8_t[]){1,2,3,4}));
+
+  snprintf (astr, sizeof (astr), "%s/1.2.3.4", fact->m_typename);
+  res = ddsi_locator_from_string (&gv, &loc, astr, fact);
+  CU_ASSERT_FATAL (res == AFSR_OK);
+  CU_ASSERT_FATAL (loc.kind == fact->m_kind);
+  CU_ASSERT_FATAL (loc.port == NN_LOCATOR_PORT_INVALID);
+  CU_ASSERT_FATAL (loc.tran == fact);
+  CU_ASSERT_FATAL (check_ipv4_address (&loc, (uint8_t[]){1,2,3,4}));
+
+  snprintf (astr, sizeof (astr), "%s/1.2.3.4:1234", fact->m_typename);
+  res = ddsi_locator_from_string (&gv, &loc, astr, fact);
+  CU_ASSERT_FATAL (res == AFSR_OK);
+  CU_ASSERT_FATAL (loc.kind == fact->m_kind);
+  CU_ASSERT_FATAL (loc.port == 1234);
+  CU_ASSERT_FATAL (loc.tran == fact);
+  CU_ASSERT_FATAL (check_ipv4_address (&loc, (uint8_t[]){1,2,3,4}));
+  fini (&gv);
+}
+
+CU_Test (ddsi_locator_from_string, ipv4_cross1)
+{
+  struct ddsi_domaingv gv;
+  struct ddsi_tran_factory * const fact = init (&gv, TRANS_UDP);
+  nn_locator_t loc;
+  enum ddsi_locator_from_string_result res;
+  res = ddsi_locator_from_string (&gv, &loc, "tcp/1.2.3.4:1234", fact);
+  CU_ASSERT_FATAL (res == AFSR_OK);
+  CU_ASSERT_FATAL (loc.kind == NN_LOCATOR_KIND_TCPv4);
+  CU_ASSERT_FATAL (loc.port == 1234);
+  CU_ASSERT_FATAL (loc.tran != fact);
+  CU_ASSERT_FATAL (check_ipv4_address (&loc, (uint8_t[]){1,2,3,4}));
+  fini (&gv);
+}
+
+CU_Test (ddsi_locator_from_string, ipv4_cross2)
+{
+  struct ddsi_domaingv gv;
+  struct ddsi_tran_factory * const fact = init (&gv, TRANS_TCP);
+  nn_locator_t loc;
+  enum ddsi_locator_from_string_result res;
+  res = ddsi_locator_from_string (&gv, &loc, "udp/1.2.3.4:1234", fact);
+  CU_ASSERT_FATAL (res == AFSR_OK);
+  CU_ASSERT_FATAL (loc.kind == NN_LOCATOR_KIND_UDPv4);
+  CU_ASSERT_FATAL (loc.port == 1234);
+  CU_ASSERT_FATAL (loc.tran != fact);
+  CU_ASSERT_FATAL (check_ipv4_address (&loc, (uint8_t[]){1,2,3,4}));
+  fini (&gv);
+}
+
+CU_Test (ddsi_locator_from_string, udpv4mcgen)
+{
+  struct ddsi_domaingv gv;
+  struct ddsi_tran_factory * const fact = init (&gv, TRANS_UDP);
+  nn_locator_t loc;
+  enum ddsi_locator_from_string_result res;
+  res = ddsi_locator_from_string (&gv, &loc, "239.255.0.1;4;8;1:1234", fact);
+  CU_ASSERT_FATAL (res == AFSR_OK);
+  CU_ASSERT_FATAL (loc.kind == NN_LOCATOR_KIND_UDPv4MCGEN);
+  CU_ASSERT_FATAL (loc.port == 1234);
+  CU_ASSERT_FATAL (loc.tran == fact);
+  CU_ASSERT_FATAL (loc.address[0] == 239 && loc.address[1] == 255 && loc.address[2] == 0 && loc.address[3] == 1);
+  CU_ASSERT_FATAL (loc.address[4] == 4 && loc.address[5] == 8 && loc.address[6] == 1);
+  CU_ASSERT_FATAL (loc.address[7] == 0 && loc.address[8] == 0 && loc.address[9] == 0);
+  CU_ASSERT_FATAL (loc.address[10] == 0 && loc.address[11] == 0 && loc.address[12] == 0);
+  CU_ASSERT_FATAL (loc.address[13] == 0 && loc.address[14] == 0 && loc.address[15] == 0);
+
+  res = ddsi_locator_from_string (&gv, &loc, "239.255.0.1;4;0;1:1234", fact);
+  CU_ASSERT_FATAL (res == AFSR_INVALID || res == AFSR_UNKNOWN);
+  res = ddsi_locator_from_string (&gv, &loc, "239.255.0.1;4;0;1:2345", fact);
+  CU_ASSERT_FATAL (res == AFSR_INVALID || res == AFSR_UNKNOWN);
+  res = ddsi_locator_from_string (&gv, &loc, "239.255.0.1;30;1;1:3456", fact);
+  CU_ASSERT_FATAL (res == AFSR_INVALID || res == AFSR_UNKNOWN);
+  res = ddsi_locator_from_string (&gv, &loc, "239.255.0.1;4;24;1:4567", fact);
+  CU_ASSERT_FATAL (res == AFSR_INVALID || res == AFSR_UNKNOWN);
+  res = ddsi_locator_from_string (&gv, &loc, "239.255.0.1;4;3;3:5678", fact);
+  CU_ASSERT_FATAL (res == AFSR_INVALID || res == AFSR_UNKNOWN);
+  fini (&gv);
+}
+
+CU_TheoryDataPoints(ddsi_locator_from_string, ipv6_invalid) = {
+  CU_DataPoints(enum transport_selector, TRANS_UDP6, TRANS_TCP6)
+};
+
+CU_Theory ((enum transport_selector tr), ddsi_locator_from_string, ipv6_invalid)
+{
+#if DDSRT_HAVE_IPV6
+  struct ddsi_domaingv gv;
+  struct ddsi_tran_factory * const fact = init (&gv, tr);
+  nn_locator_t loc;
+  enum ddsi_locator_from_string_result res;
+  char astr[40];
+  snprintf (astr, sizeof (astr), "%s/", fact->m_typename);
+  res = ddsi_locator_from_string (&gv, &loc, astr, fact);
+  CU_ASSERT_FATAL (res == AFSR_INVALID);
+  // if DNS is supported, a hostname lookup is tried whenever parsing as a numerical address fails
+  // which means we may get UNKNOWN
+  snprintf (astr, sizeof (astr), "%s/::1:31415", fact->m_typename);
+  res = ddsi_locator_from_string (&gv, &loc, astr, fact);
+  CU_ASSERT_FATAL (res == AFSR_INVALID || res == AFSR_UNKNOWN);
+  snprintf (astr, sizeof (astr), "%s/:", fact->m_typename);
+  res = ddsi_locator_from_string (&gv, &loc, astr, fact);
+  CU_ASSERT_FATAL (res == AFSR_INVALID || res == AFSR_UNKNOWN);
+  snprintf (astr, sizeof (astr), "%s/1.2:", fact->m_typename);
+  res = ddsi_locator_from_string (&gv, &loc, astr, fact);
+  CU_ASSERT_FATAL (res == AFSR_INVALID || res == AFSR_UNKNOWN);
+  snprintf (astr, sizeof (astr), "%s/]:", fact->m_typename);
+  res = ddsi_locator_from_string (&gv, &loc, astr, fact);
+  CU_ASSERT_FATAL (res == AFSR_INVALID || res == AFSR_UNKNOWN);
+  snprintf (astr, sizeof (astr), "%s/[", fact->m_typename);
+  res = ddsi_locator_from_string (&gv, &loc, astr, fact);
+  CU_ASSERT_FATAL (res == AFSR_INVALID || res == AFSR_UNKNOWN);
+  snprintf (astr, sizeof (astr), "%s/[]", fact->m_typename);
+  res = ddsi_locator_from_string (&gv, &loc, astr, fact);
+  CU_ASSERT_FATAL (res == AFSR_INVALID || res == AFSR_UNKNOWN);
+  snprintf (astr, sizeof (astr), "%s/:1234", fact->m_typename);
+  res = ddsi_locator_from_string (&gv, &loc, astr, fact);
+  CU_ASSERT_FATAL (res == AFSR_INVALID || res == AFSR_UNKNOWN);
+  fini (&gv);
+#else
+  CU_PASS ("No IPv6 support");
+#endif
+}
+
+CU_TheoryDataPoints(ddsi_locator_from_string, ipv6) = {
+  CU_DataPoints(enum transport_selector, TRANS_UDP6, TRANS_TCP6)
+};
+
+CU_Theory ((enum transport_selector tr), ddsi_locator_from_string, ipv6)
+{
+#if DDSRT_HAVE_IPV6
+  struct ddsi_domaingv gv;
+  struct ddsi_tran_factory * const fact = init (&gv, tr);
+  nn_locator_t loc;
+  enum ddsi_locator_from_string_result res;
+  char astr[40];
+
+#if DDSRT_HAVE_DNS
+  {
+    enum ddsi_locator_from_string_result exp;
+    struct sockaddr_in6 localhost;
+    ddsrt_hostent_t *hent = NULL;
+    if (ddsrt_gethostbyname ("localhost", AF_INET6, &hent) != 0)
+      exp = AFSR_UNKNOWN;
+    else
+    {
+      CU_ASSERT_FATAL (hent->addrs[0].ss_family == AF_INET6);
+      memcpy (&localhost, &hent->addrs[0], sizeof (localhost));
+      ddsrt_free (hent);
+      exp = AFSR_OK;
+    }
+    res = ddsi_locator_from_string (&gv, &loc, "localhost", fact);
+    CU_ASSERT_FATAL (res == exp);
+    if (res == AFSR_OK)
+    {
+      CU_ASSERT_FATAL (loc.kind == fact->m_kind);
+      CU_ASSERT_FATAL (loc.port == NN_LOCATOR_PORT_INVALID);
+      CU_ASSERT_FATAL (loc.tran == fact);
+      CU_ASSERT_FATAL (memcmp (loc.address, &localhost.sin6_addr.s6_addr, 16) == 0);
+    }
+    res = ddsi_locator_from_string (&gv, &loc, "[localhost]", fact);
+    CU_ASSERT_FATAL (res == exp);
+    if (res == AFSR_OK)
+    {
+      CU_ASSERT_FATAL (loc.kind == fact->m_kind);
+      CU_ASSERT_FATAL (loc.port == NN_LOCATOR_PORT_INVALID);
+      CU_ASSERT_FATAL (loc.tran == fact);
+      CU_ASSERT_FATAL (memcmp (loc.address, &localhost.sin6_addr.s6_addr, 16) == 0);
+    }
+    res = ddsi_locator_from_string (&gv, &loc, "localhost:1234", fact);
+    CU_ASSERT_FATAL (res == exp);
+    if (res == AFSR_OK)
+    {
+      CU_ASSERT_FATAL (loc.kind == fact->m_kind);
+      CU_ASSERT_FATAL (loc.port == 1234);
+      CU_ASSERT_FATAL (loc.tran == fact);
+      CU_ASSERT_FATAL (memcmp (loc.address, &localhost.sin6_addr.s6_addr, 16) == 0);
+    }
+    res = ddsi_locator_from_string (&gv, &loc, "[localhost]:4567", fact);
+    CU_ASSERT_FATAL (res == exp);
+    if (res == AFSR_OK)
+    {
+      CU_ASSERT_FATAL (loc.kind == fact->m_kind);
+      CU_ASSERT_FATAL (loc.port == 4567);
+      CU_ASSERT_FATAL (loc.tran == fact);
+      CU_ASSERT_FATAL (memcmp (loc.address, &localhost.sin6_addr.s6_addr, 16) == 0);
+    }
+  }
+#endif
+
+  res = ddsi_locator_from_string (&gv, &loc, "1.2.3.4", fact);
+  CU_ASSERT_FATAL (res == AFSR_OK || res == AFSR_UNKNOWN);
+  if (res == AFSR_OK)
+  {
+    CU_ASSERT_FATAL (loc.kind == fact->m_kind);
+    CU_ASSERT_FATAL (loc.port == NN_LOCATOR_PORT_INVALID);
+    CU_ASSERT_FATAL (loc.tran == fact);
+    CU_ASSERT_FATAL (check_ipv64_address (&loc, (uint8_t[]){1,2,3,4}));
+  }
+
+  res = ddsi_locator_from_string (&gv, &loc, "[1.2.3.4]", fact);
+  CU_ASSERT_FATAL (res == AFSR_OK || res == AFSR_UNKNOWN);
+  if (res == AFSR_OK)
+  {
+    CU_ASSERT_FATAL (loc.kind == fact->m_kind);
+    CU_ASSERT_FATAL (loc.port == NN_LOCATOR_PORT_INVALID);
+    CU_ASSERT_FATAL (loc.tran == fact);
+    CU_ASSERT_FATAL (check_ipv64_address (&loc, (uint8_t[]){1,2,3,4}));
+  }
+
+  snprintf (astr, sizeof (astr), "%s/1.2.3.4", fact->m_typename);
+  res = ddsi_locator_from_string (&gv, &loc, astr, fact);
+  CU_ASSERT_FATAL (res == AFSR_OK || res == AFSR_UNKNOWN);  if (res == AFSR_OK)
+  {
+    CU_ASSERT_FATAL (loc.kind == fact->m_kind);
+    CU_ASSERT_FATAL (loc.port == NN_LOCATOR_PORT_INVALID);
+    CU_ASSERT_FATAL (loc.tran == fact);
+    CU_ASSERT_FATAL (check_ipv64_address (&loc, (uint8_t[]){1,2,3,4}));
+  }
+
+  snprintf (astr, sizeof (astr), "%s/1.2.3.4:6789", fact->m_typename);
+  res = ddsi_locator_from_string (&gv, &loc, astr, fact);
+  CU_ASSERT_FATAL (res == AFSR_OK || res == AFSR_UNKNOWN);
+  if (res == AFSR_OK)
+  {
+    CU_ASSERT_FATAL (loc.kind == fact->m_kind);
+    CU_ASSERT_FATAL (loc.port == 6789);
+    CU_ASSERT_FATAL (loc.tran == fact);
+    CU_ASSERT_FATAL (check_ipv64_address (&loc, (uint8_t[]){1,2,3,4}));
+  }
+
+  snprintf (astr, sizeof (astr), "%s/[1.2.3.4]:7890", fact->m_typename);
+  res = ddsi_locator_from_string (&gv, &loc, astr, fact);
+  if (res == AFSR_OK)
+  {
+    CU_ASSERT_FATAL (res == AFSR_OK || res == AFSR_UNKNOWN);
+    CU_ASSERT_FATAL (loc.kind == fact->m_kind);
+    CU_ASSERT_FATAL (loc.port == 7890);
+    CU_ASSERT_FATAL (loc.tran == fact);
+    CU_ASSERT_FATAL (check_ipv64_address (&loc, (uint8_t[]){1,2,3,4}));
+  }
+
+  snprintf (astr, sizeof (astr), "%s/[::1]:8901", fact->m_typename);
+  res = ddsi_locator_from_string (&gv, &loc, astr, fact);
+  CU_ASSERT_FATAL (res == AFSR_OK);
+  CU_ASSERT_FATAL (loc.kind == fact->m_kind);
+  CU_ASSERT_FATAL (loc.port == 8901);
+  CU_ASSERT_FATAL (loc.tran == fact);
+  CU_ASSERT_FATAL (prefix_zero (&loc, 15) && loc.address[15] == 1);
+
+  fini (&gv);
+#else
+  CU_PASS ("No IPv6 support");
+#endif
+}


### PR DESCRIPTION
This PR addresses some recently discovered issues with IPv6 and raw Ethernet support, as well some bugs that were discovered along the way:

* IPv6 link-local addresses need the IPv6 scope_id to be set correctly, or they won't work. This used to be the case, I broke it in 4df38f5bf9de41c0691c7336df3782d5e40e09f9 ... Curiously this doesn't seem to bother macOS. Last time I checked one can't use IPv6 on Travis CI for Linux.
* "Raw" Ethernet support got broken d1ed8df9f343b1cd441e3cd7ceaa750b480b7ce9 because that introduced a socket with a random port number that the raw Ethernet support code is unwilling to handle. I believe we don't actually need that socket anymore, but that needs verification.
* The cleaning-up of discovery data parsing (replacing a huge hard-coded and hand-written switch statement to a table-driven mechanism) in 3322fc086d1e4bf9ae34686cf7d3ad94e41f10fd changed the locator handling, but it accidentally set the "present" bit also when an locator in the input was ignored (known invalid ones are rejected, but unsupport ones are ignored). This then leads to using uninitialized data and so is pretty bad.
* There were some weird inconsistencies in handling peer address specifications, I believe those are now cleaned up as well.