### PR TITLE
Start at last_seq on first HB is Cyclone-specific

### DIFF
--- a/src/core/ddsc/tests/builtin_topics.c
+++ b/src/core/ddsc/tests/builtin_topics.c
@@ -24,8 +24,6 @@ static dds_entity_t g_topic       = 0;
 
 #define MAX_SAMPLES 2
 
-static dds_sample_info_t g_info[MAX_SAMPLES];
-
 static void setup (void)
 {
   const char *config = "\
@@ -183,12 +181,13 @@ CU_Test(ddsc_builtin_topics, read_publication_data, .init = setup, .fini = teard
   dds_return_t ret;
   dds_builtintopic_endpoint_t *data;
   void *samples[MAX_SAMPLES];
+  dds_sample_info_t info[MAX_SAMPLES];
 
   reader = dds_create_reader(g_participant, DDS_BUILTIN_TOPIC_DCPSPUBLICATION, NULL, NULL);
   CU_ASSERT_FATAL(reader > 0);
 
   samples[0] = NULL;
-  ret = dds_read(reader, samples, g_info, MAX_SAMPLES, MAX_SAMPLES);
+  ret = dds_read(reader, samples, info, MAX_SAMPLES, MAX_SAMPLES);
   data = samples[0];
   CU_ASSERT_FATAL(ret > 0);
   CU_ASSERT_STRING_EQUAL_FATAL(data->topic_name, "RoundTrip");
@@ -200,6 +199,7 @@ CU_Test(ddsc_builtin_topics, read_subscription_data, .init = setup, .fini = tear
   dds_entity_t reader;
   dds_return_t ret;
   void * samples[MAX_SAMPLES];
+  dds_sample_info_t info[MAX_SAMPLES];
   const char *exp[] = { "DCPSSubscription", "RoundTrip" };
   unsigned seen = 0;
   dds_qos_t *qos;
@@ -208,7 +208,7 @@ CU_Test(ddsc_builtin_topics, read_subscription_data, .init = setup, .fini = tear
   CU_ASSERT_FATAL(reader > 0);
 
   samples[0] = NULL;
-  ret = dds_read(reader, samples, g_info, MAX_SAMPLES, MAX_SAMPLES);
+  ret = dds_read(reader, samples, info, MAX_SAMPLES, MAX_SAMPLES);
   CU_ASSERT_FATAL(ret == 2);
   qos = dds_create_qos();
   for (int i = 0; i < ret; i++) {
@@ -233,14 +233,14 @@ CU_Test(ddsc_builtin_topics, read_participant_data, .init = setup, .fini = teard
 {
   dds_entity_t reader;
   dds_return_t ret;
-  //dds_builtintopic_participant_t *data;
   void * samples[MAX_SAMPLES];
+  dds_sample_info_t info[MAX_SAMPLES];
 
   reader = dds_create_reader(g_participant, DDS_BUILTIN_TOPIC_DCPSPARTICIPANT, NULL, NULL);
   CU_ASSERT_FATAL(reader > 0);
 
   samples[0] = NULL;
-  ret = dds_read(reader, samples, g_info, MAX_SAMPLES, MAX_SAMPLES);
+  ret = dds_read(reader, samples, info, MAX_SAMPLES, MAX_SAMPLES);
   CU_ASSERT_FATAL(ret > 0);
   dds_return_loan(reader, samples, ret);
 }
@@ -253,7 +253,8 @@ CU_Test(ddsc_builtin_topics, read_topic_data, .init = setup, .fini = teardown)
   dds_entity_t reader = dds_create_reader(g_participant, DDS_BUILTIN_TOPIC_DCPSTOPIC, NULL, NULL);
   CU_ASSERT_FATAL(reader > 0);
   void * samples[MAX_SAMPLES] = { NULL };
-  dds_return_t ret = dds_read(reader, samples, g_info, MAX_SAMPLES, MAX_SAMPLES);
+  dds_sample_info_t info[MAX_SAMPLES];
+  dds_return_t ret = dds_read(reader, samples, info, MAX_SAMPLES, MAX_SAMPLES);
   CU_ASSERT_FATAL(ret >= 0);
   for (int i = 0; i < ret; i++)
   {


### PR DESCRIPTION
Cyclone DDS is careful to perform a three-way handshake to have a
well-defined starting point for reliability (and hence for whether
samples can be lost despite it being reliable and the two sides being
connected all the time).

That requires dropping data until a heartbeat has been received and
starting at the highest sequence number advertised by the writer.  In
principle, this is interoperable with other implementations, but it
turns out that for the type discovery protocol (at least for OpenDDS)
this can result in dropping the first request, which (at least for
OpenDDS) stalls type discovery and prevents matching.

Hence b6dadb3439d82412b2a7492ce31017960fbb3beb changed it to accept data
from other DDS implementations before a heartbeat is received.  This
means there may be gaps in the data sequence on starting up the reliable
session if the writer is using another DDS implementation.  If this is a
problem, just use Cyclone DDS.

What did not change is that it expects to start at sequence number 1,
and it is the first heartbeat that changes that expectation.  So if,
from that other DDS implementation, the first data arrives before the
first heartbeat and it has sequence numbers > 1, it will now be buffered
and (likely) made available on receipt of the heartbeat.

The processing of the first heartbeat remained unchanged.  This has two
problematic consequences:

* It jumps forward to the latest advertised sequence number (correct for
  a Cyclone peer but arguably wrong in the light of accepting the first
  data that comes in from another peer), and

* There may be data ready for delivery where the code asserts that there
  cannot be any.  The assert in itself fortunately disappears in a
  release build (so there is no crash), but it does leak some memory.

This commit changes the handling of the first heartbeat.  In the case of
a Cyclone writer, nothing changes.  In the case of a non-Cyclone writer,
it will now simply deliver whatever was received already (in line with
the behaviour prior to adding the handshake).

Signed-off-by: Erik Boasson <eb@ilities.com>