### PR TITLE
Bounded sequences

### DIFF
--- a/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
@@ -68,15 +68,23 @@ enum dds_stream_opcode {
      [ADR, SEQ, STR, f] [offset]
      [ADR, SEQ, BST, f] [offset] [max-size]
      [ADR, SEQ,   s, f] [offset] [elem-size] [next-insn, elem-insn]
-       where s = {SEQ,ARR,UNI,STU}
+       where s = {SEQ,ARR,UNI,STU,BSQ}
      [ADR, SEQ, EXT, f] *** not supported
+
+     [ADR, BSQ, nBY, 0] [offset] [sbound]
+     [ADR, BSQ, ENU, 0] [offset] [sbound] [max]
+     [ADR, BSQ, STR, 0] [offset] [sbound]
+     [ADR, BSQ, BST, 0] [offset] [sbound] [max-size]
+     [ADR, BSQ,   s, 0] [offset] [sbound] [elem-size] [next-insn, elem-insn]
+       where s = {SEQ,ARR,UNI,STU,BSQ}
+     [ADR, BSQ, EXT, f] *** not supported
 
      [ADR, ARR, nBY, f] [offset] [alen]
      [ADR, ARR, ENU, f] [offset] [alen] [max]
      [ADR, ARR, STR, f] [offset] [alen]
      [ADR, ARR, BST, f] [offset] [alen] [0] [max-size]
      [ADR, ARR,   s, f] [offset] [alen] [next-insn, elem-insn] [elem-size]
-         where s = {SEQ,ARR,UNI,STU}
+         where s = {SEQ,ARR,UNI,STU,BSQ}
      [ADR, ARR, EXT, f] *** not supported
 
      [ADR, UNI,   d, z] [offset] [alen] [next-insn, cases]
@@ -104,6 +112,7 @@ enum dds_stream_opcode {
      [max-size]   = string bound + 1
      [max]        = max enum value
      [alen]       = array length, number of cases
+     [sbound]     = bounded sequence maximum number of elements
      [next-insn]  = (unsigned 16 bits) offset to instruction for next field, from start of insn
      [elem-insn]  = (unsigned 16 bits) offset to first instruction for element, from start of insn
      [cases]      = (unsigned 16 bits) offset to first case label, from start of insn
@@ -187,7 +196,7 @@ enum dds_stream_typecode {
   DDS_OP_VAL_ARR = 0x08, /* array */
   DDS_OP_VAL_UNI = 0x09, /* union */
   DDS_OP_VAL_STU = 0x0a, /* struct */
-  /* 0x0b **available for future use** */
+  DDS_OP_VAL_BSQ = 0x0b, /* bounded sequence */
   DDS_OP_VAL_ENU = 0x0c, /* enumerated value (long) */
   DDS_OP_VAL_EXT = 0x0d  /* field with external definition */
 };
@@ -204,6 +213,7 @@ enum dds_stream_typecode_primary {
   DDS_OP_TYPE_ARR = DDS_OP_VAL_ARR << 16,
   DDS_OP_TYPE_UNI = DDS_OP_VAL_UNI << 16,
   DDS_OP_TYPE_STU = DDS_OP_VAL_STU << 16,
+  DDS_OP_TYPE_BSQ = DDS_OP_VAL_BSQ << 16,
   DDS_OP_TYPE_ENU = DDS_OP_VAL_ENU << 16,
   DDS_OP_TYPE_EXT = DDS_OP_VAL_EXT << 16
 };
@@ -230,6 +240,7 @@ enum dds_stream_typecode_subtype {
   DDS_OP_SUBTYPE_ARR = DDS_OP_VAL_ARR << 8,
   DDS_OP_SUBTYPE_UNI = DDS_OP_VAL_UNI << 8,
   DDS_OP_SUBTYPE_STU = DDS_OP_VAL_STU << 8,
+  DDS_OP_SUBTYPE_BSQ = DDS_OP_VAL_BSQ << 8,
   DDS_OP_SUBTYPE_ENU = DDS_OP_VAL_ENU << 8
 };
 #define DDS_OP_SUBTYPE_BOO DDS_OP_SUBTYPE_1BY

--- a/src/core/ddsc/tests/cdrstream.c
+++ b/src/core/ddsc/tests/cdrstream.c
@@ -1789,7 +1789,8 @@ CU_Theory ((const char *descr, const dds_topic_descriptor_t *desc1, const dds_to
     };
 
     void * msg_wr = t ? sample_init_fn2 () : sample_init_fn1 ();
-    dds_stream_write_sample (&os, msg_wr, &tp_wr);
+    bool ret = dds_stream_write_sample (&os, msg_wr, &tp_wr);
+    CU_ASSERT_FATAL (ret);
 
     /* Read data */
     dds_istream_t is;

--- a/src/core/ddsi/include/dds/ddsi/ddsi_cdrstream.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_cdrstream.h
@@ -64,9 +64,9 @@ DDS_EXPORT const uint32_t *dds_stream_write (dds_ostream_t * __restrict os, cons
 DDS_EXPORT const uint32_t *dds_stream_writeLE (dds_ostreamLE_t * __restrict os, const char * __restrict data, const uint32_t * __restrict ops);
 DDS_EXPORT const uint32_t *dds_stream_writeBE (dds_ostreamBE_t * __restrict os, const char * __restrict data, const uint32_t * __restrict ops);
 DDS_EXPORT const uint32_t * dds_stream_write_with_byte_order (dds_ostream_t * __restrict os, const char * __restrict data, const uint32_t * __restrict ops, enum ddsrt_byte_order_selector bo);
-DDS_EXPORT void dds_stream_write_sample (dds_ostream_t * __restrict os, const void * __restrict data, const struct ddsi_sertype_default * __restrict type);
-DDS_EXPORT void dds_stream_write_sampleLE (dds_ostreamLE_t * __restrict os, const void * __restrict data, const struct ddsi_sertype_default * __restrict type);
-DDS_EXPORT void dds_stream_write_sampleBE (dds_ostreamBE_t * __restrict os, const void * __restrict data, const struct ddsi_sertype_default * __restrict type);
+DDS_EXPORT bool dds_stream_write_sample (dds_ostream_t * __restrict os, const void * __restrict data, const struct ddsi_sertype_default * __restrict type);
+DDS_EXPORT bool dds_stream_write_sampleLE (dds_ostreamLE_t * __restrict os, const void * __restrict data, const struct ddsi_sertype_default * __restrict type);
+DDS_EXPORT bool dds_stream_write_sampleBE (dds_ostreamBE_t * __restrict os, const void * __restrict data, const struct ddsi_sertype_default * __restrict type);
 DDS_EXPORT void dds_stream_read_sample (dds_istream_t * __restrict is, void * __restrict data, const struct ddsi_sertype_default * __restrict type);
 DDS_EXPORT void dds_stream_free_sample (void * __restrict data, const uint32_t * __restrict ops);
 

--- a/src/core/ddsi/src/ddsi_cdrstream_keys.part.c
+++ b/src/core/ddsi/src/ddsi_cdrstream_keys.part.c
@@ -38,7 +38,7 @@ static void dds_stream_write_keyBO_impl (DDS_OSTREAM_T * __restrict os, const ui
       dds_stream_write_keyBO_impl (os, jsr_ops, addr, --key_offset_count, ++key_offset_insn);
       break;
     }
-    case DDS_OP_VAL_SEQ: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU: {
+    case DDS_OP_VAL_SEQ: case DDS_OP_VAL_BSQ: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU: {
       // FIXME: implement support for sequences and unions as part of the key
       abort ();
       break;

--- a/src/core/ddsi/src/ddsi_serdata_default.c
+++ b/src/core/ddsi/src/ddsi_serdata_default.c
@@ -572,7 +572,8 @@ static struct ddsi_serdata_default *serdata_default_from_sample_cdr_common (cons
       }
       break;
     case SDK_DATA:
-      dds_stream_write_sample (&os, sample, tp);
+      if (!dds_stream_write_sample (&os, sample, tp))
+        return NULL;
       dds_ostream_add_to_serdata_default (&os, &d);
       if (!gen_serdata_key_from_sample (tp, &d->key, sample))
         return NULL;

--- a/src/core/ddsi/src/ddsi_sertype_default.c
+++ b/src/core/ddsi/src/ddsi_sertype_default.c
@@ -277,8 +277,7 @@ static size_t sertype_default_get_serialized_size (
 static bool sertype_default_serialize_into (const struct ddsi_sertype *type, const void *sample, void* dst_buffer, size_t dst_size) {
   const struct ddsi_sertype_default *type_default = (const struct ddsi_sertype_default *)type;
   dds_ostream_t os = ostream_from_buffer(dst_buffer, dst_size, type_default->encoding_version);
-  dds_stream_write_sample(&os, sample, type_default);
-  return true;
+  return dds_stream_write_sample(&os, sample, type_default);
 }
 
 const struct ddsi_sertype_ops ddsi_sertype_ops_default = {

--- a/src/tools/idlc/src/descriptor_type_meta.h
+++ b/src/tools/idlc/src/descriptor_type_meta.h
@@ -32,7 +32,7 @@ struct descriptor_type_meta {
   struct type_meta *stack;
 };
 
-void
+idl_retcode_t
 get_type_hash (DDS_XTypes_EquivalenceHash hash, const DDS_XTypes_TypeObject *to);
 
 idl_retcode_t

--- a/src/tools/idlc/tests/type_meta.c
+++ b/src/tools/idlc/tests/type_meta.c
@@ -108,7 +108,8 @@ static void xcdr2_ser (const void *obj, const dds_topic_descriptor_t *desc, dds_
   os->m_index = 0;
   os->m_size = 0;
   os->m_xcdr_version = CDR_ENC_VERSION_2;
-  dds_stream_write_sampleLE ((dds_ostreamLE_t *) os, obj, &sertype);
+  bool ret = dds_stream_write_sampleLE ((dds_ostreamLE_t *) os, obj, &sertype);
+  CU_ASSERT_FATAL (ret);
 }
 
 static void xcdr2_deser (unsigned char *buf, uint32_t sz, void **obj, const dds_topic_descriptor_t *desc)
@@ -257,7 +258,8 @@ static void get_typeid (DDS_XTypes_TypeIdentifier *ti, DDS_XTypes_TypeObject *to
 {
   memset (ti, 0, sizeof (*ti));
   ti->_d = DDS_XTypes_EK_COMPLETE;
-  get_type_hash (ti->_u.equivalence_hash, to);
+  idl_retcode_t ret = get_type_hash (ti->_u.equivalence_hash, to);
+  CU_ASSERT_EQUAL_FATAL (ret, IDL_RETCODE_OK);
   dds_stream_free_sample (to, DDS_XTypes_TypeObject_desc.m_ops);
   free (to);
 }

--- a/src/tools/idlc/xtests/CMakeLists.txt
+++ b/src/tools/idlc/xtests/CMakeLists.txt
@@ -25,6 +25,7 @@ set(_sources
   test_struct_r.idl
   test_union_member_types_r.idl
   test_union_r.idl
+  test_bounded_seq.idl
 )
 
 set(_includes "${_includes}\\;${CMAKE_SOURCE_DIR}/src/core/ddsc/include")

--- a/src/tools/idlc/xtests/main.c
+++ b/src/tools/idlc/xtests/main.c
@@ -64,11 +64,16 @@ int main(int argc, char **argv)
     // write data
     printf("cdr write %s\n", tests[i] == BE ? "BE" : "LE");
     dds_ostream_t os = { NULL, 0, 0, CDR_ENC_VERSION_2 };
+    bool ret;
     if (tests[i] == BE)
-      dds_stream_write_sampleBE ((dds_ostreamBE_t *)(&os), msg_wr, &sertype);
+      ret = dds_stream_write_sampleBE ((dds_ostreamBE_t *)(&os), msg_wr, &sertype);
     else
-      dds_stream_write_sampleLE ((dds_ostreamLE_t *)(&os), msg_wr, &sertype);
-
+      ret = dds_stream_write_sampleLE ((dds_ostreamLE_t *)(&os), msg_wr, &sertype);
+    if (!ret)
+    {
+      printf("cdr write failed\n");
+      return 1;
+    }
 
     // output raw cdr
     for (uint32_t n = 0; n < os.m_index; n++)

--- a/src/tools/idlc/xtests/test_bounded_seq.idl
+++ b/src/tools/idlc/xtests/test_bounded_seq.idl
@@ -1,0 +1,187 @@
+/*
+ * Copyright(c) 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+#if defined(__IDLC__)
+
+module test_module
+{
+  enum en {
+      E1,
+      E2
+  };
+
+  @nested @final
+  struct n {
+      long n1;
+  };
+
+  typedef sequence<char> cseq;
+  typedef sequence<char, 3> bcseq;
+  typedef char carr[98];
+
+  @nested @final
+  union u switch (short) {
+      case 1: sequence<long, 1> u1;
+  };
+
+  @final
+  struct test_bounded_seq {
+      sequence<long, 1> f1;
+      sequence<string, 2> f2;
+      sequence<string<99>, 3> f3;
+      sequence<cseq, 4> f4;
+      sequence<bcseq, 5> f5;
+      sequence<carr, 6> f6;
+      sequence<u, 7> f7;
+      sequence<n, 8> f8;
+      sequence<long, 9> f9[99];
+      sequence<en, 10> f10;
+  };
+};
+
+#else
+
+#include "dds/ddsrt/heap.h"
+#include "test_bounded_seq.h"
+#include "common.h"
+
+const dds_topic_descriptor_t *desc = &test_module_test_bounded_seq_desc;
+void init_sample (void *s);
+int cmp_sample (const void *sa, const void *sb);
+
+void init_sample (void *s)
+{
+  test_module_test_bounded_seq *s1 = (test_module_test_bounded_seq *) s;
+  SEQA(s1->f1, 1);
+  s1->f1._buffer[0] = 123;
+
+  SEQA (s1->f2, 2);
+  for (int n = 0; n < 2; n++)
+    STRA (s1->f2._buffer[n], STR128);
+
+  SEQA (s1->f3, 3);
+  for (int n = 0; n < 3; n++)
+    strcpy (s1->f3._buffer[n], STR16);
+
+  SEQA (s1->f4, 4);
+  for (int n = 0; n < 4; n++)
+  {
+    SEQA (s1->f4._buffer[n], 2);
+    for (int m = 0; m < 2; m++)
+      s1->f4._buffer[n]._buffer[m] = n * m;
+  }
+
+  SEQA (s1->f5, 5);
+  for (int n = 0; n < 5; n++)
+  {
+    SEQA (s1->f5._buffer[n], 3);
+    for (int m = 0; m < 3; m++)
+      s1->f5._buffer[n]._buffer[m] = n * m;
+  }
+
+  SEQA (s1->f6, 6);
+  for (int n = 0; n < 6; n++)
+  {
+    for (int m = 0; m < 98; m++)
+      s1->f6._buffer[n][m] = m;
+  }
+
+  SEQA (s1->f7, 7);
+  for (int n = 0; n < 7; n++)
+  {
+    s1->f7._buffer[n]._d = 1;
+    SEQA (s1->f7._buffer[n]._u.u1, 1);
+    s1->f7._buffer[n]._u.u1._buffer[0] = 10 * n;
+  }
+
+  SEQA (s1->f8, 8);
+  for (int n = 0; n < 8; n++)
+    s1->f8._buffer[n].n1 = 10 * n;
+
+  for (int m = 0; m < 99; m++)
+  {
+    SEQA (s1->f9[m], 9);
+    for (int n = 0; n < 9; n++)
+      s1->f9[m]._buffer[n] = m * n;
+  }
+
+  SEQA (s1->f10, 10);
+  for (int n = 0; n < 10; n++)
+    s1->f10._buffer[n] = n % 2 ? test_module_E1 : test_module_E2;
+
+}
+
+int cmp_sample (const void *sa, const void *sb)
+{
+  test_module_test_bounded_seq *a = (test_module_test_bounded_seq *) sa;
+  test_module_test_bounded_seq *b = (test_module_test_bounded_seq *) sb;
+  CMP (a, b, f1._length, 1);
+  CMP (a, b, f1._buffer[0], 123);
+
+  CMP (a, b, f2._length, 2);
+  for (int n = 0; n < 2; n++)
+    CMPSTR (a, b, f2._buffer[n], STR128);
+
+  CMP (a, b, f3._length, 3);
+  for (int n = 0; n < 3; n++)
+    CMPSTR (a, b, f3._buffer[n], STR16);
+
+  CMP (a, b, f4._length, 4);
+  for (int n = 0; n < 4; n++)
+  {
+    CMP (a, b, f4._buffer[n]._length, 2);
+    for (int m = 0; m < 2; m++)
+      CMP (a, b, f4._buffer[n]._buffer[m], n * m);
+  }
+
+  CMP (a, b, f5._length, 5);
+  for (int n = 0; n < 5; n++)
+  {
+    CMP (a, b, f5._buffer[n]._length, 3);
+    for (int m = 0; m < 3; m++)
+      CMP (a, b, f5._buffer[n]._buffer[m], n * m);
+  }
+
+  CMP (a, b, f6._length, 6);
+  for (int n = 0; n < 6; n++)
+  {
+    for (int m = 0; m < 98; m++)
+      CMP (a, b, f6._buffer[n][m], m);
+  }
+
+  CMP (a, b, f7._length, 7);
+  for (int n = 0; n < 7; n++)
+  {
+    CMP (a, b, f7._buffer[n]._d, 1);
+    CMP (a, b, f7._buffer[n]._u.u1._length, 1);
+    CMP (a, b, f7._buffer[n]._u.u1._buffer[0], 10 * n);
+  }
+
+  CMP (a, b, f8._length, 8);
+  for (int n = 0; n < 8; n++)
+    CMP (a, b, f8._buffer[n].n1, 10 * n);
+
+  for (int m = 0; m < 99; m++)
+  {
+    CMP (a, b, f9[m]._length, 9);
+    for (int n = 0; n < 9; n++)
+      CMP (a, b, f9[m]._buffer[n], n * m);
+  }
+
+  CMP (a, b, f10._length, 10);
+  for (int n = 0; n < 10; n++)
+    CMP (a, b, f10._buffer[n], n % 2 ? test_module_E1 : test_module_E2);
+
+  return 0;
+}
+
+#endif


### PR DESCRIPTION
This PR adds the implementation of bounded sequences in IDLC and the cdrstream serializer. A new serializer instruction `BSQ` is introduced, that has a bound parameter and is handled similar to the existing `SEQ` instruction.

Serialization of a sample that has a sequence-type member containing more elements than the specified bound will fail. For incoming data, deserialization (`dds_stream_normalize`) also fails in case a sequence has an element count that is larger than the bound set in the type; the sample will be dropped in that case.
