### PR TITLE
Fix for using string types in dynamic type API

### DIFF
--- a/examples/dyntype/dyntype.c
+++ b/examples/dyntype/dyntype.c
@@ -91,6 +91,14 @@ int main (int argc, char ** argv)
       .name = "dynamic_alias"
   });
 
+  // String types
+  dds_dynamic_type_t dstring = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_STRING8 });
+  dds_dynamic_type_t dstring_bounded = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) {
+    .kind = DDS_DYNAMIC_STRING8,
+    .bounds = (uint32_t[]) { 100 },
+    .num_bounds = 1
+  });
+
   dds_dynamic_type_t dstruct = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_STRUCTURE, .name = "dynamic_struct" });
   dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER_PRIM(DDS_DYNAMIC_INT32, "member_int32"));
   dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER_ID_PRIM(DDS_DYNAMIC_FLOAT64, "member_float64", 10 /* has specific member id */));
@@ -103,6 +111,8 @@ int main (int argc, char ** argv)
   dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER(denum, "member_enum"));
   dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER(dbitmask, "member_bitmask"));
   dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER(dalias, "member_alias"));
+  dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER(dstring, "member_string8"));
+  dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER(dstring_bounded, "member_string8_bounded"));
 
   // Add members at specific index
   dds_dynamic_type_add_member (&dstruct, (dds_dynamic_member_descriptor_t) {

--- a/src/core/ddsi/include/dds/ddsi/ddsi_dynamic_type.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_dynamic_type.h
@@ -73,7 +73,7 @@ dds_return_t ddsi_dynamic_type_create_bitmask (struct ddsi_domaingv *gv, struct 
 dds_return_t ddsi_dynamic_type_create_alias (struct ddsi_domaingv *gv, struct ddsi_type **type, const char *type_name, struct ddsi_type **aliased_type);
 
 /** @component dynamic_type_support */
-dds_return_t ddsi_dynamic_type_create_string (struct ddsi_domaingv *gv, struct ddsi_type **type);
+dds_return_t ddsi_dynamic_type_create_string8 (struct ddsi_domaingv *gv, struct ddsi_type **type, uint32_t bound);
 
 /** @component dynamic_type_support */
 dds_return_t ddsi_dynamic_type_create_primitive (struct ddsi_domaingv *gv, struct ddsi_type **type, dds_dynamic_type_kind_t kind);

--- a/src/core/ddsi/src/ddsi_dynamic_type.c
+++ b/src/core/ddsi/src/ddsi_dynamic_type.c
@@ -27,8 +27,6 @@ static dds_return_t dynamic_type_ref_deps (struct ddsi_type *type)
   dds_return_t ret = DDS_RETCODE_OK;
   switch (type->xt._d)
   {
-    case DDS_XTypes_TK_STRING8:
-      break;
     case DDS_XTypes_TK_SEQUENCE:
       if ((ret = ddsi_type_register_dep (type->gv, &type->xt.id, &type->xt._u.seq.c.element_type, &type->xt._u.seq.c.element_type->xt.id.x)) != DDS_RETCODE_OK)
         goto err;
@@ -62,6 +60,9 @@ static dds_return_t dynamic_type_ref_deps (struct ddsi_type *type)
           goto err;
         ddsi_type_unref_locked (type->gv, type->xt._u.union_type.members.seq[m].type);
       }
+      break;
+    default:
+      // other types don't have dependencies
       break;
   }
 err:
@@ -241,11 +242,12 @@ dds_return_t ddsi_dynamic_type_create_alias (struct ddsi_domaingv *gv, struct dd
   return DDS_RETCODE_OK;
 }
 
-dds_return_t ddsi_dynamic_type_create_string (struct ddsi_domaingv *gv, struct ddsi_type **type)
+dds_return_t ddsi_dynamic_type_create_string8 (struct ddsi_domaingv *gv, struct ddsi_type **type, uint32_t bound)
 {
   if ((*type = ddsrt_calloc (1, sizeof (**type))) == NULL)
     return DDS_RETCODE_OUT_OF_RESOURCES;
   dynamic_type_init (gv, *type, DDS_XTypes_TK_STRING8, DDSI_TYPEID_KIND_FULLY_DESCRIPTIVE);
+  (*type)->xt._u.str8.bound = bound;
   return DDS_RETCODE_OK;
 }
 

--- a/src/core/ddsi/src/ddsi_typewrap.c
+++ b/src/core/ddsi/src/ddsi_typewrap.c
@@ -2742,10 +2742,29 @@ static void ddsi_xt_get_non_hash_id (const struct xt_type *xt, struct DDS_XTypes
     switch (xt->_d)
     {
       case DDS_XTypes_TK_STRING8:
-      case DDS_XTypes_TK_STRING16:
-        ddsi_typeid_copy_to_impl (ti, &xt->id);
+        if (xt->_u.str8.bound <= 255)
+        {
+          ti->_d = DDS_XTypes_TI_STRING8_SMALL;
+          ti->_u.string_sdefn.bound = (DDS_XTypes_SBound) xt->_u.str8.bound;
+        }
+        else
+        {
+          ti->_d = DDS_XTypes_TI_STRING8_LARGE;
+          ti->_u.string_ldefn.bound = xt->_u.str8.bound;
+        }
         break;
-
+      case DDS_XTypes_TK_STRING16:
+        if (xt->_u.str16.bound <= 255)
+        {
+          ti->_d = DDS_XTypes_TI_STRING16_SMALL;
+          ti->_u.string_sdefn.bound = (DDS_XTypes_SBound) xt->_u.str16.bound;
+        }
+        else
+        {
+          ti->_d = DDS_XTypes_TI_STRING16_LARGE;
+          ti->_u.string_ldefn.bound = xt->_u.str16.bound;
+        }
+        break;
       case DDS_XTypes_TK_SEQUENCE:
         if (xt->_u.seq.bound <= 255)
         {


### PR DESCRIPTION
Fixes a bug in the XTypes wrapper that prevented creating dynamic aggregated types with string members. This also adds support for string bounds, and includes some minor code improvements.