### PR TITLE
Bugfix for keys in base type of mutable structs

### DIFF
--- a/src/tools/idlc/src/descriptor.c
+++ b/src/tools/idlc/src/descriptor.c
@@ -2167,7 +2167,7 @@ static idl_retcode_t get_ctype_keys(const idl_pstate_t *pstate, struct descripto
            to the current PLM instruction offset, which is within its ctype). A derived type cannot add keys
            (not allowed in IDL) and therefore is not in the offset list, the offset in this list is the offset
            of the key field in the base type. */
-        uint32_t ops_offs = (uint32_t) inst->data.inst_offset.addr_offs + (uint32_t) inst->data.inst_offset.elem_offs;
+        uint32_t ops_offs = (uint32_t) base_type_ops_offs + (uint32_t) inst->data.inst_offset.addr_offs + (uint32_t) inst->data.inst_offset.elem_offs;
         if ((ret = get_ctype_keys(pstate, descriptor, cbasetype, &ctype_keys, n_keys, false, ops_offs)) != IDL_RETCODE_OK)
           goto err;
         break;

--- a/src/tools/idlc/xtests/CMakeLists.txt
+++ b/src/tools/idlc/xtests/CMakeLists.txt
@@ -31,6 +31,7 @@ set(_sources
   test_bool.idl
   test_bitmask.idl
   test_struct_keys.idl
+  test_struct_inherit_mutable_keys.idl
 )
 
 set(_includes "${_includes}\\;${CMAKE_SOURCE_DIR}/src/core/ddsc/include")

--- a/src/tools/idlc/xtests/test_struct_inherit_mutable_keys.idl
+++ b/src/tools/idlc/xtests/test_struct_inherit_mutable_keys.idl
@@ -1,0 +1,59 @@
+/*
+ * Copyright(c) 2021 to 2022 ZettaScale Technology and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+#if defined(__IDLC__)
+
+@nested @mutable struct t_base_base {
+  @key long bb1;
+};
+@nested @mutable struct t_base : t_base_base {
+  long b1;
+};
+@topic @mutable struct test_struct_inherit_mutable_keys : t_base {
+  long f1;
+};
+
+#else
+
+#include "dds/dds.h"
+#include "test_struct_inherit_mutable_keys.h"
+#include "common.h"
+
+const dds_topic_descriptor_t *desc = &test_struct_inherit_mutable_keys_desc;
+
+void init_sample (void *s)
+{
+  test_struct_inherit_mutable_keys *s1 = (test_struct_inherit_mutable_keys *) s;
+  s1->f1 = 1;
+  s1->parent.b1 = 2;
+  s1->parent.parent.bb1 = 3;
+}
+
+int cmp_sample (const void *sa, const void *sb)
+{
+  test_struct_inherit_mutable_keys *a = (test_struct_inherit_mutable_keys *) sa;
+  test_struct_inherit_mutable_keys *b = (test_struct_inherit_mutable_keys *) sb;
+  CMP(a, b, f1, 1);
+  CMP(a, b, parent.b1, 2);
+  CMP(a, b, parent.parent.bb1, 3);
+  return 0;
+}
+
+int cmp_key (const void *sa, const void *sb)
+{
+  test_struct_inherit_mutable_keys *a = (test_struct_inherit_mutable_keys *) sa;
+  test_struct_inherit_mutable_keys *b = (test_struct_inherit_mutable_keys *) sb;
+  CMP(a, b, parent.parent.bb1, 3);
+  return 0;
+}
+
+#endif


### PR DESCRIPTION
This fixes a bug in the key offset calculation (for the KOF serializer instruction) for keys in a base type of a mutable struct.