### PR TITLE
Support stdin as input for compiler + some fixes

### DIFF
--- a/src/idl/include/idl/stream.h
+++ b/src/idl/include/idl/stream.h
@@ -17,6 +17,8 @@
 
 #include "idl/export.h"
 
+IDL_EXPORT FILE *idl_fopen(const char *pathname, const char *mode);
+
 IDL_EXPORT int idl_fprintf(FILE *fp, const char *fmt, ...);
 
 IDL_EXPORT int idl_vfprintf(FILE *fp, const char *fmt, va_list ap);

--- a/src/idl/include/idl/symbol.h
+++ b/src/idl/include/idl/symbol.h
@@ -39,7 +39,7 @@ typedef struct idl_position {
   /* for error reporting purposes, the "filename" provided in the #line
      directive must be kept. on includes, idlpp provides a (relative) filename
      with the proper flags, which becomes the source. user provided #line
-     directives in the file are used merely in error reporting */
+     directives in the file are used merely for error reporting */
   const idl_file_t *file; /**< (alternate) filename in latest #line directive */
   uint32_t line;
   uint32_t column;

--- a/src/idl/src/scanner.c
+++ b/src/idl/src/scanner.c
@@ -754,7 +754,7 @@ tokenize(
         goto identifier;
       if (pstate->scanner.state == IDL_SCAN_ANNOTATION_NAME)
         goto identifier;
-      if ((code = idl_iskeyword(pstate, str, 0)))
+      if ((code = idl_iskeyword(pstate, str, !(pstate->flags & IDL_FLAG_CASE_SENSITIVE))))
         break;
 identifier:
       pstate->scanner.state = IDL_SCAN_GRAMMAR;

--- a/src/idl/src/string.c
+++ b/src/idl/src/string.c
@@ -306,6 +306,19 @@ int idl_fprintf(FILE *fp, const char *fmt, ...)
   return ret;
 }
 
+FILE *idl_fopen(const char *pathname, const char *mode)
+{
+#if _MSC_VER
+  FILE *fp = NULL;
+
+  if (fopen_s(&fp, pathname, mode) != 0)
+    return NULL;
+  return fp;
+#else
+  return fopen(pathname, mode);
+#endif
+}
+
 #if defined _WIN32
 static __declspec(thread) locale_t locale = NULL;
 

--- a/src/tools/idlc/src/generator.c
+++ b/src/tools/idlc/src/generator.c
@@ -353,18 +353,6 @@ generate_nosetup(const idl_pstate_t *pstate, struct generator *generator)
   return IDL_RETCODE_OK;
 }
 
-static FILE *open_file(const char *pathname, const char *mode)
-{
-#if _WIN32
-  FILE *handle = NULL;
-  if (fopen_s(&handle, pathname, mode) != 0)
-    return NULL;
-  return handle;
-#else
-  return fopen(pathname, mode);
-#endif
-}
-
 idl_retcode_t
 idlc_generate(const idl_pstate_t *pstate)
 {
@@ -407,11 +395,11 @@ idlc_generate(const idl_pstate_t *pstate)
   sep = dir[0] == '\0' ? "" : "/";
   if (idl_asprintf(&generator.header.path, "%s%s%s.h", dir, sep, basename) < 0)
     goto err_header;
-  if (!(generator.header.handle = open_file(generator.header.path, "wb")))
+  if (!(generator.header.handle = idl_fopen(generator.header.path, "wb")))
     goto err_header;
   if (idl_asprintf(&generator.source.path, "%s%s%s.c", dir, sep, basename) < 0)
     goto err_source;
-  if (!(generator.source.handle = open_file(generator.source.path, "wb")))
+  if (!(generator.source.handle = idl_fopen(generator.source.path, "wb")))
     goto err_source;
   ret = generate_nosetup(pstate, &generator);
 

--- a/src/tools/idlc/src/idlc.c
+++ b/src/tools/idlc/src/idlc.c
@@ -29,6 +29,7 @@
 #include "idl/processor.h"
 #include "idl/file.h"
 #include "idl/version.h"
+#include "idl/stream.h"
 
 #include "mcpp_lib.h"
 #include "mcpp_out.h"
@@ -320,15 +321,10 @@ static idl_retcode_t idlc_parse(void)
     size_t nrd;
     int nwr;
 
-    if (strcmp(config.file, "-") == 0) {
+    if (strcmp(config.file, "-") == 0)
       fin = stdin;
-    } else {
-#if _WIN32
-      fopen_s(&fin, config.file, "rb");
-#else
-      fin = fopen(config.file, "rb");
-#endif
-    }
+    else
+      fin = idl_fopen(config.file, "rb");
 
     if (!fin) {
       if (errno == ENOMEM)

--- a/src/tools/idlpp/src/configed.H.in
+++ b/src/tools/idlpp/src/configed.H.in
@@ -279,7 +279,7 @@ something so go through the trouble of defining it!
 #elif HOST_COMPILER == MSC
 #define MCPP_ATTRIBUTE(...) /* empty */
 #define MCPP_ATTRIBUTE_NORETURN() __declspec(noreturn)
-#define MSC_PRAGMA(...) _Pragma(__VA_ARGS__)
+#define MSC_PRAGMA(...) __pragma(__VA_ARGS__)
 #else
 #define MCPP_ATTRIBUTE(...) /* empty */
 #define MCPP_ATTRIBUTE_NORETURN() /* empty */

--- a/src/tools/idlpp/src/expand.c
+++ b/src/tools/idlpp/src/expand.c
@@ -526,7 +526,7 @@ static char *   chk_magic_balance(
 #if 0
                 mac_loc[ mac] = buf_p - 2;
 #endif
-                MSC_PRAGMA("warning(suppress: 6385)")
+                MSC_PRAGMA(warning(suppress: 6385))
                 memcpy( mac_id[ mac], buf_p, MAC_S_LEN - 2);
             }
             mac++;
@@ -534,9 +534,9 @@ static char *   chk_magic_balance(
             break;
         case MAC_ARG_START  :
             if (option_flags.v) {
-                MSC_PRAGMA("warning(suppress: 6386)")
+                MSC_PRAGMA(warning(suppress: 6386))
                 arg_loc[ arg] = buf_p - 2;
-                MSC_PRAGMA("warning(suppress: 6385)")
+                MSC_PRAGMA(warning(suppress: 6385))
                 memcpy( arg_id[ arg], buf_p, ARG_S_LEN - 2);
             }
             arg++;

--- a/src/tools/idlpp/src/support.c
+++ b/src/tools/idlpp/src/support.c
@@ -163,7 +163,7 @@ void    mcpp_use_mem_buffers(
     for (i = 0; i < NUM_OUTDEST; ++i) {
         if (mem_buffers[ i].buffer) {
             /* Free previously allocated memory buffer  */
-            MSC_PRAGMA("warning(suppress: 6001)")
+            MSC_PRAGMA(warning(suppress: 6001))
             free( mem_buffers[ i].buffer);
         }
         if (use_mem_buffers) {

--- a/src/tools/idlpp/src/system.c
+++ b/src/tools/idlpp/src/system.c
@@ -4716,7 +4716,7 @@ static void do_preprocessed( void)
                 || (memcmp( --comment, "/* ", 3) != 0)
                 || ((colon = strrchr( comment, ':')) == NULL))
             cfatal( corrupted, NULL, 0L, NULL);
-        MSC_PRAGMA("warning(suppress: 28182 28183)")
+        MSC_PRAGMA(warning(suppress: 28182 28183))
         src_line = (size_t)atol( colon + 1);  /* Pseudo line number   */
         *colon = EOS;
         dir = comment + 3;
@@ -5047,7 +5047,7 @@ void    clear_filelist( void)
         free( (void *) *incp);
     free( (void *) incdir);
     for (namep = fnamelist; namep < fname_end; namep++) {
-        MSC_PRAGMA("warning(suppress: 6001)")
+        MSC_PRAGMA(warning(suppress: 6001))
         free( (void *) namep->name);
     }
     free( (void *) fnamelist);


### PR DESCRIPTION
This PR fixes building the compiler on Visual Studio versions before 2019, takes `-fcase-sensitive` into account for identifiers too. Someone nagged me for `True` not working for booleans :wink: and that same someone found stdin didn't work as input. I actually intended for stdin to work from the start, but forgot about it while writing the generator. If stdin is used as input, it'll now generate `a.h` and `a.c` as output. Allowing the user to specify the output file with `-o` should probably be on the list too.

Next up is processing @reicheratwork's comments on [#71](https://github.com/eclipse-cyclonedds/cyclonedds-cxx/pull/71) in *cyclonedds-cxx*. I'll add generating a `a.hpp` as part of that PR as well.