### PR TITLE
QoS checks

### DIFF
--- a/examples/shm_throughput/CMakeLists.txt
+++ b/examples/shm_throughput/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
+# Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at

--- a/examples/shm_throughput/readme.rst
+++ b/examples/shm_throughput/readme.rst
@@ -15,7 +15,7 @@ Throughput
 Description
 ***********
 
-The Throughput example allows the measurement of data throughput when receiving samples from a publisher.
+The Throughput example allows the measurement of data throughput when receiving samples from a publisher, with message types that are supported by shared memory.
 
 
 Design
@@ -23,8 +23,8 @@ Design
 
 It consists of 2 units:
 
-- Publisher: sends samples at a specified size and rate.
-- Subscriber: Receives samples and outputs statistics about throughput
+- ShmThroughputPublisher: sends samples at a specified size and rate.
+- ShmThroughputSubscriber: Receives samples and outputs statistics about throughput
 
 Scenario
 ********
@@ -34,7 +34,7 @@ to send data in bursts. The **publisher** will continue to send data forever unl
 
 Configurable:
 
-- payloadSize: the size of the payload in bytes
+- payloadSize: the size of the payload in bytes, these should be powers of 2 from 16 to 1048576
 - burstInterval: the time interval between each burst in ms
 - burstSize: the number of samples to send each burst
 - timeOut: the number of seconds the publisher should run for (0=infinite)
@@ -56,42 +56,43 @@ Configurable:
 - maxCycles: the number of times to output statistics before terminating
 - pollingDelay
 - partitionName: the name of the partition
+- payloadSize: the size of the message in bytes, this should be the same as that given to the publisher
 
 
 Running the example
 *******************
 
-It is recommended that you run ping and pong in separate terminals to avoid mixing the output.
+It is recommended that you run the publisher and subscriber in separate terminals to avoid mixing the output.
 
 - Open 2 terminals.
-- In the first terminal start Publisher by running publisher
+- In the first terminal start the publisher by running ShmThroughputPublisher
 
   publisher usage (parameters must be supplied in order):
-    ``./publisher [payloadSize (bytes)] [burstInterval (ms)] [burstSize (samples)] [timeOut (seconds)] [partitionName]``
+    ``./ShmThroughputPublisher [payloadSize (bytes)] [burstInterval (ms)] [burstSize (samples)] [timeOut (seconds)] [partitionName]``
   defaults:
-    ``./publisher 8192 0 1 0 "Throughput example"``
+    ``./ShmThroughputPublisher 8192 0 1 0 "Throughput example"``
 
-- In the second terminal start Ping by running subscriber
+- In the second terminal start the subscriber by running ShmThroughputSubscriber
 
   subscriber usage (parameters must be supplied in order):
-    ``./subscriber [maxCycles (0=infinite)] [pollingDelay (ms, 0 = event based)] [partitionName] [payloadSize (bytes]``
+    ``./ShmThroughputSubscriber [maxCycles (0=infinite)] [pollingDelay (ms, 0 = event based)] [partitionName] [payloadSize (bytes]``
   defaults:
-    ``./subscriber 0 0 "Throughput example" 8192``
+    ``./ShmThroughputSubscriber 0 0 "Throughput example" 8192``
 
 - To achieve optimal performance it is recommended to set the CPU affinity so that ping and pong run on separate CPU cores,
   and use real-time scheduling. In a Linux environment this can be achieved as follows:
 
   publisher usage:
-    ``taskset -c 0 chrt -f 80 ./publisher [payloadSize (bytes)] [burstInterval (ms)] [burstSize (samples)] [timeOut (seconds)] [partitionName]``
+    ``taskset -c 0 chrt -f 80 ./ShmThroughputPublisher [payloadSize (bytes)] [burstInterval (ms)] [burstSize (samples)] [timeOut (seconds)] [partitionName]``
   subscriber usage:
-    ``taskset -c 1 chrt -f 80 ./subscriber [maxCycles (0 = infinite)] [pollingDelay (ms, 0 = event based)] [partitionName] [payloadSize (bytes]``
+    ``taskset -c 1 chrt -f 80 ./ShmThroughputSubscriber [maxCycles (0 = infinite)] [pollingDelay (ms, 0 = event based)] [partitionName] [payloadSize (bytes]``
 
   On Windows the CPU affinity and prioritized scheduling class can be set as follows:
 
   publisher usage:
-    ``START /affinity 1 /high cmd /k "publisher.exe" [payloadSize (bytes)] [burstInterval (ms)] [burstSize (samples)] [timeOut (seconds)] [partitionName]``
+    ``START /affinity 1 /high cmd /k "ShmThroughputPublisher.exe" [payloadSize (bytes)] [burstInterval (ms)] [burstSize (samples)] [timeOut (seconds)] [partitionName]``
   subscriber usage:
-    ``START /affinity 2 /high cmd /k "subscriber.exe" [maxCycles (0 = infinite)] [pollingDelay (ms, 0 = event based)] [partitionName] [payloadSize (bytes]``
+    ``START /affinity 2 /high cmd /k "ShmThroughputSubscriber.exe" [maxCycles (0 = infinite)] [pollingDelay (ms, 0 = event based)] [partitionName] [payloadSize (bytes]``
 
 
 

--- a/examples/shm_throughput/shmpublisher.c
+++ b/examples/shm_throughput/shmpublisher.c
@@ -276,7 +276,10 @@ static dds_entity_t prepare_dds(dds_entity_t *writer, const char *partitionName)
   /* A DataWriter is created on the publisher. */
   dwQos = dds_create_qos ();
   dds_qset_reliability (dwQos, DDS_RELIABILITY_RELIABLE, DDS_SECS (10));
-  dds_qset_history (dwQos, DDS_HISTORY_KEEP_ALL, 0);
+  dds_qset_history (dwQos, DDS_HISTORY_KEEP_LAST, 16);
+  dds_qset_deadline(dwQos, DDS_INFINITY);
+  dds_qset_durability(dwQos, DDS_DURABILITY_VOLATILE);
+  dds_qset_liveliness(dwQos, DDS_LIVELINESS_AUTOMATIC, 1e9);
   dds_qset_resource_limits (dwQos, MAX_SAMPLES, DDS_LENGTH_UNLIMITED, DDS_LENGTH_UNLIMITED);
   *writer = dds_create_writer (publisher, topic, dwQos, NULL);
   if (*writer < 0)

--- a/src/core/ddsc/src/dds_write.c
+++ b/src/core/ddsc/src/dds_write.c
@@ -239,7 +239,7 @@ dds_return_t dds_write_impl (dds_writer *wr, const void * data, dds_time_t tstam
     ddsi_serdata_ref (d);
 
 #ifdef DDS_HAS_SHM
-    if (wr->m_entity.m_domain->gv.config.enable_shm &&
+    if (wr->m_iox_pub &&
         iox_pub_has_subscribers(wr->m_iox_pub))
     {
       uint32_t send_size = ddsi_serdata_iox_size (d);

--- a/src/core/ddsc/src/dds_writer.c
+++ b/src/core/ddsc/src/dds_writer.c
@@ -210,7 +210,7 @@ static dds_return_t dds_writer_delete (dds_entity *e)
 {
   dds_writer * const wr = (dds_writer *) e;
 #ifdef DDS_HAS_SHM
-  if (e->m_domain->gv.config.enable_shm)
+  if (wr->m_iox_pub)
   {
     DDS_CLOG(DDS_LC_SHM, &e->m_domain->gv.logconfig, "Release iceoryx's publisher\n");
     iox_pub_stop_offer(wr->m_iox_pub);
@@ -291,6 +291,27 @@ const struct dds_entity_deriver dds_entity_deriver_writer = {
   .create_statistics = dds_writer_create_statistics,
   .refresh_statistics = dds_writer_refresh_statistics
 };
+
+#ifdef DDS_HAS_SHM
+#define DDS_WRITER_QOS_CHECK_FIELDS (QP_LIVELINESS|QP_DEADLINE|QP_RELIABILITY|QP_DURABILITY|QP_HISTORY)
+static bool dds_writer_support_shm(const struct ddsi_config* cfg, const dds_qos_t* qos)
+{
+  if (NULL == cfg ||
+      false == cfg->enable_shm)
+    return false;
+
+  uint32_t pub_history_cap = cfg->pub_history_capacity;
+
+  return (NULL != qos &&
+          DDS_WRITER_QOS_CHECK_FIELDS == (qos->present&DDS_WRITER_QOS_CHECK_FIELDS) &&
+          DDS_LIVELINESS_AUTOMATIC == qos->liveliness.kind &&
+          DDS_INFINITY == qos->deadline.deadline &&
+          DDS_RELIABILITY_RELIABLE == qos->reliability.kind &&
+          DDS_DURABILITY_VOLATILE == qos->durability.kind &&
+          DDS_HISTORY_KEEP_LAST == qos->history.kind &&
+          (int)pub_history_cap >= (int)qos->history.depth);
+}
+#endif
 
 dds_entity_t dds_create_writer (dds_entity_t participant_or_publisher, dds_entity_t topic, const dds_qos_t *qos, const dds_listener_t *listener)
 {
@@ -391,12 +412,17 @@ dds_entity_t dds_create_writer (dds_entity_t participant_or_publisher, dds_entit
   whc_free_wrinfo (wrinfo);
   wr->whc_batch = gv->config.whc_batch;
 
+#ifdef DDS_HAS_SHM
+  wqos->shared_memory.enabled = dds_writer_support_shm(&gv->config, qos);
+  wqos->present |= QP_SHARED_MEMORY;
+#endif
+
   rc = new_writer (&wr->m_wr, &wr->m_entity.m_guid, NULL, pp, tp->m_name, tp->m_stype, wqos, wr->m_whc, dds_writer_status_cb, wr);
   assert(rc == DDS_RETCODE_OK);
   thread_state_asleep (lookup_thread_state ());
 
 #ifdef DDS_HAS_SHM
-  if (wr->m_entity.m_domain->gv.config.enable_shm)
+  if (wqos->shared_memory.enabled)
   {
     size_t name_size, type_name_size;
     rc = dds_get_name_size (topic, &name_size);

--- a/src/core/ddsc/tests/deadline.c
+++ b/src/core/ddsc/tests/deadline.c
@@ -28,7 +28,11 @@
 
 #define DDS_DOMAINID_PUB 0
 #define DDS_DOMAINID_SUB 1
+#ifdef DDS_HAS_SHM
+#define DDS_CONFIG_NO_PORT_GAIN "${CYCLONEDDS_URI}${CYCLONEDDS_URI:+,}<Discovery><ExternalDomainId>0</ExternalDomainId></Discovery><Domain id=\"any\"><SharedMemory><Enable>false</Enable></SharedMemory></Domain>"
+#else
 #define DDS_CONFIG_NO_PORT_GAIN "${CYCLONEDDS_URI}${CYCLONEDDS_URI:+,}<Discovery><ExternalDomainId>0</ExternalDomainId></Discovery>"
+#endif
 
 static dds_entity_t g_domain = 0;
 static dds_entity_t g_participant = 0;

--- a/src/core/ddsi/include/dds/ddsi/ddsi_xqos.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_xqos.h
@@ -228,6 +228,12 @@ typedef struct dds_type_consistency_enforcement_qospolicy {
   bool force_type_validation;
 } dds_type_consistency_enforcement_qospolicy_t;
 
+#ifdef DDS_HAS_SHM
+typedef struct dds_type_shared_memory {
+  unsigned char enabled;
+} dds_type_shared_memory_t;
+#endif
+
 /***/
 
 /* Qos Present bit indices */
@@ -261,6 +267,9 @@ typedef struct dds_type_consistency_enforcement_qospolicy {
 #define QP_PROPERTY_LIST                     ((uint64_t)1 << 31)
 #define QP_TYPE_CONSISTENCY_ENFORCEMENT      ((uint64_t)1 << 32)
 #define QP_CYCLONE_TYPE_INFORMATION          ((uint64_t)1 << 33)
+#ifdef DDS_HAS_SHM
+#define QP_SHARED_MEMORY                     ((uint64_t)1 << 34)
+#endif
 
 /* Partition QoS is not RxO according to the specification (DDS 1.2,
    section 7.1.3), but communication will not take place unless it
@@ -317,6 +326,9 @@ struct dds_qos {
   /* x  */dds_ignorelocal_qospolicy_t ignorelocal;
   /*xxx */dds_property_qospolicy_t property;
   /*xxxR*/dds_type_consistency_enforcement_qospolicy_t type_consistency;
+#ifdef DDS_HAS_SHM
+  /*xxxX*/ dds_type_shared_memory_t shared_memory;
+#endif
 };
 
 struct nn_xmsg;

--- a/src/core/ddsi/include/dds/ddsi/q_entity.h
+++ b/src/core/ddsi/include/dds/ddsi/q_entity.h
@@ -240,8 +240,8 @@ struct participant
   struct ddsi_plist *plist; /* settings/QoS for this participant */
   struct xevent *spdp_xevent; /* timed event for periodically publishing SPDP */
   struct xevent *pmd_update_xevent; /* timed event for periodically publishing ParticipantMessageData */
-  ddsi_locator_t m_locator;
-  ddsi_tran_conn_t m_conn;
+  ddsi_locator_t m_locator; /* this is always a unicast address, it is set if it is in the many unicast mode */
+  ddsi_tran_conn_t m_conn; /* this is connection to m_locator, if it is set, this is used */
   struct avail_entityid_set avail_entityids; /* available entity ids [e.lock] */
   ddsrt_mutex_t refc_lock;
   int32_t user_refc; /* number of non-built-in endpoints in this participant [refc_lock] */

--- a/src/core/ddsi/src/ddsi_plist.c
+++ b/src/core/ddsi/src/ddsi_plist.c
@@ -1760,6 +1760,11 @@ static const struct piddesc piddesc_eclipse[] = {
 #ifdef DDS_HAS_TYPE_DISCOVERY
   QP  (CYCLONE_TYPE_INFORMATION,         type_information, XO),
 #endif
+#ifdef DDS_HAS_SHM
+    { PID_PAD, PDF_QOS, QP_SHARED_MEMORY, "CYCLONE_SHARED_MEMORY",
+    offsetof(struct ddsi_plist, qos.shared_memory), membersize(struct ddsi_plist, qos.shared_memory),
+    {.desc = { Xb, XSTOP } }, 0 },
+#endif
   PP  (ADLINK_PARTICIPANT_VERSION_INFO,  adlink_participant_version_info, Xux5, XS),
   PP  (ADLINK_TYPE_DESCRIPTION,          type_description, XS),
   PP  (CYCLONE_RECEIVE_BUFFER_SIZE,      cyclone_receive_buffer_size, Xu),

--- a/src/core/ddsi/src/q_ddsi_discovery.c
+++ b/src/core/ddsi/src/q_ddsi_discovery.c
@@ -214,32 +214,14 @@ void get_participant_builtin_topic_data (const struct participant *pp, ddsi_plis
     dst->aliased |= PP_DOMAIN_TAG;
     dst->domain_tag = pp->e.gv->config.domainTag;
   }
-#ifdef DDS_HAS_SHM
-  if (pp->e.gv->config.enable_shm)
-  {
-    dst->default_unicast_locators.n = 2;
-    dst->default_unicast_locators.first = &locs->def_uni_loc_one;
-    dst->default_unicast_locators.last = &locs->def_uni_loc_two;
-    dst->metatraffic_unicast_locators.n = 1;
-    dst->metatraffic_unicast_locators.first =
-      dst->metatraffic_unicast_locators.last = &locs->meta_uni_loc_one;
-    locs->def_uni_loc_one.next = &locs->def_uni_loc_two;
-    locs->meta_uni_loc_one.next = NULL;
-    locs->def_uni_loc_two.next = NULL;
-    locs->def_uni_loc_two.loc = pp->e.gv->loc_iceoryx_addr;
-  }
-  else
-#endif /*DDS_HAS_SHM*/
-  {
-    dst->default_unicast_locators.n = 1;
-    dst->default_unicast_locators.first =
-      dst->default_unicast_locators.last = &locs->def_uni_loc_one;
-    dst->metatraffic_unicast_locators.n = 1;
-    dst->metatraffic_unicast_locators.first =
-      dst->metatraffic_unicast_locators.last = &locs->meta_uni_loc_one;
-    locs->def_uni_loc_one.next = NULL;
-    locs->meta_uni_loc_one.next = NULL;
-  }
+  dst->default_unicast_locators.n = 1;
+  dst->default_unicast_locators.first =
+    dst->default_unicast_locators.last = &locs->def_uni_loc_one;
+  dst->metatraffic_unicast_locators.n = 1;
+  dst->metatraffic_unicast_locators.first =
+    dst->metatraffic_unicast_locators.last = &locs->meta_uni_loc_one;
+  locs->def_uni_loc_one.next = NULL;
+  locs->meta_uni_loc_one.next = NULL;
 
   if (pp->e.gv->config.many_sockets_mode == DDSI_MSM_MANY_UNICAST)
   {
@@ -278,36 +260,16 @@ void get_participant_builtin_topic_data (const struct participant *pp, ddsi_plis
     {
       dst->present |= PP_DEFAULT_MULTICAST_LOCATOR | PP_METATRAFFIC_MULTICAST_LOCATOR;
       dst->aliased |= PP_DEFAULT_MULTICAST_LOCATOR | PP_METATRAFFIC_MULTICAST_LOCATOR;
-#ifdef DDS_HAS_SHM
-      if (pp->e.gv->config.enable_shm)
-      {
-        dst->default_multicast_locators.n = 2;
-        dst->default_multicast_locators.first = &locs->def_multi_loc_one;
-        dst->default_multicast_locators.last = &locs->def_multi_loc_two;
-        dst->metatraffic_multicast_locators.n = 1;
-        dst->metatraffic_multicast_locators.first =
-          dst->metatraffic_multicast_locators.last = &locs->meta_multi_loc_one;
-        locs->def_multi_loc_one.next = &locs->def_multi_loc_two;
-        locs->def_multi_loc_one.loc = pp->e.gv->loc_default_mc;
-        locs->def_multi_loc_two.next = NULL;
-        locs->def_multi_loc_two.loc = pp->e.gv->loc_iceoryx_addr;
-        locs->meta_multi_loc_one.next = NULL;
-        locs->meta_multi_loc_one.loc = pp->e.gv->loc_meta_mc;
-      }
-      else
-#endif /*DDS_HAS_SHM*/
-      {
-        dst->default_multicast_locators.n = 1;
-        dst->default_multicast_locators.first =
-          dst->default_multicast_locators.last = &locs->def_multi_loc_one;
-        dst->metatraffic_multicast_locators.n = 1;
-        dst->metatraffic_multicast_locators.first =
-          dst->metatraffic_multicast_locators.last = &locs->meta_multi_loc_one;
-        locs->def_multi_loc_one.next = NULL;
-        locs->def_multi_loc_one.loc = pp->e.gv->loc_default_mc;
-        locs->meta_multi_loc_one.next = NULL;
-        locs->meta_multi_loc_one.loc = pp->e.gv->loc_meta_mc;
-      }
+      dst->default_multicast_locators.n = 1;
+      dst->default_multicast_locators.first =
+        dst->default_multicast_locators.last = &locs->def_multi_loc_one;
+      dst->metatraffic_multicast_locators.n = 1;
+      dst->metatraffic_multicast_locators.first =
+        dst->metatraffic_multicast_locators.last = &locs->meta_multi_loc_one;
+      locs->def_multi_loc_one.next = NULL;
+      locs->def_multi_loc_one.loc = pp->e.gv->loc_default_mc;
+      locs->meta_multi_loc_one.next = NULL;
+      locs->meta_multi_loc_one.loc = pp->e.gv->loc_meta_mc;
     }
   }
   dst->participant_lease_duration = pp->lease_duration;
@@ -928,6 +890,33 @@ static void add_locator_to_ps (const ddsi_locator_t *loc, void *varg)
   locs->last = elem;
 }
 
+#ifdef DDS_HAS_SHM
+static void add_iox_locator_to_ps(const ddsi_locator_t* loc, struct add_locator_to_ps_arg *arg)
+{
+  struct nn_locators_one* elem = ddsrt_malloc(sizeof(struct nn_locators_one));
+  struct nn_locators* locs = &arg->ps->unicast_locators;
+  unsigned present_flag = PP_UNICAST_LOCATOR;
+
+  elem->loc = *loc;
+  elem->next = NULL;
+
+  if (!(arg->ps->present & present_flag))
+  {
+    locs->n = 0;
+    locs->first = locs->last = NULL;
+    arg->ps->present |= present_flag;
+  }
+
+  //add iceoryx to the FRONT of the list of addresses, to indicate its higher priority
+  if (locs->first)
+    elem->next = locs->first;
+  else
+    locs->last = elem;
+  locs->first = elem;
+  locs->n++;
+}
+#endif
+
 /******************************************************************************
  ***
  *** SEDP
@@ -1013,13 +1002,30 @@ static int sedp_write_endpoint
     if (gv->config.explicitly_publish_qos_set_to_default)
       qosdiff |= ~QP_UNRECOGNIZED_INCOMPATIBLE_MASK;
 
+    struct add_locator_to_ps_arg arg;
+    arg.gv = gv;
+    arg.ps = &ps;
     if (as)
+      addrset_forall(as, add_locator_to_ps, &arg);
+
+#ifdef DDS_HAS_SHM
+    if ((xqos->present & QP_SHARED_MEMORY) == QP_SHARED_MEMORY &&
+      xqos->shared_memory.enabled)
     {
-      struct add_locator_to_ps_arg arg;
-      arg.gv = gv;
-      arg.ps = &ps;
-      addrset_forall (as, add_locator_to_ps, &arg);
+      if (0 == arg.ps->unicast_locators.n)
+      {
+        if (epcommon->pp->e.gv->config.many_sockets_mode == DDSI_MSM_MANY_UNICAST)
+          add_locator_to_ps(&epcommon->pp->m_locator, &arg);
+        else
+          add_locator_to_ps(&epcommon->pp->e.gv->loc_default_uc, &arg);
+      }
+
+      if (0 == arg.ps->multicast_locators.n)
+        add_locator_to_ps(&epcommon->pp->e.gv->loc_default_mc, &arg);
+
+      add_iox_locator_to_ps(&gv->loc_iceoryx_addr, &arg);
     }
+#endif
 
 #ifdef DDS_HAS_TYPE_DISCOVERY
     ps.qos.present |= QP_CYCLONE_TYPE_INFORMATION;


### PR DESCRIPTION
- added checks on QoS compatibility
- small fixes for unittests
- improvements for throughput example:
  - out of order messages are now messages in non-ascending order, not in non-following order
  - added correct QoS settings for shared memory throughput example