### PR TITLE
Allow Iceoryx use for best-effort readers

### DIFF
--- a/src/core/ddsc/src/dds_reader.c
+++ b/src/core/ddsc/src/dds_reader.c
@@ -460,7 +460,6 @@ static bool dds_reader_support_shm(const struct ddsi_config* cfg, const dds_qos_
     DDS_READER_QOS_CHECK_FIELDS == (qos->present & DDS_READER_QOS_CHECK_FIELDS) &&
     DDS_LIVELINESS_AUTOMATIC == qos->liveliness.kind &&
     DDS_INFINITY == qos->deadline.deadline &&
-    DDS_RELIABILITY_RELIABLE == qos->reliability.kind &&
     DDS_DURABILITY_VOLATILE == qos->durability.kind &&
     DDS_HISTORY_KEEP_LAST == qos->history.kind &&
     (int)sub_history_req >= (int)qos->history.depth);


### PR DESCRIPTION
This doesn't break the QoS matching rules for DDS while allowing the
case of a reliable writer delivering data to a best-effort reader via
Iceoryx.

Signed-off-by: Erik Boasson <eb@ilities.com>