### PR TITLE
Make qos inheritance merge property lists

### DIFF
--- a/src/core/ddsc/include/dds/ddsc/dds_public_qos.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_public_qos.h
@@ -432,6 +432,22 @@ dds_qset_prop (
 
 /**
  * @ingroup qos_setters
+ * @brief Stores a property with the provided name and string value in a qos structure.
+ *
+ * This is identical to dds_qoset_prop() except it is also emitted to the network.
+ *
+ * @param[in,out] qos - Pointer to a dds_qos_t structure that will store the property
+ * @param[in] name - Pointer to name of the property
+ * @param[in] value - Pointer to a (null-terminated) string that will be stored
+ */
+DDS_EXPORT void
+dds_qset_public_prop (
+  dds_qos_t * __restrict qos,
+  const char * name,
+  const char * value);
+
+/**
+ * @ingroup qos_setters
  * @brief Removes the property with the provided name from a qos structure.
  *
  * In case more than one property exists with this name, only the first property
@@ -461,6 +477,24 @@ dds_qunset_prop (
  */
 DDS_EXPORT void
 dds_qset_bprop (
+  dds_qos_t * __restrict qos,
+  const char * name,
+  const void * value,
+  const size_t sz);
+
+/**
+ * @ingroup qos_setters
+ * @brief Stores the provided binary data as a property in a qos structure
+ *
+ * This is identical to dds_qset_bprop() except it is also emitted to the network.
+ *
+ * @param[in,out] qos - Pointer to a dds_qos_t structure that will store the property
+ * @param[in] name - Pointer to name of the property
+ * @param[in] value - Pointer to data to be stored in the property
+ * @param[in] sz - Size of the data
+ */
+DDS_EXPORT void
+dds_qset_public_bprop (
   dds_qos_t * __restrict qos,
   const char * name,
   const void * value,
@@ -899,6 +933,24 @@ dds_qget_prop (
 
 /**
  * @ingroup qos_getters
+ * @brief Determine wether a binary property with the provided name is public in a qos structure.
+ *
+ *
+ * @param[in,out] qos - Pointer to a dds_qos_t structure that contains the property
+ * @param[in]    name - Pointer to name of the binary property
+ * @param[out] is_public - Pointer to a bool that will store wether the property is public.
+ *
+ * @returns - false iff any of the arguments is invalid, the qos is not present in the qos object or there was no binary property found with the provided name
+ */
+DDS_EXPORT bool
+dds_qget_prop_is_public (
+  const dds_qos_t * __restrict qos,
+  const char * name,
+  bool * is_public
+);
+
+/**
+ * @ingroup qos_getters
  * @brief Gets the names of the binary properties from a qos structure.
  *
  * @param[in,out] qos - Pointer to a dds_qos_t structure that contains binary properties
@@ -933,6 +985,24 @@ dds_qget_bprop (
   const char * name,
   void ** value,
   size_t * sz);
+
+/**
+ * @ingroup qos_getters
+ * @brief Determine wether a binary property with the provided name is public in a qos structure.
+ *
+ *
+ * @param[in,out] qos - Pointer to a dds_qos_t structure that contains the property
+ * @param[in]    name - Pointer to name of the binary property
+ * @param[out] is_public - Pointer to a bool that will store wether the property is public.
+ *
+ * @returns - false iff any of the arguments is invalid, the qos is not present in the qos object or there was no binary property found with the provided name
+ */
+DDS_EXPORT bool
+dds_qget_bprop_is_public (
+  const dds_qos_t * __restrict qos,
+  const char * name,
+  bool * is_public
+);
 
 /**
  * @ingroup qos_getters

--- a/src/core/ddsi/include/dds/ddsi/ddsi_xqos.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_xqos.h
@@ -427,6 +427,17 @@ dds_return_t ddsi_xqos_valid (const struct ddsrt_log_cfg *logcfg, const dds_qos_
 void ddsi_xqos_mergein_missing (dds_qos_t *a, const dds_qos_t *b, uint64_t mask);
 
 /**
+ * @brief Extend "a" with (binary) properties present in "b"
+ *
+ * This copies into "a" any (binary) properties present in "b" that are missing
+ * in "a".  It doesn't touch any properties already present in "a".
+ *
+ * @param[in,out] a       dds_qos_t to be extended with properties
+ * @param[in]     b       dds_qos_t from which to copy properties
+ */
+void ddsi_xqos_mergein_missing_props (dds_qos_t *a, const dds_qos_t * b);
+
+/**
  * @brief Determine the set of entries in which "x" differs from "y"
  *
  * This computes the entries set in "x" but not set in "y", not set in "x" but set in "y",
@@ -493,6 +504,19 @@ size_t ddsi_xqos_print (char * __restrict buf, size_t bufsize, const dds_qos_t *
  * @returns true iff xqos was modified (property did not exist yet)
  */
 bool ddsi_xqos_add_property_if_unset (dds_qos_t *xqos, bool propagate, const char *name, const char *value);
+
+/**
+ * @brief Add a property 'name' to the properties of "xqos" if it does not exists
+ *
+ * @param[in]  xqos        qos object to add property to.
+ * @param[in]  propagate   whether to propagate (emit to wire) the property
+ * @param[in]  name        property name
+ * @param[in]  value       property value
+ * @param[in]  length      property length
+ *
+ * @returns true iff xqos was modified (property did not exist yet)
+ */
+bool ddsi_xqos_add_binary_property_if_unset (dds_qos_t *xqos, bool propagate, const char *name, const void *value, uint32_t length);
 
 /**
  * @brief Duplicate "src"

--- a/src/core/xtests/symbol_export/symbol_export.c
+++ b/src/core/xtests/symbol_export/symbol_export.c
@@ -350,8 +350,10 @@ int main (int argc, char **argv)
   dds_qset_durability_service (ptr, 0, 0, 0, 0, 0, 0);
   dds_qset_ignorelocal (ptr, 0);
   dds_qset_prop (ptr, ptr2, ptr3);
+  dds_qset_public_prop (ptr, ptr2, ptr3);
   dds_qunset_prop (ptr, ptr2);
   dds_qset_bprop (ptr, ptr2, ptr3, 0);
+  dds_qset_public_bprop (ptr, ptr2, ptr3, 0);
   dds_qunset_bprop (ptr, ptr2);
   dds_qset_type_consistency (ptr, 0, 0, 0, 0, 0, 0);
   dds_qset_data_representation (ptr, 0, ptr2);
@@ -380,8 +382,10 @@ int main (int argc, char **argv)
   dds_qget_ignorelocal (ptr, 0);
   dds_qget_propnames (ptr, ptr, ptr);
   dds_qget_prop (ptr, ptr, ptr);
+  dds_qget_prop_is_public (ptr, ptr, ptr);
   dds_qget_bpropnames (ptr, ptr, ptr);
   dds_qget_bprop (ptr, ptr, ptr, ptr);
+  dds_qget_bprop_is_public (ptr, ptr, ptr);
   dds_qget_type_consistency (ptr, 0, ptr, ptr, ptr, ptr, ptr);
   dds_qget_data_representation (ptr, ptr, ptr);
   dds_qget_entity_name (ptr, ptr);


### PR DESCRIPTION
This PR changes the way the QoS (Binary) Property Policy works. Effectively, every named property becomes its own policy, to be separately considered when merging QoS "objects". This is important for tooling, since the magic "__Hostname", "__DebugMonitor" properties are now missing when a user sets properties on the participant of their own.

I was also suprised to find out that you cannot set a QoS Property Policy that has `propagate=true` via the `dds_qset_*` API. This means you can never set a Property that is externally visible as a user of CycloneDDS. I now dropped in some quickly thrown together API functions to set "public properties" which is probably not the right move, we'll need to brainstorm on this a little more.

Lastly I had to fix the security tests that looked for hardcoded strings in log output, that now differ because of the "magic properties". I did that by building a mini parser that reconstructs the property QoS from the log output. I removed the one test that looks at binary properties since parsing that was too much work for very little gain, it's plenty tested in other places.