### PR TITLE
Retrieval of historical data after partial disconnect

### DIFF
--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -502,7 +502,7 @@ This setting controls the interval with which a reader will continue NACK'ing mi
 
 Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "1 s".
+The default value is: "3 s".
 
 
 #### //CycloneDDS/Domain/Internal/BuiltinEndpointSet
@@ -1856,7 +1856,7 @@ The categorisation of tracing output is incomplete and hence most of the verbosi
 The default value is: "none".
 <!--- generated from ddsi_config.h[618b11f05cc24a67b19d704eb575106d39d3c56a] -->
 <!--- generated from ddsi_cfgunits.h[fc550f1620aa20dcd9244ef4e24299d5001efbb4] -->
-<!--- generated from ddsi_cfgelems.h[2336569264035fa1b1a77474138aab5564d3c893] -->
+<!--- generated from ddsi_cfgelems.h[5069088213adad4334ba1045cf7b14ef65482c0f] -->
 <!--- generated from ddsi_config.c[93784170c086e52b501574ea6a2f9a47ebd4da5f] -->
 <!--- generated from _confgen.h[01ffa8a2e53b2309451756861466551cfe28c8ce] -->
 <!--- generated from _confgen.c[13cd40932d695abae1470202a42c18dc4d09ea84] -->

--- a/etc/cyclonedds.rnc
+++ b/etc/cyclonedds.rnc
@@ -356,7 +356,7 @@ CycloneDDS configuration""" ] ]
         & [ a:documentation [ xml:lang="en" """
 <p>This setting controls the interval with which a reader will continue NACK'ing missing samples in the absence of a response from the writer, as a protection mechanism against writers incorrectly stopping the sending of HEARTBEAT messages.</p>
 <p>Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.</p>
-<p>The default value is: "1 s".</p>""" ] ]
+<p>The default value is: "3 s".</p>""" ] ]
         element AutoReschedNackDelay {
           duration_inf
         }?
@@ -1290,7 +1290,7 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==<br>
 }
 # generated from ddsi_config.h[618b11f05cc24a67b19d704eb575106d39d3c56a] 
 # generated from ddsi_cfgunits.h[fc550f1620aa20dcd9244ef4e24299d5001efbb4] 
-# generated from ddsi_cfgelems.h[2336569264035fa1b1a77474138aab5564d3c893] 
+# generated from ddsi_cfgelems.h[5069088213adad4334ba1045cf7b14ef65482c0f] 
 # generated from ddsi_config.c[93784170c086e52b501574ea6a2f9a47ebd4da5f] 
 # generated from _confgen.h[01ffa8a2e53b2309451756861466551cfe28c8ce] 
 # generated from _confgen.c[13cd40932d695abae1470202a42c18dc4d09ea84] 

--- a/etc/cyclonedds.xsd
+++ b/etc/cyclonedds.xsd
@@ -614,7 +614,7 @@ CycloneDDS configuration</xs:documentation>
       <xs:documentation>
 &lt;p&gt;This setting controls the interval with which a reader will continue NACK'ing missing samples in the absence of a response from the writer, as a protection mechanism against writers incorrectly stopping the sending of HEARTBEAT messages.&lt;/p&gt;
 &lt;p&gt;Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.&lt;/p&gt;
-&lt;p&gt;The default value is: "1 s".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: "3 s".&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="BuiltinEndpointSet">
@@ -1961,7 +1961,7 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
 </xs:schema>
 <!--- generated from ddsi_config.h[618b11f05cc24a67b19d704eb575106d39d3c56a] -->
 <!--- generated from ddsi_cfgunits.h[fc550f1620aa20dcd9244ef4e24299d5001efbb4] -->
-<!--- generated from ddsi_cfgelems.h[2336569264035fa1b1a77474138aab5564d3c893] -->
+<!--- generated from ddsi_cfgelems.h[5069088213adad4334ba1045cf7b14ef65482c0f] -->
 <!--- generated from ddsi_config.c[93784170c086e52b501574ea6a2f9a47ebd4da5f] -->
 <!--- generated from _confgen.h[01ffa8a2e53b2309451756861466551cfe28c8ce] -->
 <!--- generated from _confgen.c[13cd40932d695abae1470202a42c18dc4d09ea84] -->

--- a/src/core/ddsc/tests/CMakeLists.txt
+++ b/src/core/ddsc/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ if(ENABLE_TYPE_DISCOVERY)
 endif()
 
 set(ddsc_test_sources
+    "asymdisconnect.c"
     "basic.c"
     "builtin_topics.c"
     "cdr.c"

--- a/src/core/ddsc/tests/asymdisconnect.c
+++ b/src/core/ddsc/tests/asymdisconnect.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright(c) 2022 ZettaScale Technology and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include "test_common.h"
+#include "test_oneliner.h"
+
+CU_Test (ddsc_asymdisconnect, reader_keeps_nacking)
+{
+  // Override the default rescheduling delay to speed things up a bit
+  const char *config = "<Internal><AutoReschedNackDelay>100ms</AutoReschedNackDelay></Internal>";
+  
+  const int result = test_oneliner_with_config (
+    "da sm r(r=r,d=tl) pm w'(r=r,d=tl)"
+    "  ?sm r ?pm w'"
+    // given a matched reader/writer pair with a network in between
+    // write some data & make sure it is present
+    "  wr w' 1"
+    "  ?da r take{(1,0,0)} r"
+    // once the data has been acknowledged, make P deaf
+    // - r loses sight of w'
+    // - w' still knows r; all data ACK'd so no further heartbeats
+    "  ?ack w'"
+    "  deaf! P ?sm r"
+    // disconnect causes invalid sample, take that
+    // (?da r is there to reset the 'data available callback invoked flag'
+    // else we can't assert it didn't get triggered after the reconnect)
+    "  ?da r take{1} r"
+    // make w' suppress retransmits
+    // - this really is just a little devil dropping some packets
+    "  setflags(r) w'"
+    // restoring hearing triggers discovery
+    "  hearing! P"
+    // r should see w' again
+    // - r will send a pre-emptive ACKNACK, w' will respond with heartbeat
+    // - r will then send ACKNACKs requesting retransmit, w' forgets to send the data
+    "  ?sm r"
+    // let this go on for a little bit
+    "  sleep 2"
+    // change the debugging flags of w' to now ignore ACKNACKs
+    // - this really is just a little devil dropping some packets
+    // - this should cause the spontaneous heartbeats to stop
+    // - r needs to keep trying (it wouldn't because of a bug)
+    // setting the flags has some race conditions, but chances are it'll do what we want
+    "  setflags(a) w'"
+    // let this go on for a while
+    "  sleep 2"
+    // no data should have arrived: first retransmits were suppressed
+    // then the retransmit requests were ignored
+    "  ?!da"
+    // clearing all test flags on w should fix the problem
+    "  setflags() w'"
+    // without the fix and with flags cleared, disconnecting and reconnecting fixes it:
+    //   sleep 2 !?!da take{} r // so no data!
+    //   deaf! P ?sm r hearing! P ?sm r // dis-/reconnect
+    //   ?da r take{(1,0,0)} r
+    // with fix present:
+    "  ?da r take{(1,0,0)} r"
+    , config);
+  CU_ASSERT (result > 0);
+}

--- a/src/core/ddsc/tests/oneliner.c
+++ b/src/core/ddsc/tests/oneliner.c
@@ -94,7 +94,7 @@ int main (int argc, char **argv)
         printf ("------ stdin:%u ------\n", lineno);
         test_indent = indent;
         test_begin = lineno;
-        test_oneliner_init (&ctx);
+        test_oneliner_init (&ctx, NULL);
       }
 
       test_oneliner_step (&ctx, buf + idx);

--- a/src/core/ddsc/tests/test_oneliner.h
+++ b/src/core/ddsc/tests/test_oneliner.h
@@ -231,8 +231,15 @@
  * All entities share the listeners with their global state. Only the latest invocation is visible.
  *
  * @param[in]  ops  Program to execute.
+ * @param[in]  config_override  XML configuration fragment or NULL
  *
  * @return > 0 success, 0 failure, < 0 invalid input
+ */
+int test_oneliner_with_config (const char *ops, const char *config_override);
+
+/** @brief shorthand for test_oneliner_with_config (ops, NULL)
+ * @param[in] ops Program to execute
+ * @return > 0 sucess, 0 failure, < 0 invalid input
  */
 int test_oneliner (const char *ops);
 
@@ -295,13 +302,16 @@ struct oneliner_ctx {
   ddsrt_mutex_t g_mutex;
   ddsrt_cond_t g_cond;
   struct oneliner_cb cb[3];
+  
+  const char *config_override; // optional
 };
 
 /** @brief Initialize a "oneliner test" context
  *
  * @param[out] ctx   context to initialize
+ * @param[in] config_override  XML configuration fragment or NULL
  */
-void test_oneliner_init (struct oneliner_ctx *ctx);
+void test_oneliner_init (struct oneliner_ctx *ctx, const char *config_override);
 
 /** @brief Run a sequence of operations in an initialized context
  *

--- a/src/core/ddsi/defconfig.c
+++ b/src/core/ddsi/defconfig.c
@@ -68,7 +68,7 @@ void ddsi_config_init_default (struct ddsi_config *cfg)
   cfg->socket_sndbuf_size.max.isdefault = 1;
   cfg->nack_delay = INT64_C (100000000);
   cfg->ack_delay = INT64_C (10000000);
-  cfg->auto_resched_nack_delay = INT64_C (1000000000);
+  cfg->auto_resched_nack_delay = INT64_C (3000000000);
   cfg->preemptive_ack_delay = INT64_C (10000000);
   cfg->ddsi2direct_max_threads = UINT32_C (1);
   cfg->max_sample_size = UINT32_C (2147483647);
@@ -106,7 +106,7 @@ void ddsi_config_init_default (struct ddsi_config *cfg)
 }
 /* generated from ddsi_config.h[618b11f05cc24a67b19d704eb575106d39d3c56a] */
 /* generated from ddsi_cfgunits.h[fc550f1620aa20dcd9244ef4e24299d5001efbb4] */
-/* generated from ddsi_cfgelems.h[2336569264035fa1b1a77474138aab5564d3c893] */
+/* generated from ddsi_cfgelems.h[5069088213adad4334ba1045cf7b14ef65482c0f] */
 /* generated from ddsi_config.c[93784170c086e52b501574ea6a2f9a47ebd4da5f] */
 /* generated from _confgen.h[01ffa8a2e53b2309451756861466551cfe28c8ce] */
 /* generated from _confgen.c[13cd40932d695abae1470202a42c18dc4d09ea84] */

--- a/src/core/ddsi/include/dds/ddsi/ddsi_cfgelems.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_cfgelems.h
@@ -1377,7 +1377,7 @@ static struct cfgelem internal_cfgelems[] = {
       "<p>This setting controls the delay between sending identical "
       "acknowledgements.</p>"),
     UNIT("duration")),
-  STRING("AutoReschedNackDelay", NULL, 1, "1 s",
+  STRING("AutoReschedNackDelay", NULL, 1, "3 s",
     MEMBER(auto_resched_nack_delay),
     FUNCTIONS(0, uf_duration_inf, 0, pf_duration),
     DESCRIPTION(

--- a/src/core/ddsi/src/q_xevent.c
+++ b/src/core/ddsi/src/q_xevent.c
@@ -896,8 +896,6 @@ static void handle_xevk_acknack (struct nn_xpack *xp, struct xevent *ev, ddsrt_m
 
   if (!pwr->have_seen_heartbeat)
     msg = make_preemptive_acknack (ev, pwr, rwn, tnow);
-  else if (!(rwn->heartbeat_since_ack || rwn->heartbeatfrag_since_ack))
-    msg = NULL;
   else
     msg = make_and_resched_acknack (ev, pwr, rwn, tnow, false);
   ddsrt_mutex_unlock (&pwr->e.lock);


### PR DESCRIPTION
When:
- A transient-local reader/writer pair exists with a network in between, and for some reason the writer's participant's lease expires at the reader's but not the other way around (so a "partial" or "asymmetric" disconnect);
- All the data published by the writer was acknowledged and no new data is being published;
- After rediscovery of the writer by the reader, not all historical data arrives on the first NACK and the heartbeat sent by writer in its response to the first NACK is lost; then
- The reader waits forever and retrieval of the historical data stalls.

Note that this problem exists both for application transient-local data and for discovery data.

This commit restores Cyclone's old behaviour (pre-63b1a7179b5 or thereabouts) of spontaneously sending NACKs at a low rate if some data is known to be missing.

The alternative (or perhaps both should be done!) is to make the writer start sending heartbeats when it detects a reader that suffered such an asymmetrical disconnection.  It can detect this because it suddenly starts receiving requests for retransmission of already acknowledged data.

Letting the writer send heartbeats would be entirely in line with the specification, spontaneously sending retransmit requests is not. Nothing in the specification guarantees that the writer will send heartbeats in this case, and so there is no interoperable solution that adheres to the specification.

The other commits are a regression test and some changes to make that one simpler to write, as well as a slight lengthening of the interval for spontaneously sending NACKs.