### PR TITLE
Fixes for errors and warnings on FreeRTOS

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/ddsi_domaingv.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_domaingv.h
@@ -183,11 +183,9 @@ struct ddsi_domaingv {
   /* number of selected interfaces. */
   int n_interfaces;
   struct nn_interface interfaces[MAX_XMIT_CONNS];
-#if DDSRT_HAVE_IPV6
-  /* whether we're using an IPv6 link-local address (and therefore
+  /* whether we're using a link-local address (and therefore
      only listening to multicasts on that interface) */
-  int ipv6_link_local;
-#endif
+  int using_link_local_intf;
 
   /* Addressing: actual own (preferred) IP address, IP address
      advertised in discovery messages (so that an external IP address on

--- a/src/core/ddsi/src/ddsi_ownip.c
+++ b/src/core/ddsi/src/ddsi_ownip.c
@@ -405,13 +405,13 @@ int find_own_ip (struct ddsi_domaingv *gv, const char *requested_address)
     ddsrt_free (selected);
   }
 
-  gv->ipv6_link_local = false;
+  gv->using_link_local_intf = false;
   for (int i = 0; i < gv->n_interfaces; i++)
   {
     if (!gv->interfaces[i].link_local)
       continue;
-    else if (!gv->ipv6_link_local)
-      gv->ipv6_link_local = true;
+    else if (!gv->using_link_local_intf)
+      gv->using_link_local_intf = true;
     else
     {
       GVERROR ("multiple interfaces selected with at least one having a link-local address\n");

--- a/src/core/ddsi/src/ddsi_plist.c
+++ b/src/core/ddsi/src/ddsi_plist.c
@@ -1394,7 +1394,8 @@ static bool prtf_octetseq (char * __restrict *buf, size_t * __restrict bufsize, 
     uint32_t m = isprint_runlen (n - i, xs);
     if (m >= 4 || (i == 0 && m == n))
     {
-      if (!prtf (buf, bufsize, "%s\"%*.*s\"", i == 0 ? "" : ",", m, m, xs))
+      // m <= lim, so casting to int is safe
+      if (!prtf (buf, bufsize, "%s\"%*.*s\"", i == 0 ? "" : ",", (int) m, (int) m, xs))
         return false;
       xs += m;
       i += m;

--- a/src/core/ddsi/src/ddsi_udp.c
+++ b/src/core/ddsi/src/ddsi_udp.c
@@ -395,7 +395,7 @@ static dds_return_t set_mc_options_transmit_ipv6 (struct ddsi_domaingv const * c
   }
   return DDS_RETCODE_OK;
 #else
-  (void) gv; (void) sock;
+  (void) gv; (void) intf; (void) sock;
   return DDS_RETCODE_ERROR;
 #endif
 }

--- a/src/core/ddsi/src/ddsi_vnet.c
+++ b/src/core/ddsi/src/ddsi_vnet.c
@@ -12,7 +12,6 @@
 #include <string.h>
 #include <assert.h>
 #include <stdlib.h>
-#include <errno.h>
 
 #include "dds/ddsi/ddsi_tran.h"
 #include "dds/ddsi/ddsi_vnet.h"

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -1245,10 +1245,11 @@ static int convert_network_partition_addresses (struct ddsi_domaingv *gv, uint32
 
     struct networkpartition_address **nextp_uc = &np->uc_addresses;
     struct networkpartition_address **nextp_asm = &np->asm_addresses;
+    assert (*nextp_uc == NULL && *nextp_asm == NULL);
 #ifdef DDS_HAS_SSM
     struct networkpartition_address **nextp_ssm = &np->ssm_addresses;
+    assert (*nextp_ssm == NULL);
 #endif
-    assert (*nextp_uc == NULL && *nextp_asm == NULL && *nextp_ssm == NULL);
     char *copy = ddsrt_strdup (np->address_string), *cursor = copy, *tok;
     while (rc >= 0 && (tok = ddsrt_strsep (&cursor, ",;")) != NULL)
     {

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -180,27 +180,23 @@ static int set_recvips (struct ddsi_domaingv *gv)
   {
     if (ddsrt_strcasecmp (gv->config.networkRecvAddressStrings[0], "all") == 0)
     {
-#if DDSRT_HAVE_IPV6
-      if (gv->ipv6_link_local)
+      if (gv->using_link_local_intf)
       {
-        GVWARNING ("DDSI2EService/General/MulticastRecvNetworkInterfaceAddresses: using 'preferred' instead of 'all' because of IPv6 link-local address\n");
+        GVWARNING ("DDSI2EService/General/MulticastRecvNetworkInterfaceAddresses: using 'preferred' instead of 'all' because of link-local address\n");
         gv->recvips_mode = RECVIPS_MODE_PREFERRED;
       }
       else
-#endif
       {
         gv->recvips_mode = RECVIPS_MODE_ALL;
       }
     }
     else if (ddsrt_strcasecmp (gv->config.networkRecvAddressStrings[0], "any") == 0)
     {
-#if DDSRT_HAVE_IPV6
-      if (gv->ipv6_link_local)
+      if (gv->using_link_local_intf)
       {
-        GVERROR ("DDSI2EService/General/MulticastRecvNetworkInterfaceAddresses: 'any' is unsupported in combination with an IPv6 link-local address\n");
+        GVERROR ("DDSI2EService/General/MulticastRecvNetworkInterfaceAddresses: 'any' is unsupported in combination with a link-local address\n");
         return -1;
       }
-#endif
       gv->recvips_mode = RECVIPS_MODE_ANY;
     }
     else if (ddsrt_strcasecmp (gv->config.networkRecvAddressStrings[0], "preferred") == 0)
@@ -211,8 +207,7 @@ static int set_recvips (struct ddsi_domaingv *gv)
     {
       gv->recvips_mode = RECVIPS_MODE_NONE;
     }
-#if DDSRT_HAVE_IPV6
-    else if (gv->ipv6_link_local)
+    else if (gv->using_link_local_intf)
     {
       /* If the configuration explicitly includes the selected
        interface, treat it as "preferred", else as "none"; warn if
@@ -238,7 +233,6 @@ static int set_recvips (struct ddsi_domaingv *gv)
         GVWARNING ("DDSI2EService/General/MulticastRecvNetworkInterfaceAddresses: using 'preferred' because of IPv6 local address\n");
       }
     }
-#endif
     else
     {
       struct config_in_addr_node **recvnode = &gv->recvips;

--- a/src/core/ddsi/tests/locators.c
+++ b/src/core/ddsi/tests/locators.c
@@ -147,6 +147,7 @@ CU_Theory ((enum ddsi_transport_selector tr, int32_t loc_kind), ddsi_locator_fro
     enum ddsi_locator_from_string_result exp;
     struct sockaddr_in localhost;
     ddsrt_hostent_t *hent = NULL;
+    memset (&localhost, 0xee, sizeof (localhost));
     if (ddsrt_gethostbyname ("localhost", AF_INET, &hent) != 0)
       exp = AFSR_UNKNOWN;
     else
@@ -326,6 +327,7 @@ CU_Theory ((enum ddsi_transport_selector tr, int32_t loc_kind), ddsi_locator_fro
     enum ddsi_locator_from_string_result exp;
     struct sockaddr_in6 localhost;
     ddsrt_hostent_t *hent = NULL;
+    memset (&localhost, 0xee, sizeof (localhost));
     if (ddsrt_gethostbyname ("localhost", AF_INET6, &hent) != 0)
       exp = AFSR_UNKNOWN;
     else

--- a/src/core/ddsi/tests/locators.c
+++ b/src/core/ddsi/tests/locators.c
@@ -36,10 +36,12 @@ static bool check_ipv4_address (const ddsi_locator_t *loc, const uint8_t x[4])
   return prefix_zero (loc, 12) && memcmp (loc->address + 12, x, 4) == 0;
 }
 
+#if DDSRT_HAVE_IPV6
 static bool check_ipv64_address (const ddsi_locator_t *loc, const uint8_t x[4])
 {
   return prefix_zero (loc, 10) && loc->address[10] == 0xff && loc->address[11] == 0xff && memcmp (loc->address + 12, x, 4) == 0;
 }
+#endif
 
 static struct ddsi_tran_factory *init (struct ddsi_domaingv *gv, enum ddsi_transport_selector tr)
 {
@@ -293,6 +295,7 @@ CU_Theory ((enum ddsi_transport_selector tr), ddsi_locator_from_string, ipv6_inv
   CU_ASSERT_FATAL (res == AFSR_INVALID || res == AFSR_UNKNOWN);
   fini (&gv);
 #else
+  (void) tr;
   CU_PASS ("No IPv6 support");
 #endif
 }
@@ -423,6 +426,7 @@ CU_Theory ((enum ddsi_transport_selector tr, int32_t loc_kind), ddsi_locator_fro
 
   fini (&gv);
 #else
+  (void) tr; (void) loc_kind;
   CU_PASS ("No IPv6 support");
 #endif
 }


### PR DESCRIPTION
* Build errors when no IPv6 support available
* Build errors when assertions enabled and no SSM support available
* `uint32_t` vs `int` in a printf-style format string using `%*.*s` to print only a prefix of a string
* Warnings from LwIP redefining macros from `errno.h`

Plus a second attempt at eliminating two coverity false positives.