### PR TITLE
Bump minimum CMake version to 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,12 +9,8 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 project(CycloneDDS VERSION 0.10.0 LANGUAGES C)
-if(CMAKE_VERSION VERSION_LESS 3.12)
-  # GENERATE_EXPORT_HEADER requires a C++ compiler up to version 3.12
-  enable_language(CXX)
-endif()
 
 # Set a default build type if none was specified
 set(default_build_type "RelWithDebInfo")
@@ -177,12 +173,6 @@ if(${CMAKE_GENERATOR} STREQUAL "Xcode")
   set (CMAKE_XCODE_ATTRIBUTE_GCC_WARN_UNUSED_VARIABLE YES)
   set (CMAKE_XCODE_ATTRIBUTE_CLANG_WARN_DOCUMENTATION_COMMENTS YES)
   set (CMAKE_XCODE_ATTRIBUTE_GCC_WARN_ABOUT_MISSING_PROTOTYPES YES)
-endif()
-
-if(CMAKE_VERSION VERSION_LESS 3.13)
-  macro(add_link_options)
-    link_libraries(${ARGV})
-  endmacro()
 endif()
 
 # Make it easy to enable MSVC, Clang's/gcc's analyzers

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ In order to build Cyclone DDS you need a Linux, Mac or Windows 10 machine (or, w
 
   * C compiler (most commonly GCC on Linux, Visual Studio on Windows, Xcode on macOS);
   * Optionally GIT version control system;
-  * [CMake](https://cmake.org/download/), version 3.10 or later;
+  * [CMake](https://cmake.org/download/), version 3.16 or later;
   * Optionally [OpenSSL](https://www.openssl.org/), preferably version 1.1;
   * Optionally [Eclipse Iceoryx](https://iceoryx.io) version 2.0 for shared memory and zero-copy support;
   * Optionally [Bison](https://www.gnu.org/software/bison/) parser generator. A cached source is checked into the repository.

--- a/examples/dynsub/CMakeLists.txt
+++ b/examples/dynsub/CMakeLists.txt
@@ -10,7 +10,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
 project(dynsub LANGUAGES C)
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 if(NOT TARGET CycloneDDS::ddsc)
   find_package(CycloneDDS REQUIRED)

--- a/examples/helloworld/CMakeLists.txt
+++ b/examples/helloworld/CMakeLists.txt
@@ -10,7 +10,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
 project(helloword LANGUAGES C)
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 if(NOT TARGET CycloneDDS::ddsc)
   # Find the CycloneDDS package.

--- a/examples/listtopics/CMakeLists.txt
+++ b/examples/listtopics/CMakeLists.txt
@@ -10,7 +10,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
 project(listtopics LANGUAGES C)
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 if(NOT TARGET CycloneDDS::ddsc)
   find_package(CycloneDDS REQUIRED)

--- a/examples/roundtrip/CMakeLists.txt
+++ b/examples/roundtrip/CMakeLists.txt
@@ -10,7 +10,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
 project(roundtrip LANGUAGES C)
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 if(NOT TARGET CycloneDDS::ddsc)
   # Find the CycloneDDS package.

--- a/examples/shm_throughput/CMakeLists.txt
+++ b/examples/shm_throughput/CMakeLists.txt
@@ -10,7 +10,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
 project(shm_throughput LANGUAGES C)
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 if(NOT TARGET CycloneDDS::ddsc)
   # Find the CycloneDDS package.

--- a/examples/throughput/CMakeLists.txt
+++ b/examples/throughput/CMakeLists.txt
@@ -10,7 +10,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
 project(throughput LANGUAGES C)
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 if(NOT TARGET CycloneDDS::ddsc)
   # Find the CycloneDDS package.

--- a/ports/freertos-posix/CMakeLists.txt
+++ b/ports/freertos-posix/CMakeLists.txt
@@ -9,7 +9,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 project(FreeRTOS-Sim VERSION 10.0.2.0 LANGUAGES C)
 
 include(GNUInstallDirs)

--- a/src/core/xtests/cdrtest/CMakeLists.txt
+++ b/src/core/xtests/cdrtest/CMakeLists.txt
@@ -9,7 +9,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 project(CDRTest LANGUAGES C)
 list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 


### PR DESCRIPTION
Support for EXPORT_PROPERTIES was added in CMake 3.12, so either the
minimum version required needs to be bumped, or this feature needs to be
emulated.  Ubuntu 22.04 ships with CMake 3.16, is over two years old now
and also the minimum required for ROS 2 Foxy, so that seems like a
reasonable new minimum version.

Fixes #1354

Signed-off-by: Erik Boasson <eb@ilities.com>