### PR TITLE
Allow multipathing between PSMX and DDSI

### DIFF
--- a/src/core/ddsi/src/ddsi_wraddrset.c
+++ b/src/core/ddsi/src/ddsi_wraddrset.c
@@ -324,9 +324,7 @@ static const int32_t cost_discarded = 1;
 
 // Cost associated with delivering another time to a reader that has
 // already been covered by a (selected) PSMX locator.
-// Currently, it is quite painful when this happens because it can
-// lead to user observable stuttering.
-static const int32_t cost_redundant_psmx = 1000000;
+static const int32_t cost_redundant_psmx = 0;
 
 // Cost associated with delivering data for the first time (slightly
 // negative cost makes it possible to give a slightly higher initial


### PR DESCRIPTION
Once upon a time sending a sample to a single destination via PSMX and DDSI at the same time would lead to stuttering because of insufficient precise filtering in the delivery paths, but that problem has been fixed a long time ago (I think in commit ef91c275e5b6649279fff7d29462d491a0d08b28).  For a long time, no-one realised that the bit that prevented this from happening was left in.