### PR TITLE
Fix get_typelookup_writer racing new_participant

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/q_entity.h
+++ b/src/core/ddsi/include/dds/ddsi/q_entity.h
@@ -242,6 +242,13 @@ struct avail_entityid_set {
   struct inverse_uint32_set x;
 };
 
+enum participant_state {
+  PARTICIPANT_STATE_INITIALIZING,
+  PARTICIPANT_STATE_OPERATIONAL,
+  PARTICIPANT_STATE_DELETE_STARTED,
+  PARTICIPANT_STATE_DELETING_BUILTINS
+};
+
 struct participant
 {
   struct entity_common e;
@@ -257,7 +264,7 @@ struct participant
   ddsrt_mutex_t refc_lock;
   int32_t user_refc; /* number of non-built-in endpoints in this participant [refc_lock] */
   int32_t builtin_refc; /* number of built-in endpoints in this participant [refc_lock] */
-  int builtins_deleted; /* whether deletion of built-in endpoints has been initiated [refc_lock] */
+  enum participant_state state; /* current state of this participant [refc_lock] */
   ddsrt_fibheap_t ldur_auto_wr; /* Heap that contains lease duration for writers with automatic liveliness in this participant */
   ddsrt_atomic_voidp_t minl_man; /* clone of min(leaseheap_man) */
   ddsrt_fibheap_t leaseheap_man; /* keeps leases for this participant's writers (with liveliness manual-by-participant) */
@@ -723,6 +730,7 @@ dds_return_t new_participant (struct ddsi_guid *ppguid, struct ddsi_domaingv *gv
 dds_return_t delete_participant (struct ddsi_domaingv *gv, const struct ddsi_guid *ppguid);
 void update_participant_plist (struct participant *pp, const struct ddsi_plist *plist);
 uint64_t get_entity_instance_id (const struct ddsi_domaingv *gv, const struct ddsi_guid *guid);
+bool participant_builtin_writers_ready (struct participant *pp);
 
 /* Gets the interval for PMD messages, which is the minimal lease duration for writers
    with auto liveliness in this participant, or the participants lease duration if shorter */

--- a/src/core/ddsi/src/ddsi_typelookup.c
+++ b/src/core/ddsi/src/ddsi_typelookup.c
@@ -44,7 +44,10 @@ static struct writer *get_typelookup_writer (const struct ddsi_domaingv *gv, uin
   thread_state_awake (lookup_thread_state (), gv);
   entidx_enum_participant_init (&est, gv->entity_index);
   while (wr == NULL && (pp = entidx_enum_participant_next (&est)) != NULL)
-    wr = get_builtin_writer (pp, wr_eid);
+  {
+    if (participant_builtin_writers_ready (pp))
+      wr = get_builtin_writer (pp, wr_eid);
+  }
   entidx_enum_participant_fini (&est);
   thread_state_asleep (lookup_thread_state ());
   return wr;

--- a/src/core/ddsi/src/q_transmit.c
+++ b/src/core/ddsi/src/q_transmit.c
@@ -976,7 +976,7 @@ static int insert_sample_in_whc (struct writer *wr, seqno_t seq, struct ddsi_pli
     struct whc_state whcst;
     whc_get_state(wr->whc, &whcst);
     if (WHCST_ISEMPTY(&whcst))
-      assert (wr->c.pp->builtins_deleted);
+      assert (wr->c.pp->state >= PARTICIPANT_STATE_DELETING_BUILTINS);
   }
 #endif
   return res;


### PR DESCRIPTION
A new (local) participant is made visible in the entity index before
creating the built-in writers, to avoid complications in the matching.
This is generally fine, they don't get used until later on anyway,
except in those cases where one tries to use a built-in writer by simply
scanning all the participants.  And this is what the
get_typelookup_writer does.

The result is that calling get_builtin_writer may find that the
requested writer doesn't exist (yet, in this case), causing it to fall
back to the "privileged participant" without that "privileged
participant" being set for the participant.  This causes an assertion
failure.

This commit replaces a boolean value tracking the progress of deleting
the participant to a enum that allows one to mark also check progress in
initialization.  Any participant not yet ready is then simply skipped,
avoiding the race.

Signed-off-by: Erik Boasson <eb@ilities.com>