### PR TITLE
Remove MOVED entry for deleted ThreadPool setting

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/ddsi_cfgelems.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_cfgelems.h
@@ -2120,7 +2120,6 @@ static struct cfgelem root_cfgelems[] = {
   MOVED("Tracing", "CycloneDDS/Domain/Tracing"),
   MOVED("Internal|Unsupported", "CycloneDDS/Domain/Internal"),
   MOVED("TCP", "CycloneDDS/Domain/TCP"),
-  MOVED("ThreadPool", "CycloneDDS/Domain/ThreadPool"),
 #if DDS_HAS_SECURITY
   MOVED("DDSSecurity", "CycloneDDS/Domain/Security"),
 #endif


### PR DESCRIPTION
The ThreadPool configuration option has long since been
removed (f6de22e59905c7ecb6076c3039305fc5d2d2a826) but the corresponding
entry for forwarding from deprecated configurations from before the
multi-domain support still existed.

The consequence of that doubly-deprecated entry is that specifying
CycloneDDS/ThreadPool in the configuration would cause a crash in the
configuration processing.

Signed-off-by: Erik Boasson <eb@ilities.com>