### PR TITLE
Set OpenSSL API compatibility to 1.1.1

### DIFF
--- a/src/security/openssl/include/dds/security/openssl_support.h
+++ b/src/security/openssl/include/dds/security/openssl_support.h
@@ -40,6 +40,8 @@
 #include <WinSock2.h>
 #endif
 
+#define OPENSSL_API_COMPAT 10101
+
 #include <openssl/opensslv.h>
 #include <openssl/opensslconf.h>
 #include <openssl/asn1.h>


### PR DESCRIPTION
This suppresses deprecation warnings from OpenSSL 3.0. It is not a
proper fix, but the OpenSSL documentation on how to deal with the
deprecations is such that it will take some time to fix this.

Signed-off-by: Erik Boasson <eb@ilities.com>