### PR TITLE
Fixed perftest script to work with security features

### DIFF
--- a/examples/perfscript/perftest
+++ b/examples/perfscript/perftest
@@ -360,8 +360,10 @@ if $provision ; then
     done
 fi
 if [ "$security" != "none" ] ; then
-    ssh $r mkdir -p $remotedir $remotedir/secperf
-    scp $secfiles $r:$remotedir/secperf
+    for r in $remotes ; do
+    	ssh $r mkdir -p $remotedir $remotedir/secperf
+    	scp $secfiles $r:$remotedir/secperf
+    done
 fi
 
 topic=KS


### PR DESCRIPTION
ATM, the $r variable is not defined on lines 363 and 364 in the perftest script and causes the script to fail when one of the security modes is used (e.g. `-S rtps-encrypt`). I think the loop around this is just forgotten. Now it makes sure that the files needed for secure communication (certificates and key materials) are copied over to all remotes.   