### PR TITLE
Fix Coverity Scan job and use Azure Pipelines badge

### DIFF
--- a/.azure/coverity-scan.yml
+++ b/.azure/coverity-scan.yml
@@ -41,7 +41,7 @@ steps:
       code=$(curl -X HEAD -s -S -F project="${slug}" \
                                 -F token="${token}" \
                                 -o /dev/null -D ${headers} -w '%{http_code}' \
-                                "https://scan.coverity.com/download/cxx/${PLATFORM}")
+                                "https://scan.coverity.com/download/cxx/linux64")
       [ "${code}" != "200" ] && echo "cURL exited with ${code}" 1>&2 && exit 1
       file=$(sed -n -E 's/.*filename="([^"]+)".*/\1/p' ${headers})
       echo "###vso[task.setvariable variable=cov_archive;]${file}"
@@ -65,7 +65,7 @@ steps:
       code=$(curl -s -S -F project="${slug}" \
                         -F token="${token}" \
                         -O -J -D ${headers} -w '%{http_code}' \
-                        "https://scan.coverity.com/download/cxx/${PLATFORM}")
+                        "https://scan.coverity.com/download/cxx/linux64")
       [ "${code}" != "200" ] && echo "cURL exited with ${code}" 1>&2 && exit 1
       file=$(sed -n -E 's/^.*filename="([^"]+)".*$/\1/p' ${headers})
       tar -xzf ${file} -C .

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 [![Build Status](https://dev.azure.com/eclipse-cyclonedds/cyclonedds/_apis/build/status/Pull%20requests?branchName=master)](https://dev.azure.com/eclipse-cyclonedds/cyclonedds/_build/latest?definitionId=4&branchName=master)
 [![Coverity Status](https://scan.coverity.com/projects/19078/badge.svg)](https://scan.coverity.com/projects/eclipse-cyclonedds-cyclonedds)
 [![Codecov](https://codecov.io/gh/eclipse-cyclonedds/cyclonedds/branch/master/graphs/badge.svg?branch=master)](https://codecov.io/github/eclipse-cyclonedds/cyclonedds?branch=master)
+[![License](https://img.shields.io/badge/License-EPL%202.0-blue)](https://choosealicense.com/licenses/epl-2.0/)
+[![License](https://img.shields.io/badge/License-EDL%201.0-blue)](https://choosealicense.com/licenses/edl-1.0/)
 
 # Eclipse Cyclone DDS
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/eclipse-cyclonedds/cyclonedds.svg?branch=master)](https://travis-ci.com/eclipse-cyclonedds/cyclonedds)
+[![Build Status](https://dev.azure.com/eclipse-cyclonedds/cyclonedds/_apis/build/status/Pull%20requests?branchName=master)](https://dev.azure.com/eclipse-cyclonedds/cyclonedds/_build/latest?definitionId=4&branchName=master)
 [![Coverity Status](https://scan.coverity.com/projects/19078/badge.svg)](https://scan.coverity.com/projects/eclipse-cyclonedds-cyclonedds)
 [![Codecov](https://codecov.io/gh/eclipse-cyclonedds/cyclonedds/branch/master/graphs/badge.svg?branch=master)](https://codecov.io/github/eclipse-cyclonedds/cyclonedds?branch=master)
 


### PR DESCRIPTION
Title says it all. I removed the platform variable because it interfered with the builds in a previous commit, but forgot about the use of it to download and install Coverity. Also, this replaces the Travis CI badge with an Azure Pipelines one.