### PR TITLE
Type consistency enforcement qos

### DIFF
--- a/cmake/Modules/Generate.cmake
+++ b/cmake/Modules/Generate.cmake
@@ -11,26 +11,32 @@
 #
 
 function(IDLC_GENERATE)
+  set(options NO_TYPE_INFO)
   set(one_value_keywords TARGET DEFAULT_EXTENSIBILITY)
   set(multi_value_keywords FILES FEATURES INCLUDES WARNINGS)
   cmake_parse_arguments(
-    IDLC "" "${one_value_keywords}" "${multi_value_keywords}" "" ${ARGN})
+    IDLC "${options}" "${one_value_keywords}" "${multi_value_keywords}" "" ${ARGN})
 
-  idlc_generate_generic(${IDLC_UNPARSED_ARGUMENTS}
+  set(gen_args
+    ${IDLC_UNPARSED_ARGUMENTS}
     TARGET ${IDLC_TARGET}
     FILES ${IDLC_FILES}
     FEATURES ${IDLC_FEATURES}
     INCLUDES ${IDLC_INCLUDES}
     WARNINGS ${IDLC_WARNINGS}
-    DEFAULT_EXTENSIBILITY ${IDLC_DEFAULT_EXTENSIBILITY}
-  )
+    DEFAULT_EXTENSIBILITY ${IDLC_DEFAULT_EXTENSIBILITY})
+  if(${IDLC_NO_TYPE_INFO})
+    list(APPEND gen_args NO_TYPE_INFO)
+  endif()
+  idlc_generate_generic(${gen_args})
 endfunction()
 
 function(IDLC_GENERATE_GENERIC)
+  set(options NO_TYPE_INFO)
   set(one_value_keywords TARGET BACKEND DEFAULT_EXTENSIBILITY)
   set(multi_value_keywords FILES FEATURES INCLUDES WARNINGS SUFFIXES DEPENDS)
   cmake_parse_arguments(
-    IDLC "" "${one_value_keywords}" "${multi_value_keywords}" "" ${ARGN})
+    IDLC "${options}" "${one_value_keywords}" "${multi_value_keywords}" "" ${ARGN})
 
   # find idlc binary
   if(CMAKE_CROSSCOMPILING)
@@ -101,6 +107,10 @@ function(IDLC_GENERATE_GENERIC)
     foreach(_warn ${IDLC_WARNINGS})
       list(APPEND IDLC_ARGS "-W${_warn}")
     endforeach()
+  endif()
+
+  if(IDLC_NO_TYPE_INFO)
+    list(APPEND IDLC_ARGS "-t")
   endif()
 
   set(_dir ${CMAKE_CURRENT_BINARY_DIR})

--- a/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
@@ -277,7 +277,7 @@ enum dds_stream_typecode_subtype {
 #define DDS_TOPIC_NO_OPTIMIZE                   (1u << 0)
 #define DDS_TOPIC_FIXED_KEY                     (1u << 1)   /* Set if the XCDR1 serialized key fits in 16 bytes */
 #define DDS_TOPIC_CONTAINS_UNION                (1u << 2)
-#define DDS_TOPIC_DISABLE_TYPECHECK             (1u << 3)
+// (1u << 3) unused, was used for DDS_TOPIC_DISABLE_TYPECHECK
 #define DDS_TOPIC_FIXED_SIZE                    (1u << 4)
 #define DDS_TOPIC_FIXED_KEY_XCDR2               (1u << 5)   /* Set if the XCDR2 serialized key fits in 16 bytes */
 #define DDS_TOPIC_XTYPES_METADATA               (1u << 6)   /* Set if XTypes meta-data is present for this topic */

--- a/src/core/ddsc/src/dds_sertype_builtintopic.c
+++ b/src/core/ddsc/src/dds_sertype_builtintopic.c
@@ -193,7 +193,6 @@ const struct ddsi_sertype_ops ddsi_sertype_ops_builtintopic = {
   .type_id = 0,
   .type_map = 0,
   .type_info = 0,
-  .assignable_from = 0,
   .get_serialized_size = 0,
   .serialize_into = 0
 };

--- a/src/core/ddsc/tests/CMakeLists.txt
+++ b/src/core/ddsc/tests/CMakeLists.txt
@@ -21,8 +21,11 @@ idlc_generate(TARGET RWData FILES RWData.idl WARNINGS no-implicit-extensibility)
 idlc_generate(TARGET CreateWriter FILES CreateWriter.idl WARNINGS no-implicit-extensibility)
 idlc_generate(TARGET DataRepresentationTypes FILES DataRepresentationTypes.idl WARNINGS no-implicit-extensibility)
 idlc_generate(TARGET MinXcdrVersion FILES MinXcdrVersion.idl)
-idlc_generate(TARGET XSpace FILES XSpace.idl XSpaceMustUnderstand.idl XSpaceEnum.idl)
 idlc_generate(TARGET CdrStreamOptimize FILES CdrStreamOptimize.idl WARNINGS no-implicit-extensibility)
+if(ENABLE_TYPE_DISCOVERY)
+  idlc_generate(TARGET XSpace FILES XSpace.idl XSpaceEnum.idl XSpaceMustUnderstand.idl XSpaceTypeConsistencyEnforcement.idl WARNINGS no-implicit-extensibility no-inherit-appendable)
+  idlc_generate(TARGET XSpaceNoTypeInfo FILES XSpaceNoTypeInfo.idl NO_TYPE_INFO WARNINGS no-implicit-extensibility)
+endif()
 
 set(ddsc_test_sources
     "basic.c"
@@ -79,8 +82,7 @@ set(ddsc_test_sources
     "test_common.c"
     "test_oneliner.c"
     "test_oneliner.h"
-    "cdrstream.c"
-    "data_representation.c")
+    "cdrstream.c")
 
 if(ENABLE_LIFESPAN)
   list(APPEND ddsc_test_sources "lifespan.c")
@@ -91,7 +93,10 @@ if(ENABLE_DEADLINE_MISSED)
 endif()
 
 if(ENABLE_TYPE_DISCOVERY)
-  list(APPEND ddsc_test_sources "typelookup.c" "xtypes.c")
+  list(APPEND ddsc_test_sources
+    "typelookup.c"
+    "xtypes.c"
+    "data_representation.c")
 endif()
 
 if(ENABLE_TOPIC_DISCOVERY)
@@ -111,8 +116,14 @@ if(ENABLE_SHM)
     cunit_ddsc PRIVATE
     "$<BUILD_INTERFACE:$<TARGET_PROPERTY:iceoryx_binding_c::iceoryx_binding_c,INTERFACE_INCLUDE_DIRECTORIES>>")
 endif()
+
 target_link_libraries(cunit_ddsc PRIVATE
-  RoundTrip Space XSpace TypesArrayKey WriteTypes InstanceHandleTypes RWData CreateWriter DataRepresentationTypes MinXcdrVersion CdrStreamOptimize ddsc)
+  RoundTrip Space TypesArrayKey WriteTypes InstanceHandleTypes RWData CreateWriter DataRepresentationTypes MinXcdrVersion CdrStreamOptimize ddsc)
+
+if(ENABLE_TYPE_DISCOVERY)
+  target_link_libraries(cunit_ddsc PRIVATE
+  XSpace XSpaceNoTypeInfo)
+endif()
 
 # Setup environment for config-tests
 get_test_property(CUnit_ddsc_config_simple_udp ENVIRONMENT CUnit_ddsc_config_simple_udp_env)

--- a/src/core/ddsc/tests/XSpaceNoTypeInfo.idl
+++ b/src/core/ddsc/tests/XSpaceNoTypeInfo.idl
@@ -1,0 +1,15 @@
+/*
+ * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+module XSpaceNoTypeInfo {
+  struct t1 { long long_1; };
+};

--- a/src/core/ddsc/tests/XSpaceTypeConsistencyEnforcement.idl
+++ b/src/core/ddsc/tests/XSpaceTypeConsistencyEnforcement.idl
@@ -1,0 +1,40 @@
+/*
+ * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+module XSpaceTypeConsistencyEnforcement
+{
+  // sequence bounds
+  struct t1_1 { sequence<long, 5> f1; };
+  struct t1_2 { sequence<long, 10> f1;};
+  struct t1_3 { sequence<long> f1; };
+
+  // string bounds
+  struct t2_1 { string<5> f1; };
+  struct t2_2 { string<10> f1; };
+  struct t2_3 { string f1; };
+
+  // member names
+  struct t3_1 { long f1; };
+  struct t3_2 { long f1a; };
+  union t4_1 switch (long) { case 1: long f1; };
+  union t4_2 switch (long) { case 1: long f1a; };
+
+  // type widening
+  @appendable struct t5_1 { long f1; };
+  @appendable struct t5_2 : t5_1 { long f2; };
+  @appendable struct t5_3 { long f1; long f2; };
+  @appendable struct t5_4 { long f1; @optional long f2; };
+  @mutable struct t6_1 { long f1; };
+  @mutable struct t6_2 { long f1; long f2; };
+  @appendable union t7_1 switch (long) { case 1: long f1; };
+  @appendable union t7_2 switch (long) { case 1: long f1; case 2: short f2; };
+};

--- a/src/core/ddsc/tests/multi_sertopic.c
+++ b/src/core/ddsc/tests/multi_sertopic.c
@@ -81,7 +81,7 @@ static const dds_topic_descriptor_t type_seq_desc =
 {
   .m_size = sizeof (struct type_seq),
   .m_align = sizeof (void *),
-  .m_flagset = DDS_TOPIC_NO_OPTIMIZE | DDS_TOPIC_DISABLE_TYPECHECK,
+  .m_flagset = DDS_TOPIC_NO_OPTIMIZE,
   .m_nkeys = 0,
   .m_typename = "multi_sertype_type",
   .m_keys = NULL,
@@ -97,7 +97,7 @@ static const dds_topic_descriptor_t type_ary_desc =
 {
   .m_size = sizeof (struct type_ary),
   .m_align = 4u,
-  .m_flagset = DDS_TOPIC_NO_OPTIMIZE | DDS_TOPIC_DISABLE_TYPECHECK,
+  .m_flagset = DDS_TOPIC_NO_OPTIMIZE,
   .m_nkeys = 0,
   .m_typename = "multi_sertype_type",
   .m_keys = NULL,
@@ -113,7 +113,7 @@ static const dds_topic_descriptor_t type_uni_desc =
 {
   .m_size = sizeof (struct type_uni),
   .m_align = sizeof (void *),
-  .m_flagset = DDS_TOPIC_NO_OPTIMIZE | DDS_TOPIC_CONTAINS_UNION | DDS_TOPIC_DISABLE_TYPECHECK,
+  .m_flagset = DDS_TOPIC_NO_OPTIMIZE | DDS_TOPIC_CONTAINS_UNION,
   .m_nkeys = 0,
   .m_typename = "multi_sertype_type",
   .m_keys = NULL,
@@ -144,7 +144,7 @@ static const dds_topic_descriptor_t type_ary1_desc =
 {
   .m_size = sizeof (struct type_ary),
   .m_align = 1u,
-  .m_flagset = DDS_TOPIC_NO_OPTIMIZE | DDS_TOPIC_DISABLE_TYPECHECK,
+  .m_flagset = DDS_TOPIC_NO_OPTIMIZE,
   .m_nkeys = 0,
   .m_typename = "multi_sertype_type",
   .m_keys = NULL,
@@ -160,7 +160,7 @@ static const dds_topic_descriptor_t type_ary2_desc =
 {
   .m_size = sizeof (struct type_ary),
   .m_align = 2u,
-  .m_flagset = DDS_TOPIC_NO_OPTIMIZE | DDS_TOPIC_DISABLE_TYPECHECK,
+  .m_flagset = DDS_TOPIC_NO_OPTIMIZE,
   .m_nkeys = 0,
   .m_typename = "multi_sertype_type",
   .m_keys = NULL,

--- a/src/core/ddsc/tests/xtypes.c
+++ b/src/core/ddsc/tests/xtypes.c
@@ -34,6 +34,8 @@
 #include "XSpace.h"
 #include "XSpaceEnum.h"
 #include "XSpaceMustUnderstand.h"
+#include "XSpaceTypeConsistencyEnforcement.h"
+#include "XSpaceNoTypeInfo.h"
 
 #define DDS_DOMAINID_PUB 0
 #define DDS_DOMAINID_SUB 1
@@ -48,7 +50,7 @@ static dds_entity_t g_participant2 = 0;
 static dds_entity_t g_subscriber2 = 0;
 
 typedef void (*sample_init) (void *s);
-typedef void (*sample_cmp) (void *s1, void *s2);
+typedef void (*sample_check) (void *s1, void *s2);
 
 static void xtypes_init (void)
 {
@@ -93,28 +95,37 @@ static bool reader_wait_for_data (dds_entity_t pp, dds_entity_t rd, dds_duration
   return ret > 0;
 }
 
-static void check_assignable (const dds_topic_descriptor_t *rd_desc, const dds_topic_descriptor_t *wr_desc, bool assignable, sample_init fn_init, bool read_sample, sample_cmp fn_cmp)
+static void do_test (const dds_topic_descriptor_t *rd_desc, const dds_qos_t *add_rd_qos, const dds_topic_descriptor_t *wr_desc, const dds_qos_t *add_wr_qos, bool assignable, sample_init fn_init, bool read_sample, sample_check fn_check)
 {
-  char topic_name[100];
   dds_return_t ret;
-
+  char topic_name[100];
   create_unique_topic_name ("ddsc_xtypes", topic_name, sizeof (topic_name));
   dds_entity_t topic_wr = dds_create_topic (g_participant1, wr_desc, topic_name, NULL, NULL);
   CU_ASSERT_FATAL (topic_wr > 0);
   dds_entity_t topic_rd = dds_create_topic (g_participant2, rd_desc, topic_name, NULL, NULL);
   CU_ASSERT_FATAL (topic_rd > 0);
 
-  dds_qos_t *qos = dds_create_qos ();
+  dds_qos_t *qos = dds_create_qos (), *wrqos = dds_create_qos (), *rdqos = dds_create_qos ();
+  CU_ASSERT_FATAL (qos != NULL);
   dds_qset_reliability (qos, DDS_RELIABILITY_RELIABLE, DDS_SECS (10));
   dds_qset_history (qos, DDS_HISTORY_KEEP_ALL, 0);
   dds_qset_data_representation (qos, 1, (dds_data_representation_id_t[]) { DDS_DATA_REPRESENTATION_XCDR2 });
-  CU_ASSERT_FATAL (qos != NULL);
+  dds_copy_qos (wrqos, qos);
+  dds_copy_qos (rdqos, qos);
 
-  dds_entity_t writer = dds_create_writer (g_participant1, topic_wr, qos, NULL);
+  if (add_wr_qos)
+    dds_merge_qos (wrqos, add_wr_qos);
+  dds_entity_t writer = dds_create_writer (g_participant1, topic_wr, wrqos, NULL);
   CU_ASSERT_FATAL (writer > 0);
-  dds_entity_t reader = dds_create_reader (g_participant2, topic_rd, qos, NULL);
+
+  if (add_rd_qos)
+    dds_merge_qos (rdqos, add_rd_qos);
+  dds_entity_t reader = dds_create_reader (g_participant2, topic_rd, rdqos, NULL);
   CU_ASSERT_FATAL (reader > 0);
+
   dds_delete_qos (qos);
+  dds_delete_qos (wrqos);
+  dds_delete_qos (rdqos);
 
   if (assignable)
   {
@@ -122,27 +133,29 @@ static void check_assignable (const dds_topic_descriptor_t *rd_desc, const dds_t
     ret = dds_set_status_mask (reader, DDS_DATA_AVAILABLE_STATUS);
     CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
 
-    void * wr_sample = dds_alloc (wr_desc->m_size);
-    fn_init (wr_sample);
-    ret = dds_write (writer, wr_sample);
-    CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
-
-    void * rd_sample = dds_alloc (rd_desc->m_size);
-    void * rd_samples[1];
-    rd_samples[0] = rd_sample;
-    dds_sample_info_t info;
-    bool data = reader_wait_for_data (g_participant2, reader, DDS_MSECS (500));
-    CU_ASSERT_FATAL (data == read_sample);
-    if (data)
+    if (fn_init)
     {
-      CU_ASSERT_FATAL (data);
-      ret = dds_take (reader, rd_samples, &info, 1, 1);
-      CU_ASSERT_EQUAL_FATAL (ret, 1);
-      if (fn_cmp)
-        fn_cmp (wr_sample, rd_sample);
+      void * wr_sample = dds_alloc (wr_desc->m_size);
+      fn_init (wr_sample);
+      ret = dds_write (writer, wr_sample);
+      CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
+
+      void * rd_sample = dds_alloc (rd_desc->m_size);
+      void * rd_samples[1];
+      rd_samples[0] = rd_sample;
+      dds_sample_info_t info;
+      bool data = reader_wait_for_data (g_participant2, reader, DDS_MSECS (500));
+      CU_ASSERT_FATAL (data == read_sample);
+      if (data)
+      {
+        ret = dds_take (reader, rd_samples, &info, 1, 1);
+        CU_ASSERT_EQUAL_FATAL (ret, 1);
+        if (fn_check)
+          fn_check (wr_sample, rd_sample);
+      }
+      dds_sample_free (wr_sample, wr_desc, DDS_FREE_ALL);
+      dds_sample_free (rd_sample, rd_desc, DDS_FREE_ALL);
     }
-    dds_sample_free (wr_sample, wr_desc, DDS_FREE_ALL);
-    dds_sample_free (rd_sample, rd_desc, DDS_FREE_ALL);
   }
   else
   {
@@ -150,8 +163,7 @@ static void check_assignable (const dds_topic_descriptor_t *rd_desc, const dds_t
   }
 }
 
-
-/* Basic assignability test cases */
+/* Some basic tests */
 static void sample_init_XType1 (void *ptr)
 {
   XSpace_XType1 *sample = (XSpace_XType1 *) ptr;
@@ -166,7 +178,7 @@ static void sample_init_XType1a (void *ptr)
   sample->long_2 = 2;
   sample->bm_3 = 3;
 }
-static void sample_cmp_XType1_1a (void *ptr1, void *ptr2)
+static void sample_check_XType1_1a (void *ptr1, void *ptr2)
 {
   XSpace_XType1 *s_wr = (XSpace_XType1 *) ptr1;
   XSpace_XType1a *s_rd = (XSpace_XType1a *) ptr2;
@@ -174,7 +186,7 @@ static void sample_cmp_XType1_1a (void *ptr1, void *ptr2)
   CU_ASSERT_EQUAL_FATAL (s_rd->long_2, s_wr->long_2);
   CU_ASSERT_EQUAL_FATAL (s_rd->bm_3, s_wr->bm_3);
 }
-static void sample_cmp_XType1a_1 (void *ptr1, void *ptr2)
+static void sample_check_XType1a_1 (void *ptr1, void *ptr2)
 {
   XSpace_XType1a *s_wr = (XSpace_XType1a *) ptr1;
   XSpace_XType1 *s_rd = (XSpace_XType1 *) ptr2;
@@ -196,7 +208,7 @@ static void sample_init_XType2a (void *ptr)
   sample->long_2 = 2;
   sample->long_3 = 3;
 }
-static void sample_cmp_XType2_2a (void *ptr1, void *ptr2)
+static void sample_check_XType2_2a (void *ptr1, void *ptr2)
 {
   XSpace_XType2 *s_wr = (XSpace_XType2 *) ptr1;
   XSpace_XType2a *s_rd = (XSpace_XType2a *) ptr2;
@@ -204,7 +216,7 @@ static void sample_cmp_XType2_2a (void *ptr1, void *ptr2)
   CU_ASSERT_EQUAL_FATAL (s_rd->long_2, s_wr->long_2);
   CU_ASSERT_EQUAL_FATAL (s_rd->long_3, 0);
 }
-static void sample_cmp_XType2a_2 (void *ptr1, void *ptr2)
+static void sample_check_XType2a_2 (void *ptr1, void *ptr2)
 {
   XSpace_XType2a *s_wr = (XSpace_XType2a *) ptr1;
   XSpace_XType2 *s_rd = (XSpace_XType2 *) ptr2;
@@ -226,7 +238,7 @@ static void sample_init_XType3a (void *ptr)
   sample->long_2 = 2;
   sample->struct_3.long_4 = 4;
 }
-static void sample_cmp_XType3_3a (void *ptr1, void *ptr2)
+static void sample_check_XType3_3a (void *ptr1, void *ptr2)
 {
   XSpace_XType3 *s_wr = (XSpace_XType3 *) ptr1;
   XSpace_XType3a *s_rd = (XSpace_XType3a *) ptr2;
@@ -234,7 +246,7 @@ static void sample_cmp_XType3_3a (void *ptr1, void *ptr2)
   CU_ASSERT_EQUAL_FATAL (s_rd->long_2, s_wr->long_2);
   CU_ASSERT_EQUAL_FATAL (s_rd->struct_3.long_4, s_wr->struct_3.long_4);
 }
-static void sample_cmp_XType3a_3 (void *ptr1, void *ptr2)
+static void sample_check_XType3a_3 (void *ptr1, void *ptr2)
 {
   XSpace_XType3a *s_wr = (XSpace_XType3a *) ptr1;
   XSpace_XType3 *s_rd = (XSpace_XType3 *) ptr2;
@@ -245,7 +257,7 @@ static void sample_cmp_XType3a_3 (void *ptr1, void *ptr2)
 
 #define D(n) XSpace_ ## n ## _desc
 #define I(n) sample_init_ ## n
-#define C(n) sample_cmp_ ## n
+#define C(n) sample_check_ ## n
 CU_TheoryDataPoints (ddsc_xtypes, basic) = {
   CU_DataPoints (const char *,                   "mutable_bitmask",
   /*                                             |                      */"appendable_field",
@@ -254,22 +266,17 @@ CU_TheoryDataPoints (ddsc_xtypes, basic) = {
   CU_DataPoints (const dds_topic_descriptor_t *, &D(XType1a),            &D(XType2a),             &D(XType3a),            ),
   CU_DataPoints (sample_init,                    I(XType1),              I(XType2),               I(XType3),              ),
   CU_DataPoints (sample_init,                    I(XType1a),             I(XType2a),              I(XType3a),             ),
-  CU_DataPoints (sample_cmp,                     C(XType1_1a),           C(XType2_2a),            C(XType3_3a),           ),
-  CU_DataPoints (sample_cmp,                     C(XType1a_1),           C(XType2a_2),            C(XType3a_3),           ),
+  CU_DataPoints (sample_check,                   C(XType1_1a),           C(XType2_2a),            C(XType3_3a),           ),
+  CU_DataPoints (sample_check,                   C(XType1a_1),           C(XType2a_2),            C(XType3a_3),           ),
 };
 
-CU_Theory ((const char *descr, const dds_topic_descriptor_t *desc1, const dds_topic_descriptor_t *desc2, sample_init fn_init1, sample_init fn_init2, sample_cmp fn_cmp1, sample_cmp fn_cmp2),
+CU_Theory ((const char *descr, const dds_topic_descriptor_t *desc1, const dds_topic_descriptor_t *desc2, sample_init fn_init1, sample_init fn_init2, sample_check fn_check1, sample_check fn_check2),
     ddsc_xtypes, basic, .init = xtypes_init, .fini = xtypes_fini)
 {
   for (int t = 0; t <= 1; t++)
   {
     printf ("Running test xtypes_basic: %s (run %d/2)\n", descr, t + 1);
-
-    const dds_topic_descriptor_t *wr_desc = t ? desc2 : desc1,
-                                 *rd_desc = t ? desc1 : desc2;
-    sample_init fn_init = t ? fn_init2 : fn_init1;
-    sample_cmp fn_cmp = t ? fn_cmp2 : fn_cmp1;
-    check_assignable (rd_desc, wr_desc, true, fn_init, true, fn_cmp);
+    do_test (t ? desc1 : desc2, NULL, t ? desc2 : desc1, NULL, true, t ? fn_init2 : fn_init1, true, t ? fn_check2 : fn_check1);
   }
 }
 #undef D
@@ -331,14 +338,96 @@ CU_TheoryDataPoints (ddsc_xtypes, must_understand) = {
   CU_DataPoints (sample_init,                     0,         I(mu_wr1_2), I(mu_wr1_3a), I(mu_wr1_3b), I(mu_wr1_4a), I(mu_wr1_4b), I(mu_wr2_1a), I(mu_wr2_1b) ),
   CU_DataPoints (bool,                            false,     true,        true,         false,        true,         true,         true,         false        )
 };
-#undef D
-#undef I
 
 CU_Theory ((const dds_topic_descriptor_t *rd_desc, const dds_topic_descriptor_t *wr_desc, bool assignable, sample_init fn_init, bool read_sample),
     ddsc_xtypes, must_understand, .init = xtypes_init, .fini = xtypes_fini)
 {
   printf ("Running test xtypes_must_understand: %s %s\n", wr_desc->m_typename, rd_desc->m_typename);
-  check_assignable (rd_desc, wr_desc, assignable, fn_init, read_sample, 0);
+  do_test (rd_desc, NULL, wr_desc, NULL, assignable, fn_init, read_sample, 0);
+}
+#undef D
+#undef I
+
+/* Type consistency enforcement policy test cases (ignore seq/str bounds, prevent type widening, allow type coercion) */
+#define D(n) (&XSpaceTypeConsistencyEnforcement_ ## n ## _desc)
+#define I(n) sample_init_tce_ ## n
+#define C(n) sample_check_tce_ ## n
+#define ALLOW   DDS_TYPE_CONSISTENCY_ALLOW_TYPE_COERCION
+#define DISALW  DDS_TYPE_CONSISTENCY_DISALLOW_TYPE_COERCION
+#define DT true
+#define DF false
+#define DDS_TD_T const dds_topic_descriptor_t *
+#define DDS_TCE_T dds_type_consistency_kind_t
+
+CU_TheoryDataPoints (ddsc_xtypes, type_consistency_enforcement) = {
+  CU_DataPoints (const char *,
+                            "wr seq bound > rd seq bound, but ignore_seq_bounds",
+                                     "wr seq bound > rd seq bound, !ignore_seq_bounds",
+                                              "wr seq unbounded > rd seq bound, !ignore_seq_bounds",
+                                                       "wr seq bound < rd seq unbound, !ignore_seq_bounds",
+                                                                "disallow coercion, same type",
+                                                                         "disallow coercion, different (assignable) type",
+                                                                                  "wr str bound > rd str bound, but ignore_str_bounds",
+                                                                                           "wr str bound > rd str bound, !ignore_str_bounds",
+                                                                                                    "wr str unbounded > rd str bound, !ignore_str_bounds",
+                                                                                                             "wr str bound < rd str unbound, !ignore_str_bounds",
+                                                                                                                      "member names different, !ignore_member_names",
+                                                                                                                               "member names different, ignore_member_names",
+                                                                                                                                        "union member names different, !ignore_member_names",
+                                                                                                                                                 "union member names different, !ignore_member_names",
+                                                                                                                                                          "widen type, !prevent_type_widening",
+                                                                                                                                                                   "widen type, prevent_type_widening",
+                                                                                                                                                                            "same members, prevent_type_widening",
+                                                                                                                                                                                     "widen with optional member, prevent_type_widening",
+                                                                                                                                                                                              "widen mutable type, !prevent_type_widening",
+                                                                                                                                                                                                       "widen mutable type, prevent_type_widening",
+                                                                                                                                                                                                                "widen union type, !prevent_type_widening",
+                                                                                                                                                                                                                         "widen union type, prevent_type_widening"),
+  CU_DataPoints (DDS_TD_T,  D(t1_1), D(t1_1), D(t1_1), D(t1_3), D(t1_1), D(t1_1), D(t2_1), D(t2_1), D(t2_1), D(t2_3), D(t3_1), D(t3_1), D(t4_1), D(t4_1), D(t5_1), D(t5_1), D(t5_1), D(t5_1), D(t6_1), D(t6_1), D(t7_1), D(t7_1)    ),
+  CU_DataPoints (DDS_TD_T,  D(t1_2), D(t1_2), D(t1_3), D(t1_1), D(t1_1), D(t1_3), D(t2_2), D(t2_2), D(t2_3), D(t2_1), D(t3_2), D(t3_2), D(t4_2), D(t4_2), D(t5_2), D(t5_2), D(t5_3), D(t5_4), D(t6_2), D(t6_2), D(t7_2), D(t7_2)    ),
+
+  CU_DataPoints (DDS_TCE_T, ALLOW  , ALLOW  , ALLOW  , ALLOW  , DISALW , DISALW , ALLOW  , ALLOW  , ALLOW  , ALLOW  , ALLOW  , ALLOW  , ALLOW  , ALLOW  , ALLOW  , ALLOW  , ALLOW  , ALLOW  , ALLOW  , ALLOW  , ALLOW  , ALLOW      ),  // allow/disallow type coercion
+  CU_DataPoints (bool,      DF     , DF     , DF     , DF     , DF     , DF     , DF     , DF     , DF     , DF     , DF     , DF     , DF     , DF     , false  , true   , true   , true   , false  , true   , false  , true       ),  // prevent_type_widening
+  CU_DataPoints (bool,      true   , false  , false  , false  , DT     , DT     , DT     , DT     , DT     , DT     , DT     , DT     , DT     , DT     , DT     , DT     , DT     , DT     , DT     , DT     , DT     , DT         ),  // ignore_seq_bounds
+  CU_DataPoints (bool,      DT     , DT     , DT     , DT     , DT     , DT     , true   , false  , false  , false  , DT     , DT     , DT     , DT     , DT     , DT     , DT     , DT     , DT     , DT     , DT     , DT         ),  // ignore_str_bounds
+  CU_DataPoints (bool,      DF     , DF     , DF     , DF     , DF     , DF     , DF     , DF     , DF     , DF     , false  , true   , false  , true   , DF     , DF     , DF     , DF     , DF     , DF     , DF     , DF         ),  // ignore_member_names
+  CU_DataPoints (bool,      DF     , DF     , DF     , DF     , DF     , DF     , DF     , DF     , DF     , DF     , DF     , DF     , DF     , DF     , DF     , DF     , DF     , DF     , DF     , DF     , DF     , DF         ),  // force_type_validation
+
+  CU_DataPoints (bool,      true   , false  , false  , true   , true   , false  , true   , false  , false  , true   , false  , true   , false  , true   , true   , false  , false  , true   , true   , false  , true   , false      ),  // expect match
+};
+
+CU_Theory ((const char *test, const dds_topic_descriptor_t *rd_desc, const dds_topic_descriptor_t *wr_desc, dds_type_consistency_kind_t kind,
+    bool prevent_type_widening, bool ignore_seq_bounds, bool ignore_str_bounds, bool ignore_member_names, bool force_type_validation, bool assignable),
+  ddsc_xtypes, type_consistency_enforcement, .init = xtypes_init, .fini = xtypes_fini)
+{
+  printf ("Running test xtypes_type_consistency_enforcement: %s wr %s rd %s\n", test, wr_desc->m_typename, rd_desc->m_typename);
+  dds_qos_t *rd_qos = dds_create_qos ();
+  dds_qset_type_consistency (rd_qos, kind, ignore_seq_bounds, ignore_str_bounds, ignore_member_names, prevent_type_widening, force_type_validation);
+  do_test (rd_desc, rd_qos, wr_desc, NULL, assignable, 0, false, 0);
+  dds_delete_qos (rd_qos);
+}
+#undef D
+#undef I
+#undef C
+#undef ALLOW
+#undef DISALLOW
+#undef DT
+#undef DF
+#undef DDS_TD_T
+#undef DDS_TCE_T
+
+/* Type consistency enforcement policy test case for force_type_validation */
+CU_Test (ddsc_xtypes, type_consistency_enforcement_force_validation, .init = xtypes_init, .fini = xtypes_fini)
+{
+  for (uint32_t n = 0; n <= 1; n++)
+  {
+    bool force_type_validation = (n == 1);
+    printf ("Running test type_consistency_enforcement_force_validation: force_type_validation = %s\n", force_type_validation ? "true" : "false");
+    dds_qos_t *rd_qos = dds_create_qos ();
+    dds_qset_type_consistency (rd_qos, DDS_TYPE_CONSISTENCY_ALLOW_TYPE_COERCION, true, true, false, false, force_type_validation);
+    do_test (&XSpaceNoTypeInfo_t1_desc, rd_qos, &XSpaceNoTypeInfo_t1_desc, NULL, !force_type_validation, 0, false, 0);
+    dds_delete_qos (rd_qos);
+  }
 }
 
 
@@ -376,15 +465,16 @@ CU_TheoryDataPoints (ddsc_xtypes, enum_extensibility) = {
   CU_DataPoints (sample_init,                     I(en_wr1_1), 0,         0,          0,          0,          I(en_wr2_1), 0,         I(en_wr2_3), I(en_wr2_4), 0          ),
   CU_DataPoints (bool,                            true,        false,     false,      false,      false,      true,        false,     true,        true,        false      )
 };
-#undef D
-#undef DP
-#undef DM
-#undef DL
-#undef I
 
 CU_Theory ((const dds_topic_descriptor_t *rd_desc, const dds_topic_descriptor_t *wr_desc, bool assignable, sample_init fn_init, bool read_sample),
     ddsc_xtypes, enum_extensibility, .init = xtypes_init, .fini = xtypes_fini)
 {
   printf ("Running test xtypes_enum: %s %s\n", wr_desc->m_typename, rd_desc->m_typename);
-  check_assignable (rd_desc, wr_desc, assignable, fn_init, read_sample, 0);
+  do_test (rd_desc, NULL, wr_desc, NULL, assignable, fn_init, read_sample, 0);
 }
+
+#undef D
+#undef DP
+#undef DM
+#undef DL
+#undef I

--- a/src/core/ddsi/include/dds/ddsi/ddsi_sertype.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_sertype.h
@@ -132,9 +132,6 @@ typedef ddsi_typemap_t * (*ddsi_sertype_typemap_t) (const struct ddsi_sertype *t
 /* Gets the CDR blob for the type information of this sertype */
 typedef ddsi_typeinfo_t * (*ddsi_sertype_typeinfo_t) (const struct ddsi_sertype *tp);
 
-/* Check if (an object of) type a is assignable from (an object of) the type b */
-typedef bool (*ddsi_sertype_assignable_from_t) (const struct ddsi_sertype *sertype_a, const struct ddsi_type_pair *type_pair_b);
-
 /* Create a new derived sertype (a shallow copy of the provided sertype) with the
    serdata_ops for the provided data representation */
 typedef struct ddsi_sertype * (*ddsi_sertype_derive_t) (const struct ddsi_sertype *sertype, dds_data_representation_id_t data_representation, dds_type_consistency_enforcement_qospolicy_t tce_qos);
@@ -162,7 +159,6 @@ struct ddsi_sertype_ops {
   ddsi_sertype_typeid_t type_id;
   ddsi_sertype_typemap_t type_map;
   ddsi_sertype_typeinfo_t type_info;
-  ddsi_sertype_assignable_from_t assignable_from;
   ddsi_sertype_derive_t derive_sertype;
   ddsi_sertype_get_serialized_size_t get_serialized_size;
   ddsi_sertype_serialize_into_t serialize_into;
@@ -244,16 +240,6 @@ DDS_INLINE_EXPORT inline ddsi_typeinfo_t *ddsi_sertype_typeinfo (const struct dd
     return NULL;
   return tp->ops->type_info (tp);
 }
-DDS_INLINE_EXPORT inline bool ddsi_sertype_assignable_from (const struct ddsi_sertype *sertype_a, const struct ddsi_type_pair *type_pair_b) {
-  /* If sertype_a does not have a assignability check function
-     (e.g. because it is an older sertype implementation), consider
-     the types as assignable */
-  if (!sertype_a->ops->assignable_from)
-    return true;
-
-  return sertype_a->ops->assignable_from (sertype_a, type_pair_b);
-}
-
 DDS_INLINE_EXPORT inline struct ddsi_sertype * ddsi_sertype_derive_sertype (const struct ddsi_sertype *base_sertype, dds_data_representation_id_t data_representation, dds_type_consistency_enforcement_qospolicy_t tce_qos) {
   if (!base_sertype->ops->derive_sertype)
     return NULL;

--- a/src/core/ddsi/include/dds/ddsi/ddsi_typelib.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_typelib.h
@@ -75,7 +75,7 @@ DDS_EXPORT void ddsi_type_unref (struct ddsi_domaingv *gv, struct ddsi_type *typ
 DDS_EXPORT void ddsi_type_unref_sertype (struct ddsi_domaingv *gv, const struct ddsi_sertype *sertype);
 DDS_EXPORT void ddsi_type_unref_locked (struct ddsi_domaingv *gv, struct ddsi_type *type);
 
-DDS_EXPORT bool ddsi_is_assignable_from (struct ddsi_domaingv *gv, const struct ddsi_type_pair *rd_type_pair, const struct ddsi_type_pair *wr_type_pair);
+DDS_EXPORT bool ddsi_is_assignable_from (struct ddsi_domaingv *gv, const struct ddsi_type_pair *rd_type_pair, const struct ddsi_type_pair *wr_type_pair, const dds_type_consistency_enforcement_qospolicy_t *tce);
 DDS_EXPORT const ddsi_typeid_t *ddsi_type_pair_minimal_id (const struct ddsi_type_pair *type_pair);
 DDS_EXPORT const ddsi_typeid_t *ddsi_type_pair_complete_id (const struct ddsi_type_pair *type_pair);
 DDS_EXPORT const struct ddsi_sertype *ddsi_type_pair_complete_sertype (const struct ddsi_type_pair *type_pair);

--- a/src/core/ddsi/include/dds/ddsi/ddsi_typelib.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_typelib.h
@@ -75,7 +75,7 @@ DDS_EXPORT void ddsi_type_unref (struct ddsi_domaingv *gv, struct ddsi_type *typ
 DDS_EXPORT void ddsi_type_unref_sertype (struct ddsi_domaingv *gv, const struct ddsi_sertype *sertype);
 DDS_EXPORT void ddsi_type_unref_locked (struct ddsi_domaingv *gv, struct ddsi_type *type);
 
-DDS_EXPORT bool ddsi_is_assignable_from (struct ddsi_domaingv *gv, const struct ddsi_type *type_a, const struct ddsi_type_pair *type_pair_b);
+DDS_EXPORT bool ddsi_is_assignable_from (struct ddsi_domaingv *gv, const struct ddsi_type_pair *rd_type_pair, const struct ddsi_type_pair *wr_type_pair);
 DDS_EXPORT const ddsi_typeid_t *ddsi_type_pair_minimal_id (const struct ddsi_type_pair *type_pair);
 DDS_EXPORT const ddsi_typeid_t *ddsi_type_pair_complete_id (const struct ddsi_type_pair *type_pair);
 DDS_EXPORT const struct ddsi_sertype *ddsi_type_pair_complete_sertype (const struct ddsi_type_pair *type_pair);

--- a/src/core/ddsi/include/dds/ddsi/ddsi_typewrap.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_typewrap.h
@@ -63,7 +63,7 @@ DDS_EXPORT dds_return_t ddsi_xt_type_init (struct ddsi_domaingv *gv, struct xt_t
 DDS_EXPORT dds_return_t ddsi_xt_type_add_typeobj (struct ddsi_domaingv *gv, struct xt_type *xt, const struct DDS_XTypes_TypeObject *to);
 DDS_EXPORT void ddsi_xt_get_typeobject (const struct xt_type *xt, ddsi_typeobj_t *to);
 DDS_EXPORT void ddsi_xt_type_fini (struct ddsi_domaingv *gv, struct xt_type *xt);
-DDS_EXPORT bool ddsi_xt_is_assignable_from (struct ddsi_domaingv *gv, const struct xt_type *t1, const struct xt_type *t2);
+DDS_EXPORT bool ddsi_xt_is_assignable_from (struct ddsi_domaingv *gv, const struct xt_type *rd_xt, const struct xt_type *wr_xt);
 
 
 #else /* DDS_HAS_TYPE_DISCOVERY */

--- a/src/core/ddsi/include/dds/ddsi/ddsi_typewrap.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_typewrap.h
@@ -63,7 +63,7 @@ DDS_EXPORT dds_return_t ddsi_xt_type_init (struct ddsi_domaingv *gv, struct xt_t
 DDS_EXPORT dds_return_t ddsi_xt_type_add_typeobj (struct ddsi_domaingv *gv, struct xt_type *xt, const struct DDS_XTypes_TypeObject *to);
 DDS_EXPORT void ddsi_xt_get_typeobject (const struct xt_type *xt, ddsi_typeobj_t *to);
 DDS_EXPORT void ddsi_xt_type_fini (struct ddsi_domaingv *gv, struct xt_type *xt);
-DDS_EXPORT bool ddsi_xt_is_assignable_from (struct ddsi_domaingv *gv, const struct xt_type *rd_xt, const struct xt_type *wr_xt);
+DDS_EXPORT bool ddsi_xt_is_assignable_from (struct ddsi_domaingv *gv, const struct xt_type *rd_xt, const struct xt_type *wr_xt, const dds_type_consistency_enforcement_qospolicy_t *tce);
 
 
 #else /* DDS_HAS_TYPE_DISCOVERY */

--- a/src/core/ddsi/src/ddsi_plist.c
+++ b/src/core/ddsi/src/ddsi_plist.c
@@ -590,9 +590,6 @@ static dds_return_t valid_type_consistency (const void *src, size_t srcoff)
 {
   DDSRT_STATIC_ASSERT (DDS_TYPE_CONSISTENCY_DISALLOW_TYPE_COERCION == 0 && DDS_TYPE_CONSISTENCY_ALLOW_TYPE_COERCION == 1);
   dds_type_consistency_enforcement_qospolicy_t const * const x = deser_generic_src (src, &srcoff, alignof (dds_type_consistency_enforcement_qospolicy_t));
-  if (x->kind == DDS_TYPE_CONSISTENCY_DISALLOW_TYPE_COERCION
-      && (x->ignore_sequence_bounds || x->ignore_string_bounds || x->ignore_member_names || !x->prevent_type_widening))
-    return DDS_RETCODE_BAD_PARAMETER;
   if (x->kind > DDS_TYPE_CONSISTENCY_ALLOW_TYPE_COERCION)
     return DDS_RETCODE_BAD_PARAMETER;
   return 0;
@@ -3480,8 +3477,8 @@ const dds_qos_t ddsi_default_qos_reader = {
   .subscription_keys.key_list.n = 0,
   .subscription_keys.key_list.strs = NULL,
   .type_consistency.kind = DDS_TYPE_CONSISTENCY_ALLOW_TYPE_COERCION,
-  .type_consistency.ignore_sequence_bounds = false,
-  .type_consistency.ignore_string_bounds = false,
+  .type_consistency.ignore_sequence_bounds = true,
+  .type_consistency.ignore_string_bounds = true,
   .type_consistency.ignore_member_names = false,
   .type_consistency.prevent_type_widening = false,
   .type_consistency.force_type_validation = false,

--- a/src/core/ddsi/src/ddsi_sertopic.c
+++ b/src/core/ddsi/src/ddsi_sertopic.c
@@ -159,7 +159,6 @@ static const struct ddsi_sertype_ops sertopic_ops_wrap = {
   .type_id = 0,
   .type_map = 0,
   .type_info = 0,
-  .assignable_from = 0,
   .get_serialized_size = 0,
   .serialize_into = 0
 };

--- a/src/core/ddsi/src/ddsi_sertype.c
+++ b/src/core/ddsi/src/ddsi_sertype.c
@@ -300,7 +300,6 @@ DDS_EXPORT extern inline void ddsi_sertype_free_sample (const struct ddsi_sertyp
 DDS_EXPORT extern inline ddsi_typeid_t * ddsi_sertype_typeid (const struct ddsi_sertype *tp, ddsi_typeid_kind_t kind);
 DDS_EXPORT extern inline ddsi_typemap_t * ddsi_sertype_typemap (const struct ddsi_sertype *tp);
 DDS_EXPORT extern inline ddsi_typeinfo_t * ddsi_sertype_typeinfo (const struct ddsi_sertype *tp);
-DDS_EXPORT extern inline bool ddsi_sertype_assignable_from (const struct ddsi_sertype *sertype_a, const struct ddsi_type_pair *type_pair_b);
 DDS_EXPORT extern inline struct ddsi_sertype * ddsi_sertype_derive_sertype (const struct ddsi_sertype *base_sertype, dds_data_representation_id_t data_representation, dds_type_consistency_enforcement_qospolicy_t tce_qos);
 
 DDS_EXPORT extern inline size_t ddsi_sertype_get_serialized_size(const struct ddsi_sertype *tp, const void *sample);

--- a/src/core/ddsi/src/ddsi_sertype_default.c
+++ b/src/core/ddsi/src/ddsi_sertype_default.c
@@ -95,31 +95,6 @@ static ddsi_typeinfo_t *sertype_default_typeinfo (const struct ddsi_sertype *tpc
   return ddsi_typeinfo_deser (&tp->type.typeinfo_ser);
 }
 
-static bool sertype_default_assignable_from (const struct ddsi_sertype *sertype_a, const struct ddsi_type_pair *type_pair_b)
-{
-  assert (type_pair_b);
-  struct ddsi_type *type_a;
-  struct ddsi_domaingv *gv = ddsrt_atomic_ldvoidp (&sertype_a->gv);
-
-  // If receiving type disables type checking, type b is assignable
-  struct ddsi_sertype_default *a = (struct ddsi_sertype_default *) sertype_a;
-  if (a->type.flagset & DDS_TOPIC_DISABLE_TYPECHECK)
-    return true;
-
-  ddsi_typeid_t *type_id = sertype_default_typeid (sertype_a, DDSI_TYPEID_KIND_MINIMAL);
-  type_a = ddsi_type_lookup_locked (gv, type_id);
-  ddsi_typeid_fini (type_id);
-  ddsrt_free (type_id);
-  if (!type_a)
-  {
-    type_id = sertype_default_typeid (sertype_a, DDSI_TYPEID_KIND_COMPLETE);
-    type_a = ddsi_type_lookup_locked (gv, type_id);
-    ddsi_typeid_fini (type_id);
-    ddsrt_free (type_id);
-  }
-  return ddsi_is_assignable_from (gv, type_a, type_pair_b);
-}
-
 #endif /* DDS_HAS_TYPE_DISCOVERY */
 
 static uint32_t sertype_default_hash (const struct ddsi_sertype *tpcmn)
@@ -290,12 +265,10 @@ const struct ddsi_sertype_ops ddsi_sertype_ops_default = {
   .type_id = sertype_default_typeid,
   .type_map = sertype_default_typemap,
   .type_info = sertype_default_typeinfo,
-  .assignable_from = sertype_default_assignable_from,
 #else
   .type_id = 0,
   .type_map = 0,
   .type_info = 0,
-  .assignable_from = 0,
 #endif
   .derive_sertype = sertype_default_derive_sertype,
   .get_serialized_size = sertype_default_get_serialized_size,

--- a/src/core/ddsi/src/ddsi_sertype_plist.c
+++ b/src/core/ddsi/src/ddsi_sertype_plist.c
@@ -102,7 +102,6 @@ const struct ddsi_sertype_ops ddsi_sertype_ops_plist = {
   .type_id = 0,
   .type_map = 0,
   .type_info = 0,
-  .assignable_from = 0,
   .get_serialized_size = 0,
   .serialize_into = 0
 };

--- a/src/core/ddsi/src/ddsi_sertype_pserop.c
+++ b/src/core/ddsi/src/ddsi_sertype_pserop.c
@@ -126,7 +126,6 @@ const struct ddsi_sertype_ops ddsi_sertype_ops_pserop = {
   .type_id = 0,
   .type_map = 0,
   .type_info = 0,
-  .assignable_from = 0,
   .get_serialized_size = 0,
   .serialize_into = 0
 };

--- a/src/core/ddsi/src/ddsi_typelib.c
+++ b/src/core/ddsi/src/ddsi_typelib.c
@@ -667,7 +667,7 @@ uint32_t ddsi_type_get_gpe_matches (struct ddsi_domaingv *gv, const struct ddsi_
   return n;
 }
 
-bool ddsi_is_assignable_from (struct ddsi_domaingv *gv, const struct ddsi_type_pair *rd_type_pair, const struct ddsi_type_pair *wr_type_pair)
+bool ddsi_is_assignable_from (struct ddsi_domaingv *gv, const struct ddsi_type_pair *rd_type_pair, const struct ddsi_type_pair *wr_type_pair, const dds_type_consistency_enforcement_qospolicy_t *tce)
 {
   if (!rd_type_pair || !wr_type_pair)
     return false;
@@ -675,7 +675,7 @@ bool ddsi_is_assignable_from (struct ddsi_domaingv *gv, const struct ddsi_type_p
   const struct xt_type
     *rd_xt = rd_type_pair->minimal ? &rd_type_pair->minimal->xt : &rd_type_pair->complete->xt,
     *wr_xt = wr_type_pair->minimal ? &wr_type_pair->minimal->xt : &wr_type_pair->complete->xt;
-  bool assignable = ddsi_xt_is_assignable_from (gv, rd_xt, wr_xt);
+  bool assignable = ddsi_xt_is_assignable_from (gv, rd_xt, wr_xt, tce);
   ddsrt_mutex_unlock (&gv->typelib_lock);
   return assignable;
 }

--- a/src/core/ddsi/src/ddsi_typelib.c
+++ b/src/core/ddsi/src/ddsi_typelib.c
@@ -667,15 +667,17 @@ uint32_t ddsi_type_get_gpe_matches (struct ddsi_domaingv *gv, const struct ddsi_
   return n;
 }
 
-bool ddsi_is_assignable_from (struct ddsi_domaingv *gv, const struct ddsi_type *type_a, const struct ddsi_type_pair *type_pair_b)
+bool ddsi_is_assignable_from (struct ddsi_domaingv *gv, const struct ddsi_type_pair *rd_type_pair, const struct ddsi_type_pair *wr_type_pair)
 {
-  if (!type_a || !type_pair_b)
+  if (!rd_type_pair || !wr_type_pair)
     return false;
-  if (type_pair_b->minimal)
-    return ddsi_xt_is_assignable_from (gv, &type_a->xt, &type_pair_b->minimal->xt);
-  if (type_pair_b->complete)
-    return ddsi_xt_is_assignable_from (gv, &type_a->xt, &type_pair_b->complete->xt);
-  return false;
+  ddsrt_mutex_lock (&gv->typelib_lock);
+  const struct xt_type
+    *rd_xt = rd_type_pair->minimal ? &rd_type_pair->minimal->xt : &rd_type_pair->complete->xt,
+    *wr_xt = wr_type_pair->minimal ? &wr_type_pair->minimal->xt : &wr_type_pair->complete->xt;
+  bool assignable = ddsi_xt_is_assignable_from (gv, rd_xt, wr_xt);
+  ddsrt_mutex_unlock (&gv->typelib_lock);
+  return assignable;
 }
 
 char *ddsi_make_typeid_str_impl (struct ddsi_typeid_str *buf, const DDS_XTypes_TypeIdentifier *type_id)

--- a/src/core/ddsi/src/ddsi_typewrap.c
+++ b/src/core/ddsi/src/ddsi_typewrap.c
@@ -1874,9 +1874,9 @@ struct_failed:
   return result;
 }
 
-bool ddsi_xt_is_assignable_from (struct ddsi_domaingv *gv, const struct xt_type *t1a, const struct xt_type *t2a)
+bool ddsi_xt_is_assignable_from (struct ddsi_domaingv *gv, const struct xt_type *rd_xt, const struct xt_type *wr_xt)
 {
-  const struct xt_type *t1 = ddsi_xt_unalias (t1a), *t2 = ddsi_xt_unalias (t2a);
+  const struct xt_type *t1 = ddsi_xt_unalias (rd_xt), *t2 = ddsi_xt_unalias (wr_xt);
 
   if (xt_is_equivalent_minimal (t1, t2))
     return true;


### PR DESCRIPTION
This adds the implementation for the type consistency enforcement qos policy: 
- Add support for `ignore_sequence_bounds`, `ignore_string_bounds`, `ignore_member_names`, `prevent_type_widening`
and the type consistency kind (allow/disallow type coercion) options that can be set using the type consistency enforcement qos policy
- Commit 56cc62067f13264706b7d329e95962e8cff98376 removes the assignability check from sertype interface: this initial implementation will not work for all intended use cases (specific non-xtypes based implementations), and might be replaced by a new generic interface in a future release. For now the assignability check is called directly from the qos matching function. 
- Fixes for a bug and memory leaks in the assignability check
- Add option to disable type meta-data generation in the `idlc_generation` cmake function