### PR TITLE
Fix data representation in RTPS encapsulation identifier

### DIFF
--- a/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
@@ -265,7 +265,6 @@ enum dds_stream_typecode_subtype {
                                       an optional member also gets the FLAG_EXT, see above. */
 
 /* Topic descriptor flag values */
-#define DDS_TOPIC_FLAGS_MASK                    0x3fffffff  /* The 2 most significant bits are used for type extensibility */
 #define DDS_TOPIC_NO_OPTIMIZE                   (1u << 0)
 #define DDS_TOPIC_FIXED_KEY                     (1u << 1)   /* Set if the XCDR1 serialized key fits in 16 bytes */
 #define DDS_TOPIC_CONTAINS_UNION                (1u << 2)
@@ -276,13 +275,6 @@ enum dds_stream_typecode_subtype {
 
 /* Max size of fixed key */
 #define DDS_FIXED_KEY_MAX_SIZE (16)
-
-
-#define DDS_TOPIC_TYPE_EXTENSIBILITY_MASK       0xc0000000
-#define DDS_TOPIC_TYPE_EXTENSIBILITY(fs)        (((fs) & DDS_TOPIC_TYPE_EXTENSIBILITY_MASK) >> 30)
-#define DDS_TOPIC_TYPE_EXTENSIBILITY_FINAL      (0u << 30)
-#define DDS_TOPIC_TYPE_EXTENSIBILITY_APPENDABLE (1u << 30)
-#define DDS_TOPIC_TYPE_EXTENSIBILITY_MUTABLE    (2u << 30)
 
 #if defined(__cplusplus)
 }

--- a/src/core/ddsc/tests/cdrstream.c
+++ b/src/core/ddsc/tests/cdrstream.c
@@ -712,7 +712,7 @@ static const uint32_t TestIdl_AppendableMsg_ops [] =
   DDS_OP_RTS,
 };
 
-const dds_topic_descriptor_t TestIdl_MsgAppendable_desc = { sizeof (TestIdl_AppendableMsg), 4u, DDS_TOPIC_NO_OPTIMIZE | DDS_TOPIC_TYPE_EXTENSIBILITY_APPENDABLE, 0u, "TestIdl::AppendableMsg", NULL, 4, TestIdl_AppendableMsg_ops, "" };
+const dds_topic_descriptor_t TestIdl_MsgAppendable_desc = { sizeof (TestIdl_AppendableMsg), 4u, DDS_TOPIC_NO_OPTIMIZE, 0u, "TestIdl::AppendableMsg", NULL, 4, TestIdl_AppendableMsg_ops, "" };
 
 static void * sample_init_appendable (void)
 {

--- a/src/core/ddsi/include/dds/ddsi/ddsi_cdrstream.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_cdrstream.h
@@ -92,6 +92,8 @@ DDS_EXPORT size_t dds_stream_print_sample (dds_istream_t * __restrict is, const 
 
 DDS_EXPORT uint16_t dds_stream_minimum_xcdr_version (const uint32_t * __restrict ops);
 DDS_EXPORT uint32_t dds_stream_type_nesting_depth (const uint32_t * __restrict ops);
+DDS_EXPORT bool dds_stream_extensibility (const uint32_t * __restrict ops, enum ddsi_sertype_extensibility *ext);
+
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsi/include/dds/ddsi/ddsi_serdata_default.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_serdata_default.h
@@ -123,7 +123,6 @@ struct ddsi_sertype_default_desc {
   uint32_t size;    /* Size of topic type */
   uint32_t align;   /* Alignment of topic type */
   uint32_t flagset; /* Flags */
-  enum ddsi_sertype_extensibility extensibility;  /* Extensibility of the top-level type */
   ddsi_sertype_default_desc_key_seq_t keys;
   ddsi_sertype_default_desc_op_seq_t ops;
   ddsi_sertype_cdr_data_t typeinfo_ser;

--- a/src/core/ddsi/include/dds/ddsi/ddsi_sertype.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_sertype.h
@@ -197,10 +197,10 @@ DDS_EXPORT uint32_t ddsi_sertype_compute_serdata_basehash (const struct ddsi_ser
 DDS_EXPORT bool ddsi_sertype_equal (const struct ddsi_sertype *a, const struct ddsi_sertype *b);
 DDS_EXPORT uint32_t ddsi_sertype_hash (const struct ddsi_sertype *tp);
 
-DDS_EXPORT uint16_t ddsi_sertype_get_encoding_format (enum ddsi_sertype_extensibility type_extensibility);
-DDS_EXPORT uint16_t ddsi_sertype_get_native_encoding_identifier (uint32_t enc_version, uint32_t encoding_format);
-DDS_EXPORT uint32_t get_xcdr_version (uint16_t cdr_identifier);
-
+DDS_EXPORT uint16_t ddsi_sertype_extensibility_enc_format (enum ddsi_sertype_extensibility type_extensibility);
+DDS_EXPORT uint16_t ddsi_sertype_get_native_enc_identifier (uint32_t enc_version, uint32_t encoding_format);
+DDS_EXPORT uint32_t ddsi_sertype_enc_id_xcdr_version (uint16_t cdr_identifier);
+DDS_EXPORT uint32_t ddsi_sertype_enc_id_enc_format (uint16_t cdr_identifier);
 
 DDS_INLINE_EXPORT inline void ddsi_sertype_free (struct ddsi_sertype *tp) {
   tp->ops->free (tp);

--- a/src/core/ddsi/src/ddsi_cdrstream.c
+++ b/src/core/ddsi/src/ddsi_cdrstream.c
@@ -2430,13 +2430,15 @@ static const uint32_t *stream_normalize_data_impl (char * __restrict data, uint3
         break;
       }
       case DDS_OP_DLC: {
-        assert (xcdr_version == CDR_ENC_VERSION_2);
+        if (xcdr_version != CDR_ENC_VERSION_2)
+          return NULL;
         if ((ops = stream_normalize_delimited (data, off, size, bswap, xcdr_version, ops)) == NULL)
           return NULL;
         break;
       }
       case DDS_OP_PLC: {
-        assert (xcdr_version == CDR_ENC_VERSION_2);
+        if (xcdr_version != CDR_ENC_VERSION_2)
+          return NULL;
         if ((ops = stream_normalize_pl (data, off, size, bswap, xcdr_version, ops)) == NULL)
           return NULL;
         break;
@@ -2508,14 +2510,14 @@ static bool stream_normalize_key (void * __restrict data, uint32_t size, bool bs
   return true;
 }
 
-bool dds_stream_normalize (void * __restrict data, uint32_t size, bool bswap, uint32_t xcdr_version, const struct ddsi_sertype_default * __restrict topic, bool just_key, uint32_t * __restrict actual_size)
+bool dds_stream_normalize (void * __restrict data, uint32_t size, bool bswap, uint32_t xcdr_version, const struct ddsi_sertype_default * __restrict sertype, bool just_key, uint32_t * __restrict actual_size)
 {
   uint32_t off = 0;
   if (size > CDR_SIZE_MAX)
     return false;
   else if (just_key)
-    return stream_normalize_key (data, size, bswap, xcdr_version, &topic->type, actual_size);
-  else if (!stream_normalize_data_impl (data, &off, size, bswap, xcdr_version, topic->type.ops.ops, false))
+    return stream_normalize_key (data, size, bswap, xcdr_version, &sertype->type, actual_size);
+  else if (!stream_normalize_data_impl (data, &off, size, bswap, xcdr_version, sertype->type.ops.ops, false))
     return false;
   else
   {
@@ -3671,7 +3673,7 @@ void dds_istream_from_serdata_default (dds_istream_t * __restrict s, const struc
 #elif DDSRT_ENDIAN == DDSRT_BIG_ENDIAN
   assert (!CDR_ENC_LE (d->hdr.identifier));
 #endif
-  s->m_xcdr_version = get_xcdr_version (d->hdr.identifier);
+  s->m_xcdr_version = ddsi_sertype_enc_id_xcdr_version (d->hdr.identifier);
 }
 
 void dds_ostream_from_serdata_default (dds_ostream_t * __restrict s, const struct ddsi_serdata_default * __restrict d)
@@ -3684,7 +3686,7 @@ void dds_ostream_from_serdata_default (dds_ostream_t * __restrict s, const struc
 #elif DDSRT_ENDIAN == DDSRT_BIG_ENDIAN
   assert (!CDR_ENC_LE (d->hdr.identifier));
 #endif
-  s->m_xcdr_version = get_xcdr_version (d->hdr.identifier);
+  s->m_xcdr_version = ddsi_sertype_enc_id_xcdr_version (d->hdr.identifier);
 }
 
 void dds_ostream_add_to_serdata_default (dds_ostream_t * __restrict s, struct ddsi_serdata_default ** __restrict d)
@@ -3704,13 +3706,43 @@ void dds_ostream_add_to_serdata_default (dds_ostream_t * __restrict s, struct dd
 
 /* Gets the (minimum) extensibility of the types used for this topic, and returns the XCDR
    version that is required for (de)serializing the type for this topic descriptor */
-// FIXME: move this check to idl-compile time?
 uint16_t dds_stream_minimum_xcdr_version (const uint32_t * __restrict ops)
 {
   uint16_t min_xcdrv = CDR_ENC_VERSION_1;
   const uint32_t *ops_end = ops;
   dds_stream_countops1 (ops, &ops_end, &min_xcdrv, 0, NULL);
   return min_xcdrv;
+}
+
+/* Gets the extensibility of the top-level type for a topic, by inspecting the serializer ops */
+bool dds_stream_extensibility (const uint32_t * __restrict ops, enum ddsi_sertype_extensibility *ext)
+{
+  uint32_t insn;
+
+  assert (ext);
+  while ((insn = *ops) != DDS_OP_RTS)
+  {
+    switch (DDS_OP (insn))
+    {
+      case DDS_OP_ADR:
+        *ext = DDSI_SERTYPE_EXT_FINAL;
+        return true;
+      case DDS_OP_JSR:
+        if (DDS_OP_JUMP (insn) > 0)
+          return dds_stream_extensibility (ops + DDS_OP_JUMP (insn), ext);
+        break;
+      case DDS_OP_DLC:
+        *ext = DDSI_SERTYPE_EXT_APPENDABLE;
+        return true;
+      case DDS_OP_PLC:
+        *ext = DDSI_SERTYPE_EXT_MUTABLE;
+        return true;
+      case DDS_OP_RTS: case DDS_OP_JEQ: case DDS_OP_JEQ4: case DDS_OP_KOF: case DDS_OP_PLM:
+        abort ();
+        break;
+    }
+  }
+  return false;
 }
 
 uint32_t dds_stream_type_nesting_depth (const uint32_t * __restrict ops)

--- a/src/core/ddsi/src/ddsi_serdata_plist.c
+++ b/src/core/ddsi/src/ddsi_serdata_plist.c
@@ -213,7 +213,7 @@ static void serdata_plist_to_ser_unref (struct ddsi_serdata *serdata_common, con
 static struct ddsi_serdata *serdata_plist_from_sample (const struct ddsi_sertype *tpcmn, enum ddsi_serdata_kind kind, const void *sample)
 {
   const struct ddsi_sertype_plist *tp = (const struct ddsi_sertype_plist *)tpcmn;
-  const struct { uint16_t identifier, options; } header = { ddsi_sertype_get_native_encoding_identifier (CDR_ENC_VERSION_1, tp->encoding_format), 0 };
+  const struct { uint16_t identifier, options; } header = { ddsi_sertype_get_native_enc_identifier (CDR_ENC_VERSION_1, tp->encoding_format), 0 };
 
   // FIXME: key must not require byteswapping (GUIDs are ok)
   // FIXME: rework plist stuff so it doesn't need an nn_xmsg

--- a/src/core/ddsi/src/ddsi_serdata_pserop.c
+++ b/src/core/ddsi/src/ddsi_serdata_pserop.c
@@ -201,7 +201,7 @@ static void serdata_pserop_to_ser_unref (struct ddsi_serdata *serdata_common, co
 static struct ddsi_serdata *serdata_pserop_from_sample (const struct ddsi_sertype *tpcmn, enum ddsi_serdata_kind kind, const void *sample)
 {
   const struct ddsi_sertype_pserop *tp = (const struct ddsi_sertype_pserop *)tpcmn;
-  const struct { uint16_t identifier, options; } header = { ddsi_sertype_get_native_encoding_identifier (CDR_ENC_VERSION_1, tp->encoding_format), 0 };
+  const struct { uint16_t identifier, options; } header = { ddsi_sertype_get_native_enc_identifier (CDR_ENC_VERSION_1, tp->encoding_format), 0 };
   if (kind == SDK_KEY && tp->ops_key == NULL)
     return serdata_pserop_fix (tp, serdata_pserop_new (tp, kind, 0, &header));
   else

--- a/src/core/ddsi/src/ddsi_sertype.c
+++ b/src/core/ddsi/src/ddsi_sertype.c
@@ -213,7 +213,7 @@ uint32_t ddsi_sertype_compute_serdata_basehash (const struct ddsi_serdata_ops *o
   return res;
 }
 
-uint16_t ddsi_sertype_get_native_encoding_identifier (uint32_t enc_version, uint32_t enc_format)
+uint16_t ddsi_sertype_get_native_enc_identifier (uint32_t enc_version, uint32_t enc_format)
 {
 #define CONCAT_(a,b) (a ## b)
 #define CONCAT(id,suffix) CONCAT_(id,suffix)
@@ -244,7 +244,7 @@ uint16_t ddsi_sertype_get_native_encoding_identifier (uint32_t enc_version, uint
 #undef CONCAT_
 }
 
-uint16_t ddsi_sertype_get_encoding_format (enum ddsi_sertype_extensibility type_extensibility)
+uint16_t ddsi_sertype_extensibility_enc_format (enum ddsi_sertype_extensibility type_extensibility)
 {
   switch (type_extensibility)
   {
@@ -259,7 +259,7 @@ uint16_t ddsi_sertype_get_encoding_format (enum ddsi_sertype_extensibility type_
   }
 }
 
-uint32_t get_xcdr_version (uint16_t cdr_identifier)
+uint32_t ddsi_sertype_enc_id_xcdr_version (uint16_t cdr_identifier)
 {
   switch (cdr_identifier)
   {
@@ -271,6 +271,22 @@ uint32_t get_xcdr_version (uint16_t cdr_identifier)
       return CDR_ENC_VERSION_2;
     default:
       return CDR_ENC_VERSION_UNDEF;
+  }
+}
+
+uint32_t ddsi_sertype_enc_id_enc_format (uint16_t cdr_identifier)
+{
+  switch (cdr_identifier)
+  {
+    case CDR_LE: case CDR_BE:
+    case CDR2_LE: case CDR2_BE:
+      return CDR_ENC_FORMAT_PLAIN;
+    case D_CDR2_LE: case D_CDR2_BE:
+      return CDR_ENC_FORMAT_DELIMITED;
+    case PL_CDR2_LE: case PL_CDR2_BE:
+      return CDR_ENC_FORMAT_PL;
+    default:
+      abort ();
   }
 }
 


### PR DESCRIPTION
The RTPS encapsulation identifier should correspond to the encoding version and data representation of the outermost object of the type used for a topic. This commit fixes the issue that Cyclone was using an incorrect value for this identifier when writing data for a topic with an appendable or mutable top-level type.

The Cyclone deserializer uses the data representation as provided in the serializer instructions for that type, but did not check that the encapsulation identifier in the RTPS submessage indicates the same data representation. This commit also introduces that check.