### PR TITLE
Odds and ends

### DIFF
--- a/src/core/ddsc/tests/domain.c
+++ b/src/core/ddsc/tests/domain.c
@@ -317,6 +317,7 @@ static void logsink (void *varg, const dds_log_data_t *msg)
     // do by rewriting the {0} to {}
     char *p = strchr (arg->buf[arg->size], '{');
     CU_ASSERT_FATAL (p != NULL);
+    assert (p != NULL); // Clang static analyzer
     p++;
     CU_ASSERT_FATAL (strcmp (p, "}\n") == 0 || strcmp (p, "0}\n") == 0);
     if (*p == '0')

--- a/src/core/ddsc/tests/test_oneliner.c
+++ b/src/core/ddsc/tests/test_oneliner.c
@@ -244,9 +244,15 @@ static dds_return_t check_status_change_fields_are_0 (int ll, dds_entity_t ent)
 #define TOK_INVALID -7
 
 static int setresult (struct oneliner_ctx *ctx, int result, const char *msg, ...) ddsrt_attribute_format((printf, 3, 4));
-static void error (struct oneliner_ctx *ctx, const char *msg, ...) ddsrt_attribute_format((printf, 2, 3));
-static void error_dds (struct oneliner_ctx *ctx, dds_return_t ret, const char *msg, ...) ddsrt_attribute_format((printf, 3, 4));
-static void testfail (struct oneliner_ctx *ctx, const char *msg, ...) ddsrt_attribute_format((printf, 2, 3));
+static void error (struct oneliner_ctx *ctx, const char *msg, ...)
+  ddsrt_attribute_noreturn
+  ddsrt_attribute_format((printf, 2, 3));
+static void error_dds (struct oneliner_ctx *ctx, dds_return_t ret, const char *msg, ...)
+  ddsrt_attribute_noreturn
+  ddsrt_attribute_format((printf, 3, 4));
+static void testfail (struct oneliner_ctx *ctx, const char *msg, ...)
+  ddsrt_attribute_noreturn
+  ddsrt_attribute_format((printf, 2, 3));
 
 static void vsetresult (struct oneliner_ctx *ctx, int result, const char *msg, va_list ap)
 {

--- a/src/core/ddsi/src/ddsi_udp.c
+++ b/src/core/ddsi/src/ddsi_udp.c
@@ -362,7 +362,7 @@ static dds_return_t set_sndbuf (struct ddsi_domaingv const * const gv, ddsrt_soc
       GVLOG (DDS_LC_CONFIG | DDS_LC_ERROR,
              "failed to increase socket send buffer size to %"PRIu32" bytes, maximum is %"PRIu32" bytes\n",
              min_size, size);
-      rc = DDS_RETCODE_NOT_ENOUGH_SPACE;
+      return DDS_RETCODE_NOT_ENOUGH_SPACE;
     }
   }
 


### PR DESCRIPTION
Some minor (this time it is true!) changes.

* One externally visible change: actually treating a failure to get the requested socket buffer size as an error rather than vying for a place in the Underhanded C code contest;
* One performance improvement: the removal of an unnecessary padding clearing loop when concatenating received fragments;
* Two fixes for suppressing warnings from Clang's static analyser.