### PR TITLE
Remove wrong inline in ddsi_cdrstream.c

### DIFF
--- a/src/core/ddsi/src/ddsi_cdrstream.c
+++ b/src/core/ddsi/src/ddsi_cdrstream.c
@@ -1282,7 +1282,7 @@ static inline bool dds_stream_write_bitmask_arr (dds_ostream_t * __restrict os, 
   return dds_stream_write_bitmask_arrLE ((dds_ostreamLE_t *) os, insn, addr, num, bits_h, bits_l);
 }
 
-inline const uint32_t *dds_stream_write (dds_ostream_t * __restrict os, const char * __restrict data, const uint32_t * __restrict ops)
+const uint32_t *dds_stream_write (dds_ostream_t * __restrict os, const char * __restrict data, const uint32_t * __restrict ops)
 {
   return dds_stream_writeLE ((dds_ostreamLE_t *) os, data, ops);
 }
@@ -1338,12 +1338,12 @@ static inline bool dds_stream_write_bitmask_arr (dds_ostream_t * __restrict os, 
   return dds_stream_write_bitmask_arrBE ((dds_ostreamBE_t *) os, insn, addr, num, bits_h, bits_l);
 }
 
-inline const uint32_t *dds_stream_write (dds_ostream_t * __restrict os, const char * __restrict data, const uint32_t * __restrict ops)
+const uint32_t *dds_stream_write (dds_ostream_t * __restrict os, const char * __restrict data, const uint32_t * __restrict ops)
 {
   return dds_stream_writeBE ((dds_ostreamBE_t *) os, data, ops);
 }
 
-inline bool dds_stream_write_sample (dds_ostream_t * __restrict os, const void * __restrict data, const struct ddsi_sertype_default * __restrict type)
+bool dds_stream_write_sample (dds_ostream_t * __restrict os, const void * __restrict data, const struct ddsi_sertype_default * __restrict type)
 {
   return dds_stream_write_sampleBE ((dds_ostreamBE_t *) os, data, type);
 }

--- a/src/core/ddsi/src/ddsi_cdrstream.c
+++ b/src/core/ddsi/src/ddsi_cdrstream.c
@@ -1287,7 +1287,7 @@ inline const uint32_t *dds_stream_write (dds_ostream_t * __restrict os, const ch
   return dds_stream_writeLE ((dds_ostreamLE_t *) os, data, ops);
 }
 
-inline bool dds_stream_write_sample (dds_ostream_t * __restrict os, const void * __restrict data, const struct ddsi_sertype_default * __restrict type)
+bool dds_stream_write_sample (dds_ostream_t * __restrict os, const void * __restrict data, const struct ddsi_sertype_default * __restrict type)
 {
   return dds_stream_write_sampleLE ((dds_ostreamLE_t *) os, data, type);
 }


### PR DESCRIPTION
The function is declared as export in the header. Defining the implementation as `inline` breaks building a static library.