### PR TITLE
Exclude iceoryx from windows build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,7 +40,13 @@ if(ENABLE_SOURCE_SPECIFIC_MULTICAST)
 endif()
 
 # Prefer iceoryx integration but do not require it.
-set(ENABLE_SHM "AUTO" CACHE STRING "Enable shared memory support")
+if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+  set(ENABLE_SHM "OFF" CACHE STRING "Disable shared memory support")
+  message(STATUS "Warning: iceoryx binding for Windows currently not supported")
+else()
+  set(ENABLE_SHM "AUTO" CACHE STRING "Enable shared memory support")
+endif()
+
 set_property(CACHE ENABLE_SHM PROPERTY STRINGS ON OFF AUTO)
 if(ENABLE_SHM)
   if(NOT ENABLE_SHM STREQUAL "AUTO")


### PR DESCRIPTION
Signed-off-by: Dietrich Krönke <dietrich.kroenke@apex.ai>

@eboasson This excludes iceoryx from the windows build

- Closes #1208 