### PR TITLE
Make sequence numbers unsigned

### DIFF
--- a/src/core/ddsc/src/dds_whc.c
+++ b/src/core/ddsc/src/dds_whc.c
@@ -220,7 +220,7 @@ static uint32_t whc_node_hash (const void *vn)
   /* we hash the lower 32 bits, on the assumption that with 4 billion
    samples in between there won't be significant correlation */
   const uint64_t c = UINT64_C (16292676669999574021);
-  const uint32_t x = (uint32_t) n->seq;
+  const uint32_t x = (uint32_t) n->seq.v;
   return (uint32_t) ((x * c) >> 32);
 }
 
@@ -228,7 +228,7 @@ static int whc_node_eq (const void *va, const void *vb)
 {
   const struct whc_node *a = va;
   const struct whc_node *b = vb;
-  return a->seq == b->seq;
+  return a->seq.v == b->seq.v;
 }
 #endif
 
@@ -249,7 +249,7 @@ static int compare_seq (const void *va, const void *vb)
 {
   const seqno_t *a = va;
   const seqno_t *b = vb;
-  return (*a == *b) ? 0 : (*a < *b) ? -1 : 1;
+  return ((*a).v == (*b).v) ? 0 : ((*a).v < (*b).v) ? -1 : 1;
 }
 
 static struct whc_node *whc_findmax_procedurally (const struct whc_impl *whc)
@@ -287,12 +287,12 @@ static void check_whc (const struct whc_impl *whc)
   {
     assert (whc->open_intv->last);
     assert (whc->maxseq_node == whc->open_intv->last);
-    assert (whc->open_intv->min < whc->open_intv->maxp1);
-    assert (whc->maxseq_node->seq + 1 == whc->open_intv->maxp1);
+    assert (whc->open_intv->min.v < whc->open_intv->maxp1.v);
+    assert (whc->maxseq_node->seq.v + 1 == whc->open_intv->maxp1.v);
   }
   else
   {
-    assert (whc->open_intv->min == whc->open_intv->maxp1);
+    assert (whc->open_intv->min.v == whc->open_intv->maxp1.v);
   }
   assert (whc->maxseq_node == whc_findmax_procedurally (whc));
 
@@ -301,13 +301,13 @@ static void check_whc (const struct whc_impl *whc)
   {
     struct whc_intvnode *firstintv;
     struct whc_node *cur;
-    seqno_t prevseq = 0;
+    seqno_t prevseq = { 0 };
     firstintv = ddsrt_avl_find_min (&whc_seq_treedef, &whc->seq);
     assert (firstintv);
     cur = firstintv->first;
     while (cur)
     {
-      assert (cur->seq > prevseq);
+      assert (cur->seq.v > prevseq.v);
       prevseq = cur->seq;
       assert (whc_findseq (whc, cur->seq) == cur);
       cur = cur->next_seq;
@@ -457,7 +457,7 @@ struct whc *whc_new (struct ddsi_domaingv *gv, const struct whc_writer_info *wri
   whc->tkmap = gv->m_tkmap;
   memcpy (&whc->wrinfo, wrinfo, sizeof (*wrinfo));
   whc->seq_size = 0;
-  whc->max_drop_seq = 0;
+  whc->max_drop_seq = (seqno_t){ 0 };
   whc->unacked_bytes = 0;
   whc->total_bytes = 0;
   whc->sample_overhead = sample_overhead;
@@ -481,7 +481,7 @@ struct whc *whc_new (struct ddsi_domaingv *gv, const struct whc_writer_info *wri
   /* seq interval tree: always has an "open" node */
   ddsrt_avl_init (&whc_seq_treedef, &whc->seq);
   intv = ddsrt_malloc (sizeof (*intv));
-  intv->min = intv->maxp1 = 1;
+  intv->min = intv->maxp1 = (seqno_t){ 1 };
   intv->first = intv->last = NULL;
   ddsrt_avl_insert (&whc_seq_treedef, &whc->seq, intv);
   whc->open_intv = intv;
@@ -564,7 +564,7 @@ static void get_state_locked (const struct whc_impl *whc, struct whc_state *st)
 {
   if (whc->seq_size == 0)
   {
-    st->min_seq = st->max_seq = 0;
+    st->min_seq = st->max_seq = (seqno_t){ 0 };
     st->unacked_bytes = 0;
   }
   else
@@ -574,7 +574,7 @@ static void get_state_locked (const struct whc_impl *whc, struct whc_state *st)
     /* not empty, open node may be anything but is (by definition)
      findmax, and whc is claimed to be non-empty, so min interval
      can't be empty */
-    assert (intv->maxp1 > intv->min);
+    assert (intv->maxp1.v > intv->min.v);
     st->min_seq = intv->min;
     st->max_seq = whc->maxseq_node->seq;
     st->unacked_bytes = whc->unacked_bytes;
@@ -602,14 +602,14 @@ static struct whc_node *find_nextseq_intv (struct whc_intvnode **p_intv, const s
 #ifndef NDEBUG
     {
       struct whc_intvnode *predintv = ddsrt_avl_lookup_pred_eq (&whc_seq_treedef, &whc->seq, &seq);
-      assert (predintv == NULL || predintv->maxp1 <= seq);
+      assert (predintv == NULL || predintv->maxp1.v <= seq.v);
     }
 #endif
     if ((intv = ddsrt_avl_lookup_succ_eq (&whc_seq_treedef, &whc->seq, &seq)) == NULL) {
       assert (ddsrt_avl_lookup_pred_eq (&whc_seq_treedef, &whc->seq, &seq) == whc->open_intv);
       return NULL;
-    } else if (intv->min < intv->maxp1) { /* only if not empty interval */
-      assert (intv->min > seq);
+    } else if (intv->min.v < intv->maxp1.v) { /* only if not empty interval */
+      assert (intv->min.v > seq.v);
       *p_intv = intv;
       return intv->first;
     } else { /* but note: only open_intv may be empty */
@@ -625,7 +625,7 @@ static struct whc_node *find_nextseq_intv (struct whc_intvnode **p_intv, const s
   else
   {
     assert (whc->maxseq_node != NULL);
-    assert (n->seq < whc->maxseq_node->seq);
+    assert (n->seq.v < whc->maxseq_node->seq.v);
     n = n->next_seq;
     *p_intv = ddsrt_avl_lookup_pred_eq (&whc_seq_treedef, &whc->seq, &n->seq);
     return n;
@@ -641,7 +641,7 @@ static seqno_t whc_default_next_seq (const struct whc *whc_generic, seqno_t seq)
   ddsrt_mutex_lock ((ddsrt_mutex_t *)&whc->lock);
   check_whc (whc);
   if ((n = find_nextseq_intv (&intv, whc, seq)) == NULL)
-    nseq = MAX_SEQ_NUMBER;
+    nseq = (seqno_t){ MAX_SEQ_NUMBER };
   else
     nseq = n->seq;
   ddsrt_mutex_unlock ((ddsrt_mutex_t *)&whc->lock);
@@ -666,7 +666,7 @@ static void free_one_instance_from_idx (struct whc_impl *whc, seqno_t max_drop_s
     {
       struct whc_node *oldn = idxn->hist[i];
       oldn->idxnode = NULL;
-      if (oldn->seq <= max_drop_seq)
+      if (oldn->seq.v <= max_drop_seq.v)
       {
         TRACE ("  prune tl whcn %p\n", (void *)oldn);
         assert (oldn != whc->maxseq_node);
@@ -732,7 +732,7 @@ static uint32_t whc_default_downgrade_to_volatile (struct whc *whc_generic, stru
 #ifdef DDS_HAS_DEADLINE_MISSED
         deadline_unregister_instance_locked (&whc->deadline, &idxn->deadline);
 #endif
-        free_one_instance_from_idx (whc, 0, idxn);
+        free_one_instance_from_idx (whc, (seqno_t){ 0 }, idxn);
       }
       ddsrt_hh_free (whc->idx_hash);
       whc->wrinfo.idxdepth = 0;
@@ -744,10 +744,10 @@ static uint32_t whc_default_downgrade_to_volatile (struct whc *whc_generic, stru
    next ack); but need to make sure remove_acked_messages processes
    them all. */
   old_max_drop_seq = whc->max_drop_seq;
-  whc->max_drop_seq = 0;
+  whc->max_drop_seq = (seqno_t){ 0 };
   cnt = whc_default_remove_acked_messages_full (whc, old_max_drop_seq, &deferred_free_list);
   whc_default_free_deferred_free_list (whc_generic, deferred_free_list);
-  assert (whc->max_drop_seq == old_max_drop_seq);
+  assert (whc->max_drop_seq.v == old_max_drop_seq.v);
   get_state_locked (whc, st);
   ddsrt_mutex_unlock (&whc->lock);
   return cnt;
@@ -772,7 +772,7 @@ static void whc_delete_one_intv (struct whc_impl *whc, struct whc_intvnode **p_i
    correctly for the next sample in sequence number order */
   struct whc_intvnode *intv = *p_intv;
   struct whc_node *whcn = *p_whcn;
-  assert (whcn->seq >= intv->min && whcn->seq < intv->maxp1);
+  assert (whcn->seq.v >= intv->min.v && whcn->seq.v < intv->maxp1.v);
   *p_whcn = whcn->next_seq;
 
   /* If it is in the tlidx, take it out.  Transient-local data never gets here */
@@ -810,21 +810,21 @@ static void whc_delete_one_intv (struct whc_impl *whc, struct whc_intvnode **p_i
     else
     {
       intv->first = whcn->next_seq;
-      intv->min++;
+      intv->min.v++;
       assert (intv->first != NULL || intv == whc->open_intv);
-      assert (intv->min < intv->maxp1 || intv == whc->open_intv);
-      assert ((intv->first == NULL) == (intv->min == intv->maxp1));
+      assert (intv->min.v < intv->maxp1.v || intv == whc->open_intv);
+      assert ((intv->first == NULL) == (intv->min.v == intv->maxp1.v));
     }
   }
   else if (whcn == intv->last)
   {
     /* well, at least it isn't the first one & so the interval is
      still non-empty and we don't have to drop the interval */
-    assert (intv->min < whcn->seq);
+    assert (intv->min.v < whcn->seq.v);
     assert (whcn->prev_seq);
-    assert (whcn->prev_seq->seq + 1 == whcn->seq);
+    assert (whcn->prev_seq->seq.v + 1 == whcn->seq.v);
     intv->last = whcn->prev_seq;
-    intv->maxp1--;
+    intv->maxp1.v--;
     *p_intv = ddsrt_avl_find_succ (&whc_seq_treedef, &whc->seq, intv);
   }
   else
@@ -840,15 +840,15 @@ static void whc_delete_one_intv (struct whc_impl *whc, struct whc_intvnode **p_i
 
     /* new interval starts at the next node */
     assert (whcn->next_seq);
-    assert (whcn->seq + 1 == whcn->next_seq->seq);
+    assert (whcn->seq.v + 1 == whcn->next_seq->seq.v);
     new_intv->first = whcn->next_seq;
     new_intv->last = intv->last;
-    new_intv->min = whcn->seq + 1;
+    new_intv->min = (seqno_t){ whcn->seq.v + 1 };
     new_intv->maxp1 = intv->maxp1;
     intv->last = whcn->prev_seq;
     intv->maxp1 = whcn->seq;
-    assert (intv->min < intv->maxp1);
-    assert (new_intv->min < new_intv->maxp1);
+    assert (intv->min.v < intv->maxp1.v);
+    assert (new_intv->min.v < new_intv->maxp1.v);
 
     /* insert new node & continue the loop with intv set to the
     new interval */
@@ -913,9 +913,9 @@ static uint32_t whc_default_remove_acked_messages_noidx (struct whc_impl *whc, s
   uint32_t ndropped = 0;
 
   /* In the trivial case of an empty WHC, get out quickly */
-  if (max_drop_seq <= whc->max_drop_seq || whc->maxseq_node == NULL)
+  if (max_drop_seq.v <= whc->max_drop_seq.v || whc->maxseq_node == NULL)
   {
-    if (max_drop_seq > whc->max_drop_seq)
+    if (max_drop_seq.v > whc->max_drop_seq.v)
       whc->max_drop_seq = max_drop_seq;
     *deferred_free_list = NULL;
     return 0;
@@ -934,12 +934,12 @@ static uint32_t whc_default_remove_acked_messages_noidx (struct whc_impl *whc, s
    the highest available sequence number (which then must be less) */
   if ((whcn = whc_findseq (whc, max_drop_seq)) == NULL)
   {
-    if (max_drop_seq < intv->min)
+    if (max_drop_seq.v < intv->min.v)
     {
       /* at startup, whc->max_drop_seq = 0 and reader states have max ack'd seq taken from wr->seq;
        so if multiple readers are matched and the writer runs ahead of the readers, for the first
        ack, whc->max_drop_seq < max_drop_seq = MIN (readers max ack) < intv->min */
-      if (max_drop_seq > whc->max_drop_seq)
+      if (max_drop_seq.v > whc->max_drop_seq.v)
         whc->max_drop_seq = max_drop_seq;
       *deferred_free_list = NULL;
       return 0;
@@ -947,15 +947,15 @@ static uint32_t whc_default_remove_acked_messages_noidx (struct whc_impl *whc, s
     else
     {
       whcn = whc->maxseq_node;
-      assert (whcn->seq < max_drop_seq);
+      assert (whcn->seq.v < max_drop_seq.v);
     }
   }
 
   *deferred_free_list = intv->first;
-  ndropped = (uint32_t) (whcn->seq - intv->min + 1);
+  ndropped = (uint32_t) (whcn->seq.v - intv->min.v + 1);
 
   intv->first = whcn->next_seq;
-  intv->min = max_drop_seq + 1;
+  intv->min = (seqno_t){ max_drop_seq.v + 1 };
   if (whcn->next_seq == NULL)
   {
     whc->maxseq_node = NULL;
@@ -963,7 +963,7 @@ static uint32_t whc_default_remove_acked_messages_noidx (struct whc_impl *whc, s
   }
   else
   {
-    assert (whcn->next_seq->seq == max_drop_seq + 1);
+    assert (whcn->next_seq->seq.v == max_drop_seq.v + 1);
     whcn->next_seq->prev_seq = NULL;
   }
   whcn->next_seq = NULL;
@@ -999,7 +999,7 @@ static uint32_t whc_default_remove_acked_messages_full (struct whc_impl *whc, se
     /* KEEP_ALL on transient local, so we can never ever delete anything, but
        we have to ack the data in whc */
     TRACE ("  KEEP_ALL transient-local: ack data\n");
-    while (whcn && whcn->seq <= max_drop_seq)
+    while (whcn && whcn->seq.v <= max_drop_seq.v)
     {
       if (whcn->unacked)
       {
@@ -1016,9 +1016,9 @@ static uint32_t whc_default_remove_acked_messages_full (struct whc_impl *whc, se
 
   deferred_list_head.next_seq = NULL;
   prev_seq = whcn ? whcn->prev_seq : NULL;
-  while (whcn && whcn->seq <= max_drop_seq)
+  while (whcn && whcn->seq.v <= max_drop_seq.v)
   {
-    TRACE ("  whcn %p %"PRId64, (void *) whcn, whcn->seq);
+    TRACE ("  whcn %p %"PRIu64, (void *) whcn, whcn->seq.v);
     if (whcn_in_tlidx (whc, whcn->idxnode, whcn->idxnode_pos))
     {
       /* quickly skip over samples in tlidx */
@@ -1069,17 +1069,17 @@ static uint32_t whc_default_remove_acked_messages_full (struct whc_impl *whc, se
      encounter samples that were retained because of the transient-local durability setting
      (the rest has been dropped already) and we prune old samples in the instance */
     whcn = find_nextseq_intv (&intv, whc, whc->max_drop_seq);
-    while (whcn && whcn->seq <= max_drop_seq)
+    while (whcn && whcn->seq.v <= max_drop_seq.v)
     {
       struct whc_idxnode * const idxn = whcn->idxnode;
       uint32_t cnt, idx;
 
-      TRACE ("  whcn %p %"PRId64" idxn %p prune_seq %"PRId64":", (void *) whcn, whcn->seq, (void *) idxn, idxn->prune_seq);
+      TRACE ("  whcn %p %"PRIu64" idxn %p prune_seq %"PRIu64":", (void *) whcn, whcn->seq.v, (void *) idxn, idxn->prune_seq.v);
 
       assert (whcn_in_tlidx (whc, idxn, whcn->idxnode_pos));
-      assert (idxn->prune_seq <= max_drop_seq);
+      assert (idxn->prune_seq.v <= max_drop_seq.v);
 
-      if (idxn->prune_seq == max_drop_seq)
+      if (idxn->prune_seq.v == max_drop_seq.v)
       {
         TRACE (" already pruned\n");
         whcn = whcn->next_seq;
@@ -1101,9 +1101,9 @@ static uint32_t whc_default_remove_acked_messages_full (struct whc_impl *whc, se
 #ifndef NDEBUG
           struct whc_idxnode template;
           template.iid = idxn->iid;
-          assert (oldn->seq < whcn->seq);
+          assert (oldn->seq.v < whcn->seq.v);
 #endif
-          TRACE (" del %p %"PRId64, (void *) oldn, oldn->seq);
+          TRACE (" del %p %"PRIu64, (void *) oldn, oldn->seq.v);
           whc_delete_one (whc, oldn);
 #ifndef NDEBUG
           assert (ddsrt_hh_lookup (whc->idx_hash, &template) == idxn);
@@ -1130,16 +1130,16 @@ static uint32_t whc_default_remove_acked_messages (struct whc *whc_generic, seqn
   uint32_t cnt;
 
   ddsrt_mutex_lock (&whc->lock);
-  assert (max_drop_seq < MAX_SEQ_NUMBER);
-  assert (max_drop_seq >= whc->max_drop_seq);
+  assert (max_drop_seq.v < MAX_SEQ_NUMBER);
+  assert (max_drop_seq.v >= whc->max_drop_seq.v);
 
   if (whc->gv->logconfig.c.mask & DDS_LC_WHC)
   {
     struct whc_state tmp;
     get_state_locked (whc, &tmp);
-    TRACE ("whc_default_remove_acked_messages(%p max_drop_seq %"PRId64")\n", (void *)whc, max_drop_seq);
-    TRACE ("  whc: [%"PRId64",%"PRId64"] max_drop_seq %"PRId64" h %"PRIu32" tl %"PRIu32"\n",
-           tmp.min_seq, tmp.max_seq, whc->max_drop_seq, whc->wrinfo.hdepth, whc->wrinfo.tldepth);
+    TRACE ("whc_default_remove_acked_messages(%p max_drop_seq %"PRIu64")\n", (void *)whc, max_drop_seq.v);
+    TRACE ("  whc: [%"PRIu64",%"PRIu64"] max_drop_seq %"PRIu64" h %"PRIu32" tl %"PRIu32"\n",
+           tmp.min_seq.v, tmp.max_seq.v, whc->max_drop_seq.v, whc->wrinfo.hdepth, whc->wrinfo.tldepth);
   }
 
   check_whc (whc);
@@ -1169,7 +1169,7 @@ static struct whc_node *whc_default_insert_seq (struct whc_impl *whc, seqno_t ma
     newn = ddsrt_malloc (sizeof (*newn));
   newn->seq = seq;
   newn->plist = plist;
-  newn->unacked = (seq > max_drop_seq);
+  newn->unacked = (seq.v > max_drop_seq.v);
   newn->borrowed = 0;
   newn->idxnode = NULL; /* initial state, may be changed */
   newn->idxnode_pos = 0;
@@ -1198,14 +1198,14 @@ static struct whc_node *whc_default_insert_seq (struct whc_impl *whc, seqno_t ma
   {
     /* open_intv is empty => reset open_intv */
     whc->open_intv->min = seq;
-    whc->open_intv->maxp1 = seq + 1;
+    whc->open_intv->maxp1 = (seqno_t){ seq.v + 1 };
     whc->open_intv->first = whc->open_intv->last = newn;
   }
-  else if (whc->open_intv->maxp1 == seq)
+  else if (whc->open_intv->maxp1.v == seq.v)
   {
     /* no gap => append to open_intv */
     whc->open_intv->last = newn;
-    whc->open_intv->maxp1++;
+    whc->open_intv->maxp1.v++;
   }
   else
   {
@@ -1214,7 +1214,7 @@ static struct whc_node *whc_default_insert_seq (struct whc_impl *whc, seqno_t ma
     ddsrt_avl_ipath_t path;
     intv1 = ddsrt_malloc (sizeof (*intv1));
     intv1->min = seq;
-    intv1->maxp1 = seq + 1;
+    intv1->maxp1 = (seqno_t){ seq.v + 1 };
     intv1->first = intv1->last = newn;
     if (ddsrt_avl_lookup_ipath (&whc_seq_treedef, &whc->seq, &seq, &path) != NULL)
       assert (0);
@@ -1249,19 +1249,19 @@ static int whc_default_insert (struct whc *whc_generic, seqno_t max_drop_seq, se
   {
     struct whc_state whcst;
     get_state_locked (whc, &whcst);
-    TRACE ("whc_default_insert(%p max_drop_seq %"PRId64" seq %"PRId64" exp %"PRId64" plist %p serdata %p:%"PRIx32")\n",
-           (void *) whc, max_drop_seq, seq, exp.v, (void *) plist, (void *) serdata, serdata->hash);
-    TRACE ("  whc: [%"PRId64",%"PRId64"] max_drop_seq %"PRId64" h %"PRIu32" tl %"PRIu32"\n",
-           whcst.min_seq, whcst.max_seq, whc->max_drop_seq, whc->wrinfo.hdepth, whc->wrinfo.tldepth);
+    TRACE ("whc_default_insert(%p max_drop_seq %"PRIu64" seq %"PRIu64" exp %"PRId64" plist %p serdata %p:%"PRIx32")\n",
+           (void *) whc, max_drop_seq.v, seq.v, exp.v, (void *) plist, (void *) serdata, serdata->hash);
+    TRACE ("  whc: [%"PRIu64",%"PRIu64"] max_drop_seq %"PRIu64" h %"PRIu32" tl %"PRIu32"\n",
+           whcst.min_seq.v, whcst.max_seq.v, whc->max_drop_seq.v, whc->wrinfo.hdepth, whc->wrinfo.tldepth);
   }
 
-  assert (max_drop_seq < MAX_SEQ_NUMBER);
-  assert (max_drop_seq >= whc->max_drop_seq);
+  assert (max_drop_seq.v < MAX_SEQ_NUMBER);
+  assert (max_drop_seq.v >= whc->max_drop_seq.v);
 
   /* Seq must be greater than what is currently stored. Usually it'll
    be the next sequence number, but if there are no readers
    temporarily, a gap may be among the possibilities */
-  assert (whc->seq_size == 0 || seq > whc->maxseq_node->seq);
+  assert (whc->seq_size == 0 || seq.v > whc->maxseq_node->seq.v);
 
   /* Always insert in seq admin */
   newn = whc_default_insert_seq (whc, max_drop_seq, seq, exp, plist, serdata);
@@ -1285,7 +1285,7 @@ static int whc_default_insert (struct whc *whc_generic, seqno_t max_drop_seq, se
     {
       TRACE (" unreg:delete\n");
       delete_one_instance_from_idx (whc, max_drop_seq, idxn);
-      if (newn->seq <= max_drop_seq)
+      if (newn->seq.v <= max_drop_seq.v)
       {
         struct whc_node *prev_seq = newn->prev_seq;
         TRACE (" unreg:seq <= max_drop_seq: delete newn\n");
@@ -1312,7 +1312,7 @@ static int whc_default_insert (struct whc *whc_generic, seqno_t max_drop_seq, se
         newn->idxnode = idxn;
         newn->idxnode_pos = idxn->headidx;
 
-        if (oldn && (whc->wrinfo.hdepth > 0 || oldn->seq <= max_drop_seq) && (!whc->wrinfo.is_transient_local || whc->wrinfo.tldepth > 0))
+        if (oldn && (whc->wrinfo.hdepth > 0 || oldn->seq.v <= max_drop_seq.v) && (!whc->wrinfo.is_transient_local || whc->wrinfo.tldepth > 0))
         {
           TRACE (" prune whcn %p", (void *)oldn);
           assert (oldn != whc->maxseq_node || whc->wrinfo.has_deadline);
@@ -1325,7 +1325,7 @@ static int whc_default_insert (struct whc *whc_generic, seqno_t max_drop_seq, se
         auto-acknowledged (for lack of reliable readers), and the keep-last T-L history is
         shallower than the keep-last regular history (normal path handles this via pruning in
         whc_default_remove_acked_messages, but that never happens when there are no readers). */
-        if (seq <= max_drop_seq && whc->wrinfo.tldepth > 0 && whc->wrinfo.idxdepth > whc->wrinfo.tldepth)
+        if (seq.v <= max_drop_seq.v && whc->wrinfo.tldepth > 0 && whc->wrinfo.idxdepth > whc->wrinfo.tldepth)
         {
           uint32_t pos = idxn->headidx + whc->wrinfo.idxdepth - whc->wrinfo.tldepth;
           if (pos >= whc->wrinfo.idxdepth)
@@ -1352,7 +1352,7 @@ static int whc_default_insert (struct whc *whc_generic, seqno_t max_drop_seq, se
       ddsi_tkmap_instance_ref (tk);
       idxn->iid = tk->m_iid;
       idxn->tk = tk;
-      idxn->prune_seq = 0;
+      idxn->prune_seq = (seqno_t){ 0 };
       idxn->headidx = 0;
       if (whc->wrinfo.idxdepth > 0)
       {
@@ -1370,7 +1370,7 @@ static int whc_default_insert (struct whc *whc_generic, seqno_t max_drop_seq, se
     else
     {
       TRACE (" unreg:skip");
-      if (newn->seq <= max_drop_seq)
+      if (newn->seq.v <= max_drop_seq.v)
       {
         struct whc_node *prev_seq = newn->prev_seq;
         TRACE (" unreg:seq <= max_drop_seq: delete newn\n");
@@ -1488,7 +1488,7 @@ static bool whc_default_sample_iter_borrow_next (struct whc_sample_iter *opaque_
   else
   {
     it->first = false;
-    seq = 0;
+    seq = (seqno_t){ 0 };
   }
   if ((whcn = find_nextseq_intv (&intv, whc, seq)) == NULL)
     valid = false;

--- a/src/core/ddsc/src/dds_whc.c
+++ b/src/core/ddsc/src/dds_whc.c
@@ -564,7 +564,7 @@ static void get_state_locked (const struct whc_impl *whc, struct whc_state *st)
 {
   if (whc->seq_size == 0)
   {
-    st->min_seq = st->max_seq = -1;
+    st->min_seq = st->max_seq = 0;
     st->unacked_bytes = 0;
   }
   else

--- a/src/core/ddsc/src/dds_whc_builtintopic.c
+++ b/src/core/ddsc/src/dds_whc_builtintopic.c
@@ -227,8 +227,8 @@ static bool bwhc_sample_iter_borrow_next (struct whc_sample_iter *opaque_it, str
 static void bwhc_get_state (const struct whc *whc, struct whc_state *st)
 {
   (void)whc;
-  st->max_seq = 0;
-  st->min_seq = 0;
+  st->max_seq = (seqno_t){ 0 };
+  st->min_seq = (seqno_t){ 0 };
   st->unacked_bytes = 0;
 }
 

--- a/src/core/ddsc/src/dds_whc_builtintopic.c
+++ b/src/core/ddsc/src/dds_whc_builtintopic.c
@@ -227,8 +227,8 @@ static bool bwhc_sample_iter_borrow_next (struct whc_sample_iter *opaque_it, str
 static void bwhc_get_state (const struct whc *whc, struct whc_state *st)
 {
   (void)whc;
-  st->max_seq = -1;
-  st->min_seq = -1;
+  st->max_seq = 0;
+  st->min_seq = 0;
   st->unacked_bytes = 0;
 }
 

--- a/src/core/ddsc/src/dds_whc_builtintopic.c
+++ b/src/core/ddsc/src/dds_whc_builtintopic.c
@@ -227,8 +227,8 @@ static bool bwhc_sample_iter_borrow_next (struct whc_sample_iter *opaque_it, str
 static void bwhc_get_state (const struct whc *whc, struct whc_state *st)
 {
   (void)whc;
-  st->max_seq = (seqno_t){ 0 };
-  st->min_seq = (seqno_t){ 0 };
+  st->max_seq = 0;
+  st->min_seq = 0;
   st->unacked_bytes = 0;
 }
 

--- a/src/core/ddsc/tests/lifespan.c
+++ b/src/core/ddsc/tests/lifespan.c
@@ -117,8 +117,8 @@ static void check_whc_state(dds_entity_t writer, seqno_t exp_min, seqno_t exp_ma
   thread_state_asleep(lookup_thread_state());
   dds_entity_unpin(wr_entity);
 
-  CU_ASSERT_EQUAL_FATAL (whcst.min_seq, exp_min);
-  CU_ASSERT_EQUAL_FATAL (whcst.max_seq, exp_max);
+  CU_ASSERT_EQUAL_FATAL (whcst.min_seq.v, exp_min.v);
+  CU_ASSERT_EQUAL_FATAL (whcst.max_seq.v, exp_max.v);
 }
 
 CU_Test(ddsc_lifespan, basic, .init=lifespan_init, .fini=lifespan_fini)
@@ -134,20 +134,20 @@ CU_Test(ddsc_lifespan, basic, .init=lifespan_init, .fini=lifespan_fini)
   /* Write with default qos: lifespan inifinite */
   ret = dds_write (g_writer, &sample);
   CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
-  check_whc_state(g_writer, 1, 1);
+  check_whc_state(g_writer, (seqno_t){ 1 }, (seqno_t){ 1 });
 
   dds_sleepfor (2 * exp);
-  check_whc_state(g_writer, 1, 1);
+  check_whc_state(g_writer, (seqno_t){ 1 }, (seqno_t){ 1 });
 
   dds_qset_lifespan(qos, exp);
   ret = dds_set_qos(g_writer, qos);
   CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
   ret = dds_write (g_writer, &sample);
   CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
-  check_whc_state(g_writer, 2, 2);
+  check_whc_state(g_writer, (seqno_t){ 2 }, (seqno_t){ 2 });
 
   dds_sleepfor (2 * exp);
-  check_whc_state(g_writer, 0, 0);
+  check_whc_state(g_writer, (seqno_t){ 0 }, (seqno_t){ 0 });
 
   dds_delete_qos(qos);
 }

--- a/src/core/ddsc/tests/lifespan.c
+++ b/src/core/ddsc/tests/lifespan.c
@@ -147,7 +147,7 @@ CU_Test(ddsc_lifespan, basic, .init=lifespan_init, .fini=lifespan_fini)
   check_whc_state(g_writer, 2, 2);
 
   dds_sleepfor (2 * exp);
-  check_whc_state(g_writer, -1, -1);
+  check_whc_state(g_writer, 0, 0);
 
   dds_delete_qos(qos);
 }

--- a/src/core/ddsc/tests/lifespan.c
+++ b/src/core/ddsc/tests/lifespan.c
@@ -117,8 +117,8 @@ static void check_whc_state(dds_entity_t writer, seqno_t exp_min, seqno_t exp_ma
   thread_state_asleep(lookup_thread_state());
   dds_entity_unpin(wr_entity);
 
-  CU_ASSERT_EQUAL_FATAL (whcst.min_seq.v, exp_min.v);
-  CU_ASSERT_EQUAL_FATAL (whcst.max_seq.v, exp_max.v);
+  CU_ASSERT_EQUAL_FATAL (whcst.min_seq, exp_min);
+  CU_ASSERT_EQUAL_FATAL (whcst.max_seq, exp_max);
 }
 
 CU_Test(ddsc_lifespan, basic, .init=lifespan_init, .fini=lifespan_fini)
@@ -134,20 +134,20 @@ CU_Test(ddsc_lifespan, basic, .init=lifespan_init, .fini=lifespan_fini)
   /* Write with default qos: lifespan inifinite */
   ret = dds_write (g_writer, &sample);
   CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
-  check_whc_state(g_writer, (seqno_t){ 1 }, (seqno_t){ 1 });
+  check_whc_state(g_writer, 1, 1);
 
   dds_sleepfor (2 * exp);
-  check_whc_state(g_writer, (seqno_t){ 1 }, (seqno_t){ 1 });
+  check_whc_state(g_writer, 1, 1);
 
   dds_qset_lifespan(qos, exp);
   ret = dds_set_qos(g_writer, qos);
   CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
   ret = dds_write (g_writer, &sample);
   CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
-  check_whc_state(g_writer, (seqno_t){ 2 }, (seqno_t){ 2 });
+  check_whc_state(g_writer, 2, 2);
 
   dds_sleepfor (2 * exp);
-  check_whc_state(g_writer, (seqno_t){ 0 }, (seqno_t){ 0 });
+  check_whc_state(g_writer, 0, 0);
 
   dds_delete_qos(qos);
 }

--- a/src/core/ddsc/tests/liveliness.c
+++ b/src/core/ddsc/tests/liveliness.c
@@ -166,7 +166,7 @@ static void test_pmd_count(dds_liveliness_kind_t kind, uint32_t ldur, double mul
          kind == 0 ? "A" : "MP", ldur, (int32_t)(mult * ldur), remote_reader ? "remote" : "local");
 
   /* wait for initial PMD to be sent by the participant */
-  while (get_pmd_seqno(g_pub_participant) < 1)
+  while (get_pmd_seqno(g_pub_participant).v < 1)
     dds_sleepfor(DDS_MSECS(50));
 
   /* topics */
@@ -202,16 +202,16 @@ static void test_pmd_count(dds_liveliness_kind_t kind, uint32_t ldur, double mul
   end_seqno = get_pmd_seqno(g_pub_participant);
 
   t = dds_time();
-  printf("%d.%06d PMD sequence no: start %" PRId64 " -> end %" PRId64 "\n",
+  printf("%d.%06d PMD sequence no: start %" PRIu64 " -> end %" PRIu64 "\n",
          (int32_t)(t / DDS_NSECS_IN_SEC), (int32_t)(t % DDS_NSECS_IN_SEC) / 1000,
-         start_seqno, end_seqno);
+         start_seqno.v, end_seqno.v);
 
   /* End-start should be mult - 1 under ideal circumstances, but consider the test successful
            when at least 50% of the expected PMD's was sent. This checks that the frequency for sending
            PMDs was increased when the writer was added. */
-  CU_ASSERT_FATAL((double) (end_seqno - start_seqno) >= (kind == DDS_LIVELINESS_AUTOMATIC ? (50 * (mult - 1)) / 100 : 0))
+  CU_ASSERT_FATAL((double) (end_seqno.v - start_seqno.v) >= (kind == DDS_LIVELINESS_AUTOMATIC ? (50 * (mult - 1)) / 100 : 0))
   if (kind != DDS_LIVELINESS_AUTOMATIC)
-    CU_ASSERT_FATAL((double) (get_pmd_seqno(g_pub_participant) - start_seqno) < mult)
+    CU_ASSERT_FATAL((double) (get_pmd_seqno(g_pub_participant).v - start_seqno.v) < mult)
 
   /* cleanup */
   if (remote_reader)

--- a/src/core/ddsc/tests/liveliness.c
+++ b/src/core/ddsc/tests/liveliness.c
@@ -166,7 +166,7 @@ static void test_pmd_count(dds_liveliness_kind_t kind, uint32_t ldur, double mul
          kind == 0 ? "A" : "MP", ldur, (int32_t)(mult * ldur), remote_reader ? "remote" : "local");
 
   /* wait for initial PMD to be sent by the participant */
-  while (get_pmd_seqno(g_pub_participant).v < 1)
+  while (get_pmd_seqno(g_pub_participant) < 1)
     dds_sleepfor(DDS_MSECS(50));
 
   /* topics */
@@ -204,14 +204,14 @@ static void test_pmd_count(dds_liveliness_kind_t kind, uint32_t ldur, double mul
   t = dds_time();
   printf("%d.%06d PMD sequence no: start %" PRIu64 " -> end %" PRIu64 "\n",
          (int32_t)(t / DDS_NSECS_IN_SEC), (int32_t)(t % DDS_NSECS_IN_SEC) / 1000,
-         start_seqno.v, end_seqno.v);
+         start_seqno, end_seqno);
 
   /* End-start should be mult - 1 under ideal circumstances, but consider the test successful
            when at least 50% of the expected PMD's was sent. This checks that the frequency for sending
            PMDs was increased when the writer was added. */
-  CU_ASSERT_FATAL((double) (end_seqno.v - start_seqno.v) >= (kind == DDS_LIVELINESS_AUTOMATIC ? (50 * (mult - 1)) / 100 : 0))
+  CU_ASSERT_FATAL((double) (end_seqno - start_seqno) >= (kind == DDS_LIVELINESS_AUTOMATIC ? (50 * (mult - 1)) / 100 : 0))
   if (kind != DDS_LIVELINESS_AUTOMATIC)
-    CU_ASSERT_FATAL((double) (get_pmd_seqno(g_pub_participant).v - start_seqno.v) < mult)
+    CU_ASSERT_FATAL((double) (get_pmd_seqno(g_pub_participant) - start_seqno) < mult)
 
   /* cleanup */
   if (remote_reader)

--- a/src/core/ddsc/tests/whc.c
+++ b/src/core/ddsc/tests/whc.c
@@ -119,19 +119,19 @@ static void check_intermediate_whc_state(dds_entity_t writer, seqno_t exp_min, s
   get_writer_whc_state (writer, &whcst);
   /* WHC must not contain any samples < exp_min and must contain at least exp_max if it
      contains at least one sample.  (We never know for certain when ACKs arrive.) */
-  printf(" -- intermediate state: unacked: %zu; min %"PRIu64" (exp %"PRIu64"); max %"PRIu64" (exp %"PRIu64")\n", whcst.unacked_bytes, whcst.min_seq.v, exp_min.v, whcst.max_seq.v, exp_max.v);
-  CU_ASSERT_FATAL (whcst.min_seq.v >= exp_min.v || (whcst.min_seq.v == 0 && whcst.max_seq.v == 0));
-  CU_ASSERT_FATAL (whcst.max_seq.v == exp_max.v || (whcst.min_seq.v == 0 && whcst.max_seq.v == 0));
+  printf(" -- intermediate state: unacked: %zu; min %"PRIu64" (exp %"PRIu64"); max %"PRIu64" (exp %"PRIu64")\n", whcst.unacked_bytes, whcst.min_seq, exp_min, whcst.max_seq, exp_max);
+  CU_ASSERT_FATAL (whcst.min_seq >= exp_min || (whcst.min_seq == 0 && whcst.max_seq == 0));
+  CU_ASSERT_FATAL (whcst.max_seq == exp_max || (whcst.min_seq == 0 && whcst.max_seq == 0));
 }
 
 static void check_whc_state(dds_entity_t writer, seqno_t exp_min, seqno_t exp_max)
 {
   struct whc_state whcst;
   get_writer_whc_state (writer, &whcst);
-  printf(" -- final state: unacked: %zu; min %"PRIu64" (exp %"PRIu64"); max %"PRIu64" (exp %"PRIu64")\n", whcst.unacked_bytes, whcst.min_seq.v, exp_min.v, whcst.max_seq.v, exp_max.v);
+  printf(" -- final state: unacked: %zu; min %"PRIu64" (exp %"PRIu64"); max %"PRIu64" (exp %"PRIu64")\n", whcst.unacked_bytes, whcst.min_seq, exp_min, whcst.max_seq, exp_max);
   CU_ASSERT_EQUAL_FATAL (whcst.unacked_bytes, 0);
-  CU_ASSERT_EQUAL_FATAL (whcst.min_seq.v, exp_min.v);
-  CU_ASSERT_EQUAL_FATAL (whcst.max_seq.v, exp_max.v);
+  CU_ASSERT_EQUAL_FATAL (whcst.min_seq, exp_min);
+  CU_ASSERT_EQUAL_FATAL (whcst.max_seq, exp_max);
 }
 
 #define V DDS_DURABILITY_VOLATILE
@@ -209,11 +209,11 @@ static void test_whc_end_state(dds_durability_kind_t d, dds_reliability_kind_t r
         // change to unsigned means we need to clamp it
         if (exp_min < 0)
           exp_min = 0;
-        check_intermediate_whc_state (writer, (seqno_t){ (uint32_t)exp_min }, (seqno_t){ (uint32_t)exp_max });
+        check_intermediate_whc_state (writer, (uint32_t)exp_min, (uint32_t)exp_max);
       }
       else
       {
-        check_intermediate_whc_state (writer, (seqno_t){ 0 }, (seqno_t){ 0 });
+        check_intermediate_whc_state (writer, 0, 0);
       }
     }
   }
@@ -242,7 +242,7 @@ static void test_whc_end_state(dds_durability_kind_t d, dds_reliability_kind_t r
   /* check whc state */
   int32_t exp_max = (d == TL) ? ni * SAMPLE_COUNT : 0;
   int32_t exp_min = (d == TL) ? ((dh == KA) ? 1 : exp_max - dhd * ni + 1) : 0;
-  check_whc_state (writer, (seqno_t){ (uint32_t)exp_min }, (seqno_t){ (uint32_t)exp_max });
+  check_whc_state (writer, (uint32_t)exp_min, (uint32_t)exp_max);
 
   dds_delete (writer);
   dds_delete (remote_topic);

--- a/src/core/ddsi/include/dds/ddsi/ddsi_security_msg.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_security_msg.h
@@ -48,7 +48,7 @@ struct ddsi_serdata;
 
 typedef struct nn_message_identity {
   ddsi_guid_t source_guid;
-  int64_t sequence_number;
+  seqno_t sequence_number;
 } nn_message_identity_t;
 
 typedef struct nn_participant_generic_message {
@@ -71,7 +71,7 @@ DDS_EXPORT void
 nn_participant_generic_message_init(
    nn_participant_generic_message_t *msg,
    const ddsi_guid_t *wrguid,
-   int64_t wrseq,
+   seqno_t wrseq,
    const ddsi_guid_t *dstpguid,
    const ddsi_guid_t *dsteguid,
    const ddsi_guid_t *srceguid,

--- a/src/core/ddsi/include/dds/ddsi/q_entity.h
+++ b/src/core/ddsi/include/dds/ddsi/q_entity.h
@@ -386,15 +386,15 @@ struct writer
 };
 
 DDS_INLINE_EXPORT inline seqno_t writer_read_seq_xmit (const struct writer *wr) {
-  return (seqno_t){ ddsrt_atomic_ld64 (&wr->seq_xmit) };
+  return ddsrt_atomic_ld64 (&wr->seq_xmit);
 }
 
 DDS_INLINE_EXPORT inline void writer_update_seq_xmit (struct writer *wr, seqno_t nv) {
   uint64_t ov;
   do {
     ov = ddsrt_atomic_ld64 (&wr->seq_xmit);
-    if (nv.v <= ov) break;
-  } while (!ddsrt_atomic_cas64 (&wr->seq_xmit, ov, nv.v));
+    if (nv <= ov) break;
+  } while (!ddsrt_atomic_cas64 (&wr->seq_xmit, ov, nv));
 }
 
 struct reader

--- a/src/core/ddsi/include/dds/ddsi/q_misc.h
+++ b/src/core/ddsi/include/dds/ddsi/q_misc.h
@@ -20,7 +20,7 @@ extern "C" {
 
 DDS_INLINE_EXPORT inline seqno_t fromSN (const nn_sequence_number_t sn) {
   uint64_t sn_high = (uint32_t) sn.high;
-  return (seqno_t) ((sn_high << 32) | sn.low);
+  return (seqno_t){ (sn_high << 32) | sn.low };
 }
 
 DDS_INLINE_EXPORT inline bool validating_fromSN (const nn_sequence_number_t sn, seqno_t *res) {
@@ -36,13 +36,13 @@ DDS_INLINE_EXPORT inline bool validating_fromSN (const nn_sequence_number_t sn, 
   // Since we use uint64_t, we can easily test by checking whether (s-1) is in [0 .. 2**63-1)
   const seqno_t tmp = fromSN (sn);
   *res = tmp;
-  return ((uint64_t) tmp - 1) < MAX_SEQ_NUMBER;
+  return (tmp.v - 1) < MAX_SEQ_NUMBER;
 }
 
 DDS_INLINE_EXPORT inline nn_sequence_number_t toSN (seqno_t n) {
   nn_sequence_number_t x;
-  x.high = (int) ((uint64_t) n >> 32);
-  x.low = (unsigned) n;
+  x.high = (int32_t) (n.v >> 32);
+  x.low = (uint32_t) n.v;
   return x;
 }
 

--- a/src/core/ddsi/include/dds/ddsi/q_misc.h
+++ b/src/core/ddsi/include/dds/ddsi/q_misc.h
@@ -20,7 +20,7 @@ extern "C" {
 
 DDS_INLINE_EXPORT inline seqno_t fromSN (const nn_sequence_number_t sn) {
   uint64_t sn_high = (uint32_t) sn.high;
-  return (seqno_t){ (sn_high << 32) | sn.low };
+  return (sn_high << 32) | sn.low;
 }
 
 DDS_INLINE_EXPORT inline bool validating_fromSN (const nn_sequence_number_t sn, seqno_t *res) {
@@ -36,13 +36,13 @@ DDS_INLINE_EXPORT inline bool validating_fromSN (const nn_sequence_number_t sn, 
   // Since we use uint64_t, we can easily test by checking whether (s-1) is in [0 .. 2**63-1)
   const seqno_t tmp = fromSN (sn);
   *res = tmp;
-  return (tmp.v - 1) < MAX_SEQ_NUMBER;
+  return (tmp - 1) < MAX_SEQ_NUMBER;
 }
 
 DDS_INLINE_EXPORT inline nn_sequence_number_t toSN (seqno_t n) {
   nn_sequence_number_t x;
-  x.high = (int32_t) (n.v >> 32);
-  x.low = (uint32_t) n.v;
+  x.high = (int32_t) (n >> 32);
+  x.low = (uint32_t) n;
   return x;
 }
 

--- a/src/core/ddsi/include/dds/ddsi/q_receive.h
+++ b/src/core/ddsi/include/dds/ddsi/q_receive.h
@@ -26,14 +26,14 @@ struct writer;
 struct proxy_reader;
 
 struct nn_gap_info {
-  int64_t gapstart;
-  int64_t gapend;
+  seqno_t gapstart; // == 0 on init, indicating no gap recorded yet
+  seqno_t gapend;   // >= gapstart
   uint32_t gapnumbits;
   uint32_t gapbits[256 / 32];
 };
 
 void nn_gap_info_init(struct nn_gap_info *gi);
-void nn_gap_info_update(struct ddsi_domaingv *gv, struct nn_gap_info *gi, int64_t seqnr);
+void nn_gap_info_update(struct ddsi_domaingv *gv, struct nn_gap_info *gi, seqno_t seqnr);
 struct nn_xmsg * nn_gap_info_create_gap(struct writer *wr, struct proxy_reader *prd, struct nn_gap_info *gi);
 
 void trigger_recv_threads (const struct ddsi_domaingv *gv);

--- a/src/core/ddsi/include/dds/ddsi/q_rtps.h
+++ b/src/core/ddsi/include/dds/ddsi/q_rtps.h
@@ -23,7 +23,7 @@ extern "C" {
 typedef struct {
   uint8_t major, minor;
 } nn_protocol_version_t;
-typedef struct { uint64_t v; } seqno_t;
+typedef uint64_t seqno_t;
 #define MAX_SEQ_NUMBER INT64_MAX
 
 #define PGUIDPREFIX(gp) (gp).u[0], (gp).u[1], (gp).u[2]

--- a/src/core/ddsi/include/dds/ddsi/q_rtps.h
+++ b/src/core/ddsi/include/dds/ddsi/q_rtps.h
@@ -23,7 +23,7 @@ extern "C" {
 typedef struct {
   uint8_t major, minor;
 } nn_protocol_version_t;
-typedef int64_t seqno_t;
+typedef struct { uint64_t v; } seqno_t;
 #define MAX_SEQ_NUMBER INT64_MAX
 
 #define PGUIDPREFIX(gp) (gp).u[0], (gp).u[1], (gp).u[2]

--- a/src/core/ddsi/include/dds/ddsi/q_whc.h
+++ b/src/core/ddsi/include/dds/ddsi/q_whc.h
@@ -39,7 +39,7 @@ struct whc_state {
   seqno_t max_seq; /* 0 if WHC empty, else >= min_seq */
   size_t unacked_bytes;
 };
-#define WHCST_ISEMPTY(whcst) ((whcst)->max_seq == 0)
+#define WHCST_ISEMPTY(whcst) ((whcst)->max_seq.v == 0)
 
 /* Adjust SIZE and alignment stuff as needed: they are here simply so we can allocate
    an iter on the stack without specifying an implementation. If future changes or

--- a/src/core/ddsi/include/dds/ddsi/q_whc.h
+++ b/src/core/ddsi/include/dds/ddsi/q_whc.h
@@ -35,11 +35,11 @@ struct whc_borrowed_sample {
 };
 
 struct whc_state {
-  seqno_t min_seq; /* -1 if WHC empty, else > 0 */
-  seqno_t max_seq; /* -1 if WHC empty, else >= min_seq */
+  seqno_t min_seq; /* 0 if WHC empty, else > 0 */
+  seqno_t max_seq; /* 0 if WHC empty, else >= min_seq */
   size_t unacked_bytes;
 };
-#define WHCST_ISEMPTY(whcst) ((whcst)->max_seq == -1)
+#define WHCST_ISEMPTY(whcst) ((whcst)->max_seq == 0)
 
 /* Adjust SIZE and alignment stuff as needed: they are here simply so we can allocate
    an iter on the stack without specifying an implementation. If future changes or

--- a/src/core/ddsi/include/dds/ddsi/q_whc.h
+++ b/src/core/ddsi/include/dds/ddsi/q_whc.h
@@ -39,7 +39,7 @@ struct whc_state {
   seqno_t max_seq; /* 0 if WHC empty, else >= min_seq */
   size_t unacked_bytes;
 };
-#define WHCST_ISEMPTY(whcst) ((whcst)->max_seq.v == 0)
+#define WHCST_ISEMPTY(whcst) ((whcst)->max_seq == 0)
 
 /* Adjust SIZE and alignment stuff as needed: they are here simply so we can allocate
    an iter on the stack without specifying an implementation. If future changes or

--- a/src/core/ddsi/src/ddsi_acknack.c
+++ b/src/core/ddsi/src/ddsi_acknack.c
@@ -67,10 +67,10 @@ static seqno_t next_deliv_seq (const struct proxy_writer *pwr, const seqno_t nex
      before delivery. */
   const uint32_t lw = ddsrt_atomic_ld32 (&pwr->next_deliv_seq_lowword);
   seqno_t next_deliv_seq;
-  next_deliv_seq.v = (next_seq.v & ~(uint64_t)UINT32_MAX) | lw;
-  if (next_deliv_seq.v > next_seq.v)
-    next_deliv_seq.v -= ((uint64_t) 1) << 32;
-  assert (0 < next_deliv_seq.v && next_deliv_seq.v <= next_seq.v);
+  next_deliv_seq = (next_seq & ~(uint64_t)UINT32_MAX) | lw;
+  if (next_deliv_seq > next_seq)
+    next_deliv_seq -= ((uint64_t) 1) << 32;
+  assert (0 < next_deliv_seq && next_deliv_seq <= next_seq);
   return next_deliv_seq;
 }
 
@@ -128,28 +128,28 @@ static bool add_AckNack_makebitmaps (const struct proxy_writer *pwr, const struc
   const uint32_t numbits = nn_reorder_nackmap (reorder, bitmap_base, last_seq, &info->acknack.set, info->acknack.bits, NN_SEQUENCE_NUMBER_SET_MAX_BITS, notail);
   if (numbits == 0)
   {
-    info->nackfrag.seq.v = 0;
+    info->nackfrag.seq = 0;
     return false;
   }
 
   /* Scan through bitmap, cutting it off at the first missing sample that the defragmenter
      knows about. Then note the sequence number & add a NACKFRAG for that sample */
-  info->nackfrag.seq.v = 0;
+  info->nackfrag.seq = 0;
   const seqno_t base = fromSN (info->acknack.set.bitmap_base);
   for (uint32_t i = 0; i < numbits; i++)
   {
     if (!nn_bitset_isset (numbits, info->acknack.bits, i))
       continue;
 
-    const seqno_t seq = { base.v + i };
-    const uint32_t fragnum = (seq.v == pwr->last_seq.v) ? pwr->last_fragnum : UINT32_MAX;
+    const seqno_t seq = base + i;
+    const uint32_t fragnum = (seq == pwr->last_seq) ? pwr->last_fragnum : UINT32_MAX;
     switch (nn_defrag_nackmap (pwr->defrag, seq, fragnum, &info->nackfrag.set, info->nackfrag.bits, NN_FRAGMENT_NUMBER_SET_MAX_BITS))
     {
       case DEFRAG_NACKMAP_UNKNOWN_SAMPLE:
         break;
       case DEFRAG_NACKMAP_ALL_ADVERTISED_FRAGMENTS_KNOWN:
         /* Cut the NACK short (or make it an ACK if this is the first sample), no NACKFRAG */
-        info->nackfrag.seq = (seqno_t){ 0 };
+        info->nackfrag.seq = 0;
         info->acknack.set.numbits = i;
         return (i > 0);
       case DEFRAG_NACKMAP_FRAGMENTS_MISSING:
@@ -192,7 +192,7 @@ static void add_NackFrag (struct nn_xmsg *msg, const struct proxy_writer *pwr, c
   if (pwr->e.gv->logconfig.c.mask & DDS_LC_TRACE)
   {
     ETRACE (pwr, "nackfrag #%"PRIu32":%"PRIu64"/%"PRIu32"/%"PRIu32":",
-            pwr->nackfragcount, fromSN (nf->writerSN).v,
+            pwr->nackfragcount, fromSN (nf->writerSN),
             nf->fragmentNumberState.bitmap_base, nf->fragmentNumberState.numbits);
     for (uint32_t ui = 0; ui != nf->fragmentNumberState.numbits; ui++)
       ETRACE (pwr, "%c", nn_bitset_isset (nf->fragmentNumberState.numbits, nf->bits, ui) ? '1' : '0');
@@ -238,7 +238,7 @@ static void add_AckNack (struct nn_xmsg *msg, const struct proxy_writer *pwr, co
   {
     ETRACE (pwr, "acknack "PGUIDFMT" -> "PGUIDFMT": F#%"PRIu32":%"PRIu64"/%"PRIu32":",
             PGUID (rwn->rd_guid), PGUID (pwr->e.guid), rwn->count,
-            fromSN (an->readerSNState.bitmap_base).v, an->readerSNState.numbits);
+            fromSN (an->readerSNState.bitmap_base), an->readerSNState.numbits);
     for (uint32_t ui = 0; ui != an->readerSNState.numbits; ui++)
       ETRACE (pwr, "%c", nn_bitset_isset (an->readerSNState.numbits, an->bits, ui) ? '1' : '0');
   }
@@ -263,7 +263,7 @@ static enum add_AckNack_result get_AckNack_info (const struct proxy_writer *pwr,
   {
     info->nack_sent_on_nackdelay = rwn->nack_sent_on_nackdelay;
     nack_summary->seq_base = fromSN (info->acknack.set.bitmap_base);
-    nack_summary->seq_end_p1 = (seqno_t){ 0 };
+    nack_summary->seq_end_p1 = 0;
     nack_summary->frag_base = 0;
     nack_summary->frag_end_p1 = 0;
     result = AANR_ACK;
@@ -272,11 +272,11 @@ static enum add_AckNack_result get_AckNack_info (const struct proxy_writer *pwr,
   {
     // [seq_base:0 .. seq_end_p1:0) + [seq_end_p1:frag_base .. seq_end_p1:frag_end_p1) if frag_end_p1 > 0
     const seqno_t seq_base = fromSN (info->acknack.set.bitmap_base);
-    assert (seq_base.v >= 1 && (info->acknack.set.numbits > 0 || info->nackfrag.seq.v > 0));
-    assert (info->nackfrag.seq.v == 0 || info->nackfrag.set.numbits > 0);
-    const seqno_t seq_end_p1 = (seqno_t){ seq_base.v + info->acknack.set.numbits };
-    const uint32_t frag_base = (info->nackfrag.seq.v > 0) ? info->nackfrag.set.bitmap_base : 0;
-    const uint32_t frag_end_p1 = (info->nackfrag.seq.v > 0) ? info->nackfrag.set.bitmap_base + info->nackfrag.set.numbits : 0;
+    assert (seq_base >= 1 && (info->acknack.set.numbits > 0 || info->nackfrag.seq > 0));
+    assert (info->nackfrag.seq == 0 || info->nackfrag.set.numbits > 0);
+    const seqno_t seq_end_p1 = seq_base + info->acknack.set.numbits;
+    const uint32_t frag_base = (info->nackfrag.seq > 0) ? info->nackfrag.set.bitmap_base : 0;
+    const uint32_t frag_end_p1 = (info->nackfrag.seq > 0) ? info->nackfrag.set.bitmap_base + info->nackfrag.set.numbits : 0;
 
     /* Let caller know whether it is a nack, and, in steady state, set
        final to prevent a response if it isn't.  The initial
@@ -292,7 +292,7 @@ static enum add_AckNack_result get_AckNack_info (const struct proxy_writer *pwr,
     nack_summary->frag_base = frag_base;
 
     // [seq_base:0 .. seq_end_p1:0) and [seq_end_p1:frag_base .. seq_end_p1:frag_end_p1) if frag_end_p1 > 0
-    if (seq_base.v > rwn->last_nack.seq_end_p1.v || (seq_base.v == rwn->last_nack.seq_end_p1.v && frag_base >= rwn->last_nack.frag_end_p1))
+    if (seq_base > rwn->last_nack.seq_end_p1 || (seq_base == rwn->last_nack.seq_end_p1 && frag_base >= rwn->last_nack.frag_end_p1))
     {
       // A NACK for something not previously NACK'd or NackDelay passed, update nack_{seq,frag} to reflect
       // the changed state
@@ -327,7 +327,7 @@ static enum add_AckNack_result get_AckNack_info (const struct proxy_writer *pwr,
 #endif
       info->nack_sent_on_nackdelay = rwn->nack_sent_on_nackdelay;
       info->acknack.set.numbits = 0;
-      info->nackfrag.seq = (seqno_t){ 0 };
+      info->nackfrag.seq = 0;
       result = AANR_SUPPRESSED_NACK;
     }
   }
@@ -337,10 +337,10 @@ static enum add_AckNack_result get_AckNack_info (const struct proxy_writer *pwr,
     // ACK and SUPPRESSED_NACK both end up being a pure ACK; send those only if we have to
     if (!(rwn->heartbeat_since_ack && rwn->ack_requested))
       result = AANR_SUPPRESSED_ACK; // writer didn't ask for it
-    else if (!(nack_summary->seq_base.v > rwn->last_nack.seq_base.v || ackdelay_passed))
+    else if (!(nack_summary->seq_base > rwn->last_nack.seq_base || ackdelay_passed))
       result = AANR_SUPPRESSED_ACK; // no progress since last, not enough time passed
   }
-  else if (info->acknack.set.numbits == 0 && info->nackfrag.seq.v > 0 && !rwn->ack_requested)
+  else if (info->acknack.set.numbits == 0 && info->nackfrag.seq > 0 && !rwn->ack_requested)
   {
     // if we are not NACK'ing full samples and we are NACK'ing fragments, skip the ACKNACK submessage if we
     // have no interest in a HEARTBEAT and the writer hasn't asked for an ACKNACK since the last one we sent.
@@ -440,7 +440,7 @@ struct nn_xmsg *make_and_resched_acknack (struct xevent *ev, struct proxy_writer
 
   if (aanr != AANR_NACKFRAG_ONLY)
     add_AckNack (msg, pwr, rwn, &info);
-  if (info.nackfrag.seq.v > 0)
+  if (info.nackfrag.seq > 0)
   {
     ETRACE (pwr, " + ");
     add_NackFrag (msg, pwr, rwn, &info);

--- a/src/core/ddsi/src/ddsi_security_exchange.c
+++ b/src/core/ddsi/src/ddsi_security_exchange.c
@@ -55,7 +55,7 @@ bool write_auth_handshake_message(const struct participant *pp, const struct pro
   }
 
   ddsrt_mutex_lock (&wr->e.lock);
-  seq = ++wr->seq;
+  seq = (seqno_t){ ++wr->seq.v };
 
   if (request) {
     nn_participant_generic_message_init(&pmg, &wr->e.guid, seq, &proxypp->e.guid, NULL, NULL, DDS_SECURITY_AUTH_REQUEST, mdata, NULL);
@@ -166,7 +166,7 @@ static bool write_crypto_exchange_message(const struct participant *pp, const dd
   GVLOG (DDS_LC_DISCOVERY, "send crypto tokens("PGUIDFMT" --> "PGUIDFMT")\n", PGUID (wr->e.guid), PGUID (prd_guid));
 
   ddsrt_mutex_lock (&wr->e.lock);
-  seq = ++wr->seq;
+  seq = (seqno_t){ ++wr->seq.v };
 
   /* Get serialized message. */
   nn_participant_generic_message_init(&pmg, &wr->e.guid, seq, dst_pguid, dst_eguid, src_eguid, classid, tokens, NULL);

--- a/src/core/ddsi/src/ddsi_security_exchange.c
+++ b/src/core/ddsi/src/ddsi_security_exchange.c
@@ -55,7 +55,7 @@ bool write_auth_handshake_message(const struct participant *pp, const struct pro
   }
 
   ddsrt_mutex_lock (&wr->e.lock);
-  seq = (seqno_t){ ++wr->seq.v };
+  seq = ++wr->seq;
 
   if (request) {
     nn_participant_generic_message_init(&pmg, &wr->e.guid, seq, &proxypp->e.guid, NULL, NULL, DDS_SECURITY_AUTH_REQUEST, mdata, NULL);
@@ -166,7 +166,7 @@ static bool write_crypto_exchange_message(const struct participant *pp, const dd
   GVLOG (DDS_LC_DISCOVERY, "send crypto tokens("PGUIDFMT" --> "PGUIDFMT")\n", PGUID (wr->e.guid), PGUID (prd_guid));
 
   ddsrt_mutex_lock (&wr->e.lock);
-  seq = (seqno_t){ ++wr->seq.v };
+  seq = ++wr->seq;
 
   /* Get serialized message. */
   nn_participant_generic_message_init(&pmg, &wr->e.guid, seq, dst_pguid, dst_eguid, src_eguid, classid, tokens, NULL);

--- a/src/core/ddsi/src/ddsi_security_exchange.c
+++ b/src/core/ddsi/src/ddsi_security_exchange.c
@@ -37,7 +37,7 @@ bool write_auth_handshake_message(const struct participant *pp, const struct pro
   struct nn_participant_generic_message pmg;
   struct ddsi_serdata *serdata;
   struct writer *wr;
-  int64_t seq;
+  seqno_t seq;
   struct proxy_reader *prd;
   ddsi_guid_t prd_guid;
   bool result = false;

--- a/src/core/ddsi/src/ddsi_security_msg.c
+++ b/src/core/ddsi/src/ddsi_security_msg.c
@@ -94,7 +94,7 @@ void
 nn_participant_generic_message_init(
    nn_participant_generic_message_t *msg,
    const ddsi_guid_t *wrguid,
-   int64_t wrseq,
+   seqno_t wrseq,
    const ddsi_guid_t *dstpguid,
    const ddsi_guid_t *dsteguid,
    const ddsi_guid_t *srceguid,

--- a/src/core/ddsi/src/ddsi_typelookup.c
+++ b/src/core/ddsi/src/ddsi_typelookup.c
@@ -87,9 +87,9 @@ bool ddsi_tl_request_type (struct ddsi_domaingv * const gv, const ddsi_typeid_t 
   memset (&request, 0, sizeof (request));
   memcpy (&request.header.requestId.writer_guid.guidPrefix, &wr->e.guid.prefix, sizeof (request.header.requestId.writer_guid.guidPrefix));
   memcpy (&request.header.requestId.writer_guid.entityId, &wr->e.guid.entityid, sizeof (request.header.requestId.writer_guid.entityId));
-  type->request_seqno.v++;
-  request.header.requestId.sequence_number.high = (int32_t) (type->request_seqno.v >> 32);
-  request.header.requestId.sequence_number.low = (uint32_t) type->request_seqno.v;
+  type->request_seqno++;
+  request.header.requestId.sequence_number.high = (int32_t) (type->request_seqno >> 32);
+  request.header.requestId.sequence_number.low = (uint32_t) type->request_seqno;
   (void) snprintf (request.header.instanceName, sizeof (request.header.instanceName), "dds.builtin.TOS.%08"PRIx32 "%08"PRIx32 "%08"PRIx32 "%08"PRIx32,
     wr->c.pp->e.guid.prefix.u[0], wr->c.pp->e.guid.prefix.u[1], wr->c.pp->e.guid.prefix.u[2], wr->c.pp->e.guid.entityid.u);
   request.data._d = DDS_Builtin_TypeLookup_getTypes_HashId;
@@ -124,8 +124,8 @@ static void write_typelookup_reply (struct writer *wr, seqno_t seqno, struct DDS
   GVTRACE (" tl-reply ");
   memcpy (&reply.header.requestId.writer_guid.guidPrefix, &wr->e.guid.prefix, sizeof (reply.header.requestId.writer_guid.guidPrefix));
   memcpy (&reply.header.requestId.writer_guid.entityId, &wr->e.guid.entityid, sizeof (reply.header.requestId.writer_guid.entityId));
-  reply.header.requestId.sequence_number.high = (int32_t) (seqno.v >> 32);
-  reply.header.requestId.sequence_number.low = (uint32_t) seqno.v;
+  reply.header.requestId.sequence_number.high = (int32_t) (seqno >> 32);
+  reply.header.requestId.sequence_number.low = (uint32_t) seqno;
   (void) snprintf (reply.header.instanceName, sizeof (reply.header.instanceName), "dds.builtin.TOS.%08"PRIx32 "%08"PRIx32 "%08"PRIx32 "%08"PRIx32,
     wr->c.pp->e.guid.prefix.u[0], wr->c.pp->e.guid.prefix.u[1], wr->c.pp->e.guid.prefix.u[2], wr->c.pp->e.guid.entityid.u);
   reply.return_data._d = DDS_Builtin_TypeLookup_getTypes_HashId;
@@ -161,7 +161,7 @@ void ddsi_tl_handle_request (struct ddsi_domaingv *gv, struct ddsi_serdata *d)
   DDS_Builtin_TypeLookup_Request req;
   memset (&req, 0, sizeof (req));
   ddsi_serdata_to_sample (d, &req, NULL, NULL);
-  GVTRACE (" handle-tl-req wr "PGUIDFMT " seqnr %"PRIu64" ntypeids %"PRIu32, PGUID (from_guid (&req.header.requestId.writer_guid)), from_seqno (&req.header.requestId.sequence_number).v, req.data._u.getTypes.type_ids._length);
+  GVTRACE (" handle-tl-req wr "PGUIDFMT " seqnr %"PRIu64" ntypeids %"PRIu32, PGUID (from_guid (&req.header.requestId.writer_guid)), from_seqno (&req.header.requestId.sequence_number), req.data._u.getTypes.type_ids._length);
 
   ddsrt_mutex_lock (&gv->typelib_lock);
   struct DDS_XTypes_TypeIdentifierTypeObjectPairSeq types = { 0, 0, NULL, false };
@@ -212,7 +212,7 @@ void ddsi_tl_handle_reply (struct ddsi_domaingv *gv, struct ddsi_serdata *d)
   ddsi_serdata_to_sample (d, &reply, NULL, NULL);
   bool resolved = false;
   ddsrt_mutex_lock (&gv->typelib_lock);
-  GVTRACE ("handle-tl-reply wr "PGUIDFMT " seqnr %"PRIu64" ntypeids %"PRIu32"\n", PGUID (from_guid (&reply.header.requestId.writer_guid)), from_seqno (&reply.header.requestId.sequence_number).v, reply.return_data._u.getType._u.result.types._length);
+  GVTRACE ("handle-tl-reply wr "PGUIDFMT " seqnr %"PRIu64" ntypeids %"PRIu32"\n", PGUID (from_guid (&reply.header.requestId.writer_guid)), from_seqno (&reply.header.requestId.sequence_number), reply.return_data._u.getType._u.result.types._length);
   for (uint32_t n = 0; n < reply.return_data._u.getType._u.result.types._length; n++)
   {
     struct ddsi_typeid_str str;

--- a/src/core/ddsi/src/ddsi_typelookup.c
+++ b/src/core/ddsi/src/ddsi_typelookup.c
@@ -87,9 +87,9 @@ bool ddsi_tl_request_type (struct ddsi_domaingv * const gv, const ddsi_typeid_t 
   memset (&request, 0, sizeof (request));
   memcpy (&request.header.requestId.writer_guid.guidPrefix, &wr->e.guid.prefix, sizeof (request.header.requestId.writer_guid.guidPrefix));
   memcpy (&request.header.requestId.writer_guid.entityId, &wr->e.guid.entityid, sizeof (request.header.requestId.writer_guid.entityId));
-  type->request_seqno++;
-  request.header.requestId.sequence_number.high = (int32_t) (type->request_seqno >> 32);
-  request.header.requestId.sequence_number.low = (uint32_t) type->request_seqno;
+  type->request_seqno.v++;
+  request.header.requestId.sequence_number.high = (int32_t) (type->request_seqno.v >> 32);
+  request.header.requestId.sequence_number.low = (uint32_t) type->request_seqno.v;
   (void) snprintf (request.header.instanceName, sizeof (request.header.instanceName), "dds.builtin.TOS.%08"PRIx32 "%08"PRIx32 "%08"PRIx32 "%08"PRIx32,
     wr->c.pp->e.guid.prefix.u[0], wr->c.pp->e.guid.prefix.u[1], wr->c.pp->e.guid.prefix.u[2], wr->c.pp->e.guid.entityid.u);
   request.data._d = DDS_Builtin_TypeLookup_getTypes_HashId;
@@ -124,8 +124,8 @@ static void write_typelookup_reply (struct writer *wr, seqno_t seqno, struct DDS
   GVTRACE (" tl-reply ");
   memcpy (&reply.header.requestId.writer_guid.guidPrefix, &wr->e.guid.prefix, sizeof (reply.header.requestId.writer_guid.guidPrefix));
   memcpy (&reply.header.requestId.writer_guid.entityId, &wr->e.guid.entityid, sizeof (reply.header.requestId.writer_guid.entityId));
-  reply.header.requestId.sequence_number.high = (int32_t) (seqno >> 32);
-  reply.header.requestId.sequence_number.low = (uint32_t) seqno;
+  reply.header.requestId.sequence_number.high = (int32_t) (seqno.v >> 32);
+  reply.header.requestId.sequence_number.low = (uint32_t) seqno.v;
   (void) snprintf (reply.header.instanceName, sizeof (reply.header.instanceName), "dds.builtin.TOS.%08"PRIx32 "%08"PRIx32 "%08"PRIx32 "%08"PRIx32,
     wr->c.pp->e.guid.prefix.u[0], wr->c.pp->e.guid.prefix.u[1], wr->c.pp->e.guid.prefix.u[2], wr->c.pp->e.guid.entityid.u);
   reply.return_data._d = DDS_Builtin_TypeLookup_getTypes_HashId;
@@ -151,7 +151,7 @@ static ddsi_guid_t from_guid (const DDS_GUID_t *guid)
 
 static seqno_t from_seqno (const DDS_SequenceNumber *seqno)
 {
-  return (((int64_t) seqno->high) << 32llu) + (int64_t) seqno->low;
+  return fromSN((nn_sequence_number_t){ .high = seqno->high, .low = seqno->low });
 }
 
 void ddsi_tl_handle_request (struct ddsi_domaingv *gv, struct ddsi_serdata *d)
@@ -161,7 +161,7 @@ void ddsi_tl_handle_request (struct ddsi_domaingv *gv, struct ddsi_serdata *d)
   DDS_Builtin_TypeLookup_Request req;
   memset (&req, 0, sizeof (req));
   ddsi_serdata_to_sample (d, &req, NULL, NULL);
-  GVTRACE (" handle-tl-req wr "PGUIDFMT " seqnr %"PRIi64" ntypeids %"PRIu32, PGUID (from_guid (&req.header.requestId.writer_guid)), from_seqno (&req.header.requestId.sequence_number), req.data._u.getTypes.type_ids._length);
+  GVTRACE (" handle-tl-req wr "PGUIDFMT " seqnr %"PRIu64" ntypeids %"PRIu32, PGUID (from_guid (&req.header.requestId.writer_guid)), from_seqno (&req.header.requestId.sequence_number).v, req.data._u.getTypes.type_ids._length);
 
   ddsrt_mutex_lock (&gv->typelib_lock);
   struct DDS_XTypes_TypeIdentifierTypeObjectPairSeq types = { 0, 0, NULL, false };
@@ -212,7 +212,7 @@ void ddsi_tl_handle_reply (struct ddsi_domaingv *gv, struct ddsi_serdata *d)
   ddsi_serdata_to_sample (d, &reply, NULL, NULL);
   bool resolved = false;
   ddsrt_mutex_lock (&gv->typelib_lock);
-  GVTRACE ("handle-tl-reply wr "PGUIDFMT " seqnr %"PRIi64" ntypeids %"PRIu32"\n", PGUID (from_guid (&reply.header.requestId.writer_guid)), from_seqno (&reply.header.requestId.sequence_number), reply.return_data._u.getType._u.result.types._length);
+  GVTRACE ("handle-tl-reply wr "PGUIDFMT " seqnr %"PRIu64" ntypeids %"PRIu32"\n", PGUID (from_guid (&reply.header.requestId.writer_guid)), from_seqno (&reply.header.requestId.sequence_number).v, reply.return_data._u.getType._u.result.types._length);
   for (uint32_t n = 0; n < reply.return_data._u.getType._u.result.types._length; n++)
   {
     struct ddsi_typeid_str str;

--- a/src/core/ddsi/src/q_ddsi_discovery.c
+++ b/src/core/ddsi/src/q_ddsi_discovery.c
@@ -798,7 +798,7 @@ static int handle_spdp_alive (const struct receiver_state *rst, seqno_t seq, dds
       if ((lease = ddsrt_atomic_ldvoidp (&proxypp->minl_auto)) != NULL)
         lease_renew (lease, ddsrt_time_elapsed ());
       ddsrt_mutex_lock (&proxypp->e.lock);
-      if (proxypp->implicitly_created || seq > proxypp->seq)
+      if (proxypp->implicitly_created || seq.v > proxypp->seq.v)
       {
         interesting = 1;
         if (!(gv->logconfig.c.mask & DDS_LC_TRACE))
@@ -1519,7 +1519,7 @@ static bool handle_sedp_checks (struct ddsi_domaingv * const gv, ddsi_sedp_kind_
   if ((*proxypp = entidx_lookup_proxy_participant_guid (gv->entity_index, ppguid)) == NULL)
   {
     GVLOGDISC (" unknown-proxypp");
-    if ((*proxypp = implicitly_create_proxypp (gv, ppguid, datap, src_guid_prefix, vendorid, timestamp, 0)) == NULL)
+    if ((*proxypp = implicitly_create_proxypp (gv, ppguid, datap, src_guid_prefix, vendorid, timestamp, (seqno_t){ 0 })) == NULL)
       E ("?\n", err);
     /* Repeat regular SEDP trace for convenience */
     GVLOGDISC ("SEDP ST0 "PGUIDFMT" (cont)", PGUID (*entity_guid));
@@ -1968,8 +1968,8 @@ int builtins_dqueue_handler (const struct nn_rsample_info *sampleinfo, const str
     if ((plist_ret = ddsi_plist_init_frommsg (&qos, NULL, PP_STATUSINFO | PP_KEYHASH, 0, &src, gv)) < 0)
     {
       if (plist_ret != DDS_RETCODE_UNSUPPORTED)
-        GVWARNING ("data(builtin, vendor %u.%u): "PGUIDFMT" #%"PRId64": invalid inline qos\n",
-                   src.vendorid.id[0], src.vendorid.id[1], PGUID (srcguid), sampleinfo->seq);
+        GVWARNING ("data(builtin, vendor %u.%u): "PGUIDFMT" #%"PRIu64": invalid inline qos\n",
+                   src.vendorid.id[0], src.vendorid.id[1], PGUID (srcguid), sampleinfo->seq.v);
       goto done_upd_deliv;
     }
     /* Complex qos bit also gets set when statusinfo bits other than
@@ -2054,16 +2054,16 @@ int builtins_dqueue_handler (const struct nn_rsample_info *sampleinfo, const str
     d = ddsi_serdata_from_keyhash (type, &qos.keyhash);
   else
   {
-    GVLOGDISC ("data(builtin, vendor %u.%u): "PGUIDFMT" #%"PRId64": missing payload\n",
+    GVLOGDISC ("data(builtin, vendor %u.%u): "PGUIDFMT" #%"PRIu64": missing payload\n",
                sampleinfo->rst->vendor.id[0], sampleinfo->rst->vendor.id[1],
-               PGUID (srcguid), sampleinfo->seq);
+               PGUID (srcguid), sampleinfo->seq.v);
     goto done_upd_deliv;
   }
   if (d == NULL)
   {
-    GVLOG (DDS_LC_DISCOVERY | DDS_LC_WARNING, "data(builtin, vendor %u.%u): "PGUIDFMT" #%"PRId64": deserialization failed\n",
+    GVLOG (DDS_LC_DISCOVERY | DDS_LC_WARNING, "data(builtin, vendor %u.%u): "PGUIDFMT" #%"PRIu64": deserialization failed\n",
            sampleinfo->rst->vendor.id[0], sampleinfo->rst->vendor.id[1],
-           PGUID (srcguid), sampleinfo->seq);
+           PGUID (srcguid), sampleinfo->seq.v);
     goto done_upd_deliv;
   }
 
@@ -2087,9 +2087,9 @@ int builtins_dqueue_handler (const struct nn_rsample_info *sampleinfo, const str
     if (gv->logconfig.c.mask & DDS_LC_CONTENT)
       res = ddsi_serdata_print (d, tmp, sizeof (tmp));
     if (pwr) guid = pwr->e.guid; else memset (&guid, 0, sizeof (guid));
-    GVTRACE ("data(builtin, vendor %u.%u): "PGUIDFMT" #%"PRId64": ST%x %s/%s:%s%s\n",
+    GVTRACE ("data(builtin, vendor %u.%u): "PGUIDFMT" #%"PRIu64": ST%x %s/%s:%s%s\n",
              sampleinfo->rst->vendor.id[0], sampleinfo->rst->vendor.id[1],
-             PGUID (guid), sampleinfo->seq, statusinfo,
+             PGUID (guid), sampleinfo->seq.v, statusinfo,
              pwr ? pwr->c.xqos->topic_name : "", d->type->type_name,
              tmp, res < sizeof (tmp) - 1 ? "" : "(trunc)");
   }
@@ -2130,9 +2130,9 @@ int builtins_dqueue_handler (const struct nn_rsample_info *sampleinfo, const str
       break;
 #endif
     default:
-      GVLOGDISC ("data(builtin, vendor %u.%u): "PGUIDFMT" #%"PRId64": not handled\n",
+      GVLOGDISC ("data(builtin, vendor %u.%u): "PGUIDFMT" #%"PRIu64": not handled\n",
                  sampleinfo->rst->vendor.id[0], sampleinfo->rst->vendor.id[1],
-                 PGUID (srcguid), sampleinfo->seq);
+                 PGUID (srcguid), sampleinfo->seq.v);
       break;
   }
 
@@ -2142,7 +2142,7 @@ int builtins_dqueue_handler (const struct nn_rsample_info *sampleinfo, const str
   if (pwr)
   {
     /* No proxy writer for SPDP */
-    ddsrt_atomic_st32 (&pwr->next_deliv_seq_lowword, (uint32_t) (sampleinfo->seq + 1));
+    ddsrt_atomic_st32 (&pwr->next_deliv_seq_lowword, (uint32_t) (sampleinfo->seq.v + 1));
   }
   return 0;
 }

--- a/src/core/ddsi/src/q_debmon.c
+++ b/src/core/ddsi/src/q_debmon.c
@@ -200,10 +200,10 @@ static int print_participants (struct thread_state1 * const ts1, struct ddsi_dom
         print_endpoint_common (conn, "wr", &w->e, &w->c, w->xqos);
         whc_get_state(w->whc, &whcst);
         x += cpf (conn, "    whc [%"PRIu64",%"PRIu64"] unacked %"PRIuSIZE"%s [%"PRIu32",%"PRIu32"] seq %"PRIu64" seq_xmit %"PRIu64" cs_seq %"PRIu64"\n",
-                  whcst.min_seq.v, whcst.max_seq.v, whcst.unacked_bytes,
+                  whcst.min_seq, whcst.max_seq, whcst.unacked_bytes,
                   w->throttling ? " THROTTLING" : "",
                   w->whc_low, w->whc_high,
-                  w->seq.v, writer_read_seq_xmit (w).v, w->cs_seq.v);
+                  w->seq, writer_read_seq_xmit (w), w->cs_seq);
         if (w->reliable)
         {
           x += cpf (conn, "    hb %"PRIu32" ackhb %"PRId64" hb %"PRId64" wr %"PRId64" sched %"PRId64" #rel %"PRId32"\n",
@@ -212,7 +212,7 @@ static int print_participants (struct thread_state1 * const ts1, struct ddsi_dom
                     w->hbcontrol.tsched.v, w->num_reliable_readers);
           x += cpf (conn, "    #acks %"PRIu32" #nacks %"PRIu32" #rexmit %"PRIu32" #lost %"PRIu32" #throttle %"PRIu32"\n",
                     w->num_acks_received, w->num_nacks_received, w->rexmit_count, w->rexmit_lost_count, w->throttle_count);
-          x += cpf (conn, "    max-drop-seq %"PRIu64"\n", writer_max_drop_seq (w).v);
+          x += cpf (conn, "    max-drop-seq %"PRIu64"\n", writer_max_drop_seq (w));
         }
         x += print_addrset_if_notempty (conn, "    as", w->as, "\n");
         for (m = ddsrt_avl_iter_first (&wr_readers_treedef, &w->readers, &rdit); m; m = ddsrt_avl_iter_next (&rdit))
@@ -223,7 +223,7 @@ static int print_participants (struct thread_state1 * const ts1, struct ddsi_dom
           wr_prd_flags[2] = m->has_replied_to_hb ? 'a' : '.'; /* a = ack seen */
           wr_prd_flags[3] = 0;
           x += cpf (conn, "    prd "PGUIDFMT" %s @ %"PRIu64" [%"PRIu64",%"PRIu64"] #nacks %"PRIu32"\n",
-                    PGUID (m->prd_guid), wr_prd_flags, m->seq.v, m->min_seq.v, m->max_seq.v, m->rexmit_requests);
+                    PGUID (m->prd_guid), wr_prd_flags, m->seq, m->min_seq, m->max_seq, m->rexmit_requests);
         }
         ddsrt_mutex_unlock (&w->e.lock);
       }
@@ -281,20 +281,20 @@ static int print_proxy_participants (struct thread_state1 * const ts1, struct dd
           continue;
         ddsrt_mutex_lock (&w->e.lock);
         print_proxy_endpoint_common (conn, "pwr", &w->e, &w->c);
-        x += cpf (conn, "    last_seq %"PRIu64" last_fragnum %"PRIu32"\n", w->last_seq.v, w->last_fragnum);
+        x += cpf (conn, "    last_seq %"PRIu64" last_fragnum %"PRIu32"\n", w->last_seq, w->last_fragnum);
         for (m = ddsrt_avl_iter_first (&wr_readers_treedef, &w->readers, &rdit); m; m = ddsrt_avl_iter_next (&rdit))
         {
           x += cpf (conn, "    rd "PGUIDFMT" (nack %"PRIu64" frag %"PRIu32" %"PRId64")\n",
-                    PGUID (m->rd_guid), m->last_nack.seq_end_p1.v, m->last_nack.frag_end_p1, m->t_last_nack.v);
+                    PGUID (m->rd_guid), m->last_nack.seq_end_p1, m->last_nack.frag_end_p1, m->t_last_nack.v);
           switch (m->in_sync)
           {
             case PRMSS_SYNC:
               break;
             case PRMSS_TLCATCHUP:
-              x += cpf (conn, "      tl-catchup end_of_tl_seq %"PRIu64"\n", m->u.not_in_sync.end_of_tl_seq.v);
+              x += cpf (conn, "      tl-catchup end_of_tl_seq %"PRIu64"\n", m->u.not_in_sync.end_of_tl_seq);
               break;
             case PRMSS_OUT_OF_SYNC:
-              x += cpf (conn, "      out-of-sync end_of_tl_seq %"PRIu64"\n", m->u.not_in_sync.end_of_tl_seq.v);
+              x += cpf (conn, "      out-of-sync end_of_tl_seq %"PRIu64"\n", m->u.not_in_sync.end_of_tl_seq);
               break;
           }
         }

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -2089,8 +2089,8 @@ static void proxy_writer_drop_connection (const struct ddsi_guid *pwr_guid, stru
       if (pwr->n_reliable_readers == 0 && isreliable && pwr->have_seen_heartbeat)
       {
         pwr->have_seen_heartbeat = 0;
-        nn_defrag_notegap (pwr->defrag, 1, pwr->last_seq + 1);
-        nn_reorder_drop_upto (pwr->reorder, pwr->last_seq + 1);
+        nn_defrag_notegap (pwr->defrag, (seqno_t){ 1 }, (seqno_t){ pwr->last_seq.v + 1 });
+        nn_reorder_drop_upto (pwr->reorder, (seqno_t){ pwr->last_seq.v + 1 });
       }
       local_reader_ary_remove (&pwr->rdary, rd);
     }
@@ -2178,7 +2178,7 @@ static void writer_add_connection (struct writer *wr, struct proxy_reader *prd, 
 #else
   if (pretend_everything_acked)
 #endif
-    m->seq = MAX_SEQ_NUMBER;
+    m->seq = (seqno_t){ MAX_SEQ_NUMBER };
   else
     m->seq = wr->seq;
   m->last_seq = m->seq;
@@ -2192,8 +2192,8 @@ static void writer_add_connection (struct writer *wr, struct proxy_reader *prd, 
   }
   else
   {
-    ELOGDISC (wr, "  writer_add_connection(wr "PGUIDFMT" prd "PGUIDFMT") - ack seq %"PRId64"\n",
-              PGUID (wr->e.guid), PGUID (prd->e.guid), m->seq);
+    ELOGDISC (wr, "  writer_add_connection(wr "PGUIDFMT" prd "PGUIDFMT") - ack seq %"PRIu64"\n",
+              PGUID (wr->e.guid), PGUID (prd->e.guid), m->seq.v);
     ddsrt_avl_insert_ipath (&wr_readers_treedef, &wr->readers, m, &path);
     wr->num_readers++;
     wr->num_reliable_readers += m->is_reliable;
@@ -2468,11 +2468,11 @@ static void proxy_writer_add_connection (struct proxy_writer *pwr, struct reader
   m->t_heartbeat_accepted.v = 0;
   m->t_last_nack.v = 0;
   m->t_last_ack.v = 0;
-  m->last_nack.seq_end_p1 = 0;
-  m->last_nack.seq_base = 0;
+  m->last_nack.seq_end_p1 = (seqno_t){ 0 };
+  m->last_nack.seq_base = (seqno_t){ 0 };
   m->last_nack.frag_end_p1 = 0;
   m->last_nack.frag_base = 0;
-  m->last_seq = 0;
+  m->last_seq = (seqno_t){ 0 };
   m->filtered = 0;
   m->ack_requested = 0;
   m->heartbeat_since_ack = 0;
@@ -2525,7 +2525,7 @@ static void proxy_writer_add_connection (struct proxy_writer *pwr, struct reader
       m->in_sync = PRMSS_OUT_OF_SYNC;
     else
       m->in_sync = PRMSS_SYNC;
-    m->u.not_in_sync.end_of_tl_seq = MAX_SEQ_NUMBER;
+    m->u.not_in_sync.end_of_tl_seq = (seqno_t){ MAX_SEQ_NUMBER };
   }
   else
   {
@@ -3478,22 +3478,22 @@ static void augment_wr_prd_match (void *vnode, const void *vleft, const void *vr
      reader that has not yet replied to a heartbeat as a demoted
      one */
   min_seq = n->seq;
-  max_seq = (n->seq < MAX_SEQ_NUMBER) ? n->seq : 0;
+  max_seq = (n->seq.v < MAX_SEQ_NUMBER) ? n->seq : (seqno_t){ 0 };
 
   /* 1. Compute {min,max} & have_replied. */
   if (left)
   {
-    if (left->min_seq < min_seq)
+    if (left->min_seq.v < min_seq.v)
       min_seq = left->min_seq;
-    if (left->max_seq > max_seq)
+    if (left->max_seq.v > max_seq.v)
       max_seq = left->max_seq;
     have_replied = have_replied && left->all_have_replied_to_hb;
   }
   if (right)
   {
-    if (right->min_seq < min_seq)
+    if (right->min_seq.v < min_seq.v)
       min_seq = right->min_seq;
-    if (right->max_seq > max_seq)
+    if (right->max_seq.v > max_seq.v)
       max_seq = right->max_seq;
     have_replied = have_replied && right->all_have_replied_to_hb;
   }
@@ -3502,7 +3502,7 @@ static void augment_wr_prd_match (void *vnode, const void *vleft, const void *vr
   n->all_have_replied_to_hb = have_replied ? 1 : 0;
 
   /* 2. Compute num_reliable_readers_where_seq_equals_max */
-  if (max_seq == 0)
+  if (max_seq.v == 0)
   {
     /* excludes demoted & best-effort readers; note that max == 0
        cannot happen if {left,right}.max > 0 */
@@ -3512,23 +3512,23 @@ static void augment_wr_prd_match (void *vnode, const void *vleft, const void *vr
   {
     /* if demoted or best-effort, seq != max */
     n->num_reliable_readers_where_seq_equals_max =
-      (n->seq == max_seq && n->has_replied_to_hb);
-    if (left && left->max_seq == max_seq)
+      (n->seq.v == max_seq.v && n->has_replied_to_hb);
+    if (left && left->max_seq.v == max_seq.v)
       n->num_reliable_readers_where_seq_equals_max +=
         left->num_reliable_readers_where_seq_equals_max;
-    if (right && right->max_seq == max_seq)
+    if (right && right->max_seq.v == max_seq.v)
       n->num_reliable_readers_where_seq_equals_max +=
         right->num_reliable_readers_where_seq_equals_max;
   }
 
   /* 3. Compute arbitrary unacked reader */
   /* 3a: maybe this reader is itself a candidate */
-  if (n->seq < max_seq)
+  if (n->seq.v < max_seq.v)
   {
     /* seq < max cannot be true for a best-effort reader or a demoted */
     n->arbitrary_unacked_reader = n->prd_guid;
   }
-  else if (n->is_reliable && (n->seq == MAX_SEQ_NUMBER || n->seq == 0 || !n->has_replied_to_hb))
+  else if (n->is_reliable && (n->seq.v == MAX_SEQ_NUMBER || n->seq.v == 0 || !n->has_replied_to_hb))
   {
     /* demoted readers and reliable readers that have not yet replied to a heartbeat are candidates */
     n->arbitrary_unacked_reader = n->prd_guid;
@@ -3544,11 +3544,11 @@ static void augment_wr_prd_match (void *vnode, const void *vleft, const void *vr
   }
   /* 3c: else it may be that we can now determine one of our children
      is actually a candidate */
-  else if (left && left->max_seq != 0 && left->max_seq < max_seq)
+  else if (left && left->max_seq.v != 0 && left->max_seq.v < max_seq.v)
   {
     n->arbitrary_unacked_reader = left->prd_guid;
   }
-  else if (right && right->max_seq != 0 && right->max_seq < max_seq)
+  else if (right && right->max_seq.v != 0 && right->max_seq.v < max_seq.v)
   {
     n->arbitrary_unacked_reader = right->prd_guid;
   }
@@ -3565,7 +3565,7 @@ seqno_t writer_max_drop_seq (const struct writer *wr)
   if (ddsrt_avl_is_empty (&wr->readers))
     return wr->seq;
   n = ddsrt_avl_root_non_empty (&wr_readers_treedef, &wr->readers);
-  return (n->min_seq == MAX_SEQ_NUMBER) ? wr->seq : n->min_seq;
+  return (n->min_seq.v == MAX_SEQ_NUMBER) ? wr->seq : n->min_seq;
 }
 
 int writer_must_have_hb_scheduled (const struct writer *wr, const struct whc_state *whcst)
@@ -3594,7 +3594,7 @@ int writer_must_have_hb_scheduled (const struct writer *wr, const struct whc_sta
        requiring a non-empty whc_seq: if it is transient_local,
        whc_seq usually won't be empty even when all msgs have been
        ack'd. */
-    return writer_max_drop_seq (wr) < whcst->max_seq;
+    return writer_max_drop_seq (wr).v < whcst->max_seq.v;
   }
 }
 
@@ -3724,8 +3724,8 @@ int writer_set_notalive (struct writer *wr, bool notify)
 static void new_writer_guid_common_init (struct writer *wr, const char *topic_name, const struct ddsi_sertype *type, const struct dds_qos *xqos, struct whc *whc, status_cb_t status_cb, void * status_entity)
 {
   ddsrt_cond_init (&wr->throttle_cond);
-  wr->seq = 0;
-  wr->cs_seq = 0;
+  wr->seq = (seqno_t){ 0 };
+  wr->cs_seq = (seqno_t){ 0 };
   ddsrt_atomic_st64 (&wr->seq_xmit, (uint64_t) 0);
   wr->hbcount = 1;
   wr->state = WRST_OPERATIONAL;
@@ -4171,21 +4171,21 @@ dds_return_t writer_wait_for_acks (struct writer *wr, const ddsi_guid_t *rdguid,
   ref_seq = wr->seq;
   if (rdguid == NULL)
   {
-    while (wr->state == WRST_OPERATIONAL && ref_seq > writer_max_drop_seq (wr))
+    while (wr->state == WRST_OPERATIONAL && ref_seq.v > writer_max_drop_seq (wr).v)
       if (!ddsrt_cond_waituntil (&wr->throttle_cond, &wr->e.lock, abstimeout))
         break;
-    rc = (ref_seq <= writer_max_drop_seq (wr)) ? DDS_RETCODE_OK : DDS_RETCODE_TIMEOUT;
+    rc = (ref_seq.v <= writer_max_drop_seq (wr).v) ? DDS_RETCODE_OK : DDS_RETCODE_TIMEOUT;
   }
   else
   {
     struct wr_prd_match *m = ddsrt_avl_lookup (&wr_readers_treedef, &wr->readers, rdguid);
-    while (wr->state == WRST_OPERATIONAL && m && ref_seq > m->seq)
+    while (wr->state == WRST_OPERATIONAL && m && ref_seq.v > m->seq.v)
     {
       if (!ddsrt_cond_waituntil (&wr->throttle_cond, &wr->e.lock, abstimeout))
         break;
       m = ddsrt_avl_lookup (&wr_readers_treedef, &wr->readers, rdguid);
     }
-    rc = (m == NULL || ref_seq <= m->seq) ? DDS_RETCODE_OK : DDS_RETCODE_TIMEOUT;
+    rc = (m == NULL || ref_seq.v <= m->seq.v) ? DDS_RETCODE_OK : DDS_RETCODE_TIMEOUT;
   }
   ddsrt_mutex_unlock (&wr->e.lock);
   return rc;
@@ -4865,14 +4865,14 @@ static void create_proxy_builtin_endpoint_impl (struct ddsi_domaingv *gv, ddsrt_
   plist->qos.topic_name = dds_string_dup (topic_name);
   plist->qos.present |= QP_TOPIC_NAME;
   if (is_writer_entityid (ep_guid->entityid))
-    new_proxy_writer (gv, ppguid, ep_guid, proxypp->as_meta, plist, gv->builtins_dqueue, gv->xevents, timestamp, 0);
+    new_proxy_writer (gv, ppguid, ep_guid, proxypp->as_meta, plist, gv->builtins_dqueue, gv->xevents, timestamp, (seqno_t){ 0 });
   else
   {
 #ifdef DDS_HAS_SSM
     const int ssm = addrset_contains_ssm (gv, proxypp->as_meta);
-    new_proxy_reader (gv, ppguid, ep_guid, proxypp->as_meta, plist, timestamp, 0, ssm);
+    new_proxy_reader (gv, ppguid, ep_guid, proxypp->as_meta, plist, timestamp, (seqno_t){ 0 }, ssm);
 #else
-    new_proxy_reader (gv, ppguid, ep_guid, proxypp->as_meta, plist, timestamp, 0);
+    new_proxy_reader (gv, ppguid, ep_guid, proxypp->as_meta, plist, timestamp, (seqno_t){ 0 });
 #endif
   }
 }
@@ -5344,7 +5344,7 @@ bool new_proxy_participant (struct ddsi_domaingv *gv, const struct ddsi_guid *pp
 
 int update_proxy_participant_plist_locked (struct proxy_participant *proxypp, seqno_t seq, const struct ddsi_plist *datap, ddsrt_wctime_t timestamp)
 {
-  if (seq > proxypp->seq)
+  if (seq.v > proxypp->seq.v)
   {
     proxypp->seq = seq;
 
@@ -5897,7 +5897,7 @@ void update_proxy_topic (struct proxy_participant *proxypp, struct proxy_topic *
     ddsrt_mutex_unlock (&proxypp->e.lock);
     return;
   }
-  if (seq <= proxytp->seq)
+  if (seq.v <= proxytp->seq.v)
   {
     GVLOGDISC (" seqno not new\n");
     ddsrt_mutex_unlock (&proxypp->e.lock);
@@ -6118,7 +6118,7 @@ int new_proxy_writer (struct ddsi_domaingv *gv, const struct ddsi_guid *ppguid, 
   ddsrt_avl_init (&pwr_readers_treedef, &pwr->readers);
   pwr->n_reliable_readers = 0;
   pwr->n_readers_out_of_sync = 0;
-  pwr->last_seq = 0;
+  pwr->last_seq = (seqno_t){ 0 };
   pwr->last_fragnum = UINT32_MAX;
   pwr->nackfragcount = 1;
   pwr->alive = 1;
@@ -6193,7 +6193,7 @@ int new_proxy_writer (struct ddsi_domaingv *gv, const struct ddsi_guid *ppguid, 
      * reader is always considered out of sync the reorder administration of the corresponding reader will be used
      * instead.
      */
-    nn_reorder_set_next_seq(pwr->reorder, MAX_SEQ_NUMBER);
+    nn_reorder_set_next_seq(pwr->reorder, (seqno_t){ MAX_SEQ_NUMBER });
     pwr->filtered = 1;
   }
 
@@ -6228,7 +6228,7 @@ void update_proxy_writer (struct proxy_writer *pwr, seqno_t seq, struct addrset 
   /* Update proxy writer endpoints (from SEDP alive) */
 
   ddsrt_mutex_lock (&pwr->e.lock);
-  if (seq > pwr->c.seq)
+  if (seq.v > pwr->c.seq.v)
   {
     pwr->c.seq = seq;
     if (! addrset_eq_onesidederr (pwr->c.as, as))
@@ -6264,7 +6264,7 @@ void update_proxy_reader (struct proxy_reader *prd, seqno_t seq, struct addrset 
   memset (&wrguid, 0, sizeof (wrguid));
 
   ddsrt_mutex_lock (&prd->e.lock);
-  if (seq > prd->c.seq)
+  if (seq.v > prd->c.seq.v)
   {
     prd->c.seq = seq;
     if (! addrset_eq_onesidederr (prd->c.as, as))
@@ -6565,7 +6565,7 @@ static void proxy_reader_set_delete_and_ack_all_messages (struct proxy_reader *p
       if ((m_wr = ddsrt_avl_lookup (&wr_readers_treedef, &wr->readers, &prd->e.guid)) != NULL)
       {
         struct whc_state whcst;
-        m_wr->seq = MAX_SEQ_NUMBER;
+        m_wr->seq = (seqno_t){ MAX_SEQ_NUMBER };
         ddsrt_avl_augment_update (&wr_readers_treedef, m_wr);
         (void)remove_acked_messages (wr, &whcst, &deferred_free_list);
         writer_clear_retransmitting (wr);

--- a/src/core/ddsi/src/q_misc.c
+++ b/src/core/ddsi/src/q_misc.c
@@ -19,6 +19,7 @@
 #include "dds/ddsi/q_misc.h"
 
 DDS_EXPORT extern inline seqno_t fromSN (const nn_sequence_number_t sn);
+DDS_EXPORT extern inline bool validating_fromSN (const nn_sequence_number_t sn, seqno_t *res);
 DDS_EXPORT extern inline nn_sequence_number_t toSN (seqno_t n);
 
 #ifdef DDS_HAS_NETWORK_PARTITIONS

--- a/src/core/ddsi/src/q_radmin.c
+++ b/src/core/ddsi/src/q_radmin.c
@@ -885,7 +885,7 @@ static int compare_seqno (const void *va, const void *vb)
 {
   seqno_t a = *((const seqno_t *) va);
   seqno_t b = *((const seqno_t *) vb);
-  return (a.v == b.v) ? 0 : (a.v < b.v) ? -1 : 1;
+  return (a == b) ? 0 : (a < b) ? -1 : 1;
 }
 
 struct nn_defrag *nn_defrag_new (const struct ddsrt_log_cfg *logcfg, enum nn_defrag_drop_mode drop_mode, uint32_t max_samples)
@@ -955,7 +955,7 @@ void nn_defrag_free (struct nn_defrag *defrag)
   s = ddsrt_avl_find_min (&defrag_sampletree_treedef, &defrag->sampletree);
   while (s)
   {
-    TRACE (defrag, "defrag_free(%p, sample %p seq %"PRIu64")\n", (void *) defrag, (void *) s, s->u.defrag.seq.v);
+    TRACE (defrag, "defrag_free(%p, sample %p seq %"PRIu64")\n", (void *) defrag, (void *) s, s->u.defrag.seq);
     defrag_rsample_drop (defrag, s);
     s = ddsrt_avl_find_min (&defrag_sampletree_treedef, &defrag->sampletree);
   }
@@ -1107,7 +1107,7 @@ static struct nn_rsample *reorder_rsample_new (struct nn_rdata *rdata, const str
 
   s = &rsample->u.reorder;
   s->min = sampleinfo->seq;
-  s->maxp1 = (seqno_t){ sampleinfo->seq.v + 1 };
+  s->maxp1 = sampleinfo->seq + 1;
   s->n_samples = 1;
   s->sc.first = s->sc.last = sce;
   return rsample;
@@ -1160,7 +1160,7 @@ static void rsample_convert_defrag_to_reorder (struct nn_rsample *sample)
 
   sample->u.reorder.sc.first = sample->u.reorder.sc.last = sce;
   sample->u.reorder.min = seq;
-  sample->u.reorder.maxp1 = (seqno_t){ seq.v + 1 };
+  sample->u.reorder.maxp1 = seq + 1;
   sample->u.reorder.n_samples = 1;
 }
 
@@ -1176,7 +1176,7 @@ static struct nn_rsample *defrag_add_fragment (struct nn_defrag *defrag, struct 
   assert (min < maxp1);
   /* and it must concern this message */
   assert (dfsample);
-  assert (dfsample->seq.v == sampleinfo->seq.v);
+  assert (dfsample->seq == sampleinfo->seq);
   /* there must be a last fragment */
   assert (dfsample->lastfrag);
   /* relatively expensive test: lastfrag, tree must be consistent */
@@ -1297,7 +1297,7 @@ static int defrag_limit_samples (struct nn_defrag *defrag, seqno_t seq, seqno_t 
   {
     case NN_DEFRAG_DROP_LATEST:
       TRACE (defrag, "  drop mode = DROP_LATEST\n");
-      if (seq.v > defrag->max_sample->u.defrag.seq.v)
+      if (seq > defrag->max_sample->u.defrag.seq)
       {
         TRACE (defrag, "  new sample is new latest => discarding it\n");
         return 0;
@@ -1308,7 +1308,7 @@ static int defrag_limit_samples (struct nn_defrag *defrag, seqno_t seq, seqno_t 
       TRACE (defrag, "  drop mode = DROP_OLDEST\n");
       sample_to_drop = ddsrt_avl_find_min (&defrag_sampletree_treedef, &defrag->sampletree);
       assert (sample_to_drop);
-      if (seq.v < sample_to_drop->u.defrag.seq.v)
+      if (seq < sample_to_drop->u.defrag.seq)
       {
         TRACE (defrag, "  new sample is new oldest => discarding it\n");
         return 0;
@@ -1320,9 +1320,9 @@ static int defrag_limit_samples (struct nn_defrag *defrag, seqno_t seq, seqno_t 
   if (sample_to_drop == defrag->max_sample)
   {
     defrag->max_sample = ddsrt_avl_find_max (&defrag_sampletree_treedef, &defrag->sampletree);
-    *max_seq = defrag->max_sample ? defrag->max_sample->u.defrag.seq : (seqno_t){ 0 };
+    *max_seq = defrag->max_sample ? defrag->max_sample->u.defrag.seq : 0;
     TRACE (defrag, "  updating max_sample: now %p %"PRIu64"\n",
-           (void *) defrag->max_sample, defrag->max_sample ? defrag->max_sample->u.defrag.seq.v : 0);
+           (void *) defrag->max_sample, defrag->max_sample ? defrag->max_sample->u.defrag.seq : 0);
   }
   return 1;
 }
@@ -1366,14 +1366,14 @@ struct nn_rsample *nn_defrag_rsample (struct nn_defrag *defrag, struct nn_rdata 
      last message in 'defrag'. max_seq and max_sample must be
      consistent. Max_sample must be consistent with tree */
   assert (defrag->max_sample == ddsrt_avl_find_max (&defrag_sampletree_treedef, &defrag->sampletree));
-  max_seq = defrag->max_sample ? defrag->max_sample->u.defrag.seq : (seqno_t){ 0 };
+  max_seq = defrag->max_sample ? defrag->max_sample->u.defrag.seq : 0;
   TRACE (defrag, "defrag_rsample(%p, %p [%"PRIu32"..%"PRIu32") msg %p, %p seq %"PRIu64" size %"PRIu32") max_seq %p %"PRIu64":\n",
          (void *) defrag, (void *) rdata, rdata->min, rdata->maxp1, (void *) rdata->rmsg,
-         (void *) sampleinfo, sampleinfo->seq.v, sampleinfo->size,
-         (void *) defrag->max_sample, max_seq.v);
+         (void *) sampleinfo, sampleinfo->seq, sampleinfo->size,
+         (void *) defrag->max_sample, max_seq);
   /* fast path: rdata is part of message with the highest sequence
      number we're currently defragmenting, or is beyond that */
-  if (sampleinfo->seq.v == max_seq.v)
+  if (sampleinfo->seq == max_seq)
   {
     TRACE (defrag, "  add fragment to max_sample\n");
     result = defrag_add_fragment (defrag, defrag->max_sample, rdata, sampleinfo);
@@ -1383,7 +1383,7 @@ struct nn_rsample *nn_defrag_rsample (struct nn_defrag *defrag, struct nn_rdata 
     TRACE (defrag, "  discarding sample\n");
     result = NULL;
   }
-  else if (sampleinfo->seq.v > max_seq.v)
+  else if (sampleinfo->seq > max_seq)
   {
     /* a node with a key greater than the maximum always is the right
        child of the old maximum node */
@@ -1401,7 +1401,7 @@ struct nn_rsample *nn_defrag_rsample (struct nn_defrag *defrag, struct nn_rdata 
   {
     /* a new sequence number, but smaller than the maximum */
     TRACE (defrag, "  new sample less than max\n");
-    assert (sampleinfo->seq.v < max_seq.v);
+    assert (sampleinfo->seq < max_seq);
     if ((sample = defrag_rsample_new (rdata, sampleinfo)) == NULL)
       return NULL;
     ddsrt_avl_insert_ipath (&defrag_sampletree_treedef, &defrag->sampletree, sample, &path);
@@ -1428,7 +1428,7 @@ struct nn_rsample *nn_defrag_rsample (struct nn_defrag *defrag, struct nn_rdata 
     {
       defrag->max_sample = ddsrt_avl_find_max (&defrag_sampletree_treedef, &defrag->sampletree);
       TRACE (defrag, "  updating max_sample: now %p %"PRIu64"\n",
-             (void *) defrag->max_sample, defrag->max_sample ? defrag->max_sample->u.defrag.seq.v : 0);
+             (void *) defrag->max_sample, defrag->max_sample ? defrag->max_sample->u.defrag.seq : 0);
     }
     rsample_convert_defrag_to_reorder (result);
   }
@@ -1443,7 +1443,7 @@ void nn_defrag_notegap (struct nn_defrag *defrag, seqno_t min, seqno_t maxp1)
      fragments in that range must be discarded.  Used both for
      Hearbeats (by setting min=1) and for Gaps. */
   struct nn_rsample *s = ddsrt_avl_lookup_succ_eq (&defrag_sampletree_treedef, &defrag->sampletree, &min);
-  while (s && s->u.defrag.seq.v < maxp1.v)
+  while (s && s->u.defrag.seq < maxp1)
   {
     struct nn_rsample *s1 = ddsrt_avl_find_succ (&defrag_sampletree_treedef, &defrag->sampletree, s);
     defrag_rsample_drop (defrag, s);
@@ -1679,7 +1679,7 @@ struct nn_reorder *nn_reorder_new (const struct ddsrt_log_cfg *logcfg, enum nn_r
     return NULL;
   ddsrt_avl_init (&reorder_sampleivtree_treedef, &r->sampleivtree);
   r->max_sampleiv = NULL;
-  r->next_seq = (seqno_t){ 1 };
+  r->next_seq = 1;
   r->mode = mode;
   r->max_samples = max_samples;
   r->n_samples = 0;
@@ -1738,11 +1738,11 @@ static void reorder_add_rsampleiv (struct nn_reorder *reorder, struct nn_rsample
 #ifndef NDEBUG
 static int rsample_is_singleton (const struct nn_rsample_reorder *s)
 {
-  assert (s->min.v < s->maxp1.v);
+  assert (s->min < s->maxp1);
   if (s->n_samples != 1)
     return 0;
-  assert (s->min.v + 1 == s->maxp1.v);
-  assert (s->min.v + s->n_samples <= s->maxp1.v);
+  assert (s->min + 1 == s->maxp1);
+  assert (s->min + s->n_samples <= s->maxp1);
   assert (s->sc.first != NULL);
   assert (s->sc.first == s->sc.last);
   assert (s->sc.first->next == NULL);
@@ -1765,21 +1765,21 @@ static int reorder_try_append_and_discard (struct nn_reorder *reorder, struct nn
     TRACE (reorder, "  try_append_and_discard: fail: todiscard = NULL\n");
     return 0;
   }
-  else if (appendto->u.reorder.maxp1.v < todiscard->u.reorder.min.v)
+  else if (appendto->u.reorder.maxp1 < todiscard->u.reorder.min)
   {
     TRACE (reorder, "  try_append_and_discard: fail: appendto = [%"PRIu64",%"PRIu64") @ %p, "
            "todiscard = [%"PRIu64",%"PRIu64") @ %p - gap\n",
-           appendto->u.reorder.min.v, appendto->u.reorder.maxp1.v, (void *) appendto,
-           todiscard->u.reorder.min.v, todiscard->u.reorder.maxp1.v, (void *) todiscard);
+           appendto->u.reorder.min, appendto->u.reorder.maxp1, (void *) appendto,
+           todiscard->u.reorder.min, todiscard->u.reorder.maxp1, (void *) todiscard);
     return 0;
   }
   else
   {
     TRACE (reorder, "  try_append_and_discard: success: appendto = [%"PRIu64",%"PRIu64") @ %p, "
            "todiscard = [%"PRIu64",%"PRIu64") @ %p\n",
-           appendto->u.reorder.min.v, appendto->u.reorder.maxp1.v, (void *) appendto,
-           todiscard->u.reorder.min.v, todiscard->u.reorder.maxp1.v, (void *) todiscard);
-    assert (todiscard->u.reorder.min.v == appendto->u.reorder.maxp1.v);
+           appendto->u.reorder.min, appendto->u.reorder.maxp1, (void *) appendto,
+           todiscard->u.reorder.min, todiscard->u.reorder.maxp1, (void *) todiscard);
+    assert (todiscard->u.reorder.min == appendto->u.reorder.maxp1);
     ddsrt_avl_delete (&reorder_sampleivtree_treedef, &reorder->sampleivtree, todiscard);
     append_rsample_interval (appendto, todiscard);
     TRACE (reorder, "  try_append_and_discard: max_sampleiv needs update? %s\n",
@@ -1821,7 +1821,7 @@ struct nn_rsample *nn_reorder_rsample_dup_first (struct nn_rmsg *rmsg, struct nn
   sce->next = NULL;
   sce->sampleinfo = rsampleiv->u.reorder.sc.first->sampleinfo;
   rsampleiv_new->u.reorder.min = rsampleiv->u.reorder.min;
-  rsampleiv_new->u.reorder.maxp1 = (seqno_t){ rsampleiv_new->u.reorder.min.v + 1 };
+  rsampleiv_new->u.reorder.maxp1 = rsampleiv_new->u.reorder.min + 1;
   rsampleiv_new->u.reorder.n_samples = 1;
   rsampleiv_new->u.reorder.sc.first = rsampleiv_new->u.reorder.sc.last = sce;
   return rsampleiv_new;
@@ -1876,9 +1876,9 @@ static void delete_last_sample (struct nn_reorder *reorder)
        large!).  Can't be a singleton list, so might as well chop off
        one evaluation of the loop condition. */
     struct nn_rsample_chain_elem *e, *pe;
-    TRACE (reorder, "  delete_last_sample: scanning last interval [%"PRIu64"..%"PRIu64")\n", last->min.v, last->maxp1.v);
+    TRACE (reorder, "  delete_last_sample: scanning last interval [%"PRIu64"..%"PRIu64")\n", last->min, last->maxp1);
     assert (last->n_samples >= 1);
-    assert (last->min.v + last->n_samples <= last->maxp1.v);
+    assert (last->min + last->n_samples <= last->maxp1);
     e = last->sc.first;
     do {
       pe = e;
@@ -1887,9 +1887,9 @@ static void delete_last_sample (struct nn_reorder *reorder)
     reorder->discarded_bytes += e->sampleinfo->size;
     fragchain = e->fragchain;
     pe->next = NULL;
-    assert (pe->sampleinfo->seq.v + 1 < last->maxp1.v);
+    assert (pe->sampleinfo->seq + 1 < last->maxp1);
     last->sc.last = pe;
-    last->maxp1.v--;
+    last->maxp1--;
     last->n_samples--;
   }
 
@@ -1908,8 +1908,8 @@ nn_reorder_result_t nn_reorder_rsample (struct nn_rsample_chain *sc, struct nn_r
   struct nn_rsample_reorder *s = &rsampleiv->u.reorder;
 
   TRACE (reorder, "reorder_sample(%p %c, %"PRIu64" @ %p) expecting %"PRIu64":\n",
-         (void *) reorder, reorder_mode_as_char (reorder), rsampleiv->u.reorder.min.v,
-         (void *) rsampleiv, reorder->next_seq.v);
+         (void *) reorder, reorder_mode_as_char (reorder), rsampleiv->u.reorder.min,
+         (void *) rsampleiv, reorder->next_seq);
 
   /* Incoming rsample must be a singleton */
   assert (rsample_is_singleton (s));
@@ -1920,8 +1920,8 @@ nn_reorder_result_t nn_reorder_rsample (struct nn_rsample_chain *sc, struct nn_r
   {
     struct nn_rsample *min = ddsrt_avl_find_min (&reorder_sampleivtree_treedef, &reorder->sampleivtree);
     if (min)
-      TRACE (reorder, "  min = %"PRIu64" @ %p\n", min->u.reorder.min.v, (void *) min);
-    assert (min == NULL || reorder->next_seq.v < min->u.reorder.min.v);
+      TRACE (reorder, "  min = %"PRIu64" @ %p\n", min->u.reorder.min, (void *) min);
+    assert (min == NULL || reorder->next_seq < min->u.reorder.min);
     assert ((reorder->max_sampleiv == NULL && min == NULL) ||
             (reorder->max_sampleiv != NULL && min != NULL));
   }
@@ -1930,11 +1930,11 @@ nn_reorder_result_t nn_reorder_rsample (struct nn_rsample_chain *sc, struct nn_r
   assert (reorder->max_sampleiv == NULL || reorder->max_sampleiv == ddsrt_avl_find_max (&reorder_sampleivtree_treedef, &reorder->sampleivtree));
   assert (reorder->n_samples <= reorder->max_samples);
   if (reorder->max_sampleiv)
-    TRACE (reorder, "  max = [%"PRIu64",%"PRIu64") @ %p\n", reorder->max_sampleiv->u.reorder.min.v,
-           reorder->max_sampleiv->u.reorder.maxp1.v, (void *) reorder->max_sampleiv);
+    TRACE (reorder, "  max = [%"PRIu64",%"PRIu64") @ %p\n", reorder->max_sampleiv->u.reorder.min,
+           reorder->max_sampleiv->u.reorder.maxp1, (void *) reorder->max_sampleiv);
 
-  if (s->min.v == reorder->next_seq.v ||
-      (s->min.v > reorder->next_seq.v && reorder->mode == NN_REORDER_MODE_MONOTONICALLY_INCREASING) ||
+  if (s->min == reorder->next_seq ||
+      (s->min > reorder->next_seq && reorder->mode == NN_REORDER_MODE_MONOTONICALLY_INCREASING) ||
       reorder->mode == NN_REORDER_MODE_ALWAYS_DELIVER)
   {
     /* Can deliver at least one sample, but that appends samples to
@@ -1964,17 +1964,17 @@ nn_reorder_result_t nn_reorder_rsample (struct nn_rsample_chain *sc, struct nn_r
     reorder->next_seq = s->maxp1;
     *sc = rsampleiv->u.reorder.sc;
     (*refcount_adjust)++;
-    TRACE (reorder, "  return [%"PRIu64",%"PRIu64")\n", s->min.v, s->maxp1.v);
+    TRACE (reorder, "  return [%"PRIu64",%"PRIu64")\n", s->min, s->maxp1);
 
     /* Adjust reorder->n_samples, new sample is not counted yet */
-    assert (s->maxp1.v - s->min.v >= 1);
-    assert (s->maxp1.v - s->min.v <= (int) INT32_MAX);
-    assert (s->min.v + s->n_samples <= s->maxp1.v);
+    assert (s->maxp1 - s->min >= 1);
+    assert (s->maxp1 - s->min <= (int) INT32_MAX);
+    assert (s->min + s->n_samples <= s->maxp1);
     assert (reorder->n_samples >= s->n_samples - 1);
     reorder->n_samples -= s->n_samples - 1;
     return (nn_reorder_result_t) s->n_samples;
   }
-  else if (s->min.v < reorder->next_seq.v)
+  else if (s->min < reorder->next_seq)
   {
     /* we've moved beyond this one: discard it; no need to adjust
        n_samples */
@@ -2002,7 +2002,7 @@ nn_reorder_result_t nn_reorder_rsample (struct nn_rsample_chain *sc, struct nn_r
       reorder->n_samples++;
     }
   }
-  else if (((void) assert (reorder->max_sampleiv != NULL)), (s->min.v == reorder->max_sampleiv->u.reorder.maxp1.v))
+  else if (((void) assert (reorder->max_sampleiv != NULL)), (s->min == reorder->max_sampleiv->u.reorder.maxp1))
   {
     /* (sampleivtree not empty) <=> (max_sampleiv is non-NULL), for which there is an assert at the beginning but compilers and static analyzers don't all quite get that ... the somewhat crazy assert shuts up Clang's static analyzer */
     if (delivery_queue_full_p)
@@ -2027,7 +2027,7 @@ nn_reorder_result_t nn_reorder_rsample (struct nn_rsample_chain *sc, struct nn_r
       return NN_REORDER_REJECT;
     }
   }
-  else if (s->min.v > reorder->max_sampleiv->u.reorder.maxp1.v)
+  else if (s->min > reorder->max_sampleiv->u.reorder.maxp1)
   {
     if (delivery_queue_full_p)
     {
@@ -2072,10 +2072,10 @@ nn_reorder_result_t nn_reorder_rsample (struct nn_rsample_chain *sc, struct nn_r
     predeq = ddsrt_avl_lookup_pred_eq (&reorder_sampleivtree_treedef, &reorder->sampleivtree, &s->min);
     if (predeq)
       TRACE (reorder, "  predeq = [%"PRIu64",%"PRIu64") @ %p\n",
-             predeq->u.reorder.min.v, predeq->u.reorder.maxp1.v, (void *) predeq);
+             predeq->u.reorder.min, predeq->u.reorder.maxp1, (void *) predeq);
     else
       TRACE (reorder, "  predeq = null\n");
-    if (predeq && s->min.v >= predeq->u.reorder.min.v && s->min.v < predeq->u.reorder.maxp1.v)
+    if (predeq && s->min >= predeq->u.reorder.min && s->min < predeq->u.reorder.maxp1)
     {
       /* contained in predeq */
       TRACE (reorder, "  discard: contained in predeq\n");
@@ -2086,10 +2086,10 @@ nn_reorder_result_t nn_reorder_rsample (struct nn_rsample_chain *sc, struct nn_r
     immsucc = ddsrt_avl_lookup (&reorder_sampleivtree_treedef, &reorder->sampleivtree, &s->maxp1);
     if (immsucc)
       TRACE (reorder, "  immsucc = [%"PRIu64",%"PRIu64") @ %p\n",
-             immsucc->u.reorder.min.v, immsucc->u.reorder.maxp1.v, (void *) immsucc);
+             immsucc->u.reorder.min, immsucc->u.reorder.maxp1, (void *) immsucc);
     else
       TRACE (reorder, "  immsucc = null\n");
-    if (predeq && s->min.v == predeq->u.reorder.maxp1.v)
+    if (predeq && s->min == predeq->u.reorder.maxp1)
     {
       /* grow predeq at end, and maybe append immsucc as well */
       TRACE (reorder, "  growing predeq at end ...\n");
@@ -2154,12 +2154,12 @@ static struct nn_rsample *coalesce_intervals_touching_range (struct nn_reorder *
   *valuable = 0;
   /* Find first (lowest m) interval [m,n) s.t. n >= min && m <= maxp1 */
   s = ddsrt_avl_lookup_pred_eq (&reorder_sampleivtree_treedef, &reorder->sampleivtree, &min);
-  if (s && s->u.reorder.maxp1.v >= min.v)
+  if (s && s->u.reorder.maxp1 >= min)
   {
     /* m <= min && n >= min (note: pred of s [m',n') necessarily has n' < m) */
 #ifndef NDEBUG
     struct nn_rsample *q = ddsrt_avl_find_pred (&reorder_sampleivtree_treedef, &reorder->sampleivtree, s);
-    assert (q == NULL || q->u.reorder.maxp1.v < min.v);
+    assert (q == NULL || q->u.reorder.maxp1 < min);
 #endif
   }
   else
@@ -2168,25 +2168,25 @@ static struct nn_rsample *coalesce_intervals_touching_range (struct nn_reorder *
        NULL) may still have m <= maxp1 (m > min is implied now).  If
        not, no such interval.  */
     s = ddsrt_avl_find_succ (&reorder_sampleivtree_treedef, &reorder->sampleivtree, s);
-    if (!(s && s->u.reorder.min.v <= maxp1.v))
+    if (!(s && s->u.reorder.min <= maxp1))
       return NULL;
   }
   /* Append successors [m',n') s.t. m' <= maxp1 to s */
-  assert (s->u.reorder.min.v + s->u.reorder.n_samples <= s->u.reorder.maxp1.v);
-  while ((t = ddsrt_avl_find_succ (&reorder_sampleivtree_treedef, &reorder->sampleivtree, s)) != NULL && t->u.reorder.min.v <= maxp1.v)
+  assert (s->u.reorder.min + s->u.reorder.n_samples <= s->u.reorder.maxp1);
+  while ((t = ddsrt_avl_find_succ (&reorder_sampleivtree_treedef, &reorder->sampleivtree, s)) != NULL && t->u.reorder.min <= maxp1)
   {
     ddsrt_avl_delete (&reorder_sampleivtree_treedef, &reorder->sampleivtree, t);
-    assert (t->u.reorder.min.v + t->u.reorder.n_samples <= t->u.reorder.maxp1.v);
+    assert (t->u.reorder.min + t->u.reorder.n_samples <= t->u.reorder.maxp1);
     append_rsample_interval (s, t);
     *valuable = 1;
   }
   /* If needed, grow range to [min,maxp1) */
-  if (min.v < s->u.reorder.min.v)
+  if (min < s->u.reorder.min)
   {
     *valuable = 1;
     s->u.reorder.min = min;
   }
-  if (maxp1.v > s->u.reorder.maxp1.v)
+  if (maxp1 > s->u.reorder.maxp1)
   {
     *valuable = 1;
     s->u.reorder.maxp1 = maxp1;
@@ -2257,9 +2257,9 @@ nn_reorder_result_t nn_reorder_gap (struct nn_rsample_chain *sc, struct nn_reord
 
   TRACE (reorder, "reorder_gap(%p %c, [%"PRIu64",%"PRIu64") data %p) expecting %"PRIu64":\n",
          (void *) reorder, reorder_mode_as_char (reorder),
-         min.v, maxp1.v, (void *) rdata, reorder->next_seq.v);
+         min, maxp1, (void *) rdata, reorder->next_seq);
 
-  if (maxp1.v <= reorder->next_seq.v)
+  if (maxp1 <= reorder->next_seq)
   {
     TRACE (reorder, "  too old\n");
     return NN_REORDER_TOO_OLD;
@@ -2275,14 +2275,14 @@ nn_reorder_result_t nn_reorder_gap (struct nn_rsample_chain *sc, struct nn_reord
   {
     nn_reorder_result_t res;
     TRACE (reorder, "  coalesced = null\n");
-    if (min.v <= reorder->next_seq.v)
+    if (min <= reorder->next_seq)
     {
-      TRACE (reorder, "  next expected: %"PRIu64"\n", maxp1.v);
+      TRACE (reorder, "  next expected: %"PRIu64"\n", maxp1);
       reorder->next_seq = maxp1;
       res = NN_REORDER_ACCEPT;
     }
     else if (reorder->n_samples == reorder->max_samples &&
-             (reorder->max_sampleiv == NULL || min.v > reorder->max_sampleiv->u.reorder.maxp1.v))
+             (reorder->max_sampleiv == NULL || min > reorder->max_sampleiv->u.reorder.maxp1))
     {
       /* n_samples = max_samples => (max_sampleiv = NULL <=> max_samples = 0) */
       TRACE (reorder, "  discarding gap: max_samples reached and gap at end\n");
@@ -2309,21 +2309,21 @@ nn_reorder_result_t nn_reorder_gap (struct nn_rsample_chain *sc, struct nn_reord
     reorder->max_sampleiv = ddsrt_avl_find_max (&reorder_sampleivtree_treedef, &reorder->sampleivtree);
     return res;
   }
-  else if (coalesced->u.reorder.min.v <= reorder->next_seq.v)
+  else if (coalesced->u.reorder.min <= reorder->next_seq)
   {
     TRACE (reorder, "  coalesced = [%"PRIu64",%"PRIu64") @ %p containing %"PRId32" samples\n",
-           coalesced->u.reorder.min.v, coalesced->u.reorder.maxp1.v,
+           coalesced->u.reorder.min, coalesced->u.reorder.maxp1,
            (void *) coalesced, coalesced->u.reorder.n_samples);
     ddsrt_avl_delete (&reorder_sampleivtree_treedef, &reorder->sampleivtree, coalesced);
-    if (coalesced->u.reorder.min.v <= reorder->next_seq.v)
-      assert (min.v <= reorder->next_seq.v);
+    if (coalesced->u.reorder.min <= reorder->next_seq)
+      assert (min <= reorder->next_seq);
     reorder->next_seq = coalesced->u.reorder.maxp1;
     reorder->max_sampleiv = ddsrt_avl_find_max (&reorder_sampleivtree_treedef, &reorder->sampleivtree);
-    TRACE (reorder, "  next expected: %"PRIu64"\n", reorder->next_seq.v);
+    TRACE (reorder, "  next expected: %"PRIu64"\n", reorder->next_seq);
     *sc = coalesced->u.reorder.sc;
 
     /* Adjust n_samples */
-    assert (coalesced->u.reorder.min.v + coalesced->u.reorder.n_samples <= coalesced->u.reorder.maxp1.v);
+    assert (coalesced->u.reorder.min + coalesced->u.reorder.n_samples <= coalesced->u.reorder.maxp1);
     assert (reorder->n_samples >= coalesced->u.reorder.n_samples);
     reorder->n_samples -= coalesced->u.reorder.n_samples;
     return (nn_reorder_result_t) coalesced->u.reorder.n_samples;
@@ -2331,7 +2331,7 @@ nn_reorder_result_t nn_reorder_gap (struct nn_rsample_chain *sc, struct nn_reord
   else
   {
     TRACE (reorder, "  coalesced = [%"PRIu64",%"PRIu64") @ %p - that is all\n",
-           coalesced->u.reorder.min.v, coalesced->u.reorder.maxp1.v, (void *) coalesced);
+           coalesced->u.reorder.min, coalesced->u.reorder.maxp1, (void *) coalesced);
     reorder->max_sampleiv = ddsrt_avl_find_max (&reorder_sampleivtree_treedef, &reorder->sampleivtree);
     return valuable ? NN_REORDER_ACCEPT : NN_REORDER_REJECT;
   }
@@ -2344,7 +2344,7 @@ void nn_reorder_drop_upto (struct nn_reorder *reorder, seqno_t maxp1)
   // >= maxp1 for which all sequence numbers starting from maxp1 are present.
   // Requiring that no samples are present beyond maxp1 means we're not dropping
   // too much.  That's good enough for the current purpose.
-  assert (reorder->max_sampleiv == NULL || reorder->max_sampleiv->u.reorder.maxp1.v <= maxp1.v);
+  assert (reorder->max_sampleiv == NULL || reorder->max_sampleiv->u.reorder.maxp1 <= maxp1);
   // gap won't be stored, so can safely be stack-allocated for the purpose of calling
   // nn_reorder_gap
   struct nn_rdata gap = {
@@ -2355,7 +2355,7 @@ void nn_reorder_drop_upto (struct nn_reorder *reorder, seqno_t maxp1)
   };
   struct nn_rsample_chain sc;
   int refc_adjust = 0;
-  if (nn_reorder_gap (&sc, reorder, &gap, (seqno_t){ 1 }, maxp1, &refc_adjust) > 0)
+  if (nn_reorder_gap (&sc, reorder, &gap, 1, maxp1, &refc_adjust) > 0)
   {
     while (sc.first)
     {
@@ -2365,19 +2365,19 @@ void nn_reorder_drop_upto (struct nn_reorder *reorder, seqno_t maxp1)
     }
   }
   assert (refc_adjust == 0 && !ddsrt_atomic_ld32 (&gap.refcount_bias_added));
-  assert (nn_reorder_next_seq (reorder).v >= maxp1.v);
+  assert (nn_reorder_next_seq (reorder) >= maxp1);
 }
 
 int nn_reorder_wantsample (const struct nn_reorder *reorder, seqno_t seq)
 {
   struct nn_rsample *s;
-  if (seq.v < reorder->next_seq.v)
+  if (seq < reorder->next_seq)
     /* trivially not interesting */
     return 0;
   /* Find interval that contains seq, if we know seq.  We are
      interested if seq is outside this interval (if any). */
   s = ddsrt_avl_lookup_pred_eq (&reorder_sampleivtree_treedef, &reorder->sampleivtree, &seq);
-  return (s == NULL || s->u.reorder.maxp1.v <= seq.v);
+  return (s == NULL || s->u.reorder.maxp1 <= seq);
 }
 
 unsigned nn_reorder_nackmap (const struct nn_reorder *reorder, seqno_t base, seqno_t maxseq, struct nn_sequence_number_set_header *map, uint32_t *mapbits, uint32_t maxsz, int notail)
@@ -2397,45 +2397,45 @@ unsigned nn_reorder_nackmap (const struct nn_reorder *reorder, seqno_t base, seq
      delivery */
   base = reorder->next_seq;
 #else
-  if (base.v > reorder->next_seq.v)
+  if (base > reorder->next_seq)
   {
-    DDS_CERROR (reorder->logcfg, "nn_reorder_nackmap: incorrect base sequence number supplied (%"PRIu64" > %"PRIu64")\n", base.v, reorder->next_seq.v);
+    DDS_CERROR (reorder->logcfg, "nn_reorder_nackmap: incorrect base sequence number supplied (%"PRIu64" > %"PRIu64")\n", base, reorder->next_seq);
     base = reorder->next_seq;
   }
 #endif
-  if (maxseq.v + 1 < base.v)
+  if (maxseq + 1 < base)
   {
-    DDS_CERROR (reorder->logcfg, "nn_reorder_nackmap: incorrect max sequence number supplied (maxseq %"PRIu64" base %"PRIu64")\n", maxseq.v, base.v);
-    maxseq = (seqno_t){ base.v - 1 };
+    DDS_CERROR (reorder->logcfg, "nn_reorder_nackmap: incorrect max sequence number supplied (maxseq %"PRIu64" base %"PRIu64")\n", maxseq, base);
+    maxseq = base - 1;
   }
 
   map->bitmap_base = toSN (base);
-  if (maxseq.v + 1 - base.v > maxsz)
+  if (maxseq + 1 - base > maxsz)
     map->numbits = maxsz;
   else
-    map->numbits = (uint32_t) (maxseq.v + 1 - base.v);
+    map->numbits = (uint32_t) (maxseq + 1 - base);
   nn_bitset_zero (map->numbits, mapbits);
 
   struct nn_rsample *iv = ddsrt_avl_find_min (&reorder_sampleivtree_treedef, &reorder->sampleivtree);
-  assert (iv == NULL || iv->u.reorder.min.v > base.v);
+  assert (iv == NULL || iv->u.reorder.min > base);
   seqno_t i = base;
-  while (iv && i.v < base.v + map->numbits)
+  while (iv && i < base + map->numbits)
   {
-    for (; i.v < base.v + map->numbits && i.v < iv->u.reorder.min.v; i.v++)
+    for (; i < base + map->numbits && i < iv->u.reorder.min; i++)
     {
-      uint32_t x = (uint32_t) (i.v - base.v);
+      uint32_t x = (uint32_t) (i - base);
       nn_bitset_set (map->numbits, mapbits, x);
     }
     i = iv->u.reorder.maxp1;
     iv = ddsrt_avl_find_succ (&reorder_sampleivtree_treedef, &reorder->sampleivtree, iv);
   }
-  if (notail && i.v < base.v + map->numbits)
-    map->numbits = (uint32_t) (i.v - base.v);
+  if (notail && i < base + map->numbits)
+    map->numbits = (uint32_t) (i - base);
   else
   {
-    for (; i.v < base.v + map->numbits; i.v++)
+    for (; i < base + map->numbits; i++)
     {
-      uint32_t x = (uint32_t) (i.v - base.v);
+      uint32_t x = (uint32_t) (i - base);
       nn_bitset_set (map->numbits, mapbits, x);
     }
   }

--- a/src/core/ddsi/src/q_receive.c
+++ b/src/core/ddsi/src/q_receive.c
@@ -637,15 +637,18 @@ static int accept_ack_or_hb_w_timeout (nn_count_t new_count, nn_count_t *prev_co
 
 void nn_gap_info_init(struct nn_gap_info *gi)
 {
-  gi->gapstart = -1;
-  gi->gapend = -1;
+  gi->gapstart = 0;
+  gi->gapend = 0;
   gi->gapnumbits = 0;
   memset(gi->gapbits, 0, sizeof(gi->gapbits));
 }
 
 void nn_gap_info_update(struct ddsi_domaingv *gv, struct nn_gap_info *gi, int64_t seqnr)
 {
-  if (gi->gapstart == -1)
+  assert (gi->gapend >= gi->gapstart);
+  assert (seqnr >= gi->gapend);
+
+  if (gi->gapstart == 0)
   {
     GVTRACE (" M%"PRId64, seqnr);
     gi->gapstart = seqnr;

--- a/src/core/ddsi/src/q_receive.c
+++ b/src/core/ddsi/src/q_receive.c
@@ -87,7 +87,7 @@ static void maybe_set_reader_in_sync (struct proxy_writer *pwr, struct pwr_rd_ma
       assert(0);
       break;
     case PRMSS_TLCATCHUP:
-      if (last_deliv_seq >= wn->u.not_in_sync.end_of_tl_seq)
+      if (last_deliv_seq.v >= wn->u.not_in_sync.end_of_tl_seq.v)
       {
         wn->in_sync = PRMSS_SYNC;
         if (--pwr->n_readers_out_of_sync == 0)
@@ -97,7 +97,7 @@ static void maybe_set_reader_in_sync (struct proxy_writer *pwr, struct pwr_rd_ma
     case PRMSS_OUT_OF_SYNC:
       if (!wn->filtered)
       {
-        if (pwr->have_seen_heartbeat && nn_reorder_next_seq (wn->u.not_in_sync.reorder) == nn_reorder_next_seq (pwr->reorder))
+        if (pwr->have_seen_heartbeat && nn_reorder_next_seq (wn->u.not_in_sync.reorder).v == nn_reorder_next_seq (pwr->reorder).v)
         {
           ETRACE (pwr, " msr_in_sync("PGUIDFMT" out-of-sync to tlcatchup)", PGUID (wn->rd_guid));
           wn->in_sync = PRMSS_TLCATCHUP;
@@ -112,7 +112,7 @@ static bool valid_sequence_number_set (const nn_sequence_number_set_header_t *sn
 {
   // reject sets that imply sequence numbers beyond the range of valid sequence numbers
   // (not a spec'd requirement)
-  return (validating_fromSN (snset->bitmap_base, start) && snset->numbits <= 256 && snset->numbits <= MAX_SEQ_NUMBER - *start);
+  return (validating_fromSN (snset->bitmap_base, start) && snset->numbits <= 256 && snset->numbits <= MAX_SEQ_NUMBER - (*start).v);
 }
 
 static bool valid_fragment_number_set (const nn_fragment_number_set_header_t *fnset)
@@ -165,9 +165,9 @@ static enum validation_result validate_AckNack (const struct receiver_state *rst
     /* FastRTPS, Connext send invalid pre-emptive ACKs -- patch the message to
        make it well-formed and process it as normal */
     if (! DDSI_SC_STRICT_P (rst->gv->config) &&
-        (ackseq == 0 && msg->readerSNState.numbits == 0) &&
+        (ackseq.v == 0 && msg->readerSNState.numbits == 0) &&
         (vendor_is_eprosima (rst->vendor) || vendor_is_rti (rst->vendor)))
-      msg->readerSNState.bitmap_base = toSN (1);
+      msg->readerSNState.bitmap_base = toSN ((seqno_t){ 1 });
     else
       return VR_MALFORMED;
   }
@@ -209,7 +209,7 @@ static enum validation_result validate_Gap (Gap_t *msg, size_t size, int byteswa
   // the only plausible interpretation is that the interval is empty and that only the
   // bitmap matters (which could then be all-0 in which case the message is roughly
   // equivalent to a heartbeat that says 1 .. N ...  Rewrite so at least end >= start
-  if (gapend < gapstart)
+  if (gapend.v < gapstart.v)
     msg->gapStart = msg->gapList.bitmap_base;
   if (size < GAP_SIZE (msg->gapList.numbits))
     return VR_MALFORMED;
@@ -266,7 +266,7 @@ static enum validation_result validate_Heartbeat (Heartbeat_t *msg, size_t size,
   msg->writerId = nn_ntoh_entityid (msg->writerId);
   /* Validation following 8.3.7.5.3; lastSN + 1 == firstSN: no data; test using
      firstSN-1 because lastSN+1 can overflow and we already know firstSN-1 >= 0 */
-  if (fromSN (msg->firstSN) <= 0 || fromSN (msg->lastSN) < fromSN (msg->firstSN) - 1)
+  if (fromSN (msg->firstSN).v <= 0 || fromSN (msg->lastSN).v < fromSN (msg->firstSN).v - 1)
     return VR_MALFORMED;
   // do reader/writer entity id validation last: if it returns "NOT_UNDERSTOOD" for an
   // otherwise malformed message, we still need to discard the message in its entirety
@@ -285,7 +285,7 @@ static enum validation_result validate_HeartbeatFrag (HeartbeatFrag_t *msg, size
   }
   msg->readerId = nn_ntoh_entityid (msg->readerId);
   msg->writerId = nn_ntoh_entityid (msg->writerId);
-  if (fromSN (msg->writerSN) <= 0 || msg->lastFragmentNum == 0)
+  if (fromSN (msg->writerSN).v <= 0 || msg->lastFragmentNum == 0)
     return VR_MALFORMED;
   // do reader/writer entity id validation last: if it returns "NOT_UNDERSTOOD" for an
   // otherwise malformed message, we still need to discard the message in its entirety
@@ -570,11 +570,11 @@ int add_Gap (struct nn_xmsg *msg, struct writer *wr, struct proxy_reader *prd, s
 
 static seqno_t grow_gap_to_next_seq (const struct writer *wr, seqno_t seq)
 {
-  seqno_t next_seq = whc_next_seq (wr->whc, seq - 1);
+  seqno_t next_seq = whc_next_seq (wr->whc, (seqno_t){ seq.v - 1 });
   seqno_t seq_xmit = writer_read_seq_xmit (wr);
-  if (next_seq == MAX_SEQ_NUMBER) /* no next sample */
-    return seq_xmit + 1;
-  else if (next_seq > seq_xmit)  /* next is beyond last actually transmitted */
+  if (next_seq.v == MAX_SEQ_NUMBER) /* no next sample */
+    return (seqno_t){ seq_xmit.v + 1 };
+  else if (next_seq.v > seq_xmit.v)  /* next is beyond last actually transmitted */
     return seq_xmit;
   else /* next one is already visible in the outside world */
     return next_seq;
@@ -637,32 +637,32 @@ static int accept_ack_or_hb_w_timeout (nn_count_t new_count, nn_count_t *prev_co
 
 void nn_gap_info_init(struct nn_gap_info *gi)
 {
-  gi->gapstart = 0;
-  gi->gapend = 0;
+  gi->gapstart = (seqno_t){ 0 };
+  gi->gapend = (seqno_t){ 0 };
   gi->gapnumbits = 0;
   memset(gi->gapbits, 0, sizeof(gi->gapbits));
 }
 
-void nn_gap_info_update(struct ddsi_domaingv *gv, struct nn_gap_info *gi, int64_t seqnr)
+void nn_gap_info_update(struct ddsi_domaingv *gv, struct nn_gap_info *gi, seqno_t seqnr)
 {
-  assert (gi->gapend >= gi->gapstart);
-  assert (seqnr >= gi->gapend);
+  assert (gi->gapend.v >= gi->gapstart.v);
+  assert (seqnr.v >= gi->gapend.v);
 
-  if (gi->gapstart == 0)
+  if (gi->gapstart.v == 0)
   {
-    GVTRACE (" M%"PRId64, seqnr);
+    GVTRACE (" M%"PRIu64, seqnr.v);
     gi->gapstart = seqnr;
-    gi->gapend = gi->gapstart + 1;
+    gi->gapend = (seqno_t){ gi->gapstart.v + 1 };
   }
-  else if (seqnr == gi->gapend)
+  else if (seqnr.v == gi->gapend.v)
   {
-    GVTRACE (" M%"PRId64, seqnr);
-    gi->gapend = seqnr + 1;
+    GVTRACE (" M%"PRIu64, seqnr.v);
+    gi->gapend = (seqno_t){ seqnr.v + 1 };
   }
-  else if (seqnr - gi->gapend < 256)
+  else if (seqnr.v - gi->gapend.v < 256)
   {
-    unsigned idx = (unsigned) (seqnr - gi->gapend);
-    GVTRACE (" M%"PRId64, seqnr);
+    uint32_t idx = (uint32_t) (seqnr.v - gi->gapend.v);
+    GVTRACE (" M%"PRIu64, seqnr.v);
     gi->gapnumbits = idx + 1;
     nn_bitset_set (gi->gapnumbits, gi->gapbits, idx);
   }
@@ -672,7 +672,7 @@ struct nn_xmsg * nn_gap_info_create_gap(struct writer *wr, struct proxy_reader *
 {
   struct nn_xmsg *m;
 
-  if (gi->gapstart <= 0)
+  if (gi->gapstart.v == 0)
     return NULL;
 
   m = nn_xmsg_new (wr->e.gv->xmsgpool, &wr->e.guid, wr->c.pp, 0, NN_XMSG_KIND_CONTROL);
@@ -686,7 +686,7 @@ struct nn_xmsg * nn_gap_info_create_gap(struct writer *wr, struct proxy_reader *
   }
   else
   {
-    ETRACE (wr, " FXGAP%"PRId64"..%"PRId64"/%"PRIu32":", gi->gapstart, gi->gapend, gi->gapnumbits);
+    ETRACE (wr, " FXGAP%"PRIu64"..%"PRIu64"/%"PRIu32":", gi->gapstart.v, gi->gapend.v, gi->gapnumbits);
     for (uint32_t i = 0; i < gi->gapnumbits; i++)
       ETRACE (wr, "%c", nn_bitset_isset (gi->gapnumbits, gi->gapbits, i) ? '1' : '0');
   }
@@ -782,11 +782,12 @@ static int handle_AckNack (struct receiver_state *rst, ddsrt_etime_t tnow, const
   src.entityid = msg->readerId;
   dst.prefix = rst->dst_guid_prefix;
   dst.entityid = msg->writerId;
-  RSTTRACE ("ACKNACK(%s#%"PRId32":%"PRId64"/%"PRIu32":", msg->smhdr.flags & ACKNACK_FLAG_FINAL ? "F" : "",
-            *countp, fromSN (msg->readerSNState.bitmap_base), msg->readerSNState.numbits);
+  RSTTRACE ("ACKNACK(%s#%"PRId32":%"PRIu64"/%"PRIu32":", msg->smhdr.flags & ACKNACK_FLAG_FINAL ? "F" : "",
+            *countp, fromSN (msg->readerSNState.bitmap_base).v, msg->readerSNState.numbits);
   for (uint32_t i = 0; i < msg->readerSNState.numbits; i++)
     RSTTRACE ("%c", nn_bitset_isset (msg->readerSNState.numbits, msg->bits, i) ? '1' : '0');
   seqbase = fromSN (msg->readerSNState.bitmap_base);
+  assert (seqbase.v > 0); // documentation, really, to make it obvious that subtracting 1 is ok
 
   if (!rst->forme)
   {
@@ -841,8 +842,8 @@ static int handle_AckNack (struct receiver_state *rst, ddsrt_etime_t tnow, const
      get set when only historical data is being acked, which is
      relevant to setting "has_replied_to_hb" and "assumed_in_sync". */
   is_pure_ack = !acknack_is_nack (msg);
-  is_pure_nonhist_ack = is_pure_ack && seqbase - 1 >= rn->seq;
-  is_preemptive_ack = seqbase < 1 || (seqbase == 1 && *countp == 0);
+  is_pure_nonhist_ack = is_pure_ack && seqbase.v - 1 >= rn->seq.v;
+  is_preemptive_ack = seqbase.v < 1 || (seqbase.v == 1 && *countp == 0);
 
   wr->num_acks_received++;
   if (!is_pure_ack)
@@ -876,19 +877,18 @@ static int handle_AckNack (struct receiver_state *rst, ddsrt_etime_t tnow, const
   /* First, the ACK part: if the AckNack advances the highest sequence
      number ack'd by the remote reader, update state & try dropping
      some messages */
-  if (seqbase - 1 > rn->seq)
+  if (seqbase.v - 1 > rn->seq.v)
   {
-    int64_t n_ack = (seqbase - 1) - rn->seq;
-    unsigned n;
-    rn->seq = seqbase - 1;
-    if (rn->seq > wr->seq) {
+    const uint64_t n_ack = (seqbase.v - 1) - rn->seq.v;
+    rn->seq = (seqno_t){ seqbase.v - 1 };
+    if (rn->seq.v > wr->seq.v) {
       /* Prevent a reader from ACKing future samples (is only malicious because we require
          that rn->seq <= wr->seq) */
       rn->seq = wr->seq;
     }
     ddsrt_avl_augment_update (&wr_readers_treedef, rn);
-    n = remove_acked_messages (wr, &whcst, &deferred_free_list);
-    RSTTRACE (" ACK%"PRId64" RM%u", n_ack, n);
+    const unsigned n = remove_acked_messages (wr, &whcst, &deferred_free_list);
+    RSTTRACE (" ACK%"PRIu64" RM%u", n_ack, n);
   }
   else
   {
@@ -898,17 +898,17 @@ static int handle_AckNack (struct receiver_state *rst, ddsrt_etime_t tnow, const
 
   /* If this reader was marked as "non-responsive" in the past, it's now responding again,
      so update its status */
-  if (rn->seq == MAX_SEQ_NUMBER && prd->c.xqos->reliability.kind == DDS_RELIABILITY_RELIABLE)
+  if (rn->seq.v == MAX_SEQ_NUMBER && prd->c.xqos->reliability.kind == DDS_RELIABILITY_RELIABLE)
   {
     seqno_t oldest_seq;
     oldest_seq = WHCST_ISEMPTY(&whcst) ? wr->seq : whcst.max_seq;
     rn->has_replied_to_hb = 1; /* was temporarily cleared to ensure heartbeats went out */
-    rn->seq = seqbase - 1;
-    if (oldest_seq > rn->seq) {
+    rn->seq = (seqno_t){ seqbase.v - 1 };
+    if (oldest_seq.v > rn->seq.v) {
       /* Prevent a malicious reader from lowering the min. sequence number retained in the WHC. */
       rn->seq = oldest_seq;
     }
-    if (rn->seq > wr->seq) {
+    if (rn->seq.v > wr->seq.v) {
       /* Prevent a reader from ACKing future samples (is only malicious because we require
          that rn->seq <= wr->seq) */
       rn->seq = wr->seq;
@@ -923,7 +923,7 @@ static int handle_AckNack (struct receiver_state *rst, ddsrt_etime_t tnow, const
   numbits = msg->readerSNState.numbits;
   msgs_sent = 0;
   msgs_lost = 0;
-  max_seq_in_reply = 0;
+  max_seq_in_reply = (seqno_t){ 0 };
   if (!rn->has_replied_to_hb && is_pure_nonhist_ack)
   {
     RSTTRACE (" setting-has-replied-to-hb");
@@ -998,10 +998,10 @@ static int handle_AckNack (struct receiver_state *rst, ddsrt_etime_t tnow, const
   enqueued = 1;
   seq_xmit = writer_read_seq_xmit (wr);
   nn_gap_info_init(&gi);
-  const bool gap_for_already_acked = vendor_is_eclipse (rst->vendor) && prd->c.xqos->durability.kind == DDS_DURABILITY_VOLATILE && seqbase <= rn->seq;
-  const seqno_t min_seq_to_rexmit = gap_for_already_acked ? rn->seq + 1 : 0;
+  const bool gap_for_already_acked = vendor_is_eclipse (rst->vendor) && prd->c.xqos->durability.kind == DDS_DURABILITY_VOLATILE && seqbase.v <= rn->seq.v;
+  const seqno_t min_seq_to_rexmit = gap_for_already_acked ? (seqno_t){ rn->seq.v + 1 } : (seqno_t){ 0 };
   uint32_t limit = wr->rexmit_burst_size_limit;
-  for (uint32_t i = 0; i < numbits && seqbase + i <= seq_xmit && enqueued && limit > 0; i++)
+  for (uint32_t i = 0; i < numbits && seqbase.v + i <= seq_xmit.v && enqueued && limit > 0; i++)
   {
     /* Accelerated schedule may run ahead of sequence number set
        contained in the acknack, and assumes all messages beyond the
@@ -1009,9 +1009,9 @@ static int handle_AckNack (struct receiver_state *rst, ddsrt_etime_t tnow, const
        left off ... */
     if (i >= msg->readerSNState.numbits || nn_bitset_isset (numbits, msg->bits, i))
     {
-      seqno_t seq = seqbase + i;
+      seqno_t seq = (seqno_t){ seqbase.v + i };
       struct whc_borrowed_sample sample;
-      if (seqbase + i >= min_seq_to_rexmit && whc_borrow_sample (wr->whc, seq, &sample))
+      if (seqbase.v + i >= min_seq_to_rexmit.v && whc_borrow_sample (wr->whc, seq, &sample))
       {
         if (!wr->retransmitting && sample.unacked)
           writer_set_retransmitting (wr);
@@ -1022,11 +1022,11 @@ static int handle_AckNack (struct receiver_state *rst, ddsrt_etime_t tnow, const
           ddsrt_mtime_t tstamp = ddsrt_time_monotonic ();
           if (tstamp.v > sample.last_rexmit_ts.v + rst->gv->config.retransmit_merging_period)
           {
-            RSTTRACE (" RX%"PRId64, seqbase + i);
+            RSTTRACE (" RX%"PRIu64, seqbase.v + i);
             enqueued = (enqueue_sample_wrlock_held (wr, seq, sample.plist, sample.serdata, NULL, 0) >= 0);
             if (enqueued)
             {
-              max_seq_in_reply = seqbase + i;
+              max_seq_in_reply = (seqno_t){ seqbase.v + i };
               msgs_sent++;
               sample.last_rexmit_ts = tstamp;
               // FIXME: now enqueue_sample_wrlock_held limits retransmit requests of a large sample to 1 fragment
@@ -1041,7 +1041,7 @@ static int handle_AckNack (struct receiver_state *rst, ddsrt_etime_t tnow, const
           }
           else
           {
-            RSTTRACE (" RX%"PRId64" (merged)", seqbase + i);
+            RSTTRACE (" RX%"PRIu64" (merged)", seqbase.v + i);
           }
         }
         else
@@ -1049,15 +1049,15 @@ static int handle_AckNack (struct receiver_state *rst, ddsrt_etime_t tnow, const
           /* Is this a volatile reader with a filter?
            * If so, call the filter to see if we should re-arrange the sequence gap when needed. */
           if (prd->filter && !prd->filter (wr, prd, sample.serdata))
-            nn_gap_info_update (rst->gv, &gi, seqbase + i);
+            nn_gap_info_update (rst->gv, &gi, (seqno_t){ seqbase.v + i });
           else
           {
             /* no merging, send directed retransmit */
-            RSTTRACE (" RX%"PRId64"", seqbase + i);
+            RSTTRACE (" RX%"PRIu64"", seqbase.v + i);
             enqueued = (enqueue_sample_wrlock_held (wr, seq, sample.plist, sample.serdata, prd, 0) >= 0);
             if (enqueued)
             {
-              max_seq_in_reply = seqbase + i;
+              max_seq_in_reply = (seqno_t){ seqbase.v + i };
               msgs_sent++;
               sample.rexmit_count++;
               // FIXME: now enqueue_sample_wrlock_held limits retransmit requests of a large sample to 1 fragment
@@ -1075,7 +1075,7 @@ static int handle_AckNack (struct receiver_state *rst, ddsrt_etime_t tnow, const
       }
       else
       {
-        nn_gap_info_update (rst->gv, &gi, seqbase + i);
+        nn_gap_info_update (rst->gv, &gi, (seqno_t){ seqbase.v + i });
         msgs_lost++;
       }
     }
@@ -1084,15 +1084,15 @@ static int handle_AckNack (struct receiver_state *rst, ddsrt_etime_t tnow, const
   if (!enqueued)
     RSTTRACE (" rexmit-limit-hit");
   /* Generate a Gap message if some of the sequence is missing */
-  if (gi.gapstart > 0)
+  if (gi.gapstart.v > 0)
   {
     struct nn_xmsg *gap;
 
-    if (gi.gapend == seqbase + msg->readerSNState.numbits)
+    if (gi.gapend.v == seqbase.v + msg->readerSNState.numbits)
       gi.gapend = grow_gap_to_next_seq (wr, gi.gapend);
 
-    if (gi.gapend-1 + gi.gapnumbits > max_seq_in_reply)
-      max_seq_in_reply = gi.gapend-1 + gi.gapnumbits;
+    if (gi.gapend.v-1 + gi.gapnumbits > max_seq_in_reply.v)
+      max_seq_in_reply = (seqno_t){ gi.gapend.v-1 + gi.gapnumbits };
 
     gap = nn_gap_info_create_gap (wr, prd, &gi);
     if (gap)
@@ -1106,7 +1106,7 @@ static int handle_AckNack (struct receiver_state *rst, ddsrt_etime_t tnow, const
   wr->rexmit_lost_count += msgs_lost;
   if (msgs_sent)
   {
-    RSTTRACE (" rexmit#%"PRIu32" maxseq:%"PRId64"<%"PRId64"<=%"PRId64"", msgs_sent, max_seq_in_reply, seq_xmit, wr->seq);
+    RSTTRACE (" rexmit#%"PRIu32" maxseq:%"PRIu64"<%"PRIu64"<=%"PRIu64"", msgs_sent, max_seq_in_reply.v, seq_xmit.v, wr->seq.v);
 
     defer_heartbeat_to_peer (wr, &whcst, prd, 1, defer_hb_state);
     hb_sent_in_response = 1;
@@ -1216,7 +1216,7 @@ static void handle_Heartbeat_helper (struct pwr_rd_match * const wn, struct hand
       refseq = nn_reorder_next_seq (pwr->reorder);
     else
       refseq = nn_reorder_next_seq (wn->u.not_in_sync.reorder);
-    RSTTRACE (" "PGUIDFMT"@%"PRId64"%s", PGUID (wn->rd_guid), refseq - 1, (wn->in_sync == PRMSS_SYNC) ? "(sync)" : (wn->in_sync == PRMSS_TLCATCHUP) ? "(tlcatchup)" : "");
+    RSTTRACE (" "PGUIDFMT"@%"PRIu64"%s", PGUID (wn->rd_guid), refseq.v - 1, (wn->in_sync == PRMSS_SYNC) ? "(sync)" : (wn->in_sync == PRMSS_TLCATCHUP) ? "(tlcatchup)" : "");
   }
 
   wn->heartbeat_since_ack = 1;
@@ -1253,8 +1253,8 @@ static int handle_Heartbeat (struct receiver_state *rst, ddsrt_etime_t tnow, str
   dst.prefix = rst->dst_guid_prefix;
   dst.entityid = msg->readerId;
 
-  RSTTRACE ("HEARTBEAT(%s%s#%"PRId32":%"PRId64"..%"PRId64" ", msg->smhdr.flags & HEARTBEAT_FLAG_FINAL ? "F" : "",
-    msg->smhdr.flags & HEARTBEAT_FLAG_LIVELINESS ? "L" : "", msg->count, firstseq, lastseq);
+  RSTTRACE ("HEARTBEAT(%s%s#%"PRId32":%"PRIu64"..%"PRIu64" ", msg->smhdr.flags & HEARTBEAT_FLAG_FINAL ? "F" : "",
+    msg->smhdr.flags & HEARTBEAT_FLAG_LIVELINESS ? "L" : "", msg->count, firstseq.v, lastseq.v);
 
   if (!rst->forme)
   {
@@ -1300,9 +1300,9 @@ static int handle_Heartbeat (struct receiver_state *rst, ddsrt_etime_t tnow, str
     struct nn_rsample_chain sc;
     int refc_adjust = 0;
     nn_reorder_result_t res;
-    nn_defrag_notegap (pwr->defrag, 1, lastseq + 1);
+    nn_defrag_notegap (pwr->defrag, (seqno_t){ 1 }, (seqno_t){ lastseq.v + 1 });
     gap = nn_rdata_newgap (rmsg);
-    res = nn_reorder_gap (&sc, pwr->reorder, gap, 1, lastseq + 1, &refc_adjust);
+    res = nn_reorder_gap (&sc, pwr->reorder, gap, (seqno_t){ 1 }, (seqno_t){ lastseq.v + 1 }, &refc_adjust);
     /* proxy writer is not accepting data until it has received a heartbeat, so
        there can't be any data to deliver */
     assert (res <= 0);
@@ -1311,17 +1311,17 @@ static int handle_Heartbeat (struct receiver_state *rst, ddsrt_etime_t tnow, str
     pwr->have_seen_heartbeat = 1;
   }
 
-  if (lastseq > pwr->last_seq)
+  if (lastseq.v > pwr->last_seq.v)
   {
     pwr->last_seq = lastseq;
     pwr->last_fragnum = UINT32_MAX;
   }
-  else if (pwr->last_fragnum != UINT32_MAX && lastseq == pwr->last_seq)
+  else if (pwr->last_fragnum != UINT32_MAX && lastseq.v == pwr->last_seq.v)
   {
     pwr->last_fragnum = UINT32_MAX;
   }
 
-  nn_defrag_notegap (pwr->defrag, 1, firstseq);
+  nn_defrag_notegap (pwr->defrag, (seqno_t){ 1 }, firstseq);
 
   {
     struct nn_rdata *gap;
@@ -1341,9 +1341,9 @@ static int handle_Heartbeat (struct receiver_state *rst, ddsrt_etime_t tnow, str
           if (wn->filtered)
           {
             struct nn_reorder *ro = wn->u.not_in_sync.reorder;
-            if ((res = nn_reorder_gap (&sc, ro, gap, 1, firstseq, &refc_adjust)) > 0)
+            if ((res = nn_reorder_gap (&sc, ro, gap, (seqno_t){ 1 }, firstseq, &refc_adjust)) > 0)
               nn_dqueue_enqueue1 (pwr->dqueue, &wn->rd_guid, &sc, res);
-            if (fromSN (msg->lastSN) > wn->last_seq)
+            if (fromSN (msg->lastSN).v > wn->last_seq.v)
             {
               wn->last_seq = fromSN (msg->lastSN);
             }
@@ -1356,7 +1356,7 @@ static int handle_Heartbeat (struct receiver_state *rst, ddsrt_etime_t tnow, str
 
     if (!filtered)
     {
-      if ((res = nn_reorder_gap (&sc, pwr->reorder, gap, 1, firstseq, &refc_adjust)) > 0)
+      if ((res = nn_reorder_gap (&sc, pwr->reorder, gap, (seqno_t){ 1 }, firstseq, &refc_adjust)) > 0)
       {
         if (pwr->deliver_synchronously)
           deliver_user_data_synchronously (&sc, NULL);
@@ -1365,35 +1365,34 @@ static int handle_Heartbeat (struct receiver_state *rst, ddsrt_etime_t tnow, str
       }
       for (wn = ddsrt_avl_find_min (&pwr_readers_treedef, &pwr->readers); wn; wn = ddsrt_avl_find_succ (&pwr_readers_treedef, &pwr->readers, wn))
       {
-        if (wn->in_sync != PRMSS_SYNC)
+        if (wn->in_sync == PRMSS_SYNC)
+          continue;
+        if (wn->u.not_in_sync.end_of_tl_seq.v == MAX_SEQ_NUMBER)
         {
-          seqno_t last_deliv_seq = 0;
-          switch (wn->in_sync)
-          {
-            case PRMSS_SYNC:
-              assert(0);
-              break;
-            case PRMSS_TLCATCHUP:
-              last_deliv_seq = nn_reorder_next_seq (pwr->reorder) - 1;
-              break;
-            case PRMSS_OUT_OF_SYNC: {
-              struct nn_reorder *ro = wn->u.not_in_sync.reorder;
-              if ((res = nn_reorder_gap (&sc, ro, gap, 1, firstseq, &refc_adjust)) > 0)
-              {
-                if (pwr->deliver_synchronously)
-                  deliver_user_data_synchronously (&sc, &wn->rd_guid);
-                else
-                  nn_dqueue_enqueue1 (pwr->dqueue, &wn->rd_guid, &sc, res);
-              }
-              last_deliv_seq = nn_reorder_next_seq (wn->u.not_in_sync.reorder) - 1;
+          wn->u.not_in_sync.end_of_tl_seq = fromSN (msg->lastSN);
+          RSTTRACE (" end-of-tl-seq(rd "PGUIDFMT" #%"PRIu64")", PGUID(wn->rd_guid), wn->u.not_in_sync.end_of_tl_seq.v);
+        }
+        switch (wn->in_sync)
+        {
+          case PRMSS_SYNC:
+            assert(0);
+            break;
+          case PRMSS_TLCATCHUP:
+            assert (nn_reorder_next_seq (pwr->reorder).v > 0);
+            maybe_set_reader_in_sync (pwr, wn, (seqno_t){ nn_reorder_next_seq (pwr->reorder).v - 1 });
+            break;
+          case PRMSS_OUT_OF_SYNC: {
+            struct nn_reorder *ro = wn->u.not_in_sync.reorder;
+            if ((res = nn_reorder_gap (&sc, ro, gap, (seqno_t){ 1 }, firstseq, &refc_adjust)) > 0)
+            {
+              if (pwr->deliver_synchronously)
+                deliver_user_data_synchronously (&sc, &wn->rd_guid);
+              else
+                nn_dqueue_enqueue1 (pwr->dqueue, &wn->rd_guid, &sc, res);
             }
+            assert (nn_reorder_next_seq (wn->u.not_in_sync.reorder).v > 0);
+            maybe_set_reader_in_sync (pwr, wn, (seqno_t){ nn_reorder_next_seq (wn->u.not_in_sync.reorder).v - 1 });
           }
-          if (wn->u.not_in_sync.end_of_tl_seq == MAX_SEQ_NUMBER)
-          {
-            wn->u.not_in_sync.end_of_tl_seq = fromSN (msg->lastSN);
-            RSTTRACE (" end-of-tl-seq(rd "PGUIDFMT" #%"PRId64")", PGUID(wn->rd_guid), wn->u.not_in_sync.end_of_tl_seq);
-          }
-          maybe_set_reader_in_sync (pwr, wn, last_deliv_seq);
         }
       }
     }
@@ -1428,7 +1427,7 @@ static int handle_HeartbeatFrag (struct receiver_state *rst, UNUSED_ARG(ddsrt_et
   dst.entityid = msg->readerId;
   const bool directed_heartbeat = (dst.entityid.u != NN_ENTITYID_UNKNOWN && vendor_is_eclipse (rst->vendor));
 
-  RSTTRACE ("HEARTBEATFRAG(#%"PRId32":%"PRId64"/[1,%"PRIu32"]", msg->count, seq, fragnum+1);
+  RSTTRACE ("HEARTBEATFRAG(#%"PRId32":%"PRIu64"/[1,%"PRIu32"]", msg->count, seq.v, fragnum+1);
   if (!rst->forme)
   {
     RSTTRACE (" "PGUIDFMT" -> "PGUIDFMT" not-for-me)", PGUID (src), PGUID (dst));
@@ -1453,12 +1452,12 @@ static int handle_HeartbeatFrag (struct receiver_state *rst, UNUSED_ARG(ddsrt_et
   RSTTRACE (" "PGUIDFMT" -> "PGUIDFMT"", PGUID (src), PGUID (dst));
   ddsrt_mutex_lock (&pwr->e.lock);
 
-  if (seq > pwr->last_seq)
+  if (seq.v > pwr->last_seq.v)
   {
     pwr->last_seq = seq;
     pwr->last_fragnum = fragnum;
   }
-  else if (seq == pwr->last_seq && fragnum > pwr->last_fragnum)
+  else if (seq.v == pwr->last_seq.v && fragnum > pwr->last_fragnum)
   {
     pwr->last_fragnum = fragnum;
   }
@@ -1508,7 +1507,7 @@ static int handle_HeartbeatFrag (struct receiver_state *rst, UNUSED_ARG(ddsrt_et
         }
       }
     }
-    else if (seq < nn_reorder_next_seq (pwr->reorder))
+    else if (seq.v < nn_reorder_next_seq (pwr->reorder).v)
     {
       if (directed_heartbeat)
       {
@@ -1552,7 +1551,7 @@ static int handle_HeartbeatFrag (struct receiver_state *rst, UNUSED_ARG(ddsrt_et
         uint32_t bits[NN_FRAGMENT_NUMBER_SET_MAX_BITS / 32];
       } nackfrag;
       const seqno_t last_seq = m->filtered ? m->last_seq : pwr->last_seq;
-      if (seq == last_seq && nn_defrag_nackmap (pwr->defrag, seq, fragnum, &nackfrag.set, nackfrag.bits, NN_FRAGMENT_NUMBER_SET_MAX_BITS) == DEFRAG_NACKMAP_FRAGMENTS_MISSING)
+      if (seq.v == last_seq.v && nn_defrag_nackmap (pwr->defrag, seq, fragnum, &nackfrag.set, nackfrag.bits, NN_FRAGMENT_NUMBER_SET_MAX_BITS) == DEFRAG_NACKMAP_FRAGMENTS_MISSING)
       {
         // don't rush it ...
         resched_xevent_if_earlier (m->acknack_xevent, ddsrt_mtime_add_duration (ddsrt_time_monotonic (), pwr->e.gv->config.nack_delay));
@@ -1581,7 +1580,7 @@ static int handle_NackFrag (struct receiver_state *rst, ddsrt_etime_t tnow, cons
   dst.prefix = rst->dst_guid_prefix;
   dst.entityid = msg->writerId;
 
-  RSTTRACE ("NACKFRAG(#%"PRId32":%"PRId64"/%"PRIu32"/%"PRIu32":", *countp, seq, msg->fragmentNumberState.bitmap_base, msg->fragmentNumberState.numbits);
+  RSTTRACE ("NACKFRAG(#%"PRId32":%"PRIu64"/%"PRIu32"/%"PRIu32":", *countp, seq.v, msg->fragmentNumberState.bitmap_base, msg->fragmentNumberState.numbits);
   for (uint32_t i = 0; i < msg->fragmentNumberState.numbits; i++)
     RSTTRACE ("%c", nn_bitset_isset (msg->fragmentNumberState.numbits, msg->bits, i) ? '1' : '0');
 
@@ -1677,10 +1676,10 @@ static int handle_NackFrag (struct receiver_state *rst, ddsrt_etime_t tnow, cons
     m = nn_xmsg_new (rst->gv->xmsgpool, &wr->e.guid, wr->c.pp, 0, NN_XMSG_KIND_CONTROL);
     nn_xmsg_setdstPRD (m, prd);
     /* length-1 bitmap with the bit clear avoids the illegal case of a length-0 bitmap */
-    add_Gap (m, wr, prd, seq, seq+1, 0, &zero);
+    add_Gap (m, wr, prd, seq, (seqno_t){ seq.v+1 }, 0, &zero);
     qxev_msg (wr->evq, m);
   }
-  if (seq <= writer_read_seq_xmit (wr))
+  if (seq.v <= writer_read_seq_xmit (wr).v)
   {
     /* Not everything was retransmitted yet, so force a heartbeat out
        to give the reader a chance to nack the rest and make sure
@@ -1752,6 +1751,7 @@ static int handle_one_gap (struct proxy_writer *pwr, struct pwr_rd_match *wn, se
   nn_reorder_result_t res = 0;
   int gap_was_valuable = 0;
   ASSERT_MUTEX_HELD (&pwr->e.lock);
+  assert (a.v > 0 && b.v >= a.v);
 
   /* Clean up the defrag admin: no fragments of a missing sample will
      be arriving in the future */
@@ -1808,7 +1808,7 @@ static int handle_one_gap (struct proxy_writer *pwr, struct pwr_rd_match *wn, se
        is something to deliver; for missing data, you just don't know.
        The return value of reorder_gap _is_ sufficiently precise, but
        why not simply check?  It isn't a very expensive test. */
-    maybe_set_reader_in_sync (pwr, wn, b-1);
+    maybe_set_reader_in_sync (pwr, wn, (seqno_t){ b.v-1 });
   }
 
   return gap_was_valuable;
@@ -1837,7 +1837,7 @@ static int handle_Gap (struct receiver_state *rst, ddsrt_etime_t tnow, struct nn
   struct lease *lease;
   ddsi_guid_t src, dst;
   seqno_t gapstart, listbase;
-  int32_t last_included_rel;
+  uint32_t first_excluded_rel;
   uint32_t listidx;
 
   src.prefix = rst->src_guid_prefix;
@@ -1846,7 +1846,11 @@ static int handle_Gap (struct receiver_state *rst, ddsrt_etime_t tnow, struct nn
   dst.entityid = msg->readerId;
   gapstart = fromSN (msg->gapStart);
   listbase = fromSN (msg->gapList.bitmap_base);
-  RSTTRACE ("GAP(%"PRId64"..%"PRId64"/%"PRIu32" ", gapstart, listbase, msg->gapList.numbits);
+  RSTTRACE ("GAP(%"PRIu64"..%"PRIu64"/%"PRIu32" ", gapstart.v, listbase.v, msg->gapList.numbits);
+
+  // valid_Gap guarantees this, but as we are doing sequence number
+  // calculations it doesn't hurt to document it here again
+  assert (listbase.v >= gapstart.v && gapstart.v >= 1);
 
   /* There is no _good_ reason for a writer to start the bitmap with a
      1 bit, but check for it just in case, to reduce the number of
@@ -1854,7 +1858,7 @@ static int handle_Gap (struct receiver_state *rst, ddsrt_etime_t tnow, struct nn
   for (listidx = 0; listidx < msg->gapList.numbits; listidx++)
     if (!nn_bitset_isset (msg->gapList.numbits, msg->bits, listidx))
       break;
-  last_included_rel = (int32_t) listidx - 1;
+  first_excluded_rel = listidx;
 
   if (!rst->forme)
   {
@@ -1900,12 +1904,12 @@ static int handle_Gap (struct receiver_state *rst, ddsrt_etime_t tnow, struct nn
     int refc_adjust = 0;
     struct nn_rdata *gap;
     gap = nn_rdata_newgap (rmsg);
-    if (gapstart < listbase + listidx)
+    if (gapstart.v < listbase.v + listidx)
     {
       /* sanity check on sequence numbers because a GAP message is not invalid even
          if start >= listbase (DDSI 2.1 sect 8.3.7.4.3), but only handle non-empty
          intervals */
-      (void) handle_one_gap (pwr, wn, gapstart, listbase + listidx, gap, &refc_adjust);
+      (void) handle_one_gap (pwr, wn, gapstart, (seqno_t){ listbase.v + listidx }, gap, &refc_adjust);
     }
     while (listidx < msg->gapList.numbits)
     {
@@ -1920,9 +1924,9 @@ static int handle_Gap (struct receiver_state *rst, ddsrt_etime_t tnow, struct nn
         /* spec says gapList (2) identifies an additional list of sequence numbers that
            are invalid (8.3.7.4.2), so by that rule an insane start would simply mean the
            initial interval is to be ignored and the bitmap to be applied */
-        (void) handle_one_gap (pwr, wn, listbase + listidx, listbase + j, gap, &refc_adjust);
+        (void) handle_one_gap (pwr, wn, (seqno_t){ listbase.v + listidx }, (seqno_t){ listbase.v + j }, gap, &refc_adjust);
         assert(j >= 1);
-        last_included_rel = (int32_t) j - 1;
+        first_excluded_rel = j;
         listidx = j;
       }
     }
@@ -1935,18 +1939,17 @@ static int handle_Gap (struct receiver_state *rst, ddsrt_etime_t tnow, struct nn
      doesn't tell us anything (which is something that RTI apparently
      got wrong in its interpetation of pure acks that do include a
      bitmap).  */
-  if (listbase + last_included_rel > pwr->last_seq)
+  const seqno_t lastseq = { listbase.v + first_excluded_rel - 1 };
+  if (lastseq.v > pwr->last_seq.v)
   {
-    pwr->last_seq = listbase + last_included_rel;
+    pwr->last_seq = lastseq;
     pwr->last_fragnum = UINT32_MAX;
   }
 
   if (wn && wn->filtered)
   {
-    if (listbase + last_included_rel > wn->last_seq)
-    {
-      wn->last_seq = listbase + last_included_rel;
-    }
+    if (lastseq.v > wn->last_seq.v)
+      wn->last_seq = lastseq;
   }
   RSTTRACE (")");
   ddsrt_mutex_unlock (&pwr->e.lock);
@@ -1998,9 +2001,9 @@ static struct ddsi_serdata *remote_make_sample (struct ddsi_tkmap_instance **tk,
          an error path, it doesn't hurt to survive that */
       if (pwr) guid = pwr->e.guid; else memset (&guid, 0, sizeof (guid));
       DDS_CTRACE (&gv->logconfig,
-                  "data(application, vendor %u.%u): "PGUIDFMT" #%"PRId64": write without proper payload (data_smhdr_flags 0x%x size %"PRIu32")\n",
+                  "data(application, vendor %u.%u): "PGUIDFMT" #%"PRIu64": write without proper payload (data_smhdr_flags 0x%x size %"PRIu32")\n",
                   sampleinfo->rst->vendor.id[0], sampleinfo->rst->vendor.id[1],
-                  PGUID (guid), sampleinfo->seq,
+                  PGUID (guid), sampleinfo->seq.v,
                   si->data_smhdr_flags, sampleinfo->size);
       return NULL;
     }
@@ -2054,9 +2057,9 @@ static struct ddsi_serdata *remote_make_sample (struct ddsi_tkmap_instance **tk,
     ddsi_guid_t guid;
     if (pwr) guid = pwr->e.guid; else memset (&guid, 0, sizeof (guid));
     DDS_CWARNING (&gv->logconfig,
-                  "data(application, vendor %u.%u): "PGUIDFMT" #%"PRId64": deserialization %s/%s failed (%s)\n",
+                  "data(application, vendor %u.%u): "PGUIDFMT" #%"PRIu64": deserialization %s/%s failed (%s)\n",
                   sampleinfo->rst->vendor.id[0], sampleinfo->rst->vendor.id[1],
-                  PGUID (guid), sampleinfo->seq,
+                  PGUID (guid), sampleinfo->seq.v,
                   pwr && (pwr->c.xqos->present & QP_TOPIC_NAME) ? pwr->c.xqos->topic_name : "", type->type_name,
                   failmsg ? failmsg : "for reasons unknown");
   }
@@ -2077,9 +2080,9 @@ static struct ddsi_serdata *remote_make_sample (struct ddsi_tkmap_instance **tk,
       if (gv->logconfig.c.mask & DDS_LC_CONTENT)
         res = ddsi_serdata_print (sample, tmp, sizeof (tmp));
       if (pwr) guid = pwr->e.guid; else memset (&guid, 0, sizeof (guid));
-      GVTRACE ("data(application, vendor %u.%u): "PGUIDFMT" #%"PRId64": ST%"PRIx32" %s/%s:%s%s",
+      GVTRACE ("data(application, vendor %u.%u): "PGUIDFMT" #%"PRIu64": ST%"PRIx32" %s/%s:%s%s",
                sampleinfo->rst->vendor.id[0], sampleinfo->rst->vendor.id[1],
-               PGUID (guid), sampleinfo->seq, statusinfo,
+               PGUID (guid), sampleinfo->seq.v, statusinfo,
                pwr && (pwr->c.xqos->present & QP_TOPIC_NAME) ? pwr->c.xqos->topic_name : "", type->type_name,
                tmp, res < sizeof (tmp) - 1 ? "" : "(trunc)");
     }
@@ -2212,8 +2215,8 @@ static int deliver_user_data (const struct nn_rsample_info *sampleinfo, const st
     if ((plist_ret = ddsi_plist_init_frommsg (&qos, NULL, PP_STATUSINFO | PP_KEYHASH | PP_COHERENT_SET, 0, &src, gv)) < 0)
     {
       if (plist_ret != DDS_RETCODE_UNSUPPORTED)
-        GVWARNING ("data(application, vendor %u.%u): "PGUIDFMT" #%"PRId64": invalid inline qos\n",
-                   src.vendorid.id[0], src.vendorid.id[1], PGUID (pwr->e.guid), sampleinfo->seq);
+        GVWARNING ("data(application, vendor %u.%u): "PGUIDFMT" #%"PRIu64": invalid inline qos\n",
+                   src.vendorid.id[0], src.vendorid.id[1], PGUID (pwr->e.guid), sampleinfo->seq.v);
       return 0;
     }
     statusinfo = (qos.present & PP_STATUSINFO) ? qos.statusinfo : 0;
@@ -2237,7 +2240,7 @@ static int deliver_user_data (const struct nn_rsample_info *sampleinfo, const st
   else
   {
     (void) deliver_locally_allinsync (gv, &pwr->e, pwr_locked != 0, &pwr->rdary, &wrinfo, &deliver_locally_ops, &sourceinfo);
-    ddsrt_atomic_st32 (&pwr->next_deliv_seq_lowword, (uint32_t) (sampleinfo->seq + 1));
+    ddsrt_atomic_st32 (&pwr->next_deliv_seq_lowword, (uint32_t) (sampleinfo->seq.v + 1));
   }
 
   ddsi_plist_fini (&qos);
@@ -2280,12 +2283,12 @@ static void clean_defrag (struct proxy_writer *pwr)
       if (wn->in_sync == PRMSS_OUT_OF_SYNC)
       {
         seqno_t seq1 = nn_reorder_next_seq (wn->u.not_in_sync.reorder);
-        if (seq1 < seq)
+        if (seq1.v < seq.v)
           seq = seq1;
       }
     }
   }
-  nn_defrag_notegap (pwr->defrag, 1, seq);
+  nn_defrag_notegap (pwr->defrag, (seqno_t){ 1 }, seq);
 }
 
 static void handle_regular (struct receiver_state *rst, ddsrt_etime_t tnow, struct nn_rmsg *rmsg, const Data_DataFrag_common_t *msg, const struct nn_rsample_info *sampleinfo,
@@ -2359,12 +2362,12 @@ static void handle_regular (struct receiver_state *rst, ddsrt_etime_t tnow, stru
   /* Track highest sequence number we know of -- we track both
      sequence number & fragment number so that the NACK generation can
      do the Right Thing. */
-  if (sampleinfo->seq > pwr->last_seq)
+  if (sampleinfo->seq.v > pwr->last_seq.v)
   {
     pwr->last_seq = sampleinfo->seq;
     pwr->last_fragnum = max_fragnum_in_msg;
   }
-  else if (sampleinfo->seq == pwr->last_seq && max_fragnum_in_msg > pwr->last_fragnum)
+  else if (sampleinfo->seq.v == pwr->last_seq.v && max_fragnum_in_msg > pwr->last_fragnum)
   {
     pwr->last_fragnum = max_fragnum_in_msg;
   }
@@ -2389,7 +2392,7 @@ static void handle_regular (struct receiver_state *rst, ddsrt_etime_t tnow, stru
           if (wn->filtered)
           {
             rres2 = nn_reorder_rsample (&sc, wn->u.not_in_sync.reorder, rsample, &refc_adjust, nn_dqueue_is_full (pwr->dqueue));
-            if (sampleinfo->seq > wn->last_seq)
+            if (sampleinfo->seq.v > wn->last_seq.v)
             {
               wn->last_seq = sampleinfo->seq;
             }
@@ -2419,7 +2422,7 @@ static void handle_regular (struct receiver_state *rst, ddsrt_etime_t tnow, stru
            will force delivery of this sample, and not cause the gap to
            be added to the reorder admin. */
         int gap_refc_adjust = 0;
-        rres = nn_reorder_gap (&sc, pwr->reorder, rdata, 1, sampleinfo->seq, &gap_refc_adjust);
+        rres = nn_reorder_gap (&sc, pwr->reorder, rdata, (seqno_t){ 1 }, sampleinfo->seq, &gap_refc_adjust);
         assert (rres > 0);
         assert (gap_refc_adjust == 0);
       }
@@ -2547,8 +2550,8 @@ static void drop_oversize (struct receiver_state *rst, struct nn_rmsg *rmsg, con
     if ((msg->writerId.u == NN_ENTITYID_SPDP_BUILTIN_PARTICIPANT_WRITER) ||
         (msg->writerId.u == NN_ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_WRITER))
     {
-      DDS_CWARNING (&rst->gv->logconfig, "dropping oversize (%"PRIu32" > %"PRIu32") SPDP sample %"PRId64" from remote writer "PGUIDFMT"\n",
-                    sampleinfo->size, rst->gv->config.max_sample_size, sampleinfo->seq,
+      DDS_CWARNING (&rst->gv->logconfig, "dropping oversize (%"PRIu32" > %"PRIu32") SPDP sample %"PRIu64" from remote writer "PGUIDFMT"\n",
+                    sampleinfo->size, rst->gv->config.max_sample_size, sampleinfo->seq.v,
                     PGUIDPREFIX (rst->src_guid_prefix), msg->writerId.u);
     }
   }
@@ -2569,7 +2572,7 @@ static void drop_oversize (struct receiver_state *rst, struct nn_rmsg *rmsg, con
 
     ddsrt_mutex_lock (&pwr->e.lock);
     wn = ddsrt_avl_lookup (&pwr_readers_treedef, &pwr->readers, &dst);
-    gap_was_valuable = handle_one_gap (pwr, wn, sampleinfo->seq, sampleinfo->seq+1, gap, &refc_adjust);
+    gap_was_valuable = handle_one_gap (pwr, wn, sampleinfo->seq, (seqno_t){ sampleinfo->seq.v+1 }, gap, &refc_adjust);
     nn_fragchain_adjust_refcount (gap, refc_adjust);
     ddsrt_mutex_unlock (&pwr->e.lock);
 
@@ -2577,8 +2580,8 @@ static void drop_oversize (struct receiver_state *rst, struct nn_rmsg *rmsg, con
     {
       const char *tname = (pwr->c.xqos->present & QP_TOPIC_NAME) ? pwr->c.xqos->topic_name : "(null)";
       const char *ttname = (pwr->c.xqos->present & QP_TYPE_NAME) ? pwr->c.xqos->type_name : "(null)";
-      DDS_CWARNING (&rst->gv->logconfig, "dropping oversize (%"PRIu32" > %"PRIu32") sample %"PRId64" from remote writer "PGUIDFMT" %s/%s\n",
-                    sampleinfo->size, rst->gv->config.max_sample_size, sampleinfo->seq,
+      DDS_CWARNING (&rst->gv->logconfig, "dropping oversize (%"PRIu32" > %"PRIu32") sample %"PRIu64" from remote writer "PGUIDFMT" %s/%s\n",
+                    sampleinfo->size, rst->gv->config.max_sample_size, sampleinfo->seq.v,
                     PGUIDPREFIX (rst->src_guid_prefix), msg->writerId.u,
                     tname, ttname);
     }
@@ -2587,10 +2590,10 @@ static void drop_oversize (struct receiver_state *rst, struct nn_rmsg *rmsg, con
 
 static int handle_Data (struct receiver_state *rst, ddsrt_etime_t tnow, struct nn_rmsg *rmsg, const Data_t *msg, size_t size, struct nn_rsample_info *sampleinfo, const ddsi_keyhash_t *keyhash, unsigned char *datap, struct nn_dqueue **deferred_wakeup, SubmessageKind_t prev_smid)
 {
-  RSTTRACE ("DATA("PGUIDFMT" -> "PGUIDFMT" #%"PRId64,
+  RSTTRACE ("DATA("PGUIDFMT" -> "PGUIDFMT" #%"PRIu64,
             PGUIDPREFIX (rst->src_guid_prefix), msg->x.writerId.u,
             PGUIDPREFIX (rst->dst_guid_prefix), msg->x.readerId.u,
-            fromSN (msg->x.writerSN));
+            fromSN (msg->x.writerSN).v);
   if (!rst->forme)
   {
     RSTTRACE (" not-for-me)");
@@ -2656,10 +2659,10 @@ static int handle_Data (struct receiver_state *rst, ddsrt_etime_t tnow, struct n
 
 static int handle_DataFrag (struct receiver_state *rst, ddsrt_etime_t tnow, struct nn_rmsg *rmsg, const DataFrag_t *msg, size_t size, struct nn_rsample_info *sampleinfo, const ddsi_keyhash_t *keyhash, unsigned char *datap, struct nn_dqueue **deferred_wakeup, SubmessageKind_t prev_smid)
 {
-  RSTTRACE ("DATAFRAG("PGUIDFMT" -> "PGUIDFMT" #%"PRId64"/[%"PRIu32"..%"PRIu32"]",
+  RSTTRACE ("DATAFRAG("PGUIDFMT" -> "PGUIDFMT" #%"PRIu64"/[%"PRIu32"..%"PRIu32"]",
             PGUIDPREFIX (rst->src_guid_prefix), msg->x.writerId.u,
             PGUIDPREFIX (rst->dst_guid_prefix), msg->x.readerId.u,
-            fromSN (msg->x.writerSN),
+            fromSN (msg->x.writerSN).v,
             msg->fragmentStartingNum, (nn_fragment_number_t) (msg->fragmentStartingNum + msg->fragmentsInSubmessage - 1));
   if (!rst->forme)
   {
@@ -2691,8 +2694,8 @@ static int handle_DataFrag (struct receiver_state *rst, ddsrt_etime_t tnow, stru
         case NN_ENTITYID_SPDP_BUILTIN_PARTICIPANT_WRITER:
         /* fall through */
         case NN_ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_WRITER:
-          DDS_CWARNING (&rst->gv->logconfig, "DATAFRAG("PGUIDFMT" #%"PRId64" -> "PGUIDFMT") - fragmented builtin data not yet supported\n",
-                        PGUIDPREFIX (rst->src_guid_prefix), msg->x.writerId.u, fromSN (msg->x.writerSN),
+          DDS_CWARNING (&rst->gv->logconfig, "DATAFRAG("PGUIDFMT" #%"PRIu64" -> "PGUIDFMT") - fragmented builtin data not yet supported\n",
+                        PGUIDPREFIX (rst->src_guid_prefix), msg->x.writerId.u, fromSN (msg->x.writerSN).v,
                         PGUIDPREFIX (rst->dst_guid_prefix), msg->x.readerId.u);
           return 1;
         case NN_ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_WRITER:
@@ -2832,56 +2835,56 @@ static void malformed_packet_received (const struct ddsi_domaingv *gv, const uns
       case SMID_ACKNACK:
         if (smsize >= sizeof (AckNack_t)) {
           const AckNack_t *x = (const AckNack_t *) submsg;
-          (void) snprintf (tmp + pos, sizeof (tmp) - pos, " rid 0x%"PRIx32" wid 0x%"PRIx32" base %"PRId64" numbits %"PRIu32,
-                           x->readerId.u, x->writerId.u, fromSN (x->readerSNState.bitmap_base),
+          (void) snprintf (tmp + pos, sizeof (tmp) - pos, " rid 0x%"PRIx32" wid 0x%"PRIx32" base %"PRIu64" numbits %"PRIu32,
+                           x->readerId.u, x->writerId.u, fromSN (x->readerSNState.bitmap_base).v,
                            x->readerSNState.numbits);
         }
         break;
       case SMID_HEARTBEAT:
         if (smsize >= sizeof (Heartbeat_t)) {
           const Heartbeat_t *x = (const Heartbeat_t *) submsg;
-          (void) snprintf (tmp + pos, sizeof (tmp) - pos, " rid 0x%"PRIx32" wid 0x%"PRIx32" first %"PRId64" last %"PRId64,
-                           x->readerId.u, x->writerId.u, fromSN (x->firstSN), fromSN (x->lastSN));
+          (void) snprintf (tmp + pos, sizeof (tmp) - pos, " rid 0x%"PRIx32" wid 0x%"PRIx32" first %"PRIu64" last %"PRIu64,
+                           x->readerId.u, x->writerId.u, fromSN (x->firstSN).v, fromSN (x->lastSN).v);
         }
         break;
       case SMID_GAP:
         if (smsize >= sizeof (Gap_t)) {
           const Gap_t *x = (const Gap_t *) submsg;
-          (void) snprintf (tmp + pos, sizeof (tmp) - pos, " rid 0x%"PRIx32" wid 0x%"PRIx32" gapstart %"PRId64" base %"PRId64" numbits %"PRIu32,
-                           x->readerId.u, x->writerId.u, fromSN (x->gapStart),
-                           fromSN (x->gapList.bitmap_base), x->gapList.numbits);
+          (void) snprintf (tmp + pos, sizeof (tmp) - pos, " rid 0x%"PRIx32" wid 0x%"PRIx32" gapstart %"PRIu64" base %"PRIu64" numbits %"PRIu32,
+                           x->readerId.u, x->writerId.u, fromSN (x->gapStart).v,
+                           fromSN (x->gapList.bitmap_base).v, x->gapList.numbits);
         }
         break;
       case SMID_NACK_FRAG:
         if (smsize >= sizeof (NackFrag_t)) {
           const NackFrag_t *x = (const NackFrag_t *) submsg;
-          (void) snprintf (tmp + pos, sizeof (tmp) - pos, " rid 0x%"PRIx32" wid 0x%"PRIx32" seq# %"PRId64" base %"PRIu32" numbits %"PRIu32,
-                           x->readerId.u, x->writerId.u, fromSN (x->writerSN),
+          (void) snprintf (tmp + pos, sizeof (tmp) - pos, " rid 0x%"PRIx32" wid 0x%"PRIx32" seq# %"PRIu64" base %"PRIu32" numbits %"PRIu32,
+                           x->readerId.u, x->writerId.u, fromSN (x->writerSN).v,
                            x->fragmentNumberState.bitmap_base, x->fragmentNumberState.numbits);
         }
         break;
       case SMID_HEARTBEAT_FRAG:
         if (smsize >= sizeof (HeartbeatFrag_t)) {
           const HeartbeatFrag_t *x = (const HeartbeatFrag_t *) submsg;
-          (void) snprintf (tmp + pos, sizeof (tmp) - pos, " rid 0x%"PRIx32" wid 0x%"PRIx32" seq %"PRId64" frag %"PRIu32,
-                           x->readerId.u, x->writerId.u, fromSN (x->writerSN),
+          (void) snprintf (tmp + pos, sizeof (tmp) - pos, " rid 0x%"PRIx32" wid 0x%"PRIx32" seq %"PRIu64" frag %"PRIu32,
+                           x->readerId.u, x->writerId.u, fromSN (x->writerSN).v,
                            x->lastFragmentNum);
         }
         break;
       case SMID_DATA:
         if (smsize >= sizeof (Data_t)) {
           const Data_t *x = (const Data_t *) submsg;
-          (void) snprintf (tmp + pos, sizeof (tmp) - pos, " xflags %x otiq %u rid 0x%"PRIx32" wid 0x%"PRIx32" seq %"PRId64,
+          (void) snprintf (tmp + pos, sizeof (tmp) - pos, " xflags %x otiq %u rid 0x%"PRIx32" wid 0x%"PRIx32" seq %"PRIu64,
                            x->x.extraFlags, x->x.octetsToInlineQos,
-                           x->x.readerId.u, x->x.writerId.u, fromSN (x->x.writerSN));
+                           x->x.readerId.u, x->x.writerId.u, fromSN (x->x.writerSN).v);
         }
         break;
       case SMID_DATA_FRAG:
         if (smsize >= sizeof (DataFrag_t)) {
           const DataFrag_t *x = (const DataFrag_t *) submsg;
-          (void) snprintf (tmp + pos, sizeof (tmp) - pos, " xflags %x otiq %u rid 0x%"PRIx32" wid 0x%"PRIx32" seq %"PRId64" frag %"PRIu32"  fragsinmsg %"PRIu16" fragsize %"PRIu16" samplesize %"PRIu32,
+          (void) snprintf (tmp + pos, sizeof (tmp) - pos, " xflags %x otiq %u rid 0x%"PRIx32" wid 0x%"PRIx32" seq %"PRIu64" frag %"PRIu32"  fragsinmsg %"PRIu16" fragsize %"PRIu16" samplesize %"PRIu32,
                            x->x.extraFlags, x->x.octetsToInlineQos,
-                           x->x.readerId.u, x->x.writerId.u, fromSN (x->x.writerSN),
+                           x->x.readerId.u, x->x.writerId.u, fromSN (x->x.writerSN).v,
                            x->fragmentStartingNum, x->fragmentsInSubmessage, x->fragmentSize, x->sampleSize);
         }
         break;

--- a/src/core/ddsi/src/q_transmit.c
+++ b/src/core/ddsi/src/q_transmit.c
@@ -962,7 +962,7 @@ static int insert_sample_in_whc (struct writer *wr, seqno_t seq, struct ddsi_pli
       uint32_t n = whc_remove_acked_messages (wr->whc, seq, &whcst, &deferred_free_list);
       (void)n;
       assert (n <= 1);
-      assert (whcst.min_seq == -1 && whcst.max_seq == -1);
+      assert (whcst.min_seq == 0 && whcst.max_seq == 0);
       whc_free_deferred_free_list (wr->whc, deferred_free_list);
     }
 #endif

--- a/src/core/ddsi/src/q_xmsg.c
+++ b/src/core/ddsi/src/q_xmsg.c
@@ -444,8 +444,8 @@ int nn_xmsg_compare_fragid (const struct nn_xmsg *a, const struct nn_xmsg *b)
      seq, frag */
   if ((c = memcmp (&a->kindspecific.data.wrguid, &b->kindspecific.data.wrguid, sizeof (a->kindspecific.data.wrguid))) != 0)
     return c;
-  else if (a->kindspecific.data.wrseq.v != b->kindspecific.data.wrseq.v)
-    return (a->kindspecific.data.wrseq.v < b->kindspecific.data.wrseq.v) ? -1 : 1;
+  else if (a->kindspecific.data.wrseq != b->kindspecific.data.wrseq)
+    return (a->kindspecific.data.wrseq < b->kindspecific.data.wrseq) ? -1 : 1;
   else if (a->kindspecific.data.wrfragid != b->kindspecific.data.wrfragid)
     return (a->kindspecific.data.wrfragid < b->kindspecific.data.wrfragid) ? -1 : 1;
   else
@@ -810,18 +810,18 @@ static int readerId_compatible (const struct nn_xmsg *m, const struct nn_xmsg *m
 
 int nn_xmsg_merge_rexmit_destinations_wrlock_held (struct ddsi_domaingv *gv, struct nn_xmsg *m, const struct nn_xmsg *madd)
 {
-  assert (m->kindspecific.data.wrseq.v >= 1);
+  assert (m->kindspecific.data.wrseq >= 1);
   assert (m->kindspecific.data.wrguid.prefix.u[0] != 0);
   assert (is_writer_entityid (m->kindspecific.data.wrguid.entityid));
   assert (memcmp (&m->kindspecific.data.wrguid, &madd->kindspecific.data.wrguid, sizeof (m->kindspecific.data.wrguid)) == 0);
-  assert (m->kindspecific.data.wrseq.v == madd->kindspecific.data.wrseq.v);
+  assert (m->kindspecific.data.wrseq == madd->kindspecific.data.wrseq);
   assert (m->kindspecific.data.wrfragid == madd->kindspecific.data.wrfragid);
   assert (m->kind == NN_XMSG_KIND_DATA_REXMIT);
   assert (madd->kind == NN_XMSG_KIND_DATA_REXMIT);
   assert (m->kindspecific.data.readerId_off != 0);
   assert (madd->kindspecific.data.readerId_off != 0);
 
-  GVTRACE (" ("PGUIDFMT"#%"PRId64"/%"PRIu32":", PGUID (m->kindspecific.data.wrguid), m->kindspecific.data.wrseq.v, m->kindspecific.data.wrfragid + 1);
+  GVTRACE (" ("PGUIDFMT"#%"PRId64"/%"PRIu32":", PGUID (m->kindspecific.data.wrguid), m->kindspecific.data.wrseq, m->kindspecific.data.wrfragid + 1);
 
   switch (m->dstmode)
   {
@@ -1030,7 +1030,7 @@ static void nn_xmsg_chain_release (struct ddsi_domaingv *gv, struct nn_xmsg_chai
           wrguid.entityid.u != m->kindspecific.data.wrguid.entityid.u)
       {
         struct writer *wr;
-        assert (m->kindspecific.data.wrseq.v != 0);
+        assert (m->kindspecific.data.wrseq != 0);
         wrguid = m->kindspecific.data.wrguid;
         if ((wr = entidx_lookup_writer_guid (gv->entity_index, &m->kindspecific.data.wrguid)) != NULL)
           writer_update_seq_xmit (wr, m->kindspecific.data.wrseq);
@@ -1595,7 +1595,7 @@ int nn_xpack_addmsg (struct nn_xpack *xp, struct nn_xmsg *m, const uint32_t flag
       GVTRACE ("%s("PGUIDFMT":#%"PRId64"/%"PRIu32")",
                (m->kind == NN_XMSG_KIND_DATA) ? "data" : "rexmit",
                PGUID (m->kindspecific.data.wrguid),
-               m->kindspecific.data.wrseq.v,
+               m->kindspecific.data.wrseq,
                m->kindspecific.data.wrfragid + 1);
       break;
   }

--- a/src/core/ddsi/src/q_xmsg.c
+++ b/src/core/ddsi/src/q_xmsg.c
@@ -444,8 +444,8 @@ int nn_xmsg_compare_fragid (const struct nn_xmsg *a, const struct nn_xmsg *b)
      seq, frag */
   if ((c = memcmp (&a->kindspecific.data.wrguid, &b->kindspecific.data.wrguid, sizeof (a->kindspecific.data.wrguid))) != 0)
     return c;
-  else if (a->kindspecific.data.wrseq != b->kindspecific.data.wrseq)
-    return (a->kindspecific.data.wrseq < b->kindspecific.data.wrseq) ? -1 : 1;
+  else if (a->kindspecific.data.wrseq.v != b->kindspecific.data.wrseq.v)
+    return (a->kindspecific.data.wrseq.v < b->kindspecific.data.wrseq.v) ? -1 : 1;
   else if (a->kindspecific.data.wrfragid != b->kindspecific.data.wrfragid)
     return (a->kindspecific.data.wrfragid < b->kindspecific.data.wrfragid) ? -1 : 1;
   else
@@ -810,18 +810,18 @@ static int readerId_compatible (const struct nn_xmsg *m, const struct nn_xmsg *m
 
 int nn_xmsg_merge_rexmit_destinations_wrlock_held (struct ddsi_domaingv *gv, struct nn_xmsg *m, const struct nn_xmsg *madd)
 {
-  assert (m->kindspecific.data.wrseq >= 1);
+  assert (m->kindspecific.data.wrseq.v >= 1);
   assert (m->kindspecific.data.wrguid.prefix.u[0] != 0);
   assert (is_writer_entityid (m->kindspecific.data.wrguid.entityid));
   assert (memcmp (&m->kindspecific.data.wrguid, &madd->kindspecific.data.wrguid, sizeof (m->kindspecific.data.wrguid)) == 0);
-  assert (m->kindspecific.data.wrseq == madd->kindspecific.data.wrseq);
+  assert (m->kindspecific.data.wrseq.v == madd->kindspecific.data.wrseq.v);
   assert (m->kindspecific.data.wrfragid == madd->kindspecific.data.wrfragid);
   assert (m->kind == NN_XMSG_KIND_DATA_REXMIT);
   assert (madd->kind == NN_XMSG_KIND_DATA_REXMIT);
   assert (m->kindspecific.data.readerId_off != 0);
   assert (madd->kindspecific.data.readerId_off != 0);
 
-  GVTRACE (" ("PGUIDFMT"#%"PRId64"/%"PRIu32":", PGUID (m->kindspecific.data.wrguid), m->kindspecific.data.wrseq, m->kindspecific.data.wrfragid + 1);
+  GVTRACE (" ("PGUIDFMT"#%"PRId64"/%"PRIu32":", PGUID (m->kindspecific.data.wrguid), m->kindspecific.data.wrseq.v, m->kindspecific.data.wrfragid + 1);
 
   switch (m->dstmode)
   {
@@ -1030,7 +1030,7 @@ static void nn_xmsg_chain_release (struct ddsi_domaingv *gv, struct nn_xmsg_chai
           wrguid.entityid.u != m->kindspecific.data.wrguid.entityid.u)
       {
         struct writer *wr;
-        assert (m->kindspecific.data.wrseq != 0);
+        assert (m->kindspecific.data.wrseq.v != 0);
         wrguid = m->kindspecific.data.wrguid;
         if ((wr = entidx_lookup_writer_guid (gv->entity_index, &m->kindspecific.data.wrguid)) != NULL)
           writer_update_seq_xmit (wr, m->kindspecific.data.wrseq);
@@ -1595,7 +1595,7 @@ int nn_xpack_addmsg (struct nn_xpack *xp, struct nn_xmsg *m, const uint32_t flag
       GVTRACE ("%s("PGUIDFMT":#%"PRId64"/%"PRIu32")",
                (m->kind == NN_XMSG_KIND_DATA) ? "data" : "rexmit",
                PGUID (m->kindspecific.data.wrguid),
-               m->kindspecific.data.wrseq,
+               m->kindspecific.data.wrseq.v,
                m->kindspecific.data.wrfragid + 1);
       break;
   }

--- a/src/core/ddsi/tests/security_msg.c
+++ b/src/core/ddsi/tests/security_msg.c
@@ -19,11 +19,11 @@
 
 static nn_participant_generic_message_t test_msg_in =
 {
-  .message_identity             = { {{.u={1,2,3}},{4}}, {5} },
-  .related_message_identity     = { {{.u={5,4,3}},{2}}, {1} },
-  .destination_participant_guid = {  {.u={2,3,4}},{5}       },
-  .destination_endpoint_guid    = {  {.u={3,4,5}},{6}       },
-  .source_endpoint_guid         = {  {.u={4,5,6}},{7}       },
+  .message_identity             = { {{.u={1,2,3}},{4}}, 5 },
+  .related_message_identity     = { {{.u={5,4,3}},{2}}, 1 },
+  .destination_participant_guid = {  {.u={2,3,4}},{5}     },
+  .destination_endpoint_guid    = {  {.u={3,4,5}},{6}     },
+  .source_endpoint_guid         = {  {.u={4,5,6}},{7}     },
   .message_class_id             = "testing message",
   .message_data                 = {
      .n = 4,
@@ -147,11 +147,11 @@ static nn_participant_generic_message_t test_msg_in =
 /* Same as test_msg_in, excluding the non-propagated properties. */
 static nn_participant_generic_message_t test_msg_out =
 {
-  .message_identity             = { {{.u={1,2,3}},{4}}, {5} },
-  .related_message_identity     = { {{.u={5,4,3}},{2}}, {1} },
-  .destination_participant_guid = {  {.u={2,3,4}},{5}       },
-  .destination_endpoint_guid    = {  {.u={3,4,5}},{6}       },
-  .source_endpoint_guid         = {  {.u={4,5,6}},{7}       },
+  .message_identity             = { {{.u={1,2,3}},{4}}, 5 },
+  .related_message_identity     = { {{.u={5,4,3}},{2}}, 1 },
+  .destination_participant_guid = {  {.u={2,3,4}},{5}     },
+  .destination_endpoint_guid    = {  {.u={3,4,5}},{6}     },
+  .source_endpoint_guid         = {  {.u={4,5,6}},{7}     },
   .message_class_id             = "testing message",
   .message_data                 = {
      .n = 4,

--- a/src/core/ddsi/tests/security_msg.c
+++ b/src/core/ddsi/tests/security_msg.c
@@ -19,11 +19,11 @@
 
 static nn_participant_generic_message_t test_msg_in =
 {
-  .message_identity             = { {{.u={1,2,3}},{4}}, 5 },
-  .related_message_identity     = { {{.u={5,4,3}},{2}}, 1 },
-  .destination_participant_guid = {  {.u={2,3,4}},{5}     },
-  .destination_endpoint_guid    = {  {.u={3,4,5}},{6}     },
-  .source_endpoint_guid         = {  {.u={4,5,6}},{7}     },
+  .message_identity             = { {{.u={1,2,3}},{4}}, {5} },
+  .related_message_identity     = { {{.u={5,4,3}},{2}}, {1} },
+  .destination_participant_guid = {  {.u={2,3,4}},{5}       },
+  .destination_endpoint_guid    = {  {.u={3,4,5}},{6}       },
+  .source_endpoint_guid         = {  {.u={4,5,6}},{7}       },
   .message_class_id             = "testing message",
   .message_data                 = {
      .n = 4,
@@ -147,11 +147,11 @@ static nn_participant_generic_message_t test_msg_in =
 /* Same as test_msg_in, excluding the non-propagated properties. */
 static nn_participant_generic_message_t test_msg_out =
 {
-  .message_identity             = { {{.u={1,2,3}},{4}}, 5 },
-  .related_message_identity     = { {{.u={5,4,3}},{2}}, 1 },
-  .destination_participant_guid = {  {.u={2,3,4}},{5}     },
-  .destination_endpoint_guid    = {  {.u={3,4,5}},{6}     },
-  .source_endpoint_guid         = {  {.u={4,5,6}},{7}     },
+  .message_identity             = { {{.u={1,2,3}},{4}}, {5} },
+  .related_message_identity     = { {{.u={5,4,3}},{2}}, {1} },
+  .destination_participant_guid = {  {.u={2,3,4}},{5}       },
+  .destination_endpoint_guid    = {  {.u={3,4,5}},{6}       },
+  .source_endpoint_guid         = {  {.u={4,5,6}},{7}       },
   .message_class_id             = "testing message",
   .message_data                 = {
      .n = 4,


### PR DESCRIPTION
There are some issues handling sequence number 2**63-1 (the maximum sequence number allowed by the spec), representing them as unsigned numbers fixes those issues.

The first few commits deal with some cleanups to prepare the code base by removing the few cases where -1 was used and by consistently using the `seqno_t` type for sequence numbers.

The next-to-last commit is the actual transformation. In addition to making the representation unsigned, it also wraps it in a struct to guarantee that all arithmetical and relational operations turn into compile-time errors. This ensures that every potentially problematic case must be inspected. It eliminates the risk of overlooking a usage, it doesn't guarantee that the inspection and manual modification is correct.

The final commit is a (mostly mechanical) rewrite to remove the wrapper.