### PR TITLE
Fix use of non-existent paths when building as a subproject

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -11,7 +11,7 @@
 #
 set(CMAKE_INSTALL_EXAMPLESDIR "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/examples")
 
-include("${CMAKE_SOURCE_DIR}/cmake/Modules/Generate.cmake")
+include("${CycloneDDS_SOURCE_DIR}/cmake/Modules/Generate.cmake")
 
 install(
   FILES

--- a/src/tools/idlc/CMakeLists.txt
+++ b/src/tools/idlc/CMakeLists.txt
@@ -49,7 +49,7 @@ target_include_directories(
 
 if(WIN32 OR NOT HAVE_GETOPT_H)
   # use getopt.h from ddsrt
-  file(READ "${CMAKE_SOURCE_DIR}/src/ddsrt/include/getopt.h.in" getopt_h)
+  file(READ "${CycloneDDS_SOURCE_DIR}/src/ddsrt/include/getopt.h.in" getopt_h)
   # remove occurrences of DDS_EXPORT
   string(REGEX REPLACE "\n[ \t]*DDS_EXPORT[ \t]+" "\n" getopt_h "${getopt_h}")
   # remove dds/* includes
@@ -59,7 +59,7 @@ if(WIN32 OR NOT HAVE_GETOPT_H)
   target_include_directories(idlc PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
   # add getopt.c
   configure_file(
-    "${CMAKE_SOURCE_DIR}/src/ddsrt/src/getopt.c"
+    "${CycloneDDS_SOURCE_DIR}/src/ddsrt/src/getopt.c"
     "${CMAKE_CURRENT_BINARY_DIR}/getopt.c"
     COPYONLY)
   target_sources(idlc PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/getopt.c)
@@ -88,9 +88,9 @@ if (MSVC)
 endif()
 
 install(
-  FILES "${CMAKE_SOURCE_DIR}/cmake/Modules/Generate.cmake"
+  FILES "${CycloneDDS_SOURCE_DIR}/cmake/Modules/Generate.cmake"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/idlc"
   COMPONENT dev)
 
-include("${CMAKE_SOURCE_DIR}/cmake/Modules/Generate.cmake")
+include("${CycloneDDS_SOURCE_DIR}/cmake/Modules/Generate.cmake")
 


### PR DESCRIPTION
CMAKE_SOURCE_DIR always points to the top-level CMake project, so if
CycloneDDS was included as a gitmodule or pulled in using CMake
FetchContent, the CMake step would fail with errors like

```
CMake Error at cyclonedds/src/tools/idlc/CMakeLists.txt:52 (file):
file failed to open for reading (No such file or directory):
/home/robin/dds-project/src/ddsrt/include/getopt.h.in

CMake Error: File /home/robin/dds-project/src/ddsrt/src/getopt.c does not exist.
CMake Error at cyclonedds/src/tools/idlc/CMakeLists.txt:61 (configure_file):
configure_file Problem configuring file

CMake Error at cyclonedds/src/tools/idlc/CMakeLists.txt:95 (include):
include could not find load file:
/home/robin/dds-project/cmake/Modules/Generate.cmake
```

This commit replaces CMAKE_SOURCE_DIR with <PROJECT_NAME>_SOURCE_DIR, a
variable that always points to the source dir of the named project.

See:
https://cmake.org/cmake/help/v3.21/variable/CMAKE_SOURCE_DIR.html
https://cmake.org/cmake/help/v3.21/variable/PROJECT-NAME_SOURCE_DIR.html