### PR TITLE
Default values as code fragment in config docs

### DIFF
--- a/docs/manual/config/config_file_reference.rst
+++ b/docs/manual/config/config_file_reference.rst
@@ -36,7 +36,7 @@ Text
 
 Domain id this configuration applies to, or "any" if it applies to all domain ids.
 
-The default value is: `any`
+The default value is: ``any``
 
 
 .. _`//CycloneDDS/Domain/Compatibility`:
@@ -58,7 +58,7 @@ Boolean
 
 This option assumes ParticipantMessageData endpoints required by the liveliness protocol are present in RTI participants even when not properly advertised by the participant discovery protocol.
 
-The default value is: `false`
+The default value is: ``false``
 
 
 .. _`//CycloneDDS/Domain/Compatibility/ExplicitlyPublishQosSetToDefault`:
@@ -72,7 +72,7 @@ This element specifies whether QoS settings set to default values are explicitly
 
 When interoperability is required with an implementation that does not follow the specifications in this regard, setting this option to true will help.
 
-The default value is: `false`
+The default value is: ``false``
 
 
 .. _`//CycloneDDS/Domain/Compatibility/ManySocketsMode`:
@@ -86,7 +86,7 @@ This option specifies whether a network socket will be created for each domain p
 
 Disabling it slightly improves performance and reduces network traffic somewhat. It also causes the set of port numbers needed by Cyclone DDS to become predictable, which may be useful for firewall and NAT configuration.
 
-The default value is: `single`
+The default value is: ``single``
 
 
 .. _`//CycloneDDS/Domain/Compatibility/StandardsConformance`:
@@ -104,7 +104,7 @@ This element sets the level of standards conformance of this instance of the Cyc
  * lax: attempt to provide the smoothest possible interoperability, anticipating future revisions of elements in the standard in areas that other implementations do not adhere to, even though there is no good reason not to.
 
 
-The default value is: `lax`
+The default value is: ``lax``
 
 
 .. _`//CycloneDDS/Domain/Discovery`:
@@ -128,7 +128,7 @@ This setting controls for how long endpoints discovered via a Cloud discovery se
 
 Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: `30 s`
+The default value is: ``30 s``
 
 
 .. _`//CycloneDDS/Domain/Discovery/DefaultMulticastAddress`:
@@ -140,7 +140,7 @@ Text
 
 This element specifies the default multicast address for all traffic other than participant discovery packets. It defaults to Discovery/SPDPMulticastAddress.
 
-The default value is: `auto`
+The default value is: ``auto``
 
 
 .. _`//CycloneDDS/Domain/Discovery/EnableTopicDiscoveryEndpoints`:
@@ -152,7 +152,7 @@ Boolean
 
 This element controls whether the built-in endpoints for topic discovery are created and used to exchange topic discovery information.
 
-The default value is: `false`
+The default value is: ``false``
 
 
 .. _`//CycloneDDS/Domain/Discovery/ExternalDomainId`:
@@ -164,7 +164,7 @@ Text
 
 An override for the domain id is used to discovery and determine the port number mapping. This allows the creating of multiple domains in a single process while making them appear as a single domain on the network. The value "default" disables the override.
 
-The default value is: `default`
+The default value is: ``default``
 
 
 .. _`//CycloneDDS/Domain/Discovery/LeaseDuration`:
@@ -177,7 +177,7 @@ Number-with-unit
 This setting controls the default participant lease duration.
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: `10 s`
+The default value is: ``10 s``
 
 
 .. _`//CycloneDDS/Domain/Discovery/MaxAutoParticipantIndex`:
@@ -189,7 +189,7 @@ Integer
 
 This element specifies the maximum DDSI participant index selected by this instance of the Cyclone DDS service if the Discovery/ParticipantIndex is "auto".
 
-The default value is: `9`
+The default value is: ``9``
 
 
 .. _`//CycloneDDS/Domain/Discovery/ParticipantIndex`:
@@ -207,7 +207,7 @@ This element specifies the DDSI participant index used by this instance of the C
  * none:, which causes it to use arbitrary port numbers for unicast sockets which entirely removes the constraints on the participant index but makes unicast discovery impossible.
 
 
-The default value is: `none`
+The default value is: ``none``
 
 
 .. _`//CycloneDDS/Domain/Discovery/Peers`:
@@ -239,7 +239,7 @@ Text
 
 This element specifies an IP address to which discovery packets must be sent, in addition to the default multicast address (see also General/AllowMulticast). Both hostnames and a numerical IP address are accepted; the hostname or IP address may be suffixed with :PORT to explicitly set the port to which it must be sent. Multiple Peers may be specified.
 
-The default value is: `<empty>`
+The default value is: ``<empty>``
 
 
 .. _`//CycloneDDS/Domain/Discovery/Ports`:
@@ -261,7 +261,7 @@ Integer
 
 This element specifies the base port number (refer to the DDSI 2.1 specification, section 9.6.1, constant PB).
 
-The default value is: `7400`
+The default value is: ``7400``
 
 
 .. _`//CycloneDDS/Domain/Discovery/Ports/DomainGain`:
@@ -273,7 +273,7 @@ Integer
 
 This element specifies the domain gain, relating domain ids to sets of port numbers (refer to the DDSI 2.1 specification, section 9.6.1, constant DG).
 
-The default value is: `250`
+The default value is: ``250``
 
 
 .. _`//CycloneDDS/Domain/Discovery/Ports/MulticastDataOffset`:
@@ -285,7 +285,7 @@ Integer
 
 This element specifies the port number for multicast data traffic (refer to the DDSI 2.1 specification, section 9.6.1, constant d2).
 
-The default value is: `1`
+The default value is: ``1``
 
 
 .. _`//CycloneDDS/Domain/Discovery/Ports/MulticastMetaOffset`:
@@ -297,7 +297,7 @@ Integer
 
 This element specifies the port number for multicast meta traffic (refer to the DDSI 2.1 specification, section 9.6.1, constant d0).
 
-The default value is: `0`
+The default value is: ``0``
 
 
 .. _`//CycloneDDS/Domain/Discovery/Ports/ParticipantGain`:
@@ -309,7 +309,7 @@ Integer
 
 This element specifies the participant gain, relating p0, participant index to sets of port numbers (refer to the DDSI 2.1 specification, section 9.6.1, constant PG).
 
-The default value is: `2`
+The default value is: ``2``
 
 
 .. _`//CycloneDDS/Domain/Discovery/Ports/UnicastDataOffset`:
@@ -321,7 +321,7 @@ Integer
 
 This element specifies the port number for unicast data traffic (refer to the DDSI 2.1 specification, section 9.6.1, constant d3).
 
-The default value is: `11`
+The default value is: ``11``
 
 
 .. _`//CycloneDDS/Domain/Discovery/Ports/UnicastMetaOffset`:
@@ -333,7 +333,7 @@ Integer
 
 This element specifies the port number for unicast meta traffic (refer to the DDSI 2.1 specification, section 9.6.1, constant d1).
 
-The default value is: `10`
+The default value is: ``10``
 
 
 .. _`//CycloneDDS/Domain/Discovery/SPDPInterval`:
@@ -347,7 +347,7 @@ This element specifies the interval between spontaneous transmissions of partici
 
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: `30 s`
+The default value is: ``30 s``
 
 
 .. _`//CycloneDDS/Domain/Discovery/SPDPMulticastAddress`:
@@ -359,7 +359,7 @@ Text
 
 This element specifies the multicast address used as the destination for the participant discovery packets. In IPv4 mode the default is the (standardised) 239.255.0.1, in IPv6 mode it becomes ff02::ffff:239.255.0.1, which is a non-standardised link-local multicast address.
 
-The default value is: `239.255.0.1`
+The default value is: ``239.255.0.1``
 
 
 .. _`//CycloneDDS/Domain/Discovery/Tag`:
@@ -371,7 +371,7 @@ Text
 
 String extension for domain id that remote participants must match to be discovered.
 
-The default value is: `<empty>`
+The default value is: ``<empty>``
 
 
 .. _`//CycloneDDS/Domain/General`:
@@ -409,7 +409,7 @@ When set to "false" all multicasting is disabled. The default, "true" enables th
 
 "default" maps on spdp if the network is a WiFi network, on true if it is a wired network
 
-The default value is: `default`
+The default value is: ``default``
 
 
 .. _`//CycloneDDS/Domain/General/DontRoute`:
@@ -421,7 +421,7 @@ Boolean
 
 This element allows setting the SO\_DONTROUTE option for outgoing packets to bypass the local routing tables. This is generally useful only when the routing tables cannot be trusted, which is highly unusual.
 
-The default value is: `false`
+The default value is: ``false``
 
 
 .. _`//CycloneDDS/Domain/General/EnableMulticastLoopback`:
@@ -433,7 +433,7 @@ Boolean
 
 This element specifies whether Cyclone DDS allows IP multicast packets to be visible to all DDSI participants in the same node, including itself. It must be "true" for intra-node multicast communications. However, if a node runs only a single Cyclone DDS service and does not host any other DDSI-capable programs, it should be set to "false" for improved performance.
 
-The default value is: `true`
+The default value is: ``true``
 
 
 .. _`//CycloneDDS/Domain/General/EntityAutoNaming`:
@@ -447,7 +447,7 @@ One of: empty, fancy
 
 This element specifies the entity autonaming mode. By default set to 'empty' which means no name will be set (but you can still use dds\_qset\_entity\_name). When set to 'fancy' participants, publishers, subscribers, writers, and readers will get randomly generated names. An autonamed entity will share a 3-letter prefix with their parent entity.
 
-The default value is: `empty`
+The default value is: ``empty``
 
 
 .. _`//CycloneDDS/Domain/General/EntityAutoNaming[@seed]`:
@@ -459,7 +459,7 @@ Text
 
 Provide an initial seed for the entity naming. Your string will be hashed to provide the random state. When provided, the same sequence of names is generated every run. Creating your entities in the same order will ensure they are the same between runs. If you run multiple nodes, set this via environment variable to ensure every node generates unique names. A random starting seed is chosen when left empty, (the default). 
 
-The default value is: `<empty>`
+The default value is: ``<empty>``
 
 
 .. _`//CycloneDDS/Domain/General/ExternalNetworkAddress`:
@@ -471,7 +471,7 @@ Text
 
 This element allows explicitly overruling the network address Cyclone DDS advertises in the discovery protocol, which by default is the address of the preferred network interface (General/NetworkInterfaceAddress), to allow Cyclone DDS to communicate across a Network Address Translation (NAT) device.
 
-The default value is: `auto`
+The default value is: ``auto``
 
 
 .. _`//CycloneDDS/Domain/General/ExternalNetworkMask`:
@@ -483,7 +483,7 @@ Text
 
 This element specifies the network mask of the external network address. This element is relevant only when an external network address (General/ExternalNetworkAddress) is explicitly configured. In this case locators received via the discovery protocol that are within the same external subnet (as defined by this mask) will be translated to an internal address by replacing the network portion of the external address with the corresponding portion of the preferred network interface address. This option is IPv4-only.
 
-The default value is: `0.0.0.0`
+The default value is: ``0.0.0.0``
 
 
 .. _`//CycloneDDS/Domain/General/FragmentSize`:
@@ -497,7 +497,7 @@ This element specifies the size of DDSI sample fragments generated by Cyclone DD
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: `1344 B`
+The default value is: ``1344 B``
 
 
 .. _`//CycloneDDS/Domain/General/Interfaces`:
@@ -529,7 +529,7 @@ Text
 
 This attribute specifies the address of the interface. With ipv4 allows  matching on the network part if the host part is set to zero. 
 
-The default value is: `<empty>`
+The default value is: ``<empty>``
 
 
 .. _`//CycloneDDS/Domain/General/Interfaces/NetworkInterface[@autodetermine]`:
@@ -541,7 +541,7 @@ Text
 
 If set to "true" an interface is automatically selected. Specifying a name or an address when automatic is set is considered an error.
 
-The default value is: `false`
+The default value is: ``false``
 
 
 .. _`//CycloneDDS/Domain/General/Interfaces/NetworkInterface[@multicast]`:
@@ -552,7 +552,7 @@ The default value is: `false`
 Text
 
 This attribute specifies whether the interface should use multicast. On its default setting, 'default', it will use the value as return by the operating system. If set to 'true', the interface will be assumed to be multicast capable even when the interface flags returned by the operating system state it is not (this provides a workaround for some platforms). If set to 'false', the interface will never be used for multicast.
-The default value is: `default`
+The default value is: ``default``
 
 
 .. _`//CycloneDDS/Domain/General/Interfaces/NetworkInterface[@name]`:
@@ -564,7 +564,7 @@ Text
 
 This attribute specifies the name of the interface. 
 
-The default value is: `<empty>`
+The default value is: ``<empty>``
 
 
 .. _`//CycloneDDS/Domain/General/Interfaces/NetworkInterface[@prefer_multicast]`:
@@ -576,7 +576,7 @@ Boolean
 
 When false (default), Cyclone DDS uses unicast for data whenever a single unicast suffices. Setting this to true makes it prefer multicasting data, falling back to unicast only when no multicast is available.
 
-The default value is: `false`
+The default value is: ``false``
 
 
 .. _`//CycloneDDS/Domain/General/Interfaces/NetworkInterface[@presence_required]`:
@@ -588,7 +588,7 @@ Boolean
 
 By default, all specified network interfaces must be present; if they are missing Cyclone will not start. By explicitly setting this setting for an interface, you can instruct Cyclone to ignore that interface if it is not present.
 
-The default value is: `true`
+The default value is: ``true``
 
 
 .. _`//CycloneDDS/Domain/General/Interfaces/NetworkInterface[@priority]`:
@@ -600,7 +600,7 @@ Text
 
 This attribute specifies the interface priority (decimal integer or default). The default value for loopback interfaces is 2, for all other interfaces it is 0.
 
-The default value is: `default`
+The default value is: ``default``
 
 
 .. _`//CycloneDDS/Domain/General/MaxMessageSize`:
@@ -616,7 +616,7 @@ On some networks it may be necessary to set this item to keep the packetsize bel
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: `14720 B`
+The default value is: ``14720 B``
 
 
 .. _`//CycloneDDS/Domain/General/MaxRexmitMessageSize`:
@@ -632,7 +632,7 @@ On some networks it may be necessary to set this item to keep the packetsize bel
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: `1456 B`
+The default value is: ``1456 B``
 
 
 .. _`//CycloneDDS/Domain/General/MulticastRecvNetworkInterfaceAddresses`:
@@ -658,7 +658,7 @@ This element specifies which network interfaces Cyclone DDS listens to multicast
 
 If Cyclone DDS is in IPv6 mode and the address of the preferred network interface is a link-local address, "all" is treated as a synonym for "preferred" and a comma-separated list is treated as "preferred" if it contains the preferred interface and as "none" if not.
 
-The default value is: `preferred`
+The default value is: ``preferred``
 
 
 .. _`//CycloneDDS/Domain/General/MulticastTimeToLive`:
@@ -670,7 +670,7 @@ Integer
 
 This element specifies the time-to-live setting for outgoing multicast packets.
 
-The default value is: `32`
+The default value is: ``32``
 
 
 .. _`//CycloneDDS/Domain/General/RedundantNetworking`:
@@ -682,7 +682,7 @@ Boolean
 
 When enabled, use selected network interfaces in parallel for redundancy.
 
-The default value is: `false`
+The default value is: ``false``
 
 
 .. _`//CycloneDDS/Domain/General/Transport`:
@@ -694,7 +694,7 @@ One of: default, udp, udp6, tcp, tcp6, raweth
 
 This element allows selecting the transport to be used (udp, udp6, tcp, tcp6, raweth)
 
-The default value is: `default`
+The default value is: ``default``
 
 
 .. _`//CycloneDDS/Domain/General/UseIPv6`:
@@ -706,7 +706,7 @@ One of: false, true, default
 
 Deprecated (use Transport instead)
 
-The default value is: `default`
+The default value is: ``default``
 
 
 .. _`//CycloneDDS/Domain/Internal`:
@@ -728,7 +728,7 @@ Integer
 
 Proxy readers that are assumed to still be retrieving historical data get this many samples retransmitted when they NACK something, even if some of these samples have sequence numbers outside the set covered by the NACK.
 
-The default value is: `0`
+The default value is: ``0``
 
 
 .. _`//CycloneDDS/Domain/Internal/AckDelay`:
@@ -742,7 +742,7 @@ This setting controls the delay between sending identical acknowledgements.
 
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: `10 ms`
+The default value is: ``10 ms``
 
 
 .. _`//CycloneDDS/Domain/Internal/AutoReschedNackDelay`:
@@ -756,7 +756,7 @@ This setting controls the interval with which a reader will continue NACK'ing mi
 
 Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: `3 s`
+The default value is: ``3 s``
 
 
 .. _`//CycloneDDS/Domain/Internal/BuiltinEndpointSet`:
@@ -776,7 +776,7 @@ This element controls which participants will have which built-in endpoints for 
 
 The default is writers, as this is thought to be compliant and reasonably efficient. Minimal may or may not be compliant but is most efficient, and full is inefficient but certain to be compliant.
 
-The default value is: `writers`
+The default value is: ``writers``
 
 
 .. _`//CycloneDDS/Domain/Internal/BurstSize`:
@@ -800,7 +800,7 @@ This element specifies how much more than the (presumed or discovered) receive b
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: `4294967295`
+The default value is: ``4294967295``
 
 
 .. _`//CycloneDDS/Domain/Internal/BurstSize/MaxRexmit`:
@@ -814,7 +814,7 @@ This element specifies the amount of data to be retransmitted in response to one
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: `1 MiB`
+The default value is: ``1 MiB``
 
 
 .. _`//CycloneDDS/Domain/Internal/ControlTopic`:
@@ -834,7 +834,7 @@ Integer
 
 This element sets the maximum number of extra threads for an experimental, undocumented, and unsupported direct mode.
 
-The default value is: `1`
+The default value is: ``1``
 
 
 .. _`//CycloneDDS/Domain/Internal/DefragReliableMaxSamples`:
@@ -846,7 +846,7 @@ Integer
 
 This element sets the maximum number of samples that can be defragmented simultaneously for a reliable writer. This has to be large enough to handle retransmissions of historical data in addition to new samples.
 
-The default value is: `16`
+The default value is: ``16``
 
 
 .. _`//CycloneDDS/Domain/Internal/DefragUnreliableMaxSamples`:
@@ -858,7 +858,7 @@ Integer
 
 This element sets the maximum number of samples that can be defragmented simultaneously for best-effort writers.
 
-The default value is: `4`
+The default value is: ``4``
 
 
 .. _`//CycloneDDS/Domain/Internal/DeliveryQueueMaxSamples`:
@@ -870,7 +870,7 @@ Integer
 
 This element controls the maximum size of a delivery queue, expressed in samples. Once a delivery queue is full, incoming samples destined for that queue are dropped until space becomes available again.
 
-The default value is: `256`
+The default value is: ``256``
 
 
 .. _`//CycloneDDS/Domain/Internal/EnableExpensiveChecks`:
@@ -892,7 +892,7 @@ This element enables expensive checks in builds with assertions enabled and is i
 
 In addition, there is the keyword all that enables all checks.
 
-The default value is: `<empty>`
+The default value is: ``<empty>``
 
 
 .. _`//CycloneDDS/Domain/Internal/GenerateKeyhash`:
@@ -904,7 +904,7 @@ Boolean
 
 When true, include keyhashes in outgoing data for topics with keys.
 
-The default value is: `false`
+The default value is: ``false``
 
 
 .. _`//CycloneDDS/Domain/Internal/HeartbeatInterval`:
@@ -920,7 +920,7 @@ This element allows configuring the base interval for sending writer heartbeats 
 
 Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: `100 ms`
+The default value is: ``100 ms``
 
 
 .. _`//CycloneDDS/Domain/Internal/HeartbeatInterval[@max]`:
@@ -934,7 +934,7 @@ This attribute sets the maximum interval for periodic heartbeats.
 
 Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: `8 s`
+The default value is: ``8 s``
 
 
 .. _`//CycloneDDS/Domain/Internal/HeartbeatInterval[@min]`:
@@ -948,7 +948,7 @@ This attribute sets the minimum interval that must have passed since the most re
 
 Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: `5 ms`
+The default value is: ``5 ms``
 
 
 .. _`//CycloneDDS/Domain/Internal/HeartbeatInterval[@minsched]`:
@@ -962,7 +962,7 @@ This attribute sets the minimum interval for periodic heartbeats. Other events m
 
 Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: `20 ms`
+The default value is: ``20 ms``
 
 
 .. _`//CycloneDDS/Domain/Internal/LateAckMode`:
@@ -974,7 +974,7 @@ Boolean
 
 Ack a sample only when it has been delivered, instead of when committed to delivering it.
 
-The default value is: `false`
+The default value is: ``false``
 
 
 .. _`//CycloneDDS/Domain/Internal/LivelinessMonitoring`:
@@ -988,7 +988,7 @@ Boolean
 
 This element controls whether or not implementation should internally monitor its own liveliness. If liveliness monitoring is enabled, stack traces can be dumped automatically when some thread appears to have stopped making progress.
 
-The default value is: `false`
+The default value is: ``false``
 
 
 .. _`//CycloneDDS/Domain/Internal/LivelinessMonitoring[@Interval]`:
@@ -1002,7 +1002,7 @@ This element controls the interval to check whether threads have been making pro
 
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: `1s`
+The default value is: ``1s``
 
 
 .. _`//CycloneDDS/Domain/Internal/LivelinessMonitoring[@StackTraces]`:
@@ -1014,7 +1014,7 @@ Boolean
 
 This element controls whether or not to write stack traces to the DDSI2 trace when a thread fails to make progress (on select platforms only).
 
-The default value is: `true`
+The default value is: ``true``
 
 
 .. _`//CycloneDDS/Domain/Internal/MaxParticipants`:
@@ -1026,7 +1026,7 @@ Integer
 
 This elements configures the maximum number of DCPS domain participants this Cyclone DDS instance is willing to service. 0 is unlimited.
 
-The default value is: `0`
+The default value is: ``0``
 
 
 .. _`//CycloneDDS/Domain/Internal/MaxQueuedRexmitBytes`:
@@ -1040,7 +1040,7 @@ This setting limits the maximum number of bytes queued for retransmission. The d
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: `512 kB`
+The default value is: ``512 kB``
 
 
 .. _`//CycloneDDS/Domain/Internal/MaxQueuedRexmitMessages`:
@@ -1052,7 +1052,7 @@ Integer
 
 This setting limits the maximum number of samples queued for retransmission.
 
-The default value is: `200`
+The default value is: ``200``
 
 
 .. _`//CycloneDDS/Domain/Internal/MaxSampleSize`:
@@ -1066,7 +1066,7 @@ This setting controls the maximum (CDR) serialised size of samples that Cyclone 
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: `2147483647 B`
+The default value is: ``2147483647 B``
 
 
 .. _`//CycloneDDS/Domain/Internal/MeasureHbToAckLatency`:
@@ -1078,7 +1078,7 @@ Boolean
 
 This element enables heartbeat-to-ack latency among Cyclone DDS services by prepending timestamps to Heartbeat and AckNack messages and calculating round trip times. This is non-standard behaviour. The measured latencies are quite noisy and are currently not used anywhere.
 
-The default value is: `false`
+The default value is: ``false``
 
 
 .. _`//CycloneDDS/Domain/Internal/MonitorPort`:
@@ -1090,7 +1090,7 @@ Integer
 
 This element allows configuring a service that dumps a text description of part the internal state to TCP clients. By default (-1), this is disabled; specifying 0 means a kernel-allocated port is used; a positive number is used as the TCP port number.
 
-The default value is: `-1`
+The default value is: ``-1``
 
 
 .. _`//CycloneDDS/Domain/Internal/MultipleReceiveThreads`:
@@ -1104,7 +1104,7 @@ One of: false, true, default
 
 This element controls whether all traffic is handled by a single receive thread (false) or whether multiple receive threads may be used to improve latency (true). By default it is disabled on Windows because it appears that one cannot count on being able to send packets to oneself, which is necessary to stop the thread during shutdown. Currently multiple receive threads are only used for connectionless transport (e.g., UDP) and ManySocketsMode not set to single (the default).
 
-The default value is: `default`
+The default value is: ``default``
 
 
 .. _`//CycloneDDS/Domain/Internal/MultipleReceiveThreads[@maxretries]`:
@@ -1116,7 +1116,7 @@ Integer
 
 Receive threads dedicated to a single socket can only be triggered for termination by sending a packet. Reception of any packet will do, so termination failure due to packet loss is exceedingly unlikely, but to eliminate all risks, it will retry as many times as specified by this attribute before aborting.
 
-The default value is: `4294967295`
+The default value is: ``4294967295``
 
 
 .. _`//CycloneDDS/Domain/Internal/NackDelay`:
@@ -1130,7 +1130,7 @@ This setting controls the delay between receipt of a HEARTBEAT indicating missin
 
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: `100 ms`
+The default value is: ``100 ms``
 
 
 .. _`//CycloneDDS/Domain/Internal/PreEmptiveAckDelay`:
@@ -1144,7 +1144,7 @@ This setting controls the delay between the discovering a remote writer and send
 
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: `10 ms`
+The default value is: ``10 ms``
 
 
 .. _`//CycloneDDS/Domain/Internal/PrimaryReorderMaxSamples`:
@@ -1156,7 +1156,7 @@ Integer
 
 This element sets the maximum size in samples of a primary re-order administration. Each proxy writer has one primary re-order administration to buffer the packet flow in case some packets arrive out of order. Old samples are forwarded to secondary re-order administrations associated with readers needing historical data.
 
-The default value is: `128`
+The default value is: ``128``
 
 
 .. _`//CycloneDDS/Domain/Internal/PrioritizeRetransmit`:
@@ -1168,7 +1168,7 @@ Boolean
 
 This element controls whether retransmits are prioritized over new data, speeding up recovery.
 
-The default value is: `true`
+The default value is: ``true``
 
 
 .. _`//CycloneDDS/Domain/Internal/RediscoveryBlacklistDuration`:
@@ -1184,7 +1184,7 @@ This element controls for how long a remote participant that was previously dele
 
 Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: `0s`
+The default value is: ``0s``
 
 
 .. _`//CycloneDDS/Domain/Internal/RediscoveryBlacklistDuration[@enforce]`:
@@ -1196,7 +1196,7 @@ Boolean
 
 This attribute controls whether the configured time during which recently deleted participants will not be rediscovered (i.e., "black listed") is enforced and following complete removal of the participant in Cyclone DDS, or whether it can be rediscovered earlier provided all traces of that participant have been removed already.
 
-The default value is: `false`
+The default value is: ``false``
 
 
 .. _`//CycloneDDS/Domain/Internal/RetransmitMerging`:
@@ -1216,7 +1216,7 @@ This elements controls the addressing and timing of retransmits. Possible values
 
 The default is never. See also Internal/RetransmitMergingPeriod.
 
-The default value is: `never`
+The default value is: ``never``
 
 
 .. _`//CycloneDDS/Domain/Internal/RetransmitMergingPeriod`:
@@ -1232,7 +1232,7 @@ See also Internal/RetransmitMerging.
 
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: `5 ms`
+The default value is: ``5 ms``
 
 
 .. _`//CycloneDDS/Domain/Internal/RetryOnRejectBestEffort`:
@@ -1244,7 +1244,7 @@ Boolean
 
 Whether or not to locally retry pushing a received best-effort sample into the reader caches when resource limits are reached.
 
-The default value is: `false`
+The default value is: ``false``
 
 
 .. _`//CycloneDDS/Domain/Internal/SPDPResponseMaxDelay`:
@@ -1258,7 +1258,7 @@ Maximum pseudo-random delay in milliseconds between discovering aremote particip
 
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: `0 ms`
+The default value is: ``0 ms``
 
 
 .. _`//CycloneDDS/Domain/Internal/ScheduleTimeRounding`:
@@ -1272,7 +1272,7 @@ This setting allows the timing of scheduled events to be rounded up so that more
 
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: `0 ms`
+The default value is: ``0 ms``
 
 
 .. _`//CycloneDDS/Domain/Internal/SecondaryReorderMaxSamples`:
@@ -1284,7 +1284,7 @@ Integer
 
 This element sets the maximum size in samples of a secondary re-order administration. The secondary re-order administration is per reader needing historical data.
 
-The default value is: `128`
+The default value is: ``128``
 
 
 .. _`//CycloneDDS/Domain/Internal/SocketReceiveBufferSize`:
@@ -1310,7 +1310,7 @@ This sets the size of the socket receive buffer to request, with the special val
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: `default`
+The default value is: ``default``
 
 
 .. _`//CycloneDDS/Domain/Internal/SocketReceiveBufferSize[@min]`:
@@ -1324,7 +1324,7 @@ This sets the minimum acceptable socket receive buffer size, with the special va
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: `default`
+The default value is: ``default``
 
 
 .. _`//CycloneDDS/Domain/Internal/SocketSendBufferSize`:
@@ -1350,7 +1350,7 @@ This sets the size of the socket send buffer to request, with the special value 
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: `default`
+The default value is: ``default``
 
 
 .. _`//CycloneDDS/Domain/Internal/SocketSendBufferSize[@min]`:
@@ -1364,7 +1364,7 @@ This sets the minimum acceptable socket send buffer size, with the special value
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: `64 KiB`
+The default value is: ``64 KiB``
 
 
 .. _`//CycloneDDS/Domain/Internal/SquashParticipants`:
@@ -1376,7 +1376,7 @@ Boolean
 
 This element controls whether Cyclone DDS advertises all the domain participants it serves in DDSI (when set to false), or rather only one domain participant (the one corresponding to the Cyclone DDS process; when set to true). In the latter case, Cyclone DDS becomes the virtual owner of all readers and writers of all domain participants, dramatically reducing discovery traffic (a similar effect can be obtained by setting Internal/BuiltinEndpointSet to "minimal" but with less loss of information).
 
-The default value is: `false`
+The default value is: ``false``
 
 
 .. _`//CycloneDDS/Domain/Internal/SynchronousDeliveryLatencyBound`:
@@ -1390,7 +1390,7 @@ This element controls whether samples sent by a writer with QoS settings transpo
 
 Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: `inf`
+The default value is: ``inf``
 
 
 .. _`//CycloneDDS/Domain/Internal/SynchronousDeliveryPriorityThreshold`:
@@ -1402,7 +1402,7 @@ Integer
 
 This element controls whether samples sent by a writer with QoS settings latency\_budget <= SynchronousDeliveryLatencyBound and transport\_priority greater than or equal to this element's value will be delivered synchronously from the "recv" thread, all others will be delivered asynchronously through delivery queues. This reduces latency at the expense of aggregate bandwidth.
 
-The default value is: `0`
+The default value is: ``0``
 
 
 .. _`//CycloneDDS/Domain/Internal/Test`:
@@ -1424,7 +1424,7 @@ Integer
 
 This element controls the fraction of outgoing packets to drop, specified as samples per thousand.
 
-The default value is: `0`
+The default value is: ``0``
 
 
 .. _`//CycloneDDS/Domain/Internal/UnicastResponseToSPDPMessages`:
@@ -1436,7 +1436,7 @@ Boolean
 
 This element controls whether the response to a newly discovered participant is sent as a unicasted SPDP packet instead of rescheduling the periodic multicasted one. There is no known benefit to setting this to false.
 
-The default value is: `true`
+The default value is: ``true``
 
 
 .. _`//CycloneDDS/Domain/Internal/UseMulticastIfMreqn`:
@@ -1448,7 +1448,7 @@ Integer
 
 Do not use.
 
-The default value is: `0`
+The default value is: ``0``
 
 
 .. _`//CycloneDDS/Domain/Internal/Watermarks`:
@@ -1470,7 +1470,7 @@ Boolean
 
 This element controls whether Cyclone DDS will adapt the high-water mark to current traffic conditions based on retransmit requests and transmit pressure.
 
-The default value is: `true`
+The default value is: ``true``
 
 
 .. _`//CycloneDDS/Domain/Internal/Watermarks/WhcHigh`:
@@ -1484,7 +1484,7 @@ This element sets the maximum allowed high-water mark for the Cyclone DDS WHCs, 
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: `500 kB`
+The default value is: ``500 kB``
 
 
 .. _`//CycloneDDS/Domain/Internal/Watermarks/WhcHighInit`:
@@ -1498,7 +1498,7 @@ This element sets the initial level of the high-water mark for the Cyclone DDS W
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: `30 kB`
+The default value is: ``30 kB``
 
 
 .. _`//CycloneDDS/Domain/Internal/Watermarks/WhcLow`:
@@ -1512,7 +1512,7 @@ This element sets the low-water mark for the Cyclone DDS WHCs, expressed in byte
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: `1 kB`
+The default value is: ``1 kB``
 
 
 .. _`//CycloneDDS/Domain/Internal/WriteBatch`:
@@ -1524,7 +1524,7 @@ Boolean
 
 This element enables the batching of write operations. By default each write operation writes through the write cache and out onto the transport. Enabling write batching causes multiple small write operations to be aggregated within the write cache into a single larger write. This gives greater throughput at the expense of latency. Currently, there is no mechanism for the write cache to automatically flush itself, so that if write batching is enabled, the application may have to use the dds\_write\_flush function to ensure that all samples are written.
 
-The default value is: `false`
+The default value is: ``false``
 
 
 .. _`//CycloneDDS/Domain/Internal/WriterLingerDuration`:
@@ -1537,7 +1537,7 @@ Number-with-unit
 This setting controls the maximum duration for which actual deletion of a reliable writer with unacknowledged data in its history will be postponed to provide proper reliable transmission.
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: `1 s`
+The default value is: ``1 s``
 
 
 .. _`//CycloneDDS/Domain/Partitioning`:
@@ -1571,7 +1571,7 @@ Text
 
 This element can prevent certain combinations of DCPS partition and topic from being transmitted over the network. Cyclone DDS will completely ignore readers and writers for which all DCPS partitions as well as their topic is ignored, not even creating DDSI readers and writers to mirror the DCPS ones.
 
-The default value is: `<empty>`
+The default value is: ``<empty>``
 
 
 .. _`//CycloneDDS/Domain/Partitioning/IgnoredPartitions/IgnoredPartition[@DCPSPartitionTopic]`:
@@ -1583,7 +1583,7 @@ Text
 
 This attribute specifies a partition and a topic expression, separated by a single '.', which are used to determine if a given partition and topic will be ignored or not. The expressions may use the usual wildcards '\*' and '?'. Cyclone DDS will consider a wildcard DCPS partition to match an expression if a string that satisfies both expressions exists.
 
-The default value is: `<empty>`
+The default value is: ``<empty>``
 
 
 .. _`//CycloneDDS/Domain/Partitioning/NetworkPartitions`:
@@ -1607,7 +1607,7 @@ Text
 
 This element defines a Cyclone DDS network partition.
 
-The default value is: `<empty>`
+The default value is: ``<empty>``
 
 
 .. _`//CycloneDDS/Domain/Partitioning/NetworkPartitions/NetworkPartition[@Address]`:
@@ -1624,7 +1624,7 @@ Readers matching this network partition (cf. Partitioning/PartitionMappings) wil
 
 The unicast addresses advertised by a reader are the only unicast addresses a writer will use to send data to it and are used to select the subset of network interfaces to use for transmitting multicast data with the intent of reaching it.
 
-The default value is: `<empty>`
+The default value is: ``<empty>``
 
 
 .. _`//CycloneDDS/Domain/Partitioning/NetworkPartitions/NetworkPartition[@Interface]`:
@@ -1636,7 +1636,7 @@ Text
 
 This attribute takes a comma-separated list of interface name that the reader is willing to receive data on. This is implemented by adding the interface addresses to the set address set configured using the sibling "Address" attribute. See there for more details.
 
-The default value is: `<empty>`
+The default value is: ``<empty>``
 
 
 .. _`//CycloneDDS/Domain/Partitioning/NetworkPartitions/NetworkPartition[@Name]`:
@@ -1648,7 +1648,7 @@ Text
 
 This attribute specifies the name of this Cyclone DDS network partition. Two network partitions cannot have the same name. Partition mappings (cf. Partitioning/PartitionMappings) refer to network partitions using these names.
 
-The default value is: `<empty>`
+The default value is: ``<empty>``
 
 
 .. _`//CycloneDDS/Domain/Partitioning/PartitionMappings`:
@@ -1672,7 +1672,7 @@ Text
 
 This element defines a mapping from a DCPS partition/topic combination to a Cyclone DDS network partition. This allows partitioning data flows by using special multicast addresses for part of the data and possibly encrypting the data flow.
 
-The default value is: `<empty>`
+The default value is: ``<empty>``
 
 
 .. _`//CycloneDDS/Domain/Partitioning/PartitionMappings/PartitionMapping[@DCPSPartitionTopic]`:
@@ -1684,7 +1684,7 @@ Text
 
 This attribute specifies a partition and a topic expression, separated by a single '.', which are used to determine if a given partition and topic maps to the Cyclone DDS network partition named by the NetworkPartition attribute in this PartitionMapping element. The expressions may use the usual wildcards '\*' and '?'. Cyclone DDS will consider a wildcard DCPS partition to match an expression if there exists a string that satisfies both expressions.
 
-The default value is: `<empty>`
+The default value is: ``<empty>``
 
 
 .. _`//CycloneDDS/Domain/Partitioning/PartitionMappings/PartitionMapping[@NetworkPartition]`:
@@ -1696,7 +1696,7 @@ Text
 
 This attribute specifies which Cyclone DDS network partition is to be used for DCPS partition/topic combinations matching the DCPSPartitionTopic attribute within this PartitionMapping element.
 
-The default value is: `<empty>`
+The default value is: ``<empty>``
 
 
 .. _`//CycloneDDS/Domain/SSL`:
@@ -1718,7 +1718,7 @@ Boolean
 
 If disabled this allows SSL connections to occur even if an X509 certificate fails verification.
 
-The default value is: `true`
+The default value is: ``true``
 
 
 .. _`//CycloneDDS/Domain/SSL/Ciphers`:
@@ -1730,7 +1730,7 @@ Text
 
 The set of ciphers used by SSL/TLS
 
-The default value is: `ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH`
+The default value is: ``ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH``
 
 
 .. _`//CycloneDDS/Domain/SSL/Enable`:
@@ -1742,7 +1742,7 @@ Boolean
 
 This enables SSL/TLS for TCP.
 
-The default value is: `false`
+The default value is: ``false``
 
 
 .. _`//CycloneDDS/Domain/SSL/EntropyFile`:
@@ -1754,7 +1754,7 @@ Text
 
 The SSL/TLS random entropy file name.
 
-The default value is: `<empty>`
+The default value is: ``<empty>``
 
 
 .. _`//CycloneDDS/Domain/SSL/KeyPassphrase`:
@@ -1766,7 +1766,7 @@ Text
 
 The SSL/TLS key pass phrase for encrypted keys.
 
-The default value is: `secret`
+The default value is: ``secret``
 
 
 .. _`//CycloneDDS/Domain/SSL/KeystoreFile`:
@@ -1778,7 +1778,7 @@ Text
 
 The SSL/TLS key and certificate store file name. The keystore must be in PEM format.
 
-The default value is: `keystore`
+The default value is: ``keystore``
 
 
 .. _`//CycloneDDS/Domain/SSL/MinimumTLSVersion`:
@@ -1790,7 +1790,7 @@ Text
 
 The minimum TLS version that may be negotiated, valid values are 1.2 and 1.3.
 
-The default value is: `1.3`
+The default value is: ``1.3``
 
 
 .. _`//CycloneDDS/Domain/SSL/SelfSignedCertificates`:
@@ -1802,7 +1802,7 @@ Boolean
 
 This enables the use of self signed X509 certificates.
 
-The default value is: `false`
+The default value is: ``false``
 
 
 .. _`//CycloneDDS/Domain/SSL/VerifyClient`:
@@ -1814,7 +1814,7 @@ Boolean
 
 This enables an SSL server to check the X509 certificate of a connecting client.
 
-The default value is: `true`
+The default value is: ``true``
 
 
 .. _`//CycloneDDS/Domain/Security`:
@@ -1888,7 +1888,7 @@ MIIDuAYJKoZIhv ...al5s=
 
 ------F9A8A198D6F08E1285A292ADF14DD04F-]]</Governance>
 
-The default value is: `<empty>`
+The default value is: ``<empty>``
 
 
 .. _`//CycloneDDS/Domain/Security/AccessControl/Library`:
@@ -1902,7 +1902,7 @@ Text
 
 This element specifies the library to be loaded as the DDS Security Access Control plugin.
 
-The default value is: `<empty>`
+The default value is: ``<empty>``
 
 
 .. _`//CycloneDDS/Domain/Security/AccessControl/Library[@finalizeFunction]`:
@@ -1914,7 +1914,7 @@ Text
 
 This element names the finalization function of Access Control plugin. This function is called to let the plugin release its resources.
 
-The default value is: `finalize\_access\_control`
+The default value is: ``finalize\_access\_control``
 
 
 .. _`//CycloneDDS/Domain/Security/AccessControl/Library[@initFunction]`:
@@ -1926,7 +1926,7 @@ Text
 
 This element names the initialization function of Access Control plugin. This function is called after loading the plugin library for instantiation purposes. The Init function must return an object that implements the DDS Security Access Control interface.
 
-The default value is: `init\_access\_control`
+The default value is: ``init\_access\_control``
 
 
 .. _`//CycloneDDS/Domain/Security/AccessControl/Library[@path]`:
@@ -1942,7 +1942,7 @@ It can be either absolute path excluding file extension ( /usr/lib/dds\_security
 
 If a single file is supplied, the library is located by the current working directory, or LD\_LIBRARY\_PATH for Unix systems, and PATH for Windows systems.
 
-The default value is: `dds\_security\_ac`
+The default value is: ``dds\_security\_ac``
 
 
 .. _`//CycloneDDS/Domain/Security/AccessControl/Permissions`:
@@ -1965,7 +1965,7 @@ Example data URI:
 
 <Permissions><![CDATA[data:,.........]]</Permissions>
 
-The default value is: `<empty>`
+The default value is: ``<empty>``
 
 
 .. _`//CycloneDDS/Domain/Security/AccessControl/PermissionsCA`:
@@ -1990,7 +1990,7 @@ MIIC3DCCAcQCCQCWE5x+Z ... PhovK0mp2ohhRLYI0ZiyYQ==
 
 -----END CERTIFICATE-----</PermissionsCA>
 
-The default value is: `<empty>`
+The default value is: ``<empty>``
 
 
 .. _`//CycloneDDS/Domain/Security/Authentication`:
@@ -2022,7 +2022,7 @@ Examples:
 MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg=<br>
 -----END X509 CRL-----</CRL>
 
-The default value is: `<empty>`
+The default value is: ``<empty>``
 
 
 .. _`//CycloneDDS/Domain/Security/Authentication/IdentityCA`:
@@ -2046,7 +2046,7 @@ Examples:
 MIIC3DCCAcQCCQCWE5x+Z...PhovK0mp2ohhRLYI0ZiyYQ==<br>
 -----END CERTIFICATE-----</IdentityCA>
 
-The default value is: `<empty>`
+The default value is: ``<empty>``
 
 
 .. _`//CycloneDDS/Domain/Security/Authentication/IdentityCertificate`:
@@ -2068,7 +2068,7 @@ Examples:
 MIIDjjCCAnYCCQDCEu9...6rmT87dhTo=<br>
 -----END CERTIFICATE-----</IdentityCertificate>
 
-The default value is: `<empty>`
+The default value is: ``<empty>``
 
 
 .. _`//CycloneDDS/Domain/Security/Authentication/IncludeOptionalFields`:
@@ -2080,7 +2080,7 @@ Boolean
 
 The authentication handshake tokens may contain optional fields to be included for finding interoperability problems. If this parameter is set to true the optional fields are included in the handshake token exchange.
 
-The default value is: `false`
+The default value is: ``false``
 
 
 .. _`//CycloneDDS/Domain/Security/Authentication/Library`:
@@ -2094,7 +2094,7 @@ Text
 
 This element specifies the library to be loaded as the DDS Security Access Control plugin.
 
-The default value is: `<empty>`
+The default value is: ``<empty>``
 
 
 .. _`//CycloneDDS/Domain/Security/Authentication/Library[@finalizeFunction]`:
@@ -2106,7 +2106,7 @@ Text
 
 This element names the finalization function of the Authentication plugin. This function is called to let the plugin release its resources.
 
-The default value is: `finalize\_authentication`
+The default value is: ``finalize\_authentication``
 
 
 .. _`//CycloneDDS/Domain/Security/Authentication/Library[@initFunction]`:
@@ -2118,7 +2118,7 @@ Text
 
 This element names the initialization function of the Authentication plugin. This function is called after loading the plugin library for instantiation purposes. The Init function must return an object that implements the DDS Security Authentication interface.
 
-The default value is: `init\_authentication`
+The default value is: ``init\_authentication``
 
 
 .. _`//CycloneDDS/Domain/Security/Authentication/Library[@path]`:
@@ -2134,7 +2134,7 @@ It can be either absolute path excluding file extension ( /usr/lib/dds\_security
 
 If a single file is supplied, the library is located by the current working directory, or LD\_LIBRARY\_PATH for Unix systems, and PATH for Windows systems.
 
-The default value is: `dds\_security\_auth`
+The default value is: ``dds\_security\_auth``
 
 
 .. _`//CycloneDDS/Domain/Security/Authentication/Password`:
@@ -2150,7 +2150,7 @@ The value of the password property shall be interpreted as the Base64 encoding o
 
 If the password property is not present, then the value supplied in the private\_key property must contain the unencrypted private key.
 
-The default value is: `<empty>`
+The default value is: ``<empty>``
 
 
 .. _`//CycloneDDS/Domain/Security/Authentication/PrivateKey`:
@@ -2172,7 +2172,7 @@ Examples:
 MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==<br>
 -----END RSA PRIVATE KEY-----</PrivateKey>
 
-The default value is: `<empty>`
+The default value is: ``<empty>``
 
 
 .. _`//CycloneDDS/Domain/Security/Authentication/TrustedCADirectory`:
@@ -2184,7 +2184,7 @@ Text
 
 Trusted CA Directory which contains trusted CA certificates as separated files.
 
-The default value is: `<empty>`
+The default value is: ``<empty>``
 
 
 .. _`//CycloneDDS/Domain/Security/Cryptographic`:
@@ -2208,7 +2208,7 @@ Text
 
 This element specifies the library to be loaded as the DDS Security Cryptographic plugin.
 
-The default value is: `<empty>`
+The default value is: ``<empty>``
 
 
 .. _`//CycloneDDS/Domain/Security/Cryptographic/Library[@finalizeFunction]`:
@@ -2220,7 +2220,7 @@ Text
 
 This element names the finalization function of the Cryptographic plugin. This function is called to let the plugin release its resources.
 
-The default value is: `finalize\_crypto`
+The default value is: ``finalize\_crypto``
 
 
 .. _`//CycloneDDS/Domain/Security/Cryptographic/Library[@initFunction]`:
@@ -2232,7 +2232,7 @@ Text
 
 This element names the initialization function of the Cryptographic plugin. This function is called after loading the plugin library for instantiation purposes. The Init function must return an object that implements the DDS Security Cryptographic interface.
 
-The default value is: `init\_crypto`
+The default value is: ``init\_crypto``
 
 
 .. _`//CycloneDDS/Domain/Security/Cryptographic/Library[@path]`:
@@ -2248,7 +2248,7 @@ It can be either absolute path excluding file extension ( /usr/lib/dds\_security
 
 If a single file is supplied, the is library located by the current working directory, or LD\_LIBRARY\_PATH for Unix systems, and PATH for Windows systems.
 
-The default value is: `dds\_security\_crypto`
+The default value is: ``dds\_security\_crypto``
 
 
 .. _`//CycloneDDS/Domain/SharedMemory`:
@@ -2270,7 +2270,7 @@ Boolean
 
 This element allows for enabling shared memory in Cyclone DDS.
 
-The default value is: `false`
+The default value is: ``false``
 
 
 .. _`//CycloneDDS/Domain/SharedMemory/Locator`:
@@ -2282,7 +2282,7 @@ Text
 
 Explicitly set the Iceoryx locator used by Cyclone to check whether a pair of processes is attached to the same Iceoryx shared memory.  The default is to use one of the MAC addresses of the machine, which should work well in most cases.
 
-The default value is: `<empty>`
+The default value is: ``<empty>``
 
 
 .. _`//CycloneDDS/Domain/SharedMemory/LogLevel`:
@@ -2309,7 +2309,7 @@ This element decides the verbosity level of shared memory message:
 
 If you don't want to see any log from shared memory, use off to disable logging.
 
-The default value is: `info`
+The default value is: ``info``
 
 
 .. _`//CycloneDDS/Domain/SharedMemory/Prefix`:
@@ -2321,7 +2321,7 @@ Text
 
 Override the Iceoryx service name used by Cyclone.
 
-The default value is: `DDS\_CYCLONE`
+The default value is: ``DDS\_CYCLONE``
 
 
 .. _`//CycloneDDS/Domain/Sizing`:
@@ -2345,7 +2345,7 @@ This element specifies the size of one allocation unit in the receive buffer. It
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: `128 KiB`
+The default value is: ``128 KiB``
 
 
 .. _`//CycloneDDS/Domain/Sizing/ReceiveBufferSize`:
@@ -2359,7 +2359,7 @@ This element sets the size of a single receive buffer. Many receive buffers may 
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: `1 MiB`
+The default value is: ``1 MiB``
 
 
 .. _`//CycloneDDS/Domain/TCP`:
@@ -2381,7 +2381,7 @@ Boolean
 
 Setting this to true means the unicast addresses in SPDP packets will be ignored, and the peer address from the TCP connection will be used instead. This may help work around incorrectly advertised addresses when using TCP.
 
-The default value is: `false`
+The default value is: ``false``
 
 
 .. _`//CycloneDDS/Domain/TCP/Enable`:
@@ -2393,7 +2393,7 @@ One of: false, true, default
 
 This element enables the optional TCP transport - deprecated, use General/Transport instead.
 
-The default value is: `default`
+The default value is: ``default``
 
 
 .. _`//CycloneDDS/Domain/TCP/NoDelay`:
@@ -2405,7 +2405,7 @@ Boolean
 
 This element enables the TCP\_NODELAY socket option, preventing multiple DDSI messages from being sent in the same TCP request. Setting this option typically optimises latency over throughput.
 
-The default value is: `true`
+The default value is: ``true``
 
 
 .. _`//CycloneDDS/Domain/TCP/Port`:
@@ -2417,7 +2417,7 @@ Integer
 
 This element specifies the TCP port number on which Cyclone DDS accepts connections. If the port is set, it is used in entity locators, published with DDSI discovery, dynamically allocated if zero, and disabled if -1 or not configured. If disabled other DDSI services will not be able to establish connections with the service, the service can only communicate by establishing connections to other services.
 
-The default value is: `-1`
+The default value is: ``-1``
 
 
 .. _`//CycloneDDS/Domain/TCP/ReadTimeout`:
@@ -2431,7 +2431,7 @@ This element specifies the timeout for blocking TCP read operations. If this tim
 
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: `2 s`
+The default value is: ``2 s``
 
 
 .. _`//CycloneDDS/Domain/TCP/WriteTimeout`:
@@ -2445,7 +2445,7 @@ This element specifies the timeout for blocking TCP write operations. If this ti
 
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: `2 s`
+The default value is: ``2 s``
 
 
 .. _`//CycloneDDS/Domain/Threads`:
@@ -2497,7 +2497,7 @@ The Name of the thread for which properties are being set. The following threads
  * tev.CHAN: timed-event thread for channel CHAN.
 
 
-The default value is: `<empty>`
+The default value is: ``<empty>``
 
 
 .. _`//CycloneDDS/Domain/Threads/Thread/Scheduling`:
@@ -2519,7 +2519,7 @@ One of: realtime, timeshare, default
 
 This element specifies the thread scheduling class (realtime, timeshare or default). The user may need special privileges from the underlying operating system to be able to assign some of the privileged scheduling classes.
 
-The default value is: `default`
+The default value is: ``default``
 
 
 .. _`//CycloneDDS/Domain/Threads/Thread/Scheduling/Priority`:
@@ -2531,7 +2531,7 @@ Text
 
 This element specifies the thread priority (decimal integer or default). Only priorities supported by the underlying operating system can be assigned to this element. The user may need special privileges from the underlying operating system to be able to assign some of the privileged priorities.
 
-The default value is: `default`
+The default value is: ``default``
 
 
 .. _`//CycloneDDS/Domain/Threads/Thread/StackSize`:
@@ -2545,7 +2545,7 @@ This element configures the stack size for this thread. The default value defaul
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: `default`
+The default value is: ``default``
 
 
 .. _`//CycloneDDS/Domain/Tracing`:
@@ -2567,7 +2567,7 @@ Boolean
 
 This option specifies whether the output should be appended to an existing log file. The default is to create a new log file each time, which is generally the best option if a detailed log is generated.
 
-The default value is: `false`
+The default value is: ``false``
 
 
 .. _`//CycloneDDS/Domain/Tracing/Category`:
@@ -2613,7 +2613,7 @@ This element enables individual logging categories. These are enabled in additio
 In addition, there is the keyword trace that enables all but radmin, topic, plist and whc.
 The categorisation of tracing output is incomplete and hence most of the verbosity levels and categories are not of much use in the current release. This is an ongoing process and here we describe the target situation rather than the current situation. Currently, the most useful is trace.
 
-The default value is: `<empty>`
+The default value is: ``<empty>``
 
 
 .. _`//CycloneDDS/Domain/Tracing/OutputFile`:
@@ -2625,7 +2625,7 @@ Text
 
 This option specifies where the logging is printed to. Note that stdout and stderr are treated as special values, representing "standard out" and "standard error" respectively. No file is created unless logging categories are enabled using the Tracing/Verbosity or Tracing/EnabledCategory settings.
 
-The default value is: `cyclonedds.log`
+The default value is: ``cyclonedds.log``
 
 
 .. _`//CycloneDDS/Domain/Tracing/PacketCaptureFile`:
@@ -2637,7 +2637,7 @@ Text
 
 This option specifies the file to which received and sent packets will be logged in the "pcap" format suitable for analysis using common networking tools, such as WireShark. IP and UDP headers are fictitious, in particular the destination address of received packets. The TTL may be used to distinguish between sent and received packets: it is 255 for sent packets and 128 for received ones. Currently IPv4 only.
 
-The default value is: `<empty>`
+The default value is: ``<empty>``
 
 
 .. _`//CycloneDDS/Domain/Tracing/Verbosity`:
@@ -2669,7 +2669,7 @@ While none prevents any message from being written to a DDSI2 log file.
 
 The categorisation of tracing output is incomplete and hence most of the verbosity levels and categories are not of much use in the current release. This is an ongoing process and here we describe the target situation rather than the current situation. Currently, the most useful verbosity levels are config, fine and finest.
 
-The default value is: `none`
+The default value is: ``none``
 
 ..
    generated from ddsi_config.h[75edea6617af11bacc46f91e519773f6df580655] 
@@ -2680,6 +2680,6 @@ The default value is: `none`
    generated from _confgen.c[ba2e8c0cfd41039421548fdb03bcd2db8f8b172e] 
    generated from generate_rnc.c[a2ec6e48d33ac14a320c8ec3f320028a737920e0] 
    generated from generate_md.c[37efe4fa9caf56e2647bafc9a7f009f72ff5d2e0] 
-   generated from generate_rst.c[32da07860a0043708b47e9f793b63ca05f5106bb] 
+   generated from generate_rst.c[50739f627792ef056e2b4feeb20fda4edfcef079] 
    generated from generate_xsd.c[45064e8869b3c00573057d7c8f02d20f04b40e16] 
    generated from generate_defconfig.c[eec9ab7b2d053e68500799b693d089e84153a37b] 

--- a/docs/manual/config/config_file_reference.rst
+++ b/docs/manual/config/config_file_reference.rst
@@ -36,7 +36,7 @@ Text
 
 Domain id this configuration applies to, or "any" if it applies to all domain ids.
 
-The default value is: "any".
+The default value is: `any`
 
 
 .. _`//CycloneDDS/Domain/Compatibility`:
@@ -58,7 +58,7 @@ Boolean
 
 This option assumes ParticipantMessageData endpoints required by the liveliness protocol are present in RTI participants even when not properly advertised by the participant discovery protocol.
 
-The default value is: "false".
+The default value is: `false`
 
 
 .. _`//CycloneDDS/Domain/Compatibility/ExplicitlyPublishQosSetToDefault`:
@@ -72,7 +72,7 @@ This element specifies whether QoS settings set to default values are explicitly
 
 When interoperability is required with an implementation that does not follow the specifications in this regard, setting this option to true will help.
 
-The default value is: "false".
+The default value is: `false`
 
 
 .. _`//CycloneDDS/Domain/Compatibility/ManySocketsMode`:
@@ -86,7 +86,7 @@ This option specifies whether a network socket will be created for each domain p
 
 Disabling it slightly improves performance and reduces network traffic somewhat. It also causes the set of port numbers needed by Cyclone DDS to become predictable, which may be useful for firewall and NAT configuration.
 
-The default value is: "single".
+The default value is: `single`
 
 
 .. _`//CycloneDDS/Domain/Compatibility/StandardsConformance`:
@@ -104,7 +104,7 @@ This element sets the level of standards conformance of this instance of the Cyc
  * lax: attempt to provide the smoothest possible interoperability, anticipating future revisions of elements in the standard in areas that other implementations do not adhere to, even though there is no good reason not to.
 
 
-The default value is: "lax".
+The default value is: `lax`
 
 
 .. _`//CycloneDDS/Domain/Discovery`:
@@ -128,7 +128,7 @@ This setting controls for how long endpoints discovered via a Cloud discovery se
 
 Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "30 s".
+The default value is: `30 s`
 
 
 .. _`//CycloneDDS/Domain/Discovery/DefaultMulticastAddress`:
@@ -140,7 +140,7 @@ Text
 
 This element specifies the default multicast address for all traffic other than participant discovery packets. It defaults to Discovery/SPDPMulticastAddress.
 
-The default value is: "auto".
+The default value is: `auto`
 
 
 .. _`//CycloneDDS/Domain/Discovery/EnableTopicDiscoveryEndpoints`:
@@ -152,7 +152,7 @@ Boolean
 
 This element controls whether the built-in endpoints for topic discovery are created and used to exchange topic discovery information.
 
-The default value is: "false".
+The default value is: `false`
 
 
 .. _`//CycloneDDS/Domain/Discovery/ExternalDomainId`:
@@ -164,7 +164,7 @@ Text
 
 An override for the domain id is used to discovery and determine the port number mapping. This allows the creating of multiple domains in a single process while making them appear as a single domain on the network. The value "default" disables the override.
 
-The default value is: "default".
+The default value is: `default`
 
 
 .. _`//CycloneDDS/Domain/Discovery/LeaseDuration`:
@@ -177,7 +177,7 @@ Number-with-unit
 This setting controls the default participant lease duration.
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "10 s".
+The default value is: `10 s`
 
 
 .. _`//CycloneDDS/Domain/Discovery/MaxAutoParticipantIndex`:
@@ -189,7 +189,7 @@ Integer
 
 This element specifies the maximum DDSI participant index selected by this instance of the Cyclone DDS service if the Discovery/ParticipantIndex is "auto".
 
-The default value is: "9".
+The default value is: `9`
 
 
 .. _`//CycloneDDS/Domain/Discovery/ParticipantIndex`:
@@ -207,7 +207,7 @@ This element specifies the DDSI participant index used by this instance of the C
  * none:, which causes it to use arbitrary port numbers for unicast sockets which entirely removes the constraints on the participant index but makes unicast discovery impossible.
 
 
-The default value is: "none".
+The default value is: `none`
 
 
 .. _`//CycloneDDS/Domain/Discovery/Peers`:
@@ -239,7 +239,7 @@ Text
 
 This element specifies an IP address to which discovery packets must be sent, in addition to the default multicast address (see also General/AllowMulticast). Both hostnames and a numerical IP address are accepted; the hostname or IP address may be suffixed with :PORT to explicitly set the port to which it must be sent. Multiple Peers may be specified.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 .. _`//CycloneDDS/Domain/Discovery/Ports`:
@@ -261,7 +261,7 @@ Integer
 
 This element specifies the base port number (refer to the DDSI 2.1 specification, section 9.6.1, constant PB).
 
-The default value is: "7400".
+The default value is: `7400`
 
 
 .. _`//CycloneDDS/Domain/Discovery/Ports/DomainGain`:
@@ -273,7 +273,7 @@ Integer
 
 This element specifies the domain gain, relating domain ids to sets of port numbers (refer to the DDSI 2.1 specification, section 9.6.1, constant DG).
 
-The default value is: "250".
+The default value is: `250`
 
 
 .. _`//CycloneDDS/Domain/Discovery/Ports/MulticastDataOffset`:
@@ -285,7 +285,7 @@ Integer
 
 This element specifies the port number for multicast data traffic (refer to the DDSI 2.1 specification, section 9.6.1, constant d2).
 
-The default value is: "1".
+The default value is: `1`
 
 
 .. _`//CycloneDDS/Domain/Discovery/Ports/MulticastMetaOffset`:
@@ -297,7 +297,7 @@ Integer
 
 This element specifies the port number for multicast meta traffic (refer to the DDSI 2.1 specification, section 9.6.1, constant d0).
 
-The default value is: "0".
+The default value is: `0`
 
 
 .. _`//CycloneDDS/Domain/Discovery/Ports/ParticipantGain`:
@@ -309,7 +309,7 @@ Integer
 
 This element specifies the participant gain, relating p0, participant index to sets of port numbers (refer to the DDSI 2.1 specification, section 9.6.1, constant PG).
 
-The default value is: "2".
+The default value is: `2`
 
 
 .. _`//CycloneDDS/Domain/Discovery/Ports/UnicastDataOffset`:
@@ -321,7 +321,7 @@ Integer
 
 This element specifies the port number for unicast data traffic (refer to the DDSI 2.1 specification, section 9.6.1, constant d3).
 
-The default value is: "11".
+The default value is: `11`
 
 
 .. _`//CycloneDDS/Domain/Discovery/Ports/UnicastMetaOffset`:
@@ -333,7 +333,7 @@ Integer
 
 This element specifies the port number for unicast meta traffic (refer to the DDSI 2.1 specification, section 9.6.1, constant d1).
 
-The default value is: "10".
+The default value is: `10`
 
 
 .. _`//CycloneDDS/Domain/Discovery/SPDPInterval`:
@@ -347,7 +347,7 @@ This element specifies the interval between spontaneous transmissions of partici
 
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "30 s".
+The default value is: `30 s`
 
 
 .. _`//CycloneDDS/Domain/Discovery/SPDPMulticastAddress`:
@@ -359,7 +359,7 @@ Text
 
 This element specifies the multicast address used as the destination for the participant discovery packets. In IPv4 mode the default is the (standardised) 239.255.0.1, in IPv6 mode it becomes ff02::ffff:239.255.0.1, which is a non-standardised link-local multicast address.
 
-The default value is: "239.255.0.1".
+The default value is: `239.255.0.1`
 
 
 .. _`//CycloneDDS/Domain/Discovery/Tag`:
@@ -371,7 +371,7 @@ Text
 
 String extension for domain id that remote participants must match to be discovered.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 .. _`//CycloneDDS/Domain/General`:
@@ -409,7 +409,7 @@ When set to "false" all multicasting is disabled. The default, "true" enables th
 
 "default" maps on spdp if the network is a WiFi network, on true if it is a wired network
 
-The default value is: "default".
+The default value is: `default`
 
 
 .. _`//CycloneDDS/Domain/General/DontRoute`:
@@ -421,7 +421,7 @@ Boolean
 
 This element allows setting the SO\_DONTROUTE option for outgoing packets to bypass the local routing tables. This is generally useful only when the routing tables cannot be trusted, which is highly unusual.
 
-The default value is: "false".
+The default value is: `false`
 
 
 .. _`//CycloneDDS/Domain/General/EnableMulticastLoopback`:
@@ -433,7 +433,7 @@ Boolean
 
 This element specifies whether Cyclone DDS allows IP multicast packets to be visible to all DDSI participants in the same node, including itself. It must be "true" for intra-node multicast communications. However, if a node runs only a single Cyclone DDS service and does not host any other DDSI-capable programs, it should be set to "false" for improved performance.
 
-The default value is: "true".
+The default value is: `true`
 
 
 .. _`//CycloneDDS/Domain/General/EntityAutoNaming`:
@@ -447,7 +447,7 @@ One of: empty, fancy
 
 This element specifies the entity autonaming mode. By default set to 'empty' which means no name will be set (but you can still use dds\_qset\_entity\_name). When set to 'fancy' participants, publishers, subscribers, writers, and readers will get randomly generated names. An autonamed entity will share a 3-letter prefix with their parent entity.
 
-The default value is: "empty".
+The default value is: `empty`
 
 
 .. _`//CycloneDDS/Domain/General/EntityAutoNaming[@seed]`:
@@ -459,7 +459,7 @@ Text
 
 Provide an initial seed for the entity naming. Your string will be hashed to provide the random state. When provided, the same sequence of names is generated every run. Creating your entities in the same order will ensure they are the same between runs. If you run multiple nodes, set this via environment variable to ensure every node generates unique names. A random starting seed is chosen when left empty, (the default). 
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 .. _`//CycloneDDS/Domain/General/ExternalNetworkAddress`:
@@ -471,7 +471,7 @@ Text
 
 This element allows explicitly overruling the network address Cyclone DDS advertises in the discovery protocol, which by default is the address of the preferred network interface (General/NetworkInterfaceAddress), to allow Cyclone DDS to communicate across a Network Address Translation (NAT) device.
 
-The default value is: "auto".
+The default value is: `auto`
 
 
 .. _`//CycloneDDS/Domain/General/ExternalNetworkMask`:
@@ -483,7 +483,7 @@ Text
 
 This element specifies the network mask of the external network address. This element is relevant only when an external network address (General/ExternalNetworkAddress) is explicitly configured. In this case locators received via the discovery protocol that are within the same external subnet (as defined by this mask) will be translated to an internal address by replacing the network portion of the external address with the corresponding portion of the preferred network interface address. This option is IPv4-only.
 
-The default value is: "0.0.0.0".
+The default value is: `0.0.0.0`
 
 
 .. _`//CycloneDDS/Domain/General/FragmentSize`:
@@ -497,7 +497,7 @@ This element specifies the size of DDSI sample fragments generated by Cyclone DD
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: "1344 B".
+The default value is: `1344 B`
 
 
 .. _`//CycloneDDS/Domain/General/Interfaces`:
@@ -529,7 +529,7 @@ Text
 
 This attribute specifies the address of the interface. With ipv4 allows  matching on the network part if the host part is set to zero. 
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 .. _`//CycloneDDS/Domain/General/Interfaces/NetworkInterface[@autodetermine]`:
@@ -541,7 +541,7 @@ Text
 
 If set to "true" an interface is automatically selected. Specifying a name or an address when automatic is set is considered an error.
 
-The default value is: "false".
+The default value is: `false`
 
 
 .. _`//CycloneDDS/Domain/General/Interfaces/NetworkInterface[@multicast]`:
@@ -552,7 +552,7 @@ The default value is: "false".
 Text
 
 This attribute specifies whether the interface should use multicast. On its default setting, 'default', it will use the value as return by the operating system. If set to 'true', the interface will be assumed to be multicast capable even when the interface flags returned by the operating system state it is not (this provides a workaround for some platforms). If set to 'false', the interface will never be used for multicast.
-The default value is: "default".
+The default value is: `default`
 
 
 .. _`//CycloneDDS/Domain/General/Interfaces/NetworkInterface[@name]`:
@@ -564,7 +564,7 @@ Text
 
 This attribute specifies the name of the interface. 
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 .. _`//CycloneDDS/Domain/General/Interfaces/NetworkInterface[@prefer_multicast]`:
@@ -576,7 +576,7 @@ Boolean
 
 When false (default), Cyclone DDS uses unicast for data whenever a single unicast suffices. Setting this to true makes it prefer multicasting data, falling back to unicast only when no multicast is available.
 
-The default value is: "false".
+The default value is: `false`
 
 
 .. _`//CycloneDDS/Domain/General/Interfaces/NetworkInterface[@presence_required]`:
@@ -588,7 +588,7 @@ Boolean
 
 By default, all specified network interfaces must be present; if they are missing Cyclone will not start. By explicitly setting this setting for an interface, you can instruct Cyclone to ignore that interface if it is not present.
 
-The default value is: "true".
+The default value is: `true`
 
 
 .. _`//CycloneDDS/Domain/General/Interfaces/NetworkInterface[@priority]`:
@@ -600,7 +600,7 @@ Text
 
 This attribute specifies the interface priority (decimal integer or default). The default value for loopback interfaces is 2, for all other interfaces it is 0.
 
-The default value is: "default".
+The default value is: `default`
 
 
 .. _`//CycloneDDS/Domain/General/MaxMessageSize`:
@@ -616,7 +616,7 @@ On some networks it may be necessary to set this item to keep the packetsize bel
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: "14720 B".
+The default value is: `14720 B`
 
 
 .. _`//CycloneDDS/Domain/General/MaxRexmitMessageSize`:
@@ -632,7 +632,7 @@ On some networks it may be necessary to set this item to keep the packetsize bel
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: "1456 B".
+The default value is: `1456 B`
 
 
 .. _`//CycloneDDS/Domain/General/MulticastRecvNetworkInterfaceAddresses`:
@@ -658,7 +658,7 @@ This element specifies which network interfaces Cyclone DDS listens to multicast
 
 If Cyclone DDS is in IPv6 mode and the address of the preferred network interface is a link-local address, "all" is treated as a synonym for "preferred" and a comma-separated list is treated as "preferred" if it contains the preferred interface and as "none" if not.
 
-The default value is: "preferred".
+The default value is: `preferred`
 
 
 .. _`//CycloneDDS/Domain/General/MulticastTimeToLive`:
@@ -670,7 +670,7 @@ Integer
 
 This element specifies the time-to-live setting for outgoing multicast packets.
 
-The default value is: "32".
+The default value is: `32`
 
 
 .. _`//CycloneDDS/Domain/General/RedundantNetworking`:
@@ -682,7 +682,7 @@ Boolean
 
 When enabled, use selected network interfaces in parallel for redundancy.
 
-The default value is: "false".
+The default value is: `false`
 
 
 .. _`//CycloneDDS/Domain/General/Transport`:
@@ -694,7 +694,7 @@ One of: default, udp, udp6, tcp, tcp6, raweth
 
 This element allows selecting the transport to be used (udp, udp6, tcp, tcp6, raweth)
 
-The default value is: "default".
+The default value is: `default`
 
 
 .. _`//CycloneDDS/Domain/General/UseIPv6`:
@@ -706,7 +706,7 @@ One of: false, true, default
 
 Deprecated (use Transport instead)
 
-The default value is: "default".
+The default value is: `default`
 
 
 .. _`//CycloneDDS/Domain/Internal`:
@@ -728,7 +728,7 @@ Integer
 
 Proxy readers that are assumed to still be retrieving historical data get this many samples retransmitted when they NACK something, even if some of these samples have sequence numbers outside the set covered by the NACK.
 
-The default value is: "0".
+The default value is: `0`
 
 
 .. _`//CycloneDDS/Domain/Internal/AckDelay`:
@@ -742,7 +742,7 @@ This setting controls the delay between sending identical acknowledgements.
 
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "10 ms".
+The default value is: `10 ms`
 
 
 .. _`//CycloneDDS/Domain/Internal/AutoReschedNackDelay`:
@@ -756,7 +756,7 @@ This setting controls the interval with which a reader will continue NACK'ing mi
 
 Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "3 s".
+The default value is: `3 s`
 
 
 .. _`//CycloneDDS/Domain/Internal/BuiltinEndpointSet`:
@@ -776,7 +776,7 @@ This element controls which participants will have which built-in endpoints for 
 
 The default is writers, as this is thought to be compliant and reasonably efficient. Minimal may or may not be compliant but is most efficient, and full is inefficient but certain to be compliant.
 
-The default value is: "writers".
+The default value is: `writers`
 
 
 .. _`//CycloneDDS/Domain/Internal/BurstSize`:
@@ -800,7 +800,7 @@ This element specifies how much more than the (presumed or discovered) receive b
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: "4294967295".
+The default value is: `4294967295`
 
 
 .. _`//CycloneDDS/Domain/Internal/BurstSize/MaxRexmit`:
@@ -814,7 +814,7 @@ This element specifies the amount of data to be retransmitted in response to one
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: "1 MiB".
+The default value is: `1 MiB`
 
 
 .. _`//CycloneDDS/Domain/Internal/ControlTopic`:
@@ -834,7 +834,7 @@ Integer
 
 This element sets the maximum number of extra threads for an experimental, undocumented, and unsupported direct mode.
 
-The default value is: "1".
+The default value is: `1`
 
 
 .. _`//CycloneDDS/Domain/Internal/DefragReliableMaxSamples`:
@@ -846,7 +846,7 @@ Integer
 
 This element sets the maximum number of samples that can be defragmented simultaneously for a reliable writer. This has to be large enough to handle retransmissions of historical data in addition to new samples.
 
-The default value is: "16".
+The default value is: `16`
 
 
 .. _`//CycloneDDS/Domain/Internal/DefragUnreliableMaxSamples`:
@@ -858,7 +858,7 @@ Integer
 
 This element sets the maximum number of samples that can be defragmented simultaneously for best-effort writers.
 
-The default value is: "4".
+The default value is: `4`
 
 
 .. _`//CycloneDDS/Domain/Internal/DeliveryQueueMaxSamples`:
@@ -870,7 +870,7 @@ Integer
 
 This element controls the maximum size of a delivery queue, expressed in samples. Once a delivery queue is full, incoming samples destined for that queue are dropped until space becomes available again.
 
-The default value is: "256".
+The default value is: `256`
 
 
 .. _`//CycloneDDS/Domain/Internal/EnableExpensiveChecks`:
@@ -892,7 +892,7 @@ This element enables expensive checks in builds with assertions enabled and is i
 
 In addition, there is the keyword all that enables all checks.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 .. _`//CycloneDDS/Domain/Internal/GenerateKeyhash`:
@@ -904,7 +904,7 @@ Boolean
 
 When true, include keyhashes in outgoing data for topics with keys.
 
-The default value is: "false".
+The default value is: `false`
 
 
 .. _`//CycloneDDS/Domain/Internal/HeartbeatInterval`:
@@ -920,7 +920,7 @@ This element allows configuring the base interval for sending writer heartbeats 
 
 Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "100 ms".
+The default value is: `100 ms`
 
 
 .. _`//CycloneDDS/Domain/Internal/HeartbeatInterval[@max]`:
@@ -934,7 +934,7 @@ This attribute sets the maximum interval for periodic heartbeats.
 
 Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "8 s".
+The default value is: `8 s`
 
 
 .. _`//CycloneDDS/Domain/Internal/HeartbeatInterval[@min]`:
@@ -948,7 +948,7 @@ This attribute sets the minimum interval that must have passed since the most re
 
 Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "5 ms".
+The default value is: `5 ms`
 
 
 .. _`//CycloneDDS/Domain/Internal/HeartbeatInterval[@minsched]`:
@@ -962,7 +962,7 @@ This attribute sets the minimum interval for periodic heartbeats. Other events m
 
 Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "20 ms".
+The default value is: `20 ms`
 
 
 .. _`//CycloneDDS/Domain/Internal/LateAckMode`:
@@ -974,7 +974,7 @@ Boolean
 
 Ack a sample only when it has been delivered, instead of when committed to delivering it.
 
-The default value is: "false".
+The default value is: `false`
 
 
 .. _`//CycloneDDS/Domain/Internal/LivelinessMonitoring`:
@@ -988,7 +988,7 @@ Boolean
 
 This element controls whether or not implementation should internally monitor its own liveliness. If liveliness monitoring is enabled, stack traces can be dumped automatically when some thread appears to have stopped making progress.
 
-The default value is: "false".
+The default value is: `false`
 
 
 .. _`//CycloneDDS/Domain/Internal/LivelinessMonitoring[@Interval]`:
@@ -1002,7 +1002,7 @@ This element controls the interval to check whether threads have been making pro
 
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "1s".
+The default value is: `1s`
 
 
 .. _`//CycloneDDS/Domain/Internal/LivelinessMonitoring[@StackTraces]`:
@@ -1014,7 +1014,7 @@ Boolean
 
 This element controls whether or not to write stack traces to the DDSI2 trace when a thread fails to make progress (on select platforms only).
 
-The default value is: "true".
+The default value is: `true`
 
 
 .. _`//CycloneDDS/Domain/Internal/MaxParticipants`:
@@ -1026,7 +1026,7 @@ Integer
 
 This elements configures the maximum number of DCPS domain participants this Cyclone DDS instance is willing to service. 0 is unlimited.
 
-The default value is: "0".
+The default value is: `0`
 
 
 .. _`//CycloneDDS/Domain/Internal/MaxQueuedRexmitBytes`:
@@ -1040,7 +1040,7 @@ This setting limits the maximum number of bytes queued for retransmission. The d
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: "512 kB".
+The default value is: `512 kB`
 
 
 .. _`//CycloneDDS/Domain/Internal/MaxQueuedRexmitMessages`:
@@ -1052,7 +1052,7 @@ Integer
 
 This setting limits the maximum number of samples queued for retransmission.
 
-The default value is: "200".
+The default value is: `200`
 
 
 .. _`//CycloneDDS/Domain/Internal/MaxSampleSize`:
@@ -1066,7 +1066,7 @@ This setting controls the maximum (CDR) serialised size of samples that Cyclone 
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: "2147483647 B".
+The default value is: `2147483647 B`
 
 
 .. _`//CycloneDDS/Domain/Internal/MeasureHbToAckLatency`:
@@ -1078,7 +1078,7 @@ Boolean
 
 This element enables heartbeat-to-ack latency among Cyclone DDS services by prepending timestamps to Heartbeat and AckNack messages and calculating round trip times. This is non-standard behaviour. The measured latencies are quite noisy and are currently not used anywhere.
 
-The default value is: "false".
+The default value is: `false`
 
 
 .. _`//CycloneDDS/Domain/Internal/MonitorPort`:
@@ -1090,7 +1090,7 @@ Integer
 
 This element allows configuring a service that dumps a text description of part the internal state to TCP clients. By default (-1), this is disabled; specifying 0 means a kernel-allocated port is used; a positive number is used as the TCP port number.
 
-The default value is: "-1".
+The default value is: `-1`
 
 
 .. _`//CycloneDDS/Domain/Internal/MultipleReceiveThreads`:
@@ -1104,7 +1104,7 @@ One of: false, true, default
 
 This element controls whether all traffic is handled by a single receive thread (false) or whether multiple receive threads may be used to improve latency (true). By default it is disabled on Windows because it appears that one cannot count on being able to send packets to oneself, which is necessary to stop the thread during shutdown. Currently multiple receive threads are only used for connectionless transport (e.g., UDP) and ManySocketsMode not set to single (the default).
 
-The default value is: "default".
+The default value is: `default`
 
 
 .. _`//CycloneDDS/Domain/Internal/MultipleReceiveThreads[@maxretries]`:
@@ -1116,7 +1116,7 @@ Integer
 
 Receive threads dedicated to a single socket can only be triggered for termination by sending a packet. Reception of any packet will do, so termination failure due to packet loss is exceedingly unlikely, but to eliminate all risks, it will retry as many times as specified by this attribute before aborting.
 
-The default value is: "4294967295".
+The default value is: `4294967295`
 
 
 .. _`//CycloneDDS/Domain/Internal/NackDelay`:
@@ -1130,7 +1130,7 @@ This setting controls the delay between receipt of a HEARTBEAT indicating missin
 
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "100 ms".
+The default value is: `100 ms`
 
 
 .. _`//CycloneDDS/Domain/Internal/PreEmptiveAckDelay`:
@@ -1144,7 +1144,7 @@ This setting controls the delay between the discovering a remote writer and send
 
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "10 ms".
+The default value is: `10 ms`
 
 
 .. _`//CycloneDDS/Domain/Internal/PrimaryReorderMaxSamples`:
@@ -1156,7 +1156,7 @@ Integer
 
 This element sets the maximum size in samples of a primary re-order administration. Each proxy writer has one primary re-order administration to buffer the packet flow in case some packets arrive out of order. Old samples are forwarded to secondary re-order administrations associated with readers needing historical data.
 
-The default value is: "128".
+The default value is: `128`
 
 
 .. _`//CycloneDDS/Domain/Internal/PrioritizeRetransmit`:
@@ -1168,7 +1168,7 @@ Boolean
 
 This element controls whether retransmits are prioritized over new data, speeding up recovery.
 
-The default value is: "true".
+The default value is: `true`
 
 
 .. _`//CycloneDDS/Domain/Internal/RediscoveryBlacklistDuration`:
@@ -1184,7 +1184,7 @@ This element controls for how long a remote participant that was previously dele
 
 Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "0s".
+The default value is: `0s`
 
 
 .. _`//CycloneDDS/Domain/Internal/RediscoveryBlacklistDuration[@enforce]`:
@@ -1196,7 +1196,7 @@ Boolean
 
 This attribute controls whether the configured time during which recently deleted participants will not be rediscovered (i.e., "black listed") is enforced and following complete removal of the participant in Cyclone DDS, or whether it can be rediscovered earlier provided all traces of that participant have been removed already.
 
-The default value is: "false".
+The default value is: `false`
 
 
 .. _`//CycloneDDS/Domain/Internal/RetransmitMerging`:
@@ -1216,7 +1216,7 @@ This elements controls the addressing and timing of retransmits. Possible values
 
 The default is never. See also Internal/RetransmitMergingPeriod.
 
-The default value is: "never".
+The default value is: `never`
 
 
 .. _`//CycloneDDS/Domain/Internal/RetransmitMergingPeriod`:
@@ -1232,7 +1232,7 @@ See also Internal/RetransmitMerging.
 
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "5 ms".
+The default value is: `5 ms`
 
 
 .. _`//CycloneDDS/Domain/Internal/RetryOnRejectBestEffort`:
@@ -1244,7 +1244,7 @@ Boolean
 
 Whether or not to locally retry pushing a received best-effort sample into the reader caches when resource limits are reached.
 
-The default value is: "false".
+The default value is: `false`
 
 
 .. _`//CycloneDDS/Domain/Internal/SPDPResponseMaxDelay`:
@@ -1258,7 +1258,7 @@ Maximum pseudo-random delay in milliseconds between discovering aremote particip
 
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "0 ms".
+The default value is: `0 ms`
 
 
 .. _`//CycloneDDS/Domain/Internal/ScheduleTimeRounding`:
@@ -1272,7 +1272,7 @@ This setting allows the timing of scheduled events to be rounded up so that more
 
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "0 ms".
+The default value is: `0 ms`
 
 
 .. _`//CycloneDDS/Domain/Internal/SecondaryReorderMaxSamples`:
@@ -1284,7 +1284,7 @@ Integer
 
 This element sets the maximum size in samples of a secondary re-order administration. The secondary re-order administration is per reader needing historical data.
 
-The default value is: "128".
+The default value is: `128`
 
 
 .. _`//CycloneDDS/Domain/Internal/SocketReceiveBufferSize`:
@@ -1310,7 +1310,7 @@ This sets the size of the socket receive buffer to request, with the special val
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: "default".
+The default value is: `default`
 
 
 .. _`//CycloneDDS/Domain/Internal/SocketReceiveBufferSize[@min]`:
@@ -1324,7 +1324,7 @@ This sets the minimum acceptable socket receive buffer size, with the special va
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: "default".
+The default value is: `default`
 
 
 .. _`//CycloneDDS/Domain/Internal/SocketSendBufferSize`:
@@ -1350,7 +1350,7 @@ This sets the size of the socket send buffer to request, with the special value 
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: "default".
+The default value is: `default`
 
 
 .. _`//CycloneDDS/Domain/Internal/SocketSendBufferSize[@min]`:
@@ -1364,7 +1364,7 @@ This sets the minimum acceptable socket send buffer size, with the special value
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: "64 KiB".
+The default value is: `64 KiB`
 
 
 .. _`//CycloneDDS/Domain/Internal/SquashParticipants`:
@@ -1376,7 +1376,7 @@ Boolean
 
 This element controls whether Cyclone DDS advertises all the domain participants it serves in DDSI (when set to false), or rather only one domain participant (the one corresponding to the Cyclone DDS process; when set to true). In the latter case, Cyclone DDS becomes the virtual owner of all readers and writers of all domain participants, dramatically reducing discovery traffic (a similar effect can be obtained by setting Internal/BuiltinEndpointSet to "minimal" but with less loss of information).
 
-The default value is: "false".
+The default value is: `false`
 
 
 .. _`//CycloneDDS/Domain/Internal/SynchronousDeliveryLatencyBound`:
@@ -1390,7 +1390,7 @@ This element controls whether samples sent by a writer with QoS settings transpo
 
 Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "inf".
+The default value is: `inf`
 
 
 .. _`//CycloneDDS/Domain/Internal/SynchronousDeliveryPriorityThreshold`:
@@ -1402,7 +1402,7 @@ Integer
 
 This element controls whether samples sent by a writer with QoS settings latency\_budget <= SynchronousDeliveryLatencyBound and transport\_priority greater than or equal to this element's value will be delivered synchronously from the "recv" thread, all others will be delivered asynchronously through delivery queues. This reduces latency at the expense of aggregate bandwidth.
 
-The default value is: "0".
+The default value is: `0`
 
 
 .. _`//CycloneDDS/Domain/Internal/Test`:
@@ -1424,7 +1424,7 @@ Integer
 
 This element controls the fraction of outgoing packets to drop, specified as samples per thousand.
 
-The default value is: "0".
+The default value is: `0`
 
 
 .. _`//CycloneDDS/Domain/Internal/UnicastResponseToSPDPMessages`:
@@ -1436,7 +1436,7 @@ Boolean
 
 This element controls whether the response to a newly discovered participant is sent as a unicasted SPDP packet instead of rescheduling the periodic multicasted one. There is no known benefit to setting this to false.
 
-The default value is: "true".
+The default value is: `true`
 
 
 .. _`//CycloneDDS/Domain/Internal/UseMulticastIfMreqn`:
@@ -1448,7 +1448,7 @@ Integer
 
 Do not use.
 
-The default value is: "0".
+The default value is: `0`
 
 
 .. _`//CycloneDDS/Domain/Internal/Watermarks`:
@@ -1470,7 +1470,7 @@ Boolean
 
 This element controls whether Cyclone DDS will adapt the high-water mark to current traffic conditions based on retransmit requests and transmit pressure.
 
-The default value is: "true".
+The default value is: `true`
 
 
 .. _`//CycloneDDS/Domain/Internal/Watermarks/WhcHigh`:
@@ -1484,7 +1484,7 @@ This element sets the maximum allowed high-water mark for the Cyclone DDS WHCs, 
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: "500 kB".
+The default value is: `500 kB`
 
 
 .. _`//CycloneDDS/Domain/Internal/Watermarks/WhcHighInit`:
@@ -1498,7 +1498,7 @@ This element sets the initial level of the high-water mark for the Cyclone DDS W
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: "30 kB".
+The default value is: `30 kB`
 
 
 .. _`//CycloneDDS/Domain/Internal/Watermarks/WhcLow`:
@@ -1512,7 +1512,7 @@ This element sets the low-water mark for the Cyclone DDS WHCs, expressed in byte
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: "1 kB".
+The default value is: `1 kB`
 
 
 .. _`//CycloneDDS/Domain/Internal/WriteBatch`:
@@ -1524,7 +1524,7 @@ Boolean
 
 This element enables the batching of write operations. By default each write operation writes through the write cache and out onto the transport. Enabling write batching causes multiple small write operations to be aggregated within the write cache into a single larger write. This gives greater throughput at the expense of latency. Currently, there is no mechanism for the write cache to automatically flush itself, so that if write batching is enabled, the application may have to use the dds\_write\_flush function to ensure that all samples are written.
 
-The default value is: "false".
+The default value is: `false`
 
 
 .. _`//CycloneDDS/Domain/Internal/WriterLingerDuration`:
@@ -1537,7 +1537,7 @@ Number-with-unit
 This setting controls the maximum duration for which actual deletion of a reliable writer with unacknowledged data in its history will be postponed to provide proper reliable transmission.
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "1 s".
+The default value is: `1 s`
 
 
 .. _`//CycloneDDS/Domain/Partitioning`:
@@ -1571,7 +1571,7 @@ Text
 
 This element can prevent certain combinations of DCPS partition and topic from being transmitted over the network. Cyclone DDS will completely ignore readers and writers for which all DCPS partitions as well as their topic is ignored, not even creating DDSI readers and writers to mirror the DCPS ones.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 .. _`//CycloneDDS/Domain/Partitioning/IgnoredPartitions/IgnoredPartition[@DCPSPartitionTopic]`:
@@ -1583,7 +1583,7 @@ Text
 
 This attribute specifies a partition and a topic expression, separated by a single '.', which are used to determine if a given partition and topic will be ignored or not. The expressions may use the usual wildcards '\*' and '?'. Cyclone DDS will consider a wildcard DCPS partition to match an expression if a string that satisfies both expressions exists.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 .. _`//CycloneDDS/Domain/Partitioning/NetworkPartitions`:
@@ -1607,7 +1607,7 @@ Text
 
 This element defines a Cyclone DDS network partition.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 .. _`//CycloneDDS/Domain/Partitioning/NetworkPartitions/NetworkPartition[@Address]`:
@@ -1624,7 +1624,7 @@ Readers matching this network partition (cf. Partitioning/PartitionMappings) wil
 
 The unicast addresses advertised by a reader are the only unicast addresses a writer will use to send data to it and are used to select the subset of network interfaces to use for transmitting multicast data with the intent of reaching it.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 .. _`//CycloneDDS/Domain/Partitioning/NetworkPartitions/NetworkPartition[@Interface]`:
@@ -1636,7 +1636,7 @@ Text
 
 This attribute takes a comma-separated list of interface name that the reader is willing to receive data on. This is implemented by adding the interface addresses to the set address set configured using the sibling "Address" attribute. See there for more details.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 .. _`//CycloneDDS/Domain/Partitioning/NetworkPartitions/NetworkPartition[@Name]`:
@@ -1648,7 +1648,7 @@ Text
 
 This attribute specifies the name of this Cyclone DDS network partition. Two network partitions cannot have the same name. Partition mappings (cf. Partitioning/PartitionMappings) refer to network partitions using these names.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 .. _`//CycloneDDS/Domain/Partitioning/PartitionMappings`:
@@ -1672,7 +1672,7 @@ Text
 
 This element defines a mapping from a DCPS partition/topic combination to a Cyclone DDS network partition. This allows partitioning data flows by using special multicast addresses for part of the data and possibly encrypting the data flow.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 .. _`//CycloneDDS/Domain/Partitioning/PartitionMappings/PartitionMapping[@DCPSPartitionTopic]`:
@@ -1684,7 +1684,7 @@ Text
 
 This attribute specifies a partition and a topic expression, separated by a single '.', which are used to determine if a given partition and topic maps to the Cyclone DDS network partition named by the NetworkPartition attribute in this PartitionMapping element. The expressions may use the usual wildcards '\*' and '?'. Cyclone DDS will consider a wildcard DCPS partition to match an expression if there exists a string that satisfies both expressions.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 .. _`//CycloneDDS/Domain/Partitioning/PartitionMappings/PartitionMapping[@NetworkPartition]`:
@@ -1696,7 +1696,7 @@ Text
 
 This attribute specifies which Cyclone DDS network partition is to be used for DCPS partition/topic combinations matching the DCPSPartitionTopic attribute within this PartitionMapping element.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 .. _`//CycloneDDS/Domain/SSL`:
@@ -1718,7 +1718,7 @@ Boolean
 
 If disabled this allows SSL connections to occur even if an X509 certificate fails verification.
 
-The default value is: "true".
+The default value is: `true`
 
 
 .. _`//CycloneDDS/Domain/SSL/Ciphers`:
@@ -1730,7 +1730,7 @@ Text
 
 The set of ciphers used by SSL/TLS
 
-The default value is: "ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH".
+The default value is: `ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH`
 
 
 .. _`//CycloneDDS/Domain/SSL/Enable`:
@@ -1742,7 +1742,7 @@ Boolean
 
 This enables SSL/TLS for TCP.
 
-The default value is: "false".
+The default value is: `false`
 
 
 .. _`//CycloneDDS/Domain/SSL/EntropyFile`:
@@ -1754,7 +1754,7 @@ Text
 
 The SSL/TLS random entropy file name.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 .. _`//CycloneDDS/Domain/SSL/KeyPassphrase`:
@@ -1766,7 +1766,7 @@ Text
 
 The SSL/TLS key pass phrase for encrypted keys.
 
-The default value is: "secret".
+The default value is: `secret`
 
 
 .. _`//CycloneDDS/Domain/SSL/KeystoreFile`:
@@ -1778,7 +1778,7 @@ Text
 
 The SSL/TLS key and certificate store file name. The keystore must be in PEM format.
 
-The default value is: "keystore".
+The default value is: `keystore`
 
 
 .. _`//CycloneDDS/Domain/SSL/MinimumTLSVersion`:
@@ -1790,7 +1790,7 @@ Text
 
 The minimum TLS version that may be negotiated, valid values are 1.2 and 1.3.
 
-The default value is: "1.3".
+The default value is: `1.3`
 
 
 .. _`//CycloneDDS/Domain/SSL/SelfSignedCertificates`:
@@ -1802,7 +1802,7 @@ Boolean
 
 This enables the use of self signed X509 certificates.
 
-The default value is: "false".
+The default value is: `false`
 
 
 .. _`//CycloneDDS/Domain/SSL/VerifyClient`:
@@ -1814,7 +1814,7 @@ Boolean
 
 This enables an SSL server to check the X509 certificate of a connecting client.
 
-The default value is: "true".
+The default value is: `true`
 
 
 .. _`//CycloneDDS/Domain/Security`:
@@ -1888,7 +1888,7 @@ MIIDuAYJKoZIhv ...al5s=
 
 ------F9A8A198D6F08E1285A292ADF14DD04F-]]</Governance>
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 .. _`//CycloneDDS/Domain/Security/AccessControl/Library`:
@@ -1902,7 +1902,7 @@ Text
 
 This element specifies the library to be loaded as the DDS Security Access Control plugin.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 .. _`//CycloneDDS/Domain/Security/AccessControl/Library[@finalizeFunction]`:
@@ -1914,7 +1914,7 @@ Text
 
 This element names the finalization function of Access Control plugin. This function is called to let the plugin release its resources.
 
-The default value is: "finalize\_access\_control".
+The default value is: `finalize\_access\_control`
 
 
 .. _`//CycloneDDS/Domain/Security/AccessControl/Library[@initFunction]`:
@@ -1926,7 +1926,7 @@ Text
 
 This element names the initialization function of Access Control plugin. This function is called after loading the plugin library for instantiation purposes. The Init function must return an object that implements the DDS Security Access Control interface.
 
-The default value is: "init\_access\_control".
+The default value is: `init\_access\_control`
 
 
 .. _`//CycloneDDS/Domain/Security/AccessControl/Library[@path]`:
@@ -1942,7 +1942,7 @@ It can be either absolute path excluding file extension ( /usr/lib/dds\_security
 
 If a single file is supplied, the library is located by the current working directory, or LD\_LIBRARY\_PATH for Unix systems, and PATH for Windows systems.
 
-The default value is: "dds\_security\_ac".
+The default value is: `dds\_security\_ac`
 
 
 .. _`//CycloneDDS/Domain/Security/AccessControl/Permissions`:
@@ -1965,7 +1965,7 @@ Example data URI:
 
 <Permissions><![CDATA[data:,.........]]</Permissions>
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 .. _`//CycloneDDS/Domain/Security/AccessControl/PermissionsCA`:
@@ -1990,7 +1990,7 @@ MIIC3DCCAcQCCQCWE5x+Z ... PhovK0mp2ohhRLYI0ZiyYQ==
 
 -----END CERTIFICATE-----</PermissionsCA>
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 .. _`//CycloneDDS/Domain/Security/Authentication`:
@@ -2022,7 +2022,7 @@ Examples:
 MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg=<br>
 -----END X509 CRL-----</CRL>
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 .. _`//CycloneDDS/Domain/Security/Authentication/IdentityCA`:
@@ -2046,7 +2046,7 @@ Examples:
 MIIC3DCCAcQCCQCWE5x+Z...PhovK0mp2ohhRLYI0ZiyYQ==<br>
 -----END CERTIFICATE-----</IdentityCA>
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 .. _`//CycloneDDS/Domain/Security/Authentication/IdentityCertificate`:
@@ -2068,7 +2068,7 @@ Examples:
 MIIDjjCCAnYCCQDCEu9...6rmT87dhTo=<br>
 -----END CERTIFICATE-----</IdentityCertificate>
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 .. _`//CycloneDDS/Domain/Security/Authentication/IncludeOptionalFields`:
@@ -2080,7 +2080,7 @@ Boolean
 
 The authentication handshake tokens may contain optional fields to be included for finding interoperability problems. If this parameter is set to true the optional fields are included in the handshake token exchange.
 
-The default value is: "false".
+The default value is: `false`
 
 
 .. _`//CycloneDDS/Domain/Security/Authentication/Library`:
@@ -2094,7 +2094,7 @@ Text
 
 This element specifies the library to be loaded as the DDS Security Access Control plugin.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 .. _`//CycloneDDS/Domain/Security/Authentication/Library[@finalizeFunction]`:
@@ -2106,7 +2106,7 @@ Text
 
 This element names the finalization function of the Authentication plugin. This function is called to let the plugin release its resources.
 
-The default value is: "finalize\_authentication".
+The default value is: `finalize\_authentication`
 
 
 .. _`//CycloneDDS/Domain/Security/Authentication/Library[@initFunction]`:
@@ -2118,7 +2118,7 @@ Text
 
 This element names the initialization function of the Authentication plugin. This function is called after loading the plugin library for instantiation purposes. The Init function must return an object that implements the DDS Security Authentication interface.
 
-The default value is: "init\_authentication".
+The default value is: `init\_authentication`
 
 
 .. _`//CycloneDDS/Domain/Security/Authentication/Library[@path]`:
@@ -2134,7 +2134,7 @@ It can be either absolute path excluding file extension ( /usr/lib/dds\_security
 
 If a single file is supplied, the library is located by the current working directory, or LD\_LIBRARY\_PATH for Unix systems, and PATH for Windows systems.
 
-The default value is: "dds\_security\_auth".
+The default value is: `dds\_security\_auth`
 
 
 .. _`//CycloneDDS/Domain/Security/Authentication/Password`:
@@ -2150,7 +2150,7 @@ The value of the password property shall be interpreted as the Base64 encoding o
 
 If the password property is not present, then the value supplied in the private\_key property must contain the unencrypted private key.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 .. _`//CycloneDDS/Domain/Security/Authentication/PrivateKey`:
@@ -2172,7 +2172,7 @@ Examples:
 MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==<br>
 -----END RSA PRIVATE KEY-----</PrivateKey>
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 .. _`//CycloneDDS/Domain/Security/Authentication/TrustedCADirectory`:
@@ -2184,7 +2184,7 @@ Text
 
 Trusted CA Directory which contains trusted CA certificates as separated files.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 .. _`//CycloneDDS/Domain/Security/Cryptographic`:
@@ -2208,7 +2208,7 @@ Text
 
 This element specifies the library to be loaded as the DDS Security Cryptographic plugin.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 .. _`//CycloneDDS/Domain/Security/Cryptographic/Library[@finalizeFunction]`:
@@ -2220,7 +2220,7 @@ Text
 
 This element names the finalization function of the Cryptographic plugin. This function is called to let the plugin release its resources.
 
-The default value is: "finalize\_crypto".
+The default value is: `finalize\_crypto`
 
 
 .. _`//CycloneDDS/Domain/Security/Cryptographic/Library[@initFunction]`:
@@ -2232,7 +2232,7 @@ Text
 
 This element names the initialization function of the Cryptographic plugin. This function is called after loading the plugin library for instantiation purposes. The Init function must return an object that implements the DDS Security Cryptographic interface.
 
-The default value is: "init\_crypto".
+The default value is: `init\_crypto`
 
 
 .. _`//CycloneDDS/Domain/Security/Cryptographic/Library[@path]`:
@@ -2248,7 +2248,7 @@ It can be either absolute path excluding file extension ( /usr/lib/dds\_security
 
 If a single file is supplied, the is library located by the current working directory, or LD\_LIBRARY\_PATH for Unix systems, and PATH for Windows systems.
 
-The default value is: "dds\_security\_crypto".
+The default value is: `dds\_security\_crypto`
 
 
 .. _`//CycloneDDS/Domain/SharedMemory`:
@@ -2270,7 +2270,7 @@ Boolean
 
 This element allows for enabling shared memory in Cyclone DDS.
 
-The default value is: "false".
+The default value is: `false`
 
 
 .. _`//CycloneDDS/Domain/SharedMemory/Locator`:
@@ -2282,7 +2282,7 @@ Text
 
 Explicitly set the Iceoryx locator used by Cyclone to check whether a pair of processes is attached to the same Iceoryx shared memory.  The default is to use one of the MAC addresses of the machine, which should work well in most cases.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 .. _`//CycloneDDS/Domain/SharedMemory/LogLevel`:
@@ -2309,7 +2309,7 @@ This element decides the verbosity level of shared memory message:
 
 If you don't want to see any log from shared memory, use off to disable logging.
 
-The default value is: "info".
+The default value is: `info`
 
 
 .. _`//CycloneDDS/Domain/SharedMemory/Prefix`:
@@ -2321,7 +2321,7 @@ Text
 
 Override the Iceoryx service name used by Cyclone.
 
-The default value is: "DDS\_CYCLONE".
+The default value is: `DDS\_CYCLONE`
 
 
 .. _`//CycloneDDS/Domain/Sizing`:
@@ -2345,7 +2345,7 @@ This element specifies the size of one allocation unit in the receive buffer. It
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: "128 KiB".
+The default value is: `128 KiB`
 
 
 .. _`//CycloneDDS/Domain/Sizing/ReceiveBufferSize`:
@@ -2359,7 +2359,7 @@ This element sets the size of a single receive buffer. Many receive buffers may 
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: "1 MiB".
+The default value is: `1 MiB`
 
 
 .. _`//CycloneDDS/Domain/TCP`:
@@ -2381,7 +2381,7 @@ Boolean
 
 Setting this to true means the unicast addresses in SPDP packets will be ignored, and the peer address from the TCP connection will be used instead. This may help work around incorrectly advertised addresses when using TCP.
 
-The default value is: "false".
+The default value is: `false`
 
 
 .. _`//CycloneDDS/Domain/TCP/Enable`:
@@ -2393,7 +2393,7 @@ One of: false, true, default
 
 This element enables the optional TCP transport - deprecated, use General/Transport instead.
 
-The default value is: "default".
+The default value is: `default`
 
 
 .. _`//CycloneDDS/Domain/TCP/NoDelay`:
@@ -2405,7 +2405,7 @@ Boolean
 
 This element enables the TCP\_NODELAY socket option, preventing multiple DDSI messages from being sent in the same TCP request. Setting this option typically optimises latency over throughput.
 
-The default value is: "true".
+The default value is: `true`
 
 
 .. _`//CycloneDDS/Domain/TCP/Port`:
@@ -2417,7 +2417,7 @@ Integer
 
 This element specifies the TCP port number on which Cyclone DDS accepts connections. If the port is set, it is used in entity locators, published with DDSI discovery, dynamically allocated if zero, and disabled if -1 or not configured. If disabled other DDSI services will not be able to establish connections with the service, the service can only communicate by establishing connections to other services.
 
-The default value is: "-1".
+The default value is: `-1`
 
 
 .. _`//CycloneDDS/Domain/TCP/ReadTimeout`:
@@ -2431,7 +2431,7 @@ This element specifies the timeout for blocking TCP read operations. If this tim
 
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "2 s".
+The default value is: `2 s`
 
 
 .. _`//CycloneDDS/Domain/TCP/WriteTimeout`:
@@ -2445,7 +2445,7 @@ This element specifies the timeout for blocking TCP write operations. If this ti
 
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "2 s".
+The default value is: `2 s`
 
 
 .. _`//CycloneDDS/Domain/Threads`:
@@ -2497,7 +2497,7 @@ The Name of the thread for which properties are being set. The following threads
  * tev.CHAN: timed-event thread for channel CHAN.
 
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 .. _`//CycloneDDS/Domain/Threads/Thread/Scheduling`:
@@ -2519,7 +2519,7 @@ One of: realtime, timeshare, default
 
 This element specifies the thread scheduling class (realtime, timeshare or default). The user may need special privileges from the underlying operating system to be able to assign some of the privileged scheduling classes.
 
-The default value is: "default".
+The default value is: `default`
 
 
 .. _`//CycloneDDS/Domain/Threads/Thread/Scheduling/Priority`:
@@ -2531,7 +2531,7 @@ Text
 
 This element specifies the thread priority (decimal integer or default). Only priorities supported by the underlying operating system can be assigned to this element. The user may need special privileges from the underlying operating system to be able to assign some of the privileged priorities.
 
-The default value is: "default".
+The default value is: `default`
 
 
 .. _`//CycloneDDS/Domain/Threads/Thread/StackSize`:
@@ -2545,7 +2545,7 @@ This element configures the stack size for this thread. The default value defaul
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: "default".
+The default value is: `default`
 
 
 .. _`//CycloneDDS/Domain/Tracing`:
@@ -2567,7 +2567,7 @@ Boolean
 
 This option specifies whether the output should be appended to an existing log file. The default is to create a new log file each time, which is generally the best option if a detailed log is generated.
 
-The default value is: "false".
+The default value is: `false`
 
 
 .. _`//CycloneDDS/Domain/Tracing/Category`:
@@ -2613,7 +2613,7 @@ This element enables individual logging categories. These are enabled in additio
 In addition, there is the keyword trace that enables all but radmin, topic, plist and whc.
 The categorisation of tracing output is incomplete and hence most of the verbosity levels and categories are not of much use in the current release. This is an ongoing process and here we describe the target situation rather than the current situation. Currently, the most useful is trace.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 .. _`//CycloneDDS/Domain/Tracing/OutputFile`:
@@ -2625,7 +2625,7 @@ Text
 
 This option specifies where the logging is printed to. Note that stdout and stderr are treated as special values, representing "standard out" and "standard error" respectively. No file is created unless logging categories are enabled using the Tracing/Verbosity or Tracing/EnabledCategory settings.
 
-The default value is: "cyclonedds.log".
+The default value is: `cyclonedds.log`
 
 
 .. _`//CycloneDDS/Domain/Tracing/PacketCaptureFile`:
@@ -2637,7 +2637,7 @@ Text
 
 This option specifies the file to which received and sent packets will be logged in the "pcap" format suitable for analysis using common networking tools, such as WireShark. IP and UDP headers are fictitious, in particular the destination address of received packets. The TTL may be used to distinguish between sent and received packets: it is 255 for sent packets and 128 for received ones. Currently IPv4 only.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 .. _`//CycloneDDS/Domain/Tracing/Verbosity`:
@@ -2669,7 +2669,7 @@ While none prevents any message from being written to a DDSI2 log file.
 
 The categorisation of tracing output is incomplete and hence most of the verbosity levels and categories are not of much use in the current release. This is an ongoing process and here we describe the target situation rather than the current situation. Currently, the most useful verbosity levels are config, fine and finest.
 
-The default value is: "none".
+The default value is: `none`
 
 ..
    generated from ddsi_config.h[75edea6617af11bacc46f91e519773f6df580655] 
@@ -2677,9 +2677,9 @@ The default value is: "none".
    generated from ddsi_cfgelems.h[11913cd398f1cd1b52e06d924718df62a5981beb] 
    generated from ddsi_config.c[ed9898f72f9dbcfa20ce7706835da091efcea0ca] 
    generated from _confgen.h[f2d235d5551cbf920a8a2962831dddeabd2856ac] 
-   generated from _confgen.c[1193219ddb4769b90566cf197e73d22fb6f75835] 
+   generated from _confgen.c[ba2e8c0cfd41039421548fdb03bcd2db8f8b172e] 
    generated from generate_rnc.c[a2ec6e48d33ac14a320c8ec3f320028a737920e0] 
-   generated from generate_md.c[a61b6a9649d18afeca4c73b5784f36989d7994e0] 
-   generated from generate_rst.c[34dcb6b5e2ac2cd15e78497107ce0b6eed6e6e94] 
+   generated from generate_md.c[37efe4fa9caf56e2647bafc9a7f009f72ff5d2e0] 
+   generated from generate_rst.c[32da07860a0043708b47e9f793b63ca05f5106bb] 
    generated from generate_xsd.c[45064e8869b3c00573057d7c8f02d20f04b40e16] 
    generated from generate_defconfig.c[eec9ab7b2d053e68500799b693d089e84153a37b] 

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -1880,6 +1880,6 @@ The default value is: `none`
 <!--- generated from _confgen.c[ba2e8c0cfd41039421548fdb03bcd2db8f8b172e] -->
 <!--- generated from generate_rnc.c[a2ec6e48d33ac14a320c8ec3f320028a737920e0] -->
 <!--- generated from generate_md.c[37efe4fa9caf56e2647bafc9a7f009f72ff5d2e0] -->
-<!--- generated from generate_rst.c[32da07860a0043708b47e9f793b63ca05f5106bb] -->
+<!--- generated from generate_rst.c[50739f627792ef056e2b4feeb20fda4edfcef079] -->
 <!--- generated from generate_xsd.c[45064e8869b3c00573057d7c8f02d20f04b40e16] -->
 <!--- generated from generate_defconfig.c[eec9ab7b2d053e68500799b693d089e84153a37b] -->

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -16,7 +16,7 @@ Text
 
 Domain id this configuration applies to, or "any" if it applies to all domain ids.
 
-The default value is: "any".
+The default value is: `any`
 
 
 ### //CycloneDDS/Domain/Compatibility
@@ -30,7 +30,7 @@ Boolean
 
 This option assumes ParticipantMessageData endpoints required by the liveliness protocol are present in RTI participants even when not properly advertised by the participant discovery protocol.
 
-The default value is: "false".
+The default value is: `false`
 
 
 #### //CycloneDDS/Domain/Compatibility/ExplicitlyPublishQosSetToDefault
@@ -40,7 +40,7 @@ This element specifies whether QoS settings set to default values are explicitly
 
 When interoperability is required with an implementation that does not follow the specifications in this regard, setting this option to true will help.
 
-The default value is: "false".
+The default value is: `false`
 
 
 #### //CycloneDDS/Domain/Compatibility/ManySocketsMode
@@ -50,7 +50,7 @@ This option specifies whether a network socket will be created for each domain p
 
 Disabling it slightly improves performance and reduces network traffic somewhat. It also causes the set of port numbers needed by Cyclone DDS to become predictable, which may be useful for firewall and NAT configuration.
 
-The default value is: "single".
+The default value is: `single`
 
 
 #### //CycloneDDS/Domain/Compatibility/StandardsConformance
@@ -63,7 +63,7 @@ This element sets the level of standards conformance of this instance of the Cyc
 
  * lax: attempt to provide the smoothest possible interoperability, anticipating future revisions of elements in the standard in areas that other implementations do not adhere to, even though there is no good reason not to.
 
-The default value is: "lax".
+The default value is: `lax`
 
 
 ### //CycloneDDS/Domain/Discovery
@@ -79,7 +79,7 @@ This setting controls for how long endpoints discovered via a Cloud discovery se
 
 Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "30 s".
+The default value is: `30 s`
 
 
 #### //CycloneDDS/Domain/Discovery/DefaultMulticastAddress
@@ -87,7 +87,7 @@ Text
 
 This element specifies the default multicast address for all traffic other than participant discovery packets. It defaults to Discovery/SPDPMulticastAddress.
 
-The default value is: "auto".
+The default value is: `auto`
 
 
 #### //CycloneDDS/Domain/Discovery/EnableTopicDiscoveryEndpoints
@@ -95,7 +95,7 @@ Boolean
 
 This element controls whether the built-in endpoints for topic discovery are created and used to exchange topic discovery information.
 
-The default value is: "false".
+The default value is: `false`
 
 
 #### //CycloneDDS/Domain/Discovery/ExternalDomainId
@@ -103,7 +103,7 @@ Text
 
 An override for the domain id is used to discovery and determine the port number mapping. This allows the creating of multiple domains in a single process while making them appear as a single domain on the network. The value "default" disables the override.
 
-The default value is: "default".
+The default value is: `default`
 
 
 #### //CycloneDDS/Domain/Discovery/LeaseDuration
@@ -112,7 +112,7 @@ Number-with-unit
 This setting controls the default participant lease duration.
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "10 s".
+The default value is: `10 s`
 
 
 #### //CycloneDDS/Domain/Discovery/MaxAutoParticipantIndex
@@ -120,7 +120,7 @@ Integer
 
 This element specifies the maximum DDSI participant index selected by this instance of the Cyclone DDS service if the Discovery/ParticipantIndex is "auto".
 
-The default value is: "9".
+The default value is: `9`
 
 
 #### //CycloneDDS/Domain/Discovery/ParticipantIndex
@@ -133,7 +133,7 @@ This element specifies the DDSI participant index used by this instance of the C
 
  * none:, which causes it to use arbitrary port numbers for unicast sockets which entirely removes the constraints on the participant index but makes unicast discovery impossible.
 
-The default value is: "none".
+The default value is: `none`
 
 
 #### //CycloneDDS/Domain/Discovery/Peers
@@ -153,7 +153,7 @@ Text
 
 This element specifies an IP address to which discovery packets must be sent, in addition to the default multicast address (see also General/AllowMulticast). Both hostnames and a numerical IP address are accepted; the hostname or IP address may be suffixed with :PORT to explicitly set the port to which it must be sent. Multiple Peers may be specified.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 #### //CycloneDDS/Domain/Discovery/Ports
@@ -167,7 +167,7 @@ Integer
 
 This element specifies the base port number (refer to the DDSI 2.1 specification, section 9.6.1, constant PB).
 
-The default value is: "7400".
+The default value is: `7400`
 
 
 ##### //CycloneDDS/Domain/Discovery/Ports/DomainGain
@@ -175,7 +175,7 @@ Integer
 
 This element specifies the domain gain, relating domain ids to sets of port numbers (refer to the DDSI 2.1 specification, section 9.6.1, constant DG).
 
-The default value is: "250".
+The default value is: `250`
 
 
 ##### //CycloneDDS/Domain/Discovery/Ports/MulticastDataOffset
@@ -183,7 +183,7 @@ Integer
 
 This element specifies the port number for multicast data traffic (refer to the DDSI 2.1 specification, section 9.6.1, constant d2).
 
-The default value is: "1".
+The default value is: `1`
 
 
 ##### //CycloneDDS/Domain/Discovery/Ports/MulticastMetaOffset
@@ -191,7 +191,7 @@ Integer
 
 This element specifies the port number for multicast meta traffic (refer to the DDSI 2.1 specification, section 9.6.1, constant d0).
 
-The default value is: "0".
+The default value is: `0`
 
 
 ##### //CycloneDDS/Domain/Discovery/Ports/ParticipantGain
@@ -199,7 +199,7 @@ Integer
 
 This element specifies the participant gain, relating p0, participant index to sets of port numbers (refer to the DDSI 2.1 specification, section 9.6.1, constant PG).
 
-The default value is: "2".
+The default value is: `2`
 
 
 ##### //CycloneDDS/Domain/Discovery/Ports/UnicastDataOffset
@@ -207,7 +207,7 @@ Integer
 
 This element specifies the port number for unicast data traffic (refer to the DDSI 2.1 specification, section 9.6.1, constant d3).
 
-The default value is: "11".
+The default value is: `11`
 
 
 ##### //CycloneDDS/Domain/Discovery/Ports/UnicastMetaOffset
@@ -215,7 +215,7 @@ Integer
 
 This element specifies the port number for unicast meta traffic (refer to the DDSI 2.1 specification, section 9.6.1, constant d1).
 
-The default value is: "10".
+The default value is: `10`
 
 
 #### //CycloneDDS/Domain/Discovery/SPDPInterval
@@ -225,7 +225,7 @@ This element specifies the interval between spontaneous transmissions of partici
 
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "30 s".
+The default value is: `30 s`
 
 
 #### //CycloneDDS/Domain/Discovery/SPDPMulticastAddress
@@ -233,7 +233,7 @@ Text
 
 This element specifies the multicast address used as the destination for the participant discovery packets. In IPv4 mode the default is the (standardised) 239.255.0.1, in IPv6 mode it becomes ff02::ffff:239.255.0.1, which is a non-standardised link-local multicast address.
 
-The default value is: "239.255.0.1".
+The default value is: `239.255.0.1`
 
 
 #### //CycloneDDS/Domain/Discovery/Tag
@@ -241,7 +241,7 @@ Text
 
 String extension for domain id that remote participants must match to be discovered.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 ### //CycloneDDS/Domain/General
@@ -270,7 +270,7 @@ When set to "false" all multicasting is disabled. The default, "true" enables th
 
 "default" maps on spdp if the network is a WiFi network, on true if it is a wired network
 
-The default value is: "default".
+The default value is: `default`
 
 
 #### //CycloneDDS/Domain/General/DontRoute
@@ -278,7 +278,7 @@ Boolean
 
 This element allows setting the SO\_DONTROUTE option for outgoing packets to bypass the local routing tables. This is generally useful only when the routing tables cannot be trusted, which is highly unusual.
 
-The default value is: "false".
+The default value is: `false`
 
 
 #### //CycloneDDS/Domain/General/EnableMulticastLoopback
@@ -286,7 +286,7 @@ Boolean
 
 This element specifies whether Cyclone DDS allows IP multicast packets to be visible to all DDSI participants in the same node, including itself. It must be "true" for intra-node multicast communications. However, if a node runs only a single Cyclone DDS service and does not host any other DDSI-capable programs, it should be set to "false" for improved performance.
 
-The default value is: "true".
+The default value is: `true`
 
 
 #### //CycloneDDS/Domain/General/EntityAutoNaming
@@ -296,7 +296,7 @@ One of: empty, fancy
 
 This element specifies the entity autonaming mode. By default set to 'empty' which means no name will be set (but you can still use dds\_qset\_entity\_name). When set to 'fancy' participants, publishers, subscribers, writers, and readers will get randomly generated names. An autonamed entity will share a 3-letter prefix with their parent entity.
 
-The default value is: "empty".
+The default value is: `empty`
 
 
 #### //CycloneDDS/Domain/General/EntityAutoNaming[@seed]
@@ -304,7 +304,7 @@ Text
 
 Provide an initial seed for the entity naming. Your string will be hashed to provide the random state. When provided, the same sequence of names is generated every run. Creating your entities in the same order will ensure they are the same between runs. If you run multiple nodes, set this via environment variable to ensure every node generates unique names. A random starting seed is chosen when left empty, (the default). 
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 #### //CycloneDDS/Domain/General/ExternalNetworkAddress
@@ -312,7 +312,7 @@ Text
 
 This element allows explicitly overruling the network address Cyclone DDS advertises in the discovery protocol, which by default is the address of the preferred network interface (General/NetworkInterfaceAddress), to allow Cyclone DDS to communicate across a Network Address Translation (NAT) device.
 
-The default value is: "auto".
+The default value is: `auto`
 
 
 #### //CycloneDDS/Domain/General/ExternalNetworkMask
@@ -320,7 +320,7 @@ Text
 
 This element specifies the network mask of the external network address. This element is relevant only when an external network address (General/ExternalNetworkAddress) is explicitly configured. In this case locators received via the discovery protocol that are within the same external subnet (as defined by this mask) will be translated to an internal address by replacing the network portion of the external address with the corresponding portion of the preferred network interface address. This option is IPv4-only.
 
-The default value is: "0.0.0.0".
+The default value is: `0.0.0.0`
 
 
 #### //CycloneDDS/Domain/General/FragmentSize
@@ -330,7 +330,7 @@ This element specifies the size of DDSI sample fragments generated by Cyclone DD
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: "1344 B".
+The default value is: `1344 B`
 
 
 #### //CycloneDDS/Domain/General/Interfaces
@@ -350,7 +350,7 @@ Text
 
 This attribute specifies the address of the interface. With ipv4 allows  matching on the network part if the host part is set to zero. 
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 ##### //CycloneDDS/Domain/General/Interfaces/NetworkInterface[@autodetermine]
@@ -358,14 +358,14 @@ Text
 
 If set to "true" an interface is automatically selected. Specifying a name or an address when automatic is set is considered an error.
 
-The default value is: "false".
+The default value is: `false`
 
 
 ##### //CycloneDDS/Domain/General/Interfaces/NetworkInterface[@multicast]
 Text
 
 This attribute specifies whether the interface should use multicast. On its default setting, 'default', it will use the value as return by the operating system. If set to 'true', the interface will be assumed to be multicast capable even when the interface flags returned by the operating system state it is not (this provides a workaround for some platforms). If set to 'false', the interface will never be used for multicast.
-The default value is: "default".
+The default value is: `default`
 
 
 ##### //CycloneDDS/Domain/General/Interfaces/NetworkInterface[@name]
@@ -373,7 +373,7 @@ Text
 
 This attribute specifies the name of the interface. 
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 ##### //CycloneDDS/Domain/General/Interfaces/NetworkInterface[@prefer_multicast]
@@ -381,7 +381,7 @@ Boolean
 
 When false (default), Cyclone DDS uses unicast for data whenever a single unicast suffices. Setting this to true makes it prefer multicasting data, falling back to unicast only when no multicast is available.
 
-The default value is: "false".
+The default value is: `false`
 
 
 ##### //CycloneDDS/Domain/General/Interfaces/NetworkInterface[@presence_required]
@@ -389,7 +389,7 @@ Boolean
 
 By default, all specified network interfaces must be present; if they are missing Cyclone will not start. By explicitly setting this setting for an interface, you can instruct Cyclone to ignore that interface if it is not present.
 
-The default value is: "true".
+The default value is: `true`
 
 
 ##### //CycloneDDS/Domain/General/Interfaces/NetworkInterface[@priority]
@@ -397,7 +397,7 @@ Text
 
 This attribute specifies the interface priority (decimal integer or default). The default value for loopback interfaces is 2, for all other interfaces it is 0.
 
-The default value is: "default".
+The default value is: `default`
 
 
 #### //CycloneDDS/Domain/General/MaxMessageSize
@@ -409,7 +409,7 @@ On some networks it may be necessary to set this item to keep the packetsize bel
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: "14720 B".
+The default value is: `14720 B`
 
 
 #### //CycloneDDS/Domain/General/MaxRexmitMessageSize
@@ -421,7 +421,7 @@ On some networks it may be necessary to set this item to keep the packetsize bel
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: "1456 B".
+The default value is: `1456 B`
 
 
 #### //CycloneDDS/Domain/General/MulticastRecvNetworkInterfaceAddresses
@@ -442,7 +442,7 @@ This element specifies which network interfaces Cyclone DDS listens to multicast
 
 If Cyclone DDS is in IPv6 mode and the address of the preferred network interface is a link-local address, "all" is treated as a synonym for "preferred" and a comma-separated list is treated as "preferred" if it contains the preferred interface and as "none" if not.
 
-The default value is: "preferred".
+The default value is: `preferred`
 
 
 #### //CycloneDDS/Domain/General/MulticastTimeToLive
@@ -450,7 +450,7 @@ Integer
 
 This element specifies the time-to-live setting for outgoing multicast packets.
 
-The default value is: "32".
+The default value is: `32`
 
 
 #### //CycloneDDS/Domain/General/RedundantNetworking
@@ -458,7 +458,7 @@ Boolean
 
 When enabled, use selected network interfaces in parallel for redundancy.
 
-The default value is: "false".
+The default value is: `false`
 
 
 #### //CycloneDDS/Domain/General/Transport
@@ -466,7 +466,7 @@ One of: default, udp, udp6, tcp, tcp6, raweth
 
 This element allows selecting the transport to be used (udp, udp6, tcp, tcp6, raweth)
 
-The default value is: "default".
+The default value is: `default`
 
 
 #### //CycloneDDS/Domain/General/UseIPv6
@@ -474,7 +474,7 @@ One of: false, true, default
 
 Deprecated (use Transport instead)
 
-The default value is: "default".
+The default value is: `default`
 
 
 ### //CycloneDDS/Domain/Internal
@@ -488,7 +488,7 @@ Integer
 
 Proxy readers that are assumed to still be retrieving historical data get this many samples retransmitted when they NACK something, even if some of these samples have sequence numbers outside the set covered by the NACK.
 
-The default value is: "0".
+The default value is: `0`
 
 
 #### //CycloneDDS/Domain/Internal/AckDelay
@@ -498,7 +498,7 @@ This setting controls the delay between sending identical acknowledgements.
 
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "10 ms".
+The default value is: `10 ms`
 
 
 #### //CycloneDDS/Domain/Internal/AutoReschedNackDelay
@@ -508,7 +508,7 @@ This setting controls the interval with which a reader will continue NACK'ing mi
 
 Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "3 s".
+The default value is: `3 s`
 
 
 #### //CycloneDDS/Domain/Internal/BuiltinEndpointSet
@@ -523,7 +523,7 @@ This element controls which participants will have which built-in endpoints for 
 
 The default is writers, as this is thought to be compliant and reasonably efficient. Minimal may or may not be compliant but is most efficient, and full is inefficient but certain to be compliant.
 
-The default value is: "writers".
+The default value is: `writers`
 
 
 #### //CycloneDDS/Domain/Internal/BurstSize
@@ -539,7 +539,7 @@ This element specifies how much more than the (presumed or discovered) receive b
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: "4294967295".
+The default value is: `4294967295`
 
 
 ##### //CycloneDDS/Domain/Internal/BurstSize/MaxRexmit
@@ -549,7 +549,7 @@ This element specifies the amount of data to be retransmitted in response to one
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: "1 MiB".
+The default value is: `1 MiB`
 
 
 #### //CycloneDDS/Domain/Internal/ControlTopic
@@ -561,7 +561,7 @@ Integer
 
 This element sets the maximum number of extra threads for an experimental, undocumented, and unsupported direct mode.
 
-The default value is: "1".
+The default value is: `1`
 
 
 #### //CycloneDDS/Domain/Internal/DefragReliableMaxSamples
@@ -569,7 +569,7 @@ Integer
 
 This element sets the maximum number of samples that can be defragmented simultaneously for a reliable writer. This has to be large enough to handle retransmissions of historical data in addition to new samples.
 
-The default value is: "16".
+The default value is: `16`
 
 
 #### //CycloneDDS/Domain/Internal/DefragUnreliableMaxSamples
@@ -577,7 +577,7 @@ Integer
 
 This element sets the maximum number of samples that can be defragmented simultaneously for best-effort writers.
 
-The default value is: "4".
+The default value is: `4`
 
 
 #### //CycloneDDS/Domain/Internal/DeliveryQueueMaxSamples
@@ -585,7 +585,7 @@ Integer
 
 This element controls the maximum size of a delivery queue, expressed in samples. Once a delivery queue is full, incoming samples destined for that queue are dropped until space becomes available again.
 
-The default value is: "256".
+The default value is: `256`
 
 
 #### //CycloneDDS/Domain/Internal/EnableExpensiveChecks
@@ -603,7 +603,7 @@ This element enables expensive checks in builds with assertions enabled and is i
 
 In addition, there is the keyword all that enables all checks.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 #### //CycloneDDS/Domain/Internal/GenerateKeyhash
@@ -611,7 +611,7 @@ Boolean
 
 When true, include keyhashes in outgoing data for topics with keys.
 
-The default value is: "false".
+The default value is: `false`
 
 
 #### //CycloneDDS/Domain/Internal/HeartbeatInterval
@@ -623,7 +623,7 @@ This element allows configuring the base interval for sending writer heartbeats 
 
 Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "100 ms".
+The default value is: `100 ms`
 
 
 #### //CycloneDDS/Domain/Internal/HeartbeatInterval[@max]
@@ -633,7 +633,7 @@ This attribute sets the maximum interval for periodic heartbeats.
 
 Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "8 s".
+The default value is: `8 s`
 
 
 #### //CycloneDDS/Domain/Internal/HeartbeatInterval[@min]
@@ -643,7 +643,7 @@ This attribute sets the minimum interval that must have passed since the most re
 
 Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "5 ms".
+The default value is: `5 ms`
 
 
 #### //CycloneDDS/Domain/Internal/HeartbeatInterval[@minsched]
@@ -653,7 +653,7 @@ This attribute sets the minimum interval for periodic heartbeats. Other events m
 
 Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "20 ms".
+The default value is: `20 ms`
 
 
 #### //CycloneDDS/Domain/Internal/LateAckMode
@@ -661,7 +661,7 @@ Boolean
 
 Ack a sample only when it has been delivered, instead of when committed to delivering it.
 
-The default value is: "false".
+The default value is: `false`
 
 
 #### //CycloneDDS/Domain/Internal/LivelinessMonitoring
@@ -671,7 +671,7 @@ Boolean
 
 This element controls whether or not implementation should internally monitor its own liveliness. If liveliness monitoring is enabled, stack traces can be dumped automatically when some thread appears to have stopped making progress.
 
-The default value is: "false".
+The default value is: `false`
 
 
 #### //CycloneDDS/Domain/Internal/LivelinessMonitoring[@Interval]
@@ -681,7 +681,7 @@ This element controls the interval to check whether threads have been making pro
 
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "1s".
+The default value is: `1s`
 
 
 #### //CycloneDDS/Domain/Internal/LivelinessMonitoring[@StackTraces]
@@ -689,7 +689,7 @@ Boolean
 
 This element controls whether or not to write stack traces to the DDSI2 trace when a thread fails to make progress (on select platforms only).
 
-The default value is: "true".
+The default value is: `true`
 
 
 #### //CycloneDDS/Domain/Internal/MaxParticipants
@@ -697,7 +697,7 @@ Integer
 
 This elements configures the maximum number of DCPS domain participants this Cyclone DDS instance is willing to service. 0 is unlimited.
 
-The default value is: "0".
+The default value is: `0`
 
 
 #### //CycloneDDS/Domain/Internal/MaxQueuedRexmitBytes
@@ -707,7 +707,7 @@ This setting limits the maximum number of bytes queued for retransmission. The d
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: "512 kB".
+The default value is: `512 kB`
 
 
 #### //CycloneDDS/Domain/Internal/MaxQueuedRexmitMessages
@@ -715,7 +715,7 @@ Integer
 
 This setting limits the maximum number of samples queued for retransmission.
 
-The default value is: "200".
+The default value is: `200`
 
 
 #### //CycloneDDS/Domain/Internal/MaxSampleSize
@@ -725,7 +725,7 @@ This setting controls the maximum (CDR) serialised size of samples that Cyclone 
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: "2147483647 B".
+The default value is: `2147483647 B`
 
 
 #### //CycloneDDS/Domain/Internal/MeasureHbToAckLatency
@@ -733,7 +733,7 @@ Boolean
 
 This element enables heartbeat-to-ack latency among Cyclone DDS services by prepending timestamps to Heartbeat and AckNack messages and calculating round trip times. This is non-standard behaviour. The measured latencies are quite noisy and are currently not used anywhere.
 
-The default value is: "false".
+The default value is: `false`
 
 
 #### //CycloneDDS/Domain/Internal/MonitorPort
@@ -741,7 +741,7 @@ Integer
 
 This element allows configuring a service that dumps a text description of part the internal state to TCP clients. By default (-1), this is disabled; specifying 0 means a kernel-allocated port is used; a positive number is used as the TCP port number.
 
-The default value is: "-1".
+The default value is: `-1`
 
 
 #### //CycloneDDS/Domain/Internal/MultipleReceiveThreads
@@ -751,7 +751,7 @@ One of: false, true, default
 
 This element controls whether all traffic is handled by a single receive thread (false) or whether multiple receive threads may be used to improve latency (true). By default it is disabled on Windows because it appears that one cannot count on being able to send packets to oneself, which is necessary to stop the thread during shutdown. Currently multiple receive threads are only used for connectionless transport (e.g., UDP) and ManySocketsMode not set to single (the default).
 
-The default value is: "default".
+The default value is: `default`
 
 
 #### //CycloneDDS/Domain/Internal/MultipleReceiveThreads[@maxretries]
@@ -759,7 +759,7 @@ Integer
 
 Receive threads dedicated to a single socket can only be triggered for termination by sending a packet. Reception of any packet will do, so termination failure due to packet loss is exceedingly unlikely, but to eliminate all risks, it will retry as many times as specified by this attribute before aborting.
 
-The default value is: "4294967295".
+The default value is: `4294967295`
 
 
 #### //CycloneDDS/Domain/Internal/NackDelay
@@ -769,7 +769,7 @@ This setting controls the delay between receipt of a HEARTBEAT indicating missin
 
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "100 ms".
+The default value is: `100 ms`
 
 
 #### //CycloneDDS/Domain/Internal/PreEmptiveAckDelay
@@ -779,7 +779,7 @@ This setting controls the delay between the discovering a remote writer and send
 
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "10 ms".
+The default value is: `10 ms`
 
 
 #### //CycloneDDS/Domain/Internal/PrimaryReorderMaxSamples
@@ -787,7 +787,7 @@ Integer
 
 This element sets the maximum size in samples of a primary re-order administration. Each proxy writer has one primary re-order administration to buffer the packet flow in case some packets arrive out of order. Old samples are forwarded to secondary re-order administrations associated with readers needing historical data.
 
-The default value is: "128".
+The default value is: `128`
 
 
 #### //CycloneDDS/Domain/Internal/PrioritizeRetransmit
@@ -795,7 +795,7 @@ Boolean
 
 This element controls whether retransmits are prioritized over new data, speeding up recovery.
 
-The default value is: "true".
+The default value is: `true`
 
 
 #### //CycloneDDS/Domain/Internal/RediscoveryBlacklistDuration
@@ -807,7 +807,7 @@ This element controls for how long a remote participant that was previously dele
 
 Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "0s".
+The default value is: `0s`
 
 
 #### //CycloneDDS/Domain/Internal/RediscoveryBlacklistDuration[@enforce]
@@ -815,7 +815,7 @@ Boolean
 
 This attribute controls whether the configured time during which recently deleted participants will not be rediscovered (i.e., "black listed") is enforced and following complete removal of the participant in Cyclone DDS, or whether it can be rediscovered earlier provided all traces of that participant have been removed already.
 
-The default value is: "false".
+The default value is: `false`
 
 
 #### //CycloneDDS/Domain/Internal/RetransmitMerging
@@ -830,7 +830,7 @@ This elements controls the addressing and timing of retransmits. Possible values
 
 The default is never. See also Internal/RetransmitMergingPeriod.
 
-The default value is: "never".
+The default value is: `never`
 
 
 #### //CycloneDDS/Domain/Internal/RetransmitMergingPeriod
@@ -842,7 +842,7 @@ See also Internal/RetransmitMerging.
 
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "5 ms".
+The default value is: `5 ms`
 
 
 #### //CycloneDDS/Domain/Internal/RetryOnRejectBestEffort
@@ -850,7 +850,7 @@ Boolean
 
 Whether or not to locally retry pushing a received best-effort sample into the reader caches when resource limits are reached.
 
-The default value is: "false".
+The default value is: `false`
 
 
 #### //CycloneDDS/Domain/Internal/SPDPResponseMaxDelay
@@ -860,7 +860,7 @@ Maximum pseudo-random delay in milliseconds between discovering aremote particip
 
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "0 ms".
+The default value is: `0 ms`
 
 
 #### //CycloneDDS/Domain/Internal/ScheduleTimeRounding
@@ -870,7 +870,7 @@ This setting allows the timing of scheduled events to be rounded up so that more
 
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "0 ms".
+The default value is: `0 ms`
 
 
 #### //CycloneDDS/Domain/Internal/SecondaryReorderMaxSamples
@@ -878,7 +878,7 @@ Integer
 
 This element sets the maximum size in samples of a secondary re-order administration. The secondary re-order administration is per reader needing historical data.
 
-The default value is: "128".
+The default value is: `128`
 
 
 #### //CycloneDDS/Domain/Internal/SocketReceiveBufferSize
@@ -896,7 +896,7 @@ This sets the size of the socket receive buffer to request, with the special val
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: "default".
+The default value is: `default`
 
 
 #### //CycloneDDS/Domain/Internal/SocketReceiveBufferSize[@min]
@@ -906,7 +906,7 @@ This sets the minimum acceptable socket receive buffer size, with the special va
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: "default".
+The default value is: `default`
 
 
 #### //CycloneDDS/Domain/Internal/SocketSendBufferSize
@@ -924,7 +924,7 @@ This sets the size of the socket send buffer to request, with the special value 
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: "default".
+The default value is: `default`
 
 
 #### //CycloneDDS/Domain/Internal/SocketSendBufferSize[@min]
@@ -934,7 +934,7 @@ This sets the minimum acceptable socket send buffer size, with the special value
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: "64 KiB".
+The default value is: `64 KiB`
 
 
 #### //CycloneDDS/Domain/Internal/SquashParticipants
@@ -942,7 +942,7 @@ Boolean
 
 This element controls whether Cyclone DDS advertises all the domain participants it serves in DDSI (when set to false), or rather only one domain participant (the one corresponding to the Cyclone DDS process; when set to true). In the latter case, Cyclone DDS becomes the virtual owner of all readers and writers of all domain participants, dramatically reducing discovery traffic (a similar effect can be obtained by setting Internal/BuiltinEndpointSet to "minimal" but with less loss of information).
 
-The default value is: "false".
+The default value is: `false`
 
 
 #### //CycloneDDS/Domain/Internal/SynchronousDeliveryLatencyBound
@@ -952,7 +952,7 @@ This element controls whether samples sent by a writer with QoS settings transpo
 
 Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "inf".
+The default value is: `inf`
 
 
 #### //CycloneDDS/Domain/Internal/SynchronousDeliveryPriorityThreshold
@@ -960,7 +960,7 @@ Integer
 
 This element controls whether samples sent by a writer with QoS settings latency\_budget <= SynchronousDeliveryLatencyBound and transport\_priority greater than or equal to this element's value will be delivered synchronously from the "recv" thread, all others will be delivered asynchronously through delivery queues. This reduces latency at the expense of aggregate bandwidth.
 
-The default value is: "0".
+The default value is: `0`
 
 
 #### //CycloneDDS/Domain/Internal/Test
@@ -974,7 +974,7 @@ Integer
 
 This element controls the fraction of outgoing packets to drop, specified as samples per thousand.
 
-The default value is: "0".
+The default value is: `0`
 
 
 #### //CycloneDDS/Domain/Internal/UnicastResponseToSPDPMessages
@@ -982,7 +982,7 @@ Boolean
 
 This element controls whether the response to a newly discovered participant is sent as a unicasted SPDP packet instead of rescheduling the periodic multicasted one. There is no known benefit to setting this to false.
 
-The default value is: "true".
+The default value is: `true`
 
 
 #### //CycloneDDS/Domain/Internal/UseMulticastIfMreqn
@@ -990,7 +990,7 @@ Integer
 
 Do not use.
 
-The default value is: "0".
+The default value is: `0`
 
 
 #### //CycloneDDS/Domain/Internal/Watermarks
@@ -1004,7 +1004,7 @@ Boolean
 
 This element controls whether Cyclone DDS will adapt the high-water mark to current traffic conditions based on retransmit requests and transmit pressure.
 
-The default value is: "true".
+The default value is: `true`
 
 
 ##### //CycloneDDS/Domain/Internal/Watermarks/WhcHigh
@@ -1014,7 +1014,7 @@ This element sets the maximum allowed high-water mark for the Cyclone DDS WHCs, 
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: "500 kB".
+The default value is: `500 kB`
 
 
 ##### //CycloneDDS/Domain/Internal/Watermarks/WhcHighInit
@@ -1024,7 +1024,7 @@ This element sets the initial level of the high-water mark for the Cyclone DDS W
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: "30 kB".
+The default value is: `30 kB`
 
 
 ##### //CycloneDDS/Domain/Internal/Watermarks/WhcLow
@@ -1034,7 +1034,7 @@ This element sets the low-water mark for the Cyclone DDS WHCs, expressed in byte
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: "1 kB".
+The default value is: `1 kB`
 
 
 #### //CycloneDDS/Domain/Internal/WriteBatch
@@ -1042,7 +1042,7 @@ Boolean
 
 This element enables the batching of write operations. By default each write operation writes through the write cache and out onto the transport. Enabling write batching causes multiple small write operations to be aggregated within the write cache into a single larger write. This gives greater throughput at the expense of latency. Currently, there is no mechanism for the write cache to automatically flush itself, so that if write batching is enabled, the application may have to use the dds\_write\_flush function to ensure that all samples are written.
 
-The default value is: "false".
+The default value is: `false`
 
 
 #### //CycloneDDS/Domain/Internal/WriterLingerDuration
@@ -1051,7 +1051,7 @@ Number-with-unit
 This setting controls the maximum duration for which actual deletion of a reliable writer with unacknowledged data in its history will be postponed to provide proper reliable transmission.
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "1 s".
+The default value is: `1 s`
 
 
 ### //CycloneDDS/Domain/Partitioning
@@ -1073,7 +1073,7 @@ Text
 
 This element can prevent certain combinations of DCPS partition and topic from being transmitted over the network. Cyclone DDS will completely ignore readers and writers for which all DCPS partitions as well as their topic is ignored, not even creating DDSI readers and writers to mirror the DCPS ones.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 ##### //CycloneDDS/Domain/Partitioning/IgnoredPartitions/IgnoredPartition[@DCPSPartitionTopic]
@@ -1081,7 +1081,7 @@ Text
 
 This attribute specifies a partition and a topic expression, separated by a single '.', which are used to determine if a given partition and topic will be ignored or not. The expressions may use the usual wildcards '\*' and '?'. Cyclone DDS will consider a wildcard DCPS partition to match an expression if a string that satisfies both expressions exists.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 #### //CycloneDDS/Domain/Partitioning/NetworkPartitions
@@ -1097,7 +1097,7 @@ Text
 
 This element defines a Cyclone DDS network partition.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 ##### //CycloneDDS/Domain/Partitioning/NetworkPartitions/NetworkPartition[@Address]
@@ -1109,7 +1109,7 @@ Readers matching this network partition (cf. Partitioning/PartitionMappings) wil
 
 The unicast addresses advertised by a reader are the only unicast addresses a writer will use to send data to it and are used to select the subset of network interfaces to use for transmitting multicast data with the intent of reaching it.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 ##### //CycloneDDS/Domain/Partitioning/NetworkPartitions/NetworkPartition[@Interface]
@@ -1117,7 +1117,7 @@ Text
 
 This attribute takes a comma-separated list of interface name that the reader is willing to receive data on. This is implemented by adding the interface addresses to the set address set configured using the sibling "Address" attribute. See there for more details.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 ##### //CycloneDDS/Domain/Partitioning/NetworkPartitions/NetworkPartition[@Name]
@@ -1125,7 +1125,7 @@ Text
 
 This attribute specifies the name of this Cyclone DDS network partition. Two network partitions cannot have the same name. Partition mappings (cf. Partitioning/PartitionMappings) refer to network partitions using these names.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 #### //CycloneDDS/Domain/Partitioning/PartitionMappings
@@ -1141,7 +1141,7 @@ Text
 
 This element defines a mapping from a DCPS partition/topic combination to a Cyclone DDS network partition. This allows partitioning data flows by using special multicast addresses for part of the data and possibly encrypting the data flow.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 ##### //CycloneDDS/Domain/Partitioning/PartitionMappings/PartitionMapping[@DCPSPartitionTopic]
@@ -1149,7 +1149,7 @@ Text
 
 This attribute specifies a partition and a topic expression, separated by a single '.', which are used to determine if a given partition and topic maps to the Cyclone DDS network partition named by the NetworkPartition attribute in this PartitionMapping element. The expressions may use the usual wildcards '\*' and '?'. Cyclone DDS will consider a wildcard DCPS partition to match an expression if there exists a string that satisfies both expressions.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 ##### //CycloneDDS/Domain/Partitioning/PartitionMappings/PartitionMapping[@NetworkPartition]
@@ -1157,7 +1157,7 @@ Text
 
 This attribute specifies which Cyclone DDS network partition is to be used for DCPS partition/topic combinations matching the DCPSPartitionTopic attribute within this PartitionMapping element.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 ### //CycloneDDS/Domain/SSL
@@ -1171,7 +1171,7 @@ Boolean
 
 If disabled this allows SSL connections to occur even if an X509 certificate fails verification.
 
-The default value is: "true".
+The default value is: `true`
 
 
 #### //CycloneDDS/Domain/SSL/Ciphers
@@ -1179,7 +1179,7 @@ Text
 
 The set of ciphers used by SSL/TLS
 
-The default value is: "ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH".
+The default value is: `ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH`
 
 
 #### //CycloneDDS/Domain/SSL/Enable
@@ -1187,7 +1187,7 @@ Boolean
 
 This enables SSL/TLS for TCP.
 
-The default value is: "false".
+The default value is: `false`
 
 
 #### //CycloneDDS/Domain/SSL/EntropyFile
@@ -1195,7 +1195,7 @@ Text
 
 The SSL/TLS random entropy file name.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 #### //CycloneDDS/Domain/SSL/KeyPassphrase
@@ -1203,7 +1203,7 @@ Text
 
 The SSL/TLS key pass phrase for encrypted keys.
 
-The default value is: "secret".
+The default value is: `secret`
 
 
 #### //CycloneDDS/Domain/SSL/KeystoreFile
@@ -1211,7 +1211,7 @@ Text
 
 The SSL/TLS key and certificate store file name. The keystore must be in PEM format.
 
-The default value is: "keystore".
+The default value is: `keystore`
 
 
 #### //CycloneDDS/Domain/SSL/MinimumTLSVersion
@@ -1219,7 +1219,7 @@ Text
 
 The minimum TLS version that may be negotiated, valid values are 1.2 and 1.3.
 
-The default value is: "1.3".
+The default value is: `1.3`
 
 
 #### //CycloneDDS/Domain/SSL/SelfSignedCertificates
@@ -1227,7 +1227,7 @@ Boolean
 
 This enables the use of self signed X509 certificates.
 
-The default value is: "false".
+The default value is: `false`
 
 
 #### //CycloneDDS/Domain/SSL/VerifyClient
@@ -1235,7 +1235,7 @@ Boolean
 
 This enables an SSL server to check the X509 certificate of a connecting client.
 
-The default value is: "true".
+The default value is: `true`
 
 
 ### //CycloneDDS/Domain/Security
@@ -1297,7 +1297,7 @@ MIIDuAYJKoZIhv ...al5s=
 
 ------F9A8A198D6F08E1285A292ADF14DD04F-]]</Governance>
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 ##### //CycloneDDS/Domain/Security/AccessControl/Library
@@ -1307,7 +1307,7 @@ Text
 
 This element specifies the library to be loaded as the DDS Security Access Control plugin.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 ##### //CycloneDDS/Domain/Security/AccessControl/Library[@finalizeFunction]
@@ -1315,7 +1315,7 @@ Text
 
 This element names the finalization function of Access Control plugin. This function is called to let the plugin release its resources.
 
-The default value is: "finalize\_access\_control".
+The default value is: `finalize\_access\_control`
 
 
 ##### //CycloneDDS/Domain/Security/AccessControl/Library[@initFunction]
@@ -1323,7 +1323,7 @@ Text
 
 This element names the initialization function of Access Control plugin. This function is called after loading the plugin library for instantiation purposes. The Init function must return an object that implements the DDS Security Access Control interface.
 
-The default value is: "init\_access\_control".
+The default value is: `init\_access\_control`
 
 
 ##### //CycloneDDS/Domain/Security/AccessControl/Library[@path]
@@ -1335,7 +1335,7 @@ It can be either absolute path excluding file extension ( /usr/lib/dds\_security
 
 If a single file is supplied, the library is located by the current working directory, or LD\_LIBRARY\_PATH for Unix systems, and PATH for Windows systems.
 
-The default value is: "dds\_security\_ac".
+The default value is: `dds\_security\_ac`
 
 
 ##### //CycloneDDS/Domain/Security/AccessControl/Permissions
@@ -1354,7 +1354,7 @@ Example data URI:
 
 <Permissions><![CDATA[data:,.........]]</Permissions>
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 ##### //CycloneDDS/Domain/Security/AccessControl/PermissionsCA
@@ -1375,7 +1375,7 @@ MIIC3DCCAcQCCQCWE5x+Z ... PhovK0mp2ohhRLYI0ZiyYQ==
 
 -----END CERTIFICATE-----</PermissionsCA>
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 #### //CycloneDDS/Domain/Security/Authentication
@@ -1399,7 +1399,7 @@ Examples:
 MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg=<br>
 -----END X509 CRL-----</CRL>
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 ##### //CycloneDDS/Domain/Security/Authentication/IdentityCA
@@ -1419,7 +1419,7 @@ Examples:
 MIIC3DCCAcQCCQCWE5x+Z...PhovK0mp2ohhRLYI0ZiyYQ==<br>
 -----END CERTIFICATE-----</IdentityCA>
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 ##### //CycloneDDS/Domain/Security/Authentication/IdentityCertificate
@@ -1437,7 +1437,7 @@ Examples:
 MIIDjjCCAnYCCQDCEu9...6rmT87dhTo=<br>
 -----END CERTIFICATE-----</IdentityCertificate>
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 ##### //CycloneDDS/Domain/Security/Authentication/IncludeOptionalFields
@@ -1445,7 +1445,7 @@ Boolean
 
 The authentication handshake tokens may contain optional fields to be included for finding interoperability problems. If this parameter is set to true the optional fields are included in the handshake token exchange.
 
-The default value is: "false".
+The default value is: `false`
 
 
 ##### //CycloneDDS/Domain/Security/Authentication/Library
@@ -1455,7 +1455,7 @@ Text
 
 This element specifies the library to be loaded as the DDS Security Access Control plugin.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 ##### //CycloneDDS/Domain/Security/Authentication/Library[@finalizeFunction]
@@ -1463,7 +1463,7 @@ Text
 
 This element names the finalization function of the Authentication plugin. This function is called to let the plugin release its resources.
 
-The default value is: "finalize\_authentication".
+The default value is: `finalize\_authentication`
 
 
 ##### //CycloneDDS/Domain/Security/Authentication/Library[@initFunction]
@@ -1471,7 +1471,7 @@ Text
 
 This element names the initialization function of the Authentication plugin. This function is called after loading the plugin library for instantiation purposes. The Init function must return an object that implements the DDS Security Authentication interface.
 
-The default value is: "init\_authentication".
+The default value is: `init\_authentication`
 
 
 ##### //CycloneDDS/Domain/Security/Authentication/Library[@path]
@@ -1483,7 +1483,7 @@ It can be either absolute path excluding file extension ( /usr/lib/dds\_security
 
 If a single file is supplied, the library is located by the current working directory, or LD\_LIBRARY\_PATH for Unix systems, and PATH for Windows systems.
 
-The default value is: "dds\_security\_auth".
+The default value is: `dds\_security\_auth`
 
 
 ##### //CycloneDDS/Domain/Security/Authentication/Password
@@ -1495,7 +1495,7 @@ The value of the password property shall be interpreted as the Base64 encoding o
 
 If the password property is not present, then the value supplied in the private\_key property must contain the unencrypted private key.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 ##### //CycloneDDS/Domain/Security/Authentication/PrivateKey
@@ -1513,7 +1513,7 @@ Examples:
 MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==<br>
 -----END RSA PRIVATE KEY-----</PrivateKey>
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 ##### //CycloneDDS/Domain/Security/Authentication/TrustedCADirectory
@@ -1521,7 +1521,7 @@ Text
 
 Trusted CA Directory which contains trusted CA certificates as separated files.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 #### //CycloneDDS/Domain/Security/Cryptographic
@@ -1537,7 +1537,7 @@ Text
 
 This element specifies the library to be loaded as the DDS Security Cryptographic plugin.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 ##### //CycloneDDS/Domain/Security/Cryptographic/Library[@finalizeFunction]
@@ -1545,7 +1545,7 @@ Text
 
 This element names the finalization function of the Cryptographic plugin. This function is called to let the plugin release its resources.
 
-The default value is: "finalize\_crypto".
+The default value is: `finalize\_crypto`
 
 
 ##### //CycloneDDS/Domain/Security/Cryptographic/Library[@initFunction]
@@ -1553,7 +1553,7 @@ Text
 
 This element names the initialization function of the Cryptographic plugin. This function is called after loading the plugin library for instantiation purposes. The Init function must return an object that implements the DDS Security Cryptographic interface.
 
-The default value is: "init\_crypto".
+The default value is: `init\_crypto`
 
 
 ##### //CycloneDDS/Domain/Security/Cryptographic/Library[@path]
@@ -1565,7 +1565,7 @@ It can be either absolute path excluding file extension ( /usr/lib/dds\_security
 
 If a single file is supplied, the is library located by the current working directory, or LD\_LIBRARY\_PATH for Unix systems, and PATH for Windows systems.
 
-The default value is: "dds\_security\_crypto".
+The default value is: `dds\_security\_crypto`
 
 
 ### //CycloneDDS/Domain/SharedMemory
@@ -1579,7 +1579,7 @@ Boolean
 
 This element allows for enabling shared memory in Cyclone DDS.
 
-The default value is: "false".
+The default value is: `false`
 
 
 #### //CycloneDDS/Domain/SharedMemory/Locator
@@ -1587,7 +1587,7 @@ Text
 
 Explicitly set the Iceoryx locator used by Cyclone to check whether a pair of processes is attached to the same Iceoryx shared memory.  The default is to use one of the MAC addresses of the machine, which should work well in most cases.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 #### //CycloneDDS/Domain/SharedMemory/LogLevel
@@ -1610,7 +1610,7 @@ This element decides the verbosity level of shared memory message:
 
 If you don't want to see any log from shared memory, use off to disable logging.
 
-The default value is: "info".
+The default value is: `info`
 
 
 #### //CycloneDDS/Domain/SharedMemory/Prefix
@@ -1618,7 +1618,7 @@ Text
 
 Override the Iceoryx service name used by Cyclone.
 
-The default value is: "DDS\_CYCLONE".
+The default value is: `DDS\_CYCLONE`
 
 
 ### //CycloneDDS/Domain/Sizing
@@ -1634,7 +1634,7 @@ This element specifies the size of one allocation unit in the receive buffer. It
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: "128 KiB".
+The default value is: `128 KiB`
 
 
 #### //CycloneDDS/Domain/Sizing/ReceiveBufferSize
@@ -1644,7 +1644,7 @@ This element sets the size of a single receive buffer. Many receive buffers may 
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: "1 MiB".
+The default value is: `1 MiB`
 
 
 ### //CycloneDDS/Domain/TCP
@@ -1658,7 +1658,7 @@ Boolean
 
 Setting this to true means the unicast addresses in SPDP packets will be ignored, and the peer address from the TCP connection will be used instead. This may help work around incorrectly advertised addresses when using TCP.
 
-The default value is: "false".
+The default value is: `false`
 
 
 #### //CycloneDDS/Domain/TCP/Enable
@@ -1666,7 +1666,7 @@ One of: false, true, default
 
 This element enables the optional TCP transport - deprecated, use General/Transport instead.
 
-The default value is: "default".
+The default value is: `default`
 
 
 #### //CycloneDDS/Domain/TCP/NoDelay
@@ -1674,7 +1674,7 @@ Boolean
 
 This element enables the TCP\_NODELAY socket option, preventing multiple DDSI messages from being sent in the same TCP request. Setting this option typically optimises latency over throughput.
 
-The default value is: "true".
+The default value is: `true`
 
 
 #### //CycloneDDS/Domain/TCP/Port
@@ -1682,7 +1682,7 @@ Integer
 
 This element specifies the TCP port number on which Cyclone DDS accepts connections. If the port is set, it is used in entity locators, published with DDSI discovery, dynamically allocated if zero, and disabled if -1 or not configured. If disabled other DDSI services will not be able to establish connections with the service, the service can only communicate by establishing connections to other services.
 
-The default value is: "-1".
+The default value is: `-1`
 
 
 #### //CycloneDDS/Domain/TCP/ReadTimeout
@@ -1692,7 +1692,7 @@ This element specifies the timeout for blocking TCP read operations. If this tim
 
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "2 s".
+The default value is: `2 s`
 
 
 #### //CycloneDDS/Domain/TCP/WriteTimeout
@@ -1702,7 +1702,7 @@ This element specifies the timeout for blocking TCP write operations. If this ti
 
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: "2 s".
+The default value is: `2 s`
 
 
 ### //CycloneDDS/Domain/Threads
@@ -1741,7 +1741,7 @@ The Name of the thread for which properties are being set. The following threads
 
  * tev.CHAN: timed-event thread for channel CHAN.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 ##### //CycloneDDS/Domain/Threads/Thread/Scheduling
@@ -1755,7 +1755,7 @@ One of: realtime, timeshare, default
 
 This element specifies the thread scheduling class (realtime, timeshare or default). The user may need special privileges from the underlying operating system to be able to assign some of the privileged scheduling classes.
 
-The default value is: "default".
+The default value is: `default`
 
 
 ###### //CycloneDDS/Domain/Threads/Thread/Scheduling/Priority
@@ -1763,7 +1763,7 @@ Text
 
 This element specifies the thread priority (decimal integer or default). Only priorities supported by the underlying operating system can be assigned to this element. The user may need special privileges from the underlying operating system to be able to assign some of the privileged priorities.
 
-The default value is: "default".
+The default value is: `default`
 
 
 ##### //CycloneDDS/Domain/Threads/Thread/StackSize
@@ -1773,7 +1773,7 @@ This element configures the stack size for this thread. The default value defaul
 
 The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2^10 bytes), MB & MiB (2^20 bytes), GB & GiB (2^30 bytes).
 
-The default value is: "default".
+The default value is: `default`
 
 
 ### //CycloneDDS/Domain/Tracing
@@ -1787,7 +1787,7 @@ Boolean
 
 This option specifies whether the output should be appended to an existing log file. The default is to create a new log file each time, which is generally the best option if a detailed log is generated.
 
-The default value is: "false".
+The default value is: `false`
 
 
 #### //CycloneDDS/Domain/Tracing/Category
@@ -1828,7 +1828,7 @@ This element enables individual logging categories. These are enabled in additio
 In addition, there is the keyword trace that enables all but radmin, topic, plist and whc.
 The categorisation of tracing output is incomplete and hence most of the verbosity levels and categories are not of much use in the current release. This is an ongoing process and here we describe the target situation rather than the current situation. Currently, the most useful is trace.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 #### //CycloneDDS/Domain/Tracing/OutputFile
@@ -1836,7 +1836,7 @@ Text
 
 This option specifies where the logging is printed to. Note that stdout and stderr are treated as special values, representing "standard out" and "standard error" respectively. No file is created unless logging categories are enabled using the Tracing/Verbosity or Tracing/EnabledCategory settings.
 
-The default value is: "cyclonedds.log".
+The default value is: `cyclonedds.log`
 
 
 #### //CycloneDDS/Domain/Tracing/PacketCaptureFile
@@ -1844,7 +1844,7 @@ Text
 
 This option specifies the file to which received and sent packets will be logged in the "pcap" format suitable for analysis using common networking tools, such as WireShark. IP and UDP headers are fictitious, in particular the destination address of received packets. The TTL may be used to distinguish between sent and received packets: it is 255 for sent packets and 128 for received ones. Currently IPv4 only.
 
-The default value is: "".
+The default value is: `<empty>`
 
 
 #### //CycloneDDS/Domain/Tracing/Verbosity
@@ -1871,15 +1871,15 @@ While none prevents any message from being written to a DDSI2 log file.
 
 The categorisation of tracing output is incomplete and hence most of the verbosity levels and categories are not of much use in the current release. This is an ongoing process and here we describe the target situation rather than the current situation. Currently, the most useful verbosity levels are config, fine and finest.
 
-The default value is: "none".
+The default value is: `none`
 <!--- generated from ddsi_config.h[75edea6617af11bacc46f91e519773f6df580655] -->
 <!--- generated from ddsi_cfgunits.h[fc550f1620aa20dcd9244ef4e24299d5001efbb4] -->
 <!--- generated from ddsi_cfgelems.h[11913cd398f1cd1b52e06d924718df62a5981beb] -->
 <!--- generated from ddsi_config.c[ed9898f72f9dbcfa20ce7706835da091efcea0ca] -->
 <!--- generated from _confgen.h[f2d235d5551cbf920a8a2962831dddeabd2856ac] -->
-<!--- generated from _confgen.c[1193219ddb4769b90566cf197e73d22fb6f75835] -->
+<!--- generated from _confgen.c[ba2e8c0cfd41039421548fdb03bcd2db8f8b172e] -->
 <!--- generated from generate_rnc.c[a2ec6e48d33ac14a320c8ec3f320028a737920e0] -->
-<!--- generated from generate_md.c[a61b6a9649d18afeca4c73b5784f36989d7994e0] -->
-<!--- generated from generate_rst.c[34dcb6b5e2ac2cd15e78497107ce0b6eed6e6e94] -->
+<!--- generated from generate_md.c[37efe4fa9caf56e2647bafc9a7f009f72ff5d2e0] -->
+<!--- generated from generate_rst.c[32da07860a0043708b47e9f793b63ca05f5106bb] -->
 <!--- generated from generate_xsd.c[45064e8869b3c00573057d7c8f02d20f04b40e16] -->
 <!--- generated from generate_defconfig.c[eec9ab7b2d053e68500799b693d089e84153a37b] -->

--- a/etc/cyclonedds.rnc
+++ b/etc/cyclonedds.rnc
@@ -1307,6 +1307,6 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==<br>
 # generated from _confgen.c[ba2e8c0cfd41039421548fdb03bcd2db8f8b172e] 
 # generated from generate_rnc.c[a2ec6e48d33ac14a320c8ec3f320028a737920e0] 
 # generated from generate_md.c[37efe4fa9caf56e2647bafc9a7f009f72ff5d2e0] 
-# generated from generate_rst.c[32da07860a0043708b47e9f793b63ca05f5106bb] 
+# generated from generate_rst.c[50739f627792ef056e2b4feeb20fda4edfcef079] 
 # generated from generate_xsd.c[45064e8869b3c00573057d7c8f02d20f04b40e16] 
 # generated from generate_defconfig.c[eec9ab7b2d053e68500799b693d089e84153a37b] 

--- a/etc/cyclonedds.rnc
+++ b/etc/cyclonedds.rnc
@@ -10,7 +10,7 @@ CycloneDDS configuration""" ] ]
     element Domain {
       [ a:documentation [ xml:lang="en" """
 <p>Domain id this configuration applies to, or "any" if it applies to all domain ids.</p>
-<p>The default value is: "any".</p>""" ] ]
+<p>The default value is: <code>any</code></p>""" ] ]
       attribute Id {
         text
       }?
@@ -19,21 +19,21 @@ CycloneDDS configuration""" ] ]
       element Compatibility {
         [ a:documentation [ xml:lang="en" """
 <p>This option assumes ParticipantMessageData endpoints required by the liveliness protocol are present in RTI participants even when not properly advertised by the participant discovery protocol.</p>
-<p>The default value is: "false".</p>""" ] ]
+<p>The default value is: <code>false</code></p>""" ] ]
         element AssumeRtiHasPmdEndpoints {
           xsd:boolean
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element specifies whether QoS settings set to default values are explicitly published in the discovery protocol. Implementations are to use the default value for QoS settings not published, which allows a significant reduction of the amount of data that needs to be exchanged for the discovery protocol, but this requires all implementations to adhere to the default values specified by the specifications.</p>
 <p>When interoperability is required with an implementation that does not follow the specifications in this regard, setting this option to true will help.</p>
-<p>The default value is: "false".</p>""" ] ]
+<p>The default value is: <code>false</code></p>""" ] ]
         element ExplicitlyPublishQosSetToDefault {
           xsd:boolean
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This option specifies whether a network socket will be created for each domain participant on a host. The specification seems to assume that each participant has a unique address, and setting this option will ensure this to be the case. This is not the default.</p>
 <p>Disabling it slightly improves performance and reduces network traffic somewhat. It also causes the set of port numbers needed by Cyclone DDS to become predictable, which may be useful for firewall and NAT configuration.</p>
-<p>The default value is: "single".</p>""" ] ]
+<p>The default value is: <code>single</code></p>""" ] ]
         element ManySocketsMode {
           ("false"|"true"|"single"|"none"|"many")
         }?
@@ -42,7 +42,7 @@ CycloneDDS configuration""" ] ]
 <ul><li><i>pedantic</i>: very strictly conform to the specification, ultimately for compliance testing, but currently of little value because it adheres even to what will most likely turn out to be editing errors in the DDSI standard. Arguably, as long as no errata have been published, the current text is in effect, and that is what pedantic currently does.</li>
 <li><i>strict</i>: a relatively less strict view of the standard than does pedantic: it follows the established behaviour where the standard is obviously in error.</li>
 <li><i>lax</i>: attempt to provide the smoothest possible interoperability, anticipating future revisions of elements in the standard in areas that other implementations do not adhere to, even though there is no good reason not to.</li></ul>
-<p>The default value is: "lax".</p>""" ] ]
+<p>The default value is: <code>lax</code></p>""" ] ]
         element StandardsConformance {
           ("lax"|"strict"|"pedantic")
         }?
@@ -53,38 +53,38 @@ CycloneDDS configuration""" ] ]
         [ a:documentation [ xml:lang="en" """
 <p>This setting controls for how long endpoints discovered via a Cloud discovery service will survive after the discovery service disappears, allowing reconnection without loss of data when the discovery service restarts (or another instance takes over).</p>
 <p>Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.</p>
-<p>The default value is: "30 s".</p>""" ] ]
+<p>The default value is: <code>30 s</code></p>""" ] ]
         element DSGracePeriod {
           duration_inf
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element specifies the default multicast address for all traffic other than participant discovery packets. It defaults to Discovery/SPDPMulticastAddress.</p>
-<p>The default value is: "auto".</p>""" ] ]
+<p>The default value is: <code>auto</code></p>""" ] ]
         element DefaultMulticastAddress {
           text
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element controls whether the built-in endpoints for topic discovery are created and used to exchange topic discovery information.</p>
-<p>The default value is: "false".</p>""" ] ]
+<p>The default value is: <code>false</code></p>""" ] ]
         element EnableTopicDiscoveryEndpoints {
           xsd:boolean
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>An override for the domain id is used to discovery and determine the port number mapping. This allows the creating of multiple domains in a single process while making them appear as a single domain on the network. The value "default" disables the override.</p>
-<p>The default value is: "default".</p>""" ] ]
+<p>The default value is: <code>default</code></p>""" ] ]
         element ExternalDomainId {
           text
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This setting controls the default participant lease duration.<p>
 <p>The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.</p>
-<p>The default value is: "10 s".</p>""" ] ]
+<p>The default value is: <code>10 s</code></p>""" ] ]
         element LeaseDuration {
           duration
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element specifies the maximum DDSI participant index selected by this instance of the Cyclone DDS service if the Discovery/ParticipantIndex is "auto".</p>
-<p>The default value is: "9".</p>""" ] ]
+<p>The default value is: <code>9</code></p>""" ] ]
         element MaxAutoParticipantIndex {
           xsd:integer
         }?
@@ -93,7 +93,7 @@ CycloneDDS configuration""" ] ]
 <ul><li><i>auto</i>: which will attempt to automatically determine an available participant index (see also Discovery/MaxAutoParticipantIndex), or</li>
 <li>a non-negative integer less than 120, or</li>
 <li><i>none</i>:, which causes it to use arbitrary port numbers for unicast sockets which entirely removes the constraints on the participant index but makes unicast discovery impossible.</li></ul>
-<p>The default value is: "none".</p>""" ] ]
+<p>The default value is: <code>none</code></p>""" ] ]
         element ParticipantIndex {
           text
         }?
@@ -105,7 +105,7 @@ CycloneDDS configuration""" ] ]
           element Peer {
             [ a:documentation [ xml:lang="en" """
 <p>This element specifies an IP address to which discovery packets must be sent, in addition to the default multicast address (see also General/AllowMulticast). Both hostnames and a numerical IP address are accepted; the hostname or IP address may be suffixed with :PORT to explicitly set the port to which it must be sent. Multiple Peers may be specified.</p>
-<p>The default value is: "".</p>""" ] ]
+<p>The default value is: <code>&lt;empty&gt;</code></p>""" ] ]
             attribute Address {
               text
             }
@@ -116,43 +116,43 @@ CycloneDDS configuration""" ] ]
         element Ports {
           [ a:documentation [ xml:lang="en" """
 <p>This element specifies the base port number (refer to the DDSI 2.1 specification, section 9.6.1, constant PB).</p>
-<p>The default value is: "7400".</p>""" ] ]
+<p>The default value is: <code>7400</code></p>""" ] ]
           element Base {
             xsd:integer
           }?
           & [ a:documentation [ xml:lang="en" """
 <p>This element specifies the domain gain, relating domain ids to sets of port numbers (refer to the DDSI 2.1 specification, section 9.6.1, constant DG).</p>
-<p>The default value is: "250".</p>""" ] ]
+<p>The default value is: <code>250</code></p>""" ] ]
           element DomainGain {
             xsd:integer
           }?
           & [ a:documentation [ xml:lang="en" """
 <p>This element specifies the port number for multicast data traffic (refer to the DDSI 2.1 specification, section 9.6.1, constant d2).</p>
-<p>The default value is: "1".</p>""" ] ]
+<p>The default value is: <code>1</code></p>""" ] ]
           element MulticastDataOffset {
             xsd:integer
           }?
           & [ a:documentation [ xml:lang="en" """
 <p>This element specifies the port number for multicast meta traffic (refer to the DDSI 2.1 specification, section 9.6.1, constant d0).</p>
-<p>The default value is: "0".</p>""" ] ]
+<p>The default value is: <code>0</code></p>""" ] ]
           element MulticastMetaOffset {
             xsd:integer
           }?
           & [ a:documentation [ xml:lang="en" """
 <p>This element specifies the participant gain, relating p0, participant index to sets of port numbers (refer to the DDSI 2.1 specification, section 9.6.1, constant PG).</p>
-<p>The default value is: "2".</p>""" ] ]
+<p>The default value is: <code>2</code></p>""" ] ]
           element ParticipantGain {
             xsd:integer
           }?
           & [ a:documentation [ xml:lang="en" """
 <p>This element specifies the port number for unicast data traffic (refer to the DDSI 2.1 specification, section 9.6.1, constant d3).</p>
-<p>The default value is: "11".</p>""" ] ]
+<p>The default value is: <code>11</code></p>""" ] ]
           element UnicastDataOffset {
             xsd:integer
           }?
           & [ a:documentation [ xml:lang="en" """
 <p>This element specifies the port number for unicast meta traffic (refer to the DDSI 2.1 specification, section 9.6.1, constant d1).</p>
-<p>The default value is: "10".</p>""" ] ]
+<p>The default value is: <code>10</code></p>""" ] ]
           element UnicastMetaOffset {
             xsd:integer
           }?
@@ -160,19 +160,19 @@ CycloneDDS configuration""" ] ]
         & [ a:documentation [ xml:lang="en" """
 <p>This element specifies the interval between spontaneous transmissions of participant discovery packets.</p>
 <p>The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.</p>
-<p>The default value is: "30 s".</p>""" ] ]
+<p>The default value is: <code>30 s</code></p>""" ] ]
         element SPDPInterval {
           duration
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element specifies the multicast address used as the destination for the participant discovery packets. In IPv4 mode the default is the (standardised) 239.255.0.1, in IPv6 mode it becomes ff02::ffff:239.255.0.1, which is a non-standardised link-local multicast address.</p>
-<p>The default value is: "239.255.0.1".</p>""" ] ]
+<p>The default value is: <code>239.255.0.1</code></p>""" ] ]
         element SPDPMulticastAddress {
           text
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>String extension for domain id that remote participants must match to be discovered.</p>
-<p>The default value is: "".</p>""" ] ]
+<p>The default value is: <code>&lt;empty&gt;</code></p>""" ] ]
         element Tag {
           text
         }?
@@ -190,29 +190,29 @@ CycloneDDS configuration""" ] ]
 </ul>
 <p>When set to "false" all multicasting is disabled. The default, "true" enables the full use of multicasts. Listening for multicasts can be controlled by General/MulticastRecvNetworkInterfaceAddresses.</p>
 <p>"default" maps on spdp if the network is a WiFi network, on true if it is a wired network</p>
-<p>The default value is: "default".</p>""" ] ]
+<p>The default value is: <code>default</code></p>""" ] ]
         element AllowMulticast {
           xsd:token { pattern = "default|((false|spdp|asm|ssm|true)(,(false|spdp|asm|ssm|true))*)" }
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element allows setting the SO_DONTROUTE option for outgoing packets to bypass the local routing tables. This is generally useful only when the routing tables cannot be trusted, which is highly unusual.</p>
-<p>The default value is: "false".</p>""" ] ]
+<p>The default value is: <code>false</code></p>""" ] ]
         element DontRoute {
           xsd:boolean
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element specifies whether Cyclone DDS allows IP multicast packets to be visible to all DDSI participants in the same node, including itself. It must be "true" for intra-node multicast communications. However, if a node runs only a single Cyclone DDS service and does not host any other DDSI-capable programs, it should be set to "false" for improved performance.</p>
-<p>The default value is: "true".</p>""" ] ]
+<p>The default value is: <code>true</code></p>""" ] ]
         element EnableMulticastLoopback {
           xsd:boolean
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element specifies the entity autonaming mode. By default set to 'empty' which means no name will be set (but you can still use dds_qset_entity_name). When set to 'fancy' participants, publishers, subscribers, writers, and readers will get randomly generated names. An autonamed entity will share a 3-letter prefix with their parent entity.</p>
-<p>The default value is: "empty".</p>""" ] ]
+<p>The default value is: <code>empty</code></p>""" ] ]
         element EntityAutoNaming {
           [ a:documentation [ xml:lang="en" """
 <p>Provide an initial seed for the entity naming. Your string will be hashed to provide the random state. When provided, the same sequence of names is generated every run. Creating your entities in the same order will ensure they are the same between runs. If you run multiple nodes, set this via environment variable to ensure every node generates unique names. A random starting seed is chosen when left empty, (the default). </p>
-<p>The default value is: "".</p>""" ] ]
+<p>The default value is: <code>&lt;empty&gt;</code></p>""" ] ]
           attribute seed {
             text
           }?
@@ -220,20 +220,20 @@ CycloneDDS configuration""" ] ]
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element allows explicitly overruling the network address Cyclone DDS advertises in the discovery protocol, which by default is the address of the preferred network interface (General/NetworkInterfaceAddress), to allow Cyclone DDS to communicate across a Network Address Translation (NAT) device.</p>
-<p>The default value is: "auto".</p>""" ] ]
+<p>The default value is: <code>auto</code></p>""" ] ]
         element ExternalNetworkAddress {
           text
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element specifies the network mask of the external network address. This element is relevant only when an external network address (General/ExternalNetworkAddress) is explicitly configured. In this case locators received via the discovery protocol that are within the same external subnet (as defined by this mask) will be translated to an internal address by replacing the network portion of the external address with the corresponding portion of the preferred network interface address. This option is IPv4-only.</p>
-<p>The default value is: "0.0.0.0".</p>""" ] ]
+<p>The default value is: <code>0.0.0.0</code></p>""" ] ]
         element ExternalNetworkMask {
           text
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element specifies the size of DDSI sample fragments generated by Cyclone DDS. Samples larger than FragmentSize are fragmented into fragments of FragmentSize bytes each, except the last one, which may be smaller. The DDSI spec mandates a minimum fragment size of 1025 bytes, but Cyclone DDS will do whatever size is requested, accepting fragments of which the size is at least the minimum of 1025 and FragmentSize.</p>
 <p>The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2<sup>10</sup> bytes), MB & MiB (2<sup>20</sup> bytes), GB & GiB (2<sup>30</sup> bytes).</p>
-<p>The default value is: "1344 B".</p>""" ] ]
+<p>The default value is: <code>1344 B</code></p>""" ] ]
         element FragmentSize {
           memsize
         }?
@@ -245,43 +245,43 @@ CycloneDDS configuration""" ] ]
           element NetworkInterface {
             [ a:documentation [ xml:lang="en" """
 <p>This attribute specifies the address of the interface. With ipv4 allows  matching on the network part if the host part is set to zero. </p>
-<p>The default value is: "".</p>""" ] ]
+<p>The default value is: <code>&lt;empty&gt;</code></p>""" ] ]
             attribute address {
               text
             }?
             & [ a:documentation [ xml:lang="en" """
 <p>If set to "true" an interface is automatically selected. Specifying a name or an address when automatic is set is considered an error.</p>
-<p>The default value is: "false".</p>""" ] ]
+<p>The default value is: <code>false</code></p>""" ] ]
             attribute autodetermine {
               text
             }?
             & [ a:documentation [ xml:lang="en" """
 <p>This attribute specifies whether the interface should use multicast. On its default setting, 'default', it will use the value as return by the operating system. If set to 'true', the interface will be assumed to be multicast capable even when the interface flags returned by the operating system state it is not (this provides a workaround for some platforms). If set to 'false', the interface will never be used for multicast.
-<p>The default value is: "default".</p>""" ] ]
+<p>The default value is: <code>default</code></p>""" ] ]
             attribute multicast {
               text
             }?
             & [ a:documentation [ xml:lang="en" """
 <p>This attribute specifies the name of the interface. </p>
-<p>The default value is: "".</p>""" ] ]
+<p>The default value is: <code>&lt;empty&gt;</code></p>""" ] ]
             attribute name {
               text
             }?
             & [ a:documentation [ xml:lang="en" """
 <p>When false (default), Cyclone DDS uses unicast for data whenever a single unicast suffices. Setting this to true makes it prefer multicasting data, falling back to unicast only when no multicast is available.</p>
-<p>The default value is: "false".</p>""" ] ]
+<p>The default value is: <code>false</code></p>""" ] ]
             attribute prefer_multicast {
               xsd:boolean
             }?
             & [ a:documentation [ xml:lang="en" """
 <p>By default, all specified network interfaces must be present; if they are missing Cyclone will not start. By explicitly setting this setting for an interface, you can instruct Cyclone to ignore that interface if it is not present.</p>
-<p>The default value is: "true".</p>""" ] ]
+<p>The default value is: <code>true</code></p>""" ] ]
             attribute presence_required {
               xsd:boolean
             }?
             & [ a:documentation [ xml:lang="en" """
 <p>This attribute specifies the interface priority (decimal integer or <i>default</i>). The default value for loopback interfaces is 2, for all other interfaces it is 0.</p>
-<p>The default value is: "default".</p>""" ] ]
+<p>The default value is: <code>default</code></p>""" ] ]
             attribute priority {
               text
             }?
@@ -291,7 +291,7 @@ CycloneDDS configuration""" ] ]
 <p>This element specifies the maximum size of the UDP payload that Cyclone DDS will generate. Cyclone DDS will try to maintain this limit within the bounds of the DDSI specification, which means that in some cases (especially for very low values of MaxMessageSize) larger payloads may sporadically be observed (currently up to 1192 B).</p>
 <p>On some networks it may be necessary to set this item to keep the packetsize below the MTU to prevent IP fragmentation.</p>
 <p>The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2<sup>10</sup> bytes), MB & MiB (2<sup>20</sup> bytes), GB & GiB (2<sup>30</sup> bytes).</p>
-<p>The default value is: "14720 B".</p>""" ] ]
+<p>The default value is: <code>14720 B</code></p>""" ] ]
         element MaxMessageSize {
           memsize
         }?
@@ -299,7 +299,7 @@ CycloneDDS configuration""" ] ]
 <p>This element specifies the maximum size of the UDP payload that Cyclone DDS will generate for a retransmit. Cyclone DDS will try to maintain this limit within the bounds of the DDSI specification, which means that in some cases (especially for very low values) larger payloads may sporadically be observed (currently up to 1192 B).</p>
 <p>On some networks it may be necessary to set this item to keep the packetsize below the MTU to prevent IP fragmentation.</p>
 <p>The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2<sup>10</sup> bytes), MB & MiB (2<sup>20</sup> bytes), GB & GiB (2<sup>30</sup> bytes).</p>
-<p>The default value is: "1456 B".</p>""" ] ]
+<p>The default value is: <code>1456 B</code></p>""" ] ]
         element MaxRexmitMessageSize {
           memsize
         }?
@@ -313,31 +313,31 @@ CycloneDDS configuration""" ] ]
 <li>a comma-separated list of network addresses: configures Cyclone DDS to listen for multicasts on all listed addresses.</li>
 </ul>
 <p>If Cyclone DDS is in IPv6 mode and the address of the preferred network interface is a link-local address, "all" is treated as a synonym for "preferred" and a comma-separated list is treated as "preferred" if it contains the preferred interface and as "none" if not.</p>
-<p>The default value is: "preferred".</p>""" ] ]
+<p>The default value is: <code>preferred</code></p>""" ] ]
         element MulticastRecvNetworkInterfaceAddresses {
           text
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element specifies the time-to-live setting for outgoing multicast packets.</p>
-<p>The default value is: "32".</p>""" ] ]
+<p>The default value is: <code>32</code></p>""" ] ]
         element MulticastTimeToLive {
           xsd:integer
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>When enabled, use selected network interfaces in parallel for redundancy.</p>
-<p>The default value is: "false".</p>""" ] ]
+<p>The default value is: <code>false</code></p>""" ] ]
         element RedundantNetworking {
           xsd:boolean
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element allows selecting the transport to be used (udp, udp6, tcp, tcp6, raweth)</p>
-<p>The default value is: "default".</p>""" ] ]
+<p>The default value is: <code>default</code></p>""" ] ]
         element Transport {
           ("default"|"udp"|"udp6"|"tcp"|"tcp6"|"raweth")
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>Deprecated (use Transport instead)</p>
-<p>The default value is: "default".</p>""" ] ]
+<p>The default value is: <code>default</code></p>""" ] ]
         element UseIPv6 {
           ("false"|"true"|"default")
         }?
@@ -347,21 +347,21 @@ CycloneDDS configuration""" ] ]
       element Internal {
         [ a:documentation [ xml:lang="en" """
 <p>Proxy readers that are assumed to still be retrieving historical data get this many samples retransmitted when they NACK something, even if some of these samples have sequence numbers outside the set covered by the NACK.</p>
-<p>The default value is: "0".</p>""" ] ]
+<p>The default value is: <code>0</code></p>""" ] ]
         element AccelerateRexmitBlockSize {
           xsd:integer
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This setting controls the delay between sending identical acknowledgements.</p>
 <p>The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.</p>
-<p>The default value is: "10 ms".</p>""" ] ]
+<p>The default value is: <code>10 ms</code></p>""" ] ]
         element AckDelay {
           duration
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This setting controls the interval with which a reader will continue NACK'ing missing samples in the absence of a response from the writer, as a protection mechanism against writers incorrectly stopping the sending of HEARTBEAT messages.</p>
 <p>Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.</p>
-<p>The default value is: "3 s".</p>""" ] ]
+<p>The default value is: <code>3 s</code></p>""" ] ]
         element AutoReschedNackDelay {
           duration_inf
         }?
@@ -371,7 +371,7 @@ CycloneDDS configuration""" ] ]
 <li><i>writers</i>: all participants have the writers, but just one has the readers;</li>
 <li><i>minimal</i>: only one participant has built-in endpoints.</li></ul>
 <p>The default is <i>writers</i>, as this is thought to be compliant and reasonably efficient. <i>Minimal</i> may or may not be compliant but is most efficient, and <i>full</i> is inefficient but certain to be compliant.</p>
-<p>The default value is: "writers".</p>""" ] ]
+<p>The default value is: <code>writers</code></p>""" ] ]
         element BuiltinEndpointSet {
           ("full"|"writers"|"minimal")
         }?
@@ -381,14 +381,14 @@ CycloneDDS configuration""" ] ]
           [ a:documentation [ xml:lang="en" """
 <p>This element specifies how much more than the (presumed or discovered) receive buffer size may be sent when transmitting a sample for the first time, expressed as a percentage; the remainder will then be handled via retransmits. Usually, the receivers can keep up with the transmitter, at least on average, so generally it is better to hope for the best and recover. Besides, the retransmits will be unicast, and so any multicast advantage will be lost as well.</p>
 <p>The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2<sup>10</sup> bytes), MB & MiB (2<sup>20</sup> bytes), GB & GiB (2<sup>30</sup> bytes).</p>
-<p>The default value is: "4294967295".</p>""" ] ]
+<p>The default value is: <code>4294967295</code></p>""" ] ]
           element MaxInitTransmit {
             memsize
           }?
           & [ a:documentation [ xml:lang="en" """
 <p>This element specifies the amount of data to be retransmitted in response to one NACK.</p>
 <p>The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2<sup>10</sup> bytes), MB & MiB (2<sup>20</sup> bytes), GB & GiB (2<sup>30</sup> bytes).</p>
-<p>The default value is: "1 MiB".</p>""" ] ]
+<p>The default value is: <code>1 MiB</code></p>""" ] ]
           element MaxRexmit {
             memsize
           }?
@@ -400,25 +400,25 @@ CycloneDDS configuration""" ] ]
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element sets the maximum number of extra threads for an experimental, undocumented, and unsupported direct mode.</p>
-<p>The default value is: "1".</p>""" ] ]
+<p>The default value is: <code>1</code></p>""" ] ]
         element DDSI2DirectMaxThreads {
           xsd:integer
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element sets the maximum number of samples that can be defragmented simultaneously for a reliable writer. This has to be large enough to handle retransmissions of historical data in addition to new samples.</p>
-<p>The default value is: "16".</p>""" ] ]
+<p>The default value is: <code>16</code></p>""" ] ]
         element DefragReliableMaxSamples {
           xsd:integer
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element sets the maximum number of samples that can be defragmented simultaneously for best-effort writers.</p>
-<p>The default value is: "4".</p>""" ] ]
+<p>The default value is: <code>4</code></p>""" ] ]
         element DefragUnreliableMaxSamples {
           xsd:integer
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element controls the maximum size of a delivery queue, expressed in samples. Once a delivery queue is full, incoming samples destined for that queue are dropped until space becomes available again.</p>
-<p>The default value is: "256".</p>""" ] ]
+<p>The default value is: <code>256</code></p>""" ] ]
         element DeliveryQueueMaxSamples {
           xsd:integer
         }?
@@ -429,39 +429,39 @@ CycloneDDS configuration""" ] ]
 <li><i>rhc</i>: reader history cache checking</li>
 <li><i>xevent</i>: xevent checking</li>
 <p>In addition, there is the keyword <i>all</i> that enables all checks.</p>
-<p>The default value is: "".</p>""" ] ]
+<p>The default value is: <code>&lt;empty&gt;</code></p>""" ] ]
         element EnableExpensiveChecks {
           xsd:token { pattern = "((whc|rhc|xevent|all)(,(whc|rhc|xevent|all))*)|" }
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>When true, include keyhashes in outgoing data for topics with keys.</p>
-<p>The default value is: "false".</p>""" ] ]
+<p>The default value is: <code>false</code></p>""" ] ]
         element GenerateKeyhash {
           xsd:boolean
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element allows configuring the base interval for sending writer heartbeats and the bounds within which it can vary.</p>
 <p>Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.</p>
-<p>The default value is: "100 ms".</p>""" ] ]
+<p>The default value is: <code>100 ms</code></p>""" ] ]
         element HeartbeatInterval {
           [ a:documentation [ xml:lang="en" """
 <p>This attribute sets the maximum interval for periodic heartbeats.</p>
 <p>Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.</p>
-<p>The default value is: "8 s".</p>""" ] ]
+<p>The default value is: <code>8 s</code></p>""" ] ]
           attribute max {
             duration_inf
           }?
           & [ a:documentation [ xml:lang="en" """
 <p>This attribute sets the minimum interval that must have passed since the most recent heartbeat from a writer, before another asynchronous (not directly related to writing) will be sent.</p>
 <p>Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.</p>
-<p>The default value is: "5 ms".</p>""" ] ]
+<p>The default value is: <code>5 ms</code></p>""" ] ]
           attribute min {
             duration_inf
           }?
           & [ a:documentation [ xml:lang="en" """
 <p>This attribute sets the minimum interval for periodic heartbeats. Other events may still cause heartbeats to go out.</p>
 <p>Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.</p>
-<p>The default value is: "20 ms".</p>""" ] ]
+<p>The default value is: <code>20 ms</code></p>""" ] ]
           attribute minsched {
             duration_inf
           }?
@@ -469,24 +469,24 @@ CycloneDDS configuration""" ] ]
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>Ack a sample only when it has been delivered, instead of when committed to delivering it.</p>
-<p>The default value is: "false".</p>""" ] ]
+<p>The default value is: <code>false</code></p>""" ] ]
         element LateAckMode {
           xsd:boolean
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element controls whether or not implementation should internally monitor its own liveliness. If liveliness monitoring is enabled, stack traces can be dumped automatically when some thread appears to have stopped making progress.</p>
-<p>The default value is: "false".</p>""" ] ]
+<p>The default value is: <code>false</code></p>""" ] ]
         element LivelinessMonitoring {
           [ a:documentation [ xml:lang="en" """
 <p>This element controls the interval to check whether threads have been making progress.</p>
 <p>The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.</p>
-<p>The default value is: "1s".</p>""" ] ]
+<p>The default value is: <code>1s</code></p>""" ] ]
           attribute Interval {
             duration
           }?
           & [ a:documentation [ xml:lang="en" """
 <p>This element controls whether or not to write stack traces to the DDSI2 trace when a thread fails to make progress (on select platforms only).</p>
-<p>The default value is: "true".</p>""" ] ]
+<p>The default value is: <code>true</code></p>""" ] ]
           attribute StackTraces {
             xsd:boolean
           }?
@@ -494,49 +494,49 @@ CycloneDDS configuration""" ] ]
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This elements configures the maximum number of DCPS domain participants this Cyclone DDS instance is willing to service. 0 is unlimited.</p>
-<p>The default value is: "0".</p>""" ] ]
+<p>The default value is: <code>0</code></p>""" ] ]
         element MaxParticipants {
           xsd:integer
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This setting limits the maximum number of bytes queued for retransmission. The default value of 0 is unlimited unless an AuxiliaryBandwidthLimit has been set, in which case it becomes NackDelay * AuxiliaryBandwidthLimit. It must be large enough to contain the largest sample that may need to be retransmitted.</p>
 <p>The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2<sup>10</sup> bytes), MB & MiB (2<sup>20</sup> bytes), GB & GiB (2<sup>30</sup> bytes).</p>
-<p>The default value is: "512 kB".</p>""" ] ]
+<p>The default value is: <code>512 kB</code></p>""" ] ]
         element MaxQueuedRexmitBytes {
           memsize
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This setting limits the maximum number of samples queued for retransmission.</p>
-<p>The default value is: "200".</p>""" ] ]
+<p>The default value is: <code>200</code></p>""" ] ]
         element MaxQueuedRexmitMessages {
           xsd:integer
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This setting controls the maximum (CDR) serialised size of samples that Cyclone DDS will forward in either direction. Samples larger than this are discarded with a warning.</p>
 <p>The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2<sup>10</sup> bytes), MB & MiB (2<sup>20</sup> bytes), GB & GiB (2<sup>30</sup> bytes).</p>
-<p>The default value is: "2147483647 B".</p>""" ] ]
+<p>The default value is: <code>2147483647 B</code></p>""" ] ]
         element MaxSampleSize {
           memsize
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element enables heartbeat-to-ack latency among Cyclone DDS services by prepending timestamps to Heartbeat and AckNack messages and calculating round trip times. This is non-standard behaviour. The measured latencies are quite noisy and are currently not used anywhere.</p>
-<p>The default value is: "false".</p>""" ] ]
+<p>The default value is: <code>false</code></p>""" ] ]
         element MeasureHbToAckLatency {
           xsd:boolean
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element allows configuring a service that dumps a text description of part the internal state to TCP clients. By default (-1), this is disabled; specifying 0 means a kernel-allocated port is used; a positive number is used as the TCP port number.</p>
-<p>The default value is: "-1".</p>""" ] ]
+<p>The default value is: <code>-1</code></p>""" ] ]
         element MonitorPort {
           xsd:integer
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element controls whether all traffic is handled by a single receive thread (false) or whether multiple receive threads may be used to improve latency (true). By default it is disabled on Windows because it appears that one cannot count on being able to send packets to oneself, which is necessary to stop the thread during shutdown. Currently multiple receive threads are only used for connectionless transport (e.g., UDP) and ManySocketsMode not set to single (the default).</p>
-<p>The default value is: "default".</p>""" ] ]
+<p>The default value is: <code>default</code></p>""" ] ]
         element MultipleReceiveThreads {
           [ a:documentation [ xml:lang="en" """
 <p>Receive threads dedicated to a single socket can only be triggered for termination by sending a packet. Reception of any packet will do, so termination failure due to packet loss is exceedingly unlikely, but to eliminate all risks, it will retry as many times as specified by this attribute before aborting.</p>
-<p>The default value is: "4294967295".</p>""" ] ]
+<p>The default value is: <code>4294967295</code></p>""" ] ]
           attribute maxretries {
             xsd:integer
           }?
@@ -545,37 +545,37 @@ CycloneDDS configuration""" ] ]
         & [ a:documentation [ xml:lang="en" """
 <p>This setting controls the delay between receipt of a HEARTBEAT indicating missing samples and a NACK (ignored when the HEARTBEAT requires an answer). However, no NACK is sent if a NACK had been scheduled already for a response earlier than the delay requests: then that NACK will incorporate the latest information.</p>
 <p>The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.</p>
-<p>The default value is: "100 ms".</p>""" ] ]
+<p>The default value is: <code>100 ms</code></p>""" ] ]
         element NackDelay {
           duration
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This setting controls the delay between the discovering a remote writer and sending a pre-emptive AckNack to discover the available range of data.</p>
 <p>The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.</p>
-<p>The default value is: "10 ms".</p>""" ] ]
+<p>The default value is: <code>10 ms</code></p>""" ] ]
         element PreEmptiveAckDelay {
           duration
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element sets the maximum size in samples of a primary re-order administration. Each proxy writer has one primary re-order administration to buffer the packet flow in case some packets arrive out of order. Old samples are forwarded to secondary re-order administrations associated with readers needing historical data.</p>
-<p>The default value is: "128".</p>""" ] ]
+<p>The default value is: <code>128</code></p>""" ] ]
         element PrimaryReorderMaxSamples {
           xsd:integer
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element controls whether retransmits are prioritized over new data, speeding up recovery.</p>
-<p>The default value is: "true".</p>""" ] ]
+<p>The default value is: <code>true</code></p>""" ] ]
         element PrioritizeRetransmit {
           xsd:boolean
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element controls for how long a remote participant that was previously deleted will remain on a blacklist to prevent rediscovery, giving the software on a node time to perform any cleanup actions it needs to do. To some extent this delay is required internally by Cyclone DDS, but in the default configuration with the 'enforce' attribute set to false, Cyclone DDS will reallow rediscovery as soon as it has cleared its internal administration. Setting it to too small a value may result in the entry being pruned from the blacklist before Cyclone DDS is ready, it is therefore recommended to set it to at least several seconds.</p>
 <p>Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.</p>
-<p>The default value is: "0s".</p>""" ] ]
+<p>The default value is: <code>0s</code></p>""" ] ]
         element RediscoveryBlacklistDuration {
           [ a:documentation [ xml:lang="en" """
 <p>This attribute controls whether the configured time during which recently deleted participants will not be rediscovered (i.e., "black listed") is enforced and following complete removal of the participant in Cyclone DDS, or whether it can be rediscovered earlier provided all traces of that participant have been removed already.</p>
-<p>The default value is: "false".</p>""" ] ]
+<p>The default value is: <code>false</code></p>""" ] ]
           attribute enforce {
             xsd:boolean
           }?
@@ -587,7 +587,7 @@ CycloneDDS configuration""" ] ]
 <li><i>adaptive</i>: attempt to combine retransmits needed for reliability, but send historical (transient-local) data to the requesting reader only;</li>
 <li><i>always</i>: do not distinguish between different causes, always try to merge.</li></ul>
 <p>The default is <i>never</i>. See also Internal/RetransmitMergingPeriod.</p>
-<p>The default value is: "never".</p>""" ] ]
+<p>The default value is: <code>never</code></p>""" ] ]
         element RetransmitMerging {
           ("never"|"adaptive"|"always")
         }?
@@ -595,33 +595,33 @@ CycloneDDS configuration""" ] ]
 <p>This setting determines the time window size in which a NACK of some sample is ignored because a retransmit of that sample has been multicasted too recently. This setting has no effect on unicasted retransmits.</p>
 <p>See also Internal/RetransmitMerging.</p>
 <p>The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.</p>
-<p>The default value is: "5 ms".</p>""" ] ]
+<p>The default value is: <code>5 ms</code></p>""" ] ]
         element RetransmitMergingPeriod {
           duration
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>Whether or not to locally retry pushing a received best-effort sample into the reader caches when resource limits are reached.</p>
-<p>The default value is: "false".</p>""" ] ]
+<p>The default value is: <code>false</code></p>""" ] ]
         element RetryOnRejectBestEffort {
           xsd:boolean
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>Maximum pseudo-random delay in milliseconds between discovering aremote participant and responding to it.</p>
 <p>The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.</p>
-<p>The default value is: "0 ms".</p>""" ] ]
+<p>The default value is: <code>0 ms</code></p>""" ] ]
         element SPDPResponseMaxDelay {
           duration
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This setting allows the timing of scheduled events to be rounded up so that more events can be handled in a single cycle of the event queue. The default is 0 and causes no rounding at all, i.e. are scheduled exactly, whereas a value of 10ms would mean that events are rounded up to the nearest 10 milliseconds.</p>
 <p>The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.</p>
-<p>The default value is: "0 ms".</p>""" ] ]
+<p>The default value is: <code>0 ms</code></p>""" ] ]
         element ScheduleTimeRounding {
           duration
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element sets the maximum size in samples of a secondary re-order administration. The secondary re-order administration is per reader needing historical data.</p>
-<p>The default value is: "128".</p>""" ] ]
+<p>The default value is: <code>128</code></p>""" ] ]
         element SecondaryReorderMaxSamples {
           xsd:integer
         }?
@@ -632,14 +632,14 @@ CycloneDDS configuration""" ] ]
           [ a:documentation [ xml:lang="en" """
 <p>This sets the size of the socket receive buffer to request, with the special value of "default" indicating that it should try to satisfy the minimum buffer size. If both are at "default", it will request 1MiB and accept anything. It is ignored if the  maximum is set to less than the minimum.</p>
 <p>The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2<sup>10</sup> bytes), MB & MiB (2<sup>20</sup> bytes), GB & GiB (2<sup>30</sup> bytes).</p>
-<p>The default value is: "default".</p>""" ] ]
+<p>The default value is: <code>default</code></p>""" ] ]
           attribute max {
             memsize
           }?
           & [ a:documentation [ xml:lang="en" """
 <p>This sets the minimum acceptable socket receive buffer size, with the special value "default" indicating that whatever is available is acceptable.</p>
 <p>The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2<sup>10</sup> bytes), MB & MiB (2<sup>20</sup> bytes), GB & GiB (2<sup>30</sup> bytes).</p>
-<p>The default value is: "default".</p>""" ] ]
+<p>The default value is: <code>default</code></p>""" ] ]
           attribute min {
             memsize
           }?
@@ -651,34 +651,34 @@ CycloneDDS configuration""" ] ]
           [ a:documentation [ xml:lang="en" """
 <p>This sets the size of the socket send buffer to request, with the special value of "default" indicating that it should try to satisfy the minimum buffer size. If both are at "default", it will use whatever is the system default. It is ignored if the maximum is set to less than the minimum.</p>
 <p>The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2<sup>10</sup> bytes), MB & MiB (2<sup>20</sup> bytes), GB & GiB (2<sup>30</sup> bytes).</p>
-<p>The default value is: "default".</p>""" ] ]
+<p>The default value is: <code>default</code></p>""" ] ]
           attribute max {
             memsize
           }?
           & [ a:documentation [ xml:lang="en" """
 <p>This sets the minimum acceptable socket send buffer size, with the special value "default" indicating that whatever is available is acceptable.</p>
 <p>The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2<sup>10</sup> bytes), MB & MiB (2<sup>20</sup> bytes), GB & GiB (2<sup>30</sup> bytes).</p>
-<p>The default value is: "64 KiB".</p>""" ] ]
+<p>The default value is: <code>64 KiB</code></p>""" ] ]
           attribute min {
             memsize
           }?
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element controls whether Cyclone DDS advertises all the domain participants it serves in DDSI (when set to <i>false</i>), or rather only one domain participant (the one corresponding to the Cyclone DDS process; when set to <i>true</i>). In the latter case, Cyclone DDS becomes the virtual owner of all readers and writers of all domain participants, dramatically reducing discovery traffic (a similar effect can be obtained by setting Internal/BuiltinEndpointSet to "minimal" but with less loss of information).</p>
-<p>The default value is: "false".</p>""" ] ]
+<p>The default value is: <code>false</code></p>""" ] ]
         element SquashParticipants {
           xsd:boolean
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element controls whether samples sent by a writer with QoS settings transport_priority >= SynchronousDeliveryPriorityThreshold and a latency_budget at most this element's value will be delivered synchronously from the "recv" thread, all others will be delivered asynchronously through delivery queues. This reduces latency at the expense of aggregate bandwidth.</p>
 <p>Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.</p>
-<p>The default value is: "inf".</p>""" ] ]
+<p>The default value is: <code>inf</code></p>""" ] ]
         element SynchronousDeliveryLatencyBound {
           duration_inf
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element controls whether samples sent by a writer with QoS settings latency_budget <= SynchronousDeliveryLatencyBound and transport_priority greater than or equal to this element's value will be delivered synchronously from the "recv" thread, all others will be delivered asynchronously through delivery queues. This reduces latency at the expense of aggregate bandwidth.</p>
-<p>The default value is: "0".</p>""" ] ]
+<p>The default value is: <code>0</code></p>""" ] ]
         element SynchronousDeliveryPriorityThreshold {
           xsd:integer
         }?
@@ -687,20 +687,20 @@ CycloneDDS configuration""" ] ]
         element Test {
           [ a:documentation [ xml:lang="en" """
 <p>This element controls the fraction of outgoing packets to drop, specified as samples per thousand.</p>
-<p>The default value is: "0".</p>""" ] ]
+<p>The default value is: <code>0</code></p>""" ] ]
           element XmitLossiness {
             xsd:integer
           }?
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element controls whether the response to a newly discovered participant is sent as a unicasted SPDP packet instead of rescheduling the periodic multicasted one. There is no known benefit to setting this to <i>false</i>.</p>
-<p>The default value is: "true".</p>""" ] ]
+<p>The default value is: <code>true</code></p>""" ] ]
         element UnicastResponseToSPDPMessages {
           xsd:boolean
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>Do not use.</p>
-<p>The default value is: "0".</p>""" ] ]
+<p>The default value is: <code>0</code></p>""" ] ]
         element UseMulticastIfMreqn {
           xsd:integer
         }?
@@ -709,42 +709,42 @@ CycloneDDS configuration""" ] ]
         element Watermarks {
           [ a:documentation [ xml:lang="en" """
 <p>This element controls whether Cyclone DDS will adapt the high-water mark to current traffic conditions based on retransmit requests and transmit pressure.</p>
-<p>The default value is: "true".</p>""" ] ]
+<p>The default value is: <code>true</code></p>""" ] ]
           element WhcAdaptive {
             xsd:boolean
           }?
           & [ a:documentation [ xml:lang="en" """
 <p>This element sets the maximum allowed high-water mark for the Cyclone DDS WHCs, expressed in bytes. A writer is suspended when the WHC reaches this size.</p>
 <p>The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2<sup>10</sup> bytes), MB & MiB (2<sup>20</sup> bytes), GB & GiB (2<sup>30</sup> bytes).</p>
-<p>The default value is: "500 kB".</p>""" ] ]
+<p>The default value is: <code>500 kB</code></p>""" ] ]
           element WhcHigh {
             memsize
           }?
           & [ a:documentation [ xml:lang="en" """
 <p>This element sets the initial level of the high-water mark for the Cyclone DDS WHCs, expressed in bytes.</p>
 <p>The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2<sup>10</sup> bytes), MB & MiB (2<sup>20</sup> bytes), GB & GiB (2<sup>30</sup> bytes).</p>
-<p>The default value is: "30 kB".</p>""" ] ]
+<p>The default value is: <code>30 kB</code></p>""" ] ]
           element WhcHighInit {
             memsize
           }?
           & [ a:documentation [ xml:lang="en" """
 <p>This element sets the low-water mark for the Cyclone DDS WHCs, expressed in bytes. A suspended writer resumes transmitting when its Cyclone DDS WHC shrinks to this size.</p>
 <p>The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2<sup>10</sup> bytes), MB & MiB (2<sup>20</sup> bytes), GB & GiB (2<sup>30</sup> bytes).</p>
-<p>The default value is: "1 kB".</p>""" ] ]
+<p>The default value is: <code>1 kB</code></p>""" ] ]
           element WhcLow {
             memsize
           }?
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element enables the batching of write operations. By default each write operation writes through the write cache and out onto the transport. Enabling write batching causes multiple small write operations to be aggregated within the write cache into a single larger write. This gives greater throughput at the expense of latency. Currently, there is no mechanism for the write cache to automatically flush itself, so that if write batching is enabled, the application may have to use the dds_write_flush function to ensure that all samples are written.</p>
-<p>The default value is: "false".</p>""" ] ]
+<p>The default value is: <code>false</code></p>""" ] ]
         element WriteBatch {
           xsd:boolean
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This setting controls the maximum duration for which actual deletion of a reliable writer with unacknowledged data in its history will be postponed to provide proper reliable transmission.<p>
 <p>The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.</p>
-<p>The default value is: "1 s".</p>""" ] ]
+<p>The default value is: <code>1 s</code></p>""" ] ]
         element WriterLingerDuration {
           duration
         }?
@@ -757,11 +757,11 @@ CycloneDDS configuration""" ] ]
         element IgnoredPartitions {
           [ a:documentation [ xml:lang="en" """
 <p>This element can prevent certain combinations of DCPS partition and topic from being transmitted over the network. Cyclone DDS will completely ignore readers and writers for which all DCPS partitions as well as their topic is ignored, not even creating DDSI readers and writers to mirror the DCPS ones.</p>
-<p>The default value is: "".</p>""" ] ]
+<p>The default value is: <code>&lt;empty&gt;</code></p>""" ] ]
           element IgnoredPartition {
             [ a:documentation [ xml:lang="en" """
 <p>This attribute specifies a partition and a topic expression, separated by a single '.', which are used to determine if a given partition and topic will be ignored or not. The expressions may use the usual wildcards '*' and '?'. Cyclone DDS will consider a wildcard DCPS partition to match an expression if a string that satisfies both expressions exists.</p>
-<p>The default value is: "".</p>""" ] ]
+<p>The default value is: <code>&lt;empty&gt;</code></p>""" ] ]
             attribute DCPSPartitionTopic {
               text
             }
@@ -772,23 +772,23 @@ CycloneDDS configuration""" ] ]
         element NetworkPartitions {
           [ a:documentation [ xml:lang="en" """
 <p>This element defines a Cyclone DDS network partition.</p>
-<p>The default value is: "".</p>""" ] ]
+<p>The default value is: <code>&lt;empty&gt;</code></p>""" ] ]
           element NetworkPartition {
             [ a:documentation [ xml:lang="en" """
 <p>This attribute specifies the addresses associated with the network partition as a comma-separated list. The addresses are typically multicast addresses. Non-multicast addresses are allowed, provided the "Interface" attribute is not used:</p><ul><li>An address matching the address or the "external address" (see General/ExternalNetworkAddress; default is the actual address) of a configured interface results in adding the corresponding "external" address to the set of advertised unicast addresses.</li><li>An address corresponding to the (external) address of a configured interface, but not the address of the host itself, for example, a match when masking the addresses with the netmask for IPv4, results in adding the external address. For IPv4, this requires the host part to be all-zero.</li></ul><p>Readers matching this network partition (cf. Partitioning/PartitionMappings) will advertise all addresses listed to the matching writers via the discovery protocol and will join the specified multicast groups. The writers will select the most suitable address from the addresses advertised by the readers.</p><p>The unicast addresses advertised by a reader are the only unicast addresses a writer will use to send data to it and are used to select the subset of network interfaces to use for transmitting multicast data with the intent of reaching it.</p>
-<p>The default value is: "".</p>""" ] ]
+<p>The default value is: <code>&lt;empty&gt;</code></p>""" ] ]
             attribute Address {
               text
             }
             & [ a:documentation [ xml:lang="en" """
 <p>This attribute takes a comma-separated list of interface name that the reader is willing to receive data on. This is implemented by adding the interface addresses to the set address set configured using the sibling "Address" attribute. See there for more details.</p>
-<p>The default value is: "".</p>""" ] ]
+<p>The default value is: <code>&lt;empty&gt;</code></p>""" ] ]
             attribute Interface {
               text
             }?
             & [ a:documentation [ xml:lang="en" """
 <p>This attribute specifies the name of this Cyclone DDS network partition. Two network partitions cannot have the same name. Partition mappings (cf. Partitioning/PartitionMappings) refer to network partitions using these names.</p>
-<p>The default value is: "".</p>""" ] ]
+<p>The default value is: <code>&lt;empty&gt;</code></p>""" ] ]
             attribute Name {
               text
             }
@@ -799,17 +799,17 @@ CycloneDDS configuration""" ] ]
         element PartitionMappings {
           [ a:documentation [ xml:lang="en" """
 <p>This element defines a mapping from a DCPS partition/topic combination to a Cyclone DDS network partition. This allows partitioning data flows by using special multicast addresses for part of the data and possibly encrypting the data flow.</p>
-<p>The default value is: "".</p>""" ] ]
+<p>The default value is: <code>&lt;empty&gt;</code></p>""" ] ]
           element PartitionMapping {
             [ a:documentation [ xml:lang="en" """
 <p>This attribute specifies a partition and a topic expression, separated by a single '.', which are used to determine if a given partition and topic maps to the Cyclone DDS network partition named by the NetworkPartition attribute in this PartitionMapping element. The expressions may use the usual wildcards '*' and '?'. Cyclone DDS will consider a wildcard DCPS partition to match an expression if there exists a string that satisfies both expressions.</p>
-<p>The default value is: "".</p>""" ] ]
+<p>The default value is: <code>&lt;empty&gt;</code></p>""" ] ]
             attribute DCPSPartitionTopic {
               text
             }
             & [ a:documentation [ xml:lang="en" """
 <p>This attribute specifies which Cyclone DDS network partition is to be used for DCPS partition/topic combinations matching the DCPSPartitionTopic attribute within this PartitionMapping element.</p>
-<p>The default value is: "".</p>""" ] ]
+<p>The default value is: <code>&lt;empty&gt;</code></p>""" ] ]
             attribute NetworkPartition {
               text
             }
@@ -821,55 +821,55 @@ CycloneDDS configuration""" ] ]
       element SSL {
         [ a:documentation [ xml:lang="en" """
 <p>If disabled this allows SSL connections to occur even if an X509 certificate fails verification.</p>
-<p>The default value is: "true".</p>""" ] ]
+<p>The default value is: <code>true</code></p>""" ] ]
         element CertificateVerification {
           xsd:boolean
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>The set of ciphers used by SSL/TLS</p>
-<p>The default value is: "ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH".</p>""" ] ]
+<p>The default value is: <code>ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH</code></p>""" ] ]
         element Ciphers {
           text
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This enables SSL/TLS for TCP.</p>
-<p>The default value is: "false".</p>""" ] ]
+<p>The default value is: <code>false</code></p>""" ] ]
         element Enable {
           xsd:boolean
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>The SSL/TLS random entropy file name.</p>
-<p>The default value is: "".</p>""" ] ]
+<p>The default value is: <code>&lt;empty&gt;</code></p>""" ] ]
         element EntropyFile {
           text
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>The SSL/TLS key pass phrase for encrypted keys.</p>
-<p>The default value is: "secret".</p>""" ] ]
+<p>The default value is: <code>secret</code></p>""" ] ]
         element KeyPassphrase {
           text
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>The SSL/TLS key and certificate store file name. The keystore must be in PEM format.</p>
-<p>The default value is: "keystore".</p>""" ] ]
+<p>The default value is: <code>keystore</code></p>""" ] ]
         element KeystoreFile {
           text
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>The minimum TLS version that may be negotiated, valid values are 1.2 and 1.3.</p>
-<p>The default value is: "1.3".</p>""" ] ]
+<p>The default value is: <code>1.3</code></p>""" ] ]
         element MinimumTLSVersion {
           text
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This enables the use of self signed X509 certificates.</p>
-<p>The default value is: "false".</p>""" ] ]
+<p>The default value is: <code>false</code></p>""" ] ]
         element SelfSignedCertificates {
           xsd:boolean
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This enables an SSL server to check the X509 certificate of a connecting client.</p>
-<p>The default value is: "true".</p>""" ] ]
+<p>The default value is: <code>true</code></p>""" ] ]
         element VerifyClient {
           xsd:boolean
         }?
@@ -904,23 +904,23 @@ CycloneDDS configuration""" ] ]
 <p>Content-Disposition: attachment; filename="smime.p7s"</p>
 <p>MIIDuAYJKoZIhv ...al5s=</p>
 <p>------F9A8A198D6F08E1285A292ADF14DD04F-]]</Governance></p>
-<p>The default value is: "".</p>""" ] ]
+<p>The default value is: <code>&lt;empty&gt;</code></p>""" ] ]
           element Governance {
             text
           }?
           & [ a:documentation [ xml:lang="en" """
 <p>This element specifies the library to be loaded as the DDS Security Access Control plugin.</p>
-<p>The default value is: "".</p>""" ] ]
+<p>The default value is: <code>&lt;empty&gt;</code></p>""" ] ]
           element Library {
             [ a:documentation [ xml:lang="en" """
 <p>This element names the finalization function of Access Control plugin. This function is called to let the plugin release its resources.</p>
-<p>The default value is: "finalize_access_control".</p>""" ] ]
+<p>The default value is: <code>finalize_access_control</code></p>""" ] ]
             attribute finalizeFunction {
               text
             }?
             & [ a:documentation [ xml:lang="en" """
 <p>This element names the initialization function of Access Control plugin. This function is called after loading the plugin library for instantiation purposes. The Init function must return an object that implements the DDS Security Access Control interface.</p>
-<p>The default value is: "init_access_control".</p>""" ] ]
+<p>The default value is: <code>init_access_control</code></p>""" ] ]
             attribute initFunction {
               text
             }?
@@ -928,7 +928,7 @@ CycloneDDS configuration""" ] ]
 <p>This element points to the path of Access Control plugin library.</p>
 <p>It can be either absolute path excluding file extension ( /usr/lib/dds_security_ac ) or single file without extension ( dds_security_ac ).</p>
 <p>If a single file is supplied, the library is located by the current working directory, or LD_LIBRARY_PATH for Unix systems, and PATH for Windows systems.</p>
-<p>The default value is: "dds_security_ac".</p>""" ] ]
+<p>The default value is: <code>dds_security_ac</code></p>""" ] ]
             attribute path {
               text
             }?
@@ -941,7 +941,7 @@ CycloneDDS configuration""" ] ]
 <p><Permissions>file:/path_to/permissions_document.p7s</Permissions></p>
 <p>Example data URI:</p>
 <p><Permissions><![CDATA[data:,.........]]</Permissions></p>
-<p>The default value is: "".</p>""" ] ]
+<p>The default value is: <code>&lt;empty&gt;</code></p>""" ] ]
           element Permissions {
             text
           }?
@@ -955,7 +955,7 @@ CycloneDDS configuration""" ] ]
 <p><PermissionsCA>data:<strong>,</strong>-----BEGIN CERTIFICATE-----</p>
 <p>MIIC3DCCAcQCCQCWE5x+Z ... PhovK0mp2ohhRLYI0ZiyYQ==</p>
 <p>-----END CERTIFICATE-----</PermissionsCA></p>
-<p>The default value is: "".</p>""" ] ]
+<p>The default value is: <code>&lt;empty&gt;</code></p>""" ] ]
           element PermissionsCA {
             text
           }?
@@ -971,7 +971,7 @@ CycloneDDS configuration""" ] ]
 <p><CRL>data:,-----BEGIN X509 CRL-----<br>
 MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg=<br>
 -----END X509 CRL-----</CRL></p>
-<p>The default value is: "".</p>""" ] ]
+<p>The default value is: <code>&lt;empty&gt;</code></p>""" ] ]
           element CRL {
             text
           }?
@@ -984,7 +984,7 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg=<br>
 <p><IdentityCA>data:,-----BEGIN CERTIFICATE-----<br>
 MIIC3DCCAcQCCQCWE5x+Z...PhovK0mp2ohhRLYI0ZiyYQ==<br>
 -----END CERTIFICATE-----</IdentityCA></p>
-<p>The default value is: "".</p>""" ] ]
+<p>The default value is: <code>&lt;empty&gt;</code></p>""" ] ]
           element IdentityCA {
             text
           }
@@ -996,29 +996,29 @@ MIIC3DCCAcQCCQCWE5x+Z...PhovK0mp2ohhRLYI0ZiyYQ==<br>
 <p><IdentityCertificate>data:,-----BEGIN CERTIFICATE-----<br>
 MIIDjjCCAnYCCQDCEu9...6rmT87dhTo=<br>
 -----END CERTIFICATE-----</IdentityCertificate></p>
-<p>The default value is: "".</p>""" ] ]
+<p>The default value is: <code>&lt;empty&gt;</code></p>""" ] ]
           element IdentityCertificate {
             text
           }
           & [ a:documentation [ xml:lang="en" """
 <p>The authentication handshake tokens may contain optional fields to be included for finding interoperability problems. If this parameter is set to true the optional fields are included in the handshake token exchange.</p>
-<p>The default value is: "false".</p>""" ] ]
+<p>The default value is: <code>false</code></p>""" ] ]
           element IncludeOptionalFields {
             xsd:boolean
           }?
           & [ a:documentation [ xml:lang="en" """
 <p>This element specifies the library to be loaded as the DDS Security Access Control plugin.</p>
-<p>The default value is: "".</p>""" ] ]
+<p>The default value is: <code>&lt;empty&gt;</code></p>""" ] ]
           element Library {
             [ a:documentation [ xml:lang="en" """
 <p>This element names the finalization function of the Authentication plugin. This function is called to let the plugin release its resources.</p>
-<p>The default value is: "finalize_authentication".</p>""" ] ]
+<p>The default value is: <code>finalize_authentication</code></p>""" ] ]
             attribute finalizeFunction {
               text
             }?
             & [ a:documentation [ xml:lang="en" """
 <p>This element names the initialization function of the Authentication plugin. This function is called after loading the plugin library for instantiation purposes. The Init function must return an object that implements the DDS Security Authentication interface.</p>
-<p>The default value is: "init_authentication".</p>""" ] ]
+<p>The default value is: <code>init_authentication</code></p>""" ] ]
             attribute initFunction {
               text
             }?
@@ -1026,7 +1026,7 @@ MIIDjjCCAnYCCQDCEu9...6rmT87dhTo=<br>
 <p>This element points to the path of the Authentication plugin library.</p>
 <p>It can be either absolute path excluding file extension ( /usr/lib/dds_security_auth ) or single file without extension ( dds_security_auth ).</p>
 <p>If a single file is supplied, the library is located by the current working directory, or LD_LIBRARY_PATH for Unix systems, and PATH for Windows systems.</p>
-<p>The default value is: "dds_security_auth".</p>""" ] ]
+<p>The default value is: <code>dds_security_auth</code></p>""" ] ]
             attribute path {
               text
             }?
@@ -1035,7 +1035,7 @@ MIIDjjCCAnYCCQDCEu9...6rmT87dhTo=<br>
 <p>A password is used to decrypt the private_key.</p>
 <p>The value of the password property shall be interpreted as the Base64 encoding of the AES-128 key that shall be used to decrypt the private_key using AES128-CBC.</p>
 <p>If the password property is not present, then the value supplied in the private_key property must contain the unencrypted private key.</p>
-<p>The default value is: "".</p>""" ] ]
+<p>The default value is: <code>&lt;empty&gt;</code></p>""" ] ]
           element Password {
             text
           }?
@@ -1047,13 +1047,13 @@ MIIDjjCCAnYCCQDCEu9...6rmT87dhTo=<br>
 <p><PrivateKey>data:,-----BEGIN RSA PRIVATE KEY-----<br>
 MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==<br>
 -----END RSA PRIVATE KEY-----</PrivateKey></p>
-<p>The default value is: "".</p>""" ] ]
+<p>The default value is: <code>&lt;empty&gt;</code></p>""" ] ]
           element PrivateKey {
             text
           }
           & [ a:documentation [ xml:lang="en" """
 <p>Trusted CA Directory which contains trusted CA certificates as separated files.</p>
-<p>The default value is: "".</p>""" ] ]
+<p>The default value is: <code>&lt;empty&gt;</code></p>""" ] ]
           element TrustedCADirectory {
             text
           }?
@@ -1063,17 +1063,17 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==<br>
         element Cryptographic {
           [ a:documentation [ xml:lang="en" """
 <p>This element specifies the library to be loaded as the DDS Security Cryptographic plugin.</p>
-<p>The default value is: "".</p>""" ] ]
+<p>The default value is: <code>&lt;empty&gt;</code></p>""" ] ]
           element Library {
             [ a:documentation [ xml:lang="en" """
 <p>This element names the finalization function of the Cryptographic plugin. This function is called to let the plugin release its resources.</p>
-<p>The default value is: "finalize_crypto".</p>""" ] ]
+<p>The default value is: <code>finalize_crypto</code></p>""" ] ]
             attribute finalizeFunction {
               text
             }?
             & [ a:documentation [ xml:lang="en" """
 <p>This element names the initialization function of the Cryptographic plugin. This function is called after loading the plugin library for instantiation purposes. The Init function must return an object that implements the DDS Security Cryptographic interface.</p>
-<p>The default value is: "init_crypto".</p>""" ] ]
+<p>The default value is: <code>init_crypto</code></p>""" ] ]
             attribute initFunction {
               text
             }?
@@ -1081,7 +1081,7 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==<br>
 <p>This element points to the path of the Cryptographic plugin library.</p>
 <p>It can be either absolute path excluding file extension ( /usr/lib/dds_security_crypto ) or single file without extension ( dds_security_crypto ).</p>
 <p>If a single file is supplied, the is library located by the current working directory, or LD_LIBRARY_PATH for Unix systems, and PATH for Windows systems.</p>
-<p>The default value is: "dds_security_crypto".</p>""" ] ]
+<p>The default value is: <code>dds_security_crypto</code></p>""" ] ]
             attribute path {
               text
             }?
@@ -1093,13 +1093,13 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==<br>
       element SharedMemory {
         [ a:documentation [ xml:lang="en" """
 <p>This element allows for enabling shared memory in Cyclone DDS.</p>
-<p>The default value is: "false".</p>""" ] ]
+<p>The default value is: <code>false</code></p>""" ] ]
         element Enable {
           xsd:boolean
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>Explicitly set the Iceoryx locator used by Cyclone to check whether a pair of processes is attached to the same Iceoryx shared memory.  The default is to use one of the MAC addresses of the machine, which should work well in most cases.</p>
-<p>The default value is: "".</p>""" ] ]
+<p>The default value is: <code>&lt;empty&gt;</code></p>""" ] ]
         element Locator {
           text
         }?
@@ -1113,13 +1113,13 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==<br>
 <li><i>debug</i>: show debug log</li>
 <li><i>verbose</i>: show verbose log</li>
 <p>If you don't want to see any log from shared memory, use <i>off</i> to disable logging.</p>
-<p>The default value is: "info".</p>""" ] ]
+<p>The default value is: <code>info</code></p>""" ] ]
         element LogLevel {
           ("off"|"fatal"|"error"|"warn"|"info"|"debug"|"verbose")
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>Override the Iceoryx service name used by Cyclone.</p>
-<p>The default value is: "DDS_CYCLONE".</p>""" ] ]
+<p>The default value is: <code>DDS_CYCLONE</code></p>""" ] ]
         element Prefix {
           text
         }?
@@ -1130,14 +1130,14 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==<br>
         [ a:documentation [ xml:lang="en" """
 <p>This element specifies the size of one allocation unit in the receive buffer. It must be greater than the maximum packet size by a modest amount (too large packets are dropped). Each allocation is shrunk immediately after processing a message or freed straightaway.</p>
 <p>The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2<sup>10</sup> bytes), MB & MiB (2<sup>20</sup> bytes), GB & GiB (2<sup>30</sup> bytes).</p>
-<p>The default value is: "128 KiB".</p>""" ] ]
+<p>The default value is: <code>128 KiB</code></p>""" ] ]
         element ReceiveBufferChunkSize {
           memsize
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element sets the size of a single receive buffer. Many receive buffers may be needed. The minimum workable size is a little larger than Sizing/ReceiveBufferChunkSize, and the value used is taken as the configured value and the actual minimum workable size.</p>
 <p>The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2<sup>10</sup> bytes), MB & MiB (2<sup>20</sup> bytes), GB & GiB (2<sup>30</sup> bytes).</p>
-<p>The default value is: "1 MiB".</p>""" ] ]
+<p>The default value is: <code>1 MiB</code></p>""" ] ]
         element ReceiveBufferSize {
           memsize
         }?
@@ -1147,39 +1147,39 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==<br>
       element TCP {
         [ a:documentation [ xml:lang="en" """
 <p>Setting this to true means the unicast addresses in SPDP packets will be ignored, and the peer address from the TCP connection will be used instead. This may help work around incorrectly advertised addresses when using TCP.</p>
-<p>The default value is: "false".</p>""" ] ]
+<p>The default value is: <code>false</code></p>""" ] ]
         element AlwaysUsePeeraddrForUnicast {
           xsd:boolean
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element enables the optional TCP transport - deprecated, use General/Transport instead.</p>
-<p>The default value is: "default".</p>""" ] ]
+<p>The default value is: <code>default</code></p>""" ] ]
         element Enable {
           ("false"|"true"|"default")
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element enables the TCP_NODELAY socket option, preventing multiple DDSI messages from being sent in the same TCP request. Setting this option typically optimises latency over throughput.</p>
-<p>The default value is: "true".</p>""" ] ]
+<p>The default value is: <code>true</code></p>""" ] ]
         element NoDelay {
           xsd:boolean
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element specifies the TCP port number on which Cyclone DDS accepts connections. If the port is set, it is used in entity locators, published with DDSI discovery, dynamically allocated if zero, and disabled if -1 or not configured. If disabled other DDSI services will not be able to establish connections with the service, the service can only communicate by establishing connections to other services.</p>
-<p>The default value is: "-1".</p>""" ] ]
+<p>The default value is: <code>-1</code></p>""" ] ]
         element Port {
           xsd:integer
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element specifies the timeout for blocking TCP read operations. If this timeout expires then the connection is closed.</p>
 <p>The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.</p>
-<p>The default value is: "2 s".</p>""" ] ]
+<p>The default value is: <code>2 s</code></p>""" ] ]
         element ReadTimeout {
           duration
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This element specifies the timeout for blocking TCP write operations. If this timeout expires then the connection is closed.</p>
 <p>The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.</p>
-<p>The default value is: "2 s".</p>""" ] ]
+<p>The default value is: <code>2 s</code></p>""" ] ]
         element WriteTimeout {
           duration
         }?
@@ -1202,7 +1202,7 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==<br>
 <li><i>xmit.CHAN</i>: transmit thread for channel CHAN;</li>
 <li><i>dq.CHAN</i>: delivery thread for channel CHAN;</li>
 <li><i>tev.CHAN</i>: timed-event thread for channel CHAN.</li></ul>
-<p>The default value is: "".</p>""" ] ]
+<p>The default value is: <code>&lt;empty&gt;</code></p>""" ] ]
           attribute Name {
             text
           }
@@ -1211,13 +1211,13 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==<br>
           element Scheduling {
             [ a:documentation [ xml:lang="en" """
 <p>This element specifies the thread scheduling class (<i>realtime</i>, <i>timeshare</i> or <i>default</i>). The user may need special privileges from the underlying operating system to be able to assign some of the privileged scheduling classes.</p>
-<p>The default value is: "default".</p>""" ] ]
+<p>The default value is: <code>default</code></p>""" ] ]
             element Class {
               ("realtime"|"timeshare"|"default")
             }?
             & [ a:documentation [ xml:lang="en" """
 <p>This element specifies the thread priority (decimal integer or <i>default</i>). Only priorities supported by the underlying operating system can be assigned to this element. The user may need special privileges from the underlying operating system to be able to assign some of the privileged priorities.</p>
-<p>The default value is: "default".</p>""" ] ]
+<p>The default value is: <code>default</code></p>""" ] ]
             element Priority {
               text
             }?
@@ -1225,7 +1225,7 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==<br>
           & [ a:documentation [ xml:lang="en" """
 <p>This element configures the stack size for this thread. The default value <i>default</i> leaves the stack size at the operating system default.</p>
 <p>The unit must be specified explicitly. Recognised units: B (bytes), kB & KiB (2<sup>10</sup> bytes), MB & MiB (2<sup>20</sup> bytes), GB & GiB (2<sup>30</sup> bytes).</p>
-<p>The default value is: "default".</p>""" ] ]
+<p>The default value is: <code>default</code></p>""" ] ]
           element StackSize {
             memsize
           }?
@@ -1236,7 +1236,7 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==<br>
       element Tracing {
         [ a:documentation [ xml:lang="en" """
 <p>This option specifies whether the output should be appended to an existing log file. The default is to create a new log file each time, which is generally the best option if a detailed log is generated.</p>
-<p>The default value is: "false".</p>""" ] ]
+<p>The default value is: <code>false</code></p>""" ] ]
         element AppendToFile {
           xsd:boolean
         }?
@@ -1259,19 +1259,19 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==<br>
 <li><i>plist</i>: tracing of discovery parameter list interpretation</li></ul>
 <p>In addition, there is the keyword <i>trace</i> that enables all but <i>radmin</i>, <i>topic</i>, <i>plist</i> and <i>whc</i></p>.
 <p>The categorisation of tracing output is incomplete and hence most of the verbosity levels and categories are not of much use in the current release. This is an ongoing process and here we describe the target situation rather than the current situation. Currently, the most useful is <i>trace</i>.</p>
-<p>The default value is: "".</p>""" ] ]
+<p>The default value is: <code>&lt;empty&gt;</code></p>""" ] ]
         element Category {
           xsd:token { pattern = "((fatal|error|warning|info|config|discovery|data|radmin|timing|traffic|topic|tcp|plist|whc|throttle|rhc|content|shm|trace)(,(fatal|error|warning|info|config|discovery|data|radmin|timing|traffic|topic|tcp|plist|whc|throttle|rhc|content|shm|trace))*)|" }
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This option specifies where the logging is printed to. Note that <i>stdout</i> and <i>stderr</i> are treated as special values, representing "standard out" and "standard error" respectively. No file is created unless logging categories are enabled using the Tracing/Verbosity or Tracing/EnabledCategory settings.</p>
-<p>The default value is: "cyclonedds.log".</p>""" ] ]
+<p>The default value is: <code>cyclonedds.log</code></p>""" ] ]
         element OutputFile {
           text
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This option specifies the file to which received and sent packets will be logged in the "pcap" format suitable for analysis using common networking tools, such as WireShark. IP and UDP headers are fictitious, in particular the destination address of received packets. The TTL may be used to distinguish between sent and received packets: it is 255 for sent packets and 128 for received ones. Currently IPv4 only.</p>
-<p>The default value is: "".</p>""" ] ]
+<p>The default value is: <code>&lt;empty&gt;</code></p>""" ] ]
         element PacketCaptureFile {
           text
         }?
@@ -1287,7 +1287,7 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==<br>
 <li><i>finest</i>: <i>finer</i> + trace</li></ul>
 <p>While <i>none</i> prevents any message from being written to a DDSI2 log file.</p>
 <p>The categorisation of tracing output is incomplete and hence most of the verbosity levels and categories are not of much use in the current release. This is an ongoing process and here we describe the target situation rather than the current situation. Currently, the most useful verbosity levels are <i>config</i>, <i>fine</i> and <i>finest</i>.</p>
-<p>The default value is: "none".</p>""" ] ]
+<p>The default value is: <code>none</code></p>""" ] ]
         element Verbosity {
           ("finest"|"finer"|"fine"|"config"|"info"|"warning"|"severe"|"none")
         }?
@@ -1304,9 +1304,9 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==<br>
 # generated from ddsi_cfgelems.h[11913cd398f1cd1b52e06d924718df62a5981beb] 
 # generated from ddsi_config.c[ed9898f72f9dbcfa20ce7706835da091efcea0ca] 
 # generated from _confgen.h[f2d235d5551cbf920a8a2962831dddeabd2856ac] 
-# generated from _confgen.c[1193219ddb4769b90566cf197e73d22fb6f75835] 
+# generated from _confgen.c[ba2e8c0cfd41039421548fdb03bcd2db8f8b172e] 
 # generated from generate_rnc.c[a2ec6e48d33ac14a320c8ec3f320028a737920e0] 
-# generated from generate_md.c[a61b6a9649d18afeca4c73b5784f36989d7994e0] 
-# generated from generate_rst.c[34dcb6b5e2ac2cd15e78497107ce0b6eed6e6e94] 
+# generated from generate_md.c[37efe4fa9caf56e2647bafc9a7f009f72ff5d2e0] 
+# generated from generate_rst.c[32da07860a0043708b47e9f793b63ca05f5106bb] 
 # generated from generate_xsd.c[45064e8869b3c00573057d7c8f02d20f04b40e16] 
 # generated from generate_defconfig.c[eec9ab7b2d053e68500799b693d089e84153a37b] 

--- a/etc/cyclonedds.xsd
+++ b/etc/cyclonedds.xsd
@@ -1980,6 +1980,6 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
 <!--- generated from _confgen.c[ba2e8c0cfd41039421548fdb03bcd2db8f8b172e] -->
 <!--- generated from generate_rnc.c[a2ec6e48d33ac14a320c8ec3f320028a737920e0] -->
 <!--- generated from generate_md.c[37efe4fa9caf56e2647bafc9a7f009f72ff5d2e0] -->
-<!--- generated from generate_rst.c[32da07860a0043708b47e9f793b63ca05f5106bb] -->
+<!--- generated from generate_rst.c[50739f627792ef056e2b4feeb20fda4edfcef079] -->
 <!--- generated from generate_xsd.c[45064e8869b3c00573057d7c8f02d20f04b40e16] -->
 <!--- generated from generate_defconfig.c[eec9ab7b2d053e68500799b693d089e84153a37b] -->

--- a/etc/cyclonedds.xsd
+++ b/etc/cyclonedds.xsd
@@ -35,7 +35,7 @@ CycloneDDS configuration</xs:documentation>
         <xs:annotation>
           <xs:documentation>
 &lt;p&gt;Domain id this configuration applies to, or "any" if it applies to all domain ids.&lt;/p&gt;
-&lt;p&gt;The default value is: "any".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;any&lt;/code&gt;&lt;/p&gt;</xs:documentation>
         </xs:annotation>
       </xs:attribute>
     </xs:complexType>
@@ -58,7 +58,7 @@ CycloneDDS configuration</xs:documentation>
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This option assumes ParticipantMessageData endpoints required by the liveliness protocol are present in RTI participants even when not properly advertised by the participant discovery protocol.&lt;/p&gt;
-&lt;p&gt;The default value is: "false".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;false&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="ExplicitlyPublishQosSetToDefault" type="xs:boolean">
@@ -66,7 +66,7 @@ CycloneDDS configuration</xs:documentation>
       <xs:documentation>
 &lt;p&gt;This element specifies whether QoS settings set to default values are explicitly published in the discovery protocol. Implementations are to use the default value for QoS settings not published, which allows a significant reduction of the amount of data that needs to be exchanged for the discovery protocol, but this requires all implementations to adhere to the default values specified by the specifications.&lt;/p&gt;
 &lt;p&gt;When interoperability is required with an implementation that does not follow the specifications in this regard, setting this option to true will help.&lt;/p&gt;
-&lt;p&gt;The default value is: "false".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;false&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="ManySocketsMode">
@@ -74,7 +74,7 @@ CycloneDDS configuration</xs:documentation>
       <xs:documentation>
 &lt;p&gt;This option specifies whether a network socket will be created for each domain participant on a host. The specification seems to assume that each participant has a unique address, and setting this option will ensure this to be the case. This is not the default.&lt;/p&gt;
 &lt;p&gt;Disabling it slightly improves performance and reduces network traffic somewhat. It also causes the set of port numbers needed by Cyclone DDS to become predictable, which may be useful for firewall and NAT configuration.&lt;/p&gt;
-&lt;p&gt;The default value is: "single".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;single&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
     <xs:simpleType>
       <xs:restriction base="xs:token">
@@ -93,7 +93,7 @@ CycloneDDS configuration</xs:documentation>
 &lt;ul&gt;&lt;li&gt;&lt;i&gt;pedantic&lt;/i&gt;: very strictly conform to the specification, ultimately for compliance testing, but currently of little value because it adheres even to what will most likely turn out to be editing errors in the DDSI standard. Arguably, as long as no errata have been published, the current text is in effect, and that is what pedantic currently does.&lt;/li&gt;
 &lt;li&gt;&lt;i&gt;strict&lt;/i&gt;: a relatively less strict view of the standard than does pedantic: it follows the established behaviour where the standard is obviously in error.&lt;/li&gt;
 &lt;li&gt;&lt;i&gt;lax&lt;/i&gt;: attempt to provide the smoothest possible interoperability, anticipating future revisions of elements in the standard in areas that other implementations do not adhere to, even though there is no good reason not to.&lt;/li&gt;&lt;/ul&gt;
-&lt;p&gt;The default value is: "lax".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;lax&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
     <xs:simpleType>
       <xs:restriction base="xs:token">
@@ -130,28 +130,28 @@ CycloneDDS configuration</xs:documentation>
       <xs:documentation>
 &lt;p&gt;This setting controls for how long endpoints discovered via a Cloud discovery service will survive after the discovery service disappears, allowing reconnection without loss of data when the discovery service restarts (or another instance takes over).&lt;/p&gt;
 &lt;p&gt;Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.&lt;/p&gt;
-&lt;p&gt;The default value is: "30 s".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;30 s&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="DefaultMulticastAddress" type="xs:string">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element specifies the default multicast address for all traffic other than participant discovery packets. It defaults to Discovery/SPDPMulticastAddress.&lt;/p&gt;
-&lt;p&gt;The default value is: "auto".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;auto&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="EnableTopicDiscoveryEndpoints" type="xs:boolean">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element controls whether the built-in endpoints for topic discovery are created and used to exchange topic discovery information.&lt;/p&gt;
-&lt;p&gt;The default value is: "false".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;false&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="ExternalDomainId" type="xs:string">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;An override for the domain id is used to discovery and determine the port number mapping. This allows the creating of multiple domains in a single process while making them appear as a single domain on the network. The value "default" disables the override.&lt;/p&gt;
-&lt;p&gt;The default value is: "default".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;default&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="LeaseDuration" type="config:duration">
@@ -159,14 +159,14 @@ CycloneDDS configuration</xs:documentation>
       <xs:documentation>
 &lt;p&gt;This setting controls the default participant lease duration.&lt;p&gt;
 &lt;p&gt;The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.&lt;/p&gt;
-&lt;p&gt;The default value is: "10 s".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;10 s&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="MaxAutoParticipantIndex" type="xs:integer">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element specifies the maximum DDSI participant index selected by this instance of the Cyclone DDS service if the Discovery/ParticipantIndex is "auto".&lt;/p&gt;
-&lt;p&gt;The default value is: "9".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;9&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="ParticipantIndex" type="xs:string">
@@ -176,7 +176,7 @@ CycloneDDS configuration</xs:documentation>
 &lt;ul&gt;&lt;li&gt;&lt;i&gt;auto&lt;/i&gt;: which will attempt to automatically determine an available participant index (see also Discovery/MaxAutoParticipantIndex), or&lt;/li&gt;
 &lt;li&gt;a non-negative integer less than 120, or&lt;/li&gt;
 &lt;li&gt;&lt;i&gt;none&lt;/i&gt;:, which causes it to use arbitrary port numbers for unicast sockets which entirely removes the constraints on the participant index but makes unicast discovery impossible.&lt;/li&gt;&lt;/ul&gt;
-&lt;p&gt;The default value is: "none".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;none&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="Peers">
@@ -200,7 +200,7 @@ CycloneDDS configuration</xs:documentation>
         <xs:annotation>
           <xs:documentation>
 &lt;p&gt;This element specifies an IP address to which discovery packets must be sent, in addition to the default multicast address (see also General/AllowMulticast). Both hostnames and a numerical IP address are accepted; the hostname or IP address may be suffixed with :PORT to explicitly set the port to which it must be sent. Multiple Peers may be specified.&lt;/p&gt;
-&lt;p&gt;The default value is: "".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;&amp;lt;empty&amp;gt;&lt;/code&gt;&lt;/p&gt;</xs:documentation>
         </xs:annotation>
       </xs:attribute>
     </xs:complexType>
@@ -226,49 +226,49 @@ CycloneDDS configuration</xs:documentation>
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element specifies the base port number (refer to the DDSI 2.1 specification, section 9.6.1, constant PB).&lt;/p&gt;
-&lt;p&gt;The default value is: "7400".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;7400&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="DomainGain" type="xs:integer">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element specifies the domain gain, relating domain ids to sets of port numbers (refer to the DDSI 2.1 specification, section 9.6.1, constant DG).&lt;/p&gt;
-&lt;p&gt;The default value is: "250".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;250&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="MulticastDataOffset" type="xs:integer">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element specifies the port number for multicast data traffic (refer to the DDSI 2.1 specification, section 9.6.1, constant d2).&lt;/p&gt;
-&lt;p&gt;The default value is: "1".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;1&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="MulticastMetaOffset" type="xs:integer">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element specifies the port number for multicast meta traffic (refer to the DDSI 2.1 specification, section 9.6.1, constant d0).&lt;/p&gt;
-&lt;p&gt;The default value is: "0".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;0&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="ParticipantGain" type="xs:integer">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element specifies the participant gain, relating p0, participant index to sets of port numbers (refer to the DDSI 2.1 specification, section 9.6.1, constant PG).&lt;/p&gt;
-&lt;p&gt;The default value is: "2".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;2&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="UnicastDataOffset" type="xs:integer">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element specifies the port number for unicast data traffic (refer to the DDSI 2.1 specification, section 9.6.1, constant d3).&lt;/p&gt;
-&lt;p&gt;The default value is: "11".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;11&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="UnicastMetaOffset" type="xs:integer">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element specifies the port number for unicast meta traffic (refer to the DDSI 2.1 specification, section 9.6.1, constant d1).&lt;/p&gt;
-&lt;p&gt;The default value is: "10".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;10&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="SPDPInterval" type="config:duration">
@@ -276,21 +276,21 @@ CycloneDDS configuration</xs:documentation>
       <xs:documentation>
 &lt;p&gt;This element specifies the interval between spontaneous transmissions of participant discovery packets.&lt;/p&gt;
 &lt;p&gt;The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.&lt;/p&gt;
-&lt;p&gt;The default value is: "30 s".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;30 s&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="SPDPMulticastAddress" type="xs:string">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element specifies the multicast address used as the destination for the participant discovery packets. In IPv4 mode the default is the (standardised) 239.255.0.1, in IPv6 mode it becomes ff02::ffff:239.255.0.1, which is a non-standardised link-local multicast address.&lt;/p&gt;
-&lt;p&gt;The default value is: "239.255.0.1".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;239.255.0.1&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="Tag" type="xs:string">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;String extension for domain id that remote participants must match to be discovered.&lt;/p&gt;
-&lt;p&gt;The default value is: "".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;&amp;lt;empty&amp;gt;&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="General">
@@ -330,7 +330,7 @@ CycloneDDS configuration</xs:documentation>
 &lt;/ul&gt;
 &lt;p&gt;When set to "false" all multicasting is disabled. The default, "true" enables the full use of multicasts. Listening for multicasts can be controlled by General/MulticastRecvNetworkInterfaceAddresses.&lt;/p&gt;
 &lt;p&gt;"default" maps on spdp if the network is a WiFi network, on true if it is a wired network&lt;/p&gt;
-&lt;p&gt;The default value is: "default".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;default&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
     <xs:simpleType>
       <xs:restriction base="xs:token">
@@ -342,21 +342,21 @@ CycloneDDS configuration</xs:documentation>
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element allows setting the SO_DONTROUTE option for outgoing packets to bypass the local routing tables. This is generally useful only when the routing tables cannot be trusted, which is highly unusual.&lt;/p&gt;
-&lt;p&gt;The default value is: "false".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;false&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="EnableMulticastLoopback" type="xs:boolean">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element specifies whether Cyclone DDS allows IP multicast packets to be visible to all DDSI participants in the same node, including itself. It must be "true" for intra-node multicast communications. However, if a node runs only a single Cyclone DDS service and does not host any other DDSI-capable programs, it should be set to "false" for improved performance.&lt;/p&gt;
-&lt;p&gt;The default value is: "true".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;true&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="EntityAutoNaming">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element specifies the entity autonaming mode. By default set to 'empty' which means no name will be set (but you can still use dds_qset_entity_name). When set to 'fancy' participants, publishers, subscribers, writers, and readers will get randomly generated names. An autonamed entity will share a 3-letter prefix with their parent entity.&lt;/p&gt;
-&lt;p&gt;The default value is: "empty".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;empty&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
     <xs:complexType>
       <xs:simpleContent>
@@ -371,7 +371,7 @@ CycloneDDS configuration</xs:documentation>
             <xs:annotation>
               <xs:documentation>
 &lt;p&gt;Provide an initial seed for the entity naming. Your string will be hashed to provide the random state. When provided, the same sequence of names is generated every run. Creating your entities in the same order will ensure they are the same between runs. If you run multiple nodes, set this via environment variable to ensure every node generates unique names. A random starting seed is chosen when left empty, (the default). &lt;/p&gt;
-&lt;p&gt;The default value is: "".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;&amp;lt;empty&amp;gt;&lt;/code&gt;&lt;/p&gt;</xs:documentation>
             </xs:annotation>
           </xs:attribute>
         </xs:restriction>
@@ -382,14 +382,14 @@ CycloneDDS configuration</xs:documentation>
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element allows explicitly overruling the network address Cyclone DDS advertises in the discovery protocol, which by default is the address of the preferred network interface (General/NetworkInterfaceAddress), to allow Cyclone DDS to communicate across a Network Address Translation (NAT) device.&lt;/p&gt;
-&lt;p&gt;The default value is: "auto".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;auto&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="ExternalNetworkMask" type="xs:string">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element specifies the network mask of the external network address. This element is relevant only when an external network address (General/ExternalNetworkAddress) is explicitly configured. In this case locators received via the discovery protocol that are within the same external subnet (as defined by this mask) will be translated to an internal address by replacing the network portion of the external address with the corresponding portion of the preferred network interface address. This option is IPv4-only.&lt;/p&gt;
-&lt;p&gt;The default value is: "0.0.0.0".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;0.0.0.0&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="FragmentSize" type="config:memsize">
@@ -397,7 +397,7 @@ CycloneDDS configuration</xs:documentation>
       <xs:documentation>
 &lt;p&gt;This element specifies the size of DDSI sample fragments generated by Cyclone DDS. Samples larger than FragmentSize are fragmented into fragments of FragmentSize bytes each, except the last one, which may be smaller. The DDSI spec mandates a minimum fragment size of 1025 bytes, but Cyclone DDS will do whatever size is requested, accepting fragments of which the size is at least the minimum of 1025 and FragmentSize.&lt;/p&gt;
 &lt;p&gt;The unit must be specified explicitly. Recognised units: B (bytes), kB &amp; KiB (2&lt;sup&gt;10&lt;/sup&gt; bytes), MB &amp; MiB (2&lt;sup&gt;20&lt;/sup&gt; bytes), GB &amp; GiB (2&lt;sup&gt;30&lt;/sup&gt; bytes).&lt;/p&gt;
-&lt;p&gt;The default value is: "1344 B".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;1344 B&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="Interfaces">
@@ -421,49 +421,49 @@ CycloneDDS configuration</xs:documentation>
         <xs:annotation>
           <xs:documentation>
 &lt;p&gt;This attribute specifies the address of the interface. With ipv4 allows  matching on the network part if the host part is set to zero. &lt;/p&gt;
-&lt;p&gt;The default value is: "".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;&amp;lt;empty&amp;gt;&lt;/code&gt;&lt;/p&gt;</xs:documentation>
         </xs:annotation>
       </xs:attribute>
       <xs:attribute name="autodetermine">
         <xs:annotation>
           <xs:documentation>
 &lt;p&gt;If set to "true" an interface is automatically selected. Specifying a name or an address when automatic is set is considered an error.&lt;/p&gt;
-&lt;p&gt;The default value is: "false".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;false&lt;/code&gt;&lt;/p&gt;</xs:documentation>
         </xs:annotation>
       </xs:attribute>
       <xs:attribute name="multicast">
         <xs:annotation>
           <xs:documentation>
 &lt;p&gt;This attribute specifies whether the interface should use multicast. On its default setting, 'default', it will use the value as return by the operating system. If set to 'true', the interface will be assumed to be multicast capable even when the interface flags returned by the operating system state it is not (this provides a workaround for some platforms). If set to 'false', the interface will never be used for multicast.
-&lt;p&gt;The default value is: "default".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;default&lt;/code&gt;&lt;/p&gt;</xs:documentation>
         </xs:annotation>
       </xs:attribute>
       <xs:attribute name="name">
         <xs:annotation>
           <xs:documentation>
 &lt;p&gt;This attribute specifies the name of the interface. &lt;/p&gt;
-&lt;p&gt;The default value is: "".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;&amp;lt;empty&amp;gt;&lt;/code&gt;&lt;/p&gt;</xs:documentation>
         </xs:annotation>
       </xs:attribute>
       <xs:attribute name="prefer_multicast" type="xs:boolean">
         <xs:annotation>
           <xs:documentation>
 &lt;p&gt;When false (default), Cyclone DDS uses unicast for data whenever a single unicast suffices. Setting this to true makes it prefer multicasting data, falling back to unicast only when no multicast is available.&lt;/p&gt;
-&lt;p&gt;The default value is: "false".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;false&lt;/code&gt;&lt;/p&gt;</xs:documentation>
         </xs:annotation>
       </xs:attribute>
       <xs:attribute name="presence_required" type="xs:boolean">
         <xs:annotation>
           <xs:documentation>
 &lt;p&gt;By default, all specified network interfaces must be present; if they are missing Cyclone will not start. By explicitly setting this setting for an interface, you can instruct Cyclone to ignore that interface if it is not present.&lt;/p&gt;
-&lt;p&gt;The default value is: "true".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;true&lt;/code&gt;&lt;/p&gt;</xs:documentation>
         </xs:annotation>
       </xs:attribute>
       <xs:attribute name="priority">
         <xs:annotation>
           <xs:documentation>
 &lt;p&gt;This attribute specifies the interface priority (decimal integer or &lt;i&gt;default&lt;/i&gt;). The default value for loopback interfaces is 2, for all other interfaces it is 0.&lt;/p&gt;
-&lt;p&gt;The default value is: "default".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;default&lt;/code&gt;&lt;/p&gt;</xs:documentation>
         </xs:annotation>
       </xs:attribute>
     </xs:complexType>
@@ -474,7 +474,7 @@ CycloneDDS configuration</xs:documentation>
 &lt;p&gt;This element specifies the maximum size of the UDP payload that Cyclone DDS will generate. Cyclone DDS will try to maintain this limit within the bounds of the DDSI specification, which means that in some cases (especially for very low values of MaxMessageSize) larger payloads may sporadically be observed (currently up to 1192 B).&lt;/p&gt;
 &lt;p&gt;On some networks it may be necessary to set this item to keep the packetsize below the MTU to prevent IP fragmentation.&lt;/p&gt;
 &lt;p&gt;The unit must be specified explicitly. Recognised units: B (bytes), kB &amp; KiB (2&lt;sup&gt;10&lt;/sup&gt; bytes), MB &amp; MiB (2&lt;sup&gt;20&lt;/sup&gt; bytes), GB &amp; GiB (2&lt;sup&gt;30&lt;/sup&gt; bytes).&lt;/p&gt;
-&lt;p&gt;The default value is: "14720 B".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;14720 B&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="MaxRexmitMessageSize" type="config:memsize">
@@ -483,7 +483,7 @@ CycloneDDS configuration</xs:documentation>
 &lt;p&gt;This element specifies the maximum size of the UDP payload that Cyclone DDS will generate for a retransmit. Cyclone DDS will try to maintain this limit within the bounds of the DDSI specification, which means that in some cases (especially for very low values) larger payloads may sporadically be observed (currently up to 1192 B).&lt;/p&gt;
 &lt;p&gt;On some networks it may be necessary to set this item to keep the packetsize below the MTU to prevent IP fragmentation.&lt;/p&gt;
 &lt;p&gt;The unit must be specified explicitly. Recognised units: B (bytes), kB &amp; KiB (2&lt;sup&gt;10&lt;/sup&gt; bytes), MB &amp; MiB (2&lt;sup&gt;20&lt;/sup&gt; bytes), GB &amp; GiB (2&lt;sup&gt;30&lt;/sup&gt; bytes).&lt;/p&gt;
-&lt;p&gt;The default value is: "1456 B".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;1456 B&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="MulticastRecvNetworkInterfaceAddresses" type="xs:string">
@@ -498,28 +498,28 @@ CycloneDDS configuration</xs:documentation>
 &lt;li&gt;a comma-separated list of network addresses: configures Cyclone DDS to listen for multicasts on all listed addresses.&lt;/li&gt;
 &lt;/ul&gt;
 &lt;p&gt;If Cyclone DDS is in IPv6 mode and the address of the preferred network interface is a link-local address, "all" is treated as a synonym for "preferred" and a comma-separated list is treated as "preferred" if it contains the preferred interface and as "none" if not.&lt;/p&gt;
-&lt;p&gt;The default value is: "preferred".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;preferred&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="MulticastTimeToLive" type="xs:integer">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element specifies the time-to-live setting for outgoing multicast packets.&lt;/p&gt;
-&lt;p&gt;The default value is: "32".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;32&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="RedundantNetworking" type="xs:boolean">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;When enabled, use selected network interfaces in parallel for redundancy.&lt;/p&gt;
-&lt;p&gt;The default value is: "false".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;false&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="Transport">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element allows selecting the transport to be used (udp, udp6, tcp, tcp6, raweth)&lt;/p&gt;
-&lt;p&gt;The default value is: "default".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;default&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
     <xs:simpleType>
       <xs:restriction base="xs:token">
@@ -536,7 +536,7 @@ CycloneDDS configuration</xs:documentation>
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;Deprecated (use Transport instead)&lt;/p&gt;
-&lt;p&gt;The default value is: "default".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;default&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
     <xs:simpleType>
       <xs:restriction base="xs:token">
@@ -604,7 +604,7 @@ CycloneDDS configuration</xs:documentation>
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;Proxy readers that are assumed to still be retrieving historical data get this many samples retransmitted when they NACK something, even if some of these samples have sequence numbers outside the set covered by the NACK.&lt;/p&gt;
-&lt;p&gt;The default value is: "0".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;0&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="AckDelay" type="config:duration">
@@ -612,7 +612,7 @@ CycloneDDS configuration</xs:documentation>
       <xs:documentation>
 &lt;p&gt;This setting controls the delay between sending identical acknowledgements.&lt;/p&gt;
 &lt;p&gt;The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.&lt;/p&gt;
-&lt;p&gt;The default value is: "10 ms".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;10 ms&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="AutoReschedNackDelay" type="config:duration_inf">
@@ -620,7 +620,7 @@ CycloneDDS configuration</xs:documentation>
       <xs:documentation>
 &lt;p&gt;This setting controls the interval with which a reader will continue NACK'ing missing samples in the absence of a response from the writer, as a protection mechanism against writers incorrectly stopping the sending of HEARTBEAT messages.&lt;/p&gt;
 &lt;p&gt;Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.&lt;/p&gt;
-&lt;p&gt;The default value is: "3 s".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;3 s&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="BuiltinEndpointSet">
@@ -631,7 +631,7 @@ CycloneDDS configuration</xs:documentation>
 &lt;li&gt;&lt;i&gt;writers&lt;/i&gt;: all participants have the writers, but just one has the readers;&lt;/li&gt;
 &lt;li&gt;&lt;i&gt;minimal&lt;/i&gt;: only one participant has built-in endpoints.&lt;/li&gt;&lt;/ul&gt;
 &lt;p&gt;The default is &lt;i&gt;writers&lt;/i&gt;, as this is thought to be compliant and reasonably efficient. &lt;i&gt;Minimal&lt;/i&gt; may or may not be compliant but is most efficient, and &lt;i&gt;full&lt;/i&gt; is inefficient but certain to be compliant.&lt;/p&gt;
-&lt;p&gt;The default value is: "writers".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;writers&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
     <xs:simpleType>
       <xs:restriction base="xs:token">
@@ -658,7 +658,7 @@ CycloneDDS configuration</xs:documentation>
       <xs:documentation>
 &lt;p&gt;This element specifies how much more than the (presumed or discovered) receive buffer size may be sent when transmitting a sample for the first time, expressed as a percentage; the remainder will then be handled via retransmits. Usually, the receivers can keep up with the transmitter, at least on average, so generally it is better to hope for the best and recover. Besides, the retransmits will be unicast, and so any multicast advantage will be lost as well.&lt;/p&gt;
 &lt;p&gt;The unit must be specified explicitly. Recognised units: B (bytes), kB &amp; KiB (2&lt;sup&gt;10&lt;/sup&gt; bytes), MB &amp; MiB (2&lt;sup&gt;20&lt;/sup&gt; bytes), GB &amp; GiB (2&lt;sup&gt;30&lt;/sup&gt; bytes).&lt;/p&gt;
-&lt;p&gt;The default value is: "4294967295".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;4294967295&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="MaxRexmit" type="config:memsize">
@@ -666,7 +666,7 @@ CycloneDDS configuration</xs:documentation>
       <xs:documentation>
 &lt;p&gt;This element specifies the amount of data to be retransmitted in response to one NACK.&lt;/p&gt;
 &lt;p&gt;The unit must be specified explicitly. Recognised units: B (bytes), kB &amp; KiB (2&lt;sup&gt;10&lt;/sup&gt; bytes), MB &amp; MiB (2&lt;sup&gt;20&lt;/sup&gt; bytes), GB &amp; GiB (2&lt;sup&gt;30&lt;/sup&gt; bytes).&lt;/p&gt;
-&lt;p&gt;The default value is: "1 MiB".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;1 MiB&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="ControlTopic">
@@ -680,28 +680,28 @@ CycloneDDS configuration</xs:documentation>
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element sets the maximum number of extra threads for an experimental, undocumented, and unsupported direct mode.&lt;/p&gt;
-&lt;p&gt;The default value is: "1".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;1&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="DefragReliableMaxSamples" type="xs:integer">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element sets the maximum number of samples that can be defragmented simultaneously for a reliable writer. This has to be large enough to handle retransmissions of historical data in addition to new samples.&lt;/p&gt;
-&lt;p&gt;The default value is: "16".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;16&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="DefragUnreliableMaxSamples" type="xs:integer">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element sets the maximum number of samples that can be defragmented simultaneously for best-effort writers.&lt;/p&gt;
-&lt;p&gt;The default value is: "4".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;4&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="DeliveryQueueMaxSamples" type="xs:integer">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element controls the maximum size of a delivery queue, expressed in samples. Once a delivery queue is full, incoming samples destined for that queue are dropped until space becomes available again.&lt;/p&gt;
-&lt;p&gt;The default value is: "256".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;256&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="EnableExpensiveChecks">
@@ -713,7 +713,7 @@ CycloneDDS configuration</xs:documentation>
 &lt;li&gt;&lt;i&gt;rhc&lt;/i&gt;: reader history cache checking&lt;/li&gt;
 &lt;li&gt;&lt;i&gt;xevent&lt;/i&gt;: xevent checking&lt;/li&gt;
 &lt;p&gt;In addition, there is the keyword &lt;i&gt;all&lt;/i&gt; that enables all checks.&lt;/p&gt;
-&lt;p&gt;The default value is: "".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;&amp;lt;empty&amp;gt;&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
     <xs:simpleType>
       <xs:restriction base="xs:token">
@@ -725,7 +725,7 @@ CycloneDDS configuration</xs:documentation>
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;When true, include keyhashes in outgoing data for topics with keys.&lt;/p&gt;
-&lt;p&gt;The default value is: "false".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;false&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="HeartbeatInterval">
@@ -733,7 +733,7 @@ CycloneDDS configuration</xs:documentation>
       <xs:documentation>
 &lt;p&gt;This element allows configuring the base interval for sending writer heartbeats and the bounds within which it can vary.&lt;/p&gt;
 &lt;p&gt;Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.&lt;/p&gt;
-&lt;p&gt;The default value is: "100 ms".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;100 ms&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
     <xs:complexType>
       <xs:simpleContent>
@@ -743,7 +743,7 @@ CycloneDDS configuration</xs:documentation>
               <xs:documentation>
 &lt;p&gt;This attribute sets the maximum interval for periodic heartbeats.&lt;/p&gt;
 &lt;p&gt;Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.&lt;/p&gt;
-&lt;p&gt;The default value is: "8 s".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;8 s&lt;/code&gt;&lt;/p&gt;</xs:documentation>
             </xs:annotation>
           </xs:attribute>
           <xs:attribute name="min" type="config:duration_inf">
@@ -751,7 +751,7 @@ CycloneDDS configuration</xs:documentation>
               <xs:documentation>
 &lt;p&gt;This attribute sets the minimum interval that must have passed since the most recent heartbeat from a writer, before another asynchronous (not directly related to writing) will be sent.&lt;/p&gt;
 &lt;p&gt;Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.&lt;/p&gt;
-&lt;p&gt;The default value is: "5 ms".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;5 ms&lt;/code&gt;&lt;/p&gt;</xs:documentation>
             </xs:annotation>
           </xs:attribute>
           <xs:attribute name="minsched" type="config:duration_inf">
@@ -759,7 +759,7 @@ CycloneDDS configuration</xs:documentation>
               <xs:documentation>
 &lt;p&gt;This attribute sets the minimum interval for periodic heartbeats. Other events may still cause heartbeats to go out.&lt;/p&gt;
 &lt;p&gt;Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.&lt;/p&gt;
-&lt;p&gt;The default value is: "20 ms".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;20 ms&lt;/code&gt;&lt;/p&gt;</xs:documentation>
             </xs:annotation>
           </xs:attribute>
         </xs:extension>
@@ -770,14 +770,14 @@ CycloneDDS configuration</xs:documentation>
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;Ack a sample only when it has been delivered, instead of when committed to delivering it.&lt;/p&gt;
-&lt;p&gt;The default value is: "false".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;false&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="LivelinessMonitoring">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element controls whether or not implementation should internally monitor its own liveliness. If liveliness monitoring is enabled, stack traces can be dumped automatically when some thread appears to have stopped making progress.&lt;/p&gt;
-&lt;p&gt;The default value is: "false".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;false&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
     <xs:complexType>
       <xs:simpleContent>
@@ -787,14 +787,14 @@ CycloneDDS configuration</xs:documentation>
               <xs:documentation>
 &lt;p&gt;This element controls the interval to check whether threads have been making progress.&lt;/p&gt;
 &lt;p&gt;The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.&lt;/p&gt;
-&lt;p&gt;The default value is: "1s".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;1s&lt;/code&gt;&lt;/p&gt;</xs:documentation>
             </xs:annotation>
           </xs:attribute>
           <xs:attribute name="StackTraces" type="xs:boolean">
             <xs:annotation>
               <xs:documentation>
 &lt;p&gt;This element controls whether or not to write stack traces to the DDSI2 trace when a thread fails to make progress (on select platforms only).&lt;/p&gt;
-&lt;p&gt;The default value is: "true".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;true&lt;/code&gt;&lt;/p&gt;</xs:documentation>
             </xs:annotation>
           </xs:attribute>
         </xs:extension>
@@ -805,7 +805,7 @@ CycloneDDS configuration</xs:documentation>
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This elements configures the maximum number of DCPS domain participants this Cyclone DDS instance is willing to service. 0 is unlimited.&lt;/p&gt;
-&lt;p&gt;The default value is: "0".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;0&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="MaxQueuedRexmitBytes" type="config:memsize">
@@ -813,14 +813,14 @@ CycloneDDS configuration</xs:documentation>
       <xs:documentation>
 &lt;p&gt;This setting limits the maximum number of bytes queued for retransmission. The default value of 0 is unlimited unless an AuxiliaryBandwidthLimit has been set, in which case it becomes NackDelay * AuxiliaryBandwidthLimit. It must be large enough to contain the largest sample that may need to be retransmitted.&lt;/p&gt;
 &lt;p&gt;The unit must be specified explicitly. Recognised units: B (bytes), kB &amp; KiB (2&lt;sup&gt;10&lt;/sup&gt; bytes), MB &amp; MiB (2&lt;sup&gt;20&lt;/sup&gt; bytes), GB &amp; GiB (2&lt;sup&gt;30&lt;/sup&gt; bytes).&lt;/p&gt;
-&lt;p&gt;The default value is: "512 kB".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;512 kB&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="MaxQueuedRexmitMessages" type="xs:integer">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This setting limits the maximum number of samples queued for retransmission.&lt;/p&gt;
-&lt;p&gt;The default value is: "200".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;200&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="MaxSampleSize" type="config:memsize">
@@ -828,28 +828,28 @@ CycloneDDS configuration</xs:documentation>
       <xs:documentation>
 &lt;p&gt;This setting controls the maximum (CDR) serialised size of samples that Cyclone DDS will forward in either direction. Samples larger than this are discarded with a warning.&lt;/p&gt;
 &lt;p&gt;The unit must be specified explicitly. Recognised units: B (bytes), kB &amp; KiB (2&lt;sup&gt;10&lt;/sup&gt; bytes), MB &amp; MiB (2&lt;sup&gt;20&lt;/sup&gt; bytes), GB &amp; GiB (2&lt;sup&gt;30&lt;/sup&gt; bytes).&lt;/p&gt;
-&lt;p&gt;The default value is: "2147483647 B".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;2147483647 B&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="MeasureHbToAckLatency" type="xs:boolean">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element enables heartbeat-to-ack latency among Cyclone DDS services by prepending timestamps to Heartbeat and AckNack messages and calculating round trip times. This is non-standard behaviour. The measured latencies are quite noisy and are currently not used anywhere.&lt;/p&gt;
-&lt;p&gt;The default value is: "false".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;false&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="MonitorPort" type="xs:integer">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element allows configuring a service that dumps a text description of part the internal state to TCP clients. By default (-1), this is disabled; specifying 0 means a kernel-allocated port is used; a positive number is used as the TCP port number.&lt;/p&gt;
-&lt;p&gt;The default value is: "-1".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;-1&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="MultipleReceiveThreads">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element controls whether all traffic is handled by a single receive thread (false) or whether multiple receive threads may be used to improve latency (true). By default it is disabled on Windows because it appears that one cannot count on being able to send packets to oneself, which is necessary to stop the thread during shutdown. Currently multiple receive threads are only used for connectionless transport (e.g., UDP) and ManySocketsMode not set to single (the default).&lt;/p&gt;
-&lt;p&gt;The default value is: "default".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;default&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
     <xs:complexType>
       <xs:simpleContent>
@@ -865,7 +865,7 @@ CycloneDDS configuration</xs:documentation>
             <xs:annotation>
               <xs:documentation>
 &lt;p&gt;Receive threads dedicated to a single socket can only be triggered for termination by sending a packet. Reception of any packet will do, so termination failure due to packet loss is exceedingly unlikely, but to eliminate all risks, it will retry as many times as specified by this attribute before aborting.&lt;/p&gt;
-&lt;p&gt;The default value is: "4294967295".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;4294967295&lt;/code&gt;&lt;/p&gt;</xs:documentation>
             </xs:annotation>
           </xs:attribute>
         </xs:restriction>
@@ -877,7 +877,7 @@ CycloneDDS configuration</xs:documentation>
       <xs:documentation>
 &lt;p&gt;This setting controls the delay between receipt of a HEARTBEAT indicating missing samples and a NACK (ignored when the HEARTBEAT requires an answer). However, no NACK is sent if a NACK had been scheduled already for a response earlier than the delay requests: then that NACK will incorporate the latest information.&lt;/p&gt;
 &lt;p&gt;The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.&lt;/p&gt;
-&lt;p&gt;The default value is: "100 ms".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;100 ms&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="PreEmptiveAckDelay" type="config:duration">
@@ -885,21 +885,21 @@ CycloneDDS configuration</xs:documentation>
       <xs:documentation>
 &lt;p&gt;This setting controls the delay between the discovering a remote writer and sending a pre-emptive AckNack to discover the available range of data.&lt;/p&gt;
 &lt;p&gt;The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.&lt;/p&gt;
-&lt;p&gt;The default value is: "10 ms".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;10 ms&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="PrimaryReorderMaxSamples" type="xs:integer">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element sets the maximum size in samples of a primary re-order administration. Each proxy writer has one primary re-order administration to buffer the packet flow in case some packets arrive out of order. Old samples are forwarded to secondary re-order administrations associated with readers needing historical data.&lt;/p&gt;
-&lt;p&gt;The default value is: "128".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;128&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="PrioritizeRetransmit" type="xs:boolean">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element controls whether retransmits are prioritized over new data, speeding up recovery.&lt;/p&gt;
-&lt;p&gt;The default value is: "true".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;true&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="RediscoveryBlacklistDuration">
@@ -907,7 +907,7 @@ CycloneDDS configuration</xs:documentation>
       <xs:documentation>
 &lt;p&gt;This element controls for how long a remote participant that was previously deleted will remain on a blacklist to prevent rediscovery, giving the software on a node time to perform any cleanup actions it needs to do. To some extent this delay is required internally by Cyclone DDS, but in the default configuration with the 'enforce' attribute set to false, Cyclone DDS will reallow rediscovery as soon as it has cleared its internal administration. Setting it to too small a value may result in the entry being pruned from the blacklist before Cyclone DDS is ready, it is therefore recommended to set it to at least several seconds.&lt;/p&gt;
 &lt;p&gt;Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.&lt;/p&gt;
-&lt;p&gt;The default value is: "0s".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;0s&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
     <xs:complexType>
       <xs:simpleContent>
@@ -916,7 +916,7 @@ CycloneDDS configuration</xs:documentation>
             <xs:annotation>
               <xs:documentation>
 &lt;p&gt;This attribute controls whether the configured time during which recently deleted participants will not be rediscovered (i.e., "black listed") is enforced and following complete removal of the participant in Cyclone DDS, or whether it can be rediscovered earlier provided all traces of that participant have been removed already.&lt;/p&gt;
-&lt;p&gt;The default value is: "false".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;false&lt;/code&gt;&lt;/p&gt;</xs:documentation>
             </xs:annotation>
           </xs:attribute>
         </xs:extension>
@@ -931,7 +931,7 @@ CycloneDDS configuration</xs:documentation>
 &lt;li&gt;&lt;i&gt;adaptive&lt;/i&gt;: attempt to combine retransmits needed for reliability, but send historical (transient-local) data to the requesting reader only;&lt;/li&gt;
 &lt;li&gt;&lt;i&gt;always&lt;/i&gt;: do not distinguish between different causes, always try to merge.&lt;/li&gt;&lt;/ul&gt;
 &lt;p&gt;The default is &lt;i&gt;never&lt;/i&gt;. See also Internal/RetransmitMergingPeriod.&lt;/p&gt;
-&lt;p&gt;The default value is: "never".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;never&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
     <xs:simpleType>
       <xs:restriction base="xs:token">
@@ -947,14 +947,14 @@ CycloneDDS configuration</xs:documentation>
 &lt;p&gt;This setting determines the time window size in which a NACK of some sample is ignored because a retransmit of that sample has been multicasted too recently. This setting has no effect on unicasted retransmits.&lt;/p&gt;
 &lt;p&gt;See also Internal/RetransmitMerging.&lt;/p&gt;
 &lt;p&gt;The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.&lt;/p&gt;
-&lt;p&gt;The default value is: "5 ms".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;5 ms&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="RetryOnRejectBestEffort" type="xs:boolean">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;Whether or not to locally retry pushing a received best-effort sample into the reader caches when resource limits are reached.&lt;/p&gt;
-&lt;p&gt;The default value is: "false".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;false&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="SPDPResponseMaxDelay" type="config:duration">
@@ -962,7 +962,7 @@ CycloneDDS configuration</xs:documentation>
       <xs:documentation>
 &lt;p&gt;Maximum pseudo-random delay in milliseconds between discovering aremote participant and responding to it.&lt;/p&gt;
 &lt;p&gt;The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.&lt;/p&gt;
-&lt;p&gt;The default value is: "0 ms".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;0 ms&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="ScheduleTimeRounding" type="config:duration">
@@ -970,14 +970,14 @@ CycloneDDS configuration</xs:documentation>
       <xs:documentation>
 &lt;p&gt;This setting allows the timing of scheduled events to be rounded up so that more events can be handled in a single cycle of the event queue. The default is 0 and causes no rounding at all, i.e. are scheduled exactly, whereas a value of 10ms would mean that events are rounded up to the nearest 10 milliseconds.&lt;/p&gt;
 &lt;p&gt;The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.&lt;/p&gt;
-&lt;p&gt;The default value is: "0 ms".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;0 ms&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="SecondaryReorderMaxSamples" type="xs:integer">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element sets the maximum size in samples of a secondary re-order administration. The secondary re-order administration is per reader needing historical data.&lt;/p&gt;
-&lt;p&gt;The default value is: "128".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;128&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="SocketReceiveBufferSize">
@@ -992,7 +992,7 @@ CycloneDDS configuration</xs:documentation>
           <xs:documentation>
 &lt;p&gt;This sets the size of the socket receive buffer to request, with the special value of "default" indicating that it should try to satisfy the minimum buffer size. If both are at "default", it will request 1MiB and accept anything. It is ignored if the  maximum is set to less than the minimum.&lt;/p&gt;
 &lt;p&gt;The unit must be specified explicitly. Recognised units: B (bytes), kB &amp; KiB (2&lt;sup&gt;10&lt;/sup&gt; bytes), MB &amp; MiB (2&lt;sup&gt;20&lt;/sup&gt; bytes), GB &amp; GiB (2&lt;sup&gt;30&lt;/sup&gt; bytes).&lt;/p&gt;
-&lt;p&gt;The default value is: "default".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;default&lt;/code&gt;&lt;/p&gt;</xs:documentation>
         </xs:annotation>
       </xs:attribute>
       <xs:attribute name="min" type="config:memsize">
@@ -1000,7 +1000,7 @@ CycloneDDS configuration</xs:documentation>
           <xs:documentation>
 &lt;p&gt;This sets the minimum acceptable socket receive buffer size, with the special value "default" indicating that whatever is available is acceptable.&lt;/p&gt;
 &lt;p&gt;The unit must be specified explicitly. Recognised units: B (bytes), kB &amp; KiB (2&lt;sup&gt;10&lt;/sup&gt; bytes), MB &amp; MiB (2&lt;sup&gt;20&lt;/sup&gt; bytes), GB &amp; GiB (2&lt;sup&gt;30&lt;/sup&gt; bytes).&lt;/p&gt;
-&lt;p&gt;The default value is: "default".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;default&lt;/code&gt;&lt;/p&gt;</xs:documentation>
         </xs:annotation>
       </xs:attribute>
     </xs:complexType>
@@ -1017,7 +1017,7 @@ CycloneDDS configuration</xs:documentation>
           <xs:documentation>
 &lt;p&gt;This sets the size of the socket send buffer to request, with the special value of "default" indicating that it should try to satisfy the minimum buffer size. If both are at "default", it will use whatever is the system default. It is ignored if the maximum is set to less than the minimum.&lt;/p&gt;
 &lt;p&gt;The unit must be specified explicitly. Recognised units: B (bytes), kB &amp; KiB (2&lt;sup&gt;10&lt;/sup&gt; bytes), MB &amp; MiB (2&lt;sup&gt;20&lt;/sup&gt; bytes), GB &amp; GiB (2&lt;sup&gt;30&lt;/sup&gt; bytes).&lt;/p&gt;
-&lt;p&gt;The default value is: "default".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;default&lt;/code&gt;&lt;/p&gt;</xs:documentation>
         </xs:annotation>
       </xs:attribute>
       <xs:attribute name="min" type="config:memsize">
@@ -1025,7 +1025,7 @@ CycloneDDS configuration</xs:documentation>
           <xs:documentation>
 &lt;p&gt;This sets the minimum acceptable socket send buffer size, with the special value "default" indicating that whatever is available is acceptable.&lt;/p&gt;
 &lt;p&gt;The unit must be specified explicitly. Recognised units: B (bytes), kB &amp; KiB (2&lt;sup&gt;10&lt;/sup&gt; bytes), MB &amp; MiB (2&lt;sup&gt;20&lt;/sup&gt; bytes), GB &amp; GiB (2&lt;sup&gt;30&lt;/sup&gt; bytes).&lt;/p&gt;
-&lt;p&gt;The default value is: "64 KiB".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;64 KiB&lt;/code&gt;&lt;/p&gt;</xs:documentation>
         </xs:annotation>
       </xs:attribute>
     </xs:complexType>
@@ -1034,7 +1034,7 @@ CycloneDDS configuration</xs:documentation>
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element controls whether Cyclone DDS advertises all the domain participants it serves in DDSI (when set to &lt;i&gt;false&lt;/i&gt;), or rather only one domain participant (the one corresponding to the Cyclone DDS process; when set to &lt;i&gt;true&lt;/i&gt;). In the latter case, Cyclone DDS becomes the virtual owner of all readers and writers of all domain participants, dramatically reducing discovery traffic (a similar effect can be obtained by setting Internal/BuiltinEndpointSet to "minimal" but with less loss of information).&lt;/p&gt;
-&lt;p&gt;The default value is: "false".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;false&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="SynchronousDeliveryLatencyBound" type="config:duration_inf">
@@ -1042,14 +1042,14 @@ CycloneDDS configuration</xs:documentation>
       <xs:documentation>
 &lt;p&gt;This element controls whether samples sent by a writer with QoS settings transport_priority &gt;= SynchronousDeliveryPriorityThreshold and a latency_budget at most this element's value will be delivered synchronously from the "recv" thread, all others will be delivered asynchronously through delivery queues. This reduces latency at the expense of aggregate bandwidth.&lt;/p&gt;
 &lt;p&gt;Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.&lt;/p&gt;
-&lt;p&gt;The default value is: "inf".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;inf&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="SynchronousDeliveryPriorityThreshold" type="xs:integer">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element controls whether samples sent by a writer with QoS settings latency_budget &lt;= SynchronousDeliveryLatencyBound and transport_priority greater than or equal to this element's value will be delivered synchronously from the "recv" thread, all others will be delivered asynchronously through delivery queues. This reduces latency at the expense of aggregate bandwidth.&lt;/p&gt;
-&lt;p&gt;The default value is: "0".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;0&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="Test">
@@ -1067,21 +1067,21 @@ CycloneDDS configuration</xs:documentation>
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element controls the fraction of outgoing packets to drop, specified as samples per thousand.&lt;/p&gt;
-&lt;p&gt;The default value is: "0".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;0&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="UnicastResponseToSPDPMessages" type="xs:boolean">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element controls whether the response to a newly discovered participant is sent as a unicasted SPDP packet instead of rescheduling the periodic multicasted one. There is no known benefit to setting this to &lt;i&gt;false&lt;/i&gt;.&lt;/p&gt;
-&lt;p&gt;The default value is: "true".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;true&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="UseMulticastIfMreqn" type="xs:integer">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;Do not use.&lt;/p&gt;
-&lt;p&gt;The default value is: "0".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;0&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="Watermarks">
@@ -1102,7 +1102,7 @@ CycloneDDS configuration</xs:documentation>
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element controls whether Cyclone DDS will adapt the high-water mark to current traffic conditions based on retransmit requests and transmit pressure.&lt;/p&gt;
-&lt;p&gt;The default value is: "true".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;true&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="WhcHigh" type="config:memsize">
@@ -1110,7 +1110,7 @@ CycloneDDS configuration</xs:documentation>
       <xs:documentation>
 &lt;p&gt;This element sets the maximum allowed high-water mark for the Cyclone DDS WHCs, expressed in bytes. A writer is suspended when the WHC reaches this size.&lt;/p&gt;
 &lt;p&gt;The unit must be specified explicitly. Recognised units: B (bytes), kB &amp; KiB (2&lt;sup&gt;10&lt;/sup&gt; bytes), MB &amp; MiB (2&lt;sup&gt;20&lt;/sup&gt; bytes), GB &amp; GiB (2&lt;sup&gt;30&lt;/sup&gt; bytes).&lt;/p&gt;
-&lt;p&gt;The default value is: "500 kB".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;500 kB&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="WhcHighInit" type="config:memsize">
@@ -1118,7 +1118,7 @@ CycloneDDS configuration</xs:documentation>
       <xs:documentation>
 &lt;p&gt;This element sets the initial level of the high-water mark for the Cyclone DDS WHCs, expressed in bytes.&lt;/p&gt;
 &lt;p&gt;The unit must be specified explicitly. Recognised units: B (bytes), kB &amp; KiB (2&lt;sup&gt;10&lt;/sup&gt; bytes), MB &amp; MiB (2&lt;sup&gt;20&lt;/sup&gt; bytes), GB &amp; GiB (2&lt;sup&gt;30&lt;/sup&gt; bytes).&lt;/p&gt;
-&lt;p&gt;The default value is: "30 kB".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;30 kB&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="WhcLow" type="config:memsize">
@@ -1126,14 +1126,14 @@ CycloneDDS configuration</xs:documentation>
       <xs:documentation>
 &lt;p&gt;This element sets the low-water mark for the Cyclone DDS WHCs, expressed in bytes. A suspended writer resumes transmitting when its Cyclone DDS WHC shrinks to this size.&lt;/p&gt;
 &lt;p&gt;The unit must be specified explicitly. Recognised units: B (bytes), kB &amp; KiB (2&lt;sup&gt;10&lt;/sup&gt; bytes), MB &amp; MiB (2&lt;sup&gt;20&lt;/sup&gt; bytes), GB &amp; GiB (2&lt;sup&gt;30&lt;/sup&gt; bytes).&lt;/p&gt;
-&lt;p&gt;The default value is: "1 kB".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;1 kB&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="WriteBatch" type="xs:boolean">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element enables the batching of write operations. By default each write operation writes through the write cache and out onto the transport. Enabling write batching causes multiple small write operations to be aggregated within the write cache into a single larger write. This gives greater throughput at the expense of latency. Currently, there is no mechanism for the write cache to automatically flush itself, so that if write batching is enabled, the application may have to use the dds_write_flush function to ensure that all samples are written.&lt;/p&gt;
-&lt;p&gt;The default value is: "false".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;false&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="WriterLingerDuration" type="config:duration">
@@ -1141,7 +1141,7 @@ CycloneDDS configuration</xs:documentation>
       <xs:documentation>
 &lt;p&gt;This setting controls the maximum duration for which actual deletion of a reliable writer with unacknowledged data in its history will be postponed to provide proper reliable transmission.&lt;p&gt;
 &lt;p&gt;The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.&lt;/p&gt;
-&lt;p&gt;The default value is: "1 s".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;1 s&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="Partitioning">
@@ -1172,14 +1172,14 @@ CycloneDDS configuration</xs:documentation>
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element can prevent certain combinations of DCPS partition and topic from being transmitted over the network. Cyclone DDS will completely ignore readers and writers for which all DCPS partitions as well as their topic is ignored, not even creating DDSI readers and writers to mirror the DCPS ones.&lt;/p&gt;
-&lt;p&gt;The default value is: "".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;&amp;lt;empty&amp;gt;&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
     <xs:complexType>
       <xs:attribute name="DCPSPartitionTopic" use="required">
         <xs:annotation>
           <xs:documentation>
 &lt;p&gt;This attribute specifies a partition and a topic expression, separated by a single '.', which are used to determine if a given partition and topic will be ignored or not. The expressions may use the usual wildcards '*' and '?'. Cyclone DDS will consider a wildcard DCPS partition to match an expression if a string that satisfies both expressions exists.&lt;/p&gt;
-&lt;p&gt;The default value is: "".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;&amp;lt;empty&amp;gt;&lt;/code&gt;&lt;/p&gt;</xs:documentation>
         </xs:annotation>
       </xs:attribute>
     </xs:complexType>
@@ -1199,28 +1199,28 @@ CycloneDDS configuration</xs:documentation>
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element defines a Cyclone DDS network partition.&lt;/p&gt;
-&lt;p&gt;The default value is: "".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;&amp;lt;empty&amp;gt;&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
     <xs:complexType>
       <xs:attribute name="Address" use="required">
         <xs:annotation>
           <xs:documentation>
 &lt;p&gt;This attribute specifies the addresses associated with the network partition as a comma-separated list. The addresses are typically multicast addresses. Non-multicast addresses are allowed, provided the "Interface" attribute is not used:&lt;/p&gt;&lt;ul&gt;&lt;li&gt;An address matching the address or the "external address" (see General/ExternalNetworkAddress; default is the actual address) of a configured interface results in adding the corresponding "external" address to the set of advertised unicast addresses.&lt;/li&gt;&lt;li&gt;An address corresponding to the (external) address of a configured interface, but not the address of the host itself, for example, a match when masking the addresses with the netmask for IPv4, results in adding the external address. For IPv4, this requires the host part to be all-zero.&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Readers matching this network partition (cf. Partitioning/PartitionMappings) will advertise all addresses listed to the matching writers via the discovery protocol and will join the specified multicast groups. The writers will select the most suitable address from the addresses advertised by the readers.&lt;/p&gt;&lt;p&gt;The unicast addresses advertised by a reader are the only unicast addresses a writer will use to send data to it and are used to select the subset of network interfaces to use for transmitting multicast data with the intent of reaching it.&lt;/p&gt;
-&lt;p&gt;The default value is: "".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;&amp;lt;empty&amp;gt;&lt;/code&gt;&lt;/p&gt;</xs:documentation>
         </xs:annotation>
       </xs:attribute>
       <xs:attribute name="Interface">
         <xs:annotation>
           <xs:documentation>
 &lt;p&gt;This attribute takes a comma-separated list of interface name that the reader is willing to receive data on. This is implemented by adding the interface addresses to the set address set configured using the sibling "Address" attribute. See there for more details.&lt;/p&gt;
-&lt;p&gt;The default value is: "".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;&amp;lt;empty&amp;gt;&lt;/code&gt;&lt;/p&gt;</xs:documentation>
         </xs:annotation>
       </xs:attribute>
       <xs:attribute name="Name" use="required">
         <xs:annotation>
           <xs:documentation>
 &lt;p&gt;This attribute specifies the name of this Cyclone DDS network partition. Two network partitions cannot have the same name. Partition mappings (cf. Partitioning/PartitionMappings) refer to network partitions using these names.&lt;/p&gt;
-&lt;p&gt;The default value is: "".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;&amp;lt;empty&amp;gt;&lt;/code&gt;&lt;/p&gt;</xs:documentation>
         </xs:annotation>
       </xs:attribute>
     </xs:complexType>
@@ -1240,21 +1240,21 @@ CycloneDDS configuration</xs:documentation>
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element defines a mapping from a DCPS partition/topic combination to a Cyclone DDS network partition. This allows partitioning data flows by using special multicast addresses for part of the data and possibly encrypting the data flow.&lt;/p&gt;
-&lt;p&gt;The default value is: "".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;&amp;lt;empty&amp;gt;&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
     <xs:complexType>
       <xs:attribute name="DCPSPartitionTopic" use="required">
         <xs:annotation>
           <xs:documentation>
 &lt;p&gt;This attribute specifies a partition and a topic expression, separated by a single '.', which are used to determine if a given partition and topic maps to the Cyclone DDS network partition named by the NetworkPartition attribute in this PartitionMapping element. The expressions may use the usual wildcards '*' and '?'. Cyclone DDS will consider a wildcard DCPS partition to match an expression if there exists a string that satisfies both expressions.&lt;/p&gt;
-&lt;p&gt;The default value is: "".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;&amp;lt;empty&amp;gt;&lt;/code&gt;&lt;/p&gt;</xs:documentation>
         </xs:annotation>
       </xs:attribute>
       <xs:attribute name="NetworkPartition" use="required">
         <xs:annotation>
           <xs:documentation>
 &lt;p&gt;This attribute specifies which Cyclone DDS network partition is to be used for DCPS partition/topic combinations matching the DCPSPartitionTopic attribute within this PartitionMapping element.&lt;/p&gt;
-&lt;p&gt;The default value is: "".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;&amp;lt;empty&amp;gt;&lt;/code&gt;&lt;/p&gt;</xs:documentation>
         </xs:annotation>
       </xs:attribute>
     </xs:complexType>
@@ -1272,7 +1272,7 @@ CycloneDDS configuration</xs:documentation>
           <xs:annotation>
             <xs:documentation>
 &lt;p&gt;This enables SSL/TLS for TCP.&lt;/p&gt;
-&lt;p&gt;The default value is: "false".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;false&lt;/code&gt;&lt;/p&gt;</xs:documentation>
           </xs:annotation>
         </xs:element>
         <xs:element minOccurs="0" ref="config:EntropyFile"/>
@@ -1288,56 +1288,56 @@ CycloneDDS configuration</xs:documentation>
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;If disabled this allows SSL connections to occur even if an X509 certificate fails verification.&lt;/p&gt;
-&lt;p&gt;The default value is: "true".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;true&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="Ciphers" type="xs:string">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;The set of ciphers used by SSL/TLS&lt;/p&gt;
-&lt;p&gt;The default value is: "ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="EntropyFile" type="xs:string">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;The SSL/TLS random entropy file name.&lt;/p&gt;
-&lt;p&gt;The default value is: "".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;&amp;lt;empty&amp;gt;&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="KeyPassphrase" type="xs:string">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;The SSL/TLS key pass phrase for encrypted keys.&lt;/p&gt;
-&lt;p&gt;The default value is: "secret".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;secret&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="KeystoreFile" type="xs:string">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;The SSL/TLS key and certificate store file name. The keystore must be in PEM format.&lt;/p&gt;
-&lt;p&gt;The default value is: "keystore".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;keystore&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="MinimumTLSVersion" type="xs:string">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;The minimum TLS version that may be negotiated, valid values are 1.2 and 1.3.&lt;/p&gt;
-&lt;p&gt;The default value is: "1.3".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;1.3&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="SelfSignedCertificates" type="xs:boolean">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This enables the use of self signed X509 certificates.&lt;/p&gt;
-&lt;p&gt;The default value is: "false".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;false&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="VerifyClient" type="xs:boolean">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This enables an SSL server to check the X509 certificate of a connecting client.&lt;/p&gt;
-&lt;p&gt;The default value is: "true".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;true&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="Security">
@@ -1365,21 +1365,21 @@ CycloneDDS configuration</xs:documentation>
           <xs:annotation>
             <xs:documentation>
 &lt;p&gt;This element specifies the library to be loaded as the DDS Security Access Control plugin.&lt;/p&gt;
-&lt;p&gt;The default value is: "".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;&amp;lt;empty&amp;gt;&lt;/code&gt;&lt;/p&gt;</xs:documentation>
           </xs:annotation>
           <xs:complexType>
             <xs:attribute name="finalizeFunction">
               <xs:annotation>
                 <xs:documentation>
 &lt;p&gt;This element names the finalization function of Access Control plugin. This function is called to let the plugin release its resources.&lt;/p&gt;
-&lt;p&gt;The default value is: "finalize_access_control".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;finalize_access_control&lt;/code&gt;&lt;/p&gt;</xs:documentation>
               </xs:annotation>
             </xs:attribute>
             <xs:attribute name="initFunction">
               <xs:annotation>
                 <xs:documentation>
 &lt;p&gt;This element names the initialization function of Access Control plugin. This function is called after loading the plugin library for instantiation purposes. The Init function must return an object that implements the DDS Security Access Control interface.&lt;/p&gt;
-&lt;p&gt;The default value is: "init_access_control".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;init_access_control&lt;/code&gt;&lt;/p&gt;</xs:documentation>
               </xs:annotation>
             </xs:attribute>
             <xs:attribute name="path">
@@ -1388,7 +1388,7 @@ CycloneDDS configuration</xs:documentation>
 &lt;p&gt;This element points to the path of Access Control plugin library.&lt;/p&gt;
 &lt;p&gt;It can be either absolute path excluding file extension ( /usr/lib/dds_security_ac ) or single file without extension ( dds_security_ac ).&lt;/p&gt;
 &lt;p&gt;If a single file is supplied, the library is located by the current working directory, or LD_LIBRARY_PATH for Unix systems, and PATH for Windows systems.&lt;/p&gt;
-&lt;p&gt;The default value is: "dds_security_ac".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;dds_security_ac&lt;/code&gt;&lt;/p&gt;</xs:documentation>
               </xs:annotation>
             </xs:attribute>
           </xs:complexType>
@@ -1424,7 +1424,7 @@ CycloneDDS configuration</xs:documentation>
 &lt;p&gt;Content-Disposition: attachment; filename="smime.p7s"&lt;/p&gt;
 &lt;p&gt;MIIDuAYJKoZIhv ...al5s=&lt;/p&gt;
 &lt;p&gt;------F9A8A198D6F08E1285A292ADF14DD04F-]]&lt;/Governance&gt;&lt;/p&gt;
-&lt;p&gt;The default value is: "".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;&amp;lt;empty&amp;gt;&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="Permissions" type="xs:string">
@@ -1437,7 +1437,7 @@ CycloneDDS configuration</xs:documentation>
 &lt;p&gt;&lt;Permissions&gt;file:/path_to/permissions_document.p7s&lt;/Permissions&gt;&lt;/p&gt;
 &lt;p&gt;Example data URI:&lt;/p&gt;
 &lt;p&gt;&lt;Permissions&gt;&lt;![CDATA[data:,.........]]&lt;/Permissions&gt;&lt;/p&gt;
-&lt;p&gt;The default value is: "".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;&amp;lt;empty&amp;gt;&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="PermissionsCA" type="xs:string">
@@ -1452,7 +1452,7 @@ CycloneDDS configuration</xs:documentation>
 &lt;p&gt;&lt;PermissionsCA&gt;data:&lt;strong&gt;,&lt;/strong&gt;-----BEGIN CERTIFICATE-----&lt;/p&gt;
 &lt;p&gt;MIIC3DCCAcQCCQCWE5x+Z ... PhovK0mp2ohhRLYI0ZiyYQ==&lt;/p&gt;
 &lt;p&gt;-----END CERTIFICATE-----&lt;/PermissionsCA&gt;&lt;/p&gt;
-&lt;p&gt;The default value is: "".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;&amp;lt;empty&amp;gt;&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="Authentication">
@@ -1470,21 +1470,21 @@ CycloneDDS configuration</xs:documentation>
           <xs:annotation>
             <xs:documentation>
 &lt;p&gt;This element specifies the library to be loaded as the DDS Security Access Control plugin.&lt;/p&gt;
-&lt;p&gt;The default value is: "".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;&amp;lt;empty&amp;gt;&lt;/code&gt;&lt;/p&gt;</xs:documentation>
           </xs:annotation>
           <xs:complexType>
             <xs:attribute name="finalizeFunction">
               <xs:annotation>
                 <xs:documentation>
 &lt;p&gt;This element names the finalization function of the Authentication plugin. This function is called to let the plugin release its resources.&lt;/p&gt;
-&lt;p&gt;The default value is: "finalize_authentication".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;finalize_authentication&lt;/code&gt;&lt;/p&gt;</xs:documentation>
               </xs:annotation>
             </xs:attribute>
             <xs:attribute name="initFunction">
               <xs:annotation>
                 <xs:documentation>
 &lt;p&gt;This element names the initialization function of the Authentication plugin. This function is called after loading the plugin library for instantiation purposes. The Init function must return an object that implements the DDS Security Authentication interface.&lt;/p&gt;
-&lt;p&gt;The default value is: "init_authentication".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;init_authentication&lt;/code&gt;&lt;/p&gt;</xs:documentation>
               </xs:annotation>
             </xs:attribute>
             <xs:attribute name="path">
@@ -1493,7 +1493,7 @@ CycloneDDS configuration</xs:documentation>
 &lt;p&gt;This element points to the path of the Authentication plugin library.&lt;/p&gt;
 &lt;p&gt;It can be either absolute path excluding file extension ( /usr/lib/dds_security_auth ) or single file without extension ( dds_security_auth ).&lt;/p&gt;
 &lt;p&gt;If a single file is supplied, the library is located by the current working directory, or LD_LIBRARY_PATH for Unix systems, and PATH for Windows systems.&lt;/p&gt;
-&lt;p&gt;The default value is: "dds_security_auth".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;dds_security_auth&lt;/code&gt;&lt;/p&gt;</xs:documentation>
               </xs:annotation>
             </xs:attribute>
           </xs:complexType>
@@ -1514,7 +1514,7 @@ CycloneDDS configuration</xs:documentation>
 &lt;p&gt;&lt;CRL&gt;data:,-----BEGIN X509 CRL-----&lt;br&gt;
 MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg=&lt;br&gt;
 -----END X509 CRL-----&lt;/CRL&gt;&lt;/p&gt;
-&lt;p&gt;The default value is: "".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;&amp;lt;empty&amp;gt;&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="IdentityCA" type="xs:string">
@@ -1528,7 +1528,7 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg=&lt;br&gt;
 &lt;p&gt;&lt;IdentityCA&gt;data:,-----BEGIN CERTIFICATE-----&lt;br&gt;
 MIIC3DCCAcQCCQCWE5x+Z...PhovK0mp2ohhRLYI0ZiyYQ==&lt;br&gt;
 -----END CERTIFICATE-----&lt;/IdentityCA&gt;&lt;/p&gt;
-&lt;p&gt;The default value is: "".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;&amp;lt;empty&amp;gt;&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="IdentityCertificate" type="xs:string">
@@ -1541,14 +1541,14 @@ MIIC3DCCAcQCCQCWE5x+Z...PhovK0mp2ohhRLYI0ZiyYQ==&lt;br&gt;
 &lt;p&gt;&lt;IdentityCertificate&gt;data:,-----BEGIN CERTIFICATE-----&lt;br&gt;
 MIIDjjCCAnYCCQDCEu9...6rmT87dhTo=&lt;br&gt;
 -----END CERTIFICATE-----&lt;/IdentityCertificate&gt;&lt;/p&gt;
-&lt;p&gt;The default value is: "".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;&amp;lt;empty&amp;gt;&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="IncludeOptionalFields" type="xs:boolean">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;The authentication handshake tokens may contain optional fields to be included for finding interoperability problems. If this parameter is set to true the optional fields are included in the handshake token exchange.&lt;/p&gt;
-&lt;p&gt;The default value is: "false".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;false&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="Password" type="xs:string">
@@ -1557,7 +1557,7 @@ MIIDjjCCAnYCCQDCEu9...6rmT87dhTo=&lt;br&gt;
 &lt;p&gt;A password is used to decrypt the private_key.&lt;/p&gt;
 &lt;p&gt;The value of the password property shall be interpreted as the Base64 encoding of the AES-128 key that shall be used to decrypt the private_key using AES128-CBC.&lt;/p&gt;
 &lt;p&gt;If the password property is not present, then the value supplied in the private_key property must contain the unencrypted private key.&lt;/p&gt;
-&lt;p&gt;The default value is: "".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;&amp;lt;empty&amp;gt;&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="PrivateKey" type="xs:string">
@@ -1570,14 +1570,14 @@ MIIDjjCCAnYCCQDCEu9...6rmT87dhTo=&lt;br&gt;
 &lt;p&gt;&lt;PrivateKey&gt;data:,-----BEGIN RSA PRIVATE KEY-----&lt;br&gt;
 MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
 -----END RSA PRIVATE KEY-----&lt;/PrivateKey&gt;&lt;/p&gt;
-&lt;p&gt;The default value is: "".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;&amp;lt;empty&amp;gt;&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="TrustedCADirectory" type="xs:string">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;Trusted CA Directory which contains trusted CA certificates as separated files.&lt;/p&gt;
-&lt;p&gt;The default value is: "".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;&amp;lt;empty&amp;gt;&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="Cryptographic">
@@ -1591,21 +1591,21 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
           <xs:annotation>
             <xs:documentation>
 &lt;p&gt;This element specifies the library to be loaded as the DDS Security Cryptographic plugin.&lt;/p&gt;
-&lt;p&gt;The default value is: "".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;&amp;lt;empty&amp;gt;&lt;/code&gt;&lt;/p&gt;</xs:documentation>
           </xs:annotation>
           <xs:complexType>
             <xs:attribute name="finalizeFunction">
               <xs:annotation>
                 <xs:documentation>
 &lt;p&gt;This element names the finalization function of the Cryptographic plugin. This function is called to let the plugin release its resources.&lt;/p&gt;
-&lt;p&gt;The default value is: "finalize_crypto".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;finalize_crypto&lt;/code&gt;&lt;/p&gt;</xs:documentation>
               </xs:annotation>
             </xs:attribute>
             <xs:attribute name="initFunction">
               <xs:annotation>
                 <xs:documentation>
 &lt;p&gt;This element names the initialization function of the Cryptographic plugin. This function is called after loading the plugin library for instantiation purposes. The Init function must return an object that implements the DDS Security Cryptographic interface.&lt;/p&gt;
-&lt;p&gt;The default value is: "init_crypto".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;init_crypto&lt;/code&gt;&lt;/p&gt;</xs:documentation>
               </xs:annotation>
             </xs:attribute>
             <xs:attribute name="path">
@@ -1614,7 +1614,7 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
 &lt;p&gt;This element points to the path of the Cryptographic plugin library.&lt;/p&gt;
 &lt;p&gt;It can be either absolute path excluding file extension ( /usr/lib/dds_security_crypto ) or single file without extension ( dds_security_crypto ).&lt;/p&gt;
 &lt;p&gt;If a single file is supplied, the is library located by the current working directory, or LD_LIBRARY_PATH for Unix systems, and PATH for Windows systems.&lt;/p&gt;
-&lt;p&gt;The default value is: "dds_security_crypto".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;dds_security_crypto&lt;/code&gt;&lt;/p&gt;</xs:documentation>
               </xs:annotation>
             </xs:attribute>
           </xs:complexType>
@@ -1633,7 +1633,7 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
           <xs:annotation>
             <xs:documentation>
 &lt;p&gt;This element allows for enabling shared memory in Cyclone DDS.&lt;/p&gt;
-&lt;p&gt;The default value is: "false".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;false&lt;/code&gt;&lt;/p&gt;</xs:documentation>
           </xs:annotation>
         </xs:element>
         <xs:element minOccurs="0" ref="config:Locator"/>
@@ -1646,7 +1646,7 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;Explicitly set the Iceoryx locator used by Cyclone to check whether a pair of processes is attached to the same Iceoryx shared memory.  The default is to use one of the MAC addresses of the machine, which should work well in most cases.&lt;/p&gt;
-&lt;p&gt;The default value is: "".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;&amp;lt;empty&amp;gt;&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="LogLevel">
@@ -1661,7 +1661,7 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
 &lt;li&gt;&lt;i&gt;debug&lt;/i&gt;: show debug log&lt;/li&gt;
 &lt;li&gt;&lt;i&gt;verbose&lt;/i&gt;: show verbose log&lt;/li&gt;
 &lt;p&gt;If you don't want to see any log from shared memory, use &lt;i&gt;off&lt;/i&gt; to disable logging.&lt;/p&gt;
-&lt;p&gt;The default value is: "info".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;info&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
     <xs:simpleType>
       <xs:restriction base="xs:token">
@@ -1679,7 +1679,7 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;Override the Iceoryx service name used by Cyclone.&lt;/p&gt;
-&lt;p&gt;The default value is: "DDS_CYCLONE".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;DDS_CYCLONE&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="Sizing">
@@ -1699,7 +1699,7 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
       <xs:documentation>
 &lt;p&gt;This element specifies the size of one allocation unit in the receive buffer. It must be greater than the maximum packet size by a modest amount (too large packets are dropped). Each allocation is shrunk immediately after processing a message or freed straightaway.&lt;/p&gt;
 &lt;p&gt;The unit must be specified explicitly. Recognised units: B (bytes), kB &amp; KiB (2&lt;sup&gt;10&lt;/sup&gt; bytes), MB &amp; MiB (2&lt;sup&gt;20&lt;/sup&gt; bytes), GB &amp; GiB (2&lt;sup&gt;30&lt;/sup&gt; bytes).&lt;/p&gt;
-&lt;p&gt;The default value is: "128 KiB".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;128 KiB&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="ReceiveBufferSize" type="config:memsize">
@@ -1707,7 +1707,7 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
       <xs:documentation>
 &lt;p&gt;This element sets the size of a single receive buffer. Many receive buffers may be needed. The minimum workable size is a little larger than Sizing/ReceiveBufferChunkSize, and the value used is taken as the configured value and the actual minimum workable size.&lt;/p&gt;
 &lt;p&gt;The unit must be specified explicitly. Recognised units: B (bytes), kB &amp; KiB (2&lt;sup&gt;10&lt;/sup&gt; bytes), MB &amp; MiB (2&lt;sup&gt;20&lt;/sup&gt; bytes), GB &amp; GiB (2&lt;sup&gt;30&lt;/sup&gt; bytes).&lt;/p&gt;
-&lt;p&gt;The default value is: "1 MiB".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;1 MiB&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="TCP">
@@ -1722,7 +1722,7 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
           <xs:annotation>
             <xs:documentation>
 &lt;p&gt;This element enables the optional TCP transport - deprecated, use General/Transport instead.&lt;/p&gt;
-&lt;p&gt;The default value is: "default".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;default&lt;/code&gt;&lt;/p&gt;</xs:documentation>
           </xs:annotation>
           <xs:simpleType>
             <xs:restriction base="xs:token">
@@ -1743,21 +1743,21 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;Setting this to true means the unicast addresses in SPDP packets will be ignored, and the peer address from the TCP connection will be used instead. This may help work around incorrectly advertised addresses when using TCP.&lt;/p&gt;
-&lt;p&gt;The default value is: "false".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;false&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="NoDelay" type="xs:boolean">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element enables the TCP_NODELAY socket option, preventing multiple DDSI messages from being sent in the same TCP request. Setting this option typically optimises latency over throughput.&lt;/p&gt;
-&lt;p&gt;The default value is: "true".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;true&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="Port" type="xs:integer">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element specifies the TCP port number on which Cyclone DDS accepts connections. If the port is set, it is used in entity locators, published with DDSI discovery, dynamically allocated if zero, and disabled if -1 or not configured. If disabled other DDSI services will not be able to establish connections with the service, the service can only communicate by establishing connections to other services.&lt;/p&gt;
-&lt;p&gt;The default value is: "-1".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;-1&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="ReadTimeout" type="config:duration">
@@ -1765,7 +1765,7 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
       <xs:documentation>
 &lt;p&gt;This element specifies the timeout for blocking TCP read operations. If this timeout expires then the connection is closed.&lt;/p&gt;
 &lt;p&gt;The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.&lt;/p&gt;
-&lt;p&gt;The default value is: "2 s".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;2 s&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="WriteTimeout" type="config:duration">
@@ -1773,7 +1773,7 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
       <xs:documentation>
 &lt;p&gt;This element specifies the timeout for blocking TCP write operations. If this timeout expires then the connection is closed.&lt;/p&gt;
 &lt;p&gt;The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.&lt;/p&gt;
-&lt;p&gt;The default value is: "2 s".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;2 s&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="Threads">
@@ -1811,7 +1811,7 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
 &lt;li&gt;&lt;i&gt;xmit.CHAN&lt;/i&gt;: transmit thread for channel CHAN;&lt;/li&gt;
 &lt;li&gt;&lt;i&gt;dq.CHAN&lt;/i&gt;: delivery thread for channel CHAN;&lt;/li&gt;
 &lt;li&gt;&lt;i&gt;tev.CHAN&lt;/i&gt;: timed-event thread for channel CHAN.&lt;/li&gt;&lt;/ul&gt;
-&lt;p&gt;The default value is: "".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;&amp;lt;empty&amp;gt;&lt;/code&gt;&lt;/p&gt;</xs:documentation>
         </xs:annotation>
       </xs:attribute>
     </xs:complexType>
@@ -1832,7 +1832,7 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element specifies the thread scheduling class (&lt;i&gt;realtime&lt;/i&gt;, &lt;i&gt;timeshare&lt;/i&gt; or &lt;i&gt;default&lt;/i&gt;). The user may need special privileges from the underlying operating system to be able to assign some of the privileged scheduling classes.&lt;/p&gt;
-&lt;p&gt;The default value is: "default".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;default&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
     <xs:simpleType>
       <xs:restriction base="xs:token">
@@ -1846,7 +1846,7 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This element specifies the thread priority (decimal integer or &lt;i&gt;default&lt;/i&gt;). Only priorities supported by the underlying operating system can be assigned to this element. The user may need special privileges from the underlying operating system to be able to assign some of the privileged priorities.&lt;/p&gt;
-&lt;p&gt;The default value is: "default".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;default&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="StackSize" type="config:memsize">
@@ -1854,7 +1854,7 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
       <xs:documentation>
 &lt;p&gt;This element configures the stack size for this thread. The default value &lt;i&gt;default&lt;/i&gt; leaves the stack size at the operating system default.&lt;/p&gt;
 &lt;p&gt;The unit must be specified explicitly. Recognised units: B (bytes), kB &amp; KiB (2&lt;sup&gt;10&lt;/sup&gt; bytes), MB &amp; MiB (2&lt;sup&gt;20&lt;/sup&gt; bytes), GB &amp; GiB (2&lt;sup&gt;30&lt;/sup&gt; bytes).&lt;/p&gt;
-&lt;p&gt;The default value is: "default".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;default&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="Tracing">
@@ -1876,7 +1876,7 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This option specifies whether the output should be appended to an existing log file. The default is to create a new log file each time, which is generally the best option if a detailed log is generated.&lt;/p&gt;
-&lt;p&gt;The default value is: "false".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;false&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="Category">
@@ -1900,7 +1900,7 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
 &lt;li&gt;&lt;i&gt;plist&lt;/i&gt;: tracing of discovery parameter list interpretation&lt;/li&gt;&lt;/ul&gt;
 &lt;p&gt;In addition, there is the keyword &lt;i&gt;trace&lt;/i&gt; that enables all but &lt;i&gt;radmin&lt;/i&gt;, &lt;i&gt;topic&lt;/i&gt;, &lt;i&gt;plist&lt;/i&gt; and &lt;i&gt;whc&lt;/i&gt;&lt;/p&gt;.
 &lt;p&gt;The categorisation of tracing output is incomplete and hence most of the verbosity levels and categories are not of much use in the current release. This is an ongoing process and here we describe the target situation rather than the current situation. Currently, the most useful is &lt;i&gt;trace&lt;/i&gt;.&lt;/p&gt;
-&lt;p&gt;The default value is: "".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;&amp;lt;empty&amp;gt;&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
     <xs:simpleType>
       <xs:restriction base="xs:token">
@@ -1912,14 +1912,14 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This option specifies where the logging is printed to. Note that &lt;i&gt;stdout&lt;/i&gt; and &lt;i&gt;stderr&lt;/i&gt; are treated as special values, representing "standard out" and "standard error" respectively. No file is created unless logging categories are enabled using the Tracing/Verbosity or Tracing/EnabledCategory settings.&lt;/p&gt;
-&lt;p&gt;The default value is: "cyclonedds.log".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;cyclonedds.log&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="PacketCaptureFile" type="xs:string">
     <xs:annotation>
       <xs:documentation>
 &lt;p&gt;This option specifies the file to which received and sent packets will be logged in the "pcap" format suitable for analysis using common networking tools, such as WireShark. IP and UDP headers are fictitious, in particular the destination address of received packets. The TTL may be used to distinguish between sent and received packets: it is 255 for sent packets and 128 for received ones. Currently IPv4 only.&lt;/p&gt;
-&lt;p&gt;The default value is: "".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;&amp;lt;empty&amp;gt;&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="Verbosity">
@@ -1936,7 +1936,7 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
 &lt;li&gt;&lt;i&gt;finest&lt;/i&gt;: &lt;i&gt;finer&lt;/i&gt; + trace&lt;/li&gt;&lt;/ul&gt;
 &lt;p&gt;While &lt;i&gt;none&lt;/i&gt; prevents any message from being written to a DDSI2 log file.&lt;/p&gt;
 &lt;p&gt;The categorisation of tracing output is incomplete and hence most of the verbosity levels and categories are not of much use in the current release. This is an ongoing process and here we describe the target situation rather than the current situation. Currently, the most useful verbosity levels are &lt;i&gt;config&lt;/i&gt;, &lt;i&gt;fine&lt;/i&gt; and &lt;i&gt;finest&lt;/i&gt;.&lt;/p&gt;
-&lt;p&gt;The default value is: "none".&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;none&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
     <xs:simpleType>
       <xs:restriction base="xs:token">
@@ -1977,9 +1977,9 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
 <!--- generated from ddsi_cfgelems.h[11913cd398f1cd1b52e06d924718df62a5981beb] -->
 <!--- generated from ddsi_config.c[ed9898f72f9dbcfa20ce7706835da091efcea0ca] -->
 <!--- generated from _confgen.h[f2d235d5551cbf920a8a2962831dddeabd2856ac] -->
-<!--- generated from _confgen.c[1193219ddb4769b90566cf197e73d22fb6f75835] -->
+<!--- generated from _confgen.c[ba2e8c0cfd41039421548fdb03bcd2db8f8b172e] -->
 <!--- generated from generate_rnc.c[a2ec6e48d33ac14a320c8ec3f320028a737920e0] -->
-<!--- generated from generate_md.c[a61b6a9649d18afeca4c73b5784f36989d7994e0] -->
-<!--- generated from generate_rst.c[34dcb6b5e2ac2cd15e78497107ce0b6eed6e6e94] -->
+<!--- generated from generate_md.c[37efe4fa9caf56e2647bafc9a7f009f72ff5d2e0] -->
+<!--- generated from generate_rst.c[32da07860a0043708b47e9f793b63ca05f5106bb] -->
 <!--- generated from generate_xsd.c[45064e8869b3c00573057d7c8f02d20f04b40e16] -->
 <!--- generated from generate_defconfig.c[eec9ab7b2d053e68500799b693d089e84153a37b] -->

--- a/src/core/ddsi/defconfig.c
+++ b/src/core/ddsi/defconfig.c
@@ -109,9 +109,9 @@ void ddsi_config_init_default (struct ddsi_config *cfg)
 /* generated from ddsi_cfgelems.h[11913cd398f1cd1b52e06d924718df62a5981beb] */
 /* generated from ddsi_config.c[ed9898f72f9dbcfa20ce7706835da091efcea0ca] */
 /* generated from _confgen.h[f2d235d5551cbf920a8a2962831dddeabd2856ac] */
-/* generated from _confgen.c[1193219ddb4769b90566cf197e73d22fb6f75835] */
+/* generated from _confgen.c[ba2e8c0cfd41039421548fdb03bcd2db8f8b172e] */
 /* generated from generate_rnc.c[a2ec6e48d33ac14a320c8ec3f320028a737920e0] */
-/* generated from generate_md.c[a61b6a9649d18afeca4c73b5784f36989d7994e0] */
-/* generated from generate_rst.c[34dcb6b5e2ac2cd15e78497107ce0b6eed6e6e94] */
+/* generated from generate_md.c[37efe4fa9caf56e2647bafc9a7f009f72ff5d2e0] */
+/* generated from generate_rst.c[32da07860a0043708b47e9f793b63ca05f5106bb] */
 /* generated from generate_xsd.c[45064e8869b3c00573057d7c8f02d20f04b40e16] */
 /* generated from generate_defconfig.c[eec9ab7b2d053e68500799b693d089e84153a37b] */

--- a/src/core/ddsi/defconfig.c
+++ b/src/core/ddsi/defconfig.c
@@ -112,6 +112,6 @@ void ddsi_config_init_default (struct ddsi_config *cfg)
 /* generated from _confgen.c[ba2e8c0cfd41039421548fdb03bcd2db8f8b172e] */
 /* generated from generate_rnc.c[a2ec6e48d33ac14a320c8ec3f320028a737920e0] */
 /* generated from generate_md.c[37efe4fa9caf56e2647bafc9a7f009f72ff5d2e0] */
-/* generated from generate_rst.c[32da07860a0043708b47e9f793b63ca05f5106bb] */
+/* generated from generate_rst.c[50739f627792ef056e2b4feeb20fda4edfcef079] */
 /* generated from generate_xsd.c[45064e8869b3c00573057d7c8f02d20f04b40e16] */
 /* generated from generate_defconfig.c[eec9ab7b2d053e68500799b693d089e84153a37b] */

--- a/src/tools/_confgen/_confgen.c
+++ b/src/tools/_confgen/_confgen.c
@@ -524,7 +524,7 @@ format(
   return 0;
 }
 
-#define DFLTFMT "<p>The default value is: \"%s\".</p>"
+#define DFLTFMT "<p>The default value is: <code>%s</code></p>"
 
 int makedescription(
   struct cfgelem *elem,
@@ -534,7 +534,7 @@ int makedescription(
   if (elem->description) {
     char *src = NULL;
     char *dest = elem->meta.description;
-    const char *dflt = "";
+    const char *dflt = "&lt;empty&gt;";
     size_t len = 0, pos = 0;
     const struct cfgunit *unit = NULL;
 
@@ -542,7 +542,10 @@ int makedescription(
       src = strdup(elem->description);
     } else {
       if (elem->value)
-        dflt = elem->value;
+      {
+        if (strlen(elem->value) > 0)
+          dflt = elem->value;
+      }
       if (elem->meta.unit) {
         unit = findunit(units, elem->meta.unit);
         assert(unit);

--- a/src/tools/_confgen/generate_md.c
+++ b/src/tools/_confgen/generate_md.c
@@ -26,6 +26,8 @@ static const char *xlatmd(const char *str, const char **end)
     { "<li>", " * " }, { "</li>", "\n" },
     { "<ul>", "" }, { "</ul>", "" },
     { "<sup>", "^" }, { "</sup>", "" },
+    { "<code>", "`" }, { "</code>", "`" },
+    { "&lt;empty&gt;", "<empty>" },
     { "*", "\\*" }, { "_", "\\_" },
     { NULL, NULL }
   };

--- a/src/tools/_confgen/generate_rst.c
+++ b/src/tools/_confgen/generate_rst.c
@@ -26,7 +26,7 @@ static const char *xlatmd(const char *str, const char **end)
     { "<li>", " * " }, { "</li>", "\n" },
     { "<ul>", "" }, { "</ul>", "\n" },
     { "<sup>", "^" }, { "</sup>", "" },
-    { "<code>", "`" }, { "</code>", "`" },
+    { "<code>", "``" }, { "</code>", "``" },
     { "&lt;empty&gt;", "<empty>" },
     { "*", "\\*" }, { "_", "\\_" },
     { NULL, NULL }

--- a/src/tools/_confgen/generate_rst.c
+++ b/src/tools/_confgen/generate_rst.c
@@ -26,6 +26,8 @@ static const char *xlatmd(const char *str, const char **end)
     { "<li>", " * " }, { "</li>", "\n" },
     { "<ul>", "" }, { "</ul>", "\n" },
     { "<sup>", "^" }, { "</sup>", "" },
+    { "<code>", "`" }, { "</code>", "`" },
+    { "&lt;empty&gt;", "<empty>" },
     { "*", "\\*" }, { "_", "\\_" },
     { NULL, NULL }
   };


### PR DESCRIPTION
Add the default value in the configuration guide as a code fragment, so that it is clear that the value does not include quotes. 

Related to https://github.com/eclipse-cyclonedds/cyclonedds/issues/1454#issuecomment-1290228361
