### PR TITLE
Fix padding issue in authentication plugin

### DIFF
--- a/src/security/core/src/dds_security_serialize.c
+++ b/src/security/core/src/dds_security_serialize.c
@@ -250,7 +250,6 @@ DDS_Security_Serialize_string(
 
     memcpy(&(ser->buffer[ser->offset]), str, len);
     ser->offset += len;
-    serbuffer_align(ser, sizeof(uint32_t));
 }
 
 static void
@@ -553,8 +552,6 @@ DDS_Security_Deserialize_string(
 
     if (sz > 0 && (dser->cursor[sz-1] == 0)) {
        *value = ddsrt_strdup((char *)dser->cursor);
-       /* Consider padding */
-       sz = alignup_size(sz, sizeof(uint32_t));
        dser->cursor += sz;
        dser->remain -= sz;
     } else {
@@ -593,12 +590,10 @@ DDS_Security_Deserialize_OctetSeq(
     }
 
     if (seq->_length > 0) {
-        /* Consider padding */
-        size_t a_size = alignup_size(seq->_length, sizeof(uint32_t));
         seq->_buffer = ddsrt_malloc(seq->_length);
         memcpy(seq->_buffer, dser->cursor, seq->_length);
-        dser->cursor += a_size;
-        dser->remain -= a_size;
+        dser->cursor += seq->_length;
+        dser->remain -= seq->_length;
     } else {
         seq->_buffer = NULL;
     }
@@ -749,10 +744,13 @@ DDS_Security_Deserialize_ParticipantBuiltinTopicData(
         DDS_Security_Deserialize_align(dser, 4);
         r = DDS_Security_Deserialize_uint16(dser, &pid) &&
             DDS_Security_Deserialize_uint16(dser, &len);
-
-        if (r && (len <= dser->remain)) {
-            const unsigned char *next_cursor = dser->cursor + len;
-
+        if (!r) {
+            DDS_Security_Exception_set(ex, "Deserialization", DDS_SECURITY_ERR_UNDEFINED_CODE, DDS_SECURITY_VALIDATION_FAILED,
+                  "Deserialize parameter header failed");
+        } else if (len > dser->remain) {
+            DDS_Security_Exception_set(ex, "Deserialization", DDS_SECURITY_ERR_UNDEFINED_CODE, DDS_SECURITY_VALIDATION_FAILED,
+                  "Deserialize parameter failed: payload too long for buffer");
+        } else {
             switch (pid) {
             case PID_PARTICIPANT_GUID:
                 r = DDS_Security_Deserialize_BuiltinTopicKey(dser, pdata->key);
@@ -780,25 +778,12 @@ DDS_Security_Deserialize_ParticipantBuiltinTopicData(
                 dser->remain -= len;
                 break;
             }
-
-            if (r) {
-                if (dser->cursor != next_cursor) {
-                    DDS_Security_Exception_set(ex, "Deserialization", DDS_SECURITY_ERR_UNDEFINED_CODE, DDS_SECURITY_VALIDATION_FAILED,
-                            "Deserialize PID 0x%x failed: internal_size %d != external_size %d", pid, (int)len + (int)(dser->cursor - next_cursor), (int)len);
-                    r = 0;
-                }
-            } else {
+            if (!r) {
                 DDS_Security_Exception_set(ex, "Deserialization", DDS_SECURITY_ERR_UNDEFINED_CODE, DDS_SECURITY_VALIDATION_FAILED,
                         "Deserialize PID 0x%x failed: parsing failed", pid);
             }
-        } else {
-            if (!r) {
-                DDS_Security_Exception_set(ex, "Deserialization", DDS_SECURITY_ERR_UNDEFINED_CODE, DDS_SECURITY_VALIDATION_FAILED,
-                        "Deserialize parameter header failed");
-            }
         }
     } while (r && !ready && dser->remain > 0);
-
     return ready;
 }
 

--- a/src/security/core/tests/CMakeLists.txt
+++ b/src/security/core/tests/CMakeLists.txt
@@ -115,6 +115,7 @@ if(ENABLE_SSL AND OPENSSL_FOUND)
     "builtintopic.c"
     "config.c"
     "crypto.c"
+    "deserialize.c"
     "handshake.c"
     "plugin_loading.c"
     "secure_communication.c"

--- a/src/security/core/tests/deserialize.c
+++ b/src/security/core/tests/deserialize.c
@@ -1,0 +1,57 @@
+// Copyright(c) 2024 Robert Femmer
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#include "CUnit/CUnit.h"
+#include "CUnit/Test.h"
+
+#include "dds/security/core/dds_security_serialize.h"
+#include "dds/ddsrt/heap.h"
+
+CU_Test(dds_security_serialize, deserialize_octet_seq)
+{
+    unsigned char heapdata[] =
+    {
+        // transformation_kind (OctetArray) 4 bytes
+        0x0, 0x0, 0x0, 0x0,
+        // master_salt (OctetSeq)
+        // length of octet seq
+        0x0, 0x0, 0x0, 0x1,
+        // the octet sequence
+        0x0,
+        // This is all the data we attempt to deserialize
+        // Three padding bytes that the deserializer will skip
+        0x0, 0x0, 0x0,
+        // Suppose unknown heap memory starts here. This would be parsed into sender_key_id
+        0x0, 0x0, 0x0, 0x0,
+        // This would be the length of the next master_send_key.
+        0x0, 0x0, 0x0, 0x0,
+        // Next would be receiver_specific_key_id.
+        0x0, 0x0, 0x0, 0x0,
+        // master_receiver_specific_key OctetSeq. This could be any size up to 4GB, which will be allocated.
+        // Here, we allocate 16 bytes, which is longer than the 9 bytes we feed to the deserializer.
+        0x0, 0x0, 0x0, 0x10,
+        // the key
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
+    };
+
+    // Pass the pointer to the prepared buffer and claim that length is only 9 bytes.
+    DDS_Security_Deserializer dser = DDS_Security_Deserializer_new(heapdata, 9);
+    DDS_Security_KeyMaterial_AES_GCM_GMAC data;
+    int r = DDS_Security_Deserialize_KeyMaterial_AES_GCM_GMAC(dser, &data);
+    // This should fail, because 9 bytes is not enough to deserialize the key material
+    CU_ASSERT_EQUAL(r, 0);
+    // Specifically, master_receiver_specific_key._buffer should be NULL, because
+    // the octet sequence itself is longer than the serialized data according to dser->remain
+    CU_ASSERT_EQUAL(data.master_receiver_specific_key._buffer, NULL);
+
+    ddsrt_free(data.master_salt._buffer);
+    ddsrt_free(data.master_sender_key._buffer);
+    ddsrt_free(data.master_receiver_specific_key._buffer);
+    DDS_Security_Deserializer_free(dser);
+}


### PR DESCRIPTION
The discovery data is to be serialized as a parameter list, serialising each parameter in turn as a 4-byte aligned, 32-bit header followed by arbitrary payload, itself serialised according to the rules of the original CDR spec (i.e., XCDR1 in XTypes' Newspeak) as-if that payload starts at offset 0.  There is never any padding other than that required by these rules.

The code for handling strings and octet sequences used by the authentication plugin got this wrong by (inconsistently) padding out strings and octet sequences to the next multiple of 4.  In the deserialization this also interferes with the bounds checking.

In principle this can lead to a failure to read/write well-formed discovery data.  In practice, the types happen to be such that that padding always ends up being present because of the next field.