### PR TITLE
Set CMake CMP0075 policy to NEW

### DIFF
--- a/src/ddsrt/CMakeLists.txt
+++ b/src/ddsrt/CMakeLists.txt
@@ -121,6 +121,11 @@ if(WITH_LWIP)
     "${source_dir}/src/sockets/posix/gethostname.c")
 else()
   if(WIN32)
+    if(POLICY CMP0075)
+      # suppress warnings concerning a change in behaviour of check_include_files in
+      # combination with CMAKE_REQUIRED_LIBRARIES
+      cmake_policy(SET CMP0075 NEW)
+    endif()
     set(CMAKE_EXTRA_INCLUDE_FILES "ws2tcpip.h")
     set(CMAKE_REQUIRED_LIBRARIES ws2_32 iphlpapi)
     set(hostname_header "winsock2.h")


### PR DESCRIPTION
CMP0075 concerns a change in behaviour in the combination of
check_include_files and CMAKE_REQUIRED_LIBRARIES. This combination
occurs on Windows, and in this case both the old and the new behaviour
are acceptable.

We support CMake versions older than the one where the policy was
introduced, so select the new behaviour only if the policy actually
exists.

Note: needs backport to `releases/0.9.x` branch because of the ROS 2 build farm.

Signed-off-by: Erik Boasson <eb@ilities.com>