### PR TITLE
Set multicast socket options only when needed

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/ddsi_tran.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_tran.h
@@ -214,9 +214,10 @@ struct ddsi_tran_factory
 };
 
 enum ddsi_tran_qos_purpose {
-  DDSI_TRAN_QOS_XMIT,
-  DDSI_TRAN_QOS_RECV_UC,
-  DDSI_TRAN_QOS_RECV_MC
+  DDSI_TRAN_QOS_XMIT_UC, // will send unicast only
+  DDSI_TRAN_QOS_XMIT_MC, // may send unicast or multicast
+  DDSI_TRAN_QOS_RECV_UC, // will be used for receiving unicast
+  DDSI_TRAN_QOS_RECV_MC  // will be used for receiving multicast
 };
 
 struct ddsi_tran_qos
@@ -244,7 +245,7 @@ DDS_INLINE_EXPORT inline uint32_t ddsi_receive_buffer_size (const struct ddsi_tr
 }
 DDS_INLINE_EXPORT inline dds_return_t ddsi_factory_create_conn (ddsi_tran_conn_t *conn, ddsi_tran_factory_t factory, uint32_t port, const struct ddsi_tran_qos *qos) {
   *conn = NULL;
-  if ((qos->m_interface != NULL) != (qos->m_purpose == DDSI_TRAN_QOS_XMIT))
+  if ((qos->m_interface != NULL) != (qos->m_purpose == DDSI_TRAN_QOS_XMIT_UC || qos->m_purpose == DDSI_TRAN_QOS_XMIT_MC))
     return DDS_RETCODE_BAD_PARAMETER;
   if (!ddsi_is_valid_port (factory, port))
     return DDS_RETCODE_BAD_PARAMETER;

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -1648,7 +1648,11 @@ int rtps_init (struct ddsi_domaingv *gv)
     dds_return_t rc;
     for (int i = 0; i < gv->n_interfaces; i++)
     {
-      const ddsi_tran_qos_t qos = { .m_purpose = DDSI_TRAN_QOS_XMIT, .m_diffserv = 0, .m_interface = &gv->interfaces[i] };
+      const ddsi_tran_qos_t qos = {
+        .m_purpose = (gv->config.allowMulticast ? DDSI_TRAN_QOS_XMIT_MC : DDSI_TRAN_QOS_XMIT_UC),
+        .m_diffserv = 0,
+        .m_interface = &gv->interfaces[i]
+      };
       // FIXME: looking up the factory here is a hack to support iceoryx in addition to (e.g.) UDP
       ddsi_tran_factory_t fact = ddsi_factory_find_supported_kind (gv, gv->interfaces[i].loc.kind);
       rc = ddsi_factory_create_conn (&gv->xmit_conns[i], fact, 0, &qos);


### PR DESCRIPTION
This commit makes the setting of multicast transmit options conditional on whether the socket may be used for sending multicast packets.

It doesn't seem to make a difference with any of the usual network stacks, but it does seem like LwIP configured without multicast support would require it.