### PR TITLE
idlc tests not behind cmake switch turn CUnit into hard requirement

### DIFF
--- a/src/tools/idlc/CMakeLists.txt
+++ b/src/tools/idlc/CMakeLists.txt
@@ -94,7 +94,9 @@ install(
 
 include("${CycloneDDS_SOURCE_DIR}/cmake/Modules/Generate.cmake")
 
-add_subdirectory(tests)
+if(BUILD_TESTING)
+  add_subdirectory(tests)
+endif()
 
 if(BUILD_IDLC_TESTING)
   add_subdirectory(xtests)


### PR DESCRIPTION
This snuck into the xtypes merge and immediately popped up in my environment without CUnit. Trivial fix.