### PR TITLE
Fix crash caused by security overall timeout race

### DIFF
--- a/src/security/core/src/dds_security_fsm.c
+++ b/src/security/core/src/dds_security_fsm.c
@@ -268,7 +268,6 @@ static void fsm_state_change (struct dds_security_fsm_control *control, struct f
 static void fsm_handle_timeout (struct dds_security_fsm_control *control, struct fsm_timer_event *timer_event)
 {
   struct dds_security_fsm *fsm = timer_event->fsm;
-
   switch (timer_event->kind)
   {
   case FSM_TIMEOUT_STATE:
@@ -283,9 +282,6 @@ static void fsm_handle_timeout (struct dds_security_fsm_control *control, struct
       ddsrt_cond_broadcast(&control->cond);
     break;
   }
-
-  /* mark timer event as being processed */
-  timer_event->endtime = DDS_NEVER;
 }
 
 static uint32_t handle_events (struct dds_security_fsm_control *control)
@@ -315,6 +311,8 @@ static uint32_t handle_events (struct dds_security_fsm_control *control)
       else
       {
         struct fsm_timer_event *timer_event = ddsrt_fibheap_extract_min (&timer_events_fhdef, &control->timers);
+        /* set endtime to NEVER to maintain the invariant that (on heap) <=> (endtime != NEVER) */
+        timer_event->endtime = DDS_NEVER;
         fsm_handle_timeout (control, timer_event);
       }
     }


### PR DESCRIPTION
This fixes a race condition in handling the "overall timeout" in the security (handshake) state machinery: we get here

  cyclonedds/src/security/core/src/dds_security_fsm.c
  Lines 317 to 318 in 37c25f2
    struct fsm_timer_event *timer_event =
      ddsrt_fibheap_extract_min (&timer_events_fhdef, &control->timers);
    fsm_handle_timeout (control, timer_event);

so at the point of calling the handler, the "overall timeout" event is no longer on the heap but the endtime is still < infinity, which means the invariant that "endtime = infinity" <=> "timeout event not on heap" doesn't hold at this point.

The handler code does update it, attempting to restore the invariant, except it does this after allowing arbitrary state changes:

  cyclonedds/src/security/core/src/dds_security_fsm.c
  Lines 277 to 288 in 37c25f2
    case FSM_TIMEOUT_OVERALL:
      ddsrt_mutex_unlock (&control->lock);
      if (fsm->overall_timeout_action)
        fsm->overall_timeout_action (fsm, fsm->arg);
      ddsrt_mutex_lock (&control->lock);
      ...
  timer_event->endtime = DDS_NEVER;

So any code that manipulates this timeout will do the wrong thing: it can fail to set a new timeout, or it can call ddsrt_fibheap_delete to remove a timeout event from the heap that is no longer on it.  Both lead to disaster, and both can happen.

Fixes #1548