### PR TITLE
Add CI build for Python and C++ bindings

### DIFF
--- a/.azure/templates/cxx-binding.yml
+++ b/.azure/templates/cxx-binding.yml
@@ -1,0 +1,64 @@
+#
+# Copyright(c) 2023 ZettaScale Technology and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+
+steps:
+  - bash: |
+      sudo apt install -y clang clang-tools clang-tidy libboost-dev
+    name: setup_linux
+    displayName: Setup Linux
+  - bash: |
+      git clone --depth 1 --branch release-1.12.1 https://github.com/google/googletest.git
+      mkdir googletest/build
+      cd googletest/build
+      cmake -DCMAKE_INSTALL_PREFIX=install -DBUILD_SHARED_LIBS=on ..
+      cmake --build . --config $BUILD_TYPE --target install -- -j 4
+    name: setup_googletest
+    displayName: Setup Google Test
+  - bash: |
+      set -e -x
+      mkdir build
+      cd build
+      cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+            -DCMAKE_INSTALL_PREFIX=install \
+            -DENABLE_SSL=off \
+            -DENABLE_SECURITY=off \
+            -DBUILD_TESTING=off \
+            -DBUILD_IDLC_XTESTS=off \
+            -DBUILD_EXAMPLES=off \
+            -DWERROR=on \
+            ..
+      cmake --build . --config $BUILD_TYPE --target install -- -j 4
+    name: build_cyclonedds_c
+    displayName: Build Cyclone C
+  - bash: |
+      git clone https://github.com/eclipse-cyclonedds/cyclonedds-cxx.git cyclonedds_cxx --branch master
+    name: clone_cyclonedds_cxx
+    displayName: Clone Cyclone C++
+  - bash: |
+      set -e -x
+      mkdir cyclonedds_cxx/build
+      cd cyclonedds_cxx/build
+      cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+            -DCMAKE_INSTALL_PREFIX=install \
+            -DCMAKE_PREFIX_PATH="$BUILD_SOURCESDIRECTORY/build/install;$BUILD_SOURCESDIRECTORY/googletest/build/install" \
+            -DBUILD_TESTING=on \
+            -DBUILD_EXAMPLES=on \
+            -DWERROR=on \
+            ..
+      cmake --build . --config $BUILD_TYPE --target install -- -j 4
+    name: build_cyclonedds_cxx
+    displayName: Build Cyclone C++
+  - bash: |
+      cd cyclonedds_cxx/build
+      ctest -j 4 --output-on-failure --schedule-random
+    name: test_cyclonedds_cxx
+    displayName: Run Cyclone C++ tests

--- a/.azure/templates/python-binding.yml
+++ b/.azure/templates/python-binding.yml
@@ -1,0 +1,63 @@
+#
+# Copyright(c) 2023 ZettaScale Technology and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+
+steps:
+  - bash: |
+      sudo apt install -y clang clang-tools clang-tidy
+    name: setup_linux
+    displayName: Setup Linux
+  - bash: |
+      set -e -x
+      mkdir build
+      cd build
+      cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+            -DCMAKE_INSTALL_PREFIX=install \
+            -DENABLE_SSL=off \
+            -DENABLE_SECURITY=off \
+            -DBUILD_TESTING=off \
+            -DBUILD_IDLC_XTESTS=off \
+            -DBUILD_EXAMPLES=off \
+            -DWERROR=on \
+            ..
+      cmake --build . --config $BUILD_TYPE --target install -- -j 4
+    name: build_cyclonedds_c
+    displayName: Build Cyclone C
+  - bash: |
+      git clone https://github.com/eclipse-cyclonedds/cyclonedds-python.git cyclonedds_python --branch master
+    name: clone_cyclonedds_py
+    displayName: Clone the Python binding
+  - bash: |
+      set -e -x
+      export CYCLONEDDS_HOME=$BUILD_SOURCESDIRECTORY/build/install
+      export PATH=$PATH:$CYCLONEDDS_HOME/bin
+      python -m pip install --user --upgrade pip wheel setuptools
+      python -m pip install --user --upgrade pytest-azurepipelines
+      python -m pip install --user ./cyclonedds_python[dev]
+    name: install_cyclonedds_py
+    displayName: Install Python binding
+  - bash: |
+      cd cyclonedds_python/tests
+      python -m pytest .. -vv --no-coverage-upload --color=yes
+    name: test_cyclonedds_py
+    displayName: Run Python tests
+  - bash: |
+      set -e -x
+      export CYCLONEDDS_HOME=$BUILD_SOURCESDIRECTORY/build/install
+      export PATH=$PATH:$CYCLONEDDS_HOME/bin
+      export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CYCLONEDDS_HOME/lib
+      export CYCLONEDDS_URI=
+      export RSEED=$(shuf -i 1-100000 -n 1)
+      cd cyclonedds_python/tests
+      echo "Random seed used: $RSEED"
+      python -m pytest .. -vv --no-coverage-upload --color=yes -k fuzzy --fuzzing num_types=100 type_seed=$RSEED -s
+    name: test_cyclonedds_py_fuzzing
+    displayName: Run Python fuzzing tests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,8 @@ variables:
   cyclonedds_uri: '<CycloneDDS><Domain><Internal><EnableExpensiveChecks>rhc,whc</EnableExpensiveChecks><LivelinessMonitoring>true</LivelinessMonitoring></Internal><Tracing><Verbosity>config</Verbosity><OutputFile>stderr</OutputFile></Tracing></Domain></CycloneDDS>'
 
 jobs:
-- job: BuildAndTest
+- job: build_and_test
+  displayName: Build and test Cyclone
   pool:
     vmImage: $(image)
   strategy:
@@ -142,8 +143,9 @@ jobs:
   steps:
     - template: /.azure/templates/build-test.yml
 
-- job: CoverageAndTestsReport
-  dependsOn: BuildAndTest
+- job: coverage_and_test_report
+  displayName: Coverage and Tests Report
+  dependsOn: build_and_test
   condition: succeededOrFailed()  # Always run, even when failed tests, because they should be reported in the dasboard of course!
   pool:
     vmImage: ubuntu-20.04
@@ -165,3 +167,29 @@ jobs:
     inputs:
       codeCoverageTool: Cobertura
       summaryFileLocation: coverage.xml
+
+- job: python_binding
+  displayName: Python Binding
+  pool:
+    vmImage: $(image)
+  strategy:
+    matrix:
+      'Test and fuzzing (Ubuntu 22.04 LTS, Clang 12, Debug)':
+        image: ubuntu-22.04
+        cc: clang-12
+        build_type: Debug
+  steps:
+    - template: /.azure/templates/python-binding.yml
+
+- job: cxx_binding
+  displayName: C++ Binding
+  pool:
+    vmImage: $(image)
+  strategy:
+    matrix:
+      'Build and test (Ubuntu 22.04 LTS, Clang 12, Debug)':
+        image: ubuntu-22.04
+        cc: clang-12
+        build_type: Debug
+  steps:
+    - template: /.azure/templates/cxx-binding.yml


### PR DESCRIPTION
This PR adds CI builds for the Python and C++ bindings. This enables detection of incompatibilities with language bindings (e.g. because of changes in the (internal) API used by these bindings). Both CI jobs include running the binding's tests, and the Python fuzzer tests are also included. 
