### PR TITLE
Iceoryx logging and resource cleanup

### DIFF
--- a/docs/manual/shared_memory.rst
+++ b/docs/manual/shared_memory.rst
@@ -63,8 +63,7 @@ Save the following xml as cyclonedds.xml.
 SubQueueCapacity, SubHistoryRequest and PubHistoryCapacity can be optionally set if Shared Memory is enabled.
 SubQueueCapacity controls how many samples a reader using shared memory can hold before the least recent is discarded.
 PubHistoryCapacity defines how many samples a shared memory writer will keep to send to late-joining subscribers.
-SubHistoryRequest is the number of samples a late-joining reader will request from a writer (this can be at most 
-as many as were send and at most PubHistoryCapacity).
+SubHistoryRequest is the number of samples a late-joining reader will request from a writer (this can only be as many as were sent and at most PubHistoryCapacity).
 
 The Loglevel controls the output of the iceoryx runtime and can be set to:
 verbose, debug, info, warn, error, fatal and off

--- a/docs/manual/shared_memory.rst
+++ b/docs/manual/shared_memory.rst
@@ -55,6 +55,7 @@ Save the following xml as cyclonedds.xml.
               <SubQueueCapacity>256</SubQueueCapacity>
               <SubHistoryRequest>16</SubHistoryRequest>
               <PubHistoryCapacity>16</PubHistoryCapacity>
+              <LogLevel>info</LogLevel>
           </SharedMemory>
       </Domain>
   </CycloneDDS>
@@ -63,7 +64,11 @@ SubQueueCapacity, SubHistoryRequest and PubHistoryCapacity can be optionally set
 SubQueueCapacity controls how many samples a reader using shared memory can hold before the least recent is discarded.
 PubHistoryCapacity defines how many samples a shared memory writer will keep to send to late-joining subscribers.
 SubHistoryRequest is the number of samples a late-joining reader will request from a writer (this can be at most 
-as many as were send and at most PubHistoryCapacity).   
+as many as were send and at most PubHistoryCapacity).
+
+The Loglevel controls the output of the iceoryx runtime and can be set to:
+verbose, debug, info, warn, error, fatal and off
+in order of decreasing output level. It is set to info by default. 
 
 Now we start to run Cyclone DDS with shared memory.
 In the 1st terminal we will start RouDi.

--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,8 @@
     <exec_depend>openssl</exec_depend>
 
     <depend>iceoryx_binding_c</depend>
+    <depend>iceoryx_posh</depend>
+    <depend>iceoryx_utils</depend>
     <test_depend>libcunit-dev</test_depend>
 
     <doc_depend>doxygen</doc_depend>

--- a/src/core/ddsc/src/dds_domain.c
+++ b/src/core/ddsc/src/dds_domain.c
@@ -139,8 +139,10 @@ static dds_entity_t dds_domain_init (dds_domain *domain, dds_domainid_t domain_i
   // TODO: isolate the shm runtime creation in a separate function
 
   // create the shared memory monitor based on iceoryx
-  if (domain->gv.config.enable_shm)
+  if (domain->gv.config.enable_shm) 
+  {
     shm_monitor_init(&domain->m_shm_monitor);
+  }
 #endif
 
   /* Start monitoring the liveliness of threads if this is the first

--- a/src/core/ddsc/src/shm_monitor.c
+++ b/src/core/ddsc/src/shm_monitor.c
@@ -80,7 +80,7 @@ dds_return_t shm_monitor_wake_and_enable(shm_monitor_t* monitor)
 dds_return_t shm_monitor_attach_reader(shm_monitor_t* monitor, struct dds_reader* reader) 
 {
 
-    if(iox_listener_attach_subscriber_event(monitor->m_listener, reader->m_iox_sub, SubscriberEvent_HAS_DATA, shm_subscriber_callback) != ListenerResult_SUCCESS) {
+    if(iox_listener_attach_subscriber_event(monitor->m_listener, reader->m_iox_sub, SubscriberState_HAS_DATA, shm_subscriber_callback) != ListenerResult_SUCCESS) {
         DDS_CLOG(DDS_LC_SHM, &reader->m_rd->e.gv->logconfig, "error attaching reader\n");    
         return DDS_RETCODE_OUT_OF_RESOURCES;
     }
@@ -91,7 +91,7 @@ dds_return_t shm_monitor_attach_reader(shm_monitor_t* monitor, struct dds_reader
 
 dds_return_t shm_monitor_detach_reader(shm_monitor_t* monitor, struct dds_reader* reader) 
 {
-    iox_listener_detach_subscriber_event(monitor->m_listener, reader->m_iox_sub, SubscriberEvent_HAS_DATA); 
+    iox_listener_detach_subscriber_event(monitor->m_listener, reader->m_iox_sub, SubscriberState_HAS_DATA); 
     --monitor->m_number_of_attached_readers;
     return DDS_RETCODE_OK;
 }

--- a/src/core/ddsi/CMakeLists.txt
+++ b/src/core/ddsi/CMakeLists.txt
@@ -90,6 +90,10 @@ if(ENABLE_TYPE_DISCOVERY)
   "${CMAKE_CURRENT_LIST_DIR}/src/ddsi_typeid.c"
   "${CMAKE_CURRENT_LIST_DIR}/src/ddsi_typelookup.c")
 endif()
+if (ENABLE_SHM)
+  list(APPEND srcs_ddsi 
+  "${CMAKE_CURRENT_LIST_DIR}/src/shm_init.c")
+endif()
 
 # The includes should reside close to the code. As long as that's not the case,
 # pull them in from this CMakeLists.txt.

--- a/src/core/ddsi/include/dds/ddsi/shm_init.h
+++ b/src/core/ddsi/include/dds/ddsi/shm_init.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright(c) 2021 Apex.AI Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+#ifndef SHM_INIT_H
+#define SHM_INIT_H
+
+#include "dds/ddsi/ddsi_config.h"
+
+// ICEORYX_TODO: move shared memory initialization here (runtime name etc.)
+// this should be done after some consolidation to avoid conflicts.
+// Note that it is not as eay as moving the initialization logic in q_init.c, 
+// since error handling must be considered.
+// 
+// dds_return_t shm_init();
+
+// For now we just add some of the logging logic here. Major restructuring will follow 
+// once the shared memory functionality is complete. 
+
+void shm_set_loglevel(enum ddsi_shm_loglevel);
+
+#endif
+

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -72,6 +72,7 @@
 #include "dds/ddsrt/io.h"
 #include "dds/ddsrt/shm_sync.h"
 #include "iceoryx_binding_c/runtime.h"
+#include "dds/ddsi/shm_init.h"
 #endif
 
 static void add_peer_addresses (const struct ddsi_domaingv *gv, struct addrset *as, const struct ddsi_config_peer_listelem *list)
@@ -1147,15 +1148,15 @@ int rtps_init (struct ddsi_domaingv *gv)
   }
 
 #ifdef DDS_HAS_SHM
-  //ICEORYX_TODO: refactor this into separate function/module?
+  //ICEORYX_TODO: refactor this into separate function/module!
   if (gv->config.enable_shm)
   {
+    shm_set_loglevel(gv->config.shm_log_lvl);
     char str[128];
     char *sptr = str;
     unsigned char mac_addr[6];
     uint32_t pid = (uint32_t) ddsrt_getpid ();
 
-    // SHM_TODO: Now we use pid_time, but maybe we can just use pid.
     ddsrt_asprintf (&sptr, "iceoryx_rt_%d_%ld", pid, gv->tstart.v);
     GVLOG (DDS_LC_SHM, "Current process name for iceoryx is %s\n", sptr);
     iox_runtime_init (sptr);

--- a/src/core/ddsi/src/shm_init.c
+++ b/src/core/ddsi/src/shm_init.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright(c) 2021 Apex.AI Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+#include "dds/ddsi/shm_init.h"
+#include "iceoryx_binding_c/log.h"
+
+static enum iox_LogLevel to_iox_loglevel(enum ddsi_shm_loglevel level) {
+    switch(level) {
+        case DDSI_SHM_OFF : return Iceoryx_LogLevel_Off;
+        case DDSI_SHM_FATAL : return Iceoryx_LogLevel_Fatal;
+        case DDSI_SHM_ERROR : return Iceoryx_LogLevel_Error;
+        case DDSI_SHM_WARN : return Iceoryx_LogLevel_Warn;
+        case DDSI_SHM_INFO : return Iceoryx_LogLevel_Info;
+        case DDSI_SHM_DEBUG : return Iceoryx_LogLevel_Debug;
+        case DDSI_SHM_VERBOSE : return Iceoryx_LogLevel_Verbose;
+    }
+    return Iceoryx_LogLevel_Off;
+}
+
+void shm_set_loglevel(enum ddsi_shm_loglevel level) {
+    iox_set_loglevel(to_iox_loglevel(level));
+}

--- a/src/core/xtests/rhc_torture/CMakeLists.txt
+++ b/src/core/xtests/rhc_torture/CMakeLists.txt
@@ -10,6 +10,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
 idlc_generate(RhcTypes RhcTypes.idl)
+include(${CMAKE_CURRENT_LIST_DIR}/../../../../cmake/Modules/CUnit.cmake)
 
 add_executable(rhc_torture rhc_torture.c)
 


### PR DESCRIPTION
Fixes the problem that a reader could be deleted while still being used in a shared memory monitoring callback.

Adapts iceoryx listener usage to a small iceoryx API change.

Reintroduces setting the shared memory logging capability.

Prepare restructuring of shared memory init code but this will be postponed postponed until the conditional use of shared memory (depending on QoS and types) has been added. Currently it just isolates the logging translation logic for iceoryx.