### PR TITLE
Fix manual liveliness with infinite lease duration

### DIFF
--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -4005,6 +4005,10 @@ static dds_return_t new_writer_guid (struct writer **wr_out, const struct ddsi_g
       }
     }
   }
+  else
+  {
+    wr->lease = NULL;
+  }
 
   return 0;
 }


### PR DESCRIPTION
This fixes the issue that the lease renewal for writers incorrectly checks for a non-null writer lease, which is not initialized in case the lease duration is infinite. Using a manual liveliness policy with an infinite lease on a writer duration caused a segfault. Similar to the implementation for proxy writers, the renewal code should check for a non-infinite lease duration.

Fixes https://github.com/ros2/rmw_cyclonedds/issues/390#issuecomment-1111871668
