### PR TITLE
Provide more control over socket buffer sizes

### DIFF
--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -67,7 +67,7 @@ The default value is: "lax".
 
 
 ### //CycloneDDS/Domain/Discovery
-Children: [DSGracePeriod](#cycloneddsdomaindiscoverydsgraceperiod), [DefaultMulticastAddress](#cycloneddsdomaindiscoverydefaultmulticastaddress), [ExternalDomainId](#cycloneddsdomaindiscoveryexternaldomainid), [MaxAutoParticipantIndex](#cycloneddsdomaindiscoverymaxautoparticipantindex), [ParticipantIndex](#cycloneddsdomaindiscoveryparticipantindex), [Peers](#cycloneddsdomaindiscoverypeers), [Ports](#cycloneddsdomaindiscoveryports), [SPDPInterval](#cycloneddsdomaindiscoveryspdpinterval), [SPDPMulticastAddress](#cycloneddsdomaindiscoveryspdpmulticastaddress), [Tag](#cycloneddsdomaindiscoverytag)
+Children: [DSGracePeriod](#cycloneddsdomaindiscoverydsgraceperiod), [DefaultMulticastAddress](#cycloneddsdomaindiscoverydefaultmulticastaddress), [EnableTopicDiscoveryEndpoints](#cycloneddsdomaindiscoveryenabletopicdiscoveryendpoints), [ExternalDomainId](#cycloneddsdomaindiscoveryexternaldomainid), [MaxAutoParticipantIndex](#cycloneddsdomaindiscoverymaxautoparticipantindex), [ParticipantIndex](#cycloneddsdomaindiscoveryparticipantindex), [Peers](#cycloneddsdomaindiscoverypeers), [Ports](#cycloneddsdomaindiscoveryports), [SPDPInterval](#cycloneddsdomaindiscoveryspdpinterval), [SPDPMulticastAddress](#cycloneddsdomaindiscoveryspdpmulticastaddress), [Tag](#cycloneddsdomaindiscoverytag)
 
 The Discovery element allows specifying various parameters related to the discovery of peers.
 
@@ -88,6 +88,14 @@ Text
 This element specifies the default multicast address for all traffic other than participant discovery packets. It defaults to Discovery/SPDPMulticastAddress.
 
 The default value is: "auto".
+
+
+#### //CycloneDDS/Domain/Discovery/EnableTopicDiscoveryEndpoints
+Boolean
+
+This element controls whether the built-in endpoints for topic discovery are created and used to exchange topic discovery information.
+
+The default value is: "false".
 
 
 #### //CycloneDDS/Domain/Discovery/ExternalDomainId
@@ -414,7 +422,7 @@ The default value is: "default".
 
 
 ### //CycloneDDS/Domain/Internal
-Children: [AccelerateRexmitBlockSize](#cycloneddsdomaininternalacceleraterexmitblocksize), [AckDelay](#cycloneddsdomaininternalackdelay), [AssumeMulticastCapable](#cycloneddsdomaininternalassumemulticastcapable), [AutoReschedNackDelay](#cycloneddsdomaininternalautoreschednackdelay), [BuiltinEndpointSet](#cycloneddsdomaininternalbuiltinendpointset), [BurstSize](#cycloneddsdomaininternalburstsize), [ControlTopic](#cycloneddsdomaininternalcontroltopic), [DDSI2DirectMaxThreads](#cycloneddsdomaininternalddsidirectmaxthreads), [DefragReliableMaxSamples](#cycloneddsdomaininternaldefragreliablemaxsamples), [DefragUnreliableMaxSamples](#cycloneddsdomaininternaldefragunreliablemaxsamples), [DeliveryQueueMaxSamples](#cycloneddsdomaininternaldeliveryqueuemaxsamples), [EnableExpensiveChecks](#cycloneddsdomaininternalenableexpensivechecks), [GenerateKeyhash](#cycloneddsdomaininternalgeneratekeyhash), [HeartbeatInterval](#cycloneddsdomaininternalheartbeatinterval), [LateAckMode](#cycloneddsdomaininternallateackmode), [LeaseDuration](#cycloneddsdomaininternalleaseduration), [LivelinessMonitoring](#cycloneddsdomaininternallivelinessmonitoring), [MaxParticipants](#cycloneddsdomaininternalmaxparticipants), [MaxQueuedRexmitBytes](#cycloneddsdomaininternalmaxqueuedrexmitbytes), [MaxQueuedRexmitMessages](#cycloneddsdomaininternalmaxqueuedrexmitmessages), [MaxSampleSize](#cycloneddsdomaininternalmaxsamplesize), [MeasureHbToAckLatency](#cycloneddsdomaininternalmeasurehbtoacklatency), [MinimumSocketReceiveBufferSize](#cycloneddsdomaininternalminimumsocketreceivebuffersize), [MinimumSocketSendBufferSize](#cycloneddsdomaininternalminimumsocketsendbuffersize), [MonitorPort](#cycloneddsdomaininternalmonitorport), [MultipleReceiveThreads](#cycloneddsdomaininternalmultiplereceivethreads), [NackDelay](#cycloneddsdomaininternalnackdelay), [PreEmptiveAckDelay](#cycloneddsdomaininternalpreemptiveackdelay), [PrimaryReorderMaxSamples](#cycloneddsdomaininternalprimaryreordermaxsamples), [PrioritizeRetransmit](#cycloneddsdomaininternalprioritizeretransmit), [RediscoveryBlacklistDuration](#cycloneddsdomaininternalrediscoveryblacklistduration), [RetransmitMerging](#cycloneddsdomaininternalretransmitmerging), [RetransmitMergingPeriod](#cycloneddsdomaininternalretransmitmergingperiod), [RetryOnRejectBestEffort](#cycloneddsdomaininternalretryonrejectbesteffort), [SPDPResponseMaxDelay](#cycloneddsdomaininternalspdpresponsemaxdelay), [ScheduleTimeRounding](#cycloneddsdomaininternalscheduletimerounding), [SecondaryReorderMaxSamples](#cycloneddsdomaininternalsecondaryreordermaxsamples), [SquashParticipants](#cycloneddsdomaininternalsquashparticipants), [SynchronousDeliveryLatencyBound](#cycloneddsdomaininternalsynchronousdeliverylatencybound), [SynchronousDeliveryPriorityThreshold](#cycloneddsdomaininternalsynchronousdeliveryprioritythreshold), [Test](#cycloneddsdomaininternaltest), [UnicastResponseToSPDPMessages](#cycloneddsdomaininternalunicastresponsetospdpmessages), [UseMulticastIfMreqn](#cycloneddsdomaininternalusemulticastifmreqn), [Watermarks](#cycloneddsdomaininternalwatermarks), [WriteBatch](#cycloneddsdomaininternalwritebatch), [WriterLingerDuration](#cycloneddsdomaininternalwriterlingerduration)
+Children: [AccelerateRexmitBlockSize](#cycloneddsdomaininternalacceleraterexmitblocksize), [AckDelay](#cycloneddsdomaininternalackdelay), [AssumeMulticastCapable](#cycloneddsdomaininternalassumemulticastcapable), [AutoReschedNackDelay](#cycloneddsdomaininternalautoreschednackdelay), [BuiltinEndpointSet](#cycloneddsdomaininternalbuiltinendpointset), [BurstSize](#cycloneddsdomaininternalburstsize), [ControlTopic](#cycloneddsdomaininternalcontroltopic), [DDSI2DirectMaxThreads](#cycloneddsdomaininternalddsidirectmaxthreads), [DefragReliableMaxSamples](#cycloneddsdomaininternaldefragreliablemaxsamples), [DefragUnreliableMaxSamples](#cycloneddsdomaininternaldefragunreliablemaxsamples), [DeliveryQueueMaxSamples](#cycloneddsdomaininternaldeliveryqueuemaxsamples), [EnableExpensiveChecks](#cycloneddsdomaininternalenableexpensivechecks), [GenerateKeyhash](#cycloneddsdomaininternalgeneratekeyhash), [HeartbeatInterval](#cycloneddsdomaininternalheartbeatinterval), [LateAckMode](#cycloneddsdomaininternallateackmode), [LeaseDuration](#cycloneddsdomaininternalleaseduration), [LivelinessMonitoring](#cycloneddsdomaininternallivelinessmonitoring), [MaxParticipants](#cycloneddsdomaininternalmaxparticipants), [MaxQueuedRexmitBytes](#cycloneddsdomaininternalmaxqueuedrexmitbytes), [MaxQueuedRexmitMessages](#cycloneddsdomaininternalmaxqueuedrexmitmessages), [MaxSampleSize](#cycloneddsdomaininternalmaxsamplesize), [MeasureHbToAckLatency](#cycloneddsdomaininternalmeasurehbtoacklatency), [MonitorPort](#cycloneddsdomaininternalmonitorport), [MultipleReceiveThreads](#cycloneddsdomaininternalmultiplereceivethreads), [NackDelay](#cycloneddsdomaininternalnackdelay), [PreEmptiveAckDelay](#cycloneddsdomaininternalpreemptiveackdelay), [PrimaryReorderMaxSamples](#cycloneddsdomaininternalprimaryreordermaxsamples), [PrioritizeRetransmit](#cycloneddsdomaininternalprioritizeretransmit), [RediscoveryBlacklistDuration](#cycloneddsdomaininternalrediscoveryblacklistduration), [RetransmitMerging](#cycloneddsdomaininternalretransmitmerging), [RetransmitMergingPeriod](#cycloneddsdomaininternalretransmitmergingperiod), [RetryOnRejectBestEffort](#cycloneddsdomaininternalretryonrejectbesteffort), [SPDPResponseMaxDelay](#cycloneddsdomaininternalspdpresponsemaxdelay), [ScheduleTimeRounding](#cycloneddsdomaininternalscheduletimerounding), [SecondaryReorderMaxSamples](#cycloneddsdomaininternalsecondaryreordermaxsamples), [SocketReceiveBufferSize](#cycloneddsdomaininternalsocketreceivebuffersize), [SocketSendBufferSize](#cycloneddsdomaininternalsocketsendbuffersize), [SquashParticipants](#cycloneddsdomaininternalsquashparticipants), [SynchronousDeliveryLatencyBound](#cycloneddsdomaininternalsynchronousdeliverylatencybound), [SynchronousDeliveryPriorityThreshold](#cycloneddsdomaininternalsynchronousdeliveryprioritythreshold), [Test](#cycloneddsdomaininternaltest), [UnicastResponseToSPDPMessages](#cycloneddsdomaininternalunicastresponsetospdpmessages), [UseMulticastIfMreqn](#cycloneddsdomaininternalusemulticastifmreqn), [Watermarks](#cycloneddsdomaininternalwatermarks), [WriteBatch](#cycloneddsdomaininternalwritebatch), [WriterLingerDuration](#cycloneddsdomaininternalwriterlingerduration)
 
 The Internal elements deal with a variety of settings that evolving and that are not necessarily fully supported. For the vast majority of the Internal settings, the functionality per-se is supported, but the right to change the way the options control the functionality is reserved. This includes renaming or moving options.
 
@@ -689,28 +697,6 @@ This element enables heartbeat-to-ack latency among Cyclone DDS services by prep
 The default value is: "false".
 
 
-#### //CycloneDDS/Domain/Internal/MinimumSocketReceiveBufferSize
-Number-with-unit
-
-This setting controls the minimum size of socket receive buffers. The operating system provides some size receive buffer upon creation of the socket, this option can be used to increase the size of the buffer beyond that initially provided by the operating system. If the buffer size cannot be increased to the specified size, an error is reported.
-
-The default setting is the word "default", which means Cyclone DDS will attempt to increase the buffer size to 1MB, but will silently accept a smaller buffer should that attempt fail.
-
-The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
-
-The default value is: "default".
-
-
-#### //CycloneDDS/Domain/Internal/MinimumSocketSendBufferSize
-Number-with-unit
-
-This setting controls the minimum size of socket send buffers. This setting can only increase the size of the send buffer, if the operating system by default creates a larger buffer, it is left unchanged.
-
-The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
-
-The default value is: "64 KiB".
-
-
 #### //CycloneDDS/Domain/Internal/MonitorPort
 Integer
 
@@ -854,6 +840,62 @@ Integer
 This element sets the maximum size in samples of a secondary re-order administration. The secondary re-order administration is per reader in need of historical data.
 
 The default value is: "128".
+
+
+#### //CycloneDDS/Domain/Internal/SocketReceiveBufferSize
+Attributes: [max](#cycloneddsdomaininternalsocketreceivebuffersizemax), [min](#cycloneddsdomaininternalsocketreceivebuffersizemin)
+
+The settings in this element control the size of the socket receive buffers. The operating system provides some size receive buffer upon creation of the socket, this option can be used to increase the size of the buffer beyond that initially provided by the operating system. If the buffer size cannot be increased to the requested minimum size, an error is reported.
+
+The default setting requests a buffer size of 1MiB but accepts whatever is available after that.
+
+
+#### //CycloneDDS/Domain/Internal/SocketReceiveBufferSize[@max]
+Number-with-unit
+
+This sets the size of the socket receive buffer to request, with the special value of "default" indicating that it should try to satisfy the minimum buffer size. If both are at "default", it will request 1MiB and accept anything. If the maximum is set to less than the minimum, it is ignored.
+
+The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
+
+The default value is: "default".
+
+
+#### //CycloneDDS/Domain/Internal/SocketReceiveBufferSize[@min]
+Number-with-unit
+
+This sets the minimum acceptable socket receive buffer size, with the special value "default" indicating that whatever is available is acceptable.
+
+The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
+
+The default value is: "default".
+
+
+#### //CycloneDDS/Domain/Internal/SocketSendBufferSize
+Attributes: [max](#cycloneddsdomaininternalsocketsendbuffersizemax), [min](#cycloneddsdomaininternalsocketsendbuffersizemin)
+
+The settings in this element control the size of the socket send buffers. The operating system provides some size send buffer upon creation of the socket, this option can be used to increase the size of the buffer beyond that initially provided by the operating system. If the buffer size cannot be increased to the requested minimum size, an error is reported.
+
+The default setting requires a buffer of at least 64KiB.
+
+
+#### //CycloneDDS/Domain/Internal/SocketSendBufferSize[@max]
+Number-with-unit
+
+This sets the size of the socket send buffer to request, with the special value of "default" indicating that it should try to satisfy the minimum buffer size. If both are at "default", it will use whatever is the system default. If the maximum is set to less than the minimum, it is ignored.
+
+The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
+
+The default value is: "default".
+
+
+#### //CycloneDDS/Domain/Internal/SocketSendBufferSize[@min]
+Number-with-unit
+
+This sets the minimum acceptable socket send buffer size, with the special value "default" indicating that whatever is available is acceptable.
+
+The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
+
+The default value is: "64 KiB".
 
 
 #### //CycloneDDS/Domain/Internal/SquashParticipants

--- a/etc/cyclonedds.rnc
+++ b/etc/cyclonedds.rnc
@@ -64,6 +64,12 @@ CycloneDDS configuration""" ] ]
           text
         }?
         & [ a:documentation [ xml:lang="en" """
+<p>This element controls whether the built-in endpoints for topic discovery are created and used to exchange topic discovery information.</p>
+<p>The default value is: "false".</p>""" ] ]
+        element EnableTopicDiscoveryEndpoints {
+          xsd:boolean
+        }?
+        & [ a:documentation [ xml:lang="en" """
 <p>An override for the domain id, to be used in discovery and for determining the port number mapping. This allows creating multiple domains in a single process while making them appear as a single domain on the network. The value "default" disables the override.</p>
 <p>The default value is: "default".</p>""" ] ]
         element ExternalDomainId {
@@ -490,21 +496,6 @@ CycloneDDS configuration""" ] ]
           xsd:boolean
         }?
         & [ a:documentation [ xml:lang="en" """
-<p>This setting controls the minimum size of socket receive buffers. The operating system provides some size receive buffer upon creation of the socket, this option can be used to increase the size of the buffer beyond that initially provided by the operating system. If the buffer size cannot be increased to the specified size, an error is reported.</p>
-<p>The default setting is the word "default", which means Cyclone DDS will attempt to increase the buffer size to 1MB, but will silently accept a smaller buffer should that attempt fail.</p>
-<p>The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2<sup>10</sup> bytes), MB & MiB (2<sup>20</sup> bytes), GB & GiB (2<sup>30</sup> bytes).</p>
-<p>The default value is: "default".</p>""" ] ]
-        element MinimumSocketReceiveBufferSize {
-          memsize
-        }?
-        & [ a:documentation [ xml:lang="en" """
-<p>This setting controls the minimum size of socket send buffers. This setting can only increase the size of the send buffer, if the operating system by default creates a larger buffer, it is left unchanged.</p>
-<p>The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2<sup>10</sup> bytes), MB & MiB (2<sup>20</sup> bytes), GB & GiB (2<sup>30</sup> bytes).</p>
-<p>The default value is: "64 KiB".</p>""" ] ]
-        element MinimumSocketSendBufferSize {
-          memsize
-        }?
-        & [ a:documentation [ xml:lang="en" """
 <p>This element allows configuring a service that dumps a text description of part the internal state to TCP clients. By default (-1), this is disabled; specifying 0 means a kernel-allocated port is used; a positive number is used as the TCP port number.</p>
 <p>The default value is: "-1".</p>""" ] ]
         element MonitorPort {
@@ -604,6 +595,44 @@ CycloneDDS configuration""" ] ]
 <p>The default value is: "128".</p>""" ] ]
         element SecondaryReorderMaxSamples {
           xsd:integer
+        }?
+        & [ a:documentation [ xml:lang="en" """
+<p>The settings in this element control the size of the socket receive buffers. The operating system provides some size receive buffer upon creation of the socket, this option can be used to increase the size of the buffer beyond that initially provided by the operating system. If the buffer size cannot be increased to the requested minimum size, an error is reported.</p>
+<p>The default setting requests a buffer size of 1MiB but accepts whatever is available after that.</p>""" ] ]
+        element SocketReceiveBufferSize {
+          [ a:documentation [ xml:lang="en" """
+<p>This sets the size of the socket receive buffer to request, with the special value of "default" indicating that it should try to satisfy the minimum buffer size. If both are at "default", it will request 1MiB and accept anything. If the maximum is set to less than the minimum, it is ignored.</p>
+<p>The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2<sup>10</sup> bytes), MB & MiB (2<sup>20</sup> bytes), GB & GiB (2<sup>30</sup> bytes).</p>
+<p>The default value is: "default".</p>""" ] ]
+          attribute max {
+            memsize
+          }?
+          & [ a:documentation [ xml:lang="en" """
+<p>This sets the minimum acceptable socket receive buffer size, with the special value "default" indicating that whatever is available is acceptable.</p>
+<p>The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2<sup>10</sup> bytes), MB & MiB (2<sup>20</sup> bytes), GB & GiB (2<sup>30</sup> bytes).</p>
+<p>The default value is: "default".</p>""" ] ]
+          attribute min {
+            memsize
+          }?
+        }?
+        & [ a:documentation [ xml:lang="en" """
+<p>The settings in this element control the size of the socket send buffers. The operating system provides some size send buffer upon creation of the socket, this option can be used to increase the size of the buffer beyond that initially provided by the operating system. If the buffer size cannot be increased to the requested minimum size, an error is reported.</p>
+<p>The default setting requires a buffer of at least 64KiB.</p>""" ] ]
+        element SocketSendBufferSize {
+          [ a:documentation [ xml:lang="en" """
+<p>This sets the size of the socket send buffer to request, with the special value of "default" indicating that it should try to satisfy the minimum buffer size. If both are at "default", it will use whatever is the system default. If the maximum is set to less than the minimum, it is ignored.</p>
+<p>The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2<sup>10</sup> bytes), MB & MiB (2<sup>20</sup> bytes), GB & GiB (2<sup>30</sup> bytes).</p>
+<p>The default value is: "default".</p>""" ] ]
+          attribute max {
+            memsize
+          }?
+          & [ a:documentation [ xml:lang="en" """
+<p>This sets the minimum acceptable socket send buffer size, with the special value "default" indicating that whatever is available is acceptable.</p>
+<p>The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2<sup>10</sup> bytes), MB & MiB (2<sup>20</sup> bytes), GB & GiB (2<sup>30</sup> bytes).</p>
+<p>The default value is: "64 KiB".</p>""" ] ]
+          attribute min {
+            memsize
+          }?
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element controls whether Cyclone DDS advertises all the domain participants it serves in DDSI (when set to <i>false</i>), or rather only one domain participant (the one corresponding to the Cyclone DDS process; when set to <i>true</i>). In the latter case Cyclone DDS becomes the virtual owner of all readers and writers of all domain participants, dramatically reducing discovery traffic (a similar effect can be obtained by setting Internal/BuiltinEndpointSet to "minimal" but with less loss of information).</p>

--- a/etc/cyclonedds.xsd
+++ b/etc/cyclonedds.xsd
@@ -112,6 +112,7 @@ CycloneDDS configuration</xs:documentation>
       <xs:all>
         <xs:element minOccurs="0" ref="config:DSGracePeriod"/>
         <xs:element minOccurs="0" ref="config:DefaultMulticastAddress"/>
+        <xs:element minOccurs="0" ref="config:EnableTopicDiscoveryEndpoints"/>
         <xs:element minOccurs="0" ref="config:ExternalDomainId"/>
         <xs:element minOccurs="0" ref="config:MaxAutoParticipantIndex"/>
         <xs:element minOccurs="0" ref="config:ParticipantIndex"/>
@@ -136,6 +137,13 @@ CycloneDDS configuration</xs:documentation>
       <xs:documentation>
 &lt;p&gt;This element specifies the default multicast address for all traffic other than participant discovery packets. It defaults to Discovery/SPDPMulticastAddress.&lt;/p&gt;
 &lt;p&gt;The default value is: "auto".&lt;/p&gt;</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="EnableTopicDiscoveryEndpoints" type="xs:boolean">
+    <xs:annotation>
+      <xs:documentation>
+&lt;p&gt;This element controls whether the built-in endpoints for topic discovery are created and used to exchange topic discovery information.&lt;/p&gt;
+&lt;p&gt;The default value is: "false".&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="ExternalDomainId" type="xs:string">
@@ -491,8 +499,6 @@ CycloneDDS configuration</xs:documentation>
         <xs:element minOccurs="0" ref="config:MaxQueuedRexmitMessages"/>
         <xs:element minOccurs="0" ref="config:MaxSampleSize"/>
         <xs:element minOccurs="0" ref="config:MeasureHbToAckLatency"/>
-        <xs:element minOccurs="0" ref="config:MinimumSocketReceiveBufferSize"/>
-        <xs:element minOccurs="0" ref="config:MinimumSocketSendBufferSize"/>
         <xs:element minOccurs="0" ref="config:MonitorPort"/>
         <xs:element minOccurs="0" ref="config:MultipleReceiveThreads"/>
         <xs:element minOccurs="0" ref="config:NackDelay"/>
@@ -506,6 +512,8 @@ CycloneDDS configuration</xs:documentation>
         <xs:element minOccurs="0" ref="config:SPDPResponseMaxDelay"/>
         <xs:element minOccurs="0" ref="config:ScheduleTimeRounding"/>
         <xs:element minOccurs="0" ref="config:SecondaryReorderMaxSamples"/>
+        <xs:element minOccurs="0" ref="config:SocketReceiveBufferSize"/>
+        <xs:element minOccurs="0" ref="config:SocketSendBufferSize"/>
         <xs:element minOccurs="0" ref="config:SquashParticipants"/>
         <xs:element minOccurs="0" ref="config:SynchronousDeliveryLatencyBound"/>
         <xs:element minOccurs="0" ref="config:SynchronousDeliveryPriorityThreshold"/>
@@ -771,23 +779,6 @@ CycloneDDS configuration</xs:documentation>
 &lt;p&gt;The default value is: "false".&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="MinimumSocketReceiveBufferSize" type="config:memsize">
-    <xs:annotation>
-      <xs:documentation>
-&lt;p&gt;This setting controls the minimum size of socket receive buffers. The operating system provides some size receive buffer upon creation of the socket, this option can be used to increase the size of the buffer beyond that initially provided by the operating system. If the buffer size cannot be increased to the specified size, an error is reported.&lt;/p&gt;
-&lt;p&gt;The default setting is the word "default", which means Cyclone DDS will attempt to increase the buffer size to 1MB, but will silently accept a smaller buffer should that attempt fail.&lt;/p&gt;
-&lt;p&gt;The unit must be specified explicitly. Recognised units: B (bytes), kB &amp; KiB (2&lt;sup&gt;10&lt;/sup&gt; bytes), MB &amp; MiB (2&lt;sup&gt;20&lt;/sup&gt; bytes), GB &amp; GiB (2&lt;sup&gt;30&lt;/sup&gt; bytes).&lt;/p&gt;
-&lt;p&gt;The default value is: "default".&lt;/p&gt;</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="MinimumSocketSendBufferSize" type="config:memsize">
-    <xs:annotation>
-      <xs:documentation>
-&lt;p&gt;This setting controls the minimum size of socket send buffers. This setting can only increase the size of the send buffer, if the operating system by default creates a larger buffer, it is left unchanged.&lt;/p&gt;
-&lt;p&gt;The unit must be specified explicitly. Recognised units: B (bytes), kB &amp; KiB (2&lt;sup&gt;10&lt;/sup&gt; bytes), MB &amp; MiB (2&lt;sup&gt;20&lt;/sup&gt; bytes), GB &amp; GiB (2&lt;sup&gt;30&lt;/sup&gt; bytes).&lt;/p&gt;
-&lt;p&gt;The default value is: "64 KiB".&lt;/p&gt;</xs:documentation>
-    </xs:annotation>
-  </xs:element>
   <xs:element name="MonitorPort" type="xs:integer">
     <xs:annotation>
       <xs:documentation>
@@ -929,6 +920,56 @@ CycloneDDS configuration</xs:documentation>
 &lt;p&gt;This element sets the maximum size in samples of a secondary re-order administration. The secondary re-order administration is per reader in need of historical data.&lt;/p&gt;
 &lt;p&gt;The default value is: "128".&lt;/p&gt;</xs:documentation>
     </xs:annotation>
+  </xs:element>
+  <xs:element name="SocketReceiveBufferSize">
+    <xs:annotation>
+      <xs:documentation>
+&lt;p&gt;The settings in this element control the size of the socket receive buffers. The operating system provides some size receive buffer upon creation of the socket, this option can be used to increase the size of the buffer beyond that initially provided by the operating system. If the buffer size cannot be increased to the requested minimum size, an error is reported.&lt;/p&gt;
+&lt;p&gt;The default setting requests a buffer size of 1MiB but accepts whatever is available after that.&lt;/p&gt;</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="max" type="config:memsize">
+        <xs:annotation>
+          <xs:documentation>
+&lt;p&gt;This sets the size of the socket receive buffer to request, with the special value of "default" indicating that it should try to satisfy the minimum buffer size. If both are at "default", it will request 1MiB and accept anything. If the maximum is set to less than the minimum, it is ignored.&lt;/p&gt;
+&lt;p&gt;The unit must be specified explicitly. Recognised units: B (bytes), kB &amp; KiB (2&lt;sup&gt;10&lt;/sup&gt; bytes), MB &amp; MiB (2&lt;sup&gt;20&lt;/sup&gt; bytes), GB &amp; GiB (2&lt;sup&gt;30&lt;/sup&gt; bytes).&lt;/p&gt;
+&lt;p&gt;The default value is: "default".&lt;/p&gt;</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="min" type="config:memsize">
+        <xs:annotation>
+          <xs:documentation>
+&lt;p&gt;This sets the minimum acceptable socket receive buffer size, with the special value "default" indicating that whatever is available is acceptable.&lt;/p&gt;
+&lt;p&gt;The unit must be specified explicitly. Recognised units: B (bytes), kB &amp; KiB (2&lt;sup&gt;10&lt;/sup&gt; bytes), MB &amp; MiB (2&lt;sup&gt;20&lt;/sup&gt; bytes), GB &amp; GiB (2&lt;sup&gt;30&lt;/sup&gt; bytes).&lt;/p&gt;
+&lt;p&gt;The default value is: "default".&lt;/p&gt;</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="SocketSendBufferSize">
+    <xs:annotation>
+      <xs:documentation>
+&lt;p&gt;The settings in this element control the size of the socket send buffers. The operating system provides some size send buffer upon creation of the socket, this option can be used to increase the size of the buffer beyond that initially provided by the operating system. If the buffer size cannot be increased to the requested minimum size, an error is reported.&lt;/p&gt;
+&lt;p&gt;The default setting requires a buffer of at least 64KiB.&lt;/p&gt;</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="max" type="config:memsize">
+        <xs:annotation>
+          <xs:documentation>
+&lt;p&gt;This sets the size of the socket send buffer to request, with the special value of "default" indicating that it should try to satisfy the minimum buffer size. If both are at "default", it will use whatever is the system default. If the maximum is set to less than the minimum, it is ignored.&lt;/p&gt;
+&lt;p&gt;The unit must be specified explicitly. Recognised units: B (bytes), kB &amp; KiB (2&lt;sup&gt;10&lt;/sup&gt; bytes), MB &amp; MiB (2&lt;sup&gt;20&lt;/sup&gt; bytes), GB &amp; GiB (2&lt;sup&gt;30&lt;/sup&gt; bytes).&lt;/p&gt;
+&lt;p&gt;The default value is: "default".&lt;/p&gt;</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="min" type="config:memsize">
+        <xs:annotation>
+          <xs:documentation>
+&lt;p&gt;This sets the minimum acceptable socket send buffer size, with the special value "default" indicating that whatever is available is acceptable.&lt;/p&gt;
+&lt;p&gt;The unit must be specified explicitly. Recognised units: B (bytes), kB &amp; KiB (2&lt;sup&gt;10&lt;/sup&gt; bytes), MB &amp; MiB (2&lt;sup&gt;20&lt;/sup&gt; bytes), GB &amp; GiB (2&lt;sup&gt;30&lt;/sup&gt; bytes).&lt;/p&gt;
+&lt;p&gt;The default value is: "64 KiB".&lt;/p&gt;</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
   </xs:element>
   <xs:element name="SquashParticipants" type="xs:boolean">
     <xs:annotation>

--- a/src/core/ddsi/include/dds/ddsi/ddsi_cfgelems.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_cfgelems.h
@@ -1011,6 +1011,50 @@ static struct cfgelem multiple_recv_threads_attrs[] = {
   END_MARKER
 };
 
+static struct cfgelem sock_rcvbuf_size_attrs[] = {
+  STRING("min", NULL, 1, "default",
+    MEMBER(socket_rcvbuf_size.min),
+    FUNCTIONS(0, uf_maybe_memsize, 0, pf_maybe_memsize),
+    DESCRIPTION(
+      "<p>This sets the minimum acceptable socket receive buffer size, "
+      "with the special value \"default\" indicating that whatever is "
+      "available is acceptable.</p>"),
+    UNIT("memsize")),
+  STRING("max", NULL, 1, "default",
+    MEMBER(socket_rcvbuf_size.max),
+    FUNCTIONS(0, uf_maybe_memsize, 0, pf_maybe_memsize),
+    DESCRIPTION(
+      "<p>This sets the size of the socket receive buffer to request, "
+      "with the special value of \"default\" indicating that it should "
+      "try to satisfy the minimum buffer size. If both are at \"default\", "
+      "it will request 1MiB and accept anything. If the maximum is set "
+      "to less than the minimum, it is ignored.</p>"),
+    UNIT("memsize")),
+  END_MARKER
+};
+
+static struct cfgelem sock_sndbuf_size_attrs[] = {
+  STRING("min", NULL, 1, "64 KiB",
+    MEMBER(socket_sndbuf_size.min),
+    FUNCTIONS(0, uf_maybe_memsize, 0, pf_maybe_memsize),
+    DESCRIPTION(
+      "<p>This sets the minimum acceptable socket send buffer size, "
+      "with the special value \"default\" indicating that whatever is "
+      "available is acceptable.</p>"),
+    UNIT("memsize")),
+  STRING("max", NULL, 1, "default",
+    MEMBER(socket_sndbuf_size.max),
+    FUNCTIONS(0, uf_maybe_memsize, 0, pf_maybe_memsize),
+    DESCRIPTION(
+      "<p>This sets the size of the socket send buffer to request, "
+      "with the special value of \"default\" indicating that it should "
+      "try to satisfy the minimum buffer size. If both are at \"default\", "
+      "it will use whatever is the system default. If the maximum is set "
+      "to less than the minimum, it is ignored.</p>"),
+    UNIT("memsize")),
+  END_MARKER
+};
+
 static struct cfgelem internal_cfgelems[] = {
   MOVED("MaxMessageSize", "CycloneDDS/Domain/General/MaxMessageSize"),
   MOVED("FragmentSize", "CycloneDDS/Domain/General/FragmentSize"),
@@ -1187,29 +1231,31 @@ static struct cfgelem internal_cfgelems[] = {
       "deletion of a reliable writer with unacknowledged data in its history "
       "will be postponed to provide proper reliable transmission.<p>"),
     UNIT("duration")),
-  STRING("MinimumSocketReceiveBufferSize", NULL, 1, "default",
-    MEMBER(socket_min_rcvbuf_size),
-    FUNCTIONS(0, uf_maybe_memsize, 0, pf_maybe_memsize),
+  MOVED("MinimumSocketReceiveBufferSize", "CycloneDDS/Domain/Internal/SocketReceiveBufferSize[@min]"),
+  MOVED("MinimumSocketSendBufferSize", "CycloneDDS/Domain/Internal/SocketSendBufferSize[@min]"),
+  GROUP("SocketReceiveBufferSize", NULL, sock_rcvbuf_size_attrs, 1,
+    NOMEMBER,
+    NOFUNCTIONS,
     DESCRIPTION(
-      "<p>This setting controls the minimum size of socket receive buffers. "
+      "<p>The settings in this element control the size of the socket receive buffers. "
       "The operating system provides some size receive buffer upon creation "
       "of the socket, this option can be used to increase the size of the "
       "buffer beyond that initially provided by the operating system. If the "
-      "buffer size cannot be increased to the specified size, an error is "
+      "buffer size cannot be increased to the requested minimum size, an error is "
       "reported.</p>\n"
-      "<p>The default setting is the word \"default\", which means Cyclone DDS "
-      "will attempt to increase the buffer size to 1MB, but will silently "
-      "accept a smaller buffer should that attempt fail.</p>"),
-    UNIT("memsize")),
-  STRING("MinimumSocketSendBufferSize", NULL, 1, "64 KiB",
-    MEMBER(socket_min_sndbuf_size),
-    FUNCTIONS(0, uf_memsize, 0, pf_memsize),
+      "<p>The default setting requests a buffer size of 1MiB but accepts whatever "
+      "is available after that.</p>")),
+  GROUP("SocketSendBufferSize", NULL, sock_sndbuf_size_attrs, 1,
+    NOMEMBER,
+    NOFUNCTIONS,
     DESCRIPTION(
-      "<p>This setting controls the minimum size of socket send buffers. "
-      "This setting can only increase the size of the send buffer, if the "
-      "operating system by default creates a larger buffer, it is left "
-      "unchanged.</p>"),
-    UNIT("memsize")),
+      "<p>The settings in this element control the size of the socket send buffers. "
+      "The operating system provides some size send buffer upon creation "
+      "of the socket, this option can be used to increase the size of the "
+      "buffer beyond that initially provided by the operating system. If the "
+      "buffer size cannot be increased to the requested minimum size, an error is "
+      "reported.</p>\n"
+      "<p>The default setting requires a buffer of at least 64KiB.</p>")),
   STRING("NackDelay", NULL, 1, "100 ms",
     MEMBER(nack_delay),
     FUNCTIONS(0, uf_duration_ms_1hr, 0, pf_duration),

--- a/src/core/ddsi/include/dds/ddsi/ddsi_config.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_config.h
@@ -230,6 +230,10 @@ struct ddsi_config_ssl_min_version {
 };
 #endif
 
+struct ddsi_config_socket_buf_size {
+  struct ddsi_config_maybe_uint32 min, max;
+};
+
 /* Expensive checks (compiled in when NDEBUG not defined, enabled only if flag set in xchecks) */
 #define DDSI_XCHECK_WHC 1u
 #define DDSI_XCHECK_RHC 2u
@@ -358,8 +362,8 @@ struct ddsi_config
   uint32_t max_participants;
   int64_t writer_linger_duration;
   int multicast_ttl;
-  struct ddsi_config_maybe_uint32 socket_min_rcvbuf_size;
-  uint32_t socket_min_sndbuf_size;
+  struct ddsi_config_socket_buf_size socket_rcvbuf_size;
+  struct ddsi_config_socket_buf_size socket_sndbuf_size;
   int64_t ack_delay;
   int64_t nack_delay;
   int64_t preemptive_ack_delay;

--- a/src/core/ddsi/src/ddsi_udp.c
+++ b/src/core/ddsi/src/ddsi_udp.c
@@ -266,112 +266,83 @@ static dds_return_t set_dont_route (struct ddsi_domaingv const * const gv, ddsrt
   return rc;
 }
 
-static dds_return_t set_rcvbuf (struct ddsi_domaingv const * const gv, ddsrt_socket_t sock, const struct ddsi_config_maybe_uint32 *min_size)
+static dds_return_t set_socket_buffer (struct ddsi_domaingv const * const gv, ddsrt_socket_t sock, int32_t socket_option, const char *socket_option_name, const char *name, const struct ddsi_config_socket_buf_size *config, uint32_t default_min_size)
 {
-  uint32_t size;
-  socklen_t optlen = (socklen_t) sizeof (size);
-  uint32_t socket_min_rcvbuf_size;
+  // if (min, max)=   and   initbuf=   then  request=  and  result=
+  //    (def, def)          < defmin         defmin         whatever it is
+  //    (def, N)            anything         N              whatever it is
+  //    (M,   def)          < M              M              error if < M
+  //    (M,   N<M)          < M              M              error if < M
+  //    (M,  N>=M)          anything         N              error if < M
+  // defmin = 1MB for receive buffer, 0B for send buffer
+  const bool always_set_size = // whether to call setsockopt unconditionally
+    ((config->min.isdefault && !config->max.isdefault) ||
+     (!config->min.isdefault && !config->max.isdefault && config->max.value >= config->min.value));
+  const uint32_t socket_min_buf_size = // error if it ends up below this
+    !config->min.isdefault ? config->min.value : 0;
+  const uint32_t socket_req_buf_size = // size to request
+    (!config->max.isdefault && config->max.value > socket_min_buf_size) ? config->max.value
+    : !config->min.isdefault ? config->min.value
+    : default_min_size;
+
+  uint32_t actsize;
+  socklen_t optlen = (socklen_t) sizeof (actsize);
   dds_return_t rc;
 
-  socket_min_rcvbuf_size = min_size->isdefault ? 1048576 : min_size->value;
-  rc = ddsrt_getsockopt (sock, SOL_SOCKET, SO_RCVBUF, &size, &optlen);
+  rc = ddsrt_getsockopt (sock, SOL_SOCKET, socket_option, &actsize, &optlen);
   if (rc == DDS_RETCODE_BAD_PARAMETER)
   {
     /* not all stacks support getting/setting RCVBUF */
-    GVLOG (DDS_LC_CONFIG, "cannot retrieve socket receive buffer size\n");
+    GVLOG (DDS_LC_CONFIG, "cannot retrieve socket %s buffer size\n", name);
     return DDS_RETCODE_OK;
   }
   else if (rc != DDS_RETCODE_OK)
   {
-    GVERROR ("ddsi_udp_create_conn: get SO_RCVBUF failed: %s\n", dds_strretcode (rc));
+    GVERROR ("ddsi_udp_create_conn: get %s failed: %s\n", socket_option_name, dds_strretcode (rc));
     return rc;
   }
 
-  if (size < socket_min_rcvbuf_size)
+  if (always_set_size || actsize < socket_req_buf_size)
   {
-    /* make sure the receive buffersize is at least the minimum required */
-    size = socket_min_rcvbuf_size;
-    (void) ddsrt_setsockopt (sock, SOL_SOCKET, SO_RCVBUF, &size, sizeof (size));
+    (void) ddsrt_setsockopt (sock, SOL_SOCKET, socket_option, &socket_req_buf_size, sizeof (actsize));
 
     /* We don't check the return code from setsockopt, because some O/Ss tend
        to silently cap the buffer size.  The only way to make sure is to read
        the option value back and check it is now set correctly. */
-    if ((rc = ddsrt_getsockopt (sock, SOL_SOCKET, SO_RCVBUF, &size, &optlen)) != DDS_RETCODE_OK)
+    if ((rc = ddsrt_getsockopt (sock, SOL_SOCKET, socket_option, &actsize, &optlen)) != DDS_RETCODE_OK)
     {
-      GVERROR ("ddsi_udp_create_conn: get SO_RCVBUF failed: %s\n", dds_strretcode (rc));
+      GVERROR ("ddsi_udp_create_conn: get %s failed: %s\n", socket_option_name, dds_strretcode (rc));
       return rc;
     }
 
-    if (size >= socket_min_rcvbuf_size)
-      GVLOG (DDS_LC_CONFIG, "socket receive buffer size set to %"PRIu32" bytes\n", size);
-    else if (min_size->isdefault)
-    GVLOG (DDS_LC_CONFIG,
-           "failed to increase socket receive buffer size to %"PRIu32" bytes, continuing with %"PRIu32" bytes\n",
-           socket_min_rcvbuf_size, size);
+    if (actsize >= socket_req_buf_size)
+      GVLOG (DDS_LC_CONFIG, "socket %s buffer size set to %"PRIu32" bytes\n", name, actsize);
+    else if (actsize >= socket_min_buf_size)
+      GVLOG (DDS_LC_CONFIG,
+             "failed to increase socket %s buffer size to %"PRIu32" bytes, continuing with %"PRIu32" bytes\n",
+             name, socket_req_buf_size, actsize);
     else
     {
       /* If the configuration states it must be >= X, then error out if the
          kernel doesn't give us at least X */
       GVLOG (DDS_LC_CONFIG | DDS_LC_ERROR,
-             "failed to increase socket receive buffer size to %"PRIu32" bytes, maximum is %"PRIu32" bytes\n",
-             socket_min_rcvbuf_size, size);
+             "failed to increase socket %s buffer size to at least %"PRIu32" bytes, current is %"PRIu32" bytes\n",
+             name, socket_min_buf_size, actsize);
       rc = DDS_RETCODE_NOT_ENOUGH_SPACE;
     }
   }
 
-  return (rc < 0) ? rc : (size > (uint32_t) INT32_MAX) ? INT32_MAX : (int32_t) size;
+  return (rc < 0) ? rc : (actsize > (uint32_t) INT32_MAX) ? INT32_MAX : (int32_t) actsize;
 }
 
-static dds_return_t set_sndbuf (struct ddsi_domaingv const * const gv, ddsrt_socket_t sock, uint32_t min_size)
+static dds_return_t set_rcvbuf (struct ddsi_domaingv const * const gv, ddsrt_socket_t sock, const struct ddsi_config_socket_buf_size *config)
 {
-  uint32_t size;
-  socklen_t optlen = (socklen_t) sizeof(size);
-  dds_return_t rc;
+  return set_socket_buffer (gv, sock, SO_RCVBUF, "SO_RCVBUF", "receive", config, 1048576);
+}
 
-  rc = ddsrt_getsockopt (sock, SOL_SOCKET, SO_SNDBUF, &size, &optlen);
-  if (rc == DDS_RETCODE_BAD_PARAMETER)
-  {
-    /* not all stacks support getting/setting SNDBUF */
-    GVLOG (DDS_LC_CONFIG, "cannot retrieve socket send buffer size\n");
-    return DDS_RETCODE_OK;
-  }
-  else if (rc != DDS_RETCODE_OK)
-  {
-    GVERROR ("ddsi_udp_create_conn: get SO_SNDBUF failed: %s\n", dds_strretcode (rc));
-    return rc;
-  }
-
-  if (size < min_size)
-  {
-    /* make sure the send buffersize is at least the minimum required */
-    size = min_size;
-    (void) ddsrt_setsockopt (sock, SOL_SOCKET, SO_SNDBUF, &size, sizeof (size));
-
-    /* We don't check the return code from setsockopt, because some O/Ss tend
-       to silently cap the buffer size.  The only way to make sure is to read
-       the option value back and check it is now set correctly. */
-    if ((rc = ddsrt_getsockopt (sock, SOL_SOCKET, SO_SNDBUF, &size, &optlen)) != DDS_RETCODE_OK)
-    {
-      GVERROR ("ddsi_udp_create_conn: get SO_SNDBUF failed: %s\n", dds_strretcode (rc));
-      return rc;
-    }
-
-    if (size >= min_size)
-    {
-      GVLOG (DDS_LC_CONFIG, "socket send buffer size set to %"PRIu32" bytes\n", size);
-    }
-    else
-    {
-      /* If the configuration states it must be >= X, then error out if the
-         kernel doesn't give us at least X */
-      GVLOG (DDS_LC_CONFIG | DDS_LC_ERROR,
-             "failed to increase socket send buffer size to %"PRIu32" bytes, maximum is %"PRIu32" bytes\n",
-             min_size, size);
-      return DDS_RETCODE_NOT_ENOUGH_SPACE;
-    }
-  }
-
-  return DDS_RETCODE_OK;
+static dds_return_t set_sndbuf (struct ddsi_domaingv const * const gv, ddsrt_socket_t sock, const struct ddsi_config_socket_buf_size *config)
+{
+  return set_socket_buffer (gv, sock, SO_SNDBUF, "SO_SNDBUF", "send", config, 65536);
 }
 
 static dds_return_t set_mc_options_transmit_ipv6 (struct ddsi_domaingv const * const gv, struct nn_interface const * const intf, ddsrt_socket_t sock)
@@ -519,7 +490,7 @@ static dds_return_t ddsi_udp_create_conn (ddsi_tran_conn_t *conn_out, ddsi_tran_
     }
   }
 
-  if ((rc = set_rcvbuf (gv, sock, &gv->config.socket_min_rcvbuf_size)) < 0)
+  if ((rc = set_rcvbuf (gv, sock, &gv->config.socket_rcvbuf_size)) < 0)
     goto fail_w_socket;
   if (rc > 0) {
     // set fact->receive_buf_size to the smallest observed value
@@ -531,7 +502,7 @@ static dds_return_t ddsi_udp_create_conn (ddsi_tran_conn_t *conn_out, ddsi_tran_
     } while (!ddsrt_atomic_cas32 (&fact->receive_buf_size, old, (uint32_t) rc));
   }
 
-  if (set_sndbuf (gv, sock, gv->config.socket_min_sndbuf_size) != DDS_RETCODE_OK)
+  if (set_sndbuf (gv, sock, &gv->config.socket_sndbuf_size) < 0)
     goto fail_w_socket;
   if (gv->config.dontRoute && set_dont_route (gv, sock, ipv6) != DDS_RETCODE_OK)
     goto fail_w_socket;


### PR DESCRIPTION
It used to only be possible to specify a minimum buffer size, with an inability to get that minimum size a hard error. In particular, it was impossible to configure the size to request if one was willing to accept anything, so trying to get 4MB while accepting whatever is given was not a possibility.

This commit moves the MinimumSocket{Send,Receive}BufferSize elements to the "min" attribute of Socket{Send,Receive}BufferSize and adds a "max" attribute. The default settings match the original behaviour: default/default for the receive buffer size and 64kB/default. But it is now also possible to specify min=default and max=4MB to request a 4MB buffer but continue with whatever is the result after the setsockopt call.

With thanks to @rotu for his original efforts in #489. It has taken a while (😳😳😳) but it at least it hasn't been forgotten completely.