### PR TITLE
Avoid passing a null pointer to ddsrt_memdup

### DIFF
--- a/.azure/templates/build-test.yml
+++ b/.azure/templates/build-test.yml
@@ -132,7 +132,8 @@ steps:
   - bash: |
       set -e -x
       cd build
-      ctest -j 4 --output-on-failure -T test -E '^CUnit_ddsrt_random_default_random$' -C ${BUILD_TYPE}
+      UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 \
+        ctest -j 4 --output-on-failure -T test -E '^CUnit_ddsrt_random_default_random$' -C ${BUILD_TYPE}
       [[ "${BUILD_TYPE}" != 'Release' ]] || [[ "${COVERAGE:-off}" == 'off' ]] || \
         ${SHELL} ../src/tools/ddsperf/sanity.bash
     condition: ne(variables['testing'], 'off')

--- a/src/core/cdr/src/dds_cdrstream.c
+++ b/src/core/cdr/src/dds_cdrstream.c
@@ -372,9 +372,18 @@ static void dds_stream_swap (void * __restrict vbuf, uint32_t size, uint32_t num
       break;
     }
     case 8: {
-      uint64_t *buf = vbuf;
-      for (uint32_t i = 0; i < num; i++)
-        buf[i] = ddsrt_bswap8u (buf[i]);
+      uint32_t *buf = vbuf;
+      // max size of sample is 4GB or thereabouts, so a 64-bit int or double
+      // array or sequence can never have more than 0.5G elements
+      //
+      // need to byte-swap using 32-bit elements because of XCDR2 droping the
+      // natural alignment requirement
+      for (uint32_t i = 0; i < num; i++) {
+        uint32_t a = ddsrt_bswap4u (buf[2*i]);
+        uint32_t b = ddsrt_bswap4u (buf[2*i+1]);
+        buf[2*i] = b;
+        buf[2*i+1] = a;
+      }
       break;
     }
   }
@@ -2218,13 +2227,16 @@ static inline bool read_and_normalize_uint64 (uint64_t * __restrict val, char * 
 {
   if ((*off = check_align_prim (*off, size, xcdr_version == DDSI_RTPS_CDR_ENC_VERSION_2 ? 2 : 3, 3)) == UINT32_MAX)
     return false;
+  union { uint32_t u32[2]; uint64_t u64; } u;
+  u.u32[0] = * (uint32_t *) (data + *off);
+  u.u32[1] = * ((uint32_t *) (data + *off) + 1);
   if (bswap)
   {
-    uint32_t x = ddsrt_bswap4u (* (uint32_t *) (data + *off));
-    *((uint32_t *) (data + *off)) = ddsrt_bswap4u (* ((uint32_t *) (data + *off) + 1));
-    *((uint32_t *) (data + *off) + 1) = x;
+    u.u64 = ddsrt_bswap8u (u.u64);
+    *((uint32_t *) (data + *off)) = u.u32[0];
+    *((uint32_t *) (data + *off) + 1) = u.u32[1];
   }
-  *val = *((uint64_t *) (data + *off));
+  *val = u.u64;
   (*off) += 8;
   return true;
 }
@@ -2352,37 +2364,21 @@ static bool normalize_primarray (char * __restrict data, uint32_t * __restrict o
       if ((*off = check_align_prim_many (*off, size, 1, 1, num)) == UINT32_MAX)
         return false;
       if (bswap)
-      {
-        uint16_t *xs = (uint16_t *) (data + *off);
-        for (uint32_t i = 0; i < num; i++)
-          xs[i] = ddsrt_bswap2u (xs[i]);
-      }
+        dds_stream_swap (data + *off, 2, num);
       *off += 2 * num;
       return true;
     case DDS_OP_VAL_4BY:
       if ((*off = check_align_prim_many (*off, size, 2, 2, num)) == UINT32_MAX)
         return false;
       if (bswap)
-      {
-        uint32_t *xs = (uint32_t *) (data + *off);
-        for (uint32_t i = 0; i < num; i++)
-          xs[i] = ddsrt_bswap4u (xs[i]);
-      }
+        dds_stream_swap (data + *off, 4, num);
       *off += 4 * num;
       return true;
     case DDS_OP_VAL_8BY:
       if ((*off = check_align_prim_many (*off, size, xcdr_version == DDSI_RTPS_CDR_ENC_VERSION_2 ? 2 : 3, 3, num)) == UINT32_MAX)
         return false;
       if (bswap)
-      {
-        uint64_t *xs = (uint64_t *) (data + *off);
-        for (uint32_t i = 0; i < num; i++)
-        {
-          uint32_t x = ddsrt_bswap4u (* (uint32_t *) &xs[i]);
-          *(uint32_t *) &xs[i] = ddsrt_bswap4u (* (((uint32_t *) &xs[i]) + 1));
-          *(((uint32_t *) &xs[i]) + 1) = x;
-        }
-      }
+        dds_stream_swap (data + *off, 8, num);
       *off += 8 * num;
       return true;
     default:

--- a/src/core/cdr/src/dds_cdrstream.c
+++ b/src/core/cdr/src/dds_cdrstream.c
@@ -3072,7 +3072,7 @@ bool dds_stream_normalize (void * __restrict data, uint32_t size, bool bswap, ui
 static const uint32_t *dds_stream_free_sample_seq (char * __restrict addr, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, uint32_t insn)
 {
   dds_sequence_t * const seq = (dds_sequence_t *) addr;
-  uint32_t num = (seq->_maximum > seq->_length) ? seq->_maximum : seq->_length;
+  uint32_t num = (seq->_buffer == NULL) ? 0 : (seq->_maximum > seq->_length) ? seq->_maximum : seq->_length;
   const enum dds_stream_typecode subtype = DDS_OP_SUBTYPE (insn);
   uint32_t bound_op = seq_is_bounded (DDS_OP_TYPE (insn)) ? 1 : 0;
   if ((seq->_release && num) || subtype > DDS_OP_VAL_STR)

--- a/src/core/ddsc/src/dds_serdata_default.c
+++ b/src/core/ddsc/src/dds_serdata_default.c
@@ -822,7 +822,8 @@ static void serdata_default_get_keyhash (const struct ddsi_serdata *serdata_comm
   else
   {
     memset (buf->value, 0, DDS_FIXED_KEY_MAX_SIZE);
-    memcpy (buf->value, os.x.m_buffer, actual_keysz);
+    if (actual_keysz > 0)
+      memcpy (buf->value, os.x.m_buffer, actual_keysz);
   }
   dds_ostreamBE_fini (&os, &dds_cdrstream_default_allocator);
 }

--- a/src/core/ddsc/tests/iceoryx.c
+++ b/src/core/ddsc/tests/iceoryx.c
@@ -191,7 +191,7 @@ static void check_writer_addrset_helper (const ddsi_xlocator_t *loc, void *varg)
   CU_ASSERT_FATAL (i < arg->nports);
 }
 
-static bool check_writer_addrset (dds_entity_t wrhandle, int nports, const uint32_t ports[nports])
+static bool check_writer_addrset (dds_entity_t wrhandle, int nports, const uint32_t *ports)
 {
   dds_return_t rc;
   struct dds_entity *x;

--- a/src/core/ddsc/tests/time_based_filter.c
+++ b/src/core/ddsc/tests/time_based_filter.c
@@ -140,7 +140,15 @@ static void test_insert(void)
 
     sd->twrite.v = DDS_TIME_INVALID;
 
-    struct ddsi_writer_info wi;
+  struct ddsi_writer_info wi = {
+    .guid = { .prefix = { .u = {1,1,1} }, .entityid = { .u = 0x102 } },
+    .auto_dispose = false,
+    .ownership_strength = 0,
+    .iid = 1
+#ifdef DDS_HAS_LIFESPAN
+    , .lifespan_exp = { DDS_INFINITY }
+#endif
+    };
     const struct ddsi_domaingv *gv = get_gv (pp);
     CU_ASSERT_PTR_NOT_NULL_FATAL(gv);
     if (!gv)

--- a/src/core/ddsi/src/ddsi_pmd.c
+++ b/src/core/ddsi/src/ddsi_pmd.c
@@ -141,7 +141,7 @@ void ddsi_write_pmd_message_xevent_cb (struct ddsi_domaingv *gv, struct ddsi_xev
   ddsi_write_pmd_message (thrst, xp, pp, DDSI_PARTICIPANT_MESSAGE_DATA_KIND_AUTOMATIC_LIVELINESS_UPDATE);
 
   intv = ddsi_participant_get_pmd_interval (pp);
-  if (intv == DDS_INFINITY)
+  if (intv < 0 || intv == DDS_INFINITY)
   {
     tnext.v = DDS_NEVER;
     GVTRACE ("resched pmd("PGUIDFMT"): never\n", PGUID (pp->e.guid));

--- a/src/core/ddsi/src/ddsi_typewrap.c
+++ b/src/core/ddsi/src/ddsi_typewrap.c
@@ -1041,8 +1041,10 @@ static dds_return_t add_minimal_typeobj (struct ddsi_domaingv *gv, struct xt_typ
           xt->_u.union_type.members.seq[n].label_seq._buffer =
             ddsrt_memdup (mto->_u.union_type.member_seq._buffer[n].common.label_seq._buffer,
                           mto->_u.union_type.member_seq._buffer[n].common.label_seq._length * sizeof (*mto->_u.union_type.member_seq._buffer[n].common.label_seq._buffer));
+          xt->_u.union_type.members.seq[n].label_seq._release = true;
         } else {
           xt->_u.union_type.members.seq[n].label_seq._buffer = NULL;
+          xt->_u.union_type.members.seq[n].label_seq._release = false;
         }
         memcpy (xt->_u.union_type.members.seq[n].detail.name_hash, mto->_u.union_type.member_seq._buffer[n].detail.name_hash,
           sizeof (xt->_u.union_type.members.seq[n].detail.name_hash));
@@ -1212,8 +1214,10 @@ static dds_return_t add_complete_typeobj (struct ddsi_domaingv *gv, struct xt_ty
           xt->_u.union_type.members.seq[n].label_seq._buffer =
             ddsrt_memdup (cto->_u.union_type.member_seq._buffer[n].common.label_seq._buffer,
                           cto->_u.union_type.member_seq._buffer[n].common.label_seq._length * sizeof (*cto->_u.union_type.member_seq._buffer[n].common.label_seq._buffer));
+          xt->_u.union_type.members.seq[n].label_seq._release = true;
         } else {
           xt->_u.union_type.members.seq[n].label_seq._buffer = NULL;
+          xt->_u.union_type.members.seq[n].label_seq._release = false;
         }
         set_member_detail (&xt->_u.union_type.members.seq[n].detail, &cto->_u.union_type.member_seq._buffer[n].detail);
       }
@@ -2941,10 +2945,11 @@ void ddsi_xt_get_typeobject_kind_impl (const struct xt_type *xt, struct DDS_XTyp
             munion->member_seq._buffer[n].common.label_seq._buffer =
               ddsrt_memdup (xt->_u.union_type.members.seq[n].label_seq._buffer,
                             xt->_u.union_type.members.seq[n].label_seq._length * sizeof (*xt->_u.union_type.members.seq[n].label_seq._buffer));
+            munion->member_seq._buffer[n].common.label_seq._release = true;
           } else {
             munion->member_seq._buffer[n].common.label_seq._buffer = NULL;
+            munion->member_seq._buffer[n].common.label_seq._release = false;
           }
-          munion->member_seq._buffer[n].common.label_seq._release = true;
           get_minimal_member_detail (&munion->member_seq._buffer[n].detail, &xt->_u.union_type.members.seq[n].detail);
         }
         break;
@@ -3079,10 +3084,11 @@ void ddsi_xt_get_typeobject_kind_impl (const struct xt_type *xt, struct DDS_XTyp
             cunion->member_seq._buffer[n].common.label_seq._buffer =
               ddsrt_memdup (xt->_u.union_type.members.seq[n].label_seq._buffer,
                             xt->_u.union_type.members.seq[n].label_seq._length * sizeof (*xt->_u.union_type.members.seq[n].label_seq._buffer));
+            cunion->member_seq._buffer[n].common.label_seq._release = true;
           } else {
             cunion->member_seq._buffer[n].common.label_seq._buffer = NULL;
+            cunion->member_seq._buffer[n].common.label_seq._release = false;
           }
-          cunion->member_seq._buffer[n].common.label_seq._release = true;
           get_member_detail (&cunion->member_seq._buffer[n].detail, &xt->_u.union_type.members.seq[n].detail);
         }
         break;

--- a/src/core/ddsi/src/ddsi_typewrap.c
+++ b/src/core/ddsi/src/ddsi_typewrap.c
@@ -1037,8 +1037,13 @@ static dds_return_t add_minimal_typeobj (struct ddsi_domaingv *gv, struct xt_typ
           goto err_to;
         }
         xt->_u.union_type.members.seq[n].label_seq._length = mto->_u.union_type.member_seq._buffer[n].common.label_seq._length;
-        xt->_u.union_type.members.seq[n].label_seq._buffer = ddsrt_memdup (mto->_u.union_type.member_seq._buffer[n].common.label_seq._buffer,
-          mto->_u.union_type.member_seq._buffer[n].common.label_seq._length * sizeof (*mto->_u.union_type.member_seq._buffer[n].common.label_seq._buffer));
+        if (xt->_u.union_type.members.seq[n].label_seq._length > 0) {
+          xt->_u.union_type.members.seq[n].label_seq._buffer =
+            ddsrt_memdup (mto->_u.union_type.member_seq._buffer[n].common.label_seq._buffer,
+                          mto->_u.union_type.member_seq._buffer[n].common.label_seq._length * sizeof (*mto->_u.union_type.member_seq._buffer[n].common.label_seq._buffer));
+        } else {
+          xt->_u.union_type.members.seq[n].label_seq._buffer = NULL;
+        }
         memcpy (xt->_u.union_type.members.seq[n].detail.name_hash, mto->_u.union_type.member_seq._buffer[n].detail.name_hash,
           sizeof (xt->_u.union_type.members.seq[n].detail.name_hash));
       }
@@ -1203,8 +1208,13 @@ static dds_return_t add_complete_typeobj (struct ddsi_domaingv *gv, struct xt_ty
           goto err_to;
         }
         xt->_u.union_type.members.seq[n].label_seq._length = cto->_u.union_type.member_seq._buffer[n].common.label_seq._length;
-        xt->_u.union_type.members.seq[n].label_seq._buffer = ddsrt_memdup (cto->_u.union_type.member_seq._buffer[n].common.label_seq._buffer,
-          cto->_u.union_type.member_seq._buffer[n].common.label_seq._length * sizeof (*cto->_u.union_type.member_seq._buffer[n].common.label_seq._buffer));
+        if (xt->_u.union_type.members.seq[n].label_seq._length > 0) {
+          xt->_u.union_type.members.seq[n].label_seq._buffer =
+            ddsrt_memdup (cto->_u.union_type.member_seq._buffer[n].common.label_seq._buffer,
+                          cto->_u.union_type.member_seq._buffer[n].common.label_seq._length * sizeof (*cto->_u.union_type.member_seq._buffer[n].common.label_seq._buffer));
+        } else {
+          xt->_u.union_type.members.seq[n].label_seq._buffer = NULL;
+        }
         set_member_detail (&xt->_u.union_type.members.seq[n].detail, &cto->_u.union_type.member_seq._buffer[n].detail);
       }
       break;
@@ -2927,8 +2937,13 @@ void ddsi_xt_get_typeobject_kind_impl (const struct xt_type *xt, struct DDS_XTyp
           munion->member_seq._buffer[n].common.member_flags = xt->_u.union_type.members.seq[n].flags;
           ddsi_xt_get_typeid_impl (&xt->_u.union_type.members.seq[n].type->xt, &munion->member_seq._buffer[n].common.type_id, DDSI_TYPEID_KIND_MINIMAL);
           munion->member_seq._buffer[n].common.label_seq._length = xt->_u.union_type.members.seq[n].label_seq._length;
-          munion->member_seq._buffer[n].common.label_seq._buffer = ddsrt_memdup (xt->_u.union_type.members.seq[n].label_seq._buffer,
-            xt->_u.union_type.members.seq[n].label_seq._length * sizeof (*xt->_u.union_type.members.seq[n].label_seq._buffer));
+          if (munion->member_seq._buffer[n].common.label_seq._length > 0) {
+            munion->member_seq._buffer[n].common.label_seq._buffer =
+              ddsrt_memdup (xt->_u.union_type.members.seq[n].label_seq._buffer,
+                            xt->_u.union_type.members.seq[n].label_seq._length * sizeof (*xt->_u.union_type.members.seq[n].label_seq._buffer));
+          } else {
+            munion->member_seq._buffer[n].common.label_seq._buffer = NULL;
+          }
           munion->member_seq._buffer[n].common.label_seq._release = true;
           get_minimal_member_detail (&munion->member_seq._buffer[n].detail, &xt->_u.union_type.members.seq[n].detail);
         }
@@ -3060,8 +3075,13 @@ void ddsi_xt_get_typeobject_kind_impl (const struct xt_type *xt, struct DDS_XTyp
           cunion->member_seq._buffer[n].common.member_flags = xt->_u.union_type.members.seq[n].flags;
           ddsi_xt_get_typeid_impl (&xt->_u.union_type.members.seq[n].type->xt, &cunion->member_seq._buffer[n].common.type_id, DDSI_TYPEID_KIND_COMPLETE);
           cunion->member_seq._buffer[n].common.label_seq._length = xt->_u.union_type.members.seq[n].label_seq._length;
-          cunion->member_seq._buffer[n].common.label_seq._buffer = ddsrt_memdup (xt->_u.union_type.members.seq[n].label_seq._buffer,
-            xt->_u.union_type.members.seq[n].label_seq._length * sizeof (*xt->_u.union_type.members.seq[n].label_seq._buffer));
+          if (cunion->member_seq._buffer[n].common.label_seq._length > 0) {
+            cunion->member_seq._buffer[n].common.label_seq._buffer =
+              ddsrt_memdup (xt->_u.union_type.members.seq[n].label_seq._buffer,
+                            xt->_u.union_type.members.seq[n].label_seq._length * sizeof (*xt->_u.union_type.members.seq[n].label_seq._buffer));
+          } else {
+            cunion->member_seq._buffer[n].common.label_seq._buffer = NULL;
+          }
           cunion->member_seq._buffer[n].common.label_seq._release = true;
           get_member_detail (&cunion->member_seq._buffer[n].detail, &xt->_u.union_type.members.seq[n].detail);
         }

--- a/src/ddsrt/src/strtol.c
+++ b/src/ddsrt/src/strtol.c
@@ -95,7 +95,7 @@ ddsrt_strtoll(
 {
   dds_return_t rc = DDS_RETCODE_OK;
   size_t cnt = 0;
-  long long tot = 1;
+  int sign = 1;
   unsigned long long ullng = 0, max = INT64_MAX;
 
   assert(str != NULL);
@@ -106,7 +106,7 @@ ddsrt_strtoll(
   }
 
   if (str[cnt] == '-') {
-    tot = -1;
+    sign = -1;
     max++;
     cnt++;
   } else if (str[cnt] == '+') {
@@ -116,9 +116,11 @@ ddsrt_strtoll(
   rc = ullfstr(str + cnt, endptr, base, &ullng, max);
   if (endptr && *endptr == (str + cnt))
     *endptr = (char *)str;
-  if (rc != DDS_RETCODE_BAD_PARAMETER)
-    *llng = tot * (long long)ullng;
-
+  if (rc != DDS_RETCODE_BAD_PARAMETER) {
+    *llng = (long long)ullng;
+    if (sign == -1 && *llng != INT64_MIN)
+      *llng = - *llng;
+  }
   return rc;
 }
 

--- a/src/idl/src/symbol.c
+++ b/src/idl/src/symbol.c
@@ -19,7 +19,7 @@
 
 const idl_location_t *idl_location(const void *symbol)
 {
-  return &((const idl_symbol_t *)symbol)->location;
+  return symbol ? &((const idl_symbol_t *)symbol)->location : NULL;
 }
 
 void idl_delete_name(idl_name_t *name)

--- a/src/security/builtin_plugins/cryptographic/src/crypto_cipher.c
+++ b/src/security/builtin_plugins/cryptographic/src/crypto_cipher.c
@@ -51,7 +51,7 @@ static bool trusted_check_buffer_sizes (const size_t num, const trusted_crypto_d
   DDSRT_STATIC_ASSERT (sizeof (trusted_crypto_data_t) == sizeof (tainted_crypto_data_t));
   DDSRT_STATIC_ASSERT (offsetof (trusted_crypto_data_t, x.base) == offsetof (tainted_crypto_data_t, base));
   DDSRT_STATIC_ASSERT (offsetof (trusted_crypto_data_t, x.length) == offsetof (tainted_crypto_data_t, length));
-  return check_buffer_sizes (num, (const const_tainted_crypto_data_t *) inp, &outp->x);
+  return check_buffer_sizes (num, (const const_tainted_crypto_data_t *) inp, outp ? &outp->x : NULL);
 }
 #endif
 

--- a/src/security/builtin_plugins/cryptographic/src/crypto_key_exchange.c
+++ b/src/security/builtin_plugins/cryptographic/src/crypto_key_exchange.c
@@ -134,17 +134,23 @@ serialize_master_key_material(
 
   sd[i++] = ddsrt_toBE4u(keymat->transformation_kind);
   sd[i++] = ddsrt_toBE4u(key_bytes);
-  memcpy(&sd[i], keymat->master_salt, key_bytes);
+  if (key_bytes > 0) {
+    memcpy(&sd[i], keymat->master_salt, key_bytes);
+  }
   i += key_bytes / sizeof (uint32_t);
   sd[i++] = ddsrt_toBE4u(keymat->sender_key_id);
   sd[i++] = ddsrt_toBE4u(key_bytes);
-  memcpy(&sd[i], keymat->master_sender_key, key_bytes);
+  if (key_bytes > 0) {
+    memcpy(&sd[i], keymat->master_sender_key, key_bytes);
+  }
   i += key_bytes / sizeof (uint32_t);
   sd[i++] = ddsrt_toBE4u(keymat->receiver_specific_key_id);
   if (keymat->receiver_specific_key_id)
   {
     sd[i++] = ddsrt_toBE4u(key_bytes);
-    memcpy(&sd[i], keymat->master_receiver_specific_key, key_bytes);
+    if (key_bytes > 0) {
+      memcpy(&sd[i], keymat->master_receiver_specific_key, key_bytes);
+    }
   }
   else
   {

--- a/src/security/core/src/dds_security_serialize.c
+++ b/src/security/core/src/dds_security_serialize.c
@@ -270,10 +270,12 @@ DDS_Security_Serialize_OctetSeq(
      DDS_Security_Serializer ser,
      const DDS_Security_OctetSeq *seq)
 {
-     DDS_Security_Serialize_uint32_t(ser, seq->_length);
-     serbuffer_adjust_size(ser, seq->_length);
-     memcpy(&(ser->buffer[ser->offset]), seq->_buffer, seq->_length);
-     ser->offset += seq->_length;
+    DDS_Security_Serialize_uint32_t(ser, seq->_length);
+    if (seq->_length) {
+        serbuffer_adjust_size(ser, seq->_length);
+        memcpy(&(ser->buffer[ser->offset]), seq->_buffer, seq->_length);
+        ser->offset += seq->_length;
+    }
 }
 
 static void

--- a/src/security/core/src/dds_security_utils.c
+++ b/src/security/core/src/dds_security_utils.c
@@ -41,7 +41,9 @@ DDS_Security_BinaryProperty_deinit(
     }
 
     ddsrt_free(p->name);
-    memset (p->value._buffer, 0, p->value._length); /* because key material can be stored in binary property */
+    if (p->value._length > 0) {
+        memset (p->value._buffer, 0, p->value._length); /* because key material can be stored in binary property */
+    }
     ddsrt_free(p->value._buffer);
 }
 

--- a/src/security/openssl/src/openssl_support.c
+++ b/src/security/openssl/src/openssl_support.c
@@ -115,7 +115,9 @@ void DDS_Security_Exception_set_with_openssl_error (DDS_Security_SecurityExcepti
     size_t exception_msg_len = len + strlen (error_area) + 1;
     char *str = ddsrt_malloc (exception_msg_len);
     ddsrt_strlcpy (str, error_area, exception_msg_len);
-    memcpy (str + strlen (error_area), buf, len);
+    if (len > 0) {
+      memcpy (str + strlen (error_area), buf, len);
+    }
     str[exception_msg_len - 1] = '\0';
     ex->message = str;
     ex->code = code;


### PR DESCRIPTION
It is currently handled correctly, but the interface specification states the argument must be non-null (like all the standard C library functions of similar character), and the undefined behaviour sanitizer flags this.