### PR TITLE
Replace type identifier field by pointer to type lookup meta data

### DIFF
--- a/src/core/ddsc/src/dds_matched.c
+++ b/src/core/ddsc/src/dds_matched.c
@@ -181,7 +181,7 @@ dds_builtintopic_endpoint_t *dds_get_matched_subscription_data (dds_entity_t wri
         if (prd->e.iid == ih)
         {
 #ifdef DDS_HAS_TYPE_DISCOVERY
-          ret = make_builtintopic_endpoint (&prd->e.guid, &prd->c.proxypp->e.guid, prd->c.proxypp->e.iid, prd->c.xqos, &prd->c.type_id);
+          ret = make_builtintopic_endpoint (&prd->e.guid, &prd->c.proxypp->e.guid, prd->c.proxypp->e.iid, prd->c.xqos, prd->c.tlm ? &prd->c.tlm->type_id : NULL);
 #else
           ret = make_builtintopic_endpoint (&prd->e.guid, &prd->c.proxypp->e.guid, prd->c.proxypp->e.iid, prd->c.xqos);
 #endif
@@ -198,7 +198,7 @@ dds_builtintopic_endpoint_t *dds_get_matched_subscription_data (dds_entity_t wri
         if (rd->e.iid == ih)
         {
 #ifdef DDS_HAS_TYPE_DISCOVERY
-          ret = make_builtintopic_endpoint (&rd->e.guid, &rd->c.pp->e.guid, rd->c.pp->e.iid, rd->xqos, &rd->c.type_id);
+          ret = make_builtintopic_endpoint (&rd->e.guid, &rd->c.pp->e.guid, rd->c.pp->e.iid, rd->xqos, rd->c.tlm ? &rd->c.tlm->type_id : NULL);
 #else
           ret = make_builtintopic_endpoint (&rd->e.guid, &rd->c.pp->e.guid, rd->c.pp->e.iid, rd->xqos);
 #endif
@@ -236,7 +236,7 @@ dds_builtintopic_endpoint_t *dds_get_matched_publication_data (dds_entity_t read
         if (pwr->e.iid == ih)
         {
 #ifdef DDS_HAS_TYPE_DISCOVERY
-          ret = make_builtintopic_endpoint (&pwr->e.guid, &pwr->c.proxypp->e.guid, pwr->c.proxypp->e.iid, pwr->c.xqos, &pwr->c.type_id);
+          ret = make_builtintopic_endpoint (&pwr->e.guid, &pwr->c.proxypp->e.guid, pwr->c.proxypp->e.iid, pwr->c.xqos, pwr->c.tlm ? &pwr->c.tlm->type_id : NULL);
 #else
           ret = make_builtintopic_endpoint (&pwr->e.guid, &pwr->c.proxypp->e.guid, pwr->c.proxypp->e.iid, pwr->c.xqos);
 #endif
@@ -253,7 +253,7 @@ dds_builtintopic_endpoint_t *dds_get_matched_publication_data (dds_entity_t read
         if (wr->e.iid == ih)
         {
 #ifdef DDS_HAS_TYPE_DISCOVERY
-          ret = make_builtintopic_endpoint (&wr->e.guid, &wr->c.pp->e.guid, wr->c.pp->e.iid, wr->xqos, &wr->c.type_id);
+          ret = make_builtintopic_endpoint (&wr->e.guid, &wr->c.pp->e.guid, wr->c.pp->e.iid, wr->xqos, wr->c.tlm ? &wr->c.tlm->type_id : NULL);
 #else
           ret = make_builtintopic_endpoint (&wr->e.guid, &wr->c.pp->e.guid, wr->c.pp->e.iid, wr->xqos);
 #endif

--- a/src/core/ddsc/src/dds_topic.c
+++ b/src/core/ddsc/src/dds_topic.c
@@ -738,7 +738,7 @@ static dds_entity_t find_remote_topic_impl (dds_participant *pp_topic, const cha
     return ret;
   if (tpd == NULL)
     return DDS_RETCODE_OK;
-  if ((ret = dds_domain_resolve_type (pp_topic->m_entity.m_hdllink.hdl, tpd->type_id.hash, sizeof (tpd->type_id.hash), timeout, &sertype)) != DDS_RETCODE_OK)
+  if ((ret = dds_domain_resolve_type (pp_topic->m_entity.m_hdllink.hdl, tpd->tlm->type_id.hash, sizeof (tpd->tlm->type_id.hash), timeout, &sertype)) != DDS_RETCODE_OK)
   {
     /* if topic definition is found, but the type for this topic is not resolved
         and timeout 0 means we don't want to request and wait for the type to be retrieved */

--- a/src/core/ddsc/tests/typelookup.c
+++ b/src/core/ddsc/tests/typelookup.c
@@ -85,12 +85,12 @@ static type_identifier_t *get_type_identifier(dds_entity_t entity)
   if (ec->kind == EK_PROXY_READER || ec->kind == EK_PROXY_WRITER)
   {
     struct generic_proxy_endpoint *gpe = (struct generic_proxy_endpoint *)ec;
-    tid = ddsi_typeid_dup (&gpe->c.type_id);
+    tid = ddsi_typeid_dup (&gpe->c.tlm->type_id);
   }
   else if (ec->kind == EK_READER || ec->kind == EK_WRITER)
   {
     struct generic_endpoint *ge = (struct generic_endpoint *)ec;
-    tid = ddsi_typeid_dup (&ge->c.type_id);
+    tid = ddsi_typeid_dup (&ge->c.tlm->type_id);
   }
   thread_state_asleep (lookup_thread_state ());
   dds_entity_unpin (e);

--- a/src/core/ddsi/include/dds/ddsi/ddsi_typelookup.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_typelookup.h
@@ -81,7 +81,7 @@ extern size_t typelookup_service_reply_nops;
  * Reference the type lookup meta object identified by the provided type identifier
  * and register the proxy endpoint with this entry.
  */
-void ddsi_tl_meta_proxy_ref (struct ddsi_domaingv *gv, const type_identifier_t *type_id, const ddsi_guid_t *proxy_ep_guid);
+struct tl_meta * ddsi_tl_meta_proxy_ref (struct ddsi_domaingv *gv, const type_identifier_t *type_id, const ddsi_guid_t *proxy_ep_guid);
 
 /**
  * Reference the type lookup meta object identifier by the provided type identifier
@@ -89,19 +89,19 @@ void ddsi_tl_meta_proxy_ref (struct ddsi_domaingv *gv, const type_identifier_t *
  * yet registered with the type lookup meta object, this field will be set in the meta
  * object.
  */
-void ddsi_tl_meta_local_ref (struct ddsi_domaingv *gv, const type_identifier_t *type_id, const struct ddsi_sertype *type);
+struct tl_meta * ddsi_tl_meta_local_ref (struct ddsi_domaingv *gv, const type_identifier_t *type_id, const struct ddsi_sertype *type);
 
 /**
  * Dereference the type lookup meta object identified by the provided type identifier.
  * The proxy endpoint will be deregistered for this entry.
  */
-void ddsi_tl_meta_proxy_unref (struct ddsi_domaingv *gv, const type_identifier_t *type_id, const ddsi_guid_t *proxy_ep_guid);
+void ddsi_tl_meta_proxy_unref (struct ddsi_domaingv *gv, const struct tl_meta *tlm, const ddsi_guid_t *proxy_ep_guid);
 
 /**
  * Dereference the type lookup meta object identifier by the provided type identifier
  * or the provided type object.
  */
-void ddsi_tl_meta_local_unref (struct ddsi_domaingv *gv, const type_identifier_t *type_id, const struct ddsi_sertype *type);
+void ddsi_tl_meta_local_unref (struct ddsi_domaingv *gv, const struct tl_meta *tlm, const struct ddsi_sertype *type);
 
 /**
  * Returns the type lookup meta object for the provided type identifier.

--- a/src/core/ddsi/include/dds/ddsi/q_entity.h
+++ b/src/core/ddsi/include/dds/ddsi/q_entity.h
@@ -260,8 +260,8 @@ struct participant
 
 #ifdef DDS_HAS_TOPIC_DISCOVERY
 struct ddsi_topic_definition {
-  unsigned char key[16]; /* key for this topic definition (MD5 hash of the type_id and qos */
-  type_identifier_t type_id; /* type identifier for this topic */
+  unsigned char key[16]; /* key for this topic definition (MD5 hash of the type_id and qos) */
+  struct tl_meta *tlm;
   struct dds_qos *xqos; /* contains also the topic name and type name */
   uint32_t refc;
   struct ddsi_domaingv *gv;
@@ -278,7 +278,7 @@ struct endpoint_common {
   struct participant *pp;
   ddsi_guid_t group_guid;
 #ifdef DDS_HAS_TYPE_DISCOVERY
-  type_identifier_t type_id;
+  struct tl_meta *tlm;
 #endif
 };
 
@@ -486,7 +486,7 @@ struct proxy_endpoint_common
   nn_vendorid_t vendor; /* cached from proxypp->vendor */
   seqno_t seq; /* sequence number of most recent SEDP message */
 #ifdef DDS_HAS_TYPE_DISCOVERY
-  type_identifier_t type_id; /* type identifier for for type used by this proxy endpoint */
+  struct tl_meta *tlm;
   const struct ddsi_sertype * type; /* sertype for data this endpoint reads/writes */
 #endif
 #ifdef DDS_HAS_SECURITY

--- a/src/core/ddsi/src/q_ddsi_discovery.c
+++ b/src/core/ddsi/src/q_ddsi_discovery.c
@@ -995,9 +995,12 @@ static int sedp_write_endpoint_impl
     }
 
 #ifdef DDS_HAS_TYPE_DISCOVERY
-    ps.qos.present |= QP_CYCLONE_TYPE_INFORMATION;
-    ps.qos.type_information.length = sizeof (*type_id);
-    ps.qos.type_information.value = ddsrt_memdup (&type_id->hash, ps.qos.type_information.length);
+    if (type_id)
+    {
+      ps.qos.present |= QP_CYCLONE_TYPE_INFORMATION;
+      ps.qos.type_information.length = sizeof (*type_id);
+      ps.qos.type_information.value = ddsrt_memdup (&type_id->hash, ps.qos.type_information.length);
+    }
 #endif
   }
 
@@ -1049,7 +1052,7 @@ int sedp_write_topic (struct topic *tp, bool alive)
     unsigned entityid = determine_topic_writer (tp);
     struct writer *sedp_wr = get_sedp_writer (tp->pp, entityid);
     ddsrt_mutex_lock (&tp->e.qos_lock);
-    res = sedp_write_topic_impl (sedp_wr, alive, &tp->e.guid, tp->definition->xqos, &tp->definition->type_id);
+    res = sedp_write_topic_impl (sedp_wr, alive, &tp->e.guid, tp->definition->xqos, &tp->definition->tlm->type_id);
     ddsrt_mutex_unlock (&tp->e.qos_lock);
   }
   return res;
@@ -1077,7 +1080,7 @@ int sedp_write_writer (struct writer *wr)
     }
 #endif
 #ifdef DDS_HAS_TYPE_DISCOVERY
-    return sedp_write_endpoint_impl (sedp_wr, 1, &wr->e.guid, &wr->e, &wr->c, wr->xqos, as, security, &wr->c.type_id);
+    return sedp_write_endpoint_impl (sedp_wr, 1, &wr->e.guid, &wr->e, &wr->c, wr->xqos, as, security, wr->c.tlm ? &wr->c.tlm->type_id : NULL);
 #else
     return sedp_write_endpoint_impl (sedp_wr, 1, &wr->e.guid, &wr->e, &wr->c, wr->xqos, as, security);
 #endif
@@ -1105,7 +1108,7 @@ int sedp_write_reader (struct reader *rd)
     }
 #endif
 #ifdef DDS_HAS_TYPE_DISCOVERY
-    return sedp_write_endpoint_impl (sedp_wr, 1, &rd->e.guid, &rd->e, &rd->c, rd->xqos, as, security, &rd->c.type_id);
+    return sedp_write_endpoint_impl (sedp_wr, 1, &rd->e.guid, &rd->e, &rd->c, rd->xqos, as, security, rd->c.tlm ? &rd->c.tlm->type_id : NULL);
 #else
     return sedp_write_endpoint_impl (sedp_wr, 1, &rd->e.guid, &rd->e, &rd->c, rd->xqos, as, security);
 #endif


### PR DESCRIPTION
Replace the type identifier field in (proxy) endpoints and topic definitions by a pointer to the type-lookup meta data record. This change is to prepare for the implementation of the XTypes type system, in which a type identifier can't be used as an identifier in certain cases, because a minimal and complete version of the type identifier exists.