### PR TITLE
Fix idl_strip for typedefs to array

### DIFF
--- a/src/idl/include/idl/tree.h
+++ b/src/idl/include/idl/tree.h
@@ -548,8 +548,8 @@ IDL_EXPORT void *idl_iterate(const void *root, const void *node);
 
 IDL_EXPORT void *idl_unalias(const void *node);
 
-#define IDL_STRIP_ALIASES (1u<<0) /**< expose base type of aliase(s) */
-#define IDL_STRIP_ARRAYS (1u<<1) /**< expose base type of array(s) */
+#define IDL_STRIP_ALIASES (1u<<0) /**< expose base type of aliase(s) for a non-array type */
+#define IDL_STRIP_ALIASES_ARRAY (1u<<1) /**< expose base type of aliase(s) for array type */
 #define IDL_STRIP_FORWARD (1u<<2) /**< expose definition */
 IDL_EXPORT void *idl_strip(const void *node, uint32_t flags);
 

--- a/src/idl/src/directive.c
+++ b/src/idl/src/directive.c
@@ -378,7 +378,7 @@ push_keylist(idl_pstate_t *pstate, struct keylist *dir)
     ts = idl_strip(ts, IDL_STRIP_ALIASES);
     if (idl_is_array(ts))
       mask &= (idl_mask_t)~IDL_STRING;
-    ts = idl_strip(ts, IDL_STRIP_ALIASES|IDL_STRIP_ARRAYS);
+    ts = idl_strip(ts, IDL_STRIP_ALIASES|IDL_STRIP_ALIASES_ARRAY);
     if (!(idl_mask(ts) & mask)) {
       idl_error(pstate, idl_location(dir->keys[i]),
         "Invalid key '%s' in keylist directive", dir->keys[i]->identifier);

--- a/src/idl/src/visit.c
+++ b/src/idl/src/visit.c
@@ -207,12 +207,9 @@ idl_visit(
       }
 
       if (ret & IDL_VISIT_TYPE_SPEC) {
-        if (ret & IDL_VISIT_FWD_DECL_TARGET) // >> FIXME: this should definitely be handled in another way
-          node = ((idl_forward_t *)node)->type_spec;
-        else
           node = idl_type_spec(node);
         if (ret & IDL_VISIT_UNALIAS_TYPE_SPEC)
-          node = idl_strip(node, IDL_STRIP_ALIASES|IDL_STRIP_ARRAYS);
+          node = idl_strip(node, IDL_STRIP_ALIASES|IDL_STRIP_ALIASES_ARRAY);
         assert(node);
         if (!push(&stack, node))
           goto err_push;

--- a/src/tools/idlc/src/descriptor.c
+++ b/src/tools/idlc/src/descriptor.c
@@ -885,7 +885,7 @@ emit_switch_type_spec(
 
   (void)revisit;
 
-  type_spec = idl_unalias(idl_type_spec(node));
+  type_spec = idl_strip(idl_type_spec(node), IDL_STRIP_ALIASES);
   assert(!idl_is_typedef(type_spec) && !idl_is_array(type_spec));
   const idl_union_t *union_spec = idl_parent(node);
   assert(idl_is_union(union_spec));
@@ -1218,9 +1218,9 @@ emit_array(
 
   if (idl_is_array(node)) {
     dims = idl_array_size(node);
-    type_spec = idl_strip(idl_type_spec(node), IDL_STRIP_ALIASES|IDL_STRIP_FORWARD);
+    type_spec = idl_strip(idl_type_spec(node), IDL_STRIP_FORWARD);
   } else {
-    type_spec = idl_unalias(idl_type_spec(node));
+    type_spec = idl_strip(idl_type_spec(node), IDL_STRIP_ALIASES|IDL_STRIP_FORWARD);
     assert(idl_is_array(type_spec));
     dims = idl_array_size(type_spec);
     type_spec = idl_type_spec(type_spec);


### PR DESCRIPTION
This changes the `idl_strip` function so that it only resolves forward declarations and alias types, and not arrays. This also changes the `idl_is_alias` function back the behavior before PR #1068, which allowed array to be an alias. This, in combination with changes in the flags passed in calls to `idl_strip` from `emit_array`, fixes issue #1079
