### PR TITLE
Fix typo in getting started guide

### DIFF
--- a/docs/manual/getting_started/helloworld/helloworld_idl.rst
+++ b/docs/manual/getting_started/helloworld/helloworld_idl.rst
@@ -179,7 +179,7 @@ Generated files with the IDL compiler
 
         .. code-block:: console
 
-            idlc -l C++ HelloWorldData.idl
+            idlc -l cxx HelloWorldData.idl
 
         This results in the following new files that need to be compiled and
         their associated object file linked with the Hello *World!* publisher


### PR DESCRIPTION
The getting started guide describes using the C++ idlc backend by running `idlc -l C++`, this leads to idlc trying to find a  library named `libcycloneddsidlC++.so`.  However the idlc backend implemented in [eclipse-cyclonedds/cyclonedds-cxx](https://github.com/eclipse-cyclonedds/cyclonedds-cxx) is named `libcycloneddsidlcxx.so`.