### PR TITLE
Added typedef for "struct ser_data" in order to disambiguate an issue in the idlcxx repo that chokes the Windows compiler.

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/ddsi_serdata.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_serdata.h
@@ -43,6 +43,8 @@ struct ddsi_serdata {
   ddsrt_mtime_t twrite; /* write time, not source timestamp, set post-throttling */
 };
 
+typedef struct ddsi_serdata ddsi_serdata_t;
+
 /* Serialised size of sample inclusive of DDSI encoding header
    - uint32_t because the protocol can't handle samples larger than 4GB anyway
    - FIXME: get the encoding header out of the serialised data */


### PR DESCRIPTION

Signed-off-by: Erik Hendriks <erik.hendriks@adlinktech.com>