### PR TITLE
Bump docker ubuntu jammy

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -58,6 +58,6 @@ fi
 
 mkdir -p build
 cd build
-cmake -DCMAKE_INSTALL_PREFIX=$CYCLONEDDS_INSTALL_PREFIX -DBUILD_IDLC=ON ..
+cmake -DCMAKE_INSTALL_PREFIX=$CYCLONEDDS_INSTALL_PREFIX -DBUILD_IDLC=ON -DBUILD_EXAMPLES=ON ..
 cmake --build .
 cmake --build . --target install

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -8,7 +8,7 @@
 
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
-FROM ubuntu:bionic
+FROM ubuntu:jammy
 
 # Dependencies required to build cyclonedds
 RUN apt update && apt install -y \

--- a/scripts/docker/README.md
+++ b/scripts/docker/README.md
@@ -5,8 +5,8 @@ Additionally you can also build a docker image with pre-built cyclonedds example
 
 # Bulid docker image 
 There are two docker images you can build.  
-- **ubuntu:cyclonedds** : ubuntu bionic based image that contains dependencies to build cyclonedds. 
-- **cyclonedds:latest** : ubuntu bionic based image with pre-built cyclonedds core & applications (based on the checked out revision).
+- **ubuntu:cyclonedds** : ubuntu jammy based image that contains dependencies to build cyclonedds. 
+- **cyclonedds:latest** : ubuntu jammy based image with pre-built cyclonedds core & applications (based on the checked out revision).
 
 ## How to build the images
 

--- a/scripts/docker/build_cyclonedds.sh
+++ b/scripts/docker/build_cyclonedds.sh
@@ -21,6 +21,6 @@ echo "WORKSPACE is $WORKSPACE"
 
 docker run -it --rm -v $WORKSPACE/:/cyclonedds --workdir /cyclonedds $IMAGE_NAME /bin/bash -c "./scripts/build.sh clean"
 # Launch the docker after build
-docker run --name $CONTAINER_NAME -it -v $WORKSPACE/:/cyclonedds --workdir /cyclonedds $IMAGE_NAME /bin/bash
+docker run --name $CONTAINER_NAME -it --rm -v $WORKSPACE/:/cyclonedds --workdir /cyclonedds $IMAGE_NAME /bin/bash
 # If you want to connect to the above docker to run cyclonedds examples (multiple apps in separate terminals) , use the below command
 # docker exec -it cyclonedds /bin/bash


### PR DESCRIPTION
Use Ubuntu Jammy (LTS) for the docker images because that provides a version of CMake that is required to build the project

- Updated README.md accordingly
- Enable building the examples in build.sh
- Remove the docker containers on exit