### PR TITLE
Fix a warning when building in release mode.

### DIFF
--- a/src/core/ddsc/src/dds_serdata_builtintopic.c
+++ b/src/core/ddsc/src/dds_serdata_builtintopic.c
@@ -102,6 +102,8 @@ static struct ddsi_serdata_builtintopic *serdata_builtin_new(const struct ddsi_s
     case DSBT_WRITER:
       size = sizeof (struct ddsi_serdata_builtintopic_endpoint);
       break;
+    default:
+      abort();
   }
   struct ddsi_serdata_builtintopic *d = ddsrt_malloc(size);
   ddsi_serdata_init (&d->c, &tp->c, serdata_kind);
@@ -465,7 +467,7 @@ struct ddsi_serdata *dds_serdata_builtin_from_topic_definition (const struct dds
   const struct ddsi_sertype_builtintopic *tp = (const struct ddsi_sertype_builtintopic *) tpcmn;
   assert (tp->entity_kind == DSBT_TOPIC);
   struct ddsi_serdata_builtintopic_topic *d = (struct ddsi_serdata_builtintopic_topic *) serdata_builtin_new (tp, kind);
-  memcpy (&d->common.key.raw, key, sizeof (d->common.key.raw));
+  memcpy (d->common.key.raw, key->d, sizeof (d->common.key.raw));
   if (tpd != NULL && kind == SDK_DATA)
     from_qos (&d->common, tpd->xqos);
   return fix_serdata_builtin (&d->common, DSBT_TOPIC, tp->c.serdata_basehash);

--- a/src/core/ddsc/src/dds_serdata_builtintopic.c
+++ b/src/core/ddsc/src/dds_serdata_builtintopic.c
@@ -83,29 +83,29 @@ static void serdata_builtin_free(struct ddsi_serdata *dcmn)
   ddsrt_free (d);
 }
 
-static struct ddsi_serdata_builtintopic *serdata_builtin_new(const struct ddsi_sertype_builtintopic *tp, enum ddsi_serdata_kind serdata_kind)
+static size_t serdata_builtin_sizeof(enum ddsi_sertype_builtintopic_entity_kind entity_kind)
 {
-  size_t size = 0;
-  switch (tp->entity_kind)
+  switch (entity_kind)
   {
     case DSBT_PARTICIPANT:
-      size = sizeof (struct ddsi_serdata_builtintopic_participant);
-      break;
+      return sizeof (struct ddsi_serdata_builtintopic_participant);
     case DSBT_TOPIC:
 #ifdef DDS_HAS_TOPIC_DISCOVERY
-      size = sizeof (struct ddsi_serdata_builtintopic_topic);
+      return sizeof (struct ddsi_serdata_builtintopic_topic);
 #else
-      assert(0);
-#endif
       break;
+#endif
     case DSBT_READER:
     case DSBT_WRITER:
-      size = sizeof (struct ddsi_serdata_builtintopic_endpoint);
-      break;
-    default:
-      abort();
+      return sizeof (struct ddsi_serdata_builtintopic_endpoint);
   }
-  struct ddsi_serdata_builtintopic *d = ddsrt_malloc(size);
+  abort ();
+  return 0;
+}
+
+static struct ddsi_serdata_builtintopic *serdata_builtin_new(const struct ddsi_sertype_builtintopic *tp, enum ddsi_serdata_kind serdata_kind)
+{
+  struct ddsi_serdata_builtintopic *d = ddsrt_malloc(serdata_builtin_sizeof(tp->entity_kind));
   ddsi_serdata_init (&d->c, &tp->c, serdata_kind);
   return d;
 }


### PR DESCRIPTION
When building the 0.10.x branch in release mode, we are seeing the following warning:

In function ‘dds_serdata_builtin_from_topic_definition’,
    inlined from ‘dds__builtin_make_sample_topic_impl’ at ros2_rolling/src/eclipse-cyclonedds/cyclonedds/src/core/ddsc/src/dds_builtin.c:302:34:
ros2_rolling/src/eclipse-cyclonedds/cyclonedds/src/core/ddsc/src/dds_serdata_builtintopic.c:468:3: warning: writing 16 bytes into a region of size 0 [-Wstringop-overflow=]
  468 |   memcpy (&d->common.key.raw, key, sizeof (d->common.key.raw));

I believe what is happening here is that the compiler is finding a path through the code where serdata_builtin_new() can allocate and return a struct of 0 size.  That can theoretically happen if the tp->entity_kind is not one of the known types when serdata_builtin_new() is called. Given that this is an exceptional situation, detect this and abort().  Note that we use abort() and not assert() here as the latter will be compiled out in release builds.

While we are in here, change the syntax of the memcpy command as well.  While the previous version wasn't wrong, this one makes it much more clear that we are copying the key bytes from one structure to another.  If this part is objectionable, it can be dropped.

To be totally transparent, I do *not* see this issue with the `master` branch, even though the code here is largely the same between the `0.10.x` branch and the `master` branch.  I don't really understand how that can be, but I'd suggest porting this to the `master` branch anyway.