### PR TITLE
Fix ddsperf deadlock

### DIFF
--- a/src/tools/ddsperf/CMakeLists.txt
+++ b/src/tools/ddsperf/CMakeLists.txt
@@ -14,7 +14,11 @@ if (BUILD_DDSPERF)
   include(Generate)
 
   idlc_generate(TARGET ddsperf_types FILES ddsperf_types.idl)
-  add_executable(ddsperf ddsperf.c cputime.c cputime.h netload.c netload.h)
+  add_executable(ddsperf
+    ddsperf.c
+    cputime.c cputime.h
+    netload.c netload.h
+    async_listener.c async_listener.h)
   target_link_libraries(ddsperf ddsperf_types ddsc)
 
   if(WIN32)

--- a/src/tools/ddsperf/async_listener.c
+++ b/src/tools/ddsperf/async_listener.c
@@ -1,0 +1,171 @@
+#include <stdlib.h>
+
+#include "dds/ddsrt/sync.h"
+#include "dds/ddsrt/threads.h"
+#include "dds/dds.h"
+
+#include "async_listener.h"
+
+enum async_listener_kind {
+  ALK_DATA_AVAILABLE,
+  ALK_PUBLICATION_MATCHED,
+  ALK_SUBSCRIPTION_MATCHED
+};
+
+struct async_listener_event {
+  struct async_listener_event *next;
+  enum async_listener_kind kind;
+  dds_entity_t handle;
+  void *fn_arg;
+  union {
+    struct {
+      dds_on_data_available_fn fn;
+    } da;
+    struct {
+      dds_on_publication_matched_fn fn;
+      dds_publication_matched_status_t st;
+    } pm;
+    struct {
+      dds_on_subscription_matched_fn fn;
+      dds_subscription_matched_status_t st;
+    } sm;
+  } u;
+};
+
+struct async_listener {
+  ddsrt_mutex_t lock;
+  ddsrt_cond_t cond;
+  ddsrt_thread_t tid;
+  bool stop;
+  struct async_listener_event *oldest;
+  struct async_listener_event *latest;
+};
+
+static uint32_t async_listener_thread (void *val)
+{
+  struct async_listener * const al = val;
+  ddsrt_mutex_lock (&al->lock);
+  while (!al->stop || al->oldest != NULL)
+  {
+    if (al->oldest == NULL)
+      ddsrt_cond_wait (&al->cond, &al->lock);
+    else
+    {
+      struct async_listener_event *ev = al->oldest;
+      al->oldest = ev->next;
+      ddsrt_mutex_unlock (&al->lock);
+      switch (ev->kind)
+      {
+        case ALK_DATA_AVAILABLE:
+          ev->u.da.fn (ev->handle, ev->fn_arg);
+          break;
+        case ALK_PUBLICATION_MATCHED:
+          ev->u.pm.fn (ev->handle, ev->u.pm.st, ev->fn_arg);
+          break;
+        case ALK_SUBSCRIPTION_MATCHED:
+          ev->u.sm.fn (ev->handle, ev->u.sm.st, ev->fn_arg);
+          break;
+      }
+      free (ev);
+      ddsrt_mutex_lock (&al->lock);
+    }
+  }
+  ddsrt_mutex_unlock (&al->lock);
+  return 0;
+}
+
+struct async_listener *async_listener_new (void)
+{
+  struct async_listener *al;
+  if ((al = malloc (sizeof (*al))) == NULL)
+    return NULL;
+  ddsrt_mutex_init (&al->lock);
+  ddsrt_cond_init (&al->cond);
+  al->stop = 0;
+  al->oldest = NULL;
+  al->latest = NULL;
+  return al;
+}
+
+bool async_listener_start (struct async_listener *al)
+{
+  dds_return_t rc;
+  ddsrt_threadattr_t tattr;
+  ddsrt_threadattr_init (&tattr);
+  rc = ddsrt_thread_create (&al->tid, "al", &tattr, async_listener_thread, al);
+  return rc == 0;
+}
+
+void async_listener_stop (struct async_listener *al)
+{
+  ddsrt_mutex_lock (&al->lock);
+  al->stop = true;
+  ddsrt_cond_signal (&al->cond);
+  ddsrt_mutex_unlock (&al->lock);
+  (void) ddsrt_thread_join (al->tid, NULL);
+  assert (al->oldest == NULL);
+}
+
+void async_listener_free (struct async_listener *al)
+{
+  ddsrt_cond_destroy (&al->cond);
+  ddsrt_mutex_destroy (&al->lock);
+  free (al);
+}
+
+static void async_listener_enqueue (struct async_listener *al, struct async_listener_event ev0)
+{
+  struct async_listener_event *ev;
+  if ((ev = malloc (sizeof (*ev))) == NULL)
+    abort (); // if we run out of memory, ddsperf is dead anyway
+  *ev = ev0;
+  ddsrt_mutex_lock (&al->lock);
+  assert (!al->stop);
+  ev->next = NULL;
+  if (al->oldest)
+    al->latest->next = ev;
+  else
+    al->oldest = ev;
+  al->latest = ev;
+  ddsrt_cond_signal (&al->cond);
+  ddsrt_mutex_unlock (&al->lock);
+}
+
+void async_listener_enqueue_data_available (struct async_listener *al, dds_on_data_available_fn fn, dds_entity_t rd, void *arg)
+{
+  async_listener_enqueue (al, (struct async_listener_event) {
+    .kind = ALK_DATA_AVAILABLE,
+    .handle = rd,
+    .fn_arg = arg,
+    .u = { .da = {
+      .fn = fn
+    } }
+  });
+}
+
+void async_listener_enqueue_subscription_matched (struct async_listener *al, dds_on_subscription_matched_fn fn, dds_entity_t rd, const dds_subscription_matched_status_t status, void *arg)
+{
+  async_listener_enqueue (al, (struct async_listener_event) {
+    .kind = ALK_SUBSCRIPTION_MATCHED,
+    .handle = rd,
+    .fn_arg = arg,
+    .u = { .sm = {
+      .fn = fn,
+      .st = status
+    } }
+  });
+}
+
+void async_listener_enqueue_publication_matched (struct async_listener *al, dds_on_publication_matched_fn fn, dds_entity_t wr, const dds_publication_matched_status_t status, void *arg)
+{
+  async_listener_enqueue (al, (struct async_listener_event) {
+    .kind = ALK_PUBLICATION_MATCHED,
+    .handle = wr,
+    .fn_arg = arg,
+    .u = { .pm = {
+      .fn = fn,
+      .st = status
+    } }
+  });
+}
+

--- a/src/tools/ddsperf/async_listener.h
+++ b/src/tools/ddsperf/async_listener.h
@@ -1,0 +1,17 @@
+#ifndef ASYNC_LISTENER_H
+#define ASYNC_LISTENER_H
+
+#include "dds/ddsrt/attributes.h"
+
+struct async_listener;
+
+struct async_listener *async_listener_new (void) ddsrt_attribute_warn_unused_result;
+bool async_listener_start (struct async_listener *al) ddsrt_nonnull_all;
+void async_listener_stop (struct async_listener *al) ddsrt_nonnull_all;
+void async_listener_free (struct async_listener *al) ddsrt_nonnull_all;
+
+void async_listener_enqueue_data_available (struct async_listener *al, dds_on_data_available_fn fn, dds_entity_t rd, void *arg) ddsrt_nonnull ((1, 2));
+void async_listener_enqueue_subscription_matched (struct async_listener *al, dds_on_subscription_matched_fn fn, dds_entity_t rd, const dds_subscription_matched_status_t status, void *arg) ddsrt_nonnull ((1, 2));
+void async_listener_enqueue_publication_matched (struct async_listener *al, dds_on_publication_matched_fn fn, dds_entity_t wr, const dds_publication_matched_status_t status, void *arg) ddsrt_nonnull ((1, 2));
+
+#endif

--- a/src/tools/ddsperf/ddsperf.c
+++ b/src/tools/ddsperf/ddsperf.c
@@ -1492,18 +1492,12 @@ static void publication_matched_listener (dds_entity_t wr, const dds_publication
 
 static void set_data_available_listener (dds_entity_t rd, const char *rd_name, dds_on_data_available_fn fn, void *arg)
 {
-  /* This convoluted code is so that we leave all listeners unchanged, except the
-     data_available one.  There is no real need for these complications, but it is
-     a nice exercise. */
+  /* Update data available listener leaving the others untouched. */
   dds_listener_t *listener = dds_create_listener (arg);
   dds_return_t rc;
-  dds_lset_data_available (listener, fn);
-  dds_listener_t *tmplistener = dds_create_listener (NULL);
-  if ((rc = dds_get_listener (rd, tmplistener)) < 0)
+  if ((rc = dds_get_listener (rd, listener)) < 0)
     error2 ("dds_get_listener(%s) failed: %d\n", rd_name, (int) rc);
-  dds_merge_listener (listener, tmplistener);
-  dds_delete_listener (tmplistener);
-
+  dds_lset_data_available_arg (listener, fn, arg, true);
   if ((rc = dds_set_listener (rd, listener)) < 0)
     error2 ("dds_set_listener(%s) failed: %d\n", rd_name, (int) rc);
   dds_delete_listener (listener);


### PR DESCRIPTION
Calling create_reader from within a subscription_matched listener can cause a deadlock by a thread biting its own tail. This is an accepted consequence of the synchronous listeners, but it is a nasty pitfall that gets everyone eventually ...

Deadlock signature:
```
  log_stacktrace_sigh + 30
  _sigtramp + 29
  libsystem_blocks.dylib + 1808
  ddsrt_cond_wait + 9
  dds_reader_status_cb + 75
  connect_writer_with_reader_wrapper + 801
  generic_do_match + 1104
  new_writer_guid + 751
  new_writer + 266
  dds_create_writer + 766
  participant_data_listener + 1520
  endpoint_matched_listener + 45
  dds_reader_status_cb + 1524
  connect_writer_with_reader_wrapper + 1066
  generic_do_match + 1104
  new_reader_guid + 3017
  new_reader + 270
  dds_create_reader_int + 944
  main + 3797
  start + 1
```
It would probably be best to implement asynchronous listener invocations and make the current synchronous listeners opt-in for those cases where the timing guarantees of the synchronous ones matter.  For now, however, solve the problem internally in ddsperf by enqueuing the synchronous events for eventual processing.
