### PR TITLE
Backport fix for missing braces in mcpp

### DIFF
--- a/src/tools/idlpp/src/support.c
+++ b/src/tools/idlpp/src/support.c
@@ -1802,12 +1802,13 @@ end_line:
             temp++;
         if (*temp == '#'        /* This line starts with # token    */
                 || (mcpp_mode == STD && *temp == '%' && *(temp + 1) == ':'))
-            if (warn_level & 1)
+            if (warn_level & 1) {
                 assert( macro_line >= (ssize_t)LONG_MIN &&
                         macro_line <= (ssize_t)LONG_MAX);
                 cwarn(
     "Macro started at line %.0s%ld swallowed directive-like line"
                     , NULL, (long)macro_line, NULL);              /* _W1_ */
+            }
     }
     return  infile->buffer;
 }


### PR DESCRIPTION
This is a cherry-pick of a0036df2df5bc373b8284662af04997170ae2195 — thanks @homalozoa for pointing it out in #861. 