### PR TITLE
Const serialized meta-data in topic descriptor

### DIFF
--- a/src/core/ddsc/include/dds/ddsc/dds_public_impl.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_public_impl.h
@@ -86,7 +86,7 @@ dds_key_descriptor_t;
  */
 struct dds_type_meta_ser
 {
-  unsigned char * data;  /**< data pointer */
+  const unsigned char * data;  /**< data pointer */
   uint32_t sz;  /**< data size */
 };
 

--- a/src/core/ddsc/tests/test_common.c
+++ b/src/core/ddsc/tests/test_common.c
@@ -95,7 +95,7 @@ void xcdr2_ser (const void *obj, const dds_topic_descriptor_t *topic_desc, dds_o
   CU_ASSERT_FATAL (ret);
 }
 
-void xcdr2_deser (unsigned char *buf, uint32_t sz, void **obj, const dds_topic_descriptor_t *desc)
+void xcdr2_deser (const unsigned char *buf, uint32_t sz, void **obj, const dds_topic_descriptor_t *desc)
 {
   unsigned char *data;
   uint32_t srcoff = 0;
@@ -110,7 +110,7 @@ void xcdr2_deser (unsigned char *buf, uint32_t sz, void **obj, const dds_topic_d
     CU_ASSERT_NOT_EQUAL_FATAL (ret, NULL);
   }
   else
-    data = buf;
+    data = (void *) buf;
 
   dds_istream_t is = { .m_buffer = data, .m_index = 0, .m_size = sz, .m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2 };
   *obj = ddsrt_calloc (1, desc->m_size);

--- a/src/core/ddsc/tests/test_common.h
+++ b/src/core/ddsc/tests/test_common.h
@@ -26,6 +26,6 @@
 #include "RoundTrip.h"
 
 void xcdr2_ser (const void *obj, const dds_topic_descriptor_t *desc, dds_ostream_t *os);
-void xcdr2_deser (unsigned char *buf, uint32_t sz, void **obj, const dds_topic_descriptor_t *desc);
+void xcdr2_deser (const unsigned char *buf, uint32_t sz, void **obj, const dds_topic_descriptor_t *desc);
 
 #endif /* _TEST_COMMON_H_ */

--- a/src/core/ddsc/tests/xtypes.c
+++ b/src/core/ddsc/tests/xtypes.c
@@ -653,7 +653,7 @@ CU_Test (ddsc_xtypes, invalid_top_level_local_hash, .init = xtypes_init, .fini =
 
     ddsi_typeinfo_fini ((ddsi_typeinfo_t *) ti);
     ddsrt_free (ti);
-    ddsrt_free (desc.type_information.data);
+    ddsrt_free ((void *) desc.type_information.data);
   }
 }
 
@@ -679,7 +679,7 @@ CU_Test (ddsc_xtypes, invalid_top_level_local_non_hash, .init = xtypes_init, .fi
 
   ddsi_typeinfo_fini ((ddsi_typeinfo_t *) ti);
   ddsrt_free (ti);
-  ddsrt_free (desc.type_information.data);
+  ddsrt_free ((void *) desc.type_information.data);
 }
 
 static void mod_toplevel (dds_sequence_DDS_XTypes_TypeIdentifierTypeObjectPair *type_id_obj_seq, uint32_t kind)
@@ -835,8 +835,8 @@ CU_Theory ((const char *test_descr, const dds_topic_descriptor_t *topic_desc, ty
   CU_ASSERT_FATAL (topic < 0);
 
   if (matching_typeinfo)
-    ddsrt_free (desc.type_information.data);
-  ddsrt_free (desc.type_mapping.data);
+    ddsrt_free ((void *) desc.type_information.data);
+  ddsrt_free ((void *) desc.type_mapping.data);
 }
 
 /* Invalid hashed type (with valid hash type id) as top-level type for proxy endpoint */
@@ -936,8 +936,8 @@ CU_Theory ((const char *test_descr, const dds_topic_descriptor_t *topic_desc, ty
   ddsrt_free (ti);
   ddsi_typemap_fini ((ddsi_typemap_t *) tmap);
   ddsrt_free (tmap);
-  ddsrt_free (desc.type_information.data);
-  ddsrt_free (desc.type_mapping.data);
+  ddsrt_free ((void *) desc.type_information.data);
+  ddsrt_free ((void *) desc.type_mapping.data);
 }
 
 static void mod_dep_test (dds_sequence_DDS_XTypes_TypeIdentifierTypeObjectPair *type_id_obj_seq, uint32_t kind)
@@ -1038,8 +1038,8 @@ CU_Test (ddsc_xtypes, resolve_dep_type, .init = xtypes_init, .fini = xtypes_fini
   ddsrt_free (ti);
   ddsi_typemap_fini ((ddsi_typemap_t *) tmap);
   ddsrt_free (tmap);
-  ddsrt_free (desc.type_information.data);
-  ddsrt_free (desc.type_mapping.data);
+  ddsrt_free ((void *) desc.type_information.data);
+  ddsrt_free ((void *) desc.type_mapping.data);
 }
 
 CU_Test (ddsc_xtypes, get_type_info, .init = xtypes_init, .fini = xtypes_fini)

--- a/src/core/ddsi/src/ddsi_typebuilder.c
+++ b/src/core/ddsi/src/ddsi_typebuilder.c
@@ -1817,8 +1817,8 @@ static dds_return_t get_topic_descriptor (dds_topic_descriptor_t *desc, struct t
   if (d.m_typename == NULL)
   {
     ddsrt_free ((void *) d.m_typename);
-    ddsrt_free (d.type_information.data);
-    ddsrt_free (d.type_mapping.data);
+    ddsrt_free ((void *) d.type_information.data);
+    ddsrt_free ((void *) d.type_mapping.data);
     ret = DDS_RETCODE_OUT_OF_RESOURCES;
     goto err;
   }

--- a/src/tools/idlc/src/descriptor_type_meta.c
+++ b/src/tools/idlc/src/descriptor_type_meta.c
@@ -1531,7 +1531,7 @@ print_ser_data(FILE *fp, const char *kind, const char *type, unsigned char *data
 {
   char *sep = ", ", *lsep = "\\\n  ", *fmt;
 
-  fmt = "#define %1$s_%2$s (unsigned char []){ ";
+  fmt = "#define %1$s_%2$s (const unsigned char []){ ";
   if (idl_fprintf(fp, fmt, kind, type) < 0)
     return IDL_RETCODE_NO_MEMORY;
 


### PR DESCRIPTION
This makes the serialized type information and type mapping `const` in the topic descriptor