### PR TITLE
Possibility of testing byteswapped input in non-default serdata implementations

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/ddsi_cdrstream.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_cdrstream.h
@@ -41,6 +41,7 @@ DDS_EXPORT void dds_ostreamBE_init (dds_ostreamBE_t * __restrict st, uint32_t si
 DDS_EXPORT void dds_ostreamBE_fini (dds_ostreamBE_t * __restrict st);
 
 bool dds_stream_normalize (void * __restrict data, uint32_t size, bool bswap, const struct ddsi_sertype_default * __restrict type, bool just_key);
+bool dds_stream_native_to_swapped (void * __restrict data, uint32_t size, const struct ddsi_sertype_default * __restrict topic, bool just_key);
 
 void dds_stream_write_sample (dds_ostream_t * __restrict os, const void * __restrict data, const struct ddsi_sertype_default * __restrict type);
 void dds_stream_read_sample (dds_istream_t * __restrict is, void * __restrict data, const struct ddsi_sertype_default * __restrict type);


### PR DESCRIPTION
This may be of sufficient value to be included in the Cyclone source tree, but then again, it may not be. It changes the CDR serializer a bit, the upcoming work on XTypes may well render this irrelevant anyway. It has proven useful in testing the C++ deserializer.

* Converting a CDR stream from native-to-swapped by making the boolean
  "bswap" a tri-state, where 0 and 1 correspond to the original
  behaviour of false and true; and where -1 forces it to byteswap after
  reading from the stream (needed for string/sequence lengths and union
  discriminators)

* Adds a reasonable interface for this: dds_stream_native_to_swapped

* Makes ddsi_serdata_ref_as_type end up creating a swapped copy of the
  input CDR if a compile-time switch is thrown

Signed-off-by: Erik Boasson <eb@ilities.com>