### PR TITLE
Fix crash when idlc cannot find a scoped name

### DIFF
--- a/src/idl/src/symbol.c
+++ b/src/idl/src/symbol.c
@@ -72,8 +72,10 @@ idl_create_scoped_name(
   size_t len, off;
   const char *root = absolute ? "::" : "";
 
+  if (!name)
+    return IDL_RETCODE_SYNTAX_ERROR;
+
   (void)pstate;
-  assert(name);
   assert(name->identifier);
   if (!(scoped_name = calloc(1, sizeof(*scoped_name))))
     goto err_alloc;


### PR DESCRIPTION
This may occur when for instance you use the annotation: @bla(X) and
X cannot be located
A more elegant manner of exiting the program is used

Signed-off-by: Martijn Reicher <martijn.reicher@zettascale.tech>