### PR TITLE
Add IDL compiler option to specify the output directory for the generated code (fixes #801)

### DIFF
--- a/src/idl/include/idl/processor.h
+++ b/src/idl/include/idl/processor.h
@@ -56,6 +56,7 @@ struct idl_pstate {
   idl_file_t *paths; /**< normalized paths used in include statements */
   idl_file_t *files; /**< filenames used in #line directives */
   idl_source_t *sources;
+  char *outdir; /**< output directory */
   idl_scope_t *global_scope, *annotation_scope, *scope;
   void *directive;
   idl_node_t *builtin_root, *root;

--- a/src/idl/src/processor.c
+++ b/src/idl/src/processor.c
@@ -226,6 +226,7 @@ void idl_delete_pstate(idl_pstate_t *pstate)
     /* buffer */
     if (pstate->buffer.data)
       free(pstate->buffer.data);
+    free(pstate->outdir);
     free(pstate);
   }
 }

--- a/src/tools/idlc/src/generator.c
+++ b/src/tools/idlc/src/generator.c
@@ -356,7 +356,12 @@ idlc_generate(const idl_pstate_t *pstate)
   }
 
   file = sep ? sep + 1 : path;
-  if (idl_isabsolute(path) || !sep)
+  if (pstate->outdir) {
+    if (!(dir = idl_strdup(pstate->outdir))) {
+      goto err_dir;
+    }
+  }
+  else if (idl_isabsolute(path) || !sep)
     dir = empty;
   else if (!(dir = idl_strndup(path, (size_t)(sep-path))))
     goto err_dir;

--- a/src/tools/idlc/src/idlc.c
+++ b/src/tools/idlc/src/idlc.c
@@ -46,6 +46,7 @@
 static struct {
   char *file; /* path of input file or "-" for STDIN */
   const char *lang;
+  const char *outdir;
   int compile;
   int preprocess;
   int keylist;
@@ -285,6 +286,12 @@ static idl_retcode_t idlc_parse(void)
       idl_delete_pstate(pstate);
       return IDL_RETCODE_NO_MEMORY;
     }
+    if (config.outdir) {
+      if (!(pstate->outdir = idl_strdup(config.outdir))) {
+        idl_delete_pstate(pstate);
+        return IDL_RETCODE_NO_MEMORY;
+      }
+    }
     source->parent = NULL;
     source->previous = source->next = NULL;
     source->includes = NULL;
@@ -463,6 +470,9 @@ static const idlc_option_t *compopts[] = {
   &(idlc_option_t){
     IDLC_STRING, { .string = &config.lang }, 'l', "", "<language>",
     "Compile representation for <language>. (default:c)." },
+  &(idlc_option_t){
+    IDLC_STRING, { .string = &config.outdir }, 'd', "", "<directory>",
+    "Specify the location where to place the generated files." },
   &(idlc_option_t){
     IDLC_FLAG, { .flag = &config.version }, 'v', "", "",
     "Display version information." },


### PR DESCRIPTION
This PR adds a `char *outdir;` member to `idl_pstate`, along with option handling and setting the output directory in `idlc_generate`. A separate PR for `cyclonedds-cxx` will be submitted as well.