### PR TITLE
Replacement for os_sockWaitSet

### DIFF
--- a/src/ddsrt/CMakeLists.txt
+++ b/src/ddsrt/CMakeLists.txt
@@ -152,7 +152,7 @@ list(APPEND sources
 # network stack. In order to mix-and-match various compilers, architectures,
 # operating systems, etc input from the build system is required.
 foreach(feature atomics cdtors environ heap ifaddrs random rusage
-                sockets string sync threads time md5 process netstat)
+                sockets string sync threads time md5 process netstat events)
   if(EXISTS "${include_path}/dds/ddsrt/${feature}.h")
     list(APPEND headers "${include_path}/dds/ddsrt/${feature}.h")
     file(GLOB_RECURSE

--- a/src/ddsrt/include/dds/ddsrt/events.h
+++ b/src/ddsrt/include/dds/ddsrt/events.h
@@ -1,0 +1,181 @@
+/*
+ * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#ifndef DDSRT_EVENTS_H
+#define DDSRT_EVENTS_H
+
+#include "dds/ddsrt/retcode.h"
+#include "dds/ddsrt/sockets.h"
+#include "dds/ddsrt/atomics.h"
+
+#if __APPLE__
+#include "dds/ddsrt/events/darwin.h"
+#else
+#include "dds/ddsrt/events/posix.h"
+#endif
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+  /**
+  * @name Definitions for event trigger flags.
+  * These flags describe the different type of trigger events which can be watched for.
+  */
+///@{
+  /**< the flag is not set */
+#define DDSRT_EVENT_FLAG_UNSET 0u
+  /**< resource has data available for reading */
+#define DDSRT_EVENT_FLAG_READ (1u<<0) 
+  /**< resource can be written to */
+//#define DDSRT_EVENT_FLAG_WRITE (1u<<1) 
+  /**< resource has been opened */
+//#define DDSRT_EVENT_FLAG_OPEN (1u<<2) 
+  /**< resource has been closed */
+//#define DDSRT_EVENT_FLAG_CLOSE (1u<<3) 
+  /**< timeout has occurred on the resource */
+//#define DDSRT_EVENT_FLAG_TIMEOUT (1u<<4)
+  /**< notification of ip address change on the resource*/
+//#define DDSRT_EVENT_FLAG_IP_CHANGE (1u<<5)  
+///@}
+
+  /**
+  * @brief Describes the type of object being monitored for events.
+  */
+  enum ddsrt_event_type {
+    ddsrt_event_type_unset, /**< unitialized state*/
+    ddsrt_event_type_socket /**< indicating a socket type connection*/
+    /*,
+    ddsrt_event_type_file,
+    ddsrt_event_type_ifaddr*/
+  };
+  typedef enum ddsrt_event_type ddsrt_event_type_t;
+
+  /**
+  * @brief Structure containing the information of which object is being watched.
+  *
+  * Is used by ddsrt_event_queue to keep track of objects being watched.
+  */
+  struct ddsrt_event {
+    uint32_t flags; /**< Type of event being watched for, composited from DDSRT_EVENT_FLAG_$EVENT_TYPE$.*/
+    ddsrt_event_type_t type; /**< Type of object being watched.*/
+    ddsrt_atomic_uint32_t triggered; /**< Trigger status after a call to ddsrt_event_queue_wait.*/
+    union {
+      struct { ddsrt_socket_t sock; } socket;
+      /*struct ddsrt_event_file file;  this is for future expansion to be able to register events on files*/
+      /*struct ddsrt_event_ifaddr ifaddr; this is for future expansion to be able to register IP address changes*/
+    } data; /**< Container for the object being watched.*/
+  };
+
+  typedef struct ddsrt_event ddsrt_event_t;
+
+  typedef struct ddsrt_event_queue ddsrt_event_queue_t;
+  
+  /**
+  * @brief Initializes an existing event to indicate a socket.
+  *
+  * @param ev Pointer to the event to initialize.
+  * @param sock Socket to initialize the event with.
+  * @param flags Flags to set for the event.
+  *
+  * @returns DDS_RETCODE_OK if everything went OK.
+  */
+  dds_return_t ddsrt_event_socket_init(ddsrt_event_t* ev, ddsrt_socket_t sock, uint32_t flags);
+
+  dds_return_t ddsrt_event_fini(ddsrt_event_t* ev);
+
+  /**
+  * @brief Event queue creation function.
+  *
+  * @returns Pointer to the created queue.
+  */
+  ddsrt_event_queue_t* ddsrt_event_queue_create(void);
+
+  /**
+  * @brief Cleans up an event queue.
+  *
+  * Will finish the event queue first, then free the memory of the queue.
+  *
+  * @param queue The queue to clean up.
+  *
+  * @returns DDS_RETCODE_OK if everything went OK.
+  */
+  dds_return_t ddsrt_event_queue_destroy(ddsrt_event_queue_t* queue);
+
+  /**
+  * @brief Getter for the number of stored events.
+  *
+  * @param queue The queue to get the number of events of.
+  *
+  * @returns The number of events stored by the queue.
+  */
+  size_t ddsrt_event_queue_nevents(ddsrt_event_queue_t* queue);
+
+  /**
+  * @brief Triggers a wait for events for the queue.
+  *
+  * @param queue The queue to trigger.
+  * @param reltime The maximum amount of time to wait.
+  *
+  * @returns DDS_RETCODE_OK if everything went OK.
+  */
+  dds_return_t ddsrt_event_queue_wait(ddsrt_event_queue_t* queue, dds_duration_t reltime);
+
+  /**
+  * @brief Interrupts a triggered wait of a queue.
+  *
+  * @param queue The queue to interrupt.
+  *
+  * @returns DDS_RETCODE_OK if everything went OK.
+  */
+  dds_return_t ddsrt_event_queue_signal(ddsrt_event_queue_t* queue);
+
+  /**
+  * @brief Adds an event to the queue.
+  * 
+  * This event will be stored by the queue, any additional actions such as registration to other services will also be done.
+  *
+  * @param queue The queue to add the event to.
+  * @param evt Pointer to the event to add.
+  *
+  * @returns DDS_RETCODE_OK if everything went OK.
+  */
+  dds_return_t ddsrt_event_queue_add(ddsrt_event_queue_t* queue, ddsrt_event_t* evt);
+
+  /**
+  * @brief Removes an event from the queue.
+  *
+  * This event will be removed from the queue, any additional actions such as deregistration from other services will also be done.
+  *
+  * @param queue The queue to remove the event from.
+  * @param evt Pointer to the event to remove.
+  *
+  * @returns DDS_RETCODE_OK if everything went OK.
+  */
+  dds_return_t ddsrt_event_queue_remove(ddsrt_event_queue_t* queue, ddsrt_event_t* evt);
+
+  /**
+  * @brief Gets the next triggered events from the queue.
+  *
+  * Will go over the stored events until it reaches one where any trigger flag is set.
+  * Successive calls to this function will start from the previously used point.
+  * Will be reset after a call to ddsrt_event_queue_wait.
+  *
+  * @param queue The queue to retrieve.
+  *
+  * @returns Pointer to the event which has a trigger flag set, NULL if none has this flag set.
+  */
+  ddsrt_event_t* ddsrt_event_queue_next(ddsrt_event_queue_t* queue);
+
+#if defined (__cplusplus)
+}
+#endif
+#endif /* DDSRT_EVENTS_H */

--- a/src/ddsrt/include/dds/ddsrt/events.h
+++ b/src/ddsrt/include/dds/ddsrt/events.h
@@ -82,15 +82,13 @@ extern "C" {
   /**
   * @brief Initializes an existing event to indicate a socket.
   *
-  * @param ev Pointer to the event to initialize.
-  * @param sock Socket to initialize the event with.
-  * @param flags Flags to set for the event.
+  * @param[out] ev Pointer to the event to initialize.
+  * @param[in] sock Socket to initialize the event with.
+  * @param[in] flags Flags to set for the event.
   *
   * @returns DDS_RETCODE_OK if everything went OK.
   */
   dds_return_t ddsrt_event_socket_init(ddsrt_event_t* ev, ddsrt_socket_t sock, uint32_t flags);
-
-  dds_return_t ddsrt_event_fini(ddsrt_event_t* ev);
 
   /**
   * @brief Event queue creation function.
@@ -104,7 +102,7 @@ extern "C" {
   *
   * Will finish the event queue first, then free the memory of the queue.
   *
-  * @param queue The queue to clean up.
+  * @param[out] queue The queue to clean up.
   *
   * @returns DDS_RETCODE_OK if everything went OK.
   */
@@ -113,7 +111,7 @@ extern "C" {
   /**
   * @brief Getter for the number of stored events.
   *
-  * @param queue The queue to get the number of events of.
+  * @param[in] queue The queue to get the number of events of.
   *
   * @returns The number of events stored by the queue.
   */
@@ -122,8 +120,8 @@ extern "C" {
   /**
   * @brief Triggers a wait for events for the queue.
   *
-  * @param queue The queue to trigger.
-  * @param reltime The maximum amount of time to wait.
+  * @param[out] queue The queue to trigger.
+  * @param[in] reltime The maximum amount of time to wait.
   *
   * @returns DDS_RETCODE_OK if everything went OK.
   */
@@ -132,7 +130,7 @@ extern "C" {
   /**
   * @brief Interrupts a triggered wait of a queue.
   *
-  * @param queue The queue to interrupt.
+  * @param[out] queue The queue to interrupt.
   *
   * @returns DDS_RETCODE_OK if everything went OK.
   */
@@ -143,8 +141,8 @@ extern "C" {
   * 
   * This event will be stored by the queue, any additional actions such as registration to other services will also be done.
   *
-  * @param queue The queue to add the event to.
-  * @param evt Pointer to the event to add.
+  * @param[out] queue The queue to add the event to.
+  * @param[in] evt Pointer to the event to add.
   *
   * @returns DDS_RETCODE_OK if everything went OK.
   */
@@ -155,8 +153,8 @@ extern "C" {
   *
   * This event will be removed from the queue, any additional actions such as deregistration from other services will also be done.
   *
-  * @param queue The queue to remove the event from.
-  * @param evt Pointer to the event to remove.
+  * @param[out] queue The queue to remove the event from.
+  * @param[in] evt Pointer to the event to remove.
   *
   * @returns DDS_RETCODE_OK if everything went OK.
   */
@@ -169,7 +167,7 @@ extern "C" {
   * Successive calls to this function will start from the previously used point.
   * Will be reset after a call to ddsrt_event_queue_wait.
   *
-  * @param queue The queue to retrieve.
+  * @param[out] queue The queue to retrieve.
   *
   * @returns Pointer to the event which has a trigger flag set, NULL if none has this flag set.
   */

--- a/src/ddsrt/include/dds/ddsrt/events/darwin.h
+++ b/src/ddsrt/include/dds/ddsrt/events/darwin.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+#ifndef DDSRT_EVENTS_DARWIN_H
+#define DDSRT_EVENTS_DARWIN_H
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+#if defined (__cplusplus)
+}
+#endif
+#endif /* DDSRT_EVENTS_DARWIN_H */

--- a/src/ddsrt/include/dds/ddsrt/events/posix.h
+++ b/src/ddsrt/include/dds/ddsrt/events/posix.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+#ifndef DDSRT_EVENTS_POSIX_H
+#define DDSRT_EVENTS_POSIX_H
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+#if defined (__cplusplus)
+}
+#endif
+#endif /* DDSRT_EVENTS_POSIX_H */

--- a/src/ddsrt/src/events.c
+++ b/src/ddsrt/src/events.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+#include "dds/ddsrt/events.h"
+#include "dds/ddsrt/heap.h"
+
+dds_return_t ddsrt_event_socket_init(ddsrt_event_t* ev, ddsrt_socket_t sock, uint32_t flags) {
+  assert(ev);
+  assert(sock);
+  ev->type = ddsrt_event_type_socket;
+  ev->flags = flags;
+  ev->data.socket.sock = sock;
+  ddsrt_atomic_st32(&ev->triggered, DDSRT_EVENT_FLAG_UNSET);
+  return DDS_RETCODE_OK;
+}

--- a/src/ddsrt/src/events/darwin/events_darwin.c
+++ b/src/ddsrt/src/events/darwin/events_darwin.c
@@ -63,7 +63,7 @@ static dds_return_t ddsrt_event_queue_init(ddsrt_event_queue_t* queue) {
   kevent kev;
   EV_SET(&kev, queue->interrupt[0], EVFILT_READ, EV_ADD, 0, 0, 0);
   assert(kevent(kq, &kev, 1, NULL, 0, NULL) != -1);
-#endif
+#endif /* !LWIP_SOCKET */
 
   /*create kevents array*/
   queue->kevents = ddsrt_malloc(sizeof(kevent) * queue->cevents);
@@ -96,7 +96,7 @@ static dds_return_t ddsrt_event_queue_fini(ddsrt_event_queue_t* queue) {
     EV_SET(&kev, interrupt[0], EVFILT_READ, EV_DELETE, 0, 0, 0);
   close(queue->interrupt[0]);
   close(queue->interrupt[1]);
-#endif
+#endif /* !LWIP_SOCKET */
   close(queue->kq);
 
   ddsrt_mutex_destroy(&queue->lock);
@@ -150,7 +150,7 @@ dds_return_t ddsrt_event_queue_wait(ddsrt_event_queue_t* queue, dds_duration_t r
 #if !defined(LWIP_SOCKET)
       char buf;
       read(queue->interrupt[0], &buf, 0);
-#endif
+#endif /* !LWIP_SOCKET */
     }
   }
   ddsrt_mutex_unlock(&queue->lock);
@@ -184,8 +184,8 @@ dds_return_t ddsrt_event_queue_signal(ddsrt_event_queue_t* queue) {
   char buf = 0;
   if (-1 == write(queue->interrupt[1], &buf, 1))
     return DDS_RETCODE_ERROR;
-#endif
-  return DDS_RETURN_OK;
+#endif /* !LWIP_SOCKET */
+  return DDS_RETCODE_OK;
 }
 
 dds_return_t ddsrt_event_queue_remove(ddsrt_event_queue_t* queue, ddsrt_event_t* evt) {

--- a/src/ddsrt/src/events/darwin/events_darwin.c
+++ b/src/ddsrt/src/events/darwin/events_darwin.c
@@ -1,0 +1,222 @@
+/*
+ * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "dds/ddsrt/events/darwin.h"
+#include "dds/ddsrt/events.h"
+#include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/sync.h"
+
+#define EVENTS_CONTAINER_DELTA 8
+
+struct ddsrt_event_queue {
+  ddsrt_event_t**         events;   /**< container for triggered events*/
+  size_t                  nevents;  /**< number of triggered events stored*/
+  size_t                  cevents;  /**< capacity of triggered events stored*/
+  size_t                  ievents;  /**< current iterator for getting the next triggered event*/
+  int                     kq;       /**< kevent polling instance*/
+  kevent*                 kevents;  /**< array which kevent uses to write back to, has identical size as this->events*/
+  ddsrt_mutex_t           lock;     /**< for add/delete */
+#if !defined(LWIP_SOCKET)
+  ddsrt_socket_t          interrupt[2]; /**< pipe for interrupting waits*/
+#endif
+};
+
+/**
+* @brief Initializes an event queue.
+*
+* Will set the counters to 0 and create the containers for triggers and additional necessary ones.
+*
+* @param[in] queue The queue to initialize.
+*
+* @returns DDS_RETCODE_OK if everything went OK.
+*/
+static dds_return_t ddsrt_event_queue_init(ddsrt_event_queue_t* queue) {
+  queue->nevents = 0;
+  queue->cevents = 8;
+  queue->ievents = 0;
+  ddsrt_mutex_init(&queue->lock);
+
+  /*create kevent polling instance */
+  queue->kq = kqueue();
+  assert(queue->kq != -1);
+  assert(fcntl(queue->kq, F_SETFD, fcntl(queue->kq, F_GETFD) | FD_CLOEXEC) != -1);
+
+  queue->events = ddsrt_malloc(sizeof(ddsrt_event_t*) * queue->cevents);
+  assert(queue->events);
+
+#if !defined(LWIP_SOCKET)
+  if (-1 == pipe(queue->interrupt))
+    return DDS_RETCODE_ERROR;
+  /*register interrupt event*/
+  kevent kev;
+  EV_SET(&kev, queue->interrupt[0], EVFILT_READ, EV_ADD, 0, 0, 0);
+  assert(kevent(kq, &kev, 1, NULL, 0, NULL) != -1);
+#endif
+
+  /*create kevents array*/
+  queue->kevents = ddsrt_malloc(sizeof(kevent) * queue->cevents);
+  assert(queue->kevents);
+
+  return DDS_RETCODE_OK;
+}
+
+/**
+* @brief Finishes an event queue.
+*
+* Will free created containers and do any additional cleanup of things created in ddsrt_event_queue_init.
+*
+* @param queue The queue to finish.
+*
+* @returns DDS_RETCODE_OK if everything went OK.
+*/
+static dds_return_t ddsrt_event_queue_fini(ddsrt_event_queue_t* queue) {
+  assert(queue);
+  /*deregister all currently stored triggers from kqueue*/
+  kevent kev;
+  for (unsigned int i = 0; i < queue->nevents; i++) {
+    ddsrt_event_t* evt = queue->events[i];
+    if (evt->flags & DDSRT_EVENT_FLAG_READ)
+      EV_SET(&kev, evt->data.socket, EVFILT_READ, EV_DELETE, 0, 0, evt);
+    assert(kevent(kq, &kev, 1, NULL, 0, NULL) != -1);
+  }
+#if !defined(LWIP_SOCKET)
+  if (evt->flags & DDSRT_EVENT_FLAG_READ)
+    EV_SET(&kev, interrupt[0], EVFILT_READ, EV_DELETE, 0, 0, 0);
+  close(queue->interrupt[0]);
+  close(queue->interrupt[1]);
+#endif
+  close(queue->kq);
+
+  ddsrt_mutex_destroy(&queue->lock);
+  ddsrt_free(queue->events);
+  ddsrt_free(queue->kevents);
+  return DDS_RETCODE_OK;
+}
+
+ddsrt_event_queue_t* ddsrt_event_queue_create(void) {
+  ddsrt_event_queue_t* returnptr = ddsrt_malloc(sizeof(ddsrt_event_queue_t));
+  assert(returnptr);
+  ddsrt_event_queue_init(returnptr);
+  return returnptr;
+}
+
+dds_return_t ddsrt_event_queue_destroy(ddsrt_event_queue_t* queue) {
+  assert(queue);
+  ddsrt_event_queue_fini(queue);
+  ddsrt_free(queue);
+  return DDS_RETCODE_OK;
+}
+
+size_t ddsrt_event_queue_nevents(ddsrt_event_queue_t* queue) {
+  size_t ret;
+  ddsrt_mutex_lock(&queue->lock);
+  ret = queue->nevents;
+  ddsrt_mutex_unlock(&queue->lock);
+  return ret;
+}
+
+dds_return_t ddsrt_event_queue_wait(ddsrt_event_queue_t* queue, dds_duration_t reltime) {
+  assert(queue);
+
+  /*reset triggered status*/
+  ddsrt_mutex_lock(&queue->lock);
+  queue->ievents = 0;
+  for (unsigned int i = 0; i < queue->nevents; queue++)
+    ddsrt_atomic_st32(&queue->events[i]->triggered, DDSRT_EVENT_FLAG_UNSET);
+  ddsrt_mutex_unlock(&queue->lock);
+
+  struct timespec tmout = { milliseconds / 1000,     /* waittime (seconds) */
+                           milliseconds * 1000000 }; /* waittime (nanoseconds) */
+  int nevs = kevent(queue->kq, NULL, 0, queue->kevents, queue->nevents, &tmout);
+  ddsrt_mutex_lock(&queue->lock);
+  for (int i = 0; i < nevs; i++) {
+    ddsrt_event_t* evt = queue->kevents[i].udata;
+    if (NULL != evt) {
+      ddsrt_atomic_st32(evt->triggered, DDSRT_EVENT_FLAG_READ);
+    }
+    else {
+#if !defined(LWIP_SOCKET)
+      char buf;
+      read(queue->interrupt[0], &buf, 0);
+#endif
+    }
+  }
+  ddsrt_mutex_unlock(&queue->lock);
+
+  return DDS_RETCODE_OK;
+}
+
+dds_return_t ddsrt_event_queue_add(ddsrt_event_queue_t* queue, ddsrt_event_t* evt) {
+  assert(queue);
+  assert(evt);
+
+  ddsrt_mutex_lock(&queue->lock);
+  if (queue->nevents == queue->cevents) {
+    queue->cevents += EVENTS_CONTAINER_DELTA;
+    ddsrt_realloc(queue->events, queue->events, sizeof(ddsrt_event_t*) * queue->cevents);
+    ddsrt_realloc(queue->kevents, queue->kevents, sizeof(kevent) * queue->cevents);
+  }
+  queue->events[queue->nevents++] = evt;
+  ddsrt_mutex_unlock(&queue->lock);
+
+  /*register to queue->kq*/
+  kevent kev;
+  EV_SET(&kev, evt->data.socket.sock, EVFILT_READ, EV_ADD, 0, 0, evt);
+  assert(kevent(kq, &kev, 1, NULL, 0, NULL) != -1);
+
+  return DDS_RETCODE_OK;
+}
+
+dds_return_t ddsrt_event_queue_signal(ddsrt_event_queue_t* queue) {
+#if !defined(LWIP_SOCKET)
+  char buf = 0;
+  if (-1 == write(queue->interrupt[1], &buf, 1))
+    return DDS_RETCODE_ERROR;
+#endif
+  return DDS_RETURN_OK;
+}
+
+dds_return_t ddsrt_event_queue_remove(ddsrt_event_queue_t* queue, ddsrt_event_t* evt) {
+  ddsrt_mutex_lock(&queue->lock);
+  for (unsigned int i = 0; i < queue->nevents; i++) {
+    if (queue->events[i] == evt) {
+      /*deregister from queue->kq*/
+      kevent kev;
+      EV_SET(&kev, evt->data.socket.sock, EVFILT_READ, EV_DELETE, 0, 0, evt);
+      assert(kevent(kq, &kev, 1, NULL, 0, NULL) != -1);
+
+      memmove(queue->events + i, queue->events + i + 1, (queue->nevents - i - 1) * sizeof(ddsrt_event_t*));
+      if (queue->ievents > i)
+        queue->ievents--;
+      queue->nevents--;
+      break;
+    }
+  }
+  ddsrt_mutex_unlock(&queue->lock);
+
+  return DDS_RETCODE_OK;
+}
+
+ddsrt_event_t* ddsrt_event_queue_next(ddsrt_event_queue_t* queue) {
+  ddsrt_event_t* ptr = NULL;
+  ddsrt_mutex_lock(&queue->lock);
+  while (queue->ievents < queue->nevents) {
+    ddsrt_event_t* evt = queue->events[queue->ievents++];
+    if (DDSRT_EVENT_FLAG_UNSET != evt->triggered)
+      ptr = evt;
+  }
+  ddsrt_mutex_unlock(&queue->lock);
+  return ptr;
+}

--- a/src/ddsrt/src/events/posix/events_posix.c
+++ b/src/ddsrt/src/events/posix/events_posix.c
@@ -1,0 +1,273 @@
+/*
+ * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "dds/ddsrt/events/posix.h"
+#include "dds/ddsrt/events.h"
+#include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/sync.h"
+
+#ifdef __VXWORKS__
+#include <pipeDrv.h>
+#include <ioLib.h>
+#include <string.h>
+#include <selectLib.h>
+#define OSPL_PIPENAMESIZE 26
+#endif
+
+#define EVENTS_CONTAINER_DELTA 8
+
+struct ddsrt_event_queue {
+  ddsrt_event_t**         events;  /**< container for administered events*/
+  size_t                  nevents;  /**< number of administered events stored*/
+  size_t                  cevents;  /**< capacity of administered events stored*/
+  size_t                  ievents;  /**< current iterator for getting the next triggered event*/
+  fd_set                  rfds;     /**< set of fds for reading data*/
+  ddsrt_mutex_t           lock;     /**< for add/delete */
+#if !defined(LWIP_SOCKET)
+  ddsrt_socket_t          interrupt[2]; /**< pipe for interrupting waits*/
+#endif
+};
+
+/**
+* @brief Initializes an event queue.
+*
+* Will set the counters to 0 and create the containers for triggers and additional necessary ones.
+*
+* @param[in] queue The queue to initialize.
+*
+* @returns DDS_RETCODE_OK if everything went OK.
+*/
+static dds_return_t ddsrt_event_queue_init(ddsrt_event_queue_t* queue) {
+  queue->nevents = 0;
+  queue->cevents = 8;
+  queue->ievents = 0;
+  queue->events = ddsrt_malloc(sizeof(ddsrt_event_t*) * queue->cevents);
+  assert(queue->events);
+  ddsrt_mutex_init(&queue->lock);
+#if (defined _WIN32 || defined(_WIN64))
+  /*windows type sockets*/
+  struct sockaddr_in addr;
+  socklen_t asize = sizeof(addr);
+  ddsrt_socket_t listener = socket(AF_INET, SOCK_STREAM, 0);
+  queue->interrupt[0] = socket(AF_INET, SOCK_STREAM, 0);
+  queue->interrupt[1] = DDSRT_INVALID_SOCKET;
+
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  addr.sin_port = 0;
+  if (bind(listener, (struct sockaddr*)&addr, sizeof(addr)) == -1 ||
+    getsockname(listener, (struct sockaddr*)&addr, &asize) == -1 ||
+    listen(listener, 1) == -1 ||
+    connect(queue->interrupt[0], (struct sockaddr*)&addr, sizeof(addr)) == -1 ||
+    (queue->interrupt[1] = accept(listener, 0, 0)) == -1) {
+    closesocket(queue->interrupt[0]);
+    closesocket(queue->interrupt[1]);
+    return DDS_RETCODE_ERROR;
+  }
+  SetHandleInformation((HANDLE)queue->interrupt[0], HANDLE_FLAG_INHERIT, 0);
+  SetHandleInformation((HANDLE)queue->interrupt[1], HANDLE_FLAG_INHERIT, 0);
+#elif defined(__VXWORKS__)  
+  /*vxworks type pipe*/
+  char pipename[OSPL_PIPENAMESIZE];
+  int pipecount = 0;
+  int pipe_result = 0;
+  do {
+    snprintf((char*)&pipename, sizeof(pipename), "/pipe/ospl%d", pipecount++);
+  } while ((pipe_result = pipeDevCreate((char*)&pipename, 1, 1)) == -1 &&
+    os_getErrno() == EINVAL);
+  if (pipe_result != -1)
+    return DDS_RETCODE_ERROR;
+  queue->interrupt[0] = open((char*)&pipename, O_RDWR, 0644);
+  queue->interrupt[1] = open((char*)&pipename, O_RDWR, 0644);
+  /*the pipe was succesfully created, but one of the sockets on either end was not*/
+  if (-1 == queue->interrupt[0] || -1 == p[1]) {
+    pipeDevDelete(pipename, 0);
+    if (-1 != queue->interrupt[0])
+      close(queue->interrupt[0]);
+    if (-1 != queue->interrupt[1])
+      close(queue->interrupt[1]);
+    return DDS_RETCODE_ERROR;
+  }
+#elif !defined(LWIP_SOCKET)
+  /*simple linux type pipe*/
+  if (pipe(queue->interrupt) == -1) return DDS_RETCODE_ERROR;
+#endif
+  return DDS_RETCODE_OK;
+}
+
+/**
+* @brief Finishes an event queue.
+*
+* Will free created containers and do any additional cleanup of things created in ddsrt_event_queue_init.
+*
+* @param queue The queue to finish.
+*
+* @returns DDS_RETCODE_OK if everything went OK.
+*/
+static dds_return_t ddsrt_event_queue_fini(ddsrt_event_queue_t* queue) {
+  assert(queue);
+  ddsrt_mutex_destroy(&queue->lock); 
+#if !defined(LWIP_SOCKET)
+#if defined(__VXWORKS__) && defined(__RTP__)
+  char nameBuf[OSPL_PIPENAMESIZE];
+  ioctl(queue->interrupt[0], FIOGETNAME, &nameBuf);
+#endif
+#if (defined _WIN32 || defined(_WIN64))
+  closesocket(queue->interrupt[0]);
+  closesocket(queue->interrupt[1]);
+#else
+  close(queue->interrupt[0]);
+  close(queue->interrupt[1]);
+#endif
+#if defined(__VXWORKS__) && defined(__RTP__)
+  pipeDevDelete((char*)&nameBuf, 0);
+#endif
+#endif
+  ddsrt_free(queue->events);
+  return DDS_RETCODE_OK;
+}
+
+ddsrt_event_queue_t* ddsrt_event_queue_create(void) {
+  ddsrt_event_queue_t* returnptr = ddsrt_malloc(sizeof(ddsrt_event_queue_t));
+  assert(returnptr);
+  ddsrt_event_queue_init(returnptr);
+  return returnptr;
+}
+
+dds_return_t ddsrt_event_queue_destroy(ddsrt_event_queue_t* queue) {
+  assert(queue);
+  ddsrt_event_queue_fini(queue);
+  ddsrt_free(queue);
+  return DDS_RETCODE_OK;
+}
+
+size_t ddsrt_event_queue_nevents(ddsrt_event_queue_t* queue) {
+  return queue->nevents;
+}
+
+dds_return_t ddsrt_event_queue_wait(ddsrt_event_queue_t* queue, dds_duration_t reltime) {
+  assert(queue);
+  
+  /*reset triggered status*/
+  ddsrt_mutex_lock(&queue->lock);
+  queue->ievents = 0;
+  for (size_t i = 0; i < queue->nevents; i++)
+    ddsrt_atomic_st32(&queue->events[i]->triggered, DDSRT_EVENT_FLAG_UNSET);
+
+  /*zero all fds*/
+  fd_set* rfds = &queue->rfds;
+  FD_ZERO(rfds);
+#if !defined(LWIP_SOCKET)
+  FD_SET(queue->interrupt[0],rfds);
+#endif
+
+  /*add events to queue->rfds*/
+  ddsrt_socket_t maxfd = 0;
+  for (size_t i = 0; i < queue->nevents; i++) {
+    ddsrt_event_t *evt = queue->events[i];
+    if (evt->type != ddsrt_event_type_socket)
+      continue;
+
+    ddsrt_socket_t s = evt->data.socket.sock;
+    if (evt->flags & DDSRT_EVENT_FLAG_READ) {
+      FD_SET(s, rfds);
+      if (s > maxfd)
+        maxfd = s;
+    }
+  }
+  ddsrt_mutex_unlock(&queue->lock);
+
+  /*start wait*/
+  int ready = -1;
+  dds_return_t retval = ddsrt_select(maxfd + 1, rfds, NULL, NULL, reltime, &ready);
+
+  if (DDS_RETCODE_OK == retval ||
+    DDS_RETCODE_TIMEOUT == retval) {
+
+    /*check queue->rfds for set items*/
+    ddsrt_mutex_lock(&queue->lock);
+    for (size_t i = 0; i < queue->nevents; i++) {
+      ddsrt_event_t *evt = queue->events[i];
+      if (evt->type != ddsrt_event_type_socket)
+        continue;
+
+      ddsrt_socket_t s = evt->data.socket.sock;
+      if (FD_ISSET(s, rfds))
+        ddsrt_atomic_st32(&evt->triggered, DDSRT_EVENT_FLAG_READ);
+    }
+    ddsrt_mutex_unlock(&queue->lock);
+  }
+  else {
+    /*something else happened*/
+    return DDS_RETCODE_ERROR;
+  }
+
+  return DDS_RETCODE_OK;
+}
+
+dds_return_t ddsrt_event_queue_signal(ddsrt_event_queue_t* queue) {
+#if !defined(LWIP_SOCKET)
+  char buf = 0;
+#if (defined _WIN32 || defined(_WIN64))
+  send(queue->interrupt[1], &buf, 1, 0);
+#else
+  write(queue->interrupt[1], &buf, 1);
+#endif
+#endif
+  return DDS_RETCODE_OK;
+}
+
+dds_return_t ddsrt_event_queue_add(ddsrt_event_queue_t* queue, ddsrt_event_t* evt) {
+  assert(queue);
+  assert(evt);
+
+  ddsrt_mutex_lock(&queue->lock);
+  if (queue->nevents == queue->cevents) {
+    queue->cevents += EVENTS_CONTAINER_DELTA;
+    ddsrt_realloc(queue->events, sizeof(ddsrt_event_t*) * queue->cevents);
+  }
+  
+  queue->events[queue->nevents++] = evt;
+  ddsrt_mutex_unlock(&queue->lock);
+  
+  return DDS_RETCODE_OK;
+}
+
+dds_return_t ddsrt_event_queue_remove(ddsrt_event_queue_t* queue, ddsrt_event_t* evt) {
+  ddsrt_mutex_lock(&queue->lock);
+  for (size_t i = 0; i < queue->nevents; i++) {
+    if (queue->events[i] == evt) {
+      memmove(queue->events + i, queue->events + i + 1, (queue->nevents - i - 1)*sizeof(ddsrt_event_t*));
+      if (queue->ievents > i)
+          queue->ievents--;
+      queue->nevents--;
+      break;
+    }
+  }
+  ddsrt_mutex_unlock(&queue->lock);
+  return DDS_RETCODE_OK;
+}
+
+ddsrt_event_t* ddsrt_event_queue_next(ddsrt_event_queue_t* queue) {
+  ddsrt_event_t* ptr = NULL;
+  ddsrt_mutex_lock(&queue->lock);
+  while (queue->ievents < queue->nevents) {
+    ddsrt_event_t* evt = queue->events[queue->ievents++];
+    if (DDSRT_EVENT_FLAG_UNSET != ddsrt_atomic_ld32(&evt->triggered))
+      ptr = evt;
+  }
+  ddsrt_mutex_unlock(&queue->lock);
+  return ptr;
+}

--- a/src/ddsrt/src/events/posix/events_posix.c
+++ b/src/ddsrt/src/events/posix/events_posix.c
@@ -28,6 +28,13 @@
 
 #define EVENTS_CONTAINER_DELTA 8
 
+/**
+* @brief Posix implementation of ddsrt_event_queue.
+*
+* This implementation uses the ddsrt_select function to set the rfds set of file descriptors 
+* for sockets which have data available for reading. If this not implemented under the light-
+* weight IP stack, then interuption of a wait using a trigger on a self socket.
+*/
 struct ddsrt_event_queue {
   ddsrt_event_t**         events;  /**< container for administered events*/
   size_t                  nevents;  /**< number of administered events stored*/
@@ -45,7 +52,7 @@ struct ddsrt_event_queue {
 *
 * Will set the counters to 0 and create the containers for triggers and additional necessary ones.
 *
-* @param[in] queue The queue to initialize.
+* @param[out] queue The queue to initialize.
 *
 * @returns DDS_RETCODE_OK if everything went OK.
 */
@@ -112,7 +119,7 @@ static dds_return_t ddsrt_event_queue_init(ddsrt_event_queue_t* queue) {
 *
 * Will free created containers and do any additional cleanup of things created in ddsrt_event_queue_init.
 *
-* @param queue The queue to finish.
+* @param[out] queue The queue to finish.
 *
 * @returns DDS_RETCODE_OK if everything went OK.
 */

--- a/src/ddsrt/tests/CMakeLists.txt
+++ b/src/ddsrt/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ include(GenerateDummyExportHeader)
 list(APPEND sources
   "atomics.c"
   "environ.c"
+  "events.c"
   "heap.c"
   "ifaddrs.c"
   "sync.c"

--- a/src/ddsrt/tests/events.c
+++ b/src/ddsrt/tests/events.c
@@ -1,0 +1,311 @@
+/*
+ * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+#include <stdio.h>
+#include "CUnit/Test.h"
+#include "dds/ddsrt/cdtors.h"
+#include "dds/ddsrt/events.h"
+#include "dds/ddsrt/threads.h"
+
+#ifdef __VXWORKS__
+#include <pipeDrv.h>
+#include <ioLib.h>
+#include <string.h>
+#include <selectLib.h>
+#define OSPL_PIPENAMESIZE 26
+#endif
+
+CU_Init(ddsrt_event) {
+  ddsrt_init();
+  return 0;
+}
+
+CU_Clean(ddsrt_event) {
+  ddsrt_fini();
+  return 0;
+}
+
+
+#if defined(_WIN32) || defined(_WIN64)
+void ddsrt_sleep(int microsecs) {
+  Sleep(microsecs / 1000);
+}
+#else
+static void ddsrt_sleep(int microsecs) {
+  usleep((unsigned)microsecs);
+}
+#endif
+
+static dds_return_t ddsrt_pipe_create(ddsrt_socket_t p[2]) {
+#if (defined _WIN32 || defined(_WIN64))
+  /*windows type sockets*/
+  struct sockaddr_in addr;
+  socklen_t asize = sizeof(addr);
+  ddsrt_socket_t listener = socket(AF_INET, SOCK_STREAM, 0);
+  p[0] = socket(AF_INET, SOCK_STREAM, 0);
+  p[1] = DDSRT_INVALID_SOCKET;
+
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  addr.sin_port = 0;
+  if (bind(listener, (struct sockaddr*)&addr, sizeof(addr)) == -1 ||
+    getsockname(listener, (struct sockaddr*)&addr, &asize) == -1 ||
+    listen(listener, 1) == -1 ||
+    connect(p[0], (struct sockaddr*)&addr, sizeof(addr)) == -1 ||
+    (p[1] = accept(listener, 0, 0)) == -1) {
+    closesocket(p[0]);
+    closesocket(p[1]);
+    return DDS_RETCODE_ERROR;
+  }
+  SetHandleInformation((HANDLE)p[0], HANDLE_FLAG_INHERIT, 0);
+  SetHandleInformation((HANDLE)p[1], HANDLE_FLAG_INHERIT, 0);
+#elif defined(__VXWORKS__)  
+  /*vxworks type pipe*/
+  char pipename[OSPL_PIPENAMESIZE];
+  int pipecount = 0;
+  int pipe_result = 0;
+  do {
+    snprintf((char*)&pipename, sizeof(pipename), "/pipe/ospl%d", pipecount++);
+  } while ((pipe_result = pipeDevCreate((char*)&pipename, 1, 1)) == -1 &&
+    os_getErrno() == EINVAL);
+  if (pipe_result != -1)
+    return DDS_RETCODE_ERROR;
+  p[0] = open((char*)&pipename, O_RDWR, 0644);
+  p[1] = open((char*)&pipename, O_RDWR, 0644);
+  /*the pipe was succesfully created, but one of the sockets on either end was not*/
+  if (-1 == p[0] || -1 == p[1]) {
+    pipeDevDelete(pipename, 0);
+    if (-1 != p[0])
+      close(p[0]);
+    if (-1 != p[1])
+      close(p[1]);
+    return DDS_RETCODE_ERROR;
+  }
+#elif !defined(LWIP_SOCKET)
+  /*simple linux type pipe*/
+  if (pipe(p) == -1) return DDS_RETCODE_ERROR;
+#endif
+  return DDS_RETCODE_OK;
+}
+
+static dds_return_t ddsrt_pipe_destroy(ddsrt_socket_t p[2]) {
+#if !defined(LWIP_SOCKET)
+#if defined(__VXWORKS__) && defined(__RTP__)
+  char nameBuf[OSPL_PIPENAMESIZE];
+  ioctl(p[0], FIOGETNAME, &nameBuf);
+#endif
+#if (defined _WIN32 || defined(_WIN64))
+  closesocket(p[0]);
+  closesocket(p[1]);
+#else
+  close(p[0]);
+  close(p[1]);
+#endif
+#if defined(__VXWORKS__) && defined(__RTP__)
+  pipeDevDelete((char*)&nameBuf, 0);
+#endif
+#endif
+  return DDS_RETCODE_OK;
+}
+
+static dds_return_t ddsrt_pipe_push(ddsrt_socket_t p[2]) {
+  char buf;
+#if defined(LWIP_SOCKET)
+  return DDS_RETCODE_OK
+#elif (defined _WIN32 || defined(_WIN64))
+  send(p[1], &buf, 1, 0);
+#else
+  write(p[1], &buf, 1);
+#endif
+  return DDS_RETCODE_OK;
+}
+
+static dds_return_t ddsrt_pipe_pull(ddsrt_socket_t p[2]) {
+  char buf;
+#if defined(LWIP_SOCKET)
+  return DDS_RETCODE_OK
+#elif (defined _WIN32 || defined(_WIN64))
+  recv(p[0], &buf, 1, 0);
+#else
+  read(p[0], &buf, 1);
+#endif
+  return DDS_RETCODE_OK;
+}
+
+
+
+CU_Test(ddsrt_event, event_create) {
+  ddsrt_socket_t sock = 123;
+  uint32_t flags = DDSRT_EVENT_FLAG_READ;
+  ddsrt_event_t evt;
+  CU_ASSERT_EQUAL(ddsrt_event_socket_init(&evt,sock,flags), DDS_RETCODE_OK);
+  CU_ASSERT_EQUAL(evt.flags, DDSRT_EVENT_FLAG_READ);
+  CU_ASSERT_EQUAL(ddsrt_atomic_ld32(&evt.triggered), DDSRT_EVENT_FLAG_UNSET);
+  CU_ASSERT_EQUAL(evt.type, ddsrt_event_type_socket);
+  CU_ASSERT_EQUAL(evt.data.socket.sock, sock);
+
+  CU_PASS("event_create");
+}
+
+CU_Test(ddsrt_event, queue_create) {
+  ddsrt_event_queue_t* q = ddsrt_event_queue_create();
+  
+  CU_ASSERT_PTR_NOT_EQUAL(q, NULL);
+  CU_ASSERT_EQUAL(0,ddsrt_event_queue_nevents(q));
+  CU_ASSERT_EQUAL(DDS_RETCODE_OK, ddsrt_event_queue_destroy(q));
+
+  CU_PASS("queue_create");
+}
+
+CU_Test(ddsrt_event, queue_add_event) {
+  ddsrt_event_queue_t* q = ddsrt_event_queue_create();
+
+  ddsrt_socket_t sock = 123;
+  uint32_t flags = DDSRT_EVENT_FLAG_READ;
+
+  ddsrt_event_t evt;
+  ddsrt_event_socket_init(&evt,sock,flags);
+  ddsrt_event_queue_add(q, &evt);
+  CU_ASSERT_EQUAL(1, ddsrt_event_queue_nevents(q));
+  ddsrt_event_queue_add(q, &evt);
+  CU_ASSERT_EQUAL(2, ddsrt_event_queue_nevents(q));
+  ddsrt_event_queue_add(q, &evt);
+  CU_ASSERT_EQUAL(3, ddsrt_event_queue_nevents(q));
+
+  ddsrt_event_queue_destroy(q);
+  CU_PASS("queue_add_event");
+}
+
+static uint32_t wait_func(void* arg) {
+  printf("starting wait for event\n");
+  ddsrt_event_queue_wait((ddsrt_event_queue_t*)arg, (dds_duration_t)5e8);
+  printf("done with wait for event\n");
+  return 0;
+}
+
+static uint32_t write_func(void* arg) {
+  ddsrt_socket_t* p = (ddsrt_socket_t*)arg;
+  printf("starting wait for send to %d\n", (int)p[1]);
+  ddsrt_sleep(250000);
+  printf("sending to %d\n", (int)p[1]);
+  ddsrt_pipe_push(p);
+  printf("done with send\n");
+  return 0;
+}
+
+static uint32_t interrupt_func(void* arg) {
+  printf("starting wait for interrupt\n");
+  ddsrt_sleep(125000);
+  printf("interrupting\n");
+  ddsrt_event_queue_signal((ddsrt_event_queue_t*)arg);
+  printf("done with interrupt\n");
+  return 0;
+}
+
+CU_Test(ddsrt_event, queue_wait) {
+  ddsrt_event_queue_t* q = ddsrt_event_queue_create();
+
+  /*create socket*/
+  ddsrt_socket_t p[2];
+  CU_ASSERT_EQUAL_FATAL(DDS_RETCODE_OK, ddsrt_pipe_create(p));
+
+  /*create event for socket*/
+  ddsrt_event_t evt;
+  ddsrt_event_socket_init(&evt, p[0], DDSRT_EVENT_FLAG_READ);
+  ddsrt_event_queue_add(q, &evt);
+
+  ddsrt_thread_t thr1, thr2;
+  uint32_t res1 = 0, res2 = 0;
+
+  ddsrt_threadattr_t attr;
+  ddsrt_threadattr_init(&attr);
+  attr.schedClass = DDSRT_SCHED_DEFAULT;
+  attr.schedPriority = 0;
+
+  dds_return_t ret1 = ddsrt_thread_create(&thr1, "reader", &attr, &wait_func, q);
+  dds_return_t ret2 = ddsrt_thread_create(&thr2, "writer", &attr, &write_func, p);
+
+  if (ret1 == DDS_RETCODE_OK) {
+    ret1 = ddsrt_thread_join(thr1, &res1);
+    CU_ASSERT_EQUAL(ret1, DDS_RETCODE_OK);
+  }
+
+  if (ret2 == DDS_RETCODE_OK) {
+    ret2 = ddsrt_thread_join(thr2, &res2);
+    CU_ASSERT_EQUAL(ret2, DDS_RETCODE_OK);
+  }
+
+  /*check for triggered event on socket*/
+  ddsrt_event_t* evtout = ddsrt_event_queue_next(q);
+  CU_ASSERT_PTR_NOT_EQUAL_FATAL(evtout, NULL);
+  CU_ASSERT_EQUAL(evtout->type, ddsrt_event_type_socket);
+  CU_ASSERT_EQUAL(ddsrt_atomic_ld32(&evtout->triggered), DDSRT_EVENT_FLAG_READ);
+  CU_ASSERT_EQUAL(evtout->data.socket.sock, p[0]);
+
+  /*read data from the pipe*/
+  CU_ASSERT_EQUAL_FATAL(DDS_RETCODE_OK, ddsrt_pipe_pull(p));
+
+  ddsrt_pipe_destroy(p);
+  ddsrt_event_queue_destroy(q);
+  CU_PASS("queue_wait");
+}
+
+CU_Test(ddsrt_event, queue_signal) {
+  ddsrt_event_queue_t* q = ddsrt_event_queue_create();
+
+  /*create socket*/
+  ddsrt_socket_t p[2];
+  CU_ASSERT_EQUAL_FATAL(DDS_RETCODE_OK, ddsrt_pipe_create(p));
+
+  /*create event for socket*/
+  ddsrt_event_t evt;
+  ddsrt_event_socket_init(&evt, p[0], DDSRT_EVENT_FLAG_READ);
+  ddsrt_event_queue_add(q, &evt);
+
+  ddsrt_thread_t thr1, thr2, thr3;
+  uint32_t res1 = 0, res2 = 0, res3 = 0;
+
+  ddsrt_threadattr_t attr;
+  ddsrt_threadattr_init(&attr);
+  attr.schedClass = DDSRT_SCHED_DEFAULT;
+  attr.schedPriority = 0;
+
+  dds_return_t ret1 = ddsrt_thread_create(&thr1, "reader", &attr, &wait_func, q);
+  dds_return_t ret2 = ddsrt_thread_create(&thr2, "writer", &attr, &write_func, p);
+  dds_return_t ret3 = ddsrt_thread_create(&thr3, "interrupter", &attr, &interrupt_func, q);
+
+  if (ret1 == DDS_RETCODE_OK) {
+    ret1 = ddsrt_thread_join(thr1, &res1);
+    CU_ASSERT_EQUAL(ret1, DDS_RETCODE_OK);
+  }
+
+  if (ret2 == DDS_RETCODE_OK) {
+    ret2 = ddsrt_thread_join(thr2, &res2);
+    CU_ASSERT_EQUAL(ret2, DDS_RETCODE_OK);
+  }
+
+  if (ret3 == DDS_RETCODE_OK) {
+    ret3 = ddsrt_thread_join(thr3, &res3);
+    CU_ASSERT_EQUAL(ret3, DDS_RETCODE_OK);
+  }
+
+  /*check for triggered event on socket*/
+  ddsrt_event_t* evtout = ddsrt_event_queue_next(q);
+  CU_ASSERT_PTR_EQUAL_FATAL(evtout, NULL);
+
+  /*read data from the pipe*/
+  CU_ASSERT_EQUAL_FATAL(DDS_RETCODE_OK, ddsrt_pipe_pull(p));
+
+  ddsrt_pipe_destroy(p);
+  ddsrt_event_queue_destroy(q);
+  CU_PASS("queue_wait");
+}

--- a/src/ddsrt/tests/events.c
+++ b/src/ddsrt/tests/events.c
@@ -35,7 +35,7 @@ CU_Clean(ddsrt_event) {
 }
 
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 void ddsrt_sleep(int microsecs) {
   Sleep(microsecs / 1000);
 }
@@ -46,7 +46,7 @@ static void ddsrt_sleep(int microsecs) {
 #endif
 
 static dds_return_t ddsrt_pipe_create(ddsrt_socket_t p[2]) {
-#if (defined _WIN32 || defined(_WIN64))
+#if defined(_WIN32)
   /*windows type sockets*/
   struct sockaddr_in addr;
   socklen_t asize = sizeof(addr);
@@ -118,7 +118,7 @@ static dds_return_t ddsrt_pipe_destroy(ddsrt_socket_t p[2]) {
 }
 
 static dds_return_t ddsrt_pipe_push(ddsrt_socket_t p[2]) {
-  char buf;
+  char buf = 0x0;
 #if defined(LWIP_SOCKET)
   return DDS_RETCODE_OK
 #elif (defined _WIN32 || defined(_WIN64))


### PR DESCRIPTION
The current os_sockWaitSet does not support notifying IP address changes.
In order to support this functionality a new struct ddsrt_event_queue is created which will be expanded to support this functionality.
The implementation of the ddsrt_event_queue has mirrored that of the os_sockWaitSet as much as possible in order to make replacing one with the other as effortless as possible.
This draft is created to elicit comments and suggestions regarding the interface in general and the implementation in specific.

* Created new ddsrt_event_queue struct which supports notifying users of data being received on sockets through ddsrt_event structs.
* Implementation for POSIX select type and Darwin kevent type notification.
* Added unittests for checking the newly created functionality.

Signed-off-by:  Martijn Reicher <martijn.reicher@adlinktech.com>