### PR TITLE
Fix two memory leaks in configuration processing

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/ddsi_cfgelems.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_cfgelems.h
@@ -1769,7 +1769,7 @@ static struct cfgelem discovery_peers_cfgelems[] = {
 };
 
 static struct cfgelem discovery_cfgelems[] = {
-  STRING("Tag", NULL, 0, "",
+  STRING("Tag", NULL, 1, "",
     MEMBER(domainTag),
     FUNCTIONS(0, uf_string, ff_free, pf_string),
     DESCRIPTION(
@@ -1863,7 +1863,7 @@ static struct cfgelem discovery_cfgelems[] = {
       "changed.</p>"
     )),
 #ifdef DDS_HAS_TOPIC_DISCOVERY
-  BOOL("EnableTopicDiscoveryEndpoints", NULL, 0, "false",
+  BOOL("EnableTopicDiscoveryEndpoints", NULL, 1, "false",
     MEMBER(enable_topic_discovery_endpoints),
     FUNCTIONS(0, uf_boolean, 0, pf_boolean),
     DESCRIPTION(
@@ -1970,6 +1970,8 @@ static struct cfgelem tracing_cfgelems[] = {
   END_MARKER
 };
 
+/* Multiplicity = 0 is a special for Domain/[@Id] as it has some special processing to
+   only process relevant configuration sections. */
 static struct cfgelem domain_cfgattrs[] = {
   STRING("Id", NULL, 0, "any",
     MEMBER(domainId),

--- a/src/core/ddsi/include/dds/ddsi/ddsi_cfgelems.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_cfgelems.h
@@ -1847,7 +1847,7 @@ static struct cfgelem discovery_cfgelems[] = {
     UNIT("duration")),
   STRING("DefaultMulticastAddress", NULL, 1, "auto",
     MEMBER(defaultMulticastAddressString),
-    FUNCTIONS(0, uf_networkAddress, 0, pf_networkAddress),
+    FUNCTIONS(0, uf_networkAddress, ff_free, pf_networkAddress),
     DESCRIPTION(
       "<p>This element specifies the default multicast address for all "
       "traffic other than participant discovery packets. It defaults to "


### PR DESCRIPTION
The code for overwriting a configuration element set by an earlier configuration fragment frees the old value only if the "multiplicity" is 1, on the grounds that in other cases they would be combined one way or another. The Domain/Tag element had "multiplicity" = 0 causing a leak.

Discovery/EnableTopicDiscoveryEndpoints also had multiplicity incorrectly set to 0. This is a boolean and it was therefore harmless as far as memory allocation go, but it also means it no error would be report if a configuration file gave multiple values for it.

Discovery/DefaultMulticastAddress would leak if set to anything other than "auto" because no free function had been specified.

Fixes #1054.