### PR TITLE
Fix idlc typedef for scoped name

### DIFF
--- a/src/idl/src/scope.c
+++ b/src/idl/src/scope.c
@@ -198,6 +198,8 @@ idl_declare(
              its first occurrence in a scope */
           if (kind == IDL_MODULE_DECLARATION)
             goto exists;
+          if (kind == IDL_USE_DECLARATION)
+            goto exists;
           goto clash;
         case IDL_FORWARD_DECLARATION:
           /* instance declarations cannot occur in the same scope */

--- a/src/idl/tests/typedef.c
+++ b/src/idl/tests/typedef.c
@@ -330,3 +330,24 @@ CU_Test(idl_typedef, constructed_type)
     idl_delete_pstate(pstate);
   }
 }
+
+CU_Test(idl_typedef, scoped_name)
+{
+  static const struct {
+    idl_retcode_t retcode;
+    const char *idl;
+  } tests[] = {
+    { IDL_RETCODE_OK, "module m1 { struct a { long f1; }; }; typedef m1::a b;" },
+    { IDL_RETCODE_OK, "module m1 { module m2 { struct a { long f1; }; }; }; typedef m1::m2::a b;" },
+    { IDL_RETCODE_OK, "module m1 { module m2 { struct a { long f1; }; }; typedef m2::a b; };" },
+  };
+
+  for (size_t i = 0; i < sizeof(tests)/sizeof(tests[0]); i++) {
+    idl_retcode_t ret;
+    idl_pstate_t *pstate = NULL;
+    printf("test idl: %s\n", tests[i].idl);
+    ret = parse_string(tests[i].idl, &pstate);
+    CU_ASSERT_EQUAL_FATAL(ret, tests[i].retcode);
+    idl_delete_pstate(pstate);
+  }
+}


### PR DESCRIPTION
This fixes a bug in IDLC that causes the compilation to fail when the IDL contains a typedef with a scoped name as type definition:

```idl
module m1 {
  struct s1 { long a; };
};
typedef m1::s1 m2;
```
