### PR TITLE
Drop MinGW build from CI

### DIFF
--- a/CYCLONEDDS_QUALITY_DECLARATION.md
+++ b/CYCLONEDDS_QUALITY_DECLARATION.md
@@ -109,7 +109,6 @@ Cyclone DDS CI results are [public](https://dev.azure.com/eclipse-cyclonedds/cyc
 - macOS 10.15 with clang 12
 - macOS 10.15 with clang 12 while targeting macOS 10.12
 - Windows Server 2019 with Visual Studio 2019
-- Windows Server 2019 with gcc 10 (mingw)
 
 These are run with a mixture of debug, debug-with-address sanitizer and release builds.
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -110,13 +110,13 @@ jobs:
         build_type: Release
         idlc_testing: off
         generator: 'Visual Studio 16 2019'
-      'Windows 2019 with GCC 10 (Debug, x86_64)':
-        image: windows-2019
-        build_type: Debug
-        idlc_testing: off
-        generator: 'MinGW Makefiles'
-        cc: 'C:/msys64/mingw64/bin/gcc.exe'
-        cxx: 'C:/msys64/mingw64/bin/g++.exe'
+      #'Windows 2019 with GCC 10 (Debug, x86_64)':
+      #  image: windows-2019
+      #  build_type: Debug
+      #  idlc_testing: off
+      #  generator: 'MinGW Makefiles'
+      #  cc: 'C:/msys64/mingw64/bin/gcc.exe'
+      #  cxx: 'C:/msys64/mingw64/bin/g++.exe'
 
   steps:
     - template: /.azure/templates/build-test.yml


### PR DESCRIPTION
Something changed somewhere in the MinGW setup on Azure because it
started failing with the following error (with some editing to reduce
line length):

    -- Check for working C compiler: C:/msys64/mingw64/bin/gcc.exe
    -- Check for working C compiler: C:/msys64/mingw64/bin/gcc.exe - broken
    CMake Error at C:/Program Files/CMake/share/cmake-3.23/Modules/CMakeTestCCompiler.cmake:69 (message):
      The C compiler

        "C:/msys64/mingw64/bin/gcc.exe"

      is not able to compile a simple test program.

      It fails with the following output:

        Change Dir: D:/a/1/s/build/CMakeFiles/CMakeTmp

        Run Build
        Command(s):C:/ProgramData/chocolatey/bin/mingw32-make.exe \
            -f Makefile cmTC_7f05c/fast && \
            C:/ProgramData/chocolatey/lib/mingw/tools/install/mingw64/bin/mingw32-make \
            -f CMakeFiles\cmTC_7f05c.dir\build.make CMakeFiles/cmTC_7f05c.dir/build
        mingw32-make[1]: Entering directory 'D:/a/1/s/build/CMakeFiles/CMakeTmp'
        Building C object CMakeFiles/cmTC_7f05c.dir/testCCompiler.c.obj
        C:\msys64\mingw64\bin\gcc.exe \
            -o CMakeFiles\cmTC_7f05c.dir\testCCompiler.c.obj \
            -c D:\a\1\s\build\CMakeFiles\CMakeTmp\testCCompiler.c
        mingw32-make[1]: *** [CMakeFiles\cmTC_7f05c.dir\build.make:77: \
            CMakeFiles/cmTC_7f05c.dir/testCCompiler.c.obj] Error 1
        mingw32-make[1]: Leaving directory 'D:/a/1/s/build/CMakeFiles/CMakeTmp'
        mingw32-make: *** [Makefile:126: cmTC_7f05c/fast] Error 2

At this point, `gcc` has already been used successfully for building
CUnit and OpenSSL, therefore it must have something to do with how CMake
invokes it.  Unfortunately, the error message tells us little, locally
it doesn't reproduce and a days' worth of trying to fix this using
either the windows-2019 or the windows-2022 image (that by the way fail
in totally different ways) has yielded exactly nothing.

To have a perennially broken CI build is not acceptable and the
investment for fixing it seems to be higher than reasonable for such a
niche platform.  This commit drops it from the CI matrix.

Signed-off-by: Erik Boasson <eb@ilities.com>