### PR TITLE
Return the actual default partition in dds_qget_partition() whenever possible

### DIFF
--- a/src/core/ddsc/src/dds_qos.c
+++ b/src/core/ddsc/src/dds_qos.c
@@ -618,8 +618,20 @@ bool dds_qget_partition (const dds_qos_t * __restrict qos, uint32_t *n, char ***
     *n = qos->partition.n;
   if (ps)
   {
-    if (qos->partition.n == 0)
-      *ps = NULL;
+    if (qos->partition.n == 0) {
+      /* This is the default partition.
+       * Only when the argument n is non-null, we'll
+       * actually return the default partition (i.e.,
+       * the empty string "").
+       *  */
+      if (n) {
+        *n = 1;
+        *ps = dds_alloc (sizeof (char*));
+        (*ps)[0] = dds_string_dup ("");
+      } else {
+        *ps = NULL;
+      }
+    }
     else
     {
       *ps = dds_alloc (sizeof (char*) * qos->partition.n);


### PR DESCRIPTION
I have run into an issue related to dds_qget_partition()  a number of times. Just recently it reached my annoyance threshold level, so I decided to make a pull request for it.

The issue has to do with dds_qget_partition() related to the default partition. Currently, the behaviour of dds_qget_partition() is to return zero as the number of partition and a NULL-ish list of partitions in case the partition is the default partition (i.e., ""). According to the DDS specification is perfectly legitimate, so from a functional point of view I have no problem with this whatsoever.

However, from a useability point of view I do have problem with it. Typically, in application code that needs to access the code you do something like this:

```
if (dds_qget_partition(qos, &n, &partitions)) {
  for (int i=0; i < n; i++) {
    do_something(partition[i]);
  }
}
```

For the default partition this doesn't work, because the default partition is treated differently: it returns n=0 in that case, so it suggests that there are no partition at all! As a consequence, an application developer needs to treat the default partition case as a special case, in order to deal with the default partition. This is a pity, because it complicates code writing for an application deveoper. And it is easy to forget that the default partition should be treated differently.

To makes life for application developers a little bit easier I suggest to treat the default partition case similar as normal partitions whenever possible. That means that when `dds_qget_partition(qos, &n, &partitions)` is called and the default partition must be returned, then it returns n=1 and partitions[0]="" for the default partition (provided &n and &partitions are non-NULL). In this way an application developer can handle the default partition that is returned from dds_qget_partition() similar as partitions.

This pull request contains the fix that changes the behaviour of dds_qget_partition() for the default partition. In case you share my viewpoints regarding this issue, I would appreciate if you can have a look at this pull request.  
