### PR TITLE
Bugfix in idl meta data generation for int8

### DIFF
--- a/src/tools/idlc/src/descriptor_type_meta.c
+++ b/src/tools/idlc/src/descriptor_type_meta.c
@@ -252,6 +252,7 @@ get_plain_typeid (const idl_pstate_t *pstate, struct descriptor_type_meta *dtm, 
     switch (idl_type (type_spec))
     {
       case IDL_BOOL: ti->_d = DDS_XTypes_TK_BOOLEAN; break;
+      case IDL_INT8: case IDL_CHAR: ti->_d = DDS_XTypes_TK_CHAR8; break;
       case IDL_UINT8: case IDL_OCTET: ti->_d = DDS_XTypes_TK_BYTE; break;
       case IDL_INT16: case IDL_SHORT: ti->_d = DDS_XTypes_TK_INT16; break;
       case IDL_INT32: case IDL_LONG: ti->_d = DDS_XTypes_TK_INT32; break;
@@ -262,7 +263,6 @@ get_plain_typeid (const idl_pstate_t *pstate, struct descriptor_type_meta *dtm, 
       case IDL_FLOAT: ti->_d = DDS_XTypes_TK_FLOAT32; break;
       case IDL_DOUBLE: ti->_d = DDS_XTypes_TK_FLOAT64; break;
       case IDL_LDOUBLE: ti->_d = DDS_XTypes_TK_FLOAT128; break;
-      case IDL_CHAR: ti->_d = DDS_XTypes_TK_CHAR8; break;
       case IDL_STRING:
       {
         if (!idl_is_bounded(type_spec)) {
@@ -616,6 +616,11 @@ set_xtypes_annotation_parameter_value(
       val->_d = DDS_XTypes_TK_BOOLEAN;
       val->_u.boolean_value = lit->value.bln;
       break;
+    case IDL_INT8:
+    case IDL_CHAR:
+      val->_d = DDS_XTypes_TK_CHAR8;
+      val->_u.char_value = lit->value.chr;
+      break;
     case IDL_OCTET:
     case IDL_UINT8:
       val->_d = DDS_XTypes_TK_BYTE;
@@ -658,10 +663,6 @@ set_xtypes_annotation_parameter_value(
     case IDL_DOUBLE:
       val->_d = DDS_XTypes_TK_FLOAT64;
       val->_u.float64_value = lit->value.dbl;
-      break;
-    case IDL_CHAR:
-      val->_d = DDS_XTypes_TK_CHAR8;
-      val->_u.char_value = lit->value.chr;
       break;
     /*  //enums are currently not allowed in min/max/range annotations
     case IDL_ENUM:

--- a/src/tools/idlc/tests/type_meta.c
+++ b/src/tools/idlc/tests/type_meta.c
@@ -223,10 +223,13 @@ static DDS_XTypes_TypeObject *get_typeobj1 (void)
     "t1::test_struct",
     DDS_XTypes_IS_APPENDABLE,
     (DDS_XTypes_TypeIdentifier) { ._d = DDS_XTypes_TK_NONE },
-    3, (smember_t[]) {
+    6, (smember_t[]) {
       { 0, DDS_XTypes_IS_KEY | DDS_XTypes_IS_MUST_UNDERSTAND | DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TK_INT64 }, "f1" },
       { 1, DDS_XTypes_IS_OPTIONAL | DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TI_STRING8_SMALL, ._u.string_sdefn.bound = 0 }, "f2" },
-      { 4, DDS_XTypes_IS_EXTERNAL | DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TK_CHAR8 }, "f3" }
+      { 4, DDS_XTypes_IS_EXTERNAL | DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TK_CHAR8 }, "f3" },
+      { 3, DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TK_CHAR8 }, "f4" },
+      { 8, DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TK_UINT32 }, "f5" },
+      { 7, DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TK_INT64 }, "f6" }
     });
 }
 
@@ -710,7 +713,7 @@ CU_Test(idlc_type_meta, type_obj_serdes)
     char idl[256];
     get_typeobj_t get_typeobj_fn;
   } tests[] = {
-    { "module t1 { @appendable struct test_struct { @key long long f1; @optional string f2; @external @id(4) char f3; }; };", get_typeobj1 },
+    { "module t1 { @appendable struct test_struct { @key long long f1; @optional string f2; @external @id(4) char f3; @id(3) int8 f4; @id(8) uint32 f5; @id(7) int64 f6; }; };", get_typeobj1 },
     { "module t2 { @mutable struct test_struct { @optional @external unsigned long f1, f2; }; };", get_typeobj2 },
     { "module t3 { @final union test_union switch (short) { case 1: long f1; case 2: case 3: default: @external string f2; }; };", get_typeobj3 },
     { "module t4 { @mutable @nested struct a { @id(5) long a1; }; @mutable @topic struct test_struct : a { @id(10) long f1; }; };", get_typeobj4 },


### PR DESCRIPTION
This fixes the type meta data generation for int8 IDL data type,
which was not mapped in the function to get a fully descriptive
type identifier.

Signed-off-by: Dennis Potman <dennis@zettascale.tech>