### PR TITLE
ddsi_ipaddr_is_nearby_address: ignore non-IP ones

### DIFF
--- a/src/core/ddsi/src/ddsi_ipaddr.c
+++ b/src/core/ddsi/src/ddsi_ipaddr.c
@@ -61,6 +61,9 @@ enum ddsi_nearby_address_result ddsi_ipaddr_is_nearby_address (const ddsi_locato
   ddsi_ipaddr_from_loc(&tmp, loc);
   for (size_t i = 0; i < ninterf; i++)
   {
+    if (interf[i].loc.kind != loc->kind)
+      continue;
+
     ddsi_ipaddr_from_loc(&iftmp, &interf[i].loc);
     ddsi_ipaddr_from_loc(&nmtmp, &interf[i].netmask);
     if (ddsrt_sockaddr_insamesubnet ((struct sockaddr *) &tmp, (struct sockaddr *) &iftmp, (struct sockaddr *) &nmtmp))


### PR DESCRIPTION
This fixes an assert(0) in converting a locator to an IP address when
the interface is not actually using IP addressing, e.g., when it is the
virtual one representing Iceoryx.

In a release build it would behave correctly because the interface
address would be all-zero and hence the address families in the struct
sockaddr would be different.

Signed-off-by: Erik Boasson <eb@ilities.com>