### PR TITLE
Config error handling

### DIFF
--- a/etc/coverity-model.c
+++ b/etc/coverity-model.c
@@ -1,0 +1,7 @@
+int CU_assertImplementation (int bValue, unsigned uiLine, const char *strCondition, const char *strFile, const char *strFunction, int bFatal)
+{
+  if (!bValue && bFatal) {
+    __coverity_panic__ ();
+  }
+  return bValue;
+}

--- a/src/core/ddsc/tests/config.c
+++ b/src/core/ddsc/tests/config.c
@@ -353,3 +353,36 @@ CU_Test(ddsc_security_qos, empty, .init = ddsrt_init, .fini = ddsrt_fini)
   CU_ASSERT_FATAL (found == 0x3);
 #endif
 }
+
+CU_Test(ddsc_config, invalid_envvar, .init = ddsrt_init, .fini = ddsrt_fini)
+{
+  const char *log_expected[] = {
+    "*invalid expansion*",
+    NULL
+  };
+
+  dds_set_log_mask (DDS_LC_FATAL|DDS_LC_ERROR|DDS_LC_WARNING|DDS_LC_CONFIG);
+  dds_set_log_sink (&logger, (void *) log_expected);
+  dds_set_trace_sink (&logger, (void *) log_expected);
+
+  found = 0;
+  dds_entity_t domain;
+  domain = dds_create_domain (0, "<Discovery><Tag>${INVALID_EXPANSION</Tag></Discovery>");
+  CU_ASSERT_FATAL (domain < 0);
+  CU_ASSERT_FATAL (found == 0x1);
+
+  found = 0;
+  domain = dds_create_domain (0, "<Discovery><Peers><Peer address=\"${INVALID_EXPANSION\"/></Peers></Discovery>");
+  CU_ASSERT_FATAL (domain < 0);
+  CU_ASSERT_FATAL (found == 0x1);
+
+  dds_set_log_sink (NULL, NULL);
+  dds_set_trace_sink (NULL, NULL);
+}
+
+CU_Test(ddsc_config, too_deep_nesting, .init = ddsrt_init, .fini = ddsrt_fini)
+{
+  dds_entity_t domain;
+  domain = dds_create_domain (0, "<A><B><C><D><E><F><G><H><I><J><K><L>");
+  CU_ASSERT_FATAL (domain < 0);
+}

--- a/src/core/ddsc/tests/config.c
+++ b/src/core/ddsc/tests/config.c
@@ -382,7 +382,20 @@ CU_Test(ddsc_config, invalid_envvar, .init = ddsrt_init, .fini = ddsrt_fini)
 
 CU_Test(ddsc_config, too_deep_nesting, .init = ddsrt_init, .fini = ddsrt_fini)
 {
-  dds_entity_t domain;
-  domain = dds_create_domain (0, "<A><B><C><D><E><F><G><H><I><J><K><L>");
+  const char *log_expected[] = {
+    "*too deeply nested*",
+    NULL
+  };
+
+  dds_set_log_mask (DDS_LC_FATAL|DDS_LC_ERROR|DDS_LC_WARNING|DDS_LC_CONFIG);
+  dds_set_log_sink (&logger, (void *) log_expected);
+  dds_set_trace_sink (&logger, (void *) log_expected);
+
+  found = 0;
+  dds_entity_t domain = dds_create_domain (0, "<A><B><C><D><E><F><G><H><I><J><K><L>");
   CU_ASSERT_FATAL (domain < 0);
+  CU_ASSERT_FATAL (found == 0x1);
+
+  dds_set_log_sink (NULL, NULL);
+  dds_set_trace_sink (NULL, NULL);
 }

--- a/src/core/ddsi/src/q_config.c
+++ b/src/core/ddsi/src/q_config.c
@@ -1962,6 +1962,8 @@ static int proc_update_cfgelem (struct cfgst *cfgst, const struct cfgelem *ce, c
 {
   void *parent = cfgst_parent (cfgst);
   char *xvalue = ddsrt_expand_envvars (value, cfgst->cfg->domainId);
+  if (xvalue == NULL)
+    return -1;
   enum update_result res;
   cfgst_push (cfgst, isattr, isattr ? ce : NULL, parent);
   res = do_update (cfgst, ce->update, parent, ce, xvalue, cfgst->source);


### PR DESCRIPTION
This fixes two mistakes in handling some incorrect configuration files: invalid environment variable expansions, and too escaping too deeply nested inputs.

(The Coverity modelling file slipped in in this PR, it has been in effect in Coverity for a while and was accidentally not committed in the repository. It doesn't really seem worth another PR, but I can make one if needed, of course.)