### PR TITLE
Extend content filters to metadata

### DIFF
--- a/src/core/ddsc/src/dds__types.h
+++ b/src/core/ddsc/src/dds__types.h
@@ -311,8 +311,7 @@ typedef struct dds_topic {
   struct ddsi_sertopic *m_stopic;
   struct dds_ktopic *m_ktopic; /* refc'd, constant */
 
-  dds_topic_filter_arg_fn filter_fn;
-  void *filter_ctx;
+  struct dds_topic_filter m_filter;
 
   /* Status metrics */
 


### PR DESCRIPTION
This adds `dds_set_topic_filter_extended` and `dds_get_topic_filter_extended` which allow selecting from different function prototypes for the filter functions: with or without sample data, and with or without sample info. Note that the filtering interface is unstable and that remains so.

Signed-off-by: Erik Boasson <eb@ilities.com>