### PR TITLE
Update conanfile.txt

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
 cunit/2.1-3
-openssl/1.1.1j
+openssl/1.1.1u
 
 [generators]
 cmake


### PR DESCRIPTION
Mitigate for very slow `OBJ_obj2txt()` performance with gigantic OBJECT IDENTIFIER sub-identities. (CVE-2023-2650) Fixed documentation of X509_VERIFY_PARAM_add0_policy() (CVE-2023-0466) Fixed handling of invalid certificate policies in leaf certificates (CVE-2023-0465) Limited the number of nodes created in a policy tree ([CVE-2023-0464]) Major changes between OpenSSL 1.1.1s and OpenSSL 1.1.1t [7 Feb 2023] Fixed X.400 address type confusion in X.509 GeneralName (CVE-2023-0286) Fixed Use-after-free following BIO_new_NDEF (CVE-2023-0215) Fixed Double free after calling PEM_read_bio_ex (CVE-2022-4450) Fixed Timing Oracle in RSA Decryption (CVE-2022-4304) Major changes between OpenSSL 1.1.1r and OpenSSL 1.1.1s [1 Nov 2022] Fixed a regression introduced in OpenSSL 1.1.1r not refreshing the certificate data to be signed before signing the certificate. Major changes between OpenSSL 1.1.1q and OpenSSL 1.1.1r [11 Oct 2022] Added a missing header for memcmp that caused compilation failure on some platforms Major changes between OpenSSL 1.1.1p and OpenSSL 1.1.1q [5 Jul 2022] Fixed AES OCB failure to encrypt some bytes on 32-bit x86 platforms (CVE-2022-2097) Major changes between OpenSSL 1.1.1o and OpenSSL 1.1.1p [21 Jun 2022] Fixed additional bugs in the c_rehash script which was not properly sanitising shell metacharacters to prevent command injection (CVE-2022-2068) Major changes between OpenSSL 1.1.1n and OpenSSL 1.1.1o [3 May 2022] Fixed a bug in the c_rehash script which was not properly sanitising shell metacharacters to prevent command injection (CVE-2022-1292) Major changes between OpenSSL 1.1.1m and OpenSSL 1.1.1n [15 Mar 2022] Fixed a bug in the BN_mod_sqrt() function that can cause it to loop forever for non-prime moduli (CVE-2022-0778) Major changes between OpenSSL 1.1.1l and OpenSSL 1.1.1m [14 Dec 2021] None
Major changes between OpenSSL 1.1.1k and OpenSSL 1.1.1l [24 Aug 2021] Fixed an SM2 Decryption Buffer Overflow (CVE-2021-3711) Fixed various read buffer overruns processing ASN.1 strings (CVE-2021-3712) Major changes between OpenSSL 1.1.1j and OpenSSL 1.1.1k [25 Mar 2021] Fixed a problem with verifying a certificate chain when using the X509_V_FLAG_X509_STRICT flag (CVE-2021-3450) Fixed an issue where an OpenSSL TLS server may crash if sent a maliciously crafted renegotiation ClientHello message from a client (CVE-2021-3449)