### PR TITLE
Generate pkg-config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,6 +307,18 @@ install(
   DESTINATION "${CMAKE_INSTALL_CMAKEDIR}"
   COMPONENT dev)
 
+# Generate Pkg-Config file
+configure_file(
+  "PkgConfig.pc.in"
+  "${PROJECT_NAME}.pc"
+  @ONLY
+)
+install(
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+  COMPONENT dev
+)
+
 add_subdirectory(src)
 if(BUILD_EXAMPLES)
   add_subdirectory(examples)

--- a/PkgConfig.pc.in
+++ b/PkgConfig.pc.in
@@ -1,0 +1,9 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+
+Name: @PROJECT_NAME@
+Description: Eclipse Cyclone DDS library
+Version: @PROJECT_VERSION@
+Libs: -L${libdir} -lddsc
+Cflags: -I${includedir}


### PR DESCRIPTION
This PR installs a pkg-config file that can be used by buildsystems other than CMake.