### PR TITLE
Unreliable readers are always "in sync" with pwr

### DIFF
--- a/src/core/ddsi/src/ddsi_endpoint_match.c
+++ b/src/core/ddsi/src/ddsi_endpoint_match.c
@@ -1003,7 +1003,12 @@ void ddsi_proxy_writer_add_connection (struct ddsi_proxy_writer *pwr, struct dds
   /* These can change as a consequence of handling data and/or
      discovery activities. The safe way of dealing with them is to
      lock the proxy writer */
-  if (ddsi_is_builtin_entityid (rd->e.guid.entityid, DDSI_VENDORID_ECLIPSE) && !ddsrt_avl_is_empty (&pwr->readers) && !pwr->filtered)
+  if (!rd->reliable)
+  {
+    /* unreliable readers cannot be out-of-sync */
+    m->in_sync = PRMSS_SYNC;
+  }
+  else if (ddsi_is_builtin_entityid (rd->e.guid.entityid, DDSI_VENDORID_ECLIPSE) && !ddsrt_avl_is_empty (&pwr->readers) && !pwr->filtered)
   {
     /* builtins really don't care about multiple copies or anything */
     m->in_sync = PRMSS_SYNC;


### PR DESCRIPTION
The "in sync" vs "out sync" exists to handle retrieving with historical data and determining when the "wait for historical data" operation can return, and to handle cases where a reader deliberately falls behind a writer because of resource limits.

Neither case exists for unreliable (a.k.a. best-effort) readers. So arguably, all unreliable readers should always state they are "in sync".

The difference is negligible in the case of *unreliable* remote writers, but not in the case of *reliable* remote writers. In the latter it can cause message loss.

Fixes #1561