### PR TITLE
Backport 631: Fix openssl dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,7 +14,10 @@
 
     <buildtool_depend>cmake</buildtool_depend>
 
-    <depend>openssl</depend>
+    <build_depend>libssl-dev</build_depend>
+
+    <exec_depend>openssl</exec_depend>
+
     <test_depend>libcunit-dev</test_depend>
 
     <doc_depend>doxygen</doc_depend>


### PR DESCRIPTION
Backport of #631 for release into Foxy

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>