### PR TITLE
Dereference as void* to avoid crash with -O2

### DIFF
--- a/src/idl/src/tree.c
+++ b/src/idl/src/tree.c
@@ -277,7 +277,7 @@ create_node(
   node->describe = methods->describe;
   node->references = 1;
 
-  *((idl_node_t **)nodep) = node;
+  *((void **)nodep) = (void *)node;
   return IDL_RETCODE_OK;
 }
 


### PR DESCRIPTION
Ref: [pr 809](https://github.com/eclipse-cyclonedds/cyclonedds/pull/809)

This fix cyclonedds building in ArchLinux with GCC 11.1. Related issue https://github.com/eclipse-cyclonedds/cyclonedds/issues/808

Signed-off-by: Homalozoa <xuhaiwang@xiaomi.com>