### PR TITLE
Typebuilder fix for union-members with multiple case labels

### DIFF
--- a/src/core/ddsc/tests/TypeBuilderTypes.idl
+++ b/src/core/ddsc/tests/TypeBuilderTypes.idl
@@ -338,4 +338,33 @@ module TypeBuilderTypes {
     arr_s2 f1[2];
   };
 
+
+  struct t24_1 {
+    long f1;
+  };
+  union t24_2 switch(octet) {
+    case 1: long a;
+    case 2: case 3: t24_1 b;
+    case 4: case 5: sequence<t24_1> c;
+  };
+  union t24 switch(octet) {
+    case 1: case 2:
+      sequence<t24_1> u1;
+    case 3: case 4:
+      t24_1 u2;
+    case 5: case 6:
+      t24_1 u3[2];
+    case 7: case 8:
+      sequence<t24_1> u4[2];
+
+    case 10: case 11:
+      sequence<t24_2> s1;
+    case 12: case 13:
+      t24_2 s2;
+
+    case 99:
+    default:
+      sequence<t24_1> u99;
+  };
+
 };

--- a/src/core/ddsc/tests/typebuilder.c
+++ b/src/core/ddsc/tests/typebuilder.c
@@ -134,7 +134,7 @@ static bool tmap_equal (ddsi_typemap_t *a, ddsi_typemap_t *b)
 CU_TheoryDataPoints (ddsc_typebuilder, topic_desc) = {
   CU_DataPoints (const dds_topic_descriptor_t *, &D(t1), &D(t2), &D(t3), &D(t4), &D(t5), &D(t6), &D(t7), &D(t8),
                                                  &D(t9), &D(t10), &D(t11), &D(t12), &D(t13), &D(t14), &D(t15), &D(t16),
-                                                 &D(t17), &D(t18), &D(t19), &D(t20), &D(t21), &D(t22), &D(t23) ),
+                                                 &D(t17), &D(t18), &D(t19), &D(t20), &D(t21), &D(t22), &D(t23), &D(t24) ),
 };
 #undef D
 

--- a/src/core/ddsi/src/ddsi_typebuilder.c
+++ b/src/core/ddsi/src/ddsi_typebuilder.c
@@ -1360,6 +1360,12 @@ static dds_return_t resolve_ops_offsets_union (const struct typebuilder_union *t
   dds_return_t ret = DDS_RETCODE_OK;
   for (uint32_t m = 0; m < tb_union->n_cases; m++)
   {
+    /* In case its not the last label and the member type is not an aggregated
+       type defined outside the current union, the offset to the in-union type
+       ops is already set (or not required, for primitive types which are inline
+       in the current JEQ4) */
+    if (!tb_union->cases[m].is_last_label && tb_union->cases[m].type.type_code != DDS_OP_VAL_STU && tb_union->cases[m].type.type_code != DDS_OP_VAL_UNI)
+      continue;
     if ((ret = resolve_ops_offsets_type (&tb_union->cases[m].type, ops)))
       return ret;
   }


### PR DESCRIPTION
This fixes a bug in the topic descriptor generation that caused an incorrect opcode at index 0 when the type has a union that has multiple labels for a member with a member-type that is represented in-union (after the union cases) in the generated ops, e.g.:

```
  struct t { long t1; };
  union u switch(octet) {
    case 1: case 2:
      sequence<t> u1;
  };
```