### PR TITLE
Add FreeBSD target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -130,6 +130,18 @@ macos1015_xcode11_6: &macos1015_xcode11_6
   install:
     - python3 -m pip install conan --upgrade --user
 
+freebsd12_clang8: &freebsd12_clang8
+  os: freebsd
+  compiler: clang
+  addons:
+    pkg:
+      packages: [ py37-pip ]
+  before_install:
+    - eval "export BUILD_TOOL_OPTIONS='-j 4'"
+    - eval "export GENERATOR='Unix Makefiles'"
+  install:
+    - pip install conan --upgrade --user
+
 windows1809_vs2017: &windows1809_vs2017
   os: windows
   # Conan will automatically determine the best compiler for a given platform
@@ -213,6 +225,8 @@ jobs:
       env: [ ARCH=x86_64, BUILD_TYPE=Debug, SSL=YES, SECURITY=YES, LIFESPAN=YES, DEADLINE=YES ]
     - <<: *windows1809_vs2017
       env: [ ARCH=x86_64, BUILD_TYPE=Release, SSL=YES, SECURITY=YES, LIFESPAN=YES, DEADLINE=YES ]
+    - <<: *freebsd12_clang8
+      env: [ ARCH=x86_64, BUILD_TYPE=Debug, SSL=NO, SECURITY=NO, LIFESPAN=YES, DEADLINE=YES ]
 
 before_script:
   - conan profile new default --detect

--- a/src/core/ddsi/src/q_radmin.c
+++ b/src/core/ddsi/src/q_radmin.c
@@ -2483,7 +2483,9 @@ static enum dqueue_elem_kind dqueue_elem_kind (const struct nn_rsample_chain_ele
 static uint32_t dqueue_thread (struct nn_dqueue *q)
 {
   struct thread_state1 * const ts1 = lookup_thread_state ();
+#if DDSRT_HAVE_RUSAGE
   struct ddsi_domaingv const * const gv = ddsrt_atomic_ldvoidp (&ts1->gv);
+#endif
   ddsrt_mtime_t next_thread_cputime = { 0 };
   int keepgoing = 1;
   ddsi_guid_t rdguid, *prdguid = NULL;

--- a/src/core/ddsi/src/sysdeps.c
+++ b/src/core/ddsi/src/sysdeps.c
@@ -21,6 +21,7 @@
 #if DDSRT_WITH_FREERTOS || !(defined __APPLE__ || (defined __linux && (defined __GLIBC__ || defined __UCLIBC__))) || (__GNUC__ > 0 && (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) < 40100)
 void log_stacktrace (const struct ddsrt_log_cfg *logcfg, const char *name, ddsrt_thread_t tid)
 {
+  DDSRT_UNUSED_ARG (logcfg);
   DDSRT_UNUSED_ARG (name);
   DDSRT_UNUSED_ARG (tid);
 }

--- a/src/ddsrt/include/dds/ddsrt/threads/posix.h
+++ b/src/ddsrt/include/dds/ddsrt/threads/posix.h
@@ -34,10 +34,10 @@ typedef long int ddsrt_tid_t;
 #define PRIdTID "ld"
 typedef long int ddsrt_thread_list_id_t;
 /* __linux */
-#elif defined(__FreeBSD__) && (__FreeBSD_version >= 900031)
+#elif defined(__FreeBSD__) && (__FreeBSD__ >= 9)
 /* FreeBSD >= 9.0 */
-typedef unsigned long ddsrt_tid_t;
-#define PRIdTID "lu"
+typedef int ddsrt_tid_t;
+#define PRIdTID "d"
 /* __FreeBSD__ */
 #elif defined(__APPLE__) && !(defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && \
                                       __MAC_OS_X_VERSION_MIN_REQUIRED < 1060)

--- a/src/ddsrt/include/dds/ddsrt/threads/posix.h
+++ b/src/ddsrt/include/dds/ddsrt/threads/posix.h
@@ -36,8 +36,8 @@ typedef long int ddsrt_thread_list_id_t;
 /* __linux */
 #elif defined(__FreeBSD__) && (__FreeBSD_version >= 900031)
 /* FreeBSD >= 9.0 */
-typedef int ddsrt_tid_t;
-#define PRIdTID "d"
+typedef unsigned long ddsrt_tid_t;
+#define PRIdTID "lu"
 /* __FreeBSD__ */
 #elif defined(__APPLE__) && !(defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && \
                                       __MAC_OS_X_VERSION_MIN_REQUIRED < 1060)

--- a/src/ddsrt/src/ifaddrs/posix/ifaddrs.c
+++ b/src/ddsrt/src/ifaddrs/posix/ifaddrs.c
@@ -104,8 +104,10 @@ static enum ddsrt_iftype guess_iftype (const struct ifaddrs *sys_ifa)
     switch (IFM_TYPE (ifmr.ifm_active))
     {
       case IFM_ETHER:
+#if !defined __FreeBSD__
       case IFM_TOKEN:
       case IFM_FDDI:
+#endif
         type = DDSRT_IFTYPE_WIRED;
         break;
       case IFM_IEEE80211:

--- a/src/ddsrt/src/ifaddrs/posix/ifaddrs.c
+++ b/src/ddsrt/src/ifaddrs/posix/ifaddrs.c
@@ -79,7 +79,7 @@ static enum ddsrt_iftype guess_iftype (const struct ifaddrs *sys_ifa)
   fclose (fp);
   return type;
 }
-#elif defined __APPLE__ /* probably works for all BSDs */
+#elif defined __APPLE__ || defined __FreeBSD__ /* probably works for all BSDs */
 #include <sys/ioctl.h>
 #include <sys/sockio.h>
 #include <net/if.h>

--- a/src/ddsrt/src/threads/posix/threads.c
+++ b/src/ddsrt/src/threads/posix/threads.c
@@ -332,7 +332,7 @@ ddsrt_gettid(void)
 
 #if defined(__linux)
   tid = syscall(SYS_gettid);
-#elif defined(__FreeBSD__) && (__FreeBSD_version >= 900031)
+#elif defined(__FreeBSD__) && (__FreeBSD__ >= 9)
   /* FreeBSD >= 9.0 */
   tid = pthread_getthreadid_np();
 #elif defined(__APPLE__) && !(defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && \

--- a/src/tools/ddsperf/cputime.c
+++ b/src/tools/ddsperf/cputime.c
@@ -253,6 +253,7 @@ bool record_cputime (struct record_cputime_state *state, const char *prefix, dds
   (void) state;
   (void) prefix;
   (void) tnow;
+  return false;
 }
 
 double record_cputime_read_rss (const struct record_cputime_state *state)
@@ -264,6 +265,7 @@ double record_cputime_read_rss (const struct record_cputime_state *state)
 struct record_cputime_state *record_cputime_new (dds_entity_t wr)
 {
   (void) wr;
+  return NULL;
 }
 
 void record_cputime_free (struct record_cputime_state *state)


### PR DESCRIPTION
For some strange reason I Googled for "FreeBSD CI ... something" again while waiting for the macOS builds to complete and found that Travis gained support for FreeBSD in some forgotten forum thread in some "dark" corner of the web. Anyway, gave it a try, it actually works :slightly_smiling_face: So, without further ado, here is the FreeBSD target and some compiler warning fixes.