### PR TITLE
Register number of unused labels in union

### DIFF
--- a/src/idl/include/idl/tree.h
+++ b/src/idl/include/idl/tree.h
@@ -56,6 +56,10 @@
 #define IDL_FORWARD (1llu<<29)
 #define IDL_CASE (1llu<<28)
 #define IDL_CASE_LABEL (1llu<<27)
+/* if explicit default is specified */
+#define IDL_DEFAULT_CASE_LABEL (IDL_CASE_LABEL | 1u)
+/* if no explicit default is specified and range is not covered */
+#define IDL_IMPLICIT_DEFAULT_CASE_LABEL (IDL_DEFAULT_CASE_LABEL | 2u)
 #define IDL_ENUMERATOR (1llu<<26)
 #define IDL_DECLARATOR (1llu<<25)
 /* annotations */
@@ -359,27 +363,22 @@ struct idl_switch_type_spec {
   idl_boolean_t key;
 };
 
-typedef struct idl_default_discriminator idl_default_discriminator_t;
-struct idl_default_discriminator {
-  enum {
-    IDL_DEFAULT_CASE, /** union has a default case specified */
-    IDL_IMPLICIT_DEFAULT, /** union has an implicit default member */
-    IDL_FIRST_DISCRIMINANT /** entire range covered, no default */
-  } condition;
-  idl_const_expr_t *const_expr;
-  const idl_case_t *branch; /** branch associated with discriminant, if any */
-};
-
 typedef struct idl_union idl_union_t;
 struct idl_union {
   idl_node_t node;
   struct idl_name *name;
   idl_switch_type_spec_t *switch_type_spec;
-  idl_case_t *branches;
+  idl_case_t *cases;
   /* metadata */
+  /* label associated with the default value for the discriminator. i.e.
+   * the first discriminant value if the entire range of the discriminator is
+   * covered, the default case if specified, or a spontaneously materialised
+   * implicit default case that does not reference any branch
+   */
+  idl_case_label_t *default_case;
+  uint64_t unused_labels; /**< number of unused labels */
   idl_nested_t nested; /**< if type is topic (sum total of annotations) */
   idl_extensibility_t extensibility;
-  idl_default_discriminator_t default_discriminator;
 };
 
 typedef struct idl_enumerator idl_enumerator_t;

--- a/src/tools/idlc/src/descriptor.c
+++ b/src/tools/idlc/src/descriptor.c
@@ -727,7 +727,7 @@ emit_union(
       return ret;
     pop_type(descriptor);
   } else {
-    const idl_case_t *branch;
+    const idl_case_t *_case;
     const idl_case_label_t *label;
 
     if ((ret = push_type(descriptor, node, &type)))
@@ -737,9 +737,9 @@ emit_union(
 
     /* determine total number of case labels as opcodes for complex elements
        are stored after case label opcodes */
-    branch = ((const idl_union_t *)node)->branches;
-    for (; branch; branch = idl_next(branch)) {
-      for (label = branch->labels; label; label = idl_next(label))
+    _case = ((const idl_union_t *)node)->cases;
+    for (; _case; _case = idl_next(_case)) {
+      for (label = _case->labels; label; label = idl_next(label))
         type->labels++;
     }
 


### PR DESCRIPTION
* Register number of unused labels in each union for easy generation of member modifiers in generators. e.g. C++11 generator.
* Introduce IDL_DEFAULT_CASE_LABEL and IDL_IMPLICIT_DEFAULT_CASE_LABEL masks and reference the discriminant value in const_expr member of labels for default and implicit default cases respectively.
* Drop default_discriminator member from union in favor of default_case member that references label associated with default discriminant value.