### PR TITLE
Dynamic Type API

### DIFF
--- a/docs/components.csv
+++ b/docs/components.csv
@@ -37,6 +37,7 @@ DDSI,Data Type Handling,Dynamic Types,dynamic_types
 DDSI,Data Type Handling,Type Lookup,type_lookup
 DDSI,Data Type Handling,Type System,type_system
 DDSI,Data Type Handling,XTypes Type Wrapper,xtypes_wrapper
+DDSI,Data Type Handling,Dynamic Type API,dynamic_type_api
 DDSI,Debugging and Monitoring,DDSI Statistics,ddsi_statistics
 DDSI,Debugging and Monitoring,Debug Support,debug_support
 DDSI,Debugging and Monitoring,Packet Capturing,packet_capturing
@@ -98,6 +99,7 @@ DDSI,Type Support,Type Support CDR Implementation,typesupport_cdr
 DDSI,Type Support,Type Support Interface,typesupport_if
 DDSI,Type Support,Type Support Parameter List Implementation,typesupport_pl
 DDSI,Type Support,Type Support Pserop Implementation,typesupport_pserop
+DDSI,Type Support,Dynamic Type Support,dynamic_type_support
 DDSI,Utils,Bitset,bitset
 DDSI,Utils,DDSI Byteswapping,ddsi_byteswap
 DDSI,Utils,DDSI Freelist,ddsi_freelist

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -43,6 +43,15 @@ install(
   DESTINATION "${CMAKE_INSTALL_EXAMPLESDIR}/throughput"
   COMPONENT dev)
 
+if (ENABLE_TYPE_DISCOVERY)
+  install(
+    FILES
+      dyntype/dyntype.c
+      dyntype/CMakeLists.txt
+    DESTINATION "${CMAKE_INSTALL_EXAMPLESDIR}/dyntype"
+    COMPONENT dev)
+endif ()
+
 if (ENABLE_TOPIC_DISCOVERY)
   install(
     FILES
@@ -80,6 +89,9 @@ add_subdirectory(throughput)
 if (ENABLE_TOPIC_DISCOVERY)
   add_subdirectory(listtopics)
   add_subdirectory(dynsub)
+endif ()
+if (ENABLE_TYPE_DISCOVERY)
+  add_subdirectory(dyntype)
 endif ()
 if (ENABLE_SHM)
   add_subdirectory(shm_throughput)

--- a/examples/dyntype/CMakeLists.txt
+++ b/examples/dyntype/CMakeLists.txt
@@ -1,0 +1,21 @@
+#
+# Copyright(c) 2022 ZettaScale Technology and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+project(dyntype LANGUAGES C)
+cmake_minimum_required(VERSION 3.16)
+
+if(NOT TARGET CycloneDDS::ddsc)
+  find_package(CycloneDDS REQUIRED)
+endif()
+
+add_executable(dyntype dyntype.c)
+
+target_link_libraries(dyntype CycloneDDS::ddsc)

--- a/examples/dyntype/dyntype.c
+++ b/examples/dyntype/dyntype.c
@@ -1,0 +1,154 @@
+/*
+ * Copyright(c) 2023 ZettaScale Technology and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include "dds/dds.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+int main (int argc, char ** argv)
+{
+  (void) argc;
+  (void) argv;
+
+  dds_return_t rc;
+  dds_entity_t participant = dds_create_participant (DDS_DOMAIN_DEFAULT, NULL, NULL);
+  if (participant < 0)
+    DDS_FATAL("dds_create_participant: %s\n", dds_strretcode (-participant));
+
+  dds_dynamic_type_t dsubstruct = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_STRUCTURE, .name = "dynamic_substruct" });
+  dds_dynamic_type_set_extensibility (&dsubstruct, DDS_DYNAMIC_TYPE_EXT_APPENDABLE);
+  dds_dynamic_type_set_autoid (&dsubstruct, DDS_DYNAMIC_TYPE_AUTOID_HASH);
+  dds_dynamic_type_add_member (&dsubstruct, DDS_DYNAMIC_MEMBER_PRIM(DDS_DYNAMIC_UINT16, "submember_uint16"));
+
+  dds_dynamic_type_t dsubunion = dds_dynamic_type_create (participant,
+      (dds_dynamic_type_descriptor_t) {
+        .kind = DDS_DYNAMIC_UNION,
+        .discriminator_type = DDS_DYNAMIC_TYPE_SPEC_PRIM(DDS_DYNAMIC_INT32),
+        .name = "dynamic_subunion"
+      });
+  dds_dynamic_type_add_member (&dsubunion, DDS_DYNAMIC_UNION_MEMBER_PRIM(DDS_DYNAMIC_INT32, "member_int32", 2, ((int32_t[]) { 1, 2 })));
+  dds_dynamic_type_add_member (&dsubunion, DDS_DYNAMIC_UNION_MEMBER_ID_PRIM(DDS_DYNAMIC_FLOAT64, "member_float64", 100 /* has specific member id */, 2, ((int32_t[]) { 9, 10 })));
+  dds_dynamic_type_add_member (&dsubunion, DDS_DYNAMIC_UNION_MEMBER(dds_dynamic_type_ref (&dsubstruct) /* increase ref because type is re-used */, "submember_substruct", 2, ((int32_t[]) { 15, 16 })));
+  dds_dynamic_type_add_member (&dsubunion, DDS_DYNAMIC_UNION_MEMBER_DEFAULT_PRIM(DDS_DYNAMIC_BOOLEAN, "submember_default"));
+
+  dds_dynamic_type_t dsubunion2 = dds_dynamic_type_dup (&dsubunion);
+  dds_dynamic_type_add_member (&dsubunion2, DDS_DYNAMIC_UNION_MEMBER_PRIM(DDS_DYNAMIC_BOOLEAN, "submember_bool", 1, ((int32_t[]) { 5 })));
+
+  dds_dynamic_type_t dsubsubstruct = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_STRUCTURE, .name = "dynamic_subsubstruct" });
+  dds_dynamic_type_add_member (&dsubsubstruct, DDS_DYNAMIC_MEMBER(dsubunion2, "subsubmember_union"));
+
+  // Sequences
+  dds_dynamic_type_t dseq = dds_dynamic_type_create (participant,
+      (dds_dynamic_type_descriptor_t) {
+        .kind = DDS_DYNAMIC_SEQUENCE,
+        .name = "dynamic_seq",
+        .element_type = DDS_DYNAMIC_TYPE_SPEC_PRIM(DDS_DYNAMIC_INT32),
+        .bounds = (uint32_t[]) { 10 },
+        .num_bounds = 1
+      });
+  dds_dynamic_type_t dseq2 = dds_dynamic_type_create (participant,
+      (dds_dynamic_type_descriptor_t) {
+        .kind = DDS_DYNAMIC_SEQUENCE,
+        .name = "dynamic_seq2",
+        .element_type = DDS_DYNAMIC_TYPE_SPEC(dds_dynamic_type_ref (&dsubstruct)) /* increase ref because type is re-used */,
+        .num_bounds = 0
+      });
+
+  // Arrays
+  dds_dynamic_type_t darr = dds_dynamic_type_create (participant,
+    (dds_dynamic_type_descriptor_t) {
+      .kind = DDS_DYNAMIC_ARRAY,
+      .name = "dynamic_array",
+      .element_type = DDS_DYNAMIC_TYPE_SPEC_PRIM(DDS_DYNAMIC_FLOAT64),
+      .bounds = (uint32_t[]) { 5, 99 },
+      .num_bounds = 2
+    });
+
+  // Enum
+  dds_dynamic_type_t denum = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_ENUMERATION, .name = "dynamic_enum" });
+  dds_dynamic_type_add_enum_literal (&denum, "DYNAMIC_ENUM_VALUE1", DDS_DYNAMIC_ENUM_LITERAL_VALUE_AUTO, false);
+  dds_dynamic_type_add_enum_literal (&denum, "DYNAMIC_ENUM_VALUE2", DDS_DYNAMIC_ENUM_LITERAL_VALUE_AUTO, false);
+  dds_dynamic_type_add_enum_literal (&denum, "DYNAMIC_ENUM_VALUE5", DDS_DYNAMIC_ENUM_LITERAL_VALUE(5), false);
+
+  // Bitmask
+  dds_dynamic_type_t dbitmask = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_BITMASK, .name = "dynamic_bitmask" });
+  dds_dynamic_type_add_bitmask_field (&dbitmask, "DYNAMIC_BITMASK_1", DDS_DYNAMIC_BITMASK_POSITION_AUTO);
+  dds_dynamic_type_add_bitmask_field (&dbitmask, "DYNAMIC_BITMASK_5", 5);
+  dds_dynamic_type_add_bitmask_field (&dbitmask, "DYNAMIC_BITMASK_6", DDS_DYNAMIC_BITMASK_POSITION_AUTO);
+
+  // Alias
+  dds_dynamic_type_t dalias = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) {
+      .kind = DDS_DYNAMIC_ALIAS,
+      .base_type = DDS_DYNAMIC_TYPE_SPEC(dds_dynamic_type_ref (&dseq2)), /* increase ref because type is re-used */
+      .name = "dynamic_alias"
+  });
+
+  dds_dynamic_type_t dstruct = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_STRUCTURE, .name = "dynamic_struct" });
+  dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER_PRIM(DDS_DYNAMIC_INT32, "member_int32"));
+  dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER_ID_PRIM(DDS_DYNAMIC_FLOAT64, "member_float64", 10 /* has specific member id */));
+  dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER_PRIM(DDS_DYNAMIC_BOOLEAN, "member_bool"));
+  dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER(dds_dynamic_type_ref (&dsubstruct) /* increase ref because type is re-used */, "member_struct"));
+  dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER(dsubstruct, "member_struct2"));
+  dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER_ID(dsubunion, "member_union", 20 /* has specific member id */));
+  dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER(dseq, "member_seq"));
+  dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER(darr, "member_array"));
+  dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER(denum, "member_enum"));
+  dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER(dbitmask, "member_bitmask"));
+  dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER(dalias, "member_alias"));
+
+  // Add members at specific index
+  dds_dynamic_type_add_member (&dstruct, (dds_dynamic_member_descriptor_t) {
+      .type = DDS_DYNAMIC_TYPE_SPEC(dseq2),
+      .name = "member_seq2",
+      .index = 0,
+      .id = 999
+  });
+  dds_dynamic_type_add_member (&dstruct, (dds_dynamic_member_descriptor_t) {
+      .type = DDS_DYNAMIC_TYPE_SPEC(dsubsubstruct),
+      .name = "member_substruct",
+      .index = 3,
+      .id = DDS_DYNAMIC_MEMBER_ID_AUTO
+  });
+
+  // Register type and create topic
+  dds_typeinfo_t *type_info;
+  rc = dds_dynamic_type_register (&dstruct, &type_info);
+  if (rc != DDS_RETCODE_OK)
+    DDS_FATAL ("dds_dynamic_type_register: %s\n", dds_strretcode (-rc));
+
+  dds_topic_descriptor_t *descriptor;
+  rc = dds_create_topic_descriptor (DDS_FIND_SCOPE_LOCAL_DOMAIN, participant, type_info, 0, &descriptor);
+  if (rc != DDS_RETCODE_OK)
+    DDS_FATAL ("dds_create_topic_descriptor: %s\n", dds_strretcode (-rc));
+
+  dds_entity_t topic = dds_create_topic (participant, descriptor, "dynamictopic", NULL, NULL);
+  if (topic < 0)
+    DDS_FATAL ("dds_create_topic: %s\n", dds_strretcode (-topic));
+
+  dds_entity_t writer = dds_create_writer (participant, topic, NULL, NULL);
+  if (writer < 0)
+    DDS_FATAL ("dds_create_writer: %s\n", dds_strretcode (-writer));
+
+  // Cleanup
+  dds_free_typeinfo (type_info);
+  dds_delete_topic_descriptor (descriptor);
+  dds_dynamic_type_unref (&dstruct);
+
+  printf ("<press enter to exit>\n");
+  getchar ();
+
+  /* Deleting the participant will delete all its children recursively as well. */
+  rc = dds_delete (participant);
+  if (rc != DDS_RETCODE_OK)
+    DDS_FATAL("dds_delete: %s\n", dds_strretcode (-rc));
+
+  return EXIT_SUCCESS;
+}

--- a/src/core/ddsc/CMakeLists.txt
+++ b/src/core/ddsc/CMakeLists.txt
@@ -44,7 +44,12 @@ prepend(srcs_ddsc "${CMAKE_CURRENT_LIST_DIR}/src/"
   dds_serdata_default.c
   dds_sertype_default.c
   dds_data_allocator.c
-  dds_loan.c)
+  dds_loan.c
+)
+
+if(ENABLE_TYPE_DISCOVERY)
+  list(APPEND srcs_ddsc "${CMAKE_CURRENT_LIST_DIR}/src/dds_dynamic_type.c")
+endif()
 
 if(ENABLE_SHM)
   list(APPEND srcs_ddsc
@@ -93,6 +98,10 @@ prepend(hdrs_public_ddsc "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>$<
   ddsc/dds_opcodes.h
   ddsc/dds_data_allocator.h
   ddsc/dds_loan_api.h)
+
+if(ENABLE_TYPE_DISCOVERY)
+  list(APPEND hdrs_public_ddsc "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>/dds/ddsc/dds_public_dynamic_type.h")
+endif()
 
 if(ENABLE_SHM)
   list(APPEND hdrs_private_ddsc

--- a/src/core/ddsc/include/dds/dds.h
+++ b/src/core/ddsc/include/dds/dds.h
@@ -46,6 +46,7 @@
 #include "dds/ddsc/dds_public_error.h"
 #include "dds/ddsc/dds_public_status.h"
 #include "dds/ddsc/dds_public_listener.h"
+#include "dds/ddsc/dds_public_dynamic_type.h"
 
 #if defined (__cplusplus)
 extern "C" {

--- a/src/core/ddsc/include/dds/ddsc/dds_public_dynamic_type.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_public_dynamic_type.h
@@ -1,0 +1,626 @@
+/*
+ * Copyright(c) 2023 ZettaScale Technology and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+#ifndef DDS_DYNAMIC_TYPE_H
+#define DDS_DYNAMIC_TYPE_H
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+struct ddsi_typeinfo;
+
+/**
+ * @defgroup dynamic_type (Dynamic Type API)
+ * @ingroup dds
+ * The Dynamic Type API to construct and manipulate data types.
+ */
+
+/**
+ * @brief Dynamic Type
+ * @ingroup dynamic_type
+ *
+ * Representation of a dynamically created type. This struct has an opaque pointer
+ * to the type in the type system. During construction of the type (setting properties
+ * and adding members), the internal type has the state 'CONSTRUCTION'. Once the type
+ * is registered, the state is updated to 'RESOLVED' and the type cannot be modified.
+ *
+ * The 'ret' member of this struct holds the return code of operations performed on
+ * this type. In case this value is not DDS_RETCODE_OK, the type cannot be used for
+ * further processing (e.g. adding members, registering the type, etc.).
+ *
+ */
+typedef struct dds_dynamic_type {
+  void * x;
+  dds_return_t ret;
+} dds_dynamic_type_t;
+
+/**
+ * @ingroup dynamic_type
+ *
+ * Invalid member ID: used when adding a member, to indicate that the member should get
+ * the id (m+1) where m is the highest member id in the current set of members. A valid
+ * member id has the 4 most significant bits set to 0 (because of usage in the EMHEADER),
+ * so also when hashed-id are used, the hash member id will never be set to the invalid
+ * member id.
+ */
+#define DDS_DYNAMIC_MEMBER_ID_INVALID 0xf000000u
+#define DDS_DYNAMIC_MEMBER_ID_AUTO DDS_DYNAMIC_MEMBER_ID_INVALID
+
+/**
+ * @ingroup dynamic_type
+ *
+ * When adding members, index 0 is used to indicate that a member should be inserted as
+ * the first member. A value higher than the current maximum index can be used to indicate
+ * that the member should be added after the other members
+ */
+#define DDS_DYNAMIC_MEMBER_INDEX_START 0u
+#define DDS_DYNAMIC_MEMBER_INDEX_END UINT32_MAX
+
+/**
+ * @brief Dynamic Type Kind
+ * @ingroup dynamic_type
+ *
+ * Enumeration with the type kind values that can be used to create a dynamic type.
+ */
+typedef enum dds_dynamic_type_kind
+{
+  DDS_DYNAMIC_NONE,
+  DDS_DYNAMIC_BOOLEAN,
+  DDS_DYNAMIC_BYTE,
+  DDS_DYNAMIC_INT16,
+  DDS_DYNAMIC_INT32,
+  DDS_DYNAMIC_INT64,
+  DDS_DYNAMIC_UINT16,
+  DDS_DYNAMIC_UINT32,
+  DDS_DYNAMIC_UINT64,
+  DDS_DYNAMIC_FLOAT32,
+  DDS_DYNAMIC_FLOAT64,
+  DDS_DYNAMIC_FLOAT128,
+  DDS_DYNAMIC_INT8,
+  DDS_DYNAMIC_UINT8,
+  DDS_DYNAMIC_CHAR8,
+  DDS_DYNAMIC_CHAR16,
+  DDS_DYNAMIC_STRING8,
+  DDS_DYNAMIC_STRING16,
+  DDS_DYNAMIC_ENUMERATION,
+  DDS_DYNAMIC_BITMASK,
+  DDS_DYNAMIC_ALIAS,
+  DDS_DYNAMIC_ARRAY,
+  DDS_DYNAMIC_SEQUENCE,
+  DDS_DYNAMIC_MAP,
+  DDS_DYNAMIC_STRUCTURE,
+  DDS_DYNAMIC_UNION,
+  DDS_DYNAMIC_BITSET
+} dds_dynamic_type_kind_t;
+
+/**
+ * @ingroup dynamic_type
+ *
+ * Short notation for initializer of a dynamic type spec for non-primitive and primitive types.
+ */
+#define DDS_DYNAMIC_TYPE_SPEC(t) ((dds_dynamic_type_spec_t) { .kind = DDS_DYNAMIC_TYPE_KIND_DEFINITION, .type.type = (t) })
+#define DDS_DYNAMIC_TYPE_SPEC_PRIM(p) ((dds_dynamic_type_spec_t) { .kind = DDS_DYNAMIC_TYPE_KIND_PRIMITIVE, .type.primitive = (p) })
+
+/**
+ * @ingroup dynamic_type
+ *
+ * Short notation for struct member descriptor with different sets of commonly used properties
+ */
+#define DDS_DYNAMIC_MEMBER_(member_type_spec,member_name,member_id,member_index) \
+    ((dds_dynamic_member_descriptor_t) { \
+      .type = (member_type_spec), \
+      .name = (member_name), \
+      .id = (member_id), \
+      .index = (member_index) \
+    })
+#define DDS_DYNAMIC_MEMBER_ID(member_type,member_name,member_id) \
+    DDS_DYNAMIC_MEMBER_ (DDS_DYNAMIC_TYPE_SPEC((member_type)),(member_name),(member_id),DDS_DYNAMIC_MEMBER_INDEX_END)
+#define DDS_DYNAMIC_MEMBER_ID_PRIM(member_prim_type,member_name,member_id) \
+    DDS_DYNAMIC_MEMBER_(DDS_DYNAMIC_TYPE_SPEC_PRIM((member_prim_type)),(member_name),(member_id),DDS_DYNAMIC_MEMBER_INDEX_END)
+#define DDS_DYNAMIC_MEMBER(member_type,member_name) \
+    DDS_DYNAMIC_MEMBER_ID((member_type),(member_name),DDS_DYNAMIC_MEMBER_ID_INVALID)
+#define DDS_DYNAMIC_MEMBER_PRIM(member_prim_type,member_name) \
+    DDS_DYNAMIC_MEMBER_ID_PRIM((member_prim_type),(member_name),DDS_DYNAMIC_MEMBER_ID_INVALID)
+
+/**
+ * @ingroup dynamic_type
+ *
+ * Short notation for union member descriptor with different sets of commonly used properties
+ */
+#define DDS_DYNAMIC_UNION_MEMBER_(member_type_spec,member_name,member_id,member_index,member_num_labels,member_labels,member_is_default) \
+    ((dds_dynamic_member_descriptor_t) { \
+      .type = (member_type_spec), \
+      .id = (member_id), \
+      .index = (member_index), \
+      .name = (member_name), \
+      .num_labels = (member_num_labels), \
+      .labels = (member_labels), \
+      .default_label = (member_is_default) \
+    })
+#define DDS_DYNAMIC_UNION_MEMBER_ID(member_type,member_name,member_id,member_num_labels,member_labels) \
+    DDS_DYNAMIC_UNION_MEMBER_(DDS_DYNAMIC_TYPE_SPEC((member_type)),(member_name),(member_id),DDS_DYNAMIC_MEMBER_INDEX_END,(member_num_labels),(member_labels),false)
+#define DDS_DYNAMIC_UNION_MEMBER_ID_PRIM(member_prim_type,member_name,member_id,member_num_labels,member_labels) \
+    DDS_DYNAMIC_UNION_MEMBER_(DDS_DYNAMIC_TYPE_SPEC_PRIM((member_prim_type)),(member_name),(member_id),DDS_DYNAMIC_MEMBER_INDEX_END,(member_num_labels),(member_labels),false)
+#define DDS_DYNAMIC_UNION_MEMBER(member_type,member_name,member_num_labels,member_labels) \
+    DDS_DYNAMIC_UNION_MEMBER_ID((member_type),(member_name),DDS_DYNAMIC_MEMBER_ID_INVALID,(member_num_labels),(member_labels))
+#define DDS_DYNAMIC_UNION_MEMBER_PRIM(member_prim_type,member_name,member_num_labels,member_labels) \
+    DDS_DYNAMIC_UNION_MEMBER_ID_PRIM((member_prim_type),(member_name),DDS_DYNAMIC_MEMBER_ID_INVALID,(member_num_labels),(member_labels))
+
+#define DDS_DYNAMIC_UNION_MEMBER_DEFAULT_ID(member_type,member_name,member_id) \
+    DDS_DYNAMIC_UNION_MEMBER_(DDS_DYNAMIC_TYPE_SPEC((member_type)),(member_name),(member_id),DDS_DYNAMIC_MEMBER_INDEX_END,0,NULL,true)
+#define DDS_DYNAMIC_UNION_MEMBER_DEFAULT_ID_PRIM(member_prim_type,member_name,member_id) \
+    DDS_DYNAMIC_UNION_MEMBER_(DDS_DYNAMIC_TYPE_SPEC_PRIM((member_prim_type)),(member_name),(member_id),DDS_DYNAMIC_MEMBER_INDEX_END,0,NULL,true)
+#define DDS_DYNAMIC_UNION_MEMBER_DEFAULT(member_type,member_name) \
+    DDS_DYNAMIC_UNION_MEMBER_DEFAULT_ID((member_type),(member_name),DDS_DYNAMIC_MEMBER_ID_INVALID)
+#define DDS_DYNAMIC_UNION_MEMBER_DEFAULT_PRIM(member_prim_type,member_name) \
+    DDS_DYNAMIC_UNION_MEMBER_DEFAULT_ID_PRIM((member_prim_type),(member_name),DDS_DYNAMIC_MEMBER_ID_INVALID)
+
+/**
+ * @ingroup dynamic_type
+ *
+ * Dynamic Type specification kind
+ */
+typedef enum dds_dynamic_type_spec_kind {
+  DDS_DYNAMIC_TYPE_KIND_UNSET,
+  DDS_DYNAMIC_TYPE_KIND_DEFINITION,
+  DDS_DYNAMIC_TYPE_KIND_PRIMITIVE
+} dds_dynamic_type_spec_kind_t;
+
+/**
+ * @ingroup dynamic_type
+ *
+ * Dynamic Type specification: a reference to dynamic type, which can be a primitive type
+ * kind (just the type kind enumeration value), or a (primitive or non-primitive) dynamic
+ * type reference.
+ */
+typedef struct dds_dynamic_type_spec {
+  dds_dynamic_type_spec_kind_t kind;
+  union {
+    dds_dynamic_type_t type;
+    dds_dynamic_type_kind_t primitive;
+  } type;
+} dds_dynamic_type_spec_t;
+
+/**
+ * @brief Dynamic Type descriptor
+ * @ingroup dynamic_type
+ *
+ * Structure that holds the properties for creating a Dynamic Type. For each type kind,
+ * specific member fields are applicable and/or required.
+ */
+typedef struct dds_dynamic_type_descriptor {
+  dds_dynamic_type_kind_t kind; /**< Type kind. Required for all types. */
+  const char * name; /**< Type name. Required for struct, union, alias, enum, bitmask, array, sequence. */
+  dds_dynamic_type_spec_t base_type; /**< Option base type for a struct, or (required) aliased type in case of an alias type. */
+  dds_dynamic_type_spec_t discriminator_type; /**< Discriminator type for a union (required). */
+  uint32_t num_bounds; /**< Number of bounds for array and sequence types. In case of sequence, this can be 0 (unbounded) or 1. */
+  const uint32_t *bounds; /**< Bounds for array (0..num_bounds) and sequence (single value) */
+  dds_dynamic_type_spec_t element_type; /**< Element type for array and sequence, required. */
+  dds_dynamic_type_spec_t key_element_type; /**< Key element type for map type */
+} dds_dynamic_type_descriptor_t;
+
+/**
+ * @brief Dynamic Type Member descriptor
+ * @ingroup dynamic_type
+ *
+ * Structure that holds the properities for adding a member to a dynamic type. Depending on
+ * the member type, different fields apply and are required.
+ */
+typedef struct dds_dynamic_member_descriptor {
+  const char * name; /**< Name of the member, required */
+  uint32_t id; /**< Identifier of the member, applicable for struct and union members. DDS_DYNAMIC_MEMBER_ID_AUTO can be used to indicate the next available id (current max + 1) should be used. */
+  dds_dynamic_type_spec_t type; /**< Member type, required for struct and union members. */
+  char *default_value; /**< Default value for the member */
+  uint32_t index; /**< Member index, applicable for struct and union members. DDS_DYNAMIC_MEMBER_INDEX_START and DDS_DYNAMIC_MEMBER_INDEX_END can be used to add a member as first or last member in the parent type. */
+  uint32_t num_labels; /**< Number of labels, required for union members in case not default_label */
+  int32_t *labels; /**< Labels for a union member, 1..n required for union members in case not default_label */
+  bool default_label; /**< Is default union member */
+} dds_dynamic_member_descriptor_t;
+
+/**
+ * @ingroup dynamic_type
+ *
+ * Dynamic Type extensibility
+ */
+enum dds_dynamic_type_extensibility {
+  DDS_DYNAMIC_TYPE_EXT_FINAL,
+  DDS_DYNAMIC_TYPE_EXT_APPENDABLE,
+  DDS_DYNAMIC_TYPE_EXT_MUTABLE
+};
+
+/**
+ * @ingroup dynamic_type
+ *
+ * Dynamic Type automatic member ID kind
+ */
+enum dds_dynamic_type_autoid {
+  DDS_DYNAMIC_TYPE_AUTOID_SEQUENTIAL, /**< The member ID are assigned sequential */
+  DDS_DYNAMIC_TYPE_AUTOID_HASH /**< The member ID is the hash of the member's name */
+};
+
+/**
+ * @ingroup dynamic_type
+ *
+ * Dynamic Enumeration type literal value kind and value. Can be set to NEXT_AVAIL to indicate
+ * that the current max value + 1 should be used for this member, or an explicit value can be
+ * provided.
+ */
+typedef struct dds_dynamic_enum_literal_value {
+  enum {
+    DDS_DYNAMIC_ENUM_LITERAL_VALUE_NEXT_AVAIL,
+    DDS_DYNAMIC_ENUM_LITERAL_VALUE_EXPLICIT
+  } value_kind;
+  int32_t value;
+} dds_dynamic_enum_literal_value_t;
+
+/**
+ * @ingroup dynamic_type
+ *
+ * Short notation for initializing a Dynamic Enum value struct.
+ */
+#define DDS_DYNAMIC_ENUM_LITERAL_VALUE_AUTO ((dds_dynamic_enum_literal_value_t) { DDS_DYNAMIC_ENUM_LITERAL_VALUE_NEXT_AVAIL, 0 })
+#define DDS_DYNAMIC_ENUM_LITERAL_VALUE(v) ((dds_dynamic_enum_literal_value_t) { DDS_DYNAMIC_ENUM_LITERAL_VALUE_EXPLICIT, (v) })
+
+/**
+ * @ingroup dynamic_type
+ *
+ * Used to indicate that the bitmask field should get the next available position (current maximum + 1)
+ */
+#define DDS_DYNAMIC_BITMASK_POSITION_AUTO (UINT16_MAX)
+
+/**
+ * @brief Create a new Dynamic Type
+ * @ingroup dynamic_type
+ * @component dynamic_type_api
+ *
+ * Creates a new Dynamic Type, using the properties that are set in the type descriptor.
+ * In case these properties include a base-type, element-type or discriminator type, the
+ * ownership of these types is transferred to the newly created type.
+ *
+ * @param[in] entity Any DDS entity. This entity is used to get the type library of the entity's domain, to add the type to.
+ * @param[in] descriptor The Dynamic Type descriptor.
+ *
+ * @return dds_dynamic_type_t A Dynamic Type reference for the created type.
+ *
+ * @retval DDS_RETCODE_OK
+ *            The type is created successfully.
+ * @retval DDS_RETCODE_BAD_PARAMETER
+ *            One or more of the provided parameters are invalid.
+ * @retval DDS_RETCODE_UNSUPPORTED
+ *            The provided type kind is not supported.
+ * @retval DDS_RETCODE_OUT_OF_RESOURCES
+ *            Not enough resources to create the type.
+ */
+DDS_EXPORT dds_dynamic_type_t dds_dynamic_type_create (dds_entity_t entity, dds_dynamic_type_descriptor_t descriptor);
+
+/**
+ * @brief Set the extensibility of a Dynamic Type
+ * @ingroup dynamic_type
+ * @component dynamic_type_api
+ *
+ * @param[in,out] type Dynamic Type to set the extensibility for. This can be a structure, union, bitmask or enum type. This type must be in the CONSTRUCTING state and have no members added.
+ * @param[in] extensibility The extensibility to set (@ref enum dds_dynamic_type_extensibility).
+ *
+ * @return dds_return_t Return code. In case of an error, the return code field in the provided type is also set to this value.
+ *
+ * @retval DDS_RETCODE_OK
+ *            The extensibility is set successfully.
+ * @retval DDS_RETCODE_BAD_PARAMETER
+ *            One or more of the provided parameters are invalid.
+ * @retval DDS_RETCODE_PRECONDITION_NOT_MET
+ *            The provided type is not in the CONSTRUCTING state.
+ */
+DDS_EXPORT dds_return_t dds_dynamic_type_set_extensibility (dds_dynamic_type_t *type, enum dds_dynamic_type_extensibility extensibility);
+
+/**
+ * @brief Set the bit-bound of a Dynamic Type
+ * @ingroup dynamic_type
+ * @component dynamic_type_api
+ *
+ * @param[in,out] type Dynamic Type to set the bit-bound for. This can be a bitmask or enum type.
+ * @param[in] bit_bound The bit-bound value to set, in the (including) range 1..32 for enum and 1..64 for bitmask.
+ *
+ * @return dds_return_t Return code. In case of an error, the return code field in the provided type is also set to this value.
+ *
+ * @retval DDS_RETCODE_OK
+ *            The bit-bound is set successfully.
+ * @retval DDS_RETCODE_BAD_PARAMETER
+ *            One or more of the provided parameters are invalid.
+ * @retval DDS_RETCODE_PRECONDITION_NOT_MET
+ *            The provided type is not in the CONSTRUCTING state.
+ */
+DDS_EXPORT dds_return_t dds_dynamic_type_set_bit_bound (dds_dynamic_type_t *type, uint16_t bit_bound);
+
+/**
+ * @brief Set the nested flag of a Dynamic Type
+ * @ingroup dynamic_type
+ * @component dynamic_type_api
+ *
+ * @param[in,out] type Dynamic Type to set the nested flag for. This can be a structure or union type.
+ * @param[in] is_nested Whether the nested flag is set.
+ *
+ * @return dds_return_t Return code. In case of an error, the return code field in the provided type is also set to this value.
+ *
+ * @retval DDS_RETCODE_OK
+ *            The flag is set successfully.
+ * @retval DDS_RETCODE_BAD_PARAMETER
+ *            One or more of the provided parameters are invalid.
+ * @retval DDS_RETCODE_PRECONDITION_NOT_MET
+ *            The provided type is not in the CONSTRUCTING state.
+ */
+DDS_EXPORT dds_return_t dds_dynamic_type_set_nested (dds_dynamic_type_t *type, bool is_nested);
+
+/**
+ * @brief Set the auto-id kind of a Dynamic Type
+ * @ingroup dynamic_type
+ * @component dynamic_type_api
+ *
+ * @param[in,out] type Dynamic Type to set the auto-id kind for. This can be a structure or union type.
+ * @param[in] value The auto-id kind, see @ref dds_dynamic_type_autoid.
+ *
+ * @return dds_return_t Return code. In case of an error, the return code field in the provided type is also set to this value.
+ *
+ * @retval DDS_RETCODE_OK
+ *            The value is set successfully.
+ * @retval DDS_RETCODE_BAD_PARAMETER
+ *            One or more of the provided parameters are invalid.
+ * @retval DDS_RETCODE_PRECONDITION_NOT_MET
+ *            The provided type is not in the CONSTRUCTING state.
+ */
+DDS_EXPORT dds_return_t dds_dynamic_type_set_autoid (dds_dynamic_type_t *type, enum dds_dynamic_type_autoid value);
+
+/**
+ * @brief Add a member to a Dynamic Type
+ * @ingroup dynamic_type
+ * @component dynamic_type_api
+ *
+ * This function is used to add a member to a Dynamic Type. The parent type can be a structure,
+ * union, enumeration or bitmask type. The parent type the member is added to takes over the
+ * ownership of the member type and dereferences the member type when it is deleted.
+ * (@see dds_dynamic_type_ref for re-using a type)
+ *
+ * @param[in,out] type The Dynamic type to add the member to.
+ * @param[in] member_descriptor The member descriptor that has the properties of the member to add, @see dds_dynamic_member_descriptor.
+ *
+ * @return dds_return_t Return code. In case of an error, the return code field in the provided type is also set to this value.
+ *
+ * @retval DDS_RETCODE_OK
+ *            The member is added successfully.
+ * @retval DDS_RETCODE_BAD_PARAMETER
+ *            One or more of the provided parameters are invalid.
+ * @retval DDS_RETCODE_PRECONDITION_NOT_MET
+ *            The provided type (non the member type) is not in the CONSTRUCTING state.
+ */
+DDS_EXPORT dds_return_t dds_dynamic_type_add_member (dds_dynamic_type_t *type, dds_dynamic_member_descriptor_t member_descriptor);
+
+/**
+ * @brief Add a literal to a Dynamic Enum Type
+ * @ingroup dynamic_type
+ * @component dynamic_type_api
+ *
+ * This function is used to add a literal to a Dynamic Enum Type.
+ *
+ * @param[in,out] type The Dynamic enum type to add the member to.
+ * @param[in] name The name of the literal to add.
+ * @param[in] value The value for the literal (@see dds_dynamic_enum_literal_value).
+ * @param[in] is_default Indicates if the literal if default for the enum.
+ *
+ * @return dds_return_t Return code. In case of an error, the return code field in the provided type is also set to this value.
+ *
+ * @retval DDS_RETCODE_OK
+ *            The member is added successfully
+ * @retval DDS_RETCODE_BAD_PARAMETER
+ *            One or more of the provided parameters are invalid.
+ * @retval DDS_RETCODE_PRECONDITION_NOT_MET
+ *            The provided type is not in the CONSTRUCTING state.
+ */
+DDS_EXPORT dds_return_t dds_dynamic_type_add_enum_literal (dds_dynamic_type_t *type, const char *name, dds_dynamic_enum_literal_value_t value, bool is_default);
+
+/**
+ * @brief Add a field to a Dynamic bitmask Type
+ * @ingroup dynamic_type
+ * @component dynamic_type_api
+ *
+ * This function is used to add a field to a Dynamic bitmask Type.
+ *
+ * @param[in,out] type The Dynamic bitmask type to add the field to.
+ * @param[in] name The name of the field to add.
+ * @param[in] position The position for the field (@see DDS_DYNAMIC_BITMASK_POSITION_AUTO).
+ *
+ * @return dds_return_t Return code. In case of an error, the return code field in the provided type is also set to this value.
+ *
+ * @retval DDS_RETCODE_OK
+ *            The member is added successfully
+ * @retval DDS_RETCODE_BAD_PARAMETER
+ *            One or more of the provided parameters are invalid.
+ * @retval DDS_RETCODE_PRECONDITION_NOT_MET
+ *            The provided type is not in the CONSTRUCTING state.
+ */
+DDS_EXPORT dds_return_t dds_dynamic_type_add_bitmask_field (dds_dynamic_type_t *type, const char *name, uint16_t position);
+
+/**
+ * @brief Set the key flag for a Dynamic Type member
+ * @ingroup dynamic_type
+ * @component dynamic_type_api
+ *
+ * @param[in,out] type Dynamic Type that contains the member to set the key flag for (must be a structure type).
+ * @param[in] member_id The ID of the member to set the flag for.
+ * @param[in] is_key Indicates whether the key flag should be set or cleared.
+ *
+ * @return dds_return_t Return code. In case of an error, the return code field in the provided type is also set to this value.
+ *
+ * @retval DDS_RETCODE_OK
+ *            The flag is updated successfully.
+ * @retval DDS_RETCODE_BAD_PARAMETER
+ *            One or more of the provided parameters are invalid.
+ * @retval DDS_RETCODE_PRECONDITION_NOT_MET
+ *            The provided type is not in the CONSTRUCTING state.
+ */
+DDS_EXPORT dds_return_t dds_dynamic_member_set_key (dds_dynamic_type_t *type, uint32_t member_id, bool is_key);
+
+/**
+ * @brief Set the optional flag for a Dynamic Type member
+ * @ingroup dynamic_type
+ * @component dynamic_type_api
+ *
+ * @param[in,out] type Dynamic Type that contains the member to set the optional flag for (must be a structure type).
+ * @param[in] member_id The ID of the member to set the flag for.
+ * @param[in] is_optional Indicates whether the optional flag should be set or cleared.
+ *
+ * @return dds_return_t Return code. In case of an error, the return code field in the provided type is also set to this value.
+ *
+ * @retval DDS_RETCODE_OK
+ *            The flag is updated successfully.
+ * @retval DDS_RETCODE_BAD_PARAMETER
+ *            One or more of the provided parameters are invalid.
+ * @retval DDS_RETCODE_PRECONDITION_NOT_MET
+ *            The provided type is not in the CONSTRUCTING state.
+ */
+DDS_EXPORT dds_return_t dds_dynamic_member_set_optional (dds_dynamic_type_t *type, uint32_t member_id, bool is_optional);
+
+/**
+ * @brief Set the external flag for a Dynamic Type member
+ * @ingroup dynamic_type
+ * @component dynamic_type_api
+ *
+ * @param[in,out] type Dynamic Type that contains the member to set the external flag for (must be a structure or union type).
+ * @param[in] member_id The ID of the member to set the flag for.
+ * @param[in] is_external Indicates whether the external flag should be set or cleared.
+ *
+ * @return dds_return_t Return code. In case of an error, the return code field in the provided type is also set to this value.
+ *
+ * @retval DDS_RETCODE_OK
+ *            The flag is updated successfully.
+ * @retval DDS_RETCODE_BAD_PARAMETER
+ *            One or more of the provided parameters are invalid.
+ * @retval DDS_RETCODE_PRECONDITION_NOT_MET
+ *            The provided type is not in the CONSTRUCTING state.
+ */
+DDS_EXPORT dds_return_t dds_dynamic_member_set_external (dds_dynamic_type_t *type, uint32_t member_id, bool is_external);
+
+/**
+ * @brief Set the hash ID flag and hash field name for a Dynamic Type member
+ * @ingroup dynamic_type
+ * @component dynamic_type_api
+ *
+ * @param[in,out] type Dynamic Type that contains the member to set the flag and hash-name for (must be a structure or union type).
+ * @param[in] member_id The ID of the member to set the flag and hash-name for.
+ * @param[in] hash_member_name The hash-name that should be used for calculating the member ID.
+ *
+ * @return dds_return_t Return code. In case of an error, the return code field in the provided type is also set to this value.
+ *
+ * @retval DDS_RETCODE_OK
+ *            The flag is updated successfully.
+ * @retval DDS_RETCODE_BAD_PARAMETER
+ *            One or more of the provided parameters are invalid.
+ * @retval DDS_RETCODE_PRECONDITION_NOT_MET
+ *            The provided type is not in the CONSTRUCTING state.
+ */
+DDS_EXPORT dds_return_t dds_dynamic_member_set_hashid (dds_dynamic_type_t *type, uint32_t member_id, const char *hash_member_name);
+
+/**
+ * @brief Set the must-understand flag for a Dynamic Type member
+ * @ingroup dynamic_type
+ * @component dynamic_type_api
+ *
+ * @param[in,out] type Dynamic Type that contains the member to set the must-understand flag for (must be a structure type).
+ * @param[in] member_id The ID of the member to set the flag for.
+ * @param[in] is_must_understand Indicates whether the must-understand flag should be set or cleared.
+ *
+ * @return dds_return_t Return code. In case of an error, the return code field in the provided type is also set to this value.
+ *
+ * @retval DDS_RETCODE_OK
+ *            The flag is updated successfully.
+ * @retval DDS_RETCODE_BAD_PARAMETER
+ *            One or more of the provided parameters are invalid.
+ * @retval DDS_RETCODE_PRECONDITION_NOT_MET
+ *            The provided type is not in the CONSTRUCTING state.
+ */
+DDS_EXPORT dds_return_t dds_dynamic_member_set_must_understand (dds_dynamic_type_t *type, uint32_t member_id, bool is_must_understand);
+
+
+/**
+ * @brief Registers a Dynamic Type
+ * @ingroup dynamic_type
+ * @component dynamic_type_api
+ *
+ * This function registers a dynamic type, making it immutable and finalizing
+ * its definition. A type that is registered, get the state 'RESOLVED' and is
+ * stored in the type library.
+ *
+ * @param[in] type A pointer to the dynamic type to be registered.
+ * @param[out] type_info A pointer to a pointer to a ddsi_typeinfo structure that holds information about the registered type.
+ *
+ * @return dds_return_t Return code.
+ *
+ * @retval DDS_RETCODE_OK
+ *            The type was successfully registered.
+ * @retval DDS_RETCODE_BAD_PARAMETER
+ *            One or more of the provided parameters are invalid.
+ * @retval DDS_RETCODE_PRECONDITION_NOT_MET
+ *            The provided type is not in the CONSTRUCTING state.
+ * @retval DDS_RETCODE_OUT_OF_RESOURCES
+ *            Not enough resources to create the type.
+ */
+DDS_EXPORT dds_return_t dds_dynamic_type_register (dds_dynamic_type_t *type, struct ddsi_typeinfo **type_info);
+
+/**
+ * @brief Reference a Dynamic Type
+ * @ingroup dynamic_type
+ * @component dynamic_type_api
+ *
+ * References a Dynamic Type and increases the ref-count of the type. This
+ * can e.g. be used to re-use a subtype when constructing a type.
+ *
+ * @param type Dynamic Type to reference
+ *
+ * @return dds_dynamic_type_t Dynamic Type with increased ref-count
+ */
+DDS_EXPORT dds_dynamic_type_t dds_dynamic_type_ref (dds_dynamic_type_t *type);
+
+/**
+ * @brief Unref a Dynamic Type
+ *
+ * @param type The Dynamic Type to dereference.
+ *
+ * @return dds_return_t Return code.
+ *
+ * @retval DDS_RETCODE_OK
+ *            The type was successfully registered.
+ * @retval DDS_RETCODE_BAD_PARAMETER
+ *            One or more of the provided parameters are invalid.
+ * @retval DDS_RETCODE_PRECONDITION_NOT_MET
+ *            The provided type is not in the CONSTRUCTING state.
+ */
+DDS_EXPORT dds_return_t dds_dynamic_type_unref (dds_dynamic_type_t *type);
+
+/**
+ * @brief Duplicate a Dynamic Type
+ * @ingroup dynamic_type
+ * @component dynamic_type_api
+ *
+ * Duplicates a Dynamic Type. Dependencies of the type are not duplicated,
+ * but their ref-count is increased.
+ *
+ * @param src The type to duplicate.
+ *
+ * @return dds_dynamic_type_t A duplicate of the source type.
+ */
+DDS_EXPORT dds_dynamic_type_t dds_dynamic_type_dup (const dds_dynamic_type_t *src);
+
+
+#if defined (__cplusplus)
+}
+#endif
+
+#endif // DDS_DYNAMIC_TYPE_H

--- a/src/core/ddsc/include/dds/ddsc/dds_public_dynamic_type.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_public_dynamic_type.h
@@ -287,7 +287,7 @@ typedef struct dds_dynamic_enum_literal_value {
  * In case these properties include a base-type, element-type or discriminator type, the
  * ownership of these types is transferred to the newly created type.
  *
- * @param[in] entity Any DDS entity. This entity is used to get the type library of the entity's domain, to add the type to.
+ * @param[in] entity A DDS entity (any entity, except the pseudo root entity identified by DDS_CYCLONEDDS_HANDLE). This entity is used to get the type library of the entity's domain, to add the type to.
  * @param[in] descriptor The Dynamic Type descriptor.
  *
  * @return dds_dynamic_type_t A Dynamic Type reference for the created type.

--- a/src/core/ddsc/src/dds_dynamic_type.c
+++ b/src/core/ddsc/src/dds_dynamic_type.c
@@ -1,0 +1,557 @@
+/*
+ * Copyright(c) 2023 ZettaScale Technology and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include <assert.h>
+#include <string.h>
+#include "dds/dds.h"
+#include "dds/ddsi/ddsi_entity.h"
+#include "dds/ddsi/ddsi_dynamic_type.h"
+#include "dds/ddsi/ddsi_typelib.h"
+#include "dds__entity.h"
+
+static struct ddsi_domaingv * get_entity_gv (dds_entity_t entity)
+{
+  struct ddsi_domaingv *gv = NULL;
+  struct dds_entity *e;
+  if ((dds_entity_pin (entity, &e)) == DDS_RETCODE_OK)
+    gv = &e->m_domain->gv;
+  dds_entity_unpin (e);
+  return gv;
+}
+
+static DDS_XTypes_TypeKind typekind_to_xtkind (dds_dynamic_type_kind_t type_kind)
+{
+  switch (type_kind) {
+    case DDS_DYNAMIC_NONE:        return DDS_XTypes_TK_NONE;
+    case DDS_DYNAMIC_BOOLEAN:     return DDS_XTypes_TK_BOOLEAN;
+    case DDS_DYNAMIC_BYTE:        return DDS_XTypes_TK_BYTE;
+    case DDS_DYNAMIC_INT16:       return DDS_XTypes_TK_INT16;
+    case DDS_DYNAMIC_INT32:       return DDS_XTypes_TK_INT32;
+    case DDS_DYNAMIC_INT64:       return DDS_XTypes_TK_INT64;
+    case DDS_DYNAMIC_UINT16:      return DDS_XTypes_TK_UINT16;
+    case DDS_DYNAMIC_UINT32:      return DDS_XTypes_TK_UINT32;
+    case DDS_DYNAMIC_UINT64:      return DDS_XTypes_TK_UINT64;
+    case DDS_DYNAMIC_FLOAT32:     return DDS_XTypes_TK_FLOAT32;
+    case DDS_DYNAMIC_FLOAT64:     return DDS_XTypes_TK_FLOAT64;
+    case DDS_DYNAMIC_FLOAT128:    return DDS_XTypes_TK_FLOAT128;
+    case DDS_DYNAMIC_INT8:        return DDS_XTypes_TK_INT8;
+    case DDS_DYNAMIC_UINT8:       return DDS_XTypes_TK_UINT8;
+    case DDS_DYNAMIC_CHAR8:       return DDS_XTypes_TK_CHAR8;
+    case DDS_DYNAMIC_CHAR16:      return DDS_XTypes_TK_CHAR16;
+    case DDS_DYNAMIC_STRING8:     return DDS_XTypes_TK_STRING8;
+    case DDS_DYNAMIC_STRING16:    return DDS_XTypes_TK_STRING16;
+    case DDS_DYNAMIC_ENUMERATION: return DDS_XTypes_TK_ENUM;
+    case DDS_DYNAMIC_BITMASK:     return DDS_XTypes_TK_BITMASK;
+    case DDS_DYNAMIC_ALIAS:       return DDS_XTypes_TK_ALIAS;
+    case DDS_DYNAMIC_ARRAY:       return DDS_XTypes_TK_ARRAY;
+    case DDS_DYNAMIC_SEQUENCE:    return DDS_XTypes_TK_SEQUENCE;
+    case DDS_DYNAMIC_MAP:         return DDS_XTypes_TK_MAP;
+    case DDS_DYNAMIC_STRUCTURE:   return DDS_XTypes_TK_STRUCTURE;
+    case DDS_DYNAMIC_UNION:       return DDS_XTypes_TK_UNION;
+    case DDS_DYNAMIC_BITSET:      return DDS_XTypes_TK_BITSET;
+  }
+  return DDS_XTypes_TK_NONE;
+}
+
+static dds_dynamic_type_kind_t xtkind_to_typekind (DDS_XTypes_TypeKind xt_kind)
+{
+  switch (xt_kind) {
+    case DDS_XTypes_TK_BOOLEAN: return DDS_DYNAMIC_BOOLEAN;
+    case DDS_XTypes_TK_BYTE: return DDS_DYNAMIC_BYTE;
+    case DDS_XTypes_TK_INT16: return DDS_DYNAMIC_INT16;
+    case DDS_XTypes_TK_INT32: return DDS_DYNAMIC_INT32;
+    case DDS_XTypes_TK_INT64: return DDS_DYNAMIC_INT64;
+    case DDS_XTypes_TK_UINT16: return DDS_DYNAMIC_UINT16;
+    case DDS_XTypes_TK_UINT32: return DDS_DYNAMIC_UINT32;
+    case DDS_XTypes_TK_UINT64: return DDS_DYNAMIC_UINT64;
+    case DDS_XTypes_TK_FLOAT32: return DDS_DYNAMIC_FLOAT32;
+    case DDS_XTypes_TK_FLOAT64: return DDS_DYNAMIC_FLOAT64;
+    case DDS_XTypes_TK_FLOAT128: return DDS_DYNAMIC_FLOAT128;
+    case DDS_XTypes_TK_INT8: return DDS_DYNAMIC_INT8;
+    case DDS_XTypes_TK_UINT8: return DDS_DYNAMIC_UINT8;
+    case DDS_XTypes_TK_CHAR8: return DDS_DYNAMIC_CHAR8;
+    case DDS_XTypes_TK_CHAR16: return DDS_DYNAMIC_CHAR16;
+    case DDS_XTypes_TK_STRING8: return DDS_DYNAMIC_STRING8;
+    case DDS_XTypes_TK_STRING16: return DDS_DYNAMIC_STRING16;
+    case DDS_XTypes_TK_ENUM: return DDS_DYNAMIC_ENUMERATION;
+    case DDS_XTypes_TK_BITMASK: return DDS_DYNAMIC_BITMASK;
+    case DDS_XTypes_TK_ALIAS: return DDS_DYNAMIC_ALIAS;
+    case DDS_XTypes_TK_ARRAY: return DDS_DYNAMIC_ARRAY;
+    case DDS_XTypes_TK_SEQUENCE: return DDS_DYNAMIC_SEQUENCE;
+    case DDS_XTypes_TK_MAP: return DDS_DYNAMIC_MAP;
+    case DDS_XTypes_TK_STRUCTURE: return DDS_DYNAMIC_STRUCTURE;
+    case DDS_XTypes_TK_UNION: return DDS_DYNAMIC_UNION;
+    case DDS_XTypes_TK_BITSET: return DDS_DYNAMIC_BITSET;
+  }
+  return DDS_DYNAMIC_NONE;
+}
+
+static dds_dynamic_type_t dyntype_from_typespec (struct ddsi_domaingv *gv, dds_dynamic_type_spec_t type_spec)
+{
+  switch (type_spec.kind)
+  {
+    case DDS_DYNAMIC_TYPE_KIND_UNSET:
+      return (dds_dynamic_type_t) { .ret = DDS_RETCODE_OK };
+    case DDS_DYNAMIC_TYPE_KIND_PRIMITIVE: {
+      dds_dynamic_type_t type;
+      type.ret = ddsi_dynamic_type_create_primitive (gv, (struct ddsi_type **) &type.x, typekind_to_xtkind (type_spec.type.primitive));
+      return type;
+    }
+    case DDS_DYNAMIC_TYPE_KIND_DEFINITION:
+      return type_spec.type.type;
+  }
+
+  return (dds_dynamic_type_t) { .ret = DDS_RETCODE_BAD_PARAMETER };
+}
+
+static bool typespec_valid (dds_dynamic_type_spec_t type_spec, bool allow_unset)
+{
+  switch (type_spec.kind)
+  {
+    case DDS_DYNAMIC_TYPE_KIND_UNSET:
+      return allow_unset;
+    case DDS_DYNAMIC_TYPE_KIND_PRIMITIVE:
+      return type_spec.type.primitive >= DDS_DYNAMIC_BOOLEAN && type_spec.type.primitive <= DDS_DYNAMIC_CHAR16;
+    case DDS_DYNAMIC_TYPE_KIND_DEFINITION:
+      return type_spec.type.type.ret == DDS_RETCODE_OK && type_spec.type.type.x != NULL;
+  }
+  return false;
+}
+
+static bool union_disc_valid (dds_dynamic_type_spec_t type_spec)
+{
+  switch (type_spec.kind)
+  {
+    case DDS_DYNAMIC_TYPE_KIND_UNSET:
+      return false;
+    case DDS_DYNAMIC_TYPE_KIND_PRIMITIVE:
+      return type_spec.type.primitive == DDS_DYNAMIC_BOOLEAN || type_spec.type.primitive == DDS_DYNAMIC_BYTE ||
+        type_spec.type.primitive == DDS_DYNAMIC_INT8 || type_spec.type.primitive == DDS_DYNAMIC_INT16 || type_spec.type.primitive == DDS_DYNAMIC_INT32 || type_spec.type.primitive == DDS_DYNAMIC_INT64 ||
+        type_spec.type.primitive == DDS_DYNAMIC_UINT8 || type_spec.type.primitive == DDS_DYNAMIC_UINT16 || type_spec.type.primitive == DDS_DYNAMIC_UINT32 || type_spec.type.primitive == DDS_DYNAMIC_UINT64 ||
+        type_spec.type.primitive == DDS_DYNAMIC_CHAR8 || type_spec.type.primitive == DDS_DYNAMIC_CHAR16;
+    case DDS_DYNAMIC_TYPE_KIND_DEFINITION: {
+      if (type_spec.type.type.ret != DDS_RETCODE_OK || type_spec.type.type.x == NULL)
+        return false;
+      DDS_XTypes_TypeKind xtkind = ddsi_type_get_kind ((struct ddsi_type *) type_spec.type.type.x);
+      return xtkind == DDS_XTypes_TK_ENUM || xtkind == DDS_XTypes_TK_ALIAS;
+    }
+  }
+  return false;
+}
+
+static bool typename_valid (const char *name)
+{
+  size_t len = strlen (name);
+  return len > 0 && len < (sizeof (DDS_XTypes_QualifiedTypeName) - 1);
+}
+
+static bool membername_valid (const char *name)
+{
+  size_t len = strlen (name);
+  return len > 0 && len < (sizeof (DDS_XTypes_MemberName) - 1);
+}
+
+dds_dynamic_type_t dds_dynamic_type_create (dds_entity_t entity, dds_dynamic_type_descriptor_t descriptor)
+{
+  dds_dynamic_type_t type = { .ret = DDS_RETCODE_BAD_PARAMETER };
+  struct ddsi_domaingv *gv;
+  if ((gv = get_entity_gv (entity)) == NULL)
+    goto err;
+
+  switch (descriptor.kind)
+  {
+    case DDS_DYNAMIC_NONE:
+      type.ret = DDS_RETCODE_BAD_PARAMETER;
+      break;
+
+    case DDS_DYNAMIC_BOOLEAN:
+    case DDS_DYNAMIC_BYTE:
+    case DDS_DYNAMIC_INT16:
+    case DDS_DYNAMIC_INT32:
+    case DDS_DYNAMIC_INT64:
+    case DDS_DYNAMIC_UINT16:
+    case DDS_DYNAMIC_UINT32:
+    case DDS_DYNAMIC_UINT64:
+    case DDS_DYNAMIC_FLOAT32:
+    case DDS_DYNAMIC_FLOAT64:
+    case DDS_DYNAMIC_FLOAT128:
+    case DDS_DYNAMIC_INT8:
+    case DDS_DYNAMIC_UINT8:
+    case DDS_DYNAMIC_CHAR8:
+      type.ret = ddsi_dynamic_type_create_primitive (gv, (struct ddsi_type **) &type.x, descriptor.kind);
+      break;
+    case DDS_DYNAMIC_STRING8:
+      type.ret = ddsi_dynamic_type_create_string (gv, (struct ddsi_type **) &type.x);
+      break;
+    case DDS_DYNAMIC_ALIAS: {
+      if (!typespec_valid (descriptor.base_type, false) || !typename_valid (descriptor.name))
+        goto err;
+      dds_dynamic_type_t aliased_type = dyntype_from_typespec (gv, descriptor.base_type);
+      type.ret = ddsi_dynamic_type_create_alias (gv, (struct ddsi_type **) &type.x, descriptor.name, (struct ddsi_type **) &aliased_type.x);
+      break;
+    }
+    case DDS_DYNAMIC_ENUMERATION:
+      if (!typename_valid (descriptor.name))
+        goto err;
+      type.ret = ddsi_dynamic_type_create_enum (gv, (struct ddsi_type **) &type.x, descriptor.name);
+      break;
+    case DDS_DYNAMIC_BITMASK:
+      if (!typename_valid (descriptor.name))
+        goto err;
+      type.ret = ddsi_dynamic_type_create_bitmask (gv, (struct ddsi_type **) &type.x, descriptor.name);
+      break;
+    case DDS_DYNAMIC_ARRAY: {
+      if (!typespec_valid (descriptor.element_type, false) || !typename_valid (descriptor.name) || descriptor.num_bounds == 0 || descriptor.bounds == NULL)
+        goto err;
+      for (uint32_t n = 0; n < descriptor.num_bounds; n++)
+        if (descriptor.bounds[n] == 0)
+          goto err;
+      dds_dynamic_type_t element_type = dyntype_from_typespec (gv, descriptor.element_type);
+      type.ret = ddsi_dynamic_type_create_array (gv, (struct ddsi_type **) &type.x, descriptor.name, (struct ddsi_type **) &element_type.x, descriptor.num_bounds, descriptor.bounds);
+      break;
+    }
+    case DDS_DYNAMIC_SEQUENCE: {
+      if (!typespec_valid (descriptor.element_type, false) || !typename_valid (descriptor.name) || descriptor.num_bounds > 1 || (descriptor.num_bounds == 1 && descriptor.bounds == NULL))
+        goto err;
+      dds_dynamic_type_t element_type = dyntype_from_typespec (gv, descriptor.element_type);
+      type.ret = ddsi_dynamic_type_create_sequence (gv, (struct ddsi_type **) &type.x, descriptor.name, (struct ddsi_type **) &element_type.x, descriptor.num_bounds > 0 ? descriptor.bounds[0] : 0);
+      break;
+    }
+    case DDS_DYNAMIC_STRUCTURE: {
+      if (!typespec_valid (descriptor.base_type, true) || !typename_valid (descriptor.name))
+        goto err;
+      dds_dynamic_type_t base_type = dyntype_from_typespec (gv, descriptor.base_type);
+      type.ret = ddsi_dynamic_type_create_struct (gv, (struct ddsi_type **) &type.x, descriptor.name, (struct ddsi_type **) &base_type.x);
+      break;
+    }
+    case DDS_DYNAMIC_UNION: {
+      if (!typespec_valid (descriptor.discriminator_type, false) || !union_disc_valid (descriptor.discriminator_type) || !typename_valid (descriptor.name))
+        goto err;
+      dds_dynamic_type_t discriminator_type = dyntype_from_typespec (gv, descriptor.discriminator_type);
+      type.ret = ddsi_dynamic_type_create_union (gv, (struct ddsi_type **) &type.x, descriptor.name, (struct ddsi_type **) &discriminator_type.x);
+      break;
+    }
+
+    case DDS_DYNAMIC_CHAR16:
+    case DDS_DYNAMIC_STRING16:
+    case DDS_DYNAMIC_MAP:
+    case DDS_DYNAMIC_BITSET:
+      type.ret = DDS_RETCODE_UNSUPPORTED;
+      break;
+  }
+
+err:
+  return type;
+}
+
+static dds_return_t check_type_param (const dds_dynamic_type_t *type, bool allow_non_constructing)
+{
+  if (type == NULL)
+    return DDS_RETCODE_BAD_PARAMETER;
+  if (type->ret != DDS_RETCODE_OK)
+    return type->ret;
+  if (!allow_non_constructing && !ddsi_dynamic_type_is_constructing ((struct ddsi_type *) type->x))
+    return DDS_RETCODE_PRECONDITION_NOT_MET;
+  return DDS_RETCODE_OK;
+}
+
+dds_return_t dds_dynamic_type_add_enum_literal (dds_dynamic_type_t *type, const char *name, dds_dynamic_enum_literal_value_t value, bool is_default)
+{
+  dds_return_t ret;
+  if ((ret = check_type_param (type, false)) != DDS_RETCODE_OK)
+    return ret;
+  else if (!membername_valid (name))
+    type->ret = DDS_RETCODE_BAD_PARAMETER;
+  else
+  {
+    type->ret = ddsi_dynamic_type_add_enum_literal ((struct ddsi_type *) type->x, (struct ddsi_dynamic_type_enum_literal_param) {
+      .name = name,
+      .is_auto_value = value.value_kind == DDS_DYNAMIC_ENUM_LITERAL_VALUE_NEXT_AVAIL,
+      .value = value.value,
+      .is_default = is_default
+    });
+  }
+  return type->ret;
+}
+
+dds_return_t dds_dynamic_type_add_bitmask_field (dds_dynamic_type_t *type, const char *name, uint16_t position)
+{
+  dds_return_t ret;
+  if ((ret = check_type_param (type, false)) != DDS_RETCODE_OK)
+    return ret;
+  else if (!membername_valid (name))
+    type->ret = DDS_RETCODE_BAD_PARAMETER;
+  else
+  {
+    type->ret = ddsi_dynamic_type_add_bitmask_field ((struct ddsi_type *) type->x, (struct ddsi_dynamic_type_bitmask_field_param) {
+      .name = name,
+      .is_auto_position = (position == DDS_DYNAMIC_BITMASK_POSITION_AUTO),
+      .position = (position == DDS_DYNAMIC_BITMASK_POSITION_AUTO) ? 0 : position
+    });
+  }
+  return type->ret;
+}
+
+dds_return_t dds_dynamic_type_add_member (dds_dynamic_type_t *type, dds_dynamic_member_descriptor_t member_descriptor)
+{
+  dds_return_t ret;
+  if ((ret = check_type_param (type, false)) != DDS_RETCODE_OK)
+    return ret;
+
+  if (!membername_valid (member_descriptor.name))
+  {
+    type->ret = DDS_RETCODE_BAD_PARAMETER;
+    goto err;
+  }
+
+  switch (xtkind_to_typekind (ddsi_type_get_kind ((struct ddsi_type *) type->x)))
+  {
+    case DDS_DYNAMIC_ENUMERATION:
+      type->ret = dds_dynamic_type_add_enum_literal (type, member_descriptor.name, DDS_DYNAMIC_ENUM_LITERAL_VALUE_AUTO, member_descriptor.default_label);
+      break;
+    case DDS_DYNAMIC_BITMASK:
+      type->ret = dds_dynamic_type_add_bitmask_field (type, member_descriptor.name, DDS_DYNAMIC_BITMASK_POSITION_AUTO);
+      break;
+    case DDS_DYNAMIC_UNION: {
+      if (!typespec_valid (member_descriptor.type, false) ||
+        (!member_descriptor.default_label && (member_descriptor.num_labels == 0 || member_descriptor.labels == NULL)))
+      {
+        type->ret = DDS_RETCODE_BAD_PARAMETER;
+        goto err;
+      }
+      dds_dynamic_type_t member_type = dyntype_from_typespec (ddsi_type_get_gv ((struct ddsi_type *) type->x), member_descriptor.type);
+      type->ret = ddsi_dynamic_type_add_union_member ((struct ddsi_type *) type->x, (struct ddsi_type **) &member_type.x,
+          (struct ddsi_dynamic_type_union_member_param) {
+            .id = member_descriptor.id,
+            .name = member_descriptor.name,
+            .index = member_descriptor.index,
+            .is_default = member_descriptor.default_label,
+            .labels = member_descriptor.labels,
+            .n_labels = member_descriptor.num_labels
+          });
+      if (type->ret != DDS_RETCODE_OK)
+        dds_dynamic_type_unref (&member_type);
+      break;
+    }
+    case DDS_DYNAMIC_STRUCTURE: {
+      if (!typespec_valid (member_descriptor.type, false))
+      {
+        type->ret = DDS_RETCODE_BAD_PARAMETER;
+        goto err;
+      }
+      dds_dynamic_type_t member_type = dyntype_from_typespec (ddsi_type_get_gv ((struct ddsi_type *) type->x), member_descriptor.type);
+      type->ret = ddsi_dynamic_type_add_struct_member ((struct ddsi_type *) type->x, (struct ddsi_type **) &member_type.x,
+          (struct ddsi_dynamic_type_struct_member_param) {
+            .id = member_descriptor.id,
+            .name = member_descriptor.name,
+            .index = member_descriptor.index,
+            .is_key = false
+          });
+      if (type->ret != DDS_RETCODE_OK)
+        dds_dynamic_type_unref (&member_type);
+      break;
+    }
+    default:
+      type->ret = DDS_RETCODE_BAD_PARAMETER;
+      break;
+  }
+
+err:
+  return type->ret;
+}
+
+dds_return_t dds_dynamic_type_set_extensibility (dds_dynamic_type_t *type, enum dds_dynamic_type_extensibility extensibility)
+{
+  dds_return_t ret;
+  if ((ret = check_type_param (type, false)) != DDS_RETCODE_OK)
+    return ret;
+
+  if (extensibility > DDS_DYNAMIC_TYPE_EXT_MUTABLE)
+    return DDS_RETCODE_BAD_PARAMETER;
+
+  switch (xtkind_to_typekind (ddsi_type_get_kind ((struct ddsi_type *) type->x)))
+  {
+    case DDS_DYNAMIC_STRUCTURE:
+    case DDS_DYNAMIC_UNION:
+    case DDS_DYNAMIC_ENUMERATION:
+    case DDS_DYNAMIC_BITMASK:
+      type->ret = ddsi_dynamic_type_set_extensibility ((struct ddsi_type *) type->x, extensibility);
+      break;
+    default:
+      type->ret = DDS_RETCODE_BAD_PARAMETER;
+      break;
+  }
+
+  return type->ret;
+}
+
+dds_return_t dds_dynamic_type_set_nested (dds_dynamic_type_t *type, bool is_nested)
+{
+  dds_return_t ret;
+  if ((ret = check_type_param (type, false)) != DDS_RETCODE_OK)
+    return ret;
+
+  switch (xtkind_to_typekind (ddsi_type_get_kind ((struct ddsi_type *) type->x)))
+  {
+    case DDS_DYNAMIC_STRUCTURE:
+    case DDS_DYNAMIC_UNION:
+      type->ret = ddsi_dynamic_type_set_nested ((struct ddsi_type *) type->x, is_nested);
+      break;
+    default:
+      type->ret = DDS_RETCODE_BAD_PARAMETER;
+      break;
+  }
+
+  return type->ret;
+}
+
+dds_return_t dds_dynamic_type_set_autoid (dds_dynamic_type_t *type, enum dds_dynamic_type_autoid value)
+{
+  dds_return_t ret;
+  if ((ret = check_type_param (type, false)) != DDS_RETCODE_OK)
+    return ret;
+
+  if (value != DDS_DYNAMIC_TYPE_AUTOID_HASH && value != DDS_DYNAMIC_TYPE_AUTOID_SEQUENTIAL)
+    type->ret = DDS_RETCODE_BAD_PARAMETER;
+  else
+  {
+    switch (xtkind_to_typekind (ddsi_type_get_kind ((struct ddsi_type *) type->x)))
+    {
+      case DDS_DYNAMIC_STRUCTURE:
+      case DDS_DYNAMIC_UNION:
+        type->ret = ddsi_dynamic_type_set_autoid ((struct ddsi_type *) type->x, value);
+        break;
+      default:
+        type->ret = DDS_RETCODE_BAD_PARAMETER;
+        break;
+    }
+  }
+  return type->ret;
+}
+
+dds_return_t dds_dynamic_type_set_bit_bound (dds_dynamic_type_t *type, uint16_t bit_bound)
+{
+  dds_return_t ret;
+  if ((ret = check_type_param (type, false)) != DDS_RETCODE_OK)
+    return ret;
+
+  switch (xtkind_to_typekind (ddsi_type_get_kind ((struct ddsi_type *) type->x)))
+  {
+    case DDS_DYNAMIC_ENUMERATION:
+      type->ret = (bit_bound > 0 && bit_bound <= 32) ? ddsi_dynamic_type_set_bitbound ((struct ddsi_type *) type->x, bit_bound) : DDS_RETCODE_BAD_PARAMETER;
+      break;
+    case DDS_DYNAMIC_BITMASK:
+      type->ret = (bit_bound > 0 && bit_bound <= 64) ? ddsi_dynamic_type_set_bitbound ((struct ddsi_type *) type->x, bit_bound) : DDS_RETCODE_BAD_PARAMETER;
+      break;
+    default:
+      type->ret = DDS_RETCODE_BAD_PARAMETER;
+      break;
+  }
+  return type->ret;
+}
+
+typedef dds_return_t (*set_struct_prop_fn) (struct ddsi_type *type, uint32_t member_id, bool is_key);
+
+static dds_return_t set_member_bool_prop (dds_dynamic_type_t *type, uint32_t member_id, bool value, set_struct_prop_fn set_fn_struct, set_struct_prop_fn set_fn_union)
+{
+  dds_return_t ret;
+  if ((ret = check_type_param (type, false)) != DDS_RETCODE_OK)
+    return ret;
+
+  switch (xtkind_to_typekind (ddsi_type_get_kind ((struct ddsi_type *) type->x)))
+  {
+    case DDS_DYNAMIC_STRUCTURE:
+      type->ret = set_fn_struct ? set_fn_struct ((struct ddsi_type *) type->x, member_id, value) : DDS_RETCODE_BAD_PARAMETER;
+      break;
+    case DDS_DYNAMIC_UNION:
+      type->ret = set_fn_union ? set_fn_union ((struct ddsi_type *) type->x, member_id, value) : DDS_RETCODE_BAD_PARAMETER;
+      break;
+    default:
+      type->ret = DDS_RETCODE_BAD_PARAMETER;
+      break;
+  }
+  return type->ret;
+}
+
+dds_return_t dds_dynamic_member_set_key (dds_dynamic_type_t *type, uint32_t member_id, bool is_key)
+{
+  return (type->ret = set_member_bool_prop (type, member_id, is_key, ddsi_dynamic_type_member_set_key, 0));
+}
+
+dds_return_t dds_dynamic_member_set_optional (dds_dynamic_type_t *type, uint32_t member_id, bool is_optional)
+{
+  return (type->ret = set_member_bool_prop (type, member_id, is_optional, ddsi_dynamic_type_member_set_optional, 0));
+}
+
+dds_return_t dds_dynamic_member_set_external (dds_dynamic_type_t *type, uint32_t member_id, bool is_external)
+{
+  return (type->ret = set_member_bool_prop (type, member_id, is_external, ddsi_dynamic_struct_member_set_external, ddsi_dynamic_union_member_set_external));
+}
+
+dds_return_t dds_dynamic_member_set_hashid (dds_dynamic_type_t *type, uint32_t member_id, const char *hash_member_name)
+{
+  dds_return_t ret;
+  if ((ret = check_type_param (type, false)) != DDS_RETCODE_OK)
+    return ret;
+
+  switch (xtkind_to_typekind (ddsi_type_get_kind ((struct ddsi_type *) type->x)))
+  {
+    case DDS_DYNAMIC_STRUCTURE:
+    case DDS_DYNAMIC_UNION:
+      type->ret = ddsi_dynamic_type_member_set_hashid ((struct ddsi_type *) type->x, member_id, hash_member_name);
+      break;
+    default:
+      type->ret = DDS_RETCODE_BAD_PARAMETER;
+      break;
+  }
+  return type->ret;
+}
+
+dds_return_t dds_dynamic_member_set_must_understand (dds_dynamic_type_t *type, uint32_t member_id, bool is_must_understand)
+{
+  return (type->ret = set_member_bool_prop (type, member_id, is_must_understand, ddsi_dynamic_type_member_set_must_understand, 0));
+}
+
+dds_return_t dds_dynamic_type_register (dds_dynamic_type_t *type, dds_typeinfo_t **type_info)
+{
+  dds_return_t ret;
+  if ((ret = check_type_param (type, false)) != DDS_RETCODE_OK)
+    return ret;
+  return ddsi_dynamic_type_register ((struct ddsi_type **) &type->x, type_info);
+}
+
+dds_dynamic_type_t dds_dynamic_type_ref (dds_dynamic_type_t *type)
+{
+  dds_dynamic_type_t ref;
+  if ((ref.ret = check_type_param (type, true)) != DDS_RETCODE_OK)
+    return ref;
+  ref.x = ddsi_dynamic_type_ref ((struct ddsi_type *) type->x);
+  return ref;
+}
+
+dds_return_t dds_dynamic_type_unref (dds_dynamic_type_t *type)
+{
+  if (type == NULL)
+    return DDS_RETCODE_BAD_PARAMETER;
+  ddsi_dynamic_type_unref ((struct ddsi_type *) type->x);
+  return DDS_RETCODE_OK;
+}
+
+dds_dynamic_type_t dds_dynamic_type_dup (const dds_dynamic_type_t *src)
+{
+  dds_dynamic_type_t dst;
+  if ((dst.ret = check_type_param (src, true)) == DDS_RETCODE_OK)
+  {
+    dst.x = ddsi_dynamic_type_dup ((struct ddsi_type *) src->x);
+    dst.ret = src->ret;
+  }
+  return dst;
+}

--- a/src/core/ddsc/src/dds_topic.c
+++ b/src/core/ddsc/src/dds_topic.c
@@ -1048,7 +1048,7 @@ dds_return_t dds_get_type_name (dds_entity_t topic, char *name, size_t size)
 
 DDS_GET_STATUS(topic, inconsistent_topic, INCONSISTENT_TOPIC, total_count_change)
 
-#ifdef DDS_HAS_TOPIC_DISCOVERY
+#ifdef DDS_HAS_TYPE_DISCOVERY
 
 dds_return_t dds_create_topic_descriptor (dds_find_scope_t scope, dds_entity_t participant, const dds_typeinfo_t *type_info, dds_duration_t timeout, dds_topic_descriptor_t **descriptor)
 {
@@ -1097,7 +1097,7 @@ dds_return_t dds_delete_topic_descriptor (dds_topic_descriptor_t *descriptor)
   return DDS_RETCODE_OK;
 }
 
-#else
+#else /* DDS_HAS_TYPE_DISCOVERY */
 
 dds_return_t dds_create_topic_descriptor (dds_find_scope_t scope, dds_entity_t participant, const dds_typeinfo_t *type_info, dds_duration_t timeout, dds_topic_descriptor_t **descriptor)
 {
@@ -1111,7 +1111,7 @@ dds_return_t dds_delete_topic_descriptor (dds_topic_descriptor_t *descriptor)
   return DDS_RETCODE_UNSUPPORTED;
 }
 
-#endif /* DDS_HAS_TOPIC_DISCOVERY */
+#endif /* DDS_HAS_TYPE_DISCOVERY */
 
 void dds_cdrstream_desc_from_topic_desc (struct dds_cdrstream_desc *desc, const dds_topic_descriptor_t *topic_desc)
 {

--- a/src/core/ddsc/tests/CMakeLists.txt
+++ b/src/core/ddsc/tests/CMakeLists.txt
@@ -88,7 +88,8 @@ set(ddsc_test_sources
     "test_common.c"
     "test_oneliner.c"
     "test_oneliner.h"
-    "cdrstream.c")
+    "cdrstream.c"
+  )
 
 if(ENABLE_LIFESPAN)
   list(APPEND ddsc_test_sources "lifespan.c")
@@ -102,7 +103,9 @@ if(ENABLE_TYPE_DISCOVERY)
   list(APPEND ddsc_test_sources
     "xtypes.c"
     "data_representation.c"
-    "typebuilder.c")
+    "typebuilder.c"
+    "dynamic_type.c"
+  )
 endif()
 
 if(ENABLE_TOPIC_DISCOVERY)

--- a/src/core/ddsc/tests/dynamic_type.c
+++ b/src/core/ddsc/tests/dynamic_type.c
@@ -1,0 +1,559 @@
+/*
+ * Copyright(c) 2023 ZettaScale Technology and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+#include "CUnit/Theory.h"
+#include "dds/dds.h"
+#include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/md5.h"
+#include "dds/ddsi/ddsi_typelib.h"
+#include "ddsi__dynamic_type.h"
+#include "ddsi__xt_impl.h"
+#include "test_util.h"
+
+dds_entity_t participant;
+
+static void dynamic_type_init(void)
+{
+  participant = dds_create_participant (DDS_DOMAIN_DEFAULT, NULL, NULL);
+  CU_ASSERT_FATAL (participant >= 0);
+}
+
+static void dynamic_type_fini(void)
+{
+  dds_return_t ret = dds_delete (participant);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
+}
+
+static void do_test (dds_dynamic_type_t *dtype)
+{
+  dds_return_t ret;
+  dds_typeinfo_t *type_info;
+  ret = dds_dynamic_type_register (dtype, &type_info);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
+
+  dds_topic_descriptor_t *descriptor;
+  ret = dds_create_topic_descriptor (DDS_FIND_SCOPE_LOCAL_DOMAIN, participant, type_info, 0, &descriptor);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
+
+  char topic_name[100];
+  create_unique_topic_name ("ddsc_dynamic_type", topic_name, sizeof (topic_name));
+  dds_entity_t topic = dds_create_topic (participant, descriptor, topic_name, NULL, NULL);
+  CU_ASSERT_FATAL (topic >= 0);
+
+  dds_free_typeinfo (type_info);
+  dds_delete_topic_descriptor (descriptor);
+  dds_dynamic_type_unref (dtype);
+}
+
+CU_Test (ddsc_dynamic_type, basic, .init = dynamic_type_init, .fini = dynamic_type_fini)
+{
+  dds_dynamic_type_t dstruct = dds_dynamic_type_create (participant,
+    (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_STRUCTURE, .name = "dynamic_struct" });
+  dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER_PRIM(DDS_DYNAMIC_UINT32, "member_uint32"));
+  do_test (&dstruct);
+}
+
+/* Copy of the DDS_DYNAMIC_TYPE_SPEC_PRIM macro, without the explicit cast because
+   that causes a build error on MSVC when used in a designated initializer. */
+#define TYPE_SPEC_PRIM_NC(p) { .kind = DDS_DYNAMIC_TYPE_KIND_PRIMITIVE, .type.primitive = (p) }
+
+CU_Test (ddsc_dynamic_type, type_create, .init = dynamic_type_init, .fini = dynamic_type_fini)
+{
+  static const uint32_t bounds[] = { 10 };
+  static const struct {
+    dds_dynamic_type_descriptor_t desc;
+    dds_return_t ret;
+  } tests[] = {
+    { { .kind = DDS_DYNAMIC_NONE, .name = "t" }, DDS_RETCODE_BAD_PARAMETER },
+    { { .kind = DDS_DYNAMIC_BOOLEAN, .name = "t" }, DDS_RETCODE_OK },
+    { { .kind = DDS_DYNAMIC_BYTE, .name = "t" }, DDS_RETCODE_OK },
+    { { .kind = DDS_DYNAMIC_INT16, .name = "t" }, DDS_RETCODE_OK },
+    { { .kind = DDS_DYNAMIC_INT32, .name = "t" }, DDS_RETCODE_OK },
+    { { .kind = DDS_DYNAMIC_INT64, .name = "t" }, DDS_RETCODE_OK },
+    { { .kind = DDS_DYNAMIC_UINT16, .name = "t" }, DDS_RETCODE_OK },
+    { { .kind = DDS_DYNAMIC_UINT32, .name = "t" }, DDS_RETCODE_OK },
+    { { .kind = DDS_DYNAMIC_UINT64, .name = "t" }, DDS_RETCODE_OK },
+    { { .kind = DDS_DYNAMIC_FLOAT32, .name = "t" }, DDS_RETCODE_OK },
+    { { .kind = DDS_DYNAMIC_FLOAT64, .name = "t" }, DDS_RETCODE_OK },
+    { { .kind = DDS_DYNAMIC_FLOAT128, .name = "t" }, DDS_RETCODE_OK },
+    { { .kind = DDS_DYNAMIC_INT8, .name = "t" }, DDS_RETCODE_OK },
+    { { .kind = DDS_DYNAMIC_UINT8, .name = "t" }, DDS_RETCODE_OK },
+    { { .kind = DDS_DYNAMIC_CHAR8, .name = "t" }, DDS_RETCODE_OK },
+    { { .kind = DDS_DYNAMIC_CHAR16, .name = "t" }, DDS_RETCODE_UNSUPPORTED },
+    { { .kind = DDS_DYNAMIC_STRING8, .name = "t" }, DDS_RETCODE_OK },
+    { { .kind = DDS_DYNAMIC_STRING16, .name = "t" }, DDS_RETCODE_UNSUPPORTED },
+    { { .kind = DDS_DYNAMIC_ENUMERATION, .name = "t" }, DDS_RETCODE_OK },
+    { { .kind = DDS_DYNAMIC_BITMASK, .name = "t" }, DDS_RETCODE_OK },
+    { { .kind = DDS_DYNAMIC_ALIAS, .name = "t", .base_type = TYPE_SPEC_PRIM_NC(DDS_DYNAMIC_INT32) }, DDS_RETCODE_OK },
+    { { .kind = DDS_DYNAMIC_ARRAY, .name = "t", .element_type = TYPE_SPEC_PRIM_NC(DDS_DYNAMIC_INT32), .bounds = bounds, .num_bounds = 1 }, DDS_RETCODE_OK },
+    { { .kind = DDS_DYNAMIC_SEQUENCE, .name = "t", .element_type = TYPE_SPEC_PRIM_NC(DDS_DYNAMIC_INT32) }, DDS_RETCODE_OK },
+    { { .kind = DDS_DYNAMIC_MAP, .name = "t" }, DDS_RETCODE_UNSUPPORTED },
+    { { .kind = DDS_DYNAMIC_STRUCTURE, .name = "t" }, DDS_RETCODE_OK },
+    { { .kind = DDS_DYNAMIC_UNION, .name = "t", .discriminator_type = TYPE_SPEC_PRIM_NC(DDS_DYNAMIC_INT32) }, DDS_RETCODE_OK },
+    { { .kind = DDS_DYNAMIC_BITSET, .name = "t" }, DDS_RETCODE_UNSUPPORTED }
+  };
+
+  for (uint32_t i = 0; i < sizeof (tests) / sizeof (tests[0]); i++)
+  {
+    dds_dynamic_type_t dtype = dds_dynamic_type_create (participant, tests[i].desc);
+    printf("create type kind %u, return code %d\n", tests[i].desc.kind, dtype.ret);
+    CU_ASSERT_EQUAL_FATAL (dtype.ret, tests[i].ret);
+    if (tests[i].ret == DDS_RETCODE_OK)
+      dds_dynamic_type_unref (&dtype);
+  }
+}
+
+static struct ddsi_type * get_ddsi_type (dds_dynamic_type_t *dtype)
+{
+  struct ddsi_domaingv *gv = get_domaingv (participant);
+  dds_typeinfo_t *type_info;
+  dds_return_t ret = dds_dynamic_type_register (dtype, &type_info);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
+
+  const ddsi_typeid_t *type_id = ddsi_typeinfo_complete_typeid (type_info);
+  struct ddsi_type *type = ddsi_type_lookup (gv, type_id);
+  CU_ASSERT_FATAL (type != NULL);
+  dds_free_typeinfo (type_info);
+  return type;
+}
+
+CU_Test (ddsc_dynamic_type, struct_member_id, .init = dynamic_type_init, .fini = dynamic_type_fini)
+{
+  dds_dynamic_type_t dstruct;
+
+  dstruct = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_STRUCTURE, .name = "t" });
+  dds_dynamic_type_set_autoid (&dstruct, DDS_DYNAMIC_TYPE_AUTOID_HASH);
+  dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER_PRIM(DDS_DYNAMIC_UINT16, "m1"));
+  dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER_ID_PRIM(DDS_DYNAMIC_UINT16, "m2", 123));
+  dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER_PRIM(DDS_DYNAMIC_UINT16, "m3"));
+  dds_dynamic_type_add_member (&dstruct, ((dds_dynamic_member_descriptor_t) {
+      .type = DDS_DYNAMIC_TYPE_SPEC_PRIM(DDS_DYNAMIC_UINT16),
+      .name = "m0",
+      .id = DDS_DYNAMIC_MEMBER_ID_AUTO,
+      .index = DDS_DYNAMIC_MEMBER_INDEX_START
+  }));
+
+  struct ddsi_type *type = get_ddsi_type (&dstruct);
+  CU_ASSERT_EQUAL_FATAL (type->xt._u.structure.members.length, 4);
+  CU_ASSERT_EQUAL_FATAL (type->xt._u.structure.members.seq[0].id, ddsi_dynamic_type_member_hashid ("m0"));
+  CU_ASSERT_EQUAL_FATAL (type->xt._u.structure.members.seq[1].id, ddsi_dynamic_type_member_hashid ("m1"));
+  CU_ASSERT_EQUAL_FATAL (type->xt._u.structure.members.seq[2].id, 123);
+  CU_ASSERT_EQUAL_FATAL (type->xt._u.structure.members.seq[3].id, ddsi_dynamic_type_member_hashid ("m3"));
+
+  dds_dynamic_type_unref (&dstruct);
+}
+
+CU_Test (ddsc_dynamic_type, extensibility_invalid, .init = dynamic_type_init, .fini = dynamic_type_fini)
+{
+  dds_return_t ret;
+
+  // Type parameter NULL
+  ret = dds_dynamic_type_set_extensibility (NULL, DDS_DYNAMIC_TYPE_EXT_APPENDABLE);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_BAD_PARAMETER);
+
+  // Invalid type
+  dds_dynamic_type_t dbool = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_BOOLEAN });
+  ret = dds_dynamic_type_set_extensibility (&dbool, DDS_DYNAMIC_TYPE_EXT_FINAL);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_BAD_PARAMETER);
+  dds_dynamic_type_unref (&dbool);
+
+  // Invalid extensibility value
+  dds_dynamic_type_t dstruct = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_STRUCTURE, .name = "t" });
+  ret = dds_dynamic_type_set_extensibility (&dstruct, (enum dds_dynamic_type_extensibility) 99);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_BAD_PARAMETER);
+  dds_dynamic_type_unref (&dstruct);
+
+  // Type may not have members
+  dstruct = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_STRUCTURE, .name = "t" });
+  dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER_PRIM(DDS_DYNAMIC_UINT16, "m1"));
+  ret = dds_dynamic_type_set_extensibility (&dstruct, DDS_DYNAMIC_TYPE_EXT_APPENDABLE);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_PRECONDITION_NOT_MET);
+  dds_dynamic_type_unref (&dstruct);
+
+  // Type must be in constructing state
+  dstruct = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_STRUCTURE, .name = "t" });
+  dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER_PRIM(DDS_DYNAMIC_UINT16, "m1"));
+  (void) get_ddsi_type (&dstruct);
+  ret = dds_dynamic_type_set_extensibility (&dstruct, DDS_DYNAMIC_TYPE_EXT_APPENDABLE);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_PRECONDITION_NOT_MET);
+  dds_dynamic_type_unref (&dstruct);
+}
+
+CU_Test (ddsc_dynamic_type, extensibility_valid, .init = dynamic_type_init, .fini = dynamic_type_fini)
+{
+  static const struct {
+    bool default_ext;
+    enum dds_dynamic_type_extensibility dyn_ext;
+    uint16_t xt_ext;
+  } tests[] = {
+    { true, 0, DDS_XTypes_IS_FINAL },
+    { false, DDS_DYNAMIC_TYPE_EXT_FINAL, DDS_XTypes_IS_FINAL },
+    { false, DDS_DYNAMIC_TYPE_EXT_APPENDABLE, DDS_XTypes_IS_APPENDABLE },
+    { false, DDS_DYNAMIC_TYPE_EXT_MUTABLE, DDS_XTypes_IS_MUTABLE }
+  };
+
+  for (uint32_t i = 0; i < sizeof (tests) / sizeof (tests[0]); i++)
+  {
+    dds_dynamic_type_t dstruct = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_STRUCTURE, .name = "t" });
+    if (!tests[i].default_ext)
+      dds_dynamic_type_set_extensibility (&dstruct, tests[i].dyn_ext);
+    dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER_PRIM(DDS_DYNAMIC_UINT16, "m1"));
+
+    struct ddsi_type *type = get_ddsi_type (&dstruct);
+    uint16_t exp_xt_ext = tests[i].default_ext ? DDS_XTypes_IS_FINAL : tests[i].xt_ext;
+    CU_ASSERT_FATAL (type->xt._u.structure.flags & exp_xt_ext);
+
+    dds_dynamic_type_unref (&dstruct);
+  }
+}
+
+CU_Test (ddsc_dynamic_type, bit_bound, .init = dynamic_type_init, .fini = dynamic_type_fini)
+{
+  dds_return_t ret;
+
+  // Type parameter NULL
+  ret = dds_dynamic_type_set_bit_bound (NULL, 16);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_BAD_PARAMETER);
+
+  // Invalid type kind
+  dds_dynamic_type_t dstruct = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_STRUCTURE, .name = "t" });
+  ret = dds_dynamic_type_set_bit_bound (NULL, 16);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_BAD_PARAMETER);
+  dds_dynamic_type_unref (&dstruct);
+
+  // Invalid bit-bound value
+  dds_dynamic_type_t dbitmask = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_BITMASK, .name = "b" });
+  dds_dynamic_type_t denum = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_ENUMERATION, .name = "e" });
+  ret = dds_dynamic_type_set_bit_bound (&dbitmask, 0);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_BAD_PARAMETER);
+  ret = dds_dynamic_type_set_bit_bound (&dbitmask, 65);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_BAD_PARAMETER);
+  ret = dds_dynamic_type_set_bit_bound (&denum, 0);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_BAD_PARAMETER);
+  ret = dds_dynamic_type_set_bit_bound (&denum, 33);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_BAD_PARAMETER);
+  dds_dynamic_type_unref (&dbitmask);
+  dds_dynamic_type_unref (&denum);
+
+  // Type may not have members
+  dbitmask = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_BITMASK, .name = "b" });
+  dds_dynamic_type_add_bitmask_field (&dbitmask, "b1", 1);
+  ret = dds_dynamic_type_set_bit_bound (&dbitmask, 16);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_PRECONDITION_NOT_MET);
+  dds_dynamic_type_unref (&dbitmask);
+
+  // Type must be in constructing state
+  dbitmask = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_BITMASK, .name = "b" });
+  dds_dynamic_type_add_bitmask_field (&dbitmask, "b1", 1);
+  (void) get_ddsi_type (&dbitmask);
+  ret = dds_dynamic_type_set_bit_bound (&dbitmask, 16);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_PRECONDITION_NOT_MET);
+  dds_dynamic_type_unref (&dbitmask);
+}
+
+CU_Test (ddsc_dynamic_type, bitmask, .init = dynamic_type_init, .fini = dynamic_type_fini)
+{
+  dds_dynamic_type_t dbitmask = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_BITMASK, .name = "b" });
+  dds_return_t ret = dds_dynamic_type_set_bit_bound (&dbitmask, 16);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
+  dds_dynamic_type_add_bitmask_field (&dbitmask, "b_auto0", DDS_DYNAMIC_BITMASK_POSITION_AUTO);
+  dds_dynamic_type_add_bitmask_field (&dbitmask, "b_auto1", DDS_DYNAMIC_BITMASK_POSITION_AUTO);
+  dds_dynamic_type_add_bitmask_field (&dbitmask, "b_10", 10);
+  dds_dynamic_type_add_bitmask_field (&dbitmask, "b_5", 5);
+
+  struct ddsi_type *type = get_ddsi_type (&dbitmask);
+  CU_ASSERT_EQUAL_FATAL (type->xt._u.bitmask.bit_bound, 16);
+  CU_ASSERT_EQUAL_FATAL (type->xt._u.bitmask.bitflags.length, 4);
+  CU_ASSERT_EQUAL_FATAL (type->xt._u.bitmask.bitflags.seq[0].position, 0);
+  CU_ASSERT_EQUAL_FATAL (type->xt._u.bitmask.bitflags.seq[1].position, 1);
+  CU_ASSERT_EQUAL_FATAL (type->xt._u.bitmask.bitflags.seq[2].position, 10);
+  CU_ASSERT_EQUAL_FATAL (type->xt._u.bitmask.bitflags.seq[3].position, 5);
+
+  dds_dynamic_type_unref (&dbitmask);
+}
+
+CU_Test (ddsc_dynamic_type, bitmask_field_invalid, .init = dynamic_type_init, .fini = dynamic_type_fini)
+{
+  // Bitmask type NULL
+  dds_return_t ret = dds_dynamic_type_add_bitmask_field (NULL, "b1", 1);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_BAD_PARAMETER);
+
+  // Name property missing
+  dds_dynamic_type_t dbitmask = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_BITMASK, .name = "b" });
+  ret = dds_dynamic_type_add_bitmask_field (&dbitmask, "", 1);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_BAD_PARAMETER);
+  dds_dynamic_type_unref (&dbitmask);
+
+  // Position in use
+  dbitmask = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_BITMASK, .name = "b" });
+  dds_dynamic_type_add_bitmask_field (&dbitmask, "b1", 1);
+  ret = dds_dynamic_type_add_bitmask_field (&dbitmask, "b2", 1);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_BAD_PARAMETER);
+  dds_dynamic_type_unref (&dbitmask);
+
+  // Invalid position for bit-bound
+  dbitmask = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_BITMASK, .name = "b" });
+  dds_dynamic_type_set_bit_bound (&dbitmask, 2);
+  ret = dds_dynamic_type_add_bitmask_field (&dbitmask, "b1", 2);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_BAD_PARAMETER);
+  dds_dynamic_type_unref (&dbitmask);
+}
+
+CU_Test (ddsc_dynamic_type, enum_type, .init = dynamic_type_init, .fini = dynamic_type_fini)
+{
+  dds_dynamic_type_t denum = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_ENUMERATION, .name = "e" });
+  dds_return_t ret = dds_dynamic_type_set_bit_bound (&denum, 31);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
+  dds_dynamic_type_add_enum_literal (&denum, "e_auto0", DDS_DYNAMIC_ENUM_LITERAL_VALUE_AUTO, false);
+  dds_dynamic_type_add_enum_literal (&denum, "e_auto1", DDS_DYNAMIC_ENUM_LITERAL_VALUE_AUTO, true);
+  dds_dynamic_type_add_enum_literal (&denum, "e_31", DDS_DYNAMIC_ENUM_LITERAL_VALUE ((1u << 31) - 1), false);
+  dds_dynamic_type_add_enum_literal (&denum, "e_2", DDS_DYNAMIC_ENUM_LITERAL_VALUE (2), false);
+
+  struct ddsi_type *type = get_ddsi_type (&denum);
+  CU_ASSERT_EQUAL_FATAL (type->xt._u.bitmask.bit_bound, 31);
+  CU_ASSERT_EQUAL_FATAL (type->xt._u.enum_type.literals.length, 4);
+
+  CU_ASSERT_EQUAL_FATAL (type->xt._u.enum_type.literals.seq[0].value, 0);
+  CU_ASSERT_FATAL (!(type->xt._u.enum_type.literals.seq[0].flags & DDS_XTypes_IS_DEFAULT));
+
+  CU_ASSERT_EQUAL_FATAL (type->xt._u.enum_type.literals.seq[1].value, 1);
+  CU_ASSERT_FATAL (type->xt._u.enum_type.literals.seq[1].flags & DDS_XTypes_IS_DEFAULT);
+
+  CU_ASSERT_EQUAL_FATAL (type->xt._u.enum_type.literals.seq[2].value, (1u << 31) - 1);
+  CU_ASSERT_FATAL (!(type->xt._u.enum_type.literals.seq[2].flags & DDS_XTypes_IS_DEFAULT));
+
+  CU_ASSERT_EQUAL_FATAL (type->xt._u.enum_type.literals.seq[3].value, 2);
+  CU_ASSERT_FATAL (!(type->xt._u.enum_type.literals.seq[3].flags & DDS_XTypes_IS_DEFAULT));
+
+  dds_dynamic_type_unref (&denum);
+}
+
+CU_Test (ddsc_dynamic_type, enum_literal_invalid, .init = dynamic_type_init, .fini = dynamic_type_fini)
+{
+  // Enum type NULL
+  dds_return_t ret = dds_dynamic_type_add_enum_literal (NULL, "b1", DDS_DYNAMIC_ENUM_LITERAL_VALUE (1), false);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_BAD_PARAMETER);
+
+  // Name property missing
+  dds_dynamic_type_t denum = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_ENUMERATION, .name = "e" });
+  ret = dds_dynamic_type_add_enum_literal (&denum, "", DDS_DYNAMIC_ENUM_LITERAL_VALUE (1), false);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_BAD_PARAMETER);
+  dds_dynamic_type_unref (&denum);
+
+  // Value in use
+  denum = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_ENUMERATION, .name = "e" });
+  dds_dynamic_type_add_enum_literal (&denum, "e1", DDS_DYNAMIC_ENUM_LITERAL_VALUE (1), false);
+  ret = dds_dynamic_type_add_enum_literal (&denum, "e2", DDS_DYNAMIC_ENUM_LITERAL_VALUE (1), false);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_BAD_PARAMETER);
+  dds_dynamic_type_unref (&denum);
+
+  // Name in use
+  denum = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_ENUMERATION, .name = "e" });
+  dds_dynamic_type_add_enum_literal (&denum, "e1", DDS_DYNAMIC_ENUM_LITERAL_VALUE (1), false);
+  ret = dds_dynamic_type_add_enum_literal (&denum, "e1", DDS_DYNAMIC_ENUM_LITERAL_VALUE (2), false);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_BAD_PARAMETER);
+  dds_dynamic_type_unref (&denum);
+
+  // Multiple default values
+  denum = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_ENUMERATION, .name = "e" });
+  dds_dynamic_type_add_enum_literal (&denum, "e1", DDS_DYNAMIC_ENUM_LITERAL_VALUE (1), true);
+  ret = dds_dynamic_type_add_enum_literal (&denum, "e2", DDS_DYNAMIC_ENUM_LITERAL_VALUE (2), true);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_BAD_PARAMETER);
+  dds_dynamic_type_unref (&denum);
+
+  // Invalid value for bit-bound
+  denum = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_ENUMERATION, .name = "e" });
+  dds_dynamic_type_set_bit_bound (&denum, 2);
+  ret = dds_dynamic_type_add_enum_literal (&denum, "e1", DDS_DYNAMIC_ENUM_LITERAL_VALUE (4), false);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_BAD_PARAMETER);
+  dds_dynamic_type_unref (&denum);
+}
+
+CU_Test (ddsc_dynamic_type, struct_member_prop, .init = dynamic_type_init, .fini = dynamic_type_fini)
+{
+  dds_dynamic_type_t dstruct = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_STRUCTURE, .name = "t" });
+  dds_dynamic_type_set_autoid (&dstruct, DDS_DYNAMIC_TYPE_AUTOID_HASH);
+  dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER_PRIM(DDS_DYNAMIC_UINT16, "m1"));
+  dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER_PRIM(DDS_DYNAMIC_UINT16, "m2"));
+
+  dds_return_t ret = dds_dynamic_member_set_key (&dstruct, ddsi_dynamic_type_member_hashid ("m2"), true);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
+  ret = dds_dynamic_member_set_optional (&dstruct, ddsi_dynamic_type_member_hashid ("m2"), true);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
+  ret = dds_dynamic_member_set_external (&dstruct, ddsi_dynamic_type_member_hashid ("m2"), true);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
+  ret = dds_dynamic_member_set_hashid (&dstruct, ddsi_dynamic_type_member_hashid ("m2"), "m2_name");
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
+  // Because of the set_hashid, from this point the member has a different id
+  ret = dds_dynamic_member_set_must_understand (&dstruct, ddsi_dynamic_type_member_hashid ("m2_name"), true);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
+
+  struct ddsi_type *type = get_ddsi_type (&dstruct);
+  CU_ASSERT_EQUAL_FATAL (type->xt._u.structure.members.length, 2);
+
+  CU_ASSERT_EQUAL_FATAL (type->xt._u.structure.members.seq[0].id, ddsi_dynamic_type_member_hashid ("m1"));
+  CU_ASSERT_FATAL (!(type->xt._u.structure.members.seq[0].flags & DDS_XTypes_IS_KEY));
+  CU_ASSERT_FATAL (!(type->xt._u.structure.members.seq[0].flags & DDS_XTypes_IS_OPTIONAL));
+  CU_ASSERT_FATAL (!(type->xt._u.structure.members.seq[0].flags & DDS_XTypes_IS_EXTERNAL));
+  CU_ASSERT_FATAL (!(type->xt._u.structure.members.seq[0].flags & DDS_XTypes_IS_MUST_UNDERSTAND));
+
+  CU_ASSERT_EQUAL_FATAL (type->xt._u.structure.members.seq[1].id, ddsi_dynamic_type_member_hashid ("m2_name"));
+  CU_ASSERT_FATAL (type->xt._u.structure.members.seq[1].flags & DDS_XTypes_IS_KEY);
+  CU_ASSERT_FATAL (type->xt._u.structure.members.seq[1].flags & DDS_XTypes_IS_OPTIONAL);
+  CU_ASSERT_FATAL (type->xt._u.structure.members.seq[1].flags & DDS_XTypes_IS_EXTERNAL);
+  CU_ASSERT_FATAL (type->xt._u.structure.members.seq[1].flags & DDS_XTypes_IS_MUST_UNDERSTAND);
+
+  dds_dynamic_type_unref (&dstruct);
+}
+
+CU_Test (ddsc_dynamic_type, struct_member_prop_invalid, .init = dynamic_type_init, .fini = dynamic_type_fini)
+{
+  dds_dynamic_type_t dstruct;
+  dds_return_t ret;
+
+  // Re-used member hash-name
+  dstruct = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_STRUCTURE, .name = "t" });
+  dds_dynamic_type_set_autoid (&dstruct, DDS_DYNAMIC_TYPE_AUTOID_HASH);
+  dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER_PRIM(DDS_DYNAMIC_UINT16, "m1"));
+  dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER_PRIM(DDS_DYNAMIC_UINT16, "m2"));
+  ret = dds_dynamic_member_set_hashid (&dstruct, ddsi_dynamic_type_member_hashid ("m2"), "m1");
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_BAD_PARAMETER);
+  dds_dynamic_type_unref (&dstruct);
+
+  // Empty member name
+  dstruct = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_STRUCTURE, .name = "t" });
+  ret = dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER_PRIM(DDS_DYNAMIC_UINT16, ""));
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_BAD_PARAMETER);
+  dds_dynamic_type_unref (&dstruct);
+
+  // Non-primitive type member, re-used member id
+  dds_dynamic_type_t dsubstruct = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_STRUCTURE, .name = "s" });
+  dds_dynamic_type_add_member (&dsubstruct, DDS_DYNAMIC_MEMBER_PRIM(DDS_DYNAMIC_UINT16, "s1"));
+
+  dstruct = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_STRUCTURE, .name = "t" });
+  dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER_ID_PRIM(DDS_DYNAMIC_INT32, "m1", 1));
+  ret = dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER_ID(dsubstruct, "m2", 1));
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_BAD_PARAMETER);
+  dds_dynamic_type_unref (&dstruct);
+}
+
+CU_Test (ddsc_dynamic_type, union_member_prop, .init = dynamic_type_init, .fini = dynamic_type_fini)
+{
+  dds_dynamic_type_t dunion = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) {
+    .kind = DDS_DYNAMIC_UNION,
+    .name = "u",
+    .discriminator_type = DDS_DYNAMIC_TYPE_SPEC_PRIM(DDS_DYNAMIC_INT32)
+  });
+  dds_dynamic_type_set_autoid (&dunion, DDS_DYNAMIC_TYPE_AUTOID_HASH);
+  dds_dynamic_type_add_member (&dunion, DDS_DYNAMIC_UNION_MEMBER_PRIM(DDS_DYNAMIC_INT32, "m1", 2, ((int32_t[]) { 1, 2 })));
+  dds_dynamic_type_add_member (&dunion, DDS_DYNAMIC_UNION_MEMBER_PRIM(DDS_DYNAMIC_INT32, "m2", 1, ((int32_t[]) { 5 })));
+  dds_dynamic_type_add_member (&dunion, DDS_DYNAMIC_UNION_MEMBER_DEFAULT_PRIM(DDS_DYNAMIC_BOOLEAN, "md"));
+
+  dds_return_t ret = dds_dynamic_member_set_hashid (&dunion, ddsi_dynamic_type_member_hashid ("m2"), "m2_name");
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
+  // Because of the set_hashid, from this point the member has a different id
+  ret = dds_dynamic_member_set_external (&dunion, ddsi_dynamic_type_member_hashid ("m2_name"), true);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
+
+  struct ddsi_type *type = get_ddsi_type (&dunion);
+  CU_ASSERT_EQUAL_FATAL (type->xt._u.union_type.members.length, 3);
+
+  CU_ASSERT_EQUAL_FATAL (type->xt._u.union_type.members.seq[0].id, ddsi_dynamic_type_member_hashid ("m1"));
+  CU_ASSERT_FATAL (!(type->xt._u.union_type.members.seq[0].flags & DDS_XTypes_IS_EXTERNAL));
+  CU_ASSERT_FATAL (!(type->xt._u.union_type.members.seq[0].flags & DDS_XTypes_IS_DEFAULT));
+
+  CU_ASSERT_EQUAL_FATAL (type->xt._u.union_type.members.seq[1].id, ddsi_dynamic_type_member_hashid ("m2_name"));
+  CU_ASSERT_FATAL (type->xt._u.union_type.members.seq[1].flags & DDS_XTypes_IS_EXTERNAL);
+  CU_ASSERT_FATAL (!(type->xt._u.union_type.members.seq[1].flags & DDS_XTypes_IS_DEFAULT));
+
+  CU_ASSERT_EQUAL_FATAL (type->xt._u.union_type.members.seq[2].id, ddsi_dynamic_type_member_hashid ("md"));
+  CU_ASSERT_FATAL (!(type->xt._u.union_type.members.seq[2].flags & DDS_XTypes_IS_EXTERNAL));
+  CU_ASSERT_FATAL (type->xt._u.union_type.members.seq[2].flags & DDS_XTypes_IS_DEFAULT);
+
+  dds_dynamic_type_unref (&dunion);
+}
+
+CU_Test (ddsc_dynamic_type, union_member_prop_invalid, .init = dynamic_type_init, .fini = dynamic_type_fini)
+{
+  dds_dynamic_type_t dunion;
+  dds_return_t ret;
+  dds_dynamic_type_descriptor_t desc = {
+    .kind = DDS_DYNAMIC_UNION,
+    .name = "u",
+    .discriminator_type = DDS_DYNAMIC_TYPE_SPEC_PRIM(DDS_DYNAMIC_INT32)
+  };
+
+  // Existing hash name
+  dunion = dds_dynamic_type_create (participant, desc);
+  dds_dynamic_type_set_autoid (&dunion, DDS_DYNAMIC_TYPE_AUTOID_HASH);
+  dds_dynamic_type_add_member (&dunion, DDS_DYNAMIC_UNION_MEMBER_PRIM(DDS_DYNAMIC_INT32, "m1", 1, ((int32_t[]) { 1 })));
+  dds_dynamic_type_add_member (&dunion, DDS_DYNAMIC_UNION_MEMBER_PRIM(DDS_DYNAMIC_INT32, "m2", 1, ((int32_t[]) { 2 })));
+  ret = dds_dynamic_member_set_hashid (&dunion, ddsi_dynamic_type_member_hashid ("m2"), "m1");
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_BAD_PARAMETER);
+  dds_dynamic_type_unref (&dunion);
+
+  // Re-used label
+  dunion = dds_dynamic_type_create (participant, desc);
+  dds_dynamic_type_add_member (&dunion, DDS_DYNAMIC_UNION_MEMBER_PRIM(DDS_DYNAMIC_INT32, "m1", 1, ((int32_t[]) { 1 })));
+  ret = dds_dynamic_type_add_member (&dunion, DDS_DYNAMIC_UNION_MEMBER_PRIM(DDS_DYNAMIC_INT32, "m2", 1, ((int32_t[]) { 1 })));
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_BAD_PARAMETER);
+  dds_dynamic_type_unref (&dunion);
+
+  // Multiple default
+  dunion = dds_dynamic_type_create (participant, desc);
+  dds_dynamic_type_add_member (&dunion, DDS_DYNAMIC_UNION_MEMBER_DEFAULT_PRIM(DDS_DYNAMIC_INT32, "m1"));
+  ret = dds_dynamic_type_add_member (&dunion, DDS_DYNAMIC_UNION_MEMBER_DEFAULT_PRIM(DDS_DYNAMIC_INT32, "m2"));
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_BAD_PARAMETER);
+  dds_dynamic_type_unref (&dunion);
+
+  // Non-primitive type member, re-used label
+  dds_dynamic_type_t dstruct = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_STRUCTURE, .name = "t" });
+  dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER_PRIM(DDS_DYNAMIC_UINT16, "m1"));
+
+  dunion = dds_dynamic_type_create (participant, desc);
+  dds_dynamic_type_add_member (&dunion, DDS_DYNAMIC_UNION_MEMBER(dstruct, "m1", 1, ((int32_t[]) { 1 })));
+  ret = dds_dynamic_type_add_member (&dunion, DDS_DYNAMIC_UNION_MEMBER_PRIM(DDS_DYNAMIC_INT16, "m2", 1, ((int32_t[]) { 1 })));
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_BAD_PARAMETER);
+  dds_dynamic_type_unref (&dunion);
+}
+
+CU_Test (ddsc_dynamic_type, no_members, .init = dynamic_type_init, .fini = dynamic_type_fini)
+{
+  dds_typeinfo_t *type_info;
+  dds_return_t ret;
+
+  // Struct without members
+  dds_dynamic_type_t dstruct = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_STRUCTURE, .name = "t" });
+  ret = dds_dynamic_type_register (&dstruct, &type_info);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_BAD_PARAMETER);
+  dds_dynamic_type_unref (&dstruct);
+
+  // Struct with basetype without members
+  dds_dynamic_type_t dbasestruct = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_STRUCTURE, .name = "b" });
+  dstruct = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_STRUCTURE, .name = "t", .base_type = DDS_DYNAMIC_TYPE_SPEC (dbasestruct) });
+  CU_ASSERT_EQUAL_FATAL (dstruct.ret, DDS_RETCODE_BAD_PARAMETER);
+  dds_dynamic_type_unref (&dbasestruct);
+
+  // Struct with substruct without members
+  dds_dynamic_type_t dsubstruct = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_STRUCTURE, .name = "s" });
+  dstruct = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_STRUCTURE, .name = "t" });
+  ret = dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER(dsubstruct, "m1"));
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_BAD_PARAMETER);
+  dds_dynamic_type_unref (&dstruct);
+
+  // Union without members
+  dds_dynamic_type_t dunion = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t)
+      { .kind = DDS_DYNAMIC_UNION, .name = "u", .discriminator_type = DDS_DYNAMIC_TYPE_SPEC_PRIM(DDS_DYNAMIC_INT32) });
+  ret = dds_dynamic_type_register (&dunion, &type_info);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_BAD_PARAMETER);
+  dds_dynamic_type_unref (&dunion);
+}

--- a/src/core/ddsi/CMakeLists.txt
+++ b/src/core/ddsi/CMakeLists.txt
@@ -230,6 +230,7 @@ if(ENABLE_TYPE_DISCOVERY)
     ddsi_typelookup.c
     ddsi_typewrap.c
     ddsi_typebuilder.c
+    ddsi_dynamic_type.c
   )
   list(APPEND hdrs_ddsi
     ddsi_xt_typeinfo.h
@@ -237,10 +238,12 @@ if(ENABLE_TYPE_DISCOVERY)
     ddsi_xt_typemap.h
     ddsi_typewrap.h
     ddsi_typebuilder.h
+    ddsi_dynamic_type.h
   )
   list(APPEND hdrs_private_ddsi
     ddsi__xt_impl.h
     ddsi__typelookup.h
+    ddsi__dynamic_type.h
   )
 endif()
 if(ENABLE_SECURITY)

--- a/src/core/ddsi/idl/ddsi_xt_typeinfo.idl
+++ b/src/core/ddsi/idl/ddsi_xt_typeinfo.idl
@@ -25,6 +25,8 @@ module DDS { module XTypes {
     const octet TK_FLOAT32    = 0x09;
     const octet TK_FLOAT64    = 0x0A;
     const octet TK_FLOAT128   = 0x0B;
+    const octet TK_INT8       = 0x0C; // XTypes 1.3 spec Annex B
+    const octet TK_UINT8      = 0x0D; // XTypes 1.3 spec Annex B
     const octet TK_CHAR8      = 0x10;
     const octet TK_CHAR16     = 0x11;
 
@@ -351,6 +353,10 @@ module DDS { module XTypes {
             boolean             boolean_value;
         case TK_BYTE:
             octet               byte_value;
+        case TK_INT8:  // XTypes 1.3 spec Annex B
+            int8                int8_value;
+        case TK_UINT8:  // XTypes 1.3 spec Annex B
+            uint8               uint8_value;
         case TK_INT16:
             short               int16_value;
         case TK_UINT16:

--- a/src/core/ddsi/include/dds/ddsi/ddsi_dynamic_type.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_dynamic_type.h
@@ -1,0 +1,145 @@
+/*
+ * Copyright(c) 2023 ZettaScale Technology and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#ifndef DDSI_DYNAMIC_TYPE_H
+#define DDSI_DYNAMIC_TYPE_H
+
+#include "dds/export.h"
+#include "dds/features.h"
+#include "dds/ddsrt/avl.h"
+#include "dds/ddsi/ddsi_typewrap.h"
+#include "dds/ddsi/ddsi_domaingv.h"
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+struct ddsi_dynamic_type_struct_member_param {
+  uint32_t id;
+  const char *name;
+  uint32_t index;
+  bool is_key;
+};
+
+struct ddsi_dynamic_type_union_member_param {
+  uint32_t id;
+  const char *name;
+  uint32_t index;
+  bool is_default;
+  uint32_t n_labels;
+  int32_t *labels;
+};
+
+struct ddsi_dynamic_type_enum_literal_param {
+  const char *name;
+  bool is_auto_value;
+  int32_t value;
+  bool is_default;
+};
+
+struct ddsi_dynamic_type_bitmask_field_param {
+  const char *name;
+  bool is_auto_position;
+  uint16_t position;
+};
+
+/** @component dynamic_type_support */
+dds_return_t ddsi_dynamic_type_create_struct (struct ddsi_domaingv *gv, struct ddsi_type **type, const char *type_name, struct ddsi_type **base_type);
+
+/** @component dynamic_type_support */
+dds_return_t ddsi_dynamic_type_create_union (struct ddsi_domaingv *gv, struct ddsi_type **type, const char *type_name, struct ddsi_type **discriminant_type);
+
+/** @component dynamic_type_support */
+dds_return_t ddsi_dynamic_type_create_sequence (struct ddsi_domaingv *gv, struct ddsi_type **type, const char *type_name, struct ddsi_type **element_type, uint32_t bound);
+
+/** @component dynamic_type_support */
+dds_return_t ddsi_dynamic_type_create_array (struct ddsi_domaingv *gv, struct ddsi_type **type, const char *type_name, struct ddsi_type **element_type, uint32_t num_bounds, const uint32_t *bounds);
+
+/** @component dynamic_type_support */
+dds_return_t ddsi_dynamic_type_create_enum (struct ddsi_domaingv *gv, struct ddsi_type **type, const char *type_name);
+
+/** @component dynamic_type_support */
+dds_return_t ddsi_dynamic_type_create_bitmask (struct ddsi_domaingv *gv, struct ddsi_type **type, const char *type_name);
+
+/** @component dynamic_type_support */
+dds_return_t ddsi_dynamic_type_create_alias (struct ddsi_domaingv *gv, struct ddsi_type **type, const char *type_name, struct ddsi_type **aliased_type);
+
+/** @component dynamic_type_support */
+dds_return_t ddsi_dynamic_type_create_string (struct ddsi_domaingv *gv, struct ddsi_type **type);
+
+/** @component dynamic_type_support */
+dds_return_t ddsi_dynamic_type_create_primitive (struct ddsi_domaingv *gv, struct ddsi_type **type, dds_dynamic_type_kind_t kind);
+
+
+/** @component dynamic_type_support */
+dds_return_t ddsi_dynamic_type_set_extensibility (struct ddsi_type *type, enum dds_dynamic_type_extensibility extensibility);
+
+/** @component dynamic_type_support */
+dds_return_t ddsi_dynamic_type_set_bitbound (struct ddsi_type *type, uint16_t bit_bound);
+
+/** @component dynamic_type_support */
+dds_return_t ddsi_dynamic_type_set_nested (struct ddsi_type *type, bool is_nested);
+
+/** @component dynamic_type_support */
+dds_return_t ddsi_dynamic_type_set_autoid (struct ddsi_type *type, enum dds_dynamic_type_autoid value);
+
+/** @component dynamic_type_support */
+dds_return_t ddsi_dynamic_type_add_struct_member (struct ddsi_type *type, struct ddsi_type **member_type, struct ddsi_dynamic_type_struct_member_param params);
+
+/** @component dynamic_type_support */
+dds_return_t ddsi_dynamic_type_add_union_member (struct ddsi_type *type, struct ddsi_type **member_type, struct ddsi_dynamic_type_union_member_param params);
+
+/** @component dynamic_type_support */
+dds_return_t ddsi_dynamic_type_add_enum_literal (struct ddsi_type *type, struct ddsi_dynamic_type_enum_literal_param params);
+
+/** @component dynamic_type_support */
+dds_return_t ddsi_dynamic_type_add_bitmask_field (struct ddsi_type *type, struct ddsi_dynamic_type_bitmask_field_param params);
+
+
+/** @component dynamic_type_support */
+dds_return_t ddsi_dynamic_type_member_set_key (struct ddsi_type *type, uint32_t member_id, bool is_key);
+
+/** @component dynamic_type_support */
+dds_return_t ddsi_dynamic_type_member_set_optional (struct ddsi_type *type, uint32_t member_id, bool is_optional);
+
+/** @component dynamic_type_support */
+dds_return_t ddsi_dynamic_struct_member_set_external (struct ddsi_type *type, uint32_t member_id, bool is_external);
+
+/** @component dynamic_type_support */
+dds_return_t ddsi_dynamic_union_member_set_external (struct ddsi_type *type, uint32_t member_id, bool is_external);
+
+/** @component dynamic_type_support */
+dds_return_t ddsi_dynamic_type_member_set_must_understand (struct ddsi_type *type, uint32_t member_id, bool is_must_understand);
+
+/** @component dynamic_type_support */
+dds_return_t ddsi_dynamic_type_member_set_hashid (struct ddsi_type *type, uint32_t member_id, const char *hash_member_name);
+
+
+/** @component dynamic_type_support */
+dds_return_t ddsi_dynamic_type_register (struct ddsi_type **type, ddsi_typeinfo_t **type_info);
+
+/** @component dynamic_type_support */
+struct ddsi_type * ddsi_dynamic_type_ref (struct ddsi_type *type);
+
+/** @component dynamic_type_support */
+void ddsi_dynamic_type_unref (struct ddsi_type *type);
+
+/** @component dynamic_type_support */
+struct ddsi_type * ddsi_dynamic_type_dup (const struct ddsi_type *src);
+
+/** @component dynamic_type_support */
+bool ddsi_dynamic_type_is_constructing (const struct ddsi_type *type);
+
+#if defined (__cplusplus)
+}
+#endif
+
+#endif /* DDSI_DYNAMIC_TYPE_H */

--- a/src/core/ddsi/include/dds/ddsi/ddsi_typelib.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_typelib.h
@@ -56,6 +56,9 @@ DDS_EXPORT ddsi_typeinfo_t *ddsi_typeinfo_deser (const unsigned char *data, uint
 DDS_EXPORT void ddsi_typeinfo_fini (ddsi_typeinfo_t *typeinfo);
 
 /** @component type_system */
+DDS_EXPORT void ddsi_typeinfo_free (ddsi_typeinfo_t *typeinfo);
+
+/** @component type_system */
 DDS_EXPORT ddsi_typeinfo_t * ddsi_typeinfo_dup (const ddsi_typeinfo_t *src);
 
 /** @component type_system */
@@ -100,6 +103,11 @@ struct ddsi_typeobj *ddsi_type_get_typeobj (struct ddsi_domaingv *gv, const stru
 /** @component type_system */
 bool ddsi_type_resolved (struct ddsi_domaingv *gv, const struct ddsi_type *type, ddsi_type_include_deps_t resolved_kind);
 
+/** @component type_system */
+struct ddsi_domaingv *ddsi_type_get_gv (const struct ddsi_type *type);
+
+/** @component type_system */
+DDS_XTypes_TypeKind ddsi_type_get_kind (const struct ddsi_type *type);
 
 /**
  * @brief Waits for the provided type to be resolved

--- a/src/core/ddsi/include/dds/ddsi/ddsi_xt_typeinfo.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_xt_typeinfo.h
@@ -41,6 +41,8 @@ typedef uint8_t DDS_XTypes_TypeKind;
 #define DDS_XTypes_TK_FLOAT32 9
 #define DDS_XTypes_TK_FLOAT64 10
 #define DDS_XTypes_TK_FLOAT128 11
+#define DDS_XTypes_TK_INT8 12
+#define DDS_XTypes_TK_UINT8 13
 #define DDS_XTypes_TK_CHAR8 16
 #define DDS_XTypes_TK_CHAR16 17
 #define DDS_XTypes_TK_STRING8 32
@@ -383,6 +385,8 @@ typedef struct DDS_XTypes_AnnotationParameterValue
   {
     bool boolean_value;
     uint8_t byte_value;
+    int8_t int8_value;
+    uint8_t uint8_value;
     int16_t int16_value;
     uint16_t uint_16_value;
     int32_t int32_value;

--- a/src/core/ddsi/src/ddsi__dynamic_type.h
+++ b/src/core/ddsi/src/ddsi__dynamic_type.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright(c) 2023 ZettaScale Technology and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#ifndef DDSI__DYNAMIC_TYPE_H
+#define DDSI__DYNAMIC_TYPE_H
+
+#include "dds/export.h"
+#include "dds/features.h"
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+#define DDSI_DYNAMIC_TYPE_MEMBERID_MASK 0x0fffffffu
+
+/**
+ * @brief Calculate aggregate type member ID
+ *
+ * Calculates the ID of a member of an aggregated type from it's (hash-)name,
+ * (see Xtypes spec 1.3, 7.3.1.2.1.1)
+ *
+ * @component dynamic_type_support
+ *
+ * @param[in] member_hash_name Name of the member (or name provided in the hashid annotation).
+ *
+ */
+uint32_t ddsi_dynamic_type_member_hashid (const char *member_hash_name);
+
+#if defined (__cplusplus)
+}
+#endif
+
+#endif /* DDSI__DYNAMIC_TYPE_H */

--- a/src/core/ddsi/src/ddsi__typelib.h
+++ b/src/core/ddsi/src/ddsi__typelib.h
@@ -45,6 +45,7 @@ enum ddsi_type_state {
   DDSI_TYPE_PARTIAL_RESOLVED,
   DDSI_TYPE_RESOLVED,
   DDSI_TYPE_INVALID,
+  DDSI_TYPE_CONSTRUCTING
 };
 
 /** @component type_system */
@@ -52,6 +53,9 @@ dds_return_t ddsi_type_register_dep (struct ddsi_domaingv *gv, const ddsi_typeid
 
 /** @component type_system */
 void ddsi_type_ref_locked (struct ddsi_domaingv *gv, struct ddsi_type **type, const struct ddsi_type *src);
+
+/** @component type_system */
+void ddsi_type_ref (struct ddsi_domaingv *gv, struct ddsi_type **type, const struct ddsi_type *src);
 
 /** @component type_system */
 dds_return_t ddsi_type_ref_id_locked (struct ddsi_domaingv *gv, struct ddsi_type **type, const ddsi_typeid_t *type_id);
@@ -80,6 +84,9 @@ void ddsi_type_unref_locked (struct ddsi_domaingv *gv, struct ddsi_type *type);
 /** @component type_system */
 bool ddsi_type_resolved_locked (struct ddsi_domaingv *gv, const struct ddsi_type *type, ddsi_type_include_deps_t resolved_kind);
 
+/** @component type_system */
+void ddsi_type_free (struct ddsi_type *type);
+
 
 /** @component type_system */
 bool ddsi_is_assignable_from (struct ddsi_domaingv *gv, const struct ddsi_type_pair *rd_type_pair, uint32_t rd_resolved, const struct ddsi_type_pair *wr_type_pair, uint32_t wr_resolved, const dds_type_consistency_enforcement_qospolicy_t *tce);
@@ -101,7 +108,6 @@ struct ddsi_type_pair *ddsi_type_pair_init (const ddsi_typeid_t *type_id_minimal
 
 /** @component type_system */
 void ddsi_type_pair_free (struct ddsi_type_pair *type_pair);
-
 /**
  * @brief Returns the type lookup meta object for the provided type identifier.
  * @component type_system

--- a/src/core/ddsi/src/ddsi__typewrap.h
+++ b/src/core/ddsi/src/ddsi__typewrap.h
@@ -41,6 +41,7 @@ bool ddsi_type_id_with_deps_equal (const struct DDS_XTypes_TypeIdentifierWithDep
 
 /** @component xtypes_wrapper */
 const char * ddsi_typekind_descr (unsigned char disc);
+void ddsi_xt_get_typeid_impl (const struct xt_type *xt, struct DDS_XTypes_TypeIdentifier *ti, ddsi_typeid_kind_t kind);
 
 
 /** @component xtypes_wrapper */
@@ -76,6 +77,12 @@ bool ddsi_xt_is_unresolved (const struct xt_type *t);
 
 /** @component xtypes_wrapper */
 bool ddsi_xt_is_resolved (const struct xt_type *t);
+
+/** @component xtypes_wrapper */
+void ddsi_xt_copy (struct ddsi_domaingv *gv, struct xt_type *dst, const struct xt_type *src);
+
+/** @component xtypes_wrapper */
+void ddsi_xt_get_namehash (DDS_XTypes_NameHash name_hash, const char *name);
 
 #endif /* DDS_HAS_TYPE_DISCOVERY */
 

--- a/src/core/ddsi/src/ddsi__xt_impl.h
+++ b/src/core/ddsi/src/ddsi__xt_impl.h
@@ -277,6 +277,7 @@ struct ddsi_type_dep {
 
 struct ddsi_type {
   struct xt_type xt;                            /* wrapper for XTypes type id/obj */
+  struct ddsi_domaingv *gv;
   ddsrt_avl_node_t avl_node;
   enum ddsi_type_state state;
   ddsi_seqno_t request_seqno;                        /* sequence number of the last type lookup request message */

--- a/src/core/ddsi/src/ddsi__xt_impl.h
+++ b/src/core/ddsi/src/ddsi__xt_impl.h
@@ -223,6 +223,7 @@ struct xt_type
     // case TK_NONE:
     // case TK_BOOLEAN:
     // case TK_BYTE:
+    // case TK_INT8:
     // case TK_INT16:
     // case TK_INT32:
     // case TK_INT64:

--- a/src/core/ddsi/src/ddsi_dynamic_type.c
+++ b/src/core/ddsi/src/ddsi_dynamic_type.c
@@ -1,0 +1,785 @@
+/*
+ * Copyright(c) 2023 ZettaScale Technology and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include <assert.h>
+#include <string.h>
+#include "dds/dds.h"
+#include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/md5.h"
+#include "dds/ddsrt/string.h"
+#include "dds/ddsi/ddsi_entity.h"
+#include "dds/ddsi/ddsi_typelib.h"
+#include "dds/ddsi/ddsi_dynamic_type.h"
+#include "ddsi__xt_impl.h"
+#include "ddsi__typewrap.h"
+#include "ddsi__dynamic_type.h"
+
+static void dynamic_type_ref_deps (struct ddsi_type *type)
+{
+  switch (type->xt._d)
+  {
+    case DDS_XTypes_TK_STRING8:
+      break;
+    case DDS_XTypes_TK_SEQUENCE:
+      ddsi_type_register_dep (type->gv, &type->xt.id, &type->xt._u.seq.c.element_type, &type->xt._u.seq.c.element_type->xt.id.x);
+      ddsi_type_unref_locked (type->gv, type->xt._u.seq.c.element_type);
+      break;
+    case DDS_XTypes_TK_ARRAY:
+      ddsi_type_register_dep (type->gv, &type->xt.id, &type->xt._u.array.c.element_type, &type->xt._u.array.c.element_type->xt.id.x);
+      ddsi_type_unref_locked (type->gv, type->xt._u.array.c.element_type);
+      break;
+    case DDS_XTypes_TK_MAP:
+      ddsi_type_register_dep (type->gv, &type->xt.id, &type->xt._u.map.c.element_type, &type->xt._u.map.c.element_type->xt.id.x);
+      ddsi_type_register_dep (type->gv, &type->xt.id, &type->xt._u.map.key_type, &type->xt._u.map.key_type->xt.id.x);
+      ddsi_type_unref_locked (type->gv, type->xt._u.map.c.element_type);
+      ddsi_type_unref_locked (type->gv, type->xt._u.map.key_type);
+      break;
+    case DDS_XTypes_TK_STRUCTURE:
+      for (uint32_t m = 0; m < type->xt._u.structure.members.length; m++)
+      {
+        ddsi_type_register_dep (type->gv, &type->xt.id, &type->xt._u.structure.members.seq[m].type, &type->xt._u.structure.members.seq[m].type->xt.id.x);
+        ddsi_type_unref_locked (type->gv, type->xt._u.structure.members.seq[m].type);
+      }
+      break;
+    case DDS_XTypes_TK_UNION:
+      for (uint32_t m = 0; m < type->xt._u.union_type.members.length; m++)
+      {
+        ddsi_type_register_dep (type->gv, &type->xt.id, &type->xt._u.union_type.members.seq[m].type, &type->xt._u.union_type.members.seq[m].type->xt.id.x);
+        ddsi_type_unref_locked (type->gv, type->xt._u.union_type.members.seq[m].type);
+      }
+      break;
+  }
+}
+
+static dds_return_t dynamic_type_complete (struct ddsi_type **type)
+{
+  dds_return_t ret = DDS_RETCODE_OK;
+  struct ddsi_domaingv *gv = (*type)->gv;
+  ddsrt_mutex_lock (&gv->typelib_lock);
+
+  if ((*type)->state != DDSI_TYPE_CONSTRUCTING)
+  {
+    assert ((*type)->state == DDSI_TYPE_RESOLVED);
+    ddsrt_mutex_unlock (&gv->typelib_lock);
+    return ret;
+  }
+
+  struct DDS_XTypes_TypeIdentifier ti;
+  assert (ddsi_typeid_is_none (&(*type)->xt.id));
+  ddsi_xt_get_typeid_impl (&(*type)->xt, &ti, (*type)->xt.kind);
+
+  struct ddsi_type *ref_type = ddsi_type_lookup_locked_impl (gv, &ti);
+  if (ref_type)
+  {
+    /* The constructed type exists in the type library, so replace the type
+       pointer with the existing type and transfer the refcount for the constructed
+       type to the existing type. */
+    ref_type->refc += (*type)->refc;
+    ddsi_type_free (*type);
+    *type = ref_type;
+  }
+  else
+  {
+    if ((ret = ddsi_xt_validate (gv, &(*type)->xt)) == DDS_RETCODE_OK)
+    {
+      ddsi_typeid_copy_impl (&(*type)->xt.id.x, &ti);
+      (*type)->xt.kind = ddsi_typeid_kind (&(*type)->xt.id);
+      (*type)->state = DDSI_TYPE_RESOLVED;
+      ddsrt_avl_insert (&ddsi_typelib_treedef, &gv->typelib, *type);
+      dynamic_type_ref_deps (*type);
+    }
+  }
+  ddsi_typeid_fini_impl (&ti);
+  ddsrt_mutex_unlock (&gv->typelib_lock);
+  return ret;
+}
+
+static void dynamic_type_init (struct ddsi_domaingv *gv, struct ddsi_type *type, DDS_XTypes_TypeKind data_type, ddsi_typeid_kind_t kind)
+{
+  assert (type);
+  type->gv = gv;
+  type->refc = 1;
+  type->state = DDSI_TYPE_CONSTRUCTING;
+  type->xt._d = data_type;
+  type->xt.kind = kind;
+}
+
+bool ddsi_dynamic_type_is_constructing (const struct ddsi_type *type)
+{
+  assert (type);
+  return (type->state == DDSI_TYPE_CONSTRUCTING);
+}
+
+dds_return_t ddsi_dynamic_type_create_struct (struct ddsi_domaingv *gv, struct ddsi_type **type, const char *type_name, struct ddsi_type **base_type)
+{
+  dds_return_t ret = DDS_RETCODE_OK;
+  if ((*type = ddsrt_calloc (1, sizeof (**type))) == NULL)
+  {
+    ret = DDS_RETCODE_OUT_OF_RESOURCES;
+    goto err;
+  }
+  dynamic_type_init (gv, *type, DDS_XTypes_TK_STRUCTURE, DDSI_TYPEID_KIND_COMPLETE);
+  if (*base_type)
+  {
+    if ((ret = dynamic_type_complete (base_type)) != DDS_RETCODE_OK)
+    {
+      ddsrt_free (*type);
+      goto err;
+    }
+    (*type)->xt._u.structure.base_type = *base_type;
+  }
+  (*type)->xt._u.structure.flags = DDS_XTypes_IS_FINAL;
+  ddsrt_strlcpy ((*type)->xt._u.structure.detail.type_name, type_name, sizeof ((*type)->xt._u.structure.detail.type_name));
+err:
+  return ret;
+}
+
+dds_return_t ddsi_dynamic_type_create_union (struct ddsi_domaingv *gv, struct ddsi_type **type, const char *type_name, struct ddsi_type **discriminant_type)
+{
+  dds_return_t ret = DDS_RETCODE_OK;
+  if ((ret = dynamic_type_complete (discriminant_type)) != DDS_RETCODE_OK)
+    return ret;
+  if ((*type = ddsrt_calloc (1, sizeof (**type))) == NULL)
+    return DDS_RETCODE_OUT_OF_RESOURCES;
+  dynamic_type_init (gv, *type, DDS_XTypes_TK_UNION, DDSI_TYPEID_KIND_COMPLETE);
+  (*type)->xt._u.union_type.flags = DDS_XTypes_IS_FINAL;
+  (*type)->xt._u.union_type.disc_type = *discriminant_type;
+  ddsrt_strlcpy ((*type)->xt._u.union_type.detail.type_name, type_name, sizeof ((*type)->xt._u.union_type.detail.type_name));
+  return DDS_RETCODE_OK;
+}
+
+dds_return_t ddsi_dynamic_type_create_sequence (struct ddsi_domaingv *gv, struct ddsi_type **type, const char *type_name, struct ddsi_type **element_type, uint32_t bound)
+{
+  dds_return_t ret = DDS_RETCODE_OK;
+  if ((ret = dynamic_type_complete (element_type)) != DDS_RETCODE_OK)
+    return ret;
+  if ((*type = ddsrt_calloc (1, sizeof (**type))) == NULL)
+    return DDS_RETCODE_OUT_OF_RESOURCES;
+  dynamic_type_init (gv, *type, DDS_XTypes_TK_SEQUENCE, DDSI_TYPEID_KIND_PLAIN_COLLECTION_COMPLETE);
+  (*type)->xt._u.seq.bound = bound;
+  (*type)->xt._u.seq.c.element_type = *element_type;
+  ddsrt_strlcpy ((*type)->xt._u.seq.c.detail.type_name, type_name, sizeof ((*type)->xt._u.seq.c.detail.type_name));
+  return DDS_RETCODE_OK;
+}
+
+dds_return_t ddsi_dynamic_type_create_array (struct ddsi_domaingv *gv, struct ddsi_type **type, const char *type_name, struct ddsi_type **element_type, uint32_t num_bounds, const uint32_t *bounds)
+{
+  dds_return_t ret;
+  if ((ret = dynamic_type_complete (element_type)) != DDS_RETCODE_OK)
+    return ret;
+  if ((*type = ddsrt_calloc (1, sizeof (**type))) == NULL)
+    return DDS_RETCODE_OUT_OF_RESOURCES;
+  dynamic_type_init (gv, *type, DDS_XTypes_TK_ARRAY, DDSI_TYPEID_KIND_PLAIN_COLLECTION_COMPLETE);
+  (*type)->xt._u.array.bounds._maximum = (*type)->xt._u.array.bounds._length = num_bounds;
+  if (((*type)->xt._u.array.bounds._buffer = ddsrt_malloc (num_bounds * sizeof (*(*type)->xt._u.array.bounds._buffer))) == NULL)
+  {
+    ddsrt_free (*type);
+    return DDS_RETCODE_OUT_OF_RESOURCES;
+  }
+  memcpy ((*type)->xt._u.array.bounds._buffer, bounds, num_bounds * sizeof (*(*type)->xt._u.array.bounds._buffer));
+  (*type)->xt._u.array.c.element_type = *element_type;
+  ddsrt_strlcpy ((*type)->xt._u.array.c.detail.type_name, type_name, sizeof ((*type)->xt._u.array.c.detail.type_name));
+  return DDS_RETCODE_OK;
+}
+
+dds_return_t ddsi_dynamic_type_create_enum (struct ddsi_domaingv *gv, struct ddsi_type **type, const char *type_name)
+{
+  if ((*type = ddsrt_calloc (1, sizeof (**type))) == NULL)
+    return DDS_RETCODE_OUT_OF_RESOURCES;
+  dynamic_type_init (gv, *type, DDS_XTypes_TK_ENUM, DDSI_TYPEID_KIND_COMPLETE);
+  (*type)->xt._u.enum_type.flags = DDS_XTypes_IS_FINAL;
+  (*type)->xt._u.enum_type.bit_bound = 32;
+  ddsrt_strlcpy ((*type)->xt._u.enum_type.detail.type_name, type_name, sizeof ((*type)->xt._u.enum_type.detail.type_name));
+  return DDS_RETCODE_OK;
+}
+
+dds_return_t ddsi_dynamic_type_create_bitmask (struct ddsi_domaingv *gv, struct ddsi_type **type, const char *type_name)
+{
+  if ((*type = ddsrt_calloc (1, sizeof (**type))) == NULL)
+    return DDS_RETCODE_OUT_OF_RESOURCES;
+  dynamic_type_init (gv, *type, DDS_XTypes_TK_BITMASK, DDSI_TYPEID_KIND_COMPLETE);
+  (*type)->xt._u.bitmask.flags = DDS_XTypes_IS_FINAL;
+  (*type)->xt._u.bitmask.bit_bound = 32;
+  ddsrt_strlcpy ((*type)->xt._u.bitmask.detail.type_name, type_name, sizeof ((*type)->xt._u.bitmask.detail.type_name));
+  return DDS_RETCODE_OK;
+}
+
+dds_return_t ddsi_dynamic_type_create_alias (struct ddsi_domaingv *gv, struct ddsi_type **type, const char *type_name, struct ddsi_type **aliased_type)
+{
+  dds_return_t ret;
+  if ((ret = dynamic_type_complete (aliased_type)) != DDS_RETCODE_OK)
+    return ret;
+  if ((*type = ddsrt_calloc (1, sizeof (**type))) == NULL)
+    return DDS_RETCODE_OUT_OF_RESOURCES;
+  dynamic_type_init (gv, *type, DDS_XTypes_TK_ALIAS, DDSI_TYPEID_KIND_COMPLETE);
+  (*type)->xt._u.alias.related_type = *aliased_type;
+  ddsrt_strlcpy ((*type)->xt._u.alias.detail.type_name, type_name, sizeof ((*type)->xt._u.alias.detail.type_name));
+  return DDS_RETCODE_OK;
+}
+
+dds_return_t ddsi_dynamic_type_create_string (struct ddsi_domaingv *gv, struct ddsi_type **type)
+{
+  if ((*type = ddsrt_calloc (1, sizeof (**type))) == NULL)
+    return DDS_RETCODE_OUT_OF_RESOURCES;
+  dynamic_type_init (gv, *type, DDS_XTypes_TK_STRING8, DDSI_TYPEID_KIND_FULLY_DESCRIPTIVE);
+  return DDS_RETCODE_OK;
+}
+
+dds_return_t ddsi_dynamic_type_create_primitive (struct ddsi_domaingv *gv, struct ddsi_type **type, dds_dynamic_type_kind_t kind)
+{
+  if ((*type = ddsrt_calloc (1, sizeof (**type))) == NULL)
+    return DDS_RETCODE_OUT_OF_RESOURCES;
+  uint8_t data_type = DDS_XTypes_TK_NONE;
+  switch (kind)
+  {
+    case DDS_DYNAMIC_BOOLEAN: data_type = DDS_XTypes_TK_BOOLEAN; break;
+    case DDS_DYNAMIC_BYTE: data_type = DDS_XTypes_TK_BYTE; break;
+    case DDS_DYNAMIC_INT16: data_type = DDS_XTypes_TK_INT16; break;
+    case DDS_DYNAMIC_INT32: data_type = DDS_XTypes_TK_INT32; break;
+    case DDS_DYNAMIC_INT64: data_type = DDS_XTypes_TK_INT64; break;
+    case DDS_DYNAMIC_UINT16: data_type = DDS_XTypes_TK_UINT16; break;
+    case DDS_DYNAMIC_UINT32: data_type = DDS_XTypes_TK_UINT32; break;
+    case DDS_DYNAMIC_UINT64: data_type = DDS_XTypes_TK_UINT64; break;
+    case DDS_DYNAMIC_FLOAT32: data_type = DDS_XTypes_TK_FLOAT32; break;
+    case DDS_DYNAMIC_FLOAT64: data_type = DDS_XTypes_TK_FLOAT64; break;
+    case DDS_DYNAMIC_FLOAT128: data_type = DDS_XTypes_TK_FLOAT128; break;
+    case DDS_DYNAMIC_INT8: data_type = DDS_XTypes_TK_INT8; break;
+    case DDS_DYNAMIC_UINT8: data_type = DDS_XTypes_TK_UINT8; break;
+    case DDS_DYNAMIC_CHAR8: data_type = DDS_XTypes_TK_CHAR8; break;
+    case DDS_DYNAMIC_CHAR16: data_type = DDS_XTypes_TK_CHAR16; break;
+    default:
+      ddsrt_free (*type);
+      return DDS_RETCODE_BAD_PARAMETER;
+  }
+  if (data_type == DDS_XTypes_TK_NONE)
+    return DDS_RETCODE_BAD_PARAMETER;
+
+  dynamic_type_init (gv, *type, data_type, DDSI_TYPEID_KIND_FULLY_DESCRIPTIVE);
+  return DDS_RETCODE_OK;
+}
+
+static dds_return_t set_type_flags (struct ddsi_type *type, uint16_t flag, uint16_t mask)
+{
+  assert (type->state == DDSI_TYPE_CONSTRUCTING);
+  dds_return_t ret = DDS_RETCODE_OK;
+  switch (type->xt._d)
+  {
+    case DDS_XTypes_TK_ENUM:
+      if (type->xt._u.enum_type.literals.length > 0)
+        ret = DDS_RETCODE_PRECONDITION_NOT_MET;
+      else
+        type->xt._u.enum_type.flags = (type->xt._u.enum_type.flags & (uint16_t) ~mask) | flag;
+      break;
+    case DDS_XTypes_TK_BITMASK:
+      if (type->xt._u.bitmask.bitflags.length > 0)
+        ret = DDS_RETCODE_PRECONDITION_NOT_MET;
+      else
+        type->xt._u.bitmask.flags = (type->xt._u.bitmask.flags & (uint16_t) ~mask) | flag;
+      break;
+    case DDS_XTypes_TK_STRUCTURE:
+      if (type->xt._u.structure.members.length > 0)
+        ret = DDS_RETCODE_PRECONDITION_NOT_MET;
+      else
+        type->xt._u.structure.flags = (type->xt._u.structure.flags & (uint16_t) ~mask) | flag;
+      break;
+    case DDS_XTypes_TK_UNION:
+      if (type->xt._u.union_type.members.length > 0)
+        ret = DDS_RETCODE_PRECONDITION_NOT_MET;
+      else
+        type->xt._u.union_type.flags = (type->xt._u.union_type.flags & (uint16_t) ~mask) | flag;
+      break;
+    default:
+      abort ();
+  }
+  return ret;
+}
+
+dds_return_t ddsi_dynamic_type_set_extensibility (struct ddsi_type *type, enum dds_dynamic_type_extensibility extensibility)
+{
+  assert (type->xt._d == DDS_XTypes_TK_STRUCTURE
+      || type->xt._d == DDS_XTypes_TK_UNION
+      || type->xt._d == DDS_XTypes_TK_ENUM
+      || type->xt._d == DDS_XTypes_TK_BITMASK);
+  uint16_t flag = 0;
+  if (extensibility == DDS_DYNAMIC_TYPE_EXT_FINAL)
+    flag = DDS_XTypes_IS_FINAL;
+  else if (extensibility == DDS_DYNAMIC_TYPE_EXT_APPENDABLE)
+    flag = DDS_XTypes_IS_APPENDABLE;
+  else if (extensibility == DDS_DYNAMIC_TYPE_EXT_MUTABLE)
+    flag = DDS_XTypes_IS_MUTABLE;
+  else
+    abort ();
+  return set_type_flags (type, flag, DDS_DYNAMIC_TYPE_EXT_FINAL | DDS_DYNAMIC_TYPE_EXT_APPENDABLE | DDS_DYNAMIC_TYPE_EXT_MUTABLE);
+}
+
+dds_return_t ddsi_dynamic_type_set_nested (struct ddsi_type *type, bool is_nested)
+{
+  assert (type->xt._d == DDS_XTypes_TK_STRUCTURE || type->xt._d == DDS_XTypes_TK_UNION);
+  uint16_t flag = is_nested ? DDS_XTypes_IS_NESTED : 0u;
+  return set_type_flags (type, flag, DDS_XTypes_IS_NESTED);
+}
+
+dds_return_t ddsi_dynamic_type_set_autoid (struct ddsi_type *type, enum dds_dynamic_type_autoid value)
+{
+  assert (type->xt._d == DDS_XTypes_TK_STRUCTURE || type->xt._d == DDS_XTypes_TK_UNION);
+  assert (value == DDS_DYNAMIC_TYPE_AUTOID_HASH || value == DDS_DYNAMIC_TYPE_AUTOID_SEQUENTIAL);
+  uint16_t flag = value == DDS_DYNAMIC_TYPE_AUTOID_HASH ? DDS_XTypes_IS_AUTOID_HASH : 0u;
+  return set_type_flags (type, flag, DDS_XTypes_IS_AUTOID_HASH);
+}
+
+dds_return_t ddsi_dynamic_type_set_bitbound (struct ddsi_type *type, uint16_t bit_bound)
+{
+  assert (type->xt._d == DDS_XTypes_TK_ENUM || type->xt._d == DDS_XTypes_TK_BITMASK);
+  assert (type->state == DDSI_TYPE_CONSTRUCTING);
+  dds_return_t ret = DDS_RETCODE_OK;
+  switch (type->xt._d)
+  {
+    case DDS_XTypes_TK_ENUM:
+      if (type->xt._u.enum_type.literals.length > 0)
+        ret = DDS_RETCODE_PRECONDITION_NOT_MET;
+      else
+      {
+        assert (bit_bound > 0 && bit_bound <= 32);
+        type->xt._u.enum_type.bit_bound = bit_bound;
+      }
+      break;
+    case DDS_XTypes_TK_BITMASK:
+      if (type->xt._u.bitmask.bitflags.length > 0)
+        ret = DDS_RETCODE_PRECONDITION_NOT_MET;
+      else
+      {
+        assert (bit_bound > 0 && bit_bound <= 64);
+        type->xt._u.bitmask.bit_bound = bit_bound;
+      }
+      break;
+    default:
+      abort ();
+  }
+  return ret;
+}
+
+uint32_t ddsi_dynamic_type_member_hashid (const char *name)
+{
+  uint32_t id;
+  ddsrt_md5_state_t md5st;
+  ddsrt_md5_byte_t digest[16];
+
+  ddsrt_md5_init (&md5st);
+  ddsrt_md5_append (&md5st, (ddsrt_md5_byte_t *) name, (unsigned int) strlen(name));
+  ddsrt_md5_finish (&md5st, digest);
+  id = digest[0] | ((uint32_t) digest[1] << 8) | ((uint32_t) digest[2] << 16) | ((uint32_t) digest[3] << 24);
+  return id & DDSI_DYNAMIC_TYPE_MEMBERID_MASK;
+}
+
+dds_return_t ddsi_dynamic_type_add_struct_member (struct ddsi_type *type, struct ddsi_type **member_type, struct ddsi_dynamic_type_struct_member_param params)
+{
+  dds_return_t ret;
+  assert (type->state == DDSI_TYPE_CONSTRUCTING);
+  assert (type->xt._d == DDS_XTypes_TK_STRUCTURE);
+  if (type->xt._u.structure.members.length == UINT32_MAX)
+    return DDS_RETCODE_BAD_PARAMETER;
+  if ((ret = dynamic_type_complete (member_type)) != DDS_RETCODE_OK)
+    return ret;
+
+  // check member id or set to max+1
+  uint32_t member_id = 0;
+  if (params.id == DDS_DYNAMIC_MEMBER_ID_INVALID)
+  {
+    if (type->xt._u.structure.flags & DDS_XTypes_IS_AUTOID_HASH)
+      member_id = ddsi_dynamic_type_member_hashid (params.name);
+    else
+    {
+      for (uint32_t n = 0; n < type->xt._u.structure.members.length; n++)
+        if (type->xt._u.structure.members.seq[n].id >= member_id)
+          member_id = type->xt._u.structure.members.seq[n].id + 1;
+    }
+  }
+  else
+  {
+    /* the 4 most significant bits in the member id are reserved (used in EMHEADER) */
+    if (params.id & ~DDSI_DYNAMIC_TYPE_MEMBERID_MASK)
+      return DDS_RETCODE_BAD_PARAMETER;
+    member_id = params.id;
+  }
+
+  for (uint32_t n = 0; n < type->xt._u.structure.members.length; n++)
+    if (type->xt._u.structure.members.seq[n].id == member_id)
+      return DDS_RETCODE_BAD_PARAMETER;
+
+  struct xt_struct_member *tmp = ddsrt_realloc (type->xt._u.structure.members.seq,
+      (type->xt._u.structure.members.length + 1) * sizeof (*type->xt._u.structure.members.seq));
+  if (tmp == NULL)
+    return DDS_RETCODE_OUT_OF_RESOURCES;
+  type->xt._u.structure.members.length++;
+  type->xt._u.structure.members.seq = tmp;
+
+  /* Set max index and move current members if required */
+  uint32_t member_index = params.index;
+  if (member_index > type->xt._u.structure.members.length - 1)
+    member_index = type->xt._u.structure.members.length - 1;
+  if (member_index < type->xt._u.structure.members.length - 1)
+  {
+    memmove (&type->xt._u.structure.members.seq[member_index + 1], &type->xt._u.structure.members.seq[member_index],
+        (type->xt._u.structure.members.length - 1 - member_index) * sizeof (*type->xt._u.structure.members.seq));
+  }
+
+  struct xt_struct_member *m = &type->xt._u.structure.members.seq[member_index];
+  memset (m, 0, sizeof (*m));
+  m->type = *member_type;
+  m->id = member_id;
+  if (params.is_key)
+    m->flags = DDS_XTypes_IS_KEY;
+  ddsrt_strlcpy (m->detail.name, params.name, sizeof (m->detail.name));
+
+  return DDS_RETCODE_OK;
+}
+
+dds_return_t ddsi_dynamic_type_add_union_member (struct ddsi_type *type, struct ddsi_type **member_type, struct ddsi_dynamic_type_union_member_param params)
+{
+  dds_return_t ret;
+  assert (type->state == DDSI_TYPE_CONSTRUCTING);
+  assert (type->gv == (*member_type)->gv);
+  assert (type->xt._d == DDS_XTypes_TK_UNION);
+
+  if ((ret = dynamic_type_complete (member_type)) != DDS_RETCODE_OK)
+    return ret;
+
+  // check member id or set to max+1
+  uint32_t member_id = 0;
+  if (params.id == DDS_DYNAMIC_MEMBER_ID_INVALID)
+  {
+    if (type->xt._u.union_type.flags & DDS_XTypes_IS_AUTOID_HASH)
+      member_id = ddsi_dynamic_type_member_hashid (params.name);
+    else
+    {
+      for (uint32_t n = 0; n < type->xt._u.union_type.members.length; n++)
+        if (type->xt._u.union_type.members.seq[n].id >= member_id)
+          member_id = type->xt._u.union_type.members.seq[n].id + 1;
+    }
+  }
+  else
+  {
+    // The 4 most significant bits in the member id are reserved (used in EMHEADER)
+    if (params.id & ~DDSI_DYNAMIC_TYPE_MEMBERID_MASK)
+      return DDS_RETCODE_BAD_PARAMETER;
+    member_id = params.id;
+  }
+
+  // Detect duplicate labels, duplicate member ids and multiple default members
+  for (uint32_t n = 0; n < type->xt._u.union_type.members.length; n++)
+  {
+    if (type->xt._u.union_type.members.seq[n].id == member_id)
+      return DDS_RETCODE_BAD_PARAMETER;
+    if (params.is_default && (type->xt._u.union_type.members.seq[n].flags & DDS_XTypes_IS_DEFAULT))
+      return DDS_RETCODE_BAD_PARAMETER;
+    for (uint32_t lp = 0; lp < params.n_labels; lp++)
+    {
+      for (uint32_t lm = 0; lm < type->xt._u.union_type.members.seq[n].label_seq._length; lm++)
+      {
+        if (type->xt._u.union_type.members.seq[n].label_seq._buffer[lm] == params.labels[lp])
+          return DDS_RETCODE_BAD_PARAMETER;
+      }
+    }
+  }
+
+  type->xt._u.union_type.members.length++;
+  struct xt_union_member *tmp = ddsrt_realloc (type->xt._u.union_type.members.seq,
+      type->xt._u.union_type.members.length * sizeof (*type->xt._u.union_type.members.seq));
+  if (tmp == NULL)
+    return DDS_RETCODE_OUT_OF_RESOURCES;
+  type->xt._u.union_type.members.seq = tmp;
+
+  /* Set max index and move current members if required */
+  uint32_t member_index = params.index;
+  if (member_index > type->xt._u.union_type.members.length - 1)
+    member_index = type->xt._u.union_type.members.length - 1;
+  if (member_index < type->xt._u.union_type.members.length - 1)
+  {
+    memmove (&type->xt._u.union_type.members.seq[member_index + 1], &type->xt._u.union_type.members.seq[member_index],
+        (type->xt._u.union_type.members.length - 1 - member_index) * sizeof (*type->xt._u.union_type.members.seq));
+  }
+
+  struct xt_union_member *m = &type->xt._u.union_type.members.seq[member_index];
+  memset (m, 0, sizeof (*m));
+  m->type = *member_type;
+  m->id = member_id;
+  ddsrt_strlcpy (m->detail.name, params.name, sizeof (m->detail.name));
+  if (params.is_default)
+    m->flags = DDS_XTypes_IS_DEFAULT;
+  else
+  {
+    assert (sizeof (*m->label_seq._buffer) == sizeof (*params.labels));
+    m->label_seq._maximum = m->label_seq._length = params.n_labels;
+    m->label_seq._buffer = ddsrt_malloc (params.n_labels * sizeof (*m->label_seq._buffer));
+    if (m->label_seq._buffer == NULL)
+      return DDS_RETCODE_OUT_OF_RESOURCES;
+    m->label_seq._release = true;
+    memcpy (m->label_seq._buffer, params.labels, params.n_labels * sizeof (*m->label_seq._buffer));
+  }
+  return DDS_RETCODE_OK;
+}
+
+dds_return_t ddsi_dynamic_type_add_enum_literal (struct ddsi_type *type, struct ddsi_dynamic_type_enum_literal_param params)
+{
+  assert (type->state == DDSI_TYPE_CONSTRUCTING);
+  assert (type->xt._d == DDS_XTypes_TK_ENUM);
+
+  /* Get maximum value for a literal in this enum. Type object has long type
+     to store the literal value, so limited to int32_max */
+  assert (type->xt._u.enum_type.bit_bound <= 32);
+  uint32_t max_literal_value = (uint32_t) (1ull << (uint64_t) type->xt._u.enum_type.bit_bound) - 1;
+  if (max_literal_value > INT32_MAX)
+    max_literal_value = INT32_MAX;
+
+  if (type->xt._u.enum_type.literals.length >= max_literal_value)
+    return DDS_RETCODE_BAD_PARAMETER;
+
+  int32_t literal_value = 0;
+  if (params.is_auto_value)
+  {
+    for (uint32_t n = 0; n < type->xt._u.enum_type.literals.length; n++)
+    {
+      if (type->xt._u.enum_type.literals.seq[n].value >= (int32_t) literal_value)
+      {
+        if (type->xt._u.enum_type.literals.seq[n].value == (int32_t) max_literal_value)
+          return DDS_RETCODE_BAD_PARAMETER;
+        literal_value = type->xt._u.enum_type.literals.seq[n].value + 1;
+      }
+    }
+  }
+  else
+  {
+    if ((uint32_t) params.value > max_literal_value)
+      return DDS_RETCODE_BAD_PARAMETER;
+    for (uint32_t n = 0; n < type->xt._u.enum_type.literals.length; n++)
+      if (type->xt._u.enum_type.literals.seq[n].value == params.value)
+        return DDS_RETCODE_BAD_PARAMETER;
+    literal_value = params.value;
+  }
+
+  for (uint32_t n = 0; n < type->xt._u.enum_type.literals.length; n++)
+  {
+    if (params.is_default && (type->xt._u.enum_type.literals.seq[n].flags & DDS_XTypes_IS_DEFAULT))
+      return DDS_RETCODE_BAD_PARAMETER;
+    if (!strcmp (type->xt._u.enum_type.literals.seq[n].detail.name, params.name))
+      return DDS_RETCODE_BAD_PARAMETER;
+  }
+
+  struct xt_enum_literal *tmp = ddsrt_realloc (type->xt._u.enum_type.literals.seq,
+      (type->xt._u.enum_type.literals.length + 1) * sizeof (*type->xt._u.enum_type.literals.seq));
+  if (tmp == NULL)
+    return DDS_RETCODE_OUT_OF_RESOURCES;
+  type->xt._u.enum_type.literals.length++;
+  type->xt._u.enum_type.literals.seq = tmp;
+
+  struct xt_enum_literal *l = &type->xt._u.enum_type.literals.seq[type->xt._u.enum_type.literals.length - 1];
+  memset (l, 0, sizeof (*l));
+  l->value = literal_value;
+  if (params.is_default)
+    l->flags |= DDS_XTypes_IS_DEFAULT;
+  ddsrt_strlcpy (l->detail.name, params.name, sizeof (l->detail.name));
+
+  return DDS_RETCODE_OK;
+}
+
+dds_return_t ddsi_dynamic_type_add_bitmask_field (struct ddsi_type *type, struct ddsi_dynamic_type_bitmask_field_param params)
+{
+  assert (type->state == DDSI_TYPE_CONSTRUCTING);
+  assert (type->xt._d == DDS_XTypes_TK_BITMASK);
+  if (type->xt._u.bitmask.bitflags.length == type->xt._u.bitmask.bit_bound)
+    return DDS_RETCODE_BAD_PARAMETER;
+
+  uint16_t position = 0;
+  if (params.is_auto_position)
+  {
+    for (uint32_t n = 0; n < type->xt._u.bitmask.bitflags.length; n++)
+    {
+      if (type->xt._u.bitmask.bitflags.seq[n].position >= position)
+      {
+        if (type->xt._u.bitmask.bitflags.seq[n].position == type->xt._u.bitmask.bit_bound - 1)
+          return DDS_RETCODE_BAD_PARAMETER;
+        position = (uint16_t) (type->xt._u.bitmask.bitflags.seq[n].position + 1);
+      }
+    }
+  }
+  else
+  {
+    if (params.position >= type->xt._u.bitmask.bit_bound)
+      return DDS_RETCODE_BAD_PARAMETER;
+    for (uint32_t n = 0; n < type->xt._u.bitmask.bitflags.length; n++)
+      if (type->xt._u.bitmask.bitflags.seq[n].position == params.position)
+        return DDS_RETCODE_BAD_PARAMETER;
+    position = params.position;
+  }
+
+  struct xt_bitflag *tmp = ddsrt_realloc (type->xt._u.bitmask.bitflags.seq,
+      (type->xt._u.bitmask.bitflags.length + 1) * sizeof (*type->xt._u.bitmask.bitflags.seq));
+  if (tmp == NULL)
+    return DDS_RETCODE_OUT_OF_RESOURCES;
+  type->xt._u.bitmask.bitflags.length++;
+  type->xt._u.bitmask.bitflags.seq = tmp;
+
+  struct xt_bitflag *f = &type->xt._u.bitmask.bitflags.seq[type->xt._u.bitmask.bitflags.length - 1];
+  memset (f, 0, sizeof (*f));
+  f->position = position;
+  ddsrt_strlcpy (f->detail.name, params.name, sizeof (f->detail.name));
+
+  return DDS_RETCODE_OK;
+}
+
+static dds_return_t find_struct_member (struct ddsi_type *type, uint32_t member_id, uint32_t *member_index)
+{
+  for (uint32_t n = 0; n < type->xt._u.structure.members.length; n++)
+  {
+    if (type->xt._u.structure.members.seq[n].id == member_id)
+    {
+      *member_index = n;
+      return DDS_RETCODE_OK;
+    }
+  }
+  return DDS_RETCODE_BAD_PARAMETER;
+}
+
+static dds_return_t find_union_member (struct ddsi_type *type, uint32_t member_id, uint32_t *member_index)
+{
+  for (uint32_t n = 0; n < type->xt._u.union_type.members.length; n++)
+  {
+    if (type->xt._u.union_type.members.seq[n].id == member_id)
+    {
+      *member_index = n;
+      return DDS_RETCODE_OK;
+    }
+  }
+  return DDS_RETCODE_BAD_PARAMETER;
+}
+
+static dds_return_t set_struct_member_flag (struct ddsi_type *type, uint32_t member_id, bool set, uint16_t flag)
+{
+  assert (type->state == DDSI_TYPE_CONSTRUCTING);
+  assert (type->xt._d == DDS_XTypes_TK_STRUCTURE);
+  dds_return_t ret;
+  uint32_t member_index = 0;
+  if ((ret = find_struct_member (type, member_id, &member_index)) == DDS_RETCODE_OK)
+  {
+    if (set)
+      type->xt._u.structure.members.seq[member_index].flags |= flag;
+    else
+      type->xt._u.structure.members.seq[member_index].flags &= (uint16_t) ~flag;
+  }
+  return ret;
+}
+
+static dds_return_t set_union_member_flag (struct ddsi_type *type, uint32_t member_id, bool set, uint16_t flag)
+{
+  assert (type->state == DDSI_TYPE_CONSTRUCTING);
+  assert (type->xt._d == DDS_XTypes_TK_UNION);
+  dds_return_t ret;
+  uint32_t member_index;
+  if ((ret = find_union_member (type, member_id, &member_index)) == DDS_RETCODE_OK)
+  {
+    if (set)
+      type->xt._u.union_type.members.seq[member_index].flags |= flag;
+    else
+      type->xt._u.union_type.members.seq[member_index].flags &= (uint16_t) ~flag;
+  }
+  return ret;
+}
+
+dds_return_t ddsi_dynamic_type_member_set_key (struct ddsi_type *type, uint32_t member_id, bool is_key)
+{
+  return set_struct_member_flag (type, member_id, is_key, DDS_XTypes_IS_KEY);
+}
+
+dds_return_t ddsi_dynamic_type_member_set_optional (struct ddsi_type *type, uint32_t member_id, bool is_optional)
+{
+  return set_struct_member_flag (type, member_id, is_optional, DDS_XTypes_IS_OPTIONAL);
+}
+
+dds_return_t ddsi_dynamic_struct_member_set_external (struct ddsi_type *type, uint32_t member_id, bool is_external)
+{
+  return set_struct_member_flag (type, member_id, is_external, DDS_XTypes_IS_EXTERNAL);
+}
+
+dds_return_t ddsi_dynamic_union_member_set_external (struct ddsi_type *type, uint32_t member_id, bool is_external)
+{
+  return set_union_member_flag (type, member_id, is_external, DDS_XTypes_IS_EXTERNAL);
+}
+
+dds_return_t ddsi_dynamic_type_member_set_must_understand (struct ddsi_type *type, uint32_t member_id, bool is_must_understand)
+{
+  return set_struct_member_flag (type, member_id, is_must_understand, DDS_XTypes_IS_MUST_UNDERSTAND);
+}
+
+dds_return_t ddsi_dynamic_type_member_set_hashid (struct ddsi_type *type, uint32_t member_id, const char *hash_member_name)
+{
+  assert (type->state == DDSI_TYPE_CONSTRUCTING);
+  assert (type->xt._d == DDS_XTypes_TK_STRUCTURE || type->xt._d == DDS_XTypes_TK_UNION);
+  dds_return_t ret;
+  uint32_t member_index;
+  uint32_t id = ddsi_dynamic_type_member_hashid (hash_member_name);
+  if (type->xt._d == DDS_XTypes_TK_STRUCTURE)
+  {
+    if (!(type->xt._u.structure.flags & DDS_XTypes_IS_AUTOID_HASH))
+      return DDS_RETCODE_PRECONDITION_NOT_MET;
+    if ((ret = find_struct_member (type, member_id, &member_index)) == DDS_RETCODE_OK)
+    {
+      for (uint32_t n = 0; n < type->xt._u.structure.members.length; n++)
+        if (type->xt._u.structure.members.seq[n].id == id)
+          return DDS_RETCODE_BAD_PARAMETER;
+
+      type->xt._u.structure.members.seq[member_index].id = id;
+    }
+  }
+  else
+  {
+    if (!(type->xt._u.union_type.flags & DDS_XTypes_IS_AUTOID_HASH))
+      return DDS_RETCODE_PRECONDITION_NOT_MET;
+    if ((ret = find_union_member (type, member_id, &member_index)) == DDS_RETCODE_OK)
+    {
+      for (uint32_t n = 0; n < type->xt._u.union_type.members.length; n++)
+        if (type->xt._u.union_type.members.seq[n].id == id)
+          return DDS_RETCODE_BAD_PARAMETER;
+      type->xt._u.union_type.members.seq[member_index].id = id;
+    }
+  }
+  return ret;
+}
+
+dds_return_t ddsi_dynamic_type_register (struct ddsi_type **type, ddsi_typeinfo_t **type_info)
+{
+  dds_return_t ret;
+  if ((ret = dynamic_type_complete (type)) != DDS_RETCODE_OK)
+    return ret;
+  if ((*type_info = ddsrt_malloc (sizeof (**type_info))) == NULL)
+    return DDS_RETCODE_OUT_OF_RESOURCES;
+  return ddsi_type_get_typeinfo ((*type)->gv, *type, *type_info);
+}
+
+struct ddsi_type * ddsi_dynamic_type_ref (struct ddsi_type *type)
+{
+  struct ddsi_type *ref;
+  ddsi_type_ref (type->gv, &ref, type);
+  return ref;
+}
+
+void ddsi_dynamic_type_unref (struct ddsi_type *type)
+{
+  ddsi_type_unref (type->gv, type);
+}
+
+struct ddsi_type *ddsi_dynamic_type_dup (const struct ddsi_type *src)
+{
+  assert (src->state == DDSI_TYPE_CONSTRUCTING);
+  struct ddsi_type *dst = ddsrt_calloc (1, sizeof (*dst));
+  dynamic_type_init (src->gv, dst, src->xt._d, src->xt.kind);
+  ddsi_xt_copy (src->gv, &dst->xt, &src->xt);
+  return dst;
+}

--- a/src/core/ddsi/src/ddsi_typebuilder.c
+++ b/src/core/ddsi/src/ddsi_typebuilder.c
@@ -379,10 +379,12 @@ static dds_return_t typebuilder_add_type (struct typebuilder_data *tbd, uint32_t
       *align = ALGN (uint8_t, is_ext);
       *size = SZ (uint8_t, is_ext);
       break;
+    case DDS_XTypes_TK_INT8:
+    case DDS_XTypes_TK_UINT8:
     case DDS_XTypes_TK_CHAR8:
     case DDS_XTypes_TK_BYTE:
       tb_type->type_code = DDS_OP_VAL_1BY;
-      tb_type->args.prim_args.is_signed = (type->xt._d == DDS_XTypes_TK_CHAR8);
+      tb_type->args.prim_args.is_signed = (type->xt._d == DDS_XTypes_TK_CHAR8 || type->xt._d == DDS_XTypes_TK_INT8);
       tb_type->cdr_align = 1;
       *align = ALGN (uint8_t, is_ext);
       *size = SZ (uint8_t, is_ext);

--- a/src/core/ddsi/src/ddsi_typelib.c
+++ b/src/core/ddsi/src/ddsi_typelib.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2022 ZettaScale Technology and others
+ * Copyright(c) 2006 to 2023 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -132,6 +132,12 @@ ddsi_typeid_t *ddsi_typeinfo_typeid (const ddsi_typeinfo_t *type_info, ddsi_type
 void ddsi_typeinfo_fini (ddsi_typeinfo_t *typeinfo)
 {
   dds_stream_free_sample (typeinfo, &dds_cdrstream_default_allocator, DDS_XTypes_TypeInformation_desc.m_ops);
+}
+
+void ddsi_typeinfo_free (ddsi_typeinfo_t *typeinfo)
+{
+  ddsi_typeinfo_fini (typeinfo);
+  ddsrt_free (typeinfo);
 }
 
 const ddsi_typeid_t *ddsi_typeinfo_minimal_typeid (const ddsi_typeinfo_t *typeinfo)
@@ -350,8 +356,9 @@ static void type_dep_trace (struct ddsi_domaingv *gv, const char *prefix, struct
   GVTRACE ("%sdep <%s, %s>\n", prefix, ddsi_make_typeid_str (&tistr, &dep->src_type_id), ddsi_make_typeid_str (&tistrdep, &dep->dep_type_id));
 }
 
-static void ddsi_type_free (struct ddsi_domaingv *gv, struct ddsi_type *type)
+void ddsi_type_free (struct ddsi_type *type)
 {
+  struct ddsi_domaingv *gv = type->gv;
   struct ddsi_type_dep key;
   memset (&key, 0, sizeof (key));
   ddsi_typeid_copy (&key.src_type_id, &type->xt.id);
@@ -422,11 +429,12 @@ static dds_return_t ddsi_type_new (struct ddsi_domaingv *gv, struct ddsi_type **
 
   if ((*type = ddsrt_calloc (1, sizeof (**type))) == NULL)
     return DDS_RETCODE_OUT_OF_RESOURCES;
+  (*type)->gv = gv;
 
   GVTRACE (" new %p", *type);
   if ((ret = ddsi_xt_type_init_impl (gv, &(*type)->xt, type_id, type_obj)) != DDS_RETCODE_OK)
   {
-    ddsi_type_free (gv, *type);
+    ddsi_type_free (*type);
     *type = NULL;
     return ret;
   }
@@ -584,6 +592,13 @@ void ddsi_type_ref_locked (struct ddsi_domaingv *gv, struct ddsi_type **type, co
   GVTRACE ("ref ddsi_type %p refc %"PRIu32"\n", t, t->refc);
   if (type)
     *type = t;
+}
+
+void ddsi_type_ref (struct ddsi_domaingv *gv, struct ddsi_type **type, const struct ddsi_type *src)
+{
+  ddsrt_mutex_lock (&gv->typelib_lock);
+  ddsi_type_ref_locked (gv, type, src);
+  ddsrt_mutex_unlock (&gv->typelib_lock);
 }
 
 dds_return_t ddsi_type_ref_id_locked_impl (struct ddsi_domaingv *gv, struct ddsi_type **type, const struct DDS_XTypes_TypeIdentifier *type_id)
@@ -1063,14 +1078,25 @@ struct ddsi_typeobj *ddsi_type_get_typeobj (struct ddsi_domaingv *gv, const stru
   return to;
 }
 
+struct ddsi_domaingv *ddsi_type_get_gv (const struct ddsi_type *type)
+{
+  return type->gv;
+}
+
+DDS_XTypes_TypeKind ddsi_type_get_kind (const struct ddsi_type *type)
+{
+  return type->xt._d;
+}
+
 static void ddsi_type_unref_impl_locked (struct ddsi_domaingv *gv, struct ddsi_type *type)
 {
   assert (type->refc > 0);
   if (--type->refc == 0)
   {
     GVTRACE (" refc 0 remove type ");
-    ddsrt_avl_delete (&ddsi_typelib_treedef, &gv->typelib, type);
-    ddsi_type_free (gv, type);
+    if (type->state != DDSI_TYPE_CONSTRUCTING)
+      ddsrt_avl_delete (&ddsi_typelib_treedef, &gv->typelib, type);
+    ddsi_type_free (type);
   }
   else
     GVTRACE (" refc %" PRIu32 " ", type->refc);

--- a/src/core/ddsi/src/ddsi_typewrap.c
+++ b/src/core/ddsi/src/ddsi_typewrap.c
@@ -158,9 +158,11 @@ const char * ddsi_typekind_descr (unsigned char disc)
     case DDS_XTypes_TK_NONE: return "NONE";
     case DDS_XTypes_TK_BOOLEAN: return "BOOLEAN";
     case DDS_XTypes_TK_BYTE: return "BYTE";
+    case DDS_XTypes_TK_INT8: return "INT8";
     case DDS_XTypes_TK_INT16: return "INT16";
     case DDS_XTypes_TK_INT32: return "INT32";
     case DDS_XTypes_TK_INT64: return "INT64";
+    case DDS_XTypes_TK_UINT8: return "UINT8";
     case DDS_XTypes_TK_UINT16: return "UINT16";
     case DDS_XTypes_TK_UINT32: return "UINT32";
     case DDS_XTypes_TK_UINT64: return "UINT64";
@@ -563,9 +565,10 @@ static dds_return_t xt_valid_union_disc_type (struct ddsi_domaingv *gv, const st
   if (ddsi_xt_is_unresolved (&t->_u.union_type.disc_type->xt))
     return DDS_RETCODE_OK;
   uint8_t d = ddsi_xt_unalias (&t->_u.union_type.disc_type->xt)->_d;
-  if (d != DDS_XTypes_TK_BOOLEAN && d != DDS_XTypes_TK_BYTE && d != DDS_XTypes_TK_CHAR8 && d != DDS_XTypes_TK_CHAR16
-      && d != DDS_XTypes_TK_INT16 && d != DDS_XTypes_TK_INT32 && d != DDS_XTypes_TK_INT64
-      && d != DDS_XTypes_TK_UINT16 && d != DDS_XTypes_TK_UINT32 && d != DDS_XTypes_TK_UINT64
+  if (d != DDS_XTypes_TK_BOOLEAN
+      && d != DDS_XTypes_TK_BYTE && d != DDS_XTypes_TK_CHAR8 && d != DDS_XTypes_TK_CHAR16
+      && d != DDS_XTypes_TK_INT8 && d != DDS_XTypes_TK_INT16 && d != DDS_XTypes_TK_INT32 && d != DDS_XTypes_TK_INT64
+      && d != DDS_XTypes_TK_UINT8 && d != DDS_XTypes_TK_UINT16 && d != DDS_XTypes_TK_UINT32 && d != DDS_XTypes_TK_UINT64
       && d != DDS_XTypes_TK_ENUM && d != DDS_XTypes_TK_BITMASK)
   {
     GVTRACE ("discriminator type for union is invalid\n");
@@ -944,8 +947,8 @@ static dds_return_t xt_validate_impl (struct ddsi_domaingv *gv, const struct xt_
         return ret;
       break;
     case DDS_XTypes_TK_BOOLEAN: case DDS_XTypes_TK_BYTE:
-    case DDS_XTypes_TK_INT16: case DDS_XTypes_TK_INT32: case DDS_XTypes_TK_INT64:
-    case DDS_XTypes_TK_UINT16: case DDS_XTypes_TK_UINT32: case DDS_XTypes_TK_UINT64:
+    case DDS_XTypes_TK_INT8: case DDS_XTypes_TK_INT16: case DDS_XTypes_TK_INT32: case DDS_XTypes_TK_INT64:
+    case DDS_XTypes_TK_UINT8: case DDS_XTypes_TK_UINT16: case DDS_XTypes_TK_UINT32: case DDS_XTypes_TK_UINT64:
     case DDS_XTypes_TK_FLOAT32: case DDS_XTypes_TK_FLOAT64: case DDS_XTypes_TK_FLOAT128:
     case DDS_XTypes_TK_CHAR8: case DDS_XTypes_TK_CHAR16: case DDS_XTypes_TK_STRING8:
       // no validations

--- a/src/core/xtests/symbol_export/symbol_export.c
+++ b/src/core/xtests/symbol_export/symbol_export.c
@@ -402,6 +402,27 @@ int main (int argc, char **argv)
   dds_get_requested_deadline_missed_status (1, ptr);
   dds_get_requested_incompatible_qos_status (1, ptr);
 
+#ifdef DDS_HAS_TYPE_DISCOVERY
+  // dds_public_dynamic_type.h
+  dds_dynamic_member_set_external (ptr, 0, 0);
+  dds_dynamic_member_set_hashid (ptr, 0, ptr);
+  dds_dynamic_member_set_key (ptr, 0, 0);
+  dds_dynamic_member_set_must_understand (ptr, 0, 0);
+  dds_dynamic_member_set_optional (ptr, 0, 0);
+  dds_dynamic_type_add_bitmask_field (ptr, ptr, 0);
+  dds_dynamic_type_add_enum_literal (ptr, ptr, (dds_dynamic_enum_literal_value_t) { .value_kind = 0 }, 0);
+  dds_dynamic_type_add_member (ptr, (dds_dynamic_member_descriptor_t) { .name = "dummy" });
+  dds_dynamic_type_create (0, (dds_dynamic_type_descriptor_t) { .name = "dummy" });
+  dds_dynamic_type_dup (ptr);
+  dds_dynamic_type_ref (ptr);
+  dds_dynamic_type_register (ptr, ptr);
+  dds_dynamic_type_set_autoid (ptr, 0);
+  dds_dynamic_type_set_bit_bound (ptr, 0);
+  dds_dynamic_type_set_extensibility (ptr, 0);
+  dds_dynamic_type_set_nested (ptr, 0);
+  dds_dynamic_type_unref (ptr);
+#endif
+
   // dds_rhs.h
   dds_rhc_associate (ptr, NULL, NULL, NULL);
   dds_rhc_store (ptr, NULL, NULL, NULL);
@@ -636,6 +657,7 @@ int main (int argc, char **argv)
   ddsi_typeinfo_typeid (ptr, 0);
   ddsi_typeinfo_deser (ptr, 0);
   ddsi_typeinfo_fini (ptr);
+  ddsi_typeinfo_free (ptr);
   ddsi_typeinfo_dup (ptr);
   ddsi_typeinfo_minimal_typeid (ptr);
   ddsi_typeinfo_complete_typeid (ptr);

--- a/src/tools/idlc/src/descriptor_type_meta.c
+++ b/src/tools/idlc/src/descriptor_type_meta.c
@@ -262,11 +262,13 @@ get_plain_typeid (const idl_pstate_t *pstate, struct descriptor_type_meta *dtm, 
     switch (idl_type (type_spec))
     {
       case IDL_BOOL: ti->_d = DDS_XTypes_TK_BOOLEAN; break;
-      case IDL_INT8: case IDL_CHAR: ti->_d = DDS_XTypes_TK_CHAR8; break;
-      case IDL_UINT8: case IDL_OCTET: ti->_d = DDS_XTypes_TK_BYTE; break;
+      case IDL_CHAR: ti->_d = DDS_XTypes_TK_CHAR8; break;
+      case IDL_OCTET: ti->_d = DDS_XTypes_TK_BYTE; break;
+      case IDL_INT8: ti->_d = DDS_XTypes_TK_INT8; break;
       case IDL_INT16: case IDL_SHORT: ti->_d = DDS_XTypes_TK_INT16; break;
       case IDL_INT32: case IDL_LONG: ti->_d = DDS_XTypes_TK_INT32; break;
       case IDL_INT64: case IDL_LLONG: ti->_d = DDS_XTypes_TK_INT64; break;
+      case IDL_UINT8: ti->_d = DDS_XTypes_TK_UINT8; break;
       case IDL_UINT16: case IDL_USHORT: ti->_d = DDS_XTypes_TK_UINT16; break;
       case IDL_UINT32: case IDL_ULONG: ti->_d = DDS_XTypes_TK_UINT32; break;
       case IDL_UINT64: case IDL_ULLONG: ti->_d = DDS_XTypes_TK_UINT64; break;
@@ -626,15 +628,21 @@ set_xtypes_annotation_parameter_value(
       val->_d = DDS_XTypes_TK_BOOLEAN;
       val->_u.boolean_value = lit->value.bln;
       break;
-    case IDL_INT8:
     case IDL_CHAR:
       val->_d = DDS_XTypes_TK_CHAR8;
       val->_u.char_value = lit->value.chr;
       break;
     case IDL_OCTET:
-    case IDL_UINT8:
       val->_d = DDS_XTypes_TK_BYTE;
       val->_u.byte_value = lit->value.uint8;
+      break;
+    case IDL_INT8:
+      val->_d = DDS_XTypes_TK_INT8;
+      val->_u.int8_value = lit->value.int8;
+      break;
+    case IDL_UINT8:
+      val->_d = DDS_XTypes_TK_UINT8;
+      val->_u.uint8_value = lit->value.uint8;
       break;
     case IDL_SHORT:
     case IDL_INT16:

--- a/src/tools/idlc/tests/type_meta.c
+++ b/src/tools/idlc/tests/type_meta.c
@@ -222,13 +222,15 @@ static DDS_XTypes_TypeObject *get_typeobj1 (void)
     "t1::test_struct",
     DDS_XTypes_IS_APPENDABLE,
     (DDS_XTypes_TypeIdentifier) { ._d = DDS_XTypes_TK_NONE },
-    6, (smember_t[]) {
+    8, (smember_t[]) {
       { 0, DDS_XTypes_IS_KEY | DDS_XTypes_IS_MUST_UNDERSTAND | DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TK_INT64 }, "f1" },
       { 1, DDS_XTypes_IS_OPTIONAL | DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TI_STRING8_SMALL, ._u.string_sdefn.bound = 0 }, "f2" },
       { 4, DDS_XTypes_IS_EXTERNAL | DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TK_CHAR8 }, "f3" },
-      { 3, DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TK_CHAR8 }, "f4" },
+      { 3, DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TK_INT8 }, "f4" },
       { 8, DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TK_UINT32 }, "f5" },
-      { 7, DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TK_INT64 }, "f6" }
+      { 7, DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TK_INT64 }, "f6" },
+      { 10, DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TK_UINT8 }, "f7" },
+      { 11, DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TK_BYTE }, "f8" }
     });
 }
 
@@ -800,7 +802,7 @@ CU_Test(idlc_type_meta, type_obj_serdes)
     char idl[256];
     get_typeobj_t get_typeobj_fn;
   } tests[] = {
-    { "module t1 { @appendable struct test_struct { @key long long f1; @optional string f2; @external @id(4) char f3; @id(3) int8 f4; @id(8) uint32 f5; @id(7) int64 f6; }; };", get_typeobj1 },
+    { "module t1 { @appendable struct test_struct { @key long long f1; @optional string f2; @external @id(4) char f3; @id(3) int8 f4; @id(8) uint32 f5; @id(7) int64 f6; @id(10) uint8 f7; octet f8; }; };", get_typeobj1 },
     { "module t2 { @mutable struct test_struct { @optional @external unsigned long f1, f2; }; };", get_typeobj2 },
     { "module t3 { @final union test_union switch (short) { case 1: long f1; case 2: case 3: default: @external string f2; }; };", get_typeobj3 },
     { "module t4 { @mutable @nested struct a { @id(5) long a1; }; @mutable @topic struct test_struct : a { @id(10) long f1; }; };", get_typeobj4 },


### PR DESCRIPTION
This PR introduces the Dynamic Type API, part of the Dynamic Language Binding as defined in section 7.5.2 of the DDS XTypes 1.3 specification. 

Note that the first commits in this PR is cherry-picked from #1556. That PR needs to be merged before this PR. 