### PR TITLE
Fix alignment for reading collections with 64 bits element type

### DIFF
--- a/src/core/ddsi/src/ddsi_cdrstream.c
+++ b/src/core/ddsi/src/ddsi_cdrstream.c
@@ -240,7 +240,7 @@ static uint32_t dds_is_peek4 (dds_istream_t * __restrict s)
 
 static uint64_t dds_is_get8 (dds_istream_t * __restrict s)
 {
-  dds_cdr_alignto (s, s->m_xcdr_version == CDR_ENC_VERSION_2 ? 4 : 8);
+  dds_cdr_alignto (s, xcdr_max_align (s->m_xcdr_version, 8));
   size_t off_low = (DDSRT_ENDIAN == DDSRT_LITTLE_ENDIAN) ? 0 : 4, off_high = 4 - off_low;
   uint32_t v_low = * ((uint32_t *) (s->m_buffer + s->m_index + off_low)),
     v_high = * ((uint32_t *) (s->m_buffer + s->m_index + off_high));
@@ -251,7 +251,8 @@ static uint64_t dds_is_get8 (dds_istream_t * __restrict s)
 
 static void dds_is_get_bytes (dds_istream_t * __restrict s, void * __restrict b, uint32_t num, uint32_t elem_size)
 {
-  dds_cdr_alignto (s, elem_size);
+  const uint32_t align = xcdr_max_align (s->m_xcdr_version, elem_size);
+  dds_cdr_alignto (s, align);
   memcpy (b, s->m_buffer + s->m_index, num * elem_size);
   s->m_index += num * elem_size;
 }
@@ -2892,9 +2893,10 @@ static void dds_stream_extract_key_from_data_skip_subtype (dds_istream_t * __res
       break;
     }
     case DDS_OP_VAL_8BY: {
-      const uint32_t elem_size = is->m_xcdr_version == CDR_ENC_VERSION_2 ? 4 : 8;
-      dds_cdr_alignto (is, elem_size);
-      is->m_index += num * 8;
+      const uint32_t elem_size = 8;
+      const uint32_t align = xcdr_max_align (is->m_xcdr_version, 8);
+      dds_cdr_alignto (is, align);
+      is->m_index += num * elem_size;
       break;
     }
     case DDS_OP_VAL_STR: case DDS_OP_VAL_BST: {

--- a/src/core/ddsi/src/ddsi_cdrstream_keys.part.c
+++ b/src/core/ddsi/src/ddsi_cdrstream_keys.part.c
@@ -25,8 +25,9 @@ static void dds_stream_write_keyBO_impl (DDS_OSTREAM_T * __restrict os, const ui
     case DDS_OP_VAL_BST: dds_stream_write_stringBO (os, addr); break;
     case DDS_OP_VAL_ARR: {
       const uint32_t elem_size = get_type_size (DDS_OP_SUBTYPE (*insnp));
+      const uint32_t align = xcdr_max_align (((struct dds_ostream *)os)->m_xcdr_version, elem_size);
       const uint32_t num = insnp[2];
-      dds_cdr_alignto_clear_and_resizeBO (os, elem_size, num * elem_size);
+      dds_cdr_alignto_clear_and_resizeBO (os, align, num * elem_size);
       void * const dst = ((struct dds_ostream *)os)->m_buffer + ((struct dds_ostream *)os)->m_index;
       dds_os_put_bytes ((struct dds_ostream *)os, addr, num * elem_size);
       dds_stream_swap_if_needed_insituBO (dst, elem_size, num);

--- a/src/core/ddsi/src/ddsi_cdrstream_write.part.c
+++ b/src/core/ddsi/src/ddsi_cdrstream_write.part.c
@@ -53,7 +53,7 @@ static const uint32_t *dds_stream_write_seqBO (DDS_OSTREAM_T * __restrict os, co
         /* fall through */
       case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY: {
         const uint32_t elem_size = get_type_size (subtype);
-        const uint32_t align = is_xcdr2 && subtype == DDS_OP_VAL_8BY ? 4 : elem_size;
+        const uint32_t align = xcdr_max_align (((struct dds_ostream *)os)->m_xcdr_version, elem_size);
         void * dst;
         /* Combining put bytes and swap into a single step would improve the performance
            of writing data in non-native endianess. But in most cases the data will
@@ -109,7 +109,7 @@ static const uint32_t *dds_stream_write_arrBO (DDS_OSTREAM_T * __restrict os, co
   const enum dds_stream_typecode subtype = DDS_OP_SUBTYPE (insn);
   uint32_t offs = 0;
   bool is_xcdr2 = ((struct dds_ostream *)os)->m_xcdr_version == CDR_ENC_VERSION_2;
-  if (subtype > DDS_OP_VAL_8BY && ((struct dds_ostream *)os)->m_xcdr_version == CDR_ENC_VERSION_2)
+  if (subtype > DDS_OP_VAL_8BY && is_xcdr2)
   {
     /* reserve space for DHEADER */
     dds_os_reserve4BO (os);
@@ -123,7 +123,7 @@ static const uint32_t *dds_stream_write_arrBO (DDS_OSTREAM_T * __restrict os, co
       /* fall through */
     case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY: {
       const uint32_t elem_size = get_type_size (subtype);
-      const uint32_t align = is_xcdr2 && subtype == DDS_OP_VAL_8BY ? 4 : elem_size;
+      const uint32_t align = xcdr_max_align (((struct dds_ostream *)os)->m_xcdr_version, elem_size);
       void * dst;
       /* See comment for stream_write_seq, swap is a no-op in most cases */
       dds_os_put_bytes_aligned ((struct dds_ostream *)os, addr, num, elem_size, align, &dst);

--- a/src/tools/idlc/xtests/CMakeLists.txt
+++ b/src/tools/idlc/xtests/CMakeLists.txt
@@ -22,6 +22,7 @@ set(_sources
   test_union_external.idl
   test_optional.idl
   test_optional_mutable.idl
+  test_struct_alignment.idl
   test_struct_r.idl
   test_union_member_types_r.idl
   test_union_r.idl

--- a/src/tools/idlc/xtests/test_struct_alignment.idl
+++ b/src/tools/idlc/xtests/test_struct_alignment.idl
@@ -1,0 +1,61 @@
+/*
+ * Copyright(c) 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+#if defined(__IDLC__)
+
+@nested @final
+struct b {
+  boolean b1;
+  long long b2[2];
+};
+
+@topic @mutable
+struct struct_test {
+  b a1[2];
+};
+
+#else
+
+#include <string.h>
+#include "dds/dds.h"
+#include "test_struct_alignment.h"
+#include "common.h"
+
+const dds_topic_descriptor_t *desc = &struct_test_desc;
+void init_sample (void *s);
+int cmp_sample (const void *sa, const void *sb);
+
+void init_sample (void *s)
+{
+  struct_test *t = (struct_test *) s;
+  t->a1[0].b1 = false;
+  t->a1[0].b2[0] = 1;
+  t->a1[0].b2[1] = 1;
+  t->a1[1].b1 = true;
+  t->a1[1].b2[0] = 3;
+  t->a1[1].b2[1] = 4;
+}
+
+int cmp_sample (const void *sa, const void *sb)
+{
+  struct_test *a = (struct_test *) sa;
+  struct_test *b = (struct_test *) sb;
+  CMP(a, b, a1[0].b1, false);
+  CMP(a, b, a1[0].b2[0], 1);
+  CMP(a, b, a1[0].b2[1], 1);
+  CMP(a, b, a1[1].b1, true);
+  CMP(a, b, a1[1].b2[0], 3);
+  CMP(a, b, a1[1].b2[1], 4);
+  return 0;
+}
+
+#endif


### PR DESCRIPTION
This fixes an issue in the cdrstream deserializer, the alignment of elements of collections with 64 bits element type. When reading data from a XCDR2 stream containing a sequence or array that has a 64 bits element type, the max-alignment for xcdr2 (4 bytes) was not taken into account.
