### PR TITLE
Fix false positive from gcc7.5 not raised by gcc10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -189,7 +189,7 @@ jobs:
       if: type = cron
     - <<: *ubuntu1804_gcc10
       env: [ ARCH=x86_64, BUILD_TYPE=Debug, SSL=YES, SECURITY=YES, LIFESPAN=YES, DEADLINE=YES ]
-    - <<: *ubuntu1804_gcc10
+    - <<: *ubuntu1804_gcc7
       env: [ ARCH=x86_64, BUILD_TYPE=Debug, SSL=YES, SECURITY=YES, LIFESPAN=YES, DEADLINE=YES, CONANFILE=conanfile102.txt ]
     - <<: *ubuntu1804_gcc10
       env: [ ARCH=x86_64, BUILD_TYPE=Release, SSL=YES, SECURITY=YES, LIFESPAN=YES, DEADLINE=YES ]

--- a/src/core/ddsc/tests/cdr.c
+++ b/src/core/ddsc/tests/cdr.c
@@ -161,7 +161,7 @@ static struct ddsi_serdata *sd_from_ser_iov (const struct ddsi_sertopic *tpcmn, 
   off += sizeof (uint32_t);
   sd->data.key = strdup_with_len (base + off, sd->keysz);
   off += sd->keysz;
-  sd->pad0 = ((off % 4) == 0) ? 0 : 4 - (off % 4);
+  sd->pad0 = (uint32_t) (((off % 4) == 0) ? 0 : 4 - (off % 4));
   off += sd->pad0;
   if (kind == SDK_DATA)
   {
@@ -170,7 +170,7 @@ static struct ddsi_serdata *sd_from_ser_iov (const struct ddsi_sertopic *tpcmn, 
     sd->data.value = strdup_with_len (base + off, sd->valuesz);
     off += sd->valuesz;
     // FIXME: not sure if this is still needed, it shouldn't be, but ...
-    sd->pad1 = ((off % 4) == 0) ? 0 : 4 - (off % 4);
+    sd->pad1 = (uint32_t) (((off % 4) == 0) ? 0 : 4 - (off % 4));
   }
   else
   {


### PR DESCRIPTION
GCC seems to be getting better at taking into account the possible ranges of variables when implicit conversions happen. But as gcc 7.5 is not old enough to ignore (and not only because we still use it for Coverity builds) better add an explicit cast.

+ switch one of the non-cron job builds over to gcc 7 as well, otherwise this'll bite us again

Signed-off-by: Erik Boasson <eb@ilities.com>