### PR TITLE
Fix Zephyr ipv4 multicast join/leave support

### DIFF
--- a/src/ddsrt/include/dds/ddsrt/sockets/posix.h
+++ b/src/ddsrt/include/dds/ddsrt/sockets/posix.h
@@ -65,11 +65,6 @@ typedef struct ddsrt_socket_ext {
 # define IP_MULTICAST_TTL   33
 # define IP_MULTICAST_LOOP  34
 
-struct ip_mreq {
-    struct in_addr imr_multiaddr;
-    struct in_addr imr_interface;
-};
-
 /* for ddsrt_getifaddrs */
 # define IFF_UP              0x1
 # define IFF_BROADCAST       0x2


### PR DESCRIPTION
Since i neglected to remove the now deprecated `struct ip_mreq` workaround for Zephyr in my last PR #1988, it went unnoticed that Zephyr's POSIX implementation (or should i say interpretation?) demands the use of `ip_mreqn` without a fall-back to `ip_mreq` as supported by almost any other OS out there.