### PR TITLE
Check return of dds_register_instance calls

### DIFF
--- a/src/tools/pubsub/pubsub.c
+++ b/src/tools/pubsub/pubsub.c
@@ -1069,7 +1069,7 @@ static void pub_do_auto(const struct writerspec *spec) {
     for (k = 0; (uint32_t) k < nkeyvals; k++) {
         d.seq_keyval.keyval = k;
         if(spec->register_instances) {
-            dds_register_instance(spec->wr, &handle[k], &d);
+            (void) dds_register_instance(spec->wr, &handle[k], &d);
         }
     }
 


### PR DESCRIPTION
CID 309661 in ddsperf: check added.

CID 309662 in pubsub: that program needs a complete rewrite, so casting to "void" is a reasonable choice.

Signed-off-by: Erik Boasson <eb@ilities.com>