### PR TITLE
Detect module name collision in idlc

### DIFF
--- a/src/idl/include/idl/scope.h
+++ b/src/idl/include/idl/scope.h
@@ -77,6 +77,7 @@ struct idl_pstate;
 #define IDL_FIND_IGNORE_CASE (1u<<0)
 #define IDL_FIND_IGNORE_IMPORTS (1u<<1)
 #define IDL_FIND_ANNOTATION (1u<<2)
+#define IDL_FIND_SCOPE_DECLARATION (1u<<3)
 
 IDL_EXPORT const idl_declaration_t *
 idl_find(

--- a/src/idl/src/scope.c
+++ b/src/idl/src/scope.c
@@ -390,7 +390,8 @@ idl_find(
   cmp = (flags & IDL_FIND_IGNORE_CASE) ? &namecasecmp : &namecmp;
 
   for (entry = scope->declarations.first; entry; entry = entry->next) {
-    if (is_annotation(scope, entry) && !(flags & IDL_FIND_ANNOTATION))
+    if ((is_annotation(scope, entry) && !(flags & IDL_FIND_ANNOTATION))
+        || (entry->kind == IDL_SCOPE_DECLARATION && !(flags & IDL_FIND_SCOPE_DECLARATION)))
       continue;
     if (cmp(name, entry->name) == 0)
     {
@@ -431,7 +432,7 @@ idl_find_scoped_name(
 
   for (size_t i=0; i < scoped_name->length && scope;) {
     const idl_name_t *name = scoped_name->names[i];
-    entry = idl_find(pstate, scope, name, (flags|IDL_FIND_IGNORE_CASE));
+    entry = idl_find(pstate, scope, name, (flags|IDL_FIND_IGNORE_CASE|IDL_FIND_SCOPE_DECLARATION));
     if (entry && entry->kind != IDL_USE_DECLARATION) {
       if (cmp(name, entry->name) != 0)
         return NULL;
@@ -515,7 +516,7 @@ idl_resolve(
 
   for (size_t i=0; i < scoped_name->length && scope;) {
     const idl_name_t *name = scoped_name->names[i];
-    entry = idl_find(pstate, scope, name, flags|ignore_case);
+    entry = idl_find(pstate, scope, name, flags|ignore_case|IDL_FIND_SCOPE_DECLARATION);
     if (entry && entry->kind != IDL_USE_DECLARATION) {
       /* identifiers are case insensitive. however, all references to a
          definition must use the same case as the defining occurence */


### PR DESCRIPTION
This fixes issue #1245, although I'm not sure if this is the correct approach for fixing this problem as I don't fully understand the reason for the `IDL_SCOPE_DECLARATION` entry in a scope's declaration list. 