### PR TITLE
Set must-understand flag on key members

### DIFF
--- a/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
@@ -63,19 +63,19 @@ enum dds_stream_opcode {
      [ADR, STR,   0, f] [offset]
      [ADR, BST,   0, f] [offset] [max-size]
 
-     [ADR, SEQ, nBY, 0] [offset]
-     [ADR, SEQ, ENU, 0] [offset] [max]
-     [ADR, SEQ, STR, 0] [offset]
-     [ADR, SEQ, BST, 0] [offset] [max-size]
-     [ADR, SEQ,   s, 0] [offset] [elem-size] [next-insn, elem-insn]
+     [ADR, SEQ, nBY, f] [offset]
+     [ADR, SEQ, ENU, f] [offset] [max]
+     [ADR, SEQ, STR, f] [offset]
+     [ADR, SEQ, BST, f] [offset] [max-size]
+     [ADR, SEQ,   s, f] [offset] [elem-size] [next-insn, elem-insn]
        where s = {SEQ,ARR,UNI,STU}
      [ADR, SEQ, EXT, f] *** not supported
 
      [ADR, ARR, nBY, f] [offset] [alen]
      [ADR, ARR, ENU, f] [offset] [alen] [max]
-     [ADR, ARR, STR, 0] [offset] [alen]
-     [ADR, ARR, BST, 0] [offset] [alen] [0] [max-size]
-     [ADR, ARR,   s, 0] [offset] [alen] [next-insn, elem-insn] [elem-size]
+     [ADR, ARR, STR, f] [offset] [alen]
+     [ADR, ARR, BST, f] [offset] [alen] [0] [max-size]
+     [ADR, ARR,   s, f] [offset] [alen] [next-insn, elem-insn] [elem-size]
          where s = {SEQ,ARR,UNI,STU}
      [ADR, ARR, EXT, f] *** not supported
 
@@ -156,7 +156,6 @@ enum dds_stream_opcode {
        for members of aggregated mutable types (pl-cdr):
        where
          f           = flags:
-                       - must-understand (DDS_OP_FLAG_MU)
                        - jump to base type (DDS_OP_FLAG_BASE)
          [elem-insn] = (unsigned 16 bits) offset to instruction for element, from start of insn
                         when FLAG_BASE is set, this is the offset of the PLM list of the base type

--- a/src/core/ddsc/tests/cdrstream.c
+++ b/src/core/ddsc/tests/cdrstream.c
@@ -1316,7 +1316,7 @@ typedef struct TestIdl_MsgMutable1 {
 static const uint32_t TestIdl_MsgMutable1_ops [] =
 {
   DDS_OP_PLC,
-    DDS_OP_PLM | DDS_OP_FLAG_MU << 16 | 19u, 1,
+    DDS_OP_PLM | 19u, 1,
     DDS_OP_PLM | 20u, 2,
     DDS_OP_PLM | 21u, 3,
     DDS_OP_PLM | 23u, 4,
@@ -1326,7 +1326,7 @@ static const uint32_t TestIdl_MsgMutable1_ops [] =
     DDS_OP_PLM | 31u, 10,
     DDS_OP_PLM | 34u, 11,
   DDS_OP_RTS,
-  DDS_OP_ADR | DDS_OP_TYPE_4BY, offsetof (TestIdl_MsgMutable1, msg_field1),
+  DDS_OP_ADR | DDS_OP_TYPE_4BY | DDS_OP_FLAG_MU, offsetof (TestIdl_MsgMutable1, msg_field1),
   DDS_OP_RTS,
   DDS_OP_ADR | DDS_OP_TYPE_2BY, offsetof (TestIdl_MsgMutable1, msg_field2),
   DDS_OP_RTS,

--- a/src/core/ddsc/tests/xtypes.c
+++ b/src/core/ddsc/tests/xtypes.c
@@ -283,13 +283,13 @@ static void sample_init_mu_wr1_3b (void *ptr)
 {
   XSpaceMustUnderstand_wr1_3 *sample = (XSpaceMustUnderstand_wr1_3 *) ptr;
   sample->f1 = 1;
-  sample->f2 = dds_alloc (sizeof (sample->f2));
+  sample->f2 = dds_alloc (sizeof (*sample->f2));
   *(sample->f2) = 1;
 }
 static void sample_init_mu_wr1_4a (void *ptr)
 {
   XSpaceMustUnderstand_wr1_4 *sample = (XSpaceMustUnderstand_wr1_4 *) ptr;
-  sample->f1 = dds_alloc (sizeof (sample->f1));
+  sample->f1 = dds_alloc (sizeof (*sample->f1));
   *(sample->f1) = 1;
 }
 static void sample_init_mu_wr1_4b (void *ptr)
@@ -308,7 +308,7 @@ static void sample_init_mu_wr2_1b (void *ptr)
 {
   XSpaceMustUnderstand_wr2_1 *sample = (XSpaceMustUnderstand_wr2_1 *) ptr;
   sample->f1.f1 = 1;
-  sample->f1.f2 = dds_alloc (sizeof (sample->f1.f2));
+  sample->f1.f2 = dds_alloc (sizeof (*sample->f1.f2));
   *(sample->f1.f2) = 1;
 }
 

--- a/src/tools/idlc/src/descriptor_type_meta.c
+++ b/src/tools/idlc/src/descriptor_type_meta.c
@@ -383,7 +383,8 @@ get_struct_member_flags(const idl_member_t *member)
     flags |= DDS_XTypes_IS_KEY;
   if (member->optional.value)
     flags |= DDS_XTypes_IS_OPTIONAL;
-  if (member->must_understand.value)
+  // XTypes spec 7.2.2.4.4.4.8: Key members shall always have their 'must understand' attribute set to true
+  if (member->must_understand.value || member->key.value)
     flags |= DDS_XTypes_IS_MUST_UNDERSTAND;
   return flags;
 }
@@ -411,6 +412,8 @@ static DDS_XTypes_UnionDiscriminatorFlag
 get_union_discriminator_flags(const idl_switch_type_spec_t *switch_type_spec)
 {
   DDS_XTypes_UnionDiscriminatorFlag flags = 0u;
+  // XTypes spec 7.2.2.4.4.4.6: In a union type, the discriminator member shall always have the 'must understand' attribute set to true
+  flags |= DDS_XTypes_IS_MUST_UNDERSTAND;
   if (switch_type_spec->key.value)
     flags |= DDS_XTypes_IS_KEY;
   // optional and external not allowed

--- a/src/tools/idlc/tests/type_meta.c
+++ b/src/tools/idlc/tests/type_meta.c
@@ -201,7 +201,7 @@ static DDS_XTypes_TypeObject *get_typeobj_union(const char *name, uint16_t flags
     ._d = DDS_XTypes_TK_UNION,
     ._u.union_type = (DDS_XTypes_CompleteUnionType) {
       .union_flags = flags,
-      .discriminator = { .common = { .member_flags = 0, .type_id = disc_type } },
+      .discriminator = { .common = { .member_flags = DDS_XTypes_IS_MUST_UNDERSTAND, .type_id = disc_type } },
       .member_seq = {
         ._maximum = member_cnt,
         ._length = member_cnt,
@@ -223,7 +223,7 @@ static DDS_XTypes_TypeObject *get_typeobj1 (void)
     DDS_XTypes_IS_APPENDABLE,
     (DDS_XTypes_TypeIdentifier) { ._d = DDS_XTypes_TK_NONE },
     3, (smember_t[]) {
-      { 0, DDS_XTypes_IS_KEY, { ._d = DDS_XTypes_TK_INT64 }, "f1" },
+      { 0, DDS_XTypes_IS_KEY | DDS_XTypes_IS_MUST_UNDERSTAND, { ._d = DDS_XTypes_TK_INT64 }, "f1" },
       { 1, DDS_XTypes_IS_OPTIONAL, { ._d = DDS_XTypes_TI_STRING8_SMALL, ._u.string_sdefn.bound = 0 }, "f2" },
       { 4, DDS_XTypes_IS_EXTERNAL, { ._d = DDS_XTypes_TK_CHAR8 }, "f3" }
     });


### PR DESCRIPTION
This adds setting the must-understand (MU) flag on key members in the cdrstream serializer instructions and in the type object that is generated for aggregated types (so that it conforms to the XTypes spec section 7.2.2.4.4.4.6 and 7.2.2.4.4.4.8). Some refactoring is also included, to move the MU flag in the serializer instructions from the mutable member's PLM instruction to its ADR instruction, to keep the KEY and MU flags together. Commit b3273e35373e4ad510d5dd9642df54074c362cd7 is included to fix a few issues found by Coverity in #1102. 

In the python fuzzer tests, the lines for setting the MU flags in type object for keys/discriminators are currently commented out. @thijsmie could you open a PR for the Python binding to enable these lines? 