### PR TITLE
Fix documentation for `dds_qos_equal`

### DIFF
--- a/src/core/ddsc/include/dds/ddsc/dds_public_qos.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_public_qos.h
@@ -95,14 +95,12 @@ dds_merge_qos (dds_qos_t * __restrict dst, const dds_qos_t * __restrict src);
 /**
  * @ingroup qos
  * @component qos_obj
- * @brief Copy all QoS-policies from one structure to another, unless already set
+ * @brief Check if two qos structures contain the same set of QoS-policies.
  *
- * Policies are copied from src to dst, unless src already has the policy set to a non-default value.
+ * @param[in] a - Pointer to a qos structure
+ * @param[in] b - Pointer to a qos structure
  *
- * @param[in,out] a - Pointer to the destination qos structure
- * @param[in] b - Pointer to the source qos structure
- *
- * @returns whether the copy was successful.
+ * @returns whether the two qos structures contain the same set of QoS-policies
  */
 DDS_EXPORT bool
 dds_qos_equal (const dds_qos_t * __restrict a, const dds_qos_t * __restrict b);


### PR DESCRIPTION
Thanks to @firuze-cagliyan for spotting this. 

I double-checked the implementation and it uses a `qmask` that excludes `DDSI_QP_TYPE_INFORMATION`. I don't think this actually corresponds with a QoS policy that the consumers of Cyclone actually interact with, but I'm not 100% sure. If not then the comment might need to be updated to document what QoS policy is excluded from the `eq` check. 