### PR TITLE
remove grammars from legal notice

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -35,10 +35,6 @@ libmd5-rfc (2002-04-13)
 
 * License: Zlib
 
-grammers-v4 (git SHA 6610e82ee235992f50e108cd59204f3bcd7128c1)
-
-* License: New BSD License
-
 getopt 1.5 (1998-03-11)
 
 * License: Public domain


### PR DESCRIPTION
This PR removes grammars from the legal notice since it's not present anymore in cyclonedds.

Signed-off-by: Alberto Soragna <alberto.soragna@gmail.com>