### PR TITLE
Use SHA256 digest when generating ddssec testing CA

### DIFF
--- a/src/security/core/tests/common/cert_utils.c
+++ b/src/security/core/tests/common/cert_utils.c
@@ -44,6 +44,7 @@ static char * get_x509_data(X509 * cert)
   BIO *output_bio = BIO_new (BIO_s_mem ());
   if (!PEM_write_bio_X509 (output_bio, cert)) {
     printf ("Error writing certificate\n");
+    ERR_print_errors_fp (stderr);
     CU_ASSERT_FATAL (false);
   }
 
@@ -87,7 +88,7 @@ char * generate_ca(const char *ca_name, const char * ca_priv_key_str, int not_va
 
   X509_set_pubkey (ca_cert, ca_priv_key);
   X509_set_issuer_name (ca_cert, X509_get_subject_name (ca_cert)); /* self-signed */
-  X509_sign (ca_cert, ca_priv_key, EVP_sha1 ());
+  X509_sign (ca_cert, ca_priv_key, EVP_sha256 ());
   char * output = get_x509_data (ca_cert);
 
   EVP_PKEY_free (ca_priv_key);


### PR DESCRIPTION
RHEL 9 has disabled the (broken) SHA1 digest by default, resulting in 15 test failures in CycloneDDS. Switching the testing CA to use SHA256 made all of the tests pass.

With the error printing call I added to the failing routine, the following OpenSSL errors were printed:
```
806FAA1CB97F0000:error:03000098:digital envelope routines:do_sigver_init:invalid digest:crypto/evp/m_sigver.c:343:
806FAA1CB97F0000:error:068000DE:asn1 encoding routines:asn1_template_ex_i2d:illegal zero content:crypto/asn1/tasn_enc.c:374:
806FAA1CB97F0000:error:0488000D:PEM routines:PEM_ASN1_write_bio:ASN1 lib:crypto/pem/pem_lib.c:341:
```

In particular, `invalid digest` tipped me off and I traced the certificates digest generation to the `EVP_sha1` call.

I'd like to see this change backported to the `releases/0.9.x` branch which is in use by ROS 2 Rolling.