### PR TITLE
Fixes for 32-bits builds

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/q_whc.h
+++ b/src/core/ddsi/include/dds/ddsi/q_whc.h
@@ -45,7 +45,7 @@ struct whc_state {
    an iter on the stack without specifying an implementation. If future changes or
    implementations require more, these can be adjusted.  An implementation should check
    things fit at compile time. */
-#define WHC_SAMPLE_ITER_SIZE (8 * sizeof(void *))
+#define WHC_SAMPLE_ITER_SIZE (9 * sizeof(void *))
 struct whc_sample_iter_base {
   struct whc *whc;
 };

--- a/src/core/ddsi/src/ddsi_cdrstream_keys.part.c
+++ b/src/core/ddsi/src/ddsi_cdrstream_keys.part.c
@@ -130,8 +130,9 @@ static const uint32_t *dds_stream_extract_keyBO_from_data_adr (uint32_t insn, dd
     if (ops_offs)
     {
       assert (ops_offs_idx < DDSI_CDRSTREAM_MAX_NESTING_DEPTH);
-      assert (ops - op0 < UINT32_MAX);
-      ops_offs[ops_offs_idx] = (uint32_t) (ops - op0_type);
+      ptrdiff_t offs = ops - op0_type;
+      assert (offs >= INT32_MIN && offs <= INT32_MAX);
+      ops_offs[ops_offs_idx] = (uint32_t) (offs);
     }
 
     /* skip DLC instruction for base type, handle as if it is final because the base type's
@@ -162,8 +163,9 @@ static const uint32_t *dds_stream_extract_keyBO_from_data_adr (uint32_t insn, dd
       {
         assert (ops_offs);
         assert (ops_offs_idx < DDSI_CDRSTREAM_MAX_NESTING_DEPTH);
-        assert (ops - op0 < UINT32_MAX);
-        ops_offs[ops_offs_idx] = (uint32_t) (ops - op0_type);
+        ptrdiff_t offs = ops - op0_type;
+        assert (offs >= INT32_MIN && offs <= INT32_MAX);
+        ops_offs[ops_offs_idx] = (uint32_t) (offs);
         bool found = false;
         uint32_t n;
 


### PR DESCRIPTION
- For 32 bits builds, GCC uses 4 byte alignment for 64 bits types, so `WHC_SAMPLE_ITER_SIZE` needs to be increased so that
`whc_sample_iter_impl` fits in
- Fix incorrect asserts in `ddsi_cdrstream_extract_keys`
