### PR TITLE
Make "real" built-in topic entities inaccessible

### DIFF
--- a/src/core/ddsc/src/dds__builtin.h
+++ b/src/core/ddsc/src/dds__builtin.h
@@ -20,6 +20,12 @@ extern "C"
 {
 #endif
 
+/* Get name and typename based from a builtin-topic pseudo-handle; returns an DDS_RETCODE_BAD_PARAMETER if pseudo_handle is invalid */
+dds_return_t dds__get_builtin_topic_name_typename (dds_entity_t pseudo_handle, const char **name, const char **typename);
+
+/* Returns the pseudo handle for the given typename, returns DDS_RETCODE_BAD_PARAMETER if typename isn't one of the built-in topics */
+dds_entity_t dds__get_builtin_topic_pseudo_handle_from_typename (const char *typename);
+
 /* Get actual topic in related participant related to topic 'id'. */
 dds_entity_t dds__get_builtin_topic (dds_entity_t e, dds_entity_t topic);
 

--- a/src/core/ddsc/src/dds__builtin.h
+++ b/src/core/ddsc/src/dds__builtin.h
@@ -29,6 +29,9 @@ dds_entity_t dds__get_builtin_topic_pseudo_handle_from_typename (const char *typ
 /* Get actual topic in related participant related to topic 'id'. */
 dds_entity_t dds__get_builtin_topic (dds_entity_t e, dds_entity_t topic);
 
+/* Constructs the QoS object for a built-in topic QoS */
+dds_qos_t *dds__create_builtin_qos (void);
+
 /* Subscriber singleton within related participant. */
 dds_entity_t dds__get_builtin_subscriber (dds_entity_t e);
 

--- a/src/core/ddsc/src/dds__entity.h
+++ b/src/core/ddsc/src/dds__entity.h
@@ -25,6 +25,7 @@ dds_entity_init(
   dds_entity * parent,
   dds_entity_kind_t kind,
   bool implicit,
+  bool user_access,
   dds_qos_t * qos,
   const dds_listener_t *listener,
   status_mask_t mask);
@@ -125,6 +126,7 @@ DDS_EXPORT void dds_entity_final_deinit_before_free (dds_entity *e);
 DDS_EXPORT bool dds_entity_in_scope (const dds_entity *e, const dds_entity *root);
 
 enum delete_impl_state {
+  DIS_USER,        /* delete invoked directly by application */
   DIS_EXPLICIT,    /* explicit delete on this entity */
   DIS_FROM_PARENT, /* called because the parent is being deleted */
   DIS_IMPLICIT     /* called from child; delete if implicit w/o children */
@@ -137,7 +139,13 @@ dds_entity_pin (
   dds_entity_t hdl,
   dds_entity **eptr);
 
-DDS_EXPORT dds_return_t dds_entity_pin_for_delete (dds_entity_t hdl, bool explicit, dds_entity **eptr);
+DDS_EXPORT dds_return_t
+dds_entity_pin_with_origin (
+  dds_entity_t hdl,
+  bool from_user,
+  dds_entity **eptr);
+
+DDS_EXPORT dds_return_t dds_entity_pin_for_delete (dds_entity_t hdl, bool explicit, bool from_user, dds_entity **eptr);
 
 DDS_EXPORT void dds_entity_unpin (
   dds_entity *e);

--- a/src/core/ddsc/src/dds__handles.h
+++ b/src/core/ddsc/src/dds__handles.h
@@ -77,6 +77,7 @@ typedef int32_t dds_handle_t;
 #define HDL_FLAG_PENDING         (0x20000000u)
 #define HDL_FLAG_IMPLICIT        (0x10000000u)
 #define HDL_FLAG_ALLOW_CHILDREN  (0x08000000u) /* refc counts children */
+#define HDL_FLAG_NO_USER_ACCESS  (0x04000000u)
 
 struct dds_handle_link {
   dds_handle_t hdl;
@@ -120,7 +121,8 @@ DDS_EXPORT dds_handle_t
 dds_handle_create(
         struct dds_handle_link *link,
         bool implicit,
-        bool allow_children);
+        bool allow_children,
+        bool user_access);
 
 
 /*
@@ -168,8 +170,15 @@ dds_handle_pin(
         struct dds_handle_link **entity);
 
 DDS_EXPORT int32_t
-dds_handle_pin_and_ref(
+dds_handle_pin_with_origin(
         dds_handle_t hdl,
+        bool from_user,
+        struct dds_handle_link **entity);
+
+DDS_EXPORT int32_t
+dds_handle_pin_and_ref_with_origin(
+        dds_handle_t hdl,
+        bool from_user,
         struct dds_handle_link **entity);
 
 
@@ -185,7 +194,7 @@ DDS_EXPORT void
 dds_handle_unpin(
         struct dds_handle_link *link);
 
-int32_t dds_handle_pin_for_delete (dds_handle_t hdl, bool explicit, struct dds_handle_link **link);
+int32_t dds_handle_pin_for_delete (dds_handle_t hdl, bool explicit, bool from_user, struct dds_handle_link **link);
 bool dds_handle_drop_childref_and_pin (struct dds_handle_link *link, bool may_delete_parent);
 
 /*

--- a/src/core/ddsc/src/dds__topic.h
+++ b/src/core/ddsc/src/dds__topic.h
@@ -23,6 +23,7 @@ DEFINE_ENTITY_LOCK_UNLOCK(inline, dds_topic, DDS_KIND_TOPIC)
 
 DDS_EXPORT void dds_topic_free (dds_domainid_t domainid, struct ddsi_sertype * st) ddsrt_nonnull_all;
 
+DDS_EXPORT dds_return_t dds_topic_pin_with_origin (dds_entity_t handle, bool from_user, struct dds_topic **tp) ddsrt_nonnull_all;
 DDS_EXPORT dds_return_t dds_topic_pin (dds_entity_t handle, struct dds_topic **tp) ddsrt_nonnull_all;
 DDS_EXPORT void dds_topic_unpin (struct dds_topic *tp) ddsrt_nonnull_all;
 DDS_EXPORT void dds_topic_defer_set_qos (struct dds_topic *tp) ddsrt_nonnull_all;

--- a/src/core/ddsc/src/dds__topic.h
+++ b/src/core/ddsc/src/dds__topic.h
@@ -45,10 +45,6 @@ DDS_EXPORT dds_entity_t dds_create_topic_impl (
     const ddsi_plist_t *sedp_plist,
     bool is_builtin);
 
-DDS_EXPORT dds_return_t dds_get_name_size (dds_entity_t topic, size_t *size);
-
-DDS_EXPORT dds_return_t dds_get_type_name_size (dds_entity_t topic, size_t *size);
-
 #if defined (__cplusplus)
 }
 #endif

--- a/src/core/ddsc/src/dds_builtin.c
+++ b/src/core/ddsc/src/dds_builtin.c
@@ -25,6 +25,7 @@
 #include "dds__builtin.h"
 #include "dds__entity.h"
 #include "dds__subscriber.h"
+#include "dds__qos.h"
 #include "dds__topic.h"
 #include "dds__write.h"
 #include "dds__writer.h"
@@ -33,7 +34,7 @@
 #include "dds/ddsi/q_qosmatch.h"
 #include "dds/ddsi/ddsi_tkmap.h"
 
-static dds_qos_t *dds__create_builtin_qos (void)
+dds_qos_t *dds__create_builtin_qos (void)
 {
   const char *partition = "__BUILT-IN PARTITION__";
   dds_qos_t *qos = dds_create_qos ();
@@ -41,6 +42,11 @@ static dds_qos_t *dds__create_builtin_qos (void)
   dds_qset_presentation (qos, DDS_PRESENTATION_TOPIC, false, false);
   dds_qset_reliability (qos, DDS_RELIABILITY_RELIABLE, DDS_MSECS(100));
   dds_qset_partition (qos, 1, &partition);
+  // FIXME: make the various default QoS compile-time constants
+  dds_qos_t *dq = dds_create_qos ();
+  ddsi_xqos_init_default_topic (dq);
+  ddsi_xqos_mergein_missing (qos, dq, DDS_TOPIC_QOS_MASK);
+  dds_delete_qos (dq);
   return qos;
 }
 

--- a/src/core/ddsc/src/dds_builtin.c
+++ b/src/core/ddsc/src/dds_builtin.c
@@ -42,11 +42,7 @@ dds_qos_t *dds__create_builtin_qos (void)
   dds_qset_presentation (qos, DDS_PRESENTATION_TOPIC, false, false);
   dds_qset_reliability (qos, DDS_RELIABILITY_RELIABLE, DDS_MSECS(100));
   dds_qset_partition (qos, 1, &partition);
-  // FIXME: make the various default QoS compile-time constants
-  dds_qos_t *dq = dds_create_qos ();
-  ddsi_xqos_init_default_topic (dq);
-  ddsi_xqos_mergein_missing (qos, dq, DDS_TOPIC_QOS_MASK);
-  dds_delete_qos (dq);
+  ddsi_xqos_mergein_missing (qos, &ddsi_default_qos_topic, DDS_TOPIC_QOS_MASK);
   return qos;
 }
 

--- a/src/core/ddsc/src/dds_builtin.c
+++ b/src/core/ddsc/src/dds_builtin.c
@@ -44,6 +44,58 @@ static dds_qos_t *dds__create_builtin_qos (void)
   return qos;
 }
 
+static const struct {
+  dds_entity_t pseudo_handle;
+  const char *name;
+  const char *typename;
+} builtin_topic_list[] = {
+  { DDS_BUILTIN_TOPIC_DCPSPARTICIPANT, DDS_BUILTIN_TOPIC_PARTICIPANT_NAME, "org::eclipse::cyclonedds::builtin::DCPSParticipant" },
+  { DDS_BUILTIN_TOPIC_DCPSTOPIC, DDS_BUILTIN_TOPIC_TOPIC_NAME, "org::eclipse::cyclonedds::builtin::DCPSTopic" },
+  { DDS_BUILTIN_TOPIC_DCPSPUBLICATION, DDS_BUILTIN_TOPIC_PUBLICATION_NAME, "org::eclipse::cyclonedds::builtin::DCPSPublication" },
+  { DDS_BUILTIN_TOPIC_DCPSSUBSCRIPTION, DDS_BUILTIN_TOPIC_SUBSCRIPTION_NAME, "org::eclipse::cyclonedds::builtin::DCPSSubscription" }
+};
+
+dds_return_t dds__get_builtin_topic_name_typename (dds_entity_t pseudo_handle, const char **name, const char **typename)
+{
+  const char *n;
+  const char *tn;
+  // avoid a search (mostly because we can)
+  DDSRT_STATIC_ASSERT (DDS_BUILTIN_TOPIC_DCPSTOPIC == DDS_BUILTIN_TOPIC_DCPSPARTICIPANT + 1 &&
+                       DDS_BUILTIN_TOPIC_DCPSPUBLICATION == DDS_BUILTIN_TOPIC_DCPSTOPIC + 1 &&
+                       DDS_BUILTIN_TOPIC_DCPSSUBSCRIPTION == DDS_BUILTIN_TOPIC_DCPSPUBLICATION + 1);
+  switch (pseudo_handle)
+  {
+    case DDS_BUILTIN_TOPIC_DCPSPARTICIPANT:
+    case DDS_BUILTIN_TOPIC_DCPSTOPIC:
+    case DDS_BUILTIN_TOPIC_DCPSPUBLICATION:
+    case DDS_BUILTIN_TOPIC_DCPSSUBSCRIPTION: {
+      dds_entity_t idx = pseudo_handle - DDS_BUILTIN_TOPIC_DCPSPARTICIPANT;
+      n = builtin_topic_list[idx].name;
+      tn = builtin_topic_list[idx].typename;
+      break;
+    }
+    default: {
+      // no assert: this is also used by some API calls
+      return DDS_RETCODE_BAD_PARAMETER;
+    }
+  }
+  if (name)
+    *name = n;
+  if (typename)
+    *typename = tn;
+  return 0;
+}
+
+dds_entity_t dds__get_builtin_topic_pseudo_handle_from_typename (const char *typename)
+{
+  for (size_t i = 0; i < sizeof (builtin_topic_list) / sizeof (builtin_topic_list[0]); i++)
+  {
+    if (strcmp (typename, builtin_topic_list[i].typename) == 0)
+      return builtin_topic_list[i].pseudo_handle;
+  }
+  return DDS_RETCODE_BAD_PARAMETER;
+}
+
 dds_entity_t dds__get_builtin_topic (dds_entity_t entity, dds_entity_t topic)
 {
   dds_entity_t tp;
@@ -59,26 +111,23 @@ dds_entity_t dds__get_builtin_topic (dds_entity_t entity, dds_entity_t topic)
     return DDS_RETCODE_ILLEGAL_OPERATION;
   }
 
-  char *topic_name;
+  const char *topic_name;
   struct ddsi_sertype *sertype;
+  (void) dds__get_builtin_topic_name_typename (topic, &topic_name, NULL);
   switch (topic)
   {
     case DDS_BUILTIN_TOPIC_DCPSPARTICIPANT:
-      topic_name = DDS_BUILTIN_TOPIC_PARTICIPANT_NAME;
       sertype = e->m_domain->builtin_participant_type;
       break;
 #ifdef DDS_HAS_TOPIC_DISCOVERY
     case DDS_BUILTIN_TOPIC_DCPSTOPIC:
-      topic_name = DDS_BUILTIN_TOPIC_TOPIC_NAME;
       sertype = e->m_domain->builtin_topic_type;
       break;
 #endif
     case DDS_BUILTIN_TOPIC_DCPSPUBLICATION:
-      topic_name = DDS_BUILTIN_TOPIC_PUBLICATION_NAME;
       sertype = e->m_domain->builtin_writer_type;
       break;
     case DDS_BUILTIN_TOPIC_DCPSSUBSCRIPTION:
-      topic_name = DDS_BUILTIN_TOPIC_SUBSCRIPTION_NAME;
       sertype = e->m_domain->builtin_reader_type;
       break;
     default:
@@ -332,12 +381,17 @@ void dds__builtin_init (struct dds_domain *dom)
 #endif
   dom->gv.builtin_topic_interface = &dom->btif;
 
-  dom->builtin_participant_type = new_sertype_builtintopic (DSBT_PARTICIPANT, "org::eclipse::cyclonedds::builtin::DCPSParticipant");
+  const char *typename;
+  (void) dds__get_builtin_topic_name_typename (DDS_BUILTIN_TOPIC_DCPSPARTICIPANT, NULL, &typename);
+  dom->builtin_participant_type = new_sertype_builtintopic (DSBT_PARTICIPANT, typename);
 #ifdef DDS_HAS_TOPIC_DISCOVERY
-  dom->builtin_topic_type = new_sertype_builtintopic_topic (DSBT_TOPIC, "org::eclipse::cyclonedds::builtin::DCPSTopic");
+  (void) dds__get_builtin_topic_name_typename (DDS_BUILTIN_TOPIC_DCPSTOPIC, NULL, &typename);
+  dom->builtin_topic_type = new_sertype_builtintopic_topic (DSBT_TOPIC, typename);
 #endif
-  dom->builtin_reader_type = new_sertype_builtintopic (DSBT_READER, "org::eclipse::cyclonedds::builtin::DCPSSubscription");
-  dom->builtin_writer_type = new_sertype_builtintopic (DSBT_WRITER, "org::eclipse::cyclonedds::builtin::DCPSPublication");
+  (void) dds__get_builtin_topic_name_typename (DDS_BUILTIN_TOPIC_DCPSSUBSCRIPTION, NULL, &typename);
+  dom->builtin_reader_type = new_sertype_builtintopic (DSBT_READER, typename);
+  (void) dds__get_builtin_topic_name_typename (DDS_BUILTIN_TOPIC_DCPSPUBLICATION, NULL, &typename);
+  dom->builtin_writer_type = new_sertype_builtintopic (DSBT_WRITER, typename);
 
   ddsrt_mutex_lock (&dom->gv.sertypes_lock);
   ddsi_sertype_register_locked (&dom->gv, dom->builtin_participant_type);

--- a/src/core/ddsc/src/dds_domain.c
+++ b/src/core/ddsc/src/dds_domain.c
@@ -68,7 +68,7 @@ static dds_entity_t dds_domain_init (dds_domain *domain, dds_domainid_t domain_i
   dds_entity_t domh;
   uint32_t len;
 
-  if ((domh = dds_entity_init (&domain->m_entity, &dds_global.m_entity, DDS_KIND_DOMAIN, implicit, NULL, NULL, 0)) < 0)
+  if ((domh = dds_entity_init (&domain->m_entity, &dds_global.m_entity, DDS_KIND_DOMAIN, implicit, true, NULL, NULL, 0)) < 0)
     return domh;
   domain->m_entity.m_domain = domain;
   domain->m_entity.m_iid = ddsi_iid_gen ();

--- a/src/core/ddsc/src/dds_entity.c
+++ b/src/core/ddsc/src/dds_entity.c
@@ -259,7 +259,7 @@ dds_entity_t dds_entity_init (dds_entity *e, dds_entity *parent, dds_entity_kind
   {
     /* for topics, refc counts readers/writers, for all others, it counts children (this we can get away with
        as long as topics can't have children) */
-    if ((handle = dds_handle_create (&e->m_hdllink, implicit, entity_may_have_children (e))) <= 0)
+    if ((handle = dds_handle_create (&e->m_hdllink, implicit, entity_may_have_children (e), true)) <= 0)
       return (dds_entity_t) handle;
   }
 
@@ -1281,7 +1281,7 @@ dds_return_t dds_entity_pin_for_delete (dds_entity_t hdl, bool explicit, dds_ent
 {
   dds_return_t hres;
   struct dds_handle_link *hdllink;
-  if ((hres = dds_handle_pin_for_delete (hdl, explicit, &hdllink)) < 0)
+  if ((hres = dds_handle_pin_for_delete (hdl, explicit, true, &hdllink)) < 0)
     return hres;
   else
   {

--- a/src/core/ddsc/src/dds_guardcond.c
+++ b/src/core/ddsc/src/dds_guardcond.c
@@ -59,7 +59,7 @@ dds_entity_t dds_create_guardcondition (dds_entity_t owner)
   }
 
   dds_guardcond *gcond = dds_alloc (sizeof (*gcond));
-  dds_entity_t hdl = dds_entity_init (&gcond->m_entity, e, DDS_KIND_COND_GUARD, false, NULL, NULL, 0);
+  dds_entity_t hdl = dds_entity_init (&gcond->m_entity, e, DDS_KIND_COND_GUARD, false, true, NULL, NULL, 0);
   gcond->m_entity.m_iid = ddsi_iid_gen ();
   dds_entity_register_child (e, &gcond->m_entity);
   dds_entity_init_complete (&gcond->m_entity);

--- a/src/core/ddsc/src/dds_handles.c
+++ b/src/core/ddsc/src/dds_handles.c
@@ -20,7 +20,7 @@
 #include "dds__handles.h"
 #include "dds__types.h"
 
-#define HDL_REFCOUNT_MASK  (0x07fff000u)
+#define HDL_REFCOUNT_MASK  (0x03fff000u)
 #define HDL_REFCOUNT_UNIT  (0x00001000u)
 #define HDL_REFCOUNT_SHIFT 12
 #define HDL_PINCOUNT_MASK  (0x00000fffu)
@@ -119,9 +119,13 @@ void dds_handle_server_fini (void)
 }
 
 static bool hhadd (struct ddsrt_hh *ht, void *elem) { return ddsrt_hh_add (ht, elem); }
-static dds_handle_t dds_handle_create_int (struct dds_handle_link *link, bool implicit, bool refc_counts_children)
+static dds_handle_t dds_handle_create_int (struct dds_handle_link *link, bool implicit, bool refc_counts_children, bool user_access)
 {
-  ddsrt_atomic_st32 (&link->cnt_flags, HDL_FLAG_PENDING | (implicit ? HDL_FLAG_IMPLICIT : HDL_REFCOUNT_UNIT) | (refc_counts_children ? HDL_FLAG_ALLOW_CHILDREN : 0) | 1u);
+  uint32_t flags = HDL_FLAG_PENDING;
+  flags |= implicit ? HDL_FLAG_IMPLICIT : HDL_REFCOUNT_UNIT;
+  flags |= refc_counts_children ? HDL_FLAG_ALLOW_CHILDREN : 0;
+  flags |= user_access ? 0 : HDL_FLAG_NO_USER_ACCESS;
+  ddsrt_atomic_st32 (&link->cnt_flags, flags | 1u);
   do {
     do {
       link->hdl = (int32_t) (ddsrt_random () & INT32_MAX);
@@ -130,7 +134,7 @@ static dds_handle_t dds_handle_create_int (struct dds_handle_link *link, bool im
   return link->hdl;
 }
 
-dds_handle_t dds_handle_create (struct dds_handle_link *link, bool implicit, bool allow_children)
+dds_handle_t dds_handle_create (struct dds_handle_link *link, bool implicit, bool allow_children, bool user_access)
 {
   dds_handle_t ret;
   ddsrt_mutex_lock (&handles.lock);
@@ -142,7 +146,7 @@ dds_handle_t dds_handle_create (struct dds_handle_link *link, bool implicit, boo
   else
   {
     handles.count++;
-    ret = dds_handle_create_int (link, implicit, allow_children);
+    ret = dds_handle_create_int (link, implicit, allow_children, user_access);
     ddsrt_mutex_unlock (&handles.lock);
     assert (ret > 0);
   }
@@ -210,7 +214,7 @@ int32_t dds_handle_delete (struct dds_handle_link *link)
   return DDS_RETCODE_OK;
 }
 
-static int32_t dds_handle_pin_int (dds_handle_t hdl, uint32_t delta, struct dds_handle_link **link)
+static int32_t dds_handle_pin_int (dds_handle_t hdl, uint32_t delta, bool from_user, struct dds_handle_link **link)
 {
   struct dds_handle_link dummy = { .hdl = hdl };
   int32_t rc;
@@ -237,10 +241,18 @@ static int32_t dds_handle_pin_int (dds_handle_t hdl, uint32_t delta, struct dds_
     rc = DDS_RETCODE_OK;
     do {
       cf = ddsrt_atomic_ld32 (&(*link)->cnt_flags);
-      if (cf & (HDL_FLAG_CLOSING | HDL_FLAG_PENDING))
+      if (cf & (HDL_FLAG_CLOSING | HDL_FLAG_PENDING | HDL_FLAG_NO_USER_ACCESS))
       {
-        rc = DDS_RETCODE_BAD_PARAMETER;
-        break;
+        if (cf & (HDL_FLAG_CLOSING | HDL_FLAG_PENDING))
+        {
+          rc = DDS_RETCODE_BAD_PARAMETER;
+          break;
+        }
+        else if (from_user)
+        {
+          rc = DDS_RETCODE_BAD_PARAMETER;
+          break;
+        }
       }
     } while (!ddsrt_atomic_cas32 (&(*link)->cnt_flags, cf, cf + delta));
   }
@@ -250,10 +262,15 @@ static int32_t dds_handle_pin_int (dds_handle_t hdl, uint32_t delta, struct dds_
 
 int32_t dds_handle_pin (dds_handle_t hdl, struct dds_handle_link **link)
 {
-  return dds_handle_pin_int (hdl, 1u, link);
+  return dds_handle_pin_int (hdl, 1u, true, link);
 }
 
-int32_t dds_handle_pin_for_delete (dds_handle_t hdl, bool explicit, struct dds_handle_link **link)
+int32_t dds_handle_pin_with_origin (dds_handle_t hdl, bool from_user, struct dds_handle_link **link)
+{
+  return dds_handle_pin_int (hdl, 1u, from_user, link);
+}
+
+int32_t dds_handle_pin_for_delete (dds_handle_t hdl, bool explicit, bool from_user, struct dds_handle_link **link)
 {
   struct dds_handle_link dummy = { .hdl = hdl };
   int32_t rc;
@@ -280,7 +297,13 @@ int32_t dds_handle_pin_for_delete (dds_handle_t hdl, bool explicit, struct dds_h
     do {
       cf = ddsrt_atomic_ld32 (&(*link)->cnt_flags);
 
-      if (cf & (HDL_FLAG_CLOSING | HDL_FLAG_PENDING))
+      if (from_user && (cf & (HDL_FLAG_NO_USER_ACCESS)))
+      {
+        /* If the user isn't allowed to delete the handle, just say it doesn't exist */
+        rc = DDS_RETCODE_BAD_PARAMETER;
+        break;
+      }
+      else if (cf & (HDL_FLAG_CLOSING | HDL_FLAG_PENDING))
       {
         /* Only one can succeed (and if closing is already set, the handle's reference has
            already been dropped) */
@@ -416,9 +439,9 @@ bool dds_handle_drop_childref_and_pin (struct dds_handle_link *link, bool may_de
   return del_parent;
 }
 
-int32_t dds_handle_pin_and_ref (dds_handle_t hdl, struct dds_handle_link **link)
+int32_t dds_handle_pin_and_ref_with_origin (dds_handle_t hdl, bool from_user, struct dds_handle_link **link)
 {
-  return dds_handle_pin_int (hdl, HDL_REFCOUNT_UNIT + 1u, link);
+  return dds_handle_pin_int (hdl, HDL_REFCOUNT_UNIT + 1u, from_user, link);
 }
 
 void dds_handle_repin (struct dds_handle_link *link)

--- a/src/core/ddsc/src/dds_init.c
+++ b/src/core/ddsc/src/dds_init.c
@@ -121,7 +121,7 @@ dds_return_t dds_init (void)
     goto fail_handleserver;
   }
 
-  dds_entity_init (&dds_global.m_entity, NULL, DDS_KIND_CYCLONEDDS, true, NULL, NULL, 0);
+  dds_entity_init (&dds_global.m_entity, NULL, DDS_KIND_CYCLONEDDS, true, true, NULL, NULL, 0);
   dds_global.m_entity.m_iid = ddsi_iid_gen ();
   dds_handle_repin (&dds_global.m_entity.m_hdllink);
   dds_entity_add_ref_locked (&dds_global.m_entity);

--- a/src/core/ddsc/src/dds_init.c
+++ b/src/core/ddsc/src/dds_init.c
@@ -75,7 +75,7 @@ static bool cyclonedds_entity_ready (uint32_t s)
   else
   {
     struct dds_handle_link *x;
-    return dds_handle_pin_and_ref (DDS_CYCLONEDDS_HANDLE, &x) == DDS_RETCODE_OK;
+    return dds_handle_pin_and_ref_with_origin (DDS_CYCLONEDDS_HANDLE, false, &x) == DDS_RETCODE_OK;
   }
 }
 

--- a/src/core/ddsc/src/dds_participant.c
+++ b/src/core/ddsc/src/dds_participant.c
@@ -131,7 +131,7 @@ dds_entity_t dds_create_participant (const dds_domainid_t domain, const dds_qos_
   }
 
   pp = dds_alloc (sizeof (*pp));
-  if ((ret = dds_entity_init (&pp->m_entity, &dom->m_entity, DDS_KIND_PARTICIPANT, false, new_qos, listener, DDS_PARTICIPANT_STATUS_MASK)) < 0)
+  if ((ret = dds_entity_init (&pp->m_entity, &dom->m_entity, DDS_KIND_PARTICIPANT, false, true, new_qos, listener, DDS_PARTICIPANT_STATUS_MASK)) < 0)
     goto err_entity_init;
 
   pp->m_entity.m_guid = guid;

--- a/src/core/ddsc/src/dds_publisher.c
+++ b/src/core/ddsc/src/dds_publisher.c
@@ -66,7 +66,7 @@ dds_entity_t dds__create_publisher_l (dds_participant *par, bool implicit, const
   }
 
   pub = dds_alloc (sizeof (*pub));
-  hdl = dds_entity_init (&pub->m_entity, &par->m_entity, DDS_KIND_PUBLISHER, implicit, new_qos, listener, DDS_PUBLISHER_STATUS_MASK);
+  hdl = dds_entity_init (&pub->m_entity, &par->m_entity, DDS_KIND_PUBLISHER, implicit, true, new_qos, listener, DDS_PUBLISHER_STATUS_MASK);
   pub->m_entity.m_iid = ddsi_iid_gen ();
   dds_entity_register_child (&par->m_entity, &pub->m_entity);
   dds_entity_init_complete (&pub->m_entity);

--- a/src/core/ddsc/src/dds_publisher.c
+++ b/src/core/ddsc/src/dds_publisher.c
@@ -58,7 +58,7 @@ dds_entity_t dds__create_publisher_l (dds_participant *par, bool implicit, const
   new_qos = dds_create_qos ();
   if (qos)
     ddsi_xqos_mergein_missing (new_qos, qos, DDS_PUBLISHER_QOS_MASK);
-  ddsi_xqos_mergein_missing (new_qos, &par->m_entity.m_domain->gv.default_xqos_pub, ~(uint64_t)0);
+  ddsi_xqos_mergein_missing (new_qos, &ddsi_default_qos_publisher_subscriber, ~(uint64_t)0);
   if ((ret = ddsi_xqos_valid (&par->m_entity.m_domain->gv.logconfig, new_qos)) != DDS_RETCODE_OK)
   {
     dds_participant_unlock (par);

--- a/src/core/ddsc/src/dds_readcond.c
+++ b/src/core/ddsc/src/dds_readcond.c
@@ -45,7 +45,7 @@ dds_readcond *dds_create_readcond (dds_reader *rd, dds_entity_kind_t kind, uint3
 {
   dds_readcond *cond = dds_alloc (sizeof (*cond));
   assert ((kind == DDS_KIND_COND_READ && filter == 0) || (kind == DDS_KIND_COND_QUERY && filter != 0));
-  (void) dds_entity_init (&cond->m_entity, &rd->m_entity, kind, false, NULL, NULL, 0);
+  (void) dds_entity_init (&cond->m_entity, &rd->m_entity, kind, false, true, NULL, NULL, 0);
   cond->m_entity.m_iid = ddsi_iid_gen ();
   dds_entity_register_child (&rd->m_entity, &cond->m_entity);
   cond->m_sample_states = mask & DDS_ANY_SAMPLE_STATE;

--- a/src/core/ddsc/src/dds_reader.c
+++ b/src/core/ddsc/src/dds_reader.c
@@ -550,7 +550,7 @@ static dds_entity_t dds_create_reader_int (dds_entity_t participant_or_subscribe
     ddsi_xqos_mergein_missing (rqos, sub->m_entity.m_qos, ~(uint64_t)0);
   if (tp->m_ktopic->qos)
     ddsi_xqos_mergein_missing (rqos, tp->m_ktopic->qos, ~(uint64_t)0);
-  ddsi_xqos_mergein_missing (rqos, &gv->default_xqos_rd, ~(uint64_t)0);
+  ddsi_xqos_mergein_missing (rqos, &ddsi_default_qos_reader, ~(uint64_t)0);
 
   if ((rc = ddsi_xqos_valid (&gv->logconfig, rqos)) < 0 || (rc = validate_reader_qos(rqos)) != DDS_RETCODE_OK)
     goto err_bad_qos;

--- a/src/core/ddsc/src/dds_reader.c
+++ b/src/core/ddsc/src/dds_reader.c
@@ -519,7 +519,9 @@ static dds_entity_t dds_create_reader_int (dds_entity_t participant_or_subscribe
     }
   }
 
-  if ((rc = dds_topic_pin (topic, &tp)) < 0)
+  /* If pseudo_topic != 0, topic didn't didn't originate from the application and we allow pinning
+     it despite it being marked as NO_USER_ACCESS */
+  if ((rc = dds_topic_pin_with_origin (topic, pseudo_topic ? false : true, &tp)) < 0)
     goto err_pin_topic;
   assert (tp->m_stype);
   if (dds_entity_participant (&sub->m_entity) != dds_entity_participant (&tp->m_entity))

--- a/src/core/ddsc/src/dds_reader.c
+++ b/src/core/ddsc/src/dds_reader.c
@@ -586,7 +586,7 @@ static dds_entity_t dds_create_reader_int (dds_entity_t participant_or_subscribe
 
   /* Create reader and associated read cache (if not provided by caller) */
   struct dds_reader * const rd = dds_alloc (sizeof (*rd));
-  const dds_entity_t reader = dds_entity_init (&rd->m_entity, &sub->m_entity, DDS_KIND_READER, false, rqos, listener, DDS_READER_STATUS_MASK);
+  const dds_entity_t reader = dds_entity_init (&rd->m_entity, &sub->m_entity, DDS_KIND_READER, false, true, rqos, listener, DDS_READER_STATUS_MASK);
   rd->m_sample_rejected_status.last_reason = DDS_NOT_REJECTED;
   rd->m_topic = tp;
   rd->m_wrapped_sertopic = (tp->m_stype->wrapped_sertopic != NULL) ? 1 : 0;

--- a/src/core/ddsc/src/dds_reader.c
+++ b/src/core/ddsc/src/dds_reader.c
@@ -616,18 +616,7 @@ static dds_entity_t dds_create_reader_int (dds_entity_t participant_or_subscribe
 #ifdef DDS_HAS_SHM
   if (0x0 == (rqos->ignore_locator_type & NN_LOCATOR_KIND_SHEM))
   {
-    size_t name_size, type_name_size;
-    rc = dds_get_name_size(topic, &name_size);
-    assert(rc == DDS_RETCODE_OK);
-    rc = dds_get_type_name_size(topic, &type_name_size);
-    assert(rc == DDS_RETCODE_OK);
-    char topic_name[name_size + 1];
-    char type_name[type_name_size + 1];
-    rc = dds_get_name(topic, topic_name, name_size + 1);
-    assert(rc == DDS_RETCODE_OK);
-    rc = dds_get_type_name(topic, type_name, type_name_size + 1);
-    assert(rc == DDS_RETCODE_OK);
-    DDS_CLOG (DDS_LC_SHM, &rd->m_entity.m_domain->gv.logconfig, "Reader's topic name will be DDS:Cyclone:%s\n", topic_name);
+    DDS_CLOG (DDS_LC_SHM, &rd->m_entity.m_domain->gv.logconfig, "Reader's topic name will be DDS:Cyclone:%s\n", rd->m_topic->m_name);
 
     iox_sub_options_t opts;
     iox_sub_options_init(&opts);
@@ -638,7 +627,7 @@ static dds_entity_t dds_create_reader_int (dds_entity_t participant_or_subscribe
     assert (rqos->durability.kind == DDS_DURABILITY_VOLATILE);
     opts.queueCapacity = rd->m_entity.m_domain->gv.config.sub_queue_capacity;
     opts.historyRequest = 0;
-    rd->m_iox_sub = iox_sub_init(&rd->m_iox_sub_stor.storage, gv->config.iceoryx_service, type_name, topic_name, &opts);
+    rd->m_iox_sub = iox_sub_init(&rd->m_iox_sub_stor.storage, gv->config.iceoryx_service, rd->m_topic->m_stype->type_name, rd->m_topic->m_name, &opts);
     shm_monitor_attach_reader(&rd->m_entity.m_domain->m_shm_monitor, rd);
 
     // those are set once and never changed

--- a/src/core/ddsc/src/dds_subscriber.c
+++ b/src/core/ddsc/src/dds_subscriber.c
@@ -66,7 +66,7 @@ dds_entity_t dds__create_subscriber_l (dds_participant *participant, bool implic
   }
 
   sub = dds_alloc (sizeof (*sub));
-  subscriber = dds_entity_init (&sub->m_entity, &participant->m_entity, DDS_KIND_SUBSCRIBER, implicit, new_qos, listener, DDS_SUBSCRIBER_STATUS_MASK);
+  subscriber = dds_entity_init (&sub->m_entity, &participant->m_entity, DDS_KIND_SUBSCRIBER, implicit, true, new_qos, listener, DDS_SUBSCRIBER_STATUS_MASK);
   sub->m_entity.m_iid = ddsi_iid_gen ();
   dds_entity_register_child (&participant->m_entity, &sub->m_entity);
   dds_entity_init_complete (&sub->m_entity);

--- a/src/core/ddsc/src/dds_subscriber.c
+++ b/src/core/ddsc/src/dds_subscriber.c
@@ -58,7 +58,7 @@ dds_entity_t dds__create_subscriber_l (dds_participant *participant, bool implic
   new_qos = dds_create_qos ();
   if (qos)
     ddsi_xqos_mergein_missing (new_qos, qos, DDS_SUBSCRIBER_QOS_MASK);
-  ddsi_xqos_mergein_missing (new_qos, &participant->m_entity.m_domain->gv.default_xqos_sub, ~(uint64_t)0);
+  ddsi_xqos_mergein_missing (new_qos, &ddsi_default_qos_publisher_subscriber, ~(uint64_t)0);
   if ((ret = ddsi_xqos_valid (&participant->m_entity.m_domain->gv.logconfig, new_qos)) != DDS_RETCODE_OK)
   {
     dds_delete_qos (new_qos);

--- a/src/core/ddsc/src/dds_topic.c
+++ b/src/core/ddsc/src/dds_topic.c
@@ -1023,32 +1023,6 @@ dds_topic_filter_fn dds_topic_get_filter (dds_entity_t topic)
   return dds_get_topic_filter_deprecated (topic);
 }
 
-dds_return_t dds_get_name_size (dds_entity_t topic, size_t *size)
-{
-  dds_topic *t;
-  dds_return_t ret;
-  if (size == NULL)
-    return DDS_RETCODE_BAD_PARAMETER;
-  if ((ret = dds_topic_pin (topic, &t)) != DDS_RETCODE_OK)
-    return ret;
-  *size = strlen (t->m_name);
-  dds_topic_unpin (t);
-  return DDS_RETCODE_OK;
-}
-
-dds_return_t dds_get_type_name_size (dds_entity_t topic, size_t *size)
-{
-  dds_topic *t;
-  dds_return_t ret;
-  if (size == NULL)
-    return DDS_RETCODE_BAD_PARAMETER;
-  if ((ret = dds_topic_pin (topic, &t)) != DDS_RETCODE_OK)
-    return ret;
-  *size = strlen (t->m_stype->type_name);
-  dds_topic_unpin (t);
-  return DDS_RETCODE_OK;
-}
-
 dds_return_t dds_get_name (dds_entity_t topic, char *name, size_t size)
 {
   dds_topic *t;

--- a/src/core/ddsc/src/dds_topic.c
+++ b/src/core/ddsc/src/dds_topic.c
@@ -333,7 +333,7 @@ static dds_entity_t create_topic_pp_locked (struct dds_participant *pp, struct d
   (void) sedp_plist;
   dds_entity_t hdl;
   dds_topic *tp = dds_alloc (sizeof (*tp));
-  hdl = dds_entity_init (&tp->m_entity, &pp->m_entity, DDS_KIND_TOPIC, implicit, NULL, listener, DDS_TOPIC_STATUS_MASK);
+  hdl = dds_entity_init (&tp->m_entity, &pp->m_entity, DDS_KIND_TOPIC, implicit, true, NULL, listener, DDS_TOPIC_STATUS_MASK);
   tp->m_entity.m_iid = ddsi_iid_gen ();
   dds_entity_register_child (&pp->m_entity, &tp->m_entity);
   tp->m_ktopic = ktp;

--- a/src/core/ddsc/src/dds_waitset.c
+++ b/src/core/ddsc/src/dds_waitset.c
@@ -168,7 +168,7 @@ dds_entity_t dds_create_waitset (dds_entity_t owner)
   }
 
   dds_waitset *waitset = dds_alloc (sizeof (*waitset));
-  dds_entity_t hdl = dds_entity_init (&waitset->m_entity, e, DDS_KIND_WAITSET, false, NULL, NULL, 0);
+  dds_entity_t hdl = dds_entity_init (&waitset->m_entity, e, DDS_KIND_WAITSET, false, true, NULL, NULL, 0);
   ddsrt_mutex_init (&waitset->wait_lock);
   ddsrt_cond_init (&waitset->wait_cond);
   waitset->m_entity.m_iid = ddsi_iid_gen ();

--- a/src/core/ddsc/src/dds_writer.c
+++ b/src/core/ddsc/src/dds_writer.c
@@ -379,7 +379,7 @@ dds_entity_t dds_create_writer (dds_entity_t participant_or_publisher, dds_entit
     ddsi_xqos_mergein_missing (wqos, pub->m_entity.m_qos, ~(uint64_t)0);
   if (tp->m_ktopic->qos)
     ddsi_xqos_mergein_missing (wqos, tp->m_ktopic->qos, ~(uint64_t)0);
-  ddsi_xqos_mergein_missing (wqos, &gv->default_xqos_wr, ~(uint64_t)0);
+  ddsi_xqos_mergein_missing (wqos, &ddsi_default_qos_writer, ~(uint64_t)0);
 
   if ((rc = ddsi_xqos_valid (&gv->logconfig, wqos)) < 0 || (rc = validate_writer_qos(wqos)) != DDS_RETCODE_OK)
     goto err_bad_qos;

--- a/src/core/ddsc/src/dds_writer.c
+++ b/src/core/ddsc/src/dds_writer.c
@@ -410,7 +410,7 @@ dds_entity_t dds_create_writer (dds_entity_t participant_or_publisher, dds_entit
 
   /* Create writer */
   struct dds_writer * const wr = dds_alloc (sizeof (*wr));
-  const dds_entity_t writer = dds_entity_init (&wr->m_entity, &pub->m_entity, DDS_KIND_WRITER, false, wqos, listener, DDS_WRITER_STATUS_MASK);
+  const dds_entity_t writer = dds_entity_init (&wr->m_entity, &pub->m_entity, DDS_KIND_WRITER, false, true, wqos, listener, DDS_WRITER_STATUS_MASK);
   wr->m_topic = tp;
   dds_entity_add_ref_locked (&tp->m_entity);
   wr->m_xp = nn_xpack_new (gv, get_bandwidth_limit (wqos->transport_priority), async_mode);

--- a/src/core/ddsc/src/dds_writer.c
+++ b/src/core/ddsc/src/dds_writer.c
@@ -432,23 +432,11 @@ dds_entity_t dds_create_writer (dds_entity_t participant_or_publisher, dds_entit
 #ifdef DDS_HAS_SHM
   if (0x0 == (wqos->ignore_locator_type & NN_LOCATOR_KIND_SHEM))
   {
-    size_t name_size, type_name_size;
-    rc = dds_get_name_size (topic, &name_size);
-    assert(rc == DDS_RETCODE_OK);
-    rc = dds_get_type_name_size (topic, &type_name_size);
-    assert (rc == DDS_RETCODE_OK);
-    char topic_name[name_size+1];
-    char type_name[type_name_size+1];
-    rc = dds_get_name (topic, topic_name, name_size+1);
-    assert(rc == DDS_RETCODE_OK);
-    rc = dds_get_type_name (topic, type_name, type_name_size+1);
-    assert (rc == DDS_RETCODE_OK);
-    DDS_CLOG (DDS_LC_SHM, &wr->m_entity.m_domain->gv.logconfig, "Writer's topic name will be DDS:Cyclone:%s\n", topic_name);
-    // SHM_TODO: We should do error handling if there is duplicate publish topic. iceoryx doesn't support multiple pub now.
+    DDS_CLOG (DDS_LC_SHM, &wr->m_entity.m_domain->gv.logconfig, "Writer's topic name will be DDS:Cyclone:%s\n", wr->m_topic->m_name);
     iox_pub_options_t opts;
     iox_pub_options_init(&opts);
     opts.historyCapacity = wr->m_entity.m_domain->gv.config.pub_history_capacity;
-    wr->m_iox_pub = iox_pub_init(&wr->m_iox_pub_stor, gv->config.iceoryx_service, type_name, topic_name, &opts);
+    wr->m_iox_pub = iox_pub_init(&wr->m_iox_pub_stor, gv->config.iceoryx_service, wr->m_topic->m_stype->type_name, wr->m_topic->m_name, &opts);
     memset(wr->m_iox_pub_loans, 0, sizeof(wr->m_iox_pub_loans));
     dds_sleepfor(DDS_MSECS(10));
   }

--- a/src/core/ddsi/include/dds/ddsi/ddsi_domaingv.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_domaingv.h
@@ -242,14 +242,7 @@ struct ddsi_domaingv {
      supplying values for missing QoS settings in incoming discovery
      packets); plus the actual QoSs needed for the builtin
      endpoints. */
-  ddsi_plist_t default_plist_pp;
   ddsi_plist_t default_local_plist_pp;
-  dds_qos_t default_xqos_rd;
-  dds_qos_t default_xqos_wr;
-  dds_qos_t default_xqos_wr_nad;
-  dds_qos_t default_xqos_tp;
-  dds_qos_t default_xqos_sub;
-  dds_qos_t default_xqos_pub;
   dds_qos_t spdp_endpoint_xqos;
   dds_qos_t builtin_endpoint_xqos_rd;
   dds_qos_t builtin_endpoint_xqos_wr;

--- a/src/core/ddsi/include/dds/ddsi/ddsi_plist.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_plist.h
@@ -253,6 +253,8 @@ typedef struct ddsi_plist_src {
   bool strict;                            /**< whether to be strict in checking */
 } ddsi_plist_src_t;
 
+DDS_EXPORT extern const ddsi_plist_t ddsi_default_plist_participant;
+
 /**
  * @brief Initialize global parameter-list parsing indices.
  *
@@ -424,13 +426,6 @@ DDS_EXPORT void ddsi_plist_addtomsg (struct nn_xmsg *m, const ddsi_plist_t *ps, 
  * @param[in]     bo       byte order
  */
 DDS_EXPORT void ddsi_plist_addtomsg_bo (struct nn_xmsg *m, const ddsi_plist_t *ps, uint64_t pwanted, uint64_t qwanted, enum ddsrt_byte_order_selector bo);
-
-/**
- * @brief Initialize plist to match default settings for a participant
- *
- * @param[out] plist    plist to contain the default settings.
- */
-DDS_EXPORT void ddsi_plist_init_default_participant (ddsi_plist_t *plist);
 
 /**
  * @brief Determine the set of entries in which "x" differs from "y"

--- a/src/core/ddsi/include/dds/ddsi/ddsi_xqos.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_xqos.h
@@ -325,6 +325,11 @@ struct dds_qos {
 
 struct nn_xmsg;
 
+DDS_EXPORT extern const dds_qos_t ddsi_default_qos_reader;
+DDS_EXPORT extern const dds_qos_t ddsi_default_qos_writer;
+DDS_EXPORT extern const dds_qos_t ddsi_default_qos_topic;
+DDS_EXPORT extern const dds_qos_t ddsi_default_qos_publisher_subscriber;
+
 /**
  * @brief Initialize a new empty dds_qos_t as an empty object
  *
@@ -334,63 +339,6 @@ struct nn_xmsg;
  * @param[out] xqos  qos object to be initialized.
  */
 DDS_EXPORT void ddsi_xqos_init_empty (dds_qos_t *xqos);
-
-/**
- * @brief Initialize xqos to match default QoS settings for a reader
- *
- * @param[out] xqos    qos object to contain the default settings.
- */
-DDS_EXPORT void ddsi_xqos_init_default_reader (dds_qos_t *xqos);
-
-/**
- * @brief Initialize xqos to match default QoS settings for a writer
- *
- * @param[out] xqos    qos object to contain the default settings.
- */
-DDS_EXPORT void ddsi_xqos_init_default_writer (dds_qos_t *xqos);
-
-/**
- * @brief Initialize xqos to match default QoS settings for a non-autodispose writer
- *
- * The default writer QoS has "auto dispose unregistered instances" set to true, and
- * opinions differ about what the correct behaviour is, but the setting doesn't really
- * make any sense if it is treated as a macro on the writing such, such that each
- * "unregister" call also performs a dispose.  Cyclone DDS implements the interpretation
- * that matches the name (whenever no registrations are left, make it disposed), which is
- * a refinement of OpenSplice's interpretation (whenever an unregister event occurs, make
- * it disposed).  All these differences originate in the DCPS spec not being clear enough
- * and the complicating factor is that the two different interpretations existed before
- * the introduction of the DDSI specification, and yet the DDSI specification doesn't
- * provide a standard way of discovering the setting for remote writers.
- *
- * Cyclone DDS uses the same vendor-specific extension as OpenSplice for communicating it,
- * and uses a different default for different implementations.  So this is the default
- * used for the "RTI interpretation".
- *
- * @param[out] xqos    qos object to contain the default settings.
- */
-DDS_EXPORT void ddsi_xqos_init_default_writer_noautodispose (dds_qos_t *xqos);
-
-/**
- * @brief Initialize xqos to match default QoS settings for a subscriber
- *
- * @param[out] xqos    qos object to contain the default settings.
- */
-DDS_EXPORT void ddsi_xqos_init_default_subscriber (dds_qos_t *xqos);
-
-/**
- * @brief Initialize xqos to match default QoS settings for a publisher
- *
- * @param[out] xqos    qos object to contain the default settings.
- */
-DDS_EXPORT void ddsi_xqos_init_default_publisher (dds_qos_t *xqos);
-
-/**
- * @brief Initialize xqos to match default QoS settings for a topic
- *
- * @param[out] xqos    qos object to contain the default settings.
- */
-DDS_EXPORT void ddsi_xqos_init_default_topic (dds_qos_t *xqos);
 
 /**
  * @brief Copy "src" to "dst"

--- a/src/core/ddsi/src/ddsi_plist.c
+++ b/src/core/ddsi/src/ddsi_plist.c
@@ -3193,209 +3193,152 @@ void ddsi_xqos_init_empty (dds_qos_t *dest)
   dest->present = dest->aliased = 0;
 }
 
-void ddsi_plist_init_default_participant (ddsi_plist_t *plist)
-{
-  ddsi_plist_init_empty (plist);
+const ddsi_plist_t ddsi_default_plist_participant = {
+  .present = 0,
+  .aliased = 0,
+  .qos = {
+    .present = QP_ADLINK_ENTITY_FACTORY | QP_USER_DATA,
+    .aliased = 0,
+    .entity_factory.autoenable_created_entities = 0,
+    .user_data.length = 0,
+    .user_data.value = NULL
+  }
+};
 
-  plist->qos.present |= QP_ADLINK_ENTITY_FACTORY;
-  plist->qos.entity_factory.autoenable_created_entities = 0;
+const dds_qos_t ddsi_default_qos_reader = {
+  .present = QP_PRESENTATION | QP_DURABILITY | QP_DEADLINE | QP_LATENCY_BUDGET | QP_LIVELINESS | QP_DESTINATION_ORDER | QP_HISTORY | QP_RESOURCE_LIMITS | QP_TRANSPORT_PRIORITY | QP_OWNERSHIP | QP_CYCLONE_IGNORELOCAL | QP_TOPIC_DATA | QP_GROUP_DATA | QP_USER_DATA | QP_PARTITION | QP_RELIABILITY | QP_TIME_BASED_FILTER | QP_ADLINK_READER_DATA_LIFECYCLE | QP_ADLINK_READER_LIFESPAN | QP_ADLINK_SUBSCRIPTION_KEYS | QP_TYPE_CONSISTENCY_ENFORCEMENT | QP_LOCATOR_MASK,
+  .aliased = 0,
+  .presentation.access_scope = DDS_PRESENTATION_INSTANCE,
+  .presentation.coherent_access = 0,
+  .presentation.ordered_access = 0,
+  .durability.kind = DDS_DURABILITY_VOLATILE,
+  .deadline.deadline = DDS_INFINITY,
+  .latency_budget.duration = 0,
+  .liveliness.kind = DDS_LIVELINESS_AUTOMATIC,
+  .liveliness.lease_duration = DDS_INFINITY,
+  .destination_order.kind = DDS_DESTINATIONORDER_BY_RECEPTION_TIMESTAMP,
+  .history.kind = DDS_HISTORY_KEEP_LAST,
+  .history.depth = 1,
+  .resource_limits.max_samples = DDS_LENGTH_UNLIMITED,
+  .resource_limits.max_instances = DDS_LENGTH_UNLIMITED,
+  .resource_limits.max_samples_per_instance = DDS_LENGTH_UNLIMITED,
+  .transport_priority.value = 0,
+  .ownership.kind = DDS_OWNERSHIP_SHARED,
+  .ignorelocal.value = DDS_IGNORELOCAL_NONE,
+  .topic_data.length = 0,
+  .topic_data.value = NULL,
+  .group_data.length = 0,
+  .group_data.value = NULL,
+  .user_data.length = 0,
+  .user_data.value = NULL,
+  .partition.n = 0,
+  .partition.strs = NULL,
+  .reliability.kind = DDS_RELIABILITY_BEST_EFFORT,
+  .time_based_filter.minimum_separation = 0,
+  .reader_data_lifecycle.autopurge_nowriter_samples_delay = DDS_INFINITY,
+  .reader_data_lifecycle.autopurge_disposed_samples_delay = DDS_INFINITY,
+  .reader_lifespan.use_lifespan = 0,
+  .reader_lifespan.duration = DDS_INFINITY,
+  .subscription_keys.use_key_list = 0,
+  .subscription_keys.key_list.n = 0,
+  .subscription_keys.key_list.strs = NULL,
+  .type_consistency.kind = DDS_TYPE_CONSISTENCY_ALLOW_TYPE_COERCION,
+  .type_consistency.ignore_sequence_bounds = false,
+  .type_consistency.ignore_string_bounds = false,
+  .type_consistency.ignore_member_names = false,
+  .type_consistency.prevent_type_widening = false,
+  .type_consistency.force_type_validation = false,
+  .ignore_locator_type = 0
+};
 
-  plist->qos.present |= QP_USER_DATA;
-  plist->qos.user_data.length = 0;
-  plist->qos.user_data.value = NULL;
-}
+const dds_qos_t ddsi_default_qos_writer = {
+  .present = QP_PRESENTATION | QP_DURABILITY | QP_DEADLINE | QP_LATENCY_BUDGET | QP_LIVELINESS | QP_DESTINATION_ORDER | QP_HISTORY | QP_RESOURCE_LIMITS | QP_OWNERSHIP | QP_CYCLONE_IGNORELOCAL | QP_TOPIC_DATA | QP_GROUP_DATA | QP_USER_DATA | QP_PARTITION | QP_DURABILITY_SERVICE | QP_RELIABILITY | QP_OWNERSHIP_STRENGTH | QP_TRANSPORT_PRIORITY | QP_LIFESPAN | QP_ADLINK_WRITER_DATA_LIFECYCLE | QP_LOCATOR_MASK,
+  .aliased = 0,
+  .presentation.access_scope = DDS_PRESENTATION_INSTANCE,
+  .presentation.coherent_access = 0,
+  .presentation.ordered_access = 0,
+  .durability.kind = DDS_DURABILITY_VOLATILE,
+  .deadline.deadline = DDS_INFINITY,
+  .latency_budget.duration = 0,
+  .liveliness.kind = DDS_LIVELINESS_AUTOMATIC,
+  .liveliness.lease_duration = DDS_INFINITY,
+  .destination_order.kind = DDS_DESTINATIONORDER_BY_RECEPTION_TIMESTAMP,
+  .history.kind = DDS_HISTORY_KEEP_LAST,
+  .history.depth = 1,
+  .resource_limits.max_samples = DDS_LENGTH_UNLIMITED,
+  .resource_limits.max_instances = DDS_LENGTH_UNLIMITED,
+  .resource_limits.max_samples_per_instance = DDS_LENGTH_UNLIMITED,
+  .ownership.kind = DDS_OWNERSHIP_SHARED,
+  .ignorelocal.value = DDS_IGNORELOCAL_NONE,
+  .topic_data.length = 0,
+  .topic_data.value = NULL,
+  .group_data.length = 0,
+  .group_data.value = NULL,
+  .user_data.length = 0,
+  .user_data.value = NULL,
+  .partition.n = 0,
+  .partition.strs = NULL,
+  .durability_service.service_cleanup_delay = 0,
+  .durability_service.history.kind = DDS_HISTORY_KEEP_LAST,
+  .durability_service.history.depth = 1,
+  .durability_service.resource_limits.max_samples = DDS_LENGTH_UNLIMITED,
+  .durability_service.resource_limits.max_instances = DDS_LENGTH_UNLIMITED,
+  .durability_service.resource_limits.max_samples_per_instance = DDS_LENGTH_UNLIMITED,
+  .reliability.kind = DDS_RELIABILITY_RELIABLE,
+  .reliability.max_blocking_time = DDS_MSECS (100),
+  .ownership_strength.value = 0,
+  .transport_priority.value = 0,
+  .lifespan.duration = DDS_INFINITY,
+  .writer_data_lifecycle.autodispose_unregistered_instances = 1,
+  .ignore_locator_type = 0
+};
 
-static void xqos_init_default_common (dds_qos_t *xqos)
-{
-  ddsi_xqos_init_empty (xqos);
+const dds_qos_t ddsi_default_qos_topic = {
+  .present = QP_PRESENTATION | QP_DURABILITY | QP_DEADLINE | QP_LATENCY_BUDGET | QP_LIVELINESS | QP_DESTINATION_ORDER | QP_HISTORY | QP_RESOURCE_LIMITS | QP_TRANSPORT_PRIORITY | QP_OWNERSHIP | QP_CYCLONE_IGNORELOCAL | QP_DURABILITY_SERVICE | QP_RELIABILITY | QP_ADLINK_SUBSCRIPTION_KEYS | QP_LIFESPAN,
+  .aliased = 0,
+  .presentation.access_scope = DDS_PRESENTATION_INSTANCE,
+  .presentation.coherent_access = 0,
+  .presentation.ordered_access = 0,
+  .durability.kind = DDS_DURABILITY_VOLATILE,
+  .deadline.deadline = DDS_INFINITY,
+  .latency_budget.duration = 0,
+  .liveliness.kind = DDS_LIVELINESS_AUTOMATIC,
+  .liveliness.lease_duration = DDS_INFINITY,
+  .destination_order.kind = DDS_DESTINATIONORDER_BY_RECEPTION_TIMESTAMP,
+  .history.kind = DDS_HISTORY_KEEP_LAST,
+  .history.depth = 1,
+  .resource_limits.max_samples = DDS_LENGTH_UNLIMITED,
+  .resource_limits.max_instances = DDS_LENGTH_UNLIMITED,
+  .resource_limits.max_samples_per_instance = DDS_LENGTH_UNLIMITED,
+  .transport_priority.value = 0,
+  .ownership.kind = DDS_OWNERSHIP_SHARED,
+  .ignorelocal.value = DDS_IGNORELOCAL_NONE,
+  .reliability.kind = DDS_RELIABILITY_BEST_EFFORT,
+  .reliability.max_blocking_time = DDS_MSECS (100),
+  .durability_service.service_cleanup_delay = 0,
+  .durability_service.history.kind = DDS_HISTORY_KEEP_LAST,
+  .durability_service.history.depth = 1,
+  .durability_service.resource_limits.max_samples = DDS_LENGTH_UNLIMITED,
+  .durability_service.resource_limits.max_instances = DDS_LENGTH_UNLIMITED,
+  .durability_service.resource_limits.max_samples_per_instance = DDS_LENGTH_UNLIMITED,
+  .subscription_keys.use_key_list = 0,
+  .subscription_keys.key_list.n = 0,
+  .subscription_keys.key_list.strs = NULL,
+  .lifespan.duration = DDS_INFINITY
+};
 
-  xqos->present |= QP_PRESENTATION;
-  xqos->presentation.access_scope = DDS_PRESENTATION_INSTANCE;
-  xqos->presentation.coherent_access = 0;
-  xqos->presentation.ordered_access = 0;
-
-  xqos->present |= QP_DURABILITY;
-  xqos->durability.kind = DDS_DURABILITY_VOLATILE;
-
-  xqos->present |= QP_DEADLINE;
-  xqos->deadline.deadline = DDS_INFINITY;
-
-  xqos->present |= QP_LATENCY_BUDGET;
-  xqos->latency_budget.duration = 0;
-
-  xqos->present |= QP_LIVELINESS;
-  xqos->liveliness.kind = DDS_LIVELINESS_AUTOMATIC;
-  xqos->liveliness.lease_duration = DDS_INFINITY;
-
-  xqos->present |= QP_DESTINATION_ORDER;
-  xqos->destination_order.kind = DDS_DESTINATIONORDER_BY_RECEPTION_TIMESTAMP;
-
-  xqos->present |= QP_HISTORY;
-  xqos->history.kind = DDS_HISTORY_KEEP_LAST;
-  xqos->history.depth = 1;
-
-  xqos->present |= QP_RESOURCE_LIMITS;
-  xqos->resource_limits.max_samples = DDS_LENGTH_UNLIMITED;
-  xqos->resource_limits.max_instances = DDS_LENGTH_UNLIMITED;
-  xqos->resource_limits.max_samples_per_instance = DDS_LENGTH_UNLIMITED;
-
-  xqos->present |= QP_TRANSPORT_PRIORITY;
-  xqos->transport_priority.value = 0;
-
-  xqos->present |= QP_OWNERSHIP;
-  xqos->ownership.kind = DDS_OWNERSHIP_SHARED;
-
-  xqos->present |= QP_CYCLONE_IGNORELOCAL;
-  xqos->ignorelocal.value = DDS_IGNORELOCAL_NONE;
-}
-
-static void ddsi_xqos_init_default_endpoint (dds_qos_t *xqos)
-{
-  xqos_init_default_common (xqos);
-
-  xqos->present |= QP_TOPIC_DATA;
-  xqos->topic_data.length = 0;
-  xqos->topic_data.value = NULL;
-
-  xqos->present |= QP_GROUP_DATA;
-  xqos->group_data.length = 0;
-  xqos->group_data.value = NULL;
-
-  xqos->present |= QP_USER_DATA;
-  xqos->user_data.length = 0;
-  xqos->user_data.value = NULL;
-
-  xqos->present |= QP_PARTITION;
-  xqos->partition.n = 0;
-  xqos->partition.strs = NULL;
-}
-
-void ddsi_xqos_init_default_reader (dds_qos_t *xqos)
-{
-  ddsi_xqos_init_default_endpoint (xqos);
-
-  xqos->present |= QP_RELIABILITY;
-  xqos->reliability.kind = DDS_RELIABILITY_BEST_EFFORT;
-
-  xqos->present |= QP_TIME_BASED_FILTER;
-  xqos->time_based_filter.minimum_separation = 0;
-
-  xqos->present |= QP_ADLINK_READER_DATA_LIFECYCLE;
-  xqos->reader_data_lifecycle.autopurge_nowriter_samples_delay = DDS_INFINITY;
-  xqos->reader_data_lifecycle.autopurge_disposed_samples_delay = DDS_INFINITY;
-
-  xqos->present |= QP_ADLINK_READER_LIFESPAN;
-  xqos->reader_lifespan.use_lifespan = 0;
-  xqos->reader_lifespan.duration = DDS_INFINITY;
-
-  xqos->present |= QP_ADLINK_SUBSCRIPTION_KEYS;
-  xqos->subscription_keys.use_key_list = 0;
-  xqos->subscription_keys.key_list.n = 0;
-  xqos->subscription_keys.key_list.strs = NULL;
-
-  xqos->present |= QP_TYPE_CONSISTENCY_ENFORCEMENT;
-  xqos->type_consistency.kind = DDS_TYPE_CONSISTENCY_ALLOW_TYPE_COERCION;
-  xqos->type_consistency.ignore_sequence_bounds = false;
-  xqos->type_consistency.ignore_string_bounds = false;
-  xqos->type_consistency.ignore_member_names = false;
-  xqos->type_consistency.prevent_type_widening = false;
-  xqos->type_consistency.force_type_validation = false;
-
-  xqos->present |= QP_LOCATOR_MASK;
-  xqos->ignore_locator_type = 0;
-}
-
-void ddsi_xqos_init_default_writer (dds_qos_t *xqos)
-{
-  ddsi_xqos_init_default_endpoint (xqos);
-
-  xqos->present |= QP_DURABILITY_SERVICE;
-  xqos->durability_service.service_cleanup_delay = 0;
-  xqos->durability_service.history.kind = DDS_HISTORY_KEEP_LAST;
-  xqos->durability_service.history.depth = 1;
-  xqos->durability_service.resource_limits.max_samples = DDS_LENGTH_UNLIMITED;
-  xqos->durability_service.resource_limits.max_instances = DDS_LENGTH_UNLIMITED;
-  xqos->durability_service.resource_limits.max_samples_per_instance = DDS_LENGTH_UNLIMITED;
-
-  xqos->present |= QP_RELIABILITY;
-  xqos->reliability.kind = DDS_RELIABILITY_RELIABLE;
-  xqos->reliability.max_blocking_time = DDS_MSECS (100);
-
-  xqos->present |= QP_OWNERSHIP_STRENGTH;
-  xqos->ownership_strength.value = 0;
-
-  xqos->present |= QP_TRANSPORT_PRIORITY;
-  xqos->transport_priority.value = 0;
-
-  xqos->present |= QP_LIFESPAN;
-  xqos->lifespan.duration = DDS_INFINITY;
-
-  xqos->present |= QP_ADLINK_WRITER_DATA_LIFECYCLE;
-  xqos->writer_data_lifecycle.autodispose_unregistered_instances = 1;
-
-  xqos->present |= QP_LOCATOR_MASK;
-  xqos->ignore_locator_type = 0;
-}
-
-void ddsi_xqos_init_default_writer_noautodispose (dds_qos_t *xqos)
-{
-  ddsi_xqos_init_default_writer (xqos);
-  xqos->writer_data_lifecycle.autodispose_unregistered_instances = 0;
-}
-
-void ddsi_xqos_init_default_topic (dds_qos_t *xqos)
-{
-  xqos_init_default_common (xqos);
-
-  xqos->present |= QP_DURABILITY_SERVICE;
-  xqos->durability_service.service_cleanup_delay = 0;
-  xqos->durability_service.history.kind = DDS_HISTORY_KEEP_LAST;
-  xqos->durability_service.history.depth = 1;
-  xqos->durability_service.resource_limits.max_samples = DDS_LENGTH_UNLIMITED;
-  xqos->durability_service.resource_limits.max_instances = DDS_LENGTH_UNLIMITED;
-  xqos->durability_service.resource_limits.max_samples_per_instance = DDS_LENGTH_UNLIMITED;
-
-  xqos->present |= QP_RELIABILITY;
-  xqos->reliability.kind = DDS_RELIABILITY_BEST_EFFORT;
-  xqos->reliability.max_blocking_time = DDS_MSECS (100);
-
-  xqos->present |= QP_TRANSPORT_PRIORITY;
-  xqos->transport_priority.value = 0;
-
-  xqos->present |= QP_LIFESPAN;
-  xqos->lifespan.duration = DDS_INFINITY;
-
-  xqos->present |= QP_ADLINK_SUBSCRIPTION_KEYS;
-  xqos->subscription_keys.use_key_list = 0;
-  xqos->subscription_keys.key_list.n = 0;
-  xqos->subscription_keys.key_list.strs = NULL;
-}
-
-static void ddsi_xqos_init_default_publisher_subscriber (dds_qos_t *xqos)
-{
-  ddsi_xqos_init_empty (xqos);
-
-  xqos->present |= QP_GROUP_DATA;
-  xqos->group_data.length = 0;
-  xqos->group_data.value = NULL;
-
-  xqos->present |= QP_ADLINK_ENTITY_FACTORY;
-  xqos->entity_factory.autoenable_created_entities = 1;
-
-  xqos->present |= QP_PARTITION;
-  xqos->partition.n = 0;
-  xqos->partition.strs = NULL;
-}
-
-void ddsi_xqos_init_default_subscriber (dds_qos_t *xqos)
-{
-  ddsi_xqos_init_default_publisher_subscriber (xqos);
-}
-
-void ddsi_xqos_init_default_publisher (dds_qos_t *xqos)
-{
-  ddsi_xqos_init_default_publisher_subscriber (xqos);
-}
+const dds_qos_t ddsi_default_qos_publisher_subscriber = {
+  .present = QP_GROUP_DATA | QP_PARTITION | QP_ADLINK_ENTITY_FACTORY,
+  .aliased = 0,
+  .presentation.access_scope = DDS_PRESENTATION_INSTANCE,
+  .presentation.coherent_access = 0,
+  .presentation.ordered_access = 0,
+  .entity_factory.autoenable_created_entities = 1,
+  .group_data.length = 0,
+  .group_data.value = NULL,
+  .partition.n = 0,
+  .partition.strs = NULL
+};
 
 void ddsi_xqos_copy (dds_qos_t *dst, const dds_qos_t *src)
 {

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -3688,7 +3688,7 @@ static void new_writer_guid_common_init (struct writer *wr, const char *topic_na
 
   wr->xqos = ddsrt_malloc (sizeof (*wr->xqos));
   ddsi_xqos_copy (wr->xqos, xqos);
-  ddsi_xqos_mergein_missing (wr->xqos, &wr->e.gv->default_xqos_wr, ~(uint64_t)0);
+  ddsi_xqos_mergein_missing (wr->xqos, &ddsi_default_qos_writer, ~(uint64_t)0);
   assert (wr->xqos->aliased == 0);
   set_topic_type_name (wr->xqos, topic_name, type->type_name);
 
@@ -4327,7 +4327,7 @@ static dds_return_t new_reader_guid
   /* Copy QoS, merging in defaults */
   rd->xqos = ddsrt_malloc (sizeof (*rd->xqos));
   ddsi_xqos_copy (rd->xqos, xqos);
-  ddsi_xqos_mergein_missing (rd->xqos, &pp->e.gv->default_xqos_rd, ~(uint64_t)0);
+  ddsi_xqos_mergein_missing (rd->xqos, &ddsi_default_qos_reader, ~(uint64_t)0);
   assert (rd->xqos->aliased == 0);
   set_topic_type_name (rd->xqos, topic_name, type->type_name);
 
@@ -4577,7 +4577,7 @@ dds_return_t ddsi_new_topic
   /* Copy QoS, merging in defaults */
   struct dds_qos *tp_qos = ddsrt_malloc (sizeof (*tp_qos));
   ddsi_xqos_copy (tp_qos, xqos);
-  ddsi_xqos_mergein_missing (tp_qos, &gv->default_xqos_tp, ~(uint64_t)0);
+  ddsi_xqos_mergein_missing (tp_qos, &ddsi_default_qos_topic, ~(uint64_t)0);
   assert (tp_qos->aliased == 0);
 
   /* Set topic name, type name and type id in qos */
@@ -5215,7 +5215,7 @@ bool new_proxy_participant (struct ddsi_domaingv *gv, const struct ddsi_guid *pp
   proxy_topic_list_init (&proxypp->topics);
 #endif
   proxypp->plist = ddsi_plist_dup (plist);
-  ddsi_xqos_mergein_missing (&proxypp->plist->qos, &gv->default_plist_pp.qos, ~(uint64_t)0);
+  ddsi_xqos_mergein_missing (&proxypp->plist->qos, &ddsi_default_plist_participant.qos, ~(uint64_t)0);
   ddsrt_avl_init (&proxypp_groups_treedef, &proxypp->groups);
 
 #ifdef DDS_HAS_SECURITY
@@ -5264,13 +5264,12 @@ int update_proxy_participant_plist_locked (struct proxy_participant *proxypp, se
   {
     proxypp->seq = seq;
 
-    struct ddsi_domaingv * const gv = proxypp->e.gv;
     const uint64_t pmask = PP_ENTITY_NAME;
     const uint64_t qmask = QP_USER_DATA;
     ddsi_plist_t *new_plist = ddsrt_malloc (sizeof (*new_plist));
     ddsi_plist_init_empty (new_plist);
     ddsi_plist_mergein_missing (new_plist, datap, pmask, qmask);
-    ddsi_plist_mergein_missing (new_plist, &gv->default_plist_pp, ~(uint64_t)0, ~(uint64_t)0);
+    ddsi_plist_mergein_missing (new_plist, &ddsi_default_plist_participant, ~(uint64_t)0, ~(uint64_t)0);
     (void) update_qos_locked (&proxypp->e, &proxypp->plist->qos, &new_plist->qos, timestamp);
     ddsi_plist_fini (new_plist);
     ddsrt_free (new_plist);

--- a/src/core/xtests/rhc_torture/rhc_torture.c
+++ b/src/core/xtests/rhc_torture/rhc_torture.c
@@ -167,7 +167,7 @@ static uint64_t store (struct ddsi_tkmap *tkmap, struct dds_rhc *rhc, struct pro
   return iid;
 }
 
-static struct proxy_writer *mkwr (const struct ddsi_domaingv *gv, bool auto_dispose)
+static struct proxy_writer *mkwr (bool auto_dispose)
 {
   struct proxy_writer *pwr;
   struct dds_qos *xqos;
@@ -177,7 +177,7 @@ static struct proxy_writer *mkwr (const struct ddsi_domaingv *gv, bool auto_disp
   wr_iid = ddsi_iid_gen ();
   memset (pwr, 0, sizeof (*pwr));
   ddsi_xqos_init_empty (xqos);
-  ddsi_xqos_mergein_missing (xqos, &gv->default_xqos_wr, ~(uint64_t)0);
+  ddsi_xqos_mergein_missing (xqos, &ddsi_default_qos_writer, ~(uint64_t)0);
   xqos->ownership_strength.value = 0;
   xqos->writer_data_lifecycle.autodispose_unregistered_instances = auto_dispose;
   pwr->e.iid = wr_iid;
@@ -207,7 +207,7 @@ static struct dds_rhc *mkrhc (struct ddsi_domaingv *gv, dds_reader *rd, dds_hist
   rqos.history.kind = hk;
   rqos.history.depth = hdepth;
   rqos.destination_order.kind = dok;
-  ddsi_xqos_mergein_missing (&rqos, &gv->default_xqos_rd, ~(uint64_t)0);
+  ddsi_xqos_mergein_missing (&rqos, &ddsi_default_qos_reader, ~(uint64_t)0);
   thread_state_awake_domain_ok (lookup_thread_state ());
   rhc = dds_rhc_default_new_xchecks (rd, gv, mdtype, true);
   dds_rhc_set_qos(rhc, &rqos);
@@ -603,7 +603,7 @@ static void test_conditions (dds_entity_t pp, dds_entity_t tp, const int count, 
 
   const struct ddsi_domaingv *gv = get_gv (pp);
   struct ddsi_tkmap *tkmap = gv->m_tkmap;
-  struct proxy_writer *wr[] = { mkwr (gv, 0), mkwr (gv, 1), mkwr (gv, 1) };
+  struct proxy_writer *wr[] = { mkwr (0), mkwr (1), mkwr (1) };
 
   static const uint32_t stab[] = {
     DDS_READ_SAMPLE_STATE, DDS_NOT_READ_SAMPLE_STATE,
@@ -953,8 +953,8 @@ int main (int argc, char **argv)
     if (print)
       printf ("************* 0 *************\n");
     struct dds_rhc *rhc = mkrhc (gv, NULL, DDS_HISTORY_KEEP_LAST, 1, DDS_DESTINATIONORDER_BY_SOURCE_TIMESTAMP);
-    struct proxy_writer *wr0 = mkwr (gv, 1);
-    struct proxy_writer *wr1 = mkwr (gv, 1);
+    struct proxy_writer *wr0 = mkwr (1);
+    struct proxy_writer *wr1 = mkwr (1);
     uint64_t iid0, iid1, iid_t;
     iid0 = store (tkmap, rhc, wr0, mksample (0, 0), print, false);
     iid1 = store (tkmap, rhc, wr0, mksample (1, NN_STATUSINFO_DISPOSE), print, false);
@@ -1028,7 +1028,7 @@ int main (int argc, char **argv)
     if (print)
       printf ("************* 1 *************\n");
     struct dds_rhc *rhc = mkrhc (gv, NULL, DDS_HISTORY_KEEP_LAST, 4, DDS_DESTINATIONORDER_BY_SOURCE_TIMESTAMP);
-    struct proxy_writer *wr[] = { mkwr (gv, 0), mkwr (gv, 0), mkwr (gv, 0) };
+    struct proxy_writer *wr[] = { mkwr (0), mkwr (0), mkwr (0) };
     uint64_t iid0, iid_t;
     int nregs = 3, isreg[] = { 1, 1, 1 };
     iid0 = store (tkmap, rhc, wr[0], mksample (0, 0), print, false);


### PR DESCRIPTION
The API says the application must use pseudo handles/compile-time constants when creating a reader for a built-in topic, but the implementation underneath does require the existence of a full topic entity, which is created just-in-time by `create_reader`.

It used to be that `get_topic` on a reader created using one of these pseudo handles would return the actual topic entity. It does seem strange that `T==get_topic(create_reader(...,T,...))` could be false even though both operations succeed. Furthermore, it means the application could set a listener on this topic entity, change the `TOPIC_DATA` QoS, create a writer with it ... None of those are desirable because the internals do make some assumptions on how this behaves.

That leaves one operation that would return the actual handle: `get_children`, and so that one now simply skips over the actual topic entity.

Then, it used to be that you couldn't pass the pseudo-handle to `dds_get_name` to get the topic name. That doesn't work out so nicely if the `get_topic` is fixed to return the pseudo-handle.

Still, this doesn't plug all the holes, because an application could just call `dds_get_name(T,...)` in a loop until it get a successful return of something starting with `DCPS` and then do all the things it might want to do to wreak havoc. Therefore, this PR also extends the handles with a "user accessible" bit.