### PR TITLE
Fix issues in cdrstream and type builder

### DIFF
--- a/src/core/ddsc/tests/TypeBuilderTypes.idl
+++ b/src/core/ddsc/tests/TypeBuilderTypes.idl
@@ -272,9 +272,10 @@ module TypeBuilderTypes {
   };
 
   /* enum with non-default bit-bound as switch type */
-  union t17 switch(en8) {
-    case EN8_1: t14 u1;
-    case EN8_2: t15 u2;
+  @bit_bound(12) enum en16 { EN16_1, EN16_2 };
+  union t17 switch(en16) {
+    case EN16_1: t14 u1;
+    case EN16_2: t15 u2;
   };
 
   /* hash member id */
@@ -365,6 +366,39 @@ module TypeBuilderTypes {
     case 99:
     default:
       sequence<t24_1> u99;
+  };
+
+  union t25_1 switch(long) {
+    default:
+      string<9>  u1;
+  };
+  struct t25 {
+    t25_1 f1;
+  };
+
+  /* default case with non-zero value */
+  @nested union t26_1 switch(octet) {
+    case 0:
+      long u1;
+    default:
+      long u2;
+  };
+  struct t26 {
+    t26_1 f1;
+  };
+
+  /* default case with non-zero enum value */
+  enum en27 { @value(4) E27_3, E27_1, @value(3) E27_2 };
+  @nested union t27_1 switch(en27) {
+    case E27_1:
+      long u1;
+    case E27_3:
+      long u3;
+    default:
+      long ud;
+  };
+  struct t27 {
+    t27_1 f1;
   };
 
 };

--- a/src/core/ddsc/tests/typebuilder.c
+++ b/src/core/ddsc/tests/typebuilder.c
@@ -134,8 +134,10 @@ static bool tmap_equal (ddsi_typemap_t *a, ddsi_typemap_t *b)
 CU_TheoryDataPoints (ddsc_typebuilder, topic_desc) = {
   CU_DataPoints (const dds_topic_descriptor_t *, &D(t1), &D(t2), &D(t3), &D(t4), &D(t5), &D(t6), &D(t7), &D(t8),
                                                  &D(t9), &D(t10), &D(t11), &D(t12), &D(t13), &D(t14), &D(t15), &D(t16),
-                                                 &D(t17), &D(t18), &D(t19), &D(t20), &D(t21), &D(t22), &D(t23), &D(t24) ),
+                                                 &D(t17), &D(t18), &D(t19), &D(t20), &D(t21), &D(t22), &D(t23), &D(t24),
+                                                 &D(t25), &D(t26), &D(t27) ),
 };
+
 #undef D
 
 CU_Theory((const dds_topic_descriptor_t *desc), ddsc_typebuilder, topic_desc, .init = typebuilder_init, .fini = typebuilder_fini)

--- a/src/core/ddsi/src/ddsi_cdrstream_keys.part.c
+++ b/src/core/ddsi/src/ddsi_cdrstream_keys.part.c
@@ -214,7 +214,7 @@ static const uint32_t *dds_stream_extract_keyBO_from_data_delimited (dds_istream
 {
   uint32_t delimited_sz = dds_is_get4 (is), delimited_offs = is->m_index, insn;
   ops++;
-  while (*keys_remaining > 0 && (insn = *ops) != DDS_OP_RTS)
+  while ((insn = *ops) != DDS_OP_RTS)
   {
     switch (DDS_OP (insn))
     {
@@ -232,9 +232,7 @@ static const uint32_t *dds_stream_extract_keyBO_from_data_delimited (dds_istream
         break;
     }
   }
-  /* Skip remainder of serialized data for this appendable type */
-  if (delimited_sz > is->m_index - delimited_offs)
-    is->m_index += delimited_sz - (is->m_index - delimited_offs);
+  assert (delimited_sz == is->m_index - delimited_offs);
   return ops;
 }
 
@@ -323,7 +321,7 @@ static const uint32_t *dds_stream_extract_keyBO_from_data1 (dds_istream_t * __re
   uint32_t n_keys, uint32_t * __restrict keys_remaining, const ddsi_sertype_default_desc_key_t * __restrict keys, struct key_off_info * __restrict key_offs)
 {
   uint32_t insn;
-  while (*keys_remaining > 0 && (insn = *ops) != DDS_OP_RTS)
+  while ((insn = *ops) != DDS_OP_RTS)
   {
     switch (DDS_OP (insn))
     {

--- a/src/core/ddsi/src/ddsi_typebuilder.c
+++ b/src/core/ddsi/src/ddsi_typebuilder.c
@@ -785,8 +785,6 @@ static dds_return_t typebuilder_add_union (struct typebuilder_data *tbd, struct 
       member_sz = sz;
   }
 
-  tb_aggrtype->align = member_align; // FIXME: wrong alignment in idlc, should be: max(member_align, disc_align)
-
   // union size (size of c struct that has discriminator and c union)
   tb_aggrtype->size = disc_sz;
   align_to (&tb_aggrtype->size, member_align);
@@ -794,6 +792,7 @@ static dds_return_t typebuilder_add_union (struct typebuilder_data *tbd, struct 
 
   // padding at end of union
   uint32_t max_align = member_align > disc_align ? member_align : disc_align;
+  tb_aggrtype->align = max_align;
   align_to (&tb_aggrtype->size, max_align);
 
   // offset for union members

--- a/src/core/ddsi/src/ddsi_typebuilder.c
+++ b/src/core/ddsi/src/ddsi_typebuilder.c
@@ -1207,6 +1207,12 @@ static dds_return_t get_ops_union (const struct typebuilder_union *tb_union, uin
       if (tb_union->disc_type.args.prim_args.is_signed)
         flags |= DDS_OP_FLAG_SGN;
       break;
+    case DDS_OP_VAL_ENU:
+      flags |= get_bitbound_flags (tb_union->disc_type.args.enum_args.bit_bound);
+      break;
+    case DDS_OP_VAL_BMK:
+      flags |= get_bitbound_flags (tb_union->disc_type.args.bitmask_args.bit_bound);
+      break;
     default:
       break;
   }

--- a/src/idl/include/idl/tree.h
+++ b/src/idl/include/idl/tree.h
@@ -543,6 +543,8 @@ IDL_EXPORT bool idl_is_case(const void *node);
 IDL_EXPORT bool idl_is_default_case(const void *node);
 IDL_EXPORT bool idl_is_implicit_default_case(const void *ptr);
 IDL_EXPORT bool idl_is_case_label(const void *node);
+IDL_EXPORT bool idl_is_default_case_label(const void *node);
+IDL_EXPORT bool idl_is_implicit_default_case_label(const void *node);
 IDL_EXPORT bool idl_is_enum(const void *node);
 IDL_EXPORT bool idl_is_enumerator(const void *node);
 IDL_EXPORT bool idl_is_bitmask(const void *node);

--- a/src/idl/src/tree.c
+++ b/src/idl/src/tree.c
@@ -2379,6 +2379,26 @@ bool idl_is_case_label(const void *ptr)
   return true;
 }
 
+static bool idl_is_case_label_mask_impl(const void *ptr, const idl_mask_t mask)
+{
+  const idl_case_label_t *node = ptr;
+  if (!(idl_mask(node) & IDL_CASE_LABEL))
+    return false;
+  if ((idl_mask(node) & mask) == mask)
+    return true;
+  return false;
+}
+
+bool idl_is_default_case_label(const void *ptr)
+{
+  return idl_is_case_label_mask_impl (ptr, IDL_DEFAULT_CASE_LABEL);
+}
+
+bool idl_is_implicit_default_case_label(const void *ptr)
+{
+  return idl_is_case_label_mask_impl (ptr, IDL_IMPLICIT_DEFAULT_CASE_LABEL);
+}
+
 static void delete_case_label(void *ptr)
 {
   idl_case_label_t *node = ptr;

--- a/src/tools/idlc/src/descriptor.c
+++ b/src/tools/idlc/src/descriptor.c
@@ -818,8 +818,8 @@ emit_case(
         descriptor->n_opcodes++; /* this stashes an opcode, but is using stash_jeq_offset so we'll increase the opcode count here */
         off++;
       }
-      /* generate union case discriminator */
-      if ((ret = stash_constant(pstate, &ctype->instructions, off++, label->const_expr)))
+      /* generate union case discriminator, use 0 for default case */
+      if ((ret = stash_constant(pstate, &ctype->instructions, off++, idl_is_default_case_label(label) || idl_is_implicit_default_case_label(label) ? 0 : label->const_expr)))
         return ret;
       /* generate union case member (address) offset; use offset 0 for empty types,
          as these members are not generated and no offset can be calculated */


### PR DESCRIPTION
This fixes a number of issues in the cdrstream key extraction and in the XTypes typebuilder implementation for union types. See commit messages for details. 