### PR TITLE
Include type-info in sertype_equal for default sertype implementation

### DIFF
--- a/src/core/ddsc/src/dds_sertype_default.c
+++ b/src/core/ddsc/src/dds_sertype_default.c
@@ -57,6 +57,29 @@ static bool sertype_default_equal (const struct ddsi_sertype *acmn, const struct
     return false;
   assert (a->type.opt_size_xcdr1 == b->type.opt_size_xcdr1);
   assert (a->type.opt_size_xcdr2 == b->type.opt_size_xcdr2);
+
+#ifdef DDS_HAS_TYPE_DISCOVERY
+  if (a->type.flagset & DDS_TOPIC_XTYPES_METADATA)
+  {
+    ddsi_typeinfo_t *ti_a, *ti_b;
+    ti_a = ddsi_typeinfo_deser (a->typeinfo_ser.data, a->typeinfo_ser.sz);
+    ti_b = ddsi_typeinfo_deser (b->typeinfo_ser.data, b->typeinfo_ser.sz);
+    bool ti_eq = ti_a != NULL && ti_b != NULL && ddsi_typeinfo_equal (ti_a, ti_b, DDSI_TYPE_IGNORE_DEPS);
+    if (ti_a != NULL)
+    {
+      ddsi_typeinfo_fini (ti_a);
+      ddsrt_free (ti_a);
+    }
+    if (ti_b != NULL)
+    {
+      ddsi_typeinfo_fini (ti_b);
+      ddsrt_free (ti_b);
+    }
+    if (!ti_eq)
+      return false;
+  }
+#endif
+
   return true;
 }
 

--- a/src/core/ddsc/tests/CMakeLists.txt
+++ b/src/core/ddsc/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ idlc_generate(TARGET DataRepresentationTypes FILES DataRepresentationTypes.idl W
 idlc_generate(TARGET MinXcdrVersion FILES MinXcdrVersion.idl)
 idlc_generate(TARGET CdrStreamOptimize FILES CdrStreamOptimize.idl WARNINGS no-implicit-extensibility)
 idlc_generate(TARGET CdrStreamSkipDefault FILES CdrStreamSkipDefault.idl)
+idlc_generate(TARGET SertypeData FILES SertypeData.idl)
 if(ENABLE_TYPE_DISCOVERY)
   idlc_generate(TARGET XSpace FILES XSpace.idl XSpaceEnum.idl XSpaceMustUnderstand.idl XSpaceTypeConsistencyEnforcement.idl WARNINGS no-implicit-extensibility no-inherit-appendable)
   idlc_generate(TARGET XSpaceNoTypeInfo FILES XSpaceNoTypeInfo.idl NO_TYPE_INFO WARNINGS no-implicit-extensibility)
@@ -89,6 +90,7 @@ set(ddsc_test_sources
     "test_oneliner.c"
     "test_oneliner.h"
     "cdrstream.c"
+    "sertype.c"
   )
 
 if(ENABLE_LIFESPAN)
@@ -130,7 +132,7 @@ if(ENABLE_SHM)
 endif()
 
 target_link_libraries(cunit_ddsc PRIVATE
-  RoundTrip Space TypesArrayKey WriteTypes InstanceHandleTypes RWData CreateWriter DataRepresentationTypes MinXcdrVersion CdrStreamOptimize CdrStreamSkipDefault ddsc)
+  RoundTrip Space TypesArrayKey WriteTypes InstanceHandleTypes RWData CreateWriter DataRepresentationTypes MinXcdrVersion CdrStreamOptimize CdrStreamSkipDefault SertypeData ddsc)
 
 if(ENABLE_TYPE_DISCOVERY)
   target_link_libraries(cunit_ddsc PRIVATE

--- a/src/core/ddsc/tests/SertypeData.idl
+++ b/src/core/ddsc/tests/SertypeData.idl
@@ -1,0 +1,20 @@
+// Copyright(c) 2023 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+@final
+struct SertypeDefaultCompare1 {
+  long f1;
+};
+
+@final
+struct SertypeDefaultCompare2 {
+  @min(1) @max(10)
+  long f1;
+};

--- a/src/core/ddsc/tests/sertype.c
+++ b/src/core/ddsc/tests/sertype.c
@@ -1,0 +1,77 @@
+// Copyright(c) 2023 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+#include "CUnit/Theory.h"
+#include "dds/dds.h"
+#include "dds/ddsi/ddsi_typelib.h"
+#include "dds/ddsi/ddsi_typewrap.h"
+#include "test_common.h"
+#include "test_util.h"
+#include "SertypeData.h"
+
+CU_Test (ddsc_sertype_default, compare)
+{
+  dds_return_t ret;
+  dds_entity_t domain = dds_create_domain (0, NULL);
+  CU_ASSERT_FATAL (domain >= 0);
+  dds_entity_t participant = dds_create_participant (0, NULL, NULL);
+  CU_ASSERT_FATAL (participant >= 0);
+
+  char topic_name[100];
+  create_unique_topic_name ("ddsc_dynamic_type", topic_name, sizeof (topic_name));
+
+  dds_topic_descriptor_t SertypeDefaultCompare1a_desc = SertypeDefaultCompare2_desc;
+  SertypeDefaultCompare1a_desc.m_typename = "SertypeDefaultCompare1";
+  dds_entity_t topic1 = dds_create_topic (participant, &SertypeDefaultCompare1_desc, topic_name, NULL, NULL);
+  dds_entity_t topic2 = dds_create_topic (participant, &SertypeDefaultCompare1a_desc, topic_name, NULL, NULL);
+
+  dds_entity_t rd = dds_create_reader (participant, topic1, NULL, NULL);
+  dds_entity_t wr = dds_create_writer (participant, topic2, NULL, NULL);
+  sync_reader_writer (participant, rd, participant, wr);
+
+  dds_typeinfo_t *rd_type_info, *wr_type_info;
+  const struct ddsi_sertype *rd_sertype, *wr_sertype;
+
+  ret = dds_get_entity_sertype (rd, &rd_sertype);
+  CU_ASSERT_EQUAL (ret, DDS_RETCODE_OK);
+  ret = dds_get_entity_sertype (wr, &wr_sertype);
+  CU_ASSERT_EQUAL (ret, DDS_RETCODE_OK);
+
+#ifdef DDS_HAS_TYPE_DISCOVERY
+  ret = dds_get_typeinfo (rd, &rd_type_info);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
+  ret = dds_get_typeinfo (wr, &wr_type_info);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
+
+  // Minimal types should be equal, but complete types different because of annotation on type 1a
+  const ddsi_typeid_t * rd_type_min = ddsi_typeinfo_minimal_typeid (rd_type_info);
+  const ddsi_typeid_t * wr_type_min = ddsi_typeinfo_minimal_typeid (wr_type_info);
+  const ddsi_typeid_t * rd_type_compl = ddsi_typeinfo_complete_typeid (rd_type_info);
+  const ddsi_typeid_t * wr_type_compl = ddsi_typeinfo_complete_typeid (wr_type_info);
+
+  CU_ASSERT (ddsi_typeid_compare (rd_type_min, wr_type_min) == 0);
+  CU_ASSERT (ddsi_typeid_compare (rd_type_compl, wr_type_compl) != 0);
+
+  // Sertypes should be different, because of different complete types
+  CU_ASSERT_NOT_EQUAL (rd_sertype, wr_sertype);
+#else
+  ret = dds_get_typeinfo (rd, &rd_type_info);
+  CU_ASSERT_NOT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
+  ret = dds_get_typeinfo (rd, &wr_type_info);
+  CU_ASSERT_NOT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
+
+  // Sertypes should be the same, because other than type-info, types are equal
+  CU_ASSERT_EQUAL (rd_sertype, wr_sertype);
+#endif
+
+  dds_free_typeinfo (rd_type_info);
+  dds_free_typeinfo (wr_type_info);
+}
+


### PR DESCRIPTION
When comparing sertypes that have xtypes type meta-data, the type information should be included. This PR adds the check to the default sertype implementation and adds a test for this.