### PR TITLE
Fixes thanks to Coverity

### DIFF
--- a/src/core/ddsi/src/ddsi_typelookup.c
+++ b/src/core/ddsi/src/ddsi_typelookup.c
@@ -118,7 +118,7 @@ static dds_return_t create_tl_request_msg (struct ddsi_domaingv * const gv, DDS_
     deps = ddsrt_hh_new (1, deps_typeid_hash, deps_typeid_equal);
     cnt += tl_request_get_deps (gv, deps, 0, type);
   }
-  assert (cnt >= 0 && cnt <= INT32_MAX);
+  assert (cnt >= 0);
   request->data._u.getTypes.type_ids._length = (uint32_t) cnt;
   if ((request->data._u.getTypes.type_ids._buffer = ddsrt_malloc ((uint32_t) cnt * sizeof (*request->data._u.getTypes.type_ids._buffer))) == NULL)
   {

--- a/src/ddsrt/src/process/posix/process.c
+++ b/src/ddsrt/src/process/posix/process.c
@@ -50,13 +50,11 @@ ddsrt_getprocessname(void)
   const char * appname = NULL;
 
   char buff[400];
-  struct stat statbuf;
-  if (stat("/proc/self/cmdline", &statbuf) == 0) {
-    FILE *f = fopen("/proc/self/cmdline", "r");
-
+  FILE *fp;
+  if ((fp = fopen("/proc/self/cmdline", "r")) != NULL) {
     buff[0] = '\0';
     for(size_t i = 0; i < sizeof(buff); ++i) {
-      int c = fgetc(f);
+      int c = fgetc(fp);
       if (c == EOF || c == '\0') {
         buff[i] = '\0';
         break;
@@ -64,12 +62,10 @@ ddsrt_getprocessname(void)
         buff[i] = (char) c;
       }
     }
-
     if (buff[0] != '\0') {
       appname = _basename(buff);
     }
-
-    if (f) fclose(f);
+    fclose(fp);
   }
 #endif
 

--- a/src/ddsrt/src/process/posix/process.c
+++ b/src/ddsrt/src/process/posix/process.c
@@ -42,7 +42,6 @@ static const char *_basename(char const *path)
 char *
 ddsrt_getprocessname(void)
 {
-  char *ret;
 #if defined(__APPLE__) || defined(__FreeBSD__)
   const char * appname = getprogname();
 #elif defined(_GNU_SOURCE)
@@ -74,12 +73,17 @@ ddsrt_getprocessname(void)
   }
 #endif
 
-  if (!appname) {
-    if (!ddsrt_asprintf(&ret, "process-%ld", (long) ddsrt_getpid())) return NULL;
-    return ret;
+  if (appname) {
+    return ddsrt_strdup (appname);
+  } else {
+    char *ret = NULL;
+    if (ddsrt_asprintf (&ret, "process-%ld", (long) ddsrt_getpid()) > 0) {
+      return ret;
+    } else {
+      if (ret)
+        ddsrt_free (ret);
+      return NULL;
+    }
   }
-
-  ret = ddsrt_strdup(appname);
-  return ret;
 }
 


### PR DESCRIPTION
Thanks are warranted, even if none of them really is a major issue:
* allocating too much memory for thread states ( a `break` statement moved from an outer loop to an inner loop ... resulting in it never finding an available slot)
* asserting that a signed 32-bit int is ≤ `INT32_MAX` is kinda useless
* some path through `ddsrt_getprocessname` and `ddsrt_asprintf` could lead to a memory leak, though I have my doubts whether it could actually occur
* opening `/proc/self/cmdline` was guarded by `stat`ing it, flagged as TOCTOU by Coverity though in this case harmless because (1) it only used the return value of stat, not the information provided on success, and (2) it did check whether `fopen` succeeded