### PR TITLE
Fix field order in key-only sample serialization

### DIFF
--- a/src/core/cdr/src/dds_cdrstream.c
+++ b/src/core/cdr/src/dds_cdrstream.c
@@ -4397,8 +4397,7 @@ static uint32_t add_to_key_size_impl (uint32_t keysize, uint32_t field_size, uin
 
 static void add_to_key_size_xcdrv1 (struct key_props *k, uint32_t field_size, uint32_t field_dims, uint32_t field_align)
 {
-  if (k->min_xcdrv == DDSI_RTPS_CDR_ENC_VERSION_1)
-    k->sz_xcdrv1 = add_to_key_size_impl (k->sz_xcdrv1, field_size, field_dims, field_align, XCDR1_MAX_ALIGN);
+  k->sz_xcdrv1 = add_to_key_size_impl (k->sz_xcdrv1, field_size, field_dims, field_align, XCDR1_MAX_ALIGN);
 }
 
 static void add_to_key_size_xcdrv2 (struct key_props *k, uint32_t field_size, uint32_t field_dims, uint32_t field_align)
@@ -4425,8 +4424,6 @@ static const uint32_t *dds_stream_key_size_arr (const uint32_t * __restrict ops,
   const enum dds_stream_typecode subtype = DDS_OP_SUBTYPE (insn);
   uint32_t bound = ops[2];
 
-  if (is_dheader_needed (subtype, DDSI_RTPS_CDR_ENC_VERSION_1))
-    add_to_key_size_xcdrv1 (k, 4, 1, 4);
   if (is_dheader_needed (subtype, DDSI_RTPS_CDR_ENC_VERSION_2))
     add_to_key_size_xcdrv2 (k, 4, 1, 4);
 
@@ -4734,7 +4731,7 @@ uint32_t dds_stream_key_flags (struct dds_cdrstream_desc *desc, uint32_t *keysz_
         key_flags |= DDS_TOPIC_KEY_APPENDABLE;
 
       if (keysz_xcdrv1 != NULL)
-        *keysz_xcdrv1 = key_properties.sz_xcdrv1;
+        *keysz_xcdrv1 = key_properties.min_xcdrv == DDSI_RTPS_CDR_ENC_VERSION_1 ? key_properties.sz_xcdrv1 : 0;
       if (keysz_xcdrv2 != NULL)
         *keysz_xcdrv2 = key_properties.sz_xcdrv2;
     }

--- a/src/core/cdr/test/mem_ser.h
+++ b/src/core/cdr/test/mem_ser.h
@@ -14,6 +14,10 @@
 #include "dds/ddsrt/endian.h"
 
 #if DDSRT_ENDIAN == DDSRT_BIG_ENDIAN
+#define SER16(v) \
+  (unsigned char)(((uint16_t)(v) >>  8) & 0xff), \
+  (unsigned char)( (uint16_t)(v)        & 0xff)
+#define SER16BE(v) SER16(v)
 #define SER32(v) \
   (unsigned char)( (uint32_t)(v) >> 24        ), \
   (unsigned char)(((uint32_t)(v) >> 16) & 0xff), \
@@ -29,7 +33,14 @@
   (unsigned char)(((uint32_t)(v) >> 16) & 0xff), \
   (unsigned char)(((uint32_t)(v) >>  8) & 0xff), \
   (unsigned char)( (uint32_t)(v)        & 0xff)
+#define SER64BE(v) SER64(v)
 #else
+#define SER16(v) \
+  (unsigned char)( (uint16_t)(v)        & 0xff), \
+  (unsigned char)(((uint16_t)(v) >>  8) & 0xff)
+#define SER16BE(v) \
+  (unsigned char)(((uint16_t)(v) >>  8) & 0xff), \
+  (unsigned char)( (uint16_t)(v)        & 0xff)
 #define SER32(v) \
   (unsigned char)( (uint32_t)(v)        & 0xff), \
   (unsigned char)(((uint32_t)(v) >>  8) & 0xff), \
@@ -49,6 +60,19 @@
   (unsigned char)(((uint64_t)(v) >> 40) & 0xff), \
   (unsigned char)(((uint64_t)(v) >> 48) & 0xff), \
   (unsigned char)( (uint64_t)(v) >> 56)
+#define SER64BE(v) \
+  (unsigned char)( (uint64_t)(v) >> 56        ), \
+  (unsigned char)(((uint64_t)(v) >> 48) & 0xff), \
+  (unsigned char)(((uint64_t)(v) >> 40) & 0xff), \
+  (unsigned char)(((uint64_t)(v) >> 32) & 0xff), \
+  (unsigned char)(((uint64_t)(v) >> 24) & 0xff), \
+  (unsigned char)(((uint64_t)(v) >> 16) & 0xff), \
+  (unsigned char)(((uint64_t)(v) >>  8) & 0xff), \
+  (unsigned char)( (uint64_t)(v)        & 0xff)
 #endif
+
+#define SER_DHEADER(l) SER32(l)
+#define SER_EMHEADER(mu,lc,mid) SER32(((mu) ? (1u << 31) : 0) + ((uint32_t) (lc) << 28) + ((uint32_t) (mid) & 0x0fffffff))
+#define SER_NEXTINT(l) SER32(l)
 
 #endif /* DDSI_TEST_MEM_SER_H */

--- a/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
@@ -610,6 +610,36 @@ enum dds_stream_typecode_subtype {
  */
 #define DDS_TOPIC_RESTRICT_DATA_REPRESENTATION  (1u << 7)
 
+
+/**
+ * @anchor DDS_TOPIC_KEY_MUTABLE
+ * @ingroup topic_flags
+ * @brief Set if any of the key fields of a type is in a mutable aggregated type.
+ */
+#define DDS_TOPIC_KEY_MUTABLE                  (1u << 8)
+
+/**
+ * @anchor DDS_TOPIC_KEY_APPENDABLE
+ * @ingroup topic_flags
+ * @brief Set if any of the key fields of a type is in an appendable aggregated type.
+ */
+#define DDS_TOPIC_KEY_APPENDABLE                (1u << 9)
+
+/**
+ * @anchor DDS_TOPIC_FIXED_KEY_XCDR2_KEYHASH
+ * @ingroup topic_flags
+ * @brief The XCDRV2 serialized key with field in member-id order fits
+ * in 16 bytes. If statically determined that a serialized key that is
+ * used to get the keyhash always fits in 16 bytes, the spec specifies
+ * that the keyhash of a sample is the resulting CDR. If it is longer
+ * we must use MD5 to hash the resultant key CDR.
+ *
+ * The XCDRV1 key-hash is calculated from the serialized key with the
+ * fields in definition order, so DDS_TOPIC_FIXED_KEY can also be used
+ * for key-hash for XCDR1.
+ */
+#define DDS_TOPIC_FIXED_KEY_XCDR2_KEYHASH       (1u << 10)
+
 /**
  * @anchor DDS_FIXED_KEY_MAX_SIZE
  * @ingroup topic_flags

--- a/src/core/ddsc/src/dds__serdata_default.h
+++ b/src/core/ddsc/src/dds__serdata_default.h
@@ -32,6 +32,19 @@ extern "C" {
 
 #define SERDATA_DEFAULT_KEYSIZE_MASK        0x3FFFFFFFu
 
+
+/**
+ * @brief Key buffer
+ *
+ * Stores the serialized key in XCDRV2 encoding, which is the
+ * serialized KeyHolder obtained from the data type, as defined
+ * in the XTypes spec secion 7.2.2.4.7.
+ *
+ * The keyholder members are serialized in the order they are
+ * defined, and the extensibility is the same as the actual
+ * data-type. As a result, the serialized key can have DHEADERS
+ * and/or EMHEADERS in case of an appendable or mutable data-type.
+ */
 struct dds_serdata_default_key {
   unsigned buftype : 2;
   unsigned keysize : 30;

--- a/src/core/ddsc/src/dds_topic.c
+++ b/src/core/ddsc/src/dds_topic.c
@@ -58,7 +58,7 @@ static bool is_valid_name (const char *name)
   // DDS Spec does not explicitly specify what constitutes a valid name.
   // Per https://github.com/eclipse-cyclonedds/cyclonedds/pull/1426
   //  Require isprint is true and not <space>*?[]"' for the time being, then work our way to supporting UTF-8
-   
+
   const char* invalid = "*?[]\"'#$";
 
   if (name[0] == '\0')
@@ -1116,20 +1116,6 @@ dds_return_t dds_delete_topic_descriptor (dds_topic_descriptor_t *descriptor)
 void dds_cdrstream_desc_from_topic_desc (struct dds_cdrstream_desc *desc, const dds_topic_descriptor_t *topic_desc)
 {
   memset (desc, 0, sizeof (*desc));
-  desc->size = topic_desc->m_size;
-  desc->align = topic_desc->m_align;
-  desc->flagset = topic_desc->m_flagset;
-  desc->ops.nops = dds_stream_countops (topic_desc->m_ops, topic_desc->m_nkeys, topic_desc->m_keys);
-  desc->ops.ops = dds_alloc (desc->ops.nops * sizeof (*desc->ops.ops));
-  memcpy (desc->ops.ops, topic_desc->m_ops, desc->ops.nops * sizeof (*desc->ops.ops));
-  desc->keys.nkeys = topic_desc->m_nkeys;
-  if (desc->keys.nkeys > 0)
-  {
-    desc->keys.keys = dds_alloc (desc->keys.nkeys * sizeof (*desc->keys.keys));
-    for (uint32_t i = 0; i < desc->keys.nkeys; i++)
-    {
-      desc->keys.keys[i].ops_offs = topic_desc->m_keys[i].m_offset;
-      desc->keys.keys[i].idx = topic_desc->m_keys[i].m_idx;
-    }
-  }
+  dds_cdrstream_desc_init (desc, &dds_cdrstream_default_allocator, topic_desc->m_size, topic_desc->m_align, topic_desc->m_flagset,
+      topic_desc->m_ops, topic_desc->m_keys, topic_desc->m_nkeys);
 }

--- a/src/core/ddsc/tests/CMakeLists.txt
+++ b/src/core/ddsc/tests/CMakeLists.txt
@@ -22,6 +22,9 @@ idlc_generate(TARGET DataRepresentationTypes FILES DataRepresentationTypes.idl W
 idlc_generate(TARGET MinXcdrVersion FILES MinXcdrVersion.idl)
 idlc_generate(TARGET CdrStreamOptimize FILES CdrStreamOptimize.idl WARNINGS no-implicit-extensibility)
 idlc_generate(TARGET CdrStreamSkipDefault FILES CdrStreamSkipDefault.idl)
+idlc_generate(TARGET CdrStreamKeySize FILES CdrStreamKeySize.idl)
+idlc_generate(TARGET CdrStreamKeyExt FILES CdrStreamKeyExt.idl)
+idlc_generate(TARGET SerdataData FILES SerdataData.idl)
 if(ENABLE_TYPE_DISCOVERY)
   idlc_generate(TARGET XSpace FILES XSpace.idl XSpaceEnum.idl XSpaceMustUnderstand.idl XSpaceTypeConsistencyEnforcement.idl WARNINGS no-implicit-extensibility no-inherit-appendable)
   idlc_generate(TARGET XSpaceNoTypeInfo FILES XSpaceNoTypeInfo.idl NO_TYPE_INFO WARNINGS no-implicit-extensibility)
@@ -90,6 +93,7 @@ set(ddsc_test_sources
     "test_oneliner.c"
     "test_oneliner.h"
     "cdrstream.c"
+    "serdata_keys.c"
   )
 
 if(ENABLE_LIFESPAN)
@@ -123,7 +127,8 @@ target_include_directories(
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../ddsc/src>"
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../ddsi/include>"
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../ddsi/src>"
-  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../cdr/include>")
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../cdr/include>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../cdr/test>")
 if(ENABLE_SHM)
   target_include_directories(
     cunit_ddsc PRIVATE
@@ -131,7 +136,7 @@ if(ENABLE_SHM)
 endif()
 
 target_link_libraries(cunit_ddsc PRIVATE
-  RoundTrip Space TypesArrayKey WriteTypes InstanceHandleTypes RWData CreateWriter DataRepresentationTypes MinXcdrVersion CdrStreamOptimize CdrStreamSkipDefault ddsc)
+  RoundTrip Space TypesArrayKey WriteTypes InstanceHandleTypes RWData CreateWriter DataRepresentationTypes MinXcdrVersion CdrStreamOptimize CdrStreamSkipDefault CdrStreamKeySize CdrStreamKeyExt SerdataData ddsc)
 
 if(ENABLE_TYPE_DISCOVERY)
   target_link_libraries(cunit_ddsc PRIVATE

--- a/src/core/ddsc/tests/CdrStreamKeyExt.idl
+++ b/src/core/ddsc/tests/CdrStreamKeyExt.idl
@@ -1,0 +1,25 @@
+// Copyright(c) 2022 to 2023 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+module CdrStreamKeyExt {
+  @final struct t1 { @key long a; };
+  @final struct t1a { @key @external long a; };
+  @appendable struct t2 { @key long a; };
+  @mutable struct t3 { @key long a; };
+  @appendable struct nested4 { @key long a; }; @final struct t4 { @key long a; nested4 b; };
+  @appendable struct nested4a { @key long a; }; @final struct t4a { @key long a; @key nested4a b; };
+  @appendable struct nested4b { long a; }; @final struct t4b { @key long a; @key nested4b b; };
+  @mutable struct nested5 { @key long a; }; @final struct t5 { @key long a; nested5 b; };
+  @mutable struct nested5a { @key long a; }; @final struct t5a { @key long a; @key nested5a b; };
+  @mutable struct nested5b { long a; }; @final struct t5b { @key long a; @key nested5b b; };
+  @mutable struct nested6 { @key long a; }; @appendable struct t6 { @key long a; nested6 b; };
+  @mutable struct nested6a { @key long a; }; @appendable struct t6a { @key long a; @key nested6a b; };
+  @mutable struct nested6b { long a; }; @appendable struct t6b { @key long a; @key nested6b b; };
+};

--- a/src/core/ddsc/tests/CdrStreamKeySize.idl
+++ b/src/core/ddsc/tests/CdrStreamKeySize.idl
@@ -1,0 +1,42 @@
+// Copyright(c) 2022 to 2023 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+module CdrStreamKeySize {
+  @topic @final struct t1 { @key long a; @key short b; };
+  @topic @final struct t2 { @key char a; @key long long b; @key short c; };
+  @nested @final struct nested3 { @key char a; @key long long b; @key short c; }; @topic @final struct t3 { @key nested3 a; };
+  @nested @final struct nested4 { char a; short b; }; @topic @final struct t4 { @key nested4 a; @key long long b; @key char c; };
+  @topic @final struct t5 { @key long a[5]; };
+  @nested @final struct nested6 { @key long long a; }; @topic @final struct t6 { @key nested6 a; long b[5]; @key char c; @key float d; };
+  @nested @final struct nested7_1 { @key short a; }; @nested @final struct nested7_2 { @key long long a; }; @topic @final struct t7 { @key nested7_1 a; @key nested7_2 b; @key char c; @key nested7_1 d; };
+  @topic @final struct t8 { @key char a[15]; };
+  @topic @final struct t9 { @key short a[6]; };
+  @nested @final struct nested10 { @key long long a; long b; }; @topic @final struct t10 { nested10 a; @key nested10 b; };
+  @topic @final struct t11 { @key string<3> a; @key long long b; };
+  @topic @final struct t12 { @key char a; @key string<3> b; @key long c; };
+  @topic @final struct t13 { @key @id(2) float a; @key @id(1) char b; @key @id(0) double c; };
+  @topic @final struct t14 { @key @id(0) char b; @key @id(1) double a; @key @id(2) float c; };
+  @topic @final struct t15 { @key @id(0) char c1; @key @id(2) char c2; @key @id(4) char c3; @key @id(1) long l1; @key @id(3) long l2; };
+  enum e16 { E16_0, E16_1 }; @topic @final struct t16 { @key e16 a; };
+  @bit_bound(8) enum e17 { E17_0, E17_1 }; @topic @final struct t17 { @key e17 a; };
+  @bit_bound(16) enum e18 { E18_0, E18_1 }; @topic @final struct t18 { @key char a; @key e18 b[4]; };
+  bitmask bm19 { BM19_0, BM19_1 }; @topic @final struct t19 { @key bm19 a; };
+  @bit_bound(8) bitmask bm20 { BM20_0, BM20_1 }; @topic @final struct t20 { @key bm20 a; };
+  @bit_bound(43) bitmask bm21 { BM21_0, BM21_1 }; @topic @final struct t21 { @key char a; @key bm21 b[1]; };
+
+  @topic @appendable struct t22 { @key int32 a; };
+  @topic @mutable struct t23 { @key int32 a; };
+  @nested @appendable struct nested24 { int32 a; }; @topic @appendable struct t24 { @key nested24 a; };
+  @nested @mutable struct nested25 { int32 a; }; @topic @mutable struct t25 { @key nested25 a; };
+  @nested @appendable struct nested26 { int8 a; }; @topic @mutable struct t26 { @key nested26 a; };
+  @nested @appendable struct nested27 { int32 a; @key uint8 b; }; @topic @appendable struct t27 { @key nested27 a; };
+  @bit_bound(8) enum e28 { E28_0, E28_1 }; @topic @mutable struct t28 { @key e28 a[2]; };
+  @nested @mutable struct base29 { @key int32 k; }; @topic @mutable struct t29 : base29 { int32 a; };
+};

--- a/src/core/ddsc/tests/SerdataData.idl
+++ b/src/core/ddsc/tests/SerdataData.idl
@@ -1,0 +1,188 @@
+// Copyright(c) 2023 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+@final
+struct SerdataKeyOrder {
+    @key uint8 a;
+    uint8 b;
+    @key uint64 c;
+};
+
+@final
+struct SerdataKeyOrderId {
+    @id(2) @key uint8 a;
+    @id(3) uint8 b;
+    @id(1) @key uint64 c;
+};
+
+@final @autoid(HASH)
+struct SerdataKeyOrderHashId {
+    @key uint8 a;       // 158712076
+    uint8 b;            // 241167250
+    @key uint64 c;      //    559690
+};
+
+@appendable
+struct SerdataKeyOrderAppendable {
+    @id(3) @key uint8 a;
+    @id(2) uint8 b;
+    @id(1) @key uint64 c;
+};
+
+@mutable
+struct SerdataKeyOrderMutable {
+    @id(3) @key uint8 a;
+    @id(2) uint8 b;
+    @id(1) @key uint64 c;
+};
+
+@final
+struct SerdataKeyString {
+    @key uint8 a;
+    @key string b;
+};
+
+@final
+struct SerdataKeyStringBounded {
+    @key uint8 a;
+    @key string<3> b;
+};
+
+@appendable
+struct SerdataKeyStringAppendable {
+    @key uint8 a;
+    @key string b;
+};
+
+@appendable
+struct SerdataKeyStringBoundedAppendable {
+    @key uint8 a;
+    @key string<3> b;
+};
+
+@final
+struct SerdataKeyArr {
+    @key uint8 a[12];
+};
+
+// TODO: currently not supported
+// @final
+// struct SerdataKeyArrStrBounded {
+//     @key string<2> a[2];
+// };
+
+
+// Nested aggregated types
+
+@final
+struct SerdataKeyOrderFinalNestedMutable {
+    @id(3) @key uint8 x;
+    @id(2) uint8 y;
+    @id(1) @key SerdataKeyOrderMutable z;
+};
+
+@appendable
+struct SerdataKeyOrderAppendableNestedMutable {
+    @id(3) @key uint8 x;
+    @id(2) uint8 y;
+    @id(1) @key SerdataKeyOrderMutable z;
+};
+
+@mutable
+struct SerdataKeyOrderMutableNestedMutable {
+    @id(3) @key uint8 x;
+    @id(2) uint8 y;
+    @id(1) @key SerdataKeyOrderMutable z;
+};
+
+@mutable
+struct SerdataKeyOrderMutableNestedAppendable {
+    @id(3) @key uint8 x;
+    @id(2) uint8 y;
+    @id(1) @key SerdataKeyOrderAppendable z;
+};
+
+@mutable
+struct SerdataKeyOrderMutableNestedFinal {
+    @id(3) @key uint8 x;
+    @id(2) uint8 y;
+    @id(1) @key SerdataKeyOrder z;
+};
+
+// Implicit key members in nested type
+
+@final @nested
+struct SerdataKeyNestedFinalImplicitSubtype {
+    @id(3) uint8 x;
+    @id(2) uint8 y;
+    @id(1) SerdataKeyOrder z;
+};
+@final
+struct SerdataKeyNestedFinalImplicit {
+    @id(3) @key SerdataKeyNestedFinalImplicitSubtype d;
+    @id(2) SerdataKeyNestedFinalImplicitSubtype e;
+    @id(1) @key uint32 f;
+};
+
+
+@final @nested
+struct SerdataKeyNestedFinalImplicit2Subtype3 {
+    uint8 x;
+    uint8 y;
+};
+@final @nested
+struct SerdataKeyNestedFinalImplicit2Subtype2 {
+    @key SerdataKeyNestedFinalImplicit2Subtype3 e;
+    SerdataKeyNestedFinalImplicit2Subtype3 f;
+};
+@final @nested
+struct SerdataKeyNestedFinalImplicit2Subtype1 {
+    SerdataKeyNestedFinalImplicit2Subtype2 c;
+    SerdataKeyNestedFinalImplicit2Subtype2 d;
+};
+@final
+struct SerdataKeyNestedFinalImplicit2 {
+    @key SerdataKeyNestedFinalImplicit2Subtype1 a;
+    SerdataKeyNestedFinalImplicit2Subtype1 b;
+};
+
+@mutable @nested
+struct SerdataKeyNestedMutableImplicitSubtype {
+    @id(3) uint8 x;
+    @id(2) uint8 y;
+    @id(1) SerdataKeyOrder z;
+};
+@appendable
+struct SerdataKeyNestedMutableImplicit {
+    @id(3) @key SerdataKeyNestedMutableImplicitSubtype d;
+    @id(2) SerdataKeyNestedMutableImplicitSubtype e;
+    @id(1) @key uint32 f;
+};
+
+@appendable @nested
+struct SerdataKeyInheritMutableNested {
+    @key @id(9) uint16 nx;
+    @id(8) uint16 ny;
+    @key @id(7) uint16 nz;
+};
+
+@mutable @nested
+struct SerdataKeyInheritMutableBase {
+    @id(6) @key SerdataKeyInheritMutableNested bx;
+    @id(5) uint16 by;
+    @id(4) @key uint16 bz;
+};
+
+@mutable
+struct SerdataKeyInheritMutable : SerdataKeyInheritMutableBase {
+    @id(3) SerdataKeyInheritMutableNested a;
+    @id(2) uint16 b;
+    @id(1) uint16 c;
+};

--- a/src/core/ddsc/tests/serdata_keys.c
+++ b/src/core/ddsc/tests/serdata_keys.c
@@ -1,0 +1,1097 @@
+// Copyright(c) 2023 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+#include <assert.h>
+#include <limits.h>
+
+#include "dds/dds.h"
+#include "dds/ddsrt/environ.h"
+#include "dds/ddsrt/string.h"
+#include "dds/ddsrt/md5.h"
+#include "dds/ddsi/ddsi_serdata.h"
+#include "dds/ddsi/ddsi_protocol.h"
+#include "dds__serdata_default.h"
+#include "test_common.h"
+#include "mem_ser.h"
+#include "SerdataData.h"
+
+#define DDS_CONFIG "${CYCLONEDDS_URI}${CYCLONEDDS_URI:+,}<Discovery><ExternalDomainId>0</ExternalDomainId></Discovery>"
+
+
+static dds_entity_t create_pp (dds_domainid_t domain_id)
+{
+  char *conf = ddsrt_expand_envvars(DDS_CONFIG, domain_id);
+  dds_entity_t domain = dds_create_domain (domain_id, conf);
+  CU_ASSERT_FATAL (domain >= 0);
+  dds_entity_t participant = dds_create_participant (domain_id, NULL, NULL);
+  CU_ASSERT_FATAL (participant >= 0);
+  ddsrt_free (conf);
+  return participant;
+}
+
+static void do_test_key_write_xcdrv (const dds_topic_descriptor_t *desc, size_t sample_sz, dds_data_representation_id_t data_repr)
+{
+  dds_entity_t participant1 = create_pp (0);
+  dds_entity_t participant2 = create_pp (1);
+
+  dds_qos_t *qos = dds_create_qos ();
+  dds_qset_data_representation (qos, 1, (dds_data_representation_id_t[]) { data_repr });
+  dds_qset_history (qos, DDS_HISTORY_KEEP_ALL, 0);
+  dds_qset_reliability (qos, DDS_RELIABILITY_RELIABLE, DDS_SECS (10));
+
+  char topic_name[100];
+  create_unique_topic_name ("ddsc_serdata", topic_name, sizeof (topic_name));
+  dds_entity_t topic1 = dds_create_topic (participant1, desc, topic_name, qos, NULL);
+  dds_entity_t topic2 = dds_create_topic (participant2, desc, topic_name, qos, NULL);
+  dds_delete_qos (qos);
+
+  dds_entity_t rd = dds_create_reader (participant1, topic1, NULL, NULL);
+  dds_entity_t wr1 = dds_create_writer (participant1, topic1, NULL, NULL);
+  dds_entity_t wr2 = dds_create_writer (participant2, topic2, NULL, NULL);
+  sync_reader_writer (participant1, rd, participant1, wr1);
+  sync_reader_writer (participant1, rd, participant2, wr2);
+
+  unsigned char * sample = dds_alloc (sample_sz);
+  memset (sample, 1, sample_sz);
+  dds_sample_info_t sample_info[2];
+  dds_return_t ret;
+
+  ret = dds_set_status_mask (rd, DDS_DATA_AVAILABLE_STATUS);
+  CU_ASSERT_FATAL (ret == 0);
+  dds_entity_t ws = dds_create_waitset (participant1);
+  CU_ASSERT_FATAL (ws >= 0);
+  ret = dds_waitset_attach (ws, rd, 0);
+  CU_ASSERT_FATAL (ret == 0);
+
+  // Write data (checks key-from-sample and key-from-data)
+  dds_write (wr1, sample);
+  dds_write (wr2, sample);
+
+  void *samples[2];
+  samples[0] = NULL;
+
+  ret = dds_waitset_wait (ws, NULL, 0, DDS_INFINITY);
+  CU_ASSERT_FATAL (ret >= 0);
+
+  uint32_t n_data = 0;
+  dds_instance_handle_t ih = 0;
+  while (n_data < 2)
+  {
+    dds_return_t n = dds_take (rd, samples, sample_info, 2, 2);
+    CU_ASSERT_FATAL (n >= 0);
+    n_data += (uint32_t) n;
+    for (int32_t m = 0; m < n; m++)
+    {
+      CU_ASSERT_FATAL (sample_info[m].valid_data);
+      if (ih == 0)
+        ih = sample_info[m].instance_handle;
+      else
+        CU_ASSERT_EQUAL_FATAL (ih, sample_info[m].instance_handle);
+    }
+    dds_return_loan (rd, samples, n);
+    dds_sleepfor (DDS_MSECS (10));
+  }
+
+  // Dispose (checks key-from-sample and key-from-key)
+  dds_dispose (wr1, sample);
+  ret = dds_waitset_wait (ws, NULL, 0, DDS_INFINITY);
+  CU_ASSERT_FATAL (ret >= 0);
+
+  // take the dispose and store its instance handle
+  samples[0] = NULL;
+  ret = dds_take (rd, samples, sample_info, 1, 1);
+  CU_ASSERT_EQUAL_FATAL (ret, 1);
+  ih = sample_info[0].instance_handle;
+  CU_ASSERT_FATAL (!sample_info[0].valid_data);
+  dds_return_loan (rd, samples, ret);
+
+  // write a sample to make the instance alive again
+  dds_write (wr2, sample);
+  ret = dds_waitset_wait (ws, NULL, 0, DDS_INFINITY);
+  CU_ASSERT_FATAL (ret >= 0);
+  samples[0] = NULL;
+  ret = dds_take (rd, samples, sample_info, 1, 1);
+  CU_ASSERT_EQUAL_FATAL (ret, 1);
+  dds_return_loan (rd, samples, ret);
+
+  // dispose from wr2 and take the dispose
+  dds_dispose (wr2, sample);
+  ret = dds_waitset_wait (ws, NULL, 0, DDS_INFINITY);
+  CU_ASSERT_FATAL (ret >= 0);
+  samples[0] = NULL;
+  ret = dds_take (rd, samples, sample_info, 1, 1);
+  CU_ASSERT_EQUAL_FATAL (ret, 1);
+  CU_ASSERT_FATAL (!sample_info[0].valid_data);
+  CU_ASSERT_EQUAL_FATAL (ih, sample_info[0].instance_handle);
+  dds_return_loan (rd, samples, ret);
+
+  // Cleanup
+  dds_delete (DDS_CYCLONEDDS_HANDLE);
+  dds_free (sample);
+}
+
+#define D(t, x) { &t ## _desc, sizeof (t), x }
+CU_Test(ddsc_serdata, key_write_xcdrv)
+{
+  static dds_data_representation_id_t data_repr[2] = { DDS_DATA_REPRESENTATION_XCDR1, DDS_DATA_REPRESENTATION_XCDR2 };
+
+  static const struct {
+    const dds_topic_descriptor_t *desc;
+    size_t sample_sz;
+    bool use_xcdrv1;
+  } tests[] = {
+    D(SerdataKeyOrder, true),
+    D(SerdataKeyOrderId, true),
+    D(SerdataKeyOrderHashId, true),
+    D(SerdataKeyOrderAppendable, false),
+    D(SerdataKeyOrderMutable, false)
+  };
+
+  for (uint32_t i = 0; i < sizeof (tests) / sizeof (tests[0]); i++)
+    for (uint32_t dr = 0; dr < sizeof (data_repr) / sizeof (data_repr[0]); dr++)
+      if (tests[i].use_xcdrv1 || data_repr[dr] != DDS_DATA_REPRESENTATION_XCDR1)
+        do_test_key_write_xcdrv (tests[i].desc, tests[i].sample_sz, data_repr[dr]);
+}
+#undef D
+
+#define T_INIT_SIMPLE(t) static void *init_ ## t (void) { \
+  t *sample = ddsrt_malloc (sizeof (*sample)); \
+  sample->a = 1; \
+  sample->b = 2; \
+  sample->c = 3; \
+  return sample; \
+}
+
+T_INIT_SIMPLE(SerdataKeyOrder)
+T_INIT_SIMPLE(SerdataKeyOrderId)
+T_INIT_SIMPLE(SerdataKeyOrderHashId)
+T_INIT_SIMPLE(SerdataKeyOrderAppendable)
+T_INIT_SIMPLE(SerdataKeyOrderMutable)
+
+#define T_INIT_NESTED(t) static void *init_ ## t (void) { \
+  t *sample = ddsrt_malloc (sizeof (*sample)); \
+  sample->x = 10; \
+  sample->y = 20; \
+  sample->z.a = 1; \
+  sample->z.b = 2; \
+  sample->z.c = 3; \
+  return sample; \
+}
+
+T_INIT_NESTED(SerdataKeyOrderFinalNestedMutable)
+T_INIT_NESTED(SerdataKeyOrderAppendableNestedMutable)
+T_INIT_NESTED(SerdataKeyOrderMutableNestedMutable)
+T_INIT_NESTED(SerdataKeyOrderMutableNestedAppendable)
+T_INIT_NESTED(SerdataKeyOrderMutableNestedFinal)
+
+static void *init_SerdataKeyString (void)
+{
+  SerdataKeyString *sample = ddsrt_malloc (sizeof (*sample));
+  sample->a = 1;
+  sample->b = ddsrt_strdup ("test");
+  return sample;
+}
+
+static void *init_SerdataKeyStringBounded (void)
+{
+  SerdataKeyStringBounded *sample = ddsrt_malloc (sizeof (*sample));
+  sample->a = 1;
+  ddsrt_strlcpy (sample->b, "ts", 4);
+  return sample;
+}
+
+static void *init_SerdataKeyStringAppendable (void)
+{
+  SerdataKeyStringAppendable *sample = ddsrt_malloc (sizeof (*sample));
+  sample->a = 1;
+  sample->b = ddsrt_strdup ("test");
+  return sample;
+}
+
+static void *init_SerdataKeyStringBoundedAppendable (void)
+{
+  SerdataKeyStringBoundedAppendable *sample = ddsrt_malloc (sizeof (*sample));
+  sample->a = 1;
+  ddsrt_strlcpy (sample->b, "tst", 4);
+  return sample;
+}
+
+static void *init_SerdataKeyArr (void)
+{
+  SerdataKeyArr *sample = ddsrt_malloc (sizeof (*sample));
+  for (uint32_t n = 0; n < 12; n++)
+    sample->a[n] = (uint8_t) n;
+  return sample;
+}
+
+// FIXME: currently not supported
+// static void *init_SerdataKeyArrStrBounded (void)
+// {
+//   SerdataKeyArrStrBounded *sample = ddsrt_malloc (sizeof (*sample));
+//   for (uint32_t n = 0; n < 2; n++)
+//     ddsrt_strcpy (sample->a[n], "ts");
+//   return sample;
+// }
+
+static void *init_SerdataKeyNestedFinalImplicit (void)
+{
+  SerdataKeyNestedFinalImplicit *sample = ddsrt_malloc (sizeof (*sample));
+  sample->d = (SerdataKeyNestedFinalImplicitSubtype) { .x = 1, .y = 2, .z = { .a = 3, .b = 4, .c = 5 } };
+  sample->e = (SerdataKeyNestedFinalImplicitSubtype) { .x = 11, .y = 12, .z = { .a = 13, .b = 14, .c = 15 } };
+  sample->f = 20;
+  return sample;
+}
+
+static void *init_SerdataKeyNestedFinalImplicit2 (void)
+{
+  SerdataKeyNestedFinalImplicit2 *sample = ddsrt_malloc (sizeof (*sample));
+  sample->a = (SerdataKeyNestedFinalImplicit2Subtype1) { .c = { .e = { .x = 1, .y = 2 }, .f = { .x = 3, .y = 4 } }, .d = { .e = { .x = 5, .y = 6 }, .f = { .x = 7, .y = 8 } } };
+  sample->b = (SerdataKeyNestedFinalImplicit2Subtype1) { .c = { .e = { .x = 11, .y = 12 }, .f = { .x = 13, .y = 14 } }, .d = { .e = { .x = 15, .y = 16 }, .f = { .x = 17, .y = 18 } } };
+  return sample;
+}
+
+static void *init_SerdataKeyNestedMutableImplicit (void)
+{
+  SerdataKeyNestedMutableImplicit *sample = ddsrt_malloc (sizeof (*sample));
+  sample->d = (SerdataKeyNestedMutableImplicitSubtype) { .x = 1, .y = 2, .z = { .a = 3, .b = 4, .c = 5 } };
+  sample->e = (SerdataKeyNestedMutableImplicitSubtype) { .x = 11, .y = 12, .z = { .a = 13, .b = 14, .c = 15 } };
+  sample->f = 20;
+  return sample;
+}
+
+static void *init_SerdataKeyInheritMutable (void)
+{
+  SerdataKeyInheritMutable *sample = ddsrt_malloc (sizeof (*sample));
+  sample->a = (SerdataKeyInheritMutableNested) { .nx = 1, .ny = 2, .nz = 3 };
+  sample->b = 4;
+  sample->c = 5;
+  sample->parent.bx = (SerdataKeyInheritMutableNested) { .nx = 6, .ny = 7, .nz = 8 };
+  sample->parent.by = 9;
+  sample->parent.bz = 10;
+  return sample;
+}
+
+
+typedef void * (*init_fn) (void);
+typedef unsigned char raw[];
+
+static const unsigned char *serdata_default_keybuf (const struct dds_serdata_default *d)
+{
+  assert(d->key.buftype != KEYBUFTYPE_UNSET);
+  return (d->key.buftype == KEYBUFTYPE_STATIC) ? d->key.u.stbuf : d->key.u.dynbuf;
+}
+
+static size_t alignN(const size_t off, const size_t align)
+{
+  return (off + align - 1) & ~(align - 1);
+}
+
+static void print_check_cdr (const struct dds_serdata_default *sd, const unsigned char *exp_cdr, size_t exp_cdr_sz)
+{
+  printf("CDR (expected/actual):\n");
+  for (uint32_t i = 0; i < exp_cdr_sz; i++)
+    printf ("%02x%s", (uint8_t) exp_cdr[i], ((i % 4) == 3) ? " " : "");
+  printf("\n");
+
+  if (sd->pos == exp_cdr_sz && memcmp (sd->data, exp_cdr, exp_cdr_sz) == 0)
+    printf("== match ==\n");
+  else
+  {
+    for (uint32_t i = 0; i < sd->pos; i++)
+      printf ("%02x%s", (uint8_t) sd->data[i], ((i % 4) == 3) ? " " : "");
+    printf("\n");
+  }
+}
+
+static void check_key_keyhash (struct dds_serdata_default *sd,
+  const unsigned char *expected_key_xcdrv2, size_t expected_key_sz_xcdrv2,
+  const unsigned char *expected_key_keyhash, size_t expected_key_sz_keyhash)
+{
+  // key in sd must be translated into XCDRv2 key, so also check when testing data representation XCDR1
+  CU_ASSERT_EQUAL (sd->key.keysize, expected_key_sz_xcdrv2);
+  int cmp_key = memcmp (serdata_default_keybuf (sd), expected_key_xcdrv2, expected_key_sz_xcdrv2);
+  if (cmp_key != 0)
+    printf("** key match failed **\n");
+  CU_ASSERT_EQUAL (cmp_key, 0);
+
+  // get and check keyhash
+  struct ddsi_keyhash kh, exp_kh;
+  ddsi_serdata_get_keyhash (&sd->c, &kh, true);
+
+  ddsrt_md5_state_t md5st;
+  ddsrt_md5_init (&md5st);
+  ddsrt_md5_append (&md5st, (ddsrt_md5_byte_t *) expected_key_keyhash, (uint32_t) expected_key_sz_keyhash);
+  ddsrt_md5_finish (&md5st, (ddsrt_md5_byte_t *) exp_kh.value);
+
+  int cmp = memcmp (kh.value, exp_kh.value, 16);
+  if (cmp != 0)
+    printf("** keyhash match failed **\n");
+  CU_ASSERT_FATAL (cmp == 0);
+}
+
+// FIXME: the CDR used in this test assumes running on a little-endian machine
+CU_Test(ddsc_serdata, key_serialization)
+{
+  struct expected_key {
+    uint16_t top_level_enc;           // encoding for the top-level type of the (key) CDR
+    const unsigned char * data;       // CDR data
+    size_t data_sz;                   // CDR data length
+    const unsigned char * key;        // CDR for key-only sample
+    size_t key_sz;                    // length of key CDR
+    const unsigned char * keyhash;    // CDR used for keyhash calculation (big-endian, final)
+    size_t keyhash_sz;                // length of CDR for keyhash
+  };
+
+  const struct {
+    const dds_topic_descriptor_t *desc;
+    init_fn init;
+    struct expected_key xcdrv[2];
+  } tests[] = {
+    { &SerdataKeyOrder_desc, init_SerdataKeyOrder,
+      { {
+        DDSI_RTPS_CDR_LE,
+        (raw){
+          1,2,0,0,0,0,0,0,SER64(3)
+        }, 16,
+        (raw){
+          1,0,0,0,0,0,0,0,SER64(3)
+        }, 16,
+        (raw){
+          1,0,0,0,0,0,0,0,SER64BE(3)
+        }, 16
+      }, {
+        DDSI_RTPS_CDR2_LE,
+        (raw){
+          1,2,0,0,SER64(3)
+        }, 12,
+        (raw){
+          1,0,0,0,SER64(3)
+        }, 12,
+        (raw){
+          1,0,0,0,SER64BE(3)
+        }, 12
+      } }
+    },
+    { &SerdataKeyOrderId_desc, init_SerdataKeyOrderId,
+      { {
+        DDSI_RTPS_CDR_LE,
+        (raw){
+          1,2,0,0,0,0,0,0,SER64(3)
+        }, 16,
+        (raw){
+          1,0,0,0,0,0,0,0,SER64(3)
+        }, 16,
+        (raw){
+          1,0,0,0,0,0,0,0,SER64BE(3)
+        }, 16
+      }, {
+        DDSI_RTPS_CDR2_LE,
+        (raw){
+          1,2,0,0,SER64(3)
+        }, 12,
+        (raw){
+          1,0,0,0,SER64(3)
+        }, 12,
+        (raw){
+          SER64BE(3),1,
+          0,0,0, // padding
+        }, 9
+      } }
+    },
+    { &SerdataKeyOrderHashId_desc, init_SerdataKeyOrderHashId,
+      { {
+        DDSI_RTPS_CDR_LE,
+        (raw){
+          1,2,0,0,0,0,0,0,SER64(3)
+        }, 16,
+        (raw){
+          1,0,0,0,0,0,0,0,SER64(3)
+        }, 16,
+        (raw){
+          1,0,0,0,0,0,0,0,SER64BE(3)
+        }, 16
+      }, {
+        DDSI_RTPS_CDR2_LE,
+        (raw){
+          1,2,0,0,SER64(3)
+        }, 12,
+        (raw){
+          1,0,0,0,SER64(3)
+        }, 12,
+        (raw){
+          SER64BE(3),1,
+          0,0,0, // padding
+        }, 9
+      } }
+    },
+    { &SerdataKeyOrderAppendable_desc, init_SerdataKeyOrderAppendable,
+      { {
+        0 // not supported
+      }, {
+        DDSI_RTPS_D_CDR2_LE,
+        (raw){
+          SER_DHEADER(12),1,2,0,0,
+          SER64(3)
+        }, 16,
+        (raw){
+          SER_DHEADER(12),1,0,0,0,
+          SER64(3)
+        }, 16,
+        (raw){
+          SER64BE(3),1,
+          0,0,0 // padding
+        }, 9
+      } }
+    },
+    { &SerdataKeyOrderMutable_desc, init_SerdataKeyOrderMutable,
+      { {
+        0 // not supported
+      }, {
+        DDSI_RTPS_PL_CDR2_LE,
+        (raw){
+          SER_DHEADER(28),
+          SER_EMHEADER(1,0,3),1,0,0,0,
+          SER_EMHEADER(0,0,2),2,0,0,0,
+          SER_EMHEADER(1,3,1),SER64(3)
+        }, 32,
+        (raw){
+          SER_DHEADER(20),
+          SER_EMHEADER(1,0,3),1,0,0,0,
+          SER_EMHEADER(1,3,1),SER64(3)
+        }, 24,
+        (raw){
+          SER64BE(3),1,
+          0,0,0 // padding
+        }, 9
+      } }
+    },
+    { &SerdataKeyOrderFinalNestedMutable_desc, init_SerdataKeyOrderFinalNestedMutable,
+      { {
+        0 // not supported
+      }, {
+        DDSI_RTPS_CDR2_LE,
+        (raw){
+          10,20,0,0,
+            SER_DHEADER(28),
+            SER_EMHEADER(1,0,3),1,0,0,0,
+            SER_EMHEADER(0,0,2),2,0,0,0,
+            SER_EMHEADER(1,3,1),SER64(3)
+        }, 36,
+        (raw){
+          10,0,0,0,
+            SER_DHEADER(20),
+            SER_EMHEADER(1,0,3),1,0,0,0,
+            SER_EMHEADER(1,3,1),SER64(3)
+        }, 28,
+        (raw){
+          SER64BE(3),1,
+          10,
+          0,0 // padding
+        }, 10
+      } }
+    },
+    { &SerdataKeyOrderAppendableNestedMutable_desc, init_SerdataKeyOrderAppendableNestedMutable,
+      { {
+        0 // not supported
+      }, {
+        DDSI_RTPS_D_CDR2_LE,
+        (raw){
+          SER_DHEADER(36),10,20,0,0,
+            SER_DHEADER(28),
+            SER_EMHEADER(1,0,3),1,0,0,0,
+            SER_EMHEADER(0,0,2),2,0,0,0,
+            SER_EMHEADER(1,3,1),SER64(3)
+        }, 40,
+        (raw){
+          SER_DHEADER(28),10,0,0,0,
+            SER_DHEADER(20),
+            SER_EMHEADER(1,0,3),1,0,0,0,
+            SER_EMHEADER(1,3,1),SER64(3)
+        }, 32,
+        (raw){
+          SER64BE(3),1,
+          10,
+          0,0 // padding
+        }, 10
+      } }
+    },
+    { &SerdataKeyOrderMutableNestedMutable_desc, init_SerdataKeyOrderMutableNestedMutable,
+      { {
+        0 // not supported
+      }, {
+        DDSI_RTPS_PL_CDR2_LE,
+        (raw){
+          SER_DHEADER(56),
+          SER_EMHEADER(1,0,3),10,0,0,0,
+          SER_EMHEADER(0,0,2),20,0,0,0,
+          SER_EMHEADER(1,4,1),SER_NEXTINT(32),
+            SER_DHEADER(28),
+            SER_EMHEADER(1,0,3),1,0,0,0,
+            SER_EMHEADER(0,0,2),2,0,0,0,
+            SER_EMHEADER(1,3,1),SER64(3)
+        }, 60,
+        (raw){
+          SER_DHEADER(40),
+          SER_EMHEADER(1,0,3),10,0,0,0,
+          SER_EMHEADER(1,4,1),SER_NEXTINT(24),
+            SER_DHEADER(20),
+            SER_EMHEADER(1,0,3),1,0,0,0,
+            SER_EMHEADER(1,3,1),SER64(3)
+        }, 44,
+        (raw){
+          SER64BE(3),1,
+          10,
+          0,0 // padding
+        }, 10
+      } }
+    },
+    { &SerdataKeyOrderMutableNestedAppendable_desc, init_SerdataKeyOrderMutableNestedAppendable,
+      { {
+        0 // not supported
+      }, {
+        DDSI_RTPS_PL_CDR2_LE,
+        (raw){
+          SER_DHEADER(40),
+          SER_EMHEADER(1,0,3),10,0,0,0,
+          SER_EMHEADER(0,0,2),20,0,0,0,
+          SER_EMHEADER(1,4,1),SER_NEXTINT(16),
+            SER_DHEADER(12),1,2,0,0,
+            SER64(3)
+        }, 44,
+        (raw){
+          SER_DHEADER(32),
+          SER_EMHEADER(1,0,3),10,0,0,0,
+          SER_EMHEADER(1,4,1),SER_NEXTINT(16),
+            SER_DHEADER(12),1,0,0,0,
+            SER64(3)
+        }, 36,
+        (raw){
+          SER64BE(3),1,
+          10,
+          0,0 // padding
+        }, 10
+      } }
+    },
+    { &SerdataKeyOrderMutableNestedFinal_desc, init_SerdataKeyOrderMutableNestedFinal,
+      { {
+        0 // not supported
+      }, {
+        DDSI_RTPS_PL_CDR2_LE,
+        (raw){
+          SER_DHEADER(36),
+          SER_EMHEADER(1,0,3),10,0,0,0,
+          SER_EMHEADER(0,0,2),20,0,0,0,
+          SER_EMHEADER(1,4,1),SER_NEXTINT(12),
+            1,2,0,0,
+            SER64(3)
+        }, 40,
+        (raw){
+          SER_DHEADER(28),
+          SER_EMHEADER(1,0,3),10,0,0,0,
+          SER_EMHEADER(1,4,1),SER_NEXTINT(12),
+            1,0,0,0,
+            SER64(3)
+        }, 32,
+        (raw){
+          1,0,0,0,SER64BE(3),
+          10,
+          0,0,0 // padding
+        }, 13
+      } }
+    },
+    { &SerdataKeyString_desc, init_SerdataKeyString,
+      { {
+        DDSI_RTPS_CDR_LE,
+        (raw){
+          1,0,0,0,
+          SER32(5),'t','e','s','t','\0',
+          0,0,0 // padding
+        }, 13,
+        (raw){
+          1,0,0,0,
+          SER32(5),'t','e','s','t','\0',
+          0,0,0 // padding
+        }, 13,
+        (raw){
+          1,0,0,0,
+          SER32BE(5),'t','e','s','t','\0',
+          0,0,0 // padding
+        }, 13
+      }, {
+        DDSI_RTPS_CDR2_LE,
+        (raw){
+          1,0,0,0,
+          SER32(5),'t','e','s','t','\0',
+          0,0,0 // padding
+        }, 13,
+        (raw){
+          1,0,0,0,
+          SER32(5),'t','e','s','t','\0',
+          0,0,0 // padding
+        }, 13,
+        (raw){
+          1,0,0,0,
+          SER32BE(5),'t','e','s','t','\0',
+          0,0,0 // padding
+        }, 13
+      } }
+    },
+    { &SerdataKeyStringBounded_desc, init_SerdataKeyStringBounded,
+      { {
+        DDSI_RTPS_CDR_LE,
+        (raw){
+          1,0,0,0,
+          SER32(3),'t','s','\0',
+          0 // padding
+        }, 11,
+        (raw){
+          1,0,0,0,
+          SER32(3),'t','s','\0',
+          0 // padding
+        }, 11,
+        (raw){
+          1,0,0,0,
+          SER32BE(3),'t','s','\0',
+          0 // padding
+        }, 11
+      }, {
+        DDSI_RTPS_CDR2_LE,
+        (raw){
+          1,0,0,0,
+          SER32(3),'t','s','\0',
+          0 // padding
+        }, 11,
+        (raw){
+          1,0,0,0,
+          SER32(3),'t','s','\0',
+          0 // padding
+        }, 11,
+        (raw){
+          1,0,0,0,
+          SER32BE(3),'t','s','\0',
+          0 // padding
+        }, 11
+      } }
+    },
+    { &SerdataKeyStringAppendable_desc, init_SerdataKeyStringAppendable,
+      { {
+        0 // not supported
+      }, {
+        DDSI_RTPS_D_CDR2_LE,
+        (raw){
+          SER_DHEADER(13),
+          1,0,0,0,
+          SER32(5),'t','e','s','t','\0',
+          0,0,0 // padding
+        }, 17,
+        (raw){
+          SER_DHEADER(13),
+          1,0,0,0,
+          SER32(5),'t','e','s','t','\0',
+          0,0,0 // padding
+        }, 17,
+        (raw){
+          1,0,0,0,SER32BE(5),'t','e','s','t','\0',
+          0,0,0 // padding
+        }, 13
+      } }
+    },
+    { &SerdataKeyStringBoundedAppendable_desc, init_SerdataKeyStringBoundedAppendable,
+      { {
+        0 // not supported
+      }, {
+        DDSI_RTPS_D_CDR2_LE,
+        (raw){
+          SER_DHEADER(12),
+          1,0,0,0,
+          SER32(4),'t','s','t','\0'
+        }, 16,
+        (raw){
+          SER_DHEADER(12),
+          1,0,0,0,
+          SER32(4),'t','s','t','\0'
+        }, 16,
+        (raw){
+          1,0,0,0,
+          SER32BE(4),'t','s','t','\0'
+        }, 12
+      } }
+    },
+    { &SerdataKeyArr_desc, init_SerdataKeyArr,
+      { {
+        DDSI_RTPS_CDR_LE,
+        (raw){
+          0,1,2,3,4,5,6,7,8,9,10,11
+        }, 12,
+        (raw){
+          0,1,2,3,4,5,6,7,8,9,10,11
+        }, 12,
+        (raw){
+          0,1,2,3,4,5,6,7,8,9,10,11
+        }, 12
+      }, {
+        DDSI_RTPS_CDR2_LE,
+        (raw){
+          0,1,2,3,4,5,6,7,8,9,10,11
+        }, 12,
+        (raw){
+          0,1,2,3,4,5,6,7,8,9,10,11
+        }, 12,
+        (raw){
+          0,1,2,3,4,5,6,7,8,9,10,11
+        }, 12
+      } }
+    },
+    // TODO: not supported
+    // { &SerdataKeyArrStrBounded_desc, init_SerdataKeyArrStrBounded,
+    //   { {
+    //     DDSI_RTPS_CDR_LE,
+    //     (raw){
+    //       SER32(3),'t','s','\0',
+    //       SER32(3),'t','s','\0'
+    //     }, 14,
+    //     (raw){
+    //       SER32(3),'t','s','\0',
+    //       SER32(3),'t','s','\0'
+    //     }, 14,
+    //     (raw){
+    //       SER32BE(3),'t','s','\0',
+    //       SER32BE(3),'t','s','\0'
+    //     }, 14
+    //   }, {
+    //     DDSI_RTPS_CDR2_LE,
+    //     (raw){
+    //       SER32(3),'t','s','\0',
+    //       SER32(3),'t','s','\0'
+    //     }, 14,
+    //     (raw){
+    //       SER32(3),'t','s','\0',
+    //       SER32(3),'t','s','\0'
+    //     }, 14,
+    //     (raw){
+    //       SER32BE(3),'t','s','\0',
+    //       SER32BE(3),'t','s','\0'
+    //     }, 14
+    //   } }
+    // }
+    { &SerdataKeyNestedFinalImplicit_desc, init_SerdataKeyNestedFinalImplicit,
+      { {
+        DDSI_RTPS_CDR_LE,
+        (raw){
+          // d
+          1,2,
+            3,4,0,0,0,0,SER64(5),
+          // e
+          11,12,
+            13,14,0,0,0,0,SER64(15),
+          // f
+          SER32(20)
+        }, 36,
+        (raw){
+          // d
+          1,2,
+            3,0,0,0,0,0,SER64(5),
+          // f
+          SER32(20)
+        }, 20,
+        (raw){
+          // d
+          1,2,
+            3,0,0,0,0,0,SER64BE(5),
+          // f
+          SER32BE(20)
+        }, 20
+      }, {
+        DDSI_RTPS_CDR2_LE,
+        (raw){
+          // d
+          1,2,
+            3,4,SER64(5),
+          // e
+          11,12,
+            13,14,SER64(15),
+          // f
+          SER32(20)
+        }, 28,
+        (raw){
+          // d
+          1,2,
+            3,0,SER64(5),
+          // f
+          SER32(20)
+        }, 16,
+        (raw){
+          SER32BE(20),  // f
+          3,0,0,0,      // d.z.a
+          SER64BE(5),   // d.z.c
+          2,            // d.y
+          1,            // d.x
+          0,0           // padding
+        }, 18
+      } }
+    },
+    { &SerdataKeyNestedFinalImplicit2_desc, init_SerdataKeyNestedFinalImplicit2,
+      { {
+        DDSI_RTPS_CDR_LE,
+        (raw){
+          // a
+          1,2,3,4,
+          5,6,7,8,
+          // b
+          11,12,13,14,
+          15,16,17,18
+        }, 16,
+        (raw){
+          // a
+          1,2,
+          5,6
+        }, 4,
+        (raw){
+          // a
+          1,2,
+          5,6
+        }, 4
+      }, {
+        DDSI_RTPS_CDR2_LE,
+        (raw){
+          // a
+          1,2,3,4,
+          5,6,7,8,
+          // b
+          11,12,13,14,
+          15,16,17,18
+        }, 16,
+        (raw){
+          // a
+          1,2,
+          5,6
+        }, 4,
+        (raw){
+          // a
+          1,2,
+          5,6
+        }, 4
+      } }
+    },
+    { &SerdataKeyNestedMutableImplicit_desc, init_SerdataKeyNestedMutableImplicit,
+      { {
+        0 // not supported
+      }, {
+        DDSI_RTPS_D_CDR2_LE,
+        (raw){
+          SER_DHEADER(84),
+          // d
+          SER_DHEADER(36),
+          SER_EMHEADER(1,0,3),1,0,0,0,
+          SER_EMHEADER(1,0,2),2,0,0,0,
+          SER_EMHEADER(1,4,1),SER_NEXTINT(12),
+            3,4,0,0,
+            SER64(5),
+          // e
+          SER_DHEADER(36),
+          /* FIXME: for these 3 members the must-understand bit is set because the
+              type is also used as key. Is this correct, or shouldn't the bit be set
+              in when used as non-key? */
+          SER_EMHEADER(1,0,3),11,0,0,0,
+          SER_EMHEADER(1,0,2),12,0,0,0,
+          SER_EMHEADER(1,4,1),SER_NEXTINT(12),
+            13,14,0,0,
+            SER64(15),
+          // f
+          SER32(20)
+        }, 88,
+        (raw){
+          SER_DHEADER(44),
+          // d
+          SER_DHEADER(36),
+          SER_EMHEADER(1,0,3),1,0,0,0,
+          SER_EMHEADER(1,0,2),2,0,0,0,
+          SER_EMHEADER(1,4,1),SER_NEXTINT(12),
+            3,0,0,0,
+            SER64(5),
+          SER32(20)
+        }, 48,
+        (raw){
+          SER32BE(20),  // f
+          3,0,0,0,      // d.z.a
+          SER64BE(5),   // d.z.c
+          2,            // d.y
+          1,            // d.x
+          0,0           // padding
+        }, 18
+      } }
+    },
+    { &SerdataKeyInheritMutable_desc, init_SerdataKeyInheritMutable,
+      { {
+        0 // not supported
+      }, {
+        DDSI_RTPS_PL_CDR2_LE,
+        (raw){
+          SER_DHEADER(70),
+          // bx, by, bz
+          SER_EMHEADER(1,4,6),
+          SER_NEXTINT(10),
+            // nx, ny, nz
+            SER_DHEADER(6),
+            SER16(6),SER16(7),
+            SER16(8),
+          0,0, // padding
+          SER_EMHEADER(0,1,5),SER16(9),
+          0,0, // padding
+          SER_EMHEADER(1,1,4),SER16(10),
+          0,0, // padding
+          // a, b, c
+          SER_EMHEADER(0,4,3),
+          SER_NEXTINT(10),
+            // nx, ny, nz
+            SER_DHEADER(6),
+            SER16(1),SER16(2),
+            SER16(3),
+          0,0, // padding
+          SER_EMHEADER(0,1,2),SER16(4),
+          0,0, // padding
+          SER_EMHEADER(0,1,1),SER16(5),
+          0,0 // padding
+        }, 74,
+        (raw){
+          SER_DHEADER(22),
+          // bx, bz
+          SER_EMHEADER(1,4,6),
+          SER_NEXTINT(8),
+            // nx, nz
+            SER_DHEADER(4),
+            SER16(6),SER16(8),
+          SER_EMHEADER(1,1,4),SER16(10),
+          0,0 // padding
+        }, 26,
+        (raw){
+          SER16BE(10),
+          SER16BE(8),
+          SER16BE(6),
+          0,0 // padding
+        }, 6
+      } }
+    }
+  };
+
+  static dds_data_representation_id_t data_repr[2] = { DDS_DATA_REPRESENTATION_XCDR1, DDS_DATA_REPRESENTATION_XCDR2 };
+
+  for (uint32_t test_index = 0; test_index < sizeof (tests) / sizeof (tests[0]); test_index++)
+  {
+    dds_entity_t participant = create_pp (0);
+
+    for (uint32_t dr = 0; dr < sizeof (data_repr) / sizeof (data_repr[0]); dr++)
+    {
+      printf ("\ntest type %s (XCDRv%u)\n", tests[test_index].desc->m_typename, dr + 1);
+      if (dds_stream_minimum_xcdr_version (tests[test_index].desc->m_ops) == DDSI_RTPS_CDR_ENC_VERSION_2
+          && data_repr[dr] != DDS_DATA_REPRESENTATION_XCDR2)
+      {
+        printf ("xcdrv not supported\n");
+        continue;
+      }
+
+      dds_qos_t *qos = dds_create_qos ();
+      dds_qset_data_representation (qos, 1, (dds_data_representation_id_t[]) { data_repr[dr] });
+
+      char topic_name[100];
+      create_unique_topic_name ("ddsc_serdata", topic_name, sizeof (topic_name));
+      dds_entity_t tp = dds_create_topic (participant, tests[test_index].desc, topic_name, qos, NULL);
+      dds_delete_qos (qos);
+
+      const struct ddsi_sertype *sertype;
+      dds_return_t ret = dds_get_entity_sertype (tp, &sertype);
+      CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
+
+      void *sample = tests[test_index].init ();
+
+      // Create SDK_DATA serdata from sample
+      {
+        struct dds_serdata_default *sd = (struct dds_serdata_default *) ddsi_serdata_from_sample (sertype, SDK_DATA, sample);
+        CU_ASSERT_FATAL (sd != NULL);
+        assert (sd != NULL);
+
+        if (data_repr[dr] == DDS_DATA_REPRESENTATION_XCDR2)
+        {
+          size_t exp_sz_aligned = alignN (tests[test_index].xcdrv[dr].data_sz, 4);
+          printf ("Data: ");
+          print_check_cdr (sd, tests[test_index].xcdrv[dr].data, exp_sz_aligned);
+          CU_ASSERT_EQUAL (exp_sz_aligned, sd->pos);
+          int cmp = memcmp (sd->data, tests[test_index].xcdrv[dr].data, exp_sz_aligned);
+          CU_ASSERT_EQUAL (cmp, 0);
+        }
+
+        check_key_keyhash (sd, tests[test_index].xcdrv[1].key, tests[test_index].xcdrv[1].key_sz,
+            tests[test_index].xcdrv[dr].keyhash, tests[test_index].xcdrv[dr].keyhash_sz);
+        ddsi_serdata_unref (&sd->c);
+      }
+
+      // Create SDK_KEY serdata from sample
+      {
+        struct dds_serdata_default *sd = (struct dds_serdata_default *) ddsi_serdata_from_sample (sertype, SDK_KEY, sample);
+        CU_ASSERT_FATAL (sd != NULL);
+        assert (sd != NULL);
+
+        size_t exp_sz = tests[test_index].xcdrv[dr].key_sz;
+        const unsigned char *exp_data = tests[test_index].xcdrv[dr].key;
+        size_t exp_sz_aligned = alignN (exp_sz, 4);
+        printf ("Key: ");
+        print_check_cdr (sd, exp_data, exp_sz_aligned);
+        CU_ASSERT_EQUAL (exp_sz_aligned, sd->pos);
+        int cmp = memcmp (sd->data, exp_data, exp_sz_aligned);
+        CU_ASSERT_EQUAL (cmp, 0);
+
+        check_key_keyhash (sd, tests[test_index].xcdrv[1].key, tests[test_index].xcdrv[1].key_sz,
+            tests[test_index].xcdrv[dr].keyhash, tests[test_index].xcdrv[dr].keyhash_sz);
+        ddsi_serdata_unref (&sd->c);
+      }
+
+      // Create serdata from key CDR
+      struct dds_cdr_header hdr = { tests[test_index].xcdrv[dr].top_level_enc, 0 };
+      {
+        ddsrt_iovec_t key_cdr;
+        key_cdr.iov_len = (ddsrt_iov_len_t) tests[test_index].xcdrv[dr].key_sz + sizeof (hdr);
+        key_cdr.iov_base = ddsrt_malloc (key_cdr.iov_len);
+        memcpy (key_cdr.iov_base, &hdr, sizeof (hdr));
+        memcpy ((unsigned char *) key_cdr.iov_base + sizeof (hdr), tests[test_index].xcdrv[dr].key, tests[test_index].xcdrv[dr].key_sz);
+        struct dds_serdata_default *sd = (struct dds_serdata_default *) ddsi_serdata_from_ser_iov (sertype, SDK_KEY, 1, &key_cdr, key_cdr.iov_len);
+        CU_ASSERT_FATAL (sd != NULL);
+        assert (sd != NULL);
+        ddsrt_free (key_cdr.iov_base);
+
+        check_key_keyhash (sd, tests[test_index].xcdrv[1].key, tests[test_index].xcdrv[1].key_sz,
+            tests[test_index].xcdrv[dr].keyhash, tests[test_index].xcdrv[dr].keyhash_sz);
+
+        ddsi_serdata_unref (&sd->c);
+      }
+
+      // Create serdata from sample CDR
+      {
+        ddsrt_iovec_t data_cdr;
+        data_cdr.iov_len = (ddsrt_iov_len_t) tests[test_index].xcdrv[dr].data_sz + sizeof (hdr);
+        data_cdr.iov_base = ddsrt_malloc (data_cdr.iov_len);
+        memcpy (data_cdr.iov_base, &hdr, sizeof (hdr));
+        memcpy ((unsigned char *) data_cdr.iov_base + sizeof (hdr), tests[test_index].xcdrv[dr].data, tests[test_index].xcdrv[dr].data_sz);
+        struct dds_serdata_default *sd = (struct dds_serdata_default *) ddsi_serdata_from_ser_iov (sertype, SDK_DATA, 1, &data_cdr, data_cdr.iov_len);
+        CU_ASSERT_FATAL (sd != NULL);
+        assert (sd != NULL);
+        ddsrt_free (data_cdr.iov_base);
+
+        check_key_keyhash (sd, tests[test_index].xcdrv[1].key, tests[test_index].xcdrv[1].key_sz,
+            tests[test_index].xcdrv[dr].keyhash, tests[test_index].xcdrv[dr].keyhash_sz);
+
+        ddsi_serdata_unref (&sd->c);
+      }
+
+      dds_sample_free (sample, tests[test_index].desc, DDS_FREE_ALL);
+
+    } // iterate data representations
+    dds_delete (DDS_CYCLONEDDS_HANDLE);
+  } // iterate tests
+}

--- a/src/core/ddsi/src/ddsi_sertype_cdr.c
+++ b/src/core/ddsi/src/ddsi_sertype_cdr.c
@@ -160,13 +160,8 @@ dds_return_t ddsi_sertype_cdr_init (const struct ddsi_domaingv *gv, struct ddsi_
   st->c.fixed_size = (st->c.fixed_size || (desc->m_flagset & DDS_TOPIC_FIXED_SIZE)) ? 1u : 0u;
   st->c.allowed_data_representation = DDS_DATA_REPRESENTATION_FLAG_XCDR2;
   st->encoding_format = ddsi_sertype_extensibility_enc_format (type_ext);
-  /* Store the encoding version used for writing data using this sertype. When reading data,
-     the encoding version from the encapsulation header in the CDR is used */
-  st->type.size = desc->m_size;
-  st->type.align = desc->m_align;
-  st->type.flagset = desc->m_flagset;
-  st->type.ops.nops = dds_stream_countops (desc->m_ops, 0, NULL);
-  st->type.ops.ops = ddsrt_memdup (desc->m_ops, st->type.ops.nops * sizeof (*st->type.ops.ops));
+
+  dds_cdrstream_desc_init (&st->type, &dds_cdrstream_default_allocator, desc->m_size, desc->m_align, desc->m_flagset, desc->m_ops, desc->m_keys, desc->m_nkeys);
 
   if (dds_stream_type_nesting_depth (desc->m_ops) > DDS_CDRSTREAM_MAX_NESTING_DEPTH)
   {

--- a/src/core/ddsi/tests/CMakeLists.txt
+++ b/src/core/ddsi/tests/CMakeLists.txt
@@ -18,8 +18,7 @@ set(ddsi_test_sources
     "plist.c"
     "plist_leasedur.c"
     "radmin.c"
-    "sysdeps.c"
-    "mem_ser.h")
+    "sysdeps.c")
 
 if(ENABLE_SECURITY)
   set(ddsi_test_sources ${ddsi_test_sources} "security_msg.c")
@@ -33,7 +32,8 @@ target_include_directories(
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../ddsc/src>"
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../ddsi/include>"
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../ddsi/src>"
-    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../cdr/include>")
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../cdr/include>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../cdr/test>")
 if(ENABLE_SHM)
   target_include_directories(
     cunit_ddsi PRIVATE

--- a/src/core/xtests/symbol_export/symbol_export.c
+++ b/src/core/xtests/symbol_export/symbol_export.c
@@ -481,9 +481,9 @@ int main (int argc, char **argv)
   dds_stream_print_sample (ptr, ptr2, ptr3, 0);
 
   dds_stream_extract_key_from_data (ptr, ptr2, ptr3, ptr4);
-  dds_stream_extract_key_from_key (ptr, ptr2, ptr3, ptr4);
+  dds_stream_extract_key_from_key (ptr, ptr2, 0, ptr3, ptr4);
   dds_stream_extract_keyBE_from_data (ptr, ptr2, ptr3, ptr4);
-  dds_stream_extract_keyBE_from_key (ptr, ptr2, ptr3, ptr4);
+  dds_stream_extract_keyBE_from_key (ptr, ptr2, 0, ptr3, ptr4);
   dds_cdrstream_desc_from_topic_desc (ptr, ptr2);
   dds_cdrstream_desc_fini (ptr, ptr2);
 

--- a/src/idl/src/tree.c
+++ b/src/idl/src/tree.c
@@ -3670,18 +3670,32 @@ idl_keytype_t idl_is_topic_key(const void *node, bool keylist, const idl_path_t 
         return IDL_KEYTYPE_NONE;
 
       if (member->key.value)
+      {
         key = IDL_KEYTYPE_EXPLICIT;
+        all_keys = false;
+      }
       /* possibly implicit @key, but only if no other members are explicitly
         annotated, an intermediate aggregate type has no explicitly annotated
         fields and node is not on the first level */
-      else if (all_keys || no_specific_key(idl_parent(member)))
+      else if (all_keys)
       {
-        all_keys = (i > 1);
-        key = (i > 1) ? IDL_KEYTYPE_IMPLICIT : IDL_KEYTYPE_NONE;
+        if (no_specific_key(idl_parent(member)))
+          key = IDL_KEYTYPE_IMPLICIT;
+        else
+        {
+          key = IDL_KEYTYPE_NONE;
+          all_keys = false;
+        }
+      }
+      else if (no_specific_key(idl_parent(member)) && i > 1)
+      {
+        key = IDL_KEYTYPE_IMPLICIT;
+        all_keys = true;
       }
       else
       {
         key = IDL_KEYTYPE_NONE;
+        all_keys = false;
       }
 
       /* if key member found, get the id from the declarator node which

--- a/src/tools/idlc/src/descriptor.h
+++ b/src/tools/idlc/src/descriptor.h
@@ -133,10 +133,10 @@ struct stack_type {
 
 struct key_meta_data {
   char *name;
-  uint32_t inst_offs;
-  uint32_t n_order;
-  uint32_t *order;
-  uint32_t key_idx;
+  uint32_t inst_offs;         /**< instruction offset in the instruction set */
+  uint32_t n_order;           /**< number or order entries (nesting level of key field) */
+  uint32_t *order;            /**< order of the key field in the containing aggregated type */
+  uint32_t key_idx;           /**< index of this key when sorting key fields in definition order */
   uint32_t dims;
   uint32_t size;
   bool dheader;
@@ -151,8 +151,6 @@ struct descriptor {
   uint32_t n_opcodes; /**< number of opcodes in descriptor */
   uint32_t flags; /**< topic descriptor flag values */
   uint32_t data_representations; /**< restrict data representations for top-level type */
-  uint32_t keysz_xcdr1; /**< size of the XCDR1 serialized key (or set to MAX_FIXED_KEY + 1 if more than MAX_FIXED_KEY) */
-  uint32_t keysz_xcdr2; /**< size of the XCDR2 serialized key (or set to MAX_FIXED_KEY + 1 if more than MAX_FIXED_KEY) */
   struct stack_type *type_stack;
   struct constructed_type *constructed_types;
   struct instructions key_offsets;

--- a/src/tools/idlc/tests/descriptor.c
+++ b/src/tools/idlc/tests/descriptor.c
@@ -30,7 +30,7 @@ CU_Test(idlc_descriptor, keys_nested)
     uint32_t n_keys;
     uint32_t n_key_offs; // number of key offset: the sum of (1 + number of nesting levels) for all keys
     bool keylist; // indicates if pragma keylist is used
-    uint32_t key_order[TEST_MAX_KEYS][TEST_MAX_KEY_OFFS]; // key order (used only when pragma keylist is used)
+    uint32_t key_order[TEST_MAX_KEYS][TEST_MAX_KEY_OFFS]; // key order scoped to containing type
     const char *key_name[TEST_MAX_KEYS];
     uint32_t key_index[TEST_MAX_KEYS]; // key index as printed in the dds key descriptor, indicates the index (order 0..n) of the key in the CDR
   } tests[] = {
@@ -180,88 +180,6 @@ CU_Test(idlc_descriptor, default_extensibility)
 
 #undef S
 #undef U
-
-#define VAR (DDS_FIXED_KEY_MAX_SIZE + 1)
-CU_Test(idlc_descriptor, key_size)
-{
-  static const struct {
-    const char *idl;
-    bool fixed_key_xcdr1;
-    bool fixed_key_xcdr2;
-    uint32_t keysz_xcdr1;
-    uint32_t keysz_xcdr2;
-  } tests[] = {
-    { "@topic struct test { @key long a; @key short b; }; ",
-      true, true, 6, 6 },   // key size: 4 + 2
-    { "@topic struct test { @key char a; @key long long b; @key short c; }; ",
-      false, true, VAR, 14 },  // key size: 1 + 7/3 (pad) + 8 + 2
-    { "@nested struct nested1 { @key char a; @key long long b; @key short c; }; @topic struct test { @key nested1 a; }; ",
-      false, true, VAR, 14 },  // key size: 1 + 7/3 (pad) + 8 + 2
-    { "@nested struct nested1 { char a; short b; }; @topic struct test { @key nested1 a; @key long long b; @key char c; }; ",
-      false, true, VAR, 13 },  // key size: 1 + 1 (pad) + 2 + 4/0 (pad) + 8 + 1
-    { "@topic struct test { @key long a[5]; }; ",
-      false, false, VAR, VAR },
-    { "@nested struct nested1 { @key long long a; }; @topic struct test { @key nested1 a; long b[5]; @key char c; @key float d; }; ",
-      true, true, 16, 16 }, // key size: 8 + 1 + 3 (pad) + 4
-    { "@nested struct nested1 { @key short a; }; @nested struct nested2 { @key long long a; }; @topic struct test { @key nested1 a; @key nested2 b; @key char c; @key nested1 d; }; ",
-      false, true, VAR, 16 }, // key size: 2 + 6/2 (pad) + 8 + 1 + 1 (pad) 2
-    { "@topic struct test { @key char a[15]; }; ",
-      true, true, 15, 15 },
-    { "@topic struct test { @key short a[6]; }; ",
-      true, true, 12, 12 },
-    { "@nested struct nested1 { @key long long a; long b; }; @topic struct test { nested1 a; @key nested1 b; }; ",
-      true, true, 8, 8 }, // key size: 8
-    { "@topic struct test { @key string<3> a; @key long long b; }; ",
-      true, true, 16, 16 }, // key size: 8 + 8
-    { "@topic struct test { @key char a; @key string<3> b; @key long c; }; ",
-      true, true, 16, 16 }, // key size: 1 + 3 (pad) + 8 + 4
-    { "@topic struct test { @key @id(2) float a; @key @id(1) char b; @key @id(0) double c; }; ",
-      true, true, 16, 16 }, // key size XCDR1: 4 + 1 + 3 (pad) + 8 / XCDR2: 8 + 1 + 3 (pad) + 4
-    { "@topic struct test { @key @id(0) char b; @key @id(1) double a; @key @id(2) float c; }; ",
-      false, true, VAR, 16 }, // key size XCDR1: 1 + 7 (pad) + 8 + 4 / XCDR2: 1 + 3 (pad) + 8 + 4
-    { "@topic struct test { @key @id(0) char c1; @key @id(2) char c2; @key @id(4) char c3; @key @id(1) long l1; @key @id(3) long l2; }; ",
-      true, false, 12, VAR }, // key size XCDR1: 1 + 1 + 1 + 1 (pad) + 4 + 4 / XCDR2: 1 + 3 (pad) + 4 + 1 + 3 (pad) + 4 + 1
-    { "enum e { E0, E1 }; @topic struct test { @key e a; }; ",
-      true, true, 4, 4 }, // key size: 4
-    { "@bit_bound(8) enum e { E0, E1 }; @topic struct test { @key e a; }; ",
-      true, true, 1, 1 }, // key size: 1
-    { "@bit_bound(16) enum e { E0, E1 }; @topic struct test { @key char a; @key e b[4]; }; ",
-      true, true, 10, 16 }, // key size XCDR1: 1 + 1 (pad) + 4 * 2 / XCDR2: 1 + 3 (pad) + 4 (dheader) + 4 * 2
-    { "bitmask bm { BM0, BM1 }; @topic struct test { @key bm a; }; ",
-      true, true, 4, 4 }, // key size: 4
-    { "@bit_bound(8) bitmask bm { BM0, BM1 }; @topic struct test { @key bm a; }; ",
-      true, true, 1, 1 }, // key size: 1
-    { "@bit_bound(43) bitmask bm { BM0, BM1 }; @topic struct test { @key char a; @key bm b[1]; }; ",
-      true, true, 16, 16 }, // key size XCDR1: 1 + 7 (pad) + 1 * 8 / XCDR2: 1 + 3 (pad) + 4 (dheader) + 1 * 8 /
-  };
-
-  idl_retcode_t ret;
-  uint32_t flags = IDL_FLAG_EXTENDED_DATA_TYPES |
-                   IDL_FLAG_ANONYMOUS_TYPES |
-                   IDL_FLAG_ANNOTATIONS;
-  for (size_t i = 0; i < sizeof (tests) / sizeof (tests[0]); i++) {
-    static idl_pstate_t *pstate = NULL;
-    struct descriptor descriptor;
-
-    printf ("running test for idl: %s\n", tests[i].idl);
-
-    ret = idl_create_pstate (flags, NULL, &pstate);
-    CU_ASSERT_EQUAL_FATAL (ret, IDL_RETCODE_OK);
-
-    memset (&descriptor, 0, sizeof (descriptor)); /* static analyzer */
-    ret = generate_test_descriptor (pstate, tests[i].idl, &descriptor);
-    CU_ASSERT_EQUAL_FATAL (ret, IDL_RETCODE_OK);
-    CU_ASSERT_EQUAL_FATAL ((descriptor.flags & DDS_TOPIC_FIXED_KEY) != 0, tests[i].fixed_key_xcdr1);
-    CU_ASSERT_EQUAL_FATAL ((descriptor.flags & DDS_TOPIC_FIXED_KEY_XCDR2) != 0, tests[i].fixed_key_xcdr2);
-    CU_ASSERT_EQUAL_FATAL (descriptor.keysz_xcdr1, tests[i].keysz_xcdr1);
-    CU_ASSERT_EQUAL_FATAL (descriptor.keysz_xcdr2, tests[i].keysz_xcdr2);
-
-    descriptor_fini (&descriptor);
-
-    idl_delete_pstate (pstate);
-  }
-}
-#undef VAR
 
 CU_Test(idlc_descriptor, key_valid_types)
 {


### PR DESCRIPTION
Use definition order for key field order in serialized key-only sample, and use the extensibility of the original type for key serialization. This commit update the CDR stream serializer for this, and changes the IDL compiler and dynamic type builder to include the keys in definition order. The sort-order (3rd column) in the key list of the topic descriptor reflects the member-ID order of the key fields, which is used in serialization of the key for calculating the key hash.

The calculation of the key flags is moved to the CDR stream serializer and is done runtime, so that this can be used for both IDLC and type builder generated descriptors.

For the Python and C++ bindings a separate PR will be created to update the key field order; these PRs need to be merged with this one to ensure interoperability. 