### PR TITLE
Bugfix in extract key from data

### DIFF
--- a/src/core/ddsi/src/ddsi_cdrstream_keys.part.c
+++ b/src/core/ddsi/src/ddsi_cdrstream_keys.part.c
@@ -191,12 +191,14 @@ static const uint32_t *dds_stream_extract_keyBO_from_data1 (dds_istream_t * __re
         }
         else if (is_key)
         {
+          assert (*keys_remaining <= n_keys);
           const uint32_t idx = key[n_keys - *keys_remaining].idx;
           key_offs[idx].src_off = is->m_index;
           key_offs[idx].op_off = ops;
+          ops = dds_stream_extract_key_from_data_skip_adr (is, ops, type);
+          assert (*keys_remaining > 0);
           if (--(*keys_remaining) == 0)
             return ops;
-          ops = dds_stream_extract_key_from_data_skip_adr (is, ops, type);
         }
         else
         {


### PR DESCRIPTION
This fixes a bug in extract key from data in the cdrstream serializer: after storing `ops` and source offset for a key field, skip the field in `ops` and input stream. 