### PR TITLE
Make security_core and ddsrt interface libraries with imported global…

### DIFF
--- a/cmake/Modules/Packaging.cmake
+++ b/cmake/Modules/Packaging.cmake
@@ -37,15 +37,13 @@ install(
         "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Version.cmake"
   DESTINATION "${CMAKE_INSTALL_CMAKEDIR}" COMPONENT dev)
 
-if((NOT DEFINED BUILD_SHARED_LIBS) OR BUILD_SHARED_LIBS)
-  # Generates <Package>Targets.cmake file included by <Package>Config.cmake.
-  # The files are placed in CMakeFiles/Export in the build tree.
-  install(
-    EXPORT "${PROJECT_NAME}"
-    FILE "${PROJECT_NAME}Targets.cmake"
-    NAMESPACE "${PROJECT_NAME}::"
-    DESTINATION "${CMAKE_INSTALL_CMAKEDIR}" COMPONENT dev)
-endif()
+# Generates <Package>Targets.cmake file included by <Package>Config.cmake.
+# The files are placed in CMakeFiles/Export in the build tree.
+install(
+  EXPORT "${PROJECT_NAME}"
+  FILE "${PROJECT_NAME}Targets.cmake"
+  NAMESPACE "${PROJECT_NAME}::"
+  DESTINATION "${CMAKE_INSTALL_CMAKEDIR}" COMPONENT dev)
 
 
 set(CPACK_PACKAGE_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})

--- a/src/ddsrt/CMakeLists.txt
+++ b/src/ddsrt/CMakeLists.txt
@@ -75,7 +75,7 @@ endif()
 # 3.12. At the time of this writing most long-term stable distributions still
 # ship an older version, so an interface library with public sources is used
 # as a workaround for now.
-add_library(ddsrt INTERFACE)
+add_library(ddsrt INTERFACE IMPORTED GLOBAL)
 
 foreach(opt WITH_LWIP WITH_DNS WITH_FREERTOS)
   if(${opt})

--- a/src/security/core/CMakeLists.txt
+++ b/src/security/core/CMakeLists.txt
@@ -33,7 +33,7 @@ if(NOT WIN32)
   set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC" )
 endif()
 
-add_library(security_core INTERFACE)
+add_library(security_core INTERFACE IMPORTED GLOBAL)
 
 target_sources(security_core INTERFACE ${srcs_security_core})
 


### PR DESCRIPTION
Connect to https://github.com/eclipse-cyclonedds/cyclonedds/issues/317

Can not static build rmw_cyclonedds_cpp due to lack of CycloneDDSTargets.cmake. This is caused by interface libraries (security_core and ddsrt) are interface targets and are not exported. This pull request is to solve exporting interface targets in CycloneDDS.

The tested command : 
```
colcon build --build-base build-static --install-base install-static --packages-ignore rosidl_generator_py rosidl_typesupport_c rosidl_typesupport_cpp --packages-ignore-regex .*fastrtps.* .*connext.* --cmake-args -DBUILD_SHARED_LIBS=OFF --no-warn-unused-cli -DBUILD_TESTING=OFF --packages-up-to rcl
```