### PR TITLE
Add the option to prematurely return a publisher loan using the already existing dds_return_loan function.

### DIFF
--- a/src/core/ddsc/include/dds/dds.h
+++ b/src/core/ddsc/include/dds/dds.h
@@ -3535,7 +3535,7 @@ dds_read_next_wl(
  * the memory is released so that the buffer can be reused during a successive read/take operation.
  * When a condition is provided, the reader to which the condition belongs is looked up.
  *
- * @param[in] reader_or_condition Reader or condition that belongs to a reader.
+ * @param[in] entity The entity that the loan belongs to.
  * @param[in] buf An array of (pointers to) samples.
  * @param[in] bufsz The number of (pointers to) samples stored in buf.
  *
@@ -3544,7 +3544,7 @@ dds_read_next_wl(
 /* TODO: Add list of possible return codes */
 DDS_EXPORT dds_return_t
 dds_return_loan(
-  dds_entity_t reader_or_condition,
+  dds_entity_t entity,
   void **buf,
   int32_t bufsz);
 

--- a/src/core/ddsc/include/dds/dds.h
+++ b/src/core/ddsc/include/dds/dds.h
@@ -3530,10 +3530,14 @@ dds_read_next_wl(
 /**
  * @brief Return loaned samples to data-reader or condition associated with a data-reader
  *
- * Used to release sample buffers returned by a read/take operation. When the application
- * provides an empty buffer, memory is allocated and managed by DDS. By calling dds_return_loan,
- * the memory is released so that the buffer can be reused during a successive read/take operation.
- * When a condition is provided, the reader to which the condition belongs is looked up.
+ * Used to release sample buffers returned by a read/take operation (a so called reader-loan)
+ * or, in case shared memory is enabled, of the loan_sample operation ( a so called writer-loan).
+ * When the application provides an empty buffer to a reader-loan, memory is allocated and
+ * managed by DDS. By calling dds_return_loan, the reader-loan is released so that the buffer
+ * can be reused during a successive read/take operation. When a condition is provided, the
+ * reader to which the condition belongs is looked up.
+ * Writer-loans are normally released implicitly when writing a loaned sample, but you can
+ * cancel a writer-loan prematurely by invoking the return_loan operation.
  *
  * @param[in] entity The entity that the loan belongs to.
  * @param[in] buf An array of (pointers to) samples.

--- a/src/core/ddsc/src/dds__reader.h
+++ b/src/core/ddsc/src/dds__reader.h
@@ -23,6 +23,8 @@ struct status_cb_data;
 
 void dds_reader_status_cb (void *entity, const struct status_cb_data * data);
 
+dds_return_t dds_return_reader_loan (dds_entity *p_entity, void **buf, int32_t bufsz);
+
 /*
   dds_reader_lock_samples: Returns number of samples in read cache and locks the
   reader cache to make sure that the samples content doesn't change.

--- a/src/core/ddsc/src/dds__writer.h
+++ b/src/core/ddsc/src/dds__writer.h
@@ -23,6 +23,7 @@ DEFINE_ENTITY_LOCK_UNLOCK(inline, dds_writer, DDS_KIND_WRITER)
 struct status_cb_data;
 
 void dds_writer_status_cb (void *entity, const struct status_cb_data * data);
+dds_return_t dds_return_writer_loan(dds_writer *writer, void *sample);
 DDS_EXPORT dds_return_t dds__writer_wait_for_acks (struct dds_writer *wr, ddsi_guid_t *rdguid, dds_time_t abstimeout);
 
 #if defined (__cplusplus)

--- a/src/core/ddsc/src/dds_entity.c
+++ b/src/core/ddsc/src/dds_entity.c
@@ -1547,3 +1547,27 @@ dds_return_t dds_assert_liveliness (dds_entity_t entity)
   dds_entity_unpin (e);
   return rc;
 }
+
+dds_return_t dds_return_loan (dds_entity_t entity, void **buf, int32_t bufsz)
+{
+  dds_entity *p_entity;
+  dds_return_t ret;
+
+  if (buf == NULL || (buf[0] == NULL && bufsz > 0) || (buf[0] != NULL && bufsz <= 0))
+    return DDS_RETCODE_BAD_PARAMETER;
+
+  if ((ret = dds_entity_pin (entity, &p_entity)) >= 0) {
+    if (dds_entity_kind (p_entity) == DDS_KIND_READER ||
+        dds_entity_kind (p_entity) == DDS_KIND_COND_READ ||
+        dds_entity_kind (p_entity) == DDS_KIND_COND_QUERY) {
+      ret = dds_return_reader_loan(p_entity, buf, bufsz);
+    } else if (dds_entity_kind (p_entity) == DDS_KIND_WRITER) {
+      ret = dds_return_writer_loan((dds_writer *) p_entity, *buf);
+    } else {
+      ret = DDS_RETCODE_ILLEGAL_OPERATION;
+    }
+    dds_entity_unpin (p_entity);
+  }
+  return ret;
+}
+

--- a/src/core/ddsc/src/dds_read.c
+++ b/src/core/ddsc/src/dds_read.c
@@ -13,6 +13,7 @@
 #include <string.h>
 #include "dds__entity.h"
 #include "dds__reader.h"
+#include "dds__writer.h"
 #include "dds/ddsi/ddsi_tkmap.h"
 #include "dds/ddsc/dds_rhc.h"
 #include "dds/ddsi/q_thread.h"
@@ -509,24 +510,28 @@ dds_return_t dds_take_next_wl (dds_entity_t reader, void **buf, dds_sample_info_
   return dds_read_impl (true, reader, buf, 1u, 1u, si, mask, DDS_HANDLE_NIL, true, true);
 }
 
-dds_return_t dds_return_loan (dds_entity_t reader_or_condition, void **buf, int32_t bufsz)
+dds_return_t dds_return_loan (dds_entity_t entity, void **buf, int32_t bufsz)
 {
   dds_reader *rd;
-  dds_entity *entity;
+  dds_entity *p_entity;
   dds_return_t ret;
 
   if (buf == NULL || (buf[0] == NULL && bufsz > 0) || (buf[0] != NULL && bufsz <= 0))
     return DDS_RETCODE_BAD_PARAMETER;
 
-  if ((ret = dds_entity_pin (reader_or_condition, &entity)) < 0) {
+  if ((ret = dds_entity_pin (entity, &p_entity)) < 0) {
     return ret;
-  } else if (dds_entity_kind (entity) == DDS_KIND_READER) {
-    rd = (dds_reader *) entity;
-  } else if (dds_entity_kind (entity) != DDS_KIND_COND_READ && dds_entity_kind (entity) != DDS_KIND_COND_QUERY) {
-    dds_entity_unpin (entity);
+  } else if (dds_entity_kind (p_entity) == DDS_KIND_READER) {
+    rd = (dds_reader *) p_entity;
+  } else if (dds_entity_kind (p_entity) == DDS_KIND_WRITER) {
+    ret = dds_return_writer_loan((dds_writer *) p_entity, *buf);
+    dds_entity_unpin (p_entity);
+    return ret;
+  } else if (dds_entity_kind (p_entity) != DDS_KIND_COND_READ && dds_entity_kind (p_entity) != DDS_KIND_COND_QUERY) {
+    dds_entity_unpin (p_entity);
     return DDS_RETCODE_ILLEGAL_OPERATION;
   } else {
-    rd = (dds_reader *) entity->m_parent;
+    rd = (dds_reader *) p_entity->m_parent;
   }
 
   if (bufsz <= 0)
@@ -534,7 +539,7 @@ dds_return_t dds_return_loan (dds_entity_t reader_or_condition, void **buf, int3
     /* No data whatsoever, or an invocation following a failed read/take call.  Read/take
        already take care of restoring the state prior to their invocation if they return
        no data.  Return late so invalid handles can be detected. */
-    dds_entity_unpin (entity);
+    dds_entity_unpin (p_entity);
     return DDS_RETCODE_OK;
   }
   assert (buf[0] != NULL);
@@ -558,7 +563,7 @@ dds_return_t dds_return_loan (dds_entity_t reader_or_condition, void **buf, int3
   {
     /* Trying to return a loan that has been returned already */
     ddsrt_mutex_unlock (&rd->m_entity.m_mutex);
-    dds_entity_unpin (entity);
+    dds_entity_unpin (p_entity);
     return DDS_RETCODE_PRECONDITION_NOT_MET;
   }
   else
@@ -572,6 +577,6 @@ dds_return_t dds_return_loan (dds_entity_t reader_or_condition, void **buf, int3
     buf[0] = NULL;
   }
   ddsrt_mutex_unlock (&rd->m_entity.m_mutex);
-  dds_entity_unpin (entity);
+  dds_entity_unpin (p_entity);
   return DDS_RETCODE_OK;
 }


### PR DESCRIPTION
This functionality is only supported when CycloneDDS is built using the ENABLE_SHM macro, otherwise it will return DDS_RETCODE_UNSUPPORTED.