### PR TITLE
Fix C.UTF-8 warnings generated by idlc

### DIFF
--- a/src/tools/idlpp/src/support.c
+++ b/src/tools/idlpp/src/support.c
@@ -1802,12 +1802,13 @@ end_line:
             temp++;
         if (*temp == '#'        /* This line starts with # token    */
                 || (mcpp_mode == STD && *temp == '%' && *(temp + 1) == ':'))
-            if (warn_level & 1)
+            if (warn_level & 1) {
                 assert( macro_line >= (ssize_t)LONG_MIN &&
                         macro_line <= (ssize_t)LONG_MAX);
                 cwarn(
     "Macro started at line %.0s%ld swallowed directive-like line"
                     , NULL, (long)macro_line, NULL);              /* _W1_ */
+            }
     }
     return  infile->buffer;
 }


### PR DESCRIPTION
This little PR adds very rudimentary support for the so-called [XPG syntax](https://www.gnu.org/software/libc/manual/html_node/Locale-Names.html) to mcpp. This fixes the `warning: Unknown encoding: C.UTF-8` warnings on some systems.