### PR TITLE
Bitmask support in idl compiler front-end

### DIFF
--- a/src/idl/include/idl/tree.h
+++ b/src/idl/include/idl/tree.h
@@ -38,37 +38,38 @@
   (IDL_BASE_TYPE | IDL_TEMPL_TYPE | IDL_CONSTR_TYPE | IDL_TYPEDEF)
 
 #define IDL_CONSTR_TYPE \
-  (IDL_STRUCT | IDL_UNION | IDL_ENUM)
+  (IDL_STRUCT | IDL_UNION | IDL_ENUM | IDL_BITMASK)
 
 #define IDL_TEMPL_TYPE \
   (IDL_SEQUENCE | IDL_STRING | IDL_WSTRING | IDL_FIXED_PT)
 
 /* miscellaneous */
-#define IDL_KEYLIST (1llu<<37)
-#define IDL_KEY (1llu<<36)
-#define IDL_INHERIT_SPEC (1llu<<35)
-#define IDL_SWITCH_TYPE_SPEC (1llu<<34)
-#define IDL_LITERAL (1ull<<33)
+#define IDL_KEYLIST (1llu<<38)
+#define IDL_KEY (1llu<<37)
+#define IDL_INHERIT_SPEC (1llu<<36)
+#define IDL_SWITCH_TYPE_SPEC (1llu<<35)
+#define IDL_LITERAL (1ull<<34)
 /* declarations */
-#define IDL_MODULE (1llu<<32)
-#define IDL_CONST (1llu<<31)
-#define IDL_MEMBER (1llu<<30)
-#define IDL_FORWARD (1llu<<29)
-#define IDL_CASE (1llu<<28)
-#define IDL_CASE_LABEL (1llu<<27)
+#define IDL_MODULE (1llu<<33)
+#define IDL_CONST (1llu<<32)
+#define IDL_MEMBER (1llu<<31)
+#define IDL_FORWARD (1llu<<30)
+#define IDL_CASE (1llu<<29)
+#define IDL_CASE_LABEL (1llu<<28)
 /* if explicit default is specified */
 #define IDL_DEFAULT_CASE_LABEL (IDL_CASE_LABEL | 1u)
 /* if no explicit default is specified and range is not covered */
 #define IDL_IMPLICIT_DEFAULT_CASE_LABEL (IDL_DEFAULT_CASE_LABEL | 2u)
-#define IDL_ENUMERATOR (1llu<<26)
-#define IDL_DECLARATOR (1llu<<25)
+#define IDL_ENUMERATOR (1llu<<27)
+#define IDL_BIT_VALUE (1llu<<39)
+#define IDL_DECLARATOR (1llu<<26)
 /* annotations */
-#define IDL_ANNOTATION (1llu<<24)
-#define IDL_ANNOTATION_MEMBER (1llu<<23)
-#define IDL_ANNOTATION_APPL (1llu<<22)
-#define IDL_ANNOTATION_APPL_PARAM (1llu<<21)
+#define IDL_ANNOTATION (1llu<<25)
+#define IDL_ANNOTATION_MEMBER (1llu<<24)
+#define IDL_ANNOTATION_APPL (1llu<<23)
+#define IDL_ANNOTATION_APPL_PARAM (1llu<<22)
 
-/* bits 19 - 20 are reserved for operators (not exposed in tree) */
+/* bits 20 - 21 are reserved for operators (not exposed in tree) */
 
 typedef enum idl_type idl_type_t;
 enum idl_type {
@@ -78,6 +79,7 @@ enum idl_type {
   IDL_STRUCT = (1u<<17),
   IDL_UNION = (1u<<16),
   IDL_ENUM = (1u<<15),
+  IDL_BITMASK = (1u<<19),
   /* template types */
   IDL_SEQUENCE = (1llu<<14),
   IDL_STRING = (1llu<<13),
@@ -397,6 +399,23 @@ struct idl_enum {
   idl_node_t node;
   struct idl_name *name;
   idl_enumerator_t *enumerators;
+  uint16_t bit_bound;
+  idl_extensibility_t extensibility;
+};
+
+typedef struct idl_bit_value idl_bit_value_t;
+struct idl_bit_value {
+  idl_node_t node;
+  struct idl_name *name;
+  uint16_t position;
+};
+
+typedef struct idl_bitmask idl_bitmask_t;
+struct idl_bitmask {
+  idl_node_t node;
+  struct idl_name *name;
+  idl_bit_value_t *bit_values;
+  uint16_t bit_bound;
   idl_extensibility_t extensibility;
 };
 
@@ -469,6 +488,8 @@ IDL_EXPORT bool idl_is_default_case(const void *node);
 IDL_EXPORT bool idl_is_case_label(const void *node);
 IDL_EXPORT bool idl_is_enum(const void *node);
 IDL_EXPORT bool idl_is_enumerator(const void *node);
+IDL_EXPORT bool idl_is_bitmask(const void *node);
+IDL_EXPORT bool idl_is_bit_value(const void *node);
 IDL_EXPORT bool idl_is_alias(const void *node);
 IDL_EXPORT bool idl_is_typedef(const void *node);
 IDL_EXPORT bool idl_is_declarator(const void *node);
@@ -491,6 +512,7 @@ IDL_EXPORT const char *idl_identifier(const void *node);
 IDL_EXPORT const idl_name_t *idl_name(const void *node);
 IDL_EXPORT uint32_t idl_array_size(const void *node);
 IDL_EXPORT uint32_t idl_bound(const void *node);
+IDL_EXPORT uint16_t idl_bit_bound(const void *node);
 
 /* navigation */
 IDL_EXPORT void *idl_ancestor(const void *node, size_t levels);

--- a/src/idl/src/expression.h
+++ b/src/idl/src/expression.h
@@ -24,11 +24,11 @@
 typedef enum idl_operator idl_operator_t;
 enum idl_operator {
   IDL_NOP = 0,
-#define IDL_UNARY_OPERATOR (1ull<<20)
+#define IDL_UNARY_OPERATOR (1ull<<21)
   IDL_MINUS = (IDL_UNARY_OPERATOR|1u),
   IDL_PLUS,
   IDL_NOT,
-#define IDL_BINARY_OPERATOR (1ull<<19)
+#define IDL_BINARY_OPERATOR (1ull<<20)
   IDL_OR = (IDL_BINARY_OPERATOR|1u),
   IDL_XOR,
   IDL_AND,

--- a/src/idl/src/tree.h
+++ b/src/idl/src/tree.h
@@ -200,6 +200,21 @@ idl_create_enum(
   void *nodep);
 
 idl_retcode_t
+idl_create_bit_value(
+  idl_pstate_t *pstate,
+  const idl_location_t *location,
+  idl_name_t *name,
+  void *nodep);
+
+idl_retcode_t
+idl_create_bitmask(
+  idl_pstate_t *pstate,
+  const idl_location_t *location,
+  idl_name_t *name,
+  idl_bit_value_t *bit_values,
+  void *nodep);
+
+idl_retcode_t
 idl_create_typedef(
   idl_pstate_t *pstate,
   const idl_location_t *location,

--- a/src/idl/tests/parser.c
+++ b/src/idl/tests/parser.c
@@ -245,3 +245,31 @@ CU_Test(idl_parser, struct_in_struct_other_module)
 //   x.x. see union
 // x. constant expressions
 // x. identifier that collides with a keyword
+
+CU_Test(idl_parser, bitmask)
+{
+  idl_retcode_t ret;
+  idl_pstate_t *pstate = NULL;
+  idl_bitmask_t *bm;
+  idl_bit_value_t *bv1, *bv2;
+  const char str[] = "bitmask MyBitmask { flag0, flag1, flag2 };";
+
+  ret = idl_create_pstate(0u, NULL, &pstate);
+  CU_ASSERT_EQUAL_FATAL(ret, IDL_RETCODE_OK);
+  CU_ASSERT_PTR_NOT_NULL(pstate);
+  assert(pstate);
+  ret = idl_parse_string(pstate, str);
+  CU_ASSERT_EQUAL_FATAL(ret, IDL_RETCODE_OK);
+  bm = (idl_bitmask_t *)pstate->root;
+  CU_ASSERT_FATAL(idl_is_bitmask(bm));
+  bv1 = (idl_bit_value_t *)bm->bit_values;
+  CU_ASSERT_FATAL(idl_is_bit_value(bv1));
+  CU_ASSERT_PTR_EQUAL(bv1->node.parent, bm);
+  CU_ASSERT_EQUAL_FATAL(bv1->position, 0);
+  bv2 = idl_next(bv1);
+  CU_ASSERT_FATAL(idl_is_bit_value(bv2));
+  CU_ASSERT_PTR_EQUAL(bv2->node.parent, bm);
+  CU_ASSERT_EQUAL_FATAL(bv2->position, 1);
+  idl_delete_pstate(pstate);
+}
+


### PR DESCRIPTION
Adds the implementation for the bitmask data type in the idl compiler front-end, including some basic tests. This also adds the @bit_bound annotation, which can be used with bitmask and enum types. Note that the current idlc back-end does not yet support the bitmask type, this will be added later.
