### PR TITLE
Obligatory ddsperf build makes idlc a hard requirement.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/Modules")
 
 option(BUILD_IDLC "Build IDL preprocessor" ${not_crosscompiling})
 option(BUILD_DDSCONF "Build DDSCONF buildtool" ${not_crosscompiling})
-
+option(BUILD_DDSPERF "Build ddsperf tool" ${not_crosscompiling})
 
 set(CMAKE_C_STANDARD 99)
 if(CMAKE_SYSTEM_NAME STREQUAL "VxWorks")

--- a/src/tools/ddsperf/CMakeLists.txt
+++ b/src/tools/ddsperf/CMakeLists.txt
@@ -10,25 +10,27 @@
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
 
-include(Generate)
+if (BUILD_DDSPERF)
+  include(Generate)
 
-idlc_generate(TARGET ddsperf_types FILES ddsperf_types.idl)
-add_executable(ddsperf ddsperf.c cputime.c cputime.h netload.c netload.h)
-target_link_libraries(ddsperf ddsperf_types ddsc)
+  idlc_generate(TARGET ddsperf_types FILES ddsperf_types.idl)
+  add_executable(ddsperf ddsperf.c cputime.c cputime.h netload.c netload.h)
+  target_link_libraries(ddsperf ddsperf_types ddsc)
 
-if(WIN32)
-  target_compile_definitions(ddsperf PRIVATE _CRT_SECURE_NO_WARNINGS)
-endif()
+  if(WIN32)
+    target_compile_definitions(ddsperf PRIVATE _CRT_SECURE_NO_WARNINGS)
+  endif()
 
-install(
-  TARGETS ddsperf
-  DESTINATION "${CMAKE_INSTALL_BINDIR}"
-  COMPONENT dev
-)
-if (MSVC)
-  install(FILES $<TARGET_PDB_FILE:ddsperf>
+  install(
+    TARGETS ddsperf
     DESTINATION "${CMAKE_INSTALL_BINDIR}"
     COMPONENT dev
-    OPTIONAL
   )
-endif()
+  if (MSVC)
+    install(FILES $<TARGET_PDB_FILE:ddsperf>
+      DESTINATION "${CMAKE_INSTALL_BINDIR}"
+      COMPONENT dev
+      OPTIONAL
+    )
+  endif()
+endif ()


### PR DESCRIPTION
In the cmake changes for crosscompiling (#948) the `if (BUILD_IDLC)` check for ddsperf was removed, since you might want to cross-build `ddsperf` for a target with your native idlc. However, this turns having idlc a hard requirement which was not the intended change: if you want `BUILD_IDLC=off` and not supply a pre-built `idlc` that should be legal. I considered a "allow failure" mode here for `idlc_generate` but it just complicates things for a rare usecase. I think it is good enough that if you really don't want to build `idlc` you will have to specify `-DBUILD_IDLC=off -DBUILD_DDSPERF=off`.