### PR TITLE
Cyclone config tool

### DIFF
--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -10,6 +10,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
 set(CMAKE_INSTALL_TOOLSDIR "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/tools")
+add_subdirectory(cyclone-config)
 add_subdirectory(pubsub)
 add_subdirectory(ddsls)
 add_subdirectory(ddsconf)

--- a/src/tools/cyclone-config/CMakeLists.txt
+++ b/src/tools/cyclone-config/CMakeLists.txt
@@ -1,0 +1,28 @@
+#
+# Copyright(c) 2021 ADLINK Technology Limited and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+
+IF (WIN32)
+  string(REPLACE "/" "\\\\" CYCLONE_CONFIG_PREFIX ${CMAKE_INSTALL_PREFIX})
+ELSE()
+  set(CYCLONE_CONFIG_PREFIX ${CMAKE_INSTALL_PREFIX})
+ENDIF()
+
+configure_file(src/cyclone-config.h.in ${CMAKE_CURRENT_BINARY_DIR}/src/cyclone-config.h)
+add_executable(cyclone-config src/cyclone-config.c)
+set_target_properties(cyclone-config PROPERTIES LINKER_LANGUAGE C)
+target_include_directories(cyclone-config PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src>)
+
+install(
+  TARGETS cyclone-config
+  DESTINATION "${CMAKE_INSTALL_BINDIR}"
+  COMPONENT dev
+)

--- a/src/tools/cyclone-config/src/cyclone-config.c
+++ b/src/tools/cyclone-config/src/cyclone-config.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright(c) 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include <stdio.h>
+#include <string.h>
+#include "cyclone-config.h"
+
+#ifdef _WIN32
+#define SEPARATOR "\\"
+#else
+#define SEPARATOR "/"
+#endif
+
+void print_usage(char* prog);
+void print_usage(char* prog)
+{
+    printf("cyclone-config for Cyclone " VERSION " installed to " PREFIX "\nUsage: $ %s --help|--prefix|--libdir|--includedir|--bindir\n", prog);
+}
+
+
+int main(int argc, char* argv[]) {
+    if (argc < 2 || argc > 2) {
+        print_usage(argv[0]);
+        return 1;
+    }
+
+    if (strcmp(argv[1], "--prefix") == 0) {
+        printf(PREFIX);
+    }
+    else if (strcmp(argv[1], "--libdir") == 0) {
+        printf(PREFIX SEPARATOR "lib");
+    }
+    else if (strcmp(argv[1], "--includedir") == 0) {
+        printf(PREFIX SEPARATOR "include");
+    }
+    else if (strcmp(argv[1], "--libdir") == 0) {
+        printf(PREFIX SEPARATOR "lib");
+    }
+    else if (strcmp(argv[1], "--bindir") == 0) {
+        printf(PREFIX SEPARATOR "bin");
+    }
+    else if (strcmp(argv[1], "--version") == 0) {
+        printf(VERSION);
+    }
+    else if (strcmp(argv[1], "--help") == 0) {
+        print_usage(argv[0]);
+    }
+    else {
+        print_usage(argv[0]);
+        return 1;
+    }
+    return 0;
+}

--- a/src/tools/cyclone-config/src/cyclone-config.h.in
+++ b/src/tools/cyclone-config/src/cyclone-config.h.in
@@ -1,0 +1,18 @@
+/*
+ * Copyright(c) 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#ifndef CYCLONE_CONFIG_H
+#define CYCLONE_CONFIG_H
+
+#define PREFIX "@CYCLONE_CONFIG_PREFIX@"
+#define VERSION "@CMAKE_PROJECT_VERSION@"
+
+#endif


### PR DESCRIPTION
This commit adds a very minimal tool that can print the path to binary, include and library directories for CycloneDDS. When you make cyclone-config available on your path it allows tools that depend on CycloneDDS, such as the Python API, to easily find the libraries and headers. It was inspired by tools like python-config and root-config which perform a similar function.