### PR TITLE
Update "perftest" script configuration settings

### DIFF
--- a/examples/perfscript/perftest
+++ b/examples/perfscript/perftest
@@ -309,10 +309,12 @@ cat >>$cfg <<EOF
 EOF
 fi
 cat >>$cfg <<EOF
+    <Discovery>
+      <LeaseDuration>2s</LeaseDuration>
+    </Discovery>
     <Internal>
       <SynchronousDeliveryPriorityThreshold>\${async:-0}</SynchronousDeliveryPriorityThreshold>
-      <LeaseDuration>2s</LeaseDuration>
-      <MinimumSocketReceiveBufferSize>6MB</MinimumSocketReceiveBufferSize>
+      <SocketReceiveBufferSize max="6MB"/>
       $watermarks
     </Internal>
     <Tracing>


### PR DESCRIPTION
This script was overlooked when updating the configuration settings on two points:

* Moving the default lease duration to the Discovery section
* Improving the way socket buffer sizes get specified

The old settings are still handled, but it shouldn't trigger any deprecation warnings.  The new way of specifying socket receive buffer sizes also distinguishes between what to ask for and what the require. This should prevent an error on many Linux systems in the default configuration.

Fixes #1303 I believe. @JesseRengers would you be willing to check this?