### PR TITLE
Bump version to 0.10.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
 cmake_minimum_required(VERSION 3.10)
-project(CycloneDDS VERSION 0.9.0 LANGUAGES C)
+project(CycloneDDS VERSION 0.10.0 LANGUAGES C)
 if(CMAKE_VERSION VERSION_LESS 3.12)
   # GENERATE_EXPORT_HEADER requires a C++ compiler up to version 3.12
   enable_language(CXX)

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>cyclonedds</name>
-    <version>0.9.0</version>
+    <version>0.10.0</version>
     <description>Eclipse Cyclone DDS is a very performant and robust open-source DDS implementation. Cyclone DDS is developed completely in the open as an Eclipse IoT project.</description>
     <maintainer email="cyclonedds-dev@eclipse.org">Eclipse Foundation, Inc.</maintainer>
     <license>Eclipse Public License 2.0</license>


### PR DESCRIPTION
Now that the 0.9.x release branch exists, master should no longer call itself a
0.9.0.

Signed-off-by: Erik Boasson <eb@ilities.com>