### PR TITLE
Add support for (u)int8 type kind in IDLC and type library

### DIFF
--- a/src/core/ddsi/idl/ddsi_xt_typeinfo.idl
+++ b/src/core/ddsi/idl/ddsi_xt_typeinfo.idl
@@ -25,6 +25,8 @@ module DDS { module XTypes {
     const octet TK_FLOAT32    = 0x09;
     const octet TK_FLOAT64    = 0x0A;
     const octet TK_FLOAT128   = 0x0B;
+    const octet TK_INT8       = 0x0C; // XTypes 1.3 spec Annex B
+    const octet TK_UINT8      = 0x0D; // XTypes 1.3 spec Annex B
     const octet TK_CHAR8      = 0x10;
     const octet TK_CHAR16     = 0x11;
 
@@ -351,6 +353,10 @@ module DDS { module XTypes {
             boolean             boolean_value;
         case TK_BYTE:
             octet               byte_value;
+        case TK_INT8:  // XTypes 1.3 spec Annex B
+            int8                int8_value;
+        case TK_UINT8:  // XTypes 1.3 spec Annex B
+            uint8               uint8_value;
         case TK_INT16:
             short               int16_value;
         case TK_UINT16:

--- a/src/core/ddsi/include/dds/ddsi/ddsi_xt_typeinfo.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_xt_typeinfo.h
@@ -41,6 +41,8 @@ typedef uint8_t DDS_XTypes_TypeKind;
 #define DDS_XTypes_TK_FLOAT32 9
 #define DDS_XTypes_TK_FLOAT64 10
 #define DDS_XTypes_TK_FLOAT128 11
+#define DDS_XTypes_TK_INT8 12
+#define DDS_XTypes_TK_UINT8 13
 #define DDS_XTypes_TK_CHAR8 16
 #define DDS_XTypes_TK_CHAR16 17
 #define DDS_XTypes_TK_STRING8 32
@@ -383,6 +385,8 @@ typedef struct DDS_XTypes_AnnotationParameterValue
   {
     bool boolean_value;
     uint8_t byte_value;
+    int8_t int8_value;
+    uint8_t uint8_value;
     int16_t int16_value;
     uint16_t uint_16_value;
     int32_t int32_value;

--- a/src/core/ddsi/src/ddsi__xt_impl.h
+++ b/src/core/ddsi/src/ddsi__xt_impl.h
@@ -223,6 +223,7 @@ struct xt_type
     // case TK_NONE:
     // case TK_BOOLEAN:
     // case TK_BYTE:
+    // case TK_INT8:
     // case TK_INT16:
     // case TK_INT32:
     // case TK_INT64:

--- a/src/core/ddsi/src/ddsi_typebuilder.c
+++ b/src/core/ddsi/src/ddsi_typebuilder.c
@@ -379,10 +379,12 @@ static dds_return_t typebuilder_add_type (struct typebuilder_data *tbd, uint32_t
       *align = ALGN (uint8_t, is_ext);
       *size = SZ (uint8_t, is_ext);
       break;
+    case DDS_XTypes_TK_INT8:
+    case DDS_XTypes_TK_UINT8:
     case DDS_XTypes_TK_CHAR8:
     case DDS_XTypes_TK_BYTE:
       tb_type->type_code = DDS_OP_VAL_1BY;
-      tb_type->args.prim_args.is_signed = (type->xt._d == DDS_XTypes_TK_CHAR8);
+      tb_type->args.prim_args.is_signed = (type->xt._d == DDS_XTypes_TK_CHAR8 || type->xt._d == DDS_XTypes_TK_INT8);
       tb_type->cdr_align = 1;
       *align = ALGN (uint8_t, is_ext);
       *size = SZ (uint8_t, is_ext);

--- a/src/core/ddsi/src/ddsi_typewrap.c
+++ b/src/core/ddsi/src/ddsi_typewrap.c
@@ -157,9 +157,11 @@ const char * ddsi_typekind_descr (unsigned char disc)
     case DDS_XTypes_TK_NONE: return "NONE";
     case DDS_XTypes_TK_BOOLEAN: return "BOOLEAN";
     case DDS_XTypes_TK_BYTE: return "BYTE";
+    case DDS_XTypes_TK_INT8: return "INT8";
     case DDS_XTypes_TK_INT16: return "INT16";
     case DDS_XTypes_TK_INT32: return "INT32";
     case DDS_XTypes_TK_INT64: return "INT64";
+    case DDS_XTypes_TK_UINT8: return "UINT8";
     case DDS_XTypes_TK_UINT16: return "UINT16";
     case DDS_XTypes_TK_UINT32: return "UINT32";
     case DDS_XTypes_TK_UINT64: return "UINT64";
@@ -562,9 +564,10 @@ static dds_return_t xt_valid_union_disc_type (struct ddsi_domaingv *gv, const st
   if (ddsi_xt_is_unresolved (&t->_u.union_type.disc_type->xt))
     return DDS_RETCODE_OK;
   uint8_t d = ddsi_xt_unalias (&t->_u.union_type.disc_type->xt)->_d;
-  if (d != DDS_XTypes_TK_BOOLEAN && d != DDS_XTypes_TK_BYTE && d != DDS_XTypes_TK_CHAR8 && d != DDS_XTypes_TK_CHAR16
-      && d != DDS_XTypes_TK_INT16 && d != DDS_XTypes_TK_INT32 && d != DDS_XTypes_TK_INT64
-      && d != DDS_XTypes_TK_UINT16 && d != DDS_XTypes_TK_UINT32 && d != DDS_XTypes_TK_UINT64
+  if (d != DDS_XTypes_TK_BOOLEAN
+      && d != DDS_XTypes_TK_BYTE && d != DDS_XTypes_TK_CHAR8 && d != DDS_XTypes_TK_CHAR16
+      && d != DDS_XTypes_TK_INT8 && d != DDS_XTypes_TK_INT16 && d != DDS_XTypes_TK_INT32 && d != DDS_XTypes_TK_INT64
+      && d != DDS_XTypes_TK_UINT8 && d != DDS_XTypes_TK_UINT16 && d != DDS_XTypes_TK_UINT32 && d != DDS_XTypes_TK_UINT64
       && d != DDS_XTypes_TK_ENUM && d != DDS_XTypes_TK_BITMASK)
   {
     GVTRACE ("discriminator type for union is invalid\n");
@@ -943,8 +946,8 @@ static dds_return_t xt_validate_impl (struct ddsi_domaingv *gv, const struct xt_
         return ret;
       break;
     case DDS_XTypes_TK_BOOLEAN: case DDS_XTypes_TK_BYTE:
-    case DDS_XTypes_TK_INT16: case DDS_XTypes_TK_INT32: case DDS_XTypes_TK_INT64:
-    case DDS_XTypes_TK_UINT16: case DDS_XTypes_TK_UINT32: case DDS_XTypes_TK_UINT64:
+    case DDS_XTypes_TK_INT8: case DDS_XTypes_TK_INT16: case DDS_XTypes_TK_INT32: case DDS_XTypes_TK_INT64:
+    case DDS_XTypes_TK_UINT8: case DDS_XTypes_TK_UINT16: case DDS_XTypes_TK_UINT32: case DDS_XTypes_TK_UINT64:
     case DDS_XTypes_TK_FLOAT32: case DDS_XTypes_TK_FLOAT64: case DDS_XTypes_TK_FLOAT128:
     case DDS_XTypes_TK_CHAR8: case DDS_XTypes_TK_CHAR16: case DDS_XTypes_TK_STRING8:
       // no validations

--- a/src/tools/idlc/src/descriptor_type_meta.c
+++ b/src/tools/idlc/src/descriptor_type_meta.c
@@ -260,11 +260,13 @@ get_plain_typeid (const idl_pstate_t *pstate, struct descriptor_type_meta *dtm, 
     switch (idl_type (type_spec))
     {
       case IDL_BOOL: ti->_d = DDS_XTypes_TK_BOOLEAN; break;
-      case IDL_INT8: case IDL_CHAR: ti->_d = DDS_XTypes_TK_CHAR8; break;
-      case IDL_UINT8: case IDL_OCTET: ti->_d = DDS_XTypes_TK_BYTE; break;
+      case IDL_CHAR: ti->_d = DDS_XTypes_TK_CHAR8; break;
+      case IDL_OCTET: ti->_d = DDS_XTypes_TK_BYTE; break;
+      case IDL_INT8: ti->_d = DDS_XTypes_TK_INT8; break;
       case IDL_INT16: case IDL_SHORT: ti->_d = DDS_XTypes_TK_INT16; break;
       case IDL_INT32: case IDL_LONG: ti->_d = DDS_XTypes_TK_INT32; break;
       case IDL_INT64: case IDL_LLONG: ti->_d = DDS_XTypes_TK_INT64; break;
+      case IDL_UINT8: ti->_d = DDS_XTypes_TK_UINT8; break;
       case IDL_UINT16: case IDL_USHORT: ti->_d = DDS_XTypes_TK_UINT16; break;
       case IDL_UINT32: case IDL_ULONG: ti->_d = DDS_XTypes_TK_UINT32; break;
       case IDL_UINT64: case IDL_ULLONG: ti->_d = DDS_XTypes_TK_UINT64; break;
@@ -624,15 +626,21 @@ set_xtypes_annotation_parameter_value(
       val->_d = DDS_XTypes_TK_BOOLEAN;
       val->_u.boolean_value = lit->value.bln;
       break;
-    case IDL_INT8:
     case IDL_CHAR:
       val->_d = DDS_XTypes_TK_CHAR8;
       val->_u.char_value = lit->value.chr;
       break;
     case IDL_OCTET:
-    case IDL_UINT8:
       val->_d = DDS_XTypes_TK_BYTE;
       val->_u.byte_value = lit->value.uint8;
+      break;
+    case IDL_INT8:
+      val->_d = DDS_XTypes_TK_INT8;
+      val->_u.int8_value = lit->value.int8;
+      break;
+    case IDL_UINT8:
+      val->_d = DDS_XTypes_TK_UINT8;
+      val->_u.uint8_value = lit->value.uint8;
       break;
     case IDL_SHORT:
     case IDL_INT16:

--- a/src/tools/idlc/tests/type_meta.c
+++ b/src/tools/idlc/tests/type_meta.c
@@ -223,13 +223,15 @@ static DDS_XTypes_TypeObject *get_typeobj1 (void)
     "t1::test_struct",
     DDS_XTypes_IS_APPENDABLE,
     (DDS_XTypes_TypeIdentifier) { ._d = DDS_XTypes_TK_NONE },
-    6, (smember_t[]) {
+    8, (smember_t[]) {
       { 0, DDS_XTypes_IS_KEY | DDS_XTypes_IS_MUST_UNDERSTAND | DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TK_INT64 }, "f1" },
       { 1, DDS_XTypes_IS_OPTIONAL | DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TI_STRING8_SMALL, ._u.string_sdefn.bound = 0 }, "f2" },
       { 4, DDS_XTypes_IS_EXTERNAL | DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TK_CHAR8 }, "f3" },
-      { 3, DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TK_CHAR8 }, "f4" },
+      { 3, DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TK_INT8 }, "f4" },
       { 8, DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TK_UINT32 }, "f5" },
-      { 7, DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TK_INT64 }, "f6" }
+      { 7, DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TK_INT64 }, "f6" },
+      { 10, DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TK_UINT8 }, "f7" },
+      { 11, DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TK_BYTE }, "f8" }
     });
 }
 
@@ -762,7 +764,7 @@ CU_Test(idlc_type_meta, type_obj_serdes)
     char idl[256];
     get_typeobj_t get_typeobj_fn;
   } tests[] = {
-    { "module t1 { @appendable struct test_struct { @key long long f1; @optional string f2; @external @id(4) char f3; @id(3) int8 f4; @id(8) uint32 f5; @id(7) int64 f6; }; };", get_typeobj1 },
+    { "module t1 { @appendable struct test_struct { @key long long f1; @optional string f2; @external @id(4) char f3; @id(3) int8 f4; @id(8) uint32 f5; @id(7) int64 f6; @id(10) uint8 f7; octet f8; }; };", get_typeobj1 },
     { "module t2 { @mutable struct test_struct { @optional @external unsigned long f1, f2; }; };", get_typeobj2 },
     { "module t3 { @final union test_union switch (short) { case 1: long f1; case 2: case 3: default: @external string f2; }; };", get_typeobj3 },
     { "module t4 { @mutable @nested struct a { @id(5) long a1; }; @mutable @topic struct test_struct : a { @id(10) long f1; }; };", get_typeobj4 },


### PR DESCRIPTION
This adds support for the int8 and uint8 type kinds in the IDL compiler and the type library and XTypes wrapper. The IDL file describing the type object that is provided by the OMG spec was not updated for these missing type kinds, which was fixed in the spec text (including the IDL that is included in the spec as annex). See also https://issues.omg.org/issues/DDSXTY14-52

The Python binding, that also has its own implementation for building type objects, also needs an update for these kinds. I'll create a separate PR for that. 

Fixes #1554