### PR TITLE
Data representation qos refactoring

### DIFF
--- a/src/core/ddsc/src/dds__types.h
+++ b/src/core/ddsc/src/dds__types.h
@@ -355,7 +355,6 @@ typedef struct dds_writer {
   struct writer *m_wr;
   struct whc *m_whc; /* FIXME: ownership still with underlying DDSI writer (cos of DDSI built-in writers )*/
   bool whc_batch; /* FIXME: channels + latency budget */
-  dds_data_representation_id_t m_data_representation;
 #ifdef DDS_HAS_SHM
   iox_pub_storage_t m_iox_pub_stor;
   iox_pub_t m_iox_pub;

--- a/src/core/ddsc/src/dds_topic.c
+++ b/src/core/ddsc/src/dds_topic.c
@@ -482,6 +482,8 @@ dds_entity_t dds_create_topic_impl (
    * for reliability that is dependent on the entity type: readers and
    * topics default to best-effort, but writers to reliable.
    *
+   * Similar for DATA_REPRESENTATION.
+   *
    * Leaving the topic QoS sparse means a default-default topic QoS of
    * best-effort will do "the right thing" and let a writer still default to
    * reliable ... (and keep behaviour unchanged) */

--- a/src/core/ddsc/src/dds_writer.c
+++ b/src/core/ddsc/src/dds_writer.c
@@ -415,7 +415,6 @@ dds_entity_t dds_create_writer (dds_entity_t participant_or_publisher, dds_entit
   wr->m_whc = whc_new (gv, wrinfo);
   whc_free_wrinfo (wrinfo);
   wr->whc_batch = gv->config.whc_batch;
-  wr->m_data_representation = data_representation;
 
 #ifdef DDS_HAS_SHM
   assert(wqos->present & QP_LOCATOR_MASK);
@@ -423,7 +422,7 @@ dds_entity_t dds_create_writer (dds_entity_t participant_or_publisher, dds_entit
     wqos->ignore_locator_type |= NN_LOCATOR_KIND_SHEM;
 #endif
 
-  struct ddsi_sertype *sertype = ddsi_sertype_derive_sertype (tp->m_stype, wr->m_data_representation,
+  struct ddsi_sertype *sertype = ddsi_sertype_derive_sertype (tp->m_stype, data_representation,
     wqos->present & QP_TYPE_CONSISTENCY_ENFORCEMENT ? wqos->type_consistency : ddsi_default_qos_topic.type_consistency);
   if (!sertype)
     sertype = tp->m_stype;

--- a/src/core/ddsc/src/dds_writer.c
+++ b/src/core/ddsc/src/dds_writer.c
@@ -370,13 +370,12 @@ dds_entity_t dds_create_writer (dds_entity_t participant_or_publisher, dds_entit
     ddsi_xqos_mergein_missing (wqos, pub->m_entity.m_qos, ~(uint64_t)0);
   if (tp->m_ktopic->qos)
     ddsi_xqos_mergein_missing (wqos, tp->m_ktopic->qos, ~(uint64_t)0);
-  ddsi_xqos_mergein_missing (wqos, &ddsi_default_qos_writer, ~(uint64_t)0);
+  ddsi_xqos_mergein_missing (wqos, &ddsi_default_qos_writer, ~QP_DATA_REPRESENTATION);
+  if ((rc = dds_ensure_valid_data_representation (wqos, tp->m_stype->min_xcdrv, false)) != 0)
+    goto err_data_repr;
 
   if ((rc = ddsi_xqos_valid (&gv->logconfig, wqos)) < 0 || (rc = validate_writer_qos(wqos)) != DDS_RETCODE_OK)
     goto err_bad_qos;
-
-  if ((rc = dds_ensure_valid_data_representation (wqos, tp->m_stype->min_xcdrv, false)) != 0)
-    goto err_data_repr;
 
   assert (wqos->present & QP_DATA_REPRESENTATION && wqos->data_representation.value.n > 0);
   dds_data_representation_id_t data_representation = wqos->data_representation.value.ids[0];
@@ -469,8 +468,8 @@ dds_entity_t dds_create_writer (dds_entity_t participant_or_publisher, dds_entit
 err_not_allowed:
   thread_state_asleep (lookup_thread_state ());
 #endif
-err_data_repr:
 err_bad_qos:
+err_data_repr:
   dds_delete_qos(wqos);
   dds_topic_allow_set_qos (tp);
 err_pp_mismatch:

--- a/src/core/ddsc/tests/data_representation.c
+++ b/src/core/ddsc/tests/data_representation.c
@@ -433,7 +433,7 @@ CU_Test (ddsc_data_representation, update_qos, .init = data_representation_init,
   enum { RD, WR, TP } tests[] = { RD, WR, TP };
   for (uint32_t i = 0; i < sizeof (tests) / sizeof (tests[0]); i++)
   {
-    dds_entity_t ent;
+    dds_entity_t ent = 0;
     switch (tests[i]) {
       case RD: printf("RD\n"); ent = dds_create_reader (dp1, tp1, NULL, NULL); break;
       case WR: printf("WR\n"); ent = dds_create_writer (dp1, tp1, NULL, NULL); break;
@@ -463,7 +463,7 @@ CU_Test (ddsc_data_representation, update_qos, .init = data_representation_init,
     {
       // get qos from entity, update mutable qos policy and set qos to entity
       dds_qos_t *qos = dds_create_qos ();
-      dds_return_t ret = dds_get_qos (ent, qos);
+      ret = dds_get_qos (ent, qos);
       CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
       dds_qset_partition1 (qos, "test1");
       ret = dds_set_qos (ent, qos);

--- a/src/core/ddsi/src/ddsi_plist.c
+++ b/src/core/ddsi/src/ddsi_plist.c
@@ -625,8 +625,12 @@ static dds_return_t deser_data_representation (void * __restrict dst, struct fla
   uint32_t cnt;
   int16_t v;
   (void) gv;
-  if (deser_uint32 (&cnt, dd, &srcoff) < 0)
+  if (deser_uint32 (&cnt, dd, &srcoff) < 0 || cnt > (dd->bufsz - srcoff) / sizeof (int16_t))
     return DDS_RETCODE_BAD_PARAMETER;
+  /* Consider an empty list as if the parameter is not set, the resulting qos will get default
+     data representation when the default qos for the entity is merged in. */
+  if (cnt == 0)
+    return 0;
   x->value.n = cnt;
   x->value.ids = ddsrt_malloc (cnt * sizeof (*x->value.ids));
   /* coverity[tainted_data: FALSE] */

--- a/src/core/ddsi/src/q_qosmatch.c
+++ b/src/core/ddsi/src/q_qosmatch.c
@@ -101,33 +101,18 @@ static bool check_endpoint_typeid (struct ddsi_domaingv *gv, char *type_name, co
 
 #endif /* DDS_HAS_TYPE_DISCOVERY */
 
-static int data_representation_match_default (const dds_qos_t *x, bool is_writer)
-{
-  if (x->data_representation.value.n == 0)
-    return 1;
-  /* For writer use only the first value */
-  for (uint32_t i = 0; i < (is_writer ? 1 : x->data_representation.value.n); i++)
-    if (x->data_representation.value.ids[i] == DDS_DATA_REPRESENTATION_XCDR1)
-      return 1;
-  return 0;
-}
-
 static int data_representation_match_p (const dds_qos_t *rd_qos, const dds_qos_t *wr_qos)
 {
   assert (rd_qos->present & QP_DATA_REPRESENTATION);
+  assert (rd_qos->data_representation.value.n > 0);
   assert (wr_qos->present & QP_DATA_REPRESENTATION);
-  if (rd_qos->data_representation.value.n == 0)
-    return data_representation_match_default (wr_qos, true);
-  else if (wr_qos->data_representation.value.n == 0)
-    return data_representation_match_default (rd_qos, false);
-  else
-  {
-    /* For the writer only use the first representation identifier and ignore 1..n (spec 7.6.3.1.1) */
-    for (uint32_t i = 0; i < rd_qos->data_representation.value.n; i++)
-      if (rd_qos->data_representation.value.ids[i] == wr_qos->data_representation.value.ids[0])
-        return 1;
-    return 0;
-  }
+  assert (wr_qos->data_representation.value.n > 0);
+
+  /* For the writer only use the first representation identifier and ignore 1..n (spec 7.6.3.1.1) */
+  for (uint32_t i = 0; i < rd_qos->data_representation.value.n; i++)
+    if (rd_qos->data_representation.value.ids[i] == wr_qos->data_representation.value.ids[0])
+      return 1;
+  return 0;
 }
 
 #ifdef DDS_HAS_TYPE_DISCOVERY


### PR DESCRIPTION
Some minor refactoring of the implementation of the data representation qos: in discovery data, consider an empty list of values as 'not present', so that the default (`XCDR1`) will be merged in the qos, and the qos matching code can safely assume that the data representation qos is always present and has at least 1 value.

Also add a check in `deser_data_representation` to ensure that the buffer has sufficient bytes remaining to the provided data representation value count, to avoid allocating a large amount of memory (e.g. in case of a malicious node that send a large count).