### PR TITLE
Array of bitmask or enum in xcdr2 cannot be optimized

### DIFF
--- a/src/core/ddsc/tests/CdrStreamOptimize.idl
+++ b/src/core/ddsc/tests/CdrStreamOptimize.idl
@@ -112,4 +112,17 @@ module CdrStreamOptimize {
     long f1;
     n4 f2;
   };
+
+  @bit_bound(8)
+  bitmask bm1 { B1, B2, B3 };
+
+  @final
+  struct t10 {
+    bm1 f1[3];
+  };
+
+  @final
+  struct t11 {
+    en1 f1[3];
+  };
 };

--- a/src/core/ddsc/tests/cdrstream.c
+++ b/src/core/ddsc/tests/cdrstream.c
@@ -1859,10 +1859,12 @@ CU_TheoryDataPoints (ddsc_cdrstream, check_optimize) = {
                                                  |      |        |        |      |      |      |        |        |      / array of non-primitive type is currently not optimized (FIXME: could be optimized for XCDR1?)
                                                  |      |        |        |      |      |      |        |        |      |      / CDR and memory have equal alignment
                                                  |      |        |        |      |      |      |        |        |      |      |      / field f2 is 1-byte aligned in CDR (because of 1-byte type in nested type), but 2-byte in memory
-                                                 |      |        |        |      |      |      |        |        |      |      |      |      / type of f2 is appendable */
-  CU_DataPoints (const dds_topic_descriptor_t *, D(t1), D(t1_a), D(t1_m), D(t2), D(t3), D(t4), D(t4_1), D(t4_2), D(t5), D(t6), D(t7), D(t8), D(t9) ),
-  CU_DataPoints (size_t,                         4,     0,       0,       16,    0,     5,     13,      29,      16,    0,     16,    0,     0     ), /* optimized size xcdr1 */
-  CU_DataPoints (size_t,                         4,     0,       0,       0,     0,     5,     13,      29,      0,     0,     16,    0,     0     )  /* optimized size xcdr2 */
+                                                 |      |        |        |      |      |      |        |        |      |      |      |      / type of f2 is appendable
+                                                 |      |        |        |      |      |      |        |        |      |      |      |      |      / bitmask (bit bound 8) array (dheader in v2)
+                                                 |      |        |        |      |      |      |        |        |      |      |      |      |      |       / enum (bit bound 32) array (dheader in v2) */
+  CU_DataPoints (const dds_topic_descriptor_t *, D(t1), D(t1_a), D(t1_m), D(t2), D(t3), D(t4), D(t4_1), D(t4_2), D(t5), D(t6), D(t7), D(t8), D(t9), D(t10), D(t11) ),
+  CU_DataPoints (size_t,                         4,     0,       0,       16,    0,     5,     13,      29,      16,    0,     16,    0,     0,     3,      12     ), /* optimized size xcdr1 */
+  CU_DataPoints (size_t,                         4,     0,       0,       0,     0,     5,     13,      29,      0,     0,     16,    0,     0,     0,      0      )  /* optimized size xcdr2 */
 };
 
 CU_Theory ((const dds_topic_descriptor_t *desc, size_t opt_size_xcdr1, size_t opt_size_xcdr2), ddsc_cdrstream, check_optimize)

--- a/src/core/ddsi/src/ddsi_cdrstream.c
+++ b/src/core/ddsi/src/ddsi_cdrstream.c
@@ -596,11 +596,15 @@ static uint32_t dds_stream_check_optimize1 (const struct ddsi_sertype_default_de
             ops += 3;
             break;
           case DDS_OP_VAL_ENU:
+            if (xcdr_version == CDR_ENC_VERSION_2) /* xcdr2 arrays have a dheader for non-primitive types */
+              return 0;
             if (DDS_OP_TYPE_SZ (insn) != 4 || !check_optimize_impl (xcdr_version, ops, sizeof (uint32_t), ops[2], &off, member_offs))
               return 0;
             ops += 4;
             break;
           case DDS_OP_VAL_BMK:
+            if (xcdr_version == CDR_ENC_VERSION_2) /* xcdr2 arrays have a dheader for non-primitive types */
+              return 0;
             if (!check_optimize_impl (xcdr_version, ops, DDS_OP_TYPE_SZ (insn), ops[2], &off, member_offs))
               return 0;
             ops += 5;


### PR DESCRIPTION
Because arrays of a non-primitive type have a DHEADER in xcdrv2, messages containing an array with bitmask or enum element type cannot be optimized (memcpy'ed) in the serializer. 