### PR TITLE
Fix MISRA rule 8-8

### DIFF
--- a/src/core/ddsc/src/dds_whc.c
+++ b/src/core/ddsc/src/dds_whc.c
@@ -503,7 +503,7 @@ static void free_whc_node_contents (struct dds_whc_default_node *whcn)
   ddsi_serdata_unref (whcn->serdata);
 }
 
-void whc_default_free (struct ddsi_whc *whc_generic)
+static void whc_default_free (struct ddsi_whc *whc_generic)
 {
   /* Freeing stuff without regards for maintaining data structures */
   struct whc_impl * const whc = (struct whc_impl *)whc_generic;


### PR DESCRIPTION
This PR addresses rule 8.8.
```
The static storage class specifier shall be used in definitions and declarations of objects and functions that have internal linkage
```