### PR TITLE
Fix MISRA rule 21-18

### DIFF
--- a/.github/codeql/resolved-misra-rules.yml
+++ b/.github/codeql/resolved-misra-rules.yml
@@ -5,3 +5,4 @@ queries:
   - uses: ./codeql-coding-standards/c/misra/src/rules/RULE-3-1/CharacterSequencesAndUsedWithinAComment.ql
   - uses: ./codeql-coding-standards/c/misra/src/rules/RULE-10-2/AdditionSubtractionOnEssentiallyCharType.ql
   - uses: ./codeql-coding-standards/c/misra/src/rules/RULE-21-19/ValuesReturnedByLocaleSettingUsedAsPtrToConst.ql
+  - uses: ./codeql-coding-standards/c/misra/src/rules/RULE-21-18/StringLibrarySizeArgumentOutOfBounds.ql

--- a/src/ddsrt/src/expand_vars.c
+++ b/src/ddsrt/src/expand_vars.c
@@ -95,7 +95,9 @@ static char *expand_varbrace (const char **src, expand_fn expand, expand_lookup_
         goto err;
     }
     name = ddsrt_malloc ((size_t) (*src - start) + 1);
-    memcpy (name, start, (size_t) (*src - start));
+    if (*src > start) {
+      memcpy (name, start, (size_t) (*src - start));
+    }
     name[*src - start] = 0;
     if (**src == '}') {
         (*src)++;

--- a/src/ddsrt/src/string.c
+++ b/src/ddsrt/src/string.c
@@ -99,7 +99,9 @@ ddsrt_strlcpy(
     if (size <= srclen) {
       len = size - 1;
     }
-    memcpy(dest, src, len);
+    if (len > 0) {
+      memcpy(dest, src, len);
+    }
     dest[len] = '\0';
   }
 

--- a/src/ddsrt/src/xmlparser.c
+++ b/src/ddsrt/src/xmlparser.c
@@ -192,7 +192,9 @@ static int make_chars_available (struct ddsrt_xmlp_state *st, size_t nmin)
     /* ensure buffer space is available */
     if (st->fp != NULL) {
         if (pos + nmin > st->cbufmax) {
-            memmove (st->cbuf, st->cbuf + pos, st->cbufn - pos);
+            if (st->cbufn > pos) {
+              memmove (st->cbuf, st->cbuf + pos, st->cbufn - pos);
+            }
             st->cbufn -= pos;
             st->cbufp -= pos;
             if (st->cbufmark != NOMARKER) {


### PR DESCRIPTION
This addresses rule 21.18.
```
The size_t argument passed to any function in string.h shall have an appropriate value 
```