### PR TITLE
Backport to 0.10.x: multicast+iceoryx, dump malformed packets, port 0 in SEDP

### DIFF
--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -1774,7 +1774,7 @@ The default value is: "false".
 
 #### //CycloneDDS/Domain/Tracing/Category
 One of:
-* Comma-separated list of: fatal, error, warning, info, config, discovery, data, radmin, timing, traffic, topic, tcp, plist, whc, throttle, rhc, content, shm, trace
+* Comma-separated list of: fatal, error, warning, info, config, discovery, data, radmin, timing, traffic, topic, tcp, plist, whc, throttle, rhc, content, shm, malformed, trace
 * Or empty
 
 This element enables individual logging categories. These are enabled in addition to those enabled by Tracing/Verbosity. Recognised categories are:
@@ -1799,7 +1799,11 @@ This element enables individual logging categories. These are enabled in additio
 
  * traffic: periodic reporting of total outgoing data
 
+ * throttle: tracing of throttling events
+
  * whc: tracing of writer history cache changes
+
+ * rhc: tracing of reader history cache changes
 
  * tcp: tracing of TCP-specific activity
 
@@ -1807,7 +1811,14 @@ This element enables individual logging categories. These are enabled in additio
 
  * plist: tracing of discovery parameter list interpretation
 
-In addition, there is the keyword trace that enables all but radmin, topic, plist and whc.
+ * content: tracing of sample contents
+
+ * shm: tracing of Iceoryx integration
+
+ * malformed: dump malformed full packet as warning
+
+
+In addition, there is the keyword trace that enables: fatal, error, warning, info, config, discovery, data, trace, timing, traffic, tcp, throttle, content..
 The categorisation of tracing output is incomplete and hence most of the verbosity levels and categories are not of much use in the current release. This is an ongoing process and here we describe the target situation rather than the current situation. Currently, the most useful is trace.
 
 The default value is: "".
@@ -1856,8 +1867,8 @@ The categorisation of tracing output is incomplete and hence most of the verbosi
 The default value is: "none".
 <!--- generated from ddsi_config.h[87da706bc9c463a87326e87b311d8291d5761d43] -->
 <!--- generated from ddsi_cfgunits.h[fc550f1620aa20dcd9244ef4e24299d5001efbb4] -->
-<!--- generated from ddsi_cfgelems.h[a294ec068e0de39ae662e4709f6ed3226a2412f2] -->
-<!--- generated from ddsi_config.c[960218b9e3e9e0137b8a44c21006b5d75e4c9513] -->
+<!--- generated from ddsi_cfgelems.h[779636e47ae3db4f970aae732353db6d7ba9583f] -->
+<!--- generated from ddsi_config.c[f1481cfdb01fe1010eabd34a879d5aa2c2262bec] -->
 <!--- generated from _confgen.h[01ffa8a2e53b2309451756861466551cfe28c8ce] -->
 <!--- generated from _confgen.c[13cd40932d695abae1470202a42c18dc4d09ea84] -->
 <!--- generated from generate_rnc.c[a2ec6e48d33ac14a320c8ec3f320028a737920e0] -->

--- a/etc/cyclonedds.rnc
+++ b/etc/cyclonedds.rnc
@@ -1242,15 +1242,21 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==<br>
 <li><i>radmin</i>: receive buffer administration</li>
 <li><i>timing</i>: periodic reporting of CPU loads per thread</li>
 <li><i>traffic</i>: periodic reporting of total outgoing data</li>
+<li><i>throttle</i>: tracing of throttling events</li>
 <li><i>whc</i>: tracing of writer history cache changes</li>
+<li><i>rhc</i>: tracing of reader history cache changes</li>
 <li><i>tcp</i>: tracing of TCP-specific activity</li>
 <li><i>topic</i>: tracing of topic definitions</li>
-<li><i>plist</i>: tracing of discovery parameter list interpretation</li></ul>
-<p>In addition, there is the keyword <i>trace</i> that enables all but <i>radmin</i>, <i>topic</i>, <i>plist</i> and <i>whc</i></p>.
+<li><i>plist</i>: tracing of discovery parameter list interpretation</li>
+<li><i>content</i>: tracing of sample contents</li>
+<li><i>shm</i>: tracing of Iceoryx integration</li>
+<li><i>malformed</i>: dump malformed full packet as warning</li>
+</ul>
+<p>In addition, there is the keyword <i>trace</i> that enables: <i>fatal</i>, <i>error</i>, <i>warning</i>, <i>info</i>, <i>config</i>, <i>discovery</i>, <i>data</i>, <i>trace</i>, <i>timing</i>, <i>traffic</i>, <i>tcp</i>, <i>throttle</i>, <i>content</i>.</p>.
 <p>The categorisation of tracing output is incomplete and hence most of the verbosity levels and categories are not of much use in the current release. This is an ongoing process and here we describe the target situation rather than the current situation. Currently, the most useful is <i>trace</i>.</p>
 <p>The default value is: "".</p>""" ] ]
         element Category {
-          xsd:token { pattern = "((fatal|error|warning|info|config|discovery|data|radmin|timing|traffic|topic|tcp|plist|whc|throttle|rhc|content|shm|trace)(,(fatal|error|warning|info|config|discovery|data|radmin|timing|traffic|topic|tcp|plist|whc|throttle|rhc|content|shm|trace))*)|" }
+          xsd:token { pattern = "((fatal|error|warning|info|config|discovery|data|radmin|timing|traffic|topic|tcp|plist|whc|throttle|rhc|content|shm|malformed|trace)(,(fatal|error|warning|info|config|discovery|data|radmin|timing|traffic|topic|tcp|plist|whc|throttle|rhc|content|shm|malformed|trace))*)|" }
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This option specifies where the logging is printed to. Note that <i>stdout</i> and <i>stderr</i> are treated as special values, representing "standard out" and "standard error" respectively. No file is created unless logging categories are enabled using the Tracing/Verbosity or Tracing/EnabledCategory settings.</p>
@@ -1290,8 +1296,8 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==<br>
 }
 # generated from ddsi_config.h[87da706bc9c463a87326e87b311d8291d5761d43] 
 # generated from ddsi_cfgunits.h[fc550f1620aa20dcd9244ef4e24299d5001efbb4] 
-# generated from ddsi_cfgelems.h[a294ec068e0de39ae662e4709f6ed3226a2412f2] 
-# generated from ddsi_config.c[960218b9e3e9e0137b8a44c21006b5d75e4c9513] 
+# generated from ddsi_cfgelems.h[779636e47ae3db4f970aae732353db6d7ba9583f] 
+# generated from ddsi_config.c[f1481cfdb01fe1010eabd34a879d5aa2c2262bec] 
 # generated from _confgen.h[01ffa8a2e53b2309451756861466551cfe28c8ce] 
 # generated from _confgen.c[13cd40932d695abae1470202a42c18dc4d09ea84] 
 # generated from generate_rnc.c[a2ec6e48d33ac14a320c8ec3f320028a737920e0] 

--- a/etc/cyclonedds.xsd
+++ b/etc/cyclonedds.xsd
@@ -1880,17 +1880,23 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
 &lt;li&gt;&lt;i&gt;radmin&lt;/i&gt;: receive buffer administration&lt;/li&gt;
 &lt;li&gt;&lt;i&gt;timing&lt;/i&gt;: periodic reporting of CPU loads per thread&lt;/li&gt;
 &lt;li&gt;&lt;i&gt;traffic&lt;/i&gt;: periodic reporting of total outgoing data&lt;/li&gt;
+&lt;li&gt;&lt;i&gt;throttle&lt;/i&gt;: tracing of throttling events&lt;/li&gt;
 &lt;li&gt;&lt;i&gt;whc&lt;/i&gt;: tracing of writer history cache changes&lt;/li&gt;
+&lt;li&gt;&lt;i&gt;rhc&lt;/i&gt;: tracing of reader history cache changes&lt;/li&gt;
 &lt;li&gt;&lt;i&gt;tcp&lt;/i&gt;: tracing of TCP-specific activity&lt;/li&gt;
 &lt;li&gt;&lt;i&gt;topic&lt;/i&gt;: tracing of topic definitions&lt;/li&gt;
-&lt;li&gt;&lt;i&gt;plist&lt;/i&gt;: tracing of discovery parameter list interpretation&lt;/li&gt;&lt;/ul&gt;
-&lt;p&gt;In addition, there is the keyword &lt;i&gt;trace&lt;/i&gt; that enables all but &lt;i&gt;radmin&lt;/i&gt;, &lt;i&gt;topic&lt;/i&gt;, &lt;i&gt;plist&lt;/i&gt; and &lt;i&gt;whc&lt;/i&gt;&lt;/p&gt;.
+&lt;li&gt;&lt;i&gt;plist&lt;/i&gt;: tracing of discovery parameter list interpretation&lt;/li&gt;
+&lt;li&gt;&lt;i&gt;content&lt;/i&gt;: tracing of sample contents&lt;/li&gt;
+&lt;li&gt;&lt;i&gt;shm&lt;/i&gt;: tracing of Iceoryx integration&lt;/li&gt;
+&lt;li&gt;&lt;i&gt;malformed&lt;/i&gt;: dump malformed full packet as warning&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;In addition, there is the keyword &lt;i&gt;trace&lt;/i&gt; that enables: &lt;i&gt;fatal&lt;/i&gt;, &lt;i&gt;error&lt;/i&gt;, &lt;i&gt;warning&lt;/i&gt;, &lt;i&gt;info&lt;/i&gt;, &lt;i&gt;config&lt;/i&gt;, &lt;i&gt;discovery&lt;/i&gt;, &lt;i&gt;data&lt;/i&gt;, &lt;i&gt;trace&lt;/i&gt;, &lt;i&gt;timing&lt;/i&gt;, &lt;i&gt;traffic&lt;/i&gt;, &lt;i&gt;tcp&lt;/i&gt;, &lt;i&gt;throttle&lt;/i&gt;, &lt;i&gt;content&lt;/i&gt;.&lt;/p&gt;.
 &lt;p&gt;The categorisation of tracing output is incomplete and hence most of the verbosity levels and categories are not of much use in the current release. This is an ongoing process and here we describe the target situation rather than the current situation. Currently, the most useful is &lt;i&gt;trace&lt;/i&gt;.&lt;/p&gt;
 &lt;p&gt;The default value is: "".&lt;/p&gt;</xs:documentation>
     </xs:annotation>
     <xs:simpleType>
       <xs:restriction base="xs:token">
-        <xs:pattern value="((fatal|error|warning|info|config|discovery|data|radmin|timing|traffic|topic|tcp|plist|whc|throttle|rhc|content|shm|trace)(,(fatal|error|warning|info|config|discovery|data|radmin|timing|traffic|topic|tcp|plist|whc|throttle|rhc|content|shm|trace))*)|"/>
+        <xs:pattern value="((fatal|error|warning|info|config|discovery|data|radmin|timing|traffic|topic|tcp|plist|whc|throttle|rhc|content|shm|malformed|trace)(,(fatal|error|warning|info|config|discovery|data|radmin|timing|traffic|topic|tcp|plist|whc|throttle|rhc|content|shm|malformed|trace))*)|"/>
       </xs:restriction>
     </xs:simpleType>
   </xs:element>
@@ -1960,8 +1966,8 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
 </xs:schema>
 <!--- generated from ddsi_config.h[87da706bc9c463a87326e87b311d8291d5761d43] -->
 <!--- generated from ddsi_cfgunits.h[fc550f1620aa20dcd9244ef4e24299d5001efbb4] -->
-<!--- generated from ddsi_cfgelems.h[a294ec068e0de39ae662e4709f6ed3226a2412f2] -->
-<!--- generated from ddsi_config.c[960218b9e3e9e0137b8a44c21006b5d75e4c9513] -->
+<!--- generated from ddsi_cfgelems.h[779636e47ae3db4f970aae732353db6d7ba9583f] -->
+<!--- generated from ddsi_config.c[f1481cfdb01fe1010eabd34a879d5aa2c2262bec] -->
 <!--- generated from _confgen.h[01ffa8a2e53b2309451756861466551cfe28c8ce] -->
 <!--- generated from _confgen.c[13cd40932d695abae1470202a42c18dc4d09ea84] -->
 <!--- generated from generate_rnc.c[a2ec6e48d33ac14a320c8ec3f320028a737920e0] -->

--- a/src/core/ddsi/defconfig.c
+++ b/src/core/ddsi/defconfig.c
@@ -106,8 +106,8 @@ void ddsi_config_init_default (struct ddsi_config *cfg)
 }
 /* generated from ddsi_config.h[87da706bc9c463a87326e87b311d8291d5761d43] */
 /* generated from ddsi_cfgunits.h[fc550f1620aa20dcd9244ef4e24299d5001efbb4] */
-/* generated from ddsi_cfgelems.h[a294ec068e0de39ae662e4709f6ed3226a2412f2] */
-/* generated from ddsi_config.c[960218b9e3e9e0137b8a44c21006b5d75e4c9513] */
+/* generated from ddsi_cfgelems.h[779636e47ae3db4f970aae732353db6d7ba9583f] */
+/* generated from ddsi_config.c[f1481cfdb01fe1010eabd34a879d5aa2c2262bec] */
 /* generated from _confgen.h[01ffa8a2e53b2309451756861466551cfe28c8ce] */
 /* generated from _confgen.c[13cd40932d695abae1470202a42c18dc4d09ea84] */
 /* generated from generate_rnc.c[a2ec6e48d33ac14a320c8ec3f320028a737920e0] */

--- a/src/core/ddsi/include/dds/ddsi/ddsi_cfgelems.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_cfgelems.h
@@ -1985,13 +1985,20 @@ static struct cfgelem tracing_cfgelems[] = {
       "<li><i>radmin</i>: receive buffer administration</li>\n"
       "<li><i>timing</i>: periodic reporting of CPU loads per thread</li>\n"
       "<li><i>traffic</i>: periodic reporting of total outgoing data</li>\n"
+      "<li><i>throttle</i>: tracing of throttling events</li>\n"
       "<li><i>whc</i>: tracing of writer history cache changes</li>\n"
+      "<li><i>rhc</i>: tracing of reader history cache changes</li>\n"
       "<li><i>tcp</i>: tracing of TCP-specific activity</li>\n"
       "<li><i>topic</i>: tracing of topic definitions</li>\n"
-      "<li><i>plist</i>: tracing of discovery parameter list interpretation</li>"
+      "<li><i>plist</i>: tracing of discovery parameter list interpretation</li>\n"
+      "<li><i>content</i>: tracing of sample contents</li>\n"
+      "<li><i>shm</i>: tracing of Iceoryx integration</li>\n"
+      "<li><i>malformed</i>: dump malformed full packet as warning</li>\n"
       "</ul>\n"
-      "<p>In addition, there is the keyword <i>trace</i> that enables all "
-      "but <i>radmin</i>, <i>topic</i>, <i>plist</i> and <i>whc</i></p>.\n"
+      "<p>In addition, there is the keyword <i>trace</i> that enables: "
+      "<i>fatal</i>, <i>error</i>, <i>warning</i>, <i>info</i>, <i>config</i>, "
+      "<i>discovery</i>, <i>data</i>, <i>trace</i>, <i>timing</i>, <i>traffic</i>, "
+      "<i>tcp</i>, <i>throttle</i>, <i>content</i>.</p>.\n"
       "<p>The categorisation of tracing output is incomplete and hence most "
       "of the verbosity levels and categories are not of much use in the "
       "current release. This is an ongoing process and here we describe the "
@@ -2000,7 +2007,7 @@ static struct cfgelem tracing_cfgelems[] = {
     VALUES(
       "fatal","error","warning","info","config","discovery","data","radmin",
       "timing","traffic","topic","tcp","plist","whc","throttle","rhc",
-      "content","shm","trace"
+      "content","shm","malformed","trace"
     )),
   ENUM("Verbosity", NULL, 1, "none",
     NOMEMBER,

--- a/src/core/ddsi/src/ddsi_config.c
+++ b/src/core/ddsi/src/ddsi_config.c
@@ -1008,10 +1008,10 @@ GENERIC_ENUM_CTYPE (shm_loglevel, enum ddsi_shm_loglevel)
 
 /* "trace" is special: it enables (nearly) everything */
 static const char *tracemask_names[] = {
-  "fatal", "error", "warning", "info", "config", "discovery", "data", "radmin", "timing", "traffic", "topic", "tcp", "plist", "whc", "throttle", "rhc", "content", "shm", "trace", NULL
+  "fatal", "error", "warning", "info", "config", "discovery", "data", "radmin", "timing", "traffic", "topic", "tcp", "plist", "whc", "throttle", "rhc", "content", "shm", "malformed", "trace", NULL
 };
 static const uint32_t tracemask_codes[] = {
-  DDS_LC_FATAL, DDS_LC_ERROR, DDS_LC_WARNING, DDS_LC_INFO, DDS_LC_CONFIG, DDS_LC_DISCOVERY, DDS_LC_DATA, DDS_LC_RADMIN, DDS_LC_TIMING, DDS_LC_TRAFFIC, DDS_LC_TOPIC, DDS_LC_TCP, DDS_LC_PLIST, DDS_LC_WHC, DDS_LC_THROTTLE, DDS_LC_RHC, DDS_LC_CONTENT, DDS_LC_SHM, DDS_LC_ALL
+  DDS_LC_FATAL, DDS_LC_ERROR, DDS_LC_WARNING, DDS_LC_INFO, DDS_LC_CONFIG, DDS_LC_DISCOVERY, DDS_LC_DATA, DDS_LC_RADMIN, DDS_LC_TIMING, DDS_LC_TRAFFIC, DDS_LC_TOPIC, DDS_LC_TCP, DDS_LC_PLIST, DDS_LC_WHC, DDS_LC_THROTTLE, DDS_LC_RHC, DDS_LC_CONTENT, DDS_LC_SHM, DDS_LC_MALFORMED, DDS_LC_ALL
 };
 
 static enum update_result uf_tracemask (struct cfgst *cfgst, UNUSED_ARG (void *parent), UNUSED_ARG (struct cfgelem const * const cfgelem), UNUSED_ARG (int first), const char *value)

--- a/src/core/ddsi/src/ddsi_wraddrset.c
+++ b/src/core/ddsi/src/ddsi_wraddrset.c
@@ -303,10 +303,8 @@ static struct locset *wras_calc_locators (const struct ddsrt_log_cfg *logcfg, st
 static const int32_t cost_discarded = 1;
 
 // Cost associated with delivering another time to a reader that has
-// already been covered by a (selected) Iceoryx locator.  Currently,
-// it is quite painful when this happens because it can lead to user
-// observable stuttering
-static const int32_t cost_redundant_iceoryx = 1000000;
+// already been covered by a (selected) Iceoryx locator.
+static const int32_t cost_redundant_iceoryx = 0;
 
 // Cost associated with delivering data for the first time (slightly
 // negative cost makes it possible to give a slightly higher initial

--- a/src/core/ddsi/src/q_receive.c
+++ b/src/core/ddsi/src/q_receive.c
@@ -2801,7 +2801,7 @@ static const char *submsg_name (SubmessageKind_t id, struct submsg_name *buffer)
   return buffer->x;
 }
 
-static void malformed_packet_received (const struct ddsi_domaingv *gv, const unsigned char *msg, const unsigned char *submsg, size_t len, nn_vendorid_t vendorid)
+static void malformed_packet_received_shortmsg (const struct ddsi_domaingv *gv, const unsigned char *msg, const unsigned char *submsg, size_t len, nn_vendorid_t vendorid)
 {
   char tmp[1024];
   size_t i, pos, smsize;
@@ -2810,7 +2810,10 @@ static void malformed_packet_received (const struct ddsi_domaingv *gv, const uns
   SubmessageKind_t smkind;
   const char *state0;
   const char *state1;
-  if (submsg == NULL || (submsg < msg || submsg >= msg + len)) {
+  // can safely subtract the two pointers after casting to uintptr_t, on all practical platforms
+  // this'll just give us a useful offset as long as submsg isn't a null pointer
+  const intptr_t offset = (intptr_t) ((uintptr_t) submsg - (uintptr_t) msg);
+  if (submsg == NULL || (submsg < msg || submsg > msg + len)) {
     // outside buffer shouldn't happen, but this is for dealing with junk, so better be careful
     smkind = SMID_PAD;
     state0 = "";
@@ -2826,15 +2829,16 @@ static void malformed_packet_received (const struct ddsi_domaingv *gv, const uns
     state1 = submsg_name (smkind, &submsg_name_buffer);
   }
   assert (submsg >= msg && submsg <= msg + len);
+  const size_t clamped_offset = (offset < 0) ? 0 : ((size_t) offset > len) ? len : (size_t) offset;
 
   /* Show beginning of message and of submessage (as hex dumps) */
-  pos = (size_t) snprintf (tmp, sizeof (tmp), "malformed packet received from vendor %u.%u state %s%s <", vendorid.id[0], vendorid.id[1], state0, state1);
-  for (i = 0; i < 32 && i < len && msg + i < submsg && pos < sizeof (tmp); i++)
+  pos = (size_t) snprintf (tmp, sizeof (tmp), "malformed packet received from vendor %u.%u length %" PRIuSIZE " state %s%s <", vendorid.id[0], vendorid.id[1], len, state0, state1);
+  for (i = 0; i < 32 && i < len && i < clamped_offset && pos < sizeof (tmp); i++)
     pos += (size_t) snprintf (tmp + pos, sizeof (tmp) - pos, "%s%02x", (i > 0 && (i%4) == 0) ? " " : "", msg[i]);
   if (pos < sizeof (tmp))
-    pos += (size_t) snprintf (tmp + pos, sizeof (tmp) - pos, " @0x%x ", (int) (submsg - msg));
-  for (i = 0; i < 64 && i < len - (size_t) (submsg - msg) && pos < sizeof (tmp); i++)
-    pos += (size_t) snprintf (tmp + pos, sizeof (tmp) - pos, "%s%02x", (i > 0 && (i%4) == 0) ? " " : "", submsg[i]);
+    pos += (size_t) snprintf (tmp + pos, sizeof (tmp) - pos, " @%" PRIdPTR " ", offset);
+  for (i = 0; i < 64 && i < len - clamped_offset && pos < sizeof (tmp); i++)
+    pos += (size_t) snprintf (tmp + pos, sizeof (tmp) - pos, "%s%02x", (i > 0 && (i%4) == 0) ? " " : "", msg[clamped_offset + i]);
   if (pos < sizeof (tmp))
     pos += (size_t) snprintf (tmp + pos, sizeof (tmp) - pos, "> (note: maybe partially bswap'd)");
   assert (pos < (int) sizeof (tmp));
@@ -2908,6 +2912,44 @@ static void malformed_packet_received (const struct ddsi_domaingv *gv, const uns
     }
   }
   GVWARNING ("%s\n", tmp);
+}
+
+static void malformed_packet_received_fulldump (const struct ddsi_domaingv *gv, const unsigned char *msg, const unsigned char *submsg, size_t len, nn_vendorid_t vendorid, uint32_t logmask)
+{
+  GVLOG (logmask, "malformed packet: vendor %u.%u msg %p submsg %p length %" PRIuSIZE " contents:\n", vendorid.id[0], vendorid.id[1], (void *) msg, (void *) submsg, len);
+  for (size_t off16 = 0; off16 < len; off16 += 16)
+  {
+    GVLOG (logmask, "%c%04" PRIxSIZE " ", (msg + off16 <= submsg && (size_t) (submsg - (msg + off16)) < 16) ? '*' : ' ', off16);
+    char sep = ' ';
+    size_t off1;
+    for (off1 = 0; off1 < 16 && off16 + off1 < len; off1++) {
+      if (msg + off16 + off1 == submsg)
+        sep = '[';
+      else if (sep == '[')
+        sep = ']';
+      else
+        sep =' ';
+      GVLOG (logmask, "%s%c%02x", (off1 == 8) ? " " : "", sep, msg[off16 + off1]);
+    }
+    for (; off1 < 16; off1++) {
+      GVLOG (logmask, "%s%c  ", (off1 == 8) ? " " : "", (sep == '[') ? ']' : sep);
+      sep = ' ';
+    }
+    GVLOG (logmask, "  |");
+    for (off1 = 0; off1 < 16 && off16 + off1 < len; off1++) {
+      GVLOG (logmask, "%c", isprint (msg[off16 + off1]) ? msg[off16 + off1] : '.');
+    }
+    GVLOG (logmask, "|\n");
+  }
+}
+
+static void malformed_packet_received (const struct ddsi_domaingv *gv, const unsigned char *msg, const unsigned char *submsg, size_t len, nn_vendorid_t vendorid)
+{
+  malformed_packet_received_shortmsg (gv, msg, submsg, len, vendorid);
+  if (gv->logconfig.c.mask & DDS_LC_MALFORMED)
+    malformed_packet_received_fulldump (gv, msg, submsg, len, vendorid, DDS_LC_WARNING);
+  else // dump it if we're writing a trace file, no matter the tracing options
+    malformed_packet_received_fulldump (gv, msg, submsg, len, vendorid, DDS_TRACE_MASK);
 }
 
 static struct receiver_state *rst_cow_if_needed (int *rst_live, struct nn_rmsg *rmsg, struct receiver_state *rst)

--- a/src/ddsrt/include/dds/ddsrt/log.h
+++ b/src/ddsrt/include/dds/ddsrt/log.h
@@ -79,6 +79,8 @@ extern "C" {
 #define DDS_LC_CONTENT (131072u)
 /** Debug/trace messages related to SHMEM */
 #define DDS_LC_SHM (262144u)
+/** Output full dump of malformed messages as warnings */
+#define DDS_LC_MALFORMED (524288u)
 /** All common trace categories. */
 #define DDS_LC_ALL \
     (DDS_LC_FATAL | DDS_LC_ERROR | DDS_LC_WARNING | DDS_LC_INFO | \


### PR DESCRIPTION
* A fix for advertising port 0 in endpoint discovery data if unicast addresses are used in network partitions in combination with ParticipantIndex "none". This is only known to be a problem if trying to coax 0.10.x into publishing some topics on a specific network interface. (Master is much nicer for this.)
* Writing a full a dump of a malformed packet to the trace, and optionally to stderr. The "mini dump" that it has always provided too often only offers a hint but is missing the detail one really needs.
* Allows multipathing between Iceoryx and the network, which really means it allows use of multicast if there are some readers reachable via Iceoryx and multiple not reachable via Iceoryx. Like the commit message says, the reason it was disabled has long since been fixed.

@clalancette I think it makes sense to include them in a 0.10.5 tag and I'm pretty sure these will work fine for you as well, but given that none of them are strictly necessary I thought it be worth checking with you first. Meanwhile I am trying to get `master` in a state where I can tag it as a pre-release and allow ROS 2 to finally leave 0.10.x behind. Two more details to go for that (aging of participant discovery addresses and a race condition in the way master sets up Iceoryx).