### PR TITLE
Free'ing non-owned pointer on normalize failure

### DIFF
--- a/src/core/ddsi/src/ddsi_typelib.c
+++ b/src/core/ddsi/src/ddsi_typelib.c
@@ -90,7 +90,8 @@ ddsi_typeinfo_t *ddsi_typeinfo_deser (const struct ddsi_sertype_cdr_data *ser)
     data = ser->data;
   if (!dds_stream_normalize_data ((char *) data, &srcoff, ser->sz, bswap, CDR_ENC_VERSION_2, DDS_XTypes_TypeInformation_desc.m_ops))
   {
-    ddsrt_free (data);
+    if (bswap)
+      ddsrt_free (data);
     return NULL;
   }
 


### PR DESCRIPTION
You only run into this if you make a mistake elsewhere, but still, `ddsi_typeinfo_deser` should not free the data pointer in a serdata if it did not make its own copy to byteswap and the stream normalize fails.