### PR TITLE
Fix wrong unlock in participant sec attributes

### DIFF
--- a/src/core/ddsi/src/ddsi_security_omg.c
+++ b/src/core/ddsi/src/ddsi_security_omg.c
@@ -1260,9 +1260,7 @@ static void cleanup_participant_sec_attributes(void *arg)
   if (!sc->crypto_context->crypto_key_factory->unregister_participant(sc->crypto_context->crypto_key_factory, attr->crypto_handle, &exception))
     EXCEPTION_ERROR(gv, &exception, "Failed to unregister participant");
 
-  ddsrt_avl_cfree(&pp_proxypp_treedef, &attr->proxy_participants, NULL);
-  ddsrt_mutex_unlock(&attr->lock);
-  ddsrt_free(attr);
+  participant_sec_attributes_free(attr);
   ddsrt_free(arg);
 }
 


### PR DESCRIPTION
An incorrect call to "unlock" on an unlocked mutex causes a problem on
QNX (and is illegal on all platforms).  It should have been a call to
"destroy".  With that change, the three lines are identical to what
"participant_sec_attributes_free" does.

Fixes #1275 