### PR TITLE
Fix CMake package config version file name

### DIFF
--- a/cmake/Modules/Packaging.cmake
+++ b/cmake/Modules/Packaging.cmake
@@ -28,13 +28,13 @@ configure_package_config_file(
 
 # Generates <Package>Version.cmake.
 write_basic_package_version_file(
-  "${PROJECT_NAME}Version.cmake"
+  "${PROJECT_NAME}ConfigVersion.cmake"
   VERSION ${PROJECT_VERSION}
   COMPATIBILITY SameMajorVersion)
 
 install(
   FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
-        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Version.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
   DESTINATION "${CMAKE_INSTALL_CMAKEDIR}" COMPONENT dev)
 
 if((NOT DEFINED BUILD_SHARED_LIBS) OR BUILD_SHARED_LIBS)


### PR DESCRIPTION
According to the [CMake Manual](https://cmake.org/cmake/help/latest/command/find_package.html#version-selection), the version file must be named `<ConfigName>Version.cmake`, i.e., `CycloneDDSConfigVersion.cmake`.