### PR TITLE
Fix MISRA rule 17-4

### DIFF
--- a/.github/codeql/resolved-misra-rules.yml
+++ b/.github/codeql/resolved-misra-rules.yml
@@ -5,3 +5,4 @@ queries:
   - uses: ./codeql-coding-standards/c/misra/src/rules/RULE-3-1/CharacterSequencesAndUsedWithinAComment.ql
   - uses: ./codeql-coding-standards/c/misra/src/rules/RULE-10-2/AdditionSubtractionOnEssentiallyCharType.ql
   - uses: ./codeql-coding-standards/c/misra/src/rules/RULE-21-19/ValuesReturnedByLocaleSettingUsedAsPtrToConst.ql
+  - uses: ./codeql-coding-standards/c/misra/src/rules/RULE-17-4/NonVoidFunctionReturnCondition.ql

--- a/src/ddsrt/src/sync/posix/sync.c
+++ b/src/ddsrt/src/sync/posix/sync.c
@@ -119,6 +119,7 @@ ddsrt_cond_waituntil(
   }
 
   abort();
+  return false;
 }
 
 bool


### PR DESCRIPTION
This addresses rule 17.4.
```
All exit paths from a function with non-void return type shall have an explicit return statement with an expression 
```