### PR TITLE
Export dds_write_impl

### DIFF
--- a/cmake/Modules/GenerateExportHeader.cmake
+++ b/cmake/Modules/GenerateExportHeader.cmake
@@ -63,6 +63,19 @@ if(_include_file)
 #    define ${_prefix_name}${_base_name_upper}_INLINE_EXPORT ${_prefix_name}${_base_name_upper}_EXPORT
 #  endif
 #endif
+
+// Some internal functions are exported even though are not part of the API nor
+// foreseen to ever be called by a user of the library (unlike some functions
+// that are exported for convenience in building tools or even examples, such as
+// the AVL tree).  One reason for this is that they are useful in instrumenting
+// Cyclone DDS with some performance analysis tools, and it is in the interest
+// of the projec that such analyses can be done.
+//
+// There is no guarantee that such internal symbols will remain available or
+// that their role will be the same.
+#ifndef ${_prefix_name}${_base_name_upper}_EXPORT_INTERNAL_FUNCTION
+#  define ${_prefix_name}${_base_name_upper}_EXPORT_INTERNAL_FUNCTION ${_prefix_name}${_base_name_upper}_EXPORT
+#endif
 ")
 
     if(_GEHW_CUSTOM_CONTENT_FROM_VARIABLE)

--- a/src/core/ddsc/src/dds__write.h
+++ b/src/core/ddsc/src/dds__write.h
@@ -11,6 +11,8 @@
 #ifndef DDS__WRITE_H
 #define DDS__WRITE_H
 
+#include "dds/export.h"
+
 #if defined (__cplusplus)
 extern "C" {
 #endif
@@ -29,6 +31,7 @@ typedef enum {
 } dds_write_action;
 
 /** @component write_data */
+DDS_EXPORT_INTERNAL_FUNCTION
 dds_return_t dds_write_impl (dds_writer *wr, const void *data, dds_time_t tstamp, dds_write_action action);
 
 /** @component write_data */

--- a/src/core/xtests/symbol_export/symbol_export.c
+++ b/src/core/xtests/symbol_export/symbol_export.c
@@ -71,6 +71,8 @@
 
 #include "dds/cdr/dds_cdrstream.h"
 
+#include "dds__write.h" // dds_write_impl
+
 DDSRT_WARNING_DEPRECATED_OFF
 
 #ifdef DDS_HAS_SECURITY
@@ -1050,6 +1052,9 @@ int main (int argc, char **argv)
   // ddsrt/io.h
   test_ddsrt_vasprintf (ptr, " ");
   ddsrt_asprintf (ptr, " ");
+
+  // dds__write.h
+  dds_write_impl (ptr, ptr, 0, (dds_write_action) 0);
 
   return 0;
 }


### PR DESCRIPTION
dds_write_impl is a convenient trace point for instrumenting the code for performance measurements.

Fixes #1833.