### PR TITLE
Issue #1312: Generated include guards are insufficient

### DIFF
--- a/src/idl/include/idl/processor.h
+++ b/src/idl/include/idl/processor.h
@@ -25,6 +25,7 @@
 #include "idl/scope.h"
 #include "idl/visit.h"
 #include "idl/attributes.h"
+#include "idl/md5.h"
 
 /* enable "#pragma keylist" for backwards compatibility */
 #define IDL_FLAG_KEYLIST (1u<<0)
@@ -88,6 +89,7 @@ struct idl_pstate {
   void *directive;
   idl_node_t *builtin_root, *root;
   idl_buffer_t buffer; /**< dynamically sized input buffer */
+  idl_md5_byte_t digest[16]; /**< md5 digest of idl source */
   struct {
     enum {
       IDL_SCAN,

--- a/src/tools/idlc/src/libidlc/libidlc__generator.h
+++ b/src/tools/idlc/src/libidlc/libidlc__generator.h
@@ -32,6 +32,7 @@ struct generator {
   struct {
     idlc_generator_config_t c;
     char *export_macro;
+    char *guard_macro;
     bool generate_cdrstream_desc;
   } config;
 };


### PR DESCRIPTION
This commit computes the MD5 hash for IDL source files and utilizes the result to generate a unique header guard macro when combined with the header file path.

Fixes #1312 