### PR TITLE
Support abbreviating attribute names in XML

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/ddsi_cfgelems.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_cfgelems.h
@@ -994,8 +994,8 @@ static struct cfgelem multiple_recv_threads_attrs[] = {
 };
 
 static struct cfgelem internal_cfgelems[] = {
-  MOVED("MaxMessageSize", "CycloneDDS/General/MaxMessageSize"),
-  MOVED("FragmentSize", "CycloneDDS/General/FragmentSize"),
+  MOVED("MaxMessageSize", "CycloneDDS/Domain/General/MaxMessageSize"),
+  MOVED("FragmentSize", "CycloneDDS/Domain/General/FragmentSize"),
   INT("DeliveryQueueMaxSamples", NULL, 1, "256",
     MEMBER(delivery_queue_maxsamples),
     FUNCTIONS(0, uf_uint, 0, pf_uint),


### PR DESCRIPTION
This allows abbreviating attributes names in XML read directly from `CYCLONEDDS_URI`, just like abbreviating element names is already allowed. Some elements have only a single attribute with a long name, and I found it really annoying to have to type those out in full 🙂