### PR TITLE
Increase timeouts for some security tests

### DIFF
--- a/src/security/core/tests/access_control.c
+++ b/src/security/core/tests/access_control.c
@@ -214,7 +214,7 @@ CU_Theory(
   (const char * test_descr,
     int32_t perm1_not_before, int32_t perm1_not_after, int32_t perm2_not_before, int32_t perm2_not_after,
     uint32_t delay_perm, bool exp_pp1_fail, bool exp_pp2_fail, uint32_t write_read_dur, bool exp_read_fail),
-  ddssec_access_control, permissions_expiry, .timeout=30)
+  ddssec_access_control, permissions_expiry, .timeout=60)
 {
   print_test_msg ("running test permissions_expiry: %s\n", test_descr);
 
@@ -275,7 +275,7 @@ static dds_time_t ceiling_sec (dds_time_t t)
 #define PERM_EXP_INCR 2
 /* Tests permissions configuration expiry using multiple writers, to validate
    that a reader keeps receiving data from writers that have valid permissions config */
-CU_Test(ddssec_access_control, permissions_expiry_multiple, .timeout=20)
+CU_Test(ddssec_access_control, permissions_expiry_multiple, .timeout=60)
 {
   char topic_name[100];
   create_topic_name ("ddssec_access_control_", g_topic_nr++, topic_name, sizeof (topic_name));
@@ -446,7 +446,7 @@ CU_TheoryDataPoints(ddssec_access_control, hooks) = {
    not-allowed mode to force denial of a specified entity. */
 CU_Theory(
   (const char * init_fn, bool exp_pp_fail, bool exp_local_topic_fail, bool exp_remote_topic_fail, bool exp_wr_fail, bool exp_rd_fail, bool exp_wr_rd_sync_fail, bool exp_rd_wr_sync_fail),
-  ddssec_access_control, hooks, .timeout=60)
+  ddssec_access_control, hooks, .timeout=90)
 {
   for (int i = 0; i <= 1; i++)
   {
@@ -524,7 +524,7 @@ CU_TheoryDataPoints(ddssec_access_control, join_access_control) = {
    valid/invalid permissions for 2 participants. */
 CU_Theory(
   (const char * test_descr, bool join_ac_pp1, bool join_ac_pp2, bool perm_inv_pp1, bool perm_inv_pp2, bool exp_pp1_fail, bool exp_pp2_fail, bool exp_hs_fail),
-  ddssec_access_control, join_access_control, .timeout=30)
+  ddssec_access_control, join_access_control, .timeout=60)
 {
   print_test_msg ("running test join_access_control: %s\n", test_descr);
 
@@ -824,7 +824,7 @@ static void test_readwrite_protection (
 /* Test read/write access control by running test cases with different combinations
    of allow and deny rules for publishing and subscribing on a topic, and check correct
    working of the default policy. */
-CU_Test(ddssec_access_control, readwrite_protection, .timeout=60)
+CU_Test(ddssec_access_control, readwrite_protection, .timeout=90)
 {
   for (int allow_pub = 0; allow_pub <= 1; allow_pub++)
     for (int allow_sub = 0; allow_sub <= 1; allow_sub++)

--- a/src/security/core/tests/secure_communication.c
+++ b/src/security/core/tests/secure_communication.c
@@ -395,7 +395,7 @@ static void test_payload_secret(DDS_Security_ProtectionKind rtps_pk, DDS_Securit
 
 /* Test communication between 2 nodes for all combinations of RTPS, metadata (submsg)
    and payload protection kinds using a single reader and writer */
-CU_Test(ddssec_secure_communication, protection_kinds, .timeout = 120)
+CU_Test(ddssec_secure_communication, protection_kinds, .timeout = 150)
 {
   DDS_Security_ProtectionKind rtps_pk[] = { PK_N, PK_S, PK_E };
   DDS_Security_ProtectionKind metadata_pk[] = { PK_N, PK_S, PK_E };
@@ -414,7 +414,7 @@ CU_Test(ddssec_secure_communication, protection_kinds, .timeout = 120)
 
 /* Test communication between 2 nodes for all combinations of discovery and
    liveliness protection kinds using a single reader and writer */
-CU_Test(ddssec_secure_communication, discovery_liveliness_protection, .timeout = 60)
+CU_Test(ddssec_secure_communication, discovery_liveliness_protection, .timeout = 90)
 {
   DDS_Security_ProtectionKind discovery_pk[] = { PK_N, PK_S, PK_E };
   DDS_Security_ProtectionKind liveliness_pk[] = { PK_N, PK_S, PK_E };
@@ -429,7 +429,7 @@ CU_Test(ddssec_secure_communication, discovery_liveliness_protection, .timeout =
 
 /* Test that a specific character sequence from the plain data does not appear in
    encrypted payload, submessage or rtps message when protection kind is ENCRYPT*/
-CU_Test(ddssec_secure_communication, check_encrypted_secret, .timeout = 60)
+CU_Test(ddssec_secure_communication, check_encrypted_secret, .timeout = 90)
 {
   DDS_Security_ProtectionKind rtps_pk[] = { PK_N, PK_E, PK_EOA };
   DDS_Security_ProtectionKind metadata_pk[] = { PK_N, PK_E, PK_EOA };
@@ -453,7 +453,7 @@ CU_TheoryDataPoints(ddssec_secure_communication, multiple_readers) = {
     CU_DataPoints(size_t, 1, 3, 1, 3), /* number of participants per domain */
     CU_DataPoints(size_t, 3, 1, 3, 3), /* number of readers per participant */
 };
-CU_Theory((size_t n_dom, size_t n_pp, size_t n_rd), ddssec_secure_communication, multiple_readers, .timeout = 90, .disabled = false)
+CU_Theory((size_t n_dom, size_t n_pp, size_t n_rd), ddssec_secure_communication, multiple_readers, .timeout = 120, .disabled = false)
 {
   DDS_Security_ProtectionKind metadata_pk[] = { PK_N, PK_SOA, PK_EOA };
   DDS_Security_BasicProtectionKind payload_pk[] = { BPK_N, BPK_S, BPK_E };
@@ -475,7 +475,7 @@ CU_TheoryDataPoints(ddssec_secure_communication, multiple_readers_writers) = {
     CU_DataPoints(size_t, 1, 1, 2), /* number of writer domains */
     CU_DataPoints(size_t, 1, 3, 3), /* number of writers per domain */
 };
-CU_Theory((size_t n_rd_dom, size_t n_rd, size_t n_wr_dom, size_t n_wr), ddssec_secure_communication, multiple_readers_writers, .timeout = 60, .disabled = false)
+CU_Theory((size_t n_rd_dom, size_t n_rd, size_t n_wr_dom, size_t n_wr), ddssec_secure_communication, multiple_readers_writers, .timeout = 90, .disabled = false)
 {
   DDS_Security_ProtectionKind metadata_pk[] = { PK_SOA, PK_EOA };
   for (size_t metadata = 0; metadata < sizeof (metadata_pk) / sizeof (metadata_pk[0]); metadata++)


### PR DESCRIPTION
Based on a handful of CI runs, these tweaks appear to reduce the incidence of timeouts in the tests. The timeouts were originally chosen based on what worked in practice and bumping them a bit doesn't seem like it should introduce any new problems.

I have looked at changing it so each data point runs as a separate test with a separate timeout (that would then probably be the default 10s) but that's quite a project. That makes a few tweaks here and there worth a try.

Signed-off-by: Erik Boasson <eb@ilities.com>