### PR TITLE
Sertype opt_size for each supported data representation

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/ddsi_serdata_default.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_serdata_default.h
@@ -142,11 +142,12 @@ struct ddsi_sertype_default_desc {
 
 struct ddsi_sertype_default {
   struct ddsi_sertype c;
-  uint16_t encoding_format; /* CDR_ENC_FORMAT_(PLAIN|DELIMITED|PL) */
-  uint16_t encoding_version; /* CDR_ENC_VERSION_(1|2) */
+  uint16_t encoding_format; /* CDR_ENC_FORMAT_(PLAIN|DELIMITED|PL) - CDR encoding format for the top-level type in this sertype */
+  uint16_t write_encoding_version; /* CDR_ENC_VERSION_(1|2) - CDR encoding version used for writing data using this sertype */
   struct serdatapool *serpool;
   struct ddsi_sertype_default_desc type;
-  size_t opt_size;
+  size_t opt_size_xcdr1;
+  size_t opt_size_xcdr2;
 };
 
 struct ddsi_plist_sample {

--- a/src/core/ddsi/src/ddsi_cdrstream.c
+++ b/src/core/ddsi/src/ddsi_cdrstream.c
@@ -1299,9 +1299,10 @@ inline bool dds_stream_write_sample (dds_ostream_t * __restrict os, const void *
 bool dds_stream_write_sampleLE (dds_ostreamLE_t * __restrict os, const void * __restrict data, const struct ddsi_sertype_default * __restrict type)
 {
   const struct ddsi_sertype_default_desc *desc = &type->type;
-  if (type->opt_size && desc->align && (((struct dds_ostream *)os)->m_index % desc->align) == 0)
+  size_t opt_size = os->x.m_xcdr_version == CDR_ENC_VERSION_1 ? type->opt_size_xcdr1 : type->opt_size_xcdr2;
+  if (opt_size && desc->align && (((struct dds_ostream *)os)->m_index % desc->align) == 0)
   {
-    dds_os_put_bytes ((struct dds_ostream *)os, data, (uint32_t) type->opt_size);
+    dds_os_put_bytes ((struct dds_ostream *)os, data, (uint32_t) opt_size);
     return true;
   }
   else
@@ -1360,9 +1361,10 @@ bool dds_stream_write_sampleLE (dds_ostreamLE_t * __restrict os, const void * __
 bool dds_stream_write_sampleBE (dds_ostreamBE_t * __restrict os, const void * __restrict data, const struct ddsi_sertype_default * __restrict type)
 {
   const struct ddsi_sertype_default_desc *desc = &type->type;
-  if (type->opt_size && desc->align && (((struct dds_ostream *)os)->m_index % desc->align) == 0)
+  size_t opt_size = os->x.m_xcdr_version == CDR_ENC_VERSION_1 ? type->opt_size_xcdr1 : type->opt_size_xcdr2;
+  if (opt_size && desc->align && (((struct dds_ostream *)os)->m_index % desc->align) == 0)
   {
-    dds_os_put_bytes ((struct dds_ostream *)os, data, (uint32_t) type->opt_size);
+    dds_os_put_bytes ((struct dds_ostream *)os, data, (uint32_t) opt_size);
     return true;
   }
   else
@@ -3537,12 +3539,13 @@ static const uint32_t *dds_stream_extract_key_from_data_skip_adr (dds_istream_t 
 void dds_stream_read_sample (dds_istream_t * __restrict is, void * __restrict data, const struct ddsi_sertype_default * __restrict type)
 {
   const struct ddsi_sertype_default_desc *desc = &type->type;
-  if (type->opt_size)
+  size_t opt_size = is->m_xcdr_version == CDR_ENC_VERSION_1 ? type->opt_size_xcdr1 : type->opt_size_xcdr2;
+  if (opt_size)
   {
     /* Layout of struct & CDR is the same, but sizeof(struct) may include padding at
-       the end that is not present in CDR, so we must use type->opt_size to avoid a
+       the end that is not present in CDR, so we must use type->opt_size_xcdrx to avoid a
        potential out-of-bounds read */
-    dds_is_get_bytes (is, data, (uint32_t) type->opt_size, 1);
+    dds_is_get_bytes (is, data, (uint32_t) opt_size, 1);
   }
   else
   {

--- a/src/core/ddsi/src/ddsi_serdata_default.c
+++ b/src/core/ddsi/src/ddsi_serdata_default.c
@@ -475,7 +475,7 @@ static struct ddsi_serdata* serdata_default_from_received_iox_buffer(const struc
 
   const struct ddsi_sertype_default* tp = (const struct ddsi_sertype_default*)tpcmn;
 
-  struct ddsi_serdata_default *d = serdata_default_new_size (tp, kind, ice_hdr->data_size, tp->encoding_version);
+  struct ddsi_serdata_default *d = serdata_default_new_size (tp, kind, ice_hdr->data_size, tp->write_encoding_version);
 
   // note: we do not deserialize or memcpy here, just take ownership of the chunk
   d->c.iox_chunk = iox_buffer;
@@ -495,7 +495,7 @@ static struct ddsi_serdata* serdata_default_from_received_iox_buffer(const struc
 static struct ddsi_serdata *ddsi_serdata_default_from_loaned_sample (const struct ddsi_sertype *type, enum ddsi_serdata_kind kind, const char *sample)
 {
   const struct ddsi_sertype_default *t = (const struct ddsi_sertype_default *)type;
-  struct ddsi_serdata_default *d = serdata_default_new (t, kind, t->encoding_version);
+  struct ddsi_serdata_default *d = serdata_default_new (t, kind, t->write_encoding_version);
 
   if(d == NULL)
     return NULL;
@@ -541,7 +541,9 @@ static struct ddsi_serdata_default *serdata_default_from_sample_cdr_common (cons
 
       /* FIXME: detect cases where the XCDR1 and 2 representations are equal,
          so that we could alias the XCDR1 key from d->data */
-      if (tp->encoding_version == CDR_ENC_VERSION_2)
+      /* FIXME: use CDR encoding version used by the writer, not the write encoding
+         of the sertype */
+      if (tp->write_encoding_version == CDR_ENC_VERSION_2)
       {
         d->key.buftype = KEYBUFTYPE_DYNALIAS;
         // dds_ostream_add_to_serdata_default pads the size to a multiple of 4,


### PR DESCRIPTION
Sertype needs an `opt_size` for each data representation, because a reader uses the same sertype instance for reading xcdrv1 and xcdrv2 data. Also rename `sertype.encoding_version` to indicate it should only be used for writing data, not for reading.