### PR TITLE
Avoid qsort_r because of older MUSL versions

### DIFF
--- a/src/idl/include/idl/vector.h
+++ b/src/idl/include/idl/vector.h
@@ -31,6 +31,6 @@ void *idl_boxed_vector_next (struct idl_boxed_vector_iter *it);
 void *idl_boxed_vector_first (struct idl_boxed_vector *v, struct idl_boxed_vector_iter *it);
 const void *idl_boxed_vector_next_c (struct idl_boxed_vector_iter *it);
 const void *idl_boxed_vector_first_c (const struct idl_boxed_vector *v, struct idl_boxed_vector_iter *it);
-void idl_boxed_vector_sort (struct idl_boxed_vector *v, int (*cmp) (const void *a, const void *b));
+void idl_boxed_vector_sort (struct idl_boxed_vector *v, int (*cmp) (const void **a, const void **b));
 
 #endif /* IDL_VECTOR_H */

--- a/src/idl/src/keylist.c
+++ b/src/idl/src/keylist.c
@@ -157,9 +157,9 @@ static struct key_container *key_containers_next (struct key_containers_iter *it
 
 /* ======= end of new/free/iterators/... wrappers ======== */
 
-static int cmp_parent_path (const void *a, const void *b)
+static int cmp_parent_path (const void **a, const void **b)
 {
-  return strcmp (a, b);
+  return strcmp (*a, *b);
 }
 
 static void sort_parent_paths (struct key_containers *key_containers)

--- a/src/idl/src/vector.c
+++ b/src/idl/src/vector.c
@@ -8,8 +8,6 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
-#define _GNU_SOURCE
-
 #include <stdlib.h>
 #include <stdint.h>
 #include <assert.h>
@@ -70,36 +68,7 @@ const void *idl_boxed_vector_first_c (const struct idl_boxed_vector *v, struct i
   return idl_boxed_vector_first ((struct idl_boxed_vector *) v, it);
 }
 
-struct cmp_context {
-  int (*cmp) (const void *a, const void *b);
-};
-
-#if defined __GLIBC__
-static int cmp_wrapper (const void *va, const void *vb, void *vcontext)
+void idl_boxed_vector_sort (struct idl_boxed_vector *v, int (*cmp) (const void **a, const void **b))
 {
-  struct cmp_context *context = vcontext;
-  const void * const *a = va;
-  const void * const *b = vb;
-  return context->cmp (*a, *b);
-}
-#else
-static int cmp_wrapper (void *vcontext, const void *va, const void *vb)
-{
-  struct cmp_context *context = vcontext;
-  const void * const *a = va;
-  const void * const *b = vb;
-  return context->cmp (*a, *b);
-}
-#endif
-
-void idl_boxed_vector_sort (struct idl_boxed_vector *v, int (*cmp) (const void *a, const void *b))
-{
-  struct cmp_context context = { .cmp = cmp };
-#if defined __GLIBC__
-  qsort_r (v->xs, v->n, sizeof (*v->xs), cmp_wrapper, &context);
-#elif _WIN32
-  qsort_s (v->xs, v->n, sizeof (*v->xs), cmp_wrapper, &context);
-#else
-  qsort_r (v->xs, v->n, sizeof (*v->xs), &context, cmp_wrapper);
-#endif
+  qsort (v->xs, v->n, sizeof (*v->xs), (int (*) (const void *, const void *)) cmp);
 }


### PR DESCRIPTION
There was only place where it is used, that is in the IDL compiler, to sort a vector of strings. By using qsort_r, the compare function supplied to the "sort vector" operation could operate on elements, with the dereferencing step done inside the vector implementation, which is much nicer than requiring the supplied compare function to do that dereference.

Unfortunately, qsort_r is not sufficiently widely supported.