### PR TITLE
Fix rexmit duplicate crash

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/q_xevent.h
+++ b/src/core/ddsi/include/dds/ddsi/q_xevent.h
@@ -50,9 +50,13 @@ DDS_EXPORT void qxev_pwr_entityid (struct proxy_writer * pwr, const ddsi_guid_t 
 DDS_EXPORT void qxev_prd_entityid (struct proxy_reader * prd, const ddsi_guid_t *guid);
 DDS_EXPORT void qxev_nt_callback (struct xeventq *evq, void (*cb) (void *arg), void *arg);
 
-/* Returns 1 if queued, 0 otherwise (no point in returning the
-   event, you can't do anything with it anyway) */
-DDS_EXPORT int qxev_msg_rexmit_wrlock_held (struct xeventq *evq, struct nn_xmsg *msg, int force);
+enum qxev_msg_rexmit_result {
+  QXEV_MSG_REXMIT_DROPPED,
+  QXEV_MSG_REXMIT_MERGED,
+  QXEV_MSG_REXMIT_QUEUED
+};
+
+DDS_EXPORT enum qxev_msg_rexmit_result qxev_msg_rexmit_wrlock_held (struct xeventq *evq, struct nn_xmsg *msg, int force);
 
 /* All of the following lock EVQ for the duration of the operation */
 DDS_EXPORT void delete_xevent (struct xevent *ev);

--- a/src/core/ddsi/src/q_receive.c
+++ b/src/core/ddsi/src/q_receive.c
@@ -1642,7 +1642,7 @@ static int handle_NackFrag (struct receiver_state *rst, ddsrt_etime_t tnow, cons
         struct nn_xmsg *reply;
         if (create_fragment_message (wr, seq, sample.plist, sample.serdata, base + i, 1, prd, &reply, 0, 0) < 0)
           nfrags_lim = 0;
-        else if (!qxev_msg_rexmit_wrlock_held (wr->evq, reply, 0))
+        else if (qxev_msg_rexmit_wrlock_held (wr->evq, reply, 0) == QXEV_MSG_REXMIT_DROPPED)
           nfrags_lim = 0;
         else
         {

--- a/src/core/ddsi/src/q_xevent.c
+++ b/src/core/ddsi/src/q_xevent.c
@@ -1356,7 +1356,7 @@ void qxev_pwr_entityid (struct proxy_writer *pwr, const ddsi_guid_t *guid)
   }
 }
 
-int qxev_msg_rexmit_wrlock_held (struct xeventq *evq, struct nn_xmsg *msg, int force)
+enum qxev_msg_rexmit_result qxev_msg_rexmit_wrlock_held (struct xeventq *evq, struct nn_xmsg *msg, int force)
 {
   struct ddsi_domaingv * const gv = evq->gv;
   size_t msg_size = nn_xmsg_size (msg);
@@ -1370,7 +1370,7 @@ int qxev_msg_rexmit_wrlock_held (struct xeventq *evq, struct nn_xmsg *msg, int f
     /* MSG got merged with a pending retransmit, so it has effectively been queued */
     ddsrt_mutex_unlock (&evq->lock);
     nn_xmsg_free (msg);
-    return 1;
+    return QXEV_MSG_REXMIT_MERGED;
   }
   else if ((evq->queued_rexmit_bytes > evq->max_queued_rexmit_bytes ||
             evq->queued_rexmit_msgs == evq->max_queued_rexmit_msgs) &&
@@ -1383,7 +1383,7 @@ int qxev_msg_rexmit_wrlock_held (struct xeventq *evq, struct nn_xmsg *msg, int f
     GVTRACE (" qxev_msg_rexmit%s drop (sz %"PA_PRIuSIZE" qb %"PA_PRIuSIZE" qm %"PA_PRIuSIZE")", force ? "!" : "",
              msg_size, evq->queued_rexmit_bytes, evq->queued_rexmit_msgs);
 #endif
-    return 0;
+    return QXEV_MSG_REXMIT_DROPPED;
   }
   else
   {
@@ -1399,7 +1399,7 @@ int qxev_msg_rexmit_wrlock_held (struct xeventq *evq, struct nn_xmsg *msg, int f
     GVTRACE ("AAA(%p,%"PA_PRIuSIZE")", (void *) ev, msg_size);
 #endif
     ddsrt_mutex_unlock (&evq->lock);
-    return 2;
+    return QXEV_MSG_REXMIT_QUEUED;
   }
 }
 


### PR DESCRIPTION
The retransmit queue tracks messages by writer GUID, sequence number and
fragment number. If a duplicate is presented for insertion in the queue,
it first tries to merge it, enqueueing it only if that fails.  The cases
where it fails are exceedingly rare, but if it does, it would end up
trying to insert a second entry with the same key in an AVL tree that
doesn't allow duplicates, leading to a crash (an assertion in a debug
build, a null pointer dereference in a release one).

This commit marks a duplicate message such that it is not entered in the
table at all.