### PR TITLE
Initialize the ret variable to fix compiler warnings.

### DIFF
--- a/src/core/ddsi/src/ddsi_raweth.c
+++ b/src/core/ddsi/src/ddsi_raweth.c
@@ -218,7 +218,7 @@ static ssize_t ddsi_raweth_conn_write (struct ddsi_tran_conn * conn, const ddsi_
 {
   ddsi_raweth_conn_t uc = (ddsi_raweth_conn_t) conn;
   dds_return_t rc;
-  ssize_t ret;
+  ssize_t ret = -1;
   unsigned retry = 2;
   int sendflags = 0;
   struct msghdr msg;
@@ -507,7 +507,7 @@ static ssize_t ddsi_raweth_conn_write (struct ddsi_tran_conn * conn, const ddsi_
 {
   ddsi_raweth_conn_t uc = (ddsi_raweth_conn_t) conn;
   dds_return_t rc = DDS_RETCODE_OK;
-  ssize_t ret;
+  ssize_t ret = -1;
   struct ddsi_vlan_header vhdr;
   size_t hdrlen;
   (void) flags;


### PR DESCRIPTION
This is a simple fix to a compiler warning we found with Clang. Please review. Thanks. 