### PR TITLE
Add tests for cdrstream skip-default and fix some issues

### DIFF
--- a/src/core/ddsc/tests/CMakeLists.txt
+++ b/src/core/ddsc/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ idlc_generate(TARGET CreateWriter FILES CreateWriter.idl WARNINGS no-implicit-ex
 idlc_generate(TARGET DataRepresentationTypes FILES DataRepresentationTypes.idl WARNINGS no-implicit-extensibility)
 idlc_generate(TARGET MinXcdrVersion FILES MinXcdrVersion.idl)
 idlc_generate(TARGET CdrStreamOptimize FILES CdrStreamOptimize.idl WARNINGS no-implicit-extensibility)
+idlc_generate(TARGET CdrStreamSkipDefault FILES CdrStreamSkipDefault.idl)
 if(ENABLE_TYPE_DISCOVERY)
   idlc_generate(TARGET XSpace FILES XSpace.idl XSpaceEnum.idl XSpaceMustUnderstand.idl XSpaceTypeConsistencyEnforcement.idl WARNINGS no-implicit-extensibility no-inherit-appendable)
   idlc_generate(TARGET XSpaceNoTypeInfo FILES XSpaceNoTypeInfo.idl NO_TYPE_INFO WARNINGS no-implicit-extensibility)
@@ -125,7 +126,7 @@ if(ENABLE_SHM)
 endif()
 
 target_link_libraries(cunit_ddsc PRIVATE
-  RoundTrip Space TypesArrayKey WriteTypes InstanceHandleTypes RWData CreateWriter DataRepresentationTypes MinXcdrVersion CdrStreamOptimize ddsc)
+  RoundTrip Space TypesArrayKey WriteTypes InstanceHandleTypes RWData CreateWriter DataRepresentationTypes MinXcdrVersion CdrStreamOptimize CdrStreamSkipDefault ddsc)
 
 if(ENABLE_TYPE_DISCOVERY)
   target_link_libraries(cunit_ddsc PRIVATE

--- a/src/core/ddsc/tests/CdrStreamSkipDefault.idl
+++ b/src/core/ddsc/tests/CdrStreamSkipDefault.idl
@@ -1,0 +1,45 @@
+/*
+ * Copyright(c) 2006 to 2022 ZettaScale Technology and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+module CdrStreamSkipDefault {
+
+  // t1
+  @appendable @nested struct t1_append { long s1; string s2; sequence<string> s3; };
+  @appendable struct t1_pub { long f1; };
+  @appendable struct t1_sub { long f1; t1_append f2; };
+
+  // t2
+  @mutable @nested struct t2_mutable { long s1; string s2; uint64 s3; @external long s4; };
+  @appendable struct t2_pub { long f1; };
+  @appendable struct t2_sub { long f1; t2_mutable f2; double f3; };
+
+  // t3
+  @mutable @nested struct t3_sub2 { string s1; sequence<long> s2; };
+  @mutable @nested struct t3_sub1 { long s1; t3_sub2 s2; };
+  @mutable struct t3_pub { long f1; };
+  @mutable struct t3_sub { long f1; t3_sub1 f2; double f3; t3_sub2 f4; };
+
+  // t4
+  enum t4_enum { E4_1, E4_2 };
+  @appendable @nested struct t4_sub2 { t4_enum s1; @external sequence<long> s2; };
+  @appendable @nested struct t4_sub1 { long s1; t4_sub2 s2; };
+  @mutable struct t4_pub { long f1; };
+  @mutable struct t4_sub { long f1; t4_sub1 f2; double f3; t4_sub2 f4; };
+
+  // t5
+  @appendable @nested struct t5_pub1 { long s1; };
+  @mutable struct t5_pub { long f1; t5_pub1 f2; };
+
+  @appendable @nested struct t5_sub2 { long s1; sequence<long> s2; };
+  @appendable @nested struct t5_sub1 { long s1; t5_sub2 s2; };
+  @mutable struct t5_sub { long f1; t5_sub1 f2; };
+
+};

--- a/src/tools/idlc/xtests/test_bitmask.idl
+++ b/src/tools/idlc/xtests/test_bitmask.idl
@@ -51,7 +51,7 @@ typedef bm8 b;
 typedef bm16 b_arr[50];
 typedef sequence<bm> b_seq_arr[2];
 
-@topic @final
+@topic @mutable
 struct test_bitmask {
   @key bm f1;
   @key bm8 f2;

--- a/src/tools/idlc/xtests/test_optional_mutable.idl
+++ b/src/tools/idlc/xtests/test_optional_mutable.idl
@@ -26,6 +26,13 @@ struct test_opt_base {
   @optional long b1n;
 };
 
+@bit_bound(15)
+bitmask bm16 {
+  @position(1) BM_1,
+  @position(10) BM_10,
+  BM_11
+};
+
 @topic @mutable
 struct test_opt : test_opt_base {
   @optional long f1;
@@ -40,6 +47,8 @@ struct test_opt : test_opt_base {
   @optional short f5n[2][3];
   @optional sequence<seqlong_t> f6;
   @optional sequence<seqlong_t> f6n;
+  @optional bm16 f7[2];
+  @optional bm16 f7n[2];
 };
 
 #else
@@ -86,6 +95,11 @@ void init_sample (void *s)
     s1->f6->_buffer[n]._buffer[1] = 20 * n + 10;
   }
   s1->f6n = NULL;
+
+  A (s1->f7);
+  (*(s1->f7))[0] = BM_10;
+  (*(s1->f7))[1] = BM_1;
+  s1->f7n = NULL;
 }
 
 int cmp_sample (const void *sa, const void *sb)
@@ -119,6 +133,10 @@ int cmp_sample (const void *sa, const void *sb)
     CMP(a, b, f6->_buffer[n]._buffer[1], 20 * n + 10);
   }
   CMP (a, b, f6n, NULL);
+
+  CMPEXTA (a, b, f7, 0, BM_10);
+  CMPEXTA (a, b, f7, 1, BM_1);
+  CMP (a, b, f7n, NULL);
 
   return 0;
 }


### PR DESCRIPTION
This PR adds and improves tests for the skip-default functionality in the cdrstream serializer for appendable and mutable types. These tests revealed a few new issues, that are fixed in c66e943eaf52c224fbe2537d586651b5792facbb:
- Memory for members of an existing sample that is passed when deserializing data is not freed in all cases:
   - in the skip-default functionality of the cdrstream serializer
   - when reading a sample of a mutable type in case the reader type has additional members that are not in the data
- Skip-default for an array with enum or bitmask element type was not updating the ops pointer correctly