### PR TITLE
Fix submission to Coverity Scan

### DIFF
--- a/.azure/coverity-scan.yml
+++ b/.azure/coverity-scan.yml
@@ -25,10 +25,9 @@ schedules:
 
 strategy:
   matrix:
-    # Coverity Scan still does not support GCC 10?
-    'Ubuntu 18.04 LTS with GCC 7 (Debug, x86_64)':
-      image: ubuntu-18.04
-      cc: gcc-7
+    'Ubuntu 20.04 LTS with GCC 10 (Debug, x86_64)':
+      image: ubuntu-20.04
+      cc: gcc-10
 
 pool:
   vmImage: $(image)

--- a/.azure/coverity-scan.yml
+++ b/.azure/coverity-scan.yml
@@ -100,3 +100,8 @@ steps:
     name: submit_to_coverity_scan
     env:
       token: $(COVERITY_SCAN_TOKEN)
+  ## Save Coverity build log for debugging
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathToPublish: cov-int/build-log.txt
+      artifactName: 'coverity-build-log.txt'

--- a/.azure/templates/build-test.yml
+++ b/.azure/templates/build-test.yml
@@ -100,7 +100,7 @@ steps:
             -DWERROR=on \
             ${GENERATOR:+-G} "${GENERATOR}" -A "${PLATFORM}" -T "${TOOLSET}" ..
       ${SCAN_BUILD} cmake --build . --config ${BUILD_TYPE} --target install -- ${BUILD_TOOL_OPTIONS}
-      ${SCAN_BUILD} cmake --build . --config ${BUILD_TYPE} --target package -- ${BUILD_TOOL_OPTIONS}
+      cmake --build . --config ${BUILD_TYPE} --target package -- ${BUILD_TOOL_OPTIONS}
     name: script
   - bash: |
       set -e -x


### PR DESCRIPTION
Yes, again. Previously a version of GCC that was too new was the cause. Unfortunately that wasn't the case this time around so there are two useless commits in master...

Turns out the second invocation of CMake that creates a package for the target platform was prefixed with SCAN_BUILD too, discarding the results of the first run. Since nothing is actually compiled the second time around no compilation units are captured and no files emitted causing Coverity Scan to report a build error.

I've verified with Coverity Scan this time around.

Signed-off-by: Jeroen Koekkoek <jeroen@koekkoek.nl>