### PR TITLE
Address MISRA rule 10.2 violations across Cyclone

### DIFF
--- a/.github/codeql/resolved-misra-rules.yml
+++ b/.github/codeql/resolved-misra-rules.yml
@@ -3,3 +3,4 @@ disable-default-queries: true
 # List of MISRA rules that have been resolved to check for regressions against.
 queries:
   - uses: ./codeql-coding-standards/c/misra/src/rules/RULE-3-1/CharacterSequencesAndUsedWithinAComment.ql
+  - uses: ./codeql-coding-standards/c/misra/src/rules/RULE-10-2/AdditionSubtractionOnEssentiallyCharType.ql

--- a/src/core/ddsi/src/ddsi_tran.c
+++ b/src/core/ddsi/src/ddsi_tran.c
@@ -70,7 +70,7 @@ static bool type_is_numeric (const char *type, size_t len, int32_t *value)
   {
     if (!isdigit ((unsigned char) type[i]))
       return false;
-    int32_t d = (unsigned char) type[i] - '0';
+    int32_t d = (char) type[i] - '0';
     if (*value > INT32_MAX / 10 || 10 * *value > INT32_MAX - d)
       return false;
     *value = 10 * *value + d;

--- a/src/ddsrt/src/strtol.c
+++ b/src/ddsrt/src/strtol.c
@@ -18,11 +18,11 @@
 int32_t ddsrt_todigit(const int chr)
 {
   if (chr >= '0' && chr <= '9') {
-    return chr - '0';
+    return (char) chr - '0';
   } else if (chr >= 'a' && chr <= 'z') {
-    return 10 + (chr - 'a');
+    return 10 + ((char) chr - 'a');
   } else if (chr >= 'A' && chr <= 'Z') {
-    return 10 + (chr - 'A');
+    return 10 + ((char) chr - 'A');
   }
 
   return -1;

--- a/src/idl/src/string.c
+++ b/src/idl/src/string.c
@@ -90,11 +90,11 @@ int idl_isdigit(int chr, int base)
   int num = -1;
   assert(base > 0 && base < 36);
   if (chr >= '0' && chr <= '9')
-    num = chr - '0';
+    num = (char) chr - '0';
   else if (chr >= 'a' && chr <= 'z')
-    num = chr - 'a';
+    num = (char) chr - 'a';
   else if (chr >= 'A' && chr <= 'Z')
-    num = chr - 'A';
+    num = (char) chr - 'A';
   return num != -1 && num < base ? num : -1;
 }
 

--- a/src/tools/idlpp/src/support.c
+++ b/src/tools/idlpp/src/support.c
@@ -1163,7 +1163,7 @@ static char *   scan_ucn(
         }
         c = tolower( c);
         *out++ = (char)c;
-        c = (isdigit( c) ? (c - '0') : (c - 'a' + 10));
+        c = (isdigit( c) ? ((char) c - '0') : ((char) c - 'a' + 10));
         value = (value << 4) | (unsigned int)c;
     }
     if (infile->fp                              /* In source        */

--- a/src/tools/idlpp/src/system.c
+++ b/src/tools/idlpp/src/system.c
@@ -1107,7 +1107,7 @@ plus:
             i = *mcpp_optarg;
             if (! isdigit( i) || *(mcpp_optarg + 1) != EOS)
                 usage( opt);
-            stdc_val = i - '0';
+            stdc_val = (char) i - '0';
             sflag = TRUE;
             break;
 


### PR DESCRIPTION
This addresses rule 10.2 by casting to `char` where appropriate or fixing casts that were slightly wonky. See the body of the commit in 7ea3b2381c83181f7a05c8723af4af53b7f7b284 for a little bit more information.

This also adds a MISRA regression check in 159754f4cccf1d78da8251f176420643f84b97fd.