### PR TITLE
Fix running ShmThroughputSubscriber with no args

### DIFF
--- a/examples/shm_throughput/shmsubscriber.c
+++ b/examples/shm_throughput/shmsubscriber.c
@@ -40,7 +40,7 @@ static unsigned long long total_samples = 0;
 
 static dds_time_t startTime = 0;
 
-static int payloadSize = 0;
+static int payloadSize = 8192;
 
 static void * data [MAX_SAMPLES];
 static void * samples[MAX_SAMPLES];


### PR DESCRIPTION
Currently, when you run ShmThroughputSubscriber with no args, you get:

```
Cycles: 0 | PollingDelay: -1 | Partition: Throughput example
ShmThroughputSubscriber: /home/jakub/dev/cyclonedds/examples/shm_throughput/shmsubscriber.c:432: prepare_dds: Assertion `0' failed.
Aborted (core dumped)
```

Fix the default payload size in shmsubscriber.c to match with the default payload size in shmpublisher.c.