### PR TITLE
(idlc) Add options for output directory and path reconstruction / prefix

### DIFF
--- a/src/idl/include/idl/file.h
+++ b/src/idl/include/idl/file.h
@@ -15,6 +15,9 @@
 #include "idl/export.h"
 #include "idl/retcode.h"
 
+#define IDL_GEN_OUTFILE(path, output_dir, base_dir, out_ext, out_ptr) \
+  idl_generate_out_file(path, output_dir, base_dir, out_est, out_ptr, false)
+
 IDL_EXPORT unsigned int
 idl_isseparator(int chr);
 
@@ -32,5 +35,8 @@ idl_relative_path(const char *base, const char *path, char **relpathp);
 
 IDL_EXPORT idl_retcode_t
 idl_mkpath(const char *path);
+
+IDL_EXPORT idl_retcode_t
+idl_generate_out_file(const char *path, const char *output_dir, const char *base_dir, const char *out_ext, char ** out_ptr, int skip_mkpath);
 
 #endif /* IDL_FILE_H */

--- a/src/idl/include/idl/file.h
+++ b/src/idl/include/idl/file.h
@@ -30,4 +30,7 @@ idl_normalize_path(const char *path, char **abspathp);
 IDL_EXPORT idl_retcode_t
 idl_relative_path(const char *base, const char *path, char **relpathp);
 
+IDL_EXPORT idl_retcode_t
+idl_mkpath(const char *path);
+
 #endif /* IDL_FILE_H */

--- a/src/idl/tests/file.c
+++ b/src/idl/tests/file.c
@@ -324,3 +324,56 @@ CU_Test(idl_file, relative)
       free(rel);
   }
 }
+
+
+typedef struct out_file_test{
+  const char *path;
+  const char *output_dir;
+  const char *base_dir;
+  const char *out_ext;
+  idl_retcode_t ret;
+  const char *expected_out;
+} out_file_test_t;
+
+static void test_out_file(const out_file_test_t test)
+{
+  char *out = NULL;
+  idl_retcode_t ret = idl_generate_out_file(test.path, test.output_dir, test.base_dir, test.out_ext, &out, true);
+
+  CU_ASSERT_EQUAL(ret, test.ret);
+
+  if(ret != IDL_RETCODE_BAD_PARAMETER){
+    CU_ASSERT_STRING_EQUAL(out, test.expected_out);
+  }
+
+  if (out)
+    free(out);
+}
+
+CU_Test(idl_file, out_file_generation)
+{
+  const out_file_test_t out_tests[] = {
+      {"a/b.idl",            NULL,    NULL,         NULL, IDL_RETCODE_OK,            "a/b"},
+      {"a/b.idl",            NULL,    NULL,         "c",  IDL_RETCODE_OK,            "a/b.c"},
+      {"a/b.idl",            "c",     NULL,         NULL, IDL_RETCODE_OK,            "c/a/b"},
+      {ROOT"a/b.idl",        NULL,    ROOT"a",      "c",  IDL_RETCODE_OK,            "b.c"},
+      {ROOT"a/b.idl",        "f",     ROOT"a",      "c",  IDL_RETCODE_OK,            "f/b.c"},
+      {ROOT"a/b.idl",        NULL,    NULL,         NULL, IDL_RETCODE_OK,            "b"},
+      {ROOT"a/b.idl",        NULL,    NULL,         "c",  IDL_RETCODE_OK,            "b.c"},
+      {"a/b.idl",            "c",     NULL,         NULL, IDL_RETCODE_OK,            "c/a/b"},
+      {ROOT"a/b.idl",        "c",     NULL,         NULL, IDL_RETCODE_OK,            "c/b"},
+      {"a/b.idl",            ROOT"c", NULL,         NULL, IDL_RETCODE_OK,            ROOT"c/a/b"},
+      {"a/b/c.idl",          "..",    NULL,         NULL, IDL_RETCODE_OK,            "../a/b/c"},
+      {"a/b/c.idl",          "../d",  NULL,         NULL, IDL_RETCODE_OK,            "../d/a/b/c"},
+      {"a/b/c.idl",          ".",     NULL,         NULL, IDL_RETCODE_OK,            "./a/b/c"},
+      {ROOT"a/b/c/file.idl", ".",     ROOT"a/b/",   NULL, IDL_RETCODE_OK,            "./c/file"},
+      {ROOT"a/b/c/file.idl", "..",    ROOT"a/b/",   "h",  IDL_RETCODE_OK,            "../c/file.h"},
+      {ROOT"a/b/c/file.idl", ".",     ROOT"a/b/",   NULL, IDL_RETCODE_OK,            "./c/file"},
+      {ROOT"a/b/c/file.idl", NULL,    ROOT"a/b/",   NULL, IDL_RETCODE_OK,            "c/file"},
+      {ROOT"a/b/c/file.idl", ".",     ROOT"a/b/d/", NULL, IDL_RETCODE_BAD_PARAMETER, "./c/file"},
+      {ROOT"a/b/c/file.idl", NULL,    ROOT"a/b/d/", NULL, IDL_RETCODE_BAD_PARAMETER, "c/file"}
+  };
+
+  for (size_t i = 0; i < sizeof(out_tests)/sizeof(out_tests[0]); i++)
+    test_out_file(out_tests[i]);
+}

--- a/src/tools/idlc/include/idlc/generator.h
+++ b/src/tools/idlc/include/idlc/generator.h
@@ -28,6 +28,9 @@ extern "C" {
 
 typedef struct idlc_generator_config idlc_generator_config_t;
 struct idlc_generator_config  {
+  char *output_dir; /* path to write completed files */
+  char* base_dir; /* Path to start reconstruction of dir structure */
+
   /** Flag to indicate if xtypes type information is included in the generated types */
   bool generate_type_info;
 

--- a/src/tools/idlc/src/idlc.c
+++ b/src/tools/idlc/src/idlc.c
@@ -24,7 +24,6 @@
 #include "idl/tree.h"
 #include "idl/string.h"
 #include "idl/processor.h"
-#include "idl/file.h"
 #include "idl/version.h"
 #include "idl/stream.h"
 
@@ -36,6 +35,7 @@
 #include "plugin.h"
 #include "options.h"
 #include "descriptor_type_meta.h"
+#include "file.h"
 
 #if 0
 #define IDLC_DEBUG_PREPROCESSOR (1u<<2)
@@ -54,6 +54,8 @@ struct idlc_disable_warning_list
 static struct {
   char *file; /* path of input file or "-" for STDIN */
   const char *lang;
+  const char *output_dir; /* path to write completed files */
+  const char* base_dir; /* Path to start reconstruction of dir structure */
   int compile;
   int preprocess;
   int keylist;
@@ -544,6 +546,15 @@ static const idlc_option_t *compopts[] = {
     "Enable or disable warnings. Possible values are: no-implicit-extensibility, "
     "no-extra-token-directive, no-unknown_escape_seq, no-inherit-appendable, "
     "no-eof-newline, no-enum-consecutive. " },
+  &(idlc_option_t){
+    IDLC_STRING, { .string = &config.output_dir }, 'o', "", "<directory>",
+    "Set the output directory for compiled files." },
+  &(idlc_option_t){
+    IDLC_STRING, { .string = &config.base_dir }, 'b', "", "<directory>",
+    "Enable directory reconstruction starting from <base_dir> "
+    "Attempts to recreate directory structure matching input. "
+    "Use without the -o option will compile IDL files in-place. "
+    "Fail-silent if root_dir is not a parent of input" },
 #ifdef DDS_HAS_TYPE_DISCOVERY
   &(idlc_option_t){
     IDLC_FLAG, { .flag = &config.no_type_info }, 't', "", "",
@@ -676,6 +687,19 @@ int main(int argc, char *argv[])
     } else if (config.compile) {
       idlc_generator_config_t generator_config;
       memset(&generator_config, 0, sizeof(generator_config));
+
+      // Duplicate/Untaint the output dir to keep header guards neat
+      if(config.output_dir) {
+        if(!(generator_config.output_dir = idl_strdup(config.output_dir)))
+          goto err_generate;
+        if(idl_untaint_path(generator_config.output_dir) < 0)
+          goto err_generate;
+      }
+      // Root dir must be normalized because relativity comparison will be done
+      if(config.base_dir) {
+        if(idl_normalize_path(config.base_dir, &generator_config.base_dir) < 0)
+          goto err_generate;
+      }
 #ifdef DDS_HAS_TYPE_DISCOVERY
       if(!config.no_type_info)
         generator_config.generate_type_info = true;
@@ -683,6 +707,11 @@ int main(int argc, char *argv[])
 #endif // DDS_HAS_TYPE_DISCOVERY
       if (gen.generate)
         ret = gen.generate(pstate, &generator_config);
+
+      if(generator_config.output_dir)
+        free(generator_config.output_dir);
+      if(generator_config.base_dir)
+        free(generator_config.base_dir);
       idl_delete_pstate(pstate);
       if (ret) {
         fprintf(stderr, "Failed to compile '%s'\n", config.file);


### PR DESCRIPTION
Updated IDLC to allow for an output directory flag, as well as the option to specify how to preserve a directory structure.
* Added -d command line option to specify an output directory which may or may not exist.
* Added -b command line option to specify a base path for a directory structure.
* When using -b, any directories from <base_dir> to <file> will be reconstructed in the output directory. If no output directory is specified, this will result in files being compiled in-place.
* Necessary directories will be constructed automatically to hold the output files. 

This PR uses a bit of code from @k0ekk0ek's PR for creating the directory structure (`idl_mkpath`).

Also updated Generate.cmake to allow the idlc_generate function to make use of the new options.
* -d is added as a default option to the `add_custom_command` call but is not available to the outside caller since the output should usually be the output directory.
* Prefix directory can be specified with `BASE_DIR` argument, cmake will do the same path calculation that idlc does to determine where the output files go.

Fixes #801
Fixes #922  
Fixes #947 
Fixes #1220