### PR TITLE
Export additional symbols that are required by the Iceoryx PSMX plugin.

### DIFF
--- a/src/core/xtests/symbol_export/symbol_export.c
+++ b/src/core/xtests/symbol_export/symbol_export.c
@@ -36,6 +36,7 @@
 #include "dds/ddsrt/strtol.h"
 #include "dds/ddsrt/xmlparser.h"
 #include "dds/ddsrt/io.h"
+#include "dds/ddsrt/ifaddrs.h"
 #if DDSRT_HAVE_FILESYSTEM
 #include "dds/ddsrt/filesystem.h"
 #endif
@@ -1068,6 +1069,10 @@ int main (int argc, char **argv)
   // ddsrt/io.h
   test_ddsrt_vasprintf (ptr, " ");
   ddsrt_asprintf (ptr, " ");
+
+  // ddsrt/ifaddrs.h
+  ddsrt_getifaddrs (ptr, ptr);
+  ddsrt_freeifaddrs (ptr);
 
   // dds__write.h
   dds_write_impl (ptr, ptr, 0, (dds_write_action) 0);

--- a/src/ddsrt/include/dds/ddsrt/ifaddrs.h
+++ b/src/ddsrt/include/dds/ddsrt/ifaddrs.h
@@ -58,7 +58,7 @@ typedef struct ddsrt_ifaddrs ddsrt_ifaddrs_t;
  * @param[in] afs an array of address families
  * @return a DDS_RETCODE (OK, ERROR, OUT_OF_RESOURCES, NOT_ALLOWED)
  */
-dds_return_t
+DDS_EXPORT dds_return_t
 ddsrt_getifaddrs(
   ddsrt_ifaddrs_t **ifap,
   const int *afs);
@@ -68,7 +68,7 @@ ddsrt_getifaddrs(
  * 
  * @param[in] ifa the interface addresses to free
  */
-void
+DDS_EXPORT void
 ddsrt_freeifaddrs(
   ddsrt_ifaddrs_t *ifa);
 


### PR DESCRIPTION
This PR exports the ddsrt_getifaddrs and ddsrt_freeifaddrs symbols that are required by the Iceoryx PSMX plugin.