### PR TITLE
Fix detection of reopened modules

### DIFF
--- a/src/idl/src/parser.y
+++ b/src/idl/src/parser.y
@@ -981,12 +981,13 @@ static void *push(void *list, void *node)
     return node;
   }
 
-  for (last = list; last->next; last = last->next) {
-    if (last == node) {
-      assert(idl_is_masked(node, IDL_MODULE));
-      return list;
-    }
+  for (last = list; last != node && last->next; last = last->next) ;
+
+  if (last == node) {
+    assert(idl_is_masked(node, IDL_MODULE));
+    return list;
   }
+
   last->next = node;
   ((idl_node_t *)node)->previous = last;
   return list;


### PR DESCRIPTION
Small fix for a rookie mistake :sweat_smile: Last node in the list was looked up by checking if the node had a sibling and the duplicate check was located in that loop, needless to say, the last node was never compared to the node added to the list which resulted in a node pointing towards itself, which caused an infinite loop in the C++ backend. @reicheratwork, care to take a quick look?