### PR TITLE
Accept dlerror messages too large for the buffer

### DIFF
--- a/src/ddsrt/tests/dynlib.c
+++ b/src/ddsrt/tests/dynlib.c
@@ -29,7 +29,7 @@ do { \
   if (var == NULL) { \
     char err[256]; \
     r = ddsrt_dlerror(err, sizeof(err)); \
-    CU_ASSERT_FATAL(r > 0); \
+    CU_ASSERT_FATAL(r > 0 || r == DDS_RETCODE_NOT_ENOUGH_SPACE); \
     printf("\n%s", err); \
     CU_FAIL_FATAL(msg); \
   } \
@@ -93,7 +93,7 @@ CU_Test(ddsrt_library, dlopen_unknown)
   CU_ASSERT_PTR_NULL_FATAL(l);
 
   r = ddsrt_dlerror(buffer, sizeof(buffer));
-  CU_ASSERT_FATAL(r > 0);
+  CU_ASSERT_FATAL(r > 0 || r == DDS_RETCODE_NOT_ENOUGH_SPACE);
   printf("\n%s", buffer);
 }
 
@@ -134,7 +134,7 @@ CU_Test(ddsrt_library, dlsym_unknown)
   CU_ASSERT_PTR_NULL_FATAL(f);
 
   r = ddsrt_dlerror(buffer, sizeof(buffer));
-  CU_ASSERT_FATAL(r > 0);
+  CU_ASSERT_FATAL(r > 0 || r == DDS_RETCODE_NOT_ENOUGH_SPACE);
   printf("\n%s", buffer);
 
   r = ddsrt_dlclose(l);


### PR DESCRIPTION
This is because macOS 12 lists all paths it tried in the error message
after failure to open the library. ddsrt_dlerror uses strlcpy, which
means that the error message is truncated when this happens, but still
safe to print.

Signed-off-by: Erik Boasson <eb@ilities.com>