### PR TITLE
Fix windows docs build

### DIFF
--- a/docs/manual/conf.py
+++ b/docs/manual/conf.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 # -- Project information -----------------------------------------------------
 
 project = '@PROJECT_NAME@'
@@ -43,7 +45,7 @@ html_static_path = ['_static']
 autosummary_generate=True
 # Setup the exhale extension
 exhale_args = {
-    "containmentFolder":     "@_sourcedir@/ddsc_api_docs",
+    "containmentFolder":     str(Path("@_sourcedir@/ddsc_api_docs").resolve()),
     "rootFileName":          "library_root.rst",
     "rootFileTitle":         "Raw C API",
     "fullToctreeMaxDepth":   1,


### PR DESCRIPTION
Sometimes tools are misled by windows path conventions, and who can blame them, because it confuses me too sometimes. In any case: the windows docs build was messing up because cmake inserts a UNIX style path into the python config, that is then compared to the build directory, which then concludes that C:/something/something/subdir is not a subdirectory of C:\something\something.

I could go through the trouble of trying to make CMAKE output a windows native path on windows, but I decided not to bother and lean on the excellent python pathlib to solve this for me, by converting to a python Path instance and then back to string.