### PR TITLE
Coverity fixes

### DIFF
--- a/src/core/ddsc/src/dds__types.h
+++ b/src/core/ddsc/src/dds__types.h
@@ -15,6 +15,7 @@
 
 #include "dds/dds.h"
 #include "dds/ddsrt/sync.h"
+#include "dds/ddsrt/dynlib.h"
 #include "dds/ddsi/ddsi_protocol.h"
 #include "dds/ddsi/ddsi_domaingv.h"
 #ifdef DDS_HAS_TOPIC_DISCOVERY
@@ -273,6 +274,7 @@ typedef struct dds_cyclonedds_entity {
 struct dds_psmx_set {
   uint32_t length;
   struct dds_psmx *instances[DDS_MAX_PSMX_INSTANCES];
+  ddsrt_dynlib_t lib_handles[DDS_MAX_PSMX_INSTANCES];
 };
 
 typedef struct dds_domain {

--- a/src/core/ddsc/tests/psmx_cdds_impl.c
+++ b/src/core/ddsc/tests/psmx_cdds_impl.c
@@ -497,6 +497,7 @@ dds_return_t cdds_create_psmx (dds_psmx_t **psmx_out, dds_psmx_instance_id_t ins
         dds_free (lstr);
         goto err_locator;
       }
+      unsigned char * const dst = (unsigned char *) psmx->c.locator->address;
       for (uint32_t n = 0; n < 32 && lstr[n]; n++)
       {
         int32_t num;
@@ -505,7 +506,10 @@ dds_return_t cdds_create_psmx (dds_psmx_t **psmx_out, dds_psmx_instance_id_t ins
           dds_free (lstr);
           goto err_locator;
         }
-        ((char *) (psmx->c.locator->address))[n / 2] |= (char) ((n % 1) ? (num << 4) : num);
+        if ((n % 2) == 0)
+          dst[n / 2] = (uint8_t) (num << 4);
+        else
+          dst[n / 2] |= (uint8_t) num;
       }
       dds_free (lstr);
     }


### PR DESCRIPTION
Coverity found (only!) two real mishaps in the PSMX code base:

* A silly mistake in computing the locator in the Cyclone-based PSMX plugin for testing (in a way that doesn't affect the test)
* Not invoking `dlclose` on the PSMX plugin on shutdown.