### PR TITLE
add missing DDS_EXPORT in ddsi_sertype.c

### DIFF
--- a/src/core/ddsi/src/ddsi_sertype.c
+++ b/src/core/ddsi/src/ddsi_sertype.c
@@ -298,5 +298,5 @@ DDS_EXPORT extern inline ddsi_typemap_t * ddsi_sertype_typemap (const struct dds
 DDS_EXPORT extern inline ddsi_typeinfo_t * ddsi_sertype_typeinfo (const struct ddsi_sertype *tp);
 DDS_EXPORT extern inline struct ddsi_sertype * ddsi_sertype_derive_sertype (const struct ddsi_sertype *base_sertype, dds_data_representation_id_t data_representation, dds_type_consistency_enforcement_qospolicy_t tce_qos);
 
-extern inline size_t ddsi_sertype_get_serialized_size(const struct ddsi_sertype *tp, const void *sample);
-extern inline bool ddsi_sertype_serialize_into(const struct ddsi_sertype *tp, const void *sample, void *dst_buffer, size_t dst_size);
+DDS_EXPORT extern inline size_t ddsi_sertype_get_serialized_size(const struct ddsi_sertype *tp, const void *sample);
+DDS_EXPORT extern inline bool ddsi_sertype_serialize_into(const struct ddsi_sertype *tp, const void *sample, void *dst_buffer, size_t dst_size);


### PR DESCRIPTION
Without these exports, cyclone build fails on Windows 10 with MinGW on the symbol_export_test.