### PR TITLE
Allow CDR to be compiled as standalone project/library

### DIFF
--- a/src/core/cdr/CMakeLists.txt
+++ b/src/core/cdr/CMakeLists.txt
@@ -10,19 +10,64 @@
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
 
+if(NOT ${CMAKE_PROJECT_NAME} STREQUAL "CycloneDDS")
+  cmake_minimum_required(VERSION 3.16)
+  project(cdr VERSION 0.11.0 LANGUAGES C)
+endif()
+
 set(srcs_cdr
-  dds_cdrstream.c)
+  "${CMAKE_CURRENT_LIST_DIR}/src/dds_cdrstream.c")
 
 set(hdrs_private_cdr
-  dds_cdrstream.h)
+  "${CMAKE_CURRENT_LIST_DIR}/include/dds/cdr/dds_cdrstream.h")
 
-prepend(hdrs_private_cdr "${CMAKE_CURRENT_LIST_DIR}/include/dds/cdr/" ${hdrs_private_cdr})
-prepend(srcs_cdr "${CMAKE_CURRENT_LIST_DIR}/src/" ${srcs_cdr})
+if(${CMAKE_PROJECT_NAME} STREQUAL "CycloneDDS")
+  target_sources(ddsc PRIVATE ${srcs_cdr} ${hdrs_private_cdr})
+  target_include_directories(ddsc PRIVATE "${CMAKE_CURRENT_LIST_DIR}/include")
 
-target_sources(ddsc PRIVATE ${srcs_cdr} ${hdrs_private_cdr})
-target_include_directories(ddsc PRIVATE "${CMAKE_CURRENT_LIST_DIR}/include")
+  install(
+    DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/include/"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+    COMPONENT dev)
+else()
+  set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Modules")
+  include(Generate)
+  include(GenerateExportHeader)
 
-install(
-  DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/include/"
-  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
-  COMPONENT dev)
+  if (BUILD_SHARED_LIBS OR NOT DEFINED BUILD_SHARED_LIBS)
+    add_library(cdr SHARED "")
+  else()
+    add_library(cdr)
+  endif()
+
+  add_library(${PROJECT_NAME}::cdr ALIAS cdr)
+
+  target_sources(cdr PRIVATE ${srcs_cdr} ${hdrs_private_cdr})
+  target_include_directories(cdr PUBLIC "${CMAKE_CURRENT_LIST_DIR}/include"
+                                         "${PROJECT_BINARY_DIR}/include"
+                                         "${CMAKE_CURRENT_LIST_DIR}/../../ddsrt/include"
+                                         "${CMAKE_CURRENT_LIST_DIR}/../ddsc/include")
+
+  configure_file(${CMAKE_CURRENT_LIST_DIR}/../../ddsrt/include/dds/config.h.in include/dds/config.h)
+  configure_file(${CMAKE_CURRENT_LIST_DIR}/../../ddsrt/include/dds/features.h.in include/dds/features.h)
+  configure_file(${CMAKE_CURRENT_LIST_DIR}/../../ddsrt/include/dds/version.h.in include/dds/version.h)
+
+  generate_export_header(
+  cdr BASE_NAME DDS EXPORT_FILE_NAME include/dds/export.h)
+
+  install(
+    TARGETS cdr
+    EXPORT "${PROJECT_NAME}"
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT lib
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT lib
+    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT lib
+  )
+
+  install(
+    DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/include/"
+              "${PROJECT_BINARY_DIR}/include/"
+              "${CMAKE_CURRENT_LIST_DIR}/../../ddsrt/include/"
+              "${CMAKE_CURRENT_LIST_DIR}/../ddsc/include/"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+    COMPONENT dev)
+endif()


### PR DESCRIPTION
Allows CDR to compiled as its own project.
Which creates libcdr.so library target so that external applications can utilize the cdr serializer/deserializer.

