### PR TITLE
Fix Coverity issues introduced by typeobject → serializer code

### DIFF
--- a/src/core/ddsc/tests/typelookup.c
+++ b/src/core/ddsc/tests/typelookup.c
@@ -361,6 +361,11 @@ CU_Test(ddsc_typelookup, api_resolve, .init = typelookup_init, .fini = typelooku
   dds_free (type_name);
 }
 
+// the definition of `ddsi_typeid_t` is well hidden, but we need it if we want to
+// have a static assertion that an intentional but weird memset doesn't go out of
+// bounds
+#include "dds/ddsi/ddsi_xt_impl.h"
+
 CU_Test(ddsc_typelookup, api_resolve_invalid, .init = typelookup_init, .fini = typelookup_fini)
 {
   char name[100];
@@ -388,6 +393,8 @@ CU_Test(ddsc_typelookup, api_resolve_invalid, .init = typelookup_init, .fini = t
 
   /* confirm that invalid type id cannot be resolved */
   struct dds_entity *e;
+  DDSRT_STATIC_ASSERT (sizeof (*type_id) >= 8);
+  // coverity[suspicious_sizeof]
   memset (type_id, 0xff, 8);
   CU_ASSERT_EQUAL_FATAL (dds_entity_pin (g_participant2, &e), 0);
   struct ddsi_type *type;

--- a/src/core/ddsi/src/ddsi_typebuilder.c
+++ b/src/core/ddsi/src/ddsi_typebuilder.c
@@ -455,10 +455,7 @@ static dds_return_t typebuilder_add_type (struct typebuilder_data *tbd, uint32_t
     case DDS_XTypes_TK_BITMASK: {
       uint64_t bits = 0;
       for (uint32_t n = 0; n < type->xt._u.bitmask.bitflags.length; n++)
-      {
-        assert (type->xt._u.bitmask.bitflags.seq[n].position >= 0);
         bits |= 1llu << type->xt._u.bitmask.bitflags.seq[n].position;
-      }
       tb_type->type_code = DDS_OP_VAL_BMK;
       tb_type->args.bitmask_args.bits_l = (uint32_t) (bits & 0xffffffffu);
       tb_type->args.bitmask_args.bits_h = (uint32_t) (bits >> 32);


### PR DESCRIPTION
Two were really much ado about nothing (yes, an unsigned value is always ≥ 0, and a suspicious memset that turned out to be correct), the other was slightly more interesting because some issues in handling an out-of-memory condition that was otherwise handled quite diligently.

I've opted to refactor the code in question a bit, splitting it into multiple functions so that the error handling is slightly more compact.