### PR TITLE
Duplicate increment of input buffer position upon array key readout

### DIFF
--- a/src/core/ddsi/src/ddsi_cdrstream.c
+++ b/src/core/ddsi/src/ddsi_cdrstream.c
@@ -1620,7 +1620,6 @@ static void dds_stream_extract_key_from_key_prim_op (dds_istream_t * __restrict 
       void * const dst = os->m_buffer + os->m_index;
       dds_is_get_bytes (is, dst, num, align);
       os->m_index += num * align;
-      is->m_index += num * align;
       break;
     }
     case DDS_OP_VAL_SEQ: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU: {


### PR DESCRIPTION
Ran into this while fuzzy testing the Python serializer for key correctness: this statement is duplicated between the removed line and the function ``dds_is_get_bytes``, resulting in incorrect keys or even segfaults when a type has multiple keys and an array key occurs before another key.