### PR TITLE
fix MISRA rule 8.2

### DIFF
--- a/.github/codeql/resolved-misra-rules.yml
+++ b/.github/codeql/resolved-misra-rules.yml
@@ -6,3 +6,4 @@ queries:
   - uses: ./codeql-coding-standards/c/misra/src/rules/RULE-10-2/AdditionSubtractionOnEssentiallyCharType.ql
   - uses: ./codeql-coding-standards/c/misra/src/rules/RULE-21-19/ValuesReturnedByLocaleSettingUsedAsPtrToConst.ql
   - uses: ./codeql-coding-standards/c/misra/src/rules/RULE-17-4/NonVoidFunctionReturnCondition.ql
+  - uses: ./codeql-coding-standards/c/misra/src/rules/RULE-8-2/FunctionTypesNotInPrototypeForm.ql

--- a/src/core/ddsi/include/dds/ddsi/ddsi_shm_transport.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_shm_transport.h
@@ -81,7 +81,7 @@ DDS_EXPORT void free_iox_chunk(iox_sub_t *iox_sub, void **iox_chunk);
 DDS_EXPORT iceoryx_header_t *iceoryx_header_from_chunk(const void *iox_chunk);
 
 /** @component iceoryx_support */
-void shm_set_loglevel(enum ddsi_shm_loglevel);
+void shm_set_loglevel(enum ddsi_shm_loglevel level);
 
 /** @component iceoryx_support */
 void *shm_create_chunk(iox_pub_t iox_pub, size_t size);

--- a/src/ddsrt/include/dds/ddsrt/log.h
+++ b/src/ddsrt/include/dds/ddsrt/log.h
@@ -113,7 +113,7 @@ typedef struct {
 } dds_log_data_t;
 
 /** Function signature that log and trace callbacks must adhere too. */
-typedef void (*dds_log_write_fn_t) (void *, const dds_log_data_t *);
+typedef void (*dds_log_write_fn_t) (void * p, const dds_log_data_t * d);
 
 /** Semi-opaque type for log/trace configuration. */
 struct ddsrt_log_cfg_common {

--- a/src/ddsrt/include/dds/ddsrt/threads.h
+++ b/src/ddsrt/include/dds/ddsrt/threads.h
@@ -58,7 +58,7 @@ extern "C" {
 /**
  * @brief Definition for a thread routine invoked on thread create.
  */
-typedef uint32_t (*ddsrt_thread_routine_t)(void*);
+typedef uint32_t (*ddsrt_thread_routine_t)(void* p);
 
 /**
  * @brief Definition of the thread attributes
@@ -257,7 +257,7 @@ DDS_EXPORT dds_return_t ddsrt_thread_getname_anythread (ddsrt_thread_list_id_t t
  */
 DDS_EXPORT dds_return_t
 ddsrt_thread_cleanup_push(
-  void (*routine)(void*),
+  void (*routine)(void* p),
   void *arg);
 
 /**

--- a/src/ddsrt/src/threads/posix/threads.c
+++ b/src/ddsrt/src/threads/posix/threads.c
@@ -249,7 +249,7 @@ ddsrt_thread_create (
   ddsrt_thread_t *threadptr,
   const char *name,
   const ddsrt_threadattr_t *threadAttr,
-  uint32_t (*start_routine) (void *),
+  uint32_t (*start_routine) (void * p),
   void *arg)
 {
   pthread_attr_t attr;
@@ -613,7 +613,7 @@ static void thread_init(void)
   (void)pthread_once(&thread_once, &thread_init_once);
 }
 
-dds_return_t ddsrt_thread_cleanup_push (void (*routine) (void *), void *arg)
+dds_return_t ddsrt_thread_cleanup_push (void (*routine) (void * p), void *arg)
 {
   int err;
   thread_cleanup_t *prev, *tail;

--- a/src/ddsrt/src/threads_priv.h
+++ b/src/ddsrt/src/threads_priv.h
@@ -16,7 +16,7 @@
 /** \brief Internal structure used to store cleanup handlers (private) */
 typedef struct {
   void *prev;
-  void (*routine)(void *);
+  void (*routine)(void * p);
   void *arg;
 } thread_cleanup_t;
 


### PR DESCRIPTION
This addresses rule 8.2
```
Function types shall have named parameters.
```