### PR TITLE
Fix a couple of compiler warnings under gcc.

### DIFF
--- a/src/core/ddsi/src/ddsi_typebuilder.c
+++ b/src/core/ddsi/src/ddsi_typebuilder.c
@@ -1782,7 +1782,7 @@ static dds_return_t get_topic_descriptor (dds_topic_descriptor_t *desc, struct t
     goto err;
   }
 
-  struct dds_key_descriptor *key_desc;
+  struct dds_key_descriptor *key_desc = NULL;
   if ((ret = typebuilder_get_keys (tbd, &ops, &key_desc)))
   {
     typebuilder_ops_fini (&ops);

--- a/src/core/ddsi/src/ddsi_typewrap.c
+++ b/src/core/ddsi/src/ddsi_typewrap.c
@@ -2564,7 +2564,7 @@ bool ddsi_xt_is_assignable_from (struct ddsi_domaingv *gv, const struct xt_type 
 
 static ddsi_typeid_kind_t ddsi_typeid_kind_impl (const struct DDS_XTypes_TypeIdentifier *type_id)
 {
-  ddsi_typeid_kind_t kind;
+  ddsi_typeid_kind_t kind = DDSI_TYPEID_KIND_MINIMAL;
   if (ddsi_typeid_is_hash_impl (type_id))
     kind = ddsi_typeid_is_minimal_impl (type_id) ? DDSI_TYPEID_KIND_MINIMAL : DDSI_TYPEID_KIND_COMPLETE;
   else


### PR DESCRIPTION
When compiling CycloneDDS 0.10.x under gcc 11.3.0 on Ubuntu 22.04, we see warnings that certain variables may be used uninitialized.

This PR fixes both of them by initializing the variables when they are declared.  For the one in get_topic_descriptor(), I think setting it to NULL is a reasonable fix.  For the one in ddsi_typeid_kind_impl(), I'm less certain.  I don't know if we want to assume that the TypeID is MINIMAL if we don't elsewhere find it.  I'm open to other suggestions here.

I'll note that this fix specifically targets the 0.10.x branch, as that is what we are trying to get in for ROS 2 Iron.  I can forward port this to master as well if necessary.

@eboasson We are under a bit of a time crunch to get this in before the Iron RMW freeze on April 10, so any thoughts from you (or anyone else on the CycloneDDS team) are most appreciated.

This is related to https://github.com/ros2/ros2/pull/1402