### PR TITLE
Link fuzzers as C++

### DIFF
--- a/fuzz/fuzz_config_init/CMakeLists.txt
+++ b/fuzz/fuzz_config_init/CMakeLists.txt
@@ -25,4 +25,6 @@ target_include_directories(
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../src/core/cdr/include>"
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../src/core/ddsi/include>"
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../src/core/ddsi/src>")
+
+set_target_properties(fuzz_config_init PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(fuzz_config_init CycloneDDS::ddsc $ENV{LIB_FUZZING_ENGINE})

--- a/fuzz/fuzz_handle_rtps_message/CMakeLists.txt
+++ b/fuzz/fuzz_handle_rtps_message/CMakeLists.txt
@@ -25,4 +25,6 @@ target_include_directories(
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../src/core/cdr/include>"
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../src/core/ddsi/src>"
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../src/core/ddsi/include>")
+
+set_target_properties(fuzz_handle_rtps_message PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(fuzz_handle_rtps_message CycloneDDS::ddsc $ENV{LIB_FUZZING_ENGINE})

--- a/fuzz/fuzz_sample_deser/CMakeLists.txt
+++ b/fuzz/fuzz_sample_deser/CMakeLists.txt
@@ -17,4 +17,5 @@ target_include_directories(
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../src/core/ddsi/src>")
   
 target_compile_options(fuzz_sample_deser PRIVATE -fsanitize=fuzzer,address -g)
+set_target_properties(fuzz_sample_deser PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(fuzz_sample_deser fuzz_sample CycloneDDS::ddsc -fsanitize=fuzzer,address)

--- a/fuzz/fuzz_sample_deser/CMakeLists.txt
+++ b/fuzz/fuzz_sample_deser/CMakeLists.txt
@@ -16,6 +16,5 @@ target_include_directories(
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../src/core/ddsi/include>"
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../src/core/ddsi/src>")
   
-target_compile_options(fuzz_sample_deser PRIVATE -fsanitize=fuzzer,address -g)
 set_target_properties(fuzz_sample_deser PROPERTIES LINKER_LANGUAGE CXX)
-target_link_libraries(fuzz_sample_deser fuzz_sample CycloneDDS::ddsc -fsanitize=fuzzer,address)
+target_link_libraries(fuzz_sample_deser CycloneDDS::ddsc $ENV{LIB_FUZZING_ENGINE})

--- a/fuzz/fuzz_type_object/CMakeLists.txt
+++ b/fuzz/fuzz_type_object/CMakeLists.txt
@@ -25,4 +25,6 @@ target_include_directories(
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../src/core/cdr/include>"
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../src/core/ddsi/src>"
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../src/core/ddsi/include>")
+
+set_target_properties(fuzz_type_object PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(fuzz_type_object CycloneDDS::ddsc $ENV{LIB_FUZZING_ENGINE})


### PR DESCRIPTION
Building for the libfuzzer, afl and honggfuzz engines works fine when linked as C, but the centipede fuzzer runs into link errors because it needs the C++ standard library.