### PR TITLE
Bit bound validation

### DIFF
--- a/src/idl/src/annotation.c
+++ b/src/idl/src/annotation.c
@@ -982,12 +982,6 @@ annotate_bit_bound(
     idl_bitmask_t *bm = (idl_bitmask_t *)node;
     bm->bit_bound.annotation = annotation_appl;
     bm->bit_bound.value = value;
-    for (idl_bit_value_t *e1 = bm->bit_values; e1; e1 = idl_next(e1)) {
-      if (e1->position.value >= bm->bit_bound.value) {
-        idl_error(pstate, idl_location(e1), "Position overflow for bit value '%s' (%u), bit_bound is %u", e1->name->identifier, (unsigned) e1->position.value, (unsigned) bm->bit_bound.value);
-        return IDL_RETCODE_OUT_OF_RANGE;
-      }
-    }
   } else if (idl_is_enum(node)) {
     if (value == 0 || value > 32) {
       idl_error(pstate, idl_location(annotation_appl),
@@ -997,12 +991,6 @@ annotate_bit_bound(
     idl_enum_t *_enum = (idl_enum_t *)node;
     _enum->bit_bound.annotation = annotation_appl;
     _enum->bit_bound.value = value;
-    for (idl_enumerator_t *e1 = _enum->enumerators; e1; e1 = idl_next(e1)) {
-      if (e1->value.value >= (1ull << _enum->bit_bound.value)) {
-        idl_error(pstate, idl_location(e1), "Enumerator value (%u) overflow, bit_bound is %u", e1->value.value, _enum->bit_bound.value);
-        return IDL_RETCODE_OUT_OF_RANGE;
-      }
-    }
   } else {
     idl_error(pstate, idl_location(annotation_appl),
       "@bit_bound can only be applied to enum and bitmask types");

--- a/src/idl/src/parser.c
+++ b/src/idl/src/parser.c
@@ -1,4 +1,4 @@
-/* A Bison parser, made by GNU Bison 3.5.1.  */
+/* A Bison parser, made by GNU Bison 3.7.  */
 
 /* Bison implementation for Yacc-like parsers in C
 
@@ -34,6 +34,10 @@
 /* C LALR(1) parser skeleton written by Richard Stallman, by
    simplifying the original so-called "semantic" parser.  */
 
+/* DO NOT RELY ON FEATURES THAT ARE NOT DOCUMENTED in the manual,
+   especially those whose name start with YY_ or yy_.  They are
+   private implementation details that can be changed or removed.  */
+
 /* All symbols defined below should begin with yy or YY, to avoid
    infringing on user name space.  This should be done even for local
    variables, as they might otherwise be expanded by user macros.
@@ -41,14 +45,11 @@
    define necessary library symbols; they are noted "INFRINGES ON
    USER NAME SPACE" below.  */
 
-/* Undocumented macros, especially those whose name start with YY_,
-   are private implementation details.  Do not rely on them.  */
-
 /* Identify Bison output.  */
 #define YYBISON 1
 
 /* Bison version.  */
-#define YYBISON_VERSION "3.5.1"
+#define YYBISON_VERSION "3.7"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -68,6 +69,7 @@
 /* Substitute the variable and function names.  */
 #define yypush_parse    idl_yypush_parse
 #define yypstate_new    idl_yypstate_new
+#define yypstate_clear  idl_yypstate_clear
 #define yypstate_delete idl_yypstate_delete
 #define yypstate        idl_yypstate
 #define yylex           idl_yylex
@@ -149,7 +151,7 @@ static void yyerror(idl_location_t *, idl_pstate_t *, idl_retcode_t *, const cha
 #define TRY(action) \
   TRY_EXCEPT((action), 0)
 
-#line 153 "parser.c"
+#line 155 "parser.c"
 
 # ifndef YY_CAST
 #  ifdef __cplusplus
@@ -172,202 +174,186 @@ static void yyerror(idl_location_t *, idl_pstate_t *, idl_retcode_t *, const cha
 #  endif
 # endif
 
-/* Enabling verbose error messages.  */
-#ifdef YYERROR_VERBOSE
-# undef YYERROR_VERBOSE
-# define YYERROR_VERBOSE 1
-#else
-# define YYERROR_VERBOSE 0
-#endif
-
-/* Use api.header.include to #include this header
-   instead of duplicating it here.  */
-#ifndef YY_IDL_YY_PARSER_H_INCLUDED
-# define YY_IDL_YY_PARSER_H_INCLUDED
-/* Debug traces.  */
-#ifndef IDL_YYDEBUG
-# if defined YYDEBUG
-#if YYDEBUG
-#   define IDL_YYDEBUG 1
-#  else
-#   define IDL_YYDEBUG 0
-#  endif
-# else /* ! defined YYDEBUG */
-#  define IDL_YYDEBUG 1
-# endif /* ! defined YYDEBUG */
-#endif  /* ! defined IDL_YYDEBUG */
-#if IDL_YYDEBUG
-extern int idl_yydebug;
-#endif
-/* "%code requires" blocks.  */
-#line 85 "src/parser.y"
-
-#include "tree.h"
-
-/* make yytoknum available */
-#define YYPRINT(A,B,C) (void)0
-/* use YYLTYPE definition below */
-#define IDL_YYLTYPE_IS_DECLARED
-typedef struct idl_location IDL_YYLTYPE;
-
-#define LOC(first, last) \
-  &(IDL_YYLTYPE){ first, last }
-
-#line 217 "parser.c"
-
-/* Token type.  */
-#ifndef IDL_YYTOKENTYPE
-# define IDL_YYTOKENTYPE
-  enum idl_yytokentype
-  {
-    IDL_TOKEN_LINE_COMMENT = 258,
-    IDL_TOKEN_COMMENT = 259,
-    IDL_TOKEN_PP_NUMBER = 260,
-    IDL_TOKEN_IDENTIFIER = 261,
-    IDL_TOKEN_CHAR_LITERAL = 262,
-    IDL_TOKEN_STRING_LITERAL = 263,
-    IDL_TOKEN_INTEGER_LITERAL = 264,
-    IDL_TOKEN_FLOATING_PT_LITERAL = 265,
-    IDL_TOKEN_ANNOTATION_SYMBOL = 266,
-    IDL_TOKEN_ANNOTATION = 267,
-    IDL_TOKEN_SCOPE = 268,
-    IDL_TOKEN_SCOPE_NO_SPACE = 269,
-    IDL_TOKEN_MODULE = 270,
-    IDL_TOKEN_CONST = 271,
-    IDL_TOKEN_NATIVE = 272,
-    IDL_TOKEN_STRUCT = 273,
-    IDL_TOKEN_TYPEDEF = 274,
-    IDL_TOKEN_UNION = 275,
-    IDL_TOKEN_SWITCH = 276,
-    IDL_TOKEN_CASE = 277,
-    IDL_TOKEN_DEFAULT = 278,
-    IDL_TOKEN_ENUM = 279,
-    IDL_TOKEN_UNSIGNED = 280,
-    IDL_TOKEN_FIXED = 281,
-    IDL_TOKEN_SEQUENCE = 282,
-    IDL_TOKEN_STRING = 283,
-    IDL_TOKEN_WSTRING = 284,
-    IDL_TOKEN_FLOAT = 285,
-    IDL_TOKEN_DOUBLE = 286,
-    IDL_TOKEN_SHORT = 287,
-    IDL_TOKEN_LONG = 288,
-    IDL_TOKEN_CHAR = 289,
-    IDL_TOKEN_WCHAR = 290,
-    IDL_TOKEN_BOOLEAN = 291,
-    IDL_TOKEN_OCTET = 292,
-    IDL_TOKEN_ANY = 293,
-    IDL_TOKEN_MAP = 294,
-    IDL_TOKEN_BITSET = 295,
-    IDL_TOKEN_BITFIELD = 296,
-    IDL_TOKEN_BITMASK = 297,
-    IDL_TOKEN_INT8 = 298,
-    IDL_TOKEN_INT16 = 299,
-    IDL_TOKEN_INT32 = 300,
-    IDL_TOKEN_INT64 = 301,
-    IDL_TOKEN_UINT8 = 302,
-    IDL_TOKEN_UINT16 = 303,
-    IDL_TOKEN_UINT32 = 304,
-    IDL_TOKEN_UINT64 = 305,
-    IDL_TOKEN_TRUE = 306,
-    IDL_TOKEN_FALSE = 307,
-    IDL_TOKEN_LSHIFT = 308,
-    IDL_TOKEN_RSHIFT = 309
-  };
-#endif
-
-/* Value type.  */
-#if ! defined IDL_YYSTYPE && ! defined IDL_YYSTYPE_IS_DECLARED
-union IDL_YYSTYPE
+#include "parser.h"
+/* Symbol kind.  */
+enum yysymbol_kind_t
 {
-#line 103 "src/parser.y"
-
-  void *node;
-  /* expressions */
-  idl_literal_t *literal;
-  idl_const_expr_t *const_expr;
-  /* simple specifications */
-  idl_mask_t kind;
-  idl_name_t *name;
-  idl_scoped_name_t *scoped_name;
-  idl_inherit_spec_t *inherit_spec;
-  char *string_literal;
-  /* specifications */
-  idl_switch_type_spec_t *switch_type_spec;
-  idl_type_spec_t *type_spec;
-  idl_sequence_t *sequence;
-  idl_string_t *string;
-  /* declarations */
-  idl_definition_t *definition;
-  idl_module_t *module_dcl;
-  idl_struct_t *struct_dcl;
-  idl_forward_t *forward;
-  idl_member_t *member;
-  idl_declarator_t *declarator;
-  idl_union_t *union_dcl;
-  idl_case_t *_case;
-  idl_case_label_t *case_label;
-  idl_enum_t *enum_dcl;
-  idl_enumerator_t *enumerator;
-  idl_bitmask_t *bitmask_dcl;
-  idl_bit_value_t *bit_value;
-  idl_typedef_t *typedef_dcl;
-  idl_const_t *const_dcl;
-  /* annotations */
-  idl_annotation_t *annotation;
-  idl_annotation_member_t *annotation_member;
-  idl_annotation_appl_t *annotation_appl;
-  idl_annotation_appl_param_t *annotation_appl_param;
-
-  bool bln;
-  char *str;
-  char chr;
-  unsigned long long ullng;
-  long double ldbl;
-
-#line 328 "parser.c"
-
+  YYSYMBOL_YYEMPTY = -2,
+  YYSYMBOL_YYEOF = 0,                      /* "end of file"  */
+  YYSYMBOL_YYerror = 1,                    /* error  */
+  YYSYMBOL_YYUNDEF = 2,                    /* "invalid token"  */
+  YYSYMBOL_IDL_TOKEN_LINE_COMMENT = 3,     /* IDL_TOKEN_LINE_COMMENT  */
+  YYSYMBOL_IDL_TOKEN_COMMENT = 4,          /* IDL_TOKEN_COMMENT  */
+  YYSYMBOL_IDL_TOKEN_PP_NUMBER = 5,        /* IDL_TOKEN_PP_NUMBER  */
+  YYSYMBOL_IDL_TOKEN_IDENTIFIER = 6,       /* IDL_TOKEN_IDENTIFIER  */
+  YYSYMBOL_IDL_TOKEN_CHAR_LITERAL = 7,     /* IDL_TOKEN_CHAR_LITERAL  */
+  YYSYMBOL_IDL_TOKEN_STRING_LITERAL = 8,   /* IDL_TOKEN_STRING_LITERAL  */
+  YYSYMBOL_IDL_TOKEN_INTEGER_LITERAL = 9,  /* IDL_TOKEN_INTEGER_LITERAL  */
+  YYSYMBOL_IDL_TOKEN_FLOATING_PT_LITERAL = 10, /* IDL_TOKEN_FLOATING_PT_LITERAL  */
+  YYSYMBOL_IDL_TOKEN_ANNOTATION_SYMBOL = 11, /* "@"  */
+  YYSYMBOL_IDL_TOKEN_ANNOTATION = 12,      /* "annotation"  */
+  YYSYMBOL_IDL_TOKEN_SCOPE = 13,           /* IDL_TOKEN_SCOPE  */
+  YYSYMBOL_IDL_TOKEN_SCOPE_NO_SPACE = 14,  /* IDL_TOKEN_SCOPE_NO_SPACE  */
+  YYSYMBOL_IDL_TOKEN_MODULE = 15,          /* "module"  */
+  YYSYMBOL_IDL_TOKEN_CONST = 16,           /* "const"  */
+  YYSYMBOL_IDL_TOKEN_NATIVE = 17,          /* "native"  */
+  YYSYMBOL_IDL_TOKEN_STRUCT = 18,          /* "struct"  */
+  YYSYMBOL_IDL_TOKEN_TYPEDEF = 19,         /* "typedef"  */
+  YYSYMBOL_IDL_TOKEN_UNION = 20,           /* "union"  */
+  YYSYMBOL_IDL_TOKEN_SWITCH = 21,          /* "switch"  */
+  YYSYMBOL_IDL_TOKEN_CASE = 22,            /* "case"  */
+  YYSYMBOL_IDL_TOKEN_DEFAULT = 23,         /* "default"  */
+  YYSYMBOL_IDL_TOKEN_ENUM = 24,            /* "enum"  */
+  YYSYMBOL_IDL_TOKEN_UNSIGNED = 25,        /* "unsigned"  */
+  YYSYMBOL_IDL_TOKEN_FIXED = 26,           /* "fixed"  */
+  YYSYMBOL_IDL_TOKEN_SEQUENCE = 27,        /* "sequence"  */
+  YYSYMBOL_IDL_TOKEN_STRING = 28,          /* "string"  */
+  YYSYMBOL_IDL_TOKEN_WSTRING = 29,         /* "wstring"  */
+  YYSYMBOL_IDL_TOKEN_FLOAT = 30,           /* "float"  */
+  YYSYMBOL_IDL_TOKEN_DOUBLE = 31,          /* "double"  */
+  YYSYMBOL_IDL_TOKEN_SHORT = 32,           /* "short"  */
+  YYSYMBOL_IDL_TOKEN_LONG = 33,            /* "long"  */
+  YYSYMBOL_IDL_TOKEN_CHAR = 34,            /* "char"  */
+  YYSYMBOL_IDL_TOKEN_WCHAR = 35,           /* "wchar"  */
+  YYSYMBOL_IDL_TOKEN_BOOLEAN = 36,         /* "boolean"  */
+  YYSYMBOL_IDL_TOKEN_OCTET = 37,           /* "octet"  */
+  YYSYMBOL_IDL_TOKEN_ANY = 38,             /* "any"  */
+  YYSYMBOL_IDL_TOKEN_MAP = 39,             /* "map"  */
+  YYSYMBOL_IDL_TOKEN_BITSET = 40,          /* "bitset"  */
+  YYSYMBOL_IDL_TOKEN_BITFIELD = 41,        /* "bitfield"  */
+  YYSYMBOL_IDL_TOKEN_BITMASK = 42,         /* "bitmask"  */
+  YYSYMBOL_IDL_TOKEN_INT8 = 43,            /* "int8"  */
+  YYSYMBOL_IDL_TOKEN_INT16 = 44,           /* "int16"  */
+  YYSYMBOL_IDL_TOKEN_INT32 = 45,           /* "int32"  */
+  YYSYMBOL_IDL_TOKEN_INT64 = 46,           /* "int64"  */
+  YYSYMBOL_IDL_TOKEN_UINT8 = 47,           /* "uint8"  */
+  YYSYMBOL_IDL_TOKEN_UINT16 = 48,          /* "uint16"  */
+  YYSYMBOL_IDL_TOKEN_UINT32 = 49,          /* "uint32"  */
+  YYSYMBOL_IDL_TOKEN_UINT64 = 50,          /* "uint64"  */
+  YYSYMBOL_IDL_TOKEN_TRUE = 51,            /* "TRUE"  */
+  YYSYMBOL_IDL_TOKEN_FALSE = 52,           /* "FALSE"  */
+  YYSYMBOL_IDL_TOKEN_LSHIFT = 53,          /* "<<"  */
+  YYSYMBOL_IDL_TOKEN_RSHIFT = 54,          /* ">>"  */
+  YYSYMBOL_55_ = 55,                       /* ';'  */
+  YYSYMBOL_56_ = 56,                       /* '{'  */
+  YYSYMBOL_57_ = 57,                       /* '}'  */
+  YYSYMBOL_58_ = 58,                       /* '='  */
+  YYSYMBOL_59_ = 59,                       /* '|'  */
+  YYSYMBOL_60_ = 60,                       /* '^'  */
+  YYSYMBOL_61_ = 61,                       /* '&'  */
+  YYSYMBOL_62_ = 62,                       /* '+'  */
+  YYSYMBOL_63_ = 63,                       /* '-'  */
+  YYSYMBOL_64_ = 64,                       /* '*'  */
+  YYSYMBOL_65_ = 65,                       /* '/'  */
+  YYSYMBOL_66_ = 66,                       /* '%'  */
+  YYSYMBOL_67_ = 67,                       /* '~'  */
+  YYSYMBOL_68_ = 68,                       /* '('  */
+  YYSYMBOL_69_ = 69,                       /* ')'  */
+  YYSYMBOL_70_ = 70,                       /* '<'  */
+  YYSYMBOL_71_ = 71,                       /* ','  */
+  YYSYMBOL_72_ = 72,                       /* '>'  */
+  YYSYMBOL_73_ = 73,                       /* ':'  */
+  YYSYMBOL_74_ = 74,                       /* '['  */
+  YYSYMBOL_75_ = 75,                       /* ']'  */
+  YYSYMBOL_YYACCEPT = 76,                  /* $accept  */
+  YYSYMBOL_specification = 77,             /* specification  */
+  YYSYMBOL_definitions = 78,               /* definitions  */
+  YYSYMBOL_definition = 79,                /* definition  */
+  YYSYMBOL_module_dcl = 80,                /* module_dcl  */
+  YYSYMBOL_module_header = 81,             /* module_header  */
+  YYSYMBOL_scoped_name = 82,               /* scoped_name  */
+  YYSYMBOL_const_dcl = 83,                 /* const_dcl  */
+  YYSYMBOL_const_type = 84,                /* const_type  */
+  YYSYMBOL_const_expr = 85,                /* const_expr  */
+  YYSYMBOL_or_expr = 86,                   /* or_expr  */
+  YYSYMBOL_xor_expr = 87,                  /* xor_expr  */
+  YYSYMBOL_and_expr = 88,                  /* and_expr  */
+  YYSYMBOL_shift_expr = 89,                /* shift_expr  */
+  YYSYMBOL_shift_operator = 90,            /* shift_operator  */
+  YYSYMBOL_add_expr = 91,                  /* add_expr  */
+  YYSYMBOL_add_operator = 92,              /* add_operator  */
+  YYSYMBOL_mult_expr = 93,                 /* mult_expr  */
+  YYSYMBOL_mult_operator = 94,             /* mult_operator  */
+  YYSYMBOL_unary_expr = 95,                /* unary_expr  */
+  YYSYMBOL_unary_operator = 96,            /* unary_operator  */
+  YYSYMBOL_primary_expr = 97,              /* primary_expr  */
+  YYSYMBOL_literal = 98,                   /* literal  */
+  YYSYMBOL_boolean_literal = 99,           /* boolean_literal  */
+  YYSYMBOL_string_literal = 100,           /* string_literal  */
+  YYSYMBOL_positive_int_const = 101,       /* positive_int_const  */
+  YYSYMBOL_type_dcl = 102,                 /* type_dcl  */
+  YYSYMBOL_type_spec = 103,                /* type_spec  */
+  YYSYMBOL_simple_type_spec = 104,         /* simple_type_spec  */
+  YYSYMBOL_base_type_spec = 105,           /* base_type_spec  */
+  YYSYMBOL_floating_pt_type = 106,         /* floating_pt_type  */
+  YYSYMBOL_integer_type = 107,             /* integer_type  */
+  YYSYMBOL_signed_int = 108,               /* signed_int  */
+  YYSYMBOL_unsigned_int = 109,             /* unsigned_int  */
+  YYSYMBOL_char_type = 110,                /* char_type  */
+  YYSYMBOL_wide_char_type = 111,           /* wide_char_type  */
+  YYSYMBOL_boolean_type = 112,             /* boolean_type  */
+  YYSYMBOL_octet_type = 113,               /* octet_type  */
+  YYSYMBOL_template_type_spec = 114,       /* template_type_spec  */
+  YYSYMBOL_sequence_type = 115,            /* sequence_type  */
+  YYSYMBOL_string_type = 116,              /* string_type  */
+  YYSYMBOL_constr_type_dcl = 117,          /* constr_type_dcl  */
+  YYSYMBOL_struct_dcl = 118,               /* struct_dcl  */
+  YYSYMBOL_struct_forward_dcl = 119,       /* struct_forward_dcl  */
+  YYSYMBOL_struct_def = 120,               /* struct_def  */
+  YYSYMBOL_struct_header = 121,            /* struct_header  */
+  YYSYMBOL_struct_inherit_spec = 122,      /* struct_inherit_spec  */
+  YYSYMBOL_struct_body = 123,              /* struct_body  */
+  YYSYMBOL_members = 124,                  /* members  */
+  YYSYMBOL_member = 125,                   /* member  */
+  YYSYMBOL_union_dcl = 126,                /* union_dcl  */
+  YYSYMBOL_union_def = 127,                /* union_def  */
+  YYSYMBOL_union_forward_dcl = 128,        /* union_forward_dcl  */
+  YYSYMBOL_union_header = 129,             /* union_header  */
+  YYSYMBOL_switch_header = 130,            /* switch_header  */
+  YYSYMBOL_switch_type_spec = 131,         /* switch_type_spec  */
+  YYSYMBOL_switch_body = 132,              /* switch_body  */
+  YYSYMBOL_case = 133,                     /* case  */
+  YYSYMBOL_case_labels = 134,              /* case_labels  */
+  YYSYMBOL_case_label = 135,               /* case_label  */
+  YYSYMBOL_element_spec = 136,             /* element_spec  */
+  YYSYMBOL_enum_dcl = 137,                 /* enum_dcl  */
+  YYSYMBOL_enum_def = 138,                 /* enum_def  */
+  YYSYMBOL_enumerators = 139,              /* enumerators  */
+  YYSYMBOL_enumerator = 140,               /* enumerator  */
+  YYSYMBOL_bitmask_dcl = 141,              /* bitmask_dcl  */
+  YYSYMBOL_bitmask_def = 142,              /* bitmask_def  */
+  YYSYMBOL_bit_values = 143,               /* bit_values  */
+  YYSYMBOL_bit_value = 144,                /* bit_value  */
+  YYSYMBOL_array_declarator = 145,         /* array_declarator  */
+  YYSYMBOL_fixed_array_sizes = 146,        /* fixed_array_sizes  */
+  YYSYMBOL_fixed_array_size = 147,         /* fixed_array_size  */
+  YYSYMBOL_simple_declarator = 148,        /* simple_declarator  */
+  YYSYMBOL_complex_declarator = 149,       /* complex_declarator  */
+  YYSYMBOL_typedef_dcl = 150,              /* typedef_dcl  */
+  YYSYMBOL_declarators = 151,              /* declarators  */
+  YYSYMBOL_declarator = 152,               /* declarator  */
+  YYSYMBOL_identifier = 153,               /* identifier  */
+  YYSYMBOL_annotation_dcl = 154,           /* annotation_dcl  */
+  YYSYMBOL_annotation_header = 155,        /* annotation_header  */
+  YYSYMBOL_156_1 = 156,                    /* $@1  */
+  YYSYMBOL_annotation_body = 157,          /* annotation_body  */
+  YYSYMBOL_annotation_member = 158,        /* annotation_member  */
+  YYSYMBOL_annotation_member_type = 159,   /* annotation_member_type  */
+  YYSYMBOL_annotation_member_default = 160, /* annotation_member_default  */
+  YYSYMBOL_any_const_type = 161,           /* any_const_type  */
+  YYSYMBOL_annotations = 162,              /* annotations  */
+  YYSYMBOL_annotation_appls = 163,         /* annotation_appls  */
+  YYSYMBOL_annotation_appl = 164,          /* annotation_appl  */
+  YYSYMBOL_annotation_appl_header = 165,   /* annotation_appl_header  */
+  YYSYMBOL_166_2 = 166,                    /* $@2  */
+  YYSYMBOL_annotation_appl_name = 167,     /* annotation_appl_name  */
+  YYSYMBOL_annotation_appl_params = 168,   /* annotation_appl_params  */
+  YYSYMBOL_annotation_appl_keyword_params = 169, /* annotation_appl_keyword_params  */
+  YYSYMBOL_annotation_appl_keyword_param = 170, /* annotation_appl_keyword_param  */
+  YYSYMBOL_171_3 = 171                     /* @3  */
 };
-typedef union IDL_YYSTYPE IDL_YYSTYPE;
-# define IDL_YYSTYPE_IS_TRIVIAL 1
-# define IDL_YYSTYPE_IS_DECLARED 1
-#endif
+typedef enum yysymbol_kind_t yysymbol_kind_t;
 
-/* Location type.  */
-#if ! defined IDL_YYLTYPE && ! defined IDL_YYLTYPE_IS_DECLARED
-typedef struct IDL_YYLTYPE IDL_YYLTYPE;
-struct IDL_YYLTYPE
-{
-  int first_line;
-  int first_column;
-  int last_line;
-  int last_column;
-};
-# define IDL_YYLTYPE_IS_DECLARED 1
-# define IDL_YYLTYPE_IS_TRIVIAL 1
-#endif
-
-
-
-#ifndef YYPUSH_MORE_DEFINED
-# define YYPUSH_MORE_DEFINED
-enum { YYPUSH_MORE = 4 };
-#endif
-
-typedef struct idl_yypstate idl_yypstate;
-
-int idl_yypush_parse (idl_yypstate *ps, int pushed_char, IDL_YYSTYPE const *pushed_val, IDL_YYLTYPE *pushed_loc, idl_pstate_t *pstate, idl_retcode_t *result);
-
-idl_yypstate * idl_yypstate_new (void);
-void idl_yypstate_delete (idl_yypstate *ps);
-/* "%code provides" blocks.  */
-#line 98 "src/parser.y"
-
-int idl_iskeyword(idl_pstate_t *pstate, const char *str, int nc);
-void idl_yypstate_delete_stack(idl_yypstate *yyps);
-
-#line 369 "parser.c"
-
-#endif /* !YY_IDL_YY_PARSER_H_INCLUDED  */
 
 
 
@@ -467,6 +453,7 @@ typedef int yytype_uint16;
 
 #define YYSIZEOF(X) YY_CAST (YYPTRDIFF_T, sizeof (X))
 
+
 /* Stored state numbers (used for stacks). */
 typedef yytype_int16 yy_state_t;
 
@@ -484,6 +471,7 @@ typedef int yy_state_fast_t;
 #  define YY_(Msgid) Msgid
 # endif
 #endif
+
 
 #ifndef YY_ATTRIBUTE_PURE
 # if defined __GNUC__ && 2 < __GNUC__ + (96 <= __GNUC_MINOR__)
@@ -542,7 +530,7 @@ typedef int yy_state_fast_t;
 
 #define YY_ASSERT(E) ((void) (0 && (E)))
 
-#if ! defined yyoverflow || YYERROR_VERBOSE
+#if !defined yyoverflow
 
 /* The parser invokes alloca or malloc; define the necessary symbols.  */
 
@@ -583,8 +571,7 @@ void free (void *); /* INFRINGES ON USER NAME SPACE */
 #   endif
 #  endif
 # endif
-#endif /* ! defined yyoverflow || YYERROR_VERBOSE */
-
+#endif /* !defined yyoverflow */
 
 #if (! defined yyoverflow \
      && (! defined __cplusplus \
@@ -663,14 +650,16 @@ union yyalloc
 /* YYNSTATES -- Number of states.  */
 #define YYNSTATES  286
 
-#define YYUNDEFTOK  2
+/* YYMAXUTOK -- Last valid token kind.  */
 #define YYMAXUTOK   309
 
 
 /* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
    as returned by yylex, with out-of-bounds checking.  */
-#define YYTRANSLATE(YYX)                                                \
-  (0 <= (YYX) && (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
+#define YYTRANSLATE(YYX)                                \
+  (0 <= (YYX) && (YYX) <= YYMAXUTOK                     \
+   ? YY_CAST (yysymbol_kind_t, yytranslate[YYX])        \
+   : YYSYMBOL_YYUNDEF)
 
 /* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
    as returned by yylex.  */
@@ -731,35 +720,43 @@ static const yytype_int16 yyrline[] =
      892,   897,   902,   906,   909,   911,   928,   930,   935,   936,
      940,   957,   968,   967,   976,   978,   980,   982,   984,   986,
      991,   996,   998,  1003,  1005,  1010,  1015,  1017,  1022,  1024,
-    1029,  1040,  1039,  1063,  1065,  1067,  1074,  1076,  1078,  1083,
-    1085,  1091,  1090
+    1029,  1040,  1039,  1065,  1067,  1069,  1076,  1078,  1080,  1085,
+    1087,  1093,  1092
 };
 #endif
 
-#if IDL_YYDEBUG || YYERROR_VERBOSE || 1
+/** Accessing symbol of state STATE.  */
+#define YY_ACCESSING_SYMBOL(State) YY_CAST (yysymbol_kind_t, yystos[State])
+
+#if IDL_YYDEBUG || 1
+/* The user-facing name of the symbol whose (internal) number is
+   YYSYMBOL.  No bounds checking.  */
+static const char *yysymbol_name (yysymbol_kind_t yysymbol) YY_ATTRIBUTE_UNUSED;
+
 /* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
    First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
 static const char *const yytname[] =
 {
-  "$end", "error", "$undefined", "IDL_TOKEN_LINE_COMMENT",
-  "IDL_TOKEN_COMMENT", "IDL_TOKEN_PP_NUMBER", "IDL_TOKEN_IDENTIFIER",
-  "IDL_TOKEN_CHAR_LITERAL", "IDL_TOKEN_STRING_LITERAL",
-  "IDL_TOKEN_INTEGER_LITERAL", "IDL_TOKEN_FLOATING_PT_LITERAL", "\"@\"",
-  "\"annotation\"", "IDL_TOKEN_SCOPE", "IDL_TOKEN_SCOPE_NO_SPACE",
-  "\"module\"", "\"const\"", "\"native\"", "\"struct\"", "\"typedef\"",
-  "\"union\"", "\"switch\"", "\"case\"", "\"default\"", "\"enum\"",
-  "\"unsigned\"", "\"fixed\"", "\"sequence\"", "\"string\"", "\"wstring\"",
-  "\"float\"", "\"double\"", "\"short\"", "\"long\"", "\"char\"",
-  "\"wchar\"", "\"boolean\"", "\"octet\"", "\"any\"", "\"map\"",
-  "\"bitset\"", "\"bitfield\"", "\"bitmask\"", "\"int8\"", "\"int16\"",
-  "\"int32\"", "\"int64\"", "\"uint8\"", "\"uint16\"", "\"uint32\"",
-  "\"uint64\"", "\"TRUE\"", "\"FALSE\"", "\"<<\"", "\">>\"", "';'", "'{'",
-  "'}'", "'='", "'|'", "'^'", "'&'", "'+'", "'-'", "'*'", "'/'", "'%'",
-  "'~'", "'('", "')'", "'<'", "','", "'>'", "':'", "'['", "']'", "$accept",
-  "specification", "definitions", "definition", "module_dcl",
-  "module_header", "scoped_name", "const_dcl", "const_type", "const_expr",
-  "or_expr", "xor_expr", "and_expr", "shift_expr", "shift_operator",
-  "add_expr", "add_operator", "mult_expr", "mult_operator", "unary_expr",
+  "\"end of file\"", "error", "\"invalid token\"",
+  "IDL_TOKEN_LINE_COMMENT", "IDL_TOKEN_COMMENT", "IDL_TOKEN_PP_NUMBER",
+  "IDL_TOKEN_IDENTIFIER", "IDL_TOKEN_CHAR_LITERAL",
+  "IDL_TOKEN_STRING_LITERAL", "IDL_TOKEN_INTEGER_LITERAL",
+  "IDL_TOKEN_FLOATING_PT_LITERAL", "\"@\"", "\"annotation\"",
+  "IDL_TOKEN_SCOPE", "IDL_TOKEN_SCOPE_NO_SPACE", "\"module\"", "\"const\"",
+  "\"native\"", "\"struct\"", "\"typedef\"", "\"union\"", "\"switch\"",
+  "\"case\"", "\"default\"", "\"enum\"", "\"unsigned\"", "\"fixed\"",
+  "\"sequence\"", "\"string\"", "\"wstring\"", "\"float\"", "\"double\"",
+  "\"short\"", "\"long\"", "\"char\"", "\"wchar\"", "\"boolean\"",
+  "\"octet\"", "\"any\"", "\"map\"", "\"bitset\"", "\"bitfield\"",
+  "\"bitmask\"", "\"int8\"", "\"int16\"", "\"int32\"", "\"int64\"",
+  "\"uint8\"", "\"uint16\"", "\"uint32\"", "\"uint64\"", "\"TRUE\"",
+  "\"FALSE\"", "\"<<\"", "\">>\"", "';'", "'{'", "'}'", "'='", "'|'",
+  "'^'", "'&'", "'+'", "'-'", "'*'", "'/'", "'%'", "'~'", "'('", "')'",
+  "'<'", "','", "'>'", "':'", "'['", "']'", "$accept", "specification",
+  "definitions", "definition", "module_dcl", "module_header",
+  "scoped_name", "const_dcl", "const_type", "const_expr", "or_expr",
+  "xor_expr", "and_expr", "shift_expr", "shift_operator", "add_expr",
+  "add_operator", "mult_expr", "mult_operator", "unary_expr",
   "unary_operator", "primary_expr", "literal", "boolean_literal",
   "string_literal", "positive_int_const", "type_dcl", "type_spec",
   "simple_type_spec", "base_type_spec", "floating_pt_type", "integer_type",
@@ -781,9 +778,15 @@ static const char *const yytname[] =
   "annotation_appl_name", "annotation_appl_params",
   "annotation_appl_keyword_params", "annotation_appl_keyword_param", "@3", YY_NULLPTR
 };
+
+static const char *
+yysymbol_name (yysymbol_kind_t yysymbol)
+{
+  return yytname[yysymbol];
+}
 #endif
 
-# ifdef YYPRINT
+#ifdef YYPRINT
 /* YYTOKNUM[NUM] -- (External) token number corresponding to the
    (internal) symbol number NUM (which must be that of a token).  */
 static const yytype_int16 yytoknum[] =
@@ -797,7 +800,7 @@ static const yytype_int16 yytoknum[] =
       94,    38,    43,    45,    42,    47,    37,   126,    40,    41,
       60,    44,    62,    58,    91,    93
 };
-# endif
+#endif
 
 #define YYPACT_NINF (-201)
 
@@ -1089,10 +1092,10 @@ static const yytype_int8 yyr2[] =
 };
 
 
+enum { YYENOMEM = -2 };
+
 #define yyerrok         (yyerrstatus = 0)
-#define yyclearin       (yychar = YYEMPTY)
-#define YYEMPTY         (-2)
-#define YYEOF           0
+#define yyclearin       (yychar = IDL_YYEMPTY)
 
 #define YYACCEPT        goto yyacceptlab
 #define YYABORT         goto yyabortlab
@@ -1103,7 +1106,7 @@ static const yytype_int8 yyr2[] =
 
 #define YYBACKUP(Token, Value)                                    \
   do                                                              \
-    if (yychar == YYEMPTY)                                        \
+    if (yychar == IDL_YYEMPTY)                                        \
       {                                                           \
         yychar = (Token);                                         \
         yylval = (Value);                                         \
@@ -1118,10 +1121,9 @@ static const yytype_int8 yyr2[] =
       }                                                           \
   while (0)
 
-/* Error token number */
-#define YYTERROR        1
-#define YYERRCODE       256
-
+/* Backward compatibility with an undocumented macro.
+   Use IDL_YYerror or IDL_YYUNDEF. */
+#define YYERRCODE IDL_YYUNDEF
 
 /* YYLLOC_DEFAULT -- Set CURRENT to span from RHS[1] to RHS[N].
    If N is 0, then set CURRENT to the empty location which ends
@@ -1169,8 +1171,8 @@ do {                                            \
    This macro was not mandated originally: define only if we know
    we won't break user code: when these are the locations we know.  */
 
-#ifndef YY_LOCATION_PRINT
-# if defined IDL_YYLTYPE_IS_TRIVIAL && IDL_YYLTYPE_IS_TRIVIAL
+# ifndef YY_LOCATION_PRINT
+#  if defined IDL_YYLTYPE_IS_TRIVIAL && IDL_YYLTYPE_IS_TRIVIAL
 
 /* Print *YYLOCP on YYO.  Private, do not rely on its existence. */
 
@@ -1200,22 +1202,22 @@ yy_location_print_ (FILE *yyo, YYLTYPE const * const yylocp)
   return res;
  }
 
-#  define YY_LOCATION_PRINT(File, Loc)          \
+#   define YY_LOCATION_PRINT(File, Loc)          \
   yy_location_print_ (File, &(Loc))
 
-# else
-#  define YY_LOCATION_PRINT(File, Loc) ((void) 0)
-# endif
-#endif
+#  else
+#   define YY_LOCATION_PRINT(File, Loc) ((void) 0)
+#  endif
+# endif /* !defined YY_LOCATION_PRINT */
 
 
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)                    \
+# define YY_SYMBOL_PRINT(Title, Kind, Value, Location)                    \
 do {                                                                      \
   if (yydebug)                                                            \
     {                                                                     \
       YYFPRINTF (stderr, "%s ", Title);                                   \
       yy_symbol_print (stderr,                                            \
-                  Type, Value, Location, pstate, result); \
+                  Kind, Value, Location, pstate, result); \
       YYFPRINTF (stderr, "\n");                                           \
     }                                                                     \
 } while (0)
@@ -1226,7 +1228,8 @@ do {                                                                      \
 `-----------------------------------*/
 
 static void
-yy_symbol_value_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp, idl_pstate_t *pstate, idl_retcode_t *result)
+yy_symbol_value_print (FILE *yyo,
+                       yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp, idl_pstate_t *pstate, idl_retcode_t *result)
 {
   FILE *yyoutput = yyo;
   YYUSE (yyoutput);
@@ -1236,11 +1239,11 @@ yy_symbol_value_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep, YY
   if (!yyvaluep)
     return;
 # ifdef YYPRINT
-  if (yytype < YYNTOKENS)
-    YYPRINT (yyo, yytoknum[yytype], *yyvaluep);
+  if (yykind < YYNTOKENS)
+    YYPRINT (yyo, yytoknum[yykind], *yyvaluep);
 # endif
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-  YYUSE (yytype);
+  YYUSE (yykind);
   YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
 
@@ -1250,14 +1253,15 @@ yy_symbol_value_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep, YY
 `---------------------------*/
 
 static void
-yy_symbol_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp, idl_pstate_t *pstate, idl_retcode_t *result)
+yy_symbol_print (FILE *yyo,
+                 yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp, idl_pstate_t *pstate, idl_retcode_t *result)
 {
   YYFPRINTF (yyo, "%s %s (",
-             yytype < YYNTOKENS ? "token" : "nterm", yytname[yytype]);
+             yykind < YYNTOKENS ? "token" : "nterm", yysymbol_name (yykind));
 
   YY_LOCATION_PRINT (yyo, *yylocationp);
   YYFPRINTF (yyo, ": ");
-  yy_symbol_value_print (yyo, yytype, yyvaluep, yylocationp, pstate, result);
+  yy_symbol_value_print (yyo, yykind, yyvaluep, yylocationp, pstate, result);
   YYFPRINTF (yyo, ")");
 }
 
@@ -1290,7 +1294,8 @@ do {                                                            \
 `------------------------------------------------*/
 
 static void
-yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp, YYLTYPE *yylsp, int yyrule, idl_pstate_t *pstate, idl_retcode_t *result)
+yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp, YYLTYPE *yylsp,
+                 int yyrule, idl_pstate_t *pstate, idl_retcode_t *result)
 {
   int yylno = yyrline[yyrule];
   int yynrhs = yyr2[yyrule];
@@ -1302,9 +1307,9 @@ yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp, YYLTYPE *yylsp, int yyrule, 
     {
       YYFPRINTF (stderr, "   $%d = ", yyi + 1);
       yy_symbol_print (stderr,
-                       yystos[+yyssp[yyi + 1 - yynrhs]],
-                       &yyvsp[(yyi + 1) - (yynrhs)]
-                       , &(yylsp[(yyi + 1) - (yynrhs)])                       , pstate, result);
+                       YY_ACCESSING_SYMBOL (+yyssp[yyi + 1 - yynrhs]),
+                       &yyvsp[(yyi + 1) - (yynrhs)],
+                       &(yylsp[(yyi + 1) - (yynrhs)]), pstate, result);
       YYFPRINTF (stderr, "\n");
     }
 }
@@ -1319,8 +1324,8 @@ do {                                    \
    multiple parsers can coexist.  */
 int yydebug;
 #else /* !IDL_YYDEBUG */
-# define YYDPRINTF(Args)
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)
+# define YYDPRINTF(Args) ((void) 0)
+# define YY_SYMBOL_PRINT(Title, Kind, Value, Location)
 # define YY_STACK_PRINT(Bottom, Top)
 # define YY_REDUCE_PRINT(Rule)
 #endif /* !IDL_YYDEBUG */
@@ -1341,246 +1346,53 @@ int yydebug;
 #ifndef YYMAXDEPTH
 # define YYMAXDEPTH 10000
 #endif
-
-
-#if YYERROR_VERBOSE
-
-# ifndef yystrlen
-#  if defined __GLIBC__ && defined _STRING_H
-#   define yystrlen(S) (YY_CAST (YYPTRDIFF_T, strlen (S)))
-#  else
-/* Return the length of YYSTR.  */
-static YYPTRDIFF_T
-yystrlen (const char *yystr)
-{
-  YYPTRDIFF_T yylen;
-  for (yylen = 0; yystr[yylen]; yylen++)
-    continue;
-  return yylen;
-}
-#  endif
-# endif
-
-# ifndef yystpcpy
-#  if defined __GLIBC__ && defined _STRING_H && defined _GNU_SOURCE
-#   define yystpcpy stpcpy
-#  else
-/* Copy YYSRC to YYDEST, returning the address of the terminating '\0' in
-   YYDEST.  */
-static char *
-yystpcpy (char *yydest, const char *yysrc)
-{
-  char *yyd = yydest;
-  const char *yys = yysrc;
-
-  while ((*yyd++ = *yys++) != '\0')
-    continue;
-
-  return yyd - 1;
-}
-#  endif
-# endif
-
-# ifndef yytnamerr
-/* Copy to YYRES the contents of YYSTR after stripping away unnecessary
-   quotes and backslashes, so that it's suitable for yyerror.  The
-   heuristic is that double-quoting is unnecessary unless the string
-   contains an apostrophe, a comma, or backslash (other than
-   backslash-backslash).  YYSTR is taken from yytname.  If YYRES is
-   null, do not copy; instead, return the length of what the result
-   would have been.  */
-static YYPTRDIFF_T
-yytnamerr (char *yyres, const char *yystr)
-{
-  if (*yystr == '"')
-    {
-      YYPTRDIFF_T yyn = 0;
-      char const *yyp = yystr;
-
-      for (;;)
-        switch (*++yyp)
-          {
-          case '\'':
-          case ',':
-            goto do_not_strip_quotes;
-
-          case '\\':
-            if (*++yyp != '\\')
-              goto do_not_strip_quotes;
-            else
-              goto append;
-
-          append:
-          default:
-            if (yyres)
-              yyres[yyn] = *yyp;
-            yyn++;
-            break;
-
-          case '"':
-            if (yyres)
-              yyres[yyn] = '\0';
-            return yyn;
-          }
-    do_not_strip_quotes: ;
-    }
-
-  if (yyres)
-    return yystpcpy (yyres, yystr) - yyres;
-  else
-    return yystrlen (yystr);
-}
-# endif
-
-/* Copy into *YYMSG, which is of size *YYMSG_ALLOC, an error message
-   about the unexpected token YYTOKEN for the state stack whose top is
-   YYSSP.
-
-   Return 0 if *YYMSG was successfully written.  Return 1 if *YYMSG is
-   not large enough to hold the message.  In that case, also set
-   *YYMSG_ALLOC to the required number of bytes.  Return 2 if the
-   required number of bytes is too large to store.  */
-static int
-yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
-                yy_state_t *yyssp, int yytoken)
-{
-  enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 5 };
-  /* Internationalized format string. */
-  const char *yyformat = YY_NULLPTR;
-  /* Arguments of yyformat: reported tokens (one for the "unexpected",
-     one per "expected"). */
-  char const *yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
-  /* Actual size of YYARG. */
-  int yycount = 0;
-  /* Cumulated lengths of YYARG.  */
-  YYPTRDIFF_T yysize = 0;
-
-  /* There are many possibilities here to consider:
-     - If this state is a consistent state with a default action, then
-       the only way this function was invoked is if the default action
-       is an error action.  In that case, don't check for expected
-       tokens because there are none.
-     - The only way there can be no lookahead present (in yychar) is if
-       this state is a consistent state with a default action.  Thus,
-       detecting the absence of a lookahead is sufficient to determine
-       that there is no unexpected or expected token to report.  In that
-       case, just report a simple "syntax error".
-     - Don't assume there isn't a lookahead just because this state is a
-       consistent state with a default action.  There might have been a
-       previous inconsistent state, consistent state with a non-default
-       action, or user semantic action that manipulated yychar.
-     - Of course, the expected token list depends on states to have
-       correct lookahead information, and it depends on the parser not
-       to perform extra reductions after fetching a lookahead from the
-       scanner and before detecting a syntax error.  Thus, state merging
-       (from LALR or IELR) and default reductions corrupt the expected
-       token list.  However, the list is correct for canonical LR with
-       one exception: it will still contain any token that will not be
-       accepted due to an error action in a later state.
-  */
-  if (yytoken != YYEMPTY)
-    {
-      int yyn = yypact[+*yyssp];
-      YYPTRDIFF_T yysize0 = yytnamerr (YY_NULLPTR, yytname[yytoken]);
-      yysize = yysize0;
-      yyarg[yycount++] = yytname[yytoken];
-      if (!yypact_value_is_default (yyn))
-        {
-          /* Start YYX at -YYN if negative to avoid negative indexes in
-             YYCHECK.  In other words, skip the first -YYN actions for
-             this state because they are default actions.  */
-          int yyxbegin = yyn < 0 ? -yyn : 0;
-          /* Stay within bounds of both yycheck and yytname.  */
-          int yychecklim = YYLAST - yyn + 1;
-          int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
-          int yyx;
-
-          for (yyx = yyxbegin; yyx < yyxend; ++yyx)
-            if (yycheck[yyx + yyn] == yyx && yyx != YYTERROR
-                && !yytable_value_is_error (yytable[yyx + yyn]))
-              {
-                if (yycount == YYERROR_VERBOSE_ARGS_MAXIMUM)
-                  {
-                    yycount = 1;
-                    yysize = yysize0;
-                    break;
-                  }
-                yyarg[yycount++] = yytname[yyx];
-                {
-                  YYPTRDIFF_T yysize1
-                    = yysize + yytnamerr (YY_NULLPTR, yytname[yyx]);
-                  if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
-                    yysize = yysize1;
-                  else
-                    return 2;
-                }
-              }
-        }
-    }
-
-  switch (yycount)
-    {
-# define YYCASE_(N, S)                      \
-      case N:                               \
-        yyformat = S;                       \
-      break
-    default: /* Avoid compiler warnings. */
-      YYCASE_(0, YY_("syntax error"));
-      YYCASE_(1, YY_("syntax error, unexpected %s"));
-      YYCASE_(2, YY_("syntax error, unexpected %s, expecting %s"));
-      YYCASE_(3, YY_("syntax error, unexpected %s, expecting %s or %s"));
-      YYCASE_(4, YY_("syntax error, unexpected %s, expecting %s or %s or %s"));
-      YYCASE_(5, YY_("syntax error, unexpected %s, expecting %s or %s or %s or %s"));
-# undef YYCASE_
-    }
-
+/* Parser data structure.  */
+struct yypstate
   {
-    /* Don't count the "%s"s in the final size, but reserve room for
-       the terminator.  */
-    YYPTRDIFF_T yysize1 = yysize + (yystrlen (yyformat) - 2 * yycount) + 1;
-    if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
-      yysize = yysize1;
-    else
-      return 2;
-  }
+    /* Number of syntax errors so far.  */
+    int yynerrs;
 
-  if (*yymsg_alloc < yysize)
-    {
-      *yymsg_alloc = 2 * yysize;
-      if (! (yysize <= *yymsg_alloc
-             && *yymsg_alloc <= YYSTACK_ALLOC_MAXIMUM))
-        *yymsg_alloc = YYSTACK_ALLOC_MAXIMUM;
-      return 1;
-    }
+    yy_state_fast_t yystate;
+    /* Number of tokens to shift before error messages enabled.  */
+    int yyerrstatus;
 
-  /* Avoid sprintf, as that infringes on the user's name space.
-     Don't have undefined behavior even if the translation
-     produced a string with the wrong number of "%s"s.  */
-  {
-    char *yyp = *yymsg;
-    int yyi = 0;
-    while ((*yyp = *yyformat) != '\0')
-      if (*yyp == '%' && yyformat[1] == 's' && yyi < yycount)
-        {
-          yyp += yytnamerr (yyp, yyarg[yyi++]);
-          yyformat += 2;
-        }
-      else
-        {
-          ++yyp;
-          ++yyformat;
-        }
-  }
-  return 0;
-}
-#endif /* YYERROR_VERBOSE */
+    /* Refer to the stacks through separate pointers, to allow yyoverflow
+       to reallocate them elsewhere.  */
+
+    /* Their size.  */
+    YYPTRDIFF_T yystacksize;
+
+    /* The state stack: array, bottom, top.  */
+    yy_state_t yyssa[YYINITDEPTH];
+    yy_state_t *yyss;
+    yy_state_t *yyssp;
+
+    /* The semantic value stack: array, bottom, top.  */
+    YYSTYPE yyvsa[YYINITDEPTH];
+    YYSTYPE *yyvs;
+    YYSTYPE *yyvsp;
+
+    /* The location stack: array, bottom, top.  */
+    YYLTYPE yylsa[YYINITDEPTH];
+    YYLTYPE *yyls;
+    YYLTYPE *yylsp;
+    /* Whether this instance has not started parsing yet.
+     * If 2, it corresponds to a finished parsing.  */
+    int yynew;
+  };
+
+
+
+
+
 
 /*-----------------------------------------------.
 | Release the memory associated to this symbol.  |
 `-----------------------------------------------*/
 
 static void
-yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocationp, idl_pstate_t *pstate, idl_retcode_t *result)
+yydestruct (const char *yymsg,
+            yysymbol_kind_t yykind, YYSTYPE *yyvaluep, YYLTYPE *yylocationp, idl_pstate_t *pstate, idl_retcode_t *result)
 {
   YYUSE (yyvaluep);
   YYUSE (yylocationp);
@@ -1588,471 +1400,471 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   YYUSE (result);
   if (!yymsg)
     yymsg = "Deleting";
-  YY_SYMBOL_PRINT (yymsg, yytype, yyvaluep, yylocationp);
+  YY_SYMBOL_PRINT (yymsg, yykind, yyvaluep, yylocationp);
 
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-  switch (yytype)
+  switch (yykind)
     {
-    case 78: /* definitions  */
+    case YYSYMBOL_definitions: /* definitions  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).node)); }
-#line 1600 "parser.c"
+#line 1412 "parser.c"
         break;
 
-    case 79: /* definition  */
+    case YYSYMBOL_definition: /* definition  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).node)); }
-#line 1606 "parser.c"
+#line 1418 "parser.c"
         break;
 
-    case 80: /* module_dcl  */
+    case YYSYMBOL_module_dcl: /* module_dcl  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).module_dcl)); }
-#line 1612 "parser.c"
+#line 1424 "parser.c"
         break;
 
-    case 81: /* module_header  */
+    case YYSYMBOL_module_header: /* module_header  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).module_dcl)); }
-#line 1618 "parser.c"
+#line 1430 "parser.c"
         break;
 
-    case 82: /* scoped_name  */
+    case YYSYMBOL_scoped_name: /* scoped_name  */
 #line 208 "src/parser.y"
             { idl_delete_scoped_name(((*yyvaluep).scoped_name)); }
-#line 1624 "parser.c"
+#line 1436 "parser.c"
         break;
 
-    case 83: /* const_dcl  */
+    case YYSYMBOL_const_dcl: /* const_dcl  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).const_dcl)); }
-#line 1630 "parser.c"
+#line 1442 "parser.c"
         break;
 
-    case 84: /* const_type  */
+    case YYSYMBOL_const_type: /* const_type  */
 #line 211 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).type_spec)); }
-#line 1636 "parser.c"
+#line 1448 "parser.c"
         break;
 
-    case 85: /* const_expr  */
+    case YYSYMBOL_const_expr: /* const_expr  */
 #line 211 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).const_expr)); }
-#line 1642 "parser.c"
+#line 1454 "parser.c"
         break;
 
-    case 86: /* or_expr  */
+    case YYSYMBOL_or_expr: /* or_expr  */
 #line 211 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).const_expr)); }
-#line 1648 "parser.c"
+#line 1460 "parser.c"
         break;
 
-    case 87: /* xor_expr  */
+    case YYSYMBOL_xor_expr: /* xor_expr  */
 #line 211 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).const_expr)); }
-#line 1654 "parser.c"
+#line 1466 "parser.c"
         break;
 
-    case 88: /* and_expr  */
+    case YYSYMBOL_and_expr: /* and_expr  */
 #line 211 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).const_expr)); }
-#line 1660 "parser.c"
+#line 1472 "parser.c"
         break;
 
-    case 89: /* shift_expr  */
+    case YYSYMBOL_shift_expr: /* shift_expr  */
 #line 211 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).const_expr)); }
-#line 1666 "parser.c"
+#line 1478 "parser.c"
         break;
 
-    case 91: /* add_expr  */
+    case YYSYMBOL_add_expr: /* add_expr  */
 #line 211 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).const_expr)); }
-#line 1672 "parser.c"
+#line 1484 "parser.c"
         break;
 
-    case 93: /* mult_expr  */
+    case YYSYMBOL_mult_expr: /* mult_expr  */
 #line 211 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).const_expr)); }
-#line 1678 "parser.c"
+#line 1490 "parser.c"
         break;
 
-    case 95: /* unary_expr  */
+    case YYSYMBOL_unary_expr: /* unary_expr  */
 #line 211 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).const_expr)); }
-#line 1684 "parser.c"
+#line 1496 "parser.c"
         break;
 
-    case 97: /* primary_expr  */
+    case YYSYMBOL_primary_expr: /* primary_expr  */
 #line 211 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).const_expr)); }
-#line 1690 "parser.c"
+#line 1502 "parser.c"
         break;
 
-    case 98: /* literal  */
+    case YYSYMBOL_literal: /* literal  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).literal)); }
-#line 1696 "parser.c"
+#line 1508 "parser.c"
         break;
 
-    case 100: /* string_literal  */
+    case YYSYMBOL_string_literal: /* string_literal  */
 #line 203 "src/parser.y"
             { free(((*yyvaluep).string_literal)); }
-#line 1702 "parser.c"
+#line 1514 "parser.c"
         break;
 
-    case 101: /* positive_int_const  */
+    case YYSYMBOL_positive_int_const: /* positive_int_const  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).literal)); }
-#line 1708 "parser.c"
+#line 1520 "parser.c"
         break;
 
-    case 102: /* type_dcl  */
+    case YYSYMBOL_type_dcl: /* type_dcl  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).node)); }
-#line 1714 "parser.c"
+#line 1526 "parser.c"
         break;
 
-    case 103: /* type_spec  */
+    case YYSYMBOL_type_spec: /* type_spec  */
 #line 211 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).type_spec)); }
-#line 1720 "parser.c"
+#line 1532 "parser.c"
         break;
 
-    case 104: /* simple_type_spec  */
+    case YYSYMBOL_simple_type_spec: /* simple_type_spec  */
 #line 211 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).type_spec)); }
-#line 1726 "parser.c"
+#line 1538 "parser.c"
         break;
 
-    case 114: /* template_type_spec  */
+    case YYSYMBOL_template_type_spec: /* template_type_spec  */
 #line 211 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).type_spec)); }
-#line 1732 "parser.c"
+#line 1544 "parser.c"
         break;
 
-    case 115: /* sequence_type  */
+    case YYSYMBOL_sequence_type: /* sequence_type  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).sequence)); }
-#line 1738 "parser.c"
+#line 1550 "parser.c"
         break;
 
-    case 116: /* string_type  */
+    case YYSYMBOL_string_type: /* string_type  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).string)); }
-#line 1744 "parser.c"
+#line 1556 "parser.c"
         break;
 
-    case 117: /* constr_type_dcl  */
+    case YYSYMBOL_constr_type_dcl: /* constr_type_dcl  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).node)); }
-#line 1750 "parser.c"
+#line 1562 "parser.c"
         break;
 
-    case 118: /* struct_dcl  */
+    case YYSYMBOL_struct_dcl: /* struct_dcl  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).node)); }
-#line 1756 "parser.c"
+#line 1568 "parser.c"
         break;
 
-    case 119: /* struct_forward_dcl  */
+    case YYSYMBOL_struct_forward_dcl: /* struct_forward_dcl  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).forward)); }
-#line 1762 "parser.c"
+#line 1574 "parser.c"
         break;
 
-    case 120: /* struct_def  */
+    case YYSYMBOL_struct_def: /* struct_def  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).struct_dcl)); }
-#line 1768 "parser.c"
+#line 1580 "parser.c"
         break;
 
-    case 121: /* struct_header  */
+    case YYSYMBOL_struct_header: /* struct_header  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).struct_dcl)); }
-#line 1774 "parser.c"
+#line 1586 "parser.c"
         break;
 
-    case 122: /* struct_inherit_spec  */
+    case YYSYMBOL_struct_inherit_spec: /* struct_inherit_spec  */
 #line 211 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).type_spec)); }
-#line 1780 "parser.c"
+#line 1592 "parser.c"
         break;
 
-    case 123: /* struct_body  */
+    case YYSYMBOL_struct_body: /* struct_body  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).member)); }
-#line 1786 "parser.c"
+#line 1598 "parser.c"
         break;
 
-    case 124: /* members  */
+    case YYSYMBOL_members: /* members  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).member)); }
-#line 1792 "parser.c"
+#line 1604 "parser.c"
         break;
 
-    case 125: /* member  */
+    case YYSYMBOL_member: /* member  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).member)); }
-#line 1798 "parser.c"
+#line 1610 "parser.c"
         break;
 
-    case 126: /* union_dcl  */
+    case YYSYMBOL_union_dcl: /* union_dcl  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).node)); }
-#line 1804 "parser.c"
+#line 1616 "parser.c"
         break;
 
-    case 127: /* union_def  */
+    case YYSYMBOL_union_def: /* union_def  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).union_dcl)); }
-#line 1810 "parser.c"
+#line 1622 "parser.c"
         break;
 
-    case 128: /* union_forward_dcl  */
+    case YYSYMBOL_union_forward_dcl: /* union_forward_dcl  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).forward)); }
-#line 1816 "parser.c"
+#line 1628 "parser.c"
         break;
 
-    case 129: /* union_header  */
+    case YYSYMBOL_union_header: /* union_header  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).union_dcl)); }
-#line 1822 "parser.c"
+#line 1634 "parser.c"
         break;
 
-    case 130: /* switch_header  */
+    case YYSYMBOL_switch_header: /* switch_header  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).switch_type_spec)); }
-#line 1828 "parser.c"
+#line 1640 "parser.c"
         break;
 
-    case 131: /* switch_type_spec  */
+    case YYSYMBOL_switch_type_spec: /* switch_type_spec  */
 #line 211 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).type_spec)); }
-#line 1834 "parser.c"
+#line 1646 "parser.c"
         break;
 
-    case 132: /* switch_body  */
+    case YYSYMBOL_switch_body: /* switch_body  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep)._case)); }
-#line 1840 "parser.c"
+#line 1652 "parser.c"
         break;
 
-    case 133: /* case  */
+    case YYSYMBOL_case: /* case  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep)._case)); }
-#line 1846 "parser.c"
+#line 1658 "parser.c"
         break;
 
-    case 134: /* case_labels  */
+    case YYSYMBOL_case_labels: /* case_labels  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).case_label)); }
-#line 1852 "parser.c"
+#line 1664 "parser.c"
         break;
 
-    case 135: /* case_label  */
+    case YYSYMBOL_case_label: /* case_label  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).case_label)); }
-#line 1858 "parser.c"
+#line 1670 "parser.c"
         break;
 
-    case 136: /* element_spec  */
+    case YYSYMBOL_element_spec: /* element_spec  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep)._case)); }
-#line 1864 "parser.c"
+#line 1676 "parser.c"
         break;
 
-    case 137: /* enum_dcl  */
+    case YYSYMBOL_enum_dcl: /* enum_dcl  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).node)); }
-#line 1870 "parser.c"
+#line 1682 "parser.c"
         break;
 
-    case 138: /* enum_def  */
+    case YYSYMBOL_enum_def: /* enum_def  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).enum_dcl)); }
-#line 1876 "parser.c"
+#line 1688 "parser.c"
         break;
 
-    case 139: /* enumerators  */
+    case YYSYMBOL_enumerators: /* enumerators  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).enumerator)); }
-#line 1882 "parser.c"
+#line 1694 "parser.c"
         break;
 
-    case 140: /* enumerator  */
+    case YYSYMBOL_enumerator: /* enumerator  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).enumerator)); }
-#line 1888 "parser.c"
+#line 1700 "parser.c"
         break;
 
-    case 141: /* bitmask_dcl  */
+    case YYSYMBOL_bitmask_dcl: /* bitmask_dcl  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).node)); }
-#line 1894 "parser.c"
+#line 1706 "parser.c"
         break;
 
-    case 142: /* bitmask_def  */
+    case YYSYMBOL_bitmask_def: /* bitmask_def  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).bitmask_dcl)); }
-#line 1900 "parser.c"
+#line 1712 "parser.c"
         break;
 
-    case 143: /* bit_values  */
+    case YYSYMBOL_bit_values: /* bit_values  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).bit_value)); }
-#line 1906 "parser.c"
+#line 1718 "parser.c"
         break;
 
-    case 144: /* bit_value  */
+    case YYSYMBOL_bit_value: /* bit_value  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).bit_value)); }
-#line 1912 "parser.c"
+#line 1724 "parser.c"
         break;
 
-    case 145: /* array_declarator  */
+    case YYSYMBOL_array_declarator: /* array_declarator  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).declarator)); }
-#line 1918 "parser.c"
+#line 1730 "parser.c"
         break;
 
-    case 146: /* fixed_array_sizes  */
+    case YYSYMBOL_fixed_array_sizes: /* fixed_array_sizes  */
 #line 211 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).const_expr)); }
-#line 1924 "parser.c"
+#line 1736 "parser.c"
         break;
 
-    case 147: /* fixed_array_size  */
+    case YYSYMBOL_fixed_array_size: /* fixed_array_size  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).literal)); }
-#line 1930 "parser.c"
+#line 1742 "parser.c"
         break;
 
-    case 148: /* simple_declarator  */
+    case YYSYMBOL_simple_declarator: /* simple_declarator  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).declarator)); }
-#line 1936 "parser.c"
+#line 1748 "parser.c"
         break;
 
-    case 149: /* complex_declarator  */
+    case YYSYMBOL_complex_declarator: /* complex_declarator  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).declarator)); }
-#line 1942 "parser.c"
+#line 1754 "parser.c"
         break;
 
-    case 150: /* typedef_dcl  */
+    case YYSYMBOL_typedef_dcl: /* typedef_dcl  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).typedef_dcl)); }
-#line 1948 "parser.c"
+#line 1760 "parser.c"
         break;
 
-    case 151: /* declarators  */
+    case YYSYMBOL_declarators: /* declarators  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).declarator)); }
-#line 1954 "parser.c"
+#line 1766 "parser.c"
         break;
 
-    case 152: /* declarator  */
+    case YYSYMBOL_declarator: /* declarator  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).declarator)); }
-#line 1960 "parser.c"
+#line 1772 "parser.c"
         break;
 
-    case 153: /* identifier  */
+    case YYSYMBOL_identifier: /* identifier  */
 #line 205 "src/parser.y"
             { idl_delete_name(((*yyvaluep).name)); }
-#line 1966 "parser.c"
+#line 1778 "parser.c"
         break;
 
-    case 154: /* annotation_dcl  */
+    case YYSYMBOL_annotation_dcl: /* annotation_dcl  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).annotation)); }
-#line 1972 "parser.c"
+#line 1784 "parser.c"
         break;
 
-    case 155: /* annotation_header  */
+    case YYSYMBOL_annotation_header: /* annotation_header  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).annotation)); }
-#line 1978 "parser.c"
+#line 1790 "parser.c"
         break;
 
-    case 157: /* annotation_body  */
+    case YYSYMBOL_annotation_body: /* annotation_body  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).annotation_member)); }
-#line 1984 "parser.c"
+#line 1796 "parser.c"
         break;
 
-    case 158: /* annotation_member  */
+    case YYSYMBOL_annotation_member: /* annotation_member  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).annotation_member)); }
-#line 1990 "parser.c"
+#line 1802 "parser.c"
         break;
 
-    case 159: /* annotation_member_type  */
+    case YYSYMBOL_annotation_member_type: /* annotation_member_type  */
 #line 211 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).type_spec)); }
-#line 1996 "parser.c"
+#line 1808 "parser.c"
         break;
 
-    case 160: /* annotation_member_default  */
+    case YYSYMBOL_annotation_member_default: /* annotation_member_default  */
 #line 211 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).const_expr)); }
-#line 2002 "parser.c"
+#line 1814 "parser.c"
         break;
 
-    case 161: /* any_const_type  */
+    case YYSYMBOL_any_const_type: /* any_const_type  */
 #line 211 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).type_spec)); }
-#line 2008 "parser.c"
+#line 1820 "parser.c"
         break;
 
-    case 162: /* annotations  */
+    case YYSYMBOL_annotations: /* annotations  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).annotation_appl)); }
-#line 2014 "parser.c"
+#line 1826 "parser.c"
         break;
 
-    case 163: /* annotation_appls  */
+    case YYSYMBOL_annotation_appls: /* annotation_appls  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).annotation_appl)); }
-#line 2020 "parser.c"
+#line 1832 "parser.c"
         break;
 
-    case 164: /* annotation_appl  */
+    case YYSYMBOL_annotation_appl: /* annotation_appl  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).annotation_appl)); }
-#line 2026 "parser.c"
+#line 1838 "parser.c"
         break;
 
-    case 165: /* annotation_appl_header  */
+    case YYSYMBOL_annotation_appl_header: /* annotation_appl_header  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).annotation_appl)); }
-#line 2032 "parser.c"
+#line 1844 "parser.c"
         break;
 
-    case 167: /* annotation_appl_name  */
+    case YYSYMBOL_annotation_appl_name: /* annotation_appl_name  */
 #line 208 "src/parser.y"
             { idl_delete_scoped_name(((*yyvaluep).scoped_name)); }
-#line 2038 "parser.c"
+#line 1850 "parser.c"
         break;
 
-    case 168: /* annotation_appl_params  */
+    case YYSYMBOL_annotation_appl_params: /* annotation_appl_params  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).annotation_appl_param)); }
-#line 2044 "parser.c"
+#line 1856 "parser.c"
         break;
 
-    case 169: /* annotation_appl_keyword_params  */
+    case YYSYMBOL_annotation_appl_keyword_params: /* annotation_appl_keyword_params  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).annotation_appl_param)); }
-#line 2050 "parser.c"
+#line 1862 "parser.c"
         break;
 
-    case 170: /* annotation_appl_keyword_param  */
+    case YYSYMBOL_annotation_appl_keyword_param: /* annotation_appl_keyword_param  */
 #line 214 "src/parser.y"
             { idl_delete_node(((*yyvaluep).annotation_appl_param)); }
-#line 2056 "parser.c"
+#line 1868 "parser.c"
         break;
 
       default:
@@ -2063,73 +1875,7 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
 
 
 
-struct yypstate
-  {
-    /* Number of syntax errors so far.  */
-    int yynerrs;
 
-    yy_state_fast_t yystate;
-    /* Number of tokens to shift before error messages enabled.  */
-    int yyerrstatus;
-
-    /* The stacks and their tools:
-       'yyss': related to states.
-       'yyvs': related to semantic values.
-       'yyls': related to locations.
-
-       Refer to the stacks through separate pointers, to allow yyoverflow
-       to reallocate them elsewhere.  */
-
-    /* The state stack.  */
-    yy_state_t yyssa[YYINITDEPTH];
-    yy_state_t *yyss;
-    yy_state_t *yyssp;
-
-    /* The semantic value stack.  */
-    YYSTYPE yyvsa[YYINITDEPTH];
-    YYSTYPE *yyvs;
-    YYSTYPE *yyvsp;
-
-    /* The location stack.  */
-    YYLTYPE yylsa[YYINITDEPTH];
-    YYLTYPE *yyls;
-    YYLTYPE *yylsp;
-
-    /* The locations where the error started and ended.  */
-    YYLTYPE yyerror_range[3];
-
-    YYPTRDIFF_T yystacksize;
-    /* Used to determine if this is the first time this instance has
-       been used.  */
-    int yynew;
-  };
-
-/* Initialize the parser data structure.  */
-yypstate *
-yypstate_new (void)
-{
-  yypstate *yyps;
-  yyps = YY_CAST (yypstate *, malloc (sizeof *yyps));
-  if (!yyps)
-    return YY_NULLPTR;
-  yyps->yynew = 1;
-  return yyps;
-}
-
-void
-yypstate_delete (yypstate *yyps)
-{
-  if (yyps)
-    {
-#ifndef yyoverflow
-      /* If the stack was reallocated but the parse did not complete, then the
-         stack still needs to be freed.  */
-      if (!yyps->yynew && yyps->yyss != yyps->yyssa)
-        YYSTACK_FREE (yyps->yyss);
-#endif
-      free (yyps);
-    }
-}
 
 #define idl_yynerrs yyps->idl_yynerrs
 #define yystate yyps->yystate
@@ -2143,8 +1889,57 @@ yypstate_delete (yypstate *yyps)
 #define yylsa yyps->yylsa
 #define yyls yyps->yyls
 #define yylsp yyps->yylsp
-#define yyerror_range yyps->yyerror_range
 #define yystacksize yyps->yystacksize
+
+/* Initialize the parser data structure.  */
+static void
+yypstate_clear (yypstate *yyps)
+{
+  yynerrs = 0;
+  yystate = 0;
+  yyerrstatus = 0;
+
+  yyssp = yyss;
+  yyvsp = yyvs;
+  yylsp = yyls;
+
+  /* Initialize the state stack, in case yypcontext_expected_tokens is
+     called before the first call to yyparse. */
+  *yyssp = 0;
+  yyps->yynew = 1;
+}
+
+/* Initialize the parser data structure.  */
+yypstate *
+yypstate_new (void)
+{
+  yypstate *yyps;
+  yyps = YY_CAST (yypstate *, malloc (sizeof *yyps));
+  if (!yyps)
+    return YY_NULLPTR;
+  yystacksize = YYINITDEPTH;
+  yyss = yyssa;
+  yyvs = yyvsa;
+  yyls = yylsa;
+  yypstate_clear (yyps);
+  return yyps;
+}
+
+void
+yypstate_delete (yypstate *yyps)
+{
+  if (yyps)
+    {
+#ifndef yyoverflow
+      /* If the stack was reallocated but the parse did not complete, then the
+         stack still needs to be freed.  */
+      if (yyss != yyssa)
+        YYSTACK_FREE (yyss);
+#endif
+      free (yyps);
+    }
+}
+
 
 
 /*---------------.
@@ -2152,9 +1947,10 @@ yypstate_delete (yypstate *yyps)
 `---------------*/
 
 int
-yypush_parse (yypstate *yyps, int yypushed_char, YYSTYPE const *yypushed_val, YYLTYPE *yypushed_loc, idl_pstate_t *pstate, idl_retcode_t *result)
+yypush_parse (yypstate *yyps,
+              int yypushed_char, YYSTYPE const *yypushed_val, YYLTYPE *yypushed_loc, idl_pstate_t *pstate, idl_retcode_t *result)
 {
-/* The lookahead symbol.  */
+/* Lookahead token kind.  */
 int yychar;
 
 
@@ -2173,20 +1969,19 @@ static YYLTYPE yyloc_default
 YYLTYPE yylloc = yyloc_default;
 
   int yyn;
+  /* The return value of yyparse.  */
   int yyresult;
-  /* Lookahead token as an internal (translated) token number.  */
-  int yytoken = 0;
+  /* Lookahead symbol kind.  */
+  yysymbol_kind_t yytoken = YYSYMBOL_YYEMPTY;
   /* The variables used to return semantic value and location from the
      action routines.  */
   YYSTYPE yyval;
   YYLTYPE yyloc;
 
-#if YYERROR_VERBOSE
-  /* Buffer for error messages, and its allocated size.  */
-  char yymsgbuf[128];
-  char *yymsg = yymsgbuf;
-  YYPTRDIFF_T yymsg_alloc = sizeof yymsgbuf;
-#endif
+  /* The locations where the error started and ended.  */
+  YYLTYPE yyerror_range[3];
+
+
 
 #define YYPOPSTACK(N)   (yyvsp -= (N), yyssp -= (N), yylsp -= (N))
 
@@ -2194,23 +1989,21 @@ YYLTYPE yylloc = yyloc_default;
      Keep to zero when no symbol should be popped.  */
   int yylen = 0;
 
-  if (!yyps->yynew)
+  switch (yyps->yynew)
     {
+    case 2:
+      yypstate_clear (yyps);
+      goto case_0;
+
+    case_0:
+    case 0:
       yyn = yypact[yystate];
       goto yyread_pushed_token;
     }
 
-  yyssp = yyss = yyssa;
-  yyvsp = yyvs = yyvsa;
-  yylsp = yyls = yylsa;
-  yystacksize = YYINITDEPTH;
-
   YYDPRINTF ((stderr, "Starting parse\n"));
 
-  yystate = 0;
-  yyerrstatus = 0;
-  yynerrs = 0;
-  yychar = YYEMPTY; /* Cause a token to be read.  */
+  yychar = IDL_YYEMPTY; /* Cause a token to be read.  */
   yylsp[0] = *yypushed_loc;
   goto yysetstate;
 
@@ -2233,6 +2026,7 @@ yysetstate:
   YY_IGNORE_USELESS_CAST_BEGIN
   *yyssp = YY_CAST (yy_state_t, yystate);
   YY_IGNORE_USELESS_CAST_END
+  YY_STACK_PRINT (yyss, yyssp);
 
   if (yyss + yystacksize - 1 <= yyssp)
 #if !defined yyoverflow && !defined YYSTACK_RELOCATE
@@ -2282,7 +2076,7 @@ yysetstate:
         YYSTACK_RELOCATE (yyss_alloc, yyss);
         YYSTACK_RELOCATE (yyvs_alloc, yyvs);
         YYSTACK_RELOCATE (yyls_alloc, yyls);
-# undef YYSTACK_RELOCATE
+#  undef YYSTACK_RELOCATE
         if (yyss1 != yyssa)
           YYSTACK_FREE (yyss1);
       }
@@ -2322,8 +2116,8 @@ yybackup:
 
   /* Not known => get a lookahead token if don't already have one.  */
 
-  /* YYCHAR is either YYEMPTY or YYEOF or a valid lookahead symbol.  */
-  if (yychar == YYEMPTY)
+  /* YYCHAR is either empty, or end-of-input, or a valid lookahead.  */
+  if (yychar == IDL_YYEMPTY)
     {
       if (!yyps->yynew)
         {
@@ -2333,7 +2127,7 @@ yybackup:
         }
       yyps->yynew = 0;
 yyread_pushed_token:
-      YYDPRINTF ((stderr, "Reading a token: "));
+      YYDPRINTF ((stderr, "Reading a token\n"));
       yychar = yypushed_char;
       if (yypushed_val)
         yylval = *yypushed_val;
@@ -2341,10 +2135,22 @@ yyread_pushed_token:
         yylloc = *yypushed_loc;
     }
 
-  if (yychar <= YYEOF)
+  if (yychar <= IDL_YYEOF)
     {
-      yychar = yytoken = YYEOF;
+      yychar = IDL_YYEOF;
+      yytoken = YYSYMBOL_YYEOF;
       YYDPRINTF ((stderr, "Now at end of input.\n"));
+    }
+  else if (yychar == IDL_YYerror)
+    {
+      /* The scanner already issued an error message, process directly
+         to error recovery.  But do not keep the error token as
+         lookahead, it is too special and may lead us to an endless
+         loop in error recovery. */
+      yychar = IDL_YYUNDEF;
+      yytoken = YYSYMBOL_YYerror;
+      yyerror_range[1] = yylloc;
+      goto yyerrlab1;
     }
   else
     {
@@ -2380,7 +2186,7 @@ yyread_pushed_token:
   *++yylsp = yylloc;
 
   /* Discard the shifted token.  */
-  yychar = YYEMPTY;
+  yychar = IDL_YYEMPTY;
   goto yynewstate;
 
 
@@ -2417,137 +2223,137 @@ yyreduce:
   YY_REDUCE_PRINT (yyn);
   switch (yyn)
     {
-  case 2:
+  case 2: /* specification: %empty  */
 #line 287 "src/parser.y"
       { pstate->root = NULL; }
-#line 2424 "parser.c"
+#line 2230 "parser.c"
     break;
 
-  case 3:
+  case 3: /* specification: definitions  */
 #line 289 "src/parser.y"
       { pstate->root = (yyvsp[0].node); }
-#line 2430 "parser.c"
+#line 2236 "parser.c"
     break;
 
-  case 4:
+  case 4: /* definitions: definition  */
 #line 294 "src/parser.y"
       { (yyval.node) = (yyvsp[0].node); }
-#line 2436 "parser.c"
+#line 2242 "parser.c"
     break;
 
-  case 5:
+  case 5: /* definitions: definitions definition  */
 #line 296 "src/parser.y"
       { (yyval.node) = idl_push_node((yyvsp[-1].node), (yyvsp[0].node)); }
-#line 2442 "parser.c"
+#line 2248 "parser.c"
     break;
 
-  case 6:
+  case 6: /* definition: annotation_dcl ';'  */
 #line 301 "src/parser.y"
       { (yyval.node) = (yyvsp[-1].annotation); }
-#line 2448 "parser.c"
+#line 2254 "parser.c"
     break;
 
-  case 7:
+  case 7: /* definition: annotations module_dcl ';'  */
 #line 303 "src/parser.y"
       { TRY(idl_annotate(pstate, (yyvsp[-1].module_dcl), (yyvsp[-2].annotation_appl)));
         (yyval.node) = (yyvsp[-1].module_dcl);
       }
-#line 2456 "parser.c"
+#line 2262 "parser.c"
     break;
 
-  case 8:
+  case 8: /* definition: annotations const_dcl ';'  */
 #line 307 "src/parser.y"
       { TRY(idl_annotate(pstate, (yyvsp[-1].const_dcl), (yyvsp[-2].annotation_appl)));
         (yyval.node) = (yyvsp[-1].const_dcl);
       }
-#line 2464 "parser.c"
+#line 2270 "parser.c"
     break;
 
-  case 9:
+  case 9: /* definition: annotations type_dcl ';'  */
 #line 311 "src/parser.y"
       { TRY(idl_annotate(pstate, (yyvsp[-1].node), (yyvsp[-2].annotation_appl)));
         (yyval.node) = (yyvsp[-1].node);
       }
-#line 2472 "parser.c"
+#line 2278 "parser.c"
     break;
 
-  case 10:
+  case 10: /* module_dcl: module_header '{' definitions '}'  */
 #line 318 "src/parser.y"
       { TRY(idl_finalize_module(pstate, LOC((yylsp[-3]).first, (yylsp[0]).last), (yyvsp[-3].module_dcl), (yyvsp[-1].node)));
         (yyval.module_dcl) = (yyvsp[-3].module_dcl);
       }
-#line 2480 "parser.c"
+#line 2286 "parser.c"
     break;
 
-  case 11:
+  case 11: /* module_header: "module" identifier  */
 #line 325 "src/parser.y"
       { TRY(idl_create_module(pstate, LOC((yylsp[-1]).first, (yylsp[0]).last), (yyvsp[0].name), &(yyval.module_dcl))); }
-#line 2486 "parser.c"
+#line 2292 "parser.c"
     break;
 
-  case 12:
+  case 12: /* scoped_name: identifier  */
 #line 330 "src/parser.y"
       { TRY(idl_create_scoped_name(pstate, &(yylsp[0]), (yyvsp[0].name), false, &(yyval.scoped_name))); }
-#line 2492 "parser.c"
+#line 2298 "parser.c"
     break;
 
-  case 13:
+  case 13: /* scoped_name: IDL_TOKEN_SCOPE identifier  */
 #line 332 "src/parser.y"
       { TRY(idl_create_scoped_name(pstate, LOC((yylsp[-1]).first, (yylsp[0]).last), (yyvsp[0].name), true, &(yyval.scoped_name))); }
-#line 2498 "parser.c"
+#line 2304 "parser.c"
     break;
 
-  case 14:
+  case 14: /* scoped_name: scoped_name IDL_TOKEN_SCOPE identifier  */
 #line 334 "src/parser.y"
       { TRY(idl_push_scoped_name(pstate, (yyvsp[-2].scoped_name), (yyvsp[0].name)));
         (yyval.scoped_name) = (yyvsp[-2].scoped_name);
       }
-#line 2506 "parser.c"
+#line 2312 "parser.c"
     break;
 
-  case 15:
+  case 15: /* const_dcl: "const" const_type identifier '=' const_expr  */
 #line 341 "src/parser.y"
       { TRY(idl_create_const(pstate, LOC((yylsp[-4]).first, (yylsp[0]).last), (yyvsp[-3].type_spec), (yyvsp[-2].name), (yyvsp[0].const_expr), &(yyval.const_dcl))); }
-#line 2512 "parser.c"
+#line 2318 "parser.c"
     break;
 
-  case 16:
+  case 16: /* const_type: integer_type  */
 #line 346 "src/parser.y"
       { TRY(idl_create_base_type(pstate, &(yylsp[0]), (yyvsp[0].kind), &(yyval.type_spec))); }
-#line 2518 "parser.c"
+#line 2324 "parser.c"
     break;
 
-  case 17:
+  case 17: /* const_type: floating_pt_type  */
 #line 348 "src/parser.y"
       { TRY(idl_create_base_type(pstate, &(yylsp[0]), (yyvsp[0].kind), &(yyval.type_spec))); }
-#line 2524 "parser.c"
+#line 2330 "parser.c"
     break;
 
-  case 18:
+  case 18: /* const_type: char_type  */
 #line 350 "src/parser.y"
       { TRY(idl_create_base_type(pstate, &(yylsp[0]), (yyvsp[0].kind), &(yyval.type_spec))); }
-#line 2530 "parser.c"
+#line 2336 "parser.c"
     break;
 
-  case 19:
+  case 19: /* const_type: boolean_type  */
 #line 352 "src/parser.y"
       { TRY(idl_create_base_type(pstate, &(yylsp[0]), (yyvsp[0].kind), &(yyval.type_spec))); }
-#line 2536 "parser.c"
+#line 2342 "parser.c"
     break;
 
-  case 20:
+  case 20: /* const_type: octet_type  */
 #line 354 "src/parser.y"
       { TRY(idl_create_base_type(pstate, &(yylsp[0]), (yyvsp[0].kind), &(yyval.type_spec))); }
-#line 2542 "parser.c"
+#line 2348 "parser.c"
     break;
 
-  case 21:
+  case 21: /* const_type: string_type  */
 #line 356 "src/parser.y"
       { (yyval.type_spec) = (idl_type_spec_t *)(yyvsp[0].string); }
-#line 2548 "parser.c"
+#line 2354 "parser.c"
     break;
 
-  case 22:
+  case 22: /* const_type: scoped_name  */
 #line 358 "src/parser.y"
       { idl_node_t *node;
         const idl_declaration_t *declaration;
@@ -2560,151 +2366,151 @@ yyreduce:
         (yyval.type_spec) = idl_reference_node((idl_node_t *)declaration->node);
         idl_delete_scoped_name((yyvsp[0].scoped_name));
       }
-#line 2564 "parser.c"
+#line 2370 "parser.c"
     break;
 
-  case 23:
+  case 23: /* const_expr: or_expr  */
 #line 371 "src/parser.y"
                     { (yyval.const_expr) = (yyvsp[0].const_expr); }
-#line 2570 "parser.c"
+#line 2376 "parser.c"
     break;
 
-  case 25:
+  case 25: /* or_expr: or_expr '|' xor_expr  */
 #line 376 "src/parser.y"
       { (yyval.const_expr) = NULL;
         if (pstate->parser.state != IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS)
           TRY(idl_create_binary_expr(pstate, &(yylsp[-1]), IDL_OR, (yyvsp[-2].const_expr), (yyvsp[0].const_expr), &(yyval.const_expr)));
       }
-#line 2579 "parser.c"
+#line 2385 "parser.c"
     break;
 
-  case 27:
+  case 27: /* xor_expr: xor_expr '^' and_expr  */
 #line 385 "src/parser.y"
       { (yyval.const_expr) = NULL;
         if (pstate->parser.state != IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS)
           TRY(idl_create_binary_expr(pstate, &(yylsp[-1]), IDL_XOR, (yyvsp[-2].const_expr), (yyvsp[0].const_expr), &(yyval.const_expr)));
       }
-#line 2588 "parser.c"
+#line 2394 "parser.c"
     break;
 
-  case 29:
+  case 29: /* and_expr: and_expr '&' shift_expr  */
 #line 394 "src/parser.y"
       { (yyval.const_expr) = NULL;
         if (pstate->parser.state != IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS)
           TRY(idl_create_binary_expr(pstate, &(yylsp[-1]), IDL_AND, (yyvsp[-2].const_expr), (yyvsp[0].const_expr), &(yyval.const_expr)));
       }
-#line 2597 "parser.c"
+#line 2403 "parser.c"
     break;
 
-  case 31:
+  case 31: /* shift_expr: shift_expr shift_operator add_expr  */
 #line 403 "src/parser.y"
       { (yyval.const_expr) = NULL;
         if (pstate->parser.state != IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS)
           TRY(idl_create_binary_expr(pstate, &(yylsp[-1]), (yyvsp[-1].kind), (yyvsp[-2].const_expr), (yyvsp[0].const_expr), &(yyval.const_expr)));
       }
-#line 2606 "parser.c"
+#line 2412 "parser.c"
     break;
 
-  case 32:
+  case 32: /* shift_operator: ">>"  */
 #line 410 "src/parser.y"
          { (yyval.kind) = IDL_RSHIFT; }
-#line 2612 "parser.c"
+#line 2418 "parser.c"
     break;
 
-  case 33:
+  case 33: /* shift_operator: "<<"  */
 #line 411 "src/parser.y"
          { (yyval.kind) = IDL_LSHIFT; }
-#line 2618 "parser.c"
+#line 2424 "parser.c"
     break;
 
-  case 35:
+  case 35: /* add_expr: add_expr add_operator mult_expr  */
 #line 416 "src/parser.y"
       { (yyval.const_expr) = NULL;
         if (pstate->parser.state != IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS)
           TRY(idl_create_binary_expr(pstate, &(yylsp[-1]), (yyvsp[-1].kind), (yyvsp[-2].const_expr), (yyvsp[0].const_expr), &(yyval.const_expr)));
       }
-#line 2627 "parser.c"
+#line 2433 "parser.c"
     break;
 
-  case 36:
+  case 36: /* add_operator: '+'  */
 #line 423 "src/parser.y"
         { (yyval.kind) = IDL_ADD; }
-#line 2633 "parser.c"
+#line 2439 "parser.c"
     break;
 
-  case 37:
+  case 37: /* add_operator: '-'  */
 #line 424 "src/parser.y"
         { (yyval.kind) = IDL_SUBTRACT; }
-#line 2639 "parser.c"
+#line 2445 "parser.c"
     break;
 
-  case 38:
+  case 38: /* mult_expr: unary_expr  */
 #line 428 "src/parser.y"
       { (yyval.const_expr) = (yyvsp[0].const_expr); }
-#line 2645 "parser.c"
+#line 2451 "parser.c"
     break;
 
-  case 39:
+  case 39: /* mult_expr: mult_expr mult_operator unary_expr  */
 #line 430 "src/parser.y"
       { (yyval.const_expr) = NULL;
         if (pstate->parser.state != IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS)
           TRY(idl_create_binary_expr(pstate, &(yylsp[-1]), (yyvsp[-1].kind), (yyvsp[-2].const_expr), (yyvsp[0].const_expr), &(yyval.const_expr)));
       }
-#line 2654 "parser.c"
+#line 2460 "parser.c"
     break;
 
-  case 40:
+  case 40: /* mult_operator: '*'  */
 #line 437 "src/parser.y"
         { (yyval.kind) = IDL_MULTIPLY; }
-#line 2660 "parser.c"
+#line 2466 "parser.c"
     break;
 
-  case 41:
+  case 41: /* mult_operator: '/'  */
 #line 438 "src/parser.y"
         { (yyval.kind) = IDL_DIVIDE; }
-#line 2666 "parser.c"
+#line 2472 "parser.c"
     break;
 
-  case 42:
+  case 42: /* mult_operator: '%'  */
 #line 439 "src/parser.y"
         { (yyval.kind) = IDL_MODULO; }
-#line 2672 "parser.c"
+#line 2478 "parser.c"
     break;
 
-  case 43:
+  case 43: /* unary_expr: unary_operator primary_expr  */
 #line 443 "src/parser.y"
       { (yyval.const_expr) = NULL;
         if (pstate->parser.state != IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS)
           TRY(idl_create_unary_expr(pstate, &(yylsp[-1]), (yyvsp[-1].kind), (yyvsp[0].const_expr), &(yyval.const_expr)));
       }
-#line 2681 "parser.c"
+#line 2487 "parser.c"
     break;
 
-  case 44:
+  case 44: /* unary_expr: primary_expr  */
 #line 448 "src/parser.y"
       { (yyval.const_expr) = (yyvsp[0].const_expr); }
-#line 2687 "parser.c"
+#line 2493 "parser.c"
     break;
 
-  case 45:
+  case 45: /* unary_operator: '-'  */
 #line 452 "src/parser.y"
         { (yyval.kind) = IDL_MINUS; }
-#line 2693 "parser.c"
+#line 2499 "parser.c"
     break;
 
-  case 46:
+  case 46: /* unary_operator: '+'  */
 #line 453 "src/parser.y"
         { (yyval.kind) = IDL_PLUS; }
-#line 2699 "parser.c"
+#line 2505 "parser.c"
     break;
 
-  case 47:
+  case 47: /* unary_operator: '~'  */
 #line 454 "src/parser.y"
         { (yyval.kind) = IDL_NOT; }
-#line 2705 "parser.c"
+#line 2511 "parser.c"
     break;
 
-  case 48:
+  case 48: /* primary_expr: scoped_name  */
 #line 459 "src/parser.y"
       { (yyval.const_expr) = NULL;
         if (pstate->parser.state != IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS) {
@@ -2721,22 +2527,22 @@ yyreduce:
         }
         idl_delete_scoped_name((yyvsp[0].scoped_name));
       }
-#line 2725 "parser.c"
+#line 2531 "parser.c"
     break;
 
-  case 49:
+  case 49: /* primary_expr: literal  */
 #line 475 "src/parser.y"
       { (yyval.const_expr) = (yyvsp[0].literal); }
-#line 2731 "parser.c"
+#line 2537 "parser.c"
     break;
 
-  case 50:
+  case 50: /* primary_expr: '(' const_expr ')'  */
 #line 477 "src/parser.y"
       { (yyval.const_expr) = (yyvsp[-1].const_expr); }
-#line 2737 "parser.c"
+#line 2543 "parser.c"
     break;
 
-  case 51:
+  case 51: /* literal: IDL_TOKEN_INTEGER_LITERAL  */
 #line 482 "src/parser.y"
       { idl_type_t type;
         idl_literal_t literal;
@@ -2759,10 +2565,10 @@ yyreduce:
         TRY(idl_create_literal(pstate, &(yylsp[0]), type, &(yyval.literal)));
         (yyval.literal)->value = literal.value;
       }
-#line 2763 "parser.c"
+#line 2569 "parser.c"
     break;
 
-  case 52:
+  case 52: /* literal: IDL_TOKEN_FLOATING_PT_LITERAL  */
 #line 504 "src/parser.y"
       { idl_type_t type;
         idl_literal_t literal;
@@ -2786,10 +2592,10 @@ _Pragma("GCC diagnostic pop")
         TRY(idl_create_literal(pstate, &(yylsp[0]), type, &(yyval.literal)));
         (yyval.literal)->value = literal.value;
       }
-#line 2790 "parser.c"
+#line 2596 "parser.c"
     break;
 
-  case 53:
+  case 53: /* literal: IDL_TOKEN_CHAR_LITERAL  */
 #line 527 "src/parser.y"
       { (yyval.literal) = NULL;
         if (pstate->parser.state == IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS)
@@ -2797,10 +2603,10 @@ _Pragma("GCC diagnostic pop")
         TRY(idl_create_literal(pstate, &(yylsp[0]), IDL_CHAR, &(yyval.literal)));
         (yyval.literal)->value.chr = (yyvsp[0].chr);
       }
-#line 2801 "parser.c"
+#line 2607 "parser.c"
     break;
 
-  case 54:
+  case 54: /* literal: boolean_literal  */
 #line 534 "src/parser.y"
       { (yyval.literal) = NULL;
         if (pstate->parser.state == IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS)
@@ -2808,10 +2614,10 @@ _Pragma("GCC diagnostic pop")
         TRY(idl_create_literal(pstate, &(yylsp[0]), IDL_BOOL, &(yyval.literal)));
         (yyval.literal)->value.bln = (yyvsp[0].bln);
       }
-#line 2812 "parser.c"
+#line 2618 "parser.c"
     break;
 
-  case 55:
+  case 55: /* literal: string_literal  */
 #line 541 "src/parser.y"
       { (yyval.literal) = NULL;
         if (pstate->parser.state == IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS)
@@ -2819,22 +2625,22 @@ _Pragma("GCC diagnostic pop")
         TRY(idl_create_literal(pstate, &(yylsp[0]), IDL_STRING, &(yyval.literal)));
         (yyval.literal)->value.str = (yyvsp[0].string_literal);
       }
-#line 2823 "parser.c"
+#line 2629 "parser.c"
     break;
 
-  case 56:
+  case 56: /* boolean_literal: "TRUE"  */
 #line 551 "src/parser.y"
       { (yyval.bln) = true; }
-#line 2829 "parser.c"
+#line 2635 "parser.c"
     break;
 
-  case 57:
+  case 57: /* boolean_literal: "FALSE"  */
 #line 553 "src/parser.y"
       { (yyval.bln) = false; }
-#line 2835 "parser.c"
+#line 2641 "parser.c"
     break;
 
-  case 58:
+  case 58: /* string_literal: IDL_TOKEN_STRING_LITERAL  */
 #line 558 "src/parser.y"
       { (yyval.string_literal) = NULL;
         if (pstate->parser.state == IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS)
@@ -2842,10 +2648,10 @@ _Pragma("GCC diagnostic pop")
         if (!((yyval.string_literal) = idl_strdup((yyvsp[0].str))))
           NO_MEMORY();
       }
-#line 2846 "parser.c"
+#line 2652 "parser.c"
     break;
 
-  case 59:
+  case 59: /* string_literal: string_literal IDL_TOKEN_STRING_LITERAL  */
 #line 565 "src/parser.y"
       { size_t n1, n2;
         (yyval.string_literal) = NULL;
@@ -2859,34 +2665,34 @@ _Pragma("GCC diagnostic pop")
         memmove((yyval.string_literal)+n1, (yyvsp[0].str), n2);
         (yyval.string_literal)[n1+n2] = '\0';
       }
-#line 2863 "parser.c"
+#line 2669 "parser.c"
     break;
 
-  case 60:
+  case 60: /* positive_int_const: const_expr  */
 #line 581 "src/parser.y"
       { TRY(idl_evaluate(pstate, (yyvsp[0].const_expr), IDL_ULONG, &(yyval.literal))); }
-#line 2869 "parser.c"
+#line 2675 "parser.c"
     break;
 
-  case 61:
+  case 61: /* type_dcl: constr_type_dcl  */
 #line 585 "src/parser.y"
                     { (yyval.node) = (yyvsp[0].node); }
-#line 2875 "parser.c"
+#line 2681 "parser.c"
     break;
 
-  case 62:
+  case 62: /* type_dcl: typedef_dcl  */
 #line 586 "src/parser.y"
                 { (yyval.node) = (yyvsp[0].typedef_dcl); }
-#line 2881 "parser.c"
+#line 2687 "parser.c"
     break;
 
-  case 65:
+  case 65: /* simple_type_spec: base_type_spec  */
 #line 597 "src/parser.y"
       { TRY(idl_create_base_type(pstate, &(yylsp[0]), (yyvsp[0].kind), &(yyval.type_spec))); }
-#line 2887 "parser.c"
+#line 2693 "parser.c"
     break;
 
-  case 66:
+  case 66: /* simple_type_spec: scoped_name  */
 #line 599 "src/parser.y"
       { const idl_declaration_t *declaration = NULL;
         static const char fmt[] =
@@ -2897,210 +2703,210 @@ _Pragma("GCC diagnostic pop")
         (yyval.type_spec) = idl_reference_node((idl_node_t *)declaration->node);
         idl_delete_scoped_name((yyvsp[0].scoped_name));
       }
-#line 2901 "parser.c"
+#line 2707 "parser.c"
     break;
 
-  case 73:
+  case 73: /* floating_pt_type: "float"  */
 #line 620 "src/parser.y"
             { (yyval.kind) = IDL_FLOAT; }
-#line 2907 "parser.c"
+#line 2713 "parser.c"
     break;
 
-  case 74:
+  case 74: /* floating_pt_type: "double"  */
 #line 621 "src/parser.y"
              { (yyval.kind) = IDL_DOUBLE; }
-#line 2913 "parser.c"
+#line 2719 "parser.c"
     break;
 
-  case 75:
+  case 75: /* floating_pt_type: "long" "double"  */
 #line 622 "src/parser.y"
                     { (yyval.kind) = IDL_LDOUBLE; }
-#line 2919 "parser.c"
+#line 2725 "parser.c"
     break;
 
-  case 78:
+  case 78: /* signed_int: "short"  */
 #line 631 "src/parser.y"
             { (yyval.kind) = IDL_SHORT; }
-#line 2925 "parser.c"
+#line 2731 "parser.c"
     break;
 
-  case 79:
+  case 79: /* signed_int: "long"  */
 #line 632 "src/parser.y"
            { (yyval.kind) = IDL_LONG; }
-#line 2931 "parser.c"
+#line 2737 "parser.c"
     break;
 
-  case 80:
+  case 80: /* signed_int: "long" "long"  */
 #line 633 "src/parser.y"
                   { (yyval.kind) = IDL_LLONG; }
-#line 2937 "parser.c"
+#line 2743 "parser.c"
     break;
 
-  case 81:
+  case 81: /* signed_int: "int8"  */
 #line 635 "src/parser.y"
            { (yyval.kind) = IDL_INT8; }
-#line 2943 "parser.c"
+#line 2749 "parser.c"
     break;
 
-  case 82:
+  case 82: /* signed_int: "int16"  */
 #line 636 "src/parser.y"
             { (yyval.kind) = IDL_INT16; }
-#line 2949 "parser.c"
+#line 2755 "parser.c"
     break;
 
-  case 83:
+  case 83: /* signed_int: "int32"  */
 #line 637 "src/parser.y"
             { (yyval.kind) = IDL_INT32; }
-#line 2955 "parser.c"
+#line 2761 "parser.c"
     break;
 
-  case 84:
+  case 84: /* signed_int: "int64"  */
 #line 638 "src/parser.y"
             { (yyval.kind) = IDL_INT64; }
-#line 2961 "parser.c"
+#line 2767 "parser.c"
     break;
 
-  case 85:
+  case 85: /* unsigned_int: "unsigned" "short"  */
 #line 642 "src/parser.y"
                        { (yyval.kind) = IDL_USHORT; }
-#line 2967 "parser.c"
+#line 2773 "parser.c"
     break;
 
-  case 86:
+  case 86: /* unsigned_int: "unsigned" "long"  */
 #line 643 "src/parser.y"
                       { (yyval.kind) = IDL_ULONG; }
-#line 2973 "parser.c"
+#line 2779 "parser.c"
     break;
 
-  case 87:
+  case 87: /* unsigned_int: "unsigned" "long" "long"  */
 #line 644 "src/parser.y"
                              { (yyval.kind) = IDL_ULLONG; }
-#line 2979 "parser.c"
+#line 2785 "parser.c"
     break;
 
-  case 88:
+  case 88: /* unsigned_int: "uint8"  */
 #line 646 "src/parser.y"
             { (yyval.kind) = IDL_UINT8; }
-#line 2985 "parser.c"
+#line 2791 "parser.c"
     break;
 
-  case 89:
+  case 89: /* unsigned_int: "uint16"  */
 #line 647 "src/parser.y"
              { (yyval.kind) = IDL_UINT16; }
-#line 2991 "parser.c"
+#line 2797 "parser.c"
     break;
 
-  case 90:
+  case 90: /* unsigned_int: "uint32"  */
 #line 648 "src/parser.y"
              { (yyval.kind) = IDL_UINT32; }
-#line 2997 "parser.c"
+#line 2803 "parser.c"
     break;
 
-  case 91:
+  case 91: /* unsigned_int: "uint64"  */
 #line 649 "src/parser.y"
              { (yyval.kind) = IDL_UINT64; }
-#line 3003 "parser.c"
+#line 2809 "parser.c"
     break;
 
-  case 92:
+  case 92: /* char_type: "char"  */
 #line 653 "src/parser.y"
            { (yyval.kind) = IDL_CHAR; }
-#line 3009 "parser.c"
+#line 2815 "parser.c"
     break;
 
-  case 93:
+  case 93: /* wide_char_type: "wchar"  */
 #line 656 "src/parser.y"
             { (yyval.kind) = IDL_WCHAR; }
-#line 3015 "parser.c"
+#line 2821 "parser.c"
     break;
 
-  case 94:
+  case 94: /* boolean_type: "boolean"  */
 #line 659 "src/parser.y"
               { (yyval.kind) = IDL_BOOL; }
-#line 3021 "parser.c"
+#line 2827 "parser.c"
     break;
 
-  case 95:
+  case 95: /* octet_type: "octet"  */
 #line 662 "src/parser.y"
             { (yyval.kind) = IDL_OCTET; }
-#line 3027 "parser.c"
+#line 2833 "parser.c"
     break;
 
-  case 96:
+  case 96: /* template_type_spec: sequence_type  */
 #line 665 "src/parser.y"
                   { (yyval.type_spec) = (yyvsp[0].sequence); }
-#line 3033 "parser.c"
+#line 2839 "parser.c"
     break;
 
-  case 97:
+  case 97: /* template_type_spec: string_type  */
 #line 666 "src/parser.y"
                   { (yyval.type_spec) = (yyvsp[0].string); }
-#line 3039 "parser.c"
+#line 2845 "parser.c"
     break;
 
-  case 98:
+  case 98: /* sequence_type: "sequence" '<' type_spec ',' positive_int_const '>'  */
 #line 671 "src/parser.y"
       { TRY(idl_create_sequence(pstate, LOC((yylsp[-5]).first, (yylsp[0]).last), (yyvsp[-3].type_spec), (yyvsp[-1].literal), &(yyval.sequence))); }
-#line 3045 "parser.c"
+#line 2851 "parser.c"
     break;
 
-  case 99:
+  case 99: /* sequence_type: "sequence" '<' type_spec '>'  */
 #line 673 "src/parser.y"
       { TRY(idl_create_sequence(pstate, LOC((yylsp[-3]).first, (yylsp[0]).last), (yyvsp[-1].type_spec), NULL, &(yyval.sequence))); }
-#line 3051 "parser.c"
+#line 2857 "parser.c"
     break;
 
-  case 100:
+  case 100: /* string_type: "string" '<' positive_int_const '>'  */
 #line 678 "src/parser.y"
       { TRY(idl_create_string(pstate, LOC((yylsp[-3]).first, (yylsp[0]).last), (yyvsp[-1].literal), &(yyval.string))); }
-#line 3057 "parser.c"
+#line 2863 "parser.c"
     break;
 
-  case 101:
+  case 101: /* string_type: "string"  */
 #line 680 "src/parser.y"
       { TRY(idl_create_string(pstate, LOC((yylsp[0]).first, (yylsp[0]).last), NULL, &(yyval.string))); }
-#line 3063 "parser.c"
+#line 2869 "parser.c"
     break;
 
-  case 106:
+  case 106: /* struct_dcl: struct_def  */
 #line 691 "src/parser.y"
                { (yyval.node) = (yyvsp[0].struct_dcl); }
-#line 3069 "parser.c"
+#line 2875 "parser.c"
     break;
 
-  case 107:
+  case 107: /* struct_dcl: struct_forward_dcl  */
 #line 692 "src/parser.y"
                        { (yyval.node) = (yyvsp[0].forward); }
-#line 3075 "parser.c"
+#line 2881 "parser.c"
     break;
 
-  case 108:
+  case 108: /* struct_forward_dcl: "struct" identifier  */
 #line 697 "src/parser.y"
       { TRY(idl_create_forward(pstate, &(yylsp[-1]), (yyvsp[0].name), IDL_STRUCT, &(yyval.forward))); }
-#line 3081 "parser.c"
+#line 2887 "parser.c"
     break;
 
-  case 109:
+  case 109: /* struct_def: struct_header '{' struct_body '}'  */
 #line 702 "src/parser.y"
       { TRY(idl_finalize_struct(pstate, LOC((yylsp[-3]).first, (yylsp[0]).last), (yyvsp[-3].struct_dcl), (yyvsp[-1].member)));
         (yyval.struct_dcl) = (yyvsp[-3].struct_dcl);
       }
-#line 3089 "parser.c"
+#line 2895 "parser.c"
     break;
 
-  case 110:
+  case 110: /* struct_header: "struct" identifier struct_inherit_spec  */
 #line 709 "src/parser.y"
       { TRY(idl_create_struct(pstate, LOC((yylsp[-2]).first, (yyvsp[0].type_spec) ? (yylsp[0]).last : (yylsp[-1]).last), (yyvsp[-1].name), (yyvsp[0].type_spec), &(yyval.struct_dcl))); }
-#line 3095 "parser.c"
+#line 2901 "parser.c"
     break;
 
-  case 111:
+  case 111: /* struct_inherit_spec: %empty  */
 #line 713 "src/parser.y"
             { (yyval.type_spec) = NULL; }
-#line 3101 "parser.c"
+#line 2907 "parser.c"
     break;
 
-  case 112:
+  case 112: /* struct_inherit_spec: ':' scoped_name  */
 #line 717 "src/parser.y"
       { idl_node_t *node;
         const idl_declaration_t *declaration;
@@ -3113,74 +2919,74 @@ _Pragma("GCC diagnostic pop")
         TRY(idl_create_inherit_spec(pstate, &(yylsp[0]), idl_reference_node(node), &(yyval.type_spec)));
         idl_delete_scoped_name((yyvsp[0].scoped_name));
       }
-#line 3117 "parser.c"
+#line 2923 "parser.c"
     break;
 
-  case 113:
+  case 113: /* struct_body: members  */
 #line 732 "src/parser.y"
       { (yyval.member) = (yyvsp[0].member); }
-#line 3123 "parser.c"
+#line 2929 "parser.c"
     break;
 
-  case 114:
+  case 114: /* struct_body: %empty  */
 #line 736 "src/parser.y"
       { (yyval.member) = NULL; }
-#line 3129 "parser.c"
+#line 2935 "parser.c"
     break;
 
-  case 115:
+  case 115: /* members: member  */
 #line 741 "src/parser.y"
       { (yyval.member) = (yyvsp[0].member); }
-#line 3135 "parser.c"
+#line 2941 "parser.c"
     break;
 
-  case 116:
+  case 116: /* members: members member  */
 #line 743 "src/parser.y"
       { (yyval.member) = idl_push_node((yyvsp[-1].member), (yyvsp[0].member)); }
-#line 3141 "parser.c"
+#line 2947 "parser.c"
     break;
 
-  case 117:
+  case 117: /* member: annotations type_spec declarators ';'  */
 #line 748 "src/parser.y"
       { TRY(idl_create_member(pstate, LOC((yylsp[-2]).first, (yylsp[0]).last), (yyvsp[-2].type_spec), (yyvsp[-1].declarator), &(yyval.member)));
         TRY_EXCEPT(idl_annotate(pstate, (yyval.member), (yyvsp[-3].annotation_appl)), free((yyval.member)));
       }
-#line 3149 "parser.c"
+#line 2955 "parser.c"
     break;
 
-  case 118:
+  case 118: /* union_dcl: union_def  */
 #line 754 "src/parser.y"
               { (yyval.node) = (yyvsp[0].union_dcl); }
-#line 3155 "parser.c"
+#line 2961 "parser.c"
     break;
 
-  case 119:
+  case 119: /* union_dcl: union_forward_dcl  */
 #line 755 "src/parser.y"
                       { (yyval.node) = (yyvsp[0].forward); }
-#line 3161 "parser.c"
+#line 2967 "parser.c"
     break;
 
-  case 120:
+  case 120: /* union_def: union_header '{' switch_body '}'  */
 #line 760 "src/parser.y"
       { TRY(idl_finalize_union(pstate, LOC((yylsp[-3]).first, (yylsp[0]).last), (yyvsp[-3].union_dcl), (yyvsp[-1]._case)));
         (yyval.union_dcl) = (yyvsp[-3].union_dcl);
       }
-#line 3169 "parser.c"
+#line 2975 "parser.c"
     break;
 
-  case 121:
+  case 121: /* union_forward_dcl: "union" identifier  */
 #line 767 "src/parser.y"
       { TRY(idl_create_forward(pstate, &(yylsp[-1]), (yyvsp[0].name), IDL_UNION, &(yyval.forward))); }
-#line 3175 "parser.c"
+#line 2981 "parser.c"
     break;
 
-  case 122:
+  case 122: /* union_header: "union" identifier switch_header  */
 #line 772 "src/parser.y"
       { TRY(idl_create_union(pstate, LOC((yylsp[-2]).first, (yylsp[0]).last), (yyvsp[-1].name), (yyvsp[0].switch_type_spec), &(yyval.union_dcl))); }
-#line 3181 "parser.c"
+#line 2987 "parser.c"
     break;
 
-  case 123:
+  case 123: /* switch_header: "switch" '(' annotations switch_type_spec ')'  */
 #line 777 "src/parser.y"
       { /* switch_header action is a separate non-terminal, as opposed to a
            mid-rule action, to avoid freeing the type specifier twice (once
@@ -3189,202 +2995,202 @@ _Pragma("GCC diagnostic pop")
         TRY(idl_create_switch_type_spec(pstate, &(yylsp[-1]), (yyvsp[-1].type_spec), &(yyval.switch_type_spec)));
         TRY_EXCEPT(idl_annotate(pstate, (yyval.switch_type_spec), (yyvsp[-2].annotation_appl)), idl_delete_node((yyval.switch_type_spec)));
       }
-#line 3193 "parser.c"
+#line 2999 "parser.c"
     break;
 
-  case 124:
+  case 124: /* switch_type_spec: integer_type  */
 #line 788 "src/parser.y"
       { TRY(idl_create_base_type(pstate, &(yylsp[0]), (yyvsp[0].kind), &(yyval.type_spec))); }
-#line 3199 "parser.c"
+#line 3005 "parser.c"
     break;
 
-  case 125:
+  case 125: /* switch_type_spec: char_type  */
 #line 790 "src/parser.y"
       { TRY(idl_create_base_type(pstate, &(yylsp[0]), (yyvsp[0].kind), &(yyval.type_spec))); }
-#line 3205 "parser.c"
+#line 3011 "parser.c"
     break;
 
-  case 126:
+  case 126: /* switch_type_spec: boolean_type  */
 #line 792 "src/parser.y"
       { TRY(idl_create_base_type(pstate, &(yylsp[0]), (yyvsp[0].kind), &(yyval.type_spec))); }
-#line 3211 "parser.c"
+#line 3017 "parser.c"
     break;
 
-  case 127:
+  case 127: /* switch_type_spec: scoped_name  */
 #line 794 "src/parser.y"
       { const idl_declaration_t *declaration;
         TRY(idl_resolve(pstate, 0u, (yyvsp[0].scoped_name), &declaration));
         idl_delete_scoped_name((yyvsp[0].scoped_name));
         (yyval.type_spec) = idl_reference_node((idl_node_t *)declaration->node);
       }
-#line 3221 "parser.c"
+#line 3027 "parser.c"
     break;
 
-  case 128:
+  case 128: /* switch_type_spec: wide_char_type  */
 #line 800 "src/parser.y"
       { TRY(idl_create_base_type(pstate, &(yylsp[0]), (yyvsp[0].kind), &(yyval.type_spec))); }
-#line 3227 "parser.c"
+#line 3033 "parser.c"
     break;
 
-  case 129:
+  case 129: /* switch_type_spec: octet_type  */
 #line 802 "src/parser.y"
       { TRY(idl_create_base_type(pstate, &(yylsp[0]), (yyvsp[0].kind), &(yyval.type_spec))); }
-#line 3233 "parser.c"
+#line 3039 "parser.c"
     break;
 
-  case 130:
+  case 130: /* switch_body: case  */
 #line 807 "src/parser.y"
       { (yyval._case) = (yyvsp[0]._case); }
-#line 3239 "parser.c"
+#line 3045 "parser.c"
     break;
 
-  case 131:
+  case 131: /* switch_body: switch_body case  */
 #line 809 "src/parser.y"
       { (yyval._case) = idl_push_node((yyvsp[-1]._case), (yyvsp[0]._case)); }
-#line 3245 "parser.c"
+#line 3051 "parser.c"
     break;
 
-  case 132:
+  case 132: /* case: case_labels element_spec ';'  */
 #line 814 "src/parser.y"
       { TRY(idl_finalize_case(pstate, &(yylsp[-1]), (yyvsp[-1]._case), (yyvsp[-2].case_label)));
         (yyval._case) = (yyvsp[-1]._case);
       }
-#line 3253 "parser.c"
+#line 3059 "parser.c"
     break;
 
-  case 133:
+  case 133: /* case_labels: case_label  */
 #line 821 "src/parser.y"
       { (yyval.case_label) = (yyvsp[0].case_label); }
-#line 3259 "parser.c"
+#line 3065 "parser.c"
     break;
 
-  case 134:
+  case 134: /* case_labels: case_labels case_label  */
 #line 823 "src/parser.y"
       { (yyval.case_label) = idl_push_node((yyvsp[-1].case_label), (yyvsp[0].case_label)); }
-#line 3265 "parser.c"
+#line 3071 "parser.c"
     break;
 
-  case 135:
+  case 135: /* case_label: "case" const_expr ':'  */
 #line 828 "src/parser.y"
       { TRY(idl_create_case_label(pstate, LOC((yylsp[-2]).first, (yylsp[-1]).last), (yyvsp[-1].const_expr), &(yyval.case_label))); }
-#line 3271 "parser.c"
+#line 3077 "parser.c"
     break;
 
-  case 136:
+  case 136: /* case_label: "default" ':'  */
 #line 830 "src/parser.y"
       { TRY(idl_create_case_label(pstate, &(yylsp[-1]), NULL, &(yyval.case_label))); }
-#line 3277 "parser.c"
+#line 3083 "parser.c"
     break;
 
-  case 137:
+  case 137: /* element_spec: annotations type_spec declarator  */
 #line 837 "src/parser.y"
       { TRY(idl_create_case(pstate, LOC((yylsp[-2]).first, (yylsp[0]).last), (yyvsp[-1].type_spec), (yyvsp[0].declarator), &(yyval._case)));
         TRY_EXCEPT(idl_annotate(pstate, (yyval._case), (yyvsp[-2].annotation_appl)), free((yyval._case)));
       }
-#line 3285 "parser.c"
+#line 3091 "parser.c"
     break;
 
-  case 138:
+  case 138: /* enum_dcl: enum_def  */
 #line 842 "src/parser.y"
                    { (yyval.node) = (yyvsp[0].enum_dcl); }
-#line 3291 "parser.c"
+#line 3097 "parser.c"
     break;
 
-  case 139:
+  case 139: /* enum_def: "enum" identifier '{' enumerators '}'  */
 #line 846 "src/parser.y"
       { TRY(idl_create_enum(pstate, LOC((yylsp[-4]).first, (yylsp[0]).last), (yyvsp[-3].name), (yyvsp[-1].enumerator), &(yyval.enum_dcl))); }
-#line 3297 "parser.c"
+#line 3103 "parser.c"
     break;
 
-  case 140:
+  case 140: /* enumerators: enumerator  */
 #line 851 "src/parser.y"
       { (yyval.enumerator) = (yyvsp[0].enumerator); }
-#line 3303 "parser.c"
+#line 3109 "parser.c"
     break;
 
-  case 141:
+  case 141: /* enumerators: enumerators ',' enumerator  */
 #line 853 "src/parser.y"
       { (yyval.enumerator) = idl_push_node((yyvsp[-2].enumerator), (yyvsp[0].enumerator)); }
-#line 3309 "parser.c"
+#line 3115 "parser.c"
     break;
 
-  case 142:
+  case 142: /* enumerator: annotations identifier  */
 #line 858 "src/parser.y"
       { TRY(idl_create_enumerator(pstate, &(yylsp[0]), (yyvsp[0].name), &(yyval.enumerator)));
         TRY_EXCEPT(idl_annotate(pstate, (yyval.enumerator), (yyvsp[-1].annotation_appl)), free((yyval.enumerator)));
       }
-#line 3317 "parser.c"
+#line 3123 "parser.c"
     break;
 
-  case 143:
+  case 143: /* bitmask_dcl: bitmask_def  */
 #line 863 "src/parser.y"
                          { (yyval.node) = (yyvsp[0].bitmask_dcl); }
-#line 3323 "parser.c"
+#line 3129 "parser.c"
     break;
 
-  case 144:
+  case 144: /* bitmask_def: "bitmask" identifier '{' bit_values '}'  */
 #line 867 "src/parser.y"
       { TRY(idl_create_bitmask(pstate, LOC((yylsp[-4]).first, (yylsp[0]).last), (yyvsp[-3].name), (yyvsp[-1].bit_value), &(yyval.bitmask_dcl))); }
-#line 3329 "parser.c"
+#line 3135 "parser.c"
     break;
 
-  case 145:
+  case 145: /* bit_values: bit_value  */
 #line 872 "src/parser.y"
       { (yyval.bit_value) = (yyvsp[0].bit_value); }
-#line 3335 "parser.c"
+#line 3141 "parser.c"
     break;
 
-  case 146:
+  case 146: /* bit_values: bit_values ',' bit_value  */
 #line 874 "src/parser.y"
       { (yyval.bit_value) = idl_push_node((yyvsp[-2].bit_value), (yyvsp[0].bit_value)); }
-#line 3341 "parser.c"
+#line 3147 "parser.c"
     break;
 
-  case 147:
+  case 147: /* bit_value: annotations identifier  */
 #line 879 "src/parser.y"
       { TRY(idl_create_bit_value(pstate, &(yylsp[0]), (yyvsp[0].name), &(yyval.bit_value)));
         TRY_EXCEPT(idl_annotate(pstate, (yyval.bit_value), (yyvsp[-1].annotation_appl)), free((yyval.bit_value)));
       }
-#line 3349 "parser.c"
+#line 3155 "parser.c"
     break;
 
-  case 148:
+  case 148: /* array_declarator: identifier fixed_array_sizes  */
 #line 886 "src/parser.y"
       { TRY(idl_create_declarator(pstate, LOC((yylsp[-1]).first, (yylsp[0]).last), (yyvsp[-1].name), (yyvsp[0].const_expr), &(yyval.declarator))); }
-#line 3355 "parser.c"
+#line 3161 "parser.c"
     break;
 
-  case 149:
+  case 149: /* fixed_array_sizes: fixed_array_size  */
 #line 891 "src/parser.y"
       { (yyval.const_expr) = (yyvsp[0].literal); }
-#line 3361 "parser.c"
+#line 3167 "parser.c"
     break;
 
-  case 150:
+  case 150: /* fixed_array_sizes: fixed_array_sizes fixed_array_size  */
 #line 893 "src/parser.y"
       { (yyval.const_expr) = idl_push_node((yyvsp[-1].const_expr), (yyvsp[0].literal)); }
-#line 3367 "parser.c"
+#line 3173 "parser.c"
     break;
 
-  case 151:
+  case 151: /* fixed_array_size: '[' positive_int_const ']'  */
 #line 898 "src/parser.y"
       { (yyval.literal) = (yyvsp[-1].literal); }
-#line 3373 "parser.c"
+#line 3179 "parser.c"
     break;
 
-  case 152:
+  case 152: /* simple_declarator: identifier  */
 #line 903 "src/parser.y"
       { TRY(idl_create_declarator(pstate, &(yylsp[0]), (yyvsp[0].name), NULL, &(yyval.declarator))); }
-#line 3379 "parser.c"
+#line 3185 "parser.c"
     break;
 
-  case 154:
+  case 154: /* typedef_dcl: "typedef" type_spec declarators  */
 #line 910 "src/parser.y"
       { TRY(idl_create_typedef(pstate, LOC((yylsp[-2]).first, (yylsp[0]).last), (yyvsp[-1].type_spec), (yyvsp[0].declarator), &(yyval.typedef_dcl))); }
-#line 3385 "parser.c"
+#line 3191 "parser.c"
     break;
 
-  case 155:
+  case 155: /* typedef_dcl: "typedef" constr_type_dcl declarators  */
 #line 912 "src/parser.y"
       {
         idl_typedef_t *node;
@@ -3399,22 +3205,22 @@ _Pragma("GCC diagnostic pop")
         idl_reference_node(type_spec);
         (yyval.typedef_dcl) = idl_push_node((yyvsp[-1].node), node);
       }
-#line 3403 "parser.c"
+#line 3209 "parser.c"
     break;
 
-  case 156:
+  case 156: /* declarators: declarator  */
 #line 929 "src/parser.y"
       { (yyval.declarator) = (yyvsp[0].declarator); }
-#line 3409 "parser.c"
+#line 3215 "parser.c"
     break;
 
-  case 157:
+  case 157: /* declarators: declarators ',' declarator  */
 #line 931 "src/parser.y"
       { (yyval.declarator) = idl_push_node((yyvsp[-2].declarator), (yyvsp[0].declarator)); }
-#line 3415 "parser.c"
+#line 3221 "parser.c"
     break;
 
-  case 160:
+  case 160: /* identifier: IDL_TOKEN_IDENTIFIER  */
 #line 941 "src/parser.y"
       { (yyval.name) = NULL;
         size_t n;
@@ -3429,10 +3235,10 @@ _Pragma("GCC diagnostic pop")
         if (pstate->parser.state != IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS)
           TRY(idl_create_name(pstate, &(yylsp[0]), idl_strdup((yyvsp[0].str)+n), &(yyval.name)));
       }
-#line 3433 "parser.c"
+#line 3239 "parser.c"
     break;
 
-  case 161:
+  case 161: /* annotation_dcl: annotation_header '{' annotation_body '}'  */
 #line 958 "src/parser.y"
       { (yyval.annotation) = NULL;
         /* discard annotation in case of redefinition */
@@ -3440,120 +3246,120 @@ _Pragma("GCC diagnostic pop")
           (yyval.annotation) = (yyvsp[-3].annotation);
         TRY(idl_finalize_annotation(pstate, LOC((yylsp[-3]).first, (yylsp[0]).last), (yyvsp[-3].annotation), (yyvsp[-1].annotation_member)));
       }
-#line 3444 "parser.c"
+#line 3250 "parser.c"
     break;
 
-  case 162:
+  case 162: /* $@1: %empty  */
 #line 968 "src/parser.y"
       { pstate->annotations = true; /* register annotation occurence */
         pstate->parser.state = IDL_PARSE_ANNOTATION;
       }
-#line 3452 "parser.c"
+#line 3258 "parser.c"
     break;
 
-  case 163:
+  case 163: /* annotation_header: "@" "annotation" $@1 identifier  */
 #line 972 "src/parser.y"
       { TRY(idl_create_annotation(pstate, LOC((yylsp[-3]).first, (yylsp[-2]).last), (yyvsp[0].name), &(yyval.annotation))); }
-#line 3458 "parser.c"
+#line 3264 "parser.c"
     break;
 
-  case 164:
+  case 164: /* annotation_body: %empty  */
 #line 977 "src/parser.y"
       { (yyval.annotation_member) = NULL; }
-#line 3464 "parser.c"
+#line 3270 "parser.c"
     break;
 
-  case 165:
+  case 165: /* annotation_body: annotation_body annotation_member ';'  */
 #line 979 "src/parser.y"
       { (yyval.annotation_member) = idl_push_node((yyvsp[-2].annotation_member), (yyvsp[-1].annotation_member)); }
-#line 3470 "parser.c"
+#line 3276 "parser.c"
     break;
 
-  case 166:
+  case 166: /* annotation_body: annotation_body enum_dcl ';'  */
 #line 981 "src/parser.y"
       { (yyval.annotation_member) = idl_push_node((yyvsp[-2].annotation_member), (yyvsp[-1].node)); }
-#line 3476 "parser.c"
+#line 3282 "parser.c"
     break;
 
-  case 167:
+  case 167: /* annotation_body: annotation_body bitmask_dcl ';'  */
 #line 983 "src/parser.y"
       { (yyval.annotation_member) = idl_push_node((yyvsp[-2].annotation_member), (yyvsp[-1].node)); }
-#line 3482 "parser.c"
+#line 3288 "parser.c"
     break;
 
-  case 168:
+  case 168: /* annotation_body: annotation_body const_dcl ';'  */
 #line 985 "src/parser.y"
       { (yyval.annotation_member) = idl_push_node((yyvsp[-2].annotation_member), (yyvsp[-1].const_dcl)); }
-#line 3488 "parser.c"
+#line 3294 "parser.c"
     break;
 
-  case 169:
+  case 169: /* annotation_body: annotation_body typedef_dcl ';'  */
 #line 987 "src/parser.y"
       { (yyval.annotation_member) = idl_push_node((yyvsp[-2].annotation_member), (yyvsp[-1].typedef_dcl)); }
-#line 3494 "parser.c"
+#line 3300 "parser.c"
     break;
 
-  case 170:
+  case 170: /* annotation_member: annotation_member_type simple_declarator annotation_member_default  */
 #line 992 "src/parser.y"
       { TRY(idl_create_annotation_member(pstate, LOC((yylsp[-2]).first, (yylsp[0]).last), (yyvsp[-2].type_spec), (yyvsp[-1].declarator), (yyvsp[0].const_expr), &(yyval.annotation_member))); }
-#line 3500 "parser.c"
+#line 3306 "parser.c"
     break;
 
-  case 171:
+  case 171: /* annotation_member_type: const_type  */
 #line 997 "src/parser.y"
       { (yyval.type_spec) = (yyvsp[0].type_spec); }
-#line 3506 "parser.c"
+#line 3312 "parser.c"
     break;
 
-  case 172:
+  case 172: /* annotation_member_type: any_const_type  */
 #line 999 "src/parser.y"
       { (yyval.type_spec) = (yyvsp[0].type_spec); }
-#line 3512 "parser.c"
+#line 3318 "parser.c"
     break;
 
-  case 173:
+  case 173: /* annotation_member_default: %empty  */
 #line 1004 "src/parser.y"
       { (yyval.const_expr) = NULL; }
-#line 3518 "parser.c"
+#line 3324 "parser.c"
     break;
 
-  case 174:
+  case 174: /* annotation_member_default: "default" const_expr  */
 #line 1006 "src/parser.y"
       { (yyval.const_expr) = (yyvsp[0].const_expr); }
-#line 3524 "parser.c"
+#line 3330 "parser.c"
     break;
 
-  case 175:
+  case 175: /* any_const_type: "any"  */
 #line 1011 "src/parser.y"
       { TRY(idl_create_base_type(pstate, &(yylsp[0]), IDL_ANY, &(yyval.type_spec))); }
-#line 3530 "parser.c"
+#line 3336 "parser.c"
     break;
 
-  case 176:
+  case 176: /* annotations: annotation_appls  */
 #line 1016 "src/parser.y"
       { (yyval.annotation_appl) = (yyvsp[0].annotation_appl); }
-#line 3536 "parser.c"
+#line 3342 "parser.c"
     break;
 
-  case 177:
+  case 177: /* annotations: %empty  */
 #line 1018 "src/parser.y"
       { (yyval.annotation_appl) = NULL; }
-#line 3542 "parser.c"
+#line 3348 "parser.c"
     break;
 
-  case 178:
+  case 178: /* annotation_appls: annotation_appl  */
 #line 1023 "src/parser.y"
       { (yyval.annotation_appl) = (yyvsp[0].annotation_appl); }
-#line 3548 "parser.c"
+#line 3354 "parser.c"
     break;
 
-  case 179:
+  case 179: /* annotation_appls: annotation_appls annotation_appl  */
 #line 1025 "src/parser.y"
       { (yyval.annotation_appl) = idl_push_node((yyvsp[-1].annotation_appl), (yyvsp[0].annotation_appl)); }
-#line 3554 "parser.c"
+#line 3360 "parser.c"
     break;
 
-  case 180:
+  case 180: /* annotation_appl: annotation_appl_header annotation_appl_params  */
 #line 1030 "src/parser.y"
       { if (pstate->parser.state != IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS)
           TRY(idl_finalize_annotation_appl(pstate, LOC((yylsp[-1]).first, (yylsp[0]).last), (yyvsp[-1].annotation_appl), (yyvsp[0].annotation_appl_param)));
@@ -3561,16 +3367,16 @@ _Pragma("GCC diagnostic pop")
         pstate->annotation_scope = NULL;
         (yyval.annotation_appl) = (yyvsp[-1].annotation_appl);
       }
-#line 3565 "parser.c"
+#line 3371 "parser.c"
     break;
 
-  case 181:
+  case 181: /* $@2: %empty  */
 #line 1040 "src/parser.y"
       { pstate->parser.state = IDL_PARSE_ANNOTATION_APPL; }
-#line 3571 "parser.c"
+#line 3377 "parser.c"
     break;
 
-  case 182:
+  case 182: /* annotation_appl_header: "@" $@2 annotation_appl_name  */
 #line 1042 "src/parser.y"
       { const idl_annotation_t *annotation;
         const idl_declaration_t *declaration =
@@ -3586,65 +3392,67 @@ _Pragma("GCC diagnostic pop")
           pstate->annotation_scope = declaration->scope;
         } else {
           pstate->parser.state = IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS;
+          if (strcmp((yylsp[-2]).first.file->name, "<builtin>") && strcmp((yylsp[0]).last.file->name, "<builtin>"))
+            idl_warning(pstate, IDL_WARN_UNSUPPORTED_ANNOTATIONS, LOC((yylsp[-2]).first, (yylsp[0]).last), "Unrecognized annotation: @%s", (yyvsp[0].scoped_name)->identifier);
         }
 
         idl_delete_scoped_name((yyvsp[0].scoped_name));
       }
-#line 3594 "parser.c"
+#line 3402 "parser.c"
     break;
 
-  case 183:
-#line 1064 "src/parser.y"
-      { TRY(idl_create_scoped_name(pstate, &(yylsp[0]), (yyvsp[0].name), false, &(yyval.scoped_name))); }
-#line 3600 "parser.c"
-    break;
-
-  case 184:
+  case 183: /* annotation_appl_name: identifier  */
 #line 1066 "src/parser.y"
-      { TRY(idl_create_scoped_name(pstate, LOC((yylsp[-1]).first, (yylsp[0]).last), (yyvsp[0].name), true, &(yyval.scoped_name))); }
-#line 3606 "parser.c"
+      { TRY(idl_create_scoped_name(pstate, &(yylsp[0]), (yyvsp[0].name), false, &(yyval.scoped_name))); }
+#line 3408 "parser.c"
     break;
 
-  case 185:
+  case 184: /* annotation_appl_name: IDL_TOKEN_SCOPE_NO_SPACE identifier  */
 #line 1068 "src/parser.y"
+      { TRY(idl_create_scoped_name(pstate, LOC((yylsp[-1]).first, (yylsp[0]).last), (yyvsp[0].name), true, &(yyval.scoped_name))); }
+#line 3414 "parser.c"
+    break;
+
+  case 185: /* annotation_appl_name: annotation_appl_name IDL_TOKEN_SCOPE_NO_SPACE identifier  */
+#line 1070 "src/parser.y"
       { TRY(idl_push_scoped_name(pstate, (yyvsp[-2].scoped_name), (yyvsp[0].name)));
         (yyval.scoped_name) = (yyvsp[-2].scoped_name);
       }
-#line 3614 "parser.c"
+#line 3422 "parser.c"
     break;
 
-  case 186:
-#line 1075 "src/parser.y"
-      { (yyval.annotation_appl_param) = NULL; }
-#line 3620 "parser.c"
-    break;
-
-  case 187:
+  case 186: /* annotation_appl_params: %empty  */
 #line 1077 "src/parser.y"
-      { (yyval.annotation_appl_param) = (yyvsp[-1].const_expr); }
-#line 3626 "parser.c"
+      { (yyval.annotation_appl_param) = NULL; }
+#line 3428 "parser.c"
     break;
 
-  case 188:
+  case 187: /* annotation_appl_params: '(' const_expr ')'  */
 #line 1079 "src/parser.y"
+      { (yyval.annotation_appl_param) = (yyvsp[-1].const_expr); }
+#line 3434 "parser.c"
+    break;
+
+  case 188: /* annotation_appl_params: '(' annotation_appl_keyword_params ')'  */
+#line 1081 "src/parser.y"
       { (yyval.annotation_appl_param) = (yyvsp[-1].annotation_appl_param); }
-#line 3632 "parser.c"
+#line 3440 "parser.c"
     break;
 
-  case 189:
-#line 1084 "src/parser.y"
-      { (yyval.annotation_appl_param) = (yyvsp[0].annotation_appl_param); }
-#line 3638 "parser.c"
-    break;
-
-  case 190:
+  case 189: /* annotation_appl_keyword_params: annotation_appl_keyword_param  */
 #line 1086 "src/parser.y"
-      { (yyval.annotation_appl_param) = idl_push_node((yyvsp[-2].annotation_appl_param), (yyvsp[0].annotation_appl_param)); }
-#line 3644 "parser.c"
+      { (yyval.annotation_appl_param) = (yyvsp[0].annotation_appl_param); }
+#line 3446 "parser.c"
     break;
 
-  case 191:
-#line 1091 "src/parser.y"
+  case 190: /* annotation_appl_keyword_params: annotation_appl_keyword_params ',' annotation_appl_keyword_param  */
+#line 1088 "src/parser.y"
+      { (yyval.annotation_appl_param) = idl_push_node((yyvsp[-2].annotation_appl_param), (yyvsp[0].annotation_appl_param)); }
+#line 3452 "parser.c"
+    break;
+
+  case 191: /* @3: %empty  */
+#line 1093 "src/parser.y"
       { idl_annotation_member_t *node = NULL;
         if (pstate->parser.state != IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS) {
           const idl_declaration_t *declaration = NULL;
@@ -3660,21 +3468,21 @@ _Pragma("GCC diagnostic pop")
         (yyval.annotation_member) = node;
         idl_delete_name((yyvsp[0].name));
       }
-#line 3664 "parser.c"
+#line 3472 "parser.c"
     break;
 
-  case 192:
-#line 1107 "src/parser.y"
+  case 192: /* annotation_appl_keyword_param: identifier @3 '=' const_expr  */
+#line 1109 "src/parser.y"
       { (yyval.annotation_appl_param) = NULL;
         if (pstate->parser.state != IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS) {
           TRY(idl_create_annotation_appl_param(pstate, &(yylsp[-3]), (yyvsp[-2].annotation_member), (yyvsp[0].const_expr), &(yyval.annotation_appl_param)));
         }
       }
-#line 3674 "parser.c"
+#line 3482 "parser.c"
     break;
 
 
-#line 3678 "parser.c"
+#line 3486 "parser.c"
 
       default: break;
     }
@@ -3689,11 +3497,10 @@ _Pragma("GCC diagnostic pop")
      case of YYERROR or YYBACKUP, subsequent parser actions might lead
      to an incorrect destructor call or verbose syntax error message
      before the lookahead is translated.  */
-  YY_SYMBOL_PRINT ("-> $$ =", yyr1[yyn], &yyval, &yyloc);
+  YY_SYMBOL_PRINT ("-> $$ =", YY_CAST (yysymbol_kind_t, yyr1[yyn]), &yyval, &yyloc);
 
   YYPOPSTACK (yylen);
   yylen = 0;
-  YY_STACK_PRINT (yyss, yyssp);
 
   *++yyvsp = yyval;
   *++yylsp = yyloc;
@@ -3718,66 +3525,31 @@ _Pragma("GCC diagnostic pop")
 yyerrlab:
   /* Make sure we have latest lookahead translation.  See comments at
      user semantic actions for why this is necessary.  */
-  yytoken = yychar == YYEMPTY ? YYEMPTY : YYTRANSLATE (yychar);
-
+  yytoken = yychar == IDL_YYEMPTY ? YYSYMBOL_YYEMPTY : YYTRANSLATE (yychar);
   /* If not already recovering from an error, report this error.  */
   if (!yyerrstatus)
     {
       ++yynerrs;
-#if ! YYERROR_VERBOSE
       yyerror (&yylloc, pstate, result, YY_("syntax error"));
-#else
-# define YYSYNTAX_ERROR yysyntax_error (&yymsg_alloc, &yymsg, \
-                                        yyssp, yytoken)
-      {
-        char const *yymsgp = YY_("syntax error");
-        int yysyntax_error_status;
-        yysyntax_error_status = YYSYNTAX_ERROR;
-        if (yysyntax_error_status == 0)
-          yymsgp = yymsg;
-        else if (yysyntax_error_status == 1)
-          {
-            if (yymsg != yymsgbuf)
-              YYSTACK_FREE (yymsg);
-            yymsg = YY_CAST (char *, YYSTACK_ALLOC (YY_CAST (YYSIZE_T, yymsg_alloc)));
-            if (!yymsg)
-              {
-                yymsg = yymsgbuf;
-                yymsg_alloc = sizeof yymsgbuf;
-                yysyntax_error_status = 2;
-              }
-            else
-              {
-                yysyntax_error_status = YYSYNTAX_ERROR;
-                yymsgp = yymsg;
-              }
-          }
-        yyerror (&yylloc, pstate, result, yymsgp);
-        if (yysyntax_error_status == 2)
-          goto yyexhaustedlab;
-      }
-# undef YYSYNTAX_ERROR
-#endif
     }
 
   yyerror_range[1] = yylloc;
-
   if (yyerrstatus == 3)
     {
       /* If just tried and failed to reuse lookahead token after an
          error, discard it.  */
 
-      if (yychar <= YYEOF)
+      if (yychar <= IDL_YYEOF)
         {
           /* Return failure if at end of input.  */
-          if (yychar == YYEOF)
+          if (yychar == IDL_YYEOF)
             YYABORT;
         }
       else
         {
           yydestruct ("Error: discarding",
                       yytoken, &yylval, &yylloc, pstate, result);
-          yychar = YYEMPTY;
+          yychar = IDL_YYEMPTY;
         }
     }
 
@@ -3810,13 +3582,14 @@ yyerrorlab:
 yyerrlab1:
   yyerrstatus = 3;      /* Each real token shifted decrements this.  */
 
+  /* Pop stack until we find a state that shifts the error token.  */
   for (;;)
     {
       yyn = yypact[yystate];
       if (!yypact_value_is_default (yyn))
         {
-          yyn += YYTERROR;
-          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYTERROR)
+          yyn += YYSYMBOL_YYerror;
+          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYSYMBOL_YYerror)
             {
               yyn = yytable[yyn];
               if (0 < yyn)
@@ -3830,7 +3603,7 @@ yyerrlab1:
 
       yyerror_range[1] = *yylsp;
       yydestruct ("Error: popping",
-                  yystos[yystate], yyvsp, yylsp, pstate, result);
+                  YY_ACCESSING_SYMBOL (yystate), yyvsp, yylsp, pstate, result);
       YYPOPSTACK (1);
       yystate = *yyssp;
       YY_STACK_PRINT (yyss, yyssp);
@@ -3841,13 +3614,11 @@ yyerrlab1:
   YY_IGNORE_MAYBE_UNINITIALIZED_END
 
   yyerror_range[2] = yylloc;
-  /* Using YYLLOC is tempting, but would change the location of
-     the lookahead.  YYLOC is available though.  */
-  YYLLOC_DEFAULT (yyloc, yyerror_range, 2);
-  *++yylsp = yyloc;
+  ++yylsp;
+  YYLLOC_DEFAULT (*yylsp, yyerror_range, 2);
 
   /* Shift the error token.  */
-  YY_SYMBOL_PRINT ("Shifting", yystos[yyn], yyvsp, yylsp);
+  YY_SYMBOL_PRINT ("Shifting", YY_ACCESSING_SYMBOL (yyn), yyvsp, yylsp);
 
   yystate = yyn;
   goto yynewstate;
@@ -3869,22 +3640,22 @@ yyabortlab:
   goto yyreturn;
 
 
-#if !defined yyoverflow || YYERROR_VERBOSE
+#if !defined yyoverflow
 /*-------------------------------------------------.
 | yyexhaustedlab -- memory exhaustion comes here.  |
 `-------------------------------------------------*/
 yyexhaustedlab:
   yyerror (&yylloc, pstate, result, YY_("memory exhausted"));
   yyresult = 2;
-  /* Fall through.  */
+  goto yyreturn;
 #endif
 
 
-/*-----------------------------------------------------.
-| yyreturn -- parsing is finished, return the result.  |
-`-----------------------------------------------------*/
+/*-------------------------------------------------------.
+| yyreturn -- parsing is finished, clean up and return.  |
+`-------------------------------------------------------*/
 yyreturn:
-  if (yychar != YYEMPTY)
+  if (yychar != IDL_YYEMPTY)
     {
       /* Make sure we have latest lookahead translation.  See comments at
          user semantic actions for why this is necessary.  */
@@ -3899,27 +3670,34 @@ yyreturn:
   while (yyssp != yyss)
     {
       yydestruct ("Cleanup: popping",
-                  yystos[+*yyssp], yyvsp, yylsp, pstate, result);
+                  YY_ACCESSING_SYMBOL (+*yyssp), yyvsp, yylsp, pstate, result);
       YYPOPSTACK (1);
     }
-#ifndef yyoverflow
-  if (yyss != yyssa)
-    YYSTACK_FREE (yyss);
-#endif
-  yyps->yynew = 1;
+  yyps->yynew = 2;
+  goto yypushreturn;
 
 
-/*-----------------------------------------.
-| yypushreturn -- ask for the next token.  |
-`-----------------------------------------*/
+/*-------------------------.
+| yypushreturn -- return.  |
+`-------------------------*/
 yypushreturn:
-#if YYERROR_VERBOSE
-  if (yymsg != yymsgbuf)
-    YYSTACK_FREE (yymsg);
-#endif
+
   return yyresult;
 }
-#line 1114 "src/parser.y"
+#undef idl_yynerrs
+#undef yystate
+#undef yyerrstatus
+#undef yyssa
+#undef yyss
+#undef yyssp
+#undef yyvsa
+#undef yyvs
+#undef yyvsp
+#undef yylsa
+#undef yyls
+#undef yylsp
+#undef yystacksize
+#line 1116 "src/parser.y"
 
 
 #if defined(__GNUC__)
@@ -4009,4 +3787,5 @@ yyerror(idl_location_t *loc, idl_pstate_t *pstate, idl_retcode_t *result, const 
   idl_error(pstate, loc, "%s", str);
   *result = IDL_RETCODE_SYNTAX_ERROR;
 }
-/* generated from parser.y[82e26f82aaa31c5b02630cd864b56142d56a9d30] */
+/* generated from parser.y[c5eaedb4a13d082e1b358e1e9b92f9d888389cf7] */
+/* generated from parser.y[c5eaedb4a13d082e1b358e1e9b92f9d888389cf7] */

--- a/src/idl/src/parser.h
+++ b/src/idl/src/parser.h
@@ -1,4 +1,4 @@
-/* A Bison parser, made by GNU Bison 3.5.1.  */
+/* A Bison parser, made by GNU Bison 3.7.  */
 
 /* Bison interface for Yacc-like parsers in C
 
@@ -31,8 +31,9 @@
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
 
-/* Undocumented macros, especially those whose name start with YY_,
-   are private implementation details.  Do not rely on them.  */
+/* DO NOT RELY ON FEATURES THAT ARE NOT DOCUMENTED in the manual,
+   especially those whose name start with YY_ or yy_.  They are
+   private implementation details that can be changed or removed.  */
 
 #ifndef YY_IDL_YY_PARSER_H_INCLUDED
 # define YY_IDL_YY_PARSER_H_INCLUDED
@@ -65,66 +66,71 @@ typedef struct idl_location IDL_YYLTYPE;
 #define LOC(first, last) \
   &(IDL_YYLTYPE){ first, last }
 
-#line 69 "parser.h"
+#line 70 "parser.h"
 
-/* Token type.  */
+/* Token kinds.  */
 #ifndef IDL_YYTOKENTYPE
 # define IDL_YYTOKENTYPE
   enum idl_yytokentype
   {
-    IDL_TOKEN_LINE_COMMENT = 258,
-    IDL_TOKEN_COMMENT = 259,
-    IDL_TOKEN_PP_NUMBER = 260,
-    IDL_TOKEN_IDENTIFIER = 261,
-    IDL_TOKEN_CHAR_LITERAL = 262,
-    IDL_TOKEN_STRING_LITERAL = 263,
-    IDL_TOKEN_INTEGER_LITERAL = 264,
-    IDL_TOKEN_FLOATING_PT_LITERAL = 265,
-    IDL_TOKEN_ANNOTATION_SYMBOL = 266,
-    IDL_TOKEN_ANNOTATION = 267,
-    IDL_TOKEN_SCOPE = 268,
-    IDL_TOKEN_SCOPE_NO_SPACE = 269,
-    IDL_TOKEN_MODULE = 270,
-    IDL_TOKEN_CONST = 271,
-    IDL_TOKEN_NATIVE = 272,
-    IDL_TOKEN_STRUCT = 273,
-    IDL_TOKEN_TYPEDEF = 274,
-    IDL_TOKEN_UNION = 275,
-    IDL_TOKEN_SWITCH = 276,
-    IDL_TOKEN_CASE = 277,
-    IDL_TOKEN_DEFAULT = 278,
-    IDL_TOKEN_ENUM = 279,
-    IDL_TOKEN_UNSIGNED = 280,
-    IDL_TOKEN_FIXED = 281,
-    IDL_TOKEN_SEQUENCE = 282,
-    IDL_TOKEN_STRING = 283,
-    IDL_TOKEN_WSTRING = 284,
-    IDL_TOKEN_FLOAT = 285,
-    IDL_TOKEN_DOUBLE = 286,
-    IDL_TOKEN_SHORT = 287,
-    IDL_TOKEN_LONG = 288,
-    IDL_TOKEN_CHAR = 289,
-    IDL_TOKEN_WCHAR = 290,
-    IDL_TOKEN_BOOLEAN = 291,
-    IDL_TOKEN_OCTET = 292,
-    IDL_TOKEN_ANY = 293,
-    IDL_TOKEN_MAP = 294,
-    IDL_TOKEN_BITSET = 295,
-    IDL_TOKEN_BITFIELD = 296,
-    IDL_TOKEN_BITMASK = 297,
-    IDL_TOKEN_INT8 = 298,
-    IDL_TOKEN_INT16 = 299,
-    IDL_TOKEN_INT32 = 300,
-    IDL_TOKEN_INT64 = 301,
-    IDL_TOKEN_UINT8 = 302,
-    IDL_TOKEN_UINT16 = 303,
-    IDL_TOKEN_UINT32 = 304,
-    IDL_TOKEN_UINT64 = 305,
-    IDL_TOKEN_TRUE = 306,
-    IDL_TOKEN_FALSE = 307,
-    IDL_TOKEN_LSHIFT = 308,
-    IDL_TOKEN_RSHIFT = 309
+    IDL_YYEMPTY = -2,
+    IDL_YYEOF = 0,                 /* "end of file"  */
+    IDL_YYerror = 256,             /* error  */
+    IDL_YYUNDEF = 257,             /* "invalid token"  */
+    IDL_TOKEN_LINE_COMMENT = 258,  /* IDL_TOKEN_LINE_COMMENT  */
+    IDL_TOKEN_COMMENT = 259,       /* IDL_TOKEN_COMMENT  */
+    IDL_TOKEN_PP_NUMBER = 260,     /* IDL_TOKEN_PP_NUMBER  */
+    IDL_TOKEN_IDENTIFIER = 261,    /* IDL_TOKEN_IDENTIFIER  */
+    IDL_TOKEN_CHAR_LITERAL = 262,  /* IDL_TOKEN_CHAR_LITERAL  */
+    IDL_TOKEN_STRING_LITERAL = 263, /* IDL_TOKEN_STRING_LITERAL  */
+    IDL_TOKEN_INTEGER_LITERAL = 264, /* IDL_TOKEN_INTEGER_LITERAL  */
+    IDL_TOKEN_FLOATING_PT_LITERAL = 265, /* IDL_TOKEN_FLOATING_PT_LITERAL  */
+    IDL_TOKEN_ANNOTATION_SYMBOL = 266, /* "@"  */
+    IDL_TOKEN_ANNOTATION = 267,    /* "annotation"  */
+    IDL_TOKEN_SCOPE = 268,         /* IDL_TOKEN_SCOPE  */
+    IDL_TOKEN_SCOPE_NO_SPACE = 269, /* IDL_TOKEN_SCOPE_NO_SPACE  */
+    IDL_TOKEN_MODULE = 270,        /* "module"  */
+    IDL_TOKEN_CONST = 271,         /* "const"  */
+    IDL_TOKEN_NATIVE = 272,        /* "native"  */
+    IDL_TOKEN_STRUCT = 273,        /* "struct"  */
+    IDL_TOKEN_TYPEDEF = 274,       /* "typedef"  */
+    IDL_TOKEN_UNION = 275,         /* "union"  */
+    IDL_TOKEN_SWITCH = 276,        /* "switch"  */
+    IDL_TOKEN_CASE = 277,          /* "case"  */
+    IDL_TOKEN_DEFAULT = 278,       /* "default"  */
+    IDL_TOKEN_ENUM = 279,          /* "enum"  */
+    IDL_TOKEN_UNSIGNED = 280,      /* "unsigned"  */
+    IDL_TOKEN_FIXED = 281,         /* "fixed"  */
+    IDL_TOKEN_SEQUENCE = 282,      /* "sequence"  */
+    IDL_TOKEN_STRING = 283,        /* "string"  */
+    IDL_TOKEN_WSTRING = 284,       /* "wstring"  */
+    IDL_TOKEN_FLOAT = 285,         /* "float"  */
+    IDL_TOKEN_DOUBLE = 286,        /* "double"  */
+    IDL_TOKEN_SHORT = 287,         /* "short"  */
+    IDL_TOKEN_LONG = 288,          /* "long"  */
+    IDL_TOKEN_CHAR = 289,          /* "char"  */
+    IDL_TOKEN_WCHAR = 290,         /* "wchar"  */
+    IDL_TOKEN_BOOLEAN = 291,       /* "boolean"  */
+    IDL_TOKEN_OCTET = 292,         /* "octet"  */
+    IDL_TOKEN_ANY = 293,           /* "any"  */
+    IDL_TOKEN_MAP = 294,           /* "map"  */
+    IDL_TOKEN_BITSET = 295,        /* "bitset"  */
+    IDL_TOKEN_BITFIELD = 296,      /* "bitfield"  */
+    IDL_TOKEN_BITMASK = 297,       /* "bitmask"  */
+    IDL_TOKEN_INT8 = 298,          /* "int8"  */
+    IDL_TOKEN_INT16 = 299,         /* "int16"  */
+    IDL_TOKEN_INT32 = 300,         /* "int32"  */
+    IDL_TOKEN_INT64 = 301,         /* "int64"  */
+    IDL_TOKEN_UINT8 = 302,         /* "uint8"  */
+    IDL_TOKEN_UINT16 = 303,        /* "uint16"  */
+    IDL_TOKEN_UINT32 = 304,        /* "uint32"  */
+    IDL_TOKEN_UINT64 = 305,        /* "uint64"  */
+    IDL_TOKEN_TRUE = 306,          /* "TRUE"  */
+    IDL_TOKEN_FALSE = 307,         /* "FALSE"  */
+    IDL_TOKEN_LSHIFT = 308,        /* "<<"  */
+    IDL_TOKEN_RSHIFT = 309         /* ">>"  */
   };
+  typedef enum idl_yytokentype idl_yytoken_kind_t;
 #endif
 
 /* Value type.  */
@@ -176,7 +182,7 @@ union IDL_YYSTYPE
   unsigned long long ullng;
   long double ldbl;
 
-#line 180 "parser.h"
+#line 186 "parser.h"
 
 };
 typedef union IDL_YYSTYPE IDL_YYSTYPE;
@@ -207,17 +213,21 @@ enum { YYPUSH_MORE = 4 };
 
 typedef struct idl_yypstate idl_yypstate;
 
-int idl_yypush_parse (idl_yypstate *ps, int pushed_char, IDL_YYSTYPE const *pushed_val, IDL_YYLTYPE *pushed_loc, idl_pstate_t *pstate, idl_retcode_t *result);
 
-idl_yypstate * idl_yypstate_new (void);
+int idl_yypush_parse (idl_yypstate *ps,
+                  int pushed_char, IDL_YYSTYPE const *pushed_val, IDL_YYLTYPE *pushed_loc, idl_pstate_t *pstate, idl_retcode_t *result);
+
+idl_yypstate *idl_yypstate_new (void);
 void idl_yypstate_delete (idl_yypstate *ps);
+
 /* "%code provides" blocks.  */
 #line 98 "src/parser.y"
 
 int idl_iskeyword(idl_pstate_t *pstate, const char *str, int nc);
 void idl_yypstate_delete_stack(idl_yypstate *yyps);
 
-#line 221 "parser.h"
+#line 230 "parser.h"
 
 #endif /* !YY_IDL_YY_PARSER_H_INCLUDED  */
-/* generated from parser.y[82e26f82aaa31c5b02630cd864b56142d56a9d30] */
+/* generated from parser.y[c5eaedb4a13d082e1b358e1e9b92f9d888389cf7] */
+/* generated from parser.y[c5eaedb4a13d082e1b358e1e9b92f9d888389cf7] */

--- a/src/idl/src/parser.y
+++ b/src/idl/src/parser.y
@@ -1053,6 +1053,8 @@ annotation_appl_header:
           pstate->annotation_scope = declaration->scope;
         } else {
           pstate->parser.state = IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS;
+          if (strcmp(@1.first.file->name, "<builtin>") && strcmp(@3.last.file->name, "<builtin>"))
+            idl_warning(pstate, IDL_WARN_UNSUPPORTED_ANNOTATIONS, LOC(@1.first, @3.last), "Unrecognized annotation: @%s", $3->identifier);
         }
 
         idl_delete_scoped_name($3);

--- a/src/idl/src/tree.c
+++ b/src/idl/src/tree.c
@@ -2455,8 +2455,8 @@ bool idl_is_enum(const void *ptr)
     return false;
   /* an enum must have a name */
   assert(node->name && node->name->identifier);
-  /* an enum must have no parent or a module parent */
-  assert(!node->node.parent || (idl_mask(node->node.parent) & IDL_MODULE));
+  /* an enum must have no parent or a module or annotation parent */
+  assert(!node->node.parent || idl_mask(node->node.parent) & (IDL_MODULE | IDL_ANNOTATION));
   /* an enum must have at least one enumerator */
   assert(node->enumerators && (idl_mask(node->enumerators) & IDL_ENUMERATOR));
   return true;


### PR DESCRIPTION
Additional validation of bit bounds of bitmasks and enums

This validation was previously only triggered on the @bit_bound annotation being present, now it is done when the tree is completed parsing.