### PR TITLE
circlist.h: add doxygen comments

### DIFF
--- a/src/ddsrt/include/dds/ddsrt/circlist.h
+++ b/src/ddsrt/include/dds/ddsrt/circlist.h
@@ -36,23 +36,21 @@ struct ddsrt_circlist {
   struct ddsrt_circlist_elem *latest; /**< pointer to latest inserted element */
 };
 
-/**
- * @brief The circlist element is the basic element of circular doubly linked list structure.
- * 
- * To store user data in the list, the element must be embedded in a user element, which is a struct containing the user data.
- * All API calls with an element as input or output, deal with the circlist element. Example:
- * @code{.c}
- * typedef struct num_s{ // user element
- *   uint64_t val; // user data
- *   ddsrt_circlist_elem elem;
- * }num_t;
- * @endcode
- * 
- * For functions like @ref ddsrt_circlist_latest, this means that to get a pointer to the user element, you can use the macro @ref DDSRT_FROM_CIRCLIST :
- * @code{.c}
- * num_t* num = DDSRT_FROM_CIRCLIST(num_t, elem, ddsrt_circlist_latest(listptr));
- * @endcode
- */
+/// @brief The circlist element is the basic element of circular doubly linked list structure.
+/// 
+/// To store user data in the list, the element must be embedded in a user element, which is a struct containing the user data.
+/// All API calls with an element as input or output, deal with the circlist element. Example:
+/// @code{.c}
+/// typedef struct num_s{ // user element
+///   uint64_t val; // user data
+///   ddsrt_circlist_elem elem;
+/// }num_t;
+/// @endcode
+/// 
+/// For functions like @ref ddsrt_circlist_latest, this means that to get a pointer to the user element, you can use the macro @ref DDSRT_FROM_CIRCLIST :
+/// @code{.c}
+/// num_t* num = DDSRT_FROM_CIRCLIST(num_t, elem, ddsrt_circlist_latest(listptr));
+/// @endcode
 struct ddsrt_circlist_elem {
   struct ddsrt_circlist_elem *next;
   struct ddsrt_circlist_elem *prev;
@@ -78,7 +76,8 @@ bool ddsrt_circlist_isempty (const struct ddsrt_circlist *list);
  * 
  * @param[in,out] list the circular list
  * @param[in] elem the element to append
- * @see @ref ddsrt_circlist_remove
+ * 
+ * See @ref ddsrt_circlist_remove
  */
 void ddsrt_circlist_append (struct ddsrt_circlist *list, struct ddsrt_circlist_elem *elem);
 
@@ -89,7 +88,8 @@ void ddsrt_circlist_append (struct ddsrt_circlist *list, struct ddsrt_circlist_e
  * 
  * @param[in,out] list the circular list
  * @param[in] elem the element to append
- * @see @ref ddsrt_circlist_append
+ * 
+ * See @ref ddsrt_circlist_append
  */
 void ddsrt_circlist_remove (struct ddsrt_circlist *list, struct ddsrt_circlist_elem *elem);
 
@@ -98,8 +98,8 @@ void ddsrt_circlist_remove (struct ddsrt_circlist *list, struct ddsrt_circlist_e
  * 
  * @param[in] list the circular list
  * @return pointer to the oldest element
- * @see @ref ddsrt_circlist_latest
- * @see @ref ddsrt_circlist_elem
+ * 
+ * See @ref ddsrt_circlist_latest, @ref ddsrt_circlist_elem
  */
 struct ddsrt_circlist_elem *ddsrt_circlist_oldest (const struct ddsrt_circlist *list);
 
@@ -108,8 +108,8 @@ struct ddsrt_circlist_elem *ddsrt_circlist_oldest (const struct ddsrt_circlist *
  * 
  * @param[in] list the circular list
  * @return pointer to the latest element
- * @see @ref ddsrt_circlist_oldest
- * @see @ref ddsrt_circlist_elem
+ * 
+ * See @ref ddsrt_circlist_oldest, @ref ddsrt_circlist_elem
  */
 struct ddsrt_circlist_elem *ddsrt_circlist_latest (const struct ddsrt_circlist *list);
 

--- a/src/ddsrt/include/dds/ddsrt/circlist.h
+++ b/src/ddsrt/include/dds/ddsrt/circlist.h
@@ -27,7 +27,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Convenience macro to get the pointer to the user node, see @ref ddsrt_circlist_elem for an example.
+ * @brief Macro to get the pointer to the user node, see @ref ddsrt_circlist_elem for an example.
  */
 #define DDSRT_FROM_CIRCLIST(typ_, member_, cle_) ((typ_ *) ((char *) (cle_) - offsetof (typ_, member_)))
 
@@ -48,14 +48,7 @@ struct ddsrt_circlist {
  * }num_t;
  * @endcode
  * 
- * For functions like @ref ddsrt_circlist_latest, this means that to get a pointer to the user element, you'll have to subtract
- * the offset (obviously can be skipped if the offset is zero) and typecast accordingly:
- * 
- * @code{.c}
- * num_t* num = (num_t*)((char*)(ddsrt_circlist_latest(listptr)) - offsetof(num_t, elem));
- * @endcode
- * 
- * Alternatively you can use the macro @ref DDSRT_FROM_CIRCLIST :
+ * For functions like @ref ddsrt_circlist_latest, this means that to get a pointer to the user element, you can use the macro @ref DDSRT_FROM_CIRCLIST :
  * @code{.c}
  * num_t* num = DDSRT_FROM_CIRCLIST(num_t, elem, ddsrt_circlist_latest(listptr));
  * @endcode

--- a/src/ddsrt/include/dds/ddsrt/circlist.h
+++ b/src/ddsrt/include/dds/ddsrt/circlist.h
@@ -12,7 +12,11 @@
 #ifndef DDSRT_CIRCLIST_H
 #define DDSRT_CIRCLIST_H
 
-/* Circular doubly linked list implementation */
+/**
+ * @file circlist.h
+ * 
+ * Circular doubly linked list implementation.
+ */
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -22,22 +26,102 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Convenience macro to get the pointer to the user node, see @ref ddsrt_circlist_elem for an example.
+ */
 #define DDSRT_FROM_CIRCLIST(typ_, member_, cle_) ((typ_ *) ((char *) (cle_) - offsetof (typ_, member_)))
 
+/** @brief the circular doubly linked list */
 struct ddsrt_circlist {
-  struct ddsrt_circlist_elem *latest; /* pointer to latest inserted element */
+  struct ddsrt_circlist_elem *latest; /**< pointer to latest inserted element */
 };
 
+/**
+ * @brief The circlist element is the basic element of circular doubly linked list structure.
+ * 
+ * To store user data in the list, the element must be embedded in a user element, which is a struct containing the user data.
+ * All API calls with an element as input or output, deal with the circlist element. Example:
+ * @code{.c}
+ * typedef struct num_s{ // user element
+ *   uint64_t val; // user data
+ *   ddsrt_circlist_elem elem;
+ * }num_t;
+ * @endcode
+ * 
+ * For functions like @ref ddsrt_circlist_latest, this means that to get a pointer to the user element, you'll have to subtract
+ * the offset (obviously can be skipped if the offset is zero) and typecast accordingly:
+ * 
+ * @code{.c}
+ * num_t* num = (num_t*)((char*)(ddsrt_circlist_latest(listptr)) - offsetof(num_t, elem));
+ * @endcode
+ * 
+ * Alternatively you can use the macro @ref DDSRT_FROM_CIRCLIST :
+ * @code{.c}
+ * num_t* num = DDSRT_FROM_CIRCLIST(num_t, elem, ddsrt_circlist_latest(listptr));
+ * @endcode
+ */
 struct ddsrt_circlist_elem {
   struct ddsrt_circlist_elem *next;
   struct ddsrt_circlist_elem *prev;
 };
 
+/**
+ * @brief initialize the list
+ * 
+ * @param[out] list the circular list
+ */
 void ddsrt_circlist_init (struct ddsrt_circlist *list);
+
+/**
+ * @brief check whether the list is empty
+ * 
+ * @param[in] list the circular list
+ * @return true if empty, false if not empty
+ */
 bool ddsrt_circlist_isempty (const struct ddsrt_circlist *list);
+
+/**
+ * @brief append an element to the list
+ * 
+ * @param[in,out] list the circular list
+ * @param[in] elem the element to append
+ * @see @ref ddsrt_circlist_remove
+ */
 void ddsrt_circlist_append (struct ddsrt_circlist *list, struct ddsrt_circlist_elem *elem);
+
+/**
+ * @brief remove an element from the list
+ * 
+ * The user is still responsible for freeing the memory associated with the element.
+ * 
+ * @param[in,out] list the circular list
+ * @param[in] elem the element to append
+ * @see @ref ddsrt_circlist_append
+ */
 void ddsrt_circlist_remove (struct ddsrt_circlist *list, struct ddsrt_circlist_elem *elem);
+
+/**
+ * @brief get the oldest (earliest appended) element
+ * 
+ * @param[in] list the circular list
+ * @return pointer to the oldest element
+ * @see @ref ddsrt_circlist_latest
+ * @see @ref ddsrt_circlist_elem
+ */
 struct ddsrt_circlist_elem *ddsrt_circlist_oldest (const struct ddsrt_circlist *list);
+
+/**
+ * @brief get the latest (most recently appended) element
+ * 
+ * @param[in] list the circular list
+ * @return pointer to the latest element
+ * @see @ref ddsrt_circlist_oldest
+ * @see @ref ddsrt_circlist_elem
+ */
 struct ddsrt_circlist_elem *ddsrt_circlist_latest (const struct ddsrt_circlist *list);
+
+#if defined(__cplusplus)
+}
+#endif
 
 #endif /* DDSRT_CIRCLIST_H */


### PR DESCRIPTION
Aside from the comments, I noticed a missing closing bracket for `#if defined(__cplusplus)`, so I added that as well.