### PR TITLE
Compile-time options via CMake-written features.h

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,6 +28,8 @@ endif()
 option(ENABLE_SECURITY "Enable OMG DDS Security support" ON)
 option(ENABLE_LIFESPAN "Enable Lifespan QoS support" ON)
 option(ENABLE_DEADLINE_MISSED "Enable Deadline Missed QoS support" ON)
+option(ENABLE_NETWORK_PARTITIONS "Enable network partition support" ON)
+option(ENABLE_SOURCE_SPECIFIC_MULTICAST "Enable support for source-specific multicast" ON)
 if(ENABLE_SECURITY)
   set(DDS_HAS_SECURITY "1")
 endif()
@@ -37,9 +39,15 @@ endif()
 if(ENABLE_DEADLINE_MISSED)
   set(DDS_HAS_DEADLINE_MISSED "1")
 endif()
-configure_file(features.h.in "${CMAKE_CURRENT_BINARY_DIR}/core/include/dds/features.h")
-
-add_definitions(-DDDSI_INCLUDE_NETWORK_PARTITIONS -DDDSI_INCLUDE_SSM)
+if(ENABLE_NETWORK_PARTITIONS)
+  set(DDS_HAS_NETWORK_PARTITIONS "1")
+endif()
+if(ENABLE_SOURCE_SPECIFIC_MULTICAST)
+  set(DDS_HAS_SSM "1")
+endif()
+# ones that linger in the sources
+# - DDS_HAS_BANDWIDTH_LIMITING
+# - DDS_HAS_NETWORK_CHANNELS
 
 # OpenSSL is huge, raising the RSS by 1MB or so, and moreover find_package(OpenSSL) causes
 # trouble on some older CMake versions that otherwise work fine, so provide an option to avoid
@@ -53,31 +61,21 @@ if(NOT DDSC_ENABLE_OPENSSL)
   message(ERROR "DDSC_ENABLE_OPENSSL is deprecated, please use ENABLE_SSL instead")
   set(ENABLE_SSL OFF)
 endif()
-
 if(ENABLE_SSL)
   find_package(OpenSSL)
   if(OPENSSL_FOUND)
-    add_definitions(-DDDSI_INCLUDE_SSL)
+    set(DDS_HAS_SSL "1")
     message(STATUS "Building with OpenSSL support")
   else()
     message(STATUS "Building without OpenSSL support")
   endif()
 endif()
 
-# Support the OMG DDS Security within ddsc adds quite a bit of code.
 if(NOT ENABLE_SECURITY)
   message(STATUS "Building without OMG DDS Security support")
-else()
-  add_definitions(-DDDSI_INCLUDE_SECURITY)
 endif()
 
-if(ENABLE_LIFESPAN)
-  add_definitions(-DDDSI_INCLUDE_LIFESPAN)
-endif()
-
-if(ENABLE_DEADLINE_MISSED)
-  add_definitions(-DDDSI_INCLUDE_DEADLINE_MISSED)
-endif()
+configure_file(features.h.in "${CMAKE_CURRENT_BINARY_DIR}/core/include/dds/features.h")
 
 add_subdirectory(ddsrt)
 

--- a/src/core/ddsc/src/dds__rhc_default.h
+++ b/src/core/ddsc/src/dds__rhc_default.h
@@ -12,6 +12,8 @@
 #ifndef _DDS_RHC_DEFAULT_H_
 #define _DDS_RHC_DEFAULT_H_
 
+#include "dds/features.h"
+
 #if defined (__cplusplus)
 extern "C" {
 #endif
@@ -25,10 +27,10 @@ struct rhc_sample;
 
 DDS_EXPORT struct dds_rhc *dds_rhc_default_new_xchecks (dds_reader *reader, struct ddsi_domaingv *gv, const struct ddsi_sertopic *topic, bool xchecks);
 DDS_EXPORT struct dds_rhc *dds_rhc_default_new (struct dds_reader *reader, const struct ddsi_sertopic *topic);
-#ifdef DDSI_INCLUDE_LIFESPAN
+#ifdef DDS_HAS_LIFESPAN
 DDS_EXPORT ddsrt_mtime_t dds_rhc_default_sample_expired_cb(void *hc, ddsrt_mtime_t tnow);
 #endif
-#ifdef DDSI_INCLUDE_DEADLINE_MISSED
+#ifdef DDS_HAS_DEADLINE_MISSED
 DDS_EXPORT ddsrt_mtime_t dds_rhc_default_deadline_missed_cb(void *hc, ddsrt_mtime_t tnow);
 #endif
 

--- a/src/core/ddsc/src/dds_reader.c
+++ b/src/core/ddsc/src/dds_reader.c
@@ -77,7 +77,7 @@ static dds_return_t dds_reader_delete (dds_entity *e)
 
 static dds_return_t validate_reader_qos (const dds_qos_t *rqos)
 {
-#ifndef DDSI_INCLUDE_DEADLINE_MISSED
+#ifndef DDS_HAS_DEADLINE_MISSED
   if (rqos != NULL && (rqos->present & QP_DEADLINE) && rqos->deadline.deadline != DDS_INFINITY)
     return DDS_RETCODE_BAD_PARAMETER;
 #else
@@ -506,7 +506,7 @@ static dds_entity_t dds_create_reader_int (dds_entity_t participant_or_subscribe
      the subscriber lock, we can assert that the participant exists. */
   assert (pp != NULL);
 
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
   /* Check if DDS Security is enabled */
   if (q_omg_participant_is_secure (pp))
   {
@@ -549,7 +549,7 @@ static dds_entity_t dds_create_reader_int (dds_entity_t participant_or_subscribe
   dds_subscriber_unlock (sub);
   return reader;
 
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
 err_not_allowed:
   thread_state_asleep (lookup_thread_state ());
 #endif

--- a/src/core/ddsc/src/dds_writer.c
+++ b/src/core/ddsc/src/dds_writer.c
@@ -167,7 +167,7 @@ void dds_writer_status_cb (void *entity, const struct status_cb_data *data)
 
 static uint32_t get_bandwidth_limit (dds_transport_priority_qospolicy_t transport_priority)
 {
-#ifdef DDSI_INCLUDE_NETWORK_CHANNELS
+#ifdef DDS_HAS_NETWORK_CHANNELS
   struct ddsi_config_channel_listelem *channel = find_channel (&config, transport_priority);
   return channel->data_bandwidth_limit;
 #else
@@ -219,15 +219,15 @@ static dds_return_t dds_writer_delete (dds_entity *e)
 
 static dds_return_t validate_writer_qos (const dds_qos_t *wqos)
 {
-#ifndef DDSI_INCLUDE_LIFESPAN
+#ifndef DDS_HAS_LIFESPAN
   if (wqos != NULL && (wqos->present & QP_LIFESPAN) && wqos->lifespan.duration != DDS_INFINITY)
     return DDS_RETCODE_BAD_PARAMETER;
 #endif
-#ifndef DDSI_INCLUDE_DEADLINE_MISSED
+#ifndef DDS_HAS_DEADLINE_MISSED
   if (wqos != NULL && (wqos->present & QP_DEADLINE) && wqos->deadline.deadline != DDS_INFINITY)
     return DDS_RETCODE_BAD_PARAMETER;
 #endif
-#if defined(DDSI_INCLUDE_LIFESPAN) && defined(DDSI_INCLUDE_DEADLINE_MISSED)
+#if defined(DDS_HAS_LIFESPAN) && defined(DDS_HAS_DEADLINE_MISSED)
   DDSRT_UNUSED_ARG (wqos);
 #endif
   return DDS_RETCODE_OK;
@@ -358,7 +358,7 @@ dds_entity_t dds_create_writer (dds_entity_t participant_or_publisher, dds_entit
      the publisher lock, we can assert that the participant exists. */
   assert (pp != NULL);
 
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
   /* Check if DDS Security is enabled */
   if (q_omg_participant_is_secure (pp))
   {
@@ -397,7 +397,7 @@ dds_entity_t dds_create_writer (dds_entity_t participant_or_publisher, dds_entit
   dds_publisher_unlock (pub);
   return writer;
 
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
 err_not_allowed:
   thread_state_asleep (lookup_thread_state ());
 #endif

--- a/src/core/ddsc/tests/config.c
+++ b/src/core/ddsc/tests/config.c
@@ -109,7 +109,7 @@ CU_Test(ddsc_security_config, empty, .init = ddsrt_init, .fini = ddsrt_fini)
      test this one here to be sure that it refuses to start when security is configured
      but the implementation doesn't include support for it. */
   const char *log_expected[] = {
-#ifndef DDSI_INCLUDE_SECURITY
+#ifndef DDS_HAS_SECURITY
     "config: //CycloneDDS/Domain: Security: unknown element*",
 #else
     "config: //CycloneDDS/Domain/Security/Authentication/IdentityCertificate/#text: element missing in configuration*",
@@ -136,7 +136,7 @@ CU_Test(ddsc_security_config, empty, .init = ddsrt_init, .fini = ddsrt_fini)
   dds_set_trace_sink(NULL, NULL);
 
   /* All traces should have been provided. */
-#ifndef DDSI_INCLUDE_SECURITY
+#ifndef DDS_HAS_SECURITY
   CU_ASSERT_FATAL(found == 0x1);
 #else
   CU_ASSERT_FATAL(found == 0x7);
@@ -150,7 +150,7 @@ CU_Test(ddsc_security_qos, empty, .init = ddsrt_init, .fini = ddsrt_fini)
      start when security is configured but the implementation doesn't include
      support for it. */
   const char *log_expected[] = {
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
     "new_participant(*): using security settings from QoS*",
     "new_participant(*): required security property * missing*",
 #endif
@@ -176,7 +176,7 @@ CU_Test(ddsc_security_qos, empty, .init = ddsrt_init, .fini = ddsrt_fini)
   dds_set_trace_sink (NULL, NULL);
 
   /* All traces should have been provided. */
-#ifndef DDSI_INCLUDE_SECURITY
+#ifndef DDS_HAS_SECURITY
   CU_ASSERT_FATAL (found == 0x0);
 #else
   CU_ASSERT_FATAL (found == 0x3);

--- a/src/core/ddsc/tests/whc.c
+++ b/src/core/ddsc/tests/whc.c
@@ -257,7 +257,7 @@ CU_Test(ddsc_whc, check_end_state, .init=whc_init, .fini=whc_fini, .timeout=30)
   bool rem_rd[] = {false, true};
   int32_t n_inst[] = {1, 3};
   bool keyed[] = {false, true};
-#ifdef DDSI_INCLUDE_DEADLINE_MISSED
+#ifdef DDS_HAS_DEADLINE_MISSED
   bool deadline[] = {false, true};
 #else
   bool deadline[] = {false};

--- a/src/core/ddsi/include/dds/ddsi/ddsi_cfgelems.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_cfgelems.h
@@ -12,6 +12,8 @@
 #ifndef DDSI_CFGELEMS_H
 #define DDSI_CFGELEMS_H
 
+#include "dds/features.h"
+
 static struct cfgelem general_cfgelems[] = {
   STRING("NetworkInterfaceAddress", NULL, 1, "auto",
     MEMBER(networkAddressString),
@@ -192,7 +194,7 @@ static struct cfgelem general_cfgelems[] = {
   END_MARKER
 };
 
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
 static struct cfgelem authentication_library_attributes[] = {
   STRING("path", NULL, 1, "dds_security_auth",
     MEMBEROF(ddsi_config_omg_security_listelem, cfg.authentication_plugin.library_path),
@@ -471,9 +473,9 @@ static struct cfgelem security_omg_config_elements[] = {
     )),
   END_MARKER
 };
-#endif /* DDSI_INCLUDE_SECURITY */
+#endif /* DDS_HAS_SECURITY */
 
-#ifdef DDSI_INCLUDE_NETWORK_PARTITIONS
+#ifdef DDS_HAS_NETWORK_PARTITIONS
 static struct cfgelem networkpartition_cfgattrs[] = {
   STRING("Name", NULL, 1, NULL,
     MEMBEROF(ddsi_config_networkpartition_listelem, name),
@@ -594,11 +596,11 @@ static struct cfgelem partitioning_cfgelems[] = {
     )),
   END_MARKER
 };
-#endif /* DDSI_INCLUDE_NETWORK_PARTITIONS */
+#endif /* DDS_HAS_NETWORK_PARTITIONS */
 
-#ifdef DDSI_INCLUDE_NETWORK_CHANNELS
+#ifdef DDS_HAS_NETWORK_CHANNELS
 static struct cfgelem channel_cfgelems[] = {
-#ifdef DDSI_INCLUDE_BANDWIDTH_LIMITING
+#ifdef DDS_HAS_BANDWIDTH_LIMITING
   STRING("DataBandwidthLimit", NULL, 1, "inf",
     MEMBEROF(ddsi_config_channel_listelem, data_bandwidth_limit),
     FUNCTIONS(0, uf_bandwidth, 0, pf_bandwidth),
@@ -672,7 +674,7 @@ static struct cfgelem channels_cfgelems[] = {
     DESCRIPTION("<p>This element defines a channel.</p>")),
   END_MARKER
 };
-#endif /* DDSI_INCLUDE_NETWORK_CHANNELS */
+#endif /* DDS_HAS_NETWORK_CHANNELS */
 
 static struct cfgelem thread_properties_sched_cfgelems[] = {
   ENUM("Class", NULL, 1, "default",
@@ -1234,7 +1236,7 @@ static struct cfgelem internal_cfgelems[] = {
       "scheduled exactly, whereas a value of 10ms would mean that events are "
       "rounded up to the nearest 10 milliseconds.</p>"),
     UNIT("duration")),
-#ifdef DDSI_INCLUDE_BANDWIDTH_LIMITING
+#ifdef DDS_HAS_BANDWIDTH_LIMITING
   STRING("AuxiliaryBandwidthLimit", NULL, 1, "inf",
     MEMBER(auxiliary_bandwidth_limit),
     FUNCTIONS(0, uf_bandwidth, 0, pf_bandwidth),
@@ -1555,7 +1557,7 @@ static struct cfgelem tcp_cfgelems[] = {
   END_MARKER
 };
 
-#ifdef DDSI_INCLUDE_SSL
+#ifdef DDS_HAS_SSL
 static struct cfgelem ssl_cfgelems[] = {
   BOOL("Enable", NULL, 1, "false",
     MEMBER(ssl_enable),
@@ -1868,7 +1870,7 @@ static struct cfgelem domain_cfgelems[] = {
     DESCRIPTION(
       "<p>The General element specifies overall Cyclone DDS service settings.</p>"
     )),
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
   GROUP("Security|DDSSecurity", security_omg_config_elements, NULL, INT_MAX,
     MEMBER(omg_security_configuration),
     FUNCTIONS(if_omg_security, 0, 0, 0),
@@ -1879,7 +1881,7 @@ static struct cfgelem domain_cfgelems[] = {
     MAXIMUM(1)), /* Security must occur at most once, but INT_MAX is required
                     because of the way its processed (for now) */
 #endif
-#ifdef DDSI_INCLUDE_NETWORK_PARTITIONS
+#ifdef DDS_HAS_NETWORK_PARTITIONS
   GROUP("Partitioning", partitioning_cfgelems, NULL, 1,
     NOMEMBER,
     NOFUNCTIONS,
@@ -1889,7 +1891,7 @@ static struct cfgelem domain_cfgelems[] = {
       "partitions.</p>"
     )),
 #endif
-#ifdef DDSI_INCLUDE_NETWORK_CHANNELS
+#ifdef DDS_HAS_NETWORK_CHANNELS
   GROUP("Channels", channels_cfgelems, NULL, 1,
     NOMEMBER,
     NOFUNCTIONS,
@@ -1955,7 +1957,7 @@ static struct cfgelem domain_cfgelems[] = {
       "<p>The TCP element allows specifying various parameters related to "
       "running DDSI over TCP.</p>"
     )),
-#ifdef DDSI_INCLUDE_SSL
+#ifdef DDS_HAS_SSL
   GROUP("SSL", ssl_cfgelems, NULL, 1,
     NOMEMBER,
     NOFUNCTIONS,
@@ -1975,10 +1977,10 @@ static struct cfgelem root_cfgelems[] = {
       "<p>The General element specifying Domain related settings.</p>"
     )),
   MOVED("General", "CycloneDDS/Domain/General"),
-#if DDSI_INCLUDE_NETWORK_PARTITIONS
+#if DDS_HAS_NETWORK_PARTITIONS
   MOVED("Partitioning", "CycloneDDS/Domain/Partitioning"),
 #endif
-#if DDSI_INCLUDE_NETWORK_CHANNELS
+#if DDS_HAS_NETWORK_CHANNELS
   MOVED("Channels", "CycloneDDS/Domain/Channels"),
 #endif
   MOVED("Threads", "CycloneDDS/Domain/Threads"),
@@ -1989,10 +1991,10 @@ static struct cfgelem root_cfgelems[] = {
   MOVED("Internal|Unsupported", "CycloneDDS/Domain/Internal"),
   MOVED("TCP", "CycloneDDS/Domain/TCP"),
   MOVED("ThreadPool", "CycloneDDS/Domain/ThreadPool"),
-#if DDSI_INCLUDE_SECURITY
+#if DDS_HAS_SECURITY
   MOVED("DDSSecurity", "CycloneDDS/Domain/Security"),
 #endif
-#if DDSI_INCLUDE_SSL
+#if DDS_HAS_SSL
   MOVED("SSL", "CycloneDDS/Domain/SSL"),
 #endif
   MOVED("DDSI2E|DDSI2", "CycloneDDS/Domain"),

--- a/src/core/ddsi/include/dds/ddsi/ddsi_config.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_config.h
@@ -15,6 +15,7 @@
 #include <stdio.h>
 
 #include "dds/export.h"
+#include "dds/features.h"
 #include "dds/ddsrt/sched.h"
 #include "dds/ddsi/ddsi_portmapping.h"
 #include "dds/ddsi/ddsi_locator.h"
@@ -67,7 +68,7 @@ struct ddsi_config_listelem {
   struct ddsi_config_listelem *next;
 };
 
-#ifdef DDSI_INCLUDE_NETWORK_PARTITIONS
+#ifdef DDS_HAS_NETWORK_PARTITIONS
 struct ddsi_config_networkpartition_listelem {
   struct ddsi_config_networkpartition_listelem *next;
   char *name;
@@ -86,15 +87,15 @@ struct ddsi_config_partitionmapping_listelem {
   char *DCPSPartitionTopic;
   struct ddsi_config_networkpartition_listelem *partition;
 };
-#endif /* DDSI_INCLUDE_NETWORK_PARTITIONS */
+#endif /* DDS_HAS_NETWORK_PARTITIONS */
 
-#ifdef DDSI_INCLUDE_NETWORK_CHANNELS
+#ifdef DDS_HAS_NETWORK_CHANNELS
 struct ddsi_config_channel_listelem {
   struct ddsi_config_channel_listelem *next;
   char   *name;
   int    priority;
   int64_t resolution;
-#ifdef DDSI_INCLUDE_BANDWIDTH_LIMITING
+#ifdef DDS_HAS_BANDWIDTH_LIMITING
   uint32_t data_bandwidth_limit;
   uint32_t auxiliary_bandwidth_limit;
 #endif
@@ -105,7 +106,7 @@ struct ddsi_config_channel_listelem {
   uint32_t queueId; /* the index of the networkqueue serviced by this channel*/
   struct ddsi_tran_conn * transmit_conn; /* the connection used for sending data out via this channel */
 };
-#endif /* DDSI_INCLUDE_NETWORK_CHANNELS */
+#endif /* DDS_HAS_NETWORK_CHANNELS */
 
 struct ddsi_config_maybe_int32 {
   int isdefault;
@@ -140,7 +141,7 @@ struct ddsi_config_prune_deleted_ppant {
 #define DDSI_AMC_FALSE 0u
 #define DDSI_AMC_SPDP 1u
 #define DDSI_AMC_ASM 2u
-#ifdef DDSI_INCLUDE_SSM
+#ifdef DDS_HAS_SSM
 #define DDSI_AMC_SSM 4u
 #define DDSI_AMC_TRUE (DDSI_AMC_SPDP | DDSI_AMC_ASM | DDSI_AMC_SSM)
 #else
@@ -164,7 +165,7 @@ enum ddsi_many_sockets_mode {
   DDSI_MSM_MANY_UNICAST
 };
 
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
 struct ddsi_plugin_library_properties {
   char *library_path;
   char *library_init;
@@ -198,9 +199,9 @@ struct ddsi_config_omg_security_listelem {
   struct ddsi_config_omg_security_listelem *next;
   struct ddsi_config_omg_security cfg;
 };
-#endif /* DDSI_INCLUDE_SECURITY */
+#endif /* DDS_HAS_SECURITY */
 
-#ifdef DDSI_INCLUDE_SSL
+#ifdef DDS_HAS_SSL
 struct ddsi_config_ssl_min_version {
   int major;
   int minor;
@@ -279,7 +280,7 @@ struct ddsi_config
   int64_t tcp_write_timeout;
   int tcp_use_peeraddr_for_unicast;
 
-#ifdef DDSI_INCLUDE_SSL
+#ifdef DDS_HAS_SSL
   /* SSL support for TCP */
   int ssl_enable;
   int ssl_verify;
@@ -292,16 +293,16 @@ struct ddsi_config
   struct ddsi_config_ssl_min_version ssl_min_version;
 #endif
 
-#ifdef DDSI_INCLUDE_NETWORK_CHANNELS
+#ifdef DDS_HAS_NETWORK_CHANNELS
   struct ddsi_config_channel_listelem *channels;
   struct ddsi_config_channel_listelem *max_channel; /* channel with highest prio; always computed */
-#endif /* DDSI_INCLUDE_NETWORK_CHANNELS */
-#ifdef DDSI_INCLUDE_NETWORK_PARTITIONS
+#endif /* DDS_HAS_NETWORK_CHANNELS */
+#ifdef DDS_HAS_NETWORK_PARTITIONS
   struct ddsi_config_networkpartition_listelem *networkPartitions;
   unsigned nof_networkPartitions;
   struct ddsi_config_ignoredpartition_listelem *ignoredPartitions;
   struct ddsi_config_partitionmapping_listelem *partitionMappings;
-#endif /* DDSI_INCLUDE_NETWORK_PARTITIONS */
+#endif /* DDS_HAS_NETWORK_PARTITIONS */
   struct ddsi_config_peer_listelem *peers;
   struct ddsi_config_peer_listelem *peers_group;
   struct ddsi_config_thread_properties_listelem *thread_properties;
@@ -339,7 +340,7 @@ struct ddsi_config
   int64_t schedule_time_rounding;
   int64_t auto_resched_nack_delay;
   int64_t ds_grace_period;
-#ifdef DDSI_INCLUDE_BANDWIDTH_LIMITING
+#ifdef DDS_HAS_BANDWIDTH_LIMITING
   uint32_t auxiliary_bandwidth_limit; /* bytes/second */
 #endif
   uint32_t max_queued_rexmit_bytes;
@@ -368,7 +369,7 @@ struct ddsi_config
   int use_multicast_if_mreqn;
   struct ddsi_config_prune_deleted_ppant prune_deleted_ppant;
 
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
   struct ddsi_config_omg_security_listelem *omg_security_configuration;
 #endif
 

--- a/src/core/ddsi/include/dds/ddsi/ddsi_domaingv.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_domaingv.h
@@ -15,6 +15,8 @@
 #include <stdio.h>
 
 #include "dds/export.h"
+#include "dds/features.h"
+
 #include "dds/ddsrt/atomics.h"
 #include "dds/ddsrt/sockets.h"
 #include "dds/ddsrt/sync.h"
@@ -257,7 +259,7 @@ struct ddsi_domaingv {
   dds_qos_t spdp_endpoint_xqos;
   dds_qos_t builtin_endpoint_xqos_rd;
   dds_qos_t builtin_endpoint_xqos_wr;
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
   dds_qos_t builtin_volatile_xqos_rd;
   dds_qos_t builtin_volatile_xqos_wr;
   dds_qos_t builtin_stateless_xqos_rd;
@@ -278,7 +280,7 @@ struct ddsi_domaingv {
 
   struct debug_monitor *debmon;
 
-#ifndef DDSI_INCLUDE_NETWORK_CHANNELS
+#ifndef DDS_HAS_NETWORK_CHANNELS
   uint32_t networkQueueId;
   struct thread_state1 *channel_reader_ts;
 
@@ -294,7 +296,7 @@ struct ddsi_domaingv {
   struct ddsi_sertopic *sedp_reader_topic; /* key = endpoint GUID */
   struct ddsi_sertopic *sedp_writer_topic; /* key = endpoint GUID */
   struct ddsi_sertopic *pmd_topic; /* participant message data */
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
   struct ddsi_sertopic *spdp_secure_topic; /* key = participant GUID */
   struct ddsi_sertopic *sedp_reader_secure_topic; /* key = endpoint GUID */
   struct ddsi_sertopic *sedp_writer_secure_topic; /* key = endpoint GUID */
@@ -323,7 +325,7 @@ struct ddsi_domaingv {
   struct ddsrt_hh *sertopics;
 
   /* security globals */
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
   struct dds_security_context *security_context;
   struct ddsi_hsadmin *hsadmin;
   bool handshake_include_optional;

--- a/src/core/ddsi/include/dds/ddsi/ddsi_handshake.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_handshake.h
@@ -40,7 +40,7 @@ typedef void (*ddsi_handshake_end_cb_t)(
     struct proxy_participant *proxypp,
     enum ddsi_handshake_state result);
 
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
 
 #include "dds/ddsi/ddsi_security_msg.h"
 
@@ -182,7 +182,7 @@ void ddsi_handshake_admin_stop(struct ddsi_domaingv *gv);
  */
 void ddsi_handshake_admin_deinit(struct ddsi_domaingv *gv);
 
-#else /* DDSI_INCLUDE_SECURITY */
+#else /* DDS_HAS_SECURITY */
 
 #include "dds/ddsi/q_unused.h"
 
@@ -217,7 +217,7 @@ inline struct ddsi_handshake * ddsi_handshake_find(UNUSED_ARG(struct participant
   return NULL;
 }
 
-#endif /* DDSI_INCLUDE_SECURITY */
+#endif /* DDS_HAS_SECURITY */
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsi/include/dds/ddsi/ddsi_plist.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_plist.h
@@ -49,7 +49,7 @@ extern "C" {
 #define PP_ADLINK_PARTICIPANT_VERSION_INFO      ((uint64_t)1 << 26)
 #define PP_ADLINK_TYPE_DESCRIPTION              ((uint64_t)1 << 27)
 #define PP_COHERENT_SET                         ((uint64_t)1 << 28)
-#ifdef DDSI_INCLUDE_SSM
+#ifdef DDS_HAS_SSM
 #define PP_READER_FAVOURS_SSM                   ((uint64_t)1 << 29)
 #endif
 #define PP_DOMAIN_ID                            ((uint64_t)1 << 30)
@@ -99,7 +99,7 @@ typedef uint32_t nn_ipv4address_t;
 
 typedef uint32_t nn_port_t;
 
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
 typedef struct nn_tag {
   char *name;
   char *value;
@@ -115,13 +115,13 @@ typedef struct nn_datatags {
 } nn_datatags_t;
 #endif
 
-#ifdef DDSI_INCLUDE_SSM
+#ifdef DDS_HAS_SSM
 typedef struct nn_reader_favours_ssm {
   uint32_t state; /* default is false */
 } nn_reader_favours_ssm_t;
 #endif
 
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
 typedef struct nn_dataholder
 {
   char *class_id;
@@ -215,7 +215,7 @@ typedef struct ddsi_plist {
   nn_adlink_participant_version_info_t adlink_participant_version_info;
   char *type_description;
   nn_sequence_number_t coherent_set_seqno;
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
   nn_token_t identity_token;
   nn_token_t permissions_token;
   nn_security_info_t endpoint_security_info;
@@ -223,7 +223,7 @@ typedef struct ddsi_plist {
   nn_token_t identity_status_token;
   nn_datatags_t data_tags;
 #endif
-#ifdef DDSI_INCLUDE_SSM
+#ifdef DDS_HAS_SSM
   nn_reader_favours_ssm_t reader_favours_ssm;
 #endif
   uint32_t domain_id;

--- a/src/core/ddsi/include/dds/ddsi/ddsi_rhc.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_rhc.h
@@ -17,6 +17,7 @@
 #include <stdbool.h>
 
 #include "dds/export.h"
+#include "dds/features.h"
 
 /* DDS_EXPORT inline i.c.w. __attributes__((visibility...)) and some compilers: */
 #include "dds/ddsrt/attributes.h"
@@ -39,7 +40,7 @@ struct ddsi_writer_info
   bool auto_dispose;
   int32_t ownership_strength;
   uint64_t iid;
-#ifdef DDSI_INCLUDE_LIFESPAN
+#ifdef DDS_HAS_LIFESPAN
   ddsrt_mtime_t lifespan_exp;
 #endif
 };

--- a/src/core/ddsi/include/dds/ddsi/ddsi_security_exchange.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_security_exchange.h
@@ -12,7 +12,9 @@
 #ifndef DDSI_SECURITY_EXCHANGE_H
 #define DDSI_SECURITY_EXCHANGE_H
 
-#ifdef DDSI_INCLUDE_SECURITY
+#include "dds/features.h"
+
+#ifdef DDS_HAS_SECURITY
 
 #if defined (__cplusplus)
 extern "C" {
@@ -40,10 +42,10 @@ bool write_crypto_reader_tokens(const struct reader *rd, const struct proxy_writ
 }
 #endif
 
-#else /* DDSI_INCLUDE_SECURITY */
+#else /* DDS_HAS_SECURITY */
 
 #define volatile_secure_data_filter NULL
 
-#endif /* DDSI_INCLUDE_SECURITY */
+#endif /* DDS_HAS_SECURITY */
 
 #endif /* DDSI_SECURITY_EXCHANGE_H */

--- a/src/core/ddsi/include/dds/ddsi/ddsi_security_msg.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_security_msg.h
@@ -12,7 +12,9 @@
 #ifndef DDSI_SECURITY_MSG_H
 #define DDSI_SECURITY_MSG_H
 
-#ifdef DDSI_INCLUDE_SECURITY
+#include "dds/features.h"
+
+#ifdef DDS_HAS_SECURITY
 
 #include "dds/ddsi/ddsi_plist.h"
 #include "dds/ddsi/ddsi_guid.h"

--- a/src/core/ddsi/include/dds/ddsi/ddsi_security_omg.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_security_omg.h
@@ -12,6 +12,8 @@
 #ifndef DDSI_OMG_SECURITY_H
 #define DDSI_OMG_SECURITY_H
 
+#include "dds/features.h"
+
 #include "dds/ddsrt/sync.h"
 #include "dds/ddsrt/avl.h"
 
@@ -25,7 +27,7 @@
 #include "dds/ddsrt/sync.h"
 #include "dds/ddsi/ddsi_xqos.h"
 
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
 #include "dds/security/dds_security_api.h"
 #endif
 
@@ -39,7 +41,7 @@ typedef enum {
   NN_RTPS_MSG_STATE_ENCODED
 } nn_rtps_msg_state_t;
 
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
 
 struct ddsi_hsadmin;
 struct participant_sec_attributes;
@@ -1099,7 +1101,7 @@ void q_omg_security_free (struct ddsi_domaingv *gv);
 
 bool q_omg_is_security_loaded(  struct dds_security_context *sc );
 
-#else /* DDSI_INCLUDE_SECURITY */
+#else /* DDS_HAS_SECURITY */
 
 #include "dds/ddsi/q_unused.h"
 
@@ -1409,7 +1411,7 @@ inline void q_omg_log_endpoint_protection(UNUSED_ARG(struct ddsi_domaingv * cons
 {
 }
 
-#endif /* DDSI_INCLUDE_SECURITY */
+#endif /* DDS_HAS_SECURITY */
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsi/include/dds/ddsi/ddsi_security_util.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_security_util.h
@@ -12,7 +12,9 @@
 #ifndef DDSI_SECURITY_UTIL_H
 #define DDSI_SECURITY_UTIL_H
 
-#ifdef DDSI_INCLUDE_SECURITY
+#include "dds/features.h"
+
+#ifdef DDS_HAS_SECURITY
 
 #include "dds/ddsi/ddsi_plist.h"
 #include "dds/security/core/dds_security_utils.h"
@@ -59,6 +61,6 @@ void q_omg_shallow_free_TopicBuiltinTopicData(DDS_Security_TopicBuiltinTopicData
 #endif
 
 
-#endif /* DDSI_INCLUDE_SECURITY */
+#endif /* DDS_HAS_SECURITY */
 
 #endif /* DDSI_SECURITY_UTIL_H */

--- a/src/core/ddsi/include/dds/ddsi/ddsi_ssl.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_ssl.h
@@ -12,7 +12,9 @@
 #ifndef _DDSI_SSL_H_
 #define _DDSI_SSL_H_
 
-#ifdef DDSI_INCLUDE_SSL
+#include "dds/features.h"
+
+#ifdef DDS_HAS_SSL
 
 #ifdef _WIN32
 /* supposedly WinSock2 must be included before openssl headers otherwise winsock will be used */

--- a/src/core/ddsi/include/dds/ddsi/ddsi_xqos.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_xqos.h
@@ -12,6 +12,8 @@
 #ifndef DDSI_XQOS_H
 #define DDSI_XQOS_H
 
+#include "dds/features.h"
+
 #include "dds/ddsc/dds_public_qosdefs.h"
 /*XXX*/
 #include "dds/ddsi/q_protocol.h"
@@ -540,7 +542,7 @@ DDS_EXPORT bool ddsi_xqos_has_prop_prefix (const dds_qos_t *xqos, const char *na
  */
 DDS_EXPORT bool ddsi_xqos_find_prop (const dds_qos_t *xqos, const char *name, const char **value);
 
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
 struct ddsi_config_omg_security;
 DDS_EXPORT void ddsi_xqos_mergein_security_config (dds_qos_t *xqos, const struct ddsi_config_omg_security *cfg);
 #endif

--- a/src/core/ddsi/include/dds/ddsi/q_addrset.h
+++ b/src/core/ddsi/include/dds/ddsi/q_addrset.h
@@ -77,7 +77,7 @@ void set_unspec_locator (ddsi_locator_t *loc);
 struct ddsi_domaingv;
 int add_addresses_to_addrset (const struct ddsi_domaingv *gv, struct addrset *as, const char *addrs, int port_mode, const char *msgtag, int req_mc);
 
-#ifdef DDSI_INCLUDE_SSM
+#ifdef DDS_HAS_SSM
 int addrset_contains_ssm (const struct ddsi_domaingv *gv, const struct addrset *as);
 int addrset_any_ssm (const struct ddsi_domaingv *gv, const struct addrset *as, ddsi_locator_t *dst);
 int addrset_any_non_ssm_mc (const struct ddsi_domaingv *gv, const struct addrset *as, ddsi_locator_t *dst);

--- a/src/core/ddsi/include/dds/ddsi/q_feature_check.h
+++ b/src/core/ddsi/include/dds/ddsi/q_feature_check.h
@@ -27,9 +27,10 @@
    - NETWORK_CHANNELS: support for multiple network channels
 
 */
+#include "dds/features.h"
 
-#ifdef DDSI_INCLUDE_SSM
-  #ifndef DDSI_INCLUDE_NETWORK_PARTITIONS
+#ifdef DDS_HAS_SSM
+  #ifndef DDS_HAS_NETWORK_PARTITIONS
     #error "SSM requires NETWORK_PARTITIONS"
   #endif
 
@@ -37,12 +38,12 @@
   #ifndef DDSRT_HAVE_SSM
     #error "DDSRT_HAVE_SSM should be defined"
   #elif ! DDSRT_HAVE_SSM
-    #undef DDSI_INCLUDE_SSM
+    #undef DDS_HAS_SSM
   #endif
 #endif
 
-#ifdef DDSI_INCLUDE_BANDWIDTH_LIMITING
-  #ifndef DDSI_INCLUDE_NETWORK_CHANNELS
+#ifdef DDS_HAS_BANDWIDTH_LIMITING
+  #ifndef DDS_HAS_NETWORK_CHANNELS
     #error "BANDWIDTH_LIMITING requires NETWORK_CHANNELS"
   #endif
 #endif

--- a/src/core/ddsi/include/dds/ddsi/q_hbcontrol.h
+++ b/src/core/ddsi/include/dds/ddsi/q_hbcontrol.h
@@ -12,6 +12,8 @@
 #ifndef Q_HBCONTROL_H
 #define Q_HBCONTROL_H
 
+#include "dds/features.h"
+
 #if defined (__cplusplus)
 extern "C" {
 #endif
@@ -37,7 +39,7 @@ struct nn_xmsg *writer_hbcontrol_piggyback (struct writer *wr, const struct whc_
 int writer_hbcontrol_must_send (const struct writer *wr, const struct whc_state *whcst, ddsrt_mtime_t tnow);
 struct nn_xmsg *writer_hbcontrol_create_heartbeat (struct writer *wr, const struct whc_state *whcst, ddsrt_mtime_t tnow, int hbansreq, int issync);
 
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
 struct nn_xmsg *writer_hbcontrol_p2p(struct writer *wr, const struct whc_state *whcst, int hbansreq, struct proxy_reader *prd);
 #endif
 

--- a/src/core/ddsi/include/dds/ddsi/q_misc.h
+++ b/src/core/ddsi/include/dds/ddsi/q_misc.h
@@ -31,7 +31,7 @@ inline nn_sequence_number_t toSN (seqno_t n) {
 
 unsigned char normalize_data_datafrag_flags (const SubmessageHeader_t *smhdr);
 
-#ifdef DDSI_INCLUDE_NETWORK_PARTITIONS
+#ifdef DDS_HAS_NETWORK_PARTITIONS
 int WildcardOverlap(char * p1, char * p2);
 #endif
 
@@ -40,13 +40,13 @@ DDS_EXPORT int guid_prefix_eq (const ddsi_guid_prefix_t *a, const ddsi_guid_pref
 DDS_EXPORT int guid_eq (const struct ddsi_guid *a, const struct ddsi_guid *b);
 DDS_EXPORT int ddsi2_patmatch (const char *pat, const char *str);
 
-#ifdef DDSI_INCLUDE_NETWORK_PARTITIONS
+#ifdef DDS_HAS_NETWORK_PARTITIONS
 struct ddsi_config;
 struct ddsi_config_partitionmapping_listelem;
 struct ddsi_config_partitionmapping_listelem *find_partitionmapping (const struct ddsi_config *cfg, const char *partition, const char *topic);
 int is_ignored_partition (const struct ddsi_config *cfg, const char *partition, const char *topic);
 #endif
-#ifdef DDSI_INCLUDE_NETWORK_CHANNELS
+#ifdef DDS_HAS_NETWORK_CHANNELS
 struct ddsi_config;
 struct ddsi_config_channel_listelem;
 struct ddsi_config_channel_listelem *find_channel (const struct config *cfg, nn_transport_priority_qospolicy_t transport_priority);

--- a/src/core/ddsi/include/dds/ddsi/q_protocol.h
+++ b/src/core/ddsi/include/dds/ddsi/q_protocol.h
@@ -387,7 +387,7 @@ typedef union Submessage {
 #define PID_PARTICIPANT_SECURITY_INFO           0x1005u
 #define PID_IDENTITY_STATUS_TOKEN               0x1006u
 
-#ifdef DDSI_INCLUDE_SSM
+#ifdef DDS_HAS_SSM
 /* To indicate whether a reader favours the use of SSM.  Iff the
    reader favours SSM, it will use SSM if available. */
 #define PID_READER_FAVOURS_SSM                  0x72u

--- a/src/core/ddsi/include/dds/ddsi/q_xmsg.h
+++ b/src/core/ddsi/include/dds/ddsi/q_xmsg.h
@@ -75,7 +75,7 @@ void nn_xmsg_setdstN (struct nn_xmsg *msg, struct addrset *as, struct addrset *a
 
 int nn_xmsg_setmaxdelay (struct nn_xmsg *msg, int64_t maxdelay);
 
-#ifdef DDSI_INCLUDE_NETWORK_PARTITIONS
+#ifdef DDS_HAS_NETWORK_PARTITIONS
 int nn_xmsg_setencoderid (struct nn_xmsg *msg, uint32_t encoderid);
 #endif
 
@@ -119,7 +119,7 @@ void *nn_xmsg_submsg_from_marker (struct nn_xmsg *msg, struct nn_xmsg_marker mar
 void *nn_xmsg_append (struct nn_xmsg *m, struct nn_xmsg_marker *marker, size_t sz);
 void nn_xmsg_shrink (struct nn_xmsg *m, struct nn_xmsg_marker marker, size_t sz);
 void nn_xmsg_serdata (struct nn_xmsg *m, struct ddsi_serdata *serdata, size_t off, size_t len, struct writer *wr);
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
 size_t nn_xmsg_submsg_size (struct nn_xmsg *msg, struct nn_xmsg_marker marker);
 void nn_xmsg_submsg_remove (struct nn_xmsg *msg, struct nn_xmsg_marker sm_marker);
 void nn_xmsg_submsg_replace (struct nn_xmsg *msg, struct nn_xmsg_marker sm_marker, unsigned char *new_submsg, size_t new_len);

--- a/src/core/ddsi/src/ddsi_handshake.c
+++ b/src/core/ddsi/src/ddsi_handshake.c
@@ -9,11 +9,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
-
+#include "dds/features.h"
 #include "dds/ddsi/ddsi_handshake.h"
 
-
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
 
 #include <string.h>
 
@@ -1299,4 +1298,4 @@ extern inline void ddsi_handshake_register(UNUSED_ARG(struct participant *pp), U
 extern inline void ddsi_handshake_remove(UNUSED_ARG(struct participant *pp), UNUSED_ARG(struct proxy_participant *proxypp), UNUSED_ARG(struct ddsi_handshake *handshake));
 extern inline struct ddsi_handshake * ddsi_handshake_find(UNUSED_ARG(struct participant *pp), UNUSED_ARG(struct proxy_participant *proxypp));
 
-#endif /* DDSI_INCLUDE_DDS_SECURITY */
+#endif /* DDS_HAS_DDS_SECURITY */

--- a/src/core/ddsi/src/ddsi_mcgroup.c
+++ b/src/core/ddsi/src/ddsi_mcgroup.c
@@ -134,7 +134,7 @@ static char *make_joinleave_msg (char *buf, size_t bufsz, ddsi_tran_conn_t conn,
   char mcstr[DDSI_LOCSTRLEN], interfstr[DDSI_LOCSTRLEN];
   char srcstr[DDSI_LOCSTRLEN] = { '*', '\0' };
   int n;
-#ifdef DDSI_INCLUDE_SSM
+#ifdef DDS_HAS_SSM
   if (srcloc) {
     ddsi_locator_to_string_no_port(srcstr, sizeof(srcstr), srcloc);
   }

--- a/src/core/ddsi/src/ddsi_plist.c
+++ b/src/core/ddsi/src/ddsi_plist.c
@@ -1528,7 +1528,7 @@ static dds_return_t dvx_endpoint_guid (void * __restrict dst, const struct dd * 
   }
 }
 
-#ifdef DDSI_INCLUDE_SSM
+#ifdef DDS_HAS_SSM
 static dds_return_t dvx_reader_favours_ssm (void * __restrict dst, const struct dd * __restrict dd)
 {
   uint32_t * const favours_ssm = dst;
@@ -1585,10 +1585,10 @@ static const struct piddesc piddesc_omg[] = {
   PP  (ENTITY_NAME,                         entity_name, XS),
   PP  (KEYHASH,                             keyhash, XK),
   PPV (ENDPOINT_GUID,                       endpoint_guid, XG),
-#ifdef DDSI_INCLUDE_SSM
+#ifdef DDS_HAS_SSM
   PPV (READER_FAVOURS_SSM,                  reader_favours_ssm, Xu),
 #endif
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
   PP  (ENDPOINT_SECURITY_INFO,              endpoint_security_info, Xu, Xu),
   PP  (PARTICIPANT_SECURITY_INFO,           participant_security_info, Xu, Xu),
   PP  (IDENTITY_TOKEN,                      identity_token,        XS, XQ, XbPROP, XS, XS, XSTOP, XQ, XbPROP, XS, XO, XSTOP),
@@ -1707,12 +1707,12 @@ struct piddesc_index {
 
    FIXME: should compute them at build-time */
 #define DEFAULT_PROC_ARRAY_SIZE                20
-#ifdef DDSI_INCLUDE_SSM
+#ifdef DDS_HAS_SSM
 #define DEFAULT_OMG_PIDS_ARRAY_SIZE            (PID_READER_FAVOURS_SSM + 1)
 #else
 #define DEFAULT_OMG_PIDS_ARRAY_SIZE            (PID_STATUSINFO + 1)
 #endif
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
 #define SECURITY_OMG_PIDS_ARRAY_SIZE           (PID_IDENTITY_STATUS_TOKEN - PID_IDENTITY_TOKEN + 1)
 #define SECURITY_PROC_ARRAY_SIZE               4
 #else
@@ -1755,7 +1755,7 @@ static size_t pid_to_index (nn_parameterid_t pid)
 {
   /* pid without flags. */
   size_t idx = (size_t)(pid & ~(PID_VENDORSPECIFIC_FLAG | PID_UNRECOGNIZED_INCOMPATIBLE_FLAG));
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
   if ((idx >= PID_IDENTITY_TOKEN) && (idx <= PID_IDENTITY_STATUS_TOKEN))
   {
     /* Security PIDs start after the 'normal' PIDs. */
@@ -3295,7 +3295,7 @@ bool ddsi_xqos_find_prop (const dds_qos_t *xqos, const char *name, const char **
   return false;
 }
 
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
 static void fill_property(dds_property_t *prop, const char *name, const char *value)
 {
   prop->name = ddsrt_strdup(name);
@@ -3345,7 +3345,7 @@ void ddsi_xqos_mergein_security_config (dds_qos_t *xqos, const struct ddsi_confi
   if (cfg->authentication_properties.trusted_ca_dir )
     fill_property(&(xqos->property.value.props[xqos->property.value.n++]), DDS_SEC_PROP_ACCESS_TRUSTED_CA_DIR, cfg->authentication_properties.trusted_ca_dir);
 }
-#endif /* DDSI_INCLUDE_SECURITY */
+#endif /* DDS_HAS_SECURITY */
 
 static int partition_is_default (const dds_partition_qospolicy_t *a)
 {

--- a/src/core/ddsi/src/ddsi_security_exchange.c
+++ b/src/core/ddsi/src/ddsi_security_exchange.c
@@ -9,7 +9,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
-#ifdef DDSI_INCLUDE_SECURITY
+#include "dds/features.h"
+#ifdef DDS_HAS_SECURITY
 
 #include <string.h>
 
@@ -258,4 +259,4 @@ void handle_crypto_exchange_message(const struct receiver_state *rst, struct dds
   }
 }
 
-#endif /* DDSI_INCLUDE_SECURITY */
+#endif /* DDS_HAS_SECURITY */

--- a/src/core/ddsi/src/ddsi_security_omg.c
+++ b/src/core/ddsi/src/ddsi_security_omg.c
@@ -9,7 +9,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
-#ifdef DDSI_INCLUDE_SECURITY
+#include "dds/features.h"
+
+#ifdef DDS_HAS_SECURITY
 
 #include <string.h>
 #include <stdarg.h>
@@ -3871,7 +3873,7 @@ void q_omg_log_endpoint_protection(struct ddsi_domaingv * const gv, const ddsi_p
   GVLOGDISC (")");
 }
 
-#else /* DDSI_INCLUDE_SECURITY */
+#else /* DDS_HAS_SECURITY */
 
 #include "dds/ddsi/ddsi_security_omg.h"
 
@@ -4011,4 +4013,4 @@ extern inline bool q_omg_is_endpoint_protected(UNUSED_ARG(const ddsi_plist_t *pl
 extern inline void q_omg_log_endpoint_protection(UNUSED_ARG(struct ddsi_domaingv * const gv), UNUSED_ARG(const ddsi_plist_t *plist));
 
 
-#endif /* DDSI_INCLUDE_SECURITY */
+#endif /* DDS_HAS_SECURITY */

--- a/src/core/ddsi/src/ddsi_security_util.c
+++ b/src/core/ddsi/src/ddsi_security_util.c
@@ -9,8 +9,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
-
-#ifdef DDSI_INCLUDE_SECURITY
+#include "dds/features.h"
+#ifdef DDS_HAS_SECURITY
 
 #include <string.h>
 #include <stdarg.h>
@@ -723,4 +723,4 @@ q_omg_shallow_free_TopicBuiltinTopicData(
 
 
 
-#endif /* DDSI_INCLUDE_SECURITY */
+#endif /* DDS_HAS_SECURITY */

--- a/src/core/ddsi/src/ddsi_ssl.c
+++ b/src/core/ddsi/src/ddsi_ssl.c
@@ -15,7 +15,7 @@
 #include "dds/ddsrt/log.h"
 #include "dds/ddsrt/misc.h"
 
-#ifdef DDSI_INCLUDE_SSL
+#ifdef DDS_HAS_SSL
 
 #include <assert.h>
 #include <string.h>
@@ -414,4 +414,4 @@ void ddsi_ssl_config_plugin (struct ddsi_ssl_plugins *plugin)
   plugin->accept = ddsi_ssl_accept;
 }
 
-#endif /* DDSI_INCLUDE_SSL */
+#endif /* DDS_HAS_SSL */

--- a/src/core/ddsi/src/ddsi_udp.c
+++ b/src/core/ddsi/src/ddsi_udp.c
@@ -551,7 +551,7 @@ static dds_return_t ddsi_udp_create_conn (ddsi_tran_conn_t *conn_out, ddsi_tran_
   if (rc != DDS_RETCODE_OK)
     goto fail_w_socket;
 
-#ifdef DDSI_INCLUDE_NETWORK_CHANNELS
+#ifdef DDS_HAS_NETWORK_CHANNELS
   if (qos->m_diffserv != 0 && fact->m_kind == NN_LOCATOR_KIND_UDPv4)
   {
     if ((rc = ddsrt_setsockopt (sock, IPPROTO_IP, IP_TOS, &qos->m_diffserv, sizeof (qos->m_diffserv))) != DDS_RETCODE_OK)
@@ -625,7 +625,7 @@ static int joinleave_asm_mcgroup (ddsrt_socket_t socket, int join, const ddsi_lo
   return (rc == DDS_RETCODE_OK) ? 0 : -1;
 }
 
-#ifdef DDSI_INCLUDE_SSM
+#ifdef DDS_HAS_SSM
 static int joinleave_ssm_mcgroup (ddsrt_socket_t socket, int join, const ddsi_locator_t *srcloc, const ddsi_locator_t *mcloc, const struct nn_interface *interf)
 {
   dds_return_t rc;
@@ -663,7 +663,7 @@ static int ddsi_udp_join_mc (ddsi_tran_conn_t conn_cmn, const ddsi_locator_t *sr
 {
   ddsi_udp_conn_t conn = (ddsi_udp_conn_t) conn_cmn;
   (void) srcloc;
-#ifdef DDSI_INCLUDE_SSM
+#ifdef DDS_HAS_SSM
   if (srcloc)
     return joinleave_ssm_mcgroup (conn->m_sock, 1, srcloc, mcloc, interf);
   else
@@ -675,7 +675,7 @@ static int ddsi_udp_leave_mc (ddsi_tran_conn_t conn_cmn, const ddsi_locator_t *s
 {
   ddsi_udp_conn_t conn = (ddsi_udp_conn_t) conn_cmn;
   (void) srcloc;
-#ifdef DDSI_INCLUDE_SSM
+#ifdef DDS_HAS_SSM
   if (srcloc)
     return joinleave_ssm_mcgroup (conn->m_sock, 0, srcloc, mcloc, interf);
   else
@@ -722,7 +722,7 @@ static int ddsi_udp_is_mcaddr (const struct ddsi_tran_factory *tran, const ddsi_
   }
 }
 
-#ifdef DDSI_INCLUDE_SSM
+#ifdef DDS_HAS_SSM
 static int ddsi_udp_is_ssm_mcaddr (const struct ddsi_tran_factory *tran, const ddsi_locator_t *loc)
 {
   (void) tran;
@@ -866,7 +866,7 @@ int ddsi_udp_init (struct ddsi_domaingv*gv)
   fact->fact.m_join_mc_fn = ddsi_udp_join_mc;
   fact->fact.m_leave_mc_fn = ddsi_udp_leave_mc;
   fact->fact.m_is_mcaddr_fn = ddsi_udp_is_mcaddr;
-#ifdef DDSI_INCLUDE_SSM
+#ifdef DDS_HAS_SSM
   fact->fact.m_is_ssm_mcaddr_fn = ddsi_udp_is_ssm_mcaddr;
 #endif
   fact->fact.m_is_nearby_address_fn = ddsi_ipaddr_is_nearby_address;

--- a/src/core/ddsi/src/q_addrset.c
+++ b/src/core/ddsi/src/q_addrset.c
@@ -198,7 +198,7 @@ int is_unspec_locator (const ddsi_locator_t *loc)
           memcmp (&zloc.address, loc->address, sizeof (zloc.address)) == 0);
 }
 
-#ifdef DDSI_INCLUDE_SSM
+#ifdef DDS_HAS_SSM
 int addrset_contains_ssm (const struct ddsi_domaingv *gv, const struct addrset *as)
 {
   struct addrset_node *n;
@@ -319,7 +319,7 @@ void copy_addrset_into_addrset (const struct ddsi_domaingv *gv, struct addrset *
   copy_addrset_into_addrset_mc (gv, as, asadd);
 }
 
-#ifdef DDSI_INCLUDE_SSM
+#ifdef DDS_HAS_SSM
 void copy_addrset_into_addrset_no_ssm_mc (const struct ddsi_domaingv *gv, struct addrset *as, const struct addrset *asadd)
 {
   struct addrset_node *n;

--- a/src/core/ddsi/src/q_config.c
+++ b/src/core/ddsi/src/q_config.c
@@ -177,14 +177,14 @@ DUPF(retransmit_merging);
 DUPF(sched_class);
 DUPF(maybe_memsize);
 DUPF(maybe_int32);
-#ifdef DDSI_INCLUDE_BANDWIDTH_LIMITING
+#ifdef DDS_HAS_BANDWIDTH_LIMITING
 DUPF(bandwidth);
 #endif
 DUPF(domainId);
 DUPF(transport_selector);
 DUPF(many_sockets_mode);
 DU(deaf_mute);
-#ifdef DDSI_INCLUDE_SSL
+#ifdef DDS_HAS_SSL
 DUPF(min_tls_version);
 #endif
 #undef DUPF
@@ -197,17 +197,17 @@ DF(ff_networkAddresses);
 #undef DF
 
 #define DI(fname) static int fname (struct cfgst *cfgst, void *parent, struct cfgelem const * const cfgelem)
-#ifdef DDSI_INCLUDE_NETWORK_CHANNELS
+#ifdef DDS_HAS_NETWORK_CHANNELS
 DI(if_channel);
-#endif /* DDSI_INCLUDE_NETWORK_CHANNELS */
-#ifdef DDSI_INCLUDE_NETWORK_PARTITIONS
+#endif /* DDS_HAS_NETWORK_CHANNELS */
+#ifdef DDS_HAS_NETWORK_PARTITIONS
 DI(if_network_partition);
 DI(if_ignored_partition);
 DI(if_partition_mapping);
 #endif
 DI(if_peer);
 DI(if_thread_properties);
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
 DI(if_omg_security);
 #endif
 #undef DI
@@ -318,7 +318,7 @@ static const struct unit unittab_memsize[] = {
   { NULL, 0 }
 };
 
-#ifdef DDSI_INCLUDE_BANDWIDTH_LIMITING
+#ifdef DDS_HAS_BANDWIDTH_LIMITING
 static const struct unit unittab_bandwidth_bps[] = {
   { "b/s", 1 },{ "bps", 1 },
   { "Kib/s", 1024 },{ "Kibps", 1024 },
@@ -648,7 +648,7 @@ static int if_thread_properties (struct cfgst *cfgst, void *parent, struct cfgel
   return 0;
 }
 
-#ifdef DDSI_INCLUDE_NETWORK_CHANNELS
+#ifdef DDS_HAS_NETWORK_CHANNELS
 static int if_channel(struct cfgst *cfgst, void *parent, struct cfgelem const * const cfgelem)
 {
   struct ddsi_config_channel_listelem *new = if_common (cfgst, parent, cfgelem, sizeof(*new));
@@ -662,9 +662,9 @@ static int if_channel(struct cfgst *cfgst, void *parent, struct cfgelem const * 
   new->transmit_conn = NULL;
   return 0;
 }
-#endif /* DDSI_INCLUDE_NETWORK_CHANNELS */
+#endif /* DDS_HAS_NETWORK_CHANNELS */
 
-#ifdef DDSI_INCLUDE_NETWORK_PARTITIONS
+#ifdef DDS_HAS_NETWORK_PARTITIONS
 static int if_network_partition (struct cfgst *cfgst, void *parent, struct cfgelem const * const cfgelem)
 {
   struct ddsi_config_networkpartition_listelem *new = if_common (cfgst, parent, cfgelem, sizeof(*new));
@@ -695,7 +695,7 @@ static int if_partition_mapping (struct cfgst *cfgst, void *parent, struct cfgel
   new->partition = NULL;
   return 0;
 }
-#endif /* DDSI_INCLUDE_NETWORK_PARTITIONS */
+#endif /* DDS_HAS_NETWORK_PARTITIONS */
 
 static int if_peer (struct cfgst *cfgst, void *parent, struct cfgelem const * const cfgelem)
 {
@@ -706,7 +706,7 @@ static int if_peer (struct cfgst *cfgst, void *parent, struct cfgelem const * co
   return 0;
 }
 
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
 static int if_omg_security (struct cfgst *cfgst, void *parent, struct cfgelem const * const cfgelem)
 {
   struct ddsi_config_omg_security_listelem *new = if_common (cfgst, parent, cfgelem, sizeof (*new));
@@ -1006,7 +1006,7 @@ static void pf_xcheck (struct cfgst *cfgst, void *parent, struct cfgelem const *
   do_print_uint32_bitset (cfgst, *p, sizeof (xcheck_codes) / sizeof (*xcheck_codes), xcheck_names, xcheck_codes, sources, suffix);
 }
 
-#ifdef DDSI_INCLUDE_SSL
+#ifdef DDS_HAS_SSL
 static enum update_result uf_min_tls_version (struct cfgst *cfgst, UNUSED_ARG (void *parent), UNUSED_ARG (struct cfgelem const * const cfgelem), UNUSED_ARG (int first), const char *value)
 {
   static const char *vs[] = {
@@ -1044,7 +1044,7 @@ static void pf_string (struct cfgst *cfgst, void *parent, struct cfgelem const *
   cfg_logelem (cfgst, sources, "%s", *p ? *p : "(null)");
 }
 
-#ifdef DDSI_INCLUDE_BANDWIDTH_LIMITING
+#ifdef DDS_HAS_BANDWIDTH_LIMITING
 static enum update_result uf_bandwidth (struct cfgst *cfgst, void *parent, struct cfgelem const * const cfgelem, UNUSED_ARG (int first), const char *value)
 {
   int64_t bandwidth_bps = 0;
@@ -1221,7 +1221,7 @@ static void ff_networkAddresses (struct cfgst *cfgst, void *parent, struct cfgel
   ddsrt_free (*elem);
 }
 
-#ifdef DDSI_INCLUDE_SSM
+#ifdef DDS_HAS_SSM
 static const char *allow_multicast_names[] = { "false", "spdp", "asm", "ssm", "true", NULL };
 static const uint32_t allow_multicast_codes[] = { DDSI_AMC_FALSE, DDSI_AMC_SPDP, DDSI_AMC_ASM, DDSI_AMC_SSM, DDSI_AMC_TRUE };
 #else
@@ -2038,7 +2038,7 @@ static int cfgst_node_cmp (const void *va, const void *vb)
   return memcmp (va, vb, sizeof (struct cfgst_nodekey));
 }
 
-#ifdef DDSI_INCLUDE_NETWORK_CHANNELS
+#ifdef DDS_HAS_NETWORK_CHANNELS
 static int set_default_channel (struct config *cfg)
 {
   if (cfg->channels == NULL)
@@ -2051,7 +2051,7 @@ static int set_default_channel (struct config *cfg)
     c->name = ddsrt_strdup ("user");
     c->priority = 0;
     c->resolution = DDS_MSECS (1);
-#ifdef DDSI_INCLUDE_BANDWIDTH_LIMITING
+#ifdef DDS_HAS_BANDWIDTH_LIMITING
     c->data_bandwidth_limit = 0;
     c->auxiliary_bandwidth_limit = 0;
 #endif
@@ -2116,7 +2116,7 @@ static int sort_channels_check_nodups (struct config *cfg, uint32_t domid)
   ddsrt_free (ary);
   return result;
 }
-#endif /* DDSI_INCLUDE_NETWORK_CHANNELS */
+#endif /* DDS_HAS_NETWORK_CHANNELS */
 
 static FILE *config_open_file (char *tok, char **cursor, uint32_t domid)
 {
@@ -2280,7 +2280,7 @@ struct cfgst *config_init (const char *config, struct ddsi_config *cfg, uint32_t
     cfgst->cfg->compat_tcp_enable = (cfgst->cfg->transport_selector == DDSI_TRANS_TCP || cfgst->cfg->transport_selector == DDSI_TRANS_TCP6) ? DDSI_BOOLDEF_TRUE : DDSI_BOOLDEF_FALSE;
   }
 
-#ifdef DDSI_INCLUDE_NETWORK_CHANNELS
+#ifdef DDS_HAS_NETWORK_CHANNELS
   /* Default channel gets set outside set_defaults -- a bit too
      complicated for the poor framework */
   if (ok)
@@ -2292,7 +2292,7 @@ struct cfgst *config_init (const char *config, struct ddsi_config *cfg, uint32_t
   }
 #endif
 
-#ifdef DDSI_INCLUDE_NETWORK_PARTITIONS
+#ifdef DDS_HAS_NETWORK_PARTITIONS
   /* Create links from the partitionmappings to the network partitions
      and signal errors if partitions do not exist */
   if (ok)
@@ -2313,7 +2313,7 @@ struct cfgst *config_init (const char *config, struct ddsi_config *cfg, uint32_t
       m = m->next;
     }
   }
-#endif /* DDSI_INCLUDE_NETWORK_PARTITIONS */
+#endif /* DDS_HAS_NETWORK_PARTITIONS */
 
   if (ok)
   {

--- a/src/core/ddsi/src/q_debmon.c
+++ b/src/core/ddsi/src/q_debmon.c
@@ -166,7 +166,7 @@ static int print_participants (struct thread_state1 * const ts1, struct ddsi_dom
           continue;
         ddsrt_mutex_lock (&r->e.lock);
         print_endpoint_common (conn, "rd", &r->e, &r->c, r->xqos);
-#ifdef DDSI_INCLUDE_NETWORK_PARTITIONS
+#ifdef DDS_HAS_NETWORK_PARTITIONS
         x += print_addrset_if_notempty (conn, "    as", r->as, "\n");
 #endif
         for (m = ddsrt_avl_iter_first (&rd_writers_treedef, &r->writers, &writ); m; m = ddsrt_avl_iter_next (&writ))

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -138,7 +138,7 @@ static void make_builtin_endpoint_xqos (dds_qos_t *q, const dds_qos_t *template)
   q->durability.kind = DDS_DURABILITY_TRANSIENT_LOCAL;
 }
 
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
 static void make_builtin_volatile_endpoint_xqos (dds_qos_t *q, const dds_qos_t *template)
 {
   ddsi_xqos_copy (q, template);
@@ -328,7 +328,7 @@ static int set_spdp_address (struct ddsi_domaingv *gv)
     rc = string_to_default_locator (gv, &gv->loc_spdp_mc, gv->m_factory->m_default_spdp_address, port, 1, "SPDP address");
     assert (rc > 0);
   }
-#ifdef DDSI_INCLUDE_SSM
+#ifdef DDS_HAS_SSM
   if (gv->loc_spdp_mc.kind != NN_LOCATOR_KIND_INVALID && ddsi_is_ssm_mcaddr (gv, &gv->loc_spdp_mc))
   {
     GVERROR ("%s: SPDP address may not be an SSM address\n", gv->config.spdpMulticastAddressString);
@@ -388,7 +388,7 @@ static int set_ext_address_and_mask (struct ddsi_domaingv *gv)
   return 0;
 }
 
-#ifdef DDSI_INCLUDE_NETWORK_CHANNELS
+#ifdef DDS_HAS_NETWORK_CHANNELS
 static int known_channel_p (const struct ddsi_domaingv *gv, const char *name)
 {
   const struct ddsi_config_channel_listelem *c;
@@ -401,7 +401,7 @@ static int known_channel_p (const struct ddsi_domaingv *gv, const char *name)
 
 static int check_thread_properties (const struct ddsi_domaingv *gv)
 {
-#ifdef DDSI_INCLUDE_NETWORK_CHANNELS
+#ifdef DDS_HAS_NETWORK_CHANNELS
   static const char *fixed[] = { "recv", "tev", "gc", "lease", "dq.builtins", "debmon", "fsm", NULL };
   static const char *chanprefix[] = { "xmit.", "tev.","dq.",NULL };
 #else
@@ -416,7 +416,7 @@ static int check_thread_properties (const struct ddsi_domaingv *gv)
         break;
     if (fixed[i] == NULL)
     {
-#ifdef DDSI_INCLUDE_NETWORK_CHANNELS
+#ifdef DDS_HAS_NETWORK_CHANNELS
       /* Some threads are named after the channel, with names of the form PREFIX.CHAN */
 
       for (i = 0; chanprefix[i]; i++)
@@ -433,7 +433,7 @@ static int check_thread_properties (const struct ddsi_domaingv *gv)
 #else
       DDS_ILOG (DDS_LC_ERROR, gv->config.domainId, "config: DDSI2Service/Threads/Thread[@name=\"%s\"]: unknown thread\n", e->name);
       ok = 0;
-#endif /* DDSI_INCLUDE_NETWORK_CHANNELS */
+#endif /* DDS_HAS_NETWORK_CHANNELS */
     }
   }
   return ok;
@@ -477,7 +477,7 @@ int rtps_config_open_trace (struct ddsi_domaingv *gv)
 
 int rtps_config_prep (struct ddsi_domaingv *gv, struct cfgst *cfgst)
 {
-#ifdef DDSI_INCLUDE_NETWORK_CHANNELS
+#ifdef DDS_HAS_NETWORK_CHANNELS
   unsigned num_channels = 0;
   unsigned num_channel_threads = 0;
 #endif
@@ -541,7 +541,7 @@ int rtps_config_prep (struct ddsi_domaingv *gv, struct cfgst *cfgst)
   }
   if (gv->config.max_queued_rexmit_bytes == 0)
   {
-#ifdef DDSI_INCLUDE_BANDWIDTH_LIMITING
+#ifdef DDS_HAS_BANDWIDTH_LIMITING
     if (gv->config.auxiliary_bandwidth_limit == 0)
       gv->config.max_queued_rexmit_bytes = 2147483647u;
     else
@@ -556,7 +556,7 @@ int rtps_config_prep (struct ddsi_domaingv *gv, struct cfgst *cfgst)
     }
 #else
     gv->config.max_queued_rexmit_bytes = 2147483647u;
-#endif /* DDSI_INCLUDE_BANDWIDTH_LIMITING */
+#endif /* DDS_HAS_BANDWIDTH_LIMITING */
   }
 
   /* Verify thread properties refer to defined threads */
@@ -565,7 +565,7 @@ int rtps_config_prep (struct ddsi_domaingv *gv, struct cfgst *cfgst)
     goto err_config_late_error;
   }
 
-#ifdef DDSI_INCLUDE_NETWORK_CHANNELS
+#ifdef DDS_HAS_NETWORK_CHANNELS
   {
     /* Determine number of configured channels to be able to
      determine the correct number of threads.  Also fix fields if
@@ -590,7 +590,7 @@ int rtps_config_prep (struct ddsi_domaingv *gv, struct cfgst *cfgst)
       }
 
       if (
-#ifdef DDSI_INCLUDE_BANDWIDTH_LIMITING
+#ifdef DDS_HAS_BANDWIDTH_LIMITING
           chptr->auxiliary_bandwidth_limit > 0 ||
 #endif
           lookup_thread_properties (thread_name))
@@ -602,7 +602,7 @@ int rtps_config_prep (struct ddsi_domaingv *gv, struct cfgst *cfgst)
     if (error)
       goto err_config_late_error;
   }
-#endif /* DDSI_INCLUDE_NETWORK_CHANNELS */
+#endif /* DDS_HAS_NETWORK_CHANNELS */
 
   /* Open tracing file after all possible config errors have been printed */
   if (! rtps_config_open_trace (gv))
@@ -621,7 +621,7 @@ int rtps_config_prep (struct ddsi_domaingv *gv, struct cfgst *cfgst)
   */
 #define USER_MAX_THREADS 50
 
-#ifdef DDSI_INCLUDE_NETWORK_CHANNELS
+#ifdef DDS_HAS_NETWORK_CHANNELS
     const unsigned max_threads = 9 + USER_MAX_THREADS + num_channel_threads + gv->config.ddsi2direct_max_threads;
 #else
     const unsigned max_threads = 11 + USER_MAX_THREADS + gv->config.ddsi2direct_max_threads;
@@ -661,7 +661,7 @@ static void joinleave_spdp_defmcip_helper (const ddsi_locator_t *loc, void *varg
   struct joinleave_spdp_defmcip_helper_arg *arg = varg;
   if (!ddsi_is_mcaddr (arg->gv, loc))
     return;
-#ifdef DDSI_INCLUDE_SSM
+#ifdef DDS_HAS_SSM
   /* Can't join SSM until we actually have a source */
   if (ddsi_is_ssm_mcaddr (arg->gv, loc))
     return;
@@ -826,7 +826,7 @@ static struct ddsi_sertopic *make_special_topic_plist (const char *name, const c
 
 static void free_special_topics (struct ddsi_domaingv *gv)
 {
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
   ddsi_sertopic_unref (gv->pgm_volatile_topic);
   ddsi_sertopic_unref (gv->pgm_stateless_topic);
   ddsi_sertopic_unref (gv->pmd_secure_topic);
@@ -847,7 +847,7 @@ static void make_special_topics (struct ddsi_domaingv *gv)
   gv->sedp_writer_topic = make_special_topic_plist ("DCPSPublication", "PublicationBuiltinTopicData", PID_ENDPOINT_GUID);
   gv->pmd_topic = make_special_topic_pserop ("DCPSParticipantMessage", "ParticipantMessageData", sizeof (ParticipantMessageData_t), participant_message_data_nops, participant_message_data_ops, participant_message_data_nops_key, participant_message_data_ops_key);
 
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
   gv->spdp_secure_topic = make_special_topic_plist ("DCPSParticipantsSecure", "ParticipantBuiltinTopicDataSecure", PID_PARTICIPANT_GUID);
   gv->sedp_reader_secure_topic = make_special_topic_plist ("DCPSSubscriptionsSecure", "SubscriptionBuiltinTopicDataSecure", PID_ENDPOINT_GUID);
   gv->sedp_writer_secure_topic = make_special_topic_plist ("DCPSPublicationsSecure", "PublicationBuiltinTopicDataSecure", PID_ENDPOINT_GUID);
@@ -861,7 +861,7 @@ static void make_special_topics (struct ddsi_domaingv *gv)
   ddsi_sertopic_register_locked (gv, gv->sedp_reader_topic);
   ddsi_sertopic_register_locked (gv, gv->sedp_writer_topic);
   ddsi_sertopic_register_locked (gv, gv->pmd_topic);
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
   ddsi_sertopic_register_locked (gv, gv->spdp_secure_topic);
   ddsi_sertopic_register_locked (gv, gv->sedp_reader_secure_topic);
   ddsi_sertopic_register_locked (gv, gv->sedp_writer_secure_topic);
@@ -1161,7 +1161,7 @@ int rtps_init (struct ddsi_domaingv *gv)
     GVLOG (DDS_LC_CONFIG, "extmask: %s%s\n", ddsi_locator_to_string_no_port (buf, sizeof(buf), &gv->extmask), gv->m_factory->m_kind != NN_LOCATOR_KIND_UDPv4 ? " (not applicable)" : "");
     GVLOG (DDS_LC_CONFIG, "SPDP MC: %s\n", ddsi_locator_to_string_no_port (buf, sizeof(buf), &gv->loc_spdp_mc));
     GVLOG (DDS_LC_CONFIG, "default MC: %s\n", ddsi_locator_to_string_no_port (buf, sizeof(buf), &gv->loc_default_mc));
-#ifdef DDSI_INCLUDE_SSM
+#ifdef DDS_HAS_SSM
     GVLOG (DDS_LC_CONFIG, "SSM support included\n");
 #endif
   }
@@ -1169,7 +1169,7 @@ int rtps_init (struct ddsi_domaingv *gv)
   if (gv->ownloc.kind != gv->extloc.kind)
     DDS_FATAL ("mismatch between network address kinds\n");
 
-#ifdef DDSI_INCLUDE_NETWORK_PARTITIONS
+#ifdef DDS_HAS_NETWORK_PARTITIONS
   /* Convert address sets in partition mappings from string to address sets */
   {
     const uint32_t port = ddsi_get_port (&gv->config, DDSI_PORT_MULTI_DATA, 0);
@@ -1207,7 +1207,7 @@ int rtps_init (struct ddsi_domaingv *gv)
   assert (gv->spdp_endpoint_xqos.reliability.kind == DDS_RELIABILITY_BEST_EFFORT);
   make_builtin_endpoint_xqos (&gv->builtin_endpoint_xqos_rd, &gv->default_xqos_rd);
   make_builtin_endpoint_xqos (&gv->builtin_endpoint_xqos_wr, &gv->default_xqos_wr);
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
   make_builtin_volatile_endpoint_xqos(&gv->builtin_volatile_xqos_rd, &gv->default_xqos_rd);
   make_builtin_volatile_endpoint_xqos(&gv->builtin_volatile_xqos_wr, &gv->default_xqos_wr);
   ddsi_xqos_copy (&gv->builtin_stateless_xqos_rd, &gv->default_xqos_rd);
@@ -1420,7 +1420,7 @@ int rtps_init (struct ddsi_domaingv *gv)
       goto err_mc_conn;
   }
 
-#ifdef DDSI_INCLUDE_NETWORK_CHANNELS
+#ifdef DDS_HAS_NETWORK_CHANNELS
   {
     struct ddsi_config_channel_listelem *chptr = gv->config.channels;
     while (chptr)
@@ -1448,7 +1448,7 @@ int rtps_init (struct ddsi_domaingv *gv)
       }
       GVLOG (DDS_LC_CONFIG, "channel %s: transmit port %d\n", chptr->name, (int) ddsi_tran_port (chptr->transmit_conn));
 
-#ifdef DDSI_INCLUDE_BANDWIDTH_LIMITING
+#ifdef DDS_HAS_BANDWIDTH_LIMITING
       if (chptr->auxiliary_bandwidth_limit > 0 || lookup_thread_properties (tname))
       {
         chptr->evq = xeventq_new
@@ -1475,7 +1475,7 @@ int rtps_init (struct ddsi_domaingv *gv)
       chptr = chptr->next;
     }
   }
-#endif /* DDSI_INCLUDE_NETWORK_CHANNELS */
+#endif /* DDS_HAS_NETWORK_CHANNELS */
 
   /* Create event queues */
 
@@ -1484,14 +1484,14 @@ int rtps_init (struct ddsi_domaingv *gv)
     gv->xmit_conn,
     gv->config.max_queued_rexmit_bytes,
     gv->config.max_queued_rexmit_msgs,
-#ifdef DDSI_INCLUDE_BANDWIDTH_LIMITING
+#ifdef DDS_HAS_BANDWIDTH_LIMITING
     gv->config.auxiliary_bandwidth_limit
 #else
     0
 #endif
   );
 
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
   q_omg_security_init(gv);
 #endif
 
@@ -1535,7 +1535,7 @@ int rtps_init (struct ddsi_domaingv *gv)
   }
 
   gv->builtins_dqueue = nn_dqueue_new ("builtins", gv, gv->config.delivery_queue_maxsamples, builtins_dqueue_handler, NULL);
-#ifdef DDSI_INCLUDE_NETWORK_CHANNELS
+#ifdef DDS_HAS_NETWORK_CHANNELS
   for (struct ddsi_config_channel_listelem *chptr = gv->config.channels; chptr; chptr = chptr->next)
     chptr->dqueue = nn_dqueue_new (chptr->name, &gv->config, gv->config.delivery_queue_maxsamples, user_dqueue_handler, NULL);
 #else
@@ -1547,7 +1547,7 @@ int rtps_init (struct ddsi_domaingv *gv)
   return 0;
 
 #if 0
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
 err_post_omg_security_init:
   q_omg_security_stop (gv); // should be a no-op as it starts lazily
   q_omg_security_deinit(gv->security_context);
@@ -1581,7 +1581,7 @@ err_unicast_sockets:
 #endif
   ddsrt_hh_free (gv->sertopics);
   ddsrt_mutex_destroy (&gv->sertopics_lock);
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
   ddsi_xqos_fini (&gv->builtin_stateless_xqos_wr);
   ddsi_xqos_fini (&gv->builtin_stateless_xqos_rd);
   ddsi_xqos_fini (&gv->builtin_volatile_xqos_wr);
@@ -1601,7 +1601,7 @@ err_unicast_sockets:
 
   ddsi_serdatapool_free (gv->serpool);
   nn_xmsgpool_free (gv->xmsgpool);
-#ifdef DDSI_INCLUDE_NETWORK_PARTITIONS
+#ifdef DDS_HAS_NETWORK_PARTITIONS
 err_network_partition_addrset:
   for (struct ddsi_config_networkpartition_listelem *np = gv->config.networkPartitions; np; np = np->next)
     unref_addrset (np->as);
@@ -1622,7 +1622,7 @@ err_udp_tcp_init:
   return -1;
 }
 
-#ifdef DDSI_INCLUDE_NETWORK_CHANNELS
+#ifdef DDS_HAS_NETWORK_CHANNELS
 static void stop_all_xeventq_upto (struct ddsi_config_channel_listelem *chptr)
 {
   for (struct ddsi_config_channel_listelem *chptr1 = gv->config.channels; chptr1 != chptr; chptr1 = chptr1->next)
@@ -1635,7 +1635,7 @@ int rtps_start (struct ddsi_domaingv *gv)
 {
   if (xeventq_start (gv->xevents, NULL) < 0)
     return -1;
-#ifdef DDSI_INCLUDE_NETWORK_CHANNELS
+#ifdef DDS_HAS_NETWORK_CHANNELS
   for (struct ddsi_config_channel_listelem *chptr = gv->config.channels; chptr; chptr = chptr->next)
   {
     if (chptr->evq)
@@ -1652,7 +1652,7 @@ int rtps_start (struct ddsi_domaingv *gv)
 
   if (setup_and_start_recv_threads (gv) < 0)
   {
-#ifdef DDSI_INCLUDE_NETWORK_CHANNELS
+#ifdef DDS_HAS_NETWORK_CHANNELS
     stop_all_xeventq_upto (NULL);
 #endif
     xeventq_stop (gv->xevents);
@@ -1701,7 +1701,7 @@ void rtps_stop (struct ddsi_domaingv *gv)
 {
   struct thread_state1 * const ts1 = lookup_thread_state ();
 
-#ifdef DDSI_INCLUDE_NETWORK_CHANNELS
+#ifdef DDS_HAS_NETWORK_CHANNELS
   struct ddsi_config_channel_listelem * chptr;
 #endif
 
@@ -1723,13 +1723,13 @@ void rtps_stop (struct ddsi_domaingv *gv)
   }
 
   xeventq_stop (gv->xevents);
-#ifdef DDSI_INCLUDE_NETWORK_CHANNELS
+#ifdef DDS_HAS_NETWORK_CHANNELS
   for (chptr = gv->config.channels; chptr; chptr = chptr->next)
   {
     if (chptr->evq)
       xeventq_stop (chptr->evq);
   }
-#endif /* DDSI_INCLUDE_NETWORK_CHANNELS */
+#endif /* DDS_HAS_NETWORK_CHANNELS */
 
   /* Send a bubble through the delivery queue for built-ins, so that any
      pending proxy participant discovery is finished before we start
@@ -1811,7 +1811,7 @@ void rtps_stop (struct ddsi_domaingv *gv)
 
   /* Stop background (handshake) processing in security implementation,
      do this only once we know no new events will be coming in. */
-#if DDSI_INCLUDE_SECURITY
+#if DDS_HAS_SECURITY
   q_omg_security_stop (gv);
 #endif
 
@@ -1844,7 +1844,7 @@ void rtps_fini (struct ddsi_domaingv *gv)
      the expected reference counts all over the radmin thingummies. */
   nn_dqueue_free (gv->builtins_dqueue);
 
-#ifdef DDSI_INCLUDE_NETWORK_CHANNELS
+#ifdef DDS_HAS_NETWORK_CHANNELS
   chptr = gv->config.channels;
   while (chptr)
   {
@@ -1855,7 +1855,7 @@ void rtps_fini (struct ddsi_domaingv *gv)
   nn_dqueue_free (gv->user_dqueue);
 #endif
 
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
   q_omg_security_deinit (gv->security_context);
 #endif
 
@@ -1867,7 +1867,7 @@ void rtps_fini (struct ddsi_domaingv *gv)
     nn_xpack_sendq_fini (gv);
   }
 
-#ifdef DDSI_INCLUDE_NETWORK_CHANNELS
+#ifdef DDS_HAS_NETWORK_CHANNELS
   chptr = gv->config.channels;
   while (chptr)
   {
@@ -1894,7 +1894,7 @@ void rtps_fini (struct ddsi_domaingv *gv)
     fclose (gv->pcap_fp);
   }
 
-#ifdef DDSI_INCLUDE_NETWORK_PARTITIONS
+#ifdef DDS_HAS_NETWORK_PARTITIONS
   for (struct ddsi_config_networkpartition_listelem *np = gv->config.networkPartitions; np; np = np->next)
     unref_addrset (np->as);
 #endif
@@ -1930,7 +1930,7 @@ void rtps_fini (struct ddsi_domaingv *gv)
   ddsrt_hh_free (gv->sertopics);
   ddsrt_mutex_destroy (&gv->sertopics_lock);
 
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
   q_omg_security_free (gv);
   ddsi_xqos_fini (&gv->builtin_stateless_xqos_wr);
   ddsi_xqos_fini (&gv->builtin_stateless_xqos_rd);

--- a/src/core/ddsi/src/q_misc.c
+++ b/src/core/ddsi/src/q_misc.c
@@ -21,7 +21,7 @@
 extern inline seqno_t fromSN (const nn_sequence_number_t sn);
 extern inline nn_sequence_number_t toSN (seqno_t n);
 
-#ifdef DDSI_INCLUDE_NETWORK_PARTITIONS
+#ifdef DDS_HAS_NETWORK_PARTITIONS
 int WildcardOverlap(char * p1, char * p2)
 {
   /* both patterns are empty or contain wildcards => overlap */
@@ -107,7 +107,7 @@ int ddsi2_patmatch (const char *pat, const char *str)
   return *str == 0;
 }
 
-#ifdef DDSI_INCLUDE_NETWORK_PARTITIONS
+#ifdef DDS_HAS_NETWORK_PARTITIONS
 static char *get_partition_search_pattern (const char *partition, const char *topic)
 {
   size_t sz = strlen (partition) + strlen (topic) + 2;
@@ -137,9 +137,9 @@ int is_ignored_partition (const struct ddsi_config *cfg, const char *partition, 
   ddsrt_free (pt);
   return ip != NULL;
 }
-#endif /* DDSI_INCLUDE_NETWORK_PARTITIONS */
+#endif /* DDS_HAS_NETWORK_PARTITIONS */
 
-#ifdef DDSI_INCLUDE_NETWORK_CHANNELS
+#ifdef DDS_HAS_NETWORK_CHANNELS
 struct ddsi_config_channel_listelem *find_channel (const struct config *cfg, nn_transport_priority_qospolicy_t transport_priority)
 {
   struct ddsi_config_channel_listelem *c;
@@ -156,4 +156,4 @@ struct ddsi_config_channel_listelem *find_channel (const struct config *cfg, nn_
   }
   return cfg->max_channel;
 }
-#endif /* DDSI_INCLUDE_NETWORK_CHANNELS */
+#endif /* DDS_HAS_NETWORK_CHANNELS */

--- a/src/core/ddsi/src/q_transmit.c
+++ b/src/core/ddsi/src/q_transmit.c
@@ -315,7 +315,7 @@ struct nn_xmsg *writer_hbcontrol_piggyback (struct writer *wr, const struct whc_
   return msg;
 }
 
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
 struct nn_xmsg *writer_hbcontrol_p2p(struct writer *wr, const struct whc_state *whcst, int hbansreq, struct proxy_reader *prd)
 {
   struct ddsi_domaingv const * const gv = wr->e.gv;
@@ -919,7 +919,7 @@ static int insert_sample_in_whc (struct writer *wr, seqno_t seq, struct ddsi_pli
   }
 
   assert (wr->reliable || have_reliable_subs (wr) == 0);
-#ifdef DDSI_INCLUDE_DEADLINE_MISSED
+#ifdef DDS_HAS_DEADLINE_MISSED
   /* If deadline missed duration is not infinite, the sample is inserted in
      the whc so that the instance is created (or renewed) in the whc and the deadline
      missed event is registered. The sample is removed immediately after inserting it
@@ -930,7 +930,7 @@ static int insert_sample_in_whc (struct writer *wr, seqno_t seq, struct ddsi_pli
   if ((wr->reliable && have_reliable_subs (wr)) || wr_deadline || wr->handle_as_transient_local)
   {
     ddsrt_mtime_t exp = DDSRT_MTIME_NEVER;
-#ifdef DDSI_INCLUDE_LIFESPAN
+#ifdef DDS_HAS_LIFESPAN
     /* Don't set expiry for samples with flags unregister or dispose, because these are required
      * for sample lifecycle and should always be delivered to the reader so that is can clean up
      * its history cache. */
@@ -939,7 +939,7 @@ static int insert_sample_in_whc (struct writer *wr, seqno_t seq, struct ddsi_pli
 #endif
     res = ((insres = whc_insert (wr->whc, writer_max_drop_seq (wr), seq, exp, plist, serdata, tk)) < 0) ? insres : 1;
 
-#ifdef DDSI_INCLUDE_DEADLINE_MISSED
+#ifdef DDS_HAS_DEADLINE_MISSED
     if (!(wr->reliable && have_reliable_subs (wr)) && !wr->handle_as_transient_local)
     {
       /* Sample was inserted only because writer has deadline, so we'll remove the sample from whc */

--- a/src/core/ddsi/src/q_xevent.c
+++ b/src/core/ddsi/src/q_xevent.c
@@ -625,7 +625,7 @@ static void handle_xevk_entityid (struct nn_xpack *xp, struct xevent_nt *ev)
   nn_xpack_addmsg (xp, ev->u.entityid.msg, 0);
 }
 
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
 static int send_heartbeat_to_all_readers_check_and_sched (struct xevent *ev, struct writer *wr, const struct whc_state *whcst, ddsrt_mtime_t tnow, ddsrt_mtime_t *t_next)
 {
   int send;
@@ -710,8 +710,6 @@ static void send_heartbeat_to_all_readers (struct nn_xpack *xp, struct xevent *e
 
   ddsrt_mutex_unlock (&wr->e.lock);
 }
-
-
 #endif
 
 static void handle_xevk_heartbeat (struct nn_xpack *xp, struct xevent *ev, ddsrt_mtime_t tnow)
@@ -729,7 +727,7 @@ static void handle_xevk_heartbeat (struct nn_xpack *xp, struct xevent *ev, ddsrt
     return;
   }
 
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
   if (wr->e.guid.entityid.u == NN_ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER)
   {
     send_heartbeat_to_all_readers(xp, ev, wr, tnow);

--- a/src/core/ddsi/tests/plist.c
+++ b/src/core/ddsi/tests/plist.c
@@ -16,6 +16,7 @@
 #include "dds/ddsrt/endian.h"
 #include "dds/ddsi/ddsi_xqos.h"
 #include "dds/ddsi/ddsi_plist.h"
+#include "dds/features.h"
 
 CU_Test (ddsi_plist, unalias_copy_merge)
 {
@@ -33,7 +34,7 @@ CU_Test (ddsi_plist, unalias_copy_merge)
   p0strs[0] = p0.qos.partition.strs[0] = "aap";
   p0strs[1] = p0.qos.partition.strs[1] = "noot";
   p0strs[2] = p0.qos.partition.strs[2] = "mies";
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
   p0.present |= PP_IDENTITY_TOKEN;
   p0.aliased |= PP_IDENTITY_TOKEN;
   p0.identity_token.class_id = "class_id";
@@ -54,7 +55,7 @@ CU_Test (ddsi_plist, unalias_copy_merge)
   ddsi_plist_t p0alias;
   memcpy (&p0alias, &p0, sizeof (p0));
   p0alias.qos.partition.strs = ddsrt_memdup (p0alias.qos.partition.strs, p0.qos.partition.n * sizeof (*p0.qos.partition.strs));
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
   p0alias.identity_token.properties.props = ddsrt_memdup (p0alias.identity_token.properties.props,
                                               p0.identity_token.properties.n * sizeof (*p0.identity_token.properties.props));
 #endif
@@ -64,7 +65,7 @@ CU_Test (ddsi_plist, unalias_copy_merge)
   CU_ASSERT_STRING_EQUAL (p0.qos.partition.strs[0], p0strs[0]);
   CU_ASSERT_STRING_EQUAL (p0.qos.partition.strs[1], p0strs[1]);
   CU_ASSERT_STRING_EQUAL (p0.qos.partition.strs[2], p0strs[2]);
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
   CU_ASSERT_STRING_EQUAL (p0.identity_token.properties.props[0].name,  p0strs[3]);
   CU_ASSERT_STRING_EQUAL (p0.identity_token.properties.props[0].value, p0strs[4]);
   CU_ASSERT_STRING_EQUAL (p0.identity_token.properties.props[1].name,  p0strs[5]);
@@ -90,7 +91,7 @@ CU_Test (ddsi_plist, unalias_copy_merge)
   CU_ASSERT_STRING_EQUAL (p1.qos.partition.strs[0], p0.qos.partition.strs[0]);
   CU_ASSERT_STRING_EQUAL (p1.qos.partition.strs[1], p0.qos.partition.strs[1]);
   CU_ASSERT_STRING_EQUAL (p1.qos.partition.strs[2], p0.qos.partition.strs[2]);
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
   CU_ASSERT (p1.identity_token.class_id != p0.identity_token.class_id);
   CU_ASSERT_STRING_EQUAL (p1.identity_token.class_id, p0.identity_token.class_id);
   CU_ASSERT (p1.identity_token.properties.n == p0.identity_token.properties.n);
@@ -134,7 +135,7 @@ CU_Test (ddsi_plist, unalias_copy_merge)
   CU_ASSERT_STRING_EQUAL (p2.qos.partition.strs[0], p0.qos.partition.strs[0]);
   CU_ASSERT_STRING_EQUAL (p2.qos.partition.strs[1], p0.qos.partition.strs[1]);
   CU_ASSERT_STRING_EQUAL (p2.qos.partition.strs[2], p0.qos.partition.strs[2]);
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
   CU_ASSERT (p2.identity_token.class_id != p0.identity_token.class_id);
   CU_ASSERT_STRING_EQUAL (p2.identity_token.class_id, p0.identity_token.class_id);
   CU_ASSERT (p2.identity_token.properties.n == p0.identity_token.properties.n);
@@ -169,7 +170,7 @@ CU_Test (ddsi_plist, unalias_copy_merge)
   CU_ASSERT_STRING_EQUAL (p0.qos.partition.strs[0], p0strs[0]);
   CU_ASSERT_STRING_EQUAL (p0.qos.partition.strs[1], p0strs[1]);
   CU_ASSERT_STRING_EQUAL (p0.qos.partition.strs[2], p0strs[2]);
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
   CU_ASSERT (p0.identity_token.properties.props[0].name  != p0strs[3]);
   CU_ASSERT (p0.identity_token.properties.props[0].value != p0strs[4]);
   CU_ASSERT (p0.identity_token.properties.props[1].name  != p0strs[5]);
@@ -201,7 +202,7 @@ CU_Test (ddsi_plist, unalias_copy_merge)
   CU_ASSERT_STRING_EQUAL (p3.qos.partition.strs[0], p0.qos.partition.strs[0]);
   CU_ASSERT_STRING_EQUAL (p3.qos.partition.strs[1], p0.qos.partition.strs[1]);
   CU_ASSERT_STRING_EQUAL (p3.qos.partition.strs[2], p0.qos.partition.strs[2]);
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
   CU_ASSERT (p3.identity_token.class_id != p0.identity_token.class_id);
   CU_ASSERT_STRING_EQUAL (p3.identity_token.class_id, p0.identity_token.class_id);
   CU_ASSERT (p3.identity_token.properties.n == p0.identity_token.properties.n);
@@ -245,7 +246,7 @@ CU_Test (ddsi_plist, unalias_copy_merge)
   CU_ASSERT_STRING_EQUAL (p4.qos.partition.strs[0], p0.qos.partition.strs[0]);
   CU_ASSERT_STRING_EQUAL (p4.qos.partition.strs[1], p0.qos.partition.strs[1]);
   CU_ASSERT_STRING_EQUAL (p4.qos.partition.strs[2], p0.qos.partition.strs[2]);
-#ifdef DDSI_INCLUDE_SECURITY
+#ifdef DDS_HAS_SECURITY
   CU_ASSERT (p4.identity_token.class_id != p0.identity_token.class_id);
   CU_ASSERT_STRING_EQUAL (p4.identity_token.class_id, p0.identity_token.class_id);
   CU_ASSERT (p4.identity_token.properties.n == p0.identity_token.properties.n);

--- a/src/core/xtests/rhc_torture/rhc_torture.c
+++ b/src/core/xtests/rhc_torture/rhc_torture.c
@@ -33,7 +33,7 @@
 #include "dds/ddsc/dds_rhc.h"
 #include "dds__rhc_default.h"
 #include "dds/ddsi/ddsi_iid.h"
-#ifdef DDSI_INCLUDE_LIFESPAN
+#ifdef DDS_HAS_LIFESPAN
 #include "dds/ddsi/ddsi_lifespan.h"
 #endif
 
@@ -73,7 +73,7 @@ static char *print_tstamp (char *buf, size_t sz, dds_time_t t)
   if (d / 1000000000 != 0)
     pos += (size_t) snprintf (buf + pos, sz - pos, "%+ds", (int) (d / 1000000000));
   if (d % 1000000000 != 0)
-	(void) snprintf (buf + pos, sz - pos, "%+dns", (int) (d % 1000000000));
+        (void) snprintf (buf + pos, sz - pos, "%+dns", (int) (d % 1000000000));
   return buf;
 }
 
@@ -107,7 +107,7 @@ static struct ddsi_serdata *mkkeysample (int32_t keyval, unsigned statusinfo)
   return sd;
 }
 
-#if defined(DDSI_INCLUDE_LIFESPAN) || defined (DDSI_INCLUDE_DEADLINE_MISSED)
+#if defined(DDS_HAS_LIFESPAN) || defined (DDS_HAS_DEADLINE_MISSED)
 static ddsrt_mtime_t rand_texp ()
 {
   ddsrt_mtime_t ret = ddsrt_time_monotonic();
@@ -116,7 +116,7 @@ static ddsrt_mtime_t rand_texp ()
 }
 #endif
 
-#ifdef DDSI_INCLUDE_DEADLINE_MISSED
+#ifdef DDS_HAS_DEADLINE_MISSED
 static dds_duration_t rand_deadline ()
 {
   return (dds_duration_t) (ddsrt_prng_random (&prng) % DDS_MSECS(500));
@@ -125,7 +125,7 @@ static dds_duration_t rand_deadline ()
 
 static uint64_t store (struct ddsi_tkmap *tkmap, struct dds_rhc *rhc, struct proxy_writer *wr, struct ddsi_serdata *sd, bool print, bool lifespan_expiry)
 {
-#ifndef DDSI_INCLUDE_LIFESPAN
+#ifndef DDS_HAS_LIFESPAN
   DDSRT_UNUSED_ARG (lifespan_expiry);
 #endif
   /* beware: unrefs sd */
@@ -154,7 +154,7 @@ static uint64_t store (struct ddsi_tkmap *tkmap, struct dds_rhc *rhc, struct pro
   pwr_info.guid = wr->e.guid;
   pwr_info.iid = wr->e.iid;
   pwr_info.ownership_strength = wr->c.xqos->ownership_strength.value;
-#ifdef DDSI_INCLUDE_LIFESPAN
+#ifdef DDS_HAS_LIFESPAN
   if (lifespan_expiry && (sd->statusinfo & (NN_STATUSINFO_UNREGISTER | NN_STATUSINFO_DISPOSE)) == 0)
     pwr_info.lifespan_exp = rand_texp();
   else
@@ -576,7 +576,7 @@ static void test_conditions (dds_entity_t pp, dds_entity_t tp, const int count, 
   dds_qos_t *qos = dds_create_qos ();
   dds_qset_history (qos, DDS_HISTORY_KEEP_LAST, MAX_HIST_DEPTH);
   dds_qset_destination_order (qos, DDS_DESTINATIONORDER_BY_SOURCE_TIMESTAMP);
-#ifdef DDSI_INCLUDE_DEADLINE_MISSED
+#ifdef DDS_HAS_DEADLINE_MISSED
   dds_qset_deadline (qos, rand_deadline());
 #endif
   /* two identical readers because we need 63 conditions while we can currently only attach 32 a single reader */
@@ -699,12 +699,12 @@ static void test_conditions (dds_entity_t pp, dds_entity_t tp, const int count, 
     [9]  = 30,  /* take cond */
     [10] = 100, /* take cond, max 1 */
     [11] = 1,   /* unreg writer */
-#ifdef DDSI_INCLUDE_LIFESPAN
+#ifdef DDS_HAS_LIFESPAN
     [12] = 100, /* drop expired sample */
 #else
     [12] = 0,   /* drop expired sample */
 #endif
-#ifdef DDSI_INCLUDE_DEADLINE_MISSED
+#ifdef DDS_HAS_DEADLINE_MISSED
     [13] = 100  /* deadline missed */
 #else
     [13] = 0    /* drop expired sample */
@@ -830,7 +830,7 @@ static void test_conditions (dds_entity_t pp, dds_entity_t tp, const int count, 
         wr_info.guid = wr[which]->e.guid;
         wr_info.iid = wr[which]->e.iid;
         wr_info.ownership_strength = wr[which]->c.xqos->ownership_strength.value;
-#ifdef DDSI_INCLUDE_LIFESPAN
+#ifdef DDS_HAS_LIFESPAN
         wr_info.lifespan_exp = DDSRT_MTIME_NEVER;
 #endif
         for (size_t k = 0; k < nrd; k++)
@@ -839,7 +839,7 @@ static void test_conditions (dds_entity_t pp, dds_entity_t tp, const int count, 
         break;
       }
       case 12: {
-#ifdef DDSI_INCLUDE_LIFESPAN
+#ifdef DDS_HAS_LIFESPAN
         thread_state_awake_domain_ok (lookup_thread_state ());
         /* We can assume that rhc[k] is a dds_rhc_default at this point */
         for (size_t k = 0; k < nrd; k++)
@@ -849,7 +849,7 @@ static void test_conditions (dds_entity_t pp, dds_entity_t tp, const int count, 
         break;
       }
       case 13: {
-#ifdef DDSI_INCLUDE_DEADLINE_MISSED
+#ifdef DDS_HAS_DEADLINE_MISSED
         thread_state_awake_domain_ok (lookup_thread_state ());
         /* We can assume that rhc[k] is a dds_rhc_default at this point */
         for (size_t k = 0; k < nrd; k++)
@@ -995,7 +995,7 @@ int main (int argc, char **argv)
     wr0_info.guid = wr0->e.guid;
     wr0_info.iid = wr0->e.iid;
     wr0_info.ownership_strength = wr0->c.xqos->ownership_strength.value;
-#ifdef DDSI_INCLUDE_LIFESPAN
+#ifdef DDS_HAS_LIFESPAN
     wr0_info.lifespan_exp = DDSRT_MTIME_NEVER;
 #endif
     dds_rhc_unregister_wr (rhc, &wr0_info);

--- a/src/features.h.in
+++ b/src/features.h.in
@@ -21,4 +21,13 @@
 /* Whether or not support for generating "deadline missed" events is included */
 #cmakedefine DDS_HAS_DEADLINE_MISSED @DDS_HAS_DEADLINE_MISSED@
 
+/* Whether or not support for network partitions is included */
+#cmakedefine DDS_HAS_NETWORK_PARTITIONS @DDS_HAS_NETWORK_PARTITIONS@
+
+/* Whether or not support for source-specific multicast is included */
+#cmakedefine DDS_HAS_SSM @DDS_HAS_SSM@
+
+/* Whether or not features dependent on OpenSSL are included */
+#cmakedefine DDS_HAS_SSL @DDS_HAS_SSL@
+
 #endif

--- a/src/mpt/tests/qos/procs/rw.c
+++ b/src/mpt/tests/qos/procs/rw.c
@@ -93,12 +93,12 @@ static void setqos (dds_qos_t *q, size_t i, bool isrd, bool create)
   dds_qset_history (q, (dds_history_kind_t) ((i + 1) % 2), (int32_t) (i + 1));
   dds_qset_resource_limits (q, (int32_t) i + 3, (int32_t) i + 2, (int32_t) i + 1);
   dds_qset_presentation (q, (dds_presentation_access_scope_kind_t) ((psi + 1) % 3), 1, 1);
-#ifdef DDSI_INCLUDE_LIFESPAN
+#ifdef DDS_HAS_LIFESPAN
   dds_qset_lifespan (q, INT64_C (23456789012345678) + (int32_t) i);
 #else
   dds_qset_lifespan (q, DDS_INFINITY);
 #endif
-#ifdef DDSI_INCLUDE_DEADLINE_MISSED
+#ifdef DDS_HAS_DEADLINE_MISSED
   dds_qset_deadline (q, INT64_C (67890123456789012) + (int32_t) i);
 #else
   dds_qset_deadline (q, DDS_INFINITY);

--- a/src/tools/ddsconf/ddsconf.h
+++ b/src/tools/ddsconf/ddsconf.h
@@ -13,6 +13,8 @@
 #include <stdbool.h>
 #include <stdio.h>
 
+#include "dds/features.h"
+
 struct cfgelem;
 
 void gendef_pf_nop (FILE *fp, void *parent, struct cfgelem const * const cfgelem);
@@ -22,14 +24,14 @@ void gendef_pf_uint32 (FILE *fp, void *parent, struct cfgelem const * const cfge
 void gendef_pf_int64 (FILE *fp, void *parent, struct cfgelem const * const cfgelem);
 void gendef_pf_maybe_int32 (FILE *fp, void *parent, struct cfgelem const * const cfgelem);
 void gendef_pf_maybe_uint32 (FILE *fp, void *parent, struct cfgelem const * const cfgelem);
-#ifdef DDSI_INCLUDE_SSL
+#ifdef DDS_HAS_SSL
 void gendef_pf_min_tls_version (FILE *fp, void *parent, struct cfgelem const * const cfgelem);
 #endif
 void gendef_pf_string (FILE *fp, void *parent, struct cfgelem const * const cfgelem);
 void gendef_pf_networkAddresses (FILE *fp, void *parent, struct cfgelem const * const cfgelem);
 void gendef_pf_tracemask (FILE *fp, void *parent, struct cfgelem const * const cfgelem);
 void gendef_pf_xcheck (FILE *fp, void *parent, struct cfgelem const * const cfgelem);
-#ifdef DDSI_INCLUDE_BANDWIDTH_LIMITING
+#ifdef DDS_HAS_BANDWIDTH_LIMITING
 void gendef_pf_bandwidth (FILE *fp, void *parent, struct cfgelem const * const cfgelem);
 #endif
 void gendef_pf_memsize (FILE *fp, void *parent, struct cfgelem const * const cfgelem);

--- a/src/tools/ddsconf/defconfig.c
+++ b/src/tools/ddsconf/defconfig.c
@@ -9,6 +9,7 @@
 #include "dds/ddsrt/static_assert.h"
 #include "dds/ddsrt/misc.h"
 #include "dds/ddsi/q_config.h"
+#include "dds/features.h"
 
 #include "ddsconf.h"
 
@@ -71,7 +72,7 @@ void gendef_pf_maybe_uint32 (FILE *out, void *parent, struct cfgelem const * con
     fprintf (out, "  cfg->%s.value = UINT32_C (%"PRIu32");\n", cfgelem->membername, p->value);
 }
 
-#ifdef DDSI_INCLUDE_SSL
+#ifdef DDS_HAS_SSL
 void gendef_pf_min_tls_version (FILE *out, void *parent, struct cfgelem const * const cfgelem)
 {
   struct ddsi_config_ssl_min_version * const p = cfg_address (parent, cfgelem);
@@ -119,7 +120,7 @@ void gendef_pf_tracemask (FILE *out, void *parent, struct cfgelem const * const 
 void gendef_pf_xcheck (FILE *out, void *parent, struct cfgelem const * const cfgelem) {
   gendef_pf_uint32 (out, parent, cfgelem);
 }
-#ifdef DDSI_INCLUDE_BANDWIDTH_LIMITING
+#ifdef DDS_HAS_BANDWIDTH_LIMITING
 void gendef_pf_bandwidth (FILE *out, void *parent, struct cfgelem const * const cfgelem) {
   gendef_pf_uint32 (out, parent, cfgelem);
 }


### PR DESCRIPTION
Compile-time options (e.g., security, deadline) are configured via CMake options and reflected in a generated file named "features.h" with names like DDS_HAS_...  This commit changes the code to exclusively rely on this generated features.h file.

That means there is no longer a need to specify DDSI_INCLUDE_... on the the compiler command line (via CMake's add_definitions).  Anyone wishing to, e.g., use dds_create_participant_config thus need not worry which set of macros needs to be defined.

Signed-off-by: Erik Boasson <eb@ilities.com>