### PR TITLE
Use "python -m pip" instead of "pip" on Azure

### DIFF
--- a/.azure/templates/build-test.yml
+++ b/.azure/templates/build-test.yml
@@ -74,12 +74,12 @@ steps:
   - template: /.azure/templates/install-conan.yml
   - bash: |
       set -e -x
-      pip install pip wheel setuptools --user --upgrade
-      pip install pre-commit --user --upgrade
+      python -m pip install pip wheel setuptools --user --upgrade
+      python -m pip install pre-commit --user --upgrade
       pre-commit run --all-files
     name: run_pre_commit
   - bash: |
-      pip install gcovr==5.0 --user --upgrade
+      python -m pip install gcovr==5.0 --user --upgrade
     condition: eq(variables['coverage'], 'on')
     name: install_gcovr
   - bash: |


### PR DESCRIPTION
This way updating pip itself works again on Windows platforms.

Signed-off-by: Erik Boasson <eb@ilities.com>