### PR TITLE
Drop macOS 10 on CI, make musl libc build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,19 +73,12 @@ jobs:
         topic_discovery: off
         idlc_testing: off # temporary dislabled because of passing -t option to idlc in this test for recursive types
         cc: clang-10
-      'macOS 10.15 with Clang 12 (macOS 10.12, Release, x86_64)':
-        image: macOS-10.15
-        build_type: Release
-        sanitizer: undefined
-        macos_deployment_target: '10.12'
-        ssl: off
-        cc: clang
-      'macOS 10.15 with Clang 12 (Debug, x86_64)':
-        image: macOS-10.15
+      'macOS 11 with Clang 12 (Debug, x86_64)':
+        image: macOS-11
         sanitizer: address,undefined
         cc: clang
-      'macOS 10.15 with Clang 12 (Release, x86_64)':
-        image: macOS-10.15
+      'macOS 11 with Clang 12 (Release, x86_64)':
+        image: macOS-11
         build_type: Release
         sanitizer: undefined
         cc: clang

--- a/src/idl/src/string.c
+++ b/src/idl/src/string.c
@@ -36,6 +36,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#if !defined(__USE_GNU) || !defined(__APPLE__) || !defined(__FreeBSD__)
+  #define __MUSL__
+#endif
+
 #if defined _WIN32
 # include <locale.h>
 typedef _locale_t locale_t;
@@ -268,7 +272,9 @@ unsigned long long idl_strtoull(const char *str, char **endptr, int base)
 {
   assert(str);
   assert(base >= 0 && base <= 36);
-#if _WIN32
+#ifdef __MUSL__
+  return strtoull(str, endptr, base);
+#elif _WIN32
 #if __GNUC__
   return strtoull(str, endptr, base);
 #else


### PR DESCRIPTION
Sorry for combining these two small fixes, but I figured the PR is still small enough to review :smile:

Azure Pipelines is dropping macOS 10 very soon, I've already noticed a dropoff in build machine availability and more failing tests on timing, presumably due to overcrowdedness of the still available ones. This switches all builds over to macOS 11.

I am also building python wheels to run on Alpine-based containers with musl libc where I ran into the fact that `strtoull_l` is not defined. The maintainers of musl claim that a `__MUSL__` is never needed :confounded: so they don't provide one so I had to hack one together.