### PR TITLE
Add missing dds_ prefix to is_loan_available

### DIFF
--- a/src/core/ddsc/include/dds/ddsc/dds_data_allocator.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_data_allocator.h
@@ -118,7 +118,9 @@ DDS_EXPORT dds_return_t dds_data_allocator_free (dds_data_allocator_t *data_allo
  *
  * @returns loan available or not
  */
-DDS_EXPORT bool is_loan_available (const dds_entity_t entity);
+DDS_EXPORT bool dds_is_loan_available (const dds_entity_t entity);
+
+DDS_DEPRECATED_EXPORT bool is_loan_available (const dds_entity_t entity);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsc/src/dds_data_allocator.c
+++ b/src/core/ddsc/src/dds_data_allocator.c
@@ -158,7 +158,7 @@ dds_return_t dds_data_allocator_free (dds_data_allocator_t *data_allocator, void
   return ret;
 }
 
-bool is_loan_available(const dds_entity_t entity)
+bool dds_is_loan_available(const dds_entity_t entity)
 {
   bool ret = false;
 #ifdef DDS_HAS_SHM
@@ -183,4 +183,9 @@ bool is_loan_available(const dds_entity_t entity)
 #endif
   (void) entity;
   return ret;
+}
+
+bool is_loan_available(const dds_entity_t entity)
+{
+  return dds_is_loan_available(entity);
 }


### PR DESCRIPTION
It remains (for now) available under the unprefixed name as deprecated
export.

Signed-off-by: Erik Boasson <eb@ilities.com>