### PR TITLE
Add API function to get sertype from an entity

### DIFF
--- a/src/core/ddsc/include/dds/dds.h
+++ b/src/core/ddsc/include/dds/dds.h
@@ -4682,6 +4682,31 @@ DDS_EXPORT dds_return_t
 dds_free_typeinfo (
   dds_typeinfo_t *type_info);
 
+
+/**
+ * @brief Gets the sertype of an entity
+ *
+ * The provided entity must be a topic or endpoint. This function returns a pointer to
+ * the sertype of the entity. The refcount of the sertype is not incremented. The lifetime
+ * of the returned sertype pointer is at least that of the lifetime of the entity on which
+ * it was invoked.
+ *
+ * @param[in] entity A topic, reader or writer entity
+ * @param[out] sertype A pointer to the entity's sertype is stored in this parameter (see note above on lifetime of this pointer)
+ *
+ * @returns A dds_return_t indicating success or failure.
+ * @retval DDS_RETCODE_OK
+ *             The operation was successful.
+ * @retval DDS_RETCODE_BAD_PARAMETER
+ *             The sertype parameter is NULL
+ * @retval DDS_RETCODE_ILLEGAL_OPERATION
+ *             Not a topic, reader or writer entity
+ */
+DDS_EXPORT dds_return_t
+dds_get_entity_sertype (
+  dds_entity_t entity,
+  const struct ddsi_sertype **sertype);
+
 #if defined (__cplusplus)
 }
 #endif

--- a/src/core/ddsc/src/dds_entity.c
+++ b/src/core/ddsc/src/dds_entity.c
@@ -1666,3 +1666,38 @@ dds_return_t dds_free_typeinfo (dds_typeinfo_t *type_info)
 }
 
 #endif /* DDS_HAS_TYPE_DISCOVERY */
+
+
+dds_return_t dds_get_entity_sertype (dds_entity_t entity, const struct ddsi_sertype **sertype)
+{
+  dds_return_t ret;
+  dds_entity *e;
+
+  if (!sertype)
+    return DDS_RETCODE_BAD_PARAMETER;
+  if ((ret = dds_entity_pin (entity, &e)) != DDS_RETCODE_OK)
+    return ret;
+  switch (dds_entity_kind (e))
+  {
+    case DDS_KIND_TOPIC: {
+      struct dds_topic * const tp = (struct dds_topic *) e;
+      *sertype = tp->m_stype;
+      break;
+    }
+    case DDS_KIND_READER: {
+      struct dds_reader * const rd = (struct dds_reader *) e;
+      *sertype = rd->m_rd->type;
+      break;
+    }
+    case DDS_KIND_WRITER: {
+      struct dds_writer * const wr = (struct dds_writer *) e;
+      *sertype = wr->m_wr->type;
+      break;
+    }
+    default:
+      ret = DDS_RETCODE_ILLEGAL_OPERATION;
+      break;
+  }
+  dds_entity_unpin (e);
+  return ret;
+}

--- a/src/core/xtests/symbol_export/symbol_export.c
+++ b/src/core/xtests/symbol_export/symbol_export.c
@@ -233,6 +233,7 @@ int main (int argc, char **argv)
   dds_free_typeobj (ptr);
   dds_get_typeinfo (1, ptr);
   dds_free_typeinfo (ptr);
+  dds_get_entity_sertype (1, ptr);
 
   // dds_data_allocator.h
   dds_data_allocator_init (1, ptr);


### PR DESCRIPTION
This adds a function `dds_get_entity_sertype` in the public API, that allows to get a sertype object from an endpoint or topic, 