### PR TITLE
Fixed issue with @key annotations

### DIFF
--- a/src/idl/src/annotation.c
+++ b/src/idl/src/annotation.c
@@ -285,21 +285,26 @@ annotate_key(
   idl_annotation_appl_t *annotation,
   uint32_t *seen)
 {
+  bool key = true;
+
   if (!idl_is_masked(node, IDL_MEMBER)) {
     idl_error(proc, &annotation->node.location,
       "@key can only be applied to struct member declarations");
     return IDL_RETCODE_SEMANTIC_ERROR;
   }
-  if (annotation) {
+  if (annotation->parameters) {
     if (!idl_is_masked(annotation->parameters, IDL_BOOLEAN_LITERAL)) {
       idl_error(proc, &annotation->node.location,
         "@key requires a boolean constant expression");
       return IDL_RETCODE_SEMANTIC_ERROR;
+    } else if (!((idl_literal_t *)annotation->parameters)->value.bln) {
+      key = false;
     }
   }
 
   *seen |= IDL_ANNOTATION_APPL_KEY;
-  node->mask |= IDL_KEY;
+  if (key)
+    node->mask |= IDL_KEY;
   return IDL_RETCODE_OK;
 }
 

--- a/src/tools/idlc/idlc.c
+++ b/src/tools/idlc/idlc.c
@@ -226,7 +226,7 @@ static int32_t idlc_parse(idl_tree_t **treeptr)
   }
 
   if (opts.flags & IDLC_PREPROCESS) {
-    proc.flags |= IDL_WRITE;
+    proc.flags |= IDL_WRITE | IDL_FLAG_ANNOTATIONS;
     mcpp_set_out_func(&idlc_putc, &idlc_puts, &idlc_printf);
     if (mcpp_lib_main(opts.argc, opts.argv) == 0) {
       assert(!(opts.flags & IDLC_COMPILE) || retcode == 0);

--- a/src/tools/idlc/idlc.c
+++ b/src/tools/idlc/idlc.c
@@ -226,7 +226,7 @@ static int32_t idlc_parse(idl_tree_t **treeptr)
   }
 
   if (opts.flags & IDLC_PREPROCESS) {
-    proc.flags |= IDL_WRITE | IDL_FLAG_ANNOTATIONS;
+    proc.flags |= IDL_WRITE | IDL_FLAG_ANNOTATIONS | IDL_FLAG_EXTENDED_DATA_TYPES;
     mcpp_set_out_func(&idlc_putc, &idlc_puts, &idlc_printf);
     if (mcpp_lib_main(opts.argc, opts.argv) == 0) {
       assert(!(opts.flags & IDLC_COMPILE) || retcode == 0);


### PR DESCRIPTION
Fixed issue with @key annotations not correctly showing up in the parsed tree.

Signed-off-by: Martijn Reicher <martijn.reicher@adlinktech.com>