### PR TITLE
Redesign the type definition of "ddsrt_ifaddrs"

### DIFF
--- a/src/core/ddsi/src/ddsi_ownip.c
+++ b/src/core/ddsi/src/ddsi_ownip.c
@@ -133,7 +133,7 @@ static enum maybe_add_interface_result maybe_add_interface (struct ddsi_domaingv
   if ((ifa->flags & IFF_UP) == 0) {
     GVLOG (DDS_LC_CONFIG, " (interface down)");
     return MAI_IGNORED;
-  } else if (ddsrt_sockaddr_isunspecified(ifa->addr)) {
+  } else if (ddsrt_sockaddr_isunspecified(ifa->ifaddr.ipaddr.addr)) {
     GVLOG (DDS_LC_CONFIG, " (address unspecified)");
     return MAI_IGNORED;
   }
@@ -150,7 +150,7 @@ static enum maybe_add_interface_result maybe_add_interface (struct ddsi_domaingv
       break;
   }
 
-  if (ddsi_locator_from_sockaddr (gv->m_factory, &dst->loc, ifa->addr) < 0)
+  if (ddsi_locator_from_sockaddr (gv->m_factory, &dst->loc, ifa->ifaddr.ipaddr.addr) < 0)
     return MAI_IGNORED;
   ddsi_locator_to_string_no_port(addrbuf, sizeof(addrbuf), &dst->loc);
   GVLOG (DDS_LC_CONFIG, " %s(", addrbuf);
@@ -203,9 +203,9 @@ static enum maybe_add_interface_result maybe_add_interface (struct ddsi_domaingv
 
   GVLOG (DDS_LC_CONFIG, "q%d)", q);
 
-  if (ifa->addr->sa_family == AF_INET && ifa->netmask)
+  if (ifa->ifaddr.ipaddr.addr->sa_family == AF_INET && ifa->ifaddr.ipaddr.netmask)
   {
-    if (ddsi_locator_from_sockaddr (gv->m_factory, &dst->netmask, ifa->netmask) < 0)
+    if (ddsi_locator_from_sockaddr (gv->m_factory, &dst->netmask, ifa->ifaddr.ipaddr.netmask) < 0)
       return MAI_IGNORED;
   }
   else

--- a/src/core/ddsi/src/ddsi_vnet.c
+++ b/src/core/ddsi/src/ddsi_vnet.c
@@ -162,11 +162,11 @@ static int ddsi_vnet_enumerate_interfaces (ddsi_tran_factory_t fact, enum ddsi_t
   (*ifs)->name = ddsrt_strdup (fact->m_typename);
   (*ifs)->index = 0;
   (*ifs)->flags = IFF_UP | IFF_MULTICAST;
-  (*ifs)->addr = ddsrt_malloc (sizeof (struct sockaddr_storage));
-  memset ((*ifs)->addr, 0, sizeof (struct sockaddr_storage));
-  (*ifs)->addr->sa_data[0] = 1;
-  (*ifs)->netmask = NULL;
-  (*ifs)->broadaddr = NULL;
+  (*ifs)->ifaddr.ipaddr.addr = ddsrt_malloc (sizeof (struct sockaddr_storage));
+  memset ((*ifs)->ifaddr.ipaddr.addr, 0, sizeof (struct sockaddr_storage));
+  (*ifs)->ifaddr.ipaddr.addr->sa_data[0] = 1;
+  (*ifs)->ifaddr.ipaddr.netmask = NULL;
+  (*ifs)->ifaddr.ipaddr.broadaddr = NULL;
   return 0;
 }
 

--- a/src/ddsrt/include/dds/ddsrt/ifaddrs.h
+++ b/src/ddsrt/include/dds/ddsrt/ifaddrs.h
@@ -30,9 +30,13 @@ struct ddsrt_ifaddrs {
   uint32_t index;
   uint32_t flags;
   enum ddsrt_iftype type;
-  struct sockaddr *addr;
-  struct sockaddr *netmask;
-  struct sockaddr *broadaddr;
+  union {
+    struct {
+	  struct sockaddr *addr;
+	  struct sockaddr *netmask;
+	  struct sockaddr *broadaddr; 
+	}ipaddr;
+  }ifaddr;
 };
 
 typedef struct ddsrt_ifaddrs ddsrt_ifaddrs_t;

--- a/src/ddsrt/src/ifaddrs.c
+++ b/src/ddsrt/src/ifaddrs.c
@@ -20,9 +20,9 @@ ddsrt_freeifaddrs(ddsrt_ifaddrs_t *ifa)
   while (ifa != NULL) {
     next = ifa->next;
     ddsrt_free(ifa->name);
-    ddsrt_free(ifa->addr);
-    ddsrt_free(ifa->netmask);
-    ddsrt_free(ifa->broadaddr);
+    ddsrt_free(ifa->ifaddr.ipaddr.addr);
+    ddsrt_free(ifa->ifaddr.ipaddr.netmask);
+    ddsrt_free(ifa->ifaddr.ipaddr.broadaddr);
     ddsrt_free(ifa);
     ifa = next;
   }

--- a/src/ddsrt/src/ifaddrs/lwip/ifaddrs.c
+++ b/src/ddsrt/src/ifaddrs/lwip/ifaddrs.c
@@ -88,7 +88,7 @@ copyaddr(
      structure as described in lwip/netif.h */
 
   if ((ifa = ddsrt_calloc_s(1, sizeof(*ifa))) == NULL ||
-      (ifa->addr = ddsrt_memdup(&sa, sa.s2_len)) == NULL ||
+      (ifa->ifaddr.ipaddr.addr = ddsrt_memdup(&sa, sa.s2_len)) == NULL ||
       (ddsrt_asprintf(&ifa->name, "%s%d", netif->name, netif->num) == -1))
   {
     rc = DDS_RETCODE_OUT_OF_RESOURCES;
@@ -99,8 +99,8 @@ copyaddr(
 
     if (IP_IS_V4(addr)) {
       static const size_t sz = sizeof(struct sockaddr_in);
-      if ((ifa->netmask = ddsrt_calloc_s(1, sz)) == NULL ||
-          (ifa->broadaddr = ddsrt_calloc_s(1, sz)) == NULL)
+      if ((ifa->ifaddr.ipaddr.netmask = ddsrt_calloc_s(1, sz)) == NULL ||
+          (ifa->ifaddr.ipaddr.broadaddr = ddsrt_calloc_s(1, sz)) == NULL)
       {
         rc = DDS_RETCODE_OUT_OF_RESOURCES;
       } else {
@@ -108,8 +108,8 @@ copyaddr(
           ip_2_ip4(&netif->ip_addr)->addr |
           ip_2_ip4(&netif->netmask)->addr);
 
-        sockaddr_from_ip_addr((struct sockaddr*)ifa->netmask, &netif->netmask);
-        sockaddr_from_ip_addr((struct sockaddr*)ifa->broadaddr, &broadaddr);
+        sockaddr_from_ip_addr((struct sockaddr*)ifa->ifaddr.ipaddr.netmask, &netif->netmask);
+        sockaddr_from_ip_addr((struct sockaddr*)ifa->ifaddr.ipaddr.broadaddr, &broadaddr);
       }
     }
   }

--- a/src/ddsrt/src/ifaddrs/posix/ifaddrs.c
+++ b/src/ddsrt/src/ifaddrs/posix/ifaddrs.c
@@ -147,19 +147,19 @@ copyaddr(ddsrt_ifaddrs_t **ifap, const struct ifaddrs *sys_ifa, enum ddsrt_iftyp
     ifa->type = type;
     ifa->flags = sys_ifa->ifa_flags;
     if ((ifa->name = ddsrt_strdup(sys_ifa->ifa_name)) == NULL ||
-        (ifa->addr = ddsrt_memdup(sys_ifa->ifa_addr, sz)) == NULL ||
+        (ifa->ifaddr.ipaddr.addr = ddsrt_memdup(sys_ifa->ifa_addr, sz)) == NULL ||
           (sys_ifa->ifa_netmask != NULL &&
-        (ifa->netmask = ddsrt_memdup(sys_ifa->ifa_netmask, sz)) == NULL) ||
+        (ifa->ifaddr.ipaddr.netmask = ddsrt_memdup(sys_ifa->ifa_netmask, sz)) == NULL) ||
           (sys_ifa->ifa_broadaddr != NULL &&
           (sys_ifa->ifa_flags & IFF_BROADCAST) &&
-        (ifa->broadaddr = ddsrt_memdup(sys_ifa->ifa_broadaddr, sz)) == NULL))
+        (ifa->ifaddr.ipaddr.broadaddr = ddsrt_memdup(sys_ifa->ifa_broadaddr, sz)) == NULL))
     {
       err = DDS_RETCODE_OUT_OF_RESOURCES;
     }
     /* Seen on macOS using OpenVPN: netmask without an address family,
        in which case copy it from the interface address */
-    if (ifa->addr && ifa->netmask && ifa->netmask->sa_family == 0) {
-      ifa->netmask->sa_family = ifa->addr->sa_family;
+    if (ifa->ifaddr.ipaddr.addr && ifa->ifaddr.ipaddr.netmask && ifa->ifaddr.ipaddr.netmask->sa_family == 0) {
+      ifa->ifaddr.ipaddr.netmask->sa_family = ifa->ifaddr.ipaddr.addr->sa_family;
     }
   }
 

--- a/src/ddsrt/src/ifaddrs/solaris2.6/ifaddrs.c
+++ b/src/ddsrt/src/ifaddrs/solaris2.6/ifaddrs.c
@@ -68,10 +68,10 @@ ddsrt_getifaddrs(
     ifa->index = (int) (ifr - ifc.ifc_req);
     ifa->flags = IFF_UP | ((strcmp(ifr->ifr_name, "lo0")==0) ? IFF_LOOPBACK : IFF_MULTICAST);
     ifa->name = strdup (ifr->ifr_name);
-    ifa->addr = ddsrt_memdup (&ifr->ifr_addr, sizeof (struct sockaddr_in));
-    ifa->netmask = ddsrt_memdup (&ifr->ifr_addr, sizeof (struct sockaddr_in));
-    ((struct sockaddr_in *) ifa->netmask)->sin_addr.s_addr = htonl (0xffffff00);
-    ifa->broadaddr = NULL;
+    ifa->ifaddr.ipaddr.addr = ddsrt_memdup (&ifr->ifr_addr, sizeof (struct sockaddr_in));
+    ifa->ifaddr.ipaddr.netmask = ddsrt_memdup (&ifr->ifr_addr, sizeof (struct sockaddr_in));
+    ((struct sockaddr_in *) ifa->ifaddr.ipaddr.netmask)->sin_addr.s_addr = htonl (0xffffff00);
+    ifa->ifaddr.ipaddr.broadaddr = NULL;
     ifa->next = NULL;
     *ifap = ifa;
     ifap = &ifa->next;

--- a/src/ddsrt/src/ifaddrs/windows/ifaddrs.c
+++ b/src/ddsrt/src/ifaddrs/windows/ifaddrs.c
@@ -213,16 +213,16 @@ copyaddr(
     goto err_ifa;
   ifa->flags = getflags(iface);
   ifa->type = guess_iftype(iface);
-  if (!(ifa->addr = ddsrt_memdup(sa, sz)))
+  if (!(ifa->ifaddr.ipaddr.addr = ddsrt_memdup(sa, sz)))
     goto err_ifa_addr;
   if ((rc = copyname(iface->FriendlyName, &ifa->name)))
     goto err_ifa_name;
 
-  if (ifa->addr->sa_family == AF_INET6) {
+  if (ifa->ifaddr.ipaddr.addr->sa_family == AF_INET6) {
     ifa->index = iface->Ipv6IfIndex;
 
     /* Address is not in addrtable if the interface is not connected. */
-  } else if (ifa->addr->sa_family == AF_INET && (ifa->flags & IFF_UP)) {
+  } else if (ifa->ifaddr.ipaddr.addr->sa_family == AF_INET && (ifa->flags & IFF_UP)) {
     DWORD i = 0;
     struct sockaddr_in nm, bc, *sin = (struct sockaddr_in *)sa;
 
@@ -241,9 +241,9 @@ copyaddr(
     }
 
     assert(i < addrtable->dwNumEntries);
-    if (!(ifa->netmask = ddsrt_memdup(&nm, sz)))
+    if (!(ifa->ifaddr.ipaddr.netmask = ddsrt_memdup(&nm, sz)))
       goto err_ifa_netmask;
-    if (!(ifa->broadaddr = ddsrt_memdup(&bc, sz)))
+    if (!(ifa->ifaddr.ipaddr.broadaddr = ddsrt_memdup(&bc, sz)))
       goto err_ifa_broadaddr;
   }
 

--- a/src/ddsrt/tests/ifaddrs.c
+++ b/src/ddsrt/tests/ifaddrs.c
@@ -73,14 +73,14 @@ CU_Test(ddsrt_getifaddrs, ipv4)
   ret = ddsrt_getifaddrs(&ifa_root, afs);
   CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
   for (ifa = ifa_root; ifa; ifa = ifa->next) {
-    CU_ASSERT_PTR_NOT_EQUAL_FATAL(ifa->addr, NULL);
-    assert (ifa->addr != NULL); /* for the benefit of clang's static analyzer */
-    CU_ASSERT_EQUAL(ifa->addr->sa_family, AF_INET);
-    if (ifa->addr->sa_family == AF_INET) {
+    CU_ASSERT_PTR_NOT_EQUAL_FATAL(ifa->ifaddr.ipaddr.addr, NULL);
+    assert (ifa->ifaddr.ipaddr.addr != NULL); /* for the benefit of clang's static analyzer */
+    CU_ASSERT_EQUAL(ifa->ifaddr.ipaddr.addr->sa_family, AF_INET);
+    if (ifa->ifaddr.ipaddr.addr->sa_family == AF_INET) {
       if (ifa->flags & IFF_LOOPBACK) {
-        CU_ASSERT(ddsrt_sockaddr_isloopback(ifa->addr));
+        CU_ASSERT(ddsrt_sockaddr_isloopback(ifa->ifaddr.ipaddr.addr));
       } else {
-        CU_ASSERT(!ddsrt_sockaddr_isloopback(ifa->addr));
+        CU_ASSERT(!ddsrt_sockaddr_isloopback(ifa->ifaddr.ipaddr.addr));
       }
       seen = 1;
     }
@@ -99,7 +99,7 @@ CU_Test(ddsrt_getifaddrs, null_filter)
   ret = ddsrt_getifaddrs(&ifa_root, NULL);
   CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
   for (ifa = ifa_root; ifa; ifa = ifa->next) {
-    CU_ASSERT_PTR_NOT_EQUAL_FATAL(ifa->addr, NULL);
+    CU_ASSERT_PTR_NOT_EQUAL_FATAL(ifa->ifaddr.ipaddr.addr, NULL);
     cnt++;
   }
 


### PR DESCRIPTION
With the consideration of other transports whose address is not sockaddr, redesign the type definition of "ddsrt_ifaddrs".