### PR TITLE
FreeRTOS fix build warnings

### DIFF
--- a/src/core/ddsc/src/dds_rhc_default.c
+++ b/src/core/ddsc/src/dds_rhc_default.c
@@ -1577,7 +1577,7 @@ static bool dds_rhc_default_store (struct ddsi_rhc * __restrict rhc_common, cons
   dds_entity *triggers[MAX_FAST_TRIGGERS];
   size_t ntriggers;
 
-  TRACE ("rhc_store %"PRIx64",%"PRIx64" si %x has_data %d:", tk->m_iid, wr_iid, statusinfo, has_data);
+  TRACE ("rhc_store %"PRIx64",%"PRIx64" si %"PRIx32" has_data %d:", tk->m_iid, wr_iid, statusinfo, has_data);
   if (!has_data && statusinfo == 0)
   {
     /* Write with nothing but a key -- I guess that would be a
@@ -2214,7 +2214,7 @@ static int32_t read_w_qminv (struct dds_rhc_default * __restrict rhc, bool lock,
     ddsrt_mutex_lock (&rhc->lock);
   }
 
-  TRACE ("read_w_qminv(%p,%p,%p,%"PRId32",%x,%"PRIx64",%p) - inst %"PRIu32" nonempty %"PRIu32" disp %"PRIu32" nowr %"PRIu32" new %"PRIu32" samples %"PRIu32"+%"PRIu32" read %"PRIu32"+%"PRIu32"\n",
+  TRACE ("read_w_qminv(%p,%p,%p,%"PRId32",%"PRIx32",%"PRIx64",%p) - inst %"PRIu32" nonempty %"PRIu32" disp %"PRIu32" nowr %"PRIu32" new %"PRIu32" samples %"PRIu32"+%"PRIu32" read %"PRIu32"+%"PRIu32"\n",
     (void *) rhc, (void *) values, (void *) info_seq, max_samples, qminv, handle, (void *) cond,
     rhc->n_instances, rhc->n_nonempty_instances, rhc->n_not_alive_disposed,
     rhc->n_not_alive_no_writers, rhc->n_new, rhc->n_vsamples, rhc->n_invsamples,
@@ -2260,7 +2260,7 @@ static int32_t take_w_qminv (struct dds_rhc_default * __restrict rhc, bool lock,
     ddsrt_mutex_lock (&rhc->lock);
   }
 
-  TRACE ("take_w_qminv(%p,%p,%p,%"PRId32",%x,%"PRIx64",%p) - inst %"PRIu32" nonempty %"PRIu32" disp %"PRIu32" nowr %"PRIu32" new %"PRIu32" samples %"PRIu32"+%"PRIu32" read %"PRIu32"+%"PRIu32"\n",
+  TRACE ("take_w_qminv(%p,%p,%p,%"PRId32",%"PRIx32",%"PRIx64",%p) - inst %"PRIu32" nonempty %"PRIu32" disp %"PRIu32" nowr %"PRIu32" new %"PRIu32" samples %"PRIu32"+%"PRIu32" read %"PRIu32"+%"PRIu32"\n",
     (void*) rhc, (void*) values, (void*) info_seq, max_samples, qminv, handle, (void *) cond,
     rhc->n_instances, rhc->n_nonempty_instances, rhc->n_not_alive_disposed,
     rhc->n_not_alive_no_writers, rhc->n_new, rhc->n_vsamples,

--- a/src/core/ddsc/src/dds_whc_builtintopic.c
+++ b/src/core/ddsc/src/dds_whc_builtintopic.c
@@ -156,14 +156,14 @@ static int bwhc_insert (struct whc *whc, seqno_t max_drop_seq, seqno_t seq, ddsr
   return 0;
 }
 
-static unsigned bwhc_downgrade_to_volatile (struct whc *whc, struct whc_state *st)
+static uint32_t bwhc_downgrade_to_volatile (struct whc *whc, struct whc_state *st)
 {
   (void)whc;
   (void)st;
   return 0;
 }
 
-static unsigned bwhc_remove_acked_messages (struct whc *whc, seqno_t max_drop_seq, struct whc_state *whcst, struct whc_node **deferred_free_list)
+static uint32_t bwhc_remove_acked_messages (struct whc *whc, seqno_t max_drop_seq, struct whc_state *whcst, struct whc_node **deferred_free_list)
 {
   (void)whc;
   (void)max_drop_seq;

--- a/src/core/ddsi/include/dds/ddsi/q_receive.h
+++ b/src/core/ddsi/include/dds/ddsi/q_receive.h
@@ -27,8 +27,8 @@ struct proxy_reader;
 struct nn_gap_info {
   int64_t gapstart;
   int64_t gapend;
-  unsigned gapnumbits;
-  unsigned gapbits[256 / 32];
+  uint32_t gapnumbits;
+  uint32_t gapbits[256 / 32];
 };
 
 void nn_gap_info_init(struct nn_gap_info *gi);

--- a/src/core/ddsi/src/ddsi_pmd.c
+++ b/src/core/ddsi/src/ddsi_pmd.c
@@ -92,7 +92,7 @@ void handle_pmd_message (const struct receiver_state *rst, struct ddsi_serdata *
   struct proxy_participant *proxypp;
   ddsi_guid_t ppguid;
   struct lease *l;
-  RSTTRACE (" PMD ST%x", sample->c.statusinfo);
+  RSTTRACE (" PMD ST%"PRIx32, sample->c.statusinfo);
   switch (sample->c.statusinfo & (NN_STATUSINFO_DISPOSE | NN_STATUSINFO_UNREGISTER))
   {
     case 0: {

--- a/src/core/ddsi/src/ddsi_threadmon.c
+++ b/src/core/ddsi/src/ddsi_threadmon.c
@@ -116,7 +116,7 @@ static uint32_t threadmon_thread (struct ddsi_threadmon *sl)
       {
         tmdom->msgpos +=
           (size_t) snprintf (tmdom->msg + tmdom->msgpos, sizeof (tmdom->msg) - tmdom->msgpos,
-                             " %u(%s):%c:%"PRIx32"->%"PRIx32, i, thread_states.ts[i].name, alive ? 'a' : 'd', sl->av_ary[i].vt, vt);
+                             " %"PRIu32"(%s):%c:%"PRIx32"->%"PRIx32, i, thread_states.ts[i].name, alive ? 'a' : 'd', sl->av_ary[i].vt, vt);
       }
 
       sl->av_ary[i].vt = vt;

--- a/src/core/ddsi/src/q_config.c
+++ b/src/core/ddsi/src/q_config.c
@@ -1281,7 +1281,7 @@ static void pf_maybe_int32 (struct cfgst *cfgst, void *parent, struct cfgelem co
   if (p->isdefault)
     cfg_logelem (cfgst, sources, "default");
   else
-    cfg_logelem (cfgst, sources, "%d", p->value);
+    cfg_logelem (cfgst, sources, "%"PRId32, p->value);
 }
 
 static enum update_result uf_maybe_memsize (struct cfgst *cfgst, void *parent, struct cfgelem const * const cfgelem, UNUSED_ARG (int first), const char *value)
@@ -1371,7 +1371,7 @@ static enum update_result uf_uint (struct cfgst *cfgst, void *parent, struct cfg
 static void pf_uint (struct cfgst *cfgst, void *parent, struct cfgelem const * const cfgelem, uint32_t sources)
 {
   uint32_t const * const p = cfg_address (cfgst, parent, cfgelem);
-  cfg_logelem (cfgst, sources, "%u", *p);
+  cfg_logelem (cfgst, sources, "%"PRIu32, *p);
 }
 
 static enum update_result uf_duration_gen (struct cfgst *cfgst, void *parent, struct cfgelem const * const cfgelem, const char *value, int64_t def_mult, int64_t min_ns, int64_t max_ns)

--- a/src/core/ddsi/src/q_ddsi_discovery.c
+++ b/src/core/ddsi/src/q_ddsi_discovery.c
@@ -653,7 +653,7 @@ static int handle_SPDP_alive (const struct receiver_state *rst, seqno_t seq, dds
   /* Make sure we don't create any security builtin endpoint when it's considered unsecure. */
   if (!is_secure)
     builtin_endpoint_set &= NN_BES_MASK_NON_SECURITY;
-  GVLOGDISC ("SPDP ST0 "PGUIDFMT" bes %x%s NEW", PGUID (datap->participant_guid), builtin_endpoint_set, is_secure ? " (secure)" : "");
+  GVLOGDISC ("SPDP ST0 "PGUIDFMT" bes %"PRIx32"%s NEW", PGUID (datap->participant_guid), builtin_endpoint_set, is_secure ? " (secure)" : "");
 
   if (datap->present & PP_PARTICIPANT_LEASE_DURATION)
   {
@@ -670,7 +670,7 @@ static int handle_SPDP_alive (const struct receiver_state *rst, seqno_t seq, dds
         (datap->adlink_participant_version_info.flags & NN_ADLINK_FL_PARTICIPANT_IS_DDSI2))
       custom_flags |= CF_PARTICIPANT_IS_DDSI2;
 
-    GVLOGDISC (" (0x%08x-0x%08x-0x%08x-0x%08x-0x%08x %s)",
+    GVLOGDISC (" (0x%08"PRIx32"-0x%08"PRIx32"-0x%08"PRIx32"-0x%08"PRIx32"-0x%08"PRIx32" %s)",
                datap->adlink_participant_version_info.version,
                datap->adlink_participant_version_info.flags,
                datap->adlink_participant_version_info.unused[0],
@@ -1362,7 +1362,7 @@ static void handle_SEDP (const struct receiver_state *rst, seqno_t seq, struct d
   if (ddsi_serdata_to_sample (serdata, &decoded_data, NULL, NULL))
   {
     struct ddsi_domaingv * const gv = rst->gv;
-    GVLOGDISC ("SEDP ST%x", serdata->statusinfo);
+    GVLOGDISC ("SEDP ST%"PRIx32, serdata->statusinfo);
     switch (serdata->statusinfo & (NN_STATUSINFO_DISPOSE | NN_STATUSINFO_UNREGISTER))
     {
       case 0:

--- a/src/core/ddsi/src/q_gc.c
+++ b/src/core/ddsi/src/q_gc.c
@@ -37,7 +37,7 @@ struct gcreq_queue {
   struct thread_state1 *ts;
 };
 
-static void threads_vtime_gather_for_wait (const struct ddsi_domaingv *gv, unsigned *nivs, struct idx_vtime *ivs)
+static void threads_vtime_gather_for_wait (const struct ddsi_domaingv *gv, uint32_t *nivs, struct idx_vtime *ivs)
 {
   /* copy vtimes of threads, skipping those that are sleeping */
   uint32_t i, j;

--- a/src/core/ddsi/src/q_receive.c
+++ b/src/core/ddsi/src/q_receive.c
@@ -641,9 +641,8 @@ struct nn_xmsg * nn_gap_info_create_gap(struct writer *wr, struct proxy_reader *
   }
   else
   {
-    unsigned i;
-    ETRACE (wr, " FXGAP%"PRId64"..%"PRId64"/%d:", gi->gapstart, gi->gapend, gi->gapnumbits);
-    for (i = 0; i < gi->gapnumbits; i++)
+    ETRACE (wr, " FXGAP%"PRId64"..%"PRId64"/%"PRIu32":", gi->gapstart, gi->gapend, gi->gapnumbits);
+    for (uint32_t i = 0; i < gi->gapnumbits; i++)
       ETRACE (wr, "%c", nn_bitset_isset (gi->gapnumbits, gi->gapbits, i) ? '1' : '0');
   }
 
@@ -2033,7 +2032,7 @@ static struct ddsi_serdata *remote_make_sample (struct ddsi_tkmap_instance **tk,
       if (gv->logconfig.c.mask & DDS_LC_CONTENT)
         res = ddsi_serdata_print (sample, tmp, sizeof (tmp));
       if (pwr) guid = pwr->e.guid; else memset (&guid, 0, sizeof (guid));
-      GVTRACE ("data(application, vendor %u.%u): "PGUIDFMT" #%"PRId64": ST%x %s/%s:%s%s",
+      GVTRACE ("data(application, vendor %u.%u): "PGUIDFMT" #%"PRId64": ST%"PRIx32" %s/%s:%s%s",
                sampleinfo->rst->vendor.id[0], sampleinfo->rst->vendor.id[1],
                PGUID (guid), sampleinfo->seq, statusinfo, topic->name, topic->type_name,
                tmp, res < sizeof (tmp) - 1 ? "" : "(trunc)");
@@ -3417,7 +3416,7 @@ static void rebuild_local_participant_set (struct thread_state1 * const ts1, str
     qsort (lps->ps, lps->nps, sizeof (*lps->ps), local_participant_cmp);
     lps->nps = (unsigned) dedup_sorted_array (lps->ps, lps->nps, sizeof (*lps->ps), local_participant_cmp);
   }
-  GVTRACE ("  nparticipants %u\n", lps->nps);
+  GVTRACE ("  nparticipants %"PRIu32"\n", lps->nps);
 }
 
 uint32_t listen_thread (struct ddsi_tran_listener *listener)
@@ -3468,12 +3467,12 @@ void trigger_recv_threads (const struct ddsi_domaingv *gv)
         ddsrt_iovec_t iov;
         iov.iov_base = &dummy;
         iov.iov_len = 1;
-        GVTRACE ("trigger_recv_threads: %d single %s\n", i, ddsi_locator_to_string (buf, sizeof (buf), dst));
+        GVTRACE ("trigger_recv_threads: %"PRIu32" single %s\n", i, ddsi_locator_to_string (buf, sizeof (buf), dst));
         ddsi_conn_write (gv->xmit_conn, dst, 1, &iov, 0);
         break;
       }
       case RTM_MANY: {
-        GVTRACE ("trigger_recv_threads: %d many %p\n", i, (void *) gv->recv_threads[i].arg.u.many.ws);
+        GVTRACE ("trigger_recv_threads: %"PRIu32" many %p\n", i, (void *) gv->recv_threads[i].arg.u.many.ws);
         os_sockWaitsetTrigger (gv->recv_threads[i].arg.u.many.ws);
         break;
       }

--- a/src/core/ddsi/src/q_xmsg.c
+++ b/src/core/ddsi/src/q_xmsg.c
@@ -1650,7 +1650,7 @@ int nn_xpack_addmsg (struct nn_xpack *xp, struct nn_xmsg *m, const uint32_t flag
   xp->niov = niov;
 
   const bool rexmit = xp->includes_rexmit || nn_xmsg_is_rexmit (m);
-  const unsigned max_msg_size = rexmit ? xp->gv->config.max_rexmit_msg_size : xp->gv->config.max_msg_size;
+  const uint32_t max_msg_size = rexmit ? xp->gv->config.max_rexmit_msg_size : xp->gv->config.max_msg_size;
   if (xpo_niov > 0 && sz > max_msg_size)
   {
     GVTRACE (" => now niov %d sz %"PRIuSIZE" > max_msg_size %"PRIu32", nn_xpack_send niov %d sz %"PRIu32" now\n",

--- a/src/core/xtests/initsampledeliv/subscriber.c
+++ b/src/core/xtests/initsampledeliv/subscriber.c
@@ -169,7 +169,7 @@ int main (int argc, char ** argv)
   }
   if (tldepth == 0 || endmsg == 0)
     oops ();
-  for (int i = 0; i < 2; i++)
+  for (int32_t i = 0; i < 2; i++)
   {
     if (rd[i] == 0)
       continue;
@@ -187,7 +187,7 @@ int main (int argc, char ** argv)
       /* allow the rare cases where an additional sample was received for volatile data
          (for t-l data, the publisher waits to give so the subscriber can get the data
          in time */
-      printf ("reader %d: first seq %d but refseq %d\n", i, (int) firstmsg[i], refseq);
+      printf ("reader %"PRId32": first seq %"PRId32" but refseq %"PRId32"\n", i, firstmsg[i], refseq);
       oops ();
     }
   }

--- a/src/core/xtests/rhc_torture/rhc_torture.c
+++ b/src/core/xtests/rhc_torture/rhc_torture.c
@@ -311,7 +311,7 @@ static void print_seq (int n, const dds_sample_info_t *iseq, const RhcTypes_T *m
   }
 }
 
-static void rdtkcond (struct dds_rhc *rhc, dds_readcond *cond, const struct check *chk, bool print, int max, const char *opname, int (*op) (struct dds_rhc *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, dds_readcond *cond), uint32_t states_seen[STATIC_ARRAY_DIM 2*2*3][2])
+static void rdtkcond (struct dds_rhc *rhc, dds_readcond *cond, const struct check *chk, bool print, int max, const char *opname, int32_t (*op) (struct dds_rhc *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, dds_readcond *cond), uint32_t states_seen[STATIC_ARRAY_DIM 2*2*3][2])
 {
   int cnt;
 

--- a/src/ddsrt/src/heap/freertos/heap.c
+++ b/src/ddsrt/src/heap/freertos/heap.c
@@ -20,6 +20,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include "dds/ddsrt/heap.h"
 
 static const size_t ofst = sizeof(size_t);
 

--- a/src/tools/pubsub/common.c
+++ b/src/tools/pubsub/common.c
@@ -957,7 +957,7 @@ bool dds_err_check (dds_return_t err, unsigned flags, const char * where)
     if (flags & (DDS_CHECK_REPORT | DDS_CHECK_FAIL))
     {
       char msg[DDS_ERR_MSG_MAX];
-      (void) snprintf (msg, DDS_ERR_MSG_MAX, "Error %"PRId32":M%"PRId32":%s", dds_err_file_id(err), dds_err_line(err), dds_err_str(err));
+      (void) snprintf (msg, DDS_ERR_MSG_MAX, "Error:%s", dds_err_str(err));
       if (flags & DDS_CHECK_REPORT)
       {
         printf ("%s: %s\n", where, msg);


### PR DESCRIPTION
This PR resolves the build warnings in the FreeRTOS build, by using `PRI*32` format specifiers and replacing a few instances of `unsigned` by `uint32_t`. The declaration of `main` is added to avoid the 'no previous prototype' warning in case the main function is wrapped and redefined as `_real_main`.