### PR TITLE
Fix warning when building CycloneDDS with gcc 11.

### DIFF
--- a/src/ddsrt/src/threads/posix/threads.c
+++ b/src/ddsrt/src/threads/posix/threads.c
@@ -237,8 +237,8 @@ ddsrt_thread_create (
   if (tattr.stackSize != 0)
   {
 #ifdef PTHREAD_STACK_MIN
-    if (tattr.stackSize < PTHREAD_STACK_MIN)
-      tattr.stackSize = PTHREAD_STACK_MIN;
+    if (tattr.stackSize < (uint32_t)PTHREAD_STACK_MIN)
+      tattr.stackSize = (uint32_t)PTHREAD_STACK_MIN;
 #endif
     if ((result = pthread_attr_setstacksize (&attr, tattr.stackSize)) != 0)
     {


### PR DESCRIPTION
gcc 11 warns that there is a conversion from 'long int'
to 'uint32_t' when assigning the value of PTHREAD_STACK_MIN
to tattr.stackSize.  It's pedantically correct; tattr.stackSize
is a uint32_t, and PTHREAD_STACK_MIN is either an integer (if
it is hard-coded), or the result of calling sysconf(), which
always returns a long.  In either case it is a signed value,
so we should explicitly cast it to uint32_t here.  This quiets
the warning.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Note that I've targeted this at the `releases/0.8.x` branch, as that is what ROS 2 is currently targeting.  If preferred, I can target it to the `master` branch (though I will then request a backport to `releases/0.8.x` once it is on `master`).