### PR TITLE
Remove enum forward declarations

### DIFF
--- a/src/idl/include/idl/expression.h
+++ b/src/idl/include/idl/expression.h
@@ -13,14 +13,13 @@
 
 #include "idl/tree.h"
 
-typedef enum idl_equality idl_equality_t;
-enum idl_equality {
+typedef enum idl_equality {
   IDL_INVALID = -3,
   IDL_MISMATCH = -2, /**< type mismatch */
   IDL_LESS = -1,
   IDL_EQUAL,
   IDL_GREATER,
-};
+} idl_equality_t;
 
 IDL_EXPORT idl_equality_t
 idl_compare(

--- a/src/idl/include/idl/processor.h
+++ b/src/idl/include/idl/processor.h
@@ -59,8 +59,7 @@ struct idl_typeinfo_typemap {
   size_t typemap_size;
 };
 
-typedef enum idl_warning idl_warning_t;
-enum idl_warning {
+typedef enum idl_warning {
   IDL_WARN_GENERIC,
   IDL_WARN_IMPLICIT_EXTENSIBILITY,
   IDL_WARN_EXTRA_TOKEN_DIRECTIVE,
@@ -68,7 +67,7 @@ enum idl_warning {
   IDL_WARN_INHERIT_APPENDABLE,
   IDL_WARN_ENUM_CONSECUTIVE,
   IDL_WARN_UNSUPPORTED_ANNOTATIONS
-};
+} idl_warning_t;
 
 typedef bool (*track_warning_fn)(idl_warning_t warning);
 

--- a/src/idl/include/idl/tree.h
+++ b/src/idl/include/idl/tree.h
@@ -72,8 +72,7 @@
 
 /* bits 20 - 21 are reserved for operators (not exposed in tree) */
 
-typedef enum idl_type idl_type_t;
-enum idl_type {
+typedef enum idl_type {
   IDL_NULL = 0u,
   IDL_TYPEDEF = (1llu<<19),
   /* constructed types */
@@ -119,7 +118,7 @@ enum idl_type {
   IDL_FLOAT = (IDL_BASE_TYPE | IDL_FLOATING_PT_TYPE | 1u),
   IDL_DOUBLE = (IDL_BASE_TYPE | IDL_FLOATING_PT_TYPE | 2u),
   IDL_LDOUBLE = (IDL_BASE_TYPE | IDL_FLOATING_PT_TYPE | 3u)
-};
+} idl_type_t;
 
 #define IDL_TYPE_MASK ((IDL_TYPEDEF << 1) - 1)
 
@@ -180,25 +179,22 @@ struct idl_path {
   const idl_node_t **nodes;
 };
 
-typedef enum idl_autoid idl_autoid_t;
-enum idl_autoid {
+typedef enum idl_autoid {
   IDL_SEQUENTIAL,
   IDL_HASH
-};
+} idl_autoid_t;
 
-typedef enum idl_extensibility idl_extensibility_t;
-enum idl_extensibility {
+typedef enum idl_extensibility {
   IDL_FINAL,
   IDL_APPENDABLE,
   IDL_MUTABLE
-};
+} idl_extensibility_t;
 
-typedef enum idl_try_construct idl_try_construct_t;
-enum idl_try_construct {
+typedef enum idl_try_construct {
   IDL_DISCARD,
   IDL_USE_DEFAULT,
   IDL_TRIM
-};
+} idl_try_construct_t;
 
 typedef uint32_t allowable_data_representations_t;
 #define IDL_ALLOWABLE_DATAREPRESENTATION_DEFAULT (0xffffffff)

--- a/src/idl/include/idl/visit.h
+++ b/src/idl/include/idl/visit.h
@@ -16,8 +16,7 @@
 
 struct idl_pstate;
 
-typedef enum idl_accept idl_accept_t;
-enum idl_accept {
+typedef enum idl_accept {
   IDL_ACCEPT_INHERIT_SPEC,
   IDL_ACCEPT_SWITCH_TYPE_SPEC,
   IDL_ACCEPT_MODULE,
@@ -39,7 +38,7 @@ enum idl_accept {
   IDL_ACCEPT_SEQUENCE,
   IDL_ACCEPT_STRING,
   IDL_ACCEPT /**< generic callback, used if no specific callback exists */
-};
+} idl_accept_t;
 
 /* generating native language representations for types is relatively
    straightforward, but generating serialization code requires more context.
@@ -64,30 +63,27 @@ typedef idl_retcode_t(*idl_visitor_callback_t)(
    instruct the visitor to recurse, iterate and/or revisit by signalling the
    inverse */
 
-typedef enum idl_visit_recurse idl_visit_recurse_t;
-enum idl_visit_recurse {
+typedef enum idl_visit_recurse {
   IDL_VISIT_RECURSE_BY_DEFAULT = 0,
   IDL_VISIT_RECURSE = (1<<0), /**< Recurse into subtree(s) */
   IDL_VISIT_DONT_RECURSE = (1<<1) /**< Do not recurse into subtree(s) */
-};
+} idl_visit_recurse_t;
 
 /* FIXME: it now applies to the next level. instead, it should apply to the
         current level. in which case IDL_VISIT_ITERATE instructs the
         visitor to continue, IDL_VISIT_DONT_ITERATE does the inverse!
 */
-typedef enum idl_visit_iterate idl_visit_iterate_t;
-enum idl_visit_iterate {
+typedef enum idl_visit_iterate {
   IDL_VISIT_ITERATE_BY_DEFAULT = 0,
   IDL_VISIT_ITERATE = (1<<2), /**< Iterate over subtree(s) */
   IDL_VISIT_DONT_ITERATE = (1<<3) /**< Do not iterate over subtree(s) */
-};
+} idl_visit_iterate_t;
 
-typedef enum idl_visit_revisit idl_visit_revisit_t;
-enum idl_visit_revisit {
+typedef enum idl_visit_revisit {
   IDL_VISIT_DONT_REVISIT_BY_DEFAULT = 0,
   IDL_VISIT_REVISIT = (1<<4), /**< Revisit node(s) on exit */
   IDL_VISIT_DONT_REVISIT = (1<<5) /**< Do not revisit node(s) on exit */
-};
+} idl_visit_revisit_t;
 
 /** Visit associated type specifier (callback signal) */
 #define IDL_VISIT_TYPE_SPEC (1<<6)

--- a/src/idl/src/expression.h
+++ b/src/idl/src/expression.h
@@ -20,8 +20,7 @@
 #define IDL_EXPRESSION \
   (IDL_LITERAL|IDL_UNARY_OPERATOR|IDL_BINARY_OPERATOR)
 
-typedef enum idl_operator idl_operator_t;
-enum idl_operator {
+typedef enum idl_operator {
   IDL_NOP = 0,
 #define IDL_UNARY_OPERATOR (1ull<<21)
   IDL_MINUS = (IDL_UNARY_OPERATOR|1u),
@@ -38,7 +37,7 @@ enum idl_operator {
   IDL_MULTIPLY,
   IDL_DIVIDE,
   IDL_MODULO
-};
+} idl_operator_t;
 
 idl_operator_t idl_operator(const void *node);
 


### PR DESCRIPTION
C++ forbids forward declaration of enums, so including CycloneDDS headers in a C++ program generates a compile-time error. 

This PR fixes the issue by removing the forward declaration of enums.