### PR TITLE
Removed clang warnings

### DIFF
--- a/src/core/ddsc/tests/deadline.c
+++ b/src/core/ddsc/tests/deadline.c
@@ -384,6 +384,7 @@ CU_Theory((int32_t n_inst, uint8_t unreg_nth, uint8_t dispose_nth), ddsc_deadlin
     /* FIXME: should unregistered instances cause deadline expirations? I do think so
        and that is what it actually implemented
        if they shouldn't: n_alive = n_inst - n_dispose - n_unreg */
+    (void) n_unreg;
     n_alive = n_inst - n_dispose;
 
     /* Sleep deadline_dur + 50% and check missed deadline count */

--- a/src/core/ddsc/tests/domain_torture.c
+++ b/src/core/ddsc/tests/domain_torture.c
@@ -53,7 +53,7 @@ static uint32_t create_participants_thread (void *varg)
 }
 
 
-static void participant_creation_torture()
+static void participant_creation_torture(void)
 {
   dds_return_t rc;
   ddsrt_thread_t tids[N_THREADS];

--- a/src/core/ddsi/include/dds/ddsi/ddsi_security_omg.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_security_omg.h
@@ -336,8 +336,8 @@ bool q_omg_get_writer_security_info(const struct ddsi_writer *wr, nn_security_in
  * @param[in] wr Writer to determine the publication writer from.
  *
  * @returns unsigned
- * @retval NN_ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER
- * @retval NN_ENTITYID_SEDP_BUILTIN_PUBLICATIONS_WRITER
+ * @retval NN_ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER \emptydescription
+ * @retval NN_ENTITYID_SEDP_BUILTIN_PUBLICATIONS_WRITER \emptydescription
  */
 unsigned determine_publication_writer(const struct ddsi_writer *wr);
 
@@ -407,8 +407,8 @@ bool q_omg_get_reader_security_info(const struct ddsi_reader *rd, nn_security_in
  * @param[in] rd Reader to determine the subscription writer from.
  *
  * @returns unsigned
- * @retval NN_ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER
- * @retval NN_ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_WRITER
+ * @retval NN_ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER \emptydescription
+ * @retval NN_ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_WRITER \emptydescription
  */
 unsigned determine_subscription_writer(const struct ddsi_reader *rd);
 
@@ -422,7 +422,7 @@ unsigned determine_subscription_writer(const struct ddsi_reader *rd);
  * @param[in] tp Topic to determine the writer from.
  *
  * @returns unsigned
- * @retval NN_ENTITYID_SEDP_BUILTIN_TOPIC_WRITER
+ * @retval NN_ENTITYID_SEDP_BUILTIN_TOPIC_WRITER \emptydescription
  */
 unsigned determine_topic_writer(const struct ddsi_topic *tp);
 #endif /* DDS_HAS_TOPIC_DISCOVERY */

--- a/src/core/ddsi/src/q_thread.c
+++ b/src/core/ddsi/src/q_thread.c
@@ -284,7 +284,7 @@ static struct thread_state *grow_thread_states (void)
   return &x->thrst[0];
 }
 
-static struct thread_state *get_available_thread_slot ()
+static struct thread_state *get_available_thread_slot (void)
 {
   struct thread_states_list *cur;
   uint32_t i;

--- a/src/core/xtests/rhc_torture/rhc_torture.c
+++ b/src/core/xtests/rhc_torture/rhc_torture.c
@@ -111,7 +111,7 @@ static struct ddsi_serdata *mkkeysample (int32_t keyval, unsigned statusinfo)
 }
 
 #if defined(DDS_HAS_LIFESPAN) || defined (DDS_HAS_DEADLINE_MISSED)
-static ddsrt_mtime_t rand_texp ()
+static ddsrt_mtime_t rand_texp (void)
 {
   ddsrt_mtime_t ret = ddsrt_time_monotonic();
   ret.v -= DDS_MSECS(500) + (int64_t) (ddsrt_prng_random (&prng) % DDS_MSECS(1500));
@@ -120,7 +120,7 @@ static ddsrt_mtime_t rand_texp ()
 #endif
 
 #ifdef DDS_HAS_DEADLINE_MISSED
-static dds_duration_t rand_deadline ()
+static dds_duration_t rand_deadline (void)
 {
   return (dds_duration_t) (ddsrt_prng_random (&prng) % DDS_MSECS(500));
 }

--- a/src/ddsrt/tests/thread_cleanup.c
+++ b/src/ddsrt/tests/thread_cleanup.c
@@ -85,6 +85,7 @@ thread_main(
   void *arg)
 {
   int pushed = 0;
+  (void) pushed;
   int popped = 0;
   int execute = 0;
   struct thread_argument *targ = (struct thread_argument *)arg;

--- a/src/security/builtin_plugins/tests/register_matched_remote_datareader/src/register_matched_remote_datareader_utests.c
+++ b/src/security/builtin_plugins/tests/register_matched_remote_datareader/src/register_matched_remote_datareader_utests.c
@@ -60,7 +60,7 @@ static void prepare_endpoint_security_attributes(DDS_Security_EndpointSecurityAt
   attributes->plugin_endpoint_attributes |= DDS_SECURITY_PLUGIN_ENDPOINT_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ENCRYPTED;
 }
 
-static void register_local_regular()
+static void register_local_regular(void)
 {
   DDS_Security_SecurityException exception = {NULL, 0, 0};
   DDS_Security_PropertySeq datawriter_properties;

--- a/src/security/builtin_plugins/tests/register_matched_remote_datawriter/src/register_matched_remote_datawriter_utests.c
+++ b/src/security/builtin_plugins/tests/register_matched_remote_datawriter/src/register_matched_remote_datawriter_utests.c
@@ -60,7 +60,7 @@ static void prepare_endpoint_security_attributes(DDS_Security_EndpointSecurityAt
   attributes->plugin_endpoint_attributes |= DDS_SECURITY_PLUGIN_ENDPOINT_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ENCRYPTED;
 }
 
-static void register_local_regular()
+static void register_local_regular(void)
 {
   DDS_Security_SecurityException exception = {NULL, 0, 0};
   DDS_Security_PropertySeq datareader_properties;

--- a/src/security/core/tests/common/authentication_wrapper.c
+++ b/src/security/core/tests/common/authentication_wrapper.c
@@ -462,7 +462,7 @@ void test_authentication_plugin_release_msg(struct message *msg)
   delete_message(msg);
 }
 
-static struct dds_security_authentication_impl * init_test_authentication_common()
+static struct dds_security_authentication_impl * init_test_authentication_common(void)
 {
   struct dds_security_authentication_impl * impl = ddsrt_malloc(sizeof(*impl));
   memset(impl, 0, sizeof(*impl));

--- a/src/security/core/tests/config.c
+++ b/src/security/core/tests/config.c
@@ -113,7 +113,7 @@ static void set_logger_exp(const void * log_expected, const char * _extract_line
   dds_set_trace_sink(&logger, (void*)log_expected);
 }
 
-static void reset_logger()
+static void reset_logger(void)
 {
   dds_set_log_sink(NULL, NULL);
   dds_set_trace_sink(NULL, NULL);

--- a/src/security/core/tests/plugin_loading.c
+++ b/src/security/core/tests/plugin_loading.c
@@ -51,7 +51,7 @@ static void set_logger_exp(const void *log_expected)
   dds_set_trace_sink(&logger, (void *)log_expected);
 }
 
-static void reset_logger()
+static void reset_logger(void)
 {
   dds_set_log_sink(NULL, NULL);
   dds_set_trace_sink(NULL, NULL);

--- a/src/security/core/tests/secure_communication.c
+++ b/src/security/core/tests/secure_communication.c
@@ -106,7 +106,7 @@ const char * g_pp_secret = "ppsecret";
 const char * g_groupdata_secret = "groupsecret";
 const char * g_ep_secret = "epsecret";
 
-static dds_qos_t *get_qos()
+static dds_qos_t *get_qos(void)
 {
   dds_qos_t * qos = dds_create_qos ();
   CU_ASSERT_FATAL (qos != NULL);

--- a/src/tools/ddsperf/ddsperf.c
+++ b/src/tools/ddsperf/ddsperf.c
@@ -622,7 +622,6 @@ static uint32_t pubthread (void *varg)
   dds_instance_handle_t *ihs;
   dds_time_t ntot = 0, tfirst;
   union data data;
-  uint64_t timeouts = 0;
   void *baggage = NULL;
   (void) varg;
 
@@ -672,7 +671,6 @@ static uint32_t pubthread (void *varg)
       fflush (stdout);
       if (result != DDS_RETCODE_TIMEOUT)
         exit (2);
-      timeouts++;
       /* retry with original timestamp, it really is just a way of reporting
          blocking for an exceedingly long time, but do force a fresh time stamp
          for the next sample */


### PR DESCRIPTION
There are some clang warnings on CI nightly builds https://ci.ros2.org/view/nightly/job/nightly_linux_clang_libcxx/1869/clang-tidy/new/ . This PR should remove them