### PR TITLE
Validate CDR in ddsi_typemap_deser and fix sanitize issue

### DIFF
--- a/src/core/ddsi/src/ddsi_typelib.c
+++ b/src/core/ddsi/src/ddsi_typelib.c
@@ -227,16 +227,15 @@ ddsi_typemap_t *ddsi_typemap_deser (const struct ddsi_sertype_cdr_data *ser)
   bool bswap = (DDSRT_ENDIAN != DDSRT_LITTLE_ENDIAN);
   DDSRT_WARNING_MSVC_ON(6326)
   if (bswap)
-  {
     data = ddsrt_memdup (ser->data, ser->sz);
-    if (!dds_stream_normalize_data ((char *) data, &srcoff, ser->sz, bswap, CDR_ENC_VERSION_2, DDS_XTypes_TypeMapping_desc.m_ops))
-    {
-      ddsrt_free (data);
-      return NULL;
-    }
-  }
   else
     data = ser->data;
+  if (!dds_stream_normalize_data ((char *) data, &srcoff, ser->sz, bswap, CDR_ENC_VERSION_2, DDS_XTypes_TypeMapping_desc.m_ops))
+  {
+    if (bswap)
+      ddsrt_free (data);
+    return NULL;
+  }
 
   dds_istream_t is = { .m_buffer = data, .m_index = 0, .m_size = ser->sz, .m_xcdr_version = CDR_ENC_VERSION_2 };
   ddsi_typemap_t *typemap = ddsrt_calloc (1, sizeof (*typemap));

--- a/src/core/ddsi/src/ddsi_typewrap.c
+++ b/src/core/ddsi/src/ddsi_typewrap.c
@@ -354,7 +354,7 @@ bool ddsi_typeid_is_none_impl (const struct DDS_XTypes_TypeIdentifier *type_id)
 
 bool ddsi_typeid_is_none (const ddsi_typeid_t *type_id)
 {
-  return ddsi_typeid_is_none_impl (&type_id->x);
+  return type_id == NULL || ddsi_typeid_is_none_impl (&type_id->x);
 }
 
 bool ddsi_typeid_is_hash_impl (const struct DDS_XTypes_TypeIdentifier *type_id)
@@ -364,7 +364,7 @@ bool ddsi_typeid_is_hash_impl (const struct DDS_XTypes_TypeIdentifier *type_id)
 
 bool ddsi_typeid_is_hash (const ddsi_typeid_t *type_id)
 {
-  return ddsi_typeid_is_hash_impl (&type_id->x);
+  return type_id != NULL && ddsi_typeid_is_hash_impl (&type_id->x);
 }
 
 bool ddsi_typeid_is_minimal_impl (const struct DDS_XTypes_TypeIdentifier *type_id)
@@ -374,7 +374,7 @@ bool ddsi_typeid_is_minimal_impl (const struct DDS_XTypes_TypeIdentifier *type_i
 
 bool ddsi_typeid_is_minimal (const ddsi_typeid_t *type_id)
 {
-  return ddsi_typeid_is_minimal_impl (&type_id->x);
+  return type_id != NULL && ddsi_typeid_is_minimal_impl (&type_id->x);
 }
 
 bool ddsi_typeid_is_complete_impl (const struct DDS_XTypes_TypeIdentifier *type_id)
@@ -384,7 +384,7 @@ bool ddsi_typeid_is_complete_impl (const struct DDS_XTypes_TypeIdentifier *type_
 
 bool ddsi_typeid_is_complete (const ddsi_typeid_t *type_id)
 {
-  return ddsi_typeid_is_complete_impl (&type_id->x);
+  return type_id != NULL && ddsi_typeid_is_complete_impl (&type_id->x);
 }
 
 void ddsi_typeid_get_equivalence_hash (const ddsi_typeid_t *type_id, DDS_XTypes_EquivalenceHash *hash)


### PR DESCRIPTION
Similar to `ddsi_typeinfo_deser`, the function `ddsi_typemap_deser` should validate the CDR by calling the normalize function also in case there is no byte swapping. And fixing an undefined behavior sanitizer error, that showed up in CI (unrelated to the changes in the other commit in this PR). 