### PR TITLE
Improve handling of external vs internal addresses

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/ddsi_domaingv.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_domaingv.h
@@ -196,9 +196,6 @@ struct ddsi_domaingv {
   struct config_in_addr_node *recvips;
   ddsi_locator_t extmask;
 
-  // extloc: if not UNSPEC, overrides advertised address
-  ddsi_locator_t extloc;
-
   /* Locators */
 
   ddsi_locator_t loc_spdp_mc;

--- a/src/core/ddsi/include/dds/ddsi/ddsi_ownip.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_ownip.h
@@ -26,7 +26,8 @@ struct ddsi_domaingv;
 
 #define MAX_INTERFACES 128
 struct nn_interface {
-  ddsi_locator_t loc;
+  ddsi_locator_t loc; // actual interface address
+  ddsi_locator_t extloc; // interface address to advertise in discovery
   ddsi_locator_t netmask;
   uint32_t if_index;
   unsigned mc_capable: 1;

--- a/src/core/ddsi/src/ddsi_ipaddr.c
+++ b/src/core/ddsi/src/ddsi_ipaddr.c
@@ -57,7 +57,7 @@ int ddsi_ipaddr_compare (const struct sockaddr *const sa1, const struct sockaddr
 
 enum ddsi_nearby_address_result ddsi_ipaddr_is_nearby_address (const ddsi_locator_t *loc, size_t ninterf, const struct nn_interface interf[], size_t *interf_idx)
 {
-  struct sockaddr_storage tmp, iftmp, nmtmp;
+  struct sockaddr_storage tmp, iftmp, xiftmp, nmtmp;
   ddsi_ipaddr_from_loc(&tmp, loc);
   for (size_t i = 0; i < ninterf; i++)
   {
@@ -65,8 +65,10 @@ enum ddsi_nearby_address_result ddsi_ipaddr_is_nearby_address (const ddsi_locato
       continue;
 
     ddsi_ipaddr_from_loc(&iftmp, &interf[i].loc);
+    ddsi_ipaddr_from_loc(&xiftmp, &interf[i].extloc);
     ddsi_ipaddr_from_loc(&nmtmp, &interf[i].netmask);
-    if (ddsrt_sockaddr_insamesubnet ((struct sockaddr *) &tmp, (struct sockaddr *) &iftmp, (struct sockaddr *) &nmtmp))
+    if (ddsrt_sockaddr_insamesubnet ((struct sockaddr *) &tmp, (struct sockaddr *) &iftmp, (struct sockaddr *) &nmtmp) ||
+        ddsrt_sockaddr_insamesubnet ((struct sockaddr *) &tmp, (struct sockaddr *) &xiftmp, (struct sockaddr *) &nmtmp))
     {
       if (interf_idx)
         *interf_idx = i;

--- a/src/core/ddsi/src/ddsi_ownip.c
+++ b/src/core/ddsi/src/ddsi_ownip.c
@@ -308,6 +308,7 @@ int find_own_ip (struct ddsi_domaingv *gv, const char *requested_address)
       interfaces[n_interfaces].netmask.port = NN_LOCATOR_PORT_INVALID;
       memset(&interfaces[n_interfaces].netmask.address, 0, sizeof(interfaces[n_interfaces].netmask.address));
     }
+    interfaces[n_interfaces].extloc = interfaces[n_interfaces].loc;
     interfaces[n_interfaces].mc_capable = ((ifa->flags & IFF_MULTICAST) != 0);
     interfaces[n_interfaces].mc_flaky = ((ifa->type == DDSRT_IFTYPE_WIFI) != 0);
     interfaces[n_interfaces].point_to_point = ((ifa->flags & IFF_POINTOPOINT) != 0);

--- a/src/core/ddsi/src/ddsi_ownip.c
+++ b/src/core/ddsi/src/ddsi_ownip.c
@@ -308,6 +308,8 @@ int find_own_ip (struct ddsi_domaingv *gv, const char *requested_address)
       interfaces[n_interfaces].netmask.port = NN_LOCATOR_PORT_INVALID;
       memset(&interfaces[n_interfaces].netmask.address, 0, sizeof(interfaces[n_interfaces].netmask.address));
     }
+    // Default external (i.e., advertised in discovery) address to the actual interface
+    // address.  This can subsequently be overridden by the configuration.
     interfaces[n_interfaces].extloc = interfaces[n_interfaces].loc;
     interfaces[n_interfaces].mc_capable = ((ifa->flags & IFF_MULTICAST) != 0);
     interfaces[n_interfaces].mc_flaky = ((ifa->type == DDSRT_IFTYPE_WIFI) != 0);

--- a/src/core/ddsi/src/ddsi_raweth.c
+++ b/src/core/ddsi/src/ddsi_raweth.c
@@ -168,7 +168,7 @@ static int ddsi_raweth_conn_locator (ddsi_tran_factory_t fact, ddsi_tran_base_t 
   {
     loc->kind = NN_LOCATOR_KIND_RAWETH;
     loc->port = uc->m_base.m_base.m_port;
-    memcpy(loc->address, uc->m_base.m_base.gv->extloc.address, sizeof (loc->address));
+    memcpy(loc->address, uc->m_base.m_base.gv->interfaces[0].loc.address, sizeof (loc->address));
     ret = 0;
   }
   return ret;

--- a/src/core/ddsi/src/q_ddsi_discovery.c
+++ b/src/core/ddsi/src/q_ddsi_discovery.c
@@ -207,7 +207,7 @@ static struct addrset *addrset_from_locatorlists (const struct ddsi_domaingv *gv
       assert (gv->n_interfaces == 1); // gv->extmask: the hack is only supported if limited to a single interface
       struct in_addr tmp4 = *((struct in_addr *) (loc.address + 12));
       const struct in_addr ownip = *((struct in_addr *) (gv->interfaces[0].loc.address + 12));
-      const struct in_addr extip = *((struct in_addr *) (gv->extloc.address + 12));
+      const struct in_addr extip = *((struct in_addr *) (gv->interfaces[0].extloc.address + 12));
       const struct in_addr extmask = *((struct in_addr *) (gv->extmask.address + 12));
 
       if ((tmp4.s_addr & extmask.s_addr) == (extip.s_addr & extmask.s_addr))
@@ -398,8 +398,8 @@ void get_participant_builtin_topic_data (const struct participant *pp, ddsi_plis
           continue;
         }
         // FIXME: should have multiple loc_default_uc/loc_meta_uc or compute ports here
-        locators_add_one (&def_uni, &pp->e.gv->interfaces[i].loc, pp->e.gv->loc_default_uc.port);
-        locators_add_one (&meta_uni, &pp->e.gv->interfaces[i].loc, pp->e.gv->loc_meta_uc.port);
+        locators_add_one (&def_uni, &pp->e.gv->interfaces[i].extloc, pp->e.gv->loc_default_uc.port);
+        locators_add_one (&meta_uni, &pp->e.gv->interfaces[i].extloc, pp->e.gv->loc_meta_uc.port);
       }
     }
     if (pp->e.gv->config.publish_uc_locators)
@@ -1179,7 +1179,7 @@ static int sedp_write_endpoint_impl
               continue;
             }
             // FIXME: should have multiple loc_default_uc/loc_meta_uc or compute ports here
-            ddsi_locator_t loc = epcommon->pp->e.gv->interfaces[i].loc;
+            ddsi_locator_t loc = epcommon->pp->e.gv->interfaces[i].extloc;
             loc.port = epcommon->pp->e.gv->loc_default_uc.port;
             add_locator_to_ps(&loc, &arg);
           }

--- a/src/core/ddsi/src/q_ddsi_discovery.c
+++ b/src/core/ddsi/src/q_ddsi_discovery.c
@@ -173,14 +173,15 @@ static struct addrset *addrset_from_locatorlists (const struct ddsi_domaingv *gv
     allow_loopback = (a || b);
   }
 
-  // if any non-loopback address is identical to one of our own addresses, assume it is the
-  // same machine, in which case loopback addresses may be picked up
+  // if any non-loopback address is identical to one of our own addresses (actual or advertised),
+  // assume it is the same machine, in which case loopback addresses may be picked up
   for (struct nn_locators_one *l = uc->first; l != NULL && !allow_loopback; l = l->next)
   {
     if (ddsi_is_loopbackaddr (gv, &l->loc))
       continue;
     for (int i = 0; i < gv->n_interfaces && !allow_loopback; i++)
-      allow_loopback = (memcmp (l->loc.address, gv->interfaces[i].loc.address, sizeof (l->loc.address)) == 0);
+      allow_loopback = (memcmp (l->loc.address, gv->interfaces[i].loc.address, sizeof (l->loc.address)) == 0 ||
+                        memcmp (l->loc.address, gv->interfaces[i].extloc.address, sizeof (l->loc.address)) == 0);
   }
   //GVTRACE(" allow_loopback=%d\n", allow_loopback);
 


### PR DESCRIPTION
This PR improves the behaviour of the ExternalNetworkAddress setting, which is intended to allow advertising an address different from the actual address in discovery messages. As a background, the current behaviour is rather simple: specifying an ExternalNetworkAddress means that gets advertised in SPDP/SEDP and used without further consideration by other nodes.

That leads to a problem in cases where the other processes should sometimes use this "external address" and sometimes the normal address, e.g., the external one *if and only if* on a different host. It turns out that containers have this issue; I'm sure that a bit of thinking will yield plenty of interesting scenarios with NAT'ing firewalls where the boundary should not be the host but the local network, &c. I'm not sure all can be solved with a simple setting ...

One of the commits rewrites discovered locators that contain the configured external address to use the actual interface address. It would be a weird machine indeed where sending to the interface address does not work while sending to some random other address does work to get a packet to another process on the same machine.

Another broadens the notion of what a local address is to include those addresses matching the external address. This affects the heuristics for figuring out to which interface another is likely to be connected (which matters for multicast), as well as whether the loopback interface can possibly be used .

Finally, there is one that simply moves it out of the globals and into the network interface description and reworks the setting to effectively ignore loopback interfaces. It used to be disallowed to configure an external address if there were multiple network interfaces, now it is only disallowed if it there are multiple non-loopback ones. It could equally be done by allowing one to be specified for each interface independently, but that would require extending the configuration elements and can be done at a later time.