### PR TITLE
Fix for idl_generate_generic with files directly on BASE_DIR

### DIFF
--- a/cmake/Modules/Generate.cmake
+++ b/cmake/Modules/Generate.cmake
@@ -168,7 +168,7 @@ function(IDLC_GENERATE_GENERIC)
         message(FATAL_ERROR "Cannot use base dir with different file tree from input file (${_base_dir_abs} to ${_file} yields ${_file_path_rel})")
       endif()
       string(REPLACE ${_name_ext} "" _mid_dir_path ${_file_path_rel})
-      string(REGEX REPLACE "[\\/]$" "" _mid_dir_path ${_mid_dir_path})
+      string(REGEX REPLACE "[\\/]$" "" _mid_dir_path "${_mid_dir_path}")
     endif()
 
     set(_file_outputs "")


### PR DESCRIPTION
An error occurs in CMake when you supply the idlc_generate_generic function a path which contains a file directly located on a supplied BASE_DIR, in this case the _mid_dir_path component does not exist, so the REGEX operation does not get enough arguments Fixed this by converting the _mid_dir_path to a string explicitly, so even when this parameter does not exist, you get an empty string