### PR TITLE
Fix submission to Coverity Scan

### DIFF
--- a/.azure/coverity-scan.yml
+++ b/.azure/coverity-scan.yml
@@ -84,17 +84,18 @@ steps:
   - template: /.azure/templates/build-test.yml
   ## Submit to Coverity Scan
   - bash: |
-      set -e
+      set -e -x
       slug=$(echo "${BUILD_REPOSITORY_URI}" | sed -nE 's#.*/([^/]+/[^\]+)#\1#p')
-      tar -czf analysis-results.tgz "$(pwd)/cov-int"
+      tar -czf analysis-results.tgz cov-int
       code=$(curl -s -S -F project="${slug}" \
                         -F token="${token}" \
                         -F file=@analysis-results.tgz \
                         -F version=$(git rev-parse --short HEAD) \
                         -F description="Azure Pipelines build" \
                         -F email="${COVERITY_SCAN_EMAIL:=cyclonedds-inbox@eclipse.org}" \
+                        -w '%{http_code}' \
                         "https://scan.coverity.com/builds")
-      [ "${code}" != "200" ] && echo "cURL exited with ${code}" 1>&2 && exit 1
+      [[ "${code}" =~ "success" ]] || (echo "cURL exited with ${code}" 1>&2 && exit 1)
       rm -f analysis-results.tgz
     name: submit_to_coverity_scan
     env:


### PR DESCRIPTION
I figured I needed to up my commit count, so I chose not to fix submission in my last commit and save that for another one :sweat_smile:. Of course, going through the trouble of creating a separate project to actually test it was the real reason. Anyway, I did so now (see [continuous-integration](https://scan.coverity.com/projects/k0ekk0ek-continuous-integration)) so this should be the last commit regarding the switch to Azure Pipelines. In case anyone's wondering, the addition of `set -e -x` won't cause the token to be displayed as can be seen in the [respective build log](https://dev.azure.com/k0ekk0ek/7d6b5076-3ee5-4367-8c8b-432cd9e7409e/_apis/build/builds/389/logs/17).