### PR TITLE
Keep weak references to annotatable metadata in IDL tree

### DIFF
--- a/src/core/ddsc/tests/topic.c
+++ b/src/core/ddsc/tests/topic.c
@@ -242,7 +242,7 @@ CU_Test(ddsc_topic_get_type_name, deleted, .init = ddsc_topic_init, .fini = ddsc
 CU_Test(ddsc_topic_set_qos, valid, .init = ddsc_topic_init, .fini = ddsc_topic_fini)
 {
   dds_return_t ret;
-  char data[10];
+  char data[10] = { 0 };
   dds_qset_topicdata(g_qos, &data, 10);
   ret = dds_set_qos(g_topic_rtmdt, g_qos);
   CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);

--- a/src/idl/src/annotation.c
+++ b/src/idl/src/annotation.c
@@ -660,7 +660,6 @@ idl_annotate(
   if ((ret = dedup(pstate, node, annotation_appls)))
     return ret;
 
-  ((idl_node_t *)node)->annotations = annotation_appls;
   for (idl_annotation_appl_t *a = annotation_appls; a; a = idl_next(a)) {
     idl_annotation_callback_t callback = a->annotation->callback;
     if (callback && (ret = callback(pstate, a, node)))
@@ -668,5 +667,6 @@ idl_annotate(
     a->node.parent = node;
   }
 
+  ((idl_node_t *)node)->annotations = annotation_appls;
   return IDL_RETCODE_OK;
 }

--- a/src/idl/src/expression.c
+++ b/src/idl/src/expression.c
@@ -970,9 +970,9 @@ compare_enum(const idl_const_expr_t *lhs, const idl_const_expr_t *rhs)
   assert(idl_is_enumerator(rval));
   if (lval->node.parent != rval->node.parent)
     return IDL_MISMATCH; /* incompatible enums */
-  if (lval->value < rval->value)
+  if (lval->value.value < rval->value.value)
     return IDL_LESS;
-  if (lval->value > rval->value)
+  if (lval->value.value > rval->value.value)
     return IDL_GREATER;
   return IDL_EQUAL;
 }

--- a/src/idl/src/parser.y
+++ b/src/idl/src/parser.y
@@ -467,7 +467,7 @@ primary_expr:
              (builtin) annotation, stick to syntax checks */
           const idl_declaration_t *declaration = NULL;
           static const char fmt[] =
-            "Scoped name '%s' does not resolve to an enumerator or a contant";
+            "Scoped name '%s' does not resolve to an enumerator or a constant";
           TRY(idl_resolve(pstate, 0u, $1, &declaration));
           if (!(idl_mask(declaration->node) & (IDL_CONST|IDL_ENUMERATOR)))
             SEMANTIC_ERROR(pstate, &@1, fmt, $1->identifier);

--- a/src/idl/tests/module.c
+++ b/src/idl/tests/module.c
@@ -56,7 +56,7 @@ CU_Test(idl_module, reopen)
   assert(mem1);
   CU_ASSERT_PTR_EQUAL(s1,mem1->node.parent);
   CU_ASSERT((idl_mask(mem1->type_spec) & IDL_LONG) == IDL_LONG);
-  CU_ASSERT(!mem1->key);
+  CU_ASSERT(!mem1->key.value);
 
   idl_declarator_t* decl1 = mem1->declarators;
   CU_ASSERT_PTR_NOT_NULL_FATAL(decl1);
@@ -84,7 +84,7 @@ CU_Test(idl_module, reopen)
   assert(mem2);
   CU_ASSERT_PTR_EQUAL(s2, mem2->node.parent);
   CU_ASSERT_PTR_EQUAL(mem2->type_spec, s1);
-  CU_ASSERT(!mem2->key);
+  CU_ASSERT(!mem2->key.value);
 
   idl_declarator_t* decl2 = mem2->declarators;
   CU_ASSERT_PTR_NOT_NULL_FATAL(decl2);

--- a/src/tools/idlc/src/types.c
+++ b/src/tools/idlc/src/types.c
@@ -403,7 +403,7 @@ emit_enum(
   for (; enumerator; enumerator = idl_next(enumerator)) {
     if (IDL_PRINTA(&name, print_type, enumerator) < 0)
       return IDL_RETCODE_NO_MEMORY;
-    value = enumerator->value;
+    value = enumerator->value.value;
     /* FIXME: IDL 3.5 did not support fixed enumerator values */
     if (value == skip)
       fmt = "%s  %s";


### PR DESCRIPTION
This PR changes the tree structure around to keep a reference to the actual annotation used to assign (or not) a certain value. This makes some of the constructs a little easier, like the field identifier for struct members and allows us to check if a certain value must be assigned when closing the enclosing scope or has been previously assigned through annotations.

This impacts #903 by @dennis-adlink and #919 by @reicheratwork. I think I'm going to write a couple more tests, but if you could check if this'll work for you, that'd be much appreciated.