### PR TITLE
Fixed iceoryx crash (#1445)

### DIFF
--- a/src/core/ddsc/src/dds_data_allocator.c
+++ b/src/core/ddsc/src/dds_data_allocator.c
@@ -152,7 +152,9 @@ dds_return_t dds_data_allocator_free (dds_data_allocator_t *data_allocator, void
       case DDS_IOX_ALLOCATOR_KIND_SUBSCRIBER:
         if (ptr != NULL) {
           ddsrt_mutex_lock(&d->mutex);
+          shm_lock_iox_sub(d->ref.sub);
           iox_sub_release_chunk(d->ref.sub, ptr);
+          shm_unlock_iox_sub(d->ref.sub);
           ddsrt_mutex_unlock(&d->mutex);
         }
         break;


### PR DESCRIPTION
The crash #1445 was caused by accessing non-thread-safe resources of iceoryx subscriber at the same time from different threads (one thread was [reading](https://github.com/eclipse-cyclonedds/cyclonedds/blob/cd3c6ed83899035b98f76266d4e73223a9b911da/src/core/ddsc/src/shm_monitor.c#L102) chunks, another thread was [releasing](https://github.com/eclipse-cyclonedds/cyclonedds/blob/cd3c6ed83899035b98f76266d4e73223a9b911da/src/core/ddsc/src/dds_data_allocator.c#L155) processed chunks).

Note: This fixes the particular crash scenario but there may be other places where iox locking is needed...