### PR TITLE
Fix MISRA rule 21-19

### DIFF
--- a/.github/codeql/resolved-misra-rules.yml
+++ b/.github/codeql/resolved-misra-rules.yml
@@ -4,3 +4,4 @@ disable-default-queries: true
 queries:
   - uses: ./codeql-coding-standards/c/misra/src/rules/RULE-3-1/CharacterSequencesAndUsedWithinAComment.ql
   - uses: ./codeql-coding-standards/c/misra/src/rules/RULE-10-2/AdditionSubtractionOnEssentiallyCharType.ql
+  - uses: ./codeql-coding-standards/c/misra/src/rules/RULE-21-19/ValuesReturnedByLocaleSettingUsedAsPtrToConst.ql

--- a/src/ddsrt/src/environ/posix/environ.c
+++ b/src/ddsrt/src/environ/posix/environ.c
@@ -25,7 +25,7 @@ isenvvar(const char *name)
 dds_return_t
 ddsrt_getenv(const char *name, const char **value)
 {
-  char *env;
+  const char *env;
 
   assert(name != NULL);
   assert(value != NULL);


### PR DESCRIPTION
This addresses rule 21.19 .

```
returned by the Standard Library functions 'localeconv', 'getenv', 'setlocale' or, 'strerror' shall only be used as if they have pointer to const-qualified type
```