### PR TITLE
Use constants for security property names

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/ddsi_security_msg.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_security_msg.h
@@ -19,6 +19,7 @@
 #include "dds/ddsi/ddsi_plist.h"
 #include "dds/ddsi/ddsi_guid.h"
 #include "dds/ddsrt/retcode.h"
+#include "dds/ddsrt/misc.h"
 #include "dds/ddsi/ddsi_plist_generic.h"
 
 #if defined (__cplusplus)
@@ -32,10 +33,17 @@ struct ddsi_serdata;
 
 #define DDS_SECURITY_AUTH_REQUEST                     "dds.sec.auth_request"
 #define DDS_SECURITY_AUTH_HANDSHAKE                   "dds.sec.auth"
-#define DDS_SECURITY_AUTH_REQUEST_TOKEN_CLASS_ID      "DDS:Auth:PKI-DH:1.0+AuthReq"
-#define DDS_SECURITY_AUTH_HANDSHAKE_REQUEST_TOKEN_ID  "DDS:Auth:PKI-DH:1.0+Req"
-#define DDS_SECURITY_AUTH_HANDSHAKE_REPLY_TOKEN_ID    "DDS:Auth:PKI-DH:1.0+Reply"
-#define DDS_SECURITY_AUTH_HANDSHAKE_FINAL_TOKEN_ID    "DDS:Auth:PKI-DH:1.0+Final"
+
+#define DDS_SECURITY_AUTH_VERSION_MAJOR 1
+#define DDS_SECURITY_AUTH_VERSION_MINOR 0
+
+#define DDS_SECURITY_AUTH_TOKEN_CLASS_ID_BASE         "DDS:Auth:PKI-DH:"
+#define DDS_SECURITY_AUTH_TOKEN_CLASS_ID              DDS_SECURITY_AUTH_TOKEN_CLASS_ID_BASE DDSRT_STRINGIFY(DDS_SECURITY_AUTH_VERSION_MAJOR) "." DDSRT_STRINGIFY(DDS_SECURITY_AUTH_VERSION_MINOR)
+
+#define DDS_SECURITY_AUTH_REQUEST_TOKEN_CLASS_ID      DDS_SECURITY_AUTH_TOKEN_CLASS_ID "+AuthReq"
+#define DDS_SECURITY_AUTH_HANDSHAKE_REQUEST_TOKEN_ID  DDS_SECURITY_AUTH_TOKEN_CLASS_ID "+Req"
+#define DDS_SECURITY_AUTH_HANDSHAKE_REPLY_TOKEN_ID    DDS_SECURITY_AUTH_TOKEN_CLASS_ID "+Reply"
+#define DDS_SECURITY_AUTH_HANDSHAKE_FINAL_TOKEN_ID    DDS_SECURITY_AUTH_TOKEN_CLASS_ID "+Final"
 
 
 typedef struct nn_message_identity {

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -915,7 +915,7 @@ static dds_return_t check_and_load_security_config (struct ddsi_domaingv * const
      XML configuration configures a CRL.
 
      This may modify "qos" */
-  if (ddsi_xqos_has_prop_prefix (qos, "dds.sec.") || ddsi_xqos_has_prop_prefix (qos, "org.eclipse.cyclonedds.sec."))
+  if (ddsi_xqos_has_prop_prefix (qos, DDS_SEC_PROP_PREFIX) || ddsi_xqos_has_prop_prefix (qos, ORG_ECLIPSE_CYCLONEDDS_SEC_PREFIX))
   {
     char const * const req[] = {
       DDS_SEC_PROP_AUTH_IDENTITY_CA,

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -1495,8 +1495,8 @@ int rtps_init (struct ddsi_domaingv *gv)
 
   /* Setting these properties allows the CryptoKeyFactory to recognize
    * the entities (see DDS Security spec chapter 8.8.8.1). */
-  add_property_to_xqos(&gv->builtin_secure_volatile_xqos_rd, "dds.sec.builtin_endpoint_name", "BuiltinParticipantVolatileMessageSecureReader");
-  add_property_to_xqos(&gv->builtin_secure_volatile_xqos_wr, "dds.sec.builtin_endpoint_name", "BuiltinParticipantVolatileMessageSecureWriter");
+  add_property_to_xqos(&gv->builtin_secure_volatile_xqos_rd, DDS_SEC_PROP_BUILTIN_ENDPOINT_NAME, "BuiltinParticipantVolatileMessageSecureReader");
+  add_property_to_xqos(&gv->builtin_secure_volatile_xqos_wr, DDS_SEC_PROP_BUILTIN_ENDPOINT_NAME, "BuiltinParticipantVolatileMessageSecureWriter");
 #endif
 
   ddsrt_mutex_init (&gv->sertypes_lock);

--- a/src/ddsrt/include/dds/ddsrt/misc.h
+++ b/src/ddsrt/include/dds/ddsrt/misc.h
@@ -18,6 +18,9 @@
 extern "C" {
 #endif
 
+#define DDSRT_STRINGIFY(x) DDSRT_STRINGIFY1(x)
+#define DDSRT_STRINGIFY1(x) #x
+
 #if defined(__clang__) || \
     defined(__GNUC__) && ((__GNUC__ * 100) + __GNUC_MINOR__) >= 402
 # define DDSRT_STR(s) #s

--- a/src/security/api/include/dds/security/dds_security_api_defs.h
+++ b/src/security/api/include/dds/security/dds_security_api_defs.h
@@ -188,26 +188,31 @@ typedef enum {
  * Security Property Key Names                                                     *
  *                                                                        *
  *************************************************************************/
-#define DDS_SEC_PROP_AUTH_LIBRARY_PATH "dds.sec.auth.library.path"
-#define DDS_SEC_PROP_AUTH_LIBRARY_INIT "dds.sec.auth.library.init"
-#define DDS_SEC_PROP_AUTH_LIBRARY_FINALIZE "dds.sec.auth.library.finalize"
-#define DDS_SEC_PROP_CRYPTO_LIBRARY_PATH "dds.sec.crypto.library.path"
-#define DDS_SEC_PROP_CRYPTO_LIBRARY_INIT "dds.sec.crypto.library.init"
-#define DDS_SEC_PROP_CRYPTO_LIBRARY_FINALIZE "dds.sec.crypto.library.finalize"
-#define DDS_SEC_PROP_ACCESS_LIBRARY_PATH "dds.sec.access.library.path"
-#define DDS_SEC_PROP_ACCESS_LIBRARY_INIT "dds.sec.access.library.init"
-#define DDS_SEC_PROP_ACCESS_LIBRARY_FINALIZE "dds.sec.access.library.finalize"
+#define DDS_SEC_PROP_PREFIX "dds.sec."
+#define ORG_ECLIPSE_CYCLONEDDS_SEC_PREFIX "org.eclipse.cyclonedds.sec."
 
-#define DDS_SEC_PROP_AUTH_IDENTITY_CA "dds.sec.auth.identity_ca"
-#define DDS_SEC_PROP_AUTH_PRIV_KEY "dds.sec.auth.private_key"
-#define DDS_SEC_PROP_AUTH_IDENTITY_CERT "dds.sec.auth.identity_certificate"
-#define DDS_SEC_PROP_AUTH_PASSWORD "dds.sec.auth.password"
-#define ORG_ECLIPSE_CYCLONEDDS_SEC_AUTH_CRL "org.eclipse.cyclonedds.sec.auth.crl"
-#define DDS_SEC_PROP_ACCESS_PERMISSIONS_CA "dds.sec.access.permissions_ca"
-#define DDS_SEC_PROP_ACCESS_GOVERNANCE "dds.sec.access.governance"
-#define DDS_SEC_PROP_ACCESS_PERMISSIONS "dds.sec.access.permissions"
-#define DDS_SEC_PROP_ACCESS_TRUSTED_CA_DIR "dds.sec.auth.trusted_ca_dir"
+#define DDS_SEC_PROP_AUTH_LIBRARY_PATH DDS_SEC_PROP_PREFIX "auth.library.path"
+#define DDS_SEC_PROP_AUTH_LIBRARY_INIT DDS_SEC_PROP_PREFIX "auth.library.init"
+#define DDS_SEC_PROP_AUTH_LIBRARY_FINALIZE DDS_SEC_PROP_PREFIX "auth.library.finalize"
+#define DDS_SEC_PROP_CRYPTO_LIBRARY_PATH DDS_SEC_PROP_PREFIX "crypto.library.path"
+#define DDS_SEC_PROP_CRYPTO_LIBRARY_INIT DDS_SEC_PROP_PREFIX "crypto.library.init"
+#define DDS_SEC_PROP_CRYPTO_LIBRARY_FINALIZE DDS_SEC_PROP_PREFIX "crypto.library.finalize"
+#define DDS_SEC_PROP_ACCESS_LIBRARY_PATH DDS_SEC_PROP_PREFIX "access.library.path"
+#define DDS_SEC_PROP_ACCESS_LIBRARY_INIT DDS_SEC_PROP_PREFIX "access.library.init"
+#define DDS_SEC_PROP_ACCESS_LIBRARY_FINALIZE DDS_SEC_PROP_PREFIX "access.library.finalize"
 
+#define DDS_SEC_PROP_AUTH_IDENTITY_CA DDS_SEC_PROP_PREFIX "auth.identity_ca"
+#define DDS_SEC_PROP_AUTH_PRIV_KEY DDS_SEC_PROP_PREFIX "auth.private_key"
+#define DDS_SEC_PROP_AUTH_IDENTITY_CERT DDS_SEC_PROP_PREFIX "auth.identity_certificate"
+#define DDS_SEC_PROP_AUTH_PASSWORD DDS_SEC_PROP_PREFIX "auth.password"
+#define ORG_ECLIPSE_CYCLONEDDS_SEC_AUTH_CRL ORG_ECLIPSE_CYCLONEDDS_SEC_PREFIX "auth.crl"
+#define DDS_SEC_PROP_ACCESS_PERMISSIONS_CA DDS_SEC_PROP_PREFIX "access.permissions_ca"
+#define DDS_SEC_PROP_ACCESS_GOVERNANCE DDS_SEC_PROP_PREFIX "access.governance"
+#define DDS_SEC_PROP_ACCESS_PERMISSIONS DDS_SEC_PROP_PREFIX "access.permissions"
+#define DDS_SEC_PROP_ACCESS_TRUSTED_CA_DIR DDS_SEC_PROP_PREFIX "auth.trusted_ca_dir"
+
+#define DDS_SEC_PROP_BUILTIN_ENDPOINT_NAME DDS_SEC_PROP_PREFIX "builtin_endpoint_name"
+#define DDS_SEC_PROP_CRYPTO_KEYSIZE DDS_SEC_PROP_PREFIX "crypto.keysize"
 
 #if defined (__cplusplus)
 }

--- a/src/security/builtin_plugins/access_control/CMakeLists.txt
+++ b/src/security/builtin_plugins/access_control/CMakeLists.txt
@@ -20,7 +20,8 @@ set(private_headers
   src/access_control_objects.h
   src/access_control_parser.h
   src/access_control_utils.h
-  src/access_control.h)
+  src/access_control.h
+  ../include/ac_tokens.h)
 
 add_library(dds_security_ac SHARED ${sources} ${private_headers})
 
@@ -43,6 +44,7 @@ target_include_directories(dds_security_ac
         "$<BUILD_INTERFACE:$<TARGET_PROPERTY:security_core,INTERFACE_INCLUDE_DIRECTORIES>>"
         "$<BUILD_INTERFACE:$<TARGET_PROPERTY:security_openssl,INTERFACE_INCLUDE_DIRECTORIES>>"
         "$<BUILD_INTERFACE:$<TARGET_PROPERTY:ddsrt,INTERFACE_INCLUDE_DIRECTORIES>>"
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../include>"
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
 )
 

--- a/src/security/builtin_plugins/authentication/CMakeLists.txt
+++ b/src/security/builtin_plugins/authentication/CMakeLists.txt
@@ -13,7 +13,9 @@ include(GenerateExportHeader)
 
 set(sources
   src/authentication.c
-  src/auth_utils.c)
+  src/auth_utils.c
+  ../include/auth_tokens.h
+  ../include/ac_tokens.h)
 
 set(private_headers
   src/authentication.h
@@ -42,6 +44,7 @@ target_include_directories(dds_security_auth
         "$<BUILD_INTERFACE:$<TARGET_PROPERTY:security_openssl,INTERFACE_INCLUDE_DIRECTORIES>>"
         "$<BUILD_INTERFACE:$<TARGET_PROPERTY:ddsrt,INTERFACE_INCLUDE_DIRECTORIES>>"
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../include>"
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../../../core/ddsi/include>"
 )
 

--- a/src/security/builtin_plugins/cryptographic/CMakeLists.txt
+++ b/src/security/builtin_plugins/cryptographic/CMakeLists.txt
@@ -26,7 +26,8 @@ set(private_headers
   src/crypto_objects.h
   src/crypto_transform.h
   src/crypto_utils.h
-  src/cryptography.h)
+  src/cryptography.h
+  ../include/crypto_tokens.h)
 
 add_library(dds_security_crypto SHARED ${sources} ${private_headers})
 
@@ -50,6 +51,7 @@ target_include_directories(dds_security_crypto
         "$<BUILD_INTERFACE:$<TARGET_PROPERTY:security_openssl,INTERFACE_INCLUDE_DIRECTORIES>>"
         "$<BUILD_INTERFACE:$<TARGET_PROPERTY:ddsrt,INTERFACE_INCLUDE_DIRECTORIES>>"
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../include>"
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../../../core/ddsi/include>"
 )
 

--- a/src/security/builtin_plugins/cryptographic/src/crypto_key_exchange.c
+++ b/src/security/builtin_plugins/cryptographic/src/crypto_key_exchange.c
@@ -21,9 +21,7 @@
 #include "cryptography.h"
 #include "crypto_key_exchange.h"
 #include "crypto_key_factory.h"
-
-static const char *CRYPTO_TOKEN_CLASS_ID = "DDS:Crypto:AES_GCM_GMAC";
-static const char *CRYPTO_TOKEN_PROPERTY_NAME = "dds.cryp.keymat";
+#include "crypto_tokens.h"
 
 /**
  * Implementation structure for storing encapsulated members of the instance
@@ -47,11 +45,11 @@ static bool check_crypto_tokens(const DDS_Security_DataHolderSeq *tokens)
   for (i = 0; status && (i < tokens->_length); i++)
   {
     status = (tokens->_buffer[i].class_id != NULL) &&
-             (strcmp(CRYPTO_TOKEN_CLASS_ID, tokens->_buffer[i].class_id) == 0) &&
+             (strcmp(DDS_CRYPTOTOKEN_CLASS_ID, tokens->_buffer[i].class_id) == 0) &&
              (tokens->_buffer[i].binary_properties._length == 1) &&
              (tokens->_buffer[i].binary_properties._buffer != NULL) &&
              (tokens->_buffer[i].binary_properties._buffer[0].name != NULL) &&
-             (strcmp(CRYPTO_TOKEN_PROPERTY_NAME, tokens->_buffer[i].binary_properties._buffer[0].name) == 0) &&
+             (strcmp(DDS_CRYPTOTOKEN_PROP_KEYMAT, tokens->_buffer[i].binary_properties._buffer[0].name) == 0) &&
              (tokens->_buffer[i].binary_properties._buffer[0].value._length > 0) &&
              (tokens->_buffer[i].binary_properties._buffer[0].value._buffer != NULL);
   }
@@ -187,10 +185,10 @@ create_local_participant_crypto_tokens(
 
   tokens->_buffer = DDS_Security_DataHolderSeq_allocbuf(1);
   tokens->_length = tokens->_maximum = 1;
-  tokens->_buffer[0].class_id = ddsrt_strdup(CRYPTO_TOKEN_CLASS_ID);
+  tokens->_buffer[0].class_id = ddsrt_strdup(DDS_CRYPTOTOKEN_CLASS_ID);
   tokens->_buffer[0].binary_properties._buffer = DDS_Security_BinaryPropertySeq_allocbuf(1);
   tokens->_buffer[0].binary_properties._length = tokens->_buffer[0].binary_properties._maximum = 1;
-  tokens->_buffer[0].binary_properties._buffer[0].name = ddsrt_strdup(CRYPTO_TOKEN_PROPERTY_NAME);
+  tokens->_buffer[0].binary_properties._buffer[0].name = ddsrt_strdup(DDS_CRYPTOTOKEN_PROP_KEYMAT);
   tokens->_buffer[0].binary_properties._buffer[0].value._length =
       tokens->_buffer[0].binary_properties._buffer[0].value._maximum = length;
   tokens->_buffer[0].binary_properties._buffer[0].value._buffer = buffer;
@@ -323,10 +321,10 @@ create_local_datawriter_crypto_tokens(
 
     serialize_master_key_material(key_mat[i], &buffer, &length);
 
-    tokens->_buffer[i].class_id = ddsrt_strdup(CRYPTO_TOKEN_CLASS_ID);
+    tokens->_buffer[i].class_id = ddsrt_strdup(DDS_CRYPTOTOKEN_CLASS_ID);
     tokens->_buffer[i].binary_properties._buffer = DDS_Security_BinaryPropertySeq_allocbuf(1);
     tokens->_buffer[i].binary_properties._length = tokens->_buffer[0].binary_properties._maximum = 1;
-    tokens->_buffer[i].binary_properties._buffer[0].name = ddsrt_strdup(CRYPTO_TOKEN_PROPERTY_NAME);
+    tokens->_buffer[i].binary_properties._buffer[0].name = ddsrt_strdup(DDS_CRYPTOTOKEN_PROP_KEYMAT);
     tokens->_buffer[i].binary_properties._buffer[0].value._length =
         tokens->_buffer[i].binary_properties._buffer[0].value._maximum = length;
     tokens->_buffer[i].binary_properties._buffer[0].value._buffer = buffer;
@@ -446,10 +444,10 @@ create_local_datareader_crypto_tokens(
     tokens->_buffer = DDS_Security_DataHolderSeq_allocbuf(1);
     tokens->_length = tokens->_maximum = 1;
 
-    tokens->_buffer[0].class_id = ddsrt_strdup(CRYPTO_TOKEN_CLASS_ID);
+    tokens->_buffer[0].class_id = ddsrt_strdup(DDS_CRYPTOTOKEN_CLASS_ID);
     tokens->_buffer[0].binary_properties._buffer = DDS_Security_BinaryPropertySeq_allocbuf(1);
     tokens->_buffer[0].binary_properties._length = tokens->_buffer[0].binary_properties._maximum = 1;
-    tokens->_buffer[0].binary_properties._buffer[0].name = ddsrt_strdup(CRYPTO_TOKEN_PROPERTY_NAME);
+    tokens->_buffer[0].binary_properties._buffer[0].name = ddsrt_strdup(DDS_CRYPTOTOKEN_PROP_KEYMAT);
     tokens->_buffer[0].binary_properties._buffer[0].value._length =
         tokens->_buffer[0].binary_properties._buffer[0].value._maximum = length;
     tokens->_buffer[0].binary_properties._buffer[0].value._buffer = buffer;

--- a/src/security/builtin_plugins/cryptographic/src/crypto_key_factory.c
+++ b/src/security/builtin_plugins/cryptographic/src/crypto_key_factory.c
@@ -490,7 +490,7 @@ register_local_datawriter(
   if (datawriter_properties != NULL && datawriter_properties->_length > 0)
   {
     const DDS_Security_Property_t *property = DDS_Security_PropertySeq_find_property(
-        datawriter_properties, "dds.sec.builtin_endpoint_name");
+        datawriter_properties, DDS_SEC_PROP_BUILTIN_ENDPOINT_NAME);
     if (property != NULL && strcmp(property->value, "BuiltinParticipantVolatileMessageSecureWriter") == 0)
       is_builtin = true;
   }
@@ -671,7 +671,7 @@ register_local_datareader(
   if (datareader_properties != NULL && datareader_properties->_length > 0)
   {
     const DDS_Security_Property_t *property = DDS_Security_PropertySeq_find_property(
-        datareader_properties, "dds.sec.builtin_endpoint_name");
+        datareader_properties, DDS_SEC_PROP_BUILTIN_ENDPOINT_NAME);
     if (property != NULL && strcmp(property->value, "BuiltinParticipantVolatileMessageSecureReader") == 0)
       is_builtin = true;
   }

--- a/src/security/builtin_plugins/include/ac_tokens.h
+++ b/src/security/builtin_plugins/include/ac_tokens.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright(c) 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#ifndef DDS_SECURITY_AC_TOKENS_H
+#define DDS_SECURITY_AC_TOKENS_H
+
+// FIXME: move token names into separate file
+#include "dds/ddsi/ddsi_security_msg.h"
+
+// PermissionsCredentialToken
+#define DDS_ACTOKEN_PERMISSIONS_CREDENTIAL_CLASS_ID "DDS:Access:PermissionsCredential"
+#define DDS_ACTOKEN_PROP_PERM_CERT "dds.perm.cert"
+
+// PermissionsToken
+#define DDS_ACTOKEN_PERMISSIONS_CLASS_ID "DDS:Access:Permissions:1.0"
+#define DDS_ACTOKEN_PROP_C_ID "c.id"
+#define DDS_ACTOKEN_PROP_C_PERM "c.perm"
+#define DDS_ACTOKEN_PROP_PERM_CA_SN "dds.perm_ca.sn"
+#define DDS_ACTOKEN_PROP_PERM_CA_ALGO "dds.perm_ca.algo"
+
+#endif

--- a/src/security/builtin_plugins/include/auth_tokens.h
+++ b/src/security/builtin_plugins/include/auth_tokens.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright(c) 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#ifndef DDS_SECURITY_AUTH_TOKENS_H
+#define DDS_SECURITY_AUTH_TOKENS_H
+
+// FIXME: move token names into separate file
+#include "dds/ddsi/ddsi_security_msg.h"
+
+// IdentityToken
+#define DDS_AUTHTOKEN_CLASS_ID "DDS:Auth:PKI-DH:1.0"
+#define DDS_AUTHTOKEN_PROP_CERT_SN "dds.cert.sn"
+#define DDS_AUTHTOKEN_PROP_CERT_ALGO "dds.cert.algo"
+#define DDS_AUTHTOKEN_PROP_CA_SN "dds.ca.sn"
+#define DDS_AUTHTOKEN_PROP_CA_ALGO "dds.ca.algo"
+
+// IdentityStatusToken
+//#define DDS_AUTHTOKEN_CLASS_ID "DDS:Auth:PKI-DH:1.0"
+#define DDS_AUTHTOKEN_PROP_OCSP_STATUS "ocsp_status"
+
+// AuthenticatedPeerCredentialToken
+//#define DDS_AUTHTOKEN_CLASS_ID "DDS:Auth:PKI-DH:1.0"
+#define DDS_AUTHTOKEN_PROP_C_ID "c.id"
+#define DDS_AUTHTOKEN_PROP_C_PERM "c.perm"
+
+// AuthRequestMessageToken
+#define DDS_AUTHTOKEN_AUTHREQ_CLASS_ID "DDS:Auth:PKI-DH:1.0+AuthReq"
+#define DDS_AUTHTOKEN_PROP_FUTURE_CHALLENGE "future_challenge"
+
+// HandshakeRequestMessageToken
+#define DDS_AUTHTOKEN_REQ_CLASS_ID "DDS:Auth:PKI-DH:1.0+Req"
+//#define DDS_AUTHTOKEN_PROP_C_ID "c.id"
+//#define DDS_AUTHTOKEN_PROP_C_PERM "c.perm"
+#define DDS_AUTHTOKEN_PROP_C_PDATA "c.pdata"
+#define DDS_AUTHTOKEN_PROP_C_DSIGN_ALGO "c.dsign_algo"
+#define DDS_AUTHTOKEN_PROP_C_KAGREE_ALGO "c.kagree_algo"
+#define DDS_AUTHTOKEN_PROP_HASH_C1 "hash_c1"
+#define DDS_AUTHTOKEN_PROP_DH1 "dh1"
+#define DDS_AUTHTOKEN_PROP_CHALLENGE1 "challenge1"
+//#define DDS_AUTHTOKEN_PROP_OCSP_STATUS "ocsp_status"
+
+// HandshakeReplyMessageToken
+#define DDS_AUTHTOKEN_REPLY_CLASS_ID "DDS:Auth:PKI-DH:1.0+Reply"
+//#define DDS_AUTHTOKEN_PROP_C_ID "c.id"
+//#define DDS_AUTHTOKEN_PROP_C_PERM "c.perm"
+//#define DDS_AUTHTOKEN_PROP_C_PDATA "c.pdata"
+//#define DDS_AUTHTOKEN_PROP_C_DSIGN_ALGO "c.dsign_algo"
+//#define DDS_AUTHTOKEN_PROP_C_KAGREE_ALGO "c.kagree_algo"
+#define DDS_AUTHTOKEN_PROP_HASH_C2 "hash_c2"
+#define DDS_AUTHTOKEN_PROP_DH2 "dh2"
+//#define DDS_AUTHTOKEN_PROP_HASH_C1 "hash_c1"
+//#define DDS_AUTHTOKEN_PROP_DH1 "dh1"
+//#define DDS_AUTHTOKEN_PROP_CHALLENGE1 "challenge1"
+#define DDS_AUTHTOKEN_PROP_CHALLENGE2 "challenge2"
+//#define DDS_AUTHTOKEN_PROP_OCSP_STATUS "ocsp_status"
+#define DDS_AUTHTOKEN_PROP_SIGNATURE "signature"
+
+// HandshakeFinalMessageToken
+#define DDS_AUTHTOKEN_FINAL_CLASS_ID "DDS:Auth:PKI-DH:1.0+Final"
+//#define DDS_AUTHTOKEN_PROP_HASH_C1 "hash_c1"
+//#define DDS_AUTHTOKEN_PROP_HASH_C2 "hash_c2"
+//#define DDS_AUTHTOKEN_PROP_DH1 "dh1"
+//#define DDS_AUTHTOKEN_PROP_DH2 "dh2"
+//#define DDS_AUTHTOKEN_PROP_CHALLENGE1 "challenge1"
+//#define DDS_AUTHTOKEN_PROP_CHALLENGE2 "challenge2"
+//#define DDS_AUTHTOKEN_PROP_SIGNATURE "signature"
+
+#endif

--- a/src/security/builtin_plugins/include/crypto_tokens.h
+++ b/src/security/builtin_plugins/include/crypto_tokens.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright(c) 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#ifndef DDS_SECURITY_CRYPTO_TOKENS_H
+#define DDS_SECURITY_CRYPTO_TOKENS_H
+
+// FIXME: move token names into separate file
+#include "dds/ddsi/ddsi_security_msg.h"
+
+// CryptoToken
+#define DDS_CRYPTOTOKEN_CLASS_ID "DDS:Crypto:AES_GCM_GMAC"
+#define DDS_CRYPTOTOKEN_PROP_KEYMAT "dds.cryp.keymat"
+
+#endif

--- a/src/security/builtin_plugins/tests/create_local_datareader_crypto_tokens/src/create_local_datareader_crypto_tokens_utests.c
+++ b/src/security/builtin_plugins/tests/create_local_datareader_crypto_tokens/src/create_local_datareader_crypto_tokens_utests.c
@@ -22,14 +22,12 @@
 #include "CUnit/Test.h"
 #include "common/src/loader.h"
 #include "crypto_objects.h"
+#include "crypto_tokens.h"
 
 #define TEST_SHARED_SECRET_SIZE 32
 
 #define CRYPTO_TRANSFORM_KIND(k) (*(uint32_t *)&((k)[0]))
 #define CRYPTO_TRANSFORM_ID(k) (*(uint32_t *)&((k)[0]))
-
-static const char *CRYPTO_TOKEN_CLASS_ID = "DDS:Crypto:AES_GCM_GMAC";
-static const char *CRYPTO_TOKEN_PROPERTY_NAME = "dds.cryp.keymat";
 
 static struct plugins_hdl *plugins = NULL;
 static dds_security_cryptography *crypto = NULL;
@@ -324,11 +322,11 @@ static bool check_token_validity(const DDS_Security_DatawriterCryptoTokenSeq *to
   for (i = 0; status && (i < tokens->_length); i++)
   {
     status = (tokens->_buffer[i].class_id != NULL) &&
-             (strcmp(CRYPTO_TOKEN_CLASS_ID, tokens->_buffer[i].class_id) == 0) &&
+             (strcmp(DDS_CRYPTOTOKEN_CLASS_ID, tokens->_buffer[i].class_id) == 0) &&
              (tokens->_buffer[i].binary_properties._length == 1) &&
              (tokens->_buffer[i].binary_properties._buffer != NULL) &&
              (tokens->_buffer[i].binary_properties._buffer[0].name != NULL) &&
-             (strcmp(CRYPTO_TOKEN_PROPERTY_NAME, tokens->_buffer[i].binary_properties._buffer[0].name) == 0) &&
+             (strcmp(DDS_CRYPTOTOKEN_PROP_KEYMAT, tokens->_buffer[i].binary_properties._buffer[0].name) == 0) &&
              (tokens->_buffer[i].binary_properties._buffer[0].value._length > 0) &&
              (tokens->_buffer[i].binary_properties._buffer[0].value._buffer != NULL);
 

--- a/src/security/builtin_plugins/tests/create_local_datawriter_crypto_tokens/src/create_local_datawriter_crypto_tokens_utests.c
+++ b/src/security/builtin_plugins/tests/create_local_datawriter_crypto_tokens/src/create_local_datawriter_crypto_tokens_utests.c
@@ -22,14 +22,12 @@
 #include "CUnit/Test.h"
 #include "common/src/loader.h"
 #include "crypto_objects.h"
+#include "crypto_tokens.h"
 
 #define TEST_SHARED_SECRET_SIZE 32
 
 #define CRYPTO_TRANSFORM_KIND(k) (*(uint32_t *)&((k)[0]))
 #define CRYPTO_TRANSFORM_ID(k) (*(uint32_t *)&((k)[0]))
-
-static const char *CRYPTO_TOKEN_CLASS_ID = "DDS:Crypto:AES_GCM_GMAC";
-static const char *CRYPTO_TOKEN_PROPERTY_NAME = "dds.cryp.keymat";
 
 static struct plugins_hdl *plugins = NULL;
 static dds_security_cryptography *crypto = NULL;
@@ -327,11 +325,11 @@ static bool check_token_validity(const DDS_Security_DatawriterCryptoTokenSeq *to
   for (i = 0; status && (i < tokens->_length); i++)
   {
     status = (tokens->_buffer[i].class_id != NULL) &&
-             (strcmp(CRYPTO_TOKEN_CLASS_ID, tokens->_buffer[i].class_id) == 0) &&
+             (strcmp(DDS_CRYPTOTOKEN_CLASS_ID, tokens->_buffer[i].class_id) == 0) &&
              (tokens->_buffer[i].binary_properties._length == 1) &&
              (tokens->_buffer[i].binary_properties._buffer != NULL) &&
              (tokens->_buffer[i].binary_properties._buffer[0].name != NULL) &&
-             (strcmp(CRYPTO_TOKEN_PROPERTY_NAME, tokens->_buffer[i].binary_properties._buffer[0].name) == 0) &&
+             (strcmp(DDS_CRYPTOTOKEN_PROP_KEYMAT, tokens->_buffer[i].binary_properties._buffer[0].name) == 0) &&
              (tokens->_buffer[i].binary_properties._buffer[0].value._length > 0) &&
              (tokens->_buffer[i].binary_properties._buffer[0].value._buffer != NULL);
 

--- a/src/security/builtin_plugins/tests/create_local_participant_crypto_tokens/src/create_local_participant_crypto_tokens_utests.c
+++ b/src/security/builtin_plugins/tests/create_local_participant_crypto_tokens/src/create_local_participant_crypto_tokens_utests.c
@@ -22,11 +22,9 @@
 #include "CUnit/Test.h"
 #include "common/src/loader.h"
 #include "crypto_objects.h"
+#include "crypto_tokens.h"
 
 #define TEST_SHARED_SECRET_SIZE 32
-
-static const char *CRYPTO_TOKEN_CLASS_ID = "DDS:Crypto:AES_GCM_GMAC";
-static const char *CRYPTO_TOKEN_PROPERTY_NAME = "dds.cryp.keymat";
 
 static struct plugins_hdl *plugins = NULL;
 static dds_security_cryptography *crypto = NULL;
@@ -189,11 +187,11 @@ static DDS_Security_boolean check_token_validity(const DDS_Security_ParticipantC
   for (i = 0; status && (i < tokens->_length); i++)
   {
     status = (tokens->_buffer[i].class_id != NULL) &&
-             (strcmp(CRYPTO_TOKEN_CLASS_ID, tokens->_buffer[i].class_id) == 0) &&
+             (strcmp(DDS_CRYPTOTOKEN_CLASS_ID, tokens->_buffer[i].class_id) == 0) &&
              (tokens->_buffer[i].binary_properties._length == 1) &&
              (tokens->_buffer[i].binary_properties._buffer != NULL) &&
              (tokens->_buffer[i].binary_properties._buffer[0].name != NULL) &&
-             (strcmp(CRYPTO_TOKEN_PROPERTY_NAME, tokens->_buffer[i].binary_properties._buffer[0].name) == 0) &&
+             (strcmp(DDS_CRYPTOTOKEN_PROP_KEYMAT, tokens->_buffer[i].binary_properties._buffer[0].name) == 0) &&
              (tokens->_buffer[i].binary_properties._buffer[0].value._length > 0) &&
              (tokens->_buffer[i].binary_properties._buffer[0].value._buffer != NULL);
   }

--- a/src/security/builtin_plugins/tests/decode_datareader_submessage/src/decode_datareader_submessage_utests.c
+++ b/src/security/builtin_plugins/tests/decode_datareader_submessage/src/decode_datareader_submessage_utests.c
@@ -221,7 +221,7 @@ static void prepare_endpoint_security_attributes_and_properties(DDS_Security_End
     properties->_maximum = properties->_length = 1;
     properties->_buffer = ddsrt_malloc(sizeof(DDS_Security_Property_t));
 
-    properties->_buffer[0].name = ddsrt_strdup("dds.sec.crypto.keysize");
+    properties->_buffer[0].name = ddsrt_strdup(DDS_SEC_PROP_CRYPTO_KEYSIZE);
 
     if (transformation_kind == CRYPTO_TRANSFORMATION_KIND_AES128_GCM || transformation_kind == CRYPTO_TRANSFORMATION_KIND_AES128_GMAC)
     {
@@ -1589,13 +1589,13 @@ CU_Test(ddssec_builtin_decode_datareader_submessage, volatile_sec, .init = suite
 
   datareader_properties._length = datareader_properties._maximum = 1;
   datareader_properties._buffer = DDS_Security_PropertySeq_allocbuf(1);
-  datareader_properties._buffer[0].name = ddsrt_strdup("dds.sec.builtin_endpoint_name");
+  datareader_properties._buffer[0].name = ddsrt_strdup(DDS_SEC_PROP_BUILTIN_ENDPOINT_NAME);
   datareader_properties._buffer[0].value = ddsrt_strdup("BuiltinParticipantVolatileMessageSecureReader");
   datareader_properties._buffer[0].propagate = false;
 
   datawriter_properties._length = datawriter_properties._maximum = 1;
   datawriter_properties._buffer = DDS_Security_PropertySeq_allocbuf(1);
-  datawriter_properties._buffer[0].name = ddsrt_strdup("dds.sec.builtin_endpoint_name");
+  datawriter_properties._buffer[0].name = ddsrt_strdup(DDS_SEC_PROP_BUILTIN_ENDPOINT_NAME);
   datawriter_properties._buffer[0].value = ddsrt_strdup("BuiltinParticipantVolatileMessageSecureWriter");
   datawriter_properties._buffer[0].propagate = false;
 

--- a/src/security/builtin_plugins/tests/decode_datawriter_submessage/src/decode_datawriter_submessage_utests.c
+++ b/src/security/builtin_plugins/tests/decode_datawriter_submessage/src/decode_datawriter_submessage_utests.c
@@ -155,7 +155,7 @@ static void prepare_endpoint_security_attributes_and_properties(DDS_Security_End
     properties->_maximum = properties->_length = 1;
     properties->_buffer = ddsrt_malloc(sizeof(DDS_Security_Property_t));
 
-    properties->_buffer[0].name = ddsrt_strdup("dds.sec.crypto.keysize");
+    properties->_buffer[0].name = ddsrt_strdup(DDS_SEC_PROP_CRYPTO_KEYSIZE);
 
     if (transformation_kind == CRYPTO_TRANSFORMATION_KIND_AES128_GCM || transformation_kind == CRYPTO_TRANSFORMATION_KIND_AES128_GMAC)
     {
@@ -1595,13 +1595,13 @@ CU_Test(ddssec_builtin_decode_datawriter_submessage, volatile_sec, .init = suite
 
   datareader_properties._length = datareader_properties._maximum = 1;
   datareader_properties._buffer = DDS_Security_PropertySeq_allocbuf(1);
-  datareader_properties._buffer[0].name = ddsrt_strdup("dds.sec.builtin_endpoint_name");
+  datareader_properties._buffer[0].name = ddsrt_strdup(DDS_SEC_PROP_BUILTIN_ENDPOINT_NAME);
   datareader_properties._buffer[0].value = ddsrt_strdup("BuiltinParticipantVolatileMessageSecureReader");
   datareader_properties._buffer[0].propagate = false;
 
   datawriter_properties._length = datawriter_properties._maximum = 1;
   datawriter_properties._buffer = DDS_Security_PropertySeq_allocbuf(1);
-  datawriter_properties._buffer[0].name = ddsrt_strdup("dds.sec.builtin_endpoint_name");
+  datawriter_properties._buffer[0].name = ddsrt_strdup(DDS_SEC_PROP_BUILTIN_ENDPOINT_NAME);
   datawriter_properties._buffer[0].value = ddsrt_strdup("BuiltinParticipantVolatileMessageSecureWriter");
   datawriter_properties._buffer[0].propagate = false;
 

--- a/src/security/builtin_plugins/tests/decode_rtps_message/src/decode_rtps_message_utests.c
+++ b/src/security/builtin_plugins/tests/decode_rtps_message/src/decode_rtps_message_utests.c
@@ -143,7 +143,7 @@ static void prepare_participant_security_attributes_and_properties(DDS_Security_
     properties->_maximum = properties->_length = 1;
     properties->_buffer = ddsrt_malloc(sizeof(DDS_Security_Property_t));
 
-    properties->_buffer[0].name = ddsrt_strdup("dds.sec.crypto.keysize");
+    properties->_buffer[0].name = ddsrt_strdup(DDS_SEC_PROP_CRYPTO_KEYSIZE);
 
     if (transformation_kind == CRYPTO_TRANSFORMATION_KIND_AES128_GCM || transformation_kind == CRYPTO_TRANSFORMATION_KIND_AES128_GMAC)
     {

--- a/src/security/builtin_plugins/tests/encode_datareader_submessage/src/encode_datareader_submessage_utests.c
+++ b/src/security/builtin_plugins/tests/encode_datareader_submessage/src/encode_datareader_submessage_utests.c
@@ -653,7 +653,7 @@ static void prepare_endpoint_security_attributes_and_properties(DDS_Security_End
   properties->_maximum = properties->_length = 1;
   properties->_buffer = ddsrt_malloc(sizeof(DDS_Security_Property_t));
 
-  properties->_buffer[0].name = ddsrt_strdup("dds.sec.crypto.keysize");
+  properties->_buffer[0].name = ddsrt_strdup(DDS_SEC_PROP_CRYPTO_KEYSIZE);
   if (transformation_kind == CRYPTO_TRANSFORMATION_KIND_AES128_GCM || transformation_kind == CRYPTO_TRANSFORMATION_KIND_AES128_GMAC)
   {
     properties->_buffer[0].value = ddsrt_strdup("128");

--- a/src/security/builtin_plugins/tests/encode_datawriter_submessage/src/encode_datawriter_submessage_utests.c
+++ b/src/security/builtin_plugins/tests/encode_datawriter_submessage/src/encode_datawriter_submessage_utests.c
@@ -192,7 +192,7 @@ static void prepare_endpoint_security_attributes_and_properties(DDS_Security_End
   properties->_maximum = properties->_length = 1;
   properties->_buffer = ddsrt_malloc(sizeof(DDS_Security_Property_t));
 
-  properties->_buffer[0].name = ddsrt_strdup("dds.sec.crypto.keysize");
+  properties->_buffer[0].name = ddsrt_strdup(DDS_SEC_PROP_CRYPTO_KEYSIZE);
   if (transformation_kind == CRYPTO_TRANSFORMATION_KIND_AES128_GCM || transformation_kind == CRYPTO_TRANSFORMATION_KIND_AES128_GMAC)
   {
     properties->_buffer[0].value = ddsrt_strdup("128");

--- a/src/security/builtin_plugins/tests/encode_rtps_message/src/encode_rtps_message_utests.c
+++ b/src/security/builtin_plugins/tests/encode_rtps_message/src/encode_rtps_message_utests.c
@@ -732,7 +732,7 @@ static void prepare_participant_security_attributes_and_properties(
   properties->_maximum = properties->_length = 1;
   properties->_buffer = ddsrt_malloc(sizeof(DDS_Security_Property_t));
 
-  properties->_buffer[0].name = ddsrt_strdup("dds.sec.crypto.keysize");
+  properties->_buffer[0].name = ddsrt_strdup(DDS_SEC_PROP_CRYPTO_KEYSIZE);
   if (transformation_kind == CRYPTO_TRANSFORMATION_KIND_AES128_GCM || transformation_kind == CRYPTO_TRANSFORMATION_KIND_AES128_GMAC)
   {
     properties->_buffer[0].value = ddsrt_strdup("128");

--- a/src/security/builtin_plugins/tests/get_permissions_credential_token/src/get_permissions_credential_token_utests.c
+++ b/src/security/builtin_plugins/tests/get_permissions_credential_token/src/get_permissions_credential_token_utests.c
@@ -351,17 +351,17 @@ static bool validate_permissions_token(DDS_Security_PermissionsCredentialToken *
   property = find_property(token, DDS_ACTOKEN_PROP_PERM_CERT);
   if (property == NULL)
   {
-    CU_FAIL("PermissionsCredentialToken property 'dds.perm.cert' not found");
+    CU_FAIL("PermissionsCredentialToken property '" DDS_ACTOKEN_PROP_PERM_CERT "' not found");
     return false;
   }
   if (property->value == NULL)
   {
-    CU_FAIL("PermissionsCredentialToken property 'dds.perm.cert' does not have a value");
+    CU_FAIL("PermissionsCredentialToken property '" DDS_ACTOKEN_PROP_PERM_CERT "' does not have a value");
     return false;
   }
   if (strcmp(property->value, permissions) != 0)
   {
-    CU_FAIL("PermissionsCredentialToken property 'dds.perm.cert' content does not match the permissions file");
+    CU_FAIL("PermissionsCredentialToken property '" DDS_ACTOKEN_PROP_PERM_CERT "' content does not match the permissions file");
     return false;
   }
 

--- a/src/security/builtin_plugins/tests/get_permissions_credential_token/src/get_permissions_credential_token_utests.c
+++ b/src/security/builtin_plugins/tests/get_permissions_credential_token/src/get_permissions_credential_token_utests.c
@@ -24,16 +24,10 @@
 #include "CUnit/Test.h"
 #include "common/src/loader.h"
 #include "config_env.h"
+#include "ac_tokens.h"
 
 static const char *PERMISSIONS_FILE_NAME = "Test_Permissions_ok.p7s";
 static const char *GOVERNANCE_FILE_NAME = "Test_Governance_ok.p7s";
-
-static const char *PROPERTY_IDENTITY_CA = "dds.sec.auth.identity_ca";
-static const char *PROPERTY_PRIVATE_KEY = "dds.sec.auth.private_key";
-static const char *PROPERTY_IDENTITY_CERT = "dds.sec.auth.identity_certificate";
-static const char *PROPERTY_PERMISSIONS_CA = "dds.sec.access.permissions_ca";
-static const char *PROPERTY_PERMISSIONS = "dds.sec.access.permissions";
-static const char *PROPERTY_GOVERNANCE = "dds.sec.access.governance";
 
 static const char *RELATIVE_PATH_TO_ETC_DIR = "/get_permissions_credential_token/etc/";
 
@@ -220,17 +214,17 @@ static void fill_participant_qos(DDS_Security_Qos *qos, const char *permission_f
 
   memset(qos, 0, sizeof(*qos));
   dds_security_property_init(&qos->property.value, 6);
-  qos->property.value._buffer[0].name = ddsrt_strdup(PROPERTY_IDENTITY_CERT);
+  qos->property.value._buffer[0].name = ddsrt_strdup(DDS_SEC_PROP_AUTH_IDENTITY_CERT);
   qos->property.value._buffer[0].value = ddsrt_strdup(IDENTITY_CERTIFICATE);
-  qos->property.value._buffer[1].name = ddsrt_strdup(PROPERTY_IDENTITY_CA);
+  qos->property.value._buffer[1].name = ddsrt_strdup(DDS_SEC_PROP_AUTH_IDENTITY_CA);
   qos->property.value._buffer[1].value = ddsrt_strdup(IDENTITY_CA);
-  qos->property.value._buffer[2].name = ddsrt_strdup(PROPERTY_PRIVATE_KEY);
+  qos->property.value._buffer[2].name = ddsrt_strdup(DDS_SEC_PROP_AUTH_PRIV_KEY);
   qos->property.value._buffer[2].value = ddsrt_strdup(PRIVATE_KEY);
-  qos->property.value._buffer[3].name = ddsrt_strdup(PROPERTY_PERMISSIONS_CA);
+  qos->property.value._buffer[3].name = ddsrt_strdup(DDS_SEC_PROP_ACCESS_PERMISSIONS_CA);
   qos->property.value._buffer[3].value = ddsrt_strdup(PERMISSIONS_CA);
-  qos->property.value._buffer[4].name = ddsrt_strdup(PROPERTY_PERMISSIONS);
+  qos->property.value._buffer[4].name = ddsrt_strdup(DDS_SEC_PROP_ACCESS_PERMISSIONS);
   qos->property.value._buffer[4].value = ddsrt_strdup(permission_uri);
-  qos->property.value._buffer[5].name = ddsrt_strdup(PROPERTY_GOVERNANCE);
+  qos->property.value._buffer[5].name = ddsrt_strdup(DDS_SEC_PROP_ACCESS_GOVERNANCE);
   qos->property.value._buffer[5].value = ddsrt_strdup(governance_uri);
 
   ddsrt_free(permission_uri);
@@ -348,13 +342,13 @@ static bool validate_permissions_token(DDS_Security_PermissionsCredentialToken *
 {
   DDS_Security_Property_t *property;
 
-  if (!token->class_id || strcmp(token->class_id, "DDS:Access:PermissionsCredential") != 0)
+  if (!token->class_id || strcmp(token->class_id, DDS_ACTOKEN_PERMISSIONS_CREDENTIAL_CLASS_ID) != 0)
   {
     CU_FAIL("PermissionsCredentialToken incorrect class_id");
     return false;
   }
 
-  property = find_property(token, "dds.perm.cert");
+  property = find_property(token, DDS_ACTOKEN_PROP_PERM_CERT);
   if (property == NULL)
   {
     CU_FAIL("PermissionsCredentialToken property 'dds.perm.cert' not found");

--- a/src/security/builtin_plugins/tests/get_permissions_token/src/get_permissions_token_utests.c
+++ b/src/security/builtin_plugins/tests/get_permissions_token/src/get_permissions_token_utests.c
@@ -23,13 +23,7 @@
 #include "CUnit/Test.h"
 #include "common/src/loader.h"
 #include "config_env.h"
-
-static const char *PROPERTY_IDENTITY_CA = "dds.sec.auth.identity_ca";
-static const char *PROPERTY_PRIVATE_KEY = "dds.sec.auth.private_key";
-static const char *PROPERTY_IDENTITY_CERT = "dds.sec.auth.identity_certificate";
-static const char *PROPERTY_PERMISSIONS_CA = "dds.sec.access.permissions_ca";
-static const char *PROPERTY_PERMISSIONS = "dds.sec.access.permissions";
-static const char *PROPERTY_GOVERNANCE = "dds.sec.access.governance";
+#include "ac_tokens.h"
 
 static const char *RELATIVE_PATH_TO_ETC_DIR = "/get_permissions_token/etc/";
 
@@ -197,17 +191,17 @@ static void fill_participant_qos(DDS_Security_Qos *qos, const char *permission_f
 
   memset(qos, 0, sizeof(*qos));
   dds_security_property_init(&qos->property.value, 6);
-  qos->property.value._buffer[0].name = ddsrt_strdup(PROPERTY_IDENTITY_CERT);
+  qos->property.value._buffer[0].name = ddsrt_strdup(DDS_SEC_PROP_AUTH_IDENTITY_CERT);
   qos->property.value._buffer[0].value = ddsrt_strdup(IDENTITY_CERTIFICATE);
-  qos->property.value._buffer[1].name = ddsrt_strdup(PROPERTY_IDENTITY_CA);
+  qos->property.value._buffer[1].name = ddsrt_strdup(DDS_SEC_PROP_AUTH_IDENTITY_CA);
   qos->property.value._buffer[1].value = ddsrt_strdup(IDENTITY_CA);
-  qos->property.value._buffer[2].name = ddsrt_strdup(PROPERTY_PRIVATE_KEY);
+  qos->property.value._buffer[2].name = ddsrt_strdup(DDS_SEC_PROP_AUTH_PRIV_KEY);
   qos->property.value._buffer[2].value = ddsrt_strdup(PRIVATE_KEY);
-  qos->property.value._buffer[3].name = ddsrt_strdup(PROPERTY_PERMISSIONS_CA);
+  qos->property.value._buffer[3].name = ddsrt_strdup(DDS_SEC_PROP_ACCESS_PERMISSIONS_CA);
   qos->property.value._buffer[3].value = ddsrt_strdup(PERMISSIONS_CA);
-  qos->property.value._buffer[4].name = ddsrt_strdup(PROPERTY_PERMISSIONS);
+  qos->property.value._buffer[4].name = ddsrt_strdup(DDS_SEC_PROP_ACCESS_PERMISSIONS);
   qos->property.value._buffer[4].value = ddsrt_strdup(permission_uri);
-  qos->property.value._buffer[5].name = ddsrt_strdup(PROPERTY_GOVERNANCE);
+  qos->property.value._buffer[5].name = ddsrt_strdup(DDS_SEC_PROP_ACCESS_GOVERNANCE);
   qos->property.value._buffer[5].value = ddsrt_strdup(governance_uri);
 
   ddsrt_free(permission_uri);
@@ -303,17 +297,17 @@ static void suite_get_permissions_token_fini(void)
 static bool validate_permissions_token(
     DDS_Security_PermissionsToken *token)
 {
-  if (!token->class_id || strcmp(token->class_id, "DDS:Access:Permissions:1.0") != 0)
+  if (!token->class_id || strcmp(token->class_id, DDS_ACTOKEN_PERMISSIONS_CLASS_ID) != 0)
   {
     CU_FAIL("PermissionsToken incorrect class_id");
     return false;
   }
 
   /* Optional. */
-  if (find_property(token, "dds.perm_ca.sn") == NULL)
-    printf("Optional PermissionsToken property 'dds.perm_ca.sn' not found\n");
-  if (find_property(token, "dds.perm_ca.algo") == NULL)
-    printf("Optional PermissionsToken property 'dds.perm_ca.algo' not found\n");
+  if (find_property(token, DDS_ACTOKEN_PROP_PERM_CA_SN) == NULL)
+    printf("Optional PermissionsToken property '" DDS_ACTOKEN_PROP_PERM_CA_SN "' not found\n");
+  if (find_property(token, DDS_ACTOKEN_PROP_PERM_CA_ALGO) == NULL)
+    printf("Optional PermissionsToken property '" DDS_ACTOKEN_PROP_PERM_CA_ALGO "' not found\n");
   return true;
 }
 

--- a/src/security/builtin_plugins/tests/get_xxx_sec_attributes/src/get_xxx_sec_attributes_utests.c
+++ b/src/security/builtin_plugins/tests/get_xxx_sec_attributes/src/get_xxx_sec_attributes_utests.c
@@ -30,13 +30,6 @@
 
 static const char *RELATIVE_PATH_TO_ETC_DIR = "/get_xxx_sec_attributes/etc/";
 
-static const char *PROPERTY_IDENTITY_CA = "dds.sec.auth.identity_ca";
-static const char *PROPERTY_PRIVATE_KEY = "dds.sec.auth.private_key";
-static const char *PROPERTY_IDENTITY_CERT = "dds.sec.auth.identity_certificate";
-static const char *PROPERTY_PERMISSIONS_CA = "dds.sec.access.permissions_ca";
-static const char *PROPERTY_PERMISSIONS = "dds.sec.access.permissions";
-static const char *PROPERTY_GOVERNANCE = "dds.sec.access.governance";
-
 static const char *IDENTITY_CERTIFICATE =
     "data:,-----BEGIN CERTIFICATE-----\n"
     "MIIEQTCCAymgAwIBAgIINpuaAAnrQZIwDQYJKoZIhvcNAQELBQAwXzELMAkGA1UE\n"
@@ -219,17 +212,17 @@ static void fill_participant_qos(DDS_Security_Qos *qos, const char *permission_f
 
   memset(qos, 0, sizeof(*qos));
   dds_security_property_init(&qos->property.value, 6);
-  qos->property.value._buffer[0].name = ddsrt_strdup(PROPERTY_IDENTITY_CERT);
+  qos->property.value._buffer[0].name = ddsrt_strdup(DDS_SEC_PROP_AUTH_IDENTITY_CERT);
   qos->property.value._buffer[0].value = ddsrt_strdup(IDENTITY_CERTIFICATE);
-  qos->property.value._buffer[1].name = ddsrt_strdup(PROPERTY_IDENTITY_CA);
+  qos->property.value._buffer[1].name = ddsrt_strdup(DDS_SEC_PROP_AUTH_IDENTITY_CA);
   qos->property.value._buffer[1].value = ddsrt_strdup(IDENTITY_CA);
-  qos->property.value._buffer[2].name = ddsrt_strdup(PROPERTY_PRIVATE_KEY);
+  qos->property.value._buffer[2].name = ddsrt_strdup(DDS_SEC_PROP_AUTH_PRIV_KEY);
   qos->property.value._buffer[2].value = ddsrt_strdup(PRIVATE_KEY);
-  qos->property.value._buffer[3].name = ddsrt_strdup(PROPERTY_PERMISSIONS_CA);
+  qos->property.value._buffer[3].name = ddsrt_strdup(DDS_SEC_PROP_ACCESS_PERMISSIONS_CA);
   qos->property.value._buffer[3].value = ddsrt_strdup(PERMISSIONS_CA);
-  qos->property.value._buffer[4].name = ddsrt_strdup(PROPERTY_PERMISSIONS);
+  qos->property.value._buffer[4].name = ddsrt_strdup(DDS_SEC_PROP_ACCESS_PERMISSIONS);
   qos->property.value._buffer[4].value = ddsrt_strdup(permission_uri);
-  qos->property.value._buffer[5].name = ddsrt_strdup(PROPERTY_GOVERNANCE);
+  qos->property.value._buffer[5].name = ddsrt_strdup(DDS_SEC_PROP_ACCESS_GOVERNANCE);
   qos->property.value._buffer[5].value = ddsrt_strdup(governance_uri);
 
   ddsrt_free(permission_uri);

--- a/src/security/builtin_plugins/tests/listeners_access_control/src/listeners_access_control_utests.c
+++ b/src/security/builtin_plugins/tests/listeners_access_control/src/listeners_access_control_utests.c
@@ -27,21 +27,8 @@
 #include "CUnit/Test.h"
 #include "common/src/loader.h"
 #include "config_env.h"
-
-static const char *ACCESS_PERMISSIONS_TOKEN_ID = "DDS:Access:Permissions:1.0";
-static const char *AUTH_PROTOCOL_CLASS_ID = "DDS:Auth:PKI-DH:1.0";
-
-static const char *PROPERTY_IDENTITY_CA = "dds.sec.auth.identity_ca";
-static const char *PROPERTY_PRIVATE_KEY = "dds.sec.auth.private_key";
-static const char *PROPERTY_IDENTITY_CERT = "dds.sec.auth.identity_certificate";
-static const char *PROPERTY_PERMISSIONS_CA = "dds.sec.access.permissions_ca";
-static const char *PROPERTY_PERMISSIONS = "dds.sec.access.permissions";
-static const char *PROPERTY_GOVERNANCE = "dds.sec.access.governance";
-
-static const char *PROPERTY_PERMISSIONS_CA_SN = "dds.perm_ca.sn";
-static const char *PROPERTY_PERMISSIONS_CA_ALGO = "dds.perm_ca.algo";
-static const char *PROPERTY_C_ID = "c.id";
-static const char *PROPERTY_C_PERM = "c.perm";
+#include "auth_tokens.h"
+#include "ac_tokens.h"
 
 static const char *SUBJECT_NAME_PERMISSIONS_CA = "C=NL, ST=Some-State, O=ADLINK Technolocy Inc., CN=adlinktech.com";
 static const char *RSA_2048_ALGORITHM_NAME = "RSA-2048";
@@ -348,17 +335,17 @@ static void fill_participant_qos(DDS_Security_Qos *qos, int32_t permission_expir
 
   memset(qos, 0, sizeof(*qos));
   dds_security_property_init(&qos->property.value, 6);
-  qos->property.value._buffer[0].name = ddsrt_strdup(PROPERTY_IDENTITY_CERT);
+  qos->property.value._buffer[0].name = ddsrt_strdup(DDS_SEC_PROP_AUTH_IDENTITY_CERT);
   qos->property.value._buffer[0].value = ddsrt_strdup(identity_certificate);
-  qos->property.value._buffer[1].name = ddsrt_strdup(PROPERTY_IDENTITY_CA);
+  qos->property.value._buffer[1].name = ddsrt_strdup(DDS_SEC_PROP_AUTH_IDENTITY_CA);
   qos->property.value._buffer[1].value = ddsrt_strdup(identity_ca);
-  qos->property.value._buffer[2].name = ddsrt_strdup(PROPERTY_PRIVATE_KEY);
+  qos->property.value._buffer[2].name = ddsrt_strdup(DDS_SEC_PROP_AUTH_PRIV_KEY);
   qos->property.value._buffer[2].value = ddsrt_strdup(private_key);
-  qos->property.value._buffer[3].name = ddsrt_strdup(PROPERTY_PERMISSIONS_CA);
+  qos->property.value._buffer[3].name = ddsrt_strdup(DDS_SEC_PROP_ACCESS_PERMISSIONS_CA);
   qos->property.value._buffer[3].value = ddsrt_strdup(permissions_ca);
-  qos->property.value._buffer[4].name = ddsrt_strdup(PROPERTY_PERMISSIONS);
+  qos->property.value._buffer[4].name = ddsrt_strdup(DDS_SEC_PROP_ACCESS_PERMISSIONS);
   qos->property.value._buffer[4].value = ddsrt_strdup(permission_uri);
-  qos->property.value._buffer[5].name = ddsrt_strdup(PROPERTY_GOVERNANCE);
+  qos->property.value._buffer[5].name = ddsrt_strdup(DDS_SEC_PROP_ACCESS_GOVERNANCE);
   qos->property.value._buffer[5].value = ddsrt_strdup(governance_uri);
 
   ddsrt_free(permission_uri);
@@ -373,14 +360,14 @@ static void fill_permissions_token(DDS_Security_PermissionsToken *token)
 {
   memset(token, 0, sizeof(DDS_Security_PermissionsToken));
 
-  token->class_id = ddsrt_strdup(ACCESS_PERMISSIONS_TOKEN_ID);
+  token->class_id = ddsrt_strdup(DDS_ACTOKEN_PERMISSIONS_CLASS_ID);
   token->properties._length = token->properties._maximum = 2;
   token->properties._buffer = DDS_Security_PropertySeq_allocbuf(2);
 
-  token->properties._buffer[0].name = ddsrt_strdup(PROPERTY_PERMISSIONS_CA_SN);
+  token->properties._buffer[0].name = ddsrt_strdup(DDS_ACTOKEN_PROP_PERM_CA_SN);
   token->properties._buffer[0].value = ddsrt_strdup(SUBJECT_NAME_PERMISSIONS_CA);
 
-  token->properties._buffer[1].name = ddsrt_strdup(PROPERTY_PERMISSIONS_CA_ALGO);
+  token->properties._buffer[1].name = ddsrt_strdup(DDS_ACTOKEN_PROP_PERM_CA_ALGO);
   token->properties._buffer[1].value = ddsrt_strdup(RSA_2048_ALGORITHM_NAME);
 }
 
@@ -412,14 +399,14 @@ static int fill_peer_credential_token(DDS_Security_AuthenticatedPeerCredentialTo
 
   if (permission_data)
   {
-    token->class_id = ddsrt_strdup(AUTH_PROTOCOL_CLASS_ID);
+    token->class_id = ddsrt_strdup(DDS_AUTHTOKEN_CLASS_ID);
     token->properties._length = token->properties._maximum = 2;
     token->properties._buffer = DDS_Security_PropertySeq_allocbuf(2);
 
-    token->properties._buffer[0].name = ddsrt_strdup(PROPERTY_C_ID);
+    token->properties._buffer[0].name = ddsrt_strdup(DDS_AUTHTOKEN_PROP_C_ID);
     token->properties._buffer[0].value = ddsrt_strdup(&identity_certificate[6]);
 
-    token->properties._buffer[1].name = ddsrt_strdup(PROPERTY_C_PERM);
+    token->properties._buffer[1].name = ddsrt_strdup(DDS_AUTHTOKEN_PROP_C_PERM);
     token->properties._buffer[1].value = permission_data;
   }
   else

--- a/src/security/builtin_plugins/tests/preprocess_secure_submsg/src/preprocess_secure_submsg_utests.c
+++ b/src/security/builtin_plugins/tests/preprocess_secure_submsg/src/preprocess_secure_submsg_utests.c
@@ -758,7 +758,7 @@ CU_Test(ddssec_builtin_preprocess_secure_submsg, volatile_secure, .init = suite_
 
     datareader_properties._length = datareader_properties._maximum = 1;
     datareader_properties._buffer = DDS_Security_PropertySeq_allocbuf(1);
-    datareader_properties._buffer[0].name = ddsrt_strdup("dds.sec.builtin_endpoint_name");
+    datareader_properties._buffer[0].name = ddsrt_strdup(DDS_SEC_PROP_BUILTIN_ENDPOINT_NAME);
     datareader_properties._buffer[0].value = ddsrt_strdup("BuiltinParticipantVolatileMessageSecureReader");
     datareader_properties._buffer[0].propagate = false;
 
@@ -767,7 +767,7 @@ CU_Test(ddssec_builtin_preprocess_secure_submsg, volatile_secure, .init = suite_
 
     datawriter_properties._length = datawriter_properties._maximum = 1;
     datawriter_properties._buffer = DDS_Security_PropertySeq_allocbuf(1);
-    datawriter_properties._buffer[0].name = ddsrt_strdup("dds.sec.builtin_endpoint_name");
+    datawriter_properties._buffer[0].name = ddsrt_strdup(DDS_SEC_PROP_BUILTIN_ENDPOINT_NAME);
     datawriter_properties._buffer[0].value = ddsrt_strdup("BuiltinParticipantVolatileMessageSecureWriter");
     datawriter_properties._buffer[0].propagate = false;
 

--- a/src/security/builtin_plugins/tests/register_local_datareader/src/register_local_datareader_utests.c
+++ b/src/security/builtin_plugins/tests/register_local_datareader/src/register_local_datareader_utests.c
@@ -214,7 +214,7 @@ CU_Test(ddssec_builtin_register_local_datareader, builtin_endpoint, .init = suit
   datareader_properties._buffer = DDS_Security_PropertySeq_allocbuf(1);
   datareader_properties._length = datareader_properties._maximum = 1;
 
-  datareader_properties._buffer[0].name = ddsrt_strdup("dds.sec.builtin_endpoint_name");
+  datareader_properties._buffer[0].name = ddsrt_strdup(DDS_SEC_PROP_BUILTIN_ENDPOINT_NAME);
   datareader_properties._buffer[0].value = ddsrt_strdup("BuiltinSecureEndpointName");
 
   prepare_endpoint_security_attributes(&datareader_security_attributes);
@@ -268,7 +268,7 @@ CU_Test(ddssec_builtin_register_local_datareader, special_endpoint_name, .init =
   /*set special endpoint name*/
   datareader_properties._buffer = DDS_Security_PropertySeq_allocbuf(1);
   datareader_properties._length = datareader_properties._maximum = 1;
-  datareader_properties._buffer[0].name = ddsrt_strdup("dds.sec.builtin_endpoint_name");
+  datareader_properties._buffer[0].name = ddsrt_strdup(DDS_SEC_PROP_BUILTIN_ENDPOINT_NAME);
   datareader_properties._buffer[0].value = ddsrt_strdup("BuiltinParticipantVolatileMessageSecureReader");
 
   prepare_endpoint_security_attributes(&datareader_security_attributes);

--- a/src/security/builtin_plugins/tests/register_local_datawriter/src/register_local_datawriter_utests.c
+++ b/src/security/builtin_plugins/tests/register_local_datawriter/src/register_local_datawriter_utests.c
@@ -229,7 +229,7 @@ CU_Test(ddssec_builtin_register_local_datawriter, builtin_endpoint, .init = suit
 
   datawriter_properties._buffer = DDS_Security_PropertySeq_allocbuf(1);
   datawriter_properties._length = datawriter_properties._maximum = 1;
-  datawriter_properties._buffer[0].name = ddsrt_strdup("dds.sec.builtin_endpoint_name");
+  datawriter_properties._buffer[0].name = ddsrt_strdup(DDS_SEC_PROP_BUILTIN_ENDPOINT_NAME);
   datawriter_properties._buffer[0].value = ddsrt_strdup("BuiltinSecureEndpointName");
 
   /* Now call the function. */
@@ -292,7 +292,7 @@ CU_Test(ddssec_builtin_register_local_datawriter, special_endpoint_name, .init =
   /*set special endpoint name*/
   datawriter_properties._buffer = DDS_Security_PropertySeq_allocbuf(1);
   datawriter_properties._length = datawriter_properties._maximum = 1;
-  datawriter_properties._buffer[0].name = ddsrt_strdup("dds.sec.builtin_endpoint_name");
+  datawriter_properties._buffer[0].name = ddsrt_strdup(DDS_SEC_PROP_BUILTIN_ENDPOINT_NAME);
   datawriter_properties._buffer[0].value = ddsrt_strdup("BuiltinParticipantVolatileMessageSecureWriter");
 
   /* Now call the function. */

--- a/src/security/builtin_plugins/tests/register_matched_remote_datareader/src/register_matched_remote_datareader_utests.c
+++ b/src/security/builtin_plugins/tests/register_matched_remote_datareader/src/register_matched_remote_datareader_utests.c
@@ -239,7 +239,7 @@ CU_Test(ddssec_builtin_register_remote_datareader, volatile_secure, .init = suit
 
   datawriter_properties._length = datawriter_properties._maximum = 1;
   datawriter_properties._buffer = DDS_Security_PropertySeq_allocbuf(1);
-  datawriter_properties._buffer[0].name = ddsrt_strdup("dds.sec.builtin_endpoint_name");
+  datawriter_properties._buffer[0].name = ddsrt_strdup(DDS_SEC_PROP_BUILTIN_ENDPOINT_NAME);
   datawriter_properties._buffer[0].value = ddsrt_strdup("BuiltinParticipantVolatileMessageSecureWriter");
   datawriter_properties._buffer[0].propagate = false;
 

--- a/src/security/builtin_plugins/tests/register_matched_remote_datawriter/src/register_matched_remote_datawriter_utests.c
+++ b/src/security/builtin_plugins/tests/register_matched_remote_datawriter/src/register_matched_remote_datawriter_utests.c
@@ -229,7 +229,7 @@ CU_Test(ddssec_builtin_register_remote_datawriter, volatile_secure, .init = suit
 
   datareader_properties._length = datareader_properties._maximum = 1;
   datareader_properties._buffer = DDS_Security_PropertySeq_allocbuf(1);
-  datareader_properties._buffer[0].name = ddsrt_strdup("dds.sec.builtin_endpoint_name");
+  datareader_properties._buffer[0].name = ddsrt_strdup(DDS_SEC_PROP_BUILTIN_ENDPOINT_NAME);
   datareader_properties._buffer[0].value = ddsrt_strdup("BuiltinParticipantVolatileMessageSecureReader");
   datareader_properties._buffer[0].propagate = false;
   memset(&datareader_security_attributes, 0, sizeof(datareader_security_attributes));

--- a/src/security/builtin_plugins/tests/set_remote_datareader_crypto_tokens/src/set_remote_datareader_crypto_tokens_utests.c
+++ b/src/security/builtin_plugins/tests/set_remote_datareader_crypto_tokens/src/set_remote_datareader_crypto_tokens_utests.c
@@ -22,13 +22,11 @@
 #include "CUnit/Test.h"
 #include "common/src/loader.h"
 #include "crypto_objects.h"
+#include "crypto_tokens.h"
 
 #define TEST_SHARED_SECRET_SIZE 32
 #define CRYPTO_TRANSFORM_KIND(k) (*(uint32_t *)&((k)[0]))
 #define CRYPTO_TRANSFORM_ID(k) (*(uint32_t *)&((k)[0]))
-
-static const char *CRYPTO_TOKEN_CLASS_ID = "DDS:Crypto:AES_GCM_GMAC";
-static const char *CRYPTO_TOKEN_PROPERTY_NAME = "dds.cryp.keymat";
 
 static struct plugins_hdl *plugins = NULL;
 static dds_security_cryptography *crypto = NULL;
@@ -311,11 +309,11 @@ static void create_reader_tokens(DDS_Security_DatawriterCryptoTokenSeq *tokens)
 {
   tokens->_length = tokens->_maximum = 1;
   tokens->_buffer = DDS_Security_DataHolderSeq_allocbuf(1);
-  tokens->_buffer[0].class_id = ddsrt_strdup(CRYPTO_TOKEN_CLASS_ID);
+  tokens->_buffer[0].class_id = ddsrt_strdup(DDS_CRYPTOTOKEN_CLASS_ID);
   tokens->_buffer[0].binary_properties._length = 1;
   tokens->_buffer[0].binary_properties._maximum = 1;
   tokens->_buffer[0].binary_properties._buffer = DDS_Security_BinaryPropertySeq_allocbuf(1);
-  tokens->_buffer[0].binary_properties._buffer[0].name = ddsrt_strdup(CRYPTO_TOKEN_PROPERTY_NAME);
+  tokens->_buffer[0].binary_properties._buffer[0].name = ddsrt_strdup(DDS_CRYPTOTOKEN_PROP_KEYMAT);
   create_key_material(&tokens->_buffer[0].binary_properties._buffer[0].value, false);
 }
 
@@ -323,11 +321,11 @@ static void create_reader_tokens_no_key_material(DDS_Security_DatawriterCryptoTo
 {
   tokens->_length = tokens->_maximum = 1;
   tokens->_buffer = DDS_Security_DataHolderSeq_allocbuf(1);
-  tokens->_buffer[0].class_id = ddsrt_strdup(CRYPTO_TOKEN_CLASS_ID);
+  tokens->_buffer[0].class_id = ddsrt_strdup(DDS_CRYPTOTOKEN_CLASS_ID);
   tokens->_buffer[0].binary_properties._length = 1;
   tokens->_buffer[0].binary_properties._maximum = 1;
   tokens->_buffer[0].binary_properties._buffer = DDS_Security_BinaryPropertySeq_allocbuf(1);
-  tokens->_buffer[0].binary_properties._buffer[0].name = ddsrt_strdup(CRYPTO_TOKEN_PROPERTY_NAME);
+  tokens->_buffer[0].binary_properties._buffer[0].name = ddsrt_strdup(DDS_CRYPTOTOKEN_PROP_KEYMAT);
 }
 
 static void serialize_key_material(DDS_Security_OctetSeq *seq, DDS_Security_KeyMaterial_AES_GCM_GMAC *keymat)
@@ -595,7 +593,7 @@ CU_Test(ddssec_builtin_set_remote_datareader_crypto_tokens, invalid_tokens, .ini
     CU_ASSERT(exception.message != NULL);
     reset_exception(&exception);
     ddsrt_free(tokens._buffer[0].class_id);
-    tokens._buffer[0].class_id = ddsrt_strdup(CRYPTO_TOKEN_CLASS_ID);
+    tokens._buffer[0].class_id = ddsrt_strdup(DDS_CRYPTOTOKEN_CLASS_ID);
   }
 
   /* no key material, binary_property missing */
@@ -661,7 +659,7 @@ CU_Test(ddssec_builtin_set_remote_datareader_crypto_tokens, invalid_tokens, .ini
     CU_ASSERT(exception.message != NULL);
     reset_exception(&exception);
     ddsrt_free(tokens._buffer[0].binary_properties._buffer[0].name);
-    tokens._buffer[0].binary_properties._buffer[0].name = ddsrt_strdup(CRYPTO_TOKEN_PROPERTY_NAME);
+    tokens._buffer[0].binary_properties._buffer[0].name = ddsrt_strdup(DDS_CRYPTOTOKEN_PROP_KEYMAT);
   }
 
   DDS_Security_DataHolderSeq_deinit(&tokens);

--- a/src/security/builtin_plugins/tests/set_remote_datawriter_crypto_tokens/src/set_remote_datawriter_crypto_tokens_utests.c
+++ b/src/security/builtin_plugins/tests/set_remote_datawriter_crypto_tokens/src/set_remote_datawriter_crypto_tokens_utests.c
@@ -22,13 +22,11 @@
 #include "CUnit/Test.h"
 #include "common/src/loader.h"
 #include "crypto_objects.h"
+#include "crypto_tokens.h"
 
 #define TEST_SHARED_SECRET_SIZE 32
 #define CRYPTO_TRANSFORM_KIND(k) (*(uint32_t *)&((k)[0]))
 #define CRYPTO_TRANSFORM_ID(k) (*(uint32_t *)&((k)[0]))
-
-static const char *CRYPTO_TOKEN_CLASS_ID = "DDS:Crypto:AES_GCM_GMAC";
-static const char *CRYPTO_TOKEN_PROPERTY_NAME = "dds.cryp.keymat";
 
 static struct plugins_hdl *plugins = NULL;
 static dds_security_cryptography *crypto = NULL;
@@ -301,11 +299,11 @@ static void create_writer_tokens(DDS_Security_DatawriterCryptoTokenSeq *tokens, 
   tokens->_buffer = DDS_Security_DataHolderSeq_allocbuf(num);
   for (uint32_t i = 0; i < num; i++)
   {
-    tokens->_buffer[i].class_id = ddsrt_strdup(CRYPTO_TOKEN_CLASS_ID);
+    tokens->_buffer[i].class_id = ddsrt_strdup(DDS_CRYPTOTOKEN_CLASS_ID);
     tokens->_buffer[i].binary_properties._length = 1;
     tokens->_buffer[i].binary_properties._maximum = 1;
     tokens->_buffer[i].binary_properties._buffer = DDS_Security_BinaryPropertySeq_allocbuf(1);
-    tokens->_buffer[i].binary_properties._buffer[0].name = ddsrt_strdup(CRYPTO_TOKEN_PROPERTY_NAME);
+    tokens->_buffer[i].binary_properties._buffer[0].name = ddsrt_strdup(DDS_CRYPTOTOKEN_PROP_KEYMAT);
     create_key_material(&tokens->_buffer[i].binary_properties._buffer[0].value, false);
   }
 }
@@ -316,11 +314,11 @@ static void create_writer_tokens_no_key_material(DDS_Security_DatawriterCryptoTo
   tokens->_buffer = DDS_Security_DataHolderSeq_allocbuf(num);
   for (uint32_t i = 0; i < num; i++)
   {
-    tokens->_buffer[i].class_id = ddsrt_strdup(CRYPTO_TOKEN_CLASS_ID);
+    tokens->_buffer[i].class_id = ddsrt_strdup(DDS_CRYPTOTOKEN_CLASS_ID);
     tokens->_buffer[i].binary_properties._length = 1;
     tokens->_buffer[i].binary_properties._maximum = 1;
     tokens->_buffer[i].binary_properties._buffer = DDS_Security_BinaryPropertySeq_allocbuf(1);
-    tokens->_buffer[i].binary_properties._buffer[0].name = ddsrt_strdup(CRYPTO_TOKEN_PROPERTY_NAME);
+    tokens->_buffer[i].binary_properties._buffer[0].name = ddsrt_strdup(DDS_CRYPTOTOKEN_PROP_KEYMAT);
   }
 }
 
@@ -585,7 +583,7 @@ CU_Test(ddssec_builtin_set_remote_datawriter_crypto_tokens, invalid_tokens, .ini
   /* invalid token class id */
   {
     ddsrt_free(tokens._buffer[0].class_id);
-    tokens._buffer[0].class_id = ddsrt_strdup(CRYPTO_TOKEN_CLASS_ID);
+    tokens._buffer[0].class_id = ddsrt_strdup(DDS_CRYPTOTOKEN_CLASS_ID);
     ddsrt_free(tokens._buffer[1].class_id);
     tokens._buffer[1].class_id = ddsrt_strdup("invalid class");
     result = crypto->crypto_key_exchange->set_remote_datawriter_crypto_tokens(
@@ -603,7 +601,7 @@ CU_Test(ddssec_builtin_set_remote_datawriter_crypto_tokens, invalid_tokens, .ini
     CU_ASSERT(exception.message != NULL);
     reset_exception(&exception);
     ddsrt_free(tokens._buffer[1].class_id);
-    tokens._buffer[1].class_id = ddsrt_strdup(CRYPTO_TOKEN_CLASS_ID);
+    tokens._buffer[1].class_id = ddsrt_strdup(DDS_CRYPTOTOKEN_CLASS_ID);
   }
 
   /* no key material, binary_property missing */
@@ -689,7 +687,7 @@ CU_Test(ddssec_builtin_set_remote_datawriter_crypto_tokens, invalid_tokens, .ini
     CU_ASSERT(exception.message != NULL);
     reset_exception(&exception);
     ddsrt_free(tokens._buffer[0].binary_properties._buffer[0].name);
-    tokens._buffer[0].binary_properties._buffer[0].name = ddsrt_strdup(CRYPTO_TOKEN_PROPERTY_NAME);
+    tokens._buffer[0].binary_properties._buffer[0].name = ddsrt_strdup(DDS_CRYPTOTOKEN_PROP_KEYMAT);
   }
 
   /* invalid property name */
@@ -712,7 +710,7 @@ CU_Test(ddssec_builtin_set_remote_datawriter_crypto_tokens, invalid_tokens, .ini
     CU_ASSERT(exception.message != NULL);
     reset_exception(&exception);
     ddsrt_free(tokens._buffer[1].binary_properties._buffer[0].name);
-    tokens._buffer[1].binary_properties._buffer[0].name = ddsrt_strdup(CRYPTO_TOKEN_PROPERTY_NAME);
+    tokens._buffer[1].binary_properties._buffer[0].name = ddsrt_strdup(DDS_CRYPTOTOKEN_PROP_KEYMAT);
   }
 
   DDS_Security_DataHolderSeq_deinit(&tokens);

--- a/src/security/builtin_plugins/tests/set_remote_participant_crypto_tokens/src/set_remote_participant_crypto_tokens_utests.c
+++ b/src/security/builtin_plugins/tests/set_remote_participant_crypto_tokens/src/set_remote_participant_crypto_tokens_utests.c
@@ -22,11 +22,9 @@
 #include "CUnit/Test.h"
 #include "common/src/loader.h"
 #include "crypto_objects.h"
+#include "crypto_tokens.h"
 
 #define TEST_SHARED_SECRET_SIZE 32
-
-static const char *CRYPTO_TOKEN_CLASS_ID = "DDS:Crypto:AES_GCM_GMA";
-static const char *CRYPTO_TOKEN_PROPERTY_NAME = "dds.cryp.keymat";
 
 static struct plugins_hdl *plugins = NULL;
 static dds_security_cryptography *crypto = NULL;
@@ -398,7 +396,7 @@ CU_Test(ddssec_builtin_set_remote_participant_crypto_tokens, invalid_tokens, .in
   reset_exception(&exception);
 
   /* no key material, binary_property missing */
-  invalid_tokens._buffer[0].class_id = ddsrt_strdup(CRYPTO_TOKEN_CLASS_ID);
+  invalid_tokens._buffer[0].class_id = ddsrt_strdup(DDS_CRYPTOTOKEN_CLASS_ID);
   result = crypto->crypto_key_exchange->set_remote_participant_crypto_tokens(
       crypto->crypto_key_exchange,
       local_crypto_handle,
@@ -448,7 +446,7 @@ CU_Test(ddssec_builtin_set_remote_participant_crypto_tokens, invalid_tokens, .in
   reset_exception(&exception);
 
   /* invalid property name */
-  invalid_tokens._buffer[0].binary_properties._buffer[0].name = ddsrt_strdup(CRYPTO_TOKEN_PROPERTY_NAME);
+  invalid_tokens._buffer[0].binary_properties._buffer[0].name = ddsrt_strdup(DDS_CRYPTOTOKEN_PROP_KEYMAT);
   result = crypto->crypto_key_exchange->set_remote_participant_crypto_tokens(
       crypto->crypto_key_exchange,
       local_crypto_handle,

--- a/src/security/builtin_plugins/tests/validate_local_identity/src/validate_local_identity_utests.c
+++ b/src/security/builtin_plugins/tests/validate_local_identity/src/validate_local_identity_utests.c
@@ -22,13 +22,6 @@
 #include <dds/ddsrt/string.h>
 #include <config_env.h>
 
-static const char * PROPERTY_IDENTITY_CA                = "dds.sec.auth.identity_ca";
-static const char * PROPERTY_PRIVATE_KEY                = "dds.sec.auth.private_key";
-static const char * PROPERTY_PASSWORD                   = "dds.sec.auth.password";
-static const char * PROPERTY_IDENTITY_CERT              = "dds.sec.auth.identity_certificate";
-static const char * PROPERTY_TRUSTED_CA_DIR             = "dds.sec.auth.trusted_ca_dir";
-static const char * PROPERTY_CRL                        = "org.eclipse.cyclonedds.sec.auth.crl";
-
 // See ../etc/README.md for how the certificates and keys are generated.
 
 static const char *identity_certificate_filename = "identity_certificate";
@@ -545,7 +538,7 @@ fill_participant_qos(
     dds_security_property_init(&participant_qos->property.value, size);
 
     valbuf = &participant_qos->property.value._buffer[offset++];
-    valbuf->name = ddsrt_strdup(PROPERTY_IDENTITY_CERT);
+    valbuf->name = ddsrt_strdup(DDS_SEC_PROP_AUTH_IDENTITY_CERT);
     if (is_file_certificate) {
 #ifdef WIN32
         snprintf(identity_cert_path, 1024, "file:%s\\validate_local_identity\\etc\\%s", CONFIG_ENV_TESTS_DIR, certificate);
@@ -559,7 +552,7 @@ fill_participant_qos(
     }
 
     valbuf = &participant_qos->property.value._buffer[offset++];
-    valbuf->name = ddsrt_strdup(PROPERTY_IDENTITY_CA);
+    valbuf->name = ddsrt_strdup(DDS_SEC_PROP_AUTH_IDENTITY_CA);
     if (is_file_ca) {
 #ifdef WIN32
         snprintf(identity_CA_path, 1024, "file:%s\\validate_local_identity\\etc\\%s", CONFIG_ENV_TESTS_DIR, ca);
@@ -573,7 +566,7 @@ fill_participant_qos(
     }
 
     valbuf = &participant_qos->property.value._buffer[offset++];
-    valbuf->name = ddsrt_strdup(PROPERTY_PRIVATE_KEY);
+    valbuf->name = ddsrt_strdup(DDS_SEC_PROP_AUTH_PRIV_KEY);
     if (is_file_private_key) {
 #ifdef WIN32
         snprintf(private_key_path, 1024, "file:%s\\validate_local_identity\\etc\\%s", CONFIG_ENV_TESTS_DIR, private_key_data);
@@ -588,13 +581,13 @@ fill_participant_qos(
 
     if (password) {
         valbuf = &participant_qos->property.value._buffer[offset++];
-        valbuf->name = ddsrt_strdup(PROPERTY_PASSWORD);
+        valbuf->name = ddsrt_strdup(DDS_SEC_PROP_AUTH_PASSWORD);
         valbuf->value = ddsrt_strdup(password);
     }
 
     if (crl_data) {
       valbuf = &participant_qos->property.value._buffer[offset++];
-      valbuf->name = ddsrt_strdup(PROPERTY_CRL);
+      valbuf->name = ddsrt_strdup(ORG_ECLIPSE_CYCLONEDDS_SEC_AUTH_CRL);
       if (is_file_crl) {
 #ifdef WIN32
           snprintf(crl_path, 1024, "file:%s\\validate_local_identity\\etc\\%s", CONFIG_ENV_TESTS_DIR, crl_data);
@@ -615,7 +608,7 @@ fill_participant_qos(
 #else
         snprintf(trusted_ca_dir_path, 1024, "%s/validate_local_identity/etc/%s", CONFIG_ENV_TESTS_DIR, trusted_ca_dir);
 #endif
-        valbuf->name = ddsrt_strdup(PROPERTY_TRUSTED_CA_DIR);
+        valbuf->name = ddsrt_strdup(DDS_SEC_PROP_ACCESS_TRUSTED_CA_DIR);
         valbuf->value = ddsrt_strdup(trusted_ca_dir_path);
     }
 }
@@ -1201,11 +1194,11 @@ CU_Test(ddssec_builtin_validate_local_identity,missing_certificate_property)
 
     memset(&participant_qos, 0, sizeof(participant_qos));
     dds_security_property_init(&participant_qos.property.value, 3);
-    participant_qos.property.value._buffer[0].name = ddsrt_strdup("dds.sec.auth.identity_cert");
+    participant_qos.property.value._buffer[0].name = ddsrt_strdup(DDS_SEC_PROP_PREFIX "auth.identity_cert"); // deliberately *not* DDS_SEC_PROP_AUTH_IDENTITY_CERT
     participant_qos.property.value._buffer[0].value = ddsrt_strdup(identity_certificate);
-    participant_qos.property.value._buffer[1].name = ddsrt_strdup(PROPERTY_IDENTITY_CA);
+    participant_qos.property.value._buffer[1].name = ddsrt_strdup(DDS_SEC_PROP_AUTH_IDENTITY_CA);
     participant_qos.property.value._buffer[1].value = ddsrt_strdup(identity_ca);
-    participant_qos.property.value._buffer[2].name = ddsrt_strdup(PROPERTY_PRIVATE_KEY);
+    participant_qos.property.value._buffer[2].name = ddsrt_strdup(DDS_SEC_PROP_AUTH_PRIV_KEY);
     participant_qos.property.value._buffer[2].value = ddsrt_strdup(private_key_1024);
 
     /* Now call the function. */
@@ -1227,7 +1220,7 @@ CU_Test(ddssec_builtin_validate_local_identity,missing_certificate_property)
     CU_ASSERT (exception.minor_code != 0);
     CU_ASSERT_FATAL (exception.message != NULL);
     assert(exception.message != NULL); // for Clang's static analyzer
-    CU_ASSERT(strcmp(exception.message, "validate_local_identity: missing property 'dds.sec.auth.identity_certificate'") == 0);
+    CU_ASSERT(strcmp(exception.message, "validate_local_identity: missing property '" DDS_SEC_PROP_AUTH_IDENTITY_CERT "'") == 0);
 
     dds_security_property_deinit(&participant_qos.property.value);
     reset_exception(&exception);
@@ -1260,11 +1253,11 @@ CU_Test(ddssec_builtin_validate_local_identity,missing_ca_property)
 
     memset(&participant_qos, 0, sizeof(participant_qos));
     dds_security_property_init(&participant_qos.property.value, 3);
-    participant_qos.property.value._buffer[0].name = ddsrt_strdup(PROPERTY_IDENTITY_CERT);
+    participant_qos.property.value._buffer[0].name = ddsrt_strdup(DDS_SEC_PROP_AUTH_IDENTITY_CERT);
     participant_qos.property.value._buffer[0].value = ddsrt_strdup(identity_certificate);
-    participant_qos.property.value._buffer[1].name = ddsrt_strdup("dds.sec.auth.identit_ca");
+    participant_qos.property.value._buffer[1].name = ddsrt_strdup(DDS_SEC_PROP_PREFIX "auth.identit_ca"); // deliberately *not* DDS_SEC_PROP_AUTH_IDENTITY_CA
     participant_qos.property.value._buffer[1].value = ddsrt_strdup(identity_ca);
-    participant_qos.property.value._buffer[2].name = ddsrt_strdup(PROPERTY_PRIVATE_KEY);
+    participant_qos.property.value._buffer[2].name = ddsrt_strdup(DDS_SEC_PROP_AUTH_PRIV_KEY);
     participant_qos.property.value._buffer[2].value = ddsrt_strdup(private_key_1024);
 
     /* Now call the function. */
@@ -1286,7 +1279,7 @@ CU_Test(ddssec_builtin_validate_local_identity,missing_ca_property)
     CU_ASSERT (exception.minor_code != 0);
     CU_ASSERT_FATAL (exception.message != NULL);
     assert(exception.message != NULL); // for Clang's static analyzer
-    CU_ASSERT(strcmp(exception.message, "validate_local_identity: missing property 'dds.sec.auth.identity_ca'") == 0);
+    CU_ASSERT(strcmp(exception.message, "validate_local_identity: missing property '" DDS_SEC_PROP_AUTH_IDENTITY_CA "'") == 0);
 
     dds_security_property_deinit(&participant_qos.property.value);
     reset_exception(&exception);
@@ -1316,9 +1309,9 @@ CU_Test(ddssec_builtin_validate_local_identity,missing_private_key_property)
 
     memset(&participant_qos, 0, sizeof(participant_qos));
     dds_security_property_init(&participant_qos.property.value, 2);
-    participant_qos.property.value._buffer[0].name = ddsrt_strdup(PROPERTY_IDENTITY_CERT);
+    participant_qos.property.value._buffer[0].name = ddsrt_strdup(DDS_SEC_PROP_AUTH_IDENTITY_CERT);
     participant_qos.property.value._buffer[0].value = ddsrt_strdup(identity_certificate);
-    participant_qos.property.value._buffer[1].name = ddsrt_strdup(PROPERTY_IDENTITY_CA);
+    participant_qos.property.value._buffer[1].name = ddsrt_strdup(DDS_SEC_PROP_AUTH_IDENTITY_CA);
     participant_qos.property.value._buffer[1].value = ddsrt_strdup(identity_ca);
 
     /* Now call the function. */
@@ -1340,7 +1333,7 @@ CU_Test(ddssec_builtin_validate_local_identity,missing_private_key_property)
     CU_ASSERT (exception.minor_code != 0);
     CU_ASSERT_FATAL (exception.message != NULL);
     assert(exception.message != NULL); // for Clang's static analyzer
-    CU_ASSERT(strcmp(exception.message, "validate_local_identity: missing property 'dds.sec.auth.private_key'") == 0);
+    CU_ASSERT(strcmp(exception.message, "validate_local_identity: missing property '" DDS_SEC_PROP_AUTH_PRIV_KEY "'") == 0);
 
     dds_security_property_deinit(&participant_qos.property.value);
     reset_exception(&exception);

--- a/src/security/builtin_plugins/tests/validate_local_permissions/src/validate_local_permissions_utests.c
+++ b/src/security/builtin_plugins/tests/validate_local_permissions/src/validate_local_permissions_utests.c
@@ -24,13 +24,6 @@
 #include "common/src/loader.h"
 #include "config_env.h"
 
-static const char *PROPERTY_IDENTITY_CA = "dds.sec.auth.identity_ca";
-static const char *PROPERTY_PRIVATE_KEY = "dds.sec.auth.private_key";
-static const char *PROPERTY_IDENTITY_CERT = "dds.sec.auth.identity_certificate";
-static const char *PROPERTY_PERMISSIONS_CA = "dds.sec.access.permissions_ca";
-static const char *PROPERTY_PERMISSIONS = "dds.sec.access.permissions";
-static const char *PROPERTY_GOVERNANCE = "dds.sec.access.governance";
-
 static const char *RELATIVE_PATH_TO_ETC_DIR = "/validate_local_permissions/etc/";
 
 static const char *AUTH_IDENTITY_CERT =
@@ -230,18 +223,18 @@ static void fill_property_policy(DDS_Security_PropertyQosPolicy *property, const
 {
   dds_security_property_init(&property->value, 6);
   /* Authentication properties. */
-  property->value._buffer[0].name = ddsrt_strdup(PROPERTY_IDENTITY_CERT);
+  property->value._buffer[0].name = ddsrt_strdup(DDS_SEC_PROP_AUTH_IDENTITY_CERT);
   property->value._buffer[0].value = ddsrt_strdup(AUTH_IDENTITY_CERT);
-  property->value._buffer[1].name = ddsrt_strdup(PROPERTY_IDENTITY_CA);
+  property->value._buffer[1].name = ddsrt_strdup(DDS_SEC_PROP_AUTH_IDENTITY_CA);
   property->value._buffer[1].value = ddsrt_strdup(AUTH_IDENTITY_CA);
-  property->value._buffer[2].name = ddsrt_strdup(PROPERTY_PRIVATE_KEY);
+  property->value._buffer[2].name = ddsrt_strdup(DDS_SEC_PROP_AUTH_PRIV_KEY);
   property->value._buffer[2].value = ddsrt_strdup(AUTH_PRIVATE_KEY);
   /* AccessControl properties. */
-  property->value._buffer[3].name = ddsrt_strdup(PROPERTY_PERMISSIONS_CA);
+  property->value._buffer[3].name = ddsrt_strdup(DDS_SEC_PROP_ACCESS_PERMISSIONS_CA);
   property->value._buffer[3].value = permission_ca ? ddsrt_strdup(permission_ca) : NULL;
-  property->value._buffer[4].name = ddsrt_strdup(PROPERTY_PERMISSIONS);
+  property->value._buffer[4].name = ddsrt_strdup(DDS_SEC_PROP_ACCESS_PERMISSIONS);
   property->value._buffer[4].value = permission_uri ? ddsrt_strdup(permission_uri) : NULL;
-  property->value._buffer[5].name = ddsrt_strdup(PROPERTY_GOVERNANCE);
+  property->value._buffer[5].name = ddsrt_strdup(DDS_SEC_PROP_ACCESS_GOVERNANCE);
   property->value._buffer[5].value = governance_uri ? ddsrt_strdup(governance_uri) : NULL;
 }
 
@@ -603,9 +596,9 @@ static DDS_Security_long test_corrupted_signature(bool corrupt_permissions, bool
 
   /* Corrupt the signature. */
   if (corrupt_permissions)
-    prop = dds_security_property_find(&(participant_qos.property.value), PROPERTY_PERMISSIONS);
+    prop = dds_security_property_find(&(participant_qos.property.value), DDS_SEC_PROP_ACCESS_PERMISSIONS);
   if (corrupt_governance)
-    prop = dds_security_property_find(&(participant_qos.property.value), PROPERTY_GOVERNANCE);
+    prop = dds_security_property_find(&(participant_qos.property.value), DDS_SEC_PROP_ACCESS_GOVERNANCE);
 
   /* Just some (hardcoded) sanity checks. */
   CU_ASSERT_FATAL(prop != NULL);

--- a/src/security/core/src/dds_security_utils.c
+++ b/src/security/core/src/dds_security_utils.c
@@ -877,7 +877,7 @@ static uint32_t DDS_Security_getKeySize (const DDS_Security_PropertySeq *propert
     const DDS_Security_Property_t *key_size_property;
     if (properties != NULL)
     {
-        key_size_property = DDS_Security_PropertySeq_find_property (properties, "dds.sec.crypto.keysize");
+        key_size_property = DDS_Security_PropertySeq_find_property (properties, DDS_SEC_PROP_CRYPTO_KEYSIZE);
         if (key_size_property != NULL && !strcmp(key_size_property->value, "128"))
             return 128;
     }

--- a/src/security/core/tests/common/authentication_wrapper.c
+++ b/src/security/core/tests/common/authentication_wrapper.c
@@ -66,11 +66,11 @@ static DDS_Security_ValidationResult_t test_validate_local_identity_all_ok(
   for (unsigned i = 0; i < participant_qos->property.value._length; i++)
   {
     printf("%s\n", participant_qos->property.value._buffer[i].name);
-    if (!strcmp(participant_qos->property.value._buffer[i].name, "dds.sec.auth.private_key"))
+    if (!strcmp(participant_qos->property.value._buffer[i].name, DDS_SEC_PROP_AUTH_PRIV_KEY))
       private_key = participant_qos->property.value._buffer[i].value;
-    else if (!strcmp(participant_qos->property.value._buffer[i].name, "dds.sec.auth.identity_ca"))
+    else if (!strcmp(participant_qos->property.value._buffer[i].name, DDS_SEC_PROP_AUTH_IDENTITY_CA))
       identity_ca = participant_qos->property.value._buffer[i].value;
-    else if (!strcmp(participant_qos->property.value._buffer[i].name, "dds.sec.auth.identity_certificate"))
+    else if (!strcmp(participant_qos->property.value._buffer[i].name, DDS_SEC_PROP_AUTH_IDENTITY_CERT))
       identity_certificate = participant_qos->property.value._buffer[i].value;
   }
 

--- a/src/security/core/tests/common/cryptography_wrapper.c
+++ b/src/security/core/tests/common/cryptography_wrapper.c
@@ -21,10 +21,8 @@
 #include "dds/security/dds_security_api.h"
 #include "dds/security/dds_security_api_defs.h"
 #include "dds/security/core/dds_security_utils.h"
+#include "crypto_tokens.h"
 #include "cryptography_wrapper.h"
-
-#define CRYPTO_TOKEN_CLASS_ID "DDS:Crypto:AES_GCM_GMAC"
-#define CRYPTO_TOKEN_PROPERTY_NAME "dds.cryp.keymat"
 
 int32_t init_crypto(const char *argument, void **context, struct ddsi_domaingv *gv);
 int32_t finalize_crypto(void *context);
@@ -145,11 +143,11 @@ static bool check_crypto_tokens(const DDS_Security_DataHolderSeq *tokens)
     for (uint32_t i = 0; result && (i < tokens->_length); i++)
     {
       result = (tokens->_buffer[i].class_id != NULL &&
-        strcmp(CRYPTO_TOKEN_CLASS_ID, tokens->_buffer[i].class_id) == 0 &&
+        strcmp(DDS_CRYPTOTOKEN_CLASS_ID, tokens->_buffer[i].class_id) == 0 &&
         tokens->_buffer[i].binary_properties._length == 1 &&
         tokens->_buffer[i].binary_properties._buffer != NULL &&
         tokens->_buffer[i].binary_properties._buffer[0].name != NULL &&
-        strcmp(CRYPTO_TOKEN_PROPERTY_NAME, tokens->_buffer[i].binary_properties._buffer[0].name) == 0 &&
+        strcmp(DDS_CRYPTOTOKEN_PROP_KEYMAT, tokens->_buffer[i].binary_properties._buffer[0].name) == 0 &&
         tokens->_buffer[i].binary_properties._buffer[0].value._length > 0 &&
         tokens->_buffer[i].binary_properties._buffer[0].value._buffer != NULL);
     }

--- a/src/security/core/tests/config.c
+++ b/src/security/core/tests/config.c
@@ -25,21 +25,21 @@
 
 #define PROPLIST(init_auth, fin_auth, init_crypto, fin_crypto, init_ac, fin_ac, perm_ca, gov, perm, pre_str, post_str, binprops)         \
   "property_list={" pre_str                                             \
-  "0:\"dds.sec.auth.library.path\":\""WRAPPERLIB_PATH("dds_security_authentication_wrapper")"\","                         \
-  "0:\"dds.sec.auth.library.init\":\""init_auth"\","            \
-  "0:\"dds.sec.auth.library.finalize\":\""fin_auth"\","    \
-  "0:\"dds.sec.crypto.library.path\":\""WRAPPERLIB_PATH("dds_security_cryptography_wrapper")"\","                     \
-  "0:\"dds.sec.crypto.library.init\":\""init_crypto"\","                  \
-  "0:\"dds.sec.crypto.library.finalize\":\""fin_crypto"\","          \
-  "0:\"dds.sec.access.library.path\":\""WRAPPERLIB_PATH("dds_security_access_control_wrapper")"\","                         \
-  "0:\"dds.sec.access.library.init\":\""init_ac"\","          \
-  "0:\"dds.sec.access.library.finalize\":\""fin_ac"\","  \
-  "0:\"dds.sec.auth.identity_ca\":\"" TEST_IDENTITY_CA_CERTIFICATE_DUMMY "\","  \
-  "0:\"dds.sec.auth.private_key\":\"" TEST_IDENTITY_PRIVATE_KEY_DUMMY "\","     \
-  "0:\"dds.sec.auth.identity_certificate\":\"" TEST_IDENTITY_CERTIFICATE_DUMMY "\"," \
-  "0:\"dds.sec.access.permissions_ca\":\""perm_ca"\","    \
-  "0:\"dds.sec.access.governance\":\""gov"\","            \
-  "0:\"dds.sec.access.permissions\":\""perm"\""           \
+  "0:\"" DDS_SEC_PROP_AUTH_LIBRARY_PATH "\":\""WRAPPERLIB_PATH("dds_security_authentication_wrapper")"\","                         \
+  "0:\"" DDS_SEC_PROP_AUTH_LIBRARY_INIT "\":\""init_auth"\","            \
+  "0:\"" DDS_SEC_PROP_AUTH_LIBRARY_FINALIZE "\":\""fin_auth"\","    \
+  "0:\"" DDS_SEC_PROP_CRYPTO_LIBRARY_PATH "\":\""WRAPPERLIB_PATH("dds_security_cryptography_wrapper")"\","                     \
+  "0:\"" DDS_SEC_PROP_CRYPTO_LIBRARY_INIT "\":\""init_crypto"\","                  \
+  "0:\"" DDS_SEC_PROP_CRYPTO_LIBRARY_FINALIZE "\":\""fin_crypto"\","          \
+  "0:\"" DDS_SEC_PROP_ACCESS_LIBRARY_PATH "\":\""WRAPPERLIB_PATH("dds_security_access_control_wrapper")"\","                         \
+  "0:\"" DDS_SEC_PROP_ACCESS_LIBRARY_INIT "\":\""init_ac"\","          \
+  "0:\"" DDS_SEC_PROP_ACCESS_LIBRARY_FINALIZE "\":\""fin_ac"\","  \
+  "0:\"" DDS_SEC_PROP_AUTH_IDENTITY_CA "\":\"" TEST_IDENTITY_CA_CERTIFICATE_DUMMY "\","  \
+  "0:\"" DDS_SEC_PROP_AUTH_PRIV_KEY "\":\"" TEST_IDENTITY_PRIVATE_KEY_DUMMY "\","     \
+  "0:\"" DDS_SEC_PROP_AUTH_IDENTITY_CERT "\":\"" TEST_IDENTITY_CERTIFICATE_DUMMY "\"," \
+  "0:\"" DDS_SEC_PROP_ACCESS_PERMISSIONS_CA "\":\""perm_ca"\","    \
+  "0:\"" DDS_SEC_PROP_ACCESS_GOVERNANCE "\":\""gov"\","            \
+  "0:\"" DDS_SEC_PROP_ACCESS_PERMISSIONS "\":\""perm"\""           \
   post_str "}:{" binprops "}"
 #define PARTICIPANT_QOS(init_auth, fin_auth, init_crypto, fin_crypto, init_ac, fin_ac, perm_ca, gov, perm, pre_str, post_str, binprops)  \
   "PARTICIPANT * QOS={*" PROPLIST (init_auth, fin_auth, init_crypto, fin_crypto, init_ac, fin_ac, perm_ca, gov, perm, pre_str, post_str, binprops) "*"
@@ -207,7 +207,7 @@ CU_Test(ddssec_config, all, .init = ddsrt_init, .fini = ddsrt_fini)
     "config: Domain/Security/Cryptographic/Library[@initFunction]: init_test_cryptography_all_ok*",
     "config: Domain/Security/Cryptographic/Library[@finalizeFunction]: finalize_test_cryptography_all_ok*",
     /* The config should have been parsed into the participant QoS. */
-    PARTICIPANT_QOS_ALL_OK ("", ",0:\"dds.sec.auth.password\":\"testtext_Password_testtext\",0:\"dds.sec.auth.trusted_ca_dir\":\"testtext_Dir_testtext\",0:\"org.eclipse.cyclonedds.sec.auth.crl\":\"testtext_Crl_testtext\"", ""),
+    PARTICIPANT_QOS_ALL_OK ("", ",0:\"" DDS_SEC_PROP_AUTH_PASSWORD "\":\"testtext_Password_testtext\",0:\"" DDS_SEC_PROP_ACCESS_TRUSTED_CA_DIR "\":\"testtext_Dir_testtext\",0:\"" ORG_ECLIPSE_CYCLONEDDS_SEC_AUTH_CRL "\":\"testtext_Crl_testtext\"", ""),
     NULL
   };
 
@@ -280,7 +280,7 @@ CU_Test(ddssec_config, security, .init = ddsrt_init, .fini = ddsrt_fini)
     "config: Domain/Security/Cryptographic/Library[@initFunction]: init_test_cryptography_all_ok*",
     "config: Domain/Security/Cryptographic/Library[@finalizeFunction]: finalize_test_cryptography_all_ok*",
     /* The config should have been parsed into the participant QoS. */
-    PARTICIPANT_QOS_ALL_OK ("", ",0:\"dds.sec.auth.password\":\"\",0:\"dds.sec.auth.trusted_ca_dir\":\"\",0:\"org.eclipse.cyclonedds.sec.auth.crl\":\"\"", ""),
+    PARTICIPANT_QOS_ALL_OK ("", ",0:\"" DDS_SEC_PROP_AUTH_PASSWORD "\":\"\",0:\"" DDS_SEC_PROP_ACCESS_TRUSTED_CA_DIR "\":\"\",0:\"" ORG_ECLIPSE_CYCLONEDDS_SEC_AUTH_CRL "\":\"\"", ""),
     NULL
   };
 
@@ -349,7 +349,7 @@ CU_Test(ddssec_config, deprecated, .init = ddsrt_init, .fini = ddsrt_fini)
     "config: Domain/Security/Cryptographic/Library[@initFunction]: init_test_cryptography_all_ok*",
     "config: Domain/Security/Cryptographic/Library[@finalizeFunction]: finalize_test_cryptography_all_ok*",
     /* The config should have been parsed into the participant QoS. */
-    PARTICIPANT_QOS_ALL_OK ("", ",0:\"dds.sec.auth.password\":\"testtext_Password_testtext\",0:\"dds.sec.auth.trusted_ca_dir\":\"testtext_Dir_testtext\",0:\"org.eclipse.cyclonedds.sec.auth.crl\":\"testtext_Crl_testtext\"", ""),
+    PARTICIPANT_QOS_ALL_OK ("", ",0:\"" DDS_SEC_PROP_AUTH_PASSWORD "\":\"testtext_Password_testtext\",0:\"" DDS_SEC_PROP_ACCESS_TRUSTED_CA_DIR "\":\"testtext_Dir_testtext\",0:\"" ORG_ECLIPSE_CYCLONEDDS_SEC_AUTH_CRL "\":\"testtext_Crl_testtext\"", ""),
     NULL
   };
 
@@ -401,30 +401,30 @@ CU_Test(ddssec_config, qos, .init = ddsrt_init, .fini = ddsrt_fini)
   dds_qos_t * qos;
   const char *log_expected[] = {
     /* The config should have been parsed into the participant QoS. */
-    PARTICIPANT_QOS_ALL_OK ("", ",0:\"dds.sec.auth.password\":\"testtext_Password_testtext\",0:\"dds.sec.auth.trusted_ca_dir\":\"file:/test/dir\",0:\"org.eclipse.cyclonedds.sec.auth.crl\":\"file:/test/crl\"", ""),
+    PARTICIPANT_QOS_ALL_OK ("", ",0:\"" DDS_SEC_PROP_AUTH_PASSWORD "\":\"testtext_Password_testtext\",0:\"" DDS_SEC_PROP_ACCESS_TRUSTED_CA_DIR "\":\"file:/test/dir\",0:\"" ORG_ECLIPSE_CYCLONEDDS_SEC_AUTH_CRL "\":\"file:/test/crl\"", ""),
     NULL
   };
 
   /* Create the qos */
   CU_ASSERT_FATAL((qos = dds_create_qos()) != NULL);
-  dds_qset_prop(qos, "dds.sec.auth.library.path", ""WRAPPERLIB_PATH("dds_security_authentication_wrapper")"");
-  dds_qset_prop(qos, "dds.sec.auth.library.init", "init_test_authentication_all_ok");
-  dds_qset_prop(qos, "dds.sec.auth.library.finalize", "finalize_test_authentication_all_ok");
-  dds_qset_prop(qos, "dds.sec.crypto.library.path", ""WRAPPERLIB_PATH("dds_security_cryptography_wrapper")"");
-  dds_qset_prop(qos, "dds.sec.crypto.library.init", "init_test_cryptography_all_ok");
-  dds_qset_prop(qos, "dds.sec.crypto.library.finalize", "finalize_test_cryptography_all_ok");
-  dds_qset_prop(qos, "dds.sec.access.library.path", ""WRAPPERLIB_PATH("dds_security_access_control_wrapper")"");
-  dds_qset_prop(qos, "dds.sec.access.library.init", "init_test_access_control_all_ok");
-  dds_qset_prop(qos, "dds.sec.access.library.finalize", "finalize_test_access_control_all_ok");
-  dds_qset_prop(qos, "dds.sec.auth.identity_ca", ""TEST_IDENTITY_CA_CERTIFICATE_DUMMY"");
-  dds_qset_prop(qos, "dds.sec.auth.private_key", ""TEST_IDENTITY_PRIVATE_KEY_DUMMY"");
-  dds_qset_prop(qos, "dds.sec.auth.identity_certificate", ""TEST_IDENTITY_CERTIFICATE_DUMMY"");
-  dds_qset_prop(qos, "dds.sec.access.permissions_ca", "file:Permissions_CA.pem");
-  dds_qset_prop(qos, "dds.sec.access.governance", "file:Governance.p7s");
-  dds_qset_prop(qos, "dds.sec.access.permissions", "file:Permissions.p7s");
-  dds_qset_prop(qos, "dds.sec.auth.password", "testtext_Password_testtext");
-  dds_qset_prop(qos, "dds.sec.auth.trusted_ca_dir", "file:/test/dir");
-  dds_qset_prop(qos, "org.eclipse.cyclonedds.sec.auth.crl", "file:/test/crl");
+  dds_qset_prop(qos, DDS_SEC_PROP_AUTH_LIBRARY_PATH, WRAPPERLIB_PATH("dds_security_authentication_wrapper")"");
+  dds_qset_prop(qos, DDS_SEC_PROP_AUTH_LIBRARY_INIT, "init_test_authentication_all_ok");
+  dds_qset_prop(qos, DDS_SEC_PROP_AUTH_LIBRARY_FINALIZE, "finalize_test_authentication_all_ok");
+  dds_qset_prop(qos, DDS_SEC_PROP_CRYPTO_LIBRARY_PATH, WRAPPERLIB_PATH("dds_security_cryptography_wrapper")"");
+  dds_qset_prop(qos, DDS_SEC_PROP_CRYPTO_LIBRARY_INIT, "init_test_cryptography_all_ok");
+  dds_qset_prop(qos, DDS_SEC_PROP_CRYPTO_LIBRARY_FINALIZE, "finalize_test_cryptography_all_ok");
+  dds_qset_prop(qos, DDS_SEC_PROP_ACCESS_LIBRARY_PATH, WRAPPERLIB_PATH("dds_security_access_control_wrapper")"");
+  dds_qset_prop(qos, DDS_SEC_PROP_ACCESS_LIBRARY_INIT, "init_test_access_control_all_ok");
+  dds_qset_prop(qos, DDS_SEC_PROP_ACCESS_LIBRARY_FINALIZE, "finalize_test_access_control_all_ok");
+  dds_qset_prop(qos, DDS_SEC_PROP_AUTH_IDENTITY_CA, ""TEST_IDENTITY_CA_CERTIFICATE_DUMMY"");
+  dds_qset_prop(qos, DDS_SEC_PROP_AUTH_PRIV_KEY, ""TEST_IDENTITY_PRIVATE_KEY_DUMMY"");
+  dds_qset_prop(qos, DDS_SEC_PROP_AUTH_IDENTITY_CERT, ""TEST_IDENTITY_CERTIFICATE_DUMMY"");
+  dds_qset_prop(qos, DDS_SEC_PROP_ACCESS_PERMISSIONS_CA, "file:Permissions_CA.pem");
+  dds_qset_prop(qos, DDS_SEC_PROP_ACCESS_GOVERNANCE, "file:Governance.p7s");
+  dds_qset_prop(qos, DDS_SEC_PROP_ACCESS_PERMISSIONS, "file:Permissions.p7s");
+  dds_qset_prop(qos, DDS_SEC_PROP_AUTH_PASSWORD, "testtext_Password_testtext");
+  dds_qset_prop(qos, DDS_SEC_PROP_ACCESS_TRUSTED_CA_DIR, "file:/test/dir");
+  dds_qset_prop(qos, ORG_ECLIPSE_CYCLONEDDS_SEC_AUTH_CRL, "file:/test/crl");
 
   set_logger_exp(log_expected);
   domain = dds_create_domain(0, default_config);
@@ -447,7 +447,7 @@ CU_Test(ddssec_config, qos_props, .init = ddsrt_init, .fini = ddsrt_fini)
   dds_qos_t * qos;
   const char *log_expected[] = {
     /* The config should have been parsed into the participant QoS. */
-    PARTICIPANT_QOS_ALL_OK ("", ",0:\"dds.sec.auth.password\":\"testtext_Password_testtext\",0:\"dds.sec.auth.trusted_ca_dir\":\"file:/test/dir\",0:\"org.eclipse.cyclonedds.sec.auth.crl\":\"file:/test/crl\",0:\"test.prop1\":\"testtext_value1_testtext\",0:\"test.prop2\":\"testtext_value2_testtext\"",
+    PARTICIPANT_QOS_ALL_OK ("", ",0:\"" DDS_SEC_PROP_AUTH_PASSWORD "\":\"testtext_Password_testtext\",0:\"" DDS_SEC_PROP_ACCESS_TRUSTED_CA_DIR "\":\"file:/test/dir\",0:\"" ORG_ECLIPSE_CYCLONEDDS_SEC_AUTH_CRL "\":\"file:/test/crl\",0:\"test.prop1\":\"testtext_value1_testtext\",0:\"test.prop2\":\"testtext_value2_testtext\"",
                             "0:\"test.bprop1\":3<1,2,3>"),
     NULL
   };
@@ -455,24 +455,24 @@ CU_Test(ddssec_config, qos_props, .init = ddsrt_init, .fini = ddsrt_fini)
   /* Create the qos */
   unsigned char bvalue[3] = { 0x01, 0x02, 0x03 };
   CU_ASSERT_FATAL((qos = dds_create_qos()) != NULL);
-  dds_qset_prop(qos, "dds.sec.auth.library.path", ""WRAPPERLIB_PATH("dds_security_authentication_wrapper")"");
-  dds_qset_prop(qos, "dds.sec.auth.library.init", "init_test_authentication_all_ok");
-  dds_qset_prop(qos, "dds.sec.auth.library.finalize", "finalize_test_authentication_all_ok");
-  dds_qset_prop(qos, "dds.sec.crypto.library.path", ""WRAPPERLIB_PATH("dds_security_cryptography_wrapper")"");
-  dds_qset_prop(qos, "dds.sec.crypto.library.init", "init_test_cryptography_all_ok");
-  dds_qset_prop(qos, "dds.sec.crypto.library.finalize", "finalize_test_cryptography_all_ok");
-  dds_qset_prop(qos, "dds.sec.access.library.path", ""WRAPPERLIB_PATH("dds_security_access_control_wrapper")"");
-  dds_qset_prop(qos, "dds.sec.access.library.init", "init_test_access_control_all_ok");
-  dds_qset_prop(qos, "dds.sec.access.library.finalize", "finalize_test_access_control_all_ok");
-  dds_qset_prop(qos, "dds.sec.auth.identity_ca", TEST_IDENTITY_CA_CERTIFICATE_DUMMY);
-  dds_qset_prop(qos, "dds.sec.auth.private_key", TEST_IDENTITY_PRIVATE_KEY_DUMMY);
-  dds_qset_prop(qos, "dds.sec.auth.identity_certificate", TEST_IDENTITY_CERTIFICATE_DUMMY);
-  dds_qset_prop(qos, "dds.sec.access.permissions_ca", "file:Permissions_CA.pem");
-  dds_qset_prop(qos, "dds.sec.access.governance", "file:Governance.p7s");
-  dds_qset_prop(qos, "dds.sec.access.permissions", "file:Permissions.p7s");
-  dds_qset_prop(qos, "dds.sec.auth.password", "testtext_Password_testtext");
-  dds_qset_prop(qos, "dds.sec.auth.trusted_ca_dir", "file:/test/dir");
-  dds_qset_prop(qos, "org.eclipse.cyclonedds.sec.auth.crl", "file:/test/crl");
+  dds_qset_prop(qos, DDS_SEC_PROP_AUTH_LIBRARY_PATH, WRAPPERLIB_PATH("dds_security_authentication_wrapper")"");
+  dds_qset_prop(qos, DDS_SEC_PROP_AUTH_LIBRARY_INIT, "init_test_authentication_all_ok");
+  dds_qset_prop(qos, DDS_SEC_PROP_AUTH_LIBRARY_FINALIZE, "finalize_test_authentication_all_ok");
+  dds_qset_prop(qos, DDS_SEC_PROP_CRYPTO_LIBRARY_PATH, WRAPPERLIB_PATH("dds_security_cryptography_wrapper")"");
+  dds_qset_prop(qos, DDS_SEC_PROP_CRYPTO_LIBRARY_INIT, "init_test_cryptography_all_ok");
+  dds_qset_prop(qos, DDS_SEC_PROP_CRYPTO_LIBRARY_FINALIZE, "finalize_test_cryptography_all_ok");
+  dds_qset_prop(qos, DDS_SEC_PROP_ACCESS_LIBRARY_PATH, WRAPPERLIB_PATH("dds_security_access_control_wrapper")"");
+  dds_qset_prop(qos, DDS_SEC_PROP_ACCESS_LIBRARY_INIT, "init_test_access_control_all_ok");
+  dds_qset_prop(qos, DDS_SEC_PROP_ACCESS_LIBRARY_FINALIZE, "finalize_test_access_control_all_ok");
+  dds_qset_prop(qos, DDS_SEC_PROP_AUTH_IDENTITY_CA, TEST_IDENTITY_CA_CERTIFICATE_DUMMY);
+  dds_qset_prop(qos, DDS_SEC_PROP_AUTH_PRIV_KEY, TEST_IDENTITY_PRIVATE_KEY_DUMMY);
+  dds_qset_prop(qos, DDS_SEC_PROP_AUTH_IDENTITY_CERT, TEST_IDENTITY_CERTIFICATE_DUMMY);
+  dds_qset_prop(qos, DDS_SEC_PROP_ACCESS_PERMISSIONS_CA, "file:Permissions_CA.pem");
+  dds_qset_prop(qos, DDS_SEC_PROP_ACCESS_GOVERNANCE, "file:Governance.p7s");
+  dds_qset_prop(qos, DDS_SEC_PROP_ACCESS_PERMISSIONS, "file:Permissions.p7s");
+  dds_qset_prop(qos, DDS_SEC_PROP_AUTH_PASSWORD, "testtext_Password_testtext");
+  dds_qset_prop(qos, DDS_SEC_PROP_ACCESS_TRUSTED_CA_DIR, "file:/test/dir");
+  dds_qset_prop(qos, ORG_ECLIPSE_CYCLONEDDS_SEC_AUTH_CRL, "file:/test/crl");
   dds_qset_prop(qos, "test.prop1", "testtext_value1_testtext");
   dds_qset_prop(qos, "test.prop2", "testtext_value2_testtext");
   dds_qset_bprop(qos, "test.bprop1", bvalue, 3);
@@ -537,12 +537,12 @@ CU_Test(ddssec_config, config_qos, .init = ddsrt_init, .fini = ddsrt_fini)
   dds_qset_prop(qos, DDS_SEC_PROP_ACCESS_LIBRARY_PATH, WRAPPERLIB_PATH("dds_security_access_control_wrapper"));
   dds_qset_prop(qos, DDS_SEC_PROP_ACCESS_LIBRARY_INIT, "init_test_access_control_all_ok");
   dds_qset_prop(qos, DDS_SEC_PROP_ACCESS_LIBRARY_FINALIZE, "finalize_test_access_control_all_ok");
-  dds_qset_prop(qos, "dds.sec.auth.identity_ca", TEST_IDENTITY_CA_CERTIFICATE_DUMMY);
-  dds_qset_prop(qos, "dds.sec.auth.private_key", TEST_IDENTITY_PRIVATE_KEY_DUMMY);
-  dds_qset_prop(qos, "dds.sec.auth.identity_certificate", TEST_IDENTITY_CERTIFICATE_DUMMY);
-  dds_qset_prop(qos, "dds.sec.access.permissions_ca", "file:QOS_Permissions_CA.pem");
-  dds_qset_prop(qos, "dds.sec.access.governance", "file:QOS_Governance.p7s");
-  dds_qset_prop(qos, "dds.sec.access.permissions", "file:QOS_Permissions.p7s");
+  dds_qset_prop(qos, DDS_SEC_PROP_AUTH_IDENTITY_CA, TEST_IDENTITY_CA_CERTIFICATE_DUMMY);
+  dds_qset_prop(qos, DDS_SEC_PROP_AUTH_PRIV_KEY, TEST_IDENTITY_PRIVATE_KEY_DUMMY);
+  dds_qset_prop(qos, DDS_SEC_PROP_AUTH_IDENTITY_CERT, TEST_IDENTITY_CERTIFICATE_DUMMY);
+  dds_qset_prop(qos, DDS_SEC_PROP_ACCESS_PERMISSIONS_CA, "file:QOS_Permissions_CA.pem");
+  dds_qset_prop(qos, DDS_SEC_PROP_ACCESS_GOVERNANCE, "file:QOS_Governance.p7s");
+  dds_qset_prop(qos, DDS_SEC_PROP_ACCESS_PERMISSIONS, "file:QOS_Permissions.p7s");
 
   set_logger_exp(log_expected);
   domain = dds_create_domain(0, sec_config);
@@ -566,7 +566,7 @@ CU_Test(ddssec_config, other_prop, .init = ddsrt_init, .fini = ddsrt_fini)
   dds_qos_t * qos;
   const char *log_expected[] = {
     /* The security settings from config should have been parsed into the participant QoS. */
-    PARTICIPANT_QOS_ALL_OK ("0:\"test.dds.sec.prop1\":\"testtext_value1_testtext\",", ",0:\"dds.sec.auth.password\":\"testtext_Password_testtext\",0:\"dds.sec.auth.trusted_ca_dir\":\"testtext_Dir_testtext\",0:\"org.eclipse.cyclonedds.sec.auth.crl\":\"testtext_Crl_testtext\"", ""),
+    PARTICIPANT_QOS_ALL_OK ("0:\"test.dds.sec.prop1\":\"testtext_value1_testtext\",", ",0:\"" DDS_SEC_PROP_AUTH_PASSWORD "\":\"testtext_Password_testtext\",0:\"" DDS_SEC_PROP_ACCESS_TRUSTED_CA_DIR "\":\"testtext_Dir_testtext\",0:\"" ORG_ECLIPSE_CYCLONEDDS_SEC_AUTH_CRL "\":\"testtext_Crl_testtext\"", ""),
     NULL
   };
 
@@ -623,21 +623,21 @@ CU_Test(ddssec_config, qos_invalid, .init = ddsrt_init, .fini = ddsrt_fini)
   const char *log_expected[] = {
     /* The config should have been parsed into the participant QoS. */
     "new_participant(*): using security settings from QoS*",
-    "new_participant(*): required security property dds.sec.auth.identity_ca missing in Property QoS*",
-    "new_participant(*): required security property dds.sec.auth.private_key missing in Property QoS*",
-    "new_participant(*): required security property dds.sec.auth.identity_certificate missing in Property QoS*",
-    "new_participant(*): required security property dds.sec.access.permissions_ca missing in Property QoS*",
-    "new_participant(*): required security property dds.sec.access.governance missing in Property QoS*",
-    "new_participant(*): required security property dds.sec.access.permissions missing in Property QoS*",
-    "new_participant(*): required security property dds.sec.auth.library.path missing in Property QoS*",
-    "new_participant(*): required security property dds.sec.auth.library.init missing in Property QoS*",
-    "new_participant(*): required security property dds.sec.auth.library.finalize missing in Property QoS*",
-    "new_participant(*): required security property dds.sec.crypto.library.path missing in Property QoS*",
-    "new_participant(*): required security property dds.sec.crypto.library.init missing in Property QoS*",
-    "new_participant(*): required security property dds.sec.crypto.library.finalize missing in Property QoS*",
-    "new_participant(*): required security property dds.sec.access.library.path missing in Property QoS*",
-    "new_participant(*): required security property dds.sec.access.library.init missing in Property QoS*",
-    "new_participant(*): required security property dds.sec.access.library.finalize missing in Property QoS*",
+    "new_participant(*): required security property " DDS_SEC_PROP_AUTH_IDENTITY_CA " missing in Property QoS*",
+    "new_participant(*): required security property " DDS_SEC_PROP_AUTH_PRIV_KEY " missing in Property QoS*",
+    "new_participant(*): required security property " DDS_SEC_PROP_AUTH_IDENTITY_CERT " missing in Property QoS*",
+    "new_participant(*): required security property " DDS_SEC_PROP_ACCESS_PERMISSIONS_CA " missing in Property QoS*",
+    "new_participant(*): required security property " DDS_SEC_PROP_ACCESS_GOVERNANCE " missing in Property QoS*",
+    "new_participant(*): required security property " DDS_SEC_PROP_ACCESS_PERMISSIONS " missing in Property QoS*",
+    "new_participant(*): required security property " DDS_SEC_PROP_AUTH_LIBRARY_PATH " missing in Property QoS*",
+    "new_participant(*): required security property " DDS_SEC_PROP_AUTH_LIBRARY_INIT " missing in Property QoS*",
+    "new_participant(*): required security property " DDS_SEC_PROP_AUTH_LIBRARY_FINALIZE " missing in Property QoS*",
+    "new_participant(*): required security property " DDS_SEC_PROP_CRYPTO_LIBRARY_PATH " missing in Property QoS*",
+    "new_participant(*): required security property " DDS_SEC_PROP_CRYPTO_LIBRARY_INIT " missing in Property QoS*",
+    "new_participant(*): required security property " DDS_SEC_PROP_CRYPTO_LIBRARY_FINALIZE " missing in Property QoS*",
+    "new_participant(*): required security property " DDS_SEC_PROP_ACCESS_LIBRARY_PATH " missing in Property QoS*",
+    "new_participant(*): required security property " DDS_SEC_PROP_ACCESS_LIBRARY_INIT " missing in Property QoS*",
+    "new_participant(*): required security property " DDS_SEC_PROP_ACCESS_LIBRARY_FINALIZE " missing in Property QoS*",
     NULL
   };
 
@@ -664,7 +664,7 @@ CU_Test(ddssec_config, qos_invalid, .init = ddsrt_init, .fini = ddsrt_fini)
   set_logger_exp(log_expected);
 
   CU_ASSERT_FATAL((qos = dds_create_qos()) != NULL);
-  dds_qset_prop(qos, "dds.sec.dummy", "testtext_dummy_testtext");
+  dds_qset_prop(qos, DDS_SEC_PROP_PREFIX "dummy", "testtext_dummy_testtext");
 
   /* Create participant with security config in qos. */
   domain = dds_create_domain(0, sec_config);
@@ -687,21 +687,21 @@ CU_Test(ddssec_config, qos_invalid_proprietary, .init = ddsrt_init, .fini = ddsr
   const char *log_expected[] = {
     /* The config should have been parsed into the participant QoS. */
     "new_participant(*): using security settings from QoS*",
-    "new_participant(*): required security property dds.sec.auth.identity_ca missing in Property QoS*",
-    "new_participant(*): required security property dds.sec.auth.private_key missing in Property QoS*",
-    "new_participant(*): required security property dds.sec.auth.identity_certificate missing in Property QoS*",
-    "new_participant(*): required security property dds.sec.access.permissions_ca missing in Property QoS*",
-    "new_participant(*): required security property dds.sec.access.governance missing in Property QoS*",
-    "new_participant(*): required security property dds.sec.access.permissions missing in Property QoS*",
-    "new_participant(*): required security property dds.sec.auth.library.path missing in Property QoS*",
-    "new_participant(*): required security property dds.sec.auth.library.init missing in Property QoS*",
-    "new_participant(*): required security property dds.sec.auth.library.finalize missing in Property QoS*",
-    "new_participant(*): required security property dds.sec.crypto.library.path missing in Property QoS*",
-    "new_participant(*): required security property dds.sec.crypto.library.init missing in Property QoS*",
-    "new_participant(*): required security property dds.sec.crypto.library.finalize missing in Property QoS*",
-    "new_participant(*): required security property dds.sec.access.library.path missing in Property QoS*",
-    "new_participant(*): required security property dds.sec.access.library.init missing in Property QoS*",
-    "new_participant(*): required security property dds.sec.access.library.finalize missing in Property QoS*",
+    "new_participant(*): required security property " DDS_SEC_PROP_AUTH_IDENTITY_CA " missing in Property QoS*",
+    "new_participant(*): required security property " DDS_SEC_PROP_AUTH_PRIV_KEY " missing in Property QoS*",
+    "new_participant(*): required security property " DDS_SEC_PROP_AUTH_IDENTITY_CERT " missing in Property QoS*",
+    "new_participant(*): required security property " DDS_SEC_PROP_ACCESS_PERMISSIONS_CA " missing in Property QoS*",
+    "new_participant(*): required security property " DDS_SEC_PROP_ACCESS_GOVERNANCE " missing in Property QoS*",
+    "new_participant(*): required security property " DDS_SEC_PROP_ACCESS_PERMISSIONS " missing in Property QoS*",
+    "new_participant(*): required security property " DDS_SEC_PROP_AUTH_LIBRARY_PATH " missing in Property QoS*",
+    "new_participant(*): required security property " DDS_SEC_PROP_AUTH_LIBRARY_INIT " missing in Property QoS*",
+    "new_participant(*): required security property " DDS_SEC_PROP_AUTH_LIBRARY_FINALIZE " missing in Property QoS*",
+    "new_participant(*): required security property " DDS_SEC_PROP_CRYPTO_LIBRARY_PATH " missing in Property QoS*",
+    "new_participant(*): required security property " DDS_SEC_PROP_CRYPTO_LIBRARY_INIT " missing in Property QoS*",
+    "new_participant(*): required security property " DDS_SEC_PROP_CRYPTO_LIBRARY_FINALIZE " missing in Property QoS*",
+    "new_participant(*): required security property " DDS_SEC_PROP_ACCESS_LIBRARY_PATH " missing in Property QoS*",
+    "new_participant(*): required security property " DDS_SEC_PROP_ACCESS_LIBRARY_INIT " missing in Property QoS*",
+    "new_participant(*): required security property " DDS_SEC_PROP_ACCESS_LIBRARY_FINALIZE " missing in Property QoS*",
     NULL
   };
 
@@ -750,7 +750,7 @@ CU_Test(ddssec_config, config_qos_missing_crl, .init = ddsrt_init, .fini = ddsrt
   dds_qos_t * qos;
   const char *log_expected[] = {
     /* The security settings from qos properties should have been parsed into the participant QoS. */
-    "*CRL security property org.eclipse.cyclonedds.sec.auth.crl absent in Property QoS but specified in XML configuration*",
+    "*CRL security property " ORG_ECLIPSE_CYCLONEDDS_SEC_AUTH_CRL " absent in Property QoS but specified in XML configuration*",
     NULL
   };
 
@@ -785,12 +785,12 @@ CU_Test(ddssec_config, config_qos_missing_crl, .init = ddsrt_init, .fini = ddsrt
   dds_qset_prop(qos, DDS_SEC_PROP_ACCESS_LIBRARY_PATH, WRAPPERLIB_PATH("dds_security_access_control_wrapper"));
   dds_qset_prop(qos, DDS_SEC_PROP_ACCESS_LIBRARY_INIT, "init_test_access_control_all_ok");
   dds_qset_prop(qos, DDS_SEC_PROP_ACCESS_LIBRARY_FINALIZE, "finalize_test_access_control_all_ok");
-  dds_qset_prop(qos, "dds.sec.auth.identity_ca", TEST_IDENTITY_CA_CERTIFICATE_DUMMY);
-  dds_qset_prop(qos, "dds.sec.auth.private_key", TEST_IDENTITY_PRIVATE_KEY_DUMMY);
-  dds_qset_prop(qos, "dds.sec.auth.identity_certificate", TEST_IDENTITY_CERTIFICATE_DUMMY);
-  dds_qset_prop(qos, "dds.sec.access.permissions_ca", "file:QOS_Permissions_CA.pem");
-  dds_qset_prop(qos, "dds.sec.access.governance", "file:QOS_Governance.p7s");
-  dds_qset_prop(qos, "dds.sec.access.permissions", "file:QOS_Permissions.p7s");
+  dds_qset_prop(qos, DDS_SEC_PROP_AUTH_IDENTITY_CA, TEST_IDENTITY_CA_CERTIFICATE_DUMMY);
+  dds_qset_prop(qos, DDS_SEC_PROP_AUTH_PRIV_KEY, TEST_IDENTITY_PRIVATE_KEY_DUMMY);
+  dds_qset_prop(qos, DDS_SEC_PROP_AUTH_IDENTITY_CERT, TEST_IDENTITY_CERTIFICATE_DUMMY);
+  dds_qset_prop(qos, DDS_SEC_PROP_ACCESS_PERMISSIONS_CA, "file:QOS_Permissions_CA.pem");
+  dds_qset_prop(qos, DDS_SEC_PROP_ACCESS_GOVERNANCE, "file:QOS_Governance.p7s");
+  dds_qset_prop(qos, DDS_SEC_PROP_ACCESS_PERMISSIONS, "file:QOS_Permissions.p7s");
 
   set_logger_exp(log_expected);
   domain = dds_create_domain(0, sec_config);
@@ -837,7 +837,7 @@ CU_Test(ddssec_config, config_qos_override_crl, .init = ddsrt_init, .fini = ddsr
                    "init_test_cryptography_all_ok", "finalize_test_cryptography_all_ok", \
                    "init_test_access_control_all_ok", "finalize_test_access_control_all_ok", \
                    "file:QOS_Permissions_CA.pem", "file:QOS_Governance.p7s", "file:QOS_Permissions.p7s", \
-                   "", ",0:\"org.eclipse.cyclonedds.sec.auth.crl\":\"\"", ""),
+                   "", ",0:\"" ORG_ECLIPSE_CYCLONEDDS_SEC_AUTH_CRL "\":\"\"", ""),
     NULL
   };
 
@@ -877,12 +877,12 @@ CU_Test(ddssec_config, config_qos_override_crl, .init = ddsrt_init, .fini = ddsr
   dds_qset_prop(qos, DDS_SEC_PROP_ACCESS_LIBRARY_PATH, WRAPPERLIB_PATH("dds_security_access_control_wrapper"));
   dds_qset_prop(qos, DDS_SEC_PROP_ACCESS_LIBRARY_INIT, "init_test_access_control_all_ok");
   dds_qset_prop(qos, DDS_SEC_PROP_ACCESS_LIBRARY_FINALIZE, "finalize_test_access_control_all_ok");
-  dds_qset_prop(qos, "dds.sec.auth.identity_ca", TEST_IDENTITY_CA_CERTIFICATE_DUMMY);
-  dds_qset_prop(qos, "dds.sec.auth.private_key", TEST_IDENTITY_PRIVATE_KEY_DUMMY);
-  dds_qset_prop(qos, "dds.sec.auth.identity_certificate", TEST_IDENTITY_CERTIFICATE_DUMMY);
-  dds_qset_prop(qos, "dds.sec.access.permissions_ca", "file:QOS_Permissions_CA.pem");
-  dds_qset_prop(qos, "dds.sec.access.governance", "file:QOS_Governance.p7s");
-  dds_qset_prop(qos, "dds.sec.access.permissions", "file:QOS_Permissions.p7s");
+  dds_qset_prop(qos, DDS_SEC_PROP_AUTH_IDENTITY_CA, TEST_IDENTITY_CA_CERTIFICATE_DUMMY);
+  dds_qset_prop(qos, DDS_SEC_PROP_AUTH_PRIV_KEY, TEST_IDENTITY_PRIVATE_KEY_DUMMY);
+  dds_qset_prop(qos, DDS_SEC_PROP_AUTH_IDENTITY_CERT, TEST_IDENTITY_CERTIFICATE_DUMMY);
+  dds_qset_prop(qos, DDS_SEC_PROP_ACCESS_PERMISSIONS_CA, "file:QOS_Permissions_CA.pem");
+  dds_qset_prop(qos, DDS_SEC_PROP_ACCESS_GOVERNANCE, "file:QOS_Governance.p7s");
+  dds_qset_prop(qos, DDS_SEC_PROP_ACCESS_PERMISSIONS, "file:QOS_Permissions.p7s");
   dds_qset_prop(qos, ORG_ECLIPSE_CYCLONEDDS_SEC_AUTH_CRL, "");
 
   set_logger_exp(log_expected);

--- a/src/security/core/tests/plugin_loading.c
+++ b/src/security/core/tests/plugin_loading.c
@@ -436,7 +436,7 @@ CU_Test(ddssec_security_plugin_loading, missing_plugin_property_with_props, .ini
   dds_qos_t *qos;
   const char *log_expected[] = {
       "*using security settings from QoS*",
-      "*required security property dds.sec.auth.library.init missing in Property QoS*",
+      "*required security property " DDS_SEC_PROP_AUTH_LIBRARY_INIT " missing in Property QoS*",
       NULL};
 
   unsigned char bvalue[3] = {0x01, 0x02, 0x03};
@@ -483,7 +483,7 @@ CU_Test(ddssec_security_plugin_loading, empty_plugin_property_with_props, .init 
   dds_qos_t *qos;
   const char *log_expected[] = {
       "*using security settings from QoS*",
-      "*required security property dds.sec.auth.library.finalize missing in Property QoS*",
+      "*required security property " DDS_SEC_PROP_AUTH_LIBRARY_FINALIZE " missing in Property QoS*",
       NULL};
 
   unsigned char bvalue[3] = {0x01, 0x02, 0x03};
@@ -530,7 +530,7 @@ CU_Test(ddssec_security_plugin_loading, missing_security_property_with_props, .i
   dds_qos_t *qos;
   const char *log_expected[] = {
       "*using security settings from QoS*",
-      "*required security property dds.sec.access.permissions missing in Property QoS*",
+      "*required security property " DDS_SEC_PROP_ACCESS_PERMISSIONS " missing in Property QoS*",
       NULL};
 
   unsigned char bvalue[3] = {0x01, 0x02, 0x03};


### PR DESCRIPTION
This mostly eliminates the large number of string literals containing
property names used by security (both property names that occur in the
API and property names that are used on the wire).

There is still a little bit of duplication because of the core/plug-in
split.

Signed-off-by: Erik Boasson <eb@ilities.com>