### PR TITLE
Capitalize Id in Readme as defined in cyclonedds.xsd

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ point to it.  E.g. (on Linux):
     $ cat cyclonedds.xml
     <?xml version="1.0" encoding="UTF-8" ?>
     <CycloneDDS xmlns="https://cdds.io/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://cdds.io/config https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/master/etc/cyclonedds.xsd">
-        <Domain id="any">
+        <Domain Id="any">
             <General>
                 <NetworkInterfaceAddress>auto</NetworkInterfaceAddress>
                 <AllowMulticast>default</AllowMulticast>


### PR DESCRIPTION
The typo probably never affected functionality but my editor was complaining so here is a fix