### PR TITLE
Removed global shared memory mutex

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/shm_sync.h
+++ b/src/core/ddsi/include/dds/ddsi/shm_sync.h
@@ -31,11 +31,6 @@ typedef struct {
     struct dds_reader* parent_reader;
 } iox_sub_storage_extension_t;
 
-// lock and unlock global shared memory mutex
-DDS_EXPORT int shm_mutex_init(void);
-DDS_EXPORT void shm_mutex_lock(void);
-DDS_EXPORT void shm_mutex_unlock(void);
-
 //lock and unlock for individual subscribers
 DDS_EXPORT void iox_sub_storage_extension_init(iox_sub_storage_extension_t* storage);
 DDS_EXPORT void iox_sub_storage_extension_fini(iox_sub_storage_extension_t* storage);

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -71,7 +71,6 @@
 
 #ifdef DDS_HAS_SHM
 #include "dds/ddsrt/io.h"
-#include "dds/ddsi/shm_sync.h"
 #include "iceoryx_binding_c/runtime.h"
 #include "dds/ddsi/shm_init.h"
 #endif
@@ -1116,7 +1115,7 @@ static void free_conns (struct ddsi_domaingv *gv)
 static int iceoryx_init (struct ddsi_domaingv *gv)
 {
   shm_set_loglevel(gv->config.shm_log_lvl);
-  
+
   char *sptr;
   ddsrt_asprintf (&sptr, "iceoryx_rt_%"PRIdPID"_%"PRId64, ddsrt_getpid (), gv->tstart.v);
   GVLOG (DDS_LC_SHM, "Current process name for iceoryx is %s\n", sptr);
@@ -1153,7 +1152,7 @@ static int iceoryx_init (struct ddsi_domaingv *gv)
   else
   {
     int if_index;
-    
+
     // Try to avoid loopback interfaces for getting a MAC address, but if all
     // we have are loopback interfaces, then it really doesn't matter.
     for (if_index = 0; if_index < gv->n_interfaces; if_index++)
@@ -1205,8 +1204,6 @@ static int iceoryx_init (struct ddsi_domaingv *gv)
   intf->netmask.port = NN_LOCATOR_PORT_INVALID;
   memset (intf->netmask.address, 0, sizeof (intf->netmask.address) - 6);
   gv->n_interfaces++;
-
-  shm_mutex_init();
   return 0;
 }
 #endif

--- a/src/core/ddsi/src/shm_sync.c
+++ b/src/core/ddsi/src/shm_sync.c
@@ -11,30 +11,6 @@
  */
 #include "dds/ddsi/shm_sync.h"
 
-static ddsrt_mutex_t shm_mutex;
-static int shm_mutex_initialized = 0;
-
-int shm_mutex_init()
-{
-  if (shm_mutex_initialized)
-    return 1;
-
-  ddsrt_mutex_init(&shm_mutex);
-  shm_mutex_initialized = 1;
-
-  return 0;
-}
-
-void shm_mutex_lock(void)
-{
-  ddsrt_mutex_lock(&shm_mutex);
-}
-
-void shm_mutex_unlock(void)
-{
-  ddsrt_mutex_unlock(&shm_mutex);
-}
-
 void iox_sub_storage_extension_init(iox_sub_storage_extension_t *storage)
 {
   storage->monitor = NULL;


### PR DESCRIPTION
This is the second commit of @reicheratwork 's #753 rebased to current master.

- removed functions and variables associated with the global
shared memory mutex, since this is not used anywhere anymore
