### PR TITLE
Do not list files in CMake add_library INTERFACE

### DIFF
--- a/src/security/api/CMakeLists.txt
+++ b/src/security/api/CMakeLists.txt
@@ -20,7 +20,8 @@ set(headers
   dds_security_api_types.h)
 prepend(headers "${CMAKE_CURRENT_LIST_DIR}/include/dds/security" ${headers})
 
-add_library(security_api INTERFACE ${headers})
+add_library(security_api INTERFACE)
+target_sources(security_api INTERFACE ${headers})
 
 target_include_directories(
   security_api INTERFACE


### PR DESCRIPTION
This is a feature introduced by CMake 3.19, which is a bit too recent.
A separate target_sources command has the same result.

Signed-off-by: Erik Boasson <eb@ilities.com>