### PR TITLE
IDLC fix for array of enum in union member

### DIFF
--- a/src/tools/idlc/src/descriptor.c
+++ b/src/tools/idlc/src/descriptor.c
@@ -894,18 +894,19 @@ emit_case(
 
       bool has_size = false;
       if (case_type == INLINE || case_type == IN_UNION) {
+        uint32_t label_opcode = opcode;
         /* update offset to first instruction for in-union cases */
         if (!idl_is_enum(type_spec))
-          opcode &= (DDS_OP_MASK | DDS_OP_TYPE_FLAGS_MASK | DDS_OP_TYPE_MASK);
+          label_opcode &= (DDS_OP_MASK | DDS_OP_TYPE_FLAGS_MASK | DDS_OP_TYPE_MASK);
         if (case_type == IN_UNION)
-          opcode |= (cnt - off);
-        /* generate union case opcode */
-        if ((ret = stash_opcode(pstate, descriptor, &ctype->instructions, off++, opcode, 0u)))
-          return ret;
+          label_opcode |= (cnt - off);
         if (idl_is_external(node) && !idl_is_unbounded_string(type_spec)) {
-          opcode |= DDS_OP_FLAG_EXT;
+          label_opcode |= DDS_OP_FLAG_EXT;
           has_size = idl_is_array(type_spec) || idl_is_sequence(type_spec);
         }
+        /* generate union case opcode */
+        if ((ret = stash_opcode(pstate, descriptor, &ctype->instructions, off++, label_opcode, 0u)))
+          return ret;
       } else { /* EXTERNAL */
         assert(off <= INT16_MAX);
         if (idl_is_external(node))

--- a/src/tools/idlc/xtests/test_union.idl
+++ b/src/tools/idlc/xtests/test_union.idl
@@ -14,17 +14,24 @@
 
 union test_union;
 
+enum e { E1, E2 };
+
 @nested
 union union_nested1 switch (short) {
   case 1:
     long a1;
   case 2:
     @external test_union c1;
+  case 3:
+  case 4:
+  case 5:
+    e d1[2];
 };
 
 @nested
 struct struct_nested1 {
   @external union_nested1 a2;
+  @external union_nested1 a3;
 };
 
 @topic @appendable
@@ -47,12 +54,18 @@ void init_sample (void *s)
 {
   test_union *s1 = (test_union *) s;
   s1->_d = 2;
+
   A (s1->_u.b.a2);
   s1->_u.b.a2->_d = 2;
   A (s1->_u.b.a2->_u.c1);
   s1->_u.b.a2->_u.c1->_d = 1;
   s1->_u.b.a2->_u.c1->_u.a._d = 1;
   s1->_u.b.a2->_u.c1->_u.a._u.a1 = 123;
+
+  A (s1->_u.b.a3);
+  s1->_u.b.a3->_d = 5;
+  s1->_u.b.a3->_u.d1[0] = E2;
+  s1->_u.b.a3->_u.d1[1] = E1;
 }
 
 int cmp_sample (const void *sa, const void *sb)
@@ -61,8 +74,13 @@ int cmp_sample (const void *sa, const void *sb)
   test_union *b = (test_union *) sb;
   CMP(a, b, _d, 2)
   CMP(a, b, _u.b.a2->_d, 2)
+  CMP(a, b, _u.b.a2->_u.c1->_d, 1)
   CMP(a, b, _u.b.a2->_u.c1->_u.a._d, 1)
   CMP(a, b, _u.b.a2->_u.c1->_u.a._u.a1, 123)
+
+  CMP(a, b, _u.b.a3->_d, 5)
+  CMP(a, b, _u.b.a3->_u.d1[0], E2)
+  CMP(a, b, _u.b.a3->_u.d1[1], E1)
   return 0;
 }
 


### PR DESCRIPTION
Fix bug in serializer opcode generation for array of enums in union member with multiple case labels: the offset to the member type definition in the opcodes was incorrect in this situation. 
