### PR TITLE
Do not inherit irrelevant topic QoS in rd/wr

### DIFF
--- a/src/core/ddsc/src/dds_reader.c
+++ b/src/core/ddsc/src/dds_reader.c
@@ -624,7 +624,7 @@ static dds_entity_t dds_create_reader_int (dds_entity_t participant_or_subscribe
   if (sub->m_entity.m_qos)
     ddsi_xqos_mergein_missing (rqos, sub->m_entity.m_qos, ~DDSI_QP_ENTITY_NAME);
   if (tp->m_ktopic->qos)
-    ddsi_xqos_mergein_missing (rqos, tp->m_ktopic->qos, ~DDSI_QP_ENTITY_NAME);
+    ddsi_xqos_mergein_missing (rqos, tp->m_ktopic->qos, (DDS_READER_QOS_MASK | DDSI_QP_TOPIC_DATA) & ~DDSI_QP_ENTITY_NAME);
   ddsi_xqos_mergein_missing (rqos, &ddsi_default_qos_reader, ~DDSI_QP_DATA_REPRESENTATION);
   dds_apply_entity_naming(rqos, sub->m_entity.m_qos, gv);
 

--- a/src/core/ddsc/src/dds_writer.c
+++ b/src/core/ddsc/src/dds_writer.c
@@ -393,7 +393,7 @@ dds_entity_t dds_create_writer (dds_entity_t participant_or_publisher, dds_entit
   if (pub->m_entity.m_qos)
     ddsi_xqos_mergein_missing (wqos, pub->m_entity.m_qos, ~DDSI_QP_ENTITY_NAME);
   if (tp->m_ktopic->qos)
-    ddsi_xqos_mergein_missing (wqos, tp->m_ktopic->qos, ~DDSI_QP_ENTITY_NAME);
+    ddsi_xqos_mergein_missing (wqos, tp->m_ktopic->qos, (DDS_WRITER_QOS_MASK | DDSI_QP_TOPIC_DATA) & ~DDSI_QP_ENTITY_NAME);
   ddsi_xqos_mergein_missing (wqos, &ddsi_default_qos_writer, ~DDSI_QP_DATA_REPRESENTATION);
   dds_apply_entity_naming(wqos, pub->m_entity.m_qos, gv);
 


### PR DESCRIPTION
The set of topic QoS is an extended subset of the reader QoS (e.g., the "lifespan" QoS). Allowing those that are irrelevant to the reader to end up in the reader's QoS object means it shows up as a difference with the default QoS settings and causes it to be published in the endpoint discovery data.

As the topic QoS object is deliberately left sparse, this only happens when the application explicitly sets a QoS on the topic that is not relevant to the reader. For example, setting the lifespan in the topic QoS -- and even explicitly setting it to the default value -- causes this.

The impact is very low because the recipients of the endpoint discovery data ignore irrelevant (but otherwise valid) QoS values.

See #1572 Thanks @binbowang1987!