### PR TITLE
Support annotations parameters in idl is string

### DIFF
--- a/src/idl/src/tree.c
+++ b/src/idl/src/tree.c
@@ -945,7 +945,7 @@ bool idl_is_string(const void *ptr)
 {
 #if !defined(NDEBUG)
   static const idl_mask_t mask = IDL_CONST | IDL_TYPEDEF | IDL_MEMBER |
-                                 IDL_CASE | IDL_SEQUENCE |
+                                 IDL_CASE | IDL_SEQUENCE | IDL_ANNOTATION_APPL_PARAM |
                                  IDL_SWITCH_TYPE_SPEC;
 #endif
   const idl_string_t *node = ptr;

--- a/src/idl/tests/annotation.c
+++ b/src/idl/tests/annotation.c
@@ -1466,3 +1466,24 @@ CU_Test(idl_annotation, data_representation)
 #undef XCDR2
 #undef XML
 #undef DEFAULT
+
+CU_Test(idl_annotation, idl_is_string_fix)
+{
+  idl_pstate_t *pstate = NULL;
+  idl_retcode_t ret = parse_string(IDL_FLAG_ANNOTATIONS, "struct s { @default(\"abcdef\") string str;};", &pstate);
+  CU_ASSERT_EQUAL(ret, IDL_RETCODE_OK);
+
+  if (ret)
+    return;
+
+  const idl_struct_t *_struct = (const idl_struct_t*)pstate->root;
+  CU_ASSERT_FATAL(idl_is_struct(pstate->root));
+
+  const idl_member_t *_member = _struct->members;
+  CU_ASSERT_FATAL(idl_is_member(_member));
+
+  CU_ASSERT_FATAL(_member->value.annotation != NULL);
+  CU_ASSERT(idl_is_string(_member->value.value));
+
+  idl_delete_pstate(pstate);
+}

--- a/src/idl/tests/annotation.c
+++ b/src/idl/tests/annotation.c
@@ -1214,7 +1214,6 @@ static void test_min_max(minmax_test_t test)
 {
   idl_pstate_t *pstate = NULL;
   idl_retcode_t ret = parse_string(IDL_FLAG_ANNOTATIONS, test.s, &pstate);
-  if (ret != test.ret)
   CU_ASSERT_EQUAL(ret, test.ret);
 
   if (ret)
@@ -1319,7 +1318,6 @@ static void test_unit(unit_test_t test)
 {
   idl_pstate_t *pstate = NULL;
   idl_retcode_t ret = parse_string(IDL_FLAG_ANNOTATIONS, test.s, &pstate);
-  if (ret != test.ret)
   CU_ASSERT_EQUAL(ret, test.ret);
 
   if (ret)
@@ -1402,7 +1400,6 @@ static void test_representation(rep_test_t test)
 {
   idl_pstate_t *pstate = NULL;
   idl_retcode_t ret = parse_string(IDL_FLAG_ANNOTATIONS, test.s, &pstate);
-  if (ret != test.ret)
   CU_ASSERT_EQUAL(ret, test.ret);
 
   if (ret)

--- a/src/idl/tests/parser.c
+++ b/src/idl/tests/parser.c
@@ -273,6 +273,8 @@ static void test_require_xcdr2(rep_req_xcdr2_t *test)
   idl_retcode_t ret = idl_create_pstate(IDL_FLAG_ANNOTATIONS, NULL, &pstate);
   CU_ASSERT_EQUAL_FATAL(ret, IDL_RETCODE_OK);
   CU_ASSERT_PTR_NOT_NULL_FATAL(pstate);
+  if (!pstate)
+    return;
   pstate->config.default_extensibility = IDL_FINAL;
   ret = idl_parse_string(pstate, test->idl);
   CU_ASSERT_EQUAL(ret, IDL_RETCODE_OK);


### PR DESCRIPTION
This fixes a bug which occurs when calling idl_is_string on an idl_literal_t whose parent is an idl_annotation_appl_param_t, which happens in the case that a string literal is a parameter of an annotation