### PR TITLE
Fix compilation error on GNU Hurd architectures

### DIFF
--- a/src/ddsrt/include/dds/ddsrt/filesystem/posix.h
+++ b/src/ddsrt/include/dds/ddsrt/filesystem/posix.h
@@ -20,7 +20,11 @@
 typedef DIR *ddsrt_dir_handle_t;
 typedef mode_t ddsrt_mode_t;
 
+#ifdef PATH_MAX
 #define DDSRT_PATH_MAX PATH_MAX
+#else
+#define DDSRT_PATH_MAX FILENAME_MAX
+#endif
 #define DDSRT_FILESEPCHAR '/'
 
 #if defined(__cplusplus)

--- a/src/ddsrt/src/threads/posix/threads.c
+++ b/src/ddsrt/src/threads/posix/threads.c
@@ -66,7 +66,9 @@ typedef struct {
 size_t
 ddsrt_thread_getname(char *str, size_t size)
 {
+#ifdef MAXTHREADNAMESIZE
   char buf[MAXTHREADNAMESIZE + 1] = "";
+#endif
   size_t cnt = 0;
 
   assert(str != NULL);


### PR DESCRIPTION
The MAXTHREADNAMESIZE macro is not (yet?) defined for builds on GNU
Hurd, so the ddsrt_thead_getname() function cannot rely on it.