### PR TITLE
Fix for unittests and removed unnecessary code

### DIFF
--- a/src/core/ddsc/tests/data_avail_stress.c
+++ b/src/core/ddsc/tests/data_avail_stress.c
@@ -88,7 +88,23 @@ static void setup (bool remote, struct writethread_arg *wrarg)
 {
   // Creating/deleting readers while writing becomes interesting
   // only once the network is lossy.
+#ifdef DDS_HAS_SHM
   const char *config = "${CYCLONEDDS_URI}${CYCLONEDDS_URI:+,}\
+    <Discovery>\
+      <ExternalDomainId>0</ExternalDomainId>\
+    </Discovery>\
+    <Domain id=\"any\">\
+      <SharedMemory>\
+        <Enable>false</Enable>\
+      </SharedMemory>\
+    </Domain>\
+    <Internal>\
+      <Test>\
+        <XmitLossiness>100</XmitLossiness>\
+      </Test>\
+    </Internal>";
+#else
+  const char* config = "${CYCLONEDDS_URI}${CYCLONEDDS_URI:+,}\
     <Discovery>\
       <ExternalDomainId>0</ExternalDomainId>\
     </Discovery>\
@@ -97,6 +113,7 @@ static void setup (bool remote, struct writethread_arg *wrarg)
         <XmitLossiness>100</XmitLossiness>\
       </Test>\
     </Internal>";
+#endif
   char *conf_pub = ddsrt_expand_envvars (config, 0);
   char *conf_sub = ddsrt_expand_envvars (config, 1);
   pub_dom = dds_create_domain (0, conf_pub);

--- a/src/core/ddsc/tests/dispose.c
+++ b/src/core/ddsc/tests/dispose.c
@@ -31,6 +31,7 @@ static dds_entity_t g_topic       = 0;
 static dds_entity_t g_reader      = 0;
 static dds_entity_t g_writer      = 0;
 static dds_entity_t g_waitset     = 0;
+static dds_entity_t g_domain      = 0;
 
 static dds_time_t   g_past        = 0;
 static dds_time_t   g_present     = 0;
@@ -52,7 +53,15 @@ disposing_init(void)
     /* Use by source timestamp to be able to check the time related funtions. */
     dds_qset_destination_order(qos, DDS_DESTINATIONORDER_BY_SOURCE_TIMESTAMP);
 
-    g_participant = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL, NULL);
+#ifdef DDS_HAS_SHM
+    const char* config = "<Domain id=\"any\"><SharedMemory><Enable>false</Enable></SharedMemory></Domain>";
+#else
+    const char* config = "";
+#endif
+    g_domain = dds_create_domain(0, config);
+    CU_ASSERT_FATAL(g_domain > 0);
+
+    g_participant = dds_create_participant(0, NULL, NULL);
     CU_ASSERT_FATAL(g_participant > 0);
 
     g_waitset = dds_create_waitset(g_participant);
@@ -124,6 +133,7 @@ disposing_fini(void)
     dds_delete(g_waitset);
     dds_delete(g_topic);
     dds_delete(g_participant);
+    dds_delete(g_domain);
 }
 
 

--- a/src/core/ddsc/tests/register.c
+++ b/src/core/ddsc/tests/register.c
@@ -32,6 +32,7 @@ static dds_entity_t g_topic       = 0;
 static dds_entity_t g_reader      = 0;
 static dds_entity_t g_writer      = 0;
 static dds_entity_t g_waitset     = 0;
+static dds_entity_t g_domain      = 0;
 
 static dds_time_t   g_past        = 0;
 static dds_time_t   g_present     = 0;
@@ -51,7 +52,15 @@ registering_init(void)
     /* Use by source timestamp to be able to check the time related funtions. */
     dds_qset_destination_order(qos, DDS_DESTINATIONORDER_BY_SOURCE_TIMESTAMP);
 
-    g_participant = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL, NULL);
+#ifdef DDS_HAS_SHM
+    const char* config = "<Domain id=\"any\"><SharedMemory><Enable>false</Enable></SharedMemory></Domain>";
+#else
+    const char* config = "";
+#endif
+    g_domain = dds_create_domain(0, config);
+    CU_ASSERT_FATAL(g_domain > 0);
+
+    g_participant = dds_create_participant(0, NULL, NULL);
     CU_ASSERT_FATAL(g_participant > 0);
 
     g_waitset = dds_create_waitset(g_participant);
@@ -123,6 +132,7 @@ registering_fini(void)
     dds_delete(g_waitset);
     dds_delete(g_topic);
     dds_delete(g_participant);
+    dds_delete(g_domain);
 }
 
 

--- a/src/core/ddsc/tests/unregister.c
+++ b/src/core/ddsc/tests/unregister.c
@@ -31,6 +31,7 @@ static dds_entity_t g_topic       = 0;
 static dds_entity_t g_reader      = 0;
 static dds_entity_t g_writer      = 0;
 static dds_entity_t g_waitset     = 0;
+static dds_entity_t g_domain      = 0;
 
 static dds_time_t   g_past        = 0;
 static dds_time_t   g_present     = 0;
@@ -51,7 +52,15 @@ unregistering_init(void)
     /* Use by source timestamp to be able to check the time related funtions. */
     dds_qset_destination_order(qos, DDS_DESTINATIONORDER_BY_SOURCE_TIMESTAMP);
 
-    g_participant = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL, NULL);
+#ifdef DDS_HAS_SHM
+    const char* config = "<Domain id=\"any\"><SharedMemory><Enable>false</Enable></SharedMemory></Domain>";
+#else
+    const char* config = "";
+#endif
+    g_domain = dds_create_domain(0, config);
+    CU_ASSERT_FATAL(g_domain > 0);
+
+    g_participant = dds_create_participant(0, NULL, NULL);
     CU_ASSERT_FATAL(g_participant > 0);
 
     g_waitset = dds_create_waitset(g_participant);
@@ -123,6 +132,7 @@ unregistering_fini(void)
     dds_delete(g_waitset);
     dds_delete(g_topic);
     dds_delete(g_participant);
+    dds_delete(g_domain);
 }
 
 

--- a/src/core/ddsi/include/dds/ddsi/shm_sync.h
+++ b/src/core/ddsi/include/dds/ddsi/shm_sync.h
@@ -31,11 +31,6 @@ typedef struct {
     struct dds_reader* parent_reader;
 } iox_sub_storage_extension_t;
 
-// lock and unlock global shared memory mutex
-DDS_EXPORT int shm_mutex_init(void);
-DDS_EXPORT void shm_mutex_lock(void);
-DDS_EXPORT void shm_mutex_unlock(void);
-
 //lock and unlock for individual subscribers
 DDS_EXPORT void iox_sub_storage_extension_init(iox_sub_storage_extension_t* storage);
 DDS_EXPORT void iox_sub_storage_extension_fini(iox_sub_storage_extension_t* storage);

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -1195,8 +1195,6 @@ int rtps_init (struct ddsi_domaingv *gv)
     GVLOG (DDS_LC_SHM, "My iceoryx address: %s, Port: %d\n", sptr, pid);
     memset ((char *) gv->loc_iceoryx_addr.address, 0, sizeof (gv->loc_iceoryx_addr.address));
     ddsrt_strlcpy ((char *) gv->loc_iceoryx_addr.address, sptr, strlen (sptr));
-
-    shm_mutex_init();
   }
 #endif
 

--- a/src/core/ddsi/src/shm_sync.c
+++ b/src/core/ddsi/src/shm_sync.c
@@ -11,30 +11,6 @@
  */
 #include "dds/ddsi/shm_sync.h"
 
-static ddsrt_mutex_t shm_mutex;
-static int shm_mutex_initialized = 0;
-
-int shm_mutex_init()
-{
-  if (shm_mutex_initialized)
-    return 1;
-
-  ddsrt_mutex_init(&shm_mutex);
-  shm_mutex_initialized = 1;
-
-  return 0;
-}
-
-void shm_mutex_lock(void)
-{
-  ddsrt_mutex_lock(&shm_mutex);
-}
-
-void shm_mutex_unlock(void)
-{
-  ddsrt_mutex_unlock(&shm_mutex);
-}
-
 void iox_sub_storage_extension_init(iox_sub_storage_extension_t *storage)
 {
   storage->monitor = NULL;


### PR DESCRIPTION
Fixed unitests for dispose/(un)register by disabling shared memory for these tests.
Removed unnecessary shared memory global mutex related code