### PR TITLE
by-source-timestamp destination order and a silly crash

### DIFF
--- a/src/core/ddsc/src/dds_instance.c
+++ b/src/core/ddsc/src/dds_instance.c
@@ -66,7 +66,6 @@ static void dds_instance_remove (struct dds_domain *dom, const dds_writer *write
 
 dds_return_t dds_register_instance (dds_entity_t writer, dds_instance_handle_t *handle, const void *data)
 {
-  struct thread_state * const thrst = lookup_thread_state ();
   dds_writer *wr;
   dds_return_t ret;
 
@@ -76,6 +75,7 @@ dds_return_t dds_register_instance (dds_entity_t writer, dds_instance_handle_t *
   if ((ret = dds_writer_lock (writer, &wr)) != DDS_RETCODE_OK)
     return ret;
 
+  struct thread_state * const thrst = lookup_thread_state ();
   thread_state_awake (thrst, &wr->m_entity.m_domain->gv);
   struct ddsi_tkmap_instance * const inst = dds_instance_find (wr, data, true);
   if (inst == NULL)
@@ -102,7 +102,6 @@ dds_return_t dds_unregister_instance_ih (dds_entity_t writer, dds_instance_handl
 
 dds_return_t dds_unregister_instance_ts (dds_entity_t writer, const void *data, dds_time_t timestamp)
 {
-  struct thread_state * const thrst = lookup_thread_state ();
   dds_return_t ret;
   bool autodispose = true;
   dds_write_action action = DDS_WR_ACTION_UNREGISTER;
@@ -117,6 +116,7 @@ dds_return_t dds_unregister_instance_ts (dds_entity_t writer, const void *data, 
   if (wr->m_entity.m_qos)
     (void) dds_qget_writer_data_lifecycle (wr->m_entity.m_qos, &autodispose);
 
+  struct thread_state * const thrst = lookup_thread_state ();
   thread_state_awake (thrst, &wr->m_entity.m_domain->gv);
   if (autodispose)
   {
@@ -131,7 +131,6 @@ dds_return_t dds_unregister_instance_ts (dds_entity_t writer, const void *data, 
 
 dds_return_t dds_unregister_instance_ih_ts (dds_entity_t writer, dds_instance_handle_t handle, dds_time_t timestamp)
 {
-  struct thread_state * const thrst = lookup_thread_state ();
   dds_return_t ret = DDS_RETCODE_OK;
   bool autodispose = true;
   dds_write_action action = DDS_WR_ACTION_UNREGISTER;
@@ -144,6 +143,7 @@ dds_return_t dds_unregister_instance_ih_ts (dds_entity_t writer, dds_instance_ha
   if (wr->m_entity.m_qos)
     (void) dds_qget_writer_data_lifecycle (wr->m_entity.m_qos, &autodispose);
 
+  struct thread_state * const thrst = lookup_thread_state ();
   thread_state_awake (thrst, &wr->m_entity.m_domain->gv);
   if (autodispose)
   {
@@ -168,13 +168,13 @@ dds_return_t dds_unregister_instance_ih_ts (dds_entity_t writer, dds_instance_ha
 
 dds_return_t dds_writedispose_ts (dds_entity_t writer, const void *data, dds_time_t timestamp)
 {
-  struct thread_state * const thrst = lookup_thread_state ();
   dds_return_t ret;
   dds_writer *wr;
 
   if ((ret = dds_writer_lock (writer, &wr)) != DDS_RETCODE_OK)
     return ret;
 
+  struct thread_state * const thrst = lookup_thread_state ();
   thread_state_awake (thrst, &wr->m_entity.m_domain->gv);
   if ((ret = dds_write_impl (wr, data, timestamp, DDS_WR_ACTION_WRITE_DISPOSE)) == DDS_RETCODE_OK)
     dds_instance_remove (wr->m_entity.m_domain, wr, data, DDS_HANDLE_NIL);
@@ -196,7 +196,6 @@ static dds_return_t dds_dispose_impl (dds_writer *wr, const void *data, dds_inst
 
 dds_return_t dds_dispose_ts (dds_entity_t writer, const void *data, dds_time_t timestamp)
 {
-  struct thread_state * const thrst = lookup_thread_state ();
   dds_return_t ret;
   dds_writer *wr;
 
@@ -206,6 +205,7 @@ dds_return_t dds_dispose_ts (dds_entity_t writer, const void *data, dds_time_t t
   if ((ret = dds_writer_lock (writer, &wr)) != DDS_RETCODE_OK)
     return ret;
 
+  struct thread_state * const thrst = lookup_thread_state ();
   thread_state_awake (thrst, &wr->m_entity.m_domain->gv);
   ret = dds_dispose_impl (wr, data, DDS_HANDLE_NIL, timestamp);
   thread_state_asleep (thrst);
@@ -215,7 +215,6 @@ dds_return_t dds_dispose_ts (dds_entity_t writer, const void *data, dds_time_t t
 
 dds_return_t dds_dispose_ih_ts (dds_entity_t writer, dds_instance_handle_t handle, dds_time_t timestamp)
 {
-  struct thread_state * const thrst = lookup_thread_state ();
   dds_return_t ret;
   dds_writer *wr;
 
@@ -223,6 +222,7 @@ dds_return_t dds_dispose_ih_ts (dds_entity_t writer, dds_instance_handle_t handl
     return ret;
 
   struct ddsi_tkmap_instance *tk;
+  struct thread_state * const thrst = lookup_thread_state ();
   thread_state_awake (thrst, &wr->m_entity.m_domain->gv);
   if ((tk = ddsi_tkmap_find_by_id (wr->m_entity.m_domain->gv.m_tkmap, handle)) == NULL)
     ret = DDS_RETCODE_PRECONDITION_NOT_MET;
@@ -242,7 +242,6 @@ dds_return_t dds_dispose_ih_ts (dds_entity_t writer, dds_instance_handle_t handl
 
 dds_instance_handle_t dds_lookup_instance (dds_entity_t entity, const void *data)
 {
-  struct thread_state * const thrst = lookup_thread_state ();
   const struct ddsi_sertype *sertype;
   struct ddsi_serdata *sd;
   dds_entity *w_or_r;
@@ -267,6 +266,7 @@ dds_instance_handle_t dds_lookup_instance (dds_entity_t entity, const void *data
   }
 
   dds_instance_handle_t ih;
+  struct thread_state * const thrst = lookup_thread_state ();
   thread_state_awake (thrst, &w_or_r->m_domain->gv);
   if ((sd = ddsi_serdata_from_sample (sertype, SDK_KEY, data)) == NULL)
     ih = DDS_HANDLE_NIL;
@@ -287,7 +287,6 @@ dds_instance_handle_t dds_instance_lookup (dds_entity_t entity, const void *data
 
 dds_return_t dds_instance_get_key (dds_entity_t entity, dds_instance_handle_t ih, void *data)
 {
-  struct thread_state * const thrst = lookup_thread_state ();
   dds_return_t ret;
   const dds_topic *topic;
   struct ddsi_tkmap_instance *tk;
@@ -315,6 +314,7 @@ dds_return_t dds_instance_get_key (dds_entity_t entity, dds_instance_handle_t ih
       return DDS_RETCODE_ILLEGAL_OPERATION;
   }
 
+  struct thread_state * const thrst = lookup_thread_state ();
   thread_state_awake (thrst, &e->m_domain->gv);
   if ((tk = ddsi_tkmap_find_by_id (e->m_domain->gv.m_tkmap, ih)) == NULL)
     ret = DDS_RETCODE_BAD_PARAMETER;

--- a/src/core/ddsc/src/dds_read.c
+++ b/src/core/ddsc/src/dds_read.c
@@ -33,7 +33,6 @@
 */
 static dds_return_t dds_read_impl (bool take, dds_entity_t reader_or_condition, void **buf, size_t bufsz, uint32_t maxs, dds_sample_info_t *si, uint32_t mask, dds_instance_handle_t hand, bool lock, bool only_reader)
 {
-  struct thread_state * const thrst = lookup_thread_state ();
   dds_return_t ret = DDS_RETCODE_OK;
   struct dds_entity *entity;
   struct dds_reader *rd;
@@ -62,6 +61,7 @@ static dds_return_t dds_read_impl (bool take, dds_entity_t reader_or_condition, 
     cond = (dds_readcond *) entity;
   }
 
+  struct thread_state * const thrst = lookup_thread_state ();
   thread_state_awake (thrst, &entity->m_domain->gv);
 
   /* Allocate samples if not provided (assuming all or none provided) */
@@ -143,7 +143,6 @@ fail:
 
 static dds_return_t dds_readcdr_impl (bool take, dds_entity_t reader_or_condition, struct ddsi_serdata **buf, uint32_t maxs, dds_sample_info_t *si, uint32_t mask, dds_instance_handle_t hand, bool lock)
 {
-  struct thread_state * const thrst = lookup_thread_state ();
   dds_return_t ret = DDS_RETCODE_OK;
   struct dds_reader *rd;
   struct dds_entity *entity;
@@ -162,6 +161,7 @@ static dds_return_t dds_readcdr_impl (bool take, dds_entity_t reader_or_conditio
     rd = (dds_reader *) entity->m_parent;
   }
 
+  struct thread_state * const thrst = lookup_thread_state ();
   thread_state_awake (thrst, &entity->m_domain->gv);
 
   /* read/take resets data available status -- must reset before reading because

--- a/src/core/ddsc/src/dds_write.c
+++ b/src/core/ddsc/src/dds_write.c
@@ -607,10 +607,10 @@ dds_return_t dds_writecdr_impl (dds_writer *wr, struct nn_xpack *xp, struct ddsi
 
 void dds_write_flush (dds_entity_t writer)
 {
-  struct thread_state * const thrst = lookup_thread_state ();
   dds_writer *wr;
   if (dds_writer_lock (writer, &wr) == DDS_RETCODE_OK)
   {
+    struct thread_state * const thrst = lookup_thread_state ();
     thread_state_awake (thrst, &wr->m_entity.m_domain->gv);
     nn_xpack_send (wr->m_xp, true);
     thread_state_asleep (thrst);

--- a/src/core/ddsc/tests/CMakeLists.txt
+++ b/src/core/ddsc/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ set(ddsc_test_sources
     "cdr.c"
     "config.c"
     "data_avail_stress.c"
+    "destorder.c"
     "discstress.c"
     "dispose.c"
     "domain.c"

--- a/src/core/ddsc/tests/CMakeLists.txt
+++ b/src/core/ddsc/tests/CMakeLists.txt
@@ -67,6 +67,7 @@ set(ddsc_test_sources
     "topic_find_local.c"
     "transientlocal.c"
     "types.c"
+    "uninitialized.c"
     "unregister.c"
     "unsupported.c"
     "userdata.c"

--- a/src/core/ddsc/tests/destorder.c
+++ b/src/core/ddsc/tests/destorder.c
@@ -1,0 +1,129 @@
+/*
+ * Copyright(c) 2022 ZettaScale Technology
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+#include <assert.h>
+#include "test_common.h"
+#include "test_oneliner.h"
+
+#define dotest(ops) CU_ASSERT_FATAL (test_oneliner (ops) > 0)
+
+CU_Test (ddsc_destorder, by_source)
+{
+  // Assumes GUIDs are allocated in increasing order in a participant.
+
+  // Now that we're at it: also do some simple sanity checks that never caused a problem
+  dotest ("w(do=s) x(do=s) r(do=s,h=1)"
+          "  wr w (1,1,0)@1"    // initializes instance: GUID w
+          "  wr x (1,2,0)@1"    // may not update instance: GUID x > GUID w
+          "  take{(1,1,0)} r"); // expect to read sample written by w
+  dotest ("w(do=s) x(do=s) r(do=s,h=1)"
+          "  wr x (1,0,0)@1"
+          "  wr w (1,1,0)@1"
+          "  wr x (1,2,0)@1"
+          "  take{(1,1,0)} r");
+  dotest ("w(do=s) x(do=s) y(do=s) r(do=s,h=1)"
+          "  wr y (1,0,0)@1"    // initializes instance: GUID y
+          "  wr w (1,1,0)@1"    // updates instance: GUID w < GUID y
+          "  wr x (1,2,0)@1"    // may not update instance: GUID x > GUID w
+          "  take{(1,1,0)} r");
+}
+
+CU_Test (ddsc_destorder, by_reception)
+{
+  // While we're at it: also do some simple sanity checks that never caused a problem
+  dotest ("w(do=r) x(do=r) r(do=r,h=1)"
+          "  wr w (1,1,0)@1"
+          "  wr x (1,2,0)@1"
+          "  take{(1,2,0)} r");
+  dotest ("w(do=r) x(do=r) r(do=r,h=1)"
+          "  wr x (1,0,0)@1"
+          "  wr w (1,1,0)@1"
+          "  wr x (1,2,0)@1"
+          "  take{(1,2,0)} r");
+  dotest ("w(do=r) x(do=r) y(do=r) r(do=r,h=1)"
+          "  wr y (1,0,0)@1"
+          "  wr w (1,1,0)@1"
+          "  wr x (1,2,0)@1"
+          "  take{(1,2,0)} r");
+}
+
+CU_Test (ddsc_destorder, by_source_history)
+{
+  // Deeper history: it accepts/rejects samples based on how it compares with the current
+  // state, it doesn't rewrite history.  This is a point of debate with regards to the
+  // spec: what precisely is covered by eventual consistency?
+  //
+  // Cyclone DDS treats the reader as something that in a sense "samples" the data space,
+  // OpenSplice tries to make the history eventually consistent, but then has to break
+  // that anyway because of some other requirement on "take".  The specs are completely
+  // oblivious to the possibility of non-monotonically increasing timestamps and the
+  // cosequences thereof and the DCPS spec is essentially silent on the topic anyway.  The
+  // DDSI says it concerns the full history, but then only considers a single writer and
+  // so almost by definition only makes some subtly wrong suggestions about the system
+  // behaviour.
+  //
+  // In my humble view of things, the only sane approach is to consider DDS as a data
+  // space that writers update and where the writer history cache settings affect which
+  // updates can be counted upon to be visible (for however briefly a time), and where the
+  // readers sample the current state and update their own local history.
+  //
+  // Not-quite-coincidentally, that fits with what Cyclone does.  (Well, I tried ...)
+  dotest ("w(do=s) x(do=s) y(do=s) r(do=s,h=3)"
+          "  wr y (1,0,0)@1"
+          "  wr w (1,1,0)@1"
+          "  wr x (1,2,0)@1"
+          "  take{(1,0,0),(1,1,0)} r");
+
+  // Same with GUIDs monotonically decreasing (so in increasing priority): we expect them
+  // all
+  dotest ("w(do=s) x(do=s) y(do=s) r(do=s,h=3)"
+          "  wr y (1,0,0)@1"
+          "  wr x (1,1,0)@1"
+          "  wr w (1,2,0)@1"
+          "  take{(1,0,0),(1,1,0),(1,2,0)} r");
+
+  // Monotonically increasing GUIDs (decreasing priority), but increasing time stamps:
+  // expect them all
+  dotest ("w(do=s) x(do=s) y(do=s) r(do=s,h=3)"
+          "  wr w (1,0,0)@1"
+          "  wr x (1,1,0)@1.1"
+          "  wr y (1,2,0)@1.2"
+          "  take{(1,0,0),(1,1,0),(1,2,0)} r");
+
+  // GUIDs monotonically decreasing (so in increasing priority), timestamps monotonically
+  // decreasing: only the first
+  dotest ("w(do=s) x(do=s) y(do=s) r(do=s,h=3)"
+          "  wr y (1,0,0)@1.2"
+          "  wr x (1,1,0)@1.1"
+          "  wr w (1,2,0)@1.0"
+          "  take{(1,0,0)} r");
+}
+
+CU_Test (ddsc_destorder, by_reception_history)
+{
+  // timestamps don't matter
+  dotest ("w(do=r) x(do=r) y(do=r) r(do=r,h=3)"
+          "  wr y (1,0,0)@1"
+          "  wr w (1,1,0)@1.1"
+          "  wr x (1,2,0)@1.2"
+          "  take{(1,0,0),(1,1,0),(1,2,0)} r");
+  dotest ("w(do=r) x(do=r) y(do=r) r(do=r,h=3)"
+          "  wr y (1,0,0)@1"
+          "  wr w (1,1,0)@1"
+          "  wr x (1,2,0)@1"
+          "  take{(1,0,0),(1,1,0),(1,2,0)} r");
+  dotest ("w(do=r) x(do=r) y(do=r) r(do=r,h=3)"
+          "  wr y (1,0,0)@1.2"
+          "  wr w (1,1,0)@1.1"
+          "  wr x (1,2,0)@1"
+          "  take{(1,0,0),(1,1,0),(1,2,0)} r");
+}

--- a/src/core/ddsc/tests/uninitialized.c
+++ b/src/core/ddsc/tests/uninitialized.c
@@ -1,0 +1,224 @@
+/*
+ * Copyright(c) 2022 ZettaScale Technology and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include <assert.h>
+#include <limits.h>
+
+#include "dds/dds.h"
+#include "dds/ddsc/dds_rhc.h"
+#include "test_common.h"
+
+// internals, to allow creating all objects we need on the stack
+#include "dds__qos.h"
+#include "dds__listener.h"
+#ifdef DDS_HAS_TYPE_DISCOVERY
+#include "dds/ddsi/ddsi_xt_impl.h"
+#endif
+
+/* Calling API functions on an uninitialized library should fail with
+   PRECONDITION_NOT_MET, BAD_PARAMETER or UNSUPPORTED.
+
+   A few exceptions exist that initialize the library:
+   - dds_create_domain
+   - dds create_participant
+   - dds_lookup_participant
+   - dds_write_set_batch dds_create_waitset
+   - dds_create_guardcondition
+
+   So those we don't bother checking here.  Another bunch of functions doesn't do anything
+   interesting, like dds_free_typeinfo, and those we also skip.
+
+   The arguments passed are all arguments that are not trivially invalid, like a null
+   pointer where a non-null pointer is expected. */
+
+static void check (dds_return_t res)
+{
+  CU_ASSERT (res == DDS_RETCODE_PRECONDITION_NOT_MET || res == DDS_RETCODE_BAD_PARAMETER || res == DDS_RETCODE_UNSUPPORTED);
+}
+
+static void check_0 (void *ptr)
+{
+  CU_ASSERT (ptr == 0);
+}
+
+static void check_ih (dds_instance_handle_t ih)
+{
+  CU_ASSERT (ih == 0);
+}
+
+static bool filter_fn (const void *sample) { (void) sample; return true; }
+static bool filter_arg_fn (const void *sample, void *arg) { (void) sample; (void) arg; return true; }
+
+DDSRT_WARNING_DEPRECATED_OFF
+
+CU_Test (ddsc_uninitialized, various)
+{
+  check (dds_enable (1));
+  check (dds_delete (1));
+  check (dds_get_publisher (1));
+  check (dds_get_subscriber (1));
+  check (dds_get_datareader (1));
+  check (dds_get_parent (1));
+  check (dds_get_participant (1));
+  check (dds_set_status_mask (1, 1));
+  check (dds_set_enabled_status (1, 1));
+  uint32_t mask;
+  check (dds_get_mask (1, &mask));
+  check (dds_get_status_changes (1, &mask));
+  check (dds_get_status_mask (1, &mask));
+  check (dds_get_enabled_status (1, &mask));
+  check (dds_read_status (1, &mask, 1));
+  check (dds_take_status (1, &mask, 1));
+  dds_instance_handle_t ih;
+  check (dds_get_instance_handle (1, &ih));
+  dds_domainid_t domainid;
+  check (dds_get_domainid (1, &domainid));
+  dds_guid_t guid;
+  check (dds_get_guid (1, &guid));
+  dds_qos_t qos = { 0 };
+  check (dds_get_qos (1, &qos));
+  check (dds_set_qos (1, &qos));
+  dds_listener_t listener = { 0 };
+  check (dds_get_listener (1, &listener));
+  check (dds_set_listener (1, &listener));
+  dds_entity_t es[3];
+  check (dds_get_children (1, es, sizeof (es) / sizeof (*es)));
+
+  check (dds_create_topic (1, &Space_Type1_desc, "aap", NULL, NULL));
+
+  struct ddsi_sertype sertype = { 0 }, *psertype = &sertype;
+  check (dds_create_topic_sertype (1, "aap", &psertype, NULL, NULL, NULL));
+
+  check (dds_find_topic (DDS_FIND_SCOPE_LOCAL_DOMAIN, 1, "aap", NULL, 1));
+  check (dds_find_topic_scoped (DDS_FIND_SCOPE_LOCAL_DOMAIN, 1, "aap", 1));
+
+  dds_topic_descriptor_t *desc;
+  check (dds_create_topic_descriptor (DDS_FIND_SCOPE_LOCAL_DOMAIN, 1, NULL, 1, &desc));
+
+  char buf[20];
+  check (dds_get_name (1, buf, sizeof (buf)));
+  check (dds_get_type_name (1, buf, sizeof (buf)));
+
+  dds_set_topic_filter (1, filter_fn);
+  dds_topic_set_filter (1, filter_fn);
+  struct dds_topic_filter filter = {
+    .mode = DDS_TOPIC_FILTER_SAMPLE,
+    .f = { .sample = filter_fn },
+    .arg = NULL
+  };
+  check (dds_set_topic_filter_and_arg (1, filter_arg_fn, NULL));
+  check (dds_set_topic_filter_extended (1, &filter));
+
+  check_0 (dds_get_topic_filter (1));
+  check_0 (dds_topic_get_filter (1));
+  check (dds_get_topic_filter_and_arg (1, NULL, NULL));
+  check (dds_get_topic_filter_extended (1, &filter));
+
+  check (dds_create_subscriber (1, NULL, NULL));
+  check (dds_create_publisher (1, NULL, NULL));
+  check (dds_suspend (1));
+  check (dds_resume (1));
+  check (dds_wait_for_acks (1, 0));
+
+  check (dds_create_reader (1, 2, NULL, NULL));
+  struct dds_rhc rhc = { 0 };
+  check (dds_create_reader_rhc (1, 2, NULL, NULL, &rhc));
+  check (dds_reader_wait_for_historical_data (1, 0));
+
+  check (dds_create_writer (1, 2, NULL, NULL));
+  char data = 0;
+  check (dds_register_instance (1, &ih, &data));
+  check (dds_unregister_instance (1, &data));
+  check (dds_unregister_instance_ih (1, 1));
+  check (dds_unregister_instance_ts (1, &data, 1));
+  check (dds_unregister_instance_ih_ts (1, 1, 1));
+  check (dds_writedispose (1, &data));
+  check (dds_writedispose_ts (1, &data, 1));
+  check (dds_dispose (1, &data));
+  check (dds_dispose_ts (1, &data, 1));
+  check (dds_dispose_ih (1, 1));
+  check (dds_dispose_ih_ts (1, 1, 1));
+  check (dds_write (1, &data));
+  dds_write_flush (1);
+  struct ddsi_serdata serdata = { 0 };
+  check (dds_writecdr (1, &serdata));
+  check (dds_forwardcdr (1, &serdata));
+  check (dds_write_ts (1, &data, 1));
+
+  check (dds_create_readcondition (1, DDS_ANY_STATE));
+  check (dds_create_querycondition (1, DDS_ANY_STATE, filter_fn));
+
+  check (dds_set_guardcondition (1, true));
+  bool triggered;
+  check (dds_read_guardcondition (1, &triggered));
+  check (dds_take_guardcondition (1, &triggered));
+
+  check (dds_waitset_get_entities (1, es, sizeof (es) / sizeof (*es)));
+  check (dds_waitset_attach (1, 2, 3));
+  check (dds_waitset_detach (1, 2));
+  check (dds_waitset_set_trigger (1, true));
+  check (dds_waitset_wait (1, NULL, 0, 0));
+  check (dds_waitset_wait_until (1, NULL, 0, DDS_NEVER));
+
+  void *raw = NULL;
+  dds_sample_info_t si;
+  check (dds_read (1, &raw, &si, 1, 1));
+  check (dds_read_wl (1, &raw, &si, 1));
+  check (dds_read_mask (1, &raw, &si, 1, 1, DDS_ANY_STATE));
+  check (dds_read_mask_wl (1, &raw, &si, 1, DDS_ANY_STATE));
+  check (dds_read_instance (1, &raw, &si, 1, 1, 1));
+  check (dds_read_instance_wl (1, &raw, &si, 1, 1));
+  check (dds_read_instance_mask (1, &raw, &si, 1, 1, 1, DDS_ANY_STATE));
+  check (dds_read_instance_mask_wl (1, &raw, &si, 1, 1, DDS_ANY_STATE));
+  check (dds_read_next (1, &raw, &si));
+  check (dds_read_next_wl (1, &raw, &si));
+  check (dds_take (1, &raw, &si, 1, 1));
+  check (dds_take_wl (1, &raw, &si, 1));
+  check (dds_take_mask (1, &raw, &si, 1, 1, DDS_ANY_STATE));
+  check (dds_take_mask_wl (1, &raw, &si, 1, DDS_ANY_STATE));
+  check (dds_take_instance (1, &raw, &si, 1, 1, 1));
+  check (dds_take_instance_wl (1, &raw, &si, 1, 1));
+  check (dds_take_instance_mask (1, &raw, &si, 1, 1, 1, DDS_ANY_STATE));
+  check (dds_take_instance_mask_wl (1, &raw, &si, 1, 1, DDS_ANY_STATE));
+  check (dds_take_next (1, &raw, &si));
+  check (dds_take_next_wl (1, &raw, &si));
+  struct ddsi_serdata *pserdata = NULL;
+  check (dds_readcdr (1, &pserdata, 1, &si, DDS_ANY_STATE));
+  check (dds_readcdr_instance (1, &pserdata, 1, &si, 1, DDS_ANY_STATE));
+  check (dds_takecdr (1, &pserdata, 1, &si, DDS_ANY_STATE));
+  check (dds_takecdr_instance (1, &pserdata, 1, &si, 1, DDS_ANY_STATE));
+
+  check (dds_return_loan (1, &raw, 1));
+  check_ih (dds_lookup_instance (1, &data));
+  check_ih (dds_instance_lookup (1, &data));
+  check (dds_instance_get_key (1, 1, &data));
+
+  check (dds_begin_coherent (1));
+  check (dds_end_coherent (1));
+  check (dds_notify_readers (1));
+  check (dds_triggered (1));
+  check (dds_get_topic (1));
+  check (dds_get_matched_subscriptions (1, &ih, 1));
+  check_0 (dds_get_matched_subscription_data (1, ih));
+  check (dds_get_matched_publications (1, &ih, 1));
+  check_0 (dds_get_matched_publication_data (1, ih));
+
+  check (dds_assert_liveliness (1));
+  check (dds_domain_set_deafmute (1, true, true, 1));
+
+#ifdef DDS_HAS_TYPE_DISCOVERY
+  const dds_typeid_t typeid = { 0 }; // FIXME: get a real one
+  dds_typeobj_t *typeobj;
+  check (dds_get_typeobj (1, &typeid, 1, &typeobj));
+  dds_typeinfo_t *typeinfo;
+  check (dds_get_typeinfo (1, &typeinfo));
+#endif
+}


### PR DESCRIPTION
It turns out that #754 uncovered a nasty bug that makes the by-source-timestamp destination order work fine with 2 writers but not with 3 or more ...

Fixes #754. Thanks @secondage for spotting it and reporting it!

In the process of figuring it out and building a regression test, I ran into a crash when calling `dds_take` before the library is initialized (that means the reader handle is by definition invalid, and it should return error). That turns out to be caused by calling `lookup_thread_state` before making sure the library is initialized. This led to a test case and some trivial fixes. These are obviously unrelated to the subject matter, but they are so straightforward that I figured I could just include them here.