### PR TITLE
Enable idlc_generate() to support "dot-separated" idl files	(#1612)

### DIFF
--- a/cmake/Modules/Generate.cmake
+++ b/cmake/Modules/Generate.cmake
@@ -156,7 +156,7 @@ function(IDLC_GENERATE_GENERIC)
   endif()
   set(_outputs "")
   foreach(_file ${_files})
-    get_filename_component(_name ${_file} NAME_WE)
+    get_filename_component(_name ${_file} NAME_WLE)
     get_filename_component(_name_ext ${_file} NAME)
 
     # Determine middle path for directory reconstruction


### PR DESCRIPTION
Fix #1612