### PR TITLE
Add value checking for boolean type in cdrstream serializer

### DIFF
--- a/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
@@ -61,11 +61,13 @@ enum dds_stream_opcode {
 
   /* data field
      [ADR, nBY,   0, f] [offset]
+     [ADR, BLN,   0, f] [offset]
      [ADR, ENU,   0, f] [offset] [max]
      [ADR, STR,   0, f] [offset]
      [ADR, BST,   0, f] [offset] [max-size]
 
      [ADR, SEQ, nBY, f] [offset]
+     [ADR, SEQ, BLN, f] [offset]
      [ADR, SEQ, ENU, f] [offset] [max]
      [ADR, SEQ, STR, f] [offset]
      [ADR, SEQ, BST, f] [offset] [max-size]
@@ -74,6 +76,7 @@ enum dds_stream_opcode {
      [ADR, SEQ, EXT, f] *** not supported
 
      [ADR, BSQ, nBY, f] [offset] [sbound]
+     [ADR, BSQ, BLN, f] [offset] [sbound]
      [ADR, BSQ, ENU, f] [offset] [sbound] [max]
      [ADR, BSQ, STR, f] [offset] [sbound]
      [ADR, BSQ, BST, f] [offset] [sbound] [max-size]
@@ -82,6 +85,7 @@ enum dds_stream_opcode {
      [ADR, BSQ, EXT, f] *** not supported
 
      [ADR, ARR, nBY, f] [offset] [alen]
+     [ADR, ARR, BLN, f] [offset] [alen]
      [ADR, ARR, ENU, f] [offset] [alen] [max]
      [ADR, ARR, STR, f] [offset] [alen]
      [ADR, ARR, BST, f] [offset] [alen] [0] [max-size]
@@ -93,7 +97,7 @@ enum dds_stream_opcode {
      [ADR, UNI, ENU, z] [offset] [alen] [next-insn, cases] [max]
      [ADR, UNI, EXT, f] *** not supported
        where
-         d = discriminant type of {1BY,2BY,4BY}
+         d = discriminant type of {1BY,2BY,4BY,BLN}
          z = default present/not present (DDS_OP_FLAG_DEF)
          offset = discriminant offset
          max = max enum value
@@ -132,6 +136,7 @@ enum dds_stream_opcode {
 
   /* jump-if-equal, used for union cases:
      [JEQ, nBY, 0] [disc] [offset]
+     [JEQ, BLN, 0] [disc] [offset]
      [JEQ, STR, 0] [disc] [offset]
      [JEQ, s,   i] [disc] [offset]
      [JEQ4, e | nBY, 0] [disc] [offset] 0
@@ -190,9 +195,9 @@ enum dds_stream_opcode {
 };
 
 enum dds_stream_typecode {
-  DDS_OP_VAL_1BY = 0x01, /* one byte simple type (char, octet, boolean) */
+  DDS_OP_VAL_1BY = 0x01, /* one byte simple type (char, octet) */
   DDS_OP_VAL_2BY = 0x02, /* two byte simple type ((unsigned) short) */
-  DDS_OP_VAL_4BY = 0x03, /* four byte simple type ((unsigned) long, enums, float) */
+  DDS_OP_VAL_4BY = 0x03, /* four byte simple type ((unsigned) long, float) */
   DDS_OP_VAL_8BY = 0x04, /* eight byte simple type ((unsigned) long long, double) */
   DDS_OP_VAL_STR = 0x05, /* string */
   DDS_OP_VAL_BST = 0x06, /* bounded string */
@@ -202,7 +207,8 @@ enum dds_stream_typecode {
   DDS_OP_VAL_STU = 0x0a, /* struct */
   DDS_OP_VAL_BSQ = 0x0b, /* bounded sequence */
   DDS_OP_VAL_ENU = 0x0c, /* enumerated value (long) */
-  DDS_OP_VAL_EXT = 0x0d  /* field with external definition */
+  DDS_OP_VAL_EXT = 0x0d, /* field with external definition */
+  DDS_OP_VAL_BLN = 0x0e  /* boolean */
 };
 
 /* primary type code for DDS_OP_ADR, DDS_OP_JEQ */
@@ -219,7 +225,8 @@ enum dds_stream_typecode_primary {
   DDS_OP_TYPE_STU = DDS_OP_VAL_STU << 16,
   DDS_OP_TYPE_BSQ = DDS_OP_VAL_BSQ << 16,
   DDS_OP_TYPE_ENU = DDS_OP_VAL_ENU << 16,
-  DDS_OP_TYPE_EXT = DDS_OP_VAL_EXT << 16
+  DDS_OP_TYPE_EXT = DDS_OP_VAL_EXT << 16,
+  DDS_OP_TYPE_BLN = DDS_OP_VAL_BLN << 16
 };
 #define DDS_OP_TYPE_BOO DDS_OP_TYPE_1BY
 
@@ -245,9 +252,9 @@ enum dds_stream_typecode_subtype {
   DDS_OP_SUBTYPE_UNI = DDS_OP_VAL_UNI << 8,
   DDS_OP_SUBTYPE_STU = DDS_OP_VAL_STU << 8,
   DDS_OP_SUBTYPE_BSQ = DDS_OP_VAL_BSQ << 8,
-  DDS_OP_SUBTYPE_ENU = DDS_OP_VAL_ENU << 8
+  DDS_OP_SUBTYPE_ENU = DDS_OP_VAL_ENU << 8,
+  DDS_OP_SUBTYPE_BLN = DDS_OP_VAL_BLN << 8
 };
-#define DDS_OP_SUBTYPE_BOO DDS_OP_SUBTYPE_1BY
 
 /* key field: applicable to {1,2,4,8}BY, STR, BST, ARR-of-{1,2,4,8}BY.
    Note that when defining keys in nested types, the key flag should be set

--- a/src/core/ddsi/src/ddsi_cdrstream_keys.part.c
+++ b/src/core/ddsi/src/ddsi_cdrstream_keys.part.c
@@ -22,6 +22,7 @@ static void dds_stream_write_keyBO_impl (DDS_OSTREAM_T * __restrict os, const ui
 
   switch (DDS_OP_TYPE (insn))
   {
+    case DDS_OP_VAL_BLN:
     case DDS_OP_VAL_1BY: dds_os_put1BO (os, *((uint8_t *) addr)); break;
     case DDS_OP_VAL_2BY: dds_os_put2BO (os, *((uint16_t *) addr)); break;
     case DDS_OP_VAL_4BY: dds_os_put4BO (os, *((uint32_t *) addr)); break;
@@ -35,7 +36,7 @@ static void dds_stream_write_keyBO_impl (DDS_OSTREAM_T * __restrict os, const ui
       const uint32_t num = ops[2];
       switch (DDS_OP_SUBTYPE (insn))
       {
-        case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY: {
+        case DDS_OP_VAL_BLN: case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY: {
           const uint32_t elem_size = get_type_size (DDS_OP_SUBTYPE (insn));
           const align_t align = get_align (((struct dds_ostream *)os)->m_xcdr_version, elem_size);
           dds_cdr_alignto_clear_and_resizeBO (os, align, num * elem_size);

--- a/src/core/ddsi/src/ddsi_cdrstream_write.part.c
+++ b/src/core/ddsi/src/ddsi_cdrstream_write.part.c
@@ -104,7 +104,7 @@ static const uint32_t *dds_stream_write_seqBO (DDS_OSTREAM_T * __restrict os, co
   uint32_t bound_op = seq_is_bounded (DDS_OP_TYPE (insn)) ? 1 : 0;
   uint32_t bound = bound_op ? ops[2] : 0;
 
-  if (!is_primitive_type (subtype) && xcdrv == CDR_ENC_VERSION_2)
+  if (is_dheader_needed (subtype, xcdrv))
   {
     /* reserve space for DHEADER */
     dds_os_reserve4BO (os);
@@ -185,11 +185,9 @@ static const uint32_t *dds_stream_write_seqBO (DDS_OSTREAM_T * __restrict os, co
     }
   }
 
-  if (!is_primitive_type (subtype) && xcdrv == CDR_ENC_VERSION_2)
-  {
-    /* write DHEADER */
+  /* write DHEADER */
+  if (is_dheader_needed (subtype, xcdrv))
     *((uint32_t *) (((struct dds_ostream *)os)->m_buffer + offs - 4)) = to_BO4u(((struct dds_ostream *)os)->m_index - offs);
-  }
 
   return ops;
 }
@@ -198,7 +196,7 @@ static const uint32_t *dds_stream_write_arrBO (DDS_OSTREAM_T * __restrict os, co
 {
   const enum dds_stream_typecode subtype = DDS_OP_SUBTYPE (insn);
   uint32_t offs = 0, xcdrv = ((struct dds_ostream *)os)->m_xcdr_version;
-  if (!is_primitive_type (subtype) && xcdrv == CDR_ENC_VERSION_2)
+  if (is_dheader_needed (subtype, xcdrv))
   {
     /* reserve space for DHEADER */
     dds_os_reserve4BO (os);
@@ -257,11 +255,9 @@ static const uint32_t *dds_stream_write_arrBO (DDS_OSTREAM_T * __restrict os, co
       break;
   }
 
-  if (!is_primitive_type (subtype) && xcdrv == CDR_ENC_VERSION_2)
-  {
-    /* write DHEADER */
+  /* write DHEADER */
+  if (is_dheader_needed (subtype, xcdrv))
     *((uint32_t *) (((struct dds_ostream *)os)->m_buffer + offs - 4)) = to_BO4u(((struct dds_ostream *)os)->m_index - offs);
-  }
 
   return ops;
 }

--- a/src/tools/idlc/src/descriptor.c
+++ b/src/tools/idlc/src/descriptor.c
@@ -229,6 +229,7 @@ stash_opcode(
     case DDS_OP_VAL_2BY:
       alignment = ALIGNMENT_2BY;
       break;
+    case DDS_OP_VAL_BLN:
     case DDS_OP_VAL_1BY:
       alignment = ALIGNMENT_1BY;
       break;
@@ -244,8 +245,6 @@ stash_opcode(
          less than the alignment of the members */
       alignment = ALIGNMENT_1BY;
       descriptor->flags |= DDS_TOPIC_NO_OPTIMIZE | DDS_TOPIC_CONTAINS_UNION;
-      break;
-    default:
       break;
   }
 
@@ -589,7 +588,7 @@ static idl_retcode_t add_typecode(const idl_pstate_t *pstate, const idl_type_spe
       *add_to |= ((uint32_t)DDS_OP_VAL_1BY << shift) | (uint32_t)DDS_OP_FLAG_SGN;
       break;
     case IDL_BOOL:
-      *add_to |=  ((uint32_t)DDS_OP_VAL_1BY << shift);
+      *add_to |=  ((uint32_t)DDS_OP_VAL_BLN << shift);
       break;
     case IDL_INT8:
       *add_to |= ((uint32_t)DDS_OP_VAL_1BY << shift) | (uint32_t)DDS_OP_FLAG_SGN;
@@ -1671,6 +1670,7 @@ static int print_opcode(FILE *fp, const struct instruction *inst)
     if (inst->data.opcode.code & DDS_OP_FLAG_EXT)
       vec[len++] = " | DDS_OP_FLAG_EXT";
     switch (DDS_OP_TYPE(inst->data.opcode.code)) {
+      case DDS_OP_VAL_BLN: vec[len++] = " | DDS_OP_TYPE_BLN"; break;
       case DDS_OP_VAL_1BY: vec[len++] = " | DDS_OP_TYPE_1BY"; break;
       case DDS_OP_VAL_2BY: vec[len++] = " | DDS_OP_TYPE_2BY"; break;
       case DDS_OP_VAL_4BY: vec[len++] = " | DDS_OP_TYPE_4BY"; break;
@@ -1692,7 +1692,7 @@ static int print_opcode(FILE *fp, const struct instruction *inst)
     if (type == DDS_OP_VAL_ENU) {
       idl_snprintf(buf, sizeof(buf), " | (%u << DDS_OP_FLAG_SZ_SHIFT)", (inst->data.opcode.code & DDS_OP_FLAG_SZ_MASK) >> DDS_OP_FLAG_SZ_SHIFT);
       vec[len++] = buf;
-    } else if (type != DDS_OP_VAL_1BY && type != DDS_OP_VAL_2BY && type != DDS_OP_VAL_4BY && type != DDS_OP_VAL_8BY && type != DDS_OP_VAL_STR) {
+    } else if (type != DDS_OP_VAL_BLN && type != DDS_OP_VAL_1BY && type != DDS_OP_VAL_2BY && type != DDS_OP_VAL_4BY && type != DDS_OP_VAL_8BY && type != DDS_OP_VAL_STR) {
       /* lower 16 bits contain an offset */
       idl_snprintf(buf, sizeof(buf), " | %u", (uint16_t) DDS_OP_JUMP (inst->data.opcode.code));
       vec[len++] = buf;
@@ -1704,6 +1704,7 @@ static int print_opcode(FILE *fp, const struct instruction *inst)
     enum dds_stream_typecode subtype = DDS_OP_SUBTYPE(inst->data.opcode.code);
     assert((type == DDS_OP_VAL_SEQ || type == DDS_OP_VAL_ARR || type == DDS_OP_VAL_UNI || type == DDS_OP_VAL_STU || type == DDS_OP_VAL_BSQ) == (subtype != 0));
     switch (subtype) {
+      case DDS_OP_VAL_BLN: vec[len++] = " | DDS_OP_SUBTYPE_BLN"; break;
       case DDS_OP_VAL_1BY: vec[len++] = " | DDS_OP_SUBTYPE_1BY"; break;
       case DDS_OP_VAL_2BY: vec[len++] = " | DDS_OP_SUBTYPE_2BY"; break;
       case DDS_OP_VAL_4BY: vec[len++] = " | DDS_OP_SUBTYPE_4BY"; break;
@@ -2012,6 +2013,7 @@ static idl_retcode_t get_ctype_keys_adr(
       assert(ctype->instructions.table[offs + 2].type == SINGLE);
       key->dims = ctype->instructions.table[offs + 2].data.single;
       switch (DDS_OP_SUBTYPE(inst->data.opcode.code)) {
+        case DDS_OP_VAL_BLN:
         case DDS_OP_VAL_1BY: key->size = key->align = 1; break;
         case DDS_OP_VAL_2BY: key->size = key->align = 2; break;
         case DDS_OP_VAL_4BY: key->size = key->align = 4; break;
@@ -2038,6 +2040,7 @@ static idl_retcode_t get_ctype_keys_adr(
     } else {
       key->dims = 1;
       switch (DDS_OP_TYPE(inst->data.opcode.code)) {
+        case DDS_OP_VAL_BLN:
         case DDS_OP_VAL_1BY: key->size = key->align = 1; break;
         case DDS_OP_VAL_2BY: key->size = key->align = 2; break;
         case DDS_OP_VAL_4BY: key->size = key->align = 4; break;

--- a/src/tools/idlc/xtests/CMakeLists.txt
+++ b/src/tools/idlc/xtests/CMakeLists.txt
@@ -28,6 +28,7 @@ set(_sources
   test_union_r.idl
   test_bounded_seq.idl
   test_enum.idl
+  test_bool.idl
 )
 
 set(_includes "${_includes}\\;${CMAKE_SOURCE_DIR}/src/core/ddsc/include")

--- a/src/tools/idlc/xtests/test_bool.idl
+++ b/src/tools/idlc/xtests/test_bool.idl
@@ -1,0 +1,119 @@
+/*
+ * Copyright(c) 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+#if defined(__IDLC__)
+
+@final @nested
+union u switch (boolean) {
+  case true: @external boolean u1;
+  case false: boolean u2;
+};
+
+typedef boolean b;
+typedef boolean b_arr[50];
+typedef sequence<boolean> b_seq_arr[2];
+
+@topic @final
+struct test_bool {
+  @key boolean f1;
+  @key boolean f2[3];
+  sequence<boolean> f3;
+  u f4;
+  @external boolean f5;
+  @optional boolean f6;
+  @key @external boolean f7[4];
+  b f8;
+  @key b_arr f9;
+  b_seq_arr f10;
+};
+
+#else
+
+#include <string.h>
+#include "dds/dds.h"
+#include "dds/ddsi/ddsi_cdrstream.h"
+#include "test_bool.h"
+#include "common.h"
+
+const dds_topic_descriptor_t *desc = &test_bool_desc;
+
+void init_sample (void *s)
+{
+  test_bool *s1 = (test_bool *) s;
+  s1->f1 = true;
+  for (uint32_t n = 0; n < 3; n++)
+    s1->f2[n] = n % 2;
+  SEQA(s1->f3, 2)
+  s1->f3._buffer[0] = false;
+  s1->f3._buffer[1] = true;
+  s1->f4._d = true;
+  EXTA(s1->f4._u.u1, true);
+  EXTA(s1->f5, false);
+  s1->f6 = NULL;
+  A(s1->f7);
+  for (uint32_t n = 0; n < 4; n++)
+    (*s1->f7)[n] = n % 2 ? false : true;
+  s1->f8 = true;
+  for (uint32_t n = 0; n < 50; n++)
+    s1->f9[n] = true;
+  SEQA(s1->f10[0], 1);
+  s1->f10[0]._buffer[0] = true;
+  SEQA(s1->f10[1], 2);
+  s1->f10[1]._buffer[0] = true;
+  s1->f10[1]._buffer[1] = false;
+}
+
+int cmp_sample (const void *sa, const void *sb)
+{
+  test_bool *a = (test_bool *) sa;
+  test_bool *b = (test_bool *) sb;
+
+  CMP (a, b, f1, true);
+  for (uint32_t n = 0; n < 3; n++)
+    CMP (a, b, f2[n], n % 2);
+  CMP (a, b, f3._length, 2);
+  CMP (a, b, f3._buffer[0], false);
+  CMP (a, b, f3._buffer[1], true);
+  CMP (a, b, f4._d, true);
+  CMPEXT (a, b, f4._u.u1, true);
+  CMPEXT (a, b, f5, false);
+  CMP (a, b, f6, NULL);
+  for (uint32_t n = 0; n < 4; n++)
+    CMPEXTA (a, b, f7, n, n % 2 ? false : true);
+  CMP (a, b, f8, true);
+  for (uint32_t n = 0; n < 50; n++)
+    CMP (a, b, f9[n], true);
+  CMP (a, b, f10[0]._length, 1);
+  CMP (a, b, f10[0]._buffer[0], true);
+  CMP (a, b, f10[1]._length, 2);
+  CMP (a, b, f10[1]._buffer[0], true);
+  CMP (a, b, f10[1]._buffer[1], false);
+  return 0;
+}
+
+int cmp_key (const void *sa, const void *sb)
+{
+  test_bool *a = (test_bool *) sa;
+  test_bool *b = (test_bool *) sb;
+
+  CMP (a, b, f1, true);
+  for (uint32_t n = 0; n < 3; n++)
+    CMP (a, b, f2[n], n % 2);
+  for (uint32_t n = 0; n < 4; n++)
+    CMPEXTA (a, b, f7, n, n % 2 ? false : true);
+  for (uint32_t n = 0; n < 50; n++)
+    CMP (a, b, f9[n], true);
+
+  return 0;
+}
+
+#endif


### PR DESCRIPTION
Note: this PR builds on #1149 and includes the commits from that PR. When #1149 is merged (after I've fixed the issues from the review) I'll rebase the changes for this PR. 

This adds a serializer opcode for boolean type in idlc and cdrstream, to enable checking for valid value for boolean types when reading and writing sample data and keys. 

Commit 1c45bfce8b00dcffbd4ca4cd636871494a3e9bb8 contains a fix for a bug that I found when writing a test-case for this PR. This fixes the `sizeof()` that is included in the serializer instructions for the element size of a typedef of an array of sequences. 