### PR TITLE
Returning writer loans

### DIFF
--- a/src/core/ddsc/include/dds/dds.h
+++ b/src/core/ddsc/include/dds/dds.h
@@ -3549,12 +3549,11 @@ dds_read_next_wl(
  *
  * @returns A dds_return_t indicating success or failure
  * @retval DDS_RETCODE_OK
- *             - the operation was successful; for a writer loan, all entries in buf are set to null.
  *             - the operation was successful; for a writer loan, all entries in buf are set to null
  *             - this specifically includes cases where bufsz <= 0 while entity is valid
  * @retval DDS_RETCODE_BAD_PARAMETER
  *             - the entity parameter is not a valid parameter
- *             - buf is null, or buf[0] is null and bufsz > 0 or buf[0] is non-null and bufsz <= 0
+ *             - buf is null, or bufsz > 0 and buf[0] = null
  *             - (for writer loans) buf[0 <= i < bufsz] is null; operation is aborted, all buf[j < i] = null on return
  * @retval DDS_RETCODE_PRECONDITION_NOT_MET
  *             - (for reader loans) buf was already returned (not guaranteed to be detected)

--- a/src/core/ddsc/include/dds/dds.h
+++ b/src/core/ddsc/include/dds/dds.h
@@ -3530,12 +3530,16 @@ dds_read_next_wl(
 /**
  * @brief Return loaned samples to data-reader or condition associated with a data-reader
  *
- * Used to release sample buffers returned by a read/take operation. When the application
- * provides an empty buffer, memory is allocated and managed by DDS. By calling dds_return_loan,
- * the memory is released so that the buffer can be reused during a successive read/take operation.
- * When a condition is provided, the reader to which the condition belongs is looked up.
+ * Used to release sample buffers returned by a read/take operation (a so called reader-loan)
+ * or, in case shared memory is enabled, of the loan_sample operation ( a so called writer-loan).
+ * When the application provides an empty buffer to a reader-loan, memory is allocated and
+ * managed by DDS. By calling dds_return_loan, the reader-loan is released so that the buffer
+ * can be reused during a successive read/take operation. When a condition is provided, the
+ * reader to which the condition belongs is looked up.
+ * Writer-loans are normally released implicitly when writing a loaned sample, but you can
+ * cancel a writer-loan prematurely by invoking the return_loan operation.
  *
- * @param[in] reader_or_condition Reader or condition that belongs to a reader.
+ * @param[in] entity The entity that the loan belongs to.
  * @param[in] buf An array of (pointers to) samples.
  * @param[in] bufsz The number of (pointers to) samples stored in buf.
  *
@@ -3544,7 +3548,7 @@ dds_read_next_wl(
 /* TODO: Add list of possible return codes */
 DDS_EXPORT dds_return_t
 dds_return_loan(
-  dds_entity_t reader_or_condition,
+  dds_entity_t entity,
   void **buf,
   int32_t bufsz);
 

--- a/src/core/ddsc/src/dds__reader.h
+++ b/src/core/ddsc/src/dds__reader.h
@@ -23,6 +23,8 @@ struct status_cb_data;
 
 void dds_reader_status_cb (void *entity, const struct status_cb_data * data);
 
+dds_return_t dds_return_reader_loan (dds_entity *p_entity, void **buf, int32_t bufsz);
+
 /*
   dds_reader_lock_samples: Returns number of samples in read cache and locks the
   reader cache to make sure that the samples content doesn't change.

--- a/src/core/ddsc/src/dds__reader.h
+++ b/src/core/ddsc/src/dds__reader.h
@@ -23,7 +23,7 @@ struct status_cb_data;
 
 void dds_reader_status_cb (void *entity, const struct status_cb_data * data);
 
-dds_return_t dds_return_reader_loan (dds_entity *p_entity, void **buf, int32_t bufsz);
+dds_return_t dds_return_reader_loan (dds_reader *rd, void **buf, int32_t bufsz);
 
 /*
   dds_reader_lock_samples: Returns number of samples in read cache and locks the

--- a/src/core/ddsc/src/dds__writer.h
+++ b/src/core/ddsc/src/dds__writer.h
@@ -23,6 +23,7 @@ DEFINE_ENTITY_LOCK_UNLOCK(inline, dds_writer, DDS_KIND_WRITER)
 struct status_cb_data;
 
 void dds_writer_status_cb (void *entity, const struct status_cb_data * data);
+dds_return_t dds_return_writer_loan(dds_writer *writer, void *sample);
 DDS_EXPORT dds_return_t dds__writer_wait_for_acks (struct dds_writer *wr, ddsi_guid_t *rdguid, dds_time_t abstimeout);
 
 #if defined (__cplusplus)

--- a/src/core/ddsc/src/dds__writer.h
+++ b/src/core/ddsc/src/dds__writer.h
@@ -23,7 +23,7 @@ DEFINE_ENTITY_LOCK_UNLOCK(inline, dds_writer, DDS_KIND_WRITER)
 struct status_cb_data;
 
 void dds_writer_status_cb (void *entity, const struct status_cb_data * data);
-dds_return_t dds_return_writer_loan(dds_writer *writer, void *sample);
+dds_return_t dds_return_writer_loan(dds_writer *writer, void **buf, int32_t bufsz) ddsrt_nonnull_all;
 DDS_EXPORT dds_return_t dds__writer_wait_for_acks (struct dds_writer *wr, ddsi_guid_t *rdguid, dds_time_t abstimeout);
 
 #if defined (__cplusplus)

--- a/src/core/ddsc/src/dds_entity.c
+++ b/src/core/ddsc/src/dds_entity.c
@@ -1589,3 +1589,27 @@ dds_return_t dds_assert_liveliness (dds_entity_t entity)
   dds_entity_unpin (e);
   return rc;
 }
+
+dds_return_t dds_return_loan (dds_entity_t entity, void **buf, int32_t bufsz)
+{
+  dds_entity *p_entity;
+  dds_return_t ret;
+
+  if (buf == NULL || (buf[0] == NULL && bufsz > 0) || (buf[0] != NULL && bufsz <= 0))
+    return DDS_RETCODE_BAD_PARAMETER;
+
+  if ((ret = dds_entity_pin (entity, &p_entity)) >= 0) {
+    if (dds_entity_kind (p_entity) == DDS_KIND_READER ||
+        dds_entity_kind (p_entity) == DDS_KIND_COND_READ ||
+        dds_entity_kind (p_entity) == DDS_KIND_COND_QUERY) {
+      ret = dds_return_reader_loan(p_entity, buf, bufsz);
+    } else if (dds_entity_kind (p_entity) == DDS_KIND_WRITER) {
+      ret = dds_return_writer_loan((dds_writer *) p_entity, *buf);
+    } else {
+      ret = DDS_RETCODE_ILLEGAL_OPERATION;
+    }
+    dds_entity_unpin (p_entity);
+  }
+  return ret;
+}
+

--- a/src/core/ddsc/src/dds_entity.c
+++ b/src/core/ddsc/src/dds_entity.c
@@ -1595,7 +1595,16 @@ dds_return_t dds_return_loan (dds_entity_t entity, void **buf, int32_t bufsz)
   dds_entity *p_entity;
   dds_return_t ret;
 
-  if (buf == NULL || (buf[0] == NULL && bufsz > 0) || (buf[0] != NULL && bufsz <= 0))
+  // bufsz <= 0 is accepted because it allows one to write:
+  //
+  // if (dds_return_loan(rd, buf, dds_take(rd, buf, ...)) < 0)
+  //   abort();
+  //
+  // with abort only being called if there is a real problem.
+  //
+  // The wisdom of such code may be debatable, but it has been allowed for a long
+  // time and changing it may well break existing application code.
+  if (buf == NULL || (bufsz > 0 && buf[0] == NULL))
     return DDS_RETCODE_BAD_PARAMETER;
 
   if ((ret = dds_entity_pin (entity, &p_entity)) < 0)

--- a/src/core/ddsc/src/dds_read.c
+++ b/src/core/ddsc/src/dds_read.c
@@ -509,16 +509,8 @@ dds_return_t dds_take_next_wl (dds_entity_t reader, void **buf, dds_sample_info_
   return dds_read_impl (true, reader, buf, 1u, 1u, si, mask, DDS_HANDLE_NIL, true, true);
 }
 
-dds_return_t dds_return_reader_loan (dds_entity *p_entity, void **buf, int32_t bufsz)
+dds_return_t dds_return_reader_loan (dds_reader *rd, void **buf, int32_t bufsz)
 {
-  dds_reader *rd;
-
-  if (dds_entity_kind (p_entity) == DDS_KIND_READER) {
-    rd = (dds_reader *) p_entity;
-  } else {
-    rd = (dds_reader *) p_entity->m_parent;
-  }
-
   if (bufsz <= 0)
   {
     /* No data whatsoever, or an invocation following a failed read/take call.  Read/take

--- a/src/core/ddsc/tests/Array100.idl
+++ b/src/core/ddsc/tests/Array100.idl
@@ -1,0 +1,15 @@
+/*
+ * Copyright(c) 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+struct Array100 {
+  octet data[100];
+};
+#pragma keylist Array100

--- a/src/core/ddsc/tests/CMakeLists.txt
+++ b/src/core/ddsc/tests/CMakeLists.txt
@@ -144,6 +144,8 @@ target_link_libraries(oneliner PRIVATE RoundTrip Space ddsc)
 # better not be part of the tests.  That also saves us from
 # having to figure out now how to start/stop RouDi on Windows.
 if(iceoryx_binding_c_FOUND AND NOT WIN32)
+  idlc_generate(TARGET Array100 FILES Array100.idl)
+
   add_cunit_executable(cunit_ddsc_iox
     "iceoryx.c"
     "test_util.c"
@@ -155,7 +157,7 @@ if(iceoryx_binding_c_FOUND AND NOT WIN32)
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../ddsi/include>"
     "$<BUILD_INTERFACE:$<TARGET_PROPERTY:iceoryx_binding_c::iceoryx_binding_c,INTERFACE_INCLUDE_DIRECTORIES>>")
 
-  target_link_libraries(cunit_ddsc_iox PRIVATE RoundTrip Space ddsc)
+  target_link_libraries(cunit_ddsc_iox PRIVATE RoundTrip Space Array100 ddsc)
 
   # We need to start RouDi, so we need to find it
   find_program(ICEORYX_ROUDI iox-roudi REQUIRED)
@@ -195,10 +197,12 @@ kill -0 `cat ctest_fixture_iox_roudi.pid`")
   add_test(NAME stop_roudi COMMAND bash -c "kill `cat ctest_fixture_iox_roudi.pid` ; cat ctest_fixture_iox_roudi.output")
 
   set_tests_properties(CUnit_ddsc_iceoryx_one_writer PROPERTIES FIXTURES_REQUIRED iox)
+  set_tests_properties(CUnit_ddsc_iceoryx_return_loan PROPERTIES FIXTURES_REQUIRED iox)
   set_tests_properties(start_roudi PROPERTIES FIXTURES_SETUP iox)
   set_tests_properties(stop_roudi PROPERTIES FIXTURES_CLEANUP iox)
   set_tests_properties(
     CUnit_ddsc_iceoryx_one_writer
+    CUnit_ddsc_iceoryx_return_loan
     start_roudi
     stop_roudi
     PROPERTIES RESOURCE_LOCK iox_lock)

--- a/src/core/ddsc/tests/loan.c
+++ b/src/core/ddsc/tests/loan.c
@@ -64,15 +64,11 @@ CU_Test (ddsc_loan, bad_params, .init = create_entities, .fini = delete_entities
   void *buf = NULL;
   result = dds_return_loan (reader, &buf, 1);
   CU_ASSERT (result == DDS_RETCODE_BAD_PARAMETER);
+
+  /* not a reader or condition (checking only the ones we have at hand) */
   /* buf[0] != NULL, size <= 0 */
   char dummy = 0;
   buf = &dummy;
-  result = dds_return_loan (reader, &buf, 0);
-  CU_ASSERT (result == DDS_RETCODE_BAD_PARAMETER);
-  result = dds_return_loan (reader, &buf, -1);
-  CU_ASSERT (result == DDS_RETCODE_BAD_PARAMETER);
-
-  /* not a reader or condition (checking only the ones we have at hand) */
   result = dds_return_loan (participant, &buf, 1);
   CU_ASSERT (result == DDS_RETCODE_ILLEGAL_OPERATION);
   result = dds_return_loan (topic, &buf, 1);


### PR DESCRIPTION
This reworks some details in #871 because I had hoped to be able to merge this last week already (@e-hndrks, I hope you don't mind):
* consistent behaviour between returning reader and writer loans
* fixes to input checking (though these were arguably already broken in the `dds_return_loan`)
* more precise specification of the behaviour in the doxygen comment
* somehow these also led to some cosmetic changes that I wouldn't have bothered with if it weren't for the above