### PR TITLE
Move project() statements below cmake_minimum_required()

### DIFF
--- a/examples/dynsub/CMakeLists.txt
+++ b/examples/dynsub/CMakeLists.txt
@@ -9,8 +9,8 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
-project(dynsub LANGUAGES C)
 cmake_minimum_required(VERSION 3.16)
+project(dynsub LANGUAGES C)
 
 if(NOT TARGET CycloneDDS::ddsc)
   find_package(CycloneDDS REQUIRED)

--- a/examples/helloworld/CMakeLists.txt
+++ b/examples/helloworld/CMakeLists.txt
@@ -9,8 +9,8 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
-project(helloword LANGUAGES C)
 cmake_minimum_required(VERSION 3.16)
+project(helloword LANGUAGES C)
 
 if(NOT TARGET CycloneDDS::ddsc)
   # Find the CycloneDDS package.

--- a/examples/listtopics/CMakeLists.txt
+++ b/examples/listtopics/CMakeLists.txt
@@ -9,8 +9,8 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
-project(listtopics LANGUAGES C)
 cmake_minimum_required(VERSION 3.16)
+project(listtopics LANGUAGES C)
 
 if(NOT TARGET CycloneDDS::ddsc)
   find_package(CycloneDDS REQUIRED)

--- a/examples/roundtrip/CMakeLists.txt
+++ b/examples/roundtrip/CMakeLists.txt
@@ -9,8 +9,8 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
-project(roundtrip LANGUAGES C)
 cmake_minimum_required(VERSION 3.16)
+project(roundtrip LANGUAGES C)
 
 if(NOT TARGET CycloneDDS::ddsc)
   # Find the CycloneDDS package.

--- a/examples/shm_throughput/CMakeLists.txt
+++ b/examples/shm_throughput/CMakeLists.txt
@@ -9,8 +9,8 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
-project(shm_throughput LANGUAGES C)
 cmake_minimum_required(VERSION 3.16)
+project(shm_throughput LANGUAGES C)
 
 if(NOT TARGET CycloneDDS::ddsc)
   # Find the CycloneDDS package.

--- a/examples/throughput/CMakeLists.txt
+++ b/examples/throughput/CMakeLists.txt
@@ -9,8 +9,8 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
-project(throughput LANGUAGES C)
 cmake_minimum_required(VERSION 3.16)
+project(throughput LANGUAGES C)
 
 if(NOT TARGET CycloneDDS::ddsc)
   # Find the CycloneDDS package.


### PR DESCRIPTION
The `cmake_minimum_required()` statement configures compatibility settings and CMake policies which also affect `project()`. Therefore, it should be the first statement executed. Starting with CMake 3.26, a warning is issued otherwise. This PR fixes the examples and silences the warning.
