### PR TITLE
Consistency of type consistency QoS serialization

### DIFF
--- a/src/core/ddsi/src/ddsi_plist.c
+++ b/src/core/ddsi/src/ddsi_plist.c
@@ -578,11 +578,11 @@ static dds_return_t ser_type_consistency (struct nn_xmsg *xmsg, nn_parameterid_t
   const uint16_t kind = ddsrt_toBO2u (bo, (uint16_t) x->kind);
   memcpy (p, &kind, 2);
   size_t offs = sizeof (kind);
-  p[offs + 0] = x->force_type_validation;
-  p[offs + 1] = x->ignore_sequence_bounds;
-  p[offs + 2] = x->ignore_string_bounds;
-  p[offs + 3] = x->ignore_member_names;
-  p[offs + 4] = x->prevent_type_widening;
+  p[offs + 0] = x->ignore_sequence_bounds;
+  p[offs + 1] = x->ignore_string_bounds;
+  p[offs + 2] = x->ignore_member_names;
+  p[offs + 3] = x->prevent_type_widening;
+  p[offs + 4] = x->force_type_validation;
   return 0;
 }
 


### PR DESCRIPTION
This brings the serialization of the type consistency QoS in line with
the deserialization of it, which, I believe is consistent with the
XTypes 1.3 spec:
```
  @extensibility(APPENDABLE) @nested
  struct TypeConsistencyEnforcementQosPolicy {
    TypeConsistencyKind kind;
    boolean ignore_sequence_bounds;
    boolean ignore_string_bounds;
    boolean ignore_member_names;
    boolean prevent_type_widening;
    boolean force_type_validation;
  };
```
Signed-off-by: Erik Boasson <eb@ilities.com>