### PR TITLE
IDLC command line option for default extensibility

### DIFF
--- a/cmake/Modules/Generate.cmake
+++ b/cmake/Modules/Generate.cmake
@@ -11,7 +11,7 @@
 #
 
 function(IDLC_GENERATE)
-  set(one_value_keywords TARGET)
+  set(one_value_keywords TARGET DEFAULT_EXTENSIBILITY)
   set(multi_value_keywords FILES FEATURES INCLUDES)
   cmake_parse_arguments(
     IDLC "" "${one_value_keywords}" "${multi_value_keywords}" "" ${ARGN})
@@ -20,11 +20,12 @@ function(IDLC_GENERATE)
     FILES ${IDLC_FILES}
     FEATURES ${IDLC_FEATURES}
     INCLUDES ${IDLC_INCLUDES}
+    DEFAULT_EXTENSIBILITY ${IDLC_DEFAULT_EXTENSIBILITY}
   )
 endfunction()
 
 function(IDLC_GENERATE_GENERIC)
-  set(one_value_keywords TARGET BACKEND)
+  set(one_value_keywords TARGET BACKEND DEFAULT_EXTENSIBILITY)
   set(multi_value_keywords FILES FEATURES INCLUDES SUFFIXES DEPENDS)
   cmake_parse_arguments(
     IDLC "" "${one_value_keywords}" "${multi_value_keywords}" "" ${ARGN})
@@ -87,6 +88,11 @@ function(IDLC_GENERATE_GENERIC)
     list(APPEND _depends ${_idlc_depends} ${IDLC_DEPENDS})
   else()
     set(_depends ${_idlc_depends})
+  endif()
+
+  if(IDLC_DEFAULT_EXTENSIBILITY)
+    set(_default_extensibility ${IDLC_DEFAULT_EXTENSIBILITY})
+    list(APPEND IDLC_ARGS "-x" ${_default_extensibility})
   endif()
 
   set(_dir ${CMAKE_CURRENT_BINARY_DIR})

--- a/cmake/Modules/Generate.cmake
+++ b/cmake/Modules/Generate.cmake
@@ -12,7 +12,7 @@
 
 function(IDLC_GENERATE)
   set(one_value_keywords TARGET DEFAULT_EXTENSIBILITY)
-  set(multi_value_keywords FILES FEATURES INCLUDES NO_WARN)
+  set(multi_value_keywords FILES FEATURES INCLUDES WARNINGS)
   cmake_parse_arguments(
     IDLC "" "${one_value_keywords}" "${multi_value_keywords}" "" ${ARGN})
 
@@ -20,14 +20,14 @@ function(IDLC_GENERATE)
     FILES ${IDLC_FILES}
     FEATURES ${IDLC_FEATURES}
     INCLUDES ${IDLC_INCLUDES}
-    NO_WARN ${IDLC_NOWARN}
+    WARNINGS ${IDLC_WARNINGS}
     DEFAULT_EXTENSIBILITY ${IDLC_DEFAULT_EXTENSIBILITY}
   )
 endfunction()
 
 function(IDLC_GENERATE_GENERIC)
   set(one_value_keywords TARGET BACKEND DEFAULT_EXTENSIBILITY)
-  set(multi_value_keywords FILES FEATURES INCLUDES NO_WARN SUFFIXES DEPENDS)
+  set(multi_value_keywords FILES FEATURES INCLUDES WARNINGS SUFFIXES DEPENDS)
   cmake_parse_arguments(
     IDLC "" "${one_value_keywords}" "${multi_value_keywords}" "" ${ARGN})
 
@@ -96,9 +96,9 @@ function(IDLC_GENERATE_GENERIC)
     list(APPEND IDLC_ARGS "-x" ${_default_extensibility})
   endif()
 
-  if(IDLC_NO_WARN)
-    foreach(_no_warn ${IDLC_NO_WARN})
-      list(APPEND IDLC_ARGS "-Wno-${_no_warn}")
+  if(IDLC_WARNINGS)
+    foreach(_warn ${IDLC_WARNINGS})
+      list(APPEND IDLC_ARGS "-W${_warn}")
     endforeach()
   endif()
 

--- a/cmake/Modules/Generate.cmake
+++ b/cmake/Modules/Generate.cmake
@@ -12,7 +12,7 @@
 
 function(IDLC_GENERATE)
   set(one_value_keywords TARGET DEFAULT_EXTENSIBILITY)
-  set(multi_value_keywords FILES FEATURES INCLUDES)
+  set(multi_value_keywords FILES FEATURES INCLUDES NO_WARN)
   cmake_parse_arguments(
     IDLC "" "${one_value_keywords}" "${multi_value_keywords}" "" ${ARGN})
 
@@ -20,13 +20,14 @@ function(IDLC_GENERATE)
     FILES ${IDLC_FILES}
     FEATURES ${IDLC_FEATURES}
     INCLUDES ${IDLC_INCLUDES}
+    NO_WARN ${IDLC_NOWARN}
     DEFAULT_EXTENSIBILITY ${IDLC_DEFAULT_EXTENSIBILITY}
   )
 endfunction()
 
 function(IDLC_GENERATE_GENERIC)
   set(one_value_keywords TARGET BACKEND DEFAULT_EXTENSIBILITY)
-  set(multi_value_keywords FILES FEATURES INCLUDES SUFFIXES DEPENDS)
+  set(multi_value_keywords FILES FEATURES INCLUDES NO_WARN SUFFIXES DEPENDS)
   cmake_parse_arguments(
     IDLC "" "${one_value_keywords}" "${multi_value_keywords}" "" ${ARGN})
 
@@ -93,6 +94,12 @@ function(IDLC_GENERATE_GENERIC)
   if(IDLC_DEFAULT_EXTENSIBILITY)
     set(_default_extensibility ${IDLC_DEFAULT_EXTENSIBILITY})
     list(APPEND IDLC_ARGS "-x" ${_default_extensibility})
+  endif()
+
+  if(IDLC_NO_WARN)
+    foreach(_no_warn ${IDLC_NO_WARN})
+      list(APPEND IDLC_ARGS "-Wno-${_no_warn}")
+    endforeach()
   endif()
 
   set(_dir ${CMAKE_CURRENT_BINARY_DIR})

--- a/examples/helloworld/CMakeLists.txt
+++ b/examples/helloworld/CMakeLists.txt
@@ -21,7 +21,7 @@ endif()
 # that will supply a library target related the the given idl file.
 # In short, it takes the idl file, generates the source files with
 # the proper data types and compiles them into a library.
-idlc_generate(TARGET HelloWorldData_lib FILES "HelloWorldData.idl")
+idlc_generate(TARGET HelloWorldData_lib FILES "HelloWorldData.idl" NO_WARN implicit-extensibility)
 
 # Both executables have only one related source file.
 add_executable(HelloworldPublisher publisher.c)

--- a/examples/helloworld/CMakeLists.txt
+++ b/examples/helloworld/CMakeLists.txt
@@ -21,7 +21,7 @@ endif()
 # that will supply a library target related the the given idl file.
 # In short, it takes the idl file, generates the source files with
 # the proper data types and compiles them into a library.
-idlc_generate(TARGET HelloWorldData_lib FILES "HelloWorldData.idl" NO_WARN implicit-extensibility)
+idlc_generate(TARGET HelloWorldData_lib FILES "HelloWorldData.idl" WARNINGS no-implicit-extensibility)
 
 # Both executables have only one related source file.
 add_executable(HelloworldPublisher publisher.c)

--- a/examples/helloworld/HelloWorldData.idl
+++ b/examples/helloworld/HelloWorldData.idl
@@ -2,8 +2,8 @@ module HelloWorldData
 {
   struct Msg
   {
+    @key
     long userID;
     string message;
   };
-  #pragma keylist Msg userID
 };

--- a/examples/roundtrip/RoundTrip.idl
+++ b/examples/roundtrip/RoundTrip.idl
@@ -1,8 +1,8 @@
 module RoundTripModule
 {
+  @final
   struct DataType
   {
     sequence<octet> payload;
   };
-  #pragma keylist DataType
 };

--- a/examples/shm_throughput/ShmThroughput.idl
+++ b/examples/shm_throughput/ShmThroughput.idl
@@ -1,146 +1,145 @@
 module ThroughputModule
 {
+  @final
+  struct DataType_Base
+  {
+    unsigned long long count;
+    unsigned long payloadsize;
+  };
 
-struct DataType_Base
-{
-  unsigned long long count;
-  unsigned long payloadsize;
-};
-#pragma keylist DataType_Base
+  @final
+  struct DataType_16
+  {
+    unsigned long long count;
+    unsigned long payloadsize;
+    octet payload[16 - 12];
+  };
 
-struct DataType_16
-{
-  unsigned long long count;
-  unsigned long payloadsize;
-  octet payload[16 - 12];
-};
-#pragma keylist DataType_16
+  @final
+  struct DataType_32
+  {
+    unsigned long long count;
+    unsigned long payloadsize;
+    octet payload[32 - 12];
+  };
 
-struct DataType_32
-{
-  unsigned long long count;
-  unsigned long payloadsize;
-  octet payload[32 - 12];
-};
-#pragma keylist DataType_32
+  @final
+  struct DataType_64
+  {
+    unsigned long long count;
+    unsigned long payloadsize;
+    octet payload[64 - 12];
+  };
 
-struct DataType_64
-{
-  unsigned long long count;
-  unsigned long payloadsize;
-  octet payload[64 - 12];
-};
-#pragma keylist DataType_64
+  @final
+  struct DataType_128
+  {
+    unsigned long long count;
+    unsigned long payloadsize;
+    octet payload[128 - 12];
+  };
 
-struct DataType_128
-{
-  unsigned long long count;
-  unsigned long payloadsize;
-  octet payload[128 - 12];
-};
-#pragma keylist DataType_128
+  @final
+  struct DataType_256
+  {
+    unsigned long long count;
+    unsigned long payloadsize;
+    octet payload[256 - 12];
+  };
 
-struct DataType_256
-{
-  unsigned long long count;
-  unsigned long payloadsize;
-  octet payload[256 - 12];
-};
-#pragma keylist DataType_256
+  @final
+  struct DataType_512
+  {
+    unsigned long long count;
+    unsigned long payloadsize;
+    octet payload[512 - 12];
+  };
 
-struct DataType_512
-{
-  unsigned long long count;
-  unsigned long payloadsize;
-  octet payload[512 - 12];
-};
-#pragma keylist DataType_512
+  @final
+  struct DataType_1024
+  {
+    unsigned long long count;
+    unsigned long payloadsize;
+    octet payload[1024 - 12];
+  };
 
-struct DataType_1024
-{
-  unsigned long long count;
-  unsigned long payloadsize;
-  octet payload[1024 - 12];
-};
-#pragma keylist DataType_1024
+  @final
+  struct DataType_2048
+  {
+    unsigned long long count;
+    unsigned long payloadsize;
+    octet payload[2048 - 12];
+  };
 
-struct DataType_2048
-{
-  unsigned long long count;
-  unsigned long payloadsize;
-  octet payload[2048 - 12];
-};
-#pragma keylist DataType_2048
+  @final
+  struct DataType_4096
+  {
+    unsigned long long count;
+    unsigned long payloadsize;
+    octet payload[4096 - 12];
+  };
 
-struct DataType_4096
-{
-  unsigned long long count;
-  unsigned long payloadsize;
-  octet payload[4096 - 12];
-};
-#pragma keylist DataType_4096
+  @final
+  struct DataType_8192
+  {
+    unsigned long long count;
+    unsigned long payloadsize;
+    octet payload[8192 - 12];
+  };
 
-struct DataType_8192
-{
-  unsigned long long count;
-  unsigned long payloadsize;
-  octet payload[8192 - 12];
-};
-#pragma keylist DataType_8192
+  @final
+  struct DataType_16384
+  {
+    unsigned long long count;
+    unsigned long payloadsize;
+    octet payload[16384 - 12];
+  };
 
-struct DataType_16384
-{
-  unsigned long long count;
-  unsigned long payloadsize;
-  octet payload[16384 - 12];
-};
-#pragma keylist DataType_16384
+  @final
+  struct DataType_32768
+  {
+    unsigned long long count;
+    unsigned long payloadsize;
+    octet payload[32768 - 12];
+  };
 
-struct DataType_32768
-{
-  unsigned long long count;
-  unsigned long payloadsize;
-  octet payload[32768 - 12];
-};
-#pragma keylist DataType_32768
+  @final
+  struct DataType_65536
+  {
+    unsigned long long count;
+    unsigned long payloadsize;
+    octet payload[65536 - 12];
+  };
 
-struct DataType_65536
-{
-  unsigned long long count;
-  unsigned long payloadsize;
-  octet payload[65536 - 12];
-};
-#pragma keylist DataType_65536
+  @final
+  struct DataType_131072
+  {
+    unsigned long long count;
+    unsigned long payloadsize;
+    octet payload[131072 - 12];
+  };
 
-struct DataType_131072
-{
-  unsigned long long count;
-  unsigned long payloadsize;
-  octet payload[131072 - 12];
-};
-#pragma keylist DataType_131072
+  @final
+  struct DataType_262144
+  {
+    unsigned long long count;
+    unsigned long payloadsize;
+    octet payload[262144 - 12];
+  };
 
-struct DataType_262144
-{
-  unsigned long long count;
-  unsigned long payloadsize;
-  octet payload[262144 - 12];
-};
-#pragma keylist DataType_262144
+  @final
+  struct DataType_524288
+  {
+    unsigned long long count;
+    unsigned long payloadsize;
+    octet payload[524288 - 12];
+  };
 
-struct DataType_524288
-{
-  unsigned long long count;
-  unsigned long payloadsize;
-  octet payload[524288 - 12];
-};
-#pragma keylist DataType_524288
-
-struct DataType_1048576
-{
-  unsigned long long count;
-  unsigned long payloadsize;
-  octet payload[1048576 - 12];
-};
-#pragma keylist DataType_1048576
+  @final
+  struct DataType_1048576
+  {
+    unsigned long long count;
+    unsigned long payloadsize;
+    octet payload[1048576 - 12];
+  };
 };

--- a/examples/throughput/Throughput.idl
+++ b/examples/throughput/Throughput.idl
@@ -1,9 +1,9 @@
 module ThroughputModule
 {
+  @final
   struct DataType
   {
     unsigned long long count;
     sequence<octet> payload;
   };
-  #pragma keylist DataType
 };

--- a/src/core/ddsc/tests/Array100.idl
+++ b/src/core/ddsc/tests/Array100.idl
@@ -12,4 +12,3 @@
 struct Array100 {
   octet data[100];
 };
-#pragma keylist Array100

--- a/src/core/ddsc/tests/CMakeLists.txt
+++ b/src/core/ddsc/tests/CMakeLists.txt
@@ -12,17 +12,17 @@
 include(CUnit)
 
 idlc_generate(TARGET RoundTrip FILES RoundTrip.idl)
-idlc_generate(TARGET Space FILES Space.idl)
-idlc_generate(TARGET TypesArrayKey FILES TypesArrayKey.idl)
-idlc_generate(TARGET WriteTypes FILES WriteTypes.idl)
-idlc_generate(TARGET InstanceHandleTypes FILES InstanceHandleTypes.idl)
-idlc_generate(TARGET RWData FILES RWData.idl)
-idlc_generate(TARGET CreateWriter FILES CreateWriter.idl)
-idlc_generate(TARGET DataRepresentationTypes FILES DataRepresentationTypes.idl)
+idlc_generate(TARGET Space FILES Space.idl NO_WARN implicit-extensibility)
+idlc_generate(TARGET TypesArrayKey FILES TypesArrayKey.idl NO_WARN implicit-extensibility)
+idlc_generate(TARGET WriteTypes FILES WriteTypes.idl NO_WARN implicit-extensibility)
+idlc_generate(TARGET InstanceHandleTypes FILES InstanceHandleTypes.idl NO_WARN implicit-extensibility)
+idlc_generate(TARGET RWData FILES RWData.idl NO_WARN implicit-extensibility)
+idlc_generate(TARGET CreateWriter FILES CreateWriter.idl NO_WARN implicit-extensibility)
+idlc_generate(TARGET DataRepresentationTypes FILES DataRepresentationTypes.idl NO_WARN implicit-extensibility)
 idlc_generate(TARGET MinXcdrVersion FILES MinXcdrVersion.idl)
 idlc_generate(TARGET XSpace FILES XSpace.idl)
-idlc_generate(TARGET CdrStreamOptimize FILES CdrStreamOptimize.idl)
 idlc_generate(TARGET XSpaceMustUnderstand FILES XSpaceMustUnderstand.idl)
+idlc_generate(TARGET CdrStreamOptimize FILES CdrStreamOptimize.idl NO_WARN implicit-extensibility)
 
 set(ddsc_test_sources
     "basic.c"

--- a/src/core/ddsc/tests/CMakeLists.txt
+++ b/src/core/ddsc/tests/CMakeLists.txt
@@ -12,17 +12,17 @@
 include(CUnit)
 
 idlc_generate(TARGET RoundTrip FILES RoundTrip.idl)
-idlc_generate(TARGET Space FILES Space.idl NO_WARN implicit-extensibility)
-idlc_generate(TARGET TypesArrayKey FILES TypesArrayKey.idl NO_WARN implicit-extensibility)
-idlc_generate(TARGET WriteTypes FILES WriteTypes.idl NO_WARN implicit-extensibility)
-idlc_generate(TARGET InstanceHandleTypes FILES InstanceHandleTypes.idl NO_WARN implicit-extensibility)
-idlc_generate(TARGET RWData FILES RWData.idl NO_WARN implicit-extensibility)
-idlc_generate(TARGET CreateWriter FILES CreateWriter.idl NO_WARN implicit-extensibility)
-idlc_generate(TARGET DataRepresentationTypes FILES DataRepresentationTypes.idl NO_WARN implicit-extensibility)
+idlc_generate(TARGET Space FILES Space.idl WARNINGS no-implicit-extensibility)
+idlc_generate(TARGET TypesArrayKey FILES TypesArrayKey.idl WARNINGS no-implicit-extensibility)
+idlc_generate(TARGET WriteTypes FILES WriteTypes.idl WARNINGS no-implicit-extensibility)
+idlc_generate(TARGET InstanceHandleTypes FILES InstanceHandleTypes.idl WARNINGS no-implicit-extensibility)
+idlc_generate(TARGET RWData FILES RWData.idl WARNINGS no-implicit-extensibility)
+idlc_generate(TARGET CreateWriter FILES CreateWriter.idl WARNINGS no-implicit-extensibility)
+idlc_generate(TARGET DataRepresentationTypes FILES DataRepresentationTypes.idl WARNINGS no-implicit-extensibility)
 idlc_generate(TARGET MinXcdrVersion FILES MinXcdrVersion.idl)
 idlc_generate(TARGET XSpace FILES XSpace.idl)
 idlc_generate(TARGET XSpaceMustUnderstand FILES XSpaceMustUnderstand.idl)
-idlc_generate(TARGET CdrStreamOptimize FILES CdrStreamOptimize.idl NO_WARN implicit-extensibility)
+idlc_generate(TARGET CdrStreamOptimize FILES CdrStreamOptimize.idl WARNINGS no-implicit-extensibility)
 
 set(ddsc_test_sources
     "basic.c"

--- a/src/core/ddsc/tests/CMakeLists.txt
+++ b/src/core/ddsc/tests/CMakeLists.txt
@@ -151,8 +151,8 @@ target_link_libraries(oneliner PRIVATE RoundTrip Space ddsc)
 # better not be part of the tests.  That also saves us from
 # having to figure out now how to start/stop RouDi on Windows.
 if(ENABLE_SHM)
-  idlc_generate(TARGET Array100 FILES Array100.idl)
-  idlc_generate(TARGET DynamicData FILES DynamicData.idl)
+  idlc_generate(TARGET Array100 FILES Array100.idl WARNINGS no-implicit-extensibility)
+  idlc_generate(TARGET DynamicData FILES DynamicData.idl WARNINGS no-implicit-extensibility)
 
   add_cunit_executable(cunit_ddsc_iox
     "iceoryx.c"

--- a/src/core/ddsc/tests/CreateWriter.idl
+++ b/src/core/ddsc/tests/CreateWriter.idl
@@ -7,6 +7,5 @@ module DiscStress {
       unsigned long histidx;
       unsigned long seq;
     };
-#pragma keylist Msg
   };
 };

--- a/src/core/ddsc/tests/DynamicData.idl
+++ b/src/core/ddsc/tests/DynamicData.idl
@@ -1,6 +1,6 @@
 module DynamicData {
   struct Msg {
-    string message;    
+    string message;
     int32 scalar;
     sequence<int32> values;
   };

--- a/src/core/ddsc/tests/InstanceHandleTypes.idl
+++ b/src/core/ddsc/tests/InstanceHandleTypes.idl
@@ -11,17 +11,19 @@
  */
 module InstanceHandleTypes {
   struct A {
-    unsigned long k; //@Key
+    @key
+    unsigned long k;
     unsigned long v;
   };
-#pragma keylist A k
+
   struct C {
-    unsigned long k; //@Key
+    @key
+    unsigned long k;
     unsigned long v;
   };
-#pragma keylist C k
+
   struct MD5 {
-    octet k[8*16]; //@Key
+    @key
+    octet k[8*16];
   };
-#pragma keylist MD5 k
 };

--- a/src/core/ddsc/tests/RWData.idl
+++ b/src/core/ddsc/tests/RWData.idl
@@ -13,7 +13,7 @@ module RWData
 {
   struct Msg
   {
+    @key
     long k;
   };
-  #pragma keylist Msg k
 };

--- a/src/core/ddsc/tests/RoundTrip.idl
+++ b/src/core/ddsc/tests/RoundTrip.idl
@@ -11,16 +11,18 @@
  */
 module RoundTripModule
 {
+  @final
   struct DataType
   {
     sequence<octet> payload;
   };
-  #pragma keylist DataType
 
+  @final
   struct Address
   {
+    @key
     string ip;
+    @key
     long port;
   };
-  #pragma keylist Address ip port
 };

--- a/src/core/ddsc/tests/Space.idl
+++ b/src/core/ddsc/tests/Space.idl
@@ -10,37 +10,38 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
 module Space {
-    struct Type1 {
-	long	long_1; //@Key
-	long	long_2;
-	long	long_3;
-    };
-#pragma keylist Type1 long_1
-    struct Type2 {
-	long	long_1; //@Key
-	long	long_2;
-	long	long_3;
-    };
-#pragma keylist Type2 long_1
-    struct Type3 {
-	long	long_1;
-	long	long_2;
-	long	long_3;
-    };
-#pragma keylist Type3
+  struct Type1 {
+    @key
+    long	long_1;
+    long	long_2;
+    long	long_3;
+  };
 
-    struct simpletypes {
-        long                l;
-        long long           ll;
-        unsigned short      us;
-        unsigned long       ul;
-        unsigned long long  ull;
-        float               f;
-        double              d;
-        char                c;
-        boolean             b;
-        octet               o;
-        string              s; //@Key
-    };
-#pragma keylist simpletypes s
+  struct Type2 {
+    @key
+    long	long_1;
+    long	long_2;
+    long	long_3;
+  };
+
+  struct Type3 {
+    long	long_1;
+    long	long_2;
+    long	long_3;
+  };
+
+  struct simpletypes {
+    long                l;
+    long long           ll;
+    unsigned short      us;
+    unsigned long       ul;
+    unsigned long long  ull;
+    float               f;
+    double              d;
+    char                c;
+    boolean             b;
+    octet               o;
+    @key
+    string              s;
+  };
 };

--- a/src/core/ddsc/tests/TypesArrayKey.idl
+++ b/src/core/ddsc/tests/TypesArrayKey.idl
@@ -10,72 +10,82 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
 module TypesArrayKey {
-    struct long_arraytypekey {
-        long key[20]; //@Key
-    };
-#pragma keylist long_arraytypekey key
+  struct long_arraytypekey {
+    @key
+    long key[20];
+  };
 
-    typedef long long longlong;
-    struct longlong_arraytypekey {
-        longlong key[20]; //@Key
-    };
-#pragma keylist longlong_arraytypekey key
+  typedef long long longlong;
+  struct longlong_arraytypekey {
+    @key
+    longlong key[20];
+  };
 
-    typedef unsigned short unsignedshort;
-    struct unsignedshort_arraytypekey {
-        unsignedshort key[20]; //@Key
-    };
-#pragma keylist unsignedshort_arraytypekey key
+  typedef unsigned short unsignedshort;
+  struct unsignedshort_arraytypekey {
+    @key
+    unsignedshort key[20];
+  };
 
-    typedef unsigned long unsignedlong;
-    struct unsignedlong_arraytypekey {
-        unsignedlong key[20]; //@Key
-    };
-#pragma keylist unsignedlong_arraytypekey key
+  typedef unsigned long unsignedlong;
+  struct unsignedlong_arraytypekey {
+    @key
+    unsignedlong key[20];
+  };
 
-    typedef unsigned long long unsignedlonglong;
-    struct unsignedlonglong_arraytypekey {
-        unsignedlonglong key[20]; //@Key
-    };
-#pragma keylist unsignedlonglong_arraytypekey key
+  typedef unsigned long long unsignedlonglong;
+  struct unsignedlonglong_arraytypekey {
+    @key
+    unsignedlonglong key[20];
+  };
 
-    struct float_arraytypekey {
-        float key[20]; //@Key
-    };
-#pragma keylist float_arraytypekey key
+  struct float_arraytypekey {
+    @key
+    float key[20];
+  };
 
-    struct double_arraytypekey {
-        double key[20]; //@Key
-    };
-#pragma keylist double_arraytypekey key
+  struct double_arraytypekey {
+    @key
+    double key[20];
+  };
 
-    struct char_arraytypekey {
-        char key[128]; //@Key
-    };
-#pragma keylist char_arraytypekey key
+  struct char_arraytypekey {
+    @key
+    char key[128];
+  };
 
-    struct boolean_arraytypekey {
-        boolean key[128]; //@Key
-    };
-#pragma keylist boolean_arraytypekey key
+  struct boolean_arraytypekey {
+    @key
+    boolean key[128];
+  };
 
-    struct octet_arraytypekey {
-        octet key[128]; //@Key
-    };
-#pragma keylist octet_arraytypekey key
+  struct octet_arraytypekey {
+    @key
+    octet key[128];
+  };
 
-    struct alltypeskey {
-        long                l;
-        long long           ll;
-        unsigned short      us;
-        unsigned long       ul;
-        unsigned long long  ull;
-        float               f;
-        double              d;
-        char                c;
-        boolean             b;
-        octet               o;
-        string              s; //@Key
-    };
-#pragma keylist alltypeskey l ll us ul ull f d c b o s
+  struct alltypeskey {
+    @key
+    long                l;
+    @key
+    long long           ll;
+    @key
+    unsigned short      us;
+    @key
+    unsigned long       ul;
+    @key
+    unsigned long long  ull;
+    @key
+    float               f;
+    @key
+    double              d;
+    @key
+    char                c;
+    @key
+    boolean             b;
+    @key
+    octet               o;
+    @key
+    string              s;
+  };
 };

--- a/src/core/ddsc/tests/WriteTypes.idl
+++ b/src/core/ddsc/tests/WriteTypes.idl
@@ -1,25 +1,25 @@
 module WriteTypes {
   struct a {
+    @key
     octet k[3];
     unsigned long long ll;
   };
-#pragma keylist a k
 
   struct b {
+    @key
     unsigned short k[3];
     unsigned long long ll;
   };
-#pragma keylist b k
 
   struct c {
+    @key
     unsigned long k[3];
     unsigned long long ll;
   };
-#pragma keylist c k
-  
+
   struct d {
+    @key
     unsigned long long k[3];
     unsigned long long ll;
   };
-#pragma keylist d k
 };

--- a/src/core/xtests/initsampledeliv/CMakeLists.txt
+++ b/src/core/xtests/initsampledeliv/CMakeLists.txt
@@ -9,7 +9,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
-idlc_generate(TARGET InitSampleDeliv_lib FILES InitSampleDelivData.idl NO_WARN implicit-extensibility)
+idlc_generate(TARGET InitSampleDeliv_lib FILES InitSampleDelivData.idl WARNINGS no-implicit-extensibility)
 
 add_executable(InitSampleDelivPub publisher.c)
 add_executable(InitSampleDelivSub subscriber.c)

--- a/src/core/xtests/initsampledeliv/CMakeLists.txt
+++ b/src/core/xtests/initsampledeliv/CMakeLists.txt
@@ -9,7 +9,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
-idlc_generate(TARGET InitSampleDeliv_lib FILES InitSampleDelivData.idl)
+idlc_generate(TARGET InitSampleDeliv_lib FILES InitSampleDelivData.idl NO_WARN implicit-extensibility)
 
 add_executable(InitSampleDelivPub publisher.c)
 add_executable(InitSampleDelivSub subscriber.c)

--- a/src/core/xtests/initsampledeliv/InitSampleDelivData.idl
+++ b/src/core/xtests/initsampledeliv/InitSampleDelivData.idl
@@ -9,11 +9,10 @@
 // SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 struct Msg {
+  @key
   long keyval;
   long seq;
   long tldepth;
   long final_seq;
   long seq_at_match[2];
 };
-
-#pragma keylist Msg keyval

--- a/src/core/xtests/rhc_torture/CMakeLists.txt
+++ b/src/core/xtests/rhc_torture/CMakeLists.txt
@@ -9,7 +9,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
-idlc_generate(TARGET RhcTypes FILES RhcTypes.idl)
+idlc_generate(TARGET RhcTypes FILES RhcTypes.idl NO_WARN implicit-extensibility)
 
 add_executable(rhc_torture rhc_torture.c)
 

--- a/src/core/xtests/rhc_torture/CMakeLists.txt
+++ b/src/core/xtests/rhc_torture/CMakeLists.txt
@@ -9,7 +9,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
-idlc_generate(TARGET RhcTypes FILES RhcTypes.idl NO_WARN implicit-extensibility)
+idlc_generate(TARGET RhcTypes FILES RhcTypes.idl WARNINGS no-implicit-extensibility)
 
 add_executable(rhc_torture rhc_torture.c)
 

--- a/src/core/xtests/rhc_torture/RhcTypes.idl
+++ b/src/core/xtests/rhc_torture/RhcTypes.idl
@@ -11,10 +11,11 @@
  */
 module RhcTypes {
   struct T {
+    @key
     long   k;
+    @key
     string ks;
     long   x, y;
     string s;
   };
-#pragma keylist T k ks
 };

--- a/src/idl/include/idl/processor.h
+++ b/src/idl/include/idl/processor.h
@@ -39,8 +39,6 @@
 #define IDL_FLAG_ANONYMOUS_TYPES (1u<<3)
 /* enable building block annotations */
 #define IDL_FLAG_ANNOTATIONS (1u<<4)
-/* include CDR serialized type information */
-#define IDL_FLAG_TYPE_INFO (1u<<5)
 /* flag used by idlc to indicate end-of-buffer (private) */
 #define IDL_WRITE (1u<<31)
 
@@ -63,7 +61,9 @@ typedef struct idl_pstate idl_pstate_t;
 struct idl_pstate {
   bool keylists;
   bool annotations;
-  uint32_t flags; /**< processor options */
+  struct {
+    uint32_t flags; /**< processor options */
+  } config;
   idl_file_t *paths; /**< normalized paths used in include statements */
   idl_file_t *files; /**< filenames used in #line directives */
   idl_source_t *sources;
@@ -128,15 +128,6 @@ struct idl_pstate {
     } state;
     void *yypstate; /**< state of Bison generated parser */
   } parser;
-
-  /** Generating xtypes typeinfo and typemap is logically a language independent operation that
-   various language backends will need to do, but at the same time doing so requires XCDR2
-   serialization, which, for an IDL compiler written in C, really means relying on the C backend.
-   Passing a pointer to a generator function is a reasonable way of avoiding the layering problems
-   this introduces; passing it here (in pstate_t) is a purely pragmatic choice.
-
-   May be a null pointer */
-  idl_retcode_t (*generate_typeinfo_typemap) (const idl_pstate_t *pstate, const idl_node_t *node, idl_typeinfo_typemap_t *result);
 };
 
 typedef struct idl_builtin_annotation idl_builtin_annotation_t;

--- a/src/idl/include/idl/processor.h
+++ b/src/idl/include/idl/processor.h
@@ -60,6 +60,15 @@ struct idl_typeinfo_typemap {
   size_t typemap_size;
 };
 
+typedef enum idl_warning idl_warning_t;
+enum idl_warning {
+  IDL_WARN_GENERIC,
+  IDL_WARN_IMPLICIT_EXTENSIBILITY,
+  IDL_WARN_EXTRA_TOKEN_DIRECTIVE,
+  IDL_WARN_UNKNOWN_ESCAPE_SEQ,
+  IDL_WARN_INHERIT_APPENDABLE
+};
+
 typedef struct idl_pstate idl_pstate_t;
 struct idl_pstate {
   bool keylists;
@@ -67,6 +76,8 @@ struct idl_pstate {
   struct {
     uint32_t flags; /**< processor options */
     int default_extensibility; /**< default extensibility for aggregated types */
+    const idl_warning_t *disable_warnings; /**< list of warning that will be suppressed */
+    size_t n_disable_warnings; /**< number of items in disable_warnings */
   } config;
   idl_file_t *paths; /**< normalized paths used in include statements */
   idl_file_t *files; /**< filenames used in #line directives */
@@ -164,7 +175,7 @@ idl_error(const idl_pstate_t *pstate, const idl_location_t *loc, const char *fmt
   idl_attribute_format_printf(3, 4);
 
 IDL_EXPORT void
-idl_warning(const idl_pstate_t *pstate, const idl_location_t *loc, const char *fmt, ...)
-  idl_attribute_format_printf(3, 4);
+idl_warning(const idl_pstate_t *pstate, idl_warning_t warning, const idl_location_t *loc, const char *fmt, ...)
+  idl_attribute_format_printf(4, 5);
 
 #endif /* IDL_COMPILER_H */

--- a/src/idl/include/idl/processor.h
+++ b/src/idl/include/idl/processor.h
@@ -42,6 +42,9 @@
 /* flag used by idlc to indicate end-of-buffer (private) */
 #define IDL_WRITE (1u<<31)
 
+/* used to indicate that default extensibility is not set */
+#define IDL_DEFAULT_EXTENSIBILITY_UNDEFINED (-1)
+
 typedef struct idl_buffer idl_buffer_t;
 struct idl_buffer {
   char *data;
@@ -63,6 +66,7 @@ struct idl_pstate {
   bool annotations;
   struct {
     uint32_t flags; /**< processor options */
+    int default_extensibility; /**< default extensibility for aggregated types */
   } config;
   idl_file_t *paths; /**< normalized paths used in include statements */
   idl_file_t *files; /**< filenames used in #line directives */

--- a/src/idl/include/idl/tree.h
+++ b/src/idl/include/idl/tree.h
@@ -207,7 +207,7 @@ enum idl_extensibility {
    the construct itself may be referenced. e.g. @default_nested annotations
    are only referenced by the annotated module, not by any subconstructs */
 #define IDL_ANNOTATABLE(type) \
-  struct { const struct idl_annotation_appl *annotation; type value; }
+  struct { const struct idl_annotation_appl *annotation; type value; bool implicit; }
 
 /* annotations */
 
@@ -518,6 +518,8 @@ IDL_EXPORT bool idl_is_forward(const void *node);
 /* 1-based, returns 0 if path does not refer to key, non-0 otherwise */
 IDL_EXPORT bool idl_is_topic_key(const void *node, bool keylist, const idl_path_t *path, uint32_t *order);
 IDL_EXPORT bool idl_is_extensible(const idl_node_t *node, idl_extensibility_t extensibility);
+IDL_EXPORT bool idl_has_implicit_default_extensibility(const idl_node_t *node);
+IDL_EXPORT idl_retcode_t idl_set_default_extensibility(idl_node_t *node, idl_extensibility_t default_extensibility);
 IDL_EXPORT bool idl_is_external(const idl_node_t *node);
 IDL_EXPORT bool idl_is_optional(const idl_node_t *node);
 IDL_EXPORT bool idl_is_must_understand(const idl_node_t *node);

--- a/src/idl/include/idl/tree.h
+++ b/src/idl/include/idl/tree.h
@@ -207,7 +207,7 @@ enum idl_extensibility {
    the construct itself may be referenced. e.g. @default_nested annotations
    are only referenced by the annotated module, not by any subconstructs */
 #define IDL_ANNOTATABLE(type) \
-  struct { const struct idl_annotation_appl *annotation; type value; bool implicit; }
+  struct { const struct idl_annotation_appl *annotation; type value; }
 
 /* annotations */
 
@@ -518,7 +518,7 @@ IDL_EXPORT bool idl_is_forward(const void *node);
 /* 1-based, returns 0 if path does not refer to key, non-0 otherwise */
 IDL_EXPORT bool idl_is_topic_key(const void *node, bool keylist, const idl_path_t *path, uint32_t *order);
 IDL_EXPORT bool idl_is_extensible(const idl_node_t *node, idl_extensibility_t extensibility);
-IDL_EXPORT idl_retcode_t idl_set_default_extensibility_recursive(idl_node_t *node, idl_extensibility_t default_extensibility, uint32_t *num_updated);
+IDL_EXPORT bool idl_has_unset_extensibility_r(idl_node_t *node);
 IDL_EXPORT bool idl_is_external(const idl_node_t *node);
 IDL_EXPORT bool idl_is_optional(const idl_node_t *node);
 IDL_EXPORT bool idl_is_must_understand(const idl_node_t *node);

--- a/src/idl/include/idl/tree.h
+++ b/src/idl/include/idl/tree.h
@@ -518,8 +518,7 @@ IDL_EXPORT bool idl_is_forward(const void *node);
 /* 1-based, returns 0 if path does not refer to key, non-0 otherwise */
 IDL_EXPORT bool idl_is_topic_key(const void *node, bool keylist, const idl_path_t *path, uint32_t *order);
 IDL_EXPORT bool idl_is_extensible(const idl_node_t *node, idl_extensibility_t extensibility);
-IDL_EXPORT bool idl_has_implicit_default_extensibility(const idl_node_t *node);
-IDL_EXPORT idl_retcode_t idl_set_default_extensibility(idl_node_t *node, idl_extensibility_t default_extensibility);
+IDL_EXPORT idl_retcode_t idl_set_default_extensibility_recursive(idl_node_t *node, idl_extensibility_t default_extensibility, uint32_t *num_updated);
 IDL_EXPORT bool idl_is_external(const idl_node_t *node);
 IDL_EXPORT bool idl_is_optional(const idl_node_t *node);
 IDL_EXPORT bool idl_is_must_understand(const idl_node_t *node);

--- a/src/idl/src/annotation.c
+++ b/src/idl/src/annotation.c
@@ -551,23 +551,18 @@ set_implicitly_nested(void *node)
   for (; ret == IDL_RETCODE_OK && node; node = idl_next(node)) {
     if (idl_is_struct(node)) {
       /* skip if annotated with @nested or @topic before */
-      if (!((idl_struct_t *)node)->nested.annotation) {
+      if (!((idl_struct_t *)node)->nested.annotation)
         ((idl_struct_t *)node)->nested.value = true;
-        ((idl_struct_t *)node)->nested.implicit = true;
-      }
     } else if (idl_is_union(node)) {
       /* skip if annotated with @nested or @topic before */
-      if (!((idl_union_t *)node)->nested.annotation) {
+      if (!((idl_union_t *)node)->nested.annotation)
         ((idl_union_t *)node)->nested.value = true;
-        ((idl_union_t *)node)->nested.implicit = true;
-      }
     } else if (idl_is_module(node)) {
       idl_module_t *module = node;
       /* skip if annotated with @default_nested before */
       if (module->default_nested.annotation)
         continue;
       module->default_nested.value = true;
-      module->default_nested.implicit = true;
       ret = set_implicitly_nested(module->definitions);
     }
   }

--- a/src/idl/src/annotation.c
+++ b/src/idl/src/annotation.c
@@ -551,18 +551,23 @@ set_implicitly_nested(void *node)
   for (; ret == IDL_RETCODE_OK && node; node = idl_next(node)) {
     if (idl_is_struct(node)) {
       /* skip if annotated with @nested or @topic before */
-      if (!((idl_struct_t *)node)->nested.annotation)
+      if (!((idl_struct_t *)node)->nested.annotation) {
         ((idl_struct_t *)node)->nested.value = true;
+        ((idl_struct_t *)node)->nested.implicit = true;
+      }
     } else if (idl_is_union(node)) {
       /* skip if annotated with @nested or @topic before */
-      if (!((idl_union_t *)node)->nested.annotation)
+      if (!((idl_union_t *)node)->nested.annotation) {
         ((idl_union_t *)node)->nested.value = true;
+        ((idl_union_t *)node)->nested.implicit = true;
+      }
     } else if (idl_is_module(node)) {
       idl_module_t *module = node;
       /* skip if annotated with @default_nested before */
       if (module->default_nested.annotation)
         continue;
       module->default_nested.value = true;
+      module->default_nested.implicit = true;
       ret = set_implicitly_nested(module->definitions);
     }
   }

--- a/src/idl/src/directive.c
+++ b/src/idl/src/directive.c
@@ -252,7 +252,7 @@ parse_line(idl_pstate_t *pstate, idl_token_t *tok)
           pstate->scanner.state = IDL_SCAN_FILE;
       } else {
 extra_tokens:
-        idl_warning(pstate, &tok->location, "Extra tokens at end of %s", type);
+        idl_warning(pstate, IDL_WARN_EXTRA_TOKEN_DIRECTIVE, &tok->location, "Extra tokens at end of %s", type);
         pstate->scanner.state = IDL_SCAN_EXTRA_TOKENS;
       }
       break;

--- a/src/idl/src/keylist.c
+++ b/src/idl/src/keylist.c
@@ -304,7 +304,6 @@ void idl_set_keylist_key_flags(idl_pstate_t *pstate, void *list)
             assert(idl_is_member(m));
             m->key.value = true;
             m->key.annotation = NULL;
-            m->key.implicit = true;
             key_names.length--;
           }
         }

--- a/src/idl/src/keylist.c
+++ b/src/idl/src/keylist.c
@@ -304,6 +304,7 @@ void idl_set_keylist_key_flags(idl_pstate_t *pstate, void *list)
             assert(idl_is_member(m));
             m->key.value = true;
             m->key.annotation = NULL;
+            m->key.implicit = true;
             key_names.length--;
           }
         }

--- a/src/idl/src/parser.y
+++ b/src/idl/src/parser.y
@@ -940,7 +940,7 @@ identifier:
     IDL_TOKEN_IDENTIFIER
       { $$ = NULL;
         size_t n;
-        bool nocase = (pstate->flags & IDL_FLAG_CASE_SENSITIVE) == 0;
+        bool nocase = (pstate->config.flags & IDL_FLAG_CASE_SENSITIVE) == 0;
         if (pstate->parser.state == IDL_PARSE_ANNOTATION_APPL)
           n = 0;
         else if (pstate->parser.state == IDL_PARSE_ANNOTATION)
@@ -1184,7 +1184,7 @@ int idl_iskeyword(idl_pstate_t *pstate, const char *str, int nc)
     case IDL_TOKEN_MAP:
       /* intX and uintX are considered keywords if and only if building block
          extended data-types is enabled */
-      if (!(pstate->flags & IDL_FLAG_EXTENDED_DATA_TYPES))
+      if (!(pstate->config.flags & IDL_FLAG_EXTENDED_DATA_TYPES))
         return 0;
       break;
     default:

--- a/src/idl/src/processor.c
+++ b/src/idl/src/processor.c
@@ -285,9 +285,13 @@ idl_error(
 
 void
 idl_warning(
-  const idl_pstate_t *pstate, const idl_location_t *loc, const char *fmt, ...)
+  const idl_pstate_t *pstate, idl_warning_t warning, const idl_location_t *loc, const char *fmt, ...)
 {
   va_list ap;
+
+  for (size_t n = 0; n < pstate->config.n_disable_warnings; n++)
+    if (pstate->config.disable_warnings[n] == warning)
+      return;
 
   va_start(ap, fmt);
   idl_log(pstate, IDL_LC_WARNING, loc, fmt, ap);
@@ -399,7 +403,7 @@ static idl_retcode_t validate_must_understand(idl_pstate_t *pstate, void *root)
 static idl_retcode_t set_type_extensibility(idl_pstate_t *pstate)
 {
   if (pstate->config.default_extensibility == IDL_DEFAULT_EXTENSIBILITY_UNDEFINED && idl_has_implicit_default_extensibility(pstate->root)) {
-    idl_warning(pstate, NULL, "No default extensibility provided. For one or more of the "
+    idl_warning(pstate, IDL_WARN_IMPLICIT_EXTENSIBILITY, NULL, "No default extensibility provided. For one or more of the "
       "aggregated types in the IDL the extensibility is not explicitly set. "
       "Currently the default extensibility for these types is 'final', but this "
       "may change to 'appendable' in a future release because that is the "

--- a/src/idl/src/processor.c
+++ b/src/idl/src/processor.c
@@ -402,13 +402,7 @@ static idl_retcode_t validate_must_understand(idl_pstate_t *pstate, void *root)
 
 static idl_retcode_t set_type_extensibility(idl_pstate_t *pstate)
 {
-  idl_retcode_t ret = IDL_RETCODE_OK;
-  idl_extensibility_t def_ext = pstate->config.default_extensibility >= 0 ? (idl_extensibility_t) pstate->config.default_extensibility : IDL_FINAL;
-  uint32_t num_ext_undefined = 0;
-
-  if ((ret = idl_set_default_extensibility_recursive(pstate->root, def_ext, &num_ext_undefined)) < 0)
-    return ret;
-  if (num_ext_undefined > 0 && pstate->config.default_extensibility == IDL_DEFAULT_EXTENSIBILITY_UNDEFINED) {
+  if (pstate->config.default_extensibility == IDL_DEFAULT_EXTENSIBILITY_UNDEFINED && idl_has_unset_extensibility_r(pstate->root)) {
     idl_warning(pstate, IDL_WARN_IMPLICIT_EXTENSIBILITY, NULL,
       "No default extensibility provided. For one or more of the "
       "aggregated types in the IDL the extensibility is not explicitly set. "
@@ -416,7 +410,7 @@ static idl_retcode_t set_type_extensibility(idl_pstate_t *pstate)
       "may change to 'appendable' in a future release because that is the "
       "default in the DDS XTypes specification.");
   }
-  return ret;
+  return IDL_RETCODE_OK;
 }
 
 idl_retcode_t idl_parse(idl_pstate_t *pstate)

--- a/src/idl/src/processor.c
+++ b/src/idl/src/processor.c
@@ -152,10 +152,10 @@ idl_create_pstate(
   if (idl_create_scope(pstate, IDL_GLOBAL_SCOPE, &builtin_name, NULL, &scope))
     goto err_scope;
 
-  pstate->flags = flags;
+  pstate->config.flags = flags;
   pstate->global_scope = pstate->scope = scope;
 
-  if (pstate->flags & IDL_FLAG_ANNOTATIONS) {
+  if (pstate->config.flags & IDL_FLAG_ANNOTATIONS) {
     idl_retcode_t ret;
     if ((ret = parse_builtin_annotations(pstate, builtin_annotations))) {
       idl_delete_pstate(pstate);

--- a/src/idl/src/scanner.c
+++ b/src/idl/src/scanner.c
@@ -693,7 +693,7 @@ unescape(
           str[pos++] = seq[j][1];
         } else {
           str[pos++] = str[i];
-          idl_warning(pstate, &lex->location,
+          idl_warning(pstate, IDL_WARN_UNKNOWN_ESCAPE_SEQ, &lex->location,
             "unknown escape sequence '\\%c'", str[i]);
         }
         i++;

--- a/src/idl/src/scanner.c
+++ b/src/idl/src/scanner.c
@@ -27,16 +27,16 @@ static int32_t
 have_newline(idl_pstate_t *pstate, const char *cur)
 {
   if (cur == pstate->scanner.limit)
-    return pstate->flags & IDL_WRITE ? -2 : 0;
+    return pstate->config.flags & IDL_WRITE ? -2 : 0;
   assert(cur < pstate->scanner.limit);
   if (cur[0] == '\n') {
     if (cur < pstate->scanner.limit - 1)
       return cur[1] == '\r' ? 2 : 1;
-    return pstate->flags & IDL_WRITE ? -1 : 1;
+    return pstate->config.flags & IDL_WRITE ? -1 : 1;
   } else if (cur[0] == '\r') {
     if (cur < pstate->scanner.limit - 1)
       return cur[1] == '\n' ? 2 : 1;
-    return pstate->flags & IDL_WRITE ? -1 : 1;
+    return pstate->config.flags & IDL_WRITE ? -1 : 1;
   }
   return 0;
 }
@@ -46,7 +46,7 @@ have_skip(idl_pstate_t *pstate, const char *cur)
 {
   int cnt = 0;
   if (cur == pstate->scanner.limit)
-    return pstate->flags & IDL_WRITE ? -3 : 0;
+    return pstate->config.flags & IDL_WRITE ? -3 : 0;
   assert(cur < pstate->scanner.limit);
   if (*cur == '\\' && (cnt = have_newline(pstate, cur + 1)) > 0)
     cnt++;
@@ -57,7 +57,7 @@ static int32_t
 have_space(idl_pstate_t *pstate, const char *cur)
 {
   if (cur == pstate->scanner.limit)
-    return pstate->flags & IDL_WRITE ? -2 : 0;
+    return pstate->config.flags & IDL_WRITE ? -2 : 0;
   assert(cur < pstate->scanner.limit);
   if (*cur == ' ' || *cur == '\t' || *cur == '\f' || *cur == '\v')
     return 1;
@@ -68,7 +68,7 @@ static int32_t
 have_digit(idl_pstate_t *pstate, const char *cur)
 {
   if (cur == pstate->scanner.limit)
-    return pstate->flags & IDL_WRITE ? -1 : 0;
+    return pstate->config.flags & IDL_WRITE ? -1 : 0;
   assert(cur < pstate->scanner.limit);
   return (*cur >= '0' && *cur <= '9');
 }
@@ -77,7 +77,7 @@ static int32_t
 have_alpha(idl_pstate_t *pstate, const char *cur)
 {
   if (cur == pstate->scanner.limit)
-    return pstate->flags & IDL_WRITE ? -1 : 0;
+    return pstate->config.flags & IDL_WRITE ? -1 : 0;
   assert(cur < pstate->scanner.limit);
   return (*cur >= 'a' && *cur <= 'z') ||
          (*cur >= 'A' && *cur <= 'Z') ||
@@ -88,7 +88,7 @@ static int32_t
 have_alnum(idl_pstate_t *pstate, const char *cur)
 {
   if (cur == pstate->scanner.limit)
-    return pstate->flags & IDL_WRITE ? -1 : 0;
+    return pstate->config.flags & IDL_WRITE ? -1 : 0;
   assert(cur < pstate->scanner.limit);
   return (*cur >= 'a' && *cur <= 'z') ||
          (*cur >= 'A' && *cur <= 'Z') ||
@@ -630,7 +630,7 @@ scan(idl_pstate_t *pstate, idl_lexeme_t *lex)
       pstate->scanner.state = IDL_SCAN_DIRECTIVE;
       lim = cur + 1;
       code = (unsigned char)*cur;
-    } else if ((pstate->flags & IDL_WRITE) && next(pstate, cur) == pstate->scanner.limit) {
+    } else if ((pstate->config.flags & IDL_WRITE) && next(pstate, cur) == pstate->scanner.limit) {
       code = IDL_RETCODE_NEED_REFILL;
     } else {
       pstate->scanner.state = IDL_SCAN_GRAMMAR;
@@ -759,7 +759,7 @@ tokenize(
         goto identifier;
       if (pstate->scanner.state == IDL_SCAN_ANNOTATION_NAME)
         goto identifier;
-      if ((code = idl_iskeyword(pstate, str, !(pstate->flags & IDL_FLAG_CASE_SENSITIVE))))
+      if ((code = idl_iskeyword(pstate, str, !(pstate->config.flags & IDL_FLAG_CASE_SENSITIVE))))
         break;
 identifier:
       pstate->scanner.state = IDL_SCAN_GRAMMAR;

--- a/src/idl/src/scope.c
+++ b/src/idl/src/scope.c
@@ -172,7 +172,7 @@ idl_declare(
   int (*cmp)(const char *, const char *);
 
   assert(pstate && pstate->scope);
-  cmp = (pstate->flags & IDL_FLAG_CASE_SENSITIVE) ? &strcmp : &idl_strcasecmp;
+  cmp = (pstate->config.flags & IDL_FLAG_CASE_SENSITIVE) ? &strcmp : &idl_strcasecmp;
 
   /* ensure there is no collision with an earlier declaration */
   for (entry = pstate->scope->declarations.first; entry; entry = entry->next) {
@@ -502,7 +502,7 @@ idl_resolve(
 
   if (kind == IDL_ANNOTATION_DECLARATION)
     flags |= IDL_FIND_ANNOTATION;
-  if (pstate->flags & IDL_FLAG_CASE_SENSITIVE)
+  if (pstate->config.flags & IDL_FLAG_CASE_SENSITIVE)
     ignore_case = 0u;
 
   if (scoped_name->absolute)

--- a/src/idl/src/tree.c
+++ b/src/idl/src/tree.c
@@ -976,7 +976,7 @@ bool idl_is_struct(const void *ptr)
      data types is enabled */
 #if 0
   members = ((const idl_struct_t *)node)->members;
-  if (!(pstate->flags & IDL_FLAG_EXTENDED_DATA_TYPES))
+  if (!(pstate->config.flags & IDL_FLAG_EXTENDED_DATA_TYPES))
     assert(members);
   if (members)
     assert(idl_mask(members) & IDL_MEMBER);
@@ -2020,7 +2020,7 @@ idl_is_switch_type_spec(const void *ptr)
     case IDL_WCHAR:
     case IDL_OCTET:
 #if 0
-      assert(pstate->flags & IDL_FLAG_EXTENDED_DATA_TYPES);
+      assert(pstate->config.flags & IDL_FLAG_EXTENDED_DATA_TYPES);
 #endif
       return true;
     default:
@@ -2072,7 +2072,7 @@ idl_create_switch_type_spec(
   static const struct methods methods = { delete_switch_type_spec,
                                           iterate_switch_type_spec,
                                           describe_switch_type_spec };
-  bool ext = (pstate->flags & IDL_FLAG_EXTENDED_DATA_TYPES) != 0;
+  bool ext = (pstate->config.flags & IDL_FLAG_EXTENDED_DATA_TYPES) != 0;
 
   assert(type_spec);
   type = idl_type(idl_unalias(type_spec));

--- a/src/idl/src/tree.c
+++ b/src/idl/src/tree.c
@@ -1239,7 +1239,7 @@ idl_finalize_struct(
     if (base->extensibility.value == IDL_APPENDABLE) {
       static bool extensibility_inheritance_warned = false;
       if (!extensibility_inheritance_warned) {
-        idl_warning(state, idl_location(node),
+        idl_warning(state, IDL_WARN_INHERIT_APPENDABLE, idl_location(node),
           "Inheriting from appendable structs is unsafe");
         extensibility_inheritance_warned = true;
       }

--- a/src/security/core/tests/CMakeLists.txt
+++ b/src/security/core/tests/CMakeLists.txt
@@ -12,7 +12,7 @@
 include (GenerateExportHeader)
 include (CUnit)
 
-idlc_generate(TARGET SecurityCoreTests FILES SecurityCoreTests.idl)
+idlc_generate(TARGET SecurityCoreTests FILES SecurityCoreTests.idl WARNINGS no-implicit-extensibility)
 
 function(add_wrapper libname linklibs)
   set(srcs_wrapper

--- a/src/security/core/tests/SecurityCoreTests.idl
+++ b/src/security/core/tests/SecurityCoreTests.idl
@@ -10,15 +10,15 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
 module SecurityCoreTests {
-    struct Type1 {
-        long	id; //@Key
-        long    value;
-    };
-#pragma keylist Type1 id
+  struct Type1 {
+    @key
+    long	id;
+    long    value;
+  };
 
-    struct Type2 {
-        long    id; //@Key
-        string  text;
-    };
-#pragma keylist Type2 id
+  struct Type2 {
+    @key
+    long    id;
+    string  text;
+  };
 };

--- a/src/tools/ddsperf/CMakeLists.txt
+++ b/src/tools/ddsperf/CMakeLists.txt
@@ -13,7 +13,7 @@
 if (BUILD_DDSPERF)
   include(Generate)
 
-  idlc_generate(TARGET ddsperf_types FILES ddsperf_types.idl)
+  idlc_generate(TARGET ddsperf_types FILES ddsperf_types.idl NO_WARN implicit-extensibility)
   add_executable(ddsperf
     ddsperf.c
     cputime.c cputime.h

--- a/src/tools/ddsperf/CMakeLists.txt
+++ b/src/tools/ddsperf/CMakeLists.txt
@@ -13,7 +13,7 @@
 if (BUILD_DDSPERF)
   include(Generate)
 
-  idlc_generate(TARGET ddsperf_types FILES ddsperf_types.idl NO_WARN implicit-extensibility)
+  idlc_generate(TARGET ddsperf_types FILES ddsperf_types.idl WARNINGS no-implicit-extensibility)
   add_executable(ddsperf
     ddsperf.c
     cputime.c cputime.h

--- a/src/tools/ddsperf/ddsperf_types.idl
+++ b/src/tools/ddsperf/ddsperf_types.idl
@@ -1,47 +1,51 @@
+@final
 struct OneULong
 {
   unsigned long seq;
 };
-#pragma keylist OneULong
 
+@final
 struct Unkeyed16
 {
   unsigned long seq;
   octet baggage[12];
 };
-#pragma keylist Unkeyed16
 
+@final
 struct Unkeyed1024
 {
   unsigned long seq;
   octet baggage[1020];
 };
-#pragma keylist Unkeyed1024
 
+@final
 struct Keyed32
 {
   unsigned long seq;
+  @key
   unsigned long keyval;
   octet baggage[24];
 };
-#pragma keylist Keyed32 keyval
 
+@final
 struct Keyed256
 {
   unsigned long seq;
+  @key
   unsigned long keyval;
   octet baggage[248];
 };
-#pragma keylist Keyed256 keyval
 
+@final
 struct KeyedSeq
 {
   unsigned long seq;
+  @key
   unsigned long keyval;
   sequence<octet> baggage;
 };
-#pragma keylist KeyedSeq keyval
 
+@final @nested
 struct CPUStatThread
 {
   string name;
@@ -49,9 +53,12 @@ struct CPUStatThread
   long s_pct;
 };
 
+@final
 struct CPUStats
 {
+  @key
   string hostname;
+  @key
   unsigned long pid;
   double maxrss;
   unsigned long vcsw;
@@ -59,4 +66,3 @@ struct CPUStats
   boolean some_above;
   sequence<CPUStatThread> cpu;
 };
-#pragma keylist CPUStats hostname pid

--- a/src/tools/idlc/include/idlc/generator.h
+++ b/src/tools/idlc/include/idlc/generator.h
@@ -15,6 +15,7 @@
 #include <stdint.h>
 
 #include "idl/processor.h"
+#include "idl/tree.h"
 #include "idlc/options.h"
 
 #if defined (__cplusplus)
@@ -25,9 +26,22 @@ extern "C" {
 #define IDLC_GENERATOR_ANNOTATIONS generator_annotations
 #define IDLC_GENERATE generate
 
+typedef struct idlc_generator_config idlc_generator_config_t;
+struct idlc_generator_config  {
+  /** Flag to indicate if xtypes type information is included in the generated types */
+  bool generate_type_info;
+
+  /** Generating xtypes typeinfo and typemap is logically a language independent operation that
+   various language backends will need to do, but at the same time doing so requires XCDR2
+  serialization, which, for an IDL compiler written in C, really means relying on the C backend.
+  Passing a pointer to a generator function is a reasonable way of avoiding the layering problems
+  this introduces. May be a null pointer */
+  idl_retcode_t (*generate_typeinfo_typemap) (const idl_pstate_t *pstate, const idl_node_t *node, idl_typeinfo_typemap_t *result);
+};
+
 typedef const idlc_option_t **(*idlc_generator_options_t)(void);
 typedef const idl_builtin_annotation_t **(*idlc_generator_annotations_t)(void);
-typedef int(*idlc_generate_t)(const idl_pstate_t *);
+typedef int(*idlc_generate_t)(const idl_pstate_t *, const idlc_generator_config_t *);
 
 #if defined(__cplusplus)
 }

--- a/src/tools/idlc/src/descriptor.c
+++ b/src/tools/idlc/src/descriptor.c
@@ -1360,7 +1360,7 @@ emit_member(
   (void)user_data;
   const idl_member_t *member = (const idl_member_t *)node;
   if (member->value.annotation)
-    idl_warning(pstate, idl_location(node), "Explicit defaults are not supported yet in the C generator, the value from the @default annotation will not be used");
+    idl_warning(pstate, IDL_WARN_GENERIC, idl_location(node), "Explicit defaults are not supported yet in the C generator, the value from the @default annotation will not be used");
   return IDL_RETCODE_OK;
 }
 
@@ -1377,7 +1377,7 @@ emit_bitmask(
   (void)user_data;
   const idl_bitmask_t *bitmask = (const idl_bitmask_t *)node;
   if (bitmask->extensibility.annotation && bitmask->extensibility.value != IDL_FINAL)
-    idl_warning(pstate, idl_location(node), "Extensibility appendable and mutable for bitmask type are not yet supported in the C generator, the extensibility will not be used");
+    idl_warning(pstate, IDL_WARN_GENERIC, idl_location(node), "Extensibility appendable and mutable for bitmask type are not yet supported in the C generator, the extensibility will not be used");
   return IDL_RETCODE_OK;
 }
 
@@ -1394,7 +1394,7 @@ emit_enum(
   (void)user_data;
   const idl_enum_t *_enum = (const idl_enum_t *)node;
   if (_enum->extensibility.annotation && _enum->extensibility.value != IDL_FINAL)
-    idl_warning(pstate, idl_location(node), "Extensibility appendable and mutable for enum type are not yet supported in the C generator, the extensibility will not be used");
+    idl_warning(pstate, IDL_WARN_GENERIC, idl_location(node), "Extensibility appendable and mutable for enum type are not yet supported in the C generator, the extensibility will not be used");
   return IDL_RETCODE_OK;
 }
 

--- a/src/tools/idlc/src/descriptor.c
+++ b/src/tools/idlc/src/descriptor.c
@@ -908,7 +908,7 @@ emit_switch_type_spec(
     return ret;
   // XTypes spec 7.2.2.4.4.4.6: In a union type, the discriminator member shall always have the 'must understand' attribute set to true.
   opcode |= DDS_OP_FLAG_MU;
-  if (idl_is_topic_key(descriptor->topic, (pstate->flags & IDL_FLAG_KEYLIST) != 0, path, &order)) {
+  if (idl_is_topic_key(descriptor->topic, (pstate->config.flags & IDL_FLAG_KEYLIST) != 0, path, &order)) {
     opcode |= DDS_OP_FLAG_KEY;
     ctype->has_key_member = true;
   }
@@ -1174,7 +1174,7 @@ emit_sequence(
     opcode |= idl_is_bounded(node) ? DDS_OP_TYPE_BSQ : DDS_OP_TYPE_SEQ;
     if ((ret = add_typecode(pstate, type_spec, SUBTYPE, false, &opcode)))
       return ret;
-    if (idl_is_topic_key(descriptor->topic, (pstate->flags & IDL_FLAG_KEYLIST) != 0, path, &order)) {
+    if (idl_is_topic_key(descriptor->topic, (pstate->config.flags & IDL_FLAG_KEYLIST) != 0, path, &order)) {
       opcode |= DDS_OP_FLAG_KEY | DDS_OP_FLAG_MU;
       ctype->has_key_member = true;
     }
@@ -1301,7 +1301,7 @@ emit_array(
 
     if ((ret = add_typecode(pstate, type_spec, SUBTYPE, false, &opcode)))
       return ret;
-    if (idl_is_topic_key(descriptor->topic, (pstate->flags & IDL_FLAG_KEYLIST) != 0, path, &order)) {
+    if (idl_is_topic_key(descriptor->topic, (pstate->config.flags & IDL_FLAG_KEYLIST) != 0, path, &order)) {
       opcode |= DDS_OP_FLAG_KEY | DDS_OP_FLAG_MU;
       ctype->has_key_member = true;
     }
@@ -1460,7 +1460,7 @@ emit_declarator(
     assert(ctype->instructions.count <= INT16_MAX);
     int16_t addr_offs = (int16_t)ctype->instructions.count;
     bool has_size = false;
-    bool keylist = (pstate->flags & IDL_FLAG_KEYLIST) != 0;
+    bool keylist = (pstate->config.flags & IDL_FLAG_KEYLIST) != 0;
     opcode = DDS_OP_ADR;
     if ((ret = add_typecode(pstate, type_spec, TYPE, true, &opcode)))
       return ret;
@@ -2432,7 +2432,7 @@ generate_descriptor_impl(
   uint32_t n_keys = 0;
   if ((ret = get_ctype_keys(pstate, descriptor, ctype, &ctype_keys, &n_keys, false)) != IDL_RETCODE_OK)
     goto err;
-  if ((ret = descriptor_init_keys(pstate, ctype, ctype_keys, descriptor, n_keys, (pstate->flags & IDL_FLAG_KEYLIST) != 0)) < 0)
+  if ((ret = descriptor_init_keys(pstate, ctype, ctype_keys, descriptor, n_keys, (pstate->config.flags & IDL_FLAG_KEYLIST) != 0)) < 0)
     goto err;
   free_ctype_keys(ctype_keys);
 
@@ -2465,10 +2465,9 @@ generate_descriptor(
   if (print_keys(generator->source.handle, &descriptor, inst_count) < 0)
     { ret = IDL_RETCODE_NO_MEMORY; goto err_print; }
 #ifdef DDS_HAS_TYPE_DISCOVERY
-  bool type_info = (pstate->flags & IDL_FLAG_TYPE_INFO) != 0;
-  if (type_info && print_type_meta_ser(generator->source.handle, pstate, node) < 0)
+  if (generator->config.c.generate_type_info && print_type_meta_ser(generator->source.handle, pstate, node) < 0)
     { ret = IDL_RETCODE_NO_MEMORY; goto err_print; }
-  if (print_descriptor(generator->source.handle, &descriptor, type_info) < 0)
+  if (print_descriptor(generator->source.handle, &descriptor, generator->config.c.generate_type_info) < 0)
     { ret = IDL_RETCODE_NO_MEMORY; goto err_print; }
 #else
   if (print_descriptor(generator->source.handle, &descriptor, false) < 0)

--- a/src/tools/idlc/src/descriptor.c
+++ b/src/tools/idlc/src/descriptor.c
@@ -957,18 +957,12 @@ emit_union(
     if ((ret = add_ctype(descriptor, idl_scope(node), node, &ctype)))
       return ret;
 
-    switch (((idl_union_t *)node)->extensibility.value) {
-      case IDL_APPENDABLE:
-        if ((ret = stash_opcode(pstate, descriptor, &ctype->instructions, nop, DDS_OP_DLC, 0u)))
-          return ret;
-        break;
-      case IDL_MUTABLE:
-        idl_error(pstate, idl_location(node), "Mutable unions are not supported yet");
-        //if ((ret = stash_opcode(pstate, descriptor, &ctype->instructions, nop, DDS_OP_PLC, 0u)))
-        //  return ret;
-        return IDL_RETCODE_UNSUPPORTED;
-      case IDL_FINAL:
-        break;
+    if (idl_is_extensible(node, IDL_APPENDABLE)) {
+      if ((ret = stash_opcode(pstate, descriptor, &ctype->instructions, nop, DDS_OP_DLC, 0u)))
+        return ret;
+    } else if (idl_is_extensible(node, IDL_MUTABLE)) {
+      idl_error(pstate, idl_location(node), "Mutable unions are not supported yet");
+      return IDL_RETCODE_UNSUPPORTED;
     }
 
     if ((ret = push_type(descriptor, node, ctype, &stype)))
@@ -1097,18 +1091,13 @@ emit_struct(
     if ((ret = add_ctype(descriptor, idl_scope(node), node, &ctype)))
       return ret;
 
-    switch (((idl_struct_t *)node)->extensibility.value) {
-      case IDL_APPENDABLE:
-        if ((ret = stash_opcode(pstate, descriptor, &ctype->instructions, nop, DDS_OP_DLC, 0u)))
-          return ret;
-        break;
-      case IDL_MUTABLE:
-        if ((ret = stash_opcode(pstate, descriptor, &ctype->instructions, nop, DDS_OP_PLC, 0u)))
-          return ret;
-        ctype->pl_offset = ctype->instructions.count;
-        break;
-      case IDL_FINAL:
-        break;
+    if (idl_is_extensible(node, IDL_APPENDABLE)) {
+      if ((ret = stash_opcode(pstate, descriptor, &ctype->instructions, nop, DDS_OP_DLC, 0u)))
+        return ret;
+    } else if (idl_is_extensible(node, IDL_MUTABLE)) {
+      if ((ret = stash_opcode(pstate, descriptor, &ctype->instructions, nop, DDS_OP_PLC, 0u)))
+        return ret;
+      ctype->pl_offset = ctype->instructions.count;
     }
 
     if (!(ret = push_type(descriptor, node, ctype, NULL))) {
@@ -1342,6 +1331,10 @@ emit_array(
       }
       if (!idl_is_alias(node) && idl_is_struct(stype->node))
         pop_field(descriptor);
+      /* visit type-spec for bitmask and enum type, so that emit function is triggered
+         and check for unsupported extensibility is done */
+      if (idl_is_bitmask(type_spec) || idl_is_enum(type_spec))
+        return IDL_VISIT_TYPE_SPEC;
       return IDL_RETCODE_OK;
     }
 
@@ -1384,7 +1377,24 @@ emit_bitmask(
   (void)user_data;
   const idl_bitmask_t *bitmask = (const idl_bitmask_t *)node;
   if (bitmask->extensibility.annotation && bitmask->extensibility.value != IDL_FINAL)
-    idl_warning(pstate, idl_location(node), "Extensibility appendable and mutable are not yet supported in the C generator, the extensibility will not be used");
+    idl_warning(pstate, idl_location(node), "Extensibility appendable and mutable for bitmask type are not yet supported in the C generator, the extensibility will not be used");
+  return IDL_RETCODE_OK;
+}
+
+static idl_retcode_t
+emit_enum(
+  const idl_pstate_t *pstate,
+  bool revisit,
+  const idl_path_t *path,
+  const void *node,
+  void *user_data)
+{
+  (void)revisit;
+  (void)path;
+  (void)user_data;
+  const idl_enum_t *_enum = (const idl_enum_t *)node;
+  if (_enum->extensibility.annotation && _enum->extensibility.value != IDL_FINAL)
+    idl_warning(pstate, idl_location(node), "Extensibility appendable and mutable for enum type are not yet supported in the C generator, the extensibility will not be used");
   return IDL_RETCODE_OK;
 }
 
@@ -1512,7 +1522,11 @@ emit_declarator(
         return ret;
     }
 
-    if (idl_is_union(type_spec) || idl_is_struct(type_spec) || idl_is_bitmask(type_spec))
+    /* Type spec in case of aggregated type needs to be visited, to generate
+       the serializer ops for these types. For enumerated types, also visit
+       the type-spec, so that emit function is triggered that checks for
+       unsupported extensibility */
+    if (idl_is_union(type_spec) || idl_is_struct(type_spec) || idl_is_bitmask(type_spec) || idl_is_enum(type_spec))
       return IDL_VISIT_TYPE_SPEC | IDL_VISIT_UNALIAS_TYPE_SPEC | IDL_VISIT_REVISIT;
 
     return IDL_VISIT_REVISIT;
@@ -2401,7 +2415,7 @@ generate_descriptor_impl(
   descriptor->topic = topic_node;
 
   memset(&visitor, 0, sizeof(visitor));
-  visitor.visit = IDL_DECLARATOR | IDL_SEQUENCE | IDL_STRUCT | IDL_UNION | IDL_SWITCH_TYPE_SPEC | IDL_CASE | IDL_FORWARD | IDL_MEMBER | IDL_BITMASK | IDL_INHERIT_SPEC;
+  visitor.visit = IDL_DECLARATOR | IDL_SEQUENCE | IDL_STRUCT | IDL_UNION | IDL_SWITCH_TYPE_SPEC | IDL_CASE | IDL_FORWARD | IDL_MEMBER | IDL_BITMASK | IDL_ENUM | IDL_INHERIT_SPEC;
   visitor.accept[IDL_ACCEPT_SEQUENCE] = &emit_sequence;
   visitor.accept[IDL_ACCEPT_UNION] = &emit_union;
   visitor.accept[IDL_ACCEPT_SWITCH_TYPE_SPEC] = &emit_switch_type_spec;
@@ -2412,6 +2426,7 @@ generate_descriptor_impl(
   visitor.accept[IDL_ACCEPT_MEMBER] = &emit_member;
   visitor.accept[IDL_ACCEPT_BITMASK] = &emit_bitmask;
   visitor.accept[IDL_ACCEPT_INHERIT_SPEC] = &emit_inherit_spec;
+  visitor.accept[IDL_ACCEPT_ENUM] = &emit_enum;
 
   if ((ret = idl_visit(pstate, descriptor->topic, &visitor, descriptor))) {
     /* Clear the type stack in case an error occured during visit, so that the check

--- a/src/tools/idlc/src/generator.c
+++ b/src/tools/idlc/src/generator.c
@@ -356,7 +356,7 @@ const idlc_option_t** idlc_generator_options(void)
 }
 
 idl_retcode_t
-idlc_generate(const idl_pstate_t *pstate)
+idlc_generate(const idl_pstate_t *pstate, const idlc_generator_config_t *config)
 {
   idl_retcode_t ret = IDL_RETCODE_NO_MEMORY;
   const char *sep, *ext, *file, *path;
@@ -366,6 +366,7 @@ idlc_generate(const idl_pstate_t *pstate)
 
   assert(pstate->paths);
   assert(pstate->paths->name);
+  assert(config);
   path = pstate->sources->path->name;
   /* use relative directory if user provided a relative path, use current
      word directory otherwise */
@@ -403,17 +404,18 @@ idlc_generate(const idl_pstate_t *pstate)
     goto err_source;
   if (!(generator.source.handle = idl_fopen(generator.source.path, "wb")))
     goto err_source;
+  generator.config.c = *config;
   if (export_macro) {
-    if (!(generator.export_macro = idl_strdup (export_macro)))
+    if (!(generator.config.export_macro = idl_strdup (export_macro)))
       goto err_options;
   } else {
-    generator.export_macro = NULL;
+    generator.config.export_macro = NULL;
   }
   ret = generate_nosetup(pstate, &generator);
 
 err_options:
-  if (generator.export_macro)
-    free(generator.export_macro);
+  if (generator.config.export_macro)
+    free(generator.config.export_macro);
 err_source:
   if (generator.source.handle)
     fclose(generator.source.handle);

--- a/src/tools/idlc/src/generator.h
+++ b/src/tools/idlc/src/generator.h
@@ -30,7 +30,10 @@ struct generator {
     FILE *handle;
     char *path;
   } source;
-  char *export_macro;
+  struct {
+    struct idlc_generator_config c;
+    char *export_macro;
+  } config;
 };
 
 int print_type(char *str, size_t len, const void *ptr, void *user_data);
@@ -44,7 +47,7 @@ const idlc_option_t** idlc_generator_options(void);
 #if _WIN32
 __declspec(dllexport)
 #endif
-idl_retcode_t idlc_generate(const idl_pstate_t *pstate);
+idl_retcode_t idlc_generate(const idl_pstate_t *pstate, const idlc_generator_config_t *config);
 
 #if _WIN32
 __declspec(dllexport)

--- a/src/tools/idlc/src/idlc.c
+++ b/src/tools/idlc/src/idlc.c
@@ -50,6 +50,7 @@ static struct {
   int preprocess;
   int keylist;
   int case_sensitive;
+  int default_extensibility;
   int help;
   int version;
 #ifdef DDS_HAS_TYPE_DISCOVERY
@@ -301,6 +302,7 @@ static idl_retcode_t idlc_parse(void)
     pstate->scanner.position.line = 1;
     pstate->scanner.position.column = 1;
     pstate->config.flags |= IDL_WRITE;
+    pstate->config.default_extensibility = config.default_extensibility;
   }
 
   if (config.preprocess) {
@@ -413,6 +415,20 @@ static int set_preprocess_only(const idlc_option_t *opt, const char *arg)
   return 0;
 }
 
+static int config_default_extensibility(const idlc_option_t *opt, const char *arg)
+{
+  (void)opt;
+  if (strcmp(arg, "final") == 0)
+    config.default_extensibility = IDL_FINAL;
+  else if (strcmp(arg, "appendable") == 0)
+    config.default_extensibility = IDL_APPENDABLE;
+  else if (strcmp(arg, "mutable") == 0)
+    config.default_extensibility = IDL_MUTABLE;
+  else
+    return IDLC_BAD_ARGUMENT;
+  return 0;
+}
+
 static int add_include(const idlc_option_t *opt, const char *arg)
 {
   (void)opt;
@@ -472,6 +488,11 @@ static const idlc_option_t *compopts[] = {
   &(idlc_option_t){
     IDLC_FLAG, { .flag = &config.version }, 'v', "", "",
     "Display version information." },
+  &(idlc_option_t){
+    IDLC_FUNCTION, { .function = &config_default_extensibility }, 'x', "", "<extensibility>",
+    "Set the default extensibility that is used in case no extensibility"
+    "is set on a type. Possible values are final, appendable and mutable. "
+    "(default: final)" },
 #ifdef DDS_HAS_TYPE_DISCOVERY
   &(idlc_option_t){
     IDLC_FLAG, { .flag = &config.no_type_info }, 't', "", "",
@@ -529,6 +550,7 @@ int main(int argc, char *argv[])
 
   config.compile = 1;
   config.preprocess = 1;
+  config.default_extensibility = IDL_DEFAULT_EXTENSIBILITY_UNDEFINED;
 #ifdef DDS_HAS_TYPE_DISCOVERY
   config.no_type_info = 0;
 #endif

--- a/src/tools/idlc/src/plugin.c
+++ b/src/tools/idlc/src/plugin.c
@@ -38,6 +38,7 @@ static const char ext[] = "so";
 
 #include "plugin.h"
 #include "idl/string.h"
+#include "idlc/generator.h"
 
 static size_t extlen = sizeof(ext) - 1;
 
@@ -148,7 +149,7 @@ static int run_library_locator(const char *command, char **out_output) {
 
 
 extern const idlc_option_t** idlc_generator_options(void);
-extern int idlc_generate(const idl_pstate_t *pstate);
+extern int idlc_generate(const idl_pstate_t *pstate, const idlc_generator_config_t *config);
 
 int32_t
 idlc_load_generator(idlc_generator_plugin_t *plugin, const char *lang)

--- a/src/tools/idlc/src/types.c
+++ b/src/tools/idlc/src/types.c
@@ -232,8 +232,8 @@ emit_struct(
       return IDL_RETCODE_NO_MEMORY;
     if (!empty && idl_fprintf(gen->header.handle, "\n") < 0)
       return IDL_RETCODE_NO_MEMORY;
-    if (!empty && idl_is_topic(node, (pstate->flags & IDL_FLAG_KEYLIST) != 0)) {
-      if (gen->export_macro && idl_fprintf(gen->header.handle, "%1$s ", gen->export_macro) < 0)
+    if (!empty && idl_is_topic(node, (pstate->config.flags & IDL_FLAG_KEYLIST) != 0)) {
+      if (gen->config.export_macro && idl_fprintf(gen->header.handle, "%1$s ", gen->config.export_macro) < 0)
         return IDL_RETCODE_NO_MEMORY;
       fmt = "extern const dds_topic_descriptor_t %1$s_desc;\n"
             "\n"
@@ -311,8 +311,8 @@ emit_union(
           "\n";
     if (idl_fprintf(gen->header.handle, fmt, name) < 0)
       return IDL_RETCODE_NO_MEMORY;
-    if (idl_is_topic(node, (pstate->flags & IDL_FLAG_KEYLIST) != 0)) {
-      if (gen->export_macro && idl_fprintf(gen->header.handle, "%1$s ", gen->export_macro) < 0)
+    if (idl_is_topic(node, (pstate->config.flags & IDL_FLAG_KEYLIST) != 0)) {
+      if (gen->config.export_macro && idl_fprintf(gen->header.handle, "%1$s ", gen->config.export_macro) < 0)
         return IDL_RETCODE_NO_MEMORY;
       fmt = "extern const dds_topic_descriptor_t %1$s_desc;\n"
             "\n"

--- a/src/tools/idlc/tests/test_common.c
+++ b/src/tools/idlc/tests/test_common.c
@@ -28,7 +28,7 @@ static idl_node_t * get_topic_node(idl_pstate_t *pstate, void *list)
       if (topic)
         return topic;
     } else if (idl_mask(list) == IDL_STRUCT || idl_mask(list) == IDL_UNION) {
-      if (idl_is_topic (list, (pstate->flags & IDL_FLAG_KEYLIST)))
+      if (idl_is_topic (list, (pstate->config.flags & IDL_FLAG_KEYLIST)))
         return list;
     }
   }


### PR DESCRIPTION
This adds a command line option to the C generator for IDLC to set the default extensibility for aggregated types. Aggregated types that do not have their extensibility explicitly set, get the default value. In case no default is provided, 'final' is used. Because this is different than the default in the XTypes spec (which is 'appendable'), a warning is shown in case there are types in the IDL that do not have an explicit extensibility set and no default is provided by the command line option. Enumerated types can also have an extensibility annotation, but that is currently not supported by the C generator.

This PR depends op #903, so only commit 044dfd2 is relevant. 

@reicheratwork the C++ back-end probably also needs to support for this option, I haven't implemented that as part of this PR. If we do, the implementation for this option should probably move from the C generator to idlc.c to make it a generic option for all back-ends. 