### PR TITLE
Fix part of MISRA rule 16-N.

### DIFF
--- a/src/core/cdr/src/dds_cdrstream.c
+++ b/src/core/cdr/src/dds_cdrstream.c
@@ -385,6 +385,8 @@ static void dds_stream_swap (void * __restrict vbuf, uint32_t size, uint32_t num
       }
       break;
     }
+    default:
+      break;
   }
 }
 
@@ -950,7 +952,7 @@ static uint32_t read_union_discriminant (dds_istream_t * __restrict is, uint32_t
         case 1: return dds_is_get1 (is);
         case 2: return dds_is_get2 (is);
         case 4: return dds_is_get4 (is);
-        default: abort ();
+        default: abort (); break;
       }
       break;
     default: return 0;
@@ -1193,6 +1195,7 @@ static uint32_t get_length_code (const uint32_t * __restrict ops)
             case 2: return LENGTH_CODE_2B;
             case 4: return LENGTH_CODE_4B;
             case 8: return LENGTH_CODE_8B;
+            default: break;
           }
           break;
         case DDS_OP_VAL_STR: case DDS_OP_VAL_BST: return LENGTH_CODE_ALSO_NEXTINT; /* nextint overlaps with length from serialized string data */
@@ -1481,6 +1484,8 @@ static const uint32_t *dds_stream_read_seq (dds_istream_t * __restrict is, char 
         case 4:
           dds_is_get_bytes (is, seq->_buffer, seq->_length, elem_size);
           break;
+        default:
+          break;
       }
       if (seq->_length < num)
         dds_stream_skip_forward (is, num - seq->_length, elem_size);
@@ -1567,6 +1572,7 @@ static const uint32_t *dds_stream_read_arr (dds_istream_t * __restrict is, char 
           break;
         default:
           abort ();
+          break;
       }
       return ops + 4;
     }
@@ -1648,7 +1654,7 @@ static const uint32_t *dds_stream_read_uni (dds_istream_t * __restrict is, char 
           case 1: *((uint32_t *) valaddr) = dds_is_get1 (is); break;
           case 2: *((uint32_t *) valaddr) = dds_is_get2 (is); break;
           case 4: *((uint32_t *) valaddr) = dds_is_get4 (is); break;
-          default: abort ();
+          default: abort (); break;
         }
         break;
       case DDS_OP_VAL_STR:
@@ -1711,7 +1717,7 @@ static inline const uint32_t *dds_stream_read_adr (uint32_t insn, dds_istream_t 
         case 1: *((uint32_t *) addr) = dds_is_get1 (is); break;
         case 2: *((uint32_t *) addr) = dds_is_get2 (is); break;
         case 4: *((uint32_t *) addr) = dds_is_get4 (is); break;
-        default: abort ();
+        default: abort (); break;
       }
       ops += 3;
       break;
@@ -1723,7 +1729,7 @@ static inline const uint32_t *dds_stream_read_adr (uint32_t insn, dds_istream_t 
         case 2: *((uint16_t *) addr) = dds_is_get2 (is); break;
         case 4: *((uint32_t *) addr) = dds_is_get4 (is); break;
         case 8: *((uint64_t *) addr) = dds_is_get8 (is); break;
-        default: abort ();
+        default: abort (); break;
       }
       ops += 4;
       break;
@@ -1808,7 +1814,7 @@ static const uint32_t *dds_stream_skip_adr_default (uint32_t insn, char * __rest
         case 2: *(uint16_t *) addr = 0; break;
         case 4: *(uint32_t *) addr = 0; break;
         case 8: *(uint64_t *) addr = 0; break;
-        default: abort ();
+        default: abort (); break;
       }
       return ops + 4;
     case DDS_OP_VAL_SEQ: case DDS_OP_VAL_BSQ: {
@@ -2328,6 +2334,7 @@ static bool read_normalize_bitmask (uint64_t * __restrict val, char * __restrict
       break;
     default:
       abort ();
+      break;
   }
   if (!bitmask_value_valid (*val, bits_h, bits_l))
     return normalize_error_bool ();
@@ -2487,6 +2494,8 @@ static bool normalize_bitmaskarray (char * __restrict data, uint32_t * __restric
       *off += 8 * num;
       break;
     }
+    default:
+      break;
   }
   return true;
 }
@@ -2678,6 +2687,7 @@ static bool normalize_uni_disc (uint32_t * __restrict val, char * __restrict dat
       return read_normalize_enum (val, data, off, size, bswap, insn, ops[4]);
     default:
       abort ();
+      break;
   }
   return false;
 }
@@ -3355,7 +3365,7 @@ static void dds_stream_extract_key_from_key_prim_op (dds_istream_t * __restrict 
         case 2: dds_os_put2 (os, allocator, dds_is_get2 (is)); break;
         case 4: dds_os_put4 (os, allocator, dds_is_get4 (is)); break;
         case 8: assert (DDS_OP_TYPE(insn) == DDS_OP_VAL_BMK); dds_os_put8 (os, allocator, dds_is_get8 (is)); break;
-        default: abort ();
+        default: abort (); break;
       }
       break;
     case DDS_OP_VAL_STR: case DDS_OP_VAL_BST: {
@@ -3440,6 +3450,8 @@ static void dds_stream_swap_copy (void * __restrict vdst, const void * __restric
       }
       break;
     }
+    default:
+      break;
   }
 }
 #endif
@@ -3462,7 +3474,7 @@ static void dds_stream_extract_keyBE_from_key_prim_op (dds_istream_t * __restric
         case 2: dds_os_put2BE (os, allocator, dds_is_get2 (is)); break;
         case 4: dds_os_put4BE (os, allocator, dds_is_get4 (is)); break;
         case 8: assert (DDS_OP_TYPE (insn) == DDS_OP_VAL_BMK); dds_os_put8BE (os, allocator, dds_is_get8 (is)); break;
-        default: abort ();
+        default: abort (); break;
       }
       break;
     case DDS_OP_VAL_STR: case DDS_OP_VAL_BST: {
@@ -3703,7 +3715,7 @@ static void dds_stream_read_key_impl (dds_istream_t * __restrict is, char * __re
         case 1: *((uint32_t *) dst) = dds_is_get1 (is); break;
         case 2: *((uint32_t *) dst) = dds_is_get2 (is); break;
         case 4: *((uint32_t *) dst) = dds_is_get4 (is); break;
-        default: abort ();
+        default: abort (); break;
       }
       break;
     case DDS_OP_VAL_BMK:
@@ -3713,7 +3725,7 @@ static void dds_stream_read_key_impl (dds_istream_t * __restrict is, char * __re
         case 2: *((uint16_t *) dst) = dds_is_get2 (is); break;
         case 4: *((uint32_t *) dst) = dds_is_get4 (is); break;
         case 8: *((uint64_t *) dst) = dds_is_get8 (is); break;
-        default: abort ();
+        default: abort (); break;
       }
       break;
     case DDS_OP_VAL_STR: *((char **) dst) = dds_stream_reuse_string (is, *((char **) dst), allocator); break;
@@ -3752,6 +3764,7 @@ static void dds_stream_read_key_impl (dds_istream_t * __restrict is, char * __re
         }
         default:
           abort ();
+          break;
       }
       break;
     }
@@ -3899,6 +3912,7 @@ static bool prtf_enum_bitmask (char * __restrict *buf, size_t * __restrict bufsi
     }
     default:
       abort ();
+      break;
   }
   return false;
 }
@@ -3948,6 +3962,7 @@ static bool prtf_simple (char * __restrict *buf, size_t * __restrict bufsize, dd
     case DDS_OP_VAL_STR: case DDS_OP_VAL_BST: return prtf_str (buf, bufsize, is);
     case DDS_OP_VAL_ARR: case DDS_OP_VAL_SEQ: case DDS_OP_VAL_BSQ: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU: case DDS_OP_VAL_EXT:
       abort ();
+      break;
   }
   return false;
 }

--- a/src/core/cdr/src/dds_cdrstream_keys.part.c
+++ b/src/core/cdr/src/dds_cdrstream_keys.part.c
@@ -66,6 +66,7 @@ static void dds_stream_write_keyBO_impl (DDS_OSTREAM_T * __restrict os, const st
         }
         default:
           abort ();
+          break;
       }
       break;
     }

--- a/src/core/cdr/src/dds_cdrstream_write.part.c
+++ b/src/core/cdr/src/dds_cdrstream_write.part.c
@@ -35,6 +35,7 @@ static bool dds_stream_write_enum_valueBO (DDS_OSTREAM_T * __restrict os, const 
       break;
     default:
       abort ();
+      break;
   }
   return true;
 }
@@ -73,6 +74,7 @@ static bool dds_stream_write_bitmask_valueBO (DDS_OSTREAM_T * __restrict os, con
     }
     default:
       abort ();
+      break;
   }
   return true;
 }
@@ -127,6 +129,7 @@ static bool dds_stream_write_enum_arrBO (DDS_OSTREAM_T * __restrict os, const st
       break;
     default:
       abort ();
+      break;
   }
   return true;
 }
@@ -177,6 +180,7 @@ static bool dds_stream_write_bitmask_arrBO (DDS_OSTREAM_T * __restrict os, const
     }
     default:
       abort ();
+      break;
   }
   return true;
 }
@@ -389,6 +393,7 @@ static bool dds_stream_write_union_discriminantBO (DDS_OSTREAM_T * __restrict os
       break;
     default:
       abort ();
+      break;
   }
   return true;
 }

--- a/src/core/ddsc/src/dds_reader.c
+++ b/src/core/ddsc/src/dds_reader.c
@@ -439,6 +439,7 @@ void dds_reader_status_cb (void *ventity, const struct ddsi_status_cb_data *data
     case DDS_OFFERED_DEADLINE_MISSED_STATUS_ID:
     case DDS_OFFERED_INCOMPATIBLE_QOS_STATUS_ID:
       assert (0);
+      break;
   }
 
   rd->m_entity.m_cb_count--;

--- a/src/core/ddsc/src/dds_rhc_default.c
+++ b/src/core/ddsc/src/dds_rhc_default.c
@@ -1897,6 +1897,8 @@ static uint32_t qmask_from_dcpsquery (uint32_t sample_states, uint32_t view_stat
     case DDS_IST_NOT_ALIVE_NO_WRITERS:
       qminv |= DDS_ALIVE_INSTANCE_STATE | DDS_NOT_ALIVE_DISPOSED_INSTANCE_STATE;
       break;
+    default:
+      break;
   }
   return qminv;
 }
@@ -2345,6 +2347,7 @@ static uint32_t rhc_get_cond_trigger (struct rhc_instance * const inst, const dd
       break;
     default:
       DDS_FATAL("update_readconditions: sample_states invalid: %"PRIx32"\n", c->m_sample_states);
+      break;
   }
   return m ? 1 : 0;
 }
@@ -2552,6 +2555,7 @@ static bool update_conditions_locked (struct dds_rhc_default *rhc, bool called_f
         break;
       default:
         DDS_FATAL ("update_readconditions: sample_states invalid: %"PRIx32"\n", iter->m_sample_states);
+        break;
     }
 
     TRACE ("  cond %p %08"PRIx32": ", (void *) iter, iter->m_query.m_qcmask);
@@ -2612,6 +2616,7 @@ static bool update_conditions_locked (struct dds_rhc_default *rhc, bool called_f
           break;
         default:
           DDS_FATAL ("update_readconditions: sample_states invalid: %"PRIx32"\n", iter->m_sample_states);
+          break;
       }
 
       if (m_pre == m_post)

--- a/src/core/ddsc/src/dds_sertype_default.c
+++ b/src/core/ddsc/src/dds_sertype_default.c
@@ -286,6 +286,7 @@ dds_return_t dds_sertype_default_init (const struct dds_domain *domain, struct d
       break;
     default:
       abort ();
+      break;
   }
 
   /* Get the extensility of the outermost object in the type used for the topic. Note that the

--- a/src/core/ddsc/src/dds_writer.c
+++ b/src/core/ddsc/src/dds_writer.c
@@ -154,6 +154,7 @@ void dds_writer_status_cb (void *entity, const struct ddsi_status_cb_data *data)
     case DDS_REQUESTED_DEADLINE_MISSED_STATUS_ID:
     case DDS_REQUESTED_INCOMPATIBLE_QOS_STATUS_ID:
       assert (0);
+      break;
   }
 
   wr->m_entity.m_cb_count--;

--- a/src/ddsrt/src/mh3.c
+++ b/src/ddsrt/src/mh3.c
@@ -57,6 +57,8 @@ uint32_t ddsrt_mh3 (const void *key, size_t len, uint32_t seed)
         k1 *= c2;
         h1 ^= k1;
         /* FALLS THROUGH */
+      default:
+        break;
     }
   }
 

--- a/src/ddsrt/src/sockets.c
+++ b/src/ddsrt/src/sockets.c
@@ -119,6 +119,8 @@ ddsrt_sockaddr_isunspecified(const struct sockaddr *__restrict sa)
 #endif
     case AF_INET:
       return (((struct sockaddr_in *)sa)->sin_addr.s_addr == 0);
+    default:
+      break;
   }
 
   return false;
@@ -138,6 +140,8 @@ ddsrt_sockaddr_isloopback(const struct sockaddr *__restrict sa)
     case AF_INET:
       return (((const struct sockaddr_in *)sa)->sin_addr.s_addr
                   == htonl(INADDR_LOOPBACK));
+    default:
+      break;
   }
 
   return false;
@@ -182,6 +186,8 @@ ddsrt_sockaddr_insamesubnet(
         }
       } break;
 #endif
+    default:
+      break;
   }
 
   return eq;

--- a/src/ddsrt/src/sockets/posix/socket.c
+++ b/src/ddsrt/src/sockets/posix/socket.c
@@ -304,6 +304,8 @@ ddsrt_setsockopt(
     case SO_DONTROUTE:
       /* SO_DONTROUTE causes problems on macOS (e.g. no multicasting). */
       return DDS_RETCODE_OK;
+    default:
+      break;
   }
 
 #if defined(__ZEPHYR__)
@@ -398,6 +400,8 @@ ddsrt_setsockopt(
       }
       return DDS_RETCODE_ERROR;
     }
+    default:
+      break;
   }
 #endif /* __ZEPHYR__ */
 


### PR DESCRIPTION
This addresses rule 16-N.

> All switch statements shall be well-formed.

This PR resolve only next violations.
- "Every switch statement shall have a default label"
> > Exclude switch throw `Enum` type.
- "An unconditional break statement shall terminate every switch-clause"
> > Exclude cases when we need to "Fall through". And cases when we using `goto label;` or `return value` from switch-case _(Because otherwise it's dead code!)_.

The next violation needs to be discussed.
- "The switch-clause following the default label shall, prior to the terminating break statement, contain
either: comment, statement"
