### PR TITLE
Set OpenSSL API compatibility to 1.1.1

### DIFF
--- a/src/core/ddsi/src/ddsi_ssl.c
+++ b/src/core/ddsi/src/ddsi_ssl.c
@@ -357,7 +357,9 @@ static SSL *ddsi_ssl_accept (const struct ddsi_domaingv *gv, BIO *bio, ddsrt_soc
 static bool ddsi_ssl_init (struct ddsi_domaingv *gv)
 {
   /* FIXME: allocate this stuff ... don't copy gv into a global variable ... */
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
   ERR_load_BIO_strings ();
+#endif
   SSL_load_error_strings ();
   SSL_library_init ();
   OpenSSL_add_all_algorithms ();

--- a/src/security/openssl/include/dds/security/openssl_support.h
+++ b/src/security/openssl/include/dds/security/openssl_support.h
@@ -40,6 +40,8 @@
 #include <WinSock2.h>
 #endif
 
+#define OPENSSL_API_COMPAT 10101
+
 #include <openssl/opensslv.h>
 #include <openssl/opensslconf.h>
 #include <openssl/asn1.h>


### PR DESCRIPTION
This suppresses deprecation warnings from OpenSSL 3.0. I think this is a sensible fix for the 0.8.x release branch, but if we can avoid it for master, then that would be my preference as it really is not a proper fix to just suppress deprecation warnings.

Signed-off-by: Erik Boasson <eb@ilities.com>