### PR TITLE
Idl const fixes

### DIFF
--- a/src/idl/src/expression.c
+++ b/src/idl/src/expression.c
@@ -709,8 +709,8 @@ idl_evaluate(
   idl_retcode_t ret;
   idl_constval_t *constval;
 
-  assert(type & (IDL_BASE_TYPE|IDL_ENUMERATOR));
-  type &= (IDL_ENUMERATOR|IDL_BASE_TYPE | (IDL_BASE_TYPE - 1));
+  assert(type & (IDL_BASE_TYPE|IDL_ENUMERATOR|IDL_STRING));
+  type &= (IDL_STRING|IDL_ENUMERATOR|IDL_BASE_TYPE | (IDL_BASE_TYPE - 1));
 
   /* enumerators are referenced */
   if (type == IDL_ENUMERATOR) {
@@ -749,7 +749,15 @@ idl_evaluate(
         "Cannot evaluate '%s' as boolean expression", "<foobar>");
       goto err_eval;
     }
-    constval->value.bln = ((idl_literal_t *) expr)->value.bln;
+    constval->value.bln = ((idl_literal_t *)expr)->value.bln;
+  } else if (type == IDL_STRING) {
+    if (expr->mask != (IDL_STRING_LITERAL|IDL_EXPR)) {
+      idl_error(proc, idl_location(expr),
+        "Cannot evaluate '%s' as string expression", "<foobar>");
+      goto err_eval;
+    }
+    constval->value.str = ((idl_literal_t *)expr)->value.str;
+    ((idl_literal_t *)expr)->value.str = NULL;
   } else {
     assert(0);
   }

--- a/src/idl/src/expression.c
+++ b/src/idl/src/expression.c
@@ -737,14 +737,14 @@ idl_evaluate(
     goto err_alloc;
 
   if (type == IDL_CHAR) {
-    if (expr->mask != IDL_CHAR_LITERAL) {
+    if (expr->mask != (IDL_CHAR_LITERAL|IDL_EXPR)) {
       idl_error(proc, idl_location(expr),
         "Cannot evaluate '%s' as character expression", "<foobar>");
       goto err_eval;
     }
-    constval->value.chr = 'a';//((idl_literal_t *)expr)->value.chr;
+    constval->value.chr = ((idl_literal_t *)expr)->value.chr;
   } else if (type == IDL_BOOL) {
-    if (expr->mask != (IDL_BOOLEAN_LITERAL | IDL_EXPR)) {
+    if (expr->mask != (IDL_BOOLEAN_LITERAL|IDL_EXPR)) {
       idl_error(proc, idl_location(expr),
         "Cannot evaluate '%s' as boolean expression", "<foobar>");
       goto err_eval;

--- a/src/idl/src/parser.y
+++ b/src/idl/src/parser.y
@@ -480,7 +480,6 @@ literal:
       }
   | IDL_TOKEN_CHAR_LITERAL
       { TRY(idl_create_literal(proc, &$$, &@1, IDL_CHAR));
-        fprintf(stderr, "char literal: '%c'\n", $1);
         $$->value.chr = $1;
       }
   | boolean_literal

--- a/src/idl/src/processor.c
+++ b/src/idl/src/processor.c
@@ -266,7 +266,6 @@ idl_parse(idl_processor_t *proc, idl_node_t **nodeptr)
         proc->state = IDL_SCAN;
         break;
       case IDL_TOKEN_IDENTIFIER:
-      case IDL_TOKEN_CHAR_LITERAL:
       case IDL_TOKEN_STRING_LITERAL:
       case IDL_TOKEN_PP_NUMBER:
       case IDL_TOKEN_COMMENT:

--- a/src/idl/src/tree.c
+++ b/src/idl/src/tree.c
@@ -348,7 +348,8 @@ idl_create_const(
   static const idl_mask_t mask = IDL_DECL|IDL_CONST;
 
   assert(idl_is_masked(type_spec, IDL_BASE_TYPE) ||
-         idl_is_masked(type_spec, IDL_ENUM));
+         idl_is_masked(type_spec, IDL_ENUM) ||
+         idl_is_masked(type_spec, IDL_STRING));
 
   ret = idl_create_node(proc, &node, size, mask, location, &delete_const);
   if (ret != IDL_RETCODE_OK)

--- a/src/idl/tests/expression.c
+++ b/src/idl/tests/expression.c
@@ -107,3 +107,24 @@ CU_Test(idl_expression, unary_not_minus)
   expr2.right = (idl_const_expr_t *)&lit;
   test_unary_expr(&expr1, IDL_RETCODE_OK, &var);
 }
+
+CU_Test(idl_expression, const_string)
+{
+  idl_retcode_t ret;
+  idl_tree_t *tree = NULL;
+  idl_const_t *c;
+  idl_constval_t *v;
+
+  const char idl[] = "const string<12> c = \"foo\" \"bar\";";
+
+  ret = idl_parse_string(idl, 0u, &tree);
+  CU_ASSERT_EQUAL_FATAL(ret, IDL_RETCODE_OK);
+  CU_ASSERT_PTR_NOT_NULL_FATAL(tree);
+  c = (idl_const_t *)tree->root;
+  CU_ASSERT_FATAL(idl_is_const(c));
+  v = (idl_constval_t *)c->const_expr;
+  CU_ASSERT_FATAL(idl_is_masked(v, IDL_CONST|IDL_STRING));
+  CU_ASSERT_PTR_NOT_NULL(v->value.str);
+  CU_ASSERT_STRING_EQUAL(v->value.str, "foobar");
+  idl_delete_tree(tree);
+}

--- a/src/idl/tests/expression.c
+++ b/src/idl/tests/expression.c
@@ -108,6 +108,26 @@ CU_Test(idl_expression, unary_not_minus)
   test_unary_expr(&expr1, IDL_RETCODE_OK, &var);
 }
 
+CU_Test(idl_expression, const_char)
+{
+  idl_retcode_t ret;
+  idl_tree_t *tree = NULL;
+  idl_const_t *c;
+  idl_constval_t *v;
+
+  const char idl[] = "const char c = 'f';";
+
+  ret = idl_parse_string(idl, 0u, &tree);
+  CU_ASSERT_EQUAL_FATAL(ret, IDL_RETCODE_OK);
+  CU_ASSERT_PTR_NOT_NULL_FATAL(tree);
+  c = (idl_const_t *)tree->root;
+  CU_ASSERT_FATAL(idl_is_const(c));
+  v = (idl_constval_t *)c->const_expr;
+  CU_ASSERT_FATAL(idl_is_masked(v, IDL_CONST|IDL_CHAR));
+  CU_ASSERT_EQUAL(v->value.chr, 'f');
+  idl_delete_tree(tree);
+}
+
 CU_Test(idl_expression, const_string)
 {
   idl_retcode_t ret;


### PR DESCRIPTION
This PR adds support for `const` `string` declarations and fixes `const` `char` declarations (in the frontend). I've added two small tests to verify it works, but constant expression evaluation is still far from done. I guess that mainly applies to `integer` expressions, but tests are lacking for `floating point` expressions and more exotic `char` and `string` expressions too, so ymmv. I'll probably fix them in one go after I get around to some small redesign in the tree. Reopening of modules comes to mind and it's probably a good idea to expose the scopes to the backends as well. Stay tuned!