### PR TITLE
Bug fixes

### DIFF
--- a/src/idl/src/annotation.c
+++ b/src/idl/src/annotation.c
@@ -424,6 +424,7 @@ annotate_default(
 
   assert(annotation_appl);
   assert(annotation_appl->parameters);
+  value = annotation_appl->parameters->const_expr;
 
   if (!idl_is_member(node)) {
     idl_error(pstate, idl_location(annotation_appl),
@@ -433,10 +434,11 @@ annotate_default(
     idl_error(pstate, idl_location(annotation_appl),
       "@default cannot be set on optional members");
     return IDL_RETCODE_SEMANTIC_ERROR;
+  } else if (!(idl_mask(value) & IDL_BASE_TYPE) && !(idl_mask(value) & IDL_STRING)) {
+    idl_error(pstate, idl_location(annotation_appl),
+      "@default can only set primitive types");
+    return IDL_RETCODE_SEMANTIC_ERROR;
   }
-
-  value = annotation_appl->parameters->const_expr;
-  assert(idl_is_literal(value));
 
   /*check whether type of literal matches and falls inside spec of member*/
   idl_type_t mem_type = idl_type(mem_spec);

--- a/src/idl/src/expression.c
+++ b/src/idl/src/expression.c
@@ -962,6 +962,29 @@ static idl_floatval_t floatval(const idl_const_expr_t *const_expr)
   assert(idl_is_literal(const_expr));
 
   switch (type) {
+    case IDL_INT8:
+      return (idl_floatval_t)val->value.int8;
+    case IDL_OCTET:
+    case IDL_UINT8:
+      return (idl_floatval_t)val->value.uint8;
+    case IDL_SHORT:
+    case IDL_INT16:
+      return (idl_floatval_t)val->value.int16;
+    case IDL_USHORT:
+    case IDL_UINT16:
+      return (idl_floatval_t)val->value.uint16;
+    case IDL_LONG:
+    case IDL_INT32:
+      return (idl_floatval_t)val->value.int32;
+    case IDL_ULONG:
+    case IDL_UINT32:
+      return (idl_floatval_t)val->value.uint32;
+    case IDL_LLONG:
+    case IDL_INT64:
+      return (idl_floatval_t)val->value.int64;
+    case IDL_ULLONG:
+    case IDL_UINT64:
+      return (idl_floatval_t)val->value.uint64;
     case IDL_FLOAT:
       return (idl_floatval_t)val->value.flt;
     case IDL_DOUBLE:

--- a/src/idl/tests/annotation.c
+++ b/src/idl/tests/annotation.c
@@ -164,6 +164,7 @@ CU_Test(idl_annotation, idl_default)
   static const bool t4 = true;
   static const char *t5 = "hello world!";
   static const uint32_t t6 = 123456789;
+  static const double t7 = 123456789;
   static const idl_default_test_t tests[] = {
     {"struct s { long l; };",                                IDL_RETCODE_OK,                  false, IDL_NULL,    NULL}, //no default whatsoever
     {"struct s { @default(-123456789) long l; };",           IDL_RETCODE_OK,                  true,  IDL_LONG,    &t1},  //default long
@@ -172,13 +173,15 @@ CU_Test(idl_annotation, idl_default)
     {"struct s { @default(true) boolean b; };",              IDL_RETCODE_OK,                  true,  IDL_BOOL,    &t4},  //default bool
     {"struct s { @default(\"hello world!\") string str; };", IDL_RETCODE_OK,                  true,  IDL_STRING,  &t5},  //default string
     {"struct s { @default(123456789) unsigned long l; };",   IDL_RETCODE_OK,                  true,  IDL_ULONG,   &t6},  //default unsigned long
+    {"struct s { @default(123456789) double l; };",          IDL_RETCODE_OK,                  true,  IDL_DOUBLE,  &t7},  //setting a double member to integer default
     {"struct s { @default(123) @optional long l; };",        IDL_RETCODE_SEMANTIC_ERROR,      false, IDL_NULL,    NULL}, //mixing default and optional
     {"struct s { @default long l; };",                       IDL_RETCODE_SEMANTIC_ERROR,      false, IDL_NULL,    NULL}, //misssing parameter
     {"struct s { @default(123) string str; };",              IDL_RETCODE_ILLEGAL_EXPRESSION,  false, IDL_NULL,    NULL}, //parameter type mismatch (int vs string)
     {"struct s { @default(\"false\") boolean b; };",         IDL_RETCODE_ILLEGAL_EXPRESSION,  false, IDL_NULL,    NULL}, //parameter type mismatch (string vs bool)
     {"struct s { @default(123) boolean b; };",               IDL_RETCODE_ILLEGAL_EXPRESSION,  false, IDL_NULL,    NULL}, //parameter type mismatch (int vs bool)
     {"struct s { @default(-123) unsigned long l; };",        IDL_RETCODE_OUT_OF_RANGE,        false, IDL_NULL,    NULL}, //parameter type mismatch (unsigned vs signed)
-    {"@default(e_0) enum e { e_0, e_1, e_2, e_3 };",         IDL_RETCODE_SEMANTIC_ERROR,      false, IDL_NULL,    NULL}  //setting default on enums is done through @default_literal
+    {"@default(e_0) enum e { e_0, e_1, e_2, e_3 };",         IDL_RETCODE_SEMANTIC_ERROR,      false, IDL_NULL,    NULL},  //setting default on enums is done through @default_literal
+    {"enum e { e_0, e_1, e_2, e_3 }; struct s { @default(e_1) e m_e; };", IDL_RETCODE_SEMANTIC_ERROR, false, IDL_NULL, NULL},  //setting enums default is not yet supported
   };
 
   for (size_t i = 0; i < sizeof(tests)/sizeof(tests[0]); i++) {

--- a/src/tools/idlc/src/idlc.c
+++ b/src/tools/idlc/src/idlc.c
@@ -282,6 +282,8 @@ static idl_retcode_t idlc_parse(void)
     }
     assert(config.file);
     if (strcmp(config.file, "-") != 0 && (ret = figure_file(&pstate->paths)) != 0) {
+      if (ret == IDL_RETCODE_NO_ENTRY)
+        idl_error(pstate, NULL, "could not open file at location: %s", config.file);
       idl_delete_pstate(pstate);
       return ret;
     }

--- a/src/tools/idlpp/src/main.c
+++ b/src/tools/idlpp/src/main.c
@@ -444,11 +444,11 @@ fatal_error_exit:
     clear_symtable();
 #endif
 
-    if (fp_in != stdin)
+    if (fp_in && fp_in != stdin)
         fclose( fp_in);
-    if (fp_out != stdout)
+    if (fp_out && fp_out != stdout)
         fclose( fp_out);
-    if (fp_err != stderr)
+    if (fp_err && fp_err != stderr)
         fclose( fp_err);
 
     if (mcpp_debug & MEMORY)


### PR DESCRIPTION
Fix a number of bugs/shortcomings:
- @default annotations did not allow an integer value on a floating point field (even though they are ALSO floating point)
- passing a non-existent absolute path to the preprocessor caused fclose to be called on a nullptr
- added error message for when idlc was asked to open non-existant paths