### PR TITLE
Fix long latency for large messages

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/q_entity.h
+++ b/src/core/ddsi/include/dds/ddsi/q_entity.h
@@ -131,9 +131,10 @@ struct wr_prd_match {
   seqno_t last_seq; /* highest seq send to this reader used when filter is applied */
   int32_t num_reliable_readers_where_seq_equals_max;
   ddsi_guid_t arbitrary_unacked_reader;
-  nn_count_t next_acknack; /* next acceptable acknack sequence number */
-  nn_count_t next_nackfrag; /* next acceptable nackfrag sequence number */
+  nn_count_t prev_acknack; /* latest accepted acknack sequence number */
+  nn_count_t prev_nackfrag; /* latest accepted nackfrag sequence number */
   ddsrt_etime_t t_acknack_accepted; /* (local) time an acknack was last accepted */
+  ddsrt_etime_t t_nackfrag_accepted; /* (local) time a nackfrag was last accepted */
   struct nn_lat_estim hb_to_ack_latency;
   ddsrt_wctime_t hb_to_ack_latency_tlastlog;
   uint32_t non_responsive_count;
@@ -154,7 +155,7 @@ struct pwr_rd_match {
   ddsi_guid_t rd_guid;
   ddsrt_mtime_t tcreate;
   nn_count_t count; /* most recent acknack sequence number */
-  nn_count_t next_heartbeat; /* next acceptable heartbeat (see also add_proxy_writer_to_reader) */
+  nn_count_t prev_heartbeat; /* latest accepted heartbeat (see also add_proxy_writer_to_reader) */
   ddsrt_wctime_t hb_timestamp; /* time of most recent heartbeat that rescheduled the ack event */
   ddsrt_etime_t t_heartbeat_accepted; /* (local) time a heartbeat was last accepted */
   ddsrt_mtime_t t_last_nack; /* (local) time we last sent a NACK */  /* FIXME: probably elapsed time is better */

--- a/src/core/ddsi/include/dds/ddsi/q_protocol.h
+++ b/src/core/ddsi/include/dds/ddsi/q_protocol.h
@@ -55,9 +55,7 @@ typedef struct nn_fragment_number_set_header {
 #define NN_FRAGMENT_NUMBER_SET_MAX_BITS (256u)
 #define NN_FRAGMENT_NUMBER_SET_BITS_SIZE(numbits) ((unsigned) (4 * (((numbits) + 31) / 32)))
 #define NN_FRAGMENT_NUMBER_SET_SIZE(numbits) (sizeof (nn_fragment_number_set_header_t) + NN_FRAGMENT_NUMBER_SET_BITS_SIZE (numbits))
-typedef int32_t nn_count_t;
-#define DDSI_COUNT_MIN (-2147483647 - 1)
-#define DDSI_COUNT_MAX (2147483647)
+typedef uint32_t nn_count_t;
 /* address field in locator maintained in network byte order, the rest in host */
 typedef struct {
   const struct ddsi_tran_factory *tran;

--- a/src/core/ddsi/src/q_receive.c
+++ b/src/core/ddsi/src/q_receive.c
@@ -1579,7 +1579,7 @@ static int handle_NackFrag (struct receiver_state *rst, ddsrt_etime_t tnow, cons
       qxev_msg (wr->evq, m);
     }
   }
-  if (seq < writer_read_seq_xmit (wr))
+  if (seq <= writer_read_seq_xmit (wr))
   {
     /* Not everything was retransmitted yet, so force a heartbeat out
        to give the reader a chance to nack the rest and make sure

--- a/src/core/ddsi/src/q_transmit.c
+++ b/src/core/ddsi/src/q_transmit.c
@@ -431,7 +431,7 @@ void add_Heartbeat (struct nn_xmsg *msg, struct writer *wr, const struct whc_sta
   hb->firstSN = toSN (min);
   hb->lastSN = toSN (max);
 
-  hb->count = ++wr->hbcount;
+  hb->count = wr->hbcount++;
 
   nn_xmsg_submsg_setnext (msg, sm_marker);
   encode_datawriter_submsg(msg, sm_marker, wr);
@@ -726,7 +726,7 @@ static void create_HeartbeatFrag (struct writer *wr, seqno_t seq, unsigned fragn
   hbf->writerSN = toSN (seq);
   hbf->lastFragmentNum = fragnum + 1; /* network format is 1 based */
 
-  hbf->count = ++wr->hbfragcount;
+  hbf->count = wr->hbfragcount++;
 
   nn_xmsg_submsg_setnext (*pmsg, sm_marker);
   encode_datawriter_submsg(*pmsg, sm_marker, wr);

--- a/src/core/ddsi/src/q_xevent.c
+++ b/src/core/ddsi/src/q_xevent.c
@@ -943,11 +943,14 @@ static void add_AckNack (struct nn_xmsg *msg, struct proxy_writer *pwr, struct p
     nn_xmsg_shrink (msg, sm_marker, ACKNACK_SIZE (an->readerSNState.numbits));
     nn_xmsg_submsg_setnext (msg, sm_marker);
 
-    ETRACE (pwr, "acknack "PGUIDFMT" -> "PGUIDFMT": #%"PRId32":%"PRId64"/%"PRIu32":",
-            PGUID (rwn->rd_guid), PGUID (pwr->e.guid), rwn->count,
-            base, an->readerSNState.numbits);
-    for (uint32_t ui = 0; ui != an->readerSNState.numbits; ui++)
-      ETRACE (pwr, "%c", nn_bitset_isset (numbits, an->bits, ui) ? '1' : '0');
+    if (pwr->e.gv->logconfig.c.mask & DDS_LC_TRACE)
+    {
+      ETRACE (pwr, "acknack "PGUIDFMT" -> "PGUIDFMT": #%"PRIu32":%"PRId64"/%"PRIu32":",
+              PGUID (rwn->rd_guid), PGUID (pwr->e.guid), rwn->count,
+              base, an->readerSNState.numbits);
+      for (uint32_t ui = 0; ui != an->readerSNState.numbits; ui++)
+        ETRACE (pwr, "%c", nn_bitset_isset (numbits, an->bits, ui) ? '1' : '0');
+    }
 
     /* Encode the sub-message when needed. */
     encode_datareader_submsg(msg, sm_marker, pwr, &rwn->rd_guid);
@@ -977,7 +980,7 @@ static void add_AckNack (struct nn_xmsg *msg, struct proxy_writer *pwr, struct p
       *countp = ++pwr->nackfragcount;
       nn_xmsg_submsg_setnext (msg, sm_marker);
 
-      ETRACE (pwr, " + nackfrag #%"PRId32":%"PRId64"/%u/%"PRIu32":", *countp, fromSN (nf->writerSN), nf->fragmentNumberState.bitmap_base, nf->fragmentNumberState.numbits);
+      ETRACE (pwr, " + nackfrag #%"PRIu32":%"PRId64"/%u/%"PRIu32":", *countp, fromSN (nf->writerSN), nf->fragmentNumberState.bitmap_base, nf->fragmentNumberState.numbits);
       for (uint32_t ui = 0; ui != nf->fragmentNumberState.numbits; ui++)
         ETRACE (pwr, "%c", nn_bitset_isset (nf->fragmentNumberState.numbits, nf->bits, ui) ? '1' : '0');
     }


### PR DESCRIPTION
This fixes #484, which turns out to _not_ be an over-eager retransmission policy, but caused by dropping the heartbeat transmit rate while still retransmitting fragments. It is still not really good enough, but the real crazy long delays are gone. (As an aside, the over-eager policy does exist, but it shows up on, e.g., WiFi. A follow-up PR will bring some improvements there.)

Pipeline latency difference for the https://github.com/jacobperron/pc_pipe demo that triggered the issue (measured on an Ubuntu 20.04 VM under macOS, using Foxy and with a fix in place to use reliable communications in the test):

![image](https://user-images.githubusercontent.com/16984005/85861292-6687c880-b7c0-11ea-862a-f682239d2d95.png)

This also addresses some issues in handling retransmit requests of large messages. This is only somewhat related, but whatever ... For example, if the reader temporarily loses the connection with the writer (but not vice versa) — not very likely to happen in well-behaved networks if the writer is sending all the time, but a dirty WiFi is a different story — the resetting of the "count" fields in the retransmit requests cause those to be ignored (as per the spec). This PR adds a timeout after which they are accepted again, bounding the duration of the hiccup.

It also eliminates out some undefined behaviour by changing these counts to unsigned integers (the spec says signed ... but that doesn't mean one has to implement them as signed integers).