### PR TITLE
Align the upstream change of renaming Iceoryx_LogLevel_Verbose to Iceoryx_LogLevel_Trace

### DIFF
--- a/src/core/ddsi/src/ddsi_shm_transport.c
+++ b/src/core/ddsi/src/ddsi_shm_transport.c
@@ -56,7 +56,7 @@ static enum iox_LogLevel to_iox_loglevel(enum ddsi_shm_loglevel level) {
         case DDSI_SHM_WARN : return Iceoryx_LogLevel_Warn;
         case DDSI_SHM_INFO : return Iceoryx_LogLevel_Info;
         case DDSI_SHM_DEBUG : return Iceoryx_LogLevel_Debug;
-        case DDSI_SHM_VERBOSE : return Iceoryx_LogLevel_Verbose;
+        case DDSI_SHM_VERBOSE : return Iceoryx_LogLevel_Trace;
     }
     return Iceoryx_LogLevel_Off;
 }


### PR DESCRIPTION
As title. To prevent the compiling error due to [the latest change 28. on the master branch of iceoryx](https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md).
