### PR TITLE
Optional annotation support in IDLC and cdrstream serializer

### DIFF
--- a/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
@@ -202,9 +202,10 @@ enum dds_stream_typecode_primary {
 };
 #define DDS_OP_TYPE_BOO DDS_OP_TYPE_1BY
 
-/* This flag indicates that the type is used as external data (annotated with
-   the @external annotation in idl). It is stored in the most-significant bit
-   of the type part of the instruction. */
+/* This flag indicates that the type has external data (i.e. a mapped to a pointer type),
+   which can be the case because of (1) the @external annotation in idl or (2) the @optional
+   annotation (optional fields are also mapped to pointer types as described in the XTypes spec).
+   This flag is stored in the most-significant bit of the 'type' part of the serializer instruction. */
 #define DDS_OP_FLAG_EXT (1u << 23)
 
 
@@ -242,7 +243,8 @@ enum dds_stream_typecode_subtype {
 #define DDS_OP_FLAG_MU   (1u << 3) /* must-understand flag */
 #define DDS_OP_FLAG_BASE (1u << 4) /* jump to base type, used with PLM in mutable types and for
                                       the TYPE_EXT 'parent' member in final and appendable types */
-#define DDS_OP_FLAG_OPT  (1u << 5) /* optional flag, used with struct members */
+#define DDS_OP_FLAG_OPT  (1u << 5) /* optional flag, used with struct members. For non-string types,
+                                      an optional member also gets the FLAG_EXT, see above. */
 
 /* Topic descriptor flag values */
 #define DDS_TOPIC_FLAGS_MASK                    0x3fffffff  /* The 2 most significant bits are used for type extensibility */

--- a/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
@@ -88,7 +88,7 @@ enum dds_stream_opcode {
          max = max enum value
        followed by alen case labels: in JEQ format
 
-     [ADR, e | EXT,   0, f] [offset] [next-insn, elem-insn] [elem-size iff "external" flag e is set]
+     [ADR, e | EXT,   0, f] [offset] [next-insn, elem-insn] [elem-size iff "external" flag e is set, or flag f has DDS_OP_FLAG_OPT]
      [ADR, STU,   0, f] *** not supported
    where
      s            = subtype
@@ -96,6 +96,7 @@ enum dds_stream_opcode {
      f            = flags:
                     - key/not key (DDS_OP_FLAG_KEY)
                     - base type member, used with EXT type (DDS_OP_FLAG_BASE)
+                    - optional (DDS_OP_FLAG_OPT)
      [offset]     = field offset from start of element in memory
      [elem-size]  = element size in memory (elem-size is only included in case 'external' flag is set)
      [max-size]   = string bound + 1
@@ -241,6 +242,7 @@ enum dds_stream_typecode_subtype {
 #define DDS_OP_FLAG_MU   (1u << 3) /* must-understand flag */
 #define DDS_OP_FLAG_BASE (1u << 4) /* jump to base type, used with PLM in mutable types and for
                                       the TYPE_EXT 'parent' member in final and appendable types */
+#define DDS_OP_FLAG_OPT  (1u << 5) /* optional flag, used with struct members */
 
 /* Topic descriptor flag values */
 #define DDS_TOPIC_FLAGS_MASK                    0x3fffffff  /* The 2 most significant bits are used for type extensibility */

--- a/src/core/ddsc/src/dds__qos.h
+++ b/src/core/ddsc/src/dds__qos.h
@@ -52,7 +52,7 @@ extern "C" {
    QP_RESOURCE_LIMITS | QP_ADLINK_WRITER_DATA_LIFECYCLE |               \
    QP_CYCLONE_IGNORELOCAL | QP_PROPERTY_LIST | QP_DATA_REPRESENTATION)
 
-dds_return_t dds_ensure_valid_data_representation (dds_qos_t *qos, bool dynamic_type, bool topicqos);
+dds_return_t dds_ensure_valid_data_representation (dds_qos_t *qos, uint16_t min_xcdrv, bool topicqos);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsc/src/dds_qos.c
+++ b/src/core/ddsc/src/dds_qos.c
@@ -823,8 +823,9 @@ bool dds_qget_data_representation (const dds_qos_t * __restrict qos, uint32_t *n
   return true;
 }
 
-dds_return_t dds_ensure_valid_data_representation (dds_qos_t *qos, bool dynamic_type, bool topicqos)
+dds_return_t dds_ensure_valid_data_representation (dds_qos_t *qos, uint16_t min_xcdrv, bool topicqos)
 {
+  assert (min_xcdrv <= CDR_ENC_VERSION_2);
   if ((qos->present & QP_DATA_REPRESENTATION) && qos->data_representation.value.n > 0)
   {
     assert (qos->data_representation.value.ids != NULL);
@@ -835,7 +836,7 @@ dds_return_t dds_ensure_valid_data_representation (dds_qos_t *qos, bool dynamic_
         case DDS_DATA_REPRESENTATION_XML:
           return DDS_RETCODE_UNSUPPORTED;
         case DDS_DATA_REPRESENTATION_XCDR1:
-          if (dynamic_type)
+          if (min_xcdrv == CDR_ENC_VERSION_2)
             return DDS_RETCODE_BAD_PARAMETER;
           break;
         case DDS_DATA_REPRESENTATION_XCDR2:
@@ -847,7 +848,7 @@ dds_return_t dds_ensure_valid_data_representation (dds_qos_t *qos, bool dynamic_
   }
   else
   {
-    if (dynamic_type)
+    if (min_xcdrv == CDR_ENC_VERSION_2)
       dds_qset_data_representation (qos, 1, (dds_data_representation_id_t[]) { DDS_DATA_REPRESENTATION_XCDR2 });
     else if (!topicqos)
       dds_qset_data_representation (qos, 1, (dds_data_representation_id_t[]) { DDS_DATA_REPRESENTATION_XCDR1 });

--- a/src/core/ddsc/src/dds_reader.c
+++ b/src/core/ddsc/src/dds_reader.c
@@ -589,8 +589,7 @@ static dds_entity_t dds_create_reader_int (dds_entity_t participant_or_subscribe
     goto err_bad_qos;
   }
 
-  bool dynamic_types = tp->m_stype->dynamic_types;
-  if ((rc = dds_ensure_valid_data_representation (rqos, dynamic_types, false)) != 0)
+  if ((rc = dds_ensure_valid_data_representation (rqos, tp->m_stype->min_xcdrv, false)) != 0)
     goto err_data_repr;
 
   thread_state_awake (lookup_thread_state (), gv);

--- a/src/core/ddsc/src/dds_topic.c
+++ b/src/core/ddsc/src/dds_topic.c
@@ -624,8 +624,8 @@ dds_entity_t dds_create_topic (dds_entity_t participant, const dds_topic_descrip
      XCDR2 data representation is required and the only valid value for this QoS.
      If the data representation is not set in the QoS (or no QoS object provided), the allowed
      data representations are added to the QoS object. */
-  bool dynamic_type = dds_stream_has_dynamic_type (desc->m_ops);
-  if ((hdl = dds_ensure_valid_data_representation (tpqos, dynamic_type, true)) != 0)
+  uint16_t min_xcdrv = dds_stream_minimum_xcdr_version (desc->m_ops);
+  if ((hdl = dds_ensure_valid_data_representation (tpqos, min_xcdrv, true)) != 0)
     goto err_data_repr;
 
   assert (tpqos->present & QP_DATA_REPRESENTATION && tpqos->data_representation.value.n > 0);
@@ -650,7 +650,7 @@ dds_entity_t dds_create_topic (dds_entity_t participant, const dds_topic_descrip
   st->c.iox_size = desc->m_size;
 #endif
   st->c.fixed_size = (st->c.fixed_size || (desc->m_flagset & DDS_TOPIC_FIXED_SIZE)) ? 1u : 0u;
-  st->c.dynamic_types = dynamic_type ? 1u : 0u;
+  st->c.min_xcdrv = min_xcdrv;
   st->encoding_format = ddsi_sertype_get_encoding_format (DDS_TOPIC_TYPE_EXTENSIBILITY (desc->m_flagset));
   st->encoding_version = data_representation == DDS_DATA_REPRESENTATION_XCDR1 ? CDR_ENC_VERSION_1 : CDR_ENC_VERSION_2;
   st->serpool = ppent->m_domain->gv.serpool;

--- a/src/core/ddsc/src/dds_writer.c
+++ b/src/core/ddsc/src/dds_writer.c
@@ -373,8 +373,7 @@ dds_entity_t dds_create_writer (dds_entity_t participant_or_publisher, dds_entit
   if ((rc = ddsi_xqos_valid (&gv->logconfig, wqos)) < 0 || (rc = validate_writer_qos(wqos)) != DDS_RETCODE_OK)
     goto err_bad_qos;
 
-  bool dynamic_types = tp->m_stype->dynamic_types;
-  if ((rc = dds_ensure_valid_data_representation (wqos, dynamic_types, false)) != 0)
+  if ((rc = dds_ensure_valid_data_representation (wqos, tp->m_stype->min_xcdrv, false)) != 0)
     goto err_data_repr;
 
   assert (wqos->present & QP_DATA_REPRESENTATION && wqos->data_representation.value.n > 0);
@@ -417,7 +416,7 @@ dds_entity_t dds_create_writer (dds_entity_t participant_or_publisher, dds_entit
   wr->m_data_representation = data_representation;
 
 #ifdef DDS_HAS_SHM
-  assert(wqos->present & QP_LOCATOR_MASK);  
+  assert(wqos->present & QP_LOCATOR_MASK);
   if (!dds_writer_support_shm(&gv->config, wqos, tp))
     wqos->ignore_locator_type |= NN_LOCATOR_KIND_SHEM;
 #endif

--- a/src/core/ddsc/tests/CMakeLists.txt
+++ b/src/core/ddsc/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ idlc_generate(TARGET InstanceHandleTypes FILES InstanceHandleTypes.idl)
 idlc_generate(TARGET RWData FILES RWData.idl)
 idlc_generate(TARGET CreateWriter FILES CreateWriter.idl)
 idlc_generate(TARGET DataRepresentationTypes FILES DataRepresentationTypes.idl)
+idlc_generate(TARGET MinXcdrVersion FILES MinXcdrVersion.idl)
 
 set(ddsc_test_sources
     "basic.c"
@@ -107,7 +108,7 @@ if(iceoryx_binding_c_FOUND)
     "$<BUILD_INTERFACE:$<TARGET_PROPERTY:iceoryx_binding_c::iceoryx_binding_c,INTERFACE_INCLUDE_DIRECTORIES>>")
 endif()
 target_link_libraries(cunit_ddsc PRIVATE
-  RoundTrip Space TypesArrayKey WriteTypes InstanceHandleTypes RWData CreateWriter DataRepresentationTypes ddsc)
+  RoundTrip Space TypesArrayKey WriteTypes InstanceHandleTypes RWData CreateWriter DataRepresentationTypes MinXcdrVersion ddsc)
 
 # Setup environment for config-tests
 get_test_property(CUnit_ddsc_config_simple_udp ENVIRONMENT CUnit_ddsc_config_simple_udp_env)

--- a/src/core/ddsc/tests/MinXcdrVersion.idl
+++ b/src/core/ddsc/tests/MinXcdrVersion.idl
@@ -1,0 +1,58 @@
+/*
+ * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+module MinXcdrVersion {
+    @topic @final
+    struct t {
+        long f1;
+    };
+
+    @topic @final
+    struct t_nested {
+        t f1;
+    };
+
+    @topic @final
+    struct t_inherit : t {
+        long f2;
+    };
+
+    @topic @final
+    struct t_opt {
+        @optional long f1;
+    };
+
+    @topic @final
+    struct t_ext {
+        @external long f1;
+    };
+
+    @topic @appendable
+    struct t_append {
+        long f1;
+    };
+
+    @topic @mutable
+    struct t_mut {
+        long f1;
+    };
+
+    @topic @final
+    struct t_nested_mut {
+        t_mut f1;
+    };
+
+    @topic @final
+    struct t_nested_opt {
+        t_mut f1;
+    };
+
+};

--- a/src/core/ddsc/tests/cdrstream.c
+++ b/src/core/ddsc/tests/cdrstream.c
@@ -399,7 +399,7 @@ typedef struct TestIdl_MsgExt
 static const uint32_t TestIdl_MsgExt_ops [] =
 {
   /* TestIdl_MsgExt */
-  DDS_OP_ADR | DDS_OP_FLAG_EXT | DDS_OP_TYPE_STR, offsetof (TestIdl_MsgExt, f1),
+  DDS_OP_ADR | DDS_OP_TYPE_STR, offsetof (TestIdl_MsgExt, f1),
   DDS_OP_ADR | DDS_OP_FLAG_EXT | DDS_OP_TYPE_BST, offsetof (TestIdl_MsgExt, f2), 33u,
   DDS_OP_ADR | DDS_OP_FLAG_EXT | DDS_OP_TYPE_EXT, offsetof (TestIdl_MsgExt, f3), (4u << 16u) + 14u /* TestIdl_MsgExt_b */, sizeof (TestIdl_MsgExt_b),
   DDS_OP_ADR | DDS_OP_FLAG_EXT | DDS_OP_TYPE_ARR | DDS_OP_SUBTYPE_2BY | DDS_OP_FLAG_SGN, offsetof (TestIdl_MsgExt, f4), 3u,
@@ -481,6 +481,142 @@ static bool sample_equal_ext (void *s1, void *s2)
 static void sample_free_ext (void *s)
 {
   dds_stream_free_sample (s, TestIdl_MsgExt_desc.m_ops);
+  ddsrt_free (s);
+}
+
+/**********************************************
+ * External fields
+ **********************************************/
+
+typedef struct TestIdl_MsgOpt_b
+{
+  bool * b1;
+} TestIdl_MsgOpt_b;
+
+typedef struct TestIdl_MsgOpt_dds_sequence_b
+{
+  uint32_t _maximum;
+  uint32_t _length;
+  struct TestIdl_MsgOpt_b *_buffer;
+  bool _release;
+} TestIdl_MsgOpt_dds_sequence_b;
+
+typedef struct TestIdl_MsgOpt
+{
+  int32_t * f1;
+  char * f2;
+  struct TestIdl_MsgOpt_b * f3;
+  char (* f4)[33];
+  int32_t (* f5)[3];
+  TestIdl_MsgOpt_dds_sequence_b * f6;
+} TestIdl_MsgOpt;
+
+static const uint32_t TestIdl_MsgOpt_ops [] =
+{
+  /* TestIdl_MsgOpt */
+  DDS_OP_ADR | DDS_OP_FLAG_EXT | DDS_OP_TYPE_4BY | DDS_OP_FLAG_OPT | DDS_OP_FLAG_SGN, offsetof (TestIdl_MsgOpt, f1),
+  DDS_OP_ADR | DDS_OP_TYPE_STR | DDS_OP_FLAG_OPT, offsetof (TestIdl_MsgOpt, f2),
+  DDS_OP_ADR | DDS_OP_FLAG_EXT | DDS_OP_TYPE_EXT | DDS_OP_FLAG_OPT, offsetof (TestIdl_MsgOpt, f3), (4u << 16u) + 15u /* TestIdl_MsgOpt_b */, sizeof (TestIdl_MsgOpt_b),
+  DDS_OP_ADR | DDS_OP_FLAG_EXT | DDS_OP_TYPE_BST | DDS_OP_FLAG_OPT, offsetof (TestIdl_MsgOpt, f4), 33u,
+  DDS_OP_ADR | DDS_OP_FLAG_EXT | DDS_OP_TYPE_ARR | DDS_OP_FLAG_OPT | DDS_OP_SUBTYPE_4BY | DDS_OP_FLAG_SGN, offsetof (TestIdl_MsgOpt, f5), 3u,
+  DDS_OP_ADR | DDS_OP_FLAG_EXT | DDS_OP_TYPE_SEQ | DDS_OP_FLAG_OPT | DDS_OP_SUBTYPE_STU, offsetof (TestIdl_MsgOpt, f6), sizeof (TestIdl_MsgOpt_b), (4u << 16u) + 5u /* TestIdl_MsgOpt_b */,
+  DDS_OP_RTS,
+
+  /* TestIdl_MsgOpt_b */
+  DDS_OP_ADR | DDS_OP_FLAG_EXT | DDS_OP_TYPE_1BY | DDS_OP_FLAG_OPT, offsetof (TestIdl_MsgOpt_b, b1),
+  DDS_OP_RTS
+};
+
+const dds_topic_descriptor_t TestIdl_MsgOpt_desc = { sizeof (TestIdl_MsgOpt), sizeof (char *), DDS_TOPIC_NO_OPTIMIZE, 0u, "TestIdl_MsgOpt", NULL, 9, TestIdl_MsgOpt_ops, "" };
+
+static void * sample_init_opt (void)
+{
+  TestIdl_MsgOpt *msg = ddsrt_calloc (1, sizeof (*msg));
+
+  if (RND_INT32 % 2)
+  {
+    msg->f1 = ddsrt_malloc (sizeof (*msg->f1));
+    *msg->f1 = RND_INT32;
+  }
+  if (RND_INT32 % 2)
+    msg->f2 = ddsrt_strdup (RND_STR32);
+  if (RND_INT32 % 2)
+  {
+    msg->f3 = ddsrt_calloc (1, sizeof (*msg->f3));
+    if (RND_INT32 % 2)
+    {
+      msg->f3->b1 = ddsrt_malloc (sizeof (*msg->f3->b1));
+      *msg->f3->b1 = (RND_INT32 % 2);
+    }
+  }
+  if (RND_INT32 % 2)
+  {
+    msg->f4 = ddsrt_malloc (sizeof (*msg->f4));
+    strcpy (*msg->f4, RND_STR32);
+  }
+  if (RND_INT32 % 2)
+  {
+    msg->f5 = ddsrt_malloc (sizeof (*msg->f5));
+    (*msg->f5)[0] = RND_INT32;
+    (*msg->f5)[1] = RND_INT32;
+    (*msg->f5)[2] = RND_INT32;
+  }
+  if (RND_INT32 % 2)
+  {
+    msg->f6 = ddsrt_malloc (sizeof (*msg->f6));
+    uint32_t seqsz6 = RND_UINT32 % 255;
+    msg->f6->_length = msg->f6->_maximum = seqsz6;
+    msg->f6->_buffer = ddsrt_calloc (seqsz6, sizeof (*msg->f6->_buffer));
+    msg->f6->_release = true;
+    for (uint32_t n = 0; n < seqsz6; n++)
+    {
+      if (RND_INT32 % 2)
+      {
+        msg->f6->_buffer[n].b1 = ddsrt_malloc (sizeof (*msg->f6->_buffer[n].b1));
+        *msg->f6->_buffer[n].b1 = RND_INT32;
+      }
+    }
+  }
+  return msg;
+}
+
+static bool sample_equal_opt (void *s1, void *s2)
+{
+  TestIdl_MsgOpt *msg1 = s1, *msg2 = s2;
+
+  if (((msg1->f1 == NULL && msg2->f1 != NULL) || (msg1->f1 != NULL && msg2->f1 == NULL))
+      || ((msg1->f2 == NULL && msg2->f2 != NULL) || (msg1->f2 != NULL && msg2->f2 == NULL))
+      || ((msg1->f3 == NULL && msg2->f3 != NULL) || (msg1->f3 != NULL && msg2->f3 == NULL))
+      || (msg1->f3 != NULL && ((msg1->f3->b1 == NULL && msg2->f3->b1 != NULL) || (msg1->f3->b1 != NULL && msg2->f3->b1 == NULL)))
+      || ((msg1->f4 == NULL && msg2->f4 != NULL) || (msg1->f4 != NULL && msg2->f4 == NULL))
+      || ((msg1->f5 == NULL && msg2->f5 != NULL) || (msg1->f5 != NULL && msg2->f5 == NULL))
+      || ((msg1->f6 == NULL && msg2->f6 != NULL) || (msg1->f6 != NULL && msg2->f6 == NULL)))
+    return false;
+
+  if (msg1->f6 != NULL)
+  {
+    if (msg1->f6->_length != msg2->f6->_length)
+      return false;
+    for (uint32_t n = 0; n < msg1->f6->_length; n++)
+    {
+      if ((msg1->f6->_buffer[n].b1 == NULL && msg2->f6->_buffer[n].b1 != NULL) || (msg1->f6->_buffer[n].b1 != NULL && msg2->f6->_buffer[n].b1 == NULL))
+        return false;
+      if (msg1->f6->_buffer[n].b1 != NULL && *msg1->f6->_buffer[n].b1 != *msg2->f6->_buffer[n].b1)
+        return false;
+    }
+  }
+
+  return
+    (msg1->f1 == NULL || *msg1->f1 == *msg2->f1)
+    && (msg1->f2 == NULL || !strcmp (msg1->f2, msg2->f2))
+    && (msg1->f3 == NULL || msg1->f3->b1 == NULL || *msg1->f3->b1 == *msg2->f3->b1)
+    && (msg1->f4 == NULL || !strcmp (*msg1->f4, *msg2->f4))
+    && (msg1->f5 == NULL || ((*msg1->f5)[0] == (*msg2->f5)[0] && (*msg1->f5)[1] == (*msg2->f5)[1] && (*msg1->f5)[2] == (*msg2->f5)[2]));
+}
+
+static void sample_free_opt (void *s)
+{
+  dds_stream_free_sample (s, TestIdl_MsgOpt_desc.m_ops);
   ddsrt_free (s);
 }
 
@@ -1563,11 +1699,12 @@ CU_TheoryDataPoints (ddsc_cdrstream, ser_des_multiple) = {
   /*                                             |           |        |          |             */"appendable",
   /*                                             |           |        |          |              |              */"keys nested",
   /*                                             |           |        |          |              |               |              */"arrays",
-  /*                                             |           |        |          |              |               |               |       */"ext" ),
-  CU_DataPoints (const dds_topic_descriptor_t *, &D(Nested), &D(Str), &D(Union), &D(Recursive), &D(Appendable), &D(KeysNested), &D(Arr), &D(Ext) ),
-  CU_DataPoints (sample_init,                    I(nested),   I(str),  I(union),  I(recursive),  I(appendable),  I(keysnested),  I(arr),  I(ext) ),
-  CU_DataPoints (sample_equal,                   C(nested),   C(str),  C(union),  C(recursive),  C(appendable),  C(keysnested),  C(arr),  C(ext) ),
-  CU_DataPoints (sample_free,                    F(nested),   F(str),  F(union),  F(recursive),  F(appendable),  F(keysnested),  F(arr),  F(ext) ),
+  /*                                             |           |        |          |              |               |               |       */"ext",
+  /*                                             |           |        |          |              |               |               |        |       */"opt"  ),
+  CU_DataPoints (const dds_topic_descriptor_t *, &D(Nested), &D(Str), &D(Union), &D(Recursive), &D(Appendable), &D(KeysNested), &D(Arr), &D(Ext), &D(Opt) ),
+  CU_DataPoints (sample_init,                    I(nested),   I(str),  I(union),  I(recursive),  I(appendable),  I(keysnested),  I(arr),  I(ext), I(opt)  ),
+  CU_DataPoints (sample_equal,                   C(nested),   C(str),  C(union),  C(recursive),  C(appendable),  C(keysnested),  C(arr),  C(ext), C(opt)  ),
+  CU_DataPoints (sample_free,                    F(nested),   F(str),  F(union),  F(recursive),  F(appendable),  F(keysnested),  F(arr),  F(ext), F(opt)  ),
 };
 
 #define NUM_SAMPLES 10

--- a/src/core/ddsi/include/dds/ddsi/ddsi_cdrstream.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_cdrstream.h
@@ -54,8 +54,6 @@ DDS_EXPORT void dds_ostreamLE_fini (dds_ostreamLE_t * __restrict st);
 DDS_EXPORT void dds_ostreamBE_init (dds_ostreamBE_t * __restrict st, uint32_t size, uint32_t xcdr_version);
 DDS_EXPORT void dds_ostreamBE_fini (dds_ostreamBE_t * __restrict st);
 
-DDS_EXPORT const uint32_t *dds_stream_normalize1 (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t * __restrict ops);
-
 // *actual_size is set to the actual size of the data (*actual_size <= size) on successful return
 DDS_EXPORT bool dds_stream_normalize (void * __restrict data, uint32_t size, bool bswap, uint32_t xcdr_version, const struct ddsi_sertype_default * __restrict type, bool just_key, uint32_t * __restrict actual_size);
 

--- a/src/core/ddsi/include/dds/ddsi/ddsi_cdrstream.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_cdrstream.h
@@ -86,7 +86,7 @@ DDS_EXPORT size_t dds_stream_print_key (dds_istream_t * __restrict is, const str
 
 DDS_EXPORT size_t dds_stream_print_sample (dds_istream_t * __restrict is, const struct ddsi_sertype_default * __restrict type, char * __restrict buf, size_t size);
 
-DDS_EXPORT bool dds_stream_has_dynamic_type (const uint32_t * __restrict ops);
+DDS_EXPORT uint16_t dds_stream_minimum_xcdr_version (const uint32_t * __restrict ops);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsi/include/dds/ddsi/ddsi_sertype.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_sertype.h
@@ -46,7 +46,7 @@ struct ddsi_sertype {
   uint32_t typekind_no_key : 1;
   uint32_t request_keyhash : 1;
   uint32_t fixed_size : 1;
-  uint32_t dynamic_types : 1;  /* contains any appendable or mutable type, not necessarily the top-level type, can also be nested type */
+  uint16_t min_xcdrv;  /* minimum XCDR version required for (de)serialization */
   char *type_name;
   ddsrt_atomic_voidp_t gv; /* set during registration */
   ddsrt_atomic_uint32_t flags_refc; /* counts refs from entities (topic, reader, writer), not from data */

--- a/src/core/ddsi/src/ddsi_cdrstream_write.part.c
+++ b/src/core/ddsi/src/ddsi_cdrstream_write.part.c
@@ -10,6 +10,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
 
+static const uint32_t *dds_stream_write_implBO (DDS_OSTREAM_T * __restrict os, const char * __restrict data, const uint32_t * __restrict ops, bool is_mutable_member);
+
 static void dds_stream_write_stringBO (DDS_OSTREAM_T * __restrict os, const char * __restrict val)
 {
   uint32_t size = val ? (uint32_t) strlen (val) + 1 : 1;
@@ -83,14 +85,13 @@ static const uint32_t *dds_stream_write_seqBO (DDS_OSTREAM_T * __restrict os, co
         uint32_t const * const jsr_ops = ops + DDS_OP_ADR_JSR (ops[3]);
         const char *ptr = (const char *) seq->_buffer;
         for (uint32_t i = 0; i < num; i++)
-          (void) dds_stream_writeBO (os, ptr + i * elem_size, jsr_ops);
+          (void) dds_stream_write_implBO (os, ptr + i * elem_size, jsr_ops, false);
         ops += (jmp ? jmp : 4); /* FIXME: why would jmp be 0? */
         break;
       }
-      case DDS_OP_VAL_EXT: {
+      case DDS_OP_VAL_EXT:
         abort (); /* op type EXT as sequence subtype not supported */
         return NULL;
-      }
     }
   }
 
@@ -150,14 +151,13 @@ static const uint32_t *dds_stream_write_arrBO (DDS_OSTREAM_T * __restrict os, co
       const uint32_t jmp = DDS_OP_ADR_JMP (ops[3]);
       const uint32_t elem_size = ops[4];
       for (uint32_t i = 0; i < num; i++)
-        (void) dds_stream_writeBO (os, addr + i * elem_size, jsr_ops);
+        (void) dds_stream_write_implBO (os, addr + i * elem_size, jsr_ops, false);
       ops += (jmp ? jmp : 5);
       break;
     }
-    case DDS_OP_VAL_EXT: {
+    case DDS_OP_VAL_EXT:
       abort (); /* op type EXT as array subtype not supported */
       break;
-    }
   }
 
   if (subtype > DDS_OP_VAL_8BY && is_xcdr2)
@@ -191,6 +191,9 @@ static const uint32_t *dds_stream_write_uniBO (DDS_OSTREAM_T * __restrict os, co
     const enum dds_stream_typecode valtype = DDS_JEQ_TYPE (jeq_op[0]);
     const void *valaddr = baseaddr + jeq_op[2];
 
+    /* Union members cannot be optional, only external. For string types, the pointer
+       is dereferenced below (and there is no extra pointer indirection when using
+       @external for STR types) */
     if (op_type_external (jeq_op[0]) && valtype != DDS_OP_VAL_STR)
     {
       assert (DDS_OP (jeq_op[0]) == DDS_OP_JEQ4);
@@ -207,18 +210,62 @@ static const uint32_t *dds_stream_write_uniBO (DDS_OSTREAM_T * __restrict os, co
       case DDS_OP_VAL_STR: dds_stream_write_stringBO (os, *(const char **) valaddr); break;
       case DDS_OP_VAL_BST: dds_stream_write_stringBO (os, (const char *) valaddr); break;
       case DDS_OP_VAL_SEQ: case DDS_OP_VAL_ARR:
-        (void) dds_stream_writeBO (os, valaddr, jeq_op + DDS_OP_ADR_JSR (jeq_op[0]));
+        (void) dds_stream_write_implBO (os, valaddr, jeq_op + DDS_OP_ADR_JSR (jeq_op[0]), false);
         break;
       case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU: {
         const uint32_t *jsr_ops = jeq_op + DDS_OP_ADR_JSR (jeq_op[0]);
-        (void) dds_stream_writeBO (os, valaddr, jsr_ops);
+        (void) dds_stream_write_implBO (os, valaddr, jsr_ops, false);
         break;
       }
-      case DDS_OP_VAL_EXT: {
+      case DDS_OP_VAL_EXT:
         abort (); /* op type EXT as union subtype not supported */
         break;
-      }
     }
+  }
+  return ops;
+}
+
+static const uint32_t *dds_stream_write_adrBO (uint32_t insn, DDS_OSTREAM_T * __restrict os, const char * __restrict data, const uint32_t * __restrict ops, bool is_mutable_member)
+{
+  const void *addr = data + ops[1];
+  if (op_type_external (insn) || op_type_optional (insn) || DDS_OP_TYPE (insn) == DDS_OP_VAL_STR)
+    addr = *(char **) addr;
+  if (op_type_optional (insn))
+  {
+    if (!is_mutable_member)
+      dds_os_put1BO (os, addr ? 1 : 0);
+    if (!addr)
+      return dds_stream_skip_adr (insn, ops);
+  }
+  assert (addr || DDS_OP_TYPE (insn) == DDS_OP_VAL_STR);
+
+  switch (DDS_OP_TYPE (insn))
+  {
+    case DDS_OP_VAL_1BY: dds_os_put1BO (os, *((const uint8_t *) addr)); ops += 2; break;
+    case DDS_OP_VAL_2BY: dds_os_put2BO (os, *((const uint16_t *) addr)); ops += 2; break;
+    case DDS_OP_VAL_4BY: dds_os_put4BO (os, *((const uint32_t *) addr)); ops += 2; break;
+    case DDS_OP_VAL_8BY: dds_os_put8BO (os, *((const uint64_t *) addr)); ops += 2; break;
+    case DDS_OP_VAL_STR: dds_stream_write_stringBO (os, (const char *) addr); ops += 2; break;
+    case DDS_OP_VAL_BST: dds_stream_write_stringBO (os, (const char *) addr); ops += 3; break;
+    case DDS_OP_VAL_SEQ: ops = dds_stream_write_seqBO (os, addr, ops, insn); break;
+    case DDS_OP_VAL_ARR: ops = dds_stream_write_arrBO (os, addr, ops, insn); break;
+    case DDS_OP_VAL_UNI: ops = dds_stream_write_uniBO (os, addr, data, ops, insn); break;
+    case DDS_OP_VAL_ENU: dds_os_put4BO (os, *((const uint32_t *) addr)); ops += 3; break;
+    case DDS_OP_VAL_EXT: {
+      const uint32_t *jsr_ops = ops + DDS_OP_ADR_JSR (ops[2]);
+      const uint32_t jmp = DDS_OP_ADR_JMP (ops[2]);
+
+      /* skip DLC instruction for base type, so that the DHEADER is not
+          serialized for base types */
+      if (op_type_base (insn) && jsr_ops[0] == DDS_OP_DLC)
+        jsr_ops++;
+
+      /* don't forward is_mutable_member, subtype can have other extensibility */
+      (void) dds_stream_write_implBO (os, addr, jsr_ops, false);
+      ops += jmp ? jmp : 3;
+      break;
+    }
+    case DDS_OP_VAL_STU: abort (); break; /* op type STU only supported as subtype */
   }
   return ops;
 }
@@ -226,7 +273,9 @@ static const uint32_t *dds_stream_write_uniBO (DDS_OSTREAM_T * __restrict os, co
 static const uint32_t *dds_stream_write_delimitedBO (DDS_OSTREAM_T * __restrict os, const char * __restrict data, const uint32_t * __restrict ops)
 {
   uint32_t offs = dds_os_reserve4BO (os);
-  ops = dds_stream_writeBO (os, data, ops + 1);
+  ops = dds_stream_write_implBO (os, data, ops + 1, false);
+
+  /* add dheader, which is the serialized size of the data */
   *((uint32_t *) (os->x.m_buffer + offs - 4)) = to_BO4u (os->x.m_index - offs);
   return ops;
 }
@@ -237,8 +286,9 @@ static void dds_stream_write_pl_memberBO (bool must_understand, uint32_t mid, DD
   uint32_t lc = get_length_code (ops);
   assert (lc < LENGTH_CODE_ALSO_NEXTINT8);
   uint32_t data_offs = (lc != LENGTH_CODE_NEXTINT) ? dds_os_reserve4BO (os) : dds_os_reserve8BO (os);
-  (void) dds_stream_writeBO (os, data, ops);
+  (void) dds_stream_write_implBO (os, data, ops, true);
 
+  /* add emheader with data length code and flags and optionally the serialized size of the data */
   uint32_t em_hdr = 0;
   if (must_understand)
     em_hdr |= EMHEADER_FLAG_MUSTUNDERSTAND;
@@ -267,7 +317,7 @@ static const uint32_t *dds_stream_write_pl_memberlistBO (DDS_OSTREAM_T * __restr
           plm_ops++; /* skip PLC op to go to first PLM for the base type */
           (void) dds_stream_write_pl_memberlistBO (os, data, plm_ops);
         }
-        else
+        else if (is_member_present (data, plm_ops))
         {
           uint32_t member_id = ops[1];
           dds_stream_write_pl_memberBO (flags & DDS_OP_FLAG_MU, member_id, os, data, plm_ops);
@@ -300,70 +350,37 @@ static const uint32_t *dds_stream_write_plBO (DDS_OSTREAM_T * __restrict os, con
   return ops;
 }
 
-const uint32_t *dds_stream_writeBO (DDS_OSTREAM_T * __restrict os, const char * __restrict data, const uint32_t * __restrict ops)
+static const uint32_t *dds_stream_write_implBO (DDS_OSTREAM_T * __restrict os, const char * __restrict data, const uint32_t * __restrict ops, bool is_mutable_member)
 {
   uint32_t insn;
   while ((insn = *ops) != DDS_OP_RTS)
   {
     switch (DDS_OP (insn))
     {
-      case DDS_OP_ADR: {
-        const void *addr = data + ops[1];
-        if (op_type_external (insn) && DDS_OP_TYPE (insn) != DDS_OP_VAL_STR)
-        {
-          addr = *(char **) addr;
-          assert (addr);
-        }
-
-        switch (DDS_OP_TYPE (insn))
-        {
-          case DDS_OP_VAL_1BY: dds_os_put1BO (os, *((const uint8_t *) addr)); ops += 2; break;
-          case DDS_OP_VAL_2BY: dds_os_put2BO (os, *((const uint16_t *) addr)); ops += 2; break;
-          case DDS_OP_VAL_4BY: dds_os_put4BO (os, *((const uint32_t *) addr)); ops += 2; break;
-          case DDS_OP_VAL_8BY: dds_os_put8BO (os, *((const uint64_t *) addr)); ops += 2; break;
-          case DDS_OP_VAL_STR: dds_stream_write_stringBO (os, *((const char **) addr)); ops += 2; break;
-          case DDS_OP_VAL_BST: dds_stream_write_stringBO (os, (const char *) addr); ops += 3; break;
-          case DDS_OP_VAL_SEQ: ops = dds_stream_write_seqBO (os, addr, ops, insn); break;
-          case DDS_OP_VAL_ARR: ops = dds_stream_write_arrBO (os, addr, ops, insn); break;
-          case DDS_OP_VAL_UNI: ops = dds_stream_write_uniBO (os, addr, data, ops, insn); break;
-          case DDS_OP_VAL_ENU: dds_os_put4BO (os, *((const uint32_t *) addr)); ops += 3; break;
-          case DDS_OP_VAL_EXT: {
-            const uint32_t *jsr_ops = ops + DDS_OP_ADR_JSR (ops[2]);
-            const uint32_t jmp = DDS_OP_ADR_JMP (ops[2]);
-
-            /* skip DLC instruction for base type, so that the DHEADER is not
-               serialized for base types */
-            if (op_type_base (insn) && jsr_ops[0] == DDS_OP_DLC)
-              jsr_ops++;
-
-            (void) dds_stream_writeBO (os, addr, jsr_ops);
-            ops += jmp ? jmp : 3;
-            break;
-          }
-          case DDS_OP_VAL_STU: abort (); break; /* op type STU only supported as subtype */
-        }
+      case DDS_OP_ADR:
+        ops = dds_stream_write_adrBO (insn, os, data, ops, is_mutable_member);
         break;
-      }
-      case DDS_OP_JSR: {
-        (void) dds_stream_writeBO (os, data, ops + DDS_OP_JUMP (insn));
+      case DDS_OP_JSR:
+        (void) dds_stream_write_implBO (os, data, ops + DDS_OP_JUMP (insn), is_mutable_member);
         ops++;
         break;
-      }
-      case DDS_OP_RTS: case DDS_OP_JEQ: case DDS_OP_JEQ4: case DDS_OP_KOF: case DDS_OP_PLM: {
+      case DDS_OP_RTS: case DDS_OP_JEQ: case DDS_OP_JEQ4: case DDS_OP_KOF: case DDS_OP_PLM:
         abort ();
         break;
-      }
-      case DDS_OP_DLC: {
+      case DDS_OP_DLC:
         assert (((struct dds_ostream *)os)->m_xcdr_version == CDR_ENC_VERSION_2);
         ops = dds_stream_write_delimitedBO (os, data, ops);
         break;
-      }
-      case DDS_OP_PLC: {
+      case DDS_OP_PLC:
         assert (((struct dds_ostream *)os)->m_xcdr_version == CDR_ENC_VERSION_2);
         ops = dds_stream_write_plBO (os, data, ops);
         break;
-      }
     }
   }
   return ops;
+}
+
+const uint32_t *dds_stream_writeBO (DDS_OSTREAM_T * __restrict os, const char * __restrict data, const uint32_t * __restrict ops)
+{
+  return dds_stream_write_implBO (os, data, ops, false);
 }

--- a/src/core/ddsi/src/ddsi_sertype.c
+++ b/src/core/ddsi/src/ddsi_sertype.c
@@ -207,7 +207,7 @@ bool ddsi_sertype_deserialize (struct ddsi_domaingv *gv, struct ddsi_sertype *tp
   tp->ops = sertype_ops;
   tp->type_name = ddsrt_strdup (d.type_name);
   tp->typekind_no_key = d.typekind_no_key;
-  tp->dynamic_types = 0u;
+  tp->min_xcdrv = 0u;
   if (!tp->ops->deserialize (gv, tp, sz, serdata, &srcoff))
   {
     ddsrt_free (tp->type_name);
@@ -232,7 +232,7 @@ void ddsi_sertype_init_flags (struct ddsi_sertype *tp, const char *type_name, co
   tp->typekind_no_key = (flags & DDSI_SERTYPE_FLAG_TOPICKIND_NO_KEY) ? 1u : 0u;
   tp->request_keyhash = (flags & DDSI_SERTYPE_FLAG_REQUEST_KEYHASH) ? 1u : 0u;
   tp->fixed_size = (flags & DDSI_SERTYPE_FLAG_FIXED_SIZE) ? 1u : 0u;
-  tp->dynamic_types = 0u;
+  tp->min_xcdrv = CDR_ENC_VERSION_1;
   tp->base_sertype = NULL;
   tp->wrapped_sertopic = NULL;
 #ifdef DDS_HAS_SHM

--- a/src/core/ddsi/src/ddsi_sertype_default.c
+++ b/src/core/ddsi/src/ddsi_sertype_default.c
@@ -170,7 +170,7 @@ static bool sertype_default_deserialize (struct ddsi_domaingv *gv, struct ddsi_s
   DDSRT_WARNING_MSVC_ON(6326)
   st->encoding_format = ddsi_sertype_get_encoding_format (DDS_TOPIC_TYPE_EXTENSIBILITY (st->type.flagset));
   st->opt_size = (st->type.flagset & DDS_TOPIC_NO_OPTIMIZE) ? 0 : dds_stream_check_optimize (&st->type);
-  st->c.dynamic_types = dds_stream_has_dynamic_type (st->type.ops.ops);
+  st->c.min_xcdrv = dds_stream_minimum_xcdr_version (st->type.ops.ops);
   return true;
 }
 

--- a/src/idl/include/idl/tree.h
+++ b/src/idl/include/idl/tree.h
@@ -513,6 +513,7 @@ IDL_EXPORT bool idl_is_forward(const void *node);
 IDL_EXPORT bool idl_is_topic_key(const void *node, bool keylist, const idl_path_t *path, uint32_t *order);
 IDL_EXPORT bool idl_is_extensible(const idl_node_t *node, idl_extensibility_t extensibility);
 IDL_EXPORT bool idl_is_external(const idl_node_t *node);
+IDL_EXPORT bool idl_is_optional(const idl_node_t *node);
 
 /* accessors */
 IDL_EXPORT idl_mask_t idl_mask(const void *node);

--- a/src/idl/include/idl/tree.h
+++ b/src/idl/include/idl/tree.h
@@ -485,6 +485,8 @@ IDL_EXPORT bool idl_is_templ_type(const void *node);
 IDL_EXPORT bool idl_is_bounded(const void *node);
 IDL_EXPORT bool idl_is_sequence(const void *node);
 IDL_EXPORT bool idl_is_string(const void *node);
+IDL_EXPORT bool idl_is_unbounded_string(const void *node);
+IDL_EXPORT bool idl_is_bounded_string(const void *node);
 IDL_EXPORT bool idl_is_constr_type(const void *node);
 IDL_EXPORT bool idl_is_struct(const void *node);
 IDL_EXPORT bool idl_is_empty(const void *node);

--- a/src/idl/src/tree.c
+++ b/src/idl/src/tree.c
@@ -3515,3 +3515,8 @@ bool idl_is_external(const idl_node_t *node)
   return (idl_is_member(node) && ((idl_member_t *)node)->external.value)
     || (idl_is_case(node) && ((idl_case_t *)node)->external.value);
 }
+
+bool idl_is_optional(const idl_node_t *node)
+{
+  return (idl_is_member(node) && ((idl_member_t *)node)->optional.value);
+}

--- a/src/idl/src/tree.c
+++ b/src/idl/src/tree.c
@@ -894,6 +894,16 @@ bool idl_is_string(const void *ptr)
   return true;
 }
 
+bool idl_is_unbounded_string(const void *ptr)
+{
+  return idl_is_string(ptr) && !idl_is_bounded(ptr);
+}
+
+bool idl_is_bounded_string(const void *ptr)
+{
+  return idl_is_string(ptr) && idl_is_bounded(ptr);
+}
+
 static void delete_string(void *ptr)
 {
   free(ptr);

--- a/src/tools/idlc/src/descriptor.c
+++ b/src/tools/idlc/src/descriptor.c
@@ -1176,6 +1176,8 @@ emit_sequence(
       assert(idl_is_member(member_node));
       if (idl_is_external(member_node))
         opcode |= DDS_OP_FLAG_EXT;
+      if (idl_is_optional(member_node))
+        opcode |= DDS_OP_FLAG_OPT;
     }
     off = ctype->instructions.count;
     if ((ret = stash_opcode(pstate, descriptor, &ctype->instructions, nop, opcode, order)))
@@ -1287,8 +1289,12 @@ emit_array(
        we're processing a struct type, and this can be used to determine if its
        an external member */
     idl_node_t *parent = idl_parent(node);
-    if (idl_is_struct(stype->node) && idl_is_external(parent))
-      opcode |= DDS_OP_FLAG_EXT;
+    if (idl_is_struct(stype->node)) {
+      if (idl_is_external(parent))
+        opcode |= DDS_OP_FLAG_EXT;
+      if (idl_is_optional(parent))
+        opcode |= DDS_OP_FLAG_OPT;
+    }
 
     off = ctype->instructions.count;
     /* generate data field opcode */
@@ -1339,8 +1345,6 @@ emit_member(
   const idl_member_t *member = (const idl_member_t *)node;
   if (member->value.annotation)
     idl_warning(pstate, idl_location(node), "Explicit defaults are not supported yet in the C generator, the value from the @default annotation will not be used");
-  if (member->optional.annotation)
-    idl_warning(pstate, idl_location(node), "Optional members are not supported yet in the C generator, the @optional annotation will be ignored");
   return IDL_RETCODE_OK;
 }
 
@@ -1451,11 +1455,13 @@ emit_declarator(
       opcode |= DDS_OP_FLAG_KEY;
       ctype->has_key_member = true;
     }
-    if (idl_is_struct(stype->node) && idl_is_external(parent))
-    {
-      opcode |= DDS_OP_FLAG_EXT;
-      /* For @external fields of type OP_TYPE_EXT include the size of the field to allow the serializer to allocate
-         memory for this field when deserializing. */
+    if (idl_is_struct(stype->node) && (idl_is_external(parent) || idl_is_optional(parent))) {
+      if (idl_is_external(parent))
+        opcode |= DDS_OP_FLAG_EXT;
+      if (idl_is_optional(parent))
+        opcode |= DDS_OP_FLAG_OPT;
+      /* For @external and @optional fields of type OP_TYPE_EXT include the size of the field to
+         allow the serializer to allocate memory for this field when deserializing. */
       if (DDS_OP_TYPE(opcode) == DDS_OP_VAL_EXT)
         has_size = true;
     }
@@ -1534,7 +1540,7 @@ static int print_opcode(FILE *fp, const struct instruction *inst)
       break;
   }
 
-  if (inst->data.opcode.code & DDS_OP_FLAG_EXT)
+  if ((opcode == DDS_OP_ADR || opcode == DDS_OP_JEQ4) && inst->data.opcode.code & DDS_OP_FLAG_EXT)
     vec[len++] = " | DDS_OP_FLAG_EXT";
 
   type = DDS_OP_TYPE(inst->data.opcode.code);
@@ -1555,9 +1561,13 @@ static int print_opcode(FILE *fp, const struct instruction *inst)
   }
 
   /* FLAG_BASE to indicate inheritance in PLM list or EXT 'parent' field */
-  if (opcode == DDS_OP_ADR && inst->data.opcode.code & DDS_OP_FLAG_BASE)
-    vec[len++] = " | DDS_OP_FLAG_BASE";
-  else if (opcode == DDS_OP_PLM && (DDS_PLM_FLAGS(inst->data.opcode.code) & DDS_OP_FLAG_BASE))
+  if (opcode == DDS_OP_ADR) {
+    if (inst->data.opcode.code & DDS_OP_FLAG_BASE)
+      vec[len++] = " | DDS_OP_FLAG_BASE";
+    if (inst->data.opcode.code & DDS_OP_FLAG_OPT)
+      vec[len++] = " | DDS_OP_FLAG_OPT";
+  }
+  if (opcode == DDS_OP_PLM && (DDS_PLM_FLAGS(inst->data.opcode.code) & DDS_OP_FLAG_BASE))
     vec[len++] = " | (DDS_OP_FLAG_BASE << 16)";
 
   if (opcode == DDS_OP_JEQ || opcode == DDS_OP_JEQ4 || opcode == DDS_OP_PLM) {
@@ -1693,8 +1703,6 @@ static int print_opcodes(FILE *fp, const struct descriptor *descriptor, uint32_t
             brk = op + 3;
           else if (optype == DDS_OP_VAL_EXT) {
             brk = op + 3;
-            if (inst->data.opcode.code & DDS_OP_FLAG_EXT)
-              brk++;
           }
           else if (optype == DDS_OP_VAL_ARR || optype == DDS_OP_VAL_SEQ) {
             subtype = DDS_OP_SUBTYPE(inst->data.opcode.code);
@@ -1705,6 +1713,8 @@ static int print_opcodes(FILE *fp, const struct descriptor *descriptor, uint32_t
             brk = op + 4;
           else
             brk = op + 2;
+          if (inst->data.opcode.code & (DDS_OP_FLAG_EXT | DDS_OP_FLAG_OPT))
+            brk++;
           if (fputs(sep, fp) < 0 || print_opcode(fp, inst) < 0)
             return -1;
           break;

--- a/src/tools/idlc/src/types.c
+++ b/src/tools/idlc/src/types.c
@@ -157,7 +157,7 @@ emit_field(
   if (idl_is_string(type_spec) && !idl_is_bounded(type_spec))
     ptr_open = "* ";
 
-  if (idl_is_external(root)) {
+  if (idl_is_external(root) || idl_is_optional(root)) {
     if (idl_is_array(node) || (idl_is_string(type_spec) && idl_is_bounded(type_spec))) {
       /* for arrays and bounded strings, add paratheses so that it won't be an
          array of pointers but a pointer to the array, e.g. long (*member_name)[5] */

--- a/src/tools/idlc/xtests/CMakeLists.txt
+++ b/src/tools/idlc/xtests/CMakeLists.txt
@@ -20,6 +20,8 @@ set(_sources
   test_struct_inherit_mutable.idl
   test_struct_external.idl
   test_union_external.idl
+  test_optional.idl
+  test_optional_mutable.idl
 #  test_struct_recursive.idl
 #  test_union_member_types.idl
 #  test_union_recursive.idl

--- a/src/tools/idlc/xtests/test_optional.idl
+++ b/src/tools/idlc/xtests/test_optional.idl
@@ -1,0 +1,203 @@
+/*
+ * Copyright(c) 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+#if defined(__IDLC__)
+
+@nested @final
+struct b {
+    long b1;
+};
+
+@nested @final
+union u switch (short) {
+ case 1: long u1;
+};
+
+typedef sequence<float> seqfloat_t;
+typedef sequence<long> seqlong_t;
+typedef sequence<seqlong_t> seqlong2_t;
+
+@nested @appendable
+struct test_opt_base {
+  @optional long b1;
+  @optional long b1n;
+};
+
+@topic @appendable
+struct test_opt : test_opt_base {
+  @optional long f1;
+  @optional long f1n;
+  @optional string f2;          // char * f2;
+  @optional string f2n;
+  @optional string<128> f3;     // char (* f3)[129];
+  @optional string<128> f3n;
+  @optional b f4;
+  @optional b f4n;
+  @optional u f5;
+  @optional u f5n;
+  @optional short f6[2];        // int16_t (* f6)[10]
+  @optional short f6n[2];
+  @optional short f7[2][3];     // int16_t (* f7)[2][3]
+  @optional short f7n[2][3];
+  @optional sequence<short> f8;
+  @optional sequence<short> f8n;
+  @optional seqfloat_t f9;
+  @optional seqfloat_t f9n;
+  @optional sequence<seqlong_t> f10;
+  @optional sequence<seqlong_t> f10n;
+  @optional seqlong2_t f11;
+  @optional seqlong2_t f11n;
+  @optional @external long f12;
+  @optional @external long f12n;
+};
+
+#else
+
+#include "dds/ddsrt/heap.h"
+#include "common.h"
+#include "test_optional.h"
+
+const dds_topic_descriptor_t *desc = &test_opt_desc;
+void init_sample (void *s);
+int cmp_sample (const void *sa, const void *sb);
+
+void init_sample (void *s)
+{
+  test_opt *s1 = (test_opt *) s;
+
+  EXTA (s1->parent.b1, 789);
+  s1->parent.b1n = NULL;
+
+  EXTA (s1->f1, 123);
+  s1->f1n = NULL;
+
+  STRA (s1->f2, STR128);
+  s1->f2n = NULL;
+
+  A (s1->f3);
+  strcpy (*(s1->f3), STR128);
+  s1->f3n = NULL;
+
+  A (s1->f4);
+  (*s1->f4).b1 = 456;
+  s1->f4n = NULL;
+
+  A (s1->f5);
+  s1->f5->_d = 1;
+  s1->f5->_u.u1 = 789;
+  s1->f5n = NULL;
+
+  A (s1->f6);
+  (*s1->f6)[0] = 321;
+  (*s1->f6)[1] = 654;
+  s1->f6n = NULL;
+
+  A (s1->f7);
+  for (int n = 0; n < 6; n++)
+    (*s1->f7)[n / 3][n % 3] = 1000 * n;
+  s1->f7n = NULL;
+
+  A (s1->f8);
+  SEQA(*(s1->f8), 3);
+  for (int n = 0; n < 3; n++)
+    s1->f8->_buffer[n] = 100 * n;
+  s1->f8n = NULL;
+
+  A (s1->f9);
+  SEQA(*(s1->f9), 4);
+  for (int n = 0; n < 4; n++)
+    s1->f9->_buffer[n] = (float) (0.1 * (float) n);
+  s1->f9n = NULL;
+
+  A (s1->f10);
+  SEQA(*(s1->f10), 2);
+  for (int n = 0; n < 2; n++)
+  {
+    SEQA(s1->f10->_buffer[n], 2);
+    s1->f10->_buffer[n]._buffer[0] = 20 * n;
+    s1->f10->_buffer[n]._buffer[1] = 20 * n + 10;
+  }
+  s1->f10n = NULL;
+
+  A (s1->f11);
+  SEQA(*(s1->f11), 3);
+  for (int n = 0; n < 3; n++)
+  {
+    SEQA(s1->f11->_buffer[n], 10);
+    for (int m = 0; m < 10; m++)
+      s1->f11->_buffer[n]._buffer[m] = 123 * n + m;
+  }
+  s1->f11n = NULL;
+
+  EXTA (s1->f12, 321);
+  s1->f12n = NULL;
+}
+
+int cmp_sample (const void *sa, const void *sb)
+{
+  test_opt *a = (test_opt *) sa;
+  test_opt *b = (test_opt *) sb;
+
+  CMPEXT (a, b, parent.b1, 789);
+  CMP (a, b, parent.b1n, NULL);
+
+  CMPEXT (a, b, f1, 123);
+  CMP (a, b, f1n, NULL);
+
+  CMPSTR (a, b, f2, STR128);
+  CMP (a, b, f2n, NULL);
+
+  CMPEXTSTR (a, b, f3, STR128);
+  CMP (a, b, f3n, NULL);
+
+  CMPEXTF (a, b, f4, b1, 456);
+  CMP (a, b, f4n, NULL);
+
+  CMPEXTF (a, b, f5, _d, 1);
+  CMPEXTF (a, b, f5, _u.u1, 789);
+  CMP (a, b, f5n, NULL);
+
+  CMPEXTA (a, b, f6, 0, 321);
+  CMPEXTA (a, b, f6, 1, 654);
+  CMP (a, b, f6n, NULL);
+
+  for (int n = 0; n < 6; n++)
+    CMPEXTA2 (a, b, f7, n / 3, n % 3, 1000 * n);
+  CMP (a, b, f7n, NULL);
+
+  for (int n = 0; n < 3; n++)
+    CMP(a, b, f8->_buffer[n], 100 * n);
+  CMP (a, b, f8n, NULL);
+
+  for (int n = 0; n < 4; n++)
+    CMP(a, b, f9->_buffer[n], (float) (0.1 * (float) n));
+  CMP (a, b, f9n, NULL);
+
+  for (int n = 0; n < 2; n++)
+  {
+    CMP(a, b, f10->_buffer[n]._buffer[0], 20 * n);
+    CMP(a, b, f10->_buffer[n]._buffer[1], 20 * n + 10);
+  }
+  CMP (a, b, f10n, NULL);
+
+  for (int n = 0; n < 3; n++)
+    for (int m = 0; m < 10; m++)
+      CMP(a, b, f11->_buffer[n]._buffer[m], 123 * n + m);
+  CMP (a, b, f11n, NULL);
+
+  CMPEXT (a, b, f12, 321);
+  CMP (a, b, f12n, NULL);
+
+  return 0;
+}
+
+#endif

--- a/src/tools/idlc/xtests/test_optional_mutable.idl
+++ b/src/tools/idlc/xtests/test_optional_mutable.idl
@@ -1,0 +1,128 @@
+/*
+ * Copyright(c) 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+#if defined(__IDLC__)
+
+@nested @appendable
+union u switch (short) {
+ case 1: long u1;
+};
+
+typedef sequence<long> seqlong_t;
+typedef sequence<seqlong_t> seqlong2_t;
+
+@nested @mutable
+struct test_opt_base {
+  @optional long b1;
+  @optional long b1n;
+};
+
+@topic @mutable
+struct test_opt : test_opt_base {
+  @optional long f1;
+  @optional long f1n;
+  @optional string f2;
+  @optional string f2n;
+  @optional string<128> f3;
+  @optional string<128> f3n;
+  @optional u f4;
+  @optional u f4n;
+  @optional short f5[2][3];
+  @optional short f5n[2][3];
+  @optional sequence<seqlong_t> f6;
+  @optional sequence<seqlong_t> f6n;
+};
+
+#else
+
+#include "dds/ddsrt/heap.h"
+#include "common.h"
+#include "test_optional_mutable.h"
+
+const dds_topic_descriptor_t *desc = &test_opt_desc;
+void init_sample (void *s);
+int cmp_sample (const void *sa, const void *sb);
+
+void init_sample (void *s)
+{
+  test_opt *s1 = (test_opt *) s;
+
+  EXTA (s1->parent.b1, 789);
+  s1->parent.b1n = NULL;
+
+  EXTA (s1->f1, 123);
+  s1->f1n = NULL;
+
+  STRA (s1->f2, STR128);
+  s1->f2n = NULL;
+
+  A (s1->f3);
+  strcpy (*(s1->f3), STR128);
+  s1->f3n = NULL;
+
+  A (s1->f4);
+  s1->f4->_d = 1;
+  s1->f4->_u.u1 = 789;
+  s1->f4n = NULL;
+
+  A (s1->f5);
+  for (int n = 0; n < 6; n++)
+    (*s1->f5)[n / 3][n % 3] = 1000 * n;
+  s1->f5n = NULL;
+
+  A (s1->f6);
+  SEQA(*(s1->f6), 2);
+  for (int n = 0; n < 2; n++)
+  {
+    SEQA(s1->f6->_buffer[n], 2);
+    s1->f6->_buffer[n]._buffer[0] = 20 * n;
+    s1->f6->_buffer[n]._buffer[1] = 20 * n + 10;
+  }
+  s1->f6n = NULL;
+}
+
+int cmp_sample (const void *sa, const void *sb)
+{
+  test_opt *a = (test_opt *) sa;
+  test_opt *b = (test_opt *) sb;
+
+  CMPEXT (a, b, parent.b1, 789);
+  CMP (a, b, parent.b1n, NULL);
+
+  CMPEXT (a, b, f1, 123);
+  CMP (a, b, f1n, NULL);
+
+  CMPSTR (a, b, f2, STR128);
+  CMP (a, b, f2n, NULL);
+
+  CMPEXTSTR (a, b, f3, STR128);
+  CMP (a, b, f3n, NULL);
+
+  CMPEXTF (a, b, f4, _d, 1);
+  CMPEXTF (a, b, f4, _u.u1, 789);
+  CMP (a, b, f4n, NULL);
+
+  for (int n = 0; n < 6; n++)
+    CMPEXTA2 (a, b, f5, n / 3, n % 3, 1000 * n);
+  CMP (a, b, f5n, NULL);
+
+  for (int n = 0; n < 2; n++)
+  {
+    CMP(a, b, f6->_buffer[n]._buffer[0], 20 * n);
+    CMP(a, b, f6->_buffer[n]._buffer[1], 20 * n + 10);
+  }
+  CMP (a, b, f6n, NULL);
+
+  return 0;
+}
+
+#endif


### PR DESCRIPTION
This PR adds support for the `@optional` annotation in IDL. This annotation can be used on struct members. An optional member is generated as a pointer type in the IDLC output, similar to external members. In plain and delimited CDR the field is preceded by a bool that indicates if the field is present (in pl-cdr the field is omitted if not present).
