### PR TITLE
Fixes in typebuilder

### DIFF
--- a/src/core/ddsc/tests/TypeBuilderTypes.idl
+++ b/src/core/ddsc/tests/TypeBuilderTypes.idl
@@ -399,8 +399,10 @@ module TypeBuilderTypes {
     t27_1 f1;
   };
 
-  /* unbounded string key */
+  /* bounded and unbounded string key */
   struct t28 {
     @key string f1;
+    @key string<3> f2;
   };
+
 };


### PR DESCRIPTION
This fixes some issues in typebuilder:
- A use-after-free in case building a specific type fails (fixed by removing `typebuilder_type_fini` calls in error handling, because eventually the types are freed in `typebuilder_data_free`)
- Bounded strings should be accepted as type for a key member

Additionally, a few return-type checks are added and updated. 