### PR TITLE
Fix for using uninitialized bool in topickind_qos_match_p_lock

### DIFF
--- a/src/core/ddsi/src/ddsi_typelookup.c
+++ b/src/core/ddsi/src/ddsi_typelookup.c
@@ -239,6 +239,7 @@ static struct writer *get_typelookup_writer (const struct ddsi_domaingv *gv, uin
 bool ddsi_tl_request_type (struct ddsi_domaingv * const gv, const type_identifier_t *type_id)
 {
   ddsrt_mutex_lock (&gv->tl_admin_lock);
+  assert (!ddsi_typeid_none (type_id));
   struct tl_meta *tlm = ddsi_tl_meta_lookup_locked (gv, type_id);
   GVTRACE ("tl-req ");
   if (tlm->state != TL_META_NEW)

--- a/src/core/ddsi/src/q_qosmatch.c
+++ b/src/core/ddsi/src/q_qosmatch.c
@@ -159,6 +159,13 @@ bool qos_match_mask_p (
   assert ((wr_qos->present & musthave) == musthave);
 #endif
 
+#ifdef DDS_HAS_TYPE_DISCOVERY
+  if (rd_typeid_req_lookup != NULL)
+    *rd_typeid_req_lookup = false;
+  if (wr_typeid_req_lookup != NULL)
+    *wr_typeid_req_lookup = false;
+#endif
+
   mask &= rd_qos->present & wr_qos->present;
   *reason = DDS_INVALID_QOS_POLICY_ID;
   if ((mask & QP_TOPIC_NAME) && strcmp (rd_qos->topic_name, wr_qos->topic_name) != 0)
@@ -167,11 +174,6 @@ bool qos_match_mask_p (
     return false;
 
 #ifdef DDS_HAS_TYPE_DISCOVERY
-  if (rd_typeid_req_lookup != NULL)
-    *rd_typeid_req_lookup = false;
-  if (wr_typeid_req_lookup != NULL)
-    *wr_typeid_req_lookup = false;
-
   if (ddsi_typeid_none (rd_typeid) || ddsi_typeid_none (wr_typeid))
   {
     // Type id missing on either or both: automatic failure if "force type validation"


### PR DESCRIPTION
When matching endpoints, in the case the topic name or type name does not match and the remote endpoint does not include a type identifier, the bool variables that indicate if a type lookup request should be done are used uninitialized in `topickind_qos_match_p_lock`. This resulted in requesting type details for an empty type id.

This commit fixes the issue by initializing these boolean values to false in `qos_match_mask_p` before other checks are done.

This fixes the crash mentioned in https://github.com/eclipse-cyclonedds/cyclonedds-python/issues/41
