### PR TITLE
Add support for typedef of type declaration

### DIFF
--- a/src/idl/include/idl/scope.h
+++ b/src/idl/include/idl/scope.h
@@ -40,7 +40,8 @@ struct idl_declaration {
   const idl_scope_t *local_scope; /**< scope local to declaration */
   idl_name_t *name;
   idl_scoped_name_t *scoped_name;
-  const idl_node_t *node;
+  /* not a reference, used to populate forward declarations */
+  idl_node_t *node;
   idl_scope_t *scope; /**< scope introduced by declaration (optional) */
 };
 

--- a/src/idl/include/idl/tree.h
+++ b/src/idl/include/idl/tree.h
@@ -346,7 +346,11 @@ typedef struct idl_forward idl_forward_t;
 struct idl_forward {
   idl_node_t node;
   struct idl_name *name;
-  idl_type_spec_t *definition;
+  /* FIXME: no reference count is maintained for type specifier in forward
+            declarations as it may introduce cyclic dependencies. perfect
+            reason to remove use of destructors in Bison and use a pool
+            allocator instead */
+  idl_type_spec_t *type_spec;
 };
 
 typedef struct idl_case_label idl_case_label_t;
@@ -542,7 +546,11 @@ IDL_EXPORT void *idl_iterate(const void *root, const void *node);
 #define IDL_FOREACH(node, list) \
   for ((node) = (list); (node); (node) = idl_next(node))
 
-#define IDL_UNALIAS_IGNORE_ARRAY (1u<<0) /**< ignore array declarators */
-IDL_EXPORT void *idl_unalias(const void *node, uint32_t flags);
+IDL_EXPORT void *idl_unalias(const void *node);
+
+#define IDL_STRIP_ALIASES (1u<<0) /**< expose base type of aliase(s) */
+#define IDL_STRIP_ARRAYS (1u<<1) /**< expose base type of array(s) */
+#define IDL_STRIP_FORWARD (1u<<2) /**< expose definition */
+IDL_EXPORT void *idl_strip(const void *node, uint32_t flags);
 
 #endif /* IDL_TREE_H */

--- a/src/idl/src/parser.y
+++ b/src/idl/src/parser.y
@@ -910,6 +910,20 @@ complex_declarator: array_declarator ;
 typedef_dcl:
     "typedef" type_spec declarators
       { TRY(idl_create_typedef(pstate, LOC(@1.first, @3.last), $2, $3, &$$)); }
+  | "typedef" constr_type_dcl declarators
+      {
+        idl_typedef_t *node;
+        idl_type_spec_t *type_spec;
+        assert($2);
+        /* treat forward declaration as no-op if definition is available */
+        if ((idl_mask($2) & IDL_FORWARD) && ((idl_forward_t *)$2)->type_spec)
+          type_spec = ((idl_forward_t *)$2)->type_spec;
+        else
+          type_spec = $2;
+        TRY(idl_create_typedef(pstate, LOC(@1.first, @3.last), type_spec, $3, &node));
+        idl_reference_node(type_spec);
+        $$ = idl_push_node($2, node);
+      }
   ;
 
 declarators:

--- a/src/idl/src/parser.y
+++ b/src/idl/src/parser.y
@@ -360,7 +360,7 @@ const_type:
         static const char fmt[] =
           "Scoped name '%s' does not resolve to a valid constant type";
         TRY(idl_resolve(pstate, 0u, $1, &declaration));
-        node = idl_unalias(declaration->node, 0u);
+        node = idl_unalias(declaration->node);
         if (!(idl_mask(node) & (IDL_BASE_TYPE|IDL_STRING|IDL_ENUM)))
           SEMANTIC_ERROR(&@1, fmt, $1->identifier);
         $$ = idl_reference_node((idl_node_t *)declaration->node);
@@ -689,8 +689,7 @@ constr_type_dcl:
 
 struct_dcl:
     struct_def { $$ = $1; }
-  |
-    struct_forward_dcl { $$ = $1; }
+  | struct_forward_dcl { $$ = $1; }
   ;
 
 struct_forward_dcl:
@@ -720,7 +719,7 @@ struct_inherit_spec:
         static const char fmt[] =
           "Scoped name '%s' does not resolve to a struct";
         TRY(idl_resolve(pstate, 0u, $2, &declaration));
-        node = idl_unalias(declaration->node, 0u);
+        node = idl_unalias(declaration->node);
         if (!idl_is_struct(node))
           SEMANTIC_ERROR(&@2, fmt, $2->identifier);
         TRY(idl_create_inherit_spec(pstate, &@2, idl_reference_node(node), &$$));
@@ -753,8 +752,7 @@ member:
 
 union_dcl:
     union_def { $$ = $1; }
-  |
-    union_forward_dcl { $$ = $1; }
+  | union_forward_dcl { $$ = $1; }
   ;
 
 union_def:

--- a/src/idl/src/scope.h
+++ b/src/idl/src/scope.h
@@ -21,7 +21,7 @@ idl_create_scope(
   idl_pstate_t *pstate,
   enum idl_scope_kind kind,
   const idl_name_t *name,
-  const void *node,
+  void *node,
   idl_scope_t **scopep);
 
 void idl_delete_scope(idl_scope_t *scope);

--- a/src/idl/src/tree.h
+++ b/src/idl/src/tree.h
@@ -123,13 +123,8 @@ idl_create_forward(
   idl_pstate_t *pstate,
   const idl_location_t *location,
   idl_name_t *name,
-  idl_mask_t mask,
+  idl_type_t type,
   void *nodep);
-
-idl_retcode_t
-idl_validate_forwards(
-  idl_pstate_t *pstate,
-  void *list);
 
 idl_retcode_t
 idl_create_key(

--- a/src/idl/src/visit.c
+++ b/src/idl/src/visit.c
@@ -207,12 +207,12 @@ idl_visit(
       }
 
       if (ret & IDL_VISIT_TYPE_SPEC) {
-        if (ret & IDL_VISIT_FWD_DECL_TARGET)
-          node = ((idl_forward_t *)node)->definition;
+        if (ret & IDL_VISIT_FWD_DECL_TARGET) // >> FIXME: this should definitely be handled in another way
+          node = ((idl_forward_t *)node)->type_spec;
         else
           node = idl_type_spec(node);
         if (ret & IDL_VISIT_UNALIAS_TYPE_SPEC)
-          node = idl_unalias(node, IDL_UNALIAS_IGNORE_ARRAY);
+          node = idl_strip(node, IDL_STRIP_ALIASES|IDL_STRIP_ARRAYS);
         assert(node);
         if (!push(&stack, node))
           goto err_push;

--- a/src/idl/tests/CMakeLists.txt
+++ b/src/idl/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ add_cunit_executable(cunit_idl
   union.c
   enum.c
   pragma.c
-  module.c)
+  module.c
+  forward.c)
 
 target_link_libraries(cunit_idl PRIVATE idl)

--- a/src/idl/tests/forward.c
+++ b/src/idl/tests/forward.c
@@ -1,0 +1,153 @@
+/*
+ * Copyright(c) 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include <assert.h>
+#include <stdio.h>
+
+#include "idl/processor.h"
+
+#include "CUnit/Theory.h"
+
+static idl_retcode_t parse_string(const char *str, idl_pstate_t **pstatep)
+{
+  idl_retcode_t ret;
+  idl_pstate_t *pstate = NULL;
+
+  if ((ret = idl_create_pstate(IDL_FLAG_EXTENDED_DATA_TYPES, NULL, &pstate)))
+    return ret;
+  if ((ret = idl_parse_string(pstate, str)))
+    idl_delete_pstate(pstate);
+  else
+    *pstatep = pstate;
+  return ret;
+}
+
+CU_Test(idl_forward, struct_union_maybe_enum)
+{
+  static const struct {
+    idl_retcode_t retcode;
+    uint32_t type;
+    const char *idl;
+  } tests[] = {
+    { IDL_RETCODE_OK, IDL_STRUCT, "struct a; struct a { long b; };" },
+    { IDL_RETCODE_OK, IDL_STRUCT, "struct a; struct a; struct a { long b; };" },
+    { IDL_RETCODE_OK, IDL_UNION, "union a; union a switch (short) { case 1: long b; };" },
+    { IDL_RETCODE_OK, IDL_UNION, "union a; union a; union a switch (short) { case 1: long b; };" },
+    { IDL_RETCODE_SEMANTIC_ERROR, 0u, "struct a; union a; struct a { long b; };" },
+    { IDL_RETCODE_SEMANTIC_ERROR, 0u, "union a; struct a; struct a { long b; };" },
+    { IDL_RETCODE_SEMANTIC_ERROR, 0u, "union a; struct a; union a switch (short) { case 1: long b; };" },
+    { IDL_RETCODE_SYNTAX_ERROR, 0u, "enum a; enum a { b, c };" }
+  };
+
+  for (size_t i = 0; i < sizeof (tests) / sizeof (tests[0]); i++) {
+    idl_retcode_t ret;
+    idl_pstate_t *pstate = NULL;
+    printf("test idl: %s\n", tests[i].idl);
+    ret = parse_string(tests[i].idl, &pstate);
+    CU_ASSERT_EQUAL_FATAL(ret, tests[i].retcode);
+    if (ret == IDL_RETCODE_OK) {
+      const idl_forward_t *forward = NULL;
+      const idl_type_spec_t *node;
+      CU_ASSERT_PTR_NOT_NULL_FATAL(pstate);
+      CU_ASSERT_EQUAL_FATAL(ret, IDL_RETCODE_OK);
+      assert(pstate);
+      for (node = pstate->root; idl_is_forward(node); node = idl_next(node))
+        forward = node;
+      CU_ASSERT_FATAL(idl_is_forward(forward));
+      assert(forward);
+      CU_ASSERT_EQUAL(idl_type(node), tests[i].type);
+      CU_ASSERT_PTR_EQUAL(forward->type_spec, node);
+    }
+    idl_delete_pstate(pstate);
+  }
+}
+
+CU_Test(idl_forward, aliases)
+{
+  static const struct {
+    size_t forwards;
+    const char *idl;
+    idl_retcode_t retcode;
+    idl_type_t type;
+  } tests[] = {
+    { 1, "struct a; typedef a b; struct a { long b; };", IDL_RETCODE_OK, IDL_STRUCT },
+    { 2, "struct a; struct a; typedef a b; struct a { long b; };", IDL_RETCODE_OK, IDL_STRUCT },
+    { 1, "union a; typedef a b; union a switch(short) { case 1: long b; };", IDL_RETCODE_OK, IDL_UNION },
+    { 2, "union a; union a; typedef a b; union a switch(short) { case 1: long b; };", IDL_RETCODE_OK, IDL_UNION }
+  };
+
+  for (size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
+    idl_retcode_t ret;
+    idl_pstate_t *pstate = NULL;
+    printf("test idl: %s\n", tests[i].idl);
+    ret = parse_string(tests[i].idl, &pstate);
+    CU_ASSERT_EQUAL(ret, tests[i].retcode);
+    if (ret == IDL_RETCODE_OK) {
+      idl_forward_t *forward[2];
+      idl_typedef_t *alias;
+      idl_type_spec_t *type_spec;
+      size_t n = tests[i].forwards - 1;
+      for (size_t j = 0; j < tests[i].forwards; j++) {
+        forward[j] = j ? idl_next(forward[j - 1]) : (idl_forward_t *)pstate->root;
+        CU_ASSERT_FATAL(idl_is_forward(forward[j]));
+      }
+      alias = idl_next(forward[n]);
+      CU_ASSERT_FATAL(idl_is_typedef(alias));
+      type_spec = idl_next(alias);
+      CU_ASSERT_EQUAL_FATAL(idl_type(type_spec), tests[i].type);
+      CU_ASSERT_PTR_EQUAL(forward[n]->type_spec, type_spec);
+      CU_ASSERT_PTR_EQUAL(alias->type_spec, forward[n]);
+    }
+    idl_delete_pstate(pstate);
+  }
+}
+
+CU_Test(idl_forward, backwards_aliases)
+{
+  static const struct {
+    size_t forwards;
+    const char *idl;
+    idl_retcode_t retcode;
+    idl_type_t type;
+  } tests[] = {
+    { 1, "struct a { long b; }; struct a; typedef a b;", IDL_RETCODE_OK, IDL_STRUCT },
+    { 2, "struct a { long b; }; struct a; struct a; typedef a b;", IDL_RETCODE_OK, IDL_STRUCT },
+    { 1, "union a switch(short) { case 1: long b; }; union a; typedef a b;", IDL_RETCODE_OK, IDL_UNION },
+    { 2, "union a switch(short) { case 1: long b; }; union a; union a; typedef a b;", IDL_RETCODE_OK, IDL_UNION }
+  };
+
+  for (size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
+    idl_retcode_t ret;
+    idl_pstate_t *pstate = NULL;
+    printf("test idl: %s\n", tests[i].idl);
+    ret = parse_string(tests[i].idl, &pstate);
+    CU_ASSERT_EQUAL(ret, tests[i].retcode);
+    if (ret == IDL_RETCODE_OK) {
+      idl_forward_t *forward[2];
+      idl_typedef_t *alias;
+      idl_type_spec_t *type_spec;
+      size_t n = tests[i].forwards - 1;
+      type_spec = (idl_type_spec_t *)pstate->root;
+      CU_ASSERT_EQUAL_FATAL(idl_type(type_spec), tests[i].type);
+      for (size_t j = 0; j < tests[i].forwards; j++) {
+        forward[j] = j ? idl_next(forward[j - 1]) : idl_next(type_spec);
+        CU_ASSERT_FATAL(idl_is_forward(forward[j]));
+      }
+      alias = idl_next(forward[n]);
+      CU_ASSERT_FATAL(idl_is_typedef(alias));
+      CU_ASSERT_PTR_EQUAL(forward[n]->type_spec, type_spec);
+      CU_ASSERT_PTR_EQUAL(alias->type_spec, type_spec);
+    }
+    idl_delete_pstate(pstate);
+  }
+}
+
+// x. provide definition in reopened module

--- a/src/idl/tests/parser.c
+++ b/src/idl/tests/parser.c
@@ -236,8 +236,6 @@ CU_Test(idl_parser, forward_declared_struct_union)
 {
   idl_retcode_t ret;
   idl_pstate_t *pstate = NULL;
-  idl_forward_t *fwd1;
-  idl_node_t *n1;
   static const struct {
     bool valid;
     uint32_t type;
@@ -261,11 +259,14 @@ CU_Test(idl_parser, forward_declared_struct_union)
     ret = idl_parse_string(pstate, tests[i].idl);
     if (tests[i].valid) {
       CU_ASSERT_EQUAL_FATAL(ret, IDL_RETCODE_OK);
-      fwd1 = (idl_forward_t *)pstate->root;
-      CU_ASSERT_FATAL(idl_is_forward(fwd1));
-      n1 = idl_next(fwd1);
-      CU_ASSERT_FATAL(tests[i].type == IDL_STRUCT ? idl_is_struct(n1) : idl_is_union(n1));
-      CU_ASSERT_PTR_EQUAL_FATAL(fwd1->definition, n1);
+      const idl_forward_t *forward = NULL;
+      const idl_type_spec_t *node;
+      for (node = pstate->root; idl_is_forward(node); node = idl_next(node))
+        forward = node;
+      CU_ASSERT_FATAL(idl_is_forward(forward));
+      assert(forward);
+      CU_ASSERT_EQUAL(idl_type(node), tests[i].type);
+      CU_ASSERT_PTR_EQUAL(forward->type_spec, node);
     } else {
       CU_ASSERT_FATAL(ret != IDL_RETCODE_OK);
     }
@@ -273,6 +274,7 @@ CU_Test(idl_parser, forward_declared_struct_union)
   }
 }
 
+// x. forward declaration tests
 // x. use nonexisting type!
 // x. union with same declarators
 // x. struct with same declarators

--- a/src/idl/tests/parser.c
+++ b/src/idl/tests/parser.c
@@ -232,49 +232,6 @@ CU_Test(idl_parser, struct_in_struct_other_module)
   idl_delete_pstate(pstate);
 }
 
-CU_Test(idl_parser, forward_declared_struct_union)
-{
-  idl_retcode_t ret;
-  idl_pstate_t *pstate = NULL;
-  static const struct {
-    bool valid;
-    uint32_t type;
-    const char *idl;
-  } tests[] = {
-    { true, IDL_STRUCT, "struct a; struct a { long b; };" },
-    { true, IDL_STRUCT, "struct a; struct a; struct a { long b; };" },
-    { true, IDL_UNION, "union a; union a switch (short) { case 1: long b; };" },
-    { true, IDL_UNION, "union a; union a; union a switch (short) { case 1: long b; };" },
-    { false, 0u, "struct a; union a; struct a { long b; };" },
-    { false, 0u, "union a; struct a; struct a { long b; };" },
-    { false, 0u, "union a; struct a; union a switch (short) { case 1: long b; };" }
-  };
-
-  for (size_t i = 0; i < sizeof (tests) / sizeof (tests[0]); i++) {
-    printf("test idl: %s\n", tests[i].idl);
-    ret = idl_create_pstate(0u, NULL, &pstate);
-    CU_ASSERT_EQUAL_FATAL(ret, IDL_RETCODE_OK);
-    CU_ASSERT_PTR_NOT_NULL(pstate);
-    assert(pstate);
-    ret = idl_parse_string(pstate, tests[i].idl);
-    if (tests[i].valid) {
-      CU_ASSERT_EQUAL_FATAL(ret, IDL_RETCODE_OK);
-      const idl_forward_t *forward = NULL;
-      const idl_type_spec_t *node;
-      for (node = pstate->root; idl_is_forward(node); node = idl_next(node))
-        forward = node;
-      CU_ASSERT_FATAL(idl_is_forward(forward));
-      assert(forward);
-      CU_ASSERT_EQUAL(idl_type(node), tests[i].type);
-      CU_ASSERT_PTR_EQUAL(forward->type_spec, node);
-    } else {
-      CU_ASSERT_FATAL(ret != IDL_RETCODE_OK);
-    }
-    idl_delete_pstate(pstate);
-  }
-}
-
-// x. forward declaration tests
 // x. use nonexisting type!
 // x. union with same declarators
 // x. struct with same declarators


### PR DESCRIPTION
This PR adds support for wrapping a constructed type declaration in a typedef. Basically, when this construction is encountered, it first creates the declarated type in the tree and then creates a typedef that references it. That way no new combination is created in the tree and the existing backends will be able to generate code in the normal way.