### PR TITLE
Fix GCC 12 analyzer warnings

### DIFF
--- a/.azure/templates/build-test.yml
+++ b/.azure/templates/build-test.yml
@@ -66,6 +66,11 @@ steps:
       # choco install winflexbison3
     condition: eq(variables['Agent.OS'], 'Windows_NT')
     name: setup_windows
+  - bash: |
+      sudo apt update
+      sudo apt -y install gcc-12
+    condition: and(eq(variables['cc'], 'gcc-12'), eq(variables['Agent.OS'], 'Linux'))
+    name: install_gcc_12
   - task: Cache@2
     inputs:
       key: pip | 2 | $(Agent.OS)

--- a/.azure/templates/build-test.yml
+++ b/.azure/templates/build-test.yml
@@ -67,9 +67,9 @@ steps:
     condition: eq(variables['Agent.OS'], 'Windows_NT')
     name: setup_windows
   - bash: |
-      sudo apt update
-      sudo apt -y install gcc-12
-    condition: and(eq(variables['cc'], 'gcc-12'), eq(variables['Agent.OS'], 'Linux'))
+      brew update
+      brew upgrade gcc
+    condition: and(eq(variables['cc'], 'gcc-12'), eq(variables['Agent.OS'], 'Darwin'))
     name: install_gcc_12
   - task: Cache@2
     inputs:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,10 +200,13 @@ if(ANALYZER)
     endif()
   elseif(ANALYZER STREQUAL "on")
     if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
-      if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL "10")
+      # GCC 10 static analyzer is a bit problematic
+      # GCC 11 is a full rewrite, also not quite happy with the code
+      # GCC 12 is pretty much happy, but some parts of IDLC (main file, type object
+      # generation) still cause problems, but we can disable those
+      if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL "12")
         message(STATUS "Enabling analyzer: GCC")
-        # -Wanalyzer-malloc-leak generates lots of false positives
-        add_compile_options(-fanalyzer -Wno-analyzer-malloc-leak)
+        add_compile_options(-fanalyzer)
       endif()
     endif()
   endif()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,12 +23,12 @@ jobs:
     vmImage: $(image)
   strategy:
     matrix:
-      'Ubuntu 20.04 LTS with GCC 10 (Debug, x86_64)':
-        image: ubuntu-20.04
+      'Ubuntu 22.04 LTS with GCC 12 (Debug, x86_64)':
+        image: ubuntu-22.04
         analyzer: on
         # not enabling "undefined" because of some false positives
         sanitizer: address
-        cc: gcc-10
+        cc: gcc-12
         coverage: on
       'Ubuntu 20.04 LTS with GCC 10 (Debug, x86_64, Iceoryx)':
         image: ubuntu-20.04

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,6 +23,10 @@ jobs:
     vmImage: $(image)
   strategy:
     matrix:
+      #gcc-12.2 is the first version of gcc's static analyzer that accepts this code
+      #without -Wno-analyzer-malloc-leak without any false positives.  Ubuntu is far
+      #behind in gcc versions, and so falling back to macOS is the most pragmatic
+      #option at this time.
       #'Ubuntu 22.04 LTS with GCC 12 (Debug, x86_64)':
       #  image: ubuntu-22.04
       #  analyzer: on

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,13 +23,13 @@ jobs:
     vmImage: $(image)
   strategy:
     matrix:
-      'Ubuntu 22.04 LTS with GCC 12 (Debug, x86_64)':
-        image: ubuntu-22.04
-        analyzer: on
-        # not enabling "undefined" because of some false positives
-        sanitizer: address
-        cc: gcc-12
-        coverage: on
+      #'Ubuntu 22.04 LTS with GCC 12 (Debug, x86_64)':
+      #  image: ubuntu-22.04
+      #  analyzer: on
+      #  # not enabling "undefined" because of some false positives
+      #  sanitizer: address
+      #  cc: gcc-12
+      #  coverage: on
       'Ubuntu 20.04 LTS with GCC 10 (Debug, x86_64, Iceoryx)':
         image: ubuntu-20.04
         #analyzer: on  # disabled for now because of warnings
@@ -94,6 +94,11 @@ jobs:
         sanitizer: undefined
         cc: clang
         coverage: on
+      'macOS 12 with gcc 12 (Debug, analyzer, x86_64)':
+        image: macOS-12
+        sanitizer: undefined
+        cc: gcc-12
+        analyzer: on
       'Windows 2019 with Visual Studio 2019 (Visual Studio 2017, Debug, x86)':
         arch: x86
         image: windows-2019

--- a/src/core/ddsc/tests/qosmatch.c
+++ b/src/core/ddsc/tests/qosmatch.c
@@ -52,7 +52,7 @@ static void setqos (dds_qos_t *q, size_t i, bool isrd, bool create)
     }
     else
     {
-      char buf[20];
+      char buf[23];
       snprintf (buf, sizeof (buf), "ud%zu%c", i, isrd ? 'r' : 'w');
       dds_qset_userdata (q, buf, strlen (buf));
       snprintf (buf, sizeof (buf), "td%zu", i);
@@ -71,7 +71,7 @@ static void setqos (dds_qos_t *q, size_t i, bool isrd, bool create)
     }
     else
     {
-      char buf[20];
+      char buf[23];
       snprintf (buf, sizeof (buf), "ud%zu%c", i, isrd ? 'r' : 'w');
       dds_qset_userdata (q, buf, strlen (buf));
       snprintf (buf, sizeof (buf), "td%zu", (size_t) 0);

--- a/src/core/ddsc/tests/topic_find_global.c
+++ b/src/core/ddsc/tests/topic_find_global.c
@@ -147,14 +147,14 @@ struct create_topic_thread_arg
   const dds_topic_descriptor_t *topic_desc;
 };
 
-static void set_topic_name (char *name, const char *prefix, uint32_t index)
+static void set_topic_name (char *name, size_t size, const char *prefix, uint32_t index)
 {
-  snprintf (name, MAX_NAME_SIZE + 10, "%s_%u", prefix, index);
+  snprintf (name, size, "%s_%u", prefix, index);
 }
 
 static uint32_t topics_thread (void *a)
 {
-  char topic_name[MAX_NAME_SIZE + 10];
+  char topic_name[MAX_NAME_SIZE + 11];
   struct create_topic_thread_arg *arg = (struct create_topic_thread_arg *) a;
   dds_entity_t *topics = ddsrt_malloc (arg->num_tp * sizeof (*topics));
 
@@ -162,7 +162,7 @@ static uint32_t topics_thread (void *a)
   tprintf ("%s topics thread: creating %u topics with prefix %s\n", arg->remote ? "remote" : "local", arg->num_tp, arg->topic_name_prefix);
   for (uint32_t t = 0; t < arg->num_tp; t++)
   {
-    set_topic_name (topic_name, arg->topic_name_prefix, t);
+    set_topic_name (topic_name, sizeof (topic_name), arg->topic_name_prefix, t);
     topics[t] = dds_create_topic (arg->pp, arg->topic_desc, topic_name, NULL, NULL);
     CU_ASSERT_FATAL (topics[t] > 0);
   }
@@ -239,7 +239,7 @@ CU_Theory ((uint32_t num_local_pp, uint32_t num_remote_pp, uint32_t num_tp), dds
     dds_typeinfo_t *type_info = get_desc_typeinfo (create_args[n].topic_desc);
     for (uint32_t t = 0; t < create_args[n].num_tp; t++)
     {
-      set_topic_name (topic_name, create_args[n].topic_name_prefix, t);
+      set_topic_name (topic_name, sizeof (topic_name), create_args[n].topic_name_prefix, t);
       dds_entity_t topic = dds_find_topic (DDS_FIND_SCOPE_GLOBAL, g_participant1, topic_name, (dds_typeinfo_t *) type_info, DDS_SECS (5));
       CU_ASSERT_FATAL (topic > 0);
     }
@@ -255,7 +255,7 @@ CU_Theory ((uint32_t num_local_pp, uint32_t num_remote_pp, uint32_t num_tp), dds
   uint32_t t = 0;
   do
   {
-    set_topic_name (topic_name, create_args->topic_name_prefix, t);
+    set_topic_name (topic_name, sizeof (topic_name), create_args->topic_name_prefix, t);
     (void) dds_find_topic (DDS_FIND_SCOPE_PARTICIPANT, g_participant1, topic_name, NULL, 0);
     (void) dds_find_topic (DDS_FIND_SCOPE_PARTICIPANT, g_participant1, topic_name, NULL, DDS_MSECS (1));
     (void) dds_find_topic (DDS_FIND_SCOPE_GLOBAL, g_participant1, topic_name, NULL, 0);

--- a/src/core/ddsi/src/ddsi_entity.c
+++ b/src/core/ddsi/src/ddsi_entity.c
@@ -72,6 +72,7 @@ void ddsi_entity_common_init (struct ddsi_entity_common *e, struct ddsi_domaingv
   if (ddsi_builtintopic_is_visible (gv->builtin_topic_interface, guid, vendorid))
   {
     e->tk = ddsi_builtintopic_get_tkmap_entry (gv->builtin_topic_interface, guid);
+    assert (e->tk != NULL); // analyzer doesn't see correlation between is_visible and get_tkmap_entry
     e->iid = e->tk->m_iid;
   }
   else

--- a/src/ddsrt/include/dds/ddsrt/attributes.h
+++ b/src/ddsrt/include/dds/ddsrt/attributes.h
@@ -42,6 +42,12 @@
 # define ddsrt_attribute_malloc
 #endif
 
+#if ddsrt_has_attribute(malloc) && ddsrt_gnuc >= 120000
+# define ddsrt_attribute_malloc2(params) __attribute__ ((__malloc__ params))
+#else
+# define ddsrt_attribute_malloc2(params)
+#endif
+
 #if ddsrt_has_attribute(unused)
 # define ddsrt_attribute_unused __attribute__((__unused__))
 #else

--- a/src/idl/CMakeLists.txt
+++ b/src/idl/CMakeLists.txt
@@ -74,6 +74,7 @@ set(headers
   include/idl/string.h
   include/idl/symbol.h
   include/idl/tree.h
+  include/idl/vector.h
   include/idl/visit.h
   include/idl/heap.h
   ${binary_dir}/include/idl/version.h)
@@ -90,6 +91,7 @@ set(sources
   src/scope.c
   src/string.c
   src/tree.c
+  src/vector.c
   src/visit.c
   src/print.c
   src/keylist.c

--- a/src/idl/include/idl/heap.h
+++ b/src/idl/include/idl/heap.h
@@ -18,9 +18,9 @@
 #include "idl/export.h"
 #include "idl/attributes.h"
 
-IDL_EXPORT void* idl_malloc  (size_t size);
-IDL_EXPORT void* idl_calloc  (size_t num, size_t size);
-IDL_EXPORT void* idl_realloc (void *ptr, size_t new_size);
 IDL_EXPORT void  idl_free    (void *pt);
+IDL_EXPORT void* idl_malloc  (size_t size) idl_attribute_malloc idl_attribute_malloc2 ((idl_free, 1));
+IDL_EXPORT void* idl_calloc  (size_t num, size_t size) idl_attribute_malloc idl_attribute_malloc2 ((idl_free, 1)) idl_attribute_alloc_size ((1, 2));
+IDL_EXPORT void* idl_realloc (void *ptr, size_t new_size) idl_attribute_alloc_size ((2));
 
 #endif /* IDL_HEAP_H */

--- a/src/idl/include/idl/vector.h
+++ b/src/idl/include/idl/vector.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright(c) 2022 ZettaScale Technology and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+#ifndef VECTOR_H
+#define VECTOR_H
+
+#include <stddef.h>
+#include <stdbool.h>
+
+typedef struct idl_boxed_vector {
+  size_t n, cap;
+  void **xs;
+} idl_boxed_vector_t;
+
+typedef struct idl_boxed_vector_iter {
+  idl_boxed_vector_t *v;
+  size_t i;
+} idl_boxed_vector_iter_t;
+
+bool idl_boxed_vector_init (struct idl_boxed_vector *v);
+bool idl_boxed_vector_append (struct idl_boxed_vector *v, void *x);
+void idl_boxed_vector_fini (struct idl_boxed_vector *c, void (*f) (void *x));
+void *idl_boxed_vector_next (struct idl_boxed_vector_iter *it);
+void *idl_boxed_vector_first (struct idl_boxed_vector *v, struct idl_boxed_vector_iter *it);
+const void *idl_boxed_vector_next_c (struct idl_boxed_vector_iter *it);
+const void *idl_boxed_vector_first_c (const struct idl_boxed_vector *v, struct idl_boxed_vector_iter *it);
+void idl_boxed_vector_sort (struct idl_boxed_vector *v, int (*cmp) (const void *a, const void *b));
+
+#endif

--- a/src/idl/src/keylist.c
+++ b/src/idl/src/keylist.c
@@ -175,9 +175,10 @@ static void sort_parent_paths (struct key_containers *key_containers)
   }
 }
 
-static bool has_conflicting_keys(const struct key_containers *key_containers, const idl_node_t **node)
+static bool check_for_conflicting_keys(struct key_containers *key_containers, const idl_node_t **node)
 {
   assert (node);
+  sort_parent_paths (key_containers);
   struct key_containers_iter it;
   for (const struct key_container *cntr = key_containers_first_c (key_containers, &it); cntr; cntr = key_containers_next_c (&it))
   {
@@ -334,11 +335,10 @@ idl_retcode_t idl_validate_keylists(idl_pstate_t *pstate)
   assert(pstate);
   if ((ret = get_keylist_key_paths (pstate, pstate->root, key_containers) != IDL_RETCODE_OK))
     goto err_create_key;
-  sort_parent_paths (key_containers);
 
   /* Check for conflicting keys */
   const idl_node_t *conflicting_type;
-  if (has_conflicting_keys (key_containers, &conflicting_type))
+  if (check_for_conflicting_keys (key_containers, &conflicting_type))
   {
     idl_error(pstate, idl_location(conflicting_type),
               "Conflicting keys in keylist directive for type '%s'", idl_identifier(conflicting_type));

--- a/src/idl/src/keylist.c
+++ b/src/idl/src/keylist.c
@@ -16,39 +16,171 @@
 #include "idl/heap.h"
 #include "idl/misc.h"
 #include "idl/string.h"
+#include "idl/vector.h"
 #include "keylist.h"
 
 struct key_field {
   const idl_declarator_t *key_declarator; /* declarator node, used for finding an entry in the key_containers key_fields */
-  char **parent_paths;    /* stores the paths to this key field, as string with dot separated field names, e.g. { "field1.f2.id", "field2.f2.id" } */
-  size_t n_parent_paths;  /* number of paths in parent_paths */
+  idl_boxed_vector_t parent_paths; /* stores the paths to this key field, as string with dot separated field names, e.g. { "field1.f2.id", "field2.f2.id" } */
 };
 
 struct key_container {
   const idl_node_t *node;
-  struct key_field *key_fields;
-  size_t n_key_fields;
+  idl_boxed_vector_t key_fields;
 };
 
-static int cmp_parent_path(const void *a, const void *b)
+struct key_container_iter {
+  idl_boxed_vector_iter_t x;
+};
+
+struct key_containers {
+  idl_boxed_vector_t key_containers;
+};
+
+struct key_containers_iter {
+  idl_boxed_vector_iter_t x;
+};
+
+/* ======= new/free/iterators/... wrappers for the above ======== */
+
+static void *boxed_vector_init_with_failure_action (idl_boxed_vector_t *v, void (*failure_action) (void *c), void *c)
 {
-  return strcmp(*(char **)a, *(char **)b);
+  if (idl_boxed_vector_init (v))
+    return c;
+  failure_action (c);
+  return NULL;
 }
 
-static bool parent_path_sorted_list_equal(char **a, char **b, size_t len)
+static void *boxed_vector_append_with_failure_action (idl_boxed_vector_t *v, void *x, void (*failure_action) (void *x))
 {
-  for (size_t n = 0; n < len; n++)
-    if (strcmp(a[n], b[n]))
-      return false;
-  return true;
+  if (idl_boxed_vector_append (v, x))
+    return x;
+  else
+  {
+    failure_action (x);
+    return NULL;
+  }
 }
 
-static bool has_conflicting_keys(const struct key_container *key_containers, size_t n_key_containers, const idl_node_t **node)
+static struct key_field *key_field_new (const idl_declarator_t *key_declarator)
 {
-  assert(node);
-  for (size_t c = 0; c < n_key_containers; c++) {
-    const struct key_container *cntr = &key_containers[c];
+  struct key_field *kf;
+  if ((kf = idl_malloc (sizeof (*kf))) == NULL)
+    return NULL;
+  kf->key_declarator = key_declarator;
+  return boxed_vector_init_with_failure_action (&kf->parent_paths, idl_free, kf);
+}
 
+static void key_field_free (struct key_field *kf) {
+  idl_boxed_vector_fini (&kf->parent_paths, idl_free);
+  idl_free (kf);
+}
+static void key_field_free_wrapper (void *vkf) {
+  key_field_free (vkf);
+}
+
+static bool key_field_append (struct key_field *kf, char *parent_path)
+{
+  return idl_boxed_vector_append (&kf->parent_paths, parent_path);
+}
+
+static struct key_container *key_container_new (const idl_node_t *node)
+{
+  struct key_container *kc;
+  if ((kc = idl_malloc (sizeof (*kc))) == NULL)
+    return NULL;
+  kc->node = node;
+  return boxed_vector_init_with_failure_action (&kc->key_fields, idl_free, kc);
+}
+
+static void key_container_free (struct key_container *kc) {
+  idl_boxed_vector_fini (&kc->key_fields, key_field_free_wrapper);
+  idl_free (kc);
+}
+static void key_container_free_wrapper (void *vkc) {
+  key_container_free (vkc);
+}
+
+static struct key_field *key_container_append (struct key_container *kc, const idl_declarator_t *declarator)
+{
+  struct key_field *kf;
+  if ((kf = key_field_new (declarator)) == NULL)
+    return NULL;
+  return boxed_vector_append_with_failure_action (&kc->key_fields, kf, key_field_free_wrapper);
+}
+
+static const struct key_field *key_container_first_c (const struct key_container *kc, struct key_container_iter *it) {
+  return idl_boxed_vector_first_c (&kc->key_fields, &it->x);
+}
+static const struct key_field *key_container_next_c (struct key_container_iter *it) {
+  return idl_boxed_vector_next_c (&it->x);
+}
+static struct key_field *key_container_first (struct key_container *kc, struct key_container_iter *it) {
+  return idl_boxed_vector_first (&kc->key_fields, &it->x);
+}
+static struct key_field *key_container_next (struct key_container_iter *it) {
+  return idl_boxed_vector_next (&it->x);
+}
+
+static struct key_containers *key_containers_new (void)
+{
+  struct key_containers *kcs;
+  if ((kcs = idl_malloc (sizeof (*kcs))) == NULL)
+    return NULL;
+  return boxed_vector_init_with_failure_action (&kcs->key_containers, idl_free, kcs);
+}
+
+static void key_containers_free (struct key_containers *kcs)
+{
+  idl_boxed_vector_fini (&kcs->key_containers, key_container_free_wrapper);
+  idl_free (kcs);
+}
+
+static struct key_container *key_containers_append (struct key_containers *kcs, const idl_node_t *key_type_node)
+{
+  struct key_container *kc;
+  if ((kc = key_container_new (key_type_node)) == NULL)
+    return NULL;
+  return boxed_vector_append_with_failure_action (&kcs->key_containers, kc, key_container_free_wrapper);
+}
+
+static const struct key_container *key_containers_first (const struct key_containers *kcs, struct key_containers_iter *it) {
+  return idl_boxed_vector_first_c (&kcs->key_containers, &it->x);
+}
+static const struct key_container *key_containers_next (struct key_containers_iter *it) {
+  return idl_boxed_vector_next_c (&it->x);
+}
+static struct key_container *key_containers_first_nc (struct key_containers *kcs, struct key_containers_iter *it) {
+  return idl_boxed_vector_first (&kcs->key_containers, &it->x);
+}
+static struct key_container *key_containers_next_nc (struct key_containers_iter *it) {
+  return idl_boxed_vector_next (&it->x);
+}
+
+/* ======= end of new/free/iterators/... wrappers ======== */
+
+static int cmp_parent_path (const void *a, const void *b)
+{
+  return strcmp (a, b);
+}
+
+static void sort_parent_paths (struct key_containers *key_containers)
+{
+  struct key_containers_iter it;
+  for (struct key_container *cntr = key_containers_first_nc (key_containers, &it); cntr; cntr = key_containers_next_nc (&it))
+  {
+    struct key_container_iter kcit;
+    for (struct key_field *fld = key_container_first (cntr, &kcit); fld; fld = key_container_next (&kcit))
+      idl_boxed_vector_sort (&fld->parent_paths, cmp_parent_path);
+  }
+}
+
+static bool has_conflicting_keys(const struct key_containers *key_containers, const idl_node_t **node)
+{
+  assert (node);
+  struct key_containers_iter it;
+  for (const struct key_container *cntr = key_containers_first (key_containers, &it); cntr; cntr = key_containers_next (&it))
+  {
     /* For all keys in a key_container (struct), check if the set of parent nodes is
        equal. The parent path of a key is the list of fields that form the key,
        except the key field itself (the last field).
@@ -61,22 +193,22 @@ static bool has_conflicting_keys(const struct key_container *key_containers, siz
        only f1. So the parent paths for alls keys in inner_type are not equal, and
        therefore the keylist has conflicting keys (and cannot be represented with
        @key annotations). */
-    for (size_t k = 0; k < cntr->n_key_fields; k++) {
-      const struct key_field *fld = &cntr->key_fields[k];
-      /* parent_paths == NULL && n_parent_paths == 0 happens for keys in the outer
-         struct but qsort() requires a non-null pointer */
-      if (fld->n_parent_paths > 1) {
-        qsort(fld->parent_paths, fld->n_parent_paths,
-          sizeof(*fld->parent_paths), cmp_parent_path);
-      }
-    }
-    for (size_t k = 0; k < cntr->n_key_fields; k++) {
-      const struct key_field *fld = &cntr->key_fields[k];
-      for (size_t k1 = 0; k1 < cntr->n_key_fields; k1++) {
-        const struct key_field *fld1 = &cntr->key_fields[k1];
-        if (fld->n_parent_paths != fld1->n_parent_paths
-          || !parent_path_sorted_list_equal(fld->parent_paths, fld1->parent_paths, fld->n_parent_paths)
-        ) {
+    struct key_container_iter kcit;
+    for (const struct key_field *fld = key_container_first_c (cntr, &kcit); fld; fld = key_container_next_c (&kcit))
+    {
+      struct key_container_iter kcit1;
+      for (const struct key_field *fld1 = key_container_first_c (cntr, &kcit1); fld1; fld1 = key_container_next_c (&kcit1))
+      {
+        idl_boxed_vector_iter_t ppit, ppit1;
+        const char *pp = idl_boxed_vector_first_c (&fld->parent_paths, &ppit);
+        const char *pp1 = idl_boxed_vector_first_c (&fld1->parent_paths, &ppit1);
+        while (pp && pp1 && strcmp (pp, pp1) == 0)
+        {
+          pp = idl_boxed_vector_next (&ppit);
+          pp1 = idl_boxed_vector_next (&ppit1);
+        }
+        if (pp || pp1)
+        {
           *node = cntr->node;
           return true;
         }
@@ -86,100 +218,42 @@ static bool has_conflicting_keys(const struct key_container *key_containers, siz
   return false;
 }
 
-static struct key_container *get_key_container(const idl_node_t *key_type_node, struct key_container **key_containers, size_t *n_key_containers)
+static struct key_container *get_key_container (const idl_node_t *key_type_node, struct key_containers *key_containers)
 {
-  for (size_t n=0; n < *n_key_containers; n++) {
-    if ((*key_containers)[n].node == key_type_node)
-      return &(*key_containers)[n];
-  }
-
-  // not found => add it
-  (*n_key_containers)++;
-  struct key_container *tmp = idl_realloc(*key_containers, *n_key_containers * sizeof(**key_containers));
-  if (tmp == NULL) {
-    idl_free (*key_containers);
-    *key_containers = NULL;
-    return NULL;
-  }
-  *key_containers = tmp;
-  (*key_containers)[*n_key_containers - 1] = (struct key_container) { key_type_node, NULL, 0 };
-  return &(*key_containers)[*n_key_containers - 1];
+  struct key_containers_iter it;
+  for (struct key_container *kc = key_containers_first_nc (key_containers, &it); kc; kc = key_containers_next_nc (&it))
+    if (kc->node == key_type_node)
+      return kc;
+  return key_containers_append (key_containers, key_type_node);
 }
 
-static struct key_field *get_key_field(const idl_declarator_t *declarator, struct key_container *key_container)
+static struct key_field *get_key_field (const idl_declarator_t *declarator, struct key_container *key_container)
 {
-  for (size_t n=0; n < key_container->n_key_fields; n++) {
-    if (key_container->key_fields[n].key_declarator == declarator)
-      return &key_container->key_fields[n];
-  }
-
-  // not found => add it
-  key_container->n_key_fields++;
-  struct key_field *tmp = idl_realloc(key_container->key_fields, key_container->n_key_fields * sizeof(*key_container->key_fields));
-  if (tmp == NULL) {
-    idl_free (key_container->key_fields);
-    key_container->key_fields = NULL;
-    return NULL;
-  }
-  key_container->key_fields = tmp;
-  key_container->key_fields[key_container->n_key_fields - 1] = (struct key_field) { declarator, NULL, 0 };
-  return &key_container->key_fields[key_container->n_key_fields - 1];
+  struct key_container_iter it;
+  for (struct key_field *kf = key_container_first (key_container, &it); kf; kf = key_container_next (&it))
+    if (kf->key_declarator == declarator)
+      return kf;
+  return key_container_append (key_container, declarator);
 }
 
-static idl_retcode_t add_parent_path(struct key_field *key_field, idl_field_name_t *key)
+static bool add_parent_path (struct key_field *key_field, idl_field_name_t *key)
 {
-  assert(key->length);
+  assert (key->length);
   if (key->length == 1)
-    return IDL_RETCODE_OK;
-  key_field->n_parent_paths++;
-  char **tmp;
-  if (!(tmp = idl_realloc(key_field->parent_paths, key_field->n_parent_paths * sizeof(*key_field->parent_paths))))
-  {
-    idl_free (key_field->parent_paths);
-    key_field->parent_paths = NULL;
-    return IDL_RETCODE_NO_MEMORY;
-  }
-  key_field->parent_paths = tmp;
+    return true;
 
   size_t parent_path_len = strlen(key->identifier) - strlen(key->names[key->length - 1]->identifier) - 1;
-  assert(parent_path_len > 0);
-  if (!(key_field->parent_paths[key_field->n_parent_paths - 1] = idl_malloc(parent_path_len + 1)))
-    return IDL_RETCODE_NO_MEMORY;
-  memcpy(key_field->parent_paths[key_field->n_parent_paths - 1], key->identifier, parent_path_len);
-  key_field->parent_paths[key_field->n_parent_paths - 1][parent_path_len] = '\0';
-  return IDL_RETCODE_OK;
+  assert (parent_path_len > 0);
+  char *pp = idl_malloc (parent_path_len + 1);
+  if (pp == NULL)
+    return false;
+  memcpy (pp, key->identifier, parent_path_len);
+  pp[parent_path_len] = '\0';
+  return key_field_append (key_field, pp);
 }
 
-static void key_containers_fini(struct key_container *key_containers, size_t n_key_containers)
+static idl_retcode_t get_keylist_key_paths_struct_key(idl_pstate_t *pstate, idl_struct_t *struct_node, const idl_key_t *key_node, struct key_containers *key_containers)
 {
-  IDL_WARNING_MSVC_OFF (6001);
-  if (!key_containers)
-    return;
-  for (size_t c = 0; c < n_key_containers; c++) {
-    if (!key_containers[c].key_fields)
-      continue;
-    for (size_t f = 0; f < key_containers[c].n_key_fields; f++) {
-      if (!key_containers[c].key_fields[f].parent_paths)
-        continue;
-      for (size_t p = 0; p < key_containers[c].key_fields[f].n_parent_paths; p++) {
-        if (!key_containers[c].key_fields[f].parent_paths)
-          continue;
-        idl_free(key_containers[c].key_fields[f].parent_paths[p]);
-        key_containers[c].key_fields[f].parent_paths[p] = NULL;
-      }
-      idl_free(key_containers[c].key_fields[f].parent_paths);
-      key_containers[c].key_fields[f].parent_paths = NULL;
-    }
-    idl_free(key_containers[c].key_fields);
-    key_containers[c].key_fields = NULL;
-  }
-  idl_free(key_containers);
-  IDL_WARNING_MSVC_ON (6001);
-}
-
-static idl_retcode_t get_keylist_key_paths_struct_key(idl_pstate_t *pstate, idl_struct_t *struct_node, const idl_key_t *key_node, struct key_container **key_containers, size_t *n_key_containers)
-{
-
   /* Create a shallow copy of the key names and unalias the identifier, so that
      this copy can be used to find fields for all parts of the key, by removing
      the last name-part in each iteration. */
@@ -187,10 +261,9 @@ static idl_retcode_t get_keylist_key_paths_struct_key(idl_pstate_t *pstate, idl_
   if ((key_names.identifier = idl_strdup(key_node->field_name->identifier)) == NULL)
     return IDL_RETCODE_NO_MEMORY;
 
-  idl_retcode_t ret = IDL_RETCODE_OK;
   idl_scope_t *scope = struct_node->node.declaration->scope;
   assert(scope);
-  for (uint32_t k = 0; ret == IDL_RETCODE_OK && k < key_node->field_name->length; k++)
+  for (uint32_t k = 0; k < key_node->field_name->length; k++)
   {
     const idl_declaration_t *declaration = idl_find_field_name(pstate, scope, &key_names, 0u);
     assert(declaration && declaration->node);
@@ -206,47 +279,46 @@ static idl_retcode_t get_keylist_key_paths_struct_key(idl_pstate_t *pstate, idl_
 
     struct key_container *key_container;
     struct key_field *key_field;
-    if (!(key_container = get_key_container(key_parent, key_containers, n_key_containers)))
-      ret = IDL_RETCODE_NO_MEMORY;
+    if (!(key_container = get_key_container(key_parent, key_containers)))
+      break;
     else if (!(key_field = get_key_field(declarator, key_container)))
-      ret = IDL_RETCODE_NO_MEMORY;
+      break;
+    else if (!add_parent_path(key_field, &key_names))
+      break;
     else
-      ret = add_parent_path(key_field, &key_names);
-    if (ret == IDL_RETCODE_OK)
     {
       if (key_names.length > 1)
         key_names.identifier[strlen(key_names.identifier) - strlen(key_names.names[key_names.length - 1]->identifier) - 1] = '\0';
       key_names.length--;
     }
   }
-  assert(key_names.length == 0 || ret != IDL_RETCODE_OK);
   idl_free(key_names.identifier);
-  return ret;
+  return (key_names.length == 0) ? IDL_RETCODE_OK : IDL_RETCODE_NO_MEMORY;
 }
 
-static idl_retcode_t get_keylist_key_paths_struct(idl_pstate_t *pstate, idl_struct_t *struct_node, struct key_container **key_containers, size_t *n_key_containers)
+static idl_retcode_t get_keylist_key_paths_struct(idl_pstate_t *pstate, idl_struct_t *struct_node, struct key_containers *key_containers)
 {
   if (struct_node->keylist != NULL) {
     for (const idl_key_t *key_node = struct_node->keylist->keys; key_node; key_node = idl_next(key_node)) {
       idl_retcode_t ret;
-      if ((ret = get_keylist_key_paths_struct_key(pstate, struct_node, key_node, key_containers, n_key_containers)) != IDL_RETCODE_OK)
+      if ((ret = get_keylist_key_paths_struct_key(pstate, struct_node, key_node, key_containers)) != IDL_RETCODE_OK)
         return ret;
     }
   }
   return IDL_RETCODE_OK;
 }
 
-static idl_retcode_t get_keylist_key_paths(idl_pstate_t *pstate, void *list, struct key_container **key_containers, size_t *n_key_containers)
+static idl_retcode_t get_keylist_key_paths(idl_pstate_t *pstate, void *list, struct key_containers *key_containers)
 {
   /* Build tree of key_containers, key fields and paths to these key fields */
   idl_retcode_t ret = IDL_RETCODE_OK;
   for ( ; ret == IDL_RETCODE_OK && list; list = idl_next(list)) {
     if (idl_mask(list) == IDL_MODULE) {
       idl_module_t *node = list;
-      ret = get_keylist_key_paths(pstate, node->definitions, key_containers, n_key_containers);
+      ret = get_keylist_key_paths(pstate, node->definitions, key_containers);
     } else if (idl_mask(list) == IDL_STRUCT) {
       idl_struct_t *struct_node = list;
-      ret = get_keylist_key_paths_struct(pstate, struct_node, key_containers, n_key_containers);
+      ret = get_keylist_key_paths_struct(pstate, struct_node, key_containers);
     }
   }
   return ret;
@@ -255,26 +327,26 @@ static idl_retcode_t get_keylist_key_paths(idl_pstate_t *pstate, void *list, str
 idl_retcode_t idl_validate_keylists(idl_pstate_t *pstate)
 {
   idl_retcode_t ret = IDL_RETCODE_OK;
-  struct key_container *key_containers = NULL;
-  size_t nkc = 0;
+  struct key_containers *key_containers;
+  if ((key_containers = key_containers_new ()) == NULL)
+    return IDL_RETCODE_NO_MEMORY;
 
   assert(pstate);
-  if ((ret = get_keylist_key_paths(pstate, pstate->root, &key_containers, &nkc) != IDL_RETCODE_OK))
+  if ((ret = get_keylist_key_paths (pstate, pstate->root, key_containers) != IDL_RETCODE_OK))
     goto err_create_key;
+  sort_parent_paths (key_containers);
 
   /* Check for conflicting keys */
-  if (nkc > 0) {
-    const idl_node_t *conflicting_type;
-    if (has_conflicting_keys(key_containers, nkc, &conflicting_type))
-    {
-      idl_error(pstate, idl_location(conflicting_type),
-        "Conflicting keys in keylist directive for type '%s'", idl_identifier(conflicting_type));
-      ret = IDL_RETCODE_SEMANTIC_ERROR;
-    }
+  const idl_node_t *conflicting_type;
+  if (has_conflicting_keys (key_containers, &conflicting_type))
+  {
+    idl_error(pstate, idl_location(conflicting_type),
+              "Conflicting keys in keylist directive for type '%s'", idl_identifier(conflicting_type));
+    ret = IDL_RETCODE_SEMANTIC_ERROR;
   }
 
 err_create_key:
-  key_containers_fini(key_containers, nkc);
+  key_containers_free (key_containers);
   return ret;
 }
 

--- a/src/idl/src/keylist.c
+++ b/src/idl/src/keylist.c
@@ -144,16 +144,16 @@ static struct key_container *key_containers_append (struct key_containers *kcs, 
   return boxed_vector_append_with_failure_action (&kcs->key_containers, kc, key_container_free_wrapper);
 }
 
-static const struct key_container *key_containers_first (const struct key_containers *kcs, struct key_containers_iter *it) {
+static const struct key_container *key_containers_first_c (const struct key_containers *kcs, struct key_containers_iter *it) {
   return idl_boxed_vector_first_c (&kcs->key_containers, &it->x);
 }
-static const struct key_container *key_containers_next (struct key_containers_iter *it) {
+static const struct key_container *key_containers_next_c (struct key_containers_iter *it) {
   return idl_boxed_vector_next_c (&it->x);
 }
-static struct key_container *key_containers_first_nc (struct key_containers *kcs, struct key_containers_iter *it) {
+static struct key_container *key_containers_first (struct key_containers *kcs, struct key_containers_iter *it) {
   return idl_boxed_vector_first (&kcs->key_containers, &it->x);
 }
-static struct key_container *key_containers_next_nc (struct key_containers_iter *it) {
+static struct key_container *key_containers_next (struct key_containers_iter *it) {
   return idl_boxed_vector_next (&it->x);
 }
 
@@ -167,7 +167,7 @@ static int cmp_parent_path (const void *a, const void *b)
 static void sort_parent_paths (struct key_containers *key_containers)
 {
   struct key_containers_iter it;
-  for (struct key_container *cntr = key_containers_first_nc (key_containers, &it); cntr; cntr = key_containers_next_nc (&it))
+  for (struct key_container *cntr = key_containers_first (key_containers, &it); cntr; cntr = key_containers_next (&it))
   {
     struct key_container_iter kcit;
     for (struct key_field *fld = key_container_first (cntr, &kcit); fld; fld = key_container_next (&kcit))
@@ -179,7 +179,7 @@ static bool has_conflicting_keys(const struct key_containers *key_containers, co
 {
   assert (node);
   struct key_containers_iter it;
-  for (const struct key_container *cntr = key_containers_first (key_containers, &it); cntr; cntr = key_containers_next (&it))
+  for (const struct key_container *cntr = key_containers_first_c (key_containers, &it); cntr; cntr = key_containers_next_c (&it))
   {
     /* For all keys in a key_container (struct), check if the set of parent nodes is
        equal. The parent path of a key is the list of fields that form the key,
@@ -221,7 +221,7 @@ static bool has_conflicting_keys(const struct key_containers *key_containers, co
 static struct key_container *get_key_container (const idl_node_t *key_type_node, struct key_containers *key_containers)
 {
   struct key_containers_iter it;
-  for (struct key_container *kc = key_containers_first_nc (key_containers, &it); kc; kc = key_containers_next_nc (&it))
+  for (struct key_container *kc = key_containers_first (key_containers, &it); kc; kc = key_containers_next (&it))
     if (kc->node == key_type_node)
       return kc;
   return key_containers_append (key_containers, key_type_node);

--- a/src/idl/src/parser.c
+++ b/src/idl/src/parser.c
@@ -1,8 +1,8 @@
-/* A Bison parser, made by GNU Bison 3.5.1.  */
+/* A Bison parser, made by GNU Bison 3.8.2.  */
 
 /* Bison implementation for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2020 Free Software Foundation,
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2021 Free Software Foundation,
    Inc.
 
    This program is free software: you can redistribute it and/or modify
@@ -16,7 +16,7 @@
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
 
 /* As a special exception, you may create a larger work that contains
    part or all of the Bison parser skeleton and distribute that work
@@ -34,6 +34,10 @@
 /* C LALR(1) parser skeleton written by Richard Stallman, by
    simplifying the original so-called "semantic" parser.  */
 
+/* DO NOT RELY ON FEATURES THAT ARE NOT DOCUMENTED in the manual,
+   especially those whose name start with YY_ or yy_.  They are
+   private implementation details that can be changed or removed.  */
+
 /* All symbols defined below should begin with yy or YY, to avoid
    infringing on user name space.  This should be done even for local
    variables, as they might otherwise be expanded by user macros.
@@ -41,14 +45,11 @@
    define necessary library symbols; they are noted "INFRINGES ON
    USER NAME SPACE" below.  */
 
-/* Undocumented macros, especially those whose name start with YY_,
-   are private implementation details.  Do not rely on them.  */
+/* Identify Bison output, and Bison version.  */
+#define YYBISON 30802
 
-/* Identify Bison output.  */
-#define YYBISON 1
-
-/* Bison version.  */
-#define YYBISON_VERSION "3.5.1"
+/* Bison version string.  */
+#define YYBISON_VERSION "3.8.2"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -68,6 +69,7 @@
 /* Substitute the variable and function names.  */
 #define yypush_parse    idl_yypush_parse
 #define yypstate_new    idl_yypstate_new
+#define yypstate_clear  idl_yypstate_clear
 #define yypstate_delete idl_yypstate_delete
 #define yypstate        idl_yypstate
 #define yylex           idl_yylex
@@ -101,6 +103,7 @@ _Pragma("GCC diagnostic ignored \"-Wsign-conversion\"")
 _Pragma("GCC diagnostic ignored \"-Wmissing-prototypes\"")
 #if (__GNUC__ >= 10)
 _Pragma("GCC diagnostic ignored \"-Wanalyzer-free-of-non-heap\"")
+_Pragma("GCC diagnostic ignored \"-Wanalyzer-malloc-leak\"")
 #endif
 #endif
 
@@ -150,7 +153,7 @@ static void yyerror(idl_location_t *, idl_pstate_t *, idl_retcode_t *, const cha
 #define TRY(action) \
   TRY_EXCEPT((action), 0)
 
-#line 154 "parser.c"
+#line 157 "parser.c"
 
 # ifndef YY_CAST
 #  ifdef __cplusplus
@@ -173,202 +176,186 @@ static void yyerror(idl_location_t *, idl_pstate_t *, idl_retcode_t *, const cha
 #  endif
 # endif
 
-/* Enabling verbose error messages.  */
-#ifdef YYERROR_VERBOSE
-# undef YYERROR_VERBOSE
-# define YYERROR_VERBOSE 1
-#else
-# define YYERROR_VERBOSE 0
-#endif
-
-/* Use api.header.include to #include this header
-   instead of duplicating it here.  */
-#ifndef YY_IDL_YY_PARSER_H_INCLUDED
-# define YY_IDL_YY_PARSER_H_INCLUDED
-/* Debug traces.  */
-#ifndef IDL_YYDEBUG
-# if defined YYDEBUG
-#if YYDEBUG
-#   define IDL_YYDEBUG 1
-#  else
-#   define IDL_YYDEBUG 0
-#  endif
-# else /* ! defined YYDEBUG */
-#  define IDL_YYDEBUG 1
-# endif /* ! defined YYDEBUG */
-#endif  /* ! defined IDL_YYDEBUG */
-#if IDL_YYDEBUG
-extern int idl_yydebug;
-#endif
-/* "%code requires" blocks.  */
-#line 86 "src/parser.y"
-
-#include "tree.h"
-
-/* make yytoknum available */
-#define YYPRINT(A,B,C) (void)0
-/* use YYLTYPE definition below */
-#define IDL_YYLTYPE_IS_DECLARED
-typedef struct idl_location IDL_YYLTYPE;
-
-#define LOC(first, last) \
-  &(IDL_YYLTYPE){ first, last }
-
-#line 218 "parser.c"
-
-/* Token type.  */
-#ifndef IDL_YYTOKENTYPE
-# define IDL_YYTOKENTYPE
-  enum idl_yytokentype
-  {
-    IDL_TOKEN_LINE_COMMENT = 258,
-    IDL_TOKEN_COMMENT = 259,
-    IDL_TOKEN_PP_NUMBER = 260,
-    IDL_TOKEN_IDENTIFIER = 261,
-    IDL_TOKEN_CHAR_LITERAL = 262,
-    IDL_TOKEN_STRING_LITERAL = 263,
-    IDL_TOKEN_INTEGER_LITERAL = 264,
-    IDL_TOKEN_FLOATING_PT_LITERAL = 265,
-    IDL_TOKEN_ANNOTATION_SYMBOL = 266,
-    IDL_TOKEN_ANNOTATION = 267,
-    IDL_TOKEN_SCOPE = 268,
-    IDL_TOKEN_SCOPE_NO_SPACE = 269,
-    IDL_TOKEN_MODULE = 270,
-    IDL_TOKEN_CONST = 271,
-    IDL_TOKEN_NATIVE = 272,
-    IDL_TOKEN_STRUCT = 273,
-    IDL_TOKEN_TYPEDEF = 274,
-    IDL_TOKEN_UNION = 275,
-    IDL_TOKEN_SWITCH = 276,
-    IDL_TOKEN_CASE = 277,
-    IDL_TOKEN_DEFAULT = 278,
-    IDL_TOKEN_ENUM = 279,
-    IDL_TOKEN_UNSIGNED = 280,
-    IDL_TOKEN_FIXED = 281,
-    IDL_TOKEN_SEQUENCE = 282,
-    IDL_TOKEN_STRING = 283,
-    IDL_TOKEN_WSTRING = 284,
-    IDL_TOKEN_FLOAT = 285,
-    IDL_TOKEN_DOUBLE = 286,
-    IDL_TOKEN_SHORT = 287,
-    IDL_TOKEN_LONG = 288,
-    IDL_TOKEN_CHAR = 289,
-    IDL_TOKEN_WCHAR = 290,
-    IDL_TOKEN_BOOLEAN = 291,
-    IDL_TOKEN_OCTET = 292,
-    IDL_TOKEN_ANY = 293,
-    IDL_TOKEN_MAP = 294,
-    IDL_TOKEN_BITSET = 295,
-    IDL_TOKEN_BITFIELD = 296,
-    IDL_TOKEN_BITMASK = 297,
-    IDL_TOKEN_INT8 = 298,
-    IDL_TOKEN_INT16 = 299,
-    IDL_TOKEN_INT32 = 300,
-    IDL_TOKEN_INT64 = 301,
-    IDL_TOKEN_UINT8 = 302,
-    IDL_TOKEN_UINT16 = 303,
-    IDL_TOKEN_UINT32 = 304,
-    IDL_TOKEN_UINT64 = 305,
-    IDL_TOKEN_TRUE = 306,
-    IDL_TOKEN_FALSE = 307,
-    IDL_TOKEN_LSHIFT = 308,
-    IDL_TOKEN_RSHIFT = 309
-  };
-#endif
-
-/* Value type.  */
-#if ! defined IDL_YYSTYPE && ! defined IDL_YYSTYPE_IS_DECLARED
-union IDL_YYSTYPE
+#include "parser.h"
+/* Symbol kind.  */
+enum yysymbol_kind_t
 {
-#line 104 "src/parser.y"
-
-  void *node;
-  /* expressions */
-  idl_literal_t *literal;
-  idl_const_expr_t *const_expr;
-  /* simple specifications */
-  idl_mask_t kind;
-  idl_name_t *name;
-  idl_scoped_name_t *scoped_name;
-  idl_inherit_spec_t *inherit_spec;
-  char *string_literal;
-  /* specifications */
-  idl_switch_type_spec_t *switch_type_spec;
-  idl_type_spec_t *type_spec;
-  idl_sequence_t *sequence;
-  idl_string_t *string;
-  /* declarations */
-  idl_definition_t *definition;
-  idl_module_t *module_dcl;
-  idl_struct_t *struct_dcl;
-  idl_forward_t *forward;
-  idl_member_t *member;
-  idl_declarator_t *declarator;
-  idl_union_t *union_dcl;
-  idl_case_t *_case;
-  idl_case_label_t *case_label;
-  idl_enum_t *enum_dcl;
-  idl_enumerator_t *enumerator;
-  idl_bitmask_t *bitmask_dcl;
-  idl_bit_value_t *bit_value;
-  idl_typedef_t *typedef_dcl;
-  idl_const_t *const_dcl;
-  /* annotations */
-  idl_annotation_t *annotation;
-  idl_annotation_member_t *annotation_member;
-  idl_annotation_appl_t *annotation_appl;
-  idl_annotation_appl_param_t *annotation_appl_param;
-
-  bool bln;
-  char *str;
-  char chr;
-  unsigned long long ullng;
-  long double ldbl;
-
-#line 329 "parser.c"
-
+  YYSYMBOL_YYEMPTY = -2,
+  YYSYMBOL_YYEOF = 0,                      /* "end of file"  */
+  YYSYMBOL_YYerror = 1,                    /* error  */
+  YYSYMBOL_YYUNDEF = 2,                    /* "invalid token"  */
+  YYSYMBOL_IDL_TOKEN_LINE_COMMENT = 3,     /* IDL_TOKEN_LINE_COMMENT  */
+  YYSYMBOL_IDL_TOKEN_COMMENT = 4,          /* IDL_TOKEN_COMMENT  */
+  YYSYMBOL_IDL_TOKEN_PP_NUMBER = 5,        /* IDL_TOKEN_PP_NUMBER  */
+  YYSYMBOL_IDL_TOKEN_IDENTIFIER = 6,       /* IDL_TOKEN_IDENTIFIER  */
+  YYSYMBOL_IDL_TOKEN_CHAR_LITERAL = 7,     /* IDL_TOKEN_CHAR_LITERAL  */
+  YYSYMBOL_IDL_TOKEN_STRING_LITERAL = 8,   /* IDL_TOKEN_STRING_LITERAL  */
+  YYSYMBOL_IDL_TOKEN_INTEGER_LITERAL = 9,  /* IDL_TOKEN_INTEGER_LITERAL  */
+  YYSYMBOL_IDL_TOKEN_FLOATING_PT_LITERAL = 10, /* IDL_TOKEN_FLOATING_PT_LITERAL  */
+  YYSYMBOL_IDL_TOKEN_ANNOTATION_SYMBOL = 11, /* "@"  */
+  YYSYMBOL_IDL_TOKEN_ANNOTATION = 12,      /* "annotation"  */
+  YYSYMBOL_IDL_TOKEN_SCOPE = 13,           /* IDL_TOKEN_SCOPE  */
+  YYSYMBOL_IDL_TOKEN_SCOPE_NO_SPACE = 14,  /* IDL_TOKEN_SCOPE_NO_SPACE  */
+  YYSYMBOL_IDL_TOKEN_MODULE = 15,          /* "module"  */
+  YYSYMBOL_IDL_TOKEN_CONST = 16,           /* "const"  */
+  YYSYMBOL_IDL_TOKEN_NATIVE = 17,          /* "native"  */
+  YYSYMBOL_IDL_TOKEN_STRUCT = 18,          /* "struct"  */
+  YYSYMBOL_IDL_TOKEN_TYPEDEF = 19,         /* "typedef"  */
+  YYSYMBOL_IDL_TOKEN_UNION = 20,           /* "union"  */
+  YYSYMBOL_IDL_TOKEN_SWITCH = 21,          /* "switch"  */
+  YYSYMBOL_IDL_TOKEN_CASE = 22,            /* "case"  */
+  YYSYMBOL_IDL_TOKEN_DEFAULT = 23,         /* "default"  */
+  YYSYMBOL_IDL_TOKEN_ENUM = 24,            /* "enum"  */
+  YYSYMBOL_IDL_TOKEN_UNSIGNED = 25,        /* "unsigned"  */
+  YYSYMBOL_IDL_TOKEN_FIXED = 26,           /* "fixed"  */
+  YYSYMBOL_IDL_TOKEN_SEQUENCE = 27,        /* "sequence"  */
+  YYSYMBOL_IDL_TOKEN_STRING = 28,          /* "string"  */
+  YYSYMBOL_IDL_TOKEN_WSTRING = 29,         /* "wstring"  */
+  YYSYMBOL_IDL_TOKEN_FLOAT = 30,           /* "float"  */
+  YYSYMBOL_IDL_TOKEN_DOUBLE = 31,          /* "double"  */
+  YYSYMBOL_IDL_TOKEN_SHORT = 32,           /* "short"  */
+  YYSYMBOL_IDL_TOKEN_LONG = 33,            /* "long"  */
+  YYSYMBOL_IDL_TOKEN_CHAR = 34,            /* "char"  */
+  YYSYMBOL_IDL_TOKEN_WCHAR = 35,           /* "wchar"  */
+  YYSYMBOL_IDL_TOKEN_BOOLEAN = 36,         /* "boolean"  */
+  YYSYMBOL_IDL_TOKEN_OCTET = 37,           /* "octet"  */
+  YYSYMBOL_IDL_TOKEN_ANY = 38,             /* "any"  */
+  YYSYMBOL_IDL_TOKEN_MAP = 39,             /* "map"  */
+  YYSYMBOL_IDL_TOKEN_BITSET = 40,          /* "bitset"  */
+  YYSYMBOL_IDL_TOKEN_BITFIELD = 41,        /* "bitfield"  */
+  YYSYMBOL_IDL_TOKEN_BITMASK = 42,         /* "bitmask"  */
+  YYSYMBOL_IDL_TOKEN_INT8 = 43,            /* "int8"  */
+  YYSYMBOL_IDL_TOKEN_INT16 = 44,           /* "int16"  */
+  YYSYMBOL_IDL_TOKEN_INT32 = 45,           /* "int32"  */
+  YYSYMBOL_IDL_TOKEN_INT64 = 46,           /* "int64"  */
+  YYSYMBOL_IDL_TOKEN_UINT8 = 47,           /* "uint8"  */
+  YYSYMBOL_IDL_TOKEN_UINT16 = 48,          /* "uint16"  */
+  YYSYMBOL_IDL_TOKEN_UINT32 = 49,          /* "uint32"  */
+  YYSYMBOL_IDL_TOKEN_UINT64 = 50,          /* "uint64"  */
+  YYSYMBOL_IDL_TOKEN_TRUE = 51,            /* "TRUE"  */
+  YYSYMBOL_IDL_TOKEN_FALSE = 52,           /* "FALSE"  */
+  YYSYMBOL_IDL_TOKEN_LSHIFT = 53,          /* "<<"  */
+  YYSYMBOL_IDL_TOKEN_RSHIFT = 54,          /* ">>"  */
+  YYSYMBOL_55_ = 55,                       /* ';'  */
+  YYSYMBOL_56_ = 56,                       /* '{'  */
+  YYSYMBOL_57_ = 57,                       /* '}'  */
+  YYSYMBOL_58_ = 58,                       /* '='  */
+  YYSYMBOL_59_ = 59,                       /* '|'  */
+  YYSYMBOL_60_ = 60,                       /* '^'  */
+  YYSYMBOL_61_ = 61,                       /* '&'  */
+  YYSYMBOL_62_ = 62,                       /* '+'  */
+  YYSYMBOL_63_ = 63,                       /* '-'  */
+  YYSYMBOL_64_ = 64,                       /* '*'  */
+  YYSYMBOL_65_ = 65,                       /* '/'  */
+  YYSYMBOL_66_ = 66,                       /* '%'  */
+  YYSYMBOL_67_ = 67,                       /* '~'  */
+  YYSYMBOL_68_ = 68,                       /* '('  */
+  YYSYMBOL_69_ = 69,                       /* ')'  */
+  YYSYMBOL_70_ = 70,                       /* '<'  */
+  YYSYMBOL_71_ = 71,                       /* ','  */
+  YYSYMBOL_72_ = 72,                       /* '>'  */
+  YYSYMBOL_73_ = 73,                       /* ':'  */
+  YYSYMBOL_74_ = 74,                       /* '['  */
+  YYSYMBOL_75_ = 75,                       /* ']'  */
+  YYSYMBOL_YYACCEPT = 76,                  /* $accept  */
+  YYSYMBOL_specification = 77,             /* specification  */
+  YYSYMBOL_definitions = 78,               /* definitions  */
+  YYSYMBOL_definition = 79,                /* definition  */
+  YYSYMBOL_module_dcl = 80,                /* module_dcl  */
+  YYSYMBOL_module_header = 81,             /* module_header  */
+  YYSYMBOL_scoped_name = 82,               /* scoped_name  */
+  YYSYMBOL_const_dcl = 83,                 /* const_dcl  */
+  YYSYMBOL_const_type = 84,                /* const_type  */
+  YYSYMBOL_const_expr = 85,                /* const_expr  */
+  YYSYMBOL_or_expr = 86,                   /* or_expr  */
+  YYSYMBOL_xor_expr = 87,                  /* xor_expr  */
+  YYSYMBOL_and_expr = 88,                  /* and_expr  */
+  YYSYMBOL_shift_expr = 89,                /* shift_expr  */
+  YYSYMBOL_shift_operator = 90,            /* shift_operator  */
+  YYSYMBOL_add_expr = 91,                  /* add_expr  */
+  YYSYMBOL_add_operator = 92,              /* add_operator  */
+  YYSYMBOL_mult_expr = 93,                 /* mult_expr  */
+  YYSYMBOL_mult_operator = 94,             /* mult_operator  */
+  YYSYMBOL_unary_expr = 95,                /* unary_expr  */
+  YYSYMBOL_unary_operator = 96,            /* unary_operator  */
+  YYSYMBOL_primary_expr = 97,              /* primary_expr  */
+  YYSYMBOL_literal = 98,                   /* literal  */
+  YYSYMBOL_boolean_literal = 99,           /* boolean_literal  */
+  YYSYMBOL_string_literal = 100,           /* string_literal  */
+  YYSYMBOL_positive_int_const = 101,       /* positive_int_const  */
+  YYSYMBOL_type_dcl = 102,                 /* type_dcl  */
+  YYSYMBOL_type_spec = 103,                /* type_spec  */
+  YYSYMBOL_simple_type_spec = 104,         /* simple_type_spec  */
+  YYSYMBOL_base_type_spec = 105,           /* base_type_spec  */
+  YYSYMBOL_floating_pt_type = 106,         /* floating_pt_type  */
+  YYSYMBOL_integer_type = 107,             /* integer_type  */
+  YYSYMBOL_signed_int = 108,               /* signed_int  */
+  YYSYMBOL_unsigned_int = 109,             /* unsigned_int  */
+  YYSYMBOL_char_type = 110,                /* char_type  */
+  YYSYMBOL_wide_char_type = 111,           /* wide_char_type  */
+  YYSYMBOL_boolean_type = 112,             /* boolean_type  */
+  YYSYMBOL_octet_type = 113,               /* octet_type  */
+  YYSYMBOL_template_type_spec = 114,       /* template_type_spec  */
+  YYSYMBOL_sequence_type = 115,            /* sequence_type  */
+  YYSYMBOL_string_type = 116,              /* string_type  */
+  YYSYMBOL_constr_type_dcl = 117,          /* constr_type_dcl  */
+  YYSYMBOL_struct_dcl = 118,               /* struct_dcl  */
+  YYSYMBOL_struct_forward_dcl = 119,       /* struct_forward_dcl  */
+  YYSYMBOL_struct_def = 120,               /* struct_def  */
+  YYSYMBOL_struct_header = 121,            /* struct_header  */
+  YYSYMBOL_struct_inherit_spec = 122,      /* struct_inherit_spec  */
+  YYSYMBOL_struct_body = 123,              /* struct_body  */
+  YYSYMBOL_members = 124,                  /* members  */
+  YYSYMBOL_member = 125,                   /* member  */
+  YYSYMBOL_union_dcl = 126,                /* union_dcl  */
+  YYSYMBOL_union_def = 127,                /* union_def  */
+  YYSYMBOL_union_forward_dcl = 128,        /* union_forward_dcl  */
+  YYSYMBOL_union_header = 129,             /* union_header  */
+  YYSYMBOL_switch_header = 130,            /* switch_header  */
+  YYSYMBOL_switch_type_spec = 131,         /* switch_type_spec  */
+  YYSYMBOL_switch_body = 132,              /* switch_body  */
+  YYSYMBOL_case = 133,                     /* case  */
+  YYSYMBOL_case_labels = 134,              /* case_labels  */
+  YYSYMBOL_case_label = 135,               /* case_label  */
+  YYSYMBOL_element_spec = 136,             /* element_spec  */
+  YYSYMBOL_enum_dcl = 137,                 /* enum_dcl  */
+  YYSYMBOL_enum_def = 138,                 /* enum_def  */
+  YYSYMBOL_enumerators = 139,              /* enumerators  */
+  YYSYMBOL_enumerator = 140,               /* enumerator  */
+  YYSYMBOL_bitmask_dcl = 141,              /* bitmask_dcl  */
+  YYSYMBOL_bitmask_def = 142,              /* bitmask_def  */
+  YYSYMBOL_bit_values = 143,               /* bit_values  */
+  YYSYMBOL_bit_value = 144,                /* bit_value  */
+  YYSYMBOL_array_declarator = 145,         /* array_declarator  */
+  YYSYMBOL_fixed_array_sizes = 146,        /* fixed_array_sizes  */
+  YYSYMBOL_fixed_array_size = 147,         /* fixed_array_size  */
+  YYSYMBOL_simple_declarator = 148,        /* simple_declarator  */
+  YYSYMBOL_complex_declarator = 149,       /* complex_declarator  */
+  YYSYMBOL_typedef_dcl = 150,              /* typedef_dcl  */
+  YYSYMBOL_declarators = 151,              /* declarators  */
+  YYSYMBOL_declarator = 152,               /* declarator  */
+  YYSYMBOL_identifier = 153,               /* identifier  */
+  YYSYMBOL_annotation_dcl = 154,           /* annotation_dcl  */
+  YYSYMBOL_annotation_header = 155,        /* annotation_header  */
+  YYSYMBOL_156_1 = 156,                    /* $@1  */
+  YYSYMBOL_annotation_body = 157,          /* annotation_body  */
+  YYSYMBOL_annotation_member = 158,        /* annotation_member  */
+  YYSYMBOL_annotation_member_type = 159,   /* annotation_member_type  */
+  YYSYMBOL_annotation_member_default = 160, /* annotation_member_default  */
+  YYSYMBOL_any_const_type = 161,           /* any_const_type  */
+  YYSYMBOL_annotations = 162,              /* annotations  */
+  YYSYMBOL_annotation_appls = 163,         /* annotation_appls  */
+  YYSYMBOL_annotation_appl = 164,          /* annotation_appl  */
+  YYSYMBOL_annotation_appl_header = 165,   /* annotation_appl_header  */
+  YYSYMBOL_166_2 = 166,                    /* $@2  */
+  YYSYMBOL_annotation_appl_name = 167,     /* annotation_appl_name  */
+  YYSYMBOL_annotation_appl_params = 168,   /* annotation_appl_params  */
+  YYSYMBOL_annotation_appl_keyword_params = 169, /* annotation_appl_keyword_params  */
+  YYSYMBOL_annotation_appl_keyword_param = 170, /* annotation_appl_keyword_param  */
+  YYSYMBOL_171_3 = 171                     /* @3  */
 };
-typedef union IDL_YYSTYPE IDL_YYSTYPE;
-# define IDL_YYSTYPE_IS_TRIVIAL 1
-# define IDL_YYSTYPE_IS_DECLARED 1
-#endif
+typedef enum yysymbol_kind_t yysymbol_kind_t;
 
-/* Location type.  */
-#if ! defined IDL_YYLTYPE && ! defined IDL_YYLTYPE_IS_DECLARED
-typedef struct IDL_YYLTYPE IDL_YYLTYPE;
-struct IDL_YYLTYPE
-{
-  int first_line;
-  int first_column;
-  int last_line;
-  int last_column;
-};
-# define IDL_YYLTYPE_IS_DECLARED 1
-# define IDL_YYLTYPE_IS_TRIVIAL 1
-#endif
-
-
-
-#ifndef YYPUSH_MORE_DEFINED
-# define YYPUSH_MORE_DEFINED
-enum { YYPUSH_MORE = 4 };
-#endif
-
-typedef struct idl_yypstate idl_yypstate;
-
-int idl_yypush_parse (idl_yypstate *ps, int pushed_char, IDL_YYSTYPE const *pushed_val, IDL_YYLTYPE *pushed_loc, idl_pstate_t *pstate, idl_retcode_t *result);
-
-idl_yypstate * idl_yypstate_new (void);
-void idl_yypstate_delete (idl_yypstate *ps);
-/* "%code provides" blocks.  */
-#line 99 "src/parser.y"
-
-int idl_iskeyword(idl_pstate_t *pstate, const char *str, int nc);
-void idl_yypstate_delete_stack(idl_yypstate *yyps);
-
-#line 370 "parser.c"
-
-#endif /* !YY_IDL_YY_PARSER_H_INCLUDED  */
 
 
 
@@ -407,6 +394,18 @@ typedef __INT_LEAST16_TYPE__ yytype_int16;
 typedef int_least16_t yytype_int16;
 #else
 typedef short yytype_int16;
+#endif
+
+/* Work around bug in HP-UX 11.23, which defines these macros
+   incorrectly for preprocessor constants.  This workaround can likely
+   be removed in 2023, as HPE has promised support for HP-UX 11.23
+   (aka HP-UX 11i v2) only through the end of 2022; see Table 2 of
+   <https://h20195.www2.hpe.com/V2/getpdf.aspx/4AA4-7673ENW.pdf>.  */
+#ifdef __hpux
+# undef UINT_LEAST8_MAX
+# undef UINT_LEAST16_MAX
+# define UINT_LEAST8_MAX 255
+# define UINT_LEAST16_MAX 65535
 #endif
 
 #if defined __UINT_LEAST8_MAX__ && __UINT_LEAST8_MAX__ <= __INT_MAX__
@@ -468,6 +467,7 @@ typedef int yytype_uint16;
 
 #define YYSIZEOF(X) YY_CAST (YYPTRDIFF_T, sizeof (X))
 
+
 /* Stored state numbers (used for stacks). */
 typedef yytype_int16 yy_state_t;
 
@@ -485,6 +485,7 @@ typedef int yy_state_fast_t;
 #  define YY_(Msgid) Msgid
 # endif
 #endif
+
 
 #ifndef YY_ATTRIBUTE_PURE
 # if defined __GNUC__ && 2 < __GNUC__ + (96 <= __GNUC_MINOR__)
@@ -504,17 +505,23 @@ typedef int yy_state_fast_t;
 
 /* Suppress unused-variable warnings by "using" E.  */
 #if ! defined lint || defined __GNUC__
-# define YYUSE(E) ((void) (E))
+# define YY_USE(E) ((void) (E))
 #else
-# define YYUSE(E) /* empty */
+# define YY_USE(E) /* empty */
 #endif
 
-#if defined __GNUC__ && ! defined __ICC && 407 <= __GNUC__ * 100 + __GNUC_MINOR__
 /* Suppress an incorrect diagnostic about yylval being uninitialized.  */
-# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                            \
+#if defined __GNUC__ && ! defined __ICC && 406 <= __GNUC__ * 100 + __GNUC_MINOR__
+# if __GNUC__ * 100 + __GNUC_MINOR__ < 407
+#  define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                           \
+    _Pragma ("GCC diagnostic push")                                     \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")
+# else
+#  define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                           \
     _Pragma ("GCC diagnostic push")                                     \
     _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")              \
     _Pragma ("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
+# endif
 # define YY_IGNORE_MAYBE_UNINITIALIZED_END      \
     _Pragma ("GCC diagnostic pop")
 #else
@@ -543,7 +550,7 @@ typedef int yy_state_fast_t;
 
 #define YY_ASSERT(E) ((void) (0 && (E)))
 
-#if ! defined yyoverflow || YYERROR_VERBOSE
+#if !defined yyoverflow
 
 /* The parser invokes alloca or malloc; define the necessary symbols.  */
 
@@ -584,8 +591,7 @@ void free (void *); /* INFRINGES ON USER NAME SPACE */
 #   endif
 #  endif
 # endif
-#endif /* ! defined yyoverflow || YYERROR_VERBOSE */
-
+#endif /* !defined yyoverflow */
 
 #if (! defined yyoverflow \
      && (! defined __cplusplus \
@@ -664,14 +670,16 @@ union yyalloc
 /* YYNSTATES -- Number of states.  */
 #define YYNSTATES  286
 
-#define YYUNDEFTOK  2
+/* YYMAXUTOK -- Last valid token kind.  */
 #define YYMAXUTOK   309
 
 
 /* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
    as returned by yylex, with out-of-bounds checking.  */
-#define YYTRANSLATE(YYX)                                                \
-  (0 <= (YYX) && (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
+#define YYTRANSLATE(YYX)                                \
+  (0 <= (YYX) && (YYX) <= YYMAXUTOK                     \
+   ? YY_CAST (yysymbol_kind_t, yytranslate[YYX])        \
+   : YYSYMBOL_YYUNDEF)
 
 /* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
    as returned by yylex.  */
@@ -711,56 +719,64 @@ static const yytype_int8 yytranslate[] =
 };
 
 #if IDL_YYDEBUG
-  /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
+/* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] =
 {
-       0,   287,   287,   289,   294,   296,   301,   303,   307,   311,
-     318,   325,   330,   332,   334,   341,   346,   348,   350,   352,
-     354,   356,   358,   372,   375,   376,   384,   385,   393,   394,
-     402,   403,   411,   412,   415,   416,   424,   425,   428,   430,
-     438,   439,   440,   443,   448,   453,   454,   455,   459,   475,
-     477,   482,   504,   527,   534,   541,   551,   553,   558,   565,
-     581,   586,   587,   591,   593,   597,   599,   612,   613,   614,
-     615,   616,   617,   621,   622,   623,   627,   628,   632,   633,
-     634,   636,   637,   638,   639,   643,   644,   645,   647,   648,
-     649,   650,   654,   657,   660,   663,   666,   667,   671,   673,
-     678,   680,   685,   686,   687,   688,   692,   693,   697,   702,
-     709,   714,   717,   732,   736,   741,   743,   748,   755,   756,
-     760,   767,   772,   777,   788,   790,   792,   794,   800,   802,
-     807,   809,   814,   821,   823,   828,   830,   837,   843,   846,
-     851,   853,   858,   864,   867,   872,   874,   879,   886,   891,
-     893,   898,   903,   907,   910,   912,   929,   931,   936,   937,
-     941,   958,   969,   968,   977,   979,   981,   983,   985,   987,
-     992,   997,   999,  1004,  1006,  1011,  1016,  1018,  1023,  1025,
-    1030,  1041,  1040,  1066,  1068,  1070,  1077,  1079,  1081,  1086,
-    1088,  1094,  1093
+       0,   288,   288,   290,   295,   297,   302,   304,   308,   312,
+     319,   326,   331,   333,   335,   342,   347,   349,   351,   353,
+     355,   357,   359,   373,   376,   377,   385,   386,   394,   395,
+     403,   404,   412,   413,   416,   417,   425,   426,   429,   431,
+     439,   440,   441,   444,   449,   454,   455,   456,   460,   476,
+     478,   483,   505,   528,   535,   542,   552,   554,   559,   566,
+     582,   587,   588,   592,   594,   598,   600,   613,   614,   615,
+     616,   617,   618,   622,   623,   624,   628,   629,   633,   634,
+     635,   637,   638,   639,   640,   644,   645,   646,   648,   649,
+     650,   651,   655,   658,   661,   664,   667,   668,   672,   674,
+     679,   681,   686,   687,   688,   689,   693,   694,   698,   703,
+     710,   715,   718,   733,   737,   742,   744,   749,   756,   757,
+     761,   768,   773,   778,   789,   791,   793,   795,   801,   803,
+     808,   810,   815,   822,   824,   829,   831,   838,   844,   847,
+     852,   854,   859,   865,   868,   873,   875,   880,   887,   892,
+     894,   899,   904,   908,   911,   913,   930,   932,   937,   938,
+     942,   959,   970,   969,   978,   980,   982,   984,   986,   988,
+     993,   998,  1000,  1005,  1007,  1012,  1017,  1019,  1024,  1026,
+    1031,  1042,  1041,  1067,  1069,  1071,  1078,  1080,  1082,  1087,
+    1089,  1095,  1094
 };
 #endif
 
-#if IDL_YYDEBUG || YYERROR_VERBOSE || 1
+/** Accessing symbol of state STATE.  */
+#define YY_ACCESSING_SYMBOL(State) YY_CAST (yysymbol_kind_t, yystos[State])
+
+#if IDL_YYDEBUG || 1
+/* The user-facing name of the symbol whose (internal) number is
+   YYSYMBOL.  No bounds checking.  */
+static const char *yysymbol_name (yysymbol_kind_t yysymbol) YY_ATTRIBUTE_UNUSED;
+
 /* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
    First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
 static const char *const yytname[] =
 {
-  "$end", "error", "$undefined", "IDL_TOKEN_LINE_COMMENT",
-  "IDL_TOKEN_COMMENT", "IDL_TOKEN_PP_NUMBER", "IDL_TOKEN_IDENTIFIER",
-  "IDL_TOKEN_CHAR_LITERAL", "IDL_TOKEN_STRING_LITERAL",
-  "IDL_TOKEN_INTEGER_LITERAL", "IDL_TOKEN_FLOATING_PT_LITERAL", "\"@\"",
-  "\"annotation\"", "IDL_TOKEN_SCOPE", "IDL_TOKEN_SCOPE_NO_SPACE",
-  "\"module\"", "\"const\"", "\"native\"", "\"struct\"", "\"typedef\"",
-  "\"union\"", "\"switch\"", "\"case\"", "\"default\"", "\"enum\"",
-  "\"unsigned\"", "\"fixed\"", "\"sequence\"", "\"string\"", "\"wstring\"",
-  "\"float\"", "\"double\"", "\"short\"", "\"long\"", "\"char\"",
-  "\"wchar\"", "\"boolean\"", "\"octet\"", "\"any\"", "\"map\"",
-  "\"bitset\"", "\"bitfield\"", "\"bitmask\"", "\"int8\"", "\"int16\"",
-  "\"int32\"", "\"int64\"", "\"uint8\"", "\"uint16\"", "\"uint32\"",
-  "\"uint64\"", "\"TRUE\"", "\"FALSE\"", "\"<<\"", "\">>\"", "';'", "'{'",
-  "'}'", "'='", "'|'", "'^'", "'&'", "'+'", "'-'", "'*'", "'/'", "'%'",
-  "'~'", "'('", "')'", "'<'", "','", "'>'", "':'", "'['", "']'", "$accept",
-  "specification", "definitions", "definition", "module_dcl",
-  "module_header", "scoped_name", "const_dcl", "const_type", "const_expr",
-  "or_expr", "xor_expr", "and_expr", "shift_expr", "shift_operator",
-  "add_expr", "add_operator", "mult_expr", "mult_operator", "unary_expr",
+  "\"end of file\"", "error", "\"invalid token\"",
+  "IDL_TOKEN_LINE_COMMENT", "IDL_TOKEN_COMMENT", "IDL_TOKEN_PP_NUMBER",
+  "IDL_TOKEN_IDENTIFIER", "IDL_TOKEN_CHAR_LITERAL",
+  "IDL_TOKEN_STRING_LITERAL", "IDL_TOKEN_INTEGER_LITERAL",
+  "IDL_TOKEN_FLOATING_PT_LITERAL", "\"@\"", "\"annotation\"",
+  "IDL_TOKEN_SCOPE", "IDL_TOKEN_SCOPE_NO_SPACE", "\"module\"", "\"const\"",
+  "\"native\"", "\"struct\"", "\"typedef\"", "\"union\"", "\"switch\"",
+  "\"case\"", "\"default\"", "\"enum\"", "\"unsigned\"", "\"fixed\"",
+  "\"sequence\"", "\"string\"", "\"wstring\"", "\"float\"", "\"double\"",
+  "\"short\"", "\"long\"", "\"char\"", "\"wchar\"", "\"boolean\"",
+  "\"octet\"", "\"any\"", "\"map\"", "\"bitset\"", "\"bitfield\"",
+  "\"bitmask\"", "\"int8\"", "\"int16\"", "\"int32\"", "\"int64\"",
+  "\"uint8\"", "\"uint16\"", "\"uint32\"", "\"uint64\"", "\"TRUE\"",
+  "\"FALSE\"", "\"<<\"", "\">>\"", "';'", "'{'", "'}'", "'='", "'|'",
+  "'^'", "'&'", "'+'", "'-'", "'*'", "'/'", "'%'", "'~'", "'('", "')'",
+  "'<'", "','", "'>'", "':'", "'['", "']'", "$accept", "specification",
+  "definitions", "definition", "module_dcl", "module_header",
+  "scoped_name", "const_dcl", "const_type", "const_expr", "or_expr",
+  "xor_expr", "and_expr", "shift_expr", "shift_operator", "add_expr",
+  "add_operator", "mult_expr", "mult_operator", "unary_expr",
   "unary_operator", "primary_expr", "literal", "boolean_literal",
   "string_literal", "positive_int_const", "type_dcl", "type_spec",
   "simple_type_spec", "base_type_spec", "floating_pt_type", "integer_type",
@@ -782,23 +798,13 @@ static const char *const yytname[] =
   "annotation_appl_name", "annotation_appl_params",
   "annotation_appl_keyword_params", "annotation_appl_keyword_param", "@3", YY_NULLPTR
 };
-#endif
 
-# ifdef YYPRINT
-/* YYTOKNUM[NUM] -- (External) token number corresponding to the
-   (internal) symbol number NUM (which must be that of a token).  */
-static const yytype_int16 yytoknum[] =
+static const char *
+yysymbol_name (yysymbol_kind_t yysymbol)
 {
-       0,   256,   257,   258,   259,   260,   261,   262,   263,   264,
-     265,   266,   267,   268,   269,   270,   271,   272,   273,   274,
-     275,   276,   277,   278,   279,   280,   281,   282,   283,   284,
-     285,   286,   287,   288,   289,   290,   291,   292,   293,   294,
-     295,   296,   297,   298,   299,   300,   301,   302,   303,   304,
-     305,   306,   307,   308,   309,    59,   123,   125,    61,   124,
-      94,    38,    43,    45,    42,    47,    37,   126,    40,    41,
-      60,    44,    62,    58,    91,    93
-};
-# endif
+  return yytname[yysymbol];
+}
+#endif
 
 #define YYPACT_NINF (-201)
 
@@ -810,8 +816,8 @@ static const yytype_int16 yytoknum[] =
 #define yytable_value_is_error(Yyn) \
   0
 
-  /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
-     STATE-NUM.  */
+/* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
+   STATE-NUM.  */
 static const yytype_int16 yypact[] =
 {
       59,    65,    83,    82,  -201,    42,    45,    84,    96,  -201,
@@ -845,9 +851,9 @@ static const yytype_int16 yypact[] =
     -201,  -201,  -201,  -201,  -201,  -201
 };
 
-  /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
-     Performed when YYTABLE does not specify something else to do.  Zero
-     means the default is an error.  */
+/* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
+   Performed when YYTABLE does not specify something else to do.  Zero
+   means the default is an error.  */
 static const yytype_uint8 yydefact[] =
 {
      177,   181,     0,   177,     4,     0,     0,     0,   176,   178,
@@ -881,7 +887,7 @@ static const yytype_uint8 yydefact[] =
      141,   146,   117,   137,    98,   123
 };
 
-  /* YYPGOTO[NTERM-NUM].  */
+/* YYPGOTO[NTERM-NUM].  */
 static const yytype_int16 yypgoto[] =
 {
     -201,  -201,   103,     0,  -201,  -201,    -6,   157,   161,   -38,
@@ -896,10 +902,10 @@ static const yytype_int16 yypgoto[] =
     -201,  -201,  -201,  -201,    34,  -201
 };
 
-  /* YYDEFGOTO[NTERM-NUM].  */
+/* YYDEFGOTO[NTERM-NUM].  */
 static const yytype_int16 yydefgoto[] =
 {
-      -1,     2,     3,     4,    24,    25,   118,    26,    72,   210,
+       0,     2,     3,     4,    24,    25,   118,    26,    72,   210,
      120,   121,   122,   123,   188,   124,   191,   125,   195,   126,
      127,   128,   129,   130,   131,   211,    27,    86,    87,    88,
       89,    90,    75,    76,    91,    92,    93,    94,    95,    96,
@@ -911,9 +917,9 @@ static const yytype_int16 yydefgoto[] =
       12,    50,    45,   133,   134,   198
 };
 
-  /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
-     positive, shift that token.  If negative, reduce the rule whose
-     number is the opposite.  If YYTABLE_NINF, syntax error.  */
+/* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
+   positive, shift that token.  If negative, reduce the rule whose
+   number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_int16 yytable[] =
 {
       49,   165,    74,    14,    77,    52,   119,    82,   215,    99,
@@ -1004,8 +1010,8 @@ static const yytype_int16 yycheck[] =
       -1,    -1,    43,    44,    45,    46,    47,    48,    49,    50
 };
 
-  /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
-     symbol of state STATE-NUM.  */
+/* YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
+   state STATE-NUM.  */
 static const yytype_uint8 yystos[] =
 {
        0,    11,    77,    78,    79,   154,   155,   162,   163,   164,
@@ -1039,7 +1045,7 @@ static const yytype_uint8 yystos[] =
      140,   144,    55,   152,    72,    69
 };
 
-  /* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
+/* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
 static const yytype_uint8 yyr1[] =
 {
        0,    76,    77,    77,    78,    78,    79,    79,    79,    79,
@@ -1064,7 +1070,7 @@ static const yytype_uint8 yyr1[] =
      169,   171,   170
 };
 
-  /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
+/* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
 static const yytype_int8 yyr2[] =
 {
        0,     2,     0,     1,     1,     2,     2,     3,     3,     3,
@@ -1090,21 +1096,22 @@ static const yytype_int8 yyr2[] =
 };
 
 
+enum { YYENOMEM = -2 };
+
 #define yyerrok         (yyerrstatus = 0)
-#define yyclearin       (yychar = YYEMPTY)
-#define YYEMPTY         (-2)
-#define YYEOF           0
+#define yyclearin       (yychar = IDL_YYEMPTY)
 
 #define YYACCEPT        goto yyacceptlab
 #define YYABORT         goto yyabortlab
 #define YYERROR         goto yyerrorlab
+#define YYNOMEM         goto yyexhaustedlab
 
 
 #define YYRECOVERING()  (!!yyerrstatus)
 
 #define YYBACKUP(Token, Value)                                    \
   do                                                              \
-    if (yychar == YYEMPTY)                                        \
+    if (yychar == IDL_YYEMPTY)                                        \
       {                                                           \
         yychar = (Token);                                         \
         yylval = (Value);                                         \
@@ -1119,10 +1126,9 @@ static const yytype_int8 yyr2[] =
       }                                                           \
   while (0)
 
-/* Error token number */
-#define YYTERROR        1
-#define YYERRCODE       256
-
+/* Backward compatibility with an undocumented macro.
+   Use IDL_YYerror or IDL_YYUNDEF. */
+#define YYERRCODE IDL_YYUNDEF
 
 /* YYLLOC_DEFAULT -- Set CURRENT to span from RHS[1] to RHS[N].
    If N is 0, then set CURRENT to the empty location which ends
@@ -1166,12 +1172,19 @@ do {                                            \
 } while (0)
 
 
-/* YY_LOCATION_PRINT -- Print the location on the stream.
+/* YYLOCATION_PRINT -- Print the location on the stream.
    This macro was not mandated originally: define only if we know
    we won't break user code: when these are the locations we know.  */
 
-#ifndef YY_LOCATION_PRINT
-# if defined IDL_YYLTYPE_IS_TRIVIAL && IDL_YYLTYPE_IS_TRIVIAL
+# ifndef YYLOCATION_PRINT
+
+#  if defined YY_LOCATION_PRINT
+
+   /* Temporary convenience wrapper in case some people defined the
+      undocumented and private YY_LOCATION_PRINT macros.  */
+#   define YYLOCATION_PRINT(File, Loc)  YY_LOCATION_PRINT(File, *(Loc))
+
+#  elif defined IDL_YYLTYPE_IS_TRIVIAL && IDL_YYLTYPE_IS_TRIVIAL
 
 /* Print *YYLOCP on YYO.  Private, do not rely on its existence. */
 
@@ -1199,24 +1212,32 @@ yy_location_print_ (FILE *yyo, YYLTYPE const * const yylocp)
         res += YYFPRINTF (yyo, "-%d", end_col);
     }
   return res;
- }
+}
 
-#  define YY_LOCATION_PRINT(File, Loc)          \
-  yy_location_print_ (File, &(Loc))
+#   define YYLOCATION_PRINT  yy_location_print_
 
-# else
-#  define YY_LOCATION_PRINT(File, Loc) ((void) 0)
-# endif
-#endif
+    /* Temporary convenience wrapper in case some people defined the
+       undocumented and private YY_LOCATION_PRINT macros.  */
+#   define YY_LOCATION_PRINT(File, Loc)  YYLOCATION_PRINT(File, &(Loc))
+
+#  else
+
+#   define YYLOCATION_PRINT(File, Loc) ((void) 0)
+    /* Temporary convenience wrapper in case some people defined the
+       undocumented and private YY_LOCATION_PRINT macros.  */
+#   define YY_LOCATION_PRINT  YYLOCATION_PRINT
+
+#  endif
+# endif /* !defined YYLOCATION_PRINT */
 
 
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)                    \
+# define YY_SYMBOL_PRINT(Title, Kind, Value, Location)                    \
 do {                                                                      \
   if (yydebug)                                                            \
     {                                                                     \
       YYFPRINTF (stderr, "%s ", Title);                                   \
       yy_symbol_print (stderr,                                            \
-                  Type, Value, Location, pstate, result); \
+                  Kind, Value, Location, pstate, result); \
       YYFPRINTF (stderr, "\n");                                           \
     }                                                                     \
 } while (0)
@@ -1227,21 +1248,18 @@ do {                                                                      \
 `-----------------------------------*/
 
 static void
-yy_symbol_value_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp, idl_pstate_t *pstate, idl_retcode_t *result)
+yy_symbol_value_print (FILE *yyo,
+                       yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp, idl_pstate_t *pstate, idl_retcode_t *result)
 {
   FILE *yyoutput = yyo;
-  YYUSE (yyoutput);
-  YYUSE (yylocationp);
-  YYUSE (pstate);
-  YYUSE (result);
+  YY_USE (yyoutput);
+  YY_USE (yylocationp);
+  YY_USE (pstate);
+  YY_USE (result);
   if (!yyvaluep)
     return;
-# ifdef YYPRINT
-  if (yytype < YYNTOKENS)
-    YYPRINT (yyo, yytoknum[yytype], *yyvaluep);
-# endif
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-  YYUSE (yytype);
+  YY_USE (yykind);
   YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
 
@@ -1251,14 +1269,15 @@ yy_symbol_value_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep, YY
 `---------------------------*/
 
 static void
-yy_symbol_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp, idl_pstate_t *pstate, idl_retcode_t *result)
+yy_symbol_print (FILE *yyo,
+                 yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp, idl_pstate_t *pstate, idl_retcode_t *result)
 {
   YYFPRINTF (yyo, "%s %s (",
-             yytype < YYNTOKENS ? "token" : "nterm", yytname[yytype]);
+             yykind < YYNTOKENS ? "token" : "nterm", yysymbol_name (yykind));
 
-  YY_LOCATION_PRINT (yyo, *yylocationp);
+  YYLOCATION_PRINT (yyo, yylocationp);
   YYFPRINTF (yyo, ": ");
-  yy_symbol_value_print (yyo, yytype, yyvaluep, yylocationp, pstate, result);
+  yy_symbol_value_print (yyo, yykind, yyvaluep, yylocationp, pstate, result);
   YYFPRINTF (yyo, ")");
 }
 
@@ -1291,7 +1310,8 @@ do {                                                            \
 `------------------------------------------------*/
 
 static void
-yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp, YYLTYPE *yylsp, int yyrule, idl_pstate_t *pstate, idl_retcode_t *result)
+yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp, YYLTYPE *yylsp,
+                 int yyrule, idl_pstate_t *pstate, idl_retcode_t *result)
 {
   int yylno = yyrline[yyrule];
   int yynrhs = yyr2[yyrule];
@@ -1303,9 +1323,9 @@ yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp, YYLTYPE *yylsp, int yyrule, 
     {
       YYFPRINTF (stderr, "   $%d = ", yyi + 1);
       yy_symbol_print (stderr,
-                       yystos[+yyssp[yyi + 1 - yynrhs]],
-                       &yyvsp[(yyi + 1) - (yynrhs)]
-                       , &(yylsp[(yyi + 1) - (yynrhs)])                       , pstate, result);
+                       YY_ACCESSING_SYMBOL (+yyssp[yyi + 1 - yynrhs]),
+                       &yyvsp[(yyi + 1) - (yynrhs)],
+                       &(yylsp[(yyi + 1) - (yynrhs)]), pstate, result);
       YYFPRINTF (stderr, "\n");
     }
 }
@@ -1320,8 +1340,8 @@ do {                                    \
    multiple parsers can coexist.  */
 int yydebug;
 #else /* !IDL_YYDEBUG */
-# define YYDPRINTF(Args)
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)
+# define YYDPRINTF(Args) ((void) 0)
+# define YY_SYMBOL_PRINT(Title, Kind, Value, Location)
 # define YY_STACK_PRINT(Bottom, Top)
 # define YY_REDUCE_PRINT(Rule)
 #endif /* !IDL_YYDEBUG */
@@ -1342,718 +1362,525 @@ int yydebug;
 #ifndef YYMAXDEPTH
 # define YYMAXDEPTH 10000
 #endif
-
-
-#if YYERROR_VERBOSE
-
-# ifndef yystrlen
-#  if defined __GLIBC__ && defined _STRING_H
-#   define yystrlen(S) (YY_CAST (YYPTRDIFF_T, strlen (S)))
-#  else
-/* Return the length of YYSTR.  */
-static YYPTRDIFF_T
-yystrlen (const char *yystr)
-{
-  YYPTRDIFF_T yylen;
-  for (yylen = 0; yystr[yylen]; yylen++)
-    continue;
-  return yylen;
-}
-#  endif
-# endif
-
-# ifndef yystpcpy
-#  if defined __GLIBC__ && defined _STRING_H && defined _GNU_SOURCE
-#   define yystpcpy stpcpy
-#  else
-/* Copy YYSRC to YYDEST, returning the address of the terminating '\0' in
-   YYDEST.  */
-static char *
-yystpcpy (char *yydest, const char *yysrc)
-{
-  char *yyd = yydest;
-  const char *yys = yysrc;
-
-  while ((*yyd++ = *yys++) != '\0')
-    continue;
-
-  return yyd - 1;
-}
-#  endif
-# endif
-
-# ifndef yytnamerr
-/* Copy to YYRES the contents of YYSTR after stripping away unnecessary
-   quotes and backslashes, so that it's suitable for yyerror.  The
-   heuristic is that double-quoting is unnecessary unless the string
-   contains an apostrophe, a comma, or backslash (other than
-   backslash-backslash).  YYSTR is taken from yytname.  If YYRES is
-   null, do not copy; instead, return the length of what the result
-   would have been.  */
-static YYPTRDIFF_T
-yytnamerr (char *yyres, const char *yystr)
-{
-  if (*yystr == '"')
-    {
-      YYPTRDIFF_T yyn = 0;
-      char const *yyp = yystr;
-
-      for (;;)
-        switch (*++yyp)
-          {
-          case '\'':
-          case ',':
-            goto do_not_strip_quotes;
-
-          case '\\':
-            if (*++yyp != '\\')
-              goto do_not_strip_quotes;
-            else
-              goto append;
-
-          append:
-          default:
-            if (yyres)
-              yyres[yyn] = *yyp;
-            yyn++;
-            break;
-
-          case '"':
-            if (yyres)
-              yyres[yyn] = '\0';
-            return yyn;
-          }
-    do_not_strip_quotes: ;
-    }
-
-  if (yyres)
-    return yystpcpy (yyres, yystr) - yyres;
-  else
-    return yystrlen (yystr);
-}
-# endif
-
-/* Copy into *YYMSG, which is of size *YYMSG_ALLOC, an error message
-   about the unexpected token YYTOKEN for the state stack whose top is
-   YYSSP.
-
-   Return 0 if *YYMSG was successfully written.  Return 1 if *YYMSG is
-   not large enough to hold the message.  In that case, also set
-   *YYMSG_ALLOC to the required number of bytes.  Return 2 if the
-   required number of bytes is too large to store.  */
-static int
-yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
-                yy_state_t *yyssp, int yytoken)
-{
-  enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 5 };
-  /* Internationalized format string. */
-  const char *yyformat = YY_NULLPTR;
-  /* Arguments of yyformat: reported tokens (one for the "unexpected",
-     one per "expected"). */
-  char const *yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
-  /* Actual size of YYARG. */
-  int yycount = 0;
-  /* Cumulated lengths of YYARG.  */
-  YYPTRDIFF_T yysize = 0;
-
-  /* There are many possibilities here to consider:
-     - If this state is a consistent state with a default action, then
-       the only way this function was invoked is if the default action
-       is an error action.  In that case, don't check for expected
-       tokens because there are none.
-     - The only way there can be no lookahead present (in yychar) is if
-       this state is a consistent state with a default action.  Thus,
-       detecting the absence of a lookahead is sufficient to determine
-       that there is no unexpected or expected token to report.  In that
-       case, just report a simple "syntax error".
-     - Don't assume there isn't a lookahead just because this state is a
-       consistent state with a default action.  There might have been a
-       previous inconsistent state, consistent state with a non-default
-       action, or user semantic action that manipulated yychar.
-     - Of course, the expected token list depends on states to have
-       correct lookahead information, and it depends on the parser not
-       to perform extra reductions after fetching a lookahead from the
-       scanner and before detecting a syntax error.  Thus, state merging
-       (from LALR or IELR) and default reductions corrupt the expected
-       token list.  However, the list is correct for canonical LR with
-       one exception: it will still contain any token that will not be
-       accepted due to an error action in a later state.
-  */
-  if (yytoken != YYEMPTY)
-    {
-      int yyn = yypact[+*yyssp];
-      YYPTRDIFF_T yysize0 = yytnamerr (YY_NULLPTR, yytname[yytoken]);
-      yysize = yysize0;
-      yyarg[yycount++] = yytname[yytoken];
-      if (!yypact_value_is_default (yyn))
-        {
-          /* Start YYX at -YYN if negative to avoid negative indexes in
-             YYCHECK.  In other words, skip the first -YYN actions for
-             this state because they are default actions.  */
-          int yyxbegin = yyn < 0 ? -yyn : 0;
-          /* Stay within bounds of both yycheck and yytname.  */
-          int yychecklim = YYLAST - yyn + 1;
-          int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
-          int yyx;
-
-          for (yyx = yyxbegin; yyx < yyxend; ++yyx)
-            if (yycheck[yyx + yyn] == yyx && yyx != YYTERROR
-                && !yytable_value_is_error (yytable[yyx + yyn]))
-              {
-                if (yycount == YYERROR_VERBOSE_ARGS_MAXIMUM)
-                  {
-                    yycount = 1;
-                    yysize = yysize0;
-                    break;
-                  }
-                yyarg[yycount++] = yytname[yyx];
-                {
-                  YYPTRDIFF_T yysize1
-                    = yysize + yytnamerr (YY_NULLPTR, yytname[yyx]);
-                  if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
-                    yysize = yysize1;
-                  else
-                    return 2;
-                }
-              }
-        }
-    }
-
-  switch (yycount)
-    {
-# define YYCASE_(N, S)                      \
-      case N:                               \
-        yyformat = S;                       \
-      break
-    default: /* Avoid compiler warnings. */
-      YYCASE_(0, YY_("syntax error"));
-      YYCASE_(1, YY_("syntax error, unexpected %s"));
-      YYCASE_(2, YY_("syntax error, unexpected %s, expecting %s"));
-      YYCASE_(3, YY_("syntax error, unexpected %s, expecting %s or %s"));
-      YYCASE_(4, YY_("syntax error, unexpected %s, expecting %s or %s or %s"));
-      YYCASE_(5, YY_("syntax error, unexpected %s, expecting %s or %s or %s or %s"));
-# undef YYCASE_
-    }
-
+/* Parser data structure.  */
+struct yypstate
   {
-    /* Don't count the "%s"s in the final size, but reserve room for
-       the terminator.  */
-    YYPTRDIFF_T yysize1 = yysize + (yystrlen (yyformat) - 2 * yycount) + 1;
-    if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
-      yysize = yysize1;
-    else
-      return 2;
-  }
+    /* Number of syntax errors so far.  */
+    int yynerrs;
 
-  if (*yymsg_alloc < yysize)
-    {
-      *yymsg_alloc = 2 * yysize;
-      if (! (yysize <= *yymsg_alloc
-             && *yymsg_alloc <= YYSTACK_ALLOC_MAXIMUM))
-        *yymsg_alloc = YYSTACK_ALLOC_MAXIMUM;
-      return 1;
-    }
+    yy_state_fast_t yystate;
+    /* Number of tokens to shift before error messages enabled.  */
+    int yyerrstatus;
 
-  /* Avoid sprintf, as that infringes on the user's name space.
-     Don't have undefined behavior even if the translation
-     produced a string with the wrong number of "%s"s.  */
-  {
-    char *yyp = *yymsg;
-    int yyi = 0;
-    while ((*yyp = *yyformat) != '\0')
-      if (*yyp == '%' && yyformat[1] == 's' && yyi < yycount)
-        {
-          yyp += yytnamerr (yyp, yyarg[yyi++]);
-          yyformat += 2;
-        }
-      else
-        {
-          ++yyp;
-          ++yyformat;
-        }
-  }
-  return 0;
-}
-#endif /* YYERROR_VERBOSE */
+    /* Refer to the stacks through separate pointers, to allow yyoverflow
+       to reallocate them elsewhere.  */
+
+    /* Their size.  */
+    YYPTRDIFF_T yystacksize;
+
+    /* The state stack: array, bottom, top.  */
+    yy_state_t yyssa[YYINITDEPTH];
+    yy_state_t *yyss;
+    yy_state_t *yyssp;
+
+    /* The semantic value stack: array, bottom, top.  */
+    YYSTYPE yyvsa[YYINITDEPTH];
+    YYSTYPE *yyvs;
+    YYSTYPE *yyvsp;
+
+    /* The location stack: array, bottom, top.  */
+    YYLTYPE yylsa[YYINITDEPTH];
+    YYLTYPE *yyls;
+    YYLTYPE *yylsp;
+    /* Whether this instance has not started parsing yet.
+     * If 2, it corresponds to a finished parsing.  */
+    int yynew;
+  };
+
+
+
+
+
 
 /*-----------------------------------------------.
 | Release the memory associated to this symbol.  |
 `-----------------------------------------------*/
 
 static void
-yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocationp, idl_pstate_t *pstate, idl_retcode_t *result)
+yydestruct (const char *yymsg,
+            yysymbol_kind_t yykind, YYSTYPE *yyvaluep, YYLTYPE *yylocationp, idl_pstate_t *pstate, idl_retcode_t *result)
 {
-  YYUSE (yyvaluep);
-  YYUSE (yylocationp);
-  YYUSE (pstate);
-  YYUSE (result);
+  YY_USE (yyvaluep);
+  YY_USE (yylocationp);
+  YY_USE (pstate);
+  YY_USE (result);
   if (!yymsg)
     yymsg = "Deleting";
-  YY_SYMBOL_PRINT (yymsg, yytype, yyvaluep, yylocationp);
+  YY_SYMBOL_PRINT (yymsg, yykind, yyvaluep, yylocationp);
 
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-  switch (yytype)
+  switch (yykind)
     {
-    case 78: /* definitions  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_definitions: /* definitions  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).node)); }
-#line 1601 "parser.c"
+#line 1428 "parser.c"
         break;
 
-    case 79: /* definition  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_definition: /* definition  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).node)); }
-#line 1607 "parser.c"
+#line 1434 "parser.c"
         break;
 
-    case 80: /* module_dcl  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_module_dcl: /* module_dcl  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).module_dcl)); }
-#line 1613 "parser.c"
+#line 1440 "parser.c"
         break;
 
-    case 81: /* module_header  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_module_header: /* module_header  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).module_dcl)); }
-#line 1619 "parser.c"
+#line 1446 "parser.c"
         break;
 
-    case 82: /* scoped_name  */
-#line 209 "src/parser.y"
+    case YYSYMBOL_scoped_name: /* scoped_name  */
+#line 210 "src/parser.y"
             { idl_delete_scoped_name(((*yyvaluep).scoped_name)); }
-#line 1625 "parser.c"
+#line 1452 "parser.c"
         break;
 
-    case 83: /* const_dcl  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_const_dcl: /* const_dcl  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).const_dcl)); }
-#line 1631 "parser.c"
+#line 1458 "parser.c"
         break;
 
-    case 84: /* const_type  */
-#line 212 "src/parser.y"
+    case YYSYMBOL_const_type: /* const_type  */
+#line 213 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).type_spec)); }
-#line 1637 "parser.c"
+#line 1464 "parser.c"
         break;
 
-    case 85: /* const_expr  */
-#line 212 "src/parser.y"
+    case YYSYMBOL_const_expr: /* const_expr  */
+#line 213 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).const_expr)); }
-#line 1643 "parser.c"
+#line 1470 "parser.c"
         break;
 
-    case 86: /* or_expr  */
-#line 212 "src/parser.y"
+    case YYSYMBOL_or_expr: /* or_expr  */
+#line 213 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).const_expr)); }
-#line 1649 "parser.c"
+#line 1476 "parser.c"
         break;
 
-    case 87: /* xor_expr  */
-#line 212 "src/parser.y"
+    case YYSYMBOL_xor_expr: /* xor_expr  */
+#line 213 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).const_expr)); }
-#line 1655 "parser.c"
+#line 1482 "parser.c"
         break;
 
-    case 88: /* and_expr  */
-#line 212 "src/parser.y"
+    case YYSYMBOL_and_expr: /* and_expr  */
+#line 213 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).const_expr)); }
-#line 1661 "parser.c"
+#line 1488 "parser.c"
         break;
 
-    case 89: /* shift_expr  */
-#line 212 "src/parser.y"
+    case YYSYMBOL_shift_expr: /* shift_expr  */
+#line 213 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).const_expr)); }
-#line 1667 "parser.c"
+#line 1494 "parser.c"
         break;
 
-    case 91: /* add_expr  */
-#line 212 "src/parser.y"
+    case YYSYMBOL_add_expr: /* add_expr  */
+#line 213 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).const_expr)); }
-#line 1673 "parser.c"
+#line 1500 "parser.c"
         break;
 
-    case 93: /* mult_expr  */
-#line 212 "src/parser.y"
+    case YYSYMBOL_mult_expr: /* mult_expr  */
+#line 213 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).const_expr)); }
-#line 1679 "parser.c"
+#line 1506 "parser.c"
         break;
 
-    case 95: /* unary_expr  */
-#line 212 "src/parser.y"
+    case YYSYMBOL_unary_expr: /* unary_expr  */
+#line 213 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).const_expr)); }
-#line 1685 "parser.c"
+#line 1512 "parser.c"
         break;
 
-    case 97: /* primary_expr  */
-#line 212 "src/parser.y"
+    case YYSYMBOL_primary_expr: /* primary_expr  */
+#line 213 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).const_expr)); }
-#line 1691 "parser.c"
+#line 1518 "parser.c"
         break;
 
-    case 98: /* literal  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_literal: /* literal  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).literal)); }
-#line 1697 "parser.c"
+#line 1524 "parser.c"
         break;
 
-    case 100: /* string_literal  */
-#line 204 "src/parser.y"
+    case YYSYMBOL_string_literal: /* string_literal  */
+#line 205 "src/parser.y"
             { idl_free(((*yyvaluep).string_literal)); }
-#line 1703 "parser.c"
+#line 1530 "parser.c"
         break;
 
-    case 101: /* positive_int_const  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_positive_int_const: /* positive_int_const  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).literal)); }
-#line 1709 "parser.c"
+#line 1536 "parser.c"
         break;
 
-    case 102: /* type_dcl  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_type_dcl: /* type_dcl  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).node)); }
-#line 1715 "parser.c"
+#line 1542 "parser.c"
         break;
 
-    case 103: /* type_spec  */
-#line 212 "src/parser.y"
+    case YYSYMBOL_type_spec: /* type_spec  */
+#line 213 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).type_spec)); }
-#line 1721 "parser.c"
+#line 1548 "parser.c"
         break;
 
-    case 104: /* simple_type_spec  */
-#line 212 "src/parser.y"
+    case YYSYMBOL_simple_type_spec: /* simple_type_spec  */
+#line 213 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).type_spec)); }
-#line 1727 "parser.c"
+#line 1554 "parser.c"
         break;
 
-    case 114: /* template_type_spec  */
-#line 212 "src/parser.y"
+    case YYSYMBOL_template_type_spec: /* template_type_spec  */
+#line 213 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).type_spec)); }
-#line 1733 "parser.c"
+#line 1560 "parser.c"
         break;
 
-    case 115: /* sequence_type  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_sequence_type: /* sequence_type  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).sequence)); }
-#line 1739 "parser.c"
+#line 1566 "parser.c"
         break;
 
-    case 116: /* string_type  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_string_type: /* string_type  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).string)); }
-#line 1745 "parser.c"
+#line 1572 "parser.c"
         break;
 
-    case 117: /* constr_type_dcl  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_constr_type_dcl: /* constr_type_dcl  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).node)); }
-#line 1751 "parser.c"
+#line 1578 "parser.c"
         break;
 
-    case 118: /* struct_dcl  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_struct_dcl: /* struct_dcl  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).node)); }
-#line 1757 "parser.c"
+#line 1584 "parser.c"
         break;
 
-    case 119: /* struct_forward_dcl  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_struct_forward_dcl: /* struct_forward_dcl  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).forward)); }
-#line 1763 "parser.c"
+#line 1590 "parser.c"
         break;
 
-    case 120: /* struct_def  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_struct_def: /* struct_def  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).struct_dcl)); }
-#line 1769 "parser.c"
+#line 1596 "parser.c"
         break;
 
-    case 121: /* struct_header  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_struct_header: /* struct_header  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).struct_dcl)); }
-#line 1775 "parser.c"
+#line 1602 "parser.c"
         break;
 
-    case 122: /* struct_inherit_spec  */
-#line 212 "src/parser.y"
+    case YYSYMBOL_struct_inherit_spec: /* struct_inherit_spec  */
+#line 213 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).type_spec)); }
-#line 1781 "parser.c"
+#line 1608 "parser.c"
         break;
 
-    case 123: /* struct_body  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_struct_body: /* struct_body  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).member)); }
-#line 1787 "parser.c"
+#line 1614 "parser.c"
         break;
 
-    case 124: /* members  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_members: /* members  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).member)); }
-#line 1793 "parser.c"
+#line 1620 "parser.c"
         break;
 
-    case 125: /* member  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_member: /* member  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).member)); }
-#line 1799 "parser.c"
+#line 1626 "parser.c"
         break;
 
-    case 126: /* union_dcl  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_union_dcl: /* union_dcl  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).node)); }
-#line 1805 "parser.c"
+#line 1632 "parser.c"
         break;
 
-    case 127: /* union_def  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_union_def: /* union_def  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).union_dcl)); }
-#line 1811 "parser.c"
+#line 1638 "parser.c"
         break;
 
-    case 128: /* union_forward_dcl  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_union_forward_dcl: /* union_forward_dcl  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).forward)); }
-#line 1817 "parser.c"
+#line 1644 "parser.c"
         break;
 
-    case 129: /* union_header  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_union_header: /* union_header  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).union_dcl)); }
-#line 1823 "parser.c"
+#line 1650 "parser.c"
         break;
 
-    case 130: /* switch_header  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_switch_header: /* switch_header  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).switch_type_spec)); }
-#line 1829 "parser.c"
+#line 1656 "parser.c"
         break;
 
-    case 131: /* switch_type_spec  */
-#line 212 "src/parser.y"
+    case YYSYMBOL_switch_type_spec: /* switch_type_spec  */
+#line 213 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).type_spec)); }
-#line 1835 "parser.c"
+#line 1662 "parser.c"
         break;
 
-    case 132: /* switch_body  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_switch_body: /* switch_body  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep)._case)); }
-#line 1841 "parser.c"
+#line 1668 "parser.c"
         break;
 
-    case 133: /* case  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_case: /* case  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep)._case)); }
-#line 1847 "parser.c"
+#line 1674 "parser.c"
         break;
 
-    case 134: /* case_labels  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_case_labels: /* case_labels  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).case_label)); }
-#line 1853 "parser.c"
+#line 1680 "parser.c"
         break;
 
-    case 135: /* case_label  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_case_label: /* case_label  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).case_label)); }
-#line 1859 "parser.c"
+#line 1686 "parser.c"
         break;
 
-    case 136: /* element_spec  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_element_spec: /* element_spec  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep)._case)); }
-#line 1865 "parser.c"
+#line 1692 "parser.c"
         break;
 
-    case 137: /* enum_dcl  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_enum_dcl: /* enum_dcl  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).node)); }
-#line 1871 "parser.c"
+#line 1698 "parser.c"
         break;
 
-    case 138: /* enum_def  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_enum_def: /* enum_def  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).enum_dcl)); }
-#line 1877 "parser.c"
+#line 1704 "parser.c"
         break;
 
-    case 139: /* enumerators  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_enumerators: /* enumerators  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).enumerator)); }
-#line 1883 "parser.c"
+#line 1710 "parser.c"
         break;
 
-    case 140: /* enumerator  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_enumerator: /* enumerator  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).enumerator)); }
-#line 1889 "parser.c"
+#line 1716 "parser.c"
         break;
 
-    case 141: /* bitmask_dcl  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_bitmask_dcl: /* bitmask_dcl  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).node)); }
-#line 1895 "parser.c"
+#line 1722 "parser.c"
         break;
 
-    case 142: /* bitmask_def  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_bitmask_def: /* bitmask_def  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).bitmask_dcl)); }
-#line 1901 "parser.c"
+#line 1728 "parser.c"
         break;
 
-    case 143: /* bit_values  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_bit_values: /* bit_values  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).bit_value)); }
-#line 1907 "parser.c"
+#line 1734 "parser.c"
         break;
 
-    case 144: /* bit_value  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_bit_value: /* bit_value  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).bit_value)); }
-#line 1913 "parser.c"
+#line 1740 "parser.c"
         break;
 
-    case 145: /* array_declarator  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_array_declarator: /* array_declarator  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).declarator)); }
-#line 1919 "parser.c"
+#line 1746 "parser.c"
         break;
 
-    case 146: /* fixed_array_sizes  */
-#line 212 "src/parser.y"
+    case YYSYMBOL_fixed_array_sizes: /* fixed_array_sizes  */
+#line 213 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).const_expr)); }
-#line 1925 "parser.c"
+#line 1752 "parser.c"
         break;
 
-    case 147: /* fixed_array_size  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_fixed_array_size: /* fixed_array_size  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).literal)); }
-#line 1931 "parser.c"
+#line 1758 "parser.c"
         break;
 
-    case 148: /* simple_declarator  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_simple_declarator: /* simple_declarator  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).declarator)); }
-#line 1937 "parser.c"
+#line 1764 "parser.c"
         break;
 
-    case 149: /* complex_declarator  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_complex_declarator: /* complex_declarator  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).declarator)); }
-#line 1943 "parser.c"
+#line 1770 "parser.c"
         break;
 
-    case 150: /* typedef_dcl  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_typedef_dcl: /* typedef_dcl  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).typedef_dcl)); }
-#line 1949 "parser.c"
+#line 1776 "parser.c"
         break;
 
-    case 151: /* declarators  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_declarators: /* declarators  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).declarator)); }
-#line 1955 "parser.c"
+#line 1782 "parser.c"
         break;
 
-    case 152: /* declarator  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_declarator: /* declarator  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).declarator)); }
-#line 1961 "parser.c"
+#line 1788 "parser.c"
         break;
 
-    case 153: /* identifier  */
-#line 206 "src/parser.y"
+    case YYSYMBOL_identifier: /* identifier  */
+#line 207 "src/parser.y"
             { idl_delete_name(((*yyvaluep).name)); }
-#line 1967 "parser.c"
+#line 1794 "parser.c"
         break;
 
-    case 154: /* annotation_dcl  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_annotation_dcl: /* annotation_dcl  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).annotation)); }
-#line 1973 "parser.c"
+#line 1800 "parser.c"
         break;
 
-    case 155: /* annotation_header  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_annotation_header: /* annotation_header  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).annotation)); }
-#line 1979 "parser.c"
+#line 1806 "parser.c"
         break;
 
-    case 157: /* annotation_body  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_annotation_body: /* annotation_body  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).annotation_member)); }
-#line 1985 "parser.c"
+#line 1812 "parser.c"
         break;
 
-    case 158: /* annotation_member  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_annotation_member: /* annotation_member  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).annotation_member)); }
-#line 1991 "parser.c"
+#line 1818 "parser.c"
         break;
 
-    case 159: /* annotation_member_type  */
-#line 212 "src/parser.y"
+    case YYSYMBOL_annotation_member_type: /* annotation_member_type  */
+#line 213 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).type_spec)); }
-#line 1997 "parser.c"
+#line 1824 "parser.c"
         break;
 
-    case 160: /* annotation_member_default  */
-#line 212 "src/parser.y"
+    case YYSYMBOL_annotation_member_default: /* annotation_member_default  */
+#line 213 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).const_expr)); }
-#line 2003 "parser.c"
+#line 1830 "parser.c"
         break;
 
-    case 161: /* any_const_type  */
-#line 212 "src/parser.y"
+    case YYSYMBOL_any_const_type: /* any_const_type  */
+#line 213 "src/parser.y"
             { idl_unreference_node(((*yyvaluep).type_spec)); }
-#line 2009 "parser.c"
+#line 1836 "parser.c"
         break;
 
-    case 162: /* annotations  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_annotations: /* annotations  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).annotation_appl)); }
-#line 2015 "parser.c"
+#line 1842 "parser.c"
         break;
 
-    case 163: /* annotation_appls  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_annotation_appls: /* annotation_appls  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).annotation_appl)); }
-#line 2021 "parser.c"
+#line 1848 "parser.c"
         break;
 
-    case 164: /* annotation_appl  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_annotation_appl: /* annotation_appl  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).annotation_appl)); }
-#line 2027 "parser.c"
+#line 1854 "parser.c"
         break;
 
-    case 165: /* annotation_appl_header  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_annotation_appl_header: /* annotation_appl_header  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).annotation_appl)); }
-#line 2033 "parser.c"
+#line 1860 "parser.c"
         break;
 
-    case 167: /* annotation_appl_name  */
-#line 209 "src/parser.y"
+    case YYSYMBOL_annotation_appl_name: /* annotation_appl_name  */
+#line 210 "src/parser.y"
             { idl_delete_scoped_name(((*yyvaluep).scoped_name)); }
-#line 2039 "parser.c"
+#line 1866 "parser.c"
         break;
 
-    case 168: /* annotation_appl_params  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_annotation_appl_params: /* annotation_appl_params  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).annotation_appl_param)); }
-#line 2045 "parser.c"
+#line 1872 "parser.c"
         break;
 
-    case 169: /* annotation_appl_keyword_params  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_annotation_appl_keyword_params: /* annotation_appl_keyword_params  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).annotation_appl_param)); }
-#line 2051 "parser.c"
+#line 1878 "parser.c"
         break;
 
-    case 170: /* annotation_appl_keyword_param  */
-#line 215 "src/parser.y"
+    case YYSYMBOL_annotation_appl_keyword_param: /* annotation_appl_keyword_param  */
+#line 216 "src/parser.y"
             { idl_delete_node(((*yyvaluep).annotation_appl_param)); }
-#line 2057 "parser.c"
+#line 1884 "parser.c"
         break;
 
       default:
@@ -2064,73 +1891,7 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
 
 
 
-struct yypstate
-  {
-    /* Number of syntax errors so far.  */
-    int yynerrs;
 
-    yy_state_fast_t yystate;
-    /* Number of tokens to shift before error messages enabled.  */
-    int yyerrstatus;
-
-    /* The stacks and their tools:
-       'yyss': related to states.
-       'yyvs': related to semantic values.
-       'yyls': related to locations.
-
-       Refer to the stacks through separate pointers, to allow yyoverflow
-       to reallocate them elsewhere.  */
-
-    /* The state stack.  */
-    yy_state_t yyssa[YYINITDEPTH];
-    yy_state_t *yyss;
-    yy_state_t *yyssp;
-
-    /* The semantic value stack.  */
-    YYSTYPE yyvsa[YYINITDEPTH];
-    YYSTYPE *yyvs;
-    YYSTYPE *yyvsp;
-
-    /* The location stack.  */
-    YYLTYPE yylsa[YYINITDEPTH];
-    YYLTYPE *yyls;
-    YYLTYPE *yylsp;
-
-    /* The locations where the error started and ended.  */
-    YYLTYPE yyerror_range[3];
-
-    YYPTRDIFF_T yystacksize;
-    /* Used to determine if this is the first time this instance has
-       been used.  */
-    int yynew;
-  };
-
-/* Initialize the parser data structure.  */
-yypstate *
-yypstate_new (void)
-{
-  yypstate *yyps;
-  yyps = YY_CAST (yypstate *, malloc (sizeof *yyps));
-  if (!yyps)
-    return YY_NULLPTR;
-  yyps->yynew = 1;
-  return yyps;
-}
-
-void
-yypstate_delete (yypstate *yyps)
-{
-  if (yyps)
-    {
-#ifndef yyoverflow
-      /* If the stack was reallocated but the parse did not complete, then the
-         stack still needs to be freed.  */
-      if (!yyps->yynew && yyps->yyss != yyps->yyssa)
-        YYSTACK_FREE (yyps->yyss);
-#endif
-      free (yyps);
-    }
-}
 
 #define idl_yynerrs yyps->idl_yynerrs
 #define yystate yyps->yystate
@@ -2144,8 +1905,57 @@ yypstate_delete (yypstate *yyps)
 #define yylsa yyps->yylsa
 #define yyls yyps->yyls
 #define yylsp yyps->yylsp
-#define yyerror_range yyps->yyerror_range
 #define yystacksize yyps->yystacksize
+
+/* Initialize the parser data structure.  */
+static void
+yypstate_clear (yypstate *yyps)
+{
+  yynerrs = 0;
+  yystate = 0;
+  yyerrstatus = 0;
+
+  yyssp = yyss;
+  yyvsp = yyvs;
+  yylsp = yyls;
+
+  /* Initialize the state stack, in case yypcontext_expected_tokens is
+     called before the first call to yyparse. */
+  *yyssp = 0;
+  yyps->yynew = 1;
+}
+
+/* Initialize the parser data structure.  */
+yypstate *
+yypstate_new (void)
+{
+  yypstate *yyps;
+  yyps = YY_CAST (yypstate *, YYMALLOC (sizeof *yyps));
+  if (!yyps)
+    return YY_NULLPTR;
+  yystacksize = YYINITDEPTH;
+  yyss = yyssa;
+  yyvs = yyvsa;
+  yyls = yylsa;
+  yypstate_clear (yyps);
+  return yyps;
+}
+
+void
+yypstate_delete (yypstate *yyps)
+{
+  if (yyps)
+    {
+#ifndef yyoverflow
+      /* If the stack was reallocated but the parse did not complete, then the
+         stack still needs to be freed.  */
+      if (yyss != yyssa)
+        YYSTACK_FREE (yyss);
+#endif
+      YYFREE (yyps);
+    }
+}
+
 
 
 /*---------------.
@@ -2153,9 +1963,10 @@ yypstate_delete (yypstate *yyps)
 `---------------*/
 
 int
-yypush_parse (yypstate *yyps, int yypushed_char, YYSTYPE const *yypushed_val, YYLTYPE *yypushed_loc, idl_pstate_t *pstate, idl_retcode_t *result)
+yypush_parse (yypstate *yyps,
+              int yypushed_char, YYSTYPE const *yypushed_val, YYLTYPE *yypushed_loc, idl_pstate_t *pstate, idl_retcode_t *result)
 {
-/* The lookahead symbol.  */
+/* Lookahead token kind.  */
 int yychar;
 
 
@@ -2174,20 +1985,19 @@ static YYLTYPE yyloc_default
 YYLTYPE yylloc = yyloc_default;
 
   int yyn;
+  /* The return value of yyparse.  */
   int yyresult;
-  /* Lookahead token as an internal (translated) token number.  */
-  int yytoken = 0;
+  /* Lookahead symbol kind.  */
+  yysymbol_kind_t yytoken = YYSYMBOL_YYEMPTY;
   /* The variables used to return semantic value and location from the
      action routines.  */
   YYSTYPE yyval;
   YYLTYPE yyloc;
 
-#if YYERROR_VERBOSE
-  /* Buffer for error messages, and its allocated size.  */
-  char yymsgbuf[128];
-  char *yymsg = yymsgbuf;
-  YYPTRDIFF_T yymsg_alloc = sizeof yymsgbuf;
-#endif
+  /* The locations where the error started and ended.  */
+  YYLTYPE yyerror_range[3];
+
+
 
 #define YYPOPSTACK(N)   (yyvsp -= (N), yyssp -= (N), yylsp -= (N))
 
@@ -2195,23 +2005,24 @@ YYLTYPE yylloc = yyloc_default;
      Keep to zero when no symbol should be popped.  */
   int yylen = 0;
 
-  if (!yyps->yynew)
+  switch (yyps->yynew)
     {
+    case 0:
       yyn = yypact[yystate];
       goto yyread_pushed_token;
-    }
 
-  yyssp = yyss = yyssa;
-  yyvsp = yyvs = yyvsa;
-  yylsp = yyls = yylsa;
-  yystacksize = YYINITDEPTH;
+    case 2:
+      yypstate_clear (yyps);
+      break;
+
+    default:
+      break;
+    }
 
   YYDPRINTF ((stderr, "Starting parse\n"));
 
-  yystate = 0;
-  yyerrstatus = 0;
-  yynerrs = 0;
-  yychar = YYEMPTY; /* Cause a token to be read.  */
+  yychar = IDL_YYEMPTY; /* Cause a token to be read.  */
+
   yylsp[0] = *yypushed_loc;
   goto yysetstate;
 
@@ -2234,10 +2045,11 @@ yysetstate:
   YY_IGNORE_USELESS_CAST_BEGIN
   *yyssp = YY_CAST (yy_state_t, yystate);
   YY_IGNORE_USELESS_CAST_END
+  YY_STACK_PRINT (yyss, yyssp);
 
   if (yyss + yystacksize - 1 <= yyssp)
 #if !defined yyoverflow && !defined YYSTACK_RELOCATE
-    goto yyexhaustedlab;
+    YYNOMEM;
 #else
     {
       /* Get the current used size of the three stacks, in elements.  */
@@ -2268,7 +2080,7 @@ yysetstate:
 # else /* defined YYSTACK_RELOCATE */
       /* Extend the stack our own way.  */
       if (YYMAXDEPTH <= yystacksize)
-        goto yyexhaustedlab;
+        YYNOMEM;
       yystacksize *= 2;
       if (YYMAXDEPTH < yystacksize)
         yystacksize = YYMAXDEPTH;
@@ -2279,11 +2091,11 @@ yysetstate:
           YY_CAST (union yyalloc *,
                    YYSTACK_ALLOC (YY_CAST (YYSIZE_T, YYSTACK_BYTES (yystacksize))));
         if (! yyptr)
-          goto yyexhaustedlab;
+          YYNOMEM;
         YYSTACK_RELOCATE (yyss_alloc, yyss);
         YYSTACK_RELOCATE (yyvs_alloc, yyvs);
         YYSTACK_RELOCATE (yyls_alloc, yyls);
-# undef YYSTACK_RELOCATE
+#  undef YYSTACK_RELOCATE
         if (yyss1 != yyssa)
           YYSTACK_FREE (yyss1);
       }
@@ -2302,6 +2114,7 @@ yysetstate:
         YYABORT;
     }
 #endif /* !defined yyoverflow && !defined YYSTACK_RELOCATE */
+
 
   if (yystate == YYFINAL)
     YYACCEPT;
@@ -2323,8 +2136,8 @@ yybackup:
 
   /* Not known => get a lookahead token if don't already have one.  */
 
-  /* YYCHAR is either YYEMPTY or YYEOF or a valid lookahead symbol.  */
-  if (yychar == YYEMPTY)
+  /* YYCHAR is either empty, or end-of-input, or a valid lookahead.  */
+  if (yychar == IDL_YYEMPTY)
     {
       if (!yyps->yynew)
         {
@@ -2334,7 +2147,7 @@ yybackup:
         }
       yyps->yynew = 0;
 yyread_pushed_token:
-      YYDPRINTF ((stderr, "Reading a token: "));
+      YYDPRINTF ((stderr, "Reading a token\n"));
       yychar = yypushed_char;
       if (yypushed_val)
         yylval = *yypushed_val;
@@ -2342,10 +2155,22 @@ yyread_pushed_token:
         yylloc = *yypushed_loc;
     }
 
-  if (yychar <= YYEOF)
+  if (yychar <= IDL_YYEOF)
     {
-      yychar = yytoken = YYEOF;
+      yychar = IDL_YYEOF;
+      yytoken = YYSYMBOL_YYEOF;
       YYDPRINTF ((stderr, "Now at end of input.\n"));
+    }
+  else if (yychar == IDL_YYerror)
+    {
+      /* The scanner already issued an error message, process directly
+         to error recovery.  But do not keep the error token as
+         lookahead, it is too special and may lead us to an endless
+         loop in error recovery. */
+      yychar = IDL_YYUNDEF;
+      yytoken = YYSYMBOL_YYerror;
+      yyerror_range[1] = yylloc;
+      goto yyerrlab1;
     }
   else
     {
@@ -2381,7 +2206,7 @@ yyread_pushed_token:
   *++yylsp = yylloc;
 
   /* Discard the shifted token.  */
-  yychar = YYEMPTY;
+  yychar = IDL_YYEMPTY;
   goto yynewstate;
 
 
@@ -2418,138 +2243,138 @@ yyreduce:
   YY_REDUCE_PRINT (yyn);
   switch (yyn)
     {
-  case 2:
-#line 288 "src/parser.y"
+  case 2: /* specification: %empty  */
+#line 289 "src/parser.y"
       { pstate->root = NULL; }
-#line 2425 "parser.c"
+#line 2250 "parser.c"
     break;
 
-  case 3:
-#line 290 "src/parser.y"
+  case 3: /* specification: definitions  */
+#line 291 "src/parser.y"
       { pstate->root = (yyvsp[0].node); }
-#line 2431 "parser.c"
+#line 2256 "parser.c"
     break;
 
-  case 4:
-#line 295 "src/parser.y"
+  case 4: /* definitions: definition  */
+#line 296 "src/parser.y"
       { (yyval.node) = (yyvsp[0].node); }
-#line 2437 "parser.c"
+#line 2262 "parser.c"
     break;
 
-  case 5:
-#line 297 "src/parser.y"
+  case 5: /* definitions: definitions definition  */
+#line 298 "src/parser.y"
       { (yyval.node) = idl_push_node((yyvsp[-1].node), (yyvsp[0].node)); }
-#line 2443 "parser.c"
+#line 2268 "parser.c"
     break;
 
-  case 6:
-#line 302 "src/parser.y"
+  case 6: /* definition: annotation_dcl ';'  */
+#line 303 "src/parser.y"
       { (yyval.node) = (yyvsp[-1].annotation); }
-#line 2449 "parser.c"
+#line 2274 "parser.c"
     break;
 
-  case 7:
-#line 304 "src/parser.y"
+  case 7: /* definition: annotations module_dcl ';'  */
+#line 305 "src/parser.y"
       { TRY(idl_annotate(pstate, (yyvsp[-1].module_dcl), (yyvsp[-2].annotation_appl)));
         (yyval.node) = (yyvsp[-1].module_dcl);
       }
-#line 2457 "parser.c"
+#line 2282 "parser.c"
     break;
 
-  case 8:
-#line 308 "src/parser.y"
+  case 8: /* definition: annotations const_dcl ';'  */
+#line 309 "src/parser.y"
       { TRY(idl_annotate(pstate, (yyvsp[-1].const_dcl), (yyvsp[-2].annotation_appl)));
         (yyval.node) = (yyvsp[-1].const_dcl);
       }
-#line 2465 "parser.c"
+#line 2290 "parser.c"
     break;
 
-  case 9:
-#line 312 "src/parser.y"
+  case 9: /* definition: annotations type_dcl ';'  */
+#line 313 "src/parser.y"
       { TRY(idl_annotate(pstate, (yyvsp[-1].node), (yyvsp[-2].annotation_appl)));
         (yyval.node) = (yyvsp[-1].node);
       }
-#line 2473 "parser.c"
+#line 2298 "parser.c"
     break;
 
-  case 10:
-#line 319 "src/parser.y"
+  case 10: /* module_dcl: module_header '{' definitions '}'  */
+#line 320 "src/parser.y"
       { TRY(idl_finalize_module(pstate, LOC((yylsp[-3]).first, (yylsp[0]).last), (yyvsp[-3].module_dcl), (yyvsp[-1].node)));
         (yyval.module_dcl) = (yyvsp[-3].module_dcl);
       }
-#line 2481 "parser.c"
+#line 2306 "parser.c"
     break;
 
-  case 11:
-#line 326 "src/parser.y"
+  case 11: /* module_header: "module" identifier  */
+#line 327 "src/parser.y"
       { TRY(idl_create_module(pstate, LOC((yylsp[-1]).first, (yylsp[0]).last), (yyvsp[0].name), &(yyval.module_dcl))); }
-#line 2487 "parser.c"
+#line 2312 "parser.c"
     break;
 
-  case 12:
-#line 331 "src/parser.y"
+  case 12: /* scoped_name: identifier  */
+#line 332 "src/parser.y"
       { TRY(idl_create_scoped_name(pstate, &(yylsp[0]), (yyvsp[0].name), false, &(yyval.scoped_name))); }
-#line 2493 "parser.c"
+#line 2318 "parser.c"
     break;
 
-  case 13:
-#line 333 "src/parser.y"
+  case 13: /* scoped_name: IDL_TOKEN_SCOPE identifier  */
+#line 334 "src/parser.y"
       { TRY(idl_create_scoped_name(pstate, LOC((yylsp[-1]).first, (yylsp[0]).last), (yyvsp[0].name), true, &(yyval.scoped_name))); }
-#line 2499 "parser.c"
+#line 2324 "parser.c"
     break;
 
-  case 14:
-#line 335 "src/parser.y"
+  case 14: /* scoped_name: scoped_name IDL_TOKEN_SCOPE identifier  */
+#line 336 "src/parser.y"
       { TRY(idl_push_scoped_name(pstate, (yyvsp[-2].scoped_name), (yyvsp[0].name)));
         (yyval.scoped_name) = (yyvsp[-2].scoped_name);
       }
-#line 2507 "parser.c"
+#line 2332 "parser.c"
     break;
 
-  case 15:
-#line 342 "src/parser.y"
+  case 15: /* const_dcl: "const" const_type identifier '=' const_expr  */
+#line 343 "src/parser.y"
       { TRY(idl_create_const(pstate, LOC((yylsp[-4]).first, (yylsp[0]).last), (yyvsp[-3].type_spec), (yyvsp[-2].name), (yyvsp[0].const_expr), &(yyval.const_dcl))); }
-#line 2513 "parser.c"
+#line 2338 "parser.c"
     break;
 
-  case 16:
-#line 347 "src/parser.y"
+  case 16: /* const_type: integer_type  */
+#line 348 "src/parser.y"
       { TRY(idl_create_base_type(pstate, &(yylsp[0]), (yyvsp[0].kind), &(yyval.type_spec))); }
-#line 2519 "parser.c"
+#line 2344 "parser.c"
     break;
 
-  case 17:
-#line 349 "src/parser.y"
+  case 17: /* const_type: floating_pt_type  */
+#line 350 "src/parser.y"
       { TRY(idl_create_base_type(pstate, &(yylsp[0]), (yyvsp[0].kind), &(yyval.type_spec))); }
-#line 2525 "parser.c"
+#line 2350 "parser.c"
     break;
 
-  case 18:
-#line 351 "src/parser.y"
+  case 18: /* const_type: char_type  */
+#line 352 "src/parser.y"
       { TRY(idl_create_base_type(pstate, &(yylsp[0]), (yyvsp[0].kind), &(yyval.type_spec))); }
-#line 2531 "parser.c"
+#line 2356 "parser.c"
     break;
 
-  case 19:
-#line 353 "src/parser.y"
+  case 19: /* const_type: boolean_type  */
+#line 354 "src/parser.y"
       { TRY(idl_create_base_type(pstate, &(yylsp[0]), (yyvsp[0].kind), &(yyval.type_spec))); }
-#line 2537 "parser.c"
+#line 2362 "parser.c"
     break;
 
-  case 20:
-#line 355 "src/parser.y"
+  case 20: /* const_type: octet_type  */
+#line 356 "src/parser.y"
       { TRY(idl_create_base_type(pstate, &(yylsp[0]), (yyvsp[0].kind), &(yyval.type_spec))); }
-#line 2543 "parser.c"
+#line 2368 "parser.c"
     break;
 
-  case 21:
-#line 357 "src/parser.y"
+  case 21: /* const_type: string_type  */
+#line 358 "src/parser.y"
       { (yyval.type_spec) = (idl_type_spec_t *)(yyvsp[0].string); }
-#line 2549 "parser.c"
+#line 2374 "parser.c"
     break;
 
-  case 22:
-#line 359 "src/parser.y"
+  case 22: /* const_type: scoped_name  */
+#line 360 "src/parser.y"
       { idl_node_t *node;
         const idl_declaration_t *declaration;
         static const char fmt[] =
@@ -2561,152 +2386,152 @@ yyreduce:
         (yyval.type_spec) = idl_reference_node((idl_node_t *)declaration->node);
         idl_delete_scoped_name((yyvsp[0].scoped_name));
       }
-#line 2565 "parser.c"
+#line 2390 "parser.c"
     break;
 
-  case 23:
-#line 372 "src/parser.y"
+  case 23: /* const_expr: or_expr  */
+#line 373 "src/parser.y"
                     { (yyval.const_expr) = (yyvsp[0].const_expr); }
-#line 2571 "parser.c"
+#line 2396 "parser.c"
     break;
 
-  case 25:
-#line 377 "src/parser.y"
+  case 25: /* or_expr: or_expr '|' xor_expr  */
+#line 378 "src/parser.y"
       { (yyval.const_expr) = NULL;
         if (pstate->parser.state != IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS)
           TRY(idl_create_binary_expr(pstate, &(yylsp[-1]), IDL_OR, (yyvsp[-2].const_expr), (yyvsp[0].const_expr), &(yyval.const_expr)));
       }
-#line 2580 "parser.c"
+#line 2405 "parser.c"
     break;
 
-  case 27:
-#line 386 "src/parser.y"
+  case 27: /* xor_expr: xor_expr '^' and_expr  */
+#line 387 "src/parser.y"
       { (yyval.const_expr) = NULL;
         if (pstate->parser.state != IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS)
           TRY(idl_create_binary_expr(pstate, &(yylsp[-1]), IDL_XOR, (yyvsp[-2].const_expr), (yyvsp[0].const_expr), &(yyval.const_expr)));
       }
-#line 2589 "parser.c"
+#line 2414 "parser.c"
     break;
 
-  case 29:
-#line 395 "src/parser.y"
+  case 29: /* and_expr: and_expr '&' shift_expr  */
+#line 396 "src/parser.y"
       { (yyval.const_expr) = NULL;
         if (pstate->parser.state != IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS)
           TRY(idl_create_binary_expr(pstate, &(yylsp[-1]), IDL_AND, (yyvsp[-2].const_expr), (yyvsp[0].const_expr), &(yyval.const_expr)));
       }
-#line 2598 "parser.c"
+#line 2423 "parser.c"
     break;
 
-  case 31:
-#line 404 "src/parser.y"
+  case 31: /* shift_expr: shift_expr shift_operator add_expr  */
+#line 405 "src/parser.y"
       { (yyval.const_expr) = NULL;
         if (pstate->parser.state != IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS)
           TRY(idl_create_binary_expr(pstate, &(yylsp[-1]), (yyvsp[-1].kind), (yyvsp[-2].const_expr), (yyvsp[0].const_expr), &(yyval.const_expr)));
       }
-#line 2607 "parser.c"
+#line 2432 "parser.c"
     break;
 
-  case 32:
-#line 411 "src/parser.y"
-         { (yyval.kind) = IDL_RSHIFT; }
-#line 2613 "parser.c"
-    break;
-
-  case 33:
+  case 32: /* shift_operator: ">>"  */
 #line 412 "src/parser.y"
+         { (yyval.kind) = IDL_RSHIFT; }
+#line 2438 "parser.c"
+    break;
+
+  case 33: /* shift_operator: "<<"  */
+#line 413 "src/parser.y"
          { (yyval.kind) = IDL_LSHIFT; }
-#line 2619 "parser.c"
+#line 2444 "parser.c"
     break;
 
-  case 35:
-#line 417 "src/parser.y"
+  case 35: /* add_expr: add_expr add_operator mult_expr  */
+#line 418 "src/parser.y"
       { (yyval.const_expr) = NULL;
         if (pstate->parser.state != IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS)
           TRY(idl_create_binary_expr(pstate, &(yylsp[-1]), (yyvsp[-1].kind), (yyvsp[-2].const_expr), (yyvsp[0].const_expr), &(yyval.const_expr)));
       }
-#line 2628 "parser.c"
+#line 2453 "parser.c"
     break;
 
-  case 36:
-#line 424 "src/parser.y"
-        { (yyval.kind) = IDL_ADD; }
-#line 2634 "parser.c"
-    break;
-
-  case 37:
+  case 36: /* add_operator: '+'  */
 #line 425 "src/parser.y"
+        { (yyval.kind) = IDL_ADD; }
+#line 2459 "parser.c"
+    break;
+
+  case 37: /* add_operator: '-'  */
+#line 426 "src/parser.y"
         { (yyval.kind) = IDL_SUBTRACT; }
-#line 2640 "parser.c"
+#line 2465 "parser.c"
     break;
 
-  case 38:
-#line 429 "src/parser.y"
+  case 38: /* mult_expr: unary_expr  */
+#line 430 "src/parser.y"
       { (yyval.const_expr) = (yyvsp[0].const_expr); }
-#line 2646 "parser.c"
+#line 2471 "parser.c"
     break;
 
-  case 39:
-#line 431 "src/parser.y"
+  case 39: /* mult_expr: mult_expr mult_operator unary_expr  */
+#line 432 "src/parser.y"
       { (yyval.const_expr) = NULL;
         if (pstate->parser.state != IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS)
           TRY(idl_create_binary_expr(pstate, &(yylsp[-1]), (yyvsp[-1].kind), (yyvsp[-2].const_expr), (yyvsp[0].const_expr), &(yyval.const_expr)));
       }
-#line 2655 "parser.c"
+#line 2480 "parser.c"
     break;
 
-  case 40:
-#line 438 "src/parser.y"
-        { (yyval.kind) = IDL_MULTIPLY; }
-#line 2661 "parser.c"
-    break;
-
-  case 41:
+  case 40: /* mult_operator: '*'  */
 #line 439 "src/parser.y"
-        { (yyval.kind) = IDL_DIVIDE; }
-#line 2667 "parser.c"
+        { (yyval.kind) = IDL_MULTIPLY; }
+#line 2486 "parser.c"
     break;
 
-  case 42:
+  case 41: /* mult_operator: '/'  */
 #line 440 "src/parser.y"
-        { (yyval.kind) = IDL_MODULO; }
-#line 2673 "parser.c"
+        { (yyval.kind) = IDL_DIVIDE; }
+#line 2492 "parser.c"
     break;
 
-  case 43:
-#line 444 "src/parser.y"
+  case 42: /* mult_operator: '%'  */
+#line 441 "src/parser.y"
+        { (yyval.kind) = IDL_MODULO; }
+#line 2498 "parser.c"
+    break;
+
+  case 43: /* unary_expr: unary_operator primary_expr  */
+#line 445 "src/parser.y"
       { (yyval.const_expr) = NULL;
         if (pstate->parser.state != IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS)
           TRY(idl_create_unary_expr(pstate, &(yylsp[-1]), (yyvsp[-1].kind), (yyvsp[0].const_expr), &(yyval.const_expr)));
       }
-#line 2682 "parser.c"
+#line 2507 "parser.c"
     break;
 
-  case 44:
-#line 449 "src/parser.y"
+  case 44: /* unary_expr: primary_expr  */
+#line 450 "src/parser.y"
       { (yyval.const_expr) = (yyvsp[0].const_expr); }
-#line 2688 "parser.c"
+#line 2513 "parser.c"
     break;
 
-  case 45:
-#line 453 "src/parser.y"
-        { (yyval.kind) = IDL_MINUS; }
-#line 2694 "parser.c"
-    break;
-
-  case 46:
+  case 45: /* unary_operator: '-'  */
 #line 454 "src/parser.y"
-        { (yyval.kind) = IDL_PLUS; }
-#line 2700 "parser.c"
+        { (yyval.kind) = IDL_MINUS; }
+#line 2519 "parser.c"
     break;
 
-  case 47:
+  case 46: /* unary_operator: '+'  */
 #line 455 "src/parser.y"
-        { (yyval.kind) = IDL_NOT; }
-#line 2706 "parser.c"
+        { (yyval.kind) = IDL_PLUS; }
+#line 2525 "parser.c"
     break;
 
-  case 48:
-#line 460 "src/parser.y"
+  case 47: /* unary_operator: '~'  */
+#line 456 "src/parser.y"
+        { (yyval.kind) = IDL_NOT; }
+#line 2531 "parser.c"
+    break;
+
+  case 48: /* primary_expr: scoped_name  */
+#line 461 "src/parser.y"
       { (yyval.const_expr) = NULL;
         if (pstate->parser.state != IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS) {
           /* disregard scoped names in application of unknown annotations.
@@ -2722,23 +2547,23 @@ yyreduce:
         }
         idl_delete_scoped_name((yyvsp[0].scoped_name));
       }
-#line 2726 "parser.c"
+#line 2551 "parser.c"
     break;
 
-  case 49:
-#line 476 "src/parser.y"
+  case 49: /* primary_expr: literal  */
+#line 477 "src/parser.y"
       { (yyval.const_expr) = (yyvsp[0].literal); }
-#line 2732 "parser.c"
+#line 2557 "parser.c"
     break;
 
-  case 50:
-#line 478 "src/parser.y"
+  case 50: /* primary_expr: '(' const_expr ')'  */
+#line 479 "src/parser.y"
       { (yyval.const_expr) = (yyvsp[-1].const_expr); }
-#line 2738 "parser.c"
+#line 2563 "parser.c"
     break;
 
-  case 51:
-#line 483 "src/parser.y"
+  case 51: /* literal: IDL_TOKEN_INTEGER_LITERAL  */
+#line 484 "src/parser.y"
       { idl_type_t type;
         idl_literal_t literal;
         (yyval.literal) = NULL;
@@ -2760,11 +2585,11 @@ yyreduce:
         TRY(idl_create_literal(pstate, &(yylsp[0]), type, &(yyval.literal)));
         (yyval.literal)->value = literal.value;
       }
-#line 2764 "parser.c"
+#line 2589 "parser.c"
     break;
 
-  case 52:
-#line 505 "src/parser.y"
+  case 52: /* literal: IDL_TOKEN_FLOATING_PT_LITERAL  */
+#line 506 "src/parser.y"
       { idl_type_t type;
         idl_literal_t literal;
         (yyval.literal) = NULL;
@@ -2787,67 +2612,67 @@ _Pragma("GCC diagnostic pop")
         TRY(idl_create_literal(pstate, &(yylsp[0]), type, &(yyval.literal)));
         (yyval.literal)->value = literal.value;
       }
-#line 2791 "parser.c"
+#line 2616 "parser.c"
     break;
 
-  case 53:
-#line 528 "src/parser.y"
+  case 53: /* literal: IDL_TOKEN_CHAR_LITERAL  */
+#line 529 "src/parser.y"
       { (yyval.literal) = NULL;
         if (pstate->parser.state == IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS)
           break;
         TRY(idl_create_literal(pstate, &(yylsp[0]), IDL_CHAR, &(yyval.literal)));
         (yyval.literal)->value.chr = (yyvsp[0].chr);
       }
-#line 2802 "parser.c"
+#line 2627 "parser.c"
     break;
 
-  case 54:
-#line 535 "src/parser.y"
+  case 54: /* literal: boolean_literal  */
+#line 536 "src/parser.y"
       { (yyval.literal) = NULL;
         if (pstate->parser.state == IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS)
           break;
         TRY(idl_create_literal(pstate, &(yylsp[0]), IDL_BOOL, &(yyval.literal)));
         (yyval.literal)->value.bln = (yyvsp[0].bln);
       }
-#line 2813 "parser.c"
+#line 2638 "parser.c"
     break;
 
-  case 55:
-#line 542 "src/parser.y"
+  case 55: /* literal: string_literal  */
+#line 543 "src/parser.y"
       { (yyval.literal) = NULL;
         if (pstate->parser.state == IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS)
           break;
         TRY(idl_create_literal(pstate, &(yylsp[0]), IDL_STRING, &(yyval.literal)));
         (yyval.literal)->value.str = (yyvsp[0].string_literal);
       }
-#line 2824 "parser.c"
+#line 2649 "parser.c"
     break;
 
-  case 56:
-#line 552 "src/parser.y"
+  case 56: /* boolean_literal: "TRUE"  */
+#line 553 "src/parser.y"
       { (yyval.bln) = true; }
-#line 2830 "parser.c"
+#line 2655 "parser.c"
     break;
 
-  case 57:
-#line 554 "src/parser.y"
+  case 57: /* boolean_literal: "FALSE"  */
+#line 555 "src/parser.y"
       { (yyval.bln) = false; }
-#line 2836 "parser.c"
+#line 2661 "parser.c"
     break;
 
-  case 58:
-#line 559 "src/parser.y"
+  case 58: /* string_literal: IDL_TOKEN_STRING_LITERAL  */
+#line 560 "src/parser.y"
       { (yyval.string_literal) = NULL;
         if (pstate->parser.state == IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS)
           break;
         if (!((yyval.string_literal) = idl_strdup((yyvsp[0].str))))
           NO_MEMORY();
       }
-#line 2847 "parser.c"
+#line 2672 "parser.c"
     break;
 
-  case 59:
-#line 566 "src/parser.y"
+  case 59: /* string_literal: string_literal IDL_TOKEN_STRING_LITERAL  */
+#line 567 "src/parser.y"
       { size_t n1, n2;
         (yyval.string_literal) = NULL;
         if (pstate->parser.state == IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS)
@@ -2860,35 +2685,35 @@ _Pragma("GCC diagnostic pop")
         memmove((yyval.string_literal)+n1, (yyvsp[0].str), n2);
         (yyval.string_literal)[n1+n2] = '\0';
       }
-#line 2864 "parser.c"
+#line 2689 "parser.c"
     break;
 
-  case 60:
-#line 582 "src/parser.y"
+  case 60: /* positive_int_const: const_expr  */
+#line 583 "src/parser.y"
       { TRY(idl_evaluate(pstate, (yyvsp[0].const_expr), IDL_ULONG, &(yyval.literal))); }
-#line 2870 "parser.c"
+#line 2695 "parser.c"
     break;
 
-  case 61:
-#line 586 "src/parser.y"
-                    { (yyval.node) = (yyvsp[0].node); }
-#line 2876 "parser.c"
-    break;
-
-  case 62:
+  case 61: /* type_dcl: constr_type_dcl  */
 #line 587 "src/parser.y"
+                    { (yyval.node) = (yyvsp[0].node); }
+#line 2701 "parser.c"
+    break;
+
+  case 62: /* type_dcl: typedef_dcl  */
+#line 588 "src/parser.y"
                 { (yyval.node) = (yyvsp[0].typedef_dcl); }
-#line 2882 "parser.c"
+#line 2707 "parser.c"
     break;
 
-  case 65:
-#line 598 "src/parser.y"
+  case 65: /* simple_type_spec: base_type_spec  */
+#line 599 "src/parser.y"
       { TRY(idl_create_base_type(pstate, &(yylsp[0]), (yyvsp[0].kind), &(yyval.type_spec))); }
-#line 2888 "parser.c"
+#line 2713 "parser.c"
     break;
 
-  case 66:
-#line 600 "src/parser.y"
+  case 66: /* simple_type_spec: scoped_name  */
+#line 601 "src/parser.y"
       { const idl_declaration_t *declaration = NULL;
         static const char fmt[] =
           "Scoped name '%s' does not resolve to a type";
@@ -2898,211 +2723,211 @@ _Pragma("GCC diagnostic pop")
         (yyval.type_spec) = idl_reference_node((idl_node_t *)declaration->node);
         idl_delete_scoped_name((yyvsp[0].scoped_name));
       }
-#line 2902 "parser.c"
+#line 2727 "parser.c"
     break;
 
-  case 73:
-#line 621 "src/parser.y"
-            { (yyval.kind) = IDL_FLOAT; }
-#line 2908 "parser.c"
-    break;
-
-  case 74:
+  case 73: /* floating_pt_type: "float"  */
 #line 622 "src/parser.y"
-             { (yyval.kind) = IDL_DOUBLE; }
-#line 2914 "parser.c"
+            { (yyval.kind) = IDL_FLOAT; }
+#line 2733 "parser.c"
     break;
 
-  case 75:
+  case 74: /* floating_pt_type: "double"  */
 #line 623 "src/parser.y"
+             { (yyval.kind) = IDL_DOUBLE; }
+#line 2739 "parser.c"
+    break;
+
+  case 75: /* floating_pt_type: "long" "double"  */
+#line 624 "src/parser.y"
                     { (yyval.kind) = IDL_LDOUBLE; }
-#line 2920 "parser.c"
+#line 2745 "parser.c"
     break;
 
-  case 78:
-#line 632 "src/parser.y"
-            { (yyval.kind) = IDL_SHORT; }
-#line 2926 "parser.c"
-    break;
-
-  case 79:
+  case 78: /* signed_int: "short"  */
 #line 633 "src/parser.y"
-           { (yyval.kind) = IDL_LONG; }
-#line 2932 "parser.c"
+            { (yyval.kind) = IDL_SHORT; }
+#line 2751 "parser.c"
     break;
 
-  case 80:
+  case 79: /* signed_int: "long"  */
 #line 634 "src/parser.y"
+           { (yyval.kind) = IDL_LONG; }
+#line 2757 "parser.c"
+    break;
+
+  case 80: /* signed_int: "long" "long"  */
+#line 635 "src/parser.y"
                   { (yyval.kind) = IDL_LLONG; }
-#line 2938 "parser.c"
+#line 2763 "parser.c"
     break;
 
-  case 81:
-#line 636 "src/parser.y"
-           { (yyval.kind) = IDL_INT8; }
-#line 2944 "parser.c"
-    break;
-
-  case 82:
+  case 81: /* signed_int: "int8"  */
 #line 637 "src/parser.y"
-            { (yyval.kind) = IDL_INT16; }
-#line 2950 "parser.c"
+           { (yyval.kind) = IDL_INT8; }
+#line 2769 "parser.c"
     break;
 
-  case 83:
+  case 82: /* signed_int: "int16"  */
 #line 638 "src/parser.y"
-            { (yyval.kind) = IDL_INT32; }
-#line 2956 "parser.c"
+            { (yyval.kind) = IDL_INT16; }
+#line 2775 "parser.c"
     break;
 
-  case 84:
+  case 83: /* signed_int: "int32"  */
 #line 639 "src/parser.y"
+            { (yyval.kind) = IDL_INT32; }
+#line 2781 "parser.c"
+    break;
+
+  case 84: /* signed_int: "int64"  */
+#line 640 "src/parser.y"
             { (yyval.kind) = IDL_INT64; }
-#line 2962 "parser.c"
+#line 2787 "parser.c"
     break;
 
-  case 85:
-#line 643 "src/parser.y"
-                       { (yyval.kind) = IDL_USHORT; }
-#line 2968 "parser.c"
-    break;
-
-  case 86:
+  case 85: /* unsigned_int: "unsigned" "short"  */
 #line 644 "src/parser.y"
-                      { (yyval.kind) = IDL_ULONG; }
-#line 2974 "parser.c"
+                       { (yyval.kind) = IDL_USHORT; }
+#line 2793 "parser.c"
     break;
 
-  case 87:
+  case 86: /* unsigned_int: "unsigned" "long"  */
 #line 645 "src/parser.y"
+                      { (yyval.kind) = IDL_ULONG; }
+#line 2799 "parser.c"
+    break;
+
+  case 87: /* unsigned_int: "unsigned" "long" "long"  */
+#line 646 "src/parser.y"
                              { (yyval.kind) = IDL_ULLONG; }
-#line 2980 "parser.c"
+#line 2805 "parser.c"
     break;
 
-  case 88:
-#line 647 "src/parser.y"
-            { (yyval.kind) = IDL_UINT8; }
-#line 2986 "parser.c"
-    break;
-
-  case 89:
+  case 88: /* unsigned_int: "uint8"  */
 #line 648 "src/parser.y"
-             { (yyval.kind) = IDL_UINT16; }
-#line 2992 "parser.c"
+            { (yyval.kind) = IDL_UINT8; }
+#line 2811 "parser.c"
     break;
 
-  case 90:
+  case 89: /* unsigned_int: "uint16"  */
 #line 649 "src/parser.y"
-             { (yyval.kind) = IDL_UINT32; }
-#line 2998 "parser.c"
+             { (yyval.kind) = IDL_UINT16; }
+#line 2817 "parser.c"
     break;
 
-  case 91:
+  case 90: /* unsigned_int: "uint32"  */
 #line 650 "src/parser.y"
+             { (yyval.kind) = IDL_UINT32; }
+#line 2823 "parser.c"
+    break;
+
+  case 91: /* unsigned_int: "uint64"  */
+#line 651 "src/parser.y"
              { (yyval.kind) = IDL_UINT64; }
-#line 3004 "parser.c"
+#line 2829 "parser.c"
     break;
 
-  case 92:
-#line 654 "src/parser.y"
+  case 92: /* char_type: "char"  */
+#line 655 "src/parser.y"
            { (yyval.kind) = IDL_CHAR; }
-#line 3010 "parser.c"
+#line 2835 "parser.c"
     break;
 
-  case 93:
-#line 657 "src/parser.y"
+  case 93: /* wide_char_type: "wchar"  */
+#line 658 "src/parser.y"
             { (yyval.kind) = IDL_WCHAR; }
-#line 3016 "parser.c"
+#line 2841 "parser.c"
     break;
 
-  case 94:
-#line 660 "src/parser.y"
+  case 94: /* boolean_type: "boolean"  */
+#line 661 "src/parser.y"
               { (yyval.kind) = IDL_BOOL; }
-#line 3022 "parser.c"
+#line 2847 "parser.c"
     break;
 
-  case 95:
-#line 663 "src/parser.y"
+  case 95: /* octet_type: "octet"  */
+#line 664 "src/parser.y"
             { (yyval.kind) = IDL_OCTET; }
-#line 3028 "parser.c"
+#line 2853 "parser.c"
     break;
 
-  case 96:
-#line 666 "src/parser.y"
-                  { (yyval.type_spec) = (yyvsp[0].sequence); }
-#line 3034 "parser.c"
-    break;
-
-  case 97:
+  case 96: /* template_type_spec: sequence_type  */
 #line 667 "src/parser.y"
+                  { (yyval.type_spec) = (yyvsp[0].sequence); }
+#line 2859 "parser.c"
+    break;
+
+  case 97: /* template_type_spec: string_type  */
+#line 668 "src/parser.y"
                   { (yyval.type_spec) = (yyvsp[0].string); }
-#line 3040 "parser.c"
+#line 2865 "parser.c"
     break;
 
-  case 98:
-#line 672 "src/parser.y"
+  case 98: /* sequence_type: "sequence" '<' type_spec ',' positive_int_const '>'  */
+#line 673 "src/parser.y"
       { TRY(idl_create_sequence(pstate, LOC((yylsp[-5]).first, (yylsp[0]).last), (yyvsp[-3].type_spec), (yyvsp[-1].literal), &(yyval.sequence))); }
-#line 3046 "parser.c"
+#line 2871 "parser.c"
     break;
 
-  case 99:
-#line 674 "src/parser.y"
+  case 99: /* sequence_type: "sequence" '<' type_spec '>'  */
+#line 675 "src/parser.y"
       { TRY(idl_create_sequence(pstate, LOC((yylsp[-3]).first, (yylsp[0]).last), (yyvsp[-1].type_spec), NULL, &(yyval.sequence))); }
-#line 3052 "parser.c"
+#line 2877 "parser.c"
     break;
 
-  case 100:
-#line 679 "src/parser.y"
+  case 100: /* string_type: "string" '<' positive_int_const '>'  */
+#line 680 "src/parser.y"
       { TRY(idl_create_string(pstate, LOC((yylsp[-3]).first, (yylsp[0]).last), (yyvsp[-1].literal), &(yyval.string))); }
-#line 3058 "parser.c"
+#line 2883 "parser.c"
     break;
 
-  case 101:
-#line 681 "src/parser.y"
+  case 101: /* string_type: "string"  */
+#line 682 "src/parser.y"
       { TRY(idl_create_string(pstate, LOC((yylsp[0]).first, (yylsp[0]).last), NULL, &(yyval.string))); }
-#line 3064 "parser.c"
+#line 2889 "parser.c"
     break;
 
-  case 106:
-#line 692 "src/parser.y"
-               { (yyval.node) = (yyvsp[0].struct_dcl); }
-#line 3070 "parser.c"
-    break;
-
-  case 107:
+  case 106: /* struct_dcl: struct_def  */
 #line 693 "src/parser.y"
+               { (yyval.node) = (yyvsp[0].struct_dcl); }
+#line 2895 "parser.c"
+    break;
+
+  case 107: /* struct_dcl: struct_forward_dcl  */
+#line 694 "src/parser.y"
                        { (yyval.node) = (yyvsp[0].forward); }
-#line 3076 "parser.c"
+#line 2901 "parser.c"
     break;
 
-  case 108:
-#line 698 "src/parser.y"
+  case 108: /* struct_forward_dcl: "struct" identifier  */
+#line 699 "src/parser.y"
       { TRY(idl_create_forward(pstate, &(yylsp[-1]), (yyvsp[0].name), IDL_STRUCT, &(yyval.forward))); }
-#line 3082 "parser.c"
+#line 2907 "parser.c"
     break;
 
-  case 109:
-#line 703 "src/parser.y"
+  case 109: /* struct_def: struct_header '{' struct_body '}'  */
+#line 704 "src/parser.y"
       { TRY(idl_finalize_struct(pstate, LOC((yylsp[-3]).first, (yylsp[0]).last), (yyvsp[-3].struct_dcl), (yyvsp[-1].member)));
         (yyval.struct_dcl) = (yyvsp[-3].struct_dcl);
       }
-#line 3090 "parser.c"
+#line 2915 "parser.c"
     break;
 
-  case 110:
-#line 710 "src/parser.y"
+  case 110: /* struct_header: "struct" identifier struct_inherit_spec  */
+#line 711 "src/parser.y"
       { TRY(idl_create_struct(pstate, LOC((yylsp[-2]).first, (yyvsp[0].type_spec) ? (yylsp[0]).last : (yylsp[-1]).last), (yyvsp[-1].name), (yyvsp[0].type_spec), &(yyval.struct_dcl))); }
-#line 3096 "parser.c"
+#line 2921 "parser.c"
     break;
 
-  case 111:
-#line 714 "src/parser.y"
+  case 111: /* struct_inherit_spec: %empty  */
+#line 715 "src/parser.y"
             { (yyval.type_spec) = NULL; }
-#line 3102 "parser.c"
+#line 2927 "parser.c"
     break;
 
-  case 112:
-#line 718 "src/parser.y"
+  case 112: /* struct_inherit_spec: ':' scoped_name  */
+#line 719 "src/parser.y"
       { idl_node_t *node;
         const idl_declaration_t *declaration;
         static const char fmt[] =
@@ -3114,75 +2939,75 @@ _Pragma("GCC diagnostic pop")
         TRY(idl_create_inherit_spec(pstate, &(yylsp[0]), idl_reference_node(node), &(yyval.type_spec)));
         idl_delete_scoped_name((yyvsp[0].scoped_name));
       }
-#line 3118 "parser.c"
+#line 2943 "parser.c"
     break;
 
-  case 113:
-#line 733 "src/parser.y"
+  case 113: /* struct_body: members  */
+#line 734 "src/parser.y"
       { (yyval.member) = (yyvsp[0].member); }
-#line 3124 "parser.c"
+#line 2949 "parser.c"
     break;
 
-  case 114:
-#line 737 "src/parser.y"
+  case 114: /* struct_body: %empty  */
+#line 738 "src/parser.y"
       { (yyval.member) = NULL; }
-#line 3130 "parser.c"
+#line 2955 "parser.c"
     break;
 
-  case 115:
-#line 742 "src/parser.y"
+  case 115: /* members: member  */
+#line 743 "src/parser.y"
       { (yyval.member) = (yyvsp[0].member); }
-#line 3136 "parser.c"
+#line 2961 "parser.c"
     break;
 
-  case 116:
-#line 744 "src/parser.y"
+  case 116: /* members: members member  */
+#line 745 "src/parser.y"
       { (yyval.member) = idl_push_node((yyvsp[-1].member), (yyvsp[0].member)); }
-#line 3142 "parser.c"
+#line 2967 "parser.c"
     break;
 
-  case 117:
-#line 749 "src/parser.y"
+  case 117: /* member: annotations type_spec declarators ';'  */
+#line 750 "src/parser.y"
       { TRY(idl_create_member(pstate, LOC((yylsp[-2]).first, (yylsp[0]).last), (yyvsp[-2].type_spec), (yyvsp[-1].declarator), &(yyval.member)));
         TRY_EXCEPT(idl_annotate(pstate, (yyval.member), (yyvsp[-3].annotation_appl)), idl_free((yyval.member)));
       }
-#line 3150 "parser.c"
+#line 2975 "parser.c"
     break;
 
-  case 118:
-#line 755 "src/parser.y"
-              { (yyval.node) = (yyvsp[0].union_dcl); }
-#line 3156 "parser.c"
-    break;
-
-  case 119:
+  case 118: /* union_dcl: union_def  */
 #line 756 "src/parser.y"
-                      { (yyval.node) = (yyvsp[0].forward); }
-#line 3162 "parser.c"
+              { (yyval.node) = (yyvsp[0].union_dcl); }
+#line 2981 "parser.c"
     break;
 
-  case 120:
-#line 761 "src/parser.y"
+  case 119: /* union_dcl: union_forward_dcl  */
+#line 757 "src/parser.y"
+                      { (yyval.node) = (yyvsp[0].forward); }
+#line 2987 "parser.c"
+    break;
+
+  case 120: /* union_def: union_header '{' switch_body '}'  */
+#line 762 "src/parser.y"
       { TRY(idl_finalize_union(pstate, LOC((yylsp[-3]).first, (yylsp[0]).last), (yyvsp[-3].union_dcl), (yyvsp[-1]._case)));
         (yyval.union_dcl) = (yyvsp[-3].union_dcl);
       }
-#line 3170 "parser.c"
+#line 2995 "parser.c"
     break;
 
-  case 121:
-#line 768 "src/parser.y"
+  case 121: /* union_forward_dcl: "union" identifier  */
+#line 769 "src/parser.y"
       { TRY(idl_create_forward(pstate, &(yylsp[-1]), (yyvsp[0].name), IDL_UNION, &(yyval.forward))); }
-#line 3176 "parser.c"
+#line 3001 "parser.c"
     break;
 
-  case 122:
-#line 773 "src/parser.y"
+  case 122: /* union_header: "union" identifier switch_header  */
+#line 774 "src/parser.y"
       { TRY(idl_create_union(pstate, LOC((yylsp[-2]).first, (yylsp[0]).last), (yyvsp[-1].name), (yyvsp[0].switch_type_spec), &(yyval.union_dcl))); }
-#line 3182 "parser.c"
+#line 3007 "parser.c"
     break;
 
-  case 123:
-#line 778 "src/parser.y"
+  case 123: /* switch_header: "switch" '(' annotations switch_type_spec ')'  */
+#line 779 "src/parser.y"
       { /* switch_header action is a separate non-terminal, as opposed to a
            mid-rule action, to avoid freeing the type specifier twice (once
            through destruction of the type-spec and once through destruction
@@ -3190,203 +3015,203 @@ _Pragma("GCC diagnostic pop")
         TRY(idl_create_switch_type_spec(pstate, &(yylsp[-1]), (yyvsp[-1].type_spec), &(yyval.switch_type_spec)));
         TRY_EXCEPT(idl_annotate(pstate, (yyval.switch_type_spec), (yyvsp[-2].annotation_appl)), idl_delete_node((yyval.switch_type_spec)));
       }
-#line 3194 "parser.c"
+#line 3019 "parser.c"
     break;
 
-  case 124:
-#line 789 "src/parser.y"
+  case 124: /* switch_type_spec: integer_type  */
+#line 790 "src/parser.y"
       { TRY(idl_create_base_type(pstate, &(yylsp[0]), (yyvsp[0].kind), &(yyval.type_spec))); }
-#line 3200 "parser.c"
+#line 3025 "parser.c"
     break;
 
-  case 125:
-#line 791 "src/parser.y"
+  case 125: /* switch_type_spec: char_type  */
+#line 792 "src/parser.y"
       { TRY(idl_create_base_type(pstate, &(yylsp[0]), (yyvsp[0].kind), &(yyval.type_spec))); }
-#line 3206 "parser.c"
+#line 3031 "parser.c"
     break;
 
-  case 126:
-#line 793 "src/parser.y"
+  case 126: /* switch_type_spec: boolean_type  */
+#line 794 "src/parser.y"
       { TRY(idl_create_base_type(pstate, &(yylsp[0]), (yyvsp[0].kind), &(yyval.type_spec))); }
-#line 3212 "parser.c"
+#line 3037 "parser.c"
     break;
 
-  case 127:
-#line 795 "src/parser.y"
+  case 127: /* switch_type_spec: scoped_name  */
+#line 796 "src/parser.y"
       { const idl_declaration_t *declaration;
         TRY(idl_resolve(pstate, 0u, (yyvsp[0].scoped_name), &declaration));
         idl_delete_scoped_name((yyvsp[0].scoped_name));
         (yyval.type_spec) = idl_reference_node((idl_node_t *)declaration->node);
       }
-#line 3222 "parser.c"
+#line 3047 "parser.c"
     break;
 
-  case 128:
-#line 801 "src/parser.y"
+  case 128: /* switch_type_spec: wide_char_type  */
+#line 802 "src/parser.y"
       { TRY(idl_create_base_type(pstate, &(yylsp[0]), (yyvsp[0].kind), &(yyval.type_spec))); }
-#line 3228 "parser.c"
+#line 3053 "parser.c"
     break;
 
-  case 129:
-#line 803 "src/parser.y"
+  case 129: /* switch_type_spec: octet_type  */
+#line 804 "src/parser.y"
       { TRY(idl_create_base_type(pstate, &(yylsp[0]), (yyvsp[0].kind), &(yyval.type_spec))); }
-#line 3234 "parser.c"
+#line 3059 "parser.c"
     break;
 
-  case 130:
-#line 808 "src/parser.y"
+  case 130: /* switch_body: case  */
+#line 809 "src/parser.y"
       { (yyval._case) = (yyvsp[0]._case); }
-#line 3240 "parser.c"
+#line 3065 "parser.c"
     break;
 
-  case 131:
-#line 810 "src/parser.y"
+  case 131: /* switch_body: switch_body case  */
+#line 811 "src/parser.y"
       { (yyval._case) = idl_push_node((yyvsp[-1]._case), (yyvsp[0]._case)); }
-#line 3246 "parser.c"
+#line 3071 "parser.c"
     break;
 
-  case 132:
-#line 815 "src/parser.y"
+  case 132: /* case: case_labels element_spec ';'  */
+#line 816 "src/parser.y"
       { TRY(idl_finalize_case(pstate, &(yylsp[-1]), (yyvsp[-1]._case), (yyvsp[-2].case_label)));
         (yyval._case) = (yyvsp[-1]._case);
       }
-#line 3254 "parser.c"
+#line 3079 "parser.c"
     break;
 
-  case 133:
-#line 822 "src/parser.y"
+  case 133: /* case_labels: case_label  */
+#line 823 "src/parser.y"
       { (yyval.case_label) = (yyvsp[0].case_label); }
-#line 3260 "parser.c"
+#line 3085 "parser.c"
     break;
 
-  case 134:
-#line 824 "src/parser.y"
+  case 134: /* case_labels: case_labels case_label  */
+#line 825 "src/parser.y"
       { (yyval.case_label) = idl_push_node((yyvsp[-1].case_label), (yyvsp[0].case_label)); }
-#line 3266 "parser.c"
+#line 3091 "parser.c"
     break;
 
-  case 135:
-#line 829 "src/parser.y"
+  case 135: /* case_label: "case" const_expr ':'  */
+#line 830 "src/parser.y"
       { TRY(idl_create_case_label(pstate, LOC((yylsp[-2]).first, (yylsp[-1]).last), (yyvsp[-1].const_expr), &(yyval.case_label))); }
-#line 3272 "parser.c"
+#line 3097 "parser.c"
     break;
 
-  case 136:
-#line 831 "src/parser.y"
+  case 136: /* case_label: "default" ':'  */
+#line 832 "src/parser.y"
       { TRY(idl_create_case_label(pstate, &(yylsp[-1]), NULL, &(yyval.case_label))); }
-#line 3278 "parser.c"
+#line 3103 "parser.c"
     break;
 
-  case 137:
-#line 838 "src/parser.y"
+  case 137: /* element_spec: annotations type_spec declarator  */
+#line 839 "src/parser.y"
       { TRY(idl_create_case(pstate, LOC((yylsp[-2]).first, (yylsp[0]).last), (yyvsp[-1].type_spec), (yyvsp[0].declarator), &(yyval._case)));
         TRY_EXCEPT(idl_annotate(pstate, (yyval._case), (yyvsp[-2].annotation_appl)), idl_free((yyval._case)));
       }
-#line 3286 "parser.c"
+#line 3111 "parser.c"
     break;
 
-  case 138:
-#line 843 "src/parser.y"
+  case 138: /* enum_dcl: enum_def  */
+#line 844 "src/parser.y"
                    { (yyval.node) = (yyvsp[0].enum_dcl); }
-#line 3292 "parser.c"
+#line 3117 "parser.c"
     break;
 
-  case 139:
-#line 847 "src/parser.y"
+  case 139: /* enum_def: "enum" identifier '{' enumerators '}'  */
+#line 848 "src/parser.y"
       { TRY(idl_create_enum(pstate, LOC((yylsp[-4]).first, (yylsp[0]).last), (yyvsp[-3].name), (yyvsp[-1].enumerator), &(yyval.enum_dcl))); }
-#line 3298 "parser.c"
+#line 3123 "parser.c"
     break;
 
-  case 140:
-#line 852 "src/parser.y"
+  case 140: /* enumerators: enumerator  */
+#line 853 "src/parser.y"
       { (yyval.enumerator) = (yyvsp[0].enumerator); }
-#line 3304 "parser.c"
+#line 3129 "parser.c"
     break;
 
-  case 141:
-#line 854 "src/parser.y"
+  case 141: /* enumerators: enumerators ',' enumerator  */
+#line 855 "src/parser.y"
       { (yyval.enumerator) = idl_push_node((yyvsp[-2].enumerator), (yyvsp[0].enumerator)); }
-#line 3310 "parser.c"
+#line 3135 "parser.c"
     break;
 
-  case 142:
-#line 859 "src/parser.y"
+  case 142: /* enumerator: annotations identifier  */
+#line 860 "src/parser.y"
       { TRY(idl_create_enumerator(pstate, &(yylsp[0]), (yyvsp[0].name), &(yyval.enumerator)));
         TRY_EXCEPT(idl_annotate(pstate, (yyval.enumerator), (yyvsp[-1].annotation_appl)), idl_free((yyval.enumerator)));
       }
-#line 3318 "parser.c"
+#line 3143 "parser.c"
     break;
 
-  case 143:
-#line 864 "src/parser.y"
+  case 143: /* bitmask_dcl: bitmask_def  */
+#line 865 "src/parser.y"
                          { (yyval.node) = (yyvsp[0].bitmask_dcl); }
-#line 3324 "parser.c"
+#line 3149 "parser.c"
     break;
 
-  case 144:
-#line 868 "src/parser.y"
+  case 144: /* bitmask_def: "bitmask" identifier '{' bit_values '}'  */
+#line 869 "src/parser.y"
       { TRY(idl_create_bitmask(pstate, LOC((yylsp[-4]).first, (yylsp[0]).last), (yyvsp[-3].name), (yyvsp[-1].bit_value), &(yyval.bitmask_dcl))); }
-#line 3330 "parser.c"
+#line 3155 "parser.c"
     break;
 
-  case 145:
-#line 873 "src/parser.y"
+  case 145: /* bit_values: bit_value  */
+#line 874 "src/parser.y"
       { (yyval.bit_value) = (yyvsp[0].bit_value); }
-#line 3336 "parser.c"
+#line 3161 "parser.c"
     break;
 
-  case 146:
-#line 875 "src/parser.y"
+  case 146: /* bit_values: bit_values ',' bit_value  */
+#line 876 "src/parser.y"
       { (yyval.bit_value) = idl_push_node((yyvsp[-2].bit_value), (yyvsp[0].bit_value)); }
-#line 3342 "parser.c"
+#line 3167 "parser.c"
     break;
 
-  case 147:
-#line 880 "src/parser.y"
+  case 147: /* bit_value: annotations identifier  */
+#line 881 "src/parser.y"
       { TRY(idl_create_bit_value(pstate, &(yylsp[0]), (yyvsp[0].name), &(yyval.bit_value)));
         TRY_EXCEPT(idl_annotate(pstate, (yyval.bit_value), (yyvsp[-1].annotation_appl)), idl_free((yyval.bit_value)));
       }
-#line 3350 "parser.c"
+#line 3175 "parser.c"
     break;
 
-  case 148:
-#line 887 "src/parser.y"
+  case 148: /* array_declarator: identifier fixed_array_sizes  */
+#line 888 "src/parser.y"
       { TRY(idl_create_declarator(pstate, LOC((yylsp[-1]).first, (yylsp[0]).last), (yyvsp[-1].name), (yyvsp[0].const_expr), &(yyval.declarator))); }
-#line 3356 "parser.c"
+#line 3181 "parser.c"
     break;
 
-  case 149:
-#line 892 "src/parser.y"
+  case 149: /* fixed_array_sizes: fixed_array_size  */
+#line 893 "src/parser.y"
       { (yyval.const_expr) = (yyvsp[0].literal); }
-#line 3362 "parser.c"
+#line 3187 "parser.c"
     break;
 
-  case 150:
-#line 894 "src/parser.y"
+  case 150: /* fixed_array_sizes: fixed_array_sizes fixed_array_size  */
+#line 895 "src/parser.y"
       { (yyval.const_expr) = idl_push_node((yyvsp[-1].const_expr), (yyvsp[0].literal)); }
-#line 3368 "parser.c"
+#line 3193 "parser.c"
     break;
 
-  case 151:
-#line 899 "src/parser.y"
+  case 151: /* fixed_array_size: '[' positive_int_const ']'  */
+#line 900 "src/parser.y"
       { (yyval.literal) = (yyvsp[-1].literal); }
-#line 3374 "parser.c"
+#line 3199 "parser.c"
     break;
 
-  case 152:
-#line 904 "src/parser.y"
+  case 152: /* simple_declarator: identifier  */
+#line 905 "src/parser.y"
       { TRY(idl_create_declarator(pstate, &(yylsp[0]), (yyvsp[0].name), NULL, &(yyval.declarator))); }
-#line 3380 "parser.c"
+#line 3205 "parser.c"
     break;
 
-  case 154:
-#line 911 "src/parser.y"
+  case 154: /* typedef_dcl: "typedef" type_spec declarators  */
+#line 912 "src/parser.y"
       { TRY(idl_create_typedef(pstate, LOC((yylsp[-2]).first, (yylsp[0]).last), (yyvsp[-1].type_spec), (yyvsp[0].declarator), &(yyval.typedef_dcl))); }
-#line 3386 "parser.c"
+#line 3211 "parser.c"
     break;
 
-  case 155:
-#line 913 "src/parser.y"
+  case 155: /* typedef_dcl: "typedef" constr_type_dcl declarators  */
+#line 914 "src/parser.y"
       {
         idl_typedef_t *node;
         idl_type_spec_t *type_spec;
@@ -3400,23 +3225,23 @@ _Pragma("GCC diagnostic pop")
         idl_reference_node(type_spec);
         (yyval.typedef_dcl) = idl_push_node((yyvsp[-1].node), node);
       }
-#line 3404 "parser.c"
+#line 3229 "parser.c"
     break;
 
-  case 156:
-#line 930 "src/parser.y"
+  case 156: /* declarators: declarator  */
+#line 931 "src/parser.y"
       { (yyval.declarator) = (yyvsp[0].declarator); }
-#line 3410 "parser.c"
+#line 3235 "parser.c"
     break;
 
-  case 157:
-#line 932 "src/parser.y"
+  case 157: /* declarators: declarators ',' declarator  */
+#line 933 "src/parser.y"
       { (yyval.declarator) = idl_push_node((yyvsp[-2].declarator), (yyvsp[0].declarator)); }
-#line 3416 "parser.c"
+#line 3241 "parser.c"
     break;
 
-  case 160:
-#line 942 "src/parser.y"
+  case 160: /* identifier: IDL_TOKEN_IDENTIFIER  */
+#line 943 "src/parser.y"
       { (yyval.name) = NULL;
         size_t n;
         bool nocase = (pstate->config.flags & IDL_FLAG_CASE_SENSITIVE) == 0;
@@ -3430,149 +3255,149 @@ _Pragma("GCC diagnostic pop")
         if (pstate->parser.state != IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS)
           TRY(idl_create_name(pstate, &(yylsp[0]), idl_strdup((yyvsp[0].str)+n), &(yyval.name)));
       }
-#line 3434 "parser.c"
+#line 3259 "parser.c"
     break;
 
-  case 161:
-#line 959 "src/parser.y"
+  case 161: /* annotation_dcl: annotation_header '{' annotation_body '}'  */
+#line 960 "src/parser.y"
       { (yyval.annotation) = NULL;
         /* discard annotation in case of redefinition */
         if (pstate->parser.state != IDL_PARSE_EXISTING_ANNOTATION_BODY)
           (yyval.annotation) = (yyvsp[-3].annotation);
         TRY(idl_finalize_annotation(pstate, LOC((yylsp[-3]).first, (yylsp[0]).last), (yyvsp[-3].annotation), (yyvsp[-1].annotation_member)));
       }
-#line 3445 "parser.c"
+#line 3270 "parser.c"
     break;
 
-  case 162:
-#line 969 "src/parser.y"
+  case 162: /* $@1: %empty  */
+#line 970 "src/parser.y"
       { pstate->annotations = true; /* register annotation occurence */
         pstate->parser.state = IDL_PARSE_ANNOTATION;
       }
-#line 3453 "parser.c"
+#line 3278 "parser.c"
     break;
 
-  case 163:
-#line 973 "src/parser.y"
+  case 163: /* annotation_header: "@" "annotation" $@1 identifier  */
+#line 974 "src/parser.y"
       { TRY(idl_create_annotation(pstate, LOC((yylsp[-3]).first, (yylsp[-2]).last), (yyvsp[0].name), &(yyval.annotation))); }
-#line 3459 "parser.c"
+#line 3284 "parser.c"
     break;
 
-  case 164:
-#line 978 "src/parser.y"
+  case 164: /* annotation_body: %empty  */
+#line 979 "src/parser.y"
       { (yyval.annotation_member) = NULL; }
-#line 3465 "parser.c"
+#line 3290 "parser.c"
     break;
 
-  case 165:
-#line 980 "src/parser.y"
+  case 165: /* annotation_body: annotation_body annotation_member ';'  */
+#line 981 "src/parser.y"
       { (yyval.annotation_member) = idl_push_node((yyvsp[-2].annotation_member), (yyvsp[-1].annotation_member)); }
-#line 3471 "parser.c"
+#line 3296 "parser.c"
     break;
 
-  case 166:
-#line 982 "src/parser.y"
+  case 166: /* annotation_body: annotation_body enum_dcl ';'  */
+#line 983 "src/parser.y"
       { (yyval.annotation_member) = idl_push_node((yyvsp[-2].annotation_member), (yyvsp[-1].node)); }
-#line 3477 "parser.c"
+#line 3302 "parser.c"
     break;
 
-  case 167:
-#line 984 "src/parser.y"
+  case 167: /* annotation_body: annotation_body bitmask_dcl ';'  */
+#line 985 "src/parser.y"
       { (yyval.annotation_member) = idl_push_node((yyvsp[-2].annotation_member), (yyvsp[-1].node)); }
-#line 3483 "parser.c"
+#line 3308 "parser.c"
     break;
 
-  case 168:
-#line 986 "src/parser.y"
+  case 168: /* annotation_body: annotation_body const_dcl ';'  */
+#line 987 "src/parser.y"
       { (yyval.annotation_member) = idl_push_node((yyvsp[-2].annotation_member), (yyvsp[-1].const_dcl)); }
-#line 3489 "parser.c"
+#line 3314 "parser.c"
     break;
 
-  case 169:
-#line 988 "src/parser.y"
+  case 169: /* annotation_body: annotation_body typedef_dcl ';'  */
+#line 989 "src/parser.y"
       { (yyval.annotation_member) = idl_push_node((yyvsp[-2].annotation_member), (yyvsp[-1].typedef_dcl)); }
-#line 3495 "parser.c"
+#line 3320 "parser.c"
     break;
 
-  case 170:
-#line 993 "src/parser.y"
+  case 170: /* annotation_member: annotation_member_type simple_declarator annotation_member_default  */
+#line 994 "src/parser.y"
       { TRY(idl_create_annotation_member(pstate, LOC((yylsp[-2]).first, (yylsp[0]).last), (yyvsp[-2].type_spec), (yyvsp[-1].declarator), (yyvsp[0].const_expr), &(yyval.annotation_member))); }
-#line 3501 "parser.c"
+#line 3326 "parser.c"
     break;
 
-  case 171:
-#line 998 "src/parser.y"
+  case 171: /* annotation_member_type: const_type  */
+#line 999 "src/parser.y"
       { (yyval.type_spec) = (yyvsp[0].type_spec); }
-#line 3507 "parser.c"
+#line 3332 "parser.c"
     break;
 
-  case 172:
-#line 1000 "src/parser.y"
+  case 172: /* annotation_member_type: any_const_type  */
+#line 1001 "src/parser.y"
       { (yyval.type_spec) = (yyvsp[0].type_spec); }
-#line 3513 "parser.c"
+#line 3338 "parser.c"
     break;
 
-  case 173:
-#line 1005 "src/parser.y"
+  case 173: /* annotation_member_default: %empty  */
+#line 1006 "src/parser.y"
       { (yyval.const_expr) = NULL; }
-#line 3519 "parser.c"
+#line 3344 "parser.c"
     break;
 
-  case 174:
-#line 1007 "src/parser.y"
+  case 174: /* annotation_member_default: "default" const_expr  */
+#line 1008 "src/parser.y"
       { (yyval.const_expr) = (yyvsp[0].const_expr); }
-#line 3525 "parser.c"
+#line 3350 "parser.c"
     break;
 
-  case 175:
-#line 1012 "src/parser.y"
+  case 175: /* any_const_type: "any"  */
+#line 1013 "src/parser.y"
       { TRY(idl_create_base_type(pstate, &(yylsp[0]), IDL_ANY, &(yyval.type_spec))); }
-#line 3531 "parser.c"
+#line 3356 "parser.c"
     break;
 
-  case 176:
-#line 1017 "src/parser.y"
+  case 176: /* annotations: annotation_appls  */
+#line 1018 "src/parser.y"
       { (yyval.annotation_appl) = (yyvsp[0].annotation_appl); }
-#line 3537 "parser.c"
+#line 3362 "parser.c"
     break;
 
-  case 177:
-#line 1019 "src/parser.y"
+  case 177: /* annotations: %empty  */
+#line 1020 "src/parser.y"
       { (yyval.annotation_appl) = NULL; }
-#line 3543 "parser.c"
+#line 3368 "parser.c"
     break;
 
-  case 178:
-#line 1024 "src/parser.y"
+  case 178: /* annotation_appls: annotation_appl  */
+#line 1025 "src/parser.y"
       { (yyval.annotation_appl) = (yyvsp[0].annotation_appl); }
-#line 3549 "parser.c"
+#line 3374 "parser.c"
     break;
 
-  case 179:
-#line 1026 "src/parser.y"
+  case 179: /* annotation_appls: annotation_appls annotation_appl  */
+#line 1027 "src/parser.y"
       { (yyval.annotation_appl) = idl_push_node((yyvsp[-1].annotation_appl), (yyvsp[0].annotation_appl)); }
-#line 3555 "parser.c"
+#line 3380 "parser.c"
     break;
 
-  case 180:
-#line 1031 "src/parser.y"
+  case 180: /* annotation_appl: annotation_appl_header annotation_appl_params  */
+#line 1032 "src/parser.y"
       { if (pstate->parser.state != IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS)
           TRY(idl_finalize_annotation_appl(pstate, LOC((yylsp[-1]).first, (yylsp[0]).last), (yyvsp[-1].annotation_appl), (yyvsp[0].annotation_appl_param)));
         pstate->parser.state = IDL_PARSE;
         pstate->annotation_scope = NULL;
         (yyval.annotation_appl) = (yyvsp[-1].annotation_appl);
       }
-#line 3566 "parser.c"
+#line 3391 "parser.c"
     break;
 
-  case 181:
-#line 1041 "src/parser.y"
+  case 181: /* $@2: %empty  */
+#line 1042 "src/parser.y"
       { pstate->parser.state = IDL_PARSE_ANNOTATION_APPL; }
-#line 3572 "parser.c"
+#line 3397 "parser.c"
     break;
 
-  case 182:
-#line 1043 "src/parser.y"
+  case 182: /* annotation_appl_header: "@" $@2 annotation_appl_name  */
+#line 1044 "src/parser.y"
       { const idl_annotation_t *annotation;
         const idl_declaration_t *declaration =
           idl_find_scoped_name(pstate, NULL, (yyvsp[0].scoped_name), IDL_FIND_ANNOTATION);
@@ -3593,61 +3418,61 @@ _Pragma("GCC diagnostic pop")
 
         idl_delete_scoped_name((yyvsp[0].scoped_name));
       }
-#line 3597 "parser.c"
+#line 3422 "parser.c"
     break;
 
-  case 183:
-#line 1067 "src/parser.y"
+  case 183: /* annotation_appl_name: identifier  */
+#line 1068 "src/parser.y"
       { TRY(idl_create_scoped_name(pstate, &(yylsp[0]), (yyvsp[0].name), false, &(yyval.scoped_name))); }
-#line 3603 "parser.c"
+#line 3428 "parser.c"
     break;
 
-  case 184:
-#line 1069 "src/parser.y"
+  case 184: /* annotation_appl_name: IDL_TOKEN_SCOPE_NO_SPACE identifier  */
+#line 1070 "src/parser.y"
       { TRY(idl_create_scoped_name(pstate, LOC((yylsp[-1]).first, (yylsp[0]).last), (yyvsp[0].name), true, &(yyval.scoped_name))); }
-#line 3609 "parser.c"
+#line 3434 "parser.c"
     break;
 
-  case 185:
-#line 1071 "src/parser.y"
+  case 185: /* annotation_appl_name: annotation_appl_name IDL_TOKEN_SCOPE_NO_SPACE identifier  */
+#line 1072 "src/parser.y"
       { TRY(idl_push_scoped_name(pstate, (yyvsp[-2].scoped_name), (yyvsp[0].name)));
         (yyval.scoped_name) = (yyvsp[-2].scoped_name);
       }
-#line 3617 "parser.c"
+#line 3442 "parser.c"
     break;
 
-  case 186:
-#line 1078 "src/parser.y"
+  case 186: /* annotation_appl_params: %empty  */
+#line 1079 "src/parser.y"
       { (yyval.annotation_appl_param) = NULL; }
-#line 3623 "parser.c"
+#line 3448 "parser.c"
     break;
 
-  case 187:
-#line 1080 "src/parser.y"
+  case 187: /* annotation_appl_params: '(' const_expr ')'  */
+#line 1081 "src/parser.y"
       { (yyval.annotation_appl_param) = (yyvsp[-1].const_expr); }
-#line 3629 "parser.c"
+#line 3454 "parser.c"
     break;
 
-  case 188:
-#line 1082 "src/parser.y"
+  case 188: /* annotation_appl_params: '(' annotation_appl_keyword_params ')'  */
+#line 1083 "src/parser.y"
       { (yyval.annotation_appl_param) = (yyvsp[-1].annotation_appl_param); }
-#line 3635 "parser.c"
+#line 3460 "parser.c"
     break;
 
-  case 189:
-#line 1087 "src/parser.y"
+  case 189: /* annotation_appl_keyword_params: annotation_appl_keyword_param  */
+#line 1088 "src/parser.y"
       { (yyval.annotation_appl_param) = (yyvsp[0].annotation_appl_param); }
-#line 3641 "parser.c"
+#line 3466 "parser.c"
     break;
 
-  case 190:
-#line 1089 "src/parser.y"
+  case 190: /* annotation_appl_keyword_params: annotation_appl_keyword_params ',' annotation_appl_keyword_param  */
+#line 1090 "src/parser.y"
       { (yyval.annotation_appl_param) = idl_push_node((yyvsp[-2].annotation_appl_param), (yyvsp[0].annotation_appl_param)); }
-#line 3647 "parser.c"
+#line 3472 "parser.c"
     break;
 
-  case 191:
-#line 1094 "src/parser.y"
+  case 191: /* @3: %empty  */
+#line 1095 "src/parser.y"
       { idl_annotation_member_t *node = NULL;
         if (pstate->parser.state != IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS) {
           const idl_declaration_t *declaration = NULL;
@@ -3663,21 +3488,21 @@ _Pragma("GCC diagnostic pop")
         (yyval.annotation_member) = node;
         idl_delete_name((yyvsp[0].name));
       }
-#line 3667 "parser.c"
+#line 3492 "parser.c"
     break;
 
-  case 192:
-#line 1110 "src/parser.y"
+  case 192: /* annotation_appl_keyword_param: identifier @3 '=' const_expr  */
+#line 1111 "src/parser.y"
       { (yyval.annotation_appl_param) = NULL;
         if (pstate->parser.state != IDL_PARSE_UNKNOWN_ANNOTATION_APPL_PARAMS) {
           TRY(idl_create_annotation_appl_param(pstate, &(yylsp[-3]), (yyvsp[-2].annotation_member), (yyvsp[0].const_expr), &(yyval.annotation_appl_param)));
         }
       }
-#line 3677 "parser.c"
+#line 3502 "parser.c"
     break;
 
 
-#line 3681 "parser.c"
+#line 3506 "parser.c"
 
       default: break;
     }
@@ -3692,11 +3517,10 @@ _Pragma("GCC diagnostic pop")
      case of YYERROR or YYBACKUP, subsequent parser actions might lead
      to an incorrect destructor call or verbose syntax error message
      before the lookahead is translated.  */
-  YY_SYMBOL_PRINT ("-> $$ =", yyr1[yyn], &yyval, &yyloc);
+  YY_SYMBOL_PRINT ("-> $$ =", YY_CAST (yysymbol_kind_t, yyr1[yyn]), &yyval, &yyloc);
 
   YYPOPSTACK (yylen);
   yylen = 0;
-  YY_STACK_PRINT (yyss, yyssp);
 
   *++yyvsp = yyval;
   *++yylsp = yyloc;
@@ -3721,66 +3545,31 @@ _Pragma("GCC diagnostic pop")
 yyerrlab:
   /* Make sure we have latest lookahead translation.  See comments at
      user semantic actions for why this is necessary.  */
-  yytoken = yychar == YYEMPTY ? YYEMPTY : YYTRANSLATE (yychar);
-
+  yytoken = yychar == IDL_YYEMPTY ? YYSYMBOL_YYEMPTY : YYTRANSLATE (yychar);
   /* If not already recovering from an error, report this error.  */
   if (!yyerrstatus)
     {
       ++yynerrs;
-#if ! YYERROR_VERBOSE
       yyerror (&yylloc, pstate, result, YY_("syntax error"));
-#else
-# define YYSYNTAX_ERROR yysyntax_error (&yymsg_alloc, &yymsg, \
-                                        yyssp, yytoken)
-      {
-        char const *yymsgp = YY_("syntax error");
-        int yysyntax_error_status;
-        yysyntax_error_status = YYSYNTAX_ERROR;
-        if (yysyntax_error_status == 0)
-          yymsgp = yymsg;
-        else if (yysyntax_error_status == 1)
-          {
-            if (yymsg != yymsgbuf)
-              YYSTACK_FREE (yymsg);
-            yymsg = YY_CAST (char *, YYSTACK_ALLOC (YY_CAST (YYSIZE_T, yymsg_alloc)));
-            if (!yymsg)
-              {
-                yymsg = yymsgbuf;
-                yymsg_alloc = sizeof yymsgbuf;
-                yysyntax_error_status = 2;
-              }
-            else
-              {
-                yysyntax_error_status = YYSYNTAX_ERROR;
-                yymsgp = yymsg;
-              }
-          }
-        yyerror (&yylloc, pstate, result, yymsgp);
-        if (yysyntax_error_status == 2)
-          goto yyexhaustedlab;
-      }
-# undef YYSYNTAX_ERROR
-#endif
     }
 
   yyerror_range[1] = yylloc;
-
   if (yyerrstatus == 3)
     {
       /* If just tried and failed to reuse lookahead token after an
          error, discard it.  */
 
-      if (yychar <= YYEOF)
+      if (yychar <= IDL_YYEOF)
         {
           /* Return failure if at end of input.  */
-          if (yychar == YYEOF)
+          if (yychar == IDL_YYEOF)
             YYABORT;
         }
       else
         {
           yydestruct ("Error: discarding",
                       yytoken, &yylval, &yylloc, pstate, result);
-          yychar = YYEMPTY;
+          yychar = IDL_YYEMPTY;
         }
     }
 
@@ -3797,6 +3586,7 @@ yyerrorlab:
      label yyerrorlab therefore never appears in user code.  */
   if (0)
     YYERROR;
+  ++yynerrs;
 
   /* Do not reclaim the symbols of the rule whose action triggered
      this YYERROR.  */
@@ -3813,13 +3603,14 @@ yyerrorlab:
 yyerrlab1:
   yyerrstatus = 3;      /* Each real token shifted decrements this.  */
 
+  /* Pop stack until we find a state that shifts the error token.  */
   for (;;)
     {
       yyn = yypact[yystate];
       if (!yypact_value_is_default (yyn))
         {
-          yyn += YYTERROR;
-          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYTERROR)
+          yyn += YYSYMBOL_YYerror;
+          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYSYMBOL_YYerror)
             {
               yyn = yytable[yyn];
               if (0 < yyn)
@@ -3833,7 +3624,7 @@ yyerrlab1:
 
       yyerror_range[1] = *yylsp;
       yydestruct ("Error: popping",
-                  yystos[yystate], yyvsp, yylsp, pstate, result);
+                  YY_ACCESSING_SYMBOL (yystate), yyvsp, yylsp, pstate, result);
       YYPOPSTACK (1);
       yystate = *yyssp;
       YY_STACK_PRINT (yyss, yyssp);
@@ -3844,13 +3635,11 @@ yyerrlab1:
   YY_IGNORE_MAYBE_UNINITIALIZED_END
 
   yyerror_range[2] = yylloc;
-  /* Using YYLLOC is tempting, but would change the location of
-     the lookahead.  YYLOC is available though.  */
-  YYLLOC_DEFAULT (yyloc, yyerror_range, 2);
-  *++yylsp = yyloc;
+  ++yylsp;
+  YYLLOC_DEFAULT (*yylsp, yyerror_range, 2);
 
   /* Shift the error token.  */
-  YY_SYMBOL_PRINT ("Shifting", yystos[yyn], yyvsp, yylsp);
+  YY_SYMBOL_PRINT ("Shifting", YY_ACCESSING_SYMBOL (yyn), yyvsp, yylsp);
 
   yystate = yyn;
   goto yynewstate;
@@ -3861,7 +3650,7 @@ yyerrlab1:
 `-------------------------------------*/
 yyacceptlab:
   yyresult = 0;
-  goto yyreturn;
+  goto yyreturnlab;
 
 
 /*-----------------------------------.
@@ -3869,25 +3658,23 @@ yyacceptlab:
 `-----------------------------------*/
 yyabortlab:
   yyresult = 1;
-  goto yyreturn;
+  goto yyreturnlab;
 
 
-#if !defined yyoverflow || YYERROR_VERBOSE
-/*-------------------------------------------------.
-| yyexhaustedlab -- memory exhaustion comes here.  |
-`-------------------------------------------------*/
+/*-----------------------------------------------------------.
+| yyexhaustedlab -- YYNOMEM (memory exhaustion) comes here.  |
+`-----------------------------------------------------------*/
 yyexhaustedlab:
   yyerror (&yylloc, pstate, result, YY_("memory exhausted"));
   yyresult = 2;
-  /* Fall through.  */
-#endif
+  goto yyreturnlab;
 
 
-/*-----------------------------------------------------.
-| yyreturn -- parsing is finished, return the result.  |
-`-----------------------------------------------------*/
-yyreturn:
-  if (yychar != YYEMPTY)
+/*----------------------------------------------------------.
+| yyreturnlab -- parsing is finished, clean up and return.  |
+`----------------------------------------------------------*/
+yyreturnlab:
+  if (yychar != IDL_YYEMPTY)
     {
       /* Make sure we have latest lookahead translation.  See comments at
          user semantic actions for why this is necessary.  */
@@ -3902,27 +3689,34 @@ yyreturn:
   while (yyssp != yyss)
     {
       yydestruct ("Cleanup: popping",
-                  yystos[+*yyssp], yyvsp, yylsp, pstate, result);
+                  YY_ACCESSING_SYMBOL (+*yyssp), yyvsp, yylsp, pstate, result);
       YYPOPSTACK (1);
     }
-#ifndef yyoverflow
-  if (yyss != yyssa)
-    YYSTACK_FREE (yyss);
-#endif
-  yyps->yynew = 1;
+  yyps->yynew = 2;
+  goto yypushreturn;
 
 
-/*-----------------------------------------.
-| yypushreturn -- ask for the next token.  |
-`-----------------------------------------*/
+/*-------------------------.
+| yypushreturn -- return.  |
+`-------------------------*/
 yypushreturn:
-#if YYERROR_VERBOSE
-  if (yymsg != yymsgbuf)
-    YYSTACK_FREE (yymsg);
-#endif
+
   return yyresult;
 }
-#line 1117 "src/parser.y"
+#undef idl_yynerrs
+#undef yystate
+#undef yyerrstatus
+#undef yyssa
+#undef yyss
+#undef yyssp
+#undef yyvsa
+#undef yyvs
+#undef yyvsp
+#undef yylsa
+#undef yyls
+#undef yylsp
+#undef yystacksize
+#line 1118 "src/parser.y"
 
 
 #if defined(__GNUC__)
@@ -4012,12 +3806,4 @@ yyerror(idl_location_t *loc, idl_pstate_t *pstate, idl_retcode_t *result, const 
   idl_error(pstate, loc, "%s", str);
   *result = IDL_RETCODE_SYNTAX_ERROR;
 }
-/* generated from parser.y[8e05cc2c9b914f6a8e34b59ed29b049718b5a42c] */
-/* generated from parser.y[8e05cc2c9b914f6a8e34b59ed29b049718b5a42c] */
-/* generated from parser.y[8e05cc2c9b914f6a8e34b59ed29b049718b5a42c] */
-/* generated from parser.y[8e05cc2c9b914f6a8e34b59ed29b049718b5a42c] */
-/* generated from parser.y[8e05cc2c9b914f6a8e34b59ed29b049718b5a42c] */
-/* generated from parser.y[8e05cc2c9b914f6a8e34b59ed29b049718b5a42c] */
-/* generated from parser.y[8e05cc2c9b914f6a8e34b59ed29b049718b5a42c] */
-/* generated from parser.y[8e05cc2c9b914f6a8e34b59ed29b049718b5a42c] */
-/* generated from parser.y[8e05cc2c9b914f6a8e34b59ed29b049718b5a42c] */
+/* generated from parser.y[821616953efcd355d94b7f7a51f4923bb0119626] */

--- a/src/idl/src/parser.h
+++ b/src/idl/src/parser.h
@@ -1,8 +1,8 @@
-/* A Bison parser, made by GNU Bison 3.5.1.  */
+/* A Bison parser, made by GNU Bison 3.8.2.  */
 
 /* Bison interface for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2020 Free Software Foundation,
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2021 Free Software Foundation,
    Inc.
 
    This program is free software: you can redistribute it and/or modify
@@ -16,7 +16,7 @@
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
 
 /* As a special exception, you may create a larger work that contains
    part or all of the Bison parser skeleton and distribute that work
@@ -31,8 +31,9 @@
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
 
-/* Undocumented macros, especially those whose name start with YY_,
-   are private implementation details.  Do not rely on them.  */
+/* DO NOT RELY ON FEATURES THAT ARE NOT DOCUMENTED in the manual,
+   especially those whose name start with YY_ or yy_.  They are
+   private implementation details that can be changed or removed.  */
 
 #ifndef YY_IDL_YY_PARSER_H_INCLUDED
 # define YY_IDL_YY_PARSER_H_INCLUDED
@@ -52,7 +53,7 @@
 extern int idl_yydebug;
 #endif
 /* "%code requires" blocks.  */
-#line 86 "src/parser.y"
+#line 87 "src/parser.y"
 
 #include "tree.h"
 
@@ -65,73 +66,78 @@ typedef struct idl_location IDL_YYLTYPE;
 #define LOC(first, last) \
   &(IDL_YYLTYPE){ first, last }
 
-#line 69 "parser.h"
+#line 70 "parser.h"
 
-/* Token type.  */
+/* Token kinds.  */
 #ifndef IDL_YYTOKENTYPE
 # define IDL_YYTOKENTYPE
   enum idl_yytokentype
   {
-    IDL_TOKEN_LINE_COMMENT = 258,
-    IDL_TOKEN_COMMENT = 259,
-    IDL_TOKEN_PP_NUMBER = 260,
-    IDL_TOKEN_IDENTIFIER = 261,
-    IDL_TOKEN_CHAR_LITERAL = 262,
-    IDL_TOKEN_STRING_LITERAL = 263,
-    IDL_TOKEN_INTEGER_LITERAL = 264,
-    IDL_TOKEN_FLOATING_PT_LITERAL = 265,
-    IDL_TOKEN_ANNOTATION_SYMBOL = 266,
-    IDL_TOKEN_ANNOTATION = 267,
-    IDL_TOKEN_SCOPE = 268,
-    IDL_TOKEN_SCOPE_NO_SPACE = 269,
-    IDL_TOKEN_MODULE = 270,
-    IDL_TOKEN_CONST = 271,
-    IDL_TOKEN_NATIVE = 272,
-    IDL_TOKEN_STRUCT = 273,
-    IDL_TOKEN_TYPEDEF = 274,
-    IDL_TOKEN_UNION = 275,
-    IDL_TOKEN_SWITCH = 276,
-    IDL_TOKEN_CASE = 277,
-    IDL_TOKEN_DEFAULT = 278,
-    IDL_TOKEN_ENUM = 279,
-    IDL_TOKEN_UNSIGNED = 280,
-    IDL_TOKEN_FIXED = 281,
-    IDL_TOKEN_SEQUENCE = 282,
-    IDL_TOKEN_STRING = 283,
-    IDL_TOKEN_WSTRING = 284,
-    IDL_TOKEN_FLOAT = 285,
-    IDL_TOKEN_DOUBLE = 286,
-    IDL_TOKEN_SHORT = 287,
-    IDL_TOKEN_LONG = 288,
-    IDL_TOKEN_CHAR = 289,
-    IDL_TOKEN_WCHAR = 290,
-    IDL_TOKEN_BOOLEAN = 291,
-    IDL_TOKEN_OCTET = 292,
-    IDL_TOKEN_ANY = 293,
-    IDL_TOKEN_MAP = 294,
-    IDL_TOKEN_BITSET = 295,
-    IDL_TOKEN_BITFIELD = 296,
-    IDL_TOKEN_BITMASK = 297,
-    IDL_TOKEN_INT8 = 298,
-    IDL_TOKEN_INT16 = 299,
-    IDL_TOKEN_INT32 = 300,
-    IDL_TOKEN_INT64 = 301,
-    IDL_TOKEN_UINT8 = 302,
-    IDL_TOKEN_UINT16 = 303,
-    IDL_TOKEN_UINT32 = 304,
-    IDL_TOKEN_UINT64 = 305,
-    IDL_TOKEN_TRUE = 306,
-    IDL_TOKEN_FALSE = 307,
-    IDL_TOKEN_LSHIFT = 308,
-    IDL_TOKEN_RSHIFT = 309
+    IDL_YYEMPTY = -2,
+    IDL_YYEOF = 0,                 /* "end of file"  */
+    IDL_YYerror = 256,             /* error  */
+    IDL_YYUNDEF = 257,             /* "invalid token"  */
+    IDL_TOKEN_LINE_COMMENT = 258,  /* IDL_TOKEN_LINE_COMMENT  */
+    IDL_TOKEN_COMMENT = 259,       /* IDL_TOKEN_COMMENT  */
+    IDL_TOKEN_PP_NUMBER = 260,     /* IDL_TOKEN_PP_NUMBER  */
+    IDL_TOKEN_IDENTIFIER = 261,    /* IDL_TOKEN_IDENTIFIER  */
+    IDL_TOKEN_CHAR_LITERAL = 262,  /* IDL_TOKEN_CHAR_LITERAL  */
+    IDL_TOKEN_STRING_LITERAL = 263, /* IDL_TOKEN_STRING_LITERAL  */
+    IDL_TOKEN_INTEGER_LITERAL = 264, /* IDL_TOKEN_INTEGER_LITERAL  */
+    IDL_TOKEN_FLOATING_PT_LITERAL = 265, /* IDL_TOKEN_FLOATING_PT_LITERAL  */
+    IDL_TOKEN_ANNOTATION_SYMBOL = 266, /* "@"  */
+    IDL_TOKEN_ANNOTATION = 267,    /* "annotation"  */
+    IDL_TOKEN_SCOPE = 268,         /* IDL_TOKEN_SCOPE  */
+    IDL_TOKEN_SCOPE_NO_SPACE = 269, /* IDL_TOKEN_SCOPE_NO_SPACE  */
+    IDL_TOKEN_MODULE = 270,        /* "module"  */
+    IDL_TOKEN_CONST = 271,         /* "const"  */
+    IDL_TOKEN_NATIVE = 272,        /* "native"  */
+    IDL_TOKEN_STRUCT = 273,        /* "struct"  */
+    IDL_TOKEN_TYPEDEF = 274,       /* "typedef"  */
+    IDL_TOKEN_UNION = 275,         /* "union"  */
+    IDL_TOKEN_SWITCH = 276,        /* "switch"  */
+    IDL_TOKEN_CASE = 277,          /* "case"  */
+    IDL_TOKEN_DEFAULT = 278,       /* "default"  */
+    IDL_TOKEN_ENUM = 279,          /* "enum"  */
+    IDL_TOKEN_UNSIGNED = 280,      /* "unsigned"  */
+    IDL_TOKEN_FIXED = 281,         /* "fixed"  */
+    IDL_TOKEN_SEQUENCE = 282,      /* "sequence"  */
+    IDL_TOKEN_STRING = 283,        /* "string"  */
+    IDL_TOKEN_WSTRING = 284,       /* "wstring"  */
+    IDL_TOKEN_FLOAT = 285,         /* "float"  */
+    IDL_TOKEN_DOUBLE = 286,        /* "double"  */
+    IDL_TOKEN_SHORT = 287,         /* "short"  */
+    IDL_TOKEN_LONG = 288,          /* "long"  */
+    IDL_TOKEN_CHAR = 289,          /* "char"  */
+    IDL_TOKEN_WCHAR = 290,         /* "wchar"  */
+    IDL_TOKEN_BOOLEAN = 291,       /* "boolean"  */
+    IDL_TOKEN_OCTET = 292,         /* "octet"  */
+    IDL_TOKEN_ANY = 293,           /* "any"  */
+    IDL_TOKEN_MAP = 294,           /* "map"  */
+    IDL_TOKEN_BITSET = 295,        /* "bitset"  */
+    IDL_TOKEN_BITFIELD = 296,      /* "bitfield"  */
+    IDL_TOKEN_BITMASK = 297,       /* "bitmask"  */
+    IDL_TOKEN_INT8 = 298,          /* "int8"  */
+    IDL_TOKEN_INT16 = 299,         /* "int16"  */
+    IDL_TOKEN_INT32 = 300,         /* "int32"  */
+    IDL_TOKEN_INT64 = 301,         /* "int64"  */
+    IDL_TOKEN_UINT8 = 302,         /* "uint8"  */
+    IDL_TOKEN_UINT16 = 303,        /* "uint16"  */
+    IDL_TOKEN_UINT32 = 304,        /* "uint32"  */
+    IDL_TOKEN_UINT64 = 305,        /* "uint64"  */
+    IDL_TOKEN_TRUE = 306,          /* "TRUE"  */
+    IDL_TOKEN_FALSE = 307,         /* "FALSE"  */
+    IDL_TOKEN_LSHIFT = 308,        /* "<<"  */
+    IDL_TOKEN_RSHIFT = 309         /* ">>"  */
   };
+  typedef enum idl_yytokentype idl_yytoken_kind_t;
 #endif
 
 /* Value type.  */
 #if ! defined IDL_YYSTYPE && ! defined IDL_YYSTYPE_IS_DECLARED
 union IDL_YYSTYPE
 {
-#line 104 "src/parser.y"
+#line 105 "src/parser.y"
 
   void *node;
   /* expressions */
@@ -176,7 +182,7 @@ union IDL_YYSTYPE
   unsigned long long ullng;
   long double ldbl;
 
-#line 180 "parser.h"
+#line 186 "parser.h"
 
 };
 typedef union IDL_YYSTYPE IDL_YYSTYPE;
@@ -200,6 +206,7 @@ struct IDL_YYLTYPE
 
 
 
+
 #ifndef YYPUSH_MORE_DEFINED
 # define YYPUSH_MORE_DEFINED
 enum { YYPUSH_MORE = 4 };
@@ -207,25 +214,20 @@ enum { YYPUSH_MORE = 4 };
 
 typedef struct idl_yypstate idl_yypstate;
 
-int idl_yypush_parse (idl_yypstate *ps, int pushed_char, IDL_YYSTYPE const *pushed_val, IDL_YYLTYPE *pushed_loc, idl_pstate_t *pstate, idl_retcode_t *result);
 
-idl_yypstate * idl_yypstate_new (void);
+int idl_yypush_parse (idl_yypstate *ps,
+                  int pushed_char, IDL_YYSTYPE const *pushed_val, IDL_YYLTYPE *pushed_loc, idl_pstate_t *pstate, idl_retcode_t *result);
+
+idl_yypstate *idl_yypstate_new (void);
 void idl_yypstate_delete (idl_yypstate *ps);
+
 /* "%code provides" blocks.  */
-#line 99 "src/parser.y"
+#line 100 "src/parser.y"
 
 int idl_iskeyword(idl_pstate_t *pstate, const char *str, int nc);
 void idl_yypstate_delete_stack(idl_yypstate *yyps);
 
-#line 221 "parser.h"
+#line 231 "parser.h"
 
 #endif /* !YY_IDL_YY_PARSER_H_INCLUDED  */
-/* generated from parser.y[8e05cc2c9b914f6a8e34b59ed29b049718b5a42c] */
-/* generated from parser.y[8e05cc2c9b914f6a8e34b59ed29b049718b5a42c] */
-/* generated from parser.y[8e05cc2c9b914f6a8e34b59ed29b049718b5a42c] */
-/* generated from parser.y[8e05cc2c9b914f6a8e34b59ed29b049718b5a42c] */
-/* generated from parser.y[8e05cc2c9b914f6a8e34b59ed29b049718b5a42c] */
-/* generated from parser.y[8e05cc2c9b914f6a8e34b59ed29b049718b5a42c] */
-/* generated from parser.y[8e05cc2c9b914f6a8e34b59ed29b049718b5a42c] */
-/* generated from parser.y[8e05cc2c9b914f6a8e34b59ed29b049718b5a42c] */
-/* generated from parser.y[8e05cc2c9b914f6a8e34b59ed29b049718b5a42c] */
+/* generated from parser.y[821616953efcd355d94b7f7a51f4923bb0119626] */

--- a/src/idl/src/parser.y
+++ b/src/idl/src/parser.y
@@ -33,6 +33,7 @@ _Pragma("GCC diagnostic ignored \"-Wsign-conversion\"")
 _Pragma("GCC diagnostic ignored \"-Wmissing-prototypes\"")
 #if (__GNUC__ >= 10)
 _Pragma("GCC diagnostic ignored \"-Wanalyzer-free-of-non-heap\"")
+_Pragma("GCC diagnostic ignored \"-Wanalyzer-malloc-leak\"")
 #endif
 #endif
 

--- a/src/idl/src/vector.c
+++ b/src/idl/src/vector.c
@@ -1,0 +1,106 @@
+/*
+ * Copyright(c) 2022 ZettaScale Technology and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+#define _GNU_SOURCE
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <assert.h>
+
+#include "idl/vector.h"
+
+bool idl_boxed_vector_init (struct idl_boxed_vector *v)
+{
+  v->n = 0;
+  v->cap = 1;
+  v->xs = malloc (v->cap * sizeof (*v->xs));
+  return (v->xs != NULL);
+}
+
+bool idl_boxed_vector_append (struct idl_boxed_vector *v, void *x)
+{
+  if (v->n == v->cap)
+  {
+    assert (v->cap <= SIZE_MAX / 2);
+    const size_t cap1 = 2 * v->cap;
+    void **xs1 = realloc (v->xs, cap1 * sizeof (*xs1));
+    if (xs1 == NULL)
+      return false;
+    v->xs = xs1;
+    v->cap = cap1;
+  }
+  v->xs[v->n++] = x;
+  return true;
+}
+
+void idl_boxed_vector_fini (struct idl_boxed_vector *c, void (*f) (void *x))
+{
+  for (size_t i = 0; i < c->n; i++)
+    f (c->xs[i]);
+  free (c->xs);
+}
+
+void *idl_boxed_vector_next (struct idl_boxed_vector_iter *it)
+{
+  return (it->i < it->v->n) ? it->v->xs[it->i++] : NULL;
+}
+
+void *idl_boxed_vector_first (struct idl_boxed_vector *v, struct idl_boxed_vector_iter *it)
+{
+  it->v = v;
+  it->i = 0;
+  return idl_boxed_vector_next (it);
+}
+
+const void *idl_boxed_vector_next_c (struct idl_boxed_vector_iter *it)
+{
+  return idl_boxed_vector_next (it);
+}
+
+const void *idl_boxed_vector_first_c (const struct idl_boxed_vector *v, struct idl_boxed_vector_iter *it)
+{
+  return idl_boxed_vector_first ((struct idl_boxed_vector *) v, it);
+}
+
+struct cmp_context {
+  int (*cmp) (const void *a, const void *b);
+};
+
+#if defined __GLIBC__
+static int cmp_wrapper (const void *va, const void *vb, void *vcontext)
+{
+  struct cmp_context *context = vcontext;
+  const void * const *a = va;
+  const void * const *b = vb;
+  return context->cmp (*a, *b);
+}
+#else
+static int cmp_wrapper (void *vcontext, const void *va, const void *vb)
+{
+  struct cmp_context *context = vcontext;
+  const void * const *a = va;
+  const void * const *b = vb;
+  return context->cmp (*a, *b);
+}
+#endif
+
+void idl_boxed_vector_sort (struct idl_boxed_vector *v, int (*cmp) (const void *a, const void *b))
+{
+  struct cmp_context context = { .cmp = cmp };
+#if defined __GLIBC__
+  qsort_r (v->xs, v->n, sizeof (*v->xs), cmp_wrapper, &context);
+#elif _WIN32
+  qsort_s (v->xs, v->n, sizeof (*v->xs), cmp_wrapper, &context);
+#else
+  qsort_r (v->xs, v->n, sizeof (*v->xs), &context, cmp_wrapper);
+#endif
+}

--- a/src/idl/src/vector.c
+++ b/src/idl/src/vector.c
@@ -17,12 +17,13 @@
 #include <assert.h>
 
 #include "idl/vector.h"
+#include "idl/heap.h"
 
 bool idl_boxed_vector_init (struct idl_boxed_vector *v)
 {
   v->n = 0;
   v->cap = 1;
-  v->xs = malloc (v->cap * sizeof (*v->xs));
+  v->xs = idl_malloc (v->cap * sizeof (*v->xs));
   return (v->xs != NULL);
 }
 
@@ -32,7 +33,7 @@ bool idl_boxed_vector_append (struct idl_boxed_vector *v, void *x)
   {
     assert (v->cap <= SIZE_MAX / 2);
     const size_t cap1 = 2 * v->cap;
-    void **xs1 = realloc (v->xs, cap1 * sizeof (*xs1));
+    void **xs1 = idl_realloc (v->xs, cap1 * sizeof (*xs1));
     if (xs1 == NULL)
       return false;
     v->xs = xs1;
@@ -46,7 +47,7 @@ void idl_boxed_vector_fini (struct idl_boxed_vector *c, void (*f) (void *x))
 {
   for (size_t i = 0; i < c->n; i++)
     f (c->xs[i]);
-  free (c->xs);
+  idl_free (c->xs);
 }
 
 void *idl_boxed_vector_next (struct idl_boxed_vector_iter *it)

--- a/src/security/builtin_plugins/access_control/src/access_control.c
+++ b/src/security/builtin_plugins/access_control/src/access_control.c
@@ -2398,7 +2398,7 @@ check_and_create_remote_participant_rights(
     /* use default permissions document (all deny) if there is no permissions file
          *to communicate with access_control=false and comply with previous release */
     struct domain_rule *domainRule = find_domain_rule_in_governance(local_rights->governance_tree->dds->domain_access_rules->domain_rule, local_rights->domain_id);
-    if (!domainRule->enable_join_access_control->value)
+    if (domainRule && !domainRule->enable_join_access_control->value)
     {
       permissions_xml = ddsrt_str_replace(DDS_SECURITY_DEFAULT_PERMISSIONS, "DEFAULT_SUBJECT", identity_subject, 1);
     }

--- a/src/security/builtin_plugins/tests/encode_rtps_message/src/encode_rtps_message_utests.c
+++ b/src/security/builtin_plugins/tests/encode_rtps_message/src/encode_rtps_message_utests.c
@@ -962,6 +962,7 @@ static void encode_rtps_message_sign(DDS_Security_CryptoTransformKind_Enum trans
   /* Now call the function. */
 
   buffer = &plain_buffer;
+  encoded_buffer._buffer = NULL;
   while ((uint32_t) index != reader_list._length)
   {
     result = crypto->crypto_transform->encode_rtps_message(
@@ -979,12 +980,17 @@ static void encode_rtps_message_sign(DDS_Security_CryptoTransformKind_Enum trans
     }
 
     CU_ASSERT_FATAL(result);
+    assert(result);
     CU_ASSERT(exception.code == 0);
     CU_ASSERT(exception.message == NULL);
+
+    if (index == 0)
+      assert (encoded_buffer._buffer != NULL);
 
     reset_exception(&exception);
     buffer = NULL;
   }
+  assert (encoded_buffer._buffer != NULL);
 
   result = check_encoded_data(&encoded_buffer, encoded, &header, &footer, &data);
   CU_ASSERT_FATAL(result);

--- a/src/security/builtin_plugins/tests/get_authenticated_peer_credential_token/src/get_authenticated_peer_credential_token_utests.c
+++ b/src/security/builtin_plugins/tests/get_authenticated_peer_credential_token/src/get_authenticated_peer_credential_token_utests.c
@@ -1555,8 +1555,9 @@ CU_Test(ddssec_builtin_get_authenticated_peer_credential,token_after_reply )
 
     c_perm = find_property(&credential_token, DDS_AUTHTOKEN_PROP_C_PERM);
     CU_ASSERT_FATAL(c_perm != NULL);
+    assert(c_perm); // for Clang, GCC static analyzers
     CU_ASSERT_FATAL(c_perm->value != NULL);
-    assert(c_perm && c_perm->value); // for Clang's static analyzer
+    assert(c_perm->value); // for Clang's static analyzer
     //printf("c_perm->value: %s\n", c_perm->value);
     CU_ASSERT(strcmp(c_perm->value, PERMISSIONS_DOCUMENT) == 0);
 

--- a/src/tools/idlc/src/descriptor_type_meta.c
+++ b/src/tools/idlc/src/descriptor_type_meta.c
@@ -1612,6 +1612,18 @@ xtypes_typeinfo_fini (struct DDS_XTypes_TypeInformation *type_information)
     idl_free (type_information->complete.dependent_typeids._buffer);
 }
 
+static void
+generate_type_meta_ser_impl_free_mapping_buffers (
+  DDS_XTypes_TypeMapping *mapping)
+{
+  if (mapping->identifier_complete_minimal._buffer)
+    idl_free (mapping->identifier_complete_minimal._buffer);
+  if (mapping->identifier_object_pair_complete._buffer)
+    idl_free (mapping->identifier_object_pair_complete._buffer);
+  if (mapping->identifier_object_pair_minimal._buffer)
+    idl_free (mapping->identifier_object_pair_minimal._buffer);
+}
+
 static idl_retcode_t
 generate_type_meta_ser_impl (
   const idl_pstate_t *pstate,
@@ -1687,20 +1699,17 @@ generate_type_meta_ser_impl (
 
   if ((ret = xcdr2_ser (&mapping, &DDS_XTypes_TypeMapping_desc, os_typemap)) < 0)
     goto err_map_ser;
-  ret = IDL_RETCODE_OK;
+
+  generate_type_meta_ser_impl_free_mapping_buffers (&mapping);
+  descriptor_type_meta_fini (&dtm);
+  return IDL_RETCODE_OK;
 
 err_map_ser:
 err_map:
-  if (mapping.identifier_complete_minimal._buffer)
-    idl_free (mapping.identifier_complete_minimal._buffer);
-  if (mapping.identifier_object_pair_complete._buffer)
-    idl_free (mapping.identifier_object_pair_complete._buffer);
-  if (mapping.identifier_object_pair_minimal._buffer)
-    idl_free (mapping.identifier_object_pair_minimal._buffer);
+  generate_type_meta_ser_impl_free_mapping_buffers (&mapping);
 err_dep_ser:
 err_dep:
-  if (ret)
-    xtypes_typeinfo_fini (type_information);
+  xtypes_typeinfo_fini (type_information);
 err_gen:
   descriptor_type_meta_fini (&dtm);
   return ret;

--- a/src/tools/idlc/src/idlc.c
+++ b/src/tools/idlc/src/idlc.c
@@ -22,6 +22,7 @@
 
 #include "dds/features.h"
 #include "idl/heap.h"
+#include "idl/misc.h"
 #include "idl/tree.h"
 #include "idl/string.h"
 #include "idl/processor.h"
@@ -323,6 +324,9 @@ static idl_retcode_t idlc_parse(const idl_builtin_annotation_t ** generator_anno
       pstate = NULL;
       return ret;
     }
+#if __GNUC__ >= 12
+    IDL_WARNING_GNUC_OFF(analyzer-malloc-leak)
+#endif
     if ((pstate->files = idlc_parse_make_file (config.file)) == NULL)
     {
       idl_delete_pstate(pstate);
@@ -335,6 +339,9 @@ static idl_retcode_t idlc_parse(const idl_builtin_annotation_t ** generator_anno
       pstate = NULL;
       return IDL_RETCODE_NO_MEMORY;
     }
+#if __GNUC__ >= 12
+    IDL_WARNING_GNUC_ON(analyzer-malloc-leak)
+#endif
     pstate->config.flags |= IDL_WRITE;
     pstate->config.default_extensibility = config.default_extensibility;
     pstate->config.default_nested = config.default_nested;
@@ -377,10 +384,16 @@ static idl_retcode_t idlc_parse(const idl_builtin_annotation_t ** generator_anno
         ret = IDL_RETCODE_NO_ENTRY;
     } else {
       while ((nrd = fread(buf, sizeof(buf), 1, fin)) > 0) {
+#if __GNUC__ >= 12
+        IDL_WARNING_GNUC_OFF(analyzer-malloc-leak)
+#endif
         if ((nwr = idlc_putn(buf, nrd)) == -1) {
           ret = retcode;
           assert(ret != 0);
         }
+#if __GNUC__ >= 12
+        IDL_WARNING_GNUC_ON(analyzer-malloc-leak)
+#endif
         assert(nrd == (size_t)nwr);
       }
       if (fin != stdin)

--- a/src/tools/idlc/src/idlc.c
+++ b/src/tools/idlc/src/idlc.c
@@ -269,6 +269,37 @@ err_file:
   return ret;
 }
 
+static idl_file_t *idlc_parse_make_file (const char *file)
+{
+  idl_file_t *f;
+  if ((f = idl_malloc(sizeof(*f))) == NULL)
+    return NULL;
+  f->next = NULL;
+  if (!(f->name = idl_strdup(file))) {
+    idl_free(f);
+    return NULL;
+  }
+  return f;
+}
+
+static idl_source_t *idlc_parse_make_source (idl_position_t *position, idl_file_t *paths, idl_file_t *files)
+{
+  idl_source_t *source;
+  if ((source = idl_malloc (sizeof (*source))) == NULL)
+    return NULL;
+  source->parent = NULL;
+  source->previous = source->next = NULL;
+  source->includes = NULL;
+  source->additional_directory = false;
+  source->path = paths;
+  source->file = files;
+  position->source = source;
+  position->file = (const idl_file_t *) files;
+  position->line = 1;
+  position->column = 1;
+  return source;
+}
+
 static idl_retcode_t idlc_parse(const idl_builtin_annotation_t ** generator_annotations)
 {
   idl_retcode_t ret = IDL_RETCODE_OK;
@@ -280,8 +311,8 @@ static idl_retcode_t idlc_parse(const idl_builtin_annotation_t ** generator_anno
     flags |= IDL_FLAG_CASE_SENSITIVE;
 
   if(config.compile) {
-    idl_source_t *source;
     if ((ret = idl_create_pstate(flags, generator_annotations == NULL ? NULL : *generator_annotations, &pstate))) {
+      pstate = NULL;
       return ret;
     }
     assert(config.file);
@@ -289,33 +320,21 @@ static idl_retcode_t idlc_parse(const idl_builtin_annotation_t ** generator_anno
       if (ret == IDL_RETCODE_NO_ENTRY)
         idl_error(pstate, NULL, "could not open file at location: %s", config.file);
       idl_delete_pstate(pstate);
+      pstate = NULL;
       return ret;
     }
-    if (!(pstate->files = idl_malloc(sizeof(*pstate->files)))) {
+    if ((pstate->files = idlc_parse_make_file (config.file)) == NULL)
+    {
       idl_delete_pstate(pstate);
+      pstate = NULL;
       return IDL_RETCODE_NO_MEMORY;
     }
-    pstate->files->next = NULL;
-    if (!(pstate->files->name = idl_strdup(config.file))) {
+    if ((pstate->sources = idlc_parse_make_source (&pstate->scanner.position, pstate->paths, pstate->files)) == NULL)
+    {
       idl_delete_pstate(pstate);
+      pstate = NULL;
       return IDL_RETCODE_NO_MEMORY;
     }
-    if (!(source = idl_malloc(sizeof(*source)))) {
-      idl_delete_pstate(pstate);
-      return IDL_RETCODE_NO_MEMORY;
-    }
-    source->parent = NULL;
-    source->previous = source->next = NULL;
-    source->includes = NULL;
-    source->additional_directory = false;
-    source->path = pstate->paths;
-    source->file = pstate->files;
-    pstate->sources = source;
-    /* populate first source file */
-    pstate->scanner.position.source = source;
-    pstate->scanner.position.file = (const idl_file_t *)pstate->files;
-    pstate->scanner.position.line = 1;
-    pstate->scanner.position.column = 1;
     pstate->config.flags |= IDL_WRITE;
     pstate->config.default_extensibility = config.default_extensibility;
     pstate->config.default_nested = config.default_nested;
@@ -370,6 +389,7 @@ static idl_retcode_t idlc_parse(const idl_builtin_annotation_t ** generator_anno
   }
 
   if (ret == IDL_RETCODE_OK && config.compile) {
+    assert(pstate);
     ret = idl_parse(pstate);
     assert(ret != IDL_RETCODE_NEED_REFILL);
     if (ret == IDL_RETCODE_OK) {
@@ -388,6 +408,11 @@ static idl_retcode_t idlc_parse(const idl_builtin_annotation_t ** generator_anno
     }
   }
 
+  if (ret != IDL_RETCODE_OK)
+  {
+    idl_delete_pstate(pstate);
+    pstate = NULL;
+  }
   return ret;
 }
 
@@ -742,7 +767,6 @@ int main(int argc, char *argv[])
         idl_free(generator_config.output_dir);
       if(generator_config.base_dir)
         idl_free(generator_config.base_dir);
-      idl_delete_pstate(pstate);
       if (ret) {
         fprintf(stderr, "Failed to compile '%s'\n", config.file);
         goto err_generate;
@@ -760,5 +784,6 @@ err_alloc_opts:
     idl_free(config.disable_warnings.list);
   idl_free(config.argv);
 err_argv:
+  idl_delete_pstate(pstate);
   return exit_code;
 }

--- a/src/tools/idlc/tests/type_meta.c
+++ b/src/tools/idlc/tests/type_meta.c
@@ -32,6 +32,15 @@
 
 #ifdef DDS_HAS_TYPE_DISCOVERY
 
+static void *calloc_no_fail (size_t count, size_t size)
+{
+  assert (count > 0 && size > 0);
+  void *p = calloc (count, size);
+  if (p == NULL)
+    abort ();
+  return p;
+}
+
 /* In a type object, case label is stored as 32 bits signed integer,
    so this test should be enabled when type object generation is enabled */
 CU_Test(idlc_type_meta, union_max_label_value)
@@ -125,7 +134,7 @@ static void xcdr2_deser (unsigned char *buf, uint32_t sz, void **obj, const dds_
     data = buf;
 
   dds_istream_t is = { .m_buffer = data, .m_index = 0, .m_size = sz, .m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2 };
-  *obj = calloc (1, desc->m_size);
+  *obj = calloc_no_fail (1, desc->m_size);
   dds_stream_read (&is, (void *) *obj, desc->m_ops);
   if (bswap)
     free (data);
@@ -135,7 +144,7 @@ static void xcdr2_deser (unsigned char *buf, uint32_t sz, void **obj, const dds_
 typedef struct smember { uint32_t id; uint16_t flags; DDS_XTypes_TypeIdentifier ti; DDS_XTypes_MemberName name; } smember_t;
 static struct DDS_XTypes_CompleteStructMember *get_typeobj_struct_member_seq(uint32_t cnt, struct smember *m)
 {
-  struct DDS_XTypes_CompleteStructMember *member_seq = calloc (cnt, sizeof (*member_seq));
+  struct DDS_XTypes_CompleteStructMember *member_seq = calloc_no_fail (cnt, sizeof (*member_seq));
   for (uint32_t n = 0; n < cnt; n++)
   {
     member_seq[n] = (DDS_XTypes_CompleteStructMember) { .common = { .member_id = m[n].id, .member_flags = m[n].flags, .member_type_id = m[n].ti } };
@@ -148,7 +157,7 @@ static struct DDS_XTypes_CompleteStructMember *get_typeobj_struct_member_seq(uin
 typedef struct umember { uint32_t id; uint16_t flags; DDS_XTypes_TypeIdentifier ti; DDS_XTypes_MemberName name; uint32_t num_case_labels; int32_t *case_labels; } umember_t;
 static struct DDS_XTypes_CompleteUnionMember *get_typeobj_union_member_seq(uint32_t cnt, struct umember *m)
 {
-  struct DDS_XTypes_CompleteUnionMember *member_seq = calloc (cnt, sizeof (*member_seq));
+  struct DDS_XTypes_CompleteUnionMember *member_seq = calloc_no_fail (cnt, sizeof (*member_seq));
   for (uint32_t n = 0; n < cnt; n++)
   {
     member_seq[n] = (DDS_XTypes_CompleteUnionMember) { .common = { .member_id = m[n].id, .member_flags = m[n].flags, .type_id = m[n].ti } };
@@ -156,7 +165,7 @@ static struct DDS_XTypes_CompleteUnionMember *get_typeobj_union_member_seq(uint3
     member_seq[n].common.label_seq._length = m[n].num_case_labels;
     if (m[n].num_case_labels > 0)
     {
-      member_seq[n].common.label_seq._buffer = calloc (m[n].num_case_labels, sizeof (*member_seq[n].common.label_seq._buffer));
+      member_seq[n].common.label_seq._buffer = calloc_no_fail (m[n].num_case_labels, sizeof (*member_seq[n].common.label_seq._buffer));
       for (uint32_t cl = 0; cl < m[n].num_case_labels; cl++)
         member_seq[n].common.label_seq._buffer[cl] = m[n].case_labels[cl];
       member_seq[n].common.label_seq._release = true;
@@ -169,7 +178,7 @@ static struct DDS_XTypes_CompleteUnionMember *get_typeobj_union_member_seq(uint3
 
 static DDS_XTypes_TypeObject *get_typeobj_struct(const char *name, uint16_t flags, DDS_XTypes_TypeIdentifier base, uint32_t member_cnt, struct smember *members)
 {
-  DDS_XTypes_TypeObject *to = calloc (1, sizeof (*to));
+  DDS_XTypes_TypeObject *to = calloc_no_fail (1, sizeof (*to));
   to->_d = DDS_XTypes_EK_COMPLETE;
   to->_u.complete = (DDS_XTypes_CompleteTypeObject) {
     ._d = DDS_XTypes_TK_STRUCTURE,
@@ -191,7 +200,7 @@ static DDS_XTypes_TypeObject *get_typeobj_struct(const char *name, uint16_t flag
 
 static DDS_XTypes_TypeObject *get_typeobj_union(const char *name, uint16_t flags, DDS_XTypes_TypeIdentifier disc_type, uint32_t member_cnt, struct umember *members)
 {
-  DDS_XTypes_TypeObject *to = calloc (1, sizeof (*to));
+  DDS_XTypes_TypeObject *to = calloc_no_fail (1, sizeof (*to));
   to->_d = DDS_XTypes_EK_COMPLETE;
   to->_u.complete = (DDS_XTypes_CompleteTypeObject) {
     ._d = DDS_XTypes_TK_UNION,
@@ -284,12 +293,12 @@ static DDS_XTypes_TypeObject *get_typeobj4 (void)
 
 static DDS_XTypes_TypeObject *get_typeobj5 (void)
 {
-  DDS_XTypes_TypeIdentifier *ti_long = calloc (1, sizeof (*ti_long));
+  DDS_XTypes_TypeIdentifier *ti_long = calloc_no_fail (1, sizeof (*ti_long));
   ti_long->_d = DDS_XTypes_TK_INT32;
 
   /* get type identifier for typedef */
   DDS_XTypes_TypeIdentifier ti_alias;
-  DDS_XTypes_TypeObject *to_alias = calloc (1, sizeof (*to_alias));
+  DDS_XTypes_TypeObject *to_alias = calloc_no_fail (1, sizeof (*to_alias));
   to_alias->_d = DDS_XTypes_EK_COMPLETE;
   to_alias->_u.complete = (DDS_XTypes_CompleteTypeObject) {
     ._d = DDS_XTypes_TK_ALIAS,
@@ -316,7 +325,7 @@ static DDS_XTypes_TypeObject *get_typeobj5 (void)
       .bound = 0
     }
   };
-  ti_seq._u.seq_sdefn.element_identifier = calloc (1, sizeof (*ti_seq._u.seq_sdefn.element_identifier));
+  ti_seq._u.seq_sdefn.element_identifier = calloc_no_fail (1, sizeof (*ti_seq._u.seq_sdefn.element_identifier));
   memcpy (ti_seq._u.seq_sdefn.element_identifier, &ti_alias, sizeof (ti_alias));
 
   return get_typeobj_struct (
@@ -335,10 +344,10 @@ static DDS_XTypes_TypeObject *get_typeobj6 (void)
 
   /* f1 type identifier: long f1[5] */
   {
-    DDS_XTypes_TypeIdentifier *ti_f1_el = calloc (1, sizeof (*ti_f1_el));
+    DDS_XTypes_TypeIdentifier *ti_f1_el = calloc_no_fail (1, sizeof (*ti_f1_el));
     ti_f1_el->_d = DDS_XTypes_TK_INT32;
 
-    uint8_t *f1bound_seq = calloc (1, sizeof (*f1bound_seq));
+    uint8_t *f1bound_seq = calloc_no_fail (1, sizeof (*f1bound_seq));
     f1bound_seq[0] = 5;
     ti_f1 = (DDS_XTypes_TypeIdentifier) {
       ._d = DDS_XTypes_TI_PLAIN_ARRAY_SMALL,
@@ -359,11 +368,11 @@ static DDS_XTypes_TypeObject *get_typeobj6 (void)
 
   /* f2 type identifier: string<555> f2[999][3] */
   {
-    DDS_XTypes_TypeIdentifier *ti_f2_el = calloc (1, sizeof (*ti_f2_el));
+    DDS_XTypes_TypeIdentifier *ti_f2_el = calloc_no_fail (1, sizeof (*ti_f2_el));
     ti_f2_el->_d = DDS_XTypes_TI_STRING8_LARGE;
     ti_f2_el->_u.string_ldefn.bound = 555;
 
-    uint32_t *f2bound_seq = calloc (2, sizeof (*f2bound_seq));
+    uint32_t *f2bound_seq = calloc_no_fail (2, sizeof (*f2bound_seq));
     f2bound_seq[0] = 999;
     f2bound_seq[1] = 3;
     ti_f2 = (DDS_XTypes_TypeIdentifier) {
@@ -383,7 +392,7 @@ static DDS_XTypes_TypeObject *get_typeobj6 (void)
   /* f3 type identifier: a[3] f3 */
   {
     /* type a identifier */
-    DDS_XTypes_TypeIdentifier *ti_a = calloc (1, sizeof (*ti_a));
+    DDS_XTypes_TypeIdentifier *ti_a = calloc_no_fail (1, sizeof (*ti_a));
     get_typeid (ti_a, get_typeobj_struct (
       "t6::a",
       DDS_XTypes_IS_FINAL | DDS_XTypes_IS_NESTED,
@@ -392,7 +401,7 @@ static DDS_XTypes_TypeObject *get_typeobj6 (void)
         { 0, DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TK_INT32 }, "a1" }
       }));
 
-    uint8_t *f3bound_seq = calloc (1, sizeof (*f3bound_seq));
+    uint8_t *f3bound_seq = calloc_no_fail (1, sizeof (*f3bound_seq));
     f3bound_seq[0] = 3;
     ti_f3 = (DDS_XTypes_TypeIdentifier) {
       ._d = DDS_XTypes_TI_PLAIN_ARRAY_SMALL,
@@ -425,11 +434,11 @@ static DDS_XTypes_TypeObject *get_typeobj7 (void)
 
   /* f1 type identifier */
   {
-    struct DDS_XTypes_CompleteBitflag *flag_seq = calloc (2, sizeof (*flag_seq));
+    struct DDS_XTypes_CompleteBitflag *flag_seq = calloc_no_fail (2, sizeof (*flag_seq));
     flag_seq[0] = (DDS_XTypes_CompleteBitflag) { .common = { .position = 0, .flags = 0 }, .detail.name = "bm0" };
     flag_seq[1] = (DDS_XTypes_CompleteBitflag) { .common = { .position = 5, .flags = 0 }, .detail.name = "bm5" };
 
-    DDS_XTypes_TypeObject *to_bitmask = calloc (1, sizeof (*to_bitmask));
+    DDS_XTypes_TypeObject *to_bitmask = calloc_no_fail (1, sizeof (*to_bitmask));
     to_bitmask->_d = DDS_XTypes_EK_COMPLETE;
     to_bitmask->_u.complete = (DDS_XTypes_CompleteTypeObject) {
       ._d = DDS_XTypes_TK_BITMASK,
@@ -444,11 +453,11 @@ static DDS_XTypes_TypeObject *get_typeobj7 (void)
 
   /* f2 type identifier */
   {
-    struct DDS_XTypes_CompleteEnumeratedLiteral *literal_seq = calloc (2, sizeof (*literal_seq));
+    struct DDS_XTypes_CompleteEnumeratedLiteral *literal_seq = calloc_no_fail (2, sizeof (*literal_seq));
     literal_seq[0] = (DDS_XTypes_CompleteEnumeratedLiteral) { .common = { .value = 0, .flags = 0 }, .detail.name = "en0" };
     literal_seq[1] = (DDS_XTypes_CompleteEnumeratedLiteral) { .common = { .value = 3, .flags = 0 }, .detail.name = "en3" };
 
-    DDS_XTypes_TypeObject *to_enum = calloc (1, sizeof (*to_enum));
+    DDS_XTypes_TypeObject *to_enum = calloc_no_fail (1, sizeof (*to_enum));
     to_enum->_d = DDS_XTypes_EK_COMPLETE;
     to_enum->_u.complete = (DDS_XTypes_CompleteTypeObject) {
       ._d = DDS_XTypes_TK_ENUM,
@@ -477,10 +486,10 @@ static DDS_XTypes_TypeObject *get_typeobj8 (void)
 
   /* f1 type identifier: unsigned long long f1[1][1] */
   {
-    DDS_XTypes_TypeIdentifier *ti_f1_el = calloc (1, sizeof (*ti_f1_el));
+    DDS_XTypes_TypeIdentifier *ti_f1_el = calloc_no_fail (1, sizeof (*ti_f1_el));
     ti_f1_el->_d = DDS_XTypes_TK_UINT64;
 
-    uint8_t *f1bound_seq = calloc (2, sizeof (*f1bound_seq));
+    uint8_t *f1bound_seq = calloc_no_fail (2, sizeof (*f1bound_seq));
     f1bound_seq[0] = 1;
     f1bound_seq[1] = 1;
     ti_f1 = (DDS_XTypes_TypeIdentifier) {
@@ -508,11 +517,11 @@ static DDS_XTypes_TypeObject *get_typeobj9 (void)
 
   /* f1 and f2 type identifier */
   {
-    struct DDS_XTypes_CompleteBitflag *flag_seq = calloc (2, sizeof (*flag_seq));
+    struct DDS_XTypes_CompleteBitflag *flag_seq = calloc_no_fail (2, sizeof (*flag_seq));
     flag_seq[0] = (DDS_XTypes_CompleteBitflag) { .common = { .position = 0, .flags = 0 }, .detail.name = "bm0" };
     flag_seq[1] = (DDS_XTypes_CompleteBitflag) { .common = { .position = 1, .flags = 0 }, .detail.name = "bm1" };
 
-    DDS_XTypes_TypeObject *to_bitmask = calloc (1, sizeof (*to_bitmask));
+    DDS_XTypes_TypeObject *to_bitmask = calloc_no_fail (1, sizeof (*to_bitmask));
     to_bitmask->_d = DDS_XTypes_EK_COMPLETE;
     to_bitmask->_u.complete = (DDS_XTypes_CompleteTypeObject) {
       ._d = DDS_XTypes_TK_BITMASK,
@@ -541,11 +550,11 @@ static DDS_XTypes_TypeObject *get_typeobj10 (void)
 
   /* f1 and f2 type identifier */
   {
-    struct DDS_XTypes_CompleteEnumeratedLiteral *literal_seq = calloc (2, sizeof (*literal_seq));
+    struct DDS_XTypes_CompleteEnumeratedLiteral *literal_seq = calloc_no_fail (2, sizeof (*literal_seq));
     literal_seq[0] = (DDS_XTypes_CompleteEnumeratedLiteral) { .common = { .value = 0, .flags = 0 }, .detail.name = "en0" };
     literal_seq[1] = (DDS_XTypes_CompleteEnumeratedLiteral) { .common = { .value = 1, .flags = 0 }, .detail.name = "en1" };
 
-    DDS_XTypes_TypeObject *to_enum = calloc (1, sizeof (*to_enum));
+    DDS_XTypes_TypeObject *to_enum = calloc_no_fail (1, sizeof (*to_enum));
     to_enum->_d = DDS_XTypes_EK_COMPLETE;
     to_enum->_u.complete = (DDS_XTypes_CompleteTypeObject) {
       ._d = DDS_XTypes_TK_ENUM,
@@ -587,13 +596,13 @@ static DDS_XTypes_TypeObject *get_typeobj12 (void)
 
   /* f1 type identifier */
   {
-    DDS_XTypes_TypeIdentifier *ti_long = calloc (1, sizeof (*ti_long));
+    DDS_XTypes_TypeIdentifier *ti_long = calloc_no_fail (1, sizeof (*ti_long));
     ti_long->_d = DDS_XTypes_TK_INT32;
 
     /* typedef sequence<long> td_seq */
-    DDS_XTypes_TypeIdentifier *ti_alias_seq = calloc (1, sizeof (*ti_alias_seq));
+    DDS_XTypes_TypeIdentifier *ti_alias_seq = calloc_no_fail (1, sizeof (*ti_alias_seq));
 
-    DDS_XTypes_TypeObject *to_alias_seq = calloc (1, sizeof (*to_alias_seq));
+    DDS_XTypes_TypeObject *to_alias_seq = calloc_no_fail (1, sizeof (*to_alias_seq));
     to_alias_seq->_d = DDS_XTypes_EK_COMPLETE;
     to_alias_seq->_u.complete = (DDS_XTypes_CompleteTypeObject) {
       ._d = DDS_XTypes_TK_ALIAS,
@@ -613,9 +622,9 @@ static DDS_XTypes_TypeObject *get_typeobj12 (void)
     get_typeid (ti_alias_seq, to_alias_seq);
 
     /* typedef td_seq td_array[2] */
-    uint8_t *bound_seq = calloc (1, sizeof (*bound_seq));
+    uint8_t *bound_seq = calloc_no_fail (1, sizeof (*bound_seq));
     bound_seq[0] = 2;
-    DDS_XTypes_TypeObject *to_alias_arr = calloc (1, sizeof (*to_alias_arr));
+    DDS_XTypes_TypeObject *to_alias_arr = calloc_no_fail (1, sizeof (*to_alias_arr));
     to_alias_arr->_d = DDS_XTypes_EK_COMPLETE;
     to_alias_arr->_u.complete = (DDS_XTypes_CompleteTypeObject) {
       ._d = DDS_XTypes_TK_ALIAS,
@@ -650,12 +659,12 @@ static DDS_XTypes_TypeObject *get_typeobj13 (void)
 
   /* f1 type identifier */
   {
-    DDS_XTypes_TypeIdentifier *ti_long = calloc (1, sizeof (*ti_long));
+    DDS_XTypes_TypeIdentifier *ti_long = calloc_no_fail (1, sizeof (*ti_long));
     ti_long->_d = DDS_XTypes_TK_INT32;
 
     /* typedef long td_arr[3] */
-    DDS_XTypes_TypeObject *to_alias_arr = calloc (1, sizeof (*to_alias_arr));
-    uint8_t *bound_seq = calloc (1, sizeof (*bound_seq));
+    DDS_XTypes_TypeObject *to_alias_arr = calloc_no_fail (1, sizeof (*to_alias_arr));
+    uint8_t *bound_seq = calloc_no_fail (1, sizeof (*bound_seq));
     bound_seq[0] = 3;
     to_alias_arr->_d = DDS_XTypes_EK_COMPLETE;
     to_alias_arr->_u.complete = (DDS_XTypes_CompleteTypeObject) {
@@ -675,7 +684,7 @@ static DDS_XTypes_TypeObject *get_typeobj13 (void)
     };
 
     /* typedef td_seq td */
-    DDS_XTypes_TypeObject *to_alias = calloc (1, sizeof (*to_alias));
+    DDS_XTypes_TypeObject *to_alias = calloc_no_fail (1, sizeof (*to_alias));
     to_alias->_d = DDS_XTypes_EK_COMPLETE;
     to_alias->_u.complete = (DDS_XTypes_CompleteTypeObject) {
       ._d = DDS_XTypes_TK_ALIAS,
@@ -705,10 +714,10 @@ static DDS_XTypes_TypeObject *get_typeobj14 (void)
 
   /* f1 type identifier */
   {
-    DDS_XTypes_TypeIdentifier *ti_long = calloc (1, sizeof (*ti_long));
+    DDS_XTypes_TypeIdentifier *ti_long = calloc_no_fail (1, sizeof (*ti_long));
     ti_long->_d = DDS_XTypes_TK_INT32;
 
-    DDS_XTypes_TypeIdentifier *ti_seq = calloc (1, sizeof (*ti_seq));
+    DDS_XTypes_TypeIdentifier *ti_seq = calloc_no_fail (1, sizeof (*ti_seq));
     ti_seq->_d = DDS_XTypes_TI_PLAIN_SEQUENCE_SMALL;
     ti_seq->_u.seq_sdefn = (struct DDS_XTypes_PlainSequenceSElemDefn) {
       .header = { .equiv_kind = DDS_XTypes_EK_BOTH, .element_flags = DDS_XTypes_TRY_CONSTRUCT_DISCARD },
@@ -717,9 +726,9 @@ static DDS_XTypes_TypeObject *get_typeobj14 (void)
     };
 
     /* typedef sequence<long> td_seq_arr[2] */
-    uint8_t *bound_seq = calloc (1, sizeof (*bound_seq));
+    uint8_t *bound_seq = calloc_no_fail (1, sizeof (*bound_seq));
     bound_seq[0] = 3;
-    DDS_XTypes_TypeObject *to_alias_seq_arr = calloc (1, sizeof (*to_alias_seq_arr));
+    DDS_XTypes_TypeObject *to_alias_seq_arr = calloc_no_fail (1, sizeof (*to_alias_seq_arr));
     to_alias_seq_arr->_d = DDS_XTypes_EK_COMPLETE;
     to_alias_seq_arr->_u.complete = (DDS_XTypes_CompleteTypeObject) {
       ._d = DDS_XTypes_TK_ALIAS,


### PR DESCRIPTION
GCC 12 has a much improved static analyzer, and this PR takes care of most of the warnings it gives after enabling all of them.

There are still a few false positives in IDLC (generating idlc.c, generating type objects) that I have suppressed locally here, and there are some issues left in some test cases. So it is not quite ready for prime-time yet.

Another problem is that Azure only just added an Ubuntu 22.04 image, that Ubuntu 22.04 doesn't yet include gcc 12, and that the package repository of Ubuntu currently gives you gcc 12.0.1 instead of 12.1.0, and apparently a lot improved in the static analyzer between those two.

I think the changes are worth considering, even if perhaps it is still too early to actually switch platforms and enable all warnings from the static analyzer.