### PR TITLE
IDLC fixes for forward declarations

### DIFF
--- a/src/tools/idlc/src/descriptor_type_meta.c
+++ b/src/tools/idlc/src/descriptor_type_meta.c
@@ -1501,6 +1501,22 @@ emit_sequence(
 }
 
 static idl_retcode_t
+emit_forward(
+  const idl_pstate_t *pstate,
+  bool revisit,
+  const idl_path_t *path,
+  const void *node,
+  void *user_data)
+{
+  (void)pstate;
+  (void)revisit;
+  (void)path;
+  (void)node;
+  (void)user_data;
+  return IDL_VISIT_TYPE_SPEC;
+}
+
+static idl_retcode_t
 print_ser_data(FILE *fp, const char *kind, const char *type, unsigned char *data, uint32_t sz)
 {
   char *sep = ", ", *lsep = "\\\n  ", *fmt;
@@ -1613,6 +1629,7 @@ generate_descriptor_type_meta (
   visitor.accept[IDL_ACCEPT_ENUMERATOR] = &emit_enumerator;
   visitor.accept[IDL_ACCEPT_INHERIT_SPEC] = &emit_inherit_spec;
   visitor.accept[IDL_ACCEPT_SEQUENCE] = &emit_sequence;
+  visitor.accept[IDL_ACCEPT_FORWARD] = &emit_forward;
 
   /* must be invoked for topics only, so structs and unions */
   assert (idl_is_struct (node) || idl_is_union (node));

--- a/src/tools/idlc/src/types.c
+++ b/src/tools/idlc/src/types.c
@@ -465,7 +465,7 @@ emit_typedef(
 {
   struct generator *gen = user_data;
   char dims[32] = "";
-  const char *fmt, *star = "";
+  const char *fmt, *star = "", *type_prefix = "";
   char *name = NULL, *type = NULL;
   const idl_declarator_t *declarator;
   const idl_literal_t *literal;
@@ -479,14 +479,17 @@ emit_typedef(
     idl_snprintf(dims, sizeof(dims), "[%" PRIu32 "]", idl_bound(type_spec)+1);
   else if (idl_is_string(type_spec))
     star = "*";
+
+  type_prefix = get_type_prefix(type_spec);
+
   if (IDL_PRINTA(&type, print_type, type_spec) < 0)
     return IDL_RETCODE_NO_MEMORY;
   declarator = ((const idl_typedef_t *)node)->declarators;
   for (; declarator; declarator = idl_next(declarator)) {
     if (IDL_PRINTA(&name, print_type, declarator) < 0)
       return IDL_RETCODE_NO_MEMORY;
-    fmt = "typedef %1$s %2$s%3$s%4$s";
-    if (idl_fprintf(gen->header.handle, fmt, type, star, name, dims) < 0)
+    fmt = "typedef %1$s%2$s %3$s%4$s%5$s";
+    if (idl_fprintf(gen->header.handle, fmt, type_prefix, type, star, name, dims) < 0)
       return IDL_RETCODE_NO_MEMORY;
     literal = declarator->const_expr;
     for (; literal; literal = idl_next(literal)) {

--- a/src/tools/idlc/tests/type_meta.c
+++ b/src/tools/idlc/tests/type_meta.c
@@ -753,6 +753,45 @@ static DDS_XTypes_TypeObject *get_typeobj14 (void)
     });
 }
 
+static DDS_XTypes_TypeObject *get_typeobj15 (void)
+{
+  DDS_XTypes_TypeIdentifier ti_f1;
+
+  /* f1 type identifier */
+  {
+    DDS_XTypes_TypeObject *to_s = get_typeobj_struct (
+      "t15::s",
+      DDS_XTypes_IS_FINAL | DDS_XTypes_IS_NESTED,
+      (DDS_XTypes_TypeIdentifier) { ._d = DDS_XTypes_TK_NONE },
+      1, (smember_t[]) {
+        { 0, DDS_XTypes_TRY_CONSTRUCT_DISCARD, { ._d = DDS_XTypes_TK_INT32 }, "s1" }
+      }
+    );
+
+    /* typedef s x */
+    DDS_XTypes_TypeObject *to_alias = calloc_no_fail (1, sizeof (*to_alias));
+    to_alias->_d = DDS_XTypes_EK_COMPLETE;
+    to_alias->_u.complete = (DDS_XTypes_CompleteTypeObject) {
+      ._d = DDS_XTypes_TK_ALIAS,
+      ._u.alias_type = (DDS_XTypes_CompleteAliasType) {
+        .alias_flags = 0,
+        .header = { .detail = { .type_name = "t15::td_s" } },
+        .body = { .common = { .related_flags = 0 } }
+      }
+    };
+    get_typeid (&to_alias->_u.complete._u.alias_type.body.common.related_type, to_s);
+    get_typeid (&ti_f1, to_alias);
+  }
+
+  return get_typeobj_struct (
+    "t15::test_struct",
+    DDS_XTypes_IS_FINAL,
+    (DDS_XTypes_TypeIdentifier) { ._d = DDS_XTypes_TK_NONE },
+    1, (smember_t[]) {
+      { 0, DDS_XTypes_IS_EXTERNAL | DDS_XTypes_TRY_CONSTRUCT_DISCARD, ti_f1, "f1" },
+    });
+}
+
 typedef DDS_XTypes_TypeObject * (*get_typeobj_t) (void);
 
 CU_Test(idlc_type_meta, type_obj_serdes)
@@ -775,7 +814,8 @@ CU_Test(idlc_type_meta, type_obj_serdes)
     { "module t11 { @final union test_union switch (char) { case 'a': @id(99) long f1; default: @id(5) unsigned short f2; }; };", get_typeobj11 },
     { "module t12 { typedef sequence<long> td_seq; typedef td_seq td_array[2]; struct test_struct { td_array f1; }; };", get_typeobj12 },
     { "module t13 { typedef long td_arr[3]; typedef td_arr td; @topic @final struct test_struct { td f1; }; };", get_typeobj13 },
-    { "module t14 { typedef sequence<long> td_seq_arr[3]; @final struct test_struct { td_seq_arr f1; }; };", get_typeobj14 }
+    { "module t14 { typedef sequence<long> td_seq_arr[3]; @final struct test_struct { td_seq_arr f1; }; };", get_typeobj14 },
+    { "module t15 { struct s; typedef s td_s; @final struct test_struct { @external td_s f1; }; @final @nested struct s { long s1; }; };", get_typeobj15 }
   };
 
   uint32_t flags = IDL_FLAG_EXTENDED_DATA_TYPES |


### PR DESCRIPTION
This resolves a number of issues related to forward declarations in IDL. See the commit messages for details. Related to https://github.com/eclipse-cyclonedds/cyclonedds-cxx/issues/371. 

I think that the C++ IDLC backend also needs a fix to correctly handle forward declared types, it looks like it does not (correctly) output any forward declarations in the generated headers. 

