### PR TITLE
Data representation annotation

### DIFF
--- a/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright(c) 2022 ZettaScale Technology and others
  * Copyright(c) 2021 ADLINK Technology Limited and others
  *
  * This program and the accompanying materials are made available under the
@@ -298,6 +299,7 @@ enum dds_stream_typecode_subtype {
 #define DDS_TOPIC_FIXED_SIZE                    (1u << 4)
 #define DDS_TOPIC_FIXED_KEY_XCDR2               (1u << 5)   /* Set if the XCDR2 serialized key fits in 16 bytes */
 #define DDS_TOPIC_XTYPES_METADATA               (1u << 6)   /* Set if XTypes meta-data is present for this topic */
+#define DDS_TOPIC_RESTRICT_DATA_REPRESENTATION  (1u << 7)   /* Set if data representation restrictions for the top-level type are present in the topic descriptor */
 
 /* Max size of fixed key */
 #define DDS_FIXED_KEY_MAX_SIZE (16)

--- a/src/core/ddsc/include/dds/ddsc/dds_public_impl.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_public_impl.h
@@ -1,5 +1,6 @@
 /*
  * Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
+ * Copyright(c) 2022 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -61,6 +62,10 @@ struct dds_type_meta_ser
   uint32_t sz;
 };
 
+#define DDS_DATA_REPRESENTATION_XCDR1    0
+#define DDS_DATA_REPRESENTATION_XML      1
+#define DDS_DATA_REPRESENTATION_XCDR2    2
+
 typedef struct dds_topic_descriptor
 {
   const uint32_t m_size;               /* Size of topic type */
@@ -75,6 +80,8 @@ typedef struct dds_topic_descriptor
   struct dds_type_meta_ser type_information;  /* XCDR2 serialized TypeInformation, only present if flag DDS_TOPIC_XTYPES_METADATA is set */
   struct dds_type_meta_ser type_mapping;      /* XCDR2 serialized TypeMapping: maps type-id to type object and minimal to complete type id,
                                                    only present if flag DDS_TOPIC_XTYPES_METADATA is set */
+  const uint32_t restrict_data_representation; /* restrictions on the data representations allowed for the top-level type for this topic,
+                                           only present if flag DDS_TOPIC_RESTRICT_DATA_REPRESENTATION */
 }
 dds_topic_descriptor_t;
 

--- a/src/core/ddsc/include/dds/ddsc/dds_public_impl.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_public_impl.h
@@ -1,6 +1,6 @@
 /*
- * Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
  * Copyright(c) 2022 ZettaScale Technology and others
+ * Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -65,6 +65,11 @@ struct dds_type_meta_ser
 #define DDS_DATA_REPRESENTATION_XCDR1    0
 #define DDS_DATA_REPRESENTATION_XML      1
 #define DDS_DATA_REPRESENTATION_XCDR2    2
+
+#define DDS_DATA_REPRESENTATION_FLAG_XCDR1  (1u << DDS_DATA_REPRESENTATION_XCDR1)
+#define DDS_DATA_REPRESENTATION_FLAG_XML    (1u << DDS_DATA_REPRESENTATION_XML)
+#define DDS_DATA_REPRESENTATION_FLAG_XCDR2  (1u << DDS_DATA_REPRESENTATION_XCDR2)
+#define DDS_DATA_REPRESENTATION_RESTRICT_DEFAULT  (DDS_DATA_REPRESENTATION_FLAG_XCDR1 | DDS_DATA_REPRESENTATION_FLAG_XCDR2)
 
 typedef struct dds_topic_descriptor
 {

--- a/src/core/ddsc/include/dds/ddsc/dds_public_qosdefs.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_public_qosdefs.h
@@ -1,5 +1,6 @@
 /*
  * Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
+ * Copyright(c) 2022 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -140,9 +141,6 @@ dds_type_consistency_kind_t;
 
 /** Data Representation QoS: Applies to Topic, DataReader, DataWriter */
 typedef int16_t dds_data_representation_id_t;
-#define DDS_DATA_REPRESENTATION_XCDR1    0
-#define DDS_DATA_REPRESENTATION_XML      1
-#define DDS_DATA_REPRESENTATION_XCDR2    2
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsc/include/dds/ddsc/dds_public_qosdefs.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_public_qosdefs.h
@@ -1,6 +1,6 @@
 /*
- * Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
  * Copyright(c) 2022 ZettaScale Technology and others
+ * Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/core/ddsc/src/dds__qos.h
+++ b/src/core/ddsc/src/dds__qos.h
@@ -54,7 +54,7 @@ extern "C" {
    QP_RESOURCE_LIMITS | QP_ADLINK_WRITER_DATA_LIFECYCLE |               \
    QP_CYCLONE_IGNORELOCAL | QP_PROPERTY_LIST | QP_DATA_REPRESENTATION)
 
-dds_return_t dds_ensure_valid_data_representation (dds_qos_t *qos, uint16_t min_xcdrv, bool topicqos);
+dds_return_t dds_ensure_valid_data_representation (dds_qos_t *qos, uint32_t allowed_data_representations, bool topicqos);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsc/src/dds_qos.c
+++ b/src/core/ddsc/src/dds_qos.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright(c) 2022 ZettaScale Technology
  * Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
  *
  * This program and the accompanying materials are made available under the
@@ -823,9 +824,11 @@ bool dds_qget_data_representation (const dds_qos_t * __restrict qos, uint32_t *n
   return true;
 }
 
-dds_return_t dds_ensure_valid_data_representation (dds_qos_t *qos, uint16_t min_xcdrv, bool topicqos)
+dds_return_t dds_ensure_valid_data_representation (dds_qos_t *qos, uint32_t allowed_data_representations, bool topicqos)
 {
-  assert (min_xcdrv <= CDR_ENC_VERSION_2);
+  const bool allow1 = allowed_data_representations & DDS_DATA_REPRESENTATION_FLAG_XCDR1,
+    allow2 = allowed_data_representations & DDS_DATA_REPRESENTATION_FLAG_XCDR2;
+
   if ((qos->present & QP_DATA_REPRESENTATION) && qos->data_representation.value.n > 0)
   {
     assert (qos->data_representation.value.ids != NULL);
@@ -836,10 +839,12 @@ dds_return_t dds_ensure_valid_data_representation (dds_qos_t *qos, uint16_t min_
         case DDS_DATA_REPRESENTATION_XML:
           return DDS_RETCODE_UNSUPPORTED;
         case DDS_DATA_REPRESENTATION_XCDR1:
-          if (min_xcdrv == CDR_ENC_VERSION_2)
+          if (!allow1)
             return DDS_RETCODE_BAD_PARAMETER;
           break;
         case DDS_DATA_REPRESENTATION_XCDR2:
+          if (!allow2)
+            return DDS_RETCODE_BAD_PARAMETER;
           break;
         default:
           return DDS_RETCODE_BAD_PARAMETER;
@@ -848,9 +853,11 @@ dds_return_t dds_ensure_valid_data_representation (dds_qos_t *qos, uint16_t min_
   }
   else
   {
-    if (min_xcdrv == CDR_ENC_VERSION_2)
+    if (!allow1 && !allow2)
+      return DDS_RETCODE_BAD_PARAMETER;
+    if (!allow1)
       dds_qset_data_representation (qos, 1, (dds_data_representation_id_t[]) { DDS_DATA_REPRESENTATION_XCDR2 });
-    else if (!topicqos)
+    else if (!topicqos || !allow2)
       dds_qset_data_representation (qos, 1, (dds_data_representation_id_t[]) { DDS_DATA_REPRESENTATION_XCDR1 });
     else
       dds_qset_data_representation (qos, 2, (dds_data_representation_id_t[]) { DDS_DATA_REPRESENTATION_XCDR1, DDS_DATA_REPRESENTATION_XCDR2 });

--- a/src/core/ddsc/src/dds_reader.c
+++ b/src/core/ddsc/src/dds_reader.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright(c) 2022 ZettaScale Technology
  * Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
  *
  * This program and the accompanying materials are made available under the
@@ -577,7 +578,7 @@ static dds_entity_t dds_create_reader_int (dds_entity_t participant_or_subscribe
   if (tp->m_ktopic->qos)
     ddsi_xqos_mergein_missing (rqos, tp->m_ktopic->qos, ~(uint64_t)0);
   ddsi_xqos_mergein_missing (rqos, &ddsi_default_qos_reader, ~QP_DATA_REPRESENTATION);
-  if ((rc = dds_ensure_valid_data_representation (rqos, tp->m_stype->min_xcdrv, false)) != 0)
+  if ((rc = dds_ensure_valid_data_representation (rqos, tp->m_stype->allowed_data_representation, false)) != 0)
     goto err_data_repr;
 
   if ((rc = ddsi_xqos_valid (&gv->logconfig, rqos)) < 0 || (rc = validate_reader_qos(rqos)) != DDS_RETCODE_OK)
@@ -657,7 +658,7 @@ static dds_entity_t dds_create_reader_int (dds_entity_t participant_or_subscribe
 
     iox_sub_options_t opts;
     iox_sub_options_init(&opts);
-    
+
     iox_sub_storage_extension_init(&rd->m_iox_sub_stor);
 
     assert (rqos->durability.kind == DDS_DURABILITY_VOLATILE);
@@ -685,7 +686,7 @@ static dds_entity_t dds_create_reader_int (dds_entity_t participant_or_subscribe
     // NB: since currently we only support the volatile reader case we will
     // never request historical data
     opts.historyRequest = 0;
-    
+
     rd->m_iox_sub = iox_sub_init(&rd->m_iox_sub_stor.storage, gv->config.iceoryx_service, rd->m_topic->m_stype->type_name, rd->m_topic->m_name, &opts);
     shm_monitor_attach_reader(&rd->m_entity.m_domain->m_shm_monitor, rd);
 

--- a/src/core/ddsc/src/dds_writer.c
+++ b/src/core/ddsc/src/dds_writer.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright(c) 2022 ZettaScale Technology
  * Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
  *
  * This program and the accompanying materials are made available under the
@@ -371,7 +372,7 @@ dds_entity_t dds_create_writer (dds_entity_t participant_or_publisher, dds_entit
   if (tp->m_ktopic->qos)
     ddsi_xqos_mergein_missing (wqos, tp->m_ktopic->qos, ~(uint64_t)0);
   ddsi_xqos_mergein_missing (wqos, &ddsi_default_qos_writer, ~QP_DATA_REPRESENTATION);
-  if ((rc = dds_ensure_valid_data_representation (wqos, tp->m_stype->min_xcdrv, false)) != 0)
+  if ((rc = dds_ensure_valid_data_representation (wqos, tp->m_stype->allowed_data_representation, false)) != 0)
     goto err_data_repr;
 
   if ((rc = ddsi_xqos_valid (&gv->logconfig, wqos)) < 0 || (rc = validate_writer_qos(wqos)) != DDS_RETCODE_OK)

--- a/src/core/ddsc/tests/DataRepresentationTypes.idl
+++ b/src/core/ddsc/tests/DataRepresentationTypes.idl
@@ -1,4 +1,5 @@
 /*
+ * Copyright(c) 2022 ZettaScale Technology
  * Copyright(c) 2021 ADLINK Technology Limited and others
  *
  * This program and the accompanying materials are made available under the
@@ -84,5 +85,49 @@ module DataRepresentationTypes {
       long c;
   };
 
+  @final @topic @data_representation(XCDR1)
+  struct TypeXcdr1 {
+    long f1;
+  };
+
+  @final @topic @data_representation(XCDR2)
+  struct TypeXcdr2 {
+    long f1;
+  };
+
+  @final @topic @data_representation(XCDR1 | XCDR2)
+  struct TypeXcdr1_2 {
+    long f1;
+  };
+
+  @final @topic @data_representation(XCDR1 | XML | XCDR2)
+  struct TypeXcdr1_xml_2 {
+    long f1;
+  };
+
+  @final @topic @data_representation(XCDR1 | 0xfffffff8)
+  struct TypeXcdr1_other {
+    long f1;
+  };
+
+  @final @topic @data_representation(XCDR2 | 0xfffffff8)
+  struct TypeXcdr2_other {
+    long f1;
+  };
+
+  @appendable @topic @data_representation(XCDR1)
+  struct TypeXcdrA1 {
+    long f1;
+  };
+
+  @appendable @topic @data_representation(XCDR2)
+  struct TypeXcdrA2 {
+    long f1;
+  };
+
+  @appendable @topic @data_representation(XCDR1 | XCDR2)
+  struct TypeXcdrA1_2 {
+    long f1;
+  };
 
 };

--- a/src/core/ddsi/include/dds/ddsi/ddsi_sertype.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_sertype.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright(c) 2022 ZettaScale Technology
  * Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
  *
  * This program and the accompanying materials are made available under the
@@ -47,7 +48,8 @@ struct ddsi_sertype {
   uint32_t typekind_no_key : 1;
   uint32_t request_keyhash : 1;
   uint32_t fixed_size : 1;
-  uint16_t min_xcdrv;  /* minimum XCDR version required for (de)serialization */
+  uint32_t allowed_data_representation; /* Allowed data representations set in IDL for this type, or DDS_DATA_REPRESENTATION_RESTRICT_DEFAULT in case of
+                                            no restrictions in the IDL. Unsupported representations for the type are left out when creating the sertype. */
   char *type_name;
   ddsrt_atomic_voidp_t gv; /* set during registration */
   ddsrt_atomic_uint32_t flags_refc; /* counts refs from entities (topic, reader, writer), not from data */

--- a/src/core/ddsi/src/ddsi_sertype.c
+++ b/src/core/ddsi/src/ddsi_sertype.c
@@ -180,7 +180,7 @@ void ddsi_sertype_init_flags (struct ddsi_sertype *tp, const char *type_name, co
   tp->typekind_no_key = (flags & DDSI_SERTYPE_FLAG_TOPICKIND_NO_KEY) ? 1u : 0u;
   tp->request_keyhash = (flags & DDSI_SERTYPE_FLAG_REQUEST_KEYHASH) ? 1u : 0u;
   tp->fixed_size = (flags & DDSI_SERTYPE_FLAG_FIXED_SIZE) ? 1u : 0u;
-  tp->min_xcdrv = CDR_ENC_VERSION_1;
+  tp->allowed_data_representation = DDS_DATA_REPRESENTATION_FLAG_XCDR1;
   tp->base_sertype = NULL;
   tp->wrapped_sertopic = NULL;
 #ifdef DDS_HAS_SHM

--- a/src/core/ddsi/src/ddsi_sertype_default.c
+++ b/src/core/ddsi/src/ddsi_sertype_default.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright(c) 2022 ZettaScale Technology
  * Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
  *
  * This program and the accompanying materials are made available under the
@@ -303,7 +304,10 @@ dds_return_t ddsi_sertype_default_init (const struct ddsi_domaingv *gv, struct d
   st->c.iox_size = desc->m_size;
 #endif
   st->c.fixed_size = (st->c.fixed_size || (desc->m_flagset & DDS_TOPIC_FIXED_SIZE)) ? 1u : 0u;
-  st->c.min_xcdrv = min_xcdrv;
+  st->c.allowed_data_representation = desc->m_flagset & DDS_TOPIC_RESTRICT_DATA_REPRESENTATION ?
+      desc->restrict_data_representation : DDS_DATA_REPRESENTATION_RESTRICT_DEFAULT;
+  if (min_xcdrv == CDR_ENC_VERSION_2)
+    st->c.allowed_data_representation &= ~DDS_DATA_REPRESENTATION_FLAG_XCDR1;
   st->encoding_format = ddsi_sertype_extensibility_enc_format (type_ext);
   st->encoding_version = data_representation == DDS_DATA_REPRESENTATION_XCDR1 ? CDR_ENC_VERSION_1 : CDR_ENC_VERSION_2;
   st->serpool = gv->serpool;

--- a/src/idl/include/idl/tree.h
+++ b/src/idl/include/idl/tree.h
@@ -574,7 +574,7 @@ IDL_EXPORT uint32_t idl_array_size(const void *node);
 IDL_EXPORT uint32_t idl_bound(const void *node);
 IDL_EXPORT const idl_literal_t *idl_default_value(const void *node);
 IDL_EXPORT bool idl_requires_xcdr2(const void *node);
-IDL_EXPORT allowable_data_representations_t idl_supported_data_representations(const void *node);
+IDL_EXPORT allowable_data_representations_t idl_allowable_data_representations(const void *node);
 IDL_EXPORT uint32_t idl_enum_max_value(const void *node);
 
 /* navigation */

--- a/src/idl/include/idl/tree.h
+++ b/src/idl/include/idl/tree.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright(c) 2022 ZettaScale Technology and others
  * Copyright(c) 2021 ADLINK Technology Limited and others
  *
  * This program and the accompanying materials are made available under the
@@ -201,11 +202,19 @@ enum idl_try_construct {
 };
 
 typedef uint32_t allowable_data_representations_t;
+#define IDL_ALLOWABLE_DATAREPRESENTATION_DEFAULT (0xffffffff)
 typedef enum {
   IDL_DATAREPRESENTATION_FLAG_XCDR1 = 0x1 << 0,
   IDL_DATAREPRESENTATION_FLAG_XML   = 0x1 << 1,
   IDL_DATAREPRESENTATION_FLAG_XCDR2 = 0x1 << 2
 } idl_data_representation_flags_t;
+
+typedef enum {
+  IDL_REQUIRES_XCDR2_UNSET,
+  IDL_REQUIRES_XCDR2_SETTING,
+  IDL_REQUIRES_XCDR2_TRUE,
+  IDL_REQUIRES_XCDR2_FALSE
+} idl_requires_xcdr2_t;
 
 /* most types have convenience members for information that is shared between
    generators or makes sense to calculate in advance. e.g. the field
@@ -350,6 +359,7 @@ struct idl_struct {
   idl_member_t *members;
   /* metadata */
   idl_keylist_t *keylist; /**< if type is a topic (#pragma keylist) */
+  idl_requires_xcdr2_t requires_xcdr2;
   IDL_ANNOTATABLE(uint32_t) id;
   IDL_ANNOTATABLE(idl_autoid_t) autoid;
   /* constructed types are not considered @nested types by default, implicitly
@@ -413,6 +423,7 @@ struct idl_union {
      implicit default case that does not reference any branch */
   idl_case_label_t *default_case;
   uint64_t unused_labels; /**< number of unused labels */
+  idl_requires_xcdr2_t requires_xcdr2;
   IDL_ANNOTATABLE(bool) nested; /**< if type is nested or a topic */
   IDL_ANNOTATABLE(idl_extensibility_t) extensibility;
   IDL_ANNOTATABLE(idl_autoid_t) autoid;
@@ -562,8 +573,8 @@ IDL_EXPORT const idl_name_t *idl_name(const void *node);
 IDL_EXPORT uint32_t idl_array_size(const void *node);
 IDL_EXPORT uint32_t idl_bound(const void *node);
 IDL_EXPORT const idl_literal_t *idl_default_value(const void *node);
-IDL_EXPORT bool idl_requires_xtypes_functionality(const void *node);
-IDL_EXPORT allowable_data_representations_t supported_data_representations(const void *node);
+IDL_EXPORT bool idl_requires_xcdr2(const void *node);
+IDL_EXPORT allowable_data_representations_t idl_supported_data_representations(const void *node);
 IDL_EXPORT uint32_t idl_enum_max_value(const void *node);
 
 /* navigation */

--- a/src/idl/src/annotation.c
+++ b/src/idl/src/annotation.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright(c) 2022 ZettaScale Technology and others
  * Copyright(c) 2021 ADLINK Technology Limited and others
  *
  * This program and the accompanying materials are made available under the
@@ -823,9 +824,6 @@ annotate_datarepresentation(
   idl_literal_t *literal = annotation_appl->parameters->const_expr;
   assert(idl_type(literal) == IDL_BITMASK);
   allowable_data_representations_t val = (allowable_data_representations_t)literal->value.uint32;  //native type of datarepresentation is uint32_t
-
-  if (idl_requires_xtypes_functionality(node))
-    val &= ~((allowable_data_representations_t)IDL_DATAREPRESENTATION_FLAG_XCDR1);
 
   if (0 == val) {
     idl_error(pstate, idl_location(annotation_appl),

--- a/src/idl/src/processor.c
+++ b/src/idl/src/processor.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright(c) 2022 ZettaScale Technology and others
  * Copyright(c) 2021 ADLINK Technology Limited and others
  *
  * This program and the accompanying materials are made available under the
@@ -472,6 +473,8 @@ grammar:
   if ((ret = validate_must_understand(pstate, pstate->root)))
     goto err;
   if ((ret = idl_propagate_autoid(pstate, pstate->root, IDL_SEQUENTIAL)) != IDL_RETCODE_OK)
+    goto err;
+  if ((ret = idl_set_xcdr2_required(pstate->root) != IDL_RETCODE_OK))
     goto err;
 
   if (pstate->keylists) {

--- a/src/idl/src/tree.c
+++ b/src/idl/src/tree.c
@@ -862,15 +862,15 @@ bool idl_requires_xcdr2(const void *node)
   return false;
 }
 
-allowable_data_representations_t idl_supported_data_representations(const void *node)
+allowable_data_representations_t idl_allowable_data_representations(const void *node)
 {
   if (node == NULL)
     return IDL_ALLOWABLE_DATAREPRESENTATION_DEFAULT;
   if (idl_is_alias(node))
-    return idl_supported_data_representations(idl_unalias(node));
+    return idl_allowable_data_representations(idl_unalias(node));
 
   return idl_has_data_representation(node) ?
-    idl_data_representation_value(node) : idl_supported_data_representations(idl_parent(node));
+    idl_data_representation_value(node) : idl_allowable_data_representations(idl_parent(node));
 }
 
 bool idl_is_sequence(const void *ptr)

--- a/src/idl/src/tree.c
+++ b/src/idl/src/tree.c
@@ -1297,8 +1297,6 @@ set_node_xcdr2_required(void *node)
     };
     _union->requires_xcdr2 = ret ? IDL_REQUIRES_XCDR2_TRUE : IDL_REQUIRES_XCDR2_FALSE;
     return ret;
-  } else if (idl_is_enum(node) || idl_is_bitmask(node)) {
-    return !idl_is_extensible(node, IDL_FINAL);
   }
 
   return false;

--- a/src/idl/src/tree.h
+++ b/src/idl/src/tree.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright(c) 2022 ZettaScale Technology and others
  * Copyright(c) 2021 ADLINK Technology Limited and others
  *
  * This program and the accompanying materials are made available under the
@@ -294,5 +295,9 @@ idl_create_inherit_spec(
   const idl_location_t *location,
   void *base,
   void *nodep);
+
+idl_retcode_t
+idl_set_xcdr2_required(
+  void *node);
 
 #endif /* TREE_H */

--- a/src/idl/tests/annotation.c
+++ b/src/idl/tests/annotation.c
@@ -1389,8 +1389,8 @@ test_rep(
 
   rep_test_t *test = (rep_test_t*)user_data;
 
-  allowable_data_representations_t result, required;
-    result = idl_supported_data_representations(node),
+  allowable_data_representations_t
+    result = idl_allowable_data_representations(node),
     required = test->reps[test->i++];
   if (idl_requires_xcdr2(node))
     result &= ~((allowable_data_representations_t)IDL_DATAREPRESENTATION_FLAG_XCDR1);

--- a/src/tools/idlc/src/descriptor.c
+++ b/src/tools/idlc/src/descriptor.c
@@ -2478,7 +2478,6 @@ static int print_descriptor(FILE *fp, struct descriptor *descriptor, bool type_i
         return -1;
       if (idl_fprintf(fp, "(1u << DDS_DATA_REPRESENTATION_XCDR2)") < 0)
         return -1;
-      first = false;
     }
   }
 
@@ -2646,7 +2645,7 @@ generate_descriptor_impl(
     descriptor->flags |= DDS_TOPIC_FIXED_KEY_XCDR2;
 
   /* set data representation restriction flag and mask (ignore unsupported data representations) */
-  allowable_data_representations_t dr = idl_supported_data_representations(descriptor->topic);
+  allowable_data_representations_t dr = idl_allowable_data_representations(descriptor->topic);
   if (dr != IDL_ALLOWABLE_DATAREPRESENTATION_DEFAULT && (dr & (IDL_DATAREPRESENTATION_FLAG_XCDR1 | IDL_DATAREPRESENTATION_FLAG_XCDR2))) {
     descriptor->flags |= DDS_TOPIC_RESTRICT_DATA_REPRESENTATION;
     descriptor->data_representations = dr;

--- a/src/tools/idlc/src/descriptor.h
+++ b/src/tools/idlc/src/descriptor.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright(c) 2022 ZettaScale Technology and others
  * Copyright(c) 2021 ADLINK Technology Limited and others
  *
  * This program and the accompanying materials are made available under the
@@ -151,6 +152,7 @@ struct descriptor {
   struct key_meta_data *keys; /**< key meta-data */
   uint32_t n_opcodes; /**< number of opcodes in descriptor */
   uint32_t flags; /**< topic descriptor flag values */
+  uint32_t data_representations; /**< restrict data representations for top-level type */
   uint32_t keysz_xcdr1; /**< size of the XCDR1 serialized key (or set to MAX_FIXED_KEY + 1 if more than MAX_FIXED_KEY) */
   uint32_t keysz_xcdr2; /**< size of the XCDR2 serialized key (or set to MAX_FIXED_KEY + 1 if more than MAX_FIXED_KEY) */
   struct stack_type *type_stack;

--- a/src/tools/pubsub/testtype.c
+++ b/src/tools/pubsub/testtype.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright(c) 2022 ZettaScale Technology and others
  * Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
  *
  * This program and the accompanying materials are made available under the
@@ -40,6 +41,7 @@ const dds_topic_descriptor_t OneULong_desc =
   "<MetaData version=\"1.0.0\"><Struct name=\"OneULong\"><Member name=\"seq\"><ULong/></Member></Struct></MetaData>",
   { NULL, 0 },
   { NULL, 0 },
+  0
 };
 
 
@@ -69,6 +71,7 @@ const dds_topic_descriptor_t Keyed32_desc =
   "<MetaData version=\"1.0.0\"><Struct name=\"Keyed32\"><Member name=\"seq\"><ULong/></Member><Member name=\"keyval\"><Long/></Member><Member name=\"baggage\"><Array size=\"24\"><Octet/></Array></Member></Struct></MetaData>",
   { NULL, 0 },
   { NULL, 0 },
+  0
 };
 
 
@@ -98,6 +101,7 @@ const dds_topic_descriptor_t Keyed64_desc =
   "<MetaData version=\"1.0.0\"><Struct name=\"Keyed64\"><Member name=\"seq\"><ULong/></Member><Member name=\"keyval\"><Long/></Member><Member name=\"baggage\"><Array size=\"56\"><Octet/></Array></Member></Struct></MetaData>",
   { NULL, 0 },
   { NULL, 0 },
+  0
 };
 
 
@@ -127,6 +131,7 @@ const dds_topic_descriptor_t Keyed128_desc =
   "<MetaData version=\"1.0.0\"><Struct name=\"Keyed128\"><Member name=\"seq\"><ULong/></Member><Member name=\"keyval\"><Long/></Member><Member name=\"baggage\"><Array size=\"120\"><Octet/></Array></Member></Struct></MetaData>",
   { NULL, 0 },
   { NULL, 0 },
+  0
 };
 
 
@@ -156,6 +161,7 @@ const dds_topic_descriptor_t Keyed256_desc =
   "<MetaData version=\"1.0.0\"><Struct name=\"Keyed256\"><Member name=\"seq\"><ULong/></Member><Member name=\"keyval\"><Long/></Member><Member name=\"baggage\"><Array size=\"248\"><Octet/></Array></Member></Struct></MetaData>",
   { NULL, 0 },
   { NULL, 0 },
+  0
 };
 
 
@@ -185,4 +191,5 @@ const dds_topic_descriptor_t KeyedSeq_desc =
   "<MetaData version=\"1.0.0\"><Struct name=\"KeyedSeq\"><Member name=\"seq\"><ULong/></Member><Member name=\"keyval\"><Long/></Member><Member name=\"baggage\"><Sequence><Octet/></Sequence></Member></Struct></MetaData>",
   { NULL, 0 },
   { NULL, 0 },
+  0
 };


### PR DESCRIPTION
This PR adds support for the data representation annotation and includes some refactoring and fixes for parsing and handling this annotation in IDLC:
- 159a1ed3d3a5f59f37265567db1940cc3834b741 adds a `requires_xcdr2` field to struct and union nodes in the IDLC node tree, so that the allowed data representations and required xcdr version are stored independently. The function `idl_allowable_data_representations` (renamed from `supported_data_representations`) now returns all representations set using the annotation, not only the supported ones. To filter out unsupported representation, a backend can use the `requires_xcdr2` flag, that is set on aggregated types. 
- In 2994ed57893300a3f2b4d83d49807e0556a8780a the code in IDLC C-backend to set the allowed data representations in the topic descriptor is added
- Commit 74e78c4ef1ab941120dafce8d2020d60f8100085 adds the implementation for using the data representation restrictions from IDL annotations in DDSI, and included a test case for combinations of annotation and qos values for data representation. 