### PR TITLE
Fixes for FreeRTOS build and build directory with whitespace

### DIFF
--- a/src/core/ddsi/src/ddsi_cdrstream.c
+++ b/src/core/ddsi/src/ddsi_cdrstream.c
@@ -4064,7 +4064,7 @@ static const uint32_t *prtf_delimited (char * __restrict *buf, size_t *bufsize, 
 {
   uint32_t delimited_sz = dds_is_get4 (is), delimited_offs = is->m_index, insn;
   bool needs_comma = false;
-  if (!prtf (buf, bufsize, "dlh:%u", delimited_sz))
+  if (!prtf (buf, bufsize, "dlh:%"PRIu32, delimited_sz))
     return NULL;
   ops++;
   while ((insn = *ops) != DDS_OP_RTS)
@@ -4128,7 +4128,7 @@ static const uint32_t *prtf_pl (char * __restrict *buf, size_t *bufsize, dds_ist
   ops++;
 
   uint32_t pl_sz = dds_is_get4 (is), pl_offs = is->m_index;
-  if (!prtf (buf, bufsize, "pl:%u", pl_sz))
+  if (!prtf (buf, bufsize, "pl:%"PRIu32, pl_sz))
     return NULL;
 
   while (is->m_index - pl_offs < pl_sz)
@@ -4136,7 +4136,7 @@ static const uint32_t *prtf_pl (char * __restrict *buf, size_t *bufsize, dds_ist
     /* read emheader and next_int */
     uint32_t em_hdr = dds_is_get4 (is);
     uint32_t lc = EMHEADER_LENGTH_CODE (em_hdr), m_id = EMHEADER_MEMBERID (em_hdr), msz;
-    if (!prtf (buf, bufsize, ",lc:%u,m:%u,", lc, m_id))
+    if (!prtf (buf, bufsize, ",lc:%"PRIu32",m:%"PRIu32",", lc, m_id))
       return NULL;
     switch (lc)
     {

--- a/src/core/ddsi/src/ddsi_topic.c
+++ b/src/core/ddsi/src/ddsi_topic.c
@@ -483,7 +483,7 @@ void ddsi_update_proxy_topic (struct ddsi_proxy_participant *proxypp, struct dds
   proxytp->seq = seq;
   proxytp->tupdate = timestamp;
   uint64_t mask = ddsi_xqos_delta (tpd0->xqos, xqos, QP_CHANGEABLE_MASK & ~(QP_RXO_MASK | QP_PARTITION)) & xqos->present;
-  GVLOGDISC ("ddsi_update_proxy_topic %x delta=%"PRIu64" QOS={", proxytp->entityid.u, mask);
+  GVLOGDISC ("ddsi_update_proxy_topic %"PRIx32" delta=%"PRIu64" QOS={", proxytp->entityid.u, mask);
   ddsi_xqos_log (DDS_LC_DISCOVERY, &gv->logconfig, xqos);
   GVLOGDISC ("}\n");
   if (mask == 0)

--- a/src/core/ddsi/src/ddsi_typewrap.c
+++ b/src/core/ddsi/src/ddsi_typewrap.c
@@ -879,7 +879,7 @@ static dds_return_t xt_validate_impl (struct ddsi_domaingv *gv, const struct xt_
         {
           if (has_default)
           {
-            GVTRACE ("multiple default flags in union members (index %u)\n", n);
+            GVTRACE ("multiple default flags in union members (index %"PRIu32")\n", n);
             return DDS_RETCODE_BAD_PARAMETER;
           }
           has_default = true;

--- a/src/core/xtests/symbol_export/symbol_export.c
+++ b/src/core/xtests/symbol_export/symbol_export.c
@@ -35,8 +35,10 @@
 #include "dds/ddsrt/string.h"
 #include "dds/ddsrt/strtol.h"
 #include "dds/ddsrt/xmlparser.h"
-#include "dds/ddsrt/filesystem.h"
 #include "dds/ddsrt/io.h"
+#if DDSRT_HAVE_FILESYSTEM
+#include "dds/ddsrt/filesystem.h"
+#endif
 #if DDSRT_HAVE_NETSTAT
 #include "dds/ddsrt/netstat.h"
 #endif
@@ -975,6 +977,7 @@ int main (int argc, char **argv)
   ddsrt_xmlp_free (ptr);
   ddsrt_xmlp_parse (ptr);
 
+#if DDSRT_HAVE_FILESYSTEM
   // ddsrt/filesystem.h
   ddsrt_opendir (ptr, ptr);
   ddsrt_closedir (ptr);
@@ -982,6 +985,7 @@ int main (int argc, char **argv)
   ddsrt_stat (ptr, ptr);
   ddsrt_file_normalize (ptr);
   ddsrt_file_sep ();
+#endif
 
   // ddsrt/io.h
   test_ddsrt_vasprintf (ptr, " ");

--- a/src/idl/CMakeLists.txt
+++ b/src/idl/CMakeLists.txt
@@ -128,13 +128,13 @@ foreach(source ${templates})
   set(output "${binary_dir}/${source}")
   # process source file. i.e. replace dds and ddsrt with idl
   add_custom_command(
-    OUTPUT "${output}"
+    OUTPUT ${output}
     COMMAND "${CMAKE_COMMAND}" -DNAMESPACE=idl
-                               -DINPUT_FILE="${input}"
-                               -DOUTPUT_DIRECTORY="${binary_dir}"
-                               -DOUTPUT_FILE="${output}"
-                               -P "${script}"
-    DEPENDS "${input}" "${script}")
+                               -DINPUT_FILE=${input}
+                               -DOUTPUT_DIRECTORY=${binary_dir}
+                               -DOUTPUT_FILE=${output}
+                               -P ${script}
+    DEPENDS ${input} ${script})
   if(source MATCHES "^include/.*\\.h")
     list(APPEND headers ${output})
   else()

--- a/src/tools/idlc/src/descriptor.c
+++ b/src/tools/idlc/src/descriptor.c
@@ -1560,7 +1560,7 @@ emit_declarator(
       if ((ret = stash_bitmask_bits(pstate, &ctype->instructions, nop, (const idl_bitmask_t *)(type_spec))))
         return ret;
     } else if (idl_is_struct(type_spec) || idl_is_union(type_spec)) {
-      if ((ret = stash_element_offset(pstate, &ctype->instructions, nop, type_spec, 3 + (has_size ? 1 : 0), addr_offs)))
+      if ((ret = stash_element_offset(pstate, &ctype->instructions, nop, type_spec, (uint16_t) 3 + (has_size ? 1 : 0), addr_offs)))
         return ret;
     }
     /* generate data field element size */


### PR DESCRIPTION
This fixes a few issues and warnings in the FreeRTOS builds, and fixes an issue when using a source or build path that has whitespace in a directory name. 