### PR TITLE
Fix dds_stream_check_optimize for XCDR2

### DIFF
--- a/src/core/ddsc/tests/CMakeLists.txt
+++ b/src/core/ddsc/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ idlc_generate(TARGET CreateWriter FILES CreateWriter.idl)
 idlc_generate(TARGET DataRepresentationTypes FILES DataRepresentationTypes.idl)
 idlc_generate(TARGET MinXcdrVersion FILES MinXcdrVersion.idl)
 idlc_generate(TARGET XSpace FILES XSpace.idl)
+idlc_generate(TARGET CdrStreamOptimize FILES CdrStreamOptimize.idl)
 
 set(ddsc_test_sources
     "basic.c"
@@ -109,7 +110,7 @@ if(iceoryx_binding_c_FOUND)
     "$<BUILD_INTERFACE:$<TARGET_PROPERTY:iceoryx_binding_c::iceoryx_binding_c,INTERFACE_INCLUDE_DIRECTORIES>>")
 endif()
 target_link_libraries(cunit_ddsc PRIVATE
-  RoundTrip Space XSpace TypesArrayKey WriteTypes InstanceHandleTypes RWData CreateWriter DataRepresentationTypes MinXcdrVersion ddsc)
+  RoundTrip Space XSpace TypesArrayKey WriteTypes InstanceHandleTypes RWData CreateWriter DataRepresentationTypes MinXcdrVersion CdrStreamOptimize ddsc)
 
 # Setup environment for config-tests
 get_test_property(CUnit_ddsc_config_simple_udp ENVIRONMENT CUnit_ddsc_config_simple_udp_env)

--- a/src/core/ddsc/tests/CdrStreamOptimize.idl
+++ b/src/core/ddsc/tests/CdrStreamOptimize.idl
@@ -1,0 +1,115 @@
+/*
+ * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+module CdrStreamOptimize {
+  @final
+  struct t1 {
+    long f1;
+  };
+
+  @appendable
+  struct t1_a {
+    long f1;
+  };
+
+  @mutable
+  struct t1_m {
+    long f1;
+  };
+
+  @final
+  struct t2 {
+    octet f1;
+    long long f2;
+  };
+
+  @final
+  struct t3 {
+    @external octet f1;
+  };
+
+  @nested @final
+  struct n1 {
+    long f1;
+    octet f2;
+  };
+
+  @final
+  struct t4 {
+    n1 f1;
+  };
+
+  @final
+  struct t4_1 {
+    n1 f1;
+    n1 f2;
+  };
+
+  @final
+  struct t4_2 {
+    t4_1 f1;
+    t4_1 f2;
+  };
+
+  @nested @final
+  struct n2 {
+    octet f1;
+    long long f2;
+  };
+
+  @final
+  struct t5 {
+    n2 f1;
+  };
+
+  @final
+  struct t6 {
+    n2 f1[3];
+  };
+
+  enum en1 {
+    E1,
+    E2
+  };
+
+  @final
+  struct t7 {
+    boolean f1;
+    en1 f2;
+    octet f3;
+    short f5;
+    long f6;
+  };
+
+  @nested @final
+  struct n3 {
+    octet f1;
+    short f2;
+  };
+
+  @final
+  struct t8 {
+    octet f1;
+    n3 f2;
+    short f3;
+  };
+
+  @nested @appendable
+  struct n4 {
+    long f1;
+  };
+
+  @final
+  struct t9 {
+    long f1;
+    n4 f2;
+  };
+};

--- a/src/core/ddsi/include/dds/ddsi/ddsi_cdrstream.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_cdrstream.h
@@ -71,7 +71,7 @@ DDS_EXPORT void dds_stream_read_sample (dds_istream_t * __restrict is, void * __
 DDS_EXPORT void dds_stream_free_sample (void * __restrict data, const uint32_t * __restrict ops);
 
 DDS_EXPORT uint32_t dds_stream_countops (const uint32_t * __restrict ops, uint32_t nkeys, const dds_key_descriptor_t * __restrict keys);
-DDS_EXPORT size_t dds_stream_check_optimize (const struct ddsi_sertype_default_desc * __restrict desc);
+DDS_EXPORT size_t dds_stream_check_optimize (const struct ddsi_sertype_default_desc * __restrict desc, uint32_t xcdr_version);
 DDS_EXPORT void dds_istream_from_serdata_default (dds_istream_t * __restrict s, const struct ddsi_serdata_default * __restrict d);
 DDS_EXPORT void dds_ostream_from_serdata_default (dds_ostream_t * __restrict s, const struct ddsi_serdata_default * __restrict d);
 DDS_EXPORT void dds_ostream_add_to_serdata_default (dds_ostream_t * __restrict s, struct ddsi_serdata_default ** __restrict d);


### PR DESCRIPTION
This fixes and adds test cases for the dds_stream_check_optimize function in the cdrstream serializer:
- the XCDR version was not taken into account, and therefore incorrect alignment was used for 64-bit types
- a check for @external annotation was missing; external fields are represented as a pointer and therefore memcpy marshalling cannot be used
- types with nested structs were incorrectly always marked as non-optimized