### PR TITLE
Data_avail_stress test fix

### DIFF
--- a/src/core/ddsc/tests/data_avail_stress.c
+++ b/src/core/ddsc/tests/data_avail_stress.c
@@ -94,7 +94,7 @@ static void setup (bool remote, struct writethread_arg *wrarg)
     </Discovery>\
     <Internal>\
       <Test>\
-        <XmitLossiness>333</XmitLossiness>\
+        <XmitLossiness>100</XmitLossiness>\
       </Test>\
     </Internal>";
   char *conf_pub = ddsrt_expand_envvars (config, 0);
@@ -211,7 +211,7 @@ static void stress_data_avail_delete_reader (bool remote, int duration)
   printf ("badparam %"PRIu32"\n", ddsrt_atomic_ld32 (&lstatus.badparam));
   printf ("stop %"PRIu32"\n", ddsrt_atomic_ld32 (&wrarg.stop));
 
-  CU_ASSERT_FATAL (nreaders > 100); // sanity check
+  CU_ASSERT_FATAL (nreaders > 10); // sanity check
   CU_ASSERT_FATAL (!ddsrt_atomic_ld32 (&lstatus.error));
   CU_ASSERT_FATAL (ddsrt_atomic_ld32 (&lstatus.taken) > 100);
   CU_ASSERT_FATAL (!(ddsrt_atomic_ld32 (&wrarg.stop) & 2));


### PR DESCRIPTION
Adjust some parameters in the data_avail_stress test, to fix the intermittent failures for this test. Reproducing the test failures locally revealed that matching the reader/writer sometimes takes more than 10s because of samples containing discovery data being dropped (xmit lossiness for this test was 33.3%) and increased discovery data processing time because of large amounts of discovery data that is received from other tests that run parallel. This commit changes the transmit lossiness to 10% and the number of readers that has to be created during the test to >= 10.