### PR TITLE
Dereference as void* to avoid crash with -O2

### DIFF
--- a/src/idl/src/tree.c
+++ b/src/idl/src/tree.c
@@ -277,7 +277,7 @@ create_node(
   node->describe = methods->describe;
   node->references = 1;
 
-  *((idl_node_t **)nodep) = node;
+  *((void **)nodep) = (void *)node;
   return IDL_RETCODE_OK;
 }
 


### PR DESCRIPTION
This fixes #808.

Signed-off-by: Jeroen Koekkoek <jeroen@koekkoek.nl>