### PR TITLE
Correct encoding in serialization to shared memory

### DIFF
--- a/src/core/ddsc/src/dds_write.c
+++ b/src/core/ddsc/src/dds_write.c
@@ -521,7 +521,7 @@ static bool fill_iox_chunk(dds_writer *wr, const void *sample, void *iox_chunk,
     iox_header->shm_data_state = IOX_CHUNK_CONTAINS_RAW_DATA;
   } else {
     size_t size = iox_header->data_size;
-    ret = ddsi_sertype_serialize_into(wr->m_topic->m_stype, sample, iox_chunk, size);
+    ret = ddsi_sertype_serialize_into(wr->m_wr->type, sample, iox_chunk, size);
     if(ret) {
       iox_header->shm_data_state = IOX_CHUNK_CONTAINS_SERIALIZED_DATA;
     } else {

--- a/src/core/ddsi/src/ddsi_sertype_default.c
+++ b/src/core/ddsi/src/ddsi_sertype_default.c
@@ -211,11 +211,12 @@ static struct ddsi_sertype * sertype_default_derive_sertype (const struct ddsi_s
 }
 
 // move to cdr_stream?
-static dds_ostream_t ostream_from_buffer(void *buffer, size_t size) {
+static dds_ostream_t ostream_from_buffer(void *buffer, size_t size, uint16_t encoding_version) {
   dds_ostream_t os;
   os.m_buffer = buffer;
   os.m_size = (uint32_t) size;
   os.m_index = 0;
+  os.m_xcdr_version = encoding_version;
   return os;
 }
 
@@ -239,8 +240,8 @@ static size_t sertype_default_get_serialized_size (
 }
 
 static bool sertype_default_serialize_into (const struct ddsi_sertype *type, const void *sample, void* dst_buffer, size_t dst_size) {
-  dds_ostream_t os = ostream_from_buffer(dst_buffer, dst_size);
   const struct ddsi_sertype_default *type_default = (const struct ddsi_sertype_default *)type;
+  dds_ostream_t os = ostream_from_buffer(dst_buffer, dst_size, type_default->encoding_version);
   dds_stream_write_sample(&os, sample, type_default);
   return true;
 }


### PR DESCRIPTION
This improvement was exposed by coverity issue 342212 and should fix
it as well
Add initialization of all dds_ostream_t members
Correct m_xcdr_version member initialization: this was not initialized
previously
Also the type information of the topic was passed, the writer type
information is used now, as this can be independant from the topic

Signed-off-by: Martijn Reicher <martijn.reicher@adlinktech.com>