### PR TITLE
Make sure to use buffer with truncated name for pthread_setname_np

### DIFF
--- a/src/ddsrt/src/threads/posix/threads.c
+++ b/src/ddsrt/src/threads/posix/threads.c
@@ -129,7 +129,7 @@ ddsrt_thread_setname(const char *__restrict name)
      name exceeds the limit, so silently truncate. */
   char buf[MAXTHREADNAMESIZE + 1] = "";
   (void)ddsrt_strlcpy(buf, name, sizeof(buf));
-  (void)pthread_setname_np(pthread_self(), name);
+  (void)pthread_setname_np(pthread_self(), buf);
 #elif defined(__APPLE__)
   (void)pthread_setname_np(name);
 #elif defined(__FreeBSD__)


### PR DESCRIPTION
Otherwise names with a length of > 16 characters (including null character) will silently not be used on Linux.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>