### PR TITLE
Documentation has two different "default" values for ParticipantIndex

### DIFF
--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -116,8 +116,6 @@ This element specifies the DDSI participant index used by this instance of the C
 
  * none:, which causes it to use arbitrary port numbers for unicast sockets which entirely removes the constraints on the participant index but makes unicast discovery impossible.
 
-The default is auto. The participant index is part of the port number calculation and if predictable port numbers are needed and fixing the participant index has no adverse effects, it is recommended that the second be option be used.
-
 The default value is: "none".
 
 


### PR DESCRIPTION
https://github.com/eclipse-cyclonedds/cyclonedds/blob/master/docs/manual/options.md#cycloneddsdomaindiscoveryparticipantindex

```
The default is auto. The participant index is part of the port number calculation and if predictable port numbers are needed and fixing the participant index has no adverse effects, it is recommended that the second be option be used.

The default value is: "none".
```

I believe the actual default is none, not sure if other files need changing though.