### PR TITLE
Add validation for enum extensibility in type object

### DIFF
--- a/src/core/ddsi/src/ddsi_typewrap.c
+++ b/src/core/ddsi/src/ddsi_typewrap.c
@@ -718,6 +718,8 @@ static dds_return_t xt_valid_type_flags (struct ddsi_domaingv *gv, uint16_t flag
     case DDS_XTypes_TK_UNION:
       if (flags & ~(F|A|M|N|H))
         ret = DDS_RETCODE_BAD_PARAMETER;
+      if (!(flags & (F|A|M)))
+        ret = DDS_RETCODE_BAD_PARAMETER;
       break;
     case DDS_XTypes_TK_ALIAS:
     case DDS_XTypes_TK_BITSET:
@@ -731,6 +733,8 @@ static dds_return_t xt_valid_type_flags (struct ddsi_domaingv *gv, uint16_t flag
     case DDS_XTypes_TK_BITMASK:
       // spec says unused, but this flag is actually used for extensibility
       if (flags & ~(F|A))
+        ret = DDS_RETCODE_BAD_PARAMETER;
+      if (!(flags & (F|A)))
         ret = DDS_RETCODE_BAD_PARAMETER;
       break;
     case DDS_XTypes_TK_ANNOTATION:


### PR DESCRIPTION
The DDS XTypes spec states that enums can be `@final` or `@appendable` (section 7.4.1, table 12), however a comment in the IDL for the TypeObject says that the enumerated type flag is unused. We decided to solve this problem by ignoring the "unused" comment in the IDL and encode the extensibility in the TypeObject. This also means that the TypeObject validation should check for this, which is fixed in this PR (also for aggregated types).