### PR TITLE
Use only functions that are aware of loaned samples when dealing with…

### DIFF
--- a/src/core/ddsc/src/dds_write.c
+++ b/src/core/ddsc/src/dds_write.c
@@ -479,7 +479,7 @@ dds_return_t dds_write_impl (dds_writer *wr, const void * data, dds_time_t tstam
     // where we either have network readers (requiring serialization) or not.
 
     // do not serialize yet (may not need it if only using iceoryx or no readers)
-    d = ddsi_serdata_from_loaned_sample (ddsi_wr->type, writekey ? SDK_KEY : SDK_DATA, iox_chunk);
+    d = ddsi_serdata_from_loaned_sample (ddsi_wr->type, writekey ? SDK_KEY : SDK_DATA, false, iox_chunk);
     if(d == NULL) {
       ret = DDS_RETCODE_BAD_PARAMETER;
       goto release_chunk;
@@ -488,7 +488,13 @@ dds_return_t dds_write_impl (dds_writer *wr, const void * data, dds_time_t tstam
     // serialize for network since we will need to send via network anyway
     // we also need to serialize into an iceoryx chunk
  
-    d = ddsi_serdata_from_sample (ddsi_wr->type, writekey ? SDK_KEY : SDK_DATA, data);
+    if (iceoryx_available) {
+      d = ddsi_serdata_from_loaned_sample (ddsi_wr->type, writekey ? SDK_KEY : SDK_DATA, true, iox_chunk);
+    } else {
+      d = ddsi_serdata_from_sample (ddsi_wr->type, writekey ? SDK_KEY : SDK_DATA, data);
+    }
+
+    
     if(d == NULL) {
       ret = DDS_RETCODE_BAD_PARAMETER;
       goto release_chunk;

--- a/src/core/ddsi/include/dds/ddsi/ddsi_serdata.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_serdata.h
@@ -174,7 +174,8 @@ typedef uint32_t(*ddsi_serdata_iox_size_t) (const struct ddsi_serdata* d);
 // to avoid serializing the data for zero-copy data transfer if all subscribers are reachable via Iceoryx.
 //
 // The first case is when "sub" is not NULL, in which case it is a pointer to the Iceoryx subscriber
-typedef struct ddsi_serdata* (*ddsi_serdata_from_iox_t) (const struct ddsi_sertype* type, enum ddsi_serdata_kind kind, void* sub, void* buffer);
+// deserialize_hint is set to true if the data needs to be serialized for network use
+typedef struct ddsi_serdata* (*ddsi_serdata_from_iox_t) (const struct ddsi_sertype* type, enum ddsi_serdata_kind kind, bool deserialize_hint, void* sub, void* buffer);
 #endif
 
 struct ddsi_serdata_ops {
@@ -323,19 +324,19 @@ DDS_INLINE_EXPORT inline uint32_t ddsi_serdata_iox_size(const struct ddsi_serdat
   return d->type->iox_size;
 }
 
-inline struct ddsi_serdata* ddsi_serdata_from_iox(const struct ddsi_sertype* type, enum ddsi_serdata_kind kind, void* sub, void* iox_buffer) ddsrt_nonnull_all;
+inline struct ddsi_serdata* ddsi_serdata_from_iox(const struct ddsi_sertype* type, enum ddsi_serdata_kind kind, void* sub,  void* iox_buffer) ddsrt_nonnull_all;
 
-DDS_INLINE_EXPORT inline struct ddsi_serdata* ddsi_serdata_from_iox(const struct ddsi_sertype* type, enum ddsi_serdata_kind kind, void* sub, void* iox_buffer)
+DDS_INLINE_EXPORT inline struct ddsi_serdata* ddsi_serdata_from_iox(const struct ddsi_sertype* type, enum ddsi_serdata_kind kind, void* sub,  void* iox_buffer )
 {
-  return type->serdata_ops->from_iox_buffer(type, kind, sub, iox_buffer);
+  return type->serdata_ops->from_iox_buffer(type, kind,false, sub, iox_buffer);
 }
 
-inline struct ddsi_serdata *ddsi_serdata_from_loaned_sample(const struct ddsi_sertype *type, enum ddsi_serdata_kind kind, const char *sample) ddsrt_nonnull_all;
+inline struct ddsi_serdata *ddsi_serdata_from_loaned_sample(const struct ddsi_sertype *type, enum ddsi_serdata_kind kind, bool deserialize_hint, const char *sample) ddsrt_nonnull_all;
 
-DDS_INLINE_EXPORT inline struct ddsi_serdata *ddsi_serdata_from_loaned_sample(const struct ddsi_sertype *type, enum ddsi_serdata_kind kind, const char *sample)
+DDS_INLINE_EXPORT inline struct ddsi_serdata *ddsi_serdata_from_loaned_sample(const struct ddsi_sertype *type, enum ddsi_serdata_kind kind, bool deserialize_hint, const char *sample)
 {
   if (type->serdata_ops->from_iox_buffer)
-    return type->serdata_ops->from_iox_buffer (type, kind, NULL, (void *) sample);
+    return type->serdata_ops->from_iox_buffer (type, kind, deserialize_hint, NULL, (void *) sample);
   else
     return type->serdata_ops->from_sample (type, kind, sample);
 }

--- a/src/core/ddsi/src/ddsi_serdata.c
+++ b/src/core/ddsi/src/ddsi_serdata.c
@@ -87,5 +87,5 @@ DDS_EXPORT extern inline void ddsi_serdata_get_keyhash (const struct ddsi_serdat
 #ifdef DDS_HAS_SHM
 DDS_EXPORT extern inline uint32_t ddsi_serdata_iox_size(const struct ddsi_serdata* d);
 DDS_EXPORT extern inline struct ddsi_serdata* ddsi_serdata_from_iox(const struct ddsi_sertype* type, enum ddsi_serdata_kind kind, void* sub, void* iox_buffer);
-DDS_EXPORT extern inline struct ddsi_serdata* ddsi_serdata_from_loaned_sample(const struct ddsi_sertype *type, enum ddsi_serdata_kind kind, const char *sample);
+DDS_EXPORT extern inline struct ddsi_serdata* ddsi_serdata_from_loaned_sample(const struct ddsi_sertype *type, enum ddsi_serdata_kind kind, bool deserialize_hint, const char *sample);
 #endif

--- a/src/core/ddsi/src/ddsi_serdata_default.c
+++ b/src/core/ddsi/src/ddsi_serdata_default.c
@@ -511,8 +511,9 @@ static struct ddsi_serdata *ddsi_serdata_default_from_loaned_sample (const struc
   return serdata;
 }
 
-static struct ddsi_serdata* serdata_default_from_iox(const struct ddsi_sertype* tpcmn, enum ddsi_serdata_kind kind, void* sub, void* buffer)
+static struct ddsi_serdata* serdata_default_from_iox(const struct ddsi_sertype* tpcmn, enum ddsi_serdata_kind kind, bool deserialize_hint,  void* sub, void* buffer)
 {
+  (void)deserialize_hint;
   if (sub == NULL)
     return ddsi_serdata_default_from_loaned_sample(tpcmn, kind, buffer);
   else


### PR DESCRIPTION
loaned pointers

Loaned samples are just pointers to the iceoryx buffers. CDDS allows
bindings to wrap the sample in their own structure.  A binding needs
to know when the sample pointer is a loaned pointer so it doesn't
attempt to dereference it as a custom sample structure.

When iceorx is available on a reader we route the calls through the
ddsi_serdata_from_loaned_sample. The binding will know to handle
it properly.