### PR TITLE
Fix export of SHM_SUPPORT_IS_AVAILABLE property

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -71,7 +71,7 @@ define_property(TARGET
     FULL_DOCS "Indicator whether SHM support is available with current Cyclone DDS build configuration."
     )
 set_target_properties(ddsc PROPERTIES
-    SHM_SUPPORT_IS_AVAILABLE "${DDS_HAS_SHM}")
+    SHM_SUPPORT_IS_AVAILABLE "${ENABLE_SHM}")
 set_target_properties(ddsc PROPERTIES EXPORT_PROPERTIES
     "SHM_SUPPORT_IS_AVAILABLE")
 


### PR DESCRIPTION
I missed this one. Causes cyclonedds-cxx build to fail. Verified locally.