### PR TITLE
feat: Add conanfile.py for conan packaging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,10 @@ ubuntu1804_gcc7: &ubuntu1804_gcc7
   os: linux
   dist: bionic
   compiler: gcc
+  addons:
+    apt:
+      update: true
+      packages: [ python3-pip python3-setuptools ]
   before_install:
     - eval "export CC=gcc CXX=g++"
     - eval "export COV_COMPTYPE=gcc COV_PLATFORM=linux64"
@@ -75,7 +79,7 @@ ubuntu1804_gcc7: &ubuntu1804_gcc7
     - eval "export GENERATOR='Unix Makefiles'"
   install:
     - *install_coverity
-    - pip install conan --upgrade --user
+    - python3 -m pip install conan --upgrade --user
 
 ubuntu1804_gcc10: &ubuntu1804_gcc10
   os: linux
@@ -86,14 +90,14 @@ ubuntu1804_gcc10: &ubuntu1804_gcc10
       update: true
       sources:
         - sourceline: 'ppa:ubuntu-toolchain-r/test'
-      packages: [ gcc-10 g++-10 ]
+      packages: [ gcc-10 g++-10 python3-pip python3-setuptools ]
   before_install:
     - eval "export CC=gcc-10 CXX=g++-10"
     - eval "export COV_COMPTYPE=gcc COV_PLATFORM=linux64"
     - eval "export BUILD_TOOL_OPTIONS='-j 4'"
     - eval "export GENERATOR='Unix Makefiles'"
   install:
-    - pip install conan --upgrade --user
+    - python3 -m pip install conan --upgrade --user
 
 ubuntu1804_clang10: &ubuntu1804_clang10
   os: linux
@@ -105,14 +109,14 @@ ubuntu1804_clang10: &ubuntu1804_clang10
       sources:
         - sourceline: 'deb https://apt.llvm.org/bionic llvm-toolchain-bionic-10 main'
           key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
-      packages: [ clang-10 clang++-10 ]
+      packages: [ clang-10 clang++-10 python3-pip python3-setuptools ]
   before_install:
     - eval "export CC=clang-10 CXX=clang++-10"
     - eval "export COV_COMPTYPE=clang COV_PLATFORM=linux64"
     - eval "export BUILD_TOOL_OPTIONS='-j 4'"
     - eval "export GENERATOR='Unix Makefiles'"
   install:
-    - pip install conan --upgrade --user
+    - python3 -m pip install conan --upgrade --user
 
 macos1015_xcode11_5: &macos1015_xcode11_5
   os: osx
@@ -140,7 +144,7 @@ freebsd12_clang8: &freebsd12_clang8
     - eval "export BUILD_TOOL_OPTIONS='-j 4'"
     - eval "export GENERATOR='Unix Makefiles'"
   install:
-    - pip install conan --upgrade --user
+    - python3 -m pip install conan --upgrade --user
 
 windows1809_vs2017: &windows1809_vs2017
   os: windows
@@ -202,7 +206,7 @@ jobs:
     - <<: *ubuntu1804_gcc10
       env: [ ARCH=x86_64, BUILD_TYPE=Debug, SSL=YES, SECURITY=YES, LIFESPAN=YES, DEADLINE=YES, TYPE_DISCOVERY=YES ]
     - <<: *ubuntu1804_gcc7
-      env: [ ARCH=x86_64, BUILD_TYPE=Debug, SSL=YES, SECURITY=YES, LIFESPAN=YES, DEADLINE=YES, TYPE_DISCOVERY=YES, CONANFILE=conanfile102.txt ]
+      env: [ ARCH=x86_64, BUILD_TYPE=Debug, SSL=YES, SECURITY=YES, LIFESPAN=YES, DEADLINE=YES, TYPE_DISCOVERY=YES, CONAN_OPTIONS='-o openssl_version=1.0.2' ]
     - <<: *ubuntu1804_gcc10
       env: [ ARCH=x86_64, BUILD_TYPE=Release, SSL=YES, SECURITY=YES, LIFESPAN=YES, DEADLINE=YES, TYPE_DISCOVERY=YES ]
     - <<: *ubuntu1804_gcc10
@@ -220,13 +224,17 @@ jobs:
     - <<: *macos1015_xcode11_5
       env: [ ARCH=x86_64, BUILD_TYPE=Release, SSL=YES, SECURITY=YES, LIFESPAN=YES, DEADLINE=YES, TYPE_DISCOVERY=YES ]
     - <<: *windows1809_vs2017
-      env: [ ARCH=x86, BUILD_TYPE=Debug, SSL=YES, SECURITY=YES, LIFESPAN=YES, DEADLINE=YES, TYPE_DISCOVERY=YES, CONANFILE=conanfile102.txt ]
+      env: [ ARCH=x86, BUILD_TYPE=Debug, SSL=YES, SECURITY=YES, LIFESPAN=YES, DEADLINE=YES, TYPE_DISCOVERY=YES, CONAN_OPTIONS='-o openssl_version=1.0.2' ]
     - <<: *windows1809_vs2017
       env: [ ARCH=x86_64, BUILD_TYPE=Debug, SSL=YES, SECURITY=YES, LIFESPAN=YES, DEADLINE=YES, TYPE_DISCOVERY=YES ]
     - <<: *windows1809_vs2017
       env: [ ARCH=x86_64, BUILD_TYPE=Release, SSL=YES, SECURITY=YES, LIFESPAN=YES, DEADLINE=YES, TYPE_DISCOVERY=YES ]
     - <<: *freebsd12_clang8
       env: [ ARCH=x86_64, BUILD_TYPE=Debug, SSL=NO, SECURITY=NO, LIFESPAN=YES, DEADLINE=YES, TYPE_DISCOVERY=YES ]
+    - <<: *ubuntu1804_gcc10
+      env: [ CONAN_OPTIONS="" ]
+      script:
+        - conan create -tf scripts/conan/test_package . ${CONAN_OPTIONS}
 
 before_script:
   - conan profile new default --detect
@@ -252,7 +260,7 @@ script:
   - INSTALLPREFIX="$(pwd)/install"
   - mkdir build
   - cd build
-  - conan install -b missing -s arch=${ARCH} -s build_type=${BUILD_TYPE} ../${CONANFILE:-conanfile.txt}
+  - conan install -b missing -s arch=${ARCH} -s build_type=${BUILD_TYPE} ${CONAN_OPTIONS} ..
   - cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
           -DCMAKE_INSTALL_PREFIX=${INSTALLPREFIX}
           -DUSE_SANITIZER=${SANITIZER}

--- a/cmake/Modules/FindOpenSSL.cmake
+++ b/cmake/Modules/FindOpenSSL.cmake
@@ -9,27 +9,22 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
-if(TARGET CONAN_PKG::OpenSSL)
-  add_library(OpenSSL::SSL INTERFACE IMPORTED)
-  target_link_libraries(OpenSSL::SSL INTERFACE CONAN_PKG::OpenSSL)
-  set(OPENSSL_FOUND TRUE)
-else()
-  # Loop over a list of possible module paths (without the current directory).
-  get_filename_component(DIR "${CMAKE_CURRENT_LIST_DIR}" ABSOLUTE)
 
-  foreach(MODULE_DIR ${CMAKE_MODULE_PATH} ${CMAKE_ROOT}/Modules)
-    get_filename_component(MODULE_DIR "${MODULE_DIR}" ABSOLUTE)
-    if(NOT MODULE_DIR STREQUAL DIR)
-      if(EXISTS "${MODULE_DIR}/FindOpenSSL.cmake")
-        set(FIND_PACKAGE_FILE "${MODULE_DIR}/FindOpenSSL.cmake")
-        break()
-      endif()
+# Loop over a list of possible module paths (without the current directory).
+get_filename_component(DIR "${CMAKE_CURRENT_LIST_DIR}" ABSOLUTE)
+
+foreach(MODULE_DIR ${CMAKE_MODULE_PATH} ${CMAKE_ROOT}/Modules)
+  get_filename_component(MODULE_DIR "${MODULE_DIR}" ABSOLUTE)
+  if(NOT MODULE_DIR STREQUAL DIR)
+    if(EXISTS "${MODULE_DIR}/FindOpenSSL.cmake")
+      set(FIND_PACKAGE_FILE "${MODULE_DIR}/FindOpenSSL.cmake")
+      break()
     endif()
-  endforeach()
-
-  if(FIND_PACKAGE_FILE)
-    include("${FIND_PACKAGE_FILE}")
   endif()
+endforeach()
+
+if(FIND_PACKAGE_FILE)
+  include("${FIND_PACKAGE_FILE}")
 endif()
 
 # OpenSSL DLL on Windows: use of BIO_s_fd and BIO_s_file (directly or indirectly) requires

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,96 @@
+from conans import ConanFile, CMake, tools
+import os
+import re
+
+
+def parse_cmake_project_version(cmake_file_path):
+    """
+    Returns the project version of the given cmake file as a string.
+    If the cmake file is not found, None is returned.
+    If the cmake file doesn't contain a project or no version is
+    specified, a runtime error is raised.
+
+    This is a pimped version of
+    https://docs.conan.io/en/1.4/howtos/capture_version.html
+    """
+    try:
+        with open(cmake_file_path, 'r') as cmake_file:
+            cmake_contents = cmake_file.read().lower()
+            proj_chunk = re.search(r'project\s*\(([^\)]+)\)', cmake_contents)
+            if proj_chunk is None or proj_chunk.group(0) is None:
+                raise RuntimeError('No project found in %s' % cmake_file_path)
+            ver = re.search(r'version[\s\n]+(\d+(\.\d+(\.\d+)?)?)', proj_chunk.group(0))
+            if ver is None or ver.group(1) is None:
+                raise RuntimeError('No project version specified in %s' % cmake_file_path)
+
+            return ver.group(1)
+    except Exception:
+        return None
+
+
+class CycloneDDSConan(ConanFile):
+    name = "cyclonedds"
+    version = parse_cmake_project_version("CMakeLists.txt")
+    license = "Eclipse Public License - v 2.0"
+    author = 'Eclipse Cyclone DDS Contributors'
+    description = "Eclipse Cyclone DDS project"
+    url = 'https://github.com/eclipse-cyclonedds/cyclonedds'
+    generators = "cmake"
+    scm = {
+        "revision": "auto",
+        "type": "git",
+        "url": "auto"
+    }
+    options = {
+        "openssl_version": ["1.0.2", "1.1.1c"],
+        "enable_ssl": [True, False],
+        "enable_security": [True, False],
+        "enable_lifespan": [True, False],
+        "enable_deadline_missed": [True, False],
+        "enable_type_discovery": [True, False]
+    }
+    default_options = {
+        "openssl_version": "1.1.1c",
+        "enable_ssl": True,
+        "enable_security": True,
+        "enable_lifespan": True,
+        "enable_deadline_missed": True,
+        "enable_type_discovery": True
+    }
+
+    _cmake = None
+
+    build_requires = ("cunit/2.1-3@bincrafters/stable", "maven/3.6.3")
+
+    def build_requirements(self):
+        self.build_requires("OpenSSL/{}@conan/stable".format(self.options.openssl_version))
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+
+        self._cmake.definitions["ENABLE_SSL"] = True
+        self._cmake.definitions["ENABLE_SECURITY"] = True
+        self._cmake.definitions["ENABLE_LIFESPAN"] = True
+        self._cmake.definitions["ENABLE_DEADLINE_MISSED"] = True
+        self._cmake.definitions["ENABLE_TYPE_DISCOVERY"] = True
+        return self._cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        cmake = self._configure_cmake()
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = tools.collect_libs(self)
+        self.env_info.LD_LIBRARY_PATH.extend([
+            os.path.join(self.package_folder, x) for x in self.cpp_info.libdirs
+        ])
+        self.env_info.PATH.extend([
+            os.path.join(self.package_folder, x) for x in self.cpp_info.bindirs
+        ])

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,6 +1,0 @@
-[requires]
-cunit/2.1-3@bincrafters/stable
-OpenSSL/1.1.1c@conan/stable
-
-[generators]
-cmake

--- a/conanfile102.txt
+++ b/conanfile102.txt
@@ -1,6 +1,0 @@
-[requires]
-cunit/2.1-3@bincrafters/stable
-OpenSSL/1.0.2@conan/stable
-
-[generators]
-cmake

--- a/scripts/conan/test_package/CMakeLists.txt
+++ b/scripts/conan/test_package/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.3)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+
+# Find the CycloneDDS package. If it is not in a default location, try
+# finding it relative to the example where it most likely resides.
+find_package(CycloneDDS REQUIRED COMPONENTS idlc PATHS "${CMAKE_CURRENT_SOURCE_DIR}/../../../..")
+
+# This is a convenience function, provided by the CycloneDDS package,
+# that will supply a library target related the the given idl file.
+# In short, it takes the idl file, generates the source files with
+# the proper data types and compiles them into a library.
+idlc_generate(HelloWorldData_lib "HelloWorldData.idl")
+
+# Both executables have only one related source file.
+add_executable(HelloworldPublisher publisher.c)
+add_executable(HelloworldSubscriber subscriber.c)
+
+# Both executables need to be linked to the idl data type library and
+# the ddsc API library.
+target_link_libraries(HelloworldPublisher HelloWorldData_lib CycloneDDS::ddsc)
+target_link_libraries(HelloworldSubscriber HelloWorldData_lib CycloneDDS::ddsc)
+

--- a/scripts/conan/test_package/HelloWorldData.idl
+++ b/scripts/conan/test_package/HelloWorldData.idl
@@ -1,0 +1,9 @@
+module HelloWorldData
+{
+  struct Msg
+  {
+    long userID;
+    string message;
+  };
+  #pragma keylist Msg userID
+};

--- a/scripts/conan/test_package/conanfile.py
+++ b/scripts/conan/test_package/conanfile.py
@@ -1,0 +1,31 @@
+from conans import ConanFile, CMake, tools
+import os
+
+from subprocess import Popen, PIPE
+
+class TestPackageConan(ConanFile):
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        pub = Popen(['./HelloworldPublisher'],stdout=PIPE)
+        sub = Popen(['./HelloworldSubscriber'],stdout=PIPE)
+        pub_output = pub.communicate()[0].decode('ascii')
+        sub_output = sub.communicate()[0].decode('ascii')
+        pub.wait()
+        sub.wait()
+
+        print(pub_output)
+        print(sub_output)
+
+        if "Writing : Message (1, Hello World)" not in pub_output:
+            raise RuntimeError("Unexpected output from publisher")
+
+        if "Received : Message (1, Hello World)" not in sub_output:
+            raise RuntimeError("Unexpected output from subscriber")
+
+

--- a/scripts/conan/test_package/publisher.c
+++ b/scripts/conan/test_package/publisher.c
@@ -1,0 +1,68 @@
+#include "dds/dds.h"
+#include "HelloWorldData.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+int main (int argc, char ** argv)
+{
+  dds_entity_t participant;
+  dds_entity_t topic;
+  dds_entity_t writer;
+  dds_return_t rc;
+  HelloWorldData_Msg msg;
+  uint32_t status = 0;
+  (void)argc;
+  (void)argv;
+
+  /* Create a Participant. */
+  participant = dds_create_participant (DDS_DOMAIN_DEFAULT, NULL, NULL);
+  if (participant < 0)
+    DDS_FATAL("dds_create_participant: %s\n", dds_strretcode(-participant));
+
+  /* Create a Topic. */
+  topic = dds_create_topic (
+    participant, &HelloWorldData_Msg_desc, "HelloWorldData_Msg", NULL, NULL);
+  if (topic < 0)
+    DDS_FATAL("dds_create_topic: %s\n", dds_strretcode(-topic));
+
+  /* Create a Writer. */
+  writer = dds_create_writer (participant, topic, NULL, NULL);
+  if (writer < 0)
+    DDS_FATAL("dds_create_writer: %s\n", dds_strretcode(-writer));
+
+  printf("=== [Publisher]  Waiting for a reader to be discovered ...\n");
+  fflush (stdout);
+
+  rc = dds_set_status_mask(writer, DDS_PUBLICATION_MATCHED_STATUS);
+  if (rc != DDS_RETCODE_OK)
+    DDS_FATAL("dds_set_status_mask: %s\n", dds_strretcode(-rc));
+
+  while(!(status & DDS_PUBLICATION_MATCHED_STATUS))
+  {
+    rc = dds_get_status_changes (writer, &status);
+    if (rc != DDS_RETCODE_OK)
+      DDS_FATAL("dds_get_status_changes: %s\n", dds_strretcode(-rc));
+
+    /* Polling sleep. */
+    dds_sleepfor (DDS_MSECS (20));
+  }
+
+  /* Create a message to write. */
+  msg.userID = 1;
+  msg.message = "Hello World";
+
+  printf ("=== [Publisher]  Writing : ");
+  printf ("Message (%"PRId32", %s)\n", msg.userID, msg.message);
+  fflush (stdout);
+
+  rc = dds_write (writer, &msg);
+  if (rc != DDS_RETCODE_OK)
+    DDS_FATAL("dds_write: %s\n", dds_strretcode(-rc));
+
+  /* Deleting the participant will delete all its children recursively as well. */
+  rc = dds_delete (participant);
+  if (rc != DDS_RETCODE_OK)
+    DDS_FATAL("dds_delete: %s\n", dds_strretcode(-rc));
+
+  return EXIT_SUCCESS;
+}

--- a/scripts/conan/test_package/subscriber.c
+++ b/scripts/conan/test_package/subscriber.c
@@ -1,0 +1,84 @@
+#include "dds/dds.h"
+#include "HelloWorldData.h"
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+/* An array of one message (aka sample in dds terms) will be used. */
+#define MAX_SAMPLES 1
+
+int main (int argc, char ** argv)
+{
+  dds_entity_t participant;
+  dds_entity_t topic;
+  dds_entity_t reader;
+  HelloWorldData_Msg *msg;
+  void *samples[MAX_SAMPLES];
+  dds_sample_info_t infos[MAX_SAMPLES];
+  dds_return_t rc;
+  dds_qos_t *qos;
+  (void)argc;
+  (void)argv;
+
+  /* Create a Participant. */
+  participant = dds_create_participant (DDS_DOMAIN_DEFAULT, NULL, NULL);
+  if (participant < 0)
+    DDS_FATAL("dds_create_participant: %s\n", dds_strretcode(-participant));
+
+  /* Create a Topic. */
+  topic = dds_create_topic (
+    participant, &HelloWorldData_Msg_desc, "HelloWorldData_Msg", NULL, NULL);
+  if (topic < 0)
+    DDS_FATAL("dds_create_topic: %s\n", dds_strretcode(-topic));
+
+  /* Create a reliable Reader. */
+  qos = dds_create_qos ();
+  dds_qset_reliability (qos, DDS_RELIABILITY_RELIABLE, DDS_SECS (10));
+  reader = dds_create_reader (participant, topic, qos, NULL);
+  if (reader < 0)
+    DDS_FATAL("dds_create_reader: %s\n", dds_strretcode(-reader));
+  dds_delete_qos(qos);
+
+  printf ("\n=== [Subscriber] Waiting for a sample ...\n");
+  fflush (stdout);
+
+  /* Initialize sample buffer, by pointing the void pointer within
+   * the buffer array to a valid sample memory location. */
+  samples[0] = HelloWorldData_Msg__alloc ();
+
+  /* Poll until data has been read. */
+  while (true)
+  {
+    /* Do the actual read.
+     * The return value contains the number of read samples. */
+    rc = dds_read (reader, samples, infos, MAX_SAMPLES, MAX_SAMPLES);
+    if (rc < 0)
+      DDS_FATAL("dds_read: %s\n", dds_strretcode(-rc));
+
+    /* Check if we read some data and it is valid. */
+    if ((rc > 0) && (infos[0].valid_data))
+    {
+      /* Print Message. */
+      msg = (HelloWorldData_Msg*) samples[0];
+      printf ("=== [Subscriber] Received : ");
+      printf ("Message (%"PRId32", %s)\n", msg->userID, msg->message);
+      fflush (stdout);
+      break;
+    }
+    else
+    {
+      /* Polling sleep. */
+      dds_sleepfor (DDS_MSECS (20));
+    }
+  }
+
+  /* Free the data location. */
+  HelloWorldData_Msg_free (samples[0], DDS_FREE_ALL);
+
+  /* Deleting the participant will delete all its children recursively as well. */
+  rc = dds_delete (participant);
+  if (rc != DDS_RETCODE_OK)
+    DDS_FATAL("dds_delete: %s\n", dds_strretcode(-rc));
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Adds a conanfile.py configuration to build a conan package for cyclone dds.

You can test it locally using:
`conan create -tf scripts/conan/test_package .` in the repo root.

Conan requires Python3, therefore all pip calls are also changed to use pip3.

Since maven is required, this depends on the following two PR:

https://github.com/conan-io/conan-center-index/pull/4491
https://github.com/conan-io/conan-center-index/pull/4488