### PR TITLE
Fixes for resolving types and type dependencies

### DIFF
--- a/src/core/ddsi/src/ddsi_typelib.c
+++ b/src/core/ddsi/src/ddsi_typelib.c
@@ -648,6 +648,7 @@ uint32_t ddsi_type_get_gpe_matches (struct ddsi_domaingv *gv, const struct ddsi_
     return 0;
 
   uint32_t n = 0;
+  thread_state_awake (lookup_thread_state (), gv);
   *gpe_match_upd = ddsrt_realloc (*gpe_match_upd, (*n_match_upd + ddsi_type_proxy_guid_list_count (&type->proxy_guids)) * sizeof (**gpe_match_upd));
   struct ddsi_type_proxy_guid_list_iter it;
   for (ddsi_guid_t guid = ddsi_type_proxy_guid_list_iter_first (&type->proxy_guids, &it); !is_null_guid (&guid); guid = ddsi_type_proxy_guid_list_iter_next (&it))
@@ -664,6 +665,7 @@ uint32_t ddsi_type_get_gpe_matches (struct ddsi_domaingv *gv, const struct ddsi_
   }
   *n_match_upd += n;
   ddsi_type_register_with_proxy_endpoints_locked (gv, type);
+  thread_state_asleep (lookup_thread_state ());
   return n;
 }
 

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -3329,6 +3329,7 @@ void update_proxy_endpoint_matching (const struct ddsi_domaingv *gv, struct gene
   const char *tp = entity_topic_name (&proxy_ep->e);
   ddsrt_mtime_t tnow = ddsrt_time_monotonic ();
 
+  thread_state_awake (lookup_thread_state (), gv);
   entidx_enum_init_topic (&it, gv->entity_index, mkind, tp, &max);
   while ((em = entidx_enum_next_max (&it, &max)) != NULL)
   {
@@ -3336,6 +3337,7 @@ void update_proxy_endpoint_matching (const struct ddsi_domaingv *gv, struct gene
     generic_do_match_connect (&proxy_ep->e, em, tnow, false);
   }
   entidx_enum_fini (&it);
+  thread_state_asleep (lookup_thread_state ());
 }
 
 


### PR DESCRIPTION
Bugfix in resolving type dependencies: in case type info from proxy endpoint was received before creating local topic using the same top-level type, the type object for the local type dependencies was not added in the type library