### PR TITLE
Add read/take API calling an application-provided function for each sample

### DIFF
--- a/cmake/Modules/CUnit/src/main.c.in
+++ b/cmake/Modules/CUnit/src/main.c.in
@@ -22,10 +22,12 @@
 
 static struct {
     bool print_help;
+    CU_ErrorAction error_action;
     const char *suite;
     const char *test;
 } opts = {
     false,
+    CUEA_FAIL,
     "*",
     "*"
 };
@@ -78,6 +80,7 @@ static void help(const char *name)
     printf("Usage: %s [OPTIONS]\n", name);
     printf("\n");
     printf("Possible options:\n");
+    printf("  -f           fail fast: abort on failed fatal assert\n");
     printf("  -h           display this help and exit\n");
     printf("  -s PATTERN   run only tests in suites matching pattern\n");
     printf("  -t PATTERN   run only test matching pattern\n");
@@ -97,6 +100,9 @@ static int parse_options(int argc, char *argv[])
         switch ((argv[i][0] == '-') ? argv[i][1] : 0) {
             case 'h':
                 opts.print_help = true;
+                break;
+            case 'f':
+                opts.error_action = CUEA_ABORT;
                 break;
             case 's':
                 if ((i+1) < argc) {
@@ -176,6 +182,7 @@ int main(int argc, char *argv[])
 /* CMake will expand the macro below to register all suites and tests. */
 @defns@
 
+    CU_set_error_action(opts.error_action);
     CU_basic_run_tests();
 
     if (CU_get_error() != CUE_SUCCESS) {

--- a/src/core/ddsc/CMakeLists.txt
+++ b/src/core/ddsc/CMakeLists.txt
@@ -69,6 +69,7 @@ prepend(hdrs_private_ddsc "${CMAKE_CURRENT_LIST_DIR}/src/"
   dds__qos.h
   dds__readcond.h
   dds__guardcond.h
+  dds__read.h
   dds__reader.h
   dds__rhc_default.h
   dds__statistics.h

--- a/src/core/ddsc/include/dds/dds.h
+++ b/src/core/ddsc/include/dds/dds.h
@@ -4121,12 +4121,10 @@ dds_read_next_wl(
  * supported.
  *
  * It is called for the samples in the order compatible with the requirements of the DDS
- * specification, in particular that means instances are contiguous.  Setting the ranks
- * correctly can therefore be done by looking for a change in si.instance_handle and
- * performing a final fixup for the final instance after the call to read or take.
+ * specification, in particular that means instances are contiguous.
  *
  * @param[in] arg A pointer to the application-defined argument passed to read/take
- * @param[in] si A fully initialized sample info object, but with the sample_rank and generation_rank set to 0
+ * @param[in] si A fully initialized sample info object
  * @param[in] st The underlying ddsi_sertype (needed only if si.valid_data is false)
  * @param[in] sd The sample, if si.valid_data is false, the type has been erased (hence the "st" argument)
  *

--- a/src/core/ddsc/include/dds/ddsc/dds_internal_api.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_internal_api.h
@@ -22,35 +22,6 @@ extern "C" {
 #endif
 
 /**
- * @anchor DDS_READ_WITHOUT_LOCK
- * @ingroup internal
- * @brief Constant to use with dds_read() or dds_take() when using dds_reader_lock_samples()
- */
-#define DDS_READ_WITHOUT_LOCK (0xFFFFFFED)
-
-/**
- * @ingroup internal
- * @component reader
- * @unstable
- * @brief Returns number of samples in read cache and locks the reader cache,
- * to make sure that the samples content doesn't change.
- *
- * Because the cache is locked, you should be able to read/take without having to
- * lock first. This is done by passing the @ref DDS_READ_WITHOUT_LOCK value to the
- * read/take call as maxs. Then the read/take will not lock but still unlock.
- *
- * CycloneDDS doesn't support a read/take that just returns all
- * available samples issue #74. As a work around to support LENGTH_UNLIMITED in C++.
- * dds_reader_lock_samples() and @ref DDS_READ_WITHOUT_LOCK are needed.
- *
- * @param[in]   reader  Reader to lock the cache of.
- *
- * @returns the number of samples in the reader cache.
- */
-DDS_EXPORT uint32_t
-dds_reader_lock_samples (dds_entity_t reader);
-
-/**
  * @ingroup internal
  * @component topic
  * @unstable

--- a/src/core/ddsc/include/dds/ddsc/dds_rhc.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_rhc.h
@@ -11,10 +11,11 @@
 #ifndef _DDS_RHC_H_
 #define _DDS_RHC_H_
 
+#include "dds/dds.h"
 #include "dds/ddsrt/static_assert.h"
 #include "dds/ddsi/ddsi_rhc.h"
 
-#define NO_STATE_MASK_SET   (DDS_ANY_STATE + 1)
+#define DDS_RHC_NO_STATE_MASK_SET   (DDS_ANY_STATE + 1)
 
 #if defined (__cplusplus)
 extern "C" {
@@ -26,8 +27,7 @@ struct dds_reader;
 struct ddsi_tkmap;
 
 typedef dds_return_t (*dds_rhc_associate_t) (struct dds_rhc *rhc, struct dds_reader *reader, const struct ddsi_sertype *type, struct ddsi_tkmap *tkmap);
-typedef int32_t (*dds_rhc_read_take_t) (struct dds_rhc *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, struct dds_readcond *cond);
-typedef int32_t (*dds_rhc_read_take_cdr_t) (struct dds_rhc *rhc, bool lock, struct ddsi_serdata **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle);
+typedef int32_t (*dds_rhc_read_take_t) (struct dds_rhc *rhc, int32_t max_samples, uint32_t mask, dds_instance_handle_t handle, struct dds_readcond *cond, dds_read_with_collector_fn_t collect_sample, void *collect_sample_arg);
 
 typedef bool (*dds_rhc_add_readcondition_t) (struct dds_rhc *rhc, struct dds_readcond *cond);
 typedef void (*dds_rhc_remove_readcondition_t) (struct dds_rhc *rhc, struct dds_readcond *cond);
@@ -40,8 +40,6 @@ struct dds_rhc_ops {
   struct ddsi_rhc_ops rhc_ops;
   dds_rhc_read_take_t read;
   dds_rhc_read_take_t take;
-  dds_rhc_read_take_cdr_t readcdr;
-  dds_rhc_read_take_cdr_t takecdr;
   dds_rhc_add_readcondition_t add_readcondition;
   dds_rhc_remove_readcondition_t remove_readcondition;
   dds_rhc_lock_samples_t lock_samples;
@@ -88,23 +86,13 @@ DDS_INLINE_EXPORT inline void dds_rhc_free (struct dds_rhc *rhc) {
 }
 
 /** @component rhc */
-DDS_INLINE_EXPORT inline int32_t dds_rhc_read (struct dds_rhc *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, struct dds_readcond *cond) {
-  return (rhc->common.ops->read) (rhc, lock, values, info_seq, max_samples, mask, handle, cond);
+DDS_INLINE_EXPORT inline int32_t dds_rhc_read (struct dds_rhc *rhc, int32_t max_samples, uint32_t mask, dds_instance_handle_t handle, struct dds_readcond *cond, dds_read_with_collector_fn_t collect_sample, void *collect_sample_arg) {
+  return (rhc->common.ops->read) (rhc, max_samples, mask, handle, cond, collect_sample, collect_sample_arg);
 }
 
 /** @component rhc */
-DDS_INLINE_EXPORT inline int32_t dds_rhc_take (struct dds_rhc *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, struct dds_readcond *cond) {
-  return rhc->common.ops->take (rhc, lock, values, info_seq, max_samples, mask, handle, cond);
-}
-
-/** @component rhc */
-DDS_INLINE_EXPORT inline int32_t dds_rhc_readcdr (struct dds_rhc *rhc, bool lock, struct ddsi_serdata **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle) {
-  return rhc->common.ops->readcdr (rhc, lock, values, info_seq, max_samples, sample_states, view_states, instance_states, handle);
-}
-
-/** @component rhc */
-DDS_INLINE_EXPORT inline int32_t dds_rhc_takecdr (struct dds_rhc *rhc, bool lock, struct ddsi_serdata **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle) {
-  return rhc->common.ops->takecdr (rhc, lock, values, info_seq, max_samples, sample_states, view_states, instance_states, handle);
+DDS_INLINE_EXPORT inline int32_t dds_rhc_take (struct dds_rhc *rhc, int32_t max_samples, uint32_t mask, dds_instance_handle_t handle, struct dds_readcond *cond, dds_read_with_collector_fn_t collect_sample, void *collect_sample_arg) {
+  return rhc->common.ops->take (rhc, max_samples, mask, handle, cond, collect_sample, collect_sample_arg);
 }
 
 /** @component rhc */
@@ -115,11 +103,6 @@ DDS_INLINE_EXPORT inline bool dds_rhc_add_readcondition (struct dds_rhc *rhc, st
 /** @component rhc */
 DDS_INLINE_EXPORT inline void dds_rhc_remove_readcondition (struct dds_rhc *rhc, struct dds_readcond *cond) {
   rhc->common.ops->remove_readcondition (rhc, cond);
-}
-
-/** @component rhc */
-DDS_INLINE_EXPORT inline uint32_t dds_rhc_lock_samples (struct dds_rhc *rhc) {
-  return rhc->common.ops->lock_samples (rhc);
 }
 
 /** @component rhc */

--- a/src/core/ddsc/src/dds__read.h
+++ b/src/core/ddsc/src/dds__read.h
@@ -1,0 +1,78 @@
+// Copyright(c) 2023 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+#ifndef DDS__READ_H
+#define DDS__READ_H
+
+#include "dds__types.h"
+#include "dds__entity.h"
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+/** @component read_data */
+struct dds_read_collect_sample_arg {
+  uint32_t first_of_inst_idx;     /**< first index in ptrs/infos for current instance (initially 0) **/
+  uint32_t next_idx;              /**< next index in ptrs/infos to be filled (initially 0) **/
+  dds_instance_handle_t last_iid; /**< last seen instance handle (initially 0) **/
+  void **ptrs;                    /**< array of pointers to samples/serdatas to be filled **/
+  dds_sample_info_t *infos;       /**< array of sample infos to be filled **/
+};
+
+/** @brief Initialize the sample collector state
+ * @component read_data
+ *
+ * @param[out] arg sample collector state to be initialized
+ * @param[in] ptrs array of pointers to samples to be filled (collect_sample)
+ *            or array to be filled with pointers-to-serdata (collect_sample_refs)
+ * @param[in] infos array of sample infos to be filled */
+void dds_read_collect_sample_arg_init (struct dds_read_collect_sample_arg *arg, void **ptrs, dds_sample_info_t *infos);
+
+/** @brief Sample collector that deserializes the samples into ptrs[i]
+ * @component read_data
+ *
+ * It assumes the ptrs and infos arrays are large enough.  On instance change it patches
+ * the ranks in the sample infos using @ref dds_read_check_and_handle_instance_switch
+ *
+ * @see dds_read_with_collector_fn_t
+ *
+ * @retval DDS_RETCODE_OK if deserialization succeded
+ * @retval DDS_RETCODE_ERROR if deserialization failed */
+dds_return_t dds_read_collect_sample (void *varg, const dds_sample_info_t *si, const struct ddsi_sertype *st, struct ddsi_serdata *sd);
+
+/** @brief Sample collector that stores a pointer to the serdata and increments its refcount
+ * @component read_data
+ *
+ * It assumes the ptrs and infos arrays are large enough.  On instance change it patches
+ * the ranks in the sample infos using @ref dds_read_check_and_handle_instance_switch
+ *
+ * @see dds_read_with_collector_fn_t
+ *
+ * @retval DDS_RETCODE_OK (can't fail) */
+dds_return_t dds_read_collect_sample_refs (void *varg, const dds_sample_info_t *si, const struct ddsi_sertype *st, struct ddsi_serdata *sd);
+
+/** @brief Function to check for instance change and patch ranks in sample infos for preceding instance
+ * @component read_data
+ *
+ * @note This is called automatically by @ref dds_read_collect_sample and @ref
+ * dds_read_collect_sample_refs for each sample, but the caller of @ref dds_rhc_read (or
+ * @ref dds_rhc_take, or the other routes) needs to call it at the end to patch the final
+ * instance.
+ *
+ * @param[in] arg Current state of the collector
+ * @param[in] iid New instance handle, pass in 0 for handling the final instance */
+void dds_read_check_and_handle_instance_switch (struct dds_read_collect_sample_arg * const arg, dds_instance_handle_t iid);
+
+#if defined (__cplusplus)
+}
+#endif
+
+#endif // DDS__READ_H

--- a/src/core/ddsc/src/dds__read.h
+++ b/src/core/ddsc/src/dds__read.h
@@ -20,9 +20,7 @@ extern "C" {
 
 /** @component read_data */
 struct dds_read_collect_sample_arg {
-  uint32_t first_of_inst_idx;     /**< first index in ptrs/infos for current instance (initially 0) **/
   uint32_t next_idx;              /**< next index in ptrs/infos to be filled (initially 0) **/
-  dds_instance_handle_t last_iid; /**< last seen instance handle (initially 0) **/
   void **ptrs;                    /**< array of pointers to samples/serdatas to be filled **/
   dds_sample_info_t *infos;       /**< array of sample infos to be filled **/
 };
@@ -58,18 +56,6 @@ dds_return_t dds_read_collect_sample (void *varg, const dds_sample_info_t *si, c
  *
  * @retval DDS_RETCODE_OK (can't fail) */
 dds_return_t dds_read_collect_sample_refs (void *varg, const dds_sample_info_t *si, const struct ddsi_sertype *st, struct ddsi_serdata *sd);
-
-/** @brief Function to check for instance change and patch ranks in sample infos for preceding instance
- * @component read_data
- *
- * @note This is called automatically by @ref dds_read_collect_sample and @ref
- * dds_read_collect_sample_refs for each sample, but the caller of @ref dds_rhc_read (or
- * @ref dds_rhc_take, or the other routes) needs to call it at the end to patch the final
- * instance.
- *
- * @param[in] arg Current state of the collector
- * @param[in] iid New instance handle, pass in 0 for handling the final instance */
-void dds_read_check_and_handle_instance_switch (struct dds_read_collect_sample_arg * const arg, dds_instance_handle_t iid);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsc/src/dds__reader.h
+++ b/src/core/ddsc/src/dds__reader.h
@@ -31,25 +31,6 @@ void dds_reader_invoke_cbs_for_pending_events(struct dds_entity *e, uint32_t sta
 /** @component reader */
 dds_return_t dds_return_reader_loan (dds_reader *rd, void **buf, int32_t bufsz);
 
-
-#define DDS_READ_WITHOUT_LOCK (0xFFFFFFED)
-
-/**
- * @component reader
- *
- * Returns number of samples in read cache and locks the reader cache to make
- * sure that the samples content doesn't change. Because the cache is locked,
- * you should be able to read/take without having to lock first. This is done
- * by passing the DDS_READ_WITHOUT_LOCK value to the read/take call as maxs.
- * Then the read/take will not lock but still unlock.
- *
- * Used to support LENGTH_UNLIMITED in C++.
- *
- * @param reader reader entity
- * @return the number of samples
- */
-DDS_EXPORT uint32_t dds_reader_lock_samples (dds_entity_t reader);
-
 DEFINE_ENTITY_LOCK_UNLOCK(dds_reader, DDS_KIND_READER, reader)
 
 #if defined (__cplusplus)

--- a/src/core/ddsc/src/dds_read.c
+++ b/src/core/ddsc/src/dds_read.c
@@ -12,15 +12,154 @@
 #include <string.h>
 #include "dds__entity.h"
 #include "dds__reader.h"
+#include "dds__read.h"
 #include "dds/ddsi/ddsi_tkmap.h"
 #include "dds/ddsc/dds_rhc.h"
 #include "dds/ddsi/ddsi_thread.h"
 #include "dds/ddsi/ddsi_entity_index.h"
 #include "dds/ddsi/ddsi_entity.h"
 #include "dds/ddsi/ddsi_domaingv.h"
-#include "dds/ddsi/ddsi_sertype.h"
+#include "dds/ddsi/ddsi_serdata.h"
 
 #include "dds/ddsc/dds_loan_api.h"
+
+void dds_read_collect_sample_arg_init (struct dds_read_collect_sample_arg *arg, void **ptrs, dds_sample_info_t *infos)
+{
+  arg->first_of_inst_idx = 0;
+  arg->next_idx = 0;
+  arg->last_iid = 0;
+  arg->ptrs = ptrs;
+  arg->infos = infos;
+}
+
+static void dds_read_patch_generations (dds_sample_info_t *si, uint32_t last_of_inst)
+{
+  const uint32_t ref = si[last_of_inst].disposed_generation_count + si[last_of_inst].no_writers_generation_count;
+  assert (si[last_of_inst].sample_rank == 0);
+  assert (si[last_of_inst].generation_rank == 0);
+  for (uint32_t i = 0; i < last_of_inst; i++)
+  {
+    si[i].sample_rank = last_of_inst - i;
+    si[i].generation_rank = ref - (si[i].disposed_generation_count + si[i].no_writers_generation_count);
+  }
+}
+
+void dds_read_check_and_handle_instance_switch (struct dds_read_collect_sample_arg * const arg, dds_instance_handle_t iid)
+{
+  if (iid != arg->last_iid)
+  {
+    if (arg->next_idx > arg->first_of_inst_idx + 1)
+      dds_read_patch_generations (arg->infos + arg->first_of_inst_idx, arg->next_idx - arg->first_of_inst_idx - 1);
+    arg->first_of_inst_idx = arg->next_idx;
+    arg->last_iid = iid;
+  }
+}
+
+dds_return_t dds_read_collect_sample (void *varg, const dds_sample_info_t *si, const struct ddsi_sertype *st, struct ddsi_serdata *sd)
+{
+  struct dds_read_collect_sample_arg * const arg = varg;
+  bool ok;
+  dds_read_check_and_handle_instance_switch (arg, si->instance_handle);
+  arg->infos[arg->next_idx] = *si;
+  if (si->valid_data)
+    ok = ddsi_serdata_to_sample (sd, arg->ptrs[arg->next_idx], NULL, NULL);
+  else
+  {
+    /* ddsi_serdata_untyped_to_sample just deals with the key value, without paying any attention to attributes;
+       but that makes life harder for the user: the attributes of an invalid sample would be garbage, but would
+       nonetheless have to be freed in the end.  Zero'ing it explicitly solves that problem. */
+    ddsi_sertype_free_sample (st, arg->ptrs[arg->next_idx], DDS_FREE_CONTENTS);
+    ddsi_sertype_zero_sample (st, arg->ptrs[arg->next_idx]);
+    ok = ddsi_serdata_untyped_to_sample (st, sd, arg->ptrs[arg->next_idx], NULL, NULL);
+  }
+  arg->next_idx++;
+  return ok ? DDS_RETCODE_OK : DDS_RETCODE_ERROR;
+}
+
+dds_return_t dds_read_collect_sample_refs (void *varg, const dds_sample_info_t *si, const struct ddsi_sertype *st, struct ddsi_serdata *sd)
+{
+  (void) st;
+  struct dds_read_collect_sample_arg * const arg = varg;
+  dds_read_check_and_handle_instance_switch (arg, si->instance_handle);
+  arg->infos[arg->next_idx] = *si;
+  arg->ptrs[arg->next_idx] = ddsi_serdata_ref (sd);
+  arg->next_idx++;
+  return DDS_RETCODE_OK;
+}
+
+static dds_return_t dds_read_impl_setup (dds_entity_t reader_or_condition, bool only_reader, struct dds_entity **pentity, struct dds_reader **prd, struct dds_readcond **pcond, uint32_t *mask)
+{
+  dds_return_t ret;
+  if ((ret = dds_entity_pin (reader_or_condition, pentity)) < 0) {
+    return ret;
+  } else if (dds_entity_kind (*pentity) == DDS_KIND_READER) {
+    *prd = (dds_reader *) *pentity;
+    *pcond = NULL;
+  } else if (only_reader) {
+    dds_entity_unpin (*pentity);
+    return DDS_RETCODE_ILLEGAL_OPERATION;
+  } else if (dds_entity_kind (*pentity) != DDS_KIND_COND_READ && dds_entity_kind (*pentity) != DDS_KIND_COND_QUERY) {
+    dds_entity_unpin (*pentity);
+    return DDS_RETCODE_ILLEGAL_OPERATION;
+  } else {
+    *prd = (dds_reader *) (*pentity)->m_parent;
+    *pcond = (dds_readcond *) *pentity;
+    if (*mask == 0)
+      *mask = DDS_RHC_NO_STATE_MASK_SET;
+  }
+  return DDS_RETCODE_OK;
+}
+
+static dds_return_t dds_read_impl_common (bool take, struct dds_reader *rd, struct dds_readcond *cond, uint32_t maxs, uint32_t mask, dds_instance_handle_t hand, dds_read_with_collector_fn_t collect_sample, void *collect_sample_arg)
+{
+  /* read/take resets data available status -- must reset before reading because
+     the actual writing is protected by RHC lock, not by rd->m_entity.m_lock */
+  const uint32_t sm_old = dds_entity_status_reset_ov (&rd->m_entity, DDS_DATA_AVAILABLE_STATUS);
+  /* reset DATA_ON_READERS status on subscriber after successful read/take if materialized */
+  if (sm_old & (DDS_DATA_ON_READERS_STATUS << SAM_ENABLED_SHIFT))
+    dds_entity_status_reset (rd->m_entity.m_parent, DDS_DATA_ON_READERS_STATUS);
+
+  dds_return_t ret;
+  assert (maxs <= INT32_MAX);
+  if (take)
+    ret = dds_rhc_take (rd->m_rhc, (int32_t) maxs, mask, hand, cond, collect_sample, collect_sample_arg);
+  else
+    ret = dds_rhc_read (rd->m_rhc, (int32_t) maxs, mask, hand, cond, collect_sample, collect_sample_arg);
+  return ret;
+}
+
+static dds_return_t dds_read_with_collector_impl (bool take, dds_entity_t reader_or_condition, uint32_t maxs, uint32_t mask, dds_instance_handle_t hand, bool only_reader, dds_read_with_collector_fn_t collect_sample, void *collect_sample_arg)
+{
+  dds_return_t ret;
+  struct dds_entity *entity;
+  struct dds_reader *rd;
+  struct dds_readcond *cond;
+
+  if (collect_sample == 0 || maxs == 0 || maxs > INT32_MAX)
+    return DDS_RETCODE_BAD_PARAMETER;
+
+  if ((ret = dds_read_impl_setup (reader_or_condition, only_reader, &entity, &rd, &cond, &mask)) < 0)
+    return ret;
+
+  struct ddsi_thread_state * const thrst = ddsi_lookup_thread_state ();
+  ddsi_thread_state_awake (thrst, &entity->m_domain->gv);
+  ret = dds_read_impl_common (take, rd, cond, maxs, mask, hand, collect_sample, collect_sample_arg);
+  ddsi_thread_state_asleep (thrst);
+  dds_entity_unpin (entity);
+  return ret;
+}
+
+static dds_return_t dds_readcdr_impl (bool take, dds_entity_t reader_or_condition, struct ddsi_serdata **buf, uint32_t maxs, dds_sample_info_t *si, uint32_t mask, dds_instance_handle_t hand)
+{
+  if (buf == NULL || si == NULL)
+    return DDS_RETCODE_BAD_PARAMETER;
+  struct dds_read_collect_sample_arg collect_arg;
+  DDSRT_STATIC_ASSERT (sizeof (struct ddsi_serdata *) == sizeof (void *));
+  dds_read_collect_sample_arg_init (&collect_arg, (void **) buf, si);
+  const dds_return_t ret = dds_read_with_collector_impl (take, reader_or_condition, maxs, mask, hand, true, dds_read_collect_sample_refs, &collect_arg);
+  dds_read_check_and_handle_instance_switch (&collect_arg, 0);
+  return ret;
+}
 
 /*
   dds_read_impl: Core read/take function. Usually maxs is size of buf and si
@@ -29,7 +168,7 @@
   has been locked. This is used to support C++ API reading length unlimited
   which is interpreted as "all relevant samples in cache".
 */
-static dds_return_t dds_read_impl (bool take, dds_entity_t reader_or_condition, void **buf, size_t bufsz, uint32_t maxs, dds_sample_info_t *si, uint32_t mask, dds_instance_handle_t hand, bool lock, bool only_reader)
+static dds_return_t dds_read_impl (bool take, dds_entity_t reader_or_condition, void **buf, size_t bufsz, uint32_t maxs, dds_sample_info_t *si, uint32_t mask, dds_instance_handle_t hand, bool only_reader)
 {
   dds_return_t ret = DDS_RETCODE_OK;
   struct dds_entity *entity;
@@ -43,21 +182,8 @@ static dds_return_t dds_read_impl (bool take, dds_entity_t reader_or_condition, 
   if (buf == NULL || si == NULL || maxs == 0 || bufsz == 0 || bufsz < maxs || maxs > INT32_MAX)
     return DDS_RETCODE_BAD_PARAMETER;
 
-  if ((ret = dds_entity_pin (reader_or_condition, &entity)) < 0) {
-    goto fail;
-  } else if (dds_entity_kind (entity) == DDS_KIND_READER) {
-    rd = (dds_reader *) entity;
-    cond = NULL;
-  } else if (only_reader) {
-    ret = DDS_RETCODE_ILLEGAL_OPERATION;
-    goto fail_pinned;
-  } else if (dds_entity_kind (entity) != DDS_KIND_COND_READ && dds_entity_kind (entity) != DDS_KIND_COND_QUERY) {
-    ret = DDS_RETCODE_ILLEGAL_OPERATION;
-    goto fail_pinned;
-  } else {
-    rd = (dds_reader *) entity->m_parent;
-    cond = (dds_readcond *) entity;
-  }
+  if ((ret = dds_read_impl_setup (reader_or_condition, only_reader, &entity, &rd, &cond, &mask)) < 0)
+    return ret;
 
   struct ddsi_thread_state * const thrst = ddsi_lookup_thread_state ();
   ddsi_thread_state_awake (thrst, &entity->m_domain->gv);
@@ -99,17 +225,10 @@ static dds_return_t dds_read_impl (bool take, dds_entity_t reader_or_condition, 
     ddsrt_mutex_unlock (&rd->m_entity.m_mutex);
   }
 
-  /* read/take resets data available status -- must reset before reading because
-     the actual writing is protected by RHC lock, not by rd->m_entity.m_lock */
-  const uint32_t sm_old = dds_entity_status_reset_ov (&rd->m_entity, DDS_DATA_AVAILABLE_STATUS);
-  /* reset DATA_ON_READERS status on subscriber after successful read/take if materialized */
-  if (sm_old & (DDS_DATA_ON_READERS_STATUS << SAM_ENABLED_SHIFT))
-    dds_entity_status_reset (rd->m_entity.m_parent, DDS_DATA_ON_READERS_STATUS);
-
-  if (take)
-    ret = dds_rhc_take (rd->m_rhc, lock, buf, si, maxs, mask, hand, cond);
-  else
-    ret = dds_rhc_read (rd->m_rhc, lock, buf, si, maxs, mask, hand, cond);
+  struct dds_read_collect_sample_arg collect_arg;
+  dds_read_collect_sample_arg_init (&collect_arg, buf, si);
+  ret = dds_read_impl_common (take, rd, cond, maxs, mask, hand, dds_read_collect_sample, &collect_arg);
+  dds_read_check_and_handle_instance_switch (&collect_arg, 0);
 
   /* if no data read, restore the state to what it was before the call, with the sole
      exception of holding on to a buffer we just allocated and that is pointed to by
@@ -125,365 +244,166 @@ static dds_return_t dds_read_impl (bool take, dds_entity_t reader_or_condition, 
       buf[0] = NULL;
     ddsrt_mutex_unlock (&rd->m_entity.m_mutex);
   }
-  dds_entity_unpin (entity);
   ddsi_thread_state_asleep (thrst);
+  dds_entity_unpin (entity);
   return ret;
-
 #undef NC_CLEAR_LOAN_OUT
 #undef NC_FREE_BUF
 #undef NC_RESET_BUF
-
-fail_pinned:
-  dds_entity_unpin (entity);
-fail:
-  return ret;
-}
-
-static dds_return_t dds_readcdr_impl (bool take, dds_entity_t reader_or_condition, struct ddsi_serdata **buf, uint32_t maxs, dds_sample_info_t *si, uint32_t mask, dds_instance_handle_t hand, bool lock)
-{
-  dds_return_t ret = DDS_RETCODE_OK;
-  struct dds_reader *rd;
-  struct dds_entity *entity;
-
-  if (buf == NULL || si == NULL || maxs == 0 || maxs > INT32_MAX)
-    return DDS_RETCODE_BAD_PARAMETER;
-
-  if ((ret = dds_entity_pin (reader_or_condition, &entity)) < 0) {
-    return ret;
-  } else if (dds_entity_kind (entity) == DDS_KIND_READER) {
-    rd = (dds_reader *) entity;
-  } else if (dds_entity_kind (entity) != DDS_KIND_COND_READ && dds_entity_kind (entity) != DDS_KIND_COND_QUERY) {
-    dds_entity_unpin (entity);
-    return DDS_RETCODE_ILLEGAL_OPERATION;
-  } else {
-    rd = (dds_reader *) entity->m_parent;
-  }
-
-  struct ddsi_thread_state * const thrst = ddsi_lookup_thread_state ();
-  ddsi_thread_state_awake (thrst, &entity->m_domain->gv);
-
-  /* read/take resets data available status -- must reset before reading because
-     the actual writing is protected by RHC lock, not by rd->m_entity.m_lock */
-  const uint32_t sm_old = dds_entity_status_reset_ov (&rd->m_entity, DDS_DATA_AVAILABLE_STATUS);
-  /* reset DATA_ON_READERS status on subscriber after successful read/take if materialized */
-  if (sm_old & (DDS_DATA_ON_READERS_STATUS << SAM_ENABLED_SHIFT))
-    dds_entity_status_reset (rd->m_entity.m_parent, DDS_DATA_ON_READERS_STATUS);
-
-  if (take)
-    ret = dds_rhc_takecdr (rd->m_rhc, lock, buf, si, maxs, mask & DDS_ANY_SAMPLE_STATE, mask & DDS_ANY_VIEW_STATE, mask & DDS_ANY_INSTANCE_STATE, hand);
-  else
-    ret = dds_rhc_readcdr (rd->m_rhc, lock, buf, si, maxs, mask & DDS_ANY_SAMPLE_STATE, mask & DDS_ANY_VIEW_STATE, mask & DDS_ANY_INSTANCE_STATE, hand);
-
-  dds_entity_unpin (entity);
-  ddsi_thread_state_asleep (thrst);
-  return ret;
 }
 
 dds_return_t dds_read (dds_entity_t reader_or_condition, void **buf, dds_sample_info_t *si, size_t bufsz, uint32_t maxs)
 {
-  bool lock = true;
-  if (maxs == DDS_READ_WITHOUT_LOCK)
-  {
-    lock = false;
-    /* FIXME: Fix the interface. */
-    maxs = (uint32_t) bufsz;
-  }
-  return dds_read_impl (false, reader_or_condition, buf, bufsz, maxs, si, NO_STATE_MASK_SET, DDS_HANDLE_NIL, lock, false);
+  return dds_read_impl (false, reader_or_condition, buf, bufsz, maxs, si, 0, DDS_HANDLE_NIL, false);
 }
 
 dds_return_t dds_read_wl (dds_entity_t reader_or_condition, void **buf, dds_sample_info_t *si, uint32_t maxs)
 {
-  bool lock = true;
-  if (maxs == DDS_READ_WITHOUT_LOCK)
-  {
-    lock = false;
-    /* FIXME: Fix the interface. */
-    maxs = 100;
-  }
-  return dds_read_impl (false, reader_or_condition, buf, maxs, maxs, si, NO_STATE_MASK_SET, DDS_HANDLE_NIL, lock, false);
+  return dds_read_impl (false, reader_or_condition, buf, maxs, maxs, si, 0, DDS_HANDLE_NIL, false);
 }
 
 dds_return_t dds_read_mask (dds_entity_t reader_or_condition, void **buf, dds_sample_info_t *si, size_t bufsz, uint32_t maxs, uint32_t mask)
 {
-  bool lock = true;
-  if (maxs == DDS_READ_WITHOUT_LOCK)
-  {
-    lock = false;
-    /* FIXME: Fix the interface. */
-    maxs = (uint32_t)bufsz;
-  }
-  return dds_read_impl (false, reader_or_condition, buf, bufsz, maxs, si, mask, DDS_HANDLE_NIL, lock, false);
+  return dds_read_impl (false, reader_or_condition, buf, bufsz, maxs, si, mask, DDS_HANDLE_NIL, false);
 }
 
 dds_return_t dds_read_mask_wl (dds_entity_t reader_or_condition, void **buf, dds_sample_info_t *si, uint32_t maxs, uint32_t mask)
 {
-  bool lock = true;
-  if (maxs == DDS_READ_WITHOUT_LOCK)
-  {
-    lock = false;
-    /* FIXME: Fix the interface. */
-    maxs = 100;
-  }
-  return dds_read_impl (false, reader_or_condition, buf, maxs, maxs, si, mask, DDS_HANDLE_NIL, lock, false);
+  return dds_read_impl (false, reader_or_condition, buf, maxs, maxs, si, mask, DDS_HANDLE_NIL, false);
 }
 
 dds_return_t dds_readcdr (dds_entity_t reader_or_condition, struct ddsi_serdata **buf, uint32_t maxs, dds_sample_info_t *si, uint32_t mask)
 {
-  bool lock = true;
-  if (maxs == DDS_READ_WITHOUT_LOCK)
-  {
-    lock = false;
-    /* FIXME: Fix the interface. */
-    maxs = 100;
-  }
-  return dds_readcdr_impl (false, reader_or_condition, buf, maxs, si, mask, DDS_HANDLE_NIL, lock);
+  return dds_readcdr_impl (false, reader_or_condition, buf, maxs, si, mask, DDS_HANDLE_NIL);
 }
 
 dds_return_t dds_read_instance (dds_entity_t reader_or_condition, void **buf, dds_sample_info_t *si, size_t bufsz, uint32_t maxs, dds_instance_handle_t handle)
 {
-  bool lock = true;
-
   if (handle == DDS_HANDLE_NIL)
     return DDS_RETCODE_PRECONDITION_NOT_MET;
-
-  if (maxs == DDS_READ_WITHOUT_LOCK)
-  {
-    lock = false;
-    /* FIXME: Fix the interface. */
-    maxs = 100;
-  }
-  return dds_read_impl (false, reader_or_condition, buf, bufsz, maxs, si, NO_STATE_MASK_SET, handle, lock, false);
+  return dds_read_impl (false, reader_or_condition, buf, bufsz, maxs, si, 0, handle, false);
 }
 
 dds_return_t dds_read_instance_wl (dds_entity_t reader_or_condition, void **buf, dds_sample_info_t *si, uint32_t maxs, dds_instance_handle_t handle)
 {
-  bool lock = true;
-
   if (handle == DDS_HANDLE_NIL)
     return DDS_RETCODE_PRECONDITION_NOT_MET;
-
-  if (maxs == DDS_READ_WITHOUT_LOCK)
-  {
-    lock = false;
-    /* FIXME: Fix the interface. */
-    maxs = 100;
-  }
-  return dds_read_impl (false, reader_or_condition, buf, maxs, maxs, si, NO_STATE_MASK_SET, handle, lock, false);
+  return dds_read_impl (false, reader_or_condition, buf, maxs, maxs, si, 0, handle, false);
 }
 
 dds_return_t dds_read_instance_mask (dds_entity_t reader_or_condition, void **buf, dds_sample_info_t *si, size_t bufsz, uint32_t maxs, dds_instance_handle_t handle, uint32_t mask)
 {
-  bool lock = true;
-
   if (handle == DDS_HANDLE_NIL)
     return DDS_RETCODE_PRECONDITION_NOT_MET;
-
-  if (maxs == DDS_READ_WITHOUT_LOCK)
-  {
-    lock = false;
-    /* FIXME: Fix the interface. */
-    maxs = (uint32_t)bufsz;
-  }
-  return dds_read_impl (false, reader_or_condition, buf, bufsz, maxs, si, mask, handle, lock, false);
+  return dds_read_impl (false, reader_or_condition, buf, bufsz, maxs, si, mask, handle, false);
 }
 
 dds_return_t dds_read_instance_mask_wl (dds_entity_t reader_or_condition, void **buf, dds_sample_info_t *si, uint32_t maxs, dds_instance_handle_t handle, uint32_t mask)
 {
-  bool lock = true;
-
   if (handle == DDS_HANDLE_NIL)
     return DDS_RETCODE_PRECONDITION_NOT_MET;
-
-  if (maxs == DDS_READ_WITHOUT_LOCK)
-  {
-    lock = false;
-    /* FIXME: Fix the interface. */
-    maxs = 100;
-  }
-  return dds_read_impl (false, reader_or_condition, buf, maxs, maxs, si, mask, handle, lock, false);
+  return dds_read_impl (false, reader_or_condition, buf, maxs, maxs, si, mask, handle, false);
 }
 
 dds_return_t dds_readcdr_instance (dds_entity_t reader_or_condition, struct ddsi_serdata **buf, uint32_t maxs, dds_sample_info_t *si, dds_instance_handle_t handle, uint32_t mask)
 {
-  bool lock = true;
-
   if (handle == DDS_HANDLE_NIL)
     return DDS_RETCODE_PRECONDITION_NOT_MET;
-
-  if (maxs == DDS_READ_WITHOUT_LOCK)
-  {
-    lock = false;
-    /* FIXME: Fix the interface. */
-    maxs = 100;
-  }
-  return dds_readcdr_impl(false, reader_or_condition, buf, maxs, si, mask, handle, lock);
+  return dds_readcdr_impl(false, reader_or_condition, buf, maxs, si, mask, handle);
 }
 
 dds_return_t dds_read_next (dds_entity_t reader, void **buf, dds_sample_info_t *si)
 {
   uint32_t mask = DDS_NOT_READ_SAMPLE_STATE | DDS_ANY_VIEW_STATE | DDS_ANY_INSTANCE_STATE;
-  return dds_read_impl (false, reader, buf, 1u, 1u, si, mask, DDS_HANDLE_NIL, true, true);
+  return dds_read_impl (false, reader, buf, 1u, 1u, si, mask, DDS_HANDLE_NIL, true);
 }
 
-dds_return_t dds_read_next_wl (
-                 dds_entity_t reader,
-                 void **buf,
-                 dds_sample_info_t *si)
+dds_return_t dds_read_next_wl (dds_entity_t reader, void **buf, dds_sample_info_t *si)
 {
   uint32_t mask = DDS_NOT_READ_SAMPLE_STATE | DDS_ANY_VIEW_STATE | DDS_ANY_INSTANCE_STATE;
-  return dds_read_impl (false, reader, buf, 1u, 1u, si, mask, DDS_HANDLE_NIL, true, true);
+  return dds_read_impl (false, reader, buf, 1u, 1u, si, mask, DDS_HANDLE_NIL, true);
+}
+
+dds_return_t dds_read_with_collector (dds_entity_t reader_or_condition, uint32_t maxs, dds_instance_handle_t handle, uint32_t mask, dds_read_with_collector_fn_t collect_sample, void *collect_sample_arg)
+{
+  return dds_read_with_collector_impl (false, reader_or_condition, maxs, mask, handle, false, collect_sample, collect_sample_arg);
 }
 
 dds_return_t dds_take (dds_entity_t reader_or_condition, void **buf, dds_sample_info_t *si, size_t bufsz, uint32_t maxs)
 {
-  bool lock = true;
-  if (maxs == DDS_READ_WITHOUT_LOCK)
-  {
-    lock = false;
-    /* FIXME: Fix the interface. */
-    maxs = (uint32_t)bufsz;
-  }
-  return dds_read_impl (true, reader_or_condition, buf, bufsz, maxs, si, NO_STATE_MASK_SET, DDS_HANDLE_NIL, lock, false);
+  return dds_read_impl (true, reader_or_condition, buf, bufsz, maxs, si, 0, DDS_HANDLE_NIL, false);
 }
 
 dds_return_t dds_take_wl (dds_entity_t reader_or_condition, void ** buf, dds_sample_info_t * si, uint32_t maxs)
 {
-  bool lock = true;
-  if (maxs == DDS_READ_WITHOUT_LOCK)
-  {
-    lock = false;
-    /* FIXME: Fix the interface. */
-    maxs = 100;
-  }
-  return dds_read_impl (true, reader_or_condition, buf, maxs, maxs, si, NO_STATE_MASK_SET, DDS_HANDLE_NIL, lock, false);
+  return dds_read_impl (true, reader_or_condition, buf, maxs, maxs, si, 0, DDS_HANDLE_NIL, false);
 }
 
 dds_return_t dds_take_mask (dds_entity_t reader_or_condition, void **buf, dds_sample_info_t *si, size_t bufsz, uint32_t maxs, uint32_t mask)
 {
-  bool lock = true;
-  if (maxs == DDS_READ_WITHOUT_LOCK)
-  {
-    lock = false;
-    /* FIXME: Fix the interface. */
-    maxs = (uint32_t) bufsz;
-  }
-  return dds_read_impl (true, reader_or_condition, buf, bufsz, maxs, si, mask, DDS_HANDLE_NIL, lock, false);
+  return dds_read_impl (true, reader_or_condition, buf, bufsz, maxs, si, mask, DDS_HANDLE_NIL, false);
 }
 
 dds_return_t dds_take_mask_wl (dds_entity_t reader_or_condition, void **buf, dds_sample_info_t *si, uint32_t maxs, uint32_t mask)
 {
-  bool lock = true;
-  if (maxs == DDS_READ_WITHOUT_LOCK)
-  {
-    lock = false;
-    /* FIXME: Fix the interface. */
-    maxs = 100;
-  }
-  return dds_read_impl (true, reader_or_condition, buf, maxs, maxs, si, mask, DDS_HANDLE_NIL, lock, false);
+  return dds_read_impl (true, reader_or_condition, buf, maxs, maxs, si, mask, DDS_HANDLE_NIL, false);
 }
 
 dds_return_t dds_takecdr (dds_entity_t reader_or_condition, struct ddsi_serdata **buf, uint32_t maxs, dds_sample_info_t *si, uint32_t mask)
 {
-  bool lock = true;
-  if (maxs == DDS_READ_WITHOUT_LOCK)
-  {
-    lock = false;
-    /* FIXME: Fix the interface. */
-    maxs = 100;
-  }
-  return dds_readcdr_impl (true, reader_or_condition, buf, maxs, si, mask, DDS_HANDLE_NIL, lock);
+  return dds_readcdr_impl (true, reader_or_condition, buf, maxs, si, mask, DDS_HANDLE_NIL);
 }
 
 dds_return_t dds_take_instance (dds_entity_t reader_or_condition, void **buf, dds_sample_info_t *si, size_t bufsz, uint32_t maxs, dds_instance_handle_t handle)
 {
-  bool lock = true;
-
   if (handle == DDS_HANDLE_NIL)
     return DDS_RETCODE_PRECONDITION_NOT_MET;
-
-  if (maxs == DDS_READ_WITHOUT_LOCK)
-  {
-    lock = false;
-    /* FIXME: Fix the interface. */
-    maxs = 100;
-  }
-  return dds_read_impl(true, reader_or_condition, buf, bufsz, maxs, si, NO_STATE_MASK_SET, handle, lock, false);
+  return dds_read_impl (true, reader_or_condition, buf, bufsz, maxs, si, 0, handle, false);
 }
 
 dds_return_t dds_take_instance_wl (dds_entity_t reader_or_condition, void **buf, dds_sample_info_t *si, uint32_t maxs, dds_instance_handle_t handle)
 {
-  bool lock = true;
-
   if (handle == DDS_HANDLE_NIL)
     return DDS_RETCODE_PRECONDITION_NOT_MET;
-
-  if (maxs == DDS_READ_WITHOUT_LOCK)
-  {
-    lock = false;
-    /* FIXME: Fix the interface. */
-    maxs = 100;
-  }
-  return dds_read_impl(true, reader_or_condition, buf, maxs, maxs, si, NO_STATE_MASK_SET, handle, lock, false);
+  return dds_read_impl (true, reader_or_condition, buf, maxs, maxs, si, 0, handle, false);
 }
 
 dds_return_t dds_take_instance_mask (dds_entity_t reader_or_condition, void **buf, dds_sample_info_t *si, size_t bufsz, uint32_t maxs, dds_instance_handle_t handle, uint32_t mask)
 {
-  bool lock = true;
-
   if (handle == DDS_HANDLE_NIL)
     return DDS_RETCODE_PRECONDITION_NOT_MET;
-
-  if (maxs == DDS_READ_WITHOUT_LOCK)
-  {
-    lock = false;
-    /* FIXME: Fix the interface. */
-    maxs = (uint32_t)bufsz;
-  }
-  return dds_read_impl(true, reader_or_condition, buf, bufsz, maxs, si, mask, handle, lock, false);
+  return dds_read_impl (true, reader_or_condition, buf, bufsz, maxs, si, mask, handle, false);
 }
 
 dds_return_t dds_take_instance_mask_wl (dds_entity_t reader_or_condition, void **buf, dds_sample_info_t *si, uint32_t maxs, dds_instance_handle_t handle, uint32_t mask)
 {
-  bool lock = true;
-
   if (handle == DDS_HANDLE_NIL)
     return DDS_RETCODE_PRECONDITION_NOT_MET;
-
-  if (maxs == DDS_READ_WITHOUT_LOCK)
-  {
-    lock = false;
-    /* FIXME: Fix the interface. */
-    maxs = 100;
-  }
-  return dds_read_impl(true, reader_or_condition, buf, maxs, maxs, si, mask, handle, lock, false);
+  return dds_read_impl (true, reader_or_condition, buf, maxs, maxs, si, mask, handle, false);
 }
 
 dds_return_t dds_takecdr_instance (dds_entity_t reader_or_condition, struct ddsi_serdata **buf, uint32_t maxs, dds_sample_info_t *si, dds_instance_handle_t handle, uint32_t mask)
 {
-  bool lock = true;
-
   if (handle == DDS_HANDLE_NIL)
     return DDS_RETCODE_PRECONDITION_NOT_MET;
-
-  if (maxs == DDS_READ_WITHOUT_LOCK)
-  {
-    lock = false;
-    /* FIXME: Fix the interface. */
-    maxs = 100;
-  }
-  return dds_readcdr_impl(true, reader_or_condition, buf, maxs, si, mask, handle, lock);
+  return dds_readcdr_impl (true, reader_or_condition, buf, maxs, si, mask, handle);
 }
 
 dds_return_t dds_take_next (dds_entity_t reader, void **buf, dds_sample_info_t *si)
 {
   uint32_t mask = DDS_NOT_READ_SAMPLE_STATE | DDS_ANY_VIEW_STATE | DDS_ANY_INSTANCE_STATE;
-  return dds_read_impl (true, reader, buf, 1u, 1u, si, mask, DDS_HANDLE_NIL, true, true);
+  return dds_read_impl (true, reader, buf, 1u, 1u, si, mask, DDS_HANDLE_NIL, true);
 }
 
 dds_return_t dds_take_next_wl (dds_entity_t reader, void **buf, dds_sample_info_t *si)
 {
   uint32_t mask = DDS_NOT_READ_SAMPLE_STATE | DDS_ANY_VIEW_STATE | DDS_ANY_INSTANCE_STATE;
-  return dds_read_impl (true, reader, buf, 1u, 1u, si, mask, DDS_HANDLE_NIL, true, true);
+  return dds_read_impl (true, reader, buf, 1u, 1u, si, mask, DDS_HANDLE_NIL, true);
+}
+
+dds_return_t dds_take_with_collector (dds_entity_t reader_or_condition, uint32_t maxs, dds_instance_handle_t handle, uint32_t mask, dds_read_with_collector_fn_t collect_sample, void *collect_sample_arg)
+{
+  return dds_read_with_collector_impl (true, reader_or_condition, maxs, mask, handle, false, collect_sample, collect_sample_arg);
 }
 
 dds_return_t dds_return_reader_loan (dds_reader *rd, void **buf, int32_t bufsz)

--- a/src/core/ddsc/src/dds_reader.c
+++ b/src/core/ddsc/src/dds_reader.c
@@ -795,17 +795,6 @@ dds_entity_t dds_create_reader_rhc (dds_entity_t participant_or_subscriber, dds_
   return dds_create_reader_int (participant_or_subscriber, topic, qos, listener, rhc);
 }
 
-uint32_t dds_reader_lock_samples (dds_entity_t reader)
-{
-  dds_reader *rd;
-  uint32_t n;
-  if (dds_reader_lock (reader, &rd) != DDS_RETCODE_OK)
-    return 0;
-  n = dds_rhc_lock_samples (rd->m_rhc);
-  dds_reader_unlock (rd);
-  return n;
-}
-
 dds_return_t dds_reader_wait_for_historical_data (dds_entity_t reader, dds_duration_t max_wait)
 {
   dds_reader *rd;

--- a/src/core/ddsc/src/dds_rhc.c
+++ b/src/core/ddsc/src/dds_rhc.c
@@ -19,10 +19,7 @@ DDS_EXPORT extern inline void dds_rhc_unregister_wr (struct dds_rhc * __restrict
 DDS_EXPORT extern inline void dds_rhc_relinquish_ownership (struct dds_rhc * __restrict rhc, const uint64_t wr_iid);
 DDS_EXPORT extern inline void dds_rhc_set_qos (struct dds_rhc *rhc, const struct dds_qos *qos);
 DDS_EXPORT extern inline void dds_rhc_free (struct dds_rhc *rhc);
-DDS_EXPORT extern inline int32_t dds_rhc_read (struct dds_rhc *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, struct dds_readcond *cond);
-DDS_EXPORT extern inline int32_t dds_rhc_take (struct dds_rhc *rhc, bool lock, void **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t mask, dds_instance_handle_t handle, struct dds_readcond *cond);
-DDS_EXPORT extern inline int32_t dds_rhc_readcdr (struct dds_rhc *rhc, bool lock, struct ddsi_serdata **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle);
-DDS_EXPORT extern inline int32_t dds_rhc_takecdr (struct dds_rhc *rhc, bool lock, struct ddsi_serdata **values, dds_sample_info_t *info_seq, uint32_t max_samples, uint32_t sample_states, uint32_t view_states, uint32_t instance_states, dds_instance_handle_t handle);
+DDS_EXPORT extern inline int32_t dds_rhc_read (struct dds_rhc *rhc, int32_t max_samples, uint32_t mask, dds_instance_handle_t handle, struct dds_readcond *cond, dds_read_with_collector_fn_t collect_sample, void *collect_sample_arg);
+DDS_EXPORT extern inline int32_t dds_rhc_take (struct dds_rhc *rhc, int32_t max_samples, uint32_t mask, dds_instance_handle_t handle, struct dds_readcond *cond, dds_read_with_collector_fn_t collect_sample, void *collect_sample_arg);
 DDS_EXPORT extern inline bool dds_rhc_add_readcondition (struct dds_rhc *rhc, struct dds_readcond *cond);
 DDS_EXPORT extern inline void dds_rhc_remove_readcondition (struct dds_rhc *rhc, struct dds_readcond *cond);
-DDS_EXPORT extern inline uint32_t dds_rhc_lock_samples (struct dds_rhc *rhc);

--- a/src/core/ddsc/src/dds_rhc_default.c
+++ b/src/core/ddsc/src/dds_rhc_default.c
@@ -2124,7 +2124,7 @@ static int32_t read_w_qminv_inst_validsamples (const struct readtake_w_qminv_ins
     {
       /* sample state matches too */
       dds_sample_info_t si;
-      make_sample_info (&si, inst, sample, (uint32_t) (*state->limit - limit_at_end_of_instance), last_generation_in_result - (sample->disposed_gen + sample->no_writers_gen));
+      make_sample_info (&si, inst, sample, (uint32_t) (*state->limit - limit_at_end_of_instance - 1), last_generation_in_result - (sample->disposed_gen + sample->no_writers_gen));
       const int32_t rc = state->collect_sample (state->collect_sample_arg, &si, state->rhc->type, sample->sample);
       if (rc < 0)
       {
@@ -2181,7 +2181,7 @@ static int32_t take_w_qminv_inst_validsamples (const struct readtake_w_qminv_ins
     else
     {
       dds_sample_info_t si;
-      make_sample_info (&si, inst, sample, (uint32_t) (*state->limit - limit_at_end_of_instance), last_generation_in_result - (sample->disposed_gen + sample->no_writers_gen));
+      make_sample_info (&si, inst, sample, (uint32_t) (*state->limit - limit_at_end_of_instance - 1), last_generation_in_result - (sample->disposed_gen + sample->no_writers_gen));
       const int32_t rc = state->collect_sample (state->collect_sample_arg, &si, state->rhc->type, sample->sample);
       if (rc < 0)
         return rc;

--- a/src/core/ddsc/src/dds_rhc_default.c
+++ b/src/core/ddsc/src/dds_rhc_default.c
@@ -2034,7 +2034,7 @@ static bool readtake_w_qminv_inst_get_rank_info_shortcut (const struct readtake_
       latest_matches = inst->latest->isread;
       break;
   }
-  
+
   // If we'll hit the sample limit or we're not ending on the invalid sample or the
   // latest one, then presumably the generation rank of the latest sample we will be
   // returning can be anything, generally necessitating the long route.
@@ -2115,11 +2115,9 @@ static int32_t read_w_qminv_inst_validsamples (const struct readtake_w_qminv_ins
   if (limit_at_end_of_instance + invalid_sample_included == *state->limit)
   {
     // nothing matched, skip 2nd pass
-    // note that this doesn't save us from doing the 2nd pass through the samples
-    // if only the invalid sample matched
     return DDS_RETCODE_OK;
   }
-  
+
   struct rhc_sample *sample = inst->latest->next, * const end1 = sample;
   do {
     if ((qmask_of_sample (sample) & state->qminv) == 0 && (state->qcmask == 0 || (sample->conds & state->qcmask)))
@@ -2161,7 +2159,7 @@ static int32_t take_w_qminv_inst_validsamples (const struct readtake_w_qminv_ins
   // see read_w_qminv_inst_validsamples
   assert (*state->limit > 0);
   assert (inst->latest && (qmask_of_inst (inst) & state->qminv) == 0);
-  
+
   int32_t limit_at_end_of_instance;
   uint32_t last_generation_in_result;
   bool invalid_sample_included;

--- a/src/core/ddsc/tests/CMakeLists.txt
+++ b/src/core/ddsc/tests/CMakeLists.txt
@@ -60,6 +60,7 @@ set(ddsc_test_sources
     "qosmatch.c"
     "querycondition.c"
     "guardcondition.c"
+    "readcollect.c"
     "readcondition.c"
     "reader.c"
     "reader_iterator.c"

--- a/src/core/ddsc/tests/readcollect.c
+++ b/src/core/ddsc/tests/readcollect.c
@@ -1,0 +1,163 @@
+// Copyright(c) 2023 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+#include <assert.h>
+#include <limits.h>
+
+#include "dds/dds.h"
+#include "dds/ddsrt/misc.h"
+#include "dds/ddsrt/process.h"
+#include "dds/ddsrt/threads.h"
+#include "dds/ddsi/ddsi_serdata.h"
+
+#include "dds__entity.h"
+#include "test_common.h"
+
+/* Regular read/take is built on the same interface, so we don't need to check
+   here that it works in the regular cases.  What *is* interesting to test is
+   error handling. */
+
+typedef dds_return_t (*read_op) (dds_entity_t rd_or_cnd, uint32_t maxs, dds_instance_handle_t handle, uint32_t mask, dds_read_with_collector_fn_t collect_sample, void *collect_sample_arg);
+
+static Space_Type1 getdata (const dds_sample_info_t *si, const struct ddsi_sertype *st, struct ddsi_serdata *sd)
+{
+  Space_Type1 s;
+  if (si->valid_data)
+    ddsi_serdata_to_sample (sd, &s, NULL, NULL);
+  else
+    ddsi_serdata_untyped_to_sample (st, sd, &s, NULL, NULL);
+  return s;
+}
+
+static dds_return_t coll_fail_always (void *varg, const dds_sample_info_t *si, const struct ddsi_sertype *st, struct ddsi_serdata *sd)
+{
+  (void)varg;
+  CU_ASSERT_FATAL (!si->valid_data || st == sd->type);
+  Space_Type1 s = getdata (si, st, sd);
+  printf ("coll_fail_always: %d, %d\n", s.long_1, s.long_2);
+  return INT32_MIN; // easily recognized negative number that is not a return code from Cyclone DDS
+}
+
+struct coll_fail_after_1_arg {
+  int count;
+  int32_t k;
+};
+
+static dds_return_t coll_fail_after_1 (void *varg, const dds_sample_info_t *si, const struct ddsi_sertype *st, struct ddsi_serdata *sd)
+{
+  CU_ASSERT_FATAL (!si->valid_data || st == sd->type);
+  struct coll_fail_after_1_arg * const arg = varg;
+  Space_Type1 s = getdata (si, st, sd);
+  printf ("coll_fail_after_1: %d, %d\n", s.long_1, s.long_2);
+  arg->k = s.long_1;
+  return (arg->count++ == 0) ? 0 : INT32_MIN;
+}
+
+static void dotest (read_op op)
+{
+  const dds_entity_t dp = dds_create_participant (DDS_DOMAIN_DEFAULT, NULL, NULL);
+  CU_ASSERT_FATAL (dp > 0);
+  char topicname[100];
+  create_unique_topic_name("ddsc_read_with_collector", topicname, sizeof (topicname));
+  dds_qos_t *qos = dds_create_qos ();
+  dds_qset_reliability(qos, DDS_RELIABILITY_RELIABLE, DDS_INFINITY);
+  dds_qset_history (qos, DDS_HISTORY_KEEP_ALL, 0);
+  const dds_entity_t tp = dds_create_topic (dp, &Space_Type1_desc, topicname, qos, NULL);
+  CU_ASSERT_FATAL (tp > 0);
+  dds_delete_qos (qos);
+  const dds_entity_t rd = dds_create_reader (dp, tp, NULL, NULL);
+  CU_ASSERT_FATAL (rd > 0);
+  const dds_entity_t wr = dds_create_writer (dp, tp, NULL, NULL);
+  CU_ASSERT_FATAL (wr > 0);
+
+  dds_return_t rc;
+  for (int32_t k = 0; k < 3; k++)
+  {
+    for (int32_t v = 0; v < 3; v++)
+    {
+      rc = dds_write (wr, &(Space_Type1){ .long_1 = k, .long_2 = v, .long_3 = 0 });
+      CU_ASSERT_FATAL (rc == 0);
+    }
+  }
+
+  // failure on first call to collect: error is propagated
+  rc = op (rd, INT32_MAX, 0, 0, coll_fail_always, NULL);
+  CU_ASSERT_FATAL (rc == INT32_MIN);
+
+  // failure on subsequent calls to collect: partial result returned
+  struct coll_fail_after_1_arg arg1 = { .count = 0, .k = -1 };
+  rc = op (rd, INT32_MAX, 0, 0, coll_fail_after_1, &arg1);
+  CU_ASSERT_FATAL (rc == 1);
+  CU_ASSERT_FATAL (arg1.k >= 0 && arg1.k <= 2);
+  
+  // same should be true if instance handle is provided, use a different instance just because we can
+  dds_instance_handle_t ih;
+  rc = dds_register_instance (wr, &ih, &(Space_Type1){ .long_1 = (1+arg1.k)%3, .long_2 = 0, .long_3 = 0 });
+  CU_ASSERT_FATAL (rc == 0);
+  rc = op (rd, INT32_MAX, ih, 0, coll_fail_always, NULL);
+  CU_ASSERT_FATAL (rc == INT32_MIN);
+  struct coll_fail_after_1_arg arg2 = { .count = 0, .k = -1 };
+  rc = op (rd, INT32_MAX, ih, 0, coll_fail_after_1, &arg2);
+  CU_ASSERT_FATAL (rc == 1);
+  CU_ASSERT_FATAL (arg2.k == (1+arg1.k)%3);
+  
+  assert (op == dds_read_with_collector || op == dds_take_with_collector);
+  bool isread = (op == dds_read_with_collector);
+  
+  // check that the remainder is as we expect it
+  Space_Type1 xs[10];
+  dds_sample_info_t si[10];
+  void *ptrs[10];
+  for (uint32_t i = 0; i < 10; i++)
+    ptrs[i] = &xs[i];
+  rc = dds_take (rd, ptrs, si, 2 + isread, 2 + isread);
+  for (int i = 0; i < rc; i++)
+    printf ("take(1) %"PRId32", %"PRId32"\n", xs[i].long_1, xs[i].long_2);
+  CU_ASSERT_FATAL (rc == 2 + isread);
+  for (int i = 0; i < rc; i++)
+  {
+    CU_ASSERT_FATAL (xs[i].long_1 == arg1.k);
+    CU_ASSERT_FATAL (si[i].sample_state == (i == 0 && isread ? DDS_READ_SAMPLE_STATE : DDS_NOT_READ_SAMPLE_STATE));
+    CU_ASSERT_FATAL (si[i].view_state == DDS_NOT_NEW_VIEW_STATE);
+  }
+  rc = dds_take_instance (rd, ptrs, si, 2 + isread, 2 + isread, ih);
+  for (int i = 0; i < rc; i++)
+    printf ("take(2) %"PRId32", %"PRId32"\n", xs[i].long_1, xs[i].long_2);
+  CU_ASSERT_FATAL (rc == 2 + isread);
+  for (int i = 0; i < rc; i++)
+  {
+    CU_ASSERT_FATAL (xs[i].long_1 == arg2.k);
+    CU_ASSERT_FATAL (si[i].sample_state == (i == 0 && isread ? DDS_READ_SAMPLE_STATE : DDS_NOT_READ_SAMPLE_STATE));
+    CU_ASSERT_FATAL (si[i].view_state == DDS_NOT_NEW_VIEW_STATE);
+  }
+  rc = dds_take (rd, ptrs, si, 10, 10);
+  for (int i = 0; i < rc; i++)
+    printf ("take(3) %"PRId32", %"PRId32"\n", xs[i].long_1, xs[i].long_2);
+  CU_ASSERT_FATAL (rc == 3);
+  for (int i = 0; i < rc; i++)
+  {
+    CU_ASSERT_FATAL (xs[i].long_1 == (arg1.k+2)%3);
+    CU_ASSERT_FATAL (si[i].sample_state == DDS_NOT_READ_SAMPLE_STATE);
+    CU_ASSERT_FATAL (si[i].view_state == DDS_NEW_VIEW_STATE);
+  }
+
+  rc = dds_delete (dp);
+  CU_ASSERT_FATAL (rc == 0);
+}
+
+CU_Test(ddsc_read_with_collector, read)
+{
+  dotest (dds_read_with_collector);
+}
+
+CU_Test(ddsc_read_with_collector, take)
+{
+  dotest (dds_take_with_collector);
+}

--- a/src/core/ddsc/tests/reader.c
+++ b/src/core/ddsc/tests/reader.c
@@ -3213,13 +3213,19 @@ CU_Test(ddsc_take_mask_wl, combination_of_states, .init=reader_init, .fini=reade
 }
 /*************************************************************************************************/
 
-static bool test_even_long_2 (const void *vsample)
+static bool test_even_long_2_and_long_3_neq_0 (const void *vsample)
 {
   const Space_Type1 *sample = vsample;
-  return (sample->long_2 % 2) == 0;
+  return (sample->long_2 % 2) == 0 && sample->long_3 != 0;
 }
 
-static void do_readtake_sample_rank (dds_return_t (*op) (dds_entity_t reader_or_condition, void **buf, dds_sample_info_t *si, size_t bufsz, uint32_t maxs, uint32_t mask))
+static bool test_long_2_eq_2 (const void *vsample)
+{
+  const Space_Type1 *sample = vsample;
+  return (sample->long_2 == 2);
+}
+
+static void do_readtake_sample_rank (const char *opname_past_tense, dds_return_t (*op) (dds_entity_t reader_or_condition, void **buf, dds_sample_info_t *si, size_t bufsz, uint32_t maxs, uint32_t mask))
 {
   const dds_entity_t dp = dds_create_participant (0, NULL, NULL);
   CU_ASSERT_FATAL (dp > 0);
@@ -3249,19 +3255,19 @@ static void do_readtake_sample_rank (dds_return_t (*op) (dds_entity_t reader_or_
     printf ("\n");
     fflush (stdout);
 
-    for (int drop_even_long_2 = 0; drop_even_long_2 <= 1; drop_even_long_2++)
+    for (int skip_even_long_2 = 0; skip_even_long_2 <= 1; skip_even_long_2++)
     {
-      //printf (" drop_even_long_2 %d", drop_even_long_2);
-      int totsamp_after_maybe_dropping_even = 0;
-      if (!drop_even_long_2)
-        totsamp_after_maybe_dropping_even = totsamp;
+      printf ("  skip_even_long_2 %d\n", skip_even_long_2);
+      int totsamp_after_maybe_skipping_even = 0;
+      if (!skip_even_long_2)
+        totsamp_after_maybe_skipping_even = totsamp;
       else
       {
         for (int i = 0; nsamp[i] > 0; i++)
-          totsamp_after_maybe_dropping_even += nsamp[i] / 2;
+          totsamp_after_maybe_skipping_even += nsamp[i] / 2;
       }
 
-      for (int nrd = 1; nrd < totsamp + 1; nrd++)
+      for (int rdlimit = 1; rdlimit < totsamp + 1; rdlimit++)
       {
         const dds_entity_t rd = dds_create_reader (dp, tp, NULL, NULL);
         CU_ASSERT_FATAL (rd > 0);
@@ -3270,16 +3276,56 @@ static void do_readtake_sample_rank (dds_return_t (*op) (dds_entity_t reader_or_
 
         // write as many samples as planned for each instance,
         // add an invalid one iff # == 4
-        for (int i = 0; nsamp[i] > 0; i++) {
-          for (int s = 0; s < nsamp[i]; s++) {
-            rc = ((s < 4) ? dds_write : dds_dispose) (wr, &(Space_Type1){ .long_1 = i, .long_2 = s, 0 });
+        //
+        // constructing an invalid sample requires reading the
+        // already published data before disposing it
+        for (int i = 0; nsamp[i] > 0; i++)
+        {
+          const int nwrites = (nsamp[i] <= 3) ? nsamp[i] : 3;
+          for (int s = 0; s < nwrites; s++)
+          {
+            // Need invalid samples are also processed by the query condition (for better
+            // or for worse, because it doesn't get told whether it is valid).  For the
+            // test, use long_3 to not match an invalid sample.
+            rc = dds_write (wr, &(Space_Type1){ .long_1 = i, .long_2 = s, .long_3 = 1 });
+            CU_ASSERT_FATAL (rc == 0);
+          }
+          if (nsamp[i] > nwrites)
+          {
+            // Cyclone reader/writer instance handles are the same, so this'll work for reading
+            // only the samples we just wrote.  The obvious simpler alternative would be to first
+            // do all the writes, then read everything once, then do the disposes.  But why would
+            // one ever want to always do things the simple way?
+            dds_instance_handle_t ih;
+            rc = dds_register_instance (wr, &ih, &(Space_Type1){ .long_1 = i, .long_2 = 0, .long_3 = 0 });
+            CU_ASSERT_FATAL (rc == 0);
+            assert (nwrites == 3);
+            const dds_entity_t qc = dds_create_querycondition (rd, 0, test_long_2_eq_2);
+            rc = dds_read_instance (qc, buf, si, 1, 1, ih);
+            CU_ASSERT_FATAL (rc == 1);
+            CU_ASSERT_FATAL (xs[0].long_1 == i && xs[0].long_2 == 2 && xs[0].long_3 == 1);
+            rc = dds_delete (qc);
+            CU_ASSERT_FATAL (rc == 0);
+            rc = dds_dispose (wr, &(Space_Type1){ .long_1 = i, .long_2 = 0, .long_3 = 0 });
             CU_ASSERT_FATAL (rc == 0);
           }
         }
 
-        if (drop_even_long_2)
+        // Skipping everything with an even value for long_2 in the read where check the sample_rank
+        // - contents of each instance is a prefix of:
+        //     (unread,   valid, .long_2 = 0, .long_3 = 1)
+        //     (unread,   valid, .long_2 = 1, .long_3 = 1)
+        //     (   X  ,   valid, .long_2 = 2, .long_3 = 1) -- X is unread if nwrites < 3 else read
+        //     (unread, invalid, .long_2 = 0, .long_3 = 0)
+        //   where long_2 = 0 on the invalid sample is because it is an attribute
+        // - reading all samples with even long 2 & long_3 != 0 changes this to
+        //     (  read,   valid, .long_2 = 0, .long_3 = 1)
+        //     (unread,   valid, .long_2 = 1, .long_3 = 1)
+        //     (  read,   valid, .long_2 = 2, .long_3 = 1)
+        //     (unread, invalid, .long_2 = 0, .long_3 = 0)
+        if (skip_even_long_2)
         {
-          const dds_entity_t qc = dds_create_querycondition (rd, 0, test_even_long_2);
+          const dds_entity_t qc = dds_create_querycondition (rd, 0, test_even_long_2_and_long_3_neq_0);
           rc = dds_read (qc, buf, si, sizeof (xs) / sizeof (xs[0]), (uint32_t) (sizeof (xs) / sizeof (xs[0])));
           CU_ASSERT_FATAL (rc >= 0);
           for (int i = 0; i < rc; i++)
@@ -3288,33 +3334,33 @@ static void do_readtake_sample_rank (dds_return_t (*op) (dds_entity_t reader_or_
           CU_ASSERT_FATAL (rc == 0);
         }
 
-        assert (nrd < (int) (sizeof (xs) / sizeof (xs[0])));
-        int n = (int) op (rd, buf, si, (size_t) nrd, (uint32_t) nrd, (drop_even_long_2 ? DDS_NOT_READ_SAMPLE_STATE : 0));
-        CU_ASSERT_FATAL (n == ((nrd <= totsamp_after_maybe_dropping_even) ? nrd : totsamp_after_maybe_dropping_even));
-        //printf (" -- read %d ranks", n);
-        //for (int i = 0; i < n; i++)
-        //  printf (" %"PRIu32, si[i].sample_rank);
-        //printf ("\n");
+        assert (rdlimit < (int) (sizeof (xs) / sizeof (xs[0])));
+        int n = (int) op (rd, buf, si, (size_t) rdlimit, (uint32_t) rdlimit, (skip_even_long_2 ? DDS_NOT_READ_SAMPLE_STATE : 0));
+        printf ("  -- %s %d (<= %d), ranks:", opname_past_tense, n, rdlimit);
+        for (int i = 0; i < n; i++)
+          printf (" %"PRIu32, si[i].sample_rank);
+        printf ("\n");
+        CU_ASSERT_FATAL (n == ((rdlimit <= totsamp_after_maybe_skipping_even) ? rdlimit : totsamp_after_maybe_skipping_even));
 
         {
           int i = 0;
           while (i < n)
           {
             CU_ASSERT_FATAL (0 <= xs[i].long_1 && xs[i].long_1 <= 2);
-            CU_ASSERT_FATAL (!drop_even_long_2 || (xs[i].long_2 % 2) != 0);
-            const int nsamp_after_maybe_dropping_even = drop_even_long_2 ? nsamp[xs[i].long_1] / 2 : nsamp[xs[i].long_1];
-            const int nsamp_of_inst = (i + nsamp_after_maybe_dropping_even < n) ? nsamp_after_maybe_dropping_even : n - i;
+            CU_ASSERT_FATAL (!skip_even_long_2 || (xs[i].long_2 % 2) != 0);
+            const int nsamp_after_maybe_skipping_even = skip_even_long_2 ? nsamp[xs[i].long_1] / 2 : nsamp[xs[i].long_1];
+            const int nsamp_of_inst = (i + nsamp_after_maybe_skipping_even < n) ? nsamp_after_maybe_skipping_even : n - i;
             //printf ("i = %d nsamp_of_inst = %d\n", i, nsamp_of_inst);
             assert (nsamp_of_inst > 0);
             CU_ASSERT_FATAL (si[i].sample_rank == (uint32_t) (nsamp_of_inst - 1));
-            CU_ASSERT_FATAL (xs[i].long_3 == 0);
+            CU_ASSERT_FATAL ((!si[i].valid_data && xs[i].long_3 == 0) || (si[i].valid_data && xs[i].long_3 == 1));
             CU_ASSERT_FATAL ((int) si[i].sample_rank < nsamp_of_inst);
             const int first_of_inst = i;
             for (int j = 0; j < nsamp_of_inst; j++)
             {
               CU_ASSERT_FATAL (si[i + j].instance_handle == si[first_of_inst].instance_handle);
               CU_ASSERT_FATAL (si[i + j].sample_rank == (uint32_t) (nsamp_of_inst - j - 1));
-              CU_ASSERT_FATAL (xs[i + j].long_2 == (drop_even_long_2) ? 2*j+1 : j);
+              CU_ASSERT_FATAL (xs[i + j].long_2 == (skip_even_long_2) ? 2*j+1 : j);
             }
             i += nsamp_of_inst;
           }
@@ -3337,10 +3383,10 @@ static void do_readtake_sample_rank (dds_return_t (*op) (dds_entity_t reader_or_
 
 CU_Test (ddsc_read, sample_rank)
 {
-  do_readtake_sample_rank (dds_read_mask);
+  do_readtake_sample_rank ("read", dds_read_mask);
 }
 
 CU_Test (ddsc_take, sample_rank)
 {
-  do_readtake_sample_rank (dds_take_mask);
+  do_readtake_sample_rank ("took", dds_take_mask);
 }

--- a/src/core/xtests/rhc_torture/rhc_torture.c
+++ b/src/core/xtests/rhc_torture/rhc_torture.c
@@ -334,7 +334,6 @@ static void rdtkcond (struct dds_rhc *rhc, dds_readcond *cond, const struct chec
   struct dds_read_collect_sample_arg arg;
   dds_read_collect_sample_arg_init (&arg, rres_ptrs, rres_iseq);
   cnt = op (rhc, (max <= 0) ? (int32_t) (sizeof (rres_iseq) / sizeof (rres_iseq[0])) : max, cond ? DDS_RHC_NO_STATE_MASK_SET : (DDS_ANY_SAMPLE_STATE | DDS_ANY_VIEW_STATE | DDS_ANY_INSTANCE_STATE), 0, cond, dds_read_collect_sample, &arg);
-  dds_read_check_and_handle_instance_switch (&arg, 0);
   ddsi_thread_state_asleep (ddsi_lookup_thread_state ());
   if (max > 0 && cnt > max) {
     printf ("%s TOO MUCH DATA (%d > %d)\n", opname, cnt, max);

--- a/src/core/xtests/symbol_export/symbol_export.c
+++ b/src/core/xtests/symbol_export/symbol_export.c
@@ -91,6 +91,12 @@ static void test_ddsrt_vasprintf (char **buf, const char *fmt, ...)
   va_end (ap);
 }
 
+static dds_return_t test_collect_sample (void *arg, const dds_sample_info_t *si, const struct ddsi_sertype *st, struct ddsi_serdata *serdata)
+{
+  (void)arg; (void)si; (void)st; (void)serdata;
+  return 0;
+}
+
 /* Check that all exported functions are actually exported
    in case of a build that has testing disabled. All newly added
    functions that are exported (including DDSI and DDSRT) should
@@ -208,6 +214,8 @@ int main (int argc, char **argv)
   dds_take_next_wl (1, ptr, ptr);
   dds_read_next (1, ptr, ptr);
   dds_read_next_wl (1, ptr, ptr);
+  dds_read_with_collector (1, 0, 1, 0, test_collect_sample, ptr);
+  dds_take_with_collector (1, 0, 1, 0, test_collect_sample, ptr);
   dds_return_loan (1, ptr, 0);
   dds_lookup_instance (1, ptr);
   dds_instance_get_key (1, 1, ptr);
@@ -240,9 +248,6 @@ int main (int argc, char **argv)
   dds_data_allocator_fini (ptr);
   void* d = dds_data_allocator_alloc (ptr, 0);
   dds_data_allocator_free (ptr, d);
-
-  // dds_internal_api.h
-  dds_reader_lock_samples (1);
 
   // dds_loan_api.h
   dds_is_loan_available (1);
@@ -432,13 +437,10 @@ int main (int argc, char **argv)
   dds_rhc_relinquish_ownership (ptr, 1);
   dds_rhc_set_qos (ptr, ptr);
   dds_rhc_free (ptr);
-  dds_rhc_read (ptr, 0, ptr, ptr, 0, 0, 1, ptr);
-  dds_rhc_take (ptr, 0, ptr, ptr, 0, 0, 1, ptr);
-  dds_rhc_readcdr (ptr, 0, ptr, ptr, 0, 0, 0, 0, 1);
-  dds_rhc_takecdr (ptr, 0, ptr, ptr, 0, 0, 0, 0, 1);
+  dds_rhc_read (ptr, 0, 0, 1, ptr, 0, 0);
+  dds_rhc_take (ptr, 0, 0, 1, ptr, 0, 0);
   dds_rhc_add_readcondition (ptr, ptr);
   dds_rhc_remove_readcondition (ptr, ptr);
-  dds_rhc_lock_samples (ptr);
   dds_reader_data_available_cb (ptr);
 
   // dds_statistics.h

--- a/src/ucunit/include/ucunit/ucunit.h
+++ b/src/ucunit/include/ucunit/ucunit.h
@@ -289,15 +289,20 @@ typedef enum CU_ErrorCode {
   CUE_ERROR
 } CU_ErrorCode;
 
+typedef enum CU_ErrorAction {
+  CUEA_FAIL,
+  CUEA_ABORT // A failed CU_ASSERT_FATAL cause CU_fatal to abort()
+} CU_ErrorAction;
+
 UCUNIT_EXPORT CU_ErrorCode CU_initialize_registry (void);
 
 UCUNIT_EXPORT CU_pSuite CU_add_suite(const char *strName, CU_InitializeFunc pInit, CU_CleanupFunc pClean);
 
-UCUNIT_EXPORT CU_pSuite CU_get_suite (const char* strName);
+UCUNIT_EXPORT CU_pSuite CU_get_suite (const char *strName);
 
 UCUNIT_EXPORT CU_ErrorCode CU_set_suite_active (CU_pSuite pSuite, bool fNewActive);
 
-UCUNIT_EXPORT CU_pTest CU_add_test(CU_pSuite pSuite, const char* strName, CU_TestFunc pTestFunc);
+UCUNIT_EXPORT CU_pTest CU_add_test(CU_pSuite pSuite, const char *strName, CU_TestFunc pTestFunc);
 
 UCUNIT_EXPORT void CU_set_test_active(CU_pTest pTest, bool fNewActive);
 
@@ -312,6 +317,10 @@ UCUNIT_EXPORT uint32_t CU_get_number_of_failures (void);
 UCUNIT_EXPORT void CU_cleanup_registry (void);
 
 UCUNIT_EXPORT void CU_assertImplementation (bool value, int line, const char *expr, const char *file, const char *something, bool isfatal);
+
+UCUNIT_EXPORT void CU_fatal (void);
+
+UCUNIT_EXPORT void CU_set_error_action (CU_ErrorAction action);
 
 #if defined (__cplusplus)
 }

--- a/src/ucunit/src/ucunit.c
+++ b/src/ucunit/src/ucunit.c
@@ -26,6 +26,20 @@ static struct CU_Suite *cur_suite;
 static struct CU_Test *cur_test;
 static jmp_buf fatal_jmpbuf;
 static uint32_t failure_count;
+static CU_ErrorAction error_action;
+
+void CU_set_error_action (CU_ErrorAction action)
+{
+  error_action = action;
+}
+
+void CU_fatal (void)
+{
+  if (error_action == CUEA_FAIL)
+    longjmp (fatal_jmpbuf, 1);
+  else
+    abort ();
+}
 
 void CU_assertImplementation (bool value, int line, const char *expr, const char *file, const char *something, bool isfatal)
 {
@@ -50,11 +64,12 @@ void CU_assertImplementation (bool value, int line, const char *expr, const char
   cur_test->latest_failure = fr;
 
   if (isfatal)
-    longjmp (fatal_jmpbuf, 1);
+    CU_fatal ();
 }
 
 CU_ErrorCode CU_initialize_registry (void)
 {
+  error_action = CUEA_FAIL;
   output_filename_root = NULL;
   failure_count = 0;
   last_error = CUE_SUCCESS;


### PR DESCRIPTION
This PR proposes a new pair of API functions:

* dds_read_with_collector
* dds_take_with_collector

The key difference with all the other read/take functions is that this pair takes a callback function as an argument, to be called for each sample matched by the conditions given in the other arguments.

The RHC interface has been updated to make this the only model for reading/taking data.  Consequently, the regular read/take has been reworked and readcdr/takecdr are now simply wrappers around the new API functions.  Some of the common code in setting up read/take variants is now factored out into separate functions.

This also eliminates the abomination that was the "lock samples" operation and the magic value for the maximum number of samples to read to prevent locking.  This therefore also fixes some odd issues caused by the magic number and elimates the conditional lock/unconditional unlock in the RHC that was one of the internal consequences of the abomination.

The C++ binding is (hopefully) the only piece of code in existence that relied on the abomination. Updating the read/take functions in the C++ binding to use these new functions should improve performance a bit as well. That needs to be done before this can be merged.