### PR TITLE
Check for required serdata ops before enabling PSMX on an endpoint

### DIFF
--- a/src/core/ddsc/src/dds__qos.h
+++ b/src/core/ddsc/src/dds__qos.h
@@ -60,7 +60,7 @@ extern "C" {
 dds_return_t dds_ensure_valid_data_representation (dds_qos_t *qos, uint32_t allowed_data_representations, bool topicqos);
 
 /** @component qos_obj */
-dds_return_t dds_ensure_valid_psmx_instances (dds_qos_t *qos, dds_psmx_endpoint_type_t forwhat, dds_data_type_properties_t data_type_props, const struct dds_psmx_set *psmx_instances);
+dds_return_t dds_ensure_valid_psmx_instances (dds_qos_t *qos, dds_psmx_endpoint_type_t forwhat, const struct ddsi_sertype *stype, const struct dds_psmx_set *psmx_instances);
 
 /** @component qos_obj */
 bool dds_qos_has_psmx_instances (const dds_qos_t *qos, const char *psmx_instance_name);

--- a/src/core/ddsc/src/dds_qos.c
+++ b/src/core/ddsc/src/dds_qos.c
@@ -936,8 +936,8 @@ dds_return_t dds_ensure_valid_psmx_instances (dds_qos_t *qos, dds_psmx_endpoint_
   const char *supported_psmx[DDS_MAX_PSMX_INSTANCES];
 
   // Check sertype has operations required by PSMX
-  if (forwhat == DDS_PSMX_ENDPOINT_TYPE_WRITER && stype->serdata_ops->from_loaned_sample ||
-      forwhat == DDS_PSMX_ENDPOINT_TYPE_READER && stype->serdata_ops->from_psmx)
+  if ((forwhat == DDS_PSMX_ENDPOINT_TYPE_WRITER && stype->serdata_ops->from_loaned_sample) ||
+      (forwhat == DDS_PSMX_ENDPOINT_TYPE_READER && stype->serdata_ops->from_psmx))
   {
     if (!(qos->present & DDSI_QP_PSMX))
     {

--- a/src/core/ddsc/src/dds_qos.c
+++ b/src/core/ddsc/src/dds_qos.c
@@ -17,6 +17,7 @@
 #include "dds/ddsrt/string.h"
 #include "dds/ddsi/ddsi_plist.h"
 #include "dds/ddsi/ddsi_domaingv.h"
+#include "dds/ddsi/ddsi_serdata.h"
 #include "dds/ddsi/ddsi_sertype.h"
 #include "dds__qos.h"
 #include "dds__topic.h"
@@ -929,40 +930,45 @@ bool dds_qget_psmx_instances (const dds_qos_t * __restrict qos, uint32_t *n_out,
   return true;
 }
 
-dds_return_t dds_ensure_valid_psmx_instances (dds_qos_t *qos, dds_psmx_endpoint_type_t forwhat, dds_data_type_properties_t data_type_props, const struct dds_psmx_set *psmx_instances)
+dds_return_t dds_ensure_valid_psmx_instances (dds_qos_t *qos, dds_psmx_endpoint_type_t forwhat, const struct ddsi_sertype *stype, const struct dds_psmx_set *psmx_instances)
 {
   uint32_t n_supported = 0;
   const char *supported_psmx[DDS_MAX_PSMX_INSTANCES];
 
-  if (!(qos->present & DDSI_QP_PSMX))
+  // Check sertype has operations required by PSMX
+  if (forwhat == DDS_PSMX_ENDPOINT_TYPE_WRITER && stype->serdata_ops->from_loaned_sample ||
+      forwhat == DDS_PSMX_ENDPOINT_TYPE_READER && stype->serdata_ops->from_psmx)
   {
-    assert (psmx_instances->length <= DDS_MAX_PSMX_INSTANCES);
-    for (uint32_t i = 0; i < psmx_instances->length; i++)
+    if (!(qos->present & DDSI_QP_PSMX))
     {
-      struct dds_psmx *psmx = psmx_instances->instances[i];
-      if (psmx->ops.type_qos_supported (psmx, forwhat, data_type_props, qos))
-        supported_psmx[n_supported++] = psmx->instance_name;
-    }
-  }
-  else
-  {
-    uint32_t n = 0;
-    char **values;
-    dds_qget_psmx_instances (qos, &n, &values);
-    for (uint32_t i = 0; i < n; i++)
-    {
-      struct dds_psmx *psmx = NULL;
-      for (uint32_t s = 0; psmx == NULL && s < psmx_instances->length; s++)
+      assert (psmx_instances->length <= DDS_MAX_PSMX_INSTANCES);
+      for (uint32_t i = 0; i < psmx_instances->length; i++)
       {
-        assert (psmx_instances->instances[s]);
-        if (strcmp (psmx_instances->instances[s]->instance_name, values[i]) == 0)
-          psmx = psmx_instances->instances[i];
+        struct dds_psmx *psmx = psmx_instances->instances[i];
+        if (psmx->ops.type_qos_supported (psmx, forwhat, stype->data_type_props, qos))
+          supported_psmx[n_supported++] = psmx->instance_name;
       }
-      if (psmx != NULL && psmx->ops.type_qos_supported (psmx, forwhat, data_type_props, qos))
-        supported_psmx[n_supported++] = psmx->instance_name;
-      dds_free (values[i]);
     }
-    dds_free (values);
+    else
+    {
+      uint32_t n = 0;
+      char **values;
+      dds_qget_psmx_instances (qos, &n, &values);
+      for (uint32_t i = 0; i < n; i++)
+      {
+        struct dds_psmx *psmx = NULL;
+        for (uint32_t s = 0; psmx == NULL && s < psmx_instances->length; s++)
+        {
+          assert (psmx_instances->instances[s]);
+          if (strcmp (psmx_instances->instances[s]->instance_name, values[i]) == 0)
+            psmx = psmx_instances->instances[i];
+        }
+        if (psmx != NULL && psmx->ops.type_qos_supported (psmx, forwhat, stype->data_type_props, qos))
+          supported_psmx[n_supported++] = psmx->instance_name;
+        dds_free (values[i]);
+      }
+      dds_free (values);
+    }
   }
 
   dds_qset_psmx_instances (qos, n_supported, supported_psmx);

--- a/src/core/ddsc/src/dds_reader.c
+++ b/src/core/ddsc/src/dds_reader.c
@@ -572,7 +572,7 @@ static dds_entity_t dds_create_reader_int (dds_entity_t participant_or_subscribe
 
   if ((rc = dds_ensure_valid_data_representation (rqos, tp->m_stype->allowed_data_representation, false)) != DDS_RETCODE_OK)
     goto err_data_repr;
-  if ((rc = dds_ensure_valid_psmx_instances (rqos, DDS_PSMX_ENDPOINT_TYPE_READER, tp->m_stype->data_type_props, &sub->m_entity.m_domain->psmx_instances)) != DDS_RETCODE_OK)
+  if ((rc = dds_ensure_valid_psmx_instances (rqos, DDS_PSMX_ENDPOINT_TYPE_READER, tp->m_stype, &sub->m_entity.m_domain->psmx_instances)) != DDS_RETCODE_OK)
     goto err_psmx;
 
   if ((rc = ddsi_xqos_valid (&gv->logconfig, rqos)) < 0 || (rc = validate_reader_qos(rqos)) != DDS_RETCODE_OK)

--- a/src/core/ddsc/src/dds_writer.c
+++ b/src/core/ddsc/src/dds_writer.c
@@ -364,7 +364,7 @@ dds_entity_t dds_create_writer (dds_entity_t participant_or_publisher, dds_entit
 
   if ((rc = dds_ensure_valid_data_representation (wqos, tp->m_stype->allowed_data_representation, false)) != DDS_RETCODE_OK)
     goto err_data_repr;
-  if ((rc = dds_ensure_valid_psmx_instances (wqos, DDS_PSMX_ENDPOINT_TYPE_WRITER, tp->m_stype->data_type_props, &pub->m_entity.m_domain->psmx_instances)) != DDS_RETCODE_OK)
+  if ((rc = dds_ensure_valid_psmx_instances (wqos, DDS_PSMX_ENDPOINT_TYPE_WRITER, tp->m_stype, &pub->m_entity.m_domain->psmx_instances)) != DDS_RETCODE_OK)
     goto err_psmx;
 
   if ((rc = ddsi_xqos_valid (&gv->logconfig, wqos)) < 0 || (rc = validate_writer_qos(wqos)) != DDS_RETCODE_OK)


### PR DESCRIPTION
This PR adds an additional check to dds_ensure_valid_psmx_instances() which validates that the required serdata operations are present for the sertype. For a writer, it checks for the from_loaned_sample() operation; for a reader, it checks for the from_psmx() operation. If the required operation is not present no PSMX instances will be added to the supported_psmx list.

Without this (or a similar) check, Cyclone may call these operations on a custom sertype implementation that doesn't provide implementations potentially resulting in a segmentation fault. As an example of this, the [Zenoh DDS Bridge](https://github.com/eclipse-zenoh/zenoh-plugin-dds) uses such a custom sertype which is used when type information isn't available.