### PR TITLE
Fix new proxy topic race

### DIFF
--- a/src/core/ddsc/src/dds_handles.c
+++ b/src/core/ddsc/src/dds_handles.c
@@ -205,9 +205,7 @@ int32_t dds_handle_delete (struct dds_handle_link *link)
   assert ((cf & HDL_PINCOUNT_MASK) == 1u);
 #endif
   ddsrt_mutex_lock (&handles.lock);
-  int x = ddsrt_hh_remove (handles.ht, link);
-  assert(x);
-  (void)x;
+  ddsrt_hh_remove_present (handles.ht, link);
   assert (handles.count > 0);
   handles.count--;
   ddsrt_mutex_unlock (&handles.lock);

--- a/src/core/ddsc/src/dds_rhc_default.c
+++ b/src/core/ddsc/src/dds_rhc_default.c
@@ -1074,17 +1074,13 @@ static void update_inst (struct rhc_instance *inst, const struct ddsi_writer_inf
 static void drop_instance_noupdate_no_writers (struct dds_rhc_default *__restrict rhc, struct rhc_instance * __restrict * __restrict instptr)
 {
   struct rhc_instance *inst = *instptr;
-  int ret;
   assert (inst_is_empty (inst));
 
   rhc->n_instances--;
   if (inst->isnew)
     rhc->n_new--;
 
-  ret = ddsrt_hh_remove (rhc->instances, inst);
-  assert (ret);
-  (void) ret;
-
+  ddsrt_hh_remove_present (rhc->instances, inst);
   free_empty_instance (inst, rhc);
   *instptr = NULL;
 }

--- a/src/core/ddsc/src/dds_topic.c
+++ b/src/core/ddsc/src/dds_topic.c
@@ -114,7 +114,7 @@ static void topic_guid_map_unref (struct ddsi_domaingv * const gv, const struct 
 
   if (m->refc == 0)
   {
-    ddsrt_hh_remove (ktp->topic_guid_map, m);
+    ddsrt_hh_remove_present (ktp->topic_guid_map, m);
     thread_state_awake (lookup_thread_state (), gv);
     (void) delete_topic (gv, &m->guid);
     thread_state_asleep (lookup_thread_state ());
@@ -378,7 +378,7 @@ static bool register_topic_type_for_discovery (struct ddsi_domaingv * const gv, 
       dds_return_t rc = ddsi_new_topic (&m->tp, &m->guid, pp_ddsi, ktp->name, sertype_registered, ktp->qos, is_builtin, &new_topic_def);
       assert (rc == DDS_RETCODE_OK); /* FIXME: can be out-of-resources at the very least */
       (void) rc;
-      ddsrt_hh_add (ktp->topic_guid_map, m);
+      ddsrt_hh_add_absent (ktp->topic_guid_map, m);
       thread_state_asleep (lookup_thread_state ());
     }
     else

--- a/src/core/ddsc/src/dds_whc.c
+++ b/src/core/ddsc/src/dds_whc.c
@@ -324,8 +324,7 @@ static void insert_whcn_in_hash (struct whc_impl *whc, struct whc_node *whcn)
   if (!ddsrt_ehh_add (whc->seq_hash, &e))
     assert (0);
 #else
-  if (!ddsrt_hh_add (whc->seq_hash, whcn))
-    assert (0);
+  ddsrt_hh_add_absent (whc->seq_hash, whcn);
 #endif
 }
 
@@ -337,8 +336,7 @@ static void remove_whcn_from_hash (struct whc_impl *whc, struct whc_node *whcn)
   if (!ddsrt_ehh_remove (whc->seq_hash, &e))
     assert (0);
 #else
-  if (!ddsrt_hh_remove (whc->seq_hash, whcn))
-    assert (0);
+  ddsrt_hh_remove_present (whc->seq_hash, whcn);
 #endif
 }
 
@@ -681,8 +679,7 @@ static void free_one_instance_from_idx (struct whc_impl *whc, seqno_t max_drop_s
 
 static void delete_one_instance_from_idx (struct whc_impl *whc, seqno_t max_drop_seq, struct whc_idxnode *idxn)
 {
-  if (!ddsrt_hh_remove (whc->idx_hash, idxn))
-    assert (0);
+  ddsrt_hh_remove_present (whc->idx_hash, idxn);
 #ifdef DDS_HAS_DEADLINE_MISSED
   deadline_unregister_instance_locked (&whc->deadline, &idxn->deadline);
 #endif
@@ -1365,8 +1362,7 @@ static int whc_default_insert (struct whc *whc_generic, seqno_t max_drop_seq, se
         newn->idxnode = idxn;
         newn->idxnode_pos = 0;
       }
-      if (!ddsrt_hh_add (whc->idx_hash, idxn))
-        assert (0);
+      ddsrt_hh_add_absent (whc->idx_hash, idxn);
 #ifdef DDS_HAS_DEADLINE_MISSED
       deadline_register_instance_locked (&whc->deadline, &idxn->deadline, ddsrt_time_monotonic ());
 #endif

--- a/src/core/ddsi/src/ddsi_sertype.c
+++ b/src/core/ddsi/src/ddsi_sertype.c
@@ -91,9 +91,7 @@ void ddsi_sertype_register_locked (struct ddsi_domaingv *gv, struct ddsi_sertype
   ddsrt_atomic_stvoidp (&sertype->gv, gv);
   ddsrt_atomic_fence_stst ();
   ddsrt_atomic_or32 (&sertype->flags_refc, DDSI_SERTYPE_REGISTERED);
-  int x = ddsrt_hh_add (gv->sertypes, sertype);
-  assert (x);
-  (void) x;
+  ddsrt_hh_add_absent (gv->sertypes, sertype);
 }
 
 void ddsi_sertype_unref_locked (struct ddsi_domaingv * const gv, struct ddsi_sertype *sertype)
@@ -110,7 +108,7 @@ void ddsi_sertype_unref_locked (struct ddsi_domaingv * const gv, struct ddsi_ser
     else
     {
       if (flags_refc1 & DDSI_SERTYPE_REGISTERED)
-        (void) ddsrt_hh_remove (gv->sertypes, sertype);
+        ddsrt_hh_remove_present (gv->sertypes, sertype);
       ddsi_sertype_free (sertype);
     }
   }

--- a/src/core/ddsi/src/ddsi_threadmon.c
+++ b/src/core/ddsi/src/ddsi_threadmon.c
@@ -249,9 +249,7 @@ void ddsi_threadmon_register_domain (struct ddsi_threadmon *sl, const struct dds
     tmdom->msg[0] = 0;
 
     ddsrt_mutex_lock (&sl->lock);
-    int x = ddsrt_hh_add (sl->domains, tmdom);
-    assert (x);
-    (void) x;
+    ddsrt_hh_add_absent (sl->domains, tmdom);
     ddsrt_mutex_unlock (&sl->lock);
   }
 }
@@ -265,7 +263,7 @@ void ddsi_threadmon_unregister_domain (struct ddsi_threadmon *sl, const struct d
     dummy.gv = gv;
     struct threadmon_domain *tmdom = ddsrt_hh_lookup (sl->domains, &dummy);
     assert (tmdom);
-    (void) ddsrt_hh_remove (sl->domains, tmdom);
+    ddsrt_hh_remove_present (sl->domains, tmdom);
     ddsrt_mutex_unlock (&sl->lock);
     ddsrt_free (tmdom);
   }

--- a/src/core/ddsi/src/ddsi_typelookup.c
+++ b/src/core/ddsi/src/ddsi_typelookup.c
@@ -123,7 +123,7 @@ static void tlm_ref_impl (struct ddsi_domaingv *gv, const type_identifier_t *typ
     memset (tlm, 0, sizeof (*tlm));
     tlm->state = TL_META_NEW;
     tlm->type_id = *tid;
-    ddsrt_hh_add (gv->tl_admin, tlm);
+    ddsrt_hh_add_absent (gv->tl_admin, tlm);
     GVTRACE (" new %p", tlm);
   }
   if (proxy_guid != NULL)
@@ -176,7 +176,7 @@ static void tlm_unref_impl_locked (struct ddsi_domaingv *gv, struct tl_meta *tlm
   if (--tlm->refc == 0)
   {
     GVTRACE (" remove tl_meta\n");
-    ddsrt_hh_remove (gv->tl_admin, tlm);
+    ddsrt_hh_remove_present (gv->tl_admin, tlm);
     tlm_fini (tlm);
   }
 }

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -152,7 +152,7 @@ static void unref_topic_definition_locked (struct ddsi_topic_definition *tpd, dd
 static void unref_topic_definition (struct ddsi_domaingv *gv, struct ddsi_topic_definition *tpd, ddsrt_wctime_t timestamp);
 static void delete_topic_definition_locked (struct ddsi_topic_definition *tpd, ddsrt_wctime_t timestamp);
 
-int proxy_topic_equal (const struct proxy_topic *proxy_tp_a, const struct proxy_topic *proxy_tp_b);
+static int proxy_topic_equal (const struct proxy_topic *proxy_tp_a, const struct proxy_topic *proxy_tp_b); // FIXME: ddsrt_nonnull_all?
 DDSI_LIST_GENERIC_PTR_DECL(inline, proxy_topic_list, struct proxy_topic *, ddsrt_attribute_unused);
 DDSI_LIST_GENERIC_PTR_CODE(inline, proxy_topic_list, struct proxy_topic *, proxy_topic_equal)
 #endif /* DDS_HAS_TOPIC_DISCOVERY */
@@ -5784,7 +5784,7 @@ static void delete_topic_definition_locked (struct ddsi_topic_definition *tpd, d
 
 /* PROXY-TOPIC --------------------------------------------------- */
 
-int proxy_topic_equal (const struct proxy_topic *proxy_tp_a, const struct proxy_topic *proxy_tp_b)
+static int proxy_topic_equal (const struct proxy_topic *proxy_tp_a, const struct proxy_topic *proxy_tp_b)
 {
   if (proxy_tp_a != NULL && proxy_tp_b != NULL)
     return topic_definition_equal (proxy_tp_a->definition, proxy_tp_b->definition);

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -146,11 +146,11 @@ static int gcreq_proxy_topic (struct proxy_participant *proxypp, struct proxy_to
 
 static struct ddsi_topic_definition *lookup_topic_definition_locked (struct ddsi_domaingv *gv, struct dds_qos *qos, const type_identifier_t *type_id, const struct ddsi_sertype *type, bool *new_tpd);
 static struct ddsi_topic_definition *lookup_topic_definition (struct ddsi_domaingv *gv, struct dds_qos *qos, const type_identifier_t *type_id, const struct ddsi_sertype *type, bool *new_tpd);
-static struct ddsi_topic_definition * ref_topic_definition_locked (struct ddsi_domaingv *gv, const struct ddsi_sertype *type, const type_identifier_t *type_id, struct dds_qos *qos, bool *is_new);
-static struct ddsi_topic_definition * ref_topic_definition (struct ddsi_domaingv *gv, const struct ddsi_sertype *type, const type_identifier_t *type_id, struct dds_qos *qos, bool *is_new);
-static void unref_topic_definition_locked (struct ddsi_topic_definition *tpd, ddsrt_wctime_t timestamp);
-static void unref_topic_definition (struct ddsi_domaingv *gv, struct ddsi_topic_definition *tpd, ddsrt_wctime_t timestamp);
-static void delete_topic_definition_locked (struct ddsi_topic_definition *tpd, ddsrt_wctime_t timestamp);
+static struct ddsi_topic_definition * ref_topic_definition_locked (struct ddsi_domaingv *gv, const struct ddsi_sertype *type, const type_identifier_t *type_id, struct dds_qos *qos, bool *is_new) ddsrt_nonnull ((1, 3, 4, 5));
+static struct ddsi_topic_definition * ref_topic_definition (struct ddsi_domaingv *gv, const struct ddsi_sertype *type, const type_identifier_t *type_id, struct dds_qos *qos, bool *is_new) ddsrt_nonnull ((1, 3, 4, 5));
+static void unref_topic_definition_locked (struct ddsi_topic_definition *tpd, ddsrt_wctime_t timestamp) ddsrt_nonnull_all;
+static void unref_topic_definition (struct ddsi_domaingv *gv, struct ddsi_topic_definition *tpd, ddsrt_wctime_t timestamp) ddsrt_nonnull_all;
+static void delete_topic_definition_locked (struct ddsi_topic_definition *tpd, ddsrt_wctime_t timestamp) ddsrt_nonnull_all;
 
 static int proxy_topic_equal (const struct proxy_topic *proxy_tp_a, const struct proxy_topic *proxy_tp_b); // FIXME: ddsrt_nonnull_all?
 DDSI_LIST_GENERIC_PTR_DECL(inline, proxy_topic_list, struct proxy_topic *, ddsrt_attribute_unused);

--- a/src/ddsrt/include/dds/ddsrt/hopscotch.h
+++ b/src/ddsrt/include/dds/ddsrt/hopscotch.h
@@ -53,14 +53,16 @@ struct ddsrt_hh_iter {
     uint32_t cursor;
 };
 
-DDS_EXPORT struct ddsrt_hh *ddsrt_hh_new (uint32_t init_size, ddsrt_hh_hash_fn hash, ddsrt_hh_equals_fn equals);
-DDS_EXPORT void ddsrt_hh_free (struct ddsrt_hh * __restrict hh);
-DDS_EXPORT void *ddsrt_hh_lookup (const struct ddsrt_hh * __restrict rt, const void * __restrict template);
-DDS_EXPORT int ddsrt_hh_add (struct ddsrt_hh * __restrict rt, const void * __restrict data);
-DDS_EXPORT int ddsrt_hh_remove (struct ddsrt_hh * __restrict rt, const void * __restrict template);
-DDS_EXPORT void ddsrt_hh_enum (struct ddsrt_hh * __restrict rt, void (*f) (void *a, void *f_arg), void *f_arg); /* may delete a */
-DDS_EXPORT void *ddsrt_hh_iter_first (struct ddsrt_hh * __restrict rt, struct ddsrt_hh_iter * __restrict iter); /* may delete nodes */
-DDS_EXPORT void *ddsrt_hh_iter_next (struct ddsrt_hh_iter * __restrict iter);
+DDS_EXPORT struct ddsrt_hh *ddsrt_hh_new (uint32_t init_size, ddsrt_hh_hash_fn hash, ddsrt_hh_equals_fn equals) ddsrt_nonnull_all;
+DDS_EXPORT void ddsrt_hh_free (struct ddsrt_hh * __restrict hh) ddsrt_nonnull_all;
+DDS_EXPORT void *ddsrt_hh_lookup (const struct ddsrt_hh * __restrict rt, const void * __restrict template) ddsrt_nonnull_all;
+DDS_EXPORT int ddsrt_hh_add (struct ddsrt_hh * __restrict rt, const void * __restrict data) ddsrt_nonnull_all;
+DDS_EXPORT int ddsrt_hh_remove (struct ddsrt_hh * __restrict rt, const void * __restrict template) ddsrt_nonnull_all;
+DDS_EXPORT void ddsrt_hh_add_absent (struct ddsrt_hh * __restrict rt, const void * __restrict data) ddsrt_nonnull_all;
+DDS_EXPORT void ddsrt_hh_remove_present (struct ddsrt_hh * __restrict rt, const void * __restrict template) ddsrt_nonnull_all;
+DDS_EXPORT void ddsrt_hh_enum (struct ddsrt_hh * __restrict rt, void (*f) (void *a, void *f_arg), void *f_arg) ddsrt_nonnull ((1, 2)); /* may delete a */
+DDS_EXPORT void *ddsrt_hh_iter_first (struct ddsrt_hh * __restrict rt, struct ddsrt_hh_iter * __restrict iter) ddsrt_nonnull_all; /* may delete nodes */
+DDS_EXPORT void *ddsrt_hh_iter_next (struct ddsrt_hh_iter * __restrict iter) ddsrt_nonnull_all;
 
 /* Concurrent version */
 struct ddsrt_chh;

--- a/src/ddsrt/src/hopscotch.c
+++ b/src/ddsrt/src/hopscotch.c
@@ -239,6 +239,20 @@ int ddsrt_hh_remove (struct ddsrt_hh * __restrict rt, const void * __restrict te
   return 0;
 }
 
+void ddsrt_hh_add_absent (struct ddsrt_hh * __restrict rt, const void * __restrict data)
+{
+  const int x = ddsrt_hh_add (rt, data);
+  assert (x);
+  (void) x;
+}
+
+void ddsrt_hh_remove_present (struct ddsrt_hh * __restrict rt, const void * __restrict template)
+{
+  const int x = ddsrt_hh_remove (rt, template);
+  assert (x);
+  (void) x;
+}
+
 void ddsrt_hh_enum (struct ddsrt_hh * __restrict rt, void (*f) (void *a, void *f_arg), void *f_arg)
 {
   uint32_t i;


### PR DESCRIPTION
The primary subject of this PR is that `new_proxy_topic` got a pointer to a topic definition by calling "lookup" (not the "_locked" version), which could result in allocating a new topic definition and adding it to the topic_defs hash table while initializing its refcount to 0.  The refcount would then later on be incremented (and outside the correct lock).

If a local topic with an identical definition were to be created and deleted in between creating the topic definition with refcount 0 in new_proxy_topic and the increment of the refcount, that local topic would reuse the definition.  Deleting the local topic would cause the refcount to drop to 0, and so the definition would be removed it from the hash table and freed.

The result is a dangling pointer in the proxy topic.

This requires both a local and a proxy topic with the same definition, because the local ones do the refcounting and hash table operations atomically, and all discovery work is strictly serialized in the dq.builtins thread.  So either by itself will not cause any trouble.

The secondary subject are some small housekeeping things that got triggered by the primary subject and that do not seem worth the effort of doing another PR.