### PR TITLE
Fix use-after-free bugs in IDL parser

### DIFF
--- a/src/idl/src/tree.c
+++ b/src/idl/src/tree.c
@@ -1902,7 +1902,7 @@ bool idl_is_case_label(const void *ptr)
 static void delete_case_label(void *ptr)
 {
   idl_case_label_t *node = ptr;
-  idl_delete_node(node->const_expr);
+  delete_const_expr(node, node->const_expr);
   free(node);
 }
 

--- a/src/idl/tests/annotation.c
+++ b/src/idl/tests/annotation.c
@@ -176,9 +176,7 @@ CU_Test(idl_annotation, idl_default)
     {"struct s { @default(\"false\") boolean b; };",         IDL_RETCODE_ILLEGAL_EXPRESSION,  false, IDL_NULL,    NULL}, //parameter type mismatch (string vs bool)
     {"struct s { @default(123) boolean b; };",               IDL_RETCODE_ILLEGAL_EXPRESSION,  false, IDL_NULL,    NULL}, //parameter type mismatch (int vs bool)
     {"struct s { @default(-123) unsigned long l; };",        IDL_RETCODE_OUT_OF_RANGE,        false, IDL_NULL,    NULL}, //parameter type mismatch (unsigned vs signed)
-    /* skipping this test as idl_create_annotation_appl leaks memory if idl_resolve cannot resolve the scoped name (https://github.com/eclipse-cyclonedds/cyclonedds/issues/950)
-      {"@default(e_0) enum e { e_0, e_1, e_2, e_3 };",         IDL_RETCODE_SEMANTIC_ERROR,  false, IDL_NULL,    NULL}  //setting default on enums is done through @default_literal
-    */
+    {"@default(e_0) enum e { e_0, e_1, e_2, e_3 };",         IDL_RETCODE_SEMANTIC_ERROR,      false, IDL_NULL,    NULL}  //setting default on enums is done through @default_literal
   };
 
   for (size_t i = 0; i < sizeof(tests)/sizeof(tests[0]); i++) {

--- a/src/idl/tests/union.c
+++ b/src/idl/tests/union.c
@@ -36,6 +36,21 @@ CU_Test(idl_union, no_case)
   idl_delete_pstate(pstate);
 }
 
+CU_Test(idl_union, name_clash)
+{
+  idl_retcode_t ret;
+  idl_pstate_t *pstate = NULL;
+
+  const char str[] = "union u switch (long) { case 1: char c; };\n"
+                     "union u switch (long) { case 1: char c; };";
+  ret = idl_create_pstate(0u, NULL, &pstate);
+  CU_ASSERT_EQUAL_FATAL(ret, IDL_RETCODE_OK);
+  CU_ASSERT_PTR_NOT_NULL_FATAL(pstate);
+  ret = idl_parse_string(pstate, str);
+  CU_ASSERT_EQUAL(ret, IDL_RETCODE_SEMANTIC_ERROR);
+  idl_delete_pstate(pstate);
+}
+
 CU_Test(idl_union, single_case)
 {
   idl_retcode_t ret;

--- a/src/idl/tests/union.c
+++ b/src/idl/tests/union.c
@@ -576,3 +576,20 @@ CU_Test(idl_union, default_discriminator_enum)
   CU_ASSERT_PTR_NULL(pstate);
   idl_delete_pstate(pstate);
 }
+
+CU_Test(idl_union, two_unions_one_enum)
+{
+  idl_retcode_t ret;
+  idl_pstate_t *pstate = NULL;
+
+  const char str[] = "enum aap { noot, mies };\n"
+                     "union wim switch (aap) { case mies: double zus; };\n"
+                     "union jet switch (aap) { case noot: double zus; };";
+
+  ret = idl_create_pstate(0u, NULL, &pstate);
+  CU_ASSERT_EQUAL_FATAL(ret, IDL_RETCODE_OK);
+  CU_ASSERT_PTR_NOT_NULL_FATAL(pstate);
+  ret = idl_parse_string(pstate, str);
+  CU_ASSERT_EQUAL(ret, IDL_RETCODE_OK);
+  idl_delete_pstate(pstate);
+}


### PR DESCRIPTION
This PR fixes one bug found by @dennis-adlink where using a union with a previously declared name resulted in the type-spec for the switch-type-spec being freed twice. It also fixes #946, which was caused by the union deleting an enumerator node rather than unreferencing it, causing a use-after free when deleting the actual enum.