### PR TITLE
Improve mechanism for configuring participant lease

### DIFF
--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -67,7 +67,7 @@ The default value is: "lax".
 
 
 ### //CycloneDDS/Domain/Discovery
-Children: [DSGracePeriod](#cycloneddsdomaindiscoverydsgraceperiod), [DefaultMulticastAddress](#cycloneddsdomaindiscoverydefaultmulticastaddress), [EnableTopicDiscoveryEndpoints](#cycloneddsdomaindiscoveryenabletopicdiscoveryendpoints), [ExternalDomainId](#cycloneddsdomaindiscoveryexternaldomainid), [MaxAutoParticipantIndex](#cycloneddsdomaindiscoverymaxautoparticipantindex), [ParticipantIndex](#cycloneddsdomaindiscoveryparticipantindex), [Peers](#cycloneddsdomaindiscoverypeers), [Ports](#cycloneddsdomaindiscoveryports), [SPDPInterval](#cycloneddsdomaindiscoveryspdpinterval), [SPDPMulticastAddress](#cycloneddsdomaindiscoveryspdpmulticastaddress), [Tag](#cycloneddsdomaindiscoverytag)
+Children: [DSGracePeriod](#cycloneddsdomaindiscoverydsgraceperiod), [DefaultMulticastAddress](#cycloneddsdomaindiscoverydefaultmulticastaddress), [EnableTopicDiscoveryEndpoints](#cycloneddsdomaindiscoveryenabletopicdiscoveryendpoints), [ExternalDomainId](#cycloneddsdomaindiscoveryexternaldomainid), [LeaseDuration](#cycloneddsdomaindiscoveryleaseduration), [MaxAutoParticipantIndex](#cycloneddsdomaindiscoverymaxautoparticipantindex), [ParticipantIndex](#cycloneddsdomaindiscoveryparticipantindex), [Peers](#cycloneddsdomaindiscoverypeers), [Ports](#cycloneddsdomaindiscoveryports), [SPDPInterval](#cycloneddsdomaindiscoveryspdpinterval), [SPDPMulticastAddress](#cycloneddsdomaindiscoveryspdpmulticastaddress), [Tag](#cycloneddsdomaindiscoverytag)
 
 The Discovery element allows specifying various parameters related to the discovery of peers.
 
@@ -104,6 +104,15 @@ Text
 An override for the domain id, to be used in discovery and for determining the port number mapping. This allows creating multiple domains in a single process while making them appear as a single domain on the network. The value "default" disables the override.
 
 The default value is: "default".
+
+
+#### //CycloneDDS/Domain/Discovery/LeaseDuration
+Number-with-unit
+
+This setting controls the default participant lease duration.
+The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
+
+The default value is: "10 s".
 
 
 #### //CycloneDDS/Domain/Discovery/MaxAutoParticipantIndex
@@ -422,7 +431,7 @@ The default value is: "default".
 
 
 ### //CycloneDDS/Domain/Internal
-Children: [AccelerateRexmitBlockSize](#cycloneddsdomaininternalacceleraterexmitblocksize), [AckDelay](#cycloneddsdomaininternalackdelay), [AssumeMulticastCapable](#cycloneddsdomaininternalassumemulticastcapable), [AutoReschedNackDelay](#cycloneddsdomaininternalautoreschednackdelay), [BuiltinEndpointSet](#cycloneddsdomaininternalbuiltinendpointset), [BurstSize](#cycloneddsdomaininternalburstsize), [ControlTopic](#cycloneddsdomaininternalcontroltopic), [DDSI2DirectMaxThreads](#cycloneddsdomaininternalddsidirectmaxthreads), [DefragReliableMaxSamples](#cycloneddsdomaininternaldefragreliablemaxsamples), [DefragUnreliableMaxSamples](#cycloneddsdomaininternaldefragunreliablemaxsamples), [DeliveryQueueMaxSamples](#cycloneddsdomaininternaldeliveryqueuemaxsamples), [EnableExpensiveChecks](#cycloneddsdomaininternalenableexpensivechecks), [GenerateKeyhash](#cycloneddsdomaininternalgeneratekeyhash), [HeartbeatInterval](#cycloneddsdomaininternalheartbeatinterval), [LateAckMode](#cycloneddsdomaininternallateackmode), [LeaseDuration](#cycloneddsdomaininternalleaseduration), [LivelinessMonitoring](#cycloneddsdomaininternallivelinessmonitoring), [MaxParticipants](#cycloneddsdomaininternalmaxparticipants), [MaxQueuedRexmitBytes](#cycloneddsdomaininternalmaxqueuedrexmitbytes), [MaxQueuedRexmitMessages](#cycloneddsdomaininternalmaxqueuedrexmitmessages), [MaxSampleSize](#cycloneddsdomaininternalmaxsamplesize), [MeasureHbToAckLatency](#cycloneddsdomaininternalmeasurehbtoacklatency), [MonitorPort](#cycloneddsdomaininternalmonitorport), [MultipleReceiveThreads](#cycloneddsdomaininternalmultiplereceivethreads), [NackDelay](#cycloneddsdomaininternalnackdelay), [PreEmptiveAckDelay](#cycloneddsdomaininternalpreemptiveackdelay), [PrimaryReorderMaxSamples](#cycloneddsdomaininternalprimaryreordermaxsamples), [PrioritizeRetransmit](#cycloneddsdomaininternalprioritizeretransmit), [RediscoveryBlacklistDuration](#cycloneddsdomaininternalrediscoveryblacklistduration), [RetransmitMerging](#cycloneddsdomaininternalretransmitmerging), [RetransmitMergingPeriod](#cycloneddsdomaininternalretransmitmergingperiod), [RetryOnRejectBestEffort](#cycloneddsdomaininternalretryonrejectbesteffort), [SPDPResponseMaxDelay](#cycloneddsdomaininternalspdpresponsemaxdelay), [ScheduleTimeRounding](#cycloneddsdomaininternalscheduletimerounding), [SecondaryReorderMaxSamples](#cycloneddsdomaininternalsecondaryreordermaxsamples), [SocketReceiveBufferSize](#cycloneddsdomaininternalsocketreceivebuffersize), [SocketSendBufferSize](#cycloneddsdomaininternalsocketsendbuffersize), [SquashParticipants](#cycloneddsdomaininternalsquashparticipants), [SynchronousDeliveryLatencyBound](#cycloneddsdomaininternalsynchronousdeliverylatencybound), [SynchronousDeliveryPriorityThreshold](#cycloneddsdomaininternalsynchronousdeliveryprioritythreshold), [Test](#cycloneddsdomaininternaltest), [UnicastResponseToSPDPMessages](#cycloneddsdomaininternalunicastresponsetospdpmessages), [UseMulticastIfMreqn](#cycloneddsdomaininternalusemulticastifmreqn), [Watermarks](#cycloneddsdomaininternalwatermarks), [WriteBatch](#cycloneddsdomaininternalwritebatch), [WriterLingerDuration](#cycloneddsdomaininternalwriterlingerduration)
+Children: [AccelerateRexmitBlockSize](#cycloneddsdomaininternalacceleraterexmitblocksize), [AckDelay](#cycloneddsdomaininternalackdelay), [AssumeMulticastCapable](#cycloneddsdomaininternalassumemulticastcapable), [AutoReschedNackDelay](#cycloneddsdomaininternalautoreschednackdelay), [BuiltinEndpointSet](#cycloneddsdomaininternalbuiltinendpointset), [BurstSize](#cycloneddsdomaininternalburstsize), [ControlTopic](#cycloneddsdomaininternalcontroltopic), [DDSI2DirectMaxThreads](#cycloneddsdomaininternalddsidirectmaxthreads), [DefragReliableMaxSamples](#cycloneddsdomaininternaldefragreliablemaxsamples), [DefragUnreliableMaxSamples](#cycloneddsdomaininternaldefragunreliablemaxsamples), [DeliveryQueueMaxSamples](#cycloneddsdomaininternaldeliveryqueuemaxsamples), [EnableExpensiveChecks](#cycloneddsdomaininternalenableexpensivechecks), [GenerateKeyhash](#cycloneddsdomaininternalgeneratekeyhash), [HeartbeatInterval](#cycloneddsdomaininternalheartbeatinterval), [LateAckMode](#cycloneddsdomaininternallateackmode), [LivelinessMonitoring](#cycloneddsdomaininternallivelinessmonitoring), [MaxParticipants](#cycloneddsdomaininternalmaxparticipants), [MaxQueuedRexmitBytes](#cycloneddsdomaininternalmaxqueuedrexmitbytes), [MaxQueuedRexmitMessages](#cycloneddsdomaininternalmaxqueuedrexmitmessages), [MaxSampleSize](#cycloneddsdomaininternalmaxsamplesize), [MeasureHbToAckLatency](#cycloneddsdomaininternalmeasurehbtoacklatency), [MonitorPort](#cycloneddsdomaininternalmonitorport), [MultipleReceiveThreads](#cycloneddsdomaininternalmultiplereceivethreads), [NackDelay](#cycloneddsdomaininternalnackdelay), [PreEmptiveAckDelay](#cycloneddsdomaininternalpreemptiveackdelay), [PrimaryReorderMaxSamples](#cycloneddsdomaininternalprimaryreordermaxsamples), [PrioritizeRetransmit](#cycloneddsdomaininternalprioritizeretransmit), [RediscoveryBlacklistDuration](#cycloneddsdomaininternalrediscoveryblacklistduration), [RetransmitMerging](#cycloneddsdomaininternalretransmitmerging), [RetransmitMergingPeriod](#cycloneddsdomaininternalretransmitmergingperiod), [RetryOnRejectBestEffort](#cycloneddsdomaininternalretryonrejectbesteffort), [SPDPResponseMaxDelay](#cycloneddsdomaininternalspdpresponsemaxdelay), [ScheduleTimeRounding](#cycloneddsdomaininternalscheduletimerounding), [SecondaryReorderMaxSamples](#cycloneddsdomaininternalsecondaryreordermaxsamples), [SocketReceiveBufferSize](#cycloneddsdomaininternalsocketreceivebuffersize), [SocketSendBufferSize](#cycloneddsdomaininternalsocketsendbuffersize), [SquashParticipants](#cycloneddsdomaininternalsquashparticipants), [SynchronousDeliveryLatencyBound](#cycloneddsdomaininternalsynchronousdeliverylatencybound), [SynchronousDeliveryPriorityThreshold](#cycloneddsdomaininternalsynchronousdeliveryprioritythreshold), [Test](#cycloneddsdomaininternaltest), [UnicastResponseToSPDPMessages](#cycloneddsdomaininternalunicastresponsetospdpmessages), [UseMulticastIfMreqn](#cycloneddsdomaininternalusemulticastifmreqn), [Watermarks](#cycloneddsdomaininternalwatermarks), [WriteBatch](#cycloneddsdomaininternalwritebatch), [WriterLingerDuration](#cycloneddsdomaininternalwriterlingerduration)
 
 The Internal elements deal with a variety of settings that evolving and that are not necessarily fully supported. For the vast majority of the Internal settings, the functionality per-se is supported, but the right to change the way the options control the functionality is reserved. This includes renaming or moving options.
 
@@ -614,15 +623,6 @@ Boolean
 Ack a sample only when it has been delivered, instead of when committed to delivering it.
 
 The default value is: "false".
-
-
-#### //CycloneDDS/Domain/Internal/LeaseDuration
-Number-with-unit
-
-This setting controls the default participant lease duration.
-The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
-
-The default value is: "10 s".
 
 
 #### //CycloneDDS/Domain/Internal/LivelinessMonitoring
@@ -1518,7 +1518,7 @@ The default value is: "dds\_security\_crypto".
 
 
 ### //CycloneDDS/Domain/SharedMemory
-Children: [Enable](#cycloneddsdomainsharedmemoryenable), [Locator](#cycloneddsdomainsharedmemorylocator), [LogLevel](#cycloneddsdomainsharedmemoryloglevel), [Prefix](#cycloneddsdomainsharedmemoryprefix), [PubHistoryCapacity](#cycloneddsdomainsharedmemorypubhistorycapacity), [SubHistoryRequest](#cycloneddsdomainsharedmemorysubhistoryrequest), [SubQueueCapacity](#cycloneddsdomainsharedmemorysubqueuecapacity)
+Children: [Enable](#cycloneddsdomainsharedmemoryenable), [Locator](#cycloneddsdomainsharedmemorylocator), [LogLevel](#cycloneddsdomainsharedmemoryloglevel), [Prefix](#cycloneddsdomainsharedmemoryprefix)
 
 The Shared Memory element allows specifying various parameters related to using shared memory.
 
@@ -1568,30 +1568,6 @@ Text
 Override the Iceoryx service name used by Cyclone.
 
 The default value is: "DDS\_CYCLONE".
-
-
-#### //CycloneDDS/Domain/SharedMemory/PubHistoryCapacity
-Integer
-
-The number of messages which will be stored on the publisher for late joining subscribers. Should be a value between 0 and 16 and be equal to or larger than SubHistoryRequest.
-
-The default value is: "16".
-
-
-#### //CycloneDDS/Domain/SharedMemory/SubHistoryRequest
-Integer
-
-The number of messages published before subscription which will be requested by a subscriber upon subscription. Should be a value between 0 and 16.
-
-The default value is: "16".
-
-
-#### //CycloneDDS/Domain/SharedMemory/SubQueueCapacity
-Integer
-
-Size of the history chunk queue, this is the amount of messages stored between taking from the iceoryx subscriber, exceeding this number will cause the oldest to be pushed off the queue. Should be a value between 1 and 256.
-
-The default value is: "256".
 
 
 ### //CycloneDDS/Domain/Sizing

--- a/etc/cyclonedds.rnc
+++ b/etc/cyclonedds.rnc
@@ -76,6 +76,13 @@ CycloneDDS configuration""" ] ]
           text
         }?
         & [ a:documentation [ xml:lang="en" """
+<p>This setting controls the default participant lease duration.<p>
+<p>The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.</p>
+<p>The default value is: "10 s".</p>""" ] ]
+        element LeaseDuration {
+          duration
+        }?
+        & [ a:documentation [ xml:lang="en" """
 <p>This element specifies the maximum DDSI participant index selected by this instance of the Cyclone DDS service if the Discovery/ParticipantIndex is "auto".</p>
 <p>The default value is: "9".</p>""" ] ]
         element MaxAutoParticipantIndex {
@@ -436,13 +443,6 @@ CycloneDDS configuration""" ] ]
 <p>The default value is: "false".</p>""" ] ]
         element LateAckMode {
           xsd:boolean
-        }?
-        & [ a:documentation [ xml:lang="en" """
-<p>This setting controls the default participant lease duration.<p>
-<p>The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.</p>
-<p>The default value is: "10 s".</p>""" ] ]
-        element LeaseDuration {
-          duration
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element controls whether or not implementation should internally monitor its own liveliness. If liveliness monitoring is enabled, stack traces can be dumped automatically when some thread appears to have stopped making progress.</p>
@@ -1087,24 +1087,6 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==<br>
 <p>The default value is: "DDS_CYCLONE".</p>""" ] ]
         element Prefix {
           text
-        }?
-        & [ a:documentation [ xml:lang="en" """
-<p>The number of messages which will be stored on the publisher for late joining subscribers. Should be a value between 0 and 16 and be equal to or larger than SubHistoryRequest.</p>
-<p>The default value is: "16".</p>""" ] ]
-        element PubHistoryCapacity {
-          xsd:integer
-        }?
-        & [ a:documentation [ xml:lang="en" """
-<p>The number of messages published before subscription which will be requested by a subscriber upon subscription. Should be a value between 0 and 16.</p>
-<p>The default value is: "16".</p>""" ] ]
-        element SubHistoryRequest {
-          xsd:integer
-        }?
-        & [ a:documentation [ xml:lang="en" """
-<p>Size of the history chunk queue, this is the amount of messages stored between taking from the iceoryx subscriber, exceeding this number will cause the oldest to be pushed off the queue. Should be a value between 1 and 256.</p>
-<p>The default value is: "256".</p>""" ] ]
-        element SubQueueCapacity {
-          xsd:integer
         }?
       }?
       & [ a:documentation [ xml:lang="en" """

--- a/etc/cyclonedds.xsd
+++ b/etc/cyclonedds.xsd
@@ -114,6 +114,7 @@ CycloneDDS configuration</xs:documentation>
         <xs:element minOccurs="0" ref="config:DefaultMulticastAddress"/>
         <xs:element minOccurs="0" ref="config:EnableTopicDiscoveryEndpoints"/>
         <xs:element minOccurs="0" ref="config:ExternalDomainId"/>
+        <xs:element minOccurs="0" ref="config:LeaseDuration"/>
         <xs:element minOccurs="0" ref="config:MaxAutoParticipantIndex"/>
         <xs:element minOccurs="0" ref="config:ParticipantIndex"/>
         <xs:element minOccurs="0" ref="config:Peers"/>
@@ -151,6 +152,14 @@ CycloneDDS configuration</xs:documentation>
       <xs:documentation>
 &lt;p&gt;An override for the domain id, to be used in discovery and for determining the port number mapping. This allows creating multiple domains in a single process while making them appear as a single domain on the network. The value "default" disables the override.&lt;/p&gt;
 &lt;p&gt;The default value is: "default".&lt;/p&gt;</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LeaseDuration" type="config:duration">
+    <xs:annotation>
+      <xs:documentation>
+&lt;p&gt;This setting controls the default participant lease duration.&lt;p&gt;
+&lt;p&gt;The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.&lt;/p&gt;
+&lt;p&gt;The default value is: "10 s".&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="MaxAutoParticipantIndex" type="xs:integer">
@@ -492,7 +501,6 @@ CycloneDDS configuration</xs:documentation>
         <xs:element minOccurs="0" ref="config:GenerateKeyhash"/>
         <xs:element minOccurs="0" ref="config:HeartbeatInterval"/>
         <xs:element minOccurs="0" ref="config:LateAckMode"/>
-        <xs:element minOccurs="0" ref="config:LeaseDuration"/>
         <xs:element minOccurs="0" ref="config:LivelinessMonitoring"/>
         <xs:element minOccurs="0" ref="config:MaxParticipants"/>
         <xs:element minOccurs="0" ref="config:MaxQueuedRexmitBytes"/>
@@ -704,14 +712,6 @@ CycloneDDS configuration</xs:documentation>
       <xs:documentation>
 &lt;p&gt;Ack a sample only when it has been delivered, instead of when committed to delivering it.&lt;/p&gt;
 &lt;p&gt;The default value is: "false".&lt;/p&gt;</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="LeaseDuration" type="config:duration">
-    <xs:annotation>
-      <xs:documentation>
-&lt;p&gt;This setting controls the default participant lease duration.&lt;p&gt;
-&lt;p&gt;The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.&lt;/p&gt;
-&lt;p&gt;The default value is: "10 s".&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="LivelinessMonitoring">
@@ -1573,9 +1573,6 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
         <xs:element minOccurs="0" ref="config:Locator"/>
         <xs:element minOccurs="0" ref="config:LogLevel"/>
         <xs:element minOccurs="0" ref="config:Prefix"/>
-        <xs:element minOccurs="0" ref="config:PubHistoryCapacity"/>
-        <xs:element minOccurs="0" ref="config:SubHistoryRequest"/>
-        <xs:element minOccurs="0" ref="config:SubQueueCapacity"/>
       </xs:all>
     </xs:complexType>
   </xs:element>
@@ -1617,27 +1614,6 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
       <xs:documentation>
 &lt;p&gt;Override the Iceoryx service name used by Cyclone.&lt;/p&gt;
 &lt;p&gt;The default value is: "DDS_CYCLONE".&lt;/p&gt;</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="PubHistoryCapacity" type="xs:integer">
-    <xs:annotation>
-      <xs:documentation>
-&lt;p&gt;The number of messages which will be stored on the publisher for late joining subscribers. Should be a value between 0 and 16 and be equal to or larger than SubHistoryRequest.&lt;/p&gt;
-&lt;p&gt;The default value is: "16".&lt;/p&gt;</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="SubHistoryRequest" type="xs:integer">
-    <xs:annotation>
-      <xs:documentation>
-&lt;p&gt;The number of messages published before subscription which will be requested by a subscriber upon subscription. Should be a value between 0 and 16.&lt;/p&gt;
-&lt;p&gt;The default value is: "16".&lt;/p&gt;</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="SubQueueCapacity" type="xs:integer">
-    <xs:annotation>
-      <xs:documentation>
-&lt;p&gt;Size of the history chunk queue, this is the amount of messages stored between taking from the iceoryx subscriber, exceeding this number will cause the oldest to be pushed off the queue. Should be a value between 1 and 256.&lt;/p&gt;
-&lt;p&gt;The default value is: "256".&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="Sizing">

--- a/src/core/ddsc/src/dds__qos.h
+++ b/src/core/ddsc/src/dds__qos.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright(c) 2022 ZettaScale Technology
  * Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
  *
  * This program and the accompanying materials are made available under the
@@ -26,7 +27,8 @@ extern "C" {
    QP_DATA_REPRESENTATION)
 
 #define DDS_PARTICIPANT_QOS_MASK                                        \
-  (QP_USER_DATA | QP_ADLINK_ENTITY_FACTORY | QP_CYCLONE_IGNORELOCAL | QP_PROPERTY_LIST)
+  (QP_USER_DATA | QP_ADLINK_ENTITY_FACTORY | QP_CYCLONE_IGNORELOCAL |   \
+   QP_PROPERTY_LIST | QP_LIVELINESS) // liveliness is a Cyclone DDS special
 
 #define DDS_PUBLISHER_QOS_MASK                                          \
   (QP_PARTITION | QP_PRESENTATION | QP_GROUP_DATA |                     \

--- a/src/core/ddsc/tests/CMakeLists.txt
+++ b/src/core/ddsc/tests/CMakeLists.txt
@@ -1,4 +1,5 @@
 #
+# Copyright(c) 2022 ZettaScale Technology
 # Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
 #
 # This program and the accompanying materials are made available under the
@@ -45,6 +46,7 @@ set(ddsc_test_sources
     "loan.c"
     "multi_sertopic.c"
     "participant.c"
+    "pp_lease_dur.c"
     "publisher.c"
     "qos.c"
     "qosmatch.c"

--- a/src/core/ddsc/tests/builtin_topics.c
+++ b/src/core/ddsc/tests/builtin_topics.c
@@ -562,4 +562,3 @@ CU_Test(ddsc_builtin_topics, get_qos)
     check_default_qos_of_builtin_entity (tps[i].h, CDQOBE_TOPIC);
   }
 }
-

--- a/src/core/ddsc/tests/cdrstream.c
+++ b/src/core/ddsc/tests/cdrstream.c
@@ -1551,18 +1551,6 @@ static void sample_free_mutable2 (void *s_wr, void *s_rd)
  * Generic implementation and tests
  **********************************************/
 
-static void msg (const char *msg, ...)
-{
-  va_list args;
-  dds_time_t t;
-  t = dds_time ();
-  printf ("%d.%06d ", (int32_t)(t / DDS_NSECS_IN_SEC), (int32_t)(t % DDS_NSECS_IN_SEC) / 1000);
-  va_start (args, msg);
-  vprintf (msg, args);
-  va_end (args);
-  printf ("\n");
-}
-
 static dds_entity_t d1, d2, tp1, tp2, dp1, dp2, rd, wr;
 
 static void cdrstream_init (void)
@@ -1640,7 +1628,7 @@ CU_Theory ((const char *descr, const dds_topic_descriptor_t *desc, sample_empty 
     ddsc_cdrstream, ser_des, .init = cdrstream_init, .fini = cdrstream_fini)
 {
   dds_return_t ret;
-  msg ("Running test ser_des: %s", descr);
+  tprintf ("Running test ser_des: %s\n", descr);
 
   entity_init (desc, DDS_DATA_REPRESENTATION_XCDR2, false);
   dds_set_status_mask (rd, DDS_DATA_AVAILABLE_STATUS);
@@ -1717,7 +1705,7 @@ CU_Theory ((const char *descr, const dds_topic_descriptor_t *desc, sample_init s
     ddsc_cdrstream, ser_des_multiple, .init = cdrstream_init, .fini = cdrstream_fini)
 {
   dds_return_t ret;
-  msg ("Running test ser_des_multiple: %s", descr);
+  tprintf ("Running test ser_des_multiple: %s\n", descr);
 
   entity_init (desc, DDS_DATA_REPRESENTATION_XCDR2, false);
 
@@ -1765,7 +1753,7 @@ CU_Theory ((const char *descr, const dds_topic_descriptor_t *desc1, const dds_to
 {
   for (int t = 0; t <= 1; t++)
   {
-    msg ("Running test appendable_mutable: %s (run %d/2)", descr, t + 1);
+    tprintf ("Running test appendable_mutable: %s (run %d/2)\n", descr, t + 1);
 
     const dds_topic_descriptor_t *desc_wr = t ? desc2 : desc1;
     const dds_topic_descriptor_t *desc_rd = t ? desc1 : desc2;

--- a/src/core/ddsc/tests/pp_lease_dur.c
+++ b/src/core/ddsc/tests/pp_lease_dur.c
@@ -1,0 +1,351 @@
+/*
+ * Copyright(c) 2022 ZettaScale Technology BV
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/io.h"
+#include "dds/ddsrt/environ.h"
+#include "dds/dds.h"
+
+#include "dds__entity.h"
+#include "dds/ddsi/q_bswap.h"
+#include "dds/ddsi/q_lease.h"
+#include "dds/ddsi/ddsi_entity_index.h"
+
+#include "test_common.h"
+
+struct guidstr { char s[4*8+4]; };
+
+static char *guidstr (struct guidstr *dst, const dds_guid_t *g)
+{
+  const uint8_t *v = g->v;
+  snprintf (dst->s, sizeof (dst->s), "%02x%02x%02x%02x:%02x%02x%02x%02x:%02x%02x%02x%02x:%02x%02x%02x%02x",
+            v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7], v[8], v[9], v[10], v[11], v[12], v[13], v[14], v[15]);
+  return dst->s;
+}
+
+static void participant_lease_duration_make_doms (dds_duration_t ldur2)
+{
+  const char *conf_fmt = "\
+${CYCLONEDDS_URI}${CYCLONEDDS_URI:+,}\
+<Discovery>\
+  <Tag>${CYCLONEDDS_PID}</Tag>\
+  <ExternalDomainId>0</ExternalDomainId>\
+  <LeaseDuration>%"PRId64"ns</LeaseDuration>\
+</Discovery>";
+  char *conf_ld_def, *conf_ld_alt;
+  (void) ddsrt_asprintf (&conf_ld_def, conf_fmt, DDS_SECS (10));
+  (void) ddsrt_asprintf (&conf_ld_alt, conf_fmt, ldur2);
+  char *xconf_ld_def = ddsrt_expand_envvars (conf_ld_def, DDS_DOMAIN_DEFAULT);
+  const dds_entity_t dom0 = dds_create_domain (0, xconf_ld_def);
+  CU_ASSERT_FATAL (dom0 > 0);
+  const dds_entity_t dom1 = dds_create_domain (1, xconf_ld_def);
+  CU_ASSERT_FATAL (dom1 > 0);
+  char *xconf_ld_alt = ddsrt_expand_envvars (conf_ld_alt, DDS_DOMAIN_DEFAULT);
+  const dds_entity_t dom2 = dds_create_domain (2, xconf_ld_alt);
+  CU_ASSERT_FATAL (dom2 > 0);
+  ddsrt_free (xconf_ld_def);
+  ddsrt_free (xconf_ld_alt);
+  ddsrt_free (conf_ld_def);
+  ddsrt_free (conf_ld_alt);
+}
+
+static void check_lease_duration (const dds_qos_t *qos, dds_duration_t exp_ldur)
+{
+  dds_liveliness_kind_t kind;
+  dds_duration_t ldur;
+  const bool lpresent = dds_qget_liveliness (qos, &kind, &ldur);
+  CU_ASSERT_FATAL (lpresent);
+  CU_ASSERT_FATAL (kind == DDS_LIVELINESS_AUTOMATIC);
+  CU_ASSERT_FATAL (ldur == exp_ldur);
+}
+
+static void check_lease_duration_pp (dds_entity_t pp, dds_duration_t exp_ldur)
+{
+  dds_qos_t *qos = dds_create_qos ();
+  CU_ASSERT_FATAL (qos != NULL);
+  dds_return_t ret = dds_get_qos (pp, qos);
+  CU_ASSERT_FATAL (ret == 0);
+  check_lease_duration (qos, exp_ldur);
+  dds_delete_qos (qos);
+}
+
+CU_Test(ddsc_participant_lease_duration, invalid_setting)
+{
+  dds_qos_t *qos = dds_create_qos ();
+  CU_ASSERT_FATAL (qos != NULL);
+  dds_entity_t pp;
+  dds_qset_liveliness (qos, DDS_LIVELINESS_AUTOMATIC, -1);
+  pp = dds_create_participant (DDS_DOMAIN_DEFAULT, qos, NULL);
+  CU_ASSERT_FATAL (pp == DDS_RETCODE_BAD_PARAMETER);
+  dds_qset_liveliness (qos, DDS_LIVELINESS_MANUAL_BY_PARTICIPANT, 1);
+  pp = dds_create_participant (DDS_DOMAIN_DEFAULT, qos, NULL);
+  CU_ASSERT_FATAL (pp == DDS_RETCODE_BAD_PARAMETER);
+  dds_qset_liveliness (qos, DDS_LIVELINESS_MANUAL_BY_TOPIC, 1);
+  pp = dds_create_participant (DDS_DOMAIN_DEFAULT, qos, NULL);
+  CU_ASSERT_FATAL (pp == DDS_RETCODE_BAD_PARAMETER);
+  dds_delete_qos (qos);
+}
+
+static void participant_lease_duration_make_pps (dds_entity_t pp[3], dds_guid_t ppg[3], const dds_duration_t ldur[3])
+{
+  participant_lease_duration_make_doms (ldur[2]);
+
+  dds_qos_t *qos = dds_create_qos ();
+  CU_ASSERT_FATAL (qos != NULL);
+  // pp[0] is our "primary" participant, pp[1] and pp[2] are for checking
+  // network-related things; pp[1] has lease dur set via QoS, pp[2] via config
+  for (int i = 0; i < 3; i++)
+  {
+    dds_qset_liveliness (qos, DDS_LIVELINESS_AUTOMATIC, ldur[i]);
+    pp[i] = dds_create_participant ((dds_domainid_t) i, (i == 2) ? NULL : qos, NULL);
+    CU_ASSERT_FATAL (pp[i] > 0);
+    dds_return_t ret = dds_get_guid (pp[i], &ppg[i]);
+    CU_ASSERT_FATAL (ret == 0);
+    check_lease_duration_pp (pp[i], ldur[i]);
+  }
+  dds_delete_qos (qos);
+}
+
+CU_Test(ddsc_participant_lease_duration, builtin_topic)
+{
+  dds_entity_t pp[3];
+  dds_guid_t ppg[3];
+  dds_entity_t rd;
+  dds_return_t ret;
+  const dds_duration_t ldur[3] = { 999999937, 1000000007, 1000000009 };
+  participant_lease_duration_make_pps (pp, ppg, ldur);
+
+  rd = dds_create_reader (pp[0], DDS_BUILTIN_TOPIC_DCPSPARTICIPANT, NULL, NULL);
+  CU_ASSERT_FATAL (rd > 0);
+  ret = dds_set_status_mask (rd, DDS_DATA_AVAILABLE_STATUS);
+  CU_ASSERT_FATAL (ret == 0);
+
+  dds_entity_t ws = dds_create_waitset (pp[0]);
+  CU_ASSERT_FATAL (ws > 0);
+  ret = dds_waitset_attach (ws, rd, 0);
+  CU_ASSERT_FATAL (ret == 0);
+
+  int nseen = 0;
+  bool seen[3] = { false };
+  const dds_time_t abstimeout = dds_time () + DDS_SECS (5);
+  while (nseen != 3 && (ret = dds_waitset_wait_until (ws, NULL, 0, abstimeout) > 0))
+  {
+    dds_sample_info_t si;
+    int32_t n;
+    void *raw = NULL;
+    while ((n = dds_take (rd, &raw, &si, 1, 1)) == 1)
+    {
+      dds_builtintopic_participant_t const * const s = raw;
+      int i;
+      for (i = 0; i < 3; i++)
+        if (memcmp (&ppg[i], &s->key, sizeof (s->key)) == 0)
+          break;
+      CU_ASSERT_FATAL (i < 3); // thanks to domain tag
+      assert (i < 3); // Clang static analyzer doesn't get CU_ASSERT_FATAL
+      if (!si.valid_data)
+        continue;
+      nseen += !seen[i];
+      seen[i] = true;
+
+      check_lease_duration (s->qos, ldur[i]);
+      ret = dds_return_loan (rd, &raw, 1);
+      CU_ASSERT_FATAL (ret == 0);
+    }
+    CU_ASSERT_FATAL (n == 0);
+  }
+  CU_ASSERT_FATAL (ret >= 0);
+  CU_ASSERT_FATAL (nseen == 3);
+  ret = dds_delete (DDS_CYCLONEDDS_HANDLE);
+  CU_ASSERT_FATAL (ret == 0);
+}
+
+static int64_t sub_tref_et (int64_t t_v, ddsrt_etime_t tref)
+{
+  return (t_v == INT64_MIN) ? t_v : t_v - tref.v;
+}
+
+static bool make_pp0_deaf (const dds_entity_t pp[3], const dds_guid_t ppg[3], const ddsrt_etime_t tref_et)
+{
+  const ddsrt_etime_t tdeaf_et = ddsrt_time_elapsed ();
+  dds_return_t ret;
+  // renew the leases for the proxy participants so we know more about when the lease will expire
+  struct dds_entity *ppe;
+  bool lax_check = false;
+  ret = dds_entity_pin (pp[0], &ppe);
+  CU_ASSERT_FATAL (ret == 0);
+  thread_state_awake (lookup_thread_state (), &ppe->m_domain->gv);
+  for (int i = 1; i < 3; i++)
+  {
+    DDSRT_STATIC_ASSERT (sizeof (dds_guid_t) == sizeof (ddsi_guid_t));
+    ddsi_guid_t tmp;
+    memcpy (&tmp, &ppg[i], sizeof (tmp));
+    tmp = nn_ntoh_guid (tmp);
+    struct proxy_participant *proxypp = entidx_lookup_proxy_participant_guid (ppe->m_domain->gv.entity_index, &tmp);
+    if (proxypp == NULL) {
+      // there's always the possibility that adverse timing means it expired just now
+      lax_check = true;
+    } else {
+      struct lease *lease;
+      if ((lease = ddsrt_atomic_ldvoidp (&proxypp->minl_auto)) != NULL)
+      {
+        const int64_t old_tend = sub_tref_et ((int64_t) ddsrt_atomic_ld64 (&lease->tend), tref_et);
+        const int64_t old_tsched_unsafe = sub_tref_et (((volatile ddsrt_etime_t *) &lease->tsched)->v, tref_et);
+        lease_renew (lease, tdeaf_et);
+        const int64_t new_tend = sub_tref_et ((int64_t) ddsrt_atomic_ld64 (&lease->tend), tref_et);
+        const int64_t new_tsched_unsafe = sub_tref_et (((volatile ddsrt_etime_t *) &lease->tsched)->v, tref_et);
+        struct guidstr gs;
+        tprintf ("%d renewing proxy %s lease (end %"PRId64", sched %"PRId64") -> (%"PRId64", %"PRId64")\n",
+                 i, guidstr (&gs, &ppg[i]), old_tend, old_tsched_unsafe, new_tend, new_tsched_unsafe);
+      }
+    }
+  }
+  thread_state_asleep (lookup_thread_state ());
+  dds_entity_unpin (ppe);
+  // make pp[0] deaf
+  tprintf ("making pp0 deaf @ %"PRId64"\n", sub_tref_et (tdeaf_et.v, tref_et));
+  ret = dds_domain_set_deafmute (pp[0], true, false, DDS_INFINITY);
+  CU_ASSERT_FATAL (ret == 0);
+  return lax_check;
+}
+
+static int32_t read_with_timeout1 (dds_entity_t rd, void *raw[], dds_sample_info_t si[], uint32_t maxn, int32_t n, dds_instance_state_t reqistate)
+{
+  if (n > 0)
+    (void) dds_return_loan (rd, raw, n);
+  n = dds_read_mask (rd, raw, si, maxn, maxn, reqistate | DDS_ANY_VIEW_STATE | DDS_ANY_SAMPLE_STATE);
+  CU_ASSERT_FATAL (n >= 0);
+  return n;
+}
+
+static int32_t countinst (const dds_sample_info_t *si, int32_t n)
+{
+  if (n == 0)
+    return 0;
+  int32_t ninst = 1;
+  for (int32_t i = 1; i < n; i++)
+    ninst += (si[i].instance_handle != si[i-1].instance_handle);
+  return ninst;
+}
+
+struct read_with_timeout_result {
+  bool no_timeout;
+  int32_t nsamples;
+  int32_t ninstances;
+};
+
+static struct read_with_timeout_result read_with_timeout (dds_entity_t rd, void **raw, dds_sample_info_t *si, uint32_t maxn, int32_t minninst, dds_instance_state_t reqistate, dds_duration_t abstimeout)
+{
+  // it doesn't make sense to wait for "read" to return an empty set, that's not how waitsets work
+  assert (minninst > 0);
+  const char *whatstr = (reqistate == DDS_ALIVE_INSTANCE_STATE) ? "alive" : "not-alive";
+
+  dds_return_t ret;
+  const dds_entity_t ws = dds_create_waitset (dds_get_participant (rd));
+  CU_ASSERT_FATAL (ws > 0);
+  const dds_entity_t rdcond = dds_create_readcondition (rd, reqistate | DDS_ANY_VIEW_STATE | DDS_NOT_READ_SAMPLE_STATE);
+  CU_ASSERT_FATAL (rdcond > 0);
+  ret = dds_waitset_attach (ws, rdcond, 0);
+  CU_ASSERT_FATAL (ret == 0);
+
+  int32_t n = 0, ninst = 0; // not equal to reqn
+  dds_return_t wret = 1; // no timeout occurred yet
+  while (wret != 0 && ninst < minninst)
+  {
+    n = read_with_timeout1 (rd, raw, si, maxn, n, reqistate);
+    if ((ninst = countinst (si, n)) < minninst)
+    {
+      tprintf ("%s %"PRId32" samples %"PRId32" instances; still waiting\n", whatstr, n, ninst);
+      wret = dds_waitset_wait_until (ws, NULL, 0, abstimeout);
+      CU_ASSERT_FATAL (wret >= 0);
+    }
+  }
+  if (wret == 0)
+  {
+    ddsrt_log_cfg_t logcfg;
+    tprintf ("%s timed out\n", whatstr);
+    dds_log_cfg_init (&logcfg, 0, ~0u, stdout, stdout);
+    log_stack_traces (&logcfg, NULL);
+    n = read_with_timeout1 (rd, raw, si, maxn, n, reqistate);
+    ninst = countinst (si, n);
+  }
+
+  ret = dds_delete (ws);
+  CU_ASSERT_FATAL (ret == 0);
+  ret = dds_delete (rdcond);
+  CU_ASSERT_FATAL (ret == 0);
+
+  tprintf ("%s %"PRId32" samples %"PRId32" instances\n", whatstr, n, ninst);
+  for (int32_t i = 0; i < n; i++)
+  {
+    struct dds_builtintopic_participant const * const s = raw[i];
+    struct guidstr gs;
+    tprintf ("%"PRId32": %s iid %016"PRIx64" valid %d\n", i, guidstr (&gs, &s->key), si[i].instance_handle, si[i].valid_data);
+  }
+  return (struct read_with_timeout_result){ .no_timeout = (wret != 0), .nsamples = n, .ninstances = ninst };
+}
+
+CU_Test(ddsc_participant_lease_duration, expiry)
+{
+  dds_entity_t pp[3];
+  dds_guid_t ppg[3];
+  dds_entity_t rd;
+  dds_return_t ret;
+  const dds_duration_t ldur[3] = { 999999937, 1000000007, 1000000009 };
+  participant_lease_duration_make_pps (pp, ppg, ldur);
+  for (int i = 0; i < 3; i++)
+  {
+    struct guidstr gs;
+    tprintf ("%d: %s\n", i, guidstr (&gs, &ppg[i]));
+  }
+
+  rd = dds_create_reader (pp[0], DDS_BUILTIN_TOPIC_DCPSPARTICIPANT, NULL, NULL);
+  CU_ASSERT_FATAL (rd > 0);
+
+  // only have 3 participants, domain tag ensures no interference from other tests,
+  // but making room for 4 means we can be more confident we ran in isolation
+  // also need to allow for invalid samples
+  void *raw[7] = { NULL };
+  dds_sample_info_t si[7];
+  const dds_time_t abstimeout = dds_time () + DDS_SECS (8);
+  struct read_with_timeout_result rret;
+  rret = read_with_timeout (rd, raw, si, 7, 3, DDS_ALIVE_INSTANCE_STATE, abstimeout);
+  // all three should be alive now, no invalid samples
+  CU_ASSERT_FATAL (rret.no_timeout && rret.ninstances == 3);
+  ret = dds_return_loan (rd, raw, rret.nsamples);
+  CU_ASSERT_FATAL (ret == 0);
+
+  // make pp[0] deaf after forcing lease renewal
+  const ddsrt_etime_t tref_et = ddsrt_time_elapsed ();
+  tprintf ("tref_et = %"PRId64"\n", tref_et.v);
+  const dds_time_t tdeaf = dds_time ();
+  const bool lax_check = make_pp0_deaf (pp, ppg, tref_et);
+
+  // wait for the two remote participants to go missing: we expect invalid samples for the state change
+  // because we made sure to read all of them before
+  rret = read_with_timeout (rd, raw, si, 7, 2, DDS_NOT_ALIVE_DISPOSED_INSTANCE_STATE, abstimeout);
+  if (rret.ninstances != 2)
+  {
+    tprintf ("calling make_pp0_deaf for its debug output on lease expiry\n");
+    make_pp0_deaf (pp, ppg, tref_et);
+  }
+  CU_ASSERT_FATAL (rret.no_timeout && rret.ninstances == 2);
+  const dds_time_t texpire = dds_time ();
+  ret = dds_return_loan (rd, raw, rret.nsamples);
+  CU_ASSERT_FATAL (ret == 0);
+
+  // must not expire too soon (unless lax_check says we really don't know)
+  assert (ldur[1] <= ldur[2]);
+  CU_ASSERT_FATAL (lax_check || texpire - tdeaf > ldur[1]);
+  // must not have taken ridiculously long either
+  CU_ASSERT_FATAL (texpire - tdeaf < ldur[2] + DDS_MSECS (100));
+  ret = dds_delete (DDS_CYCLONEDDS_HANDLE);
+  CU_ASSERT_FATAL (ret == 0);
+}

--- a/src/core/ddsc/tests/test_util.c
+++ b/src/core/ddsc/tests/test_util.c
@@ -9,11 +9,22 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
+#include <stdarg.h>
 #include "dds/dds.h"
 #include "dds/ddsrt/atomics.h"
 #include "dds/ddsrt/process.h"
 #include "dds/ddsrt/threads.h"
 #include "test_util.h"
+
+void tprintf (const char *msg, ...)
+{
+  va_list args;
+  dds_time_t t = dds_time ();
+  printf ("%d.%06d ", (int32_t) (t / DDS_NSECS_IN_SEC), (int32_t) (t % DDS_NSECS_IN_SEC) / 1000);
+  va_start (args, msg);
+  vprintf (msg, args);
+  va_end (args);
+}
 
 char *create_unique_topic_name (const char *prefix, char *name, size_t size)
 {

--- a/src/core/ddsc/tests/test_util.h
+++ b/src/core/ddsc/tests/test_util.h
@@ -24,5 +24,8 @@ void sync_reader_writer (dds_entity_t participant_rd, dds_entity_t reader, dds_e
 /* Try to sync the reader to the writer and writer to reader, expect to fail */
 void no_sync_reader_writer (dds_entity_t participant_rd, dds_entity_t reader, dds_entity_t participant_wr, dds_entity_t writer, dds_duration_t timeout);
 
+/* Print message preceded by time stamp */
+void tprintf (const char *msg, ...)
+  ddsrt_attribute_format_printf (1, 2);
 
 #endif /* _TEST_UTIL_H_ */

--- a/src/core/ddsc/tests/topic_discovery.c
+++ b/src/core/ddsc/tests/topic_discovery.c
@@ -62,19 +62,6 @@ static void topic_discovery_fini (void)
   dds_delete (g_domain1);
 }
 
-static void msg (const char *msg, ...) ddsrt_attribute_format_printf(1, 2);
-
-static void msg (const char *msg, ...)
-{
-  va_list args;
-  dds_time_t t;
-  t = dds_time ();
-  printf ("%d.%06d ", (int32_t)(t / DDS_NSECS_IN_SEC), (int32_t)(t % DDS_NSECS_IN_SEC) / 1000);
-  va_start (args, msg);
-  vprintf (msg, args);
-  va_end (args);
-}
-
 CU_TheoryDataPoints(ddsc_topic_discovery, remote_topics) = {
     CU_DataPoints(uint32_t,     1,     1,     5,     5,    20,     1,     1,     5,     5,    20,    1,    5), /* number of participants */
     CU_DataPoints(uint32_t,     1,     5,     1,    30,     3,     1,     5,     1,    30,     3,    1,   30), /* number of topics per participant */
@@ -84,7 +71,7 @@ CU_TheoryDataPoints(ddsc_topic_discovery, remote_topics) = {
 
 CU_Theory ((uint32_t num_pp, uint32_t num_tp, bool hist_data, bool live_data), ddsc_topic_discovery, remote_topics, .init = topic_discovery_init, .fini = topic_discovery_fini, .timeout = 60)
 {
-  msg ("ddsc_topic_discovery.remote_topics: %u participants, %u topics,%s%s\n", num_pp, num_tp, hist_data ? " historical-data" : "", live_data ? " live-data" : "");
+  tprintf ("ddsc_topic_discovery.remote_topics: %u participants, %u topics,%s%s\n", num_pp, num_tp, hist_data ? " historical-data" : "", live_data ? " live-data" : "");
 
   CU_ASSERT_FATAL (num_pp > 0);
   CU_ASSERT_FATAL (num_tp > 0 && num_tp <= 64);
@@ -192,7 +179,7 @@ static void check_topic_samples (dds_entity_t topic_rd, char *topic_name, uint32
       CU_ASSERT_EQUAL_FATAL (n, 1);
       dds_builtintopic_topic_t *sample = raw[0];
       bool not_alive = sample_info->instance_state != DDS_IST_ALIVE;
-      msg ("read topic: %s, key={", sample->topic_name);
+      tprintf ("read topic: %s, key={", sample->topic_name);
       for (uint32_t i = 0; i < sizeof (first_key); i++)
         printf ("%02x", sample->key.d[i]);
       printf ("} %sALIVE\n", not_alive ? "NOT_" : "");
@@ -222,7 +209,7 @@ static void check_topic_samples (dds_entity_t topic_rd, char *topic_name, uint32
 
 CU_Test (ddsc_topic_discovery, single_topic_def, .init = topic_discovery_init, .fini = topic_discovery_fini)
 {
-  msg ("ddsc_topic_discovery.single_topic_def\n");
+  tprintf ("ddsc_topic_discovery.single_topic_def\n");
 
   char topic_name[100];
   create_unique_topic_name ("ddsc_topic_discovery_test_single_def", topic_name, 100);
@@ -270,7 +257,7 @@ CU_Test (ddsc_topic_discovery, single_topic_def, .init = topic_discovery_init, .
 
 CU_Test (ddsc_topic_discovery, different_type, .init = topic_discovery_init, .fini = topic_discovery_fini)
 {
-  msg ("ddsc_topic_discovery.different_type\n");
+  tprintf ("ddsc_topic_discovery.different_type\n");
 
   char topic_name[100];
   create_unique_topic_name ("ddsc_topic_discovery_test_type", topic_name, 100);
@@ -356,7 +343,7 @@ CU_Test (ddsc_topic_discovery, topic_qos_update, .init = topic_discovery_init, .
   dds_return_t ret;
   ddsrt_atomic_st32 (&terminate, 0);
 
-  msg ("ddsc_topic_discovery.topic_qos_update\n");
+  tprintf ("ddsc_topic_discovery.topic_qos_update\n");
 
   for (uint32_t p = 0; p < NUM_PP; p++)
   {
@@ -415,5 +402,5 @@ CU_Test (ddsc_topic_discovery, topic_qos_update, .init = topic_discovery_init, .
     dds_sleepfor (DDS_MSECS (DELAY_MSECS));
   }
   dds_delete_qos (qos);
-  msg ("%u qos updates\n", c);
+  tprintf ("%u qos updates\n", c);
 }

--- a/src/core/ddsc/tests/topic_find_global.c
+++ b/src/core/ddsc/tests/topic_find_global.c
@@ -102,20 +102,6 @@ CU_Test(ddsc_topic_find_global, participant, .init = topic_find_global_init, .fi
   CU_ASSERT_FATAL (topic > 0);
 }
 
-static void msg (const char *msg, ...) ddsrt_attribute_format_printf(1, 2);
-
-static void msg (const char *msg, ...)
-{
-  va_list args;
-  dds_time_t t;
-  t = dds_time ();
-  printf ("%d.%06d ", (int32_t)(t / DDS_NSECS_IN_SEC), (int32_t)(t % DDS_NSECS_IN_SEC) / 1000);
-  va_start (args, msg);
-  vprintf (msg, args);
-  va_end (args);
-  printf ("\n");
-}
-
 enum topic_thread_state {
   INIT,
   DONE,
@@ -144,7 +130,7 @@ static uint32_t topics_thread (void *a)
   dds_entity_t *topics = ddsrt_malloc (arg->num_tp * sizeof (*topics));
 
   /* create topics */
-  msg ("%s topics thread: creating %u topics with prefix %s", arg->remote ? "remote" : "local", arg->num_tp, arg->topic_name_prefix);
+  tprintf ("%s topics thread: creating %u topics with prefix %s\n", arg->remote ? "remote" : "local", arg->num_tp, arg->topic_name_prefix);
   for (uint32_t t = 0; t < arg->num_tp; t++)
   {
     set_topic_name (topic_name, arg->topic_name_prefix, t);
@@ -152,7 +138,7 @@ static uint32_t topics_thread (void *a)
     CU_ASSERT_FATAL (topics[t] > 0);
   }
   ddsrt_atomic_st32 (&arg->state, DONE);
-  msg ("%s topics thread: finished creating topics with prefix %s", arg->remote ? "remote" : "local", arg->topic_name_prefix);
+  tprintf ("%s topics thread: finished creating topics with prefix %s\n", arg->remote ? "remote" : "local", arg->topic_name_prefix);
 
   /* wait for stop signal */
   while (!ddsrt_atomic_ld32 (&g_stop))
@@ -166,7 +152,7 @@ static uint32_t topics_thread (void *a)
     dds_sleepfor (DDS_MSECS (1));
   }
   ddsrt_atomic_st32 (&arg->state, STOPPED);
-  msg ("%s topics thread: deleted topics with prefix %s", arg->remote ? "remote" : "local", arg->topic_name_prefix);
+  tprintf ("%s topics thread: deleted topics with prefix %s\n", arg->remote ? "remote" : "local", arg->topic_name_prefix);
   ddsrt_free (topics);
   return 0;
 }
@@ -187,7 +173,7 @@ CU_TheoryDataPoints (ddsc_topic_find_global, find_delete_topics) = {
 
 CU_Theory ((uint32_t num_local_pp, uint32_t num_remote_pp, uint32_t num_tp), ddsc_topic_find_global, find_delete_topics, .init = topic_find_global_init, .fini = topic_find_global_fini, .timeout = 60)
 {
-  msg("ddsc_topic_find_global.find_delete_topics: %u/%u local/remote participants, %u topics", num_local_pp, num_remote_pp, num_tp);
+  tprintf("ddsc_topic_find_global.find_delete_topics: %u/%u local/remote participants, %u topics\n", num_local_pp, num_remote_pp, num_tp);
   dds_return_t ret;
   dds_entity_t participant_remote = dds_create_participant (DDS_DOMAINID2, NULL, NULL);
   CU_ASSERT_FATAL (participant_remote > 0);
@@ -214,7 +200,7 @@ CU_Theory ((uint32_t num_local_pp, uint32_t num_remote_pp, uint32_t num_tp), dds
   }
 
   /* wait for all created topics to be found */
-  msg ("find topics");
+  tprintf ("find topics\n");
   for (uint32_t n = 0; n < num_local_pp + num_remote_pp; n++)
   {
     ret = topics_thread_state (&create_args[n], DONE, DDS_MSECS (10000));

--- a/src/core/ddsi/include/dds/ddsi/ddsi_cfgelems.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_cfgelems.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright(c) 2022 ZettaScale Technology
  * Copyright(c) 2020 ADLINK Technology Limited and others
  *
  * This program and the accompanying materials are made available under the
@@ -1217,12 +1218,7 @@ static struct cfgelem internal_cfgelems[] = {
       "<p>This settings limits the maximum number of samples queued for "
       "retransmission.</p>"
     )),
-  STRING("LeaseDuration", NULL, 1, "10 s",
-    MEMBER(lease_duration),
-    FUNCTIONS(0, uf_duration_ms_1hr, 0, pf_duration),
-    DESCRIPTION(
-      "<p>This setting controls the default participant lease duration.<p>"),
-    UNIT("duration")),
+  MOVED("LeaseDuration", "CycloneDDS/Domain/Discovery/LeaseDuration"),
   STRING("WriterLingerDuration", NULL, 1, "1 s",
     MEMBER(writer_linger_duration),
     FUNCTIONS(0, uf_duration_ms_1hr, 0, pf_duration),
@@ -1713,12 +1709,12 @@ static struct cfgelem shmem_cfgelems[] = {
     DESCRIPTION("<p>Size of the history chunk queue, this is the amount of messages stored between taking from the iceoryx subscriber, exceeding this number will cause the oldest to be pushed off the queue. Should be a value between 1 and 256.</p>")),
   INT(DEPRECATED("SubHistoryRequest"), NULL, 1, "16",
     NOMEMBER,
-    NOFUNCTIONS,    
+    NOFUNCTIONS,
     DESCRIPTION("<p>The number of messages published before subscription which will be requested by a subscriber upon subscription. Should be a value between 0 and 16.</p>")),
   INT(DEPRECATED("PubHistoryCapacity"), NULL, 1, "16",
     NOMEMBER,
     NOFUNCTIONS,
-    DESCRIPTION("<p>The number of messages which will be stored on the publisher for late joining subscribers. Should be a value between 0 and 16 and be equal to or larger than SubHistoryRequest.</p>")),    
+    DESCRIPTION("<p>The number of messages which will be stored on the publisher for late joining subscribers. Should be a value between 0 and 16 and be equal to or larger than SubHistoryRequest.</p>")),
   END_MARKER
 };
 #endif
@@ -1871,6 +1867,12 @@ static struct cfgelem discovery_cfgelems[] = {
       "discovery are created and used to exchange topic discovery information.</p>"
     )),
 #endif
+  STRING("LeaseDuration", NULL, 1, "10 s",
+    MEMBER(lease_duration),
+    FUNCTIONS(0, uf_duration_ms_1hr, 0, pf_duration),
+    DESCRIPTION(
+      "<p>This setting controls the default participant lease duration.<p>"),
+    UNIT("duration")),
   END_MARKER
 };
 

--- a/src/core/ddsi/include/dds/ddsi/q_lease.h
+++ b/src/core/ddsi/include/dds/ddsi/q_lease.h
@@ -43,7 +43,7 @@ struct lease *lease_clone (const struct lease *l);
 void lease_register (struct lease *l);
 void lease_unregister (struct lease *l);
 void lease_free (struct lease *l);
-void lease_renew (struct lease *l, ddsrt_etime_t tnow);
+DDS_EXPORT void lease_renew (struct lease *l, ddsrt_etime_t tnow);
 void lease_set_expiry (struct lease *l, ddsrt_etime_t when);
 int64_t check_and_handle_lease_expiration (struct ddsi_domaingv *gv, ddsrt_etime_t tnow);
 

--- a/src/core/ddsi/src/q_ddsi_discovery.c
+++ b/src/core/ddsi/src/q_ddsi_discovery.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright(c) 2022 ZettaScale Technology
  * Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
  *
  * This program and the accompanying materials are made available under the
@@ -501,7 +502,7 @@ void get_participant_builtin_topic_data (const struct participant *pp, ddsi_plis
   /* Participant QoS's insofar as they are set, different from the default, and mapped to the SPDP data, rather than to the Adlink-specific CMParticipant endpoint.  Currently, that means just USER_DATA. */
   qosdiff = ddsi_xqos_delta (&pp->plist->qos, &ddsi_default_plist_participant.qos, QP_USER_DATA);
   if (pp->e.gv->config.explicitly_publish_qos_set_to_default)
-    qosdiff |= ~QP_UNRECOGNIZED_INCOMPATIBLE_MASK;
+    qosdiff |= ~(QP_UNRECOGNIZED_INCOMPATIBLE_MASK | QP_LIVELINESS);
 
   assert (dst->qos.present == 0);
   ddsi_plist_mergein_missing (dst, pp->plist, 0, qosdiff);

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright(c) 2022 ZettaScale Technology
  * Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
  *
  * This program and the accompanying materials are made available under the
@@ -1078,7 +1079,10 @@ dds_return_t new_participant_guid (ddsi_guid_t *ppguid, struct ddsi_domaingv *gv
   pp->is_ddsi2_pp = (flags & (RTPS_PF_PRIVILEGED_PP | RTPS_PF_IS_DDSI2_PP)) ? 1 : 0;
   ddsrt_mutex_init (&pp->refc_lock);
   inverse_uint32_set_init(&pp->avail_entityids.x, 1, UINT32_MAX / NN_ENTITYID_ALLOCSTEP);
-  pp->lease_duration = gv->config.lease_duration;
+  if (plist->present & PP_PARTICIPANT_LEASE_DURATION)
+    pp->lease_duration = plist->participant_lease_duration;
+  else
+    pp->lease_duration = gv->config.lease_duration;
   ddsrt_fibheap_init (&ldur_fhdef, &pp->ldur_auto_wr);
   pp->plist = ddsrt_malloc (sizeof (*pp->plist));
   ddsi_plist_copy (pp->plist, plist);

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright(c) 2022 ZettaScale Technology
  * Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
  *
  * This program and the accompanying materials are made available under the
@@ -1485,6 +1486,10 @@ int rtps_init (struct ddsi_domaingv *gv)
   // a plain copy is safe because it doesn't alias anything
   gv->default_local_plist_pp = ddsi_default_plist_participant;
   assert (gv->default_local_plist_pp.aliased == 0 && gv->default_local_plist_pp.qos.aliased == 0);
+  assert (!(gv->default_local_plist_pp.qos.present & QP_LIVELINESS));
+  gv->default_local_plist_pp.qos.present |= QP_LIVELINESS;
+  gv->default_local_plist_pp.qos.liveliness.kind = DDS_LIVELINESS_AUTOMATIC;
+  gv->default_local_plist_pp.qos.liveliness.lease_duration = gv->config.lease_duration;
   ddsi_xqos_copy (&gv->spdp_endpoint_xqos, &ddsi_default_qos_reader);
   ddsi_xqos_mergein_missing (&gv->spdp_endpoint_xqos, &ddsi_default_qos_writer, ~(uint64_t)0);
   gv->spdp_endpoint_xqos.durability.kind = DDS_DURABILITY_TRANSIENT_LOCAL;


### PR DESCRIPTION
* Moves `Internal/LeaseDuration` to `Discovery/LeaseDuration` (with the old one deprecated)
* Allows configuring the lease duration for an individual participant by setting an automatic liveliness QoS on the participant (this is a non-standard extension)
* Makes the lease duration available as-if it is the liveliness QoS in the participant built-in topic

@NoeSechet this addresses part of https://github.com/eclipse-cyclonedds/cyclonedds-cxx/issues/211 but I still need to do a PR for extending the `DomainParticipantQoS` in the C++ binding.