### PR TITLE
Fix ddsperf RSS check and tweak sanity check script

### DIFF
--- a/src/tools/ddsperf/ddsperf.c
+++ b/src/tools/ddsperf/ddsperf.c
@@ -165,7 +165,7 @@ static uint32_t ping_timeouts = 0;
    final RSS sample: final one must be <=
    init * (1 + rss_factor/100) + rss_term  */
 static bool rss_check = false;
-static double rss_factor = 0;
+static double rss_factor = 1;
 static double rss_term = 0;
 
 /* Minimum number of samples, minimum number of roundtrips to
@@ -1612,7 +1612,7 @@ OPTIONS:\n\
                       bandwidth BW in bits/s (e.g., eth0:1e9)\n\
   -D DUR              run for at most DUR seconds\n\
   -Q KEY:VAL          set success criteria\n\
-                        rss:X%%       max allowed increase in RSS, in %%\n\
+                        rss:X%%        max allowed increase in RSS, in %%\n\
                         rss:X         max allowed increase in RSS, in MB\n\
                         samples:N     min received messages by \"sub\"\n\
                         roundtrips:N  min roundtrips for \"pong\"\n\

--- a/src/tools/ddsperf/sanity.bash
+++ b/src/tools/ddsperf/sanity.bash
@@ -1,8 +1,8 @@
 exitcode=0
 # RSS/samples/roundtrip numbers are based on experimentation on Travis
-bin/ddsperf -L -D10 -n10 -Qminmatch:2 -Qrss:20% -Qrss:1 -Qsamples:300000 -Qroundtrips:3000 sub ping & ddsperf_pids=$!
-bin/ddsperf -L -D10 -n10 -Qminmatch:2 -Qrss:20% -Qrss:1 pub 100Hz burst 1000 & ddsperf_pids="$ddsperf_pids $!"
-sleep 11
+bin/ddsperf -L -D20 -n10 -Qminmatch:2 -Qrss:4 -Qsamples:300000 -Qroundtrips:3000 sub ping & ddsperf_pids=$!
+bin/ddsperf -L -D20 -n10 -Qminmatch:2 -Qrss:4 pub 100Hz burst 1000 & ddsperf_pids="$ddsperf_pids $!"
+sleep 21
 for pid in $ddsperf_pids ; do
     if kill -0 $pid 2>/dev/null ; then
         echo "killing process $pid"


### PR DESCRIPTION
* The default value was zero, which means only specifying -Qrss:N would require the memory usage at the end to be <= N MB, rather than the delta.
* There is the occasional failure on Travis CI since 66daba9, which appears to be caused by a legitimate increase in memory usage that is not quite covered by the raised limits in that same commit.  This raises the limit further, but also lengthens the test to 20s to increase the likelihood of catching non-legitimate memory growth.
