### PR TITLE
remove redundant if statements in avl tree delete_generic()

### DIFF
--- a/src/ddsrt/src/avl.c
+++ b/src/ddsrt/src/avl.c
@@ -510,9 +510,8 @@ static void delete_generic (const ddsrt_avl_treedef_t *td, ddsrt_avl_tree_t *tre
                 whence->cs[1]->parent = whence;
             }
             subst->cs[0] = node->cs[0];
-            if (subst->cs[0]) {
-                subst->cs[0]->parent = subst;
-            }
+            assert(subst->cs[0] != NULL);
+            subst->cs[0]->parent = subst;
             if (path) {
                 path->p.pnode[path->p.pnodeidx+1] = &subst->cs[0];
             }
@@ -521,9 +520,8 @@ static void delete_generic (const ddsrt_avl_treedef_t *td, ddsrt_avl_tree_t *tre
         subst->parent = node->parent;
         subst->height = node->height;
         subst->cs[1] = node->cs[1];
-        if (subst->cs[1]) {
-            subst->cs[1]->parent = subst;
-        }
+        assert(subst->cs[1] != NULL);
+        subst->cs[1]->parent = subst;
         *pnode = subst;
     }
 


### PR DESCRIPTION
This was discovered whilst trying to improve code coverage. The issue is with the following code:

https://github.com/eclipse-cyclonedds/cyclonedds/blob/85261c15492307a5d05bcb0837faafa1cc8893c7/src/ddsrt/src/avl.c#L471-L528

If you go into the else of line 485, then proceed past line 506, you have a situation like in the depicted below:

```
             node <-- delete target
            /    \
           /      \
        whence     subtree
        /   \
 subtree    subst
           /
          ? 
```

The if and if else preceding the else of line 485 guarantee `node->cs[0] != NULL` and `node->cs[1] != NULL`.
Thus `if (subst->cs[0]) {` can be scrapped.
Likewise, `if (subst->cs[1]) {` can also be scrapped.