### PR TITLE
Add GitHub workflow for MISRA regressions checking

### DIFF
--- a/.github/codeql/resolved-misra-rules.yml
+++ b/.github/codeql/resolved-misra-rules.yml
@@ -1,0 +1,5 @@
+disable-default-queries: true
+
+# List of MISRA rules that have been resolved to check for regressions against.
+queries:
+  - uses: ./codeql-coding-standards/c/misra/src/rules/RULE-3-1/CharacterSequencesAndUsedWithinAComment.ql

--- a/.github/workflows/misra-regressions-check.yml
+++ b/.github/workflows/misra-regressions-check.yml
@@ -1,0 +1,60 @@
+# Check against the set of MISRA rules that have already been 
+# resolved to prevent regressions.
+name: "MISRA regressions check"
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "master" ]
+  schedule:
+    - cron: '16 12 * * 3'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: 'ubuntu-latest'
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Use only 'java' to analyze code written in Java, Kotlin or both
+        # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+        language: [ 'cpp' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Pull in the codeql-coding-standards qlpack repository.
+    # https://github.com/github/codeql-coding-standards
+    - name: Checkout codeql-coding-standards
+      uses: actions/checkout@v3
+      with:
+        repository: github/codeql-coding-standards
+        path: codeql-coding-standards/
+        ref: 39f8f9801307e058d6d9f07dcbe7c7d229c18dd0
+    
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        # Points at the config file containing the MISRA rules that have been resolved.
+        config-file: ./.github/codeql/resolved-misra-rules.yml
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "MISRA"


### PR DESCRIPTION
This introduces some infrastructure that'll let us check for MISRA regressions. We can extend the list under `.github/codeql/resolved-misra-rules.yml` with all the rules that we have resolved. You can look at the following for more information on the components that were involved:

- CodeQL Scanning:
  - https://github.com/github/codeql
  - https://codeql.github.com/docs/
- Coding Standards `qlpack`s (which includes an in-progress version of the MISRA C 2012 checks):
  - https://github.com/github/codeql-coding-standards

Once this check is in place PRs that introduce new violations will be flagged (and somewhere in the repository settings you can specify that the new warnings will mark the PR as failing the checks).