### PR TITLE
Fix issue in key extraction for mutable and appendable types in cdrstream

### DIFF
--- a/src/core/ddsi/src/ddsi_cdrstream.c
+++ b/src/core/ddsi/src/ddsi_cdrstream.c
@@ -89,6 +89,7 @@
 #define dds_stream_extract_keyBO_from_key_prim_op     NAME2_BYTE_ORDER(dds_stream_extract_key, _from_key_prim_op)
 #define dds_stream_extract_keyBO_from_data_delimited  NAME2_BYTE_ORDER(dds_stream_extract_key, _from_data_delimited)
 #define dds_stream_extract_keyBO_from_data_pl         NAME2_BYTE_ORDER(dds_stream_extract_key, _from_data_pl)
+#define dds_stream_extract_keyBO_from_data_pl_member  NAME2_BYTE_ORDER(dds_stream_extract_key, _from_data_pl_member)
 #define dds_stream_extract_keyBO_from_key             NAME2_BYTE_ORDER(dds_stream_extract_key, _from_key)
 
 #ifndef NDEBUG

--- a/src/tools/idlc/xtests/test_struct_external.idl
+++ b/src/tools/idlc/xtests/test_struct_external.idl
@@ -29,12 +29,12 @@ typedef sequence<seqlong_t> seqlong2_t;
 @topic @final
 struct test_ext {
     @external long f1;
-    @external string f2;          // char * f2;
-    @external string<128> f3;     // char (* f3)[129];
-    @external b f4;
+    @key @external string f2;      // char * f2;
+    @external string<128> f3;      // char (* f3)[129];
+    @key @external b f4;
     @external u f5;
-    @external short f6[2];        // int16_t (* f6)[10]
-    @external short f7[2][3];     // int16_t (* f7)[2][3]
+    @external short f6[2];         // int16_t (* f6)[10]
+    @key @external short f7[2][3]; // int16_t (* f7)[2][3]
     @external sequence<short> f8;
     @external seqfloat_t f9;
     @external sequence<seqlong_t> f10;
@@ -136,6 +136,15 @@ int cmp_sample (const void *sa, const void *sb)
   return 0;
 }
 
-NO_KEY_CMP
+int cmp_key (const void *sa, const void *sb)
+{
+  test_ext *a = (test_ext *) sa;
+  test_ext *b = (test_ext *) sb;
+  CMPSTR (a, b, f2, STR128);
+  CMPEXTF (a, b, f4, b1, 456);
+  for (int n = 0; n < 6; n++)
+    CMPEXTA2 (a, b, f7, n / 3, n % 3, 1000 * n);
+  return 0;
+}
 
 #endif

--- a/src/tools/idlc/xtests/test_struct_inherit.idl
+++ b/src/tools/idlc/xtests/test_struct_inherit.idl
@@ -18,7 +18,7 @@ module test {
 
   @final
   struct d {
-    short d1;
+    @key short d1;
     @external u d2;
   };
 
@@ -97,6 +97,12 @@ int cmp_sample (const void *sa, const void *sb)
   return 0;
 }
 
-NO_KEY_CMP
+int cmp_key (const void *sa, const void *sb)
+{
+  test_struct_inherit *a = (test_struct_inherit *) sa;
+  test_struct_inherit *b = (test_struct_inherit *) sb;
+  CMP(a, b, parent.parent.parent.d1, 456);
+  return 0;
+}
 
 #endif

--- a/src/tools/idlc/xtests/test_struct_inherit_appendable.idl
+++ b/src/tools/idlc/xtests/test_struct_inherit_appendable.idl
@@ -17,7 +17,7 @@ module test {
 
   @appendable
   struct c {
-    long c1;
+    @key long c1;
   };
 
   @mutable
@@ -79,6 +79,14 @@ int cmp_sample (const void *sa, const void *sb)
   return 0;
 }
 
-NO_KEY_CMP
+int cmp_key (const void *sa, const void *sb)
+{
+  test_struct_inherit *a = (test_struct_inherit *) sa;
+  test_struct_inherit *b = (test_struct_inherit *) sb;
+
+  CMP (a, b, parent.parent.c1, 321);
+
+  return 0;
+}
 
 #endif

--- a/src/tools/idlc/xtests/test_struct_inherit_mutable.idl
+++ b/src/tools/idlc/xtests/test_struct_inherit_mutable.idl
@@ -22,7 +22,7 @@ module test {
   @mutable
   struct b {
     @id(1) long f1;
-    @id(3) c f3;
+    @key @id(3) c f3;
   };
 
   @topic
@@ -65,6 +65,12 @@ int cmp_sample (const void *sa, const void *sb)
   return 0;
 }
 
-NO_KEY_CMP
+int cmp_key (const void *sa, const void *sb)
+{
+  test_struct_inherit *a = (test_struct_inherit *) sa;
+  test_struct_inherit *b = (test_struct_inherit *) sb;
+  CMP(a, b, parent.f3.c0, 321);
+  return 0;
+}
 
 #endif

--- a/src/tools/idlc/xtests/test_struct_r.idl
+++ b/src/tools/idlc/xtests/test_struct_r.idl
@@ -17,7 +17,7 @@ struct struct_test;
 @topic @final
 struct struct_test {
   sequence<struct_test> u1;
-  long u2;
+  @key long u2;
 };
 
 #else
@@ -54,6 +54,12 @@ int cmp_sample (const void *sa, const void *sb)
   return 0;
 }
 
-NO_KEY_CMP
+int cmp_key (const void *sa, const void *sb)
+{
+  struct_test *a = (struct_test *) sa;
+  struct_test *b = (struct_test *) sb;
+  CMP(a, b, u2, 1);
+  return 0;
+}
 
 #endif


### PR DESCRIPTION
Depends on #1149, only commit 3e1867c4f0374216fcc8e67d918644881cd351a6 is added in this PR. 

This fixes an issue in key extraction for mutable and appendable types that are using inheritance. The key offset list had an incorrect offset for the key field ops for keys in the base type (the offset was relative to the start of the base type). This PR fixes the issue by making the offset relative to the derived type. 

In the IDLC xtests, an `@key` annotations is added to specific members in some of the tests cases, to improve the test coverage on key extraction in cdrstream (combined with the changes from b6cdc7df3db347c71ff2c6d59ed826403f9e2d8d that extend the generic part of these tests). 