### PR TITLE
Don't try to use OpenSSL 1.0.2 on Windows x86 build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,7 +73,6 @@ strategy:
       image: macOS-10.15
       build_type: Release
       cc: clang
-    # disabled for now because 32-bit packages are missing
     'Windows 2019 with Visual Studio 2019 (Visual Studio 2017, Debug, x86)':
       arch: x86
       image: windows-2019

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,7 +77,6 @@ strategy:
     'Windows 2019 with Visual Studio 2019 (Visual Studio 2017, Debug, x86)':
       arch: x86
       image: windows-2019
-      conanfile: conanfile102.txt
       idlc_testing: off
       generator: 'Visual Studio 16 2019'
       toolset: v141


### PR DESCRIPTION
It looks like the use of OpenSSL 1.0.2 with the cross-build targetting
an older Visual Studio causes problems. No-one should be using OpenSSL
1.0.2 anymore, so if changing the build to OpenSSL 1.1 indeed makes the
problems go away, good.