### PR TITLE
B64 sysdef  `_data`

### DIFF
--- a/src/core/ddsc/src/dds__sysdef_parser.h
+++ b/src/core/ddsc/src/dds__sysdef_parser.h
@@ -10,8 +10,8 @@
 #ifndef DDS_SYSDEF_PARSER_H
 #define DDS_SYSDEF_PARSER_H
 
-#include "dds/dds.h"
 #include "dds/ddsrt/log.h"
+#include "dds/ddsrt/retcode.h"
 
 #if defined (__cplusplus)
 extern "C" {

--- a/src/core/ddsc/src/dds_sysdef_parser.c
+++ b/src/core/ddsc/src/dds_sysdef_parser.c
@@ -1435,18 +1435,26 @@ static int proc_elem_close (void *varg, UNUSED_ARG (uintptr_t eleminfo), UNUSED_
       case ELEMENT_KIND_QOS_POLICY_DURABILITY:
         ELEM_CLOSE_QOS_POLICY(DURABILITY, "Durability");
         break;
-      case ELEMENT_KIND_QOS_POLICY_DURABILITYSERVICE:
+      case ELEMENT_KIND_QOS_POLICY_DURABILITYSERVICE: {
+        struct dds_sysdef_QOS_POLICY_DURABILITYSERVICE *tmp_qp = (struct dds_sysdef_QOS_POLICY_DURABILITYSERVICE *) pstate->current;
+        if ((tmp_qp->populated & QOS_POLICY_DURABILITYSERVICE_PARAM_HISTORY_KIND) && tmp_qp->values.history.kind == DDS_HISTORY_KEEP_ALL)
+          tmp_qp->populated |= QOS_POLICY_DURABILITYSERVICE_PARAM_HISTORY_DEPTH;
         ELEM_CLOSE_QOS_POLICY(DURABILITYSERVICE, "Durability Service");
         break;
+      }
       case ELEMENT_KIND_QOS_POLICY_DURABILITYSERVICE_SERVICE_CLEANUP_DELAY:
         ELEM_CLOSE_QOS_DURATION_PROPERTY(DURABILITYSERVICE, SERVICE_CLEANUP_DELAY, service_cleanup_delay);
         break;
       case ELEMENT_KIND_QOS_POLICY_GROUPDATA:
         ELEM_CLOSE_QOS_POLICY(GROUPDATA, "Group Data");
         break;
-      case ELEMENT_KIND_QOS_POLICY_HISTORY:
+      case ELEMENT_KIND_QOS_POLICY_HISTORY: {
+        struct dds_sysdef_QOS_POLICY_HISTORY *tmp_qp = (struct dds_sysdef_QOS_POLICY_HISTORY *) pstate->current;
+        if ((tmp_qp->populated & QOS_POLICY_HISTORY_PARAM_KIND) && tmp_qp->values.kind == DDS_HISTORY_KEEP_ALL)
+          tmp_qp->populated |= QOS_POLICY_HISTORY_PARAM_DEPTH;
         ELEM_CLOSE_QOS_POLICY(HISTORY, "History");
         break;
+      }
       case ELEMENT_KIND_QOS_POLICY_LATENCYBUDGET:
         ELEM_CLOSE_QOS_POLICY(LATENCYBUDGET, "Latency Budget");
         break;
@@ -1990,9 +1998,10 @@ static int proc_elem_data (void *varg, UNUSED_ARG (uintptr_t eleminfo), const ch
     case ELEMENT_KIND_QOS_POLICY_DURABILITYSERVICE_HISTORY_KIND:
       QOS_PARAM_DATA (DURABILITYSERVICE, HISTORY_KIND);
       break;
-    case ELEMENT_KIND_QOS_POLICY_DURABILITYSERVICE_HISTORY_DEPTH:
+    case ELEMENT_KIND_QOS_POLICY_DURABILITYSERVICE_HISTORY_DEPTH:{
       QOS_PARAM_DATA (DURABILITYSERVICE, HISTORY_DEPTH);
       break;
+    }
     case ELEMENT_KIND_QOS_POLICY_DURABILITYSERVICE_RESOURCE_LIMIT_MAX_SAMPLES:
       QOS_PARAM_DATA (DURABILITYSERVICE, RESOURCE_LIMIT_MAX_SAMPLES);
       break;
@@ -2011,9 +2020,10 @@ static int proc_elem_data (void *varg, UNUSED_ARG (uintptr_t eleminfo), const ch
     case ELEMENT_KIND_QOS_POLICY_HISTORY_KIND:
       QOS_PARAM_DATA (HISTORY, KIND);
       break;
-    case ELEMENT_KIND_QOS_POLICY_HISTORY_DEPTH:
+    case ELEMENT_KIND_QOS_POLICY_HISTORY_DEPTH: {
       QOS_PARAM_DATA (HISTORY, DEPTH);
       break;
+    }
     case ELEMENT_KIND_QOS_POLICY_LIVELINESS_KIND:
       QOS_PARAM_DATA (LIVELINESS, KIND);
       break;

--- a/src/core/ddsc/src/dds_sysdef_validation.c
+++ b/src/core/ddsc/src/dds_sysdef_validation.c
@@ -47,15 +47,6 @@ static int is_wildcard_partition (const char *str)
 
 static dds_return_t validate_qos (dds_qos_t *qos, const char *qos_location)
 {
-  // History
-  dds_history_kind_t history_kind;
-  int32_t history_depth;
-  if (dds_qget_history (qos, &history_kind, &history_depth) && (history_kind != DDS_HISTORY_KEEP_LAST || history_depth < 0))
-  {
-    SYSDEF_ERROR ("Unsupported history kind or depth (%s)\n", qos_location);
-    goto failed;
-  }
-
   // Partition
   uint32_t n_partitions;
   char **partitions;


### PR DESCRIPTION
According to DDS-XML spec. `group/user/topic_data` `<value>` element should be presented in `Base64` format.
With this PR:
- decode b64 format data from xml configuration to dds_octetseq value before set.
- update qos_provider test to encode tested qos `group/user/topic_data` before form xml-string.
- remove wrong validation of history_kind.

> [!WARNING]
> cxx binding qos_provider related tests will fail, and will be fixed by [#PR488](https://github.com/eclipse-cyclonedds/cyclonedds-cxx/pull/488).