### PR TITLE
Fix type object generation for typedef of array of sequences

### DIFF
--- a/src/tools/idlc/src/descriptor_type_meta.c
+++ b/src/tools/idlc/src/descriptor_type_meta.c
@@ -1430,11 +1430,14 @@ emit_sequence(
 
   (void) path;
   /* In case the sequence is not a plain collection type identifier, which means that the
-     sequence itself (not the element type) cannot be expressed by as a (non-hash) type
+     sequence itself (not the element type) cannot be expressed by a (non-hash) type
      identifier but also needs a type object, a hashed type is added for this sequence */
-  assert (!has_fully_descriptive_typeid (node));
   if (has_plain_collection_typeid (node))
     return IDL_VISIT_TYPE_SPEC;
+
+  /* Sequence node should not be a fully descriptive type (which does not need a hashed
+     type identifier. A fully descriptive sequence is handled in emit_declarator */
+  assert (!has_fully_descriptive_typeid (node));
 
   if (revisit) {
     assert (dtm->stack->to_minimal->_u.minimal._d == DDS_XTypes_TK_SEQUENCE);

--- a/src/tools/idlc/tests/type_meta.c
+++ b/src/tools/idlc/tests/type_meta.c
@@ -704,6 +704,55 @@ static DDS_XTypes_TypeObject *get_typeobj13 (void)
     });
 }
 
+static DDS_XTypes_TypeObject *get_typeobj14 (void)
+{
+  DDS_XTypes_TypeIdentifier ti_f1;
+
+  /* f1 type identifier */
+  {
+    DDS_XTypes_TypeIdentifier *ti_long = calloc (1, sizeof (*ti_long));
+    ti_long->_d = DDS_XTypes_TK_INT32;
+
+    DDS_XTypes_TypeIdentifier *ti_seq = calloc (1, sizeof (*ti_seq));
+    ti_seq->_d = DDS_XTypes_TI_PLAIN_SEQUENCE_SMALL;
+    ti_seq->_u.seq_sdefn = (struct DDS_XTypes_PlainSequenceSElemDefn) {
+      .header = { .equiv_kind = DDS_XTypes_EK_BOTH, .element_flags = DDS_XTypes_TRY_CONSTRUCT_DISCARD },
+      .bound = 0,
+      .element_identifier = ti_long
+    };
+
+    /* typedef sequence<long> td_seq_arr[2] */
+    uint8_t *bound_seq = calloc (1, sizeof (*bound_seq));
+    bound_seq[0] = 3;
+    DDS_XTypes_TypeObject *to_alias_seq_arr = calloc (1, sizeof (*to_alias_seq_arr));
+    to_alias_seq_arr->_d = DDS_XTypes_EK_COMPLETE;
+    to_alias_seq_arr->_u.complete = (DDS_XTypes_CompleteTypeObject) {
+      ._d = DDS_XTypes_TK_ALIAS,
+      ._u.alias_type = (DDS_XTypes_CompleteAliasType) {
+        .alias_flags = 0,
+        .header = { .detail = { .type_name = "t14::td_seq_arr" } },
+        .body = { .common = { .related_flags = 0, .related_type = (DDS_XTypes_TypeIdentifier) {
+          ._d = DDS_XTypes_TI_PLAIN_ARRAY_SMALL,
+          ._u.array_sdefn = {
+            .header = { .equiv_kind = DDS_XTypes_EK_BOTH, .element_flags = DDS_XTypes_TRY_CONSTRUCT_DISCARD },
+            .array_bound_seq = { ._maximum = 1, ._length = 1, ._buffer = bound_seq, ._release = true },
+            .element_identifier = ti_seq
+          }
+        } } }
+      }
+    };
+    get_typeid (&ti_f1, to_alias_seq_arr);
+  }
+
+  return get_typeobj_struct (
+    "t14::test_struct",
+    DDS_XTypes_IS_FINAL,
+    (DDS_XTypes_TypeIdentifier) { ._d = DDS_XTypes_TK_NONE },
+    1, (smember_t[]) {
+      { 0, DDS_XTypes_TRY_CONSTRUCT_DISCARD, ti_f1, "f1" },
+    });
+}
+
 typedef DDS_XTypes_TypeObject * (*get_typeobj_t) (void);
 
 CU_Test(idlc_type_meta, type_obj_serdes)
@@ -725,7 +774,8 @@ CU_Test(idlc_type_meta, type_obj_serdes)
     { "module t10 { enum en { en0, en1 }; @topic @final struct test_struct { en f1; en f2; }; };", get_typeobj10 },
     { "module t11 { @final union test_union switch (char) { case 'a': @id(99) long f1; default: @id(5) unsigned short f2; }; };", get_typeobj11 },
     { "module t12 { typedef sequence<long> td_seq; typedef td_seq td_array[2]; struct test_struct { td_array f1; }; };", get_typeobj12 },
-    { "module t13 { typedef long td_arr[3]; typedef td_arr td; @topic @final struct test_struct { td f1; }; };", get_typeobj13 }
+    { "module t13 { typedef long td_arr[3]; typedef td_arr td; @topic @final struct test_struct { td f1; }; };", get_typeobj13 },
+    { "module t14 { typedef sequence<long> td_seq_arr[3]; @final struct test_struct { td_seq_arr f1; }; };", get_typeobj14 }
   };
 
   uint32_t flags = IDL_FLAG_EXTENDED_DATA_TYPES |


### PR DESCRIPTION
This fixes a bug in the type meta-data generation that prevented generating a type object and identifier for a struct or union member of a type that is an alias for an array of sequences of a plain type, e.g. the following IDL

```
typedef sequence<long> td[3];
struct a { td f1; };
```
