### PR TITLE
Adding missing build_depend on JDK for IDLC in package.xml.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,7 @@
     <buildtool_depend>cmake</buildtool_depend>
 
     <build_depend>libssl-dev</build_depend>
+    <build_depend>java</build_depend>
 
     <exec_depend>openssl</exec_depend>
 


### PR DESCRIPTION
Closes #642 

Should probably be ported to `releases/0.7.x` for Dashing, Eloquent, and Foxy, at least.