### PR TITLE
Fix the behavior of preprocessor with include directory search list

### DIFF
--- a/src/tools/idlpp/src/system.c
+++ b/src/tools/idlpp/src/system.c
@@ -2589,7 +2589,7 @@ static char *   norm_path(
                 if (cp1)        /* Append to the source directory   */
                     cp1[1] = '\0';
             }
-            (void)strlcat( slbuf1, slbuf2, sizeof(slbuf1));
+            (void)strlcpy( slbuf1, slbuf2, sizeof(slbuf1));
         }
     }
     if (inf) {


### PR DESCRIPTION
Fix the behavior of preprocessor when include directory search list is provided with `-I` option.

Attempt to fix #844 