### PR TITLE
Add dependency on RouDi for all tests that need it

### DIFF
--- a/src/core/ddsc/tests/CMakeLists.txt
+++ b/src/core/ddsc/tests/CMakeLists.txt
@@ -222,6 +222,8 @@ kill -0 `cat ctest_fixture_iox_roudi.pid`")
       iceoryx_one_writer
       iceoryx_one_writer_dynsize
       iceoryx_return_loan
+      shm_serialization_get_serialized_size
+      shm_serialization_serialize_into
       shm_serialization_transmit_dynamic_type)
     set_tests_properties(CUnit_ddsc_${t} PROPERTIES FIXTURES_REQUIRED iox)
     set_tests_properties(CUnit_ddsc_${t} PROPERTIES RESOURCE_LOCK iox_lock)


### PR DESCRIPTION
The shm_serialization_serialize_into test would occasionally fail, and
it turns out that it wasn't listed as a test dependent on the presence
of RouDi. It seems plausible that RouDi stopping during the test would
cause problems and the CI logs where it failed are not inconsistent with
that.

Signed-off-by: Erik Boasson <eb@ilities.com>