### PR TITLE
Switch Coverity Scan build to Clang

### DIFF
--- a/.azure/coverity-scan.yml
+++ b/.azure/coverity-scan.yml
@@ -25,9 +25,10 @@ schedules:
 
 strategy:
   matrix:
-    'Ubuntu 20.04 LTS with GCC 10 (Debug, x86_64)':
+    'Ubuntu 20.04 LTS with Clang 10 (Debug, x86_64)':
       image: ubuntu-20.04
-      cc: gcc-10
+      cc: clang
+      cxx: clang++
 
 pool:
   vmImage: $(image)
@@ -79,7 +80,7 @@ steps:
   - bash: |
       set -e -x
       echo "###vso[task.setvariable variable=scan_build;]cov-build --dir $(pwd)/cov-int"
-      cov-configure --template --compiler ${CC} --comptype gcc
+      cov-configure --clang
     name: configure_coverity
   - template: /.azure/templates/build-test.yml
   ## Submit to Coverity Scan

--- a/.azure/templates/build-test.yml
+++ b/.azure/templates/build-test.yml
@@ -31,7 +31,7 @@ steps:
       echo "###vso[task.setvariable variable=conan_cache;]${HOME}/.conan/data"
       echo "###vso[task.setvariable variable=PATH;]$(python3 -m site --user-base)/bin:${PATH}"
       echo "###vso[task.setvariable variable=build_tool_options;]-j 4"
-      sudo apt-get install -y clang-tools clang-tidy
+      sudo apt-get install -y clang clang-tools clang-tidy
     condition: eq(variables['Agent.OS'], 'Linux')
     name: setup_linux
   - bash: |


### PR DESCRIPTION
While not strictly necessary, switch the Coverity Scan build for Cyclone DDS to Clang too. That way both configurations are the same.