### PR TITLE
Revert data allocator api change

### DIFF
--- a/src/core/ddsc/include/dds/ddsc/dds_data_allocator.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_data_allocator.h
@@ -40,7 +40,6 @@ typedef struct dds_data_allocator {
  *
  * @param[in] entity the handle of the entity
  * @param[out] data_allocator opaque allocator object to initialize
- * @param[in] allocate_on_heap flag to force the allocator to allocate on heap
  *
  * @returns success or a generic error indication
  *
@@ -53,7 +52,7 @@ typedef struct dds_data_allocator {
  * @retval DDS_RETCODE_ILLEGAL_OPERATION
  *    operation not supported on this entity
  */
-DDS_EXPORT dds_return_t dds_data_allocator_init (dds_entity_t entity, dds_data_allocator_t *data_allocator, const bool allocate_on_heap);
+DDS_EXPORT dds_return_t dds_data_allocator_init (dds_entity_t entity, dds_data_allocator_t *data_allocator);
 
 /** @brief Finalize a previously initialized allocator object
  *

--- a/src/core/ddsc/src/dds__data_allocator.h
+++ b/src/core/ddsc/src/dds__data_allocator.h
@@ -46,13 +46,13 @@ DDSRT_STATIC_ASSERT(sizeof (dds_iox_allocator_t) <= sizeof (dds_data_allocator_t
 struct dds_writer;
 struct dds_reader;
 
-dds_return_t dds__writer_data_allocator_init (const struct dds_writer *wr, dds_data_allocator_t *data_allocator, const bool allocate_on_heap)
+dds_return_t dds__writer_data_allocator_init (const struct dds_writer *wr, dds_data_allocator_t *data_allocator)
   ddsrt_nonnull_all;
 
 dds_return_t dds__writer_data_allocator_fini (const struct dds_writer *wr, dds_data_allocator_t *data_allocator)
   ddsrt_nonnull_all;
 
-dds_return_t dds__reader_data_allocator_init (const struct dds_reader *wr, dds_data_allocator_t *data_allocator, const bool allocate_on_heap)
+dds_return_t dds__reader_data_allocator_init (const struct dds_reader *wr, dds_data_allocator_t *data_allocator)
   ddsrt_nonnull_all;
 
 dds_return_t dds__reader_data_allocator_fini (const struct dds_reader *wr, dds_data_allocator_t *data_allocator)

--- a/src/core/ddsc/src/dds_data_allocator.c
+++ b/src/core/ddsc/src/dds_data_allocator.c
@@ -14,7 +14,7 @@
 #include "dds__data_allocator.h"
 #include "dds__entity.h"
 
-dds_return_t dds_data_allocator_init (dds_entity_t entity, dds_data_allocator_t *data_allocator, const bool allocate_on_heap)
+dds_return_t dds_data_allocator_init (dds_entity_t entity, dds_data_allocator_t *data_allocator)
 {
   dds_entity *e;
   dds_return_t ret;
@@ -27,10 +27,10 @@ dds_return_t dds_data_allocator_init (dds_entity_t entity, dds_data_allocator_t 
   switch (dds_entity_kind (e))
   {
     case DDS_KIND_READER:
-      ret = dds__reader_data_allocator_init ((struct dds_reader *) e, data_allocator, allocate_on_heap);
+      ret = dds__reader_data_allocator_init ((struct dds_reader *) e, data_allocator);
       break;
     case DDS_KIND_WRITER:
-      ret = dds__writer_data_allocator_init ((struct dds_writer *) e, data_allocator, allocate_on_heap);
+      ret = dds__writer_data_allocator_init ((struct dds_writer *) e, data_allocator);
       break;
     default:
       ret = DDS_RETCODE_ILLEGAL_OPERATION;

--- a/src/core/ddsc/src/dds_reader.c
+++ b/src/core/ddsc/src/dds_reader.c
@@ -797,11 +797,11 @@ dds_entity_t dds_get_subscriber (dds_entity_t entity)
   }
 }
 
-dds_return_t dds__reader_data_allocator_init (const dds_reader *rd, dds_data_allocator_t *data_allocator, const bool allocate_on_heap)
+dds_return_t dds__reader_data_allocator_init (const dds_reader *rd, dds_data_allocator_t *data_allocator)
 {
 #ifdef DDS_HAS_SHM
   dds_iox_allocator_t *d = (dds_iox_allocator_t *) data_allocator->opaque.bytes;
-  if (NULL != rd->m_iox_sub && !allocate_on_heap)
+  if (NULL != rd->m_iox_sub)
   {
     d->kind = DDS_IOX_ALLOCATOR_KIND_SUBSCRIBER;
     d->ref.sub = rd->m_iox_sub;
@@ -814,7 +814,6 @@ dds_return_t dds__reader_data_allocator_init (const dds_reader *rd, dds_data_all
 #else
   (void) rd;
   (void) data_allocator;
-  (void) allocate_on_heap;
   return DDS_RETCODE_OK;
 #endif
 }

--- a/src/core/ddsc/src/dds_writer.c
+++ b/src/core/ddsc/src/dds_writer.c
@@ -509,11 +509,11 @@ dds_entity_t dds_get_publisher (dds_entity_t writer)
   }
 }
 
-dds_return_t dds__writer_data_allocator_init (const dds_writer *wr, dds_data_allocator_t *data_allocator, const bool allocate_on_heap)
+dds_return_t dds__writer_data_allocator_init (const dds_writer *wr, dds_data_allocator_t *data_allocator)
 {
 #ifdef DDS_HAS_SHM
   dds_iox_allocator_t *d = (dds_iox_allocator_t *) data_allocator->opaque.bytes;
-  if (NULL != wr->m_iox_pub && !allocate_on_heap)
+  if (NULL != wr->m_iox_pub)
   {
     d->kind = DDS_IOX_ALLOCATOR_KIND_PUBLISHER;
     d->ref.pub = wr->m_iox_pub;
@@ -526,7 +526,6 @@ dds_return_t dds__writer_data_allocator_init (const dds_writer *wr, dds_data_all
 #else
   (void) wr;
   (void) data_allocator;
-  (void) allocate_on_heap;
   return DDS_RETCODE_OK;
 #endif
 }


### PR DESCRIPTION
It is unfortunate that I merged #768 without considering the complications *at this point in time* for the ROS 2 release process. There's nothing wrong with the changes, this is merely coordination with ROS 2.

@sumanth-nirmal, there are two ways to move this forward again: one is to first get approval for the corresponding RMW change, the other is to do by adding a function to construct a "heap-only" allocator instead of adding a parameter. Both can work as far as I am concerned. So it is merely a delay. My apologies for my mistake.