### PR TITLE
Change OSS-Fuzz build script to fix coverage issue

### DIFF
--- a/fuzz/oss-fuzz-build.sh
+++ b/fuzz/oss-fuzz-build.sh
@@ -20,28 +20,16 @@ cmake \
     -DBUILD_SHARED_LIBS=OFF \
     -DBUILD_EXAMPLES=NO \
     -DENABLE_SECURITY=NO \
+    -DENABLE_SSL=NO \
     -DCMAKE_INSTALL_PREFIX=/usr/local ..
-cmake --build . 
+cmake --build .
 cmake --build . --target install
 cd ..
 )
 
-function copy_fuzzer {
-  mkdir -p "$OUT/lib"
-  cp -v "$1" "$OUT/"
-  patchelf --set-rpath '$ORIGIN/lib' "$OUT/$(basename "$1")"
-
-  ldd "$1" | grep '=>' | cut -d ' ' -f 3 | while read lib; do
-    if [[ -f $lib ]]; then
-      cp -v "$lib" "$OUT/lib/"
-      patchelf --set-rpath '$ORIGIN' "$OUT/lib/$(basename "$lib")"
-    fi
-  done
-}
-
-# copy out stuff
+# copy fuzzer executables to $OUT
 find build/bin -type f -name 'fuzz_*' | while read fuzzer; do
-    copy_fuzzer "$fuzzer"
+  cp -v "$fuzzer" "$OUT/"
 done
 
 find fuzz/ -type f -name 'fuzz_*_seed_corpus.zip' | xargs -I {} cp {} $OUT


### PR DESCRIPTION
A few changes in the OSS-Fuzz build script that will hopefully fix the segfault that occurs in the undefined behavior sanitizer when generating code coverage reports. Although on my dev machine (where I reproduced the issue) the coverage reports are generated successfully with these changes in, I'm not sure if using the unmodified rpath for shared libs will also work on CI. 
