### PR TITLE
Fix for locater test and Coverity issues

### DIFF
--- a/src/core/ddsi/tests/locators.c
+++ b/src/core/ddsi/tests/locators.c
@@ -77,7 +77,7 @@ CU_Test (ddsi_locator_from_string, bogusproto)
   CU_ASSERT_FATAL (res == AFSR_UNKNOWN);
   res = ddsi_locator_from_string (&gv, &loc, "bogusproto/xyz:1234", fact);
   CU_ASSERT_FATAL (res == AFSR_UNKNOWN);
-  res = ddsi_locator_from_string (&gv, &loc, "bogusproto/1.2.3.4:1234", fact);
+  res = ddsi_locator_from_string (&gv, &loc, "bogusproto/192.0.2.0:1234", fact);
   CU_ASSERT_FATAL (res == AFSR_UNKNOWN);
   fini (&gv);
 }
@@ -110,10 +110,10 @@ CU_Theory ((enum transport_selector tr), ddsi_locator_from_string, ipv4_invalid)
   snprintf (astr, sizeof (astr), "%s/:1234", fact->m_typename);
   res = ddsi_locator_from_string (&gv, &loc, astr, fact);
   CU_ASSERT_FATAL (res == AFSR_INVALID || res == AFSR_UNKNOWN);
-  snprintf (astr, sizeof (astr), "%s/[1.2.3.4]", fact->m_typename);
+  snprintf (astr, sizeof (astr), "%s/[192.0.2.0]", fact->m_typename);
   res = ddsi_locator_from_string (&gv, &loc, astr, fact);
   CU_ASSERT_FATAL (res == AFSR_INVALID || res == AFSR_UNKNOWN);
-  snprintf (astr, sizeof (astr), "%s/[1.2.3.4]:1234", fact->m_typename);
+  snprintf (astr, sizeof (astr), "%s/[192.0.2.0]:1234", fact->m_typename);
   res = ddsi_locator_from_string (&gv, &loc, astr, fact);
   CU_ASSERT_FATAL (res == AFSR_INVALID || res == AFSR_UNKNOWN);
   fini (&gv);
@@ -166,28 +166,28 @@ CU_Theory ((enum transport_selector tr), ddsi_locator_from_string, ipv4)
   }
 #endif
 
-  res = ddsi_locator_from_string (&gv, &loc, "1.2.3.4", fact);
+  res = ddsi_locator_from_string (&gv, &loc, "192.0.2.0", fact);
   CU_ASSERT_FATAL (res == AFSR_OK);
   CU_ASSERT_FATAL (loc.kind == fact->m_kind);
   CU_ASSERT_FATAL (loc.port == NN_LOCATOR_PORT_INVALID);
   CU_ASSERT_FATAL (loc.tran == fact);
-  CU_ASSERT_FATAL (check_ipv4_address (&loc, (uint8_t[]){1,2,3,4}));
+  CU_ASSERT_FATAL (check_ipv4_address (&loc, (uint8_t[]){192,0,2,0}));
 
-  snprintf (astr, sizeof (astr), "%s/1.2.3.4", fact->m_typename);
+  snprintf (astr, sizeof (astr), "%s/192.0.2.0", fact->m_typename);
   res = ddsi_locator_from_string (&gv, &loc, astr, fact);
   CU_ASSERT_FATAL (res == AFSR_OK);
   CU_ASSERT_FATAL (loc.kind == fact->m_kind);
   CU_ASSERT_FATAL (loc.port == NN_LOCATOR_PORT_INVALID);
   CU_ASSERT_FATAL (loc.tran == fact);
-  CU_ASSERT_FATAL (check_ipv4_address (&loc, (uint8_t[]){1,2,3,4}));
+  CU_ASSERT_FATAL (check_ipv4_address (&loc, (uint8_t[]){192,0,2,0}));
 
-  snprintf (astr, sizeof (astr), "%s/1.2.3.4:1234", fact->m_typename);
+  snprintf (astr, sizeof (astr), "%s/192.0.2.0:1234", fact->m_typename);
   res = ddsi_locator_from_string (&gv, &loc, astr, fact);
   CU_ASSERT_FATAL (res == AFSR_OK);
   CU_ASSERT_FATAL (loc.kind == fact->m_kind);
   CU_ASSERT_FATAL (loc.port == 1234);
   CU_ASSERT_FATAL (loc.tran == fact);
-  CU_ASSERT_FATAL (check_ipv4_address (&loc, (uint8_t[]){1,2,3,4}));
+  CU_ASSERT_FATAL (check_ipv4_address (&loc, (uint8_t[]){192,0,2,0}));
   fini (&gv);
 }
 
@@ -197,12 +197,12 @@ CU_Test (ddsi_locator_from_string, ipv4_cross1)
   struct ddsi_tran_factory * const fact = init (&gv, TRANS_UDP);
   nn_locator_t loc;
   enum ddsi_locator_from_string_result res;
-  res = ddsi_locator_from_string (&gv, &loc, "tcp/1.2.3.4:1234", fact);
+  res = ddsi_locator_from_string (&gv, &loc, "tcp/192.0.2.0:1234", fact);
   CU_ASSERT_FATAL (res == AFSR_OK);
   CU_ASSERT_FATAL (loc.kind == NN_LOCATOR_KIND_TCPv4);
   CU_ASSERT_FATAL (loc.port == 1234);
   CU_ASSERT_FATAL (loc.tran != fact);
-  CU_ASSERT_FATAL (check_ipv4_address (&loc, (uint8_t[]){1,2,3,4}));
+  CU_ASSERT_FATAL (check_ipv4_address (&loc, (uint8_t[]){192,0,2,0}));
   fini (&gv);
 }
 
@@ -212,12 +212,12 @@ CU_Test (ddsi_locator_from_string, ipv4_cross2)
   struct ddsi_tran_factory * const fact = init (&gv, TRANS_TCP);
   nn_locator_t loc;
   enum ddsi_locator_from_string_result res;
-  res = ddsi_locator_from_string (&gv, &loc, "udp/1.2.3.4:1234", fact);
+  res = ddsi_locator_from_string (&gv, &loc, "udp/192.0.2.0:1234", fact);
   CU_ASSERT_FATAL (res == AFSR_OK);
   CU_ASSERT_FATAL (loc.kind == NN_LOCATOR_KIND_UDPv4);
   CU_ASSERT_FATAL (loc.port == 1234);
   CU_ASSERT_FATAL (loc.tran != fact);
-  CU_ASSERT_FATAL (check_ipv4_address (&loc, (uint8_t[]){1,2,3,4}));
+  CU_ASSERT_FATAL (check_ipv4_address (&loc, (uint8_t[]){192,0,2,0}));
   fini (&gv);
 }
 
@@ -361,37 +361,37 @@ CU_Theory ((enum transport_selector tr), ddsi_locator_from_string, ipv6)
   }
 #endif
 
-  res = ddsi_locator_from_string (&gv, &loc, "1.2.3.4", fact);
+  res = ddsi_locator_from_string (&gv, &loc, "192.0.2.0", fact);
   CU_ASSERT_FATAL (res == AFSR_OK || res == AFSR_UNKNOWN);
   if (res == AFSR_OK)
   {
     CU_ASSERT_FATAL (loc.kind == fact->m_kind);
     CU_ASSERT_FATAL (loc.port == NN_LOCATOR_PORT_INVALID);
     CU_ASSERT_FATAL (loc.tran == fact);
-    CU_ASSERT_FATAL (check_ipv64_address (&loc, (uint8_t[]){1,2,3,4}));
+    CU_ASSERT_FATAL (check_ipv64_address (&loc, (uint8_t[]){192,0,2,0}));
   }
 
-  res = ddsi_locator_from_string (&gv, &loc, "[1.2.3.4]", fact);
+  res = ddsi_locator_from_string (&gv, &loc, "[192.0.2.0]", fact);
   CU_ASSERT_FATAL (res == AFSR_OK || res == AFSR_UNKNOWN);
   if (res == AFSR_OK)
   {
     CU_ASSERT_FATAL (loc.kind == fact->m_kind);
     CU_ASSERT_FATAL (loc.port == NN_LOCATOR_PORT_INVALID);
     CU_ASSERT_FATAL (loc.tran == fact);
-    CU_ASSERT_FATAL (check_ipv64_address (&loc, (uint8_t[]){1,2,3,4}));
+    CU_ASSERT_FATAL (check_ipv64_address (&loc, (uint8_t[]){192,0,2,0}));
   }
 
-  snprintf (astr, sizeof (astr), "%s/1.2.3.4", fact->m_typename);
+  snprintf (astr, sizeof (astr), "%s/192.0.2.0", fact->m_typename);
   res = ddsi_locator_from_string (&gv, &loc, astr, fact);
   CU_ASSERT_FATAL (res == AFSR_OK || res == AFSR_UNKNOWN);  if (res == AFSR_OK)
   {
     CU_ASSERT_FATAL (loc.kind == fact->m_kind);
     CU_ASSERT_FATAL (loc.port == NN_LOCATOR_PORT_INVALID);
     CU_ASSERT_FATAL (loc.tran == fact);
-    CU_ASSERT_FATAL (check_ipv64_address (&loc, (uint8_t[]){1,2,3,4}));
+    CU_ASSERT_FATAL (check_ipv64_address (&loc, (uint8_t[]){192,0,2,0}));
   }
 
-  snprintf (astr, sizeof (astr), "%s/1.2.3.4:6789", fact->m_typename);
+  snprintf (astr, sizeof (astr), "%s/192.0.2.0:6789", fact->m_typename);
   res = ddsi_locator_from_string (&gv, &loc, astr, fact);
   CU_ASSERT_FATAL (res == AFSR_OK || res == AFSR_UNKNOWN);
   if (res == AFSR_OK)
@@ -399,10 +399,10 @@ CU_Theory ((enum transport_selector tr), ddsi_locator_from_string, ipv6)
     CU_ASSERT_FATAL (loc.kind == fact->m_kind);
     CU_ASSERT_FATAL (loc.port == 6789);
     CU_ASSERT_FATAL (loc.tran == fact);
-    CU_ASSERT_FATAL (check_ipv64_address (&loc, (uint8_t[]){1,2,3,4}));
+    CU_ASSERT_FATAL (check_ipv64_address (&loc, (uint8_t[]){192,0,2,0}));
   }
 
-  snprintf (astr, sizeof (astr), "%s/[1.2.3.4]:7890", fact->m_typename);
+  snprintf (astr, sizeof (astr), "%s/[192.0.2.0]:7890", fact->m_typename);
   res = ddsi_locator_from_string (&gv, &loc, astr, fact);
   if (res == AFSR_OK)
   {
@@ -410,7 +410,7 @@ CU_Theory ((enum transport_selector tr), ddsi_locator_from_string, ipv6)
     CU_ASSERT_FATAL (loc.kind == fact->m_kind);
     CU_ASSERT_FATAL (loc.port == 7890);
     CU_ASSERT_FATAL (loc.tran == fact);
-    CU_ASSERT_FATAL (check_ipv64_address (&loc, (uint8_t[]){1,2,3,4}));
+    CU_ASSERT_FATAL (check_ipv64_address (&loc, (uint8_t[]){192,0,2,0}));
   }
 
   snprintf (astr, sizeof (astr), "%s/[::1]:8901", fact->m_typename);

--- a/src/ddsrt/include/dds/ddsrt/dynlib.h
+++ b/src/ddsrt/include/dds/ddsrt/dynlib.h
@@ -121,23 +121,24 @@ ddsrt_dlsym(
 /**
  * @brief Get the most recent library related error.
  *
- * The function ddsrt_dlerror() will return the most recent error of the operating system
- * in human readable form.
+ * The function ddsrt_dlerror() will return the most recent error of a
+ * call to ddsrt_dlopen, ddsrt_dlclose, ddsrt_dlsym in human readable form.
  *
  * If no error was found, it's either due to the fact that there
  * actually was no error since init or last ddsrt_dlerror() call,
  * or due to an unknown unrelated error.
  *
- * As error reporting function can be used for different purposes, dssrt_dlerror
- * function should be called immediately after calling ddsrt_dlopen or ddsrt_dlsym
- * function.
+ * @param[out]  buf      Buffer to store the error message
+ * @param[in]   buflen   The length of the provided buffer (must be > 0).
  *
- * @returns A dds_return_t indicating success or failure.
+ * @returns A dds_return_t indicating success (>0) or failure.
  *
- * @retval DDS_RETCODE_OK
- *             Most recent library related error returned.
- * @retval DDS_RETCODE_NOT_FOUND
- *             No library related error found.
+ * @retval >0
+ *             The length of the returned error message
+ * @retval 0
+ *             No dynamic library loading related error present
+ * @retval DDS_RETCODE_NOT_ENOUGH_SPACE
+ *             Buffer is not large enough to hold the error message
  */
 DDS_EXPORT dds_return_t
 ddsrt_dlerror(

--- a/src/ddsrt/src/dynlib/posix/dynlib.c
+++ b/src/ddsrt/src/dynlib/posix/dynlib.c
@@ -16,81 +16,61 @@
 #include <dds/ddsrt/dynlib.h>
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/io.h"
+#include "dds/ddsrt/string.h"
 
-dds_return_t ddsrt_dlopen(const char *name, bool translate,
-    ddsrt_dynlib_t *handle) {
-  dds_return_t retcode = DDS_RETCODE_OK;
-
-  assert( handle );
+dds_return_t ddsrt_dlopen (const char *name, bool translate, ddsrt_dynlib_t *handle)
+{
+  assert (handle);
   *handle = NULL;
 
-  if ((translate) && (strrchr(name, '/') == NULL )) {
-    /* Add lib and suffix to the name and try to open. */
+  if (translate && strrchr (name, '/') == NULL)
+  {
 #if __APPLE__
     static const char suffix[] = ".dylib";
 #else
     static const char suffix[] = ".so";
 #endif
-    char* libName;
-    ddsrt_asprintf( &libName, "lib%s%s", name, suffix);
-    *handle = dlopen(libName, RTLD_GLOBAL | RTLD_NOW);
-    ddsrt_free(libName);
+    char* lib_name;
+    if (ddsrt_asprintf (&lib_name, "lib%s%s", name, suffix) == -1)
+      return DDS_RETCODE_OUT_OF_RESOURCES;
+    *handle = dlopen (lib_name, RTLD_GLOBAL | RTLD_NOW);
+    ddsrt_free (lib_name);
   }
 
-  if (*handle == NULL ) {
-    /* name contains a path,
-     * (auto)translate is disabled or
-     * dlopen on translated name failed. */
-    *handle = dlopen(name, RTLD_GLOBAL | RTLD_NOW);
+  if (*handle == NULL)
+  {
+    /* name contains a path, (auto)translate is disabled or dlopen on translated name failed. */
+    *handle = dlopen (name, RTLD_GLOBAL | RTLD_NOW);
   }
 
-
-  if (*handle != NULL) {
-    retcode = DDS_RETCODE_OK;
-  } else {
-    retcode = DDS_RETCODE_ERROR;
-  }
-
-  return retcode;
+  return *handle != NULL ? DDS_RETCODE_OK : DDS_RETCODE_ERROR;
 }
 
-dds_return_t ddsrt_dlclose(ddsrt_dynlib_t handle) {
-
-  assert ( handle );
-  return (dlclose(handle) == 0) ? DDS_RETCODE_OK : DDS_RETCODE_ERROR;
-
+dds_return_t ddsrt_dlclose (ddsrt_dynlib_t handle)
+{
+  assert (handle);
+  return (dlclose (handle) == 0) ? DDS_RETCODE_OK : DDS_RETCODE_ERROR;
 }
 
-dds_return_t ddsrt_dlsym(ddsrt_dynlib_t handle, const char *symbol,
-    void **address) {
-  dds_return_t retcode = DDS_RETCODE_OK;
+dds_return_t ddsrt_dlsym (ddsrt_dynlib_t handle, const char *symbol, void **address)
+{
+  assert (handle);
+  assert (address);
+  assert (symbol);
+  *address = dlsym (handle, symbol);
+  return (*address == NULL) ? DDS_RETCODE_ERROR : DDS_RETCODE_OK;
+}
 
-  assert( handle );
-  assert( address );
-  assert( symbol );
-
-  *address = dlsym(handle, symbol);
-  if (*address == NULL) {
-    retcode = DDS_RETCODE_ERROR;
+dds_return_t ddsrt_dlerror (char *buf, size_t buflen)
+{
+  assert (buf);
+  assert (buflen);
+  const char *err = dlerror ();
+  if (err == NULL)
+  {
+    buf[0] = '\0';
+    return 0;
   }
-
-  return retcode;
+  size_t len = ddsrt_strlcpy (buf, err, buflen);
+  return (len >= buflen) ? DDS_RETCODE_NOT_ENOUGH_SPACE : (int32_t) strlen (buf);
 }
-
-dds_return_t ddsrt_dlerror(char *buf, size_t buflen) {
-
-  const char *err;
-  dds_return_t retcode = DDS_RETCODE_OK;
-
-  assert (buf );
-
-  err = dlerror();
-  if (err == NULL) {
-    retcode = DDS_RETCODE_NOT_FOUND;
-  } else {
-    snprintf(buf, buflen, "%s", err);
-  }
-
-  return retcode;
-}
-

--- a/src/ddsrt/src/dynlib/windows/dynlib.c
+++ b/src/ddsrt/src/dynlib/windows/dynlib.c
@@ -16,81 +16,84 @@
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/types.h"
 #include "dds/ddsrt/string.h"
+#include "dds/ddsrt/io.h"
+#include "dds/ddsrt/threads.h"
 
-dds_return_t ddsrt_dlopen(const char *name, bool translate,
-        ddsrt_dynlib_t *handle) {
-    dds_return_t retcode = DDS_RETCODE_OK;
+static ddsrt_thread_local DWORD dynlib_last_err;
 
-    assert( handle );
-    *handle = NULL;
+dds_return_t ddsrt_dlopen (const char *name, bool translate, ddsrt_dynlib_t *handle)
+{
+  assert (handle);
+  *handle = NULL;
 
-    if ((translate) && (strrchr(name, '/') == NULL )
-            && (strrchr(name, '\\') == NULL )) {
-        /* Add suffix to the name and try to open. */
-        static const char suffix[] = ".dll";
-        size_t len = strlen(name) + sizeof(suffix);
-        char* libName = ddsrt_malloc(len);
-        sprintf_s(libName, len, "%s%s", name, suffix);
-        *handle = (ddsrt_dynlib_t)LoadLibrary(libName);
-        ddsrt_free(libName);
-    }
+  if (translate && (strrchr (name, '/') == NULL && strrchr (name, '\\') == NULL))
+  {
+    static const char suffix[] = ".dll";
+    char *lib_name;
+    if (ddsrt_asprintf (&lib_name, "%s%s", name, suffix) == -1)
+      return DDS_RETCODE_OUT_OF_RESOURCES;
+    *handle = (ddsrt_dynlib_t) LoadLibrary (lib_name);
+    ddsrt_free (lib_name);
+  }
 
-    if (*handle == NULL) {
-        /* Name contains a path,
-        * (auto)translate is disabled or
-        * LoadLibrary on translated name failed. */
-        *handle = (ddsrt_dynlib_t)LoadLibrary(name);
-    }
+  if (*handle == NULL)
+  {
+    /* Name contains a path, (auto)translate is disabled or LoadLibrary on translated name failed. */
+    *handle = (ddsrt_dynlib_t) LoadLibrary (name);
+  }
 
-    if (*handle != NULL) {
-        retcode = DDS_RETCODE_OK;
-    } else {
-        retcode = DDS_RETCODE_ERROR;
-    }
-
-    return retcode;
+  if (*handle == NULL)
+  {
+    dynlib_last_err = GetLastError ();
+    return DDS_RETCODE_ERROR;
+  }
+  dynlib_last_err = 0;
+  return DDS_RETCODE_OK;
 }
 
-dds_return_t ddsrt_dlclose(ddsrt_dynlib_t handle) {
-
-    assert ( handle );
-    return (FreeLibrary((HMODULE)handle) == 0) ? DDS_RETCODE_ERROR : DDS_RETCODE_OK;
+dds_return_t ddsrt_dlclose (ddsrt_dynlib_t handle)
+{
+  assert (handle);
+  if (FreeLibrary ((HMODULE) handle) == 0)
+  {
+    dynlib_last_err = GetLastError ();
+    return DDS_RETCODE_ERROR;
+  }
+  dynlib_last_err = 0;
+  return DDS_RETCODE_OK;
 }
 
-dds_return_t ddsrt_dlsym(ddsrt_dynlib_t handle, const char *symbol,
-        void **address) {
-    dds_return_t retcode = DDS_RETCODE_OK;
+dds_return_t ddsrt_dlsym (ddsrt_dynlib_t handle, const char *symbol, void **address)
+{
+  assert (handle);
+  assert (address);
+  assert (symbol);
+  if ((*address = GetProcAddress ((HMODULE) handle, symbol)) == NULL)
+  {
+    dynlib_last_err = GetLastError ();
+    return DDS_RETCODE_ERROR;
+  }
+  dynlib_last_err = 0;
+  return DDS_RETCODE_OK;
+}
 
-    assert( handle );
-    assert( address );
-    assert( symbol );
-
-    *address = GetProcAddress((HMODULE)handle, symbol);
-    if ( *address == NULL ) {
-        retcode = DDS_RETCODE_ERROR;
+dds_return_t ddsrt_dlerror (char *buf, size_t buflen)
+{
+  assert (buf);
+  assert (buflen);
+  dds_return_t ret = 0;
+  buf[0] = '\0';
+  if (dynlib_last_err != 0)
+  {
+    if ((ret = ddsrt_strerror_r (dynlib_last_err, buf, buflen)) == DDS_RETCODE_OK)
+      ret = (int32_t) strlen (buf);
+    else if (ret == DDS_RETCODE_BAD_PARAMETER)
+    {
+      const char *err_unknown = "unknown error";
+      size_t len = ddsrt_strlcpy (buf, err_unknown, buflen);
+      ret = (len >= buflen) ? DDS_RETCODE_NOT_ENOUGH_SPACE : (int32_t) strlen (buf);
     }
-
-    return retcode;
+    dynlib_last_err = 0;
+  }
+  return ret;
 }
-
-dds_return_t ddsrt_dlerror(char *buf, size_t buflen) {
-
-    /* Hopefully (and likely), the last error is
-    * related to a Library action attempt. */
-    DWORD err;
-    assert ( buf );
-
-    dds_return_t retcode = DDS_RETCODE_OK;
-
-    err = GetLastError();
-    if ( err == 0 ) {
-        retcode = DDS_RETCODE_NOT_FOUND;
-    } else {
-        ddsrt_strerror_r(err, buf, buflen);
-        SetLastError(0);
-    }
-
-    return retcode;
-
-}
-

--- a/src/ddsrt/src/sockets.c
+++ b/src/ddsrt/src/sockets.c
@@ -264,6 +264,19 @@ DDSRT_WARNING_GNUC_ON(sign-conversion)
 
 #if DDSRT_HAVE_DNS
 #if DDSRT_HAVE_GETADDRINFO
+
+static bool
+is_valid_hostname_char(char c)
+{
+  return
+    (c >= 'a' && c <= 'z') ||
+    (c >= 'A' && c <= 'Z') ||
+    (c >= '0' && c <= '9') ||
+    c == '-' ||
+    c == '.' ||
+    c == ':';
+}
+
 dds_return_t
 ddsrt_gethostbyname(const char *name, int af, ddsrt_hostent_t **hentp)
 {
@@ -290,6 +303,12 @@ ddsrt_gethostbyname(const char *name, int af, ddsrt_hostent_t **hentp)
      Deny empty hostnames to keep behavior across platforms consistent. */
   if (strlen(name) == 0) {
     return DDS_RETCODE_HOST_NOT_FOUND;
+  }
+
+  for (size_t i = 0; name[i]; i++) {
+    if (!is_valid_hostname_char(name[i])) {
+      return DDS_RETCODE_HOST_NOT_FOUND;
+    }
   }
 
   memset(&hints, 0, sizeof(hints));

--- a/src/ddsrt/tests/dynlib.c
+++ b/src/ddsrt/tests/dynlib.c
@@ -27,7 +27,7 @@ do { \
   if (var == NULL) { \
     char err[256]; \
     r = ddsrt_dlerror(err, sizeof(err)); \
-    CU_ASSERT_EQUAL_FATAL(r, DDS_RETCODE_OK); \
+    CU_ASSERT_FATAL(r > 0); \
     printf("\n%s", err); \
     CU_FAIL_FATAL(msg); \
   } \
@@ -91,7 +91,7 @@ CU_Test(ddsrt_library, dlopen_unknown)
   CU_ASSERT_PTR_NULL_FATAL(l);
 
   r = ddsrt_dlerror(buffer, sizeof(buffer));
-  CU_ASSERT_EQUAL_FATAL(r, DDS_RETCODE_OK);
+  CU_ASSERT_FATAL(r > 0);
   printf("\n%s", buffer);
 }
 
@@ -132,7 +132,7 @@ CU_Test(ddsrt_library, dlsym_unknown)
   CU_ASSERT_PTR_NULL_FATAL(f);
 
   r = ddsrt_dlerror(buffer, sizeof(buffer));
-  CU_ASSERT_EQUAL_FATAL(r, DDS_RETCODE_OK);
+  CU_ASSERT_FATAL(r > 0);
   printf("\n%s", buffer);
 
   r = ddsrt_dlclose(l);

--- a/src/security/builtin_plugins/tests/encode_datareader_submessage/src/encode_datareader_submessage_utests.c
+++ b/src/security/builtin_plugins/tests/encode_datareader_submessage/src/encode_datareader_submessage_utests.c
@@ -478,6 +478,12 @@ static bool cipher_sign_data(const unsigned char *session_key, uint32_t key_size
       goto fail_encrypt;
     }
   }
+  else
+  {
+    assert (0);
+    goto fail_encrypt;
+  }
+
 
   /* Initialise key and IV */
   if (!EVP_EncryptInit_ex(ctx, NULL, NULL, session_key, iv))
@@ -546,6 +552,11 @@ static bool crypto_decrypt_data(uint32_t session_id, unsigned char *iv, DDS_Secu
         ERR_print_errors_fp(stderr);
         result = false;
       }
+    }
+    else
+    {
+      assert (0);
+      return false;
     }
   }
 

--- a/src/security/builtin_plugins/tests/encode_rtps_message/src/encode_rtps_message_utests.c
+++ b/src/security/builtin_plugins/tests/encode_rtps_message/src/encode_rtps_message_utests.c
@@ -406,6 +406,12 @@ cipher_sign_data(
       goto fail_encrypt;
     }
   }
+  else
+  {
+    assert (0);
+    goto fail_encrypt;
+  }
+
 
   /* Initialise key and IV */
   if (!EVP_EncryptInit_ex(ctx, NULL, NULL, session_key, iv))
@@ -485,6 +491,11 @@ crypto_decrypt_data(
         ERR_print_errors_fp(stderr);
         result = false;
       }
+    }
+    else
+    {
+      assert (0);
+      result = false;
     }
   }
 

--- a/src/security/core/src/dds_security_plugins.c
+++ b/src/security/core/src/dds_security_plugins.c
@@ -242,7 +242,7 @@ dds_return_t dds_security_load_security_library (const dds_security_plugin_confi
   return DDS_RETCODE_OK;
 
 library_error:
-  ddsrt_dlclose (security_plugin->lib_handle);
+  (void) ddsrt_dlclose (security_plugin->lib_handle);
   security_plugin->lib_handle = NULL;
 load_error:
   return DDS_RETCODE_ERROR;

--- a/src/tools/ddsconf/xsd.c
+++ b/src/tools/ddsconf/xsd.c
@@ -220,6 +220,7 @@ printcomplextype(
       } else {
         assert(cnt > 1);
         ce = firstelem(elem->children);
+        assert(ce != NULL);
         min[0] = min[1] = min[2] = minimum(ce);
         max[0] = max[1] = max[2] = maximum(ce);
         assert(min[1] <= max[1] || max[1] == 0);


### PR DESCRIPTION
Commit d9b0d1c fixes failing locator tests by disabling some of the tests that timeout when calling `getaddrinfo`. The default timeout for name resolving on linux is 5s with 2 retries, so keeping this tests would require an undesirable long timeout for these test cases. Commit bf2a506 contains fixes for some of the Coverity issues. 