### PR TITLE
Fix for requesting type dependencies for incomplete type lookup response

### DIFF
--- a/src/core/ddsc/tests/xtypes.c
+++ b/src/core/ddsc/tests/xtypes.c
@@ -997,10 +997,13 @@ CU_Test (ddsc_xtypes, resolve_dep_type, .init = xtypes_init, .fini = xtypes_fini
       { .types = { ._length = 1, ._maximum = 1, ._release = false, ._buffer = &tmap->identifier_object_pair_minimal._buffer[0] } } } } } }
     };
   ddsi_tl_add_types (gv, &reply, &gpe_match_upd, &n_match_upd);
-  CU_ASSERT_EQUAL_FATAL (n_match_upd, 0);
+  // FIXME expect matching triggered (but matching would fail because deps are unresolved), this needs to be fixed in ddsi_tl_handle_reply
+  CU_ASSERT_EQUAL_FATAL (n_match_upd, 1);
   ddsrt_free (gpe_match_upd);
 
   // add nested type and expect match
+  gpe_match_upd = NULL;
+  n_match_upd = 0;
   reply = (DDS_Builtin_TypeLookup_Reply) {
     .header = { .remoteEx = DDS_RPC_REMOTE_EX_OK, .relatedRequestId = { .sequence_number = { .low = 1, .high = 0 }, .writer_guid = { .guidPrefix = { 0 }, .entityId = { .entityKind = EK_WRITER, .entityKey = { 0 } } } } },
     .return_data = { ._d = DDS_Builtin_TypeLookup_getTypes_HashId, ._u = { .getType = { ._d = DDS_RETCODE_OK, ._u = { .result =

--- a/src/core/ddsi/src/ddsi_typelib.c
+++ b/src/core/ddsi/src/ddsi_typelib.c
@@ -1087,8 +1087,13 @@ static void ddsi_type_get_gpe_matches_impl (struct ddsi_domaingv *gv, const stru
 
 void ddsi_type_get_gpe_matches (struct ddsi_domaingv *gv, const struct ddsi_type *type, struct generic_proxy_endpoint ***gpe_match_upd, uint32_t *n_match_upd)
 {
-  if (ddsi_type_resolved_locked (gv, type, DDSI_TYPE_INCLUDE_DEPS))
-    ddsi_type_get_gpe_matches_impl (gv, type, gpe_match_upd, n_match_upd);
+  /* No check for resolved state of dependencies for this type at this point: matching for
+     endpoints using this type as top-level type (or dependent type, via reverse
+     dependencies) will be re-tried, and missing dependencies will be requested from there.
+     This should be changed so that dependencies are requested from this point, which will
+     also fix type resolvind triggered by find_topic, in case an incomplete type lookup
+     response is received and additional types need to be requested. */
+  ddsi_type_get_gpe_matches_impl (gv, type, gpe_match_upd, n_match_upd);
   struct ddsi_type_dep tmpl, *reverse_dep = &tmpl;
   memset (&tmpl, 0, sizeof (tmpl));
   ddsi_typeid_copy (&tmpl.dep_type_id, &type->xt.id);


### PR DESCRIPTION
When processing a type lookup response results in resolving a top-level type for an endpoint, but one or more dependent types remain unresolved (e.g. because these dependencies were not included in the `type_information` for the endpoint and therefore not requested yet), the endpoint matching is not triggered (which is reasonable, because it will fail) but there is also no request sent for the additional types required for matching.

This PR fixes this problem by re-triggering the matching for all endpoints that are using this type, regardless of the resolved 
state of its dependencies. The matching will trigger a type lookup request in case any dependencies need to be resolved. This fix is a temporary solution for this problem, and will be replaced by a proper solution that also takes `find_topic` calls into account (which could currently also run into this issue).