### PR TITLE
Add missing build_depend on JDK for IDLC in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,7 @@
     <buildtool_depend>cmake</buildtool_depend>
 
     <build_depend>libssl-dev</build_depend>
+    <build_depend>java</build_depend>
 
     <exec_depend>openssl</exec_depend>
 


### PR DESCRIPTION
The main branch deleted the Java based IDL compiler and there where quite a number of commits that shouldn't land in 0.7.x, so this is quick copy of #643, but with only that change. Thanks @JWhitleyWork!