### PR TITLE
Add statusinfo to iceoryx header

### DIFF
--- a/src/core/ddsc/src/dds_write.c
+++ b/src/core/ddsc/src/dds_write.c
@@ -339,6 +339,7 @@ dds_return_t dds_write_impl (dds_writer *wr, const void * data, dds_time_t tstam
       ice_hdr = SHIFT_BACK_TO_ICEORYX_HEADER(data);
       ice_hdr->guid = ddsi_wr->e.guid;
       ice_hdr->tstamp = tstamp;
+      ice_hdr->statusinfo = d->statusinfo;
       ice_hdr->data_kind = writekey ? SDK_KEY : SDK_DATA;
       ddsi_serdata_get_keyhash(d, &ice_hdr->keyhash, false);
       iox_pub_publish_chunk (wr->m_iox_pub, ice_hdr);
@@ -456,6 +457,7 @@ static dds_return_t dds_writecdr_impl_common (struct writer *ddsi_wr, struct nn_
       suppress_local_delivery = true;
       ice_hdr->guid = ddsi_wr->e.guid;
       ice_hdr->tstamp = dinp->timestamp.v;
+      ice_hdr->statusinfo = dinp->statusinfo;
       ice_hdr->data_kind = (unsigned char)dinp->kind;
       ddsi_serdata_get_keyhash (dinp, &ice_hdr->keyhash, false);
       // iox_pub_publish_chunk takes ownership, storing a null pointer here doesn't

--- a/src/core/ddsc/src/shm_monitor.c
+++ b/src/core/ddsc/src/shm_monitor.c
@@ -126,6 +126,7 @@ static void receive_data_wakeup_handler(struct dds_reader* rd)
     struct ddsi_serdata* d = ddsi_serdata_from_iox(rd->m_topic->m_stype, ice_hdr->data_kind, &rd->m_iox_sub, chunk);
     //keyhash needs to be set here
     d->timestamp.v = ice_hdr->tstamp;
+    d->statusinfo = ice_hdr->statusinfo;
 
     // Get struct ddsi_tkmap_instance
     struct ddsi_tkmap_instance* tk;

--- a/src/core/ddsi/include/dds/ddsi/q_xmsg.h
+++ b/src/core/ddsi/include/dds/ddsi/q_xmsg.h
@@ -58,6 +58,7 @@ enum nn_xmsg_kind {
 struct iceoryx_header {
    struct ddsi_guid guid;
    dds_time_t tstamp;
+   uint32_t statusinfo;
    uint32_t data_size;
    unsigned char data_kind;
    ddsi_keyhash_t keyhash;


### PR DESCRIPTION
Without this, disposes/unregisters will be misinterpreted as writes.

@e-hndrks or @reicheratwork, care to review?