### PR TITLE
Correct tracemask in config initializer generator

### DIFF
--- a/src/core/ddsc/tests/domain.c
+++ b/src/core/ddsc/tests/domain.c
@@ -351,6 +351,9 @@ CU_Test(ddsc_domain_create, raw_config)
 
   struct ddsi_config config;
   ddsi_config_init_default (&config);
+  /* Default tracemask is must be checked separately because we have to overwrite it
+     to automatically check all the others */
+  CU_ASSERT(config.tracemask == 0);
   config.tracemask = DDS_LC_CONFIG;
   dds_set_trace_sink (logsink, &arg_raw);
   domain = dds_create_domain_with_rawconfig (1, &config);

--- a/src/core/ddsc/tests/domain.c
+++ b/src/core/ddsc/tests/domain.c
@@ -376,7 +376,7 @@ CU_Test(ddsc_domain_create, raw_config)
     for (; i < arg_xml.size; i++)
       printf ("XML: %s", arg_xml.buf[i]);
     for (; j < arg_raw.size; j++)
-      printf ("RAW: %s", arg_xml.buf[j]);
+      printf ("RAW: %s", arg_raw.buf[j]);
   }
 
   for (size_t i = 0; i < arg_xml.size; i++)

--- a/src/tools/ddsconf/defconfig.c
+++ b/src/tools/ddsconf/defconfig.c
@@ -111,10 +111,12 @@ void gendef_pf_tracemask (FILE *out, void *parent, struct cfgelem const * const 
 {
   /* tracemask is a bit bizarre: it has no member name ... all that has to do with Verbosity and Category
      existing both, and how it is output in the trace ... */
-  const uint32_t *p = cfg_address (parent, cfgelem);
   assert (cfgelem->membername == NULL);
-  if (*p != 0)
-    fprintf (out, "  cfg->tracemask = UINT32_C (%"PRIu32");\n", *p);
+  assert (cfgelem->elem_offset == 0);
+  (void) cfgelem;
+  const struct ddsi_config *cfg = parent;
+  if (cfg->tracemask != 0)
+    fprintf (out, "  cfg->tracemask = UINT32_C (%"PRIu32");\n", cfg->tracemask);
 }
 
 void gendef_pf_xcheck (FILE *out, void *parent, struct cfgelem const * const cfgelem) {


### PR DESCRIPTION
The default config generator initialized the tracemask to the value of
the "valid" field rather than to the value of the "tracemask" field.
This slipped through the test because the test failed to explicitly
check that it is set to 0 prior to forcing it to "config", which it uses
for automatic checking of all other settings.

Signed-off-by: Erik Boasson <eb@ilities.com>