### PR TITLE
Double number of thread slots

### DIFF
--- a/src/core/ddsc/src/dds_init.c
+++ b/src/core/ddsc/src/dds_init.c
@@ -112,7 +112,7 @@ dds_return_t dds_init (void)
   ddsrt_mutex_init (&dds_global.m_mutex);
   ddsrt_cond_init (&dds_global.m_cond);
   ddsi_iid_init ();
-  thread_states_init (64);
+  thread_states_init (128);
 
   if (dds_handle_server_init () != DDS_RETCODE_OK)
   {


### PR DESCRIPTION
This should be dynamically adjusted, not statically allocated at the beginning, and it definitely should not be hard-coded.  But it should alleviate issues for people blessed with 96 cores machines and anyone else trying to have a handful over 40-odd threads calling into the API simultaneously.

Signed-off-by: Erik Boasson <eb@ilities.com>