### PR TITLE
Fix optional collections of unbounded strings

### DIFF
--- a/src/tools/idlc/src/descriptor.c
+++ b/src/tools/idlc/src/descriptor.c
@@ -1175,12 +1175,12 @@ emit_sequence(
          because the latter could be a typedef in case of an aliased type */
       idl_node_t *member_node = idl_parent(field->node);
       assert(idl_is_member(member_node));
-      if (idl_is_external(member_node) && !idl_is_unbounded_string(type_spec))
+      if (idl_is_external(member_node))
         opcode |= DDS_OP_FLAG_EXT;
-      /* Add FLAG_OPT, and add FLAG_EXT for non-string type as an optional field is represented in
-         the same way as external fields */
+      /* Add FLAG_OPT, and add FLAG_EXT, because an optional field is represented in the same way as
+         external fields */
       if (idl_is_optional(member_node))
-        opcode |= DDS_OP_FLAG_OPT | (idl_is_unbounded_string(type_spec) ? 0 : DDS_OP_FLAG_EXT);
+        opcode |= DDS_OP_FLAG_OPT | DDS_OP_FLAG_EXT;
       if (idl_is_must_understand(member_node))
         opcode |= DDS_OP_FLAG_MU;
     }
@@ -1300,10 +1300,12 @@ emit_array(
        an external member */
     idl_node_t *parent = idl_parent(node);
     if (idl_is_struct(stype->node)) {
-      if (idl_is_external(parent) && !idl_is_unbounded_string(type_spec))
+      if (idl_is_external(parent))
         opcode |= DDS_OP_FLAG_EXT;
+      /* Add FLAG_OPT, and add FLAG_EXT, because an optional field is represented in the same way as
+         external fields */
       if (idl_is_optional(parent))
-        opcode |= DDS_OP_FLAG_OPT | (idl_is_unbounded_string(type_spec) ? 0 : DDS_OP_FLAG_EXT);
+        opcode |= DDS_OP_FLAG_OPT | DDS_OP_FLAG_EXT;
       if (idl_is_must_understand(parent))
         opcode |= DDS_OP_FLAG_MU;
     }
@@ -1488,6 +1490,8 @@ emit_declarator(
     if (idl_is_struct(stype->node) && (idl_is_external(parent) || idl_is_optional(parent))) {
       if (idl_is_external(parent) && !idl_is_unbounded_string(type_spec))
         opcode |= DDS_OP_FLAG_EXT;
+      /* For optional field of non-string (or bounded string) types, add EXT flag because
+         an optional field is represented in the same way as external fields */
       if (idl_is_optional(parent))
         opcode |= DDS_OP_FLAG_OPT | (idl_is_unbounded_string(type_spec) ? 0 : DDS_OP_FLAG_EXT);
       /* For @external and @optional fields of type OP_TYPE_EXT include the size of the field to

--- a/src/tools/idlc/src/types.c
+++ b/src/tools/idlc/src/types.c
@@ -139,7 +139,7 @@ emit_field(
 {
   struct generator *gen = user_data;
   char *type;
-  const char *fmt, *indent, *name, *ptr_open = "", *ptr_close = "", *type_prefix = "";
+  const char *fmt, *indent, *name, *str_ptr = "", *ptr_open = "", *ptr_close = "", *type_prefix = "";
   const void *root;
   idl_literal_t *literal;
   idl_type_spec_t *type_spec;
@@ -155,7 +155,7 @@ emit_field(
     return IDL_RETCODE_NO_MEMORY;
 
   if (idl_is_string(type_spec) && !idl_is_bounded(type_spec))
-    ptr_open = "* ";
+    str_ptr = "* ";
 
   if (idl_is_external(root) || idl_is_optional(root)) {
     if (idl_is_array(node) || (idl_is_string(type_spec) && idl_is_bounded(type_spec))) {
@@ -179,8 +179,8 @@ emit_field(
     if (fputs("/* ", gen->header.handle) < 0)
       return IDL_RETCODE_NO_MEMORY;
 
-  fmt = "%s%s %s%s%s";
-  if (idl_fprintf(gen->header.handle, fmt, type_prefix, type, ptr_open, name, ptr_close) < 0)
+  fmt = "%s%s %s%s%s%s";
+  if (idl_fprintf(gen->header.handle, fmt, type_prefix, type, str_ptr, ptr_open, name, ptr_close) < 0)
     return IDL_RETCODE_NO_MEMORY;
 
   /* array dims */

--- a/src/tools/idlc/xtests/common.h
+++ b/src/tools/idlc/xtests/common.h
@@ -86,5 +86,10 @@
   if ((!(a->f) && (b->f)) || ((a->f) && !(b->f))) return 2; \
   if (strcmp(*(a->f), *(b->f))) return strcmp(*(a->f), *(b->f)); \
 }
+#define CMPEXTASTR(a,b,f,i,s) { \
+  if ((a->f) && strcmp((*(a->f))[(i)], s)) return -2; \
+  if ((!(a->f) && (b->f)) || ((a->f) && !(b->f))) return 2; \
+  if (strcmp((*(a->f))[(i)], (*(b->f))[(i)])) return strcmp((*(a->f))[(i)], (*(b->f))[(i)]); \
+}
 
 #endif /* CMP_H */

--- a/src/tools/idlc/xtests/test_optional.idl
+++ b/src/tools/idlc/xtests/test_optional.idl
@@ -58,6 +58,14 @@ struct test_opt : test_opt_base {
   @optional seqlong2_t f11n;
   @optional @external long f12;
   @optional @external long f12n;
+  @optional sequence<string> f13;
+  @optional sequence<string> f13n;
+  @optional string f14[3];
+  @optional string f14n[3];
+  @optional sequence<string<128> > f15;
+  @optional sequence<string<128> > f15n;
+  @optional string<128> f16[3];
+  @optional string<128> f16n[3];
 };
 
 #else
@@ -140,6 +148,28 @@ void init_sample (void *s)
 
   EXTA (s1->f12, 321);
   s1->f12n = NULL;
+
+  A (s1->f13);
+  SEQA(*(s1->f13), 3);
+  for (int n = 0; n < 3; n++)
+    STRA (s1->f13->_buffer[n], STR128);
+  s1->f13n = NULL;
+
+  A (s1->f14);
+  for (int n = 0; n < 3; n++)
+    STRA ((*s1->f14)[n], STR128);
+  s1->f14n = NULL;
+
+  A (s1->f15);
+  SEQA(*(s1->f15), 3);
+  for (int n = 0; n < 3; n++)
+    STRCPY (s1->f15->_buffer[n], STR128);
+  s1->f15n = NULL;
+
+  A (s1->f16);
+  for (int n = 0; n < 3; n++)
+    STRCPY ((*s1->f16)[n], STR128);
+  s1->f16n = NULL;
 }
 
 int cmp_sample (const void *sa, const void *sb)
@@ -196,6 +226,22 @@ int cmp_sample (const void *sa, const void *sb)
 
   CMPEXT (a, b, f12, 321);
   CMP (a, b, f12n, NULL);
+
+  for (int n = 0; n < 3; n++)
+    CMPSTR(a, b, f13->_buffer[n], STR128);
+  CMP (a, b, f13n, NULL);
+
+  for (int n = 0; n < 3; n++)
+    CMPEXTASTR(a, b, f14, n, STR128);
+  CMP (a, b, f14n, NULL);
+
+  for (int n = 0; n < 3; n++)
+    CMPSTR(a, b, f15->_buffer[n], STR128);
+  CMP (a, b, f15n, NULL);
+
+  for (int n = 0; n < 3; n++)
+    CMPEXTASTR(a, b, f16, n, STR128);
+  CMP (a, b, f16n, NULL);
 
   return 0;
 }


### PR DESCRIPTION
Fix issue in the IDL compiler C generator for optional collections of unbounded strings: only members of type unbounded string should not get the EXT flag (because that's already a pointer type), but members of type collection-of-unbounded-string should get the flag.
