### PR TITLE
Gcovr issue and some minor fixes

### DIFF
--- a/.azure/templates/build-test.yml
+++ b/.azure/templates/build-test.yml
@@ -79,7 +79,7 @@ steps:
       pre-commit run --all-files
     name: run_pre_commit
   - bash: |
-      pip install gcovr --user --upgrade
+      pip install gcovr==5.0 --user --upgrade
     condition: eq(variables['coverage'], 'on')
     name: install_gcovr
   - bash: |

--- a/cmake/Modules/FindLcov.cmake
+++ b/cmake/Modules/FindLcov.cmake
@@ -78,7 +78,7 @@ include(FindPackageHandleStandardArgs)
 find_program(LCOV_BIN lcov)
 find_program(GENINFO_BIN geninfo)
 find_program(GENHTML_BIN genhtml)
-find_package_handle_standard_args(lcov
+find_package_handle_standard_args(Lcov
 	REQUIRED_VARS LCOV_BIN GENINFO_BIN GENHTML_BIN
 )
 

--- a/src/core/ddsi/src/ddsi_config.c
+++ b/src/core/ddsi/src/ddsi_config.c
@@ -2414,8 +2414,14 @@ static int convert_assumemulticastcapable (struct ddsi_config * const cfg)
     }
     size_t addr_count;
     char ** names = split_at_comma(cfg->depr_assumeMulticastCapable, &addr_count);
-    for (size_t i = 0; i < addr_count; ++i) {
+    for (size_t i = 0; i < addr_count; ++i)
+    {
       struct ddsi_config_network_interface *iface_cfg = network_interface_find_or_append(cfg, true, names[i], NULL);
+      if (!iface_cfg)
+      {
+        ddsrt_free (names);
+        return 0;
+      }
       iface_cfg->multicast = DDSI_BOOLDEF_TRUE;
     }
     ddsrt_free (names);

--- a/src/core/ddsi/src/ddsi_security_omg.c
+++ b/src/core/ddsi/src/ddsi_security_omg.c
@@ -1751,6 +1751,9 @@ static int64_t check_remote_participant_permissions(uint32_t domain_id, struct p
   int64_t permissions_hdl = DDS_SECURITY_HANDLE_NIL;
   struct ddsi_domaingv *gv = pp->e.gv;
 
+  if (!sc)
+    goto no_sc;
+
   if (proxypp->plist->present & PP_PERMISSIONS_TOKEN)
       q_omg_shallow_copyin_DataHolder(&permissions_token, &proxypp->plist->permissions_token);
   else
@@ -1812,6 +1815,7 @@ no_credentials:
   ddsi_handshake_release(handshake);
 no_handshake:
   q_omg_shallow_free_DataHolder(&permissions_token);
+no_sc:
   return permissions_hdl;
 }
 
@@ -1927,6 +1931,9 @@ bool q_omg_security_register_remote_participant(struct participant *pp, struct p
   DDS_Security_ParticipantCryptoHandle crypto_handle;
   int64_t permissions_handle;
   bool notify_handshake = false;
+
+  if (!sc)
+    return false;
 
   permissions_handle = check_remote_participant_permissions(gv->config.domainId, pp, proxypp, proxypp->sec_attr->remote_identity_handle);
   if (permissions_handle == 0)


### PR DESCRIPTION
For some reason, gcov reports negative counts for some switch statement branches, and gcovr 5.1 doesn't accept this and reports a parse error. By setting gcovr back to version 5.0 the CI builds are passing again, so I think that's a reasonable fix until we found out why gcov is reporting negative counts?

The other two commits in this PR fix a CMake [warning](https://dev.azure.com/eclipse-cyclonedds/cyclonedds/_build/results?buildId=2489&view=logs&j=9c723939-9148-5f6a-3101-ca017cb22518&t=0fc9f1b9-5c8f-5aaf-926d-4d5cc2ce9cdb&l=120) and some analyzer issues ([this](https://dev.azure.com/dennis-zetta/cyclonedds/_build/results?buildId=100&view=logs&j=69944193-f126-526b-b021-abb6fb4b38ee&t=b51c32e4-afb7-5d6f-d65f-10ab7bc83c23&l=286) and [this](https://dev.azure.com/dennis-zetta/cyclonedds/_build/results?buildId=101&view=logs&j=69944193-f126-526b-b021-abb6fb4b38ee&t=b51c32e4-afb7-5d6f-d65f-10ab7bc83c23&l=325)) that I found when debugging the gcovr issue