### PR TITLE
Always make idlc_generate available in install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -343,6 +343,10 @@ install(
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
   COMPONENT dev
 )
+install(
+  FILES "${CycloneDDS_SOURCE_DIR}/cmake/Modules/Generate.cmake"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/idlc"
+  COMPONENT dev)
 
 # Generated file paths
 # although the following files are generated, they are checked into source

--- a/PackageConfig.cmake.in
+++ b/PackageConfig.cmake.in
@@ -12,6 +12,4 @@
 @PACKAGE_INIT@
 
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
-if(TARGET CycloneDDS::idlc)
-  include("${CMAKE_CURRENT_LIST_DIR}/idlc/Generate.cmake")
-endif()
+include("${CMAKE_CURRENT_LIST_DIR}/idlc/Generate.cmake")

--- a/src/tools/idlc/CMakeLists.txt
+++ b/src/tools/idlc/CMakeLists.txt
@@ -114,11 +114,6 @@ if (INSTALL_PDB)
   )
 endif()
 
-install(
-  FILES "${CycloneDDS_SOURCE_DIR}/cmake/Modules/Generate.cmake"
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/idlc"
-  COMPONENT dev)
-
 include("${CycloneDDS_SOURCE_DIR}/cmake/Modules/Generate.cmake")
 
 if(BUILD_TESTING)


### PR DESCRIPTION
With cross-builds, and now therefore also static builds, one does need IDLC.  Installing Generate.cmake unconditionally means one can always write

  idlc_generate(TARGET konijn FILES wortel.idl)

and one only has to make sure that CMake can find "idlc" and the backend library.  Adding the host build to the CMAKE_PREFIX_PATH as in:

  cmake -DCMAKE_PREFIX_PATH=.../target-install\;.../host-install

results in CMake finding the CycloneDDS package for the target in the target-install directory while also looking (and finding) idlc and the backend somewhere in the host-install directory.