### PR TITLE
Do follow-up requests on incomplete type responses

### DIFF
--- a/src/core/ddsi/src/ddsi_typelib.c
+++ b/src/core/ddsi/src/ddsi_typelib.c
@@ -1355,14 +1355,25 @@ static dds_return_t check_type_resolved_impl_locked (struct ddsi_domaingv *gv, c
   return ret;
 }
 
-static dds_return_t wait_for_type_resolved_impl_locked (struct ddsi_domaingv *gv, dds_duration_t timeout, const struct ddsi_type *type, ddsi_type_include_deps_t resolved_kind)
+static dds_return_t wait_for_type_resolved_impl_locked (struct ddsi_domaingv *gv, const ddsi_typeid_t *type_id, dds_duration_t timeout, const struct ddsi_type *type, ddsi_type_include_deps_t resolved_kind, ddsi_type_request_t request)
 {
   const dds_time_t tnow = dds_time ();
   const dds_time_t abstimeout = (DDS_INFINITY - timeout <= tnow) ? DDS_NEVER : (tnow + timeout);
-  while (!ddsi_type_resolved_locked (gv, type, resolved_kind))
+  bool resolved = ddsi_type_resolved_locked (gv, type, resolved_kind);
+  while (!resolved)
   {
     if (!ddsrt_cond_waituntil (&gv->typelib_resolved_cond, &gv->typelib_lock, abstimeout))
       return DDS_RETCODE_TIMEOUT;
+
+    resolved = ddsi_type_resolved_locked (gv, type, resolved_kind);
+    if (request == DDSI_TYPE_SEND_REQUEST && !resolved)
+    {
+      ddsrt_mutex_unlock (&gv->typelib_lock);
+      if (!ddsi_tl_request_type (gv, type_id, NULL, resolved_kind))
+        request = DDSI_TYPE_NO_REQUEST;
+      ddsrt_mutex_lock (&gv->typelib_lock);
+      resolved = ddsi_type_resolved_locked (gv, type, resolved_kind);
+    }
   }
   ddsi_type_ref_locked (gv, NULL, type);
   return DDS_RETCODE_OK;
@@ -1389,7 +1400,7 @@ dds_return_t ddsi_wait_for_type_resolved (struct ddsi_domaingv *gv, const ddsi_t
     return DDS_RETCODE_PRECONDITION_NOT_MET;
 
   ddsrt_mutex_lock (&gv->typelib_lock);
-  ret = wait_for_type_resolved_impl_locked (gv, timeout, *type, resolved_kind);
+  ret = wait_for_type_resolved_impl_locked (gv, type_id, timeout, *type, resolved_kind, request);
   ddsrt_mutex_unlock (&gv->typelib_lock);
 
   return ret;


### PR DESCRIPTION
When Cyclone issues a type lookup request for a type T and all its dependencies, it necessarily includes only those dependencies that is aware of.  The types learnt from the response may themselves introduce unknown dependencies.

That means that wait_for_type_resolved_impl_locked may have to issue follow-up requests.

@dpotman Perhaps you can have a look? I'm not sure this is the best way to do it. It does the trick for `dynsub` on `dyntype` but that doesn't mean it is good. I'm particularly worried that it could possibly result in a request storm, and that would be quite bad.