### PR TITLE
Use full version in shared objects

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -80,7 +80,7 @@ target_include_directories(
   $<BUILD_INTERFACE:$<TARGET_PROPERTY:ddsrt,INTERFACE_INCLUDE_DIRECTORIES>>)
 
 # SOVERSION should increase on incompatible ABI change
-set_target_properties(ddsc PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
+set_target_properties(ddsc PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION})
 
 # define target property to indicate if Cyclone DDS is compiled with SHM support
 define_property(TARGET

--- a/src/core/cdr/CMakeLists.txt
+++ b/src/core/cdr/CMakeLists.txt
@@ -42,6 +42,8 @@ else()
 
   add_library(${PROJECT_NAME}::cdr ALIAS cdr)
 
+  set_target_properties(cdr PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION})
+
   target_sources(cdr PRIVATE ${srcs_cdr} ${hdrs_private_cdr})
   target_include_directories(cdr PUBLIC "${CMAKE_CURRENT_LIST_DIR}/include"
                                          "${PROJECT_BINARY_DIR}/include"

--- a/src/idl/CMakeLists.txt
+++ b/src/idl/CMakeLists.txt
@@ -153,7 +153,7 @@ set_target_properties(
   idl PROPERTIES
   OUTPUT_NAME "cycloneddsidl"
   VERSION ${PROJECT_VERSION}
-  SOVERSION ${PROJECT_VERSION_MAJOR})
+  SOVERSION ${PROJECT_VERSION})
 
 generate_export_header(idl EXPORT_FILE_NAME include/idl/export.h)
 


### PR DESCRIPTION
One mishap too many occurred where a symbol was added to the core library, the C++ binding depended on it and the library path pointed to an older core library.

In traditional C binary interface compatibility terms, the old binaries can run with the new library and so it is compatible, but the practice turns out to be different.