### PR TITLE
Skip all work in tracing addrset calculation if no trace needed

### DIFF
--- a/src/core/ddsi/src/ddsi_wraddrset.c
+++ b/src/core/ddsi/src/ddsi_wraddrset.c
@@ -610,6 +610,8 @@ static struct costmap *wras_calc_costmap (const struct cover *covered, bool pref
 
 static void wras_trace_cover (const struct ddsi_domaingv *gv, const struct locset *locs, const struct costmap *wm, const struct cover *covered)
 {
+  if (!(gv->logconfig.c.mask & DDS_LC_DISCOVERY))
+    return;
   const int nreaders = cover_get_nreaders (covered);
   const int nlocs = cover_get_nlocs (covered);
   assert (nlocs == locs->nlocs);


### PR DESCRIPTION
What it says on the tin. If the trace is disabled, why do any work specifically for tracing ...

I don't know if the person who discovered the enormous overhead of all the conversions of locators to strings wants to mentioned here (see the flamegraph below) but I do want express my thanks publicly!

![image](https://user-images.githubusercontent.com/16984005/128004109-671f2989-ffb8-4f08-bfe6-cda39afb38c6.png)
