### PR TITLE
Fix error handling in type wrapper and type object fuzzing test

### DIFF
--- a/fuzz/fuzz_type_object/fuzz_type_object.c
+++ b/fuzz/fuzz_type_object/fuzz_type_object.c
@@ -85,10 +85,13 @@ int LLVMFuzzerTestOneInput(
         ddsi_typeid_copy_impl (&type_info.x.complete.typeid_with_size.type_id, &type_id_complete->x);
 
         struct ddsi_type *type;
-        ddsi_type_ref_proxy (&gv, &type, &type_info, DDSI_TYPEID_KIND_COMPLETE, NULL);
-        if (type)
+        dds_return_t ret = ddsi_type_ref_proxy (&gv, &type, &type_info, DDSI_TYPEID_KIND_COMPLETE, NULL);
+        if (ret == DDS_RETCODE_OK)
+        {
+          assert (type != NULL);
           ddsi_type_add_typeobj (&gv, type, &type_object_complete->x);
-        ddsi_type_unref (&gv, type);
+          ddsi_type_unref (&gv, type);
+        }
         ddsi_typeinfo_fini (&type_info);
       }
     }

--- a/src/core/ddsi/src/ddsi_typewrap.c
+++ b/src/core/ddsi/src/ddsi_typewrap.c
@@ -1001,7 +1001,7 @@ static dds_return_t add_minimal_typeobj (struct ddsi_domaingv *gv, struct xt_typ
         xt->_u.structure.members.seq[n].flags = mto->_u.struct_type.member_seq._buffer[n].common.member_flags;
         if ((ret = ddsi_type_register_dep (gv, &xt->id, &xt->_u.structure.members.seq[n].type, &mto->_u.struct_type.member_seq._buffer[n].common.member_type_id)) != DDS_RETCODE_OK)
         {
-          for (uint32_t m = 0; m < n - 1; m++)
+          for (uint32_t m = 0; m < n; m++)
             ddsi_type_unref_locked (gv, xt->_u.structure.members.seq[m].type);
           if (xt->_u.structure.base_type)
             ddsi_type_unref_locked (gv, xt->_u.structure.base_type);
@@ -1025,7 +1025,7 @@ static dds_return_t add_minimal_typeobj (struct ddsi_domaingv *gv, struct xt_typ
         xt->_u.union_type.members.seq[n].flags = mto->_u.union_type.member_seq._buffer[n].common.member_flags;
         if ((ret = ddsi_type_register_dep (gv, &xt->id, &xt->_u.union_type.members.seq[n].type, &mto->_u.union_type.member_seq._buffer[n].common.type_id)) != DDS_RETCODE_OK)
         {
-          for (uint32_t m = 0; m < n - 1; m++)
+          for (uint32_t m = 0; m < n; m++)
           {
             ddsi_type_unref_locked (gv, xt->_u.union_type.members.seq[m].type);
             ddsrt_free (xt->_u.union_type.members.seq[m].label_seq._buffer);
@@ -1170,7 +1170,7 @@ static dds_return_t add_complete_typeobj (struct ddsi_domaingv *gv, struct xt_ty
         xt->_u.structure.members.seq[n].flags = cto->_u.struct_type.member_seq._buffer[n].common.member_flags;
         if ((ret = ddsi_type_register_dep (gv, &xt->id, &xt->_u.structure.members.seq[n].type, &cto->_u.struct_type.member_seq._buffer[n].common.member_type_id)) != DDS_RETCODE_OK)
         {
-          for (uint32_t m = 0; m < n - 1; m++)
+          for (uint32_t m = 0; m < n; m++)
           {
             ddsi_type_unref_locked (gv, xt->_u.structure.members.seq[m].type);
             xt_applied_member_annotations_fini (&xt->_u.structure.members.seq[m].detail.annotations);
@@ -1197,7 +1197,7 @@ static dds_return_t add_complete_typeobj (struct ddsi_domaingv *gv, struct xt_ty
         xt->_u.union_type.members.seq[n].flags = cto->_u.union_type.member_seq._buffer[n].common.member_flags;
         if ((ret = ddsi_type_register_dep (gv, &xt->id, &xt->_u.union_type.members.seq[n].type, &cto->_u.union_type.member_seq._buffer[n].common.type_id)) != DDS_RETCODE_OK)
         {
-          for (uint32_t m = 0; m < n - 1; m++)
+          for (uint32_t m = 0; m < n; m++)
           {
             ddsi_type_unref_locked (gv, xt->_u.union_type.members.seq[m].type);
             ddsrt_free (xt->_u.union_type.members.seq[m].label_seq._buffer);


### PR DESCRIPTION
This fixes a bug in the error handling for the functions that add type details to a type in the type library. A fix in the error handling in the OSS type object fuzzer is also included. 