### PR TITLE
Use original filename if include is located in additional include directory

### DIFF
--- a/src/ddsrt/src/sync/posix/sync.c
+++ b/src/ddsrt/src/sync/posix/sync.c
@@ -22,11 +22,8 @@
 
 void ddsrt_mutex_init (ddsrt_mutex_t *mutex)
 {
-  int shared;
   assert (mutex != NULL);
-
   pthread_mutex_init (&mutex->mutex, NULL);
-  (void)shared;
 }
 
 void ddsrt_mutex_destroy (ddsrt_mutex_t *mutex)

--- a/src/idl/include/idl/attributes.h
+++ b/src/idl/include/idl/attributes.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright(c) 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#ifndef IDL_ATTRIBUTES_H
+#define IDL_ATTRIBUTES_H
+
+#if defined(__has_attribute)
+# define idl_has_attribute(params) __has_attribute(params)
+#elif __GNUC__
+# define idl_has_attribute(params) (1) /* GCC < 5 */
+#else
+# define idl_has_attribute(params) (0)
+#endif
+
+#if idl_has_attribute(format)
+# define idl_attribute_format(params) __attribute__((__format__ params))
+#else
+# define idl_attribute_format(params)
+#endif
+
+#endif /* IDL_ATTRIBUTES_H */

--- a/src/idl/include/idl/processor.h
+++ b/src/idl/include/idl/processor.h
@@ -68,8 +68,9 @@ struct idl_pstate {
       IDL_SCAN_DIRECTIVE_NAME,
       /** scanning #line directive */
       IDL_SCAN_LINE = (IDL_SCAN_DIRECTIVE | (1<<6)),
-      IDL_SCAN_FILENAME,
+      IDL_SCAN_PATH,
       IDL_SCAN_FLAGS,
+      IDL_SCAN_FILE,
       IDL_SCAN_EXTRA_TOKENS,
       /** scanning #pragma directive */
       IDL_SCAN_PRAGMA = (IDL_SCAN_DIRECTIVE | (1<<5)),

--- a/src/idl/include/idl/stream.h
+++ b/src/idl/include/idl/stream.h
@@ -16,10 +16,12 @@
 #include <stdio.h>
 
 #include "idl/export.h"
+#include "idl/attributes.h"
 
 IDL_EXPORT FILE *idl_fopen(const char *pathname, const char *mode);
 
-IDL_EXPORT int idl_fprintf(FILE *fp, const char *fmt, ...);
+IDL_EXPORT int idl_fprintf(FILE *fp, const char *fmt, ...)
+idl_attribute_format((printf, 2, 3));
 
 IDL_EXPORT int idl_vfprintf(FILE *fp, const char *fmt, va_list ap);
 

--- a/src/idl/include/idl/string.h
+++ b/src/idl/include/idl/string.h
@@ -17,6 +17,7 @@
 #include <string.h>
 
 #include "idl/export.h"
+#include "idl/attributes.h"
 
 IDL_EXPORT int idl_isalnum(int c);
 IDL_EXPORT int idl_isalpha(int c);
@@ -40,11 +41,13 @@ IDL_EXPORT char *idl_strdup(const char *str);
 
 IDL_EXPORT char *idl_strndup(const char *str, size_t len);
 
-IDL_EXPORT int idl_snprintf(char *str, size_t size, const char *fmt, ...);
+IDL_EXPORT int idl_snprintf(char *str, size_t size, const char *fmt, ...)
+idl_attribute_format((printf, 3, 4));
 
 IDL_EXPORT int idl_vsnprintf(char *str, size_t size, const char *fmt, va_list ap);
 
-IDL_EXPORT int idl_asprintf(char **strp, const char *fmt, ...);
+IDL_EXPORT int idl_asprintf(char **strp, const char *fmt, ...)
+idl_attribute_format((printf, 2, 3));
 
 IDL_EXPORT int idl_vasprintf(char **strp, const char *fmt, va_list ap);
 

--- a/src/idl/include/idl/symbol.h
+++ b/src/idl/include/idl/symbol.h
@@ -29,7 +29,7 @@ struct idl_source {
   const idl_source_t *parent;
   idl_source_t *previous, *next;
   idl_source_t *includes;
-  bool system; /**< system include */
+  bool additional_directory; /**< file does not reside in working directory */
   const idl_file_t *path; /**< normalized path of filename in #line directive */
   const idl_file_t *file; /**< filename in #line directive */
 };

--- a/src/idl/src/file.c
+++ b/src/idl/src/file.c
@@ -239,7 +239,7 @@ idl_retcode_t idl_normalize_path(const char *path, char **normpathp)
 
   free(abspath);
   *normpathp = normpath;
-  return (idl_retcode_t)len;
+  return IDL_RETCODE_OK;
 err_seg:
   free(normpath);
 err_norm:

--- a/src/tools/idlc/src/idlc.c
+++ b/src/tools/idlc/src/idlc.c
@@ -288,7 +288,7 @@ static idl_retcode_t idlc_parse(void)
     source->parent = NULL;
     source->previous = source->next = NULL;
     source->includes = NULL;
-    source->system = false;
+    source->additional_directory = false;
     source->path = pstate->paths;
     source->file = pstate->files;
     pstate->sources = source;

--- a/src/tools/idlc/src/types.c
+++ b/src/tools/idlc/src/types.c
@@ -467,7 +467,7 @@ print_literal(
     case IDL_DOUBLE:
       return idl_fprintf(fp, "%f", literal->value.dbl);
     case IDL_LDOUBLE:
-      return idl_fprintf(fp, "%lf", literal->value.ldbl);
+      return idl_fprintf(fp, "%Lf", literal->value.ldbl);
     case IDL_STRING:
       return idl_fprintf(fp, "\"%s\"", literal->value.str);
     default: {

--- a/src/tools/idlpp/src/configed.H.in
+++ b/src/tools/idlpp/src/configed.H.in
@@ -45,7 +45,7 @@
 
 /* Define the target compiler to GNUC to output GCC line directives, which
    are required to construct an include stack. */
-#define COMPILER            GNUC
+#define COMPILER            IDLC
 /* __GNUC__ and __GNUC_MINOR__ are required if COMPILER equals GNUC. */
 #define COMPILER_EXT        "__GNUC__"
 #define COMPILER_EXT_VAL    "0"
@@ -90,6 +90,7 @@
 #define WIN_SYMANTECC       0x7470  /* Symantec for Windows */
 #define LCC                 0x74C0  /* LCC-Win32 */
 #define GNUC                0x00E0  /* GNU C (GCC) */
+#define IDLC                0xFFFE  /* Eclipse Cyclone DDS IDL Compiler */
 #define INDEPENDENT         0xFFFF  /* No target, compiler-independent-build */
 
 #define SYS_FAMILY          (SYSTEM & 0xF000)

--- a/src/tools/idlpp/src/system.c
+++ b/src/tools/idlpp/src/system.c
@@ -508,7 +508,7 @@ plus:
 #if COMPILER == GNUC
         case '-':
             assert( mcpp_optarg != NULL);
-            if (memcmp( mcpp_optarg, "sysroot", 7) == 0) {
+            if (strncmp( mcpp_optarg, "sysroot", 7) == 0) {
                 if (mcpp_optarg[ 7] == '=')             /* --sysroot=DIR    */
                     sysroot = mcpp_optarg + 8;
                 else if (mcpp_optarg[ 7] == EOS)        /* --sysroot DIR    */
@@ -585,7 +585,7 @@ plus:
 #elif   COMPILER == MSC
         case 'a':
             assert( mcpp_optarg != NULL);
-            if (memcmp( mcpp_optarg, "rch", 3) == 0) {
+            if (strncmp( mcpp_optarg, "rch", 3) == 0) {
                 if (str_eq( mcpp_optarg + 3, ":SSE")        /* -arch:SSE    */
                         || str_eq( mcpp_optarg + 3, ":sse"))
                     sse = 1;
@@ -870,7 +870,7 @@ plus:
 #if COMPILER == GNUC
         case 'l':
             assert( mcpp_optarg != NULL);
-            if (memcmp( mcpp_optarg, "ang-", 4) != 0) {
+            if (strncmp( mcpp_optarg, "ang-", 4) != 0) {
                 usage( opt);
             } else if (str_eq( mcpp_optarg + 4, "c")) {     /* -lang-c  */
                 ;                           /* Ignore this option   */

--- a/src/tools/idlpp/src/system.c
+++ b/src/tools/idlpp/src/system.c
@@ -1918,6 +1918,7 @@ static void init_cpu_macro (
         return;
     }
     macro = cpu_macro[ index];
+    assert(macro);
     while (*macro)
         look_and_install( *macro++, DEF_NOARGS_PREDEF, null, "1");
 #if SYS_FAMILY == SYS_WIN

--- a/src/tools/idlpp/src/system.c
+++ b/src/tools/idlpp/src/system.c
@@ -4020,14 +4020,22 @@ static void cur_file(
         sharp_filename = save_string( name);
     }
     mcpp_fprintf( OUT, " \"%s\"", name);
-#if COMPILER == GNUC
+#if COMPILER == GNUC || COMPILER == IDLC
     if (! std_line_prefix) {
-        if (flag) {
-            mcpp_fputc( ' ', OUT);
-            mcpp_fputc( '0' + flag, OUT);
-        }
+#if COMPILER == IDLC
+        if ((flag & 1) && ! sharp_file) /* Signal non-relative file */
+            flag = (strlen(*(file->dirp)) != 0) ? 3 : 1;
+#endif
+        if (flag)
+            mcpp_fprintf( OUT, " %d", flag);
+#if COMPILER == GNUC
         if (file->sys_header)
             mcpp_fputs( " 3", OUT);
+#endif
+#if COMPILER == IDLC
+        if ((flag & 1))                 /* Output original filename */
+            mcpp_fprintf( OUT, " \"%s\"", cur_fname);
+#endif
     }
 #else
     (void)flag;


### PR DESCRIPTION
This PR changes behavior for `idlc` if an included `.idl` file is found in an additional include directory, i.e. a directory specified with the `-I` command line parameter. To achieve this, I've added `IDLC` as a compiler type to `mcpp` (`idlpp` CMake target). If an include is picked up from an additional directory, instead of printing `1` in the extended line marker to signal a new file is entered, it now prints `4` and adds the original filename to the end of the line as a string literal. The directive parser recognizes the `IDLC` specific format and copies the include directive.

~~I still have to add tests~~, but the basic mechanism shouldn't change much (unless there are remarks of course :slightly_smiling_face:).