### PR TITLE
Fix for issue #977

### DIFF
--- a/src/idl/src/scanner.c
+++ b/src/idl/src/scanner.c
@@ -636,7 +636,9 @@ scan(idl_pstate_t *pstate, idl_lexeme_t *lex)
       pstate->scanner.state = IDL_SCAN_GRAMMAR;
     }
   } while (code == '\0');
-  move(pstate, lim);
+
+  if (code > 0)
+    move(pstate, lim);
   lex->limit = lim;
   lex->location.last = pstate->scanner.position;
 


### PR DESCRIPTION
Add storing and reloading the parser state when a buffer refill
request is encountered while scanning. This will reset the parser
to the correct position for resizing/refilling the buffer.

Signed-off-by: Martijn Reicher <martijn.reicher@adlinktech.com>