### PR TITLE
Include the dev documents in the Sphinx documentation

### DIFF
--- a/.azure/publish-documentation.yml
+++ b/.azure/publish-documentation.yml
@@ -43,7 +43,7 @@ steps:
     name: cache_pip
   - bash: |
       set -e -x
-      pip install sphinx breathe exhale sphinx-rtd-theme --user --upgrade
+      pip install sphinx breathe exhale sphinx-rtd-theme myst-parser --user --upgrade
     name: install_sphinx
   - bash: |
       set -e -x

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ gen.*
 .vs/
 .vscode/
 build/
-docs/manual/ddsc_api_docs/

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -29,13 +29,23 @@ if(BUILD_SCHEMA OR BUILD_DOCS)
 endif()
 
 if(BUILD_DOCS)
+  add_custom_target(_dev_document_copy)
+  add_custom_command(
+    TARGET _dev_document_copy
+    COMMAND ${CMAKE_COMMAND} -E copy
+          ${CMAKE_CURRENT_SOURCE_DIR}/dev/*.md
+          ${CMAKE_CURRENT_SOURCE_DIR}/manual/dev/
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+          ${CMAKE_CURRENT_SOURCE_DIR}/dev/pictures
+          ${CMAKE_CURRENT_SOURCE_DIR}/manual/dev/pictures)
+
   find_package(Sphinx REQUIRED breathe exhale)
   sphinx_add_docs(
     docs
     BREATHE_PROJECTS ddsc_api_docs
     BUILDER html
     SOURCE_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/manual")
-  add_dependencies(docs schema)
+  add_dependencies(docs schema _dev_document_copy)
 
   install(
     DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/docs"

--- a/docs/manual/.gitignore
+++ b/docs/manual/.gitignore
@@ -1,0 +1,5 @@
+# Copied dev documents
+dev/*.md
+pictures
+# Exhale generated api docs
+ddsc_api_docs

--- a/docs/manual/dev/index.rst
+++ b/docs/manual/dev/index.rst
@@ -1,0 +1,22 @@
+..
+   Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
+
+   This program and the accompanying materials are made available under the
+   terms of the Eclipse Public License v. 2.0 which is available at
+   http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+   v. 1.0 which is available at
+   http://www.eclipse.org/org/documents/edl-v10.php.
+
+   SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+.. _`Guides`:
+
+#########################
+Guides on assorted topics
+#########################
+
+.. toctree::
+    :maxdepth: 1
+    :glob:
+
+    *

--- a/docs/manual/index.rst
+++ b/docs/manual/index.rst
@@ -20,9 +20,11 @@ Welcome to Eclipse Cyclone DDS's documentation!
 
    GettingStartedGuide/index
    config
+   options
    security
    shared_memory
    ddsc
+   dev/index
 
 Indices and tables
 ==================

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -1,17 +1,18 @@
-# //CycloneDDS
+# CycloneDDS configuration XML reference
+## //CycloneDDS
 Children: [Domain](#cycloneddsdomain)
 
 CycloneDDS configuration
 
 
-## //CycloneDDS/Domain
+### //CycloneDDS/Domain
 Attributes: [Id](#cycloneddsdomainid)
 Children: [Compatibility](#cycloneddsdomaincompatibility), [Discovery](#cycloneddsdomaindiscovery), [General](#cycloneddsdomaingeneral), [Internal](#cycloneddsdomaininternal), [Partitioning](#cycloneddsdomainpartitioning), [SSL](#cycloneddsdomainssl), [Security](#cycloneddsdomainsecurity), [SharedMemory](#cycloneddsdomainsharedmemory), [Sizing](#cycloneddsdomainsizing), [TCP](#cycloneddsdomaintcp), [Threads](#cycloneddsdomainthreads), [Tracing](#cycloneddsdomaintracing)
 
 The General element specifying Domain related settings.
 
 
-## //CycloneDDS/Domain[@Id]
+### //CycloneDDS/Domain[@Id]
 Text
 
 Domain id this configuration applies to, or "any" if it applies to all domain ids.
@@ -19,13 +20,13 @@ Domain id this configuration applies to, or "any" if it applies to all domain id
 The default value is: "any".
 
 
-### //CycloneDDS/Domain/Compatibility
+#### //CycloneDDS/Domain/Compatibility
 Children: [AssumeRtiHasPmdEndpoints](#cycloneddsdomaincompatibilityassumertihaspmdendpoints), [ExplicitlyPublishQosSetToDefault](#cycloneddsdomaincompatibilityexplicitlypublishqossettodefault), [ManySocketsMode](#cycloneddsdomaincompatibilitymanysocketsmode), [StandardsConformance](#cycloneddsdomaincompatibilitystandardsconformance)
 
 The Compatibility elements allows specifying various settings related to compatibility with standards and with other DDSI implementations.
 
 
-#### //CycloneDDS/Domain/Compatibility/AssumeRtiHasPmdEndpoints
+##### //CycloneDDS/Domain/Compatibility/AssumeRtiHasPmdEndpoints
 Boolean
 
 This option assumes ParticipantMessageData endpoints required by the liveliness protocol are present in RTI participants even when not properly advertised by the participant discovery protocol.
@@ -33,7 +34,7 @@ This option assumes ParticipantMessageData endpoints required by the liveliness 
 The default value is: "false".
 
 
-#### //CycloneDDS/Domain/Compatibility/ExplicitlyPublishQosSetToDefault
+##### //CycloneDDS/Domain/Compatibility/ExplicitlyPublishQosSetToDefault
 Boolean
 
 This element specifies whether QoS settings set to default values are explicitly published in the discovery protocol. Implementations are to use the default value for QoS settings not published, which allows a significant reduction of the amount of data that needs to be exchanged for the discovery protocol, but this requires all implementations to adhere to the default values specified by the specifications.
@@ -43,7 +44,7 @@ When interoperability is required with an implementation that does not follow th
 The default value is: "false".
 
 
-#### //CycloneDDS/Domain/Compatibility/ManySocketsMode
+##### //CycloneDDS/Domain/Compatibility/ManySocketsMode
 One of: false, true, single, none, many
 
 This option specifies whether a network socket will be created for each domain participant on a host. The specification seems to assume that each participant has a unique address, and setting this option will ensure this to be the case. This is not the default.
@@ -53,7 +54,7 @@ Disabling it slightly improves performance and reduces network traffic somewhat.
 The default value is: "single".
 
 
-#### //CycloneDDS/Domain/Compatibility/StandardsConformance
+##### //CycloneDDS/Domain/Compatibility/StandardsConformance
 One of: lax, strict, pedantic
 
 This element sets the level of standards conformance of this instance of the Cyclone DDS Service. Stricter conformance typically means less interoperability with other implementations. Currently three modes are defined:
@@ -66,13 +67,13 @@ This element sets the level of standards conformance of this instance of the Cyc
 The default value is: "lax".
 
 
-### //CycloneDDS/Domain/Discovery
+#### //CycloneDDS/Domain/Discovery
 Children: [DSGracePeriod](#cycloneddsdomaindiscoverydsgraceperiod), [DefaultMulticastAddress](#cycloneddsdomaindiscoverydefaultmulticastaddress), [EnableTopicDiscoveryEndpoints](#cycloneddsdomaindiscoveryenabletopicdiscoveryendpoints), [ExternalDomainId](#cycloneddsdomaindiscoveryexternaldomainid), [MaxAutoParticipantIndex](#cycloneddsdomaindiscoverymaxautoparticipantindex), [ParticipantIndex](#cycloneddsdomaindiscoveryparticipantindex), [Peers](#cycloneddsdomaindiscoverypeers), [Ports](#cycloneddsdomaindiscoveryports), [SPDPInterval](#cycloneddsdomaindiscoveryspdpinterval), [SPDPMulticastAddress](#cycloneddsdomaindiscoveryspdpmulticastaddress), [Tag](#cycloneddsdomaindiscoverytag)
 
 The Discovery element allows specifying various parameters related to the discovery of peers.
 
 
-#### //CycloneDDS/Domain/Discovery/DSGracePeriod
+##### //CycloneDDS/Domain/Discovery/DSGracePeriod
 Number-with-unit
 
 This setting controls for how long endpoints discovered via a Cloud discovery service will survive after the discovery service disappeared, allowing reconnect without loss of data when the discovery service restarts (or another instance takes over).
@@ -82,7 +83,7 @@ Valid values are finite durations with an explicit unit or the keyword 'inf' for
 The default value is: "30 s".
 
 
-#### //CycloneDDS/Domain/Discovery/DefaultMulticastAddress
+##### //CycloneDDS/Domain/Discovery/DefaultMulticastAddress
 Text
 
 This element specifies the default multicast address for all traffic other than participant discovery packets. It defaults to Discovery/SPDPMulticastAddress.
@@ -90,7 +91,7 @@ This element specifies the default multicast address for all traffic other than 
 The default value is: "auto".
 
 
-#### //CycloneDDS/Domain/Discovery/EnableTopicDiscoveryEndpoints
+##### //CycloneDDS/Domain/Discovery/EnableTopicDiscoveryEndpoints
 Boolean
 
 This element controls whether the built-in endpoints for topic discovery are created and used to exchange topic discovery information.
@@ -98,7 +99,7 @@ This element controls whether the built-in endpoints for topic discovery are cre
 The default value is: "false".
 
 
-#### //CycloneDDS/Domain/Discovery/ExternalDomainId
+##### //CycloneDDS/Domain/Discovery/ExternalDomainId
 Text
 
 An override for the domain id, to be used in discovery and for determining the port number mapping. This allows creating multiple domains in a single process while making them appear as a single domain on the network. The value "default" disables the override.
@@ -106,7 +107,7 @@ An override for the domain id, to be used in discovery and for determining the p
 The default value is: "default".
 
 
-#### //CycloneDDS/Domain/Discovery/MaxAutoParticipantIndex
+##### //CycloneDDS/Domain/Discovery/MaxAutoParticipantIndex
 Integer
 
 This element specifies the maximum DDSI participant index selected by this instance of the Cyclone DDS service if the Discovery/ParticipantIndex is "auto".
@@ -114,7 +115,7 @@ This element specifies the maximum DDSI participant index selected by this insta
 The default value is: "9".
 
 
-#### //CycloneDDS/Domain/Discovery/ParticipantIndex
+##### //CycloneDDS/Domain/Discovery/ParticipantIndex
 Text
 
 This element specifies the DDSI participant index used by this instance of the Cyclone DDS service for discovery purposes. Only one such participant id is used, independent of the number of actual DomainParticipants on the node. It is either:
@@ -129,19 +130,33 @@ The default is auto. The participant index is part of the port number calculatio
 The default value is: "none".
 
 
-#### //CycloneDDS/Domain/Discovery/Peers
+##### //CycloneDDS/Domain/Discovery/Peers
 Children: [Group](#cycloneddsdomaindiscoverypeersgroup), [Peer](#cycloneddsdomaindiscoverypeerspeer)
 
 This element statically configures addresses for discovery.
 
 
-##### //CycloneDDS/Domain/Discovery/Peers/Group
+###### //CycloneDDS/Domain/Discovery/Peers/Group
 Children: [Peer](#cycloneddsdomaindiscoverypeersgrouppeer)
 
 This element statically configures a fault tolerant group of addresses for discovery. Each member of the group is tried in sequence until one succeeds.
 
 
-###### //CycloneDDS/Domain/Discovery/Peers/Group/Peer
+####### //CycloneDDS/Domain/Discovery/Peers/Group/Peer
+Attributes: [Address](#cycloneddsdomaindiscoverypeersgrouppeeraddress)
+
+This element statically configures an addresses for discovery.
+
+
+####### //CycloneDDS/Domain/Discovery/Peers/Group/Peer[@Address]
+Text
+
+This element specifies an IP address to which discovery packets must be sent, in addition to the default multicast address (see also General/AllowMulticast). Both a hostnames and a numerical IP address is accepted; the hostname or IP address may be suffixed with :PORT to explicitly set the port to which it must be sent. Multiple Peers may be specified.
+
+The default value is: "".
+
+
+###### //CycloneDDS/Domain/Discovery/Peers/Peer
 Attributes: [Address](#cycloneddsdomaindiscoverypeersgrouppeeraddress)
 
 This element statically configures an addresses for discovery.
@@ -155,27 +170,13 @@ This element specifies an IP address to which discovery packets must be sent, in
 The default value is: "".
 
 
-##### //CycloneDDS/Domain/Discovery/Peers/Peer
-Attributes: [Address](#cycloneddsdomaindiscoverypeersgrouppeeraddress)
-
-This element statically configures an addresses for discovery.
-
-
-##### //CycloneDDS/Domain/Discovery/Peers/Group/Peer[@Address]
-Text
-
-This element specifies an IP address to which discovery packets must be sent, in addition to the default multicast address (see also General/AllowMulticast). Both a hostnames and a numerical IP address is accepted; the hostname or IP address may be suffixed with :PORT to explicitly set the port to which it must be sent. Multiple Peers may be specified.
-
-The default value is: "".
-
-
-#### //CycloneDDS/Domain/Discovery/Ports
+##### //CycloneDDS/Domain/Discovery/Ports
 Children: [Base](#cycloneddsdomaindiscoveryportsbase), [DomainGain](#cycloneddsdomaindiscoveryportsdomaingain), [MulticastDataOffset](#cycloneddsdomaindiscoveryportsmulticastdataoffset), [MulticastMetaOffset](#cycloneddsdomaindiscoveryportsmulticastmetaoffset), [ParticipantGain](#cycloneddsdomaindiscoveryportsparticipantgain), [UnicastDataOffset](#cycloneddsdomaindiscoveryportsunicastdataoffset), [UnicastMetaOffset](#cycloneddsdomaindiscoveryportsunicastmetaoffset)
 
 The Ports element allows specifying various parameters related to the port numbers used for discovery. These all have default values specified by the DDSI 2.1 specification and rarely need to be changed.
 
 
-##### //CycloneDDS/Domain/Discovery/Ports/Base
+###### //CycloneDDS/Domain/Discovery/Ports/Base
 Integer
 
 This element specifies the base port number (refer to the DDSI 2.1 specification, section 9.6.1, constant PB).
@@ -183,7 +184,7 @@ This element specifies the base port number (refer to the DDSI 2.1 specification
 The default value is: "7400".
 
 
-##### //CycloneDDS/Domain/Discovery/Ports/DomainGain
+###### //CycloneDDS/Domain/Discovery/Ports/DomainGain
 Integer
 
 This element specifies the domain gain, relating domain ids to sets of port numbers (refer to the DDSI 2.1 specification, section 9.6.1, constant DG).
@@ -191,7 +192,7 @@ This element specifies the domain gain, relating domain ids to sets of port numb
 The default value is: "250".
 
 
-##### //CycloneDDS/Domain/Discovery/Ports/MulticastDataOffset
+###### //CycloneDDS/Domain/Discovery/Ports/MulticastDataOffset
 Integer
 
 This element specifies the port number for multicast data traffic (refer to the DDSI 2.1 specification, section 9.6.1, constant d2).
@@ -199,7 +200,7 @@ This element specifies the port number for multicast data traffic (refer to the 
 The default value is: "1".
 
 
-##### //CycloneDDS/Domain/Discovery/Ports/MulticastMetaOffset
+###### //CycloneDDS/Domain/Discovery/Ports/MulticastMetaOffset
 Integer
 
 This element specifies the port number for multicast meta traffic (refer to the DDSI 2.1 specification, section 9.6.1, constant d0).
@@ -207,7 +208,7 @@ This element specifies the port number for multicast meta traffic (refer to the 
 The default value is: "0".
 
 
-##### //CycloneDDS/Domain/Discovery/Ports/ParticipantGain
+###### //CycloneDDS/Domain/Discovery/Ports/ParticipantGain
 Integer
 
 This element specifies the participant gain, relating p0, participant index to sets of port numbers (refer to the DDSI 2.1 specification, section 9.6.1, constant PG).
@@ -215,7 +216,7 @@ This element specifies the participant gain, relating p0, participant index to s
 The default value is: "2".
 
 
-##### //CycloneDDS/Domain/Discovery/Ports/UnicastDataOffset
+###### //CycloneDDS/Domain/Discovery/Ports/UnicastDataOffset
 Integer
 
 This element specifies the port number for unicast data traffic (refer to the DDSI 2.1 specification, section 9.6.1, constant d3).
@@ -223,7 +224,7 @@ This element specifies the port number for unicast data traffic (refer to the DD
 The default value is: "11".
 
 
-##### //CycloneDDS/Domain/Discovery/Ports/UnicastMetaOffset
+###### //CycloneDDS/Domain/Discovery/Ports/UnicastMetaOffset
 Integer
 
 This element specifies the port number for unicast meta traffic (refer to the DDSI 2.1 specification, section 9.6.1, constant d1).
@@ -231,7 +232,7 @@ This element specifies the port number for unicast meta traffic (refer to the DD
 The default value is: "10".
 
 
-#### //CycloneDDS/Domain/Discovery/SPDPInterval
+##### //CycloneDDS/Domain/Discovery/SPDPInterval
 Number-with-unit
 
 This element specifies the interval between spontaneous transmissions of participant discovery packets.
@@ -241,7 +242,7 @@ The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr,
 The default value is: "30 s".
 
 
-#### //CycloneDDS/Domain/Discovery/SPDPMulticastAddress
+##### //CycloneDDS/Domain/Discovery/SPDPMulticastAddress
 Text
 
 This element specifies the multicast address that is used as the destination for the participant discovery packets. In IPv4 mode the default is the (standardised) 239.255.0.1, in IPv6 mode it becomes ff02::ffff:239.255.0.1, which is a non-standardised link-local multicast address.
@@ -249,7 +250,7 @@ This element specifies the multicast address that is used as the destination for
 The default value is: "239.255.0.1".
 
 
-#### //CycloneDDS/Domain/Discovery/Tag
+##### //CycloneDDS/Domain/Discovery/Tag
 Text
 
 String extension for domain id that remote participants must match to be discovered.
@@ -257,13 +258,13 @@ String extension for domain id that remote participants must match to be discove
 The default value is: "".
 
 
-### //CycloneDDS/Domain/General
+#### //CycloneDDS/Domain/General
 Children: [AllowMulticast](#cycloneddsdomaingeneralallowmulticast), [DontRoute](#cycloneddsdomaingeneraldontroute), [EnableMulticastLoopback](#cycloneddsdomaingeneralenablemulticastloopback), [ExternalNetworkAddress](#cycloneddsdomaingeneralexternalnetworkaddress), [ExternalNetworkMask](#cycloneddsdomaingeneralexternalnetworkmask), [FragmentSize](#cycloneddsdomaingeneralfragmentsize), [MaxMessageSize](#cycloneddsdomaingeneralmaxmessagesize), [MaxRexmitMessageSize](#cycloneddsdomaingeneralmaxrexmitmessagesize), [MulticastRecvNetworkInterfaceAddresses](#cycloneddsdomaingeneralmulticastrecvnetworkinterfaceaddresses), [MulticastTimeToLive](#cycloneddsdomaingeneralmulticasttimetolive), [NetworkInterfaceAddress](#cycloneddsdomaingeneralnetworkinterfaceaddress), [PreferMulticast](#cycloneddsdomaingeneralprefermulticast), [RedundantNetworking](#cycloneddsdomaingeneralredundantnetworking), [Transport](#cycloneddsdomaingeneraltransport), [UseIPv6](#cycloneddsdomaingeneraluseipv)
 
 The General element specifies overall Cyclone DDS service settings.
 
 
-#### //CycloneDDS/Domain/General/AllowMulticast
+##### //CycloneDDS/Domain/General/AllowMulticast
 One of:
 * Keyword: default
 * Comma-separated list of: false, spdp, asm, ssm, true
@@ -286,7 +287,7 @@ When set to "false" all multicasting is disabled. The default, "true" enables fu
 The default value is: "default".
 
 
-#### //CycloneDDS/Domain/General/DontRoute
+##### //CycloneDDS/Domain/General/DontRoute
 Boolean
 
 This element allows setting the SO\_DONTROUTE option for outgoing packets, to bypass the local routing tables. This is generally useful only when the routing tables cannot be trusted, which is highly unusual.
@@ -294,7 +295,7 @@ This element allows setting the SO\_DONTROUTE option for outgoing packets, to by
 The default value is: "false".
 
 
-#### //CycloneDDS/Domain/General/EnableMulticastLoopback
+##### //CycloneDDS/Domain/General/EnableMulticastLoopback
 Boolean
 
 This element specifies whether Cyclone DDS allows IP multicast packets to be visible to all DDSI participants in the same node, including itself. It must be "true" for intra-node multicast communications, but if a node runs only a single Cyclone DDS service and does not host any other DDSI-capable programs, it should be set to "false" for improved performance.
@@ -302,7 +303,7 @@ This element specifies whether Cyclone DDS allows IP multicast packets to be vis
 The default value is: "true".
 
 
-#### //CycloneDDS/Domain/General/ExternalNetworkAddress
+##### //CycloneDDS/Domain/General/ExternalNetworkAddress
 Text
 
 This element allows explicitly overruling the network address Cyclone DDS advertises in the discovery protocol, which by default is the address of the preferred network interface (General/NetworkInterfaceAddress), to allow Cyclone DDS to communicate across a Network Address Translation (NAT) device.
@@ -310,7 +311,7 @@ This element allows explicitly overruling the network address Cyclone DDS advert
 The default value is: "auto".
 
 
-#### //CycloneDDS/Domain/General/ExternalNetworkMask
+##### //CycloneDDS/Domain/General/ExternalNetworkMask
 Text
 
 This element specifies the network mask of the external network address. This element is relevant only when an external network address (General/ExternalNetworkAddress) is explicitly configured. In this case locators received via the discovery protocol that are within the same external subnet (as defined by this mask) will be translated to an internal address by replacing the network portion of the external address with the corresponding portion of the preferred network interface address. This option is IPv4-only.
@@ -318,7 +319,7 @@ This element specifies the network mask of the external network address. This el
 The default value is: "0.0.0.0".
 
 
-#### //CycloneDDS/Domain/General/FragmentSize
+##### //CycloneDDS/Domain/General/FragmentSize
 Number-with-unit
 
 This element specifies the size of DDSI sample fragments generated by Cyclone DDS. Samples larger than FragmentSize are fragmented into fragments of FragmentSize bytes each, except the last one, which may be smaller. The DDSI spec mandates a minimum fragment size of 1025 bytes, but Cyclone DDS will do whatever size is requested, accepting fragments of which the size is at least the minimum of 1025 and FragmentSize.
@@ -328,7 +329,7 @@ The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^
 The default value is: "1344 B".
 
 
-#### //CycloneDDS/Domain/General/MaxMessageSize
+##### //CycloneDDS/Domain/General/MaxMessageSize
 Number-with-unit
 
 This element specifies the maximum size of the UDP payload that Cyclone DDS will generate. Cyclone DDS will try to maintain this limit within the bounds of the DDSI specification, which means that in some cases (especially for very low values of MaxMessageSize) larger payloads may sporadically be observed (currently up to 1192 B).
@@ -340,7 +341,7 @@ The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^
 The default value is: "14720 B".
 
 
-#### //CycloneDDS/Domain/General/MaxRexmitMessageSize
+##### //CycloneDDS/Domain/General/MaxRexmitMessageSize
 Number-with-unit
 
 This element specifies the maximum size of the UDP payload that Cyclone DDS will generate for a retransmit. Cyclone DDS will try to maintain this limit within the bounds of the DDSI specification, which means that in some cases (especially for very low values) larger payloads may sporadically be observed (currently up to 1192 B).
@@ -352,7 +353,7 @@ The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^
 The default value is: "1456 B".
 
 
-#### //CycloneDDS/Domain/General/MulticastRecvNetworkInterfaceAddresses
+##### //CycloneDDS/Domain/General/MulticastRecvNetworkInterfaceAddresses
 Text
 
 This element specifies on which network interfaces Cyclone DDS listens to multicasts. The following options are available:
@@ -373,7 +374,7 @@ If Cyclone DDS is in IPv6 mode and the address of the preferred network interfac
 The default value is: "preferred".
 
 
-#### //CycloneDDS/Domain/General/MulticastTimeToLive
+##### //CycloneDDS/Domain/General/MulticastTimeToLive
 Integer
 
 This element specifies the time-to-live setting for outgoing multicast packets.
@@ -381,7 +382,7 @@ This element specifies the time-to-live setting for outgoing multicast packets.
 The default value is: "32".
 
 
-#### //CycloneDDS/Domain/General/NetworkInterfaceAddress
+##### //CycloneDDS/Domain/General/NetworkInterfaceAddress
 Text
 
 This element specifies the preferred network interface for use by Cyclone DDS. The preferred network interface determines the IP address that Cyclone DDS advertises in the discovery protocol (but see also General/ExternalNetworkAddress), and is also the only interface over which multicasts are transmitted. The interface can be identified by its IP address, network interface name or network portion of the address. If the value "auto" is entered here, Cyclone DDS will select what it considers the most suitable interface.
@@ -389,7 +390,7 @@ This element specifies the preferred network interface for use by Cyclone DDS. T
 The default value is: "auto".
 
 
-#### //CycloneDDS/Domain/General/PreferMulticast
+##### //CycloneDDS/Domain/General/PreferMulticast
 Boolean
 
 When false (default) Cyclone DDS uses unicast for data whenever there a single unicast suffices. Setting this to true makes it prefer multicasting data, falling back to unicast only when no multicast address is available.
@@ -397,7 +398,7 @@ When false (default) Cyclone DDS uses unicast for data whenever there a single u
 The default value is: "false".
 
 
-#### //CycloneDDS/Domain/General/RedundantNetworking
+##### //CycloneDDS/Domain/General/RedundantNetworking
 Boolean
 
 When enabled, use selected network interfaces in parallel for redundancy.
@@ -405,7 +406,7 @@ When enabled, use selected network interfaces in parallel for redundancy.
 The default value is: "false".
 
 
-#### //CycloneDDS/Domain/General/Transport
+##### //CycloneDDS/Domain/General/Transport
 One of: default, udp, udp6, tcp, tcp6, raweth
 
 This element allows selecting the transport to be used (udp, udp6, tcp, tcp6, raweth)
@@ -413,7 +414,7 @@ This element allows selecting the transport to be used (udp, udp6, tcp, tcp6, ra
 The default value is: "default".
 
 
-#### //CycloneDDS/Domain/General/UseIPv6
+##### //CycloneDDS/Domain/General/UseIPv6
 One of: false, true, default
 
 Deprecated (use Transport instead)
@@ -421,13 +422,13 @@ Deprecated (use Transport instead)
 The default value is: "default".
 
 
-### //CycloneDDS/Domain/Internal
+#### //CycloneDDS/Domain/Internal
 Children: [AccelerateRexmitBlockSize](#cycloneddsdomaininternalacceleraterexmitblocksize), [AckDelay](#cycloneddsdomaininternalackdelay), [AssumeMulticastCapable](#cycloneddsdomaininternalassumemulticastcapable), [AutoReschedNackDelay](#cycloneddsdomaininternalautoreschednackdelay), [BuiltinEndpointSet](#cycloneddsdomaininternalbuiltinendpointset), [BurstSize](#cycloneddsdomaininternalburstsize), [ControlTopic](#cycloneddsdomaininternalcontroltopic), [DDSI2DirectMaxThreads](#cycloneddsdomaininternalddsidirectmaxthreads), [DefragReliableMaxSamples](#cycloneddsdomaininternaldefragreliablemaxsamples), [DefragUnreliableMaxSamples](#cycloneddsdomaininternaldefragunreliablemaxsamples), [DeliveryQueueMaxSamples](#cycloneddsdomaininternaldeliveryqueuemaxsamples), [EnableExpensiveChecks](#cycloneddsdomaininternalenableexpensivechecks), [GenerateKeyhash](#cycloneddsdomaininternalgeneratekeyhash), [HeartbeatInterval](#cycloneddsdomaininternalheartbeatinterval), [LateAckMode](#cycloneddsdomaininternallateackmode), [LeaseDuration](#cycloneddsdomaininternalleaseduration), [LivelinessMonitoring](#cycloneddsdomaininternallivelinessmonitoring), [MaxParticipants](#cycloneddsdomaininternalmaxparticipants), [MaxQueuedRexmitBytes](#cycloneddsdomaininternalmaxqueuedrexmitbytes), [MaxQueuedRexmitMessages](#cycloneddsdomaininternalmaxqueuedrexmitmessages), [MaxSampleSize](#cycloneddsdomaininternalmaxsamplesize), [MeasureHbToAckLatency](#cycloneddsdomaininternalmeasurehbtoacklatency), [MonitorPort](#cycloneddsdomaininternalmonitorport), [MultipleReceiveThreads](#cycloneddsdomaininternalmultiplereceivethreads), [NackDelay](#cycloneddsdomaininternalnackdelay), [PreEmptiveAckDelay](#cycloneddsdomaininternalpreemptiveackdelay), [PrimaryReorderMaxSamples](#cycloneddsdomaininternalprimaryreordermaxsamples), [PrioritizeRetransmit](#cycloneddsdomaininternalprioritizeretransmit), [RediscoveryBlacklistDuration](#cycloneddsdomaininternalrediscoveryblacklistduration), [RetransmitMerging](#cycloneddsdomaininternalretransmitmerging), [RetransmitMergingPeriod](#cycloneddsdomaininternalretransmitmergingperiod), [RetryOnRejectBestEffort](#cycloneddsdomaininternalretryonrejectbesteffort), [SPDPResponseMaxDelay](#cycloneddsdomaininternalspdpresponsemaxdelay), [ScheduleTimeRounding](#cycloneddsdomaininternalscheduletimerounding), [SecondaryReorderMaxSamples](#cycloneddsdomaininternalsecondaryreordermaxsamples), [SocketReceiveBufferSize](#cycloneddsdomaininternalsocketreceivebuffersize), [SocketSendBufferSize](#cycloneddsdomaininternalsocketsendbuffersize), [SquashParticipants](#cycloneddsdomaininternalsquashparticipants), [SynchronousDeliveryLatencyBound](#cycloneddsdomaininternalsynchronousdeliverylatencybound), [SynchronousDeliveryPriorityThreshold](#cycloneddsdomaininternalsynchronousdeliveryprioritythreshold), [Test](#cycloneddsdomaininternaltest), [UnicastResponseToSPDPMessages](#cycloneddsdomaininternalunicastresponsetospdpmessages), [UseMulticastIfMreqn](#cycloneddsdomaininternalusemulticastifmreqn), [Watermarks](#cycloneddsdomaininternalwatermarks), [WriteBatch](#cycloneddsdomaininternalwritebatch), [WriterLingerDuration](#cycloneddsdomaininternalwriterlingerduration)
 
 The Internal elements deal with a variety of settings that evolving and that are not necessarily fully supported. For the vast majority of the Internal settings, the functionality per-se is supported, but the right to change the way the options control the functionality is reserved. This includes renaming or moving options.
 
 
-#### //CycloneDDS/Domain/Internal/AccelerateRexmitBlockSize
+##### //CycloneDDS/Domain/Internal/AccelerateRexmitBlockSize
 Integer
 
 Proxy readers that are assumed to sill be retrieving historical data get this many samples retransmitted when they NACK something, even if some of these samples have sequence numbers outside the set covered by the NACK.
@@ -435,7 +436,7 @@ Proxy readers that are assumed to sill be retrieving historical data get this ma
 The default value is: "0".
 
 
-#### //CycloneDDS/Domain/Internal/AckDelay
+##### //CycloneDDS/Domain/Internal/AckDelay
 Number-with-unit
 
 This setting controls the delay between sending identical acknowledgements.
@@ -445,7 +446,7 @@ The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr,
 The default value is: "10 ms".
 
 
-#### //CycloneDDS/Domain/Internal/AssumeMulticastCapable
+##### //CycloneDDS/Domain/Internal/AssumeMulticastCapable
 Text
 
 This element controls which network interfaces are assumed to be capable of multicasting even when the interface flags returned by the operating system state it is not (this provides a workaround for some platforms). It is a comma-separated lists of patterns (with ? and \* wildcards) against which the interface names are matched.
@@ -453,7 +454,7 @@ This element controls which network interfaces are assumed to be capable of mult
 The default value is: "".
 
 
-#### //CycloneDDS/Domain/Internal/AutoReschedNackDelay
+##### //CycloneDDS/Domain/Internal/AutoReschedNackDelay
 Number-with-unit
 
 This setting controls the interval with which a reader will continue NACK'ing missing samples in the absence of a response from the writer, as a protection mechanism against writers incorrectly stopping the sending of HEARTBEAT messages.
@@ -463,7 +464,7 @@ Valid values are finite durations with an explicit unit or the keyword 'inf' for
 The default value is: "1 s".
 
 
-#### //CycloneDDS/Domain/Internal/BuiltinEndpointSet
+##### //CycloneDDS/Domain/Internal/BuiltinEndpointSet
 One of: full, writers, minimal
 
 This element controls which participants will have which built-in endpoints for the discovery and liveliness protocols. Valid values are:
@@ -478,13 +479,13 @@ The default is writers, as this is thought to be compliant and reasonably effici
 The default value is: "writers".
 
 
-#### //CycloneDDS/Domain/Internal/BurstSize
+##### //CycloneDDS/Domain/Internal/BurstSize
 Children: [MaxInitTransmit](#cycloneddsdomaininternalburstsizemaxinittransmit), [MaxRexmit](#cycloneddsdomaininternalburstsizemaxrexmit)
 
 Setting for controlling the size of transmit bursts.
 
 
-##### //CycloneDDS/Domain/Internal/BurstSize/MaxInitTransmit
+###### //CycloneDDS/Domain/Internal/BurstSize/MaxInitTransmit
 Number-with-unit
 
 This element specifies how much more than the (presumed or discovered) receive buffer size may be sent when transmitting a sample for the first time, expressed as a percentage; the remainder will then be handled via retransmits. Usually the receivers can keep up with transmitter, at least on average, and so generally it is better to hope for the best and recover. Besides, the retransmits will be unicast, and so any multicast advantage will be lost as well.
@@ -494,7 +495,7 @@ The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^
 The default value is: "4294967295".
 
 
-##### //CycloneDDS/Domain/Internal/BurstSize/MaxRexmit
+###### //CycloneDDS/Domain/Internal/BurstSize/MaxRexmit
 Number-with-unit
 
 This element specifies the amount of data to be retransmitted in response to one NACK.
@@ -504,11 +505,11 @@ The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^
 The default value is: "1 MiB".
 
 
-#### //CycloneDDS/Domain/Internal/ControlTopic
+##### //CycloneDDS/Domain/Internal/ControlTopic
 The ControlTopic element allows configured whether Cyclone DDS provides a special control interface via a predefined topic or not.
 
 
-#### //CycloneDDS/Domain/Internal/DDSI2DirectMaxThreads
+##### //CycloneDDS/Domain/Internal/DDSI2DirectMaxThreads
 Integer
 
 This element sets the maximum number of extra threads for an experimental, undocumented and unsupported direct mode.
@@ -516,7 +517,7 @@ This element sets the maximum number of extra threads for an experimental, undoc
 The default value is: "1".
 
 
-#### //CycloneDDS/Domain/Internal/DefragReliableMaxSamples
+##### //CycloneDDS/Domain/Internal/DefragReliableMaxSamples
 Integer
 
 This element sets the maximum number of samples that can be defragmented simultaneously for a reliable writer. This has to be large enough to handle retransmissions of historical data in addition to new samples.
@@ -524,7 +525,7 @@ This element sets the maximum number of samples that can be defragmented simulta
 The default value is: "16".
 
 
-#### //CycloneDDS/Domain/Internal/DefragUnreliableMaxSamples
+##### //CycloneDDS/Domain/Internal/DefragUnreliableMaxSamples
 Integer
 
 This element sets the maximum number of samples that can be defragmented simultaneously for a best-effort writers.
@@ -532,7 +533,7 @@ This element sets the maximum number of samples that can be defragmented simulta
 The default value is: "4".
 
 
-#### //CycloneDDS/Domain/Internal/DeliveryQueueMaxSamples
+##### //CycloneDDS/Domain/Internal/DeliveryQueueMaxSamples
 Integer
 
 This element controls the maximum size of a delivery queue, expressed in samples. Once a delivery queue is full, incoming samples destined for that queue are dropped until space becomes available again.
@@ -540,7 +541,7 @@ This element controls the maximum size of a delivery queue, expressed in samples
 The default value is: "256".
 
 
-#### //CycloneDDS/Domain/Internal/EnableExpensiveChecks
+##### //CycloneDDS/Domain/Internal/EnableExpensiveChecks
 One of:
 * Comma-separated list of: whc, rhc, xevent, all
 * Or empty
@@ -558,7 +559,7 @@ In addition, there is the keyword all that enables all checks.
 The default value is: "".
 
 
-#### //CycloneDDS/Domain/Internal/GenerateKeyhash
+##### //CycloneDDS/Domain/Internal/GenerateKeyhash
 Boolean
 
 When true, include keyhashes in outgoing data for topics with keys.
@@ -566,7 +567,7 @@ When true, include keyhashes in outgoing data for topics with keys.
 The default value is: "false".
 
 
-#### //CycloneDDS/Domain/Internal/HeartbeatInterval
+##### //CycloneDDS/Domain/Internal/HeartbeatInterval
 Attributes: [max](#cycloneddsdomaininternalheartbeatintervalmax), [min](#cycloneddsdomaininternalheartbeatintervalmin), [minsched](#cycloneddsdomaininternalheartbeatintervalminsched)
 
 Number-with-unit
@@ -578,7 +579,7 @@ Valid values are finite durations with an explicit unit or the keyword 'inf' for
 The default value is: "100 ms".
 
 
-#### //CycloneDDS/Domain/Internal/HeartbeatInterval[@max]
+##### //CycloneDDS/Domain/Internal/HeartbeatInterval[@max]
 Number-with-unit
 
 This attribute sets the maximum interval for periodic heartbeats.
@@ -588,7 +589,7 @@ Valid values are finite durations with an explicit unit or the keyword 'inf' for
 The default value is: "8 s".
 
 
-#### //CycloneDDS/Domain/Internal/HeartbeatInterval[@min]
+##### //CycloneDDS/Domain/Internal/HeartbeatInterval[@min]
 Number-with-unit
 
 This attribute sets the minimum interval that must have passed since the most recent heartbeat from a writer, before another asynchronous (not directly related to writing) will be sent.
@@ -598,7 +599,7 @@ Valid values are finite durations with an explicit unit or the keyword 'inf' for
 The default value is: "5 ms".
 
 
-#### //CycloneDDS/Domain/Internal/HeartbeatInterval[@minsched]
+##### //CycloneDDS/Domain/Internal/HeartbeatInterval[@minsched]
 Number-with-unit
 
 This attribute sets the minimum interval for periodic heartbeats. Other events may still cause heartbeats to go out.
@@ -608,7 +609,7 @@ Valid values are finite durations with an explicit unit or the keyword 'inf' for
 The default value is: "20 ms".
 
 
-#### //CycloneDDS/Domain/Internal/LateAckMode
+##### //CycloneDDS/Domain/Internal/LateAckMode
 Boolean
 
 Ack a sample only when it has been delivered, instead of when committed to delivering it.
@@ -616,7 +617,7 @@ Ack a sample only when it has been delivered, instead of when committed to deliv
 The default value is: "false".
 
 
-#### //CycloneDDS/Domain/Internal/LeaseDuration
+##### //CycloneDDS/Domain/Internal/LeaseDuration
 Number-with-unit
 
 This setting controls the default participant lease duration.
@@ -625,7 +626,7 @@ The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr,
 The default value is: "10 s".
 
 
-#### //CycloneDDS/Domain/Internal/LivelinessMonitoring
+##### //CycloneDDS/Domain/Internal/LivelinessMonitoring
 Attributes: [Interval](#cycloneddsdomaininternallivelinessmonitoringinterval), [StackTraces](#cycloneddsdomaininternallivelinessmonitoringstacktraces)
 
 Boolean
@@ -635,7 +636,7 @@ This element controls whether or not implementation should internally monitor it
 The default value is: "false".
 
 
-#### //CycloneDDS/Domain/Internal/LivelinessMonitoring[@Interval]
+##### //CycloneDDS/Domain/Internal/LivelinessMonitoring[@Interval]
 Number-with-unit
 
 This element controls the interval at which to check whether threads have been making progress.
@@ -645,7 +646,7 @@ The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr,
 The default value is: "1s".
 
 
-#### //CycloneDDS/Domain/Internal/LivelinessMonitoring[@StackTraces]
+##### //CycloneDDS/Domain/Internal/LivelinessMonitoring[@StackTraces]
 Boolean
 
 This element controls whether or not to write stack traces to the DDSI2 trace when a thread fails to make progress (on select platforms only).
@@ -653,7 +654,7 @@ This element controls whether or not to write stack traces to the DDSI2 trace wh
 The default value is: "true".
 
 
-#### //CycloneDDS/Domain/Internal/MaxParticipants
+##### //CycloneDDS/Domain/Internal/MaxParticipants
 Integer
 
 This elements configures the maximum number of DCPS domain participants this Cyclone DDS instance is willing to service. 0 is unlimited.
@@ -661,7 +662,7 @@ This elements configures the maximum number of DCPS domain participants this Cyc
 The default value is: "0".
 
 
-#### //CycloneDDS/Domain/Internal/MaxQueuedRexmitBytes
+##### //CycloneDDS/Domain/Internal/MaxQueuedRexmitBytes
 Number-with-unit
 
 This setting limits the maximum number of bytes queued for retransmission. The default value of 0 is unlimited unless an AuxiliaryBandwidthLimit has been set, in which case it becomes NackDelay \* AuxiliaryBandwidthLimit. It must be large enough to contain the largest sample that may need to be retransmitted.
@@ -671,7 +672,7 @@ The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^
 The default value is: "512 kB".
 
 
-#### //CycloneDDS/Domain/Internal/MaxQueuedRexmitMessages
+##### //CycloneDDS/Domain/Internal/MaxQueuedRexmitMessages
 Integer
 
 This settings limits the maximum number of samples queued for retransmission.
@@ -679,7 +680,7 @@ This settings limits the maximum number of samples queued for retransmission.
 The default value is: "200".
 
 
-#### //CycloneDDS/Domain/Internal/MaxSampleSize
+##### //CycloneDDS/Domain/Internal/MaxSampleSize
 Number-with-unit
 
 This setting controls the maximum (CDR) serialised size of samples that Cyclone DDS will forward in either direction. Samples larger than this are discarded with a warning.
@@ -689,7 +690,7 @@ The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^
 The default value is: "2147483647 B".
 
 
-#### //CycloneDDS/Domain/Internal/MeasureHbToAckLatency
+##### //CycloneDDS/Domain/Internal/MeasureHbToAckLatency
 Boolean
 
 This element enables heartbeat-to-ack latency among Cyclone DDS services by prepending timestamps to Heartbeat and AckNack messages and calculating round trip times. This is non-standard behaviour. The measured latencies are quite noisy and are currently not used anywhere.
@@ -697,7 +698,7 @@ This element enables heartbeat-to-ack latency among Cyclone DDS services by prep
 The default value is: "false".
 
 
-#### //CycloneDDS/Domain/Internal/MonitorPort
+##### //CycloneDDS/Domain/Internal/MonitorPort
 Integer
 
 This element allows configuring a service that dumps a text description of part the internal state to TCP clients. By default (-1), this is disabled; specifying 0 means a kernel-allocated port is used; a positive number is used as the TCP port number.
@@ -705,7 +706,7 @@ This element allows configuring a service that dumps a text description of part 
 The default value is: "-1".
 
 
-#### //CycloneDDS/Domain/Internal/MultipleReceiveThreads
+##### //CycloneDDS/Domain/Internal/MultipleReceiveThreads
 Attributes: [maxretries](#cycloneddsdomaininternalmultiplereceivethreadsmaxretries)
 
 One of: false, true, default
@@ -715,7 +716,7 @@ This element controls whether all traffic is handled by a single receive thread 
 The default value is: "default".
 
 
-#### //CycloneDDS/Domain/Internal/MultipleReceiveThreads[@maxretries]
+##### //CycloneDDS/Domain/Internal/MultipleReceiveThreads[@maxretries]
 Integer
 
 Receive threads dedicated to a single socket can only be triggered for termination by sending a packet. Reception of any packet will do, so termination failure due to packet loss is exceedingly unlikely, but to eliminate all risks, it will retry as many times as specified by this attribute before aborting.
@@ -723,7 +724,7 @@ Receive threads dedicated to a single socket can only be triggered for terminati
 The default value is: "4294967295".
 
 
-#### //CycloneDDS/Domain/Internal/NackDelay
+##### //CycloneDDS/Domain/Internal/NackDelay
 Number-with-unit
 
 This setting controls the delay between receipt of a HEARTBEAT indicating missing samples and a NACK (ignored when the HEARTBEAT requires an answer). However, no NACK is sent if a NACK had been scheduled already for a response earlier than the delay requests: then that NACK will incorporate the latest information.
@@ -733,7 +734,7 @@ The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr,
 The default value is: "100 ms".
 
 
-#### //CycloneDDS/Domain/Internal/PreEmptiveAckDelay
+##### //CycloneDDS/Domain/Internal/PreEmptiveAckDelay
 Number-with-unit
 
 This setting controls the delay between the discovering a remote writer and sending a pre-emptive AckNack to discover the range of data available.
@@ -743,7 +744,7 @@ The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr,
 The default value is: "10 ms".
 
 
-#### //CycloneDDS/Domain/Internal/PrimaryReorderMaxSamples
+##### //CycloneDDS/Domain/Internal/PrimaryReorderMaxSamples
 Integer
 
 This element sets the maximum size in samples of a primary re-order administration. Each proxy writer has one primary re-order administration to buffer the packet flow in case some packets arrive out of order. Old samples are forwarded to secondary re-order administrations associated with readers in need of historical data.
@@ -751,7 +752,7 @@ This element sets the maximum size in samples of a primary re-order administrati
 The default value is: "128".
 
 
-#### //CycloneDDS/Domain/Internal/PrioritizeRetransmit
+##### //CycloneDDS/Domain/Internal/PrioritizeRetransmit
 Boolean
 
 This element controls whether retransmits are prioritized over new data, speeding up recovery.
@@ -759,7 +760,7 @@ This element controls whether retransmits are prioritized over new data, speedin
 The default value is: "true".
 
 
-#### //CycloneDDS/Domain/Internal/RediscoveryBlacklistDuration
+##### //CycloneDDS/Domain/Internal/RediscoveryBlacklistDuration
 Attributes: [enforce](#cycloneddsdomaininternalrediscoveryblacklistdurationenforce)
 
 Number-with-unit
@@ -771,7 +772,7 @@ Valid values are finite durations with an explicit unit or the keyword 'inf' for
 The default value is: "0s".
 
 
-#### //CycloneDDS/Domain/Internal/RediscoveryBlacklistDuration[@enforce]
+##### //CycloneDDS/Domain/Internal/RediscoveryBlacklistDuration[@enforce]
 Boolean
 
 This attribute controls whether the configured time during which recently deleted participants will not be rediscovered (i.e., "black listed") is enforced and following complete removal of the participant in Cyclone DDS, or whether it can be rediscovered earlier provided all traces of that participant have been removed already.
@@ -779,7 +780,7 @@ This attribute controls whether the configured time during which recently delete
 The default value is: "false".
 
 
-#### //CycloneDDS/Domain/Internal/RetransmitMerging
+##### //CycloneDDS/Domain/Internal/RetransmitMerging
 One of: never, adaptive, always
 
 This elements controls the addressing and timing of retransmits. Possible values are:
@@ -794,7 +795,7 @@ The default is never. See also Internal/RetransmitMergingPeriod.
 The default value is: "never".
 
 
-#### //CycloneDDS/Domain/Internal/RetransmitMergingPeriod
+##### //CycloneDDS/Domain/Internal/RetransmitMergingPeriod
 Number-with-unit
 
 This setting determines the size of the time window in which a NACK of some sample is ignored because a retransmit of that sample has been multicasted too recently. This setting has no effect on unicasted retransmits.
@@ -806,7 +807,7 @@ The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr,
 The default value is: "5 ms".
 
 
-#### //CycloneDDS/Domain/Internal/RetryOnRejectBestEffort
+##### //CycloneDDS/Domain/Internal/RetryOnRejectBestEffort
 Boolean
 
 Whether or not to locally retry pushing a received best-effort sample into the reader caches when resource limits are reached.
@@ -814,7 +815,7 @@ Whether or not to locally retry pushing a received best-effort sample into the r
 The default value is: "false".
 
 
-#### //CycloneDDS/Domain/Internal/SPDPResponseMaxDelay
+##### //CycloneDDS/Domain/Internal/SPDPResponseMaxDelay
 Number-with-unit
 
 Maximum pseudo-random delay in milliseconds between discovering aremote participant and responding to it.
@@ -824,7 +825,7 @@ The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr,
 The default value is: "0 ms".
 
 
-#### //CycloneDDS/Domain/Internal/ScheduleTimeRounding
+##### //CycloneDDS/Domain/Internal/ScheduleTimeRounding
 Number-with-unit
 
 This setting allows the timing of scheduled events to be rounded up so that more events can be handled in a single cycle of the event queue. The default is 0 and causes no rounding at all, i.e. are scheduled exactly, whereas a value of 10ms would mean that events are rounded up to the nearest 10 milliseconds.
@@ -834,7 +835,7 @@ The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr,
 The default value is: "0 ms".
 
 
-#### //CycloneDDS/Domain/Internal/SecondaryReorderMaxSamples
+##### //CycloneDDS/Domain/Internal/SecondaryReorderMaxSamples
 Integer
 
 This element sets the maximum size in samples of a secondary re-order administration. The secondary re-order administration is per reader in need of historical data.
@@ -842,7 +843,7 @@ This element sets the maximum size in samples of a secondary re-order administra
 The default value is: "128".
 
 
-#### //CycloneDDS/Domain/Internal/SocketReceiveBufferSize
+##### //CycloneDDS/Domain/Internal/SocketReceiveBufferSize
 Attributes: [max](#cycloneddsdomaininternalsocketreceivebuffersizemax), [min](#cycloneddsdomaininternalsocketreceivebuffersizemin)
 
 The settings in this element control the size of the socket receive buffers. The operating system provides some size receive buffer upon creation of the socket, this option can be used to increase the size of the buffer beyond that initially provided by the operating system. If the buffer size cannot be increased to the requested minimum size, an error is reported.
@@ -850,7 +851,7 @@ The settings in this element control the size of the socket receive buffers. The
 The default setting requests a buffer size of 1MiB but accepts whatever is available after that.
 
 
-#### //CycloneDDS/Domain/Internal/SocketReceiveBufferSize[@max]
+##### //CycloneDDS/Domain/Internal/SocketReceiveBufferSize[@max]
 Number-with-unit
 
 This sets the size of the socket receive buffer to request, with the special value of "default" indicating that it should try to satisfy the minimum buffer size. If both are at "default", it will request 1MiB and accept anything. If the maximum is set to less than the minimum, it is ignored.
@@ -860,7 +861,7 @@ The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^
 The default value is: "default".
 
 
-#### //CycloneDDS/Domain/Internal/SocketReceiveBufferSize[@min]
+##### //CycloneDDS/Domain/Internal/SocketReceiveBufferSize[@min]
 Number-with-unit
 
 This sets the minimum acceptable socket receive buffer size, with the special value "default" indicating that whatever is available is acceptable.
@@ -870,7 +871,7 @@ The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^
 The default value is: "default".
 
 
-#### //CycloneDDS/Domain/Internal/SocketSendBufferSize
+##### //CycloneDDS/Domain/Internal/SocketSendBufferSize
 Attributes: [max](#cycloneddsdomaininternalsocketsendbuffersizemax), [min](#cycloneddsdomaininternalsocketsendbuffersizemin)
 
 The settings in this element control the size of the socket send buffers. The operating system provides some size send buffer upon creation of the socket, this option can be used to increase the size of the buffer beyond that initially provided by the operating system. If the buffer size cannot be increased to the requested minimum size, an error is reported.
@@ -878,7 +879,7 @@ The settings in this element control the size of the socket send buffers. The op
 The default setting requires a buffer of at least 64KiB.
 
 
-#### //CycloneDDS/Domain/Internal/SocketSendBufferSize[@max]
+##### //CycloneDDS/Domain/Internal/SocketSendBufferSize[@max]
 Number-with-unit
 
 This sets the size of the socket send buffer to request, with the special value of "default" indicating that it should try to satisfy the minimum buffer size. If both are at "default", it will use whatever is the system default. If the maximum is set to less than the minimum, it is ignored.
@@ -888,7 +889,7 @@ The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^
 The default value is: "default".
 
 
-#### //CycloneDDS/Domain/Internal/SocketSendBufferSize[@min]
+##### //CycloneDDS/Domain/Internal/SocketSendBufferSize[@min]
 Number-with-unit
 
 This sets the minimum acceptable socket send buffer size, with the special value "default" indicating that whatever is available is acceptable.
@@ -898,7 +899,7 @@ The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^
 The default value is: "64 KiB".
 
 
-#### //CycloneDDS/Domain/Internal/SquashParticipants
+##### //CycloneDDS/Domain/Internal/SquashParticipants
 Boolean
 
 This element controls whether Cyclone DDS advertises all the domain participants it serves in DDSI (when set to false), or rather only one domain participant (the one corresponding to the Cyclone DDS process; when set to true). In the latter case Cyclone DDS becomes the virtual owner of all readers and writers of all domain participants, dramatically reducing discovery traffic (a similar effect can be obtained by setting Internal/BuiltinEndpointSet to "minimal" but with less loss of information).
@@ -906,7 +907,7 @@ This element controls whether Cyclone DDS advertises all the domain participants
 The default value is: "false".
 
 
-#### //CycloneDDS/Domain/Internal/SynchronousDeliveryLatencyBound
+##### //CycloneDDS/Domain/Internal/SynchronousDeliveryLatencyBound
 Number-with-unit
 
 This element controls whether samples sent by a writer with QoS settings transport\_priority >= SynchronousDeliveryPriorityThreshold and a latency\_budget at most this element's value will be delivered synchronously from the "recv" thread, all others will be delivered asynchronously through delivery queues. This reduces latency at the expense of aggregate bandwidth.
@@ -916,7 +917,7 @@ Valid values are finite durations with an explicit unit or the keyword 'inf' for
 The default value is: "inf".
 
 
-#### //CycloneDDS/Domain/Internal/SynchronousDeliveryPriorityThreshold
+##### //CycloneDDS/Domain/Internal/SynchronousDeliveryPriorityThreshold
 Integer
 
 This element controls whether samples sent by a writer with QoS settings latency\_budget <= SynchronousDeliveryLatencyBound and transport\_priority greater than or equal to this element's value will be delivered synchronously from the "recv" thread, all others will be delivered asynchronously through delivery queues. This reduces latency at the expense of aggregate bandwidth.
@@ -924,13 +925,13 @@ This element controls whether samples sent by a writer with QoS settings latency
 The default value is: "0".
 
 
-#### //CycloneDDS/Domain/Internal/Test
+##### //CycloneDDS/Domain/Internal/Test
 Children: [XmitLossiness](#cycloneddsdomaininternaltestxmitlossiness)
 
 Testing options.
 
 
-##### //CycloneDDS/Domain/Internal/Test/XmitLossiness
+###### //CycloneDDS/Domain/Internal/Test/XmitLossiness
 Integer
 
 This element controls the fraction of outgoing packets to drop, specified as samples per thousand.
@@ -938,7 +939,7 @@ This element controls the fraction of outgoing packets to drop, specified as sam
 The default value is: "0".
 
 
-#### //CycloneDDS/Domain/Internal/UnicastResponseToSPDPMessages
+##### //CycloneDDS/Domain/Internal/UnicastResponseToSPDPMessages
 Boolean
 
 This element controls whether the response to a newly discovered participant is sent as a unicasted SPDP packet, instead of rescheduling the periodic multicasted one. There is no known benefit to setting this to false.
@@ -946,7 +947,7 @@ This element controls whether the response to a newly discovered participant is 
 The default value is: "true".
 
 
-#### //CycloneDDS/Domain/Internal/UseMulticastIfMreqn
+##### //CycloneDDS/Domain/Internal/UseMulticastIfMreqn
 Integer
 
 Do not use.
@@ -954,13 +955,13 @@ Do not use.
 The default value is: "0".
 
 
-#### //CycloneDDS/Domain/Internal/Watermarks
+##### //CycloneDDS/Domain/Internal/Watermarks
 Children: [WhcAdaptive](#cycloneddsdomaininternalwatermarkswhcadaptive), [WhcHigh](#cycloneddsdomaininternalwatermarkswhchigh), [WhcHighInit](#cycloneddsdomaininternalwatermarkswhchighinit), [WhcLow](#cycloneddsdomaininternalwatermarkswhclow)
 
 Watermarks for flow-control.
 
 
-##### //CycloneDDS/Domain/Internal/Watermarks/WhcAdaptive
+###### //CycloneDDS/Domain/Internal/Watermarks/WhcAdaptive
 Boolean
 
 This element controls whether Cyclone DDS will adapt the high-water mark to current traffic conditions, based on retransmit requests and transmit pressure.
@@ -968,7 +969,7 @@ This element controls whether Cyclone DDS will adapt the high-water mark to curr
 The default value is: "true".
 
 
-##### //CycloneDDS/Domain/Internal/Watermarks/WhcHigh
+###### //CycloneDDS/Domain/Internal/Watermarks/WhcHigh
 Number-with-unit
 
 This element sets the maximum allowed high-water mark for the Cyclone DDS WHCs, expressed in bytes. A writer is suspended when the WHC reaches this size.
@@ -978,7 +979,7 @@ The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^
 The default value is: "500 kB".
 
 
-##### //CycloneDDS/Domain/Internal/Watermarks/WhcHighInit
+###### //CycloneDDS/Domain/Internal/Watermarks/WhcHighInit
 Number-with-unit
 
 This element sets the initial level of the high-water mark for the Cyclone DDS WHCs, expressed in bytes.
@@ -988,7 +989,7 @@ The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^
 The default value is: "30 kB".
 
 
-##### //CycloneDDS/Domain/Internal/Watermarks/WhcLow
+###### //CycloneDDS/Domain/Internal/Watermarks/WhcLow
 Number-with-unit
 
 This element sets the low-water mark for the Cyclone DDS WHCs, expressed in bytes. A suspended writer resumes transmitting when its Cyclone DDS WHC shrinks to this size.
@@ -998,7 +999,7 @@ The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^
 The default value is: "1 kB".
 
 
-#### //CycloneDDS/Domain/Internal/WriteBatch
+##### //CycloneDDS/Domain/Internal/WriteBatch
 Boolean
 
 This element enables the batching of write operations. By default each write operation writes through the write cache and out onto the transport. Enabling write batching causes multiple small write operations to be aggregated within the write cache into a single larger write. This gives greater throughput at the expense of latency. Currently there is no mechanism for the write cache to automatically flush itself, so that if write batching is enabled, the application may have to use the dds\_write\_flush function to ensure that all samples are written.
@@ -1006,7 +1007,7 @@ This element enables the batching of write operations. By default each write ope
 The default value is: "false".
 
 
-#### //CycloneDDS/Domain/Internal/WriterLingerDuration
+##### //CycloneDDS/Domain/Internal/WriterLingerDuration
 Number-with-unit
 
 This setting controls the maximum duration for which actual deletion of a reliable writer with unacknowledged data in its history will be postponed to provide proper reliable transmission.
@@ -1015,19 +1016,19 @@ The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr,
 The default value is: "1 s".
 
 
-### //CycloneDDS/Domain/Partitioning
+#### //CycloneDDS/Domain/Partitioning
 Children: [IgnoredPartitions](#cycloneddsdomainpartitioningignoredpartitions), [NetworkPartitions](#cycloneddsdomainpartitioningnetworkpartitions), [PartitionMappings](#cycloneddsdomainpartitioningpartitionmappings)
 
 The Partitioning element specifies Cyclone DDS network partitions and how DCPS partition/topic combinations are mapped onto the network partitions.
 
 
-#### //CycloneDDS/Domain/Partitioning/IgnoredPartitions
+##### //CycloneDDS/Domain/Partitioning/IgnoredPartitions
 Children: [IgnoredPartition](#cycloneddsdomainpartitioningignoredpartitionsignoredpartition)
 
 The IgnoredPartitions element specifies DCPS partition/topic combinations that are not distributed over the network.
 
 
-##### //CycloneDDS/Domain/Partitioning/IgnoredPartitions/IgnoredPartition
+###### //CycloneDDS/Domain/Partitioning/IgnoredPartitions/IgnoredPartition
 Attributes: [DCPSPartitionTopic](#cycloneddsdomainpartitioningignoredpartitionsignoredpartitiondcpspartitiontopic)
 
 Text
@@ -1037,7 +1038,7 @@ This element can be used to prevent certain combinations of DCPS partition and t
 The default value is: "".
 
 
-##### //CycloneDDS/Domain/Partitioning/IgnoredPartitions/IgnoredPartition[@DCPSPartitionTopic]
+###### //CycloneDDS/Domain/Partitioning/IgnoredPartitions/IgnoredPartition[@DCPSPartitionTopic]
 Text
 
 This attribute specifies a partition and a topic expression, separated by a single '.', that are used to determine if a given partition and topic will be ignored or not. The expressions may use the usual wildcards '\*' and '?'. Cyclone DDS will consider an wildcard DCPS partition to match an expression iff there exists a string that satisfies both expressions.
@@ -1045,13 +1046,13 @@ This attribute specifies a partition and a topic expression, separated by a sing
 The default value is: "".
 
 
-#### //CycloneDDS/Domain/Partitioning/NetworkPartitions
+##### //CycloneDDS/Domain/Partitioning/NetworkPartitions
 Children: [NetworkPartition](#cycloneddsdomainpartitioningnetworkpartitionsnetworkpartition)
 
 The NetworkPartitions element specifies the Cyclone DDS network partitions.
 
 
-##### //CycloneDDS/Domain/Partitioning/NetworkPartitions/NetworkPartition
+###### //CycloneDDS/Domain/Partitioning/NetworkPartitions/NetworkPartition
 Attributes: [Address](#cycloneddsdomainpartitioningnetworkpartitionsnetworkpartitionaddress), [Name](#cycloneddsdomainpartitioningnetworkpartitionsnetworkpartitionname)
 
 Text
@@ -1061,7 +1062,7 @@ This element defines a Cyclone DDS network partition.
 The default value is: "".
 
 
-##### //CycloneDDS/Domain/Partitioning/NetworkPartitions/NetworkPartition[@Address]
+###### //CycloneDDS/Domain/Partitioning/NetworkPartitions/NetworkPartition[@Address]
 Text
 
 This attribute specifies the multicast addresses associated with the network partition as a comma-separated list. Readers matching this network partition (cf. Partitioning/PartitionMappings) will listen for multicasts on all of these addresses and advertise them in the discovery protocol. The writers will select the most suitable address from the addresses advertised by the readers.
@@ -1069,7 +1070,7 @@ This attribute specifies the multicast addresses associated with the network par
 The default value is: "".
 
 
-##### //CycloneDDS/Domain/Partitioning/NetworkPartitions/NetworkPartition[@Name]
+###### //CycloneDDS/Domain/Partitioning/NetworkPartitions/NetworkPartition[@Name]
 Text
 
 This attribute specifies the name of this Cyclone DDS network partition. Two network partitions cannot have the same name.
@@ -1077,13 +1078,13 @@ This attribute specifies the name of this Cyclone DDS network partition. Two net
 The default value is: "".
 
 
-#### //CycloneDDS/Domain/Partitioning/PartitionMappings
+##### //CycloneDDS/Domain/Partitioning/PartitionMappings
 Children: [PartitionMapping](#cycloneddsdomainpartitioningpartitionmappingspartitionmapping)
 
 The PartitionMappings element specifies the mapping from DCPS partition/topic combinations to Cyclone DDS network partitions.
 
 
-##### //CycloneDDS/Domain/Partitioning/PartitionMappings/PartitionMapping
+###### //CycloneDDS/Domain/Partitioning/PartitionMappings/PartitionMapping
 Attributes: [DCPSPartitionTopic](#cycloneddsdomainpartitioningpartitionmappingspartitionmappingdcpspartitiontopic), [NetworkPartition](#cycloneddsdomainpartitioningpartitionmappingspartitionmappingnetworkpartition)
 
 Text
@@ -1093,7 +1094,7 @@ This element defines a mapping from a DCPS partition/topic combination to a Cycl
 The default value is: "".
 
 
-##### //CycloneDDS/Domain/Partitioning/PartitionMappings/PartitionMapping[@DCPSPartitionTopic]
+###### //CycloneDDS/Domain/Partitioning/PartitionMappings/PartitionMapping[@DCPSPartitionTopic]
 Text
 
 This attribute specifies a partition and a topic expression, separated by a single '.', that are used to determine if a given partition and topic maps to the Cyclone DDS network partition named by the NetworkPartition attribute in this PartitionMapping element. The expressions may use the usual wildcards '\*' and '?'. Cyclone DDS will consider a wildcard DCPS partition to match an expression if there exists a string that satisfies both expressions.
@@ -1101,7 +1102,7 @@ This attribute specifies a partition and a topic expression, separated by a sing
 The default value is: "".
 
 
-##### //CycloneDDS/Domain/Partitioning/PartitionMappings/PartitionMapping[@NetworkPartition]
+###### //CycloneDDS/Domain/Partitioning/PartitionMappings/PartitionMapping[@NetworkPartition]
 Text
 
 This attribute specifies which Cyclone DDS network partition is to be used for DCPS partition/topic combinations matching the DCPSPartitionTopic attribute within this PartitionMapping element.
@@ -1109,13 +1110,13 @@ This attribute specifies which Cyclone DDS network partition is to be used for D
 The default value is: "".
 
 
-### //CycloneDDS/Domain/SSL
+#### //CycloneDDS/Domain/SSL
 Children: [CertificateVerification](#cycloneddsdomainsslcertificateverification), [Ciphers](#cycloneddsdomainsslciphers), [Enable](#cycloneddsdomainsslenable), [EntropyFile](#cycloneddsdomainsslentropyfile), [KeyPassphrase](#cycloneddsdomainsslkeypassphrase), [KeystoreFile](#cycloneddsdomainsslkeystorefile), [MinimumTLSVersion](#cycloneddsdomainsslminimumtlsversion), [SelfSignedCertificates](#cycloneddsdomainsslselfsignedcertificates), [VerifyClient](#cycloneddsdomainsslverifyclient)
 
 The SSL element allows specifying various parameters related to using SSL/TLS for DDSI over TCP.
 
 
-#### //CycloneDDS/Domain/SSL/CertificateVerification
+##### //CycloneDDS/Domain/SSL/CertificateVerification
 Boolean
 
 If disabled this allows SSL connections to occur even if an X509 certificate fails verification.
@@ -1123,7 +1124,7 @@ If disabled this allows SSL connections to occur even if an X509 certificate fai
 The default value is: "true".
 
 
-#### //CycloneDDS/Domain/SSL/Ciphers
+##### //CycloneDDS/Domain/SSL/Ciphers
 Text
 
 The set of ciphers used by SSL/TLS
@@ -1131,7 +1132,7 @@ The set of ciphers used by SSL/TLS
 The default value is: "ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH".
 
 
-#### //CycloneDDS/Domain/SSL/Enable
+##### //CycloneDDS/Domain/SSL/Enable
 Boolean
 
 This enables SSL/TLS for TCP.
@@ -1139,7 +1140,7 @@ This enables SSL/TLS for TCP.
 The default value is: "false".
 
 
-#### //CycloneDDS/Domain/SSL/EntropyFile
+##### //CycloneDDS/Domain/SSL/EntropyFile
 Text
 
 The SSL/TLS random entropy file name.
@@ -1147,7 +1148,7 @@ The SSL/TLS random entropy file name.
 The default value is: "".
 
 
-#### //CycloneDDS/Domain/SSL/KeyPassphrase
+##### //CycloneDDS/Domain/SSL/KeyPassphrase
 Text
 
 The SSL/TLS key pass phrase for encrypted keys.
@@ -1155,7 +1156,7 @@ The SSL/TLS key pass phrase for encrypted keys.
 The default value is: "secret".
 
 
-#### //CycloneDDS/Domain/SSL/KeystoreFile
+##### //CycloneDDS/Domain/SSL/KeystoreFile
 Text
 
 The SSL/TLS key and certificate store file name. The keystore must be in PEM format.
@@ -1163,7 +1164,7 @@ The SSL/TLS key and certificate store file name. The keystore must be in PEM for
 The default value is: "keystore".
 
 
-#### //CycloneDDS/Domain/SSL/MinimumTLSVersion
+##### //CycloneDDS/Domain/SSL/MinimumTLSVersion
 Text
 
 The minimum TLS version that may be negotiated, valid values are 1.2 and 1.3.
@@ -1171,7 +1172,7 @@ The minimum TLS version that may be negotiated, valid values are 1.2 and 1.3.
 The default value is: "1.3".
 
 
-#### //CycloneDDS/Domain/SSL/SelfSignedCertificates
+##### //CycloneDDS/Domain/SSL/SelfSignedCertificates
 Boolean
 
 This enables the use of self signed X509 certificates.
@@ -1179,7 +1180,7 @@ This enables the use of self signed X509 certificates.
 The default value is: "false".
 
 
-#### //CycloneDDS/Domain/SSL/VerifyClient
+##### //CycloneDDS/Domain/SSL/VerifyClient
 Boolean
 
 This enables an SSL server checking the X509 certificate of a connecting client.
@@ -1187,19 +1188,19 @@ This enables an SSL server checking the X509 certificate of a connecting client.
 The default value is: "true".
 
 
-### //CycloneDDS/Domain/Security
+#### //CycloneDDS/Domain/Security
 Children: [AccessControl](#cycloneddsdomainsecurityaccesscontrol), [Authentication](#cycloneddsdomainsecurityauthentication), [Cryptographic](#cycloneddsdomainsecuritycryptographic)
 
 This element is used to configure Cyclone DDS with the DDS Security specification plugins and settings.
 
 
-#### //CycloneDDS/Domain/Security/AccessControl
+##### //CycloneDDS/Domain/Security/AccessControl
 Children: [Governance](#cycloneddsdomainsecurityaccesscontrolgovernance), [Library](#cycloneddsdomainsecurityaccesscontrollibrary), [Permissions](#cycloneddsdomainsecurityaccesscontrolpermissions), [PermissionsCA](#cycloneddsdomainsecurityaccesscontrolpermissionsca)
 
 This element configures the Access Control plugin of the DDS Security specification.
 
 
-##### //CycloneDDS/Domain/Security/AccessControl/Governance
+###### //CycloneDDS/Domain/Security/AccessControl/Governance
 Text
 
 URI to the shared Governance Document signed by the Permissions CA in S/MIME format
@@ -1249,7 +1250,7 @@ MIIDuAYJKoZIhv ...al5s=
 The default value is: "".
 
 
-##### //CycloneDDS/Domain/Security/AccessControl/Library
+###### //CycloneDDS/Domain/Security/AccessControl/Library
 Attributes: [finalizeFunction](#cycloneddsdomainsecurityaccesscontrollibraryfinalizefunction), [initFunction](#cycloneddsdomainsecurityaccesscontrollibraryinitfunction), [path](#cycloneddsdomainsecurityaccesscontrollibrarypath)
 
 Text
@@ -1259,7 +1260,7 @@ This element specifies the library to be loaded as the DDS Security Access Contr
 The default value is: "".
 
 
-##### //CycloneDDS/Domain/Security/AccessControl/Library[@finalizeFunction]
+###### //CycloneDDS/Domain/Security/AccessControl/Library[@finalizeFunction]
 Text
 
 This element names the finalization function of Access Control plugin. This function is called to let the plugin release its resources.
@@ -1267,7 +1268,7 @@ This element names the finalization function of Access Control plugin. This func
 The default value is: "finalize\_access\_control".
 
 
-##### //CycloneDDS/Domain/Security/AccessControl/Library[@initFunction]
+###### //CycloneDDS/Domain/Security/AccessControl/Library[@initFunction]
 Text
 
 This element names the initialization function of Access Control plugin. This function is called after loading the plugin library for instantiation purposes. Init function must return an object that implements DDS Security Access Control interface.
@@ -1275,7 +1276,7 @@ This element names the initialization function of Access Control plugin. This fu
 The default value is: "init\_access\_control".
 
 
-##### //CycloneDDS/Domain/Security/AccessControl/Library[@path]
+###### //CycloneDDS/Domain/Security/AccessControl/Library[@path]
 Text
 
 This element points to the path of Access Control plugin library.
@@ -1287,7 +1288,7 @@ If single file is supplied, the library located by way of the current working di
 The default value is: "dds\_security\_ac".
 
 
-##### //CycloneDDS/Domain/Security/AccessControl/Permissions
+###### //CycloneDDS/Domain/Security/AccessControl/Permissions
 Text
 
 URI to the DomainParticipant permissions document signed by the Permissions CA in S/MIME format
@@ -1306,7 +1307,7 @@ Example data URI:
 The default value is: "".
 
 
-##### //CycloneDDS/Domain/Security/AccessControl/PermissionsCA
+###### //CycloneDDS/Domain/Security/AccessControl/PermissionsCA
 Text
 
 URI to a X509 certificate for the PermissionsCA in PEM format.
@@ -1327,13 +1328,13 @@ MIIC3DCCAcQCCQCWE5x+Z ... PhovK0mp2ohhRLYI0ZiyYQ==
 The default value is: "".
 
 
-#### //CycloneDDS/Domain/Security/Authentication
+##### //CycloneDDS/Domain/Security/Authentication
 Children: [CRL](#cycloneddsdomainsecurityauthenticationcrl), [IdentityCA](#cycloneddsdomainsecurityauthenticationidentityca), [IdentityCertificate](#cycloneddsdomainsecurityauthenticationidentitycertificate), [IncludeOptionalFields](#cycloneddsdomainsecurityauthenticationincludeoptionalfields), [Library](#cycloneddsdomainsecurityauthenticationlibrary), [Password](#cycloneddsdomainsecurityauthenticationpassword), [PrivateKey](#cycloneddsdomainsecurityauthenticationprivatekey), [TrustedCADirectory](#cycloneddsdomainsecurityauthenticationtrustedcadirectory)
 
 This element configures the Authentication plugin of the DDS Security specification.
 
 
-##### //CycloneDDS/Domain/Security/Authentication/CRL
+###### //CycloneDDS/Domain/Security/Authentication/CRL
 Text
 
 Optional URI to load an X509 Certificate Revocation List
@@ -1351,7 +1352,7 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg=<br>
 The default value is: "".
 
 
-##### //CycloneDDS/Domain/Security/Authentication/IdentityCA
+###### //CycloneDDS/Domain/Security/Authentication/IdentityCA
 Text
 
 URI to the X509 certificate [39] of the Identity CA that is the signer of Identity Certificate.
@@ -1371,7 +1372,7 @@ MIIC3DCCAcQCCQCWE5x+Z...PhovK0mp2ohhRLYI0ZiyYQ==<br>
 The default value is: "".
 
 
-##### //CycloneDDS/Domain/Security/Authentication/IdentityCertificate
+###### //CycloneDDS/Domain/Security/Authentication/IdentityCertificate
 Text
 
 Identity certificate that will be used for identifying all participants in the OSPL instance.<br>The content is URI to a X509 certificate signed by the IdentityCA in PEM format containing the signed public key.
@@ -1389,7 +1390,7 @@ MIIDjjCCAnYCCQDCEu9...6rmT87dhTo=<br>
 The default value is: "".
 
 
-##### //CycloneDDS/Domain/Security/Authentication/IncludeOptionalFields
+###### //CycloneDDS/Domain/Security/Authentication/IncludeOptionalFields
 Boolean
 
 The authentication handshake tokens may contain optional fields to be included for finding interoperability problems. If this parameter is set to true the optional fields are included in the handshake token exchange.
@@ -1397,7 +1398,7 @@ The authentication handshake tokens may contain optional fields to be included f
 The default value is: "false".
 
 
-##### //CycloneDDS/Domain/Security/Authentication/Library
+###### //CycloneDDS/Domain/Security/Authentication/Library
 Attributes: [finalizeFunction](#cycloneddsdomainsecurityauthenticationlibraryfinalizefunction), [initFunction](#cycloneddsdomainsecurityauthenticationlibraryinitfunction), [path](#cycloneddsdomainsecurityauthenticationlibrarypath)
 
 Text
@@ -1407,7 +1408,7 @@ This element specifies the library to be loaded as the DDS Security Access Contr
 The default value is: "".
 
 
-##### //CycloneDDS/Domain/Security/Authentication/Library[@finalizeFunction]
+###### //CycloneDDS/Domain/Security/Authentication/Library[@finalizeFunction]
 Text
 
 This element names the finalization function of Authentication plugin. This function is called to let the plugin release its resources.
@@ -1415,7 +1416,7 @@ This element names the finalization function of Authentication plugin. This func
 The default value is: "finalize\_authentication".
 
 
-##### //CycloneDDS/Domain/Security/Authentication/Library[@initFunction]
+###### //CycloneDDS/Domain/Security/Authentication/Library[@initFunction]
 Text
 
 This element names the initialization function of Authentication plugin. This function is called after loading the plugin library for instantiation purposes. Init function must return an object that implements DDS Security Authentication interface.
@@ -1423,7 +1424,7 @@ This element names the initialization function of Authentication plugin. This fu
 The default value is: "init\_authentication".
 
 
-##### //CycloneDDS/Domain/Security/Authentication/Library[@path]
+###### //CycloneDDS/Domain/Security/Authentication/Library[@path]
 Text
 
 This element points to the path of Authentication plugin library.
@@ -1435,7 +1436,7 @@ If single file is supplied, the library located by way of the current working di
 The default value is: "dds\_security\_auth".
 
 
-##### //CycloneDDS/Domain/Security/Authentication/Password
+###### //CycloneDDS/Domain/Security/Authentication/Password
 Text
 
 A password used to decrypt the private\_key.
@@ -1447,7 +1448,7 @@ If the password property is not present, then the value supplied in the private\
 The default value is: "".
 
 
-##### //CycloneDDS/Domain/Security/Authentication/PrivateKey
+###### //CycloneDDS/Domain/Security/Authentication/PrivateKey
 Text
 
 URI to access the private Private Key for all of the participants in the OSPL federation.
@@ -1465,7 +1466,7 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==<br>
 The default value is: "".
 
 
-##### //CycloneDDS/Domain/Security/Authentication/TrustedCADirectory
+###### //CycloneDDS/Domain/Security/Authentication/TrustedCADirectory
 Text
 
 Trusted CA Directory which contains trusted CA certificates as separated files.
@@ -1473,13 +1474,13 @@ Trusted CA Directory which contains trusted CA certificates as separated files.
 The default value is: "".
 
 
-#### //CycloneDDS/Domain/Security/Cryptographic
+##### //CycloneDDS/Domain/Security/Cryptographic
 Children: [Library](#cycloneddsdomainsecuritycryptographiclibrary)
 
 This element configures the Cryptographic plugin of the DDS Security specification.
 
 
-##### //CycloneDDS/Domain/Security/Cryptographic/Library
+###### //CycloneDDS/Domain/Security/Cryptographic/Library
 Attributes: [finalizeFunction](#cycloneddsdomainsecuritycryptographiclibraryfinalizefunction), [initFunction](#cycloneddsdomainsecuritycryptographiclibraryinitfunction), [path](#cycloneddsdomainsecuritycryptographiclibrarypath)
 
 Text
@@ -1489,7 +1490,7 @@ This element specifies the library to be loaded as the DDS Security Cryptographi
 The default value is: "".
 
 
-##### //CycloneDDS/Domain/Security/Cryptographic/Library[@finalizeFunction]
+###### //CycloneDDS/Domain/Security/Cryptographic/Library[@finalizeFunction]
 Text
 
 This element names the finalization function of Cryptographic plugin. This function is called to let the plugin release its resources.
@@ -1497,7 +1498,7 @@ This element names the finalization function of Cryptographic plugin. This funct
 The default value is: "finalize\_crypto".
 
 
-##### //CycloneDDS/Domain/Security/Cryptographic/Library[@initFunction]
+###### //CycloneDDS/Domain/Security/Cryptographic/Library[@initFunction]
 Text
 
 This element names the initialization function of Cryptographic plugin. This function is called after loading the plugin library for instantiation purposes. Init function must return an object that implements DDS Security Cryptographic interface.
@@ -1505,7 +1506,7 @@ This element names the initialization function of Cryptographic plugin. This fun
 The default value is: "init\_crypto".
 
 
-##### //CycloneDDS/Domain/Security/Cryptographic/Library[@path]
+###### //CycloneDDS/Domain/Security/Cryptographic/Library[@path]
 Text
 
 This element points to the path of Cryptographic plugin library.
@@ -1516,14 +1517,13 @@ If single file is supplied, the library located by way of the current working di
 
 The default value is: "dds\_security\_crypto".
 
-
-### //CycloneDDS/Domain/SharedMemory
+#### //CycloneDDS/Domain/SharedMemory
 Children: [Enable](#cycloneddsdomainsharedmemoryenable), [Locator](#cycloneddsdomainsharedmemorylocator), [LogLevel](#cycloneddsdomainsharedmemoryloglevel), [Prefix](#cycloneddsdomainsharedmemoryprefix), [PubHistoryCapacity](#cycloneddsdomainsharedmemorypubhistorycapacity), [SubHistoryRequest](#cycloneddsdomainsharedmemorysubhistoryrequest), [SubQueueCapacity](#cycloneddsdomainsharedmemorysubqueuecapacity)
 
 The Shared Memory element allows specifying various parameters related to using shared memory.
 
 
-#### //CycloneDDS/Domain/SharedMemory/Enable
+##### //CycloneDDS/Domain/SharedMemory/Enable
 Boolean
 
 This element allows to enable shared memory in Cyclone DDS.
@@ -1531,7 +1531,7 @@ This element allows to enable shared memory in Cyclone DDS.
 The default value is: "false".
 
 
-#### //CycloneDDS/Domain/SharedMemory/Locator
+##### //CycloneDDS/Domain/SharedMemory/Locator
 Text
 
 Explicitly set the Iceoryx locator used by Cyclone to check whether a pair of processes is attached to the same Iceoryx shared memory.  The default is to use one of the MAC addresses of the machine, which should work well in most cases.
@@ -1539,7 +1539,7 @@ Explicitly set the Iceoryx locator used by Cyclone to check whether a pair of pr
 The default value is: "".
 
 
-#### //CycloneDDS/Domain/SharedMemory/LogLevel
+##### //CycloneDDS/Domain/SharedMemory/LogLevel
 One of: off, fatal, error, warn, info, debug, verbose
 
 This element decides the verbosity level of shared memory message:
@@ -1562,7 +1562,7 @@ If you don't want to see any log from shared memory, use off to disable log mess
 The default value is: "info".
 
 
-#### //CycloneDDS/Domain/SharedMemory/Prefix
+##### //CycloneDDS/Domain/SharedMemory/Prefix
 Text
 
 Override the Iceoryx service name used by Cyclone.
@@ -1570,7 +1570,7 @@ Override the Iceoryx service name used by Cyclone.
 The default value is: "DDS\_CYCLONE".
 
 
-#### //CycloneDDS/Domain/SharedMemory/PubHistoryCapacity
+##### //CycloneDDS/Domain/SharedMemory/PubHistoryCapacity
 Integer
 
 The number of messages which will be stored on the publisher for late joining subscribers. Should be a value between 0 and 16 and be equal to or larger than SubHistoryRequest.
@@ -1578,7 +1578,7 @@ The number of messages which will be stored on the publisher for late joining su
 The default value is: "16".
 
 
-#### //CycloneDDS/Domain/SharedMemory/SubHistoryRequest
+##### //CycloneDDS/Domain/SharedMemory/SubHistoryRequest
 Integer
 
 The number of messages published before subscription which will be requested by a subscriber upon subscription. Should be a value between 0 and 16.
@@ -1586,7 +1586,7 @@ The number of messages published before subscription which will be requested by 
 The default value is: "16".
 
 
-#### //CycloneDDS/Domain/SharedMemory/SubQueueCapacity
+##### //CycloneDDS/Domain/SharedMemory/SubQueueCapacity
 Integer
 
 Size of the history chunk queue, this is the amount of messages stored between taking from the iceoryx subscriber, exceeding this number will cause the oldest to be pushed off the queue. Should be a value between 1 and 256.
@@ -1594,13 +1594,14 @@ Size of the history chunk queue, this is the amount of messages stored between t
 The default value is: "256".
 
 
-### //CycloneDDS/Domain/Sizing
+
+#### //CycloneDDS/Domain/Sizing
 Children: [ReceiveBufferChunkSize](#cycloneddsdomainsizingreceivebufferchunksize), [ReceiveBufferSize](#cycloneddsdomainsizingreceivebuffersize)
 
 The Sizing element specifies a variety of configuration settings dealing with expected system sizes, buffer sizes, &c.
 
 
-#### //CycloneDDS/Domain/Sizing/ReceiveBufferChunkSize
+##### //CycloneDDS/Domain/Sizing/ReceiveBufferChunkSize
 Number-with-unit
 
 This element specifies the size of one allocation unit in the receive buffer. Must be greater than the maximum packet size by a modest amount (too large packets are dropped). Each allocation is shrunk immediately after processing a message, or freed straightaway.
@@ -1610,7 +1611,7 @@ The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^
 The default value is: "128 KiB".
 
 
-#### //CycloneDDS/Domain/Sizing/ReceiveBufferSize
+##### //CycloneDDS/Domain/Sizing/ReceiveBufferSize
 Number-with-unit
 
 This element sets the size of a single receive buffer. Many receive buffers may be needed. The minimum workable size a little bit larger than Sizing/ReceiveBufferChunkSize, and the value used is taken as the configured value and the actual minimum workable size.
@@ -1620,13 +1621,13 @@ The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^
 The default value is: "1 MiB".
 
 
-### //CycloneDDS/Domain/TCP
+#### //CycloneDDS/Domain/TCP
 Children: [AlwaysUsePeeraddrForUnicast](#cycloneddsdomaintcpalwaysusepeeraddrforunicast), [Enable](#cycloneddsdomaintcpenable), [NoDelay](#cycloneddsdomaintcpnodelay), [Port](#cycloneddsdomaintcpport), [ReadTimeout](#cycloneddsdomaintcpreadtimeout), [WriteTimeout](#cycloneddsdomaintcpwritetimeout)
 
 The TCP element allows specifying various parameters related to running DDSI over TCP.
 
 
-#### //CycloneDDS/Domain/TCP/AlwaysUsePeeraddrForUnicast
+##### //CycloneDDS/Domain/TCP/AlwaysUsePeeraddrForUnicast
 Boolean
 
 Setting this to true means the unicast addresses in SPDP packets will be ignored and the peer address from the TCP connection will be used instead. This may help work around incorrectly advertised addresses when using TCP.
@@ -1634,7 +1635,7 @@ Setting this to true means the unicast addresses in SPDP packets will be ignored
 The default value is: "false".
 
 
-#### //CycloneDDS/Domain/TCP/Enable
+##### //CycloneDDS/Domain/TCP/Enable
 One of: false, true, default
 
 This element enables the optional TCP transport - deprecated, use General/Transport instead.
@@ -1642,7 +1643,7 @@ This element enables the optional TCP transport - deprecated, use General/Transp
 The default value is: "default".
 
 
-#### //CycloneDDS/Domain/TCP/NoDelay
+##### //CycloneDDS/Domain/TCP/NoDelay
 Boolean
 
 This element enables the TCP\_NODELAY socket option, preventing multiple DDSI messages being sent in the same TCP request. Setting this option typically optimises latency over throughput.
@@ -1650,7 +1651,7 @@ This element enables the TCP\_NODELAY socket option, preventing multiple DDSI me
 The default value is: "true".
 
 
-#### //CycloneDDS/Domain/TCP/Port
+##### //CycloneDDS/Domain/TCP/Port
 Integer
 
 This element specifies the TCP port number on which Cyclone DDS accepts connections. If the port is set it is used in entity locators, published with DDSI discovery. Dynamically allocated if zero. Disabled if -1 or not configured. If disabled other DDSI services will not be able to establish connections with the service, the service can only communicate by establishing connections to other services.
@@ -1658,7 +1659,7 @@ This element specifies the TCP port number on which Cyclone DDS accepts connecti
 The default value is: "-1".
 
 
-#### //CycloneDDS/Domain/TCP/ReadTimeout
+##### //CycloneDDS/Domain/TCP/ReadTimeout
 Number-with-unit
 
 This element specifies the timeout for blocking TCP read operations. If this timeout expires then the connection is closed.
@@ -1668,7 +1669,7 @@ The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr,
 The default value is: "2 s".
 
 
-#### //CycloneDDS/Domain/TCP/WriteTimeout
+##### //CycloneDDS/Domain/TCP/WriteTimeout
 Number-with-unit
 
 This element specifies the timeout for blocking TCP write operations. If this timeout expires then the connection is closed.
@@ -1678,20 +1679,20 @@ The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr,
 The default value is: "2 s".
 
 
-### //CycloneDDS/Domain/Threads
+#### //CycloneDDS/Domain/Threads
 Children: [Thread](#cycloneddsdomainthreadsthread)
 
 This element is used to set thread properties.
 
 
-#### //CycloneDDS/Domain/Threads/Thread
+##### //CycloneDDS/Domain/Threads/Thread
 Attributes: [Name](#cycloneddsdomainthreadsthreadname)
 Children: [Scheduling](#cycloneddsdomainthreadsthreadscheduling), [StackSize](#cycloneddsdomainthreadsthreadstacksize)
 
 This element is used to set thread properties.
 
 
-#### //CycloneDDS/Domain/Threads/Thread[@Name]
+##### //CycloneDDS/Domain/Threads/Thread[@Name]
 Text
 
 The Name of the thread for which properties are being set. The following threads exist:
@@ -1717,13 +1718,13 @@ The Name of the thread for which properties are being set. The following threads
 The default value is: "".
 
 
-##### //CycloneDDS/Domain/Threads/Thread/Scheduling
+###### //CycloneDDS/Domain/Threads/Thread/Scheduling
 Children: [Class](#cycloneddsdomainthreadsthreadschedulingclass), [Priority](#cycloneddsdomainthreadsthreadschedulingpriority)
 
 This element configures the scheduling properties of the thread.
 
 
-###### //CycloneDDS/Domain/Threads/Thread/Scheduling/Class
+####### //CycloneDDS/Domain/Threads/Thread/Scheduling/Class
 One of: realtime, timeshare, default
 
 This element specifies the thread scheduling class (realtime, timeshare or default). The user may need special privileges from the underlying operating system to be able to assign some of the privileged scheduling classes.
@@ -1731,7 +1732,7 @@ This element specifies the thread scheduling class (realtime, timeshare or defau
 The default value is: "default".
 
 
-###### //CycloneDDS/Domain/Threads/Thread/Scheduling/Priority
+####### //CycloneDDS/Domain/Threads/Thread/Scheduling/Priority
 Text
 
 This element specifies the thread priority (decimal integer or default). Only priorities that are supported by the underlying operating system can be assigned to this element. The user may need special privileges from the underlying operating system to be able to assign some of the privileged priorities.
@@ -1739,7 +1740,7 @@ This element specifies the thread priority (decimal integer or default). Only pr
 The default value is: "default".
 
 
-##### //CycloneDDS/Domain/Threads/Thread/StackSize
+###### //CycloneDDS/Domain/Threads/Thread/StackSize
 Number-with-unit
 
 This element configures the stack size for this thread. The default value default leaves the stack size at the operating system default.
@@ -1749,13 +1750,13 @@ The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^
 The default value is: "default".
 
 
-### //CycloneDDS/Domain/Tracing
+#### //CycloneDDS/Domain/Tracing
 Children: [AppendToFile](#cycloneddsdomaintracingappendtofile), [Category](#cycloneddsdomaintracingcategory), [OutputFile](#cycloneddsdomaintracingoutputfile), [PacketCaptureFile](#cycloneddsdomaintracingpacketcapturefile), [Verbosity](#cycloneddsdomaintracingverbosity)
 
 The Tracing element controls the amount and type of information that is written into the tracing log by the DDSI service. This is useful to track the DDSI service during application development.
 
 
-#### //CycloneDDS/Domain/Tracing/AppendToFile
+##### //CycloneDDS/Domain/Tracing/AppendToFile
 Boolean
 
 This option specifies whether the output is to be appended to an existing log file. The default is to create a new log file each time, which is generally the best option if a detailed log is generated.
@@ -1763,7 +1764,7 @@ This option specifies whether the output is to be appended to an existing log fi
 The default value is: "false".
 
 
-#### //CycloneDDS/Domain/Tracing/Category
+##### //CycloneDDS/Domain/Tracing/Category
 One of:
 * Comma-separated list of: fatal, error, warning, info, config, discovery, data, radmin, timing, traffic, topic, tcp, plist, whc, throttle, rhc, content, shm, trace
 * Or empty
@@ -1804,7 +1805,7 @@ The categorisation of tracing output is incomplete and hence most of the verbosi
 The default value is: "".
 
 
-#### //CycloneDDS/Domain/Tracing/OutputFile
+##### //CycloneDDS/Domain/Tracing/OutputFile
 Text
 
 This option specifies where the logging is printed to. Note that stdout and stderr are treated as special values, representing "standard out" and "standard error" respectively. No file is created unless logging categories are enabled using the Tracing/Verbosity or Tracing/EnabledCategory settings.
@@ -1812,7 +1813,7 @@ This option specifies where the logging is printed to. Note that stdout and stde
 The default value is: "cyclonedds.log".
 
 
-#### //CycloneDDS/Domain/Tracing/PacketCaptureFile
+##### //CycloneDDS/Domain/Tracing/PacketCaptureFile
 Text
 
 This option specifies the file to which received and sent packets will be logged in the "pcap" format suitable for analysis using common networking tools, such as WireShark. IP and UDP headers are fictitious, in particular the destination address of received packets. The TTL may be used to distinguish between sent and received packets: it is 255 for sent packets and 128 for received ones. Currently IPv4 only.
@@ -1820,7 +1821,7 @@ This option specifies the file to which received and sent packets will be logged
 The default value is: "".
 
 
-#### //CycloneDDS/Domain/Tracing/Verbosity
+##### //CycloneDDS/Domain/Tracing/Verbosity
 One of: finest, finer, fine, config, info, warning, severe, none
 
 This element enables standard groups of categories, based on a desired verbosity level. This is in addition to the categories enabled by the Tracing/Category setting. Recognised verbosity levels and the categories they map to are:

--- a/src/tools/ddsconf/md.c
+++ b/src/tools/ddsconf/md.c
@@ -283,11 +283,13 @@ static int initmd(struct cfgelem *elem, const struct cfgunit *units)
 
 int printmd(FILE *out, struct cfgelem *elem, const struct cfgunit *units)
 {
+
   if (initmd(elem, units) == -1)
     return -1;
   if (maketitles(elem, 0, "/", 1) == -1)
     return -1;
   memset(hashes, '#', sizeof(hashes));
-  printelem(out, 0u, 0u, elem, units);
+  fprintf(out, "# CycloneDDS configuration XML reference\n");
+  printelem(out, 1u, 0u, elem, units);
   return 0;
 }


### PR DESCRIPTION
This is an experiment that includes the markdown documents in the dev/ folder in the Sphinx documentation build. This also allows them to appear on the website. While I was at it I also included options.md.