### PR TITLE
Avoid serialization in write for volatile writers

### DIFF
--- a/src/core/ddsc/src/dds_write.c
+++ b/src/core/ddsc/src/dds_write.c
@@ -461,6 +461,37 @@ static dds_return_t dds_writecdr_impl_common (struct writer *ddsi_wr, struct nn_
   return ret;
 }
 
+static bool evalute_topic_filter (const dds_writer *wr, const void *data, bool writekey)
+{
+  // false if data rejected by filter
+  if (wr->m_topic->m_filter.mode == DDS_TOPIC_FILTER_NONE || writekey)
+    return true;
+
+  const struct dds_topic_filter *f = &wr->m_topic->m_filter;
+  switch (f->mode)
+  {
+    case DDS_TOPIC_FILTER_NONE:
+    case DDS_TOPIC_FILTER_SAMPLEINFO_ARG:
+      break;
+    case DDS_TOPIC_FILTER_SAMPLE:
+      if (!f->f.sample (data))
+        return false;
+      break;
+    case DDS_TOPIC_FILTER_SAMPLE_ARG:
+      if (!f->f.sample_arg (data, f->arg))
+        return false;
+      break;
+    case DDS_TOPIC_FILTER_SAMPLE_SAMPLEINFO_ARG: {
+      struct dds_sample_info si;
+      memset (&si, 0, sizeof (si));
+      if (!f->f.sample_sampleinfo_arg (data, &si, f->arg))
+        return false;
+      break;
+    }
+  }
+  return true;
+}
+
 #ifdef DDS_HAS_SHM
 dds_return_t dds_write_impl (dds_writer *wr, const void * data, dds_time_t tstamp, dds_write_action action)
 {
@@ -474,31 +505,8 @@ dds_return_t dds_write_impl (dds_writer *wr, const void * data, dds_time_t tstam
     return DDS_RETCODE_BAD_PARAMETER;
 
   // 2. Topic filter
-  if (!writekey && wr->m_topic->m_filter.mode != DDS_TOPIC_FILTER_NONE)
-  {
-    const struct dds_topic_filter *f = &wr->m_topic->m_filter;
-    switch (f->mode)
-    {
-      case DDS_TOPIC_FILTER_NONE:
-      case DDS_TOPIC_FILTER_SAMPLEINFO_ARG:
-        break;
-      case DDS_TOPIC_FILTER_SAMPLE:
-        if (!f->f.sample (data))
-          return DDS_RETCODE_OK;
-        break;
-      case DDS_TOPIC_FILTER_SAMPLE_ARG:
-        if (!f->f.sample_arg (data, f->arg))
-          return DDS_RETCODE_OK;
-        break;
-      case DDS_TOPIC_FILTER_SAMPLE_SAMPLEINFO_ARG: {
-        struct dds_sample_info si;
-        memset (&si, 0, sizeof (si));
-        if (!f->f.sample_sampleinfo_arg (data, &si, f->arg))
-          return DDS_RETCODE_OK;
-        break;
-      }
-    }
-  }
+  if (!evalute_topic_filter (wr, data, writekey))
+    return DDS_RETCODE_OK;
 
   thread_state_awake (ts1, &wr->m_entity.m_domain->gv);
 
@@ -608,31 +616,8 @@ dds_return_t dds_write_impl (dds_writer *wr, const void * data, dds_time_t tstam
     return DDS_RETCODE_BAD_PARAMETER;
 
   /* Check for topic filter */
-  if (!writekey && wr->m_topic->m_filter.mode != DDS_TOPIC_FILTER_NONE)
-  {
-    const struct dds_topic_filter *f = &wr->m_topic->m_filter;
-    switch (f->mode)
-    {
-      case DDS_TOPIC_FILTER_NONE:
-      case DDS_TOPIC_FILTER_SAMPLEINFO_ARG:
-        break;
-      case DDS_TOPIC_FILTER_SAMPLE:
-        if (!f->f.sample (data))
-          return DDS_RETCODE_OK;
-        break;
-      case DDS_TOPIC_FILTER_SAMPLE_ARG:
-        if (!f->f.sample_arg (data, f->arg))
-          return DDS_RETCODE_OK;
-        break;
-      case DDS_TOPIC_FILTER_SAMPLE_SAMPLEINFO_ARG: {
-        struct dds_sample_info si;
-        memset (&si, 0, sizeof (si));
-        if (!f->f.sample_sampleinfo_arg (data, &si, f->arg))
-          return DDS_RETCODE_OK;
-        break;
-      }
-    }
-  }
+  if (!evalute_topic_filter(wr, data, writekey))
+    return DDS_RETCODE_OK;
 
   thread_state_awake (ts1, &wr->m_entity.m_domain->gv);
 

--- a/src/core/ddsc/src/dds_write.c
+++ b/src/core/ddsc/src/dds_write.c
@@ -593,9 +593,7 @@ dds_return_t dds_write_impl (dds_writer *wr, const void * data, dds_time_t tstam
     // where we either have network readers (requiring serialization) or not.
 
     // do not serialize yet (may not need it if only using iceoryx or no readers)
-    // TODO: specific iceoryx only serialization
-    //d = ddsi_serdata_from_sample_for_iox (ddsi_wr->type, writekey ? SDK_KEY : SDK_DATA, data);
-    d = ddsi_serdata_from_sample (ddsi_wr->type, writekey ? SDK_KEY : SDK_DATA, data);
+    d = ddsi_serdata_from_sample_for_iox (ddsi_wr->type, writekey ? SDK_KEY : SDK_DATA, data);
   } else {
     // serialize since we will need to send via network anyway
     d = ddsi_serdata_from_sample (ddsi_wr->type, writekey ? SDK_KEY : SDK_DATA, data);

--- a/src/core/ddsc/src/dds_write.c
+++ b/src/core/ddsc/src/dds_write.c
@@ -522,7 +522,12 @@ dds_return_t dds_write_impl (dds_writer *wr, const void * data, dds_time_t tstam
     } 
   }
 
+  // ddsi_wr->as can be changed by the matching/unmatching of proxy readers if we don't hold the lock
+  // it is rather unfortunate that this then means we have to lock here to check, then lock again to
+  // actually distribute the data, so some further refactoring is needed.
+  ddsrt_mutex_lock (&ddsi_wr->e.lock);
   bool no_network_readers = addrset_empty (ddsi_wr->as);
+  ddsrt_mutex_unlock (&ddsi_wr->e.lock);
   bool use_only_iceoryx = iceoryx_available && no_network_readers;
 
   // iceoryx_available implies volatile 

--- a/src/core/ddsc/src/dds_write.c
+++ b/src/core/ddsc/src/dds_write.c
@@ -410,120 +410,6 @@ static dds_return_t deliver_data (struct writer *ddsi_wr, dds_writer *wr, struct
   return ret;
 }
 
-dds_return_t dds_write_impl (dds_writer *wr, const void * data, dds_time_t tstamp, dds_write_action action)
-{
-  // 1. Input validation
-  struct thread_state1 * const ts1 = lookup_thread_state ();
-  const bool writekey = action & DDS_WR_KEY_BIT;
-  struct writer *ddsi_wr = wr->m_wr;
-  int ret = DDS_RETCODE_OK;
-
-  if (data == NULL)
-    return DDS_RETCODE_BAD_PARAMETER;
-
-  // 2. Topic filter
-  if (!writekey && wr->m_topic->m_filter.mode != DDS_TOPIC_FILTER_NONE)
-  {
-    const struct dds_topic_filter *f = &wr->m_topic->m_filter;
-    switch (f->mode)
-    {
-      case DDS_TOPIC_FILTER_NONE:
-      case DDS_TOPIC_FILTER_SAMPLEINFO_ARG:
-        break;
-      case DDS_TOPIC_FILTER_SAMPLE:
-        if (!f->f.sample (data))
-          return DDS_RETCODE_OK;
-        break;
-      case DDS_TOPIC_FILTER_SAMPLE_ARG:
-        if (!f->f.sample_arg (data, f->arg))
-          return DDS_RETCODE_OK;
-        break;
-      case DDS_TOPIC_FILTER_SAMPLE_SAMPLEINFO_ARG: {
-        struct dds_sample_info si;
-        memset (&si, 0, sizeof (si));
-        if (!f->f.sample_sampleinfo_arg (data, &si, f->arg))
-          return DDS_RETCODE_OK;
-        break;
-      }
-    }
-  }
-
-  thread_state_awake (ts1, &wr->m_entity.m_domain->gv);
-
-  // 3. Check availability of iceoryx and reader status
-  // note: condition checking can be optimized - focus on readability first
-
-  bool no_network_readers = addrset_empty (ddsi_wr->as) && (ddsi_wr->as_group == NULL || addrset_empty (ddsi_wr->as_group));
-  bool iceoryx_available = wr->m_iox_pub != NULL;
-  bool use_only_iceoryx = iceoryx_available && no_network_readers && ddsi_wr->xqos->durability.kind == DDS_DURABILITY_VOLATILE;
-  //note that volatile is currently implied by the availability of iceoryx
-
-  if(iceoryx_available) {
-    //note: whether the data was loaned cannot be determined in the non-iceoryx case currently
-    if(!deregister_pub_loan(wr, data))
-    {
-      void* chunk_data = create_iox_chunk(wr); 
-      memcpy (chunk_data, data, wr->m_topic->m_stype->iox_size);
-      data = chunk_data; // note that this points to the data in the chunk which is preceded by the iceoryx header
-    } 
-  } 
-
-  // 4. Prepare serdata
-  // avoid serialization for volatile writers if there are no network readers
-
-  struct ddsi_serdata *d = NULL;
-
-  if(use_only_iceoryx) {
-    // note: If we could keep ownership of the loaned data after iox publish we could implement lazy
-    // serialization (only serializing when sending from writer history cache, i.e. not when storing).
-    // The benefit of this would be minor in most cases though, when we assume a static configuration
-    // where we either have network readers (requiring serialization) or not.
-
-    // do not serialize yet (may not need it if only using iceoryx or no readers)
-    d = ddsi_serdata_from_sample_for_iox (ddsi_wr->type, writekey ? SDK_KEY : SDK_DATA, data);
-  } else {
-    // serialize since we will need to send via network anyway
-    d = ddsi_serdata_from_sample (ddsi_wr->type, writekey ? SDK_KEY : SDK_DATA, data);
-  }
-
-  if(d == NULL) {
-    ret = DDS_RETCODE_BAD_PARAMETER; // or more appropriately error?
-    goto finalize_write;
-  }
-
-  // should be done in the serdata construction but we explicitly set it here for now
-  if(iceoryx_available) {
-    d->iox_chunk = SHIFT_BACK_TO_ICEORYX_HEADER(data); // serialization has not been performed
-  } else {
-    d->iox_chunk = NULL; // also indicates that serialization has been performed
-  }
-
-  d->statusinfo = (((action & DDS_WR_DISPOSE_BIT) ? NN_STATUSINFO_DISPOSE : 0) |
-                  ((action & DDS_WR_UNREGISTER_BIT) ? NN_STATUSINFO_UNREGISTER : 0));
-  d->timestamp.v = tstamp;
-
-  // 5. Deliver the data
-
-  if(use_only_iceoryx) {
-    // deliver via iceoryx only
-    ddsi_serdata_ref (d);
-    if(deliver_data_via_iceoryx(wr, d)) {
-      ret = DDS_RETCODE_OK;
-    } else {
-      ret = DDS_RETCODE_ERROR;
-    }
-    ddsi_serdata_unref(d);
-  } else {
-    // this may convert the input data if needed (convert_serdata) and then deliver it using
-    // network AND/OR iceoryx as required
-    ret = dds_writecdr_impl_common(ddsi_wr, wr->m_xp, d, !wr->whc_batch, wr);
-  }
-
-finalize_write:
-  thread_state_asleep (ts1);
-  return ret;
-}
-
 #if 0
 // old implementation, remove later
 static dds_return_t dds_writecdr_impl_common (struct writer *ddsi_wr, struct nn_xpack *xp, struct ddsi_serdata *dinp, bool flush, dds_writer *wr)
@@ -629,6 +515,201 @@ static dds_return_t dds_writecdr_impl_common (struct writer *ddsi_wr, struct nn_
 
   ddsi_serdata_unref (dact);
 
+  thread_state_asleep (ts1);
+  return ret;
+}
+#endif
+
+
+#ifdef DDS_HAS_SHM
+// implementation if no shared memory (iceoryx) is available
+dds_return_t dds_write_impl (dds_writer *wr, const void * data, dds_time_t tstamp, dds_write_action action)
+{
+  // 1. Input validation
+  struct thread_state1 * const ts1 = lookup_thread_state ();
+  const bool writekey = action & DDS_WR_KEY_BIT;
+  struct writer *ddsi_wr = wr->m_wr;
+  int ret = DDS_RETCODE_OK;
+
+  if (data == NULL)
+    return DDS_RETCODE_BAD_PARAMETER;
+
+  // 2. Topic filter
+  if (!writekey && wr->m_topic->m_filter.mode != DDS_TOPIC_FILTER_NONE)
+  {
+    const struct dds_topic_filter *f = &wr->m_topic->m_filter;
+    switch (f->mode)
+    {
+      case DDS_TOPIC_FILTER_NONE:
+      case DDS_TOPIC_FILTER_SAMPLEINFO_ARG:
+        break;
+      case DDS_TOPIC_FILTER_SAMPLE:
+        if (!f->f.sample (data))
+          return DDS_RETCODE_OK;
+        break;
+      case DDS_TOPIC_FILTER_SAMPLE_ARG:
+        if (!f->f.sample_arg (data, f->arg))
+          return DDS_RETCODE_OK;
+        break;
+      case DDS_TOPIC_FILTER_SAMPLE_SAMPLEINFO_ARG: {
+        struct dds_sample_info si;
+        memset (&si, 0, sizeof (si));
+        if (!f->f.sample_sampleinfo_arg (data, &si, f->arg))
+          return DDS_RETCODE_OK;
+        break;
+      }
+    }
+  }
+
+  thread_state_awake (ts1, &wr->m_entity.m_domain->gv);
+
+  // 3. Check availability of iceoryx and reader status
+  // note: condition checking can be optimized - focus on readability first
+
+  bool no_network_readers = addrset_empty (ddsi_wr->as) && (ddsi_wr->as_group == NULL || addrset_empty (ddsi_wr->as_group));
+  bool iceoryx_available = wr->m_iox_pub != NULL;
+  bool use_only_iceoryx = iceoryx_available && no_network_readers && ddsi_wr->xqos->durability.kind == DDS_DURABILITY_VOLATILE;
+  //note that volatile is currently implied by the availability of iceoryx
+
+  if(iceoryx_available) {
+    //note: whether the data was loaned cannot be determined in the non-iceoryx case currently
+    if(!deregister_pub_loan(wr, data))
+    {
+      void* chunk_data = create_iox_chunk(wr); 
+      memcpy (chunk_data, data, wr->m_topic->m_stype->iox_size);
+      data = chunk_data; // note that this points to the data in the chunk which is preceded by the iceoryx header
+    } 
+  } 
+
+  // 4. Prepare serdata
+  // avoid serialization for volatile writers if there are no network readers
+
+  struct ddsi_serdata *d = NULL;
+
+  if(use_only_iceoryx) {
+    // note: If we could keep ownership of the loaned data after iox publish we could implement lazy
+    // serialization (only serializing when sending from writer history cache, i.e. not when storing).
+    // The benefit of this would be minor in most cases though, when we assume a static configuration
+    // where we either have network readers (requiring serialization) or not.
+
+    // do not serialize yet (may not need it if only using iceoryx or no readers)
+    // TODO: specific iceoryx only serialization
+    //d = ddsi_serdata_from_sample_for_iox (ddsi_wr->type, writekey ? SDK_KEY : SDK_DATA, data);
+    d = ddsi_serdata_from_sample (ddsi_wr->type, writekey ? SDK_KEY : SDK_DATA, data);
+  } else {
+    // serialize since we will need to send via network anyway
+    d = ddsi_serdata_from_sample (ddsi_wr->type, writekey ? SDK_KEY : SDK_DATA, data);
+  }
+
+  if(d == NULL) {
+    ret = DDS_RETCODE_BAD_PARAMETER; // or more appropriately error?
+    goto finalize_write;
+  }
+
+  // should be done in the serdata construction but we explicitly set it here for now
+  if(iceoryx_available) {
+    d->iox_chunk = SHIFT_BACK_TO_ICEORYX_HEADER(data); // serialization has not been performed
+  } else {
+    d->iox_chunk = NULL; // also indicates that serialization has been performed
+  }
+
+  d->statusinfo = (((action & DDS_WR_DISPOSE_BIT) ? NN_STATUSINFO_DISPOSE : 0) |
+                  ((action & DDS_WR_UNREGISTER_BIT) ? NN_STATUSINFO_UNREGISTER : 0));
+  d->timestamp.v = tstamp;
+
+  // 5. Deliver the data
+
+  if(use_only_iceoryx) {
+    // deliver via iceoryx only
+    ddsi_serdata_ref (d);
+    if(deliver_data_via_iceoryx(wr, d)) {
+      ret = DDS_RETCODE_OK;
+    } else {
+      ret = DDS_RETCODE_ERROR;
+    }
+    ddsi_serdata_unref(d);
+  } else {
+    // this may convert the input data if needed (convert_serdata) and then deliver it using
+    // network AND/OR iceoryx as required
+    ret = dds_writecdr_impl_common(ddsi_wr, wr->m_xp, d, !wr->whc_batch, wr);
+  }
+
+finalize_write:
+  thread_state_asleep (ts1);
+  return ret;
+}
+
+#else
+
+// implementation if no shared memory (iceoryx) is available
+dds_return_t dds_write_impl (dds_writer *wr, const void * data, dds_time_t tstamp, dds_write_action action)
+{
+  struct thread_state1 * const ts1 = lookup_thread_state ();
+  const bool writekey = action & DDS_WR_KEY_BIT;
+  struct writer *ddsi_wr = wr->m_wr;
+  struct ddsi_serdata *d;
+  dds_return_t ret = DDS_RETCODE_OK;
+
+  if (data == NULL)
+    return DDS_RETCODE_BAD_PARAMETER;
+
+  /* Check for topic filter */
+  if (!writekey && wr->m_topic->m_filter.mode != DDS_TOPIC_FILTER_NONE)
+  {
+    const struct dds_topic_filter *f = &wr->m_topic->m_filter;
+    switch (f->mode)
+    {
+      case DDS_TOPIC_FILTER_NONE:
+      case DDS_TOPIC_FILTER_SAMPLEINFO_ARG:
+        break;
+      case DDS_TOPIC_FILTER_SAMPLE:
+        if (!f->f.sample (data))
+          return DDS_RETCODE_OK;
+        break;
+      case DDS_TOPIC_FILTER_SAMPLE_ARG:
+        if (!f->f.sample_arg (data, f->arg))
+          return DDS_RETCODE_OK;
+        break;
+      case DDS_TOPIC_FILTER_SAMPLE_SAMPLEINFO_ARG: {
+        struct dds_sample_info si;
+        memset (&si, 0, sizeof (si));
+        if (!f->f.sample_sampleinfo_arg (data, &si, f->arg))
+          return DDS_RETCODE_OK;
+        break;
+      }
+    }
+  }
+
+  thread_state_awake (ts1, &wr->m_entity.m_domain->gv);
+
+  /* Serialize and write data or key */
+  if ((d = ddsi_serdata_from_sample (ddsi_wr->type, writekey ? SDK_KEY : SDK_DATA, data)) == NULL)
+    ret = DDS_RETCODE_BAD_PARAMETER;
+  else
+  {
+    struct ddsi_tkmap_instance *tk;
+    d->statusinfo = (((action & DDS_WR_DISPOSE_BIT) ? NN_STATUSINFO_DISPOSE : 0) |
+                     ((action & DDS_WR_UNREGISTER_BIT) ? NN_STATUSINFO_UNREGISTER : 0));
+    d->timestamp.v = tstamp;
+    ddsi_serdata_ref (d);
+
+    tk = ddsi_tkmap_lookup_instance_ref (wr->m_entity.m_domain->gv.m_tkmap, d);
+    ret = write_sample_gc (ts1, wr->m_xp, ddsi_wr, d, tk);
+
+    if (ret >= 0) {
+      /* Flush out write unless configured to batch */
+      if (!wr->whc_batch)
+        nn_xpack_send (wr->m_xp, false);
+      ret = DDS_RETCODE_OK;
+    } else if (ret != DDS_RETCODE_TIMEOUT) {
+      ret = DDS_RETCODE_ERROR;
+    } 
+
+    if (ret == DDS_RETCODE_OK)
+      ret = deliver_locally (ddsi_wr, d, tk);
+    ddsi_serdata_unref (d);
+    ddsi_tkmap_instance_unref (wr->m_entity.m_domain->gv.m_tkmap, tk);
+  }
   thread_state_asleep (ts1);
   return ret;
 }

--- a/src/core/ddsc/src/dds_write.c
+++ b/src/core/ddsc/src/dds_write.c
@@ -29,6 +29,7 @@
 
 #ifdef DDS_HAS_SHM
 #include "dds/ddsi/shm_sync.h"
+#include "dds/ddsi/q_addrset.h"
 #endif
 
 #ifdef DDS_HAS_SHM
@@ -632,9 +633,7 @@ dds_return_t dds_write_impl (dds_writer *wr, const void * data, dds_time_t tstam
     // where we either have network readers (requiring serialization) or not.
 
     // do not serialize yet (may not need it if only using iceoryx or no readers)
-    // TODO: specific iceoryx only serialization
-    //d = ddsi_serdata_from_sample_for_iox (ddsi_wr->type, writekey ? SDK_KEY : SDK_DATA, data);
-    d = ddsi_serdata_from_sample (ddsi_wr->type, writekey ? SDK_KEY : SDK_DATA, data);
+    d = ddsi_serdata_from_sample_for_iox (ddsi_wr->type, writekey ? SDK_KEY : SDK_DATA, data);
   } else {
     // serialize since we will need to send via network anyway
     d = ddsi_serdata_from_sample (ddsi_wr->type, writekey ? SDK_KEY : SDK_DATA, data);

--- a/src/core/ddsi/include/dds/ddsi/ddsi_serdata.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_serdata.h
@@ -170,6 +170,11 @@ typedef uint32_t(*ddsi_serdata_iox_size_t) (const struct ddsi_serdata* d);
 
 // sub is really an iox_sub_t *
 typedef struct ddsi_serdata* (*ddsi_serdata_from_iox_t) (const struct ddsi_sertype* type, enum ddsi_serdata_kind kind, void* sub, void* iox_buffer);
+
+// Construct serdata from a sample in an efficient way suitable for iceoryx transport.
+// Depending on the implementation this does not need to actually serialize, allowing for
+// zero-copy data transfer.
+typedef struct ddsi_serdata* (*ddsi_serdata_from_sample_for_iox_t) (const struct ddsi_sertype *type, enum ddsi_serdata_kind kind, const char *sample);
 #endif
 
 struct ddsi_serdata_ops {
@@ -191,6 +196,7 @@ struct ddsi_serdata_ops {
 #ifdef DDS_HAS_SHM
   ddsi_serdata_iox_size_t get_sample_size;
   ddsi_serdata_from_iox_t from_iox_buffer;
+  ddsi_serdata_from_sample_for_iox_t from_sample_for_iox;
 #endif
 };
 
@@ -321,6 +327,10 @@ DDS_INLINE_EXPORT inline uint32_t ddsi_serdata_iox_size(const struct ddsi_serdat
 DDS_INLINE_EXPORT inline struct ddsi_serdata* ddsi_serdata_from_iox(const struct ddsi_sertype* type, enum ddsi_serdata_kind kind, void* sub, void* iox_buffer)
 {
   return type->serdata_ops->from_iox_buffer(type, kind, sub, iox_buffer);
+}
+
+DDS_EXPORT inline struct ddsi_serdata* ddsi_serdata_from_sample_for_iox (const struct ddsi_sertype *type, enum ddsi_serdata_kind kind, const char *sample) {
+  return type->serdata_ops->from_sample_for_iox(type, kind, sample);
 }
 #endif
 

--- a/src/core/ddsi/src/ddsi_serdata.c
+++ b/src/core/ddsi/src/ddsi_serdata.c
@@ -86,7 +86,6 @@ DDS_EXPORT extern inline bool ddsi_serdata_print_untyped (const struct ddsi_sert
 DDS_EXPORT extern inline void ddsi_serdata_get_keyhash (const struct ddsi_serdata *d, struct ddsi_keyhash *buf, bool force_md5);
 #ifdef DDS_HAS_SHM
 DDS_EXPORT extern inline uint32_t ddsi_serdata_iox_size(const struct ddsi_serdata* d);
-// sub really is an iox_sub_t *
 DDS_EXPORT extern inline struct ddsi_serdata* ddsi_serdata_from_iox(const struct ddsi_sertype* type, enum ddsi_serdata_kind kind, void* sub, void* iox_buffer);
-DDS_EXPORT extern inline struct ddsi_serdata* ddsi_serdata_from_sample_for_iox(const struct ddsi_sertype *type, enum ddsi_serdata_kind kind, const char *sample);
+DDS_EXPORT extern inline struct ddsi_serdata* ddsi_serdata_from_loaned_sample(const struct ddsi_sertype *type, enum ddsi_serdata_kind kind, const char *sample);
 #endif

--- a/src/core/ddsi/src/ddsi_serdata.c
+++ b/src/core/ddsi/src/ddsi_serdata.c
@@ -88,4 +88,5 @@ DDS_EXPORT extern inline void ddsi_serdata_get_keyhash (const struct ddsi_serdat
 DDS_EXPORT extern inline uint32_t ddsi_serdata_iox_size(const struct ddsi_serdata* d);
 // sub really is an iox_sub_t *
 DDS_EXPORT extern inline struct ddsi_serdata* ddsi_serdata_from_iox(const struct ddsi_sertype* type, enum ddsi_serdata_kind kind, void* sub, void* iox_buffer);
+DDS_EXPORT extern inline struct ddsi_serdata* ddsi_serdata_from_sample_for_iox(const struct ddsi_sertype *type, enum ddsi_serdata_kind kind, const char *sample);
 #endif

--- a/src/core/ddsi/src/ddsi_serdata_default.c
+++ b/src/core/ddsi/src/ddsi_serdata_default.c
@@ -452,6 +452,23 @@ static struct ddsi_serdata* serdata_default_from_iox(const struct ddsi_sertype* 
 
   return (struct ddsi_serdata*)d;
 }
+
+// Creates a serdata for the case where only iceoryx is required (i.e. no network).
+// This skips expensive serialization and just takes ownership of the iceoryx buffer.
+// Computing the keyhash is currently still required.
+static struct ddsi_serdata *ddsi_serdata_default_from_sample_for_iox (const struct ddsi_sertype *type, enum ddsi_serdata_kind kind, const char *sample) {
+  const struct ddsi_sertype_default *t = (const struct ddsi_sertype_default *)type;
+  struct ddsi_serdata_default *d = serdata_default_new(t, kind);
+
+  if(d == NULL) 
+    return NULL;
+
+  gen_keyhash_from_sample (t, &d->keyhash, sample);
+
+  struct ddsi_serdata *serdata = (struct ddsi_serdata*) d;
+  serdata->iox_chunk = SHIFT_BACK_TO_ICEORYX_HEADER(sample);
+  return serdata; 
+}
 #endif
 
 static struct ddsi_serdata_default *serdata_default_from_sample_cdr_common (const struct ddsi_sertype *tpcmn, enum ddsi_serdata_kind kind, const void *sample)
@@ -661,6 +678,7 @@ const struct ddsi_serdata_ops ddsi_serdata_ops_cdr = {
 #ifdef DDS_HAS_SHM
   , .get_sample_size = ddsi_serdata_iox_size
   , .from_iox_buffer = serdata_default_from_iox
+  , .from_sample_for_iox = ddsi_serdata_default_from_sample_for_iox
 #endif
 };
 
@@ -683,5 +701,6 @@ const struct ddsi_serdata_ops ddsi_serdata_ops_cdr_nokey = {
 #ifdef DDS_HAS_SHM
   , .get_sample_size = ddsi_serdata_iox_size
   , .from_iox_buffer = serdata_default_from_iox
+  , .from_sample_for_iox = ddsi_serdata_default_from_sample_for_iox
 #endif
 };

--- a/src/core/ddsi/src/ddsi_serdata_default.c
+++ b/src/core/ddsi/src/ddsi_serdata_default.c
@@ -456,16 +456,19 @@ static struct ddsi_serdata* serdata_default_from_iox(const struct ddsi_sertype* 
 // Creates a serdata for the case where only iceoryx is required (i.e. no network).
 // This skips expensive serialization and just takes ownership of the iceoryx buffer.
 // Computing the keyhash is currently still required.
-static struct ddsi_serdata *ddsi_serdata_default_from_sample_for_iox (const struct ddsi_sertype *type, enum ddsi_serdata_kind kind, const char *sample) {
+static struct ddsi_serdata *ddsi_serdata_default_from_loaned_sample (const struct ddsi_sertype *type, enum ddsi_serdata_kind kind, const char *sample) {
   const struct ddsi_sertype_default *t = (const struct ddsi_sertype_default *)type;
   struct ddsi_serdata_default *d = serdata_default_new(t, kind);
 
   if(d == NULL) 
     return NULL;
 
+  // Currently needed even in the shared memory case (since it is potentially used at the reader side).
+  // This may still incur computational costs linear in the sample size (?).
+  // TODO: Can we avoid this with specific handling on the reader side which does not require the keyhash?
   gen_keyhash_from_sample (t, &d->keyhash, sample);
 
-  struct ddsi_serdata *serdata = (struct ddsi_serdata*) d;
+  struct ddsi_serdata *serdata = &d->c;
   serdata->iox_chunk = SHIFT_BACK_TO_ICEORYX_HEADER(sample);
   return serdata; 
 }
@@ -678,7 +681,7 @@ const struct ddsi_serdata_ops ddsi_serdata_ops_cdr = {
 #ifdef DDS_HAS_SHM
   , .get_sample_size = ddsi_serdata_iox_size
   , .from_iox_buffer = serdata_default_from_iox
-  , .from_sample_for_iox = ddsi_serdata_default_from_sample_for_iox
+  , .from_loaned_sample = ddsi_serdata_default_from_loaned_sample
 #endif
 };
 
@@ -701,6 +704,6 @@ const struct ddsi_serdata_ops ddsi_serdata_ops_cdr_nokey = {
 #ifdef DDS_HAS_SHM
   , .get_sample_size = ddsi_serdata_iox_size
   , .from_iox_buffer = serdata_default_from_iox
-  , .from_sample_for_iox = ddsi_serdata_default_from_sample_for_iox
+  , .from_loaned_sample = ddsi_serdata_default_from_loaned_sample
 #endif
 };

--- a/src/core/ddsi/src/ddsi_serdata_default.c
+++ b/src/core/ddsi/src/ddsi_serdata_default.c
@@ -431,7 +431,7 @@ static void gen_keyhash_from_sample (const struct ddsi_sertype_default *type, dd
 }
 
 #ifdef DDS_HAS_SHM
-static struct ddsi_serdata* serdata_default_from_iox(const struct ddsi_sertype* tpcmn, enum ddsi_serdata_kind kind, void* sub, void* iox_buffer)
+static struct ddsi_serdata* serdata_default_from_received_iox_buffer(const struct ddsi_sertype* tpcmn, enum ddsi_serdata_kind kind, void* sub, void* iox_buffer)
 {
   iceoryx_header_t* ice_hdr = (iceoryx_header_t*)iox_buffer;
 
@@ -471,6 +471,14 @@ static struct ddsi_serdata *ddsi_serdata_default_from_loaned_sample (const struc
   struct ddsi_serdata *serdata = &d->c;
   serdata->iox_chunk = SHIFT_BACK_TO_ICEORYX_HEADER(sample);
   return serdata; 
+}
+
+static struct ddsi_serdata* serdata_default_from_iox(const struct ddsi_sertype* tpcmn, enum ddsi_serdata_kind kind, void* sub, void* buffer)
+{
+  if (sub == NULL)
+    return ddsi_serdata_default_from_loaned_sample(tpcmn, kind, buffer);
+  else
+    return serdata_default_from_received_iox_buffer(tpcmn, kind, sub, buffer);
 }
 #endif
 
@@ -681,7 +689,6 @@ const struct ddsi_serdata_ops ddsi_serdata_ops_cdr = {
 #ifdef DDS_HAS_SHM
   , .get_sample_size = ddsi_serdata_iox_size
   , .from_iox_buffer = serdata_default_from_iox
-  , .from_loaned_sample = ddsi_serdata_default_from_loaned_sample
 #endif
 };
 
@@ -704,6 +711,5 @@ const struct ddsi_serdata_ops ddsi_serdata_ops_cdr_nokey = {
 #ifdef DDS_HAS_SHM
   , .get_sample_size = ddsi_serdata_iox_size
   , .from_iox_buffer = serdata_default_from_iox
-  , .from_loaned_sample = ddsi_serdata_default_from_loaned_sample
 #endif
 };


### PR DESCRIPTION
- Extensive refactoring in dds_write.c to better handle shared memory paths
- dds_write_impl will not serialize for a writer with volatile QoS if iceoryx is available and there are no network readers (at this moment) - this is another step towards true zero copy transmission
-   added serdata construction to support this case

Closes #783