### PR TITLE
Improve topic name support

### DIFF
--- a/src/core/ddsc/src/dds_topic.c
+++ b/src/core/ddsc/src/dds_topic.c
@@ -54,20 +54,22 @@ static bool is_valid_name (const char *name) ddsrt_nonnull_all;
 
 static bool is_valid_name (const char *name)
 {
-  /* DDS Spec:
-   *  |  TOPICNAME - A topic name is an identifier for a topic, and is defined as any series of characters
-   *  |     'a', ..., 'z',
-   *  |     'A', ..., 'Z',
-   *  |     '0', ..., '9',
-   *  |     '-' but may not start with a digit.
-   * It is considered that '-' is an error in the spec and should say '_'. So, that's what we'll check for.
-   *  |     '/' got added for ROS2
+  /* DDS Spec does not explicitly specify what constitutes a valid name.
+   * Per https://github.com/eclipse-cyclonedds/cyclonedds/issues/1393#issuecomment-1248936537
+   *  "we require isprint is true and not <space>, " or ' for the time being, then work our way to supporting UTF-8"
    */
-  if (name[0] == '\0' || isdigit ((unsigned char) name[0]))
+  if (name[0] == '\0')
     return false;
+
   for (size_t i = 0; name[i]; i++)
-    if (!(isalnum ((unsigned char) name[i]) || name[i] == '_' || name[i] == '/'))
+    if (
+        (!(isprint((unsigned char) name[i])))
+        || (isspace((unsigned char) name[i]))
+        || (name[i] == '"')
+        || (name[i] == '\'')
+      )
       return false;
+    
   return true;
 }
 

--- a/src/core/ddsc/tests/topic.c
+++ b/src/core/ddsc/tests/topic.c
@@ -59,9 +59,9 @@ ddsc_topic_fini(void)
 
 /* These will check the topic creation in various ways */
 CU_TheoryDataPoints(ddsc_topic_create, valid) = {
-    CU_DataPoints(char *, "valid", "_VALID", "Val1d", "valid_", "vA_1d"),
-    CU_DataPoints(dds_qos_t **, &g_qos_null, &g_qos, &g_qos_null, &g_qos_null, &g_qos_null),
-    CU_DataPoints(dds_listener_t **, &g_list_null, &g_listener, &g_list_null, &g_list_null, &g_list_null),
+    CU_DataPoints(char *, "valid", "_VALID", "Val1d", "valid_", "vA_1d", "1valid#", "valid::topic::name", "val-id", "valid$", "val.id", "val/id" ),
+    CU_DataPoints(dds_qos_t **, &g_qos_null, &g_qos, &g_qos_null, &g_qos_null, &g_qos_null, &g_qos_null, &g_qos_null, &g_qos_null, &g_qos_null, &g_qos_null, &g_qos_null),
+    CU_DataPoints(dds_listener_t **, &g_list_null, &g_listener, &g_list_null, &g_list_null, &g_list_null, &g_list_null, &g_list_null, &g_list_null, &g_list_null, &g_list_null, &g_list_null),
 };
 CU_Theory((char *name, dds_qos_t **qos, dds_listener_t **listener), ddsc_topic_create, valid, .init = ddsc_topic_init, .fini = ddsc_topic_fini)
 {
@@ -129,7 +129,7 @@ CU_Test(ddsc_topic_create, desc_null, .init = ddsc_topic_init, .fini = ddsc_topi
 }
 
 CU_TheoryDataPoints(ddsc_topic_create, invalid_names) = {
-    CU_DataPoints(char *, NULL, "", "mi-dle", "-start", "end-", "1st", "Thus$", "pl+s", "t(4)", "DCPSmytopic"),
+    CU_DataPoints(char *, NULL, "", "sp ace", " space", "space ", "d\"quote", "s\'quote", "DCPSmytopic"),
 };
 CU_Theory((char *name), ddsc_topic_create, invalid_names, .init = ddsc_topic_init, .fini = ddsc_topic_fini)
 {


### PR DESCRIPTION
The DDS Spec does not explicitly specify what constitutes a valid name.
   Per https://github.com/eclipse-cyclonedds/cyclonedds/issues/1393#issuecomment-1248936537
   "we require isprint is true and not <space>, " or ' for the time being, then work our way to supporting UTF-8"

Resolves #1393 