### PR TITLE
LwIP return all interfaces from getifaddrs

### DIFF
--- a/src/ddsrt/src/ifaddrs/lwip/ifaddrs.c
+++ b/src/ddsrt/src/ifaddrs/lwip/ifaddrs.c
@@ -199,7 +199,7 @@ again:
   }
 
   if (rc == DDS_RETCODE_OK) {
-    *ifap = ifa;
+    *ifap = root_ifa;
   } else {
     ddsrt_freeifaddrs(root_ifa);
   }


### PR DESCRIPTION
Before it returned only the last one in the list.

This also fixes a small memory leak each time Cyclone DDS is
de-initialized when using LwIP on a platform with multiple network
interfaces.

Fixes #1014. Thanks @elrussovic!