### PR TITLE
Add APPEND_PROJECT_NAME_TO_INCLUDEDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,15 @@ include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 include(CTest)
 
+option(APPEND_PROJECT_NAME_TO_INCLUDEDIR
+  "When ON headers are installed to a folder ending with an extra ${PROJECT_NAME}. \
+  This avoids include directory search order issues when overriding this package
+  from a merged catkin, ament, or colcon workspace." ON)
+
+if(APPEND_PROJECT_NAME_TO_INCLUDEDIR)
+  set(CMAKE_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}")
+endif()
+
 if(APPLE)
   set(CMAKE_INSTALL_RPATH "@loader_path/../${CMAKE_INSTALL_LIBDIR}")
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,7 +266,7 @@ include(CTest)
 option(APPEND_PROJECT_NAME_TO_INCLUDEDIR
   "When ON headers are installed to a folder ending with an extra ${PROJECT_NAME}. \
   This avoids include directory search order issues when overriding this package
-  from a merged catkin, ament, or colcon workspace." ON)
+  from a merged catkin, ament, or colcon workspace." OFF)
 
 if(APPEND_PROJECT_NAME_TO_INCLUDEDIR)
   set(CMAKE_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}")

--- a/src/core/ddsc/CMakeLists.txt
+++ b/src/core/ddsc/CMakeLists.txt
@@ -76,7 +76,7 @@ prepend(hdrs_private_ddsc "${CMAKE_CURRENT_LIST_DIR}/src/"
   dds__get_status.h
   dds__data_allocator.h)
 
-prepend(hdrs_public_ddsc "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>$<INSTALL_INTERFACE:include>/dds/"
+prepend(hdrs_public_ddsc "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>/dds/"
   dds.h
   ddsc/dds_public_error.h
   ddsc/dds_public_impl.h
@@ -104,7 +104,7 @@ target_sources(ddsc
     ${hdrs_private_ddsc}
   PUBLIC
     ${hdrs_public_ddsc}
-    "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>$<INSTALL_INTERFACE:include>/dds/export.h")
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>/dds/export.h")
 
 target_include_directories(ddsc
   PUBLIC
@@ -114,7 +114,7 @@ target_include_directories(ddsc
   PRIVATE
     "${CMAKE_CURRENT_LIST_DIR}/src"
   INTERFACE
-    $<INSTALL_INTERFACE:include>)
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 install(
   DIRECTORY


### PR DESCRIPTION
The first commit is a bugfix that makes sure installed targets use `CMAKE_INSTALL_INCLUDEDIR` instead of hard coding `include`.

The second commit is an enhancement supporting https://github.com/ros2/ros2/issues/1150.  It adds a CMake option defaulting to `ON` that installs headers to `include/CycloneDDS` instead of `include`.

When using ROS 2 and Colcon it's possible to have two versions of a package installed: typically one from the debian packages (like`ros-[rosdistro]-cyclonedds`) and another in a from-source workspace. In Colcon terms this is called "overriding a package", and the `/opt/ros/[rosdistro]` folder would be called the underlay while the from-source workspace would be called the overlay. A user would do this when they want to try a newer version of a package without building everything from source.

When two or more packages install their headers to the same directory in an underlay, it becomes possible for packages in the overlay to accidentally find the headers of an overridden package in the underlay. This can cause build failures or undefined behavior at runtime depending on the differences between the headers in the overridden and overriding packages. The exact conditions this happens are a little complicated, so I'll skip writing it out here. In ROS 2 we're solving the issue by making every package install its headers to a unique folder using `${PROJECT_NAME}`. That's what the second commit does.