### PR TITLE
macOS: if Iceoryx used, add library dir to rpath

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,10 @@ if(ENABLE_SHM)
   endif()
   find_package(iceoryx_binding_c ${iceoryx_required})
   set(ENABLE_SHM ${iceoryx_binding_c_FOUND} CACHE STRING "" FORCE)
+  if(ENABLE_SHM AND APPLE)
+    get_filename_component(iceoryx_libdir "${ICEORYX_LIB}" DIRECTORY)
+    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_RPATH};${iceoryx_libdir}")
+  endif()
 endif()
 
 # ones that linger in the sources


### PR DESCRIPTION
The CMAKE_INSTALL_RPATH set in the top-level CMakeLists.txt causes the
rpath for the Iceoryx library to disappear on installation, but not
setting it means the build directories are used in the rpaths of the
installed Cyclone library, which also doesn't work.

This adds the directory where the iceoryx library is found to the rpath
used for installing.  I suspect there are better ways, but this should
be better than nothing.

Signed-off-by: Erik Boasson <eb@ilities.com>