### PR TITLE
OpenDDS compatibility

### DIFF
--- a/src/core/ddsi/src/q_receive.c
+++ b/src/core/ddsi/src/q_receive.c
@@ -3531,6 +3531,19 @@ uint32_t recv_thread (void *vrecv_thread_arg)
       if ((rc = recv_thread_waitset_add_conn (waitset, gv->data_conn_mc)) < 0)
         DDS_FATAL("recv_thread: failed to add data_conn_mc to waitset\n");
       num_fixed += (unsigned)rc;
+
+      // OpenDDS doesn't respect the locator lists and insists on sending to the
+      // socket it received packets from
+      for (int i = 0; i < gv->n_interfaces; i++)
+      {
+        // Iceoryx gets added as a pseudo-interface but there's no socket to wait
+        // for input on
+        if (ddsi_conn_handle (gv->xmit_conns[i]) == DDSRT_INVALID_SOCKET)
+          continue;
+        if ((rc = recv_thread_waitset_add_conn (waitset, gv->xmit_conns[i])) < 0)
+          DDS_FATAL("recv_thread: failed to add transmit_conn[%d] to waitset\n", i);
+        num_fixed += (unsigned)rc;
+      }
     }
 
     while (ddsrt_atomic_ld32 (&gv->rtps_keepgoing))


### PR DESCRIPTION
Cyclone never advertises the sockets it uses to transmit packets, and so relevant data should never arrive on them, but OpenDDS insists on ignoring the locator lists.

It is debatable whether Cyclone should be changed to fix an OpenDDS problem, but the change and the impact of the change is minimal.