### PR TITLE
Assorted minor fixes

### DIFF
--- a/src/ddsrt/include/dds/ddsrt/strtod.h
+++ b/src/ddsrt/include/dds/ddsrt/strtod.h
@@ -28,6 +28,15 @@ extern "C" {
 /**
  * @brief Convert a string to a double precision floating point number.
  *
+ * This operation handles locale specific manipulation of the floating point 
+ * string and then sets the output double based on the parsing via `strtod` 
+ * from the standard library. The function returns a failure iff:
+ * - the string to be parsed represents a value that is too large to store in a double.
+ * - the string contains junk.
+ * - the string parses to either `-nan` or `nan`.
+ * - the string parses to either `-inf` or `inf`.
+ * It is otherwise successful.
+ *
  * @param[in]   nptr    A string to convert into a double.
  * @param[out]  endptr  If not NULL, a char* where the address of first invalid
  *                      character is stored.

--- a/src/ddsrt/include/dds/ddsrt/strtod.h
+++ b/src/ddsrt/include/dds/ddsrt/strtod.h
@@ -39,19 +39,6 @@ dds_return_t
 ddsrt_strtod(const char *nptr, char **endptr, double *dblptr);
 
 /**
- * @brief Convert a string to a floating point number.
- *
- * @param[in]   nptr    A string to convert into a float.
- * @param[in]   endptr  If not NULL, a char* where the address of first invalid
- *                      character is stored.
- * @param[out]  fltptr  A float where the floating-point number is stored.
- *
- * @returns A dds_return_t indicating success or failure.
- */
-dds_return_t
-ddsrt_strtof(const char *nptr, char **endptr, float *fltptr);
-
-/**
  * @brief Convert a double-precision floating-point number to a string.
  *
  * @param[in]  src   Double-precision floating-point number to convert.

--- a/src/ddsrt/src/hopscotch.c
+++ b/src/ddsrt/src/hopscotch.c
@@ -313,7 +313,7 @@ static bool ddsrt_chh_data_valid_p (void *data)
     return data != NULL && data != CHH_BUSY;
 }
 
-static int ddsrt_chh_init (struct ddsrt_chh *rt, uint32_t init_size, ddsrt_hh_hash_fn hash, ddsrt_hh_equals_fn equals, ddsrt_hh_buckets_gc_fn gc_buckets, void *gc_buckets_arg)
+static void ddsrt_chh_init (struct ddsrt_chh *rt, uint32_t init_size, ddsrt_hh_hash_fn hash, ddsrt_hh_equals_fn equals, ddsrt_hh_buckets_gc_fn gc_buckets, void *gc_buckets_arg)
 {
     uint32_t size;
     uint32_t i;
@@ -338,7 +338,6 @@ static int ddsrt_chh_init (struct ddsrt_chh *rt, uint32_t init_size, ddsrt_hh_ha
         ddsrt_atomic_stvoidp (&b->data, NULL);
     }
     ddsrt_mutex_init (&rt->change_lock);
-    return 0;
 }
 
 static void ddsrt_chh_fini (struct ddsrt_chh *rt)
@@ -350,12 +349,8 @@ static void ddsrt_chh_fini (struct ddsrt_chh *rt)
 struct ddsrt_chh *ddsrt_chh_new (uint32_t init_size, ddsrt_hh_hash_fn hash, ddsrt_hh_equals_fn equals, ddsrt_hh_buckets_gc_fn gc_buckets, void *gc_buckets_arg)
 {
     struct ddsrt_chh *hh = ddsrt_malloc (sizeof (*hh));
-    if (ddsrt_chh_init (hh, init_size, hash, equals, gc_buckets, gc_buckets_arg) < 0) {
-        ddsrt_free (hh);
-        return NULL;
-    } else {
-        return hh;
-    }
+    ddsrt_chh_init (hh, init_size, hash, equals, gc_buckets, gc_buckets_arg);
+    return hh;
 }
 
 void ddsrt_chh_free (struct ddsrt_chh * __restrict hh)

--- a/src/ddsrt/src/hopscotch.c
+++ b/src/ddsrt/src/hopscotch.c
@@ -313,7 +313,7 @@ static bool ddsrt_chh_data_valid_p (void *data)
     return data != NULL && data != CHH_BUSY;
 }
 
-static void ddsrt_chh_init (struct ddsrt_chh *rt, uint32_t init_size, ddsrt_hh_hash_fn hash, ddsrt_hh_equals_fn equals, ddsrt_hh_buckets_gc_fn gc_buckets, void *gc_buckets_arg)
+static int ddsrt_chh_init (struct ddsrt_chh *rt, uint32_t init_size, ddsrt_hh_hash_fn hash, ddsrt_hh_equals_fn equals, ddsrt_hh_buckets_gc_fn gc_buckets, void *gc_buckets_arg)
 {
     uint32_t size;
     uint32_t i;
@@ -338,6 +338,7 @@ static void ddsrt_chh_init (struct ddsrt_chh *rt, uint32_t init_size, ddsrt_hh_h
         ddsrt_atomic_stvoidp (&b->data, NULL);
     }
     ddsrt_mutex_init (&rt->change_lock);
+    return 0;
 }
 
 static void ddsrt_chh_fini (struct ddsrt_chh *rt)
@@ -349,8 +350,12 @@ static void ddsrt_chh_fini (struct ddsrt_chh *rt)
 struct ddsrt_chh *ddsrt_chh_new (uint32_t init_size, ddsrt_hh_hash_fn hash, ddsrt_hh_equals_fn equals, ddsrt_hh_buckets_gc_fn gc_buckets, void *gc_buckets_arg)
 {
     struct ddsrt_chh *hh = ddsrt_malloc (sizeof (*hh));
-    ddsrt_chh_init (hh, init_size, hash, equals, gc_buckets, gc_buckets_arg);
-    return hh;
+    if (ddsrt_chh_init (hh, init_size, hash, equals, gc_buckets, gc_buckets_arg) < 0) {
+        ddsrt_free (hh);
+        return NULL;
+    } else {
+        return hh;
+    }
 }
 
 void ddsrt_chh_free (struct ddsrt_chh * __restrict hh)

--- a/src/ddsrt/src/retcode.c
+++ b/src/ddsrt/src/retcode.c
@@ -55,9 +55,11 @@ const char *dds_strretcode (dds_return_t ret)
   if (ret == INT32_MIN)
     return xretcodes[0];
 
+  // INT32_MIN has already been handled and so this is safe
+  // and will guarantee ret >= 0.
   if (ret < 0)
     ret = -ret;
-  if (ret >= 0 && ret < nretcodes)
+  if (ret < nretcodes)
     return retcodes[ret];
   else if (ret >= (-DDS_XRETCODE_BASE) && ret < (-DDS_XRETCODE_BASE) + nxretcodes)
     return xretcodes[ret - (-DDS_XRETCODE_BASE)];

--- a/src/ddsrt/src/strtod.c
+++ b/src/ddsrt/src/strtod.c
@@ -148,7 +148,7 @@ ddsrt_strtod(const char *nptr, char **endptr, double *dblptr)
     }
   }
 
-  if ((dbl == HUGE_VALF || dbl == HUGE_VALL || dbl == 0) && errno == ERANGE) {
+  if ((dbl == HUGE_VAL || dbl == 0) && errno == ERANGE) {
     ret = DDS_RETCODE_OUT_OF_RANGE;
   } else {
     errno = orig_errno;

--- a/src/ddsrt/src/strtod.c
+++ b/src/ddsrt/src/strtod.c
@@ -171,50 +171,6 @@ ddsrt_strtod(const char *nptr, char **endptr, double *dblptr)
   return ret;
 }
 
-dds_return_t
-ddsrt_strtof(const char *nptr, char **endptr, float *fltptr)
-{
-  float flt;
-  int orig_errno;
-  dds_return_t ret = DDS_RETCODE_OK;
-
-  assert(nptr != NULL);
-  assert(fltptr != NULL);
-
-  orig_errno = errno;
-  if (os_lcNumericGet() == '.') {
-    errno = 0;
-    /* The current locale uses '.', so strtof can be used as is. */
-    flt = strtof(nptr, endptr);
-  } else {
-    /* The current locale has to be normalized to use '.' for the floating
-       point string. */
-    char  nptrCopy[DOUBLE_STRING_MAX_LENGTH];
-    char *nptrCopyEnd = NULL;
-    delocalize_floating_point_str(nptr, nptrCopy, &nptrCopyEnd);
-
-    /* Now that we have a copy with the proper locale LC_NUMERIC, we can use
-       strtof() for the conversion. */
-    errno = 0;
-    flt = strtof(nptrCopy, &nptrCopyEnd);
-
-    /* Calculate the proper end char when needed. */
-    if (endptr != NULL) {
-      *endptr = (char*)nptr + (nptrCopyEnd - nptrCopy);
-    }
-  }
-
-  if ((flt == HUGE_VALF || flt == 0) && errno == ERANGE) {
-    ret = DDS_RETCODE_OUT_OF_RANGE;
-  } else {
-    errno = orig_errno;
-  }
-
-  *fltptr = flt;
-
-  return ret;
-}
-
 int
 ddsrt_dtostr(double src, char *str, size_t size)
 {

--- a/src/ddsrt/src/xmlparser.c
+++ b/src/ddsrt/src/xmlparser.c
@@ -404,7 +404,7 @@ static int append_to_payload (struct ddsrt_xmlp_state *st, int c)
   st->tpescp = st->tpp;
   if (append_literal_to_payload (st, c) < 0) {
     return -1;
-  };
+  }
   return 0;
 }
 

--- a/src/ddsrt/src/xmlparser.c
+++ b/src/ddsrt/src/xmlparser.c
@@ -396,12 +396,8 @@ static int append_to_payload (struct ddsrt_xmlp_state *st, int c)
     }
     st->tpp = st->tpescp + n;
   }
-  st->tp[st->tpp++] = (char) c;
+  append_literal_to_payload (st, c);
   st->tpescp = st->tpp;
-  if (st->tpp == st->tpsz) {
-    st->tpsz += 1024;
-    st->tp = ddsrt_realloc (st->tp, st->tpsz);
-  }
   return 0;
 }
 

--- a/src/ddsrt/src/xmlparser.c
+++ b/src/ddsrt/src/xmlparser.c
@@ -382,9 +382,11 @@ static dds_return_t append_literal_to_payload (struct ddsrt_xmlp_state *st, int 
   st->tp[st->tpp++] = (char) c;
   if (st->tpp == st->tpsz) {
     st->tpsz += 1024;
-    st->tp = ddsrt_realloc_s (st->tp, st->tpsz);
-    if (st->tp == NULL) {
+    void *tp_realloc = ddsrt_realloc_s (st->tp, st->tpsz);
+    if (tp_realloc == NULL) {
       return DDS_RETCODE_OUT_OF_RESOURCES;
+    } else {
+      st->tp = tp_realloc;
     }
   }
 


### PR DESCRIPTION
These are a set of assorted minor fixes primarily to reduce some checks in other functions guarding against impossible states.

I'm not certain about my (`strtof`, `strtod`) fixes because I'm not sure why the original `ddsrt_strtod` guarded against `HUGE_VALF` and `HUGE_VALL` and not `HUGE_VAL`?