### PR TITLE
Fixing build warnings in idlc xtests

### DIFF
--- a/src/core/ddsc/tests/cdrstream.c
+++ b/src/core/ddsc/tests/cdrstream.c
@@ -151,14 +151,14 @@ static void * sample_init_str (void)
 {
   TestIdl_MsgStr *msg = ddsrt_calloc (1, sizeof (*msg));
   msg->msg_field1.str1 = ddsrt_strdup (RND_STR32);
-  strcpy (msg->msg_field1.str2, RND_STR5);
+  ddsrt_strlcpy (msg->msg_field1.str2, RND_STR5, sizeof (msg->msg_field1.str2));
 
   msg->msg_field1.strseq3[0] = ddsrt_strdup (RND_STR32);
   msg->msg_field1.strseq3[1] = ddsrt_strdup (RND_STR32);
 
-  strcpy (msg->msg_field1.strseq4[0], RND_STR5);
-  strcpy (msg->msg_field1.strseq4[1], RND_STR5);
-  strcpy (msg->msg_field1.strseq4[2], RND_STR5);
+  ddsrt_strlcpy (msg->msg_field1.strseq4[0], RND_STR5, sizeof (msg->msg_field1.strseq4[0]));
+  ddsrt_strlcpy (msg->msg_field1.strseq4[1], RND_STR5, sizeof (msg->msg_field1.strseq4[1]));
+  ddsrt_strlcpy (msg->msg_field1.strseq4[2], RND_STR5, sizeof (msg->msg_field1.strseq4[2]));
 
   return msg;
 }
@@ -423,8 +423,8 @@ static void * sample_init_ext (void)
   TestIdl_MsgExt *msg = ddsrt_malloc (sizeof (*msg));
   msg->f1 = ddsrt_strdup (RND_STR32);
 
-  msg->f2 = ddsrt_malloc (sizeof (*msg->f2));
-  strcpy (*msg->f2, RND_STR32);
+  msg->f2 = ddsrt_malloc (sizeof (*msg->f2) + 1);
+  ddsrt_strlcpy (*msg->f2, RND_STR32, sizeof (*msg->f2));
 
   msg->f3 = ddsrt_malloc (sizeof (*msg->f3));
   msg->f3->b1 = ddsrt_malloc (sizeof (*msg->f3->b1));
@@ -555,8 +555,8 @@ static void * sample_init_opt (void)
   }
   if (RND_INT32 % 2)
   {
-    msg->f4 = ddsrt_malloc (sizeof (*msg->f4));
-    strcpy (*msg->f4, RND_STR32);
+    msg->f4 = ddsrt_malloc (sizeof (*msg->f4) + 1);
+    ddsrt_strlcpy (*msg->f4, RND_STR32, sizeof (*msg->f4));
   }
   if (RND_INT32 % 2)
   {

--- a/src/tools/idlc/xtests/common.h
+++ b/src/tools/idlc/xtests/common.h
@@ -14,6 +14,8 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/string.h"
 
 #define STR16 "abcdef0123456789"
 #define STR128 STR16 STR16 STR16 STR16 STR16 STR16 STR16 STR16
@@ -28,7 +30,11 @@
 #define STRA(s,str) \
 { \
   (s) = dds_alloc (strlen(str) + 1); \
-  strcpy ((s), (str)); \
+  ddsrt_strlcpy ((s), (str), strlen((str)) + 1); \
+}
+#define STRCPY(s,str) \
+{ \
+  ddsrt_strlcpy ((s), (str), sizeof ((s))); \
 }
 #define EXTA(s,n) \
 { \

--- a/src/tools/idlc/xtests/test_alias.idl
+++ b/src/tools/idlc/xtests/test_alias.idl
@@ -75,12 +75,12 @@ void init_sample (void *s)
   s1->f1._buffer[1].a1 = 2;
   // s1->f2
   for (int n = 0; n < 3; n++)
-    strcpy (s1->f2[n], STR128);
+    STRCPY (s1->f2[n], STR128);
   // s1->f3
   SEQA(s1->f3, 1)
   SEQA(s1->f3._buffer[0], 5)
   for (int n = 0; n < 5; n++)
-    strcpy(s1->f3._buffer[0]._buffer[n], STR128);
+    STRCPY(s1->f3._buffer[0]._buffer[n], STR128);
   // s1->f4
   s1->f4 = dds_alloc (sizeof (*s1->f4));
   // s1->f4->b1
@@ -99,15 +99,15 @@ void init_sample (void *s)
   s1->f4->b2[1]._buffer[1].a1 = 7;
   s1->f4->b2[2]._buffer[0].a1 = 8;
   // s1->f4->b3
-  s1->f4->b3 = 1.01;
+  s1->f4->b3 = 1.01f;
   // s1->f4->b4
   SEQA(s1->f4->b4, 2)
   s1->f4->b4._buffer[0]._d = 10;
-  strcpy(s1->f4->b4._buffer[0]._u.ud, STR128);
+  STRCPY(s1->f4->b4._buffer[0]._u.ud, STR128);
   s1->f4->b4._buffer[1]._d = 2;
   SEQA(s1->f4->b4._buffer[1]._u.u2, 5)
   for (int n = 0; n < 5; n++)
-    strcpy(s1->f4->b4._buffer[1]._u.u2._buffer[n], STR128);
+    STRCPY(s1->f4->b4._buffer[1]._u.u2._buffer[n], STR128);
 }
 
 int cmp_sample (const void *sa, const void *sb)

--- a/src/tools/idlc/xtests/test_bounded_seq.idl
+++ b/src/tools/idlc/xtests/test_bounded_seq.idl
@@ -70,7 +70,7 @@ void init_sample (void *s)
 
   SEQA (s1->f3, 3);
   for (int n = 0; n < 3; n++)
-    strcpy (s1->f3._buffer[n], STR16);
+    STRCPY (s1->f3._buffer[n], STR16);
 
   SEQA (s1->f4, 4);
   for (int n = 0; n < 4; n++)

--- a/src/tools/idlc/xtests/test_optional.idl
+++ b/src/tools/idlc/xtests/test_optional.idl
@@ -84,7 +84,7 @@ void init_sample (void *s)
   s1->f2n = NULL;
 
   A (s1->f3);
-  strcpy (*(s1->f3), STR128);
+  STRCPY (*(s1->f3), STR128);
   s1->f3n = NULL;
 
   A (s1->f4);

--- a/src/tools/idlc/xtests/test_optional_mutable.idl
+++ b/src/tools/idlc/xtests/test_optional_mutable.idl
@@ -66,7 +66,7 @@ void init_sample (void *s)
   s1->f2n = NULL;
 
   A (s1->f3);
-  strcpy (*(s1->f3), STR128);
+  STRCPY (*(s1->f3), STR128);
   s1->f3n = NULL;
 
   A (s1->f4);

--- a/src/tools/idlc/xtests/test_struct_external.idl
+++ b/src/tools/idlc/xtests/test_struct_external.idl
@@ -59,7 +59,7 @@ void init_sample (void *s)
   STRA (s1->f2, STR128);
 
   A (s1->f3);
-  strcpy (*(s1->f3), STR128);
+  STRCPY (*(s1->f3), STR128);
 
   A (s1->f4);
   (*s1->f4).b1 = 456;

--- a/src/tools/idlc/xtests/test_struct_inherit_appendable.idl
+++ b/src/tools/idlc/xtests/test_struct_inherit_appendable.idl
@@ -57,8 +57,7 @@ void init_sample (void *s)
 {
   test_struct_inherit *s1 = (test_struct_inherit *) s;
   s1->parent.b1 = 123;
-  s1->parent.b2.n1 = dds_alloc(sizeof(STR128) + 1);
-  strcpy (s1->parent.b2.n1, STR128);
+  STRA (s1->parent.b2.n1, STR128);
   s1->parent.b2.n2 = 456;
   s1->parent.b2.n3.c1 = 789;
   s1->parent.parent.c1 = 321;

--- a/src/tools/idlc/xtests/test_union_external.idl
+++ b/src/tools/idlc/xtests/test_union_external.idl
@@ -80,7 +80,7 @@ void init_sample (void *s)
 
   s1->f[2]._d = 3;
   A (s1->f[2]._u.u3);
-  strcpy (*(s1->f[2]._u.u3), STR128);
+  STRCPY (*(s1->f[2]._u.u3), STR128);
 
   s1->f[3]._d = 4;
   A (s1->f[3]._u.u4);
@@ -109,7 +109,7 @@ void init_sample (void *s)
 
   s1->f[8]._d = 9;
   A (s1->f[8]._u.u9);
-  strcpy (*(s1->f[8]._u.u9), STR128);
+  STRCPY (*(s1->f[8]._u.u9), STR128);
 
   s1->f[9]._d = 10;
   A (s1->f[9]._u.u10);

--- a/src/tools/idlc/xtests/test_union_member_types_r.idl
+++ b/src/tools/idlc/xtests/test_union_member_types_r.idl
@@ -86,7 +86,7 @@ void init_sample (void *s)
   t->s1._d = 1;
   A (t->s1._u.u1);
   t->s1._u.u1->_d = 6;
-  strcpy(t->s1._u.u1->_u.u6, STR128);
+  STRCPY(t->s1._u.u1->_u.u6, STR128);
 
   // case 2: struct_nested1 u2;
   t->s2._d = 2;
@@ -111,7 +111,7 @@ void init_sample (void *s)
 
   // case 6: string<128> u6;
   t->s6._d = 6;
-  strcpy(t->s6._u.u6, STR128);
+  STRCPY(t->s6._u.u6, STR128);
 
   // case 7: bm1 u7;
   t->s7._d = 7;


### PR DESCRIPTION
This fixes some strcpy build-warnings in the idlc xtests on Windows.