### PR TITLE
Omit Coverity Scan and Codecov pipelines for pull requests

### DIFF
--- a/.azure/codecov.yml
+++ b/.azure/codecov.yml
@@ -15,6 +15,7 @@
 #
 
 trigger: none
+pr: none
 
 schedules:
   - cron: "0 12 * * 0"

--- a/.azure/coverity-scan.yml
+++ b/.azure/coverity-scan.yml
@@ -15,6 +15,7 @@
 #
 
 trigger: none
+pr: none
 
 schedules:
   - cron: "0 12 * * 0"
@@ -27,8 +28,6 @@ strategy:
     'Ubuntu 20.04 LTS with GCC 10 (Debug, x86_64)':
       image: ubuntu-20.04
       cc: gcc-10
-      platform: linux64
-      comptype: gcc
 
 pool:
   vmImage: $(image)
@@ -80,14 +79,7 @@ steps:
   - bash: |
       set -e -x
       echo "###vso[task.setvariable variable=scan_build;]cov-build --dir $(pwd)/cov-int"
-      case "${COMPTYPE}" in
-        'gcc')   cov-configure --template --compiler ${CC} --comptype gcc
-          ;;
-        'clang') cov-configure --template --compiler ${CC} --comptype clangcc
-          ;;
-        'msvc')  cov-configure --msvc
-          ;;
-      esac
+      cov-configure --template --compiler ${CC} --comptype gcc
     name: configure_coverity
   - template: /.azure/templates/build-test.yml
   ## Submit to Coverity Scan


### PR DESCRIPTION
Like the title. Skip exotic pipelines for pull requests (`pr: none`) and pushes (`trigger: none`)