### PR TITLE
Fix for discstress test failure

### DIFF
--- a/src/core/ddsc/tests/CMakeLists.txt
+++ b/src/core/ddsc/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ set(ddsc_test_sources
     "entity_hierarchy.c"
     "entity_status.c"
     "err.c"
+    "fastpath.c"
     "filter.c"
     "instance_get_key.c"
     "instance_handle.c"

--- a/src/core/ddsc/tests/fastpath.c
+++ b/src/core/ddsc/tests/fastpath.c
@@ -1,0 +1,245 @@
+/*
+ * Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include <assert.h>
+#include <limits.h>
+
+#include "dds/dds.h"
+#include "config_env.h"
+
+#include "dds/version.h"
+#include "dds__entity.h"
+#include "dds/ddsi/q_entity.h"
+#include "dds/ddsi/ddsi_serdata.h"
+#include "dds/ddsi/ddsi_entity_index.h"
+#include "dds/ddsrt/cdtors.h"
+#include "dds/ddsrt/misc.h"
+#include "dds/ddsrt/process.h"
+#include "dds/ddsrt/threads.h"
+#include "dds/ddsrt/environ.h"
+#include "dds/ddsrt/atomics.h"
+#include "dds/ddsrt/time.h"
+
+#include "test_common.h"
+
+#define DDS_DOMAINID_PUB 0
+#define DDS_DOMAINID_SUB 1
+#define DDS_CONFIG_NO_PORT_GAIN "${CYCLONEDDS_URI}${CYCLONEDDS_URI:+,}<Discovery><ExternalDomainId>0</ExternalDomainId></Discovery>"
+
+#define NUM_READERS 2
+#define NUM_WRITERS 1
+
+static dds_entity_t g_pub_domain = 0;
+static dds_entity_t g_pub_participant = 0;
+static dds_entity_t g_pub_publisher = 0;
+
+static dds_entity_t g_sub_domain = 0;
+static dds_entity_t g_sub_participant = 0;
+static dds_entity_t g_sub_subscriber = 0;
+
+static void fastpath_init (void)
+{
+  /* Domains for pub and sub use a different domain id, but the portgain setting
+   * in configuration is 0, so that both domains will map to the same port number.
+   * This allows to create two domains in a single test process. */
+  char *conf_pub = ddsrt_expand_envvars (DDS_CONFIG_NO_PORT_GAIN, DDS_DOMAINID_PUB);
+  char *conf_sub = ddsrt_expand_envvars (DDS_CONFIG_NO_PORT_GAIN, DDS_DOMAINID_SUB);
+  g_pub_domain = dds_create_domain (DDS_DOMAINID_PUB, conf_pub);
+  g_sub_domain = dds_create_domain (DDS_DOMAINID_SUB, conf_sub);
+  dds_free (conf_pub);
+  dds_free (conf_sub);
+
+  g_pub_participant = dds_create_participant(DDS_DOMAINID_PUB, NULL, NULL);
+  CU_ASSERT_FATAL (g_pub_participant > 0);
+  g_sub_participant = dds_create_participant(DDS_DOMAINID_SUB, NULL, NULL);
+  CU_ASSERT_FATAL (g_sub_participant > 0);
+
+  g_pub_publisher = dds_create_publisher(g_pub_participant, NULL, NULL);
+  CU_ASSERT_FATAL (g_pub_publisher > 0);
+  g_sub_subscriber = dds_create_subscriber(g_sub_participant, NULL, NULL);
+  CU_ASSERT_FATAL (g_sub_subscriber > 0);
+}
+
+static void fastpath_fini (void)
+{
+  dds_delete (g_sub_domain);
+  dds_delete (g_pub_domain);
+}
+
+static bool get_and_check_writer_status (size_t nwr, const dds_entity_t *wrs, size_t nrd)
+{
+  dds_return_t rc;
+  struct dds_publication_matched_status x;
+  bool result = true;
+  for (size_t i = 0; i < nwr; i++)
+  {
+    rc = dds_get_publication_matched_status (wrs[i], &x);
+    CU_ASSERT_FATAL (rc == DDS_RETCODE_OK);
+    if (x.current_count != nrd)
+      result = false;
+  }
+  return result;
+}
+
+static bool get_and_check_reader_status (size_t nrd, const dds_entity_t *rds, size_t nwr)
+{
+  dds_return_t rc;
+  struct dds_subscription_matched_status x;
+  bool result = true;
+  for (size_t i = 0; i < nrd; i++)
+  {
+    rc = dds_get_subscription_matched_status (rds[i], &x);
+    CU_ASSERT_FATAL (rc == DDS_RETCODE_OK);
+    if (x.current_count != nwr)
+      result = false;
+  }
+  return result;
+}
+
+CU_Test(ddsc_fastpath, no_write, .init = fastpath_init, .fini = fastpath_fini)
+{
+  char name[100];
+  dds_entity_t pub_topic, writers[NUM_WRITERS], sub_topic, readers[NUM_READERS];
+  dds_entity_t waitset;
+  dds_qos_t *qos;
+  dds_return_t rc;
+
+  waitset = dds_create_waitset (DDS_CYCLONEDDS_HANDLE);
+  CU_ASSERT_FATAL (waitset > 0);
+
+  qos = dds_create_qos ();
+  CU_ASSERT_FATAL (qos != NULL);
+  dds_qset_reliability (qos, DDS_RELIABILITY_RELIABLE, DDS_INFINITY);
+  dds_qset_destination_order (qos, DDS_DESTINATIONORDER_BY_RECEPTION_TIMESTAMP);
+  dds_qset_history (qos, DDS_HISTORY_KEEP_ALL, 0);
+  create_unique_topic_name ("ddsc_fastpath_test", name, sizeof name);
+  pub_topic = dds_create_topic (g_pub_participant, &Space_Type1_desc, name, qos, NULL);
+  CU_ASSERT_FATAL (pub_topic > 0);
+  sub_topic = dds_create_topic (g_sub_participant, &Space_Type1_desc, name, qos, NULL);
+  CU_ASSERT_FATAL (sub_topic > 0);
+  for (size_t i = 0; i < sizeof (writers) / sizeof (writers[0]); i++)
+  {
+    writers[i] = dds_create_writer (g_pub_participant, pub_topic, qos, NULL);
+    CU_ASSERT_FATAL (writers[i] > 0);
+  }
+
+  for (size_t i = 0; i < sizeof (readers) / sizeof (readers[0]); i++)
+  {
+    readers[i] = dds_create_reader (g_sub_participant, sub_topic, qos, NULL);
+    CU_ASSERT_FATAL (readers[i] > 0);
+    rc = dds_set_status_mask (readers[i], DDS_SUBSCRIPTION_MATCHED_STATUS);
+    CU_ASSERT_FATAL (rc == DDS_RETCODE_OK);
+    rc = dds_waitset_attach (waitset, readers[i], (dds_attach_t)i);
+    CU_ASSERT_FATAL (rc == DDS_RETCODE_OK);
+  }
+
+  for (size_t i = 0; i < sizeof (writers) / sizeof (writers[0]); i++)
+  {
+    rc = dds_set_status_mask (writers[i], DDS_PUBLICATION_MATCHED_STATUS);
+    CU_ASSERT_FATAL (rc == DDS_RETCODE_OK);
+    rc = dds_waitset_attach (waitset, writers[i], -(dds_attach_t)i - 1);
+    CU_ASSERT_FATAL (rc == DDS_RETCODE_OK);
+  }
+
+  printf ("match all readers/writers\n");
+  bool rds = false, wrs = false;
+  do
+  {
+    rc = dds_waitset_wait (waitset, NULL, 0, DDS_SECS(10));
+    CU_ASSERT_FATAL (rc >= 1);
+    wrs = get_and_check_writer_status (sizeof (writers) / sizeof (writers[0]), writers, sizeof (readers) / sizeof (readers[0]));
+    rds = get_and_check_reader_status (sizeof (readers) / sizeof (readers[0]), readers, sizeof (writers) / sizeof (writers[0]));
+  }
+  while (!wrs || !rds);
+
+  printf ("set fastpath off for all readers\n");
+  for (size_t i = 0; i < sizeof (readers) / sizeof (readers[0]); i++)
+    waitfor_or_reset_fastpath (readers[i], false, sizeof (writers) / sizeof (writers[0]));
+
+  printf ("wait for fastpath restored on all readers\n");
+  for (size_t i = 0; i < sizeof (readers) / sizeof (readers[0]); i++)
+    waitfor_or_reset_fastpath (readers[i], true, sizeof (writers) / sizeof (writers[0]));
+
+  dds_delete_qos (qos);
+}
+
+
+CU_Test(ddsc_fastpath, pwr_sync, .init = fastpath_init, .fini = fastpath_fini)
+{
+  char name[100];
+  dds_entity_t pub_topic, writer, sub_topic, reader;
+
+  printf ("set sub domain deaf-mute\n");
+  dds_domain_set_deafmute (g_sub_domain, true, true, DDS_INFINITY);
+
+  dds_qos_t *wqos = dds_create_qos ();
+  CU_ASSERT_FATAL (wqos != NULL);
+  dds_qset_reliability (wqos, DDS_RELIABILITY_RELIABLE, DDS_INFINITY);
+  dds_qset_history (wqos, DDS_HISTORY_KEEP_ALL, 0);
+  dds_qset_durability (wqos, DDS_DURABILITY_TRANSIENT_LOCAL);
+  create_unique_topic_name ("ddsc_fastpath_test2", name, sizeof name);
+  pub_topic = dds_create_topic (g_pub_participant, &Space_Type1_desc, name, wqos, NULL);
+  CU_ASSERT_FATAL (pub_topic > 0);
+
+  writer = dds_create_writer (g_pub_participant, pub_topic, wqos, NULL);
+  CU_ASSERT_FATAL (writer > 0);
+
+  Space_Type1 sample = {0, 0, 0};
+  for (int32_t i = 0; i < 3; i++)
+  {
+    sample.long_1 = i;
+    dds_write (writer, &sample);
+  }
+
+  printf ("disable sub domain deaf-mute\n");
+  dds_domain_set_deafmute (g_sub_domain, false, false, DDS_INFINITY);
+
+  dds_qos_t *rqos = dds_create_qos ();
+  CU_ASSERT_FATAL (rqos != NULL);
+  dds_qset_reliability (rqos, DDS_RELIABILITY_RELIABLE, DDS_INFINITY);
+  dds_qset_history (rqos, DDS_HISTORY_KEEP_LAST, 3);
+  dds_qset_durability (rqos, DDS_DURABILITY_VOLATILE);
+  sub_topic = dds_create_topic (g_sub_participant, &Space_Type1_desc, name, rqos, NULL);
+  CU_ASSERT_FATAL (sub_topic > 0);
+  reader = dds_create_reader (g_sub_participant, sub_topic, rqos, NULL);
+  CU_ASSERT_FATAL (reader > 0);
+
+  printf ("sync reader/writer\n");
+  sync_reader_writer (g_sub_participant, reader, g_pub_participant, writer);
+
+  sample.long_1 = 4;
+  dds_write (writer, &sample);
+
+  printf ("read data\n");
+  void *raw[1] = { NULL };
+  dds_sample_info_t si[1];
+  int32_t n, n_read = 0;
+  dds_return_t rc;
+  while (n_read < 1)
+  {
+    n = dds_take (reader, raw, si, 1, 1);
+    if (n > 0 && si[0].valid_data)
+    {
+      n_read += n;
+      Space_Type1 const * const s = raw[0];
+      CU_ASSERT_EQUAL_FATAL (s->long_1, 4);
+    }
+    rc = dds_return_loan (reader, raw, n);
+    CU_ASSERT_FATAL (rc == 0);
+    dds_sleepfor (DDS_MSECS (100));
+  }
+
+  printf ("wait for fastpath\n");
+  waitfor_or_reset_fastpath (reader, true, 1);
+
+  dds_delete_qos (wqos);
+  dds_delete_qos (rqos);
+}

--- a/src/core/ddsc/tests/test_common.c
+++ b/src/core/ddsc/tests/test_common.c
@@ -10,9 +10,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
 #include "dds/dds.h"
+#include "dds__entity.h"
 #include "dds/ddsrt/atomics.h"
 #include "dds/ddsrt/process.h"
 #include "dds/ddsrt/threads.h"
+#include "dds/ddsi/q_entity.h"
+#include "dds/ddsi/ddsi_entity_index.h"
 #include "test_common.h"
 
 void sync_reader_writer (dds_entity_t participant_rd, dds_entity_t reader, dds_entity_t participant_wr, dds_entity_t writer)
@@ -29,7 +32,7 @@ void sync_reader_writer (dds_entity_t participant_rd, dds_entity_t reader, dds_e
   CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
   ret = dds_waitset_attach (waitset_rd, reader, reader);
   CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
-  ret = dds_waitset_wait (waitset_rd, &triggered, 1, DDS_SECS (1));
+  ret = dds_waitset_wait (waitset_rd, &triggered, 1, DDS_SECS (5));
   CU_ASSERT_EQUAL_FATAL (ret, 1);
   CU_ASSERT_EQUAL_FATAL (reader, (dds_entity_t)(intptr_t) triggered);
   ret = dds_waitset_detach (waitset_rd, reader);
@@ -41,10 +44,78 @@ void sync_reader_writer (dds_entity_t participant_rd, dds_entity_t reader, dds_e
   CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
   ret = dds_waitset_attach (waitset_wr, writer, writer);
   CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
-  ret = dds_waitset_wait (waitset_wr, &triggered, 1, DDS_SECS (1));
+  ret = dds_waitset_wait (waitset_wr, &triggered, 1, DDS_SECS (5));
   CU_ASSERT_EQUAL_FATAL (ret, 1);
   CU_ASSERT_EQUAL_FATAL (writer, (dds_entity_t)(intptr_t) triggered);
   ret = dds_waitset_detach (waitset_wr, writer);
   CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
   dds_delete (waitset_wr);
+}
+
+void waitfor_or_reset_fastpath (dds_entity_t rdhandle, bool fastpath, size_t nwr)
+{
+  dds_return_t rc;
+  struct dds_entity *x;
+
+  rc = dds_entity_pin (rdhandle, &x);
+  CU_ASSERT_FATAL (rc == DDS_RETCODE_OK);
+  CU_ASSERT_FATAL (dds_entity_kind (x) == DDS_KIND_READER);
+
+  struct reader * const rd = ((struct dds_reader *) x)->m_rd;
+  struct rd_pwr_match *m;
+  ddsi_guid_t cursor;
+  size_t wrcount = 0;
+  thread_state_awake (lookup_thread_state (), rd->e.gv);
+  ddsrt_mutex_lock (&rd->e.lock);
+
+  memset (&cursor, 0, sizeof (cursor));
+  while ((m = ddsrt_avl_lookup_succ (&rd_writers_treedef, &rd->writers, &cursor)) != NULL)
+  {
+    cursor = m->pwr_guid;
+    ddsrt_mutex_unlock (&rd->e.lock);
+    struct proxy_writer * const pwr = entidx_lookup_proxy_writer_guid (rd->e.gv->entity_index, &cursor);
+    ddsrt_mutex_lock (&pwr->rdary.rdary_lock);
+    if (!fastpath)
+      pwr->rdary.fastpath_ok = false;
+    else
+    {
+      while (!pwr->rdary.fastpath_ok)
+      {
+        ddsrt_mutex_unlock (&pwr->rdary.rdary_lock);
+        dds_sleepfor (DDS_MSECS (10));
+        ddsrt_mutex_lock (&pwr->rdary.rdary_lock);
+      }
+    }
+    wrcount++;
+    ddsrt_mutex_unlock (&pwr->rdary.rdary_lock);
+    ddsrt_mutex_lock (&rd->e.lock);
+  }
+
+  memset (&cursor, 0, sizeof (cursor));
+  while ((m = ddsrt_avl_lookup_succ (&rd_local_writers_treedef, &rd->local_writers, &cursor)) != NULL)
+  {
+    cursor = m->pwr_guid;
+    ddsrt_mutex_unlock (&rd->e.lock);
+    struct writer * const wr = entidx_lookup_writer_guid (rd->e.gv->entity_index, &cursor);
+    ddsrt_mutex_lock (&wr->rdary.rdary_lock);
+    if (!fastpath)
+      wr->rdary.fastpath_ok = fastpath;
+    else
+    {
+      while (!wr->rdary.fastpath_ok)
+      {
+        ddsrt_mutex_unlock (&wr->rdary.rdary_lock);
+        dds_sleepfor (DDS_MSECS (10));
+        ddsrt_mutex_lock (&wr->rdary.rdary_lock);
+      }
+    }
+    wrcount++;
+    ddsrt_mutex_unlock (&wr->rdary.rdary_lock);
+    ddsrt_mutex_lock (&rd->e.lock);
+  }
+  ddsrt_mutex_unlock (&rd->e.lock);
+  thread_state_asleep (lookup_thread_state ());
+  dds_entity_unpin (x);
+
+  CU_ASSERT_FATAL (wrcount == nwr);
 }

--- a/src/core/ddsc/tests/test_common.h
+++ b/src/core/ddsc/tests/test_common.h
@@ -18,9 +18,19 @@
 #include "CUnit/Test.h"
 #include "CUnit/Theory.h"
 
-#include "test_util.h"
+#include "test_common.h"
 
 #include "Space.h"
 #include "RoundTrip.h"
+
+/* Get unique g_topic name on each invocation. */
+char *create_unique_topic_name (const char *prefix, char *name, size_t size);
+
+/* Sync the reader to the writer and writer to reader */
+void sync_reader_writer (dds_entity_t participant_rd, dds_entity_t reader, dds_entity_t participant_wr, dds_entity_t writer);
+
+/* Wait for all (proxy and local) writers for the reader are in fastpath mode (fastpath param = true),
+   or reset to non-fastpath (fastpath param = false). Assert nwr writers (local + proxy) */
+void waitfor_or_reset_fastpath (dds_entity_t rdhandle, bool fastpath, size_t nwr);
 
 #endif /* _TEST_COMMON_H_ */

--- a/src/core/ddsc/tests/test_util.h
+++ b/src/core/ddsc/tests/test_util.h
@@ -18,7 +18,4 @@
 /* Get unique g_topic name on each invocation. */
 char *create_unique_topic_name (const char *prefix, char *name, size_t size);
 
-/* Sync the reader to the writer and writer to reader */
-void sync_reader_writer (dds_entity_t participant_rd, dds_entity_t reader, dds_entity_t participant_wr, dds_entity_t writer);
-
 #endif /* _TEST_UTIL_H_ */

--- a/src/core/ddsi/include/dds/ddsi/q_entity.h
+++ b/src/core/ddsi/include/dds/ddsi/q_entity.h
@@ -134,6 +134,7 @@ struct wr_prd_match {
   seqno_t max_seq; /* sort-of highest ack'd seq nr in subtree (see augment function) */
   seqno_t seq; /* highest acknowledged seq nr */
   seqno_t last_seq; /* highest seq send to this reader used when filter is applied */
+  seqno_t init_seq; /* initial sequence number when connected the reader */
   uint32_t num_reliable_readers_where_seq_equals_max;
   ddsi_guid_t arbitrary_unacked_reader;
   nn_count_t prev_acknack; /* latest accepted acknack sequence number */
@@ -179,8 +180,9 @@ struct pwr_rd_match {
   unsigned ack_requested : 1; /* set on receipt of HEARTBEAT with FINAL clear, cleared on sending an ACKNACK */
   unsigned heartbeat_since_ack : 1; /* set when a HEARTBEAT has been received since the last ACKNACK */
   unsigned heartbeatfrag_since_ack : 1; /* set when a HEARTBEATFRAG has been received since the last ACKNACK */
-  unsigned directed_heartbeat : 1; /* set on receipt of a directed heartbeat, cleared on sending an ACKNACK */
+  unsigned directed_heartbeat_since_ack : 1; /* set on receipt of a directed heartbeat, cleared on sending an ACKNACK */
   unsigned nack_sent_on_nackdelay : 1; /* set when the most recent NACK sent was because of the NackDelay  */
+  unsigned has_seen_directed_heartbeat : 1; /* has seen a heartbeat that was directed at this specific reader */
   unsigned filtered : 1;
   union {
     struct {

--- a/src/core/ddsi/include/dds/ddsi/q_transmit.h
+++ b/src/core/ddsi/include/dds/ddsi/q_transmit.h
@@ -43,7 +43,7 @@ int write_sample_nogc_notk (struct thread_state1 * const ts1, struct nn_xpack *x
 dds_return_t create_fragment_message (struct writer *wr, seqno_t seq, const struct ddsi_plist *plist, struct ddsi_serdata *serdata, uint32_t fragnum, uint16_t nfrags, struct proxy_reader *prd,struct nn_xmsg **msg, int isnew, uint32_t advertised_fragnum);
 int enqueue_sample_wrlock_held (struct writer *wr, seqno_t seq, const struct ddsi_plist *plist, struct ddsi_serdata *serdata, struct proxy_reader *prd, int isnew);
 void enqueue_spdp_sample_wrlock_held (struct writer *wr, seqno_t seq, struct ddsi_serdata *serdata, struct proxy_reader *prd);
-void add_Heartbeat (struct nn_xmsg *msg, struct writer *wr, const struct whc_state *whcst, int hbansreq, int hbliveliness, ddsi_entityid_t dst, int issync);
+void add_Heartbeat (struct nn_xmsg *msg, struct writer *wr, const struct whc_state *whcst, int hbansreq, int hbliveliness, ddsi_entityid_t dst, seqno_t rd_match_seq, bool has_replied_to_hb, int issync);
 dds_return_t write_hb_liveliness (struct ddsi_domaingv * const gv, struct ddsi_guid *wr_guid, struct nn_xpack *xp);
 int write_sample_p2p_wrlock_held(struct writer *wr, seqno_t seq, struct ddsi_plist *plist, struct ddsi_serdata *serdata, struct ddsi_tkmap_instance *tk, struct proxy_reader *prd);
 

--- a/src/core/ddsi/src/ddsi_acknack.c
+++ b/src/core/ddsi/src/ddsi_acknack.c
@@ -302,7 +302,7 @@ static enum add_AckNack_result get_AckNack_info (const struct proxy_writer *pwr,
 #endif
       result = AANR_NACK;
     }
-    else if (rwn->directed_heartbeat && (!rwn->nack_sent_on_nackdelay || nackdelay_passed))
+    else if (rwn->directed_heartbeat_since_ack && (!rwn->nack_sent_on_nackdelay || nackdelay_passed))
     {
       info->nack_sent_on_nackdelay = false;
 #if ACK_REASON_IN_FLAGS
@@ -408,7 +408,7 @@ struct nn_xmsg *make_and_resched_acknack (struct xevent *ev, struct proxy_writer
   // possibility of not sending a message, but that is only in case of failures of some sort.
   // Resetting the flags and bailing out simply means we will wait until the next heartbeat to
   // do try again.
-  rwn->directed_heartbeat = 0;
+  rwn->directed_heartbeat_since_ack = 0;
   rwn->heartbeat_since_ack = 0;
   rwn->heartbeatfrag_since_ack = 0;
   rwn->nack_sent_on_nackdelay = (info.nack_sent_on_nackdelay ? 1 : 0);


### PR DESCRIPTION
These changes fix the issue that causes the discstress test to fail (issue #275), particularly when running this test with some packet loss and using an increased writer linger duration. As I'm not sure of the side effects this fix may have, I've put this PR in draft state. It needs some more research (and tests) to find out the consequences of the changed behavior with respect to sending and handling heartbeats and gaps, e.g. because a reader can get ahead of its proxy writer, as mentioned in issue #275. 

The changes in the way heartbeats and gaps are send and handled by the proxy writer and reader:
- A reader is only set in-sync after it has received a directed heartbeat.
- Readers keep sending pre-emptive nacks until a directed heartbeat for the match with the writer is received, so that the reader will properly set its initial sequence number, which can be higher than the proxy writer's current sequence number in case of a volatile reader that joined later.
- The writer sends directed heartbeats with a seqno of at least 1 + the seqno at the moment of matching the (volatile) reader.
- Handle a gap message only for the targeted reader if the reader is not in sync. If the reader is in sync, also apply the gap to the
  proxy writer's reorder buffer
