### PR TITLE
Remove some unused parameter lists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,7 @@ if("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang" OR
              "-Wconditional-uninitialized"
              "-Wshadow")
   add_compile_options(${wflags})
+  add_link_options(-undefined error)
   if(${WERROR})
     add_compile_options(-Werror)
   endif()

--- a/src/core/ddsc/include/dds/dds.h
+++ b/src/core/ddsc/include/dds/dds.h
@@ -1339,7 +1339,7 @@ dds_create_topic(
  * @param[in,out] sertype      Internal description of the type . On return, the sertype parameter is set to the actual sertype that is used by the topic.
  * @param[in]     qos          QoS to set on the new topic (can be NULL).
  * @param[in]     listener     Any listener functions associated with the new topic (can be NULL).
- * @param[in]     sedp_plist   Topic description to be published as part of discovery (if NULL, not published).
+ * @param[in]     sedp_plist   Ignored (should be NULL, may be enforced in the future).
  *
  * @returns A valid, unique topic handle or an error code. Iff a valid handle, the domain takes ownership of provided serdata.
  *

--- a/src/core/ddsc/src/dds__topic.h
+++ b/src/core/ddsc/src/dds__topic.h
@@ -43,7 +43,6 @@ dds_entity_t dds_create_topic_impl (
     struct ddsi_sertype **sertype,
     const dds_qos_t *qos,
     const dds_listener_t *listener,
-    const ddsi_plist_t *sedp_plist,
     bool is_builtin);
 
 #if defined (__cplusplus)

--- a/src/core/ddsc/src/dds_builtin.c
+++ b/src/core/ddsc/src/dds_builtin.c
@@ -142,7 +142,7 @@ dds_entity_t dds__get_builtin_topic (dds_entity_t entity, dds_entity_t topic)
   }
 
   dds_qos_t *qos = dds__create_builtin_qos ();
-  if ((tp = dds_create_topic_impl (par->m_entity.m_hdllink.hdl, topic_name, true, &sertype, qos, NULL, NULL, true)) > 0)
+  if ((tp = dds_create_topic_impl (par->m_entity.m_hdllink.hdl, topic_name, true, &sertype, qos, NULL, true)) > 0)
   {
     /* keep ownership for built-in sertypes because there are re-used, lifetime for these
        sertypes is bound to domain */

--- a/src/core/ddsc/src/dds_whc_builtintopic.c
+++ b/src/core/ddsc/src/dds_whc_builtintopic.c
@@ -238,7 +238,7 @@ static void bwhc_get_state (const struct whc *whc, struct whc_state *st)
   st->unacked_bytes = 0;
 }
 
-static int bwhc_insert (struct whc *whc, seqno_t max_drop_seq, seqno_t seq, ddsrt_mtime_t exp, struct ddsi_plist *plist, struct ddsi_serdata *serdata, struct ddsi_tkmap_instance *tk)
+static int bwhc_insert (struct whc *whc, seqno_t max_drop_seq, seqno_t seq, ddsrt_mtime_t exp, struct ddsi_serdata *serdata, struct ddsi_tkmap_instance *tk)
 {
   (void)whc;
   (void)max_drop_seq;
@@ -246,8 +246,6 @@ static int bwhc_insert (struct whc *whc, seqno_t max_drop_seq, seqno_t seq, ddsr
   (void)exp;
   (void)serdata;
   (void)tk;
-  if (plist)
-    ddsrt_free (plist);
   return 0;
 }
 

--- a/src/core/ddsi/include/dds/ddsi/ddsi_endpoint.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_endpoint.h
@@ -68,7 +68,6 @@ struct ddsi_writer
   void * status_cb_entity;
   ddsrt_cond_t throttle_cond; /* used to trigger a transmit thread blocked in throttle_writer() or wait_for_acks() */
   seqno_t seq; /* last sequence number (transmitted seqs are 1 ... seq, 0 when nothing published yet) */
-  seqno_t cs_seq; /* 1st seq in coherent set (or 0) */
   seq_xmit_t seq_xmit; /* last sequence number actually transmitted */
   seqno_t min_local_readers_reject_seq; /* mimum of local_readers->last_deliv_seq */
   nn_count_t hbcount; /* last hb seq number */

--- a/src/core/ddsi/include/dds/ddsi/ddsi_plist.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_plist.h
@@ -50,7 +50,7 @@ extern "C" {
 #define PP_ENDPOINT_GUID                        ((uint64_t)1 << 24)
 #define PP_ADLINK_PARTICIPANT_VERSION_INFO      ((uint64_t)1 << 26)
 #define PP_ADLINK_TYPE_DESCRIPTION              ((uint64_t)1 << 27)
-#define PP_COHERENT_SET                         ((uint64_t)1 << 28)
+// ((uint64_t)1 << 28) is available
 #ifdef DDS_HAS_SSM
 #define PP_READER_FAVOURS_SSM                   ((uint64_t)1 << 29)
 #endif
@@ -220,7 +220,6 @@ typedef struct ddsi_plist {
   uint32_t statusinfo;
   nn_adlink_participant_version_info_t adlink_participant_version_info;
   char *type_description;
-  nn_sequence_number_t coherent_set_seqno;
 #ifdef DDS_HAS_SECURITY
   nn_token_t identity_token;
   nn_token_t permissions_token;

--- a/src/core/ddsi/include/dds/ddsi/ddsi_plist.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_plist.h
@@ -219,7 +219,6 @@ typedef struct ddsi_plist {
   ddsi_keyhash_t keyhash;
   uint32_t statusinfo;
   nn_adlink_participant_version_info_t adlink_participant_version_info;
-  char *type_description;
 #ifdef DDS_HAS_SECURITY
   nn_token_t identity_token;
   nn_token_t permissions_token;

--- a/src/core/ddsi/include/dds/ddsi/ddsi_xqos.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_xqos.h
@@ -200,11 +200,6 @@ typedef struct dds_external_reader_data_lifecycle_qospolicy {
   ddsi_duration_t autopurge_disposed_samples_delay;
 } dds_external_reader_data_lifecycle_qospolicy_t;
 
-typedef struct dds_subscription_keys_qospolicy {
-  unsigned char use_key_list;
-  ddsi_stringseq_t key_list;
-} dds_subscription_keys_qospolicy_t;
-
 typedef struct dds_reader_lifespan_qospolicy {
   unsigned char use_lifespan;
   dds_duration_t duration;
@@ -267,7 +262,7 @@ typedef struct dds_data_representation_qospolicy {
 #define QP_ADLINK_WRITER_DATA_LIFECYCLE      ((uint64_t)1 << 21)
 #define QP_ADLINK_READER_DATA_LIFECYCLE      ((uint64_t)1 << 22)
 #define QP_ADLINK_READER_LIFESPAN            ((uint64_t)1 << 24)
-#define QP_ADLINK_SUBSCRIPTION_KEYS          ((uint64_t)1 << 25)
+//available: ((uint64_t)1 << 25)
 #define QP_ADLINK_ENTITY_FACTORY             ((uint64_t)1 << 27)
 #define QP_CYCLONE_IGNORELOCAL               ((uint64_t)1 << 30)
 #define QP_PROPERTY_LIST                     ((uint64_t)1 << 31)
@@ -329,7 +324,6 @@ struct dds_qos {
   /*xxxR*/dds_time_based_filter_qospolicy_t time_based_filter;
   /*x  W*/dds_writer_data_lifecycle_qospolicy_t writer_data_lifecycle;
   /*x xR*/dds_reader_data_lifecycle_qospolicy_t reader_data_lifecycle;
-  /*x xR*/dds_subscription_keys_qospolicy_t subscription_keys;
   /*x xR*/dds_reader_lifespan_qospolicy_t reader_lifespan;
   /* x  */dds_ignorelocal_qospolicy_t ignorelocal;
   /*xxx */dds_property_qospolicy_t property;

--- a/src/core/ddsi/include/dds/ddsi/q_transmit.h
+++ b/src/core/ddsi/include/dds/ddsi/q_transmit.h
@@ -40,12 +40,12 @@ int write_sample_gc_notk (struct thread_state * const thrst, struct nn_xpack *xp
 int write_sample_nogc_notk (struct thread_state * const thrst, struct nn_xpack *xp, struct ddsi_writer *wr, struct ddsi_serdata *serdata);
 
 /* When calling the following functions, wr->lock must be held */
-dds_return_t create_fragment_message (struct ddsi_writer *wr, seqno_t seq, const struct ddsi_plist *plist, struct ddsi_serdata *serdata, uint32_t fragnum, uint16_t nfrags, struct ddsi_proxy_reader *prd,struct nn_xmsg **msg, int isnew, uint32_t advertised_fragnum);
-int enqueue_sample_wrlock_held (struct ddsi_writer *wr, seqno_t seq, const struct ddsi_plist *plist, struct ddsi_serdata *serdata, struct ddsi_proxy_reader *prd, int isnew);
+dds_return_t create_fragment_message (struct ddsi_writer *wr, seqno_t seq, struct ddsi_serdata *serdata, uint32_t fragnum, uint16_t nfrags, struct ddsi_proxy_reader *prd,struct nn_xmsg **msg, int isnew, uint32_t advertised_fragnum);
+int enqueue_sample_wrlock_held (struct ddsi_writer *wr, seqno_t seq, struct ddsi_serdata *serdata, struct ddsi_proxy_reader *prd, int isnew);
 void enqueue_spdp_sample_wrlock_held (struct ddsi_writer *wr, seqno_t seq, struct ddsi_serdata *serdata, struct ddsi_proxy_reader *prd);
 void add_Heartbeat (struct nn_xmsg *msg, struct ddsi_writer *wr, const struct whc_state *whcst, int hbansreq, int hbliveliness, ddsi_entityid_t dst, int issync);
 dds_return_t write_hb_liveliness (struct ddsi_domaingv * const gv, struct ddsi_guid *wr_guid, struct nn_xpack *xp);
-int write_sample_p2p_wrlock_held(struct ddsi_writer *wr, seqno_t seq, struct ddsi_plist *plist, struct ddsi_serdata *serdata, struct ddsi_tkmap_instance *tk, struct ddsi_proxy_reader *prd);
+int write_sample_p2p_wrlock_held(struct ddsi_writer *wr, seqno_t seq, struct ddsi_serdata *serdata, struct ddsi_tkmap_instance *tk, struct ddsi_proxy_reader *prd);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsi/include/dds/ddsi/q_whc.h
+++ b/src/core/ddsi/include/dds/ddsi/q_whc.h
@@ -28,7 +28,6 @@ struct whc;
 struct whc_borrowed_sample {
   seqno_t seq;
   struct ddsi_serdata *serdata;
-  struct ddsi_plist *plist;
   bool unacked;
   ddsrt_mtime_t last_rexmit_ts;
   unsigned rexmit_count;
@@ -73,7 +72,7 @@ typedef void (*whc_free_t)(struct whc *whc);
    reliable readers that have not acknowledged all data */
 /* max_drop_seq must go soon, it's way too ugly. */
 /* plist may be NULL or ddsrt_malloc'd, WHC takes ownership of plist */
-typedef int (*whc_insert_t)(struct whc *whc, seqno_t max_drop_seq, seqno_t seq, ddsrt_mtime_t exp, struct ddsi_plist *plist, struct ddsi_serdata *serdata, struct ddsi_tkmap_instance *tk);
+typedef int (*whc_insert_t)(struct whc *whc, seqno_t max_drop_seq, seqno_t seq, ddsrt_mtime_t exp, struct ddsi_serdata *serdata, struct ddsi_tkmap_instance *tk);
 typedef uint32_t (*whc_downgrade_to_volatile_t)(struct whc *whc, struct whc_state *st);
 typedef uint32_t (*whc_remove_acked_messages_t)(struct whc *whc, seqno_t max_drop_seq, struct whc_state *whcst, struct whc_node **deferred_free_list);
 typedef void (*whc_free_deferred_free_list_t)(struct whc *whc, struct whc_node *deferred_free_list);
@@ -121,8 +120,8 @@ inline bool whc_sample_iter_borrow_next (struct whc_sample_iter *it, struct whc_
 inline void whc_free (struct whc *whc) {
   whc->ops->free (whc);
 }
-inline int whc_insert (struct whc *whc, seqno_t max_drop_seq, seqno_t seq, ddsrt_mtime_t exp, struct ddsi_plist *plist, struct ddsi_serdata *serdata, struct ddsi_tkmap_instance *tk) {
-  return whc->ops->insert (whc, max_drop_seq, seq, exp, plist, serdata, tk);
+inline int whc_insert (struct whc *whc, seqno_t max_drop_seq, seqno_t seq, ddsrt_mtime_t exp, struct ddsi_serdata *serdata, struct ddsi_tkmap_instance *tk) {
+  return whc->ops->insert (whc, max_drop_seq, seq, exp, serdata, tk);
 }
 inline unsigned whc_downgrade_to_volatile (struct whc *whc, struct whc_state *st) {
   return whc->ops->downgrade_to_volatile (whc, st);

--- a/src/core/ddsi/src/ddsi_endpoint.c
+++ b/src/core/ddsi/src/ddsi_endpoint.c
@@ -719,7 +719,6 @@ static void ddsi_new_writer_guid_common_init (struct ddsi_writer *wr, const char
 {
   ddsrt_cond_init (&wr->throttle_cond);
   wr->seq = 0;
-  wr->cs_seq = 0;
   ddsrt_atomic_st64 (&wr->seq_xmit, (uint64_t) 0);
   wr->hbcount = 1;
   wr->state = WRST_OPERATIONAL;

--- a/src/core/ddsi/src/ddsi_plist.c
+++ b/src/core/ddsi/src/ddsi_plist.c
@@ -1995,7 +1995,6 @@ static const struct piddesc piddesc_eclipse[] = {
   PP  (CYCLONE_TOPIC_GUID,               topic_guid, XG),
 #endif
   PP  (ADLINK_PARTICIPANT_VERSION_INFO,  adlink_participant_version_info, Xux5, XS),
-  PP  (ADLINK_TYPE_DESCRIPTION,          type_description, XS),
   PP  (CYCLONE_RECEIVE_BUFFER_SIZE,      cyclone_receive_buffer_size, Xu),
   PP  (CYCLONE_REQUESTS_KEYHASH,         cyclone_requests_keyhash, Xb),
   PP  (CYCLONE_REDUNDANT_NETWORKING,     cyclone_redundant_networking, Xb),
@@ -2010,7 +2009,6 @@ static const struct piddesc piddesc_adlink[] = {
   QP  (ADLINK_READER_DATA_LIFECYCLE,     reader_data_lifecycle, XDx2),
   QP  (ADLINK_SUBSCRIPTION_KEYS,         subscription_keys, XbCOND, XQ, XS, XSTOP),
   PP  (ADLINK_PARTICIPANT_VERSION_INFO,  adlink_participant_version_info, Xux5, XS),
-  PP  (ADLINK_TYPE_DESCRIPTION,          type_description, XS),
   { PID_SENTINEL, 0, 0, NULL, 0, 0, { .desc = { XSTOP } }, 0 }
 };
 
@@ -2074,7 +2072,7 @@ struct piddesc_index {
 
 static const struct piddesc *piddesc_omg_index[DEFAULT_OMG_PIDS_ARRAY_SIZE + SECURITY_OMG_PIDS_ARRAY_SIZE];
 static const struct piddesc *piddesc_eclipse_index[30];
-static const struct piddesc *piddesc_adlink_index[19];
+static const struct piddesc *piddesc_adlink_index[17];
 
 #define INDEX_ANY(vendorid_, tab_) [vendorid_] = { \
     .index_max = sizeof (piddesc_##tab_##_index) / sizeof (piddesc_##tab_##_index[0]) - 1, \
@@ -2099,11 +2097,11 @@ static const struct piddesc_index piddesc_vendor_index[] = {
    initialized by ddsi_plist_init_tables; will assert when
    table too small or too large */
 #ifdef DDS_HAS_TYPE_DISCOVERY
-static const struct piddesc *piddesc_unalias[20 + SECURITY_PROC_ARRAY_SIZE];
-static const struct piddesc *piddesc_fini[20 + SECURITY_PROC_ARRAY_SIZE];
-#else
 static const struct piddesc *piddesc_unalias[19 + SECURITY_PROC_ARRAY_SIZE];
 static const struct piddesc *piddesc_fini[19 + SECURITY_PROC_ARRAY_SIZE];
+#else
+static const struct piddesc *piddesc_unalias[18 + SECURITY_PROC_ARRAY_SIZE];
+static const struct piddesc *piddesc_fini[18 + SECURITY_PROC_ARRAY_SIZE];
 #endif
 static uint64_t plist_fini_mask, qos_fini_mask;
 static ddsrt_once_t table_init_control = DDSRT_ONCE_INIT;

--- a/src/core/ddsi/src/ddsi_plist.c
+++ b/src/core/ddsi/src/ddsi_plist.c
@@ -1984,7 +1984,6 @@ static const struct piddesc piddesc_eclipse[] = {
   QP  (ADLINK_READER_LIFESPAN,           reader_lifespan, Xb, XD),
   QP  (ADLINK_WRITER_DATA_LIFECYCLE,     writer_data_lifecycle, Xb),
   QP  (ADLINK_READER_DATA_LIFECYCLE,     reader_data_lifecycle, XDx2),
-  QP  (ADLINK_SUBSCRIPTION_KEYS,         subscription_keys, XbCOND, XQ, XS, XSTOP),
   { PID_PAD, PDF_QOS, QP_CYCLONE_IGNORELOCAL, "CYCLONE_IGNORELOCAL",
     offsetof (struct ddsi_plist, qos.ignorelocal), membersize (struct ddsi_plist, qos.ignorelocal),
     { .desc = { XE2, XSTOP } }, 0 },
@@ -2007,7 +2006,6 @@ static const struct piddesc piddesc_adlink[] = {
   QP  (ADLINK_READER_LIFESPAN,           reader_lifespan, Xb, XD),
   QP  (ADLINK_WRITER_DATA_LIFECYCLE,     writer_data_lifecycle, Xb),
   QP  (ADLINK_READER_DATA_LIFECYCLE,     reader_data_lifecycle, XDx2),
-  QP  (ADLINK_SUBSCRIPTION_KEYS,         subscription_keys, XbCOND, XQ, XS, XSTOP),
   PP  (ADLINK_PARTICIPANT_VERSION_INFO,  adlink_participant_version_info, Xux5, XS),
   { PID_SENTINEL, 0, 0, NULL, 0, 0, { .desc = { XSTOP } }, 0 }
 };
@@ -2097,11 +2095,11 @@ static const struct piddesc_index piddesc_vendor_index[] = {
    initialized by ddsi_plist_init_tables; will assert when
    table too small or too large */
 #ifdef DDS_HAS_TYPE_DISCOVERY
-static const struct piddesc *piddesc_unalias[19 + SECURITY_PROC_ARRAY_SIZE];
-static const struct piddesc *piddesc_fini[19 + SECURITY_PROC_ARRAY_SIZE];
-#else
 static const struct piddesc *piddesc_unalias[18 + SECURITY_PROC_ARRAY_SIZE];
 static const struct piddesc *piddesc_fini[18 + SECURITY_PROC_ARRAY_SIZE];
+#else
+static const struct piddesc *piddesc_unalias[17 + SECURITY_PROC_ARRAY_SIZE];
+static const struct piddesc *piddesc_fini[17 + SECURITY_PROC_ARRAY_SIZE];
 #endif
 static uint64_t plist_fini_mask, qos_fini_mask;
 static ddsrt_once_t table_init_control = DDSRT_ONCE_INIT;
@@ -3435,7 +3433,7 @@ const ddsi_plist_t ddsi_default_plist_participant = {
 };
 
 const dds_qos_t ddsi_default_qos_reader = {
-  .present = QP_PRESENTATION | QP_DURABILITY | QP_DEADLINE | QP_LATENCY_BUDGET | QP_LIVELINESS | QP_DESTINATION_ORDER | QP_HISTORY | QP_RESOURCE_LIMITS | QP_TRANSPORT_PRIORITY | QP_OWNERSHIP | QP_CYCLONE_IGNORELOCAL | QP_TOPIC_DATA | QP_GROUP_DATA | QP_USER_DATA | QP_PARTITION | QP_RELIABILITY | QP_TIME_BASED_FILTER | QP_ADLINK_READER_DATA_LIFECYCLE | QP_ADLINK_READER_LIFESPAN | QP_ADLINK_SUBSCRIPTION_KEYS | QP_TYPE_CONSISTENCY_ENFORCEMENT | QP_LOCATOR_MASK | QP_DATA_REPRESENTATION,
+  .present = QP_PRESENTATION | QP_DURABILITY | QP_DEADLINE | QP_LATENCY_BUDGET | QP_LIVELINESS | QP_DESTINATION_ORDER | QP_HISTORY | QP_RESOURCE_LIMITS | QP_TRANSPORT_PRIORITY | QP_OWNERSHIP | QP_CYCLONE_IGNORELOCAL | QP_TOPIC_DATA | QP_GROUP_DATA | QP_USER_DATA | QP_PARTITION | QP_RELIABILITY | QP_TIME_BASED_FILTER | QP_ADLINK_READER_DATA_LIFECYCLE | QP_ADLINK_READER_LIFESPAN | QP_TYPE_CONSISTENCY_ENFORCEMENT | QP_LOCATOR_MASK | QP_DATA_REPRESENTATION,
   .aliased = QP_DATA_REPRESENTATION,
   .presentation.access_scope = DDS_PRESENTATION_INSTANCE,
   .presentation.coherent_access = 0,
@@ -3468,9 +3466,6 @@ const dds_qos_t ddsi_default_qos_reader = {
   .reader_data_lifecycle.autopurge_disposed_samples_delay = DDS_INFINITY,
   .reader_lifespan.use_lifespan = 0,
   .reader_lifespan.duration = DDS_INFINITY,
-  .subscription_keys.use_key_list = 0,
-  .subscription_keys.key_list.n = 0,
-  .subscription_keys.key_list.strs = NULL,
   .type_consistency.kind = DDS_TYPE_CONSISTENCY_ALLOW_TYPE_COERCION,
   .type_consistency.ignore_sequence_bounds = true,
   .type_consistency.ignore_string_bounds = true,
@@ -3527,7 +3522,7 @@ const dds_qos_t ddsi_default_qos_writer = {
 };
 
 const dds_qos_t ddsi_default_qos_topic = {
-  .present = QP_PRESENTATION | QP_DURABILITY | QP_DEADLINE | QP_LATENCY_BUDGET | QP_LIVELINESS | QP_DESTINATION_ORDER | QP_HISTORY | QP_RESOURCE_LIMITS | QP_TRANSPORT_PRIORITY | QP_OWNERSHIP | QP_CYCLONE_IGNORELOCAL | QP_DURABILITY_SERVICE | QP_RELIABILITY | QP_ADLINK_SUBSCRIPTION_KEYS | QP_LIFESPAN | QP_DATA_REPRESENTATION,
+  .present = QP_PRESENTATION | QP_DURABILITY | QP_DEADLINE | QP_LATENCY_BUDGET | QP_LIVELINESS | QP_DESTINATION_ORDER | QP_HISTORY | QP_RESOURCE_LIMITS | QP_TRANSPORT_PRIORITY | QP_OWNERSHIP | QP_CYCLONE_IGNORELOCAL | QP_DURABILITY_SERVICE | QP_RELIABILITY | QP_LIFESPAN | QP_DATA_REPRESENTATION,
   .aliased = QP_DATA_REPRESENTATION,
   .presentation.access_scope = DDS_PRESENTATION_INSTANCE,
   .presentation.coherent_access = 0,
@@ -3554,9 +3549,6 @@ const dds_qos_t ddsi_default_qos_topic = {
   .durability_service.resource_limits.max_samples = DDS_LENGTH_UNLIMITED,
   .durability_service.resource_limits.max_instances = DDS_LENGTH_UNLIMITED,
   .durability_service.resource_limits.max_samples_per_instance = DDS_LENGTH_UNLIMITED,
-  .subscription_keys.use_key_list = 0,
-  .subscription_keys.key_list.n = 0,
-  .subscription_keys.key_list.strs = NULL,
   .lifespan.duration = DDS_INFINITY,
   .data_representation.value.n = 1,
   .data_representation.value.ids = (dds_data_representation_id_t []) { DDS_DATA_REPRESENTATION_XCDR1 }

--- a/src/core/ddsi/src/ddsi_security_exchange.c
+++ b/src/core/ddsi/src/ddsi_security_exchange.c
@@ -68,7 +68,7 @@ bool write_auth_handshake_message(const struct ddsi_participant *pp, const struc
 
   serdata = ddsi_serdata_from_sample (wr->type, SDK_DATA, &pmg);
   serdata->timestamp = ddsrt_time_wallclock ();
-  result = enqueue_sample_wrlock_held (wr, seq, NULL, serdata, prd, 1) == 0;
+  result = enqueue_sample_wrlock_held (wr, seq, serdata, prd, 1) == 0;
   ddsi_serdata_unref (serdata);
   ddsrt_mutex_unlock (&wr->e.lock);
   nn_participant_generic_message_deinit(&pmg);
@@ -176,7 +176,7 @@ static bool write_crypto_exchange_message(const struct ddsi_participant *pp, con
   serdata = ddsi_serdata_from_sample (wr->type, SDK_DATA, &pmg);
   serdata->timestamp = ddsrt_time_wallclock ();
   tk = ddsi_tkmap_lookup_instance_ref (gv->m_tkmap, serdata);
-  r = write_sample_p2p_wrlock_held(wr, seq, NULL, serdata, tk, prd);
+  r = write_sample_p2p_wrlock_held(wr, seq, serdata, tk, prd);
   ddsrt_mutex_unlock (&wr->e.lock);
   ddsi_tkmap_instance_unref (gv->m_tkmap, tk);
   ddsi_serdata_unref (serdata);

--- a/src/core/ddsi/src/q_debmon.c
+++ b/src/core/ddsi/src/q_debmon.c
@@ -380,7 +380,6 @@ static void print_writer (struct st *st, void *varg)
   cpfkobj (st, "whc", print_whc_state, w);
   cpfkseqno (st, "seq", w->seq);
   cpfkseqno (st, "seq_xmit", ddsi_writer_read_seq_xmit (w));
-  cpfkseqno (st, "cs_seq", w->cs_seq);
   cpfkbool (st, "throttling", w->throttling);
   cpfkbool (st, "reliable", w->reliable);
   if (w->reliable)

--- a/src/core/ddsi/src/q_receive.c
+++ b/src/core/ddsi/src/q_receive.c
@@ -2227,7 +2227,7 @@ static int deliver_user_data (const struct nn_rsample_info *sampleinfo, const st
     src.buf = NN_RMSG_PAYLOADOFF (fragchain->rmsg, qos_offset);
     src.bufsz = NN_RDATA_PAYLOAD_OFF (fragchain) - qos_offset;
     src.strict = DDSI_SC_STRICT_P (gv->config);
-    if ((plist_ret = ddsi_plist_init_frommsg (&qos, NULL, PP_STATUSINFO | PP_KEYHASH | PP_COHERENT_SET, 0, &src, gv)) < 0)
+    if ((plist_ret = ddsi_plist_init_frommsg (&qos, NULL, PP_STATUSINFO | PP_KEYHASH, 0, &src, gv)) < 0)
     {
       if (plist_ret != DDS_RETCODE_UNSUPPORTED)
         GVWARNING ("data(application, vendor %u.%u): "PGUIDFMT" #%"PRIu64": invalid inline qos\n",

--- a/src/core/ddsi/src/q_receive.c
+++ b/src/core/ddsi/src/q_receive.c
@@ -1027,7 +1027,7 @@ static int handle_AckNack (struct receiver_state *rst, ddsrt_etime_t tnow, const
           if (tstamp.v > sample.last_rexmit_ts.v + rst->gv->config.retransmit_merging_period)
           {
             RSTTRACE (" RX%"PRIu64, seqbase + i);
-            enqueued = (enqueue_sample_wrlock_held (wr, seq, sample.plist, sample.serdata, NULL, 0) >= 0);
+            enqueued = (enqueue_sample_wrlock_held (wr, seq, sample.serdata, NULL, 0) >= 0);
             if (enqueued)
             {
               max_seq_in_reply = seqbase + i;
@@ -1058,7 +1058,7 @@ static int handle_AckNack (struct receiver_state *rst, ddsrt_etime_t tnow, const
           {
             /* no merging, send directed retransmit */
             RSTTRACE (" RX%"PRIu64"", seqbase + i);
-            enqueued = (enqueue_sample_wrlock_held (wr, seq, sample.plist, sample.serdata, prd, 0) >= 0);
+            enqueued = (enqueue_sample_wrlock_held (wr, seq, sample.serdata, prd, 0) >= 0);
             if (enqueued)
             {
               max_seq_in_reply = seqbase + i;
@@ -1664,7 +1664,7 @@ static int handle_NackFrag (struct receiver_state *rst, ddsrt_etime_t tnow, cons
       if (nn_bitset_isset (msg->fragmentNumberState.numbits, msg->bits, i))
       {
         struct nn_xmsg *reply;
-        if (create_fragment_message (wr, seq, sample.plist, sample.serdata, base + i, 1, prd, &reply, 0, 0) < 0)
+        if (create_fragment_message (wr, seq, sample.serdata, base + i, 1, prd, &reply, 0, 0) < 0)
           nfrags_lim = 0;
         else if (qxev_msg_rexmit_wrlock_held (wr->evq, reply, 0) == QXEV_MSG_REXMIT_DROPPED)
           nfrags_lim = 0;

--- a/src/core/ddsi/src/q_whc.c
+++ b/src/core/ddsi/src/q_whc.c
@@ -20,7 +20,7 @@ extern inline void whc_return_sample (struct whc *whc, struct whc_borrowed_sampl
 extern inline void whc_sample_iter_init (const struct whc *whc, struct whc_sample_iter *it);
 extern inline bool whc_sample_iter_borrow_next (struct whc_sample_iter *it, struct whc_borrowed_sample *sample);
 extern inline void whc_free (struct whc *whc);
-extern int whc_insert (struct whc *whc, seqno_t max_drop_seq, seqno_t seq, ddsrt_mtime_t exp, struct ddsi_plist *plist, struct ddsi_serdata *serdata, struct ddsi_tkmap_instance *tk);
+extern int whc_insert (struct whc *whc, seqno_t max_drop_seq, seqno_t seq, ddsrt_mtime_t exp, struct ddsi_serdata *serdata, struct ddsi_tkmap_instance *tk);
 extern unsigned whc_downgrade_to_volatile (struct whc *whc, struct whc_state *st);
 extern unsigned whc_remove_acked_messages (struct whc *whc, seqno_t max_drop_seq, struct whc_state *whcst, struct whc_node **deferred_free_list);
 extern void whc_free_deferred_free_list (struct whc *whc, struct whc_node *deferred_free_list);


### PR DESCRIPTION
This removes some dead code. Thanks @binbowang1987 for pointing out the existence of some of this, cleaning up that bit of dead code then made it clear that I could remove a bit more 🙂

Closes https://github.com/eclipse-cyclonedds/cyclonedds/issues/1406