### PR TITLE
Serialize concurrent hash table updates

### DIFF
--- a/src/core/ddsc/tests/liveliness.c
+++ b/src/core/ddsc/tests/liveliness.c
@@ -590,19 +590,21 @@ static void test_create_delete_writer_stress(bool remote_reader)
       alive_writers_man++;
   }
   dds_delete_qos(wqos);
-  printf("alive_writers_auto: %d, alive_writers_man: %d\n", alive_writers_auto, alive_writers_man);
+  printf("%"PRId64" alive_writers_auto: %d, alive_writers_man: %d\n", dds_time(), alive_writers_auto, alive_writers_man);
 
   /* wait for auto liveliness writers to become alive and manual-by-pp writers to become not-alive */
   do
   {
     CU_ASSERT_EQUAL_FATAL(dds_get_liveliness_changed_status(reader, &lstatus), DDS_RETCODE_OK);
-    printf("alive: %d, not-alive: %d\n", lstatus.alive_count, lstatus.not_alive_count);
+    printf("%"PRId64" alive: %d, not-alive: %d\n", dds_time(), lstatus.alive_count, lstatus.not_alive_count);
     dds_sleepfor(DDS_MSECS(50));
   } while (lstatus.alive_count != alive_writers_auto || lstatus.not_alive_count != alive_writers_man);
 
   /* check that counts are stable after a delay */
+  printf("%"PRId64" wait for half ldur (%"PRId64"ms)\n", dds_time(), ldur);
   dds_sleepfor(DDS_MSECS(ldur / 2));
   CU_ASSERT_EQUAL_FATAL(dds_get_liveliness_changed_status(reader, &lstatus), DDS_RETCODE_OK);
+  printf("%"PRId64" alive: %d, not-alive: %d\n", dds_time(), lstatus.alive_count, lstatus.not_alive_count);
   CU_ASSERT_FATAL(lstatus.alive_count == alive_writers_auto && lstatus.not_alive_count == alive_writers_man);
 
   /* cleanup remaining writers */
@@ -615,7 +617,7 @@ static void test_create_delete_writer_stress(bool remote_reader)
   do
   {
     CU_ASSERT_EQUAL_FATAL(dds_get_liveliness_changed_status(reader, &lstatus), DDS_RETCODE_OK);
-    printf("alive: %d, not: %d\n", lstatus.alive_count, lstatus.not_alive_count);
+    printf("%"PRId64" alive: %d, not: %d\n", dds_time(), lstatus.alive_count, lstatus.not_alive_count);
     dds_sleepfor(DDS_MSECS(ldur / 10));
   } while (lstatus.alive_count > 0 || lstatus.not_alive_count > 0);
   CU_ASSERT_EQUAL_FATAL(dds_waitset_detach(waitset, reader), DDS_RETCODE_OK);

--- a/src/ddsrt/tests/select.c
+++ b/src/ddsrt/tests/select.c
@@ -198,12 +198,12 @@ CU_Test(ddsrt_select, timeout)
 
   sockets_pipe(socks);
 
-  arg.delay = DDS_MSECS(300);
+  arg.delay = DDS_MSECS(2000);
   /* Allow the delay to be off by x microseconds (arbitrarily chosen) for
      systems with a really poor clock. This test is just to get some
      confidence that time calculation is not completely broken, it is by
      no means proof that time calculation is entirely correct! */
-  arg.skew = DDS_MSECS(50);
+  arg.skew = DDS_MSECS(1000);
   arg.sock = socks[0];
 
   fprintf (stderr, "create thread\n");


### PR DESCRIPTION
The main subject of this PR concerns strange, intermittent timeouts on Travis; the secondary subjects are tweaks to two tests to hopefully better understand the circumstances of failure in the one case, and to reduce the likelihood of failure in the other. On the main subject:

There are intermittent failures on Travis CI where tests seem to randomly timeout and appear to do so at the end of the test.  Sometimes this happens on a machine and in a state where the liveliness monitoring will cough up a stack trace.  In the cases where I have seen such stack traces and they contain more than mere numbers (so at least some symbol names), there was often (perhaps always, I am not sure of that) one thread attempting to lock a bucket in the concurrent hash table and being blocked in a ddsrt_cond_wait.  One can only conclude that there may be a problem in that implementation.

This commit eliminates the concurrent updates while leaving the lookups lock-free.  The locking scheme becomes a simple mutex around the add/remove operations.  With this change I have not seen any sign of these particular timeouts in a fairly large number of CI runs.  I confess to not yet having been able to reproduce it on either macOS or Linux, x64 or ARM, and to not yet knowing the root cause, but I think that the circumstantial evidence by now is enough to make this change.

It so happens that this change is unlikely to be bad for performance. The argument is twofold: (1) contention on updates is not actually an issue given how the hash tables are used; and (2) the simpler locking scheme allows for more efficient use of memory and should on average yield a small reduction in cache misses on lookups.

Re (1): there are two uses of the concurrent hash table in Cyclone: the GUID index (ephash) and the key-to-instance-id map (tkmap).  The former is changed only when entities are created or deleted, which is a fairly expensive operation and executed relatively rarely.  Contention on this hash table for updates is not really not an issue.

For the key-to-instance-id map, in DDS instances/key values are relatively heavy-weight because of the registrations and the need to unregister after writing.  Consequently, the vast majority of the data flowing through the system reuses existing key values.  The implementation is such that it only tries to update the hash table after a lookup has failed.  Again leading to the conclusion that contention on updates should not be a significant issue.
