### PR TITLE
Add extra condition to pacify the sanitizer for descriptor.c

### DIFF
--- a/src/tools/idlc/src/descriptor.c
+++ b/src/tools/idlc/src/descriptor.c
@@ -407,7 +407,7 @@ stash_constant(
 
   if (idl_is_enumerator(const_expr)) {
     cnt = IDL_PRINT(strp, print_type, const_expr);
-  } else {
+  } else if (const_expr != NULL) {
     const idl_literal_t *literal = const_expr;
 
     switch (idl_type(const_expr)) {


### PR DESCRIPTION
We have been having a sanitizer failure in CI for a bit, which I think is a false positive. In any case I've  "stated the obvious" in the condition which pacifies the santizer.