### PR TITLE
Return actual length from `dds_get_name`/`dds_get_type_name`

### DIFF
--- a/src/core/ddsc/include/dds/dds.h
+++ b/src/core/ddsc/include/dds/dds.h
@@ -1251,8 +1251,7 @@ dds_find_topic_scoped (dds_find_scope_t scope, dds_entity_t participant, const c
  *
  * @returns A dds_return_t indicating success or failure.
  *
- * @retval DDS_RETCODE_OK
- *             Success.
+ * @return Actual length of topic name (name is truncated if return value >= size) or error
  */
 DDS_EXPORT dds_return_t
 dds_get_name(dds_entity_t topic, char *name, size_t size);
@@ -1266,8 +1265,7 @@ dds_get_name(dds_entity_t topic, char *name, size_t size);
  *
  * @returns A dds_return_t indicating success or failure.
  *
- * @return DDS_RETCODE_OK
- *             Success.
+ * @return Actual length of type name (name is truncated if return value >= size) or error
  */
 DDS_EXPORT dds_return_t
 dds_get_type_name(dds_entity_t topic, char *name, size_t size);

--- a/src/core/ddsc/src/dds__builtin.h
+++ b/src/core/ddsc/src/dds__builtin.h
@@ -20,6 +20,12 @@ extern "C"
 {
 #endif
 
+/* Get name and typename based from a builtin-topic pseudo-handle; returns an DDS_RETCODE_BAD_PARAMETER if pseudo_handle is invalid */
+dds_return_t dds__get_builtin_topic_name_typename (dds_entity_t pseudo_handle, const char **name, const char **typename);
+
+/* Returns the pseudo handle for the given typename, returns DDS_RETCODE_BAD_PARAMETER if typename isn't one of the built-in topics */
+dds_entity_t dds__get_builtin_topic_pseudo_handle_from_typename (const char *typename);
+
 /* Get actual topic in related participant related to topic 'id'. */
 dds_entity_t dds__get_builtin_topic (dds_entity_t e, dds_entity_t topic);
 

--- a/src/core/ddsc/src/dds__entity.h
+++ b/src/core/ddsc/src/dds__entity.h
@@ -25,6 +25,7 @@ dds_entity_init(
   dds_entity * parent,
   dds_entity_kind_t kind,
   bool implicit,
+  bool user_access,
   dds_qos_t * qos,
   const dds_listener_t *listener,
   status_mask_t mask);
@@ -125,6 +126,7 @@ DDS_EXPORT void dds_entity_final_deinit_before_free (dds_entity *e);
 DDS_EXPORT bool dds_entity_in_scope (const dds_entity *e, const dds_entity *root);
 
 enum delete_impl_state {
+  DIS_USER,        /* delete invoked directly by application */
   DIS_EXPLICIT,    /* explicit delete on this entity */
   DIS_FROM_PARENT, /* called because the parent is being deleted */
   DIS_IMPLICIT     /* called from child; delete if implicit w/o children */
@@ -137,7 +139,13 @@ dds_entity_pin (
   dds_entity_t hdl,
   dds_entity **eptr);
 
-DDS_EXPORT dds_return_t dds_entity_pin_for_delete (dds_entity_t hdl, bool explicit, dds_entity **eptr);
+DDS_EXPORT dds_return_t
+dds_entity_pin_with_origin (
+  dds_entity_t hdl,
+  bool from_user,
+  dds_entity **eptr);
+
+DDS_EXPORT dds_return_t dds_entity_pin_for_delete (dds_entity_t hdl, bool explicit, bool from_user, dds_entity **eptr);
 
 DDS_EXPORT void dds_entity_unpin (
   dds_entity *e);

--- a/src/core/ddsc/src/dds__handles.h
+++ b/src/core/ddsc/src/dds__handles.h
@@ -77,6 +77,7 @@ typedef int32_t dds_handle_t;
 #define HDL_FLAG_PENDING         (0x20000000u)
 #define HDL_FLAG_IMPLICIT        (0x10000000u)
 #define HDL_FLAG_ALLOW_CHILDREN  (0x08000000u) /* refc counts children */
+#define HDL_FLAG_NO_USER_ACCESS  (0x04000000u)
 
 struct dds_handle_link {
   dds_handle_t hdl;
@@ -120,7 +121,8 @@ DDS_EXPORT dds_handle_t
 dds_handle_create(
         struct dds_handle_link *link,
         bool implicit,
-        bool allow_children);
+        bool allow_children,
+        bool user_access);
 
 
 /*
@@ -168,6 +170,12 @@ dds_handle_pin(
         struct dds_handle_link **entity);
 
 DDS_EXPORT int32_t
+dds_handle_pin_with_origin(
+        dds_handle_t hdl,
+        bool from_user,
+        struct dds_handle_link **entity);
+
+DDS_EXPORT int32_t
 dds_handle_pin_and_ref(
         dds_handle_t hdl,
         struct dds_handle_link **entity);
@@ -185,7 +193,7 @@ DDS_EXPORT void
 dds_handle_unpin(
         struct dds_handle_link *link);
 
-int32_t dds_handle_pin_for_delete (dds_handle_t hdl, bool explicit, struct dds_handle_link **link);
+int32_t dds_handle_pin_for_delete (dds_handle_t hdl, bool explicit, bool from_user, struct dds_handle_link **link);
 bool dds_handle_drop_childref_and_pin (struct dds_handle_link *link, bool may_delete_parent);
 
 /*

--- a/src/core/ddsc/src/dds__topic.h
+++ b/src/core/ddsc/src/dds__topic.h
@@ -23,6 +23,7 @@ DEFINE_ENTITY_LOCK_UNLOCK(inline, dds_topic, DDS_KIND_TOPIC)
 
 DDS_EXPORT void dds_topic_free (dds_domainid_t domainid, struct ddsi_sertype * st) ddsrt_nonnull_all;
 
+DDS_EXPORT dds_return_t dds_topic_pin_with_origin (dds_entity_t handle, bool from_user, struct dds_topic **tp) ddsrt_nonnull_all;
 DDS_EXPORT dds_return_t dds_topic_pin (dds_entity_t handle, struct dds_topic **tp) ddsrt_nonnull_all;
 DDS_EXPORT void dds_topic_unpin (struct dds_topic *tp) ddsrt_nonnull_all;
 DDS_EXPORT void dds_topic_defer_set_qos (struct dds_topic *tp) ddsrt_nonnull_all;

--- a/src/core/ddsc/src/dds__topic.h
+++ b/src/core/ddsc/src/dds__topic.h
@@ -45,10 +45,6 @@ DDS_EXPORT dds_entity_t dds_create_topic_impl (
     const ddsi_plist_t *sedp_plist,
     bool is_builtin);
 
-DDS_EXPORT dds_return_t dds_get_name_size (dds_entity_t topic, size_t *size);
-
-DDS_EXPORT dds_return_t dds_get_type_name_size (dds_entity_t topic, size_t *size);
-
 #if defined (__cplusplus)
 }
 #endif

--- a/src/core/ddsc/src/dds_builtin.c
+++ b/src/core/ddsc/src/dds_builtin.c
@@ -44,6 +44,58 @@ static dds_qos_t *dds__create_builtin_qos (void)
   return qos;
 }
 
+static const struct {
+  dds_entity_t pseudo_handle;
+  const char *name;
+  const char *typename;
+} builtin_topic_list[] = {
+  { DDS_BUILTIN_TOPIC_DCPSPARTICIPANT, DDS_BUILTIN_TOPIC_PARTICIPANT_NAME, "org::eclipse::cyclonedds::builtin::DCPSParticipant" },
+  { DDS_BUILTIN_TOPIC_DCPSTOPIC, DDS_BUILTIN_TOPIC_TOPIC_NAME, "org::eclipse::cyclonedds::builtin::DCPSTopic" },
+  { DDS_BUILTIN_TOPIC_DCPSPUBLICATION, DDS_BUILTIN_TOPIC_PUBLICATION_NAME, "org::eclipse::cyclonedds::builtin::DCPSPublication" },
+  { DDS_BUILTIN_TOPIC_DCPSSUBSCRIPTION, DDS_BUILTIN_TOPIC_SUBSCRIPTION_NAME, "org::eclipse::cyclonedds::builtin::DCPSSubscription" }
+};
+
+dds_return_t dds__get_builtin_topic_name_typename (dds_entity_t pseudo_handle, const char **name, const char **typename)
+{
+  const char *n;
+  const char *tn;
+  // avoid a search (mostly because we can)
+  DDSRT_STATIC_ASSERT (DDS_BUILTIN_TOPIC_DCPSTOPIC == DDS_BUILTIN_TOPIC_DCPSPARTICIPANT + 1 &&
+                       DDS_BUILTIN_TOPIC_DCPSPUBLICATION == DDS_BUILTIN_TOPIC_DCPSTOPIC + 1 &&
+                       DDS_BUILTIN_TOPIC_DCPSSUBSCRIPTION == DDS_BUILTIN_TOPIC_DCPSPUBLICATION + 1);
+  switch (pseudo_handle)
+  {
+    case DDS_BUILTIN_TOPIC_DCPSPARTICIPANT:
+    case DDS_BUILTIN_TOPIC_DCPSTOPIC:
+    case DDS_BUILTIN_TOPIC_DCPSPUBLICATION:
+    case DDS_BUILTIN_TOPIC_DCPSSUBSCRIPTION: {
+      dds_entity_t idx = pseudo_handle - DDS_BUILTIN_TOPIC_DCPSPARTICIPANT;
+      n = builtin_topic_list[idx].name;
+      tn = builtin_topic_list[idx].typename;
+      break;
+    }
+    default: {
+      // no assert: this is also used by some API calls
+      return DDS_RETCODE_BAD_PARAMETER;
+    }
+  }
+  if (name)
+    *name = n;
+  if (typename)
+    *typename = tn;
+  return 0;
+}
+
+dds_entity_t dds__get_builtin_topic_pseudo_handle_from_typename (const char *typename)
+{
+  for (size_t i = 0; i < sizeof (builtin_topic_list) / sizeof (builtin_topic_list[0]); i++)
+  {
+    if (strcmp (typename, builtin_topic_list[i].typename) == 0)
+      return builtin_topic_list[i].pseudo_handle;
+  }
+  return DDS_RETCODE_BAD_PARAMETER;
+}
+
 dds_entity_t dds__get_builtin_topic (dds_entity_t entity, dds_entity_t topic)
 {
   dds_entity_t tp;
@@ -59,26 +111,23 @@ dds_entity_t dds__get_builtin_topic (dds_entity_t entity, dds_entity_t topic)
     return DDS_RETCODE_ILLEGAL_OPERATION;
   }
 
-  char *topic_name;
+  const char *topic_name;
   struct ddsi_sertype *sertype;
+  (void) dds__get_builtin_topic_name_typename (topic, &topic_name, NULL);
   switch (topic)
   {
     case DDS_BUILTIN_TOPIC_DCPSPARTICIPANT:
-      topic_name = DDS_BUILTIN_TOPIC_PARTICIPANT_NAME;
       sertype = e->m_domain->builtin_participant_type;
       break;
 #ifdef DDS_HAS_TOPIC_DISCOVERY
     case DDS_BUILTIN_TOPIC_DCPSTOPIC:
-      topic_name = DDS_BUILTIN_TOPIC_TOPIC_NAME;
       sertype = e->m_domain->builtin_topic_type;
       break;
 #endif
     case DDS_BUILTIN_TOPIC_DCPSPUBLICATION:
-      topic_name = DDS_BUILTIN_TOPIC_PUBLICATION_NAME;
       sertype = e->m_domain->builtin_writer_type;
       break;
     case DDS_BUILTIN_TOPIC_DCPSSUBSCRIPTION:
-      topic_name = DDS_BUILTIN_TOPIC_SUBSCRIPTION_NAME;
       sertype = e->m_domain->builtin_reader_type;
       break;
     default:
@@ -332,12 +381,17 @@ void dds__builtin_init (struct dds_domain *dom)
 #endif
   dom->gv.builtin_topic_interface = &dom->btif;
 
-  dom->builtin_participant_type = new_sertype_builtintopic (DSBT_PARTICIPANT, "org::eclipse::cyclonedds::builtin::DCPSParticipant");
+  const char *typename;
+  (void) dds__get_builtin_topic_name_typename (DDS_BUILTIN_TOPIC_DCPSPARTICIPANT, NULL, &typename);
+  dom->builtin_participant_type = new_sertype_builtintopic (DSBT_PARTICIPANT, typename);
 #ifdef DDS_HAS_TOPIC_DISCOVERY
-  dom->builtin_topic_type = new_sertype_builtintopic_topic (DSBT_TOPIC, "org::eclipse::cyclonedds::builtin::DCPSTopic");
+  (void) dds__get_builtin_topic_name_typename (DDS_BUILTIN_TOPIC_DCPSTOPIC, NULL, &typename);
+  dom->builtin_topic_type = new_sertype_builtintopic_topic (DSBT_TOPIC, typename);
 #endif
-  dom->builtin_reader_type = new_sertype_builtintopic (DSBT_READER, "org::eclipse::cyclonedds::builtin::DCPSSubscription");
-  dom->builtin_writer_type = new_sertype_builtintopic (DSBT_WRITER, "org::eclipse::cyclonedds::builtin::DCPSPublication");
+  (void) dds__get_builtin_topic_name_typename (DDS_BUILTIN_TOPIC_DCPSSUBSCRIPTION, NULL, &typename);
+  dom->builtin_reader_type = new_sertype_builtintopic (DSBT_READER, typename);
+  (void) dds__get_builtin_topic_name_typename (DDS_BUILTIN_TOPIC_DCPSPUBLICATION, NULL, &typename);
+  dom->builtin_writer_type = new_sertype_builtintopic (DSBT_WRITER, typename);
 
   ddsrt_mutex_lock (&dom->gv.sertypes_lock);
   ddsi_sertype_register_locked (&dom->gv, dom->builtin_participant_type);

--- a/src/core/ddsc/src/dds_domain.c
+++ b/src/core/ddsc/src/dds_domain.c
@@ -68,7 +68,7 @@ static dds_entity_t dds_domain_init (dds_domain *domain, dds_domainid_t domain_i
   dds_entity_t domh;
   uint32_t len;
 
-  if ((domh = dds_entity_init (&domain->m_entity, &dds_global.m_entity, DDS_KIND_DOMAIN, implicit, NULL, NULL, 0)) < 0)
+  if ((domh = dds_entity_init (&domain->m_entity, &dds_global.m_entity, DDS_KIND_DOMAIN, implicit, true, NULL, NULL, 0)) < 0)
     return domh;
   domain->m_entity.m_domain = domain;
   domain->m_entity.m_iid = ddsi_iid_gen ();

--- a/src/core/ddsc/src/dds_entity.c
+++ b/src/core/ddsc/src/dds_entity.c
@@ -259,7 +259,7 @@ dds_entity_t dds_entity_init (dds_entity *e, dds_entity *parent, dds_entity_kind
   {
     /* for topics, refc counts readers/writers, for all others, it counts children (this we can get away with
        as long as topics can't have children) */
-    if ((handle = dds_handle_create (&e->m_hdllink, implicit, entity_may_have_children (e))) <= 0)
+    if ((handle = dds_handle_create (&e->m_hdllink, implicit, entity_may_have_children (e), true)) <= 0)
       return (dds_entity_t) handle;
   }
 
@@ -1281,7 +1281,7 @@ dds_return_t dds_entity_pin_for_delete (dds_entity_t hdl, bool explicit, dds_ent
 {
   dds_return_t hres;
   struct dds_handle_link *hdllink;
-  if ((hres = dds_handle_pin_for_delete (hdl, explicit, &hdllink)) < 0)
+  if ((hres = dds_handle_pin_for_delete (hdl, explicit, true, &hdllink)) < 0)
     return hres;
   else
   {

--- a/src/core/ddsc/src/dds_guardcond.c
+++ b/src/core/ddsc/src/dds_guardcond.c
@@ -59,7 +59,7 @@ dds_entity_t dds_create_guardcondition (dds_entity_t owner)
   }
 
   dds_guardcond *gcond = dds_alloc (sizeof (*gcond));
-  dds_entity_t hdl = dds_entity_init (&gcond->m_entity, e, DDS_KIND_COND_GUARD, false, NULL, NULL, 0);
+  dds_entity_t hdl = dds_entity_init (&gcond->m_entity, e, DDS_KIND_COND_GUARD, false, true, NULL, NULL, 0);
   gcond->m_entity.m_iid = ddsi_iid_gen ();
   dds_entity_register_child (e, &gcond->m_entity);
   dds_entity_init_complete (&gcond->m_entity);

--- a/src/core/ddsc/src/dds_init.c
+++ b/src/core/ddsc/src/dds_init.c
@@ -121,7 +121,7 @@ dds_return_t dds_init (void)
     goto fail_handleserver;
   }
 
-  dds_entity_init (&dds_global.m_entity, NULL, DDS_KIND_CYCLONEDDS, true, NULL, NULL, 0);
+  dds_entity_init (&dds_global.m_entity, NULL, DDS_KIND_CYCLONEDDS, true, true, NULL, NULL, 0);
   dds_global.m_entity.m_iid = ddsi_iid_gen ();
   dds_handle_repin (&dds_global.m_entity.m_hdllink);
   dds_entity_add_ref_locked (&dds_global.m_entity);

--- a/src/core/ddsc/src/dds_participant.c
+++ b/src/core/ddsc/src/dds_participant.c
@@ -131,7 +131,7 @@ dds_entity_t dds_create_participant (const dds_domainid_t domain, const dds_qos_
   }
 
   pp = dds_alloc (sizeof (*pp));
-  if ((ret = dds_entity_init (&pp->m_entity, &dom->m_entity, DDS_KIND_PARTICIPANT, false, new_qos, listener, DDS_PARTICIPANT_STATUS_MASK)) < 0)
+  if ((ret = dds_entity_init (&pp->m_entity, &dom->m_entity, DDS_KIND_PARTICIPANT, false, true, new_qos, listener, DDS_PARTICIPANT_STATUS_MASK)) < 0)
     goto err_entity_init;
 
   pp->m_entity.m_guid = guid;

--- a/src/core/ddsc/src/dds_publisher.c
+++ b/src/core/ddsc/src/dds_publisher.c
@@ -66,7 +66,7 @@ dds_entity_t dds__create_publisher_l (dds_participant *par, bool implicit, const
   }
 
   pub = dds_alloc (sizeof (*pub));
-  hdl = dds_entity_init (&pub->m_entity, &par->m_entity, DDS_KIND_PUBLISHER, implicit, new_qos, listener, DDS_PUBLISHER_STATUS_MASK);
+  hdl = dds_entity_init (&pub->m_entity, &par->m_entity, DDS_KIND_PUBLISHER, implicit, true, new_qos, listener, DDS_PUBLISHER_STATUS_MASK);
   pub->m_entity.m_iid = ddsi_iid_gen ();
   dds_entity_register_child (&par->m_entity, &pub->m_entity);
   dds_entity_init_complete (&pub->m_entity);

--- a/src/core/ddsc/src/dds_readcond.c
+++ b/src/core/ddsc/src/dds_readcond.c
@@ -45,7 +45,7 @@ dds_readcond *dds_create_readcond (dds_reader *rd, dds_entity_kind_t kind, uint3
 {
   dds_readcond *cond = dds_alloc (sizeof (*cond));
   assert ((kind == DDS_KIND_COND_READ && filter == 0) || (kind == DDS_KIND_COND_QUERY && filter != 0));
-  (void) dds_entity_init (&cond->m_entity, &rd->m_entity, kind, false, NULL, NULL, 0);
+  (void) dds_entity_init (&cond->m_entity, &rd->m_entity, kind, false, true, NULL, NULL, 0);
   cond->m_entity.m_iid = ddsi_iid_gen ();
   dds_entity_register_child (&rd->m_entity, &cond->m_entity);
   cond->m_sample_states = mask & DDS_ANY_SAMPLE_STATE;

--- a/src/core/ddsc/src/dds_reader.c
+++ b/src/core/ddsc/src/dds_reader.c
@@ -519,7 +519,9 @@ static dds_entity_t dds_create_reader_int (dds_entity_t participant_or_subscribe
     }
   }
 
-  if ((rc = dds_topic_pin (topic, &tp)) < 0)
+  /* If pseudo_topic != 0, topic didn't didn't originate from the application and we allow pinning
+     it despite it being marked as NO_USER_ACCESS */
+  if ((rc = dds_topic_pin_with_origin (topic, pseudo_topic ? false : true, &tp)) < 0)
     goto err_pin_topic;
   assert (tp->m_stype);
   if (dds_entity_participant (&sub->m_entity) != dds_entity_participant (&tp->m_entity))

--- a/src/core/ddsc/src/dds_reader.c
+++ b/src/core/ddsc/src/dds_reader.c
@@ -586,7 +586,7 @@ static dds_entity_t dds_create_reader_int (dds_entity_t participant_or_subscribe
 
   /* Create reader and associated read cache (if not provided by caller) */
   struct dds_reader * const rd = dds_alloc (sizeof (*rd));
-  const dds_entity_t reader = dds_entity_init (&rd->m_entity, &sub->m_entity, DDS_KIND_READER, false, rqos, listener, DDS_READER_STATUS_MASK);
+  const dds_entity_t reader = dds_entity_init (&rd->m_entity, &sub->m_entity, DDS_KIND_READER, false, true, rqos, listener, DDS_READER_STATUS_MASK);
   rd->m_sample_rejected_status.last_reason = DDS_NOT_REJECTED;
   rd->m_topic = tp;
   rd->m_wrapped_sertopic = (tp->m_stype->wrapped_sertopic != NULL) ? 1 : 0;

--- a/src/core/ddsc/src/dds_reader.c
+++ b/src/core/ddsc/src/dds_reader.c
@@ -616,18 +616,7 @@ static dds_entity_t dds_create_reader_int (dds_entity_t participant_or_subscribe
 #ifdef DDS_HAS_SHM
   if (0x0 == (rqos->ignore_locator_type & NN_LOCATOR_KIND_SHEM))
   {
-    size_t name_size, type_name_size;
-    rc = dds_get_name_size(topic, &name_size);
-    assert(rc == DDS_RETCODE_OK);
-    rc = dds_get_type_name_size(topic, &type_name_size);
-    assert(rc == DDS_RETCODE_OK);
-    char topic_name[name_size + 1];
-    char type_name[type_name_size + 1];
-    rc = dds_get_name(topic, topic_name, name_size + 1);
-    assert(rc == DDS_RETCODE_OK);
-    rc = dds_get_type_name(topic, type_name, type_name_size + 1);
-    assert(rc == DDS_RETCODE_OK);
-    DDS_CLOG (DDS_LC_SHM, &rd->m_entity.m_domain->gv.logconfig, "Reader's topic name will be DDS:Cyclone:%s\n", topic_name);
+    DDS_CLOG (DDS_LC_SHM, &rd->m_entity.m_domain->gv.logconfig, "Reader's topic name will be DDS:Cyclone:%s\n", rd->m_topic->m_name);
 
     iox_sub_options_t opts;
     iox_sub_options_init(&opts);
@@ -638,7 +627,7 @@ static dds_entity_t dds_create_reader_int (dds_entity_t participant_or_subscribe
     assert (rqos->durability.kind == DDS_DURABILITY_VOLATILE);
     opts.queueCapacity = rd->m_entity.m_domain->gv.config.sub_queue_capacity;
     opts.historyRequest = 0;
-    rd->m_iox_sub = iox_sub_init(&rd->m_iox_sub_stor.storage, gv->config.iceoryx_service, type_name, topic_name, &opts);
+    rd->m_iox_sub = iox_sub_init(&rd->m_iox_sub_stor.storage, gv->config.iceoryx_service, rd->m_topic->m_stype->type_name, rd->m_topic->m_name, &opts);
     shm_monitor_attach_reader(&rd->m_entity.m_domain->m_shm_monitor, rd);
 
     // those are set once and never changed

--- a/src/core/ddsc/src/dds_subscriber.c
+++ b/src/core/ddsc/src/dds_subscriber.c
@@ -66,7 +66,7 @@ dds_entity_t dds__create_subscriber_l (dds_participant *participant, bool implic
   }
 
   sub = dds_alloc (sizeof (*sub));
-  subscriber = dds_entity_init (&sub->m_entity, &participant->m_entity, DDS_KIND_SUBSCRIBER, implicit, new_qos, listener, DDS_SUBSCRIBER_STATUS_MASK);
+  subscriber = dds_entity_init (&sub->m_entity, &participant->m_entity, DDS_KIND_SUBSCRIBER, implicit, true, new_qos, listener, DDS_SUBSCRIBER_STATUS_MASK);
   sub->m_entity.m_iid = ddsi_iid_gen ();
   dds_entity_register_child (&participant->m_entity, &sub->m_entity);
   dds_entity_init_complete (&sub->m_entity);

--- a/src/core/ddsc/src/dds_topic.c
+++ b/src/core/ddsc/src/dds_topic.c
@@ -1039,15 +1039,13 @@ dds_return_t dds_get_name (dds_entity_t topic, char *name, size_t size)
 
   const char *bname;
   if (dds__get_builtin_topic_name_typename (topic, &bname, NULL) == 0)
-    (void) ddsrt_strlcpy (name, bname, size);
-  else
+    ret = (dds_return_t) ddsrt_strlcpy (name, bname, size);
+  else if ((ret = dds_topic_pin (topic, &t)) == DDS_RETCODE_OK)
   {
-    if ((ret = dds_topic_pin (topic, &t)) != DDS_RETCODE_OK)
-      return ret;
-    (void) ddsrt_strlcpy (name, t->m_name, size);
+    ret = (dds_return_t) ddsrt_strlcpy (name, t->m_name, size);
     dds_topic_unpin (t);
   }
-  return DDS_RETCODE_OK;
+  return ret;
 }
 
 dds_return_t dds_get_type_name (dds_entity_t topic, char *name, size_t size)
@@ -1060,15 +1058,13 @@ dds_return_t dds_get_type_name (dds_entity_t topic, char *name, size_t size)
 
   const char *bname;
   if (dds__get_builtin_topic_name_typename (topic, NULL, &bname) == 0)
-    (void) ddsrt_strlcpy (name, bname, size);
-  else
+    ret = (dds_return_t) ddsrt_strlcpy (name, bname, size);
+  else if ((ret = dds_topic_pin (topic, &t)) == DDS_RETCODE_OK)
   {
-    if ((ret = dds_topic_pin (topic, &t)) != DDS_RETCODE_OK)
-      return ret;
-    (void) ddsrt_strlcpy (name, t->m_stype->type_name, size);
+    ret = (dds_return_t) ddsrt_strlcpy (name, t->m_stype->type_name, size);
     dds_topic_unpin (t);
   }
-  return DDS_RETCODE_OK;
+  return ret;
 }
 
 DDS_GET_STATUS(topic, inconsistent_topic, INCONSISTENT_TOPIC, total_count_change)

--- a/src/core/ddsc/src/dds_topic.c
+++ b/src/core/ddsc/src/dds_topic.c
@@ -1023,32 +1023,6 @@ dds_topic_filter_fn dds_topic_get_filter (dds_entity_t topic)
   return dds_get_topic_filter_deprecated (topic);
 }
 
-dds_return_t dds_get_name_size (dds_entity_t topic, size_t *size)
-{
-  dds_topic *t;
-  dds_return_t ret;
-  if (size == NULL)
-    return DDS_RETCODE_BAD_PARAMETER;
-  if ((ret = dds_topic_pin (topic, &t)) != DDS_RETCODE_OK)
-    return ret;
-  *size = strlen (t->m_name);
-  dds_topic_unpin (t);
-  return DDS_RETCODE_OK;
-}
-
-dds_return_t dds_get_type_name_size (dds_entity_t topic, size_t *size)
-{
-  dds_topic *t;
-  dds_return_t ret;
-  if (size == NULL)
-    return DDS_RETCODE_BAD_PARAMETER;
-  if ((ret = dds_topic_pin (topic, &t)) != DDS_RETCODE_OK)
-    return ret;
-  *size = strlen (t->m_stype->type_name);
-  dds_topic_unpin (t);
-  return DDS_RETCODE_OK;
-}
-
 dds_return_t dds_get_name (dds_entity_t topic, char *name, size_t size)
 {
   dds_topic *t;

--- a/src/core/ddsc/src/dds_topic.c
+++ b/src/core/ddsc/src/dds_topic.c
@@ -333,7 +333,7 @@ static dds_entity_t create_topic_pp_locked (struct dds_participant *pp, struct d
   (void) sedp_plist;
   dds_entity_t hdl;
   dds_topic *tp = dds_alloc (sizeof (*tp));
-  hdl = dds_entity_init (&tp->m_entity, &pp->m_entity, DDS_KIND_TOPIC, implicit, NULL, listener, DDS_TOPIC_STATUS_MASK);
+  hdl = dds_entity_init (&tp->m_entity, &pp->m_entity, DDS_KIND_TOPIC, implicit, true, NULL, listener, DDS_TOPIC_STATUS_MASK);
   tp->m_entity.m_iid = ddsi_iid_gen ();
   dds_entity_register_child (&pp->m_entity, &tp->m_entity);
   tp->m_ktopic = ktp;

--- a/src/core/ddsc/src/dds_waitset.c
+++ b/src/core/ddsc/src/dds_waitset.c
@@ -168,7 +168,7 @@ dds_entity_t dds_create_waitset (dds_entity_t owner)
   }
 
   dds_waitset *waitset = dds_alloc (sizeof (*waitset));
-  dds_entity_t hdl = dds_entity_init (&waitset->m_entity, e, DDS_KIND_WAITSET, false, NULL, NULL, 0);
+  dds_entity_t hdl = dds_entity_init (&waitset->m_entity, e, DDS_KIND_WAITSET, false, true, NULL, NULL, 0);
   ddsrt_mutex_init (&waitset->wait_lock);
   ddsrt_cond_init (&waitset->wait_cond);
   waitset->m_entity.m_iid = ddsi_iid_gen ();

--- a/src/core/ddsc/src/dds_writer.c
+++ b/src/core/ddsc/src/dds_writer.c
@@ -410,7 +410,7 @@ dds_entity_t dds_create_writer (dds_entity_t participant_or_publisher, dds_entit
 
   /* Create writer */
   struct dds_writer * const wr = dds_alloc (sizeof (*wr));
-  const dds_entity_t writer = dds_entity_init (&wr->m_entity, &pub->m_entity, DDS_KIND_WRITER, false, wqos, listener, DDS_WRITER_STATUS_MASK);
+  const dds_entity_t writer = dds_entity_init (&wr->m_entity, &pub->m_entity, DDS_KIND_WRITER, false, true, wqos, listener, DDS_WRITER_STATUS_MASK);
   wr->m_topic = tp;
   dds_entity_add_ref_locked (&tp->m_entity);
   wr->m_xp = nn_xpack_new (gv, get_bandwidth_limit (wqos->transport_priority), async_mode);

--- a/src/core/ddsc/src/dds_writer.c
+++ b/src/core/ddsc/src/dds_writer.c
@@ -432,23 +432,11 @@ dds_entity_t dds_create_writer (dds_entity_t participant_or_publisher, dds_entit
 #ifdef DDS_HAS_SHM
   if (0x0 == (wqos->ignore_locator_type & NN_LOCATOR_KIND_SHEM))
   {
-    size_t name_size, type_name_size;
-    rc = dds_get_name_size (topic, &name_size);
-    assert(rc == DDS_RETCODE_OK);
-    rc = dds_get_type_name_size (topic, &type_name_size);
-    assert (rc == DDS_RETCODE_OK);
-    char topic_name[name_size+1];
-    char type_name[type_name_size+1];
-    rc = dds_get_name (topic, topic_name, name_size+1);
-    assert(rc == DDS_RETCODE_OK);
-    rc = dds_get_type_name (topic, type_name, type_name_size+1);
-    assert (rc == DDS_RETCODE_OK);
-    DDS_CLOG (DDS_LC_SHM, &wr->m_entity.m_domain->gv.logconfig, "Writer's topic name will be DDS:Cyclone:%s\n", topic_name);
-    // SHM_TODO: We should do error handling if there is duplicate publish topic. iceoryx doesn't support multiple pub now.
+    DDS_CLOG (DDS_LC_SHM, &wr->m_entity.m_domain->gv.logconfig, "Writer's topic name will be DDS:Cyclone:%s\n", wr->m_topic->m_name);
     iox_pub_options_t opts;
     iox_pub_options_init(&opts);
     opts.historyCapacity = wr->m_entity.m_domain->gv.config.pub_history_capacity;
-    wr->m_iox_pub = iox_pub_init(&wr->m_iox_pub_stor, gv->config.iceoryx_service, type_name, topic_name, &opts);
+    wr->m_iox_pub = iox_pub_init(&wr->m_iox_pub_stor, gv->config.iceoryx_service, wr->m_topic->m_stype->type_name, wr->m_topic->m_name, &opts);
     memset(wr->m_iox_pub_loans, 0, sizeof(wr->m_iox_pub_loans));
     dds_sleepfor(DDS_MSECS(10));
   }

--- a/src/core/ddsc/tests/builtin_topics.c
+++ b/src/core/ddsc/tests/builtin_topics.c
@@ -10,6 +10,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
 #include "dds/dds.h"
+#include "dds__reader.h"
 #include "test_common.h"
 
 static dds_entity_t g_participant = 0;
@@ -334,4 +335,187 @@ CU_Test(ddsc_builtin_topics, read_nothing)
 
   ret = dds_delete (pp);
   CU_ASSERT_FATAL (ret == 0);
+}
+
+static bool querycond_true (const void *sample)
+{
+  (void) sample;
+  return true;
+}
+
+CU_Test(ddsc_builtin_topics, get_topic)
+{
+  static const dds_entity_t tps[] = {
+    DDS_BUILTIN_TOPIC_DCPSPARTICIPANT,
+    DDS_BUILTIN_TOPIC_DCPSTOPIC,
+    DDS_BUILTIN_TOPIC_DCPSPUBLICATION,
+    DDS_BUILTIN_TOPIC_DCPSSUBSCRIPTION,
+    0
+  };
+  const dds_entity_t pp = dds_create_participant (DDS_DOMAIN_DEFAULT, NULL, NULL);
+  CU_ASSERT_FATAL (pp > 0);
+  for (int i = 0; tps[i]; i++)
+  {
+    const dds_entity_t rd = dds_create_reader (pp, tps[i], NULL, NULL);
+#ifdef DDS_HAS_TOPIC_DISCOVERY
+    CU_ASSERT_FATAL (rd > 0);
+#else // expect failure for DCPSTopic if topic discovery isn't enabled, but verify the error code
+    if (tps[i] != DDS_BUILTIN_TOPIC_DCPSTOPIC)
+    {
+      CU_ASSERT_FATAL (rd > 0);
+    }
+    else
+    {
+      CU_ASSERT_FATAL (rd == DDS_RETCODE_UNSUPPORTED);
+      continue;
+    }
+#endif
+    // get_topic must return the pseudo handle
+    {
+      const dds_entity_t rdtp = dds_get_topic (rd);
+      CU_ASSERT_FATAL (rdtp == tps[i]);
+    }
+    // ... also on a read condition
+    {
+      const dds_entity_t rdc = dds_create_readcondition (rd, DDS_ANY_STATE);
+      CU_ASSERT_FATAL (rdc > 0);
+      const dds_entity_t rdctp = dds_get_topic (rdc);
+      CU_ASSERT_FATAL (rdctp == tps[i]);
+    }
+    // ... and on a query condition
+    {
+      const dds_entity_t qc = dds_create_querycondition (rd, DDS_ANY_STATE, querycond_true);
+      CU_ASSERT_FATAL (qc > 0);
+      const dds_entity_t qctp = dds_get_topic (qc);
+      CU_ASSERT_FATAL (qctp == tps[i]);
+    }
+  }
+  dds_return_t rc = dds_delete (pp);
+  CU_ASSERT_FATAL (rc == 0);
+}
+
+CU_Test(ddsc_builtin_topics, get_name)
+{
+  static const struct { dds_entity_t h; const char *n; } tps[] = {
+    { DDS_BUILTIN_TOPIC_DCPSPARTICIPANT, "DCPSParticipant" },
+    { DDS_BUILTIN_TOPIC_DCPSTOPIC, "DCPSTopic" },
+    { DDS_BUILTIN_TOPIC_DCPSPUBLICATION, "DCPSPublication" },
+    { DDS_BUILTIN_TOPIC_DCPSSUBSCRIPTION, "DCPSSubscription" },
+    { 0, NULL }
+  };
+  // pseudo handles always exist and it actually works even in the absence of a domain
+  // not sure whether that's a feature or a bug ...
+  for (int i = 0; tps[i].h; i++)
+  {
+    char buf[100];
+    dds_return_t rc = dds_get_name (tps[i].h, buf, sizeof (buf));
+    CU_ASSERT_FATAL (rc == 0);
+    CU_ASSERT_FATAL (strcmp (buf, tps[i].n) == 0);
+  }
+}
+
+CU_Test(ddsc_builtin_topics, get_type_name)
+{
+  static const struct { dds_entity_t h; const char *n; } tps[] = {
+    { DDS_BUILTIN_TOPIC_DCPSPARTICIPANT, "org::eclipse::cyclonedds::builtin::DCPSParticipant" },
+    { DDS_BUILTIN_TOPIC_DCPSTOPIC, "org::eclipse::cyclonedds::builtin::DCPSTopic" },
+    { DDS_BUILTIN_TOPIC_DCPSPUBLICATION, "org::eclipse::cyclonedds::builtin::DCPSPublication" },
+    { DDS_BUILTIN_TOPIC_DCPSSUBSCRIPTION, "org::eclipse::cyclonedds::builtin::DCPSSubscription" },
+    { 0, NULL }
+  };
+  // pseudo handles always exist and it actually works even in the absence of a domain
+  // not sure whether that's a feature or a bug ...
+  for (int i = 0; tps[i].h; i++)
+  {
+    char buf[100];
+    dds_return_t rc = dds_get_type_name (tps[i].h, buf, sizeof (buf));
+    CU_ASSERT_FATAL (rc == 0);
+    CU_ASSERT_FATAL (strcmp (buf, tps[i].n) == 0);
+  }
+}
+
+CU_Test(ddsc_builtin_topics, get_children)
+{
+  static const dds_entity_t tps[] = {
+    DDS_BUILTIN_TOPIC_DCPSPARTICIPANT,
+    DDS_BUILTIN_TOPIC_DCPSTOPIC,
+    DDS_BUILTIN_TOPIC_DCPSPUBLICATION,
+    DDS_BUILTIN_TOPIC_DCPSSUBSCRIPTION,
+    0
+  };
+  const dds_entity_t pp = dds_create_participant (DDS_DOMAIN_DEFAULT, NULL, NULL);
+  CU_ASSERT_FATAL (pp > 0);
+  for (int i = 0; tps[i]; i++)
+  {
+    const dds_entity_t rd = dds_create_reader (pp, tps[i], NULL, NULL);
+#ifdef DDS_HAS_TOPIC_DISCOVERY
+    CU_ASSERT_FATAL (rd > 0);
+#else // expect failure for DCPSTopic if topic discovery isn't enabled, but verify the error code
+    if (tps[i] != DDS_BUILTIN_TOPIC_DCPSTOPIC)
+    {
+      CU_ASSERT_FATAL (rd > 0);
+    }
+    else
+    {
+      CU_ASSERT_FATAL (rd == DDS_RETCODE_UNSUPPORTED);
+      continue;
+    }
+#endif
+  }
+  // get_children on must not return the topics we just created, there should be just one
+  // subscriber in the result
+  dds_entity_t cs[1];
+  const int32_t ncs = dds_get_children (pp, cs, sizeof (cs) / sizeof (cs[0]));
+  CU_ASSERT_FATAL (ncs == 1);
+  dds_return_t rc = dds_delete (pp);
+  CU_ASSERT_FATAL (rc == 0);
+}
+
+CU_Test(ddsc_builtin_topics, cant_use_real_topic)
+{
+  static const dds_entity_t tps[] = {
+    DDS_BUILTIN_TOPIC_DCPSPARTICIPANT,
+    DDS_BUILTIN_TOPIC_DCPSTOPIC,
+    DDS_BUILTIN_TOPIC_DCPSPUBLICATION,
+    DDS_BUILTIN_TOPIC_DCPSSUBSCRIPTION,
+    0
+  };
+  const dds_entity_t pp = dds_create_participant (DDS_DOMAIN_DEFAULT, NULL, NULL);
+  CU_ASSERT_FATAL (pp > 0);
+  for (int i = 0; tps[i]; i++)
+  {
+    const dds_entity_t rd = dds_create_reader (pp, tps[i], NULL, NULL);
+#ifdef DDS_HAS_TOPIC_DISCOVERY
+    CU_ASSERT_FATAL (rd > 0);
+#else // expect failure for DCPSTopic if topic discovery isn't enabled, but verify the error code
+    if (tps[i] != DDS_BUILTIN_TOPIC_DCPSTOPIC)
+    {
+      CU_ASSERT_FATAL (rd > 0);
+    }
+    else
+    {
+      CU_ASSERT_FATAL (rd == DDS_RETCODE_UNSUPPORTED);
+      continue;
+    }
+#endif
+    
+    // extract real topic handle by digging underneath the API
+    // as a very efficient alternative to a lucky guess
+    dds_return_t rc;
+    dds_reader *rd_ent = NULL;
+    rc = dds_reader_lock (rd, &rd_ent);
+    CU_ASSERT_FATAL (rc == 0 && rd_ent != NULL);
+    assert (rc == 0 && rd_ent != NULL);
+    const dds_entity_t real_topic = rd_ent->m_topic->m_entity.m_hdllink.hdl;
+    dds_reader_unlock (rd_ent);
+
+    // can't delete
+    rc = dds_delete (real_topic);
+    CU_ASSERT_FATAL (rc == DDS_RETCODE_BAD_PARAMETER);
+
+    rc = dds_create_reader (pp, real_topic, NULL, NULL);
+    CU_ASSERT_FATAL (rc == DDS_RETCODE_BAD_PARAMETER);
+  }
+  dds_return_t rc = dds_delete (pp);
+  CU_ASSERT_FATAL (rc == 0);
 }

--- a/src/core/ddsc/tests/builtin_topics.c
+++ b/src/core/ddsc/tests/builtin_topics.c
@@ -409,7 +409,7 @@ CU_Test(ddsc_builtin_topics, get_name)
   {
     char buf[100];
     dds_return_t rc = dds_get_name (tps[i].h, buf, sizeof (buf));
-    CU_ASSERT_FATAL (rc == 0);
+    CU_ASSERT_FATAL (rc == (dds_return_t) strlen (tps[i].n));
     CU_ASSERT_FATAL (strcmp (buf, tps[i].n) == 0);
   }
 }
@@ -429,7 +429,7 @@ CU_Test(ddsc_builtin_topics, get_type_name)
   {
     char buf[100];
     dds_return_t rc = dds_get_type_name (tps[i].h, buf, sizeof (buf));
-    CU_ASSERT_FATAL (rc == 0);
+    CU_ASSERT_FATAL (rc == (dds_return_t) strlen (tps[i].n));
     CU_ASSERT_FATAL (strcmp (buf, tps[i].n) == 0);
   }
 }

--- a/src/core/ddsc/tests/topic.c
+++ b/src/core/ddsc/tests/topic.c
@@ -142,21 +142,22 @@ CU_Test(ddsc_topic_get_name, valid, .init = ddsc_topic_init, .fini = ddsc_topic_
 {
   char name[MAX_NAME_SIZE];
   dds_return_t ret = dds_get_name(g_topic_rtmdt, name, MAX_NAME_SIZE);
-  CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+  CU_ASSERT_EQUAL_FATAL(ret, (dds_return_t) strlen (g_topic_rtmdt_name));
   CU_ASSERT_STRING_EQUAL_FATAL(name, g_topic_rtmdt_name);
 
   ret = dds_get_name(g_topic_rtmaddr, name, MAX_NAME_SIZE);
-  CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+  CU_ASSERT_EQUAL_FATAL(ret, (dds_return_t) strlen (g_topic_rtmaddr_name));
   CU_ASSERT_STRING_EQUAL_FATAL(name, g_topic_rtmaddr_name);
 }
 
 CU_Test(ddsc_topic_get_name, too_small, .init = ddsc_topic_init, .fini = ddsc_topic_fini)
 {
   char name[10];
+  assert (strlen (g_topic_rtmdt_name) >= sizeof (name));
   dds_return_t ret = dds_get_name(g_topic_rtmdt, name, 10);
-  CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-  g_topic_rtmdt_name[9] = '\0';
-  CU_ASSERT_STRING_EQUAL_FATAL(name, g_topic_rtmdt_name);
+  CU_ASSERT_FATAL (name[sizeof (name) - 1] == 0);
+  CU_ASSERT_FATAL (ret == (dds_return_t) strlen (g_topic_rtmdt_name));
+  CU_ASSERT_FATAL (strncmp (g_topic_rtmdt_name, name, sizeof (name) - 1) == 0);
 }
 
 CU_Test(ddsc_topic_get_name, non_topic, .init = ddsc_topic_init, .fini = ddsc_topic_fini)
@@ -191,22 +192,24 @@ CU_Test(ddsc_topic_get_type_name, valid, .init = ddsc_topic_init, .fini = ddsc_t
   const char *rtmDataTypeType = "RoundTripModule::DataType";
   const char *rtmAddressType = "RoundTripModule::Address";
   char name[MAX_NAME_SIZE];
-  dds_return_t ret = dds_get_type_name(g_topic_rtmdt, name, MAX_NAME_SIZE);
-  CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+  dds_return_t ret = dds_get_type_name(g_topic_rtmdt, name, sizeof (name));
+  CU_ASSERT_EQUAL_FATAL(ret, (dds_return_t) strlen (rtmDataTypeType));
   CU_ASSERT_STRING_EQUAL_FATAL(name, rtmDataTypeType);
 
-  ret = dds_get_type_name(g_topic_rtmaddr, name, MAX_NAME_SIZE);
-  CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+  ret = dds_get_type_name(g_topic_rtmaddr, name, sizeof (name));
+  CU_ASSERT_EQUAL_FATAL(ret, (dds_return_t) strlen (rtmAddressType));
   CU_ASSERT_STRING_EQUAL_FATAL(name, rtmAddressType);
 }
 
 CU_Test(ddsc_topic_get_type_name, too_small, .init = ddsc_topic_init, .fini = ddsc_topic_fini)
 {
-  const char *rtmDataTypeType = "RoundTrip";
+  const char *rtmDataTypeType = "RoundTripModule::DataType";
   char name[10];
-  dds_return_t ret = dds_get_type_name(g_topic_rtmdt, name, 10);
-  CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
-  CU_ASSERT_STRING_EQUAL_FATAL(name, rtmDataTypeType);
+  assert (strlen (rtmDataTypeType) >= sizeof (name));
+  dds_return_t ret = dds_get_type_name(g_topic_rtmdt, name, sizeof (name));
+  CU_ASSERT_FATAL (name[sizeof (name) - 1] == 0);
+  CU_ASSERT_FATAL (ret == (dds_return_t) strlen (rtmDataTypeType));
+  CU_ASSERT_FATAL (strncmp (rtmDataTypeType, name, sizeof (name) - 1) == 0);
 }
 
 CU_Test(ddsc_topic_get_type_name, non_topic, .init = ddsc_topic_init, .fini = ddsc_topic_fini)


### PR DESCRIPTION
I think the behaviour of silently truncating the name if the buffer is too small to contain the full name and simply returning "OK" is a bug. It certainly doesn't fit with various other functions in the API. This changes the returned value to the actual length of name.

This breaks any application code that uses these functions and tests for "OK" or assigns the result to a variable that it later on assumes to be 0, or many variations on that theme. It is completely harmless for code that checks for errors by checking whether the returned value is negative.

The commit sits on top of #869 but that is not because it has any real dependencies, rather it is because the above incompatibility surfaces in some tests and I did them in this order. For the purposes of reviewing, please ignore all commits other than "Return actual length from dds_get_(type_)name" in this PR.