### PR TITLE
Declare hashid.c file as GENERATED to solve cmake warning

### DIFF
--- a/src/idl/CMakeLists.txt
+++ b/src/idl/CMakeLists.txt
@@ -37,6 +37,8 @@ foreach(func ddsrt_md5_init ddsrt_md5_append ddsrt_md5_finish)
 endforeach()
 
 configure_file(src/hashid.c.in ${CMAKE_CURRENT_BINARY_DIR}/hashid.c @ONLY)
+# Might not be needed in the future to declare GENERATED https://gitlab.kitware.com/cmake/cmake/-/issues/21993
+set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/hashid.c PROPERTIES GENERATED TRUE)
 
 add_library(
   idl SHARED


### PR DESCRIPTION
CMake does not consider the configured file as a file with extension in newer versions. While [upstream fix it](https://gitlab.kitware.com/cmake/cmake/-/issues/21993), I think there is no hurt on declaring it as GENERATED.

Tested: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=14407)](https://ci.ros2.org/job/ci_windows/14407/)

close: #741 