### PR TITLE
Add idlc warnings for unsupported try_construct and default_literal annotations

### DIFF
--- a/src/core/ddsc/tests/DataRepresentationTypes.idl
+++ b/src/core/ddsc/tests/DataRepresentationTypes.idl
@@ -115,6 +115,13 @@ module DataRepresentationTypes {
     long f1;
   };
 
+/*
+  @appendable @topic @data_representation(XCDR1)
+  struct TypeXcdrA1 {
+    long f1;
+  };
+*/
+
   @appendable @topic @data_representation(XCDR2)
   struct TypeXcdrA2 {
     long f1;

--- a/src/core/ddsc/tests/data_representation.c
+++ b/src/core/ddsc/tests/data_representation.c
@@ -492,6 +492,7 @@ CU_Test(ddsc_data_representation, qos_annotation, .init = data_representation_in
     { &DESC(TypeXcdr1_xml_2), { { X_, true,  X1_2 }, { X1, true,  X1 }, { X2, true,  X2 }, { X1_2, true,  X1_2 } } },
     { &DESC(TypeXcdr1_other), { { X_, true,  X1 },   { X1, true,  X1 }, { X2, false, X_ }, { X1_2, false, X_   } } },
     { &DESC(TypeXcdr2_other), { { X_, true,  X2 },   { X1, false, X_ }, { X2, true,  X2 }, { X1_2, false, X_   } } },
+    //{ &DESC(TypeXcdrA1),      { { X_, false, X_ },   { X1, false, X_ }, { X2, false, X_ }, { X1_2, false, X_   } } },
     { &DESC(TypeXcdrA2),      { { X_, true,  X2 },   { X1, false, X_ }, { X2, true,  X2 }, { X1_2, false, X_   } } },
     { &DESC(TypeXcdrA1_2),    { { X_, true,  X2 },   { X1, false, X_ }, { X2, true,  X2 }, { X1_2, false, X_   } } },
   };

--- a/src/idl/src/annotation.c
+++ b/src/idl/src/annotation.c
@@ -322,6 +322,13 @@ annotate_extensibility(
     }
   }
 
+  //check that extensibility does not clash with datarepresentation value
+  if (IDL_FINAL != extensibility && !(idl_allowable_data_representations(node) & IDL_DATAREPRESENTATION_FLAG_XCDR2)) {
+    idl_error(pstate, idl_location(annotation_appl),
+      "Non-final extensibility set while datarepresentation requires XCDR2");
+    return IDL_RETCODE_SEMANTIC_ERROR;
+  }
+
   *annotationp = annotation_appl;
   *extensibilityp = extensibility;
   return IDL_RETCODE_OK;
@@ -835,9 +842,19 @@ annotate_datarepresentation(
     ((idl_module_t*)node)->data_representation.annotation = annotation_appl;
     ((idl_module_t*)node)->data_representation.value = val;
   } else if (idl_is_struct(node)) {
+    if (IDL_FINAL != ((idl_struct_t*)node)->extensibility.value && !(val & IDL_DATAREPRESENTATION_FLAG_XCDR2)) {
+      idl_error(pstate, idl_location(annotation_appl),
+        "Datarepresentation does not support XCDR2, but non-final extensibility set.");
+      return IDL_RETCODE_SEMANTIC_ERROR;
+    }
     ((idl_struct_t*)node)->data_representation.annotation = annotation_appl;
     ((idl_struct_t*)node)->data_representation.value = val;
   } else if (idl_is_union(node)) {
+    if (IDL_FINAL != ((idl_union_t*)node)->extensibility.value && !(val & IDL_DATAREPRESENTATION_FLAG_XCDR2)) {
+      idl_error(pstate, idl_location(annotation_appl),
+        "Datarepresentation does not support XCDR2, but non-final extensibility set.");
+      return IDL_RETCODE_SEMANTIC_ERROR;
+    }
     ((idl_union_t*)node)->data_representation.annotation = annotation_appl;
     ((idl_union_t*)node)->data_representation.value = val;
   } else {

--- a/src/tools/idlc/src/descriptor.c
+++ b/src/tools/idlc/src/descriptor.c
@@ -858,6 +858,9 @@ emit_case(
     const idl_case_label_t *label;
     const idl_type_spec_t *type_spec;
 
+    if (_case->try_construct.annotation)
+      idl_warning(pstate, IDL_WARN_UNSUPPORTED_ANNOTATIONS, idl_location(node), "The @try_construct annotation is not supported yet in the C generator, the default try-construct behavior will be used");
+
     type_spec = idl_strip(idl_type_spec(node), IDL_STRIP_ALIASES|IDL_STRIP_FORWARD);
     if (idl_is_external(node) && !idl_is_unbounded_string(type_spec))
       opcode |= DDS_OP_FLAG_EXT;
@@ -1460,7 +1463,9 @@ emit_member(
   (void)user_data;
   const idl_member_t *member = (const idl_member_t *)node;
   if (member->value.annotation)
-    idl_warning(pstate, IDL_WARN_GENERIC, idl_location(node), "Explicit defaults are not supported yet in the C generator, the value from the @default annotation will not be used");
+    idl_warning(pstate, IDL_WARN_UNSUPPORTED_ANNOTATIONS, idl_location(node), "Explicit defaults are not supported yet in the C generator, the value from the @default annotation will not be used");
+  if (member->try_construct.annotation)
+    idl_warning(pstate, IDL_WARN_UNSUPPORTED_ANNOTATIONS, idl_location(node), "The @try_construct annotation is not supported yet in the C generator, the default try-construct behavior will be used");
   return IDL_RETCODE_OK;
 }
 
@@ -1477,7 +1482,7 @@ emit_bitmask(
   (void)user_data;
   const idl_bitmask_t *bitmask = (const idl_bitmask_t *)node;
   if (bitmask->extensibility.annotation && bitmask->extensibility.value != IDL_FINAL)
-    idl_warning(pstate, IDL_WARN_GENERIC, idl_location(node), "Extensibility appendable and mutable for bitmask type are not yet supported in the C generator, the extensibility will not be used");
+    idl_warning(pstate, IDL_WARN_UNSUPPORTED_ANNOTATIONS, idl_location(node), "Extensibility appendable and mutable for bitmask type are not yet supported in the C generator, the extensibility will not be used");
   return IDL_RETCODE_OK;
 }
 
@@ -1494,6 +1499,8 @@ emit_enum(
   (void)user_data;
   const idl_enum_t *_enum = (const idl_enum_t *)node;
   uint32_t value = 0, value_c = 0;
+  if (_enum->default_enumerator && idl_mask(_enum->default_enumerator) == IDL_DEFAULT_ENUMERATOR)
+    idl_warning(pstate, IDL_WARN_UNSUPPORTED_ANNOTATIONS, idl_location(node), "The @default_literal annotation is not supported yet in the C generator and will not be used");
   for (idl_enumerator_t *e1 = _enum->enumerators; e1; e1 = idl_next(e1), value++) {
     if (e1->value.annotation)
       value = e1->value.value;


### PR DESCRIPTION
Add warnings in idlc for unsupported try_construct and default_literal annotations in the C generator. 

Note: this PR includes the commits from #1194, because it is using `IDL_WARN_UNSUPPORTED_ANNOTATIONS` introduced there