### PR TITLE
Support const expressions in idl_type_spec

### DIFF
--- a/src/idl/src/tree.c
+++ b/src/idl/src/tree.c
@@ -2749,6 +2749,8 @@ idl_type_spec_t *idl_type_spec(const void *node)
     return ((const idl_sequence_t *)node)->type_spec;
   if (mask & IDL_SWITCH_TYPE_SPEC)
     return ((const idl_switch_type_spec_t *)node)->type_spec;
+  if (mask & IDL_CONST)
+    return ((const idl_const_t *)node)->type_spec;
   return NULL;
 }
 


### PR DESCRIPTION
Addition to help fix [issue 108 in cyclonedds-cxx](https://github.com/eclipse-cyclonedds/cyclonedds-cxx/issues/108).