### PR TITLE
Gracefully handle insane DEADLINE QoS values

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/ddsi_deadline.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_deadline.h
@@ -52,10 +52,16 @@ void ddsi_deadline_clear (struct ddsi_deadline_adm *deadline_adm);
 void ddsi_deadline_fini (const struct ddsi_deadline_adm *deadline_adm);
 
 /** @component deadline_qos */
+uint32_t ddsi_deadline_compute_deadlines_missed (ddsrt_mtime_t tnow, const struct deadline_elem *deadline_elem, dds_duration_t deadline_dur);
+
+/** @component deadline_qos */
 ddsrt_mtime_t ddsi_deadline_next_missed_locked (struct ddsi_deadline_adm *deadline_adm, ddsrt_mtime_t tnow, void **instance);
 
 /** @component deadline_qos */
-void ddsi_deadline_register_instance_real (struct ddsi_deadline_adm *deadline_adm, struct deadline_elem *elem, ddsrt_mtime_t tprev, ddsrt_mtime_t tnow);
+void ddsi_deadline_register_instance_real (struct ddsi_deadline_adm *deadline_adm, struct deadline_elem *elem, ddsrt_mtime_t tnow);
+
+/** @component deadline_qos */
+void ddsi_deadline_reregister_instance_real (struct ddsi_deadline_adm *deadline_adm, struct deadline_elem *elem, ddsrt_mtime_t tprev, ddsrt_mtime_t tnow);
 
 /** @component deadline_qos */
 void ddsi_deadline_unregister_instance_real (struct ddsi_deadline_adm *deadline_adm, struct deadline_elem *elem);
@@ -67,14 +73,14 @@ void ddsi_deadline_renew_instance_real (struct ddsi_deadline_adm *deadline_adm, 
 inline void ddsi_deadline_register_instance_locked (struct ddsi_deadline_adm *deadline_adm, struct deadline_elem *elem, ddsrt_mtime_t tnow)
 {
   if (deadline_adm->dur != DDS_INFINITY)
-    ddsi_deadline_register_instance_real (deadline_adm, elem, tnow, tnow);
+    ddsi_deadline_register_instance_real (deadline_adm, elem, tnow);
 }
 
 /** @component deadline_qos */
 inline void ddsi_deadline_reregister_instance_locked (struct ddsi_deadline_adm *deadline_adm, struct deadline_elem *elem, ddsrt_mtime_t tnow)
 {
   if (deadline_adm->dur != DDS_INFINITY)
-    ddsi_deadline_register_instance_real (deadline_adm, elem, elem->t_last_update, tnow);
+    ddsi_deadline_reregister_instance_real (deadline_adm, elem, elem->t_last_update, tnow);
 }
 
 /** @component deadline_qos */


### PR DESCRIPTION
This fixes a number of issues in handling extremely short and extremely long deadline durations:
* a divide-by-zero issue in the deadline handling when the deadline duration is set to zero
* spinning inside the loops processing all expired deadlines when the deadline is so short that it expires earlier than the processing completes
* a potential overflow in case of extremely short or extremely long deadlines
* rate-limits the deadline notification callbacks for periodic deadlines

Fixes #1609 