### PR TITLE
Introduce `ddsrt_abort` and `ddsrt_exit`

### DIFF
--- a/src/core/cdr/src/dds_cdrstream.c
+++ b/src/core/cdr/src/dds_cdrstream.c
@@ -15,6 +15,7 @@
 #include "dds/ddsrt/endian.h"
 #include "dds/ddsrt/md5.h"
 #include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/process.h"
 #include "dds/ddsrt/string.h"
 #include "dds/ddsrt/static_assert.h"
 #include "dds/cdr/dds_cdrstream.h"
@@ -488,7 +489,7 @@ static uint32_t get_collection_elem_size (uint32_t insn, const uint32_t * __rest
     case DDS_OP_VAL_EXT:
       break;
   }
-  abort ();
+  ddsrt_abort();
   return 0u;
 }
 
@@ -531,7 +532,7 @@ static uint32_t get_adr_type_size (uint32_t insn, const uint32_t * __restrict op
     case DDS_OP_VAL_UNI:
     case DDS_OP_VAL_STU:
       /* for UNI and STU members are externally defined, so are using EXT type */
-      abort ();
+      ddsrt_abort();
       break;
   }
   return sz;
@@ -562,7 +563,7 @@ static uint32_t get_jeq4_type_size (const enum dds_stream_typecode valtype, cons
       sz = jeq_op[3];
       break;
     case DDS_OP_VAL_EXT:
-      abort ();
+      ddsrt_abort();
       break;
   }
   return sz;
@@ -734,7 +735,7 @@ static const uint32_t *dds_stream_get_ops_info_seq (const uint32_t * __restrict 
       break;
     }
     case DDS_OP_VAL_EXT:
-      abort (); // not allowed
+      ddsrt_abort(); // not allowed
       break;
   }
   if (ops > info->ops_end)
@@ -777,7 +778,7 @@ static const uint32_t *dds_stream_get_ops_info_arr (const uint32_t * __restrict 
       break;
     }
     case DDS_OP_VAL_EXT:
-      abort (); // not allowed
+      ddsrt_abort(); // not allowed
       break;
   }
   if (ops > info->ops_end)
@@ -816,7 +817,7 @@ static const uint32_t *dds_stream_get_ops_info_uni (const uint32_t * __restrict 
           dds_stream_get_ops_info1 (jeq_op + DDS_OP_ADR_JSR (jeq_op[0]), nestc + (valtype == DDS_OP_VAL_UNI || valtype == DDS_OP_VAL_STU ? 1 : 0), info);
         break;
       case DDS_OP_VAL_EXT:
-        abort (); // not allowed
+        ddsrt_abort(); // not allowed
         break;
     }
     jeq_op += (DDS_OP (jeq_op[0]) == DDS_OP_JEQ) ? 3 : 4;
@@ -849,7 +850,7 @@ static const uint32_t *dds_stream_get_ops_info_pl (const uint32_t * __restrict o
         break;
       }
       default:
-        abort (); /* only list of (PLM, member-id) supported */
+        ddsrt_abort(); /* only list of (PLM, member-id) supported */
         break;
     }
   }
@@ -929,7 +930,7 @@ static void dds_stream_get_ops_info1 (const uint32_t * __restrict ops, uint32_t 
             break;
           }
           case DDS_OP_VAL_STU:
-            abort (); /* op type STU only supported as subtype */
+            ddsrt_abort(); /* op type STU only supported as subtype */
             break;
         }
         break;
@@ -941,7 +942,7 @@ static void dds_stream_get_ops_info1 (const uint32_t * __restrict ops, uint32_t 
         break;
       }
       case DDS_OP_RTS: case DDS_OP_JEQ: case DDS_OP_JEQ4: case DDS_OP_KOF: case DDS_OP_PLM: {
-        abort ();
+        ddsrt_abort();
         break;
       }
       case DDS_OP_DLC: {
@@ -1063,12 +1064,12 @@ static uint32_t read_union_discriminant (dds_istream_t * __restrict is, uint32_t
         case 1: return dds_is_get1 (is);
         case 2: return dds_is_get2 (is);
         case 4: return dds_is_get4 (is);
-        default: abort ();
+        default: ddsrt_abort();
       }
       break;
     default: return 0;
   }
-  abort ();
+  ddsrt_abort();
   return 0;
 }
 
@@ -1120,7 +1121,7 @@ static const uint32_t *skip_sequence_insns (uint32_t insn, const uint32_t * __re
       return ops + (jmp ? jmp : 4 + bound_op); /* FIXME: why would jmp be 0? */
     }
     case DDS_OP_VAL_EXT: {
-      abort (); /* not allowed */
+      ddsrt_abort(); /* not allowed */
       break;
     }
   }
@@ -1144,7 +1145,7 @@ static const uint32_t *skip_array_insns (uint32_t insn, const uint32_t * __restr
       return ops + (jmp ? jmp : 5);
     }
     case DDS_OP_VAL_EXT: {
-      abort (); /* not supported */
+      ddsrt_abort(); /* not supported */
       break;
     }
   }
@@ -1189,7 +1190,7 @@ static const uint32_t *skip_array_default (uint32_t insn, char * __restrict data
       return ops + (jmp ? jmp : 5);
     }
     case DDS_OP_VAL_EXT: {
-      abort (); /* not supported */
+      ddsrt_abort(); /* not supported */
       break;
     }
   }
@@ -1256,7 +1257,7 @@ static const uint32_t * skip_union_default (uint32_t insn, char * __restrict dis
         (void) dds_stream_skip_default (valaddr, allocator, jeq_op + DDS_OP_ADR_JSR (jeq_op[0]), sample_state);
         break;
       case DDS_OP_VAL_EXT: {
-        abort (); /* not supported */
+        ddsrt_abort(); /* not supported */
         break;
       }
     }
@@ -1290,10 +1291,10 @@ static uint32_t get_length_code_seq (const enum dds_stream_typecode subtype)
 
     /* not supported */
     case DDS_OP_VAL_EXT:
-      abort ();
+      ddsrt_abort();
       break;
   }
-  abort ();
+  ddsrt_abort();
   return 0u;
 }
 
@@ -1313,10 +1314,10 @@ static uint32_t get_length_code_arr (const enum dds_stream_typecode subtype)
 
     /* not supported */
     case DDS_OP_VAL_EXT:
-      abort ();
+      ddsrt_abort();
       break;
   }
-  abort ();
+  ddsrt_abort();
   return 0u;
 }
 
@@ -1348,18 +1349,18 @@ static uint32_t get_length_code (const uint32_t * __restrict ops)
         case DDS_OP_VAL_UNI: case DDS_OP_VAL_EXT: {
           return LENGTH_CODE_NEXTINT; /* FIXME: may be optimized for specific cases, e.g. when EXT type is appendable */
         }
-        case DDS_OP_VAL_STU: abort (); break; /* op type STU only supported as subtype */
+        case DDS_OP_VAL_STU: ddsrt_abort(); break; /* op type STU only supported as subtype */
       }
       break;
     }
     case DDS_OP_JSR:
       return get_length_code (ops + DDS_OP_JUMP (insn));
     case DDS_OP_RTS: case DDS_OP_JEQ: case DDS_OP_JEQ4: case DDS_OP_KOF: case DDS_OP_PLM:
-      abort ();
+      ddsrt_abort();
       break;
     case DDS_OP_DLC: case DDS_OP_PLC:
       /* members of (final/appendable/mutable) aggregated types are included using ADR | EXT */
-      abort();
+      ddsrt_abort();
       break;
   }
   return 0;
@@ -1386,11 +1387,11 @@ static bool is_member_present (const char * __restrict data, const uint32_t * __
         return is_member_present (data, ops + DDS_OP_JUMP (insn));
       case DDS_OP_RTS: case DDS_OP_JEQ: case DDS_OP_JEQ4: case DDS_OP_KOF:
       case DDS_OP_DLC: case DDS_OP_PLC: case DDS_OP_PLM:
-        abort ();
+        ddsrt_abort();
         break;
     }
   }
-  abort ();
+  ddsrt_abort();
   return false;
 }
 
@@ -1678,7 +1679,7 @@ static const uint32_t *dds_stream_read_seq (dds_istream_t * __restrict is, char 
       return ops + (jmp ? jmp : (4 + bound_op)); /* FIXME: why would jmp be 0? */
     }
     case DDS_OP_VAL_EXT: {
-      abort (); /* not supported */
+      ddsrt_abort(); /* not supported */
       break;
     }
   }
@@ -1716,7 +1717,7 @@ static const uint32_t *dds_stream_read_arr (dds_istream_t * __restrict is, char 
           dds_is_get_bytes (is, addr, num, 4);
           break;
         default:
-          abort ();
+          ddsrt_abort();
       }
       return ops + 4;
     }
@@ -1747,7 +1748,7 @@ static const uint32_t *dds_stream_read_arr (dds_istream_t * __restrict is, char 
       return ops + (jmp ? jmp : 5);
     }
     case DDS_OP_VAL_EXT: {
-      abort (); /* not supported */
+      ddsrt_abort(); /* not supported */
       break;
     }
   }
@@ -1779,7 +1780,7 @@ static const uint32_t *dds_stream_read_uni (dds_istream_t * __restrict is, char 
           case 1: *((uint32_t *) valaddr) = dds_is_get1 (is); break;
           case 2: *((uint32_t *) valaddr) = dds_is_get2 (is); break;
           case 4: *((uint32_t *) valaddr) = dds_is_get4 (is); break;
-          default: abort ();
+          default: ddsrt_abort();
         }
         break;
       case DDS_OP_VAL_STR:
@@ -1794,7 +1795,7 @@ static const uint32_t *dds_stream_read_uni (dds_istream_t * __restrict is, char 
         break;
       }
       case DDS_OP_VAL_EXT: {
-        abort (); /* not supported */
+        ddsrt_abort(); /* not supported */
         break;
       }
     }
@@ -1852,7 +1853,7 @@ static inline const uint32_t *dds_stream_read_adr (uint32_t insn, dds_istream_t 
         case 1: *((uint32_t *) addr) = dds_is_get1 (is); break;
         case 2: *((uint32_t *) addr) = dds_is_get2 (is); break;
         case 4: *((uint32_t *) addr) = dds_is_get4 (is); break;
-        default: abort ();
+        default: ddsrt_abort();
       }
       ops += 3;
       break;
@@ -1864,7 +1865,7 @@ static inline const uint32_t *dds_stream_read_adr (uint32_t insn, dds_istream_t 
         case 2: *((uint16_t *) addr) = dds_is_get2 (is); break;
         case 4: *((uint32_t *) addr) = dds_is_get4 (is); break;
         case 8: *((uint64_t *) addr) = dds_is_get8 (is); break;
-        default: abort ();
+        default: ddsrt_abort();
       }
       ops += 4;
       break;
@@ -1882,7 +1883,7 @@ static inline const uint32_t *dds_stream_read_adr (uint32_t insn, dds_istream_t 
       ops += jmp ? jmp : 3;
       break;
     }
-    case DDS_OP_VAL_STU: abort(); break; /* op type STU only supported as subtype */
+    case DDS_OP_VAL_STU: ddsrt_abort(); break; /* op type STU only supported as subtype */
   }
   return ops;
 }
@@ -1913,7 +1914,7 @@ static const uint32_t *dds_stream_skip_adr (uint32_t insn, const uint32_t * __re
       return ops + (jmp ? jmp : 3);
     }
     case DDS_OP_VAL_STU: {
-      abort(); /* op type STU only supported as subtype */
+      ddsrt_abort(); /* op type STU only supported as subtype */
       break;
     }
   }
@@ -1949,7 +1950,7 @@ static const uint32_t *dds_stream_skip_adr_default (uint32_t insn, char * __rest
         case 2: *(uint16_t *) addr = 0; break;
         case 4: *(uint32_t *) addr = 0; break;
         case 8: *(uint64_t *) addr = 0; break;
-        default: abort ();
+        default: ddsrt_abort();
       }
       return ops + 4;
     case DDS_OP_VAL_SEQ: case DDS_OP_VAL_BSQ: {
@@ -1970,7 +1971,7 @@ static const uint32_t *dds_stream_skip_adr_default (uint32_t insn, char * __rest
       return ops + (jmp ? jmp : 3);
     }
     case DDS_OP_VAL_STU: {
-      abort(); /* op type STU only supported as subtype */
+      ddsrt_abort(); /* op type STU only supported as subtype */
       break;
     }
   }
@@ -2000,7 +2001,7 @@ static void dds_stream_skip_pl_member_default (char * __restrict data, const str
         break;
       case DDS_OP_RTS: case DDS_OP_JEQ: case DDS_OP_JEQ4: case DDS_OP_KOF:
       case DDS_OP_DLC: case DDS_OP_PLC: case DDS_OP_PLM:
-        abort ();
+        ddsrt_abort();
         break;
     }
   }
@@ -2030,7 +2031,7 @@ static const uint32_t *dds_stream_skip_pl_memberlist_default (char * __restrict 
         break;
       }
       default:
-        abort (); /* other ops not supported at this point */
+        ddsrt_abort(); /* other ops not supported at this point */
         break;
     }
   }
@@ -2060,7 +2061,7 @@ static const uint32_t *dds_stream_skip_default (char * __restrict data, const st
         break;
       }
       case DDS_OP_RTS: case DDS_OP_JEQ: case DDS_OP_JEQ4: case DDS_OP_KOF: case DDS_OP_PLM:
-        abort ();
+        ddsrt_abort();
         break;
       case DDS_OP_DLC:
         ops = dds_stream_skip_delimited_default (data, allocator, ops, sample_state);
@@ -2092,7 +2093,7 @@ static const uint32_t *dds_stream_read_delimited (dds_istream_t * __restrict is,
         break;
       }
       case DDS_OP_RTS: case DDS_OP_JEQ: case DDS_OP_JEQ4: case DDS_OP_KOF: case DDS_OP_DLC: case DDS_OP_PLC: case DDS_OP_PLM: {
-        abort ();
+        ddsrt_abort();
         break;
       }
     }
@@ -2164,7 +2165,7 @@ static const uint32_t *dds_stream_read_pl (dds_istream_t * __restrict is, char *
           msz <<= (lc - 4);
         break;
       default:
-        abort ();
+        ddsrt_abort();
         break;
     }
 
@@ -2199,7 +2200,7 @@ static const uint32_t *dds_stream_read_impl (dds_istream_t * __restrict is, char
         ops++;
         break;
       case DDS_OP_RTS: case DDS_OP_JEQ: case DDS_OP_JEQ4: case DDS_OP_KOF: case DDS_OP_PLM:
-        abort ();
+        ddsrt_abort();
         break;
       case DDS_OP_DLC:
         assert (is->m_xcdr_version == DDSI_RTPS_CDR_ENC_VERSION_2);
@@ -2468,7 +2469,7 @@ static bool read_normalize_bitmask (uint64_t * __restrict val, char * __restrict
         return false;
       break;
     default:
-      abort ();
+      ddsrt_abort();
   }
   if (!bitmask_value_valid (*val, bits_h, bits_l))
     return normalize_error_bool ();
@@ -2528,7 +2529,7 @@ static bool normalize_primarray (char * __restrict data, uint32_t * __restrict o
       *off += 8 * num;
       return true;
     default:
-      abort ();
+      ddsrt_abort();
       break;
   }
   return false;
@@ -2715,7 +2716,7 @@ static const uint32_t *normalize_seq (char * __restrict data, uint32_t * __restr
     }
     case DDS_OP_VAL_EXT:
       ops = NULL;
-      abort (); /* not supported */
+      ddsrt_abort(); /* not supported */
       break;
   }
   if (has_dheader && *off != size1)
@@ -2773,7 +2774,7 @@ static const uint32_t *normalize_arr (char * __restrict data, uint32_t * __restr
     }
     case DDS_OP_VAL_EXT:
       ops = NULL;
-      abort (); /* not supported */
+      ddsrt_abort(); /* not supported */
       break;
   }
   if (has_dheader && *off != size1)
@@ -2818,7 +2819,7 @@ static bool normalize_uni_disc (uint32_t * __restrict val, char * __restrict dat
     case DDS_OP_VAL_ENU:
       return read_normalize_enum (val, data, off, size, bswap, insn, ops[4]);
     default:
-      abort ();
+      ddsrt_abort();
   }
   return false;
 }
@@ -2848,7 +2849,7 @@ static const uint32_t *normalize_uni (char * __restrict data, uint32_t * __restr
           return NULL;
         break;
       case DDS_OP_VAL_EXT:
-        abort (); /* not supported */
+        ddsrt_abort(); /* not supported */
         break;
     }
   }
@@ -2902,7 +2903,7 @@ static const uint32_t *stream_normalize_adr (uint32_t insn, char * __restrict da
       break;
     }
     case DDS_OP_VAL_STU:
-      abort (); /* op type STU only supported as subtype */
+      ddsrt_abort(); /* op type STU only supported as subtype */
       break;
   }
   return ops;
@@ -2939,7 +2940,7 @@ static const uint32_t *stream_normalize_delimited (char * __restrict data, uint3
         ops++;
         break;
       case DDS_OP_RTS: case DDS_OP_JEQ: case DDS_OP_JEQ4: case DDS_OP_KOF: case DDS_OP_DLC: case DDS_OP_PLC: case DDS_OP_PLM:
-        abort ();
+        ddsrt_abort();
         break;
     }
   }
@@ -3051,7 +3052,7 @@ static const uint32_t *stream_normalize_pl (char * __restrict data, uint32_t * _
           msz += 4;
         break;
       default:
-        abort ();
+        ddsrt_abort();
         break;
     }
     // reject if fewer than msz bytes remain in declared size of the parameter list
@@ -3107,7 +3108,7 @@ static const uint32_t *stream_normalize_data_impl (char * __restrict data, uint3
         break;
       }
       case DDS_OP_RTS: case DDS_OP_JEQ: case DDS_OP_JEQ4: case DDS_OP_KOF: case DDS_OP_PLM: {
-        abort ();
+        ddsrt_abort();
         break;
       }
       case DDS_OP_DLC: {
@@ -3159,7 +3160,7 @@ static bool stream_normalize_key_impl (void * __restrict data, uint32_t size, ui
       break;
     }
     case DDS_OP_VAL_SEQ: case DDS_OP_VAL_BSQ: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU:
-      abort ();
+      ddsrt_abort();
       break;
   }
   return true;
@@ -3199,7 +3200,7 @@ static bool stream_normalize_key (void * __restrict data, uint32_t size, bool bs
           break;
         }
         default:
-          abort ();
+          ddsrt_abort();
           break;
       }
     }
@@ -3270,7 +3271,7 @@ static const uint32_t *dds_stream_free_sample_seq (char * __restrict addr, const
         break;
       }
       case DDS_OP_VAL_EXT: {
-        abort (); /* not supported */
+        ddsrt_abort(); /* not supported */
         break;
       }
     }
@@ -3317,7 +3318,7 @@ static const uint32_t *dds_stream_free_sample_arr (char * __restrict addr, const
       break;
     }
     case DDS_OP_VAL_EXT: {
-      abort (); /* not supported */
+      ddsrt_abort(); /* not supported */
       break;
     }
   }
@@ -3332,7 +3333,7 @@ static const uint32_t *dds_stream_free_sample_uni (char * __restrict discaddr, c
     case DDS_OP_VAL_BLN: case DDS_OP_VAL_1BY: disc = *((uint8_t *) discaddr); break;
     case DDS_OP_VAL_2BY: disc = *((uint16_t *) discaddr); break;
     case DDS_OP_VAL_4BY: case DDS_OP_VAL_ENU: disc = *((uint32_t *) discaddr); break;
-    default: abort(); break;
+    default: ddsrt_abort(); break;
   }
   uint32_t const * const jeq_op = find_union_case (ops, disc);
   ops += DDS_OP_ADR_JMP (ops[3]);
@@ -3361,7 +3362,7 @@ static const uint32_t *dds_stream_free_sample_uni (char * __restrict discaddr, c
         dds_stream_free_sample (valaddr, allocator, jeq_op + DDS_OP_ADR_JSR (jeq_op[0]));
         break;
       case DDS_OP_VAL_EXT:
-        abort (); /* not supported */
+        ddsrt_abort(); /* not supported */
         break;
     }
 
@@ -3396,7 +3397,7 @@ static const uint32_t *dds_stream_free_sample_pl (char * __restrict addr, const 
         break;
       }
       default:
-        abort (); /* other ops not supported at this point */
+        ddsrt_abort(); /* other ops not supported at this point */
         break;
     }
   }
@@ -3429,7 +3430,7 @@ static const uint32_t *stream_free_sample_adr_nonexternal (uint32_t insn, void *
       break;
     }
     case DDS_OP_VAL_STU:
-      abort (); /* op type STU only supported as subtype */
+      ddsrt_abort(); /* op type STU only supported as subtype */
       break;
   }
 
@@ -3477,7 +3478,7 @@ void dds_stream_free_sample (void * __restrict data, const struct dds_cdrstream_
         ops++;
         break;
       case DDS_OP_RTS: case DDS_OP_JEQ: case DDS_OP_JEQ4: case DDS_OP_KOF: case DDS_OP_PLM:
-        abort ();
+        ddsrt_abort();
         break;
       case DDS_OP_DLC:
         ops++;
@@ -3515,7 +3516,7 @@ static void dds_stream_extract_key_from_key_prim_op (dds_istream_t * __restrict 
         case 2: dds_os_put2 (os, allocator, dds_is_get2 (is)); break;
         case 4: dds_os_put4 (os, allocator, dds_is_get4 (is)); break;
         case 8: assert (DDS_OP_TYPE(insn) == DDS_OP_VAL_BMK); dds_os_put8 (os, allocator, dds_is_get8 (is)); break;
-        default: abort ();
+        default: ddsrt_abort();
       }
       break;
     case DDS_OP_VAL_STR: case DDS_OP_VAL_BST: {
@@ -3541,7 +3542,7 @@ static void dds_stream_extract_key_from_key_prim_op (dds_istream_t * __restrict 
       else if (subtype == DDS_OP_VAL_ENU || subtype == DDS_OP_VAL_BMK)
         elem_size = DDS_OP_TYPE_SZ (insn);
       else
-        abort ();
+        ddsrt_abort();
       const align_t cdr_align = dds_cdr_get_align (os->m_xcdr_version, elem_size);
       const uint32_t num = ops[2];
       dds_cdr_alignto (is, cdr_align);
@@ -3561,7 +3562,7 @@ static void dds_stream_extract_key_from_key_prim_op (dds_istream_t * __restrict 
       break;
     }
     case DDS_OP_VAL_SEQ: case DDS_OP_VAL_BSQ: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU: {
-      abort ();
+      ddsrt_abort();
       break;
     }
   }
@@ -3622,7 +3623,7 @@ static void dds_stream_extract_keyBE_from_key_prim_op (dds_istream_t * __restric
         case 2: dds_os_put2BE (os, allocator, dds_is_get2 (is)); break;
         case 4: dds_os_put4BE (os, allocator, dds_is_get4 (is)); break;
         case 8: assert (DDS_OP_TYPE (insn) == DDS_OP_VAL_BMK); dds_os_put8BE (os, allocator, dds_is_get8 (is)); break;
-        default: abort ();
+        default: ddsrt_abort();
       }
       break;
     case DDS_OP_VAL_STR: case DDS_OP_VAL_BST: {
@@ -3648,7 +3649,7 @@ static void dds_stream_extract_keyBE_from_key_prim_op (dds_istream_t * __restric
       else if (subtype == DDS_OP_VAL_ENU || subtype == DDS_OP_VAL_BMK)
         elem_size = DDS_OP_TYPE_SZ (insn);
       else
-        abort ();
+        ddsrt_abort();
       const align_t cdr_align = dds_cdr_get_align (os->x.m_xcdr_version, elem_size);
       const uint32_t num = ops[2];
       dds_cdr_alignto (is, cdr_align);
@@ -3675,7 +3676,7 @@ static void dds_stream_extract_keyBE_from_key_prim_op (dds_istream_t * __restric
       break;
     }
     case DDS_OP_VAL_SEQ: case DDS_OP_VAL_BSQ: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU: {
-      abort ();
+      ddsrt_abort();
       break;
     }
   }
@@ -3716,7 +3717,7 @@ static void dds_stream_extract_key_from_data_skip_subtype (dds_istream_t * __res
       break;
     }
     case DDS_OP_VAL_EXT: {
-      abort (); /* not supported */
+      ddsrt_abort(); /* not supported */
       break;
     }
   }
@@ -3802,7 +3803,7 @@ static const uint32_t *dds_stream_extract_key_from_data_skip_adr (dds_istream_t 
       ops = dds_stream_extract_key_from_data_skip_union (is, ops);
       break;
     case DDS_OP_VAL_STU:
-      abort (); /* op type STU only supported as subtype */
+      ddsrt_abort(); /* op type STU only supported as subtype */
       break;
   }
   return ops;
@@ -3852,7 +3853,7 @@ static void dds_stream_read_key_impl (dds_istream_t * __restrict is, char * __re
         case 1: *((uint32_t *) dst) = dds_is_get1 (is); break;
         case 2: *((uint32_t *) dst) = dds_is_get2 (is); break;
         case 4: *((uint32_t *) dst) = dds_is_get4 (is); break;
-        default: abort ();
+        default: ddsrt_abort();
       }
       break;
     case DDS_OP_VAL_BMK:
@@ -3862,7 +3863,7 @@ static void dds_stream_read_key_impl (dds_istream_t * __restrict is, char * __re
         case 2: *((uint16_t *) dst) = dds_is_get2 (is); break;
         case 4: *((uint32_t *) dst) = dds_is_get4 (is); break;
         case 8: *((uint64_t *) dst) = dds_is_get8 (is); break;
-        default: abort ();
+        default: ddsrt_abort();
       }
       break;
     case DDS_OP_VAL_STR: *((char **) dst) = dds_stream_reuse_string (is, *((char **) dst), allocator, sample_state); break;
@@ -3900,11 +3901,11 @@ static void dds_stream_read_key_impl (dds_istream_t * __restrict is, char * __re
           break;
         }
         default:
-          abort ();
+          ddsrt_abort();
       }
       break;
     }
-    case DDS_OP_VAL_SEQ: case DDS_OP_VAL_BSQ: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU: abort (); break;
+    case DDS_OP_VAL_SEQ: case DDS_OP_VAL_BSQ: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU: ddsrt_abort(); break;
     case DDS_OP_VAL_EXT:
     {
       assert (key_offset_count > 0);
@@ -3943,7 +3944,7 @@ void dds_stream_read_key (dds_istream_t * __restrict is, char * __restrict sampl
           break;
         }
         default:
-          abort ();
+          ddsrt_abort();
           break;
       }
     }
@@ -4059,7 +4060,7 @@ static bool prtf_enum_bitmask (char * __restrict *buf, size_t * __restrict bufsi
       return prtf (buf, bufsize, "%"PRIu64, val);
     }
     default:
-      abort ();
+      ddsrt_abort();
   }
   return false;
 }
@@ -4108,7 +4109,7 @@ static bool prtf_simple (char * __restrict *buf, size_t * __restrict bufsize, dd
       return prtf_enum_bitmask (buf, bufsize, is, flags);
     case DDS_OP_VAL_STR: case DDS_OP_VAL_BST: return prtf_str (buf, bufsize, is);
     case DDS_OP_VAL_ARR: case DDS_OP_VAL_SEQ: case DDS_OP_VAL_BSQ: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU: case DDS_OP_VAL_EXT:
-      abort ();
+      ddsrt_abort();
   }
   return false;
 }
@@ -4160,7 +4161,7 @@ static bool prtf_simple_array (char * __restrict *buf, size_t * __restrict bufsi
       }
       break;
     default:
-      abort ();
+      ddsrt_abort();
       break;
   }
   return prtf (buf, bufsize, "}");
@@ -4209,7 +4210,7 @@ static const uint32_t *prtf_seq (char * __restrict *buf, size_t *bufsize, dds_is
       return ops + (jmp ? jmp : (4 + bound_op)); /* FIXME: why would jmp be 0? */
     }
     case DDS_OP_VAL_EXT: {
-      abort (); /* not supported */
+      ddsrt_abort(); /* not supported */
       break;
     }
   }
@@ -4247,7 +4248,7 @@ static const uint32_t *prtf_arr (char * __restrict *buf, size_t *bufsize, dds_is
       return ops + (jmp ? jmp : 5);
     }
     case DDS_OP_VAL_EXT: {
-      abort (); /* not supported */
+      ddsrt_abort(); /* not supported */
       break;
     }
   }
@@ -4273,7 +4274,7 @@ static const uint32_t *prtf_uni (char * __restrict *buf, size_t *bufsize, dds_is
         (void) dds_stream_print_sample1 (buf, bufsize, is, jeq_op + DDS_OP_ADR_JSR (jeq_op[0]), valtype == DDS_OP_VAL_STU, false, cdr_kind);
         break;
       case DDS_OP_VAL_EXT: {
-        abort (); /* not supported, use UNI instead */
+        ddsrt_abort(); /* not supported, use UNI instead */
         break;
       }
     }
@@ -4326,7 +4327,7 @@ static const uint32_t * dds_stream_print_adr (char * __restrict *buf, size_t * _
       break;
     }
     case DDS_OP_VAL_STU:
-      abort (); /* op type STU only supported as subtype */
+      ddsrt_abort(); /* op type STU only supported as subtype */
       break;
   }
   return ops;
@@ -4357,7 +4358,7 @@ static const uint32_t *prtf_delimited (char * __restrict *buf, size_t *bufsize, 
         ops++;
         break;
       case DDS_OP_RTS: case DDS_OP_JEQ: case DDS_OP_JEQ4: case DDS_OP_KOF: case DDS_OP_DLC: case DDS_OP_PLC: case DDS_OP_PLM: {
-        abort ();
+        ddsrt_abort();
         break;
       }
     }
@@ -4424,7 +4425,7 @@ static const uint32_t *prtf_pl (char * __restrict *buf, size_t *bufsize, dds_ist
           msz <<= (lc - 4);
         break;
       default:
-        abort ();
+        ddsrt_abort();
         break;
     }
 
@@ -4466,7 +4467,7 @@ static const uint32_t * dds_stream_print_sample1 (char * __restrict *buf, size_t
         ops++;
         break;
       case DDS_OP_RTS: case DDS_OP_JEQ: case DDS_OP_JEQ4: case DDS_OP_KOF: case DDS_OP_PLM:
-        abort ();
+        ddsrt_abort();
         break;
       case DDS_OP_DLC:
         assert (is->m_xcdr_version == DDSI_RTPS_CDR_ENC_VERSION_2);
@@ -4539,7 +4540,7 @@ bool dds_stream_extensibility (const uint32_t * __restrict ops, enum dds_cdr_typ
         *ext = DDS_CDR_TYPE_EXT_MUTABLE;
         return true;
       case DDS_OP_RTS: case DDS_OP_JEQ: case DDS_OP_JEQ4: case DDS_OP_KOF: case DDS_OP_PLM:
-        abort ();
+        ddsrt_abort();
         break;
     }
   }
@@ -4660,7 +4661,7 @@ static const uint32_t *dds_stream_key_size_arr (const uint32_t * __restrict ops,
       return ops + (jmp ? jmp : 5);
     }
     case DDS_OP_VAL_EXT: {
-      abort (); /* not supported */
+      ddsrt_abort(); /* not supported */
       break;
     }
   }
@@ -4729,7 +4730,7 @@ static const uint32_t *dds_stream_key_size_adr (const uint32_t * __restrict ops,
       ops += jmp ? jmp : 3;
       break;
     }
-    case DDS_OP_VAL_STU: abort(); break; /* op type STU only supported as subtype */
+    case DDS_OP_VAL_STU: ddsrt_abort(); break; /* op type STU only supported as subtype */
   }
   return ops;
 }
@@ -4757,7 +4758,7 @@ static const uint32_t *dds_stream_key_size_delimited (const uint32_t * __restric
         break;
       }
       case DDS_OP_RTS: case DDS_OP_JEQ: case DDS_OP_JEQ4: case DDS_OP_KOF: case DDS_OP_DLC: case DDS_OP_PLC: case DDS_OP_PLM: {
-        abort ();
+        ddsrt_abort();
         break;
       }
     }
@@ -4806,7 +4807,7 @@ static const uint32_t *dds_stream_key_size_pl_memberlist (const uint32_t * __res
         break;
       }
       default:
-        abort (); /* other ops not supported at this point */
+        ddsrt_abort(); /* other ops not supported at this point */
         break;
     }
   }
@@ -4844,7 +4845,7 @@ static void dds_stream_key_size_prim_op (const uint32_t * __restrict ops, uint16
       dds_stream_key_size_prim_op (jsr_ops, --key_offset_count, ++key_offset_insn, k);
       break;
     }
-    case DDS_OP_VAL_STU: abort(); break; /* op type STU only supported as subtype */
+    case DDS_OP_VAL_STU: ddsrt_abort(); break; /* op type STU only supported as subtype */
   }
 }
 
@@ -4869,7 +4870,7 @@ static void dds_stream_key_size_keyhash (struct dds_cdrstream_desc *desc, struct
         break;
       }
       default:
-        abort ();
+        ddsrt_abort();
         break;
     }
   }
@@ -4890,7 +4891,7 @@ static const uint32_t *dds_stream_key_size (const uint32_t * __restrict ops, str
         ops++;
         break;
       case DDS_OP_RTS: case DDS_OP_JEQ: case DDS_OP_JEQ4: case DDS_OP_KOF: case DDS_OP_PLM:
-        abort ();
+        ddsrt_abort();
         break;
       case DDS_OP_DLC:
         k->is_appendable = true;

--- a/src/core/ddsc/src/dds_builtin.c
+++ b/src/core/ddsc/src/dds_builtin.c
@@ -11,6 +11,7 @@
 #include <assert.h>
 #include <string.h>
 #include "dds/ddsrt/string.h"
+#include "dds/ddsrt/process.h"
 #include "dds/ddsi/ddsi_entity.h"
 #include "dds/ddsi/ddsi_topic.h"
 #include "dds/ddsi/ddsi_endpoint.h"
@@ -282,7 +283,7 @@ struct ddsi_serdata *dds__builtin_make_sample_endpoint (const struct ddsi_entity
       type = dom->builtin_reader_type;
       break;
     default:
-      abort ();
+      ddsrt_abort();
       break;
   }
   assert (type != NULL);
@@ -344,7 +345,7 @@ static void dds__builtin_write_endpoint (const struct ddsi_entity_common *e, dds
         bwr = dom->builtintopic_writer_subscriptions;
         break;
       default:
-        abort ();
+        ddsrt_abort();
         break;
     }
     dds_writecdr_local_orphan_impl (bwr, serdata);

--- a/src/core/ddsc/src/dds_entity.c
+++ b/src/core/ddsc/src/dds_entity.c
@@ -13,6 +13,7 @@
 
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/log.h"
+#include "dds/ddsrt/process.h"
 #include "dds__entity.h"
 #include "dds__write.h"
 #include "dds__writer.h"
@@ -162,7 +163,7 @@ static bool entity_has_status (const dds_entity *e)
     case DDS_KIND_CYCLONEDDS:
       break;
     case DDS_KIND_DONTCARE:
-      abort ();
+      ddsrt_abort();
       break;
   }
   return false;
@@ -187,7 +188,7 @@ static bool entity_may_have_children (const dds_entity *e)
     case DDS_KIND_CYCLONEDDS:
       break;
     case DDS_KIND_DONTCARE:
-      abort ();
+      ddsrt_abort();
       break;
   }
   return true;
@@ -213,7 +214,7 @@ static bool entity_kind_has_qos (dds_entity_kind_t kind)
     case DDS_KIND_CYCLONEDDS:
       break;
     case DDS_KIND_DONTCARE:
-      abort ();
+      ddsrt_abort();
       break;
   }
   return false;

--- a/src/core/ddsc/src/dds_readcond.c
+++ b/src/core/ddsc/src/dds_readcond.c
@@ -17,6 +17,7 @@
 #include "dds/ddsi/ddsi_entity_index.h"
 #include "dds/ddsi/ddsi_entity.h"
 #include "dds/ddsi/ddsi_thread.h"
+#include "dds/ddsrt/process.h"
 
 static void dds_readcond_close (dds_entity *e) ddsrt_nonnull_all;
 
@@ -60,7 +61,7 @@ dds_readcond *dds_create_readcond_impl (dds_reader *rd, dds_entity_kind_t kind, 
   {
     /* FIXME: current entity management code can't deal with an error late in the creation of the
        entity because it doesn't allow deleting it again ... */
-    abort();
+    ddsrt_abort();
   }
   return cond;
 }

--- a/src/core/ddsc/src/dds_reader.c
+++ b/src/core/ddsc/src/dds_reader.c
@@ -15,6 +15,7 @@
 #include "dds/ddsrt/static_assert.h"
 #include "dds/ddsrt/io.h"
 #include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/process.h"
 #include "dds/ddsi/ddsi_entity.h"
 #include "dds/ddsi/ddsi_endpoint.h"
 #include "dds/ddsi/ddsi_thread.h"
@@ -632,7 +633,7 @@ static dds_entity_t dds_create_reader_int (dds_entity_t participant_or_subscribe
   if (dds_rhc_associate (rd->m_rhc, rd, tp->m_stype, rd->m_entity.m_domain->gv.m_tkmap) < 0)
   {
     /* FIXME: see also create_querycond, need to be able to undo entity_init */
-    abort ();
+    ddsrt_abort();
   }
   dds_entity_add_ref_locked (&tp->m_entity);
 

--- a/src/core/ddsc/src/dds_serdata_builtintopic.c
+++ b/src/core/ddsc/src/dds_serdata_builtintopic.c
@@ -16,6 +16,7 @@
 #include "dds/ddsrt/string.h"
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/md5.h"
+#include "dds/ddsrt/process.h"
 #include "dds/ddsrt/hopscotch.h"
 
 #include "dds/ddsi/ddsi_xqos.h"
@@ -97,7 +98,7 @@ static size_t serdata_builtin_sizeof(enum ddsi_sertype_builtintopic_entity_kind 
     case DSBT_WRITER:
       return sizeof (struct ddsi_serdata_builtintopic_endpoint);
   }
-  abort ();
+  ddsrt_abort();
   return 0;
 }
 
@@ -244,7 +245,7 @@ struct ddsi_serdata *dds_serdata_builtin_from_endpoint (const struct ddsi_sertyp
         from_entity_proxy_wr ((struct ddsi_serdata_builtintopic_endpoint *) d, (const struct ddsi_proxy_writer *) entity);
         break;
       case DDSI_EK_TOPIC:
-        abort ();
+        ddsrt_abort();
         break;
     }
     ddsrt_mutex_unlock (&entity->qos_lock);
@@ -375,7 +376,7 @@ static bool serdata_builtin_untyped_to_sample (const struct ddsi_sertype *type, 
 {
   const struct ddsi_serdata_builtintopic *d = (const struct ddsi_serdata_builtintopic *)serdata_common;
   const struct ddsi_sertype_builtintopic *tp = (const struct ddsi_sertype_builtintopic *)type;
-  if (bufptr) abort(); else { (void)buflim; } /* FIXME: haven't implemented that bit yet! */
+  if (bufptr) ddsrt_abort(); else { (void)buflim; } /* FIXME: haven't implemented that bit yet! */
   /* FIXME: completing builtin topic support along these lines requires subscribers, publishers and topics to also become DDSI entities - which is probably a good thing anyway */
   switch (tp->entity_kind)
   {

--- a/src/core/ddsc/src/dds_serdata_default.c
+++ b/src/core/ddsc/src/dds_serdata_default.c
@@ -17,6 +17,7 @@
 #include "dds/ddsrt/log.h"
 #include "dds/ddsrt/md5.h"
 #include "dds/ddsrt/mh3.h"
+#include "dds/ddsrt/process.h"
 #include "dds/ddsi/ddsi_freelist.h"
 #include "dds/ddsi/ddsi_tkmap.h"
 #include "dds/cdr/dds_cdrstream.h"
@@ -713,7 +714,7 @@ static bool serdata_default_to_sample_cdr (const struct ddsi_serdata *serdata_co
   const struct dds_serdata_default *d = (const struct dds_serdata_default *)serdata_common;
   const struct dds_sertype_default *tp = (const struct dds_sertype_default *) d->c.type;
   dds_istream_t is;
-  if (bufptr) abort(); else { (void)buflim; } /* FIXME: haven't implemented that bit yet! */
+  if (bufptr) ddsrt_abort(); else { (void)buflim; } /* FIXME: haven't implemented that bit yet! */
   if (d->c.loan != NULL &&
       (d->c.loan->metadata->sample_state == DDS_LOANED_SAMPLE_STATE_RAW_DATA ||
        d->c.loan->metadata->sample_state == DDS_LOANED_SAMPLE_STATE_RAW_KEY))
@@ -742,7 +743,7 @@ static bool serdata_default_untyped_to_sample_cdr (const struct ddsi_sertype *se
   assert (d->c.kind == SDK_KEY);
   assert (d->c.ops == sertype_common->serdata_ops);
   assert (DDSI_RTPS_CDR_ENC_IS_NATIVE (d->hdr.identifier));
-  if (bufptr) abort(); else { (void)buflim; } /* FIXME: haven't implemented that bit yet! */
+  if (bufptr) ddsrt_abort(); else { (void)buflim; } /* FIXME: haven't implemented that bit yet! */
   dds_istream_init (&is, d->key.keysize, serdata_default_keybuf (d), DDSI_RTPS_CDR_ENC_VERSION_2);
   dds_stream_read_key (&is, sample, &dds_cdrstream_default_allocator, &tp->type);
   return true; /* FIXME: can't conversion to sample fail? */

--- a/src/core/ddsc/src/dds_sertype_default.c
+++ b/src/core/ddsc/src/dds_sertype_default.c
@@ -17,6 +17,7 @@
 #include "dds/ddsrt/md5.h"
 #include "dds/ddsrt/mh3.h"
 #include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/process.h"
 #include "dds/ddsrt/string.h"
 #include "dds/ddsi/ddsi_domaingv.h"
 #include "dds/ddsi/ddsi_freelist.h"
@@ -197,7 +198,7 @@ static struct ddsi_sertype * sertype_default_derive_sertype (const struct ddsi_s
   else if (data_representation == DDS_DATA_REPRESENTATION_XCDR2)
     required_ops = base_sertype->has_key ? &dds_serdata_ops_xcdr2 : &dds_serdata_ops_xcdr2_nokey;
   else
-    abort ();
+    ddsrt_abort();
 
   if (base_sertype->serdata_ops == required_ops)
     derived_sertype = (struct dds_sertype_default *) base_sertype_default;
@@ -285,7 +286,7 @@ dds_return_t dds_sertype_default_init (const struct dds_domain *domain, struct d
       serdata_ops = desc->m_nkeys ? &dds_serdata_ops_xcdr2 : &dds_serdata_ops_xcdr2_nokey;
       break;
     default:
-      abort ();
+      ddsrt_abort();
   }
 
   /* Get the extensility of the outermost object in the type used for the topic. Note that the

--- a/src/core/ddsi/src/ddsi_dynamic_type.c
+++ b/src/core/ddsi/src/ddsi_dynamic_type.c
@@ -13,6 +13,7 @@
 #include "dds/dds.h"
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/md5.h"
+#include "dds/ddsrt/process.h"
 #include "dds/ddsrt/string.h"
 #include "dds/ddsi/ddsi_entity.h"
 #include "dds/ddsi/ddsi_typelib.h"
@@ -357,7 +358,7 @@ static dds_return_t set_type_flags (struct ddsi_type *type, uint16_t flag, uint1
         type->xt._u.union_type.flags = (type->xt._u.union_type.flags & (uint16_t) ~mask) | flag;
       break;
     default:
-      abort ();
+      ddsrt_abort();
   }
   return ret;
 }
@@ -376,7 +377,7 @@ dds_return_t ddsi_dynamic_type_set_extensibility (struct ddsi_type *type, enum d
   else if (extensibility == DDS_DYNAMIC_TYPE_EXT_MUTABLE)
     flag = DDS_XTypes_IS_MUTABLE;
   else
-    abort ();
+    ddsrt_abort();
   return set_type_flags (type, flag, DDS_DYNAMIC_TYPE_EXT_FINAL | DDS_DYNAMIC_TYPE_EXT_APPENDABLE | DDS_DYNAMIC_TYPE_EXT_MUTABLE);
 }
 
@@ -421,7 +422,7 @@ dds_return_t ddsi_dynamic_type_set_bitbound (struct ddsi_type *type, uint16_t bi
       }
       break;
     default:
-      abort ();
+      ddsrt_abort();
   }
   return ret;
 }

--- a/src/core/ddsi/src/ddsi_init.c
+++ b/src/core/ddsi/src/ddsi_init.c
@@ -757,7 +757,7 @@ static void wait_for_receive_threads_helper (struct ddsi_domaingv *gv, struct dd
   struct wait_for_receive_threads_helper_arg * const arg = varg;
   (void) xp;
   if (arg->count++ == gv->config.recv_thread_stop_maxretries)
-    abort ();
+    ddsrt_abort();
   ddsi_trigger_recv_threads (gv);
   (void) ddsi_resched_xevent_if_earlier (xev, ddsrt_mtime_add_duration (tnow, DDS_SECS (1)));
 }

--- a/src/core/ddsi/src/ddsi_ipaddr.c
+++ b/src/core/ddsi/src/ddsi_ipaddr.c
@@ -15,6 +15,7 @@
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/log.h"
 #include "dds/ddsrt/bits.h"
+#include "dds/ddsrt/process.h"
 #include "dds/ddsrt/sockets.h"
 #include "dds/ddsrt/string.h"
 #include "dds/ddsi/ddsi_domaingv.h"
@@ -255,7 +256,7 @@ enum ddsi_locator_from_string_result ddsi_ipaddr_from_string (ddsi_locator_t *lo
     struct sockaddr_in6 *x = (struct sockaddr_in6 *) &tmpaddr;
     x->sin6_port = htons (port);
 #else
-    abort ();
+    ddsrt_abort();
 #endif
   }
   ddsi_ipaddr_to_loc (loc, (struct sockaddr *)&tmpaddr, kind);

--- a/src/core/ddsi/src/ddsi_radmin.c
+++ b/src/core/ddsi/src/ddsi_radmin.c
@@ -22,6 +22,7 @@
 #endif
 
 #include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/process.h"
 #include "dds/ddsrt/threads.h"
 #include "dds/ddsrt/sync.h"
 #include "dds/ddsrt/string.h"
@@ -740,7 +741,7 @@ static void ddsi_rdata_addbias (struct ddsi_rdata *rdata)
 #ifndef NDEBUG
   ASSERT_RBUFPOOL_OWNER (rmsg->chunk.rbuf->rbufpool);
   if (ddsrt_atomic_inc32_nv (&rdata->refcount_bias_added) != 1)
-    abort ();
+    ddsrt_abort();
 #endif
   ddsi_rmsg_addbias (rmsg);
 }
@@ -751,7 +752,7 @@ static void ddsi_rdata_rmbias_and_adjust (struct ddsi_rdata *rdata, int adjust)
   RMSGTRACE ("rdata_rmbias_and_adjust(%p, %d)\n", (void *) rdata, adjust);
 #ifndef NDEBUG
   if (ddsrt_atomic_dec32_ov (&rdata->refcount_bias_added) != 1)
-    abort ();
+    ddsrt_abort();
 #endif
   ddsi_rmsg_rmbias_and_adjust (rmsg, adjust);
 }
@@ -2574,7 +2575,7 @@ static uint32_t dqueue_thread (struct ddsi_dqueue *q)
               switch (b->kind)
               {
                 case DDSI_DQBK_STOP:
-                  abort ();
+                  ddsrt_abort();
                 case DDSI_DQBK_CALLBACK:
                   b->u.cb.cb (b->u.cb.arg);
                   break;

--- a/src/core/ddsi/src/ddsi_security_omg.c
+++ b/src/core/ddsi/src/ddsi_security_omg.c
@@ -19,6 +19,7 @@
 #include "dds/ddsrt/string.h"
 #include "dds/ddsrt/misc.h"
 #include "dds/ddsrt/avl.h"
+#include "dds/ddsrt/process.h"
 #include "dds/ddsrt/sync.h"
 #include "dds/ddsrt/hopscotch.h"
 #include "dds/ddsi/ddsi_domaingv.h"
@@ -1727,7 +1728,7 @@ unsigned ddsi_determine_publication_writer (const struct ddsi_writer *wr)
 unsigned ddsi_determine_topic_writer (const struct ddsi_topic *tp)
 {
   if (ddsi_omg_participant_is_discovery_protected (tp->pp))
-    abort (); /* FIXME: not implemented */
+    ddsrt_abort(); /* FIXME: not implemented */
   return DDSI_ENTITYID_SEDP_BUILTIN_TOPIC_WRITER;
 }
 #endif

--- a/src/core/ddsi/src/ddsi_serdata_cdr.c
+++ b/src/core/ddsi/src/ddsi_serdata_cdr.c
@@ -17,6 +17,7 @@
 #include "dds/ddsrt/log.h"
 #include "dds/ddsrt/md5.h"
 #include "dds/ddsrt/mh3.h"
+#include "dds/ddsrt/process.h"
 #include "dds/ddsi/ddsi_freelist.h"
 #include "dds/ddsi/ddsi_tkmap.h"
 #include "dds/ddsi/ddsi_domaingv.h"
@@ -250,7 +251,7 @@ static struct ddsi_serdata_cdr *serdata_cdr_from_sample_cdr_common (const struct
       ostream_add_to_serdata_cdr (&os, &d);
       break;
     case SDK_KEY:
-      abort ();
+      ddsrt_abort();
       break;
     case SDK_DATA:
       if (!dds_stream_write_sample (&os, &dds_cdrstream_default_allocator, sample, &tp->type))
@@ -314,7 +315,7 @@ static bool serdata_cdr_to_sample_cdr (const struct ddsi_serdata *serdata_common
   const struct ddsi_serdata_cdr *d = (const struct ddsi_serdata_cdr *)serdata_common;
   const struct ddsi_sertype_cdr *tp = (const struct ddsi_sertype_cdr *) d->c.type;
   dds_istream_t is;
-  if (bufptr) abort(); else { (void)buflim; } /* FIXME: haven't implemented that bit yet! */
+  if (bufptr) ddsrt_abort(); else { (void)buflim; } /* FIXME: haven't implemented that bit yet! */
   assert (DDSI_RTPS_CDR_ENC_IS_NATIVE (d->hdr.identifier));
   istream_from_serdata_cdr(&is, d);
   dds_stream_read_sample (&is, sample, &dds_cdrstream_default_allocator, &tp->type);

--- a/src/core/ddsi/src/ddsi_serdata_plist.c
+++ b/src/core/ddsi/src/ddsi_serdata_plist.c
@@ -17,6 +17,7 @@
 #include "dds/ddsrt/log.h"
 #include "dds/ddsrt/md5.h"
 #include "dds/ddsrt/mh3.h"
+#include "dds/ddsrt/process.h"
 #include "dds/ddsi/ddsi_freelist.h"
 #include "dds/ddsi/ddsi_tkmap.h"
 #include "dds/ddsi/ddsi_domaingv.h"
@@ -184,7 +185,7 @@ static bool serdata_plist_untyped_to_sample (const struct ddsi_sertype *tpcmn, c
   const struct ddsi_serdata_plist *d = (const struct ddsi_serdata_plist *)serdata_common;
   const struct ddsi_sertype_plist *tp = (const struct ddsi_sertype_plist *)tpcmn;
   struct ddsi_domaingv * const gv = ddsrt_atomic_ldvoidp (&tp->c.gv);
-  if (bufptr) abort(); else { (void)buflim; } /* FIXME: haven't implemented that bit yet! */
+  if (bufptr) ddsrt_abort(); else { (void)buflim; } /* FIXME: haven't implemented that bit yet! */
   ddsi_plist_src_t src = {
     .buf = (const unsigned char *) d->data,
     .bufsz = d->pos,

--- a/src/core/ddsi/src/ddsi_serdata_pserop.c
+++ b/src/core/ddsi/src/ddsi_serdata_pserop.c
@@ -17,6 +17,7 @@
 #include "dds/ddsrt/log.h"
 #include "dds/ddsrt/md5.h"
 #include "dds/ddsrt/mh3.h"
+#include "dds/ddsrt/process.h"
 #include "dds/ddsi/ddsi_freelist.h"
 #include "dds/ddsi/ddsi_tkmap.h"
 #include "dds/ddsi/ddsi_domaingv.h"
@@ -169,7 +170,7 @@ static bool serdata_pserop_to_sample (const struct ddsi_serdata *serdata_common,
 {
   const struct ddsi_serdata_pserop *d = (const struct ddsi_serdata_pserop *)serdata_common;
   const struct ddsi_sertype_pserop *tp = (const struct ddsi_sertype_pserop *) d->c.type;
-  if (bufptr) abort(); else { (void)buflim; } /* FIXME: haven't implemented that bit yet! */
+  if (bufptr) ddsrt_abort(); else { (void)buflim; } /* FIXME: haven't implemented that bit yet! */
   if (d->c.kind == SDK_KEY)
     memcpy (sample, d->sample, 16);
   else
@@ -251,7 +252,7 @@ static bool serdata_pserop_untyped_to_sample (const struct ddsi_sertype *type_co
 {
   const struct ddsi_serdata_pserop *d = (const struct ddsi_serdata_pserop *)serdata_common;
   const struct ddsi_sertype_pserop *tp = (const struct ddsi_sertype_pserop *)type_common;
-  if (bufptr) abort(); else { (void)buflim; } /* FIXME: haven't implemented that bit yet! */
+  if (bufptr) ddsrt_abort(); else { (void)buflim; } /* FIXME: haven't implemented that bit yet! */
   if (tp->ops_key)
     memcpy (sample, d->sample, 16);
   return true;

--- a/src/core/ddsi/src/ddsi_sertype.c
+++ b/src/core/ddsi/src/ddsi_sertype.c
@@ -17,6 +17,7 @@
 #include "dds/ddsrt/md5.h"
 #include "dds/ddsrt/mh3.h"
 #include "dds/ddsrt/hopscotch.h"
+#include "dds/ddsrt/process.h"
 #include "dds/ddsrt/string.h"
 #include "dds/ddsi/ddsi_freelist.h"
 #include "dds/ddsi/ddsi_iid.h"
@@ -244,7 +245,7 @@ uint16_t ddsi_sertype_get_native_enc_identifier (uint32_t enc_version, uint32_t 
         return CONCAT(DDSI_RTPS_D_CDR2, SUFFIX);
       return CONCAT(DDSI_RTPS_CDR2, SUFFIX);
     default:
-      abort (); /* unsupported */
+      ddsrt_abort(); /* unsupported */
   }
 #undef SUFFIX
 #undef CONCAT
@@ -262,7 +263,7 @@ uint16_t ddsi_sertype_extensibility_enc_format (enum dds_cdr_type_extensibility 
     case DDS_CDR_TYPE_EXT_MUTABLE:
       return DDSI_RTPS_CDR_ENC_FORMAT_PL;
     default:
-      abort ();
+      ddsrt_abort();
   }
 }
 
@@ -293,7 +294,7 @@ uint32_t ddsi_sertype_enc_id_enc_format (uint16_t cdr_identifier)
     case DDSI_RTPS_PL_CDR2_LE: case DDSI_RTPS_PL_CDR2_BE:
       return DDSI_RTPS_CDR_ENC_FORMAT_PL;
     default:
-      abort ();
+      ddsrt_abort();
   }
 }
 

--- a/src/core/ddsi/src/ddsi_sockwaitset.c
+++ b/src/core/ddsi/src/ddsi_sockwaitset.c
@@ -13,6 +13,7 @@
 #include <string.h>
 
 #include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/process.h"
 #include "dds/ddsrt/sockets.h"
 #include "dds/ddsrt/sync.h"
 
@@ -195,13 +196,13 @@ void ddsi_sock_waitset_purge (struct ddsi_sock_waitset * ws, unsigned index)
   sz = ddsrt_atomic_ld32 (&ws->sz);
   close (ws->kqueue);
   if ((ws->kqueue = kqueue()) == -1)
-    abort (); /* FIXME */
+    ddsrt_abort(); /* FIXME */
   for (i = 0; i <= index; i++)
   {
     assert (ws->entries[i].fd >= 0);
     EV_SET(&kev, (unsigned)ws->entries[i].fd, EVFILT_READ, EV_ADD, 0, 0, &ws->entries[i]);
     if (kevent(ws->kqueue, &kev, 1, NULL, 0, NULL) == -1)
-      abort (); /* FIXME */
+      ddsrt_abort(); /* FIXME */
   }
   for (; i < sz; i++)
   {
@@ -226,7 +227,7 @@ void ddsi_sock_waitset_remove (struct ddsi_sock_waitset * ws, struct ddsi_tran_c
     struct kevent kev;
     EV_SET(&kev, (unsigned)ws->entries[i].fd, EVFILT_READ, EV_DELETE, 0, 0, 0);
     if (kevent(ws->kqueue, &kev, 1, NULL, 0, NULL) == -1)
-      abort (); /* FIXME */
+      ddsrt_abort(); /* FIXME */
     ws->entries[i].fd = -1;
   }
   ddsrt_mutex_unlock (&ws->lock);

--- a/src/core/ddsi/src/ddsi_thread.c
+++ b/src/core/ddsi/src/ddsi_thread.c
@@ -15,6 +15,7 @@
 #include "dds/ddsrt/cdtors.h"
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/log.h"
+#include "dds/ddsrt/process.h"
 #include "dds/ddsrt/string.h"
 #include "dds/ddsrt/sync.h"
 #include "dds/ddsrt/threads.h"
@@ -351,7 +352,7 @@ static dds_return_t create_thread_int (struct ddsi_thread_state **ts1_out, const
 fatal:
   ddsrt_mutex_unlock (&thread_states.lock);
   *ts1_out = NULL;
-  abort ();
+  ddsrt_abort();
   return DDS_RETCODE_ERROR;
 }
 

--- a/src/core/ddsi/src/ddsi_tran.c
+++ b/src/core/ddsi/src/ddsi_tran.c
@@ -14,6 +14,7 @@
 #include <ctype.h>
 
 #include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/process.h"
 #include "dds/ddsrt/string.h"
 #include "dds/ddsrt/ifaddrs.h"
 #include "dds/ddsi/ddsi_log.h"
@@ -147,7 +148,7 @@ void ddsi_conn_free (struct ddsi_tran_conn * conn)
                 break;
               case DDSI_RTM_SINGLE:
                 if (conn->m_base.gv->recv_threads[i].arg.u.single.conn == conn)
-                  abort();
+                  ddsrt_abort();
                 break;
             }
           }

--- a/src/core/ddsi/src/ddsi_typebuilder.c
+++ b/src/core/ddsi/src/ddsi_typebuilder.c
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 #include "dds/features.h"
 #include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/process.h"
 #include "dds/ddsrt/string.h"
 #include "dds/ddsi/ddsi_domaingv.h"
 #include "dds/ddsi/ddsi_serdata.h"
@@ -1242,7 +1243,7 @@ static dds_return_t get_ops_aggrtype (struct typebuilder_aggregated_type *tb_agg
       }
       break;
     default:
-      abort ();
+      ddsrt_abort();
   }
 
   // mutable types have an RTS instruction per member
@@ -1373,7 +1374,7 @@ static dds_return_t resolve_ops_offsets_aggrtype (const struct typebuilder_aggre
       ret = resolve_ops_offsets_union (&tb_aggrtype->detail._union, ops);
       break;
     default:
-      abort ();
+      ddsrt_abort();
   }
   return ret;
 }
@@ -1486,7 +1487,7 @@ static dds_return_t get_keys_aggrtype (struct typebuilder_data *tbd, struct type
       ret = DDS_RETCODE_OK;
       break;
     default:
-      abort ();
+      ddsrt_abort();
   }
   return ret;
 }
@@ -1671,7 +1672,7 @@ static dds_return_t set_implicit_keys_aggrtype (struct typebuilder_aggregated_ty
       ret = DDS_RETCODE_OK;
       break;
     default:
-      abort ();
+      ddsrt_abort();
   }
   return ret;
 }

--- a/src/core/ddsi/src/ddsi_typelib.c
+++ b/src/core/ddsi/src/ddsi_typelib.c
@@ -13,6 +13,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/process.h"
 #include "dds/ddsrt/string.h"
 #include "dds/ddsi/ddsi_domaingv.h"
 #include "dds/ddsi/ddsi_sertype.h"
@@ -930,7 +931,7 @@ static dds_return_t ddsi_type_get_typeinfo_toplevel (struct ddsi_domaingv *gv, s
   {
     ddsi_typeid_t ti_c;
     if (ddsi_typeobj_get_hash_id (&to_c, &ti_c) != 0)
-      abort ();
+      ddsrt_abort();
     assert (ddsi_typeid_compare (&type_c->xt.id, &ti_c) == 0);
     ddsi_typeid_fini (&ti_c);
   }

--- a/src/core/ddsi/src/ddsi_typewrap.c
+++ b/src/core/ddsi/src/ddsi_typewrap.c
@@ -13,6 +13,7 @@
 #include "dds/features.h"
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/md5.h"
+#include "dds/ddsrt/process.h"
 #include "dds/ddsrt/string.h"
 #include "dds/ddsi/ddsi_domaingv.h"
 #include "dds/ddsi/ddsi_xt_typemap.h"
@@ -1679,7 +1680,7 @@ void ddsi_xt_type_fini (struct ddsi_domaingv *gv, struct xt_type *xt, bool inclu
       ddsi_type_unref_locked (gv, xt->_u.alias.related_type);
       break;
     case DDS_XTypes_TK_ANNOTATION:
-      abort (); /* FIXME: not implemented */
+      ddsrt_abort(); /* FIXME: not implemented */
       break;
     case DDS_XTypes_TK_STRUCTURE:
       if (xt->_u.structure.base_type)
@@ -2185,7 +2186,7 @@ static bool xt_is_plain_collection_equiv_kind (const struct xt_type *t, DDS_XTyp
     case DDS_XTypes_TK_MAP:
       return t->_u.map.c.ek == ek;
     default:
-      abort ();
+      ddsrt_abort();
   }
 }
 
@@ -2226,7 +2227,7 @@ static DDS_XTypes_LBound xt_string_bound (const struct xt_type *t)
     case DDS_XTypes_TK_STRING16:
       return t->_u.str16.bound;
     default:
-      abort (); /* not supported */
+      ddsrt_abort(); /* not supported */
   }
 }
 
@@ -2784,7 +2785,7 @@ static ddsi_typeid_kind_t ddsi_typeid_kind_impl (const struct DDS_XTypes_TypeIde
             element_kind = ddsi_typeid_kind_impl (type_id->_u.map_ldefn.element_identifier);
           break;
         default:
-          abort ();
+          ddsrt_abort();
       }
       switch (element_kind) {
         case DDSI_TYPEID_KIND_MINIMAL:
@@ -2989,7 +2990,7 @@ void ddsi_xt_get_typeobject_kind_impl (const struct xt_type *xt, struct DDS_XTyp
         break;
       }
       case DDS_XTypes_TK_ANNOTATION:
-        abort (); /* FIXME: not implemented */
+        ddsrt_abort(); /* FIXME: not implemented */
         break;
       case DDS_XTypes_TK_STRUCTURE:
       {
@@ -3103,7 +3104,7 @@ void ddsi_xt_get_typeobject_kind_impl (const struct xt_type *xt, struct DDS_XTyp
         break;
       }
       default:
-        abort (); /* not supported */
+        ddsrt_abort(); /* not supported */
         break;
     }
   }
@@ -3125,7 +3126,7 @@ void ddsi_xt_get_typeobject_kind_impl (const struct xt_type *xt, struct DDS_XTyp
         break;
       }
       case DDS_XTypes_TK_ANNOTATION:
-        abort (); /* FIXME: not implemented */
+        ddsrt_abort(); /* FIXME: not implemented */
         break;
       case DDS_XTypes_TK_STRUCTURE:
       {
@@ -3247,7 +3248,7 @@ void ddsi_xt_get_typeobject_kind_impl (const struct xt_type *xt, struct DDS_XTyp
         break;
       }
       default:
-        abort (); /* not supported */
+        ddsrt_abort(); /* not supported */
         break;
     }
   }

--- a/src/core/xtests/symbol_export/symbol_export.c
+++ b/src/core/xtests/symbol_export/symbol_export.c
@@ -848,6 +848,7 @@ int main (int argc, char **argv)
   ddsrt_getpid ();
   ddsrt_getprocessname ();
   ddsrt_abort ();
+  ddsrt_exit(0);
 
   // ddsrt/time.h
   ddsrt_mtime_t mt = { .v = 0};

--- a/src/core/xtests/symbol_export/symbol_export.c
+++ b/src/core/xtests/symbol_export/symbol_export.c
@@ -847,6 +847,7 @@ int main (int argc, char **argv)
   // ddsrt/process.h
   ddsrt_getpid ();
   ddsrt_getprocessname ();
+  ddsrt_abort ();
 
   // ddsrt/time.h
   ddsrt_mtime_t mt = { .v = 0};

--- a/src/ddsrt/include/dds/ddsrt/process.h
+++ b/src/ddsrt/include/dds/ddsrt/process.h
@@ -70,6 +70,14 @@ ddsrt_getpid(void);
 DDS_EXPORT char *
 ddsrt_getprocessname(void);
 
+/**
+ * @brief Terminates the process in an abnormal fashion.
+ *
+ * Does not return. Immediately terminates the process.
+ */
+DDS_EXPORT void
+ddsrt_abort(void);
+
 #if defined (__cplusplus)
 }
 #endif

--- a/src/ddsrt/include/dds/ddsrt/process.h
+++ b/src/ddsrt/include/dds/ddsrt/process.h
@@ -78,6 +78,15 @@ ddsrt_getprocessname(void);
 DDS_EXPORT void
 ddsrt_abort(void);
 
+/**
+ * @brief Performs a normal process termination.
+ *
+ * @param status
+ * @returns The least significant byte of `status` is returned to the parent.
+ */
+DDS_EXPORT void
+ddsrt_exit(int status);
+
 #if defined (__cplusplus)
 }
 #endif

--- a/src/ddsrt/include/dds/ddsrt/process.h
+++ b/src/ddsrt/include/dds/ddsrt/process.h
@@ -15,6 +15,7 @@
 #include "dds/ddsrt/time.h"
 #include "dds/ddsrt/types.h"
 #include "dds/ddsrt/retcode.h"
+#include "dds/ddsrt/attributes.h"
 
 #if DDSRT_WITH_FREERTOS
 #include <FreeRTOS.h>
@@ -76,7 +77,7 @@ ddsrt_getprocessname(void);
  * Does not return. Immediately terminates the process.
  */
 DDS_EXPORT void
-ddsrt_abort(void);
+ddsrt_abort (void) ddsrt_attribute_noreturn;
 
 /**
  * @brief Performs a normal process termination.
@@ -85,7 +86,7 @@ ddsrt_abort(void);
  * @returns The least significant byte of `status` is returned to the parent.
  */
 DDS_EXPORT void
-ddsrt_exit(int status);
+ddsrt_exit(int status) ddsrt_attribute_noreturn;
 
 #if defined (__cplusplus)
 }

--- a/src/ddsrt/src/expand_vars.c
+++ b/src/ddsrt/src/expand_vars.c
@@ -77,7 +77,7 @@ static char *expand_var (const char *name, char op, const char *alt, expand_fn e
         case '+':
             return val && *val ? expand (alt, lookup, data, depth + 1) : ddsrt_strdup ("");
         default:
-            abort ();
+            ddsrt_abort();
             return NULL;
     }
 }

--- a/src/ddsrt/src/heap/posix/heap.c
+++ b/src/ddsrt/src/heap/posix/heap.c
@@ -12,6 +12,7 @@
 
 #include "dds/ddsrt/attributes.h"
 #include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/process.h"
 
 static ddsrt_allocation_ops_t ddsrt_allocator = {
   .malloc = malloc,
@@ -40,7 +41,7 @@ ddsrt_malloc(size_t size)
 
   if (ptr == NULL) {
     /* Heap exhausted */
-    abort();
+    ddsrt_abort();
   }
 
   return ptr;
@@ -55,7 +56,7 @@ ddsrt_calloc(size_t count, size_t size)
 
   if (ptr == NULL) {
     /* Heap exhausted */
-    abort();
+    ddsrt_abort();
   }
 
   return ptr;
@@ -79,7 +80,7 @@ ddsrt_realloc(void *memblk, size_t size)
 
   if (ptr == NULL){
     /* Heap exhausted */
-    abort();
+    ddsrt_abort();
   }
 
   return ptr;

--- a/src/ddsrt/src/log.c
+++ b/src/ddsrt/src/log.c
@@ -17,6 +17,8 @@
 #include "dds/ddsrt/log.h"
 #include "dds/ddsrt/sync.h"
 #include "dds/ddsrt/threads.h"
+#include "dds/ddsrt/process.h"
+#include "dds/ddsrt/static_assert.h"
 #include "dds/ddsrt/static_assert.h"
 
 #define MAX_ID_LEN (10)
@@ -298,7 +300,7 @@ static void vlog (const struct ddsrt_log_cfg_impl *cfg, uint32_t cat, uint32_t d
   vlog1 (cfg, cat, domid, file, line, func, fmt, ap);
   unlock_sink ();
   if (cat & DDS_LC_FATAL)
-    abort();
+    ddsrt_abort();
 }
 
 void dds_log_cfg (const struct ddsrt_log_cfg *cfg, uint32_t cat, const char *file, uint32_t line, const char *func, const char *fmt, ...)

--- a/src/ddsrt/src/process/posix/process.c
+++ b/src/ddsrt/src/process/posix/process.c
@@ -84,3 +84,8 @@ ddsrt_getprocessname(void)
   }
 }
 
+void
+ddsrt_abort(void)
+{
+  abort();
+}

--- a/src/ddsrt/src/process/posix/process.c
+++ b/src/ddsrt/src/process/posix/process.c
@@ -89,3 +89,9 @@ ddsrt_abort(void)
 {
   abort();
 }
+
+void
+ddsrt_exit(int status)
+{
+  exit(status);
+}

--- a/src/ddsrt/src/sync/posix/sync.c
+++ b/src/ddsrt/src/sync/posix/sync.c
@@ -18,6 +18,7 @@
 
 #include "dds/ddsrt/sync.h"
 #include "dds/ddsrt/time.h"
+#include "dds/ddsrt/process.h"
 
 void ddsrt_mutex_init (ddsrt_mutex_t *mutex)
 {
@@ -30,7 +31,7 @@ void ddsrt_mutex_destroy (ddsrt_mutex_t *mutex)
   assert (mutex != NULL);
 
   if (pthread_mutex_destroy (&mutex->mutex) != 0)
-    abort();
+    ddsrt_abort();
 }
 
 void ddsrt_mutex_lock (ddsrt_mutex_t *mutex)
@@ -38,7 +39,7 @@ void ddsrt_mutex_lock (ddsrt_mutex_t *mutex)
   assert (mutex != NULL);
 
   if (pthread_mutex_lock (&mutex->mutex) != 0)
-    abort();
+    ddsrt_abort();
 }
 
 bool
@@ -49,7 +50,7 @@ ddsrt_mutex_trylock (ddsrt_mutex_t *mutex)
 
   err = pthread_mutex_trylock (&mutex->mutex);
   if (err != 0 && err != EBUSY)
-    abort();
+    ddsrt_abort();
   return (err == 0);
 }
 
@@ -59,7 +60,7 @@ ddsrt_mutex_unlock (ddsrt_mutex_t *mutex)
   assert (mutex != NULL);
 
   if (pthread_mutex_unlock (&mutex->mutex) != 0)
-    abort();
+    ddsrt_abort();
 }
 
 void
@@ -76,7 +77,7 @@ ddsrt_cond_destroy (ddsrt_cond_t *cond)
   assert (cond != NULL);
 
   if (pthread_cond_destroy (&cond->cond) != 0)
-    abort();
+    ddsrt_abort();
 }
 
 void
@@ -86,7 +87,7 @@ ddsrt_cond_wait (ddsrt_cond_t *cond, ddsrt_mutex_t *mutex)
   assert (mutex != NULL);
 
   if (pthread_cond_wait (&cond->cond, &mutex->mutex) != 0)
-    abort();
+    ddsrt_abort();
 }
 
 bool
@@ -118,7 +119,7 @@ ddsrt_cond_waituntil(
       break;
   }
 
-  abort();
+  ddsrt_abort();
   return false;
 }
 
@@ -141,7 +142,7 @@ ddsrt_cond_signal (ddsrt_cond_t *cond)
   assert (cond != NULL);
 
   if (pthread_cond_signal (&cond->cond) != 0)
-    abort();
+    ddsrt_abort();
 }
 
 void
@@ -150,7 +151,7 @@ ddsrt_cond_broadcast (ddsrt_cond_t *cond)
   assert (cond != NULL);
 
   if (pthread_cond_broadcast (&cond->cond) != 0)
-    abort();
+    ddsrt_abort();
 }
 
 void
@@ -160,11 +161,11 @@ ddsrt_rwlock_init (ddsrt_rwlock_t *rwlock)
 
 #if __SunOS_5_6
   if (pthread_mutex_init(&rwlock->rwlock, NULL) != 0)
-    abort();
+    ddsrt_abort();
 #else
   /* process-shared attribute is set to PTHREAD_PROCESS_PRIVATE by default */
   if (pthread_rwlock_init(&rwlock->rwlock, NULL) != 0)
-    abort();
+    ddsrt_abort();
 #endif
 }
 
@@ -174,10 +175,10 @@ ddsrt_rwlock_destroy (ddsrt_rwlock_t *rwlock)
   assert(rwlock != NULL);
 #if __SunOS_5_6
   if (pthread_mutex_destroy(&rwlock->rwlock) != 0)
-    abort();
+    ddsrt_abort();
 #else
   if (pthread_rwlock_destroy(&rwlock->rwlock) != 0)
-    abort();
+    ddsrt_abort();
 #endif
 }
 

--- a/src/ddsrt/tests/thread.c
+++ b/src/ddsrt/tests/thread.c
@@ -22,6 +22,7 @@
 #include "dds/ddsrt/cdtors.h"
 #include "dds/ddsrt/retcode.h"
 #include "dds/ddsrt/sync.h"
+#include "dds/ddsrt/process.h"
 #include "dds/ddsrt/threads.h"
 
 static int32_t min_fifo_prio = 250;
@@ -81,7 +82,7 @@ static uint32_t thread_main(void *ptr)
 #elif _WIN32
   int prio = GetThreadPriority(GetCurrentThread());
   if (prio == THREAD_PRIORITY_ERROR_RETURN)
-    abort();
+    ddsrt_abort();
   if (prio == attr->schedPriority) {
     arg->res = 1;
   }
@@ -92,7 +93,7 @@ static uint32_t thread_main(void *ptr)
 
   err = pthread_getschedparam(pthread_self(), &policy, &sched);
   if (err != 0) {
-    abort();
+    ddsrt_abort();
   }
   if (((policy == SCHED_OTHER && attr->schedClass == DDSRT_SCHED_TIMESHARE) ||
        (policy == SCHED_FIFO && attr->schedClass == DDSRT_SCHED_REALTIME))

--- a/src/tools/ddsperf/ddsperf.c
+++ b/src/tools/ddsperf/ddsperf.c
@@ -391,7 +391,7 @@ static void verrorx (int exitcode, const char *fmt, va_list ap)
 {
   vprintf (fmt, ap);
   fflush (stdout);
-  exit (exitcode);
+  ddsrt_exit (exitcode);
 }
 
 static void error2 (const char *fmt, ...)
@@ -728,7 +728,7 @@ static uint32_t pubthread (void *varg)
       {
         printf ("dds_register_instance failed: %d\n", result);
         fflush (stdout);
-        exit (2);
+        ddsrt_exit (2);
       }
     }
   }
@@ -751,7 +751,7 @@ static uint32_t pubthread (void *varg)
     {
       printf ("request loan error: %d\n", result);
       fflush (stdout);
-      exit (2);
+      ddsrt_exit (2);
     }
     else
     {
@@ -765,7 +765,7 @@ static uint32_t pubthread (void *varg)
       printf ("write error: %d\n", result);
       fflush (stdout);
       if (result != DDS_RETCODE_TIMEOUT)
-        exit (2);
+        ddsrt_exit (2);
       /* retry with original timestamp, it really is just a way of reporting
          blocking for an exceedingly long time, but do force a fresh time stamp
          for the next sample */
@@ -976,7 +976,7 @@ static int check_eseq (struct eseq_admin *ea, uint32_t seq, uint32_t keyval, uin
   if (keyval >= ea->nkeys)
   {
     printf ("received key %"PRIu32" >= nkeys %u\n", keyval, ea->nkeys);
-    exit (3);
+    ddsrt_exit (3);
   }
   ddsrt_mutex_lock (&ea->lock);
   for (uint32_t i = 0; i < ea->nph; i++)
@@ -1970,7 +1970,7 @@ EXAMPLES:\n\
     running for 10s\n\
 ", argv0, argv0, argv0);
   fflush (stdout);
-  exit (3);
+  ddsrt_exit (3);
 }
 
 struct string_int_map_elem {


### PR DESCRIPTION
This pull request:

- Introduces `ddsrt_abort` and `ddsrt_exit`
- Replaces `abort` with `ddsrt_abort` in `ddsc`, `ddsrt`, `cdr`, and `ddsi`
- Addes a symbol export test for each