### PR TITLE
Fixes for issues reported by coverity

### DIFF
--- a/src/core/ddsi/src/ddsi_ownip.c
+++ b/src/core/ddsi/src/ddsi_ownip.c
@@ -365,7 +365,7 @@ static void log_arbitrary_selection (struct ddsi_domaingv *gv, const struct nn_i
     GVLOG (DDS_LC_INFO, "%s%s", (i == 0) ? "" : ", ", interfaces[maxq_list[i]].name);
   GVLOG (DDS_LC_INFO, "\n");
 }
-  
+
 int find_own_ip (struct ddsi_domaingv *gv)
 {
   char addrbuf[DDSI_LOCSTRLEN];
@@ -373,9 +373,12 @@ int find_own_ip (struct ddsi_domaingv *gv)
   GVLOG (DDS_LC_CONFIG, "interfaces:");
 
   size_t n_interfaces, maxq_count, *maxq_list;
-  struct nn_interface *interfaces;
-  if (!gather_interfaces (gv, &n_interfaces, &interfaces, &maxq_count, &maxq_list))
+  struct nn_interface *interfaces = NULL;
+  if (!gather_interfaces (gv, &n_interfaces, &interfaces, &maxq_count, &maxq_list)) {
+    if (interfaces)
+      ddsrt_free(interfaces);
     return 0;
+  }
 #ifndef NDEBUG
   // assert that we can identify all interfaces with an `int`, so we can
   // then just cast the size_t's to int's

--- a/src/core/ddsi/src/ddsi_udp.c
+++ b/src/core/ddsi/src/ddsi_udp.c
@@ -67,7 +67,7 @@ static ssize_t ddsi_udp_conn_read (ddsi_tran_conn_t conn_cmn, unsigned char * bu
   struct ddsi_domaingv * const gv = conn->m_base.m_base.gv;
   dds_return_t rc;
   ssize_t ret = 0;
-  ddsrt_msghdr_t msghdr;
+  ddsrt_msghdr_t msghdr = {.msg_flags = 0};
   union addr src;
   ddsrt_iovec_t msg_iov;
   socklen_t srclen = (socklen_t) sizeof (src);

--- a/src/security/builtin_plugins/tests/encode_rtps_message/src/encode_rtps_message_utests.c
+++ b/src/security/builtin_plugins/tests/encode_rtps_message/src/encode_rtps_message_utests.c
@@ -464,7 +464,7 @@ crypto_decrypt_data(
 {
   bool result = true;
   EVP_CIPHER_CTX *ctx;
-  crypto_session_key_t session_key;
+  crypto_session_key_t session_key = {.data = {0} };
   uint32_t key_size = crypto_get_key_size(CRYPTO_TRANSFORM_KIND(transformation_kind));
   int len = 0;
 

--- a/src/tools/ddsperf/ddsperf.c
+++ b/src/tools/ddsperf/ddsperf.c
@@ -2125,7 +2125,7 @@ int main (int argc, char *argv[])
   sigset_t sigset, osigset;
   ddsrt_thread_t sigtid;
 #endif
-  char netload_if[256];
+  char netload_if[256] = {0};
   double netload_bw = -1;
   double rss_init = 0.0, rss_final = 0.0;
   ddsrt_threadattr_init (&attr);

--- a/src/tools/idlc/tests/type_meta.c
+++ b/src/tools/idlc/tests/type_meta.c
@@ -801,7 +801,7 @@ typedef struct struct_annotation_test {
   m_a_t members[8];
 } s_a_t;
 
-static void test_annotation_meta_info(s_a_t test)
+static void test_annotation_meta_info(const s_a_t *test)
 {
   uint32_t flags = IDL_FLAG_EXTENDED_DATA_TYPES |
                    IDL_FLAG_ANONYMOUS_TYPES |
@@ -815,7 +815,7 @@ static void test_annotation_meta_info(s_a_t test)
   CU_ASSERT_EQUAL_FATAL (ret, IDL_RETCODE_OK);
 
   memset (&descriptor, 0, sizeof (descriptor)); /* static analyzer */
-  ret = generate_test_descriptor (pstate, test.idl, &descriptor);
+  ret = generate_test_descriptor (pstate, test->idl, &descriptor);
   CU_ASSERT_EQUAL_FATAL (ret, IDL_RETCODE_OK);
 
   ret = generate_descriptor_type_meta (pstate, descriptor.topic, &dtm);
@@ -827,8 +827,8 @@ static void test_annotation_meta_info(s_a_t test)
     DDS_XTypes_CompleteStructMemberSeq mseq = tm->to_complete->_u.complete._u.struct_type.member_seq;
     for (size_t i = 0; i < mseq._length; i++)
     {
-      //CU_ASSERT_FATAL(i < sizeof(test.members)/sizeof(test.members[0]));
-      m_a_t m = test.members[i];
+      //CU_ASSERT_FATAL(i < sizeof(test->members)/sizeof(test->members[0]));
+      m_a_t m = test->members[i];
       CU_ASSERT_PTR_NOT_NULL_FATAL(mseq._buffer);
       if (!mseq._buffer)
         continue;
@@ -927,7 +927,7 @@ CU_Test(idlc_type_meta, type_obj_annotations)
     };
 
   for (size_t i = 0; i < sizeof(tests)/sizeof(tests[0]); i++)
-    test_annotation_meta_info(tests[i]);
+    test_annotation_meta_info(tests + i);
 }
 
 


### PR DESCRIPTION
This fixes a number of issues reported by coverity:
Uninitialized variable use: 349351, 349352 and 349353
Passing large entities by value: 350274
Memory leak: 350493, 350494
