### PR TITLE
CP-492 Add documentation for setting allocation strategy

### DIFF
--- a/docs/manual/config/allocation-config.rst
+++ b/docs/manual/config/allocation-config.rst
@@ -1,0 +1,21 @@
+.. _allocation_config:
+
+*********************
+Memory Allocation Configuration
+*********************
+
+Users have the flexibility to customize the memory allocation strategy for |var-project| by leveraging their own memory allocation libraries. To utilise your preferred memory allocation functions, follow these steps:
+
+1. Include `dds/ddsrt/heap.h`
+   To gain access to `ddsrt_allocation_ops_t` and `ddsrt_set_allocator`.
+
+2. Set the allocation operations
+   Define a `ddsrt_allocation_ops_t` structure that contains pointers to the functions you want to use for memory allocation and deallocation (`malloc`, `calloc`, `realloc`, and `free`).
+
+3. Provide `ddsrt` the operations
+   Utilize the `ddsrt_set_allocator` function to set the ops chosen in step 2.
+
+4. Link with custom library
+   Compile and link your application with the library that contains the functions specified in the `ddsrt_allocation_ops_t` structure created in step 2.
+
+By following these steps, you can tailor the memory allocation mechanism of |var-project| to meet your specific requirements.

--- a/docs/manual/config/index.rst
+++ b/docs/manual/config/index.rst
@@ -112,3 +112,4 @@ To determine the information included in the log file, change the :ref:`Tracing/
    conformance
    config_file_reference
    benchmarking
+   allocation-config


### PR DESCRIPTION
This will make it obvious to users that they can tailor the memory (de)allocation strategy to their specific needs.