### PR TITLE
Update data allocator API to also support allocation on the heap

### DIFF
--- a/src/core/ddsc/include/dds/ddsc/dds_data_allocator.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_data_allocator.h
@@ -40,6 +40,7 @@ typedef struct dds_data_allocator {
  *
  * @param[in] entity the handle of the entity
  * @param[out] data_allocator opaque allocator object to initialize
+ * @param[in] allocate_on_heap flag to force the allocator to allocate on heap
  *
  * @returns success or a generic error indication
  *
@@ -52,7 +53,7 @@ typedef struct dds_data_allocator {
  * @retval DDS_RETCODE_ILLEGAL_OPERATION
  *    operation not supported on this entity
  */
-DDS_EXPORT dds_return_t dds_data_allocator_init (dds_entity_t entity, dds_data_allocator_t *data_allocator);
+DDS_EXPORT dds_return_t dds_data_allocator_init (dds_entity_t entity, dds_data_allocator_t *data_allocator, const bool allocate_on_heap);
 
 /** @brief Finalize a previously initialized allocator object
  *

--- a/src/core/ddsc/src/dds__data_allocator.h
+++ b/src/core/ddsc/src/dds__data_allocator.h
@@ -46,13 +46,13 @@ DDSRT_STATIC_ASSERT(sizeof (dds_iox_allocator_t) <= sizeof (dds_data_allocator_t
 struct dds_writer;
 struct dds_reader;
 
-dds_return_t dds__writer_data_allocator_init (const struct dds_writer *wr, dds_data_allocator_t *data_allocator)
+dds_return_t dds__writer_data_allocator_init (const struct dds_writer *wr, dds_data_allocator_t *data_allocator, const bool allocate_on_heap)
   ddsrt_nonnull_all;
 
 dds_return_t dds__writer_data_allocator_fini (const struct dds_writer *wr, dds_data_allocator_t *data_allocator)
   ddsrt_nonnull_all;
 
-dds_return_t dds__reader_data_allocator_init (const struct dds_reader *wr, dds_data_allocator_t *data_allocator)
+dds_return_t dds__reader_data_allocator_init (const struct dds_reader *wr, dds_data_allocator_t *data_allocator, const bool allocate_on_heap)
   ddsrt_nonnull_all;
 
 dds_return_t dds__reader_data_allocator_fini (const struct dds_reader *wr, dds_data_allocator_t *data_allocator)

--- a/src/core/ddsc/src/dds_data_allocator.c
+++ b/src/core/ddsc/src/dds_data_allocator.c
@@ -14,7 +14,7 @@
 #include "dds__data_allocator.h"
 #include "dds__entity.h"
 
-dds_return_t dds_data_allocator_init (dds_entity_t entity, dds_data_allocator_t *data_allocator)
+dds_return_t dds_data_allocator_init (dds_entity_t entity, dds_data_allocator_t *data_allocator, const bool allocate_on_heap)
 {
   dds_entity *e;
   dds_return_t ret;
@@ -27,10 +27,10 @@ dds_return_t dds_data_allocator_init (dds_entity_t entity, dds_data_allocator_t 
   switch (dds_entity_kind (e))
   {
     case DDS_KIND_READER:
-      ret = dds__reader_data_allocator_init ((struct dds_reader *) e, data_allocator);
+      ret = dds__reader_data_allocator_init ((struct dds_reader *) e, data_allocator, allocate_on_heap);
       break;
     case DDS_KIND_WRITER:
-      ret = dds__writer_data_allocator_init ((struct dds_writer *) e, data_allocator);
+      ret = dds__writer_data_allocator_init ((struct dds_writer *) e, data_allocator, allocate_on_heap);
       break;
     default:
       ret = DDS_RETCODE_ILLEGAL_OPERATION;

--- a/src/core/ddsc/src/dds_reader.c
+++ b/src/core/ddsc/src/dds_reader.c
@@ -793,11 +793,11 @@ dds_entity_t dds_get_subscriber (dds_entity_t entity)
   }
 }
 
-dds_return_t dds__reader_data_allocator_init (const dds_reader *rd, dds_data_allocator_t *data_allocator)
+dds_return_t dds__reader_data_allocator_init (const dds_reader *rd, dds_data_allocator_t *data_allocator, const bool allocate_on_heap)
 {
 #ifdef DDS_HAS_SHM
   dds_iox_allocator_t *d = (dds_iox_allocator_t *) data_allocator->opaque.bytes;
-  if (NULL != rd->m_iox_sub)
+  if (NULL != rd->m_iox_sub && !allocate_on_heap)
   {
     d->kind = DDS_IOX_ALLOCATOR_KIND_SUBSCRIBER;
     d->ref.sub = rd->m_iox_sub;
@@ -810,6 +810,7 @@ dds_return_t dds__reader_data_allocator_init (const dds_reader *rd, dds_data_all
 #else
   (void) rd;
   (void) data_allocator;
+  (void) allocate_on_heap;
   return DDS_RETCODE_OK;
 #endif
 }

--- a/src/core/ddsc/src/dds_writer.c
+++ b/src/core/ddsc/src/dds_writer.c
@@ -506,11 +506,11 @@ dds_entity_t dds_get_publisher (dds_entity_t writer)
   }
 }
 
-dds_return_t dds__writer_data_allocator_init (const dds_writer *wr, dds_data_allocator_t *data_allocator)
+dds_return_t dds__writer_data_allocator_init (const dds_writer *wr, dds_data_allocator_t *data_allocator, const bool allocate_on_heap)
 {
 #ifdef DDS_HAS_SHM
   dds_iox_allocator_t *d = (dds_iox_allocator_t *) data_allocator->opaque.bytes;
-  if (NULL != wr->m_iox_pub)
+  if (NULL != wr->m_iox_pub && !allocate_on_heap)
   {
     d->kind = DDS_IOX_ALLOCATOR_KIND_PUBLISHER;
     d->ref.pub = wr->m_iox_pub;
@@ -523,6 +523,7 @@ dds_return_t dds__writer_data_allocator_init (const dds_writer *wr, dds_data_all
 #else
   (void) wr;
   (void) data_allocator;
+  (void) allocate_on_heap;
   return DDS_RETCODE_OK;
 #endif
 }


### PR DESCRIPTION
This MR updates the `dds_data_allocator` API to take a flag which forces the allocation on the heap regardless of the SHM