### PR TITLE
Fix deprecated use of idlc_generate

### DIFF
--- a/cmake/Modules/Generate.cmake
+++ b/cmake/Modules/Generate.cmake
@@ -16,7 +16,8 @@ function(IDLC_GENERATE)
   cmake_parse_arguments(
     IDLC "" "${one_value_keywords}" "${multi_value_keywords}" "" ${ARGN})
 
-  idlc_generate_generic(TARGET ${IDLC_TARGET}
+  idlc_generate_generic(${IDLC_UNPARSED_ARGUMENTS}
+    TARGET ${IDLC_TARGET}
     FILES ${IDLC_FILES}
     FEATURES ${IDLC_FEATURES}
     INCLUDES ${IDLC_INCLUDES}


### PR DESCRIPTION
To support the deprecated use of `idlc_generate` (without using keyword based arguments), unparsed arguments should be passed to `idlc_generate_generic`