### PR TITLE
Add message authentication/encryption to perftest

### DIFF
--- a/examples/perfscript/perftest
+++ b/examples/perfscript/perftest
@@ -15,6 +15,7 @@ provision=false
 asynclist="sync async"
 modelist="listener polling waitset"
 modelistdefault=true
+rate=""
 sizelist="0 20 50 100 200 500 1000 2000 5000 10000 20000 50000 100000 200000 500000 1000000"
 timeout=30
 loopback=true
@@ -24,6 +25,7 @@ force=false
 netstats=false
 watermarks=""
 remotes=""
+security="none"
 
 operation=throughput
 
@@ -47,6 +49,20 @@ OPTIONS
                "$modelist")
   -s SIZELIST  run for sizes in SIZELIST (default: "$sizelist")
                if SIZELIST is empty, it uses ddsperf's OU topic instead
+  -R RATE      set rate to RATE (e.g., -R 100Hz) rather than run as fast
+               as possible
+  -S MODE      whether and how to configure DDS Security:
+                 none              no security (default)
+                 sign              synonym for rtps-sign
+                 encrypt           synonym for payload-encrypt
+                 rtps-sign         RTPS message signing
+                 rtps-encrypt      RTPS message encryption
+                 metadata-sign     RTPS submessage signing
+                 metadata-encrypt  RTPS submessage encryption
+                 payload-encrypt   payload encryption only
+                 *.xml             governance XML file to use
+               the various \"encrypt\" modes use AES-256
+               uses secperf directory for storing generated security config
   -l LOOPBACK  enable/disable multicast loopback (true/false, default: $loopback)
   -o DIR       store results in dir (default: $resultdir)
   -O OPER      operation: \"throughput\" or \"latency\" (default: $operation)
@@ -74,7 +90,7 @@ dokill_and_exit () {
     exit 1
 }
 
-while getopts "fi:I:b:d:pa:m:s:t:o:O:l:WX" opt ; do
+while getopts "fi:I:b:d:pa:m:s:S:t:o:O:l:R:WX" opt ; do
     case $opt in
         f) force=true ;;
         i) nwif="$OPTARG" ;;
@@ -89,10 +105,12 @@ while getopts "fi:I:b:d:pa:m:s:t:o:O:l:WX" opt ; do
         a) asynclist="$OPTARG" ;;
         m) modelist="$OPTARG" ; modelistdefault=false ;;
         s) sizelist="$OPTARG" ;;
-        l) loopback="OPTARG" ;;
+        S) security="$OPTARG" ;;
+        l) loopback="$OPTARG" ;;
         t) timeout="$OPTARG" ;;
         o) resultdir="$OPTARG" ; resultdirdefault=false ;;
         O) operation="$OPTARG" ;;
+        R) rate="$OPTARG" ;;
         W) watermarks="<Watermarks><WhcHigh>100kB</WhcHigh></Watermarks>" ;;
         X) netstats=true ;;
         h) usage ;;
@@ -101,6 +119,7 @@ done
 shift $((OPTIND-1))
 if [ $# -lt 1 ] ; then usage ; fi
 remotes="$@"
+[ -n "$security" ] || security="none"
 
 case "$operation" in
     throughput)
@@ -129,6 +148,133 @@ for a in $asynclist ; do
         *) echo "unsupported sync/async \"$a\" for operation \"$operation\"" >&2 ; exit 1 ;;
     esac
 done
+case "$security" in
+    none)
+        gensec=false
+        gensec_governance=false
+        ;;
+    sign|encrypt|rtps-sign|rtps-encrypt|metadata-sign|metadata-encrypt|payload-encrypt)
+        gensec=true
+        gensec_governance=true
+        ;;
+    *.xml)
+        cp "$security" $secdir/governance.xml || exit 1
+        gensec=true
+        gensec_governance=false
+        ;;
+    *) echo "unsupport security mode \"$security\"" >&2 ; exit 1 ;;
+esac
+
+secfiles="secperf/sloth_priv_key.pem secperf/sloth_cert.pem secperf/id_ca_cert.pem secperf/perm_ca_cert.pem secperf/governance.p7s secperf/permissions.p7s"
+if $gensec ; then
+    mkdir -p secperf || { echo "can't create secperf directory" >&2 ; exit 1 ; }
+    if [ "`uname -s`" = "Darwin" -a "`which openssl`" = /usr/bin/openssl ] ; then
+        if which brew >/dev/null 2>&1 ; then
+            openssl="`brew --prefix openssl`/bin/openssl"
+        fi
+    else
+        openssl=openssl
+    fi
+    [ -n "$openssl" ] || { echo "this needs a functioning openssl executable" 2>&1 ; exit 1 ; }
+
+    if $gensec_governance ; then
+        case $security in
+            rtps-sign|sign)
+                rtps_protection=SIGN
+                metadata_protection=NONE
+                data_protection=NONE
+                ;;
+            rtps-encrypt)
+                rtps_protection=ENCRYPT
+                metadata_protection=NONE
+                data_protection=NONE
+                ;;
+            metadata-sign)
+                rtps_protection=NONE
+                metadata_protection=SIGN
+                data_protection=NONE
+                ;;
+            metadata-encrypt)
+                rtps_protection=NONE
+                metadata_protection=ENCRYPT
+                data_protection=NONE
+                ;;
+            payload-encrypt|encrypt)
+                rtps_protection=NONE
+                metadata_protection=NONE
+                data_protection=ENCRYPT
+                ;;
+            *) exit 1 ;;
+        esac
+        cat >secperf/governance.xml <<EOF
+<?xml version="1.0" encoding=\"utf-8\"?>
+<dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://www.omg.org/spec/DDS-SECURITY/20170901/omg_shared_ca_governance.xsd">
+  <domain_access_rules>
+    <domain_rule>
+      <domains> <id_range> <min>0</min> <max>230</max> </id_range> </domains>
+      <allow_unauthenticated_participants>false</allow_unauthenticated_participants>
+      <enable_join_access_control>true</enable_join_access_control>
+      <discovery_protection_kind>NONE</discovery_protection_kind>
+      <liveliness_protection_kind>NONE</liveliness_protection_kind>
+      <rtps_protection_kind>$rtps_protection</rtps_protection_kind>
+      <topic_access_rules>
+        <topic_rule>
+          <topic_expression>*</topic_expression>
+          <enable_discovery_protection>true</enable_discovery_protection>
+          <enable_liveliness_protection>true</enable_liveliness_protection>
+          <enable_read_access_control>true</enable_read_access_control>
+          <enable_write_access_control>true</enable_write_access_control>
+          <metadata_protection_kind>$metadata_protection</metadata_protection_kind>
+          <data_protection_kind>$data_protection</data_protection_kind>
+        </topic_rule>
+      </topic_access_rules>
+    </domain_rule>
+  </domain_access_rules>
+</dds>
+EOF
+        cat >secperf/permissions.xml <<EOF
+<?xml version="1.0" encoding="utf-8" ?>
+<dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:noNamespaceSchemaLocation="https://www.omg.org/spec/DDS-SECURITY/20170901/omg_shared_ca_permissions.xsd">
+  <permissions>
+    <grant name="default_permissions">
+      <subject_name>emailAddress=alice@cycloneddssecurity.adlinktech.com,CN=Alice Example,O=Example Organization,OU=Organizational Unit Name,L=Locality Name,ST=OV,C=NL</subject_name>
+      <validity>
+        <!-- Format is CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] in GMT -->
+        <not_before>2020-01-01T01:00:00</not_before>
+        <not_after>2120-01-01T01:00:00</not_after>
+      </validity>
+      <allow_rule>
+        <domains> <id_range> <min>0</min> <max>230</max> </id_range> </domains>
+        <publish>
+          <topics> <topic>*</topic> </topics>
+          <partitions> <partition>*</partition> </partitions>
+        </publish>
+        <subscribe>
+          <topics> <topic>*</topic> </topics>
+          <partitions> <partition>*</partition> </partitions>
+        </subscribe>
+      </allow_rule>
+      <default>DENY</default>
+    </grant>
+  </permissions>
+</dds>
+EOF
+
+        # generate any missing keys/certificates
+        [ -r secperf/id_ca_priv_key.pem ] || $openssl genrsa -out secperf/id_ca_priv_key.pem 2048
+        [ -r secperf/id_ca_cert.pem ] || $openssl req -x509 -key secperf/id_ca_priv_key.pem -out secperf/id_ca_cert.pem -days 3650 -subj "/C=NL/ST=OV/L=Locality Name/OU=Example OU/O=Example ID CA Organization/CN=Example ID CA/emailAddress=authority@cycloneddssecurity.adlinktech.com"
+        [ -r secperf/perm_ca_priv_key.pem ] || $openssl genrsa -out secperf/perm_ca_priv_key.pem 2048
+        [ -r secperf/perm_ca_cert.pem ] || $openssl req -x509 -key secperf/perm_ca_priv_key.pem -out secperf/perm_ca_cert.pem -days 3650 -subj "/C=NL/ST=OV/L=Locality Name/OU=Example OU/O=Example CA Organization/CN=Example Permissions CA/emailAddress=authority@cycloneddssecurity.adlinktech.com"
+        [ -r secperf/sloth_priv_key.pem ] || $openssl genrsa -out secperf/sloth_priv_key.pem 2048
+        [ -r secperf/sloth.csr ] || $openssl req -new -key secperf/sloth_priv_key.pem -out secperf/sloth.csr -subj "/C=NL/ST=OV/L=Locality Name/OU=Organizational Unit Name/O=Example Organization/CN=Alice Example/emailAddress=alice@cycloneddssecurity.adlinktech.com"
+        [ -r secperf/sloth_cert.pem ] || $openssl x509 -req -CA secperf/id_ca_cert.pem -CAkey secperf/id_ca_priv_key.pem -CAcreateserial -days 3650 -in secperf/sloth.csr -out secperf/sloth_cert.pem
+
+        # always sign permissions, governance
+        $openssl smime -sign -in secperf/permissions.xml -text -out secperf/permissions.p7s -signer secperf/perm_ca_cert.pem -inkey secperf/perm_ca_priv_key.pem
+        $openssl smime -sign -in secperf/governance.xml -text -out secperf/governance.p7s -signer secperf/perm_ca_cert.pem -inkey secperf/perm_ca_priv_key.pem
+    fi
+fi
 
 [ -z "$rnwif" ] && rnwif=$nwif
 cfg=cdds-simple.xml
@@ -138,10 +284,35 @@ cat >$cfg <<EOF
     <General>
       <NetworkInterfaceAddress>\${nwif}</NetworkInterfaceAddress>
       <EnableMulticastLoopback>$loopback</EnableMulticastLoopback>
+      <MaxMessageSize>65500B</MaxMessageSize>
     </General>
+EOF
+if [ "$security" != "none" ] ; then
+cat >>$cfg <<EOF
+    <Security>
+      <Authentication>
+        <Library initFunction="init_authentication" finalizeFunction="finalize_authentication" path="dds_security_auth"/>
+        <IdentityCA>file:\${secdir}/id_ca_cert.pem</IdentityCA>
+        <IdentityCertificate>file:\${secdir}/sloth_cert.pem</IdentityCertificate>
+        <PrivateKey>file:\${secdir}/sloth_priv_key.pem</PrivateKey>
+      </Authentication>
+      <Cryptographic>
+        <Library initFunction="init_crypto" finalizeFunction="finalize_crypto" path="dds_security_crypto"/>
+      </Cryptographic>
+      <AccessControl>
+        <Library initFunction="init_access_control" finalizeFunction="finalize_access_control" path="dds_security_ac"/>
+        <PermissionsCA>file:\${secdir}/perm_ca_cert.pem</PermissionsCA>
+        <Governance>file:\${secdir}/governance.p7s</Governance>
+        <Permissions>file:\${secdir}/permissions.p7s</Permissions>
+      </AccessControl>
+    </Security>
+EOF
+fi
+cat >>$cfg <<EOF
     <Internal>
       <SynchronousDeliveryPriorityThreshold>\${async:-0}</SynchronousDeliveryPriorityThreshold>
       <LeaseDuration>2s</LeaseDuration>
+      <MinimumSocketReceiveBufferSize>6MB</MinimumSocketReceiveBufferSize>
       $watermarks
     </Internal>
     <Tracing>
@@ -155,7 +326,7 @@ EOF
 
 localbindir=""
 locallibdir=""
-for x in "" /Release /RelWithDebInfo bin/Debug ; do
+for x in "" /Release /RelWithDebInfo /Debug ; do
     if [ -x bin$x/ddsperf -a -f lib$x/libddsc$libsuffix ] ; then
         localbindir=bin$x
         locallibdir=lib$x
@@ -186,6 +357,10 @@ if $provision ; then
         scp $localbindir/ddsperf $r:$remotedir/bin
     done
 fi
+if [ "$security" != "none" ] ; then
+    ssh $r mkdir -p $remotedir $remotedir/secperf
+    scp $secfiles $r:$remotedir/secperf
+fi
 
 topic=KS
 [ -z "$sizelist" ] && topic=OU
@@ -213,10 +388,11 @@ export CYCLONEDDS_URI=file://$remotedir/$cfg
 export async=$async
 export nwif=$rnwif
 export logdir=.
+export secdir=./secperf
 #export trace=trace,-content
 cd $remotedir
 remotebindir=""
-for x in "" /Release /RelWithDebInfo bin/Debug ; do
+for x in "" /Release /RelWithDebInfo Debug ; do
     if [ -x bin\$x/ddsperf ] ; then
         remotebindir=bin\$x
         break
@@ -228,7 +404,7 @@ if [ -z "\$remotebindir" ] ; then
 fi
 #/usr/sbin/tcpdump -c 20000 -s 0 -w /tmp/x.pcap -i eth0 -Z erik 'udp[8:4]=0x52545053' & tcpdumppid=\$!
 #/usr/sbin/tcpdump -c 20000 -s 0 -w /tmp/x.pcap -i eth0 -Z erik 'udp' & tcpdumppid=\$!
-\$remotebindir/ddsperf -1 -X -d $rnwif$bandwidth -c -T $topic $remote_oper $sub_mode > $remote_oper.log & pid=\$!
+\$remotebindir/ddsperf -1l -X -d $rnwif$bandwidth -c -T $topic $remote_oper $sub_mode > $remote_oper.log & pid=\$!
 echo \$pid > $operation-test-$remote_oper-\$pid.pid
 wait \$pid
 [ -n "\$tcpdumppid" ] && kill -INT \$tcpdumppid
@@ -242,6 +418,7 @@ EOF
         mkdir $outdir
         rm -f $outdir/$local_oper.log
         export logdir=$outdir
+        export secdir=./secperf
         if $netstats ; then
             ping `echo $1 | sed -e 's/.*@//'` > $outdir/icmpping.log & netstats_pids=$!
             if [ "`uname -s`" = "Darwin" ] ; then
@@ -255,7 +432,7 @@ EOF
             $localbindir/ddsperf -Q minmatch:$# -Q initwait:3 \
                         -X -c -d $nwif$bandwidth \
                         -D $timeout -T $topic \
-                        $local_oper size $size | \
+                        $local_oper size $size $rate | \
                 tee -a $outdir/$local_oper.log
         done
 

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -1056,6 +1056,13 @@ dds_return_t new_participant_guid (ddsi_guid_t *ppguid, struct ddsi_domaingv *gv
   if ((ret = q_omg_security_check_create_participant (pp, gv->config.domainId)) != DDS_RETCODE_OK)
     goto not_allowed;
   *ppguid = pp->e.guid;
+  // FIXME: Adjusting the GUID and then fixing up the GUID -> iid mapping here is an ugly hack
+  if (pp->e.tk)
+  {
+    ddsi_tkmap_instance_unref (gv->m_tkmap, pp->e.tk);
+    pp->e.tk = builtintopic_get_tkmap_entry (gv->builtin_topic_interface, &pp->e.guid);
+    pp->e.iid = pp->e.tk->m_iid;
+ }
 #else
   if (ddsi_xqos_has_prop_prefix (&pp->plist->qos, "dds.sec."))
   {

--- a/src/security/core/tests/CMakeLists.txt
+++ b/src/security/core/tests/CMakeLists.txt
@@ -78,6 +78,7 @@ if(ENABLE_SSL AND OPENSSL_FOUND)
     "common/cert_utils.c"
     "authentication.c"
     "access_control.c"
+    "builtintopic.c"
     "config.c"
     "crypto.c"
     "handshake.c"

--- a/src/security/core/tests/builtintopic.c
+++ b/src/security/core/tests/builtintopic.c
@@ -1,0 +1,116 @@
+/*
+ * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include <stdlib.h>
+#include <assert.h>
+
+#include "dds/dds.h"
+#include "CUnit/Test.h"
+#include "CUnit/Theory.h"
+
+#include "dds/version.h"
+#include "dds/ddsrt/cdtors.h"
+#include "dds/ddsrt/environ.h"
+#include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/string.h"
+#include "dds/ddsrt/threads.h"
+#include "dds/ddsrt/process.h"
+#include "dds/ddsi/q_config.h"
+#include "dds/ddsi/ddsi_domaingv.h"
+#include "dds/ddsi/q_misc.h"
+#include "dds/ddsi/ddsi_xqos.h"
+#include "dds/security/dds_security_api.h"
+
+#include "common/config_env.h"
+#include "common/test_identity.h"
+#include "common/test_utils.h"
+#include "common/security_config_test_utils.h"
+#include "common/cryptography_wrapper.h"
+#include "common/test_identity.h"
+#include "common/cert_utils.h"
+
+static const char *config =
+    "${CYCLONEDDS_URI}${CYCLONEDDS_URI:+,}"
+    "<Domain id=\"any\">"
+    "  <Discovery>"
+    "    <ExternalDomainId>0</ExternalDomainId>"
+    "    <Tag>\\${CYCLONEDDS_PID}</Tag>"
+    "  </Discovery>"
+    "  <Security>"
+    "    <Authentication>"
+    "      <Library finalizeFunction=\"finalize_test_authentication_wrapped\" initFunction=\"init_test_authentication_wrapped\" path=\"" WRAPPERLIB_PATH("dds_security_authentication_wrapper") "\"/>"
+    "      <IdentityCertificate>data:," TEST_IDENTITY1_CERTIFICATE "</IdentityCertificate>"
+    "      <PrivateKey>data:," TEST_IDENTITY1_PRIVATE_KEY "</PrivateKey>"
+    "      <IdentityCA>data:," TEST_IDENTITY_CA1_CERTIFICATE "</IdentityCA>"
+    "    </Authentication>"
+    "    <AccessControl>"
+    "      <Library finalizeFunction=\"finalize_access_control\" initFunction=\"init_access_control\"/>"
+    "      <Governance>file:" COMMON_ETC_PATH("default_governance.p7s") "</Governance>"
+    "      <PermissionsCA>file:" COMMON_ETC_PATH("default_permissions_ca.pem") "</PermissionsCA>"
+    "      <Permissions>file:" COMMON_ETC_PATH("default_permissions.p7s") "</Permissions>"
+    "    </AccessControl>"
+    "    <Cryptographic>"
+    "      <Library finalizeFunction=\"finalize_crypto\" initFunction=\"init_crypto\"/>"
+    "    </Cryptographic>"
+    "  </Security>"
+    "</Domain>";
+
+CU_Test(ddssec_builtintopic, participant_iid)
+{
+  static struct kvp config_vars[] = { { NULL, NULL, 0 } };
+  char *conf;
+  conf = ddsrt_expand_vars_sh (config, &expand_lookup_vars_env, config_vars);
+  CU_ASSERT_EQUAL_FATAL (expand_lookup_unmatched (config_vars), 0);
+  dds_entity_t domain = dds_create_domain (0, conf);
+  CU_ASSERT_FATAL (domain > 0);
+  dds_entity_t pp = dds_create_participant (0, NULL, NULL);
+  CU_ASSERT_FATAL (pp > 0);
+  ddsrt_free (conf);
+  
+  dds_return_t rc;
+  dds_guid_t guid;
+  dds_instance_handle_t iid;
+  rc = dds_get_guid (pp, &guid);
+  CU_ASSERT_FATAL (rc == 0);
+  rc = dds_get_instance_handle (pp, &iid);
+  CU_ASSERT_FATAL (rc == 0);
+  
+  dds_entity_t rd = dds_create_reader (pp, DDS_BUILTIN_TOPIC_DCPSPARTICIPANT, NULL, NULL);
+  
+  // Should be able to find it by GUID; instance id must match
+  {
+    dds_instance_handle_t iid1;
+    iid1 = dds_lookup_instance (rd, &guid);
+    CU_ASSERT_FATAL (iid1 == iid);
+  }
+  
+  // Should be able to find it by instance; GUID must match
+  {
+    dds_sample_info_t si;
+    void *raw = NULL;
+    int32_t n = dds_take_instance (rd, &raw, &si, 1, 1, iid);
+    CU_ASSERT_FATAL (n == 1);
+    CU_ASSERT_FATAL (si.valid_data);
+    const dds_builtintopic_participant_t *s = raw;
+    CU_ASSERT_FATAL (memcmp (&s->key, &guid, sizeof (guid)) == 0);
+    dds_return_loan (rd, &raw, 1);
+  }
+  
+  // There should be no other instances
+  {
+    dds_sample_info_t si;
+    void *raw = NULL;
+    int32_t n = dds_take_instance (rd, &raw, &si, 1, 1, iid);
+    CU_ASSERT_FATAL (n == 0);
+  }
+  
+  dds_delete (domain);
+}

--- a/src/tools/ddsperf/ddsperf.c
+++ b/src/tools/ddsperf/ddsperf.c
@@ -173,6 +173,9 @@ static double rss_term = 0;
 static uint64_t min_received = 0;
 static uint64_t min_roundtrips = 0;
 
+/* Whether to gather/show latency information in "sub" mode */
+static bool sublatency = false;
+
 static ddsrt_mutex_t disc_lock;
 
 /* Publisher statistics and lock protecting it */
@@ -188,6 +191,14 @@ struct hist {
 
 static ddsrt_mutex_t pubstat_lock;
 static struct hist *pubstat_hist;
+
+struct latencystat {
+  int64_t min, max;
+  int64_t sum;
+  uint32_t cnt;
+  uint64_t totcnt;
+  int64_t *raw;
+};
 
 /* Subscriber statistics for tracking number of samples received
    and lost per source */
@@ -205,6 +216,10 @@ struct eseq_stat {
     uint64_t nrecv_bytes;
   } ref[10];
   unsigned refidx;
+
+  /* for gathering latency information in case the clocks are
+     sufficiently well synchronised (e.g., single machine or PTP) */
+  struct latencystat info;
 };
 
 struct eseq_admin {
@@ -212,6 +227,7 @@ struct eseq_admin {
   unsigned nkeys;
   unsigned nph;
   dds_instance_handle_t *ph;
+  dds_instance_handle_t *pph;
   struct eseq_stat *stats;
   uint32_t **eseq;
 };
@@ -229,11 +245,7 @@ struct subthread_arg_pongwr {
 struct subthread_arg_pongstat {
   dds_instance_handle_t pubhandle;
   dds_instance_handle_t pphandle;
-  uint64_t min, max;
-  uint64_t sum;
-  uint32_t cnt;
-  uint64_t totcnt;
-  uint64_t *raw;
+  struct latencystat info;
 };
 
 /* Pong statistics is stored in n array of npongstat entries
@@ -662,12 +674,95 @@ static uint32_t pubthread (void *varg)
   return 0;
 }
 
+static uint32_t topic_payload_size (enum topicsel tp, uint32_t bgsize)
+{
+  uint32_t size = 0;
+  switch (tp)
+  {
+    case KS:     size = 12 + bgsize; break;
+    case K32:    size = 32; break;
+    case K256:   size = 256; break;
+    case OU:     size = 4; break;
+    case UK16:   size = 16; break;
+    case UK1024: size = 1024; break;
+  }
+  return size;
+}
+
+static void latencystat_init (struct latencystat *x)
+{
+  x->min = INT64_MAX;
+  x->max = INT64_MIN;
+  x->sum = x->cnt = 0;
+  x->raw = malloc (PINGPONG_RAWSIZE * sizeof (*x->raw));
+}
+
+static void latencystat_fini (struct latencystat *x)
+{
+  free (x->raw);
+}
+
+static void latencystat_reset (struct latencystat *x, int64_t *newraw)
+{
+  x->raw = newraw;
+  x->min = INT64_MAX;
+  x->max = INT64_MIN;
+  x->sum = x->cnt = 0;
+}
+
+static int cmp_int64 (const void *va, const void *vb)
+{
+  const int64_t *a = va;
+  const int64_t *b = vb;
+  return (*a == *b) ? 0 : (*a < *b) ? -1 : 1;
+}
+
+static int64_t *latencystat_print (struct latencystat *y, const char *prefix, const char *subprefix, dds_instance_handle_t pubhandle, dds_instance_handle_t pphandle, uint32_t size)
+{
+  if (y->cnt > 0)
+  {
+    const uint32_t rawcnt = (y->cnt > PINGPONG_RAWSIZE) ? PINGPONG_RAWSIZE : y->cnt;
+    char ppinfo[128];
+    struct ppant *pp;
+    ddsrt_mutex_lock (&disc_lock);
+    if ((pp = ddsrt_avl_lookup (&ppants_td, &ppants, &pphandle)) == NULL)
+      snprintf (ppinfo, sizeof (ppinfo), "%"PRIx64, pubhandle);
+    else
+      snprintf (ppinfo, sizeof (ppinfo), "%s:%"PRIu32, pp->hostname, pp->pid);
+    ddsrt_mutex_unlock (&disc_lock);
+
+    qsort (y->raw, rawcnt, sizeof (*y->raw), cmp_int64);
+    printf ("%s%s %s size %"PRIu32" mean %.3fus min %.3fus 50%% %.3fus 90%% %.3fus 99%% %.3fus max %.3fus cnt %"PRIu32"\n",
+            prefix, subprefix, ppinfo, size,
+            (double) y->sum / (double) y->cnt / 1e3,
+            (double) y->min / 1e3,
+            (double) y->raw[rawcnt - (rawcnt + 1) / 2] / 1e3,
+            (double) y->raw[rawcnt - (rawcnt + 9) / 10] / 1e3,
+            (double) y->raw[rawcnt - (rawcnt + 99) / 100] / 1e3,
+            (double) y->max / 1e3,
+            y->cnt);
+  }
+  return y->raw;
+}
+
+static void latencystat_update (struct latencystat *x, int64_t tdelta)
+{
+  if (tdelta < x->min) x->min = tdelta;
+  if (tdelta > x->max) x->max = tdelta;
+  x->sum += tdelta;
+  if (x->cnt < PINGPONG_RAWSIZE)
+    x->raw[x->cnt] = tdelta;
+  x->cnt++;
+  x->totcnt++;
+}
+
 static void init_eseq_admin (struct eseq_admin *ea, unsigned nkeys)
 {
   ddsrt_mutex_init (&ea->lock);
   ea->nkeys = nkeys;
   ea->nph = 0;
   ea->ph = NULL;
+  ea->pph = NULL;
   ea->stats = NULL;
   ea->eseq = NULL;
 }
@@ -675,49 +770,17 @@ static void init_eseq_admin (struct eseq_admin *ea, unsigned nkeys)
 static void fini_eseq_admin (struct eseq_admin *ea)
 {
   free (ea->ph);
+  free (ea->pph);
+  if (sublatency)
+  {
+    for (unsigned i = 0; i < ea->nph; i++)
+      latencystat_fini (&ea->stats[i].info);
+  }
   free (ea->stats);
   for (unsigned i = 0; i < ea->nph; i++)
     free (ea->eseq[i]);
   ddsrt_mutex_destroy (&ea->lock);
   free (ea->eseq);
-}
-
-static int check_eseq (struct eseq_admin *ea, uint32_t seq, uint32_t keyval, uint32_t size, const dds_instance_handle_t pubhandle)
-{
-  uint32_t *eseq;
-  if (keyval >= ea->nkeys)
-  {
-    printf ("received key %"PRIu32" >= nkeys %u\n", keyval, ea->nkeys);
-    exit (3);
-  }
-  ddsrt_mutex_lock (&ea->lock);
-  for (uint32_t i = 0; i < ea->nph; i++)
-    if (pubhandle == ea->ph[i])
-    {
-      uint32_t e = ea->eseq[i][keyval];
-      ea->eseq[i][keyval] = seq + ea->nkeys;
-      ea->stats[i].nrecv++;
-      ea->stats[i].nrecv_bytes += size;
-      ea->stats[i].nlost += seq - e;
-      ea->stats[i].last_size = size;
-      ddsrt_mutex_unlock (&ea->lock);
-      return seq == e;
-    }
-  ea->ph = realloc (ea->ph, (ea->nph + 1) * sizeof (*ea->ph));
-  ea->ph[ea->nph] = pubhandle;
-  ea->eseq = realloc (ea->eseq, (ea->nph + 1) * sizeof (*ea->eseq));
-  ea->eseq[ea->nph] = malloc (ea->nkeys * sizeof (*ea->eseq[ea->nph]));
-  eseq = ea->eseq[ea->nph];
-  for (unsigned i = 0; i < ea->nkeys; i++)
-    eseq[i] = seq + (i - keyval) + (i <= keyval ? ea->nkeys : 0);
-  ea->stats = realloc (ea->stats, (ea->nph + 1) * sizeof (*ea->stats));
-  memset (&ea->stats[ea->nph], 0, sizeof (ea->stats[ea->nph]));
-  ea->stats[ea->nph].nrecv = 1;
-  ea->stats[ea->nph].nrecv_bytes = size;
-  ea->stats[ea->nph].last_size = size;
-  ea->nph++;
-  ddsrt_mutex_unlock (&ea->lock);
-  return 1;
 }
 
 static dds_instance_handle_t get_pphandle_for_pubhandle (dds_instance_handle_t pubhandle)
@@ -744,7 +807,54 @@ static dds_instance_handle_t get_pphandle_for_pubhandle (dds_instance_handle_t p
   }
 }
 
-static bool update_roundtrip (dds_instance_handle_t pubhandle, uint64_t tdelta, bool isping, uint32_t seq)
+static int check_eseq (struct eseq_admin *ea, uint32_t seq, uint32_t keyval, uint32_t size, const dds_instance_handle_t pubhandle, int64_t tdelta)
+{
+  uint32_t *eseq;
+  if (keyval >= ea->nkeys)
+  {
+    printf ("received key %"PRIu32" >= nkeys %u\n", keyval, ea->nkeys);
+    exit (3);
+  }
+  ddsrt_mutex_lock (&ea->lock);
+  for (uint32_t i = 0; i < ea->nph; i++)
+    if (pubhandle == ea->ph[i])
+    {
+      uint32_t e = ea->eseq[i][keyval];
+      ea->eseq[i][keyval] = seq + ea->nkeys;
+      ea->stats[i].nrecv++;
+      ea->stats[i].nrecv_bytes += size;
+      ea->stats[i].nlost += seq - e;
+      ea->stats[i].last_size = size;
+      if (sublatency)
+        latencystat_update (&ea->stats[i].info, tdelta);
+      ddsrt_mutex_unlock (&ea->lock);
+      return seq == e;
+    }
+  ea->ph = realloc (ea->ph, (ea->nph + 1) * sizeof (*ea->ph));
+  ea->ph[ea->nph] = pubhandle;
+  ea->pph = realloc (ea->pph, (ea->nph + 1) * sizeof (*ea->pph));
+  ea->pph[ea->nph] = get_pphandle_for_pubhandle (pubhandle);
+  ea->eseq = realloc (ea->eseq, (ea->nph + 1) * sizeof (*ea->eseq));
+  ea->eseq[ea->nph] = malloc (ea->nkeys * sizeof (*ea->eseq[ea->nph]));
+  eseq = ea->eseq[ea->nph];
+  for (unsigned i = 0; i < ea->nkeys; i++)
+    eseq[i] = seq + (i - keyval) + (i <= keyval ? ea->nkeys : 0);
+  ea->stats = realloc (ea->stats, (ea->nph + 1) * sizeof (*ea->stats));
+  memset (&ea->stats[ea->nph], 0, sizeof (ea->stats[ea->nph]));
+  ea->stats[ea->nph].nrecv = 1;
+  ea->stats[ea->nph].nrecv_bytes = size;
+  ea->stats[ea->nph].last_size = size;
+  if (sublatency)
+  {
+    latencystat_init (&ea->stats[ea->nph].info);
+    latencystat_update (&ea->stats[ea->nph].info, tdelta);
+  }
+  ea->nph++;
+  ddsrt_mutex_unlock (&ea->lock);
+  return 1;
+}
+
+static bool update_roundtrip (dds_instance_handle_t pubhandle, int64_t tdelta, bool isping, uint32_t seq)
 {
   bool allseen;
   ddsrt_mutex_lock (&pongstat_lock);
@@ -761,14 +871,7 @@ static bool update_roundtrip (dds_instance_handle_t pubhandle, uint64_t tdelta, 
   for (uint32_t i = 0; i < npongstat; i++)
     if (pongstat[i].pubhandle == pubhandle)
     {
-      struct subthread_arg_pongstat * const x = &pongstat[i];
-      if (tdelta < x->min) x->min = tdelta;
-      if (tdelta > x->max) x->max = tdelta;
-      x->sum += tdelta;
-      if (x->cnt < PINGPONG_RAWSIZE)
-        x->raw[x->cnt] = tdelta;
-      x->cnt++;
-      x->totcnt++;
+      latencystat_update (&pongstat[i].info, tdelta);
       ddsrt_mutex_unlock (&pongstat_lock);
       return allseen;
     }
@@ -776,11 +879,8 @@ static bool update_roundtrip (dds_instance_handle_t pubhandle, uint64_t tdelta, 
   struct subthread_arg_pongstat * const x = &pongstat[npongstat];
   x->pubhandle = pubhandle;
   x->pphandle = get_pphandle_for_pubhandle (pubhandle);
-  x->min = x->max = x->sum = tdelta;
-  x->cnt = 1;
-  x->totcnt = 1;
-  x->raw = malloc (PINGPONG_RAWSIZE * sizeof (*x->raw));
-  x->raw[0] = tdelta;
+  latencystat_init (&x->info);
+  latencystat_update (&x->info, tdelta);
   npongstat++;
   ddsrt_mutex_unlock (&pongstat_lock);
   return allseen;
@@ -798,7 +898,7 @@ static dds_entity_t get_pong_writer_locked (dds_instance_handle_t pubhandle)
      (and having to GC it, which I'm skipping here ...) */
   pphandle = get_pphandle_for_pubhandle (pubhandle);
 
-  /* This gets called when no writer is associaed yet with pubhandle, but it may be that a writer
+  /* This gets called when no writer is associated yet with pubhandle, but it may be that a writer
      is associated already with pphandle (because there is the data writer and the ping writer) */
   for (uint32_t i = 0; i < npongwr; i++)
   {
@@ -835,21 +935,6 @@ static dds_entity_t get_pong_writer (dds_instance_handle_t pubhandle)
   return wr_pong;
 }
 
-static uint32_t topic_payload_size (enum topicsel tp, uint32_t bgsize)
-{
-  uint32_t size = 0;
-  switch (tp)
-  {
-    case KS:     size = 12 + bgsize; break;
-    case K32:    size = 32; break;
-    case K256:   size = 256; break;
-    case OU:     size = 4; break;
-    case UK16:   size = 16; break;
-    case UK1024: size = 1024; break;
-  }
-  return size;
-}
-
 static bool process_data (dds_entity_t rd, struct subthread_arg *arg)
 {
   uint32_t max_samples = arg->max_samples;
@@ -862,6 +947,7 @@ static bool process_data (dds_entity_t rd, struct subthread_arg *arg)
   {
     if (iseq[i].valid_data)
     {
+      const int64_t tdelta = dds_time () - iseq[i].source_timestamp;
       uint32_t seq = 0, keyval = 0, size = 0;
       switch (topicsel)
       {
@@ -875,7 +961,7 @@ static bool process_data (dds_entity_t rd, struct subthread_arg *arg)
         case UK16:   { Unkeyed16 *d   = mseq[i]; keyval = 0;         seq = d->seq; size = topic_payload_size (topicsel, 0); } break;
         case UK1024: { Unkeyed1024 *d = mseq[i]; keyval = 0;         seq = d->seq; size = topic_payload_size (topicsel, 0); } break;
       }
-      (void) check_eseq (&eseq_admin, seq, keyval, size, iseq[i].publication_handle);
+      (void) check_eseq (&eseq_admin, seq, keyval, size, iseq[i].publication_handle, tdelta);
       if (iseq[i].source_timestamp & 1)
       {
         dds_entity_t wr_pong;
@@ -904,16 +990,16 @@ static bool process_ping (dds_entity_t rd, struct subthread_arg *arg)
     error2 ("dds_take (rd_data): %d\n", (int) nread_ping);
   for (int32_t i = 0; i < nread_ping; i++)
   {
-    if (iseq[i].valid_data)
+    if (!iseq[i].valid_data)
+      continue;
+
+    dds_entity_t wr_pong;
+    if ((wr_pong = get_pong_writer (iseq[i].publication_handle)) != 0)
     {
-      dds_entity_t wr_pong;
-      if ((wr_pong = get_pong_writer (iseq[i].publication_handle)) != 0)
-      {
-        dds_return_t rc;
-        if ((rc = dds_write_ts (wr_pong, mseq[i], iseq[i].source_timestamp | 1)) < 0 && rc != DDS_RETCODE_TIMEOUT)
-          error2 ("dds_write_ts (wr_pong, mseq[i], iseq[i].source_timestamp): %d\n", (int) rc);
-        dds_write_flush (wr_pong);
-      }
+      dds_return_t rc;
+      if ((rc = dds_write_ts (wr_pong, mseq[i], iseq[i].source_timestamp | 1)) < 0 && rc != DDS_RETCODE_TIMEOUT)
+        error2 ("dds_write_ts (wr_pong, mseq[i], iseq[i].source_timestamp): %d\n", (int) rc);
+      dds_write_flush (wr_pong);
     }
   }
   return (nread_ping > 0);
@@ -935,7 +1021,7 @@ static bool process_pong (dds_entity_t rd, struct subthread_arg *arg)
       {
         uint32_t * const seq = mseq[i];
         const bool isping = (iseq[i].source_timestamp & 1) != 0;
-        const bool all = update_roundtrip (iseq[i].publication_handle, (uint64_t) (tnow - iseq[i].source_timestamp) / 2, isping, *seq);
+        const bool all = update_roundtrip (iseq[i].publication_handle, (tnow - iseq[i].source_timestamp) / 2, isping, *seq);
         if (isping && all && ping_intv == 0)
         {
           /* If it is a pong sent in response to a ping, and all known nodes have responded, send out a new ping */
@@ -1373,13 +1459,6 @@ static void set_data_available_listener (dds_entity_t rd, const char *rd_name, d
   dds_delete_listener (listener);
 }
 
-static int cmp_uint64 (const void *va, const void *vb)
-{
-  const uint64_t *a = va;
-  const uint64_t *b = vb;
-  return (*a == *b) ? 0 : (*a < *b) ? -1 : 1;
-}
-
 struct dds_stats {
   struct dds_statistics *pubstat;
   const struct dds_stat_keyvalue *rexmit_bytes;
@@ -1405,6 +1484,7 @@ static bool print_stats (dds_time_t tref, dds_time_t tnow, dds_time_t tprev, str
     output = true;
   }
 
+  int64_t *newraw = malloc (PINGPONG_RAWSIZE * sizeof (*newraw));
   if (submode != SM_NONE)
   {
     struct eseq_admin * const ea = &eseq_admin;
@@ -1443,47 +1523,39 @@ static bool print_stats (dds_time_t tref, dds_time_t tnow, dds_time_t tprev, str
               (double) nrecv10s * 1e6 / (10 * dt), (double) nrecv10s_bytes * 8 * 1e3 / (10 * dt));
       output = true;
     }
+
+    if (sublatency)
+    {
+      ddsrt_mutex_lock (&ea->lock);
+      for (uint32_t i = 0; i < ea->nph; i++)
+      {
+        struct eseq_stat * const x = &ea->stats[i];
+        struct latencystat y = x->info;
+        latencystat_reset (&x->info, newraw);
+        /* pongwr entries get added at the end, npongwr only grows: so can safely
+         unlock the stats in between nodes for calculating percentiles */
+        ddsrt_mutex_unlock (&ea->lock);
+        if (y.cnt > 0)
+          output = true;
+        newraw = latencystat_print (&y, prefix, " sublat", ea->ph[i], ea->pph[i], x->last_size);
+        ddsrt_mutex_lock (&ea->lock);
+      }
+      ddsrt_mutex_unlock (&ea->lock);
+    }
   }
 
-  uint64_t *newraw = malloc (PINGPONG_RAWSIZE * sizeof (*newraw));
   ddsrt_mutex_lock (&pongstat_lock);
   for (uint32_t i = 0; i < npongstat; i++)
   {
     struct subthread_arg_pongstat * const x = &pongstat[i];
     struct subthread_arg_pongstat y = *x;
-    x->raw = newraw;
-    x->min = UINT64_MAX;
-    x->max = x->sum = x->cnt = 0;
+    latencystat_reset (&x->info, newraw);
     /* pongstat entries get added at the end, npongstat only grows: so can safely
        unlock the stats in between nodes for calculating percentiles */
     ddsrt_mutex_unlock (&pongstat_lock);
-
-    if (y.cnt > 0)
-    {
-      const uint32_t rawcnt = (y.cnt > PINGPONG_RAWSIZE) ? PINGPONG_RAWSIZE : y.cnt;
-      char ppinfo[128];
-      struct ppant *pp;
-      ddsrt_mutex_lock (&disc_lock);
-      if ((pp = ddsrt_avl_lookup (&ppants_td, &ppants, &y.pphandle)) == NULL)
-        snprintf (ppinfo, sizeof (ppinfo), "%"PRIx64, y.pubhandle);
-      else
-        snprintf (ppinfo, sizeof (ppinfo), "%s:%"PRIu32, pp->hostname, pp->pid);
-      ddsrt_mutex_unlock (&disc_lock);
-
-      qsort (y.raw, rawcnt, sizeof (*y.raw), cmp_uint64);
-      printf ("%s %s size %"PRIu32" mean %.3fus min %.3fus 50%% %.3fus 90%% %.3fus 99%% %.3fus max %.3fus cnt %"PRIu32"\n",
-              prefix, ppinfo, topic_payload_size (topicsel, baggagesize),
-              (double) y.sum / (double) y.cnt / 1e3,
-              (double) y.min / 1e3,
-              (double) y.raw[rawcnt - (rawcnt + 1) / 2] / 1e3,
-              (double) y.raw[rawcnt - (rawcnt + 9) / 10] / 1e3,
-              (double) y.raw[rawcnt - (rawcnt + 99) / 100] / 1e3,
-              (double) y.max / 1e3,
-              y.cnt);
+    if (y.info.cnt > 0)
       output = true;
-    }
-    newraw = y.raw;
-
+    newraw = latencystat_print (&y.info, prefix, "", y.pubhandle, y.pphandle, topic_payload_size (topicsel, baggagesize));
     ddsrt_mutex_lock (&pongstat_lock);
   }
   ddsrt_mutex_unlock (&pongstat_lock);
@@ -1952,7 +2024,7 @@ int main (int argc, char *argv[])
 
   argv0 = argv[0];
 
-  while ((opt = getopt (argc, argv, "1cd:D:i:n:k:uLK:T:Q:R:Xh")) != EOF)
+  while ((opt = getopt (argc, argv, "1cd:D:i:n:k:ulLK:T:Q:R:Xh")) != EOF)
   {
     int pos;
     switch (opt)
@@ -1977,6 +2049,7 @@ int main (int argc, char *argv[])
       case 'n': nkeyvals = (unsigned) atoi (optarg); break;
       case 'u': reliable = false; break;
       case 'k': histdepth = atoi (optarg); if (histdepth < 0) histdepth = 0; break;
+      case 'l': sublatency = true; break;
       case 'L': ignorelocal = DDS_IGNORELOCAL_NONE; break;
       case 'T': case 'K': /* 'K' because of my muscle memory with pubsub ... */
         if (strcmp (optarg, "KS") == 0) topicsel = KS;
@@ -2528,9 +2601,9 @@ err_minmatch_wait:
   bool roundtrips_ok = true;
   for (uint32_t i = 0; i < npongstat; i++)
   {
-    if (pongstat[i].totcnt < min_roundtrips)
+    if (pongstat[i].info.totcnt < min_roundtrips)
       roundtrips_ok = false;
-    free (pongstat[i].raw);
+    latencystat_fini (&pongstat[i].info);
   }
   free (pongstat);
 


### PR DESCRIPTION
What it says on the tin. Running with "perftest -S sign" enables RTPS message authentication, running with "-S encrypt" additionally adds payload encryption.

(This builds on #730)