### PR TITLE
Fix mistyped ddsrt_mtime_t.

### DIFF
--- a/src/ddsrt/src/time/darwin/time.c
+++ b/src/ddsrt/src/time/darwin/time.c
@@ -72,7 +72,7 @@ ddsrt_etime_t ddsrt_time_elapsed(void)
   return (ddsrt_etime_t) { (int64_t) clock_gettime_nsec_np (CLOCK_MONOTONIC_RAW) };
 #else
   /* Elapsed time clock not (yet) supported on this platform. */
-  dds_mtime_t mt = ddsrt_time_monotonic();
+  ddsrt_mtime_t mt = ddsrt_time_monotonic();
   return (ddsrt_etime_t) { mt.v };
 #endif
 }


### PR DESCRIPTION
Ran into this on CI, I can't really test it locally due to lack of a mac but it is a fairly obvious typo.
Error log: https://dev.azure.com/tmiedema/57989905-544b-4946-93ca-4f71890be2ab/_apis/build/builds/195/logs/16