### PR TITLE
Fixes for build with SSM disabled

### DIFF
--- a/src/core/ddsc/tests/xtypes.c
+++ b/src/core/ddsc/tests/xtypes.c
@@ -592,7 +592,11 @@ static void test_proxy_rd_create (struct ddsi_domaingv *gv, const char *topic_na
   CU_ASSERT_FATAL (rc);
 
   ddsi_xqos_mergein_missing (&plist->qos, &ddsi_default_qos_reader, ~(uint64_t)0);
+#ifdef DDS_HAS_SSM
   rc = ddsi_new_proxy_reader (gv, pp_guid, rd_guid, as, plist, ddsrt_time_wallclock (), 1, 0);
+#else
+  rc = ddsi_new_proxy_reader (gv, pp_guid, rd_guid, as, plist, ddsrt_time_wallclock (), 1);
+#endif
   CU_ASSERT_EQUAL_FATAL (rc, exp_ret);
   ddsi_plist_fini (plist);
   ddsrt_free (plist);

--- a/src/core/ddsi/include/dds/ddsi/ddsi_xqos.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_xqos.h
@@ -14,6 +14,8 @@
 
 #include "dds/features.h"
 
+#include "dds/ddsrt/retcode.h"
+#include "dds/ddsrt/time.h"
 #include "dds/ddsc/dds_public_qosdefs.h"
 #include "dds/ddsi/ddsi_protocol.h"
 #include "dds/ddsi/ddsi_log.h"


### PR DESCRIPTION
In case the cmake configuration option `ENABLE_SOURCE_SPECIFIC_MULTICAST` is disabled:
- In `ddsi_xqos.h` the header `ddsrt/sockets.h` is not included (via `ddsi_protocol.h`, `dds_feature_check.h`), and therefore has no definition for `dds_duration_t` and `dds_retcode_t`. This PR adds the missing includes in `ddsi_xqos.h`. 
- One of the xtypes tests was not taking the SSM build option into account when calling `ddsi_new_proxy_reader`, that is fixed in the other commit in this PR. 

It's clear that we need a better check for building with combinations of build options when merging PRs, an issue is created for this: https://github.com/eclipse-cyclonedds/cyclonedds/issues/1498
