### PR TITLE
Ubuntu 18 being phased out on Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,10 +58,10 @@ jobs:
         testing: off
         idlc_xtests: off
         conan_shared_objects: True
-      'Ubuntu 18.04 LTS with GCC 7 (Debug, x86_64)':
-        image: ubuntu-18.04
+      'Ubuntu 22.04 LTS with GCC 11 (Debug, x86_64)':
+        image: ubuntu-22.04
         conanfile: conanfile102.txt
-        cc: gcc-7
+        cc: gcc-11
       'Ubuntu 20.04 LTS with Clang 10 (Debug, x86_64)':
         image: ubuntu-20.04
         analyzer: on


### PR DESCRIPTION
See title mostly. I switched the old 18 to a 22 build with GCC11 instead of just removing it, but maybe instead we want everything on 22 now and keep one 20 job?