### PR TITLE
Emit "default" flag if union has a default case

### DIFF
--- a/src/idl/include/idl/tree.h
+++ b/src/idl/include/idl/tree.h
@@ -466,6 +466,7 @@ IDL_EXPORT bool idl_is_union(const void *node);
 IDL_EXPORT bool idl_is_switch_type_spec(const void *node);
 IDL_EXPORT bool idl_is_case(const void *node);
 IDL_EXPORT bool idl_is_default_case(const void *node);
+IDL_EXPORT bool idl_is_implicit_default_case(const void *ptr);
 IDL_EXPORT bool idl_is_case_label(const void *node);
 IDL_EXPORT bool idl_is_enum(const void *node);
 IDL_EXPORT bool idl_is_enumerator(const void *node);

--- a/src/idl/src/tree.c
+++ b/src/idl/src/tree.c
@@ -1749,6 +1749,18 @@ bool idl_is_default_case(const void *ptr)
   return false;
 }
 
+bool idl_is_implicit_default_case(const void *ptr)
+{
+  const idl_case_t *node = ptr;
+  static const idl_mask_t mask = IDL_IMPLICIT_DEFAULT_CASE_LABEL;
+  if (!(idl_mask(node) & IDL_CASE))
+    return false;
+  for (const idl_case_label_t *cl = node->labels; cl; cl = idl_next(cl))
+    if ((idl_mask(cl) & mask) == mask)
+      return true;
+  return false;
+}
+
 static void delete_case(void *ptr)
 {
   idl_case_t *node = ptr;

--- a/src/tools/idlc/src/descriptor.c
+++ b/src/tools/idlc/src/descriptor.c
@@ -688,6 +688,8 @@ emit_switch_type_spec(
 
   type_spec = idl_unalias(idl_type_spec(node), 0u);
   assert(!idl_is_typedef(type_spec) && !idl_is_array(type_spec));
+  const idl_union_t *union_spec = idl_parent(node);
+  assert(idl_is_union(union_spec));
 
   if ((ret = push_field(descriptor, node, &field)))
     return ret;
@@ -695,6 +697,8 @@ emit_switch_type_spec(
   opcode = DDS_OP_ADR | DDS_OP_TYPE_UNI | typecode(type_spec, SUBTYPE);
   if ((order = idl_is_topic_key(descriptor->topic, (pstate->flags & IDL_FLAG_KEYLIST) != 0, path)))
     opcode |= DDS_OP_FLAG_KEY;
+  if (idl_is_default_case(idl_parent(union_spec->default_case)) && !idl_is_implicit_default_case(idl_parent(union_spec->default_case)))
+    opcode |= DDS_OP_FLAG_DEF;
   if ((ret = stash_opcode(descriptor, nop, opcode, order)))
     return ret;
   if ((ret = stash_offset(descriptor, nop, field)))


### PR DESCRIPTION
A union with a default case needs to have the `DDS_OP_FLAG_DEF` set on the union in the C serializer VM.