### PR TITLE
Import ddsconf when cross compiling

### DIFF
--- a/src/tools/ddsconf/CMakeLists.txt
+++ b/src/tools/ddsconf/CMakeLists.txt
@@ -9,21 +9,30 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
-add_executable(ddsconf
-  ddsconf.c rnc.c md.c xsd.c defconfig.c
-  ${CMAKE_CURRENT_LIST_DIR}/../../core/ddsi/src/q_config.c
-  )
+if(CMAKE_CROSSCOMPILING)
+  find_program(DDSCONF_EXECUTABLE ddsconf REQUIRED)
+  if(NOT DDSCONF_EXECUTABLE)
+    message(FATAL_ERROR "ddsconf not found!")
+  endif()
+  add_executable(ddsconf IMPORTED GLOBAL)
+  set_property(TARGET ddsconf PROPERTY IMPORTED_LOCATION ${DDSCONF_EXECUTABLE})
+else()
+  add_executable(ddsconf
+    ddsconf.c rnc.c md.c xsd.c defconfig.c
+    ${CMAKE_CURRENT_LIST_DIR}/../../core/ddsi/src/q_config.c
+    )
 
-target_link_libraries(ddsconf ddsrt)
+  target_link_libraries(ddsconf ddsrt)
 
-# Windows wants its pound of flesh ...
-generate_dummy_export_header(
-  ddsconf
-  BASE_NAME dds
-  EXPORT_FILE_NAME "${CMAKE_CURRENT_BINARY_DIR}/include/dds/export.h")
+  # Windows wants its pound of flesh ...
+  generate_dummy_export_header(
+    ddsconf
+    BASE_NAME dds
+    EXPORT_FILE_NAME "${CMAKE_CURRENT_BINARY_DIR}/include/dds/export.h")
 
-target_include_directories(ddsconf
-  PRIVATE
-  "${CMAKE_CURRENT_BINARY_DIR}/include"
-  $<BUILD_INTERFACE:$<TARGET_PROPERTY:ddsc,INCLUDE_DIRECTORIES>>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+  target_include_directories(ddsconf
+    PRIVATE
+    "${CMAKE_CURRENT_BINARY_DIR}/include"
+    $<BUILD_INTERFACE:$<TARGET_PROPERTY:ddsc,INCLUDE_DIRECTORIES>>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+endif()


### PR DESCRIPTION
When cross compiling Cyclone, the `ddsconf` executable from the host build should be used when running the target build. The changes in this commit make this possible, by importing the `ddsconf` executable when running a cross compilation build. 
