### PR TITLE
Export default participant QoS

### DIFF
--- a/src/core/ddsc/src/dds_participant.c
+++ b/src/core/ddsc/src/dds_participant.c
@@ -113,7 +113,7 @@ dds_entity_t dds_create_participant (const dds_domainid_t domain, const dds_qos_
   new_qos = dds_create_qos ();
   if (qos != NULL)
     ddsi_xqos_mergein_missing (new_qos, qos, DDS_PARTICIPANT_QOS_MASK);
-  ddsi_xqos_mergein_missing (new_qos, &dom->gv.default_local_plist_pp.qos, ~(uint64_t)0);
+  ddsi_xqos_mergein_missing (new_qos, &dom->gv.default_local_xqos_pp, ~(uint64_t)0);
   dds_apply_entity_naming(new_qos, NULL, &dom->gv);
 
   if ((ret = ddsi_xqos_valid (&dom->gv.logconfig, new_qos)) < 0)

--- a/src/core/ddsi/include/dds/ddsi/ddsi_domaingv.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_domaingv.h
@@ -240,7 +240,7 @@ struct ddsi_domaingv {
      supplying values for missing QoS settings in incoming discovery
      packets); plus the actual QoSs needed for the builtin
      endpoints. */
-  ddsi_plist_t default_local_plist_pp;
+  dds_qos_t default_local_xqos_pp;
   dds_qos_t spdp_endpoint_xqos;
   dds_qos_t builtin_endpoint_xqos_rd;
   dds_qos_t builtin_endpoint_xqos_wr;

--- a/src/core/ddsi/include/dds/ddsi/ddsi_xqos.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_xqos.h
@@ -295,6 +295,7 @@ DDS_EXPORT extern const dds_qos_t ddsi_default_qos_reader;
 DDS_EXPORT extern const dds_qos_t ddsi_default_qos_writer;
 DDS_EXPORT extern const dds_qos_t ddsi_default_qos_topic;
 DDS_EXPORT extern const dds_qos_t ddsi_default_qos_publisher_subscriber;
+DDS_EXPORT extern const dds_qos_t ddsi_default_qos_participant;
 
 /**
  * @brief Initialize a new empty dds_qos_t as an empty object

--- a/src/core/ddsi/src/ddsi__plist.h
+++ b/src/core/ddsi/src/ddsi__plist.h
@@ -88,8 +88,6 @@ struct ddsi_plist_sample {
   ddsi_parameterid_t keyparam;
 };
 
-extern const ddsi_plist_t ddsi_default_plist_participant;
-
 /**
  * @brief Initialize global parameter-list parsing indices.
  *

--- a/src/core/ddsi/src/ddsi_discovery.c
+++ b/src/core/ddsi/src/ddsi_discovery.c
@@ -505,7 +505,7 @@ void ddsi_get_participant_builtin_topic_data (const struct ddsi_participant *pp,
 #endif
 
   /* Participant QoS's insofar as they are set, different from the default, and mapped to the SPDP data, rather than to the Adlink-specific CMParticipant endpoint. */
-  qosdiff = ddsi_xqos_delta (&pp->plist->qos, &ddsi_default_plist_participant.qos, DDSI_QP_USER_DATA | DDSI_QP_ENTITY_NAME | DDSI_QP_PROPERTY_LIST | DDSI_QP_LIVELINESS);
+  qosdiff = ddsi_xqos_delta (&pp->plist->qos, &ddsi_default_qos_participant, DDSI_QP_USER_DATA | DDSI_QP_ENTITY_NAME | DDSI_QP_PROPERTY_LIST | DDSI_QP_LIVELINESS);
   if (pp->e.gv->config.explicitly_publish_qos_set_to_default)
     qosdiff |= ~(DDSI_QP_UNRECOGNIZED_INCOMPATIBLE_MASK | DDSI_QP_LIVELINESS);
 
@@ -853,8 +853,8 @@ static int handle_spdp_alive (const struct ddsi_receiver_state *rst, ddsi_seqno_
     lease_duration = datap->qos.liveliness.lease_duration;
   else
   {
-    assert (ddsi_default_plist_participant.qos.present & DDSI_QP_LIVELINESS);
-    lease_duration = ddsi_default_plist_participant.qos.liveliness.lease_duration;
+    assert (ddsi_default_qos_participant.present & DDSI_QP_LIVELINESS);
+    lease_duration = ddsi_default_qos_participant.liveliness.lease_duration;
   }
   /* If any of the SEDP announcer are missing AND the guid prefix of
      the SPDP writer differs from the guid prefix of the new participant,

--- a/src/core/ddsi/src/ddsi_participant.c
+++ b/src/core/ddsi/src/ddsi_participant.c
@@ -847,7 +847,7 @@ static dds_return_t new_participant_guid (ddsi_guid_t *ppguid, struct ddsi_domai
   ddsrt_fibheap_init (&ddsi_ldur_fhdef, &pp->ldur_auto_wr);
   pp->plist = ddsrt_malloc (sizeof (*pp->plist));
   ddsi_plist_copy (pp->plist, plist);
-  ddsi_plist_mergein_missing (pp->plist, &gv->default_local_plist_pp, ~(uint64_t)0, ~(uint64_t)0);
+  ddsi_xqos_mergein_missing(&pp->plist->qos, &gv->default_local_xqos_pp, ~(uint64_t)0);
 
 #ifdef DDS_HAS_SECURITY
   pp->sec_attr = NULL;

--- a/src/core/ddsi/src/ddsi_plist.c
+++ b/src/core/ddsi/src/ddsi_plist.c
@@ -3541,20 +3541,6 @@ void ddsi_xqos_init_empty (dds_qos_t *dest)
   dest->present = dest->aliased = 0;
 }
 
-const ddsi_plist_t ddsi_default_plist_participant = {
-  .present = 0,
-  .aliased = 0,
-  .qos = {
-    .present = DDSI_QP_ADLINK_ENTITY_FACTORY | DDSI_QP_USER_DATA | DDSI_QP_LIVELINESS,
-    .aliased = 0,
-    .entity_factory.autoenable_created_entities = 0,
-    .user_data.length = 0,
-    .user_data.value = NULL,
-    .liveliness.kind = DDS_LIVELINESS_AUTOMATIC,
-    .liveliness.lease_duration = DDS_SECS (100)
-  }
-};
-
 const dds_qos_t ddsi_default_qos_reader = {
   .present = DDSI_QP_PRESENTATION | DDSI_QP_DURABILITY | DDSI_QP_DEADLINE | DDSI_QP_LATENCY_BUDGET | DDSI_QP_LIVELINESS | DDSI_QP_DESTINATION_ORDER | DDSI_QP_HISTORY | DDSI_QP_RESOURCE_LIMITS | DDSI_QP_TRANSPORT_PRIORITY | DDSI_QP_OWNERSHIP | DDSI_QP_CYCLONE_IGNORELOCAL | DDSI_QP_TOPIC_DATA | DDSI_QP_GROUP_DATA | DDSI_QP_USER_DATA | DDSI_QP_PARTITION | DDSI_QP_RELIABILITY | DDSI_QP_TIME_BASED_FILTER | DDSI_QP_ADLINK_READER_DATA_LIFECYCLE | DDSI_QP_ADLINK_READER_LIFESPAN | DDSI_QP_TYPE_CONSISTENCY_ENFORCEMENT | DDSI_QP_LOCATOR_MASK | DDSI_QP_DATA_REPRESENTATION,
   .aliased = DDSI_QP_DATA_REPRESENTATION,
@@ -3688,6 +3674,16 @@ const dds_qos_t ddsi_default_qos_publisher_subscriber = {
   .group_data.value = NULL,
   .partition.n = 0,
   .partition.strs = NULL
+};
+
+const dds_qos_t ddsi_default_qos_participant= {
+  .present = DDSI_QP_ADLINK_ENTITY_FACTORY | DDSI_QP_USER_DATA | DDSI_QP_LIVELINESS,
+  .aliased = 0,
+  .entity_factory.autoenable_created_entities = 0,
+  .user_data.length = 0,
+  .user_data.value = NULL,
+  .liveliness.kind = DDS_LIVELINESS_AUTOMATIC,
+  .liveliness.lease_duration = DDS_SECS (100)
 };
 
 void ddsi_xqos_copy (dds_qos_t *dst, const dds_qos_t *src)

--- a/src/core/ddsi/src/ddsi_proxy_participant.c
+++ b/src/core/ddsi/src/ddsi_proxy_participant.c
@@ -434,7 +434,7 @@ bool ddsi_new_proxy_participant (struct ddsi_domaingv *gv, const struct ddsi_gui
   ddsrt_avl_init (&ddsi_proxypp_proxytp_treedef, &proxypp->topics);
 #endif
   proxypp->plist = ddsi_plist_dup (plist);
-  ddsi_xqos_mergein_missing (&proxypp->plist->qos, &ddsi_default_plist_participant.qos, ~(uint64_t)0);
+  ddsi_xqos_mergein_missing (&proxypp->plist->qos, &ddsi_default_qos_participant, ~(uint64_t)0);
 
 #ifdef DDS_HAS_SECURITY
   proxypp->sec_attr = NULL;
@@ -487,7 +487,7 @@ int ddsi_update_proxy_participant_plist_locked (struct ddsi_proxy_participant *p
     ddsi_plist_t *new_plist = ddsrt_malloc (sizeof (*new_plist));
     ddsi_plist_init_empty (new_plist);
     ddsi_plist_mergein_missing (new_plist, datap, pmask, qmask);
-    ddsi_plist_mergein_missing (new_plist, &ddsi_default_plist_participant, ~(uint64_t)0, ~(uint64_t)0);
+    ddsi_xqos_mergein_missing(&new_plist->qos, &ddsi_default_qos_participant,~(uint64_t)0);
     (void) ddsi_update_qos_locked (&proxypp->e, &proxypp->plist->qos, &new_plist->qos, timestamp);
     ddsi_plist_fini (new_plist);
     ddsrt_free (new_plist);


### PR DESCRIPTION
Currently the default participant QoS is hardcoded inside ddsi_default_plist_participant, and not exported in the libraries To make this follow the same pattern as the default reader/writer/etc QoSes, the ddsi_default_qos_participant was created As a side effect, the ddsi_default_plist_participant was no longer necessary, as only its QoS component was used
The code was changed to use the default participant QoS in the places where the ddsi_default_plist_participant was used previously

Signed-off-by: Martijn Reicher <martijn.reicher@zettascale.tech>