### PR TITLE
Fix for mixing shared memory and network readers

### DIFF
--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -1185,7 +1185,7 @@ int rtps_init (struct ddsi_domaingv *gv)
 
     gv->loc_iceoryx_addr.tran = NULL;
     gv->loc_iceoryx_addr.kind = NN_LOCATOR_KIND_SHEM;
-    gv->loc_iceoryx_addr.port = pid;
+    gv->loc_iceoryx_addr.port = 0;
     if (ddsrt_eth_get_mac_addr (gv->interfaces[gv->selected_interface].name, mac_addr))
     {
       GVLOG (DDS_LC_SHM, "Unable to get MAC address for iceoryx\n");


### PR DESCRIPTION
Mixing iceoryx enabled readers with non-enabled readers caused
the writer to fall back to using the UDP broadcast, even though
it should use iceoryx for the readers that support it.
This is fixed by removing the process-id from the iceoryx locator,
which made each process's iceoryx instance unique, which it isn't.
Also the iceoryx locator is added to the list of multicast locators,
which also necessitated restructuring this function a little.

Signed-off-by: Martijn Reicher <martijn.reicher@adlinktech.com>