### PR TITLE
Avoid some undocumented interfaces in bison

### DIFF
--- a/src/idl/include/idl/processor.h
+++ b/src/idl/include/idl/processor.h
@@ -116,6 +116,7 @@ struct idl_pstate {
       IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS
     } state;
     void *yypstate; /**< state of Bison generated parser */
+    idl_retcode_t result; /**< return value from idl_parse */
   } parser;
 };
 

--- a/src/idl/include/idl/processor.h
+++ b/src/idl/include/idl/processor.h
@@ -116,7 +116,6 @@ struct idl_pstate {
       IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS
     } state;
     void *yypstate; /**< state of Bison generated parser */
-    idl_retcode_t result; /**< return value from idl_parse */
   } parser;
 };
 

--- a/src/idl/src/processor.c
+++ b/src/idl/src/processor.c
@@ -169,7 +169,6 @@ idl_create_pstate(
   pstate->keylists = false;
   pstate->annotations = false;
   pstate->parser.state = IDL_PARSE;
-  pstate->parser.result = IDL_RETCODE_BAD_PARAMETER;
   pstate->scanner.state = IDL_SCAN;
   memset(&pstate->buffer, 0, sizeof(pstate->buffer));
   memset(&pstate->scanner, 0, sizeof(pstate->scanner));
@@ -316,12 +315,13 @@ static idl_retcode_t parse_grammar(idl_pstate_t *pstate, idl_token_t *tok)
       break;
   }
 
-  switch (idl_yypush_parse(pstate->parser.yypstate, tok->code, &yylval, &tok->location, pstate))
+  idl_retcode_t result = IDL_RETCODE_BAD_PARAMETER;
+  switch (idl_yypush_parse(pstate->parser.yypstate, tok->code, &yylval, &tok->location, pstate, &result))
   {
     case 0:
       return IDL_RETCODE_OK;
     case 1:
-      return pstate->parser.result;
+      return result;
     case 2:
       return IDL_RETCODE_NO_MEMORY;
     case YYPUSH_MORE:


### PR DESCRIPTION
This fixes incompatibilities with bison 3.8:

* returning user-defined values from yyparse is not supported, this
  works aruond that by storing a more meaningful return value in the
  parser state object;

* the token name table generated by %token-table is deprecated and has
  been for quite some time, and it seems that now the accompanying
  mapping to internal token numbers is gone as well, this uses a hack to
  work around that.

A follow-up fix is needed to remove the use of the token name table
entirely.  The hack here is attractive only in that it provides a quick
solution for the failing CI runs on macOS.

Signed-off-by: Erik Boasson <eb@ilities.com>