### PR TITLE
Must-understand annotation for struct members

### DIFF
--- a/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
@@ -56,6 +56,7 @@ enum dds_stream_opcode {
   /* return from subroutine, exits top-level
      [RTS,   0,   0, 0] */
   DDS_OP_RTS = 0x00 << 24,
+
   /* data field
      [ADR, nBY,   0, f] [offset]
      [ADR, ENU,   0, f] [offset] [max]
@@ -108,6 +109,7 @@ enum dds_stream_opcode {
      [cases]      = (unsigned 16 bits) offset to first case label, from start of insn
    */
   DDS_OP_ADR = 0x01 << 24,
+
   /* jump-to-subroutine (e.g. used for recursive types and appendable unions)
      [JSR,   0, e]
        where
@@ -115,6 +117,7 @@ enum dds_stream_opcode {
              instruction sequence must end in RTS, execution resumes at instruction
              following JSR */
   DDS_OP_JSR = 0x02 << 24,
+
   /* jump-if-equal, used for union cases:
      [JEQ, nBY, 0] [disc] [offset]
      [JEQ, STR, 0] [disc] [offset]
@@ -130,6 +133,10 @@ enum dds_stream_opcode {
          i  = (unsigned 16 bits) offset to first instruction for case, from start of insn
               instruction sequence must end in RTS, at which point executes continues
               at the next field's instruction as specified by the union
+
+      Note that the JEQ instruction is deprecated and replaced by the JEQ4 instruction. The
+      IDL compiler only generates JEQ4 for union cases, the JEQ instruction is included here
+      for backwards compatibility (topic descriptors generated with a previous version of IDLC)
   */
   DDS_OP_JEQ = 0x03 << 24,
 

--- a/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
@@ -97,6 +97,7 @@ enum dds_stream_opcode {
                     - key/not key (DDS_OP_FLAG_KEY)
                     - base type member, used with EXT type (DDS_OP_FLAG_BASE)
                     - optional (DDS_OP_FLAG_OPT)
+                    - must-understand (DDS_OP_FLAG_MU)
      [offset]     = field offset from start of element in memory
      [elem-size]  = element size in memory (elem-size is only included in case 'external' flag is set)
      [max-size]   = string bound + 1

--- a/src/core/ddsc/tests/CMakeLists.txt
+++ b/src/core/ddsc/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ idlc_generate(TARGET DataRepresentationTypes FILES DataRepresentationTypes.idl)
 idlc_generate(TARGET MinXcdrVersion FILES MinXcdrVersion.idl)
 idlc_generate(TARGET XSpace FILES XSpace.idl)
 idlc_generate(TARGET CdrStreamOptimize FILES CdrStreamOptimize.idl)
+idlc_generate(TARGET XSpaceMustUnderstand FILES XSpaceMustUnderstand.idl)
 
 set(ddsc_test_sources
     "basic.c"
@@ -110,7 +111,7 @@ if(iceoryx_binding_c_FOUND)
     "$<BUILD_INTERFACE:$<TARGET_PROPERTY:iceoryx_binding_c::iceoryx_binding_c,INTERFACE_INCLUDE_DIRECTORIES>>")
 endif()
 target_link_libraries(cunit_ddsc PRIVATE
-  RoundTrip Space XSpace TypesArrayKey WriteTypes InstanceHandleTypes RWData CreateWriter DataRepresentationTypes MinXcdrVersion CdrStreamOptimize ddsc)
+  RoundTrip Space XSpace XSpaceMustUnderstand TypesArrayKey WriteTypes InstanceHandleTypes RWData CreateWriter DataRepresentationTypes MinXcdrVersion CdrStreamOptimize ddsc)
 
 # Setup environment for config-tests
 get_test_property(CUnit_ddsc_config_simple_udp ENVIRONMENT CUnit_ddsc_config_simple_udp_env)

--- a/src/core/ddsc/tests/XSpaceMustUnderstand.idl
+++ b/src/core/ddsc/tests/XSpaceMustUnderstand.idl
@@ -1,0 +1,88 @@
+/*
+ * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+module XSpaceMustUnderstand {
+
+  // type 1: mutable type
+  @mutable
+  struct rd1
+  {
+    long f1;
+  };
+
+  // not assignable (non-optional m-u field not in rd type)
+  @mutable
+  struct wr1_1
+  {
+    long f1;
+    @must_understand long f2;
+  };
+
+  // assignable
+  // read sample { 1 }
+  @mutable
+  struct wr1_2
+  {
+    @must_understand long f1;
+  };
+
+  // assignable
+  // read sample { 1, NULL }
+  // drop sample { 1, 1 }
+  @mutable
+  struct wr1_3
+  {
+    long f1;
+    @optional @must_understand long f2;
+  };
+
+  // assignable (optional attribute matching rd type not required for mutable types)
+  // read sample { NULL }
+  // read sample { 1 }
+  @mutable
+  struct wr1_4
+  {
+    @optional @must_understand long f1;
+  };
+
+
+
+  // type 2: nested mutable type
+  @nested @mutable
+  struct n2
+  {
+    long f1;
+  };
+
+  @nested @mutable
+  struct n2_mu
+  {
+    long f1;
+    @optional @must_understand long f2;
+  };
+
+  @final
+  struct rd2
+  {
+    n2 f1;
+  };
+
+  // assignable
+  // read sample { { 1, NULL } }
+  // drop sample { { 1, 1 } }
+  @final
+  struct wr2_1
+  {
+    n2_mu f1;
+  };
+
+};

--- a/src/core/ddsi/src/ddsi_cdrstream.c
+++ b/src/core/ddsi/src/ddsi_cdrstream.c
@@ -2317,7 +2317,7 @@ static const uint32_t *stream_normalize_pl (char * __restrict data, uint32_t * _
     if (!read_and_normalize_uint32 (&em_hdr, data, off, size1, bswap))
       return NULL;
     uint32_t lc = EMHEADER_LENGTH_CODE (em_hdr), m_id = EMHEADER_MEMBERID (em_hdr), msz;
-    bool must_understand = (em_hdr & EMHEADER_FLAG_MASK) & EMHEADER_FLAG_MUSTUNDERSTAND;
+    bool must_understand = em_hdr & EMHEADER_FLAG_MUSTUNDERSTAND;
     switch (lc)
     {
       case LENGTH_CODE_1B: case LENGTH_CODE_2B: case LENGTH_CODE_4B: case LENGTH_CODE_8B:

--- a/src/idl/include/idl/tree.h
+++ b/src/idl/include/idl/tree.h
@@ -520,6 +520,7 @@ IDL_EXPORT bool idl_is_topic_key(const void *node, bool keylist, const idl_path_
 IDL_EXPORT bool idl_is_extensible(const idl_node_t *node, idl_extensibility_t extensibility);
 IDL_EXPORT bool idl_is_external(const idl_node_t *node);
 IDL_EXPORT bool idl_is_optional(const idl_node_t *node);
+IDL_EXPORT bool idl_is_must_understand(const idl_node_t *node);
 IDL_EXPORT int64_t idl_case_label_intvalue(const void *ptr);
 
 /* accessors */

--- a/src/idl/src/tree.c
+++ b/src/idl/src/tree.c
@@ -3516,3 +3516,8 @@ bool idl_is_optional(const idl_node_t *node)
 {
   return (idl_is_member(node) && ((idl_member_t *)node)->optional.value);
 }
+
+bool idl_is_must_understand(const idl_node_t *node)
+{
+  return (idl_is_member(node) && ((idl_member_t *)node)->must_understand.value);
+}

--- a/src/idl/tests/annotation.c
+++ b/src/idl/tests/annotation.c
@@ -301,7 +301,7 @@ static void test_key(key_test_t test)
 CU_Test(idl_annotation, key)
 {
   key_test_t tests[] = {
-    {"struct s {\n"
+    {"@mutable struct s {\n"
      "  @key char a;\n"
      "  @key(TRUE) char b;\n"
      "  @key(FALSE) char c;\n"
@@ -317,7 +317,7 @@ CU_Test(idl_annotation, key)
      " case 0: char c;\n"
      " case 1: @key double d;\n"
      "};", IDL_RETCODE_SEMANTIC_ERROR, {false}, {false}},
-    {"struct s {\n"
+    {"@mutable struct s {\n"
      "  @must_understand(FALSE) @key char c;\n"
      "};", IDL_RETCODE_SEMANTIC_ERROR, {false}, {false}},
     {"struct s {\n"
@@ -1042,7 +1042,11 @@ static void test_must_understand(mu_test_t test)
 CU_Test(idl_annotation, must_understand)
 {
   mu_test_t tests[] = {
-    {"struct s { char c; @must_understand char d; @must_understand(false) char e; @key @must_understand(true) char f; };", IDL_RETCODE_OK, {false, true, false, true}, {false, true, true, true} },
+    {"@mutable struct s { char c; @must_understand char d; @must_understand(false) char e; @key @must_understand(true) char f; };", IDL_RETCODE_OK, {false, true, false, true}, {false, true, true, true} },
+    {"@final struct s { @must_understand char c;  };", IDL_RETCODE_SEMANTIC_ERROR, {false}, {false} },
+    {"@final struct s { @must_understand(false) char c;  };", IDL_RETCODE_OK, {false}, {true} },
+    {"@appendable struct s { @must_understand char c;  };", IDL_RETCODE_SEMANTIC_ERROR, {false}, {false} },
+    {"@appendable struct s { @must_understand(false) char c;  };", IDL_RETCODE_OK, {false}, {true} },
     {"struct s { @key @must_understand(false) char c;  };", IDL_RETCODE_SEMANTIC_ERROR, {false}, {false} },
     {"@must_understand struct s { char b; char c; };", IDL_RETCODE_SEMANTIC_ERROR, {false}, {false} },
     {"@must_understand module m { struct s { char b; char c; }; }; ", IDL_RETCODE_SEMANTIC_ERROR, {false}, {false} },

--- a/src/tools/idlc/src/descriptor.c
+++ b/src/tools/idlc/src/descriptor.c
@@ -347,10 +347,10 @@ stash_jeq_offset(
 }
 
 static idl_retcode_t
-stash_member_offset(
-  const idl_pstate_t *pstate, struct instructions *instructions, uint32_t index, int16_t addr_offs)
+stash_mutable_member_offset(
+  const idl_pstate_t *pstate, struct instructions *instructions, uint32_t index, uint32_t opcode, int16_t addr_offs)
 {
-  struct instruction inst = { MEMBER_OFFSET, { .inst_offset = { .addr_offs = addr_offs } } };
+  struct instruction inst = { MEMBER_OFFSET, { .inst_offset = { .inst.opcode = opcode, .addr_offs = addr_offs } } };
   return stash_instruction(pstate, instructions, index, &inst);
 }
 
@@ -699,18 +699,22 @@ static idl_retcode_t
 add_mutable_member_offset(
   const idl_pstate_t *pstate,
   struct constructed_type *ctype,
-  uint32_t id)
+  uint32_t id,
+  bool must_understand)
 {
   idl_retcode_t ret;
   assert(idl_is_extensible(ctype->node, IDL_MUTABLE));
 
   /* add member offset for declarators of mutable types */
+  uint32_t opcode = DDS_OP_PLM;
+  if (must_understand)
+    opcode |= (DDS_OP_FLAG_MU << 16);
   assert(ctype->instructions.count <= INT16_MAX);
   int16_t addr_offs = (int16_t)(ctype->instructions.count
       - ctype->pl_offset /* offset of first op after PLC */
       + 2 /* skip this JEQ and member id */
       + 1 /* skip RTS (of the PLC list) */);
-  if ((ret = stash_member_offset(pstate, &ctype->instructions, ctype->pl_offset++, addr_offs)) ||
+  if ((ret = stash_mutable_member_offset(pstate, &ctype->instructions, ctype->pl_offset++, opcode, addr_offs)) ||
       (ret = stash_single(pstate, &ctype->instructions, ctype->pl_offset++, id)))
     return ret;
 
@@ -1388,6 +1392,7 @@ emit_declarator(
   struct descriptor *descriptor = user_data;
   struct stack_type *stype = descriptor->type_stack;
   struct constructed_type *ctype = stype->ctype;
+  idl_node_t *parent = idl_parent(node);
   bool mutable_aggr_type_member = idl_is_extensible(ctype->node, IDL_MUTABLE) &&
     (idl_is_member(idl_parent(node)) || idl_is_case(idl_parent(node)));
 
@@ -1396,7 +1401,7 @@ emit_declarator(
   /* delegate array type specifiers or declarators */
   if (idl_is_array(node) || idl_is_array(type_spec)) {
     if (!revisit && mutable_aggr_type_member) {
-      if ((ret = add_mutable_member_offset(pstate, ctype, ((idl_declarator_t *)node)->id.value)))
+      if ((ret = add_mutable_member_offset(pstate, ctype, ((idl_declarator_t *)node)->id.value, idl_is_must_understand(parent))))
         return ret;
     }
 
@@ -1426,7 +1431,7 @@ emit_declarator(
     uint32_t order = 0;
     struct field *field = NULL;
 
-    if (mutable_aggr_type_member && (ret = add_mutable_member_offset(pstate, ctype, ((idl_declarator_t *)node)->id.value)))
+    if (mutable_aggr_type_member && (ret = add_mutable_member_offset(pstate, ctype, ((idl_declarator_t *)node)->id.value, idl_is_must_understand(parent))))
       return ret;
 
     if (!idl_is_alias(node) && idl_is_struct(stype->node)) {
@@ -1446,7 +1451,6 @@ emit_declarator(
     assert(ctype->instructions.count <= INT16_MAX);
     int16_t addr_offs = (int16_t)ctype->instructions.count;
     bool has_size = false;
-    idl_node_t *parent = idl_parent(node);
     bool keylist = (pstate->flags & IDL_FLAG_KEYLIST) != 0;
     opcode = DDS_OP_ADR;
     if ((ret = add_typecode(pstate, type_spec, TYPE, true, &opcode)))
@@ -1472,6 +1476,8 @@ emit_declarator(
       if (DDS_OP_TYPE(opcode) == DDS_OP_VAL_EXT)
         has_size = true;
     }
+    if (idl_is_must_understand(parent))
+      opcode |= DDS_OP_FLAG_MU;
 
     /* use member id for key ordering */
     order = ((idl_declarator_t *)node)->id.value;
@@ -1511,7 +1517,6 @@ static int print_opcode(FILE *fp, const struct instruction *inst)
   const char *vec[10];
   size_t len = 0;
   enum dds_stream_opcode opcode;
-  enum dds_stream_typecode type, subtype;
 
   assert(inst->type == OPCODE);
 
@@ -1548,42 +1553,53 @@ static int print_opcode(FILE *fp, const struct instruction *inst)
       break;
   }
 
-  if ((opcode == DDS_OP_ADR || opcode == DDS_OP_JEQ4) && inst->data.opcode.code & DDS_OP_FLAG_EXT)
-    vec[len++] = " | DDS_OP_FLAG_EXT";
-
-  type = DDS_OP_TYPE(inst->data.opcode.code);
-  assert(opcode == DDS_OP_PLM || type);
-  switch (type) {
-    case DDS_OP_VAL_1BY: vec[len++] = " | DDS_OP_TYPE_1BY"; break;
-    case DDS_OP_VAL_2BY: vec[len++] = " | DDS_OP_TYPE_2BY"; break;
-    case DDS_OP_VAL_4BY: vec[len++] = " | DDS_OP_TYPE_4BY"; break;
-    case DDS_OP_VAL_8BY: vec[len++] = " | DDS_OP_TYPE_8BY"; break;
-    case DDS_OP_VAL_STR: vec[len++] = " | DDS_OP_TYPE_STR"; break;
-    case DDS_OP_VAL_BST: vec[len++] = " | DDS_OP_TYPE_BST"; break;
-    case DDS_OP_VAL_SEQ: vec[len++] = " | DDS_OP_TYPE_SEQ"; break;
-    case DDS_OP_VAL_ARR: vec[len++] = " | DDS_OP_TYPE_ARR"; break;
-    case DDS_OP_VAL_UNI: vec[len++] = " | DDS_OP_TYPE_UNI"; break;
-    case DDS_OP_VAL_STU: vec[len++] = " | DDS_OP_TYPE_STU"; break;
-    case DDS_OP_VAL_ENU: vec[len++] = " | DDS_OP_TYPE_ENU"; break;
-    case DDS_OP_VAL_EXT: vec[len++] = " | DDS_OP_TYPE_EXT"; break;
+  if (opcode == DDS_OP_ADR || opcode == DDS_OP_JEQ4) {
+    if (inst->data.opcode.code & DDS_OP_FLAG_EXT)
+      vec[len++] = " | DDS_OP_FLAG_EXT";
+    switch (DDS_OP_TYPE(inst->data.opcode.code)) {
+      case DDS_OP_VAL_1BY: vec[len++] = " | DDS_OP_TYPE_1BY"; break;
+      case DDS_OP_VAL_2BY: vec[len++] = " | DDS_OP_TYPE_2BY"; break;
+      case DDS_OP_VAL_4BY: vec[len++] = " | DDS_OP_TYPE_4BY"; break;
+      case DDS_OP_VAL_8BY: vec[len++] = " | DDS_OP_TYPE_8BY"; break;
+      case DDS_OP_VAL_STR: vec[len++] = " | DDS_OP_TYPE_STR"; break;
+      case DDS_OP_VAL_BST: vec[len++] = " | DDS_OP_TYPE_BST"; break;
+      case DDS_OP_VAL_SEQ: vec[len++] = " | DDS_OP_TYPE_SEQ"; break;
+      case DDS_OP_VAL_ARR: vec[len++] = " | DDS_OP_TYPE_ARR"; break;
+      case DDS_OP_VAL_UNI: vec[len++] = " | DDS_OP_TYPE_UNI"; break;
+      case DDS_OP_VAL_STU: vec[len++] = " | DDS_OP_TYPE_STU"; break;
+      case DDS_OP_VAL_ENU: vec[len++] = " | DDS_OP_TYPE_ENU"; break;
+      case DDS_OP_VAL_EXT: vec[len++] = " | DDS_OP_TYPE_EXT"; break;
+    }
   }
 
-  /* FLAG_BASE to indicate inheritance in PLM list or EXT 'parent' field */
   if (opcode == DDS_OP_ADR) {
+    /* FLAG_BASE to indicate EXT 'parent' field */
     if (inst->data.opcode.code & DDS_OP_FLAG_BASE)
       vec[len++] = " | DDS_OP_FLAG_BASE";
+    /* Must-understand */
+    if (inst->data.opcode.code & DDS_OP_FLAG_MU)
+      vec[len++] = " | DDS_OP_FLAG_MU";
+    /* Optional */
     if (inst->data.opcode.code & DDS_OP_FLAG_OPT)
       vec[len++] = " | DDS_OP_FLAG_OPT";
   }
-  if (opcode == DDS_OP_PLM && (DDS_PLM_FLAGS(inst->data.opcode.code) & DDS_OP_FLAG_BASE))
-    vec[len++] = " | (DDS_OP_FLAG_BASE << 16)";
+  if (opcode == DDS_OP_PLM) {
+    /* FLAG_BASE to indicate inheritance in PLM list */
+    if (DDS_PLM_FLAGS(inst->data.opcode.code) & DDS_OP_FLAG_BASE)
+      vec[len++] = " | (DDS_OP_FLAG_BASE << 16)";
+    /* Must-understand flag for mutable types set on PLM instruction */
+    if (DDS_PLM_FLAGS(inst->data.opcode.code) & DDS_OP_FLAG_MU)
+      vec[len++] = " | (DDS_OP_FLAG_MU << 16)";
+  }
 
   if (opcode == DDS_OP_JEQ || opcode == DDS_OP_JEQ4 || opcode == DDS_OP_PLM) {
     /* lower 16 bits contain an offset */
     idl_snprintf(buf, sizeof(buf), " | %u", (uint16_t) DDS_OP_JUMP (inst->data.opcode.code));
     vec[len++] = buf;
   } else {
-    subtype = DDS_OP_SUBTYPE(inst->data.opcode.code);
+    assert(opcode == DDS_OP_ADR);
+    enum dds_stream_typecode type = DDS_OP_TYPE(inst->data.opcode.code);
+    enum dds_stream_typecode subtype = DDS_OP_SUBTYPE(inst->data.opcode.code);
     assert(( subtype &&  (type == DDS_OP_VAL_SEQ ||
                           type == DDS_OP_VAL_ARR ||
                           type == DDS_OP_VAL_UNI ||
@@ -1763,7 +1779,7 @@ static int print_opcodes(FILE *fp, const struct descriptor *descriptor, uint32_t
         }
         case MEMBER_OFFSET:
         {
-          const struct instruction inst_op = { OPCODE, { .opcode = { .code = (DDS_OP_PLM & (DDS_OP_MASK | DDS_PLM_FLAGS_MASK)) | (uint16_t)inst->data.inst_offset.addr_offs, .order = 0 } } };
+          const struct instruction inst_op = { OPCODE, { .opcode = { .code = (inst->data.inst_offset.inst.opcode & (DDS_OP_MASK | DDS_PLM_FLAGS_MASK)) | (uint16_t)inst->data.inst_offset.addr_offs, .order = 0 } } };
           if (fputs(sep, fp) < 0 || print_opcode(fp, &inst_op) < 0)
             return -1;
           brk = op + 2;

--- a/src/tools/idlc/src/descriptor_type_meta.c
+++ b/src/tools/idlc/src/descriptor_type_meta.c
@@ -383,7 +383,8 @@ get_struct_member_flags(const idl_member_t *member)
     flags |= DDS_XTypes_IS_KEY;
   if (member->optional.value)
     flags |= DDS_XTypes_IS_OPTIONAL;
-  // FIXME: implement must-understand and try-construct
+  if (member->must_understand.value)
+    flags |= DDS_XTypes_IS_MUST_UNDERSTAND;
   return flags;
 }
 


### PR DESCRIPTION
This adds support for the must-understand annotation in the IDL C generator and cdrstream serializer. Must-understand is only supported on members of structs with extensibility mutable, because the XCDR2 data representations for final and appendable types do not provide a way to indicate that a member is must-understand in the CDR data.
