### PR TITLE
Fix memory leaks with inherited structs

### DIFF
--- a/src/idl/src/parser.y
+++ b/src/idl/src/parser.y
@@ -693,6 +693,7 @@ struct_base_type:
         if (!idl_is_masked(sym->node, IDL_STRUCT) || idl_is_masked(sym->node, IDL_FORWARD))
           ABORT(proc, &@2, "scoped name %s does not resolve to a struct", $2);
         $$ = reference((idl_node_t *)sym->node);
+        free($2);
       }
   |   { $$ = NULL; }
   ;

--- a/src/idl/src/tree.c
+++ b/src/idl/src/tree.c
@@ -285,6 +285,7 @@ bool idl_is_struct(const void *node)
 static void delete_struct(void *node)
 {
   idl_struct_t *n = (idl_struct_t *)node;
+  delete_node(n->base_type);
   delete_node(n->members);
   if (n->identifier)
     free(n->identifier);


### PR DESCRIPTION
Running the tests @reicheratwork wrote for `cyclonedds-cxx` showed a memory leak with struct inheritance. I'm not entirely convinced by the current model, something like region-based memory management might be more suitable, but this fixes the issue.