### PR TITLE
Call dds_entity_status_set independently of enabled

### DIFF
--- a/src/core/ddsc/src/dds__entity.h
+++ b/src/core/ddsc/src/dds__entity.h
@@ -114,7 +114,8 @@ union dds_status_union {
       ddsrt_mutex_lock (&e->m_entity.m_observers_lock); \
       e->m_entity.m_cb_count--; \
       e->m_entity.m_cb_pending_count--; \
-    } else if (enabled) { \
+    } \
+    if (enabled) { \
       dds_entity_status_set (&e->m_entity, (status_mask_t) (1u << DDS_##NAME_##_STATUS_ID)); \
     } \
   }

--- a/src/core/ddsc/src/dds__entity.h
+++ b/src/core/ddsc/src/dds__entity.h
@@ -104,7 +104,7 @@ union dds_status_union {
     struct dds_listener const * const listener = &e->m_entity.m_listener; \
     const bool invoke = (listener->on_##name_ != 0) && enabled; \
     union dds_status_union lst; \
-    update_##name_ (&e->m_##name_##_status, invoke ? &lst.name_ : NULL, data); \
+    update_##name_ (&e->m_##name_##_status, false ? &lst.name_ : NULL, data); \
     if (invoke) { \
       dds_entity_status_reset (&e->m_entity, (status_mask_t) (1u << DDS_##NAME_##_STATUS_ID)); \
       e->m_entity.m_cb_pending_count++; \

--- a/src/core/ddsc/src/dds_reader.c
+++ b/src/core/ddsc/src/dds_reader.c
@@ -159,13 +159,11 @@ void dds_reader_data_available_cb (struct dds_reader *rd)
     lst->on_data_available (rd->m_entity.m_hdllink.hdl, lst->on_data_available_arg);
     ddsrt_mutex_lock (&rd->m_entity.m_observers_lock);
   }
-  else
-  {
-    dds_entity_status_set (&rd->m_entity, DDS_DATA_AVAILABLE_STATUS);
-    ddsrt_mutex_lock (&sub->m_observers_lock);
-    dds_entity_status_set (sub, DDS_DATA_ON_READERS_STATUS);
-    ddsrt_mutex_unlock (&sub->m_observers_lock);
-  }
+
+  dds_entity_status_set (&rd->m_entity, DDS_DATA_AVAILABLE_STATUS);
+  ddsrt_mutex_lock (&sub->m_observers_lock);
+  dds_entity_status_set (sub, DDS_DATA_ON_READERS_STATUS);
+  ddsrt_mutex_unlock (&sub->m_observers_lock);
 
   rd->m_entity.m_cb_count--;
   rd->m_entity.m_cb_pending_count--;


### PR DESCRIPTION
Call dds_entity_status_set independently of enabled

Otherwise if an event listener callback is defined (invoke=true) dds_entity_status_set is not called, so the ROS2 waitset based executors can't identify when an event happened. This commit supports both events & waiset based ROS2 executors.
