### PR TITLE
Parameterize allocator functions in CDR stream serializer

### DIFF
--- a/src/core/cdr/include/dds/cdr/dds_cdrstream.h
+++ b/src/core/cdr/include/dds/cdr/dds_cdrstream.h
@@ -233,9 +233,6 @@ uint32_t dds_stream_type_nesting_depth (const uint32_t * __restrict ops);
 bool dds_stream_extensibility (const uint32_t * __restrict ops, enum dds_cdr_type_extensibility *ext);
 
 /** @component cdr_serializer */
-DDS_EXPORT void dds_cdrstream_desc_from_topic_desc (struct dds_cdrstream_desc *desc, const dds_topic_descriptor_t *topic_desc);
-
-/** @component cdr_serializer */
 DDS_EXPORT void dds_cdrstream_desc_fini (struct dds_cdrstream_desc *desc, const struct dds_cdrstream_allocator * __restrict allocator);
 
 

--- a/src/core/cdr/include/dds/cdr/dds_cdrstream.h
+++ b/src/core/cdr/include/dds/cdr/dds_cdrstream.h
@@ -76,6 +76,14 @@ typedef struct dds_ostreamLE {
   dds_ostream_t x;
 } dds_ostreamLE_t;
 
+typedef struct dds_cdrstream_allocator {
+  void* (*malloc) (size_t size);
+  void* (*realloc) (void *ptr, size_t new_size);
+  void (*free) (void *pt);
+  /* In a future version, a void ptr may be needed here as a parameter for
+     custom allocator implementations. */
+} dds_cdrstream_allocator_t;
+
 typedef struct dds_cdrstream_desc_key {
   uint32_t ops_offs;   /* Offset for key ops */
   uint32_t idx;        /* Key index (used for key order) */
@@ -105,31 +113,31 @@ DDSRT_STATIC_ASSERT (offsetof (dds_ostreamLE_t, x) == 0);
 DDSRT_STATIC_ASSERT (offsetof (dds_ostreamBE_t, x) == 0);
 
 /** @component cdr_serializer */
-uint32_t dds_cdr_alignto4_clear_and_resize (dds_ostream_t * __restrict s, uint32_t xcdr_version);
+uint32_t dds_cdr_alignto4_clear_and_resize (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, uint32_t xcdr_version);
 
 /** @component cdr_serializer */
-DDS_EXPORT void dds_istream_init (dds_istream_t * __restrict st, uint32_t size, const void * __restrict input, uint32_t xcdr_version);
+DDS_EXPORT void dds_istream_init (dds_istream_t * __restrict is, uint32_t size, const void * __restrict input, uint32_t xcdr_version);
 
 /** @component cdr_serializer */
-DDS_EXPORT void dds_istream_fini (dds_istream_t * __restrict st);
+DDS_EXPORT void dds_istream_fini (dds_istream_t * __restrict is);
 
 /** @component cdr_serializer */
-DDS_EXPORT void dds_ostream_init (dds_ostream_t * __restrict st, uint32_t size, uint32_t xcdr_version);
+DDS_EXPORT void dds_ostream_init (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, uint32_t size, uint32_t xcdr_version);
 
 /** @component cdr_serializer */
-DDS_EXPORT void dds_ostream_fini (dds_ostream_t * __restrict st);
+DDS_EXPORT void dds_ostream_fini (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator);
 
 /** @component cdr_serializer */
-DDS_EXPORT void dds_ostreamLE_init (dds_ostreamLE_t * __restrict st, uint32_t size, uint32_t xcdr_version);
+DDS_EXPORT void dds_ostreamLE_init (dds_ostreamLE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, uint32_t size, uint32_t xcdr_version);
 
 /** @component cdr_serializer */
-DDS_EXPORT void dds_ostreamLE_fini (dds_ostreamLE_t * __restrict st);
+DDS_EXPORT void dds_ostreamLE_fini (dds_ostreamLE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator);
 
 /** @component cdr_serializer */
-DDS_EXPORT void dds_ostreamBE_init (dds_ostreamBE_t * __restrict st, uint32_t size, uint32_t xcdr_version);
+DDS_EXPORT void dds_ostreamBE_init (dds_ostreamBE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, uint32_t size, uint32_t xcdr_version);
 
 /** @component cdr_serializer */
-DDS_EXPORT void dds_ostreamBE_fini (dds_ostreamBE_t * __restrict st);
+DDS_EXPORT void dds_ostreamBE_fini (dds_ostreamBE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator);
 
 /** @component cdr_serializer */
 dds_ostream_t dds_ostream_from_buffer(void *buffer, size_t size, uint16_t write_encoding_version);
@@ -153,31 +161,31 @@ DDS_EXPORT bool dds_stream_normalize (void * __restrict data, uint32_t size, boo
 DDS_EXPORT const uint32_t *dds_stream_normalize_data (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t * __restrict ops) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
 
 /** @component cdr_serializer */
-DDS_EXPORT const uint32_t *dds_stream_write (dds_ostream_t * __restrict os, const char * __restrict data, const uint32_t * __restrict ops);
+DDS_EXPORT const uint32_t *dds_stream_write (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict data, const uint32_t * __restrict ops);
 
 /** @component cdr_serializer */
-DDS_EXPORT const uint32_t *dds_stream_writeLE (dds_ostreamLE_t * __restrict os, const char * __restrict data, const uint32_t * __restrict ops);
+DDS_EXPORT const uint32_t *dds_stream_writeLE (dds_ostreamLE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict data, const uint32_t * __restrict ops);
 
 /** @component cdr_serializer */
-DDS_EXPORT const uint32_t *dds_stream_writeBE (dds_ostreamBE_t * __restrict os, const char * __restrict data, const uint32_t * __restrict ops);
+DDS_EXPORT const uint32_t *dds_stream_writeBE (dds_ostreamBE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict data, const uint32_t * __restrict ops);
 
 /** @component cdr_serializer */
-DDS_EXPORT const uint32_t * dds_stream_write_with_byte_order (dds_ostream_t * __restrict os, const char * __restrict data, const uint32_t * __restrict ops, enum ddsrt_byte_order_selector bo);
+DDS_EXPORT const uint32_t * dds_stream_write_with_byte_order (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict data, const uint32_t * __restrict ops, enum ddsrt_byte_order_selector bo);
 
 /** @component cdr_serializer */
-DDS_EXPORT bool dds_stream_write_sample (dds_ostream_t * __restrict os, const void * __restrict data, const struct dds_cdrstream_desc * __restrict type);
+DDS_EXPORT bool dds_stream_write_sample (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const void * __restrict data, const struct dds_cdrstream_desc * __restrict type);
 
 /** @component cdr_serializer */
-DDS_EXPORT bool dds_stream_write_sampleLE (dds_ostreamLE_t * __restrict os, const void * __restrict data, const struct dds_cdrstream_desc * __restrict type);
+DDS_EXPORT bool dds_stream_write_sampleLE (dds_ostreamLE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const void * __restrict data, const struct dds_cdrstream_desc * __restrict type);
 
 /** @component cdr_serializer */
-DDS_EXPORT bool dds_stream_write_sampleBE (dds_ostreamBE_t * __restrict os, const void * __restrict data, const struct dds_cdrstream_desc * __restrict type);
+DDS_EXPORT bool dds_stream_write_sampleBE (dds_ostreamBE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const void * __restrict data, const struct dds_cdrstream_desc * __restrict type);
 
 /** @component cdr_serializer */
-DDS_EXPORT void dds_stream_read_sample (dds_istream_t * __restrict is, void * __restrict data, const struct dds_cdrstream_desc * __restrict type);
+DDS_EXPORT void dds_stream_read_sample (dds_istream_t * __restrict is, void * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const struct dds_cdrstream_desc * __restrict type);
 
 /** @component cdr_serializer */
-DDS_EXPORT void dds_stream_free_sample (void * __restrict data, const uint32_t * __restrict ops);
+DDS_EXPORT void dds_stream_free_sample (void * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops);
 
 /** @component cdr_serializer */
 DDS_EXPORT uint32_t dds_stream_countops (const uint32_t * __restrict ops, uint32_t nkeys, const dds_key_descriptor_t * __restrict keys);
@@ -186,28 +194,28 @@ DDS_EXPORT uint32_t dds_stream_countops (const uint32_t * __restrict ops, uint32
 size_t dds_stream_check_optimize (const struct dds_cdrstream_desc * __restrict desc, uint32_t xcdr_version);
 
 /** @component cdr_serializer */
-void dds_stream_write_key (dds_ostream_t * __restrict os, const char * __restrict sample, const struct dds_cdrstream_desc * __restrict type);
+void dds_stream_write_key (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict sample, const struct dds_cdrstream_desc * __restrict type);
 
 /** @component cdr_serializer */
-void dds_stream_write_keyBE (dds_ostreamBE_t * __restrict os, const char * __restrict sample, const struct dds_cdrstream_desc * __restrict type);
+void dds_stream_write_keyBE (dds_ostreamBE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict sample, const struct dds_cdrstream_desc * __restrict type);
 
 /** @component cdr_serializer */
-DDS_EXPORT bool dds_stream_extract_key_from_data (dds_istream_t * __restrict is, dds_ostream_t * __restrict os, const struct dds_cdrstream_desc * __restrict type);
+DDS_EXPORT bool dds_stream_extract_key_from_data (dds_istream_t * __restrict is, dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const struct dds_cdrstream_desc * __restrict type);
 
 /** @component cdr_serializer */
-DDS_EXPORT void dds_stream_extract_key_from_key (dds_istream_t * __restrict is, dds_ostream_t * __restrict os, const struct dds_cdrstream_desc * __restrict type);
+DDS_EXPORT void dds_stream_extract_key_from_key (dds_istream_t * __restrict is, dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const struct dds_cdrstream_desc * __restrict type);
 
 /** @component cdr_serializer */
-DDS_EXPORT bool dds_stream_extract_keyBE_from_data (dds_istream_t * __restrict is, dds_ostreamBE_t * __restrict os, const struct dds_cdrstream_desc * __restrict type);
+DDS_EXPORT bool dds_stream_extract_keyBE_from_data (dds_istream_t * __restrict is, dds_ostreamBE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const struct dds_cdrstream_desc * __restrict type);
 
 /** @component cdr_serializer */
-DDS_EXPORT void dds_stream_extract_keyBE_from_key (dds_istream_t * __restrict is, dds_ostreamBE_t * __restrict os, const struct dds_cdrstream_desc * __restrict type);
+DDS_EXPORT void dds_stream_extract_keyBE_from_key (dds_istream_t * __restrict is, dds_ostreamBE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const struct dds_cdrstream_desc * __restrict type);
 
 /** @component cdr_serializer */
-DDS_EXPORT const uint32_t *dds_stream_read (dds_istream_t * __restrict is, char * __restrict data, const uint32_t * __restrict ops);
+DDS_EXPORT const uint32_t *dds_stream_read (dds_istream_t * __restrict is, char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops);
 
 /** @component cdr_serializer */
-DDS_EXPORT void dds_stream_read_key (dds_istream_t * __restrict is, char * __restrict sample, const struct dds_cdrstream_desc * __restrict type);
+DDS_EXPORT void dds_stream_read_key (dds_istream_t * __restrict is, char * __restrict sample, const struct dds_cdrstream_allocator * __restrict allocator, const struct dds_cdrstream_desc * __restrict type);
 
 /** @component cdr_serializer */
 DDS_EXPORT size_t dds_stream_print_key (dds_istream_t * __restrict is, const struct dds_cdrstream_desc * __restrict type, char * __restrict buf, size_t size);
@@ -228,7 +236,7 @@ bool dds_stream_extensibility (const uint32_t * __restrict ops, enum dds_cdr_typ
 DDS_EXPORT void dds_cdrstream_desc_from_topic_desc (struct dds_cdrstream_desc *desc, const dds_topic_descriptor_t *topic_desc);
 
 /** @component cdr_serializer */
-DDS_EXPORT void dds_cdrstream_desc_fini (struct dds_cdrstream_desc *desc);
+DDS_EXPORT void dds_cdrstream_desc_fini (struct dds_cdrstream_desc *desc, const struct dds_cdrstream_allocator * __restrict allocator);
 
 
 #if defined (__cplusplus)

--- a/src/core/cdr/src/dds_cdrstream.c
+++ b/src/core/cdr/src/dds_cdrstream.c
@@ -4428,26 +4428,6 @@ uint32_t dds_stream_type_nesting_depth (const uint32_t * __restrict ops)
   return nesting_depth;
 }
 
-void dds_cdrstream_desc_from_topic_desc (struct dds_cdrstream_desc *desc, const dds_topic_descriptor_t *topic_desc)
-{
-  memset (desc, 0, sizeof (*desc));
-  desc->size = topic_desc->m_size;
-  desc->align = topic_desc->m_align;
-  desc->flagset = topic_desc->m_flagset;
-  desc->ops.nops = dds_stream_countops (topic_desc->m_ops, topic_desc->m_nkeys, topic_desc->m_keys);
-  desc->ops.ops = ddsrt_memdup (topic_desc->m_ops, desc->ops.nops * sizeof (*desc->ops.ops));
-  desc->keys.nkeys = topic_desc->m_nkeys;
-  if (desc->keys.nkeys > 0)
-  {
-    desc->keys.keys = ddsrt_malloc (desc->keys.nkeys * sizeof (*desc->keys.keys));
-    for (uint32_t i = 0; i < desc->keys.nkeys; i++)
-    {
-      desc->keys.keys[i].ops_offs = topic_desc->m_keys[i].m_offset;
-      desc->keys.keys[i].idx = topic_desc->m_keys[i].m_idx;
-    }
-  }
-}
-
 void dds_cdrstream_desc_fini (struct dds_cdrstream_desc *desc, const struct dds_cdrstream_allocator * __restrict allocator)
 {
   if (desc->keys.nkeys > 0 && desc->keys.keys != NULL)

--- a/src/core/ddsc/include/dds/ddsc/dds_internal_api.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_internal_api.h
@@ -20,6 +20,7 @@
 #define DDS_INTERNAL_API_H
 
 #include "dds/export.h"
+#include "dds/cdr/dds_cdrstream.h"
 
 #if defined (__cplusplus)
 extern "C" {
@@ -53,6 +54,19 @@ extern "C" {
  */
 DDS_EXPORT uint32_t
 dds_reader_lock_samples (dds_entity_t reader);
+
+/**
+ * @ingroup internal
+ * @component topic
+ * @unstable
+ * @brief Gets a CDR stream serializer type descriptor from a topic descriptor
+ *
+ * @param[out] desc Pointer to the target struct that can be filled with the CDR stream topic descriptor
+ * @param[in] topic_desc The source topic descriptor
+ *
+*/
+DDS_EXPORT void
+dds_cdrstream_desc_from_topic_desc (struct dds_cdrstream_desc *desc, const dds_topic_descriptor_t *topic_desc);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsc/include/dds/ddsc/dds_public_alloc.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_public_alloc.h
@@ -32,6 +32,8 @@ extern "C" {
 struct dds_topic_descriptor;
 struct dds_sequence;
 
+DDS_EXPORT extern const struct dds_cdrstream_allocator dds_cdrstream_default_allocator;
+
 /**
  * @anchor DDS_FREE_KEY_BIT
  * @ingroup alloc

--- a/src/core/ddsc/src/dds_alloc.c
+++ b/src/core/ddsc/src/dds_alloc.c
@@ -17,6 +17,8 @@
 
 static dds_allocator_t dds_allocator_fns = { ddsrt_malloc, ddsrt_realloc, ddsrt_free };
 
+const struct dds_cdrstream_allocator dds_cdrstream_default_allocator = { ddsrt_malloc, ddsrt_realloc, ddsrt_free };
+
 void * dds_alloc (size_t size)
 {
   void * ret = (dds_allocator_fns.malloc) (size);
@@ -92,7 +94,7 @@ void dds_sample_free (void * sample, const struct dds_topic_descriptor * desc, d
   if (sample)
   {
     if (op & DDS_FREE_CONTENTS_BIT)
-      dds_stream_free_sample (sample, desc->m_ops);
+      dds_stream_free_sample (sample, &dds_cdrstream_default_allocator, desc->m_ops);
     else if (op & DDS_FREE_KEY_BIT)
       dds_sample_free_key (sample, desc);
 

--- a/src/core/ddsc/src/dds_sertype_default.c
+++ b/src/core/ddsc/src/dds_sertype_default.c
@@ -170,7 +170,7 @@ static void sertype_default_free_samples (const struct ddsi_sertype *sertype_com
       char *ptr = ptrs[0];
       for (size_t i = 0; i < count; i++)
       {
-        dds_stream_free_sample (ptr, type->ops.ops);
+        dds_stream_free_sample (ptr, &dds_cdrstream_default_allocator, type->ops.ops);
         ptr += size;
       }
     }
@@ -247,7 +247,7 @@ static bool sertype_default_serialize_into (const struct ddsi_sertype *type, con
 {
   const struct dds_sertype_default *type_default = (const struct dds_sertype_default *)type;
   dds_ostream_t os = ostream_from_buffer(dst_buffer, dst_size, type_default->write_encoding_version);
-  return dds_stream_write_sample(&os, sample, &type_default->type);
+  return dds_stream_write_sample(&os, &dds_cdrstream_default_allocator, sample, &type_default->type);
 }
 
 const struct ddsi_sertype_ops dds_sertype_ops_default = {

--- a/src/core/ddsc/src/dds_topic.c
+++ b/src/core/ddsc/src/dds_topic.c
@@ -36,6 +36,7 @@
 #include "dds/ddsi/ddsi_domaingv.h"
 #include "dds/ddsi/ddsi_security_omg.h"
 #include "dds/ddsi/ddsi_typebuilder.h"
+#include "dds/ddsc/dds_internal_api.h"
 #include "dds/cdr/dds_cdrstream.h"
 #include "dds__serdata_builtintopic.h"
 #include "dds__serdata_default.h"
@@ -1111,3 +1112,24 @@ dds_return_t dds_delete_topic_descriptor (dds_topic_descriptor_t *descriptor)
 }
 
 #endif /* DDS_HAS_TOPIC_DISCOVERY */
+
+void dds_cdrstream_desc_from_topic_desc (struct dds_cdrstream_desc *desc, const dds_topic_descriptor_t *topic_desc)
+{
+  memset (desc, 0, sizeof (*desc));
+  desc->size = topic_desc->m_size;
+  desc->align = topic_desc->m_align;
+  desc->flagset = topic_desc->m_flagset;
+  desc->ops.nops = dds_stream_countops (topic_desc->m_ops, topic_desc->m_nkeys, topic_desc->m_keys);
+  desc->ops.ops = dds_alloc (desc->ops.nops * sizeof (*desc->ops.ops));
+  memcpy (desc->ops.ops, topic_desc->m_ops, desc->ops.nops * sizeof (*desc->ops.ops));
+  desc->keys.nkeys = topic_desc->m_nkeys;
+  if (desc->keys.nkeys > 0)
+  {
+    desc->keys.keys = dds_alloc (desc->keys.nkeys * sizeof (*desc->keys.keys));
+    for (uint32_t i = 0; i < desc->keys.nkeys; i++)
+    {
+      desc->keys.keys[i].ops_offs = topic_desc->m_keys[i].m_offset;
+      desc->keys.keys[i].idx = topic_desc->m_keys[i].m_idx;
+    }
+  }
+}

--- a/src/core/ddsc/tests/cdrstream.c
+++ b/src/core/ddsc/tests/cdrstream.c
@@ -485,7 +485,7 @@ static bool sample_equal_ext (void *s1, void *s2)
 
 static void sample_free_ext (void *s)
 {
-  dds_stream_free_sample (s, TestIdl_MsgExt_desc.m_ops);
+  dds_stream_free_sample (s, &dds_cdrstream_default_allocator, TestIdl_MsgExt_desc.m_ops);
   ddsrt_free (s);
 }
 
@@ -621,7 +621,7 @@ static bool sample_equal_opt (void *s1, void *s2)
 
 static void sample_free_opt (void *s)
 {
-  dds_stream_free_sample (s, TestIdl_MsgOpt_desc.m_ops);
+  dds_stream_free_sample (s, &dds_cdrstream_default_allocator, TestIdl_MsgOpt_desc.m_ops);
   ddsrt_free (s);
 }
 
@@ -1779,7 +1779,7 @@ CU_Theory ((const char *descr, const dds_topic_descriptor_t *desc1, const dds_to
     };
 
     void * msg_wr = t ? sample_init_fn2 () : sample_init_fn1 ();
-    bool ret = dds_stream_write_sample (&os, msg_wr, &desc_wr);
+    bool ret = dds_stream_write_sample (&os, &dds_cdrstream_default_allocator, msg_wr, &desc_wr);
     CU_ASSERT_FATAL (ret);
 
     /* Read data */
@@ -1802,7 +1802,7 @@ CU_Theory ((const char *descr, const dds_topic_descriptor_t *desc1, const dds_to
     };
 
     void *msg_rd = ddsrt_calloc (1, desc_rd.size);
-    dds_stream_read_sample (&is, msg_rd, &desc_rd);
+    dds_stream_read_sample (&is, msg_rd, &dds_cdrstream_default_allocator, &desc_rd);
 
     /* Check for expected result */
     bool eq = t ? sample_equal_fn2 (msg_wr, msg_rd) : sample_equal_fn1 (msg_wr, msg_rd);
@@ -2031,24 +2031,24 @@ CU_Test (ddsc_cdrstream, skip_default)
     dds_ostreamLE_t os = { .x.m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2 };
     uint8_t *sample_pub = ddsrt_malloc (desc_pub.size);
     memset (sample_pub, 0xef, desc_pub.size); // assumes no pointers (strings, sequences, @external, @optional) in pub type
-    bool ret = dds_stream_write_sampleLE (&os, sample_pub, &desc_pub);
+    bool ret = dds_stream_write_sampleLE (&os, &dds_cdrstream_default_allocator, sample_pub, &desc_pub);
     CU_ASSERT_FATAL (ret);
 
     uint8_t *sample_sub = ddsrt_malloc (desc_sub.size);
     memset (sample_sub, 0xbe, desc_sub.size);
     tests[i].init_sub (sample_sub);
     dds_istream_t is = { .m_buffer = os.x.m_buffer, .m_index = 0, .m_size = os.x.m_size, .m_xcdr_version = os.x.m_xcdr_version };
-    dds_stream_read_sample (&is, sample_sub, &desc_sub);
+    dds_stream_read_sample (&is, sample_sub, &dds_cdrstream_default_allocator, &desc_sub);
     tests[i].check_sub (sample_sub);
 
     // clean-up
-    dds_ostream_fini (&os.x);
+    dds_ostream_fini (&os.x, &dds_cdrstream_default_allocator);
     ddsrt_free (sample_pub);
-    dds_stream_free_sample (sample_sub, desc_sub.ops.ops);
+    dds_stream_free_sample (sample_sub, &dds_cdrstream_default_allocator, desc_sub.ops.ops);
     ddsrt_free (sample_sub);
 
-    dds_cdrstream_desc_fini (&desc_pub);
-    dds_cdrstream_desc_fini (&desc_sub);
+    dds_cdrstream_desc_fini (&desc_pub, &dds_cdrstream_default_allocator);
+    dds_cdrstream_desc_fini (&desc_sub, &dds_cdrstream_default_allocator);
   }
 }
 #undef D

--- a/src/core/ddsc/tests/cdrstream.c
+++ b/src/core/ddsc/tests/cdrstream.c
@@ -19,6 +19,7 @@
 #include "dds/ddsrt/string.h"
 #include "dds/ddsi/ddsi_serdata.h"
 #include "dds/ddsc/dds_public_impl.h"
+#include "dds/ddsc/dds_internal_api.h"
 #include "dds/cdr/dds_cdrstream.h"
 #include "dds__topic.h"
 #include "test_util.h"

--- a/src/core/ddsc/tests/test_common.c
+++ b/src/core/ddsc/tests/test_common.c
@@ -89,8 +89,8 @@ void xcdr2_ser (const void *obj, const dds_topic_descriptor_t *topic_desc, dds_o
   os->m_index = 0;
   os->m_size = 0;
   os->m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2;
-  bool ret = dds_stream_write_sampleLE ((dds_ostreamLE_t *) os, obj, &desc);
-  dds_cdrstream_desc_fini (&desc);
+  bool ret = dds_stream_write_sampleLE ((dds_ostreamLE_t *) os, &dds_cdrstream_default_allocator, obj, &desc);
+  dds_cdrstream_desc_fini (&desc, &dds_cdrstream_default_allocator);
   CU_ASSERT_FATAL (ret);
 }
 
@@ -113,7 +113,7 @@ void xcdr2_deser (unsigned char *buf, uint32_t sz, void **obj, const dds_topic_d
 
   dds_istream_t is = { .m_buffer = data, .m_index = 0, .m_size = sz, .m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2 };
   *obj = ddsrt_calloc (1, desc->m_size);
-  dds_stream_read (&is, (void *) *obj, desc->m_ops);
+  dds_stream_read (&is, (void *) *obj, &dds_cdrstream_default_allocator, desc->m_ops);
   if (bswap)
     ddsrt_free (data);
 }

--- a/src/core/ddsc/tests/test_common.c
+++ b/src/core/ddsc/tests/test_common.c
@@ -13,6 +13,7 @@
 #include "dds/ddsrt/atomics.h"
 #include "dds/ddsrt/process.h"
 #include "dds/ddsrt/threads.h"
+#include "dds/ddsc/dds_internal_api.h"
 #include "test_common.h"
 
 static void sync_reader_writer_impl (dds_entity_t participant_rd, dds_entity_t reader, dds_entity_t participant_wr, dds_entity_t writer, bool expect_sync, dds_duration_t timeout)

--- a/src/core/ddsc/tests/typebuilder.c
+++ b/src/core/ddsc/tests/typebuilder.c
@@ -98,8 +98,8 @@ static bool ti_to_pairs_equal (dds_sequence_DDS_XTypes_TypeIdentifierTypeObjectP
     if (memcmp (to_a_ser.m_buffer, to_b_ser.m_buffer, to_a_ser.m_index))
       return false;
 
-    dds_ostream_fini (&to_a_ser);
-    dds_ostream_fini (&to_b_ser);
+    dds_ostream_fini (&to_a_ser, &dds_cdrstream_default_allocator);
+    dds_ostream_fini (&to_b_ser, &dds_cdrstream_default_allocator);
   }
   return true;
 }

--- a/src/core/ddsi/src/ddsi_plist.c
+++ b/src/core/ddsi/src/ddsi_plist.c
@@ -799,7 +799,7 @@ static dds_return_t deser_type_information (void * __restrict dst, struct flagse
   dds_istream_t is = { .m_buffer = buf, .m_index = 0, .m_size = (uint32_t) dd->bufsz, .m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2 };
   ddsi_typeinfo_t const ** x = deser_generic_dst (dst, &dstoff, dds_alignof (ddsi_typeinfo_t *));
   *x = ddsrt_calloc (1, DDS_XTypes_TypeInformation_desc.m_size);
-  dds_stream_read (&is, (void *) *x, DDS_XTypes_TypeInformation_desc.m_ops);
+  dds_stream_read (&is, (void *) *x, &dds_cdrstream_default_allocator, DDS_XTypes_TypeInformation_desc.m_ops);
   *flagset->present |= flag;
 err_normalize:
   if (dd->bswap)
@@ -813,10 +813,10 @@ static dds_return_t ser_type_information (struct ddsi_xmsg *xmsg, ddsi_parameter
   ddsi_typeinfo_t const * const * x = deser_generic_src (src, &srcoff, dds_alignof (ddsi_typeinfo_t *));
 
   dds_ostream_t os = { .m_buffer = NULL, .m_index = 0, .m_size = 0, .m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2 };
-  (void) dds_stream_write_with_byte_order (&os, (const void *) *x, DDS_XTypes_TypeInformation_desc.m_ops, bo);
+  (void) dds_stream_write_with_byte_order (&os, &dds_cdrstream_default_allocator, (const void *) *x, DDS_XTypes_TypeInformation_desc.m_ops, bo);
   char * const p = ddsi_xmsg_addpar_bo (xmsg, pid, os.m_index, bo);
   memcpy (p, os.m_buffer, os.m_index);
-  dds_ostream_fini (&os);
+  dds_ostream_fini (&os, &dds_cdrstream_default_allocator);
   return 0;
 }
 

--- a/src/core/ddsi/src/ddsi_serdata_cdr.c
+++ b/src/core/ddsi/src/ddsi_serdata_cdr.c
@@ -225,7 +225,7 @@ static void ostream_from_serdata_cdr (dds_ostream_t * __restrict s, const struct
 static void ostream_add_to_serdata_cdr (dds_ostream_t * __restrict s, struct ddsi_serdata_cdr ** __restrict d)
 {
   /* DDSI requires 4 byte alignment */
-  const uint32_t pad = dds_cdr_alignto4_clear_and_resize (s, s->m_xcdr_version);
+  const uint32_t pad = dds_cdr_alignto4_clear_and_resize (s, &dds_cdrstream_default_allocator, s->m_xcdr_version);
   assert (pad <= 3);
 
   /* Reset data pointer as stream may have reallocated */
@@ -254,7 +254,7 @@ static struct ddsi_serdata_cdr *serdata_cdr_from_sample_cdr_common (const struct
       abort ();
       break;
     case SDK_DATA:
-      if (!dds_stream_write_sample (&os, sample, &tp->type))
+      if (!dds_stream_write_sample (&os, &dds_cdrstream_default_allocator, sample, &tp->type))
         return NULL;
       ostream_add_to_serdata_cdr (&os, &d);
       break;
@@ -318,7 +318,7 @@ static bool serdata_cdr_to_sample_cdr (const struct ddsi_serdata *serdata_common
   if (bufptr) abort(); else { (void)buflim; } /* FIXME: haven't implemented that bit yet! */
   assert (DDSI_RTPS_CDR_ENC_IS_NATIVE (d->hdr.identifier));
   istream_from_serdata_cdr(&is, d);
-  dds_stream_read_sample (&is, sample, &tp->type);
+  dds_stream_read_sample (&is, sample, &dds_cdrstream_default_allocator, &tp->type);
   return true; /* FIXME: can't conversion to sample fail? */
 }
 

--- a/src/core/ddsi/src/ddsi_sertype_cdr.c
+++ b/src/core/ddsi/src/ddsi_sertype_cdr.c
@@ -119,7 +119,7 @@ static void sertype_cdr_free_samples (const struct ddsi_sertype *sertype_common,
       char *ptr = ptrs[0];
       for (size_t i = 0; i < count; i++)
       {
-        dds_stream_free_sample (ptr, type->ops.ops);
+        dds_stream_free_sample (ptr, &dds_cdrstream_default_allocator, type->ops.ops);
         ptr += size;
       }
     }

--- a/src/core/ddsi/src/ddsi_typelib.c
+++ b/src/core/ddsi/src/ddsi_typelib.c
@@ -113,7 +113,7 @@ ddsi_typeinfo_t *ddsi_typeinfo_deser (const unsigned char *data, uint32_t sz)
 
   dds_istream_t is = { .m_buffer = data_ne, .m_index = 0, .m_size = sz, .m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2 };
   ddsi_typeinfo_t *typeinfo = ddsrt_calloc (1, sizeof (*typeinfo));
-  dds_stream_read (&is, (void *) typeinfo, DDS_XTypes_TypeInformation_desc.m_ops);
+  dds_stream_read (&is, (void *) typeinfo, &dds_cdrstream_default_allocator, DDS_XTypes_TypeInformation_desc.m_ops);
   if (bswap)
     ddsrt_free (data_ne);
   return typeinfo;
@@ -131,7 +131,7 @@ ddsi_typeid_t *ddsi_typeinfo_typeid (const ddsi_typeinfo_t *type_info, ddsi_type
 
 void ddsi_typeinfo_fini (ddsi_typeinfo_t *typeinfo)
 {
-  dds_stream_free_sample (typeinfo, DDS_XTypes_TypeInformation_desc.m_ops);
+  dds_stream_free_sample (typeinfo, &dds_cdrstream_default_allocator, DDS_XTypes_TypeInformation_desc.m_ops);
 }
 
 const ddsi_typeid_t *ddsi_typeinfo_minimal_typeid (const ddsi_typeinfo_t *typeinfo)
@@ -228,7 +228,7 @@ ddsi_typemap_t *ddsi_typemap_deser (const unsigned char *data, uint32_t sz)
 
   dds_istream_t is = { .m_buffer = data_ne, .m_index = 0, .m_size = sz, .m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2 };
   ddsi_typemap_t *typemap = ddsrt_calloc (1, sizeof (*typemap));
-  dds_stream_read (&is, (void *) typemap, DDS_XTypes_TypeMapping_desc.m_ops);
+  dds_stream_read (&is, (void *) typemap, &dds_cdrstream_default_allocator, DDS_XTypes_TypeMapping_desc.m_ops);
   if (bswap)
     ddsrt_free (data_ne);
   return typemap;
@@ -236,7 +236,7 @@ ddsi_typemap_t *ddsi_typemap_deser (const unsigned char *data, uint32_t sz)
 
 void ddsi_typemap_fini (ddsi_typemap_t *typemap)
 {
-  dds_stream_free_sample (typemap, DDS_XTypes_TypeMapping_desc.m_ops);
+  dds_stream_free_sample (typemap, &dds_cdrstream_default_allocator, DDS_XTypes_TypeMapping_desc.m_ops);
 }
 
 static bool ti_to_pairs_equal (const dds_sequence_DDS_XTypes_TypeIdentifierTypeObjectPair *a, const dds_sequence_DDS_XTypes_TypeIdentifierTypeObjectPair *b)
@@ -259,11 +259,11 @@ static bool ti_to_pairs_equal (const dds_sequence_DDS_XTypes_TypeIdentifierTypeO
     {
       dds_ostream_t to_a_ser = { NULL, 0, 0, DDSI_RTPS_CDR_ENC_VERSION_2 };
       dds_ostream_t to_b_ser = { NULL, 0, 0, DDSI_RTPS_CDR_ENC_VERSION_2 };
-      dds_stream_write_sample (&to_a_ser, &a->_buffer[n].type_object, &DDS_XTypes_TypeObject_cdrstream_desc);
-      dds_stream_write_sample (&to_b_ser, to_b, &DDS_XTypes_TypeObject_cdrstream_desc);
+      dds_stream_write_sample (&to_a_ser, &dds_cdrstream_default_allocator, &a->_buffer[n].type_object, &DDS_XTypes_TypeObject_cdrstream_desc);
+      dds_stream_write_sample (&to_b_ser, &dds_cdrstream_default_allocator, to_b, &DDS_XTypes_TypeObject_cdrstream_desc);
       equal = (to_a_ser.m_index == to_b_ser.m_index) && memcmp (to_a_ser.m_buffer, to_b_ser.m_buffer, to_a_ser.m_index) == 0;
-      dds_ostream_fini (&to_a_ser);
-      dds_ostream_fini (&to_b_ser);
+      dds_ostream_fini (&to_a_ser, &dds_cdrstream_default_allocator);
+      dds_ostream_fini (&to_b_ser, &dds_cdrstream_default_allocator);
     }
   }
   return equal;
@@ -747,7 +747,7 @@ static dds_return_t xcdr2_ser (const void *obj, const struct dds_cdrstream_desc 
   os->m_index = 0;
   os->m_size = 0;
   os->m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2;
-  dds_return_t ret = dds_stream_write_sampleLE ((dds_ostreamLE_t *) os, obj, desc) ? DDS_RETCODE_OK : DDS_RETCODE_BAD_PARAMETER;
+  dds_return_t ret = dds_stream_write_sampleLE ((dds_ostreamLE_t *) os, &dds_cdrstream_default_allocator, obj, desc) ? DDS_RETCODE_OK : DDS_RETCODE_BAD_PARAMETER;
   return ret;
 }
 
@@ -759,7 +759,7 @@ static dds_return_t get_typeid_with_size (DDS_XTypes_TypeIdentifierWithSize *typ
   if ((ret = xcdr2_ser (to, &DDS_XTypes_TypeObject_cdrstream_desc, &os)) < 0)
     return ret;
   typeid_with_size->typeobject_serialized_size = os.m_index;
-  dds_ostream_fini (&os);
+  dds_ostream_fini (&os, &dds_cdrstream_default_allocator);
   return DDS_RETCODE_OK;
 }
 

--- a/src/core/ddsi/src/ddsi_typewrap.c
+++ b/src/core/ddsi/src/ddsi_typewrap.c
@@ -354,14 +354,14 @@ int ddsi_typeid_compare (const ddsi_typeid_t *a, const ddsi_typeid_t *b)
 void ddsi_typeid_ser (const ddsi_typeid_t *type_id, unsigned char **buf, uint32_t *sz)
 {
   dds_ostream_t os = { .m_buffer = NULL, .m_index = 0, .m_size = 0, .m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2 };
-  dds_stream_writeLE ((dds_ostreamLE_t *) &os, (const void *) type_id, DDS_XTypes_TypeIdentifier_desc.m_ops);
+  dds_stream_writeLE ((dds_ostreamLE_t *) &os, &dds_cdrstream_default_allocator, (const void *) type_id, DDS_XTypes_TypeIdentifier_desc.m_ops);
   *buf = os.m_buffer;
   *sz = os.m_index;
 }
 
 void ddsi_typeid_fini_impl (struct DDS_XTypes_TypeIdentifier *type_id)
 {
-  dds_stream_free_sample (type_id, DDS_XTypes_TypeIdentifier_desc.m_ops);
+  dds_stream_free_sample (type_id, &dds_cdrstream_default_allocator, DDS_XTypes_TypeIdentifier_desc.m_ops);
 }
 
 void ddsi_typeid_fini (ddsi_typeid_t *type_id)
@@ -426,7 +426,7 @@ void ddsi_typeobj_get_hash_id_impl (const struct DDS_XTypes_TypeObject *type_obj
   assert (type_id);
   assert (type_obj->_d == DDS_XTypes_EK_MINIMAL || type_obj->_d == DDS_XTypes_EK_COMPLETE);
   dds_ostream_t os = { .m_buffer = NULL, .m_index = 0, .m_size = 0, .m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2 };
-  dds_stream_writeLE ((dds_ostreamLE_t *) &os, (const void *) type_obj, DDS_XTypes_TypeObject_desc.m_ops);
+  dds_stream_writeLE ((dds_ostreamLE_t *) &os, &dds_cdrstream_default_allocator, (const void *) type_obj, DDS_XTypes_TypeObject_desc.m_ops);
 
   char buf[16];
   ddsrt_md5_state_t md5st;
@@ -435,7 +435,7 @@ void ddsi_typeobj_get_hash_id_impl (const struct DDS_XTypes_TypeObject *type_obj
   ddsrt_md5_finish (&md5st, (ddsrt_md5_byte_t *) buf);
   type_id->_d = type_obj->_d;
   memcpy (type_id->_u.equivalence_hash, buf, sizeof(DDS_XTypes_EquivalenceHash));
-  dds_ostream_fini (&os);
+  dds_ostream_fini (&os, &dds_cdrstream_default_allocator);
 }
 
 dds_return_t ddsi_typeobj_get_hash_id (const struct DDS_XTypes_TypeObject *type_obj, ddsi_typeid_t *type_id)
@@ -448,7 +448,7 @@ dds_return_t ddsi_typeobj_get_hash_id (const struct DDS_XTypes_TypeObject *type_
 
 void ddsi_typeobj_fini_impl (struct DDS_XTypes_TypeObject *typeobj)
 {
-  dds_stream_free_sample (typeobj, DDS_XTypes_TypeObject_desc.m_ops);
+  dds_stream_free_sample (typeobj, &dds_cdrstream_default_allocator, DDS_XTypes_TypeObject_desc.m_ops);
 }
 
 void ddsi_typeobj_fini (ddsi_typeobj_t *typeobj)

--- a/src/core/xtests/cdrtest/cdrtest.pl
+++ b/src/core/xtests/cdrtest/cdrtest.pl
@@ -158,7 +158,7 @@ EOF
         is.m_buffer = garbage;
         is.m_size = 1000;
         is.m_index = 0;
-        dds_stream_read_sample (&is, msg, &ddd.type);
+        dds_stream_read_sample (&is, msg, &dds_cdrstream_default_allocator, &ddd.type);
         deser_garbage++;
       }
     }
@@ -186,7 +186,7 @@ EOF
     is.m_buffer = blob;
     is.m_size = blobsz;
     is.m_index = 0;
-    dds_stream_read_sample (&is, msg, &ddd.type);
+    dds_stream_read_sample (&is, msg, &dds_cdrstream_default_allocator, &ddd.type);
     sd_cdrSerdataFree (sd);
     sd = sd_cdrSerialize (ci, samplecopy);
     blobsz = sd_cdrSerdataBlob (&blob, sd);

--- a/src/core/xtests/symbol_export/symbol_export.c
+++ b/src/core/xtests/symbol_export/symbol_export.c
@@ -100,7 +100,7 @@ int main (int argc, char **argv)
 {
   (void) argc;
   (void) argv;
-  void *ptr = &ptr, *ptr2 = &ptr2, *ptr3 = &ptr3;
+  void *ptr = &ptr, *ptr2 = &ptr2, *ptr3 = &ptr3, *ptr4 = &ptr4;
 
   /* The functions shouldn't actually be called, just included here so that
      the linker resolves the symbols. An early return (with unreachable code
@@ -428,41 +428,41 @@ int main (int argc, char **argv)
   bool ret_cdrs;
   dds_istream_init (ptr, 0, ptr2, 0);
   dds_istream_fini (ptr);
-  dds_ostream_init (ptr, 0, 0);
-  dds_ostream_fini (ptr);
-  dds_ostreamLE_init (ptr, 0, 0);
-  dds_ostreamLE_fini (ptr);
-  dds_ostreamBE_init (ptr, 0, 0);
-  dds_ostreamBE_fini (ptr);
+  dds_ostream_init (ptr, ptr2, 0, 0);
+  dds_ostream_fini (ptr, ptr2);
+  dds_ostreamLE_init (ptr, ptr2, 0, 0);
+  dds_ostreamLE_fini (ptr, ptr2);
+  dds_ostreamBE_init (ptr, ptr2, 0, 0);
+  dds_ostreamBE_fini (ptr, ptr2);
 
   ret_cdrs = dds_stream_normalize (ptr, 0, 0, 0, ptr2, 0, ptr3);
   (void) ret_cdrs;
   ret_cdrs = dds_stream_normalize_data (ptr, ptr2, 0, 0, 0, ptr3);
   (void) ret_cdrs;
 
-  dds_stream_write (ptr, ptr2, ptr3);
-  dds_stream_writeLE (ptr, ptr2, ptr3);
-  dds_stream_writeBE (ptr, ptr2, ptr3);
-  dds_stream_write_with_byte_order (ptr, ptr2, ptr3, 0);
-  dds_stream_write_sample (ptr, ptr2, ptr3);
-  dds_stream_write_sampleLE (ptr, ptr2, ptr3);
-  dds_stream_write_sampleBE (ptr, ptr2, ptr3);
+  dds_stream_write (ptr, ptr2, ptr3, ptr4);
+  dds_stream_writeLE (ptr, ptr2, ptr3, ptr4);
+  dds_stream_writeBE (ptr, ptr2, ptr3, ptr4);
+  dds_stream_write_with_byte_order (ptr, ptr2, ptr3, ptr4, 0);
+  dds_stream_write_sample (ptr, ptr2, ptr3, ptr4);
+  dds_stream_write_sampleLE (ptr, ptr2, ptr3, ptr4);
+  dds_stream_write_sampleBE (ptr, ptr2, ptr3, ptr4);
 
-  dds_stream_read (ptr, ptr2, ptr3);
-  dds_stream_read_key (ptr, ptr2, ptr3);
+  dds_stream_read (ptr, ptr2, ptr3, ptr4);
+  dds_stream_read_key (ptr, ptr2, ptr3, ptr4);
 
-  dds_stream_read_sample (ptr, ptr2, ptr3);
-  dds_stream_free_sample (ptr, ptr2);
+  dds_stream_read_sample (ptr, ptr2, ptr3, ptr4);
+  dds_stream_free_sample (ptr, ptr2, ptr3);
   dds_stream_countops (ptr, 0, ptr2);
   dds_stream_print_key (ptr, ptr2, ptr3, 0);
   dds_stream_print_sample (ptr, ptr2, ptr3, 0);
 
-  dds_stream_extract_key_from_data (ptr, ptr2, ptr3);
-  dds_stream_extract_key_from_key (ptr, ptr2, ptr3);
-  dds_stream_extract_keyBE_from_data (ptr, ptr2, ptr3);
-  dds_stream_extract_keyBE_from_key (ptr, ptr2, ptr3);
+  dds_stream_extract_key_from_data (ptr, ptr2, ptr3, ptr4);
+  dds_stream_extract_key_from_key (ptr, ptr2, ptr3, ptr4);
+  dds_stream_extract_keyBE_from_data (ptr, ptr2, ptr3, ptr4);
+  dds_stream_extract_keyBE_from_key (ptr, ptr2, ptr3, ptr4);
   dds_cdrstream_desc_from_topic_desc (ptr, ptr2);
-  dds_cdrstream_desc_fini (ptr);
+  dds_cdrstream_desc_fini (ptr, ptr2);
 
 #ifdef DDS_HAS_SECURITY
   // dds_security_timed_cb.h

--- a/src/tools/idlc/src/idlc.c
+++ b/src/tools/idlc/src/idlc.c
@@ -21,6 +21,7 @@
 #include <string.h>
 
 #include "dds/features.h"
+#include "dds/cdr/dds_cdrstream.h"
 #include "idl/heap.h"
 #include "idl/misc.h"
 #include "idl/tree.h"

--- a/src/tools/idlc/tests/type_meta.c
+++ b/src/tools/idlc/tests/type_meta.c
@@ -29,7 +29,6 @@
 
 #include "CUnit/Theory.h"
 
-
 #ifdef DDS_HAS_TYPE_DISCOVERY
 
 static void *calloc_no_fail (size_t count, size_t size)
@@ -108,7 +107,7 @@ static void xcdr2_ser (const void *obj, const struct dds_cdrstream_desc *desc, d
   os->m_index = 0;
   os->m_size = 0;
   os->m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2;
-  bool ret = dds_stream_write_sampleLE ((dds_ostreamLE_t *) os, obj, desc);
+  bool ret = dds_stream_write_sampleLE ((dds_ostreamLE_t *) os, &dds_cdrstream_default_allocator, obj, desc);
   CU_ASSERT_FATAL (ret);
 }
 
@@ -131,7 +130,7 @@ static void xcdr2_deser (unsigned char *buf, uint32_t sz, void **obj, const stru
 
   dds_istream_t is = { .m_buffer = data, .m_index = 0, .m_size = sz, .m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2 };
   *obj = calloc_no_fail (1, desc->size);
-  dds_stream_read (&is, (void *) *obj, desc->ops.ops);
+  dds_stream_read (&is, (void *) *obj, &dds_cdrstream_default_allocator, desc->ops.ops);
   if (bswap)
     free (data);
 }
@@ -263,7 +262,7 @@ static void get_typeid (DDS_XTypes_TypeIdentifier *ti, DDS_XTypes_TypeObject *to
   ti->_d = DDS_XTypes_EK_COMPLETE;
   idl_retcode_t ret = get_type_hash (ti->_u.equivalence_hash, to);
   CU_ASSERT_EQUAL_FATAL (ret, IDL_RETCODE_OK);
-  dds_stream_free_sample (to, DDS_XTypes_TypeObject_desc.m_ops);
+  dds_stream_free_sample (to, &dds_cdrstream_default_allocator, DDS_XTypes_TypeObject_desc.m_ops);
   free (to);
 }
 
@@ -862,9 +861,9 @@ CU_Test(idlc_type_meta, type_obj_serdes)
         int cmp = memcmp (os.m_buffer, os_test.m_buffer, os.m_index);
         CU_ASSERT_EQUAL_FATAL (cmp, 0);
 
-        dds_stream_free_sample (to_test, DDS_XTypes_TypeObject_desc.m_ops);
+        dds_stream_free_sample (to_test, &dds_cdrstream_default_allocator, DDS_XTypes_TypeObject_desc.m_ops);
         free (to_test);
-        dds_ostream_fini (&os_test);
+        dds_ostream_fini (&os_test, &dds_cdrstream_default_allocator);
       }
 
       // test that generated type object can be serialized
@@ -872,9 +871,9 @@ CU_Test(idlc_type_meta, type_obj_serdes)
       xcdr2_deser (os.m_buffer, os.m_index, (void **)&to, &DDS_XTypes_TypeObject_cdrstream_desc);
 
       // cleanup
-      dds_stream_free_sample (to, DDS_XTypes_TypeObject_desc.m_ops);
+      dds_stream_free_sample (to, &dds_cdrstream_default_allocator, DDS_XTypes_TypeObject_desc.m_ops);
       free (to);
-      dds_ostream_fini (&os);
+      dds_ostream_fini (&os, &dds_cdrstream_default_allocator);
     }
 
     descriptor_type_meta_fini (&dtm);

--- a/src/tools/idlc/xtests/main.c
+++ b/src/tools/idlc/xtests/main.c
@@ -26,7 +26,7 @@ extern int cmp_key (const void *sa, const void *sb);
 
 static void free_sample (void *s)
 {
-  dds_stream_free_sample (s, desc->m_ops);
+  dds_stream_free_sample (s, &dds_cdrstream_default_allocator, desc->m_ops);
   dds_free (s);
 }
 
@@ -72,7 +72,7 @@ int rd_cmp_print_key (dds_ostream_t *os, const void *msg_wr, struct dds_cdrstrea
 
   // read
   void *msg_rd = ddsrt_calloc (1, desc->m_size);
-  dds_stream_read_key (&is, msg_rd, cdrstream_desc);
+  dds_stream_read_key (&is, msg_rd, &dds_cdrstream_default_allocator, cdrstream_desc);
 
   // compare
   res = cmp_key(msg_wr, msg_rd);
@@ -114,9 +114,9 @@ int main(int argc, char **argv)
     dds_ostream_t os = { NULL, 0, 0, DDSI_RTPS_CDR_ENC_VERSION_2 };
     bool ret;
     if (tests[i] == BE)
-      ret = dds_stream_write_sampleBE ((dds_ostreamBE_t *)(&os), msg_wr, &cdrstream_desc);
+      ret = dds_stream_write_sampleBE ((dds_ostreamBE_t *)(&os), &dds_cdrstream_default_allocator, msg_wr, &cdrstream_desc);
     else
-      ret = dds_stream_write_sampleLE ((dds_ostreamLE_t *)(&os), msg_wr, &cdrstream_desc);
+      ret = dds_stream_write_sampleLE ((dds_ostreamLE_t *)(&os), &dds_cdrstream_default_allocator, msg_wr, &cdrstream_desc);
     if (!ret)
     {
       printf("cdr write failed\n");
@@ -145,7 +145,7 @@ int main(int argc, char **argv)
     // read data and check for expected result
     printf("cdr read data\n");
     void *msg_rd = ddsrt_calloc (1, desc->m_size);
-    dds_stream_read_sample (&is, msg_rd, &cdrstream_desc);
+    dds_stream_read_sample (&is, msg_rd, &dds_cdrstream_default_allocator, &cdrstream_desc);
     res = cmp_sample(msg_wr, msg_rd);
     printf("data compare result: %d\n", res);
 
@@ -159,7 +159,7 @@ int main(int argc, char **argv)
       // extract key from data
       is.m_index = 0;
       dds_ostream_t os_key_from_data = { NULL, 0, 0, DDSI_RTPS_CDR_ENC_VERSION_2 };
-      if (!dds_stream_extract_key_from_data (&is, &os_key_from_data, &cdrstream_desc))
+      if (!dds_stream_extract_key_from_data (&is, &os_key_from_data, &dds_cdrstream_default_allocator, &cdrstream_desc))
       {
         printf("extract key from data failed\n");
         return 1;
@@ -173,20 +173,20 @@ int main(int argc, char **argv)
 
       // write key
       dds_ostream_t os_wr_key = { NULL, 0, 0, DDSI_RTPS_CDR_ENC_VERSION_2 };
-      dds_stream_write_key (&os_wr_key, msg_wr, &cdrstream_desc);
+      dds_stream_write_key (&os_wr_key, &dds_cdrstream_default_allocator, msg_wr, &cdrstream_desc);
 
       // extract key from key
       dds_istream_t is_key_from_key = { os_wr_key.m_buffer, os_wr_key.m_size, 0, DDSI_RTPS_CDR_ENC_VERSION_2 };
       dds_ostream_t os_key_from_key = { NULL, 0, 0, DDSI_RTPS_CDR_ENC_VERSION_2 };
-      dds_stream_extract_key_from_key (&is_key_from_key, &os_key_from_key, &cdrstream_desc);
+      dds_stream_extract_key_from_key (&is_key_from_key, &os_key_from_key, &dds_cdrstream_default_allocator, &cdrstream_desc);
       res = rd_cmp_print_key (&os_key_from_key, msg_wr, &cdrstream_desc);
 
-      dds_ostream_fini (&os_key_from_data);
-      dds_ostream_fini (&os_key_from_key);
-      dds_ostream_fini (&os_wr_key);
+      dds_ostream_fini (&os_key_from_data, &dds_cdrstream_default_allocator);
+      dds_ostream_fini (&os_key_from_key, &dds_cdrstream_default_allocator);
+      dds_ostream_fini (&os_wr_key, &dds_cdrstream_default_allocator);
     }
 
-    dds_ostream_fini (&os);
+    dds_ostream_fini (&os, &dds_cdrstream_default_allocator);
     free_sample(msg_wr);
     free_sample(msg_rd);
     if (res != 0)


### PR DESCRIPTION
This parameterizes the memory allocator functions in the CDR stream serializer, so that an alloc/free is not crossing the library boundary (when used from IDLC). 

Fixes #1586 