### PR TITLE
Struct inheritance in idl C generator

### DIFF
--- a/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
@@ -98,6 +98,7 @@ enum dds_stream_opcode {
      e            = external: stored as external data (pointer) (DDS_OP_FLAG_EXT)
      f            = flags:
                     - key/not key (DDS_OP_FLAG_KEY)
+                    - base type member, used with EXT type (DDS_OP_FLAG_BASE)
      [offset]     = field offset from start of element in memory
      [elem-size]  = element size in memory (elem-size is only included in case 'external' flag is set)
      [max-size]   = string bound + 1
@@ -241,7 +242,8 @@ enum dds_stream_typecode_subtype {
 #define DDS_OP_FLAG_FP   (1u << 1) /* floating-point: applicable to {4,8}BY and arrays, sequences of them */
 #define DDS_OP_FLAG_SGN  (1u << 2) /* signed: applicable to {1,2,4,8}BY and arrays, sequences of them */
 #define DDS_OP_FLAG_MU   (1u << 3) /* must-understand flag */
-#define DDS_OP_FLAG_BASE (1u << 4) /* jump to base type, used with PLM in PL-CDR */
+#define DDS_OP_FLAG_BASE (1u << 4) /* jump to base type, used with PLM in mutable types and for
+                                      the TYPE_EXT 'parent' member in final and appendable types */
 
 /* Topic descriptor flag values */
 #define DDS_TOPIC_FLAGS_MASK                    0x3fffffff  /* The 2 most significant bits are used for type extensibility */

--- a/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
@@ -148,8 +148,10 @@ enum dds_stream_opcode {
        where
          f           = flags:
                        - must-understand (DDS_OP_FLAG_MU)
+                       - jump to base type (DDS_OP_FLAG_BASE)
          [elem-insn] = (unsigned 16 bits) offset to instruction for element, from start of insn
-         [member id] = id for this member
+                        when FLAG_BASE is set, this is the offset of the PLM list of the base type
+         [member id] = id for this member (0 in case FLAG_BASE is set)
   */
   DDS_OP_PLM = 0x06 << 24,
 
@@ -236,9 +238,10 @@ enum dds_stream_typecode_subtype {
    and (3) the discriminator can be an integral type (or enumerated - here treated as equivalent).
    What it can't be is a floating-point type. So DEF and FP need never be set at the same time.
    There are only a few flag bits, so saving one is not such a bad idea. */
-#define DDS_OP_FLAG_FP  (1u << 1) /* floating-point: applicable to {4,8}BY and arrays, sequences of them */
-#define DDS_OP_FLAG_SGN (1u << 2) /* signed: applicable to {1,2,4,8}BY and arrays, sequences of them */
-#define DDS_OP_FLAG_MU  (1u << 3) /* must-understand flag, used with PLM in parameter list CDR */
+#define DDS_OP_FLAG_FP   (1u << 1) /* floating-point: applicable to {4,8}BY and arrays, sequences of them */
+#define DDS_OP_FLAG_SGN  (1u << 2) /* signed: applicable to {1,2,4,8}BY and arrays, sequences of them */
+#define DDS_OP_FLAG_MU   (1u << 3) /* must-understand flag */
+#define DDS_OP_FLAG_BASE (1u << 4) /* jump to base type, used with PLM in PL-CDR */
 
 /* Topic descriptor flag values */
 #define DDS_TOPIC_FLAGS_MASK                    0x3fffffff  /* The 2 most significant bits are used for type extensibility */

--- a/src/tools/idlc/src/descriptor.h
+++ b/src/tools/idlc/src/descriptor.h
@@ -14,6 +14,10 @@
 #define MAX_KEY_OFFS (255)
 #define FIXED_KEY_MAX_SIZE (16)
 
+/* The name of the member that is added as the first member in a struct to
+   include its base type in case of inheritance */
+#define STRUCT_BASE_MEMBER_NAME "parent"
+
 /* store each instruction separately for easy post processing and reduced
    complexity. arrays and sequences introduce a new scope and the relative
    offset to the next field is stored with the instructions for the respective

--- a/src/tools/idlc/src/descriptor.h
+++ b/src/tools/idlc/src/descriptor.h
@@ -27,16 +27,17 @@
 struct instruction {
   enum {
     OPCODE,
-    OFFSET,
+    OFFSET,                 /* offsetof(type, member) */
     SIZE,
     CONSTANT,
     COUPLE,
     SINGLE,
-    ELEM_OFFSET,
-    JEQ_OFFSET,
-    MEMBER_OFFSET,
-    KEY_OFFSET,
-    KEY_OFFSET_VAL
+    ELEM_OFFSET,            /* lower 16 bits have the offset of an external type (for EXT instruction), higher 16 bits offset to next instruction */
+    JEQ_OFFSET,             /* JEQ for union case */
+    MEMBER_OFFSET,          /* PLM with offset to the member instruction within the current type */
+    BASE_MEMBERS_OFFSET,    /* PLM with FLAG_BASE set, to jump to PLM list of base type */
+    KEY_OFFSET,             /* KOF instruction, lower 16 bits have the number of offsets that follow this instruction */
+    KEY_OFFSET_VAL          /* follows KOF, and has the offset to instruction of a key part */
   } type;
   union {
     struct {

--- a/src/tools/idlc/src/types.c
+++ b/src/tools/idlc/src/types.c
@@ -228,7 +228,8 @@ emit_struct(
       if (idl_fprintf(gen->header.handle, "#endif /* empty struct */\n\n") < 0)
         return IDL_RETCODE_NO_MEMORY;
   } else {
-    const idl_member_t *members = ((const idl_struct_t *)node)->members;
+    const idl_struct_t *_struct = (const idl_struct_t *)node;
+    const idl_member_t *members = _struct->members;
     /* ensure typedefs for unnamed sequences exist beforehand */
     if (members && (ret = generate_implicit_sequences(pstate, revisit, path, members, user_data)))
       return ret;
@@ -240,6 +241,16 @@ emit_struct(
           "{\n";
     if (idl_fprintf(gen->header.handle, fmt, name) < 0)
       return IDL_RETCODE_NO_MEMORY;
+    if (_struct->inherit_spec) {
+      char *type;
+      idl_struct_t *base_struct = (idl_struct_t*)_struct->inherit_spec->base;
+      if (IDL_PRINTA(&type, print_type, base_struct) < 0)
+        return IDL_RETCODE_NO_MEMORY;
+      const char *type_prefix = get_type_prefix(base_struct);
+      fmt = "  %s%s %s;\n";
+      if (idl_fprintf(gen->header.handle, fmt, type_prefix, type, STRUCT_BASE_MEMBER_NAME) < 0)
+        return IDL_RETCODE_NO_MEMORY;
+    }
     return IDL_VISIT_REVISIT;
   }
 

--- a/src/tools/idlc/tests/descriptor.c
+++ b/src/tools/idlc/tests/descriptor.c
@@ -225,7 +225,7 @@ CU_Test(idlc_descriptor, keys_inheritance)
     { "@nested struct test_base { long a; }; @topic struct test : test_base { long c; };",
       0, { "" } },
     /* single inheritance, one key field */
-    { "@nested struct test_base { @key long a; short b; }; @topic struct test : test_base { long c; };",
+    { "@nested struct test_base { @key long a; short b; }; @topic struct test : test_base { };",
       1, { "parent.a" } },
     /* two levels of inheritance */
     { "@nested struct test_base2 { @key long a2; }; @nested struct test_base1 : test_base2 { long a1; }; @topic struct test : test_base1 { long a; };",
@@ -236,6 +236,21 @@ CU_Test(idlc_descriptor, keys_inheritance)
     /* single inheritance, key fields reversed by @id */
     { "@nested struct test_base { @key @id(1) long a; @key @id(0) short b; }; @topic struct test : test_base { @id(2) long c; };",
       2, { "parent.b", "parent.a" } },
+    /* single inheritance appendable struct, one key field */
+    { "@nested @appendable struct test_base { @key long a; short b; }; @topic @appendable struct test : test_base { long c; };",
+      1, { "parent.a" } },
+    /* single inheritance mutable struct, one key field */
+    { "@nested @mutable struct test_base { @key long a; short b; }; @topic @mutable struct test : test_base { long c; };",
+      1, { "a" } },
+    /* two levels of inheritance, mutable struct */
+    { "@nested @mutable struct test_base2 { @key long a2; @key long b2; }; @nested @mutable struct test_base1 : test_base2 { long a1; }; @topic @mutable struct test : test_base1 { long a; };",
+      2, { "a2", "b2" } },
+    /* base type has (all members of) struct type test_base2 as key, mutable struct */
+    { "@nested @appendable struct test_base2 { long a2; long b2; }; @nested @mutable struct test_base1 { @key long a1; @key test_base2 b1; }; @topic @mutable struct test : test_base1 { long c; };",
+      3, { "a1", "b1.a2", "b1.b2" } },
+    /* single inheritance, mutable types, key fields reversed by @id */
+    { "@nested @mutable struct test_base { @key @id(1) long a; @key @id(0) short b; }; @topic @mutable struct test : test_base { @id(2) long c; };",
+      2, { "b", "a" } },
   };
 
   idl_retcode_t ret;

--- a/src/tools/idlc/xtests/CMakeLists.txt
+++ b/src/tools/idlc/xtests/CMakeLists.txt
@@ -15,6 +15,8 @@ set(_sources
   test_basic.idl
   test_union.idl
   test_typedef_member.idl
+  test_struct_inherit.idl
+  test_struct_inherit_mutable.idl
 #  test_struct_recursive.idl
 #  test_union_member_types.idl
 #  test_union_recursive.idl

--- a/src/tools/idlc/xtests/CMakeLists.txt
+++ b/src/tools/idlc/xtests/CMakeLists.txt
@@ -16,6 +16,7 @@ set(_sources
   test_union.idl
   test_typedef_member.idl
   test_struct_inherit.idl
+  test_struct_inherit_appendable.idl
   test_struct_inherit_mutable.idl
 #  test_struct_recursive.idl
 #  test_union_member_types.idl

--- a/src/tools/idlc/xtests/test_struct_inherit.idl
+++ b/src/tools/idlc/xtests/test_struct_inherit.idl
@@ -1,0 +1,102 @@
+/*
+ * Copyright(c) 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+#if defined(__IDLC__)
+
+@default_nested
+module test {
+  union u;
+
+  @final
+  struct d {
+    short d1;
+    @external u d2;
+  };
+
+  @final
+  struct c : d {
+    long c1;
+  };
+
+  typedef c c_t;
+  typedef c_t c_t2;
+
+  @final
+  struct b : c_t2 {
+    long b1;
+    c b2;
+  };
+
+  @final
+  union u switch(short) {
+    case 1: long u1;
+    default: short u2;
+  };
+
+  @topic
+  @final
+  struct struct_inherit : b {
+    u s1;
+  };
+}; // module
+
+#else
+
+#include <string.h>
+#include "dds/dds.h"
+#include "dds/ddsi/ddsi_cdrstream.h"
+#include "test_struct_inherit.h"
+#include "common.h"
+
+const dds_topic_descriptor_t *desc = &test_struct_inherit_desc;
+void init_sample (void *s);
+int cmp_sample (const void *sa, const void *sb);
+
+void init_sample (void *s)
+{
+  test_struct_inherit *s1 = (test_struct_inherit *) s;
+  s1->parent.b1 = 123;
+  s1->parent.parent.c1 = 234;
+  s1->parent.parent.parent.d1 = 456;
+  s1->parent.parent.parent.d2 = dds_alloc (sizeof (*s1->parent.parent.parent.d2));
+  s1->parent.parent.parent.d2->_d = 1;
+  s1->parent.parent.parent.d2->_u.u1 = 789;
+  s1->parent.b2.parent.d1 = 654;
+  s1->parent.b2.parent.d2 = dds_alloc (sizeof (*s1->parent.b2.parent.d2));
+  s1->parent.b2.parent.d2->_d = 3;
+  s1->parent.b2.parent.d2->_u.u2 = 765;
+  s1->parent.b2.c1 = 321;
+  s1->s1._d = 2;
+  s1->s1._u.u2 = 987;
+}
+
+int cmp_sample (const void *sa, const void *sb)
+{
+  test_struct_inherit *a = (test_struct_inherit *) sa;
+  test_struct_inherit *b = (test_struct_inherit *) sb;
+
+  CMP(a, b, parent.b1, 123);
+  CMP(a, b, parent.parent.c1, 234);
+  CMP(a, b, parent.parent.parent.d1, 456);
+  CMP(a, b, parent.parent.parent.d2->_d, 1);
+  CMP(a, b, parent.parent.parent.d2->_u.u1, 789);
+  CMP(a, b, parent.b2.parent.d1, 654);
+  CMP(a, b, parent.b2.parent.d2->_d, 3);
+  CMP(a, b, parent.b2.parent.d2->_u.u2, 765);
+  CMP(a, b, parent.b2.c1, 321);
+  CMP(a, b, s1._d, 2);
+  CMP(a, b, s1._u.u2, 987);
+
+  return 0;
+}
+
+#endif

--- a/src/tools/idlc/xtests/test_struct_inherit_appendable.idl
+++ b/src/tools/idlc/xtests/test_struct_inherit_appendable.idl
@@ -1,0 +1,85 @@
+/*
+ * Copyright(c) 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+#if defined(__IDLC__)
+
+@default_nested
+module test {
+
+  @appendable
+  struct c {
+    long c1;
+  };
+
+  @mutable
+  struct struct_nested {
+    string n1;
+    short n2;
+    c n3;
+  };
+
+  @appendable
+  struct b : c {
+    long b1;
+    struct_nested b2;
+  };
+
+  @topic
+  @appendable
+  struct struct_inherit : b {
+    long i1;
+    long i2;
+  };
+}; // module
+
+#else
+
+#include <string.h>
+#include "dds/dds.h"
+#include "dds/ddsi/ddsi_cdrstream.h"
+#include "test_struct_inherit_appendable.h"
+#include "common.h"
+
+const dds_topic_descriptor_t *desc = &test_struct_inherit_desc;
+void init_sample (void *s);
+int cmp_sample (const void *sa, const void *sb);
+
+void init_sample (void *s)
+{
+  test_struct_inherit *s1 = (test_struct_inherit *) s;
+  s1->parent.b1 = 123;
+  s1->parent.b2.n1 = dds_alloc(sizeof(STR128) + 1);
+  strcpy (s1->parent.b2.n1, STR128);
+  s1->parent.b2.n2 = 456;
+  s1->parent.b2.n3.c1 = 789;
+  s1->parent.parent.c1 = 321;
+  s1->i1 = 654;
+  s1->i2 = 987;
+}
+
+int cmp_sample (const void *sa, const void *sb)
+{
+  test_struct_inherit *a = (test_struct_inherit *) sa;
+  test_struct_inherit *b = (test_struct_inherit *) sb;
+
+  CMP (a, b, parent.b1, 123);
+  CMPSTR (a, b, parent.b2.n1, STR128);
+  CMP (a, b, parent.b2.n2, 456);
+  CMP (a, b, parent.b2.n3.c1, 789);
+  CMP (a, b, parent.parent.c1, 321);
+  CMP (a, b, i1, 654);
+  CMP (a, b, i2, 987);
+
+  return 0;
+}
+
+#endif

--- a/src/tools/idlc/xtests/test_struct_inherit_mutable.idl
+++ b/src/tools/idlc/xtests/test_struct_inherit_mutable.idl
@@ -1,0 +1,70 @@
+/*
+ * Copyright(c) 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+#if defined(__IDLC__)
+
+@default_nested
+module test {
+  @final
+  struct c {
+    @id(0) long c0;
+  };
+
+  @mutable
+  struct b {
+    @id(1) long f1;
+    @id(3) c f3;
+  };
+
+  @topic
+  @mutable
+  struct struct_inherit : b {
+    @id(0) long f0;
+    @id(2) long f2;
+  };
+}; // module
+
+#else
+
+#include <string.h>
+#include "dds/dds.h"
+#include "dds/ddsi/ddsi_cdrstream.h"
+#include "test_struct_inherit_mutable.h"
+#include "common.h"
+
+const dds_topic_descriptor_t *desc = &test_struct_inherit_desc;
+void init_sample (void *s);
+int cmp_sample (const void *sa, const void *sb);
+
+void init_sample (void *s)
+{
+  test_struct_inherit *s1 = (test_struct_inherit *) s;
+  s1->parent.f1 = 123;
+  s1->parent.f3.c0 = 321;
+  s1->f0 = 456;
+  s1->f2 = 789;
+}
+
+int cmp_sample (const void *sa, const void *sb)
+{
+  test_struct_inherit *a = (test_struct_inherit *) sa;
+  test_struct_inherit *b = (test_struct_inherit *) sb;
+
+  CMP(a, b, parent.f1, 123);
+  CMP(a, b, parent.f3.c0, 321);
+  CMP(a, b, f0, 456);
+  CMP(a, b, f2, 789);
+
+  return 0;
+}
+
+#endif


### PR DESCRIPTION
This PR adds support for struct inheritance to the C generator of the IDL compiler. As described in section 7.5.1.4.1.3 of the XTypes spec, in the generated types the inheritance is "as if an instance of the base type were the first member of the subtype with the name 'parent'". As a result, in the generated opcodes for the serializer the base type is also included as if it is a member of the subtype.

When using inheritance with mutable structs, the CDR stream serializer needs a member ID for the `parent` member. The hashed ID for the member name `parent` is used in the implementation in this PR, but I'm not sure if that the best approach. And this also needs a check that other members cannot use the name `parent` and can't have the same ID as the inheritance-parent member (only in the C backend, or in the generic parser?)

This PR resolved issue #897. Inheritance for union types is not implemented in this PR. 
