### PR TITLE
Fix duplicate condition in validate_remote_identity

### DIFF
--- a/src/security/builtin_plugins/tests/listeners_authentication/src/listeners_authentication_utests.c
+++ b/src/security/builtin_plugins/tests/listeners_authentication/src/listeners_authentication_utests.c
@@ -1,3 +1,13 @@
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 /** @file qos_utests.c
  *  @brief Unit tests for qos APIs
  *

--- a/src/security/builtin_plugins/tests/process_handshake/src/process_handshake_utests.c
+++ b/src/security/builtin_plugins/tests/process_handshake/src/process_handshake_utests.c
@@ -1,3 +1,13 @@
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>

--- a/src/security/builtin_plugins/tests/validate_begin_handshake_reply/src/validate_begin_handshake_reply_utests.c
+++ b/src/security/builtin_plugins/tests/validate_begin_handshake_reply/src/validate_begin_handshake_reply_utests.c
@@ -1,3 +1,13 @@
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>

--- a/src/security/builtin_plugins/tests/validate_begin_handshake_request/src/validate_begin_handshake_request_utests.c
+++ b/src/security/builtin_plugins/tests/validate_begin_handshake_request/src/validate_begin_handshake_request_utests.c
@@ -1,6 +1,12 @@
-
-
-
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /* CUnit includes. */
 #include "dds/security/dds_security_api.h"

--- a/src/security/builtin_plugins/tests/validate_local_identity/src/validate_local_identity_utests.c
+++ b/src/security/builtin_plugins/tests/validate_local_identity/src/validate_local_identity_utests.c
@@ -1,3 +1,13 @@
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 /** @file qos_utests.c
  *  @brief Unit tests for qos APIs
  *

--- a/src/security/builtin_plugins/tests/validate_remote_identity/src/validate_remote_identity_utests.c
+++ b/src/security/builtin_plugins/tests/validate_remote_identity/src/validate_remote_identity_utests.c
@@ -1,3 +1,12 @@
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 #include "dds/security/dds_security_api.h"
 #include "dds/security/core/dds_security_serialize.h"
@@ -324,7 +333,6 @@ check_auth_request_token(
         if ((strlen(token->class_id) != 0)             ||
             (token->properties._length != 0)           ||
             (token->properties._maximum != 0)          ||
-            (token->binary_properties._buffer != NULL) ||
             (token->binary_properties._length != 0)    ||
             (token->binary_properties._maximum != 0)   ||
             (token->binary_properties._buffer != NULL) ) {


### PR DESCRIPTION
Fix duplicate condition in `validate_remote_identity` test and add some missing copyright headers in security plugin tests