### PR TITLE
Fix use-after-free on providing proxy topic historical data

### DIFF
--- a/src/core/ddsc/tests/topic_discovery.c
+++ b/src/core/ddsc/tests/topic_discovery.c
@@ -69,7 +69,7 @@ CU_TheoryDataPoints(ddsc_topic_discovery, remote_topics) = {
     CU_DataPoints(bool,     false, false, false, false, false,  true,  true,  true,  true,  true, true, true), /* test live topic discovery */
 };
 
-CU_Theory ((uint32_t num_pp, uint32_t num_tp, bool hist_data, bool live_data), ddsc_topic_discovery, remote_topics, .init = topic_discovery_init, .fini = topic_discovery_fini, .timeout = 60)
+CU_Theory ((uint32_t num_pp, uint32_t num_tp, bool hist_data, bool live_data), ddsc_topic_discovery, remote_topics, .init = topic_discovery_init, .fini = topic_discovery_fini, .timeout = 180)
 {
   tprintf ("ddsc_topic_discovery.remote_topics: %u participants, %u topics,%s%s\n", num_pp, num_tp, hist_data ? " historical-data" : "", live_data ? " live-data" : "");
 
@@ -125,7 +125,7 @@ CU_Theory ((uint32_t num_pp, uint32_t num_tp, bool hist_data, bool live_data), d
   }
 
   /* read DCPSTopic and check if all topics seen */
-  dds_time_t t_exp = dds_time () + DDS_SECS (30);
+  dds_time_t t_exp = dds_time () + DDS_SECS (180);
   do
   {
     void *raw[1] = { 0 };

--- a/src/core/ddsi/include/dds/ddsi/ddsi_entity.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_entity.h
@@ -78,11 +78,6 @@ typedef struct ddsi_type_pair
 #endif
 ddsi_type_pair_t;
 
-#ifdef DDS_HAS_TOPIC_DISCOVERY
-DDSI_LIST_GENERIC_PTR_TYPES(proxy_topic_list);
-DDSI_LIST_GENERIC_PTR_DECL(extern, proxy_topic_list, struct ddsi_proxy_topic *, ddsrt_attribute_unused);
-#endif
-
 struct ddsi_entity_common {
   enum ddsi_entity_kind kind;
   ddsi_guid_t guid;
@@ -124,6 +119,7 @@ int ddsi_compare_guid (const void *va, const void *vb);
 int ddsi_is_builtin_entityid (ddsi_entityid_t id, nn_vendorid_t vendorid);
 bool ddsi_update_qos_locked (struct ddsi_entity_common *e, dds_qos_t *ent_qos, const dds_qos_t *xqos, ddsrt_wctime_t timestamp);
 int ddsi_set_topic_type_name (dds_qos_t *xqos, const char * topic_name, const char * type_name);
+int ddsi_compare_entityid (const void *a, const void *b);
 
 DDS_EXPORT ddsi_entityid_t ddsi_to_entityid (unsigned u);
 DDS_EXPORT nn_vendorid_t ddsi_get_entity_vendorid (const struct ddsi_entity_common *e);

--- a/src/core/ddsi/include/dds/ddsi/ddsi_proxy_participant.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_proxy_participant.h
@@ -20,6 +20,7 @@
 #include "dds/ddsrt/fibheap.h"
 #include "dds/ddsi/ddsi_domaingv.h"
 #include "dds/ddsi/ddsi_entity.h"
+#include "dds/ddsi/ddsi_topic.h"
 
 #if defined (__cplusplus)
 extern "C" {
@@ -47,7 +48,7 @@ struct ddsi_proxy_participant
   struct addrset *as_meta; /* default address set to use for discovery traffic */
   struct ddsi_proxy_endpoint_common *endpoints; /* all proxy endpoints can be reached from here */
 #ifdef DDS_HAS_TOPIC_DISCOVERY
-  proxy_topic_list_t topics;
+  ddsrt_avl_tree_t topics;
 #endif
   seqno_t seq; /* sequence number of most recent SPDP message */
   uint32_t receive_buffer_size; /* assumed size of receive buffer, used to limit bursts involving this proxypp */
@@ -64,6 +65,10 @@ struct ddsi_proxy_participant
   struct ddsi_proxy_participant_sec_attributes *sec_attr;
 #endif
 };
+
+#ifdef DDS_HAS_TOPIC_DISCOVERY
+extern const ddsrt_avl_treedef_t ddsi_proxypp_proxytp_treedef;
+#endif
 
 /* Set when this proxy participant is created implicitly and has to be deleted upon disappearance
    of its last endpoint.  FIXME: Currently there is a potential race with adding a new endpoint

--- a/src/core/ddsi/include/dds/ddsi/ddsi_topic.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_topic.h
@@ -50,6 +50,7 @@ struct ddsi_proxy_topic
   struct ddsi_topic_definition *definition; /* ref to (shared) topic definition */
   ddsrt_wctime_t tupdate; /* timestamp of last update */
   seqno_t seq; /* sequence number of most recent SEDP message */
+  ddsrt_avl_node_t avlnode; /* entry in proxypp->topics */
   unsigned deleted: 1;
 };
 

--- a/src/core/ddsi/include/dds/ddsi/q_whc.h
+++ b/src/core/ddsi/include/dds/ddsi/q_whc.h
@@ -45,7 +45,7 @@ struct whc_state {
    an iter on the stack without specifying an implementation. If future changes or
    implementations require more, these can be adjusted.  An implementation should check
    things fit at compile time. */
-#define WHC_SAMPLE_ITER_SIZE (7 * sizeof(void *))
+#define WHC_SAMPLE_ITER_SIZE (8 * sizeof(void *))
 struct whc_sample_iter_base {
   struct whc *whc;
 };

--- a/src/core/ddsi/include/dds/ddsi/q_whc.h
+++ b/src/core/ddsi/include/dds/ddsi/q_whc.h
@@ -45,7 +45,7 @@ struct whc_state {
    an iter on the stack without specifying an implementation. If future changes or
    implementations require more, these can be adjusted.  An implementation should check
    things fit at compile time. */
-#define WHC_SAMPLE_ITER_SIZE (9 * sizeof(void *))
+#define WHC_SAMPLE_ITER_SIZE (7 * sizeof(void *))
 struct whc_sample_iter_base {
   struct whc *whc;
 };

--- a/src/core/ddsi/src/ddsi_entity.c
+++ b/src/core/ddsi/src/ddsi_entity.c
@@ -42,7 +42,8 @@ int ddsi_compare_guid (const void *va, const void *vb)
 
 int ddsi_compare_entityid (const void *va, const void *vb)
 {
-  return memcmp (va, vb, sizeof (ddsi_entityid_t));
+  const ddsi_entityid_t *a = va, *b = vb;
+  return (a->u == b->u) ? 0 : ((a->u < b->u) ? -1 : 1);
 }
 
 bool ddsi_is_null_guid (const ddsi_guid_t *guid)

--- a/src/core/ddsi/src/ddsi_entity.c
+++ b/src/core/ddsi/src/ddsi_entity.c
@@ -40,6 +40,11 @@ int ddsi_compare_guid (const void *va, const void *vb)
   return memcmp (va, vb, sizeof (ddsi_guid_t));
 }
 
+int ddsi_compare_entityid (const void *va, const void *vb)
+{
+  return memcmp (va, vb, sizeof (ddsi_entityid_t));
+}
+
 bool ddsi_is_null_guid (const ddsi_guid_t *guid)
 {
   return guid->prefix.u[0] == 0 && guid->prefix.u[1] == 0 && guid->prefix.u[2] == 0 && guid->entityid.u == 0;


### PR DESCRIPTION
This fixes issue #1356, a race condition between iterating proxy topics for providing historical data and (gc) deletion of proxy topics. This commit replaces the linked-list implementation for storing proxy topics in proxy participants by an AVL storage, and by looking up the next proxy topic by entityid instead of keeping a pointer to the previous proxy topic, the lookup is also safe in case proxy topics are deleted from the tree during the iteration.

Commit 55c04a7508244949db6798eae50d01b0470c6069 increases the time-out for a specific topic discovery test. By debugging a recorded session for this test, the cause for the time-out appeared to be that under high load (other tests running in parallel) that causes high packet loss, the ack-nacks and heartbeats for the built-in topic reader/writer are not received in time and the cause the test to fail. 