### PR TITLE
Add fix for Conan update

### DIFF
--- a/.azure/templates/install-conan.yml
+++ b/.azure/templates/install-conan.yml
@@ -29,7 +29,7 @@ steps:
     name: cache_conan
   - bash: |
       set -e
-      pip install conan --user --upgrade
+      pip install "conan==1.59.0" --user
       # Derive build profile architechture from system architecture.
       case "${AGENT_OSARCHITECTURE}" in
         X86) build_arch=x86 ;;


### PR DESCRIPTION
The default Conan version was updated to 2.0, so now we force fix the version to 1.59.0 as the current CUnit version (2.3.1) is currently not compatible with Conan v2.0

@NoxPardalis @dpotman , could you give this a look?