### PR TITLE
Fix bug in cdrstream extract key skip union

### DIFF
--- a/src/core/ddsi/src/ddsi_cdrstream.c
+++ b/src/core/ddsi/src/ddsi_cdrstream.c
@@ -3495,7 +3495,7 @@ static const uint32_t *dds_stream_extract_key_from_data_skip_union (dds_istream_
   const uint32_t disc = read_union_discriminant (is, insn);
   uint32_t const * const jeq_op = find_union_case (ops, disc);
   if (jeq_op)
-    dds_stream_extract_key_from_data_skip_subtype (is, 1, insn, DDS_JEQ_TYPE (jeq_op[0]), jeq_op + DDS_OP_ADR_JSR (jeq_op[0]));
+    dds_stream_extract_key_from_data_skip_subtype (is, 1, jeq_op[0], DDS_JEQ_TYPE (jeq_op[0]), jeq_op + DDS_OP_ADR_JSR (jeq_op[0]));
   return ops + DDS_OP_ADR_JMP (ops[3]);
 }
 

--- a/src/tools/idlc/xtests/CMakeLists.txt
+++ b/src/tools/idlc/xtests/CMakeLists.txt
@@ -30,6 +30,7 @@ set(_sources
   test_enum.idl
   test_bool.idl
   test_bitmask.idl
+  test_struct_keys.idl
 )
 
 set(_includes "${_includes}\\;${CMAKE_SOURCE_DIR}/src/core/ddsc/include")

--- a/src/tools/idlc/xtests/test_struct_keys.idl
+++ b/src/tools/idlc/xtests/test_struct_keys.idl
@@ -1,0 +1,78 @@
+/*
+ * Copyright(c) 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+#if defined(__IDLC__)
+
+@bit_bound(10)
+enum e { E1, E2, E3 };
+
+@nested @final
+union u switch (short) {
+case 1:
+   e u1;
+default:
+   long ud;
+};
+
+@topic @final
+struct test_struct_keys {
+  u f1;
+  @key char f2;
+  u f3;
+  @key char f4[2];
+};
+
+#else
+
+#include "dds/dds.h"
+#include "test_struct_keys.h"
+#include "common.h"
+
+const dds_topic_descriptor_t *desc = &test_struct_keys_desc;
+
+void init_sample (void *s)
+{
+  test_struct_keys *s1 = (test_struct_keys *) s;
+  s1->f1._d = 1;
+  s1->f1._u.u1 = E2;
+  s1->f2 = 'a';
+  s1->f3._d = 1;
+  s1->f3._u.u1 = E3;
+  s1->f4[0] = 'b';
+  s1->f4[1] = 'c';
+}
+
+int cmp_sample (const void *sa, const void *sb)
+{
+  test_struct_keys *a = (test_struct_keys *) sa;
+  test_struct_keys *b = (test_struct_keys *) sb;
+  CMP(a, b, f1._d, 1);
+  CMP(a, b, f1._u.u1, E2);
+  CMP(a, b, f2, 'a');
+  CMP(a, b, f3._d, 1);
+  CMP(a, b, f3._u.u1, E3);
+  CMP(a, b, f4[0], 'b');
+  CMP(a, b, f4[1], 'c');
+  return 0;
+}
+
+int cmp_key (const void *sa, const void *sb)
+{
+  test_struct_keys *a = (test_struct_keys *) sa;
+  test_struct_keys *b = (test_struct_keys *) sb;
+  CMP(a, b, f2, 'a');
+  CMP(a, b, f4[0], 'b');
+  CMP(a, b, f4[1], 'c');
+  return 0;
+}
+
+#endif


### PR DESCRIPTION
In `dds_stream_extract_key_from_data_skip_union` the wrong `ops` pointer was passed to the `skip_subtype` function, which causes the key extraction to fail in case of a non-key union member with a selected case that has an enum type with size > 8 bits. 