### PR TITLE
Use SO_REUSEPORT whenever it's defined instead of sniffing platform

### DIFF
--- a/src/core/ddsi/src/ddsi_tcp.c
+++ b/src/core/ddsi/src/ddsi_tcp.c
@@ -176,9 +176,11 @@ static void ddsi_tcp_sock_free (struct ddsi_domaingv const * const gv, ddsrt_soc
 static dds_return_t ddsi_tcp_sock_new (struct ddsi_tran_factory_tcp * const fact, ddsrt_socket_t *sock, uint16_t port)
 {
   struct ddsi_domaingv const * const gv = fact->fact.gv;
-  const int one = 1;
   union addr socketname;
   dds_return_t rc;
+#if defined SO_NOSIGPIPE || defined TCP_NODELAY
+  const int one = 1;
+#endif
 
   memset (&socketname, 0, sizeof (socketname));
   switch (fact->m_kind)
@@ -204,11 +206,17 @@ static dds_return_t ddsi_tcp_sock_new (struct ddsi_tran_factory_tcp * const fact
     goto fail;
   }
 
-  /* REUSEADDR if we're binding to a port number */
-  if (port && (rc = ddsrt_setsockopt (*sock, SOL_SOCKET, SO_REUSEADDR, &one, sizeof (one))) != DDS_RETCODE_OK)
-  {
-    GVERROR ("ddsi_tcp_sock_new: failed to enable address reuse: %s\n", dds_strretcode (rc));
-    goto fail_w_socket;
+  /* If we're binding to a port number, allow others to bind to the same port */
+  if (port && (rc = ddsrt_setsockreuse (*sock, true)) != DDS_RETCODE_OK) {
+    if (rc != DDS_RETCODE_UNSUPPORTED) {
+      GVERROR ("ddsi_tcp_sock_new: failed to enable port reuse: %s\n", dds_strretcode(rc));
+      goto fail_w_socket;
+    } else {
+      // If the network stack doesn't support it, do make it fairly easy to find out,
+      // but don't always print it to stderr because it would likely be more annoying
+      // than helpful.
+      GVLOG (DDS_LC_CONFIG, "ddsi_tcp_sock_new: port reuse not supported by network stack\n");
+    }
   }
 
   if ((rc = ddsrt_bind (*sock, &socketname.a, ddsrt_sockaddr_get_size (&socketname.a))) != DDS_RETCODE_OK)

--- a/src/ddsrt/include/dds/ddsrt/sockets.h
+++ b/src/ddsrt/include/dds/ddsrt/sockets.h
@@ -113,7 +113,7 @@ DDS_EXPORT dds_return_t
 ddsrt_getsockopt(
   ddsrt_socket_t sock,
   int32_t level, /* SOL_SOCKET */
-  int32_t optname, /* SO_REUSEADDR, SO_DONTROUTE, SO_BROADCAST, SO_SNDBUF, SO_RCVBUF */
+  int32_t optname, /* SO_REUSEADDR, SO_DONTROUTE, SO_BROADCAST, SO_SNDBUF, SO_RCVBUF, ... */
   void *optval,
   socklen_t *optlen);
 
@@ -121,7 +121,7 @@ DDS_EXPORT dds_return_t
 ddsrt_setsockopt(
   ddsrt_socket_t sock,
   int32_t level, /* SOL_SOCKET */
-  int32_t optname, /* SO_REUSEADDR, SO_DONTROUTE, SO_BROADCAST, SO_SNDBUF, SO_RCVBUF */
+  int32_t optname, /* SO_REUSEADDR, SO_DONTROUTE, SO_BROADCAST, SO_SNDBUF, SO_RCVBUF, ... */
   const void *optval,
   socklen_t optlen);
 
@@ -146,6 +146,33 @@ DDS_EXPORT dds_return_t
 ddsrt_setsocknonblocking(
   ddsrt_socket_t sock,
   bool nonblock);
+
+/**
+ * @brief Set whether a port may be shared with other sockets
+ *
+ * Maps to SO_REUSEPORT (if defined) followed by SO_REUSEADDR
+ *
+ * @param[in]   sock  Socket to set reusability for.
+ * @param[in]   reuse Whether to allow sharing the address/port.
+ *
+ * @returns A dds_return_t indicating success or failure.
+ *
+ * @retval DDS_RETCODE_OK
+ *             SO_REUSEPORT successfully set, or not defined,
+ *             or returned ENOPROTOOPT
+ *             SO_REUSEADDR successfully set
+ * @retval DDS_RETCODE_UNSUPPORTED
+ *             Network stack doesn't support SO_REUSEADDR and
+ *             returned ENOPROTOOPT
+ * @retval DDS_RETCODE_BAD_PARAMETER
+ *             Bad things happened (e.g., not a socket)
+ * @retval DDS_RETCODE_ERROR
+ *             An unknown error occurred.
+ */
+DDS_EXPORT dds_return_t
+ddsrt_setsockreuse(
+  ddsrt_socket_t sock,
+  bool reuse);
 
 DDS_EXPORT int32_t
 ddsrt_select(

--- a/src/ddsrt/src/sockets.c
+++ b/src/ddsrt/src/sockets.c
@@ -427,3 +427,23 @@ ddsrt_gethostbyname(const char *name, int af, ddsrt_hostent_t **hentp)
 }
 #endif /* DDSRT_HAVE_GETADDRINFO */
 #endif /* DDSRT_HAVE_DNS */
+
+dds_return_t
+ddsrt_setsockreuse(ddsrt_socket_t sock, bool reuse)
+{
+  int flags = reuse;
+#ifdef SO_REUSEPORT
+  const dds_return_t rc = ddsrt_setsockopt (sock, SOL_SOCKET, SO_REUSEPORT, &flags, sizeof (flags));
+  switch (rc)
+  {
+    case DDS_RETCODE_UNSUPPORTED:
+      // e.g. LWIP, which defines SO_REUSEPORT but doesn't implement it.
+      //      note that we ignore this error because some systems use SO_REUSEADDR instead
+    case DDS_RETCODE_OK:
+      break;
+    default:
+      return rc;
+  }
+#endif
+  return ddsrt_setsockopt (sock, SOL_SOCKET, SO_REUSEADDR, &flags, sizeof (flags));
+}

--- a/src/ddsrt/src/sockets/windows/socket.c
+++ b/src/ddsrt/src/sockets/windows/socket.c
@@ -351,9 +351,10 @@ ddsrt_getsockopt(
       return DDS_RETCODE_NO_NETWORK;
     case WSAEFAULT:
     case WSAEINVAL:
-    case WSAENOPROTOOPT:
     case WSAENOTSOCK:
       return DDS_RETCODE_BAD_PARAMETER;
+    case WSAENOPROTOOPT:
+      return DDS_RETCODE_UNSUPPORTED;
     case WSAEINPROGRESS:
       return DDS_RETCODE_TRY_AGAIN;
     default:
@@ -397,9 +398,10 @@ ddsrt_setsockopt(
       return DDS_RETCODE_NO_NETWORK;
     case WSAEFAULT:
     case WSAEINVAL:
-    case WSAENOPROTOOPT:
     case WSAENOTSOCK:
       return DDS_RETCODE_BAD_PARAMETER;
+    case WSAENOPROTOOPT:
+      return DDS_RETCODE_UNSUPPORTED;
     case WSAEINPROGRESS:
       return DDS_RETCODE_IN_PROGRESS;
     default:


### PR DESCRIPTION
This is an update of + a few tiny changes to #494. This may be a sad record for a good PR ... apologies, @rotu!