### PR TITLE
Set default flag in type object for enum literal

### DIFF
--- a/src/tools/idlc/src/descriptor_type_meta.c
+++ b/src/tools/idlc/src/descriptor_type_meta.c
@@ -546,6 +546,15 @@ get_enum_flags(const idl_enum_t *_enum)
   return flags;
 }
 
+static DDS_XTypes_EnumeratedLiteralFlag
+get_enum_literal_flags(const idl_enum_t *_enum, const idl_enumerator_t *_enumerator)
+{
+  DDS_XTypes_EnumeratedLiteralFlag flags = 0u;
+  if (_enum->default_enumerator == _enumerator)
+    flags |= DDS_XTypes_IS_DEFAULT;
+  return flags;
+}
+
 static idl_retcode_t
 get_typeid(
   const idl_pstate_t *pstate,
@@ -1323,6 +1332,7 @@ emit_enumerator (
   struct type_meta *tm = dtm->stack;
 
   assert (idl_is_enum (idl_parent (node)));
+  idl_enum_t *_enum = (idl_enum_t *) idl_parent (node);
   assert (tm->to_minimal->_u.minimal._d == DDS_XTypes_TK_ENUM && tm->to_complete->_u.complete._d == DDS_XTypes_TK_ENUM);
 
   DDS_XTypes_MinimalEnumeratedLiteral m;
@@ -1334,6 +1344,7 @@ emit_enumerator (
   assert (enumerator->value.value <= INT32_MAX);
   m.common.value = c.common.value = (int32_t) enumerator->value.value;
   get_namehash (m.detail.name_hash, idl_identifier (enumerator));
+  m.common.flags = c.common.flags = get_enum_literal_flags (_enum, enumerator);
   if ((ret = get_complete_member_detail (node, &c.detail)) < 0)
     return ret;
 

--- a/src/tools/idlc/tests/type_meta.c
+++ b/src/tools/idlc/tests/type_meta.c
@@ -452,7 +452,7 @@ static DDS_XTypes_TypeObject *get_typeobj7 (void)
   {
     struct DDS_XTypes_CompleteEnumeratedLiteral *literal_seq = calloc_no_fail (2, sizeof (*literal_seq));
     literal_seq[0] = (DDS_XTypes_CompleteEnumeratedLiteral) { .common = { .value = 0, .flags = 0 }, .detail.name = "en0" };
-    literal_seq[1] = (DDS_XTypes_CompleteEnumeratedLiteral) { .common = { .value = 3, .flags = 0 }, .detail.name = "en3" };
+    literal_seq[1] = (DDS_XTypes_CompleteEnumeratedLiteral) { .common = { .value = 3, .flags = DDS_XTypes_IS_DEFAULT }, .detail.name = "en3" };
 
     DDS_XTypes_TypeObject *to_enum = calloc_no_fail (1, sizeof (*to_enum));
     to_enum->_d = DDS_XTypes_EK_COMPLETE;
@@ -549,7 +549,7 @@ static DDS_XTypes_TypeObject *get_typeobj10 (void)
   {
     struct DDS_XTypes_CompleteEnumeratedLiteral *literal_seq = calloc_no_fail (2, sizeof (*literal_seq));
     literal_seq[0] = (DDS_XTypes_CompleteEnumeratedLiteral) { .common = { .value = 0, .flags = 0 }, .detail.name = "en0" };
-    literal_seq[1] = (DDS_XTypes_CompleteEnumeratedLiteral) { .common = { .value = 1, .flags = 0 }, .detail.name = "en1" };
+    literal_seq[1] = (DDS_XTypes_CompleteEnumeratedLiteral) { .common = { .value = 1, .flags = DDS_XTypes_IS_DEFAULT }, .detail.name = "en1" };
 
     DDS_XTypes_TypeObject *to_enum = calloc_no_fail (1, sizeof (*to_enum));
     to_enum->_d = DDS_XTypes_EK_COMPLETE;
@@ -811,7 +811,7 @@ CU_Test(idlc_type_meta, type_obj_serdes)
     { "module t7 { module x { @bit_bound(6) bitmask bm { @position(5) bm5, @position(0) bm0 }; enum en { @value(3) en3, @value(0) en0 }; @topic @final struct test_struct { bm f1; en f2; }; }; };", get_typeobj7 },
     { "module t8 { @topic struct test_struct { unsigned long long f1[1][1]; }; };", get_typeobj8 },
     { "module t9 { @bit_bound(2) bitmask bm { bm0, bm1 }; @topic @final struct test_struct { bm f1; bm f2; }; };", get_typeobj9 },
-    { "module t10 { enum en { en0, en1 }; @topic @final struct test_struct { en f1; en f2; }; };", get_typeobj10 },
+    { "module t10 { enum en { en0, @default_literal en1 }; @topic @final struct test_struct { en f1; en f2; }; };", get_typeobj10 },
     { "module t11 { @final union test_union switch (char) { case 'a': @id(99) long f1; default: @id(5) unsigned short f2; }; };", get_typeobj11 },
     { "module t12 { typedef sequence<long> td_seq; typedef td_seq td_array[2]; struct test_struct { td_array f1; }; };", get_typeobj12 },
     { "module t13 { typedef long td_arr[3]; typedef td_arr td; @topic @final struct test_struct { td f1; }; };", get_typeobj13 },


### PR DESCRIPTION
This fixes the issue that IDLC did not set the `DEFAULT` flag in a Type Object for the default literal of an enumeration. This can be either the implicit default (first) or an explicit default (using the @default_literal annotation). 

Not setting this flag results in a different Type Identifier, which can in case of an aggregated type with extensibility 'final' that has an `enum` member, cause the type not to be assignable when communicating with other DDS implementations (as reported in #1627). 