### PR TITLE
Dynamic type API: set TRY_CONSTRUCT to DISCARD

### DIFF
--- a/src/core/ddsi/src/ddsi_dynamic_type.c
+++ b/src/core/ddsi/src/ddsi_dynamic_type.c
@@ -465,8 +465,9 @@ dds_return_t ddsi_dynamic_type_add_struct_member (struct ddsi_type *type, struct
   memset (m, 0, sizeof (*m));
   m->type = *member_type;
   m->id = member_id;
+  m->flags = DDS_XTypes_TRY_CONSTRUCT_DISCARD;
   if (params.is_key)
-    m->flags = DDS_XTypes_IS_KEY;
+    m->flags |= DDS_XTypes_IS_KEY;
   (void) ddsrt_strlcpy (m->detail.name, params.name, sizeof (m->detail.name));
 
   return DDS_RETCODE_OK;
@@ -542,8 +543,9 @@ dds_return_t ddsi_dynamic_type_add_union_member (struct ddsi_type *type, struct 
   m->type = *member_type;
   m->id = member_id;
   (void) ddsrt_strlcpy (m->detail.name, params.name, sizeof (m->detail.name));
+  m->flags = DDS_XTypes_TRY_CONSTRUCT_DISCARD;
   if (params.is_default)
-    m->flags = DDS_XTypes_IS_DEFAULT;
+    m->flags |= DDS_XTypes_IS_DEFAULT;
   else
   {
     assert (sizeof (*m->label_seq._buffer) == sizeof (*params.labels));


### PR DESCRIPTION
Struct and union members must have a valid setting for TRY_CONSTRUCT, this sets the default value to DISCARD, in line with the XTypes specification.

Before both the TRY_CONSTRUCT1 and TRY_CONSTRUCT2 flags were clear, and so one would expect it to have been rejected by the type object validation, except we are still accepting that value for backwards compatibility with the 0.9 release.