### PR TITLE
Bugfix for array bounds in xtypes wrapper

### DIFF
--- a/src/core/ddsi/src/ddsi_typewrap.c
+++ b/src/core/ddsi/src/ddsi_typewrap.c
@@ -451,7 +451,7 @@ static void xt_sbounds_to_lbounds (struct DDS_XTypes_LBoundSeq *lb, const struct
 static void xt_lbounds_dup (struct DDS_XTypes_LBoundSeq *dst, const struct DDS_XTypes_LBoundSeq *src)
 {
   dst->_length = src->_length;
-  dst->_buffer = ddsrt_memdup (&src->_buffer, dst->_length * sizeof (*dst->_buffer));
+  dst->_buffer = ddsrt_memdup (src->_buffer, dst->_length * sizeof (*dst->_buffer));
 }
 
 static void DDS_XTypes_AppliedBuiltinMemberAnnotations_copy (struct DDS_XTypes_AppliedBuiltinMemberAnnotations *dst, const struct DDS_XTypes_AppliedBuiltinMemberAnnotations *src);


### PR DESCRIPTION
Fix incorrect memdup src address for array bounds in xtypes wrapper