### PR TITLE
CI updates

### DIFF
--- a/.azure/templates/build-test.yml
+++ b/.azure/templates/build-test.yml
@@ -80,7 +80,6 @@ steps:
     name: run_pre_commit
   - bash: |
       python -m pip install gcovr==5.0 --user --upgrade
-    condition: eq(variables['coverage'], 'on')
     name: install_gcovr
   - bash: |
       set -e -x
@@ -128,7 +127,7 @@ steps:
       set -e -x
       cd build
       ctest -j 4 --output-on-failure -T test -E '^CUnit_ddsrt_random_default_random$' -C ${BUILD_TYPE}
-      [[ "${BUILD_TYPE}" != 'Release' ]] || \
+      [[ "${BUILD_TYPE}" != 'Release' ]] || [[ "${COVERAGE:-off}" == 'off' ]] || \
         ${SHELL} ../src/tools/ddsperf/sanity.bash
       [[ "${SSL:-on}" != 'on' || "${SECURITY:-on}" != 'on' ]] || \
         diff --strip-trailing-cr ../etc/cyclonedds.rnc docs/cyclonedds.rnc && \
@@ -148,12 +147,21 @@ steps:
       set -e -x
       cd build
       cmake --build . --config ${BUILD_TYPE} --target gcov -- ${BUILD_TOOL_OPTIONS}
-      gcovr --exclude '.*/tests/.*' --root "${BUILD_SOURCESDIRECTORY}" --xml-pretty --output coverage.xml .
-    condition: eq(variables['coverage'], 'on')
+      gcovr --exclude '.*/tests/.*' --root "${BUILD_SOURCESDIRECTORY}" --json "$(System.DefaultWorkingDirectory)/coverage-$(Agent.JobName).json"
     name: generate_code_coverage
-  - task: PublishCodeCoverageResults@1
-    inputs:
-      codeCoverageTool: 'Cobertura'
-      summaryFileLocation: $(Build.SourcesDirectory)/build/coverage.xml
+    displayName: Generate coverage artifact
     condition: eq(variables['coverage'], 'on')
-    name: publish_code_coverage
+  - publish: $(System.DefaultWorkingDirectory)/coverage-$(Agent.JobName).json
+    artifact: coverage-$(Agent.JobName)
+    displayName: Publish coverage artifact
+    condition: eq(variables['coverage'], 'on')
+  - task: PublishTestResults@2
+    inputs:
+      testRunTitle: $(Agent.JobName)
+      testRunner: CTest
+      testResultsFiles: '**/Test.xml'
+      searchFolder: $(System.DefaultWorkingDirectory)/build/Testing
+      platform: $(arch)
+      configuration: $(build_type)
+    name: publish_test_results
+    displayName: Publish test results

--- a/.azure/templates/build-test.yml
+++ b/.azure/templates/build-test.yml
@@ -143,6 +143,7 @@ steps:
             ${GENERATOR:+-G} "${GENERATOR}" -A "${PLATFORM}" -T "${TOOLSET}" "${INSTALLPREFIX}/share/CycloneDDS/examples/helloworld"
       cmake --build . --config ${BUILD_TYPE} -- ${BUILD_TOOL_OPTIONS}
     name: test
+    displayName: Test
   - bash: |
       set -e -x
       cd build
@@ -150,11 +151,11 @@ steps:
       gcovr --exclude '.*/tests/.*' --root "${BUILD_SOURCESDIRECTORY}" --json "$(System.DefaultWorkingDirectory)/coverage-$(Agent.JobName).json"
     name: generate_code_coverage
     displayName: Generate coverage artifact
-    condition: eq(variables['coverage'], 'on')
+    condition: and(succeededOrFailed(), eq(variables['coverage'], 'on'))
   - publish: $(System.DefaultWorkingDirectory)/coverage-$(Agent.JobName).json
     artifact: coverage-$(Agent.JobName)
     displayName: Publish coverage artifact
-    condition: eq(variables['coverage'], 'on')
+    condition: and(succeededOrFailed(), eq(variables['coverage'], 'on'))
   - task: PublishTestResults@2
     inputs:
       testRunTitle: $(Agent.JobName)
@@ -165,3 +166,4 @@ steps:
       configuration: $(build_type)
     name: publish_test_results
     displayName: Publish test results
+    condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,101 +13,134 @@
 trigger: [ '*' ]
 pr: [ '*' ]
 
-strategy:
-  matrix:
-    'Ubuntu 20.04 LTS with GCC 10 (Debug, x86_64)':
-      image: ubuntu-20.04
-      analyzer: on
-      # not enabling "undefined" because of some false positives
-      sanitizer: address
-      cc: gcc-10
-    'Ubuntu 20.04 LTS with GCC 10 (Debug, x86_64, Iceoryx)':
-      image: ubuntu-20.04
-      #analyzer: on  # disabled for now because of warnings
-      sanitizer: address,undefined
-      iceoryx: on
-      cc: gcc-10
-    'Ubuntu 20.04 LTS with GCC 10 (Release, x86_64)':
-      image: ubuntu-20.04
-      build_type: Release
-      sanitizer: undefined
-      cc: gcc-10
-    'Ubuntu 20.04 LTS with GCC 10 (Debug, x86_64, security only)':
-      image: ubuntu-20.04
-      sanitizer: address,undefined
-      ssl: off
-      lifespan: off
-      deadline: off
-      type_discovery: off
-      topic_discovery: off
-      idlc_testing: off # temporary dislabled because of passing -t option to idlc in this test for recursive types
-      cc: gcc-10
-    'Ubuntu 18.04 LTS with GCC 7 (Debug, x86_64)':
-      image: ubuntu-18.04
-      coverage: on
-      conanfile: conanfile102.txt
-      cc: gcc-7
-    'Ubuntu 20.04 LTS with Clang 10 (Debug, x86_64)':
-      image: ubuntu-20.04
-      analyzer: on
-      sanitizer: address,undefined
-      cc: clang-10
-    'Ubuntu 20.04 LTS with Clang 10 (Debug, x86_64, no security)':
-      image: ubuntu-20.04
-      sanitizer: address,undefined
-      security: off
-      cc: clang-10
-    'Ubuntu 20.04 LTS with Clang 10 (Release, x86_64, no topic discovery)':
-      image: ubuntu-20.04
-      build_type: Release
-      sanitizer: undefined
-      topic_discovery: off
-      idlc_testing: off # temporary dislabled because of passing -t option to idlc in this test for recursive types
-      cc: clang-10
-    'macOS 10.15 with Clang 12 (macOS 10.12, Release, x86_64)':
-      image: macOS-10.15
-      build_type: Release
-      sanitizer: undefined
-      macos_deployment_target: '10.12'
-      ssl: off
-      cc: clang
-    'macOS 10.15 with Clang 12 (Debug, x86_64)':
-      image: macOS-10.15
-      sanitizer: address,undefined
-      cc: clang
-    'macOS 10.15 with Clang 12 (Release, x86_64)':
-      image: macOS-10.15
-      build_type: Release
-      sanitizer: undefined
-      cc: clang
-    'Windows 2019 with Visual Studio 2019 (Visual Studio 2017, Debug, x86)':
-      arch: x86
-      image: windows-2019
-      idlc_testing: off
-      generator: 'Visual Studio 16 2019'
-      toolset: v141
-    'Windows 2019 with Visual Studio 2019 (Debug, x86_64)':
-      image: windows-2019
-      idlc_testing: off
-      generator: 'Visual Studio 16 2019'
-    'Windows 2019 with Visual Studio 2019 (Release, x86_64)':
-      image: windows-2019
-      build_type: Release
-      idlc_testing: off
-      generator: 'Visual Studio 16 2019'
-    'Windows 2019 with GCC 10 (Debug, x86_64)':
-      image: windows-2019
-      build_type: Debug
-      idlc_testing: off
-      generator: 'MinGW Makefiles'
-      cc: 'C:/msys64/mingw64/bin/gcc.exe'
-      cxx: 'C:/msys64/mingw64/bin/g++.exe'
-
-pool:
-  vmImage: $(image)
 
 variables:
   cyclonedds_uri: '<CycloneDDS><Domain><Internal><EnableExpensiveChecks>rhc,whc</EnableExpensiveChecks><LivelinessMonitoring>true</LivelinessMonitoring></Internal><Tracing><Verbosity>config</Verbosity><OutputFile>stderr</OutputFile></Tracing></Domain></CycloneDDS>'
 
-steps:
-  - template: /.azure/templates/build-test.yml
+jobs:
+- job: BuildAndTest
+  pool:
+    vmImage: $(image)
+  strategy:
+    matrix:
+      'Ubuntu 20.04 LTS with GCC 10 (Debug, x86_64)':
+        image: ubuntu-20.04
+        analyzer: on
+        # not enabling "undefined" because of some false positives
+        sanitizer: address
+        cc: gcc-10
+        coverage: on
+      'Ubuntu 20.04 LTS with GCC 10 (Debug, x86_64, Iceoryx)':
+        image: ubuntu-20.04
+        #analyzer: on  # disabled for now because of warnings
+        sanitizer: address,undefined
+        iceoryx: on
+        cc: gcc-10
+        coverage: on
+      'Ubuntu 20.04 LTS with GCC 10 (Release, x86_64)':
+        image: ubuntu-20.04
+        build_type: Release
+        sanitizer: undefined
+        cc: gcc-10
+      'Ubuntu 20.04 LTS with GCC 10 (Debug, x86_64, security only)':
+        image: ubuntu-20.04
+        sanitizer: address,undefined
+        ssl: off
+        lifespan: off
+        deadline: off
+        type_discovery: off
+        topic_discovery: off
+        idlc_testing: off # temporary dislabled because of passing -t option to idlc in this test for recursive types
+        cc: gcc-10
+      'Ubuntu 18.04 LTS with GCC 7 (Debug, x86_64)':
+        image: ubuntu-18.04
+        conanfile: conanfile102.txt
+        cc: gcc-7
+      'Ubuntu 20.04 LTS with Clang 10 (Debug, x86_64)':
+        image: ubuntu-20.04
+        analyzer: on
+        sanitizer: address,undefined
+        cc: clang-10
+      'Ubuntu 20.04 LTS with Clang 10 (Debug, x86_64, no security)':
+        image: ubuntu-20.04
+        sanitizer: address,undefined
+        security: off
+        cc: clang-10
+      'Ubuntu 20.04 LTS with Clang 10 (Release, x86_64, no topic discovery)':
+        image: ubuntu-20.04
+        build_type: Release
+        sanitizer: undefined
+        topic_discovery: off
+        idlc_testing: off # temporary dislabled because of passing -t option to idlc in this test for recursive types
+        cc: clang-10
+      'macOS 10.15 with Clang 12 (macOS 10.12, Release, x86_64)':
+        image: macOS-10.15
+        build_type: Release
+        sanitizer: undefined
+        macos_deployment_target: '10.12'
+        ssl: off
+        cc: clang
+      'macOS 10.15 with Clang 12 (Debug, x86_64)':
+        image: macOS-10.15
+        sanitizer: address,undefined
+        cc: clang
+      'macOS 10.15 with Clang 12 (Release, x86_64)':
+        image: macOS-10.15
+        build_type: Release
+        sanitizer: undefined
+        cc: clang
+      'macOS 11 with Clang 13 (Release, x86_64)':
+        image: macOS-11
+        build_type: Release
+        sanitizer: undefined
+        cc: clang
+        coverage: on
+      'Windows 2019 with Visual Studio 2019 (Visual Studio 2017, Debug, x86)':
+        arch: x86
+        image: windows-2019
+        idlc_testing: off
+        generator: 'Visual Studio 16 2019'
+        toolset: v141
+      'Windows 2019 with Visual Studio 2019 (Debug, x86_64)':
+        image: windows-2019
+        idlc_testing: off
+        generator: 'Visual Studio 16 2019'
+      'Windows 2019 with Visual Studio 2019 (Release, x86_64)':
+        image: windows-2019
+        build_type: Release
+        idlc_testing: off
+        generator: 'Visual Studio 16 2019'
+      'Windows 2019 with GCC 10 (Debug, x86_64)':
+        image: windows-2019
+        build_type: Debug
+        idlc_testing: off
+        generator: 'MinGW Makefiles'
+        cc: 'C:/msys64/mingw64/bin/gcc.exe'
+        cxx: 'C:/msys64/mingw64/bin/g++.exe'
+
+  steps:
+    - template: /.azure/templates/build-test.yml
+
+- job: CoverageAndTestsReport
+  dependsOn: BuildAndTest
+  condition: succeededOrFailed()  # Always run, even when failed tests, because they should be reported in the dasboard of course!
+  pool:
+    vmImage: ubuntu-20.04
+  steps:
+  - bash: |
+      mkdir coverage
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      path: coverage
+    displayName: Download Coverage
+  - task: UsePythonVersion@0
+  - bash: |
+      python -m pip install gcovr==5.0 --user --upgrade
+      ls coverage
+      gcovr -a coverage/**/*.json --xml-pretty --output coverage.xml
+    displayName: Combine coverage reports
+  - task: PublishCodeCoverageResults@1
+    displayName: Publish Cobertura Coverage Report
+    inputs:
+      codeCoverageTool: Cobertura
+      summaryFileLocation: coverage.xml


### PR DESCRIPTION
A few updates to the CI pipeline:
 * Add new MacOS job. 
 * Merge all code coverage results to capture platform-dependend code. The coverage target is non-functional on windows, to be fixed.
 *  Publish all test results to azure pipelines, supersedes #1128 