### PR TITLE
Add serialized data access variants for the read/take_instance operations of the DataReader.

### DIFF
--- a/src/core/ddsc/include/dds/dds.h
+++ b/src/core/ddsc/include/dds/dds.h
@@ -3004,6 +3004,54 @@ dds_readcdr(
 
 /**
  * @brief Access the collection of serialized data values (of same type) and
+ *        sample info from the data reader, readcondition or querycondition
+ *        scoped by the provided instance handle..
+ *
+ * This operation implements the same functionality as dds_read_instance_wl, except that
+ * samples are now in their serialized form. The serialized data is made available through
+ * \ref ddsi_serdata structures. Returned samples are marked as READ.
+ *
+ * Return value provides information about the number of samples read, which will
+ * be <= maxs. Based on the count, the buffer will contain serialized data to be
+ * read only when valid_data bit in sample info structure is set.
+ * The buffer required for data values, could be allocated explicitly or can
+ * use the memory from data reader to prevent copy. In the latter case, buffer and
+ * sample_info should be returned back, once it is no longer using the data.
+ *
+ * @param[in]  reader_or_condition Reader, readcondition or querycondition entity.
+ * @param[out] buf An array of pointers to \ref ddsi_serdata structures that contain
+ *                 the serialized data. The pointers can be NULL.
+ * @param[in]  maxs Maximum number of samples to read.
+ * @param[out] si Pointer to an array of \ref dds_sample_info_t returned for each data value.
+ * @param[in]  handle Instance handle related to the samples to read.
+ * @param[in]  mask Filter the data based on dds_sample_state_t|dds_view_state_t|dds_instance_state_t.
+ *
+ * @returns A dds_return_t with the number of samples read or an error code.
+ *
+ * @retval >=0
+ *             Number of samples read.
+ * @retval DDS_RETCODE_ERROR
+ *             An internal error has occurred.
+ * @retval DDS_RETCODE_BAD_PARAMETER
+ *             One of the given arguments is not valid.
+ * @retval DDS_RETCODE_ILLEGAL_OPERATION
+ *             The operation is invoked on an inappropriate object.
+ * @retval DDS_RETCODE_ALREADY_DELETED
+ *             The entity has already been deleted.
+ * @retval DDS_RETCODE_PRECONDITION_NOT_MET
+ *             The instance handle has not been registered with this reader.
+ */
+DDS_EXPORT dds_return_t
+dds_readcdr_instance (
+    dds_entity_t reader_or_condition,
+    struct ddsi_serdata **buf,
+    uint32_t maxs,
+    dds_sample_info_t *si,
+    dds_instance_handle_t handle,
+    uint32_t mask);
+
+/**
+ * @brief Access the collection of serialized data values (of same type) and
  *        sample info from the data reader, readcondition or querycondition.
  *
  * This call accesses the serialized data from the data reader, readcondition or
@@ -3047,6 +3095,55 @@ dds_takecdr(
   uint32_t maxs,
   dds_sample_info_t *si,
   uint32_t mask);
+
+/**
+ * @brief Access the collection of serialized data values (of same type) and
+ *        sample info from the data reader, readcondition or querycondition
+ *        scoped by the provided instance handle..
+ *
+ * This operation implements the same functionality as dds_take_instance_wl, except that
+ * samples are now in their serialized form. The serialized data is made available through
+ * \ref ddsi_serdata structures. Returned samples are marked as READ.
+ *
+ * Return value provides information about the number of samples read, which will
+ * be <= maxs. Based on the count, the buffer will contain serialized data to be
+ * read only when valid_data bit in sample info structure is set.
+ * The buffer required for data values, could be allocated explicitly or can
+ * use the memory from data reader to prevent copy. In the latter case, buffer and
+ * sample_info should be returned back, once it is no longer using the data.
+ *
+ * @param[in]  reader_or_condition Reader, readcondition or querycondition entity.
+ * @param[out] buf An array of pointers to \ref ddsi_serdata structures that contain
+ *                 the serialized data. The pointers can be NULL.
+ * @param[in]  maxs Maximum number of samples to read.
+ * @param[out] si Pointer to an array of \ref dds_sample_info_t returned for each data value.
+ * @param[in]  handle Instance handle related to the samples to read.
+ * @param[in]  mask Filter the data based on dds_sample_state_t|dds_view_state_t|dds_instance_state_t.
+ *
+ * @returns A dds_return_t with the number of samples read or an error code.
+ *
+ * @retval >=0
+ *             Number of samples read.
+ * @retval DDS_RETCODE_ERROR
+ *             An internal error has occurred.
+ * @retval DDS_RETCODE_BAD_PARAMETER
+ *             One of the given arguments is not valid.
+ * @retval DDS_RETCODE_ILLEGAL_OPERATION
+ *             The operation is invoked on an inappropriate object.
+ * @retval DDS_RETCODE_ALREADY_DELETED
+ *             The entity has already been deleted.
+ * @retval DDS_RETCODE_PRECONDITION_NOT_MET
+ *             The instance handle has not been registered with this reader.
+ */
+DDS_EXPORT dds_return_t
+dds_takecdr_instance (
+    dds_entity_t reader_or_condition,
+    struct ddsi_serdata **buf,
+    uint32_t maxs,
+    dds_sample_info_t *si,
+    dds_instance_handle_t handle,
+    uint32_t mask);
+
 
 /**
  * @brief Access the collection of data values (of same type) and sample info from the

--- a/src/core/ddsc/src/dds_read.c
+++ b/src/core/ddsc/src/dds_read.c
@@ -305,6 +305,22 @@ dds_return_t dds_read_instance_mask_wl (dds_entity_t rd_or_cnd, void **buf, dds_
   return dds_read_impl (false, rd_or_cnd, buf, maxs, maxs, si, mask, handle, lock, false);
 }
 
+dds_return_t dds_readcdr_instance (dds_entity_t rd_or_cnd, struct ddsi_serdata **buf, uint32_t maxs, dds_sample_info_t *si, dds_instance_handle_t handle, uint32_t mask)
+{
+  bool lock = true;
+
+  if (handle == DDS_HANDLE_NIL)
+    return DDS_RETCODE_PRECONDITION_NOT_MET;
+
+  if (maxs == DDS_READ_WITHOUT_LOCK)
+  {
+    lock = false;
+    /* FIXME: Fix the interface. */
+    maxs = 100;
+  }
+  return dds_readcdr_impl(false, rd_or_cnd, buf, maxs, si, mask, handle, lock);
+}
+
 dds_return_t dds_read_next (dds_entity_t reader, void **buf, dds_sample_info_t *si)
 {
   uint32_t mask = DDS_NOT_READ_SAMPLE_STATE | DDS_ANY_VIEW_STATE | DDS_ANY_INSTANCE_STATE;
@@ -442,6 +458,22 @@ dds_return_t dds_take_instance_mask_wl (dds_entity_t rd_or_cnd, void **buf, dds_
     maxs = 100;
   }
   return dds_read_impl(true, rd_or_cnd, buf, maxs, maxs, si, mask, handle, lock, false);
+}
+
+dds_return_t dds_takecdr_instance (dds_entity_t rd_or_cnd, struct ddsi_serdata **buf, uint32_t maxs, dds_sample_info_t *si, dds_instance_handle_t handle, uint32_t mask)
+{
+  bool lock = true;
+
+  if (handle == DDS_HANDLE_NIL)
+    return DDS_RETCODE_PRECONDITION_NOT_MET;
+
+  if (maxs == DDS_READ_WITHOUT_LOCK)
+  {
+    lock = false;
+    /* FIXME: Fix the interface. */
+    maxs = 100;
+  }
+  return dds_readcdr_impl(true, rd_or_cnd, buf, maxs, si, mask, handle, lock);
 }
 
 dds_return_t dds_take_next (dds_entity_t reader, void **buf, dds_sample_info_t *si)


### PR DESCRIPTION
Needed to support the C++ implementation of the loaned (zero-copy) read/take operations of a Selector that was set to look for one particular instance by means of its instance handle.