### PR TITLE
Operation with raw ethernet and no network

### DIFF
--- a/fuzz/fuzz_handle_rtps_message/fuzz_handle_rtps_message.c
+++ b/fuzz/fuzz_handle_rtps_message/fuzz_handle_rtps_message.c
@@ -80,6 +80,7 @@ int LLVMFuzzerTestOneInput(
   ddsrt_mutex_init(&dds_global.m_mutex);
 
   ddsi_config_init_default(&gv.config);
+  gv.config.transport_selector = DDSI_TRANS_NONE;
 
   rtps_config_prep(&gv, cfgst);
   dds_set_log_sink(null_log_sink, NULL);

--- a/src/core/ddsi/include/dds/ddsi/ddsi_config.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_config.h
@@ -177,7 +177,8 @@ enum ddsi_transport_selector {
   DDSI_TRANS_UDP6,
   DDSI_TRANS_TCP,
   DDSI_TRANS_TCP6,
-  DDSI_TRANS_RAWETH
+  DDSI_TRANS_RAWETH,
+  DDSI_TRANS_NONE /* FIXME: see FIXME above ... :( */
 };
 
 enum ddsi_many_sockets_mode {

--- a/src/core/ddsi/src/q_config.c
+++ b/src/core/ddsi/src/q_config.c
@@ -962,8 +962,8 @@ static const char *en_sched_class_vs[] = { "realtime", "timeshare", "default", N
 static const ddsrt_sched_t en_sched_class_ms[] = { DDSRT_SCHED_REALTIME, DDSRT_SCHED_TIMESHARE, DDSRT_SCHED_DEFAULT, 0 };
 GENERIC_ENUM_CTYPE (sched_class, ddsrt_sched_t)
 
-static const char *en_transport_selector_vs[] = { "default", "udp", "udp6", "tcp", "tcp6", "raweth", NULL };
-static const enum ddsi_transport_selector en_transport_selector_ms[] = { DDSI_TRANS_DEFAULT, DDSI_TRANS_UDP, DDSI_TRANS_UDP6, DDSI_TRANS_TCP, DDSI_TRANS_TCP6, DDSI_TRANS_RAWETH, 0 };
+static const char *en_transport_selector_vs[] = { "default", "udp", "udp6", "tcp", "tcp6", "raweth", "none", NULL };
+static const enum ddsi_transport_selector en_transport_selector_ms[] = { DDSI_TRANS_DEFAULT, DDSI_TRANS_UDP, DDSI_TRANS_UDP6, DDSI_TRANS_TCP, DDSI_TRANS_TCP6, DDSI_TRANS_RAWETH, DDSI_TRANS_NONE, 0 };
 GENERIC_ENUM_CTYPE (transport_selector, enum ddsi_transport_selector)
 
 /* by putting the  "true" and "false" aliases at the end, they won't come out of the
@@ -2382,6 +2382,7 @@ struct cfgst *config_init (const char *config, struct ddsi_config *cfg, uint32_t
         ok1 = !(cfgst->cfg->compat_tcp_enable == DDSI_BOOLDEF_TRUE || cfgst->cfg->compat_use_ipv6 == DDSI_BOOLDEF_FALSE);
         break;
       case DDSI_TRANS_RAWETH:
+      case DDSI_TRANS_NONE:
         ok1 = !(cfgst->cfg->compat_tcp_enable == DDSI_BOOLDEF_TRUE || cfgst->cfg->compat_use_ipv6 == DDSI_BOOLDEF_TRUE);
         break;
     }

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -1636,34 +1636,6 @@ int rtps_init (struct ddsi_domaingv *gv)
     gv->pcap_fp = NULL;
   }
 
-  gv->mship = new_group_membership();
-
-  /* Create transmit connections */
-  for (size_t i = 0; i < MAX_XMIT_CONNS; i++)
-    gv->xmit_conns[i] = NULL;
-  if (gv->config.many_sockets_mode == DDSI_MSM_NO_UNICAST)
-    gv->xmit_conns[0] = gv->data_conn_uc;
-  else
-  {
-    dds_return_t rc;
-    for (int i = 0; i < gv->n_interfaces; i++)
-    {
-      const ddsi_tran_qos_t qos = {
-        .m_purpose = (gv->config.allowMulticast ? DDSI_TRAN_QOS_XMIT_MC : DDSI_TRAN_QOS_XMIT_UC),
-        .m_diffserv = 0,
-        .m_interface = &gv->interfaces[i]
-      };
-      // FIXME: looking up the factory here is a hack to support iceoryx in addition to (e.g.) UDP
-      ddsi_tran_factory_t fact = ddsi_factory_find_supported_kind (gv, gv->interfaces[i].loc.kind);
-      rc = ddsi_factory_create_conn (&gv->xmit_conns[i], fact, 0, &qos);
-      if (rc != DDS_RETCODE_OK)
-        goto err_mc_conn;
-      GVLOG (DDS_LC_CONFIG, "interface %s: transmit port %d\n", gv->interfaces[i].name, (int) ddsi_conn_port (gv->xmit_conns[i]));
-      gv->intf_xlocators[i].conn = gv->xmit_conns[i];
-      gv->intf_xlocators[i].c = gv->interfaces[i].loc;
-    }
-  }
-
 #ifdef DDS_HAS_NETWORK_PARTITIONS
   /* Convert address sets in partition mappings from string to address sets now that we have
      xmit_conns filled in */
@@ -1671,6 +1643,7 @@ int rtps_init (struct ddsi_domaingv *gv)
     goto err_network_partition_addrset;
 #endif
 
+  gv->mship = new_group_membership();
   if (gv->m_factory->m_connless)
   {
     if (!(gv->config.many_sockets_mode == DDSI_MSM_NO_UNICAST && gv->config.allowMulticast))
@@ -1685,6 +1658,9 @@ int rtps_init (struct ddsi_domaingv *gv)
       {
         gv->data_conn_uc = gv->data_conn_mc;
         gv->disc_conn_uc = gv->disc_conn_mc;
+        // FIXME: uc locators get set by make_uc_sockets for all cases but MSM_NO_UNICAST but we need them
+        ddsi_conn_locator (gv->disc_conn_uc, &gv->loc_meta_uc);
+        ddsi_conn_locator (gv->data_conn_uc, &gv->loc_default_uc);
       }
 
       /* Set multicast locators */
@@ -1694,9 +1670,6 @@ int rtps_init (struct ddsi_domaingv *gv)
         gv->loc_meta_mc.port = ddsi_conn_port (gv->disc_conn_mc);
       if (!is_unspec_locator(&gv->loc_default_mc))
         gv->loc_default_mc.port = ddsi_conn_port (gv->data_conn_mc);
-
-      if (joinleave_spdp_defmcip (gv, 1) < 0)
-        goto err_mc_conn;
     }
   }
   else
@@ -1727,6 +1700,44 @@ int rtps_init (struct ddsi_domaingv *gv)
       ddsi_listener_locator (gv->listener, &gv->loc_meta_uc);
       ddsi_listener_locator (gv->listener, &gv->loc_default_uc);
     }
+  }
+
+  /* Create transmit connections */
+  for (size_t i = 0; i < MAX_XMIT_CONNS; i++)
+    gv->xmit_conns[i] = NULL;
+  if (gv->config.many_sockets_mode == DDSI_MSM_NO_UNICAST)
+  {
+    gv->xmit_conns[0] = gv->data_conn_uc;
+  }
+  else
+  {
+    dds_return_t rc;
+    for (int i = 0; i < gv->n_interfaces; i++)
+    {
+      const ddsi_tran_qos_t qos = {
+        .m_purpose = (gv->config.allowMulticast ? DDSI_TRAN_QOS_XMIT_MC : DDSI_TRAN_QOS_XMIT_UC),
+        .m_diffserv = 0,
+        .m_interface = &gv->interfaces[i]
+      };
+      // FIXME: looking up the factory here is a hack to support iceoryx in addition to (e.g.) UDP
+      ddsi_tran_factory_t fact = ddsi_factory_find_supported_kind (gv, gv->interfaces[i].loc.kind);
+      rc = ddsi_factory_create_conn (&gv->xmit_conns[i], fact, 0, &qos);
+      if (rc != DDS_RETCODE_OK)
+        goto err_mc_conn;
+    }
+  }
+  for (int i = 0; i < gv->n_interfaces; i++)
+  {
+    GVLOG (DDS_LC_CONFIG, "interface %s: transmit port %d\n", gv->interfaces[i].name, (int) ddsi_conn_port (gv->xmit_conns[i]));
+    gv->intf_xlocators[i].conn = gv->xmit_conns[i];
+    gv->intf_xlocators[i].c = gv->interfaces[i].loc;
+  }
+
+  // Join SPDP, default multicast addresses if enabled
+  if (gv->m_factory->m_connless && gv->config.allowMulticast)
+  {
+    if (joinleave_spdp_defmcip (gv, 1) < 0)
+      goto err_mc_conn;
   }
 
 #ifdef DDS_HAS_NETWORK_CHANNELS

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -1384,6 +1384,15 @@ int rtps_init (struct ddsi_domaingv *gv)
         goto err_udp_tcp_init;
       gv->m_factory = ddsi_factory_find (gv, "raweth");
       break;
+    case DDSI_TRANS_NONE:
+      gv->config.publish_uc_locators = 0;
+      gv->config.enable_uc_locators = 0;
+      gv->config.participantIndex = DDSI_PARTICIPANT_INDEX_NONE;
+      gv->config.many_sockets_mode = DDSI_MSM_NO_UNICAST;
+      if (ddsi_vnet_init (gv, "dummy", INT32_MAX) < 0)
+        goto err_udp_tcp_init;
+      gv->m_factory = ddsi_factory_find (gv, "dummy");
+      break;
   }
   gv->m_factory->m_enable = true;
 
@@ -1994,7 +2003,7 @@ int rtps_start (struct ddsi_domaingv *gv)
   }
 #endif
 
-  if (setup_and_start_recv_threads (gv) < 0)
+  if (gv->config.transport_selector != DDSI_TRANS_NONE && setup_and_start_recv_threads (gv) < 0)
   {
 #ifdef DDS_HAS_NETWORK_CHANNELS
     stop_all_xeventq_upto (NULL);
@@ -2057,7 +2066,8 @@ void rtps_stop (struct ddsi_domaingv *gv)
 
   /* Stop all I/O */
   rtps_term_prep (gv);
-  wait_for_receive_threads (gv);
+  if (gv->config.transport_selector != DDSI_TRANS_NONE)
+    wait_for_receive_threads (gv);
 
   if (gv->listener)
   {


### PR DESCRIPTION
This PR fixes the initialisation order that restore the support for raw ethernet. It doesn't yet address operating with multicast support disabled, that's slightly more involved than simply initialisation order. This fixes #1066.

It also makes it possible to operate without any network interface. This is done by taking a shortcut of faking a network interface using some pre-existing code that only needed some minor extensions, and by not starting the network receive thread(s). It is probably incompatible with a variety of settings, but (1) the general usefulness of a DDS implementation that doesn't do any form of network seems debatable, and (2) the primary reason for doing this now using a shortcut is that I *suspect* it will solve some weird problem on OSS-Fuzz that is very reproducible according to OSS-Fuzz but where the reproduction procedure fails to reproduce it locally.