### PR TITLE
Fix submission to Coverity Scan

### DIFF
--- a/.azure/coverity-scan.yml
+++ b/.azure/coverity-scan.yml
@@ -25,9 +25,10 @@ schedules:
 
 strategy:
   matrix:
-    'Ubuntu 20.04 LTS with GCC 10 (Debug, x86_64)':
+    # Coverity Scan still does not support GCC 10?
+    'Ubuntu 20.04 LTS with GCC 9 (Debug, x86_64)':
       image: ubuntu-20.04
-      cc: gcc-10
+      cc: gcc-9
 
 pool:
   vmImage: $(image)


### PR DESCRIPTION
Coverity Scan results haven't been updated in quite some time due to:

```
Last Build Status: Failed. Your build has failed due to the following reason. Please fix the error and upload the build again.
Error details: The build uploaded has been only partially compiled. We recommend at least 85% capture success to avoid false-positives during analysis. As per last few lines of cov-int/build-log.txt, the percentage of compilation units ready for analysis is 36% which is less than the expected 85%
```

Which leads me to believe Coverity Scan still does not properly supports GCC 10. Instead of switching back to Ubuntu 18.04 with GCC 7, I decided to keep on Ubuntu 20.04, but use GCC 9 instead to at least use the most recent compiler available.