### PR TITLE
Add idl_is_keyless for C++ generator

### DIFF
--- a/src/idl/CMakeLists.txt
+++ b/src/idl/CMakeLists.txt
@@ -53,6 +53,7 @@ add_library(
     src/tree.c
     src/visit.c
     src/thread.c
+    src/print.c
     ${CMAKE_CURRENT_BINARY_DIR}/hashid.c
     ${BISON_parser_OUTPUT_SOURCE})
 

--- a/src/idl/include/idl/print.h
+++ b/src/idl/include/idl/print.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright(c) 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#ifndef IDL_PRINT_H
+#define IDL_PRINT_H
+
+#include <stdio.h>
+
+#include <assert.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#if defined(_MSC_VER)
+# include <malloc.h>
+#elif defined(__GNUC__) || (defined(__clang__) && __clang_major__ >= 2)
+# if !defined(__FreeBSD__)
+#   include <alloca.h>
+# endif
+#elif defined(__SUNPROC_C) || defined(__SUNPRO_CC)
+# include <alloca.h>
+#endif
+
+#include "idl/export.h"
+
+typedef int(*idl_print_t)(char *, size_t, const void *, void *);
+
+/** @private */
+IDL_EXPORT int idl_printa_arguments__(
+  char **strp, idl_print_t print, const void *object, void *user_data);
+
+/** @private */
+IDL_EXPORT size_t idl_printa_size__(void);
+
+/** @private */
+IDL_EXPORT char **idl_printa_strp__(void);
+
+/** @private */
+IDL_EXPORT int idl_printa__(void);
+
+#define IDL_COMMA__() ,
+#define IDL_SHIFT__(shift_, ...) shift_
+#define IDL_PICK__(drop1_, drop2_, pick_, ...) pick_
+#define IDL_EVALUATE__(eval_) eval_ /* required for MSVC */
+#define IDL_EXPAND__(...) IDL_EXPAND_AGAIN__(__VA_ARGS__)
+#define IDL_EXPAND_AGAIN__(...) IDL_EVALUATE__(IDL_PICK__(__VA_ARGS__, ))
+#define IDL_MAYBE__(...) \
+  IDL_EXPAND__(IDL_COMMA__ IDL_SHIFT__(__VA_ARGS__, ) (), NULL, __VA_ARGS__)
+
+#if _MSC_VER
+# define IDL_ALLOCA__(size_) (__pragma (warning(suppress: 6255)) alloca(size_))
+#else
+# define IDL_ALLOCA__(size_) (alloca(size_))
+#endif
+
+#define IDL_PRINTA__(strp_, print_, object_, ...) \
+  ((idl_printa_arguments__((strp_), (print_), (object_), IDL_MAYBE__(__VA_ARGS__)) >= 0) \
+   ? ((*(idl_printa_strp__()) = IDL_ALLOCA__(idl_printa_size__())), \
+       idl_printa__()) \
+   : (-1))
+
+#define IDL_PRINTA(strp_, print_, ...) \
+  IDL_PRINTA__((strp_), (print_), __VA_ARGS__, )
+
+IDL_EXPORT int idl_print__(
+  char **strp, idl_print_t print, const void *object, void *user_data);
+
+#define IDL_PRINT__(strp_, print_, object_, ...) \
+  idl_print__((strp_), (print_), (object_), IDL_MAYBE__(__VA_ARGS__))
+
+#define IDL_PRINT(strp_, print_, ...) \
+  IDL_PRINT__(strp_, print_, __VA_ARGS__, )
+
+#endif /* IDL_PRINT_H */

--- a/src/idl/include/idl/string.h
+++ b/src/idl/include/idl/string.h
@@ -14,6 +14,7 @@
 
 #include <stdarg.h>
 #include <stddef.h>
+#include <string.h>
 
 #include "idl/export.h"
 

--- a/src/idl/include/idl/tree.h
+++ b/src/idl/include/idl/tree.h
@@ -477,6 +477,7 @@ IDL_EXPORT bool idl_is_array(const void *node);
 IDL_EXPORT bool idl_is_annotation_member(const void *node);
 IDL_EXPORT bool idl_is_annotation_appl(const void *node);
 IDL_EXPORT bool idl_is_topic(const void *node, bool keylist);
+IDL_EXPORT bool idl_is_keyless(const void *node, bool keylist);
 /* 1-based, returns 0 if path does not refer to key, non-0 otherwise */
 IDL_EXPORT uint32_t idl_is_topic_key(const void *node, bool keylist, const idl_path_t *path);
 

--- a/src/idl/src/print.c
+++ b/src/idl/src/print.c
@@ -1,0 +1,104 @@
+/*
+ * Copyright(c) 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include "idl/print.h"
+
+#if defined(_MSC_VER)
+# define idl_thread_local __declspec(thread)
+#elif defined(__GNUC__) || (defined(__clang__) && __clang_major__ >= 2)
+# define idl_thread_local __thread
+#elif defined(__SUNPROC_C) || defined(__SUNPRO_CC)
+# define idl_thread_local __thread
+#else
+# error "Thread-local storage is not supported"
+#endif
+
+struct printa {
+  idl_print_t print;
+  const void *object;
+  void *user_data;
+  size_t size;
+  char *str, **strp;
+};
+
+static idl_thread_local struct printa printa;
+
+int idl_printa_arguments__(
+  char **strp, idl_print_t print, const void *object, void *user_data)
+{
+  int cnt;
+  char buf[1];
+
+  assert(strp);
+  assert(print);
+  assert(object);
+
+  if ((cnt = print(buf, sizeof(buf), object, user_data)) < 0)
+    return cnt;
+
+  printa.print = print;
+  printa.object = object;
+  printa.user_data = user_data;
+  printa.size = (size_t)cnt + 1;
+  printa.strp = strp;
+  printa.str = NULL;
+
+  return cnt;
+}
+
+size_t idl_printa_size__(void)
+{
+  assert(!printa.str);
+  return printa.size;
+}
+
+char **idl_printa_strp__(void)
+{
+  return &printa.str;
+}
+
+int idl_printa__(void)
+{
+  int cnt;
+
+  assert(printa.size);
+  assert(printa.str);
+  assert(printa.strp);
+
+  cnt = printa.print(
+    printa.str, printa.size, printa.object, printa.user_data);
+  if (cnt >= 0)
+    *printa.strp = printa.str;
+  printa.print = 0;
+  printa.object = NULL;
+  printa.user_data = NULL;
+  printa.size = 0;
+  printa.str = NULL;
+  printa.strp = NULL;
+  return cnt;
+}
+
+int idl_print__(
+  char **strp, idl_print_t print, const void *object, void *user_data)
+{
+  int cnt, len;
+  char buf[1], *str = NULL;
+
+  if ((len = print(buf, sizeof(buf), object, user_data)) < 0)
+    return len;
+  if (!(str = malloc((size_t)len + 1)))
+    return -1;
+  if ((cnt = print(str, (size_t)len + 1, object, user_data)) >= 0)
+    *strp = str;
+  else
+    free(str);
+  return cnt;
+}

--- a/src/idl/src/tree.c
+++ b/src/idl/src/tree.c
@@ -2782,6 +2782,17 @@ static bool no_specific_key(const void *node)
   return true;
 }
 
+bool idl_is_keyless(const void *node, bool keylist)
+{
+  if (!keylist)
+    return no_specific_key(node);
+
+  if (idl_mask(node) & IDL_STRUCT)
+    return !(((const idl_struct_t *)node)->keylist &&
+            ((const idl_struct_t *)node)->keylist->keys);
+  return true;
+}
+
 static uint32_t is_key_by_path(const void *node, const idl_path_t *path)
 {
   bool all_keys = false;

--- a/src/tools/idlc/src/descriptor.c
+++ b/src/tools/idlc/src/descriptor.c
@@ -16,6 +16,7 @@
 #include <string.h>
 #include <inttypes.h>
 
+#include "idl/print.h"
 #include "idl/processor.h"
 #include "idl/stream.h"
 #include "idl/string.h"
@@ -28,9 +29,6 @@
 #define SUBTYPE (8)
 
 #define MAX_SIZE (16)
-
-extern char *typename(const void *node);
-extern char *absolute_name(const void *node, const char *separator);
 
 static const uint16_t nop = UINT16_MAX;
 
@@ -345,7 +343,7 @@ stash_offset(
   assert(pos == 0);
 
   levels = idl_is_declarator(fld->node) != 0;
-  if (!(inst.data.offset.type = typename(idl_ancestor(fld->node, levels))))
+  if (IDL_PRINT(&inst.data.offset.type, print_type, idl_ancestor(fld->node, levels)) < 0)
     goto err_type;
 
   if (stash_instruction(descriptor, index, &inst))
@@ -378,7 +376,7 @@ stash_size(
       if (!(inst.data.size.type = idl_strdup("char *")))
         goto err_type;
     } else {
-      if (!(inst.data.size.type = typename(type_spec)))
+      if (IDL_PRINT(&inst.data.size.type, print_type, type_spec) < 0)
         goto err_type;
     }
   } else {
@@ -410,11 +408,11 @@ stash_size(
       if (!(inst.data.size.type = idl_strdup("char *")))
         goto err_type;
     } else if (idl_is_array(type_spec)) {
-      char *type;
+      char *type = NULL;
       size_t len, pos;
       const idl_const_expr_t *const_expr;
 
-      if (!(type = typename(type_spec)))
+      if (IDL_PRINT(&type, print_type, type_spec) < 0)
         goto err_type;
 
       len = pos = strlen(type);
@@ -436,7 +434,7 @@ stash_size(
         memmove(inst.data.size.type + pos, "[0]", 3);
       inst.data.size.type[pos] = '\0';
     } else {
-      if (!(inst.data.size.type = typename(type_spec)))
+      if (IDL_PRINT(&inst.data.size.type, print_type, type_spec) < 0)
         goto err_type;
     }
   }
@@ -461,7 +459,7 @@ stash_constant(
   char **strp = &inst.data.constant.value;
 
   if (idl_is_enumerator(const_expr)) {
-    *strp = typename(const_expr);
+    cnt = IDL_PRINT(strp, print_type, const_expr);
   } else {
     const idl_literal_t *literal = const_expr;
 
@@ -1132,11 +1130,11 @@ static int print_opcodes(FILE *fp, const struct descriptor *descriptor)
   const struct instruction *inst;
   enum dds_stream_opcode opcode;
   enum dds_stream_typecode_primary optype;
-  char *type;
+  char *type = NULL;
   const char *seps[] = { ", ", ",\n  " };
   const char *sep = "  ";
 
-  if (!(type = IDLC_AUTO(typename(descriptor->topic))))
+  if (IDL_PRINTA(&type, print_type, descriptor->topic) < 0)
     return -1;
   if (idl_fprintf(fp, "static const uint32_t %s_ops [] =\n{\n", type) < 0)
     return -1;
@@ -1200,7 +1198,7 @@ static int print_keys(FILE *fp, struct descriptor *descriptor, bool keylist)
     return 0;
   if (!(keys = calloc(descriptor->keys, sizeof(*keys))))
     goto err_keys;
-  if (!(type = typename(descriptor->topic)))
+  if (IDL_PRINT(&type, print_type, descriptor->topic) < 0)
     goto err_type;
   for (uint32_t i=0,k=0; i < descriptor->instructions.count && k < descriptor->keys; i++) {
     const struct instruction *inst = &descriptor->instructions.table[i];
@@ -1313,9 +1311,9 @@ static int print_descriptor(FILE *fp, struct descriptor *descriptor)
   char *name, *type;
   const char *fmt;
 
-  if (!(name = IDLC_AUTO(absolute_name(descriptor->topic, "::"))))
+  if (IDL_PRINTA(&name, print_scoped_name, descriptor->topic) < 0)
     return -1;
-  if (!(type = IDLC_AUTO(typename(descriptor->topic))))
+  if (IDL_PRINTA(&type, print_type, descriptor->topic) < 0)
     return -1;
   fmt = "const dds_topic_descriptor_t %1$s_desc =\n{\n"
         "  sizeof (%1$s),\n" /* size of type */

--- a/src/tools/idlc/src/generator.c
+++ b/src/tools/idlc/src/generator.c
@@ -24,172 +24,185 @@
 #include "idl/string.h"
 #include "idl/version.h"
 #include "idl/processor.h"
+#include "idl/print.h"
 
-idlc_thread_local struct idlc_auto_args__ idlc_auto_args__;
-
-extern char *idlc_auto__(void);
-
-char *absolute_name(const void *node, const char *separator);
-
-char *absolute_name(const void *node, const char *separator)
+static int print_base_type(
+  char *str, size_t size, const void *node, void *user_data)
 {
-  char *str;
-  size_t cnt, len = 0;
-  const char *sep, *ident;
-  const idl_node_t *root;
-  for (root=node, sep=""; root; root=root->parent) {
-    if ((idl_mask(root) & IDL_TYPEDEF) == IDL_TYPEDEF)
-      continue;
-    if ((idl_mask(root) & IDL_ENUM) == IDL_ENUM && root != node)
-      continue;
-    ident = idl_identifier(root);
-    assert(ident);
-    len += strlen(sep) + strlen(ident);
-    sep = separator;
+  const char *type;
+
+  (void)user_data;
+
+  switch (idl_type(node)) {
+    case IDL_BOOL:    type = "bool";        break;
+    case IDL_CHAR:    type = "char";        break;
+    case IDL_INT8:    type = "int8_t";      break;
+    case IDL_OCTET:
+    case IDL_UINT8:   type = "uint8_t";     break;
+    case IDL_SHORT:
+    case IDL_INT16:   type = "int16_t";     break;
+    case IDL_USHORT:
+    case IDL_UINT16:  type = "uint16_t";    break;
+    case IDL_LONG:
+    case IDL_INT32:   type = "int32_t";     break;
+    case IDL_ULONG:
+    case IDL_UINT32:  type = "uint32_t";    break;
+    case IDL_LLONG:
+    case IDL_INT64:   type = "int64_t";     break;
+    case IDL_ULLONG:
+    case IDL_UINT64:  type = "uint64_t";    break;
+    case IDL_FLOAT:   type = "float";       break;
+    case IDL_DOUBLE:  type = "double";      break;
+    case IDL_LDOUBLE: type = "long double"; break;
+    case IDL_STRING:  type = "char";        break;
+    default:
+      abort();
   }
-  if (!(str = malloc(len + 1)))
-    return NULL;
-  str[len] = '\0';
-  for (root=node, sep=separator; root; root=root->parent) {
-    if ((idl_mask(root) & IDL_TYPEDEF) == IDL_TYPEDEF)
+
+  return idl_snprintf(str, size, "%s", type);
+}
+
+static void copy(
+  char *dest, size_t off, size_t size, const char *src, size_t len)
+{
+  size_t cnt;
+
+  if (off >= size)
+    return;
+  cnt = size - off;
+  cnt = cnt > len ? len : cnt;
+  memmove(dest+off, src, cnt);
+}
+
+static int print_templ_type(
+  char *str, size_t size, const void *node, void *user_data)
+{
+  const idl_type_spec_t *type_spec;
+  char dims[32], *name = NULL;
+  const char *seg, *type;
+  size_t cnt, len = 0, seq = 0;
+
+  (void)user_data;
+  if (idl_type(node) == IDL_STRING)
+    return idl_snprintf(str, size, "char");
+  /* sequences require a little magic */
+  assert(idl_type(node) == IDL_SEQUENCE);
+
+  dims[0] = '\0';
+  type_spec = idl_type_spec(node);
+  for (; idl_is_sequence(type_spec); type_spec = idl_type_spec(type_spec))
+    seq++;
+
+  if (idl_is_base_type(type_spec) || idl_is_string(type_spec)) {
+    switch (idl_type(type_spec)) {
+      case IDL_BOOL:     type = "bool";                break;
+      case IDL_CHAR:     type = "char";                break;
+      case IDL_INT8:     type = "int8";                break;
+      case IDL_OCTET:    type = "octet";               break;
+      case IDL_UINT8:    type = "uint8";               break;
+      case IDL_SHORT:    type = "short";               break;
+      case IDL_INT16:    type = "int16";               break;
+      case IDL_USHORT:   type = "unsigned_short";      break;
+      case IDL_UINT16:   type = "uint16";              break;
+      case IDL_LONG:     type = "long";                break;
+      case IDL_INT32:    type = "int32";               break;
+      case IDL_ULONG:    type = "unsigned_long";       break;
+      case IDL_UINT32:   type = "uint32";              break;
+      case IDL_LLONG:    type = "long_long";           break;
+      case IDL_INT64:    type = "int64";               break;
+      case IDL_ULLONG:   type = "unsigned_long_long";  break;
+      case IDL_UINT64:   type = "uint64";              break;
+      case IDL_FLOAT:    type = "float";               break;
+      case IDL_DOUBLE:   type = "double";              break;
+      case IDL_LDOUBLE:  type = "long_double";         break;
+      case IDL_STRING:
+        if (idl_is_bounded(type_spec))
+          idl_snprintf(dims, sizeof(dims), "%"PRIu32, idl_bound(type_spec));
+        type = "string";
+        break;
+      default:
+        abort();
+    }
+  } else {
+    if (IDL_PRINT(&name, print_type, type_spec) < 0)
+      return -1;
+    type = name;
+  }
+
+  seg = "dds_sequence_";
+  cnt = strlen(seg);
+  copy(str, len, size, seg, cnt);
+  len += cnt;
+  seg = "sequence_";
+  cnt = strlen(seg);
+  for (; seq; len += cnt, seq--)
+    copy(str, len, size, seg, cnt);
+  cnt = strlen(type);
+  copy(str, len, size, type, cnt);
+  len += cnt;
+  cnt = strlen(dims);
+  copy(str, len, size, dims, cnt);
+  len += cnt;
+  str[ (size > len ? len : size - 1) ] = '\0';
+  if (name)
+    free(name);
+  return (int)len;
+}
+
+static int print_decl_type(
+  char *str, size_t size, const void *node, void *user_data)
+{
+  const char *ident, *sep = user_data;
+  size_t cnt, off, len = 0;
+
+  assert(sep);
+  for (const idl_node_t *n = node; n; n = n->parent) {
+    if ((idl_mask(n) & IDL_TYPEDEF) == IDL_TYPEDEF)
       continue;
-    if ((idl_mask(root) & IDL_ENUM) == IDL_ENUM && root != node)
+    if ((idl_mask(n) & IDL_ENUM) == IDL_ENUM && n != node)
       continue;
-    ident = idl_identifier(root);
+    ident = idl_identifier(n);
+    assert(ident);
+    len += strlen(ident) + (len ? strlen(sep) : 0);
+  }
+
+  off = len;
+  for (const idl_node_t *n = node; n; n = n->parent) {
+    if ((idl_mask(n) & IDL_TYPEDEF) == IDL_TYPEDEF)
+      continue;
+    if ((idl_mask(n) & IDL_ENUM) == IDL_ENUM && n != node)
+      continue;
+    ident = idl_identifier(n);
     assert(ident);
     cnt = strlen(ident);
-    assert(cnt <= len);
-    len -= cnt;
-    memmove(str+len, ident, cnt);
-    if (len == 0)
+    assert(cnt <= off);
+    off -= cnt;
+    copy(str, off, size, ident, cnt);
+    if (off == 0)
       break;
     cnt = strlen(sep);
-    assert(cnt <= len);
-    len -= cnt;
-    memmove(str+len, sep, cnt);
+    off -= cnt;
+    copy(str, off, size, sep, cnt);
   }
-  assert(len == 0);
-  return str;
+  str[ (size > len ? len : size - 1) ] = '\0';
+  return (int)len;
 }
 
-char *typename(const void *node);
-
-char *typename(const void *node)
+int print_type(
+  char *str, size_t size, const void *ptr, void *user_data)
 {
-  switch (idl_type(node)) {
-    case IDL_BOOL:     return idl_strdup("bool");
-    case IDL_CHAR:     return idl_strdup("char");
-    case IDL_INT8:     return idl_strdup("int8_t");
-    case IDL_OCTET:
-    case IDL_UINT8:    return idl_strdup("uint8_t");
-    case IDL_SHORT:
-    case IDL_INT16:    return idl_strdup("int16_t");
-    case IDL_USHORT:
-    case IDL_UINT16:   return idl_strdup("uint16_t");
-    case IDL_LONG:
-    case IDL_INT32:    return idl_strdup("int32_t");
-    case IDL_ULONG:
-    case IDL_UINT32:   return idl_strdup("uint32_t");
-    case IDL_LLONG:
-    case IDL_INT64:    return idl_strdup("int64_t");
-    case IDL_ULLONG:
-    case IDL_UINT64:   return idl_strdup("uint64_t");
-    case IDL_FLOAT:    return idl_strdup("float");
-    case IDL_DOUBLE:   return idl_strdup("double");
-    case IDL_LDOUBLE:  return idl_strdup("long double");
-    case IDL_STRING:   return idl_strdup("char");
-    case IDL_SEQUENCE: {
-      /* sequences require a little magic */
-      const char *pref = "dds_sequence_";
-      const char *seq = "sequence_";
-      char dims[32];
-      const idl_type_spec_t *type_spec;
-      const char *type;
-      char *name = NULL, *seqtype = NULL;
-      size_t cnt = 0, len = 0, pos = 0;
-
-      dims[0] = '\0';
-      type_spec = idl_type_spec(node);
-      for (; idl_is_sequence(type_spec); type_spec = idl_type_spec(type_spec))
-        cnt++;
-      if (idl_is_base_type(type_spec) || idl_is_string(type_spec))
-        switch (idl_type(type_spec)) {
-          case IDL_BOOL:     type = "bool";                break;
-          case IDL_CHAR:     type = "char";                break;
-          case IDL_INT8:     type = "int8";                break;
-          case IDL_OCTET:    type = "octet";               break;
-          case IDL_UINT8:    type = "uint8";               break;
-          case IDL_SHORT:    type = "short";               break;
-          case IDL_INT16:    type = "int16";               break;
-          case IDL_USHORT:   type = "unsigned_short";      break;
-          case IDL_UINT16:   type = "uint16";              break;
-          case IDL_LONG:     type = "long";                break;
-          case IDL_INT32:    type = "int32";               break;
-          case IDL_ULONG:    type = "unsigned_long";       break;
-          case IDL_UINT32:   type = "uint32";              break;
-          case IDL_LLONG:    type = "long_long";           break;
-          case IDL_INT64:    type = "int64";               break;
-          case IDL_ULLONG:   type = "unsigned_long_long";  break;
-          case IDL_UINT64:   type = "uint64";              break;
-          case IDL_FLOAT:    type = "float";               break;
-          case IDL_DOUBLE:   type = "double";              break;
-          case IDL_LDOUBLE:  type = "long_double";         break;
-          case IDL_STRING:
-            if (idl_is_bounded(type_spec))
-              idl_snprintf(dims, sizeof(dims), "%"PRIu32, idl_bound(type_spec));
-            type = "string";
-            break;
-          default:
-            abort();
-        }
-      else if (!(type = name = absolute_name(type_spec, "_")))
-        goto err_type;
-      len = strlen(pref) + strlen(type) + strlen(dims);
-      if (!(seqtype = malloc(len + (cnt * strlen(seq)) + 1)))
-        goto err_seqtype;
-      len = strlen(pref);
-#if defined(_MSC_VER)
-#pragma warning(suppress: 6386)
-#endif
-      memcpy(seqtype, pref, len);
-      pos += len;
-      for (; cnt; pos += strlen(seq), cnt--)
-        memcpy(seqtype+pos, seq, strlen(seq));
-      len = strlen(type);
-      memcpy(seqtype+pos, type, len);
-      pos += len;
-      len = strlen(dims);
-      memcpy(seqtype+pos, dims, len);
-      pos += len;
-      seqtype[pos] = '\0';
-err_seqtype:
-      if (name)
-        free(name);
-err_type:
-      return seqtype;
-    }
-    default:
-      break;
-  }
-
-  return absolute_name(node, "_");
+  if (idl_is_base_type(ptr))
+    return print_base_type(str, size, ptr, user_data);
+  if (idl_is_templ_type(ptr))
+    return print_templ_type(str, size, ptr, user_data);
+  return print_decl_type(str, size, ptr, "_");
 }
-static char *figure_guard(const char *file)
+
+int print_scoped_name(
+  char *str, size_t size, const void *ptr, void *user_data)
 {
-  char *inc = NULL;
-
-  if (idl_asprintf(&inc, "DDSC_%s", file) == -1)
-    return NULL;
-
-  /* replace any non-alphanumeric characters */
-  for (char *ptr = inc; *ptr; ptr++) {
-    if (idl_islower((unsigned char)*ptr))
-      *ptr = (char)idl_toupper((unsigned char)*ptr);
-    else if (!idl_isalnum((unsigned char)*ptr))
-      *ptr = '_';
-  }
-
-  return inc;
+  (void)user_data;
+  return print_decl_type(str, size, ptr, "::");
 }
 
 static idl_retcode_t print_header(FILE *fh, const char *in, const char *out)
@@ -209,21 +222,45 @@ static idl_retcode_t print_header(FILE *fh, const char *in, const char *out)
   return IDL_RETCODE_OK;
 }
 
-static idl_retcode_t print_guard_if(FILE *fh, const char *guard)
+static idl_retcode_t print_guard(FILE *fh, const char *in)
 {
-  static const char fmt[] =
-    "#ifndef %1$s\n"
-    "#define %1$s\n\n";
-  if (idl_fprintf(fh, fmt, guard) < 0)
+  if (fputs("DDSC_", fh) < 0)
+    return IDL_RETCODE_NO_MEMORY;
+  for (const char *ptr = in; *ptr; ptr++) {
+    int chr = (unsigned char)*ptr;
+    if (idl_islower((unsigned char)*ptr))
+      chr = idl_toupper((unsigned char)*ptr);
+    else if (!idl_isalnum((unsigned char)*ptr))
+      chr = '_';
+    if (fputc(chr, fh) == EOF)
+      return IDL_RETCODE_NO_MEMORY;
+  }
+
+  return IDL_RETCODE_OK;
+}
+
+static idl_retcode_t print_guard_if(FILE *fh, const char *in)
+{
+  if (fputs("#ifndef ", fh) < 0)
+    return IDL_RETCODE_NO_MEMORY;
+  if (print_guard(fh, in))
+    return IDL_RETCODE_NO_MEMORY;
+  if (fputs("\n#define ", fh) < 0)
+    return IDL_RETCODE_NO_MEMORY;
+  if (print_guard(fh, in))
+    return IDL_RETCODE_NO_MEMORY;
+  if (fputs("\n\n", fh) < 0)
     return IDL_RETCODE_NO_MEMORY;
   return IDL_RETCODE_OK;
 }
 
-static idl_retcode_t print_guard_endif(FILE *fh, const char *guard)
+static idl_retcode_t print_guard_endif(FILE *fh, const char *in)
 {
-  static const char fmt[] =
-    "#endif /* %1$s */\n";
-  if (idl_fprintf(fh, fmt, guard) < 0)
+  if (fputs("#endif /* ", fh) < 0)
+    return IDL_RETCODE_NO_MEMORY;
+  if (print_guard(fh, in))
+    return IDL_RETCODE_NO_MEMORY;
+  if (fputs(" */\n", fh) < 0)
     return IDL_RETCODE_NO_MEMORY;
   return IDL_RETCODE_OK;
 }
@@ -231,10 +268,10 @@ static idl_retcode_t print_guard_endif(FILE *fh, const char *guard)
 static idl_retcode_t print_includes(FILE *fh, const idl_source_t *source)
 {
   idl_retcode_t ret;
-  char *sep = NULL, *path;
+  char *sep = NULL, *path = NULL, *relpath = NULL;
   const idl_source_t *include;
 
-  if (!(path = IDLC_AUTO(idl_strdup(source->path->name))))
+  if (!(path = idl_strdup(source->path->name)))
     return IDL_RETCODE_NO_MEMORY;
   for (char *ptr = path; *ptr; ptr++)
     if (idl_isseparator(*ptr))
@@ -243,11 +280,9 @@ static idl_retcode_t print_includes(FILE *fh, const idl_source_t *source)
     *sep = '\0';
 
   for (include = source->includes; include; include = include->next) {
-    char *ext, *relpath = NULL;
+    char *ext;
     if ((ret = idl_relative_path(path, include->path->name, &relpath)))
-      return ret;
-    if (!(relpath = IDLC_AUTO(relpath)))
-      return IDL_RETCODE_NO_MEMORY;
+      goto err_relpath;
     ext = relpath;
     for (char *ptr = ext; *ptr; ptr++) {
       if (*ptr == '.')
@@ -257,17 +292,25 @@ static idl_retcode_t print_includes(FILE *fh, const idl_source_t *source)
       const char *fmt = "#include \"%.*s.h\"\n";
       int len = (int)(ext - relpath);
       if (idl_fprintf(fh, fmt, len, relpath) < 0)
-        return IDL_RETCODE_NO_MEMORY;
+        goto err_print;
     } else {
       const char *fmt = "#include \"%s\"\n";
       if (idl_fprintf(fh, fmt, relpath) < 0)
-        return IDL_RETCODE_NO_MEMORY;
+        goto err_print;
     }
     if (fputs("\n", fh) < 0)
-      return IDL_RETCODE_NO_MEMORY;
+      goto err_print;
+    free(relpath);
   }
 
+  free(path);
   return IDL_RETCODE_OK;
+err_print:
+  ret = IDL_RETCODE_NO_MEMORY;
+  free(relpath);
+err_relpath:
+  free(path);
+  return ret;
 }
 
 extern idl_retcode_t
@@ -277,16 +320,13 @@ idl_retcode_t
 generate_nosetup(const idl_pstate_t *pstate, struct generator *generator)
 {
   idl_retcode_t ret;
-  char *guard;
   const char *sep, *file = generator->path;
   char *const header_file = generator->header.path;
   char *const source_file = generator->source.path;
 
-  if (!(guard = IDLC_AUTO(figure_guard(header_file))))
-    return IDL_RETCODE_NO_MEMORY;
   if ((ret = print_header(generator->header.handle, file, header_file)))
     return ret;
-  if ((ret = print_guard_if(generator->header.handle, guard)))
+  if ((ret = print_guard_if(generator->header.handle, header_file)))
     return ret;
   if ((ret = print_includes(generator->header.handle, pstate->sources)))
     return ret;
@@ -307,7 +347,7 @@ generate_nosetup(const idl_pstate_t *pstate, struct generator *generator)
     return ret;
   if (fputs("#ifdef __cplusplus\n}\n#endif\n\n", generator->header.handle) < 0)
     return IDL_RETCODE_NO_MEMORY;
-  if ((ret = print_guard_endif(generator->header.handle, guard)))
+  if ((ret = print_guard_endif(generator->header.handle, header_file)))
     return ret;
 
   return IDL_RETCODE_OK;

--- a/src/tools/idlc/src/generator.h
+++ b/src/tools/idlc/src/generator.h
@@ -18,48 +18,6 @@
 
 #include <stdlib.h>
 #include <string.h>
-#if defined(_MSC_VER)
-# include <malloc.h>
-# define idlc_thread_local __declspec(thread)
-#elif defined(__GNUC__) || (defined(__clang__) && __clang_major__ >= 2)
-# if !defined(__FreeBSD__)
-#   include <alloca.h>
-# endif
-# define idlc_thread_local __thread
-#elif defined(__SUNPROC_C) || defined(__SUNPRO_CC)
-# include <alloca.h>
-# define idlc_thread_local __thread
-#else
-# error "Thread-local storage is not supported"
-#endif
-
-#define IDLC_AUTO(str) \
-  ((idlc_auto_args__.src = (str)) \
-    ? (idlc_auto_args__.len = strlen(idlc_auto_args__.src), \
-       idlc_auto_args__.dest = alloca(idlc_auto_args__.len + 1), \
-       idlc_auto__()) \
-    : (NULL))
-
-/** @private */
-struct idlc_auto_args__ {
-  char *src;
-  size_t len;
-  char *dest;
-};
-
-/** @private */
-extern idlc_thread_local struct idlc_auto_args__ idlc_auto_args__;
-
-inline char *idlc_auto__(void)
-{
-  char *dest = idlc_auto_args__.dest;
-  memmove(dest, idlc_auto_args__.src, idlc_auto_args__.len + 1);
-  free(idlc_auto_args__.src);
-  idlc_auto_args__.src = NULL;
-  idlc_auto_args__.len = 0;
-  idlc_auto_args__.dest = NULL;
-  return dest;
-}
 
 struct generator {
   const char *path;
@@ -72,6 +30,9 @@ struct generator {
     char *path;
   } source;
 };
+
+int print_type(char *str, size_t len, const void *ptr, void *user_data);
+int print_scoped_name(char *str, size_t len, const void *ptr, void *user_data);
 
 #if _WIN32
 __declspec(dllexport)


### PR DESCRIPTION
Title says it all. Simple function required originally implemented specifically for the C++ generator, but might be useful for other generators too. Also, adding these few lines here saves having to re-implement a couple of functions in cyclonedds-cxx.