### PR TITLE
Add compiler option to specify prefix directory

### DIFF
--- a/src/idl/include/idl/file.h
+++ b/src/idl/include/idl/file.h
@@ -30,4 +30,7 @@ idl_normalize_path(const char *path, char **abspathp);
 IDL_EXPORT idl_retcode_t
 idl_relative_path(const char *base, const char *path, char **relpathp);
 
+IDL_EXPORT int
+idl_mkpath(const char *path);
+
 #endif /* IDL_FILE_H */

--- a/src/idl/include/idl/string.h
+++ b/src/idl/include/idl/string.h
@@ -41,6 +41,8 @@ IDL_EXPORT char *idl_strdup(const char *str);
 
 IDL_EXPORT char *idl_strndup(const char *str, size_t len);
 
+IDL_EXPORT size_t idl_strlcpy(char * __restrict dest, const char * __restrict src, size_t size);
+
 IDL_EXPORT int idl_snprintf(char *str, size_t size, const char *fmt, ...)
 idl_attribute_format_printf(3, 4);
 

--- a/src/idl/src/string.c
+++ b/src/idl/src/string.c
@@ -139,6 +139,26 @@ char *idl_strndup(const char *str, size_t len)
   return s;
 }
 
+size_t idl_strlcpy(char * __restrict dest, const char * __restrict src, size_t size)
+{
+  size_t srclen;
+
+  assert(dest != NULL);
+  assert(src != NULL);
+
+  /* strlcpy must return the number of bytes that (would) have been written, i.e. the length of src. */
+  srclen = strlen(src);
+  if (size > 0) {
+    size_t len = srclen;
+    if (size <= srclen)
+      len = size - 1;
+    memcpy(dest, src, len);
+    dest[len] = '\0';
+  }
+
+  return srclen;
+}
+
 int idl_vsnprintf(char *str, size_t size, const char *fmt, va_list ap)
 {
 #if _WIN32

--- a/src/tools/idlc/include/idlc/generator.h
+++ b/src/tools/idlc/include/idlc/generator.h
@@ -12,25 +12,6 @@
 #ifndef IDLC_GENERATOR_H
 #define IDLC_GENERATOR_H
 
-#include <stdint.h>
-
-#include "idl/processor.h"
-#include "idlc/options.h"
-
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
-#define IDLC_GENERATOR_OPTIONS generator_options
-#define IDLC_GENERATOR_ANNOTATIONS generator_annotations
-#define IDLC_GENERATE generate
-
-typedef const idlc_option_t **(*idlc_generator_options_t)(void);
-typedef const idl_builtin_annotation_t **(*idlc_generator_annotations_t)(void);
-typedef int(*idlc_generate_t)(const idl_pstate_t *);
-
-#if defined(__cplusplus)
-}
-#endif
+#include "idlc.h"
 
 #endif /* IDLC_GENERATOR_H */

--- a/src/tools/idlc/include/idlc/idlc.h
+++ b/src/tools/idlc/include/idlc/idlc.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright(c) 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#ifndef IDLC_H
+#define IDLC_H
+
+#include <stdbool.h>
+
+#include "idl/processor.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#define IDLC_NO_MEMORY (-1)
+#define IDLC_BAD_OPTION (-2)
+#define IDLC_NO_ARGUMENT (-3)
+#define IDLC_BAD_ARGUMENT (-4)
+
+typedef struct idlc_option idlc_option_t;
+struct idlc_option {
+  enum {
+    IDLC_FLAG, /**< flag-only, i.e. (sub)option without argument */
+    IDLC_STRING,
+    IDLC_FUNCTION,
+  } type;
+  union {
+    int *flag;
+    const char **string;
+    int (*function)(const idlc_option_t *, const char *);
+  } store;
+  char option; /**< option, i.e. "o" in "-o". "-h" is reserved */
+  char *suboption; /**< name of suboption, i.e. "mount" in "-o mount" */
+  char *argument;
+  char *help;
+};
+
+typedef struct idlc_config idlc_config_t;
+struct idlc_config {
+  const char *file; /**< Path of input file or "-" for STDIN */
+  const char *prefix; /**< Path to prefix output path with */
+  const char *language; /**< Language e.g. cxx or path to generator library */
+  int compile;
+  int preprocess;
+  int keylist;
+  int case_sensitive;
+  int help;
+  int version;
+  /* (emulated) command line options for mcpp (idlpp) */
+  int argc;
+  const char **argv;
+};
+
+/** Compiler options as used by idlc not specific to any backend */
+extern const idlc_config_t *idlc_config;
+
+#define IDLC_GENERATOR_OPTIONS generator_options
+#define IDLC_GENERATOR_ANNOTATIONS generator_annotations
+#define IDLC_GENERATE generate
+
+typedef const idlc_option_t **(*idlc_generator_options_t)(void);
+typedef const idl_builtin_annotation_t **(*idlc_generator_annotations_t)(void);
+typedef int(*idlc_generate_t)(const idl_pstate_t *);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* IDLC_H */

--- a/src/tools/idlc/include/idlc/options.h
+++ b/src/tools/idlc/include/idlc/options.h
@@ -12,37 +12,6 @@
 #ifndef IDLC_OPTIONS_H
 #define IDLC_OPTIONS_H
 
-#include <stdbool.h>
-
-#if defined(__cplusplus)
-extern "C" {
-#endif
-
-#define IDLC_NO_MEMORY (-1)
-#define IDLC_BAD_OPTION (-2)
-#define IDLC_NO_ARGUMENT (-3)
-#define IDLC_BAD_ARGUMENT (-4)
-
-typedef struct idlc_option idlc_option_t;
-struct idlc_option {
-  enum {
-    IDLC_FLAG, /**< flag-only, i.e. (sub)option without argument */
-    IDLC_STRING,
-    IDLC_FUNCTION,
-  } type;
-  union {
-    int *flag;
-    const char **string;
-    int (*function)(const idlc_option_t *, const char *);
-  } store;
-  char option; /**< option, i.e. "o" in "-o". "-h" is reserved */
-  char *suboption; /**< name of suboption, i.e. "mount" in "-o mount" */
-  char *argument;
-  char *help;
-};
-
-#if defined(__cplusplus)
-}
-#endif
+#include "idlc.h"
 
 #endif /* IDLC_OPTIONS_H */

--- a/src/tools/idlc/src/generator.h
+++ b/src/tools/idlc/src/generator.h
@@ -15,6 +15,7 @@
 #include <stdio.h>
 
 #include "idl/processor.h"
+#include "idlc/idlc.h"
 
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
This PR add the `-p` command line option (short for prefix) to the IDL compiler to achieve the desired functionality mentioned in #801 and #922. Instead of letting a user simply specify the output directory I've chosen to name it the prefix directory because the structure is kept if the specified path is relative. For instance `baz/bar/foo.*` is generated if the file passed along is `baz/bar/foo.idl`. This is meant to help out with e.g. ROS2 use cases where some files have the same name. `foo.*` is generated if a full path to the file is specified or the relative path to `foo.idl` does not contain any directories. This PR let's the user specify a prefix different from the current working directory. So, running `idlc -p foobar baz/bar/foo.idl` generates `foo.*` in `foobar/baz/bar`.

This draft PR is mainly to get some input. I still have to write tests etc, I've only run it once myself. You've been warned :slightly_smiling_face: 