### PR TITLE
Fixes for coverity issues

### DIFF
--- a/src/core/ddsc/tests/cdrstream.c
+++ b/src/core/ddsc/tests/cdrstream.c
@@ -1360,7 +1360,8 @@ CU_Theory ((const char *descr, const dds_topic_descriptor_t *desc, sample_empty 
   entity_init (desc);
   dds_set_status_mask (rd, DDS_DATA_AVAILABLE_STATUS);
   dds_entity_t ws = dds_create_waitset (dp2);
-  dds_waitset_attach (ws, rd, rd);
+  ret = dds_waitset_attach (ws, rd, rd);
+  CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
 
   void * msg = sample_init_fn ();
 

--- a/src/core/ddsc/tests/qosmatch.c
+++ b/src/core/ddsc/tests/qosmatch.c
@@ -133,17 +133,24 @@ static void setqos (dds_qos_t *q, size_t i, bool isrd, bool create)
 static bool pubsub_qos_eq_h (const dds_qos_t *a, dds_entity_t ent)
 {
   dds_qos_t *b = dds_create_qos ();
-  dds_get_qos (ent, b);
-  /* internal interface is more luxurious that a simple compare for equality, and
-     using that here saves us a ton of code */
-  uint64_t delta = ddsi_xqos_delta (a, b, QP_GROUP_DATA | QP_PRESENTATION | QP_PARTITION);
-  if (delta)
+  uint64_t delta = 1;
+  struct ddsrt_log_cfg logcfg;
+  dds_log_cfg_init (&logcfg, 0, DDS_LC_ERROR, stderr, stderr);
+  if (dds_get_qos (ent, b) < 0)
   {
-    struct ddsrt_log_cfg logcfg;
-    dds_log_cfg_init (&logcfg, 0, DDS_LC_ERROR, stderr, stderr);
-    DDS_CLOG (DDS_LC_ERROR, &logcfg, "pub/sub: delta = %"PRIx64"\n", delta);
-    ddsi_xqos_log (DDS_LC_ERROR, &logcfg, a); DDS_CLOG (DDS_LC_ERROR, &logcfg, "\n");
-    ddsi_xqos_log (DDS_LC_ERROR, &logcfg, b); DDS_CLOG (DDS_LC_ERROR, &logcfg, "\n");
+    DDS_CLOG (DDS_LC_ERROR, &logcfg, "publisher/subscriber qos retrieval failure\n");
+  }
+  else
+  {
+    /* internal interface is more luxurious that a simple compare for equality, and
+       using that here saves us a ton of code */
+    delta = ddsi_xqos_delta (a, b, QP_GROUP_DATA | QP_PRESENTATION | QP_PARTITION);
+    if (delta)
+    {
+      DDS_CLOG (DDS_LC_ERROR, &logcfg, "pub/sub: delta = %"PRIx64"\n", delta);
+      ddsi_xqos_log (DDS_LC_ERROR, &logcfg, a); DDS_CLOG (DDS_LC_ERROR, &logcfg, "\n");
+      ddsi_xqos_log (DDS_LC_ERROR, &logcfg, b); DDS_CLOG (DDS_LC_ERROR, &logcfg, "\n");
+    }
   }
   dds_delete_qos (b);
   return delta == 0;
@@ -157,15 +164,22 @@ static uint64_t reader_qos_delta (const dds_qos_t *a, const dds_qos_t *b)
 static bool reader_qos_eq_h (const dds_qos_t *a, dds_entity_t ent)
 {
   dds_qos_t *b = dds_create_qos ();
-  dds_get_qos (ent, b);
-  uint64_t delta = reader_qos_delta (a, b);
-  if (delta)
+  uint64_t delta = 1;
+  struct ddsrt_log_cfg logcfg;
+  dds_log_cfg_init (&logcfg, 0, DDS_LC_ERROR, stderr, stderr);
+  if (dds_get_qos (ent, b) < 0)
   {
-    struct ddsrt_log_cfg logcfg;
-    dds_log_cfg_init (&logcfg, 0, DDS_LC_ERROR, stderr, stderr);
-    DDS_CLOG (DDS_LC_ERROR, &logcfg, "reader: delta = %"PRIx64"\n", delta);
-    ddsi_xqos_log (DDS_LC_ERROR, &logcfg, a); DDS_CLOG (DDS_LC_ERROR, &logcfg, "\n");
-    ddsi_xqos_log (DDS_LC_ERROR, &logcfg, b); DDS_CLOG (DDS_LC_ERROR, &logcfg, "\n");
+    DDS_CLOG (DDS_LC_ERROR, &logcfg, "reader qos retrieval failure\n");
+  }
+  else
+  {
+    delta = reader_qos_delta (a, b);
+    if (delta)
+    {
+      DDS_CLOG (DDS_LC_ERROR, &logcfg, "reader: delta = %"PRIx64"\n", delta);
+      ddsi_xqos_log (DDS_LC_ERROR, &logcfg, a); DDS_CLOG (DDS_LC_ERROR, &logcfg, "\n");
+      ddsi_xqos_log (DDS_LC_ERROR, &logcfg, b); DDS_CLOG (DDS_LC_ERROR, &logcfg, "\n");
+    }
   }
   dds_delete_qos (b);
   return delta == 0;
@@ -179,15 +193,22 @@ static uint64_t writer_qos_delta (const dds_qos_t *a, const dds_qos_t *b)
 static bool writer_qos_eq_h (const dds_qos_t *a, dds_entity_t ent)
 {
   dds_qos_t *b = dds_create_qos ();
-  dds_get_qos (ent, b);
-  uint64_t delta = writer_qos_delta (a, b);
-  if (delta)
+  uint64_t delta = 1;
+  struct ddsrt_log_cfg logcfg;
+  dds_log_cfg_init (&logcfg, 0, DDS_LC_ERROR, stderr, stderr);
+  if (dds_get_qos (ent, b) < 0)
   {
-    struct ddsrt_log_cfg logcfg;
-    dds_log_cfg_init (&logcfg, 0, DDS_LC_ERROR, stderr, stderr);
-    DDS_CLOG (DDS_LC_ERROR, &logcfg, "writer: delta = %"PRIx64"\n", delta);
-    ddsi_xqos_log (DDS_LC_ERROR, &logcfg, a); DDS_CLOG (DDS_LC_ERROR, &logcfg, "\n");
-    ddsi_xqos_log (DDS_LC_ERROR, &logcfg, b); DDS_CLOG (DDS_LC_ERROR, &logcfg, "\n");
+    DDS_CLOG (DDS_LC_ERROR, &logcfg, "writer qos retrieval failure\n");
+  }
+  else
+  {
+    delta = writer_qos_delta (a, b);
+    if (delta)
+    {
+      DDS_CLOG (DDS_LC_ERROR, &logcfg, "writer: delta = %"PRIx64"\n", delta);
+      ddsi_xqos_log (DDS_LC_ERROR, &logcfg, a); DDS_CLOG (DDS_LC_ERROR, &logcfg, "\n");
+      ddsi_xqos_log (DDS_LC_ERROR, &logcfg, b); DDS_CLOG (DDS_LC_ERROR, &logcfg, "\n");
+    }
   }
   dds_delete_qos (b);
   return delta == 0;

--- a/src/ddsrt/include/dds/ddsrt/bswap.h
+++ b/src/ddsrt/include/dds/ddsrt/bswap.h
@@ -30,21 +30,25 @@ enum ddsrt_byte_order_selector {
 
 DDS_INLINE_EXPORT inline uint16_t ddsrt_bswap2u (uint16_t x)
 {
+  /* coverity[byte_swapping]*/
   return (uint16_t) ((x >> 8) | (x << 8));
 }
 
 DDS_INLINE_EXPORT inline int16_t ddsrt_bswap2 (int16_t x)
 {
+  /* coverity[byte_swapping]*/
   return (int16_t) ddsrt_bswap2u ((uint16_t) x);
 }
 
 DDS_INLINE_EXPORT inline uint32_t ddsrt_bswap4u (uint32_t x)
 {
+  /* coverity[byte_swapping]*/
   return (x >> 24) | ((x >> 8) & 0xff00) | ((x << 8) & 0xff0000) | (x << 24);
 }
 
 DDS_INLINE_EXPORT inline int32_t ddsrt_bswap4 (int32_t x)
 {
+  /* coverity[byte_swapping]*/
   return (int32_t) ddsrt_bswap4u ((uint32_t) x);
 }
 
@@ -52,11 +56,13 @@ DDS_INLINE_EXPORT inline uint64_t ddsrt_bswap8u (uint64_t x)
 {
   const uint32_t newhi = ddsrt_bswap4u ((uint32_t) x);
   const uint32_t newlo = ddsrt_bswap4u ((uint32_t) (x >> 32));
+  /* coverity[byte_swapping]*/
   return ((uint64_t) newhi << 32) | (uint64_t) newlo;
 }
 
 DDS_INLINE_EXPORT inline int64_t ddsrt_bswap8 (int64_t x)
 {
+  /* coverity[byte_swapping]*/
   return (int64_t) ddsrt_bswap8u ((uint64_t) x);
 }
 

--- a/src/tools/idlc/src/descriptor.c
+++ b/src/tools/idlc/src/descriptor.c
@@ -858,11 +858,13 @@ emit_union(
 
     switch (((idl_union_t *)node)->extensibility.value) {
       case IDL_APPENDABLE:
-        stash_opcode(pstate, descriptor, &ctype->instructions, nop, DDS_OP_DLC, 0u);
+        if ((ret = stash_opcode(pstate, descriptor, &ctype->instructions, nop, DDS_OP_DLC, 0u)))
+          return ret;
         break;
       case IDL_MUTABLE:
         idl_error(pstate, idl_location(node), "Mutable unions are not supported yet");
-        // stash_opcode(pstate, descriptor, &ctype->instructions, nop, DDS_OP_PLC, 0u);
+        //if ((ret = stash_opcode(pstate, descriptor, &ctype->instructions, nop, DDS_OP_PLC, 0u)))
+        //  return ret;
         return IDL_RETCODE_UNSUPPORTED;
       case IDL_FINAL:
         break;
@@ -938,10 +940,12 @@ emit_struct(
 
     switch (((idl_struct_t *)node)->extensibility.value) {
       case IDL_APPENDABLE:
-        stash_opcode(pstate, descriptor, &ctype->instructions, nop, DDS_OP_DLC, 0u);
+        if ((ret = stash_opcode(pstate, descriptor, &ctype->instructions, nop, DDS_OP_DLC, 0u)))
+          return ret;
         break;
       case IDL_MUTABLE:
-        stash_opcode(pstate, descriptor, &ctype->instructions, nop, DDS_OP_PLC, 0u);
+        if ((ret = stash_opcode(pstate, descriptor, &ctype->instructions, nop, DDS_OP_PLC, 0u)))
+          return ret;
         ctype->pl_offset = ctype->instructions.count;
         break;
       case IDL_FINAL:
@@ -1057,9 +1061,9 @@ add_mutable_member_offset(
       - ctype->pl_offset /* offset of first op after PLC */
       + 2 /* skip this JEQ and member id */
       + 1 /* skip RTS (of the PLC list) */);
-  if ((ret = stash_member_offset(pstate, &ctype->instructions, ctype->pl_offset++, addr_offs)))
+  if ((ret = stash_member_offset(pstate, &ctype->instructions, ctype->pl_offset++, addr_offs)) ||
+      (ret = stash_single(pstate, &ctype->instructions, ctype->pl_offset++, decl->id.value)))
     return ret;
-  stash_single(pstate, &ctype->instructions, ctype->pl_offset++, decl->id.value);
 
   /* update offset for previous members for this ctype */
   struct instruction *table = ctype->instructions.table;


### PR DESCRIPTION
Fixes for the following reported coverity issues:
- unchecked return values
- conditional check which will never be done
- data tainting through byte swapping