### PR TITLE
Add typelib ifdefs in include files

### DIFF
--- a/src/core/ddsc/include/dds/ddsc/dds_public_dynamic_type.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_public_dynamic_type.h
@@ -15,6 +15,8 @@
 extern "C" {
 #endif
 
+#ifdef DDS_HAS_TYPELIB
+
 struct ddsi_typeinfo;
 
 /**
@@ -623,6 +625,8 @@ DDS_EXPORT dds_return_t dds_dynamic_type_unref (dds_dynamic_type_t *type);
  */
 DDS_EXPORT dds_dynamic_type_t dds_dynamic_type_dup (const dds_dynamic_type_t *src);
 
+
+#endif /* DDS_HAS_TYPELIB */
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsi/CMakeLists.txt
+++ b/src/core/ddsi/CMakeLists.txt
@@ -226,17 +226,6 @@ if(ENABLE_DEADLINE_MISSED)
     ddsi_deadline.h
   )
 endif()
-if(ENABLE_TYPELIB)
-  list(APPEND srcs_ddsi
-    ddsi_typelib.c
-  )
-  list(APPEND hdrs_ddsi
-    ddsi_typelib.h
-  )
-  list(APPEND hdrs_private_ddsi
-    ddsi__typelib.h
-  )
-endif()
 if(ENABLE_TOPIC_DISCOVERY)
   list(APPEND srcs_ddsi
     ddsi_discovery_topic.c
@@ -249,6 +238,7 @@ if(ENABLE_TYPELIB)
   list(APPEND srcs_ddsi
     ddsi_xt_typeinfo.c
     ddsi_xt_typemap.c
+    ddsi_typelib.c
     ddsi_typewrap.c
     ddsi_typebuilder.c
     ddsi_dynamic_type.c
@@ -256,12 +246,14 @@ if(ENABLE_TYPELIB)
   list(APPEND hdrs_ddsi
     ddsi_xt_typeinfo.h
     ddsi_xt_typemap.h
+    ddsi_typelib.h
     ddsi_typewrap.h
     ddsi_typebuilder.h
     ddsi_dynamic_type.h
   )
   list(APPEND hdrs_private_ddsi
     ddsi__xt_impl.h
+    ddsi__typelib.h
     ddsi__dynamic_type.h
   )
 endif()

--- a/src/core/ddsi/include/dds/ddsi/ddsi_dynamic_type.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_dynamic_type.h
@@ -21,6 +21,8 @@
 extern "C" {
 #endif
 
+#ifdef DDS_HAS_TYPELIB
+
 struct ddsi_dynamic_type_struct_member_param {
   uint32_t id;
   const char *name;
@@ -130,6 +132,8 @@ struct ddsi_type * ddsi_dynamic_type_dup (const struct ddsi_type *src);
 
 /** @component dynamic_type_support */
 bool ddsi_dynamic_type_is_constructing (const struct ddsi_type *type);
+
+#endif /* DDS_HAS_TYPELIB */
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsi/include/dds/ddsi/ddsi_typebuilder.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_typebuilder.h
@@ -22,11 +22,15 @@
 extern "C" {
 #endif
 
+#ifdef DDS_HAS_TYPELIB
+
 /** @component dynamic_types */
 DDS_EXPORT dds_return_t ddsi_topic_descriptor_from_type (struct ddsi_domaingv *gv, dds_topic_descriptor_t *desc, const struct ddsi_type *type);
 
 /** @component dynamic_types */
 DDS_EXPORT void ddsi_topic_descriptor_fini (dds_topic_descriptor_t *desc);
+
+#endif /* DDS_HAS_TYPELIB */
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsi/include/dds/ddsi/ddsi_typelib.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_typelib.h
@@ -25,6 +25,8 @@
 extern "C" {
 #endif
 
+#ifdef DDS_HAS_TYPELIB
+
 struct ddsi_domaingv;
 struct ddsi_sertype;
 struct ddsi_type;
@@ -140,6 +142,8 @@ DDS_EXPORT struct ddsi_type * ddsi_type_lookup (struct ddsi_domaingv *gv, const 
  *
  */
 DDS_EXPORT int ddsi_type_compare (const struct ddsi_type *a, const struct ddsi_type *b);
+
+#endif /* DDS_HAS_TYPELIB */
 
 #if defined (__cplusplus)
 }

--- a/src/core/xtests/symbol_export/symbol_export.c
+++ b/src/core/xtests/symbol_export/symbol_export.c
@@ -696,9 +696,11 @@ int main (int argc, char **argv)
   ddsi_gcreq_get_arg (ptr);
   ddsi_gcreq_set_arg (ptr, ptr2);
 
+#ifdef DDS_HAS_TYPELIB
   // ddsi/ddsi_typebuilder.h
   ddsi_topic_descriptor_from_type (ptr, ptr2, ptr3);
   ddsi_topic_descriptor_fini (ptr);
+#endif
 
   // ddsrt/atomics.h
   ddsrt_atomic_ld32 (ptr);


### PR DESCRIPTION
This adds `#ifdef`s in include files that are only available when building with the type library enabled. Required because the current cmake scripts unconditionally include all header files in the installation directory.