### PR TITLE
Fix warning when building CycloneDDS with gcc 11.

### DIFF
--- a/src/ddsrt/src/threads/posix/threads.c
+++ b/src/ddsrt/src/threads/posix/threads.c
@@ -246,8 +246,8 @@ ddsrt_thread_create (
   if (tattr.stackSize != 0)
   {
 #ifdef PTHREAD_STACK_MIN
-    if (tattr.stackSize < PTHREAD_STACK_MIN)
-      tattr.stackSize = PTHREAD_STACK_MIN;
+    if (tattr.stackSize < (uint32_t)PTHREAD_STACK_MIN)
+      tattr.stackSize = (uint32_t)PTHREAD_STACK_MIN;
 #endif
     if ((result = pthread_attr_setstacksize (&attr, tattr.stackSize)) != 0)
     {


### PR DESCRIPTION
Applying #1041 to master as well.