### PR TITLE
Add recursive checking in ddsi_type_resolved

### DIFF
--- a/src/core/ddsi/src/ddsi_typelib.c
+++ b/src/core/ddsi/src/ddsi_typelib.c
@@ -1216,6 +1216,8 @@ bool ddsi_type_resolved_locked (struct ddsi_domaingv *gv, const struct ddsi_type
       struct ddsi_type *dep_type = ddsi_type_lookup_locked (gv, &dep->dep_type_id);
       if (dep_type && ddsi_xt_is_unresolved (&dep_type->xt))
         resolved = false;
+      else
+        resolved = ddsi_type_resolved_locked (gv, dep_type, resolved_kind);
     }
     ddsi_typeid_fini (&tmpl.src_type_id);
   }


### PR DESCRIPTION
In case `ddsi_type_resolved_locked` is called to check the resolved state including dependent types (kind is `DDSI_TYPE_INCLUDE_DEPS`), the check should be done recursively for all dependencies of the type that is passed.

During endpoint matching, the top-level type is checked for being resolved. As long as that is not the case, Cyclone will not start the assignability checking and request the missing dependencies. From analyzing issue #1627 (thanks @smnrgrs for reporting this!) we found that only first-level dependencies were correctly resolved by Cyclone, not the 2..n-th level dependencies. 
This PR fixes this by making the check recursive. 
