### PR TITLE
Fix a couple of build warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,6 @@ if(APPLE)
     foreach(formula bison)
       execute_process(
         COMMAND ${brew} --prefix ${formula}
-        COMMAND_ECHO STDOUT
         OUTPUT_VARIABLE prefix
         ERROR_QUIET)
       string(STRIP "${prefix}" prefix)

--- a/src/idl/src/scope.c
+++ b/src/idl/src/scope.c
@@ -206,8 +206,8 @@ idl_declare(
 clash:
           idl_error(pstate, idl_location(node),
             "Declaration '%s%s' collides with earlier an declaration of '%s%s'",
-            kind == IDL_ANNOTATION ? "@" : "", name->identifier,
-            kind == IDL_ANNOTATION ? "@" : "", entry->name->identifier);
+            kind == IDL_ANNOTATION_DECLARATION ? "@" : "", name->identifier,
+            kind == IDL_ANNOTATION_DECLARATION ? "@" : "", entry->name->identifier);
           return IDL_RETCODE_SEMANTIC_ERROR;
       }
     }

--- a/src/idl/src/tree.c
+++ b/src/idl/src/tree.c
@@ -1352,8 +1352,8 @@ idl_finalize_union(
         ret = idl_evaluate(state, cl->const_expr, type, &literal);
         if (ret != IDL_RETCODE_OK)
           return ret;
-        if (type == IDL_ENUMERATOR) {
-          if ((uintptr_t)switch_type_spec != (uintptr_t)literal->node.parent) {
+        if (type == IDL_ENUM) {
+          if ((uintptr_t)switch_type_spec->type_spec != (uintptr_t)literal->node.parent) {
             idl_error(state, idl_location(cl),
               "Enumerator of different enum type");
             return IDL_RETCODE_SEMANTIC_ERROR;


### PR DESCRIPTION
This PR addresses three warnings in a [run on the ROS buildfarm](https://ci.ros2.org/job/chris-osx-test/1/clang/) that verifies Bison can be found if installed through Homebrew and not linked in a directory already in the path.