### PR TITLE
Fix cdrstream bug for union types

### DIFF
--- a/src/core/cdr/src/dds_cdrstream.c
+++ b/src/core/cdr/src/dds_cdrstream.c
@@ -1707,9 +1707,6 @@ static const uint32_t *dds_stream_read_uni (dds_istream_t * __restrict is, char 
 
 static void dds_stream_alloc_external (const uint32_t * __restrict ops, uint32_t insn, void ** addr, const struct dds_cdrstream_allocator * __restrict allocator, enum sample_data_state * sample_state)
 {
-  /* Allocate memory for @external member. This memory must be initialized to 0,
-      because the type may contain sequences that need to have 0 index/size
-      or external fields that need to be initialized to null */
   uint32_t sz = get_adr_type_size (insn, ops);
   if (*sample_state != SAMPLE_DATA_INITIALIZED || *((char **) *addr) == NULL)
   {

--- a/src/core/cdr/src/dds_cdrstream.c
+++ b/src/core/cdr/src/dds_cdrstream.c
@@ -111,8 +111,22 @@ enum cdr_data_kind {
   CDR_KIND_KEY
 };
 
+/**
+ * @brief Indicates if the sample data is initialized
+ *
+ * While deserializing a key or sample, the sample data state is passed in recursive
+ * calls to read functions. This state indicates if the sample data for the current
+ * scope is initialized or uninitialized. When the state is uninitialized, the
+ * sample data within the current scope may not be read. See also the comment in
+ * @ref stream_union_switch_case.
+ */
+enum sample_data_state {
+  SAMPLE_DATA_INITIALIZED,
+  SAMPLE_DATA_UNINITIALIZED
+};
+
 static const uint32_t *dds_stream_skip_adr (uint32_t insn, const uint32_t * __restrict ops);
-static const uint32_t *dds_stream_skip_default (char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops);
+static const uint32_t *dds_stream_skip_default (char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, enum sample_data_state sample_state);
 static const uint32_t *dds_stream_extract_key_from_data1 (dds_istream_t * __restrict is, dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator,
   const uint32_t * const __restrict op0, const uint32_t * __restrict ops, bool mutable_member, bool mutable_member_or_parent,
   uint32_t n_keys, uint32_t * __restrict keys_remaining);
@@ -120,10 +134,11 @@ static const uint32_t *dds_stream_extract_keyBE_from_data1 (dds_istream_t * __re
   const uint32_t * const __restrict op0, const uint32_t * __restrict ops, bool mutable_member, bool mutable_member_or_parent,
   uint32_t n_keys, uint32_t * __restrict keys_remaining);
 static const uint32_t *stream_normalize_data_impl (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t * __restrict ops, bool is_mutable_member, enum cdr_data_kind cdr_kind) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
-static const uint32_t *dds_stream_read_impl (dds_istream_t * __restrict is, char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, bool is_mutable_member, enum cdr_data_kind cdr_kind);
+static const uint32_t *dds_stream_read_impl (dds_istream_t * __restrict is, char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, bool is_mutable_member, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state);
 static const uint32_t *stream_free_sample_adr (uint32_t insn, void * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops);
-static const uint32_t *dds_stream_skip_adr_default (uint32_t insn, char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops);
+static const uint32_t *dds_stream_skip_adr_default (uint32_t insn, char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, enum sample_data_state sample_state);
 static const uint32_t *dds_stream_key_size (const uint32_t * __restrict ops, struct key_props *k);
+static const uint32_t *dds_stream_free_sample_uni (char * __restrict discaddr, char * __restrict baseaddr, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, uint32_t insn);
 
 static const uint32_t *dds_stream_write_implLE (dds_ostreamLE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict data, const uint32_t * __restrict ops, bool is_mutable_member, enum cdr_data_kind cdr_kind);
 static const uint32_t *dds_stream_write_implBE (dds_ostreamBE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict data, const uint32_t * __restrict ops, bool is_mutable_member, enum cdr_data_kind cdr_kind);
@@ -891,17 +906,20 @@ uint32_t dds_stream_countops (const uint32_t * __restrict ops, uint32_t nkeys, c
   return (uint32_t) (ops_end - ops);
 }
 
-static char *dds_stream_reuse_string_bound (dds_istream_t * __restrict is, char * __restrict str, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t size, bool alloc)
+static char *dds_stream_reuse_string_bound (dds_istream_t * __restrict is, char * __restrict str, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t size, bool alloc, enum sample_data_state sample_state)
 {
   const uint32_t length = dds_is_get4 (is);
   const void *src = is->m_buffer + is->m_index;
   /* FIXME: validation now rejects data containing an oversize bounded string,
      so this check is superfluous, but perhaps rejecting such a sample is the
      wrong thing to do */
-  if (!alloc)
-    assert (str != NULL);
-  else if (str == NULL)
-    str = allocator->malloc (size);
+  if (sample_state == SAMPLE_DATA_INITIALIZED)
+  {
+    if (!alloc)
+      assert (str != NULL);
+    else if (str == NULL)
+      str = allocator->malloc (size);
+  }
   memcpy (str, src, length > size ? size : length);
   if (length > size)
     str[size - 1] = '\0';
@@ -909,21 +927,23 @@ static char *dds_stream_reuse_string_bound (dds_istream_t * __restrict is, char 
   return str;
 }
 
-static char *dds_stream_reuse_string (dds_istream_t * __restrict is, char * __restrict str, const struct dds_cdrstream_allocator * __restrict allocator)
+static char *dds_stream_reuse_string (dds_istream_t * __restrict is, char * __restrict str, const struct dds_cdrstream_allocator * __restrict allocator, enum sample_data_state sample_state)
 {
   const uint32_t length = dds_is_get4 (is);
   const void *src = is->m_buffer + is->m_index;
-  if (str == NULL || strlen (str) + 1 < length)
-    str = allocator->realloc (str, length);
+  if (sample_state == SAMPLE_DATA_INITIALIZED && str != NULL)
+    allocator->free (str);
+  str = allocator->malloc (length);
   memcpy (str, src, length);
   is->m_index += length;
   return str;
 }
 
-static char *dds_stream_reuse_string_empty (char * __restrict str, const struct dds_cdrstream_allocator * __restrict allocator)
+static char *dds_stream_reuse_string_empty (char * __restrict str, const struct dds_cdrstream_allocator * __restrict allocator, enum sample_data_state sample_state)
 {
-  if (str == NULL)
-    str = allocator->realloc (str, 1);
+  if (sample_state == SAMPLE_DATA_INITIALIZED && str != NULL)
+    allocator->free (str);
+  str = allocator->malloc (1);
   str[0] = '\0';
   return str;
 }
@@ -1054,7 +1074,7 @@ static const uint32_t *skip_array_insns (uint32_t insn, const uint32_t * __restr
   return NULL;
 }
 
-static const uint32_t *skip_array_default (uint32_t insn, char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops)
+static const uint32_t *skip_array_default (uint32_t insn, char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, enum sample_data_state sample_state)
 {
   const enum dds_stream_typecode subtype = DDS_OP_SUBTYPE (insn);
   const uint32_t num = ops[2];
@@ -1073,7 +1093,7 @@ static const uint32_t *skip_array_default (uint32_t insn, char * __restrict data
     case DDS_OP_VAL_STR: {
       char **ptr = (char **) data;
       for (uint32_t i = 0; i < num; i++)
-        ptr[i] = dds_stream_reuse_string_empty (ptr[i], allocator);
+        ptr[i] = dds_stream_reuse_string_empty (ptr[i], allocator, sample_state);
       return ops + 3;
     }
     case DDS_OP_VAL_BST: {
@@ -1088,7 +1108,7 @@ static const uint32_t *skip_array_default (uint32_t insn, char * __restrict data
       const uint32_t jmp = DDS_OP_ADR_JMP (ops[3]);
       const uint32_t elem_size = ops[4];
       for (uint32_t i = 0; i < num; i++)
-        (void) dds_stream_skip_default (data + i * elem_size, allocator, jsr_ops);
+        (void) dds_stream_skip_default (data + i * elem_size, allocator, jsr_ops, sample_state);
       return ops + (jmp ? jmp : 5);
     }
     case DDS_OP_VAL_EXT: {
@@ -1099,30 +1119,64 @@ static const uint32_t *skip_array_default (uint32_t insn, char * __restrict data
   return NULL;
 }
 
-static const uint32_t *skip_union_default (uint32_t insn, char * __restrict discaddr, char * __restrict baseaddr, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops)
+static inline uint32_t const * stream_union_switch_case (uint32_t insn, uint32_t disc, char * __restrict discaddr, char * __restrict baseaddr, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, enum sample_data_state *sample_state)
 {
+  /* Switching union cases causes big trouble if some cases have sequences or strings,
+     and other cases have other things mapped to those addresses.  So, pretend to be
+     nice by freeing whatever was allocated, and set the sample data state to UNINITIALIZED.
+     This will make any preallocated buffers go to waste, but it does allow reusing the message
+     from read-to-read, at the somewhat reasonable price of a slower deserialization. */
+  if (*sample_state == SAMPLE_DATA_INITIALIZED)
+  {
+    dds_stream_free_sample_uni (discaddr, baseaddr, allocator, ops, insn);
+    *sample_state = SAMPLE_DATA_UNINITIALIZED;
+  }
+
   switch (DDS_OP_SUBTYPE (insn))
   {
-    case DDS_OP_VAL_BLN: case DDS_OP_VAL_1BY: *((uint8_t *) discaddr) = 0; break;
-    case DDS_OP_VAL_2BY: *((uint16_t *) discaddr) = 0; break;
-    case DDS_OP_VAL_4BY: case DDS_OP_VAL_ENU: *((uint32_t *) discaddr) = 0; break;
+    case DDS_OP_VAL_BLN: case DDS_OP_VAL_1BY: *((uint8_t *) discaddr) = (uint8_t) disc; break;
+    case DDS_OP_VAL_2BY: *((uint16_t *) discaddr) = (uint16_t) disc; break;
+    case DDS_OP_VAL_4BY: case DDS_OP_VAL_ENU: *((uint32_t *) discaddr) = disc; break;
     default: break;
   }
-  uint32_t const * const jeq_op = find_union_case (ops, 0);
+
+  return find_union_case (ops, disc);
+}
+
+static void dds_stream_union_member_alloc_external (uint32_t const * const jeq_op, const enum dds_stream_typecode valtype, void ** valaddr, const struct dds_cdrstream_allocator * __restrict allocator, enum sample_data_state *sample_state)
+{
+  assert (DDS_OP (jeq_op[0]) == DDS_OP_JEQ4);
+  if (*sample_state != SAMPLE_DATA_INITIALIZED || *((char **) *valaddr) == NULL)
+  {
+    uint32_t sz = get_jeq4_type_size (valtype, jeq_op);
+    *((char **) *valaddr) = allocator->malloc (sz);
+    *sample_state = SAMPLE_DATA_UNINITIALIZED;
+  }
+  *valaddr = *((char **) *valaddr);
+}
+
+static const uint32_t * skip_union_default (uint32_t insn, char * __restrict discaddr, char * __restrict baseaddr, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, enum sample_data_state sample_state)
+{
+  const uint32_t disc = 0;
+  uint32_t const * const jeq_op = stream_union_switch_case (insn, disc, discaddr, baseaddr, allocator, ops, &sample_state);
   ops += DDS_OP_ADR_JMP (ops[3]);
   if (jeq_op)
   {
     const enum dds_stream_typecode valtype = DDS_JEQ_TYPE (jeq_op[0]);
     void *valaddr = baseaddr + jeq_op[2];
+
+    if (op_type_external (jeq_op[0]))
+      dds_stream_union_member_alloc_external (jeq_op, valtype, &valaddr, allocator, &sample_state);
+
     switch (valtype)
     {
       case DDS_OP_VAL_BLN: case DDS_OP_VAL_1BY: *((uint8_t *) valaddr) = 0; break;
       case DDS_OP_VAL_2BY: *((uint16_t *) valaddr) = 0; break;
       case DDS_OP_VAL_4BY: case DDS_OP_VAL_ENU: *((uint32_t *) valaddr) = 0; break;
       case DDS_OP_VAL_8BY: *((uint64_t *) valaddr) = 0; break;
-      case DDS_OP_VAL_STR: *(char **) valaddr = dds_stream_reuse_string_empty (*((char **) valaddr), allocator); break;
+      case DDS_OP_VAL_STR: *(char **) valaddr = dds_stream_reuse_string_empty (*((char **) valaddr), allocator, sample_state); break;
       case DDS_OP_VAL_BST: case DDS_OP_VAL_SEQ: case DDS_OP_VAL_BSQ: case DDS_OP_VAL_ARR: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU: case DDS_OP_VAL_BMK:
-        (void) dds_stream_skip_default (valaddr, allocator, jeq_op + DDS_OP_ADR_JSR (jeq_op[0]));
+        (void) dds_stream_skip_default (valaddr, allocator, jeq_op + DDS_OP_ADR_JSR (jeq_op[0]), sample_state);
         break;
       case DDS_OP_VAL_EXT: {
         abort (); /* not supported */
@@ -1359,31 +1413,74 @@ const uint32_t * dds_stream_write_with_byte_order (dds_ostream_t * __restrict os
     return dds_stream_write (os, allocator, data, ops);
 }
 
-static void realloc_sequence_buffer_if_needed (dds_sequence_t * __restrict seq, const struct dds_cdrstream_allocator * __restrict allocator, uint32_t num, uint32_t elem_size, bool init)
+/**
+ * Sequences of types that possibly contain pointers are maintained in initialized form for all
+ * allocated entries (i.e., up to _maximum), not just the occupied ones (i.e., up to _length).
+ * This way there is no need to free any previously allocated memory when reusing the buffer
+ * for a shorter sequence.
+ *
+ * The argument is that when the samples/buffers do get reused from one call to read() to the
+ * next for complex types, this should reduce the number of memory allocations/frees and save
+ * the cost of freeing the elements. The downside is higher memory usage, which the application
+ * can avoid by using its buffers in a slightly different way, and the additional memcpy/memset
+ * on realloc, but those operations are usually cheaper than trying to free the sample.
+ */
+static inline void adjust_sequence_buffer_initialize (dds_sequence_t * __restrict seq, const struct dds_cdrstream_allocator * __restrict allocator, uint32_t num, uint32_t elem_size, enum sample_data_state *sample_state)
 {
   const uint32_t size = num * elem_size;
+  bool malloc = true;
 
-  /* maintain max sequence length (may not have been set by caller) */
-  if (seq->_length > seq->_maximum)
-    seq->_maximum = seq->_length;
-
-  if (num > seq->_maximum && seq->_release)
+  if (*sample_state == SAMPLE_DATA_INITIALIZED)
   {
-    seq->_buffer = allocator->realloc (seq->_buffer, size);
-    if (init)
+    /* maintain max sequence length (may not have been set by caller) */
+    if (seq->_length > seq->_maximum)
+      seq->_maximum = seq->_length;
+
+    if (num > seq->_maximum && seq->_release)
     {
+      malloc = false;
+      seq->_buffer = allocator->realloc (seq->_buffer, size);
       const uint32_t off = seq->_maximum * elem_size;
       memset (seq->_buffer + off, 0, size - off);
+      seq->_maximum = num;
     }
-    seq->_maximum = num;
+    else if (num == 0 || seq->_maximum > 0)
+      malloc = false;
   }
-  else if (num > 0 && seq->_maximum == 0)
+  else
+    *sample_state = SAMPLE_DATA_INITIALIZED;
+
+  if (malloc)
   {
     seq->_buffer = allocator->malloc (size);
-    if (init)
-      memset (seq->_buffer, 0, size);
+    memset (seq->_buffer, 0, size);
     seq->_release = true;
     seq->_maximum = num;
+  }
+}
+
+static inline void adjust_sequence_buffer (dds_sequence_t * __restrict seq, const struct dds_cdrstream_allocator * __restrict allocator, uint32_t num, uint32_t elem_size, enum sample_data_state *sample_state)
+{
+  const uint32_t size = num * elem_size;
+  bool malloc = true;
+  if (*sample_state == SAMPLE_DATA_INITIALIZED)
+  {
+    /* maintain max sequence length (may not have been set by caller) */
+    if (seq->_length > seq->_maximum)
+      seq->_maximum = seq->_length;
+
+    if (num > seq->_maximum && seq->_release)
+      allocator->free (seq->_buffer);
+    else if (num == 0 || seq->_maximum > 0)
+      malloc = false;
+  }
+
+  if (malloc)
+  {
+    seq->_buffer = allocator->malloc (size);
+    seq->_maximum = num;
+    seq->_release = true;
+    *sample_state = SAMPLE_DATA_UNINITIALIZED;
   }
 }
 
@@ -1392,7 +1489,7 @@ static bool stream_is_member_present (uint32_t insn, dds_istream_t * __restrict 
   return !op_type_optional (insn) || is_mutable_member || dds_is_get1 (is);
 }
 
-static const uint32_t *dds_stream_read_seq (dds_istream_t * __restrict is, char * __restrict addr, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, uint32_t insn, enum cdr_data_kind cdr_kind)
+static const uint32_t *dds_stream_read_seq (dds_istream_t * __restrict is, char * __restrict addr, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, uint32_t insn, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
 {
   dds_sequence_t * const seq = (dds_sequence_t *) addr;
   const enum dds_stream_typecode subtype = DDS_OP_SUBTYPE (insn);
@@ -1406,6 +1503,12 @@ static const uint32_t *dds_stream_read_seq (dds_istream_t * __restrict is, char 
   const uint32_t num = dds_is_get4 (is);
   if (num == 0)
   {
+    if (sample_state == SAMPLE_DATA_UNINITIALIZED)
+    {
+      seq->_buffer = NULL;
+      seq->_maximum = 0;
+      seq->_release = true;
+    }
     seq->_length = 0;
     return skip_sequence_insns (insn, ops);
   }
@@ -1414,7 +1517,7 @@ static const uint32_t *dds_stream_read_seq (dds_istream_t * __restrict is, char 
   {
     case DDS_OP_VAL_BLN: case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY: {
       const uint32_t elem_size = get_primitive_size (subtype);
-      realloc_sequence_buffer_if_needed (seq, allocator, num, elem_size, false);
+      adjust_sequence_buffer (seq, allocator, num, elem_size, &sample_state);
       seq->_length = (num <= seq->_maximum) ? num : seq->_maximum;
       dds_is_get_bytes (is, seq->_buffer, seq->_length, elem_size);
       if (seq->_length < num)
@@ -1423,7 +1526,7 @@ static const uint32_t *dds_stream_read_seq (dds_istream_t * __restrict is, char 
     }
     case DDS_OP_VAL_ENU: {
       const uint32_t elem_size = DDS_OP_TYPE_SZ (insn);
-      realloc_sequence_buffer_if_needed (seq, allocator, num, 4, false);
+      adjust_sequence_buffer (seq, allocator, num, 4, &sample_state);
       seq->_length = (num <= seq->_maximum) ? num : seq->_maximum;
       switch (elem_size)
       {
@@ -1445,7 +1548,7 @@ static const uint32_t *dds_stream_read_seq (dds_istream_t * __restrict is, char 
     }
     case DDS_OP_VAL_BMK: {
       const uint32_t elem_size = DDS_OP_TYPE_SZ (insn);
-      realloc_sequence_buffer_if_needed (seq, allocator, num, elem_size, false);
+      adjust_sequence_buffer (seq, allocator, num, elem_size, &sample_state);
       seq->_length = (num <= seq->_maximum) ? num : seq->_maximum;
       dds_is_get_bytes (is, seq->_buffer, seq->_length, elem_size);
       if (seq->_length < num)
@@ -1453,22 +1556,22 @@ static const uint32_t *dds_stream_read_seq (dds_istream_t * __restrict is, char 
       return ops + 4 + bound_op;
     }
     case DDS_OP_VAL_STR: {
-      realloc_sequence_buffer_if_needed (seq, allocator, num, sizeof (char *), true);
+      adjust_sequence_buffer_initialize (seq, allocator, num, sizeof (char *), &sample_state);
       seq->_length = (num <= seq->_maximum) ? num : seq->_maximum;
       char **ptr = (char **) seq->_buffer;
       for (uint32_t i = 0; i < seq->_length; i++)
-        ptr[i] = dds_stream_reuse_string (is, ptr[i], allocator);
+        ptr[i] = dds_stream_reuse_string (is, ptr[i], allocator, sample_state);
       for (uint32_t i = seq->_length; i < num; i++)
         dds_stream_skip_string (is);
       return ops + 2 + bound_op;
     }
     case DDS_OP_VAL_BST: {
       const uint32_t elem_size = ops[2 + bound_op];
-      realloc_sequence_buffer_if_needed (seq, allocator, num, elem_size, false);
+      adjust_sequence_buffer (seq, allocator, num, elem_size, &sample_state);
       seq->_length = (num <= seq->_maximum) ? num : seq->_maximum;
       char *ptr = (char *) seq->_buffer;
       for (uint32_t i = 0; i < seq->_length; i++)
-        (void) dds_stream_reuse_string_bound (is, ptr + i * elem_size, allocator, elem_size, false);
+        (void) dds_stream_reuse_string_bound (is, ptr + i * elem_size, allocator, elem_size, false, sample_state);
       for (uint32_t i = seq->_length; i < num; i++)
         dds_stream_skip_string (is);
       return ops + 3 + bound_op;
@@ -1477,11 +1580,11 @@ static const uint32_t *dds_stream_read_seq (dds_istream_t * __restrict is, char 
       const uint32_t elem_size = ops[2 + bound_op];
       const uint32_t jmp = DDS_OP_ADR_JMP (ops[3 + bound_op]);
       uint32_t const * const jsr_ops = ops + DDS_OP_ADR_JSR (ops[3 + bound_op]);
-      realloc_sequence_buffer_if_needed (seq, allocator, num, elem_size, true);
+      adjust_sequence_buffer_initialize (seq, allocator, num, elem_size, &sample_state);
       seq->_length = (num <= seq->_maximum) ? num : seq->_maximum;
       char *ptr = (char *) seq->_buffer;
       for (uint32_t i = 0; i < num; i++)
-        (void) dds_stream_read_impl (is, ptr + i * elem_size, allocator, jsr_ops, false, cdr_kind);
+        (void) dds_stream_read_impl (is, ptr + i * elem_size, allocator, jsr_ops, false, cdr_kind, sample_state);
       return ops + (jmp ? jmp : (4 + bound_op)); /* FIXME: why would jmp be 0? */
     }
     case DDS_OP_VAL_EXT: {
@@ -1492,7 +1595,7 @@ static const uint32_t *dds_stream_read_seq (dds_istream_t * __restrict is, char 
   return NULL;
 }
 
-static const uint32_t *dds_stream_read_arr (dds_istream_t * __restrict is, char * __restrict addr, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, uint32_t insn, enum cdr_data_kind cdr_kind)
+static const uint32_t *dds_stream_read_arr (dds_istream_t * __restrict is, char * __restrict addr, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, uint32_t insn, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
 {
   const enum dds_stream_typecode subtype = DDS_OP_SUBTYPE (insn);
   if (is_dheader_needed (subtype, is->m_xcdr_version))
@@ -1535,14 +1638,14 @@ static const uint32_t *dds_stream_read_arr (dds_istream_t * __restrict is, char 
     case DDS_OP_VAL_STR: {
       char **ptr = (char **) addr;
       for (uint32_t i = 0; i < num; i++)
-        ptr[i] = dds_stream_reuse_string (is, ptr[i], allocator);
+        ptr[i] = dds_stream_reuse_string (is, ptr[i], allocator, sample_state);
       return ops + 3;
     }
     case DDS_OP_VAL_BST: {
       char *ptr = (char *) addr;
       const uint32_t elem_size = ops[4];
       for (uint32_t i = 0; i < num; i++)
-        (void) dds_stream_reuse_string_bound (is, ptr + i * elem_size, allocator, elem_size, false);
+        (void) dds_stream_reuse_string_bound (is, ptr + i * elem_size, allocator, elem_size, false, sample_state);
       return ops + 5;
     }
     case DDS_OP_VAL_SEQ: case DDS_OP_VAL_BSQ: case DDS_OP_VAL_ARR: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU: {
@@ -1550,7 +1653,7 @@ static const uint32_t *dds_stream_read_arr (dds_istream_t * __restrict is, char 
       const uint32_t jmp = DDS_OP_ADR_JMP (ops[3]);
       const uint32_t elem_size = ops[4];
       for (uint32_t i = 0; i < num; i++)
-        (void) dds_stream_read_impl (is, addr + i * elem_size, allocator, jsr_ops, false, cdr_kind);
+        (void) dds_stream_read_impl (is, addr + i * elem_size, allocator, jsr_ops, false, cdr_kind, sample_state);
       return ops + (jmp ? jmp : 5);
     }
     case DDS_OP_VAL_EXT: {
@@ -1561,17 +1664,10 @@ static const uint32_t *dds_stream_read_arr (dds_istream_t * __restrict is, char 
   return NULL;
 }
 
-static const uint32_t *dds_stream_read_uni (dds_istream_t * __restrict is, char * __restrict discaddr, char * __restrict baseaddr, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, uint32_t insn, enum cdr_data_kind cdr_kind)
+static const uint32_t *dds_stream_read_uni (dds_istream_t * __restrict is, char * __restrict discaddr, char * __restrict baseaddr, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, uint32_t insn, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
 {
   const uint32_t disc = read_union_discriminant (is, insn);
-  switch (DDS_OP_SUBTYPE (insn))
-  {
-    case DDS_OP_VAL_BLN: case DDS_OP_VAL_1BY: *((uint8_t *) discaddr) = (uint8_t) disc; break;
-    case DDS_OP_VAL_2BY: *((uint16_t *) discaddr) = (uint16_t) disc; break;
-    case DDS_OP_VAL_4BY: case DDS_OP_VAL_ENU: *((uint32_t *) discaddr) = disc; break;
-    default: break;
-  }
-  uint32_t const * const jeq_op = find_union_case (ops, disc);
+  uint32_t const * const jeq_op = stream_union_switch_case (insn, disc, discaddr, baseaddr, allocator, ops, &sample_state);
   ops += DDS_OP_ADR_JMP (ops[3]);
   if (jeq_op)
   {
@@ -1579,19 +1675,7 @@ static const uint32_t *dds_stream_read_uni (dds_istream_t * __restrict is, char 
     void *valaddr = baseaddr + jeq_op[2];
 
     if (op_type_external (jeq_op[0]))
-    {
-      /* Allocate memory for @external union member. This memory must be initialized
-          to 0, because the type may contain sequences that need to have 0 index/size
-          or external fields that need to be initialized to null */
-      assert (DDS_OP (jeq_op[0]) == DDS_OP_JEQ4);
-      uint32_t sz = get_jeq4_type_size (valtype, jeq_op);
-      if (*((char **) valaddr) == NULL)
-      {
-        *((char **) valaddr) = allocator->malloc (sz);
-        memset (*((char **) valaddr), 0, sz);
-      }
-      valaddr = *((char **) valaddr);
-    }
+      dds_stream_union_member_alloc_external (jeq_op, valtype, &valaddr, allocator, &sample_state);
 
     switch (valtype)
     {
@@ -1609,14 +1693,14 @@ static const uint32_t *dds_stream_read_uni (dds_istream_t * __restrict is, char 
         }
         break;
       case DDS_OP_VAL_STR:
-        *(char **) valaddr = dds_stream_reuse_string (is, *((char **) valaddr), allocator);
+        *(char **) valaddr = dds_stream_reuse_string (is, *((char **) valaddr), allocator, sample_state);
         break;
       case DDS_OP_VAL_BST: case DDS_OP_VAL_SEQ: case DDS_OP_VAL_BSQ: case DDS_OP_VAL_ARR: case DDS_OP_VAL_BMK:
-        (void) dds_stream_read_impl (is, valaddr, allocator, jeq_op + DDS_OP_ADR_JSR (jeq_op[0]), false, cdr_kind);
+        (void) dds_stream_read_impl (is, valaddr, allocator, jeq_op + DDS_OP_ADR_JSR (jeq_op[0]), false, cdr_kind, sample_state);
         break;
       case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU: {
         const uint32_t *jsr_ops = jeq_op + DDS_OP_ADR_JSR (jeq_op[0]);
-        (void) dds_stream_read_impl (is, valaddr, allocator, jsr_ops, false, cdr_kind);
+        (void) dds_stream_read_impl (is, valaddr, allocator, jsr_ops, false, cdr_kind, sample_state);
         break;
       }
       case DDS_OP_VAL_EXT: {
@@ -1628,32 +1712,41 @@ static const uint32_t *dds_stream_read_uni (dds_istream_t * __restrict is, char 
   return ops;
 }
 
-static void dds_stream_alloc_external (const uint32_t * __restrict ops, uint32_t insn, void ** addr, const struct dds_cdrstream_allocator * __restrict allocator)
+static void dds_stream_alloc_external (const uint32_t * __restrict ops, uint32_t insn, void ** addr, const struct dds_cdrstream_allocator * __restrict allocator, enum sample_data_state * sample_state)
 {
   /* Allocate memory for @external member. This memory must be initialized to 0,
       because the type may contain sequences that need to have 0 index/size
       or external fields that need to be initialized to null */
   uint32_t sz = get_adr_type_size (insn, ops);
-  if (*((char **) *addr) == NULL)
+  if (*sample_state != SAMPLE_DATA_INITIALIZED || *((char **) *addr) == NULL)
   {
     *((char **) *addr) = allocator->malloc (sz);
-    memset (*((char **) *addr), 0, sz);
+    *sample_state = SAMPLE_DATA_UNINITIALIZED;
   }
   *addr = *((char **) *addr);
 }
 
-static inline const uint32_t *dds_stream_read_adr (uint32_t insn, dds_istream_t * __restrict is, char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, bool is_mutable_member, enum cdr_data_kind cdr_kind)
+static inline const uint32_t *stream_skip_member (uint32_t insn, char * __restrict data, void *addr, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, enum sample_data_state sample_state)
+{
+  if (sample_state == SAMPLE_DATA_INITIALIZED)
+    return stream_free_sample_adr (insn, data, allocator, ops);
+
+  *((char **) addr) = NULL;
+  return dds_stream_skip_adr (insn, ops);
+}
+
+static inline const uint32_t *dds_stream_read_adr (uint32_t insn, dds_istream_t * __restrict is, char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, bool is_mutable_member, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
 {
   void *addr = data + ops[1];
   if (!stream_is_member_present (insn, is, is_mutable_member))
-    return stream_free_sample_adr (insn, data, allocator, ops);
+    return stream_skip_member (insn, data, addr, allocator, ops, sample_state);
 
   const bool is_key = (insn & DDS_OP_FLAG_KEY);
   if (cdr_kind == CDR_KIND_KEY && !is_key)
     return dds_stream_skip_adr (insn, ops);
 
   if (op_type_external (insn))
-    dds_stream_alloc_external (ops, insn, &addr, allocator);
+    dds_stream_alloc_external (ops, insn, &addr, allocator, &sample_state);
 
   switch (DDS_OP_TYPE (insn))
   {
@@ -1661,11 +1754,11 @@ static inline const uint32_t *dds_stream_read_adr (uint32_t insn, dds_istream_t 
     case DDS_OP_VAL_2BY: *((uint16_t *) addr) = dds_is_get2 (is); ops += 2; break;
     case DDS_OP_VAL_4BY: *((uint32_t *) addr) = dds_is_get4 (is); ops += 2; break;
     case DDS_OP_VAL_8BY: *((uint64_t *) addr) = dds_is_get8 (is); ops += 2; break;
-    case DDS_OP_VAL_STR: *((char **) addr) = dds_stream_reuse_string (is, *((char **) addr), allocator); ops += 2; break;
-    case DDS_OP_VAL_BST: (void) dds_stream_reuse_string_bound (is, (char *) addr, allocator, ops[2], false); ops += 3; break;
-    case DDS_OP_VAL_SEQ: case DDS_OP_VAL_BSQ: ops = dds_stream_read_seq (is, addr, allocator, ops, insn, cdr_kind); break;
-    case DDS_OP_VAL_ARR: ops = dds_stream_read_arr (is, addr, allocator, ops, insn, cdr_kind); break;
-    case DDS_OP_VAL_UNI: ops = dds_stream_read_uni (is, addr, data, allocator, ops, insn, cdr_kind); break;
+    case DDS_OP_VAL_STR: *((char **) addr) = dds_stream_reuse_string (is, *((char **) addr), allocator, sample_state); ops += 2; break;
+    case DDS_OP_VAL_BST: (void) dds_stream_reuse_string_bound (is, (char *) addr, allocator, ops[2], false, sample_state); ops += 3; break;
+    case DDS_OP_VAL_SEQ: case DDS_OP_VAL_BSQ: ops = dds_stream_read_seq (is, addr, allocator, ops, insn, cdr_kind, sample_state); break;
+    case DDS_OP_VAL_ARR: ops = dds_stream_read_arr (is, addr, allocator, ops, insn, cdr_kind, sample_state); break;
+    case DDS_OP_VAL_UNI: ops = dds_stream_read_uni (is, addr, data, allocator, ops, insn, cdr_kind, sample_state); break;
     case DDS_OP_VAL_ENU: {
       switch (DDS_OP_TYPE_SZ (insn))
       {
@@ -1698,7 +1791,7 @@ static inline const uint32_t *dds_stream_read_adr (uint32_t insn, dds_istream_t 
       if (op_type_base (insn) && jsr_ops[0] == DDS_OP_DLC)
         jsr_ops++;
 
-      (void) dds_stream_read_impl (is, addr, allocator, jsr_ops, false, cdr_kind);
+      (void) dds_stream_read_impl (is, addr, allocator, jsr_ops, false, cdr_kind, sample_state);
       ops += jmp ? jmp : 3;
       break;
     }
@@ -1740,7 +1833,7 @@ static const uint32_t *dds_stream_skip_adr (uint32_t insn, const uint32_t * __re
   return NULL;
 }
 
-static const uint32_t *dds_stream_skip_adr_default (uint32_t insn, char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops)
+static const uint32_t *dds_stream_skip_adr_default (uint32_t insn, char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, enum sample_data_state sample_state)
 {
   void *addr = data + ops[1];
   /* FIXME: currently only implicit default values are used, this code should be
@@ -1750,7 +1843,7 @@ static const uint32_t *dds_stream_skip_adr_default (uint32_t insn, char * __rest
      test for optional (which also gets the external flag) is added because string type
      is the exception for this rule, that does not get the external flag */
   if (op_type_external (insn) || op_type_optional (insn))
-    return stream_free_sample_adr(insn, data, allocator, ops);
+    return stream_skip_member (insn, data, addr, allocator, ops, sample_state);
 
   switch (DDS_OP_TYPE (insn))
   {
@@ -1759,7 +1852,7 @@ static const uint32_t *dds_stream_skip_adr_default (uint32_t insn, char * __rest
     case DDS_OP_VAL_4BY: *(uint32_t *) addr = 0; return ops + 2;
     case DDS_OP_VAL_8BY: *(uint64_t *) addr = 0; return ops + 2;
 
-    case DDS_OP_VAL_STR: *(char **) addr = dds_stream_reuse_string_empty (*(char **) addr, allocator); return ops + 2;
+    case DDS_OP_VAL_STR: *(char **) addr = dds_stream_reuse_string_empty (*(char **) addr, allocator, sample_state); return ops + 2;
     case DDS_OP_VAL_BST: ((char *) addr)[0] = '\0'; return ops + 3;
     case DDS_OP_VAL_ENU: *(uint32_t *) addr = 0; return ops + 3;
     case DDS_OP_VAL_BMK:
@@ -1778,15 +1871,15 @@ static const uint32_t *dds_stream_skip_adr_default (uint32_t insn, char * __rest
       return skip_sequence_insns (insn, ops);
     }
     case DDS_OP_VAL_ARR: {
-      return skip_array_default (insn, addr, allocator, ops);
+      return skip_array_default (insn, addr, allocator, ops, sample_state);
     }
     case DDS_OP_VAL_UNI: {
-      return skip_union_default (insn, addr, data, allocator, ops);
+      return skip_union_default (insn, addr, data, allocator, ops, sample_state);
     }
     case DDS_OP_VAL_EXT: {
       const uint32_t *jsr_ops = ops + DDS_OP_ADR_JSR (ops[2]);
       const uint32_t jmp = DDS_OP_ADR_JMP (ops[2]);
-      (void) dds_stream_skip_default (addr, allocator, jsr_ops);
+      (void) dds_stream_skip_default (addr, allocator, jsr_ops, sample_state);
       return ops + (jmp ? jmp : 3);
     }
     case DDS_OP_VAL_STU: {
@@ -1798,12 +1891,12 @@ static const uint32_t *dds_stream_skip_adr_default (uint32_t insn, char * __rest
   return NULL;
 }
 
-static const uint32_t *dds_stream_skip_delimited_default (char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops)
+static const uint32_t *dds_stream_skip_delimited_default (char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, enum sample_data_state sample_state)
 {
-  return dds_stream_skip_default (data, allocator, ++ops);
+  return dds_stream_skip_default (data, allocator, ++ops, sample_state);
 }
 
-static void dds_stream_skip_pl_member_default (char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops)
+static void dds_stream_skip_pl_member_default (char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, enum sample_data_state sample_state)
 {
   uint32_t insn;
   while ((insn = *ops) != DDS_OP_RTS)
@@ -1811,11 +1904,11 @@ static void dds_stream_skip_pl_member_default (char * __restrict data, const str
     switch (DDS_OP (insn))
     {
       case DDS_OP_ADR: {
-        ops = dds_stream_skip_default (data, allocator, ops);
+        ops = dds_stream_skip_default (data, allocator, ops, sample_state);
         break;
       }
       case DDS_OP_JSR:
-        dds_stream_skip_pl_member_default (data, allocator, ops + DDS_OP_JUMP (insn));
+        dds_stream_skip_pl_member_default (data, allocator, ops + DDS_OP_JUMP (insn), sample_state);
         ops++;
         break;
       case DDS_OP_RTS: case DDS_OP_JEQ: case DDS_OP_JEQ4: case DDS_OP_KOF:
@@ -1826,7 +1919,7 @@ static void dds_stream_skip_pl_member_default (char * __restrict data, const str
   }
 }
 
-static const uint32_t *dds_stream_skip_pl_memberlist_default (char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops)
+static const uint32_t *dds_stream_skip_pl_memberlist_default (char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, enum sample_data_state sample_state)
 {
   uint32_t insn;
   while (ops && (insn = *ops) != DDS_OP_RTS)
@@ -1840,11 +1933,11 @@ static const uint32_t *dds_stream_skip_pl_memberlist_default (char * __restrict 
         {
           assert (plm_ops[0] == DDS_OP_PLC);
           plm_ops++; /* skip PLC op to go to first PLM for the base type */
-          (void) dds_stream_skip_pl_memberlist_default (data, allocator, plm_ops);
+          (void) dds_stream_skip_pl_memberlist_default (data, allocator, plm_ops, sample_state);
         }
         else
         {
-          dds_stream_skip_pl_member_default (data, allocator, plm_ops);
+          dds_stream_skip_pl_member_default (data, allocator, plm_ops, sample_state);
         }
         ops += 2;
         break;
@@ -1857,13 +1950,13 @@ static const uint32_t *dds_stream_skip_pl_memberlist_default (char * __restrict 
   return ops;
 }
 
-static const uint32_t *dds_stream_skip_pl_default (char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops)
+static const uint32_t *dds_stream_skip_pl_default (char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, enum sample_data_state sample_state)
 {
   /* skip PLC op */
-  return dds_stream_skip_pl_memberlist_default (data, allocator, ++ops);
+  return dds_stream_skip_pl_memberlist_default (data, allocator, ++ops, sample_state);
 }
 
-static const uint32_t *dds_stream_skip_default (char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops)
+static const uint32_t *dds_stream_skip_default (char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, enum sample_data_state sample_state)
 {
   uint32_t insn;
   while ((insn = *ops) != DDS_OP_RTS)
@@ -1871,11 +1964,11 @@ static const uint32_t *dds_stream_skip_default (char * __restrict data, const st
     switch (DDS_OP (insn))
     {
       case DDS_OP_ADR: {
-        ops = dds_stream_skip_adr_default (insn, data, allocator, ops);
+        ops = dds_stream_skip_adr_default (insn, data, allocator, ops, sample_state);
         break;
       }
       case DDS_OP_JSR: {
-        (void) dds_stream_skip_default (data, allocator, ops + DDS_OP_JUMP (insn));
+        (void) dds_stream_skip_default (data, allocator, ops + DDS_OP_JUMP (insn), sample_state);
         ops++;
         break;
       }
@@ -1883,17 +1976,17 @@ static const uint32_t *dds_stream_skip_default (char * __restrict data, const st
         abort ();
         break;
       case DDS_OP_DLC:
-        ops = dds_stream_skip_delimited_default (data, allocator, ops);
+        ops = dds_stream_skip_delimited_default (data, allocator, ops, sample_state);
         break;
       case DDS_OP_PLC:
-        ops = dds_stream_skip_pl_default (data, allocator, ops);
+        ops = dds_stream_skip_pl_default (data, allocator, ops, sample_state);
         break;
     }
   }
   return ops;
 }
 
-static const uint32_t *dds_stream_read_delimited (dds_istream_t * __restrict is, char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, enum cdr_data_kind cdr_kind)
+static const uint32_t *dds_stream_read_delimited (dds_istream_t * __restrict is, char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
 {
   uint32_t delimited_sz = dds_is_get4 (is), delimited_offs = is->m_index, insn;
   ops++;
@@ -1903,11 +1996,11 @@ static const uint32_t *dds_stream_read_delimited (dds_istream_t * __restrict is,
     {
       case DDS_OP_ADR: {
         /* skip fields that are not in serialized data for appendable type */
-        ops = (is->m_index - delimited_offs < delimited_sz) ? dds_stream_read_adr (insn, is, data, allocator, ops, false, cdr_kind) : dds_stream_skip_adr_default (insn, data, allocator, ops);
+        ops = (is->m_index - delimited_offs < delimited_sz) ? dds_stream_read_adr (insn, is, data, allocator, ops, false, cdr_kind, sample_state) : dds_stream_skip_adr_default (insn, data, allocator, ops, sample_state);
         break;
       }
       case DDS_OP_JSR: {
-        (void) dds_stream_read_impl (is, data, allocator, ops + DDS_OP_JUMP (insn), false, cdr_kind);
+        (void) dds_stream_read_impl (is, data, allocator, ops + DDS_OP_JUMP (insn), false, cdr_kind, sample_state);
         ops++;
         break;
       }
@@ -1923,7 +2016,7 @@ static const uint32_t *dds_stream_read_delimited (dds_istream_t * __restrict is,
   return ops;
 }
 
-static bool dds_stream_read_pl_member (dds_istream_t * __restrict is, char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, uint32_t m_id, const uint32_t * __restrict ops, enum cdr_data_kind cdr_kind)
+static bool dds_stream_read_pl_member (dds_istream_t * __restrict is, char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, uint32_t m_id, const uint32_t * __restrict ops, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
 {
   uint32_t insn, ops_csr = 0;
   bool found = false;
@@ -1939,11 +2032,11 @@ static bool dds_stream_read_pl_member (dds_istream_t * __restrict is, char * __r
     {
       assert (DDS_OP (plm_ops[0]) == DDS_OP_PLC);
       plm_ops++; /* skip PLC to go to first PLM from base type */
-      found = dds_stream_read_pl_member (is, data, allocator, m_id, plm_ops, cdr_kind);
+      found = dds_stream_read_pl_member (is, data, allocator, m_id, plm_ops, cdr_kind, sample_state);
     }
     else if (ops[ops_csr + 1] == m_id)
     {
-      (void) dds_stream_read_impl (is, data, allocator, plm_ops, true, cdr_kind);
+      (void) dds_stream_read_impl (is, data, allocator, plm_ops, true, cdr_kind, sample_state);
       found = true;
       break;
     }
@@ -1952,14 +2045,14 @@ static bool dds_stream_read_pl_member (dds_istream_t * __restrict is, char * __r
   return found;
 }
 
-static const uint32_t *dds_stream_read_pl (dds_istream_t * __restrict is, char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, enum cdr_data_kind cdr_kind)
+static const uint32_t *dds_stream_read_pl (dds_istream_t * __restrict is, char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
 {
   /* skip PLC op */
   ops++;
 
   /* default-initialize all members
       FIXME: optimize so that only members not in received data are initialized */
-  dds_stream_skip_pl_memberlist_default (data, allocator, ops);
+  dds_stream_skip_pl_memberlist_default (data, allocator, ops, sample_state);
 
   /* read DHEADER */
   uint32_t pl_sz = dds_is_get4 (is), pl_offs = is->m_index;
@@ -1989,7 +2082,7 @@ static const uint32_t *dds_stream_read_pl (dds_istream_t * __restrict is, char *
     }
 
     /* find member and deserialize */
-    if (!dds_stream_read_pl_member (is, data, allocator, m_id, ops, cdr_kind))
+    if (!dds_stream_read_pl_member (is, data, allocator, m_id, ops, cdr_kind, sample_state))
     {
       is->m_index += msz;
       if (lc >= LENGTH_CODE_ALSO_NEXTINT)
@@ -2004,7 +2097,7 @@ static const uint32_t *dds_stream_read_pl (dds_istream_t * __restrict is, char *
   return ops;
 }
 
-static const uint32_t *dds_stream_read_impl (dds_istream_t * __restrict is, char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, bool is_mutable_member, enum cdr_data_kind cdr_kind)
+static const uint32_t *dds_stream_read_impl (dds_istream_t * __restrict is, char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, bool is_mutable_member, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
 {
   uint32_t insn;
   while ((insn = *ops) != DDS_OP_RTS)
@@ -2012,10 +2105,10 @@ static const uint32_t *dds_stream_read_impl (dds_istream_t * __restrict is, char
     switch (DDS_OP (insn))
     {
       case DDS_OP_ADR:
-        ops = dds_stream_read_adr (insn, is, data, allocator, ops, is_mutable_member, cdr_kind);
+        ops = dds_stream_read_adr (insn, is, data, allocator, ops, is_mutable_member, cdr_kind, sample_state);
         break;
       case DDS_OP_JSR:
-        (void) dds_stream_read_impl (is, data, allocator, ops + DDS_OP_JUMP (insn), is_mutable_member, cdr_kind);
+        (void) dds_stream_read_impl (is, data, allocator, ops + DDS_OP_JUMP (insn), is_mutable_member, cdr_kind, sample_state);
         ops++;
         break;
       case DDS_OP_RTS: case DDS_OP_JEQ: case DDS_OP_JEQ4: case DDS_OP_KOF: case DDS_OP_PLM:
@@ -2023,11 +2116,11 @@ static const uint32_t *dds_stream_read_impl (dds_istream_t * __restrict is, char
         break;
       case DDS_OP_DLC:
         assert (is->m_xcdr_version == DDSI_RTPS_CDR_ENC_VERSION_2);
-        ops = dds_stream_read_delimited (is, data, allocator, ops, cdr_kind);
+        ops = dds_stream_read_delimited (is, data, allocator, ops, cdr_kind, sample_state);
         break;
       case DDS_OP_PLC:
         assert (is->m_xcdr_version == DDSI_RTPS_CDR_ENC_VERSION_2);
-        ops = dds_stream_read_pl (is, data, allocator, ops, cdr_kind);
+        ops = dds_stream_read_pl (is, data, allocator, ops, cdr_kind, sample_state);
         break;
     }
   }
@@ -2036,7 +2129,7 @@ static const uint32_t *dds_stream_read_impl (dds_istream_t * __restrict is, char
 
 const uint32_t *dds_stream_read (dds_istream_t * __restrict is, char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops)
 {
-  return dds_stream_read_impl (is, data, allocator, ops, false, CDR_KIND_DATA);
+  return dds_stream_read_impl (is, data, allocator, ops, false, CDR_KIND_DATA, SAMPLE_DATA_INITIALIZED);
 }
 
 /*******************************************************************************************
@@ -3646,29 +3739,18 @@ void dds_stream_read_sample (dds_istream_t * __restrict is, void * __restrict da
   }
   else
   {
-    if (desc->flagset & DDS_TOPIC_CONTAINS_UNION)
-    {
-      /* Switching union cases causes big trouble if some cases have sequences or strings,
-         and other cases have other things mapped to those addresses.  So, pretend to be
-         nice by freeing whatever was allocated, then clearing all memory.  This will
-         make any preallocated buffers go to waste, but it does allow reusing the message
-         from read-to-read, at the somewhat reasonable price of a slower deserialization
-         and not being able to use preallocated sequences in topics containing unions. */
-      dds_stream_free_sample (data, allocator, desc->ops.ops);
-      memset (data, 0, desc->size);
-    }
-    (void) dds_stream_read_impl (is, data, allocator, desc->ops.ops, false, CDR_KIND_DATA);
+    (void) dds_stream_read_impl (is, data, allocator, desc->ops.ops, false, CDR_KIND_DATA, SAMPLE_DATA_INITIALIZED);
   }
 }
 
-static void dds_stream_read_key_impl (dds_istream_t * __restrict is, char * __restrict sample, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, uint16_t key_offset_count, const uint32_t * key_offset_insn)
+static void dds_stream_read_key_impl (dds_istream_t * __restrict is, char * __restrict sample, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, uint16_t key_offset_count, const uint32_t * key_offset_insn, enum sample_data_state sample_state)
 {
   void *dst = sample + ops[1];
   uint32_t insn = ops[0];
   assert (insn_key_ok_p (insn));
 
   if (op_type_external (insn))
-    dds_stream_alloc_external (ops, insn, &dst, allocator);
+    dds_stream_alloc_external (ops, insn, &dst, allocator, &sample_state);
 
   switch (DDS_OP_TYPE (insn))
   {
@@ -3696,8 +3778,8 @@ static void dds_stream_read_key_impl (dds_istream_t * __restrict is, char * __re
         default: abort ();
       }
       break;
-    case DDS_OP_VAL_STR: *((char **) dst) = dds_stream_reuse_string (is, *((char **) dst), allocator); break;
-    case DDS_OP_VAL_BST: (void) dds_stream_reuse_string_bound (is, dst, allocator, ops[2], false); break;
+    case DDS_OP_VAL_STR: *((char **) dst) = dds_stream_reuse_string (is, *((char **) dst), allocator, sample_state); break;
+    case DDS_OP_VAL_BST: (void) dds_stream_reuse_string_bound (is, dst, allocator, ops[2], false, sample_state); break;
     case DDS_OP_VAL_ARR: {
       const enum dds_stream_typecode subtype = DDS_OP_SUBTYPE (insn);
       uint32_t num = ops[2];
@@ -3740,7 +3822,7 @@ static void dds_stream_read_key_impl (dds_istream_t * __restrict is, char * __re
     {
       assert (key_offset_count > 0);
       const uint32_t *jsr_ops = ops + DDS_OP_ADR_JSR (ops[2]) + *key_offset_insn;
-      dds_stream_read_key_impl (is, dst, allocator, jsr_ops, --key_offset_count, ++key_offset_insn);
+      dds_stream_read_key_impl (is, dst, allocator, jsr_ops, --key_offset_count, ++key_offset_insn, sample_state);
       break;
     }
   }
@@ -3752,7 +3834,7 @@ void dds_stream_read_key (dds_istream_t * __restrict is, char * __restrict sampl
   {
     /* For types with key fields in aggregated types with appendable or mutable
        extensibility, use the regular read functions to read the key fields */
-    (void) dds_stream_read_impl (is, sample, allocator, desc->ops.ops, false, CDR_KIND_KEY);
+    (void) dds_stream_read_impl (is, sample, allocator, desc->ops.ops, false, CDR_KIND_KEY, SAMPLE_DATA_INITIALIZED);
   }
   else
   {
@@ -3766,11 +3848,11 @@ void dds_stream_read_key (dds_istream_t * __restrict is, char * __restrict sampl
       {
         case DDS_OP_KOF: {
           uint16_t n_offs = DDS_OP_LENGTH (*op);
-          dds_stream_read_key_impl (is, sample, allocator, desc->ops.ops + op[1], --n_offs, op + 2);
+          dds_stream_read_key_impl (is, sample, allocator, desc->ops.ops + op[1], --n_offs, op + 2, SAMPLE_DATA_INITIALIZED);
           break;
         }
         case DDS_OP_ADR: {
-          dds_stream_read_key_impl (is, sample, allocator, op, 0, NULL);
+          dds_stream_read_key_impl (is, sample, allocator, op, 0, NULL, SAMPLE_DATA_INITIALIZED);
           break;
         }
         default:

--- a/src/core/cdr/src/dds_cdrstream.c
+++ b/src/core/cdr/src/dds_cdrstream.c
@@ -924,18 +924,26 @@ static char *dds_stream_reuse_string (dds_istream_t * __restrict is, char * __re
 {
   const uint32_t length = dds_is_get4 (is);
   const void *src = is->m_buffer + is->m_index;
+  is->m_index += length;
   if (sample_state == SAMPLE_DATA_INITIALIZED && str != NULL)
+  {
+    if (length == 1 && str[0] == '\0')
+      return str;
     allocator->free (str);
+  }
   str = allocator->malloc (length);
   memcpy (str, src, length);
-  is->m_index += length;
   return str;
 }
 
 static char *dds_stream_reuse_string_empty (char * __restrict str, const struct dds_cdrstream_allocator * __restrict allocator, enum sample_data_state sample_state)
 {
   if (sample_state == SAMPLE_DATA_INITIALIZED && str != NULL)
+  {
+    if (str[0] == '\0')
+      return str;
     allocator->free (str);
+  }
   str = allocator->malloc (1);
   str[0] = '\0';
   return str;

--- a/src/core/cdr/src/dds_cdrstream_keys.part.c
+++ b/src/core/cdr/src/dds_cdrstream_keys.part.c
@@ -383,7 +383,7 @@ static void dds_stream_extract_keyBO_from_key_impl (dds_istream_t * __restrict i
      and write the key-only CDR for this sample */
   void *sample = allocator->malloc (desc->size);
   memset (sample, 0, desc->size);
-  (void) dds_stream_read_impl (is, sample, allocator, desc->ops.ops, false, CDR_KIND_KEY);
+  (void) dds_stream_read_impl (is, sample, allocator, desc->ops.ops, false, CDR_KIND_KEY, SAMPLE_DATA_INITIALIZED);
   if (ser_kind == DDS_CDR_KEY_SERIALIZATION_KEYHASH)
     dds_stream_write_keyBE ((dds_ostreamBE_t *) os, ser_kind, allocator, sample, desc);
   else

--- a/src/core/cdr/src/dds_cdrstream_keys.part.c
+++ b/src/core/cdr/src/dds_cdrstream_keys.part.c
@@ -17,7 +17,7 @@ static void dds_stream_write_keyBO_impl (DDS_OSTREAM_T * __restrict os, const st
   void *addr = (char *) src + ops[1];
 
   if (op_type_external (insn))
-    dds_stream_alloc_external (ops, insn, &addr, allocator);
+    addr = *((char **) addr);
 
   switch (DDS_OP_TYPE (insn))
   {

--- a/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
@@ -569,7 +569,8 @@ enum dds_stream_typecode_subtype {
 /**
  * @anchor DDS_TOPIC_CONTAINS_UNION
  * @ingroup topic_flags
- * @brief at arbitrary deep nesting the topic type contains at least one union.
+ * @deprecated reserved for backward compatibility
+ * @brief ignored
  */
 #define DDS_TOPIC_CONTAINS_UNION                (1u << 2)
 

--- a/src/core/ddsc/tests/cdrstream.c
+++ b/src/core/ddsc/tests/cdrstream.c
@@ -259,7 +259,7 @@ static const uint32_t TestIdl_MsgUnion_ops [] =
   DDS_OP_RTS
 };
 
-const dds_topic_descriptor_t TestIdl_MsgUnion_desc = { sizeof (TestIdl_MsgUnion), 4u, DDS_TOPIC_CONTAINS_UNION, 0u, "TestIdl::MsgUnion", NULL, 3, TestIdl_MsgUnion_ops, "" };
+const dds_topic_descriptor_t TestIdl_MsgUnion_desc = { sizeof (TestIdl_MsgUnion), 4u, 0u, 0u, "TestIdl::MsgUnion", NULL, 3, TestIdl_MsgUnion_ops, "" };
 
 static void * sample_init_union (void)
 {
@@ -955,7 +955,7 @@ static const uint32_t TestIdl_MsgArr_ops [] =
   DDS_OP_RTS
 };
 
-const dds_topic_descriptor_t TestIdl_MsgArr_desc = { sizeof (TestIdl_MsgArr), sizeof (char *), DDS_TOPIC_CONTAINS_UNION, 0u, "TestIdl::MsgArr", NULL, 6, TestIdl_MsgArr_ops, "" };
+const dds_topic_descriptor_t TestIdl_MsgArr_desc = { sizeof (TestIdl_MsgArr), sizeof (char *), 0u, 0u, "TestIdl::MsgArr", NULL, 6, TestIdl_MsgArr_ops, "" };
 
 static void * sample_init_arr (void)
 {
@@ -1221,7 +1221,7 @@ static const uint32_t TestIdl_MsgAppendDefaults2_ops [] =
 };
 
 const dds_topic_descriptor_t TestIdl_MsgAppendDefaults1_desc = { sizeof (TestIdl_MsgAppendDefaults1), 4u, 0u, 0u, "TestIdl::MsgAppendDefaults1", NULL, 0, TestIdl_MsgAppendDefaults1_ops, "" };
-const dds_topic_descriptor_t TestIdl_MsgAppendDefaults2_desc = { sizeof (TestIdl_MsgAppendDefaults2), 4u, DDS_TOPIC_CONTAINS_UNION, 0u, "TestIdl::MsgAppendDefaults2", NULL, 0, TestIdl_MsgAppendDefaults2_ops, "" };
+const dds_topic_descriptor_t TestIdl_MsgAppendDefaults2_desc = { sizeof (TestIdl_MsgAppendDefaults2), 4u, 0u, 0u, "TestIdl::MsgAppendDefaults2", NULL, 0, TestIdl_MsgAppendDefaults2_ops, "" };
 
 static void * sample_init_appenddefaults1 (void)
 {

--- a/src/core/ddsc/tests/multi_sertype.c
+++ b/src/core/ddsc/tests/multi_sertype.c
@@ -114,7 +114,7 @@ static const dds_topic_descriptor_t type_uni_desc =
 {
   .m_size = sizeof (struct type_uni),
   .m_align = sizeof (void *),
-  .m_flagset = DDS_TOPIC_CONTAINS_UNION,
+  .m_flagset = 0u,
   .m_nkeys = 0,
   .m_typename = "multi_sertype_type",
   .m_keys = NULL,

--- a/src/core/ddsi/src/ddsi_typebuilder.c
+++ b/src/core/ddsi/src/ddsi_typebuilder.c
@@ -193,7 +193,6 @@ struct typebuilder_data
   struct typebuilder_dep_types dep_types;
   uint32_t n_keys;
   struct typebuilder_key *keys;
-  bool contains_union;
   bool fixed_size;
 };
 
@@ -563,8 +562,6 @@ static dds_return_t typebuilder_add_type (struct typebuilder_data *tbd, uint32_t
       tb_type->cdr_align = 0;
       *align = is_ext ? dds_alignof (void *) : aggrtype->align;
       *size = is_ext ? sizeof (void *) : aggrtype->size;
-      if (type->xt._d == DDS_XTypes_TK_UNION)
-        tbd->contains_union = true;
       break;
     }
     case DDS_XTypes_TK_FLOAT128:
@@ -781,7 +778,6 @@ static dds_return_t typebuilder_add_union (struct typebuilder_data *tbd, struct 
   tb_aggrtype->detail._union.member_offs = disc_sz;
   align_to (&tb_aggrtype->detail._union.member_offs, member_align);
 
-  tbd->contains_union = true;
 err:
   return ret;
 }
@@ -1683,8 +1679,6 @@ static dds_return_t set_implicit_keys_aggrtype (struct typebuilder_aggregated_ty
 static uint32_t get_descriptor_flagset (const struct typebuilder_data *tbd)
 {
   uint32_t flags = 0u;
-  if (tbd->contains_union)
-    flags |= DDS_TOPIC_CONTAINS_UNION;
   if (tbd->fixed_size)
     flags |= DDS_TOPIC_FIXED_SIZE;
   flags |= DDS_TOPIC_XTYPES_METADATA;

--- a/src/core/ddsi/src/ddsi_xt_typeinfo.c
+++ b/src/core/ddsi/src/ddsi_xt_typeinfo.c
@@ -102,7 +102,7 @@ const dds_topic_descriptor_t DDS_XTypes_TypeIdentifier_desc =
 {
   .m_size = sizeof (DDS_XTypes_TypeIdentifier),
   .m_align = dds_alignof (DDS_XTypes_TypeIdentifier),
-  .m_flagset = DDS_TOPIC_CONTAINS_UNION,
+  .m_flagset = 0u,
   .m_nkeys = 0u,
   .m_typename = "DDS::XTypes::TypeIdentifier",
   .m_keys = NULL,
@@ -115,7 +115,7 @@ const struct dds_cdrstream_desc DDS_XTypes_TypeIdentifier_cdrstream_desc =
 {
   .size = sizeof (DDS_XTypes_TypeIdentifier),
   .align = dds_alignof (DDS_XTypes_TypeIdentifier),
-  .flagset = DDS_TOPIC_CONTAINS_UNION,
+  .flagset = 0u,
   .keys = {
     .nkeys = 0u,
     .keys = NULL
@@ -729,7 +729,7 @@ const dds_topic_descriptor_t DDS_XTypes_TypeObject_desc =
 {
   .m_size = sizeof (DDS_XTypes_TypeObject),
   .m_align = dds_alignof (DDS_XTypes_TypeObject),
-  .m_flagset = DDS_TOPIC_CONTAINS_UNION,
+  .m_flagset = 0u,
   .m_nkeys = 0u,
   .m_typename = "DDS::XTypes::TypeObject",
   .m_keys = NULL,
@@ -742,7 +742,7 @@ const struct dds_cdrstream_desc DDS_XTypes_TypeObject_cdrstream_desc =
 {
   .size = sizeof (DDS_XTypes_TypeObject),
   .align = dds_alignof (DDS_XTypes_TypeObject),
-  .flagset = DDS_TOPIC_CONTAINS_UNION,
+  .flagset = 0u,
   .keys = {
     .nkeys = 0u,
     .keys = NULL
@@ -872,7 +872,7 @@ const dds_topic_descriptor_t DDS_XTypes_TypeInformation_desc =
 {
   .m_size = sizeof (DDS_XTypes_TypeInformation),
   .m_align = dds_alignof (DDS_XTypes_TypeInformation),
-  .m_flagset = DDS_TOPIC_CONTAINS_UNION,
+  .m_flagset = 0u,
   .m_nkeys = 0u,
   .m_typename = "DDS::XTypes::TypeInformation",
   .m_keys = NULL,
@@ -885,7 +885,7 @@ const struct dds_cdrstream_desc DDS_XTypes_TypeInformation_cdrstream_desc =
 {
   .size = sizeof (DDS_XTypes_TypeInformation),
   .align = dds_alignof (DDS_XTypes_TypeInformation),
-  .flagset = DDS_TOPIC_CONTAINS_UNION,
+  .flagset = 0u,
   .keys = {
     .nkeys = 0u,
     .keys = NULL

--- a/src/core/ddsi/src/ddsi_xt_typelookup.c
+++ b/src/core/ddsi/src/ddsi_xt_typelookup.c
@@ -156,7 +156,7 @@ const dds_topic_descriptor_t DDS_Builtin_TypeLookup_Request_desc =
 {
   .m_size = sizeof (DDS_Builtin_TypeLookup_Request),
   .m_align = dds_alignof (DDS_Builtin_TypeLookup_Request),
-  .m_flagset = DDS_TOPIC_CONTAINS_UNION,
+  .m_flagset = 0u,
   .m_nkeys = 0u,
   .m_typename = "DDS::Builtin::TypeLookup_Request",
   .m_keys = NULL,
@@ -169,7 +169,7 @@ const struct dds_cdrstream_desc DDS_Builtin_TypeLookup_Request_cdrstream_desc =
 {
   .size = sizeof (DDS_Builtin_TypeLookup_Request),
   .align = dds_alignof (DDS_Builtin_TypeLookup_Request),
-  .flagset = DDS_TOPIC_CONTAINS_UNION,
+  .flagset = 0u,
   .keys = {
     .nkeys = 0u,
     .keys = NULL
@@ -868,7 +868,7 @@ const dds_topic_descriptor_t DDS_Builtin_TypeLookup_Reply_desc =
 {
   .m_size = sizeof (DDS_Builtin_TypeLookup_Reply),
   .m_align = dds_alignof (DDS_Builtin_TypeLookup_Reply),
-  .m_flagset = DDS_TOPIC_CONTAINS_UNION,
+  .m_flagset = 0u,
   .m_nkeys = 0u,
   .m_typename = "DDS::Builtin::TypeLookup_Reply",
   .m_keys = NULL,
@@ -881,7 +881,7 @@ const struct dds_cdrstream_desc DDS_Builtin_TypeLookup_Reply_cdrstream_desc =
 {
   .size = sizeof (DDS_Builtin_TypeLookup_Reply),
   .align = dds_alignof (DDS_Builtin_TypeLookup_Reply),
-  .flagset = DDS_TOPIC_CONTAINS_UNION,
+  .flagset = 0u,
   .keys = {
     .nkeys = 0u,
     .keys = NULL

--- a/src/core/ddsi/src/ddsi_xt_typemap.c
+++ b/src/core/ddsi/src/ddsi_xt_typemap.c
@@ -625,7 +625,7 @@ const dds_topic_descriptor_t DDS_XTypes_TypeMapping_desc =
 {
   .m_size = sizeof (DDS_XTypes_TypeMapping),
   .m_align = dds_alignof (DDS_XTypes_TypeMapping),
-  .m_flagset = DDS_TOPIC_CONTAINS_UNION,
+  .m_flagset = 0u,
   .m_nkeys = 0u,
   .m_typename = "DDS::XTypes::TypeMapping",
   .m_keys = NULL,
@@ -638,7 +638,7 @@ const struct dds_cdrstream_desc DDS_XTypes_TypeMapping_cdrstream_desc =
 {
   .size = sizeof (DDS_XTypes_TypeMapping),
   .align = dds_alignof (DDS_XTypes_TypeMapping),
-  .flagset = DDS_TOPIC_CONTAINS_UNION,
+  .flagset = 0u,
   .keys = {
     .nkeys = 0u,
     .keys = NULL

--- a/src/tools/idlc/src/libidlc/libidlc__descriptor.c
+++ b/src/tools/idlc/src/libidlc/libidlc__descriptor.c
@@ -145,19 +145,8 @@ static idl_retcode_t
 stash_opcode(
   const idl_pstate_t *pstate, struct descriptor *descriptor, struct instructions *instructions, uint32_t index, uint32_t code, uint32_t order)
 {
-  enum dds_stream_typecode typecode;
   struct instruction inst = { OPCODE, { .opcode = { .code = code, .order = order } } };
-
   descriptor->n_opcodes++;
-  if (DDS_OP (code) == DDS_OP_ADR || DDS_OP (code) == DDS_OP_JEQ4)
-  {
-    typecode = DDS_OP_TYPE (code);
-    if (typecode == DDS_OP_VAL_ARR)
-      typecode = DDS_OP_SUBTYPE (code);
-    if (typecode == DDS_OP_VAL_UNI)
-      descriptor->flags |= DDS_TOPIC_CONTAINS_UNION;
-  }
-
   return stash_instruction(pstate, instructions, index, &inst);
 }
 
@@ -2275,8 +2264,6 @@ static int print_flags(FILE *fp, struct descriptor *descriptor, bool type_info)
   const char *vec[MAX_FLAGS] = { NULL };
   size_t cnt, len = 0;
 
-  if (descriptor->flags & DDS_TOPIC_CONTAINS_UNION)
-    vec[len++] = "DDS_TOPIC_CONTAINS_UNION";
   if (descriptor->flags & DDS_TOPIC_RESTRICT_DATA_REPRESENTATION)
     vec[len++] = "DDS_TOPIC_RESTRICT_DATA_REPRESENTATION";
 


### PR DESCRIPTION
When using a sample for deserialization of CDR for a type that has a union, the sample data for the union was cleared before
deserialization (indicated by the `DDS_TOPIC_CONTAINS_UNION` flag). In case the union type is used for an external or mutable member, this could lead to reading uninitialized sample data when re-using an allocated sample for multiple reads. E.g. in this data type:

```IDL
@final @nested
union u switch(octet) {
    case 1:
        sequence<string<3> >  u1;
    default:
        string d;
};

@mutable
struct s {
    u f1;
};
```

This commit fixes the issue by introducing a sample-data state parameter in the read functions in cdrstream, and ensures that sample data is only read when the data state is 'initialized'. In case of switching cases for a union, the state for the sample data in that context is set to 'uninitialized', so that the deserializer doesn't read the data (e.g. to check if a pointer needs to be released) for nested types; in that case it will just allocate the memory and assume releasing it is not required.

The `DDS_TOPIC_CONTAINS_UNION` flag is not used anymore and removed from the IDLC generator. It is only kept in `dds_opcodes.h` for backward compatibility.