### PR TITLE
Some fixes IDL compiler for parsing annotations

### DIFF
--- a/src/idl/src/annotation.c
+++ b/src/idl/src/annotation.c
@@ -434,7 +434,7 @@ static const idl_builtin_annotation_t annotations[] = {
     .callback = annotate_value },
   { .syntax =
       "@annotation extensibility {\n"
-      "  enum ExtensibilityKind { FINAL, APPEND, MUTABLE };\n"
+      "  enum ExtensibilityKind { FINAL, APPENDABLE, MUTABLE };\n"
       "  ExtensibilityKind value;\n"
       "};",
     .summary =

--- a/src/idl/src/scope.c
+++ b/src/idl/src/scope.c
@@ -452,10 +452,12 @@ idl_resolve(
   if (pstate->flags & IDL_FLAG_CASE_SENSITIVE)
     ignore_case = 0u;
 
-  if (pstate->parser.state == IDL_PARSE_ANNOTATION_APPL_PARAMS)
+  if (scoped_name->absolute)
+    scope = pstate->global_scope;
+  else if (pstate->parser.state == IDL_PARSE_ANNOTATION_APPL_PARAMS)
     scope = pstate->annotation_scope;
   else
-    scope = (scoped_name->absolute) ? pstate->global_scope : pstate->scope;
+    scope = pstate->scope;
   assert(scope);
 
   for (size_t i=0; i < scoped_name->length && scope;) {

--- a/src/idl/src/scope.c
+++ b/src/idl/src/scope.c
@@ -452,7 +452,10 @@ idl_resolve(
   if (pstate->flags & IDL_FLAG_CASE_SENSITIVE)
     ignore_case = 0u;
 
-  scope = (scoped_name->absolute) ? pstate->global_scope : pstate->scope;
+  if (pstate->parser.state == IDL_PARSE_ANNOTATION_APPL_PARAMS)
+    scope = pstate->annotation_scope;
+  else
+    scope = (scoped_name->absolute) ? pstate->global_scope : pstate->scope;
   assert(scope);
 
   for (size_t i=0; i < scoped_name->length && scope;) {

--- a/src/idl/src/tree.c
+++ b/src/idl/src/tree.c
@@ -2660,6 +2660,7 @@ idl_finalize_annotation_appl(
     while (definition && !member) {
       if (idl_is_annotation_member(definition))
         member = definition;
+      definition = ((idl_node_t *)definition)->next;
     }
     idl_annotation_appl_param_t *parameter = NULL;
     static const size_t size = sizeof(*parameter);

--- a/src/idl/src/tree.c
+++ b/src/idl/src/tree.c
@@ -2493,7 +2493,7 @@ static void *iterate_annotation(const void *ptr, const void *cur)
   const idl_node_t *node = cur;
   assert(root);
   if (node) {
-    assert(idl_parent(root) == node);
+    assert(idl_parent(node) == root);
     return node->next;
   }
   return root->definitions;

--- a/src/idl/tests/annotation.c
+++ b/src/idl/tests/annotation.c
@@ -328,57 +328,43 @@ CU _ Test(idl_annotation, autoid_struct)
 // x. autoid (HASH)
 // x. autoid (SEQUENTIAL)
 
-// x. @extensibility(FINAL)
-// x. @extensibility(APPENDABLE)
-// x. @extensibility(MUTABLE)
+#endif
 
-CU _ Test(idl_annotation, final_struct)
+#define A(ann) ann " struct s { char c; };"
+CU_Test(idl_annotation, struct_extensibility)
 {
+  static const struct {
+    const char *str;
+    enum idl_extensibility ext;
+  } tests[] = {
+    { A("@final"), IDL_EXTENSIBILITY_FINAL },
+    { A("@appendable"), IDL_EXTENSIBILITY_APPENDABLE },
+    { A("@mutable"), IDL_EXTENSIBILITY_MUTABLE},
+    { A("@extensibility(FINAL)"), IDL_EXTENSIBILITY_FINAL },
+    { A("@extensibility(APPENDABLE)"), IDL_EXTENSIBILITY_APPENDABLE },
+    { A("@extensibility(MUTABLE)"), IDL_EXTENSIBILITY_MUTABLE},
+  };
+  static const size_t n = sizeof(tests)/sizeof(tests[0]);
+
   idl_retcode_t ret;
-  idl_tree_t *tree = NULL;
+  idl_pstate_t *pstate = NULL;
   idl_struct_t *s;
-  const char str[] = "@final struct s { char c; };";
 
-  ret = idl_parse_string(str, IDL_FLAG_ANNOTATIONS, &tree);
-  CU_ASSERT_EQUAL_FATAL(ret, IDL_RETCODE_OK);
-  CU_ASSERT_PTR_NOT_NULL(tree);
-  s = (idl_struct_t *)tree->root;
-  CU_ASSERT_FATAL(idl_is_struct(s));
-  CU_ASSERT_EQUAL(s->extensibility, IDL_EXTENSIBILITY_FINAL);
-  idl_delete_tree(tree);
+  for (size_t i = 0; i < n; i++) {
+    pstate = NULL;
+    ret = parse_string(IDL_FLAG_ANNOTATIONS, tests[i].str, &pstate);
+    CU_ASSERT_EQUAL_FATAL(ret, IDL_RETCODE_OK);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(pstate);
+    s = (idl_struct_t *)pstate->root;
+    CU_ASSERT_PTR_NOT_NULL_FATAL(s);
+    CU_ASSERT_FATAL(idl_is_struct(s));
+    CU_ASSERT_EQUAL(s->extensibility, tests[i].ext);
+    idl_delete_pstate(pstate);
+  }
 }
+#undef A
 
-CU _ Test(idl_annotation, appendable_struct)
-{
-  idl_retcode_t ret;
-  idl_tree_t *tree = NULL;
-  idl_struct_t *s;
-  const char str[] = "@appendable struct s { char c; };";
-
-  ret = idl_parse_string(str, IDL_FLAG_ANNOTATIONS, &tree);
-  CU_ASSERT_EQUAL_FATAL(ret, IDL_RETCODE_OK);
-  CU_ASSERT_PTR_NOT_NULL(tree);
-  s = (idl_struct_t *)tree->root;
-  CU_ASSERT_FATAL(idl_is_struct(s));
-  CU_ASSERT_EQUAL(s->extensibility, IDL_EXTENSIBILITY_APPENDABLE);
-  idl_delete_tree(tree);
-}
-
-CU _ Test(idl_annotation, mutable_struct)
-{
-  idl_retcode_t ret;
-  idl_tree_t *tree = NULL;
-  idl_struct_t *s;
-  const char str[] = "@mutable struct s { char c; };";
-
-  ret = idl_parse_string(str, IDL_FLAG_ANNOTATIONS, &tree);
-  CU_ASSERT_EQUAL_FATAL(ret, IDL_RETCODE_OK);
-  CU_ASSERT_PTR_NOT_NULL(tree);
-  s = (idl_struct_t *)tree->root;
-  CU_ASSERT_FATAL(idl_is_struct(s));
-  CU_ASSERT_EQUAL(s->extensibility, IDL_EXTENSIBILITY_MUTABLE);
-  idl_delete_tree(tree);
-}
+#if 0
 
 CU _ Test(idl_annotation, foobar_struct)
 {

--- a/src/idl/tests/annotation.c
+++ b/src/idl/tests/annotation.c
@@ -361,8 +361,10 @@ CU_Test(idl_annotation, struct_extensibility)
     ret = parse_string(IDL_FLAG_ANNOTATIONS, tests[i].str, &pstate);
     CU_ASSERT_EQUAL_FATAL(ret, IDL_RETCODE_OK);
     CU_ASSERT_PTR_NOT_NULL_FATAL(pstate);
+    assert(pstate);
     s = (idl_struct_t *)pstate->root;
     CU_ASSERT_PTR_NOT_NULL_FATAL(s);
+    assert(s);
     CU_ASSERT_FATAL(idl_is_struct(s));
     CU_ASSERT_EQUAL(s->extensibility, tests[i].ext);
     idl_delete_pstate(pstate);


### PR DESCRIPTION
- fix a bug in annotation_appl parameter handling
- typo fix in extensibility annotation enum value for appendable
- enable tests for parsing extensibility annotations
