### PR TITLE
Fix crash on getting key from Iceoryx chunk

### DIFF
--- a/src/core/ddsc/src/dds_serdata_default.c
+++ b/src/core/ddsc/src/dds_serdata_default.c
@@ -467,54 +467,38 @@ static struct ddsi_serdata *serdata_default_from_keyhash_cdr_nokey (const struct
 }
 
 #ifdef DDS_HAS_SHM
-static struct ddsi_serdata* serdata_default_from_received_iox_buffer(const struct ddsi_sertype* tpcmn, enum ddsi_serdata_kind kind, void* sub, void* iox_buffer)
+static struct dds_serdata_default *serdata_default_from_iox_common (const struct ddsi_sertype *tpcmn, enum ddsi_serdata_kind kind, void *sub, void *iox_buffer)
 {
-  const iceoryx_header_t* ice_hdr = iceoryx_header_from_chunk(iox_buffer);
-
-  const struct dds_sertype_default* tp = (const struct dds_sertype_default*)tpcmn;
-
-  struct dds_serdata_default *d = serdata_default_new_size (tp, kind, ice_hdr->data_size, tp->write_encoding_version);
-
+  struct dds_sertype_default const * const tp = (const struct dds_sertype_default *) tpcmn;
+  iceoryx_header_t const * const ice_hdr = iceoryx_header_from_chunk (iox_buffer);
+  struct dds_serdata_default * const d = serdata_default_new_size (tp, kind, ice_hdr->data_size, tp->write_encoding_version);
   // note: we do not deserialize or memcpy here, just take ownership of the chunk
   d->c.iox_chunk = iox_buffer;
   d->c.iox_subscriber = sub;
-  d->key.buftype = KEYBUFTYPE_STATIC;
-  d->key.keysize = DDS_FIXED_KEY_MAX_SIZE;
-  memcpy(d->key.u.stbuf, ice_hdr->keyhash.value, DDS_FIXED_KEY_MAX_SIZE);
-
-  fix_serdata_default(d, tpcmn->serdata_basehash);
-
-  return (struct ddsi_serdata*)d;
-}
-
-// Creates a serdata for the case where only iceoryx is required (i.e. no network).
-// This skips expensive serialization and just takes ownership of the iceoryx buffer.
-// Computing the keyhash is currently still required.
-static struct ddsi_serdata *dds_serdata_default_from_loaned_sample (const struct ddsi_sertype *type, enum ddsi_serdata_kind kind, const char *sample)
-{
-  const struct dds_sertype_default *t = (const struct dds_sertype_default *)type;
-  struct dds_serdata_default *d = serdata_default_new (t, kind, t->write_encoding_version);
-
-  if(d == NULL)
-    return NULL;
-
-  // Currently needed even in the shared memory case (since it is potentially used at the reader side).
-  // This may still incur computational costs linear in the sample size (?).
-  // TODO: Can we avoid this with specific handling on the reader side which does not require the keyhash?
-  if (!gen_serdata_key_from_sample (t, &d->key, sample))
-    return NULL;
-
-  struct ddsi_serdata *serdata = &d->c;
-  serdata->iox_chunk = (void*) sample;
-  return serdata;
-}
-
-static struct ddsi_serdata* serdata_default_from_iox(const struct ddsi_sertype* tpcmn, enum ddsi_serdata_kind kind, void* sub, void* buffer)
-{
-  if (sub == NULL)
-    return dds_serdata_default_from_loaned_sample(tpcmn, kind, buffer);
+  if (ice_hdr->shm_data_state != IOX_CHUNK_CONTAINS_SERIALIZED_DATA)
+    gen_serdata_key_from_sample (tp, &d->key, iox_buffer);
   else
-    return serdata_default_from_received_iox_buffer(tpcmn, kind, sub, buffer);
+  {
+    // This is silly: we get here only from dds_write and so we have the original sample available
+    // somewhere, just not here.  This is not the time to change the serdata interface and we have
+    // to make do with what is available.
+    dds_istream_t is;
+    dds_istream_init (&is, ice_hdr->data_size, iox_buffer, tp->write_encoding_version);
+    gen_serdata_key_from_cdr (&is, &d->key, tp, kind == SDK_KEY);
+  }
+  return d;
+}
+
+static struct ddsi_serdata *serdata_default_from_iox (const struct ddsi_sertype *tpcmn, enum ddsi_serdata_kind kind, void *sub, void *iox_buffer)
+{
+  struct dds_serdata_default *d = serdata_default_from_iox_common (tpcmn, kind, sub, iox_buffer);
+  return fix_serdata_default (d, tpcmn->serdata_basehash);
+}
+
+static struct ddsi_serdata *serdata_default_from_iox_nokey (const struct ddsi_sertype *tpcmn, enum ddsi_serdata_kind kind, void *sub, void *iox_buffer)
+{
+  struct dds_serdata_default *d = serdata_default_from_iox_common (tpcmn, kind, sub, iox_buffer);
+  return fix_serdata_default_nokey (d, tpcmn->serdata_basehash);
 }
 #endif
 
@@ -889,7 +873,7 @@ const struct ddsi_serdata_ops dds_serdata_ops_cdr_nokey = {
   .get_keyhash = serdata_default_get_keyhash
 #ifdef DDS_HAS_SHM
   , .get_sample_size = ddsi_serdata_iox_size
-  , .from_iox_buffer = serdata_default_from_iox
+  , .from_iox_buffer = serdata_default_from_iox_nokey
 #endif
 };
 
@@ -911,6 +895,6 @@ const struct ddsi_serdata_ops dds_serdata_ops_xcdr2_nokey = {
   .get_keyhash = serdata_default_get_keyhash
 #ifdef DDS_HAS_SHM
   , .get_sample_size = ddsi_serdata_iox_size
-  , .from_iox_buffer = serdata_default_from_iox
+  , .from_iox_buffer = serdata_default_from_iox_nokey
 #endif
 };

--- a/src/core/ddsc/tests/CMakeLists.txt
+++ b/src/core/ddsc/tests/CMakeLists.txt
@@ -263,6 +263,7 @@ kill -0 `cat ctest_fixture_iox_roudi.pid`")
   foreach(t
       iceoryx_one_writer
       iceoryx_one_writer_dynsize
+      iceoryx_one_writer_dynsize_strkey
       iceoryx_return_loan
       iceoryx_partition_xtalk
       shm_serialization_get_serialized_size

--- a/src/core/ddsc/tests/DynamicData.idl
+++ b/src/core/ddsc/tests/DynamicData.idl
@@ -4,4 +4,10 @@ module DynamicData {
     int32 scalar;
     sequence<int32> values;
   };
+
+  struct KMsg {
+    @key string message;
+    int32 scalar;
+    sequence<int32> values;
+  };
 };

--- a/src/core/ddsc/tests/iceoryx.c
+++ b/src/core/ddsc/tests/iceoryx.c
@@ -350,7 +350,7 @@ static const char *istatestr (dds_instance_state_t s)
   return "nowriters";
 }
 
-static bool alldataseen (struct tracebuf *tb, int nrds, const dds_entity_t rds[nrds], dds_instance_state_t instance_state)
+static bool alldataseen (struct tracebuf *tb, int nrds, const dds_entity_t rds[nrds], const dds_instance_handle_t ihs[nrds], dds_instance_state_t instance_state)
 {
   assert (nrds > 0);
   dds_return_t rc;
@@ -388,9 +388,11 @@ static bool alldataseen (struct tracebuf *tb, int nrds, const dds_entity_t rds[n
         while ((n = dds_take (rdconds[i], &sampleptr, &si, 1, 1)) > 0)
         {
           (void) dds_return_loan (rdconds[i], &sampleptr, n);
-          if (si.instance_state != instance_state)
+          if (si.instance_handle != ihs[i] || si.instance_state != instance_state)
           {
-            print (tb, "[rd %d %s while expecting %s] ", i, istatestr (si.instance_state), istatestr (instance_state));
+            print (tb, "[rd %d %s ihandle %"PRIx64" while expecting %s ihandle %"PRIx64"] ",
+                   i, istatestr (si.instance_state), si.instance_handle,
+                   istatestr (instance_state), ihs[i]);
             fail_instance_state ();
             goto out;
           }
@@ -463,25 +465,82 @@ static int compare_uint32 (const void *va, const void *vb)
   return (*a == *b) ? 0 : (*a < *b) ? -1 : 1;
 }
 
+static void get_data_instance_handles (const dds_entity_t *krds, dds_instance_handle_t *ihs, const void *sample)
+{
+  dds_return_t rc;
+  dds_entity_t ws, rcs[MAX_DOMAINS];
+  dds_entity_t kwr = create_writer (dds_get_topic (krds[0]), false);
+  CU_ASSERT_FATAL (kwr > 0);
+  rc = dds_write (kwr, sample);
+  CU_ASSERT_FATAL (rc == 0);
+  ws = dds_create_waitset (DDS_CYCLONEDDS_HANDLE);
+  CU_ASSERT_FATAL (ws > 0);
+  for (int i = 0; i < MAX_DOMAINS; i++)
+  {
+    ihs[i] = 0;
+    rcs[i] = dds_create_readcondition (krds[i], DDS_NOT_READ_SAMPLE_STATE | DDS_ANY_VIEW_STATE | DDS_ANY_INSTANCE_STATE);
+    CU_ASSERT_FATAL (rcs[i] > 0);
+    rc = dds_waitset_attach (ws, rcs[i], i);
+    CU_ASSERT_FATAL (rc == 0);
+  }
+  int rem = MAX_DOMAINS;
+  while (rem > 0)
+  {
+    dds_attach_t xs[MAX_DOMAINS];
+    int32_t nxs = dds_waitset_wait (ws, xs, MAX_DOMAINS, DDS_INFINITY);
+    CU_ASSERT_FATAL (nxs >= 0);
+    for (int i = 0; i < nxs; i++)
+    {
+      CU_ASSERT_FATAL (ihs[xs[i]] == 0);
+      dds_sample_info_t si;
+      void *raw = NULL;
+      int32_t n = dds_read (krds[xs[i]], &raw, &si, 1, 1);
+      CU_ASSERT_FATAL (n > 0);
+      ihs[xs[i]] = si.instance_handle;
+      rc = dds_return_loan (krds[xs[i]], &raw, n);
+      CU_ASSERT_FATAL (rc == 0);
+      rem--;
+    }
+  }
+  for (int i = 0; i < MAX_DOMAINS; i++)
+  {
+    dds_delete (rcs[i]);
+  }
+  dds_delete (ws);
+  dds_delete (kwr);
+}
+
 static void dotest (const dds_topic_descriptor_t *tpdesc, const void *sample)
 {
   dds_return_t rc;
   dds_entity_t pp[MAX_DOMAINS];
   dds_entity_t tp[MAX_DOMAINS];
+  dds_entity_t ktp[MAX_DOMAINS], krds[MAX_DOMAINS];
+  dds_instance_handle_t ihs[MAX_DOMAINS];
   struct ddsi_domaingv *gvs[MAX_DOMAINS];
 
   const dds_entity_t ws = dds_create_waitset (DDS_CYCLONEDDS_HANDLE);
   CU_ASSERT_FATAL (ws > 0);
 
-  char topicname[100];
+  char topicname[100], ktopicname[100];
   create_unique_topic_name ("test_iceoryx", topicname, sizeof (topicname));
+  create_unique_topic_name ("test_iceoryx", ktopicname, sizeof (ktopicname));
+  dds_qos_t *kqos = dds_create_qos ();
+  dds_qset_reliability(kqos, DDS_RELIABILITY_RELIABLE, DDS_INFINITY);
+  dds_qset_durability (kqos, DDS_DURABILITY_TRANSIENT_LOCAL);
   for (int i = 0; i < MAX_DOMAINS; i++)
   {
     pp[i] = create_participant ((dds_domainid_t) i, true); // FIXME: vary shm_enable for i > 0
+    gvs[i] = get_domaingv (pp[i]);
     tp[i] = dds_create_topic (pp[i], tpdesc, topicname, NULL, NULL);
     CU_ASSERT_FATAL (tp[i] > 0);
-    gvs[i] = get_domaingv (pp[i]);
+    ktp[i] = dds_create_topic (pp[i], tpdesc, ktopicname, kqos, NULL);
+    CU_ASSERT_FATAL (ktp[i] > 0);
+    krds[i] = create_reader (ktp[i], false);
+    CU_ASSERT_FATAL (krds[i] > 0);
   }
+  dds_delete_qos (kqos);
+  get_data_instance_handles (krds, ihs, sample);
 
   for (int wr_use_iceoryx = 0; wr_use_iceoryx <= 1; wr_use_iceoryx++)
   {
@@ -503,6 +562,7 @@ static void dotest (const dds_topic_descriptor_t *tpdesc, const void *sample)
     while (rdmode[MAX_DOMAINS * MAX_READERS_PER_DOMAIN] == 0)
     {
       dds_entity_t rds[MAX_DOMAINS * MAX_READERS_PER_DOMAIN] = { 0 };
+      dds_instance_handle_t rds_ih[MAX_DOMAINS * MAX_READERS_PER_DOMAIN] = { 0 };
       uint32_t ports[MAX_DOMAINS * MAX_READERS_PER_DOMAIN];
       struct tracebuf tb = { .pos = 0 };
       int nrds_active = 0;
@@ -540,6 +600,7 @@ static void dotest (const dds_topic_descriptor_t *tpdesc, const void *sample)
         print (&tb, " %s", (rdmode[i] == 2) ? "iox" : "dds");
 
         rds[i] = create_reader (tp[dom], rdmode[i] == 2);
+        rds_ih[i] = ihs[dom];
         const uint32_t port = reader_unicast_port (rds[i]);
         if (dom == 0)
         {
@@ -631,7 +692,7 @@ static void dotest (const dds_topic_descriptor_t *tpdesc, const void *sample)
         rc = ops[opidx].op (wr, sample);
 
         CU_ASSERT_FATAL (rc == 0);
-        if (!alldataseen (&tb, MAX_READERS_PER_DOMAIN, rds, ops[opidx].istate))
+        if (!alldataseen (&tb, MAX_READERS_PER_DOMAIN, rds, rds_ih, ops[opidx].istate))
         {
           fail_one = true;
           goto next;

--- a/src/core/ddsc/tests/iceoryx.c
+++ b/src/core/ddsc/tests/iceoryx.c
@@ -758,6 +758,20 @@ CU_Test(ddsc_iceoryx, one_writer_dynsize, .timeout = 30)
   CU_ASSERT (!failed);
 }
 
+CU_Test(ddsc_iceoryx, one_writer_dynsize_strkey, .timeout = 30)
+{
+  failed = false;
+  dotest (&DynamicData_KMsg_desc, &(const DynamicData_KMsg){
+    .message = "Muss es sein?",
+    .scalar = 135,
+    .values = {
+      ._length = 4, ._maximum = 4, ._release = false,
+      ._buffer = (int32_t[]) { 193, 272, 54, 277 }
+    }
+  });
+  CU_ASSERT (!failed);
+}
+
 CU_Test(ddsc_iceoryx, return_loan)
 {
   dds_return_t rc;


### PR DESCRIPTION
dds_serdata_default (so the default sample implementation used only by the C binding) always stores the serialized key in native XCDR2 format, but this was broken for Iceoryx chunks.

For the case of a local write, the code assumed that the iox chunk contains a "raw sample" rather than a serialized sample.  This was correct until https://github.com/eclipse-cyclonedds/cyclonedds/commit/8845a81ce77f78df2816a74b01cf89686f96581d (pr https://github.com/eclipse-cyclonedds/cyclonedds/pull/1031) changed that.

The typical failure mode (but not the only one) is a crash if the key contains a string and if the data is volatile and all subscribers are addressed via Iceoryx.  In practice this turns out to have been rare enough that no-one noticed it until now.

For the case of data coming in over Iceoryx, there was a confusion between the DDSI keyhash and the key representation in serdata_default (the former is the big-endian serialisation of the key or the MD5 hash thereof; the latter is always native-endianness XCDR2 serialisation of the key and so resistant to collision attacks).

The typical failure mode here is one of instance confusion: either mapping to different key values to the same instance, or mapping what really is the same key value to different instances.

With this PR, it now always extracts the key from the actual data in the Iceoryx chunk.  In the case of a local write, we know we have the sample in memory somwhere, even if the chunk contains the serialized representation.  Nonetheless, here it extracts the key from the serialized form because at the point where we need to do it, we do not have a pointer to the original sample and changing the interface for this rare case is not worth it at this point in time.

Another consequence of the problem is that the instance handle can be wrong. That is addressed here, too.

The PR also extends the test cases in separate commits.

This should address https://github.com/ros2/rmw_cyclonedds/issues/449 . Needs backporting to 0.9 and 0.10.