### PR TITLE
Fix ShmThroughput demo help and documentation

### DIFF
--- a/examples/shm_throughput/readme.rst
+++ b/examples/shm_throughput/readme.rst
@@ -75,7 +75,7 @@ It is recommended that you run the publisher and subscriber in separate terminal
 - In the second terminal start the subscriber by running ShmThroughputSubscriber
 
   subscriber usage (parameters must be supplied in order):
-    ``./ShmThroughputSubscriber [maxCycles (0=infinite)] [pollingDelay (ms, 0 = event based)] [partitionName] [payloadSize (bytes]``
+    ``./ShmThroughputSubscriber [maxCycles (0=infinite)] [pollingDelay (ms, 0 = event based)] [partitionName] [payloadSize (bytes)]``
   defaults:
     ``./ShmThroughputSubscriber 0 0 "Throughput example" 8192``
 
@@ -85,14 +85,14 @@ It is recommended that you run the publisher and subscriber in separate terminal
   publisher usage:
     ``taskset -c 0 chrt -f 80 ./ShmThroughputPublisher [payloadSize (bytes)] [burstInterval (ms)] [burstSize (samples)] [timeOut (seconds)] [partitionName]``
   subscriber usage:
-    ``taskset -c 1 chrt -f 80 ./ShmThroughputSubscriber [maxCycles (0 = infinite)] [pollingDelay (ms, 0 = event based)] [partitionName] [payloadSize (bytes]``
+    ``taskset -c 1 chrt -f 80 ./ShmThroughputSubscriber [maxCycles (0 = infinite)] [pollingDelay (ms, 0 = event based)] [partitionName] [payloadSize (bytes)]``
 
   On Windows the CPU affinity and prioritized scheduling class can be set as follows:
 
   publisher usage:
     ``START /affinity 1 /high cmd /k "ShmThroughputPublisher.exe" [payloadSize (bytes)] [burstInterval (ms)] [burstSize (samples)] [timeOut (seconds)] [partitionName]``
   subscriber usage:
-    ``START /affinity 2 /high cmd /k "ShmThroughputSubscriber.exe" [maxCycles (0 = infinite)] [pollingDelay (ms, 0 = event based)] [partitionName] [payloadSize (bytes]``
+    ``START /affinity 2 /high cmd /k "ShmThroughputSubscriber.exe" [maxCycles (0 = infinite)] [pollingDelay (ms, 0 = event based)] [partitionName] [payloadSize (bytes)]``
 
 
 

--- a/examples/shm_throughput/shmpublisher.c
+++ b/examples/shm_throughput/shmpublisher.c
@@ -150,14 +150,14 @@ static int parse_args(
   int result = EXIT_SUCCESS;
   /*
    * Get the program parameters
-   * Parameters: publisher [payloadSize] [burstInterval] [burstSize] [timeOut] [partitionName]
+   * Parameters: ShmThroughputPublisher [payloadSize] [burstInterval] [burstSize] [timeOut] [partitionName]
    */
   if (argc == 2 && (strcmp (argv[1], "-h") == 0 || strcmp (argv[1], "--help") == 0))
   {
     printf ("Usage (parameters must be supplied in order):\n");
-    printf ("./publisher [payloadSize (bytes)] [burstInterval (ms)] [burstSize (samples)] [timeOut (seconds)] [partitionName]\n");
+    printf ("./ShmThroughputPublisher [payloadSize (bytes)] [burstInterval (ms)] [burstSize (samples)] [timeOut (seconds)] [partitionName]\n");
     printf ("Defaults:\n");
-    printf ("./publisher 8192 0 1 0 \"Throughput example\"\n");
+    printf ("./ShmThroughputPublisher 8192 0 1 0 \"Throughput example\"\n");
     return EXIT_FAILURE;
   }
   if (argc > 1)

--- a/examples/shm_throughput/shmsubscriber.c
+++ b/examples/shm_throughput/shmsubscriber.c
@@ -214,14 +214,14 @@ static int parse_args(int argc, char **argv, unsigned long long *maxCycles, char
 {
   /*
    * Get the program parameters
-   * Parameters: subscriber [maxCycles] [pollingDelay] [partitionName]
+   * Parameters: ShmThroughputSubscriber [maxCycles] [pollingDelay] [partitionName] [payloadSize]
    */
   if (argc == 2 && (strcmp (argv[1], "-h") == 0 || strcmp (argv[1], "--help") == 0))
   {
     printf ("Usage (parameters must be supplied in order):\n");
-    printf ("./subscriber [maxCycles (0 = infinite)] [pollingDelay (ms, 0 = waitset, -1 = listener)] [partitionName] [payloadSize (bytes)] \n");
+    printf ("./ShmThroughputSubscriber [maxCycles (0 = infinite)] [pollingDelay (ms, 0 = waitset, -1 = listener)] [partitionName] [payloadSize (bytes)] \n");
     printf ("Defaults:\n");
-    printf ("./subscriber 0 0 \"Throughput example\" 8192\n");
+    printf ("./ShmThroughputSubscriber 0 0 \"Throughput example\" 8192\n");
     return EXIT_FAILURE;
   }
 

--- a/examples/shm_throughput/shmsubscriber.c
+++ b/examples/shm_throughput/shmsubscriber.c
@@ -219,9 +219,9 @@ static int parse_args(int argc, char **argv, unsigned long long *maxCycles, char
   if (argc == 2 && (strcmp (argv[1], "-h") == 0 || strcmp (argv[1], "--help") == 0))
   {
     printf ("Usage (parameters must be supplied in order):\n");
-    printf ("./subscriber [maxCycles (0 = infinite)] [pollingDelay (ms, 0 = waitset, -1 = listener)] [partitionName]\n");
+    printf ("./subscriber [maxCycles (0 = infinite)] [pollingDelay (ms, 0 = waitset, -1 = listener)] [partitionName] [payloadSize (bytes)] \n");
     printf ("Defaults:\n");
-    printf ("./subscriber 0 0 \"Throughput example\"\n");
+    printf ("./subscriber 0 0 \"Throughput example\" 8192\n");
     return EXIT_FAILURE;
   }
 


### PR DESCRIPTION
Most importantly, the payload size option should be printed when doing `./ShmThroughputSubscriber --help`. Furthermore, a few typo fixes in the readme file and documentation.