### PR TITLE
Remove dead code from mcpp (CID 329677)

### DIFF
--- a/src/tools/idlpp/src/internal.H
+++ b/src/tools/idlpp/src/internal.H
@@ -230,7 +230,6 @@ typedef struct fileinfo {
         char *          bptr;       /* Current pointer into buffer  */
         size_t          line;       /* Current line number of file  */
         FILE *          fp;         /* Source file if non-null      */
-        long            pos;        /* Position next to #include    */
         struct fileinfo *   parent; /* Link to includer             */
         struct ifinfo *     initif; /* Initial ifstack (return there on EOF)*/
         int             sys_header; /* System header file or not    */

--- a/src/tools/idlpp/src/support.c
+++ b/src/tools/idlpp/src/support.c
@@ -1598,11 +1598,6 @@ int     get_ch( void)
         /* Do not free file->real_fname and file->full_fname        */
         cur_fullname = infile->full_fname;
         cur_fname = infile->real_fname;     /* Restore current fname*/
-        if (infile->pos != 0L) {            /* Includer was closed  */
-            infile->fp = fopen( cur_fullname, "r");
-            assert( infile->fp);
-            fseek( infile->fp, infile->pos, SEEK_SET);
-        }   /* Re-open the includer and restore the file-position   */
         len = (int) (infile->bptr - infile->buffer);
         infile->buffer = xrealloc( infile->buffer, NBUFF);
             /* Restore full size buffer to get the next line        */
@@ -2294,7 +2289,6 @@ FILEINFO *  get_file(
     file->buffer[ 0] = EOS;                 /* Force first read     */
     file->line = 0L;                        /* (Not used just yet)  */
     file->fp = NULL;                        /* No file yet          */
-    file->pos = 0L;                         /* No pos to remember   */
     file->parent = infile;                  /* Chain files together */
     file->initif = ifptr;                   /* Initial ifstack      */
     file->include_opt = include_opt;        /* Specified by -include*/


### PR DESCRIPTION
Commit 57e2b456b9d54971ab966ff039e6cd8142033d52 eliminated an "unchecked
return" warning from Coverity by simply removing the closing and
re-opening a file when the maximum number of open files is reached.

That left one similar case of now-dead code, causing a new Coverity
defect.  This eliminates that bit of dead code.

Signed-off-by: Erik Boasson <eb@ilities.com>