### PR TITLE
Reject locators with port = 0

### DIFF
--- a/src/core/ddsi/src/ddsi__tran.h
+++ b/src/core/ddsi/src/ddsi__tran.h
@@ -252,7 +252,7 @@ inline dds_return_t ddsi_factory_create_conn (struct ddsi_tran_conn **conn, stru
   *conn = NULL;
   if ((qos->m_interface != NULL) != (qos->m_purpose == DDSI_TRAN_QOS_XMIT_UC || qos->m_purpose == DDSI_TRAN_QOS_XMIT_MC))
     return DDS_RETCODE_BAD_PARAMETER;
-  if (!ddsi_is_valid_port (factory, port))
+  if (port != 0 && !ddsi_is_valid_port (factory, port))
     return DDS_RETCODE_BAD_PARAMETER;
   return factory->m_create_conn_fn (conn, factory, port, qos);
 }
@@ -260,7 +260,7 @@ inline dds_return_t ddsi_factory_create_conn (struct ddsi_tran_conn **conn, stru
 /** @component transport */
 inline dds_return_t ddsi_factory_create_listener (struct ddsi_tran_listener **listener, struct ddsi_tran_factory * factory, uint32_t port, const struct ddsi_tran_qos *qos) {
   *listener = NULL;
-  if (!ddsi_is_valid_port (factory, port))
+  if (port != 0 && !ddsi_is_valid_port (factory, port))
     return DDS_RETCODE_BAD_PARAMETER;
   return factory->m_create_listener_fn (listener, factory, port, qos);
 }

--- a/src/core/ddsi/src/ddsi__tran.h
+++ b/src/core/ddsi/src/ddsi__tran.h
@@ -33,6 +33,12 @@ struct ddsi_domaingv;
 /* Flags */
 #define DDSI_TRAN_ON_CONNECT 0x0001
 
+/* Magic value for port number argument in create_conn and create_listener to indicate
+   that a random port number is requested.  Note that 0 also happens to be illegal in UDP
+   and TCP and is DDSI_LOCATOR_PORT_INVALID in the DDSI spec.  What a fortunate
+   coincidence!  */
+#define DDSI_TRAN_RANDOM_PORT_NUMBER 0
+
 enum ddsi_tran_qos_purpose {
   DDSI_TRAN_QOS_XMIT_UC, // will send unicast only
   DDSI_TRAN_QOS_XMIT_MC, // may send unicast or multicast
@@ -252,7 +258,7 @@ inline dds_return_t ddsi_factory_create_conn (struct ddsi_tran_conn **conn, stru
   *conn = NULL;
   if ((qos->m_interface != NULL) != (qos->m_purpose == DDSI_TRAN_QOS_XMIT_UC || qos->m_purpose == DDSI_TRAN_QOS_XMIT_MC))
     return DDS_RETCODE_BAD_PARAMETER;
-  if (port != 0 && !ddsi_is_valid_port (factory, port))
+  if (port != DDSI_TRAN_RANDOM_PORT_NUMBER && !ddsi_is_valid_port (factory, port))
     return DDS_RETCODE_BAD_PARAMETER;
   return factory->m_create_conn_fn (conn, factory, port, qos);
 }
@@ -260,7 +266,7 @@ inline dds_return_t ddsi_factory_create_conn (struct ddsi_tran_conn **conn, stru
 /** @component transport */
 inline dds_return_t ddsi_factory_create_listener (struct ddsi_tran_listener **listener, struct ddsi_tran_factory * factory, uint32_t port, const struct ddsi_tran_qos *qos) {
   *listener = NULL;
-  if (port != 0 && !ddsi_is_valid_port (factory, port))
+  if (port != DDSI_TRAN_RANDOM_PORT_NUMBER && !ddsi_is_valid_port (factory, port))
     return DDS_RETCODE_BAD_PARAMETER;
   return factory->m_create_listener_fn (listener, factory, port, qos);
 }

--- a/src/core/ddsi/src/ddsi_debmon.c
+++ b/src/core/ddsi/src/ddsi_debmon.c
@@ -711,7 +711,7 @@ struct ddsi_debug_monitor *ddsi_new_debug_monitor (struct ddsi_domaingv *gv, int
   if ((dm->tran_factory = ddsi_factory_find (gv, "tcp")) == NULL)
     dm->tran_factory = ddsi_factory_find (gv, "tcp6");
 
-  if (port != 0 && !ddsi_is_valid_port (dm->tran_factory, (uint32_t) port))
+  if (port != DDSI_TRAN_RANDOM_PORT_NUMBER && !ddsi_is_valid_port (dm->tran_factory, (uint32_t) port))
   {
     GVERROR ("debug monitor port number %"PRId32" is invalid\n", port);
     goto err_invalid_port;

--- a/src/core/ddsi/src/ddsi_debmon.c
+++ b/src/core/ddsi/src/ddsi_debmon.c
@@ -711,7 +711,7 @@ struct ddsi_debug_monitor *ddsi_new_debug_monitor (struct ddsi_domaingv *gv, int
   if ((dm->tran_factory = ddsi_factory_find (gv, "tcp")) == NULL)
     dm->tran_factory = ddsi_factory_find (gv, "tcp6");
 
-  if (!ddsi_is_valid_port (dm->tran_factory, (uint32_t) port))
+  if (port != 0 && !ddsi_is_valid_port (dm->tran_factory, (uint32_t) port))
   {
     GVERROR ("debug monitor port number %"PRId32" is invalid\n", port);
     goto err_invalid_port;

--- a/src/core/ddsi/src/ddsi_init.c
+++ b/src/core/ddsi/src/ddsi_init.c
@@ -112,9 +112,9 @@ static enum make_uc_sockets_ret make_uc_sockets (struct ddsi_domaingv *gv, uint3
   *pdisc = ddsi_get_port (&gv->config, DDSI_PORT_UNI_DISC, ppid);
   *pdata = ddsi_get_port (&gv->config, DDSI_PORT_UNI_DATA, ppid);
 
-  if (*pdisc != 0 && !ddsi_is_valid_port (gv->m_factory, *pdisc))
+  if (*pdisc != DDSI_TRAN_RANDOM_PORT_NUMBER && !ddsi_is_valid_port (gv->m_factory, *pdisc))
     return MUSRET_INVALID_PORTS;
-  if (*pdata != 0 && !ddsi_is_valid_port (gv->m_factory, *pdata))
+  if (*pdata != DDSI_TRAN_RANDOM_PORT_NUMBER && !ddsi_is_valid_port (gv->m_factory, *pdata))
     return MUSRET_INVALID_PORTS;
 
   const struct ddsi_tran_qos qos = { .m_purpose = DDSI_TRAN_QOS_RECV_UC, .m_diffserv = 0, .m_interface = NULL };
@@ -285,7 +285,7 @@ static int string_to_default_locator (const struct ddsi_domaingv *gv, ddsi_locat
       GVERROR ("%s: invalid address kind (%s)\n", string, tag);
       return -1;
   }
-  if (port != 0 && !ddsi_is_unspec_locator(loc))
+  if (port != DDSI_LOCATOR_PORT_INVALID && !ddsi_is_unspec_locator(loc))
     loc->port = port;
   else
     loc->port = DDSI_LOCATOR_PORT_INVALID;
@@ -1492,8 +1492,8 @@ int ddsi_init (struct ddsi_domaingv *gv)
   else
   {
     if (gv->config.tcp_port < 0)
-      ; /* nop */
-    else if (gv->config.tcp_port == 0)
+      ; /* no TCP listener */
+    else if (gv->config.tcp_port == DDSI_TRAN_RANDOM_PORT_NUMBER)
       ; /* kernel-allocated random port */
     else if (!ddsi_is_valid_port (gv->m_factory, (uint32_t) gv->config.tcp_port))
     {

--- a/src/core/ddsi/src/ddsi_init.c
+++ b/src/core/ddsi/src/ddsi_init.c
@@ -112,7 +112,9 @@ static enum make_uc_sockets_ret make_uc_sockets (struct ddsi_domaingv *gv, uint3
   *pdisc = ddsi_get_port (&gv->config, DDSI_PORT_UNI_DISC, ppid);
   *pdata = ddsi_get_port (&gv->config, DDSI_PORT_UNI_DATA, ppid);
 
-  if (!ddsi_is_valid_port (gv->m_factory, *pdisc) || !ddsi_is_valid_port (gv->m_factory, *pdata))
+  if (*pdisc != 0 && !ddsi_is_valid_port (gv->m_factory, *pdisc))
+    return MUSRET_INVALID_PORTS;
+  if (*pdata != 0 && !ddsi_is_valid_port (gv->m_factory, *pdata))
     return MUSRET_INVALID_PORTS;
 
   const struct ddsi_tran_qos qos = { .m_purpose = DDSI_TRAN_QOS_RECV_UC, .m_diffserv = 0, .m_interface = NULL };
@@ -1489,8 +1491,10 @@ int ddsi_init (struct ddsi_domaingv *gv)
   }
   else
   {
-    if (gv->config.tcp_port == -1)
+    if (gv->config.tcp_port < 0)
       ; /* nop */
+    else if (gv->config.tcp_port == 0)
+      ; /* kernel-allocated random port */
     else if (!ddsi_is_valid_port (gv->m_factory, (uint32_t) gv->config.tcp_port))
     {
       GVERROR ("Listener port %d is out of range for transport %s\n", gv->config.tcp_port, gv->m_factory->m_typename);

--- a/src/core/ddsi/src/ddsi_portmapping.c
+++ b/src/core/ddsi/src/ddsi_portmapping.c
@@ -15,6 +15,9 @@
 #include "dds/ddsi/ddsi_config.h"
 #include "ddsi__portmapping.h"
 
+// for a static assert on DDSI_TRAN_RANDOM_PORT_NUMBER
+#include "ddsi__tran.h"
+
 static bool get_port_int (uint32_t *port, const struct ddsi_portmapping *map, enum ddsi_port which, uint32_t domain_id, int32_t participant_index, char *str_if_overflow, size_t strsize)
 {
   uint32_t off = UINT32_MAX, ppidx = UINT32_MAX;
@@ -38,7 +41,7 @@ static bool get_port_int (uint32_t *port, const struct ddsi_portmapping *map, en
       if (participant_index == DDSI_PARTICIPANT_INDEX_NONE)
       {
         /* participant index "none" means unicast ports get chosen by the transport */
-        *port = 0;
+        *port = DDSI_TRAN_RANDOM_PORT_NUMBER;
         return true;
       }
       off = map->d1;
@@ -48,7 +51,7 @@ static bool get_port_int (uint32_t *port, const struct ddsi_portmapping *map, en
       if (participant_index == DDSI_PARTICIPANT_INDEX_NONE)
       {
         /* participant index "none" means unicast ports get chosen by the transport */
-        *port = 0;
+        *port = DDSI_TRAN_RANDOM_PORT_NUMBER;
         return true;
       }
       off = map->d3;
@@ -62,6 +65,7 @@ static bool get_port_int (uint32_t *port, const struct ddsi_portmapping *map, en
   /* For the mapping to be valid, the port number must be in range of an unsigned 32 bit integer and must
      not be 0 (as that is used for indicating a random port should be selected by the transport).  The
      transports may limit this further, but at least we won't have to worry about overflow anymore. */
+  DDSRT_STATIC_ASSERT (DDSI_TRAN_RANDOM_PORT_NUMBER == 0);
   *port = (uint32_t) (a + b);
   if (a <= UINT32_MAX && b <= UINT32_MAX - a && *port > 0)
     return true;

--- a/src/core/ddsi/src/ddsi_tcp.c
+++ b/src/core/ddsi/src/ddsi_tcp.c
@@ -1179,7 +1179,7 @@ static enum ddsi_nearby_address_result ddsi_tcp_is_nearby_address (const ddsi_lo
 static int ddsi_tcp_is_valid_port (const struct ddsi_tran_factory *fact, uint32_t port)
 {
   (void) fact;
-  return (port <= 65535);
+  return (0 < port && port <= 65535);
 }
 
 static uint32_t ddsi_tcp_receive_buffer_size (const struct ddsi_tran_factory *fact)

--- a/src/core/ddsi/src/ddsi_udp.c
+++ b/src/core/ddsi/src/ddsi_udp.c
@@ -856,7 +856,7 @@ static void ddsi_udp_fini (struct ddsi_tran_factory * fact_cmn)
 static int ddsi_udp_is_valid_port (const struct ddsi_tran_factory *fact, uint32_t port)
 {
   (void) fact;
-  return (port <= 65535);
+  return (0 < port && port <= 65535);
 }
 
 static uint32_t ddsi_udp_receive_buffer_size (const struct ddsi_tran_factory *fact_cmn)

--- a/src/core/ddsi/tests/plist.c
+++ b/src/core/ddsi/tests/plist.c
@@ -12,10 +12,18 @@
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/string.h"
 #include "dds/ddsrt/endian.h"
+#include "dds/ddsrt/static_assert.h"
 #include "dds/ddsi/ddsi_xqos.h"
 #include "dds/ddsi/ddsi_plist.h"
-#include "ddsi__plist.h"
 #include "dds/features.h"
+
+#include "ddsi__plist.h"
+#include "ddsi__udp.h"
+#include "ddsi__tcp.h"
+#include "ddsi__tran.h"
+#include "ddsi__vendor.h"
+
+#include "mem_ser.h"
 
 CU_Test (ddsi_plist, unalias_copy_merge)
 {
@@ -249,4 +257,243 @@ CU_Test (ddsi_plist, unalias_copy_merge)
   ddsi_plist_fini (&p2);
   ddsi_plist_fini (&p3);
   ddsi_plist_fini (&p4);
+}
+
+#define UNKNOWN_KIND 0x33221133
+DDSRT_STATIC_ASSERT(
+  DDSI_LOCATOR_KIND_UDPv4 != UNKNOWN_KIND &&
+  DDSI_LOCATOR_KIND_TCPv4 != UNKNOWN_KIND &&
+  DDSI_LOCATOR_KIND_UDPv6 != UNKNOWN_KIND &&
+  DDSI_LOCATOR_KIND_TCPv6 != UNKNOWN_KIND &&
+  DDSI_LOCATOR_KIND_SHEM  != UNKNOWN_KIND &&
+  DDSI_LOCATOR_KIND_UDPv4MCGEN != UNKNOWN_KIND &&
+  DDSI_LOCATOR_KIND_RAWETH != UNKNOWN_KIND &&
+  DDSI_LOCATOR_KIND_INVALID != UNKNOWN_KIND);
+DDSRT_STATIC_ASSERT((DDSI_LOCATOR_KIND_UDPv4 & DDSI_LOCATOR_KIND_TCPv4) == 0);
+
+#define HDR(id, len) SER32BE(((uint32_t)(id) << 16) | (uint32_t)(len))
+
+static void setup (struct ddsi_domaingv *gv, uint32_t factories)
+{
+  memset (gv, 0, sizeof (*gv));
+  dds_log_cfg_init (&gv->logconfig, 0, DDS_LC_TRACE | DDS_LC_PLIST, stdout, stdout);
+  if (factories & DDSI_LOCATOR_KIND_UDPv4)
+  {
+    (void) ddsi_udp_init (gv);
+    struct ddsi_tran_factory * const udp = ddsi_factory_find (gv, "udp");
+    CU_ASSERT_FATAL (udp != NULL);
+    udp->m_enable = true;
+  }
+  if (factories & DDSI_LOCATOR_KIND_TCPv4)
+  {
+    (void) ddsi_tcp_init (gv);
+    struct ddsi_tran_factory * const tcp = ddsi_factory_find (gv, "tcp");
+    CU_ASSERT_FATAL (tcp != NULL);
+    tcp->m_enable = true;
+  }
+}
+
+static void teardown (struct ddsi_domaingv *gv)
+{
+  while (gv->ddsi_tran_factories)
+  {
+    struct ddsi_tran_factory *f = gv->ddsi_tran_factories;
+    gv->ddsi_tran_factories = f->m_factory;
+    ddsi_factory_free (f);
+  }
+}
+
+CU_Test (ddsi_plist, locator_lists_reject)
+{
+  static const uint32_t enabled_kinds[] = {
+    0,
+    DDSI_LOCATOR_KIND_UDPv4,
+    DDSI_LOCATOR_KIND_TCPv4,
+    DDSI_LOCATOR_KIND_UDPv4 | DDSI_LOCATOR_KIND_TCPv4
+  };
+  uint32_t subtest = 0; // particularly useful for setting an ignore count on a breakpoint
+  for (size_t enabled_kinds_idx = 0; enabled_kinds_idx < sizeof (enabled_kinds) / sizeof (enabled_kinds[0]); enabled_kinds_idx++)
+  {
+    const uint32_t factories = enabled_kinds[enabled_kinds_idx];
+    struct ddsi_domaingv gv;
+    setup (&gv, factories);
+    // Do this for each of the "normal" locator parameters - they are handled by the
+    // same code and should behave the same but check anyway
+    static const uint32_t kinds[] = {
+      DDSI_LOCATOR_KIND_UDPv4,
+      DDSI_LOCATOR_KIND_TCPv4,
+      UNKNOWN_KIND
+    };
+    for (size_t kindidx = 0; kindidx < sizeof (kinds) / sizeof (kinds[0]); kindidx++)
+    {
+      const uint32_t kind = kinds[kindidx];
+      // plist to be patched (this one is valid)
+      // @0...1: pid; @2...3: length; @4...7: kind, @8...11: port, @12...27: address
+      enum reject_case { REJ_SHORT_20, REJ_SHORT_23, REJ_PORT_0, REJ_PORT_64k, REJ_GARBAGE } reject_case = REJ_SHORT_20;
+      do {
+        printf ("subtest %"PRIu32": enabled_kinds = %"PRIx32" kind = %"PRIx32" reject_case = %d\n",
+                ++subtest, factories, kind, (int) reject_case);
+        unsigned char plist_rej[] = {
+          HDR(DDSI_PID_UNICAST_LOCATOR, 24), SER32BE(kind), SER32BE(1), 0,0,0,0, 0,0,0,0, 0,0,0,0, 127,0,0,1,
+          HDR(DDSI_PID_SENTINEL, 0)
+        };
+        switch (reject_case)
+        {
+          case REJ_SHORT_20: plist_rej[3] = 20; break;
+          case REJ_SHORT_23: plist_rej[3] = 23; break;
+          case REJ_PORT_0:   plist_rej[11] = 0; break;
+          case REJ_PORT_64k: plist_rej[9] = 1; plist_rej[10] = plist_rej[11] = 0; break;
+          case REJ_GARBAGE:  plist_rej[12] = 1; break;
+        }
+        const ddsi_plist_src_t src = {
+          .protocol_version = { DDSI_RTPS_MAJOR, DDSI_RTPS_MINOR },
+          .vendorid = DDSI_VENDORID_ECLIPSE,
+          .encoding = DDSI_RTPS_PL_CDR_BE,
+          .buf = plist_rej,
+          .bufsz = sizeof (plist_rej),
+          .strict = false
+        };
+        char *nextafter = NULL;
+        ddsi_plist_t plist;
+        dds_return_t rc = ddsi_plist_init_frommsg (&plist, &nextafter, ~(uint64_t)0, ~(uint64_t)0, &src, &gv, DDSI_PLIST_CONTEXT_PARTICIPANT);
+        if (reject_case <= REJ_SHORT_23) {
+          // short/invalid lengths => always reject entire plist
+          CU_ASSERT (rc == DDS_RETCODE_BAD_PARAMETER);
+        } else if (kind != UNKNOWN_KIND && (factories & kind)) {
+          // invalid content: only reject for known & enabled transports
+          CU_ASSERT (rc == DDS_RETCODE_BAD_PARAMETER);
+        } else {
+          // ignored: locator kind unknown/not enabled, so plist should be accepted but the
+          // result should be empty
+          CU_ASSERT (rc == 0);
+          CU_ASSERT ((unsigned char *) nextafter == plist_rej + sizeof (plist_rej));
+          CU_ASSERT (plist.present == 0);
+          ddsi_plist_fini (&plist);
+        }
+      } while (++reject_case <= REJ_GARBAGE);
+    }
+    teardown (&gv);
+  }
+}
+
+#define UNKLOCATOR SER32BE(UNKNOWN_KIND), SER32BE(1), SER32BE(0), SER32BE(0), SER32BE(0), SER32BE(0)
+#define UDPLOCATOR(a,b,c,d,port) \
+  SER32BE(DDSI_LOCATOR_KIND_UDPv4), \
+  SER32BE(port), \
+  SER32BE(0),SER32BE(0),SER32BE(0), \
+  (a),(b),(c),(d)
+#define TCPLOCATOR(a,b,c,d,port) \
+  SER32BE(DDSI_LOCATOR_KIND_TCPv4), \
+  SER32BE(port), \
+  SER32BE(0),SER32BE(0),SER32BE(0), \
+  (a),(b),(c),(d)
+
+CU_Test (ddsi_plist, locator_lists_accept)
+{
+  static const uint32_t enabled_kinds[] = {
+    0,
+    DDSI_LOCATOR_KIND_UDPv4,
+    DDSI_LOCATOR_KIND_TCPv4,
+    DDSI_LOCATOR_KIND_UDPv4 | DDSI_LOCATOR_KIND_TCPv4
+  };
+  for (size_t enabled_kinds_idx = 0; enabled_kinds_idx < sizeof (enabled_kinds) / sizeof (enabled_kinds[0]); enabled_kinds_idx++)
+  {
+    const uint32_t factories = enabled_kinds[enabled_kinds_idx];
+    struct ddsi_domaingv gv;
+    setup (&gv, factories);
+    static const struct {
+      uint16_t pid;
+      uint64_t pp_flag;
+      size_t pp_offset;
+    } pids[] = {
+      { DDSI_PID_UNICAST_LOCATOR, PP_UNICAST_LOCATOR, offsetof (ddsi_plist_t, unicast_locators) },
+      { DDSI_PID_MULTICAST_LOCATOR, PP_MULTICAST_LOCATOR, offsetof (ddsi_plist_t, multicast_locators) },
+      { DDSI_PID_DEFAULT_UNICAST_LOCATOR, PP_DEFAULT_UNICAST_LOCATOR, offsetof (ddsi_plist_t, default_unicast_locators) },
+      { DDSI_PID_DEFAULT_MULTICAST_LOCATOR, PP_DEFAULT_MULTICAST_LOCATOR, offsetof (ddsi_plist_t, default_multicast_locators) },
+      { DDSI_PID_METATRAFFIC_UNICAST_LOCATOR, PP_METATRAFFIC_UNICAST_LOCATOR, offsetof (ddsi_plist_t, metatraffic_unicast_locators) },
+      { DDSI_PID_METATRAFFIC_MULTICAST_LOCATOR, PP_METATRAFFIC_MULTICAST_LOCATOR, offsetof (ddsi_plist_t, metatraffic_multicast_locators) }
+    };
+    for (size_t pididx = 0; pididx < sizeof (pids) / sizeof (pids[0]); pididx++)
+    {
+      const size_t pid1idx = (pididx == (sizeof (pids) / sizeof (pids[0]) - 1)) ? 0 : pididx + 1;
+      const uint16_t pid = pids[pididx].pid;
+      const uint16_t pid1 = pids[pid1idx].pid;
+      const unsigned char plist_ok[] = {
+        HDR (pid,  24), UDPLOCATOR (127,0,0, 1, 1), // accept if UDP enabled
+        HDR (pid1, 24), UDPLOCATOR (127,0,0, 2, 1),
+        HDR (pid,  24), TCPLOCATOR (127,0,0, 3, 1), // accept if TCP enabled
+        HDR (pid1, 24), TCPLOCATOR (127,0,0, 4, 1),
+        HDR (pid,  24), UDPLOCATOR (127,0,0, 5, 1), // accept if UDP enabled (for list construction)
+        HDR (pid1, 24), UDPLOCATOR (127,0,0, 6, 1),
+        HDR (pid,  24), TCPLOCATOR (127,0,0, 7, 1), // accept if TCP enabled (for list construction)
+        HDR (pid1, 24), TCPLOCATOR (127,0,0, 8, 1),
+        HDR (pid,  24), UNKLOCATOR,                 // ignore
+        HDR (pid1, 24), UNKLOCATOR,
+        HDR (pid,  24), UDPLOCATOR (127,0,0, 9, 1), // accept if UDP enabled (three is when it gets interesting)
+        HDR (pid1, 24), UDPLOCATOR (127,0,0,10, 1),
+        HDR (pid,  24), TCPLOCATOR (127,0,0,11, 1), // accept if TCP enabled (three is when it gets interesting)
+        HDR (pid1, 24), TCPLOCATOR (127,0,0,12, 1),
+        HDR(DDSI_PID_SENTINEL, 0)
+      };
+      const ddsi_plist_src_t src = {
+        .protocol_version = { DDSI_RTPS_MAJOR, DDSI_RTPS_MINOR },
+        .vendorid = DDSI_VENDORID_ECLIPSE,
+        .encoding = DDSI_RTPS_PL_CDR_BE,
+        .buf = plist_ok,
+        .bufsz = sizeof (plist_ok),
+        .strict = false
+      };
+      char *nextafter = NULL;
+      ddsi_plist_t plist;
+      dds_return_t rc = ddsi_plist_init_frommsg (&plist, &nextafter, ~(uint64_t)0, ~(uint64_t)0, &src, &gv, DDSI_PLIST_CONTEXT_PARTICIPANT);
+      CU_ASSERT (rc == 0);
+      CU_ASSERT ((unsigned char *) nextafter == plist_ok + sizeof (plist_ok));
+      if (factories == 0)
+      {
+        // nothing enabled, nothing present
+        CU_ASSERT (plist.present == 0);
+      }
+      else
+      {
+        // should have both lists present
+        CU_ASSERT (plist.present & pids[pididx].pp_flag);
+        CU_ASSERT (plist.present & pids[pid1idx].pp_flag);
+        const struct ddsi_locators *lpid = (const struct ddsi_locators *) ((const char *) &plist + pids[pididx].pp_offset);
+        const struct ddsi_locators *lpid1 = (const struct ddsi_locators *) ((const char *) &plist + pids[pid1idx].pp_offset);
+        const struct ddsi_locators_one *l = lpid->first;
+        const struct ddsi_locators_one *l1 = lpid1->first;
+        for (size_t pi = 0; pi < sizeof (plist_ok) - 4; pi += 28)
+        {
+          uint16_t pi_pid;
+          uint32_t pi_kind, pi_port;
+          memcpy (&pi_pid, plist_ok + pi, sizeof (pi_pid));
+          memcpy (&pi_kind, plist_ok + pi + 4, sizeof (pi_kind));
+          memcpy (&pi_port, plist_ok + pi + 8, sizeof (pi_port));
+          pi_pid = ddsrt_fromBE2u (pi_pid);
+          pi_kind = ddsrt_fromBE4u (pi_kind);
+          pi_port = ddsrt_fromBE4u (pi_port);
+
+          if (pi_kind == UNKNOWN_KIND || !(factories & pi_kind))
+            ; // skip ignored ones
+          else
+          {
+            const struct ddsi_locators_one *lcmp;
+            if (pi_pid == pid) {
+              lcmp = l; l = l->next;
+            } else {
+              lcmp = l1; l1 = l1->next;
+            }
+            CU_ASSERT_FATAL (lcmp != NULL);
+            CU_ASSERT ((uint32_t) lcmp->loc.kind == pi_kind);
+            CU_ASSERT (lcmp->loc.port == pi_port);
+            CU_ASSERT (memcmp (lcmp->loc.address, plist_ok + pi + 12, sizeof (lcmp->loc.address)) == 0);
+          }
+        }
+        CU_ASSERT (l == NULL);
+        CU_ASSERT (l1 == NULL);
+      }
+      ddsi_plist_fini (&plist);
+    }
+    teardown (&gv);
+  }
 }


### PR DESCRIPTION
This PR prevents Cyclone from accepting locators with port = 0 and so should take care of the error messages reported in #1772. The other problems caused by accepting incorrect locators can't be fixed so easily.