### PR TITLE
Add missing ddsrt_mutex_lock in gcreq_queue_step

### DIFF
--- a/src/core/ddsi/src/ddsi_gc.c
+++ b/src/core/ddsi/src/ddsi_gc.c
@@ -112,7 +112,8 @@ bool ddsi_gcreq_queue_step (struct ddsi_gcreq_queue *q)
     {
       /* Give up immediately instead of waiting: this exists to make less-threaded
          (test/fuzzing) code possible.  (I don't think this case can occur in a single
-         threaded process, but it might if a some threads exist.) */
+         threaded process, but it might if some threads exist.) */
+      ddsrt_mutex_lock (&q->lock);
       break;
     }
     else


### PR DESCRIPTION
This fixes unlocked access and unlocking a non-locked mutex when the current head of the GC queue is to be postponed.

Note that the "step" function is currently only used in a fuzzer and that this case cannot occur in a single-threaded processes.