### PR TITLE
Set default symbol visibility to hidden

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -17,6 +17,8 @@ else()
   add_library(ddsc)
 endif()
 
+set_property(TARGET ddsc PROPERTY C_VISIBILITY_PRESET hidden)
+
 if("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
   target_link_libraries(ddsc PRIVATE dbghelp)
 endif()

--- a/src/core/ddsi/include/dds/ddsi/ddsi_entity.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_entity.h
@@ -120,11 +120,11 @@ struct ddsi_alive_state {
 };
 
 bool ddsi_is_null_guid (const ddsi_guid_t *guid);
-int ddsi_compare_guid (const void *va, const void *vb);
 int ddsi_is_builtin_entityid (ddsi_entityid_t id, nn_vendorid_t vendorid);
 bool ddsi_update_qos_locked (struct ddsi_entity_common *e, dds_qos_t *ent_qos, const dds_qos_t *xqos, ddsrt_wctime_t timestamp);
 int ddsi_set_topic_type_name (dds_qos_t *xqos, const char * topic_name, const char * type_name);
 
+DDS_EXPORT int ddsi_compare_guid (const void *va, const void *vb);
 DDS_EXPORT ddsi_entityid_t ddsi_to_entityid (unsigned u);
 DDS_EXPORT nn_vendorid_t ddsi_get_entity_vendorid (const struct ddsi_entity_common *e);
 DDS_EXPORT uint64_t ddsi_get_entity_instanceid (const struct ddsi_domaingv *gv, const struct ddsi_guid *guid);

--- a/src/core/ddsi/include/dds/ddsi/q_addrset.h
+++ b/src/core/ddsi/include/dds/ddsi/q_addrset.h
@@ -65,7 +65,7 @@ void addrset_any_uc_else_mc_nofail (const struct addrset *as, ddsi_xlocator_t *d
 
 /* Keeps AS locked */
 int addrset_forone (struct addrset *as, addrset_forone_fun_t f, void *arg);
-void addrset_forall (struct addrset *as, addrset_forall_fun_t f, void *arg);
+DDS_EXPORT void addrset_forall (struct addrset *as, addrset_forall_fun_t f, void *arg);
 size_t addrset_forall_count (struct addrset *as, addrset_forall_fun_t f, void *arg);
 size_t addrset_forall_uc_else_mc_count (struct addrset *as, addrset_forall_fun_t f, void *arg);
 size_t addrset_forall_mc_count (struct addrset *as, addrset_forall_fun_t f, void *arg);

--- a/src/core/ddsi/include/dds/ddsi/q_thread.h
+++ b/src/core/ddsi/include/dds/ddsi/q_thread.h
@@ -126,7 +126,14 @@ struct thread_states {
 };
 
 extern DDS_EXPORT struct thread_states thread_states;
+
+// thread_local cannot (and doesn't need to?) be exported on Windows
+#ifdef _WIN32
 extern ddsrt_thread_local struct thread_state *tsd_thread_state;
+#else
+extern DDS_EXPORT ddsrt_thread_local struct thread_state *tsd_thread_state;
+#endif
+
 
 DDS_EXPORT void thread_states_init (void);
 DDS_EXPORT bool thread_states_fini (void);


### PR DESCRIPTION
This adds the `-fvisibility=hidden` option to the GCC/Clang compile flags, so that only declarations marked with `DDS_EXPORT` are exported from the shared library. 

Note that this commit is pushed on top of the commits from PR #1372, so only commit aab6976bd508cf02a6fbb2daa20108c2e5cf4424 is relevant here. 