### PR TITLE
Add python idl locator to idlc.

### DIFF
--- a/src/tools/idlc/src/plugin.c
+++ b/src/tools/idlc/src/plugin.c
@@ -21,6 +21,8 @@
 static const char sep[] = "/\\";
 static const char lib[] = "";
 static const char ext[] = "dll";
+#define SUBPROCESS_POPEN _popen
+#define SUBPROCESS_PCLOSE _pclose
 #else
 #include <dlfcn.h>
 static const char sep[] = "/";
@@ -30,6 +32,8 @@ static const char ext[] = "dylib";
 #else
 static const char ext[] = "so";
 #endif
+#define SUBPROCESS_POPEN popen
+#define SUBPROCESS_PCLOSE pclose
 #endif
 
 #include "plugin.h"
@@ -86,6 +90,63 @@ static void liberror(char *buffer, size_t bufferlen)
   buffer[bufferlen - 1] = 0; /* ensure final zero in all cases */
 }
 
+#define SUBPROCESS_PIPE_MEMORY_LIMIT 1024 * 1024
+static int run_library_locator(const char *command, char **out_output) {
+  size_t output_size = 0;
+  size_t output_pt = 0;
+  char *output = NULL;
+  FILE *pipe;
+  int ret = 0;
+  bool success = true;
+  int c;
+
+  if ((pipe = SUBPROCESS_POPEN (command, "r")) == NULL) {
+    // broken-pipe
+    return -1;
+  }
+
+  while ((c = fgetc(pipe)) != EOF) {
+    if (c == '\n' || c == '\r') {
+      break;
+    }
+
+    if (output_pt == output_size) {
+      output_size += 128;
+      if (output_size > SUBPROCESS_PIPE_MEMORY_LIMIT) {
+        success = false;
+        break;
+      }
+
+      char* new = (char*) realloc(output, output_size);
+      if (!new) {
+        success = false;
+        break;
+      }
+      output = new;
+    }
+
+    output[output_pt++] = (char) c;
+  }
+
+  ret = SUBPROCESS_PCLOSE (pipe);
+
+  if (success && output != NULL && ret == 0) {
+    // ensure proper string termination (might be newline)
+    output[output_pt] = '\0';
+    *out_output = output;
+
+    return 0;
+  }
+
+  // error
+  if (output) {
+    free(output);
+  }
+
+  return -1;
+}
+
+
 extern int idlc_generate(const idl_pstate_t *pstate);
 
 int32_t
@@ -106,8 +167,24 @@ idlc_load_generator(idlc_generator_plugin_t *plugin, const char *lang)
     return 0;
   }
 
+  /* special case for python generator
+        The 'active' idlpy library is dependend on which python is active. Idlpy is installed
+        as part of the cyclonedds python package and it can very well be that multiple installations
+        are present on the system, by use of virtual environments, user installs and system installs.
+        Sadly activating a python distribution does not set a any library loading paths. However,
+        the python cyclonedds package has a __idlc__ module that prints the path when executed. The
+        'python3' executable is always guaranteed to point to the active python so we always get the
+        correct idlpy library.
+   */
+  if (idl_strcasecmp(lang, "py") == 0) {
+    if (run_library_locator("python3 -m cyclonedds.__idlc__", &file) != 0) {
+      return -1;
+    }
+    path = (const char*) file;
+  }
+
   /* figure out if user passed library or language */
-  if ((sep[0] && strchr(lang, sep[0])) || (sep[1] && strchr(lang, sep[1]))) {
+  else if ((sep[0] && strchr(lang, sep[0])) || (sep[1] && strchr(lang, sep[1]))) {
     path = lang; /* lang includes a directory separator, it is a path */
   } else if (len > extlen && strcmp(lang + (len - extlen), ext) == 0) {
     path = lang; /* lang terminates with extension of plugins (libs), it is a path */


### PR DESCRIPTION
Since python packages can be installed to multiple locations (system, user or virtual environment) there can be multiple idlpy libraries on your system. Which one should be used depends on which python is active in  your shell environment. Sadly, activating a python installation does not change library loading paths so regular library locating mechanisms will not work.

In cyclonedds-python there is a module called `cyclonedds.__idlc__` which prints the full path to the idlpy library it is installed with. This PR adds a locator mechanism to idlc which tries to run this module when executing `idlc -l py`. This kind of mechanism will probably also be needed for other language backends down the line.