### PR TITLE
Work-around for CI failure on CUnit

### DIFF
--- a/.azure/templates/build-test.yml
+++ b/.azure/templates/build-test.yml
@@ -106,7 +106,8 @@ steps:
       set -e -x
       mkdir build
       cd build
-      conan install -b missing -pr:b ${BUILD_PROFILE} -pr:h ${HOST_PROFILE} -s build_type=${BUILD_TYPE} -o *:shared=${CONAN_SHARED_OBJECTS:-False} ../${CONANFILE:-conanfile.txt}
+      CONAN_REVISIONS_ENABLED=1 \
+        conan install -b missing -pr:b ${BUILD_PROFILE} -pr:h ${HOST_PROFILE} -s build_type=${BUILD_TYPE} -o *:shared=${CONAN_SHARED_OBJECTS:-False} ../${CONANFILE:-conanfile.txt}
       cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
             -DCMAKE_INSTALL_PREFIX=install \
             -DCMAKE_PREFIX_PATH="${BUILD_SOURCESDIRECTORY}/iceoryx/build/install" \

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-cunit/2.1-3
+cunit/2.1-3@#27f0e9a5c37e2146ec1fcf9e6a920be9
 openssl/1.1.1j
 
 [generators]


### PR DESCRIPTION
This is a workaround for the CI builds failing on installation of CUnit (via Conan). I've tried several other solutions, e.g. adding the `with_curses` option as suggested in the error message, but that results in build failures of ncurses on some of the builds. Switching cunit to use it as a static library is also not working, that results in linker errors and conflicting symbols in certain builds. So switching back to a previous version of the conan recipe for cmake seems to be the best option for now. 