### PR TITLE
Add API to initialise data allocator to allocate on heap

### DIFF
--- a/src/core/ddsc/include/dds/ddsc/dds_data_allocator.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_data_allocator.h
@@ -54,6 +54,23 @@ typedef struct dds_data_allocator {
  */
 DDS_EXPORT dds_return_t dds_data_allocator_init (dds_entity_t entity, dds_data_allocator_t *data_allocator);
 
+/** @brief Initialize an object for performing standard allocations/frees on the heap
+ *
+ * @param[out] data_allocator opaque allocator object to initialize
+ *
+ * @returns success or a generic error indication
+ *
+ * @retval DDS_RETCODE_OK
+ *    the allocator object was successfully initialized
+ * @retval DDS_RETCODE_BAD_PARAMETER
+ *    entity is invalid, data_allocator is a null pointer
+ * @retval DDS_RETCODE_PRECONDITION_NOT_MET
+ *    Cyclone DDS is not initialized
+ * @retval DDS_RETCODE_ILLEGAL_OPERATION
+ *    operation not supported on this entity
+ */
+DDS_EXPORT dds_return_t dds_data_allocator_init_heap (dds_data_allocator_t *data_allocator);
+
 /** @brief Finalize a previously initialized allocator object
  *
  * @param[in,out] data_allocator object to finalize

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -1102,8 +1102,7 @@ static int iceoryx_init (struct ddsi_domaingv *gv)
 {
   shm_set_loglevel(gv->config.shm_log_lvl);
   
-  char str[128];
-  char *sptr = str;
+  char *sptr;
   uint32_t pid = (uint32_t) ddsrt_getpid ();
   
   ddsrt_asprintf (&sptr, "iceoryx_rt_%d_%ld", pid, gv->tstart.v);
@@ -1164,7 +1163,7 @@ static int iceoryx_init (struct ddsi_domaingv *gv)
     gv->loc_iceoryx_addr.kind = NN_LOCATOR_KIND_SHEM;
     gv->loc_iceoryx_addr.port = 0;
     memset ((char *) gv->loc_iceoryx_addr.address, 0, sizeof (gv->loc_iceoryx_addr.address));
-    ddsrt_strlcpy ((char *) gv->loc_iceoryx_addr.address, sptr, strlen (sptr));
+    ddsrt_strlcpy ((char *) gv->loc_iceoryx_addr.address, sptr, strlen (sptr) + 1);
     free(sptr);
   }
 


### PR DESCRIPTION
New API which will intialise the data_allocator to allocate on the heap,
with out the context of any entity (reader or writer). This is
considered as a special case with entity 0.

Signed-off-by: Sumanth Nirmal <sumanth.724@gmail.com>