### PR TITLE
Fix crash dropping gap from reorder buffer

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/q_radmin.h
+++ b/src/core/ddsi/include/dds/ddsi/q_radmin.h
@@ -213,24 +213,24 @@ struct ddsrt_log_cfg;
 struct nn_fragment_number_set_header;
 struct nn_sequence_number_set_header;
 
-struct nn_rbufpool *nn_rbufpool_new (const struct ddsrt_log_cfg *logcfg, uint32_t rbuf_size, uint32_t max_rmsg_size);
-void nn_rbufpool_setowner (struct nn_rbufpool *rbp, ddsrt_thread_t tid);
-void nn_rbufpool_free (struct nn_rbufpool *rbp);
+DDS_EXPORT struct nn_rbufpool *nn_rbufpool_new (const struct ddsrt_log_cfg *logcfg, uint32_t rbuf_size, uint32_t max_rmsg_size);
+DDS_EXPORT void nn_rbufpool_setowner (struct nn_rbufpool *rbp, ddsrt_thread_t tid);
+DDS_EXPORT void nn_rbufpool_free (struct nn_rbufpool *rbp);
 
-struct nn_rmsg *nn_rmsg_new (struct nn_rbufpool *rbufpool);
-void nn_rmsg_setsize (struct nn_rmsg *rmsg, uint32_t size);
-void nn_rmsg_commit (struct nn_rmsg *rmsg);
-void nn_rmsg_free (struct nn_rmsg *rmsg);
-void *nn_rmsg_alloc (struct nn_rmsg *rmsg, uint32_t size);
+DDS_EXPORT struct nn_rmsg *nn_rmsg_new (struct nn_rbufpool *rbufpool);
+DDS_EXPORT void nn_rmsg_setsize (struct nn_rmsg *rmsg, uint32_t size);
+DDS_EXPORT void nn_rmsg_commit (struct nn_rmsg *rmsg);
+DDS_EXPORT void nn_rmsg_free (struct nn_rmsg *rmsg);
+DDS_EXPORT void *nn_rmsg_alloc (struct nn_rmsg *rmsg, uint32_t size);
 
-struct nn_rdata *nn_rdata_new (struct nn_rmsg *rmsg, uint32_t start, uint32_t endp1, uint32_t submsg_offset, uint32_t payload_offset, uint32_t keyhash_offset);
-struct nn_rdata *nn_rdata_newgap (struct nn_rmsg *rmsg);
-void nn_fragchain_adjust_refcount (struct nn_rdata *frag, int adjust);
-void nn_fragchain_unref (struct nn_rdata *frag);
+DDS_EXPORT struct nn_rdata *nn_rdata_new (struct nn_rmsg *rmsg, uint32_t start, uint32_t endp1, uint32_t submsg_offset, uint32_t payload_offset, uint32_t keyhash_offset);
+DDS_EXPORT struct nn_rdata *nn_rdata_newgap (struct nn_rmsg *rmsg);
+DDS_EXPORT void nn_fragchain_adjust_refcount (struct nn_rdata *frag, int adjust);
+DDS_EXPORT void nn_fragchain_unref (struct nn_rdata *frag);
 
-struct nn_defrag *nn_defrag_new (const struct ddsrt_log_cfg *logcfg, enum nn_defrag_drop_mode drop_mode, uint32_t max_samples);
-void nn_defrag_free (struct nn_defrag *defrag);
-struct nn_rsample *nn_defrag_rsample (struct nn_defrag *defrag, struct nn_rdata *rdata, const struct nn_rsample_info *sampleinfo);
+DDS_EXPORT struct nn_defrag *nn_defrag_new (const struct ddsrt_log_cfg *logcfg, enum nn_defrag_drop_mode drop_mode, uint32_t max_samples);
+DDS_EXPORT void nn_defrag_free (struct nn_defrag *defrag);
+DDS_EXPORT struct nn_rsample *nn_defrag_rsample (struct nn_defrag *defrag, struct nn_rdata *rdata, const struct nn_rsample_info *sampleinfo);
 void nn_defrag_notegap (struct nn_defrag *defrag, seqno_t min, seqno_t maxp1);
 
 enum nn_defrag_nackmap_result {
@@ -243,16 +243,16 @@ enum nn_defrag_nackmap_result nn_defrag_nackmap (struct nn_defrag *defrag, seqno
 
 void nn_defrag_prune (struct nn_defrag *defrag, ddsi_guid_prefix_t *dst, seqno_t min);
 
-struct nn_reorder *nn_reorder_new (const struct ddsrt_log_cfg *logcfg, enum nn_reorder_mode mode, uint32_t max_samples, bool late_ack_mode);
-void nn_reorder_free (struct nn_reorder *r);
+DDS_EXPORT struct nn_reorder *nn_reorder_new (const struct ddsrt_log_cfg *logcfg, enum nn_reorder_mode mode, uint32_t max_samples, bool late_ack_mode);
+DDS_EXPORT void nn_reorder_free (struct nn_reorder *r);
 struct nn_rsample *nn_reorder_rsample_dup_first (struct nn_rmsg *rmsg, struct nn_rsample *rsampleiv);
-struct nn_rdata *nn_rsample_fragchain (struct nn_rsample *rsample);
-nn_reorder_result_t nn_reorder_rsample (struct nn_rsample_chain *sc, struct nn_reorder *reorder, struct nn_rsample *rsampleiv, int *refcount_adjust, int delivery_queue_full_p);
-nn_reorder_result_t nn_reorder_gap (struct nn_rsample_chain *sc, struct nn_reorder *reorder, struct nn_rdata *rdata, seqno_t min, seqno_t maxp1, int *refcount_adjust);
+DDS_EXPORT struct nn_rdata *nn_rsample_fragchain (struct nn_rsample *rsample);
+DDS_EXPORT nn_reorder_result_t nn_reorder_rsample (struct nn_rsample_chain *sc, struct nn_reorder *reorder, struct nn_rsample *rsampleiv, int *refcount_adjust, int delivery_queue_full_p);
+DDS_EXPORT nn_reorder_result_t nn_reorder_gap (struct nn_rsample_chain *sc, struct nn_reorder *reorder, struct nn_rdata *rdata, seqno_t min, seqno_t maxp1, int *refcount_adjust);
 void nn_reorder_drop_upto (struct nn_reorder *reorder, seqno_t maxp1); // drops [1,maxp1); next_seq' = maxp1
-int nn_reorder_wantsample (const struct nn_reorder *reorder, seqno_t seq);
+DDS_EXPORT int nn_reorder_wantsample (const struct nn_reorder *reorder, seqno_t seq);
 unsigned nn_reorder_nackmap (const struct nn_reorder *reorder, seqno_t base, seqno_t maxseq, struct nn_sequence_number_set_header *map, uint32_t *mapbits, uint32_t maxsz, int notail);
-seqno_t nn_reorder_next_seq (const struct nn_reorder *reorder);
+DDS_EXPORT seqno_t nn_reorder_next_seq (const struct nn_reorder *reorder);
 void nn_reorder_set_next_seq (struct nn_reorder *reorder, seqno_t seq);
 
 struct nn_dqueue *nn_dqueue_new (const char *name, const struct ddsi_domaingv *gv, uint32_t max_samples, nn_dqueue_handler_t handler, void *arg);
@@ -266,8 +266,8 @@ void nn_dqueue_enqueue_callback (struct nn_dqueue *q, nn_dqueue_callback_t cb, v
 int  nn_dqueue_is_full (struct nn_dqueue *q);
 void nn_dqueue_wait_until_empty_if_full (struct nn_dqueue *q);
 
-void nn_defrag_stats (struct nn_defrag *defrag, uint64_t *discarded_bytes);
-void nn_reorder_stats (struct nn_reorder *reorder, uint64_t *discarded_bytes);
+DDS_EXPORT void nn_defrag_stats (struct nn_defrag *defrag, uint64_t *discarded_bytes);
+DDS_EXPORT void nn_reorder_stats (struct nn_reorder *reorder, uint64_t *discarded_bytes);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsi/include/dds/ddsi/q_rtps.h
+++ b/src/core/ddsi/include/dds/ddsi/q_rtps.h
@@ -85,12 +85,12 @@ typedef uint64_t seqno_t;
 
 struct cfgst;
 struct ddsi_domaingv;
-int rtps_config_prep (struct ddsi_domaingv *gv, struct cfgst *cfgst);
+DDS_EXPORT int rtps_config_prep (struct ddsi_domaingv *gv, struct cfgst *cfgst);
 int rtps_config_open_trace (struct ddsi_domaingv *gv);
-int rtps_init (struct ddsi_domaingv *gv);
+DDS_EXPORT int rtps_init (struct ddsi_domaingv *gv);
 int rtps_start (struct ddsi_domaingv *gv);
 void rtps_stop (struct ddsi_domaingv *gv);
-void rtps_fini (struct ddsi_domaingv *gv);
+DDS_EXPORT void rtps_fini (struct ddsi_domaingv *gv);
 
 DDS_EXPORT void ddsi_set_deafmute (struct ddsi_domaingv *gv, bool deaf, bool mute, int64_t reset_after);
 

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -2112,10 +2112,9 @@ void rtps_stop (struct ddsi_domaingv *gv)
   }
 
   /* Once the receive threads have stopped, defragmentation and
-     reorder state can't change anymore, and can be freed safely. */
-  nn_reorder_free (gv->spdp_reorder);
-  nn_defrag_free (gv->spdp_defrag);
-  ddsrt_mutex_destroy (&gv->spdp_lock);
+     reorder state can't change anymore, and can be freed safely.
+     We don't do that here because it means rtps_init/rtps_fini
+     allow will leak it. */
 
   {
     struct entidx_enum_proxy_participant est;
@@ -2208,6 +2207,13 @@ void rtps_stop (struct ddsi_domaingv *gv)
 
 void rtps_fini (struct ddsi_domaingv *gv)
 {
+  /* The receive threads have already been stopped, therefore
+     defragmentation and reorder state can't change anymore and
+     can be freed. */
+  nn_reorder_free (gv->spdp_reorder);
+  nn_defrag_free (gv->spdp_defrag);
+  ddsrt_mutex_destroy (&gv->spdp_lock);
+
   /* Shut down the GC system -- no new requests will be added */
   gcreq_queue_free (gv->gcreq_queue);
 

--- a/src/core/ddsi/src/q_radmin.c
+++ b/src/core/ddsi/src/q_radmin.c
@@ -1860,7 +1860,8 @@ static void delete_last_sample (struct nn_reorder *reorder)
     /* Last sample is in an interval of its own - delete it, and
        recalc max_sampleiv. */
     TRACE (reorder, "  delete_last_sample: in singleton interval\n");
-    reorder->discarded_bytes += last->sc.first->sampleinfo->size;
+    if (last->sc.first->sampleinfo)
+      reorder->discarded_bytes += last->sc.first->sampleinfo->size;
     fragchain = last->sc.first->fragchain;
     ddsrt_avl_delete (&reorder_sampleivtree_treedef, &reorder->sampleivtree, reorder->max_sampleiv);
     reorder->max_sampleiv = ddsrt_avl_find_max (&reorder_sampleivtree_treedef, &reorder->sampleivtree);
@@ -1884,10 +1885,11 @@ static void delete_last_sample (struct nn_reorder *reorder)
       pe = e;
       e = e->next;
     } while (e != last->sc.last);
-    reorder->discarded_bytes += e->sampleinfo->size;
+    if (e->sampleinfo)
+      reorder->discarded_bytes += e->sampleinfo->size;
     fragchain = e->fragchain;
     pe->next = NULL;
-    assert (pe->sampleinfo->seq + 1 < last->maxp1);
+    assert (pe->sampleinfo == NULL || pe->sampleinfo->seq + 1 < last->maxp1);
     last->sc.last = pe;
     last->maxp1--;
     last->n_samples--;

--- a/src/core/ddsi/tests/CMakeLists.txt
+++ b/src/core/ddsi/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ set(ddsi_test_sources
     "locators.c"
     "plist_generic.c"
     "plist.c"
+    "radmin.c"
     "sysdeps.c"
     "mem_ser.h")
 
@@ -23,7 +24,15 @@ if(ENABLE_SECURITY)
 endif()
 
 add_cunit_executable(cunit_ddsi ${ddsi_test_sources})
+
+# need DDSC private header files only for dds_global
 target_include_directories(
   cunit_ddsi PRIVATE
-  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../ddsi/include/>")
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../ddsc/src>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../ddsi/include>")
+if(ENABLE_SHM)
+  target_include_directories(
+    cunit_ddsi PRIVATE
+    "$<BUILD_INTERFACE:$<TARGET_PROPERTY:iceoryx_binding_c::iceoryx_binding_c,INTERFACE_INCLUDE_DIRECTORIES>>")
+endif()
 target_link_libraries(cunit_ddsi PRIVATE ddsc)

--- a/src/core/ddsi/tests/radmin.c
+++ b/src/core/ddsi/tests/radmin.c
@@ -1,0 +1,160 @@
+/*
+ * Copyright(c) 2022 ZettaScale Technology and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+#include "CUnit/Theory.h"
+
+#include "dds/features.h"
+#include "dds/ddsi/ddsi_iid.h"
+#include "dds/ddsi/ddsi_config_impl.h"
+#include "dds/ddsi/ddsi_domaingv.h"
+#include "dds/ddsi/q_radmin.h"
+#include "dds/ddsi/q_thread.h"
+#include "dds/ddsi/q_misc.h"
+
+static struct ddsi_domaingv gv;
+static struct thread_state *thrst;
+static struct nn_rbufpool *rbpool;
+
+static void null_log_sink (void *varg, const dds_log_data_t *msg)
+{
+  (void)varg; (void)msg;
+}
+
+static void setup (void)
+{
+  ddsi_iid_init ();
+  thread_states_init ();
+
+  // register the main thread, then claim it as spawned by Cyclone because the
+  // internal processing has various asserts that it isn't an application thread
+  // doing the dirty work
+  thrst = lookup_thread_state ();
+  assert (thrst->state == THREAD_STATE_LAZILY_CREATED);
+  thrst->state = THREAD_STATE_ALIVE;
+  ddsrt_atomic_stvoidp (&thrst->gv, &gv);
+
+  memset (&gv, 0, sizeof (gv));
+  ddsi_config_init_default (&gv.config);
+  gv.config.transport_selector = DDSI_TRANS_NONE;
+
+  rtps_config_prep (&gv, NULL);
+  dds_set_log_sink (null_log_sink, NULL);
+  dds_set_trace_sink (null_log_sink, NULL);
+
+  rtps_init (&gv);
+  rbpool = nn_rbufpool_new (&gv.logconfig, gv.config.rbuf_size, gv.config.rmsg_chunk_size);
+  nn_rbufpool_setowner (rbpool, ddsrt_thread_self ());
+}
+
+static void teardown (void)
+{
+  rtps_fini (&gv);
+  nn_rbufpool_free (rbpool);
+
+  // On shutdown, there is an expectation that the thread was discovered dynamically.
+  // We overrode it in the setup code, we undo it now.
+  thrst->state = THREAD_STATE_LAZILY_CREATED;
+  thread_states_fini ();
+  ddsi_iid_fini ();
+}
+
+static void insert_gap (struct nn_reorder *reorder, struct nn_rmsg *rmsg, seqno_t seq)
+{
+  struct nn_rdata *gap = nn_rdata_newgap (rmsg);
+  struct nn_rsample_chain sc;
+  int refc_adjust = 0;
+  nn_reorder_result_t res = nn_reorder_gap (&sc, reorder, gap, seq, seq + 1, &refc_adjust);
+  CU_ASSERT_FATAL (res == NN_REORDER_ACCEPT);
+  nn_fragchain_adjust_refcount (gap, refc_adjust);
+}
+
+static void check_reorder (struct nn_reorder *reorder, uint64_t ndiscard, seqno_t next_exp, seqno_t end, const seqno_t *present)
+{
+  // expect to be waiting for the right sequence number
+  CU_ASSERT_FATAL (nn_reorder_next_seq (reorder) == next_exp);
+  // expect the number of discarded bytes to match
+  uint64_t discarded_bytes;
+  nn_reorder_stats (reorder, &discarded_bytes);
+  CU_ASSERT_FATAL (discarded_bytes == ndiscard);
+  // expect the set of present sequence numbers to match
+  int i = 0, err = 0;
+  printf ("check:");
+  for (seqno_t s = next_exp; s <= end; s++)
+  {
+    if (s < present[i] || present[i] == 0) {
+      int w = nn_reorder_wantsample (reorder, s);
+      printf (" -%"PRId64"/%d", s, w);
+      if (!w) err++;
+    } else {
+      if (s == present[i])
+        i++;
+      int w = nn_reorder_wantsample (reorder, s);
+      if (w) err++;
+      printf (" +%"PRId64"/%d", s, w);
+    }
+  }
+  printf ("\n");
+  CU_ASSERT_FATAL (err == 0);
+}
+
+static void insert_sample (struct nn_defrag *defrag, struct nn_reorder *reorder, struct nn_rmsg *rmsg, struct receiver_state *rst, seqno_t seq)
+{
+  struct nn_rsample_info *si = nn_rmsg_alloc (rmsg, sizeof (*si));
+  // only "seq" and "size" really matter
+  memset (si, 0, sizeof (*si));
+  si->rst = rst;
+  si->size = 1;
+  si->seq = seq;
+  struct nn_rdata *rdata = nn_rdata_new (rmsg, 0, si->size, 0, 0, 0);
+  struct nn_rsample *rsample = nn_defrag_rsample (defrag, rdata, si);
+  CU_ASSERT_FATAL (rsample != NULL);
+  
+  struct nn_rsample_chain sc;
+  int refc_adjust = 0;
+  struct nn_rdata *fragchain = nn_rsample_fragchain (rsample);
+  nn_reorder_result_t res = nn_reorder_rsample (&sc, reorder, rsample, &refc_adjust, 0);
+  CU_ASSERT_FATAL (res == NN_REORDER_ACCEPT);
+  nn_fragchain_adjust_refcount (fragchain, refc_adjust);
+}
+
+CU_Test (ddsi_radmin, drop_gap_at_end, .init = setup, .fini = teardown)
+{
+  // not doing fragmented samples in this test, so defragmenter mode & size limits are irrelevant
+  struct nn_defrag *defrag = nn_defrag_new (&gv.logconfig, NN_DEFRAG_DROP_LATEST, 1);
+  struct nn_reorder *reorder = nn_reorder_new (&gv.logconfig, NN_REORDER_MODE_NORMAL, 3, false);
+  CU_ASSERT_FATAL (nn_reorder_next_seq (reorder) == 1);
+
+  // pretending that we get all the input as a single RTPSMessage
+  struct nn_rmsg *rmsg = nn_rmsg_new (rbpool);
+  nn_rmsg_setsize (rmsg, 0); // 0 isn't true, but it doesn't matter
+  // actual receiver state is pretty much irrelevant to the reorder buffer
+  struct receiver_state *rst = nn_rmsg_alloc (rmsg, sizeof (*rst));
+  memset (rst, 0, sizeof (*rst));
+
+  // initially, we want everything
+  check_reorder(reorder, 0, 1, 6, (const seqno_t[]){0});
+  // insert gap #5 => no longer want 5
+  insert_gap (reorder, rmsg, 5);
+  check_reorder(reorder, 0, 1, 6, (const seqno_t[]){5,0});
+  // etc. etc.
+  insert_sample (defrag, reorder, rmsg, rst, 2);
+  check_reorder(reorder, 0, 1, 6, (const seqno_t[]){2,5,0});
+  insert_sample (defrag, reorder, rmsg, rst, 3);
+  check_reorder(reorder, 0, 1, 6, (const seqno_t[]){2,3,5,0});
+  // inserting #4 pushes gap out, so suddenly we want it again
+  insert_sample (defrag, reorder, rmsg, rst, 4);
+  check_reorder(reorder, 0, 1, 6, (const seqno_t[]){2,3,4,0});
+
+  nn_rmsg_commit (rmsg);
+  nn_reorder_free (reorder);
+  nn_defrag_free (defrag);
+}


### PR DESCRIPTION
If the following arrives from a remote writer expecting sequence number K and with a reorder buffer limited to storing at most N sequence numbers:
```
  GAP #(K+N+1) ; DATA #(K+N) .. DATA #(K+1)
```
then the last message (which can't be delivered yet because it was expecting #K) will force the GAP with sequence number #(K+N+1) out. Updating the number of discarded bytes then results in a null pointer dereference because GAPs don't store sample info.

Other commits in the PR are a test case and moving some code from `rtps_stop` to `rtps_fini` where it makes more sense.