### PR TITLE
Small mistake in ti_to_pairs_equal.

### DIFF
--- a/src/core/ddsi/src/ddsi_typelib.c
+++ b/src/core/ddsi/src/ddsi_typelib.c
@@ -261,7 +261,7 @@ static bool ti_to_pairs_equal (const dds_sequence_DDS_XTypes_TypeIdentifierTypeO
     dds_ostream_t to_a_ser = { NULL, 0, 0, DDSI_RTPS_CDR_ENC_VERSION_2 };
     dds_ostream_t to_b_ser = { NULL, 0, 0, DDSI_RTPS_CDR_ENC_VERSION_2 };
     dds_stream_write_sample (&to_a_ser, &a->_buffer[n].type_object, &desc);
-    dds_stream_write_sample (&to_b_ser, &b->_buffer[n].type_object, &desc);
+    dds_stream_write_sample (&to_b_ser, to_b, &desc);
     if (to_a_ser.m_index != to_b_ser.m_index)
       return false;
     if (memcmp (to_a_ser.m_buffer, to_b_ser.m_buffer, to_a_ser.m_index))


### PR DESCRIPTION
The Python fuzzer led me to this small typo in the ti_to_pairs_equal function.