### PR TITLE
Add cdr/include to include path building fuzzers

### DIFF
--- a/fuzz/fuzz_config_init/CMakeLists.txt
+++ b/fuzz/fuzz_config_init/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(fuzz_config_init fuzz_config_init.c)
 target_include_directories(
   fuzz_config_init PRIVATE
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../src/core/ddsc/src>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../src/core/cdr/include>"
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../src/core/ddsi/include>"
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../src/core/ddsi/src>")
 target_link_libraries(fuzz_config_init CycloneDDS::ddsc $ENV{LIB_FUZZING_ENGINE})

--- a/fuzz/fuzz_handle_rtps_message/CMakeLists.txt
+++ b/fuzz/fuzz_handle_rtps_message/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(fuzz_handle_rtps_message fuzz_handle_rtps_message.c)
 target_include_directories(
   fuzz_handle_rtps_message PRIVATE
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../src/core/ddsc/src>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../src/core/cdr/include>"
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../src/core/ddsi/src>"
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../src/core/ddsi/include>")
 target_link_libraries(fuzz_handle_rtps_message CycloneDDS::ddsc $ENV{LIB_FUZZING_ENGINE})


### PR DESCRIPTION
Should fix OSS-Fuzz build failures (it does locally for me).