### PR TITLE
Add dds_forwardcdr for sending unmodified serdata

### DIFF
--- a/src/core/ddsc/include/dds/dds.h
+++ b/src/core/ddsc/include/dds/dds.h
@@ -1958,7 +1958,8 @@ dds_write_flush(dds_entity_t writer);
  * @brief Write a serialized value of a data instance
  *
  * This call causes the writer to write the serialized value that is provided
- * in the serdata argument.
+ * in the serdata argument.  Timestamp and statusinfo fields are set to the
+ * current time and 0 (indicating a regular write), respectively.
  *
  * @param[in]  writer The writer entity.
  * @param[in]  serdata Serialized value to be written.
@@ -1980,6 +1981,33 @@ dds_write_flush(dds_entity_t writer);
  */
 DDS_EXPORT dds_return_t
 dds_writecdr(dds_entity_t writer, struct ddsi_serdata *serdata);
+
+/**
+ * @brief Write a serialized value of a data instance
+ *
+ * This call causes the writer to write the serialized value that is provided
+ * in the serdata argument.  Timestamp and statusinfo are used as is.
+ *
+ * @param[in]  writer The writer entity.
+ * @param[in]  serdata Serialized value to be written.
+ *
+ * @returns A dds_return_t indicating success or failure.
+ *
+ * @retval DDS_RETCODE_OK
+ *             The writer successfully wrote the serialized value.
+ * @retval DDS_RETCODE_ERROR
+ *             An internal error has occurred.
+ * @retval DDS_RETCODE_BAD_PARAMETER
+ *             One of the given arguments is not valid.
+ * @retval DDS_RETCODE_ILLEGAL_OPERATION
+ *             The operation is invoked on an inappropriate object.
+ * @retval DDS_RETCODE_ALREADY_DELETED
+ *             The entity has already been deleted.
+ * @retval DDS_RETCODE_TIMEOUT
+ *             The writer failed to write the serialized value reliably within the specified max_blocking_time.
+ */
+DDS_EXPORT dds_return_t
+dds_forwardcdr(dds_entity_t writer, struct ddsi_serdata *serdata);
 
 /**
  * @brief Write the value of a data instance along with the source timestamp passed.

--- a/src/core/ddsc/src/dds__write.h
+++ b/src/core/ddsc/src/dds__write.h
@@ -30,8 +30,7 @@ typedef enum {
 } dds_write_action;
 
 dds_return_t dds_write_impl (dds_writer *wr, const void *data, dds_time_t tstamp, dds_write_action action);
-dds_return_t dds_writecdr_impl (dds_writer *wr, struct ddsi_serdata *d, dds_time_t tstamp, dds_write_action action);
-dds_return_t dds_writecdr_impl_lowlevel (struct writer *ddsi_wr, struct nn_xpack *xp, struct ddsi_serdata *d, bool flush);
+dds_return_t dds_writecdr_impl (struct writer *ddsi_wr, struct nn_xpack *xp, struct ddsi_serdata *d, bool flush);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsc/src/dds_builtin.c
+++ b/src/core/ddsc/src/dds_builtin.c
@@ -248,7 +248,7 @@ static void dds__builtin_write (const struct entity_common *e, ddsrt_wctime_t ti
         bwr = dom->builtintopic_writer_subscriptions;
         break;
     }
-    dds_writecdr_impl_lowlevel (&bwr->wr, NULL, serdata, true);
+    dds_writecdr_impl (&bwr->wr, NULL, serdata, true);
   }
 }
 


### PR DESCRIPTION
`dds_takecdr` and `dds_readcdr` return a reference to a `ddsi_serdata`, the internal, abstract representation of a sample. One would think one could safely write these again using `dds_writecdr`, but that function (through some accident of history) mimics the regular `dds_write` function and writes the current time and the operation ("write") into it, and so this is not actually such a good idea. It works fine for the case that it originally was supposed to handle ... Secondly, there are no `dds_disposecdr` or `dds_unregistercdr` functions to dispose/unregister data based on such an abstract sample. That is an omission that could easily be fixed by adding these functions.

This PR adds a new function `dds_forwardcdr` (as in "forwarding") that doesn't modify its input. This means (0) that the caller is in full control of timestamp and operation encoded in it, and (1) that it this function can safely be invoked on a `ddsi_serdata` returned by the read/take operations, and thus allows it to be used for forwarding data from a reader to a writer. Hence the name.

(The workaround for this modifying of the input would be to make a copy of the serdata, which is possible with implementation-agnostic code by constructing a new one from the serialised form, but that adds a fair bit of overhead in a place where it, presumably, is undesirable.)

Signed-off-by: Erik Boasson <eb@ilities.com>