### PR TITLE
Fix typebuilder max key size for unbounded strings

### DIFF
--- a/src/core/ddsc/tests/TypeBuilderTypes.idl
+++ b/src/core/ddsc/tests/TypeBuilderTypes.idl
@@ -401,4 +401,8 @@ module TypeBuilderTypes {
     t27_1 f1;
   };
 
+  /* unbounded string key */
+  struct t28 {
+    @key string f1;
+  };
 };

--- a/src/core/ddsc/tests/typebuilder.c
+++ b/src/core/ddsc/tests/typebuilder.c
@@ -138,7 +138,7 @@ CU_TheoryDataPoints (ddsc_typebuilder, topic_desc) = {
   CU_DataPoints (const dds_topic_descriptor_t *, &D(t1), &D(t2), &D(t3), &D(t4), &D(t5), &D(t6), &D(t7), &D(t8),
                                                  &D(t9), &D(t10), &D(t11), &D(t12), &D(t13), &D(t14), &D(t15), &D(t16),
                                                  &D(t17), &D(t18), &D(t19), &D(t20), &D(t21), &D(t22), &D(t23), &D(t24),
-                                                 &D(t25), &D(t26), &D(t27) ),
+                                                 &D(t25), &D(t26), &D(t27), &D(t28) ),
 };
 
 #undef D


### PR DESCRIPTION
An unbounded string key field was treated as sizeof(char*) in computing the maximum serialized key size (in dynamically constructed serializer operations for the C binding), rather than as infinity.  If this computed maximum is no more than some fixed size, then (for the C binding):

* Samples rely on a pre-allocated buffer for storing the serialized key, and handling a key for which the serialised form is actually longer will result in trying to reallocate a non-malloc'd buffer;

* The decisions whether the DDSI keyhash is the serialised key or the MD5 of it will be taken incorrectly.  (Cyclone doesn't really use them, but needs to support them regardless.)

Fixes #1637 