### PR TITLE
Introduce the concept of a domain lifecycle state.

### DIFF
--- a/src/core/ddsc/include/dds/dds.h
+++ b/src/core/ddsc/include/dds/dds.h
@@ -1110,6 +1110,25 @@ enum dds_domain_lifecycle{
   DDS_DOMAIN_LIFECYCLE_OPERATIONAL
 };
 
+/// @brief Function to indicate where we are in the domain's lifecycle
+/// @note Domains starts out in the INITIALISATION
+/// state. The only transition currently allowed is to set it OPERATIONAL.
+/// The transition is currently only possible when applied to all domains via
+/// the `DDS_CYCLONEDDS_HANDLE`.
+///
+/// @param[in] domain The domain entity for which to set the lifecycle state. Only accepts `DDS_CYCLONEDDS_HANDLE`.
+/// @param[in] state The new state
+/// @return a dds_retcode_t indicating success or failure
+/// @retval DDS_RETCODE_OK transition was successful
+/// @retval DDS_RETCODE_ERROR Internal error prevented the transition. Should not be possible.
+/// @retval DDS_RETCODE_ILLEGAL_OPERATION handle refers to a non-domain entity
+/// @retval DDS_RETCODE_PRECONDITION_NOT_MET attempt at an disallowed transition
+/// @retval DDS_RETCODE_PRECONDITION_NOT_MET Cyclone DDS has not been initialised yet
+DDS_EXPORT
+dds_return_t dds_set_domain_lifecycle (
+  const dds_entity_t domain,
+  const enum dds_domain_lifecycle state);
+
 /**
  * @brief Get entity parent.
  * @ingroup entity

--- a/src/core/ddsc/include/dds/dds.h
+++ b/src/core/ddsc/include/dds/dds.h
@@ -1103,6 +1103,13 @@ dds_create_domain(const dds_domainid_t domain, const char *config);
 DDS_EXPORT dds_entity_t
 dds_create_domain_with_rawconfig(const dds_domainid_t domain, const struct ddsi_config *config);
 
+/// @brief Supported lifecycle states
+/// @ingroup domain
+enum dds_domain_lifecycle{
+  DDS_DOMAIN_LIFECYCLE_INITIALISATION,
+  DDS_DOMAIN_LIFECYCLE_OPERATIONAL
+};
+
 /**
  * @brief Get entity parent.
  * @ingroup entity

--- a/src/core/ddsc/src/dds_domain.c
+++ b/src/core/ddsc/src/dds_domain.c
@@ -491,4 +491,36 @@ dds_return_t dds_free_typeobj (dds_typeobj_t *type_obj)
   return DDS_RETCODE_UNSUPPORTED;
 }
 
+dds_return_t dds_set_domain_lifecycle(const dds_entity_t domain, const enum dds_domain_lifecycle state) {
+    dds_return_t result = DDS_RETCODE_ERROR;
+    if (dds_init () < 0) {
+        result = DDS_RETCODE_PRECONDITION_NOT_MET;
+    } else {
+        if (DDS_CYCLONEDDS_HANDLE == domain) {
+            switch (state) {
+            case DDS_DOMAIN_LIFECYCLE_OPERATIONAL:
+                // Only initialisation->operational is valid
+                if (LIFECYCLE_STATE == DDS_DOMAIN_LIFECYCLE_INITIALISATION) {
+                  result = ddsrt_lock();
+                  if (result == DDS_RETCODE_SUCCESS) {
+                    LIFECYCLE_STATE = state;
+                  } // else result is the error from ddsrt_lock()
+                } else {
+                  result = DDS_RETCODE_PRECONDITION_NOT_MET;
+                }
+                break;
+            case DDS_DOMAIN_LIFECYCLE_INITIALISATION:
+                result = DDS_RETCODE_PRECONDITION_NOT_MET;
+                break;
+            default:
+                result = DDS_RETCODE_ERROR;
+                break;
+            }
+        } else {
+          result = DDS_RETCODE_ILLEGAL_OPEATION;
+        }
+    }
+    return result;
+}
+
 #endif /* DDS_HAS_TYPE_DISCOVERY */

--- a/src/core/ddsc/src/dds_domain.c
+++ b/src/core/ddsc/src/dds_domain.c
@@ -33,6 +33,7 @@
 #include "dds__psmx.h"
 
 static dds_return_t dds_domain_free (dds_entity *vdomain);
+static dds_domain_lifecycle LIFECYCLE_STATE = DDS_DOMAIN_LIFECYCLE_INITIALISATION;
 
 const struct dds_entity_deriver dds_entity_deriver_domain = {
   .interrupt = dds_entity_deriver_dummy_interrupt,

--- a/src/ddsrt/include/dds/ddsrt/cdtors.h
+++ b/src/ddsrt/include/dds/ddsrt/cdtors.h
@@ -42,6 +42,14 @@ void ddsrt_init(void);
  * (when the reference count is 1) actually finalizes it.
  */
 void ddsrt_fini(void);
+///
+/// @brief Lock the pooled memory allocator
+///
+dds_return_t ddsrt_lock(void);
+
+/// @brief Unlock the pooled memory allocator
+///
+dds_return_t ddsrt_unlock(void);
 
 /**
  * @brief Get a pointer to the global 'init_mutex'

--- a/src/ddsrt/src/cdtors.c
+++ b/src/ddsrt/src/cdtors.c
@@ -86,6 +86,16 @@ void ddsrt_fini (void)
   }
 }
 
+dds_return_t ddsrt_lock (void) {
+  dds_return_t dds_result = DDS_RETCODE_OK;
+  return dds_result;
+}
+
+dds_return_t ddsrt_unlock (void) {
+  dds_return_t dds_result = DDS_RETCODE_OK;
+  return dds_result;
+}
+
 ddsrt_mutex_t *ddsrt_get_singleton_mutex(void)
 {
   return &init_mutex;


### PR DESCRIPTION
This PR will:

- Introduce the concept of a lifecycle state for domains
- Introduce the ability for a user to transition the lifecycle state

Limitations:

- The only two lifecycle states that will exist, for now, are `initialisation` and `operational`
- The only supported transition is `initialisation`->`operational`
- For now, there is no meaning to the two lifecycle states, but this can/will change in the future
- For now, the transition and state can only be applied to _all_ domains

