### PR TITLE
Update CYCLONEDDS_URI in Azure configuration

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,7 +84,7 @@ pool:
   vmImage: $(image)
 
 variables:
-  cyclonedds_uri: '<CycloneDDS><Domain><Internal><EnableExpensiveChecks>rhc,whc</EnableExpensiveChecks></Internal></Domain></CycloneDDS>'
+  cyclonedds_uri: '<CycloneDDS><Domain><Internal><EnableExpensiveChecks>rhc,whc</EnableExpensiveChecks><LivelinessMonitoring>true</LivelinessMonitoring></Internal><Tracing><Verbosity>config</Verbosity><OutputFile>stderr</OutputFile></Tracing></Domain></CycloneDDS>'
 
 steps:
   - template: /.azure/templates/build-test.yml


### PR DESCRIPTION
This brings the settings in line with what we have been using on Travis
CI for quite some time by enabling:

* printing of configuration so that some additional information is
  available on failure;

* thread liveliness monitoring, which has proven its worth by catching a
  few deadlocks.

Signed-off-by: Erik Boasson <eb@ilities.com>