### PR TITLE
Iceoryx partition cross-talk

### DIFF
--- a/src/core/ddsc/CMakeLists.txt
+++ b/src/core/ddsc/CMakeLists.txt
@@ -47,7 +47,9 @@ prepend(srcs_ddsc "${CMAKE_CURRENT_LIST_DIR}/src/"
   dds_loan.c)
 
 if(ENABLE_SHM)
-  list(APPEND srcs_ddsc "${CMAKE_CURRENT_LIST_DIR}/src/dds_shm_monitor.c")
+  list(APPEND srcs_ddsc
+    "${CMAKE_CURRENT_LIST_DIR}/src/dds_shm_monitor.c"
+    "${CMAKE_CURRENT_LIST_DIR}/src/dds_shm_qos.c")
 endif()
 
 prepend(hdrs_private_ddsc "${CMAKE_CURRENT_LIST_DIR}/src/"
@@ -93,7 +95,9 @@ prepend(hdrs_public_ddsc "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>$<
   ddsc/dds_loan_api.h)
 
 if(ENABLE_SHM)
-  list(APPEND hdrs_private_ddsc "${CMAKE_CURRENT_LIST_DIR}/src/dds__shm_monitor.h")
+  list(APPEND hdrs_private_ddsc
+    "${CMAKE_CURRENT_LIST_DIR}/src/dds__shm_monitor.h"
+    "${CMAKE_CURRENT_LIST_DIR}/src/dds__shm_qos.h")
 endif()
 
 generate_export_header(

--- a/src/core/ddsc/src/dds__shm_qos.h
+++ b/src/core/ddsc/src/dds__shm_qos.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright(c) 2023 ZettaScale Technology and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#ifndef DDS__SHM_QOS_H
+#define DDS__SHM_QOS_H
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+struct dds_qos;
+struct dds_topic;
+
+/**
+ * @brief Check whether the DDS QoS settings and topic are compatible with Iceoryx
+ * @component iceoryx_support
+ *
+ * @param[in] qos the QoS for which to check compatibility
+ * @param[in] tp topic
+ * @param[in] check_durability_service whether to include this one
+ *
+ * @return true iff compatible
+ */
+bool dds_shm_compatible_qos_and_topic (const struct dds_qos *qos, const struct dds_topic *tp, bool check_durability_service);
+
+/**
+ * @brief Construct a string representation partition & topic string for use in Iceoryx
+ * @component iceoryx_support
+ *
+ * @param[in] qos the QoS from which to get the partition
+ * @param[in] tp the topic
+ *
+ * @return an allocated, null-terminated string if partition is compatible and sufficent memory is available
+ */
+char *dds_shm_partition_topic (const struct dds_qos *qos, const struct dds_topic *tp);
+
+#if defined (__cplusplus)
+}
+#endif
+
+#endif /* DDS__SHM_MONITOR_H */

--- a/src/core/ddsc/src/dds_shm_qos.c
+++ b/src/core/ddsc/src/dds_shm_qos.c
@@ -1,0 +1,109 @@
+/*
+ * Copyright(c) 2023 ZettaScale Technology and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+#include <assert.h>
+#include <string.h>
+
+#include "dds/ddsrt/heap.h"
+#include "dds/ddsi/ddsi_sertype.h"
+#include "dds__qos.h"
+#include "dds__topic.h"
+#include "dds__shm_qos.h"
+
+static bool is_wildcard_partition (const char *str)
+{
+  return strchr (str, '*') || strchr (str, '?');
+}
+
+#define QOS_CHECK_FIELDS (DDSI_QP_LIVELINESS|DDSI_QP_DEADLINE|DDSI_QP_RELIABILITY|DDSI_QP_DURABILITY|DDSI_QP_HISTORY)
+
+bool dds_shm_compatible_qos_and_topic (const struct dds_qos *qos, const struct dds_topic *tp, bool check_durability_service)
+{
+  // check necessary condition: fixed size data type OR serializing into shared
+  // memory is available
+  if (!tp->m_stype->fixed_size && (!tp->m_stype->ops->get_serialized_size ||
+                                   !tp->m_stype->ops->serialize_into))
+  {
+    return false;
+  }
+
+  if (qos->history.kind != DDS_HISTORY_KEEP_LAST)
+  {
+    return false;
+  }
+
+  if (!(qos->durability.kind == DDS_DURABILITY_VOLATILE || qos->durability.kind == DDS_DURABILITY_TRANSIENT_LOCAL))
+  {
+    return false;
+  }
+
+  // we cannot support the required history with iceoryx
+  if (check_durability_service &&
+      qos->durability.kind == DDS_DURABILITY_TRANSIENT_LOCAL &&
+      qos->durability_service.history.kind == DDS_HISTORY_KEEP_LAST &&
+      qos->durability_service.history.depth > (int32_t) iox_cfg_max_publisher_history ())
+  {
+    return false;
+  }
+
+  if (qos->ignorelocal.value != DDS_IGNORELOCAL_NONE)
+  {
+    return false;
+  }
+
+  // only default partition or one non-wildcard partition
+  if (qos->partition.n > 1 ||
+      (qos->partition.n == 1 && is_wildcard_partition (qos->partition.strs[0])))
+  {
+    return false;
+  }
+
+  return (QOS_CHECK_FIELDS == (qos->present & QOS_CHECK_FIELDS) &&
+          DDS_LIVELINESS_AUTOMATIC == qos->liveliness.kind &&
+          DDS_INFINITY == qos->deadline.deadline);
+}
+
+char *dds_shm_partition_topic (const struct dds_qos *qos, const struct dds_topic *tp)
+{
+  const char *partition = "";
+  if (qos->present & DDSI_QP_PARTITION)
+  {
+    assert (qos->partition.n <= 1);
+    if (qos->partition.n == 1)
+      partition = qos->partition.strs[0];
+  }
+  assert (partition);
+  assert (!is_wildcard_partition (partition));
+
+  // compute combined string length, allowing for escaping dots
+  // (using \ in good traditional C style)
+  size_t size = 1 + strlen (tp->m_name) + 1; // dot & terminating 0
+  for (char const *src = partition; *src; src++)
+  {
+    if (*src == '\\' || *src == '.')
+      size++;
+    size++;
+  }
+  char *combined = ddsrt_malloc (size);
+  if (combined == NULL)
+    return NULL;
+  char *dst = combined;
+  for (char const *src = partition; *src; src++)
+  {
+    if (*src == '\\' || *src == '.')
+      *dst++ = '\\';
+    *dst++ = *src;
+  }
+  *dst++ = '.';
+  strcpy (dst, tp->m_name);
+  return combined;
+}

--- a/src/core/ddsc/tests/CMakeLists.txt
+++ b/src/core/ddsc/tests/CMakeLists.txt
@@ -261,6 +261,7 @@ kill -0 `cat ctest_fixture_iox_roudi.pid`")
       iceoryx_one_writer
       iceoryx_one_writer_dynsize
       iceoryx_return_loan
+      iceoryx_partition_xtalk
       shm_serialization_get_serialized_size
       shm_serialization_serialize_into
       shm_serialization_transmit_dynamic_type)


### PR DESCRIPTION
The mapping of readers/writers to Iceoryx failed to take the partition QoS into consideration, and so allow data from a writer using partition A to arrive at a reader using partition B.

This changes the logic to:

* not use Iceoryx for any complicated cases, that is: where there is more than one partition or a wildcard is involved; and

* extends the "topic" name in Iceoryx to include the (now known-to-be-simple) partition name

This eliminates the crosstalk and hopefully is flexible enough to not avoid using Iceoryx in important cases.