### PR TITLE
Added the ability to use idl_identifier() function to obtain the identifier of a const.

### DIFF
--- a/src/idl/include/idl/tree.h
+++ b/src/idl/include/idl/tree.h
@@ -410,6 +410,7 @@ IDL_EXPORT bool idl_is_templ_type(const void *node);
 IDL_EXPORT bool idl_is_sequence(const void *node);
 IDL_EXPORT bool idl_is_string(const void *node);
 IDL_EXPORT bool idl_is_base_type(const void *node);
+IDL_EXPORT bool idl_is_const(const void *node);
 
 IDL_EXPORT bool idl_is_masked(const void *node, idl_mask_t mask);
 IDL_EXPORT const char *idl_identifier(const void *node);

--- a/src/idl/src/tree.c
+++ b/src/idl/src/tree.c
@@ -79,6 +79,8 @@ const char *idl_identifier(const void *node)
     return ((const idl_declarator_t *)node)->name->identifier;
   if (idl_is_forward(node))
     return ((const idl_forward_t *)node)->name->identifier;
+  if (idl_is_const(node))
+    return ((const idl_const_t *)node)->name->identifier;
   return NULL;
 }
 
@@ -1380,6 +1382,22 @@ bool idl_is_base_type(const void *node)
          mask == IDL_DOUBLE ||
          mask == IDL_LDOUBLE);
 #endif
+  return true;
+}
+
+bool idl_is_const(const void *node)
+{
+  if (!idl_is_masked(node, IDL_CONST))
+  {
+    return false;
+#ifndef NDEBUG
+  }
+  else
+  {
+    const idl_const_type_t * const_type = ((const idl_const_t *) node)->type_spec;
+    assert(idl_is_base_type(const_type) || idl_is_string(const_type) || idl_is_enumerator(const_type));
+#endif
+  }
   return true;
 }
 


### PR DESCRIPTION
Because idl_name_t was encapsulated in tree.c, the identifier name cannot be accessed in other source files.
Using the existing idl_identifier() function to access the const identifier seemed the most obvious way to go.

Signed-off-by: Erik Hendriks <erik.hendriks@adlinktech.com>