### PR TITLE
fix ddsrt_getprocessname() for FreeRTOS

### DIFF
--- a/src/ddsrt/src/process/freertos/process.c
+++ b/src/ddsrt/src/process/freertos/process.c
@@ -9,6 +9,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 #include "dds/ddsrt/process.h"
+#include "dds/ddsrt/string.h"
 
 #include <FreeRTOS.h>
 #include <task.h>
@@ -22,5 +23,5 @@ ddsrt_getpid(void)
 char *
 ddsrt_getprocessname(void)
 {
-  return pcTaskGetName(xTaskGetCurrentTaskHandle());
+  return ddsrt_strdup(pcTaskGetName(xTaskGetCurrentTaskHandle()));
 }


### PR DESCRIPTION
Now `ddsrt_getprocessname(void)` returns the copy of string of process name, so it can be free correctly.