### PR TITLE
Remove Discovery/Peers/Group and all related code

### DIFF
--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -139,38 +139,18 @@ The default value is: "none".
 
 
 #### //CycloneDDS/Domain/Discovery/Peers
-Children: [Group](#cycloneddsdomaindiscoverypeersgroup), [Peer](#cycloneddsdomaindiscoverypeerspeer)
+Children: [Peer](#cycloneddsdomaindiscoverypeerspeer)
 
 This element statically configures addresses for discovery.
 
 
-##### //CycloneDDS/Domain/Discovery/Peers/Group
-Children: [Peer](#cycloneddsdomaindiscoverypeersgrouppeer)
-
-This element statically configures a fault tolerant group of addresses for discovery. Each member of the group is tried in sequence until one succeeds.
-
-
-###### //CycloneDDS/Domain/Discovery/Peers/Group/Peer
-Attributes: [Address](#cycloneddsdomaindiscoverypeersgrouppeeraddress)
-
-This element statically configures an addresses for discovery.
-
-
-###### //CycloneDDS/Domain/Discovery/Peers/Group/Peer[@Address]
-Text
-
-This element specifies an IP address to which discovery packets must be sent, in addition to the default multicast address (see also General/AllowMulticast). Both a hostnames and a numerical IP address is accepted; the hostname or IP address may be suffixed with :PORT to explicitly set the port to which it must be sent. Multiple Peers may be specified.
-
-The default value is: "".
-
-
 ##### //CycloneDDS/Domain/Discovery/Peers/Peer
-Attributes: [Address](#cycloneddsdomaindiscoverypeersgrouppeeraddress)
+Attributes: [Address](#cycloneddsdomaindiscoverypeerspeeraddress)
 
 This element statically configures an addresses for discovery.
 
 
-##### //CycloneDDS/Domain/Discovery/Peers/Group/Peer[@Address]
+##### //CycloneDDS/Domain/Discovery/Peers/Peer[@Address]
 Text
 
 This element specifies an IP address to which discovery packets must be sent, in addition to the default multicast address (see also General/AllowMulticast). Both a hostnames and a numerical IP address is accepted; the hostname or IP address may be suffixed with :PORT to explicitly set the port to which it must be sent. Multiple Peers may be specified.
@@ -1874,9 +1854,9 @@ While none prevents any message from being written to a DDSI2 log file.
 The categorisation of tracing output is incomplete and hence most of the verbosity levels and categories are not of much use in the current release. This is an ongoing process and here we describe the target situation rather than the current situation. Currently, the most useful verbosity levels are config, fine and finest.
 
 The default value is: "none".
-<!--- generated from ddsi_config.h[c7263a7c7d00e81bdc6c1c618a412cd3259f9e42] -->
+<!--- generated from ddsi_config.h[3feac1b401fd6ea335ff2dabcf02968d161544de] -->
 <!--- generated from ddsi_cfgunits.h[fc550f1620aa20dcd9244ef4e24299d5001efbb4] -->
-<!--- generated from ddsi_cfgelems.h[cd0320484aaf2f9bb45f1e572bd5a7fe4f2493bd] -->
+<!--- generated from ddsi_cfgelems.h[2336569264035fa1b1a77474138aab5564d3c893] -->
 <!--- generated from ddsi_config.c[b4c99f582dc579a4ae9434f1b7296b767cc8ad65] -->
 <!--- generated from _confgen.h[01ffa8a2e53b2309451756861466551cfe28c8ce] -->
 <!--- generated from _confgen.c[13cd40932d695abae1470202a42c18dc4d09ea84] -->

--- a/etc/cyclonedds.rnc
+++ b/etc/cyclonedds.rnc
@@ -102,20 +102,6 @@ CycloneDDS configuration""" ] ]
 <p>This element statically configures addresses for discovery.</p>""" ] ]
         element Peers {
           [ a:documentation [ xml:lang="en" """
-<p>This element statically configures a fault tolerant group of addresses for discovery. Each member of the group is tried in sequence until one succeeds.</p>""" ] ]
-          element Group {
-            [ a:documentation [ xml:lang="en" """
-<p>This element statically configures an addresses for discovery.</p>""" ] ]
-            element Peer {
-              [ a:documentation [ xml:lang="en" """
-<p>This element specifies an IP address to which discovery packets must be sent, in addition to the default multicast address (see also General/AllowMulticast). Both a hostnames and a numerical IP address is accepted; the hostname or IP address may be suffixed with :PORT to explicitly set the port to which it must be sent. Multiple Peers may be specified.</p>
-<p>The default value is: "".</p>""" ] ]
-              attribute Address {
-                text
-              }
-            }*
-          }*
-          & [ a:documentation [ xml:lang="en" """
 <p>This element statically configures an addresses for discovery.</p>""" ] ]
           element Peer {
             [ a:documentation [ xml:lang="en" """
@@ -1302,9 +1288,9 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==<br>
   duration_inf = xsd:token { pattern = "inf|0|(\d+(\.\d*)?([Ee][\-+]?\d+)?|\.\d+([Ee][\-+]?\d+)?) *([num]?s|min|hr|day)" }
   memsize = xsd:token { pattern = "0|(\d+(\.\d*)?([Ee][\-+]?\d+)?|\.\d+([Ee][\-+]?\d+)?) *([kMG]i?)?B" }
 }
-# generated from ddsi_config.h[c7263a7c7d00e81bdc6c1c618a412cd3259f9e42] 
+# generated from ddsi_config.h[3feac1b401fd6ea335ff2dabcf02968d161544de] 
 # generated from ddsi_cfgunits.h[fc550f1620aa20dcd9244ef4e24299d5001efbb4] 
-# generated from ddsi_cfgelems.h[cd0320484aaf2f9bb45f1e572bd5a7fe4f2493bd] 
+# generated from ddsi_cfgelems.h[2336569264035fa1b1a77474138aab5564d3c893] 
 # generated from ddsi_config.c[b4c99f582dc579a4ae9434f1b7296b767cc8ad65] 
 # generated from _confgen.h[01ffa8a2e53b2309451756861466551cfe28c8ce] 
 # generated from _confgen.c[13cd40932d695abae1470202a42c18dc4d09ea84] 

--- a/etc/cyclonedds.xsd
+++ b/etc/cyclonedds.xsd
@@ -186,18 +186,6 @@ CycloneDDS configuration</xs:documentation>
 &lt;p&gt;This element statically configures addresses for discovery.&lt;/p&gt;</xs:documentation>
     </xs:annotation>
     <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="config:Group"/>
-        <xs:element ref="config:Peer"/>
-      </xs:choice>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="Group">
-    <xs:annotation>
-      <xs:documentation>
-&lt;p&gt;This element statically configures a fault tolerant group of addresses for discovery. Each member of the group is tried in sequence until one succeeds.&lt;/p&gt;</xs:documentation>
-    </xs:annotation>
-    <xs:complexType>
       <xs:sequence>
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="config:Peer"/>
       </xs:sequence>
@@ -1971,9 +1959,9 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
     </xs:restriction>
   </xs:simpleType>
 </xs:schema>
-<!--- generated from ddsi_config.h[c7263a7c7d00e81bdc6c1c618a412cd3259f9e42] -->
+<!--- generated from ddsi_config.h[3feac1b401fd6ea335ff2dabcf02968d161544de] -->
 <!--- generated from ddsi_cfgunits.h[fc550f1620aa20dcd9244ef4e24299d5001efbb4] -->
-<!--- generated from ddsi_cfgelems.h[cd0320484aaf2f9bb45f1e572bd5a7fe4f2493bd] -->
+<!--- generated from ddsi_cfgelems.h[2336569264035fa1b1a77474138aab5564d3c893] -->
 <!--- generated from ddsi_config.c[b4c99f582dc579a4ae9434f1b7296b767cc8ad65] -->
 <!--- generated from _confgen.h[01ffa8a2e53b2309451756861466551cfe28c8ce] -->
 <!--- generated from _confgen.c[13cd40932d695abae1470202a42c18dc4d09ea84] -->

--- a/src/core/ddsi/defconfig.c
+++ b/src/core/ddsi/defconfig.c
@@ -104,9 +104,9 @@ void ddsi_config_init_default (struct ddsi_config *cfg)
   cfg->shm_log_lvl = INT32_C (4);
 #endif /* DDS_HAS_SHM */
 }
-/* generated from ddsi_config.h[c7263a7c7d00e81bdc6c1c618a412cd3259f9e42] */
+/* generated from ddsi_config.h[3feac1b401fd6ea335ff2dabcf02968d161544de] */
 /* generated from ddsi_cfgunits.h[fc550f1620aa20dcd9244ef4e24299d5001efbb4] */
-/* generated from ddsi_cfgelems.h[cd0320484aaf2f9bb45f1e572bd5a7fe4f2493bd] */
+/* generated from ddsi_cfgelems.h[2336569264035fa1b1a77474138aab5564d3c893] */
 /* generated from ddsi_config.c[b4c99f582dc579a4ae9434f1b7296b767cc8ad65] */
 /* generated from _confgen.h[01ffa8a2e53b2309451756861466551cfe28c8ce] */
 /* generated from _confgen.c[13cd40932d695abae1470202a42c18dc4d09ea84] */

--- a/src/core/ddsi/include/dds/ddsi/ddsi_cfgelems.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_cfgelems.h
@@ -1833,16 +1833,6 @@ static struct cfgelem discovery_peer_cfgattrs[] = {
   END_MARKER
 };
 
-static struct cfgelem discovery_peers_group_cfgelems[] = {
-  GROUP("Peer", NULL, discovery_peer_cfgattrs, INT_MAX,
-    MEMBER(peers_group),
-    FUNCTIONS(if_peer, 0, 0, 0),
-    DESCRIPTION(
-      "<p>This element statically configures an addresses for discovery.</p>"
-    )),
-  END_MARKER
-};
-
 static struct cfgelem discovery_peers_cfgelems[] = {
   GROUP("Peer", NULL, discovery_peer_cfgattrs, INT_MAX,
     MEMBER(peers),
@@ -1850,16 +1840,6 @@ static struct cfgelem discovery_peers_cfgelems[] = {
     DESCRIPTION(
       "<p>This element statically configures an addresses for discovery.</p>"
     )),
-  GROUP("Group", discovery_peers_group_cfgelems, NULL, 1,
-    NOMEMBER,
-    NOFUNCTIONS,
-    DESCRIPTION(
-      "<p>This element statically configures a fault tolerant group of "
-      "addresses for discovery. Each member of the group is tried in "
-      "sequence until one succeeds.</p>"
-    ),
-    MAXIMUM(0)), /* Group element can occur more than once, but 1 is required
-                    because of the way its processed (for now) */
   END_MARKER
 };
 

--- a/src/core/ddsi/include/dds/ddsi/ddsi_config.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_config.h
@@ -360,7 +360,6 @@ struct ddsi_config
   struct ddsi_config_partitionmapping_listelem *partitionMappings;
 #endif /* DDS_HAS_NETWORK_PARTITIONS */
   struct ddsi_config_peer_listelem *peers;
-  struct ddsi_config_peer_listelem *peers_group;
   struct ddsi_config_thread_properties_listelem *thread_properties;
 
   /* debug/test/undoc features: */

--- a/src/core/ddsi/include/dds/ddsi/ddsi_domaingv.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_domaingv.h
@@ -209,11 +209,9 @@ struct ddsi_domaingv {
 
   /*
     Initial discovery address set, and the current discovery address
-    set. These are the addresses that SPDP pings get sent to. The
-    as_disc_group is an FT group (only use first working).
+    set. These are the addresses that SPDP pings get sent to.
   */
   struct addrset *as_disc;
-  struct addrset *as_disc_group;
 
   ddsrt_mutex_t lock;
 

--- a/src/core/ddsi/include/dds/ddsi/q_entity.h
+++ b/src/core/ddsi/include/dds/ddsi/q_entity.h
@@ -349,7 +349,6 @@ struct writer
   uint32_t alive_vclock; /* virtual clock counting transitions between alive/not-alive */
   const struct ddsi_sertype * type; /* type of the data written by this writer */
   struct addrset *as; /* set of addresses to publish to */
-  struct addrset *as_group; /* alternate case, used for SPDP, when using Cloud with multiple bootstrap locators */
   struct xevent *heartbeat_xevent; /* timed event for "periodically" publishing heartbeats when unack'd data present, NULL <=> unreliable */
   struct ldur_fhnode *lease_duration; /* fibheap node to keep lease duration for this writer, NULL in case of automatic liveliness with inifite duration  */
   struct whc *whc; /* WHC tracking history, T-L durability service history + samples by sequence number for retransmit */

--- a/src/core/ddsi/include/dds/ddsi/q_xmsg.h
+++ b/src/core/ddsi/include/dds/ddsi/q_xmsg.h
@@ -77,7 +77,7 @@ void nn_xmsg_setdstPWR (struct nn_xmsg *m, const struct proxy_writer *pwr);
 
 /* For sending to all in the address set AS -- typically, the writer's
    address set to multicast to all matched readers */
-void nn_xmsg_setdstN (struct nn_xmsg *msg, struct addrset *as, struct addrset *as_group);
+void nn_xmsg_setdstN (struct nn_xmsg *msg, struct addrset *as);
 
 int nn_xmsg_setmaxdelay (struct nn_xmsg *msg, int64_t maxdelay);
 

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -606,9 +606,7 @@ static void force_as_disc_address(struct ddsi_domaingv *gv, const ddsi_guid_t *s
   assert (wr != NULL);
   ddsrt_mutex_lock (&wr->e.lock);
   unref_addrset (wr->as);
-  unref_addrset (wr->as_group);
   wr->as = ref_addrset (gv->as_disc);
-  wr->as_group = ref_addrset (gv->as_disc_group);
   ddsrt_mutex_unlock (&wr->e.lock);
 }
 
@@ -3813,7 +3811,6 @@ static void new_writer_guid_common_init (struct writer *wr, const char *topic_na
     ((wr->e.guid.entityid.u & NN_ENTITYID_KIND_MASK) == NN_ENTITYID_KIND_WRITER_WITH_KEY);
   wr->type = ddsi_sertype_ref (type);
   wr->as = new_addrset ();
-  wr->as_group = NULL;
 
 #ifdef DDS_HAS_NETWORK_PARTITIONS
   /* This is an open issue how to encrypt mesages send for various

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -1860,15 +1860,6 @@ int rtps_init (struct ddsi_domaingv *gv)
   {
     add_peer_addresses (gv, gv->as_disc, gv->config.peers);
   }
-  if (gv->config.peers_group)
-  {
-    gv->as_disc_group = new_addrset ();
-    add_peer_addresses (gv, gv->as_disc_group, gv->config.peers_group);
-  }
-  else
-  {
-    gv->as_disc_group = NULL;
-  }
 
   gv->gcreq_queue = gcreq_queue_new (gv);
 
@@ -2285,7 +2276,6 @@ void rtps_fini (struct ddsi_domaingv *gv)
     free_config_networkpartition_addresses (np);
 #endif
   unref_addrset (gv->as_disc);
-  unref_addrset (gv->as_disc_group);
 
   /* Must delay freeing of rbufpools until after *all* references have
      been dropped, which only happens once all receive threads have

--- a/src/core/ddsi/src/q_transmit.c
+++ b/src/core/ddsi/src/q_transmit.c
@@ -203,7 +203,7 @@ struct nn_xmsg *writer_hbcontrol_create_heartbeat (struct writer *wr, const stru
 
   if (prd_guid == NULL)
   {
-    nn_xmsg_setdstN (msg, wr->as, wr->as_group);
+    nn_xmsg_setdstN (msg, wr->as);
     add_Heartbeat (msg, wr, whcst, hbansreq, 0, to_entityid (NN_ENTITYID_UNKNOWN), issync);
   }
   else
@@ -486,7 +486,7 @@ static dds_return_t create_fragment_message_simple (struct writer *wr, seqno_t s
   if ((*pmsg = nn_xmsg_new (gv->xmsgpool, &wr->e.guid, wr->c.pp, sizeof (InfoTimestamp_t) + sizeof (Data_t) + expected_inline_qos_size, NN_XMSG_KIND_DATA)) == NULL)
     return DDS_RETCODE_OUT_OF_RESOURCES;
 
-  nn_xmsg_setdstN (*pmsg, wr->as, wr->as_group);
+  nn_xmsg_setdstN (*pmsg, wr->as);
   nn_xmsg_setmaxdelay (*pmsg, wr->xqos->latency_budget.duration);
   nn_xmsg_add_timestamp (*pmsg, serdata->timestamp);
   data = nn_xmsg_append (*pmsg, &sm_marker, sizeof (Data_t));
@@ -574,7 +574,7 @@ dds_return_t create_fragment_message (struct writer *wr, seqno_t seq, const stru
   }
   else
   {
-    nn_xmsg_setdstN (*pmsg, wr->as, wr->as_group);
+    nn_xmsg_setdstN (*pmsg, wr->as);
     nn_xmsg_setmaxdelay (*pmsg, wr->xqos->latency_budget.duration);
   }
 
@@ -699,7 +699,7 @@ static void create_HeartbeatFrag (struct writer *wr, seqno_t seq, unsigned fragn
   if (prd)
     nn_xmsg_setdstPRD (*pmsg, prd);
   else
-    nn_xmsg_setdstN (*pmsg, wr->as, wr->as_group);
+    nn_xmsg_setdstN (*pmsg, wr->as);
   hbf = nn_xmsg_append (*pmsg, &sm_marker, sizeof (HeartbeatFrag_t));
   nn_xmsg_submsg_init (*pmsg, sm_marker, SMID_HEARTBEAT_FRAG);
   hbf->readerId = nn_hton_entityid (prd ? prd->e.guid.entityid : to_entityid (NN_ENTITYID_UNKNOWN));
@@ -744,7 +744,7 @@ dds_return_t write_hb_liveliness (struct ddsi_domaingv * const gv, struct ddsi_g
   if ((msg = nn_xmsg_new (gv->xmsgpool, &wr->e.guid, wr->c.pp, sizeof (InfoTS_t) + sizeof (Heartbeat_t), NN_XMSG_KIND_CONTROL)) == NULL)
     return DDS_RETCODE_OUT_OF_RESOURCES;
   ddsrt_mutex_lock (&wr->e.lock);
-  nn_xmsg_setdstN (msg, wr->as, wr->as_group);
+  nn_xmsg_setdstN (msg, wr->as);
   whc_get_state (wr->whc, &whcst);
   add_Heartbeat (msg, wr, &whcst, 0, 1, to_entityid (NN_ENTITYID_UNKNOWN), 1);
   ddsrt_mutex_unlock (&wr->e.lock);
@@ -1316,7 +1316,7 @@ static int write_sample_eot (struct thread_state1 * const ts1, struct nn_xpack *
       ddsrt_free (plist);
     }
   }
-  else if (addrset_empty (wr->as) && (wr->as_group == NULL || addrset_empty (wr->as_group)))
+  else if (addrset_empty (wr->as))
   {
     /* No network destination, so no point in doing all the work involved
        in going all the way.  We do have to record that we "transmitted"


### PR DESCRIPTION
This setting was inherited from OpenSplice, where it was useful in
combination with another product that hasn't been available for a number
of years.

Deprecating the option would technically be the correct route, but in
this situation, it seems like no-one can ever have actually used it and
therefore deleting it outright is reasonable.

Signed-off-by: Erik Boasson <eb@ilities.com>