### PR TITLE
Add pipeline for publishing documentation

### DIFF
--- a/.azure/guides.yml
+++ b/.azure/guides.yml
@@ -1,0 +1,67 @@
+#
+# Copyright(c) 2021 ADLINK Technology Limited and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+
+#
+# Azure Pipeline specifically for building and publishing documentation
+#
+
+trigger:
+  tags:
+    include:
+    - '*'
+  branches:
+    include:
+    - 'master'
+    - 'releases/*'
+
+pool:
+  vmImage: ubuntu-20.04
+
+steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.9'
+    name: install_python
+  - bash: |
+      echo "###vso[task.setvariable variable=pip_cache;]${HOME}/.cache/pip"
+      sudo apt-get install -y doxygen
+    name: setup_linux
+  - task: Cache@2
+    inputs:
+      key: pip-docs | 4 | $(Agent.OS)
+      path: $(pip_cache)
+    name: cache_pip
+  - bash: |
+      set -e -x
+      pip install sphinx breathe exhale sphinx-rtd-theme --user --upgrade
+    name: install_sphinx
+  - bash: |
+      set -e -x
+      mkdir build
+      cd build
+      cmake .. -DBUILD_DOCS=ON
+      cmake --build . --target docs
+    name: build_documentation
+  - bash: |
+      set -e -x
+      if [ "${BUILD_SOURCEBRANCHNAME}" = "master" ]; then
+        version="latest"
+      else
+        version="$(echo ${BUILD_SOURCEBRANCHNAME} | sed -n -E 's#^.*[vV]?([0-9]+\.[0-9]+)\.[0-9]+((alpha|beta|rc)[0-9]*)?$#\1#p')"
+      fi
+      [ "${version}" != "" ] || exit 1
+      echo "###vso[task.setvariable variable=version;]${version}"
+    name: figure_version
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathToPublish: build/docs/docs
+      artifactName: 'cyclonedds-docs-$(version)'


### PR DESCRIPTION
This PR builds on #802 and adds a pipeline for generating documentation for *latest* and specific tags/releases and publishes as a build artifact. The idea is that the artifact is picked up by a pipeline for eclipse-cyclonedds.github.io, which is triggered by this pipeline, which then regenerates the website ensuring documentation is always up-to-date.