### PR TITLE
Type object validation

### DIFF
--- a/src/core/ddsc/tests/XSpace.idl
+++ b/src/core/ddsc/tests/XSpace.idl
@@ -64,7 +64,7 @@ module XSpace {
       @id(3) XType3_1a struct_3;
     };
 
-    /* Types for top-level type checking */
+    /* Test types for type object validation and type dependencies */
     typedef sequence<long> seql;
     enum e { E1, E2 };
     bitmask bm { BM1, BM2 };
@@ -84,6 +84,16 @@ module XSpace {
 
     union to_uniondisc switch (long) {
       case 1: long u1;
+    };
+
+    @nested @appendable
+    struct dep_test_nested {
+      long n1;
+      long n2;
+    };
+
+    struct dep_test {
+      dep_test_nested f1;
     };
 
 };

--- a/src/core/ddsc/tests/XSpace.idl
+++ b/src/core/ddsc/tests/XSpace.idl
@@ -1,4 +1,5 @@
 /*
+ * Copyright(c) 2022 ZettaScale Technology
  * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
  *
  * This program and the accompanying materials are made available under the
@@ -61,6 +62,28 @@ module XSpace {
       @id(1) long long_1;
       @id(2) long long_2;
       @id(3) XType3_1a struct_3;
+    };
+
+    /* Types for top-level type checking */
+    typedef sequence<long> seql;
+    enum e { E1, E2 };
+    bitmask bm { BM1, BM2 };
+    @final struct to_toplevel {
+      seql f1;
+      e f2;
+      bm f3;
+    };
+
+    @nested struct to_base {
+      long b1;
+    };
+    @nested union u switch (long) { case 1: long u1; };
+    struct to_inherit : to_base {
+      u f1;
+    };
+
+    union to_uniondisc switch (long) {
+      case 1: long u1;
     };
 
 };

--- a/src/core/ddsc/tests/iceoryx.c
+++ b/src/core/ddsc/tests/iceoryx.c
@@ -93,17 +93,6 @@ ${CYCLONEDDS_URI}${CYCLONEDDS_URI:+,}\
   return pp;
 }
 
-static struct ddsi_domaingv *get_domaingv (dds_entity_t handle)
-{
-  dds_return_t rc;
-  struct dds_entity *x;
-  rc = dds_entity_pin (handle, &x);
-  CU_ASSERT_FATAL (rc == DDS_RETCODE_OK);
-  struct ddsi_domaingv * const gv = &x->m_domain->gv;
-  dds_entity_unpin (x);
-  return gv;
-}
-
 static bool endpoint_has_iceoryx_enabled (dds_entity_t rd_or_wr)
 {
   dds_return_t rc;

--- a/src/core/ddsc/tests/test_common.h
+++ b/src/core/ddsc/tests/test_common.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright(c) 2022 ZettaScale Technology
  * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
  *
  * This program and the accompanying materials are made available under the
@@ -18,9 +19,14 @@
 #include "CUnit/Test.h"
 #include "CUnit/Theory.h"
 
+#include "dds/ddsrt/heap.h"
+#include "dds/ddsi/ddsi_cdrstream.h"
 #include "test_util.h"
 
 #include "Space.h"
 #include "RoundTrip.h"
+
+void xcdr2_ser (const void *obj, const dds_topic_descriptor_t *desc, dds_ostream_t *os);
+void xcdr2_deser (unsigned char *buf, uint32_t sz, void **obj, const dds_topic_descriptor_t *desc);
 
 #endif /* _TEST_COMMON_H_ */

--- a/src/core/ddsc/tests/test_util.c
+++ b/src/core/ddsc/tests/test_util.c
@@ -15,6 +15,7 @@
 #include "dds/ddsrt/atomics.h"
 #include "dds/ddsrt/process.h"
 #include "dds/ddsrt/threads.h"
+#include "dds/ddsi/ddsi_iid.h"
 #include "dds__entity.h"
 #include "test_util.h"
 
@@ -47,4 +48,16 @@ struct ddsi_domaingv *get_domaingv (dds_entity_t handle)
   struct ddsi_domaingv * const gv = &x->m_domain->gv;
   dds_entity_unpin (x);
   return gv;
+}
+
+void gen_test_guid (struct ddsi_domaingv *gv, ddsi_guid_t *guid, uint32_t entity_id)
+{
+  union { uint64_t u64; uint32_t u32[2]; } u;
+  u.u32[0] = gv->ppguid_base.prefix.u[1];
+  u.u32[1] = gv->ppguid_base.prefix.u[2];
+  u.u64 += ddsi_iid_gen ();
+  guid->prefix.u[0] = gv->ppguid_base.prefix.u[0];
+  guid->prefix.u[1] = u.u32[0];
+  guid->prefix.u[2] = u.u32[1];
+  guid->entityid.u = entity_id;
 }

--- a/src/core/ddsc/tests/test_util.c
+++ b/src/core/ddsc/tests/test_util.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright(c) 2022 ZettaScale Technology
  * Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
  *
  * This program and the accompanying materials are made available under the
@@ -14,6 +15,7 @@
 #include "dds/ddsrt/atomics.h"
 #include "dds/ddsrt/process.h"
 #include "dds/ddsrt/threads.h"
+#include "dds__entity.h"
 #include "test_util.h"
 
 void tprintf (const char *msg, ...)
@@ -34,4 +36,15 @@ char *create_unique_topic_name (const char *prefix, char *name, size_t size)
   const uint32_t nr = ddsrt_atomic_inc32_nv (&count);
   (void) snprintf (name, size, "%s%"PRIu32"_pid%" PRIdPID "_tid%" PRIdTID "", prefix, nr, pid, tid);
   return name;
+}
+
+struct ddsi_domaingv *get_domaingv (dds_entity_t handle)
+{
+  struct dds_entity *x;
+  dds_return_t ret = dds_entity_pin (handle, &x);
+  assert (ret == DDS_RETCODE_OK);
+  (void) ret;
+  struct ddsi_domaingv * const gv = &x->m_domain->gv;
+  dds_entity_unpin (x);
+  return gv;
 }

--- a/src/core/ddsc/tests/test_util.h
+++ b/src/core/ddsc/tests/test_util.h
@@ -33,4 +33,7 @@ void tprintf (const char *msg, ...)
 /* Get gv from the provided entity */
 struct ddsi_domaingv *get_domaingv (dds_entity_t handle);
 
+/* Generate a guid */
+void gen_test_guid (struct ddsi_domaingv *gv, ddsi_guid_t *guid, uint32_t entity_id);
+
 #endif /* _TEST_UTIL_H_ */

--- a/src/core/ddsc/tests/test_util.h
+++ b/src/core/ddsc/tests/test_util.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright(c) 2022 ZettaScale Technology
  * Copyright(c) 2020 ADLINK Technology Limited and others
  *
  * This program and the accompanying materials are made available under the
@@ -14,6 +15,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include "dds/ddsi/ddsi_domaingv.h"
 
 /* Get unique g_topic name on each invocation. */
 char *create_unique_topic_name (const char *prefix, char *name, size_t size);
@@ -27,5 +29,8 @@ void no_sync_reader_writer (dds_entity_t participant_rd, dds_entity_t reader, dd
 /* Print message preceded by time stamp */
 void tprintf (const char *msg, ...)
   ddsrt_attribute_format_printf (1, 2);
+
+/* Get gv from the provided entity */
+struct ddsi_domaingv *get_domaingv (dds_entity_t handle);
 
 #endif /* _TEST_UTIL_H_ */

--- a/src/core/ddsc/tests/xtypes.c
+++ b/src/core/ddsc/tests/xtypes.c
@@ -810,6 +810,7 @@ CU_Theory ((const char *test_descr, const dds_topic_descriptor_t *topic_desc, ty
 
   struct ddsi_type *type = ddsi_type_lookup (gv, (ddsi_typeid_t *) &tmap->identifier_object_pair_minimal._buffer[0].type_identifier);
   CU_ASSERT_PTR_NOT_NULL_FATAL (type);
+  assert (type);
   CU_ASSERT_EQUAL_FATAL (type->state, DDSI_TYPE_INVALID);
 
   // clean up

--- a/src/core/ddsi/include/dds/ddsi/ddsi_domaingv.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_domaingv.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright(c) 2022 ZettaScale Technology
  * Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
  *
  * This program and the accompanying materials are made available under the
@@ -327,6 +328,8 @@ struct ddsi_domaingv {
 #ifdef DDS_HAS_TYPE_DISCOVERY
   ddsrt_mutex_t typelib_lock;
   ddsrt_avl_tree_t typelib;
+  ddsrt_avl_tree_t typedeps;
+  ddsrt_avl_tree_t typedeps_reverse;
   ddsrt_cond_t typelib_resolved_cond;
 #endif
 #ifdef DDS_HAS_TOPIC_DISCOVERY

--- a/src/core/ddsi/include/dds/ddsi/ddsi_typelib.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_typelib.h
@@ -98,6 +98,8 @@ DDS_EXPORT void ddsi_type_pair_free (struct ddsi_type_pair *type_pair);
  *   that are referring to it.
  */
 DDS_EXPORT struct ddsi_type * ddsi_type_lookup_locked (struct ddsi_domaingv *gv, const ddsi_typeid_t *type_id);
+/* Same as above, but does not require to have the lock */
+DDS_EXPORT struct ddsi_type * ddsi_type_lookup (struct ddsi_domaingv *gv, const ddsi_typeid_t *type_id);
 
 /**
  * For all proxy endpoints registered with the type lookup meta object that is

--- a/src/core/ddsi/include/dds/ddsi/ddsi_typelib.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_typelib.h
@@ -69,7 +69,7 @@ DDS_EXPORT ddsi_typemap_t *ddsi_typemap_deser (const struct ddsi_sertype_cdr_dat
 DDS_EXPORT void ddsi_typemap_fini (ddsi_typemap_t *typemap);
 
 DDS_EXPORT void ddsi_type_register_dep (struct ddsi_domaingv *gv, const ddsi_typeid_t *src_type_id, struct ddsi_type **dst_dep_type, const struct DDS_XTypes_TypeIdentifier *dep_type_id);
-DDS_EXPORT dds_return_t ddsi_type_ref_locked (struct ddsi_domaingv *gv, struct ddsi_type **type, const struct ddsi_type *src);
+DDS_EXPORT void ddsi_type_ref_locked (struct ddsi_domaingv *gv, struct ddsi_type **type, const struct ddsi_type *src);
 DDS_EXPORT dds_return_t ddsi_type_ref_id_locked (struct ddsi_domaingv *gv, struct ddsi_type **type, const ddsi_typeid_t *type_id);
 DDS_EXPORT dds_return_t ddsi_type_ref_local (struct ddsi_domaingv *gv, struct ddsi_type **type, const struct ddsi_sertype *sertype, ddsi_typeid_kind_t kind);
 DDS_EXPORT dds_return_t ddsi_type_ref_proxy (struct ddsi_domaingv *gv, struct ddsi_type **type, const ddsi_typeinfo_t *type_info, ddsi_typeid_kind_t kind, const ddsi_guid_t *proxy_guid);

--- a/src/core/ddsi/include/dds/ddsi/ddsi_typelib.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_typelib.h
@@ -31,6 +31,8 @@ extern "C" {
 #ifdef DDS_HAS_TYPE_DISCOVERY
 
 extern const ddsrt_avl_treedef_t ddsi_typelib_treedef;
+extern const ddsrt_avl_treedef_t ddsi_typedeps_treedef;
+extern const ddsrt_avl_treedef_t ddsi_typedeps_reverse_treedef;
 
 struct generic_proxy_endpoint;
 struct ddsi_domaingv;
@@ -42,7 +44,9 @@ struct ddsi_type_pair;
 enum ddsi_type_state {
   DDSI_TYPE_UNRESOLVED,
   DDSI_TYPE_REQUESTED,
+  DDSI_TYPE_PARTIAL_RESOLVED,
   DDSI_TYPE_RESOLVED,
+  DDSI_TYPE_INVALID,
 };
 
 /* Used for converting type-id to strings */
@@ -64,6 +68,7 @@ DDS_EXPORT uint32_t ddsi_typeinfo_get_dependent_typeids (const ddsi_typeinfo_t *
 
 DDS_EXPORT ddsi_typemap_t *ddsi_typemap_deser (const struct ddsi_sertype_cdr_data *ser);
 
+DDS_EXPORT void ddsi_type_register_dep (struct ddsi_domaingv *gv, const ddsi_typeid_t *src_type_id, struct ddsi_type **dst_dep_type, const struct DDS_XTypes_TypeIdentifier *dep_type_id);
 DDS_EXPORT dds_return_t ddsi_type_ref_locked (struct ddsi_domaingv *gv, struct ddsi_type **type, const struct ddsi_type *src);
 DDS_EXPORT dds_return_t ddsi_type_ref_id_locked (struct ddsi_domaingv *gv, struct ddsi_type **type, const ddsi_typeid_t *type_id);
 DDS_EXPORT dds_return_t ddsi_type_ref_local (struct ddsi_domaingv *gv, struct ddsi_type **type, const struct ddsi_sertype *sertype, ddsi_typeid_kind_t kind);

--- a/src/core/ddsi/include/dds/ddsi/ddsi_typelib.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_typelib.h
@@ -80,6 +80,7 @@ DDS_EXPORT void ddsi_type_unreg_proxy (struct ddsi_domaingv *gv, struct ddsi_typ
 DDS_EXPORT void ddsi_type_unref (struct ddsi_domaingv *gv, struct ddsi_type *type);
 DDS_EXPORT void ddsi_type_unref_sertype (struct ddsi_domaingv *gv, const struct ddsi_sertype *sertype);
 DDS_EXPORT void ddsi_type_unref_locked (struct ddsi_domaingv *gv, struct ddsi_type *type);
+DDS_EXPORT bool ddsi_type_resolved (struct ddsi_domaingv *gv, const struct ddsi_type *type, bool require_deps);
 
 DDS_EXPORT bool ddsi_is_assignable_from (struct ddsi_domaingv *gv, const struct ddsi_type_pair *rd_type_pair, const struct ddsi_type_pair *wr_type_pair, const dds_type_consistency_enforcement_qospolicy_t *tce);
 DDS_EXPORT const ddsi_typeid_t *ddsi_type_pair_minimal_id (const struct ddsi_type_pair *type_pair);
@@ -87,9 +88,6 @@ DDS_EXPORT const ddsi_typeid_t *ddsi_type_pair_complete_id (const struct ddsi_ty
 DDS_EXPORT const struct ddsi_sertype *ddsi_type_pair_complete_sertype (const struct ddsi_type_pair *type_pair);
 DDS_EXPORT struct ddsi_type_pair *ddsi_type_pair_init (const ddsi_typeid_t *type_id_minimal, const ddsi_typeid_t *type_id_complete);
 DDS_EXPORT void ddsi_type_pair_free (struct ddsi_type_pair *type_pair);
-DDS_EXPORT bool ddsi_type_pair_has_minimal_obj (const struct ddsi_type_pair *type_pair);
-DDS_EXPORT bool ddsi_type_pair_has_complete_obj (const struct ddsi_type_pair *type_pair);
-
 
 /**
  * Returns the type lookup meta object for the provided type identifier.

--- a/src/core/ddsi/include/dds/ddsi/ddsi_typelib.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_typelib.h
@@ -106,12 +106,12 @@ DDS_EXPORT void ddsi_type_register_with_proxy_endpoints (struct ddsi_domaingv *g
 
 /**
  * Gets a list of proxy endpoints that are registered for the provided type
- * and stores it in the gpe_match_upd parameter. The parameter n_match_upd
+ * or for types that (indirectly) depend on this type. The resulting set of
+ * endpoints is stored in the gpe_match_upd parameter. The parameter n_match_upd
  * should contain the actual number of entries in gpe_match_upd and will
- * be updated if new entries are added. The return value is the number
- * of entries appended to the list.
+ * be updated if new entries are added.
  */
-DDS_EXPORT uint32_t ddsi_type_get_gpe_matches (struct ddsi_domaingv *gv, const struct ddsi_type *type, struct generic_proxy_endpoint ***gpe_match_upd, uint32_t *n_match_upd);
+DDS_EXPORT void ddsi_type_get_gpe_matches (struct ddsi_domaingv *gv, const struct ddsi_type *type, struct generic_proxy_endpoint ***gpe_match_upd, uint32_t *n_match_upd);
 
 /**
  * Compares the provided type lookup meta objects.

--- a/src/core/ddsi/include/dds/ddsi/ddsi_typelib.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_typelib.h
@@ -66,6 +66,7 @@ DDS_EXPORT const ddsi_typeid_t *ddsi_typeinfo_complete_typeid (const ddsi_typein
 DDS_EXPORT bool ddsi_typeinfo_valid (const ddsi_typeinfo_t *typeinfo);
 
 DDS_EXPORT ddsi_typemap_t *ddsi_typemap_deser (const struct ddsi_sertype_cdr_data *ser);
+DDS_EXPORT void ddsi_typemap_fini (ddsi_typemap_t *typemap);
 
 DDS_EXPORT void ddsi_type_register_dep (struct ddsi_domaingv *gv, const ddsi_typeid_t *src_type_id, struct ddsi_type **dst_dep_type, const struct DDS_XTypes_TypeIdentifier *dep_type_id);
 DDS_EXPORT dds_return_t ddsi_type_ref_locked (struct ddsi_domaingv *gv, struct ddsi_type **type, const struct ddsi_type *src);

--- a/src/core/ddsi/include/dds/ddsi/ddsi_typelib.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_typelib.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright(c) 2022 ZettaScale Technology
  * Copyright(c) 2006 to 2019 ADLINK Technology Limited and others
  *
  * This program and the accompanying materials are made available under the
@@ -63,10 +64,10 @@ DDS_EXPORT uint32_t ddsi_typeinfo_get_dependent_typeids (const ddsi_typeinfo_t *
 
 DDS_EXPORT ddsi_typemap_t *ddsi_typemap_deser (const struct ddsi_sertype_cdr_data *ser);
 
-DDS_EXPORT struct ddsi_type * ddsi_type_ref_locked (struct ddsi_domaingv *gv, struct ddsi_type *type);
-DDS_EXPORT struct ddsi_type * ddsi_type_ref_id_locked (struct ddsi_domaingv *gv, const ddsi_typeid_t *type_id);
-DDS_EXPORT struct ddsi_type * ddsi_type_ref_local (struct ddsi_domaingv *gv, const struct ddsi_sertype *sertype, ddsi_typeid_kind_t kind);
-DDS_EXPORT struct ddsi_type * ddsi_type_ref_proxy (struct ddsi_domaingv *gv, const ddsi_typeinfo_t *type_info, ddsi_typeid_kind_t kind, const ddsi_guid_t *proxy_guid);
+DDS_EXPORT dds_return_t ddsi_type_ref_locked (struct ddsi_domaingv *gv, struct ddsi_type **type, const struct ddsi_type *src);
+DDS_EXPORT dds_return_t ddsi_type_ref_id_locked (struct ddsi_domaingv *gv, struct ddsi_type **type, const ddsi_typeid_t *type_id);
+DDS_EXPORT dds_return_t ddsi_type_ref_local (struct ddsi_domaingv *gv, struct ddsi_type **type, const struct ddsi_sertype *sertype, ddsi_typeid_kind_t kind);
+DDS_EXPORT dds_return_t ddsi_type_ref_proxy (struct ddsi_domaingv *gv, struct ddsi_type **type, const ddsi_typeinfo_t *type_info, ddsi_typeid_kind_t kind, const ddsi_guid_t *proxy_guid);
 DDS_EXPORT const struct ddsi_sertype *ddsi_type_sertype (const struct ddsi_type *type);
 DDS_EXPORT bool ddsi_type_has_typeobj (const struct ddsi_type *type);
 DDS_EXPORT struct ddsi_typeobj *ddsi_type_get_typeobj (const struct ddsi_type *type);

--- a/src/core/ddsi/include/dds/ddsi/ddsi_typelib.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_typelib.h
@@ -81,7 +81,7 @@ DDS_EXPORT void ddsi_type_unref_sertype (struct ddsi_domaingv *gv, const struct 
 DDS_EXPORT void ddsi_type_unref_locked (struct ddsi_domaingv *gv, struct ddsi_type *type);
 DDS_EXPORT bool ddsi_type_resolved (struct ddsi_domaingv *gv, const struct ddsi_type *type, bool require_deps);
 
-DDS_EXPORT bool ddsi_is_assignable_from (struct ddsi_domaingv *gv, const struct ddsi_type_pair *rd_type_pair, const struct ddsi_type_pair *wr_type_pair, const dds_type_consistency_enforcement_qospolicy_t *tce);
+DDS_EXPORT bool ddsi_is_assignable_from (struct ddsi_domaingv *gv, const struct ddsi_type_pair *rd_type_pair, uint32_t rd_resolved, const struct ddsi_type_pair *wr_type_pair, uint32_t wr_resolved, const dds_type_consistency_enforcement_qospolicy_t *tce);
 DDS_EXPORT const ddsi_typeid_t *ddsi_type_pair_minimal_id (const struct ddsi_type_pair *type_pair);
 DDS_EXPORT const ddsi_typeid_t *ddsi_type_pair_complete_id (const struct ddsi_type_pair *type_pair);
 DDS_EXPORT const struct ddsi_sertype *ddsi_type_pair_complete_sertype (const struct ddsi_type_pair *type_pair);

--- a/src/core/ddsi/include/dds/ddsi/ddsi_typelib.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_typelib.h
@@ -73,6 +73,7 @@ DDS_EXPORT dds_return_t ddsi_type_ref_id_locked (struct ddsi_domaingv *gv, struc
 DDS_EXPORT dds_return_t ddsi_type_ref_local (struct ddsi_domaingv *gv, struct ddsi_type **type, const struct ddsi_sertype *sertype, ddsi_typeid_kind_t kind);
 DDS_EXPORT dds_return_t ddsi_type_ref_proxy (struct ddsi_domaingv *gv, struct ddsi_type **type, const ddsi_typeinfo_t *type_info, ddsi_typeid_kind_t kind, const ddsi_guid_t *proxy_guid);
 DDS_EXPORT const struct ddsi_sertype *ddsi_type_sertype (const struct ddsi_type *type);
+DDS_EXPORT dds_return_t ddsi_type_add_typeobj (struct ddsi_domaingv *gv, struct ddsi_type *type, const struct DDS_XTypes_TypeObject *type_obj);
 DDS_EXPORT struct ddsi_typeobj *ddsi_type_get_typeobj (struct ddsi_domaingv *gv, const struct ddsi_type *type);
 DDS_EXPORT void ddsi_type_unreg_proxy (struct ddsi_domaingv *gv, struct ddsi_type *type, const ddsi_guid_t *proxy_guid);
 DDS_EXPORT void ddsi_type_unref (struct ddsi_domaingv *gv, struct ddsi_type *type);

--- a/src/core/ddsi/include/dds/ddsi/ddsi_typelib.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_typelib.h
@@ -64,7 +64,6 @@ DDS_EXPORT ddsi_typeinfo_t * ddsi_typeinfo_dup (const ddsi_typeinfo_t *src);
 DDS_EXPORT const ddsi_typeid_t *ddsi_typeinfo_minimal_typeid (const ddsi_typeinfo_t *typeinfo);
 DDS_EXPORT const ddsi_typeid_t *ddsi_typeinfo_complete_typeid (const ddsi_typeinfo_t *typeinfo);
 DDS_EXPORT bool ddsi_typeinfo_valid (const ddsi_typeinfo_t *typeinfo);
-DDS_EXPORT uint32_t ddsi_typeinfo_get_dependent_typeids (const ddsi_typeinfo_t *type_info, const ddsi_typeid_t *** dep_ids, ddsi_typeid_kind_t kind);
 
 DDS_EXPORT ddsi_typemap_t *ddsi_typemap_deser (const struct ddsi_sertype_cdr_data *ser);
 
@@ -74,8 +73,7 @@ DDS_EXPORT dds_return_t ddsi_type_ref_id_locked (struct ddsi_domaingv *gv, struc
 DDS_EXPORT dds_return_t ddsi_type_ref_local (struct ddsi_domaingv *gv, struct ddsi_type **type, const struct ddsi_sertype *sertype, ddsi_typeid_kind_t kind);
 DDS_EXPORT dds_return_t ddsi_type_ref_proxy (struct ddsi_domaingv *gv, struct ddsi_type **type, const ddsi_typeinfo_t *type_info, ddsi_typeid_kind_t kind, const ddsi_guid_t *proxy_guid);
 DDS_EXPORT const struct ddsi_sertype *ddsi_type_sertype (const struct ddsi_type *type);
-DDS_EXPORT bool ddsi_type_has_typeobj (const struct ddsi_type *type);
-DDS_EXPORT struct ddsi_typeobj *ddsi_type_get_typeobj (const struct ddsi_type *type);
+DDS_EXPORT struct ddsi_typeobj *ddsi_type_get_typeobj (struct ddsi_domaingv *gv, const struct ddsi_type *type);
 DDS_EXPORT void ddsi_type_unreg_proxy (struct ddsi_domaingv *gv, struct ddsi_type *type, const ddsi_guid_t *proxy_guid);
 DDS_EXPORT void ddsi_type_unref (struct ddsi_domaingv *gv, struct ddsi_type *type);
 DDS_EXPORT void ddsi_type_unref_sertype (struct ddsi_domaingv *gv, const struct ddsi_sertype *sertype);

--- a/src/core/ddsi/include/dds/ddsi/ddsi_typelookup.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_typelookup.h
@@ -45,7 +45,7 @@ struct ddsi_type;
  * Send a type lookup request message in order to request type information for the
  * provided type identifier.
  */
-bool ddsi_tl_request_type (struct ddsi_domaingv * const gv, const ddsi_typeid_t *type_id, const ddsi_typeid_t ** dependent_type_ids, uint32_t dependent_type_id_count);
+bool ddsi_tl_request_type (struct ddsi_domaingv * const gv, const ddsi_typeid_t *type_id, bool include_deps);
 
 /**
  * Handle an incoming type lookup request message. For all types requested

--- a/src/core/ddsi/include/dds/ddsi/ddsi_typelookup.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_typelookup.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright(c) 2022 ZettaScale Technology
  * Copyright(c) 2006 to 2019 ADLINK Technology Limited and others
  *
  * This program and the accompanying materials are made available under the
@@ -25,6 +26,7 @@
 #include "dds/ddsi/ddsi_plist_generic.h"
 #include "dds/ddsi/ddsi_xqos.h"
 #include "dds/ddsi/ddsi_xt_typeinfo.h"
+#include "dds/ddsi/ddsi_xt_typelookup.h"
 #include "dds/ddsi/ddsi_typelib.h"
 
 #if defined (__cplusplus)
@@ -45,7 +47,7 @@ struct ddsi_type;
  * Send a type lookup request message in order to request type information for the
  * provided type identifier.
  */
-bool ddsi_tl_request_type (struct ddsi_domaingv * const gv, const ddsi_typeid_t *type_id, bool include_deps);
+DDS_EXPORT bool ddsi_tl_request_type (struct ddsi_domaingv * const gv, const ddsi_typeid_t *type_id, bool include_deps);
 
 /**
  * Handle an incoming type lookup request message. For all types requested
@@ -53,14 +55,19 @@ bool ddsi_tl_request_type (struct ddsi_domaingv * const gv, const ddsi_typeid_t 
  * lookup reply message. In case none of the requested types is known,
  * an empty reply message will be sent.
  */
-void ddsi_tl_handle_request (struct ddsi_domaingv *gv, struct ddsi_serdata *sample_common);
+DDS_EXPORT void ddsi_tl_handle_request (struct ddsi_domaingv *gv, struct ddsi_serdata *sample_common);
+
+/**
+ * Add type information from a type lookup reply to the type library.
+ */
+DDS_EXPORT void ddsi_tl_add_types (struct ddsi_domaingv *gv, const DDS_Builtin_TypeLookup_Reply *reply, struct generic_proxy_endpoint ***gpe_match_upd, uint32_t *n_match_upd);
 
 /**
  * Handle an incoming type lookup reply message. The sertypes from this
  * reply are registered in the local type administation and referenced
  * from the corresponding proxy endpoints.
  */
-void ddsi_tl_handle_reply (struct ddsi_domaingv *gv, struct ddsi_serdata *sample_common);
+DDS_EXPORT void ddsi_tl_handle_reply (struct ddsi_domaingv *gv, struct ddsi_serdata *sample_common);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsi/include/dds/ddsi/ddsi_typewrap.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_typewrap.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright(c) 2022 ZettaScale Technology
  * Copyright(c) 2006 to 2019 ADLINK Technology Limited and others
  *
  * This program and the accompanying materials are made available under the
@@ -69,7 +70,7 @@ DDS_EXPORT dds_return_t ddsi_xt_type_add_typeobj (struct ddsi_domaingv *gv, stru
 DDS_EXPORT void ddsi_xt_get_typeobject (const struct xt_type *xt, ddsi_typeobj_t *to);
 DDS_EXPORT void ddsi_xt_type_fini (struct ddsi_domaingv *gv, struct xt_type *xt);
 DDS_EXPORT bool ddsi_xt_is_assignable_from (struct ddsi_domaingv *gv, const struct xt_type *rd_xt, const struct xt_type *wr_xt, const dds_type_consistency_enforcement_qospolicy_t *tce);
-
+DDS_EXPORT dds_return_t ddsi_xt_validate (struct ddsi_domaingv *gv, const struct xt_type *t);
 
 #else /* DDS_HAS_TYPE_DISCOVERY */
 

--- a/src/core/ddsi/include/dds/ddsi/ddsi_typewrap.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_typewrap.h
@@ -63,6 +63,7 @@ DDS_EXPORT void ddsi_typeid_get_equivalence_hash (const ddsi_typeid_t *type_id, 
 DDS_EXPORT bool ddsi_type_id_with_deps_equal (const struct DDS_XTypes_TypeIdentifierWithDependencies *a, const struct DDS_XTypes_TypeIdentifierWithDependencies *b);
 DDS_EXPORT ddsi_typeid_kind_t ddsi_typeid_kind (const ddsi_typeid_t *type);
 
+DDS_EXPORT dds_return_t ddsi_typeobj_get_hash_id (const struct DDS_XTypes_TypeObject *type_obj, ddsi_typeid_t *type_id);
 DDS_EXPORT void ddsi_typeobj_fini (ddsi_typeobj_t *typeobj);
 
 DDS_EXPORT dds_return_t ddsi_xt_type_init (struct ddsi_domaingv *gv, struct xt_type *xt, const ddsi_typeid_t *ti, const ddsi_typeobj_t *to);

--- a/src/core/ddsi/include/dds/ddsi/ddsi_typewrap.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_typewrap.h
@@ -71,6 +71,7 @@ DDS_EXPORT void ddsi_xt_get_typeobject (const struct xt_type *xt, ddsi_typeobj_t
 DDS_EXPORT void ddsi_xt_type_fini (struct ddsi_domaingv *gv, struct xt_type *xt);
 DDS_EXPORT bool ddsi_xt_is_assignable_from (struct ddsi_domaingv *gv, const struct xt_type *rd_xt, const struct xt_type *wr_xt, const dds_type_consistency_enforcement_qospolicy_t *tce);
 DDS_EXPORT dds_return_t ddsi_xt_validate (struct ddsi_domaingv *gv, const struct xt_type *t);
+DDS_EXPORT bool ddsi_xt_is_unresolved (const struct xt_type *t);
 
 #else /* DDS_HAS_TYPE_DISCOVERY */
 

--- a/src/core/ddsi/include/dds/ddsi/ddsi_typewrap.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_typewrap.h
@@ -69,7 +69,7 @@ DDS_EXPORT void ddsi_typeobj_fini (ddsi_typeobj_t *typeobj);
 DDS_EXPORT dds_return_t ddsi_xt_type_init (struct ddsi_domaingv *gv, struct xt_type *xt, const ddsi_typeid_t *ti, const ddsi_typeobj_t *to);
 DDS_EXPORT dds_return_t ddsi_xt_type_add_typeobj (struct ddsi_domaingv *gv, struct xt_type *xt, const struct DDS_XTypes_TypeObject *to);
 DDS_EXPORT void ddsi_xt_get_typeobject (const struct xt_type *xt, ddsi_typeobj_t *to);
-DDS_EXPORT void ddsi_xt_type_fini (struct ddsi_domaingv *gv, struct xt_type *xt);
+DDS_EXPORT void ddsi_xt_type_fini (struct ddsi_domaingv *gv, struct xt_type *xt, bool include_typeid);
 DDS_EXPORT bool ddsi_xt_is_assignable_from (struct ddsi_domaingv *gv, const struct xt_type *rd_xt, const struct xt_type *wr_xt, const dds_type_consistency_enforcement_qospolicy_t *tce);
 DDS_EXPORT dds_return_t ddsi_xt_validate (struct ddsi_domaingv *gv, const struct xt_type *t);
 DDS_EXPORT bool ddsi_xt_is_unresolved (const struct xt_type *t);

--- a/src/core/ddsi/include/dds/ddsi/ddsi_xt_impl.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_xt_impl.h
@@ -103,15 +103,11 @@ struct xt_map {
 
 struct xt_alias {
   struct ddsi_type *related_type;
+  DDS_XTypes_AliasTypeFlag flags;
   DDS_XTypes_AliasMemberFlag related_flags;
   struct xt_type_detail detail;
 };
 
-struct xt_annotation_member {
-  DDS_XTypes_MemberName name;
-  struct ddsi_type *member_type;
-  struct DDS_XTypes_AnnotationParameterValue default_value;
-};
 struct xt_annotation_parameter {
   struct ddsi_type *member_type;
   DDS_XTypes_AnnotationParameterFlag flags;
@@ -177,6 +173,7 @@ struct xt_bitfield_seq {
   struct xt_bitfield *seq;
 };
 struct xt_bitset {
+  DDS_XTypes_BitsetTypeFlag flags;
   struct xt_bitfield_seq fields;
   struct xt_type_detail detail;
 };
@@ -191,7 +188,7 @@ struct xt_enum_literal_seq {
   struct xt_enum_literal *seq;
 };
 struct xt_enum {
-  DDS_XTypes_EnumTypeFlag flags;  // spec says unused, but this flag is actually used for extensibility
+  DDS_XTypes_EnumTypeFlag flags;
   DDS_XTypes_BitBound bit_bound;
   struct xt_enum_literal_seq literals;
   struct xt_type_detail detail;
@@ -207,7 +204,7 @@ struct xt_bitflag_seq {
   struct xt_bitflag *seq;
 };
 struct xt_bitmask {
-  DDS_XTypes_BitmaskTypeFlag flags;  // spec says unused, but this flag is actually used for extensibility
+  DDS_XTypes_BitmaskTypeFlag flags;
   DDS_XTypes_BitBound bit_bound;
   struct xt_bitflag_seq bitflags;
   struct xt_type_detail detail;

--- a/src/core/ddsi/include/dds/ddsi/ddsi_xt_impl.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_xt_impl.h
@@ -268,8 +268,11 @@ struct xt_type
 DDSRT_STATIC_ASSERT (offsetof (struct xt_type, id) == 0);
 
 struct ddsi_type_dep {
-  struct ddsi_type *type;
-  struct ddsi_type_dep *prev;
+  ddsrt_avl_node_t src_avl_node;
+  ddsrt_avl_node_t dep_avl_node;
+  ddsi_typeid_t src_type_id;    // type that has the dependency on dep_type_id
+  ddsi_typeid_t dep_type_id;    // dependent type, a direct or indirect dependency of src_type_id
+  bool from_type_info;          // entry was added based on a dependent type in the type-info, requires unref of the dependent type on deletion
 };
 
 struct ddsi_type {
@@ -280,7 +283,6 @@ struct ddsi_type {
   seqno_t request_seqno;                        /* sequence number of the last type lookup request message */
   struct ddsi_type_proxy_guid_list proxy_guids; /* administration for proxy endpoints (not proxy topics) that are using this type */
   uint32_t refc;                                /* refcount for this record */
-  struct ddsi_type_dep *deps;                   /* dependent type records */
 };
 
 /* The xt_type member must be at offset 0 so that the type identifier field

--- a/src/core/ddsi/include/dds/ddsi/ddsi_xt_impl.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_xt_impl.h
@@ -215,8 +215,6 @@ struct xt_type
 {
   ddsi_typeid_t id;
   ddsi_typeid_kind_t kind;
-  unsigned is_plain_collection : 1;
-  unsigned has_obj : 1;
   struct DDS_XTypes_StronglyConnectedComponentId sc_component_id;
 
   uint8_t _d;

--- a/src/core/ddsi/include/dds/ddsi/ddsi_xt_impl.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_xt_impl.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright(c) 2022 ZettaScale Technology
  * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
  *
  * This program and the accompanying materials are made available under the
@@ -298,7 +299,7 @@ DDS_EXPORT ddsi_typeid_t * ddsi_typeid_dup_from_impl (const struct DDS_XTypes_Ty
 DDS_EXPORT bool ddsi_typeid_is_none_impl (const struct DDS_XTypes_TypeIdentifier *type_id);
 
 DDS_EXPORT void ddsi_xt_get_typeobject_impl (const struct xt_type *xt, struct DDS_XTypes_TypeObject *to);
-DDS_EXPORT struct ddsi_type * ddsi_type_ref_id_locked_impl (struct ddsi_domaingv *gv, const struct DDS_XTypes_TypeIdentifier *type_id);
+DDS_EXPORT dds_return_t ddsi_type_ref_id_locked_impl (struct ddsi_domaingv *gv, struct ddsi_type **type, const struct DDS_XTypes_TypeIdentifier *type_id);
 DDS_EXPORT struct ddsi_type * ddsi_type_lookup_locked_impl (struct ddsi_domaingv *gv, const struct DDS_XTypes_TypeIdentifier *type_id);
 
 DDS_EXPORT bool ddsi_typeid_is_hash_impl (const struct DDS_XTypes_TypeIdentifier *type_id);

--- a/src/core/ddsi/include/dds/ddsi/q_addrset.h
+++ b/src/core/ddsi/include/dds/ddsi/q_addrset.h
@@ -37,13 +37,13 @@ struct addrset {
 typedef void (*addrset_forall_fun_t) (const ddsi_xlocator_t *loc, void *arg);
 typedef ssize_t (*addrset_forone_fun_t) (const ddsi_xlocator_t *loc, void *arg);
 
-struct addrset *new_addrset (void);
-struct addrset *ref_addrset (struct addrset *as);
-void unref_addrset (struct addrset *as);
-void add_locator_to_addrset (const struct ddsi_domaingv *gv, struct addrset *as, const ddsi_locator_t *loc);
-void add_xlocator_to_addrset (const struct ddsi_domaingv *gv, struct addrset *as, const ddsi_xlocator_t *loc);
-void remove_from_addrset (const struct ddsi_domaingv *gv, struct addrset *as, const ddsi_xlocator_t *loc);
-int addrset_purge (struct addrset *as);
+DDS_EXPORT struct addrset *new_addrset (void);
+DDS_EXPORT struct addrset *ref_addrset (struct addrset *as);
+DDS_EXPORT void unref_addrset (struct addrset *as);
+DDS_EXPORT void add_locator_to_addrset (const struct ddsi_domaingv *gv, struct addrset *as, const ddsi_locator_t *loc);
+DDS_EXPORT void add_xlocator_to_addrset (const struct ddsi_domaingv *gv, struct addrset *as, const ddsi_xlocator_t *loc);
+DDS_EXPORT void remove_from_addrset (const struct ddsi_domaingv *gv, struct addrset *as, const ddsi_xlocator_t *loc);
+DDS_EXPORT int addrset_purge (struct addrset *as);
 int compare_locators (const ddsi_locator_t *a, const ddsi_locator_t *b);
 int compare_xlocators (const ddsi_xlocator_t *a, const ddsi_xlocator_t *b);
 

--- a/src/core/ddsi/include/dds/ddsi/q_entity.h
+++ b/src/core/ddsi/include/dds/ddsi/q_entity.h
@@ -797,7 +797,7 @@ int writer_set_notalive (struct writer *wr, bool notify);
 /* Set when this proxy participant is not to be announced on the built-in topics yet */
 #define CF_PROXYPP_NO_SPDP                     (1 << 2)
 
-bool new_proxy_participant (struct ddsi_domaingv *gv, const struct ddsi_guid *guid, uint32_t bes, const struct ddsi_guid *privileged_pp_guid, struct addrset *as_default, struct addrset *as_meta, const struct ddsi_plist *plist, dds_duration_t tlease_dur, nn_vendorid_t vendor, unsigned custom_flags, ddsrt_wctime_t timestamp, seqno_t seq);
+DDS_EXPORT bool new_proxy_participant (struct ddsi_domaingv *gv, const struct ddsi_guid *guid, uint32_t bes, const struct ddsi_guid *privileged_pp_guid, struct addrset *as_default, struct addrset *as_meta, const struct ddsi_plist *plist, dds_duration_t tlease_dur, nn_vendorid_t vendor, unsigned custom_flags, ddsrt_wctime_t timestamp, seqno_t seq);
 DDS_EXPORT int delete_proxy_participant_by_guid (struct ddsi_domaingv *gv, const struct ddsi_guid *guid, ddsrt_wctime_t timestamp, int isimplicit);
 
 int update_proxy_participant_plist_locked (struct proxy_participant *proxypp, seqno_t seq, const struct ddsi_plist *datap, ddsrt_wctime_t timestamp);
@@ -822,8 +822,8 @@ int delete_proxy_topic_locked (struct proxy_participant *proxypp, struct proxy_t
 
 /* To create a new proxy writer or reader; the proxy participant is
    determined from the GUID and must exist. */
-int new_proxy_writer (struct ddsi_domaingv *gv, const struct ddsi_guid *ppguid, const struct ddsi_guid *guid, struct addrset *as, const struct ddsi_plist *plist, struct nn_dqueue *dqueue, struct xeventq *evq, ddsrt_wctime_t timestamp, seqno_t seq);
-int new_proxy_reader (struct ddsi_domaingv *gv, const struct ddsi_guid *ppguid, const struct ddsi_guid *guid, struct addrset *as, const struct ddsi_plist *plist, ddsrt_wctime_t timestamp, seqno_t seq
+DDS_EXPORT int new_proxy_writer (struct ddsi_domaingv *gv, const struct ddsi_guid *ppguid, const struct ddsi_guid *guid, struct addrset *as, const struct ddsi_plist *plist, struct nn_dqueue *dqueue, struct xeventq *evq, ddsrt_wctime_t timestamp, seqno_t seq);
+DDS_EXPORT int new_proxy_reader (struct ddsi_domaingv *gv, const struct ddsi_guid *ppguid, const struct ddsi_guid *guid, struct addrset *as, const struct ddsi_plist *plist, ddsrt_wctime_t timestamp, seqno_t seq
 #ifdef DDS_HAS_SSM
                       , int favours_ssm
 #endif
@@ -834,11 +834,11 @@ int new_proxy_reader (struct ddsi_domaingv *gv, const struct ddsi_guid *ppguid, 
    reader or writer. Actual deletion is scheduled in the future, when
    no outstanding references may still exist (determined by checking
    thread progress, &c.). */
-int delete_proxy_writer (struct ddsi_domaingv *gv, const struct ddsi_guid *guid, ddsrt_wctime_t timestamp, int isimplicit);
-int delete_proxy_reader (struct ddsi_domaingv *gv, const struct ddsi_guid *guid, ddsrt_wctime_t timestamp, int isimplicit);
+DDS_EXPORT int delete_proxy_writer (struct ddsi_domaingv *gv, const struct ddsi_guid *guid, ddsrt_wctime_t timestamp, int isimplicit);
+DDS_EXPORT int delete_proxy_reader (struct ddsi_domaingv *gv, const struct ddsi_guid *guid, ddsrt_wctime_t timestamp, int isimplicit);
 
-void update_proxy_reader (struct proxy_reader *prd, seqno_t seq, struct addrset *as, const struct dds_qos *xqos, ddsrt_wctime_t timestamp);
-void update_proxy_writer (struct proxy_writer *pwr, seqno_t seq, struct addrset *as, const struct dds_qos *xqos, ddsrt_wctime_t timestamp);
+DDS_EXPORT void update_proxy_reader (struct proxy_reader *prd, seqno_t seq, struct addrset *as, const struct dds_qos *xqos, ddsrt_wctime_t timestamp);
+DDS_EXPORT void update_proxy_writer (struct proxy_writer *pwr, seqno_t seq, struct addrset *as, const struct dds_qos *xqos, ddsrt_wctime_t timestamp);
 
 void proxy_writer_set_alive_may_unlock (struct proxy_writer *pwr, bool notify);
 int proxy_writer_set_notalive (struct proxy_writer *pwr, bool notify);

--- a/src/core/ddsi/include/dds/ddsi/q_entity.h
+++ b/src/core/ddsi/include/dds/ddsi/q_entity.h
@@ -857,7 +857,7 @@ void local_reader_ary_setfastpath_ok (struct local_reader_ary *x, bool fastpath_
 void connect_writer_with_proxy_reader_secure(struct writer *wr, struct proxy_reader *prd, ddsrt_mtime_t tnow, int64_t crypto_handle);
 void connect_reader_with_proxy_writer_secure(struct reader *rd, struct proxy_writer *pwr, ddsrt_mtime_t tnow, int64_t crypto_handle);
 
-void update_proxy_endpoint_matching (const struct ddsi_domaingv *gv, struct generic_proxy_endpoint *proxy_ep);
+DDS_EXPORT void update_proxy_endpoint_matching (const struct ddsi_domaingv *gv, struct generic_proxy_endpoint *proxy_ep);
 
 struct ddsi_writer_info;
 DDS_EXPORT void ddsi_make_writer_info(struct ddsi_writer_info *wrinfo, const struct entity_common *e, const struct dds_qos *xqos, uint32_t statusinfo);

--- a/src/core/ddsi/include/dds/ddsi/q_entity.h
+++ b/src/core/ddsi/include/dds/ddsi/q_entity.h
@@ -814,7 +814,7 @@ dds_return_t delete_topic (struct ddsi_domaingv *gv, const struct ddsi_guid *gui
 int topic_definition_equal (const struct ddsi_topic_definition *tpd_a, const struct ddsi_topic_definition *tpd_b);
 uint32_t topic_definition_hash (const struct ddsi_topic_definition *tpd);
 dds_return_t lookup_topic_definition_by_name (struct ddsi_domaingv *gv, const char * topic_name, struct ddsi_topic_definition **tpd);
-void new_proxy_topic (struct proxy_participant *proxypp, seqno_t seq, const ddsi_guid_t *guid, const ddsi_typeid_t *type_id_minimal, const ddsi_typeid_t *type_id, struct dds_qos *qos, ddsrt_wctime_t timestamp);
+dds_return_t ddsi_new_proxy_topic (struct proxy_participant *proxypp, seqno_t seq, const ddsi_guid_t *guid, const ddsi_typeid_t *type_id_minimal, const ddsi_typeid_t *type_id, struct dds_qos *qos, ddsrt_wctime_t timestamp);
 struct proxy_topic *lookup_proxy_topic (struct proxy_participant *proxypp, const ddsi_guid_t *guid);
 void update_proxy_topic (struct proxy_participant *proxypp, struct proxy_topic *proxytp, seqno_t seq, struct dds_qos *xqos, ddsrt_wctime_t timestamp);
 int delete_proxy_topic_locked (struct proxy_participant *proxypp, struct proxy_topic *proxytp, ddsrt_wctime_t timestamp);

--- a/src/core/ddsi/src/ddsi_plist.c
+++ b/src/core/ddsi/src/ddsi_plist.c
@@ -730,7 +730,7 @@ static dds_return_t ser_type_information (struct nn_xmsg *xmsg, nn_parameterid_t
 static dds_return_t valid_type_information (const void *src, size_t srcoff)
 {
   ddsi_typeinfo_t const * const * x = deser_generic_src (src, &srcoff, alignof (ddsi_typeinfo_t *));
-  return *x != NULL && ddsi_typeinfo_valid (*x);
+  return (*x != NULL && ddsi_typeinfo_valid (*x)) ? DDS_RETCODE_OK : DDS_RETCODE_BAD_PARAMETER;
 }
 
 static bool equal_type_information (const void *srcx, const void *srcy, size_t srcoff)

--- a/src/core/ddsi/src/ddsi_typelib.c
+++ b/src/core/ddsi/src/ddsi_typelib.c
@@ -361,6 +361,10 @@ static dds_return_t ddsi_type_new (struct ddsi_domaingv *gv, struct ddsi_type **
     *type = NULL;
     return ret;
   }
+  if (!ddsi_typeid_is_hash (&(*type)->xt.id))
+    (*type)->state = DDSI_TYPE_RESOLVED;
+  /* inserted with refc 0 (set by calloc), refc is increased in
+     ddsi_type_ref_* functions */
   ddsrt_avl_insert (&ddsi_typelib_treedef, &gv->typelib, *type);
   return DDS_RETCODE_OK;
 }
@@ -480,7 +484,7 @@ static dds_return_t type_add_deps (struct ddsi_domaingv *gv, struct ddsi_type *t
   return ret;
 }
 
-dds_return_t ddsi_type_ref_locked (struct ddsi_domaingv *gv, struct ddsi_type **type, const struct ddsi_type *src)
+void ddsi_type_ref_locked (struct ddsi_domaingv *gv, struct ddsi_type **type, const struct ddsi_type *src)
 {
   assert (src);
   struct ddsi_type *t = (struct ddsi_type *) src;
@@ -488,7 +492,6 @@ dds_return_t ddsi_type_ref_locked (struct ddsi_domaingv *gv, struct ddsi_type **
   GVTRACE ("ref ddsi_type %p refc %"PRIu32"\n", t, t->refc);
   if (type)
     *type = t;
-  return DDS_RETCODE_OK;
 }
 
 dds_return_t ddsi_type_ref_id_locked_impl (struct ddsi_domaingv *gv, struct ddsi_type **type, const struct DDS_XTypes_TypeIdentifier *type_id)

--- a/src/core/ddsi/src/ddsi_typelib.c
+++ b/src/core/ddsi/src/ddsi_typelib.c
@@ -325,6 +325,14 @@ struct ddsi_type * ddsi_type_lookup_locked (struct ddsi_domaingv *gv, const ddsi
   return ddsi_type_lookup_locked_impl (gv, &type_id->x);
 }
 
+struct ddsi_type * ddsi_type_lookup (struct ddsi_domaingv *gv, const ddsi_typeid_t *type_id)
+{
+  ddsrt_mutex_lock (&gv->typelib_lock);
+  struct ddsi_type *type = ddsi_type_lookup_locked_impl (gv, &type_id->x);
+  ddsrt_mutex_unlock (&gv->typelib_lock);
+  return type;
+}
+
 static dds_return_t ddsi_type_new (struct ddsi_domaingv *gv, struct ddsi_type **type, const struct DDS_XTypes_TypeIdentifier *type_id, const struct DDS_XTypes_TypeObject *type_obj)
 {
   dds_return_t ret;

--- a/src/core/ddsi/src/ddsi_typelib.c
+++ b/src/core/ddsi/src/ddsi_typelib.c
@@ -140,7 +140,7 @@ const ddsi_typeid_t *ddsi_typeinfo_complete_typeid (const ddsi_typeinfo_t *typei
   return (const ddsi_typeid_t *) &typeinfo->x.complete.typeid_with_size.type_id;
 }
 
-static bool typeinfo_dependent_typeids_valid (const struct DDS_XTypes_TypeIdentifierWithDependencies *t)
+static bool typeinfo_dependent_typeids_valid (const struct DDS_XTypes_TypeIdentifierWithDependencies *t, ddsi_typeid_kind_t kind)
 {
   if (t->dependent_typeid_count == -1)
   {
@@ -155,8 +155,9 @@ static bool typeinfo_dependent_typeids_valid (const struct DDS_XTypes_TypeIdenti
       return false;
     for (uint32_t n = 0; n < t->dependent_typeids._length; n++)
     {
-      if (!ddsi_typeid_is_minimal_impl (&t->dependent_typeids._buffer[n].type_id) ||
-          t->dependent_typeids._buffer[n].typeobject_serialized_size == 0)
+      if ((kind == DDSI_TYPEID_KIND_MINIMAL && !ddsi_typeid_is_minimal_impl (&t->dependent_typeids._buffer[n].type_id))
+          || (kind == DDSI_TYPEID_KIND_COMPLETE && !ddsi_typeid_is_complete_impl (&t->dependent_typeids._buffer[n].type_id))
+          || t->dependent_typeids._buffer[n].typeobject_serialized_size == 0)
         return false;
     }
   }
@@ -170,8 +171,8 @@ bool ddsi_typeinfo_valid (const ddsi_typeinfo_t *typeinfo)
   if (ddsi_typeid_is_none (tid_min) || !ddsi_typeid_is_hash (tid_min) ||
       ddsi_typeid_is_none (tid_compl) || !ddsi_typeid_is_hash (tid_compl))
     return false;
-  if (!typeinfo_dependent_typeids_valid (&typeinfo->x.minimal) ||
-      !typeinfo_dependent_typeids_valid (&typeinfo->x.complete))
+  if (!typeinfo_dependent_typeids_valid (&typeinfo->x.minimal, DDSI_TYPEID_KIND_MINIMAL) ||
+      !typeinfo_dependent_typeids_valid (&typeinfo->x.complete, DDSI_TYPEID_KIND_COMPLETE))
     return false;
   return true;
 }

--- a/src/core/ddsi/src/ddsi_typelib.c
+++ b/src/core/ddsi/src/ddsi_typelib.c
@@ -833,14 +833,14 @@ bool ddsi_type_resolved (struct ddsi_domaingv *gv, const struct ddsi_type *type,
   return resolved;
 }
 
-bool ddsi_is_assignable_from (struct ddsi_domaingv *gv, const struct ddsi_type_pair *rd_type_pair, const struct ddsi_type_pair *wr_type_pair, const dds_type_consistency_enforcement_qospolicy_t *tce)
+bool ddsi_is_assignable_from (struct ddsi_domaingv *gv, const struct ddsi_type_pair *rd_type_pair, uint32_t rd_resolved, const struct ddsi_type_pair *wr_type_pair, uint32_t wr_resolved, const dds_type_consistency_enforcement_qospolicy_t *tce)
 {
   if (!rd_type_pair || !wr_type_pair)
     return false;
   ddsrt_mutex_lock (&gv->typelib_lock);
   const struct xt_type
-    *rd_xt = rd_type_pair->minimal ? &rd_type_pair->minimal->xt : &rd_type_pair->complete->xt,
-    *wr_xt = wr_type_pair->minimal ? &wr_type_pair->minimal->xt : &wr_type_pair->complete->xt;
+    *rd_xt = (rd_resolved == DDS_XTypes_EK_BOTH || rd_resolved == DDS_XTypes_EK_MINIMAL) ? &rd_type_pair->minimal->xt : &rd_type_pair->complete->xt,
+    *wr_xt = (wr_resolved == DDS_XTypes_EK_BOTH || wr_resolved == DDS_XTypes_EK_MINIMAL) ? &wr_type_pair->minimal->xt : &wr_type_pair->complete->xt;
   bool assignable = ddsi_xt_is_assignable_from (gv, rd_xt, wr_xt, tce);
   ddsrt_mutex_unlock (&gv->typelib_lock);
   return assignable;

--- a/src/core/ddsi/src/ddsi_typelib.c
+++ b/src/core/ddsi/src/ddsi_typelib.c
@@ -348,7 +348,7 @@ static dds_return_t ddsi_type_new (struct ddsi_domaingv *gv, struct ddsi_type **
   GVTRACE (" new %p", *type);
   if ((ret = ddsi_xt_type_init_impl (gv, &(*type)->xt, type_id, type_obj)) != DDS_RETCODE_OK)
   {
-    ddsrt_free (*type);
+    ddsi_type_fini (gv, *type);
     *type = NULL;
     return ret;
   }
@@ -510,6 +510,17 @@ dds_return_t ddsi_type_ref_id_locked (struct ddsi_domaingv *gv, struct ddsi_type
   return ddsi_type_ref_id_locked_impl (gv, type, &type_id->x);
 }
 
+static bool valid_top_level_type (const struct ddsi_type *type)
+{
+  if (type->state == DDSI_TYPE_INVALID)
+    return false;
+  if (type->xt.kind != DDSI_TYPEID_KIND_COMPLETE && type->xt.kind != DDSI_TYPEID_KIND_MINIMAL)
+    return false;
+  if (!ddsi_xt_is_unresolved (&type->xt) && type->xt._d != DDS_XTypes_TK_STRUCTURE && type->xt._d != DDS_XTypes_TK_UNION)
+    return false;
+  return true;
+}
+
 dds_return_t ddsi_type_ref_local (struct ddsi_domaingv *gv, struct ddsi_type **type, const struct ddsi_sertype *sertype, ddsi_typeid_kind_t kind)
 {
   struct generic_proxy_endpoint **gpe_match_upd = NULL;
@@ -526,6 +537,7 @@ dds_return_t ddsi_type_ref_local (struct ddsi_domaingv *gv, struct ddsi_type **t
       *type = NULL;
     return DDS_RETCODE_OK;
   }
+
   ddsi_typemap_t *type_map = ddsi_sertype_typemap (sertype);
   const struct DDS_XTypes_TypeIdentifier *type_id = (kind == DDSI_TYPEID_KIND_MINIMAL) ? &type_info->x.minimal.typeid_with_size.type_id : &type_info->x.complete.typeid_with_size.type_id;
   const struct DDS_XTypes_TypeObject *type_obj = ddsi_typemap_typeobj (type_map, type_id);
@@ -533,7 +545,6 @@ dds_return_t ddsi_type_ref_local (struct ddsi_domaingv *gv, struct ddsi_type **t
   GVTRACE ("ref ddsi_type local sertype %p id %s", sertype, ddsi_make_typeid_str_impl (&tistr, type_id));
 
   ddsrt_mutex_lock (&gv->typelib_lock);
-
   struct ddsi_type *t = ddsi_type_lookup_locked_impl (gv, type_id);
   if (!t)
     ret = ddsi_type_new (gv, &t, type_id, type_obj);
@@ -548,9 +559,12 @@ dds_return_t ddsi_type_ref_local (struct ddsi_domaingv *gv, struct ddsi_type **t
   t->refc++;
   GVTRACE (" refc %"PRIu32"\n", t->refc);
 
-  if ((ret = type_add_deps (gv, t, type_info, type_map, kind, &n_match_upd, &gpe_match_upd))
+  if ((ret = valid_top_level_type (t) ? DDS_RETCODE_OK : DDS_RETCODE_BAD_PARAMETER)
+      || (ret = type_add_deps (gv, t, type_info, type_map, kind, &n_match_upd, &gpe_match_upd))
       || (ret = ddsi_xt_validate (gv, &t->xt)))
   {
+    GVWARNING ("local sertype with invalid top-level type %s\n", ddsi_make_typeid_str (&tistr, &t->xt.id));
+    ddsi_type_unref_locked (gv, t);
     ddsrt_mutex_unlock (&gv->typelib_lock);
     goto err;
   }
@@ -599,10 +613,20 @@ dds_return_t ddsi_type_ref_proxy (struct ddsi_domaingv *gv, struct ddsi_type **t
     goto err;
   t->refc++;
   GVTRACE(" refc %"PRIu32"\n", t->refc);
+  if (!valid_top_level_type (t))
+  {
+    ret = DDS_RETCODE_BAD_PARAMETER;
+    ddsi_type_unref_locked (gv, t);
+    GVTRACE (" invalid top-level type\n");
+    goto err;
+  }
 
   if ((ret = type_add_deps (gv, t, type_info, NULL, kind, NULL, NULL))
       || (ret = ddsi_xt_validate (gv, &t->xt)))
+  {
+    ddsi_type_unref_locked (gv, t);
     goto err;
+  }
 
   if (proxy_guid != NULL && !ddsi_type_proxy_guid_exists (t, proxy_guid))
   {

--- a/src/core/ddsi/src/ddsi_typelib.c
+++ b/src/core/ddsi/src/ddsi_typelib.c
@@ -223,7 +223,7 @@ ddsi_typemap_t *ddsi_typemap_deser (const struct ddsi_sertype_cdr_data *ser)
   return typemap;
 }
 
-static void ddsi_typemap_fini (ddsi_typemap_t *typemap)
+void ddsi_typemap_fini (ddsi_typemap_t *typemap)
 {
   dds_stream_free_sample (typemap, DDS_XTypes_TypeMapping_desc.m_ops);
 }

--- a/src/core/ddsi/src/ddsi_typelib.c
+++ b/src/core/ddsi/src/ddsi_typelib.c
@@ -283,7 +283,7 @@ static void ddsi_type_fini (struct ddsi_domaingv *gv, struct ddsi_type *type)
   struct ddsi_type_dep key;
   memset (&key, 0, sizeof (key));
   ddsi_typeid_copy (&key.src_type_id, &type->xt.id);
-  ddsi_xt_type_fini (gv, &type->xt);
+  ddsi_xt_type_fini (gv, &type->xt, true);
   if (type->sertype)
     ddsi_sertype_unref ((struct ddsi_sertype *) type->sertype);
 

--- a/src/core/ddsi/src/ddsi_typelib.c
+++ b/src/core/ddsi/src/ddsi_typelib.c
@@ -391,13 +391,10 @@ dds_return_t ddsi_type_add_typeobj (struct ddsi_domaingv *gv, struct ddsi_type *
       }
       else
       {
-        /* In case the object does not match the type id, only mark the current
-           type invalid. Types depending on this type may still be valid once
-           this type is resolved with a valid type object. */
-        type->state = DDSI_TYPE_INVALID;
-
-        /* FIXME: retry in case the type object does not match the type id? Could be a (malicious)
-           node that (intentionally) sends the wrong type object for this type-id */
+        /* In case the object does not match the type id, reset the type's state to
+           unresolved so that it can de resolved in case the correct type object
+           is received */
+        type->state = DDSI_TYPE_UNRESOLVED;
       }
     }
     else

--- a/src/core/ddsi/src/ddsi_typelookup.c
+++ b/src/core/ddsi/src/ddsi_typelookup.c
@@ -316,8 +316,8 @@ void ddsi_tl_handle_reply (struct ddsi_domaingv *gv, struct ddsi_serdata *d)
       if (ddsi_typeid_is_minimal_impl (&r.type_identifier))
       {
         GVTRACE (" resolved minimal type %s\n", ddsi_make_typeid_str_impl (&str, &r.type_identifier));
-        if (ddsi_type_get_gpe_matches (gv, type, &gpe_match_upd, &n_match_upd))
-          resolved = true;
+        ddsi_type_get_gpe_matches (gv, type, &gpe_match_upd, &n_match_upd);
+        resolved = true;
       }
       else
       {
@@ -337,9 +337,14 @@ void ddsi_tl_handle_reply (struct ddsi_domaingv *gv, struct ddsi_serdata *d)
         // ddsrt_mutex_unlock (&gv->sertypes_lock);
         // type->sertype = &st->c; // refcounted by sertype_register/lookup
 
-        if (ddsi_type_get_gpe_matches (gv, type, &gpe_match_upd, &n_match_upd))
-          resolved = true;
+        ddsi_type_get_gpe_matches (gv, type, &gpe_match_upd, &n_match_upd);
+        resolved = true;
       }
+    }
+    else
+    {
+      type->state = DDSI_TYPE_INVALID;
+
     }
   }
   if (resolved)

--- a/src/core/ddsi/src/ddsi_typelookup.c
+++ b/src/core/ddsi/src/ddsi_typelookup.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright(c) 2022 ZettaScale Technology
  * Copyright(c) 2006 to 2019 ADLINK Technology Limited and others
  *
  * This program and the accompanying materials are made available under the
@@ -256,7 +257,7 @@ void ddsi_tl_handle_reply (struct ddsi_domaingv *gv, struct ddsi_serdata *d)
       continue;
     }
 
-    if (ddsi_xt_type_add_typeobj (gv, &type->xt, &r.type_object) == 0)
+    if (ddsi_xt_type_add_typeobj (gv, &type->xt, &r.type_object) == DDS_RETCODE_OK)
     {
       type->state = DDSI_TYPE_RESOLVED;
       if (ddsi_typeid_is_minimal_impl (&r.type_identifier))

--- a/src/core/ddsi/src/ddsi_typelookup.c
+++ b/src/core/ddsi/src/ddsi_typelookup.c
@@ -262,13 +262,13 @@ void ddsi_tl_handle_reply (struct ddsi_domaingv *gv, struct ddsi_serdata *d)
       type->state = DDSI_TYPE_RESOLVED;
       if (ddsi_typeid_is_minimal_impl (&r.type_identifier))
       {
-        GVTRACE (" resolved minimal type %p\n", type);
+        GVTRACE (" resolved minimal type %s\n", ddsi_make_typeid_str_impl (&str, &r.type_identifier));
         if (ddsi_type_get_gpe_matches (gv, type, &gpe_match_upd, &n_match_upd))
           resolved = true;
       }
       else
       {
-        GVTRACE (" resolved complete type %p\n", type);
+        GVTRACE (" resolved complete type %s\n", ddsi_make_typeid_str_impl (&str, &r.type_identifier));
 
         // FIXME: create sertype from received (complete) type object, check if it exists and register if not
         // bool sertype_new = false;

--- a/src/core/ddsi/src/ddsi_typewrap.c
+++ b/src/core/ddsi/src/ddsi_typewrap.c
@@ -463,6 +463,7 @@ static dds_return_t add_minimal_typeobj (struct ddsi_domaingv *gv, struct xt_typ
   switch (mto->_d)
   {
     case DDS_XTypes_TK_ALIAS:
+      xt->_u.alias.flags = mto->_u.alias_type.alias_flags;
       xt->_u.alias.related_type = ddsi_type_ref_id_locked_impl (gv, &mto->_u.alias_type.body.common.related_type);
       xt->_u.alias.related_flags = mto->_u.alias_type.body.common.related_flags;
       break;
@@ -505,6 +506,7 @@ static dds_return_t add_minimal_typeobj (struct ddsi_domaingv *gv, struct xt_typ
       }
       break;
     case DDS_XTypes_TK_BITSET:
+      xt->_u.bitset.flags = mto->_u.bitset_type.bitset_flags;
       xt->_u.bitset.fields.length = mto->_u.bitset_type.field_seq._length;
       xt->_u.bitset.fields.seq = ddsrt_calloc (xt->_u.bitset.fields.length, sizeof (*xt->_u.bitset.fields.seq));
       for (uint32_t n = 0; n < xt->_u.bitset.fields.length; n++)
@@ -513,21 +515,25 @@ static dds_return_t add_minimal_typeobj (struct ddsi_domaingv *gv, struct xt_typ
         xt->_u.bitset.fields.seq[n].flags = mto->_u.bitset_type.field_seq._buffer[n].common.flags;
         xt->_u.bitset.fields.seq[n].bitcount = mto->_u.bitset_type.field_seq._buffer[n].common.bitcount;
         xt->_u.bitset.fields.seq[n].holder_type = mto->_u.bitset_type.field_seq._buffer[n].common.holder_type;
+        xt->_u.bitset.fields.seq[n].flags = mto->_u.bitset_type.field_seq._buffer[n].common.flags;
         memcpy (xt->_u.bitset.fields.seq[n].detail.name_hash, mto->_u.bitset_type.field_seq._buffer[n].name_hash,
           sizeof (xt->_u.bitset.fields.seq[n].detail.name_hash));
       }
       break;
     case DDS_XTypes_TK_SEQUENCE:
+      xt->_u.seq.c.flags = mto->_u.sequence_type.collection_flag;
       xt->_u.seq.c.element_type = ddsi_type_ref_id_locked_impl (gv, &mto->_u.sequence_type.element.common.type);
       xt->_u.seq.c.element_flags = mto->_u.sequence_type.element.common.element_flags;
       xt->_u.seq.bound = mto->_u.sequence_type.header.common.bound;
       break;
     case DDS_XTypes_TK_ARRAY:
+      xt->_u.array.c.flags = mto->_u.array_type.collection_flag;
       xt->_u.array.c.element_type = ddsi_type_ref_id_locked_impl (gv, &mto->_u.array_type.element.common.type);
       xt->_u.array.c.element_flags = mto->_u.array_type.element.common.element_flags;
       xt_lbounds_dup (&xt->_u.array.bounds, &mto->_u.array_type.header.common.bound_seq);
       break;
     case DDS_XTypes_TK_MAP:
+      xt->_u.map.c.flags = mto->_u.map_type.collection_flag;
       xt->_u.map.c.element_type = ddsi_type_ref_id_locked_impl (gv, &mto->_u.map_type.element.common.type);
       xt->_u.map.c.element_flags = mto->_u.map_type.element.common.element_flags;
       xt->_u.map.key_type = ddsi_type_ref_id_locked_impl (gv, &mto->_u.map_type.key.common.type);
@@ -586,6 +592,7 @@ static dds_return_t add_complete_typeobj (struct ddsi_domaingv *gv, struct xt_ty
   switch (cto->_d)
   {
     case DDS_XTypes_TK_ALIAS:
+      xt->_u.alias.flags = cto->_u.alias_type.alias_flags;
       xt->_u.alias.related_type = ddsi_type_ref_id_locked_impl (gv, &cto->_u.alias_type.body.common.related_type);
       xt->_u.alias.related_flags = cto->_u.alias_type.body.common.related_flags;
       memcpy(&xt->_u.alias.detail.type_name, cto->_u.alias_type.header.detail.type_name, sizeof(xt->_u.alias.detail.type_name));
@@ -630,6 +637,7 @@ static dds_return_t add_complete_typeobj (struct ddsi_domaingv *gv, struct xt_ty
       break;
     case DDS_XTypes_TK_BITSET:
       memcpy(&xt->_u.bitset.detail.type_name, cto->_u.bitset_type.header.detail.type_name, sizeof(xt->_u.bitset.detail.type_name));
+      xt->_u.bitset.flags = cto->_u.bitset_type.bitset_flags;
       xt->_u.bitset.fields.length = cto->_u.bitset_type.field_seq._length;
       xt->_u.bitset.fields.seq = ddsrt_calloc (xt->_u.bitset.fields.length, sizeof (*xt->_u.bitset.fields.seq));
       for (uint32_t n = 0; n < xt->_u.bitset.fields.length; n++)
@@ -638,20 +646,24 @@ static dds_return_t add_complete_typeobj (struct ddsi_domaingv *gv, struct xt_ty
         xt->_u.bitset.fields.seq[n].flags = cto->_u.bitset_type.field_seq._buffer[n].common.flags;
         xt->_u.bitset.fields.seq[n].bitcount = cto->_u.bitset_type.field_seq._buffer[n].common.bitcount;
         xt->_u.bitset.fields.seq[n].holder_type = cto->_u.bitset_type.field_seq._buffer[n].common.holder_type;
+        xt->_u.bitset.fields.seq[n].flags = cto->_u.bitset_type.field_seq._buffer[n].common.flags;
         set_member_detail(&xt->_u.bitset.fields.seq[n].detail, &cto->_u.bitset_type.field_seq._buffer[n].detail);
       }
       break;
     case DDS_XTypes_TK_SEQUENCE:
+      xt->_u.seq.c.flags = cto->_u.sequence_type.collection_flag;
       xt->_u.seq.c.element_type = ddsi_type_ref_id_locked_impl (gv, &cto->_u.sequence_type.element.common.type);
       xt->_u.seq.c.element_flags = cto->_u.sequence_type.element.common.element_flags;
       xt->_u.seq.bound = cto->_u.sequence_type.header.common.bound;
       break;
     case DDS_XTypes_TK_ARRAY:
+      xt->_u.array.c.flags = cto->_u.array_type.collection_flag;
       xt->_u.array.c.element_type = ddsi_type_ref_id_locked_impl (gv, &cto->_u.array_type.element.common.type);
       xt->_u.array.c.element_flags = cto->_u.array_type.element.common.element_flags;
       xt_lbounds_dup (&xt->_u.array.bounds, &cto->_u.array_type.header.common.bound_seq);
       break;
     case DDS_XTypes_TK_MAP:
+      xt->_u.map.c.flags = cto->_u.map_type.collection_flag;
       xt->_u.map.c.element_type = ddsi_type_ref_id_locked_impl (gv, &cto->_u.map_type.element.common.type);
       xt->_u.map.c.element_flags = cto->_u.map_type.element.common.element_flags;
       xt->_u.map.key_type = ddsi_type_ref_id_locked_impl (gv, &cto->_u.map_type.key.common.type);
@@ -1240,6 +1252,7 @@ static struct xt_type * xt_dup (struct ddsi_domaingv *gv, const struct xt_type *
       xt_applied_member_annotations_copy (&dst->_u.map.key_annotations, &src->_u.map.key_annotations);
       break;
     case DDS_XTypes_TK_ALIAS:
+      dst->_u.alias.flags = src->_u.alias.flags;
       dst->_u.alias.related_type = ddsi_type_ref_locked (gv, src->_u.alias.related_type);
       dst->_u.alias.related_flags = src->_u.alias.related_flags;
       xt_type_detail_copy (&dst->_u.alias.detail, &src->_u.alias.detail);
@@ -1264,6 +1277,7 @@ static struct xt_type * xt_dup (struct ddsi_domaingv *gv, const struct xt_type *
       xt_type_detail_copy (&dst->_u.union_type.detail, &src->_u.union_type.detail);
       break;
     case DDS_XTypes_TK_BITSET:
+      dst->_u.bitset.flags = src->_u.bitset.flags;
       xt_bitfield_seq_copy (&dst->_u.bitset.fields, &src->_u.bitset.fields);
       xt_type_detail_copy (&dst->_u.bitset.detail, &src->_u.bitset.detail);
       break;
@@ -2158,6 +2172,7 @@ void ddsi_xt_get_typeobject_impl (const struct xt_type *xt, struct DDS_XTypes_Ty
       case DDS_XTypes_TK_ALIAS:
       {
         struct DDS_XTypes_CompleteAliasType *calias = &cto->_u.alias_type;
+        calias->alias_flags = xt->_u.alias.flags;
         get_type_detail (&calias->header.detail, &xt->_u.alias.detail);
         ddsi_typeid_copy_to_impl (&calias->body.common.related_type, &xt->_u.alias.related_type->xt.id);
         calias->body.common.related_flags = xt->_u.alias.related_flags;
@@ -2214,6 +2229,7 @@ void ddsi_xt_get_typeobject_impl (const struct xt_type *xt, struct DDS_XTypes_Ty
       case DDS_XTypes_TK_BITSET:
       {
         struct DDS_XTypes_CompleteBitsetType *cbitset = &cto->_u.bitset_type;
+        cbitset->bitset_flags = xt->_u.bitset.flags;
         get_type_detail (&cbitset->header.detail, &xt->_u.bitset.detail);
         cbitset->field_seq._length = xt->_u.bitset.fields.length;
         cbitset->field_seq._buffer = ddsrt_malloc (xt->_u.bitset.fields.length * sizeof (*cbitset->field_seq._buffer));

--- a/src/core/ddsi/src/ddsi_typewrap.c
+++ b/src/core/ddsi/src/ddsi_typewrap.c
@@ -827,7 +827,7 @@ static dds_return_t add_minimal_typeobj (struct ddsi_domaingv *gv, struct xt_typ
   {
     case DDS_XTypes_TK_ALIAS:
       xt->_u.alias.flags = mto->_u.alias_type.alias_flags;
-      ddsi_type_ref_id_locked_impl (gv, &xt->_u.alias.related_type, &mto->_u.alias_type.body.common.related_type);
+      ddsi_type_register_dep (gv, &xt->id, &xt->_u.alias.related_type, &mto->_u.alias_type.body.common.related_type);
       xt->_u.alias.related_flags = mto->_u.alias_type.body.common.related_flags;
       break;
     case DDS_XTypes_TK_ANNOTATION:
@@ -836,7 +836,7 @@ static dds_return_t add_minimal_typeobj (struct ddsi_domaingv *gv, struct xt_typ
     case DDS_XTypes_TK_STRUCTURE:
       xt->_u.structure.flags = mto->_u.struct_type.struct_flags;
       if (mto->_u.struct_type.header.base_type._d)
-        ddsi_type_ref_id_locked_impl (gv, &xt->_u.structure.base_type, &mto->_u.struct_type.header.base_type);
+        ddsi_type_register_dep (gv, &xt->id, &xt->_u.structure.base_type, &mto->_u.struct_type.header.base_type);
       else
         xt->_u.structure.base_type = NULL;
       xt->_u.structure.members.length = mto->_u.struct_type.member_seq._length;
@@ -845,14 +845,14 @@ static dds_return_t add_minimal_typeobj (struct ddsi_domaingv *gv, struct xt_typ
       {
         xt->_u.structure.members.seq[n].id = mto->_u.struct_type.member_seq._buffer[n].common.member_id;
         xt->_u.structure.members.seq[n].flags = mto->_u.struct_type.member_seq._buffer[n].common.member_flags;
-        ddsi_type_ref_id_locked_impl (gv, &xt->_u.structure.members.seq[n].type, &mto->_u.struct_type.member_seq._buffer[n].common.member_type_id);
+        ddsi_type_register_dep (gv, &xt->id, &xt->_u.structure.members.seq[n].type, &mto->_u.struct_type.member_seq._buffer[n].common.member_type_id);
         memcpy (xt->_u.structure.members.seq[n].detail.name_hash, mto->_u.struct_type.member_seq._buffer[n].detail.name_hash,
           sizeof (xt->_u.structure.members.seq[n].detail.name_hash));
       }
       break;
     case DDS_XTypes_TK_UNION:
       xt->_u.union_type.flags = mto->_u.union_type.union_flags;
-      ddsi_type_ref_id_locked_impl (gv, &xt->_u.union_type.disc_type, &mto->_u.union_type.discriminator.common.type_id);
+      ddsi_type_register_dep (gv, &xt->id, &xt->_u.union_type.disc_type, &mto->_u.union_type.discriminator.common.type_id);
       xt->_u.union_type.disc_flags = mto->_u.union_type.discriminator.common.member_flags;
       xt->_u.union_type.members.length = mto->_u.union_type.member_seq._length;
       xt->_u.union_type.members.seq = ddsrt_calloc (xt->_u.union_type.members.length, sizeof (*xt->_u.union_type.members.seq));
@@ -860,7 +860,7 @@ static dds_return_t add_minimal_typeobj (struct ddsi_domaingv *gv, struct xt_typ
       {
         xt->_u.union_type.members.seq[n].id = mto->_u.union_type.member_seq._buffer[n].common.member_id;
         xt->_u.union_type.members.seq[n].flags = mto->_u.union_type.member_seq._buffer[n].common.member_flags;
-        ddsi_type_ref_id_locked_impl (gv, &xt->_u.union_type.members.seq[n].type, &mto->_u.union_type.member_seq._buffer[n].common.type_id);
+        ddsi_type_register_dep (gv, &xt->id, &xt->_u.union_type.members.seq[n].type, &mto->_u.union_type.member_seq._buffer[n].common.type_id);
         xt->_u.union_type.members.seq[n].label_seq._length = mto->_u.union_type.member_seq._buffer[n].common.label_seq._length;
         xt->_u.union_type.members.seq[n].label_seq._buffer = ddsrt_memdup (mto->_u.union_type.member_seq._buffer[n].common.label_seq._buffer,
           mto->_u.union_type.member_seq._buffer[n].common.label_seq._length * sizeof (*mto->_u.union_type.member_seq._buffer[n].common.label_seq._buffer));
@@ -885,21 +885,21 @@ static dds_return_t add_minimal_typeobj (struct ddsi_domaingv *gv, struct xt_typ
       break;
     case DDS_XTypes_TK_SEQUENCE:
       xt->_u.seq.c.flags = mto->_u.sequence_type.collection_flag;
-      ddsi_type_ref_id_locked_impl (gv, &xt->_u.seq.c.element_type, &mto->_u.sequence_type.element.common.type);
+      ddsi_type_register_dep (gv, &xt->id, &xt->_u.seq.c.element_type, &mto->_u.sequence_type.element.common.type);
       xt->_u.seq.c.element_flags = mto->_u.sequence_type.element.common.element_flags;
       xt->_u.seq.bound = mto->_u.sequence_type.header.common.bound;
       break;
     case DDS_XTypes_TK_ARRAY:
       xt->_u.array.c.flags = mto->_u.array_type.collection_flag;
-      ddsi_type_ref_id_locked_impl (gv, &xt->_u.array.c.element_type, &mto->_u.array_type.element.common.type);
+      ddsi_type_register_dep (gv, &xt->id, &xt->_u.array.c.element_type, &mto->_u.array_type.element.common.type);
       xt->_u.array.c.element_flags = mto->_u.array_type.element.common.element_flags;
       xt_lbounds_dup (&xt->_u.array.bounds, &mto->_u.array_type.header.common.bound_seq);
       break;
     case DDS_XTypes_TK_MAP:
       xt->_u.map.c.flags = mto->_u.map_type.collection_flag;
-      ddsi_type_ref_id_locked_impl (gv, &xt->_u.map.c.element_type, &mto->_u.map_type.element.common.type);
+      ddsi_type_register_dep (gv, &xt->id, &xt->_u.map.c.element_type, &mto->_u.map_type.element.common.type);
       xt->_u.map.c.element_flags = mto->_u.map_type.element.common.element_flags;
-      ddsi_type_ref_id_locked_impl (gv, &xt->_u.map.key_type, &mto->_u.map_type.key.common.type);
+      ddsi_type_register_dep (gv, &xt->id, &xt->_u.map.key_type, &mto->_u.map_type.key.common.type);
       xt->_u.map.bound = mto->_u.map_type.header.common.bound;
       break;
     case DDS_XTypes_TK_ENUM:
@@ -957,7 +957,7 @@ static dds_return_t add_complete_typeobj (struct ddsi_domaingv *gv, struct xt_ty
   {
     case DDS_XTypes_TK_ALIAS:
       xt->_u.alias.flags = cto->_u.alias_type.alias_flags;
-      ddsi_type_ref_id_locked_impl (gv, &xt->_u.alias.related_type, &cto->_u.alias_type.body.common.related_type);
+      ddsi_type_register_dep (gv, &xt->id, &xt->_u.alias.related_type, &cto->_u.alias_type.body.common.related_type);
       xt->_u.alias.related_flags = cto->_u.alias_type.body.common.related_flags;
       memcpy(&xt->_u.alias.detail.type_name, cto->_u.alias_type.header.detail.type_name, sizeof(xt->_u.alias.detail.type_name));
       xt->_u.alias.flags = cto->_u.alias_type.alias_flags;
@@ -969,7 +969,7 @@ static dds_return_t add_complete_typeobj (struct ddsi_domaingv *gv, struct xt_ty
     case DDS_XTypes_TK_STRUCTURE:
       xt->_u.structure.flags = cto->_u.struct_type.struct_flags;
       if (cto->_u.struct_type.header.base_type._d)
-        ddsi_type_ref_id_locked_impl (gv, &xt->_u.structure.base_type, &cto->_u.struct_type.header.base_type);
+        ddsi_type_register_dep (gv, &xt->id, &xt->_u.structure.base_type, &cto->_u.struct_type.header.base_type);
       else
         xt->_u.structure.base_type = NULL;
       memcpy(&xt->_u.structure.detail.type_name, cto->_u.struct_type.header.detail.type_name, sizeof(xt->_u.structure.detail.type_name));
@@ -979,13 +979,13 @@ static dds_return_t add_complete_typeobj (struct ddsi_domaingv *gv, struct xt_ty
       {
         xt->_u.structure.members.seq[n].id = cto->_u.struct_type.member_seq._buffer[n].common.member_id;
         xt->_u.structure.members.seq[n].flags = cto->_u.struct_type.member_seq._buffer[n].common.member_flags;
-        ddsi_type_ref_id_locked_impl (gv, &xt->_u.structure.members.seq[n].type, &cto->_u.struct_type.member_seq._buffer[n].common.member_type_id);
+        ddsi_type_register_dep (gv, &xt->id, &xt->_u.structure.members.seq[n].type, &cto->_u.struct_type.member_seq._buffer[n].common.member_type_id);
         set_member_detail(&xt->_u.structure.members.seq[n].detail, &cto->_u.struct_type.member_seq._buffer[n].detail);
       }
       break;
     case DDS_XTypes_TK_UNION:
       xt->_u.union_type.flags = cto->_u.union_type.union_flags;
-      ddsi_type_ref_id_locked_impl (gv, &xt->_u.union_type.disc_type, &cto->_u.union_type.discriminator.common.type_id);
+      ddsi_type_register_dep (gv, &xt->id, &xt->_u.union_type.disc_type, &cto->_u.union_type.discriminator.common.type_id);
       xt->_u.union_type.disc_flags = cto->_u.union_type.discriminator.common.member_flags;
       memcpy(&xt->_u.union_type.detail.type_name, cto->_u.union_type.header.detail.type_name, sizeof(xt->_u.union_type.detail.type_name));
       xt->_u.union_type.members.length = cto->_u.union_type.member_seq._length;
@@ -994,7 +994,7 @@ static dds_return_t add_complete_typeobj (struct ddsi_domaingv *gv, struct xt_ty
       {
         xt->_u.union_type.members.seq[n].id = cto->_u.union_type.member_seq._buffer[n].common.member_id;
         xt->_u.union_type.members.seq[n].flags = cto->_u.union_type.member_seq._buffer[n].common.member_flags;
-        ddsi_type_ref_id_locked_impl (gv, &xt->_u.union_type.members.seq[n].type, &cto->_u.union_type.member_seq._buffer[n].common.type_id);
+        ddsi_type_register_dep (gv, &xt->id, &xt->_u.union_type.members.seq[n].type, &cto->_u.union_type.member_seq._buffer[n].common.type_id);
         xt->_u.union_type.members.seq[n].label_seq._length = cto->_u.union_type.member_seq._buffer[n].common.label_seq._length;
         xt->_u.union_type.members.seq[n].label_seq._buffer = ddsrt_memdup (cto->_u.union_type.member_seq._buffer[n].common.label_seq._buffer,
           cto->_u.union_type.member_seq._buffer[n].common.label_seq._length * sizeof (*cto->_u.union_type.member_seq._buffer[n].common.label_seq._buffer));
@@ -1018,21 +1018,21 @@ static dds_return_t add_complete_typeobj (struct ddsi_domaingv *gv, struct xt_ty
       break;
     case DDS_XTypes_TK_SEQUENCE:
       xt->_u.seq.c.flags = cto->_u.sequence_type.collection_flag;
-      ddsi_type_ref_id_locked_impl (gv, &xt->_u.seq.c.element_type, &cto->_u.sequence_type.element.common.type);
+      ddsi_type_register_dep (gv, &xt->id, &xt->_u.seq.c.element_type, &cto->_u.sequence_type.element.common.type);
       xt->_u.seq.c.element_flags = cto->_u.sequence_type.element.common.element_flags;
       xt->_u.seq.bound = cto->_u.sequence_type.header.common.bound;
       break;
     case DDS_XTypes_TK_ARRAY:
       xt->_u.array.c.flags = cto->_u.array_type.collection_flag;
-      ddsi_type_ref_id_locked_impl (gv, &xt->_u.array.c.element_type, &cto->_u.array_type.element.common.type);
+      ddsi_type_register_dep (gv, &xt->id, &xt->_u.array.c.element_type, &cto->_u.array_type.element.common.type);
       xt->_u.array.c.element_flags = cto->_u.array_type.element.common.element_flags;
       xt_lbounds_dup (&xt->_u.array.bounds, &cto->_u.array_type.header.common.bound_seq);
       break;
     case DDS_XTypes_TK_MAP:
       xt->_u.map.c.flags = cto->_u.map_type.collection_flag;
-      ddsi_type_ref_id_locked_impl (gv, &xt->_u.map.c.element_type, &cto->_u.map_type.element.common.type);
+      ddsi_type_register_dep (gv, &xt->id, &xt->_u.map.c.element_type, &cto->_u.map_type.element.common.type);
       xt->_u.map.c.element_flags = cto->_u.map_type.element.common.element_flags;
-      ddsi_type_ref_id_locked_impl (gv, &xt->_u.map.key_type, &cto->_u.map_type.key.common.type);
+      ddsi_type_register_dep (gv, &xt->id, &xt->_u.map.key_type, &cto->_u.map_type.key.common.type);
       xt->_u.map.bound = cto->_u.map_type.header.common.bound;
       break;
     case DDS_XTypes_TK_ENUM:
@@ -1136,41 +1136,41 @@ dds_return_t ddsi_xt_type_init_impl (struct ddsi_domaingv *gv, struct xt_type *x
         break;
       case DDS_XTypes_TI_PLAIN_SEQUENCE_SMALL:
         xt->_d = DDS_XTypes_TK_SEQUENCE;
-        ddsi_type_ref_id_locked_impl (gv, &xt->_u.seq.c.element_type, ti->_u.seq_sdefn.element_identifier);
+        ddsi_type_register_dep (gv, &xt->id, &xt->_u.seq.c.element_type, ti->_u.seq_sdefn.element_identifier);
         xt->_u.seq.bound = (DDS_XTypes_LBound) ti->_u.seq_sdefn.bound;
         xt_collection_common_init (&xt->_u.seq.c, &ti->_u.seq_sdefn.header);
         break;
       case DDS_XTypes_TI_PLAIN_SEQUENCE_LARGE:
         xt->_d = DDS_XTypes_TK_SEQUENCE;
-        ddsi_type_ref_id_locked_impl (gv, &xt->_u.seq.c.element_type, ti->_u.seq_ldefn.element_identifier);
+        ddsi_type_register_dep (gv, &xt->id, &xt->_u.seq.c.element_type, ti->_u.seq_ldefn.element_identifier);
         xt->_u.seq.bound = ti->_u.seq_ldefn.bound;
         xt_collection_common_init (&xt->_u.seq.c, &ti->_u.seq_ldefn.header);
         break;
       case DDS_XTypes_TI_PLAIN_ARRAY_SMALL:
         xt->_d = DDS_XTypes_TK_ARRAY;
-        ddsi_type_ref_id_locked_impl (gv, &xt->_u.array.c.element_type, ti->_u.array_sdefn.element_identifier);
+        ddsi_type_register_dep (gv, &xt->id, &xt->_u.array.c.element_type, ti->_u.array_sdefn.element_identifier);
         xt_collection_common_init (&xt->_u.array.c, &ti->_u.array_sdefn.header);
         xt_sbounds_to_lbounds (&xt->_u.array.bounds, &ti->_u.array_sdefn.array_bound_seq);
         break;
       case DDS_XTypes_TI_PLAIN_ARRAY_LARGE:
         xt->_d = DDS_XTypes_TK_ARRAY;
-        ddsi_type_ref_id_locked_impl (gv, &xt->_u.array.c.element_type, ti->_u.array_ldefn.element_identifier);
+        ddsi_type_register_dep (gv, &xt->id, &xt->_u.array.c.element_type, ti->_u.array_ldefn.element_identifier);
         xt_collection_common_init (&xt->_u.array.c, &ti->_u.array_ldefn.header);
         xt_lbounds_dup (&xt->_u.array.bounds, &ti->_u.array_ldefn.array_bound_seq);
         break;
       case DDS_XTypes_TI_PLAIN_MAP_SMALL:
         xt->_d = DDS_XTypes_TK_MAP;
-        ddsi_type_ref_id_locked_impl (gv, &xt->_u.map.c.element_type, ti->_u.map_sdefn.element_identifier);
+        ddsi_type_register_dep (gv, &xt->id, &xt->_u.map.c.element_type, ti->_u.map_sdefn.element_identifier);
         xt->_u.map.bound = (DDS_XTypes_LBound) ti->_u.map_sdefn.bound;
         xt_collection_common_init (&xt->_u.map.c, &ti->_u.map_sdefn.header);
-        ddsi_type_ref_id_locked_impl (gv, &xt->_u.map.key_type, ti->_u.map_sdefn.key_identifier);
+        ddsi_type_register_dep (gv, &xt->id, &xt->_u.map.key_type, ti->_u.map_sdefn.key_identifier);
         break;
       case DDS_XTypes_TI_PLAIN_MAP_LARGE:
         xt->_d = DDS_XTypes_TK_MAP;
-        ddsi_type_ref_id_locked_impl (gv, &xt->_u.map.c.element_type, ti->_u.map_ldefn.element_identifier);
+        ddsi_type_register_dep (gv, &xt->id, &xt->_u.map.c.element_type, ti->_u.map_ldefn.element_identifier);
         xt->_u.map.bound = (DDS_XTypes_LBound) ti->_u.map_ldefn.bound;
         xt_collection_common_init (&xt->_u.map.c, &ti->_u.map_ldefn.header);
-        ddsi_type_ref_id_locked_impl (gv, &xt->_u.map.key_type, ti->_u.map_ldefn.key_identifier);
+        ddsi_type_register_dep (gv, &xt->id, &xt->_u.map.key_type, ti->_u.map_ldefn.key_identifier);
         break;
       case DDS_XTypes_EK_MINIMAL:
         if (to != NULL)
@@ -1336,7 +1336,8 @@ void ddsi_xt_type_fini (struct ddsi_domaingv *gv, struct xt_type *xt)
       abort (); /* FIXME: not implemented */
       break;
     case DDS_XTypes_TK_STRUCTURE:
-      ddsi_type_unref_locked (gv, xt->_u.structure.base_type);
+      if (xt->_u.structure.base_type)
+        ddsi_type_unref_locked (gv, xt->_u.structure.base_type);
       for (uint32_t n = 0; n < xt->_u.structure.members.length; n++)
         ddsi_type_unref_locked (gv, xt->_u.structure.members.seq[n].type);
       ddsrt_free (xt->_u.structure.members.seq);

--- a/src/core/ddsi/src/ddsi_typewrap.c
+++ b/src/core/ddsi/src/ddsi_typewrap.c
@@ -1114,7 +1114,7 @@ dds_return_t ddsi_xt_type_init_impl (struct ddsi_domaingv *gv, struct xt_type *x
 {
   assert (xt);
   assert (ti);
-  dds_return_t ret = DDS_RETCODE_OK;
+  dds_return_t ret = DDS_RETCODE_OK, ret_validate = DDS_RETCODE_OK;
 
   ddsi_typeid_copy_impl (&xt->id.x, ti);
   if (!ddsi_typeid_is_hash_impl (ti))
@@ -1206,7 +1206,13 @@ dds_return_t ddsi_xt_type_init_impl (struct ddsi_domaingv *gv, struct xt_type *x
         break;
     }
   }
-  if (ret != DDS_RETCODE_OK || (ret = ddsi_xt_validate (gv, xt)) != DDS_RETCODE_OK)
+  if (ret != DDS_RETCODE_OK || (ret_validate = ddsi_xt_validate (gv, xt)) != DDS_RETCODE_OK)
+  {
+    if (ret == DDS_RETCODE_OK)
+    {
+      ddsi_xt_type_fini (gv, xt, true);
+      ret = ret_validate;
+    }
     GVWARNING ("type " PTYPEIDFMT ": ddsi_xt_type_init_impl with invalid type object\n", PTYPEID (xt->id.x));
   return ret;
 }

--- a/src/core/ddsi/src/ddsi_typewrap.c
+++ b/src/core/ddsi/src/ddsi_typewrap.c
@@ -701,6 +701,11 @@ static dds_return_t xt_valid_type_flags (struct ddsi_domaingv *gv, uint16_t flag
 static dds_return_t xt_valid_member_flags (struct ddsi_domaingv *gv, uint16_t flags, uint8_t member_flag_kind)
 {
   dds_return_t ret = DDS_RETCODE_OK;
+
+  /* FIXME: (flags & (T1|T2)) == 0 is also invalid, but as we use this (invalid)
+     value for the try-construct flags in the 0.9 release, this check cannot currently
+     be added here */
+
   switch (member_flag_kind)
   {
     case MEMBER_FLAG_COLLECTION_ELEMENT:

--- a/src/core/ddsi/src/q_ddsi_discovery.c
+++ b/src/core/ddsi/src/q_ddsi_discovery.c
@@ -1808,7 +1808,8 @@ static void handle_sedp_alive_topic (const struct receiver_state *rst, seqno_t s
     else
     {
       GVLOGDISC (" NEW proxy-topic");
-      new_proxy_topic (proxypp, seq, &datap->topic_guid, type_id_minimal, type_id_complete, xqos, timestamp);
+      if (ddsi_new_proxy_topic (proxypp, seq, &datap->topic_guid, type_id_minimal, type_id_complete, xqos, timestamp) != DDS_RETCODE_OK)
+        GVLOGDISC (" failed");
     }
   }
 }

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -3408,8 +3408,8 @@ static void endpoint_common_init (struct entity_common *e, struct endpoint_commo
 
 #ifdef DDS_HAS_TYPE_DISCOVERY
   c->type_pair = ddsrt_malloc (sizeof (*c->type_pair));
-  c->type_pair->minimal = ddsi_type_ref_local (pp->e.gv, sertype, DDSI_TYPEID_KIND_MINIMAL);
-  c->type_pair->complete = ddsi_type_ref_local (pp->e.gv, sertype, DDSI_TYPEID_KIND_COMPLETE);
+  ddsi_type_ref_local (pp->e.gv, &c->type_pair->minimal, sertype, DDSI_TYPEID_KIND_MINIMAL);
+  ddsi_type_ref_local (pp->e.gv, &c->type_pair->complete, sertype, DDSI_TYPEID_KIND_COMPLETE);
 #endif
 }
 
@@ -5750,14 +5750,14 @@ static struct ddsi_topic_definition * new_topic_definition (struct ddsi_domaingv
   tpd->type_pair = ddsrt_malloc (sizeof (*tpd->type_pair));
   if (type != NULL)
   {
-    tpd->type_pair->minimal = ddsi_type_ref_local (gv, type, DDSI_TYPEID_KIND_MINIMAL);
-    tpd->type_pair->complete = ddsi_type_ref_local (gv, type, DDSI_TYPEID_KIND_COMPLETE);
+    ddsi_type_ref_local (gv, &tpd->type_pair->minimal, type, DDSI_TYPEID_KIND_MINIMAL);
+    ddsi_type_ref_local (gv, &tpd->type_pair->complete, type, DDSI_TYPEID_KIND_COMPLETE);
   }
   else
   {
     assert (qos->present & QP_TYPE_INFORMATION);
-    tpd->type_pair->minimal = ddsi_type_ref_proxy (gv, qos->type_information, DDSI_TYPEID_KIND_MINIMAL, NULL);
-    tpd->type_pair->complete = ddsi_type_ref_proxy (gv, qos->type_information, DDSI_TYPEID_KIND_COMPLETE, NULL);
+    ddsi_type_ref_proxy (gv, &tpd->type_pair->minimal, qos->type_information, DDSI_TYPEID_KIND_MINIMAL, NULL);
+    ddsi_type_ref_proxy (gv, &tpd->type_pair->complete, qos->type_information, DDSI_TYPEID_KIND_COMPLETE, NULL);
   }
 
   set_topic_definition_hash (tpd);
@@ -5993,8 +5993,8 @@ static int proxy_endpoint_common_init (struct entity_common *e, struct proxy_end
   if (plist->qos.present & QP_TYPE_INFORMATION)
   {
     c->type_pair = ddsrt_malloc (sizeof (*c->type_pair));
-    c->type_pair->minimal = ddsi_type_ref_proxy (proxypp->e.gv, plist->qos.type_information, DDSI_TYPEID_KIND_MINIMAL, guid);
-    c->type_pair->complete = ddsi_type_ref_proxy (proxypp->e.gv, plist->qos.type_information, DDSI_TYPEID_KIND_COMPLETE, guid);
+    ddsi_type_ref_proxy (proxypp->e.gv, &c->type_pair->minimal, plist->qos.type_information, DDSI_TYPEID_KIND_MINIMAL, guid);
+    ddsi_type_ref_proxy (proxypp->e.gv, &c->type_pair->complete, plist->qos.type_information, DDSI_TYPEID_KIND_COMPLETE, guid);
   }
   else
   {

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -2772,27 +2772,17 @@ static bool topickind_qos_match_p_lock (
 #ifdef DDS_HAS_TYPE_DISCOVERY
   bool rd_type_lookup, wr_type_lookup;
   const ddsi_typeid_t *req_type_id = NULL;
-  const ddsi_typeid_t ** req_dep_ids = NULL;
-  uint32_t req_ndep_ids = 0;
   bool ret = qos_match_p (gv, rdqos, wrqos, reason, rd_type_pair, wr_type_pair, &rd_type_lookup, &wr_type_lookup);
   if (!ret)
   {
     /* In case qos_match_p returns false, one of rd_type_look and wr_type_lookup could
        be set to indicate that type information is missing. At this point, we know this
        is the case so do a type lookup request for either rd_type_pair->minimal or
-       wr_type_pair->minimal. */
+       wr_type_pair->minimal or a dependent type for one of these. */
     if (rd_type_lookup)
-    {
       req_type_id = ddsi_type_pair_minimal_id (rd_type_pair);
-      if (rdqos->present & QP_TYPE_INFORMATION)
-        req_ndep_ids = ddsi_typeinfo_get_dependent_typeids (rdqos->type_information, &req_dep_ids, DDSI_TYPEID_KIND_MINIMAL);
-    }
     else if (wr_type_lookup)
-    {
       req_type_id = ddsi_type_pair_minimal_id (wr_type_pair);
-      if (wrqos->present & QP_TYPE_INFORMATION)
-        req_ndep_ids = ddsi_typeinfo_get_dependent_typeids (wrqos->type_information, &req_dep_ids, DDSI_TYPEID_KIND_MINIMAL);
-    }
   }
 #else
   bool ret = qos_match_p (gv, rdqos, wrqos, reason);
@@ -2803,9 +2793,7 @@ static bool topickind_qos_match_p_lock (
 #ifdef DDS_HAS_TYPE_DISCOVERY
   if (req_type_id)
   {
-    (void) ddsi_tl_request_type (gv, req_type_id, req_dep_ids, req_ndep_ids);
-    if (req_dep_ids)
-      ddsrt_free ((void *) req_dep_ids);
+    (void) ddsi_tl_request_type (gv, req_type_id, true);
     return false;
   }
 #endif

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -1521,6 +1521,8 @@ int rtps_init (struct ddsi_domaingv *gv)
   ddsrt_mutex_init (&gv->typelib_lock);
   ddsrt_cond_init (&gv->typelib_resolved_cond);
   ddsrt_avl_init (&ddsi_typelib_treedef, &gv->typelib);
+  ddsrt_avl_init (&ddsi_typedeps_treedef, &gv->typedeps);
+  ddsrt_avl_init (&ddsi_typedeps_reverse_treedef, &gv->typedeps_reverse);
 #endif
   ddsrt_mutex_init (&gv->new_topic_lock);
   ddsrt_cond_init (&gv->new_topic_cond);
@@ -1941,6 +1943,8 @@ err_unicast_sockets:
   ddsrt_cond_destroy (&gv->new_topic_cond);
 #ifdef DDS_HAS_TYPE_DISCOVERY
   ddsrt_avl_free (&ddsi_typelib_treedef, &gv->typelib, 0);
+  ddsrt_avl_free (&ddsi_typedeps_treedef, &gv->typedeps, 0);
+  ddsrt_avl_free (&ddsi_typedeps_reverse_treedef, &gv->typedeps_reverse, 0);
   ddsrt_mutex_destroy (&gv->typelib_lock);
   ddsrt_cond_destroy (&gv->typelib_resolved_cond);
 #endif
@@ -2320,9 +2324,13 @@ void rtps_fini (struct ddsi_domaingv *gv)
 #ifndef NDEBUG
   {
     assert(ddsrt_avl_is_empty(&gv->typelib));
+    assert(ddsrt_avl_is_empty(&gv->typedeps));
+    assert(ddsrt_avl_is_empty(&gv->typedeps_reverse));
   }
 #endif
   ddsrt_avl_free (&ddsi_typelib_treedef, &gv->typelib, 0);
+  ddsrt_avl_free (&ddsi_typedeps_treedef, &gv->typedeps, 0);
+  ddsrt_avl_free (&ddsi_typedeps_reverse_treedef, &gv->typedeps_reverse, 0);
   ddsrt_mutex_destroy (&gv->typelib_lock);
 #endif /* DDS_HAS_TYPE_DISCOVERY */
 #ifndef NDEBUG

--- a/src/core/ddsi/src/q_qosmatch.c
+++ b/src/core/ddsi/src/q_qosmatch.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright(c) 2022 ZettaScale Technology
  * Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
  *
  * This program and the accompanying materials are made available under the
@@ -76,7 +77,7 @@ static bool is_endpoint_type_resolved (struct ddsi_domaingv *gv, char *type_name
 {
   assert (type_pair);
   ddsrt_mutex_lock (&gv->typelib_lock);
-  if (!ddsi_type_pair_has_minimal_obj (type_pair) && !ddsi_type_pair_has_complete_obj (type_pair))
+  if (!ddsi_type_resolved (gv, type_pair->minimal, true) && !ddsi_type_resolved (gv, type_pair->complete, true))
   {
     struct ddsi_typeid_str str;
     const ddsi_typeid_t *tid_m = ddsi_type_pair_minimal_id (type_pair),

--- a/src/core/ddsi/src/q_qosmatch.c
+++ b/src/core/ddsi/src/q_qosmatch.c
@@ -70,14 +70,16 @@ static int partitions_match_p (const dds_qos_t *a, const dds_qos_t *b)
 
 #ifdef DDS_HAS_TYPE_DISCOVERY
 
-static bool is_endpoint_type_resolved (struct ddsi_domaingv *gv, char *type_name, const ddsi_type_pair_t *type_pair, bool *req_lookup, const char *entity)
+static uint32_t is_endpoint_type_resolved (struct ddsi_domaingv *gv, char *type_name, const ddsi_type_pair_t *type_pair, bool *req_lookup, const char *entity)
   ddsrt_nonnull((1, 2, 3));
 
-static bool is_endpoint_type_resolved (struct ddsi_domaingv *gv, char *type_name, const ddsi_type_pair_t *type_pair, bool *req_lookup, const char *entity)
+static uint32_t is_endpoint_type_resolved (struct ddsi_domaingv *gv, char *type_name, const ddsi_type_pair_t *type_pair, bool *req_lookup, const char *entity)
 {
   assert (type_pair);
   ddsrt_mutex_lock (&gv->typelib_lock);
-  if (!ddsi_type_resolved (gv, type_pair->minimal, true) && !ddsi_type_resolved (gv, type_pair->complete, true))
+  bool min_resolved = ddsi_type_resolved (gv, type_pair->minimal, true),
+    compl_resolved = ddsi_type_resolved (gv, type_pair->complete, true);
+  if (!min_resolved && !compl_resolved)
   {
     struct ddsi_typeid_str str;
     const ddsi_typeid_t *tid_m = ddsi_type_pair_minimal_id (type_pair),
@@ -94,10 +96,13 @@ static bool is_endpoint_type_resolved (struct ddsi_domaingv *gv, char *type_name
     if (req_lookup != NULL)
       *req_lookup = true;
     ddsrt_mutex_unlock (&gv->typelib_lock);
-    return false;
+    return DDS_XTypes_TK_NONE;
   }
   ddsrt_mutex_unlock (&gv->typelib_lock);
-  return true;
+
+  if (min_resolved && compl_resolved)
+    return DDS_XTypes_EK_BOTH;
+  return compl_resolved ? DDS_XTypes_EK_COMPLETE : DDS_XTypes_EK_MINIMAL;
 }
 
 #endif /* DDS_HAS_TYPE_DISCOVERY */
@@ -247,10 +252,12 @@ bool qos_match_mask_p (
     }
     else
     {
-      if (!is_endpoint_type_resolved (gv, rd_qos->type_name, rd_type_pair, rd_typeid_req_lookup, "rd")
-          || !is_endpoint_type_resolved (gv, wr_qos->type_name, wr_type_pair, wr_typeid_req_lookup, "wr"))
+      uint32_t rd_resolved, wr_resolved;
+      if (!(rd_resolved = is_endpoint_type_resolved (gv, rd_qos->type_name, rd_type_pair, rd_typeid_req_lookup, "rd"))
+          || !(wr_resolved = is_endpoint_type_resolved (gv, wr_qos->type_name, wr_type_pair, wr_typeid_req_lookup, "wr")))
         return false;
-      if (!ddsi_is_assignable_from (gv, rd_type_pair, wr_type_pair, &tce))
+
+      if (!ddsi_is_assignable_from (gv, rd_type_pair, rd_resolved, wr_type_pair, wr_resolved, &tce))
       {
         *reason = DDS_TYPE_CONSISTENCY_ENFORCEMENT_QOS_POLICY_ID;
         return false;


### PR DESCRIPTION
Add validation of type objects when adding types in the type library for a local created or discovered topics. The validation includes checks for type and member flags, base types, member ids, enum and bitmask positions. Checking custom annotations and some of the built-in annotations is not included.