### PR TITLE
Disable multiple receive threads by default

### DIFF
--- a/docs/manual/config/config_file_reference.rst
+++ b/docs/manual/config/config_file_reference.rst
@@ -1161,7 +1161,9 @@ Attributes: :ref:`maxretries<//CycloneDDS/Domain/Internal/MultipleReceiveThreads
 
 One of: false, true, default
 
-This element controls whether all traffic is handled by a single receive thread (false) or whether multiple receive threads may be used to improve latency (true). By default it is disabled on Windows because it appears that one cannot count on being able to send packets to oneself, which is necessary to stop the thread during shutdown. Currently multiple receive threads are only used for connectionless transport (e.g., UDP) and ManySocketsMode not set to single (the default).
+This element controls whether all traffic is handled by a single receive thread (false) or whether multiple receive threads may be used to improve latency (true). The value "default" currently maps to false because of firewalls potentially blocking the packets it sends to itself to interrupt the blocking reads during termination.
+
+Currently multiple receive threads are only used for connectionless transport (e.g., UDP) and ManySocketsMode not set to single (the default).
 
 The default value is: ``default``
 
@@ -2642,7 +2644,7 @@ The default value is: ``none``
 ..
    generated from ddsi_config.h[570f67bd3080674a4bad53d9580a8bb7ad1e6e4d] 
    generated from ddsi__cfgunits.h[bd22f0c0ed210501d0ecd3b07c992eca549ef5aa] 
-   generated from ddsi__cfgelems.h[13337a006d5313519c88c3f3643f27992840cfd3] 
+   generated from ddsi__cfgelems.h[d4d0b8c7cf61f0a1cfa4b62e02458cf7b8962536] 
    generated from ddsi_config.c[efeae198a5e12ca8977a655216470564b5c44b64] 
    generated from _confgen.h[e32eabfc35e9f3a7dcb63b19ed148c0d17c6e5fc] 
    generated from _confgen.c[237308acd53897a34e8c643e16e05a61d73ffd65] 

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -788,7 +788,9 @@ Attributes: [maxretries](#cycloneddsdomaininternalmultiplereceivethreadsmaxretri
 
 One of: false, true, default
 
-This element controls whether all traffic is handled by a single receive thread (false) or whether multiple receive threads may be used to improve latency (true). By default it is disabled on Windows because it appears that one cannot count on being able to send packets to oneself, which is necessary to stop the thread during shutdown. Currently multiple receive threads are only used for connectionless transport (e.g., UDP) and ManySocketsMode not set to single (the default).
+This element controls whether all traffic is handled by a single receive thread (false) or whether multiple receive threads may be used to improve latency (true). The value "default" currently maps to false because of firewalls potentially blocking the packets it sends to itself to interrupt the blocking reads during termination.
+
+Currently multiple receive threads are only used for connectionless transport (e.g., UDP) and ManySocketsMode not set to single (the default).
 
 The default value is: `default`
 
@@ -1846,7 +1848,7 @@ The categorisation of tracing output is incomplete and hence most of the verbosi
 The default value is: `none`
 <!--- generated from ddsi_config.h[570f67bd3080674a4bad53d9580a8bb7ad1e6e4d] -->
 <!--- generated from ddsi__cfgunits.h[bd22f0c0ed210501d0ecd3b07c992eca549ef5aa] -->
-<!--- generated from ddsi__cfgelems.h[13337a006d5313519c88c3f3643f27992840cfd3] -->
+<!--- generated from ddsi__cfgelems.h[d4d0b8c7cf61f0a1cfa4b62e02458cf7b8962536] -->
 <!--- generated from ddsi_config.c[efeae198a5e12ca8977a655216470564b5c44b64] -->
 <!--- generated from _confgen.h[e32eabfc35e9f3a7dcb63b19ed148c0d17c6e5fc] -->
 <!--- generated from _confgen.c[237308acd53897a34e8c643e16e05a61d73ffd65] -->

--- a/etc/cyclonedds.rnc
+++ b/etc/cyclonedds.rnc
@@ -559,7 +559,7 @@ CycloneDDS configuration""" ] ]
           xsd:integer
         }?
         & [ a:documentation [ xml:lang="en" """
-<p>This element controls whether all traffic is handled by a single receive thread (false) or whether multiple receive threads may be used to improve latency (true). By default it is disabled on Windows because it appears that one cannot count on being able to send packets to oneself, which is necessary to stop the thread during shutdown. Currently multiple receive threads are only used for connectionless transport (e.g., UDP) and ManySocketsMode not set to single (the default).</p>
+<p>This element controls whether all traffic is handled by a single receive thread (false) or whether multiple receive threads may be used to improve latency (true). The value "default" currently maps to false because of firewalls potentially blocking the packets it sends to itself to interrupt the blocking reads during termination.</p><p>Currently multiple receive threads are only used for connectionless transport (e.g., UDP) and ManySocketsMode not set to single (the default).</p>
 <p>The default value is: <code>default</code></p>""" ] ]
         element MultipleReceiveThreads {
           [ a:documentation [ xml:lang="en" """
@@ -1285,7 +1285,7 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==<br>
 }
 # generated from ddsi_config.h[570f67bd3080674a4bad53d9580a8bb7ad1e6e4d] 
 # generated from ddsi__cfgunits.h[bd22f0c0ed210501d0ecd3b07c992eca549ef5aa] 
-# generated from ddsi__cfgelems.h[13337a006d5313519c88c3f3643f27992840cfd3] 
+# generated from ddsi__cfgelems.h[d4d0b8c7cf61f0a1cfa4b62e02458cf7b8962536] 
 # generated from ddsi_config.c[efeae198a5e12ca8977a655216470564b5c44b64] 
 # generated from _confgen.h[e32eabfc35e9f3a7dcb63b19ed148c0d17c6e5fc] 
 # generated from _confgen.c[237308acd53897a34e8c643e16e05a61d73ffd65] 

--- a/etc/cyclonedds.xsd
+++ b/etc/cyclonedds.xsd
@@ -883,7 +883,7 @@ CycloneDDS configuration</xs:documentation>
   <xs:element name="MultipleReceiveThreads">
     <xs:annotation>
       <xs:documentation>
-&lt;p&gt;This element controls whether all traffic is handled by a single receive thread (false) or whether multiple receive threads may be used to improve latency (true). By default it is disabled on Windows because it appears that one cannot count on being able to send packets to oneself, which is necessary to stop the thread during shutdown. Currently multiple receive threads are only used for connectionless transport (e.g., UDP) and ManySocketsMode not set to single (the default).&lt;/p&gt;
+&lt;p&gt;This element controls whether all traffic is handled by a single receive thread (false) or whether multiple receive threads may be used to improve latency (true). The value "default" currently maps to false because of firewalls potentially blocking the packets it sends to itself to interrupt the blocking reads during termination.&lt;/p&gt;&lt;p&gt;Currently multiple receive threads are only used for connectionless transport (e.g., UDP) and ManySocketsMode not set to single (the default).&lt;/p&gt;
 &lt;p&gt;The default value is: &lt;code&gt;default&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
     <xs:complexType>
@@ -1941,7 +1941,7 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
 </xs:schema>
 <!--- generated from ddsi_config.h[570f67bd3080674a4bad53d9580a8bb7ad1e6e4d] -->
 <!--- generated from ddsi__cfgunits.h[bd22f0c0ed210501d0ecd3b07c992eca549ef5aa] -->
-<!--- generated from ddsi__cfgelems.h[13337a006d5313519c88c3f3643f27992840cfd3] -->
+<!--- generated from ddsi__cfgelems.h[d4d0b8c7cf61f0a1cfa4b62e02458cf7b8962536] -->
 <!--- generated from ddsi_config.c[efeae198a5e12ca8977a655216470564b5c44b64] -->
 <!--- generated from _confgen.h[e32eabfc35e9f3a7dcb63b19ed148c0d17c6e5fc] -->
 <!--- generated from _confgen.c[237308acd53897a34e8c643e16e05a61d73ffd65] -->

--- a/src/core/ddsi/defconfig.c
+++ b/src/core/ddsi/defconfig.c
@@ -101,7 +101,7 @@ void ddsi_config_init_default (struct ddsi_config *cfg)
 }
 /* generated from ddsi_config.h[570f67bd3080674a4bad53d9580a8bb7ad1e6e4d] */
 /* generated from ddsi__cfgunits.h[bd22f0c0ed210501d0ecd3b07c992eca549ef5aa] */
-/* generated from ddsi__cfgelems.h[13337a006d5313519c88c3f3643f27992840cfd3] */
+/* generated from ddsi__cfgelems.h[d4d0b8c7cf61f0a1cfa4b62e02458cf7b8962536] */
 /* generated from ddsi_config.c[efeae198a5e12ca8977a655216470564b5c44b64] */
 /* generated from _confgen.h[e32eabfc35e9f3a7dcb63b19ed148c0d17c6e5fc] */
 /* generated from _confgen.c[237308acd53897a34e8c643e16e05a61d73ffd65] */

--- a/src/core/ddsi/src/ddsi__cfgelems.h
+++ b/src/core/ddsi/src/ddsi__cfgelems.h
@@ -1525,10 +1525,10 @@ static struct cfgelem internal_cfgelems[] = {
     DESCRIPTION(
     "<p>This element controls whether all traffic is handled by a single "
     "receive thread (false) or whether multiple receive threads may be used "
-    "to improve latency (true). By default it is disabled on Windows because "
-    "it appears that one cannot count on being able to send packets to "
-    "oneself, which is necessary to stop the thread during shutdown. "
-    "Currently multiple receive threads are only used for connectionless "
+    "to improve latency (true). The value \"default\" currently maps to "
+    "false because of firewalls potentially blocking the packets it sends "
+    "to itself to interrupt the blocking reads during termination.</p>"
+    "<p>Currently multiple receive threads are only used for connectionless "
     "transport (e.g., UDP) and ManySocketsMode not set to single (the "
     "default).</p>"),
     VALUES("false","true","default")),


### PR DESCRIPTION
On non-Windows platforms, the default was to use multiple receive threads, which in turn implied the use of blocking read operations.  On termination, those blocking calls were interrupted by sending a packet to itself, but that only works if the firewall allows it.  If the firewall drops these packet, the process hangs.

Various people have run into this problem, changing to using a single thread always solves the problem.  So, changing the default until a better solution for interrupting these calls is implemented is probably for the best.

Fixes #1916