### PR TITLE
set the same vlan id on all the locators

### DIFF
--- a/src/core/ddsi/src/ddsi_nwpart.c
+++ b/src/core/ddsi/src/ddsi_nwpart.c
@@ -465,7 +465,7 @@ static int correct_nwpart_aux_locator (struct ddsi_domaingv *gv)
       }
     }
   }
-  return nwpart_iter_fini (&npit) ? 0 : -1;;
+  return nwpart_iter_fini (&npit) ? 0 : -1;
 }
 
 int ddsi_convert_nwpart_config (struct ddsi_domaingv *gv, uint32_t port_data_uc)

--- a/src/core/ddsi/src/ddsi_nwpart.c
+++ b/src/core/ddsi/src/ddsi_nwpart.c
@@ -420,6 +420,54 @@ static int check_nwpart_address_consistency (struct ddsi_domaingv *gv)
   return nwpart_iter_fini (&npit) ? 0 : -1;
 }
 
+static int correct_nwpart_aux_locator (struct ddsi_domaingv *gv)
+{
+  struct nwpart_iter npit;
+  nwpart_iter_init (&npit, gv);
+  struct ddsi_config_networkpartition_listelem *np;
+
+  if (gv->config.transport_selector != DDSI_TRANS_RAWETH)
+    return 0;
+
+  struct ddsi_tran_factory * const tran = ddsi_factory_find_supported_kind (gv, DDSI_LOCATOR_KIND_RAWETH);
+  assert (tran != NULL);
+
+  while ((np = nwpart_iter_next (&npit)) != NULL)
+  {
+    uint32_t loc_aux = 0;
+
+    for (struct ddsi_networkpartition_address *a = np->asm_addresses; a && loc_aux == 0; a = a->next)
+      loc_aux = ddsi_tran_get_locator_aux (tran, &a->loc);
+    for (struct ddsi_networkpartition_address *a = np->uc_addresses; a && loc_aux == 0; a = a->next)
+      loc_aux = ddsi_tran_get_locator_aux (tran, &a->loc);
+    if (loc_aux > 0)
+    {
+      uint32_t aux;
+      for (struct ddsi_networkpartition_address *a = np->asm_addresses; a; a = a->next)
+      {
+        if ((aux = ddsi_tran_get_locator_aux (tran, &a->loc)) == 0)
+          ddsi_tran_set_locator_aux (tran, &a->loc, loc_aux);
+        else if (aux != loc_aux)
+        {
+          nwpart_iter_error (&npit, "", "network partition should use the same vlan id for each address");
+          break;
+        }
+      }
+      for (struct ddsi_networkpartition_address *a = np->uc_addresses; a; a = a->next)
+      {
+        if ((aux = ddsi_tran_get_locator_aux (tran, &a->loc)) == 0)
+          ddsi_tran_set_locator_aux (tran, &a->loc, loc_aux);
+        else if (aux != loc_aux)
+        {
+          nwpart_iter_error (&npit, "", "network partition should use the same vlan id for each address");
+          break;
+        }
+      }
+    }
+  }
+  return nwpart_iter_fini (&npit) ? 0 : -1;;
+}
+
 int ddsi_convert_nwpart_config (struct ddsi_domaingv *gv, uint32_t port_data_uc)
 {
   int rc;
@@ -428,6 +476,8 @@ int ddsi_convert_nwpart_config (struct ddsi_domaingv *gv, uint32_t port_data_uc)
   if ((rc = convert_network_partition_interfaces (gv, port_data_uc)) < 0)
     return rc;
   if ((rc = check_nwpart_address_consistency (gv)) < 0)
+    return rc;
+  if ((rc = correct_nwpart_aux_locator (gv)) < 0)
     return rc;
   return 0;
 }

--- a/src/core/ddsi/src/ddsi_raweth.c
+++ b/src/core/ddsi/src/ddsi_raweth.c
@@ -386,7 +386,7 @@ static int joinleave_asm_mcgroup (ddsrt_socket_t socket, int join, const ddsi_lo
   mreq.mr_ifindex = (int)interf->if_index;
   mreq.mr_type = PACKET_MR_MULTICAST;
   mreq.mr_alen = 6;
-  memcpy(mreq.mr_address, mcloc + 10, 6);
+  memcpy(mreq.mr_address, mcloc->address + 10, 6);
   rc = ddsrt_setsockopt(socket, SOL_PACKET, join ? PACKET_ADD_MEMBERSHIP : PACKET_DROP_MEMBERSHIP, &mreq, sizeof(mreq));
   return (rc == DDS_RETCODE_OK) ? 0 : rc;
 }


### PR DESCRIPTION
To use a specific vlan for a particular NetworkPartition then the vlan id is configured as part of the address (multicast) set for the NetworkPartition. This results in that the vlan id is set on the corresponding multicast locator. However it is not set on the unicast locator associated with the chosen ethernet interface.