### PR TITLE
Update writecdr for iceoryx

### DIFF
--- a/src/core/ddsc/src/dds__write.h
+++ b/src/core/ddsc/src/dds__write.h
@@ -30,7 +30,7 @@ typedef enum {
 } dds_write_action;
 
 dds_return_t dds_write_impl (dds_writer *wr, const void *data, dds_time_t tstamp, dds_write_action action);
-dds_return_t dds_writecdr_impl (struct writer *ddsi_wr, struct nn_xpack *xp, struct ddsi_serdata *d, bool flush);
+dds_return_t dds_writecdr_impl (struct writer *ddsi_wr, struct nn_xpack *xp, struct ddsi_serdata *d, bool flush, dds_writer *wr);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsc/src/dds_builtin.c
+++ b/src/core/ddsc/src/dds_builtin.c
@@ -256,7 +256,7 @@ static void dds__builtin_write (const struct entity_common *e, ddsrt_wctime_t ti
         bwr = dom->builtintopic_writer_subscriptions;
         break;
     }
-    dds_writecdr_impl (&bwr->wr, NULL, serdata, true);
+    dds_writecdr_impl (&bwr->wr, NULL, serdata, true, NULL);
   }
 }
 

--- a/src/core/ddsc/src/dds_data_allocator.c
+++ b/src/core/ddsc/src/dds_data_allocator.c
@@ -92,6 +92,8 @@ void *dds_data_allocator_alloc (dds_data_allocator_t *data_allocator, size_t siz
         alloc_result = iox_pub_loan_chunk (d->ref.pub, &ptr, (uint32_t) size);
         return (alloc_result == AllocationResult_SUCCESS) ? ptr : NULL;
       }
+    default:
+      return NULL;
   }
 #else
   (void) data_allocator;

--- a/src/core/ddsc/src/dds_write.c
+++ b/src/core/ddsc/src/dds_write.c
@@ -63,7 +63,7 @@ dds_return_t dds_writecdr (dds_entity_t writer, struct ddsi_serdata *serdata)
   }
   serdata->statusinfo = 0;
   serdata->timestamp.v = dds_time ();
-  ret = dds_writecdr_impl (wr->m_wr, wr->m_xp, serdata, !wr->whc_batch);
+  ret = dds_writecdr_impl (wr->m_wr, wr->m_xp, serdata, !wr->whc_batch, wr);
   dds_writer_unlock (wr);
   return ret;
 }
@@ -83,7 +83,7 @@ dds_return_t dds_forwardcdr (dds_entity_t writer, struct ddsi_serdata *serdata)
     dds_writer_unlock (wr);
     return DDS_RETCODE_ERROR;
   }
-  ret = dds_writecdr_impl (wr->m_wr, wr->m_xp, serdata, !wr->whc_batch);
+  ret = dds_writecdr_impl (wr->m_wr, wr->m_xp, serdata, !wr->whc_batch, wr);
   dds_writer_unlock (wr);
   return ret;
 }
@@ -289,7 +289,7 @@ dds_return_t dds_write_impl (dds_writer *wr, const void * data, dds_time_t tstam
   return ret;
 }
 
-dds_return_t dds_writecdr_impl (struct writer *ddsi_wr, struct nn_xpack *xp, struct ddsi_serdata *dinp, bool flush)
+dds_return_t dds_writecdr_impl (struct writer *ddsi_wr, struct nn_xpack *xp, struct ddsi_serdata *dinp, bool flush, dds_writer *wr)
 {
   // consumes 1 refc from dinp in all paths (weird, but ... history ...)
   struct thread_state1 * const ts1 = lookup_thread_state ();
@@ -334,6 +334,21 @@ dds_return_t dds_writecdr_impl (struct writer *ddsi_wr, struct nn_xpack *xp, str
   // retain dact until after write_sample_gc so we can still pass it
   // to deliver_locally
   ddsi_serdata_ref (dact);
+
+#ifdef DDS_HAS_SHM
+  if (wr) {
+    if ((wr->m_entity.m_domain->gv.config.enable_shm && iox_pub_has_subscribers(wr->m_iox_pub)) &&
+        (dinp->iox_chunk != NULL))
+    {
+      iceoryx_header_t * ice_hdr = dinp->iox_chunk;
+      ice_hdr->guid = ddsi_wr->e.guid;
+      ice_hdr->tstamp = dinp->timestamp.v;
+      ice_hdr->data_kind = (unsigned char)dinp->kind;
+      ddsi_serdata_get_keyhash (dinp, &ice_hdr->keyhash, false);
+      iox_pub_publish_chunk (wr->m_iox_pub, ice_hdr);
+    }
+  }
+#endif
 
   tk = ddsi_tkmap_lookup_instance_ref (ddsi_wr->e.gv->m_tkmap, dact);
   // write_sample_gc always consumes 1 refc from dact

--- a/src/core/ddsi/src/ddsi_sertype.c
+++ b/src/core/ddsi/src/ddsi_sertype.c
@@ -210,9 +210,9 @@ void ddsi_sertype_init_flags (struct ddsi_sertype *tp, const char *type_name, co
   tp->ops = sertype_ops;
   tp->serdata_ops = serdata_ops;
   tp->serdata_basehash = ddsi_sertype_compute_serdata_basehash (tp->serdata_ops);
-  tp->typekind_no_key = (flags & DDSI_SERTYPE_FLAG_TOPICKIND_NO_KEY) ? 1 : 0;
-  tp->request_keyhash = (flags & DDSI_SERTYPE_FLAG_REQUEST_KEYHASH) ? 1 : 0;
-  tp->fixed_size = (flags & DDSI_SERTYPE_FLAG_FIXED_SIZE) ? 1 : 0;
+  tp->typekind_no_key = (flags & DDSI_SERTYPE_FLAG_TOPICKIND_NO_KEY) ? 1u : 0u;
+  tp->request_keyhash = (flags & DDSI_SERTYPE_FLAG_REQUEST_KEYHASH) ? 1u : 0u;
+  tp->fixed_size = (flags & DDSI_SERTYPE_FLAG_FIXED_SIZE) ? 1u : 0u;
   tp->wrapped_sertopic = NULL;
 #ifdef DDS_HAS_SHM
   tp->iox_size = 0;


### PR DESCRIPTION
This MR adds the following:

1. Updates `dds_writecdr_impl` to work with iceoryx if SHM is enabled
2. Fix compiler warning when setting ddsi_sertype init flags