### PR TITLE
For the security_timed_dispatcher use the xevent queue to schedule timer events.

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/q_xevent.h
+++ b/src/core/ddsi/include/dds/ddsi/q_xevent.h
@@ -35,7 +35,7 @@ struct proxy_writer;
 struct proxy_reader;
 struct nn_xmsg;
 
-struct xeventq *xeventq_new
+DDS_EXPORT struct xeventq *xeventq_new
 (
   struct ddsi_tran_conn * conn,
   size_t max_queued_rexmit_bytes,

--- a/src/core/ddsi/src/ddsi_security_omg.c
+++ b/src/core/ddsi/src/ddsi_security_omg.c
@@ -773,7 +773,17 @@ static void release_plugins (struct ddsi_domaingv *gv, dds_security_context *sc)
 
 void q_omg_security_stop (struct ddsi_domaingv *gv)
 {
+  dds_security_context *sc = gv->security_context;
+
   ddsi_handshake_admin_stop(gv);
+
+  if (sc)
+  {
+    if (sc->authentication_context)
+      sc->authentication_context->set_listener (sc->authentication_context, NULL, NULL);
+    if (sc->access_control_context)
+      sc->access_control_context->set_listener (sc->access_control_context, NULL, NULL);
+  }
 }
 
 void q_omg_security_deinit (struct dds_security_context *sc)

--- a/src/security/builtin_plugins/access_control/src/access_control.c
+++ b/src/security/builtin_plugins/access_control/src/access_control.c
@@ -915,7 +915,7 @@ set_listener(dds_security_access_control *instance,
   dds_security_access_control_impl *ac = (dds_security_access_control_impl *)instance;
   ac->listener = listener;
   if (listener)
-    dds_security_timed_dispatcher_enable(ac->dispatcher, ac->base.gv->xevents);
+    dds_security_timed_dispatcher_enable(ac->dispatcher);
   else
     dds_security_timed_dispatcher_disable(ac->dispatcher);
 
@@ -1479,7 +1479,7 @@ int init_access_control(const char *argument, void **context, struct ddsi_domain
   memset(access_control, 0, sizeof(*access_control));
   access_control->base.gv = gv;
   access_control->listener = NULL;
-  access_control->dispatcher = dds_security_timed_dispatcher_new();
+  access_control->dispatcher = dds_security_timed_dispatcher_new(gv->xevents);
   access_control->base.validate_local_permissions = &validate_local_permissions;
   access_control->base.validate_remote_permissions = &validate_remote_permissions;
   access_control->base.check_create_participant = &check_create_participant;

--- a/src/security/builtin_plugins/access_control/src/access_control.c
+++ b/src/security/builtin_plugins/access_control/src/access_control.c
@@ -917,7 +917,7 @@ set_listener(dds_security_access_control *instance,
   if (listener)
     dds_security_timed_dispatcher_enable(ac->dispatcher);
   else
-    dds_security_timed_dispatcher_disable(ac->dispatcher);
+    (void) dds_security_timed_dispatcher_disable(ac->dispatcher);
 
   return true;
 }

--- a/src/security/builtin_plugins/access_control/src/access_control_objects.c
+++ b/src/security/builtin_plugins/access_control/src/access_control_objects.c
@@ -266,7 +266,7 @@ ac_remote_participant_access_rights_new(
   access_control_object_init((AccessControlObject *)rights, ACCESS_CONTROL_OBJECT_KIND_REMOTE_PARTICIPANT, remote_participant_access_rights_free);
   rights->remote_identity = remote_identity;
   rights->permissions = permissions;
-  rights->permissions_expiry = permission_expiry;
+  rights->_parent.permissions_expiry = permission_expiry;
   rights->local_rights = (local_participant_access_rights *)ACCESS_CONTROL_OBJECT_KEEP(local_rights);
   if (rights->permissions)
   {

--- a/src/security/builtin_plugins/access_control/src/access_control_objects.h
+++ b/src/security/builtin_plugins/access_control/src/access_control_objects.h
@@ -16,6 +16,7 @@
 #include "dds/ddsrt/types.h"
 #include "dds/security/dds_security_api.h"
 #include "dds/security/openssl_support.h"
+#include "dds/security/core/dds_security_timed_cb.h"
 
 #define ACCESS_CONTROL_OBJECT(o)            ((AccessControlObject *)(o))
 #define ACCESS_CONTROL_OBJECT_HANDLE(o)     ((o) ? ACCESS_CONTROL_OBJECT(o)->handle : DDS_SECURITY_HANDLE_NIL)
@@ -38,6 +39,8 @@ struct AccessControlObject {
     ddsrt_atomic_uint32_t refcount;
     AccessControlObjectKind_t kind;
     AccessControlObjectDestructor destructor;
+    dds_time_t permissions_expiry;
+    dds_security_time_event_handle_t timer;
 };
 
 typedef struct local_participant_access_rights {
@@ -50,7 +53,6 @@ typedef struct local_participant_access_rights {
     char *identity_subject_name;
     char *permissions_document;
     X509 *permissions_ca;
-    dds_time_t permissions_expiry;
 } local_participant_access_rights;
 
 
@@ -66,7 +68,6 @@ typedef struct remote_participant_access_rights {
     local_participant_access_rights *local_rights;
     remote_permissions *permissions;
     char *identity_subject_name;
-    dds_time_t permissions_expiry;
 } remote_participant_access_rights;
 
 void access_control_object_init(AccessControlObject *obj, AccessControlObjectKind_t kind, AccessControlObjectDestructor destructor);

--- a/src/security/builtin_plugins/authentication/src/authentication.c
+++ b/src/security/builtin_plugins/authentication/src/authentication.c
@@ -2068,7 +2068,7 @@ DDS_Security_boolean set_listener(dds_security_authentication *instance, const d
   if (listener)
     dds_security_timed_dispatcher_enable(auth->dispatcher);
   else
-    dds_security_timed_dispatcher_disable(auth->dispatcher);
+    (void) dds_security_timed_dispatcher_disable(auth->dispatcher);
   return true;
 }
 

--- a/src/security/builtin_plugins/authentication/src/authentication.c
+++ b/src/security/builtin_plugins/authentication/src/authentication.c
@@ -2066,7 +2066,7 @@ DDS_Security_boolean set_listener(dds_security_authentication *instance, const d
   dds_security_authentication_impl *auth = (dds_security_authentication_impl *)instance;
   auth->listener = listener;
   if (listener)
-    dds_security_timed_dispatcher_enable(auth->dispatcher, auth->base.gv->xevents);
+    dds_security_timed_dispatcher_enable(auth->dispatcher);
   else
     dds_security_timed_dispatcher_disable(auth->dispatcher);
   return true;
@@ -2234,7 +2234,7 @@ int32_t init_authentication(const char *argument, void **context, struct ddsi_do
   memset(authentication, 0, sizeof(dds_security_authentication_impl));
   authentication->base.gv = gv;
   authentication->listener = NULL;
-  authentication->dispatcher = dds_security_timed_dispatcher_new();
+  authentication->dispatcher = dds_security_timed_dispatcher_new(gv->xevents);
   authentication->base.validate_local_identity = &validate_local_identity;
   authentication->base.get_identity_token = &get_identity_token;
   authentication->base.get_identity_status_token = &get_identity_status_token;
@@ -2256,10 +2256,7 @@ int32_t init_authentication(const char *argument, void **context, struct ddsi_do
   authentication->objectHash = ddsrt_hh_new(32, security_object_hash, security_object_equal);
   authentication->remoteGuidHash = ddsrt_hh_new(32, remote_guid_hash, remote_guid_equal);
   memset(&authentication->trustedCAList, 0, sizeof(X509Seq));
-  if (gv)
-    authentication->include_optional = gv->handshake_include_optional;
-  else
-    authentication->include_optional = true;
+  authentication->include_optional = gv->handshake_include_optional;
 
   dds_openssl_init ();
   *context = authentication;

--- a/src/security/builtin_plugins/tests/common/src/loader.c
+++ b/src/security/builtin_plugins/tests/common/src/loader.c
@@ -9,18 +9,21 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <sys/stat.h>
 
 #include <CUnit/Test.h>
-#include <dds/ddsrt/misc.h>
-#include "loader.h"
+#include "dds/ddsrt/misc.h"
 #include "dds/ddsrt/dynlib.h"
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/string.h"
-#include "sys/stat.h"
-#include "assert.h"
-#include "stdio.h"
-#include "string.h"
+#include "dds/ddsi/ddsi_domaingv.h"
+#include "dds/ddsi/q_xevent.h"
+#include "dds/ddsi/q_thread.h"
 #include "dds/security/core/dds_security_utils.h"
+#include "loader.h"
 
 struct plugin_info {
     void *context;
@@ -33,6 +36,9 @@ struct plugins_hdl {
     struct plugin_info plugin_ac;
     struct plugin_info plugin_auth;
     struct plugin_info plugin_crypto;
+
+    struct ddsi_domaingv gv;
+    struct ddsi_tran_conn connection;
 };
 
 static void*
@@ -84,17 +90,23 @@ load_plugins(
         dds_security_access_control **ac,
         dds_security_authentication **auth,
         dds_security_cryptography   **crypto,
-        void *args)
+        const struct ddsi_domaingv *gv_init)
 {
     struct plugins_hdl *plugins = ddsrt_malloc(sizeof(struct plugins_hdl));
     assert(plugins);
     memset(plugins, 0, sizeof(struct plugins_hdl));
+
+    if (gv_init)
+      plugins->gv = *gv_init;
+    plugins->connection.m_base.gv = &plugins->gv;
+    plugins->gv.xevents = xeventq_new (&plugins->connection, 0, 0, 0);
+
     if (ac) {
         *ac = load_plugin(&(plugins->plugin_ac),
                           "dds_security_ac",
                           "init_access_control",
                           "finalize_access_control",
-                          args);
+                          &plugins->gv);
         if (!(*ac)) {
             goto err;
         }
@@ -105,7 +117,7 @@ load_plugins(
                             "dds_security_auth",
                             "init_authentication",
                             "finalize_authentication",
-                            args);
+                            &plugins->gv);
         if (!(*auth)) {
             goto err;
         }
@@ -115,15 +127,19 @@ load_plugins(
                               "dds_security_crypto",
                               "init_crypto",
                               "finalize_crypto",
-                              args);
+                              &plugins->gv);
         if (!(*crypto)) {
             goto err;
         }
     }
+
+    thread_states_init(16);
+    xeventq_start(plugins->gv.xevents, "TEST");
     return plugins;
 
 err:
     unload_plugins(plugins);
+    xeventq_free(plugins->gv.xevents);
     return NULL;
 }
 
@@ -153,7 +169,12 @@ unload_plugins(
     unload_plugin(&(plugins->plugin_ac));
     unload_plugin(&(plugins->plugin_auth));
     unload_plugin(&(plugins->plugin_crypto));
+
+    xeventq_stop(plugins->gv.xevents);
+    xeventq_free(plugins->gv.xevents);
     ddsrt_free(plugins);
+
+    (void)thread_states_fini();
 }
 
 static size_t

--- a/src/security/builtin_plugins/tests/common/src/loader.c
+++ b/src/security/builtin_plugins/tests/common/src/loader.c
@@ -40,7 +40,8 @@ load_plugin(
         struct plugin_info *info,
         const char *name_lib,
         const char *name_init,
-        const char *name_fini)
+        const char *name_fini,
+        void *args)
 {
     dds_return_t result;
     void *plugin = NULL;
@@ -64,7 +65,7 @@ load_plugin(
         }
 
         char * init_parameters = "";
-        (void)info->func_init(init_parameters, &plugin, NULL);
+        (void)info->func_init(init_parameters, &plugin, args);
         if (plugin) {
             info->context = plugin;
         } else {
@@ -82,7 +83,8 @@ struct plugins_hdl*
 load_plugins(
         dds_security_access_control **ac,
         dds_security_authentication **auth,
-        dds_security_cryptography   **crypto)
+        dds_security_cryptography   **crypto,
+        void *args)
 {
     struct plugins_hdl *plugins = ddsrt_malloc(sizeof(struct plugins_hdl));
     assert(plugins);
@@ -91,7 +93,8 @@ load_plugins(
         *ac = load_plugin(&(plugins->plugin_ac),
                           "dds_security_ac",
                           "init_access_control",
-                          "finalize_access_control");
+                          "finalize_access_control",
+                          args);
         if (!(*ac)) {
             goto err;
         }
@@ -101,7 +104,8 @@ load_plugins(
                             //"dds_security_auth",
                             "dds_security_auth",
                             "init_authentication",
-                            "finalize_authentication");
+                            "finalize_authentication",
+                            args);
         if (!(*auth)) {
             goto err;
         }
@@ -110,7 +114,8 @@ load_plugins(
         *crypto = load_plugin(&(plugins->plugin_crypto),
                               "dds_security_crypto",
                               "init_crypto",
-                              "finalize_crypto");
+                              "finalize_crypto",
+                              args);
         if (!(*crypto)) {
             goto err;
         }

--- a/src/security/builtin_plugins/tests/common/src/loader.h
+++ b/src/security/builtin_plugins/tests/common/src/loader.h
@@ -17,12 +17,22 @@
 
 struct plugins_hdl;
 
+/** load some or all security plugins for testing
+
+ @param[out] ac      where to store address of loaded access control plugin, or NULL if not to be loaded
+ @param[out] auth    where to store address of loaded authentication plugin, or NULL if not to be loaded
+ @param[out] crypto  where to store address of loaded cryptography plugin, or NULL if not to be loaded
+ @param[in]  init_gv initial value for DDSI globals that plugins happen to rely on, or NULL if no special
+                     values need to be set.  "xevents" is always set in load_plugins
+
+ @returns pointer to opaque handle for unloading the plugins, or NULL on failure
+ */
 struct plugins_hdl*
 load_plugins(
         dds_security_access_control **ac,
         dds_security_authentication **auth,
         dds_security_cryptography   **crypto,
-        void *args);
+        const struct ddsi_domaingv *init_gv);
 
 void
 unload_plugins(

--- a/src/security/builtin_plugins/tests/common/src/loader.h
+++ b/src/security/builtin_plugins/tests/common/src/loader.h
@@ -21,7 +21,8 @@ struct plugins_hdl*
 load_plugins(
         dds_security_access_control **ac,
         dds_security_authentication **auth,
-        dds_security_cryptography   **crypto);
+        dds_security_cryptography   **crypto,
+        void *args);
 
 void
 unload_plugins(

--- a/src/security/builtin_plugins/tests/create_local_datareader_crypto_tokens/src/create_local_datareader_crypto_tokens_utests.c
+++ b/src/security/builtin_plugins/tests/create_local_datareader_crypto_tokens/src/create_local_datareader_crypto_tokens_utests.c
@@ -203,7 +203,8 @@ static void suite_create_local_datareader_crypto_tokens_init(void)
   CU_ASSERT_FATAL ((plugins = load_plugins(
                       NULL    /* Access Control */,
                       NULL    /* Authentication */,
-                      &crypto /* Cryptograpy    */)) != NULL);
+                      &crypto /* Cryptograpy    */,
+                      NULL)) != NULL);
   CU_ASSERT_EQUAL_FATAL (register_local_participant(), 0);
   CU_ASSERT_EQUAL_FATAL (register_remote_participant(), 0);
   CU_ASSERT_EQUAL_FATAL (register_local_datareader(), 0);

--- a/src/security/builtin_plugins/tests/create_local_datawriter_crypto_tokens/src/create_local_datawriter_crypto_tokens_utests.c
+++ b/src/security/builtin_plugins/tests/create_local_datawriter_crypto_tokens/src/create_local_datawriter_crypto_tokens_utests.c
@@ -206,7 +206,8 @@ static void suite_create_local_datawriter_crypto_tokens_init(void)
   CU_ASSERT_FATAL ((plugins = load_plugins(
                       NULL    /* Access Control */,
                       NULL    /* Authentication */,
-                      &crypto /* Cryptograpy    */)) != NULL);
+                      &crypto /* Cryptograpy    */,
+                      NULL)) != NULL);
   CU_ASSERT_EQUAL_FATAL (register_local_participant(), 0);
   CU_ASSERT_EQUAL_FATAL (register_remote_participant(), 0);
   CU_ASSERT_EQUAL_FATAL (register_local_datawriter(), 0);

--- a/src/security/builtin_plugins/tests/create_local_participant_crypto_tokens/src/create_local_participant_crypto_tokens_utests.c
+++ b/src/security/builtin_plugins/tests/create_local_participant_crypto_tokens/src/create_local_participant_crypto_tokens_utests.c
@@ -155,7 +155,8 @@ static void suite_create_local_participant_crypto_tokens_init(void)
   CU_ASSERT_FATAL ((plugins = load_plugins(
                       NULL    /* Access Control */,
                       NULL    /* Authentication */,
-                      &crypto /* Cryptograpy    */)) != NULL);
+                      &crypto /* Cryptograpy    */,
+                      NULL)) != NULL);
   allocate_shared_secret();
   CU_ASSERT_EQUAL_FATAL (register_participants(), 0);
 }

--- a/src/security/builtin_plugins/tests/decode_datareader_submessage/src/decode_datareader_submessage_utests.c
+++ b/src/security/builtin_plugins/tests/decode_datareader_submessage/src/decode_datareader_submessage_utests.c
@@ -433,7 +433,8 @@ static void suite_decode_datareader_submessage_init(void)
   CU_ASSERT_FATAL ((plugins = load_plugins(
                       NULL    /* Access Control */,
                       NULL    /* Authentication */,
-                      &crypto /* Cryptograpy    */)) != NULL);
+                      &crypto /* Cryptograpy    */,
+                      NULL)) != NULL);
 
   CU_ASSERT_EQUAL_FATAL (register_local_participant(), 0);
   CU_ASSERT_EQUAL_FATAL (register_remote_participant(), 0);

--- a/src/security/builtin_plugins/tests/decode_datawriter_submessage/src/decode_datawriter_submessage_utests.c
+++ b/src/security/builtin_plugins/tests/decode_datawriter_submessage/src/decode_datawriter_submessage_utests.c
@@ -408,7 +408,8 @@ static void suite_decode_datawriter_submessage_init(void)
   CU_ASSERT_FATAL ((plugins = load_plugins(
                       NULL    /* Access Control */,
                       NULL    /* Authentication */,
-                      &crypto /* Cryptograpy    */)) != NULL);
+                      &crypto /* Cryptograpy    */,
+                      NULL)) != NULL);
 
   CU_ASSERT_EQUAL_FATAL (register_local_participant(), 0);
   CU_ASSERT_EQUAL_FATAL (register_remote_participant(), 0);

--- a/src/security/builtin_plugins/tests/decode_rtps_message/src/decode_rtps_message_utests.c
+++ b/src/security/builtin_plugins/tests/decode_rtps_message/src/decode_rtps_message_utests.c
@@ -371,7 +371,8 @@ static void suite_decode_rtps_message_init(void)
   CU_ASSERT_FATAL ((plugins = load_plugins(
                       NULL    /* Access Control */,
                       NULL    /* Authentication */,
-                      &crypto /* Cryptograpy    */)) != NULL);
+                      &crypto /* Cryptograpy    */,
+                      NULL)) != NULL);
 }
 
 static void suite_decode_rtps_message_fini(void)

--- a/src/security/builtin_plugins/tests/decode_serialized_payload/src/decode_serialized_payload_utests.c
+++ b/src/security/builtin_plugins/tests/decode_serialized_payload/src/decode_serialized_payload_utests.c
@@ -392,7 +392,8 @@ static void suite_decode_serialized_payload_init(void)
   CU_ASSERT_FATAL ((plugins = load_plugins(
                       NULL    /* Access Control */,
                       NULL    /* Authentication */,
-                      &crypto /* Cryptograpy    */)) != NULL);
+                      &crypto /* Cryptograpy    */,
+                      NULL)) != NULL);
   CU_ASSERT_EQUAL_FATAL (register_local_participant(), 0);
   CU_ASSERT_EQUAL_FATAL (register_remote_participant(), 0);
 }

--- a/src/security/builtin_plugins/tests/encode_datareader_submessage/src/encode_datareader_submessage_utests.c
+++ b/src/security/builtin_plugins/tests/encode_datareader_submessage/src/encode_datareader_submessage_utests.c
@@ -770,7 +770,8 @@ static void suite_encode_datareader_submessage_init(void)
   CU_ASSERT_FATAL ((plugins = load_plugins(
                       NULL    /* Access Control */,
                       NULL    /* Authentication */,
-                      &crypto /* Cryptograpy    */)) != NULL);
+                      &crypto /* Cryptograpy    */,
+                      NULL)) != NULL);
   CU_ASSERT_EQUAL_FATAL (register_local_participant(), 0);
   CU_ASSERT_EQUAL_FATAL (register_remote_participant(), 0);
 }

--- a/src/security/builtin_plugins/tests/encode_datawriter_submessage/src/encode_datawriter_submessage_utests.c
+++ b/src/security/builtin_plugins/tests/encode_datawriter_submessage/src/encode_datawriter_submessage_utests.c
@@ -738,7 +738,8 @@ static void suite_encode_datawriter_submessage_init(void)
   CU_ASSERT_FATAL ((plugins = load_plugins(
                       NULL    /* Access Control */,
                       NULL    /* Authentication */,
-                      &crypto /* Cryptograpy    */)) != NULL);
+                      &crypto /* Cryptograpy    */,
+                      NULL)) != NULL);
   CU_ASSERT_EQUAL_FATAL (register_local_participant(), 0);
   CU_ASSERT_EQUAL_FATAL (register_remote_participant(), 0);
 }

--- a/src/security/builtin_plugins/tests/encode_rtps_message/src/encode_rtps_message_utests.c
+++ b/src/security/builtin_plugins/tests/encode_rtps_message/src/encode_rtps_message_utests.c
@@ -699,7 +699,8 @@ static void suite_encode_rtps_message_init(void)
   CU_ASSERT_FATAL ((plugins = load_plugins(
                       NULL    /* Access Control */,
                       NULL    /* Authentication */,
-                      &crypto /* Cryptograpy    */)) != NULL);
+                      &crypto /* Cryptograpy    */,
+                      NULL)) != NULL);
 }
 
 static void suite_encode_rtps_message_fini(void)

--- a/src/security/builtin_plugins/tests/encode_serialized_payload/src/encode_serialized_payload_utests.c
+++ b/src/security/builtin_plugins/tests/encode_serialized_payload/src/encode_serialized_payload_utests.c
@@ -454,7 +454,8 @@ static void suite_encode_serialized_payload_init(void)
   CU_ASSERT_FATAL ((plugins = load_plugins(
                       NULL    /* Access Control */,
                       NULL    /* Authentication */,
-                      &crypto /* Cryptograpy    */)) != NULL);
+                      &crypto /* Cryptograpy    */,
+                      NULL)) != NULL);
   CU_ASSERT_EQUAL_FATAL (register_local_participant(), 0);
   CU_ASSERT_EQUAL_FATAL (register_remote_participant(), 0);
 }

--- a/src/security/builtin_plugins/tests/get_authenticated_peer_credential_token/src/get_authenticated_peer_credential_token_utests.c
+++ b/src/security/builtin_plugins/tests/get_authenticated_peer_credential_token/src/get_authenticated_peer_credential_token_utests.c
@@ -881,7 +881,7 @@ CU_Init(ddssec_builtin_get_authenticated_peer_credential)
     g_plugins = load_plugins(NULL   /* Access Control */,
                              &g_auth  /* Authentication */,
                              NULL   /* Cryptograpy    */,
-                             NULL);
+                             &(const struct ddsi_domaingv){ .handshake_include_optional = true });
     if (g_plugins) {
         result = validate_local_identity();
         if (result >= 0) {

--- a/src/security/builtin_plugins/tests/get_authenticated_peer_credential_token/src/get_authenticated_peer_credential_token_utests.c
+++ b/src/security/builtin_plugins/tests/get_authenticated_peer_credential_token/src/get_authenticated_peer_credential_token_utests.c
@@ -880,7 +880,8 @@ CU_Init(ddssec_builtin_get_authenticated_peer_credential)
     /* Only need the authentication plugin. */
     g_plugins = load_plugins(NULL   /* Access Control */,
                              &g_auth  /* Authentication */,
-                             NULL   /* Cryptograpy    */);
+                             NULL   /* Cryptograpy    */,
+                             NULL);
     if (g_plugins) {
         result = validate_local_identity();
         if (result >= 0) {

--- a/src/security/builtin_plugins/tests/get_permissions_credential_token/src/get_permissions_credential_token_utests.c
+++ b/src/security/builtin_plugins/tests/get_permissions_credential_token/src/get_permissions_credential_token_utests.c
@@ -328,7 +328,7 @@ static void set_path_to_etc_dir(void)
 
 static void suite_get_permissions_credential_token_init(void)
 {
-  plugins = load_plugins(&access_control, &auth, NULL /* Cryptograpy */);
+  plugins = load_plugins(&access_control, &auth, NULL /* Cryptograpy */, NULL);
   CU_ASSERT_FATAL (plugins != NULL);
   set_path_to_etc_dir();
   local_permissions_init(0);

--- a/src/security/builtin_plugins/tests/get_permissions_token/src/get_permissions_token_utests.c
+++ b/src/security/builtin_plugins/tests/get_permissions_token/src/get_permissions_token_utests.c
@@ -287,7 +287,7 @@ static void set_path_to_etc_dir(void)
 
 static void suite_get_permissions_token_init(void)
 {
-  plugins = load_plugins(&access_control, &auth, NULL /* Cryptograpy */);
+  plugins = load_plugins(&access_control, &auth, NULL /* Cryptograpy */, NULL);
   CU_ASSERT_FATAL (plugins != NULL);
   set_path_to_etc_dir();
   local_permissions_init(0);

--- a/src/security/builtin_plugins/tests/get_xxx_sec_attributes/src/get_xxx_sec_attributes_utests.c
+++ b/src/security/builtin_plugins/tests/get_xxx_sec_attributes/src/get_xxx_sec_attributes_utests.c
@@ -414,7 +414,7 @@ static void suite_get_xxx_sec_attributes_fini(void)
 static bool plugins_init(void)
 {
   /* Checking AccessControl, but needing Authentication to setup local identity. */
-  plugins = load_plugins(&access_control, &auth, NULL /* Cryptograpy */);
+  plugins = load_plugins(&access_control, &auth, NULL /* Cryptograpy */, NULL);
   return plugins ? true : false;
 }
 

--- a/src/security/builtin_plugins/tests/listeners_access_control/src/listeners_access_control_utests.c
+++ b/src/security/builtin_plugins/tests/listeners_access_control/src/listeners_access_control_utests.c
@@ -51,8 +51,6 @@ static const char *PERMISSIONS_CA_CERT_FILE = "Test_Permissions_ca.pem";
 static const char *PERMISSIONS_CA_KEY_FILE = "Test_Permissions_ca_key.pem";
 static const char *PERMISSIONS_FILE = "Test_Permissions_listener.p7s";
 static dds_security_access_control_listener ac_listener;
-static struct ddsi_domaingv gv;
-static struct ddsi_tran_conn connection = { .m_base.gv = &gv };
 
 static const char *identity_certificate =
     "data:,-----BEGIN CERTIFICATE-----\n"
@@ -534,19 +532,11 @@ static void set_path_build_dir(void)
 CU_Init(ddssec_builtin_listeners_access_control)
 {
   int res = 0;
-
-  thread_states_init(16);
-
-  gv.xevents = xeventq_new(&connection, 0, 0, 0);
-  gv.handshake_include_optional = true;
-
-  plugins = load_plugins(&access_control, &auth, NULL /* Cryptograpy */, &gv);
+  plugins = load_plugins(&access_control, &auth, NULL /* Cryptograpy */,
+                         &(const struct ddsi_domaingv){ .handshake_include_optional = true });
   if (!plugins) {
-    xeventq_free(gv.xevents);
-    gv.xevents = NULL;
     res = -1;
   } else {
-    xeventq_start(gv.xevents, "TEST_EVENT_QUEUE");
     set_path_to_etc_dir();
     set_path_build_dir();
     dds_openssl_init ();
@@ -558,13 +548,6 @@ CU_Init(ddssec_builtin_listeners_access_control)
 CU_Clean(ddssec_builtin_listeners_access_control)
 {
   unload_plugins(plugins);
-
-  xeventq_stop(gv.xevents);
-  xeventq_free(gv.xevents);
-  gv.xevents = NULL;
-
-  (void)thread_states_fini();
-
   ddsrt_free(g_path_to_etc_dir);
   return 0;
 }

--- a/src/security/builtin_plugins/tests/listeners_authentication/src/listeners_authentication_utests.c
+++ b/src/security/builtin_plugins/tests/listeners_authentication/src/listeners_authentication_utests.c
@@ -53,8 +53,6 @@ static const char * AUTH_KAGREE_ALGO_ECDH_NAME = "ECDH+prime256v1-CEUM";
 static DDS_Security_PermissionsHandle remote_permissions_handle = DDS_SECURITY_HANDLE_NIL;
 static dds_security_authentication_listener auth_listener;
 static dds_security_access_control_listener access_control_listener;
-static struct ddsi_domaingv gv;
-static struct ddsi_tran_conn connection = { .m_base.gv = &gv };
 
 #define IDENTITY_CA_FILE "Identity_CA_Cert.pem"
 #define IDENTITY_CA_KEY_FILE "Identity_CA_Private_Key.pem"
@@ -1102,16 +1100,12 @@ CU_Init(ddssec_builtin_listeners_auth)
     dds_openssl_init ();
     thread_states_init(16);
 
-    gv.xevents = xeventq_new(&connection, 0, 0, 0);
-    gv.handshake_include_optional = true;
-
     plugins = load_plugins(&access_control   /* Access Control */,
                            &auth  /* Authentication */,
                            NULL   /* Cryptograpy    */,
-                           &gv);
+                           &(const struct ddsi_domaingv){ .handshake_include_optional = true });
 
     if (plugins) {
-        xeventq_start(gv.xevents, "TEST_EVENT_QUEUE");
         set_path_build_dir();
         res = set_path_to_etc_dir();
         if (res >= 0) {
@@ -1131,8 +1125,6 @@ CU_Init(ddssec_builtin_listeners_auth)
            invalid_dh_pub_key.data[0] = 0x08;
         }
     } else {
-        xeventq_free(gv.xevents);
-        gv.xevents = NULL;
         res = -1;
     }
 
@@ -1152,12 +1144,6 @@ CU_Clean(ddssec_builtin_listeners_auth)
         EVP_PKEY_free(dh_ecdh_key);
     }
     unload_plugins(plugins);
-
-    xeventq_stop(gv.xevents);
-    xeventq_free(gv.xevents);
-    gv.xevents = NULL;
-
-    (void)thread_states_fini();
 
     ddsrt_free(path_to_etc_dir);
     return 0;

--- a/src/security/builtin_plugins/tests/preprocess_secure_submsg/src/preprocess_secure_submsg_utests.c
+++ b/src/security/builtin_plugins/tests/preprocess_secure_submsg/src/preprocess_secure_submsg_utests.c
@@ -361,7 +361,8 @@ static void suite_preprocess_secure_submsg_init (void)
     CU_ASSERT_FATAL ((plugins = load_plugins(
                             NULL      /* Access Control */,
                             NULL      /* Authentication */,
-                            &crypto   /* Cryptography   */)) != NULL);
+                            &crypto   /* Cryptography   */,
+                            NULL)) != NULL);
     CU_ASSERT_EQUAL_FATAL (register_local_participant(), 0);
     CU_ASSERT_EQUAL_FATAL (register_remote_participant(), 0);
     CU_ASSERT_EQUAL_FATAL (register_local_datawriter(), 0);

--- a/src/security/builtin_plugins/tests/process_handshake/src/process_handshake_utests.c
+++ b/src/security/builtin_plugins/tests/process_handshake/src/process_handshake_utests.c
@@ -992,7 +992,8 @@ CU_Init(ddssec_builtin_process_handshake)
     /* Only need the authentication plugin. */
     plugins = load_plugins(NULL   /* Access Control */,
                            &auth  /* Authentication */,
-                           NULL   /* Cryptograpy    */);
+                           NULL   /* Cryptograpy    */,
+                           NULL);
     if (plugins) {
         result = validate_local_identity( NULL );
         if (result >= 0) {

--- a/src/security/builtin_plugins/tests/process_handshake/src/process_handshake_utests.c
+++ b/src/security/builtin_plugins/tests/process_handshake/src/process_handshake_utests.c
@@ -993,7 +993,7 @@ CU_Init(ddssec_builtin_process_handshake)
     plugins = load_plugins(NULL   /* Access Control */,
                            &auth  /* Authentication */,
                            NULL   /* Cryptograpy    */,
-                           NULL);
+                           &(const struct ddsi_domaingv){ .handshake_include_optional = true });
     if (plugins) {
         result = validate_local_identity( NULL );
         if (result >= 0) {

--- a/src/security/builtin_plugins/tests/register_local_datareader/src/register_local_datareader_utests.c
+++ b/src/security/builtin_plugins/tests/register_local_datareader/src/register_local_datareader_utests.c
@@ -72,7 +72,8 @@ static void suite_register_local_datareader_init(void)
   CU_ASSERT_FATAL((plugins = load_plugins(
                        NULL /* Access Control */,
                        NULL /* Authentication */,
-                       &crypto /* Cryptograpy    */)) != NULL);
+                       &crypto /* Cryptograpy    */,
+                       NULL)) != NULL);
 
   /* prepare test shared secret handle */
   shared_secret_handle_impl = ddsrt_malloc(sizeof(DDS_Security_SharedSecretHandleImpl));

--- a/src/security/builtin_plugins/tests/register_local_datawriter/src/register_local_datawriter_utests.c
+++ b/src/security/builtin_plugins/tests/register_local_datawriter/src/register_local_datawriter_utests.c
@@ -71,7 +71,8 @@ static void suite_register_local_datawriter_init(void)
   CU_ASSERT_FATAL ((plugins = load_plugins(
                         NULL    /* Access Control */,
                         NULL    /* Authentication */,
-                        &crypto /* Cryptograpy    */)) != NULL);
+                        &crypto /* Cryptograpy    */,
+                        NULL)) != NULL);
 
   /* prepare test shared secret handle */
   shared_secret_handle_impl = ddsrt_malloc(sizeof(DDS_Security_SharedSecretHandleImpl));

--- a/src/security/builtin_plugins/tests/register_local_participant/src/register_local_participant_utests.c
+++ b/src/security/builtin_plugins/tests/register_local_participant/src/register_local_participant_utests.c
@@ -37,7 +37,8 @@ static void suite_register_local_participant_init(void)
   CU_ASSERT_FATAL ((plugins = load_plugins(
                       NULL    /* Access Control */,
                       NULL    /* Authentication */,
-                      &crypto /* Cryptograpy    */)) != NULL);
+                      &crypto /* Cryptograpy    */,
+                      NULL)) != NULL);
 }
 
 static void suite_register_local_participant_fini(void)

--- a/src/security/builtin_plugins/tests/register_matched_remote_datareader/src/register_matched_remote_datareader_utests.c
+++ b/src/security/builtin_plugins/tests/register_matched_remote_datareader/src/register_matched_remote_datareader_utests.c
@@ -95,7 +95,8 @@ static void suite_register_matched_remote_datareader_init(void)
   CU_ASSERT_FATAL ((plugins = load_plugins(
                       NULL    /* Access Control */,
                       NULL    /* Authentication */,
-                      &crypto /* Cryptograpy    */)) != NULL);
+                      &crypto /* Cryptograpy    */,
+                      NULL)) != NULL);
   /* prepare test shared secret handle */
   shared_secret_handle_impl = ddsrt_malloc(sizeof(DDS_Security_SharedSecretHandleImpl));
   shared_secret_handle_impl->shared_secret = ddsrt_malloc(TEST_SHARED_SECRET_SIZE * sizeof(DDS_Security_octet));

--- a/src/security/builtin_plugins/tests/register_matched_remote_datawriter/src/register_matched_remote_datawriter_utests.c
+++ b/src/security/builtin_plugins/tests/register_matched_remote_datawriter/src/register_matched_remote_datawriter_utests.c
@@ -93,7 +93,8 @@ static void suite_register_matched_remote_datawriter_init(void)
   CU_ASSERT_FATAL ((plugins = load_plugins(
                       NULL    /* Access Control */,
                       NULL    /* Authentication */,
-                      &crypto /* Cryptograpy    */)) != NULL);
+                      &crypto /* Cryptograpy    */,
+                      NULL)) != NULL);
 
   /* prepare test shared secret handle */
   shared_secret_handle_impl = ddsrt_malloc(sizeof(DDS_Security_SharedSecretHandleImpl));

--- a/src/security/builtin_plugins/tests/register_matched_remote_participant/src/register_matched_remote_participant_utests.c
+++ b/src/security/builtin_plugins/tests/register_matched_remote_participant/src/register_matched_remote_participant_utests.c
@@ -37,7 +37,8 @@ static void suite_register_matched_remote_participant_init(void)
     CU_ASSERT_FATAL ((plugins = load_plugins(
                         NULL      /* Access Control */,
                         NULL      /* Authentication */,
-                        &crypto   /* Cryptograpy    */)) != NULL);
+                        &crypto   /* Cryptograpy    */,
+                        NULL)) != NULL);
 }
 
 static void suite_register_matched_remote_participant_fini(void)

--- a/src/security/builtin_plugins/tests/set_remote_datareader_crypto_tokens/src/set_remote_datareader_crypto_tokens_utests.c
+++ b/src/security/builtin_plugins/tests/set_remote_datareader_crypto_tokens/src/set_remote_datareader_crypto_tokens_utests.c
@@ -201,7 +201,8 @@ static void suite_set_remote_datareader_crypto_tokens_init(void)
   CU_ASSERT_FATAL ((plugins = load_plugins(
                       NULL    /* Access Control */,
                       NULL    /* Authentication */,
-                      &crypto /* Cryptograpy    */)) != NULL);
+                      &crypto /* Cryptograpy    */,
+                      NULL)) != NULL);
   CU_ASSERT_EQUAL_FATAL (register_local_participant(), 0);
   CU_ASSERT_EQUAL_FATAL (register_remote_participant(), 0);
   CU_ASSERT_EQUAL_FATAL (register_local_datawriter(), 0);

--- a/src/security/builtin_plugins/tests/set_remote_datawriter_crypto_tokens/src/set_remote_datawriter_crypto_tokens_utests.c
+++ b/src/security/builtin_plugins/tests/set_remote_datawriter_crypto_tokens/src/set_remote_datawriter_crypto_tokens_utests.c
@@ -189,7 +189,8 @@ static void suite_set_remote_datawriter_crypto_tokens_init(void)
   CU_ASSERT_FATAL ((plugins = load_plugins(
                       NULL    /* Access Control */,
                       NULL    /* Authentication */,
-                      &crypto /* Cryptograpy    */)) != NULL);
+                      &crypto /* Cryptograpy    */,
+                      NULL)) != NULL);
   CU_ASSERT_EQUAL_FATAL (register_local_participant(), 0);
   CU_ASSERT_EQUAL_FATAL (register_remote_participant(), 0);
   CU_ASSERT_EQUAL_FATAL (register_local_datareader(), 0);

--- a/src/security/builtin_plugins/tests/set_remote_participant_crypto_tokens/src/set_remote_participant_crypto_tokens_utests.c
+++ b/src/security/builtin_plugins/tests/set_remote_participant_crypto_tokens/src/set_remote_participant_crypto_tokens_utests.c
@@ -174,7 +174,8 @@ static void suite_set_remote_participant_crypto_tokens_init(void)
   CU_ASSERT_FATAL ((plugins = load_plugins(
                       NULL    /* Access Control */,
                       NULL    /* Authentication */,
-                      &crypto /* Cryptograpy    */)) != NULL);
+                      &crypto /* Cryptograpy    */,
+                      NULL)) != NULL);
   CU_ASSERT_EQUAL_FATAL (register_local_participant(), 0);
   CU_ASSERT_EQUAL_FATAL (register_remote_participant(), 0);
   CU_ASSERT_EQUAL_FATAL (create_crypto_tokens(), 0);

--- a/src/security/builtin_plugins/tests/validate_begin_handshake_reply/src/validate_begin_handshake_reply_utests.c
+++ b/src/security/builtin_plugins/tests/validate_begin_handshake_reply/src/validate_begin_handshake_reply_utests.c
@@ -900,7 +900,8 @@ static void init_testcase(void)
     /* Only need the authentication plugin. */
     plugins = load_plugins(NULL   /* Access Control */,
                            &auth  /* Authentication */,
-                           NULL   /* Cryptograpy    */);
+                           NULL   /* Cryptograpy    */,
+                           NULL);
 
     if (plugins) {
         res = validate_local_identity( NULL );

--- a/src/security/builtin_plugins/tests/validate_begin_handshake_reply/src/validate_begin_handshake_reply_utests.c
+++ b/src/security/builtin_plugins/tests/validate_begin_handshake_reply/src/validate_begin_handshake_reply_utests.c
@@ -901,7 +901,7 @@ static void init_testcase(void)
     plugins = load_plugins(NULL   /* Access Control */,
                            &auth  /* Authentication */,
                            NULL   /* Cryptograpy    */,
-                           NULL);
+                           &(const struct ddsi_domaingv){ .handshake_include_optional = true });
 
     if (plugins) {
         res = validate_local_identity( NULL );

--- a/src/security/builtin_plugins/tests/validate_begin_handshake_request/src/validate_begin_handshake_request_utests.c
+++ b/src/security/builtin_plugins/tests/validate_begin_handshake_request/src/validate_begin_handshake_request_utests.c
@@ -460,7 +460,7 @@ CU_Init(ddssec_builtin_validate_begin_handshake_request)
     plugins = load_plugins(NULL   /* Access Control */,
                            &auth  /* Authentication */,
                            NULL   /* Cryptograpy    */,
-                           NULL);
+                           &(const struct ddsi_domaingv){ .handshake_include_optional = true });
     if (plugins) {
         res = validate_local_identity();
         if (res >= 0) {

--- a/src/security/builtin_plugins/tests/validate_begin_handshake_request/src/validate_begin_handshake_request_utests.c
+++ b/src/security/builtin_plugins/tests/validate_begin_handshake_request/src/validate_begin_handshake_request_utests.c
@@ -459,7 +459,8 @@ CU_Init(ddssec_builtin_validate_begin_handshake_request)
     /* Only need the authentication plugin. */
     plugins = load_plugins(NULL   /* Access Control */,
                            &auth  /* Authentication */,
-                           NULL   /* Cryptograpy    */);
+                           NULL   /* Cryptograpy    */,
+                           NULL);
     if (plugins) {
         res = validate_local_identity();
         if (res >= 0) {

--- a/src/security/builtin_plugins/tests/validate_local_identity/src/validate_local_identity_utests.c
+++ b/src/security/builtin_plugins/tests/validate_local_identity/src/validate_local_identity_utests.c
@@ -411,7 +411,8 @@ CU_Init(ddssec_builtin_validate_local_identity)
     /* Only need the authentication plugin. */
     plugins = load_plugins(NULL   /* Access Control */,
                            &auth  /* Authentication */,
-                           NULL   /* Cryptograpy    */);
+                           NULL   /* Cryptograpy    */,
+                           NULL);
     return plugins ? 0 : -1;
 }
 

--- a/src/security/builtin_plugins/tests/validate_local_permissions/src/validate_local_permissions_utests.c
+++ b/src/security/builtin_plugins/tests/validate_local_permissions/src/validate_local_permissions_utests.c
@@ -434,7 +434,8 @@ static DDS_Security_IdentityHandle test_setup(DDS_Security_Qos *participant_qos)
 
   g_plugins = load_plugins(&g_access_control /* Access Control */,
                            &g_auth /* Authentication */,
-                           NULL /* Cryptograpy    */);
+                           NULL /* Cryptograpy    */,
+                           NULL);
   if (g_plugins)
   {
     CU_ASSERT_FATAL(g_auth != NULL);

--- a/src/security/builtin_plugins/tests/validate_remote_identity/src/validate_remote_identity_utests.c
+++ b/src/security/builtin_plugins/tests/validate_remote_identity/src/validate_remote_identity_utests.c
@@ -415,7 +415,8 @@ CU_Init(ddssec_builtin_validate_remote_identity)
     /* Only need the authentication plugin. */
     plugins = load_plugins(NULL   /* Access Control */,
                            &auth  /* Authentication */,
-                           NULL   /* Cryptograpy    */);
+                           NULL   /* Cryptograpy    */,
+                           NULL);
     if (plugins) {
         res = create_local_identity();
     } else {

--- a/src/security/builtin_plugins/tests/validate_remote_permissions/src/validate_remote_permissions_utests.c
+++ b/src/security/builtin_plugins/tests/validate_remote_permissions/src/validate_remote_permissions_utests.c
@@ -375,7 +375,7 @@ static void set_path_to_etc_dir(void)
 
 static void suite_validate_remote_permissions_init(void)
 {
-  plugins = load_plugins(&access_control, &auth, NULL /* Cryptograpy */);
+  plugins = load_plugins(&access_control, &auth, NULL /* Cryptograpy */, NULL);
   CU_ASSERT_FATAL(plugins != NULL);
   set_path_to_etc_dir();
   validate_local_identity_and_permissions();

--- a/src/security/core/include/dds/security/core/dds_security_timed_cb.h
+++ b/src/security/core/include/dds/security/core/dds_security_timed_cb.h
@@ -109,10 +109,15 @@ DDS_EXPORT void dds_security_timed_dispatcher_enable(struct dds_security_timed_d
  * its kind is DDS_SECURITY_TIMED_CB_KIND_TIMEOUT. DDS_SECURITY_TIMED_CB_KIND_DELETE callbacks
  * will always be triggered despite the dispatcher being possibly disabled.
  *
+ * If it returns true, there will be no further callback invocations until
+ * re-enabled. If it returns false because it was called from multiple
+ * threads at the same time, this is not guaranteed.
+ *
  * @param d             The dispatcher to disable.
  *
+ * @return true if disabled, false if it was already disabled
  */
-DDS_EXPORT void dds_security_timed_dispatcher_disable(struct dds_security_timed_dispatcher *d);
+DDS_EXPORT bool dds_security_timed_dispatcher_disable(struct dds_security_timed_dispatcher *d);
 
 /**
  * Adds a timed callback to a dispatcher.

--- a/src/security/core/include/dds/security/core/dds_security_timed_cb.h
+++ b/src/security/core/include/dds/security/core/dds_security_timed_cb.h
@@ -61,8 +61,9 @@ typedef void (*dds_security_timed_cb_t) (dds_security_time_event_handle_t timer,
  * The dispatcher is not enabled (see dds_security_timed_dispatcher_enable).
  *
  * @return              New (disabled) timed callbacks dispatcher.
+ * @param evq           The event queue used to handle the timers.
  */
-DDS_EXPORT struct dds_security_timed_dispatcher * dds_security_timed_dispatcher_new(void);
+DDS_EXPORT struct dds_security_timed_dispatcher * dds_security_timed_dispatcher_new(struct xeventq *evq);
 
 /**
  * Frees the given dispatcher.
@@ -93,10 +94,9 @@ DDS_EXPORT void dds_security_timed_dispatcher_free(struct dds_security_timed_dis
  * dispatcher being possibly disabled.
  *
  * @param d             The dispatcher to enable.
- * @param evq           The event queue used to handle the timers.
  *
  */
-DDS_EXPORT void dds_security_timed_dispatcher_enable(struct dds_security_timed_dispatcher *d, struct xeventq *evq);
+DDS_EXPORT void dds_security_timed_dispatcher_enable(struct dds_security_timed_dispatcher *d);
 
 /**
  * Disables a dispatcher for timed callbacks.

--- a/src/security/core/src/dds_security_timed_cb.c
+++ b/src/security/core/src/dds_security_timed_cb.c
@@ -19,311 +19,226 @@
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/log.h"
 #include "dds/ddsrt/sync.h"
-#include "dds/ddsrt/threads.h"
 #include "dds/ddsrt/time.h"
+#include "dds/ddsrt/avl.h"
 #include "dds/ddsrt/fibheap.h"
-
 
 #include "dds/security/core/dds_security_timed_cb.h"
 
+#define CHECK_TIMER_INTERVAL DDS_SECS(300) /* 5 minutes */
 
-struct dds_security_timed_dispatcher_t
+struct dds_security_timed_dispatcher
 {
-    bool active;
-    void *listener;
-    ddsrt_fibheap_t events;
+  bool active;
+  bool busy;
+  ddsrt_mutex_t lock;
+  ddsrt_cond_t cond;
+  struct xevent *evt;
+  ddsrt_avl_tree_t events;
+  ddsrt_fibheap_t timers;
+  dds_security_time_event_handle_t next_timer;
 };
 
-struct list_dispatcher_t
+struct dds_security_timed_event
 {
-    struct list_dispatcher_t *next;
-    struct dds_security_timed_dispatcher_t *dispatcher;
+  ddsrt_avl_node_t avlnode;
+  ddsrt_fibheap_node_t heapnode;
+  dds_security_time_event_handle_t handle;
+  dds_security_timed_cb_t callback;
+  dds_time_t trigger_time;
+  void *arg;
 };
 
-struct event_t
-{
-    ddsrt_fibheap_node_t heapnode;
-    dds_security_timed_cb_t callback;
-    dds_time_t trigger_time;
-    void *arg;
-};
-
+static int compare_time_evemt (const void *va, const void *vb);
 static int compare_timed_cb_trigger_time(const void *va, const void *vb);
-static const ddsrt_fibheap_def_t timed_cb_queue_fhdef = DDSRT_FIBHEAPDEF_INITIALIZER(offsetof(struct event_t, heapnode), compare_timed_cb_trigger_time);
+
+static const ddsrt_avl_treedef_t timed_event_treedef = DDSRT_AVL_TREEDEF_INITIALIZER (offsetof (struct dds_security_timed_event, avlnode), offsetof (struct dds_security_timed_event, handle), compare_time_evemt, 0);
+static const ddsrt_fibheap_def_t timed_cb_queue_fhdef = DDSRT_FIBHEAPDEF_INITIALIZER(offsetof(struct dds_security_timed_event, heapnode), compare_timed_cb_trigger_time);
+
+static int compare_time_evemt (const void *va, const void *vb)
+{
+  const dds_security_time_event_handle_t *ha = va;
+  const dds_security_time_event_handle_t *hb = vb;
+
+  return ((*ha > *hb) ? 1 : (*ha < *hb) ?  -1 : 0);
+}
 
 static int compare_timed_cb_trigger_time(const void *va, const void *vb)
 {
-    const struct event_t *a = va;
-    const struct event_t *b = vb;
+    const struct dds_security_timed_event *a = va;
+    const struct dds_security_timed_event *b = vb;
     return (a->trigger_time == b->trigger_time) ? 0 : (a->trigger_time < b->trigger_time) ? -1 : 1;
 }
 
-struct dds_security_timed_cb_data {
-    ddsrt_mutex_t lock;
-    ddsrt_cond_t  cond;
-    struct list_dispatcher_t *first_dispatcher_node;
-    ddsrt_thread_t thread;
-    bool terminate;
-};
+static void timed_event_cb (struct xevent *xev, void *varg, ddsrt_mtime_t tnow);
 
-
-static uint32_t timed_dispatcher_thread(
-        void *tcbv)
+static struct dds_security_timed_event * timed_event_new(dds_security_time_event_handle_t handle, dds_security_timed_cb_t callback, dds_time_t trigger_time, void *arg)
 {
-    struct list_dispatcher_t *dispatcher_node;
-    struct event_t *event;
-    dds_duration_t timeout;
-    dds_duration_t remain_time;
-    struct dds_security_timed_cb_data *tcb = (struct dds_security_timed_cb_data *)tcbv;
+  struct dds_security_timed_event *ev = ddsrt_malloc(sizeof(*ev));
+  ev->handle = handle;
+  ev->callback = callback;
+  ev->trigger_time = trigger_time;
+  ev->arg = arg;
+  return ev;
+}
 
-    ddsrt_mutex_lock(&tcb->lock);
-    do
+static void timed_event_cb (struct xevent *xev, void *arg, ddsrt_mtime_t tnow)
+{
+  struct dds_security_timed_dispatcher *dispatcher = arg;
+  dds_duration_t timeout = CHECK_TIMER_INTERVAL;
+  struct dds_security_timed_event *ev = NULL;
+  dds_duration_t delta = 1;
+
+  DDSRT_UNUSED_ARG(tnow);
+  DDSRT_UNUSED_ARG(xev);
+
+  ddsrt_mutex_lock(&dispatcher->lock);
+
+  if (!dispatcher->active)
+  {
+    ddsrt_mutex_unlock(&dispatcher->lock);
+    return;
+  }
+
+  do {
+    if ((ev = ddsrt_fibheap_min(&timed_cb_queue_fhdef, &dispatcher->timers)) != NULL)
     {
-        remain_time = DDS_INFINITY;
-        for (dispatcher_node = tcb->first_dispatcher_node; dispatcher_node != NULL; dispatcher_node = dispatcher_node->next)
-        {
-            /* Just some sanity checks. */
-            assert(dispatcher_node->dispatcher);
-            if (dispatcher_node->dispatcher->active)
-            {
-                do
-                {
-                    timeout = DDS_INFINITY;
-                    event = ddsrt_fibheap_min(&timed_cb_queue_fhdef, &dispatcher_node->dispatcher->events);
-                    if (event)
-                    {
-                        /* Just some sanity checks. */
-                        assert(event->callback);
-                        /* Determine the trigger timeout of this callback. */
-                        timeout = event->trigger_time - dds_time();
-                        if (timeout <= 0)
-                        {
-                            /* Trigger callback when related dispatcher is active. */
-                            event->callback(dispatcher_node->dispatcher,
-                                            DDS_SECURITY_TIMED_CB_KIND_TIMEOUT,
-                                            dispatcher_node->dispatcher->listener,
-                                            event->arg);
+      delta = ev->trigger_time - dds_time();
+      if (delta > 0 && delta < CHECK_TIMER_INTERVAL)
+        timeout = delta;
+      else if (delta <= 0)
+      {
+        (void)ddsrt_fibheap_extract_min(&timed_cb_queue_fhdef, &dispatcher->timers);
+        ddsrt_avl_delete(&timed_event_treedef, &dispatcher->events, ev);
+        dispatcher->busy = true;
+        ddsrt_mutex_unlock(&dispatcher->lock);
+        ev->callback(ev->handle, ev->trigger_time, DDS_SECURITY_TIMED_CB_KIND_TIMEOUT, ev->arg);
+        ddsrt_mutex_lock(&dispatcher->lock);
+        dispatcher->busy = false;
+        ddsrt_cond_signal(&dispatcher->cond);
+        ddsrt_free(ev);
+      }
+    }
+  } while (ev && delta <= 0);
 
-                            /* Remove handled event from queue, continue with next. */
-                            ddsrt_fibheap_delete(&timed_cb_queue_fhdef, &dispatcher_node->dispatcher->events, event);
-                            ddsrt_free(event);
-                        }
-                        else if (timeout < remain_time)
-                        {
-                            remain_time = timeout;
-                        }
-                    }
-                }
-                while (timeout < 0);
-            }
-        }
-        // tcb->cond condition may be triggered before this thread runs and causes
-        // this waitfor to wait infinity, hence the check of the tcb->terminate
-        if (((remain_time > 0) || (remain_time == DDS_INFINITY)) && !tcb->terminate)
-        {
-            /* Wait for new event, timeout or the end. */
-            (void)ddsrt_cond_waitfor(&tcb->cond, &tcb->lock, remain_time);
-        }
+  if (ev)
+  {
+    ddsrt_mtime_t tsched = ddsrt_mtime_add_duration(ddsrt_time_monotonic(), timeout);
+    (void)resched_xevent_if_earlier(dispatcher->evt, tsched);
+  }
 
-    } while (!tcb->terminate);
-
-    ddsrt_mutex_unlock(&tcb->lock);
-
-    return 0;
+  ddsrt_mutex_unlock(&dispatcher->lock);
 }
 
-struct dds_security_timed_cb_data*
-dds_security_timed_cb_new()
+struct dds_security_timed_dispatcher * dds_security_timed_dispatcher_new(void)
 {
-    struct dds_security_timed_cb_data *tcb = ddsrt_malloc(sizeof(*tcb));
-    dds_return_t osres;
-    ddsrt_threadattr_t attr;
+	struct dds_security_timed_dispatcher *d = ddsrt_malloc(sizeof(*d));
 
-    ddsrt_mutex_init(&tcb->lock);
-    ddsrt_cond_init(&tcb->cond);
-    tcb->first_dispatcher_node = NULL;
-    tcb->terminate = false;
+	d->active = false;
+	d->busy = false;
+	ddsrt_mutex_init (&d->lock);
+	ddsrt_cond_init(&d->cond);
+  ddsrt_avl_init(&timed_event_treedef, &d->events);
+  ddsrt_fibheap_init(&timed_cb_queue_fhdef, &d->timers);
+  d->evt = NULL;
+  d->next_timer = 1;
+  return d;
+}
 
-    ddsrt_threadattr_init(&attr);
-    osres = ddsrt_thread_create(&tcb->thread, "security_dispatcher", &attr, timed_dispatcher_thread, (void*)tcb);
-    if (osres != DDS_RETCODE_OK)
+void dds_security_timed_dispatcher_enable(struct dds_security_timed_dispatcher *d, struct xeventq *evq)
+{
+  ddsrt_mutex_lock(&d->lock);
+  if (!d->active)
+  {
+    struct dds_security_timed_event *ev = ddsrt_fibheap_min(&timed_cb_queue_fhdef, &d->timers);
+    ddsrt_mtime_t tsched = DDSRT_MTIME_NEVER;
+
+    if (ev)
     {
-        DDS_FATAL("Cannot create thread security_dispatcher");
+      dds_duration_t delta = ev->trigger_time - dds_time();
+      if (delta < 0)
+        delta = 0;
+      tsched = ddsrt_mtime_add_duration(ddsrt_time_monotonic(), delta < CHECK_TIMER_INTERVAL ? delta : CHECK_TIMER_INTERVAL);
     }
-
-    return tcb;
-}
-
-void
-dds_security_timed_cb_free(
-        struct dds_security_timed_cb_data *tcb)
-{
-    ddsrt_mutex_lock(&tcb->lock);
-    tcb->terminate = true;
-    ddsrt_mutex_unlock(&tcb->lock);
-    ddsrt_cond_signal(&tcb->cond);
-    ddsrt_thread_join(tcb->thread, NULL);
-
-    ddsrt_cond_destroy(&tcb->cond);
-    ddsrt_mutex_destroy(&tcb->lock);
-    ddsrt_free(tcb);
-}
-
-
-struct dds_security_timed_dispatcher_t*
-dds_security_timed_dispatcher_new(
-        struct dds_security_timed_cb_data *tcb)
-{
-    struct dds_security_timed_dispatcher_t *d;
-    struct list_dispatcher_t *dispatcher_node_new;
-    struct list_dispatcher_t *dispatcher_node_wrk;
-
-    /* New dispatcher. */
-    d = ddsrt_malloc(sizeof(struct dds_security_timed_dispatcher_t));
-    memset(d, 0, sizeof(struct dds_security_timed_dispatcher_t));
-
-    ddsrt_fibheap_init(&timed_cb_queue_fhdef, &d->events);
-
-    dispatcher_node_new = ddsrt_malloc(sizeof(struct list_dispatcher_t));
-    memset(dispatcher_node_new, 0, sizeof(struct list_dispatcher_t));
-    dispatcher_node_new->dispatcher = d;
-
-    ddsrt_mutex_lock(&tcb->lock);
-
-    /* Append to list */
-    if (tcb->first_dispatcher_node) {
-        struct list_dispatcher_t *last = NULL;
-        for (dispatcher_node_wrk = tcb->first_dispatcher_node; dispatcher_node_wrk != NULL; dispatcher_node_wrk = dispatcher_node_wrk->next) {
-            last = dispatcher_node_wrk;
-        }
-        last->next = dispatcher_node_new;
-    } else {
-        /* This new event is the first one. */
-        tcb->first_dispatcher_node = dispatcher_node_new;
-    }
-
-    ddsrt_mutex_unlock(&tcb->lock);
-
-
-    return d;
-}
-
-void
-dds_security_timed_dispatcher_free(
-        struct dds_security_timed_cb_data *tcb,
-        struct dds_security_timed_dispatcher_t *d)
-{
-    struct event_t *event;
-    struct list_dispatcher_t *dispatcher_node;
-    struct list_dispatcher_t *dispatcher_node_prev;
-
-    assert(d);
-
-    /* Remove related events from queue. */
-    ddsrt_mutex_lock(&tcb->lock);
-
-    while((event = ddsrt_fibheap_extract_min(&timed_cb_queue_fhdef, &d->events)) != NULL)
-    {
-        event->callback(d, DDS_SECURITY_TIMED_CB_KIND_DELETE, NULL, event->arg);
-        ddsrt_free(event);
-    }
-
-    /* Remove dispatcher from list */
-    dispatcher_node_prev = NULL;
-    for (dispatcher_node = tcb->first_dispatcher_node; dispatcher_node != NULL; dispatcher_node = dispatcher_node->next)
-    {
-        if (dispatcher_node->dispatcher == d)
-        {
-            /* remove element */
-            if (dispatcher_node_prev != NULL)
-            {
-                dispatcher_node_prev->next = dispatcher_node->next;
-            }
-            else
-            {
-                tcb->first_dispatcher_node = dispatcher_node->next;
-            }
-
-            ddsrt_free(dispatcher_node);
-            break;
-        }
-        dispatcher_node_prev = dispatcher_node;
-    }
-    /* Free this dispatcher. */
-    ddsrt_free(d);
-
-    ddsrt_mutex_unlock(&tcb->lock);
-
-}
-
-
-void
-dds_security_timed_dispatcher_enable(
-        struct dds_security_timed_cb_data *tcb,
-        struct dds_security_timed_dispatcher_t *d,
-        void *listener)
-{
-    assert(d);
-    assert(!(d->active));
-
-    ddsrt_mutex_lock(&tcb->lock);
-
-    /* Remember possible listener and activate. */
-    d->listener = listener;
+    d->evt = qxev_callback (evq, tsched, timed_event_cb, d);
     d->active = true;
-
-    /* Start thread when not running, otherwise wake it up to
-     * trigger callbacks that were (possibly) previously added. */
-    ddsrt_cond_signal(&tcb->cond);
-
-    ddsrt_mutex_unlock(&tcb->lock);
+  }
+  ddsrt_mutex_unlock(&d->lock);
 }
 
-
-void
-dds_security_timed_dispatcher_disable(
-        struct dds_security_timed_cb_data *tcb,
-        struct dds_security_timed_dispatcher_t *d)
+void dds_security_timed_dispatcher_disable(struct dds_security_timed_dispatcher *d)
 {
-    assert(d);
-    assert(d->active);
-
-    ddsrt_mutex_lock(&tcb->lock);
-
-    /* Forget listener and deactivate. */
-    d->listener = NULL;
+  ddsrt_mutex_lock(&d->lock);
+  if (d->active)
+  {
     d->active = false;
-
-    ddsrt_mutex_unlock(&tcb->lock);
+    delete_xevent_callback(d->evt);
+    d->evt = NULL;
+    while (d->busy)
+      (void)ddsrt_cond_wait(&d->cond, &d->lock);
+  }
+  ddsrt_mutex_unlock(&d->lock);
 }
 
-
-void
-dds_security_timed_dispatcher_add(
-        struct dds_security_timed_cb_data *tcb,
-        struct dds_security_timed_dispatcher_t *d,
-        dds_security_timed_cb_t cb,
-        dds_time_t trigger_time,
-        void *arg)
+void dds_security_timed_dispatcher_free(struct dds_security_timed_dispatcher *d)
 {
-    struct event_t *event_new;
+  struct dds_security_timed_event *ev;
 
-    assert(d);
-    assert(cb);
-
-    /* Create event. */
-    event_new = ddsrt_malloc(sizeof(struct event_t));
-    memset(event_new, 0, sizeof(struct event_t));
-    event_new->trigger_time = trigger_time;
-    event_new->callback = cb;
-    event_new->arg = arg;
-
-    /* Insert event based on trigger_time. */
-    ddsrt_mutex_lock(&tcb->lock);
-    ddsrt_fibheap_insert(&timed_cb_queue_fhdef, &d->events, event_new);
-    ddsrt_mutex_unlock(&tcb->lock);
-
-    /* Wake up thread (if it's running). */
-    ddsrt_cond_signal(&tcb->cond);
+  dds_security_timed_dispatcher_disable(d);
+  ev = ddsrt_fibheap_extract_min(&timed_cb_queue_fhdef, &d->timers);
+  while (ev)
+  {
+    ev->callback(ev->handle, ev->trigger_time, DDS_SECURITY_TIMED_CB_KIND_DELETE, ev->arg);
+    ddsrt_free(ev);
+    ev = ddsrt_fibheap_extract_min(&timed_cb_queue_fhdef, &d->timers);
+  }
+  ddsrt_cond_destroy(&d->cond);
+  ddsrt_mutex_destroy(&d->lock);
+  ddsrt_free(d);
 }
 
+dds_security_time_event_handle_t dds_security_timed_dispatcher_add(struct dds_security_timed_dispatcher *d, dds_security_timed_cb_t cb, dds_time_t trigger_time, void *arg)
+{
+  struct dds_security_timed_event *ev;
+  dds_duration_t delta;
+
+  delta = trigger_time - dds_time();
+
+  ddsrt_mutex_lock(&d->lock);
+  ev = timed_event_new(d->next_timer, cb, trigger_time, arg);
+  ddsrt_avl_insert(&timed_event_treedef, &d->events, ev);
+  ddsrt_fibheap_insert(&timed_cb_queue_fhdef, &d->timers, ev);
+  d->next_timer++;
+  if (d->active)
+  {
+    ddsrt_mtime_t tsched = ddsrt_mtime_add_duration(ddsrt_time_monotonic(), delta < CHECK_TIMER_INTERVAL ? delta : CHECK_TIMER_INTERVAL);
+    (void)resched_xevent_if_earlier(d->evt, tsched);
+  }
+  ddsrt_mutex_unlock(&d->lock);
+
+  return ev->handle;
+}
+
+void dds_security_timed_dispatcher_remove(struct dds_security_timed_dispatcher *d, dds_security_time_event_handle_t timer)
+{
+  bool remove = false;
+  struct dds_security_timed_event *ev;
+  ddsrt_avl_dpath_t dpath;
+
+  ddsrt_mutex_lock(&d->lock);
+  ev = ddsrt_avl_lookup_dpath(&timed_event_treedef, &d->events, &timer, &dpath);
+  if (ev)
+  {
+    ddsrt_avl_delete_dpath(&timed_event_treedef, &d->events, ev, &dpath);
+    ddsrt_fibheap_delete(&timed_cb_queue_fhdef, &d->timers, ev);
+    remove = true;
+  }
+  ddsrt_mutex_unlock(&d->lock);
+
+  if (remove)
+  {
+    ev->callback(ev->handle, ev->trigger_time, DDS_SECURITY_TIMED_CB_KIND_DELETE, ev->arg);
+    ddsrt_free(ev);
+  }
+
+}

--- a/src/security/core/src/dds_security_timed_cb.c
+++ b/src/security/core/src/dds_security_timed_cb.c
@@ -25,6 +25,11 @@
 
 #include "dds/security/core/dds_security_timed_cb.h"
 
+// The xevent mechanism runs on the monotonic clock, but certificate expiry
+// times are expressed in terms of wall-clock time.  The wall clock may jump
+// forward or backward, so we rather than wait until the next expiry event,
+// limit the interval between checks so that a certificate expiring because
+// the wall clock jumped forward is detected in a reasonable amount of time.
 #define CHECK_TIMER_INTERVAL DDS_SECS(300) /* 5 minutes */
 
 struct dds_security_timed_dispatcher
@@ -47,31 +52,29 @@ struct dds_security_timed_event
   void *arg;
 };
 
-static int compare_time_event (const void *va, const void *vb);
-static int compare_timed_cb_trigger_time(const void *va, const void *vb);
+static int compare_time_event (const void *va, const void *vb) ddsrt_nonnull_all;
+static int compare_timed_cb_trigger_time (const void *va, const void *vb) ddsrt_nonnull_all;
 
 static const ddsrt_avl_treedef_t timed_event_treedef = DDSRT_AVL_TREEDEF_INITIALIZER (offsetof (struct dds_security_timed_event, avlnode), offsetof (struct dds_security_timed_event, handle), compare_time_event, 0);
-static const ddsrt_fibheap_def_t timed_cb_queue_fhdef = DDSRT_FIBHEAPDEF_INITIALIZER(offsetof(struct dds_security_timed_event, heapnode), compare_timed_cb_trigger_time);
+static const ddsrt_fibheap_def_t timed_cb_queue_fhdef = DDSRT_FIBHEAPDEF_INITIALIZER (offsetof (struct dds_security_timed_event, heapnode), compare_timed_cb_trigger_time);
 
 static int compare_time_event (const void *va, const void *vb)
 {
   const dds_security_time_event_handle_t *ha = va;
   const dds_security_time_event_handle_t *hb = vb;
-  return ((*ha > *hb) ? 1 : (*ha < *hb) ?  -1 : 0);
+  return (*ha > *hb) ? 1 : (*ha < *hb) ? -1 : 0;
 }
 
-static int compare_timed_cb_trigger_time(const void *va, const void *vb)
+static int compare_timed_cb_trigger_time (const void *va, const void *vb)
 {
   const struct dds_security_timed_event *a = va;
   const struct dds_security_timed_event *b = vb;
   return (a->trigger_time == b->trigger_time) ? 0 : (a->trigger_time < b->trigger_time) ? -1 : 1;
 }
 
-static void timed_event_cb (struct xevent *xev, void *varg, ddsrt_mtime_t tnow);
-
-static struct dds_security_timed_event * timed_event_new(dds_security_time_event_handle_t handle, dds_security_timed_cb_t callback, dds_time_t trigger_time, void *arg)
+static struct dds_security_timed_event *timed_event_new (dds_security_time_event_handle_t handle, dds_security_timed_cb_t callback, dds_time_t trigger_time, void *arg)
 {
-  struct dds_security_timed_event *ev = ddsrt_malloc(sizeof(*ev));
+  struct dds_security_timed_event *ev = ddsrt_malloc (sizeof (*ev));
   ev->handle = handle;
   ev->callback = callback;
   ev->trigger_time = trigger_time;
@@ -79,145 +82,160 @@ static struct dds_security_timed_event * timed_event_new(dds_security_time_event
   return ev;
 }
 
-static void timed_event_cb (struct xevent *xev, void *arg, ddsrt_mtime_t tnow)
+static ddsrt_mtime_t calc_tsched (const struct dds_security_timed_event *ev, dds_time_t tnow_wc)
 {
-  struct dds_security_timed_dispatcher *dispatcher = arg;
-  dds_duration_t timeout = CHECK_TIMER_INTERVAL;
-  struct dds_security_timed_event *ev = NULL;
-  dds_duration_t delta = 1;
-
-  DDSRT_UNUSED_ARG(tnow);
-  DDSRT_UNUSED_ARG(xev);
-
-  ddsrt_mutex_lock(&dispatcher->lock);
-
-  do {
-    if ((ev = ddsrt_fibheap_min(&timed_cb_queue_fhdef, &dispatcher->timers)) != NULL)
-    {
-      delta = ev->trigger_time - dds_time();
-      if (delta > 0 && delta < CHECK_TIMER_INTERVAL)
-        timeout = delta;
-      else if (delta <= 0)
-      {
-        (void)ddsrt_fibheap_extract_min(&timed_cb_queue_fhdef, &dispatcher->timers);
-        ddsrt_avl_delete(&timed_event_treedef, &dispatcher->events, ev);
-        ddsrt_mutex_unlock(&dispatcher->lock);
-        ev->callback(ev->handle, ev->trigger_time, DDS_SECURITY_TIMED_CB_KIND_TIMEOUT, ev->arg);
-        ddsrt_mutex_lock(&dispatcher->lock);
-        ddsrt_free(ev);
-      }
-    }
-  } while (ev && delta <= 0);
-
-  if (ev)
+  if (ev == NULL)
+    return DDSRT_MTIME_NEVER;
+  else if (ev->trigger_time < tnow_wc)
+    return ddsrt_time_monotonic ();
+  else
   {
-    ddsrt_mtime_t tsched = ddsrt_mtime_add_duration(ddsrt_time_monotonic(), timeout);
-    (void)resched_xevent_if_earlier(dispatcher->evt, tsched);
+    const dds_duration_t delta = ev->trigger_time - tnow_wc;
+    const dds_duration_t timeout = (delta < CHECK_TIMER_INTERVAL) ? delta : CHECK_TIMER_INTERVAL;
+    return ddsrt_mtime_add_duration (ddsrt_time_monotonic (), timeout);
   }
-
-  ddsrt_mutex_unlock(&dispatcher->lock);
 }
 
-struct dds_security_timed_dispatcher * dds_security_timed_dispatcher_new(struct xeventq *evq)
+static void timed_event_cb (struct xevent *xev, void *arg, ddsrt_mtime_t tnow)
 {
-  struct dds_security_timed_dispatcher *d = ddsrt_malloc(sizeof(*d));
+  struct dds_security_timed_dispatcher * const dispatcher = arg;
+  (void) tnow;
+
+  ddsrt_mutex_lock (&dispatcher->lock);
+  dds_time_t tnow_wc = dds_time ();
+  struct dds_security_timed_event *ev;
+  while ((ev = ddsrt_fibheap_min (&timed_cb_queue_fhdef, &dispatcher->timers)) != NULL && ev->trigger_time < tnow_wc)
+  {
+    (void) ddsrt_fibheap_extract_min (&timed_cb_queue_fhdef, &dispatcher->timers);
+    ddsrt_avl_delete (&timed_event_treedef, &dispatcher->events, ev);
+    ddsrt_mutex_unlock (&dispatcher->lock);
+
+    ev->callback (ev->handle, ev->trigger_time, DDS_SECURITY_TIMED_CB_KIND_TIMEOUT, ev->arg);
+    ddsrt_free (ev);
+
+    ddsrt_mutex_lock (&dispatcher->lock);
+    tnow_wc = dds_time ();
+  }
+  // Note: xev may be different from dispatcher->evt if it is being
+  // disabled (in which case the latter may be a null pointer) or
+  // even a different event (in case it is already being re-enabled),
+  // and so we must use xev.
+  (void) resched_xevent_if_earlier (xev, calc_tsched (ev, tnow_wc));
+  ddsrt_mutex_unlock (&dispatcher->lock);
+}
+
+struct dds_security_timed_dispatcher *dds_security_timed_dispatcher_new (struct xeventq *evq)
+{
+  struct dds_security_timed_dispatcher *d = ddsrt_malloc (sizeof (*d));
   ddsrt_mutex_init (&d->lock);
-  ddsrt_avl_init(&timed_event_treedef, &d->events);
-  ddsrt_fibheap_init(&timed_cb_queue_fhdef, &d->timers);
+  ddsrt_avl_init (&timed_event_treedef, &d->events);
+  ddsrt_fibheap_init (&timed_cb_queue_fhdef, &d->timers);
   d->evq = evq;
   d->evt = NULL;
   d->next_timer = 1;
   return d;
 }
 
-void dds_security_timed_dispatcher_enable(struct dds_security_timed_dispatcher *d)
+void dds_security_timed_dispatcher_enable (struct dds_security_timed_dispatcher *d)
 {
-  ddsrt_mutex_lock(&d->lock);
+  ddsrt_mutex_lock (&d->lock);
   if (d->evt == NULL)
   {
-    struct dds_security_timed_event *ev = ddsrt_fibheap_min(&timed_cb_queue_fhdef, &d->timers);
-    ddsrt_mtime_t tsched = DDSRT_MTIME_NEVER;
-
-    if (ev)
-    {
-      dds_duration_t delta = ev->trigger_time - dds_time();
-      if (delta < 0)
-        delta = 0;
-      tsched = ddsrt_mtime_add_duration(ddsrt_time_monotonic(), delta < CHECK_TIMER_INTERVAL ? delta : CHECK_TIMER_INTERVAL);
-    }
-    d->evt = qxev_callback (d->evq, tsched, timed_event_cb, d);
+    struct dds_security_timed_event const * const ev = ddsrt_fibheap_min (&timed_cb_queue_fhdef, &d->timers);
+    d->evt = qxev_callback (d->evq, calc_tsched (ev, dds_time ()), timed_event_cb, d);
   }
-  ddsrt_mutex_unlock(&d->lock);
+  ddsrt_mutex_unlock (&d->lock);
 }
 
-void dds_security_timed_dispatcher_disable(struct dds_security_timed_dispatcher *d)
+bool dds_security_timed_dispatcher_disable (struct dds_security_timed_dispatcher *d)
 {
-  ddsrt_mutex_lock(&d->lock);
-  if (d->evt != NULL)
-  {
-    delete_xevent_callback(d->evt);
-    d->evt = NULL;
-  }
-  ddsrt_mutex_unlock(&d->lock);
+  // delete_xevent_callback() blocks while a possible concurrent
+  // callback invocation completes, and so disable() can't hold the
+  // dispatcher lock when it calls delete_xevent_callback().
+  //
+  // Two obvious ways of dealing with this are:
+  //
+  // - Protect the "dispatcher->evt" and the existence of a callback
+  //   event field by a separate lock, serializing enable/disable
+  //   calls but without interfering with callback execution.
+  //
+  // - Have just one lock protecting all state (including "evt"),
+  //   but call delete_xevent_callback outside it.  This means
+  //   the callbacks can execute while "evt" is a null pointer,
+  //   and that enable() can be called, installing a new callback
+  //   event while the "old" one is still executing.
+  //
+  //   It also means that for two concurrent calls to disable(),
+  //   one will reset "evt" and wait for the callback to be removed,
+  //   while the one that loses the race may return before the
+  //   callback is removed.
+  //
+  // Having multiple callback events merely leads to a minor amount
+  // of superfluous work, provided they don't depend on "evt", and
+  // the case of two concurrent calls to disable() doesn't seem to
+  // be an issue.  So the second option is sufficient.
+  struct xevent *evt;
+
+  ddsrt_mutex_lock (&d->lock);
+  evt = d->evt;
+  d->evt = NULL;
+  ddsrt_mutex_unlock (&d->lock);
+
+  if (evt != NULL)
+    delete_xevent_callback (evt);
+  return (evt != NULL);
 }
 
-void dds_security_timed_dispatcher_free(struct dds_security_timed_dispatcher *d)
+void dds_security_timed_dispatcher_free (struct dds_security_timed_dispatcher *d)
 {
   struct dds_security_timed_event *ev;
 
-  dds_security_timed_dispatcher_disable(d);
-  ev = ddsrt_fibheap_extract_min(&timed_cb_queue_fhdef, &d->timers);
-  while (ev)
+  // By this time, no other thread may be referencing "d" anymore, and so there
+  // can't be any concurrent calls to enable() or disable().  Therefore, either
+  // d->evt != NULL and the callback exists, or d->evt == NULL and the callback
+  // does not exist.
+  //
+  // Thus, following the call, there will be no callback.
+  (void) dds_security_timed_dispatcher_disable (d);
+
+  while ((ev = ddsrt_fibheap_extract_min (&timed_cb_queue_fhdef, &d->timers)) != NULL)
   {
-    ev->callback(ev->handle, ev->trigger_time, DDS_SECURITY_TIMED_CB_KIND_DELETE, ev->arg);
-    ddsrt_free(ev);
-    ev = ddsrt_fibheap_extract_min(&timed_cb_queue_fhdef, &d->timers);
+    ev->callback (ev->handle, ev->trigger_time, DDS_SECURITY_TIMED_CB_KIND_DELETE, ev->arg);
+    ddsrt_free (ev);
   }
-  ddsrt_mutex_destroy(&d->lock);
-  ddsrt_free(d);
+  ddsrt_mutex_destroy (&d->lock);
+  ddsrt_free (d);
 }
 
-dds_security_time_event_handle_t dds_security_timed_dispatcher_add(struct dds_security_timed_dispatcher *d, dds_security_timed_cb_t cb, dds_time_t trigger_time, void *arg)
+dds_security_time_event_handle_t dds_security_timed_dispatcher_add (struct dds_security_timed_dispatcher *d, dds_security_timed_cb_t cb, dds_time_t trigger_time, void *arg)
 {
-  struct dds_security_timed_event *ev;
-  dds_duration_t delta;
-
-  delta = trigger_time - dds_time();
-
-  ddsrt_mutex_lock(&d->lock);
-  ev = timed_event_new(d->next_timer, cb, trigger_time, arg);
-  ddsrt_avl_insert(&timed_event_treedef, &d->events, ev);
-  ddsrt_fibheap_insert(&timed_cb_queue_fhdef, &d->timers, ev);
+  ddsrt_mutex_lock (&d->lock);
+  struct dds_security_timed_event * const ev = timed_event_new (d->next_timer, cb, trigger_time, arg);
+  ddsrt_avl_insert (&timed_event_treedef, &d->events, ev);
+  ddsrt_fibheap_insert (&timed_cb_queue_fhdef, &d->timers, ev);
   d->next_timer++;
   if (d->evt != NULL)
-  {
-    ddsrt_mtime_t tsched = ddsrt_mtime_add_duration(ddsrt_time_monotonic(), delta < CHECK_TIMER_INTERVAL ? delta : CHECK_TIMER_INTERVAL);
-    (void)resched_xevent_if_earlier(d->evt, tsched);
-  }
-  ddsrt_mutex_unlock(&d->lock);
-
+    (void) resched_xevent_if_earlier (d->evt, calc_tsched (ev, dds_time ()));
+  ddsrt_mutex_unlock (&d->lock);
   return ev->handle;
 }
 
-void dds_security_timed_dispatcher_remove(struct dds_security_timed_dispatcher *d, dds_security_time_event_handle_t timer)
+void dds_security_timed_dispatcher_remove (struct dds_security_timed_dispatcher *d, dds_security_time_event_handle_t timer)
 {
-  bool remove = false;
-  struct dds_security_timed_event *ev;
   ddsrt_avl_dpath_t dpath;
-
-  ddsrt_mutex_lock(&d->lock);
-  ev = ddsrt_avl_lookup_dpath(&timed_event_treedef, &d->events, &timer, &dpath);
-  if (ev)
+  ddsrt_mutex_lock (&d->lock);
+  struct dds_security_timed_event * const ev = ddsrt_avl_lookup_dpath (&timed_event_treedef, &d->events, &timer, &dpath);
+  if (ev == NULL)
   {
-    ddsrt_avl_delete_dpath(&timed_event_treedef, &d->events, ev, &dpath);
-    ddsrt_fibheap_delete(&timed_cb_queue_fhdef, &d->timers, ev);
-    remove = true;
+    // if the timer id doesn't exist anymore, it already expired and this is a no-op
+    ddsrt_mutex_unlock (&d->lock);
   }
-  ddsrt_mutex_unlock(&d->lock);
-
-  if (remove)
+  else
   {
-    ev->callback(ev->handle, ev->trigger_time, DDS_SECURITY_TIMED_CB_KIND_DELETE, ev->arg);
-    ddsrt_free(ev);
+    ddsrt_avl_delete_dpath (&timed_event_treedef, &d->events, ev, &dpath);
+    ddsrt_fibheap_delete (&timed_cb_queue_fhdef, &d->timers, ev);
+    ddsrt_mutex_unlock (&d->lock);
+    ev->callback (ev->handle, ev->trigger_time, DDS_SECURITY_TIMED_CB_KIND_DELETE, ev->arg);
+    ddsrt_free (ev);
   }
 }

--- a/src/security/core/src/dds_security_timed_cb.c
+++ b/src/security/core/src/dds_security_timed_cb.c
@@ -29,10 +29,7 @@
 
 struct dds_security_timed_dispatcher
 {
-  bool active;
-  bool busy;
   ddsrt_mutex_t lock;
-  ddsrt_cond_t cond;
   struct xevent *evt;
   ddsrt_avl_tree_t events;
   ddsrt_fibheap_t timers;
@@ -49,25 +46,24 @@ struct dds_security_timed_event
   void *arg;
 };
 
-static int compare_time_evemt (const void *va, const void *vb);
+static int compare_time_event (const void *va, const void *vb);
 static int compare_timed_cb_trigger_time(const void *va, const void *vb);
 
-static const ddsrt_avl_treedef_t timed_event_treedef = DDSRT_AVL_TREEDEF_INITIALIZER (offsetof (struct dds_security_timed_event, avlnode), offsetof (struct dds_security_timed_event, handle), compare_time_evemt, 0);
+static const ddsrt_avl_treedef_t timed_event_treedef = DDSRT_AVL_TREEDEF_INITIALIZER (offsetof (struct dds_security_timed_event, avlnode), offsetof (struct dds_security_timed_event, handle), compare_time_event, 0);
 static const ddsrt_fibheap_def_t timed_cb_queue_fhdef = DDSRT_FIBHEAPDEF_INITIALIZER(offsetof(struct dds_security_timed_event, heapnode), compare_timed_cb_trigger_time);
 
-static int compare_time_evemt (const void *va, const void *vb)
+static int compare_time_event (const void *va, const void *vb)
 {
   const dds_security_time_event_handle_t *ha = va;
   const dds_security_time_event_handle_t *hb = vb;
-
   return ((*ha > *hb) ? 1 : (*ha < *hb) ?  -1 : 0);
 }
 
 static int compare_timed_cb_trigger_time(const void *va, const void *vb)
 {
-    const struct dds_security_timed_event *a = va;
-    const struct dds_security_timed_event *b = vb;
-    return (a->trigger_time == b->trigger_time) ? 0 : (a->trigger_time < b->trigger_time) ? -1 : 1;
+  const struct dds_security_timed_event *a = va;
+  const struct dds_security_timed_event *b = vb;
+  return (a->trigger_time == b->trigger_time) ? 0 : (a->trigger_time < b->trigger_time) ? -1 : 1;
 }
 
 static void timed_event_cb (struct xevent *xev, void *varg, ddsrt_mtime_t tnow);
@@ -94,12 +90,6 @@ static void timed_event_cb (struct xevent *xev, void *arg, ddsrt_mtime_t tnow)
 
   ddsrt_mutex_lock(&dispatcher->lock);
 
-  if (!dispatcher->active)
-  {
-    ddsrt_mutex_unlock(&dispatcher->lock);
-    return;
-  }
-
   do {
     if ((ev = ddsrt_fibheap_min(&timed_cb_queue_fhdef, &dispatcher->timers)) != NULL)
     {
@@ -110,12 +100,9 @@ static void timed_event_cb (struct xevent *xev, void *arg, ddsrt_mtime_t tnow)
       {
         (void)ddsrt_fibheap_extract_min(&timed_cb_queue_fhdef, &dispatcher->timers);
         ddsrt_avl_delete(&timed_event_treedef, &dispatcher->events, ev);
-        dispatcher->busy = true;
         ddsrt_mutex_unlock(&dispatcher->lock);
         ev->callback(ev->handle, ev->trigger_time, DDS_SECURITY_TIMED_CB_KIND_TIMEOUT, ev->arg);
         ddsrt_mutex_lock(&dispatcher->lock);
-        dispatcher->busy = false;
-        ddsrt_cond_signal(&dispatcher->cond);
         ddsrt_free(ev);
       }
     }
@@ -132,12 +119,8 @@ static void timed_event_cb (struct xevent *xev, void *arg, ddsrt_mtime_t tnow)
 
 struct dds_security_timed_dispatcher * dds_security_timed_dispatcher_new(void)
 {
-	struct dds_security_timed_dispatcher *d = ddsrt_malloc(sizeof(*d));
-
-	d->active = false;
-	d->busy = false;
-	ddsrt_mutex_init (&d->lock);
-	ddsrt_cond_init(&d->cond);
+  struct dds_security_timed_dispatcher *d = ddsrt_malloc(sizeof(*d));
+  ddsrt_mutex_init (&d->lock);
   ddsrt_avl_init(&timed_event_treedef, &d->events);
   ddsrt_fibheap_init(&timed_cb_queue_fhdef, &d->timers);
   d->evt = NULL;
@@ -148,7 +131,7 @@ struct dds_security_timed_dispatcher * dds_security_timed_dispatcher_new(void)
 void dds_security_timed_dispatcher_enable(struct dds_security_timed_dispatcher *d, struct xeventq *evq)
 {
   ddsrt_mutex_lock(&d->lock);
-  if (!d->active)
+  if (d->evt == NULL)
   {
     struct dds_security_timed_event *ev = ddsrt_fibheap_min(&timed_cb_queue_fhdef, &d->timers);
     ddsrt_mtime_t tsched = DDSRT_MTIME_NEVER;
@@ -161,7 +144,6 @@ void dds_security_timed_dispatcher_enable(struct dds_security_timed_dispatcher *
       tsched = ddsrt_mtime_add_duration(ddsrt_time_monotonic(), delta < CHECK_TIMER_INTERVAL ? delta : CHECK_TIMER_INTERVAL);
     }
     d->evt = qxev_callback (evq, tsched, timed_event_cb, d);
-    d->active = true;
   }
   ddsrt_mutex_unlock(&d->lock);
 }
@@ -169,13 +151,10 @@ void dds_security_timed_dispatcher_enable(struct dds_security_timed_dispatcher *
 void dds_security_timed_dispatcher_disable(struct dds_security_timed_dispatcher *d)
 {
   ddsrt_mutex_lock(&d->lock);
-  if (d->active)
+  if (d->evt != NULL)
   {
-    d->active = false;
     delete_xevent_callback(d->evt);
     d->evt = NULL;
-    while (d->busy)
-      (void)ddsrt_cond_wait(&d->cond, &d->lock);
   }
   ddsrt_mutex_unlock(&d->lock);
 }
@@ -192,7 +171,6 @@ void dds_security_timed_dispatcher_free(struct dds_security_timed_dispatcher *d)
     ddsrt_free(ev);
     ev = ddsrt_fibheap_extract_min(&timed_cb_queue_fhdef, &d->timers);
   }
-  ddsrt_cond_destroy(&d->cond);
   ddsrt_mutex_destroy(&d->lock);
   ddsrt_free(d);
 }
@@ -209,7 +187,7 @@ dds_security_time_event_handle_t dds_security_timed_dispatcher_add(struct dds_se
   ddsrt_avl_insert(&timed_event_treedef, &d->events, ev);
   ddsrt_fibheap_insert(&timed_cb_queue_fhdef, &d->timers, ev);
   d->next_timer++;
-  if (d->active)
+  if (d->evt != NULL)
   {
     ddsrt_mtime_t tsched = ddsrt_mtime_add_duration(ddsrt_time_monotonic(), delta < CHECK_TIMER_INTERVAL ? delta : CHECK_TIMER_INTERVAL);
     (void)resched_xevent_if_earlier(d->evt, tsched);
@@ -240,5 +218,4 @@ void dds_security_timed_dispatcher_remove(struct dds_security_timed_dispatcher *
     ev->callback(ev->handle, ev->trigger_time, DDS_SECURITY_TIMED_CB_KIND_DELETE, ev->arg);
     ddsrt_free(ev);
   }
-
 }

--- a/src/security/core/tests/timed_cb.c
+++ b/src/security/core/tests/timed_cb.c
@@ -157,7 +157,7 @@ CU_Test(ddssec_timed_cb, test_enabled_and_disabled, .init = setup, .fini = teard
   dds_security_timed_dispatcher_add(d1, simple_callback, future, (void *)&test_var);
   dds_security_timed_dispatcher_enable(d1);
   CU_ASSERT_FALSE(test_var);
-  dds_security_timed_dispatcher_disable(d1);
+  (void) dds_security_timed_dispatcher_disable(d1);
   dds_sleepfor(DDS_MSECS(500));
   CU_ASSERT_FALSE(test_var);
   dds_sleepfor(DDS_SECS(2));
@@ -246,7 +246,7 @@ CU_Test(ddssec_timed_cb, test_create_dispatcher, .init = setup, .fini = teardown
   dds_sleepfor(DDS_MSECS(300));
   dds_security_timed_dispatcher_enable(d);
   dds_sleepfor(DDS_MSECS(900));
-  dds_security_timed_dispatcher_disable(d);
+  (void) dds_security_timed_dispatcher_disable(d);
 
   if (test_seq_data.index >= test_seq_data.size)
   {

--- a/src/security/core/tests/timed_cb.c
+++ b/src/security/core/tests/timed_cb.c
@@ -122,10 +122,10 @@ CU_Test(ddssec_timed_cb, simple_test, .init = setup, .fini = teardown)
 {
   static bool test_var = false;
   dds_time_t future = dds_time() + DDS_SECS(2);
-  struct dds_security_timed_dispatcher *d1 = dds_security_timed_dispatcher_new();
+  struct dds_security_timed_dispatcher *d1 = dds_security_timed_dispatcher_new(xeventq);
   CU_ASSERT_PTR_NOT_NULL_FATAL(d1);
   dds_security_timed_dispatcher_add(d1, simple_callback, future, (void *)&test_var);
-  dds_security_timed_dispatcher_enable(d1, xeventq);
+  dds_security_timed_dispatcher_enable(d1);
   CU_ASSERT_FALSE_FATAL(test_var);
   dds_sleepfor(DDS_MSECS(500));
   CU_ASSERT_FALSE_FATAL(test_var);
@@ -136,12 +136,12 @@ CU_Test(ddssec_timed_cb, simple_test, .init = setup, .fini = teardown)
 
 CU_Test(ddssec_timed_cb, simple_order, .init = setup, .fini = teardown)
 {
-  struct dds_security_timed_dispatcher *d1 = dds_security_timed_dispatcher_new();
+  struct dds_security_timed_dispatcher *d1 = dds_security_timed_dispatcher_new(xeventq);
   CU_ASSERT_PTR_NOT_NULL_FATAL(d1);
   dds_time_t future = dds_time() + DDS_MSECS(20), future2 = future;
   dds_security_timed_dispatcher_add(d1, order_callback, future, (void *)1);
   dds_security_timed_dispatcher_add(d1, order_callback, future2, (void *)2);
-  dds_security_timed_dispatcher_enable(d1, xeventq);
+  dds_security_timed_dispatcher_enable(d1);
   dds_sleepfor(DDS_MSECS(10));
   dds_security_timed_dispatcher_free(d1);
   CU_ASSERT_EQUAL_FATAL(g_order_callback[0], (void *)1);
@@ -152,10 +152,10 @@ CU_Test(ddssec_timed_cb, test_enabled_and_disabled, .init = setup, .fini = teard
 {
   static bool test_var = false;
   dds_time_t future = dds_time() + DDS_SECS(2);
-  struct dds_security_timed_dispatcher *d1 = dds_security_timed_dispatcher_new();
+  struct dds_security_timed_dispatcher *d1 = dds_security_timed_dispatcher_new(xeventq);
   CU_ASSERT_PTR_NOT_NULL_FATAL(d1);
   dds_security_timed_dispatcher_add(d1, simple_callback, future, (void *)&test_var);
-  dds_security_timed_dispatcher_enable(d1, xeventq);
+  dds_security_timed_dispatcher_enable(d1);
   CU_ASSERT_FALSE(test_var);
   dds_security_timed_dispatcher_disable(d1);
   dds_sleepfor(DDS_MSECS(500));
@@ -169,9 +169,9 @@ CU_Test(ddssec_timed_cb, simple_test_with_future, .init = setup, .fini = teardow
 {
   static bool test_var = false;
   dds_time_t now = dds_time(), future = now + DDS_SECS(2), far_future = now + DDS_SECS(10);
-  struct dds_security_timed_dispatcher *d1 = dds_security_timed_dispatcher_new();
+  struct dds_security_timed_dispatcher *d1 = dds_security_timed_dispatcher_new(xeventq);
   CU_ASSERT_PTR_NOT_NULL_FATAL(d1);
-  dds_security_timed_dispatcher_enable(d1, xeventq);
+  dds_security_timed_dispatcher_enable(d1);
   dds_security_timed_dispatcher_add(d1, simple_callback, future, (void *)&test_var);
   dds_security_timed_dispatcher_add(d1, simple_callback, far_future, (void *)&test_var);
   CU_ASSERT_FALSE_FATAL(test_var);
@@ -186,11 +186,11 @@ CU_Test(ddssec_timed_cb, test_multiple_dispatchers, .init = setup, .fini = teard
 {
   static bool test_var = false;
   dds_time_t now = dds_time(), future = now + DDS_SECS(2), far_future = now + DDS_SECS(10);
-  struct dds_security_timed_dispatcher *d1 = dds_security_timed_dispatcher_new();
-  struct dds_security_timed_dispatcher *d2 = dds_security_timed_dispatcher_new();
+  struct dds_security_timed_dispatcher *d1 = dds_security_timed_dispatcher_new(xeventq);
+  struct dds_security_timed_dispatcher *d2 = dds_security_timed_dispatcher_new(xeventq);
   CU_ASSERT_PTR_NOT_NULL_FATAL(d1);
-  dds_security_timed_dispatcher_enable(d1, xeventq);
-  dds_security_timed_dispatcher_enable(d2, xeventq);
+  dds_security_timed_dispatcher_enable(d1);
+  dds_security_timed_dispatcher_enable(d2);
   dds_security_timed_dispatcher_free(d2);
   dds_security_timed_dispatcher_add(d1, simple_callback, future, (void *)&test_var);
   dds_security_timed_dispatcher_add(d1, simple_callback, far_future, (void *)&test_var);
@@ -228,7 +228,7 @@ CU_Test(ddssec_timed_cb, test_create_dispatcher, .init = setup, .fini = teardown
   struct test_sequence_data test_seq_data = { .size = NUM_TIMERS, .index = 0, .expected = expected, .received = received };
   uint32_t i;
 
-  d = dds_security_timed_dispatcher_new();
+  d = dds_security_timed_dispatcher_new(xeventq);
   CU_ASSERT_PTR_NOT_NULL_FATAL(d);
 
   memset(received, 0, NUM_TIMERS * sizeof(struct test_data));
@@ -244,7 +244,7 @@ CU_Test(ddssec_timed_cb, test_create_dispatcher, .init = setup, .fini = teardown
   /* The sleeps are added to get the timing between 'present' and 'past' callbacks right. */
   printf("before enable\n");
   dds_sleepfor(DDS_MSECS(300));
-  dds_security_timed_dispatcher_enable(d, xeventq);
+  dds_security_timed_dispatcher_enable(d);
   dds_sleepfor(DDS_MSECS(900));
   dds_security_timed_dispatcher_disable(d);
 
@@ -326,7 +326,7 @@ CU_Test(ddssec_timed_cb, test_remove_timer, .init = setup, .fini = teardown)
   struct test_sequence_data test_seq_data = { .size = NUM_TIMERS, .index = 0, .expected = expected, .received = received };
   uint32_t i;
 
-  d = dds_security_timed_dispatcher_new();
+  d = dds_security_timed_dispatcher_new(xeventq);
   CU_ASSERT_PTR_NOT_NULL_FATAL(d);
 
   memset(received, 0, NUM_TIMERS * sizeof(struct test_data));
@@ -339,7 +339,7 @@ CU_Test(ddssec_timed_cb, test_remove_timer, .init = setup, .fini = teardown)
     expected[rank].timer = dds_security_timed_dispatcher_add(d, test_callback, expected[rank].trigger_time, (void *)&test_seq_data);
   }
 
-  dds_security_timed_dispatcher_enable(d, xeventq);
+  dds_security_timed_dispatcher_enable(d);
   dds_sleepfor(DDS_MSECS(500));
 
   dds_security_timed_dispatcher_remove(d, expected[0].timer);


### PR DESCRIPTION
Each instance of the security_timed_dispatcher used a separate thread to schedule the timer events for handling expiry of certificates. This thread is now replaced by using the xeventq.