### PR TITLE
provide setting of socket recv buffer size on raw ethernet sockets

### DIFF
--- a/src/core/ddsi/src/ddsi_raweth.c
+++ b/src/core/ddsi/src/ddsi_raweth.c
@@ -37,7 +37,6 @@ typedef struct ddsi_raweth_conn {
   int m_ifindex;
 } *ddsi_raweth_conn_t;
 
-
 struct ddsi_ethernet_header {
   unsigned char dmac[ETH_ALEN];
   unsigned char smac[ETH_ALEN];
@@ -304,6 +303,18 @@ static dds_return_t ddsi_raweth_create_conn (struct ddsi_tran_conn **conn_out, s
     return DDS_RETCODE_ERROR;
   }
 
+  if ((rc = ddsi_tran_set_rcvbuf(fact, sock, &gv->config.socket_rcvbuf_size, 1048576)) < 0)
+  {
+    ddsrt_close(sock);
+    return DDS_RETCODE_ERROR;
+  }
+
+  if ((rc = ddsi_tran_set_sndbuf(fact, sock, &gv->config.socket_sndbuf_size, 65536)) < 0)
+  {
+    ddsrt_close(sock);
+    return DDS_RETCODE_ERROR;
+  }
+
   memset(&addr, 0, sizeof(addr));
   addr.sll_family = AF_PACKET;
   addr.sll_protocol = htons(ETH_P_ALL);
@@ -529,12 +540,6 @@ static int ddsi_raweth_is_valid_port (const struct ddsi_tran_factory *fact, uint
   return (eport >= 1 && eport <= 65535) && (vlanid < 4095) && vlancfi == 0;
 }
 
-static uint32_t ddsi_raweth_receive_buffer_size (const struct ddsi_tran_factory *fact)
-{
-  (void) fact;
-  return 0;
-}
-
 static int ddsi_raweth_locator_from_sockaddr (const struct ddsi_tran_factory *tran, ddsi_locator_t *loc, const struct sockaddr *sockaddr)
 {
   (void) tran;
@@ -598,16 +603,18 @@ int ddsi_raweth_init (struct ddsi_domaingv *gv)
   fact->m_locator_to_string_fn = ddsi_raweth_to_string;
   fact->m_enumerate_interfaces_fn = ddsi_raweth_enumerate_interfaces;
   fact->m_is_valid_port_fn = ddsi_raweth_is_valid_port;
-  fact->m_receive_buffer_size_fn = ddsi_raweth_receive_buffer_size;
   fact->m_locator_from_sockaddr_fn = ddsi_raweth_locator_from_sockaddr;
   fact->m_get_locator_port_fn = ddsi_raweth_get_locator_port;
   fact->m_set_locator_port_fn = ddsi_raweth_set_locator_port;
   fact->m_get_locator_aux_fn = ddsi_raweth_get_locator_aux;
   fact->m_set_locator_aux_fn = ddsi_raweth_set_locator_aux;
+  ddsrt_atomic_st32 (&fact->m_receive_buf_size, UINT32_MAX);
+
   ddsi_factory_add (gv, fact);
   GVLOG (DDS_LC_CONFIG, "raweth initialized\n");
   return 0;
 }
+
 
 #else
 

--- a/src/core/ddsi/src/ddsi_tcp.c
+++ b/src/core/ddsi/src/ddsi_tcp.c
@@ -1182,12 +1182,6 @@ static int ddsi_tcp_is_valid_port (const struct ddsi_tran_factory *fact, uint32_
   return (0 < port && port <= 65535);
 }
 
-static uint32_t ddsi_tcp_receive_buffer_size (const struct ddsi_tran_factory *fact)
-{
-  (void) fact;
-  return 0;
-}
-
 static char *ddsi_tcp_locator_to_string (char *dst, size_t sizeof_dst, const ddsi_locator_t *loc, struct ddsi_tran_conn * conn, int with_port)
 {
   (void) conn;
@@ -1240,8 +1234,9 @@ int ddsi_tcp_init (struct ddsi_domaingv *gv)
   fact->fact.m_is_ssm_mcaddr_fn = ddsi_tcp_is_ssm_mcaddr;
   fact->fact.m_is_nearby_address_fn = ddsi_tcp_is_nearby_address;
   fact->fact.m_is_valid_port_fn = ddsi_tcp_is_valid_port;
-  fact->fact.m_receive_buffer_size_fn = ddsi_tcp_receive_buffer_size;
   fact->fact.m_locator_from_sockaddr_fn = ddsi_tcp_locator_from_sockaddr;
+
+  ddsrt_atomic_st32 (&fact->fact.m_receive_buf_size, 0);
 
 #if DDSRT_HAVE_IPV6
   if (gv->config.transport_selector == DDSI_TRANS_TCP6)

--- a/src/core/ddsi/src/ddsi_vnet.c
+++ b/src/core/ddsi/src/ddsi_vnet.c
@@ -176,12 +176,6 @@ static int ddsi_vnet_is_valid_port (const struct ddsi_tran_factory *fact, uint32
   return true;
 }
 
-static uint32_t ddsi_vnet_receive_buffer_size (const struct ddsi_tran_factory *fact)
-{
-  (void) fact;
-  return 0;
-}
-
 static int ddsi_vnet_locator_from_sockaddr (const struct ddsi_tran_factory *tran, ddsi_locator_t *loc, const struct sockaddr *sockaddr)
 {
   (void) sockaddr;
@@ -224,8 +218,9 @@ int ddsi_vnet_init (struct ddsi_domaingv *gv, const char *name, int32_t locator_
   fact->m_base.m_locator_to_string_fn = ddsi_vnet_to_string;
   fact->m_base.m_enumerate_interfaces_fn = ddsi_vnet_enumerate_interfaces;
   fact->m_base.m_is_valid_port_fn = ddsi_vnet_is_valid_port;
-  fact->m_base.m_receive_buffer_size_fn = ddsi_vnet_receive_buffer_size;
   fact->m_base.m_locator_from_sockaddr_fn = ddsi_vnet_locator_from_sockaddr;
+  ddsrt_atomic_st32 (&fact->m_base.m_receive_buf_size, 0);
+
   ddsi_factory_add (gv, &fact->m_base);
   GVLOG (DDS_LC_CONFIG, "vnet %s initialized\n", name);
   return 0;


### PR DESCRIPTION
The option to set the receive socket buffer size for raw socket is added. The related code that was present in the udp transport implementation is moved to the ddsi_trans and is also used by the ddsi_raweth.c 