### PR TITLE
Add support for Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,201 @@
+#
+# Copyright(c) 2020 ADLINK Technology Limited and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+ubuntu_2004: &ubuntu_2004
+  container:
+    dockerfile: .cirrus/ubuntu2004/Dockerfile
+  env:
+    PATH: "${HOME}/.local/bin:${PATH}"
+    COV_COMPTYPE: gcc
+    COV_PLATFORM: linux64
+    GENERATOR: "Unix Makefiles"
+    BUILD_TOOL_OPTIONS: "-j 4"
+  pip_cache:
+    folder: ${HOME}/.cache/pip
+  conan_cache:
+    folder: ${HOME}/.conan/data
+  maven_cache:
+    folder: ${HOME}/.m2
+  bootstrap_script:
+    - pip3 install --user conan
+
+ubuntu_2004_gcc10: &ubuntu_2004_gcc10
+  <<: *ubuntu_2004
+  env:
+    CC: gcc-10
+
+ubuntu_2004_clang10: &ubuntu_2004_clang10
+  <<: *ubuntu_2004
+  env:
+    CC: clang-10
+
+freebsd12_clang8: &freebsd_12_clang8
+  freebsd_instance:
+    image_family: freebsd-12-1
+  env:
+    PATH: "${HOME}/.local/bin:${PATH}"
+    CC: clang
+    GENERATOR: "Unix Makefiles"
+    BUILD_TOOL_OPTIONS: "-j 4"
+  pip_cache:
+    folder: ${HOME}/.cache/pip
+  conan_cache:
+    folder: ${HOME}/.conan/data
+  maven_cache:
+    folder: ${HOME}/.m2
+  bootstrap_script:
+    - pkg update -f
+    - pkg install -y bash cmake maven openjdk11 perl5 py37-sqlite3 py37-pip
+    - pip install --user conan
+
+macos_1015_xcode11: &macos_1015_xcode11_5
+  osx_instance:
+    image: catalina-xcode-11.5
+  env:
+    PATH: "/usr/local/opt/openjdk/bin:${PATH}"
+    CC: clang
+    COV_COMPTYPE: clang
+    COV_PLATFORM: macOSX
+    GENERATOR: "Unix Makefiles"
+    BUILD_TOOL_OPTIONS: "-j 4"
+  pip_cache:
+    folder: ${HOME}/Library/Caches/pip
+  conan_cache:
+    folder: ${HOME}/.conan/data
+  maven_cache:
+    folder: ${HOME}/.m2
+  bootstrap_script:
+    - brew install bison cmake python3 maven
+    - python3 -m pip install --user conan
+    # Environment variables do not persist between scripts. Generate a proxy
+    # for Conan in /usr/local/bin/conan and forward the parameters.
+    - printf "#!/bin/bash\n$(python3 -m site --user-base)/bin/conan \"\$@\"\n" >> /usr/local/bin/conan
+    - chmod a+x /usr/local/bin/conan
+
+windows_2019_vs2019: &windows_2019_vs2019
+  windows_container:
+    dockerfile: .cirrus/windows2019/Dockerfile
+  env:
+    CIRRUS_SHELL: bash
+    COV_COMPTYPE: msvc
+    COV_PLATFORM: win64
+    BUILD_TOOL_OPTIONS: "-nologo -verbosity:minimal -maxcpucount -p:CL_MPCount=4"
+  pip_cache:
+    folder: ${LOCALAPPDATA}/pip/Cache
+  conan_cache:
+    folder: ${USERPROFILE}/.conan/data
+  maven_cache:
+    folder: ${USERPROFILE}/.m2
+  bootstrap_script:
+    - pip3 install --user conan
+
+env:
+  CYCLONEDDS_URI: '<CycloneDDS><DDSI2E><Internal><EnableExpensiveChecks>all</EnableExpensiveChecks></Internal></DDSI2E></CycloneDDS>'
+
+task:
+  matrix:
+    - name: "Ubuntu 20.04 LTS with GCC 10 (Debug)"
+      <<: *ubuntu_2004_gcc10
+      env:
+        BUILD_TYPE: Debug
+        CONANFILE: conanfile102.txt
+    - name: "Ubuntu 20.04 LTS with GCC 10 (Release)"
+      <<: *ubuntu_2004_gcc10
+      env:
+        BUILD_TYPE: Release
+        SSL: NO
+        SECURITY: NO
+    - name: "Ubuntu 20.04 LTS with Clang 10 (Debug)"
+      <<: *ubuntu_2004_clang10
+      env:
+        SANITIZER: address
+        BUILD_TYPE: Debug
+    - name: "Ubuntu 20.04 LTS with Clang 10 (Release)"
+      <<: *ubuntu_2004_clang10
+      env:
+        BUILD_TYPE: Release
+        LIFESPAN: NO
+        DEADLINE: NO
+    - name: "macOS 10.15 with Xcode 11.5 (Debug)"
+      <<: *macos_1015_xcode11_5
+      env:
+        SANITIZER: address
+        BUILD_TYPE: Debug
+    - name: "macOS 10.15 with Xcode 11.5 (Release)"
+      <<: *macos_1015_xcode11_5
+      env:
+        BUILD_TYPE: Release
+        MACOSX_DEPLOYMENT_TARGET: 10.12
+    - name: "FreeBSD 12.1 with Clang 8 (Debug)"
+      <<: *freebsd_12_clang8
+      env:
+        SANITIZER: address
+        BUILD_TYPE: Debug
+        SSL: NO
+        SECURITY: NO
+    - name: "Windows 2019 with Visual Studio 2019 (Debug, x86)"
+      <<: *windows_2019_vs2019
+      env:
+        ARCH: x86
+        PLATFORM: -A Win32
+        GENERATOR: "Visual Studio 16 2019"
+        BUILD_TYPE: Debug
+    - name: "Windows 2019 with Visual Studio 2019 (Release, x86_64)"
+      <<: *windows_2019_vs2019
+      env:
+        PLATFORM: -A x64
+        GENERATOR: "Visual Studio 16 2019"
+        BUILD_TYPE: Release
+  install_script:
+    - mkdir build
+    - cd build
+    - conan profile new default --detect
+    - conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan
+    - conan install -b missing -s arch=${ARCH:-x86_64} -s build_type=${BUILD_TYPE} ../${CONANFILE:-conanfile.txt}
+  build_script:
+    - cd build
+    - cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
+            -DCMAKE_INSTALL_PREFIX=$(pwd)/install
+            -DUSE_SANITIZER=${SANITIZER:-none}
+            -DENABLE_SSL=${SSL:-YES}
+            -DENABLE_SECURITY=${SECURITY:-YES}
+            -DENABLE_LIFESPAN=${LIFESPAN:-YES}
+            -DENABLE_DEADLINE_MISSED=${DEADLINE:-YES}
+            -DBUILD_TESTING=On
+            -DWERROR=on
+            -G "${GENERATOR}" ${PLATFORM} ..
+    - ${SCAN_BUILD} cmake --build . --config ${BUILD_TYPE} --target install -- ${BUILD_TOOL_OPTIONS}
+  test_script:
+    - cd build
+    - ctest -j 4 --output-on-failure -T test -E '^CUnit_ddsrt_random_default_random$' -C ${BUILD_TYPE}
+    - |
+      if [ "${BUILD_TYPE}" = "Release" ]; then
+        ../src/tools/ddsperf/sanity.bash
+      fi
+    - |
+      if [ -n "${SANITIZER}" ]; then
+        CMAKE_C_FLAGS="-DCMAKE_C_FLAGS=-fsanitize=${SANITIZER}"
+        CMAKE_LINKER_FLAGS="-DCMAKE_LINKER_FLAGS=-fsanitize=${SANITIZER}"
+      fi
+    - |
+      if [ "${SSL}" = "ON" ] && [ "${SECURITY}" = "ON" ]; then
+        diff --strip-trailing-cr ../etc/cyclonedds.rnc docs/cyclonedds.rnc && \
+        diff --strip-trailing-cr ../etc/cyclonedds.xsd docs/cyclonedds.xsd && \
+        diff --strip-trailing-cr ../docs/manual/options.md docs/manual/options.md
+      fi
+    - cd ..
+    - mkdir helloworld_build
+    - cd helloworld_build
+    - cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
+            -DCMAKE_PREFIX_PATH=${CIRRUS_WORKING_DIR}/build/install
+            -G "${GENERATOR}" ${PLATFORM} ..
+    - cmake --build . --config ${BUILD_TYPE}
+

--- a/.cirrus/centos8/Dockerfile
+++ b/.cirrus/centos8/Dockerfile
@@ -1,0 +1,8 @@
+FROM centos:8
+# EPEL: https://fedoraproject.org/wiki/EPEL
+RUN dnf install -y epel-release && \
+    dnf install -y 'dnf-command(config-manager)' && \
+    dnf config-manager --set-enabled PowerTools && \
+    dnf update -y
+RUN dnf install -y bison cmake make gcc clang python3 python3-pip ccache \
+                   java-11-openjdk-headless maven

--- a/.cirrus/ubuntu2004/Dockerfile
+++ b/.cirrus/ubuntu2004/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:focal
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update
+RUN apt-get install -y gnupg2 ca-certificates wget curl tzdata ccache
+RUN ln -snf /usr/share/zoneinfo/$(wget -qO - https://ipapi.co/timezone) /etc/localtime
+RUN apt-get update
+RUN apt-get install -y bison cmake gcc-10 clang-10 python3 python3-pip \
+                       openjdk-11-jdk-headless maven

--- a/.cirrus/windows2019/Dockerfile
+++ b/.cirrus/windows2019/Dockerfile
@@ -1,0 +1,19 @@
+FROM cirrusci/windowsservercore:cmake
+COPY .cirrus/windows2019/add_path.bat add_path.bat
+COPY .cirrus/windows2019/user_scripts.py user_scripts.py
+
+#
+# Disable usePackageExitCodes to disable propagation of package exit codes
+# that signal a restart is required and cause Docker build to fail.
+#
+RUN choco feature disable -n=usePackageExitCodes && \
+    choco install --yes --no-progress --installargs='ADD_CMAKE_TO_PATH=System' python3 && \
+    choco install --yes --no-progress openjdk11 maven
+RUN choco install --yes --no-progress winflexbison3 || echo "ignore reboot request"
+
+#
+# Add Python directory to the user path.
+# Add Git to the system path in order to use CIRRUS_SHEL: bash
+#
+RUN python user_scripts.py > %TEMP%\user_base && \
+    add_path READ USER %TEMP%\user_base

--- a/.cirrus/windows2019/add_path.bat
+++ b/.cirrus/windows2019/add_path.bat
@@ -1,0 +1,54 @@
+@ECHO OFF
+
+IF [%1]==[] GOTO usage
+IF [%2]==[] GOTO usage
+
+IF /i "x%1"=="xread" (
+  IF [%3]==[] GOTO usage
+  SET root=%2
+  FOR /f "delims=" %%A IN (%3) DO (
+    SET arg=%%A
+    GOTO break
+  )
+) ELSE (
+  FOR /F "useback tokens=*" %%A IN ('%2') DO SET arg=%%~A
+  SET root=%1
+)
+
+:break
+
+IF /i "x%root%"=="xuser" (
+  SET key="HKEY_CURRENT_USER\Environment"
+  GOTO user
+)
+
+IF /i "x%root%"=="xsystem" (
+  SET key="HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Environment"
+  GOTO system
+)
+
+GOTO usage
+:user
+:system
+
+FOR /F "skip=2 tokens=1,2*" %%A IN ('REG QUERY %key% /V Path') DO (
+  SET name=%%A
+  SET value=%%C
+)
+
+IF "x%value:~-1%"=="x;" SET value=%value:~0,-1%
+
+SET value="%value%;%arg%"
+
+IF DEFINED NAME (
+  REG ADD %key% /V Path /T REG_EXPAND_SZ /D %value% /F
+)
+
+GOTO:eof
+
+:usage
+ECHO Usage: %0 USER path
+ECHO   or   %0 SYSTEM path
+ECHO   or   %0 READ USER file-containing-path
+ECHO   or   %0 READ SYSTEM file-containing-path
+EXIT /B 1

--- a/.cirrus/windows2019/user_scripts.py
+++ b/.cirrus/windows2019/user_scripts.py
@@ -1,0 +1,6 @@
+#!/bin/python
+import os
+import sysconfig
+
+user_scripts_path = sysconfig.get_path('scripts', f'{os.name}_user')
+print(user_scripts_path)


### PR DESCRIPTION
This PR adds build instructions for [Cirrus CI](https://cirrus-ci.org/), a nice independent continuous integration service with some unique features, among them the ability to build with [computing services](https://cirrus-ci.org/guide/supported-computing-services/) from different vendors. Travis is charging nowadays, which is totally fair, but their infrastructure leaves a lot to be desired. i.e. their Windows image is rather messy and FreeBSD support is still beta too. I've contemplated using Azure Pipelines or GitHub actions, but both their agents are written in `C#` and won't run on non-tier-1 platforms. Apart from that, paid computing services or self-hosted runners cannot be shared between the Eclipse Cyclone DDS project and external contributors and I prefer both my own builds as well as PR builds to be as fast as possible.

I fixed the Windows image for Cirrus CI in this [PR](https://github.com/cirruslabs/docker-images-windows/pull/17). It was more work than anticipated, but if the PR is merged everything should be sorted. The Cirrus people were nice enough to [accept a feature request](https://github.com/cirruslabs/cirrus-ci-docs/issues/739), after that's implemented we should be able to use external computing resources for fast builds and contributors can simply use the community cluster, or use computing services of their own. The idea is to have Docker images of our own at some point in the future if necessary. e.g. we can simply create a private Xilinx image to verify FreeRTOS support isn't broken by a PR etc.