### PR TITLE
Only add DDS_OP_FLAG_MU for explicit key members

### DIFF
--- a/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
@@ -348,8 +348,9 @@ enum dds_stream_opcode {
      [KOF, 0, n] [offset-1] ... [offset-n]
        where
         n      = number of key offsets in following ops
-        offset = offset of the key field, relative to the previous offset
-                  (repeated n times, e.g. when key in nested struct)
+        offset = Offset of the key field relative to the previous offset, repeated n times when key is
+                 in a nested struct. In case of inheritance of mutable structs, a single offset of
+                 the key member relative to the first op of the top-level type (index 0).
   */
   DDS_OP_KOF = 0x07 << 24,
 

--- a/src/core/ddsi/src/ddsi_cdrstream_write.part.c
+++ b/src/core/ddsi/src/ddsi_cdrstream_write.part.c
@@ -527,7 +527,7 @@ static bool dds_stream_write_pl_memberBO (uint32_t mid, DDS_OSTREAM_T * __restri
 
   /* get must-understand flag from first member op */
   uint32_t flags = DDS_OP_FLAGS (ops[0]);
-  bool must_understand = flags & DDS_OP_FLAG_MU;
+  bool must_understand = flags & (DDS_OP_FLAG_MU | DDS_OP_FLAG_KEY);
 
   /* add emheader with data length code and flags and optionally the serialized size of the data */
   uint32_t em_hdr = 0;

--- a/src/idl/include/idl/tree.h
+++ b/src/idl/include/idl/tree.h
@@ -512,6 +512,12 @@ struct idl_annotation_appl {
   idl_annotation_appl_param_t *parameters;
 };
 
+typedef enum idl_keytype {
+  IDL_KEYTYPE_NONE,
+  IDL_KEYTYPE_IMPLICIT,
+  IDL_KEYTYPE_EXPLICIT
+} idl_keytype_t;
+
 IDL_EXPORT bool idl_is_declaration(const void *node);
 IDL_EXPORT bool idl_is_module(const void *node);
 IDL_EXPORT bool idl_is_const(const void *node);
@@ -550,8 +556,7 @@ IDL_EXPORT bool idl_is_annotation_appl(const void *node);
 IDL_EXPORT bool idl_is_topic(const void *node, bool keylist);
 IDL_EXPORT bool idl_is_keyless(const void *node, bool keylist);
 IDL_EXPORT bool idl_is_forward(const void *node);
-/* 1-based, returns 0 if path does not refer to key, non-0 otherwise */
-IDL_EXPORT bool idl_is_topic_key(const void *node, bool keylist, const idl_path_t *path, uint32_t *order);
+IDL_EXPORT idl_keytype_t idl_is_topic_key(const void *node, bool keylist, const idl_path_t *path, uint32_t *order);
 IDL_EXPORT bool idl_is_extensible(const idl_node_t *node, idl_extensibility_t extensibility);
 IDL_EXPORT bool idl_has_unset_extensibility_r(idl_node_t *node);
 IDL_EXPORT bool idl_is_external(const idl_node_t *node);


### PR DESCRIPTION
The must-understand flag should only be set in the serializer instructions for key members that are explicitly marked as key in the IDL, not for implicit keys (through their parent member's key attribute), because these members shouldn't be considers must-understand when used as a non-key member.