### PR TITLE
Tweak rhc_torture timeout

### DIFF
--- a/src/core/xtests/rhc_torture/CMakeLists.txt
+++ b/src/core/xtests/rhc_torture/CMakeLists.txt
@@ -28,6 +28,6 @@ target_link_libraries(rhc_torture RhcTypes ddsc)
 
 add_test(
   NAME rhc_torture
-  COMMAND rhc_torture 314159265 0 5000 0 1 16)
-set_property(TEST rhc_torture PROPERTY TIMEOUT 20)
+  COMMAND rhc_torture 314159265 0 5000 0 1 20)
+set_property(TEST rhc_torture PROPERTY TIMEOUT 30)
 set_test_library_paths(rhc_torture)

--- a/src/core/xtests/rhc_torture/CMakeLists.txt
+++ b/src/core/xtests/rhc_torture/CMakeLists.txt
@@ -28,6 +28,6 @@ target_link_libraries(rhc_torture RhcTypes ddsc)
 
 add_test(
   NAME rhc_torture
-  COMMAND rhc_torture 314159265 0 5000 0)
+  COMMAND rhc_torture 314159265 0 5000 0 1 16)
 set_property(TEST rhc_torture PROPERTY TIMEOUT 20)
 set_test_library_paths(rhc_torture)

--- a/src/core/xtests/rhc_torture/rhc_torture.c
+++ b/src/core/xtests/rhc_torture/rhc_torture.c
@@ -19,6 +19,7 @@
 #include "dds/ddsrt/process.h"
 #include "dds/ddsrt/sync.h"
 #include "dds/ddsrt/random.h"
+#include "dds/ddsrt/cdtors.h"
 #include "dds/dds.h"
 #include "dds/ddsi/ddsi_tkmap.h"
 #include "dds__entity.h"
@@ -896,8 +897,40 @@ static void test_conditions (dds_entity_t pp, dds_entity_t tp, const int count, 
     fwr (wr[i]);
 }
 
+struct stacktracethread_arg {
+  dds_time_t when;
+  dds_time_t period;
+  bool stop;
+  ddsrt_mutex_t lock;
+  ddsrt_cond_t cond;
+};
+
+static uint32_t stacktracethread (void *varg)
+{
+  struct stacktracethread_arg * const arg = varg;
+  ddsrt_log_cfg_t logcfg;
+  dds_time_t when = arg->when;
+  dds_log_cfg_init (&logcfg, 0, ~0u, stdout, stdout);
+  ddsrt_mutex_lock (&arg->lock);
+  while (!arg->stop)
+  {
+    if (ddsrt_cond_waituntil (&arg->cond, &arg->lock, when))
+      continue;
+    ddsrt_mutex_unlock (&arg->lock);
+    log_stack_traces (&logcfg, NULL);
+    ddsrt_mutex_lock (&arg->lock);
+    if (arg->period == 0)
+      break;
+    if (when < INT64_MAX)
+      when += arg->period;
+  }
+  ddsrt_mutex_unlock (&arg->lock);
+  return 0;
+}
+
 int main (int argc, char **argv)
 {
+  ddsrt_init ();
   dds_entity_t pp = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL, NULL);
   dds_entity_t tp = dds_create_topic(pp, &RhcTypes_T_desc, "RhcTypes_T", NULL, NULL);
   uint32_t states_seen[2 * 2 * 3][2] = {{ 0 }};
@@ -905,6 +938,9 @@ int main (int argc, char **argv)
   bool print = false;
   int xchecks = 1;
   int first = 0, count = 10000;
+  struct stacktracethread_arg sttarg = { 0 };
+  ddsrt_thread_t stttid;
+  memset (&stttid, 0, sizeof (stttid));
 
   ddsrt_mutex_init (&wait_gc_cycle_lock);
   ddsrt_cond_init (&wait_gc_cycle_cond);
@@ -921,6 +957,18 @@ int main (int argc, char **argv)
     print = (atoi (argv[4]) != 0);
   if (argc > 5)
     xchecks = atoi (argv[5]);
+  if (argc > 6)
+  {
+    sttarg.when = dds_time () + DDS_SECS (atoi (argv[6]));
+    sttarg.period = DDS_SECS (1);
+    sttarg.stop = 0;
+    ddsrt_mutex_init (&sttarg.lock);
+    ddsrt_cond_init (&sttarg.cond);
+    ddsrt_threadattr_t tattr;
+    ddsrt_threadattr_init (&tattr);
+    if (ddsrt_thread_create (&stttid, "stacktracethread", &tattr, stacktracethread, &sttarg) != 0)
+      abort ();
+  }
 
   printf ("%"PRId64" prng seed %u first %d count %d print %d xchecks %d\n", dds_time (), seed, first, count, print, xchecks);
   ddsrt_prng_init_simple (&prng, seed);
@@ -1116,6 +1164,18 @@ int main (int argc, char **argv)
     RhcTypes_T_free (&rres_mseq[i], DDS_FREE_CONTENTS);
 
   ddsi_sertype_unref (mdtype);
-  dds_delete(pp);
+  dds_delete (pp);
+
+  if (sttarg.when)
+  {
+    ddsrt_mutex_lock (&sttarg.lock);
+    sttarg.stop = 1;
+    ddsrt_cond_signal (&sttarg.cond);
+    ddsrt_mutex_unlock (&sttarg.lock);
+    (void) ddsrt_thread_join (stttid, NULL);
+    ddsrt_cond_destroy (&sttarg.cond);
+    ddsrt_mutex_destroy (&sttarg.lock);
+  }
+  ddsrt_fini ();
   return 0;
 }

--- a/src/core/xtests/rhc_torture/rhc_torture.c
+++ b/src/core/xtests/rhc_torture/rhc_torture.c
@@ -922,7 +922,7 @@ int main (int argc, char **argv)
   if (argc > 5)
     xchecks = atoi (argv[5]);
 
-  printf ("prng seed %u first %d count %d print %d xchecks %d\n", seed, first, count, print, xchecks);
+  printf ("%"PRId64" prng seed %u first %d count %d print %d xchecks %d\n", dds_time (), seed, first, count, print, xchecks);
   ddsrt_prng_init_simple (&prng, seed);
 
   if (xchecks != 0)
@@ -952,8 +952,7 @@ int main (int argc, char **argv)
   {
     struct ddsi_domaingv *gv = get_gv (pp);
     struct ddsi_tkmap *tkmap = gv->m_tkmap;
-    if (print)
-      printf ("************* 0 *************\n");
+    printf ("%"PRId64" ************* 0 *************\n", dds_time ());
     struct dds_rhc *rhc = mkrhc (gv, NULL, DDS_HISTORY_KEEP_LAST, 1, DDS_DESTINATIONORDER_BY_SOURCE_TIMESTAMP);
     struct proxy_writer *wr0 = mkwr (1);
     struct proxy_writer *wr1 = mkwr (1);
@@ -1027,8 +1026,7 @@ int main (int argc, char **argv)
   {
     struct ddsi_domaingv *gv = get_gv (pp);
     struct ddsi_tkmap *tkmap = gv->m_tkmap;
-    if (print)
-      printf ("************* 1 *************\n");
+    printf ("%"PRId64" ************* 1 *************\n", dds_time ());
     struct dds_rhc *rhc = mkrhc (gv, NULL, DDS_HISTORY_KEEP_LAST, 4, DDS_DESTINATIONORDER_BY_SOURCE_TIMESTAMP);
     struct proxy_writer *wr[] = { mkwr (0), mkwr (0), mkwr (0) };
     uint64_t iid0, iid_t;
@@ -1105,11 +1103,11 @@ int main (int argc, char **argv)
     for (int zz = 0; zz < (int) (sizeof (zztab) / sizeof (zztab[0])); zz++)
       if (zz + 2 >= first)
       {
-        if (print)
-          printf ("************* %d *************\n", zz + 2);
+        printf ("%"PRId64" ************* %d *************\n", dds_time (), zz + 2);
         test_conditions (pp, tp, count, zztab[zz].create, zztab[zz].filter0, zztab[zz].filter1, print);
       }
   }
+  printf ("%"PRId64" cleaning up\n", dds_time ());
 
   ddsrt_cond_destroy (&wait_gc_cycle_cond);
   ddsrt_mutex_destroy (&wait_gc_cycle_lock);

--- a/src/core/xtests/rhc_torture/rhc_torture.c
+++ b/src/core/xtests/rhc_torture/rhc_torture.c
@@ -920,7 +920,7 @@ int main (int argc, char **argv)
   if (argc > 4)
     print = (atoi (argv[4]) != 0);
   if (argc > 5)
-    xchecks = atoi (argv[4]);
+    xchecks = atoi (argv[5]);
 
   printf ("prng seed %u first %d count %d print %d xchecks %d\n", seed, first, count, print, xchecks);
   ddsrt_prng_init_simple (&prng, seed);


### PR DESCRIPTION
After a bit of investigation, it looks like the timeout was set just too tight for some of the CI platforms, but it is hard to be 100% sure. This PR increases the timeout by a bit and additionally adds some extra output to the test that will hopefully help finding the root cause if the test remains flaky.