### PR TITLE
Fix Coverity issues 339186 and 339187

### DIFF
--- a/src/idl/tests/annotation.c
+++ b/src/idl/tests/annotation.c
@@ -476,7 +476,8 @@ void test_id(
     while (idl_is_module(node)) {
       const idl_module_t *mod = (const idl_module_t *)node;
       CU_ASSERT_TRUE_FATAL(m < sizeof(test.id)/sizeof(test.id[0]));
-      CU_ASSERT_EQUAL(mod->autoid.value, test.aid[m++]);
+      CU_ASSERT_EQUAL(mod->autoid.value, test.aid[m]);
+      m++;
       assert(mod->definitions);
       node = (const idl_node_t*)mod->definitions;
     }

--- a/src/idl/tests/inheritance.c
+++ b/src/idl/tests/inheritance.c
@@ -77,8 +77,10 @@ CU_Test(idl_inheritance, empty_structs)
     while (s) {
       for (const idl_member_t *m = s->members; m; m = idl_next(m)) {
         for (const idl_declarator_t *d = m->declarators; d; d = idl_next(d)) {
-          if (ids)
-            CU_ASSERT_EQUAL(d->id.value, --ids);
+          if (ids) {
+            ids--;
+            CU_ASSERT_EQUAL(d->id.value, ids);
+          }
           fields++;
         }
       }


### PR DESCRIPTION
Split up index (de/in)crementation from the unittest check function as the check function uses assert, which possibly causes different behaviour between release and debug builds