### PR TITLE
Ignore DDS_INLINE_EXPORT in Doxygen build

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -97,6 +97,7 @@ if(BUILD_DOCS)
     "__attribute__="
     "__declspec(x)="
     "DDS_EXPORT="
+    "DDS_INLINE_EXPORT="
     "DDS_DEPRECATED_EXPORT="
     "DDSRT_STATIC_ASSERT(x)=")
   find_package(Doxygen REQUIRED)


### PR DESCRIPTION
What it says in the title. Verified locally.