### PR TITLE
Fix concurrent hopscotch test GC emulation

### DIFF
--- a/src/ddsrt/tests/hopscotch.c
+++ b/src/ddsrt/tests/hopscotch.c
@@ -221,15 +221,16 @@ CU_Theory ((const struct ops *ops, bool random, adj_fun_t adj, const char *adjna
 }
 
 struct gcelem {
+  void *block;
   struct gcelem *next;
 };
 
 static void chhtest_gc (void *block, void *arg)
 {
-  // block is large enough
   // simply defer freeing memory until the end of the test
   struct gcelem **gclist = arg;
-  struct gcelem *elem = block;
+  struct gcelem *elem = ddsrt_malloc (sizeof (*elem));
+  elem->block = block;
   elem->next = *gclist;
   *gclist = elem;
 }
@@ -402,6 +403,7 @@ CU_Test(ddsrt_hopscotch, concurrent, .timeout = 20)
   {
     struct gcelem *elem = gclist;
     gclist = gclist->next;
+    ddsrt_free (elem->block);
     ddsrt_free (elem);
   }
 }


### PR DESCRIPTION
Instead of implementing a "proper" GC that frees the memory shortly
after it becomes safe to do so, the concurrent hopscotch test defers the
freeing until the very of the test. It did this by overwriting the first
few bytes of the block with a singly linked list, even though the data
may still be used afterward.

The first few bytes of the block are the size of the bucket array, and
overwriting with some pointer means a concurrent lookup can end up
calculating a bucket index that is way outside the array, leading to a
segmentation fault.

This is the suspected cause of the observed occasional failure of this
test in the CI.

Signed-off-by: Erik Boasson <eb@ilities.com>