### PR TITLE
Export dds_writecdr_impl

### DIFF
--- a/src/core/ddsc/src/dds__write.h
+++ b/src/core/ddsc/src/dds__write.h
@@ -36,6 +36,7 @@ dds_return_t dds_write_impl (dds_writer *wr, const void *data, dds_time_t timest
   ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
 
 /** @component write_data */
+DDS_EXPORT_INTERNAL_FUNCTION
 dds_return_t dds_writecdr_impl (dds_writer *wr, struct ddsi_xpack *xp, struct ddsi_serdata *d, bool flush)
   ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
 

--- a/src/core/xtests/symbol_export/symbol_export.c
+++ b/src/core/xtests/symbol_export/symbol_export.c
@@ -71,7 +71,7 @@
 
 #include "dds/cdr/dds_cdrstream.h"
 
-#include "dds__write.h" // dds_write_impl
+#include "dds__write.h" // dds_write_impl, dds_writecdr_impl
 
 DDSRT_WARNING_DEPRECATED_OFF
 
@@ -1058,6 +1058,7 @@ int main (int argc, char **argv)
 
   // dds__write.h
   dds_write_impl (ptr, ptr, 0, (dds_write_action) 0);
+  dds_writecdr_impl (ptr, ptr, ptr, false);
 
   return 0;
 }


### PR DESCRIPTION
## Background

Hi, I am one of the development members of [CARET](https://github.com/tier4/caret).
Thanks for exporting `dds_write_impl` that were hooked in CARET in [Issue 1308](https://github.com/eclipse-cyclonedds/cyclonedds/issues/1833).
After having the symbol exported, CARET is able to perform the performance analysis as before.

We are currently developing the capability to analyze communications using `GenericPublsiher`.
To implement this feature, we need to hook `dds_writecdr_impl`, but as you know, this symbol is currently hidden.

## Changes
Export `dds_writecdr_impl` symbol. 
`dds_writecdr_impl` is a convenient trace point for instrumenting the code for performance measurements.

## Related Links
- https://github.com/eclipse-cyclonedds/cyclonedds/issues/1833
- https://github.com/eclipse-cyclonedds/cyclonedds/pull/1846