### PR TITLE
Fixes for XTypes interoperability

### DIFF
--- a/src/core/ddsc/src/dds_domain.c
+++ b/src/core/ddsc/src/dds_domain.c
@@ -489,7 +489,8 @@ static dds_return_t wait_for_type_resolved(
   }
   ddsrt_mutex_unlock (&gv->typelib_lock);
 
-  if (!ddsi_tl_request_type (gv, ddsi_type_id, include_deps))
+  // FIXME: provide proxy pp guid
+  if (!ddsi_tl_request_type (gv, ddsi_type_id, NULL, include_deps))
   {
     rc = DDS_RETCODE_PRECONDITION_NOT_MET;
     goto err_unpin;

--- a/src/core/ddsc/tests/xtypes.c
+++ b/src/core/ddsc/tests/xtypes.c
@@ -795,14 +795,12 @@ CU_Theory ((const char *test_descr, const dds_topic_descriptor_t *topic_desc, ty
 
   DDS_XTypes_TypeMapping *tmap;
   typemap_deser (&tmap, &desc.type_mapping);
-
-  // add proxy endpoint types (invalid) via tl lookup reply impl
-  DDS_Builtin_TypeLookup_Reply reply_invalid_types = {
-    .header = { .instanceName = "dummy", .requestId = { .sequence_number = { .low = 1, .high = 0 }, .writer_guid = { .guidPrefix = { 0 }, .entityId = { .entityKind = EK_WRITER, .entityKey = { 0 } } } } },
+  DDS_Builtin_TypeLookup_Reply reply = {
+    .header = { .remoteEx = DDS_RPC_REMOTE_EX_OK, .relatedRequestId = { .sequence_number = { .low = 1, .high = 0 }, .writer_guid = { .guidPrefix = { 0 }, .entityId = { .entityKind = EK_WRITER, .entityKey = { 0 } } } } },
     .return_data = { ._d = DDS_Builtin_TypeLookup_getTypes_HashId, ._u = { .getType = { ._d = DDS_RETCODE_OK, ._u = { .result =
       { .types = { ._length = tmap->identifier_object_pair_minimal._length, ._maximum = tmap->identifier_object_pair_minimal._maximum, ._release = false, ._buffer = tmap->identifier_object_pair_minimal._buffer } } } } } }
     };
-  ddsi_tl_add_types (gv, &reply_invalid_types, &gpe_match_upd, &n_match_upd);
+  ddsi_tl_add_types (gv, &reply, &gpe_match_upd, &n_match_upd);
 
   // expect no match because of invalid types
   CU_ASSERT_EQUAL_FATAL (n_match_upd, 0);
@@ -869,7 +867,7 @@ CU_Test (ddsc_xtypes, resolve_dep_type, .init = xtypes_init, .fini = xtypes_fini
 
   // add proxy reader's top-level type
   reply = (DDS_Builtin_TypeLookup_Reply) {
-    .header = { .instanceName = "dummy", .requestId = { .sequence_number = { .low = 1, .high = 0 }, .writer_guid = { .guidPrefix = { 0 }, .entityId = { .entityKind = EK_WRITER, .entityKey = { 0 } } } } },
+    .header = { .remoteEx = DDS_RPC_REMOTE_EX_OK, .relatedRequestId = { .sequence_number = { .low = 1, .high = 0 }, .writer_guid = { .guidPrefix = { 0 }, .entityId = { .entityKind = EK_WRITER, .entityKey = { 0 } } } } },
     .return_data = { ._d = DDS_Builtin_TypeLookup_getTypes_HashId, ._u = { .getType = { ._d = DDS_RETCODE_OK, ._u = { .result =
       { .types = { ._length = 1, ._maximum = 1, ._release = false, ._buffer = &tmap->identifier_object_pair_minimal._buffer[0] } } } } } }
     };
@@ -879,7 +877,7 @@ CU_Test (ddsc_xtypes, resolve_dep_type, .init = xtypes_init, .fini = xtypes_fini
 
   // add nested type and expect match
   reply = (DDS_Builtin_TypeLookup_Reply) {
-    .header = { .instanceName = "dummy", .requestId = { .sequence_number = { .low = 1, .high = 0 }, .writer_guid = { .guidPrefix = { 0 }, .entityId = { .entityKind = EK_WRITER, .entityKey = { 0 } } } } },
+    .header = { .remoteEx = DDS_RPC_REMOTE_EX_OK, .relatedRequestId = { .sequence_number = { .low = 1, .high = 0 }, .writer_guid = { .guidPrefix = { 0 }, .entityId = { .entityKind = EK_WRITER, .entityKey = { 0 } } } } },
     .return_data = { ._d = DDS_Builtin_TypeLookup_getTypes_HashId, ._u = { .getType = { ._d = DDS_RETCODE_OK, ._u = { .result =
       { .types = { ._length = 1, ._maximum = 1, ._release = false, ._buffer = &tmap->identifier_object_pair_minimal._buffer[1] } } } } } }
     };

--- a/src/core/ddsi/include/dds/ddsi/ddsi_typelookup.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_typelookup.h
@@ -47,7 +47,7 @@ struct ddsi_type;
  * Send a type lookup request message in order to request type information for the
  * provided type identifier.
  */
-DDS_EXPORT bool ddsi_tl_request_type (struct ddsi_domaingv * const gv, const ddsi_typeid_t *type_id, bool include_deps);
+DDS_EXPORT bool ddsi_tl_request_type (struct ddsi_domaingv * const gv, const ddsi_typeid_t *type_id, const ddsi_guid_t *proxypp_guid, bool include_deps);
 
 /**
  * Handle an incoming type lookup request message. For all types requested

--- a/src/core/ddsi/include/dds/ddsi/ddsi_xt_typelookup.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_xt_typelookup.h
@@ -289,7 +289,7 @@ typedef struct DDS_Builtin_TypeLookup_Return
 
 typedef struct DDS_Builtin_TypeLookup_Reply
 {
-  struct DDS_RPC_RequestHeader header;
+  struct DDS_RPC_ReplyHeader header;
   struct DDS_Builtin_TypeLookup_Return return_data;
 } DDS_Builtin_TypeLookup_Reply;
 

--- a/src/core/ddsi/include/dds/ddsi/ddsi_xt_typelookup.idl
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_xt_typelookup.idl
@@ -5,19 +5,24 @@ module DDS {
 
 typedef octet GuidPrefix_t[12];
 
+@final
 struct EntityId_t {
     octet entityKey[3]; octet entityKind;
 };
 
+@final
 struct GUID_t {
     GuidPrefix_t guidPrefix;
     EntityId_t entityId;
 };
+
+@final
 struct SequenceNumber {
     long high;
     unsigned long low;
 };
 
+@final
 struct SampleIdentity {
     GUID_t writer_guid;
     SequenceNumber sequence_number;
@@ -45,11 +50,13 @@ enum RemoteExceptionCode {
 
 typedef string<255> InstanceName;
 
+@final
 struct RequestHeader {
     DDS::SampleIdentity requestId;
     DDS::RPC::InstanceName instanceName;
 };
 
+@final
 struct ReplyHeader {
     DDS::SampleIdentity relatedRequestId;
     DDS::RPC::RemoteExceptionCode remoteEx;
@@ -112,6 +119,7 @@ union TypeLookup_Call switch(long) {
 
 @nested(FALSE)
 @RPCRequestType
+@final
 struct TypeLookup_Request {
     DDS::RPC::RequestHeader header;
     TypeLookup_Call data;
@@ -127,6 +135,7 @@ union TypeLookup_Return switch(long) {
 
 @nested(FALSE)
 @RPCReplyType
+@final
 struct TypeLookup_Reply {
     DDS::RPC::ReplyHeader header;
     TypeLookup_Return return_data; // changed from return to return_data to avoid collision with return keyword

--- a/src/core/ddsi/include/dds/ddsi/ddsi_xt_typelookup.idl
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_xt_typelookup.idl
@@ -128,7 +128,7 @@ union TypeLookup_Return switch(long) {
 @nested(FALSE)
 @RPCReplyType
 struct TypeLookup_Reply {
-    DDS::RPC::RequestHeader header;
+    DDS::RPC::ReplyHeader header;
     TypeLookup_Return return_data; // changed from return to return_data to avoid collision with return keyword
 };
 

--- a/src/core/ddsi/src/ddsi_xt_typelookup.c
+++ b/src/core/ddsi/src/ddsi_xt_typelookup.c
@@ -168,13 +168,13 @@ const dds_topic_descriptor_t DDS_Builtin_TypeLookup_Request_desc =
 static const uint32_t DDS_Builtin_TypeLookup_Reply_ops [] =
 {
   /* TypeLookup_Reply */
-  DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_Builtin_TypeLookup_Reply, header), (3u << 16u) + 7u /* RequestHeader */,
+  DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_Builtin_TypeLookup_Reply, header), (3u << 16u) + 7u /* ReplyHeader */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_Builtin_TypeLookup_Reply, return_data), (3u << 16u) + 36u /* TypeLookup_Return */,
   DDS_OP_RTS,
 
-  /* RequestHeader */
-  DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_RPC_RequestHeader, requestId), (3u << 16u) + 7u /* SampleIdentity */,
-  DDS_OP_ADR | DDS_OP_TYPE_BST, offsetof (DDS_RPC_RequestHeader, instanceName), 256u,
+  /* ReplyHeader */
+  DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_RPC_ReplyHeader, relatedRequestId), (3u << 16u) + 7u /* SampleIdentity */,
+  DDS_OP_ADR | DDS_OP_TYPE_ENU | (2 << DDS_OP_FLAG_SZ_SHIFT), offsetof (DDS_RPC_ReplyHeader, remoteEx), 5u,
   DDS_OP_RTS,
 
   /* SampleIdentity */

--- a/src/core/ddsi/src/ddsi_xt_typelookup.c
+++ b/src/core/ddsi/src/ddsi_xt_typelookup.c
@@ -42,6 +42,7 @@ static const uint32_t DDS_Builtin_TypeLookup_Request_ops [] =
   DDS_OP_RTS,
 
   /* TypeLookup_Call */
+  DDS_OP_DLC,
   DDS_OP_ADR | DDS_OP_FLAG_MU | DDS_OP_TYPE_UNI | DDS_OP_SUBTYPE_4BY | DDS_OP_FLAG_SGN, offsetof (DDS_Builtin_TypeLookup_Call, _d), 2u, (12u << 16u) + 4u,
   DDS_OP_JEQ4 | DDS_OP_TYPE_STU | 9 /* TypeLookup_getTypes_In */, 25318099, offsetof (DDS_Builtin_TypeLookup_Call, _u.getTypes), 0u,
   DDS_OP_JEQ4 | DDS_OP_TYPE_STU | 190 /* TypeLookup_getTypeDependencies_In */, 95091505, offsetof (DDS_Builtin_TypeLookup_Call, _u.getTypeDependencies), 0u,
@@ -160,7 +161,7 @@ const dds_topic_descriptor_t DDS_Builtin_TypeLookup_Request_desc =
   .m_nkeys = 0u,
   .m_typename = "DDS::Builtin::TypeLookup_Request",
   .m_keys = NULL,
-  .m_nops = 82,
+  .m_nops = 83,
   .m_ops = DDS_Builtin_TypeLookup_Request_ops,
   .m_meta = ""
 };
@@ -198,12 +199,14 @@ static const uint32_t DDS_Builtin_TypeLookup_Reply_ops [] =
   DDS_OP_RTS,
 
   /* TypeLookup_Return */
+  DDS_OP_DLC,
   DDS_OP_ADR | DDS_OP_FLAG_MU | DDS_OP_TYPE_UNI | DDS_OP_SUBTYPE_4BY | DDS_OP_FLAG_SGN, offsetof (DDS_Builtin_TypeLookup_Return, _d), 2u, (12u << 16u) + 4u,
   DDS_OP_JEQ4 | DDS_OP_TYPE_UNI | 9 /* TypeLookup_getTypes_Result */, 25318099, offsetof (DDS_Builtin_TypeLookup_Return, _u.getType), 0u,
-  DDS_OP_JEQ4 | DDS_OP_TYPE_UNI | 1063 /* TypeLookup_getTypeDependencies_Result */, 95091505, offsetof (DDS_Builtin_TypeLookup_Return, _u.getTypeDependencies), 0u,
+  DDS_OP_JEQ4 | DDS_OP_TYPE_UNI | 1064 /* TypeLookup_getTypeDependencies_Result */, 95091505, offsetof (DDS_Builtin_TypeLookup_Return, _u.getTypeDependencies), 0u,
   DDS_OP_RTS,
 
   /* TypeLookup_getTypes_Result */
+  DDS_OP_DLC,
   DDS_OP_ADR | DDS_OP_FLAG_MU | DDS_OP_TYPE_UNI | DDS_OP_SUBTYPE_4BY | DDS_OP_FLAG_SGN, offsetof (DDS_Builtin_TypeLookup_getTypes_Result, _d), 1u, (8u << 16u) + 4u,
   DDS_OP_JEQ4 | DDS_OP_TYPE_STU | 5 /* TypeLookup_getTypes_Out */, 0, offsetof (DDS_Builtin_TypeLookup_getTypes_Result, _u.result), 0u,
   DDS_OP_RTS,
@@ -823,6 +826,7 @@ static const uint32_t DDS_Builtin_TypeLookup_Reply_ops [] =
   DDS_OP_RTS,
 
   /* TypeLookup_getTypeDependencies_Result */
+  DDS_OP_DLC,
   DDS_OP_ADR | DDS_OP_FLAG_MU | DDS_OP_TYPE_UNI | DDS_OP_SUBTYPE_4BY | DDS_OP_FLAG_SGN, offsetof (DDS_Builtin_TypeLookup_getTypeDependencies_Result, _d), 1u, (8u << 16u) + 4u,
   DDS_OP_JEQ4 | DDS_OP_TYPE_STU | 5 /* TypeLookup_getTypeDependencies_Out */, 0, offsetof (DDS_Builtin_TypeLookup_getTypeDependencies_Result, _u.result), 0u,
   DDS_OP_RTS,
@@ -839,7 +843,7 @@ static const uint32_t DDS_Builtin_TypeLookup_Reply_ops [] =
 
   /* TypeIdentifierWithSize */
   DDS_OP_DLC,
-  DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_TypeIdentifierWithSize, type_id), (3u << 16u) + 64485u /* TypeIdentifier */,
+  DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_TypeIdentifierWithSize, type_id), (3u << 16u) + 64484u /* TypeIdentifier */,
   DDS_OP_ADR | DDS_OP_TYPE_4BY, offsetof (DDS_XTypes_TypeIdentifierWithSize, typeobject_serialized_size),
   DDS_OP_RTS
 };
@@ -852,7 +856,7 @@ const dds_topic_descriptor_t DDS_Builtin_TypeLookup_Reply_desc =
   .m_nkeys = 0u,
   .m_typename = "DDS::Builtin::TypeLookup_Reply",
   .m_keys = NULL,
-  .m_nops = 414,
+  .m_nops = 417,
   .m_ops = DDS_Builtin_TypeLookup_Reply_ops,
   .m_meta = ""
 };

--- a/src/core/ddsi/src/q_receive.c
+++ b/src/core/ddsi/src/q_receive.c
@@ -1890,7 +1890,7 @@ static int handle_Gap (struct receiver_state *rst, ddsrt_etime_t tnow, struct nn
   }
   RSTTRACE (PGUIDFMT" -> "PGUIDFMT, PGUID (src), PGUID (dst));
 
-  if (!pwr->have_seen_heartbeat && pwr->n_reliable_readers > 0)
+  if (!pwr->have_seen_heartbeat && pwr->n_reliable_readers > 0 && vendor_is_eclipse (rst->vendor))
   {
     RSTTRACE (": no heartbeat seen yet");
     ddsrt_mutex_unlock (&pwr->e.lock);
@@ -2345,7 +2345,7 @@ static void handle_regular (struct receiver_state *rst, ddsrt_etime_t tnow, stru
      been seen could potentially result in a disruption of the data flow to
      the best-effort readers.  That state should last only for a very short
      time, but it is rather inelegant.  */
-  if (!pwr->have_seen_heartbeat && pwr->n_reliable_readers > 0)
+  if (!pwr->have_seen_heartbeat && pwr->n_reliable_readers > 0 && vendor_is_eclipse (rst->vendor))
   {
     ddsrt_mutex_unlock (&pwr->e.lock);
     RSTTRACE (" "PGUIDFMT" -> "PGUIDFMT": no heartbeat seen yet", PGUID (pwr->e.guid), PGUID (dst));

--- a/src/tools/idlc/tests/type_meta.c
+++ b/src/tools/idlc/tests/type_meta.c
@@ -202,7 +202,7 @@ static DDS_XTypes_TypeObject *get_typeobj_union(const char *name, uint16_t flags
     ._d = DDS_XTypes_TK_UNION,
     ._u.union_type = (DDS_XTypes_CompleteUnionType) {
       .union_flags = flags,
-      .discriminator = { .common = { .member_flags = DDS_XTypes_IS_MUST_UNDERSTAND, .type_id = disc_type } },
+      .discriminator = { .common = { .member_flags = DDS_XTypes_IS_MUST_UNDERSTAND | DDS_XTypes_TRY_CONSTRUCT_DISCARD, .type_id = disc_type } },
       .member_seq = {
         ._maximum = member_cnt,
         ._length = member_cnt,
@@ -224,9 +224,9 @@ static DDS_XTypes_TypeObject *get_typeobj1 (void)
     DDS_XTypes_IS_APPENDABLE,
     (DDS_XTypes_TypeIdentifier) { ._d = DDS_XTypes_TK_NONE },
     3, (smember_t[]) {
-      { 0, DDS_XTypes_IS_KEY | DDS_XTypes_IS_MUST_UNDERSTAND, { ._d = DDS_XTypes_TK_INT64 }, "f1" },
-      { 1, DDS_XTypes_IS_OPTIONAL, { ._d = DDS_XTypes_TI_STRING8_SMALL, ._u.string_sdefn.bound = 0 }, "f2" },
-      { 4, DDS_XTypes_IS_EXTERNAL, { ._d = DDS_XTypes_TK_CHAR8 }, "f3" }
+      { 0, DDS_XTypes_IS_KEY | DDS_XTypes_IS_MUST_UNDERSTAND | DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TK_INT64 }, "f1" },
+      { 1, DDS_XTypes_IS_OPTIONAL | DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TI_STRING8_SMALL, ._u.string_sdefn.bound = 0 }, "f2" },
+      { 4, DDS_XTypes_IS_EXTERNAL | DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TK_CHAR8 }, "f3" }
     });
 }
 
@@ -237,8 +237,8 @@ static DDS_XTypes_TypeObject *get_typeobj2 (void)
     DDS_XTypes_IS_MUTABLE,
     (DDS_XTypes_TypeIdentifier) { ._d = DDS_XTypes_TK_NONE },
     2, (smember_t[]) {
-      { 0, DDS_XTypes_IS_OPTIONAL | DDS_XTypes_IS_EXTERNAL, { ._d = DDS_XTypes_TK_UINT32 }, "f1" },
-      { 1, DDS_XTypes_IS_OPTIONAL | DDS_XTypes_IS_EXTERNAL, { ._d = DDS_XTypes_TK_UINT32 }, "f2" }
+      { 0, DDS_XTypes_IS_OPTIONAL | DDS_XTypes_IS_EXTERNAL | DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TK_UINT32 }, "f1" },
+      { 1, DDS_XTypes_IS_OPTIONAL | DDS_XTypes_IS_EXTERNAL | DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TK_UINT32 }, "f2" }
     });
 }
 
@@ -249,8 +249,8 @@ static DDS_XTypes_TypeObject *get_typeobj3 (void)
     DDS_XTypes_IS_FINAL,
     (DDS_XTypes_TypeIdentifier) { ._d = DDS_XTypes_TK_INT16 },
     2, (umember_t[]) {
-      { 0, 0, { ._d = DDS_XTypes_TK_INT32 }, "f1", 1, (int32_t[]) { 1 } },
-      { 1, DDS_XTypes_IS_EXTERNAL | DDS_XTypes_IS_DEFAULT, { ._d = DDS_XTypes_TI_STRING8_SMALL, ._u.string_sdefn.bound = 0 }, "f2", 2, (int32_t[]) { 2, 3 } }
+      { 0, DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TK_INT32 }, "f1", 1, (int32_t[]) { 1 } },
+      { 1, DDS_XTypes_IS_EXTERNAL | DDS_XTypes_IS_DEFAULT | DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TI_STRING8_SMALL, ._u.string_sdefn.bound = 0 }, "f2", 2, (int32_t[]) { 2, 3 } }
     });
 }
 
@@ -273,14 +273,14 @@ static DDS_XTypes_TypeObject *get_typeobj4 (void)
     DDS_XTypes_IS_MUTABLE | DDS_XTypes_IS_NESTED,
     (DDS_XTypes_TypeIdentifier) { ._d = DDS_XTypes_TK_NONE },
     1, (smember_t[]) {
-      { 5, 0, { ._d = DDS_XTypes_TK_INT32 }, "a1" }
+      { 5, DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TK_INT32 }, "a1" }
     }));
   return get_typeobj_struct (
     "t4::test_struct",
     DDS_XTypes_IS_MUTABLE,
     ti_base,
     1, (smember_t[]) {
-      { 10, 0, { ._d = DDS_XTypes_TK_INT32 }, "f1" }
+      { 10, DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TK_INT32 }, "f1" }
     });
 }
 
@@ -301,7 +301,7 @@ static DDS_XTypes_TypeObject *get_typeobj5 (void)
       .body = { .common = { .related_flags = 0, .related_type = (DDS_XTypes_TypeIdentifier) {
         ._d = DDS_XTypes_TI_PLAIN_SEQUENCE_SMALL,
         ._u.seq_sdefn = {
-          .header = { .equiv_kind = DDS_XTypes_EK_BOTH, .element_flags = 0 },
+          .header = { .equiv_kind = DDS_XTypes_EK_BOTH, .element_flags = DDS_XTypes_TRY_CONSTRUCT_DISCARD },
           .bound = 0,
           .element_identifier = ti_long
         }
@@ -314,7 +314,7 @@ static DDS_XTypes_TypeObject *get_typeobj5 (void)
   DDS_XTypes_TypeIdentifier ti_seq = {
     ._d = DDS_XTypes_TI_PLAIN_SEQUENCE_SMALL,
     ._u.seq_sdefn = {
-      .header = { .equiv_kind = DDS_XTypes_EK_COMPLETE, .element_flags = 0 },
+      .header = { .equiv_kind = DDS_XTypes_EK_COMPLETE, .element_flags = DDS_XTypes_TRY_CONSTRUCT_DISCARD },
       .bound = 0
     }
   };
@@ -326,8 +326,8 @@ static DDS_XTypes_TypeObject *get_typeobj5 (void)
     DDS_XTypes_IS_FINAL,
     (DDS_XTypes_TypeIdentifier) { ._d = DDS_XTypes_TK_NONE },
     2, (smember_t[]) {
-      { 0, 0, ti_seq, "f1" },
-      { 1, 0, ti_alias, "f2" }
+      { 0, DDS_XTypes_TRY_CONSTRUCT_DISCARD, ti_seq, "f1" },
+      { 1, DDS_XTypes_TRY_CONSTRUCT_DISCARD, ti_alias, "f2" }
     });
 }
 
@@ -345,7 +345,7 @@ static DDS_XTypes_TypeObject *get_typeobj6 (void)
     ti_f1 = (DDS_XTypes_TypeIdentifier) {
       ._d = DDS_XTypes_TI_PLAIN_ARRAY_SMALL,
       ._u.array_sdefn = {
-        .header = { .equiv_kind = DDS_XTypes_EK_BOTH, .element_flags = 0 },
+        .header = { .equiv_kind = DDS_XTypes_EK_BOTH, .element_flags = DDS_XTypes_TRY_CONSTRUCT_DISCARD },
         .array_bound_seq = { ._maximum = 1, ._length = 1, ._buffer = f1bound_seq, ._release = true },
         .element_identifier = ti_f1_el
       }
@@ -356,6 +356,7 @@ static DDS_XTypes_TypeObject *get_typeobj6 (void)
     // the other 2 fields.
     ti_f1._u.array_sdefn.array_bound_seq._buffer = f1bound_seq;
     ti_f1._u.array_sdefn.element_identifier = ti_f1_el;
+    ti_f1._u.array_sdefn.header.element_flags = DDS_XTypes_TRY_CONSTRUCT_DISCARD;
   }
 
   /* f2 type identifier: string<555> f2[999][3] */
@@ -370,7 +371,7 @@ static DDS_XTypes_TypeObject *get_typeobj6 (void)
     ti_f2 = (DDS_XTypes_TypeIdentifier) {
       ._d = DDS_XTypes_TI_PLAIN_ARRAY_LARGE,
       ._u.array_ldefn = {
-        .header = { .equiv_kind = DDS_XTypes_EK_BOTH, .element_flags = 0 },
+        .header = { .equiv_kind = DDS_XTypes_EK_BOTH, .element_flags = DDS_XTypes_TRY_CONSTRUCT_DISCARD },
         .array_bound_seq = { ._maximum = 2, ._length = 2, ._buffer = f2bound_seq, ._release = true },
         .element_identifier = ti_f2_el
       }
@@ -378,6 +379,7 @@ static DDS_XTypes_TypeObject *get_typeobj6 (void)
     // Clang's static analyzer ...
     ti_f2._u.array_ldefn.array_bound_seq._buffer = f2bound_seq;
     ti_f2._u.array_ldefn.element_identifier = ti_f2_el;
+    ti_f2._u.array_ldefn.header.element_flags = DDS_XTypes_TRY_CONSTRUCT_DISCARD;
   }
 
   /* f3 type identifier: a[3] f3 */
@@ -389,7 +391,7 @@ static DDS_XTypes_TypeObject *get_typeobj6 (void)
       DDS_XTypes_IS_FINAL | DDS_XTypes_IS_NESTED,
       (DDS_XTypes_TypeIdentifier) { ._d = DDS_XTypes_TK_NONE },
       1, (smember_t[]) {
-        { 0, 0, { ._d = DDS_XTypes_TK_INT32 }, "a1" }
+        { 0, DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TK_INT32 }, "a1" }
       }));
 
     uint8_t *f3bound_seq = calloc (1, sizeof (*f3bound_seq));
@@ -397,7 +399,7 @@ static DDS_XTypes_TypeObject *get_typeobj6 (void)
     ti_f3 = (DDS_XTypes_TypeIdentifier) {
       ._d = DDS_XTypes_TI_PLAIN_ARRAY_SMALL,
       ._u.array_sdefn = {
-        .header = { .equiv_kind = DDS_XTypes_EK_COMPLETE, .element_flags = 0 },
+        .header = { .equiv_kind = DDS_XTypes_EK_COMPLETE, .element_flags = DDS_XTypes_TRY_CONSTRUCT_DISCARD },
         .array_bound_seq = { ._maximum = 1, ._length = 1, ._buffer = f3bound_seq, ._release = true },
         .element_identifier = ti_a
       }
@@ -405,6 +407,7 @@ static DDS_XTypes_TypeObject *get_typeobj6 (void)
     // Clang's static analyzer ...
     ti_f3._u.array_sdefn.array_bound_seq._buffer = f3bound_seq;
     ti_f3._u.array_sdefn.element_identifier = ti_a;
+    ti_f3._u.array_sdefn.header.element_flags = DDS_XTypes_TRY_CONSTRUCT_DISCARD;
   }
 
   return get_typeobj_struct (
@@ -412,9 +415,9 @@ static DDS_XTypes_TypeObject *get_typeobj6 (void)
     DDS_XTypes_IS_FINAL,
     (DDS_XTypes_TypeIdentifier) { ._d = DDS_XTypes_TK_NONE },
     3, (smember_t[]) {
-      { 0, 0, ti_f1, "f1" },
-      { 1, 0, ti_f2, "f2" },
-      { 2, 0, ti_f3, "f3" }
+      { 0, DDS_XTypes_TRY_CONSTRUCT_DISCARD, ti_f1, "f1" },
+      { 1, DDS_XTypes_TRY_CONSTRUCT_DISCARD, ti_f2, "f2" },
+      { 2, DDS_XTypes_TRY_CONSTRUCT_DISCARD, ti_f3, "f3" }
     });
 }
 
@@ -465,8 +468,8 @@ static DDS_XTypes_TypeObject *get_typeobj7 (void)
     DDS_XTypes_IS_FINAL,
     (DDS_XTypes_TypeIdentifier) { ._d = DDS_XTypes_TK_NONE },
     2, (smember_t[]) {
-      { 0, 0, ti_f1, "f1" },
-      { 1, 0, ti_f2, "f2" }
+      { 0, DDS_XTypes_TRY_CONSTRUCT_DISCARD, ti_f1, "f1" },
+      { 1, DDS_XTypes_TRY_CONSTRUCT_DISCARD, ti_f2, "f2" }
     });
 }
 
@@ -485,7 +488,7 @@ static DDS_XTypes_TypeObject *get_typeobj8 (void)
     ti_f1 = (DDS_XTypes_TypeIdentifier) {
       ._d = DDS_XTypes_TI_PLAIN_ARRAY_SMALL,
       ._u.array_sdefn = {
-        .header = { .equiv_kind = DDS_XTypes_EK_BOTH, .element_flags = 0 },
+        .header = { .equiv_kind = DDS_XTypes_EK_BOTH, .element_flags = DDS_XTypes_TRY_CONSTRUCT_DISCARD },
         .array_bound_seq = { ._maximum = 2, ._length = 2, ._buffer = f1bound_seq, ._release = true },
         .element_identifier = ti_f1_el
       }
@@ -497,7 +500,7 @@ static DDS_XTypes_TypeObject *get_typeobj8 (void)
     DDS_XTypes_IS_FINAL,
     (DDS_XTypes_TypeIdentifier) { ._d = DDS_XTypes_TK_NONE },
     1, (smember_t[]) {
-      { 0, 0, ti_f1, "f1" }
+      { 0, DDS_XTypes_TRY_CONSTRUCT_DISCARD, ti_f1, "f1" }
     });
 }
 
@@ -529,8 +532,8 @@ static DDS_XTypes_TypeObject *get_typeobj9 (void)
     DDS_XTypes_IS_FINAL,
     (DDS_XTypes_TypeIdentifier) { ._d = DDS_XTypes_TK_NONE },
     2, (smember_t[]) {
-      { 0, 0, ti_f, "f1" },
-      { 1, 0, ti_f, "f2" }
+      { 0, DDS_XTypes_TRY_CONSTRUCT_DISCARD, ti_f, "f1" },
+      { 1, DDS_XTypes_TRY_CONSTRUCT_DISCARD, ti_f, "f2" }
     });
 }
 
@@ -562,8 +565,8 @@ static DDS_XTypes_TypeObject *get_typeobj10 (void)
     DDS_XTypes_IS_FINAL,
     (DDS_XTypes_TypeIdentifier) { ._d = DDS_XTypes_TK_NONE },
     2, (smember_t[]) {
-      { 0, 0, ti_f, "f1" },
-      { 1, 0, ti_f, "f2" }
+      { 0, DDS_XTypes_TRY_CONSTRUCT_DISCARD, ti_f, "f1" },
+      { 1, DDS_XTypes_TRY_CONSTRUCT_DISCARD, ti_f, "f2" }
     });
 }
 
@@ -574,8 +577,8 @@ static DDS_XTypes_TypeObject *get_typeobj11 (void)
     DDS_XTypes_IS_FINAL,
     (DDS_XTypes_TypeIdentifier) { ._d = DDS_XTypes_TK_CHAR8 },
     2, (umember_t[]) {
-      { 99, 0, { ._d = DDS_XTypes_TK_INT32 }, "f1", 1, (int32_t[]) { 'a' } },
-      { 5, DDS_XTypes_IS_DEFAULT, { ._d = DDS_XTypes_TK_UINT16 }, "f2", 0, (int32_t[]) { 0 } }
+      { 99, DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TK_INT32 }, "f1", 1, (int32_t[]) { 'a' } },
+      { 5, DDS_XTypes_IS_DEFAULT | DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TK_UINT16 }, "f2", 0, (int32_t[]) { 0 } }
     });
 }
 
@@ -602,7 +605,7 @@ static DDS_XTypes_TypeObject *get_typeobj12 (void)
         .body = { .common = { .related_flags = 0, .related_type = (DDS_XTypes_TypeIdentifier) {
           ._d = DDS_XTypes_TI_PLAIN_SEQUENCE_SMALL,
           ._u.seq_sdefn = {
-            .header = { .equiv_kind = DDS_XTypes_EK_BOTH, .element_flags = 0 },
+            .header = { .equiv_kind = DDS_XTypes_EK_BOTH, .element_flags = DDS_XTypes_TRY_CONSTRUCT_DISCARD },
             .bound = 0,
             .element_identifier = ti_long
           }
@@ -624,7 +627,7 @@ static DDS_XTypes_TypeObject *get_typeobj12 (void)
         .body = { .common = { .related_flags = 0, .related_type = (DDS_XTypes_TypeIdentifier) {
           ._d = DDS_XTypes_TI_PLAIN_ARRAY_SMALL,
           ._u.array_sdefn = {
-            .header = { .equiv_kind = DDS_XTypes_EK_COMPLETE, .element_flags = 0 },
+            .header = { .equiv_kind = DDS_XTypes_EK_COMPLETE, .element_flags = DDS_XTypes_TRY_CONSTRUCT_DISCARD },
             .array_bound_seq = { ._maximum = 1, ._length = 1, ._buffer = bound_seq, ._release = true },
             .element_identifier = ti_alias_seq
           }
@@ -639,7 +642,7 @@ static DDS_XTypes_TypeObject *get_typeobj12 (void)
     DDS_XTypes_IS_FINAL,
     (DDS_XTypes_TypeIdentifier) { ._d = DDS_XTypes_TK_NONE },
     1, (smember_t[]) {
-      { 0, 0, ti_f1, "f1" },
+      { 0, DDS_XTypes_TRY_CONSTRUCT_DISCARD, ti_f1, "f1" },
     });
 }
 
@@ -665,7 +668,7 @@ static DDS_XTypes_TypeObject *get_typeobj13 (void)
         .body = { .common = { .related_flags = 0, .related_type = (DDS_XTypes_TypeIdentifier) {
           ._d = DDS_XTypes_TI_PLAIN_ARRAY_SMALL,
           ._u.array_sdefn = {
-            .header = { .equiv_kind = DDS_XTypes_EK_BOTH, .element_flags = 0 },
+            .header = { .equiv_kind = DDS_XTypes_EK_BOTH, .element_flags = DDS_XTypes_TRY_CONSTRUCT_DISCARD },
             .array_bound_seq = { ._maximum = 1, ._length = 1, ._buffer = bound_seq, ._release = true },
             .element_identifier = ti_long
           }
@@ -694,7 +697,7 @@ static DDS_XTypes_TypeObject *get_typeobj13 (void)
     DDS_XTypes_IS_FINAL,
     (DDS_XTypes_TypeIdentifier) { ._d = DDS_XTypes_TK_NONE },
     1, (smember_t[]) {
-      { 0, 0, ti_f1, "f1" },
+      { 0, DDS_XTypes_TRY_CONSTRUCT_DISCARD, ti_f1, "f1" },
     });
 }
 


### PR DESCRIPTION
This fixes a number of issues that were found when testing interoperability for XTypes functionality:
- The IDL for `TypeLookup_Reply` in the XTypes spec has a typo (OMG issue [DDSXTY14-39](https://issues.omg.org/issues/DDSXTY14-39)) - reply type should be using `DDS_RPC_ReplyHeader` instead of `DDS_RPC_RequestHeader`. 
- Use the proxy participant guid in the `instanceName` field in a type lookup request
- The types reused from DDS RPC in the type lookup request and response need extensibility final, other types should have the default extensibility (appendable) - OMG issue DDSXTY14-30
- Default value for the try_construct flag in struct and union members and collection element type should be `01` (discard) and not `00` (invalid).
- Accept data from a non-cyclone remote writer before the reliable handshake is completed because other implementations rely on this, e.g. for the type lookup service

Note: this PR is based on #1171, only commits starting from 9dddcacd234c0dd2e28ce47bb76a9b43cdfdeedf are part of this PR