### PR TITLE
Add ddsrt/src/bswap.c as source for cdr target

### DIFF
--- a/src/core/cdr/CMakeLists.txt
+++ b/src/core/cdr/CMakeLists.txt
@@ -42,7 +42,7 @@ else()
 
   add_library(${PROJECT_NAME}::cdr ALIAS cdr)
 
-  target_sources(cdr PRIVATE ${srcs_cdr} ${hdrs_private_cdr})
+  target_sources(cdr PRIVATE ${srcs_cdr} ${hdrs_private_cdr} ${CMAKE_CURRENT_LIST_DIR}/../../ddsrt/src/bswap.c)
   target_include_directories(cdr PUBLIC "${CMAKE_CURRENT_LIST_DIR}/include"
                                          "${PROJECT_BINARY_DIR}/include"
                                          "${CMAKE_CURRENT_LIST_DIR}/../../ddsrt/include"


### PR DESCRIPTION
Trying to use `src/core/cdr/CMakeLists.txt` directly in a side project (to benefit CDR encoding/decoding in a zenoh-pico application), I get the following errors:

```log
[ 88%] Building C object _deps/cyclonedds_cdr-build/CMakeFiles/cdr.dir/src/dds_cdrstream.c.o
[ 89%] Linking C shared library libcdr.dylib
Undefined symbols for architecture arm64:
  "_ddsrt_bswap2u", referenced from:
      _dds_os_put2BE in dds_cdrstream.c.o
      _dds_stream_swap in dds_cdrstream.c.o
      _normalize_uint16 in dds_cdrstream.c.o
      _normalize_enumarray in dds_cdrstream.c.o
      _normalize_bitmaskarray in dds_cdrstream.c.o
      _normalize_uni_disc in dds_cdrstream.c.o
      _read_and_normalize_uint16 in dds_cdrstream.c.o
      ...
  "_ddsrt_bswap4u", referenced from:
      _dds_stream_write_keyBE_impl in dds_cdrstream.c.o
      _dds_stream_extract_keyBE_from_key_prim_op in dds_cdrstream.c.o
      _dds_stream_write_delimitedBE in dds_cdrstream.c.o
      _dds_stream_write_plBE in dds_cdrstream.c.o
      _dds_os_put4BE in dds_cdrstream.c.o
      _dds_stream_write_seqBE in dds_cdrstream.c.o
      _dds_stream_write_arrBE in dds_cdrstream.c.o
      ...
  "_ddsrt_bswap8u", referenced from:
      _dds_os_put8BE in dds_cdrstream.c.o
      _read_and_normalize_uint64 in dds_cdrstream.c.o
```

The CMakeLists.txt of my project fetches `cdr` from CycloneDDS as such:
```cmake
include(FetchContent)
FetchContent_Declare(cyclonedds_cdr
  GIT_REPOSITORY "https://github.com/eclipse-cyclonedds/cyclonedds"
  GIT_TAG "origin/master"
  SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/cyclonedds"
  SOURCE_SUBDIR "src/core/cdr"
)
FetchContent_MakeAvailable(cyclonedds_cdr)
```

This PR fixes the error explicitly adding the `ddsrt/src/bswap.c` as source file for the `cdr` target.