### PR TITLE
remove leading and trailing white spaces from distinguished name when…

### DIFF
--- a/src/core/xtests/symbol_export/symbol_export.c
+++ b/src/core/xtests/symbol_export/symbol_export.c
@@ -988,6 +988,7 @@ int main (int argc, char **argv)
   ddsrt_strlcpy (ptr, ptr2, 1);
   ddsrt_strlcat (ptr, ptr2, 1);
   ddsrt_str_replace (ptr, ptr2, ptr3, 1);
+  ddsrt_str_trim (ptr);
 
   // ddsrt/strtol.h
   ddsrt_todigit (0);

--- a/src/ddsrt/include/dds/ddsrt/string.h
+++ b/src/ddsrt/include/dds/ddsrt/string.h
@@ -190,6 +190,16 @@ ddsrt_str_replace(
     size_t max)
 ddsrt_nonnull_all;
 
+/**
+ * @brief Trim leading and trailing white space characters.
+ *
+ * @param[in,out] str  pointer to string.
+ *
+ */
+DDS_EXPORT void
+ddsrt_str_trim(
+  char *str);
+
 #if defined (__cplusplus)
 }
 #endif

--- a/src/ddsrt/src/string.c
+++ b/src/ddsrt/src/string.c
@@ -219,3 +219,41 @@ ddsrt_strndup(const char *str, size_t len)
 
   return s;
 }
+
+void
+ddsrt_str_trim(char *str)
+{
+  int index, i;
+
+  if (str == NULL) {
+    return;
+  }
+  
+  /* trim leading white spaces */
+  index = 0;
+  while(str[index] == ' ' || str[index] == '\t' || str[index] == '\n') {
+    index++;
+  }
+
+  /* shift all trailing characters to its left */
+  i = 0;
+  while(str[i + index] != '\0') {
+    str[i] = str[i + index];
+    i++;
+  }
+  str[i] = '\0'; /* terminate string with NULL */
+
+  /* trim trailing white spaces */
+  i = 0;
+  index = -1;
+  while(str[i] != '\0') {
+    if(str[i] != ' ' && str[i] != '\t' && str[i] != '\n') {
+      index = i;
+    }
+    i++;
+  }
+
+  /* mark the next character to last non white space character as NULL */
+  str[index + 1] = '\0';
+}
+

--- a/src/security/builtin_plugins/access_control/src/access_control_utils.c
+++ b/src/security/builtin_plugins/access_control/src/access_control_utils.c
@@ -302,6 +302,8 @@ static bool string_to_properties(const char *str, DDS_Security_PropertySeq *prop
     if (strlen(tok) == 0)
       continue;
     char *name = ddsrt_strsep (&tok, "=");
+    ddsrt_str_trim(name);
+    ddsrt_str_trim(tok);
     if (name == NULL || tok == NULL || properties->_length >= properties->_maximum)
     {
       ddsrt_free (copy);
@@ -331,6 +333,8 @@ bool ac_check_subjects_are_equal(const char *permissions_sn, const char *identit
   {
     char *value_pmsn;
     char *name_idsn = ddsrt_strsep (&tok_idsn, "=");
+    ddsrt_str_trim(name_idsn);
+    ddsrt_str_trim(tok_idsn);
     if (name_idsn == NULL || tok_idsn == NULL)
       goto check_subj_equal_failed;
     value_pmsn = DDS_Security_Property_get_value(&prop_pmsn, name_idsn);


### PR DESCRIPTION
DDS Security v1.1 standard mentions distinguished name (DN) is used as subject name, and also DN should follow RFC4514 (String Representation of Distinguished Name). RFC2253 (obsoleted by RFC4514) gives some explanations about how to process whitespace characters in DN.  (refer to https://www.rfc-editor.org/rfc/rfc2253, chapter 4).

So following the standard, below two DNs should be the same.
CN=KeyBoard,OU=AGV,L=Graz,C=AT
CN=Keyboard, OU=AGV, L=Graz, C=AT