### PR TITLE
Fix support for configuring receive threads attributes

### DIFF
--- a/src/core/ddsi/src/ddsi_init.c
+++ b/src/core/ddsi/src/ddsi_init.c
@@ -411,7 +411,7 @@ static int set_ext_address_and_mask (struct ddsi_domaingv *gv)
 
 static int check_thread_properties (const struct ddsi_domaingv *gv)
 {
-  static const char *fixed[] = { "recv", "tev", "gc", "lease", "dq.builtins", "xmit.user", "dq.user", "debmon", "fsm", NULL };
+  static const char *fixed[] = { "recv", "recvUC", "recvMC", "tev", "gc", "lease", "dq.builtins", "xmit.user", "dq.user", "debmon", "fsm", NULL };
   const struct ddsi_config_thread_properties_listelem *e;
   int ok = 1, i;
   for (e = gv->config.thread_properties; e; e = e->next)


### PR DESCRIPTION
The thread names for `recvMC` and `recvUC` threads are not included in the function that validates thread properties from CycloneDDS configuration. This commit adds these names so properties of the receive threads can be configured like the other threads.