### PR TITLE
Access control deny rules

### DIFF
--- a/src/security/builtin_plugins/access_control/src/access_control.c
+++ b/src/security/builtin_plugins/access_control/src/access_control.c
@@ -1194,7 +1194,7 @@ is_partition_in_criteria(
     current_partition = current_partitions->partition;
     while (current_partition != NULL)
     {
-      if (ac_fnmatch(current_partition->value, partition_name))
+      if (ac_fnmatch(current_partition->value ? current_partition->value : "", partition_name))
         return true;
       current_partition = (struct string_value *)current_partition->node.next;
     }

--- a/src/security/core/tests/common/security_config_test_utils.h
+++ b/src/security/core/tests/common/security_config_test_utils.h
@@ -30,6 +30,7 @@ char * get_governance_topic_rule (const char * topic_expr, bool discovery_protec
 char * get_governance_config (bool allow_unauth_pp, bool enable_join_ac, DDS_Security_ProtectionKind discovery_protection_kind, DDS_Security_ProtectionKind liveliness_protection_kind,
     DDS_Security_ProtectionKind rtps_protection_kind, const char * topic_rules, bool add_prefix);
 
+char * get_permissions_rules_w_partitions (const char * domain_id, const char * allow_pub_topic, const char * allow_sub_topic, const char ** allow_parts, const char * deny_pub_topic, const char * deny_sub_topic, const char ** deny_parts);
 char * get_permissions_rules (const char * domain_id, const char * allow_pub_topic, const char * allow_sub_topic,
     const char * deny_pub_topic, const char * deny_sub_topic);
 char * get_permissions_grant (const char * grant_name, const char * subject_name, dds_time_t not_before, dds_time_t not_after,

--- a/src/security/core/tests/common/test_utils.h
+++ b/src/security/core/tests/common/test_utils.h
@@ -82,6 +82,13 @@ void rd_wr_init_fail (
     const char * topic_name,
     bool exp_pubtp_fail, bool exp_wr_fail,
     bool exp_subtp_fail, bool exp_rd_fail);
+void rd_wr_init_w_partitions_fail(
+    dds_entity_t pp_wr, dds_entity_t *pub, dds_entity_t *pub_tp, dds_entity_t *wr,
+    dds_entity_t pp_rd, dds_entity_t *sub, dds_entity_t *sub_tp, dds_entity_t *rd,
+    const char * topic_name,
+    const char ** partition_names,
+    bool exp_pubtp_fail, bool exp_wr_fail,
+    bool exp_subtp_fail, bool exp_rd_fail);
 void write_read_for (dds_entity_t wr, dds_entity_t pp_rd, dds_entity_t rd, dds_duration_t dur, bool exp_write_fail, bool exp_read_fail);
 const char * pk_to_str (DDS_Security_ProtectionKind pk);
 const char * bpk_to_str (DDS_Security_BasicProtectionKind bpk);


### PR DESCRIPTION
It turns out that there are two separate issues with the handling of "deny" rules in the access control plugin, which I found while doing #705 (it should come as no surprise that this PR sits on top of that one, but it is too important a detail to be hidden in some other PR).

The first is that the access control plugin implemented the wrong test: if a deny rule says partition "A" is denied than any reader/writer that includes "A" in its set of partition is to be denied (as per common sense and per DDS Security 1.1, section 9.4.1.3.2.3.2.4). Instead of implementing this, it used the same test as for allow rules, but for those, the test is whether *all* partitions are allowed.

The second is that the spec is totally broken on the subject of allow & deny rules, except in the case where wildcards are avoided like the plague, where allow = "*" and nothing is denied, or some other cases that I can't be bothered to come up with. The reason is that the spec says the matching must be done using `fnmatch` as defined in POSIX 1003.2-1992, Section B.6 (naturally it omits listing the options to be used ...). But that means if, e.g., allow = "?" (i.e. any single character name), a partition of "*" is allowed, but "*" is empathically not a single-character partition name.

That however will have to be the subject of some other PR. This one simply notes the problem in a comment and implements the specified behaviour.