### PR TITLE
Add Zephyr support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,8 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/Modules")
 option(BUILD_IDLC "Build IDL preprocessor" ${not_crosscompiling})
 option(BUILD_DDSPERF "Build ddsperf tool" ${not_crosscompiling})
 
+option(WITH_ZEPHYR "Build for Zephyr RTOS" OFF)
+
 set(CMAKE_C_STANDARD 99)
 if(CMAKE_SYSTEM_NAME STREQUAL "VxWorks")
   add_definitions(-std=c99)
@@ -127,7 +129,12 @@ if("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang" OR
   endif()
 elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
   #message(STATUS gcc)
-  add_compile_options(-Wall -Wextra -Wconversion -Wmissing-prototypes)
+  if(WITH_ZEPHYR)
+    # Suppress false warnings from system includes
+    add_compile_options(-Wall -Wextra -Wno-unused-parameter -Wmissing-prototypes)
+  else()
+    add_compile_options(-Wall -Wextra -Wconversion -Wmissing-prototypes)
+  endif()
   if(${WERROR})
     add_compile_options(-Werror)
   endif()

--- a/examples/roundtrip/ping.c
+++ b/examples/roundtrip/ping.c
@@ -118,7 +118,7 @@ static bool CtrlHandler (DWORD fdwCtrlType)
   dds_waitset_set_trigger (waitSet, true);
   return true; //Don't let other handlers handle this key
 }
-#elif !DDSRT_WITH_FREERTOS
+#elif !DDSRT_WITH_FREERTOS && !__ZEPHYR__
 static void CtrlHandler (int sig)
 {
   (void)sig;
@@ -253,7 +253,7 @@ int main (int argc, char *argv[])
   DDSRT_WARNING_GNUC_OFF(cast-function-type)
   SetConsoleCtrlHandler ((PHANDLER_ROUTINE)CtrlHandler, TRUE);
   DDSRT_WARNING_GNUC_ON(cast-function-type)
-#elif !DDSRT_WITH_FREERTOS
+#elif !DDSRT_WITH_FREERTOS && !__ZEPHYR__
   struct sigaction sat, oldAction;
   sat.sa_handler = CtrlHandler;
   sigemptyset (&sat.sa_mask);
@@ -415,7 +415,7 @@ done:
 
 #ifdef _WIN32
   SetConsoleCtrlHandler (0, FALSE);
-#elif !DDSRT_WITH_FREERTOS
+#elif !DDSRT_WITH_FREERTOS && !__ZEPHYR__
   sigaction (SIGINT, &oldAction, 0);
 #endif
 

--- a/examples/roundtrip/pong.c
+++ b/examples/roundtrip/pong.c
@@ -22,7 +22,7 @@ static bool CtrlHandler (DWORD fdwCtrlType)
   dds_waitset_set_trigger (waitSet, true);
   return true; //Don't let other handlers handle this key
 }
-#elif !DDSRT_WITH_FREERTOS
+#elif !DDSRT_WITH_FREERTOS && !__ZEPHYR__
 static void CtrlHandler (int sig)
 {
   (void)sig;
@@ -91,7 +91,7 @@ int main (int argc, char *argv[])
   DDSRT_WARNING_GNUC_OFF(cast-function-type)
   SetConsoleCtrlHandler ((PHANDLER_ROUTINE)CtrlHandler, TRUE);
   DDSRT_WARNING_GNUC_ON(cast-function-type)
-#elif !DDSRT_WITH_FREERTOS
+#elif !DDSRT_WITH_FREERTOS && !__ZEPHYR__
   struct sigaction sat, oldAction;
   sat.sa_handler = CtrlHandler;
   sigemptyset (&sat.sa_mask);
@@ -134,7 +134,7 @@ int main (int argc, char *argv[])
 
 #ifdef _WIN32
   SetConsoleCtrlHandler (0, FALSE);
-#elif !DDSRT_WITH_FREERTOS
+#elif !DDSRT_WITH_FREERTOS && !__ZEPHYR__
   sigaction (SIGINT, &oldAction, 0);
 #endif
 

--- a/examples/throughput/publisher.c
+++ b/examples/throughput/publisher.c
@@ -29,11 +29,13 @@ static int parse_args(int argc, char **argv, uint32_t *payloadSize, int *burstIn
 static dds_entity_t prepare_dds(dds_entity_t *writer, const char *partitionName);
 static void finalize_dds(dds_entity_t participant, dds_entity_t writer, ThroughputModule_DataType sample);
 
+#if !DDSRT_WITH_FREERTOS && !__ZEPHYR__
 static void sigint (int sig)
 {
   (void)sig;
   done = true;
 }
+#endif
 
 int main (int argc, char **argv)
 {
@@ -73,7 +75,9 @@ int main (int argc, char **argv)
   }
 
   /* Register handler for Ctrl-C */
+#if !DDSRT_WITH_FREERTOS && !__ZEPHYR__
   signal (SIGINT, sigint);
+#endif
 
   /* Register the sample instance and write samples repeatedly or until time out */
   start_writing(writer, &sample, burstInterval, burstSize, timeOut);

--- a/src/core/ddsi/src/ddsi__plist_generic.h
+++ b/src/core/ddsi/src/ddsi__plist_generic.h
@@ -31,7 +31,7 @@ enum ddsi_pserop {
   XSTOP,
   XO, /* octet sequence */
   XS, /* string */
-  XE1, XE2, XE3, /* enum 0..1, 0..2, 0..3 */
+  XE1, XE2, XE3, /* enum 0..1, 0..2, 0..3; mapping to integral type assumed to be the same for all three */
   Xs, /* int16_t */
   Xi, Xix2, Xix3, Xix4, /* int32_t, 1 .. 4 in a row */
   Xu, Xux2, Xux3, Xux4, Xux5, /* uint32_t, 1 .. 5 in a row */

--- a/src/core/ddsi/src/ddsi_mcgroup.c
+++ b/src/core/ddsi/src/ddsi_mcgroup.c
@@ -48,11 +48,14 @@ static int cmp_group_membership (const void *va, const void *vb)
   const struct ddsi_mcgroup_membership_node *a = va;
   const struct ddsi_mcgroup_membership_node *b = vb;
   int c;
+
+#if !defined(DDSRT_MCGROUP_JOIN_ONCE)
   if (a->conn < b->conn)
     return -1;
   else if (a->conn > b->conn)
     return 1;
-  else if ((c = locator_compare_no_port (&a->srcloc, &b->srcloc)) != 0)
+#endif
+  if ((c = locator_compare_no_port (&a->srcloc, &b->srcloc)) != 0)
     return c;
   else if ((c = locator_compare_no_port (&a->mcloc, &b->mcloc)) != 0)
     return c;

--- a/src/core/ddsi/src/ddsi_plist.c
+++ b/src/core/ddsi/src/ddsi_plist.c
@@ -1605,7 +1605,7 @@ static dds_return_t valid_generic (const void *src, size_t srcoff, const enum dd
       case XSTOP: return 0;
       case XO: SIMPLE (XO, ddsi_octetseq_t, (x->length == 0) == (x->value == NULL)); break;
       case XS: SIMPLE (XS, const char *, *x != NULL); break;
-      case XE1: case XE2: case XE3: SIMPLE (*desc, enum xe3_prototype, *x <= 1 + (uint32_t) *desc - XE1); break;
+      case XE1: case XE2: case XE3: SIMPLE (*desc, enum xe3_prototype, (uint32_t) *x <= 1 + (uint32_t) *desc - XE1); break;
       case Xs: TRIVIAL (Xs, int16_t); break;
       case Xi: case Xix2: case Xix3: case Xix4: TRIVIAL (Xi, int32_t); break;
       case Xu: case Xux2: case Xux3: case Xux4: case Xux5: TRIVIAL (Xu, uint32_t); break;

--- a/src/core/ddsi/src/ddsi_plist.c
+++ b/src/core/ddsi/src/ddsi_plist.c
@@ -44,6 +44,25 @@
    it must be -1 */
 DDSRT_STATIC_ASSERT(DDS_LENGTH_UNLIMITED == -1);
 
+/* It turns out there are some platforms where the alignment of a
+   field m in the following:
+
+     struct {
+       ...;
+       T m;
+     }
+
+   may be different from _Alignof(T) ...  So far I have only seen
+   this on some embedded platform, and I furthermore suppose one
+   should expect this to happen if one were to use "#pragma pack"
+   or any of the analogous things, but that is not something we
+   have in our code.
+
+   Still, it means some of the parameter list code fails in nasty
+   ways.  From the current set of observations, the problem
+   disappears if we use this alternative form. */
+#define plist_alignof(ty_) (offsetof(struct {char c_; ty_ t;}, t))
+
 /* These are internal to the parameter list processing. We never
    generate them, and we never want to do see them anywhere outside
    the actual parsing of an incoming parameter list. (There are
@@ -323,7 +342,7 @@ static dds_return_t deser_reliability (void * __restrict dst, struct flagset *fl
   DDSRT_STATIC_ASSERT (DDS_EXTERNAL_RELIABILITY_BEST_EFFORT == 1 && DDS_EXTERNAL_RELIABILITY_RELIABLE == 2 &&
                        DDS_RELIABILITY_BEST_EFFORT == 0 && DDS_RELIABILITY_RELIABLE == 1);
   size_t srcoff = 0, dstoff = 0;
-  dds_reliability_qospolicy_t * const x = deser_generic_dst (dst, &dstoff, dds_alignof (dds_reliability_qospolicy_t));
+  dds_reliability_qospolicy_t * const x = deser_generic_dst (dst, &dstoff, plist_alignof (dds_reliability_qospolicy_t));
   uint32_t kind, mbtsec, mbtfrac;
   ddsi_duration_t mbt;
   (void) gv;
@@ -346,7 +365,7 @@ static dds_return_t ser_reliability (struct ddsi_xmsg *xmsg, ddsi_parameterid_t 
   (void) context_kind;
   DDSRT_STATIC_ASSERT (DDS_EXTERNAL_RELIABILITY_BEST_EFFORT == 1 && DDS_EXTERNAL_RELIABILITY_RELIABLE == 2 &&
                        DDS_RELIABILITY_BEST_EFFORT == 0 && DDS_RELIABILITY_RELIABLE == 1);
-  dds_reliability_qospolicy_t const * const x = deser_generic_src (src, &srcoff, dds_alignof (dds_reliability_qospolicy_t));
+  dds_reliability_qospolicy_t const * const x = deser_generic_src (src, &srcoff, plist_alignof (dds_reliability_qospolicy_t));
   ddsi_duration_t mbt = ddsi_duration_from_dds (x->max_blocking_time);
   uint32_t * const p = ddsi_xmsg_addpar_bo (xmsg, pid, 3 * sizeof (uint32_t), bo);
   p[0] = ddsrt_toBO4u(bo, 1 + (uint32_t) x->kind);
@@ -357,7 +376,7 @@ static dds_return_t ser_reliability (struct ddsi_xmsg *xmsg, ddsi_parameterid_t 
 
 static dds_return_t valid_reliability (const void *src, size_t srcoff)
 {
-  dds_reliability_qospolicy_t const * const x = deser_generic_src (src, &srcoff, dds_alignof (dds_reliability_qospolicy_t));
+  dds_reliability_qospolicy_t const * const x = deser_generic_src (src, &srcoff, plist_alignof (dds_reliability_qospolicy_t));
   if ((x->kind == DDS_RELIABILITY_BEST_EFFORT || x->kind == DDS_RELIABILITY_RELIABLE) && x->max_blocking_time >= 0)
     return 0;
   else
@@ -366,21 +385,21 @@ static dds_return_t valid_reliability (const void *src, size_t srcoff)
 
 static bool equal_reliability (const void *srcx, const void *srcy, size_t srcoff)
 {
-  dds_reliability_qospolicy_t const * const x = deser_generic_src (srcx, &srcoff, dds_alignof (dds_reliability_qospolicy_t));
-  dds_reliability_qospolicy_t const * const y = deser_generic_src (srcy, &srcoff, dds_alignof (dds_reliability_qospolicy_t));
+  dds_reliability_qospolicy_t const * const x = deser_generic_src (srcx, &srcoff, plist_alignof (dds_reliability_qospolicy_t));
+  dds_reliability_qospolicy_t const * const y = deser_generic_src (srcy, &srcoff, plist_alignof (dds_reliability_qospolicy_t));
   return x->kind == y->kind && x->max_blocking_time == y->max_blocking_time;
 }
 
 static bool print_reliability (char * __restrict *buf, size_t * __restrict bufsize, const void *src, size_t srcoff)
 {
-  dds_reliability_qospolicy_t const * const x = deser_generic_src (src, &srcoff, dds_alignof (dds_reliability_qospolicy_t));
+  dds_reliability_qospolicy_t const * const x = deser_generic_src (src, &srcoff, plist_alignof (dds_reliability_qospolicy_t));
   return prtf (buf, bufsize, "%d:%"PRId64, (int) x->kind, x->max_blocking_time);
 }
 
 static dds_return_t deser_statusinfo (void * __restrict dst, struct flagset *flagset, uint64_t flag, const struct dd * __restrict dd, struct ddsi_domaingv const * const gv)
 {
   size_t srcoff = 0, dstoff = 0;
-  uint32_t * const x = deser_generic_dst (dst, &dstoff, dds_alignof (dds_reliability_qospolicy_t));
+  uint32_t * const x = deser_generic_dst (dst, &dstoff, plist_alignof (dds_reliability_qospolicy_t));
   size_t srcoff1 = (srcoff + 3) & ~(size_t)3;
   (void) gv;
   if (srcoff1 + 4 > dd->bufsz)
@@ -396,7 +415,7 @@ static dds_return_t deser_statusinfo (void * __restrict dst, struct flagset *fla
 static dds_return_t ser_statusinfo (struct ddsi_xmsg *xmsg, ddsi_parameterid_t pid, const void *src, size_t srcoff, enum ddsrt_byte_order_selector bo, enum ddsi_plist_context_kind context_kind)
 {
   (void) context_kind;
-  uint32_t const * const x = deser_generic_src (src, &srcoff, dds_alignof (uint32_t));
+  uint32_t const * const x = deser_generic_src (src, &srcoff, plist_alignof (uint32_t));
   uint32_t * const p = ddsi_xmsg_addpar_bo (xmsg, pid, sizeof (uint32_t), bo);
   *p = ddsrt_toBE4u (*x);
   return 0;
@@ -404,14 +423,14 @@ static dds_return_t ser_statusinfo (struct ddsi_xmsg *xmsg, ddsi_parameterid_t p
 
 static bool print_statusinfo (char * __restrict *buf, size_t * __restrict bufsize, const void *src, size_t srcoff)
 {
-  uint32_t const * const x = deser_generic_src (src, &srcoff, dds_alignof (uint32_t));
+  uint32_t const * const x = deser_generic_src (src, &srcoff, plist_alignof (uint32_t));
   return prtf (buf, bufsize, "%"PRIx32, *x);
 }
 
 static dds_return_t deser_locator (void * __restrict dst, struct flagset *flagset, uint64_t flag, const struct dd * __restrict dd, struct ddsi_domaingv const * const gv)
 {
   size_t srcoff = 0, dstoff = 0;
-  ddsi_locators_t * const x = deser_generic_dst (dst, &dstoff, dds_alignof (ddsi_locators_t));
+  ddsi_locators_t * const x = deser_generic_dst (dst, &dstoff, plist_alignof (ddsi_locators_t));
   /* FIXME: don't want to modify do_locator just yet, and don't want to require that a
      locator is the only thing in the descriptor string (even though it actually always is),
      so do alignment explicitly, fake a temporary input buffer and advance the source buffer */
@@ -437,7 +456,7 @@ static dds_return_t deser_locator (void * __restrict dst, struct flagset *flagse
 static dds_return_t ser_locator (struct ddsi_xmsg *xmsg, ddsi_parameterid_t pid, const void *src, size_t srcoff, enum ddsrt_byte_order_selector bo, enum ddsi_plist_context_kind context_kind)
 {
   (void) context_kind;
-  ddsi_locators_t const * const x = deser_generic_src (src, &srcoff, dds_alignof (ddsi_locators_t));
+  ddsi_locators_t const * const x = deser_generic_src (src, &srcoff, plist_alignof (ddsi_locators_t));
   for (const struct ddsi_locators_one *l = x->first; l != NULL; l = l->next)
   {
     char * const p = ddsi_xmsg_addpar_bo (xmsg, pid, 24, bo);
@@ -452,7 +471,7 @@ static dds_return_t ser_locator (struct ddsi_xmsg *xmsg, ddsi_parameterid_t pid,
 
 static dds_return_t unalias_locator (void * __restrict dst, size_t * __restrict dstoff, bool gen_seq_aliased)
 {
-  ddsi_locators_t * const x = deser_generic_dst (dst, dstoff, dds_alignof (ddsi_locators_t));
+  ddsi_locators_t * const x = deser_generic_dst (dst, dstoff, plist_alignof (ddsi_locators_t));
   ddsi_locators_t newlocs = { .n = x->n, .first = NULL, .last = NULL };
   struct ddsi_locators_one **pnext = &newlocs.first;
   (void) gen_seq_aliased;
@@ -471,7 +490,7 @@ static dds_return_t unalias_locator (void * __restrict dst, size_t * __restrict 
 
 static dds_return_t fini_locator (void * __restrict dst, size_t * __restrict dstoff, struct flagset *flagset, uint64_t flag)
 {
-  ddsi_locators_t * const x = deser_generic_dst (dst, dstoff, dds_alignof (ddsi_locators_t));
+  ddsi_locators_t * const x = deser_generic_dst (dst, dstoff, plist_alignof (ddsi_locators_t));
   if (!(*flagset->aliased & flag))
   {
     while (x->first)
@@ -508,7 +527,7 @@ static const enum ddsi_pserop* pserop_advance (const enum ddsi_pserop * __restri
 
 static bool print_locator (char * __restrict *buf, size_t * __restrict bufsize, const void *src, size_t srcoff)
 {
-  ddsi_locators_t const * const x = deser_generic_src (src, &srcoff, dds_alignof (ddsi_locators_t));
+  ddsi_locators_t const * const x = deser_generic_src (src, &srcoff, plist_alignof (ddsi_locators_t));
   const char *sep = "";
   prtf (buf, bufsize, "{");
   for (const struct ddsi_locators_one *l = x->first; l != NULL; l = l->next)
@@ -525,7 +544,7 @@ static dds_return_t deser_type_consistency (void * __restrict dst, struct flagse
 {
   DDSRT_STATIC_ASSERT (DDS_TYPE_CONSISTENCY_DISALLOW_TYPE_COERCION == 0 && DDS_TYPE_CONSISTENCY_ALLOW_TYPE_COERCION == 1);
   size_t srcoff = 0, dstoff = 0;
-  dds_type_consistency_enforcement_qospolicy_t * const x = deser_generic_dst (dst, &dstoff, dds_alignof (dds_type_consistency_enforcement_qospolicy_t));
+  dds_type_consistency_enforcement_qospolicy_t * const x = deser_generic_dst (dst, &dstoff, plist_alignof (dds_type_consistency_enforcement_qospolicy_t));
   const uint32_t option_count = 5;
   uint16_t kind;
   (void) gv;
@@ -572,7 +591,7 @@ static dds_return_t deser_type_consistency (void * __restrict dst, struct flagse
 static dds_return_t ser_type_consistency (struct ddsi_xmsg *xmsg, ddsi_parameterid_t pid, const void *src, size_t srcoff, enum ddsrt_byte_order_selector bo, enum ddsi_plist_context_kind context_kind)
 {
   (void) context_kind;
-  dds_type_consistency_enforcement_qospolicy_t const * const x = deser_generic_src (src, &srcoff, dds_alignof (dds_type_consistency_enforcement_qospolicy_t));
+  dds_type_consistency_enforcement_qospolicy_t const * const x = deser_generic_src (src, &srcoff, plist_alignof (dds_type_consistency_enforcement_qospolicy_t));
   char * const p = ddsi_xmsg_addpar_bo (xmsg, pid, 8, bo);
   const uint16_t kind = ddsrt_toBO2u (bo, (uint16_t) x->kind);
   memcpy (p, &kind, 2);
@@ -588,7 +607,7 @@ static dds_return_t ser_type_consistency (struct ddsi_xmsg *xmsg, ddsi_parameter
 static dds_return_t valid_type_consistency (const void *src, size_t srcoff)
 {
   DDSRT_STATIC_ASSERT (DDS_TYPE_CONSISTENCY_DISALLOW_TYPE_COERCION == 0 && DDS_TYPE_CONSISTENCY_ALLOW_TYPE_COERCION == 1);
-  dds_type_consistency_enforcement_qospolicy_t const * const x = deser_generic_src (src, &srcoff, dds_alignof (dds_type_consistency_enforcement_qospolicy_t));
+  dds_type_consistency_enforcement_qospolicy_t const * const x = deser_generic_src (src, &srcoff, plist_alignof (dds_type_consistency_enforcement_qospolicy_t));
   if (x->kind > DDS_TYPE_CONSISTENCY_ALLOW_TYPE_COERCION)
     return DDS_RETCODE_BAD_PARAMETER;
   return 0;
@@ -596,8 +615,8 @@ static dds_return_t valid_type_consistency (const void *src, size_t srcoff)
 
 static bool equal_type_consistency (const void *srcx, const void *srcy, size_t srcoff)
 {
-  dds_type_consistency_enforcement_qospolicy_t const * const x = deser_generic_src (srcx, &srcoff, dds_alignof (dds_type_consistency_enforcement_qospolicy_t));
-  dds_type_consistency_enforcement_qospolicy_t const * const y = deser_generic_src (srcy, &srcoff, dds_alignof (dds_type_consistency_enforcement_qospolicy_t));
+  dds_type_consistency_enforcement_qospolicy_t const * const x = deser_generic_src (srcx, &srcoff, plist_alignof (dds_type_consistency_enforcement_qospolicy_t));
+  dds_type_consistency_enforcement_qospolicy_t const * const y = deser_generic_src (srcy, &srcoff, plist_alignof (dds_type_consistency_enforcement_qospolicy_t));
   return x->kind == y->kind
     && x->ignore_sequence_bounds == y->ignore_sequence_bounds
     && x->ignore_string_bounds== y->ignore_string_bounds
@@ -608,7 +627,7 @@ static bool equal_type_consistency (const void *srcx, const void *srcy, size_t s
 
 static bool print_type_consistency (char * __restrict *buf, size_t * __restrict bufsize, const void *src, size_t srcoff)
 {
-  dds_type_consistency_enforcement_qospolicy_t const * const x = deser_generic_src (src, &srcoff, dds_alignof (dds_type_consistency_enforcement_qospolicy_t));
+  dds_type_consistency_enforcement_qospolicy_t const * const x = deser_generic_src (src, &srcoff, plist_alignof (dds_type_consistency_enforcement_qospolicy_t));
   return prtf (buf, bufsize, "%d:%d%d%d%d%d", (int) x->kind, x->ignore_sequence_bounds, x->ignore_string_bounds, x->ignore_member_names, x->prevent_type_widening, x->force_type_validation);
 }
 
@@ -630,7 +649,7 @@ static dds_return_t deser_liveliness (void * __restrict dst, struct flagset *fla
 {
   (void) flag; (void) gv;
   size_t srcoff = 0, dstoff = 0;
-  dds_liveliness_qospolicy_t * const x = deser_generic_dst (dst, &dstoff, dds_alignof (dds_liveliness_qospolicy_t));
+  dds_liveliness_qospolicy_t * const x = deser_generic_dst (dst, &dstoff, plist_alignof (dds_liveliness_qospolicy_t));
   switch (dd->context_kind)
   {
     case DDSI_PLIST_CONTEXT_PARTICIPANT: {
@@ -663,7 +682,7 @@ static dds_return_t deser_liveliness (void * __restrict dst, struct flagset *fla
 static dds_return_t ser_liveliness (struct ddsi_xmsg *xmsg, ddsi_parameterid_t pid, const void *src, size_t srcoff, enum ddsrt_byte_order_selector bo, enum ddsi_plist_context_kind context_kind)
 {
   (void) pid;
-  dds_liveliness_qospolicy_t const * const x = deser_generic_src (src, &srcoff, dds_alignof (dds_liveliness_qospolicy_t));
+  dds_liveliness_qospolicy_t const * const x = deser_generic_src (src, &srcoff, plist_alignof (dds_liveliness_qospolicy_t));
   switch (context_kind)
   {
     case DDSI_PLIST_CONTEXT_PARTICIPANT: {
@@ -711,7 +730,7 @@ static const enum ddsi_pserop desc_data_representation[] =  { XQ, Xs, XSTOP, XST
 static dds_return_t deser_data_representation (void * __restrict dst, struct flagset *flagset, uint64_t flag, const struct dd * __restrict dd, struct ddsi_domaingv const * const gv)
 {
   size_t srcoff = 0, dstoff = 0;
-  dds_data_representation_qospolicy_t * const x = deser_generic_dst (dst, &dstoff, dds_alignof (dds_data_representation_qospolicy_t));
+  dds_data_representation_qospolicy_t * const x = deser_generic_dst (dst, &dstoff, plist_alignof (dds_data_representation_qospolicy_t));
   uint32_t cnt;
   int16_t v;
   (void) gv;
@@ -765,7 +784,7 @@ static dds_return_t fini_data_representation (void * __restrict dst, size_t * __
 
 static bool print_data_representation (char * __restrict *buf, size_t * __restrict bufsize, const void *src, size_t srcoff)
 {
-  dds_data_representation_qospolicy_t const * const x = deser_generic_src (src, &srcoff, dds_alignof (dds_data_representation_qospolicy_t));
+  dds_data_representation_qospolicy_t const * const x = deser_generic_src (src, &srcoff, plist_alignof (dds_data_representation_qospolicy_t));
   prtf (buf, bufsize, "%"PRIu32"(", x->value.n);
   const char *sep = "";
   for (uint32_t n = 0; n < x->value.n; n++)
@@ -797,7 +816,7 @@ static dds_return_t deser_type_information (void * __restrict dst, struct flagse
   }
 
   dds_istream_t is = { .m_buffer = buf, .m_index = 0, .m_size = (uint32_t) dd->bufsz, .m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2 };
-  ddsi_typeinfo_t const ** x = deser_generic_dst (dst, &dstoff, dds_alignof (ddsi_typeinfo_t *));
+  ddsi_typeinfo_t const ** x = deser_generic_dst (dst, &dstoff, plist_alignof (ddsi_typeinfo_t *));
   *x = ddsrt_calloc (1, DDS_XTypes_TypeInformation_desc.m_size);
   dds_stream_read (&is, (void *) *x, &dds_cdrstream_default_allocator, DDS_XTypes_TypeInformation_desc.m_ops);
   *flagset->present |= flag;
@@ -810,7 +829,7 @@ err_normalize:
 static dds_return_t ser_type_information (struct ddsi_xmsg *xmsg, ddsi_parameterid_t pid, const void *src, size_t srcoff, enum ddsrt_byte_order_selector bo, enum ddsi_plist_context_kind context_kind)
 {
   (void) context_kind;
-  ddsi_typeinfo_t const * const * x = deser_generic_src (src, &srcoff, dds_alignof (ddsi_typeinfo_t *));
+  ddsi_typeinfo_t const * const * x = deser_generic_src (src, &srcoff, plist_alignof (ddsi_typeinfo_t *));
 
   dds_ostream_t os = { .m_buffer = NULL, .m_index = 0, .m_size = 0, .m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2 };
   (void) dds_stream_write_with_byte_order (&os, &dds_cdrstream_default_allocator, (const void *) *x, DDS_XTypes_TypeInformation_desc.m_ops, bo);
@@ -822,20 +841,20 @@ static dds_return_t ser_type_information (struct ddsi_xmsg *xmsg, ddsi_parameter
 
 static dds_return_t valid_type_information (const void *src, size_t srcoff)
 {
-  ddsi_typeinfo_t const * const * x = deser_generic_src (src, &srcoff, dds_alignof (ddsi_typeinfo_t *));
+  ddsi_typeinfo_t const * const * x = deser_generic_src (src, &srcoff, plist_alignof (ddsi_typeinfo_t *));
   return (*x != NULL && ddsi_typeinfo_valid (*x)) ? DDS_RETCODE_OK : DDS_RETCODE_BAD_PARAMETER;
 }
 
 static bool equal_type_information (const void *srcx, const void *srcy, size_t srcoff)
 {
-  ddsi_typeinfo_t const * const * x = deser_generic_src (srcx, &srcoff, dds_alignof (ddsi_typeinfo_t *));
-  ddsi_typeinfo_t const * const * y = deser_generic_src (srcy, &srcoff, dds_alignof (ddsi_typeinfo_t *));
+  ddsi_typeinfo_t const * const * x = deser_generic_src (srcx, &srcoff, plist_alignof (ddsi_typeinfo_t *));
+  ddsi_typeinfo_t const * const * y = deser_generic_src (srcy, &srcoff, plist_alignof (ddsi_typeinfo_t *));
   return ddsi_typeinfo_equal (*x, *y, DDSI_TYPE_INCLUDE_DEPS);
 }
 
 static dds_return_t unalias_type_information (void * __restrict dst, size_t * __restrict dstoff, bool gen_seq_aliased)
 {
-  ddsi_typeinfo_t const * * x = deser_generic_dst (dst, dstoff, dds_alignof (ddsi_typeinfo_t *));
+  ddsi_typeinfo_t const * * x = deser_generic_dst (dst, dstoff, plist_alignof (ddsi_typeinfo_t *));
   ddsi_typeinfo_t * new_type_info = ddsi_typeinfo_dup (*x);
   (void) gen_seq_aliased;
   *x = new_type_info;
@@ -845,7 +864,7 @@ static dds_return_t unalias_type_information (void * __restrict dst, size_t * __
 
 static dds_return_t fini_type_information (void * __restrict dst, size_t * __restrict dstoff, struct flagset *flagset, uint64_t flag)
 {
-  ddsi_typeinfo_t const * const * x = deser_generic_src (dst, dstoff, dds_alignof (ddsi_typeinfo_t *));
+  ddsi_typeinfo_t const * const * x = deser_generic_src (dst, dstoff, plist_alignof (ddsi_typeinfo_t *));
   if ((*flagset->present & flag) && !(*flagset->aliased & flag))
   {
     ddsi_typeinfo_fini ((ddsi_typeinfo_t *) *x);
@@ -856,7 +875,7 @@ static dds_return_t fini_type_information (void * __restrict dst, size_t * __res
 
 static bool print_type_information (char * __restrict *buf, size_t * __restrict bufsize, const void *src, size_t srcoff)
 {
-  ddsi_typeinfo_t const * const * x = deser_generic_src (src, &srcoff, dds_alignof (ddsi_typeinfo_t *));
+  ddsi_typeinfo_t const * const * x = deser_generic_src (src, &srcoff, plist_alignof (ddsi_typeinfo_t *));
   struct ddsi_typeid_str tpstrm, tpstrc;
   return prtf (buf, bufsize, "%s/%s",
     ddsi_make_typeid_str (&tpstrm, ddsi_typeinfo_minimal_typeid (*x)),
@@ -865,12 +884,21 @@ static bool print_type_information (char * __restrict *buf, size_t * __restrict 
 
 #endif /* DDS_HAS_TYPE_DISCOVERY */
 
+// The XE1 .. XE3 codes are the only ones dealing with an enumerated type and are
+// assumed to map to the same type, which would traditionally be an "int", but in
+// gcc with the -fshort-enums option enabled, it is a char.  That happens quite a
+// bit on embedded platforms, judging by a few tickets.
+//
+// This enum definition is used only in the serialisation/deserialisation code to
+// stand in for the actual type.
+enum xe3_prototype { XE3_PROTO_0, XE3_PROTO_1, XE3_PROTO_2, XE3_PROTO_3 };
+
 static size_t ser_generic_srcsize (const enum ddsi_pserop * __restrict desc)
 {
   size_t srcoff = 0, srcalign = 0;
 #define SIMPLE(basecase_, type_) do {                          \
     const uint32_t cnt = 1 + (uint32_t) (*desc - (basecase_)); \
-    const size_t align = dds_alignof (type_);                      \
+    const size_t align = plist_alignof (type_);                      \
     srcalign = (align > srcalign) ? align : srcalign;          \
     srcoff = (srcoff + align - 1) & ~(align - 1);              \
     srcoff += cnt * sizeof (type_);                            \
@@ -882,7 +910,7 @@ static size_t ser_generic_srcsize (const enum ddsi_pserop * __restrict desc)
       case XSTOP: return (srcoff + srcalign - 1) & ~(srcalign - 1);
       case XO: SIMPLE (XO, ddsi_octetseq_t); break;
       case XS: SIMPLE (XS, const char *); break;
-      case XE1: case XE2: case XE3: SIMPLE (*desc, uint32_t); break;
+      case XE1: case XE2: case XE3: SIMPLE (*desc, enum xe3_prototype); break;
       case Xs: SIMPLE (Xs, int16_t); break;
       case Xi: case Xix2: case Xix3: case Xix4: SIMPLE (Xi, int32_t); break;
       case Xu: case Xux2: case Xux3: case Xux4: case Xux5: SIMPLE (Xu, uint32_t); break;
@@ -911,7 +939,7 @@ static bool fini_generic_embeddable (void * __restrict dst, size_t * __restrict 
 {
   bool freed = false;
 #define COMPLEX(basecase_, type_, cleanup_unaliased_, cleanup_always_) do { \
-    type_ *x = deser_generic_dst (dst, dstoff, dds_alignof (type_));            \
+    type_ *x = deser_generic_dst (dst, dstoff, plist_alignof (type_));      \
     const uint32_t cnt = 1 + (uint32_t) (*desc - (basecase_));              \
     for (uint32_t xi = 0; xi < cnt; xi++, x++) {                            \
       if (!aliased) do { cleanup_unaliased_; } while (0);                   \
@@ -927,7 +955,7 @@ static bool fini_generic_embeddable (void * __restrict dst, size_t * __restrict 
       case XSTOP: return freed;
       case XO: COMPLEX (XO, ddsi_octetseq_t, { ddsrt_free (x->value); freed = true; }, (void) 0); break;
       case XS: COMPLEX (XS, char *, { ddsrt_free (*x); freed = true; }, (void) 0); break;
-      case XE1: case XE2: case XE3: COMPLEX (*desc, uint32_t, (void) 0, (void) 0); break;
+      case XE1: case XE2: case XE3: COMPLEX (*desc, enum xe3_prototype, (void) 0, (void) 0); break;
       case Xs: SIMPLE (Xs, int16_t); break;
       case Xi: case Xix2: case Xix3: case Xix4: SIMPLE (Xi, int32_t); break;
       case Xu: case Xux2: case Xux3: case Xux4: case Xux5: SIMPLE (Xu, uint32_t); break;
@@ -941,7 +969,7 @@ static bool fini_generic_embeddable (void * __restrict dst, size_t * __restrict 
       case XbPROP: SIMPLE (XbPROP, unsigned char); break;
       case XQ:
       {
-        ddsi_octetseq_t *x = deser_generic_dst (dst, dstoff, dds_alignof (ddsi_octetseq_t));
+        ddsi_octetseq_t *x = deser_generic_dst (dst, dstoff, plist_alignof (ddsi_octetseq_t));
         const size_t elem_size = ser_generic_srcsize (desc + 1);
         bool elem_freed = true;
         for (uint32_t i = 0; (i < x->length) && elem_freed; i++)
@@ -967,19 +995,19 @@ static size_t pserop_memalign (enum ddsi_pserop op)
 {
   switch (op)
   {
-    case XO: case XQ: return dds_alignof (ddsi_octetseq_t);
-    case XS: return dds_alignof (char *);
-    case XG: return dds_alignof (ddsi_guid_t);
-    case XK: return dds_alignof (ddsi_keyhash_t);
+    case XO: case XQ: return plist_alignof (ddsi_octetseq_t);
+    case XS: return plist_alignof (char *);
+    case XG: return plist_alignof (ddsi_guid_t);
+    case XK: return plist_alignof (ddsi_keyhash_t);
     case Xb: case Xbx2: case Xbx3: case Xbx4: case Xbx5: return 1;
     case Xo: case Xox2: return 1;
     case XbCOND: case XbPROP: return 1;
-    case XE1: case XE2: case XE3: return dds_alignof (uint32_t);
-    case Xs: return dds_alignof (int16_t);
-    case Xi: case Xix2: case Xix3: case Xix4: return dds_alignof (int32_t);
-    case Xu: case Xux2: case Xux3: case Xux4: case Xux5: return dds_alignof (uint32_t);
-    case Xl: return dds_alignof (int64_t);
-    case XD: case XDx2: return dds_alignof (dds_duration_t);
+    case XE1: case XE2: case XE3: return plist_alignof (enum xe3_prototype);
+    case Xs: return plist_alignof (int16_t);
+    case Xi: case Xix2: case Xix3: case Xix4: return plist_alignof (int32_t);
+    case Xu: case Xux2: case Xux3: case Xux4: case Xux5: return plist_alignof (uint32_t);
+    case Xl: return plist_alignof (int64_t);
+    case XD: case XDx2: return plist_alignof (dds_duration_t);
     case XSTOP: case Xopt: assert (0);
   }
   return 0;
@@ -1001,7 +1029,7 @@ static dds_return_t deser_generic_r (void * __restrict dst, size_t * __restrict 
       case XSTOP:
         goto success;
       case XO: { /* octet sequence */
-        ddsi_octetseq_t * const x = deser_generic_dst (dst, dstoff, dds_alignof (ddsi_octetseq_t));
+        ddsi_octetseq_t * const x = deser_generic_dst (dst, dstoff, plist_alignof (ddsi_octetseq_t));
         if (deser_uint32 (&x->length, dd, srcoff) < 0 || dd->bufsz - *srcoff < x->length)
           goto fail;
         x->value = x->length ? (unsigned char *) (dd->buf + *srcoff) : NULL;
@@ -1011,7 +1039,7 @@ static dds_return_t deser_generic_r (void * __restrict dst, size_t * __restrict 
         break;
       }
       case XS: { /* string: alias as-if octet sequence, do additional checks and store as string */
-        char ** const x = deser_generic_dst (dst, dstoff, dds_alignof (char *));
+        char ** const x = deser_generic_dst (dst, dstoff, plist_alignof (char *));
         ddsi_octetseq_t tmp;
         size_t tmpoff = 0;
         if (deser_generic_r (&tmp, &tmpoff, flagset, flag, dd, srcoff, (enum ddsi_pserop []) { XO, XSTOP }) < 0)
@@ -1023,24 +1051,24 @@ static dds_return_t deser_generic_r (void * __restrict dst, size_t * __restrict 
         break;
       }
       case XE1: case XE2: case XE3: { /* enum with max allowed value */
-        uint32_t * const x = deser_generic_dst (dst, dstoff, dds_alignof (int));
+        enum xe3_prototype * const x = deser_generic_dst (dst, dstoff, plist_alignof (enum xe3_prototype));
         const uint32_t maxval = 1 + (uint32_t) (*desc - XE1);
         uint32_t tmp;
         if (deser_uint32 (&tmp, dd, srcoff) < 0 || tmp > maxval)
           goto fail;
-        *x = (uint32_t) tmp;
+        *x = (enum xe3_prototype) tmp;
         *dstoff += sizeof (*x);
         break;
       }
       case Xs: { /* int16_t */
-        uint16_t * const x = deser_generic_dst (dst, dstoff, dds_alignof (uint16_t));
+        uint16_t * const x = deser_generic_dst (dst, dstoff, plist_alignof (uint16_t));
         if (deser_uint16(x, dd, srcoff) < 0)
           goto fail;
         *dstoff += sizeof (*x);
         break;
       }
       case Xi: case Xix2: case Xix3: case Xix4: { /* int32_t(s) */
-        uint32_t * const x = deser_generic_dst (dst, dstoff, dds_alignof (uint32_t));
+        uint32_t * const x = deser_generic_dst (dst, dstoff, plist_alignof (uint32_t));
         const uint32_t cnt = 1 + (uint32_t) (*desc - Xi);
         for (uint32_t i = 0; i < cnt; i++)
           if (deser_uint32 (&x[i], dd, srcoff) < 0)
@@ -1049,7 +1077,7 @@ static dds_return_t deser_generic_r (void * __restrict dst, size_t * __restrict 
         break;
       }
       case Xu: case Xux2: case Xux3: case Xux4: case Xux5: { /* uint32_t(s): treated the same */
-        uint32_t * const x = deser_generic_dst (dst, dstoff, dds_alignof (uint32_t));
+        uint32_t * const x = deser_generic_dst (dst, dstoff, plist_alignof (uint32_t));
         const uint32_t cnt = 1 + (uint32_t) (*desc - Xu);
         for (uint32_t i = 0; i < cnt; i++)
           if (deser_uint32 (&x[i], dd, srcoff) < 0)
@@ -1058,14 +1086,14 @@ static dds_return_t deser_generic_r (void * __restrict dst, size_t * __restrict 
         break;
       }
       case Xl: { /* int64_t */
-        int64_t * const x = deser_generic_dst (dst, dstoff, dds_alignof (int64_t));
+        int64_t * const x = deser_generic_dst (dst, dstoff, plist_alignof (int64_t));
         if (deser_int64(x, dd, srcoff) < 0)
           goto fail;
         *dstoff += sizeof (*x);
         break;
       }
       case XD: case XDx2: { /* duration(s): int64_t <=> int32_t.uint32_t (seconds.fraction) */
-        dds_duration_t * const x = deser_generic_dst (dst, dstoff, dds_alignof (dds_duration_t));
+        dds_duration_t * const x = deser_generic_dst (dst, dstoff, plist_alignof (dds_duration_t));
         const uint32_t cnt = 1 + (uint32_t) (*desc - XD);
         for (uint32_t i = 0; i < cnt; i++)
         {
@@ -1080,7 +1108,7 @@ static dds_return_t deser_generic_r (void * __restrict dst, size_t * __restrict 
         break;
       }
       case Xo: case Xox2: { /* octet(s) */
-        unsigned char * const x = deser_generic_dst (dst, dstoff, dds_alignof (unsigned char));
+        unsigned char * const x = deser_generic_dst (dst, dstoff, plist_alignof (unsigned char));
         const uint32_t cnt = 1 + (uint32_t) (*desc - Xo);
         if (dd->bufsz - *srcoff < cnt)
           goto fail;
@@ -1090,7 +1118,7 @@ static dds_return_t deser_generic_r (void * __restrict dst, size_t * __restrict 
         break;
       }
       case Xb: case Xbx2: case Xbx3: case Xbx4: case Xbx5: case XbCOND: { /* boolean(s) */
-        unsigned char * const x = deser_generic_dst (dst, dstoff, dds_alignof (unsigned char));
+        unsigned char * const x = deser_generic_dst (dst, dstoff, plist_alignof (unsigned char));
         const uint32_t cnt = 1 + ((*desc == XbCOND) ? 0 : (uint32_t) (*desc - Xb));
         if (dd->bufsz - *srcoff < cnt)
           goto fail;
@@ -1103,13 +1131,13 @@ static dds_return_t deser_generic_r (void * __restrict dst, size_t * __restrict 
         break;
       }
       case XbPROP: { /* "propagate" flag, boolean, implied in serialized representation */
-        unsigned char * const x = deser_generic_dst (dst, dstoff, dds_alignof (unsigned char));
+        unsigned char * const x = deser_generic_dst (dst, dstoff, plist_alignof (unsigned char));
         *x = 1;
         *dstoff += sizeof (*x);
         break;
       }
       case XG: { /* GUID */
-        ddsi_guid_t * const x = deser_generic_dst (dst, dstoff, dds_alignof (ddsi_guid_t));
+        ddsi_guid_t * const x = deser_generic_dst (dst, dstoff, plist_alignof (ddsi_guid_t));
         if (dd->bufsz - *srcoff < sizeof (*x))
           goto fail;
         memcpy (x, dd->buf + *srcoff, sizeof (*x));
@@ -1119,7 +1147,7 @@ static dds_return_t deser_generic_r (void * __restrict dst, size_t * __restrict 
         break;
       }
       case XK: { /* keyhash */
-        ddsi_keyhash_t * const x = deser_generic_dst (dst, dstoff, dds_alignof (ddsi_keyhash_t));
+        ddsi_keyhash_t * const x = deser_generic_dst (dst, dstoff, plist_alignof (ddsi_keyhash_t));
         if (dd->bufsz - *srcoff < sizeof (*x))
           goto fail;
         memcpy (x, dd->buf + *srcoff, sizeof (*x));
@@ -1128,7 +1156,7 @@ static dds_return_t deser_generic_r (void * __restrict dst, size_t * __restrict 
         break;
       }
       case XQ: { /* arbitrary sequence */
-        ddsi_octetseq_t * const x = deser_generic_dst (dst, dstoff, dds_alignof (ddsi_octetseq_t));
+        ddsi_octetseq_t * const x = deser_generic_dst (dst, dstoff, plist_alignof (ddsi_octetseq_t));
         if (deser_uint32 (&x->length, dd, srcoff) < 0 || x->length > dd->bufsz - *srcoff)
           goto fail;
         const size_t elem_size = ser_generic_srcsize (desc + 1);
@@ -1213,11 +1241,11 @@ dds_return_t ddsi_plist_deser_generic (void * __restrict dst, const void * __res
 
 void ddsi_plist_ser_generic_size_embeddable (size_t *dstoff, const void *src, size_t srcoff, const enum ddsi_pserop * __restrict desc)
 {
-#define COMPLEX(basecase_, type_, dstoff_update_) do {                  \
-    type_ const *x = deser_generic_src (src, &srcoff, dds_alignof (type_)); \
-    const uint32_t cnt = 1 + (uint32_t) (*desc - (basecase_));          \
-    for (uint32_t xi = 0; xi < cnt; xi++, x++) { dstoff_update_; }      \
-    srcoff += cnt * sizeof (*x);                                        \
+#define COMPLEX(basecase_, type_, dstoff_update_) do {                        \
+    type_ const *x = deser_generic_src (src, &srcoff, plist_alignof (type_)); \
+    const uint32_t cnt = 1 + (uint32_t) (*desc - (basecase_));                \
+    for (uint32_t xi = 0; xi < cnt; xi++, x++) { dstoff_update_; }            \
+    srcoff += cnt * sizeof (*x);                                              \
   } while (0)
 #define SIMPLE1(basecase_, type_) COMPLEX (basecase_, type_, *dstoff = *dstoff + sizeof (*x))
 #define SIMPLE2(basecase_, type_) COMPLEX (basecase_, type_, *dstoff = align2 (*dstoff) + sizeof (*x))
@@ -1230,7 +1258,7 @@ void ddsi_plist_ser_generic_size_embeddable (size_t *dstoff, const void *src, si
       case XSTOP: return;
       case XO: COMPLEX (XO, ddsi_octetseq_t, *dstoff = align4 (*dstoff) + 4 + x->length); break;
       case XS: COMPLEX (XS, const char *, *dstoff = align4 (*dstoff) + 4 + strlen (*x) + 1); break;
-      case XE1: case XE2: case XE3: COMPLEX (*desc, uint32_t, *dstoff = align4 (*dstoff) + 4); break;
+      case XE1: case XE2: case XE3: COMPLEX (*desc, enum xe3_prototype, *dstoff = align4 (*dstoff) + 4); break;
       case Xs: SIMPLE2 (Xs, int16_t); break;
       case Xi: case Xix2: case Xix3: case Xix4: SIMPLE4 (Xi, int32_t); break;
       case Xu: case Xux2: case Xux3: case Xux4: case Xux5: SIMPLE4 (Xu, uint32_t); break;
@@ -1290,7 +1318,7 @@ dds_return_t ddsi_plist_ser_generic_embeddable (char * const data, size_t *dstof
       case XSTOP:
         return 0;
       case XO: { /* octet sequence */
-        ddsi_octetseq_t const * const x = deser_generic_src (src, &srcoff, dds_alignof (ddsi_octetseq_t));
+        ddsi_octetseq_t const * const x = deser_generic_src (src, &srcoff, plist_alignof (ddsi_octetseq_t));
         char * const p = ser_generic_align4 (data, dstoff);
         *((uint32_t *) p) = ddsrt_toBO4u(bo, x->length);
         if (x->length) memcpy (p + 4, x->value, x->length);
@@ -1299,7 +1327,7 @@ dds_return_t ddsi_plist_ser_generic_embeddable (char * const data, size_t *dstof
         break;
       }
       case XS: { /* string */
-        char const * const * const x = deser_generic_src (src, &srcoff, dds_alignof (char *));
+        char const * const * const x = deser_generic_src (src, &srcoff, plist_alignof (char *));
         const uint32_t size = (uint32_t) (strlen (*x) + 1);
         char * const p = ser_generic_align4 (data, dstoff);
         *((uint32_t *) p) = ddsrt_toBO4u(bo, size);
@@ -1309,7 +1337,7 @@ dds_return_t ddsi_plist_ser_generic_embeddable (char * const data, size_t *dstof
         break;
       }
       case XE1: case XE2: case XE3: { /* enum */
-        uint32_t const * const x = deser_generic_src (src, &srcoff, dds_alignof (uint32_t));
+        enum xe3_prototype const * const x = deser_generic_src (src, &srcoff, plist_alignof (enum xe3_prototype));
         uint32_t * const p = ser_generic_align4 (data, dstoff);
         *p = ddsrt_toBO4u(bo, (uint32_t) *x);
         *dstoff += 4;
@@ -1317,7 +1345,7 @@ dds_return_t ddsi_plist_ser_generic_embeddable (char * const data, size_t *dstof
         break;
       }
       case Xs: { /* int16_t */
-        int16_t const * const x = deser_generic_src (src, &srcoff, dds_alignof (int16_t));
+        int16_t const * const x = deser_generic_src (src, &srcoff, plist_alignof (int16_t));
         int16_t * const p = ser_generic_align2 (data, dstoff);
         *p = ddsrt_toBO2(bo, *x);
         *dstoff += sizeof (*x);
@@ -1325,7 +1353,7 @@ dds_return_t ddsi_plist_ser_generic_embeddable (char * const data, size_t *dstof
         break;
       }
       case Xi: case Xix2: case Xix3: case Xix4: { /* int32_t(s) */
-        int32_t const * const x = deser_generic_src (src, &srcoff, dds_alignof (int32_t));
+        int32_t const * const x = deser_generic_src (src, &srcoff, plist_alignof (int32_t));
         const uint32_t cnt = 1 + (uint32_t) (*desc - Xi);
         int32_t * const p = ser_generic_align4 (data, dstoff);
         for (uint32_t i = 0; i < cnt; i++)
@@ -1335,7 +1363,7 @@ dds_return_t ddsi_plist_ser_generic_embeddable (char * const data, size_t *dstof
         break;
       }
       case Xu: case Xux2: case Xux3: case Xux4: case Xux5:  { /* uint32_t(s) */
-        uint32_t const * const x = deser_generic_src (src, &srcoff, dds_alignof (uint32_t));
+        uint32_t const * const x = deser_generic_src (src, &srcoff, plist_alignof (uint32_t));
         const uint32_t cnt = 1 + (uint32_t) (*desc - Xu);
         uint32_t * const p = ser_generic_align4 (data, dstoff);
         for (uint32_t i = 0; i < cnt; i++)
@@ -1345,7 +1373,7 @@ dds_return_t ddsi_plist_ser_generic_embeddable (char * const data, size_t *dstof
         break;
       }
       case Xl: { /* int64_t */
-        int64_t const * const x = deser_generic_src (src, &srcoff, dds_alignof (int64_t));
+        int64_t const * const x = deser_generic_src (src, &srcoff, plist_alignof (int64_t));
         int64_t * const p = ser_generic_align8 (data, dstoff);
         *p = ddsrt_toBO8(bo, *x);
         *dstoff += sizeof (*x);
@@ -1353,7 +1381,7 @@ dds_return_t ddsi_plist_ser_generic_embeddable (char * const data, size_t *dstof
         break;
       }
       case XD: case XDx2: { /* duration(s): int64_t <=> int32_t.uint32_t (seconds.fraction) */
-        dds_duration_t const * const x = deser_generic_src (src, &srcoff, dds_alignof (dds_duration_t));
+        dds_duration_t const * const x = deser_generic_src (src, &srcoff, plist_alignof (dds_duration_t));
         const uint32_t cnt = 1 + (uint32_t) (*desc - XD);
         uint32_t * const p = ser_generic_align4 (data, dstoff);
         for (uint32_t i = 0; i < cnt; i++)
@@ -1367,7 +1395,7 @@ dds_return_t ddsi_plist_ser_generic_embeddable (char * const data, size_t *dstof
         break;
       }
       case Xo: case Xox2: { /* octet(s) */
-        unsigned char const * const x = deser_generic_src (src, &srcoff, dds_alignof (unsigned char));
+        unsigned char const * const x = deser_generic_src (src, &srcoff, plist_alignof (unsigned char));
         const uint32_t cnt = 1 + (uint32_t) (*desc - Xo);
         char * const p = data + *dstoff;
         memcpy (p, x, cnt);
@@ -1376,7 +1404,7 @@ dds_return_t ddsi_plist_ser_generic_embeddable (char * const data, size_t *dstof
         break;
       }
       case Xb: case Xbx2: case Xbx3: case Xbx4: case Xbx5: case XbCOND: { /* boolean(s) */
-        unsigned char const * const x = deser_generic_src (src, &srcoff, dds_alignof (unsigned char));
+        unsigned char const * const x = deser_generic_src (src, &srcoff, plist_alignof (unsigned char));
         const uint32_t cnt = 1 + ((*desc == XbCOND) ? 0 : (uint32_t) (*desc - Xb));
         char * const p = data + *dstoff;
         memcpy (p, x, cnt);
@@ -1385,13 +1413,13 @@ dds_return_t ddsi_plist_ser_generic_embeddable (char * const data, size_t *dstof
         break;
       }
       case XbPROP: { /* "propagate" boolean: don't serialize, skip it and everything that follows if false */
-        unsigned char const * const x = deser_generic_src (src, &srcoff, dds_alignof (unsigned char));
+        unsigned char const * const x = deser_generic_src (src, &srcoff, plist_alignof (unsigned char));
         if (! *x) return 0;
         srcoff++;
         break;
       }
       case XG: { /* GUID */
-        ddsi_guid_t const * const x = deser_generic_src (src, &srcoff, dds_alignof (ddsi_guid_t));
+        ddsi_guid_t const * const x = deser_generic_src (src, &srcoff, plist_alignof (ddsi_guid_t));
         const ddsi_guid_t xn = ddsi_hton_guid (*x);
         char * const p = data + *dstoff;
         memcpy (p, &xn, sizeof (xn));
@@ -1400,7 +1428,7 @@ dds_return_t ddsi_plist_ser_generic_embeddable (char * const data, size_t *dstof
         break;
       }
       case XK: { /* keyhash */
-        ddsi_keyhash_t const * const x = deser_generic_src (src, &srcoff, dds_alignof (ddsi_keyhash_t));
+        ddsi_keyhash_t const * const x = deser_generic_src (src, &srcoff, plist_alignof (ddsi_keyhash_t));
         char * const p = data + *dstoff;
         memcpy (p, x, sizeof (*x));
         *dstoff += sizeof (*x);
@@ -1408,7 +1436,7 @@ dds_return_t ddsi_plist_ser_generic_embeddable (char * const data, size_t *dstof
         break;
       }
       case XQ: { /* arbitrary sequence */
-        ddsi_octetseq_t const * const x = deser_generic_src (src, &srcoff, dds_alignof (ddsi_octetseq_t));
+        ddsi_octetseq_t const * const x = deser_generic_src (src, &srcoff, plist_alignof (ddsi_octetseq_t));
         char * const p = ser_generic_align4 (data, dstoff);
         *dstoff += 4;
         if (x->length == 0)
@@ -1467,11 +1495,11 @@ dds_return_t ddsi_plist_ser_generic_be (void **dst, size_t *dstsize, const void 
 
 static dds_return_t unalias_generic (void * __restrict dst, size_t * __restrict dstoff, bool gen_seq_aliased, const enum ddsi_pserop * __restrict desc)
 {
-#define COMPLEX(basecase_, type_, ...) do {                      \
-    type_ *x = deser_generic_dst (dst, dstoff, dds_alignof (type_)); \
-    const uint32_t cnt = 1 + (uint32_t) (*desc - basecase_);     \
-    for (uint32_t xi = 0; xi < cnt; xi++, x++) { __VA_ARGS__; }  \
-    *dstoff += cnt * sizeof (*x);                                \
+#define COMPLEX(basecase_, type_, ...) do {                            \
+    type_ *x = deser_generic_dst (dst, dstoff, plist_alignof (type_)); \
+    const uint32_t cnt = 1 + (uint32_t) (*desc - basecase_);           \
+    for (uint32_t xi = 0; xi < cnt; xi++, x++) { __VA_ARGS__; }        \
+    *dstoff += cnt * sizeof (*x);                                      \
   } while (0)
 #define SIMPLE(basecase_, type_) COMPLEX (basecase_, type_, (void) 0)
   while (true)
@@ -1482,7 +1510,7 @@ static dds_return_t unalias_generic (void * __restrict dst, size_t * __restrict 
         return 0;
       case XO: COMPLEX (XO, ddsi_octetseq_t, if (x->value) { x->value = ddsrt_memdup (x->value, x->length); }); break;
       case XS: COMPLEX (XS, char *, if (*x) { *x = ddsrt_strdup (*x); }); break;
-      case XE1: case XE2: case XE3: COMPLEX (*desc, uint32_t, (void) 0); break;
+      case XE1: case XE2: case XE3: COMPLEX (*desc, enum xe3_prototype, (void) 0); break;
       case Xs: SIMPLE (Xs, int16_t); break;
       case Xi: case Xix2: case Xix3: case Xix4: SIMPLE (Xi, int32_t); break;
       case Xu: case Xux2: case Xux3: case Xux4: case Xux5: SIMPLE (Xu, uint32_t); break;
@@ -1562,11 +1590,11 @@ void ddsi_plist_fini_generic (void * __restrict dst, const enum ddsi_pserop *des
 
 static dds_return_t valid_generic (const void *src, size_t srcoff, const enum ddsi_pserop * __restrict desc)
 {
-#define COMPLEX(basecase_, type_, cond_stmts_) do {                     \
-    type_ const *x = deser_generic_src (src, &srcoff, dds_alignof (type_)); \
-    const uint32_t cnt = 1 + (uint32_t) (*desc - (basecase_));          \
-    for (uint32_t xi = 0; xi < cnt; xi++, x++) { cond_stmts_; }         \
-    srcoff += cnt * sizeof (*x);                                        \
+#define COMPLEX(basecase_, type_, cond_stmts_) do {                           \
+    type_ const *x = deser_generic_src (src, &srcoff, plist_alignof (type_)); \
+    const uint32_t cnt = 1 + (uint32_t) (*desc - (basecase_));                \
+    for (uint32_t xi = 0; xi < cnt; xi++, x++) { cond_stmts_; }               \
+    srcoff += cnt * sizeof (*x);                                              \
   } while (0)
 #define SIMPLE(basecase_, type_, cond_) COMPLEX (basecase_, type_, if (!(cond_)) return DDS_RETCODE_BAD_PARAMETER)
 #define TRIVIAL(basecase_, type_) COMPLEX (basecase_, type_, (void) 0)
@@ -1577,7 +1605,7 @@ static dds_return_t valid_generic (const void *src, size_t srcoff, const enum dd
       case XSTOP: return 0;
       case XO: SIMPLE (XO, ddsi_octetseq_t, (x->length == 0) == (x->value == NULL)); break;
       case XS: SIMPLE (XS, const char *, *x != NULL); break;
-      case XE1: case XE2: case XE3: SIMPLE (*desc, uint32_t, *x <= 1 + (uint32_t) *desc - XE1); break;
+      case XE1: case XE2: case XE3: SIMPLE (*desc, enum xe3_prototype, *x <= 1 + (uint32_t) *desc - XE1); break;
       case Xs: TRIVIAL (Xs, int16_t); break;
       case Xi: case Xix2: case Xix3: case Xix4: TRIVIAL (Xi, int32_t); break;
       case Xu: case Xux2: case Xux3: case Xux4: case Xux5: TRIVIAL (Xu, uint32_t); break;
@@ -1612,12 +1640,12 @@ static dds_return_t valid_generic (const void *src, size_t srcoff, const enum dd
 
 static bool equal_generic (const void *srcx, const void *srcy, size_t srcoff, const enum ddsi_pserop * __restrict desc)
 {
-#define COMPLEX(basecase_, type_, cond_stmts_) do {                      \
-    type_ const *x = deser_generic_src (srcx, &srcoff, dds_alignof (type_)); \
-    type_ const *y = deser_generic_src (srcy, &srcoff, dds_alignof (type_)); \
-    const uint32_t cnt = 1 + (uint32_t) (*desc - (basecase_));           \
-    for (uint32_t xi = 0; xi < cnt; xi++, x++, y++) { cond_stmts_; }     \
-    srcoff += cnt * sizeof (*x);                                         \
+#define COMPLEX(basecase_, type_, cond_stmts_) do {                            \
+    type_ const *x = deser_generic_src (srcx, &srcoff, plist_alignof (type_)); \
+    type_ const *y = deser_generic_src (srcy, &srcoff, plist_alignof (type_)); \
+    const uint32_t cnt = 1 + (uint32_t) (*desc - (basecase_));                 \
+    for (uint32_t xi = 0; xi < cnt; xi++, x++, y++) { cond_stmts_; }           \
+    srcoff += cnt * sizeof (*x);                                               \
   } while (0)
 #define SIMPLE(basecase_, type_, cond_) COMPLEX (basecase_, type_, if (!(cond_)) return false)
 #define TRIVIAL(basecase_, type_) SIMPLE (basecase_, type_, *x == *y)
@@ -1635,7 +1663,7 @@ static bool equal_generic (const void *srcx, const void *srcy, size_t srcoff, co
       case XS:
         SIMPLE (XS, const char *, strcmp (*x, *y) == 0);
         break;
-      case XE1: case XE2: case XE3: TRIVIAL (*desc, uint32_t); break;
+      case XE1: case XE2: case XE3: TRIVIAL (*desc, enum xe3_prototype); break;
       case Xs: TRIVIAL (Xs, int16_t); break;
       case Xi: case Xix2: case Xix3: case Xix4: TRIVIAL (Xi, int32_t); break;
       case Xu: case Xux2: case Xux3: case Xux4: case Xux5: TRIVIAL (Xu, uint32_t); break;
@@ -1732,7 +1760,7 @@ static bool print_generic1 (char * __restrict *buf, size_t * __restrict bufsize,
       case XSTOP:
         return true;
       case XO: { /* octet sequence */
-        ddsi_octetseq_t const * const x = deser_generic_src (src, &srcoff, dds_alignof (ddsi_octetseq_t));
+        ddsi_octetseq_t const * const x = deser_generic_src (src, &srcoff, plist_alignof (ddsi_octetseq_t));
         prtf (buf, bufsize, "%s%"PRIu32"<", sep, x->length);
         (void) prtf_octetseq (buf, bufsize, x->length, x->value);
         if (!prtf (buf, bufsize, ">"))
@@ -1741,28 +1769,28 @@ static bool print_generic1 (char * __restrict *buf, size_t * __restrict bufsize,
         break;
       }
       case XS: { /* string */
-        char const * const * const x = deser_generic_src (src, &srcoff, dds_alignof (char *));
+        char const * const * const x = deser_generic_src (src, &srcoff, plist_alignof (char *));
         if (!prtf (buf, bufsize, "%s\"%s\"", sep, *x))
           return false;
         srcoff += sizeof (*x);
         break;
       }
       case XE1: case XE2: case XE3: { /* enum */
-        uint32_t const * const x = deser_generic_src (src, &srcoff, dds_alignof (uint32_t));
+        enum xe3_prototype const * const x = deser_generic_src (src, &srcoff, plist_alignof (enum xe3_prototype));
         if (!prtf (buf, bufsize, "%s%"PRIu32, sep, *x))
           return false;
         srcoff += sizeof (*x);
         break;
       }
       case Xs: {
-        int16_t const * const x = deser_generic_src (src, &srcoff, dds_alignof (int16_t));
+        int16_t const * const x = deser_generic_src (src, &srcoff, plist_alignof (int16_t));
         if (!prtf (buf, bufsize, "%s%"PRId16, sep, *x))
           return false;
         srcoff += sizeof (*x);
         break;
       }
       case Xi: case Xix2: case Xix3: case Xix4: { /* int32_t(s) */
-        int32_t const * const x = deser_generic_src (src, &srcoff, dds_alignof (int32_t));
+        int32_t const * const x = deser_generic_src (src, &srcoff, plist_alignof (int32_t));
         const uint32_t cnt = 1 + (uint32_t) (*desc - Xi);
         for (uint32_t i = 0; i < cnt; i++)
         {
@@ -1774,7 +1802,7 @@ static bool print_generic1 (char * __restrict *buf, size_t * __restrict bufsize,
         break;
       }
       case Xu: case Xux2: case Xux3: case Xux4: case Xux5:  { /* uint32_t(s) */
-        uint32_t const * const x = deser_generic_src (src, &srcoff, dds_alignof (uint32_t));
+        uint32_t const * const x = deser_generic_src (src, &srcoff, plist_alignof (uint32_t));
         const uint32_t cnt = 1 + (uint32_t) (*desc - Xu);
         for (uint32_t i = 0; i < cnt; i++)
         {
@@ -1786,7 +1814,7 @@ static bool print_generic1 (char * __restrict *buf, size_t * __restrict bufsize,
         break;
       }
       case Xl: {
-        int64_t const * const x = deser_generic_src (src, &srcoff, dds_alignof (int64_t));
+        int64_t const * const x = deser_generic_src (src, &srcoff, plist_alignof (int64_t));
         const uint32_t cnt = 1 + (uint32_t) (*desc - Xl);
         for (uint32_t i = 0; i < cnt; i++)
         {
@@ -1798,7 +1826,7 @@ static bool print_generic1 (char * __restrict *buf, size_t * __restrict bufsize,
         break;
       }
       case XD: case XDx2: { /* duration(s): int64_t <=> int32_t.uint32_t (seconds.fraction) */
-        dds_duration_t const * const x = deser_generic_src (src, &srcoff, dds_alignof (dds_duration_t));
+        dds_duration_t const * const x = deser_generic_src (src, &srcoff, plist_alignof (dds_duration_t));
         const uint32_t cnt = 1 + (uint32_t) (*desc - XD);
         for (uint32_t i = 0; i < cnt; i++)
         {
@@ -1810,7 +1838,7 @@ static bool print_generic1 (char * __restrict *buf, size_t * __restrict bufsize,
         break;
       }
       case Xo: case Xox2: { /* octet(s) */
-        unsigned char const * const x = deser_generic_src (src, &srcoff, dds_alignof (unsigned char));
+        unsigned char const * const x = deser_generic_src (src, &srcoff, plist_alignof (unsigned char));
         const uint32_t cnt = 1 + (uint32_t) (*desc - Xo);
         for (uint32_t i = 0; i < cnt; i++)
         {
@@ -1822,7 +1850,7 @@ static bool print_generic1 (char * __restrict *buf, size_t * __restrict bufsize,
         break;
       }
       case Xb: case Xbx2: case Xbx3: case Xbx4: case Xbx5: case XbCOND: { /* boolean(s) */
-        unsigned char const * const x = deser_generic_src (src, &srcoff, dds_alignof (unsigned char));
+        unsigned char const * const x = deser_generic_src (src, &srcoff, plist_alignof (unsigned char));
         const uint32_t cnt = 1 + ((*desc == XbCOND) ? 0 : (uint32_t) (*desc - Xb));
         for (uint32_t i = 0; i < cnt; i++)
         {
@@ -1834,21 +1862,21 @@ static bool print_generic1 (char * __restrict *buf, size_t * __restrict bufsize,
         break;
       }
       case XbPROP: { /* "propagate" boolean: don't serialize, skip it and everything that follows if false */
-        unsigned char const * const x = deser_generic_src (src, &srcoff, dds_alignof (unsigned char));
+        unsigned char const * const x = deser_generic_src (src, &srcoff, plist_alignof (unsigned char));
         if (!prtf (buf, bufsize, "%s%d", sep, *x))
           return false;
         srcoff++;
         break;
       }
       case XG: { /* GUID */
-        ddsi_guid_t const * const x = deser_generic_src (src, &srcoff, dds_alignof (ddsi_guid_t));
+        ddsi_guid_t const * const x = deser_generic_src (src, &srcoff, plist_alignof (ddsi_guid_t));
         if (!prtf (buf, bufsize, "%s{"PGUIDFMT"}", sep, PGUID (*x)))
           return false;
         srcoff += sizeof (*x);
         break;
       }
       case XK: { /* keyhash */
-        ddsi_keyhash_t const * const x = deser_generic_src (src, &srcoff, dds_alignof (ddsi_keyhash_t));
+        ddsi_keyhash_t const * const x = deser_generic_src (src, &srcoff, plist_alignof (ddsi_keyhash_t));
         if (!prtf (buf, bufsize, "%s{%02x%02x%02x%02x:%02x%02x%02x%02x:%02x%02x%02x%02x:%02x%02x%02x%02x}", sep,
                    x->value[0], x->value[1], x->value[2], x->value[3], x->value[4], x->value[5], x->value[6], x->value[7],
                    x->value[8], x->value[9], x->value[10], x->value[11], x->value[12], x->value[13], x->value[14], x->value[15]))
@@ -1857,7 +1885,7 @@ static bool print_generic1 (char * __restrict *buf, size_t * __restrict bufsize,
         break;
       }
       case XQ: {
-        ddsi_octetseq_t const * const x = deser_generic_src (src, &srcoff, dds_alignof (ddsi_octetseq_t));
+        ddsi_octetseq_t const * const x = deser_generic_src (src, &srcoff, plist_alignof (ddsi_octetseq_t));
         if (!prtf (buf, bufsize, "%s{", sep))
           return false;
         if (x->length > 0)

--- a/src/core/ddsi/src/ddsi_udp.c
+++ b/src/core/ddsi/src/ddsi_udp.c
@@ -300,7 +300,7 @@ static dds_return_t set_socket_buffer (struct ddsi_domaingv const * const gv, dd
   dds_return_t rc;
 
   rc = ddsrt_getsockopt (sock, SOL_SOCKET, socket_option, &actsize, &optlen);
-  if (rc == DDS_RETCODE_BAD_PARAMETER)
+  if (rc == DDS_RETCODE_BAD_PARAMETER || rc == DDS_RETCODE_UNSUPPORTED)
   {
     /* not all stacks support getting/setting RCVBUF */
     GVLOG (DDS_LC_CONFIG, "cannot retrieve socket %s buffer size\n", name);

--- a/src/core/ddsi/src/ddsi_vnet.c
+++ b/src/core/ddsi/src/ddsi_vnet.c
@@ -166,7 +166,7 @@ static int ddsi_vnet_enumerate_interfaces (struct ddsi_tran_factory * fact, enum
   (*ifs)->flags = IFF_UP | IFF_MULTICAST;
   (*ifs)->addr = ddsrt_malloc (sizeof (struct sockaddr_storage));
   memset ((*ifs)->addr, 0, sizeof (struct sockaddr_storage));
-  (*ifs)->addr->sa_data[0] = 1;
+  ((char*)(*ifs)->addr)[sizeof (sa_family_t)] = 1;
   (*ifs)->netmask = NULL;
   (*ifs)->broadaddr = NULL;
   return 0;
@@ -191,7 +191,7 @@ static int ddsi_vnet_locator_from_sockaddr (const struct ddsi_tran_factory *tran
   memset (loc, 0, sizeof (*loc));
   loc->kind = fact->m_kind;
   loc->port = 0;
-  memcpy (loc->address, sockaddr->sa_data, sizeof (loc->address));
+  memcpy (loc->address, &((char*)sockaddr)[sizeof (sa_family_t)], sizeof (loc->address));
   return 0;
 }
 

--- a/src/core/ddsi/src/ddsi_vnet.c
+++ b/src/core/ddsi/src/ddsi_vnet.c
@@ -166,7 +166,7 @@ static int ddsi_vnet_enumerate_interfaces (struct ddsi_tran_factory * fact, enum
   (*ifs)->flags = IFF_UP | IFF_MULTICAST;
   (*ifs)->addr = ddsrt_malloc (sizeof (struct sockaddr_storage));
   memset ((*ifs)->addr, 0, sizeof (struct sockaddr_storage));
-  ((char*)(*ifs)->addr)[sizeof (sa_family_t)] = 1;
+  ((char*)(*ifs)->addr)[sizeof ((*ifs)->addr->sa_family)] = 1;
   (*ifs)->netmask = NULL;
   (*ifs)->broadaddr = NULL;
   return 0;
@@ -191,7 +191,7 @@ static int ddsi_vnet_locator_from_sockaddr (const struct ddsi_tran_factory *tran
   memset (loc, 0, sizeof (*loc));
   loc->kind = fact->m_kind;
   loc->port = 0;
-  memcpy (loc->address, &((char*)sockaddr)[sizeof (sa_family_t)], sizeof (loc->address));
+  memcpy (loc->address, &((char*)sockaddr)[sizeof (sockaddr->sa_family)], sizeof (loc->address));
   return 0;
 }
 

--- a/src/core/xtests/CMakeLists.txt
+++ b/src/core/xtests/CMakeLists.txt
@@ -15,6 +15,6 @@ if(BUILD_TESTING AND BUILD_IDLC)
     add_subdirectory(initsampledeliv)
 endif()
 
-if(NOT CMAKE_CROSSCOMPILING)
+if(NOT CMAKE_CROSSCOMPILING AND NOT CMAKE_SYSTEM_NAME MATCHES "iOS")
     add_subdirectory(symbol_export)
 endif()

--- a/src/core/xtests/CMakeLists.txt
+++ b/src/core/xtests/CMakeLists.txt
@@ -15,6 +15,6 @@ if(BUILD_TESTING AND BUILD_IDLC)
     add_subdirectory(initsampledeliv)
 endif()
 
-if(NOT CMAKE_SYSTEM_NAME MATCHES "iOS") 
+if(NOT CMAKE_CROSSCOMPILING)
     add_subdirectory(symbol_export)
 endif()

--- a/src/ddsrt/CMakeLists.txt
+++ b/src/ddsrt/CMakeLists.txt
@@ -148,9 +148,15 @@ else()
     list(APPEND headers
       "${source_dir}/include/dds/ddsrt/sockets/posix.h")
     list(APPEND sources
-      "${source_dir}/src/ifaddrs/posix/ifaddrs.c"
       "${source_dir}/src/sockets/posix/socket.c"
       "${source_dir}/src/sockets/posix/gethostname.c")
+    if(WITH_ZEPHYR)
+      list(APPEND sources
+        "${source_dir}/src/ifaddrs/zephyr/ifaddrs.c")
+    else()
+      list(APPEND sources
+        "${source_dir}/src/ifaddrs/posix/ifaddrs.c")
+    endif()
   endif()
 endif()
 
@@ -194,6 +200,23 @@ if(WITH_FREERTOS)
     list(APPEND sources
       "${source_dir}/src/rusage/freertos/rusage.c")
   endif()
+elseif(WITH_ZEPHYR)
+  set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+  find_package(Threads REQUIRED)
+  target_link_libraries(ddsrt INTERFACE Threads::Threads)
+
+  list(APPEND headers
+    "${source_dir}/include/dds/ddsrt/sync/posix.h"
+    "${source_dir}/include/dds/ddsrt/threads/posix.h"
+    "${source_dir}/include/dds/ddsrt/types/posix.h")
+  list(APPEND sources
+    "${source_dir}/src/environ/zephyr/environ.c"
+    "${source_dir}/src/heap/posix/heap.c"
+    "${source_dir}/src/process/posix/process.c"
+    "${source_dir}/src/random/posix/random.c"
+    "${source_dir}/src/sync/posix/sync.c"
+    "${source_dir}/src/threads/posix/threads.c"
+    "${source_dir}/src/time/posix/time.c")
 else()
   set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
   find_package(Threads REQUIRED)

--- a/src/ddsrt/include/dds/ddsrt/atomics/gcc.h
+++ b/src/ddsrt/include/dds/ddsrt/atomics/gcc.h
@@ -26,6 +26,10 @@ DDSRT_WARNING_CLANG_OFF(old-style-cast)
 # define DDSRT_HAVE_ATOMIC_LIFO 1
 #endif
 
+#if defined(__STRICT_ANSI__)
+#define asm __asm__
+#endif
+
 /* LD, ST */
 
 DDS_INLINE_EXPORT ddsrt_attribute_no_sanitize (("thread"))

--- a/src/ddsrt/include/dds/ddsrt/atomics/gcc.h
+++ b/src/ddsrt/include/dds/ddsrt/atomics/gcc.h
@@ -26,10 +26,6 @@ DDSRT_WARNING_CLANG_OFF(old-style-cast)
 # define DDSRT_HAVE_ATOMIC_LIFO 1
 #endif
 
-#if defined(__STRICT_ANSI__)
-#define asm __asm__
-#endif
-
 /* LD, ST */
 
 DDS_INLINE_EXPORT ddsrt_attribute_no_sanitize (("thread"))
@@ -293,14 +289,14 @@ DDS_INLINE_EXPORT inline void ddsrt_atomic_fence_acq (void) {
 #if !(defined __i386__ || defined __x86_64__ || defined _M_IX86 || defined _M_X64)
   ddsrt_atomic_fence ();
 #else
-  asm volatile ("" ::: "memory");
+  __asm__ volatile ("" ::: "memory");
 #endif
 }
 DDS_INLINE_EXPORT inline void ddsrt_atomic_fence_rel (void) {
 #if !(defined __i386__ || defined __x86_64__ || defined _M_IX86 || defined _M_X64)
   ddsrt_atomic_fence ();
 #else
-  asm volatile ("" ::: "memory");
+  __asm__ volatile ("" ::: "memory");
 #endif
 }
 

--- a/src/ddsrt/include/dds/ddsrt/process.h
+++ b/src/ddsrt/include/dds/ddsrt/process.h
@@ -35,6 +35,10 @@ typedef uint32_t ddsrt_pid_t;
 typedef RTP_ID ddsrt_pid_t; /* typedef struct wind_rtp *RTP_ID */
 #define PRIdPID PRIuPTR
 #define DDSRT_HAVE_MULTI_PROCESS 0
+#elif defined(__ZEPHYR__)
+typedef int ddsrt_pid_t;
+#define PRIdPID "d"
+#define DDSRT_HAVE_MULTI_PROCESS 0
 #else
 typedef pid_t ddsrt_pid_t;
 #define PRIdPID "d"

--- a/src/ddsrt/include/dds/ddsrt/types/posix.h
+++ b/src/ddsrt/include/dds/ddsrt/types/posix.h
@@ -17,7 +17,6 @@
 #if defined(__IAR_SYSTEMS_ICC__)
 typedef long int ssize_t;
 #else
-/* #undef _POSIX_THREADS */
 #include <unistd.h>
 #endif
 

--- a/src/ddsrt/include/dds/ddsrt/types/posix.h
+++ b/src/ddsrt/include/dds/ddsrt/types/posix.h
@@ -17,6 +17,7 @@
 #if defined(__IAR_SYSTEMS_ICC__)
 typedef long int ssize_t;
 #else
+/* #undef _POSIX_THREADS */
 #include <unistd.h>
 #endif
 

--- a/src/ddsrt/src/atomics.c
+++ b/src/ddsrt/src/atomics.c
@@ -170,7 +170,7 @@ void ddsrt_atomics_fini (void) { }
    something else will have to be done. */
 #define N_MUTEXES_LG2 4
 #define N_MUTEXES     (1 << N_MUTEXES_LG2)
-#ifndef PTHREAD_MUTEX_INITIALIZER
+#if !defined(PTHREAD_MUTEX_INITIALIZER) || defined(__ZEPHYR__)
 static ddsrt_mutex_t mutexes[N_MUTEXES];
 
 void ddsrt_atomics_init (void)

--- a/src/ddsrt/src/cdtors.c
+++ b/src/ddsrt/src/cdtors.c
@@ -23,6 +23,8 @@ extern void ddsrt_winsock_init(void);
 extern void ddsrt_winsock_fini(void);
 extern void ddsrt_time_init(void);
 extern void ddsrt_time_fini(void);
+#elif __ZEPHYR__
+extern void ddsrt_thread_stack_init(void);
 #endif
 
 #define INIT_STATUS_OK 0x80000000u
@@ -43,6 +45,8 @@ retry:
 #if _WIN32
     ddsrt_winsock_init();
     ddsrt_time_init();
+#elif __ZEPHYR__
+    ddsrt_thread_stack_init();
 #endif
     ddsrt_random_init();
     ddsrt_atomics_init();

--- a/src/ddsrt/src/cdtors.c
+++ b/src/ddsrt/src/cdtors.c
@@ -23,8 +23,6 @@ extern void ddsrt_winsock_init(void);
 extern void ddsrt_winsock_fini(void);
 extern void ddsrt_time_init(void);
 extern void ddsrt_time_fini(void);
-#elif __ZEPHYR__
-extern void ddsrt_thread_stack_init(void);
 #endif
 
 #define INIT_STATUS_OK 0x80000000u
@@ -45,8 +43,6 @@ retry:
 #if _WIN32
     ddsrt_winsock_init();
     ddsrt_time_init();
-#elif __ZEPHYR__
-    ddsrt_thread_stack_init();
 #endif
     ddsrt_random_init();
     ddsrt_atomics_init();

--- a/src/ddsrt/src/environ/zephyr/environ.c
+++ b/src/ddsrt/src/environ/zephyr/environ.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include <assert.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "dds/ddsrt/environ.h"
+#include "dds/ddsrt/retcode.h"
+
+static int
+isenvvar(const char *name)
+{
+  return (*name == '\0' || strchr(name, '=') != NULL) == 0;
+}
+
+dds_return_t
+ddsrt_getenv(const char *name, const char **value)
+{
+  assert(name != NULL);
+  assert(value != NULL);
+
+  if (!isenvvar(name))
+    return DDS_RETCODE_BAD_PARAMETER;
+  
+  /* TODO */
+
+  return DDS_RETCODE_NOT_FOUND;
+}
+
+dds_return_t
+ddsrt_setenv(const char *name, const char *value)
+{
+  assert(name != NULL);
+  assert(value != NULL);
+
+  if (strlen(value) == 0)
+    return ddsrt_unsetenv(name);
+  if (!isenvvar(name))
+    return DDS_RETCODE_BAD_PARAMETER;
+
+  /* TODO */
+
+  return DDS_RETCODE_OK;
+}
+
+dds_return_t
+ddsrt_unsetenv(const char *name)
+{
+  assert(name != NULL);
+
+  if (!isenvvar(name))
+    return DDS_RETCODE_BAD_PARAMETER;
+  
+  /* TODO */
+  
+  return DDS_RETCODE_OK;
+}

--- a/src/ddsrt/src/environ/zephyr/environ.c
+++ b/src/ddsrt/src/environ/zephyr/environ.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
+ * Copyright(c) 2006 to 2023 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -17,6 +17,8 @@
 #include "dds/ddsrt/environ.h"
 #include "dds/ddsrt/retcode.h"
 
+extern char **environ;
+
 static int
 isenvvar(const char *name)
 {
@@ -26,13 +28,24 @@ isenvvar(const char *name)
 dds_return_t
 ddsrt_getenv(const char *name, const char **value)
 {
+  char **ep;
+  size_t name_len;
+
   assert(name != NULL);
   assert(value != NULL);
 
   if (!isenvvar(name))
     return DDS_RETCODE_BAD_PARAMETER;
   
-  /* TODO */
+  /* poor mans getenv, good enough for CYCLONEDDS_URI */
+  name_len = strlen(name);
+  for (ep = environ; *ep != NULL; ep++)
+  {
+    if (!strncmp(*ep, name, name_len) && (*ep)[name_len] == '=') {
+      *value = *ep + name_len + 1;
+      return DDS_RETCODE_OK;
+    }
+  }
 
   return DDS_RETCODE_NOT_FOUND;
 }

--- a/src/ddsrt/src/ifaddrs/zephyr/ifaddrs.c
+++ b/src/ddsrt/src/ifaddrs/zephyr/ifaddrs.c
@@ -1,0 +1,221 @@
+/*
+ * Copyright(c) 2006 to 2023 ZettaScale Technology and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include <assert.h>
+#include <string.h>
+
+#include <zephyr/net/net_if.h>
+
+#include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/io.h"
+#include "dds/ddsrt/ifaddrs.h"
+#include "dds/ddsrt/retcode.h"
+#include "dds/ddsrt/string.h"
+
+extern const int *const os_supp_afs;
+
+struct ifaddrs_data {
+  ddsrt_ifaddrs_t *first;
+  ddsrt_ifaddrs_t *prev;
+  int getv4;
+  int getv6;
+  dds_return_t rc;
+};
+
+static uint32_t
+getflags(
+  struct net_if *iface)
+{
+  uint32_t flags = 0;
+
+  if (net_if_is_up(iface)) {
+    flags |= IFF_UP;
+  }
+  if (net_if_flag_is_set(iface, NET_IF_POINTOPOINT)) {
+    flags |= IFF_POINTOPOINT;
+  }
+  flags |= IFF_BROADCAST;
+  flags |= IFF_MULTICAST;
+
+#if defined(CONFIG_NET_LOOPBACK)
+  if (net_if_l2(iface) == &NET_L2_GET_NAME(DUMMY)) {
+    flags |= IFF_LOOPBACK;
+  }
+#endif
+
+  return flags;
+}
+
+static void netif_callback(struct net_if *iface, void *cb_data)
+{
+  ddsrt_ifaddrs_t *ifa;
+  struct ifaddrs_data *data = (struct ifaddrs_data*)cb_data;
+
+
+  if ((data->rc != DDS_RETCODE_OK)
+#if defined(CONFIG_NET_L2_ETHERNET) && defined(CONFIG_NET_L2_DUMMY)
+    || ((net_if_l2(iface) != &NET_L2_GET_NAME(ETHERNET)) && (net_if_l2(iface) != &NET_L2_GET_NAME(DUMMY)))
+#elif defined(CONFIG_NET_L2_ETHERNET)
+    || (net_if_l2(iface) != &NET_L2_GET_NAME(ETHERNET))
+#elif defined(CONFIG_NET_L2_DUMMY)
+    || (net_if_l2(iface) != &NET_L2_GET_NAME(DUMMY))
+#endif
+    ) {
+    /* Skip on previous error or unsupported interface type */
+    return;
+  }
+
+  if (data->getv4 && iface->config.ip.ipv4) {
+    struct net_if_ipv4 *cfg = iface->config.ip.ipv4;
+    struct net_if_addr *addr = NULL;
+    int i;
+    for (i = 0; i < NET_IF_MAX_IPV4_ADDR && !addr; i++) {
+      if (cfg->unicast[i].is_used &&
+          cfg->unicast[i].addr_state == NET_ADDR_PREFERRED &&
+          cfg->unicast[i].address.family == AF_INET) {
+        addr = &cfg->unicast[i];
+      }
+    }
+
+    ifa = ddsrt_calloc_s(1, sizeof(ddsrt_ifaddrs_t));
+    if (!ifa) {
+      data->rc = DDS_RETCODE_OUT_OF_RESOURCES;
+    } else {
+      ifa->name = ddsrt_strdup(iface->if_dev->dev->name);
+      if (addr) {
+        ifa->addr = ddsrt_calloc_s(1, sizeof(struct sockaddr_in));
+        ifa->netmask = ddsrt_calloc_s(1, sizeof(struct sockaddr_in));
+        ifa->broadaddr = ddsrt_calloc_s(1, sizeof(struct sockaddr_in));
+      }
+      if (!ifa->name || (addr && (!ifa->addr || !ifa->netmask || !ifa->broadaddr))) {
+        data->rc = DDS_RETCODE_OUT_OF_RESOURCES;
+      } else {
+        ifa->type = DDSRT_IFTYPE_UNKNOWN;
+        ifa->flags = getflags(iface);
+        ifa->index = net_if_get_by_iface(iface);
+
+        if (addr) {
+          net_ipaddr_copy(&(net_sin(ifa->addr)->sin_addr), &(addr->address.in_addr));
+          ifa->addr->sa_family = AF_INET;
+
+          net_ipaddr_copy(&(net_sin(ifa->netmask)->sin_addr), &(cfg->netmask));
+          ifa->netmask->sa_family = AF_INET;
+
+          ((struct sockaddr_in*)ifa->broadaddr)->sin_addr.s_addr = (net_sin(ifa->addr)->sin_addr.s_addr & net_sin(ifa->netmask)->sin_addr.s_addr) | ~net_sin(ifa->netmask)->sin_addr.s_addr;
+          ifa->broadaddr->sa_family = AF_INET;
+        }
+      }
+    }
+
+    if (data->rc == DDS_RETCODE_OK) {
+      if (data->prev) {
+        data->prev->next = ifa;
+      } else {
+        data->first = ifa;
+      }
+      data->prev = ifa;
+    } else {
+      ddsrt_freeifaddrs(ifa);
+    }
+  }
+
+#if DDSRT_HAVE_IPV6
+  if (data->getv6 && iface->config.ip.ipv6) {
+    struct net_if_ipv6 *cfg = iface->config.ip.ipv6;
+    struct net_if_addr *addr = NULL;
+    int i;
+    for (i = 0; i < NET_IF_MAX_IPV6_ADDR; i++) {
+      if (cfg->unicast[i].is_used &&
+          cfg->unicast[i].addr_state == NET_ADDR_PREFERRED &&
+          cfg->unicast[i].address.family == AF_INET6 &&
+          !net_ipv6_is_ll_addr(&cfg->unicast[i].address.in6_addr)) {
+        addr = &cfg->unicast[i];
+      }
+    }
+
+    ifa = ddsrt_calloc_s(1, sizeof(ddsrt_ifaddrs_t));
+    if (!ifa) {
+      data->rc = DDS_RETCODE_OUT_OF_RESOURCES;
+    } else {
+      ifa->name = ddsrt_strdup(iface->if_dev->dev->name);
+      if (addr) {
+        ifa->addr = ddsrt_calloc_s(1, sizeof(struct sockaddr_in6));
+      }
+      if (!ifa->name || (addr && (!ifa->addr))) {
+        data->rc = DDS_RETCODE_OUT_OF_RESOURCES;
+      } else {
+        ifa->type = DDSRT_IFTYPE_UNKNOWN;
+        ifa->flags = getflags(iface);
+        ifa->index = net_if_get_by_iface(iface);
+
+        if (addr) {
+          net_ipaddr_copy(&(net_sin6(ifa->addr)->sin6_addr), &(addr->address.in6_addr));
+          ifa->addr->sa_family = AF_INET6;
+        }
+      }
+    }
+
+    if (data->rc == DDS_RETCODE_OK) {
+      if (data->prev) {
+        data->prev->next = ifa;
+      } else {
+        data->first = ifa;
+      }
+      data->prev = ifa;
+    } else {
+      ddsrt_freeifaddrs(ifa);
+    }
+  }
+#endif
+
+  return;
+}
+
+dds_return_t
+ddsrt_getifaddrs(
+  ddsrt_ifaddrs_t **ifap,
+  const int *afs)
+{
+  struct ifaddrs_data data;
+
+  assert(ifap != NULL);
+
+  data.first = NULL;
+  data.prev = NULL;
+  data.rc = DDS_RETCODE_OK;
+  data.getv4 = 0;
+  data.getv6 = 0;
+
+  if (afs == NULL) {
+    afs = os_supp_afs;
+  }
+
+  for (int i = 0; afs[i] != DDSRT_AF_TERM; i++) {
+    if (afs[i] == AF_INET) {
+      data.getv4 = 1;
+    }
+#if DDSRT_HAVE_IPV6
+    else if (afs[i] == AF_INET6) {
+      data.getv6 = 1;
+    }
+#endif
+  }
+
+  (void)net_if_foreach(netif_callback, &data);
+
+  if (data.rc == DDS_RETCODE_OK) {
+    *ifap = data.first;
+  } else {
+    ddsrt_freeifaddrs(data.first);
+  }
+  
+  return data.rc;
+}

--- a/src/ddsrt/src/process/posix/process.c
+++ b/src/ddsrt/src/process/posix/process.c
@@ -29,7 +29,7 @@ ddsrt_getpid(void)
   return getpid();
 }
 
-#if (defined(__APPLE__) || defined(__FreeBSD__) || defined(_GNU_SOURCE))
+#if (defined(__APPLE__) || defined(__FreeBSD__) || defined(_GNU_SOURCE) || defined(__ZEPHYR__))
   // _basename not needed
 #else
 static const char *_basename(char const *path)
@@ -46,6 +46,8 @@ ddsrt_getprocessname(void)
   const char * appname = getprogname();
 #elif defined(_GNU_SOURCE)
   const char * appname = program_invocation_name;
+#elif defined(__ZEPHYR__)
+  const char * appname = NULL; /* CONFIG_KERNEL_BIN_NAME? */
 #else
   const char * appname = NULL;
 

--- a/src/ddsrt/src/sockets.c
+++ b/src/ddsrt/src/sockets.c
@@ -436,7 +436,7 @@ ddsrt_setsockreuse(ddsrt_socket_t sock, bool reuse)
   switch (rc)
   {
     case DDS_RETCODE_UNSUPPORTED:
-      // e.g. LWIP, which defines SO_REUSEPORT but doesn't implement it.
+      // e.g. LWIP or Zephyr, which defines SO_REUSEPORT but doesn't implement it.
       //      note that we ignore this error because some systems use SO_REUSEADDR instead
     case DDS_RETCODE_OK:
       break;

--- a/src/ddsrt/src/sockets/posix/socket.c
+++ b/src/ddsrt/src/sockets/posix/socket.c
@@ -37,6 +37,10 @@
 #endif /* __APPLE__ || __FreeBSD__ */
 #endif /* LWIP_SOCKET */
 
+#if defined(__ZEPHYR__) && defined(CONFIG_NET_IPV4_IGMP)
+#include <zephyr/net/igmp.h>
+#endif
+
 dds_return_t
 ddsrt_socket(ddsrt_socket_t *sockptr, int domain, int type, int protocol)
 {
@@ -256,6 +260,14 @@ ddsrt_getsockopt(
   void *optval,
   socklen_t *optlen)
 {
+#if defined(__ZEPHYR__)
+  if (optname == IP_ADD_MEMBERSHIP || optname == IP_DROP_MEMBERSHIP)
+  {
+    /* note ddsrt_getsockopt never called with this optname */
+    return DDS_RETCODE_UNSUPPORTED;
+  }
+#endif
+
   if (getsockopt(sock, level, optname, optval, optlen) == 0)
     return DDS_RETCODE_OK;
 
@@ -294,6 +306,97 @@ ddsrt_setsockopt(
       /* SO_DONTROUTE causes problems on macOS (e.g. no multicasting). */
       return DDS_RETCODE_OK;
   }
+
+#if defined(__ZEPHYR__)
+  switch (optname) {
+#if defined(DDSRT_USE_IPV6)
+    case IPV6_MULTICAST_IF:
+    case IPV6_MULTICAST_HOPS:
+    case IPV6_MULTICAST_LOOP:
+    case IPV6_UNICAST_HOPS:
+      /* ignored */
+      return DDS_RETCODE_OK;
+    case IPV6_JOIN_GROUP:
+    case IPV6_LEAVE_GROUP:
+    {
+      struct net_if *iface = NULL;
+      struct ipv6_mreq *mreq = (struct ipv6_mreq*)optval;
+      struct net_if_mcast_addr *maddr;
+      assert(level == IPPROTO_IPV6);
+      iface = net_if_get_by_index(&(mreq->ipv6mr_interface));
+      if (iface) {
+        maddr = net_if_ipv6_maddr_lookup(&(mreq->ipv6mr_multiaddr), &iface);
+        if (optname == IPV6_JOIN_GROUP) {
+          if (maddr) {
+            /* already joined */
+            return DDS_RETCODE_ERROR;
+          } else {
+            maddr = net_if_ipv6_maddr_add(iface, &(mreq->ipv6mr_multiaddr));
+            if (maddr) {
+              net_if_ipv6_maddr_join(maddr);
+              return DDS_RETCODE_OK;
+            }
+          }
+        } else if (optname == IPV6_LEAVE_GROUP) {
+          if (maddr) {
+            if (net_if_ipv6_maddr_rm(iface, &(mreq->ipv6mr_multiaddr))) {
+              net_if_ipv6_maddr_leave(maddr);
+              return DDS_RETCODE_OK;
+            }
+          }
+        }
+      }
+      return DDS_RETCODE_ERROR;
+    }
+#endif /* DDSRT_USE_IPV6 */
+    case IP_MULTICAST_IF:
+    case IP_MULTICAST_TTL:
+    case IP_MULTICAST_LOOP:
+      /* ignored */
+      return DDS_RETCODE_OK;
+    case IP_ADD_MEMBERSHIP:
+    case IP_DROP_MEMBERSHIP:
+    {
+      struct net_if *iface = NULL;
+      struct ip_mreq *mreq = (struct ip_mreq*)optval;
+      struct net_if_mcast_addr *maddr;
+      assert(level == IPPROTO_IP);
+      if (net_if_ipv4_addr_lookup(&(mreq->imr_interface), &iface)) {
+#if defined(CONFIG_NET_IPV4_IGMP)
+        int rc = -1;
+        if (optname == IP_ADD_MEMBERSHIP) {
+          rc = net_ipv4_igmp_join(iface, &(mreq->imr_multiaddr));
+        } else {
+          rc = net_ipv4_igmp_leave(iface, &(mreq->imr_multiaddr));
+        }
+        return (rc < 0) ? DDS_RETCODE_ERROR : DDS_RETCODE_OK;
+#else
+        maddr = net_if_ipv4_maddr_lookup(&(mreq->imr_multiaddr), &iface);
+        if (optname == IP_ADD_MEMBERSHIP) {
+          if (maddr && maddr->is_used) {
+            /* already joined */
+            return DDS_RETCODE_ERROR;
+          } else {
+            maddr = net_if_ipv4_maddr_add(iface, &(mreq->imr_multiaddr));
+            if (maddr) {
+              net_if_ipv4_maddr_join(maddr);
+              return DDS_RETCODE_OK;
+            }
+          }
+        } else if (optname == IP_DROP_MEMBERSHIP) {
+          if (maddr) {  
+            if (net_if_ipv4_maddr_rm(iface, &(mreq->imr_multiaddr))) {
+              net_if_ipv4_maddr_leave(maddr);
+              return DDS_RETCODE_OK;
+            }
+          }
+        }
+#endif /* CONFIG_NET_IPV4_IGMP */
+      }
+      return DDS_RETCODE_ERROR;
+    }
+  }
+#endif /* __ZEPHYR__ */
 
   if (setsockopt(sock, level, optname, optval, optlen) == 0)
     return DDS_RETCODE_OK;
@@ -398,7 +501,7 @@ ddsrt_recv(
   return recv_error_to_retcode(errno);
 }
 
-#if LWIP_SOCKET && !defined(recvmsg)
+#if (LWIP_SOCKET && !defined(recvmsg)) || defined(__ZEPHYR__)
 static ssize_t recvmsg(int sockfd, struct msghdr *msg, int flags)
 {
   assert(msg->msg_iovlen == 1);

--- a/src/ddsrt/src/sockets/posix/socket.c
+++ b/src/ddsrt/src/sockets/posix/socket.c
@@ -309,7 +309,7 @@ ddsrt_setsockopt(
 
 #if defined(__ZEPHYR__)
   switch (optname) {
-#if defined(DDSRT_USE_IPV6)
+#if defined(DDSRT_HAVE_IPV6)
     case IPV6_MULTICAST_IF:
     case IPV6_MULTICAST_HOPS:
     case IPV6_MULTICAST_LOOP:
@@ -323,7 +323,7 @@ ddsrt_setsockopt(
       struct ipv6_mreq *mreq = (struct ipv6_mreq*)optval;
       struct net_if_mcast_addr *maddr;
       assert(level == IPPROTO_IPV6);
-      iface = net_if_get_by_index(&(mreq->ipv6mr_interface));
+      iface = net_if_get_by_index(mreq->ipv6mr_interface);
       if (iface) {
         maddr = net_if_ipv6_maddr_lookup(&(mreq->ipv6mr_multiaddr), &iface);
         if (optname == IPV6_JOIN_GROUP) {
@@ -334,6 +334,7 @@ ddsrt_setsockopt(
             maddr = net_if_ipv6_maddr_add(iface, &(mreq->ipv6mr_multiaddr));
             if (maddr) {
               net_if_ipv6_maddr_join(maddr);
+              net_if_mcast_monitor(iface, &(maddr->address), true);
               return DDS_RETCODE_OK;
             }
           }
@@ -341,6 +342,7 @@ ddsrt_setsockopt(
           if (maddr) {
             if (net_if_ipv6_maddr_rm(iface, &(mreq->ipv6mr_multiaddr))) {
               net_if_ipv6_maddr_leave(maddr);
+              net_if_mcast_monitor(iface, &(maddr->address), false);
               return DDS_RETCODE_OK;
             }
           }
@@ -348,7 +350,7 @@ ddsrt_setsockopt(
       }
       return DDS_RETCODE_ERROR;
     }
-#endif /* DDSRT_USE_IPV6 */
+#endif /* DDSRT_HAVE_IPV6 */
     case IP_MULTICAST_IF:
     case IP_MULTICAST_TTL:
     case IP_MULTICAST_LOOP:
@@ -380,6 +382,7 @@ ddsrt_setsockopt(
             maddr = net_if_ipv4_maddr_add(iface, &(mreq->imr_multiaddr));
             if (maddr) {
               net_if_ipv4_maddr_join(maddr);
+              net_if_mcast_monitor(iface, &(maddr->address), true);
               return DDS_RETCODE_OK;
             }
           }
@@ -387,6 +390,7 @@ ddsrt_setsockopt(
           if (maddr) {  
             if (net_if_ipv4_maddr_rm(iface, &(mreq->imr_multiaddr))) {
               net_if_ipv4_maddr_leave(maddr);
+              net_if_mcast_monitor(iface, &(maddr->address), false);
               return DDS_RETCODE_OK;
             }
           }

--- a/src/ddsrt/src/threads/posix/threads.c
+++ b/src/ddsrt/src/threads/posix/threads.c
@@ -240,14 +240,9 @@ static void *os_startRoutineWrapper (void *threadContext)
 #error "CONFIG_MAX_PTHREAD_COUNT is insufficient to run CycloneDDS"
 #endif
 
-static int currThrIdx;
+static int currThrIdx = 0;
 K_THREAD_STACK_ARRAY_DEFINE(zephyr_stacks, CYCLONEDDS_THREAD_COUNT, CYCLONEDDS_THREAD_STACK_SIZE);
 
-void
-ddsrt_thread_stack_init (void)
-{
-  currThrIdx = 0;
-}
 #endif
 
 dds_return_t

--- a/src/tools/ddsperf/ddsperf.c
+++ b/src/tools/ddsperf/ddsperf.c
@@ -476,8 +476,10 @@ static void hist_print (const char *prefix, struct hist *h, dds_time_t dt, int r
   uint64_t peak = 0, cnt = h->under + h->over;
   size_t p = 0;
 
+  assert(l);
   xsnprintf (l, l_size, &p, "%s", prefix);
 
+  assert(hist);
   hist[h->nbins] = 0;
   for (unsigned i = 0; i < h->nbins; i++)
   {
@@ -760,6 +762,7 @@ static void latencystat_init (struct latencystat *x)
   x->max = INT64_MIN;
   x->sum = x->cnt = 0;
   x->raw = malloc (PINGPONG_RAWSIZE * sizeof (*x->raw));
+  assert(x->raw);
 }
 
 static void latencystat_fini (struct latencystat *x)
@@ -1585,6 +1588,7 @@ static bool print_stats (dds_time_t tref, dds_time_t tnow, dds_time_t tprev, str
   }
 
   int64_t *newraw = malloc (PINGPONG_RAWSIZE * sizeof (*newraw));
+  assert(newraw);
   if (submode != SM_NONE)
   {
     struct eseq_admin * const ea = &eseq_admin;
@@ -1729,7 +1733,7 @@ static void subthread_arg_fini (struct subthread_arg *arg)
   free (arg->iseq);
 }
 
-#if !DDSRT_WITH_FREERTOS
+#if !DDSRT_WITH_FREERTOS && !__ZEPHYR__
 static void signal_handler (int sig)
 {
   (void) sig;
@@ -1738,7 +1742,7 @@ static void signal_handler (int sig)
 }
 #endif
 
-#if !_WIN32 && !DDSRT_WITH_FREERTOS
+#if !_WIN32 && !DDSRT_WITH_FREERTOS && !__ZEPHYR__
 static uint32_t sigthread (void *varg)
 {
   sigset_t *set = varg;
@@ -2121,7 +2125,7 @@ int main (int argc, char *argv[])
   dds_time_t tref = DDS_INFINITY;
   ddsrt_threadattr_t attr;
   ddsrt_thread_t pubtid, subtid, subpingtid, subpongtid;
-#if !_WIN32 && !DDSRT_WITH_FREERTOS
+#if !_WIN32 && !DDSRT_WITH_FREERTOS && !__ZEPHYR__
   sigset_t sigset, osigset;
   ddsrt_thread_t sigtid;
 #endif
@@ -2522,7 +2526,7 @@ int main (int argc, char *argv[])
   /* I hate Unix signals in multi-threaded processes ... */
 #ifdef _WIN32
   signal (SIGINT, signal_handler);
-#elif !DDSRT_WITH_FREERTOS
+#elif !DDSRT_WITH_FREERTOS && !__ZEPHYR__
   sigemptyset (&sigset);
 #ifdef __APPLE__
   DDSRT_WARNING_GNUC_OFF(sign-conversion)
@@ -2647,7 +2651,7 @@ int main (int argc, char *argv[])
 
 #if _WIN32
   signal_handler (SIGINT);
-#elif !DDSRT_WITH_FREERTOS
+#elif !DDSRT_WITH_FREERTOS && !__ZEPHYR__
   {
     /* get the attention of the signal handler thread */
     void (*osigint) (int);


### PR DESCRIPTION
This PR adds basic support for running CycloneDDS on [Zephyr RTOS](https://www.zephyrproject.org). 

It was validated on Zephyr targets `qemu_x86`, `qemu_cortex_a53` (emulators) and `s32z270dc2_rtu0_r52` (physical board), using the CycloneDDS examples and ddsperf tool. Supporting code and usage examples are still in my personal repository  [here](https://github.com/PatrickM-ZS/dds_hello_world) but I intend to clean that up and merge it (into the ports directory) in a future PR.