### PR TITLE
Fix broken assert in network partition config

### DIFF
--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -1288,6 +1288,7 @@ static int convert_network_partition_addresses (struct ddsi_domaingv *gv, uint32
         rc = -1;
         continue;
       }
+      assert (**nextpp);
       (**nextpp)->loc = loc;
       (**nextpp)->next = NULL;
       *nextpp = &(**nextpp)->next;

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -1288,10 +1288,11 @@ static int convert_network_partition_addresses (struct ddsi_domaingv *gv, uint32
         rc = -1;
         continue;
       }
-      assert (**nextpp);
       (**nextpp)->loc = loc;
       (**nextpp)->next = NULL;
+      DDSRT_WARNING_MSVC_OFF(6011);
       *nextpp = &(**nextpp)->next;
+      DDSRT_WARNING_MSVC_ON(6011);
     }
     ddsrt_free (copy);
     ddsrt_free (msgtag);

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -1278,7 +1278,7 @@ static int convert_network_partition_addresses (struct ddsi_domaingv *gv, uint32
         loc.port = port_data_uc;
         nextpp = &nextp_uc;
       }
-      assert (nextpp && *nextpp && **nextpp);
+      assert (nextpp && *nextpp);
 
       if (rc == -1)
         continue;


### PR DESCRIPTION
The blame for the screw-up this fixes is mine and mine alone, but I do have to vent a bit of frustration at the tools brightly declaring that they have found a null pointer dereference when they haven't, declaring the code unacceptable because of that, and that leading to actually broken code (fortunately not in a release build) and yet more time wasting on tool pacification ...