### PR TITLE
fuzz_config_init oss-fuzz integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,4 +326,8 @@ endif()
 
 add_subdirectory(docs)
 
+if(DEFINED ENV{LIB_FUZZING_ENGINE})
+  add_subdirectory(fuzz)
+endif()
+
 include(CMakeCPack.cmake)

--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -1,0 +1,19 @@
+#
+# Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+
+set(CMAKE_INSTALL_EXAMPLESDIR "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/fuzz")
+
+include("${CMAKE_SOURCE_DIR}/cmake/Modules/Generate.cmake")
+
+add_subdirectory(fuzz_config_init)
+# add_subdirectory(fuzz_process_msg)
+# add_subdirectory(fuzz_idlc)

--- a/fuzz/fuzz_config_init/CMakeLists.txt
+++ b/fuzz/fuzz_config_init/CMakeLists.txt
@@ -1,0 +1,26 @@
+#
+# Copyright(c) 2021 ADLINK Technology Limited and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+
+project(fuzz_config_init LANGUAGES C)
+cmake_minimum_required(VERSION 3.5)
+
+if(NOT TARGET CycloneDDS::ddsc)
+  # Find the CycloneDDS package.
+  find_package(CycloneDDS REQUIRED)
+endif()
+
+add_executable(fuzz_config_init fuzz_config_init.c)
+target_include_directories(
+  fuzz_config_init PRIVATE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../src/core/ddsc/src>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../src/core/ddsi/include>")
+target_link_libraries(fuzz_config_init CycloneDDS::ddsc $ENV{LIB_FUZZING_ENGINE})

--- a/fuzz/fuzz_config_init/fuzz_config_init.c
+++ b/fuzz/fuzz_config_init/fuzz_config_init.c
@@ -1,0 +1,131 @@
+/*
+ * Copyright(c) 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <dds/dds.h>
+
+#include "dds/ddsrt/heap.h"
+#include "dds/ddsi/ddsi_iid.h"
+#include "dds/ddsi/q_thread.h"
+#include "dds/ddsi/q_config.h"
+#include "dds/ddsi/ddsi_domaingv.h"
+#include "dds/ddsi/q_entity.h"
+#include "dds/ddsi/q_radmin.h"
+#include "dds/ddsi/ddsi_plist.h"
+#include "dds/ddsi/q_transmit.h"
+#include "dds/ddsi/q_xmsg.h"
+#include "dds/ddsi/q_addrset.h"
+#include "dds/ddsi/ddsi_tkmap.h"
+#include "dds/ddsi/ddsi_sertype.h"
+#include "dds/ddsi/ddsi_serdata.h"
+#include "dds/ddsi/ddsi_builtin_topic_if.h"
+#include "dds/ddsi/ddsi_security_omg.h"
+#include "dds/ddsi/ddsi_rhc.h"
+#include "dds/ddsi/ddsi_vnet.h"
+#include "dds/ddsi/ddsi_entity_index.h"
+#include "dds/ddsi/q_bswap.h"
+#include "dds__whc.h"
+#include "dds__types.h"
+
+static struct cfgst *cfgst;
+static struct ddsi_domaingv gv;
+static struct ddsi_config cfg;
+static ddsi_tran_conn_t fakeconn;
+static ddsi_tran_factory_t fakenet;
+static struct thread_state1 *ts1;
+static struct nn_rbufpool *rbpool;
+// static struct ddsi_tkmap_instance *tk;
+
+static void null_log_sink(void *varg, const dds_log_data_t *msg)
+{
+    (void)varg;
+    (void)msg;
+}
+
+static ssize_t fakeconn_write(ddsi_tran_conn_t conn, const ddsi_locator_t *dst, size_t niov, const ddsrt_iovec_t *iov, uint32_t flags)
+{
+    return (ssize_t)niov;
+}
+
+static ssize_t fakeconn_read(ddsi_tran_conn_t conn, unsigned char *buf, size_t len, bool allow_spurious, ddsi_locator_t *srcloc)
+{
+    return (ssize_t)len;
+}
+
+int LLVMFuzzerTestOneInput(
+    const uint8_t *data,
+    size_t size)
+{
+    if (!size)
+        return EXIT_FAILURE;
+
+    ddsi_iid_init();
+    thread_states_init(64);
+
+    memset(&dds_global, 0, sizeof(dds_global));
+    ddsrt_mutex_init(&dds_global.m_mutex);
+
+    ddsi_config_init_default(&gv.config);
+
+    memset(&gv, 0, sizeof(gv));
+
+    char *str = NULL;
+
+    if ((str = (char *)malloc(size + 1)) == NULL)
+        return EXIT_FAILURE;
+
+    memcpy(str, data, size);
+    str[size] = '\0';
+
+    if ((cfgst = config_init(str, &gv.config, 0)) == NULL)
+    {
+        free(str);
+
+        return EXIT_FAILURE;
+    }
+
+// #ifdef FULL_BLOWN_DDS
+//     rtps_config_prep(&gv, cfgst);
+//     dds_set_log_sink(null_log_sink, NULL);
+//     dds_set_trace_sink(null_log_sink, NULL);
+
+//     rtps_init(&gv);
+
+//     ddsi_vnet_init(&gv, "fake", 123);
+//     fakenet = ddsi_factory_find(&gv, "fake");
+//     ddsi_factory_create_conn(&fakeconn, fakenet, 0, &(const struct ddsi_tran_qos){.m_purpose = DDSI_TRAN_QOS_XMIT, .m_interface = &gv.interfaces[0]});
+//     fakeconn = ddsrt_realloc(fakeconn, sizeof(struct ddsi_tran_conn) + 128);
+//     fakeconn->m_read_fn = &fakeconn_read;
+//     fakeconn->m_write_fn = &fakeconn_write;
+
+//     rtps_start(&gv);
+
+//     ts1 = lookup_thread_state();
+//     ts1->state = THREAD_STATE_ALIVE;
+//     ddsrt_atomic_stvoidp(&ts1->gv, &gv);
+
+//     thread_state_awake(ts1, &gv);
+//     thread_state_asleep(ts1);
+
+//     rbpool = nn_rbufpool_new(&gv.logconfig, gv.config.rbuf_size, gv.config.rmsg_chunk_size);
+//     nn_rbufpool_setowner(rbpool, ddsrt_thread_self());
+
+//     rtps_fini(&gv);
+// #endif
+
+    free(str);
+    config_fini(cfgst);
+
+    return EXIT_SUCCESS;
+}

--- a/fuzz/fuzz_config_init/fuzz_config_init_seed_corpus/53e4bc7efc41dfee4f99dfc1238e16762c82398e
+++ b/fuzz/fuzz_config_init/fuzz_config_init_seed_corpus/53e4bc7efc41dfee4f99dfc1238e16762c82398e
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CycloneDDS xmlns="https://cdds.io/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://cdds.io/config https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/master/etc/cyclonedds.xsd">
+    <Domain id="any">
+        <General>
+            <NetworkInterfaceAddress>auto</NetworkInterfaceAddress>
+            <AllowMulticast>default</AllowMulticast>
+            <MaxMessageSize>65500B</MaxMessageSize>
+            <FragmentSize>4000B</FragmentSize>
+        </General>
+        <Internal>
+            <Watermarks>
+                <WhcHigh>500kB</WhcHigh>
+            </Watermarks>
+        </Internal>
+        <Tracing>
+            <Verbosity>config</Verbosity>
+            <OutputFile>stdout</OutputFile>
+        </Tracing>
+    </Domain>
+</CycloneDDS>

--- a/fuzz/oss-fuzz-build.sh
+++ b/fuzz/oss-fuzz-build.sh
@@ -1,0 +1,49 @@
+#!/bin/bash -eu
+
+#
+# Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+
+(
+mkdir build
+cd build
+cmake \
+    -DBUILD_IDLC=ON \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DBUILD_EXAMPLES=NO \
+    -DENABLE_SECURITY=NO \
+    -DCMAKE_INSTALL_PREFIX=/usr/local ..
+cmake --build . 
+cmake --build . --target install
+cd ..
+)
+
+function copy_fuzzer {
+  mkdir -p "$OUT/lib"
+  cp -v "$1" "$OUT/"
+  patchelf --set-rpath '$ORIGIN/lib' "$OUT/$(basename "$1")"
+
+  ldd "$1" | grep '=>' | cut -d ' ' -f 3 | while read lib; do
+    if [[ -f $lib ]]; then
+      cp -v "$lib" "$OUT/lib/"
+      patchelf --set-rpath '$ORIGIN' "$OUT/lib/$(basename "$lib")"
+    fi
+  done
+}
+
+# copy out stuff
+find build/bin -type f -name 'fuzz_*' | while read fuzzer; do
+    copy_fuzzer "$fuzzer"
+done
+
+find fuzz/ -type d -name 'fuzz_*_seed_corpus' | while read corpus_dir; do
+  zip -j $OUT/$(basename "$corpus_dir").zip $corpus_dir/*
+done

--- a/src/core/ddsi/include/dds/ddsi/q_gc.h
+++ b/src/core/ddsi/include/dds/ddsi/q_gc.h
@@ -49,6 +49,7 @@ DDS_EXPORT void gcreq_queue_drain (struct gcreq_queue *q);
 DDS_EXPORT void gcreq_queue_free (struct gcreq_queue *q);
 
 DDS_EXPORT struct gcreq *gcreq_new (struct gcreq_queue *gcreq_queue, gcreq_cb_t cb);
+DDS_EXPORT bool gcreq_queue_start (struct gcreq_queue *q);
 DDS_EXPORT void gcreq_free (struct gcreq *gcreq);
 DDS_EXPORT void gcreq_enqueue (struct gcreq *gcreq);
 DDS_EXPORT int gcreq_requeue (struct gcreq *gcreq, gcreq_cb_t cb);

--- a/src/core/ddsi/include/dds/ddsi/q_radmin.h
+++ b/src/core/ddsi/include/dds/ddsi/q_radmin.h
@@ -259,6 +259,7 @@ seqno_t nn_reorder_next_seq (const struct nn_reorder *reorder);
 void nn_reorder_set_next_seq (struct nn_reorder *reorder, seqno_t seq);
 
 struct nn_dqueue *nn_dqueue_new (const char *name, const struct ddsi_domaingv *gv, uint32_t max_samples, nn_dqueue_handler_t handler, void *arg);
+bool nn_dqueue_start (struct nn_dqueue *q);
 void nn_dqueue_free (struct nn_dqueue *q);
 bool nn_dqueue_enqueue_deferred_wakeup (struct nn_dqueue *q, struct nn_rsample_chain *sc, nn_reorder_result_t rres);
 void dd_dqueue_enqueue_trigger (struct nn_dqueue *q);

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -1844,12 +1844,12 @@ int rtps_init (struct ddsi_domaingv *gv)
   gv->sendq_running = false;
   ddsrt_mutex_init (&gv->sendq_running_lock);
 
-  gv->builtins_dqueue = nn_dqueue_new ("builtins", gv, gv->config.delivery_queue_maxsamples, builtins_dqueue_handler, NULL);
+  gv->builtins_dqueue = NULL;
 #ifdef DDS_HAS_NETWORK_CHANNELS
   for (struct ddsi_config_channel_listelem *chptr = gv->config.channels; chptr; chptr = chptr->next)
-    chptr->dqueue = nn_dqueue_new (chptr->name, &gv->config, gv->config.delivery_queue_maxsamples, user_dqueue_handler, NULL);
+    chptr->dqueue = NULL;
 #else
-  gv->user_dqueue = nn_dqueue_new ("user", gv, gv->config.delivery_queue_maxsamples, user_dqueue_handler, NULL);
+  gv->user_dqueue = NULL;
 #endif
 
   if (reset_deaf_mute_time.v < DDS_NEVER)
@@ -1956,6 +1956,14 @@ static void stop_all_xeventq_upto (struct ddsi_config_channel_listelem *chptr)
 
 int rtps_start (struct ddsi_domaingv *gv)
 {
+  gv->builtins_dqueue = nn_dqueue_new ("builtins", gv, gv->config.delivery_queue_maxsamples, builtins_dqueue_handler, NULL);
+#ifdef DDS_HAS_NETWORK_CHANNELS
+  for (struct ddsi_config_channel_listelem *chptr = gv->config.channels; chptr; chptr = chptr->next)
+    chptr->dqueue = nn_dqueue_new (chptr->name, &gv->config, gv->config.delivery_queue_maxsamples, user_dqueue_handler, NULL);
+#else
+  gv->user_dqueue = nn_dqueue_new ("user", gv, gv->config.delivery_queue_maxsamples, user_dqueue_handler, NULL);
+#endif
+
   if (xeventq_start (gv->xevents, NULL) < 0)
     return -1;
 #ifdef DDS_HAS_NETWORK_CHANNELS

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -1956,6 +1956,8 @@ static void stop_all_xeventq_upto (struct ddsi_config_channel_listelem *chptr)
 
 int rtps_start (struct ddsi_domaingv *gv)
 {
+  gcreq_queue_start (gv->gcreq_queue);
+
   gv->builtins_dqueue = nn_dqueue_new ("builtins", gv, gv->config.delivery_queue_maxsamples, builtins_dqueue_handler, NULL);
 #ifdef DDS_HAS_NETWORK_CHANNELS
   for (struct ddsi_config_channel_listelem *chptr = gv->config.channels; chptr; chptr = chptr->next)


### PR DESCRIPTION
New fuzzer and make files to build it. Everything is conditional to an env variable set by the google/oss-fuzz project, so nothing interferes with production code.

The fuzzers are only built if the `FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION` variable is set, as recommended by libFuzzer.

Previous commits by @eboasson are cherry picked from eboasson/cyclonedds and are needed for other fuzzers integrations (coming soon in a separate PR).