### PR TITLE
Allow dds_write_flush on publisher, participant

### DIFF
--- a/src/core/ddsc/include/dds/dds.h
+++ b/src/core/ddsc/include/dds/dds.h
@@ -2454,15 +2454,25 @@ dds_write(dds_entity_t writer, const void *data);
  * @ingroup writing
  * @component write_data
  *
- * When using the WriteBatch mode you can manually batch small writes into larger
- * datapackets for network efficiency. The normal dds_write() calls will no longer
- * automatically decide when to send data, you will do that manually using this function.
- *
- * DOC_TODO check if my assumptions about how this function works are correct
+ * When using write batching you can manually batch small writes into larger
+ * datapackets for network efficiency. The normal `dds_write()` no longer
+ * guarantee that data is sent on the network automatically.
  *
  * @param[in]  writer The writer entity.
+
+ * @returns A dds_return_t indicating success or failure.
+ * @retval DDS_RETCODE_OK
+ *             The writer successfully forwarded to the network.
+ * @retval DDS_RETCODE_ERROR
+ *             An internal error has occurred.
+ * @retval DDS_RETCODE_BAD_PARAMETER
+ *             One of the given arguments is not valid.
+ * @retval DDS_RETCODE_ILLEGAL_OPERATION
+ *             The operation is invoked on an inappropriate object.
+ * @retval DDS_RETCODE_ALREADY_DELETED
+ *             The entity has already been deleted.
  */
-DDS_EXPORT void
+DDS_EXPORT dds_return_t
 dds_write_flush(dds_entity_t writer);
 
 /**
@@ -2477,7 +2487,7 @@ dds_write_flush(dds_entity_t writer);
  * @param[in]  writer The writer entity.
  * @param[in]  serdata Serialized value to be written.
  *
- * @returns A dds_return_t indicating success or failure.
+ * @returns A dds_return_t indicating success or failure. On error, some writers failed to flush buffered messages.
  *
  * @retval DDS_RETCODE_OK
  *             The writer successfully wrote the serialized value.

--- a/src/core/ddsc/src/dds__write.h
+++ b/src/core/ddsc/src/dds__write.h
@@ -37,6 +37,9 @@ dds_return_t dds_writecdr_impl (dds_writer *wr, struct ddsi_xpack *xp, struct dd
 /** @component write_data */
 dds_return_t dds_writecdr_local_orphan_impl (struct ddsi_local_orphan_writer *lowr, struct ddsi_serdata *d);
 
+/** @component write_data */
+void dds_write_flush_impl (dds_writer *wr);
+
 #if defined (__cplusplus)
 }
 #endif

--- a/src/core/ddsc/src/dds_entity.c
+++ b/src/core/ddsc/src/dds_entity.c
@@ -1700,3 +1700,71 @@ dds_return_t dds_get_entity_sertype (dds_entity_t entity, const struct ddsi_sert
   dds_entity_unpin (e);
   return ret;
 }
+
+static dds_return_t pushdown_write_flush (dds_entity *e)
+{
+  /* Note: e is claimed, no mutexes held */
+  dds_return_t rc = DDS_RETCODE_OK;
+  struct dds_entity *c;
+  dds_instance_handle_t last_iid = 0;
+  ddsrt_mutex_lock (&e->m_mutex);
+  while ((c = ddsrt_avl_lookup_succ (&dds_entity_children_td, &e->m_children, &last_iid)) != NULL)
+  {
+    struct dds_entity *x;
+    last_iid = c->m_iid;
+    if (dds_entity_pin (c->m_hdllink.hdl, &x) == DDS_RETCODE_OK)
+    {
+      assert (x == c);
+      ddsrt_mutex_unlock (&e->m_mutex);
+      switch (dds_entity_kind (c))
+      {
+        case DDS_KIND_WRITER: {
+          dds_write_flush_impl ((dds_writer *) c);
+          break;
+        }
+        case DDS_KIND_PUBLISHER:
+        case DDS_KIND_PARTICIPANT:
+        case DDS_KIND_DOMAIN: {
+          dds_return_t rc1;
+          if ((rc1 = pushdown_write_flush (c)) < 0 && rc1 == 0)
+            rc = rc1;
+          break;
+        }
+        default: {
+          break;
+        }
+      }
+      ddsrt_mutex_lock (&e->m_mutex);
+      dds_entity_unpin (c);
+    }
+  }
+  ddsrt_mutex_unlock (&e->m_mutex);
+  return rc;
+}
+
+dds_return_t dds_write_flush (dds_entity_t entity)
+{
+  dds_entity *e;
+  dds_return_t rc;
+  if ((rc = dds_entity_pin (entity, &e)) != DDS_RETCODE_OK)
+    return rc;
+  struct ddsi_thread_state * const thrst = ddsi_lookup_thread_state ();
+  ddsi_thread_state_awake (thrst, &e->m_domain->gv);
+  switch (dds_entity_kind (e))
+  {
+    case DDS_KIND_WRITER:
+      dds_write_flush_impl ((dds_writer *) e);
+      break;
+    case DDS_KIND_PUBLISHER:
+    case DDS_KIND_PARTICIPANT:
+    case DDS_KIND_DOMAIN:
+      rc = pushdown_write_flush (e);
+      break;
+    default:
+      rc = DDS_RETCODE_ILLEGAL_OPERATION;
+      break;
+  }
+  ddsi_thread_state_asleep (thrst);
+  dds_entity_unpin (e);
+  return rc;
+}

--- a/src/core/ddsc/src/dds_write.c
+++ b/src/core/ddsc/src/dds_write.c
@@ -583,17 +583,11 @@ dds_return_t dds_writecdr_impl (dds_writer *wr, struct ddsi_xpack *xp, struct dd
   return dds_writecdr_impl_common (wr->m_wr, xp, (struct ddsi_serdata_any *) dinp, flush, wr);
 }
 
-void dds_write_flush (dds_entity_t writer)
+void dds_write_flush_impl (dds_writer *wr)
 {
-  dds_writer *wr;
-  if (dds_writer_lock (writer, &wr) == DDS_RETCODE_OK)
-  {
-    struct ddsi_thread_state * const thrst = ddsi_lookup_thread_state ();
-    ddsi_thread_state_awake (thrst, &wr->m_entity.m_domain->gv);
-    ddsi_xpack_send (wr->m_xp, true);
-    ddsi_thread_state_asleep (thrst);
-    dds_writer_unlock (wr);
-  }
+  ddsrt_mutex_lock (&wr->m_entity.m_mutex);
+  ddsi_xpack_send (wr->m_xp, true);
+  ddsrt_mutex_unlock (&wr->m_entity.m_mutex);
 }
 
 dds_return_t dds_writecdr_local_orphan_impl (struct ddsi_local_orphan_writer *lowr, struct ddsi_serdata *d)

--- a/src/core/ddsc/tests/test_oneliner.c
+++ b/src/core/ddsc/tests/test_oneliner.c
@@ -1858,7 +1858,7 @@ static void dosetflags (struct oneliner_ctx *ctx)
     error (ctx, "setflags: entity is not a writer");
   }
   dds_writer *wr = (dds_writer *) xwr;
-  if (strspn (flagstok.n, "arhd") != strlen (flagstok.n))
+  if (strspn (flagstok.n, "arhsd") != strlen (flagstok.n))
   {
     dds_entity_unpin (xwr);
     error (ctx, "setflags: unknown flags");
@@ -1866,6 +1866,7 @@ static void dosetflags (struct oneliner_ctx *ctx)
   wr->m_wr->test_ignore_acknack = (strchr (flagstok.n, 'a') != NULL);
   wr->m_wr->test_suppress_retransmit = (strchr (flagstok.n, 'r') != NULL);
   wr->m_wr->test_suppress_heartbeat = (strchr (flagstok.n, 'h') != NULL);
+  wr->m_wr->test_suppress_flush_on_sync_heartbeat = (strchr (flagstok.n, 's') != NULL);
   wr->m_wr->test_drop_outgoing_data = (strchr (flagstok.n, 'd') != NULL);
   dds_entity_unpin (xwr);
 }

--- a/src/core/ddsc/tests/test_oneliner.c
+++ b/src/core/ddsc/tests/test_oneliner.c
@@ -1443,7 +1443,6 @@ static void dounregfail (struct oneliner_ctx *ctx) { dowritelike (ctx, "unregfai
 static void dowriteflush (struct oneliner_ctx *ctx)
 {
   dds_return_t ret;
-  dds_time_t ts = dds_time ();
   int ent;
   if ((ent = parse_entity (ctx)) < 0)
     error (ctx, "flush: expecting entity");
@@ -1451,9 +1450,7 @@ static void dowriteflush (struct oneliner_ctx *ctx)
   if (ctx->es[ent] == 0)
     make_entity (ctx, ent, NULL);
   DDSRT_WARNING_MSVC_ON(6385)
-  mprintf (ctx, "entity %"PRId32": flush", ctx->es[ent]);
-  print_timestamp (ctx, ts);
-  mprintf (ctx, "\n");
+  mprintf (ctx, "entity %"PRId32": flush\n", ctx->es[ent]);
   if ((ret = dds_write_flush (ctx->es[ent])) != 0)
     error_dds (ctx, ret, "flush: failed");
 }

--- a/src/core/ddsc/tests/test_oneliner.h
+++ b/src/core/ddsc/tests/test_oneliner.h
@@ -74,6 +74,10 @@
  *                       the test + <dt>s rather than the current time; DT is a
  *                       floating-point number
  *
+ *               | flush ENTITY-NAME
+ *
+ *                       Invokes dds_write_flush on entity
+ *
  *               | READ-LIKE ENTITY-NAME
  *               | READ-LIKE(A,B) ENTITY-NAME
  *               | READ-LIKE{[S1[,S2[,S3...]][,...]} ENTITY-NAME
@@ -226,6 +230,7 @@
  *               | tp=N          transport-priority
  *               | ud=...        user data (with escape sequences and hex/octal
  *                               input allowed)
+ *               | wr={y|n}      writer batching
  *
  * All entities share the listeners with their global state. Only the latest invocation is visible.
  *
@@ -301,13 +306,13 @@ struct oneliner_ctx {
   char msg[256];
 
   jmp_buf jb;
-  
+
   int mprintf_needs_timestamp;
 
   ddsrt_mutex_t g_mutex;
   ddsrt_cond_t g_cond;
   struct oneliner_cb cb[3];
-  
+
   const char *config_override; // optional
 };
 

--- a/src/core/ddsc/tests/test_oneliner.h
+++ b/src/core/ddsc/tests/test_oneliner.h
@@ -80,7 +80,7 @@
  *
  *               | READ-LIKE ENTITY-NAME
  *               | READ-LIKE(A,B) ENTITY-NAME
- *               | READ-LIKE{[S1[,S2[,S3...]][,...]} ENTITY-NAME
+ *               | READ-LIKE[!]{[S1[,S2[,S3...]][,...]} ENTITY-NAME
  *
  *                       Reads/takes at most 10 samples.  The second form counts the
  *                       number of valid and invalid samples seen and checks them against
@@ -91,6 +91,10 @@
  *
  *                         [STATE]K[ENTITY-NAME][@DT]
  *                         [STATE](K,X,Y)[ENTITY-NAME][@DT]
+ *
+ *                       Suffixing READ-LIKE with an exclamation mark in this third form
+ *                       makes it wait until all specified data has been received (with
+ *                       a maximum of 5s).
  *
  *                       The first form is an invalid sample with only the (integer) key
  *                       value K, the second form also specifies the two (integer)

--- a/src/core/ddsc/tests/test_oneliner.h
+++ b/src/core/ddsc/tests/test_oneliner.h
@@ -179,6 +179,8 @@
  *                         a   ignore ACKNACK messages
  *                         r   ignore retransmit requests
  *                         h   suppress periodic heartbeats
+ *                         s   suppress possible flush on synchronous (a.k.a. piggy-backed)
+ *                             heartbeat
  *                         d   drop outgoing data
  *
  *               | status LISTENER(ARGS) ENTITY-NAME

--- a/src/core/ddsi/include/dds/ddsi/ddsi_endpoint.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_endpoint.h
@@ -83,6 +83,7 @@ struct ddsi_writer
   unsigned test_ignore_acknack : 1; /* iff 1, the writer ignores all arriving ACKNACK messages */
   unsigned test_suppress_retransmit : 1; /* iff 1, the writer does not respond to retransmit requests */
   unsigned test_suppress_heartbeat : 1; /* iff 1, the writer suppresses all periodic heartbeats */
+  unsigned test_suppress_flush_on_sync_heartbeat : 1; /* iff 1, the writer never flushes because of a piggy-backed heartbeat */
   unsigned test_drop_outgoing_data : 1; /* iff 1, the writer drops outgoing data, forcing the readers to request a retransmit */
 #ifdef DDS_HAS_SHM
   unsigned has_iceoryx : 1;

--- a/src/core/ddsi/include/dds/ddsi/ddsi_hbcontrol.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_hbcontrol.h
@@ -34,6 +34,12 @@ struct ddsi_hbcontrol {
   uint32_t hbs_since_last_write; ///< Number of heartbeats sent since last write
   uint32_t last_packetid;        ///< Last RTPS message id containing a heartbeat from this writer
 };
+
+/// @brief Encoding for possible ways of adding heartbeats to messages
+enum ddsi_hbcontrol_ack_required {
+  DDSI_HBC_ACK_REQ_NO,           ///< Heartbeat does not require a response (FINAL flag set)
+  DDSI_HBC_ACK_REQ_YES,          ///< Heartbeat requires a response, may continue packing
+  DDSI_HBC_ACK_REQ_YES_AND_FLUSH ///< Heartbeat requires a response, must send immediately
 };
 
 #if defined (__cplusplus)

--- a/src/core/ddsi/include/dds/ddsi/ddsi_hbcontrol.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_hbcontrol.h
@@ -18,13 +18,22 @@
 extern "C" {
 #endif
 
+/// @brief State information used in deciding when/what kind of a heartbeat to send (per writer)
+///
+/// Heartbeats inform readers of the range of sequence numbers available from the writer and serve the dual
+/// purpose of (1) allowing the reader to detect message loss, and (2) allowing the reader to request a retransmit.
+///
+/// Because readers are not allowed to request a retransmit unless they received a heartbeat, we make an
+/// effort to a embed heartbeat in an outgoing RTPS message (~ a packet) if a preceding RTPS message
+/// also contained data from the writer. Its sole purpose is to allow it to request a retransmit.
 struct ddsi_hbcontrol {
-  ddsrt_mtime_t t_of_last_write;
-  ddsrt_mtime_t t_of_last_hb;
-  ddsrt_mtime_t t_of_last_ackhb;
-  ddsrt_mtime_t tsched;
-  uint32_t hbs_since_last_write;
-  uint32_t last_packetid;
+  ddsrt_mtime_t t_of_last_write; ///< Time of most recent write
+  ddsrt_mtime_t t_of_last_hb;    ///< Time of last heartbeat sent
+  ddsrt_mtime_t t_of_last_ackhb; ///< Time of last heartbeat sent that requires a response
+  ddsrt_mtime_t tsched;          ///< Time at which next asynchronous heartbeat is scheduled
+  uint32_t hbs_since_last_write; ///< Number of heartbeats sent since last write
+  uint32_t last_packetid;        ///< Last RTPS message id containing a heartbeat from this writer
+};
 };
 
 #if defined (__cplusplus)

--- a/src/core/ddsi/src/ddsi__hbcontrol.h
+++ b/src/core/ddsi/src/ddsi__hbcontrol.h
@@ -32,20 +32,20 @@ int64_t ddsi_writer_hbcontrol_intv (const struct ddsi_writer *wr, const struct d
 void ddsi_writer_hbcontrol_note_asyncwrite (struct ddsi_writer *wr, ddsrt_mtime_t tnow);
 
 /** @component outgoing_rtps */
-int ddsi_writer_hbcontrol_ack_required (const struct ddsi_writer *wr, const struct ddsi_whc_state *whcst, ddsrt_mtime_t tnow);
+enum ddsi_hbcontrol_ack_required ddsi_writer_hbcontrol_ack_required (const struct ddsi_writer *wr, const struct ddsi_whc_state *whcst, ddsrt_mtime_t tnow);
 
 /** @component outgoing_rtps */
-struct ddsi_xmsg *ddsi_writer_hbcontrol_piggyback (struct ddsi_writer *wr, const struct ddsi_whc_state *whcst, ddsrt_mtime_t tnow, uint32_t packetid, int *hbansreq);
+struct ddsi_xmsg *ddsi_writer_hbcontrol_piggyback (struct ddsi_writer *wr, const struct ddsi_whc_state *whcst, ddsrt_mtime_t tnow, uint32_t packetid, enum ddsi_hbcontrol_ack_required *hbansreq);
 
 /** @component outgoing_rtps */
 int ddsi_writer_hbcontrol_must_send (const struct ddsi_writer *wr, const struct ddsi_whc_state *whcst, ddsrt_mtime_t tnow);
 
 /** @component outgoing_rtps */
-struct ddsi_xmsg *ddsi_writer_hbcontrol_create_heartbeat (struct ddsi_writer *wr, const struct ddsi_whc_state *whcst, ddsrt_mtime_t tnow, int hbansreq, int issync);
+struct ddsi_xmsg *ddsi_writer_hbcontrol_create_heartbeat (struct ddsi_writer *wr, const struct ddsi_whc_state *whcst, ddsrt_mtime_t tnow, enum ddsi_hbcontrol_ack_required hbansreq, int issync);
 
 #ifdef DDS_HAS_SECURITY
 /** @component outgoing_rtps */
-struct ddsi_xmsg *ddsi_writer_hbcontrol_p2p(struct ddsi_writer *wr, const struct ddsi_whc_state *whcst, int hbansreq, struct ddsi_proxy_reader *prd);
+struct ddsi_xmsg *ddsi_writer_hbcontrol_p2p(struct ddsi_writer *wr, const struct ddsi_whc_state *whcst, enum ddsi_hbcontrol_ack_required hbansreq, struct ddsi_proxy_reader *prd);
 #endif
 
 struct ddsi_heartbeat_xevent_cb_arg {

--- a/src/core/ddsi/src/ddsi__transmit.h
+++ b/src/core/ddsi/src/ddsi__transmit.h
@@ -12,6 +12,7 @@
 #define DDSI__TRANSMIT_H
 
 #include "dds/ddsi/ddsi_transmit.h"
+#include "dds/ddsi/ddsi_hbcontrol.h"
 
 #if defined (__cplusplus)
 extern "C" {
@@ -58,7 +59,7 @@ int ddsi_enqueue_sample_wrlock_held (struct ddsi_writer *wr, ddsi_seqno_t seq, s
 void ddsi_enqueue_spdp_sample_wrlock_held (struct ddsi_writer *wr, ddsi_seqno_t seq, struct ddsi_serdata *serdata, struct ddsi_proxy_reader *prd);
 
 /** @component outgoing_rtps */
-void ddsi_add_heartbeat (struct ddsi_xmsg *msg, struct ddsi_writer *wr, const struct ddsi_whc_state *whcst, int hbansreq, int hbliveliness, ddsi_entityid_t dst, int issync);
+void ddsi_add_heartbeat (struct ddsi_xmsg *msg, struct ddsi_writer *wr, const struct ddsi_whc_state *whcst, enum ddsi_hbcontrol_ack_required hbansreq, int hbliveliness, ddsi_entityid_t dst, int issync);
 
 /** @component outgoing_rtps */
 int ddsi_write_sample_p2p_wrlock_held(struct ddsi_writer *wr, ddsi_seqno_t seq, struct ddsi_serdata *serdata, struct ddsi_tkmap_instance *tk, struct ddsi_proxy_reader *prd);

--- a/src/core/ddsi/src/ddsi_endpoint.c
+++ b/src/core/ddsi/src/ddsi_endpoint.c
@@ -757,6 +757,7 @@ static void ddsi_new_writer_guid_common_init (struct ddsi_writer *wr, const char
   wr->test_ignore_acknack = 0;
   wr->test_suppress_retransmit = 0;
   wr->test_suppress_heartbeat = 0;
+  wr->test_suppress_flush_on_sync_heartbeat = 0;
   wr->test_drop_outgoing_data = 0;
 #ifdef DDS_HAS_SHM
   wr->has_iceoryx = (0x0 == (xqos->ignore_locator_type & DDSI_LOCATOR_KIND_SHEM));

--- a/src/core/ddsi/src/ddsi_hbcontrol.c
+++ b/src/core/ddsi/src/ddsi_hbcontrol.c
@@ -277,6 +277,8 @@ struct ddsi_xmsg *ddsi_writer_hbcontrol_piggyback (struct ddsi_writer *wr, const
     /* So we force a heartbeat in - but we also rely on our caller to
        send the packet out */
     msg = ddsi_writer_hbcontrol_create_heartbeat (wr, whcst, tnow, *hbansreq, 1);
+    if (wr->test_suppress_flush_on_sync_heartbeat)
+      *hbansreq = 1;
   } else if (last_packetid != packetid && tnow.v - t_of_last_hb.v > DDS_USECS (100)) {
     /* If we crossed a packet boundary since the previous write,
        piggyback a heartbeat, with *hbansreq determining whether or

--- a/src/core/ddsi/src/ddsi_receive.c
+++ b/src/core/ddsi/src/ddsi_receive.c
@@ -699,12 +699,12 @@ struct ddsi_xmsg * ddsi_gap_info_create_gap(struct ddsi_writer *wr, struct ddsi_
 struct defer_hb_state {
   struct ddsi_xmsg *m;
   struct ddsi_xeventq *evq;
-  int hbansreq;
+  enum ddsi_hbcontrol_ack_required hbansreq;
   uint64_t wr_iid;
   uint64_t prd_iid;
 };
 
-static void defer_heartbeat_to_peer (struct ddsi_writer *wr, const struct ddsi_whc_state *whcst, struct ddsi_proxy_reader *prd, int hbansreq, struct defer_hb_state *defer_hb_state)
+static void defer_heartbeat_to_peer (struct ddsi_writer *wr, const struct ddsi_whc_state *whcst, struct ddsi_proxy_reader *prd, enum ddsi_hbcontrol_ack_required hbansreq, struct defer_hb_state *defer_hb_state)
 {
   ETRACE (wr, "defer_heartbeat_to_peer: "PGUIDFMT" -> "PGUIDFMT" - queue for transmit\n", PGUID (wr->e.guid), PGUID (prd->e.guid));
 
@@ -735,7 +735,7 @@ static void defer_heartbeat_to_peer (struct ddsi_writer *wr, const struct ddsi_w
   defer_hb_state->prd_iid = prd->e.iid;
 }
 
-static void force_heartbeat_to_peer (struct ddsi_writer *wr, const struct ddsi_whc_state *whcst, struct ddsi_proxy_reader *prd, int hbansreq, struct defer_hb_state *defer_hb_state)
+static void force_heartbeat_to_peer (struct ddsi_writer *wr, const struct ddsi_whc_state *whcst, struct ddsi_proxy_reader *prd, enum ddsi_hbcontrol_ack_required hbansreq, struct defer_hb_state *defer_hb_state)
 {
   defer_heartbeat_to_peer (wr, whcst, prd, hbansreq, defer_hb_state);
   ddsi_qxev_msg (wr->evq, defer_hb_state->m);

--- a/src/core/ddsi/src/ddsi_transmit.c
+++ b/src/core/ddsi/src/ddsi_transmit.c
@@ -426,7 +426,7 @@ static void transmit_sample_unlocks_wr (struct ddsi_xpack *xp, struct ddsi_write
   /* on entry: &wr->e.lock held; on exit: lock no longer held */
   struct ddsi_domaingv const * const gv = wr->e.gv;
   struct ddsi_xmsg *hmsg = NULL;
-  int hbansreq = 0;
+  enum ddsi_hbcontrol_ack_required hbansreq = DDSI_HBC_ACK_REQ_NO;
   uint32_t sz;
   assert(xp);
   assert((wr->heartbeat_xevent != NULL) == (whcst != NULL));
@@ -459,7 +459,7 @@ static void transmit_sample_unlocks_wr (struct ddsi_xpack *xp, struct ddsi_write
 
   if(hmsg)
     ddsi_xpack_addmsg (xp, hmsg, 0);
-  if (hbansreq >= 2)
+  if (hbansreq >= DDSI_HBC_ACK_REQ_YES_AND_FLUSH)
     ddsi_xpack_send (xp, true);
 }
 


### PR DESCRIPTION
This PR adds support for invoking `dds_write_flush` on a publisher or participant with the obvious meaning of flushing the buffers for all writers contained in that entity. The technique used is the same as that for a variety of other operations that need to act on all descendants (like `set_qos`, `set_listener`, &c.)

The test is a bit fragile in the sense that it is quite tightly bound to the behaviour of the stack, but I don't see a good way around that. After all, the batching doesn't guarantee that it never goes out, it merely stops guaranteeing that it will go out before one calls `dds_write_flush`.