### PR TITLE
Add xcheck config option for xevent checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -268,7 +268,7 @@ script:
           -DWERROR=on
           -G "${GENERATOR}" ..
   - ${SCAN_BUILD} cmake --build . --config ${BUILD_TYPE} --target install -- ${BUILD_TOOL_OPTIONS}
-  - CYCLONEDDS_URI='<CycloneDDS><Domain><Internal><EnableExpensiveChecks>all</EnableExpensiveChecks><LivelinessMonitoring>true</LivelinessMonitoring></Internal><Tracing><Verbosity>config</Verbosity><OutputFile>stderr</OutputFile></Tracing></Domain></CycloneDDS>' ctest -j 4 --output-on-failure -T test -E '^CUnit_ddsrt_random_default_random$' -C ${BUILD_TYPE}
+  - CYCLONEDDS_URI='<CycloneDDS><Domain><Internal><EnableExpensiveChecks>rhc,whc</EnableExpensiveChecks><LivelinessMonitoring>true</LivelinessMonitoring></Internal><Tracing><Verbosity>config</Verbosity><OutputFile>stderr</OutputFile></Tracing></Domain></CycloneDDS>' ctest -j 4 --output-on-failure -T test -E '^CUnit_ddsrt_random_default_random$' -C ${BUILD_TYPE}
   - |
     if [ -z "${SANITIZER}" ]; then
       ${SHELL} ../src/tools/ddsperf/sanity.bash;

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,7 +84,7 @@ pool:
   vmImage: $(image)
 
 variables:
-  cyclonedds_uri: '<CycloneDDS><Domain><Internal><EnableExpensiveChecks>all</EnableExpensiveChecks></Internal></Domain></CycloneDDS>'
+  cyclonedds_uri: '<CycloneDDS><Domain><Internal><EnableExpensiveChecks>rhc,whc</EnableExpensiveChecks></Internal></Domain></CycloneDDS>'
 
 steps:
   - template: /.azure/templates/build-test.yml

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -526,7 +526,7 @@ The default value is: "256".
 
 #### //CycloneDDS/Domain/Internal/EnableExpensiveChecks
 One of:
-* Comma-separated list of: whc, rhc, all
+* Comma-separated list of: whc, rhc, xevent, all
 * Or empty
 
 This element enables expensive checks in builds with assertions enabled and is ignored otherwise. Recognised categories are:
@@ -534,6 +534,8 @@ This element enables expensive checks in builds with assertions enabled and is i
  * whc: writer history cache checking
 
  * rhc: reader history cache checking
+
+ * xevent: xevent checking
 
 In addition, there is the keyword all that enables all checks.
 

--- a/etc/cyclonedds.rnc
+++ b/etc/cyclonedds.rnc
@@ -379,10 +379,11 @@ CycloneDDS configuration""" ] ]
 <ul>
 <li><i>whc</i>: writer history cache checking</li>
 <li><i>rhc</i>: reader history cache checking</li>
+<li><i>xevent</i>: xevent checking</li>
 <p>In addition, there is the keyword <i>all</i> that enables all checks.</p>
 <p>The default value is: "".</p>""" ] ]
         element EnableExpensiveChecks {
-          xsd:token { pattern = "((whc|rhc|all)(,(whc|rhc|all))*)|" }
+          xsd:token { pattern = "((whc|rhc|xevent|all)(,(whc|rhc|xevent|all))*)|" }
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>When true, include keyhashes in outgoing data for topics with keys.</p>

--- a/etc/cyclonedds.xsd
+++ b/etc/cyclonedds.xsd
@@ -628,12 +628,13 @@ CycloneDDS configuration</xs:documentation>
 &lt;ul&gt;
 &lt;li&gt;&lt;i&gt;whc&lt;/i&gt;: writer history cache checking&lt;/li&gt;
 &lt;li&gt;&lt;i&gt;rhc&lt;/i&gt;: reader history cache checking&lt;/li&gt;
+&lt;li&gt;&lt;i&gt;xevent&lt;/i&gt;: xevent checking&lt;/li&gt;
 &lt;p&gt;In addition, there is the keyword &lt;i&gt;all&lt;/i&gt; that enables all checks.&lt;/p&gt;
 &lt;p&gt;The default value is: "".&lt;/p&gt;</xs:documentation>
     </xs:annotation>
     <xs:simpleType>
       <xs:restriction base="xs:token">
-        <xs:pattern value="((whc|rhc|all)(,(whc|rhc|all))*)|"/>
+        <xs:pattern value="((whc|rhc|xevent|all)(,(whc|rhc|xevent|all))*)|"/>
       </xs:restriction>
     </xs:simpleType>
   </xs:element>

--- a/src/core/ddsi/include/dds/ddsi/ddsi_cfgelems.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_cfgelems.h
@@ -1420,9 +1420,10 @@ static struct cfgelem internal_cfgelems[] = {
       "<ul>\n"
       "<li><i>whc</i>: writer history cache checking</li>\n"
       "<li><i>rhc</i>: reader history cache checking</li>\n"
+      "<li><i>xevent</i>: xevent checking</li>\n"
       "<p>In addition, there is the keyword <i>all</i> that enables all "
       "checks.</p>"),
-    VALUES("whc","rhc","all")),
+    VALUES("whc","rhc","xevent","all")),
   END_MARKER
 };
 

--- a/src/core/ddsi/include/dds/ddsi/ddsi_config.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_config.h
@@ -211,6 +211,7 @@ struct ddsi_config_ssl_min_version {
 /* Expensive checks (compiled in when NDEBUG not defined, enabled only if flag set in xchecks) */
 #define DDSI_XCHECK_WHC 1u
 #define DDSI_XCHECK_RHC 2u
+#define DDSI_XCHECK_XEV 4u
 
 struct ddsi_config
 {

--- a/src/core/ddsi/src/q_config.c
+++ b/src/core/ddsi/src/q_config.c
@@ -983,10 +983,10 @@ static void pf_tracemask (struct cfgst *cfgst, UNUSED_ARG (void *parent), UNUSED
 }
 
 static const char *xcheck_names[] = {
-  "whc", "rhc", "all", NULL
+  "whc", "rhc", "xevent", "all", NULL
 };
 static const uint32_t xcheck_codes[] = {
-  DDSI_XCHECK_WHC, DDSI_XCHECK_RHC, ~(uint32_t) 0
+  DDSI_XCHECK_WHC, DDSI_XCHECK_RHC, DDSI_XCHECK_XEV, ~(uint32_t) 0
 };
 
 static enum update_result uf_xcheck (struct cfgst *cfgst, void *parent, struct cfgelem const * const cfgelem, UNUSED_ARG (int first), const char *value)

--- a/src/core/ddsi/src/q_xevent.c
+++ b/src/core/ddsi/src/q_xevent.c
@@ -300,6 +300,8 @@ static int compute_non_timed_xmit_list_size (struct xeventq *evq)
 #ifndef NDEBUG
 static int nontimed_xevent_in_queue (struct xeventq *evq, struct xevent_nt *ev)
 {
+  if (!(evq->gv->config.enabled_xchecks & DDSI_XCHECK_XEV))
+    return 0;
   struct xevent_nt *x;
   ddsrt_mutex_lock (&evq->lock);
   for (x = evq->non_timed_xmit_list_oldest; x; x = x->listnode.next)


### PR DESCRIPTION
Analysing test runs for topic discovery with a profiler revealed that asserts on the check nontimed_xevent_in_queue take a significant amount of time in these runs. This commit makes this specific check an 'expensive check', and adds a new category 'xevent' in the xchecks configuration option so that it can be explicitly enabled. In CI these checks are disabled.