### PR TITLE
Fix tkmap_instance leak in WHC

### DIFF
--- a/docs/manual/config/cyclonedds_specifics.rst
+++ b/docs/manual/config/cyclonedds_specifics.rst
@@ -145,42 +145,6 @@ linger duration has elapsed, whichever comes first.
   is requested to terminate.
 
 
-.. _`Start-up mode`:
-
-=============
-Start-up Mode
-=============
-
-A similar issue exists when starting |var-project-short|: DDSI discovery takes time, and when
-data is written immediately after the first participant was created, it is likely that
-the discovery process hasn't been completed yet, and some remote Readers have not yet been
-discovered. This would cause the Writers to throw away samples for lack of interest,
-even though matching Readers already existed at the starting time. For best-effort
-Writers, this is perhaps surprising but still acceptable; for reliable Writers, however,
-it would be very counter-intuitive.
-
-Hence, in the so-called *start-up mode*, all volatile reliable Writers are
-treated as transient-local Writers. Transient-local data is meant to ensure
-samples are available to late-joining Readers. The start-up mode uses this exact
-mechanism to ensure late-discovered Readers will also receive the data. This treatment of
-volatile data as-if it were transient-local happens internally and is invisible to the
-outside world, other than the availability of some samples that would not otherwise be available.
-
-Once the initial discovery has been completed, new local Writers can be matched locally against
-existing Readers. Consequently, new samples are published in a Writers history cache because
-these existing Readers have not acknowledged them yet. Hence, this mode is tied to the start-up
-of the DDSI stack rather than an individual Writer.
-
-Unfortunately, it is impossible to detect with certainty when the initial discovery process has
-been completed, and therefore an option controls the duration of this start-up mode:
-``General/StartupModeDuration``.
-
-Although the start-up mode is generally beneficial, its downside is that the Writers history
-caches can grow significantly larger than expected during the start-up period. Consequently,
-the extensive amounts of historical data may be transferred to Readers and discovered relatively
-late in the process.
-
-
 .. _`Writer history QoS and throttling`:
 
 =================================

--- a/src/core/ddsc/src/dds_whc.c
+++ b/src/core/ddsc/src/dds_whc.c
@@ -521,7 +521,10 @@ void whc_default_free (struct ddsi_whc *whc_generic)
   struct ddsrt_hh_iter it;
   struct whc_idxnode *idxn;
   for (idxn = ddsrt_hh_iter_first (whc->idx_hash, &it); idxn != NULL; idxn = ddsrt_hh_iter_next (&it))
+  {
+    ddsi_tkmap_instance_unref (whc->tkmap, idxn->tk);
     ddsrt_free (idxn);
+  }
   ddsrt_hh_free (whc->idx_hash);
 
   {
@@ -668,6 +671,7 @@ static void free_one_instance_from_idx (struct whc_impl *whc, ddsi_seqno_t max_d
       }
     }
   }
+  ddsi_tkmap_instance_unref (whc->tkmap, idxn->tk);
   ddsrt_free (idxn);
 }
 

--- a/src/core/ddsc/src/dds_whc_builtintopic.c
+++ b/src/core/ddsc/src/dds_whc_builtintopic.c
@@ -248,13 +248,6 @@ static int bwhc_insert (struct ddsi_whc *whc, ddsi_seqno_t max_drop_seq, ddsi_se
   return 0;
 }
 
-static uint32_t bwhc_downgrade_to_volatile (struct ddsi_whc *whc, struct ddsi_whc_state *st)
-{
-  (void)whc;
-  (void)st;
-  return 0;
-}
-
 static uint32_t bwhc_remove_acked_messages (struct ddsi_whc *whc, ddsi_seqno_t max_drop_seq, struct ddsi_whc_state *whcst, struct ddsi_whc_node **deferred_free_list)
 {
   (void)whc;
@@ -281,7 +274,6 @@ static const struct ddsi_whc_ops bwhc_ops = {
   .return_sample = 0,
   .sample_iter_init = bwhc_sample_iter_init,
   .sample_iter_borrow_next = bwhc_sample_iter_borrow_next,
-  .downgrade_to_volatile = bwhc_downgrade_to_volatile,
   .free = bwhc_free
 };
 

--- a/src/core/ddsi/include/dds/ddsi/ddsi_whc.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_whc.h
@@ -79,7 +79,6 @@ typedef void (*whc_free_t)(struct ddsi_whc *whc);
 /* max_drop_seq must go soon, it's way too ugly. */
 /* plist may be NULL or ddsrt_malloc'd, WHC takes ownership of plist */
 typedef int (*ddsi_whc_insert_t)(struct ddsi_whc *whc, ddsi_seqno_t max_drop_seq, ddsi_seqno_t seq, ddsrt_mtime_t exp, struct ddsi_serdata *serdata, struct ddsi_tkmap_instance *tk);
-typedef uint32_t (*ddsi_whc_downgrade_to_volatile_t)(struct ddsi_whc *whc, struct ddsi_whc_state *st);
 typedef uint32_t (*ddsi_whc_remove_acked_messages_t)(struct ddsi_whc *whc, ddsi_seqno_t max_drop_seq, struct ddsi_whc_state *whcst, struct ddsi_whc_node **deferred_free_list);
 typedef void (*ddsi_whc_free_deferred_free_list_t)(struct ddsi_whc *whc, struct ddsi_whc_node *deferred_free_list);
 
@@ -94,7 +93,6 @@ struct ddsi_whc_ops {
   ddsi_whc_return_sample_t return_sample;
   ddsi_whc_sample_iter_init_t sample_iter_init;
   ddsi_whc_sample_iter_borrow_next_t sample_iter_borrow_next;
-  ddsi_whc_downgrade_to_volatile_t downgrade_to_volatile;
   whc_free_t free;
 };
 

--- a/src/core/ddsi/src/ddsi__whc.h
+++ b/src/core/ddsi/src/ddsi__whc.h
@@ -51,9 +51,6 @@ inline void ddsi_whc_free (struct ddsi_whc *whc) {
 inline int ddsi_whc_insert (struct ddsi_whc *whc, ddsi_seqno_t max_drop_seq, ddsi_seqno_t seq, ddsrt_mtime_t exp, struct ddsi_serdata *serdata, struct ddsi_tkmap_instance *tk) {
   return whc->ops->insert (whc, max_drop_seq, seq, exp, serdata, tk);
 }
-inline unsigned ddsi_whc_downgrade_to_volatile (struct ddsi_whc *whc, struct ddsi_whc_state *st) {
-  return whc->ops->downgrade_to_volatile (whc, st);
-}
 inline unsigned ddsi_whc_remove_acked_messages (struct ddsi_whc *whc, ddsi_seqno_t max_drop_seq, struct ddsi_whc_state *whcst, struct ddsi_whc_node **deferred_free_list) {
   return whc->ops->remove_acked_messages (whc, max_drop_seq, whcst, deferred_free_list);
 }

--- a/src/core/ddsi/src/ddsi_whc.c
+++ b/src/core/ddsi/src/ddsi_whc.c
@@ -21,6 +21,5 @@ extern inline void ddsi_whc_sample_iter_init (const struct ddsi_whc *whc, struct
 extern inline bool ddsi_whc_sample_iter_borrow_next (struct ddsi_whc_sample_iter *it, struct ddsi_whc_borrowed_sample *sample);
 extern inline void ddsi_whc_free (struct ddsi_whc *whc);
 extern int ddsi_whc_insert (struct ddsi_whc *whc, ddsi_seqno_t max_drop_seq, ddsi_seqno_t seq, ddsrt_mtime_t exp, struct ddsi_serdata *serdata, struct ddsi_tkmap_instance *tk);
-extern unsigned ddsi_whc_downgrade_to_volatile (struct ddsi_whc *whc, struct ddsi_whc_state *st);
 extern unsigned ddsi_whc_remove_acked_messages (struct ddsi_whc *whc, ddsi_seqno_t max_drop_seq, struct ddsi_whc_state *whcst, struct ddsi_whc_node **deferred_free_list);
 extern void ddsi_whc_free_deferred_free_list (struct ddsi_whc *whc, struct ddsi_whc_node *deferred_free_list);


### PR DESCRIPTION
Fixes #1487 

A few tests keel over when asserting that the instance map is empty on shutdown, and it appears that these can be traced back to some "oddities" in registering and unregistering instances. That's some really old code that needs some TLC because it really is not quite correct (even if it mostly works ok).

So this PR simply fixes the leak. I'll create an issue for the other thing.