### PR TITLE
FIx openssl dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,7 +14,7 @@
 
     <buildtool_depend>cmake</buildtool_depend>
 
-    <depend>openssl</depend>
+    <depend>libssl-dev</depend>
     <test_depend>libcunit-dev</test_depend>
 
     <doc_depend>doxygen</doc_depend>

--- a/package.xml
+++ b/package.xml
@@ -14,7 +14,10 @@
 
     <buildtool_depend>cmake</buildtool_depend>
 
-    <depend>libssl-dev</depend>
+    <build_depend>libssl-dev</build_depend>
+
+    <exec_depend>openssl</exec_depend>
+
     <test_depend>libcunit-dev</test_depend>
 
     <doc_depend>doxygen</doc_depend>


### PR DESCRIPTION
the openssl package provides only the openssl executable and not the development libraries/headers this results in the `ros-foxy-cyclonedds` package to not contain the security plugins.
From http://build.ros2.org/view/Fbin_uF64/job/Fbin_uF64__cyclonedds__ubuntu_focal_amd64__binary/13:
"Could NOT find OpenSSL, try to set the path to OpenSSL root folder in the system variable OPENSSL_ROOT_DIR (missing: OPENSSL_CRYPTO_LIBRARY OPENSSL_INCLUDE_DIR)"

This PR declares a depenency on`libssl-dev` that is providing those.

Should fix https://github.com/ros2/ros2/issues/1051
Would need to be backported to the 0.7.x branch and released into foxy 