### PR TITLE
Build src/core/xtests only if BUILD_TESTING

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -64,7 +64,7 @@ install(
   ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT lib
 )
 
-if(BUILD_IDLC)
+if(BUILD_TESTING AND BUILD_IDLC)
   add_subdirectory(xtests)
 endif()
 

--- a/src/core/xtests/CMakeLists.txt
+++ b/src/core/xtests/CMakeLists.txt
@@ -9,5 +9,6 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
+include(CUnit)
 add_subdirectory(rhc_torture)
 add_subdirectory(initsampledeliv)

--- a/src/core/xtests/rhc_torture/CMakeLists.txt
+++ b/src/core/xtests/rhc_torture/CMakeLists.txt
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
 idlc_generate(TARGET RhcTypes FILES RhcTypes.idl)
-include(${CMAKE_CURRENT_LIST_DIR}/../../../../cmake/Modules/CUnit.cmake)
 
 add_executable(rhc_torture rhc_torture.c)
 


### PR DESCRIPTION
This removes the hard dependency on CUnit that (I think) was introduced to work around a "rpath" issue in the Iceoryx libraries.