### PR TITLE
Export typebuilder and cdrstream functions

### DIFF
--- a/src/core/cdr/include/dds/cdr/dds_cdrstream.h
+++ b/src/core/cdr/include/dds/cdr/dds_cdrstream.h
@@ -245,7 +245,7 @@ uint32_t dds_stream_key_flags (struct dds_cdrstream_desc *desc, uint32_t *keysz_
 bool dds_stream_extensibility (const uint32_t * __restrict ops, enum dds_cdr_type_extensibility *ext);
 
 /** @component cdr_serializer */
-void dds_cdrstream_desc_init (struct dds_cdrstream_desc *desc, const struct dds_cdrstream_allocator * __restrict allocator,
+DDS_EXPORT void dds_cdrstream_desc_init (struct dds_cdrstream_desc *desc, const struct dds_cdrstream_allocator * __restrict allocator,
     uint32_t size, uint32_t align, uint32_t flagset, const uint32_t *ops, const dds_key_descriptor_t *keys, uint32_t nkeys);
 
 /** @component cdr_serializer */

--- a/src/core/ddsi/include/dds/ddsi/ddsi_typebuilder.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_typebuilder.h
@@ -23,10 +23,10 @@ extern "C" {
 #endif
 
 /** @component dynamic_types */
-dds_return_t ddsi_topic_descriptor_from_type (struct ddsi_domaingv *gv, dds_topic_descriptor_t *desc, const struct ddsi_type *type);
+DDS_EXPORT dds_return_t ddsi_topic_descriptor_from_type (struct ddsi_domaingv *gv, dds_topic_descriptor_t *desc, const struct ddsi_type *type);
 
 /** @component dynamic_types */
-void ddsi_topic_descriptor_fini (dds_topic_descriptor_t *desc);
+DDS_EXPORT void ddsi_topic_descriptor_fini (dds_topic_descriptor_t *desc);
 
 #if defined (__cplusplus)
 }

--- a/src/core/xtests/symbol_export/symbol_export.c
+++ b/src/core/xtests/symbol_export/symbol_export.c
@@ -53,6 +53,7 @@
 #include "dds/ddsi/ddsi_gc.h"
 #ifdef DDS_HAS_TYPELIB
 #include "dds/ddsi/ddsi_typelib.h"
+#include "dds/ddsi/ddsi_typebuilder.h"
 #endif
 
 #ifdef DDS_HAS_SECURITY
@@ -490,6 +491,7 @@ int main (int argc, char **argv)
   dds_stream_extract_keyBE_from_data (ptr, ptr2, ptr3, ptr4);
   dds_stream_extract_keyBE_from_key (ptr, ptr2, 0, ptr3, ptr4);
   dds_cdrstream_desc_from_topic_desc (ptr, ptr2);
+  dds_cdrstream_desc_init (ptr, ptr2, 0, 0, 0, ptr3, ptr4, 0);
   dds_cdrstream_desc_fini (ptr, ptr2);
 
 #ifdef DDS_HAS_SECURITY
@@ -683,16 +685,20 @@ int main (int argc, char **argv)
   // ddsi_config_impl.h
   ddsi_config_fini (ptr);
 
-  // ddsi/q_thread.h
+  // ddsi/ddsi_thread.h
   ddsi_lookup_thread_state ();
   ddsi_lookup_thread_state_real ();
 
-  // ddsi/q_gc.h
+  // ddsi/ddsi_gc.h
   ddsi_gcreq_new (ptr, ptr);
   ddsi_gcreq_free (ptr);
   ddsi_gcreq_enqueue (ptr);
   ddsi_gcreq_get_arg (ptr);
   ddsi_gcreq_set_arg (ptr, ptr2);
+
+  // ddsi/ddsi_typebuilder.h
+  ddsi_topic_descriptor_from_type (ptr, ptr2, ptr3);
+  ddsi_topic_descriptor_fini (ptr);
 
   // ddsrt/atomics.h
   ddsrt_atomic_ld32 (ptr);


### PR DESCRIPTION
Export some additional typebuilder and cdrstream functions that are used in python binding