### PR TITLE
Use PROJECT_SOURCE_DIR instead of CMAKE_SOURCE_DIR.

### DIFF
--- a/src/idl/CMakeLists.txt
+++ b/src/idl/CMakeLists.txt
@@ -23,9 +23,9 @@ set(source_dir "${CMAKE_CURRENT_SOURCE_DIR}")
 bison_target(parser src/parser.y "${binary_dir}/parser.c")
 
 # generate hashid.c from md5.h and md5.c to avoid code duplication
-file(READ "${CMAKE_SOURCE_DIR}/src/ddsrt/include/dds/ddsrt/endian.h" endian_h)
-file(READ "${CMAKE_SOURCE_DIR}/src/ddsrt/include/dds/ddsrt/md5.h" md5_h)
-file(READ "${CMAKE_SOURCE_DIR}/src/ddsrt/src/md5.c" md5_c)
+file(READ "${PROJECT_SOURCE_DIR}/src/ddsrt/include/dds/ddsrt/endian.h" endian_h)
+file(READ "${PROJECT_SOURCE_DIR}/src/ddsrt/include/dds/ddsrt/md5.h" md5_h)
+file(READ "${PROJECT_SOURCE_DIR}/src/ddsrt/src/md5.c" md5_c)
 string(CONCAT MD5 "${endian_h}" "${md5_h}" "${md5_c}")
 # remove occurrences of DDS_EXPORT
 string(REGEX REPLACE "\n[ \t]*DDS_EXPORT[ \t]+" "\n" MD5 "${MD5}")


### PR DESCRIPTION
When I use Cyclone DDS as an external project, I found that there is compile error.

```
CMake Error at cyclonedds/src/idl/CMakeLists.txt:26 (file):
  file failed to open for reading (No such file or directory):

    /home/chenying/myproject/src/ddsrt/include/dds/ddsrt/endian.h


CMake Error at cyclonedds/src/idl/CMakeLists.txt:27 (file):
  file failed to open for reading (No such file or directory):

    /home/chenying/myproject/src/ddsrt/include/dds/ddsrt/md5.h


CMake Error at cyclonedds/src/idl/CMakeLists.txt:28 (file):
  file failed to open for reading (No such file or directory):

    /home/chenying/myproject/src/ddsrt/src/md5.c


-- Configuring incomplete, errors occurred!
```

I think the reason is that CycloneDDS use `CMAKE_SOURCE_DIR` in `src/idl/CMakeLists.txt` line 26, 27, 28.
And `CMAKE_SOURCE_DIR` will point to the root of the whole project.
We need to use `PROJECT_SOURCE_DIR` to point to the root of the CycloneDDS project.

Here is the duplicate procedure:

```bash
mkdir myproject
cd myproject
git clone https://github.com/eclipse-cyclonedds/cyclonedds.git
```
Then create the CMakeLists.txt like the following:
```
cmake_minimum_required(VERSION 3.10)
project(usecyclone VERSION 1.0.0)
add_subdirectory(cyclonedds)
```
Then build the project
```bash
cmake -Bbuild -H. && cmake --build build
```
