### PR TITLE
Disallows a DataReaderListener to receive on_data_on_readers events

### DIFF
--- a/src/core/ddsc/src/dds_entity.c
+++ b/src/core/ddsc/src/dds_entity.c
@@ -260,6 +260,11 @@ dds_entity_t dds_entity_init (dds_entity *e, dds_entity *parent, dds_entity_kind
   dds_reset_listener (&e->m_listener);
   if (listener)
     dds_merge_listener (&e->m_listener, listener);
+
+  /* Special case: the on_data_on_readers event doesn't exist on DataReaders. */
+  if (kind == DDS_KIND_READER)
+    e->m_listener.on_data_on_readers = 0;
+
   if (parent)
   {
     ddsrt_mutex_lock (&parent->m_observers_lock);
@@ -1033,6 +1038,11 @@ dds_return_t dds_set_listener (dds_entity_t entity, const dds_listener_t *listen
   dds_reset_listener (&e->m_listener);
   if (listener)
     dds_merge_listener (&e->m_listener, listener);
+
+  /* Special case: the on_data_on_readers event doesn't exist on DataReaders. */
+  if (dds_entity_kind (e) == DDS_KIND_READER)
+    e->m_listener.on_data_on_readers = 0;
+
   x = e;
   while (dds_entity_kind (x) != DDS_KIND_CYCLONEDDS)
   {
@@ -1041,6 +1051,7 @@ dds_return_t dds_set_listener (dds_entity_t entity, const dds_listener_t *listen
     dds_inherit_listener (&e->m_listener, &x->m_listener);
     ddsrt_mutex_unlock (&x->m_observers_lock);
   }
+
   ddsrt_mutex_unlock (&e->m_observers_lock);
   pushdown_listener (e);
   dds_entity_unpin (e);

--- a/src/core/ddsc/tests/test_oneliner.c
+++ b/src/core/ddsc/tests/test_oneliner.c
@@ -828,6 +828,7 @@ static void make_participant (struct oneliner_ctx *ctx, int ent, dds_listener_t 
   char* conf = ddsrt_expand_envvars("${CYCLONEDDS_URI}${CYCLONEDDS_URI:+,}<Discovery><ExternalDomainId>0</ExternalDomainId></Discovery>", domid);
 #endif
   entname_t name;
+  dds_entity_t bisub;
   printf ("create domain %"PRIu32, domid);
   fflush (stdout);
   if ((ctx->doms[domid] = dds_create_domain (domid, conf)) <= 0)
@@ -835,7 +836,7 @@ static void make_participant (struct oneliner_ctx *ctx, int ent, dds_listener_t 
   ddsrt_free (conf);
   printf (" create participant %s", getentname (&name, ent));
   fflush (stdout);
-  if ((ctx->es[ent] = dds_create_participant (domid, NULL, list)) <= 0)
+  if ((ctx->es[ent] = dds_create_participant (domid, NULL, NULL)) <= 0)
     error_dds (ctx, ctx->es[ent], "make_participant: create participant failed in domain %"PRIu32, domid);
   if ((ctx->tps[domid] = dds_create_topic (ctx->es[ent], &Space_Type1_desc, ctx->topicname, ctx->qos, NULL)) <= 0)
     error_dds (ctx, ctx->tps[domid], "make_participant: create topic failed in domain %"PRIu32, domid);
@@ -867,7 +868,10 @@ static void make_participant (struct oneliner_ctx *ctx, int ent, dds_listener_t 
     error_dds (ctx, ctx->pubrd[domid], "make_participant: create DCPSPublication reader in domain %"PRIu32, domid);
   if ((ctx->subrd[domid] = dds_create_reader (ctx->es[ent], DDS_BUILTIN_TOPIC_DCPSSUBSCRIPTION, NULL, dummylist)) <= 0)
     error_dds (ctx, ctx->subrd[domid], "make_participant: create DCPSSubscription reader in domain %"PRIu32, domid);
+  bisub = dds_get_subscriber(ctx->pubrd[domid]);
+  dds_set_listener(bisub, dummylist);
   dds_delete_listener (dummylist);
+  dds_set_listener(ctx->es[ent], list);
   //printf ("pubrd %"PRId32" subrd %"PRId32" sub %"PRId32"\n", es->pubrd[domid], es->subrd[domid], dds_get_parent (es->pubrd[domid]));
 }
 


### PR DESCRIPTION
Allowing the on_data_on_readers event on a DataReaderListener crashes the C++
API when setting the event mask to ALL, as is described in
https://github.com/eclipse-cyclonedds/cyclonedds-cxx/issues/188

Signed-off-by: Erik Hendriks <erik.hendriks@adlinktech.com>