### PR TITLE
Introduce ddsrt_allocation_ops and ddsrt_set_allocators

### DIFF
--- a/src/core/xtests/symbol_export/symbol_export.c
+++ b/src/core/xtests/symbol_export/symbol_export.c
@@ -983,6 +983,7 @@ int main (int argc, char **argv)
 #endif
 
   // ddsrt/heap.h
+  ddsrt_allocation_ops_t ao = {0,0,0,0};
   ddsrt_malloc (1);
   ddsrt_malloc_s (1);
   ddsrt_calloc (1, 1);
@@ -990,6 +991,7 @@ int main (int argc, char **argv)
   ddsrt_realloc (ptr, 1);
   ddsrt_realloc_s (ptr, 1);
   ddsrt_free (ptr);
+  ddsrt_set_allocator(ao);
 
   // ddsrt/string.h
   ddsrt_strcasecmp (ptr, ptr);

--- a/src/ddsrt/include/dds/ddsrt/heap.h
+++ b/src/ddsrt/include/dds/ddsrt/heap.h
@@ -26,6 +26,21 @@
 extern "C" {
 #endif
 
+typedef struct ddsrt_allocation_ops {
+  void* (*malloc)  (size_t size);
+  void* (*calloc)  (size_t count, size_t size);
+  void* (*realloc) (void *memblk, size_t size);
+  void  (*free)    (void *ptr);
+} ddsrt_allocation_ops_t;
+
+/// @brief Set the memory allocators
+///
+/// Set the functions to malloc, calloc, realloc, and free memory. By default
+/// the functions of `stdlib` will be used.
+DDS_EXPORT void
+ddsrt_set_allocator(
+  ddsrt_allocation_ops_t custom_ops);
+
 /**
  * @brief Allocate memory from heap.
  *

--- a/src/ddsrt/src/heap/posix/heap.c
+++ b/src/ddsrt/src/heap/posix/heap.c
@@ -13,10 +13,24 @@
 #include "dds/ddsrt/attributes.h"
 #include "dds/ddsrt/heap.h"
 
+static ddsrt_allocation_ops_t ddsrt_allocator = {
+  .malloc = malloc,
+  .calloc = calloc,
+  .realloc = realloc,
+  .free = free,
+};
+
+void
+ddsrt_set_allocator(
+  ddsrt_allocation_ops_t custom_ops)
+{
+  ddsrt_allocator = custom_ops;
+}
+
 void *
 ddsrt_malloc_s(size_t size)
 {
-  return malloc(size ? size : 1); /* Allocate memory even if size == 0 */
+  return ddsrt_allocator.malloc(size ? size : 1); /* Allocate memory even if size == 0 */
 }
 
 void *
@@ -53,7 +67,7 @@ ddsrt_calloc_s(size_t count, size_t size)
   if (count == 0 || size == 0) {
     count = size = 1;
   }
-  return calloc(count, size);
+  return ddsrt_allocator.calloc(count, size);
 }
 
 void *
@@ -78,13 +92,13 @@ ddsrt_realloc_s(void *memblk, size_t size)
      not all platforms will return newmem == NULL. We consistently do, so the
      result of a non-failing ddsrt_realloc_s always needs to be free'd, like
      ddsrt_malloc_s(0). */
-  return realloc(memblk, size ? size : 1);
+  return ddsrt_allocator.realloc(memblk, size ? size : 1);
 }
 
 void
 ddsrt_free(void *ptr)
 {
   if (ptr) {
-    free (ptr);
+    ddsrt_allocator.free (ptr);
   }
 }


### PR DESCRIPTION
This commit introduces the `ddsrt_allocation_ops_t` struct, which encapsulates memory allocation function pointers (malloc, calloc, realloc, free). Additionally the user may change these from the default functions of `stdlib` with the new function `ddsrt_set_allocators`.

The new struct makes it easier to change allocation strategies.

Changes:
- Added `ddsrt_allocation_ops_t` struct
- Added `ddsrt_set_allocators(ddsrt_allocation_ops)`
- Added `static ddsrt_allocator`, with default members from `stdlib`
- Changed `stdlib` allocator calls to use `ddsrt_allocator.{function}` etc.

CP-221