### PR TITLE
Add error handling for deps in type wrapper initialization

### DIFF
--- a/src/core/ddsi/src/ddsi__typelib.h
+++ b/src/core/ddsi/src/ddsi__typelib.h
@@ -48,7 +48,7 @@ enum ddsi_type_state {
 };
 
 /** @component type_system */
-void ddsi_type_register_dep (struct ddsi_domaingv *gv, const ddsi_typeid_t *src_type_id, struct ddsi_type **dst_dep_type, const struct DDS_XTypes_TypeIdentifier *dep_type_id);
+dds_return_t ddsi_type_register_dep (struct ddsi_domaingv *gv, const ddsi_typeid_t *src_type_id, struct ddsi_type **dst_dep_type, const struct DDS_XTypes_TypeIdentifier *dep_type_id);
 
 /** @component type_system */
 void ddsi_type_ref_locked (struct ddsi_domaingv *gv, struct ddsi_type **type, const struct ddsi_type *src);

--- a/src/core/ddsi/src/ddsi_typewrap.c
+++ b/src/core/ddsi/src/ddsi_typewrap.c
@@ -1194,6 +1194,7 @@ static dds_return_t add_complete_typeobj (struct ddsi_domaingv *gv, struct xt_ty
           {
             ddsi_type_unref_locked (gv, xt->_u.union_type.members.seq[m].type);
             ddsrt_free (xt->_u.union_type.members.seq[m].label_seq._buffer);
+            xt_applied_member_annotations_fini (&xt->_u.union_type.members.seq[m].detail.annotations);
           }
           ddsi_type_unref_locked (gv, xt->_u.union_type.disc_type);
           ddsrt_free (xt->_u.union_type.members.seq);


### PR DESCRIPTION
The XTypes type wrapper failed to verify the return value of the register dependencies function calls, which resulted in ignoring validation errors in dependent types (e.g. a structs member types) and could result in other problems, e.g. the issue reported in #1554. This fixes the issue by checking the return codes and propagating errors.
