### PR TITLE
Some small additions

### DIFF
--- a/src/core/ddsc/CMakeLists.txt
+++ b/src/core/ddsc/CMakeLists.txt
@@ -40,6 +40,7 @@ PREPEND(srcs_ddsc "${CMAKE_CURRENT_LIST_DIR}/src"
     dds_whc_builtintopic.c
     dds_serdata_builtintopic.c
     dds_sertype_builtintopic.c
+    dds_data_allocator.c
 )
 
 if (DDS_HAS_SHM)
@@ -57,6 +58,7 @@ PREPEND(hdrs_public_ddsc "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/dd
     ddsc/dds_statistics.h
     ddsc/dds_rhc.h
     ddsc/dds_internal_api.h
+    ddsc/dds_data_allocator.h
 )
 
 PREPEND(hdrs_private_ddsc "${CMAKE_CURRENT_LIST_DIR}/src"
@@ -85,6 +87,7 @@ PREPEND(hdrs_private_ddsc "${CMAKE_CURRENT_LIST_DIR}/src"
     dds__whc_builtintopic.h
     dds__serdata_builtintopic.h
     dds__get_status.h
+    dds__data_allocator.h
 )
 
 if (DDS_HAS_SHM)

--- a/src/core/ddsc/include/dds/ddsc/dds_data_allocator.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_data_allocator.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright(c) 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+#ifndef DDS_DATA_ALLOCATOR_H
+#define DDS_DATA_ALLOCATOR_H
+
+/* A quick-and-dirty provisional interface */
+
+#include "dds/dds.h"
+#include "dds/ddsrt/attributes.h"
+#include "dds/export.h"
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+#define DDS_DATA_ALLOCATOR_MAX_SIZE (8 * sizeof (void *))
+
+typedef struct dds_data_allocator {
+  dds_entity_t entity;
+  union {
+    unsigned char bytes[DDS_DATA_ALLOCATOR_MAX_SIZE];
+    void *align_ptr;
+    uint64_t align_u64;
+  } opaque;
+} dds_data_allocator_t;
+
+/** @brief Initialize an object for performing allocations/frees in the context of a reader/writer
+ *
+ * The operation will fall back to standard heap allocation if nothing better is available.
+ *
+ * @param[in] entity the handle of the entity
+ * @param[out] data_allocator opaque allocator object to initialize
+ *
+ * @returns success or a generic error indication
+ *
+ * @retval DDS_RETCODE_OK
+ *    the allocator object was successfully initialized
+ * @retval DDS_RETCODE_BAD_PARAMETER
+ *    entity is invalid, data_allocator is a null pointer
+ * @retval DDS_RETCODE_PRECONDITION_NOT_MET
+ *    Cyclone DDS is not initialized
+ * @retval DDS_RETCODE_ILLEGAL_OPERATION
+ *    operation not supported on this entity
+ */
+DDS_EXPORT dds_return_t dds_data_allocator_init (dds_entity_t entity, dds_data_allocator_t *data_allocator);
+
+/** @brief Finalize a previously initialized allocator object
+ *
+ * @param[in,out] data_allocator object to finalize
+ *
+ * @returns success or an error indication
+ *
+ * @retval DDS_RETCODE_OK
+ *    the data was successfully finalized
+ * @retval DDS_RETCODE_BAD_PARAMETER
+ *    data_allocator does not reference a valid entity
+ * @retval DDS_RETCODE_PRECONDITION_NOT_MET
+ *    Cyclone DDS is not initialized
+ */
+DDS_EXPORT dds_return_t dds_data_allocator_fini (dds_data_allocator_t *data_allocator);
+
+/** @brief Allocate memory using the given allocator
+ *
+ * @param[in,out] data_allocator  initialized allocator object
+ * @param[in] size minimum number of bytes to allocate with suitable alignment
+ *
+ * @returns a pointer to unaliased, uninitialized memory of at least the requested size, or NULL
+ */
+DDS_EXPORT void *dds_data_allocator_alloc (dds_data_allocator_t *data_allocator, size_t size)
+  ddsrt_attribute_warn_unused_result ddsrt_attribute_malloc;
+
+/** @brief Release memory using the given allocator
+ *
+ * @param[in,out] data_allocator  initialized allocator object
+ * @param[in] ptr memory to free
+ */
+DDS_EXPORT void dds_data_allocator_free (dds_data_allocator_t *data_allocator, void *ptr);
+
+#if defined (__cplusplus)
+}
+#endif
+#endif

--- a/src/core/ddsc/src/dds__data_allocator.h
+++ b/src/core/ddsc/src/dds__data_allocator.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright(c) 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#ifndef DDS__DATA_ALLOCATOR_H
+#define DDS__DATA_ALLOCATOR_H
+
+#include "dds/ddsrt/static_assert.h"
+#include "dds/ddsc/dds_data_allocator.h"
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+#ifdef DDS_HAS_SHM
+
+#include "iceoryx_binding_c/publisher.h"
+#include "iceoryx_binding_c/subscriber.h"
+
+enum dds_iox_allocator_kind {
+  DDS_IOX_ALLOCATOR_KIND_FINI,
+  DDS_IOX_ALLOCATOR_KIND_NONE, /* use heap */
+  DDS_IOX_ALLOCATOR_KIND_PUBLISHER,
+  DDS_IOX_ALLOCATOR_KIND_SUBSCRIBER
+} dds_iox_allocator_kind_t;
+
+typedef struct dds_iox_allocator {
+  enum dds_iox_allocator_kind kind;
+  union {
+    iox_pub_t pub;
+    iox_sub_t sub;
+  } ref;
+} dds_iox_allocator_t;
+
+DDSRT_STATIC_ASSERT(sizeof (dds_iox_allocator_t) <= sizeof (dds_data_allocator_t));
+
+#endif // DDS_HAS_SHM
+
+struct dds_writer;
+struct dds_reader;
+
+dds_return_t dds__writer_data_allocator_init (const struct dds_writer *wr, dds_data_allocator_t *data_allocator)
+  ddsrt_nonnull_all;
+
+dds_return_t dds__writer_data_allocator_fini (const struct dds_writer *wr, dds_data_allocator_t *data_allocator)
+  ddsrt_nonnull_all;
+
+dds_return_t dds__reader_data_allocator_init (const struct dds_reader *wr, dds_data_allocator_t *data_allocator)
+  ddsrt_nonnull_all;
+
+dds_return_t dds__reader_data_allocator_fini (const struct dds_reader *wr, dds_data_allocator_t *data_allocator)
+  ddsrt_nonnull_all;
+
+#if defined (__cplusplus)
+}
+#endif
+
+#endif

--- a/src/core/ddsc/src/dds_data_allocator.c
+++ b/src/core/ddsc/src/dds_data_allocator.c
@@ -1,0 +1,126 @@
+/*
+ * Copyright(c) 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include "dds/dds.h"
+#include "dds/ddsrt/heap.h"
+#include "dds__data_allocator.h"
+#include "dds__entity.h"
+
+dds_return_t dds_data_allocator_init (dds_entity_t entity, dds_data_allocator_t *data_allocator)
+{
+  dds_entity *e;
+  dds_return_t ret;
+
+  if (data_allocator == NULL)
+    return DDS_RETCODE_BAD_PARAMETER;
+
+  if ((ret = dds_entity_pin (entity, &e)) != DDS_RETCODE_OK)
+    return ret;
+  switch (dds_entity_kind (e))
+  {
+    case DDS_KIND_READER:
+      ret = dds__reader_data_allocator_init ((struct dds_reader *) e, data_allocator);
+      break;
+    case DDS_KIND_WRITER:
+      ret = dds__writer_data_allocator_init ((struct dds_writer *) e, data_allocator);
+      break;
+    default:
+      ret = DDS_RETCODE_ILLEGAL_OPERATION;
+      break;
+  }
+  if (ret == DDS_RETCODE_OK)
+    data_allocator->entity = entity;
+  dds_entity_unpin (e);
+  return ret;
+}
+
+dds_return_t dds_data_allocator_fini (dds_data_allocator_t *data_allocator)
+{
+  dds_entity *e;
+  dds_return_t ret;
+
+  if (data_allocator == NULL)
+    return DDS_RETCODE_BAD_PARAMETER;
+
+  if ((ret = dds_entity_pin (data_allocator->entity, &e)) != DDS_RETCODE_OK)
+    return ret;
+  switch (dds_entity_kind (e))
+  {
+    case DDS_KIND_READER:
+      ret = dds__reader_data_allocator_fini ((struct dds_reader *) e, data_allocator);
+      break;
+    case DDS_KIND_WRITER:
+      ret = dds__writer_data_allocator_fini ((struct dds_writer *) e, data_allocator);
+      break;
+    default:
+      ret = DDS_RETCODE_ILLEGAL_OPERATION;
+      break;
+  }
+  if (ret == DDS_RETCODE_OK)
+    data_allocator->entity = 0;
+  dds_entity_unpin(e);
+  return ret;
+}
+
+void *dds_data_allocator_alloc (dds_data_allocator_t *data_allocator, size_t size)
+{
+#if DDS_HAS_SHM
+  dds_iox_allocator_t *d = (dds_iox_allocator_t *) data_allocator->opaque.bytes;
+  switch (d->kind)
+  {
+    case DDS_IOX_ALLOCATOR_KIND_FINI:
+      return NULL;
+    case DDS_IOX_ALLOCATOR_KIND_NONE:
+      return ddsrt_malloc (size);
+    case DDS_IOX_ALLOCATOR_KIND_SUBSCRIBER:
+      return NULL;
+    case DDS_IOX_ALLOCATOR_KIND_PUBLISHER:
+      if (size > UINT32_MAX)
+        return NULL;
+      else
+      {
+        enum iox_AllocationResult alloc_result;
+        void *ptr;
+        alloc_result = iox_pub_loan_chunk (d->ref.pub, &ptr, (uint32_t) size);
+        return (alloc_result == AllocationResult_SUCCESS) ? ptr : NULL;
+      }
+  }
+#else
+  (void) data_allocator;
+  return ddsrt_malloc (size);
+#endif
+}
+
+void dds_data_allocator_free (dds_data_allocator_t *data_allocator, void *ptr)
+{
+#if DDS_HAS_SHM
+  dds_iox_allocator_t *d = (dds_iox_allocator_t *) data_allocator->opaque.bytes;
+  switch (d->kind)
+  {
+    case DDS_IOX_ALLOCATOR_KIND_FINI:
+      break;
+    case DDS_IOX_ALLOCATOR_KIND_NONE:
+      ddsrt_free (ptr);
+      break;
+    case DDS_IOX_ALLOCATOR_KIND_SUBSCRIBER:
+      if (ptr != NULL)
+        iox_sub_release_chunk (d->ref.sub, ptr);
+      break;
+    case DDS_IOX_ALLOCATOR_KIND_PUBLISHER:
+      if (ptr != NULL)
+        iox_pub_release_chunk (d->ref.pub, ptr);
+      break;
+  }
+#else
+  (void) data_allocator;
+  ddsrt_free (ptr);
+#endif
+}

--- a/src/core/ddsc/src/dds_reader.c
+++ b/src/core/ddsc/src/dds_reader.c
@@ -30,6 +30,7 @@
 #include "dds/ddsi/ddsi_domaingv.h"
 #include "dds__builtin.h"
 #include "dds__statistics.h"
+#include "dds__data_allocator.h"
 #include "dds/ddsi/ddsi_sertype.h"
 #include "dds/ddsi/ddsi_entity_index.h"
 #include "dds/ddsi/ddsi_security_omg.h"
@@ -754,6 +755,39 @@ dds_entity_t dds_get_subscriber (dds_entity_t entity)
     dds_entity_unpin (e);
     return subh;
   }
+}
+
+dds_return_t dds__reader_data_allocator_init (const dds_reader *rd, dds_data_allocator_t *data_allocator)
+{
+#ifdef DDS_HAS_SHM
+  dds_iox_allocator_t *d = (dds_iox_allocator_t *) data_allocator->opaque.bytes;
+  if (rd->m_entity.m_domain->gv.config.enable_shm)
+  {
+    d->kind = DDS_IOX_ALLOCATOR_KIND_SUBSCRIBER;
+    d->ref.sub = rd->m_iox_sub;
+  }
+  else
+  {
+    d->kind = DDS_IOX_ALLOCATOR_KIND_NONE;
+  }
+  return DDS_RETCODE_OK;
+#else
+  (void) rd;
+  (void) data_allocator;
+  return DDS_RETCODE_OK;
+#endif
+}
+
+dds_return_t dds__reader_data_allocator_fini (const dds_reader *rd, dds_data_allocator_t *data_allocator)
+{
+#ifdef DDS_HAS_SHM
+  dds_iox_allocator_t *d = (dds_iox_allocator_t *) data_allocator->opaque.bytes;
+  d->kind = DDS_IOX_ALLOCATOR_KIND_FINI;
+#else
+  (void) data_allocator;
+#endif
+  (void) rd;
+  return DDS_RETCODE_OK;
 }
 
 /* Reset sets everything (type) 0, including the reason field, verify that 0 is correct */

--- a/src/core/ddsc/src/dds_writer.c
+++ b/src/core/ddsc/src/dds_writer.c
@@ -31,6 +31,7 @@
 #include "dds/ddsi/ddsi_tkmap.h"
 #include "dds__whc.h"
 #include "dds__statistics.h"
+#include "dds__data_allocator.h"
 #include "dds/ddsi/ddsi_statistics.h"
 
 DECL_ENTITY_LOCK_UNLOCK (extern inline, dds_writer)
@@ -464,6 +465,39 @@ dds_entity_t dds_get_publisher (dds_entity_t writer)
     dds_entity_unpin (e);
     return pubh;
   }
+}
+
+dds_return_t dds__writer_data_allocator_init (const dds_writer *wr, dds_data_allocator_t *data_allocator)
+{
+#ifdef DDS_HAS_SHM
+  dds_iox_allocator_t *d = (dds_iox_allocator_t *) data_allocator->opaque.bytes;
+  if (wr->m_entity.m_domain->gv.config.enable_shm)
+  {
+    d->kind = DDS_IOX_ALLOCATOR_KIND_PUBLISHER;
+    d->ref.pub = wr->m_iox_pub;
+  }
+  else
+  {
+    d->kind = DDS_IOX_ALLOCATOR_KIND_NONE;
+  }
+  return DDS_RETCODE_OK;
+#else
+  (void) wr;
+  (void) data_allocator;
+  return DDS_RETCODE_OK;
+#endif
+}
+
+dds_return_t dds__writer_data_allocator_fini (const dds_writer *wr, dds_data_allocator_t *data_allocator)
+{
+#ifdef DDS_HAS_SHM
+  dds_iox_allocator_t *d = (dds_iox_allocator_t *) data_allocator->opaque.bytes;
+  d->kind = DDS_IOX_ALLOCATOR_KIND_FINI;
+#else
+  (void) data_allocator;
+#endif
+  (void) wr;
+  return DDS_RETCODE_OK;
 }
 
 dds_return_t dds__writer_wait_for_acks (struct dds_writer *wr, ddsi_guid_t *rdguid, dds_time_t abstimeout)

--- a/src/core/ddsc/tests/cdr.c
+++ b/src/core/ddsc/tests/cdr.c
@@ -321,6 +321,13 @@ static struct ddsi_serdata *sd_from_ser (const struct ddsi_sertype *tpcmn, enum 
     .iov_base = NN_RMSG_PAYLOADOFF (fragchain->rmsg, NN_RDATA_PAYLOAD_OFF (fragchain)),
     .iov_len = fragchain->maxp1 // fragchain->min = 0 for first fragment, by definition
   };
+  const ddsi_keyhash_t *kh = ddsi_serdata_keyhash_from_fragchain (fragchain);
+  CU_ASSERT_FATAL (kh != NULL);
+  printf ("kh rcv %02x%02x%02x%02x:%02x%02x%02x%02x:%02x%02x%02x%02x:%02x%02x%02x%02x\n",
+          kh->value[0], kh->value[1], kh->value[2], kh->value[3],
+          kh->value[4], kh->value[5], kh->value[6], kh->value[7],
+          kh->value[8], kh->value[9], kh->value[10], kh->value[11],
+          kh->value[12], kh->value[13], kh->value[14], kh->value[15]);
   return sd_from_ser_iov (tpcmn, kind, 1, &iov, size);
 }
 
@@ -606,6 +613,11 @@ static void sd_get_keyhash (const struct ddsi_serdata *serdata_common, struct dd
 {
   struct sd const * const sd = (const struct sd *) serdata_common;
   sdx_get_keyhash (&sd->x, buf, force_md5);
+  printf ("kh gen %02x%02x%02x%02x:%02x%02x%02x%02x:%02x%02x%02x%02x:%02x%02x%02x%02x\n",
+          buf->value[0], buf->value[1], buf->value[2], buf->value[3],
+          buf->value[4], buf->value[5], buf->value[6], buf->value[7],
+          buf->value[8], buf->value[9], buf->value[10], buf->value[11],
+          buf->value[12], buf->value[13], buf->value[14], buf->value[15]);
 }
 
 static void sd0_get_keyhash (const struct ddsi_sertopic_serdata *serdata_common, struct ddsi_keyhash *buf, bool force_md5)
@@ -1109,7 +1121,7 @@ ${CYCLONEDDS_URI}${CYCLONEDDS_URI:+,}\
 static struct tw make_topic (dds_entity_t pp, const char *topicname, const char *typename, const dds_qos_t *qos)
 {
   struct stp *stp = malloc (sizeof (*stp));
-  ddsi_sertype_init (&stp->c, typename, &stp_ops, &sd_ops, false);
+  ddsi_sertype_init_flags (&stp->c, typename, &stp_ops, &sd_ops, DDSI_SERTYPE_FLAG_REQUEST_KEYHASH);
   struct ddsi_sertype *st = &stp->c;
   dds_entity_t tp = dds_create_topic_sertype (pp, topicname, &st, qos, NULL, NULL);
   CU_ASSERT_FATAL (tp > 0);

--- a/src/core/ddsi/include/dds/ddsi/ddsi_plist.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_plist.h
@@ -63,7 +63,9 @@ extern "C" {
 #define PP_PARTICIPANT_SECURITY_INFO            ((uint64_t)1 << 35)
 #define PP_IDENTITY_STATUS_TOKEN                ((uint64_t)1 << 36)
 #define PP_DATA_TAGS                            ((uint64_t)1 << 37)
+/* Other stuff */
 #define PP_CYCLONE_RECEIVE_BUFFER_SIZE          ((uint64_t)1 << 38)
+#define PP_CYCLONE_REQUESTS_KEYHASH             ((uint64_t)1 << 39)
 
 /* Set for unrecognized parameters that are in the reserved space or
    in our own vendor-specific space that have the
@@ -232,6 +234,7 @@ typedef struct ddsi_plist {
   uint32_t domain_id;
   char *domain_tag;
   uint32_t cyclone_receive_buffer_size;
+  unsigned char cyclone_requests_keyhash;
 } ddsi_plist_t;
 
 

--- a/src/core/ddsi/include/dds/ddsi/ddsi_plist.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_plist.h
@@ -488,12 +488,13 @@ struct nn_rsample_info;
  * otherwise.
  *
  * @param[in]  src      input description (see `ddsi_plist_init_frommsg`)
+ * @param[out] keyhashp set to point to keyhash in inline QoS if present, else to NULL
  * @param[out] dest     internal sample info of which some fields will be set
  *
  * @return pointer to the first byte following the sentinel if the input is well-formed, a
  * null pointer if it is not.
 */
-DDS_EXPORT unsigned char *ddsi_plist_quickscan (struct nn_rsample_info *dest, const ddsi_plist_src_t *src);
+DDS_EXPORT unsigned char *ddsi_plist_quickscan (struct nn_rsample_info *dest, const ddsi_keyhash_t **keyhashp, const ddsi_plist_src_t *src);
 
 /**
  * @brief Locate a specific parameter in a PL_CDR-serialized parameter list

--- a/src/core/ddsi/include/dds/ddsi/ddsi_serdata.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_serdata.h
@@ -201,6 +201,14 @@ struct ddsi_serdata_ops {
 
 DDS_EXPORT void ddsi_serdata_init (struct ddsi_serdata *d, const struct ddsi_sertype *type, enum ddsi_serdata_kind kind);
 
+/**
+ * @brief Return a pointer to the keyhash in the message fragchain if it was present, or else NULL.
+ *
+ * @param[in] fragchain the fragchain argument passed to @ref ddsi_serdata_from_ser (the first one, not any subsequent ones)
+ * @returns A pointer to the keyhash in the message if it was present, NULL if not. The lifetime is at least that of the fragchain itself.
+ */
+DDS_EXPORT const ddsi_keyhash_t *ddsi_serdata_keyhash_from_fragchain (const struct nn_rdata *fragchain);
+
 /* backwards compatibility: wrap a sertopic-derived serdata so that it may be used as a sertype-derived one; increments refcount */
 DDS_EXPORT struct ddsi_serdata *ddsi_sertopic_wrap_serdata (const struct ddsi_sertype *type, enum ddsi_serdata_kind kind, void *old);
 

--- a/src/core/ddsi/include/dds/ddsi/ddsi_sertype.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_sertype.h
@@ -37,7 +37,8 @@ struct ddsi_sertype {
   const struct ddsi_sertype_ops *ops;
   const struct ddsi_serdata_ops *serdata_ops;
   uint32_t serdata_basehash;
-  bool typekind_no_key;
+  uint32_t typekind_no_key : 1;
+  uint32_t request_keyhash : 1;
   char *type_name;
   ddsrt_atomic_voidp_t gv; /* set during registration */
   ddsrt_atomic_uint32_t flags_refc; /* counts refs from entities (topic, reader, writer), not from data */
@@ -70,6 +71,11 @@ struct ddsi_sertype {
    Testing for DDSI_SERTOPIC_HAS_EQUAL_AND_HASH allows one to have a single source
    that can handle both variants, but there's no binary compatbility. */
 #define DDSI_SERTOPIC_HAS_EQUAL_AND_HASH 1
+
+/* It was a bad decision to have a boolean argument in "init" specifying whether
+   the entity kind should say "with key" or "without key".  A general "flags"
+   argument is much more flexible ... */
+#define DDSI_SERTYPE_HAS_SERTYPE_INIT_FLAGS 1
 
 /* Called to compare two sertypes for equality, if it is already known that
    type name, kind_no_Key, and operations are all the same.  (serdata_basehash
@@ -139,6 +145,12 @@ struct ddsi_sertype_ops {
 struct ddsi_sertype *ddsi_sertype_lookup_locked (struct ddsi_domaingv *gv, const struct ddsi_sertype *sertype_template);
 void ddsi_sertype_register_locked (struct ddsi_domaingv *gv, struct ddsi_sertype *sertype);
 
+#define DDSI_SERTYPE_FLAG_TOPICKIND_NO_KEY (1u)
+#define DDSI_SERTYPE_FLAG_REQUEST_KEYHASH  (2u)
+
+#define DDSI_SERTYPE_FLAG_MASK (0x3u)
+
+DDS_EXPORT void ddsi_sertype_init_flags (struct ddsi_sertype *tp, const char *type_name, const struct ddsi_sertype_ops *sertype_ops, const struct ddsi_serdata_ops *serdata_ops, uint32_t flags);
 DDS_EXPORT void ddsi_sertype_init (struct ddsi_sertype *tp, const char *type_name, const struct ddsi_sertype_ops *sertype_ops, const struct ddsi_serdata_ops *serdata_ops, bool topickind_no_key);
 DDS_EXPORT bool ddsi_sertype_deserialize (struct ddsi_domaingv *gv, struct ddsi_sertype *tp, const struct ddsi_sertype_ops *sertype_ops, size_t sz, unsigned char *serdata);
 DDS_EXPORT void ddsi_sertype_fini (struct ddsi_sertype *tp);

--- a/src/core/ddsi/include/dds/ddsi/ddsi_sertype.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_sertype.h
@@ -39,6 +39,7 @@ struct ddsi_sertype {
   uint32_t serdata_basehash;
   uint32_t typekind_no_key : 1;
   uint32_t request_keyhash : 1;
+  uint32_t fixed_size : 1;
   char *type_name;
   ddsrt_atomic_voidp_t gv; /* set during registration */
   ddsrt_atomic_uint32_t flags_refc; /* counts refs from entities (topic, reader, writer), not from data */
@@ -147,6 +148,7 @@ void ddsi_sertype_register_locked (struct ddsi_domaingv *gv, struct ddsi_sertype
 
 #define DDSI_SERTYPE_FLAG_TOPICKIND_NO_KEY (1u)
 #define DDSI_SERTYPE_FLAG_REQUEST_KEYHASH  (2u)
+#define DDSI_SERTYPE_FLAG_FIXED_SIZE       (4u)
 
 #define DDSI_SERTYPE_FLAG_MASK (0x3u)
 

--- a/src/core/ddsi/include/dds/ddsi/q_entity.h
+++ b/src/core/ddsi/include/dds/ddsi/q_entity.h
@@ -302,7 +302,6 @@ struct writer
   enum writer_state state;
   unsigned reliable: 1; /* iff 1, writer is reliable <=> heartbeat_xevent != NULL */
   unsigned handle_as_transient_local: 1; /* controls whether data is retained in WHC */
-  unsigned include_keyhash: 1; /* iff 1, this writer includes a keyhash; keyless topics => include_keyhash = 0 */
   unsigned force_md5_keyhash: 1; /* iff 1, when keyhash has to be hashed, no matter the size */
   unsigned retransmitting: 1; /* iff 1, this writer is currently retransmitting */
   unsigned alive: 1; /* iff 1, the writer is alive (lease for this writer is not expired); field may be modified only when holding both wr->e.lock and wr->c.pp->e.lock */
@@ -329,6 +328,7 @@ struct writer
   uint32_t rexmit_burst_size_limit; /* derived from reader's receive_buffer_size */
   uint32_t num_readers; /* total number of matching PROXY readers */
   uint32_t num_reliable_readers; /* number of matching reliable PROXY readers */
+  uint32_t num_readers_requesting_keyhash; /* also +1 for protected keys and config override for generating keyhash */
   ddsrt_avl_tree_t readers; /* all matching PROXY readers, see struct wr_prd_match */
   ddsrt_avl_tree_t local_readers; /* all matching LOCAL readers, see struct wr_rd_match */
 #ifdef DDS_HAS_NETWORK_PARTITIONS
@@ -373,6 +373,7 @@ struct reader
   struct dds_qos *xqos;
   unsigned reliable: 1; /* 1 iff reader is reliable */
   unsigned handle_as_transient_local: 1; /* 1 iff reader wants historical data from proxy writers */
+  unsigned request_keyhash: 1; /* really controlled by the sertype */
 #ifdef DDS_HAS_SSM
   unsigned favours_ssm: 1; /* iff 1, this reader favours SSM */
 #endif
@@ -502,6 +503,7 @@ struct proxy_reader {
   struct proxy_endpoint_common c;
   unsigned deleting: 1; /* set when being deleted */
   unsigned is_fict_trans_reader: 1; /* only true when it is certain that is a fictitious transient data reader (affects built-in topic generation) */
+  unsigned requests_keyhash: 1; /* 1 iff this reader would like to receive keyhashes */
 #ifdef DDS_HAS_SSM
   unsigned favours_ssm: 1; /* iff 1, this proxy reader favours SSM when available */
 #endif

--- a/src/core/ddsi/include/dds/ddsi/q_protocol.h
+++ b/src/core/ddsi/include/dds/ddsi/q_protocol.h
@@ -457,6 +457,7 @@ typedef union Submessage {
 #ifdef DDS_HAS_TYPE_DISCOVERY
 #define PID_CYCLONE_TYPE_INFORMATION            (PID_VENDORSPECIFIC_FLAG | 0x1au)
 #endif
+#define PID_CYCLONE_REQUESTS_KEYHASH            (PID_VENDORSPECIFIC_FLAG | 0x1cu)
 
 /* Names of the built-in topics */
 #define DDS_BUILTIN_TOPIC_PARTICIPANT_NAME "DCPSParticipant"

--- a/src/core/ddsi/include/dds/ddsi/q_radmin.h
+++ b/src/core/ddsi/include/dds/ddsi/q_radmin.h
@@ -144,9 +144,10 @@ struct nn_rsample_info {
 struct nn_rdata {
   struct nn_rmsg *rmsg;         /* received (and refcounted) in rmsg */
   struct nn_rdata *nextfrag;    /* fragment chain */
-  uint32_t min, maxp1;         /* fragment as byte offsets */
-  uint16_t submsg_zoff;        /* offset to submessage from packet start, or 0 */
-  uint16_t payload_zoff;       /* offset to payload from packet start */
+  uint32_t min, maxp1;          /* fragment as byte offsets */
+  uint16_t submsg_zoff;         /* offset to submessage from packet start, or 0 */
+  uint16_t payload_zoff;        /* offset to payload from packet start */
+  uint16_t keyhash_zoff;        /* offset to keyhash from packet start, or 0 */
 #ifndef NDEBUG
   ddsrt_atomic_uint32_t refcount_bias_added;
 #endif
@@ -171,6 +172,7 @@ struct nn_rdata {
 #endif
 #define NN_RDATA_PAYLOAD_OFF(rdata) NN_ZOFF_TO_OFF ((rdata)->payload_zoff)
 #define NN_RDATA_SUBMSG_OFF(rdata) NN_ZOFF_TO_OFF ((rdata)->submsg_zoff)
+#define NN_RDATA_KEYHASH_OFF(rdata) NN_ZOFF_TO_OFF ((rdata)->keyhash_zoff)
 
 struct nn_rsample_chain_elem {
   /* FIXME: evidently smaller than a defrag_iv, but maybe better to
@@ -224,7 +226,7 @@ void nn_rmsg_commit (struct nn_rmsg *rmsg);
 void nn_rmsg_free (struct nn_rmsg *rmsg);
 void *nn_rmsg_alloc (struct nn_rmsg *rmsg, uint32_t size);
 
-struct nn_rdata *nn_rdata_new (struct nn_rmsg *rmsg, uint32_t start, uint32_t endp1, uint32_t submsg_offset, uint32_t payload_offset);
+struct nn_rdata *nn_rdata_new (struct nn_rmsg *rmsg, uint32_t start, uint32_t endp1, uint32_t submsg_offset, uint32_t payload_offset, uint32_t keyhash_offset);
 struct nn_rdata *nn_rdata_newgap (struct nn_rmsg *rmsg);
 void nn_fragchain_adjust_refcount (struct nn_rdata *frag, int adjust);
 void nn_fragchain_unref (struct nn_rdata *frag);

--- a/src/core/ddsi/src/ddsi_plist.c
+++ b/src/core/ddsi/src/ddsi_plist.c
@@ -1763,6 +1763,7 @@ static const struct piddesc piddesc_eclipse[] = {
   PP  (ADLINK_PARTICIPANT_VERSION_INFO,  adlink_participant_version_info, Xux5, XS),
   PP  (ADLINK_TYPE_DESCRIPTION,          type_description, XS),
   PP  (CYCLONE_RECEIVE_BUFFER_SIZE,      cyclone_receive_buffer_size, Xu),
+  PP  (CYCLONE_REQUESTS_KEYHASH,         cyclone_requests_keyhash, Xb),
   { PID_SENTINEL, 0, 0, NULL, 0, 0, { .desc = { XSTOP } }, 0 }
 };
 
@@ -1833,11 +1834,7 @@ struct piddesc_index {
 #endif
 
 static const struct piddesc *piddesc_omg_index[DEFAULT_OMG_PIDS_ARRAY_SIZE + SECURITY_OMG_PIDS_ARRAY_SIZE];
-#ifdef DDS_HAS_TYPE_DISCOVERY
-static const struct piddesc *piddesc_eclipse_index[27];
-#else
-static const struct piddesc *piddesc_eclipse_index[26];
-#endif
+static const struct piddesc *piddesc_eclipse_index[29];
 static const struct piddesc *piddesc_adlink_index[19];
 
 #define INDEX_ANY(vendorid_, tab_) [vendorid_] = { \

--- a/src/core/ddsi/src/ddsi_security_omg.c
+++ b/src/core/ddsi/src/ddsi_security_omg.c
@@ -1533,8 +1533,8 @@ void q_omg_security_register_writer(struct writer *wr)
     }
   }
 
-  if (wr->sec_attr->attr.is_key_protected)
-    wr->include_keyhash = 1;
+  if (wr->sec_attr->attr.is_key_protected && (wr->e.guid.entityid.u & NN_ENTITYID_KIND_MASK) == NN_ENTITYID_KIND_WRITER_WITH_KEY)
+    wr->num_readers_requesting_keyhash++;
 
 not_registered:
 no_attr:

--- a/src/core/ddsi/src/ddsi_security_omg.c
+++ b/src/core/ddsi/src/ddsi_security_omg.c
@@ -1534,7 +1534,10 @@ void q_omg_security_register_writer(struct writer *wr)
   }
 
   if (wr->sec_attr->attr.is_key_protected && (wr->e.guid.entityid.u & NN_ENTITYID_KIND_MASK) == NN_ENTITYID_KIND_WRITER_WITH_KEY)
+  {
     wr->num_readers_requesting_keyhash++;
+    wr->force_md5_keyhash = 1;
+  }
 
 not_registered:
 no_attr:

--- a/src/core/ddsi/src/ddsi_serdata.c
+++ b/src/core/ddsi/src/ddsi_serdata.c
@@ -17,6 +17,7 @@
 #include "dds/ddsrt/md5.h"
 #include "dds/ddsi/q_bswap.h"
 #include "dds/ddsi/q_config.h"
+#include "dds/ddsi/q_radmin.h"
 #include "dds/ddsi/q_freelist.h"
 #include "dds/ddsi/ddsi_serdata.h"
 
@@ -55,6 +56,14 @@ struct ddsi_serdata *ddsi_serdata_ref_as_type (const struct ddsi_sertype *type, 
     ddsi_serdata_to_ser_unref (serdata, &iov);
     return converted;
   }
+}
+
+const ddsi_keyhash_t *ddsi_serdata_keyhash_from_fragchain (const struct nn_rdata *fragchain)
+{
+  if (fragchain->keyhash_zoff == 0)
+    return NULL;
+  else
+    return (const ddsi_keyhash_t *) NN_RMSG_PAYLOADOFF (fragchain->rmsg, NN_RDATA_KEYHASH_OFF (fragchain));
 }
 
 extern inline struct ddsi_serdata *ddsi_serdata_ref (const struct ddsi_serdata *serdata_const);

--- a/src/core/ddsi/src/ddsi_sertype.c
+++ b/src/core/ddsi/src/ddsi_sertype.c
@@ -212,6 +212,7 @@ void ddsi_sertype_init_flags (struct ddsi_sertype *tp, const char *type_name, co
   tp->serdata_basehash = ddsi_sertype_compute_serdata_basehash (tp->serdata_ops);
   tp->typekind_no_key = (flags & DDSI_SERTYPE_FLAG_TOPICKIND_NO_KEY) ? 1 : 0;
   tp->request_keyhash = (flags & DDSI_SERTYPE_FLAG_REQUEST_KEYHASH) ? 1 : 0;
+  tp->fixed_size = (flags & DDSI_SERTYPE_FLAG_FIXED_SIZE) ? 1 : 0;
   tp->wrapped_sertopic = NULL;
 #ifdef DDS_HAS_SHM
   tp->iox_size = 0;

--- a/src/core/ddsi/src/q_ddsi_discovery.c
+++ b/src/core/ddsi/src/q_ddsi_discovery.c
@@ -992,6 +992,17 @@ static int sedp_write_endpoint
       ps.group_guid = epcommon->group_guid;
     }
 
+    if (!is_writer_entityid (epguid->entityid))
+    {
+      const struct reader *rd = entidx_lookup_reader_guid (gv->entity_index, epguid);
+      assert (rd);
+      if (rd->request_keyhash)
+      {
+        ps.present |= PP_CYCLONE_REQUESTS_KEYHASH;
+        ps.cyclone_requests_keyhash = 1u;
+      }
+    }
+
 #ifdef DDS_HAS_SSM
     /* A bit of a hack -- the easy alternative would be to make it yet
      another parameter.  We only set "reader favours SSM" if we

--- a/src/core/ddsi/src/q_radmin.c
+++ b/src/core/ddsi/src/q_radmin.c
@@ -719,7 +719,7 @@ void *nn_rmsg_alloc (struct nn_rmsg *rmsg, uint32_t size)
 
 /* RDATA --------------------------------------- */
 
-struct nn_rdata *nn_rdata_new (struct nn_rmsg *rmsg, uint32_t start, uint32_t endp1, uint32_t submsg_offset, uint32_t payload_offset)
+struct nn_rdata *nn_rdata_new (struct nn_rmsg *rmsg, uint32_t start, uint32_t endp1, uint32_t submsg_offset, uint32_t payload_offset, uint32_t keyhash_offset)
 {
   struct nn_rdata *d;
   if ((d = nn_rmsg_alloc (rmsg, sizeof (*d))) == NULL)
@@ -730,6 +730,7 @@ struct nn_rdata *nn_rdata_new (struct nn_rmsg *rmsg, uint32_t start, uint32_t en
   d->maxp1 = endp1;
   d->submsg_zoff = (uint16_t) NN_OFF_TO_ZOFF (submsg_offset);
   d->payload_zoff = (uint16_t) NN_OFF_TO_ZOFF (payload_offset);
+  d->keyhash_zoff = (uint16_t) NN_OFF_TO_ZOFF (keyhash_offset);
 #ifndef NDEBUG
   ddsrt_atomic_st32 (&d->refcount_bias_added, 0);
 #endif
@@ -2196,7 +2197,7 @@ static struct nn_rsample *coalesce_intervals_touching_range (struct nn_reorder *
 struct nn_rdata *nn_rdata_newgap (struct nn_rmsg *rmsg)
 {
   struct nn_rdata *d;
-  if ((d = nn_rdata_new (rmsg, 0, 0, 0, 0)) == NULL)
+  if ((d = nn_rdata_new (rmsg, 0, 0, 0, 0, 0)) == NULL)
     return NULL;
   nn_rdata_addbias (d);
   return d;

--- a/src/core/ddsi/src/q_transmit.c
+++ b/src/core/ddsi/src/q_transmit.c
@@ -471,7 +471,7 @@ static dds_return_t create_fragment_message_simple (struct writer *wr, seqno_t s
     nn_xmsg_setwriterseq (*pmsg, &wr->e.guid, seq);
 
   /* Adding parameters means potential reallocing, so sm, ddcmn now likely become invalid */
-  if (wr->include_keyhash)
+  if (wr->num_readers_requesting_keyhash > 0)
     nn_xmsg_addpar_keyhash (*pmsg, serdata, wr->force_md5_keyhash);
   if (serdata->statusinfo)
     nn_xmsg_addpar_statusinfo (*pmsg, serdata->statusinfo);
@@ -620,7 +620,7 @@ dds_return_t create_fragment_message (struct writer *wr, seqno_t seq, const stru
   {
     int rc;
     /* Adding parameters means potential reallocing, so sm, ddcmn now likely become invalid */
-    if (wr->include_keyhash)
+    if (wr->num_readers_requesting_keyhash > 0)
     {
       nn_xmsg_addpar_keyhash (*pmsg, serdata, wr->force_md5_keyhash);
     }


### PR DESCRIPTION
These 4 commits add 2 things that are useful extensions for integrating Iceoryx:
* a `ddsi_sertype` flag for indicating all instances of the type have the same size (at which point it fits with the assumptions of Iceoryx)
* an "evolving" API for performing memory allocations or freeing memory in the context of a reader/writer, abstracted a little bit so that an application can implement a custom `ddsi_sertype` that can do zero-copy communication within a machine using Iceoryx while gracefully degrading to heap allocations

The rest is noise that I had done already and that is useful in other contexts — e.g., bridging arbitrary DDS data while respecting the DDS history behaviour.

I haven't yet had a chance to test it properly and other people may have ideas on wisdom of defining the interfaces in this manner, so considering it a "draft" seems best.