### PR TITLE
Always respect SPDPInterval setting

### DIFF
--- a/docs/manual/config/config_file_reference.rst
+++ b/docs/manual/config/config_file_reference.rst
@@ -343,11 +343,11 @@ The default value is: ``10``
 
 Number-with-unit
 
-This element specifies the interval between spontaneous transmissions of participant discovery packets.
+This element specifies the interval between spontaneous transmissions of participant discovery packets.  The special value "default" corresponds to approximately 80% of the participant lease duration with a maximum of 30s.
 
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: ``30 s``
+The default value is: ``default``
 
 
 .. _`//CycloneDDS/Domain/Discovery/SPDPMulticastAddress`:
@@ -2634,14 +2634,14 @@ The categorisation of tracing output is incomplete and hence most of the verbosi
 The default value is: ``none``
 
 ..
-   generated from ddsi_config.h[7f55b8f40b2e7f5984106abb0470128eb3d50017] 
+   generated from ddsi_config.h[1ab75f267e0a5303400a6bbfc80e02a86b4cbdce] 
    generated from ddsi__cfgunits.h[bd22f0c0ed210501d0ecd3b07c992eca549ef5aa] 
-   generated from ddsi__cfgelems.h[771184755c23b94599f2ffd6e8c242dcea7d2658] 
-   generated from ddsi_config.c[1b4f1a011d558f331b8a547fd29ab473d0d926d5] 
-   generated from _confgen.h[1b1d88a85bd851f4e87118505ded33f7b33b0435] 
+   generated from ddsi__cfgelems.h[849a4fe147dfa71c5c3a3a4ccaac458530802c8c] 
+   generated from ddsi_config.c[82930450b615afa033986cf5338869bfdaeaf04d] 
+   generated from _confgen.h[e32eabfc35e9f3a7dcb63b19ed148c0d17c6e5fc] 
    generated from _confgen.c[237308acd53897a34e8c643e16e05a61d73ffd65] 
    generated from generate_rnc.c[b50e4b7ab1d04b2bc1d361a0811247c337b74934] 
    generated from generate_md.c[789b92e422631684352909cfb8bf43f6ceb16a01] 
    generated from generate_rst.c[636ceeed42784e8508dd412b88dfd5f3b44b191b] 
    generated from generate_xsd.c[6b6818d7f17a35d56c376c04ec1410427f34c0f0] 
-   generated from generate_defconfig.c[ee80ba6719e71a457a85f1a638fe52f3756916d5] 
+   generated from generate_defconfig.c[63ca9d8ae2f1ce2e761c9d4c0510a45eb062d830] 

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -221,11 +221,11 @@ The default value is: `10`
 #### //CycloneDDS/Domain/Discovery/SPDPInterval
 Number-with-unit
 
-This element specifies the interval between spontaneous transmissions of participant discovery packets.
+This element specifies the interval between spontaneous transmissions of participant discovery packets.  The special value "default" corresponds to approximately 80% of the participant lease duration with a maximum of 30s.
 
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 
-The default value is: `30 s`
+The default value is: `default`
 
 
 #### //CycloneDDS/Domain/Discovery/SPDPMulticastAddress
@@ -1846,14 +1846,14 @@ While none prevents any message from being written to a DDSI2 log file.
 The categorisation of tracing output is incomplete and hence most of the verbosity levels and categories are not of much use in the current release. This is an ongoing process and here we describe the target situation rather than the current situation. Currently, the most useful verbosity levels are config, fine and finest.
 
 The default value is: `none`
-<!--- generated from ddsi_config.h[7f55b8f40b2e7f5984106abb0470128eb3d50017] -->
+<!--- generated from ddsi_config.h[1ab75f267e0a5303400a6bbfc80e02a86b4cbdce] -->
 <!--- generated from ddsi__cfgunits.h[bd22f0c0ed210501d0ecd3b07c992eca549ef5aa] -->
-<!--- generated from ddsi__cfgelems.h[771184755c23b94599f2ffd6e8c242dcea7d2658] -->
-<!--- generated from ddsi_config.c[1b4f1a011d558f331b8a547fd29ab473d0d926d5] -->
-<!--- generated from _confgen.h[1b1d88a85bd851f4e87118505ded33f7b33b0435] -->
+<!--- generated from ddsi__cfgelems.h[849a4fe147dfa71c5c3a3a4ccaac458530802c8c] -->
+<!--- generated from ddsi_config.c[82930450b615afa033986cf5338869bfdaeaf04d] -->
+<!--- generated from _confgen.h[e32eabfc35e9f3a7dcb63b19ed148c0d17c6e5fc] -->
 <!--- generated from _confgen.c[237308acd53897a34e8c643e16e05a61d73ffd65] -->
 <!--- generated from generate_rnc.c[b50e4b7ab1d04b2bc1d361a0811247c337b74934] -->
 <!--- generated from generate_md.c[789b92e422631684352909cfb8bf43f6ceb16a01] -->
 <!--- generated from generate_rst.c[636ceeed42784e8508dd412b88dfd5f3b44b191b] -->
 <!--- generated from generate_xsd.c[6b6818d7f17a35d56c376c04ec1410427f34c0f0] -->
-<!--- generated from generate_defconfig.c[ee80ba6719e71a457a85f1a638fe52f3756916d5] -->
+<!--- generated from generate_defconfig.c[63ca9d8ae2f1ce2e761c9d4c0510a45eb062d830] -->

--- a/etc/cyclonedds.rnc
+++ b/etc/cyclonedds.rnc
@@ -158,9 +158,9 @@ CycloneDDS configuration""" ] ]
           }?
         }?
         & [ a:documentation [ xml:lang="en" """
-<p>This element specifies the interval between spontaneous transmissions of participant discovery packets.</p>
+<p>This element specifies the interval between spontaneous transmissions of participant discovery packets.  The special value "default" corresponds to approximately 80% of the participant lease duration with a maximum of 30s.</p>
 <p>The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.</p>
-<p>The default value is: <code>30 s</code></p>""" ] ]
+<p>The default value is: <code>default</code></p>""" ] ]
         element SPDPInterval {
           duration
         }?
@@ -1280,14 +1280,14 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==<br>
   duration_inf = xsd:token { pattern = "inf|0|(\d+(\.\d*)?([Ee][\-+]?\d+)?|\.\d+([Ee][\-+]?\d+)?) *([num]?s|min|hr|day)" }
   memsize = xsd:token { pattern = "0|(\d+(\.\d*)?([Ee][\-+]?\d+)?|\.\d+([Ee][\-+]?\d+)?) *([kMG]i?)?B" }
 }
-# generated from ddsi_config.h[7f55b8f40b2e7f5984106abb0470128eb3d50017] 
+# generated from ddsi_config.h[1ab75f267e0a5303400a6bbfc80e02a86b4cbdce] 
 # generated from ddsi__cfgunits.h[bd22f0c0ed210501d0ecd3b07c992eca549ef5aa] 
-# generated from ddsi__cfgelems.h[771184755c23b94599f2ffd6e8c242dcea7d2658] 
-# generated from ddsi_config.c[1b4f1a011d558f331b8a547fd29ab473d0d926d5] 
-# generated from _confgen.h[1b1d88a85bd851f4e87118505ded33f7b33b0435] 
+# generated from ddsi__cfgelems.h[849a4fe147dfa71c5c3a3a4ccaac458530802c8c] 
+# generated from ddsi_config.c[82930450b615afa033986cf5338869bfdaeaf04d] 
+# generated from _confgen.h[e32eabfc35e9f3a7dcb63b19ed148c0d17c6e5fc] 
 # generated from _confgen.c[237308acd53897a34e8c643e16e05a61d73ffd65] 
 # generated from generate_rnc.c[b50e4b7ab1d04b2bc1d361a0811247c337b74934] 
 # generated from generate_md.c[789b92e422631684352909cfb8bf43f6ceb16a01] 
 # generated from generate_rst.c[636ceeed42784e8508dd412b88dfd5f3b44b191b] 
 # generated from generate_xsd.c[6b6818d7f17a35d56c376c04ec1410427f34c0f0] 
-# generated from generate_defconfig.c[ee80ba6719e71a457a85f1a638fe52f3756916d5] 
+# generated from generate_defconfig.c[63ca9d8ae2f1ce2e761c9d4c0510a45eb062d830] 

--- a/etc/cyclonedds.xsd
+++ b/etc/cyclonedds.xsd
@@ -274,9 +274,9 @@ CycloneDDS configuration</xs:documentation>
   <xs:element name="SPDPInterval" type="config:duration">
     <xs:annotation>
       <xs:documentation>
-&lt;p&gt;This element specifies the interval between spontaneous transmissions of participant discovery packets.&lt;/p&gt;
+&lt;p&gt;This element specifies the interval between spontaneous transmissions of participant discovery packets.  The special value "default" corresponds to approximately 80% of the participant lease duration with a maximum of 30s.&lt;/p&gt;
 &lt;p&gt;The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.&lt;/p&gt;
-&lt;p&gt;The default value is: &lt;code&gt;30 s&lt;/code&gt;&lt;/p&gt;</xs:documentation>
+&lt;p&gt;The default value is: &lt;code&gt;default&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="SPDPMulticastAddress" type="xs:string">
@@ -1947,14 +1947,14 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
     </xs:restriction>
   </xs:simpleType>
 </xs:schema>
-<!--- generated from ddsi_config.h[7f55b8f40b2e7f5984106abb0470128eb3d50017] -->
+<!--- generated from ddsi_config.h[1ab75f267e0a5303400a6bbfc80e02a86b4cbdce] -->
 <!--- generated from ddsi__cfgunits.h[bd22f0c0ed210501d0ecd3b07c992eca549ef5aa] -->
-<!--- generated from ddsi__cfgelems.h[771184755c23b94599f2ffd6e8c242dcea7d2658] -->
-<!--- generated from ddsi_config.c[1b4f1a011d558f331b8a547fd29ab473d0d926d5] -->
-<!--- generated from _confgen.h[1b1d88a85bd851f4e87118505ded33f7b33b0435] -->
+<!--- generated from ddsi__cfgelems.h[849a4fe147dfa71c5c3a3a4ccaac458530802c8c] -->
+<!--- generated from ddsi_config.c[82930450b615afa033986cf5338869bfdaeaf04d] -->
+<!--- generated from _confgen.h[e32eabfc35e9f3a7dcb63b19ed148c0d17c6e5fc] -->
 <!--- generated from _confgen.c[237308acd53897a34e8c643e16e05a61d73ffd65] -->
 <!--- generated from generate_rnc.c[b50e4b7ab1d04b2bc1d361a0811247c337b74934] -->
 <!--- generated from generate_md.c[789b92e422631684352909cfb8bf43f6ceb16a01] -->
 <!--- generated from generate_rst.c[636ceeed42784e8508dd412b88dfd5f3b44b191b] -->
 <!--- generated from generate_xsd.c[6b6818d7f17a35d56c376c04ec1410427f34c0f0] -->
-<!--- generated from generate_defconfig.c[ee80ba6719e71a457a85f1a638fe52f3756916d5] -->
+<!--- generated from generate_defconfig.c[63ca9d8ae2f1ce2e761c9d4c0510a45eb062d830] -->

--- a/src/core/ddsi/defconfig.c
+++ b/src/core/ddsi/defconfig.c
@@ -33,7 +33,7 @@ void ddsi_config_init_default (struct ddsi_config *cfg)
   cfg->participantIndex = INT32_C (-2);
   cfg->maxAutoParticipantIndex = INT32_C (9);
   cfg->spdpMulticastAddressString = "239.255.0.1";
-  cfg->spdp_interval = INT64_C (30000000000);
+  cfg->spdp_interval.isdefault = 1;
   cfg->ports.base = UINT32_C (7400);
   cfg->ports.dg = UINT32_C (250);
   cfg->ports.pg = UINT32_C (2);
@@ -103,14 +103,14 @@ void ddsi_config_init_default (struct ddsi_config *cfg)
   cfg->shm_log_lvl = INT32_C (4);
 #endif /* DDS_HAS_SHM */
 }
-/* generated from ddsi_config.h[7f55b8f40b2e7f5984106abb0470128eb3d50017] */
+/* generated from ddsi_config.h[1ab75f267e0a5303400a6bbfc80e02a86b4cbdce] */
 /* generated from ddsi__cfgunits.h[bd22f0c0ed210501d0ecd3b07c992eca549ef5aa] */
-/* generated from ddsi__cfgelems.h[771184755c23b94599f2ffd6e8c242dcea7d2658] */
-/* generated from ddsi_config.c[1b4f1a011d558f331b8a547fd29ab473d0d926d5] */
-/* generated from _confgen.h[1b1d88a85bd851f4e87118505ded33f7b33b0435] */
+/* generated from ddsi__cfgelems.h[849a4fe147dfa71c5c3a3a4ccaac458530802c8c] */
+/* generated from ddsi_config.c[82930450b615afa033986cf5338869bfdaeaf04d] */
+/* generated from _confgen.h[e32eabfc35e9f3a7dcb63b19ed148c0d17c6e5fc] */
 /* generated from _confgen.c[237308acd53897a34e8c643e16e05a61d73ffd65] */
 /* generated from generate_rnc.c[b50e4b7ab1d04b2bc1d361a0811247c337b74934] */
 /* generated from generate_md.c[789b92e422631684352909cfb8bf43f6ceb16a01] */
 /* generated from generate_rst.c[636ceeed42784e8508dd412b88dfd5f3b44b191b] */
 /* generated from generate_xsd.c[6b6818d7f17a35d56c376c04ec1410427f34c0f0] */
-/* generated from generate_defconfig.c[ee80ba6719e71a457a85f1a638fe52f3756916d5] */
+/* generated from generate_defconfig.c[63ca9d8ae2f1ce2e761c9d4c0510a45eb062d830] */

--- a/src/core/ddsi/include/dds/ddsi/ddsi_config.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_config.h
@@ -115,6 +115,11 @@ struct ddsi_config_maybe_uint32 {
   uint32_t value;
 };
 
+struct ddsi_config_maybe_duration {
+  int isdefault;
+  dds_duration_t value;
+};
+
 struct ddsi_config_thread_properties_listelem {
   struct ddsi_config_thread_properties_listelem *next;
   char *name;
@@ -278,7 +283,7 @@ struct ddsi_config
   int maxAutoParticipantIndex;
   char *spdpMulticastAddressString;
   char *defaultMulticastAddressString;
-  int64_t spdp_interval;
+  struct ddsi_config_maybe_duration spdp_interval;
   int64_t spdp_response_delay_max;
   int64_t lease_duration;
   int64_t const_hb_intv_sched;

--- a/src/core/ddsi/src/ddsi__cfgelems.h
+++ b/src/core/ddsi/src/ddsi__cfgelems.h
@@ -1844,12 +1844,14 @@ static struct cfgelem discovery_cfgelems[] = {
       "ff02::ffff:239.255.0.1, which is a non-standardised link-local "
       "multicast address.</p>"
     )),
-  STRING("SPDPInterval", NULL, 1, "30 s",
+  STRING("SPDPInterval", NULL, 1, "default",
     MEMBER(spdp_interval),
-    FUNCTIONS(0, uf_duration_ms_1hr, 0, pf_duration),
+    FUNCTIONS(0, uf_maybe_duration_ms_1hr, 0, pf_maybe_duration),
     DESCRIPTION(
       "<p>This element specifies the interval between spontaneous "
-      "transmissions of participant discovery packets.</p>"),
+      "transmissions of participant discovery packets.  The special "
+      "value \"default\" corresponds to approximately 80% of the "
+      "participant lease duration with a maximum of 30s.</p>"),
     UNIT("duration")),
   STRING("DefaultMulticastAddress", NULL, 1, "auto",
     MEMBER(defaultMulticastAddressString),

--- a/src/core/ddsi/src/ddsi_discovery_spdp.c
+++ b/src/core/ddsi/src/ddsi_discovery_spdp.c
@@ -374,9 +374,6 @@ static void ddsi_spdp_directed_xevent_cb (struct ddsi_domaingv *gv, struct ddsi_
 
 static void resched_spdp_broadcast (struct ddsi_xevent *ev, struct ddsi_participant *pp, ddsrt_mtime_t tnow)
 {
-  /* schedule next when 80% of the interval has elapsed, or 2s
-     before the lease ends, whichever comes first (similar to PMD),
-     but never wait longer than spdp_interval */
   struct ddsi_domaingv * const gv = pp->e.gv;
   const dds_duration_t mindelta = DDS_MSECS (10);
   ddsrt_mtime_t tnext;
@@ -386,6 +383,8 @@ static void resched_spdp_broadcast (struct ddsi_xevent *ev, struct ddsi_particip
     intv = gv->config.spdp_interval.value;
   else
   {
+    // Default interval is 80% of the lease duration with a bit of fiddling around the
+    // edges (similar to PMD), and with an upper limit
     const dds_duration_t ldur = pp->plist->qos.liveliness.lease_duration;
     if (ldur < 5 * mindelta / 4)
       intv = mindelta;

--- a/src/tools/_confgen/_confgen.h
+++ b/src/tools/_confgen/_confgen.h
@@ -39,6 +39,7 @@ void gendef_pf_maybe_memsize (FILE *fp, void *parent, struct cfgelem const * con
 void gendef_pf_int (FILE *fp, void *parent, struct cfgelem const * const cfgelem);
 void gendef_pf_uint (FILE *fp, void *parent, struct cfgelem const * const cfgelem);
 void gendef_pf_duration (FILE *fp, void *parent, struct cfgelem const * const cfgelem);
+void gendef_pf_maybe_duration (FILE *fp, void *parent, struct cfgelem const * const cfgelem);
 void gendef_pf_domainId(FILE *fp, void *parent, struct cfgelem const * const cfgelem);
 void gendef_pf_participantIndex (FILE *fp, void *parent, struct cfgelem const * const cfgelem);
 void gendef_pf_boolean (FILE *fp, void *parent, struct cfgelem const * const cfgelem);

--- a/src/tools/_confgen/generate_defconfig.c
+++ b/src/tools/_confgen/generate_defconfig.c
@@ -146,6 +146,12 @@ void gendef_pf_uint (FILE *out, void *parent, struct cfgelem const * const cfgel
 void gendef_pf_duration (FILE *out, void *parent, struct cfgelem const * const cfgelem) {
   gendef_pf_int64 (out, parent, cfgelem);
 }
+void gendef_pf_maybe_duration (FILE *out, void *parent, struct cfgelem const * const cfgelem) {
+  struct ddsi_config_maybe_duration const * const p = cfg_address (parent, cfgelem);
+  fprintf (out, "  cfg->%s.isdefault = %d;\n", cfgelem->membername, p->isdefault);
+  if (!p->isdefault)
+    fprintf (out, "  cfg->%s.value = INT64_C (%"PRIu64");\n", cfgelem->membername, p->value);
+}
 void gendef_pf_domainId(FILE *out, void *parent, struct cfgelem const * const cfgelem) {
   (void) out; (void) parent; (void) cfgelem;
   // skipped on purpose: set explicitly


### PR DESCRIPTION
The code used to silently limit the SPDP interval to approximately 80% of the lease duration for addressing some interoperability issues at some point in the past.  That meant that even in a Cyclone-only system it would be impossible to raise the interval beyond this limit.

This extends the valid values with the special value "default" in which case it does exactly the same as it used to do if the setting was left at the default (30s).  With this change, if it is set to a numerical value, that specified interval is respected without taking the lease duration into consideration.

That means that a configuration in which the SPDP interval was set to some value greater than 80% of the lease duration, the rate now goes down.  In all other cases, the behaviour is unchanged.