### PR TITLE
Fix topic name array sizes in "find topic" tests

### DIFF
--- a/src/core/ddsc/tests/topic_find_global.c
+++ b/src/core/ddsc/tests/topic_find_global.c
@@ -148,14 +148,14 @@ struct create_topic_thread_arg
   const dds_topic_descriptor_t *topic_desc;
 };
 
-static void set_topic_name (char *name, const char *prefix, uint32_t index)
+static void set_topic_name (char *name, size_t size, const char *prefix, uint32_t index)
 {
-  snprintf (name, MAX_NAME_SIZE + 10, "%s_%u", prefix, index);
+  snprintf (name, size, "%s_%u", prefix, index);
 }
 
 static uint32_t topics_thread (void *a)
 {
-  char topic_name[MAX_NAME_SIZE + 10];
+  char topic_name[MAX_NAME_SIZE + 11];
   struct create_topic_thread_arg *arg = (struct create_topic_thread_arg *) a;
   dds_entity_t *topics = ddsrt_malloc (arg->num_tp * sizeof (*topics));
 
@@ -163,7 +163,7 @@ static uint32_t topics_thread (void *a)
   tprintf ("%s topics thread: creating %u topics with prefix %s\n", arg->remote ? "remote" : "local", arg->num_tp, arg->topic_name_prefix);
   for (uint32_t t = 0; t < arg->num_tp; t++)
   {
-    set_topic_name (topic_name, arg->topic_name_prefix, t);
+    set_topic_name (topic_name, sizeof (topic_name), arg->topic_name_prefix, t);
     topics[t] = dds_create_topic (arg->pp, arg->topic_desc, topic_name, NULL, NULL);
     CU_ASSERT_FATAL (topics[t] > 0);
   }
@@ -240,7 +240,7 @@ CU_Theory ((uint32_t num_local_pp, uint32_t num_remote_pp, uint32_t num_tp), dds
     dds_typeinfo_t *type_info = get_desc_typeinfo (create_args[n].topic_desc);
     for (uint32_t t = 0; t < create_args[n].num_tp; t++)
     {
-      set_topic_name (topic_name, create_args[n].topic_name_prefix, t);
+      set_topic_name (topic_name, sizeof (topic_name), create_args[n].topic_name_prefix, t);
       dds_entity_t topic = dds_find_topic (DDS_FIND_SCOPE_GLOBAL, g_participant1, topic_name, (dds_typeinfo_t *) type_info, DDS_SECS (5));
       CU_ASSERT_FATAL (topic > 0);
     }
@@ -256,7 +256,7 @@ CU_Theory ((uint32_t num_local_pp, uint32_t num_remote_pp, uint32_t num_tp), dds
   uint32_t t = 0;
   do
   {
-    set_topic_name (topic_name, create_args->topic_name_prefix, t);
+    set_topic_name (topic_name, sizeof (topic_name), create_args->topic_name_prefix, t);
     (void) dds_find_topic (DDS_FIND_SCOPE_PARTICIPANT, g_participant1, topic_name, NULL, 0);
     (void) dds_find_topic (DDS_FIND_SCOPE_PARTICIPANT, g_participant1, topic_name, NULL, DDS_MSECS (1));
     (void) dds_find_topic (DDS_FIND_SCOPE_GLOBAL, g_participant1, topic_name, NULL, 0);


### PR DESCRIPTION
This is a backport of https://github.com/eclipse-cyclonedds/cyclonedds/pull/1291 to the releases/0.10.x branch, which is needed to fix warnings when building cyclonedds with gcc 13.2 on Ubuntu 24.04.

@eboasson FYI