### PR TITLE
Bug fix in freeing loaned samples

### DIFF
--- a/src/core/ddsc/src/dds_read.c
+++ b/src/core/ddsc/src/dds_read.c
@@ -84,16 +84,15 @@ static dds_return_t dds_read_impl (bool take, dds_entity_t reader_or_condition, 
         else
         {
           ddsi_sertype_realloc_samples (buf, rd->m_topic->m_stype, rd->m_loan, rd->m_loan_size, maxs);
-          rd->m_loan = buf[0];
           rd->m_loan_size = maxs;
         }
       }
       else
       {
         ddsi_sertype_realloc_samples (buf, rd->m_topic->m_stype, NULL, 0, maxs);
-        rd->m_loan = buf[0];
         rd->m_loan_size = maxs;
       }
+      rd->m_loan = buf[0];
       rd->m_loan_out = true;
       nodata_cleanups = NC_RESET_BUF | NC_CLEAR_LOAN_OUT;
     }


### PR DESCRIPTION
Loaned samples are not correctly freed in `dds_delete_reader`. This could lead to leaking memory when a reader is deleted right after reading data, before the application has returned the loaned data (the return loan will result in a precondition_not_met error in that case). 