### PR TITLE
YYLLOC_DEFAULT set source also in "last" position

### DIFF
--- a/src/idl/src/parser.y
+++ b/src/idl/src/parser.y
@@ -56,18 +56,11 @@ static void yyerror(idl_location_t *, idl_pstate_t *, idl_retcode_t *, const cha
 #define YYLLOC_DEFAULT(Cur, Rhs, N) \
   do { \
     if (N) { \
-      (Cur).first.source = YYRHSLOC(Rhs, 1).first.source; \
-      (Cur).first.file = YYRHSLOC(Rhs, 1).first.file; \
-      (Cur).first.line = YYRHSLOC(Rhs, 1).first.line; \
-      (Cur).first.column = YYRHSLOC(Rhs, 1).first.column; \
+      (Cur).first = YYRHSLOC(Rhs, 1).first; \
     } else { \
-      (Cur).first.source = YYRHSLOC(Rhs, 0).last.source; \
-      (Cur).first.file = YYRHSLOC(Rhs, 0).last.file; \
-      (Cur).first.line = YYRHSLOC(Rhs, 0).last.line; \
-      (Cur).first.column = YYRHSLOC(Rhs, 0).last.column; \
+      (Cur).first = YYRHSLOC(Rhs, 0).last; \
     } \
-    (Cur).last.line = YYRHSLOC(Rhs, N).last.line; \
-    (Cur).last.column = YYRHSLOC(Rhs, N).last.column; \
+    (Cur).last = YYRHSLOC(Rhs, N).last; \
   } while(0)
 
 #define TRY_EXCEPT(action, except) \


### PR DESCRIPTION
Not doing this results in some null pointers, at least in some
grammatical constructs and when using bison 3.8.1.

Signed-off-by: Erik Boasson <eb@ilities.com>