### PR TITLE
Improve support for @external 

### DIFF
--- a/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
@@ -120,6 +120,8 @@ enum dds_stream_opcode {
      [JEQ, nBY, 0] [disc] [offset]
      [JEQ, STR, 0] [disc] [offset]
      [JEQ, s,   i] [disc] [offset]
+     [JEQ4, nBY, 0] [disc] [offset] 0
+     [JEQ4, STR, 0] [disc] [offset] 0
      [JEQ4, ENU, 0] [disc] [offset] [max]
      [JEQ4, EXT, 0] *** not supported, use STU/UNI for external defined types
      [JEQ4, e | s, i] [disc] [offset] [elem-size iff "external" flag e is set, else 0]

--- a/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
@@ -61,13 +61,11 @@ enum dds_stream_opcode {
      [ADR, ENU,   0, f] [offset] [max]
      [ADR, STR,   0, f] [offset]
      [ADR, BST,   0, f] [offset] [max-size]
-     [ADR, BSP,   0, f] [offset] [max-size]
 
      [ADR, SEQ, nBY, 0] [offset]
      [ADR, SEQ, ENU, 0] [offset] [max]
      [ADR, SEQ, STR, 0] [offset]
      [ADR, SEQ, BST, 0] [offset] [max-size]
-     [ADR, SEQ, BSP, 0] [offset] [max-size]
      [ADR, SEQ,   s, 0] [offset] [elem-size] [next-insn, elem-insn]
        where s = {SEQ,ARR,UNI,STU}
      [ADR, SEQ, EXT, f] *** not supported
@@ -76,7 +74,6 @@ enum dds_stream_opcode {
      [ADR, ARR, ENU, f] [offset] [alen] [max]
      [ADR, ARR, STR, 0] [offset] [alen]
      [ADR, ARR, BST, 0] [offset] [alen] [0] [max-size]
-     [ADR, ARR, BSP, 0] [offset] [alen] [0] [max-size]
      [ADR, ARR,   s, 0] [offset] [alen] [next-insn, elem-insn] [elem-size]
          where s = {SEQ,ARR,UNI,STU}
      [ADR, ARR, EXT, f] *** not supported
@@ -182,7 +179,7 @@ enum dds_stream_typecode {
   DDS_OP_VAL_ARR = 0x08, /* array */
   DDS_OP_VAL_UNI = 0x09, /* union */
   DDS_OP_VAL_STU = 0x0a, /* struct */
-  DDS_OP_VAL_BSP = 0x0b, /* bounded string mapped to char * */
+  /* 0x0b **available for future use** */
   DDS_OP_VAL_ENU = 0x0c, /* enumerated value (long) */
   DDS_OP_VAL_EXT = 0x0d  /* field with external definition */
 };
@@ -199,7 +196,6 @@ enum dds_stream_typecode_primary {
   DDS_OP_TYPE_ARR = DDS_OP_VAL_ARR << 16,
   DDS_OP_TYPE_UNI = DDS_OP_VAL_UNI << 16,
   DDS_OP_TYPE_STU = DDS_OP_VAL_STU << 16,
-  DDS_OP_TYPE_BSP = DDS_OP_VAL_BSP << 16,
   DDS_OP_TYPE_ENU = DDS_OP_VAL_ENU << 16,
   DDS_OP_TYPE_EXT = DDS_OP_VAL_EXT << 16
 };
@@ -225,7 +221,6 @@ enum dds_stream_typecode_subtype {
   DDS_OP_SUBTYPE_ARR = DDS_OP_VAL_ARR << 8,
   DDS_OP_SUBTYPE_UNI = DDS_OP_VAL_UNI << 8,
   DDS_OP_SUBTYPE_STU = DDS_OP_VAL_STU << 8,
-  DDS_OP_SUBTYPE_BSP = DDS_OP_VAL_BSP << 8,
   DDS_OP_SUBTYPE_ENU = DDS_OP_VAL_ENU << 8
 };
 #define DDS_OP_SUBTYPE_BOO DDS_OP_SUBTYPE_1BY

--- a/src/core/ddsi/src/ddsi_cdrstream.c
+++ b/src/core/ddsi/src/ddsi_cdrstream.c
@@ -1316,10 +1316,12 @@ static const uint32_t *dds_stream_read_uni (dds_istream_t * __restrict is, char 
     if (op_type_external (jeq_op[0]) && valtype != DDS_OP_VAL_STR)
     {
       /* Allocate memory for @external union member. This memory must be initialized
-          to 0, because the type may contain sequences that need to have 0 index/size */
+          to 0, because the type may contain sequences that need to have 0 index/size
+          or external fields that need to be initialized to null */
       assert (DDS_OP (jeq_op[0]) == DDS_OP_JEQ4);
       uint32_t sz = get_jeq4_type_size (valtype, jeq_op);
-      *((char **) valaddr) = ddsrt_calloc (1, sz);
+      if (*((char **) valaddr) == NULL)
+        *((char **) valaddr) = ddsrt_calloc (1, sz);
       valaddr = *((char **) valaddr);
     }
 
@@ -1352,10 +1354,12 @@ static inline const uint32_t *dds_stream_read_adr (uint32_t insn, dds_istream_t 
   void *addr = data + ops[1];
   if (op_type_external (insn) && DDS_OP_TYPE (insn) != DDS_OP_VAL_STR)
   {
-    /* Allocate memory for @external struct member. This memory must be initialized
-        to 0, because the type may contain sequences that need to have 0 index/size */
+    /* Allocate memory for @external union member. This memory must be initialized
+        to 0, because the type may contain sequences that need to have 0 index/size
+        or external fields that need to be initialized to null */
     uint32_t sz = get_adr_type_size (insn, ops);
-    *((char **) addr) = ddsrt_calloc (1, sz);
+    if (*((char **) addr) == NULL)
+      *((char **) addr) = ddsrt_calloc (1, sz);
     addr = *((char **) addr);
   }
 

--- a/src/core/ddsi/src/ddsi_cdrstream.c
+++ b/src/core/ddsi/src/ddsi_cdrstream.c
@@ -372,7 +372,6 @@ static uint32_t get_elem_size (uint32_t insn, const uint32_t * __restrict ops)
         abort ();
       break;
     case DDS_OP_VAL_EXT:
-    default:
       abort ();
       break;
   }

--- a/src/core/ddsi/src/ddsi_cdrstream.c
+++ b/src/core/ddsi/src/ddsi_cdrstream.c
@@ -362,7 +362,7 @@ static uint32_t get_elem_size (uint32_t insn, const uint32_t * __restrict ops)
     case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY: case DDS_OP_VAL_ENU:
       elem_sz = get_type_size (DDS_OP_SUBTYPE (insn));
       break;
-    case DDS_OP_VAL_STR: case DDS_OP_VAL_BSP:
+    case DDS_OP_VAL_STR:
       elem_sz = sizeof (char *);
       break;
     case DDS_OP_VAL_BST: case DDS_OP_VAL_SEQ: case DDS_OP_VAL_ARR: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU:
@@ -387,7 +387,7 @@ static uint32_t get_adr_type_size (uint32_t insn, const uint32_t * __restrict op
     case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY: case DDS_OP_VAL_ENU:
       sz = get_type_size (DDS_OP_TYPE (insn));
       break;
-    case DDS_OP_VAL_STR: case DDS_OP_VAL_BSP:
+    case DDS_OP_VAL_STR:
       sz = sizeof (char *);
       break;
     case DDS_OP_VAL_BST:
@@ -425,7 +425,7 @@ static uint32_t get_jeq4_type_size (const enum dds_stream_typecode valtype, cons
     case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY: case DDS_OP_VAL_ENU:
       sz = get_type_size (valtype);
       break;
-    case DDS_OP_VAL_STR: case DDS_OP_VAL_BSP:
+    case DDS_OP_VAL_STR:
       sz = sizeof (char *);
       break;
     case DDS_OP_VAL_BST:
@@ -537,7 +537,7 @@ static const uint32_t *dds_stream_countops_seq (const uint32_t * __restrict ops,
     case DDS_OP_VAL_STR:
       ops += 2;
       break;
-    case DDS_OP_VAL_BST: case DDS_OP_VAL_BSP: case DDS_OP_VAL_ENU:
+    case DDS_OP_VAL_BST: case DDS_OP_VAL_ENU:
       ops += 3;
       break;
     case DDS_OP_VAL_SEQ: case DDS_OP_VAL_ARR: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU: {
@@ -568,7 +568,7 @@ static const uint32_t *dds_stream_countops_arr (const uint32_t * __restrict ops,
     case DDS_OP_VAL_STR:
       ops += 3;
       break;
-    case DDS_OP_VAL_BST: case DDS_OP_VAL_BSP: case DDS_OP_VAL_ENU:
+    case DDS_OP_VAL_BST: case DDS_OP_VAL_ENU:
       ops += 5;
       break;
     case DDS_OP_VAL_SEQ: case DDS_OP_VAL_ARR: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU: {
@@ -606,7 +606,7 @@ static const uint32_t *dds_stream_countops_uni (const uint32_t * __restrict ops,
       case DDS_OP_VAL_STR:
       case DDS_OP_VAL_ENU:
         break;
-      case DDS_OP_VAL_BST: case DDS_OP_VAL_BSP: case DDS_OP_VAL_SEQ: case DDS_OP_VAL_ARR: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU:
+      case DDS_OP_VAL_BST: case DDS_OP_VAL_SEQ: case DDS_OP_VAL_ARR: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU:
         if (DDS_OP_ADR_JSR (jeq_op[0]) > 0)
           dds_stream_countops1 (jeq_op + DDS_OP_ADR_JSR (jeq_op[0]), ops_end, dynamic_type);
         break;
@@ -666,7 +666,7 @@ static void dds_stream_countops1 (const uint32_t * __restrict ops, const uint32_
           case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY: case DDS_OP_VAL_STR:
             ops += 2;
             break;
-          case DDS_OP_VAL_BST: case DDS_OP_VAL_BSP: case DDS_OP_VAL_ENU:
+          case DDS_OP_VAL_BST: case DDS_OP_VAL_ENU:
             ops += 3;
             break;
           case DDS_OP_VAL_SEQ: ops = dds_stream_countops_seq (ops, insn, ops_end, dynamic_type); break;
@@ -846,7 +846,7 @@ static const uint32_t *skip_sequence_insns (uint32_t insn, const uint32_t * __re
     case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY:
     case DDS_OP_VAL_STR:
       return ops + 2;
-    case DDS_OP_VAL_BST: case DDS_OP_VAL_BSP: case DDS_OP_VAL_ENU:
+    case DDS_OP_VAL_BST: case DDS_OP_VAL_ENU:
       return ops + 3;
     case DDS_OP_VAL_SEQ: case DDS_OP_VAL_ARR: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU: {
       const uint32_t jmp = DDS_OP_ADR_JMP (ops[3]);
@@ -871,7 +871,6 @@ static const uint32_t *skip_array_insns (uint32_t insn, const uint32_t * __restr
     case DDS_OP_VAL_ENU:
       return ops + 4;
     case DDS_OP_VAL_BST:
-    case DDS_OP_VAL_BSP:
       return ops + 5;
     case DDS_OP_VAL_SEQ: case DDS_OP_VAL_ARR: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU: {
       const uint32_t jmp = DDS_OP_ADR_JMP (ops[3]);
@@ -912,12 +911,6 @@ static const uint32_t *skip_array_default (uint32_t insn, char * __restrict data
         ((char *) (ptr + i * elem_size))[0] = '\0';
       return ops + 5;
     }
-    case DDS_OP_VAL_BSP: {
-      char **ptr = (char **) data;
-      for (uint32_t i = 0; i < num; i++)
-        ptr[i] = dds_stream_reuse_string_empty (*(char **) ptr[i]);
-      return ops + 5;
-    }
     case DDS_OP_VAL_SEQ: case DDS_OP_VAL_ARR: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU: {
       const uint32_t *jsr_ops = ops + DDS_OP_ADR_JSR (ops[3]);
       const uint32_t jmp = DDS_OP_ADR_JMP (ops[3]);
@@ -956,7 +949,7 @@ static const uint32_t *skip_union_default (uint32_t insn, char * __restrict disc
       case DDS_OP_VAL_4BY: case DDS_OP_VAL_ENU: *((uint32_t *) valaddr) = 0; break;
       case DDS_OP_VAL_8BY: *((uint64_t *) valaddr) = 0; break;
       case DDS_OP_VAL_STR: *(char **) valaddr = dds_stream_reuse_string_empty (*((char **) valaddr)); break;
-      case DDS_OP_VAL_BST: case DDS_OP_VAL_BSP: case DDS_OP_VAL_SEQ: case DDS_OP_VAL_ARR: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU:
+      case DDS_OP_VAL_BST: case DDS_OP_VAL_SEQ: case DDS_OP_VAL_ARR: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU:
         (void) dds_stream_skip_default (valaddr, jeq_op + DDS_OP_ADR_JSR (jeq_op[0]));
         break;
       case DDS_OP_VAL_EXT: {
@@ -988,7 +981,7 @@ static uint32_t get_length_code_seq (const uint32_t subtype)
       return LENGTH_CODE_ALSO_NEXTINT8;
 
     /* Sequences with non-primitive subtype contain a DHEADER */
-    case DDS_OP_VAL_STR: case DDS_OP_VAL_BSP: case DDS_OP_VAL_BST:
+    case DDS_OP_VAL_STR: case DDS_OP_VAL_BST:
     case DDS_OP_VAL_SEQ: case DDS_OP_VAL_ARR: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU:
       return LENGTH_CODE_ALSO_NEXTINT;
 
@@ -1010,7 +1003,7 @@ static uint32_t get_length_code_arr (const uint32_t subtype)
       return LENGTH_CODE_NEXTINT;
 
     /* Arrays with non-primitive subtype contain a DHEADER */
-    case DDS_OP_VAL_STR: case DDS_OP_VAL_BSP: case DDS_OP_VAL_BST:
+    case DDS_OP_VAL_STR: case DDS_OP_VAL_BST:
     case DDS_OP_VAL_SEQ: case DDS_OP_VAL_ARR: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU:
       return LENGTH_CODE_ALSO_NEXTINT;
 
@@ -1035,7 +1028,7 @@ static uint32_t get_length_code (const uint32_t * __restrict ops)
         case DDS_OP_VAL_2BY: return LENGTH_CODE_2B;
         case DDS_OP_VAL_4BY: case DDS_OP_VAL_ENU: return LENGTH_CODE_4B;
         case DDS_OP_VAL_8BY: return LENGTH_CODE_8B;
-        case DDS_OP_VAL_STR: case DDS_OP_VAL_BSP: case DDS_OP_VAL_BST: return LENGTH_CODE_ALSO_NEXTINT; /* nextint overlaps with length from serialized string data */
+        case DDS_OP_VAL_STR: case DDS_OP_VAL_BST: return LENGTH_CODE_ALSO_NEXTINT; /* nextint overlaps with length from serialized string data */
         case DDS_OP_VAL_SEQ: return get_length_code_seq (DDS_OP_SUBTYPE (insn));
         case DDS_OP_VAL_ARR: return get_length_code_arr (DDS_OP_SUBTYPE (insn));
         case DDS_OP_VAL_UNI: case DDS_OP_VAL_EXT: {
@@ -1236,17 +1229,6 @@ static const uint32_t *dds_stream_read_seq (dds_istream_t * __restrict is, char 
         dds_stream_skip_string (is);
       return ops + 3;
     }
-    case DDS_OP_VAL_BSP: {
-      const uint32_t elem_size = ops[2];
-      realloc_sequence_buffer_if_needed (seq, num, elem_size, false);
-      seq->_length = (num <= seq->_maximum) ? num : seq->_maximum;
-      char **ptr = (char **) seq->_buffer;
-      for (uint32_t i = 0; i < seq->_length; i++)
-        ptr[i] = dds_stream_reuse_string_bound (is, ptr[i], elem_size, true);
-      for (uint32_t i = seq->_length; i < num; i++)
-        dds_stream_skip_string (is);
-      return ops + 3;
-    }
     case DDS_OP_VAL_SEQ: case DDS_OP_VAL_ARR: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU: {
       const uint32_t elem_size = ops[2];
       const uint32_t jmp = DDS_OP_ADR_JMP (ops[3]);
@@ -1296,13 +1278,6 @@ static const uint32_t *dds_stream_read_arr (dds_istream_t * __restrict is, char 
       const uint32_t elem_size = ops[4];
       for (uint32_t i = 0; i < num; i++)
         (void) dds_stream_reuse_string_bound (is, ptr + i * elem_size, elem_size, false);
-      return ops + 5;
-    }
-    case DDS_OP_VAL_BSP: {
-      char **ptr = (char **) addr;
-      const uint32_t elem_size = ops[4];
-      for (uint32_t i = 0; i < num; i++)
-        ptr[i] = dds_stream_reuse_string_bound (is, ptr[i], elem_size, true);
       return ops + 5;
     }
     case DDS_OP_VAL_SEQ: case DDS_OP_VAL_ARR: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU: {
@@ -1355,7 +1330,7 @@ static const uint32_t *dds_stream_read_uni (dds_istream_t * __restrict is, char 
       case DDS_OP_VAL_4BY: case DDS_OP_VAL_ENU: *((uint32_t *) valaddr) = dds_is_get4 (is); break;
       case DDS_OP_VAL_8BY: *((uint64_t *) valaddr) = dds_is_get8 (is); break;
       case DDS_OP_VAL_STR: *(char **) valaddr = dds_stream_reuse_string (is, *((char **) valaddr)); break;
-      case DDS_OP_VAL_BST: case DDS_OP_VAL_BSP: case DDS_OP_VAL_SEQ: case DDS_OP_VAL_ARR:
+      case DDS_OP_VAL_BST: case DDS_OP_VAL_SEQ: case DDS_OP_VAL_ARR:
         (void) dds_stream_read (is, valaddr, jeq_op + DDS_OP_ADR_JSR (jeq_op[0]));
         break;
       case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU: {
@@ -1392,7 +1367,6 @@ static inline const uint32_t *dds_stream_read_adr (uint32_t insn, dds_istream_t 
     case DDS_OP_VAL_8BY: *((uint64_t *) addr) = dds_is_get8 (is); ops += 2; break;
     case DDS_OP_VAL_STR: *((char **) addr) = dds_stream_reuse_string (is, *((char **) addr)); ops += 2; break;
     case DDS_OP_VAL_BST: (void) dds_stream_reuse_string_bound (is, (char *) addr, ops[2], false); ops += 3; break;
-    case DDS_OP_VAL_BSP: *((char **) addr) = dds_stream_reuse_string_bound (is, *((char **) addr), ops[2], true); ops += 3; break;
     case DDS_OP_VAL_SEQ: ops = dds_stream_read_seq (is, addr, ops, insn); break;
     case DDS_OP_VAL_ARR: ops = dds_stream_read_arr (is, addr, ops, insn); break;
     case DDS_OP_VAL_UNI: ops = dds_stream_read_uni (is, addr, data, ops, insn); break;
@@ -1426,7 +1400,6 @@ static const uint32_t *dds_stream_skip_adr (uint32_t insn, const uint32_t * __re
     case DDS_OP_VAL_STR:
       return ops + 2;
     case DDS_OP_VAL_BST:
-    case DDS_OP_VAL_BSP:
     case DDS_OP_VAL_ENU:
       return ops + 3;
     case DDS_OP_VAL_SEQ:
@@ -1463,7 +1436,6 @@ static const uint32_t *dds_stream_skip_adr_default (uint32_t insn, char * __rest
 
     case DDS_OP_VAL_STR: *(char **) addr = dds_stream_reuse_string_empty (*(char **) addr); return ops + 2;
     case DDS_OP_VAL_BST: ((char *) addr)[0] = '\0'; return ops + 3;
-    case DDS_OP_VAL_BSP: *(char **) addr = dds_stream_reuse_string_empty (*(char **) addr); return ops + 3;
     case DDS_OP_VAL_ENU: *(uint32_t *) addr = 0; return ops + 3;
     case DDS_OP_VAL_SEQ: {
       dds_sequence_t * const seq = (dds_sequence_t *) addr;
@@ -1856,7 +1828,7 @@ static const uint32_t *normalize_seq (char * __restrict data, uint32_t * __restr
         return NULL;
       return ops + 2;
     }
-    case DDS_OP_VAL_STR: case DDS_OP_VAL_BST: case DDS_OP_VAL_BSP: {
+    case DDS_OP_VAL_STR: case DDS_OP_VAL_BST: {
       const size_t maxsz = (subtype == DDS_OP_VAL_STR) ? SIZE_MAX : ops[2];
       for (uint32_t i = 0; i < num; i++)
         if (!normalize_string (data, off, size, bswap, maxsz))
@@ -1899,7 +1871,7 @@ static const uint32_t *normalize_arr (char * __restrict data, uint32_t * __restr
         return NULL;
       return ops + 3;
     }
-    case DDS_OP_VAL_STR: case DDS_OP_VAL_BST: case DDS_OP_VAL_BSP: {
+    case DDS_OP_VAL_STR: case DDS_OP_VAL_BST: {
       const size_t maxsz = (subtype == DDS_OP_VAL_STR) ? SIZE_MAX : ops[4];
       for (uint32_t i = 0; i < num; i++)
         if (!normalize_string (data, off, size, bswap, maxsz))
@@ -1980,7 +1952,7 @@ static const uint32_t *normalize_uni (char * __restrict data, uint32_t * __restr
         break;
       case DDS_OP_VAL_8BY: if (!normalize_uint64 (data, off, size, bswap, xcdr_version)) return NULL; break;
       case DDS_OP_VAL_STR: if (!normalize_string (data, off, size, bswap, SIZE_MAX)) return NULL; break;
-      case DDS_OP_VAL_BST: case DDS_OP_VAL_BSP: case DDS_OP_VAL_SEQ: case DDS_OP_VAL_ARR: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU:
+      case DDS_OP_VAL_BST: case DDS_OP_VAL_SEQ: case DDS_OP_VAL_ARR: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU:
         if (dds_stream_normalize1 (data, off, size, bswap, xcdr_version, jeq_op + DDS_OP_ADR_JSR (jeq_op[0])) == NULL)
           return NULL;
         break;
@@ -2002,7 +1974,7 @@ static const uint32_t *stream_normalize_adr (uint32_t insn, char * __restrict da
     case DDS_OP_VAL_4BY: if (!normalize_uint32 (data, off, size, bswap)) return NULL; ops += 2; break;
     case DDS_OP_VAL_8BY: if (!normalize_uint64 (data, off, size, bswap, xcdr_version)) return NULL; ops += 2; break;
     case DDS_OP_VAL_STR: if (!normalize_string (data, off, size, bswap, SIZE_MAX)) return NULL; ops += 2; break;
-    case DDS_OP_VAL_BST: case DDS_OP_VAL_BSP: if (!normalize_string (data, off, size, bswap, ops[2])) return NULL; ops += 3; break;
+    case DDS_OP_VAL_BST: if (!normalize_string (data, off, size, bswap, ops[2])) return NULL; ops += 3; break;
     case DDS_OP_VAL_SEQ: ops = normalize_seq (data, off, size, bswap, xcdr_version, ops, insn); if (!ops) return NULL; break;
     case DDS_OP_VAL_ARR: ops = normalize_arr (data, off, size, bswap, xcdr_version, ops, insn); if (!ops) return NULL; break;
     case DDS_OP_VAL_UNI: ops = normalize_uni (data, off, size, bswap, xcdr_version, ops, insn); if (!ops) return NULL; break;
@@ -2199,7 +2171,7 @@ static bool stream_normalize_key_impl (void * __restrict data, uint32_t size, ui
     case DDS_OP_VAL_4BY: case DDS_OP_VAL_ENU: if (!normalize_uint32 (data, offs, size, bswap)) return false; break;
     case DDS_OP_VAL_8BY: if (!normalize_uint64 (data, offs, size, bswap, xcdr_version)) return false; break;
     case DDS_OP_VAL_STR: if (!normalize_string (data, offs, size, bswap, SIZE_MAX)) return false; break;
-    case DDS_OP_VAL_BST: case DDS_OP_VAL_BSP: if (!normalize_string (data, offs, size, bswap, insnp[2])) return false; break;
+    case DDS_OP_VAL_BST: if (!normalize_string (data, offs, size, bswap, insnp[2])) return false; break;
     case DDS_OP_VAL_ARR: if (!normalize_arr (data, offs, size, bswap, xcdr_version, insnp, *insnp)) return false; break;
     case DDS_OP_VAL_EXT: {
       assert (key_offset_count > 0);
@@ -2274,7 +2246,6 @@ static const uint32_t *dds_stream_free_sample_seq (char * __restrict addr, const
     {
       case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY: break;
       case DDS_OP_VAL_BST: case DDS_OP_VAL_ENU: ops++; break;
-      case DDS_OP_VAL_BSP: ops++; /* fall through */
       case DDS_OP_VAL_STR: {
         char **ptr = (char **) seq->_buffer;
         while (num--)
@@ -2320,7 +2291,6 @@ static const uint32_t *dds_stream_free_sample_arr (char * __restrict addr, const
     case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY: break;
     case DDS_OP_VAL_ENU: ops++; break;
     case DDS_OP_VAL_BST: ops += 2; break;
-    case DDS_OP_VAL_BSP: ops += 2; /* fall through */
     case DDS_OP_VAL_STR: {
       char **ptr = (char **) addr;
       while (num--)
@@ -2376,7 +2346,7 @@ static const uint32_t *dds_stream_free_sample_uni (char * __restrict discaddr, c
     switch (subtype)
     {
       case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY: case DDS_OP_VAL_BST: case DDS_OP_VAL_ENU: break;
-      case DDS_OP_VAL_BSP: case DDS_OP_VAL_STR: {
+      case DDS_OP_VAL_STR: {
         dds_free (*((char **) valaddr));
         *((char **) valaddr) = NULL;
         break;
@@ -2454,7 +2424,6 @@ void dds_stream_free_sample (void * __restrict data, const uint32_t * __restrict
         switch (DDS_OP_TYPE (insn))
         {
           case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY: ops += 2; break;
-          case DDS_OP_VAL_BSP: ops++; /* fall through */
           case DDS_OP_VAL_STR: {
             dds_free (*((char **) addr));
             *((char **) addr) = NULL;
@@ -2523,7 +2492,7 @@ static void dds_stream_extract_key_from_key_prim_op (dds_istream_t * __restrict 
     case DDS_OP_VAL_2BY: dds_os_put2 (os, dds_is_get2 (is)); break;
     case DDS_OP_VAL_4BY: case DDS_OP_VAL_ENU: dds_os_put4 (os, dds_is_get4 (is)); break;
     case DDS_OP_VAL_8BY: dds_os_put8 (os, dds_is_get8 (is)); break;
-    case DDS_OP_VAL_STR: case DDS_OP_VAL_BST: case DDS_OP_VAL_BSP: {
+    case DDS_OP_VAL_STR: case DDS_OP_VAL_BST: {
       uint32_t sz = dds_is_get4 (is);
       dds_os_put4 (os, sz);
       dds_os_put_bytes (os, is->m_buffer + is->m_index, sz);
@@ -2600,7 +2569,7 @@ static void dds_stream_extract_keyBE_from_key_prim_op (dds_istream_t * __restric
     case DDS_OP_VAL_2BY: dds_os_put2BE (os, dds_is_get2 (is)); break;
     case DDS_OP_VAL_4BY: case DDS_OP_VAL_ENU: dds_os_put4BE (os, dds_is_get4 (is)); break;
     case DDS_OP_VAL_8BY: dds_os_put8BE (os, dds_is_get8 (is)); break;
-    case DDS_OP_VAL_STR: case DDS_OP_VAL_BST: case DDS_OP_VAL_BSP: {
+    case DDS_OP_VAL_STR: case DDS_OP_VAL_BST: {
       uint32_t sz = dds_is_get4 (is);
       dds_os_put4BE (os, sz);
       dds_os_put_bytes (&os->x, is->m_buffer + is->m_index, sz);
@@ -2654,7 +2623,7 @@ static void dds_stream_extract_key_from_data_skip_subtype (dds_istream_t * __res
       is->m_index += num * 8;
       break;
     }
-    case DDS_OP_VAL_STR: case DDS_OP_VAL_BST: case DDS_OP_VAL_BSP: {
+    case DDS_OP_VAL_STR: case DDS_OP_VAL_BST: {
       for (uint32_t i = 0; i < num; i++)
       {
         const uint32_t len = dds_is_get4 (is);
@@ -2729,9 +2698,9 @@ static const uint32_t *dds_stream_extract_key_from_data_skip_adr (dds_istream_t 
 {
   switch (type)
   {
-    case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY: case DDS_OP_VAL_STR: case DDS_OP_VAL_BST: case DDS_OP_VAL_BSP: case DDS_OP_VAL_ENU:
+    case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY: case DDS_OP_VAL_STR: case DDS_OP_VAL_BST: case DDS_OP_VAL_ENU:
       dds_stream_extract_key_from_data_skip_subtype (is, 1, type, NULL);
-      ops += 2 + (type == DDS_OP_VAL_BST || type == DDS_OP_VAL_BSP || type == DDS_OP_VAL_ARR || type == DDS_OP_VAL_ENU);
+      ops += 2 + (type == DDS_OP_VAL_BST || type == DDS_OP_VAL_ARR || type == DDS_OP_VAL_ENU);
       break;
     case DDS_OP_VAL_SEQ:
       ops = dds_stream_extract_key_from_data_skip_sequence (is, ops);
@@ -2794,7 +2763,6 @@ static void dds_stream_read_key_impl (dds_istream_t * __restrict is, char * __re
     case DDS_OP_VAL_8BY: *((uint64_t *) dst) = dds_is_get8 (is); break;
     case DDS_OP_VAL_STR: *((char **) dst) = dds_stream_reuse_string (is, *((char **) dst)); break;
     case DDS_OP_VAL_BST: (void) dds_stream_reuse_string_bound (is, dst, insnp[2], false); break;
-    case DDS_OP_VAL_BSP: *((char **) dst) = dds_stream_reuse_string_bound (is, dst, insnp[2], true); break;
     case DDS_OP_VAL_ARR: dds_is_get_bytes (is, dst, insnp[2], get_type_size (DDS_OP_SUBTYPE (*insnp))); break;
     case DDS_OP_VAL_SEQ: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU: abort (); break;
     case DDS_OP_VAL_EXT:
@@ -2955,7 +2923,7 @@ static bool prtf_simple (char * __restrict *buf, size_t * __restrict bufsize, dd
       else
         return prtf (buf, bufsize, "%"PRIu64, x.u);
     }
-    case DDS_OP_VAL_STR: case DDS_OP_VAL_BST: case DDS_OP_VAL_BSP: return prtf_str (buf, bufsize, is);
+    case DDS_OP_VAL_STR: case DDS_OP_VAL_BST: return prtf_str (buf, bufsize, is);
     case DDS_OP_VAL_ARR: case DDS_OP_VAL_SEQ: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU: case DDS_OP_VAL_EXT:
       abort ();
   }
@@ -2992,7 +2960,7 @@ static bool prtf_simple_array (char * __restrict *buf, size_t * __restrict bufsi
       break;
     }
     case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY: case DDS_OP_VAL_ENU:
-    case DDS_OP_VAL_STR: case DDS_OP_VAL_BST: case DDS_OP_VAL_BSP:
+    case DDS_OP_VAL_STR: case DDS_OP_VAL_BST:
       for (size_t i = 0; cont && i < num; i++)
       {
         if (i != 0)
@@ -3029,7 +2997,7 @@ static const uint32_t *prtf_seq (char * __restrict *buf, size_t *bufsize, dds_is
     case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY:
       (void) prtf_simple_array (buf, bufsize, is, num, subtype, DDS_OP_FLAGS (insn));
       return ops + 2;
-    case DDS_OP_VAL_STR: case DDS_OP_VAL_BST: case DDS_OP_VAL_BSP: case DDS_OP_VAL_ENU:
+    case DDS_OP_VAL_STR: case DDS_OP_VAL_BST: case DDS_OP_VAL_ENU:
       (void) prtf_simple_array (buf, bufsize, is, num, subtype, DDS_OP_FLAGS (insn));
       return ops + (subtype == DDS_OP_VAL_STR ? 2 : 3);
     case DDS_OP_VAL_SEQ: case DDS_OP_VAL_ARR: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU: {
@@ -3066,7 +3034,7 @@ static const uint32_t *prtf_arr (char * __restrict *buf, size_t *bufsize, dds_is
     case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY:
       (void) prtf_simple_array (buf, bufsize, is, num, subtype, DDS_OP_FLAGS (insn));
       return ops + 3;
-    case DDS_OP_VAL_STR: case DDS_OP_VAL_BST: case DDS_OP_VAL_BSP: case DDS_OP_VAL_ENU:
+    case DDS_OP_VAL_STR: case DDS_OP_VAL_BST: case DDS_OP_VAL_ENU:
       (void) prtf_simple_array (buf, bufsize, is, num, subtype, DDS_OP_FLAGS (insn));
       return ops + (subtype == DDS_OP_VAL_STR ? 3 : 5);
     case DDS_OP_VAL_SEQ: case DDS_OP_VAL_ARR: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU: {
@@ -3101,7 +3069,7 @@ static const uint32_t *prtf_uni (char * __restrict *buf, size_t *bufsize, dds_is
     switch (valtype)
     {
       case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY: case DDS_OP_VAL_ENU:
-      case DDS_OP_VAL_STR: case DDS_OP_VAL_BST: case DDS_OP_VAL_BSP:
+      case DDS_OP_VAL_STR: case DDS_OP_VAL_BST:
         (void) prtf_simple (buf, bufsize, is, valtype, DDS_OP_FLAGS (jeq_op[0]));
         break;
       case DDS_OP_VAL_SEQ: case DDS_OP_VAL_ARR: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU:
@@ -3217,7 +3185,7 @@ static bool dds_stream_print_sample1 (char * __restrict *buf, size_t * __restric
               cont = prtf_simple (buf, bufsize, is, DDS_OP_TYPE (insn), DDS_OP_FLAGS (insn));
               ops += 2;
               break;
-            case DDS_OP_VAL_BST: case DDS_OP_VAL_BSP: case DDS_OP_VAL_ENU:
+            case DDS_OP_VAL_BST: case DDS_OP_VAL_ENU:
               cont = prtf_simple (buf, bufsize, is, DDS_OP_TYPE (insn), DDS_OP_FLAGS (insn));
               ops += 3;
               break;
@@ -3306,7 +3274,7 @@ static size_t dds_stream_print_key_impl (dds_istream_t * __restrict is, const ui
   switch (DDS_OP_TYPE (*op))
   {
     case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY: case DDS_OP_VAL_ENU:
-    case DDS_OP_VAL_STR: case DDS_OP_VAL_BST: case DDS_OP_VAL_BSP:
+    case DDS_OP_VAL_STR: case DDS_OP_VAL_BST:
       *cont = prtf_simple (&buf, &bufsize, is, DDS_OP_TYPE (*op), DDS_OP_FLAGS (*op));
       break;
     case DDS_OP_VAL_ARR:

--- a/src/core/ddsi/src/ddsi_cdrstream_keys.part.c
+++ b/src/core/ddsi/src/ddsi_cdrstream_keys.part.c
@@ -21,7 +21,7 @@ static void dds_stream_write_keyBO_impl (DDS_OSTREAM_T * __restrict os, const ui
     case DDS_OP_VAL_2BY: dds_os_put2BO (os, *((uint16_t *) addr)); break;
     case DDS_OP_VAL_4BY: case DDS_OP_VAL_ENU: dds_os_put4BO (os, *((uint32_t *) addr)); break;
     case DDS_OP_VAL_8BY: dds_os_put8BO (os, *((uint64_t *) addr)); break;
-    case DDS_OP_VAL_STR: case DDS_OP_VAL_BSP: dds_stream_write_stringBO (os, *(char **) addr); break;
+    case DDS_OP_VAL_STR: dds_stream_write_stringBO (os, *(char **) addr); break;
     case DDS_OP_VAL_BST: dds_stream_write_stringBO (os, addr); break;
     case DDS_OP_VAL_ARR: {
       const uint32_t elem_size = get_type_size (DDS_OP_SUBTYPE (*insnp));

--- a/src/core/ddsi/src/ddsi_cdrstream_write.part.c
+++ b/src/core/ddsi/src/ddsi_cdrstream_write.part.c
@@ -62,11 +62,11 @@ static const uint32_t *dds_stream_write_seqBO (DDS_OSTREAM_T * __restrict os, co
         ops += 2;
         break;
       }
-      case DDS_OP_VAL_STR: case DDS_OP_VAL_BSP: {
+      case DDS_OP_VAL_STR: {
         const char **ptr = (const char **) seq->_buffer;
         for (uint32_t i = 0; i < num; i++)
           dds_stream_write_stringBO (os, ptr[i]);
-        ops += 2 + (subtype == DDS_OP_VAL_BSP ? 2 : 0);
+        ops += 2;
         break;
       }
       case DDS_OP_VAL_BST: {
@@ -130,11 +130,11 @@ static const uint32_t *dds_stream_write_arrBO (DDS_OSTREAM_T * __restrict os, co
       ops += 3;
       break;
     }
-    case DDS_OP_VAL_STR: case DDS_OP_VAL_BSP: {
+    case DDS_OP_VAL_STR: {
       const char **ptr = (const char **) addr;
       for (uint32_t i = 0; i < num; i++)
         dds_stream_write_stringBO (os, ptr[i]);
-      ops += 3 + (subtype == DDS_OP_VAL_BSP ? 2 : 0);
+      ops += 3;
       break;
     }
     case DDS_OP_VAL_BST: {
@@ -204,7 +204,7 @@ static const uint32_t *dds_stream_write_uniBO (DDS_OSTREAM_T * __restrict os, co
       case DDS_OP_VAL_2BY: dds_os_put2BO (os, *(const uint16_t *) valaddr); break;
       case DDS_OP_VAL_4BY: case DDS_OP_VAL_ENU: dds_os_put4BO (os, *(const uint32_t *) valaddr); break;
       case DDS_OP_VAL_8BY: dds_os_put8BO (os, *(const uint64_t *) valaddr); break;
-      case DDS_OP_VAL_STR: case DDS_OP_VAL_BSP: dds_stream_write_stringBO (os, *(const char **) valaddr); break;
+      case DDS_OP_VAL_STR: dds_stream_write_stringBO (os, *(const char **) valaddr); break;
       case DDS_OP_VAL_BST: dds_stream_write_stringBO (os, (const char *) valaddr); break;
       case DDS_OP_VAL_SEQ: case DDS_OP_VAL_ARR:
         (void) dds_stream_writeBO (os, valaddr, jeq_op + DDS_OP_ADR_JSR (jeq_op[0]));
@@ -322,7 +322,6 @@ const uint32_t *dds_stream_writeBO (DDS_OSTREAM_T * __restrict os, const char * 
           case DDS_OP_VAL_4BY: dds_os_put4BO (os, *((const uint32_t *) addr)); ops += 2; break;
           case DDS_OP_VAL_8BY: dds_os_put8BO (os, *((const uint64_t *) addr)); ops += 2; break;
           case DDS_OP_VAL_STR: dds_stream_write_stringBO (os, *((const char **) addr)); ops += 2; break;
-          case DDS_OP_VAL_BSP: dds_stream_write_stringBO (os, *((const char **) addr)); ops += 3; break;
           case DDS_OP_VAL_BST: dds_stream_write_stringBO (os, (const char *) addr); ops += 3; break;
           case DDS_OP_VAL_SEQ: ops = dds_stream_write_seqBO (os, addr, ops, insn); break;
           case DDS_OP_VAL_ARR: ops = dds_stream_write_arrBO (os, addr, ops, insn); break;

--- a/src/tools/idlc/src/descriptor.c
+++ b/src/tools/idlc/src/descriptor.c
@@ -177,7 +177,7 @@ stash_opcode(
   struct instruction inst = { OPCODE, { .opcode = { .code = code, .order = order } } };
   const struct alignment *alignment = NULL;
 
-  if (code | DDS_OP_FLAG_EXT) {
+  if (code & DDS_OP_FLAG_EXT) {
     descriptor->flags |= DDS_TOPIC_NO_OPTIMIZE;
     descriptor->alignment = max_alignment(descriptor->alignment, ALIGNMENT_PTR);
   }
@@ -206,8 +206,10 @@ stash_opcode(
       descriptor->flags |= DDS_TOPIC_NO_OPTIMIZE;
       break;
     case DDS_OP_VAL_EXT:
+      /* External struct or union does not mean that the type is NO_OPTIMIZE
+         (if there is no FLAG_EXT). In case of a external union, the
+         NO_OPTIMIZE flag will be set when emitting opcodes for the union. */
       alignment = ALIGNMENT_1BY;
-      descriptor->flags |= DDS_TOPIC_NO_OPTIMIZE;
       break;
     case DDS_OP_VAL_8BY:
       alignment = ALIGNMENT_8BY;

--- a/src/tools/idlc/src/descriptor.c
+++ b/src/tools/idlc/src/descriptor.c
@@ -1539,7 +1539,6 @@ static int print_opcode(FILE *fp, const struct instruction *inst)
     case DDS_OP_VAL_8BY: vec[len++] = " | DDS_OP_TYPE_8BY"; break;
     case DDS_OP_VAL_STR: vec[len++] = " | DDS_OP_TYPE_STR"; break;
     case DDS_OP_VAL_BST: vec[len++] = " | DDS_OP_TYPE_BST"; break;
-    case DDS_OP_VAL_BSP: vec[len++] = " | DDS_OP_TYPE_BSP"; break;
     case DDS_OP_VAL_SEQ: vec[len++] = " | DDS_OP_TYPE_SEQ"; break;
     case DDS_OP_VAL_ARR: vec[len++] = " | DDS_OP_TYPE_ARR"; break;
     case DDS_OP_VAL_UNI: vec[len++] = " | DDS_OP_TYPE_UNI"; break;
@@ -1575,7 +1574,6 @@ static int print_opcode(FILE *fp, const struct instruction *inst)
       case DDS_OP_VAL_8BY: vec[len++] = " | DDS_OP_SUBTYPE_8BY"; break;
       case DDS_OP_VAL_STR: vec[len++] = " | DDS_OP_SUBTYPE_STR"; break;
       case DDS_OP_VAL_BST: vec[len++] = " | DDS_OP_SUBTYPE_BST"; break;
-      case DDS_OP_VAL_BSP: vec[len++] = " | DDS_OP_SUBTYPE_BSP"; break;
       case DDS_OP_VAL_SEQ: vec[len++] = " | DDS_OP_SUBTYPE_SEQ"; break;
       case DDS_OP_VAL_ARR: vec[len++] = " | DDS_OP_SUBTYPE_ARR"; break;
       case DDS_OP_VAL_UNI: vec[len++] = " | DDS_OP_SUBTYPE_UNI"; break;
@@ -1878,7 +1876,7 @@ static idl_retcode_t get_ctype_keys_adr(
       case DDS_OP_VAL_2BY: size = align = 2; break;
       case DDS_OP_VAL_4BY: size = align = 4; break;
       case DDS_OP_VAL_8BY: size = align = 8; break;
-      case DDS_OP_VAL_BST: case DDS_OP_VAL_BSP: {
+      case DDS_OP_VAL_BST: {
         assert(offs + 2 < ctype->instructions.count);
         assert(ctype->instructions.table[offs + 2].type == SINGLE);
         /* string size if stored as bound + 1 */
@@ -2123,7 +2121,7 @@ static int print_flags(FILE *fp, struct descriptor *descriptor)
         continue;
 
       uint32_t typecode = DDS_OP_TYPE(i.data.opcode.code);
-      if (typecode == DDS_OP_VAL_STR || typecode == DDS_OP_VAL_BST || typecode == DDS_OP_VAL_BSP ||typecode == DDS_OP_VAL_SEQ)
+      if (typecode == DDS_OP_VAL_STR || typecode == DDS_OP_VAL_BST ||typecode == DDS_OP_VAL_SEQ)
         fixed_size = false;
     }
   }

--- a/src/tools/idlc/src/descriptor.c
+++ b/src/tools/idlc/src/descriptor.c
@@ -177,6 +177,11 @@ stash_opcode(
   struct instruction inst = { OPCODE, { .opcode = { .code = code, .order = order } } };
   const struct alignment *alignment = NULL;
 
+  if (code | DDS_OP_FLAG_EXT) {
+    descriptor->flags |= DDS_TOPIC_NO_OPTIMIZE;
+    descriptor->alignment = max_alignment(descriptor->alignment, ALIGNMENT_PTR);
+  }
+
   descriptor->n_opcodes++;
   switch (DDS_OP(code)) {
     case DDS_OP_ADR:

--- a/src/tools/idlc/tests/descriptor.c
+++ b/src/tools/idlc/tests/descriptor.c
@@ -286,3 +286,52 @@ CU_Test(idlc_descriptor, keys_inheritance)
   }
 }
 #undef TEST_MAX_KEYS
+
+CU_Test(idlc_descriptor, no_optimize)
+{
+  static const struct {
+    bool no_optimize;
+    const char *idl;
+  } tests[] = {
+    { false, "@topic struct test { long f1; };" },
+    { false, "@topic struct test { long f1[100]; };" },
+    { false, "@topic struct test { long f1[100]; long f2; float f3; char f4; boolean f5; };" },
+    { false, "enum en { E0, E1 }; @topic struct test { en f1; };" },
+    { false, "bitmask bm { B0, B1 }; @topic struct test { bm f1; };" },
+    { false, "@nested struct s { long s1; }; @topic struct test { s f1; };" },
+    { false, "@nested struct s2 { char f3[100]; }; @nested struct s1 { s2 f2; }; @topic struct test { s1 f1; };" },
+    { true,  "@topic struct test { string f1; };" },
+    { true,  "@topic struct test { string<100> f1; };" },
+    { true,  "@topic struct test { sequence<long> f1; };" },
+    { true,  "@topic struct test { @external long f1; };" },
+    { true,  "@topic struct test { @external long f1[100]; };" },
+    { true,  "enum en { E0, E1 }; @topic struct test { @external en f1; };" },
+    { true,  "@nested struct s { long s1; }; @topic struct test { @external s f1; };" },
+    { true,  "@nested struct s { @external long s1; }; @topic struct test { s f1; };" },
+    { true,  "@topic union test switch(short) { case 1: long f1; };" },
+    { true,  "@nested union u switch(short) { case 1: long u1; }; @topic struct test { u f1; };" }
+  };
+
+  idl_retcode_t ret;
+  uint32_t flags = IDL_FLAG_EXTENDED_DATA_TYPES |
+                   IDL_FLAG_ANONYMOUS_TYPES |
+                   IDL_FLAG_ANNOTATIONS;
+  for (size_t i = 0; i < sizeof (tests) / sizeof (tests[0]); i++) {
+    static idl_pstate_t *pstate = NULL;
+    struct descriptor descriptor;
+
+    printf ("running test for idl: %s\n", tests[i].idl);
+
+    ret = idl_create_pstate (flags, NULL, &pstate);
+    CU_ASSERT_EQUAL_FATAL (ret, IDL_RETCODE_OK);
+
+    memset (&descriptor, 0, sizeof (descriptor)); /* static analyzer */
+    ret = generate_test_descriptor (pstate, tests[i].idl, &descriptor);
+    CU_ASSERT_EQUAL_FATAL (ret, IDL_RETCODE_OK);
+    CU_ASSERT_EQUAL_FATAL ((descriptor.flags & DDS_TOPIC_NO_OPTIMIZE) != 0, tests[i].no_optimize);
+
+    ret = descriptor_fini (&descriptor);
+    CU_ASSERT_EQUAL_FATAL (ret, IDL_RETCODE_OK);
+    idl_delete_pstate (pstate);
+  }
+}

--- a/src/tools/idlc/xtests/CMakeLists.txt
+++ b/src/tools/idlc/xtests/CMakeLists.txt
@@ -18,6 +18,8 @@ set(_sources
   test_struct_inherit.idl
   test_struct_inherit_appendable.idl
   test_struct_inherit_mutable.idl
+  test_struct_external.idl
+  test_union_external.idl
 #  test_struct_recursive.idl
 #  test_union_member_types.idl
 #  test_union_recursive.idl

--- a/src/tools/idlc/xtests/common.h
+++ b/src/tools/idlc/xtests/common.h
@@ -18,14 +18,62 @@
 #define STR16 "abcdef0123456789"
 #define STR128 STR16 STR16 STR16 STR16 STR16 STR16 STR16 STR16
 
+#define A(s) { (s) = dds_alloc (sizeof (*(s))); }
 #define SEQA(s,l) \
 { \
-  s._length = s._maximum = l; \
-  s._release = true; \
-  s._buffer = dds_alloc (l * sizeof (*s._buffer)); \
+  (s)._length = (s)._maximum = l; \
+  (s)._release = true; \
+  (s)._buffer = dds_alloc (l * sizeof (*(s)._buffer)); \
+}
+#define STRA(s,str) \
+{ \
+  (s) = dds_alloc (strlen(str) + 1); \
+  strcpy ((s), (str)); \
+}
+#define EXTA(s,n) \
+{ \
+  (s) = dds_alloc (sizeof (*(s))); \
+  *(s) = n; \
 }
 
-#define CMP(a,b,f,n) { if ((a->f) != n) return -2; if ((a->f) != (b->f)) return (a->f) > (b->f) ? 1 : -1; }
-#define CMPSTR(a,b,f,s) { if (strcmp(a->f, s)) return -2; if (strcmp((a->f), (b->f))) return strcmp((a->f), (b->f)); }
+#define CMP(a,b,f,n) { \
+  if ((a->f) != n) return -2; \
+  if ((a->f) != (b->f)) return (a->f) > (b->f) ? 1 : -1; \
+}
+#define CMPSTR(a,b,f,s) { \
+  if (strcmp(a->f, s)) return -2; \
+  if (strcmp((a->f), (b->f))) return strcmp((a->f), (b->f)); \
+}
+#define CMPEXT(a,b,f,n) { \
+  if ((a->f) && *(a->f) != n) return -2; \
+  if ((!(a->f) && (b->f)) || ((a->f) && !(b->f))) return 2; \
+  if (*(a->f) != *(b->f)) return *(a->f) > *(b->f) ? 1 : -1; \
+}
+#define CMPEXTF(a,b,f,f2,n) { \
+  if ((a->f) && (*(a->f)).f2 != n) return -2; \
+  if ((!(a->f) && (b->f)) || ((a->f) && !(b->f))) return 2; \
+  if ((*(a->f)).f2 != (*(b->f)).f2) return (*(a->f)).f2 > (*(b->f)).f2 ? 1 : -1; \
+}
+#define CMPEXTEXTF(a,b,f,f2,n) { \
+  if ((a->f) && (a->f)->f2 && *((a->f)->f2) != n) return -2; \
+  if ((!(a->f) && (b->f)) || ((a->f) && !(b->f))) return 2; \
+  if ((!((a->f)->f2) && ((b->f)->f2)) || (((a->f)->f2) && !((b->f)->f2))) return 3; \
+  if (*((a->f)->f2) != *((b->f)->f2)) return *((a->f)->f2) > *((b->f)->f2) ? 1 : -1; \
+}
+#define CMPEXTA(a,b,f,i,n) { \
+  if ((a->f) && (*(a->f))[i] != n) return -2; \
+  if ((!(a->f) && (b->f)) || ((a->f) && !(b->f))) return 2; \
+  if ((*(a->f))[i] != (*(b->f))[i]) return (*(a->f))[i] > (*(b->f))[i] ? 1 : -1; \
+}
+#define CMPEXTA2(a,b,f,i,i2,n) { \
+  if ((a->f) && (*(a->f))[i][i2] != n) return -2; \
+  if ((!(a->f) && (b->f)) || ((a->f) && !(b->f))) return 2; \
+  if ((*(a->f))[i][i2] != (*(b->f))[i][i2]) return (*(a->f))[i][i2] > (*(b->f))[i][i2] ? 1 : -1; \
+}
+#define CMPEXTSTR(a,b,f,s) { \
+  if ((a->f) && strcmp(*(a->f), s)) return -2; \
+  if ((!(a->f) && (b->f)) || ((a->f) && !(b->f))) return 2; \
+  if (strcmp(*(a->f), *(b->f))) return strcmp(*(a->f), *(b->f)); \
+}
 
 #endif /* CMP_H */

--- a/src/tools/idlc/xtests/common.h
+++ b/src/tools/idlc/xtests/common.h
@@ -70,6 +70,11 @@
   if ((!(a->f) && (b->f)) || ((a->f) && !(b->f))) return 2; \
   if ((*(a->f))[i][i2] != (*(b->f))[i][i2]) return (*(a->f))[i][i2] > (*(b->f))[i][i2] ? 1 : -1; \
 }
+#define CMPEXTAF(a,b,f,i,f2,n) { \
+  if ((a->f) && (*(a->f))[i].f2 != n) return -2; \
+  if ((!(a->f) && (b->f)) || ((a->f) && !(b->f))) return 2; \
+  if ((*(a->f))[i].f2 != (*(b->f))[i].f2) return (*(a->f))[i].f2 > (*(b->f))[i].f2 ? 1 : -1; \
+}
 #define CMPEXTSTR(a,b,f,s) { \
   if ((a->f) && strcmp(*(a->f), s)) return -2; \
   if ((!(a->f) && (b->f)) || ((a->f) && !(b->f))) return 2; \

--- a/src/tools/idlc/xtests/test_struct_external.idl
+++ b/src/tools/idlc/xtests/test_struct_external.idl
@@ -22,6 +22,10 @@ union u switch (short) {
  case 1: long u1;
 };
 
+typedef sequence<float> seqfloat_t;
+typedef sequence<long> seqlong_t;
+typedef sequence<seqlong_t> seqlong2_t;
+
 @topic @final
 struct test_ext {
     @external long f1;
@@ -31,9 +35,10 @@ struct test_ext {
     @external u f5;
     @external short f6[2];        // int16_t (* f6)[10]
     @external short f7[2][3];     // int16_t (* f7)[2][3]
-
-    // not yet supported
-    // @external sequence<short> f8;
+    @external sequence<short> f8;
+    @external seqfloat_t f9;
+    @external sequence<seqlong_t> f10;
+    @external seqlong2_t f11;
 };
 
 #else
@@ -50,24 +55,54 @@ void init_sample (void *s)
 {
   test_ext *s1 = (test_ext *) s;
   EXTA (s1->f1, 123);
+
   STRA (s1->f2, STR128);
+
   A (s1->f3);
   strcpy (*(s1->f3), STR128);
+
   A (s1->f4);
   (*s1->f4).b1 = 456;
+
   A (s1->f5);
   s1->f5->_d = 1;
   s1->f5->_u.u1 = 789;
+
   A (s1->f6);
   (*s1->f6)[0] = 321;
   (*s1->f6)[1] = 654;
+
   A (s1->f7);
   for (int n = 0; n < 6; n++)
     (*s1->f7)[n / 3][n % 3] = 1000 * n;
-  // s1->f8 = dds_alloc (sizeof (*s1->f8));
-  // SEQA(*(s1->f8), 3);
-  // for (int n = 0; n < 3; n++)
-  //   s1->f8->_buffer[n] = 100 * n;
+
+  A (s1->f8);
+  SEQA(*(s1->f8), 3);
+  for (int n = 0; n < 3; n++)
+    s1->f8->_buffer[n] = 100 * n;
+
+  A (s1->f9);
+  SEQA(*(s1->f9), 4);
+  for (int n = 0; n < 4; n++)
+    s1->f9->_buffer[n] = (float) (0.1 * (float) n);
+
+  A (s1->f10);
+  SEQA(*(s1->f10), 2);
+  for (int n = 0; n < 2; n++)
+  {
+    SEQA(s1->f10->_buffer[n], 2);
+    s1->f10->_buffer[n]._buffer[0] = 20 * n;
+    s1->f10->_buffer[n]._buffer[1] = 20 * n + 10;
+  }
+
+  A (s1->f11);
+  SEQA(*(s1->f11), 3);
+  for (int n = 0; n < 3; n++)
+  {
+    SEQA(s1->f11->_buffer[n], 10);
+    for (int m = 0; m < 10; m++)
+      s1->f11->_buffer[n]._buffer[m] = 123 * n + m;
+  }
 }
 
 int cmp_sample (const void *sa, const void *sb)
@@ -85,8 +120,20 @@ int cmp_sample (const void *sa, const void *sb)
   CMPEXTA (a, b, f6, 1, 654);
   for (int n = 0; n < 6; n++)
     CMPEXTA2 (a, b, f7, n / 3, n % 3, 1000 * n);
-  // for (int n = 0; n < 3; n++)
-  //   CMP(a, b, f8->_buffer[n], n);
+  for (int n = 0; n < 3; n++)
+    CMP(a, b, f8->_buffer[n], 100 * n);
+  for (int n = 0; n < 4; n++)
+    CMP(a, b, f9->_buffer[n], (float) (0.1 * (float) n));
+
+  for (int n = 0; n < 2; n++)
+  {
+    CMP(a, b, f10->_buffer[n]._buffer[0], 20 * n);
+    CMP(a, b, f10->_buffer[n]._buffer[1], 20 * n + 10);
+  }
+
+  for (int n = 0; n < 3; n++)
+    for (int m = 0; m < 10; m++)
+      CMP(a, b, f11->_buffer[n]._buffer[m], 123 * n + m);
 
   return 0;
 }

--- a/src/tools/idlc/xtests/test_struct_external.idl
+++ b/src/tools/idlc/xtests/test_struct_external.idl
@@ -1,0 +1,94 @@
+/*
+ * Copyright(c) 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+#if defined(__IDLC__)
+
+@nested @final
+struct b {
+    long b1;
+};
+
+@nested @final
+union u switch (short) {
+ case 1: long u1;
+};
+
+@topic @final
+struct test_ext {
+    @external long f1;
+    @external string f2;          // char * f2;
+    @external string<128> f3;     // char (* f3)[129];
+    @external b f4;
+    @external u f5;
+    @external short f6[2];        // int16_t (* f6)[10]
+    @external short f7[2][3];     // int16_t (* f7)[2][3]
+
+    // not yet supported
+    // @external sequence<short> f8;
+};
+
+#else
+
+#include "dds/ddsrt/heap.h"
+#include "common.h"
+#include "test_struct_external.h"
+
+const dds_topic_descriptor_t *desc = &test_ext_desc;
+void init_sample (void *s);
+int cmp_sample (const void *sa, const void *sb);
+
+void init_sample (void *s)
+{
+  test_ext *s1 = (test_ext *) s;
+  EXTA (s1->f1, 123);
+  STRA (s1->f2, STR128);
+  A (s1->f3);
+  strcpy (*(s1->f3), STR128);
+  A (s1->f4);
+  (*s1->f4).b1 = 456;
+  A (s1->f5);
+  s1->f5->_d = 1;
+  s1->f5->_u.u1 = 789;
+  A (s1->f6);
+  (*s1->f6)[0] = 321;
+  (*s1->f6)[1] = 654;
+  A (s1->f7);
+  for (int n = 0; n < 6; n++)
+    (*s1->f7)[n / 3][n % 3] = 1000 * n;
+  // s1->f8 = dds_alloc (sizeof (*s1->f8));
+  // SEQA(*(s1->f8), 3);
+  // for (int n = 0; n < 3; n++)
+  //   s1->f8->_buffer[n] = 100 * n;
+}
+
+int cmp_sample (const void *sa, const void *sb)
+{
+  test_ext *a = (test_ext *) sa;
+  test_ext *b = (test_ext *) sb;
+
+  CMPEXT (a, b, f1, 123);
+  CMPSTR (a, b, f2, STR128);
+  CMPEXTSTR (a, b, f3, STR128);
+  CMPEXTF (a, b, f4, b1, 456);
+  CMPEXTF (a, b, f5, _d, 1);
+  CMPEXTF (a, b, f5, _u.u1, 789);
+  CMPEXTA (a, b, f6, 0, 321);
+  CMPEXTA (a, b, f6, 1, 654);
+  for (int n = 0; n < 6; n++)
+    CMPEXTA2 (a, b, f7, n / 3, n % 3, 1000 * n);
+  // for (int n = 0; n < 3; n++)
+  //   CMP(a, b, f8->_buffer[n], n);
+
+  return 0;
+}
+
+#endif

--- a/src/tools/idlc/xtests/test_struct_inherit.idl
+++ b/src/tools/idlc/xtests/test_struct_inherit.idl
@@ -67,11 +67,11 @@ void init_sample (void *s)
   s1->parent.b1 = 123;
   s1->parent.parent.c1 = 234;
   s1->parent.parent.parent.d1 = 456;
-  s1->parent.parent.parent.d2 = dds_alloc (sizeof (*s1->parent.parent.parent.d2));
+  A (s1->parent.parent.parent.d2);
   s1->parent.parent.parent.d2->_d = 1;
   s1->parent.parent.parent.d2->_u.u1 = 789;
   s1->parent.b2.parent.d1 = 654;
-  s1->parent.b2.parent.d2 = dds_alloc (sizeof (*s1->parent.b2.parent.d2));
+  A (s1->parent.b2.parent.d2);
   s1->parent.b2.parent.d2->_d = 3;
   s1->parent.b2.parent.d2->_u.u2 = 765;
   s1->parent.b2.c1 = 321;

--- a/src/tools/idlc/xtests/test_union.idl
+++ b/src/tools/idlc/xtests/test_union.idl
@@ -49,9 +49,9 @@ void init_sample (void *s)
 {
   test_union *s1 = (test_union *) s;
   s1->_d = 2;
-  s1->_u.b.a2 = dds_alloc (sizeof (*s1->_u.b.a2));
+  A (s1->_u.b.a2);
   s1->_u.b.a2->_d = 2;
-  s1->_u.b.a2->_u.c1 = dds_alloc (sizeof (*s1->_u.b.a2->_u.c1));
+  A (s1->_u.b.a2->_u.c1);
   s1->_u.b.a2->_u.c1->_d = 1;
   s1->_u.b.a2->_u.c1->_u.a._d = 1;
   s1->_u.b.a2->_u.c1->_u.a._u.a1 = 123;

--- a/src/tools/idlc/xtests/test_union_external.idl
+++ b/src/tools/idlc/xtests/test_union_external.idl
@@ -1,0 +1,140 @@
+/*
+ * Copyright(c) 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+#if defined(__IDLC__)
+
+@nested @final
+struct struct_nested {
+    @external long b1;
+};
+
+@nested @final
+union union_nested switch (short) {
+ case 1: long n1;
+};
+
+@nested @final
+union test_union switch (short) {
+  case 1:
+    @external long u1;
+  case 2:
+    @external string u2;          // char * u2;
+  case 3:
+    @external string<128> u3;     // char (* u3)[129];
+  case 4:
+    @external struct_nested u4;
+  case 5:
+    @external union_nested u5;
+  case 6:
+    @external short u6[2];        // int16_t (* u6)[10]
+  case 7:
+    @external short u7[2][3];     // int16_t (* u7)[2][3]
+  // case 8:
+  //   @external sequence<short> u8;
+};
+
+@topic @final
+struct test_ext {
+  test_union f1;
+  test_union f2;
+  test_union f3;
+  test_union f4;
+  test_union f5;
+  test_union f6;
+  test_union f7;
+};
+
+#else
+
+#include "dds/ddsrt/heap.h"
+#include "common.h"
+#include "test_union_external.h"
+
+const dds_topic_descriptor_t *desc = &test_ext_desc;
+void init_sample (void *s);
+int cmp_sample (const void *sa, const void *sb);
+
+void init_sample (void *s)
+{
+  test_ext *s1 = (test_ext *) s;
+
+  s1->f1._d = 1;
+  EXTA (s1->f1._u.u1, 123);
+
+  s1->f2._d = 2;
+  STRA (s1->f2._u.u2, STR128);
+
+  s1->f3._d = 3;
+  A (s1->f3._u.u3);
+  strcpy (*(s1->f3._u.u3), STR128);
+
+  s1->f4._d = 4;
+  A (s1->f4._u.u4);
+  EXTA (s1->f4._u.u4->b1, 456);
+
+  s1->f5._d = 5;
+  A (s1->f5._u.u5);
+  s1->f5._u.u5->_d = 1;
+  s1->f5._u.u5->_u.n1 = 789;
+
+  s1->f6._d = 6;
+  A (s1->f6._u.u6);
+  (*s1->f6._u.u6)[0] = 321;
+  (*s1->f6._u.u6)[1] = 654;
+
+  s1->f7._d = 7;
+  A (s1->f7._u.u7);
+  for (int n = 0; n < 6; n++)
+    (*s1->f7._u.u7)[n / 3][n % 3] = 1000 * n;
+
+  // s1->f8 = dds_alloc (sizeof (*s1->f8));
+  // SEQA(*(s1->f8), 3);
+  // for (int n = 0; n < 3; n++)
+  //   s1->f8->_buffer[n] = 100 * n;
+}
+
+int cmp_sample (const void *sa, const void *sb)
+{
+  test_ext *a = (test_ext *) sa;
+  test_ext *b = (test_ext *) sb;
+
+  CMP (a, b, f1._d, 1);
+  CMPEXT (a, b, f1._u.u1, 123);
+
+  CMP (a, b, f2._d, 2);
+  CMPSTR (a, b, f2._u.u2, STR128);
+
+  CMP (a, b, f3._d, 3);
+  CMPEXTSTR (a, b, f3._u.u3, STR128);
+
+  CMP (a, b, f4._d, 4);
+  CMPEXTEXTF (a, b, f4._u.u4, b1, 456);
+
+  CMP (a, b, f5._d, 5);
+  CMPEXTF (a, b, f5._u.u5, _d, 1);
+  CMPEXTF (a, b, f5._u.u5, _u.n1, 789);
+
+  CMP (a, b, f6._d, 6);
+  CMPEXTA (a, b, f6._u.u6, 0, 321);
+  CMPEXTA (a, b, f6._u.u6, 1, 654);
+
+  CMP (a, b, f7._d, 7);
+  for (int n = 0; n < 6; n++)
+    CMPEXTA2 (a, b, f7._u.u7, n / 3, n % 3, 1000 * n);
+
+  // for (int n = 0; n < 3; n++)
+  //   CMP(a, b, f8->_buffer[n], n);
+
+  return 0;
+}
+
+#endif

--- a/src/tools/idlc/xtests/test_union_external.idl
+++ b/src/tools/idlc/xtests/test_union_external.idl
@@ -20,7 +20,12 @@ struct struct_nested {
 @nested @final
 union union_nested switch (short) {
  case 1: long n1;
+ default: char n2;
 };
+
+typedef string<128> str128_t;
+typedef union_nested union_nested_t;
+typedef sequence<long> seqlong_t;
 
 @nested @final
 union test_union switch (short) {
@@ -38,19 +43,19 @@ union test_union switch (short) {
     @external short u6[2];        // int16_t (* u6)[10]
   case 7:
     @external short u7[2][3];     // int16_t (* u7)[2][3]
-  // case 8:
-  //   @external sequence<short> u8;
+  case 8:
+    @external sequence<short> u8;
+  case 9:
+    @external str128_t u9;        // char (* u3)[129];
+  case 10:
+    @external union_nested_t u10;
+  case 11:
+    @external seqlong_t u11[2];
 };
 
 @topic @final
 struct test_ext {
-  test_union f1;
-  test_union f2;
-  test_union f3;
-  test_union f4;
-  test_union f5;
-  test_union f6;
-  test_union f7;
+  test_union f[11];
 };
 
 #else
@@ -67,39 +72,58 @@ void init_sample (void *s)
 {
   test_ext *s1 = (test_ext *) s;
 
-  s1->f1._d = 1;
-  EXTA (s1->f1._u.u1, 123);
+  s1->f[0]._d = 1;
+  EXTA (s1->f[0]._u.u1, 123);
 
-  s1->f2._d = 2;
-  STRA (s1->f2._u.u2, STR128);
+  s1->f[1]._d = 2;
+  STRA (s1->f[1]._u.u2, STR128);
 
-  s1->f3._d = 3;
-  A (s1->f3._u.u3);
-  strcpy (*(s1->f3._u.u3), STR128);
+  s1->f[2]._d = 3;
+  A (s1->f[2]._u.u3);
+  strcpy (*(s1->f[2]._u.u3), STR128);
 
-  s1->f4._d = 4;
-  A (s1->f4._u.u4);
-  EXTA (s1->f4._u.u4->b1, 456);
+  s1->f[3]._d = 4;
+  A (s1->f[3]._u.u4);
+  EXTA (s1->f[3]._u.u4->b1, 456);
 
-  s1->f5._d = 5;
-  A (s1->f5._u.u5);
-  s1->f5._u.u5->_d = 1;
-  s1->f5._u.u5->_u.n1 = 789;
+  s1->f[4]._d = 5;
+  A (s1->f[4]._u.u5);
+  s1->f[4]._u.u5->_d = 1;
+  s1->f[4]._u.u5->_u.n1 = 789;
 
-  s1->f6._d = 6;
-  A (s1->f6._u.u6);
-  (*s1->f6._u.u6)[0] = 321;
-  (*s1->f6._u.u6)[1] = 654;
+  s1->f[5]._d = 6;
+  A (s1->f[5]._u.u6);
+  (*s1->f[5]._u.u6)[0] = 321;
+  (*s1->f[5]._u.u6)[1] = 654;
 
-  s1->f7._d = 7;
-  A (s1->f7._u.u7);
+  s1->f[6]._d = 7;
+  A (s1->f[6]._u.u7);
   for (int n = 0; n < 6; n++)
-    (*s1->f7._u.u7)[n / 3][n % 3] = 1000 * n;
+    (*s1->f[6]._u.u7)[n / 3][n % 3] = 1000 * n;
 
-  // s1->f8 = dds_alloc (sizeof (*s1->f8));
-  // SEQA(*(s1->f8), 3);
-  // for (int n = 0; n < 3; n++)
-  //   s1->f8->_buffer[n] = 100 * n;
+  s1->f[7]._d = 8;
+  A (s1->f[7]._u.u8);
+  SEQA(*(s1->f[7]._u.u8), 3);
+  for (int n = 0; n < 3; n++)
+    s1->f[7]._u.u8->_buffer[n] = 100 * n;
+
+  s1->f[8]._d = 9;
+  A (s1->f[8]._u.u9);
+  strcpy (*(s1->f[8]._u.u9), STR128);
+
+  s1->f[9]._d = 10;
+  A (s1->f[9]._u.u10);
+  s1->f[9]._u.u10->_d = 3;
+  s1->f[9]._u.u10->_u.n2 = 'a';
+
+  s1->f[10]._d = 11;
+  A (s1->f[10]._u.u11);
+  for (int n = 0; n < 2; n++)
+  {
+    SEQA((*(s1->f[10]._u.u11))[n], 3);
+    for (int m = 0; m < 3; m++)
+      (*s1->f[10]._u.u11)[n]._buffer[m] = 100 * n + m;
+  }
 }
 
 int cmp_sample (const void *sa, const void *sb)
@@ -107,32 +131,45 @@ int cmp_sample (const void *sa, const void *sb)
   test_ext *a = (test_ext *) sa;
   test_ext *b = (test_ext *) sb;
 
-  CMP (a, b, f1._d, 1);
-  CMPEXT (a, b, f1._u.u1, 123);
+  CMP (a, b, f[0]._d, 1);
+  CMPEXT (a, b, f[0]._u.u1, 123);
 
-  CMP (a, b, f2._d, 2);
-  CMPSTR (a, b, f2._u.u2, STR128);
+  CMP (a, b, f[1]._d, 2);
+  CMPSTR (a, b, f[1]._u.u2, STR128);
 
-  CMP (a, b, f3._d, 3);
-  CMPEXTSTR (a, b, f3._u.u3, STR128);
+  CMP (a, b, f[2]._d, 3);
+  CMPEXTSTR (a, b, f[2]._u.u3, STR128);
 
-  CMP (a, b, f4._d, 4);
-  CMPEXTEXTF (a, b, f4._u.u4, b1, 456);
+  CMP (a, b, f[3]._d, 4);
+  CMPEXTEXTF (a, b, f[3]._u.u4, b1, 456);
 
-  CMP (a, b, f5._d, 5);
-  CMPEXTF (a, b, f5._u.u5, _d, 1);
-  CMPEXTF (a, b, f5._u.u5, _u.n1, 789);
+  CMP (a, b, f[4]._d, 5);
+  CMPEXTF (a, b, f[4]._u.u5, _d, 1);
+  CMPEXTF (a, b, f[4]._u.u5, _u.n1, 789);
 
-  CMP (a, b, f6._d, 6);
-  CMPEXTA (a, b, f6._u.u6, 0, 321);
-  CMPEXTA (a, b, f6._u.u6, 1, 654);
+  CMP (a, b, f[5]._d, 6);
+  CMPEXTA (a, b, f[5]._u.u6, 0, 321);
+  CMPEXTA (a, b, f[5]._u.u6, 1, 654);
 
-  CMP (a, b, f7._d, 7);
+  CMP (a, b, f[6]._d, 7);
   for (int n = 0; n < 6; n++)
-    CMPEXTA2 (a, b, f7._u.u7, n / 3, n % 3, 1000 * n);
+    CMPEXTA2 (a, b, f[6]._u.u7, n / 3, n % 3, 1000 * n);
 
-  // for (int n = 0; n < 3; n++)
-  //   CMP(a, b, f8->_buffer[n], n);
+  CMP (a, b, f[7]._d, 8);
+  for (int n = 0; n < 3; n++)
+    CMP(a, b, f[7]._u.u8->_buffer[n], 100 * n);
+
+  CMP (a, b, f[8]._d, 9);
+  CMPEXTSTR (a, b, f[8]._u.u9, STR128);
+
+  CMP (a, b, f[9]._d, 10);
+  CMPEXTF (a, b, f[9]._u.u10, _d, 3);
+  CMPEXTF (a, b, f[9]._u.u10, _u.n2, 'a');
+
+  CMP (a, b, f[10]._d, 11);
+  for (int n = 0; n < 2; n++)
+    for (int m = 0; m < 3; m++)
+      CMPEXTAF (a, b, f[10]._u.u11, n, _buffer[m], 100 * n + m);
 
   return 0;
 }

--- a/src/tools/idlc/xtests/test_union_member_types.idl
+++ b/src/tools/idlc/xtests/test_union_member_types.idl
@@ -84,7 +84,7 @@ void init_sample (void *s)
 
   // case 1: @external union_nested1 u1;
   t->s1._d = 1;
-  t->s1._u.u1 = dds_alloc (sizeof (*t->s1._u.u1));
+  A (t->s1._u.u1);
   t->s1._u.u1->_d = 6;
   strcpy(t->s1._u.u1->_u.u6, STR128);
 

--- a/src/tools/idlc/xtests/test_union_recursive.idl
+++ b/src/tools/idlc/xtests/test_union_recursive.idl
@@ -37,9 +37,9 @@ void init_sample (void *s)
 {
   union_test *t = (union_test *) s;
   t->_d = 1;
-  t->_u.u1 = dds_alloc (sizeof (*t->_u.u1));
+  A (t->_u.u1);
   t->_u.u1->_d = 1;
-  t->_u.u1->_u.u1 = dds_alloc (sizeof (*t->_u.u1->_u.u1));
+  A (t->_u.u1->_u.u1);
   t->_u.u1->_u.u1->_d = 2;
   t->_u.u1->_u.u1->_u.u2 = 3;
 }


### PR DESCRIPTION
This PR extends support for the @external annotation in the idl C generator and the CDR stream serializer. With these changes, the external annotation can be used on struct and union members. Applying the external annotation on collection element type is not supported yet. 