### PR TITLE
Unification of lease durations in plist/qos

### DIFF
--- a/src/core/ddsc/src/dds_participant.c
+++ b/src/core/ddsc/src/dds_participant.c
@@ -131,11 +131,6 @@ dds_entity_t dds_create_participant (const dds_domainid_t domain, const dds_qos_
   ddsi_plist_init_empty (&plist);
   ddsi_xqos_mergein_missing (&plist.qos, new_qos, ~(uint64_t)0);
 
-  // Participants don't have a liveliness QoS according to the spec, that's a Cyclone
-  // extension.  DDSI has a "participant lease duration" parameter.
-  plist.participant_lease_duration = new_qos->liveliness.lease_duration;
-  plist.present |= PP_PARTICIPANT_LEASE_DURATION;
-
   ddsi_thread_state_awake (ddsi_lookup_thread_state (), &dom->gv);
   ret = ddsi_new_participant (&guid, &dom->gv, 0, &plist);
   ddsi_thread_state_asleep (ddsi_lookup_thread_state ());

--- a/src/core/ddsc/src/dds_serdata_builtintopic.c
+++ b/src/core/ddsc/src/dds_serdata_builtintopic.c
@@ -158,22 +158,11 @@ static void add_pp_addresses_to_xqos(dds_qos_t *q, const struct ddsi_proxy_parti
   }
 }
 
-static void translate_pp_lease_duration (dds_qos_t *qos, const ddsi_plist_t *plist)
-{
-  // Participant lease duration doesn't play by the rules because it doesn't officially exist as a QoS
-  // and we make it available via the liveliness QoS setting
-  assert (plist->present & PP_PARTICIPANT_LEASE_DURATION);
-  qos->present |= DDSI_QP_LIVELINESS;
-  qos->liveliness.kind = DDS_LIVELINESS_AUTOMATIC;
-  qos->liveliness.lease_duration = plist->participant_lease_duration;
-}
-
 static void from_entity_pp (struct ddsi_serdata_builtintopic_participant *d, const struct ddsi_participant *pp)
 {
   ddsi_xqos_copy(&d->common.xqos, &pp->plist->qos);
   ddsi_xqos_add_property_if_unset(&d->common.xqos, true, DDS_BUILTIN_TOPIC_PARTICIPANT_PROPERTY_NETWORKADDRESSES, "localprocess");
   d->pphandle = pp->e.iid;
-  translate_pp_lease_duration (&d->common.xqos, pp->plist);
 }
 
 static void from_entity_proxypp (struct ddsi_serdata_builtintopic_participant *d, const struct ddsi_proxy_participant *proxypp)
@@ -181,7 +170,6 @@ static void from_entity_proxypp (struct ddsi_serdata_builtintopic_participant *d
   ddsi_xqos_copy(&d->common.xqos, &proxypp->plist->qos);
   add_pp_addresses_to_xqos(&d->common.xqos, proxypp);
   d->pphandle = proxypp->e.iid;
-  translate_pp_lease_duration (&d->common.xqos, proxypp->plist);
 }
 
 static void from_qos (struct ddsi_serdata_builtintopic *d, const dds_qos_t *xqos)

--- a/src/core/ddsc/tests/xtypes.c
+++ b/src/core/ddsc/tests/xtypes.c
@@ -573,15 +573,15 @@ static void typemap_deser (DDS_XTypes_TypeMapping **tmap, const struct dds_type_
 static void test_proxy_rd_create (struct ddsi_domaingv *gv, const char *topic_name, DDS_XTypes_TypeInformation *ti, dds_return_t exp_ret, const ddsi_guid_t *pp_guid, const ddsi_guid_t *rd_guid)
 {
   ddsi_plist_t *plist = ddsrt_calloc (1, sizeof (*plist));
-  plist->present |= PP_PARTICIPANT_LEASE_DURATION;
-  plist->participant_lease_duration = DDS_INFINITY;
-  plist->qos.present |= DDSI_QP_TOPIC_NAME | DDSI_QP_TYPE_NAME | DDSI_QP_TYPE_INFORMATION | DDSI_QP_DATA_REPRESENTATION;
+  plist->qos.present |= DDSI_QP_TOPIC_NAME | DDSI_QP_TYPE_NAME | DDSI_QP_TYPE_INFORMATION | DDSI_QP_DATA_REPRESENTATION | DDSI_QP_LIVELINESS;
   plist->qos.topic_name = ddsrt_strdup (topic_name);
   plist->qos.type_name = ddsrt_strdup ("dummy");
   plist->qos.type_information = ddsi_typeinfo_dup ((struct ddsi_typeinfo *) ti);
   plist->qos.data_representation.value.n = 1;
   plist->qos.data_representation.value.ids = ddsrt_calloc (1, sizeof (*plist->qos.data_representation.value.ids));
   plist->qos.data_representation.value.ids[0] = DDS_DATA_REPRESENTATION_XCDR2;
+  plist->qos.liveliness.kind = DDS_LIVELINESS_AUTOMATIC;
+  plist->qos.liveliness.lease_duration = DDS_INFINITY;
 
   struct ddsi_thread_state * const thrst = ddsi_lookup_thread_state ();
   ddsi_thread_state_awake (thrst, gv);

--- a/src/core/ddsi/CMakeLists.txt
+++ b/src/core/ddsi/CMakeLists.txt
@@ -157,6 +157,7 @@ set(hdrs_private_ddsi
   ddsi__nwpart.h
   ddsi__ownip.h
   ddsi__participant.h
+  ddsi__plist_context_kind.h
   ddsi__plist_generic.h
   ddsi__serdata_pserop.h
   ddsi__pmd.h

--- a/src/core/ddsi/include/dds/ddsi/ddsi_participant.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_participant.h
@@ -41,7 +41,6 @@ enum ddsi_participant_state {
 struct ddsi_participant
 {
   struct ddsi_entity_common e;
-  dds_duration_t lease_duration; /* constant */
   uint32_t bes; /* built-in endpoint set */
   unsigned is_ddsi2_pp: 1; /* true for the "federation leader", the ddsi2 participant itself in OSPL; FIXME: probably should use this for broker mode as well ... */
   struct ddsi_plist *plist; /* settings/QoS for this participant */

--- a/src/core/ddsi/include/dds/ddsi/ddsi_plist.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_plist.h
@@ -35,7 +35,7 @@ extern "C" {
 #define PP_EXPECTS_INLINE_QOS                   ((uint64_t)1 <<  8)
 #define PP_PARTICIPANT_MANUAL_LIVELINESS_COUNT  ((uint64_t)1 <<  9)
 #define PP_PARTICIPANT_BUILTIN_ENDPOINTS        ((uint64_t)1 << 10)
-#define PP_PARTICIPANT_LEASE_DURATION           ((uint64_t)1 << 11)
+//#define PP_PARTICIPANT_LEASE_DURATION           ((uint64_t)1 << 11)
 #define PP_CONTENT_FILTER_PROPERTY              ((uint64_t)1 << 12)
 #define PP_PARTICIPANT_GUID                     ((uint64_t)1 << 13)
 #define PP_PARTICIPANT_ENTITYID                 ((uint64_t)1 << 14)
@@ -171,7 +171,6 @@ typedef struct ddsi_plist {
   unsigned char expects_inline_qos;
   ddsi_count_t participant_manual_liveliness_count;
   uint32_t participant_builtin_endpoints;
-  dds_duration_t participant_lease_duration;
   /* ddsi_content_filter_property_t content_filter_property; */
   ddsi_guid_t participant_guid;
   ddsi_guid_t endpoint_guid;
@@ -226,7 +225,6 @@ void ddsi_plist_init_empty (ddsi_plist_t *dest);
  * @param[in] ps   ddsi_plist_t for which to free memory
  */
 void ddsi_plist_fini (ddsi_plist_t *ps);
-
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsi/src/ddsi__plist.h
+++ b/src/core/ddsi/src/ddsi__plist.h
@@ -88,6 +88,11 @@ struct ddsi_plist_sample {
   ddsi_parameterid_t keyparam;
 };
 
+enum ddsi_plist_context_kind {
+  DDSI_PLIST_CONTEXT_PARTICIPANT,
+  DDSI_PLIST_CONTEXT_ENDPOINT,
+};
+
 extern const ddsi_plist_t ddsi_default_plist_participant;
 
 /**
@@ -152,6 +157,8 @@ ddsi_plist_t *ddsi_plist_dup (const ddsi_plist_t *src);
  *               - bufsz is the size in bytes of the input buffer
  * @param[in]  gv
  *               Global context, used for locator kind lookups and tracing
+ * @param[in]  context_kind
+ *               Context in which the nterpretation is taking place
  * @param[out] dest
  *               Filled with the recognized parameters in the input if successful, otherwise
  *               initialized to an empty parameter list.  Where possible, pointers alias the
@@ -178,7 +185,7 @@ ddsi_plist_t *ddsi_plist_dup (const ddsi_plist_t *src);
  *               Input contained an unrecognized parameter with the "incompatible-if-unknown"
  *               flag set; dest is cleared, *nextafterplist is NULL.
  */
-dds_return_t ddsi_plist_init_frommsg (ddsi_plist_t *dest, char **nextafterplist, uint64_t pwanted, uint64_t qwanted, const ddsi_plist_src_t *src, struct ddsi_domaingv const * const gv);
+dds_return_t ddsi_plist_init_frommsg (ddsi_plist_t *dest, char **nextafterplist, uint64_t pwanted, uint64_t qwanted, const ddsi_plist_src_t *src, struct ddsi_domaingv const * const gv, enum ddsi_plist_context_kind context_kind);
 
 /**
  * @brief Free memory owned by "plist" for a subset of the entries
@@ -219,8 +226,9 @@ void ddsi_plist_unalias (ddsi_plist_t *plist);
  * @param[in]     ps       source
  * @param[in]     pwanted  subset of non-QoS part of ps (if PP_X is set, add X if present)
  * @param[in]     qwanted  subset of QoS part of ps (if DDSI_QP_X is set, add X if present)
+ * @param[in]     context_kind  context in which theserialization is taking place
  */
-void ddsi_plist_addtomsg (struct ddsi_xmsg *m, const ddsi_plist_t *ps, uint64_t pwanted, uint64_t qwanted);
+void ddsi_plist_addtomsg (struct ddsi_xmsg *m, const ddsi_plist_t *ps, uint64_t pwanted, uint64_t qwanted, enum ddsi_plist_context_kind context_kind);
 
 /**
  * @brief Determine the set of entries in which "x" differs from "y"
@@ -262,8 +270,9 @@ void ddsi_plist_log (uint32_t cat, const struct ddsrt_log_cfg *logcfg, const dds
  * @param[in]     pwanted  subset of non-QoS part of ps (if PP_X is set, add X if present)
  * @param[in]     qwanted  subset of QoS part of ps (if DDSI_QP_X is set, add X if present)
  * @param[in]     bo       byte order
+ * @param[in]     context_kind  context in which theserialization is taking place
  */
-void ddsi_plist_addtomsg_bo (struct ddsi_xmsg *m, const ddsi_plist_t *ps, uint64_t pwanted, uint64_t qwanted, enum ddsrt_byte_order_selector bo);
+void ddsi_plist_addtomsg_bo (struct ddsi_xmsg *m, const ddsi_plist_t *ps, uint64_t pwanted, uint64_t qwanted, enum ddsrt_byte_order_selector bo, enum ddsi_plist_context_kind context_kind);
 
 /**
  * @brief Formats plist into a buffer

--- a/src/core/ddsi/src/ddsi__plist.h
+++ b/src/core/ddsi/src/ddsi__plist.h
@@ -19,7 +19,7 @@
 #include "dds/ddsi/ddsi_plist.h"
 #include "dds/ddsi/ddsi_domaingv.h"
 #include "ddsi__protocol.h"
-
+#include "ddsi__plist_context_kind.h"
 
 #if defined (__cplusplus)
 extern "C" {
@@ -86,11 +86,6 @@ struct ddsi_plist_sample {
   void *blob;
   size_t size;
   ddsi_parameterid_t keyparam;
-};
-
-enum ddsi_plist_context_kind {
-  DDSI_PLIST_CONTEXT_PARTICIPANT,
-  DDSI_PLIST_CONTEXT_ENDPOINT,
 };
 
 extern const ddsi_plist_t ddsi_default_plist_participant;

--- a/src/core/ddsi/src/ddsi__plist_context_kind.h
+++ b/src/core/ddsi/src/ddsi__plist_context_kind.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright(c) 2022 ZettaScale Technology and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#ifndef DDSI__PLIST_CONTEXT_KIND_H
+#define DDSI__PLIST_CONTEXT_KIND_H
+
+/** \brief Context in which a DDSI parameter list is being interpreted/generated
+
+ A participant has no "liveliness" setting in the specs and the DDSI spec states that a
+ participant has a lease that is communicated via the "participant lease duration"
+ parameter, but to all intents and purposes, this "participant lease duration" is entirely
+ equivalent to an "automatic" liveliness setting. Cyclone internally represents this
+ participant lease duration as a liveliness, requiring a transformation to be performed
+ when (de)serialising the parameter lists. This necessitates indicating which
+ interpretation is to be taken. Currently only two situations: one where this
+ transformation is needed, and one where a liveliness is simply that.
+
+ One approach would be to add (yet another) boolean boolean parameter "transform
+ liveliness to participant lease duration" to the (de)serialisation of parameter lists,
+ but this would not help with the readability of the code. Using an enumerated type for
+ the two helps, but naming it becomes problematic and raises the question whether it will
+ always be only the liveliness QoS that needs special treatment.
+
+ Another approach uses a "context" argument and leaves the way these are interpreted to
+ the (de)serialisation code. That way the call sites become straightforward and all
+ details on what it means to handle these parameter lists in a particular context becomes
+ local to the (de)serialiser. */
+enum ddsi_plist_context_kind {
+  DDSI_PLIST_CONTEXT_PARTICIPANT,   /**< for SPDP, maps "participant lease duration" to "liveliness" */
+  DDSI_PLIST_CONTEXT_ENDPOINT,      /**< for endpoint discovery ("liveliness" is just that) */
+  DDSI_PLIST_CONTEXT_TOPIC,         /**< for topics (equivalent to ENDPOINT for current specs) */
+  DDSI_PLIST_CONTEXT_INLINE_QOS,    /**< for inline QoS interpretation (equivalent to ENDPOINT for current specs) */
+  DDSI_PLIST_CONTEXT_QOS_DISALLOWED /**< contexts where QoS are disallowed (currently only used for "pserop" serdes) */
+};
+
+#endif

--- a/src/core/ddsi/src/ddsi__xqos.h
+++ b/src/core/ddsi/src/ddsi__xqos.h
@@ -18,6 +18,7 @@
 #include "dds/ddsi/ddsi_log.h"
 #include "dds/ddsi/ddsi_xqos.h"
 #include "dds/ddsc/dds_public_qosdefs.h"
+#include "ddsi__plist_context_kind.h"
 
 #if defined (__cplusplus)
 extern "C" {
@@ -62,8 +63,9 @@ void ddsi_xqos_fini_mask (dds_qos_t *xqos, uint64_t mask);
  * @param[in,out] m        message to append the parameters to
  * @param[in]     xqos     source
  * @param[in]     wanted   subset to be added (if DDSI_QP_X is set, add X if present)
+ * @param[in]     context_kind  context for interpretation of QoS settings
  */
-void ddsi_xqos_addtomsg (struct ddsi_xmsg *m, const dds_qos_t *xqos, uint64_t wanted);
+void ddsi_xqos_addtomsg (struct ddsi_xmsg *m, const dds_qos_t *xqos, uint64_t wanted, enum ddsi_plist_context_kind context_kind);
 
 /**
  * @brief Formats xqos using `ddsi_xqos_print` and writes it to the trace.

--- a/src/core/ddsi/src/ddsi_discovery.c
+++ b/src/core/ddsi/src/ddsi_discovery.c
@@ -1971,7 +1971,7 @@ int ddsi_builtins_dqueue_handler (const struct ddsi_rsample_info *sampleinfo, co
     src.buf = DDSI_RMSG_PAYLOADOFF (fragchain->rmsg, qos_offset);
     src.bufsz = DDSI_RDATA_PAYLOAD_OFF (fragchain) - qos_offset;
     src.strict = DDSI_SC_STRICT_P (gv->config);
-    if ((plist_ret = ddsi_plist_init_frommsg (&qos, NULL, PP_STATUSINFO | PP_KEYHASH, 0, &src, gv, DDSI_PLIST_CONTEXT_ENDPOINT)) < 0)
+    if ((plist_ret = ddsi_plist_init_frommsg (&qos, NULL, PP_STATUSINFO | PP_KEYHASH, 0, &src, gv, DDSI_PLIST_CONTEXT_INLINE_QOS)) < 0)
     {
       if (plist_ret != DDS_RETCODE_UNSUPPORTED)
         GVWARNING ("data(builtin, vendor %u.%u): "PGUIDFMT" #%"PRIu64": invalid inline qos\n",

--- a/src/core/ddsi/src/ddsi_init.c
+++ b/src/core/ddsi/src/ddsi_init.c
@@ -1199,6 +1199,8 @@ int ddsi_init (struct ddsi_domaingv *gv)
     gv->xmit_conns[i] = NULL;
   gv->listener = NULL;
   gv->debmon = NULL;
+  gv->n_recv_threads = 0;
+  gv->ddsi_tran_factories = NULL;
 
   /* Print start time for referencing relative times in the remainder of the DDS_LOG. */
   {
@@ -1346,9 +1348,8 @@ int ddsi_init (struct ddsi_domaingv *gv)
   // a plain copy is safe because it doesn't alias anything
   gv->default_local_plist_pp = ddsi_default_plist_participant;
   assert (gv->default_local_plist_pp.aliased == 0 && gv->default_local_plist_pp.qos.aliased == 0);
-  assert (!(gv->default_local_plist_pp.qos.present & DDSI_QP_LIVELINESS));
-  gv->default_local_plist_pp.qos.present |= DDSI_QP_LIVELINESS;
-  gv->default_local_plist_pp.qos.liveliness.kind = DDS_LIVELINESS_AUTOMATIC;
+  assert (gv->default_local_plist_pp.qos.present & DDSI_QP_LIVELINESS);
+  assert (gv->default_local_plist_pp.qos.liveliness.kind == DDS_LIVELINESS_AUTOMATIC);
   gv->default_local_plist_pp.qos.liveliness.lease_duration = gv->config.lease_duration;
 
   ddsi_xqos_copy (&gv->spdp_endpoint_xqos, &ddsi_default_qos_reader);

--- a/src/core/ddsi/src/ddsi_receive.c
+++ b/src/core/ddsi/src/ddsi_receive.c
@@ -2220,7 +2220,7 @@ static int deliver_user_data (const struct ddsi_rsample_info *sampleinfo, const 
     src.buf = DDSI_RMSG_PAYLOADOFF (fragchain->rmsg, qos_offset);
     src.bufsz = DDSI_RDATA_PAYLOAD_OFF (fragchain) - qos_offset;
     src.strict = DDSI_SC_STRICT_P (gv->config);
-    if ((plist_ret = ddsi_plist_init_frommsg (&qos, NULL, PP_STATUSINFO | PP_KEYHASH, 0, &src, gv)) < 0)
+    if ((plist_ret = ddsi_plist_init_frommsg (&qos, NULL, PP_STATUSINFO | PP_KEYHASH, 0, &src, gv, DDSI_PLIST_CONTEXT_ENDPOINT)) < 0)
     {
       if (plist_ret != DDS_RETCODE_UNSUPPORTED)
         GVWARNING ("data(application, vendor %u.%u): "PGUIDFMT" #%"PRIu64": invalid inline qos\n",

--- a/src/core/ddsi/src/ddsi_receive.c
+++ b/src/core/ddsi/src/ddsi_receive.c
@@ -2220,7 +2220,7 @@ static int deliver_user_data (const struct ddsi_rsample_info *sampleinfo, const 
     src.buf = DDSI_RMSG_PAYLOADOFF (fragchain->rmsg, qos_offset);
     src.bufsz = DDSI_RDATA_PAYLOAD_OFF (fragchain) - qos_offset;
     src.strict = DDSI_SC_STRICT_P (gv->config);
-    if ((plist_ret = ddsi_plist_init_frommsg (&qos, NULL, PP_STATUSINFO | PP_KEYHASH, 0, &src, gv, DDSI_PLIST_CONTEXT_ENDPOINT)) < 0)
+    if ((plist_ret = ddsi_plist_init_frommsg (&qos, NULL, PP_STATUSINFO | PP_KEYHASH, 0, &src, gv, DDSI_PLIST_CONTEXT_INLINE_QOS)) < 0)
     {
       if (plist_ret != DDS_RETCODE_UNSUPPORTED)
         GVWARNING ("data(application, vendor %u.%u): "PGUIDFMT" #%"PRIu64": invalid inline qos\n",

--- a/src/core/ddsi/src/ddsi_security_exchange.c
+++ b/src/core/ddsi/src/ddsi_security_exchange.c
@@ -83,7 +83,7 @@ void auth_get_serialized_participant_data(struct ddsi_participant *pp, ddsi_octe
   char *payload;
   mpayload = ddsi_xmsg_new (pp->e.gv->xmsgpool, &pp->e.guid, pp, 0, DDSI_XMSG_KIND_DATA);
   ddsi_get_participant_builtin_topic_data (pp, &ps, &locs);
-  ddsi_plist_addtomsg_bo (mpayload, &ps, ~(uint64_t)0, ~(uint64_t)0, DDSRT_BOSEL_BE);
+  ddsi_plist_addtomsg_bo (mpayload, &ps, ~(uint64_t)0, ~(uint64_t)0, DDSRT_BOSEL_BE, DDSI_PLIST_CONTEXT_PARTICIPANT);
   ddsi_xmsg_addpar_sentinel_bo (mpayload, DDSRT_BOSEL_BE);
   ddsi_plist_fini (&ps);
   payload = ddsi_xmsg_payload (&sz, mpayload);

--- a/src/core/ddsi/src/ddsi_serdata_plist.c
+++ b/src/core/ddsi/src/ddsi_serdata_plist.c
@@ -178,7 +178,12 @@ static bool serdata_plist_untyped_to_sample (const struct ddsi_sertype *tpcmn, c
     .strict = DDSI_SC_STRICT_P (gv->config),
     .vendorid = d->vendorid
   };
-  const dds_return_t rc = ddsi_plist_init_frommsg (sample, NULL, ~(uint64_t)0, ~(uint64_t)0, &src, gv);
+  enum ddsi_plist_context_kind context_kind;
+  if (tp->keyparam == DDSI_PID_PARTICIPANT_GUID)
+    context_kind = DDSI_PLIST_CONTEXT_PARTICIPANT;
+  else
+    context_kind = DDSI_PLIST_CONTEXT_ENDPOINT;
+  const dds_return_t rc = ddsi_plist_init_frommsg (sample, NULL, ~(uint64_t)0, ~(uint64_t)0, &src, gv, context_kind);
   // FIXME: need a more informative return type
   if (rc != DDS_RETCODE_OK && rc != DDS_RETCODE_UNSUPPORTED)
     GVWARNING ("Invalid %s (vendor %u.%u): invalid qos/parameters\n", tpcmn->type_name, src.vendorid.id[0], src.vendorid.id[1]);
@@ -221,7 +226,12 @@ static struct ddsi_serdata *serdata_plist_from_sample (const struct ddsi_sertype
   struct ddsi_domaingv * const gv = ddsrt_atomic_ldvoidp (&tp->c.gv);
   struct ddsi_xmsg *mpayload = ddsi_xmsg_new (gv->xmsgpool, &ddsi_nullguid, NULL, 0, DDSI_XMSG_KIND_DATA);
   memcpy (ddsi_xmsg_append (mpayload, NULL, 4), &header, 4);
-  ddsi_plist_addtomsg (mpayload, sample, ~(uint64_t)0, ~(uint64_t)0);
+  enum ddsi_plist_context_kind context_kind;
+  if (tp->keyparam == DDSI_PID_PARTICIPANT_GUID)
+    context_kind = DDSI_PLIST_CONTEXT_PARTICIPANT;
+  else
+    context_kind = DDSI_PLIST_CONTEXT_ENDPOINT;
+  ddsi_plist_addtomsg (mpayload, sample, ~(uint64_t)0, ~(uint64_t)0, context_kind);
   ddsi_xmsg_addpar_sentinel (mpayload);
 
   size_t sz;
@@ -281,7 +291,12 @@ static size_t serdata_plist_print_plist (const struct ddsi_sertype *sertype_comm
     .vendorid = d->vendorid
   };
   ddsi_plist_t tmp;
-  if (ddsi_plist_init_frommsg (&tmp, NULL, ~(uint64_t)0, ~(uint64_t)0, &src, gv) < 0)
+  enum ddsi_plist_context_kind context_kind;
+  if (tp->keyparam == DDSI_PID_PARTICIPANT_GUID)
+    context_kind = DDSI_PLIST_CONTEXT_PARTICIPANT;
+  else
+    context_kind = DDSI_PLIST_CONTEXT_ENDPOINT;
+  if (ddsi_plist_init_frommsg (&tmp, NULL, ~(uint64_t)0, ~(uint64_t)0, &src, gv, context_kind) < 0)
     return (size_t) snprintf (buf, size, "(unparseable-plist)");
   else
   {

--- a/src/core/ddsi/src/ddsi_topic.c
+++ b/src/core/ddsi/src/ddsi_topic.c
@@ -268,7 +268,7 @@ static void set_ddsi_topic_definition_hash (struct ddsi_topic_definition *tpd)
      dependent type ids and therefore may be different for equal
      type definitions */
   struct ddsi_xmsg *mqos = ddsi_xmsg_new (tpd->gv->xmsgpool, &ddsi_nullguid, NULL, 0, DDSI_XMSG_KIND_DATA);
-  ddsi_xqos_addtomsg (mqos, tpd->xqos, ~(DDSI_QP_TYPE_INFORMATION));
+  ddsi_xqos_addtomsg (mqos, tpd->xqos, ~(DDSI_QP_TYPE_INFORMATION), DDSI_PLIST_CONTEXT_TOPIC);
   size_t sqos_sz;
   void * sqos = ddsi_xmsg_payload (&sqos_sz, mqos);
   assert (sqos_sz <= UINT32_MAX);

--- a/src/core/ddsi/src/ddsi_xevent.c
+++ b/src/core/ddsi/src/ddsi_xevent.c
@@ -1028,7 +1028,7 @@ static void handle_xevk_spdp (UNUSED_ARG (struct ddsi_xpack *xp), struct ddsi_xe
   {
     /* Directed events are used to send SPDP packets to newly
        discovered peers, and used just once. */
-    if (--ev->u.spdp.directed == 0 || gv->config.spdp_interval < DDS_SECS (1) || pp->lease_duration < DDS_SECS (1))
+    if (--ev->u.spdp.directed == 0 || gv->config.spdp_interval < DDS_SECS (1) || pp->plist->qos.liveliness.lease_duration < DDS_SECS (1))
       ddsi_delete_xevent (ev);
     else
     {
@@ -1046,7 +1046,7 @@ static void handle_xevk_spdp (UNUSED_ARG (struct ddsi_xpack *xp), struct ddsi_xe
        before the lease ends, whichever comes first (similar to PMD),
        but never wait longer than spdp_interval */
     const dds_duration_t mindelta = DDS_MSECS (10);
-    const dds_duration_t ldur = pp->lease_duration;
+    const dds_duration_t ldur = pp->plist->qos.liveliness.lease_duration;
     ddsrt_mtime_t tnext;
     int64_t intv;
 

--- a/src/core/ddsi/tests/CMakeLists.txt
+++ b/src/core/ddsi/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ set(ddsi_test_sources
     "locators.c"
     "plist_generic.c"
     "plist.c"
+    "plist_leasedur.c"
     "radmin.c"
     "sysdeps.c"
     "mem_ser.h")

--- a/src/core/ddsi/tests/plist_generic.c
+++ b/src/core/ddsi/tests/plist_generic.c
@@ -39,7 +39,7 @@ typedef uint32_t raw32[];
 typedef uint64_t raw64[];
 typedef ddsi_octetseq_t oseq;
 
-struct desc descs[] = {
+static struct desc descs[] = {
   { {XSTOP}, (raw){0}, 0, (raw){0} },
   { {XO,XSTOP}, &(oseq){0, NULL },       4, (raw){SER32(0)} },
   { {XO,XSTOP}, &(oseq){1, (raw){3} },   5, (raw){SER32(1), 3} },
@@ -235,7 +235,7 @@ CU_Test (ddsi_plist_generic, unalias)
   }
 }
 
-struct desc_invalid descs_invalid[] = {
+static struct desc_invalid descs_invalid[] = {
   { {Xb,XSTOP},   1, (raw){2} }, // 2 is not a valid boolean
   { {XS,XSTOP},   8, (raw){SER32(5), 'm','e','o','w',0} }, // short input
   { {XS,XSTOP},   8, (raw){SER32(4), 'm','e','o','w',0} }, // not terminated

--- a/src/core/ddsi/tests/plist_leasedur.c
+++ b/src/core/ddsi/tests/plist_leasedur.c
@@ -28,6 +28,7 @@
 #include "ddsi__vendor.h"
 #include "ddsi__receive.h"
 #include "ddsi__tran.h"
+#include "ddsi__protocol.h"
 #include "mem_ser.h"
 
 /* We already used "liveliness" for participant lease durations in the API
@@ -267,9 +268,9 @@ static void ddsi_plist_leasedur_new_proxypp_impl (bool include_lease_duration)
     // GUID prefix: first two bytes ordinarily have vendor id, so 7,7 is
     // guaranteed to not be used locally
     TEST_GUIDPREFIX_BYTES,
-    // DATA (0x15); flags (4 = dataflag + big-endian); octets-to-next-header = 0
+    // DATA: flags (4 = dataflag + big-endian); octets-to-next-header = 0
     // means it continues until the end
-    0x15, 4, 0,0,
+    DDSI_RTPS_SMID_DATA, 4, 0,0,
     0,0, // extra flags
     0,16, // octets to inline QoS (no inline qos here, so: to payload)
     SER32BE (DDSI_ENTITYID_UNKNOWN),
@@ -379,13 +380,13 @@ static void ddsi_plist_leasedur_new_proxyrd_impl (bool include_lease_duration)
     // GUID prefix: first two bytes ordinarily have vendor id, so 7,7 is
     // guaranteed to not be used locally
     TEST_GUIDPREFIX_BYTES,
-    // INFO_DST (0xe); flags (0 = big-endian); octets-to-next-header = 12
-    0xe, 0, 0,12
+    // INFO_DST: flags (0 = big-endian); octets-to-next-header = 12
+    DDSI_RTPS_SMID_INFO_DST, 0, 0,12
     // guid prefix of local node (= ppguidprefix_base) comes here
   };
   const unsigned char pkt_p1[] = {
-    // HEARTBEAT (0x7); flags (2 = final+big-endian); octets-to-next-header = 28
-    0x7, 2, 0,28,
+    // HEARTBEAT; flags (2 = final+big-endian); octets-to-next-header = 28
+    DDSI_RTPS_SMID_HEARTBEAT, 2, 0,28,
     SER32BE (DDSI_ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_READER),
     SER32BE (DDSI_ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_WRITER),
     SER32BE (0), SER32BE (1), // min seq number 1 \_ empty WHC
@@ -393,9 +394,9 @@ static void ddsi_plist_leasedur_new_proxyrd_impl (bool include_lease_duration)
     SER32BE (1) // count
   };
   const unsigned char pkt_p2[] = {
-    // DATA (0x15); flags (4 = dataflag + big-endian); octets-to-next-header = 0
+    // DATA: flags (4 = dataflag + big-endian); octets-to-next-header = 0
     // means it continues until the end
-    0x15, 4, 0,0,
+    DDSI_RTPS_SMID_DATA, 4, 0,0,
     0,0, // extra flags
     0,16, // octets to inline QoS (no inline qos here, so: to payload)
     SER32BE (DDSI_ENTITYID_UNKNOWN),

--- a/src/core/ddsi/tests/plist_leasedur.c
+++ b/src/core/ddsi/tests/plist_leasedur.c
@@ -11,15 +11,23 @@
  */
 
 #include "CUnit/Theory.h"
+#include "dds/ddsrt/cdtors.h"
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/endian.h"
+#include "dds/ddsrt/environ.h"
+#include "dds/ddsi/ddsi_iid.h"
+#include "dds/ddsi/ddsi_proxy_participant.h"
+#include "dds/ddsi/ddsi_entity_index.h"
 #include "dds/ddsi/ddsi_domaingv.h"
 #include "dds/ddsi/ddsi_thread.h"
 #include "dds/ddsi/ddsi_init.h"
+#include "ddsi__participant.h"
 #include "ddsi__plist.h"
 #include "ddsi__radmin.h"
 #include "ddsi__xmsg.h"
 #include "ddsi__vendor.h"
+#include "ddsi__receive.h"
+#include "ddsi__tran.h"
 #include "mem_ser.h"
 
 /* We already used "liveliness" for participant lease durations in the API
@@ -87,20 +95,32 @@ static const enum ddsi_plist_context_kind contexts[] = {
   DDSI_PLIST_CONTEXT_ENDPOINT
 };
 
+static struct ddsi_cfgst *cfgst;
 static struct ddsi_domaingv gv;
+static struct ddsi_rbufpool *rbufpool;
 
 static void setup (void)
 {
+  ddsrt_init ();
+  ddsi_iid_init ();
   ddsi_thread_states_init ();
-  ddsi_config_init_default (&gv.config);
-  ddsi_config_prep (&gv, NULL);
+  const char *config = "";
+  (void) ddsrt_getenv ("CYCLONEDDS_URI", &config);
+  cfgst = ddsi_config_init (config, &gv.config, 0);
+  assert (cfgst != NULL);
+  ddsi_config_prep (&gv, cfgst);
+  rbufpool = ddsi_rbufpool_new (&gv.logconfig, 131072, 65536);
   ddsi_init (&gv);
 }
 
 static void teardown (void)
 {
   ddsi_fini (&gv);
+  ddsi_rbufpool_free (rbufpool);
+  ddsi_config_fini (cfgst);
+  ddsi_iid_fini ();
   ddsi_thread_states_fini ();
+  ddsrt_fini ();
 }
 
 CU_Test (ddsi_plist_leasedur, deser, .init = setup, .fini = teardown)
@@ -187,4 +207,274 @@ CU_Test (ddsi_plist_leasedur, ser_sedp, .init = setup, .fini = teardown)
 
   ddsi_plist_fini (&plist);
   ddsi_xmsg_free (m);
+}
+
+#define UDPLOCATOR(a,b,c,d,port) \
+  SER32BE (DDSI_LOCATOR_KIND_UDPv4), \
+  SER32BE(port), \
+  SER32BE(0),SER32BE(0),SER32BE(0), \
+  (a),(b),(c),(d)
+
+#define TEST_GUIDPREFIX_BYTES 7,7,3,4, 5,6,7,8, 9,10,11,12
+
+static void setup_and_start (void)
+{
+  setup ();
+  ddsi_set_deafmute (&gv, true, true, DDS_INFINITY);
+  ddsi_start (&gv);
+  // Register the main thread, then claim it as spawned by Cyclone because the
+  // internal processing has various asserts that it isn't an application thread
+  // doing the dirty work
+  struct ddsi_thread_state * const thrst = ddsi_lookup_thread_state ();
+  assert (thrst->state == DDSI_THREAD_STATE_LAZILY_CREATED);
+  thrst->state = DDSI_THREAD_STATE_ALIVE;
+  ddsrt_atomic_stvoidp (&thrst->gv, &gv);
+}
+
+static void stop_and_teardown (void)
+{
+  // Shutdown currently relies on sending packets to shutdown receiver threads
+  // handling individual sockets (this sometime causes issues with firewalls, too)
+  ddsi_set_deafmute (&gv, false, false, DDS_INFINITY);
+  // On shutdown there is an expectation that the thread was discovered dynamically.
+  // We overrode it in the setup code, we undo it now.
+  struct ddsi_thread_state * const thrst = ddsi_lookup_thread_state ();
+  thrst->state = DDSI_THREAD_STATE_LAZILY_CREATED;
+  ddsi_stop (&gv);
+  teardown ();
+}
+
+static void ddsi_plist_leasedur_new_proxypp_impl (bool include_lease_duration)
+{
+  struct ddsi_thread_state * const thrst = ddsi_lookup_thread_state ();
+  const uint32_t port = gv.loc_meta_uc.port;
+
+  // not static nor const: we need to patch in the port number
+  unsigned char pkt_header[] = {
+    'R', 'T', 'P', 'S', DDSI_RTPS_MAJOR, DDSI_RTPS_MINOR,
+    // vendor id: major 1 is a given
+    1, DDSI_VENDORID_MINOR_ECLIPSE,
+    // GUID prefix: first two bytes ordinarily have vendor id, so 7,7 is
+    // guaranteed to not be used locally
+    TEST_GUIDPREFIX_BYTES,
+    // DATA (0x15); flags (4 = dataflag + big-endian); octets-to-next-header = 0
+    // means it continues until the end
+    0x15, 4, 0,0,
+    0,0, // extra flags
+    0,16, // octets to inline QoS (no inline qos here, so: to payload)
+    SER32BE (DDSI_ENTITYID_UNKNOWN),
+    SER32BE (DDSI_ENTITYID_SPDP_BUILTIN_PARTICIPANT_WRITER),
+    SER32BE (0), SER32BE (1), // seq number 1
+    0,2, // PL_CDR_BE
+    0,0, // options = 0
+    HDR (DDSI_PID_PARTICIPANT_GUID, 16),
+      TEST_GUIDPREFIX_BYTES, SER32BE (DDSI_ENTITYID_PARTICIPANT),
+    HDR (DDSI_PID_BUILTIN_ENDPOINT_SET, 4),         SER32BE (DDSI_DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_ANNOUNCER),
+    HDR (DDSI_PID_PROTOCOL_VERSION, 4),             DDSI_RTPS_MAJOR, DDSI_RTPS_MINOR, 0,0,
+    HDR (DDSI_PID_VENDORID, 4),                     1, DDSI_VENDORID_MINOR_ECLIPSE, 0,0,
+    HDR (DDSI_PID_DEFAULT_UNICAST_LOCATOR, 24),     UDPLOCATOR (127,0,0,1, port),
+    HDR (DDSI_PID_METATRAFFIC_UNICAST_LOCATOR, 24), UDPLOCATOR (127,0,0,1, port)
+  };
+  unsigned char pkt_leasedur[] = {
+    HDR (DDSI_PID_PARTICIPANT_LEASE_DURATION, 8),   SER32BE (3), SER32BE (0x12345679),
+  };
+  unsigned char pkt_trailer[] = {
+    SENTINEL
+  };
+  ddsi_locator_t srcloc;
+  ddsi_conn_locator (gv.xmit_conns[0], &srcloc);
+  const ddsi_guid_t proxypp_guid = {
+    .prefix = ddsi_ntoh_guid_prefix ((ddsi_guid_prefix_t){ .s = { TEST_GUIDPREFIX_BYTES } }),
+    .entityid = { .u = DDSI_ENTITYID_PARTICIPANT }
+  };
+
+  // Process the packet we so carefully constructed above as if it was received
+  // over the network.  Stack is deaf (and mute), so there is no risk that the
+  // message gets dropped because some buffer is full
+  struct ddsi_rmsg *rmsg = ddsi_rmsg_new (rbufpool);
+  unsigned char *buf = (unsigned char *) DDSI_RMSG_PAYLOAD (rmsg);
+  size_t size = 0;
+  memcpy (buf, pkt_header, sizeof (pkt_header));
+  size += sizeof (pkt_header);
+  if (include_lease_duration)
+  {
+    memcpy (buf + size, pkt_leasedur, sizeof (pkt_leasedur));
+    size += sizeof (pkt_leasedur);
+  }
+  memcpy (buf + size, pkt_trailer, sizeof (pkt_trailer));
+  size += sizeof (pkt_trailer);
+  ddsi_rmsg_setsize (rmsg, (uint32_t) size);
+  ddsi_handle_rtps_message (thrst, &gv, gv.data_conn_uc, NULL, rbufpool, rmsg, size, buf, &srcloc);
+  ddsi_rmsg_commit (rmsg);
+
+  // Discovery data processing is done by the dq.builtin thread, so we can't be
+  // sure the SPDP message gets processed immediately.  Polling seems reasonable
+  const dds_time_t tend = dds_time () + DDS_SECS (10);
+  struct ddsi_proxy_participant *proxypp = NULL;
+  ddsi_thread_state_awake (thrst, &gv);
+  while (proxypp == NULL && dds_time () < tend)
+  {
+    ddsi_thread_state_asleep (thrst);
+    dds_sleepfor (DDS_MSECS (10));
+    ddsi_thread_state_awake (thrst, &gv);
+    proxypp = ddsi_entidx_lookup_proxy_participant_guid (gv.entity_index, &proxypp_guid);
+  }
+
+  // After waiting for a reasonable amount of time, the (fake) proxy participant
+  // should exist and have picked up the lease duration from the message
+  CU_ASSERT_FATAL (proxypp != NULL);
+  assert (proxypp); // for gcc/clang static analyzer
+  CU_ASSERT_FATAL (proxypp->plist->qos.present & DDSI_QP_LIVELINESS);
+  CU_ASSERT_FATAL (proxypp->plist->qos.liveliness.kind == DDS_LIVELINESS_AUTOMATIC);
+  if (include_lease_duration) {
+    CU_ASSERT_FATAL (proxypp->plist->qos.liveliness.lease_duration == 3071111111);
+  } else {
+    CU_ASSERT_FATAL (proxypp->plist->qos.liveliness.lease_duration == DDS_SECS (100));
+  }
+  CU_ASSERT_FATAL (proxypp->lease->tdur == proxypp->plist->qos.liveliness.lease_duration);
+  ddsi_thread_state_asleep (thrst);
+}
+
+CU_Test (ddsi_plist_leasedur, new_proxypp, .init = setup_and_start, .fini = stop_and_teardown)
+{
+  ddsi_plist_leasedur_new_proxypp_impl (true);
+}
+
+CU_Test (ddsi_plist_leasedur, new_proxypp_def, .init = setup_and_start, .fini = stop_and_teardown)
+{
+  ddsi_plist_leasedur_new_proxypp_impl (false);
+}
+
+static void ddsi_plist_leasedur_new_proxyrd_impl (bool include_lease_duration)
+{
+  struct ddsi_thread_state * const thrst = ddsi_lookup_thread_state ();
+
+  ddsi_guid_t ppguid;
+  ddsi_plist_t plist;
+  ddsi_plist_init_empty (&plist);
+  plist.qos.present |= DDSI_QP_LIVELINESS;
+  plist.qos.liveliness.kind = DDS_LIVELINESS_AUTOMATIC;
+  plist.qos.liveliness.lease_duration = DDS_SECS (10);
+  ddsi_thread_state_awake (thrst, &gv);
+  dds_return_t ret = ddsi_new_participant (&ppguid, &gv, RTPS_PF_PRIVILEGED_PP | RTPS_PF_IS_DDSI2_PP, &plist);
+  ddsi_thread_state_asleep (thrst);
+  CU_ASSERT_FATAL (ret >= 0);
+  ddsi_plist_fini (&plist);
+
+  // not static nor const: we need to patch in the port number
+  const unsigned char pkt_p0[] = {
+    'R', 'T', 'P', 'S', DDSI_RTPS_MAJOR, DDSI_RTPS_MINOR,
+    // vendor id: major 1 is a given
+    1, DDSI_VENDORID_MINOR_ECLIPSE,
+    // GUID prefix: first two bytes ordinarily have vendor id, so 7,7 is
+    // guaranteed to not be used locally
+    TEST_GUIDPREFIX_BYTES,
+    // INFO_DST (0xe); flags (0 = big-endian); octets-to-next-header = 12
+    0xe, 0, 0,12
+    // guid prefix of local node (= ppguidprefix_base) comes here
+  };
+  const unsigned char pkt_p1[] = {
+    // HEARTBEAT (0x7); flags (2 = final+big-endian); octets-to-next-header = 28
+    0x7, 2, 0,28,
+    SER32BE (DDSI_ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_READER),
+    SER32BE (DDSI_ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_WRITER),
+    SER32BE (0), SER32BE (1), // min seq number 1 \_ empty WHC
+    SER32BE (0), SER32BE (0), // max seq number 0 /
+    SER32BE (1) // count
+  };
+  const unsigned char pkt_p2[] = {
+    // DATA (0x15); flags (4 = dataflag + big-endian); octets-to-next-header = 0
+    // means it continues until the end
+    0x15, 4, 0,0,
+    0,0, // extra flags
+    0,16, // octets to inline QoS (no inline qos here, so: to payload)
+    SER32BE (DDSI_ENTITYID_UNKNOWN),
+    SER32BE (DDSI_ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_WRITER),
+    SER32BE (0), SER32BE (1), // seq number 1
+    0,2, // PL_CDR_BE
+    0,0, // options = 0
+    HDR (DDSI_PID_ENDPOINT_GUID, 16),
+      TEST_GUIDPREFIX_BYTES, SER32BE (0x107), // reader-with-key
+    HDR (DDSI_PID_TOPIC_NAME, 12), SER32BE (6), 't','o','p','i','c',0, 0,0,
+    HDR (DDSI_PID_TYPE_NAME, 12),  SER32BE (5), 't','y','p','e',0,   0,0,0,
+  };
+  unsigned char pkt_p3[] = {
+    HDR (DDSI_PID_LIVELINESS, 12),
+      SER32BE (DDS_LIVELINESS_MANUAL_BY_PARTICIPANT),
+      SER32BE (2), SER32BE (0x0abcdefb),
+  };
+  unsigned char pkt_p4[] = {
+    SENTINEL
+  };
+  ddsi_locator_t srcloc;
+  ddsi_conn_locator (gv.xmit_conns[0], &srcloc);
+  const ddsi_guid_t prd_guid = {
+    .prefix = ddsi_ntoh_guid_prefix ((ddsi_guid_prefix_t){ .s = { TEST_GUIDPREFIX_BYTES } }),
+    .entityid = { .u = 0x107 }
+  };
+
+  // Process the packet we so carefully constructed above as if it was received
+  // over the network.  Stack is deaf (and mute), so there is no risk that the
+  // message gets dropped because some buffer is full
+  struct ddsi_rmsg *rmsg = ddsi_rmsg_new (rbufpool);
+  unsigned char *buf = (unsigned char *) DDSI_RMSG_PAYLOAD (rmsg);
+  size_t size = 0;
+  memcpy (buf + size, pkt_p0, sizeof (pkt_p0));
+  size += sizeof (pkt_p0);
+  ddsi_guid_prefix_t ppguidprefix = ddsi_hton_guid_prefix (ppguid.prefix);
+  memcpy (buf + size, &ppguidprefix, sizeof (ppguidprefix));
+  size += sizeof (ppguidprefix);
+  memcpy (buf + size, pkt_p1, sizeof (pkt_p1));
+  size += sizeof (pkt_p1);
+  memcpy (buf + size, pkt_p2, sizeof (pkt_p2));
+  size += sizeof (pkt_p2);
+  if (include_lease_duration)
+  {
+    memcpy (buf + size, pkt_p3, sizeof (pkt_p3));
+    size += sizeof (pkt_p3);
+  }
+  memcpy (buf + size, pkt_p4, sizeof (pkt_p4));
+  size += sizeof (pkt_p4);
+  ddsi_rmsg_setsize (rmsg, (uint32_t) size);
+  ddsi_handle_rtps_message (thrst, &gv, gv.data_conn_uc, NULL, rbufpool, rmsg, size, buf, &srcloc);
+  ddsi_rmsg_commit (rmsg);
+
+  // Discovery data processing is done by the dq.builtin thread, so we can't be
+  // sure the SEDP message gets processed immediately.  Polling seems reasonable
+  const dds_time_t tend = dds_time () + DDS_SECS (10);
+  struct ddsi_proxy_reader *prd = NULL;
+  ddsi_thread_state_awake (thrst, &gv);
+  while (prd == NULL && dds_time () < tend)
+  {
+    ddsi_thread_state_asleep (thrst);
+    dds_sleepfor (DDS_MSECS (10));
+    ddsi_thread_state_awake (thrst, &gv);
+    prd = ddsi_entidx_lookup_proxy_reader_guid (gv.entity_index, &prd_guid);
+  }
+
+  // After waiting for a reasonable amount of time, the (fake) proxy participant
+  // should exist and have picked up the lease duration from the message
+  CU_ASSERT_FATAL (prd != NULL);
+  assert (prd); // for gcc/clang static analyzer
+  CU_ASSERT_FATAL (prd->c.xqos->present & DDSI_QP_LIVELINESS);
+  if (include_lease_duration) {
+    CU_ASSERT (prd->c.xqos->liveliness.kind == DDS_LIVELINESS_MANUAL_BY_PARTICIPANT);
+    CU_ASSERT (prd->c.xqos->liveliness.lease_duration == 2041944443);
+  } else {
+    CU_ASSERT (prd->c.xqos->liveliness.kind == DDS_LIVELINESS_AUTOMATIC);
+    CU_ASSERT (prd->c.xqos->liveliness.lease_duration == DDS_INFINITY);
+  }
+  ddsi_thread_state_asleep (thrst);
+}
+
+CU_Test (ddsi_plist_leasedur, new_proxyrd, .init = setup_and_start, .fini = stop_and_teardown)
+{
+  ddsi_plist_leasedur_new_proxypp_impl (false);
+  ddsi_plist_leasedur_new_proxyrd_impl (true);
+}
+
+CU_Test (ddsi_plist_leasedur, new_proxyrd_def, .init = setup_and_start, .fini = stop_and_teardown)
+{
+  ddsi_plist_leasedur_new_proxypp_impl (false);
+  ddsi_plist_leasedur_new_proxyrd_impl (false);
 }

--- a/src/core/ddsi/tests/plist_leasedur.c
+++ b/src/core/ddsi/tests/plist_leasedur.c
@@ -1,0 +1,190 @@
+/*
+ * Copyright(c) 2019 to 2020 ZettaScale Technology and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+#include "CUnit/Theory.h"
+#include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/endian.h"
+#include "dds/ddsi/ddsi_domaingv.h"
+#include "dds/ddsi/ddsi_thread.h"
+#include "dds/ddsi/ddsi_init.h"
+#include "ddsi__plist.h"
+#include "ddsi__radmin.h"
+#include "ddsi__xmsg.h"
+#include "ddsi__vendor.h"
+#include "mem_ser.h"
+
+/* We already used "liveliness" for participant lease durations in the API
+   (including the built-in topics), and now dropped the "participant lease
+   duration" everywhere *except* in the (de)serialisation code.
+
+   That means the discovery (de)serializer is now aware of whether it is
+   processing SPDP or SEDP data, and now needs to ignore DDSI_PI_LIVELINESS
+   for SPDP and ignore DDSI_PI_PARTICIPANT_LEASE_DURATION for SEDP, because
+   they both map to the liveliness QoS setting.
+
+   - Use big-endian for convenience, that way the parameter header is:
+
+     (id << 16) | length
+
+   and this test isn't concerned with byte-swapping anyway
+
+   - lease duration is seconds, fraction
+   - liveliness is kind, seconds, fraction */
+#define HDR(id, len) SER32BE(((uint32_t)(id) << 16) | (uint32_t)(len))
+#define SENTINEL     HDR(DDSI_PID_SENTINEL, 0)
+#define RLD(s, f)    SER32BE((uint32_t)s), SER32BE((uint32_t)f)
+#define RLL(k, s, f) SER32BE((uint32_t)(k)), RLD(s, f)
+#define LD(s, f)     HDR(DDSI_PID_PARTICIPANT_LEASE_DURATION, 8), RLD(s, f)
+#define LL(k, s, f)  HDR(DDSI_PID_LIVELINESS, 12), RLL(k, s, f)
+
+struct plist_valid {
+  bool valid;
+  bool present;
+  dds_liveliness_kind_t kind;
+  dds_duration_t lease_duration;
+};
+struct plist_cdr {
+  struct plist_valid exp[2]; // SPDP, SEDP
+  unsigned char cdr[44];
+};
+static const struct plist_cdr plists[] = {
+  { { { true, true, DDS_LIVELINESS_AUTOMATIC, 3071111111 },
+      { true, false, (dds_liveliness_kind_t)0, 0 } },
+    { LD(3,0x12345679), SENTINEL } },
+  { { { true, false, (dds_liveliness_kind_t)0, 0 },
+      { true, true, DDS_LIVELINESS_MANUAL_BY_PARTICIPANT, 2041944443 } },
+    { LL(1, 2,0x0abcdefb), SENTINEL } },
+  { { { true, true, DDS_LIVELINESS_AUTOMATIC, 3071111111 },
+      { true, true, DDS_LIVELINESS_MANUAL_BY_PARTICIPANT, 2041944443 } },
+    { LD(3,0x12345679), LL(1, 2,0x0abcdefb), SENTINEL } },
+  { { { true, true, DDS_LIVELINESS_AUTOMATIC, 3071111111 },
+      { true, true, DDS_LIVELINESS_MANUAL_BY_PARTICIPANT, 2041944443 } },
+    { LL(1, 2,0x0abcdefb), LD(3,0x12345679), SENTINEL } },
+  { // invalid for SPDP because there are two copies of lease duration,
+    // SEDP ignores those and so accepts it
+    { { false, false, (dds_liveliness_kind_t)0, 0 },
+      { true,  false, (dds_liveliness_kind_t)0, 0 } },
+    { LD(3,0x12345679), LD(4,0x12345679), SENTINEL } },
+  { // invalid for SEDP because there are two copies of liveliness,
+    // SPDP ignores those and so accepts it
+    { { true, false, (dds_liveliness_kind_t)0, 0 },
+      { false, false, (dds_liveliness_kind_t)0, 0 } },
+    { LL(1, 2,0x0abcdefb), LL(1, 5,0x0abcdefb), SENTINEL } },
+};
+
+// context table order must match use in plists[i].valid
+static const enum ddsi_plist_context_kind contexts[] = {
+  DDSI_PLIST_CONTEXT_PARTICIPANT,
+  DDSI_PLIST_CONTEXT_ENDPOINT
+};
+
+static struct ddsi_domaingv gv;
+
+static void setup (void)
+{
+  ddsi_thread_states_init ();
+  ddsi_config_init_default (&gv.config);
+  ddsi_config_prep (&gv, NULL);
+  ddsi_init (&gv);
+}
+
+static void teardown (void)
+{
+  ddsi_fini (&gv);
+  ddsi_thread_states_fini ();
+}
+
+CU_Test (ddsi_plist_leasedur, deser, .init = setup, .fini = teardown)
+{
+  for (size_t j = 0; j < sizeof (contexts) / sizeof (contexts[0]); j++)
+  {
+    for (size_t i = 0; i < sizeof (plists) / sizeof (plists[0]); i++)
+    {
+      ddsi_plist_src_t src = {
+        .protocol_version = {2, 1},
+        .vendorid = DDSI_VENDORID_ECLIPSE,
+        .encoding = DDSI_RTPS_PL_CDR_BE,
+        .buf = plists[i].cdr,
+        .bufsz = sizeof (plists[i].cdr),
+        .strict = true
+      };
+      ddsi_plist_t plist;
+      dds_return_t ret;
+
+      struct plist_valid const * const exp = &plists[i].exp[j];
+      ret = ddsi_plist_init_frommsg (&plist, NULL, ~(uint64_t)0, ~(uint64_t)0, &src, &gv, contexts[j]);
+      CU_ASSERT_FATAL ((ret == 0) == exp->valid);
+      if (exp->valid)
+      {
+        CU_ASSERT_FATAL (plist.present == 0 && plist.aliased == 0);
+        CU_ASSERT_FATAL (((plist.qos.present & DDSI_QP_LIVELINESS) != 0) == exp->present);
+        CU_ASSERT_FATAL (plist.qos.aliased == 0);
+        if (exp->present)
+        {
+          CU_ASSERT_FATAL (plist.qos.liveliness.kind == exp->kind);
+          CU_ASSERT_FATAL (plist.qos.liveliness.lease_duration == exp->lease_duration);
+        }
+        ddsi_plist_fini (&plist);
+      }
+    }
+  }
+}
+
+CU_Test (ddsi_plist_leasedur, ser_spdp, .init = setup, .fini = teardown)
+{
+  ddsi_guid_t guid;
+  memset (&guid, 0, sizeof (guid));
+  struct ddsi_xmsg *m = ddsi_xmsg_new (gv.xmsgpool, &guid, NULL, 64, DDSI_XMSG_KIND_DATA);
+  CU_ASSERT_FATAL (m != NULL);
+  struct ddsi_xmsg_marker marker;
+  (void) ddsi_xmsg_append (m, &marker, 0);
+
+  ddsi_plist_t plist;
+  ddsi_plist_init_empty (&plist);
+  plist.qos.present |= DDSI_QP_LIVELINESS;
+  plist.qos.liveliness.kind = DDS_LIVELINESS_AUTOMATIC;
+  plist.qos.liveliness.lease_duration = 3071111111;
+  ddsi_plist_addtomsg_bo (m, &plist, 0, DDSI_QP_LIVELINESS, DDSRT_BOSEL_BE, DDSI_PLIST_CONTEXT_PARTICIPANT);
+  ddsi_xmsg_addpar_sentinel_bo (m, DDSRT_BOSEL_BE);
+
+  const uint8_t expected[] = { LD(3,0x12345679), SENTINEL };
+  const unsigned char *cdr = ddsi_xmsg_submsg_from_marker (m, marker);
+  CU_ASSERT (memcmp (expected, cdr, sizeof (expected)) == 0);
+
+  ddsi_plist_fini (&plist);
+  ddsi_xmsg_free (m);
+}
+
+CU_Test (ddsi_plist_leasedur, ser_sedp, .init = setup, .fini = teardown)
+{
+  ddsi_guid_t guid;
+  memset (&guid, 0, sizeof (guid));
+  struct ddsi_xmsg *m = ddsi_xmsg_new (gv.xmsgpool, &guid, NULL, 64, DDSI_XMSG_KIND_DATA);
+  CU_ASSERT_FATAL (m != NULL);
+  struct ddsi_xmsg_marker marker;
+  (void) ddsi_xmsg_append (m, &marker, 0);
+
+  ddsi_plist_t plist;
+  ddsi_plist_init_empty (&plist);
+  plist.qos.present |= DDSI_QP_LIVELINESS;
+  plist.qos.liveliness.kind = DDS_LIVELINESS_MANUAL_BY_PARTICIPANT;
+  plist.qos.liveliness.lease_duration = 2041944443;
+  ddsi_plist_addtomsg_bo (m, &plist, 0, DDSI_QP_LIVELINESS, DDSRT_BOSEL_BE, DDSI_PLIST_CONTEXT_ENDPOINT);
+  ddsi_xmsg_addpar_sentinel_bo (m, DDSRT_BOSEL_BE);
+
+  const uint8_t expected[] = { LL(1, 2,0x0abcdefb), SENTINEL };
+  const unsigned char *cdr = ddsi_xmsg_submsg_from_marker (m, marker);
+  CU_ASSERT (memcmp (expected, cdr, sizeof (expected)) == 0);
+
+  ddsi_plist_fini (&plist);
+  ddsi_xmsg_free (m);
+}

--- a/src/core/xtests/symbol_export/symbol_export.c
+++ b/src/core/xtests/symbol_export/symbol_export.c
@@ -611,7 +611,7 @@ int main (int argc, char **argv)
   ddsi_serdata_print_untyped (ptr, ptr, buf, 0);
   ddsi_serdata_get_keyhash (ptr, ptr, 0);
 #ifdef DDS_HAS_SHM
-  ddsi_serdata_iox_size (0);
+  ddsi_serdata_iox_size (ptr);
   ddsi_serdata_from_iox (ptr, 0, ptr, ptr);
   ddsi_serdata_from_loaned_sample (ptr, 0, ptr);
 #endif

--- a/src/tools/idlpp/src/expand.c
+++ b/src/tools/idlpp/src/expand.c
@@ -41,6 +41,13 @@
 #include    "internal.H"
 #endif
 
+// sprintf is slowly getting deprecated, but this is not the time to rewrite mcpp
+#if defined(__clang__) || defined(__GNUC__) && ((__GNUC__ * 100) + __GNUC_MINOR__) >= 402
+_Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#elif defined(_MSC_VER)
+__pragma(warning(disable: 4996))
+#endif
+
 #define ARG_ERROR   (-255)
 #define CERROR      1
 #define CWARN       2

--- a/src/tools/idlpp/src/system.c
+++ b/src/tools/idlpp/src/system.c
@@ -104,6 +104,13 @@
 #endif
 #endif
 
+// sprintf is slowly getting deprecated, but this is not the time to rewrite mcpp
+#if defined(__clang__) || defined(__GNUC__) && ((__GNUC__ * 100) + __GNUC_MINOR__) >= 402
+_Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#elif defined(_MSC_VER)
+__pragma(warning(disable: 4996))
+#endif
+
 static void     version( void);
                 /* Print version message            */
 static void     usage( int opt)


### PR DESCRIPTION
This reworks the code so that participants rely on the liveliness QoS setting for their lease durations in all contexts, rather than just in the API. (The spec, for some reason, doesn't use liveliness for the participant.)

The DDSI spec requires the use of a separate "participant lease duration" parameter in the participant discovery protocol, in this PR, that is handled entirely by the (de)serialisation code. That in turn requires it to be aware of whether it is dealing with SPDP data (where "participant lease duration" is a thing, and "liveliness" is not), and all other (i.e., SEDP) data (where "liveliness" is a thing and "participant lease duration" is not).

It adds some tests to ensure that the correct parameters is used in the correct context, but it doesn't yet have unit tests that show that the parameter list (de)serialisation uses the correct context in all places. Presumably the easiest way to do that is to create some entities in a two-node setting and check the built-in data. That *may* already be covered by built-in topic tests and liveliness tests, but it needs to be looked into. Hence making this a draft PR for now.