### PR TITLE
Refactor serdata includes for C++ friendliness

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/ddsi_serdata.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_serdata.h
@@ -12,7 +12,8 @@
 #ifndef DDSI_SERDATA_H
 #define DDSI_SERDATA_H
 
-#include "dds/ddsrt/sockets.h"
+#include "dds/ddsrt/time.h"
+#include "dds/ddsrt/iovec.h"
 #include "dds/ddsi/ddsi_sertopic.h"
 #include "dds/ddsi/ddsi_keyhash.h"
 

--- a/src/core/ddsi/include/dds/ddsi/ddsi_serdata.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_serdata.h
@@ -12,6 +12,7 @@
 #ifndef DDSI_SERDATA_H
 #define DDSI_SERDATA_H
 
+#include "dds/ddsrt/misc.h"
 #include "dds/ddsrt/time.h"
 #include "dds/ddsrt/iovec.h"
 #include "dds/ddsi/ddsi_sertopic.h"
@@ -181,7 +182,15 @@ DDS_EXPORT void ddsi_serdata_init (struct ddsi_serdata *d, const struct ddsi_ser
 DDS_EXPORT struct ddsi_serdata *ddsi_serdata_ref_as_topic (const struct ddsi_sertopic *topic, struct ddsi_serdata *serdata);
 
 DDS_EXPORT inline struct ddsi_serdata *ddsi_serdata_ref (const struct ddsi_serdata *serdata_const) {
+#if defined (__cplusplus)
+  DDSRT_WARNING_GNUC_OFF(old-style-cast)
+  DDSRT_WARNING_CLANG_OFF(old-style-cast)
+#endif
   struct ddsi_serdata *serdata = (struct ddsi_serdata *)serdata_const;
+#if defined (__cplusplus)
+  DDSRT_WARNING_CLANG_ON(old-style-cast)
+  DDSRT_WARNING_GNUC_ON(old-style-cast)
+#endif
   ddsrt_atomic_inc32 (&serdata->refc);
   return serdata;
 }

--- a/src/core/ddsi/include/dds/ddsi/ddsi_tran.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_tran.h
@@ -16,14 +16,14 @@
 
 #include "dds/ddsrt/ifaddrs.h"
 #include "dds/ddsrt/atomics.h"
-#include "dds/ddsi/q_protocol.h"
-#include "dds/ddsi/q_config.h"
+#include "dds/ddsi/ddsi_locator.h"
 
 #if defined (__cplusplus)
 extern "C" {
 #endif
 
 struct nn_interface;
+struct ddsi_domaingv;
 
 /* Types supporting handles */
 
@@ -92,10 +92,9 @@ typedef enum ddsi_locator_from_string_result (*ddsi_locator_from_string_fn_t) (c
 
 typedef char * (*ddsi_locator_to_string_fn_t) (char *dst, size_t sizeof_dst, const ddsi_locator_t *loc, int with_port);
 
-typedef int (*ddsi_enumerate_interfaces_fn_t) (ddsi_tran_factory_t tran, enum ddsi_transport_selector transport_selector, ddsrt_ifaddrs_t **interfs);
+typedef int (*ddsi_enumerate_interfaces_fn_t) (ddsi_tran_factory_t tran, ddsrt_ifaddrs_t **interfs);
 
 /* Data types */
-struct ddsi_domaingv;
 struct ddsi_tran_base
 {
   /* Data */
@@ -282,7 +281,7 @@ DDS_EXPORT enum ddsi_locator_from_string_result ddsi_locator_from_string (const 
 char *ddsi_locator_to_string (char *dst, size_t sizeof_dst, const ddsi_locator_t *loc);
 char *ddsi_locator_to_string_no_port (char *dst, size_t sizeof_dst, const ddsi_locator_t *loc);
 
-int ddsi_enumerate_interfaces (ddsi_tran_factory_t factory, enum ddsi_transport_selector transport_selector, ddsrt_ifaddrs_t **interfs);
+int ddsi_enumerate_interfaces (ddsi_tran_factory_t factory, ddsrt_ifaddrs_t **interfs);
 
 inline int ddsi_listener_locator (ddsi_tran_listener_t listener, ddsi_locator_t *loc) {
   return listener->m_locator_fn (listener->m_factory, &listener->m_base, loc);

--- a/src/core/ddsi/include/dds/ddsi/ddsi_vendor.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_vendor.h
@@ -59,34 +59,34 @@ inline bool vendor_is_eclipse (nn_vendorid_t vendor) {
   return vendor_equals (vendor, x);
 }
 inline bool vendor_is_rti (nn_vendorid_t vendor) {
-  const nn_vendorid_t x = NN_VENDORID (RTI);
+  const nn_vendorid_t x = NN_VENDORID_INIT (RTI);
   return vendor_equals (vendor, x);
 }
 inline bool vendor_is_opensplice (nn_vendorid_t vendor) {
-  const nn_vendorid_t x = NN_VENDORID (ADLINK_OSPL);
+  const nn_vendorid_t x = NN_VENDORID_INIT (ADLINK_OSPL);
   return vendor_equals (vendor, x);
 }
 inline bool vendor_is_twinoaks (nn_vendorid_t vendor) {
-  const nn_vendorid_t x = NN_VENDORID (TWINOAKS);
+  const nn_vendorid_t x = NN_VENDORID_INIT (TWINOAKS);
   return vendor_equals (vendor, x);
 }
 inline bool vendor_is_eprosima (nn_vendorid_t vendor) {
-  const nn_vendorid_t x = NN_VENDORID (EPROSIMA);
+  const nn_vendorid_t x = NN_VENDORID_INIT (EPROSIMA);
   return vendor_equals (vendor, x);
 }
 inline bool vendor_is_cloud (nn_vendorid_t vendor) {
-  const nn_vendorid_t x = NN_VENDORID (ADLINK_CLOUD);
+  const nn_vendorid_t x = NN_VENDORID_INIT (ADLINK_CLOUD);
   return vendor_equals (vendor, x);
 }
 inline bool vendor_is_eclipse_or_opensplice (nn_vendorid_t vendor) {
   return vendor_is_eclipse (vendor) | vendor_is_opensplice (vendor);
 }
 inline bool vendor_is_adlink (nn_vendorid_t vendor) {
-  const nn_vendorid_t a = NN_VENDORID (ADLINK_OSPL);
-  const nn_vendorid_t b = NN_VENDORID (ADLINK_LITE);
-  const nn_vendorid_t c = NN_VENDORID (ADLINK_GATEWAY);
-  const nn_vendorid_t d = NN_VENDORID (ADLINK_JAVA);
-  const nn_vendorid_t e = NN_VENDORID (ADLINK_CLOUD);
+  const nn_vendorid_t a = NN_VENDORID_INIT (ADLINK_OSPL);
+  const nn_vendorid_t b = NN_VENDORID_INIT (ADLINK_LITE);
+  const nn_vendorid_t c = NN_VENDORID_INIT (ADLINK_GATEWAY);
+  const nn_vendorid_t d = NN_VENDORID_INIT (ADLINK_JAVA);
+  const nn_vendorid_t e = NN_VENDORID_INIT (ADLINK_CLOUD);
   return (vendor_equals (vendor, a) ||
           vendor_equals (vendor, b) ||
           vendor_equals (vendor, c) ||

--- a/src/core/ddsi/include/dds/ddsi/ddsi_vendor.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_vendor.h
@@ -39,15 +39,13 @@ typedef struct {
 #define NN_VENDORID_MINOR_ECLIPSE            0x10
 #define NN_VENDORID_MINOR_ADLINK_CLOUD       0x20
 
-#if defined(_WIN32) && defined(__cplusplus)
-#define NN_VENDORID(vendor) {{ 0x01, NN_VENDORID_MINOR_##vendor }}
-#define NN_VENDORID_UNKNOWN {{ 0x00, 0x00 }}
-#else
-#define NN_VENDORID(vendor) ((nn_vendorid_t) {{ 0x01, NN_VENDORID_MINOR_##vendor }})
-#define NN_VENDORID_UNKNOWN ((nn_vendorid_t) {{ 0x00, 0x00 }})
-#endif
+#define NN_VENDORID_INIT(vendor) {{ 0x01, NN_VENDORID_MINOR_##vendor }}
+#define NN_VENDORID_INIT_UNKNOWN {{ 0x00, 0x00 }}
 
-#define NN_VENDORID_ECLIPSE NN_VENDORID (ECLIPSE)
+#define NN_VENDORID(vendor) ((nn_vendorid_t) NN_VENDORID_INIT(vendor))
+#define NN_VENDORID_UNKNOWN ((nn_vendorid_t) NN_VENDORID_INIT_UNKNOWN)
+
+#define NN_VENDORID_ECLIPSE NN_VENDORID(ECLIPSE)
 
 #if defined (__cplusplus)
 extern "C" {
@@ -57,32 +55,43 @@ inline bool vendor_equals (nn_vendorid_t a, nn_vendorid_t b) {
   return ((a.id[0] << 8) | a.id[1]) == ((b.id[0] << 8) | b.id[1]);
 }
 inline bool vendor_is_eclipse (nn_vendorid_t vendor) {
-  return vendor_equals (vendor, NN_VENDORID (ECLIPSE));
+  const nn_vendorid_t x = NN_VENDORID_INIT (ECLIPSE);
+  return vendor_equals (vendor, x);
 }
 inline bool vendor_is_rti (nn_vendorid_t vendor) {
-  return vendor_equals (vendor, NN_VENDORID (RTI));
+  const nn_vendorid_t x = NN_VENDORID (RTI);
+  return vendor_equals (vendor, x);
 }
 inline bool vendor_is_opensplice (nn_vendorid_t vendor) {
-  return vendor_equals (vendor, NN_VENDORID (ADLINK_OSPL));
+  const nn_vendorid_t x = NN_VENDORID (ADLINK_OSPL);
+  return vendor_equals (vendor, x);
 }
 inline bool vendor_is_twinoaks (nn_vendorid_t vendor) {
-  return vendor_equals (vendor, NN_VENDORID (TWINOAKS));
+  const nn_vendorid_t x = NN_VENDORID (TWINOAKS);
+  return vendor_equals (vendor, x);
 }
 inline bool vendor_is_eprosima (nn_vendorid_t vendor) {
-  return vendor_equals (vendor, NN_VENDORID (EPROSIMA));
+  const nn_vendorid_t x = NN_VENDORID (EPROSIMA);
+  return vendor_equals (vendor, x);
 }
 inline bool vendor_is_cloud (nn_vendorid_t vendor) {
-  return vendor_equals (vendor, NN_VENDORID (ADLINK_CLOUD));
+  const nn_vendorid_t x = NN_VENDORID (ADLINK_CLOUD);
+  return vendor_equals (vendor, x);
 }
 inline bool vendor_is_eclipse_or_opensplice (nn_vendorid_t vendor) {
   return vendor_is_eclipse (vendor) | vendor_is_opensplice (vendor);
 }
 inline bool vendor_is_adlink (nn_vendorid_t vendor) {
-  return (vendor_equals (vendor, NN_VENDORID (ADLINK_OSPL)) ||
-          vendor_equals (vendor, NN_VENDORID (ADLINK_LITE)) ||
-          vendor_equals (vendor, NN_VENDORID (ADLINK_GATEWAY)) ||
-          vendor_equals (vendor, NN_VENDORID (ADLINK_JAVA)) ||
-          vendor_equals (vendor, NN_VENDORID (ADLINK_CLOUD)));
+  const nn_vendorid_t a = NN_VENDORID (ADLINK_OSPL);
+  const nn_vendorid_t b = NN_VENDORID (ADLINK_LITE);
+  const nn_vendorid_t c = NN_VENDORID (ADLINK_GATEWAY);
+  const nn_vendorid_t d = NN_VENDORID (ADLINK_JAVA);
+  const nn_vendorid_t e = NN_VENDORID (ADLINK_CLOUD);
+  return (vendor_equals (vendor, a) ||
+          vendor_equals (vendor, b) ||
+          vendor_equals (vendor, c) ||
+          vendor_equals (vendor, d) ||
+          vendor_equals (vendor, e));
 }
 inline bool vendor_is_eclipse_or_adlink (nn_vendorid_t vendor) {
   return vendor_is_eclipse (vendor) || vendor_is_adlink (vendor);

--- a/src/core/ddsi/include/dds/ddsi/q_radmin.h
+++ b/src/core/ddsi/include/dds/ddsi/q_radmin.h
@@ -14,10 +14,12 @@
 
 #include <stddef.h>
 
+#include "dds/ddsrt/time.h"
 #include "dds/ddsrt/atomics.h"
 #include "dds/ddsrt/threads.h"
 #include "dds/ddsrt/static_assert.h"
-#include "dds/ddsi/ddsi_tran.h"
+#include "dds/ddsi/ddsi_locator.h"
+#include "dds/ddsi/q_rtps.h"
 
 #if defined (__cplusplus)
 extern "C" {
@@ -34,6 +36,7 @@ struct nn_defrag;
 struct nn_reorder;
 struct nn_dqueue;
 struct ddsi_guid;
+struct ddsi_tran_conn;
 
 struct proxy_writer;
 
@@ -120,7 +123,7 @@ struct receiver_state {
   uint32_t rtps_encoded:1;                /* - */
   nn_vendorid_t vendor;                   /* 2 */
   nn_protocol_version_t protocol_version; /* 2 => 44/48 */
-  ddsi_tran_conn_t conn;                  /* Connection for request */
+  struct ddsi_tran_conn *conn;            /* Connection for request */
   ddsi_locator_t srcloc;
   struct ddsi_domaingv *gv;
 };
@@ -206,6 +209,10 @@ typedef int32_t nn_reorder_result_t;
 #define NN_REORDER_REJECT       -2 /* caller may reuse memory ("real" reject for data, "fake" for gap) */
 
 typedef void (*nn_dqueue_callback_t) (void *arg);
+
+struct ddsrt_log_cfg;
+struct nn_fragment_number_set_header;
+struct nn_sequence_number_set_header;
 
 struct nn_rbufpool *nn_rbufpool_new (const struct ddsrt_log_cfg *logcfg, uint32_t rbuf_size, uint32_t max_rmsg_size);
 void nn_rbufpool_setowner (struct nn_rbufpool *rbp, ddsrt_thread_t tid);

--- a/src/core/ddsi/src/ddsi_eth.c
+++ b/src/core/ddsi/src/ddsi_eth.c
@@ -10,6 +10,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
 #include "ddsi_eth.h"
+#include "dds/ddsi/q_protocol.h" // for NN_LOCATOR_KIND_...
 
 int ddsi_eth_enumerate_interfaces (ddsi_tran_factory_t fact, ddsrt_ifaddrs_t **ifs)
 {
@@ -18,7 +19,7 @@ int ddsi_eth_enumerate_interfaces (ddsi_tran_factory_t fact, ddsrt_ifaddrs_t **i
     (void)fact;
 
 #if DDSRT_HAVE_IPV6
-    if (fact->m_kind == DDSI_TRANS_TCP6 || fact->m_kind == DDSI_TRANS_UDP6)
+    if (fact->m_kind == NN_LOCATOR_KIND_UDPv6 || fact->m_kind == NN_LOCATOR_KIND_TCPv6)
     {
       afs[0] = AF_INET6;
     }

--- a/src/core/ddsi/src/ddsi_eth.c
+++ b/src/core/ddsi/src/ddsi_eth.c
@@ -11,16 +11,14 @@
  */
 #include "ddsi_eth.h"
 
-int ddsi_eth_enumerate_interfaces (ddsi_tran_factory_t fact, enum ddsi_transport_selector transport_selector, ddsrt_ifaddrs_t **ifs)
+int ddsi_eth_enumerate_interfaces (ddsi_tran_factory_t fact, ddsrt_ifaddrs_t **ifs)
 {
     int afs[] = { AF_INET, DDSRT_AF_TERM };
 
     (void)fact;
-    (void)transport_selector;
 
 #if DDSRT_HAVE_IPV6
-    if (transport_selector == DDSI_TRANS_TCP6 ||
-        transport_selector == DDSI_TRANS_UDP6)
+    if (fact->m_kind == DDSI_TRANS_TCP6 || fact->m_kind == DDSI_TRANS_UDP6)
     {
       afs[0] = AF_INET6;
     }

--- a/src/core/ddsi/src/ddsi_eth.h
+++ b/src/core/ddsi/src/ddsi_eth.h
@@ -19,7 +19,7 @@
 extern "C" {
 #endif
 
-int ddsi_eth_enumerate_interfaces(ddsi_tran_factory_t fact, enum ddsi_transport_selector transport_selector, ddsrt_ifaddrs_t **ifs);
+int ddsi_eth_enumerate_interfaces(ddsi_tran_factory_t fact, ddsrt_ifaddrs_t **ifs);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsi/src/ddsi_ownip.c
+++ b/src/core/ddsi/src/ddsi_ownip.c
@@ -71,7 +71,7 @@ int find_own_ip (struct ddsi_domaingv *gv, const char *requested_address)
 
   {
     int ret;
-    ret = ddsi_enumerate_interfaces(gv->m_factory, gv->config.transport_selector, &ifa_root);
+    ret = ddsi_enumerate_interfaces(gv->m_factory, &ifa_root);
     if (ret < 0) {
       GVERROR ("ddsi_enumerate_interfaces(%s): %d\n", gv->m_factory->m_typename, ret);
       return 0;

--- a/src/core/ddsi/src/ddsi_raweth.c
+++ b/src/core/ddsi/src/ddsi_raweth.c
@@ -348,11 +348,10 @@ static void ddsi_raweth_deinit(ddsi_tran_factory_t fact)
   ddsrt_free (fact);
 }
 
-static int ddsi_raweth_enumerate_interfaces (ddsi_tran_factory_t fact, enum ddsi_transport_selector transport_selector, ddsrt_ifaddrs_t **ifs)
+static int ddsi_raweth_enumerate_interfaces (ddsi_tran_factory_t fact, ddsrt_ifaddrs_t **ifs)
 {
   int afs[] = { AF_PACKET, DDSRT_AF_TERM };
   (void)fact;
-  (void)transport_selector;
   return ddsrt_getifaddrs(ifs, afs);
 }
 

--- a/src/core/ddsi/src/ddsi_tran.c
+++ b/src/core/ddsi/src/ddsi_tran.c
@@ -333,7 +333,7 @@ char *ddsi_locator_to_string_no_port (char *dst, size_t sizeof_dst, const ddsi_l
   return dst;
 }
 
-int ddsi_enumerate_interfaces (ddsi_tran_factory_t factory, enum ddsi_transport_selector transport_selector, ddsrt_ifaddrs_t **interfs)
+int ddsi_enumerate_interfaces (ddsi_tran_factory_t factory, ddsrt_ifaddrs_t **interfs)
 {
-  return factory->m_enumerate_interfaces_fn (factory, transport_selector, interfs);
+  return factory->m_enumerate_interfaces_fn (factory, interfs);
 }

--- a/src/ddsrt/include/dds/ddsrt/atomics/gcc.h
+++ b/src/ddsrt/include/dds/ddsrt/atomics/gcc.h
@@ -17,6 +17,8 @@
 
 #if defined (__cplusplus)
 extern "C" {
+DDSRT_WARNING_GNUC_OFF(old-style-cast)
+DDSRT_WARNING_CLANG_OFF(old-style-cast)
 #endif
 
 #if ( DDSRT_HAVE_ATOMIC64 && __GCC_HAVE_SYNC_COMPARE_AND_SWAP_16) || \
@@ -290,6 +292,8 @@ inline void ddsrt_atomic_fence_rel (void) {
 }
 
 #if defined (__cplusplus)
+DDSRT_WARNING_CLANG_ON(old-style-cast)
+DDSRT_WARNING_GNUC_ON(old-style-cast)
 }
 #endif
 

--- a/src/ddsrt/include/dds/ddsrt/iovec.h
+++ b/src/ddsrt/include/dds/ddsrt/iovec.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright(c) 2020 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#ifndef DDSRT_IOVEC_H
+#define DDSRT_IOVEC_H
+
+#if _WIN32
+typedef unsigned ddsrt_iov_len_t;
+typedef struct ddsrt_iovec {
+  ddsrt_iov_len_t iov_len;
+  void *iov_base;
+} ddsrt_iovec_t;
+
+// Equivalent to a DWORD
+typedef unsigned long ddsrt_msg_iovlen_t;
+
+#else // _WIN32
+
+#include <stddef.h>
+#include <sys/socket.h>
+
+typedef struct iovec ddsrt_iovec_t;
+typedef size_t ddsrt_iov_len_t;
+
+#if defined(__linux) && !LWIP_SOCKET
+typedef size_t ddsrt_msg_iovlen_t;
+#else /* POSIX says int (which macOS, FreeBSD, Solaris do) */
+typedef int ddsrt_msg_iovlen_t;
+#endif
+
+#endif // _WIN32
+
+#endif

--- a/src/ddsrt/include/dds/ddsrt/sockets/posix.h
+++ b/src/ddsrt/include/dds/ddsrt/sockets/posix.h
@@ -24,6 +24,8 @@
 #include <sys/select.h>
 #endif
 
+#include "dds/ddsrt/iovec.h"
+
 #if defined(__cplusplus)
 extern "C" {
 #endif
@@ -65,14 +67,6 @@ typedef int ddsrt_socket_t;
 # define DDSRT_HAVE_INET_PTON   1
 #endif /* LWIP_SOCKET */
 
-typedef struct iovec ddsrt_iovec_t;
-typedef size_t ddsrt_iov_len_t;
-
-#if defined(__linux) && !LWIP_SOCKET
-typedef size_t ddsrt_msg_iovlen_t;
-#else /* POSIX says int (which macOS, FreeBSD, Solaris do) */
-typedef int ddsrt_msg_iovlen_t;
-#endif
 typedef struct msghdr ddsrt_msghdr_t;
 
 #if (defined(__sun) && !defined(_XPG4_2)) || \

--- a/src/ddsrt/include/dds/ddsrt/sockets/windows.h
+++ b/src/ddsrt/include/dds/ddsrt/sockets/windows.h
@@ -3,6 +3,7 @@
 
 #include <winsock2.h>
 #include <ws2tcpip.h>
+#include "dds/ddsrt/iovec.h"
 
 #if defined(__cplusplus)
 extern "C" {
@@ -27,14 +28,6 @@ typedef SOCKET ddsrt_socket_t;
 #endif
 
 #define IFF_POINTOPOINT IFF_POINTTOPOINT
-
-typedef unsigned ddsrt_iov_len_t;
-typedef struct ddsrt_iovec {
-  ddsrt_iov_len_t iov_len;
-  void *iov_base;
-} ddsrt_iovec_t;
-
-typedef DWORD ddsrt_msg_iovlen_t;
 
 typedef struct ddsrt_msghdr {
   void *msg_name;


### PR DESCRIPTION
I think this will make C++ compilers' complaints about C99 constructs that are not also legal C++ in definitions needed for implementing sertopic/serdata go away. I may have missed something, it still needs to be verified with some C++ code. (I imagine that'll be straighforward using the `idlcxx` branch.)
