### PR TITLE
Cache Eclipse Iceoryx

### DIFF
--- a/.azure/templates/build-test.yml
+++ b/.azure/templates/build-test.yml
@@ -73,15 +73,20 @@ steps:
   - template: /.azure/templates/install-conan.yml
   - bash: |
       set -e -x
-      if [[ "${ICEORYX}" = 'on' ]] ; then
-        sudo apt install libacl1-dev libncurses5-dev pkg-config && \
-          git clone https://github.com/eclipse-iceoryx/iceoryx.git && \
-          cd iceoryx && \
-          cmake -Bbuild -Hiceoryx_meta -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=${BUILD_TYPE} && \
-          cmake --build build && \
-          sudo cmake --build build --target install
-      fi
-    name: iceoryx
+      sudo apt install libacl1-dev libncurses5-dev pkg-config
+      git clone --depth 1 \
+                --branch "${ICEORYX_BRANCH:-v1.0.1}" \
+                "${ICEORYX_REPOSITORY:-https://github.com/eclipse-iceoryx/iceoryx.git}" \
+                iceoryx
+      mkdir iceoryx/build
+      cd iceoryx/build
+      cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+            -DCMAKE_BUILD_SHARED_LIBS=on \
+            -DCMAKE_INSTALL_PREFIX=install \
+            ${GENERATOR:+-G} "${GENERATOR}" -A "${PLATFORM}" -T "${TOOLSET}" ../iceoryx_meta
+      cmake --build . --config ${BUILD_TYPE} --target install -- ${BUILD_TOOL_OPTIONS}
+    condition: eq(variables['iceoryx'], 'on')
+    name: install_iceoryx
   - bash: |
       set -e -x
       mkdir build
@@ -89,6 +94,7 @@ steps:
       conan install -b missing -pr:b ${BUILD_PROFILE} -pr:h ${HOST_PROFILE} -s build_type=${BUILD_TYPE} ../${CONANFILE:-conanfile.txt}
       cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
             -DCMAKE_INSTALL_PREFIX=install \
+            -DCMAKE_PREFIX_PATH="${BUILD_SOURCESDIRECTORY}/iceoryx/build/install" \
             -DANALYZER=${ANALYZER:-off} \
             -DSANITIZER=${SANITIZER:-none} \
             -DENABLE_SSL=${SSL:-on} \


### PR DESCRIPTION
This PR caches Eclipse Iceoryx builds if enabled for that pipeline and pins the version use to v1.0.1. By setting the `iceoryx_branch` and `iceoryx_repository` variables the respective version and origin can be overruled.