### PR TITLE
Bugfix in type object validation for union discriminator

### DIFF
--- a/src/core/ddsi/src/ddsi_typewrap.c
+++ b/src/core/ddsi/src/ddsi_typewrap.c
@@ -501,6 +501,8 @@ static dds_return_t xt_valid_struct_base_type (struct ddsi_domaingv *gv, const s
 
 static dds_return_t xt_valid_union_disc_type (struct ddsi_domaingv *gv, const struct xt_type *t)
 {
+  if (ddsi_xt_is_unresolved (&t->_u.union_type.disc_type->xt))
+    return DDS_RETCODE_OK;
   uint8_t d = ddsi_xt_unalias (&t->_u.union_type.disc_type->xt)->_d;
   if (d != DDS_XTypes_TK_BOOLEAN && d != DDS_XTypes_TK_BYTE && d != DDS_XTypes_TK_CHAR8 && d != DDS_XTypes_TK_CHAR16
       && d != DDS_XTypes_TK_INT16 && d != DDS_XTypes_TK_INT32 && d != DDS_XTypes_TK_INT64


### PR DESCRIPTION
The discriminator type for a union can be unresolved when validation the type object for a union type, in case the discriminator has a hashed type-identifier (e.g. enum type).
