### PR TITLE
Fix misra rule 5 3

### DIFF
--- a/.github/codeql/resolved-misra-rules.yml
+++ b/.github/codeql/resolved-misra-rules.yml
@@ -5,3 +5,4 @@ queries:
   - uses: ./codeql-coding-standards/c/misra/src/rules/RULE-3-1/CharacterSequencesAndUsedWithinAComment.ql
   - uses: ./codeql-coding-standards/c/misra/src/rules/RULE-10-2/AdditionSubtractionOnEssentiallyCharType.ql
   - uses: ./codeql-coding-standards/c/misra/src/rules/RULE-21-19/ValuesReturnedByLocaleSettingUsedAsPtrToConst.ql
+  - uses: ./codeql-coding-standards/c/misra/src/rules/RULE-5-3/IdentifierHidingC.ql

--- a/src/core/cdr/src/dds_cdrstream.c
+++ b/src/core/cdr/src/dds_cdrstream.c
@@ -395,10 +395,10 @@ static void dds_os_put_bytes (dds_ostream_t * __restrict os, const struct dds_cd
   os->m_index += l;
 }
 
-static void dds_os_put_bytes_aligned (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const void * __restrict data, uint32_t num, uint32_t elem_sz, align_t align, void **dst)
+static void dds_os_put_bytes_aligned (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const void * __restrict data, uint32_t num, uint32_t elem_sz, align_t cdr_align, void **dst)
 {
   const uint32_t sz = num * elem_sz;
-  dds_cdr_alignto_clear_and_resize (os, allocator, align, sz);
+  dds_cdr_alignto_clear_and_resize (os, allocator, cdr_align, sz);
   if (dst)
     *dst = os->m_buffer + os->m_index;
   memcpy (os->m_buffer + os->m_index, data, sz);
@@ -563,9 +563,9 @@ static inline bool op_type_base (const uint32_t insn)
 
 static inline bool check_optimize_impl (uint32_t xcdr_version, const uint32_t *ops, uint32_t size, uint32_t num, uint32_t *off, uint32_t member_offs)
 {
-  align_t align = dds_cdr_get_align (xcdr_version, size);
-  if (*off % ALIGN(align))
-    *off += ALIGN(align) - (*off % ALIGN(align));
+  align_t cdr_align = dds_cdr_get_align (xcdr_version, size);
+  if (*off % ALIGN(cdr_align))
+    *off += ALIGN(cdr_align) - (*off % ALIGN(cdr_align));
   if (member_offs + ops[1] != *off)
     return false;
   *off += num * size;
@@ -3376,10 +3376,10 @@ static void dds_stream_extract_key_from_key_prim_op (dds_istream_t * __restrict 
         elem_size = DDS_OP_TYPE_SZ (insn);
       else
         abort ();
-      const align_t align = dds_cdr_get_align (os->m_xcdr_version, elem_size);
+      const align_t cdr_align = dds_cdr_get_align (os->m_xcdr_version, elem_size);
       const uint32_t num = ops[2];
-      dds_cdr_alignto (is, align);
-      dds_cdr_alignto_clear_and_resize (os, allocator, align, num * elem_size);
+      dds_cdr_alignto (is, cdr_align);
+      dds_cdr_alignto_clear_and_resize (os, allocator, cdr_align, num * elem_size);
       void * const dst = os->m_buffer + os->m_index;
       dds_is_get_bytes (is, dst, num, elem_size);
       os->m_index += num * elem_size;
@@ -3483,10 +3483,10 @@ static void dds_stream_extract_keyBE_from_key_prim_op (dds_istream_t * __restric
         elem_size = DDS_OP_TYPE_SZ (insn);
       else
         abort ();
-      const align_t align = dds_cdr_get_align (os->x.m_xcdr_version, elem_size);
+      const align_t cdr_align = dds_cdr_get_align (os->x.m_xcdr_version, elem_size);
       const uint32_t num = ops[2];
-      dds_cdr_alignto (is, align);
-      dds_cdr_alignto_clear_and_resizeBE (os, allocator, align, num * elem_size);
+      dds_cdr_alignto (is, cdr_align);
+      dds_cdr_alignto_clear_and_resizeBE (os, allocator, cdr_align, num * elem_size);
       void const * const src = is->m_buffer + is->m_index;
       void * const dst = os->x.m_buffer + os->x.m_index;
 #if DDSRT_ENDIAN == DDSRT_LITTLE_ENDIAN

--- a/src/core/cdr/src/dds_cdrstream_keys.part.c
+++ b/src/core/cdr/src/dds_cdrstream_keys.part.c
@@ -40,8 +40,8 @@ static void dds_stream_write_keyBO_impl (DDS_OSTREAM_T * __restrict os, const st
       {
         case DDS_OP_VAL_BLN: case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY: {
           const uint32_t elem_size = get_primitive_size (DDS_OP_SUBTYPE (insn));
-          const align_t align = dds_cdr_get_align (((struct dds_ostream *)os)->m_xcdr_version, elem_size);
-          dds_cdr_alignto_clear_and_resizeBO (os, allocator, align, num * elem_size);
+          const align_t cdr_align = dds_cdr_get_align (((struct dds_ostream *)os)->m_xcdr_version, elem_size);
+          dds_cdr_alignto_clear_and_resizeBO (os, allocator, cdr_align, num * elem_size);
           void * const dst = ((struct dds_ostream *)os)->m_buffer + ((struct dds_ostream *)os)->m_index;
           dds_os_put_bytes ((struct dds_ostream *)os, allocator, addr, num * elem_size);
           dds_stream_swap_if_needed_insituBO (dst, elem_size, num);

--- a/src/core/cdr/src/dds_cdrstream_write.part.c
+++ b/src/core/cdr/src/dds_cdrstream_write.part.c
@@ -222,13 +222,13 @@ static const uint32_t *dds_stream_write_seqBO (DDS_OSTREAM_T * __restrict os, co
         break;
       case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY: {
         const uint32_t elem_size = get_primitive_size (subtype);
-        const align_t align = dds_cdr_get_align (xcdrv, elem_size);
+        const align_t cdr_align = dds_cdr_get_align (xcdrv, elem_size);
         void * dst;
         /* Combining put bytes and swap into a single step would improve the performance
            of writing data in non-native endianess. But in most cases the data will
            be written in native endianess, and in that case the swap is a no-op (for writing
            keys a separate function is used). */
-        dds_os_put_bytes_aligned ((struct dds_ostream *)os, allocator, seq->_buffer, num, elem_size, align, &dst);
+        dds_os_put_bytes_aligned ((struct dds_ostream *)os, allocator, seq->_buffer, num, elem_size, cdr_align, &dst);
         dds_stream_to_BO_insitu (dst, elem_size, num);
         ops += 2 + bound_op;
         break;
@@ -303,10 +303,10 @@ static const uint32_t *dds_stream_write_arrBO (DDS_OSTREAM_T * __restrict os, co
       break;
     case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY: {
       const uint32_t elem_size = get_primitive_size (subtype);
-      const align_t align = dds_cdr_get_align (xcdrv, elem_size);
+      const align_t cdr_align = dds_cdr_get_align (xcdrv, elem_size);
       void * dst;
       /* See comment for stream_write_seq, swap is a no-op in most cases */
-      dds_os_put_bytes_aligned ((struct dds_ostream *)os, allocator, addr, num, elem_size, align, &dst);
+      dds_os_put_bytes_aligned ((struct dds_ostream *)os, allocator, addr, num, elem_size, cdr_align, &dst);
       dds_stream_to_BO_insitu (dst, elem_size, num);
       ops += 3;
       break;

--- a/src/ddsrt/src/avl.c
+++ b/src/ddsrt/src/avl.c
@@ -988,15 +988,15 @@ void *ddsrt_avl_root_non_empty (const ddsrt_avl_treedef_t *td, const ddsrt_avl_t
  ****
  **************************************************************************************/
 
-void ddsrt_avl_ctreedef_init (ddsrt_avl_ctreedef_t *td, size_t avlnodeoffset, size_t keyoffset, ddsrt_avl_compare_t comparekk, ddsrt_avl_augment_t augment, uint32_t flags)
+void ddsrt_avl_ctreedef_init (ddsrt_avl_ctreedef_t *td, size_t avlnodeoffset, size_t keyoffset, ddsrt_avl_compare_t comparekk, ddsrt_avl_augment_t avl_augment, uint32_t flags)
 {
-    treedef_init_common (&td->t, avlnodeoffset, keyoffset, augment, flags);
+    treedef_init_common (&td->t, avlnodeoffset, keyoffset, avl_augment, flags);
     td->t.u.comparekk = comparekk;
 }
 
-void ddsrt_avl_ctreedef_init_r (ddsrt_avl_ctreedef_t *td, size_t avlnodeoffset, size_t keyoffset, ddsrt_avl_compare_r_t comparekk_r, void *cmp_arg, ddsrt_avl_augment_t augment, uint32_t flags)
+void ddsrt_avl_ctreedef_init_r (ddsrt_avl_ctreedef_t *td, size_t avlnodeoffset, size_t keyoffset, ddsrt_avl_compare_r_t comparekk_r, void *cmp_arg, ddsrt_avl_augment_t avl_augment, uint32_t flags)
 {
-    treedef_init_common (&td->t, avlnodeoffset, keyoffset, augment, flags | DDSRT_AVL_TREEDEF_FLAG_R);
+    treedef_init_common (&td->t, avlnodeoffset, keyoffset, avl_augment, flags | DDSRT_AVL_TREEDEF_FLAG_R);
     td->t.cmp_arg = cmp_arg;
     td->t.u.comparekk_r = comparekk_r;
 }

--- a/src/ddsrt/src/fibheap.c
+++ b/src/ddsrt/src/fibheap.c
@@ -27,10 +27,10 @@ static int cmp (const ddsrt_fibheap_def_t *fhdef, const ddsrt_fibheap_node_t *a,
     return fhdef->cmp ((const char *) a - fhdef->offset, (const char *) b - fhdef->offset);
 }
 
-void ddsrt_fibheap_def_init (ddsrt_fibheap_def_t *fhdef, uintptr_t offset, int (*cmp) (const void *va, const void *vb))
+void ddsrt_fibheap_def_init (ddsrt_fibheap_def_t *fhdef, uintptr_t offset, int (*compare) (const void *va, const void *vb))
 {
     fhdef->offset = offset;
-    fhdef->cmp = cmp;
+    fhdef->cmp = compare;
 }
 
 void ddsrt_fibheap_init (const ddsrt_fibheap_def_t *fhdef, ddsrt_fibheap_t *fh)

--- a/src/tools/ddsperf/ddsperf.c
+++ b/src/tools/ddsperf/ddsperf.c
@@ -2434,9 +2434,11 @@ int main (int argc, char *argv[])
 
   /* Just before starting the threads but after setting everything up, wait for
      the required number of peers, if requested to do so */
+  dds_time_t tnow;
+  bool ok;
   if (initmaxwait > 0)
   {
-    dds_time_t tnow = dds_time ();
+    tnow = dds_time ();
     const dds_time_t tendwait = tnow + (dds_duration_t) (initmaxwait * 1e9);
     ddsrt_mutex_lock (&disc_lock);
     while (matchcount < minmatch && tnow < tendwait)
@@ -2446,15 +2448,15 @@ int main (int argc, char *argv[])
       ddsrt_mutex_lock (&disc_lock);
       tnow = dds_time ();
     }
-    const bool ok = (matchcount >= minmatch);
-    if (!ok)
+    const bool status_ok = (matchcount >= minmatch);
+    if (!status_ok)
     {
       /* set minmatch to an impossible value to avoid a match occurring between now and
          the determining of the exit status from causing a successful return */
       minmatch = UINT32_MAX;
     }
     ddsrt_mutex_unlock (&disc_lock);
-    if (!ok)
+    if (!status_ok)
       goto err_minmatch_wait;
     dds_sleepfor (DDS_MSECS (100));
   }
@@ -2540,7 +2542,7 @@ int main (int argc, char *argv[])
 
   /* Run until time limit reached or a signal received.  (The time calculations
      ignore the possibility of overflow around the year 2260.) */
-  dds_time_t tnow = dds_time ();
+  tnow = dds_time ();
   const dds_time_t tstart = tnow;
   if (tref == DDS_INFINITY)
     tref = tstart;
@@ -2557,7 +2559,6 @@ int main (int argc, char *argv[])
     /* bail out if too few readers discovered within the deadline */
     if (tnow >= tmatch)
     {
-      bool ok;
       ddsrt_mutex_lock (&disc_lock);
       ok = (matchcount >= minmatch);
       ddsrt_mutex_unlock (&disc_lock);
@@ -2730,7 +2731,7 @@ err_minmatch_wait:
   }
   free (pongstat);
 
-  bool ok = true;
+  ok = true;
 
   {
     ddsrt_avl_iter_t it;


### PR DESCRIPTION
This PR addresses rule 5.3.
```
Identifier declared in a local or function prototype scope shall not hide an identifier declared in a global or namespace scope.
```