### PR TITLE
Add flag to disable participant and endpoint discovery

### DIFF
--- a/docs/manual/config/config_file_reference.rst
+++ b/docs/manual/config/config_file_reference.rst
@@ -2591,7 +2591,7 @@ The default value is: ``false``
 ------------------------------------
 
 One of:
-* Comma-separated list of: fatal, error, warning, info, config, discovery, data, radmin, timing, traffic, topic, tcp, plist, whc, throttle, rhc, content, malformed, trace
+* Comma-separated list of: fatal, error, warning, info, config, discovery, data, radmin, timing, traffic, topic, tcp, plist, whc, throttle, rhc, content, malformed, trace, user, user1, user2, user3
 * Or empty
 
 This element enables individual logging categories. These are enabled in addition to those enabled by Tracing/Verbosity. Recognised categories are:
@@ -2631,6 +2631,14 @@ This element enables individual logging categories. These are enabled in additio
  * content: tracing of sample contents
 
  * malformed: dump malformed full packet as warning
+
+ * user: all user-defined tracing categories
+
+ * user1: user-defined tracing category 1
+
+ * user2: user-defined tracing category 2
+
+ * user3: user-defined tracing category 3
 
 
 
@@ -2698,8 +2706,8 @@ The default value is: ``none``
 ..
    generated from ddsi_config.h[007a7968df8cbc42a122109bd139ac85bab0f6c9] 
    generated from ddsi__cfgunits.h[bd22f0c0ed210501d0ecd3b07c992eca549ef5aa] 
-   generated from ddsi__cfgelems.h[607a8f573eb5d87d6f93b1d9bce2947f29da56dc] 
-   generated from ddsi_config.c[d4ef67f90737b1bf8ae94ad932774fa015e3a2cf] 
+   generated from ddsi__cfgelems.h[194217161977869610495a7889bbc1e6bc976ce1] 
+   generated from ddsi_config.c[8c7ad90526d135063496f4a55e4e5992fa7bc72a] 
    generated from _confgen.h[e32eabfc35e9f3a7dcb63b19ed148c0d17c6e5fc] 
    generated from _confgen.c[237308acd53897a34e8c643e16e05a61d73ffd65] 
    generated from generate_rnc.c[b50e4b7ab1d04b2bc1d361a0811247c337b74934] 

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -1801,7 +1801,7 @@ The default value is: `false`
 
 #### //CycloneDDS/Domain/Tracing/Category
 One of:
-* Comma-separated list of: fatal, error, warning, info, config, discovery, data, radmin, timing, traffic, topic, tcp, plist, whc, throttle, rhc, content, malformed, trace
+* Comma-separated list of: fatal, error, warning, info, config, discovery, data, radmin, timing, traffic, topic, tcp, plist, whc, throttle, rhc, content, malformed, trace, user, user1, user2, user3
 * Or empty
 
 This element enables individual logging categories. These are enabled in addition to those enabled by Tracing/Verbosity. Recognised categories are:
@@ -1841,6 +1841,14 @@ This element enables individual logging categories. These are enabled in additio
  * content: tracing of sample contents
 
  * malformed: dump malformed full packet as warning
+
+ * user: all user-defined tracing categories
+
+ * user1: user-defined tracing category 1
+
+ * user2: user-defined tracing category 2
+
+ * user3: user-defined tracing category 3
 
 
 In addition, there is the keyword trace that enables: fatal, error, warning, info, config, discovery, data, trace, timing, traffic, tcp, throttle, content..
@@ -1892,8 +1900,8 @@ The categorisation of tracing output is incomplete and hence most of the verbosi
 The default value is: `none`
 <!--- generated from ddsi_config.h[007a7968df8cbc42a122109bd139ac85bab0f6c9] -->
 <!--- generated from ddsi__cfgunits.h[bd22f0c0ed210501d0ecd3b07c992eca549ef5aa] -->
-<!--- generated from ddsi__cfgelems.h[607a8f573eb5d87d6f93b1d9bce2947f29da56dc] -->
-<!--- generated from ddsi_config.c[d4ef67f90737b1bf8ae94ad932774fa015e3a2cf] -->
+<!--- generated from ddsi__cfgelems.h[194217161977869610495a7889bbc1e6bc976ce1] -->
+<!--- generated from ddsi_config.c[8c7ad90526d135063496f4a55e4e5992fa7bc72a] -->
 <!--- generated from _confgen.h[e32eabfc35e9f3a7dcb63b19ed148c0d17c6e5fc] -->
 <!--- generated from _confgen.c[237308acd53897a34e8c643e16e05a61d73ffd65] -->
 <!--- generated from generate_rnc.c[b50e4b7ab1d04b2bc1d361a0811247c337b74934] -->

--- a/etc/cyclonedds.rnc
+++ b/etc/cyclonedds.rnc
@@ -1266,12 +1266,16 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==<br>
 <li><i>plist</i>: tracing of discovery parameter list interpretation</li>
 <li><i>content</i>: tracing of sample contents</li>
 <li><i>malformed</i>: dump malformed full packet as warning</li>
+<li><i>user</i>: all user-defined tracing categories</li>
+<li><i>user1</i>: user-defined tracing category 1</li>
+<li><i>user2</i>: user-defined tracing category 2</li>
+<li><i>user3</i>: user-defined tracing category 3</li>
 </ul>
 <p>In addition, there is the keyword <i>trace</i> that enables: <i>fatal</i>, <i>error</i>, <i>warning</i>, <i>info</i>, <i>config</i>, <i>discovery</i>, <i>data</i>, <i>trace</i>, <i>timing</i>, <i>traffic</i>, <i>tcp</i>, <i>throttle</i>, <i>content</i>.</p>.
 <p>The categorisation of tracing output is incomplete and hence most of the verbosity levels and categories are not of much use in the current release. This is an ongoing process and here we describe the target situation rather than the current situation. Currently, the most useful is <i>trace</i>.</p>
 <p>The default value is: <code>&lt;empty&gt;</code></p>""" ] ]
         element Category {
-          xsd:token { pattern = "((fatal|error|warning|info|config|discovery|data|radmin|timing|traffic|topic|tcp|plist|whc|throttle|rhc|content|malformed|trace)(,(fatal|error|warning|info|config|discovery|data|radmin|timing|traffic|topic|tcp|plist|whc|throttle|rhc|content|malformed|trace))*)|" }
+          xsd:token { pattern = "((fatal|error|warning|info|config|discovery|data|radmin|timing|traffic|topic|tcp|plist|whc|throttle|rhc|content|malformed|trace|user|user1|user2|user3)(,(fatal|error|warning|info|config|discovery|data|radmin|timing|traffic|topic|tcp|plist|whc|throttle|rhc|content|malformed|trace|user|user1|user2|user3))*)|" }
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>This option specifies where the logging is printed to. Note that <i>stdout</i> and <i>stderr</i> are treated as special values, representing "standard out" and "standard error" respectively. No file is created unless logging categories are enabled using the Tracing/Verbosity or Tracing/EnabledCategory settings.</p>
@@ -1311,8 +1315,8 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==<br>
 }
 # generated from ddsi_config.h[007a7968df8cbc42a122109bd139ac85bab0f6c9] 
 # generated from ddsi__cfgunits.h[bd22f0c0ed210501d0ecd3b07c992eca549ef5aa] 
-# generated from ddsi__cfgelems.h[607a8f573eb5d87d6f93b1d9bce2947f29da56dc] 
-# generated from ddsi_config.c[d4ef67f90737b1bf8ae94ad932774fa015e3a2cf] 
+# generated from ddsi__cfgelems.h[194217161977869610495a7889bbc1e6bc976ce1] 
+# generated from ddsi_config.c[8c7ad90526d135063496f4a55e4e5992fa7bc72a] 
 # generated from _confgen.h[e32eabfc35e9f3a7dcb63b19ed148c0d17c6e5fc] 
 # generated from _confgen.c[237308acd53897a34e8c643e16e05a61d73ffd65] 
 # generated from generate_rnc.c[b50e4b7ab1d04b2bc1d361a0811247c337b74934] 

--- a/etc/cyclonedds.xsd
+++ b/etc/cyclonedds.xsd
@@ -1892,6 +1892,10 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
 &lt;li&gt;&lt;i&gt;plist&lt;/i&gt;: tracing of discovery parameter list interpretation&lt;/li&gt;
 &lt;li&gt;&lt;i&gt;content&lt;/i&gt;: tracing of sample contents&lt;/li&gt;
 &lt;li&gt;&lt;i&gt;malformed&lt;/i&gt;: dump malformed full packet as warning&lt;/li&gt;
+&lt;li&gt;&lt;i&gt;user&lt;/i&gt;: all user-defined tracing categories&lt;/li&gt;
+&lt;li&gt;&lt;i&gt;user1&lt;/i&gt;: user-defined tracing category 1&lt;/li&gt;
+&lt;li&gt;&lt;i&gt;user2&lt;/i&gt;: user-defined tracing category 2&lt;/li&gt;
+&lt;li&gt;&lt;i&gt;user3&lt;/i&gt;: user-defined tracing category 3&lt;/li&gt;
 &lt;/ul&gt;
 &lt;p&gt;In addition, there is the keyword &lt;i&gt;trace&lt;/i&gt; that enables: &lt;i&gt;fatal&lt;/i&gt;, &lt;i&gt;error&lt;/i&gt;, &lt;i&gt;warning&lt;/i&gt;, &lt;i&gt;info&lt;/i&gt;, &lt;i&gt;config&lt;/i&gt;, &lt;i&gt;discovery&lt;/i&gt;, &lt;i&gt;data&lt;/i&gt;, &lt;i&gt;trace&lt;/i&gt;, &lt;i&gt;timing&lt;/i&gt;, &lt;i&gt;traffic&lt;/i&gt;, &lt;i&gt;tcp&lt;/i&gt;, &lt;i&gt;throttle&lt;/i&gt;, &lt;i&gt;content&lt;/i&gt;.&lt;/p&gt;.
 &lt;p&gt;The categorisation of tracing output is incomplete and hence most of the verbosity levels and categories are not of much use in the current release. This is an ongoing process and here we describe the target situation rather than the current situation. Currently, the most useful is &lt;i&gt;trace&lt;/i&gt;.&lt;/p&gt;
@@ -1899,7 +1903,7 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
     </xs:annotation>
     <xs:simpleType>
       <xs:restriction base="xs:token">
-        <xs:pattern value="((fatal|error|warning|info|config|discovery|data|radmin|timing|traffic|topic|tcp|plist|whc|throttle|rhc|content|malformed|trace)(,(fatal|error|warning|info|config|discovery|data|radmin|timing|traffic|topic|tcp|plist|whc|throttle|rhc|content|malformed|trace))*)|"/>
+        <xs:pattern value="((fatal|error|warning|info|config|discovery|data|radmin|timing|traffic|topic|tcp|plist|whc|throttle|rhc|content|malformed|trace|user|user1|user2|user3)(,(fatal|error|warning|info|config|discovery|data|radmin|timing|traffic|topic|tcp|plist|whc|throttle|rhc|content|malformed|trace|user|user1|user2|user3))*)|"/>
       </xs:restriction>
     </xs:simpleType>
   </xs:element>
@@ -1969,8 +1973,8 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
 </xs:schema>
 <!--- generated from ddsi_config.h[007a7968df8cbc42a122109bd139ac85bab0f6c9] -->
 <!--- generated from ddsi__cfgunits.h[bd22f0c0ed210501d0ecd3b07c992eca549ef5aa] -->
-<!--- generated from ddsi__cfgelems.h[607a8f573eb5d87d6f93b1d9bce2947f29da56dc] -->
-<!--- generated from ddsi_config.c[d4ef67f90737b1bf8ae94ad932774fa015e3a2cf] -->
+<!--- generated from ddsi__cfgelems.h[194217161977869610495a7889bbc1e6bc976ce1] -->
+<!--- generated from ddsi_config.c[8c7ad90526d135063496f4a55e4e5992fa7bc72a] -->
 <!--- generated from _confgen.h[e32eabfc35e9f3a7dcb63b19ed148c0d17c6e5fc] -->
 <!--- generated from _confgen.c[237308acd53897a34e8c643e16e05a61d73ffd65] -->
 <!--- generated from generate_rnc.c[b50e4b7ab1d04b2bc1d361a0811247c337b74934] -->

--- a/src/core/ddsc/include/dds/ddsc/dds_internal_api.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_internal_api.h
@@ -22,6 +22,10 @@
 extern "C" {
 #endif
 
+// Magic numbers match the set of internal flags we want to use but do not want to expose in the API.
+// The implementation contains static assert to ensure this is kept in sync.
+#define DDS_PARTICIPANT_FLAGS_NO_DISCOVERY (1u | 2u | 32u)
+
 /**
  * @ingroup internal
  * @component topic

--- a/src/core/ddsc/include/dds/ddsc/dds_internal_api.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_internal_api.h
@@ -52,6 +52,39 @@ dds_cdrstream_desc_from_topic_desc (struct dds_cdrstream_desc *desc, const dds_t
 DDS_EXPORT dds_entity_t
 dds_create_participant_guid (const dds_domainid_t domain, const dds_qos_t *qos, const dds_listener_t *listener, uint32_t flags, const dds_guid_t *guid);
 
+/**
+ * @ingroup internal
+ * @component writer
+ * @unstable
+ * @brief Create a writer with the specified GUID
+ *
+ * @param[in]  participant_or_publisher The participant or publisher on which the writer is being created.
+ * @param[in]  topic The topic to write.
+ * @param[in]  qos The QoS to set on the new writer (can be NULL).
+ * @param[in]  listener Any listener functions associated with the new writer (can be NULL).
+ * @param[in]  guid The GUID for the new writer
+ *
+ * @returns A valid writer handle or an error code. @see dds_create_writer for details
+ */
+DDS_EXPORT dds_entity_t
+dds_create_writer_guid (dds_entity_t participant_or_publisher, dds_entity_t topic, const dds_qos_t *qos, const dds_listener_t *listener, dds_guid_t *guid);
+
+/**
+ * @ingroup internal
+ * @component reader
+ * @unstable
+ * @brief Create a reader with the specified GUID
+ *
+ * @param[in]  participant_or_subscriber The participant or subscriber on which the reader is being created.
+ * @param[in]  topic The topic to read.
+ * @param[in]  qos The QoS to set on the new reader (can be NULL).
+ * @param[in]  listener Any listener functions associated with the new reader (can be NULL).
+ * @param[in]  guid The GUID for the new reader
+ *
+ * @returns A valid reader handle or an error code. @see dds_create_reader for details
+ */
+DDS_EXPORT dds_entity_t
+dds_create_reader_guid (dds_entity_t participant_or_subscriber, dds_entity_t topic, const dds_qos_t *qos, const dds_listener_t *listener, dds_guid_t *guid);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsc/include/dds/ddsc/dds_internal_api.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_internal_api.h
@@ -15,6 +15,7 @@
 #define DDS_INTERNAL_API_H
 
 #include "dds/export.h"
+#include "dds/dds.h"
 #include "dds/cdr/dds_cdrstream.h"
 
 #if defined (__cplusplus)
@@ -33,6 +34,24 @@ extern "C" {
 */
 DDS_EXPORT void
 dds_cdrstream_desc_from_topic_desc (struct dds_cdrstream_desc *desc, const dds_topic_descriptor_t *topic_desc);
+
+/**
+ * @ingroup internal
+ * @component participant
+ * @unstable
+ * @brief Create a participant with the specified GUID
+ *
+ * @param[in]  domain The domain in which to create the participant (can be DDS_DOMAIN_DEFAULT). DDS_DOMAIN_DEFAULT is for using the domain in the configuration.
+ * @param[in]  qos The QoS to set on the new participant (can be NULL).
+ * @param[in]  listener Any listener functions associated with the new participant (can be NULL).
+ * @param[in]  flags The flags to be used when creating the participant
+ * @param[in]  guid The GUID for the new participant
+ *
+ * @returns A valid participant handle or an error code. @see dds_create_participant for details
+ */
+DDS_EXPORT dds_entity_t
+dds_create_participant_guid (const dds_domainid_t domain, const dds_qos_t *qos, const dds_listener_t *listener, uint32_t flags, const dds_guid_t *guid);
+
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsc/include/dds/ddsc/dds_loaned_sample.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_loaned_sample.h
@@ -133,6 +133,30 @@ DDS_INLINE_EXPORT inline void ddsrt_nonnull_all dds_loaned_sample_unref (dds_loa
 DDS_EXPORT dds_return_t dds_reader_store_loaned_sample (dds_entity_t reader, dds_loaned_sample_t *data)
   ddsrt_nonnull_all;
 
+/**
+ * @brief insert data from a loaned sample into the reader history cache using the provided writer meta-data
+ * @ingroup reading
+ *
+ * @param[in] reader The reader entity.
+ * @param[in] data Pointer to the loaned sample of the entity received
+ * @param[in] ownership_strength The ownership strength of the writer
+ * @param[in] autodispose_unregistered_instances Writer setting for auto-disposing unregistered entities
+ * @param[in] lifespan_duration Lifespan duration value configured for the writer
+ *
+ * @returns A dds_return_t indicating success or failure.
+ *
+ * @retval DDS_RETCODE_OK
+ *             The operation was successful.
+ * @retval DDS_RETCODE_BAD_PARAMETER
+ *             One or more parameters are invalid.
+ * @retval DDS_RETCODE_ILLEGAL_OPERATION
+ *             The operation is invoked on an inappropriate object.
+ * @retval DDS_RETCODE_ALREADY_DELETED
+ *             The reader entity has already been deleted.
+ */
+DDS_EXPORT dds_return_t dds_reader_store_loaned_sample_wr_metadata (dds_entity_t reader, dds_loaned_sample_t *data, int32_t ownership_strength, bool autodispose_unregistered_instances, dds_duration_t lifespan_duration)
+  ddsrt_nonnull_all;
+
 #if defined(__cplusplus)
 }
 #endif

--- a/src/core/ddsc/src/dds__entity.h
+++ b/src/core/ddsc/src/dds__entity.h
@@ -192,7 +192,7 @@ enum delete_impl_state {
 dds_return_t dds_delete_impl_pinned (dds_entity *e, enum delete_impl_state delstate);
 
 /** @component generic_entity */
-dds_return_t dds_entity_pin (dds_entity_t hdl, dds_entity **eptr);
+DDS_EXPORT dds_return_t dds_entity_pin (dds_entity_t hdl, dds_entity **eptr);
 
 /** @component generic_entity */
 dds_return_t dds_entity_pin_with_origin (dds_entity_t hdl, bool from_user, dds_entity **eptr);
@@ -201,7 +201,7 @@ dds_return_t dds_entity_pin_with_origin (dds_entity_t hdl, bool from_user, dds_e
 dds_return_t dds_entity_pin_for_delete (dds_entity_t hdl, bool explicit, bool from_user, dds_entity **eptr);
 
 /** @component generic_entity */
-void dds_entity_unpin (dds_entity *e);
+DDS_EXPORT void dds_entity_unpin (dds_entity *e);
 
 /** @component generic_entity */
 dds_return_t dds_entity_lock (dds_entity_t hdl, dds_entity_kind_t kind, dds_entity **eptr);

--- a/src/core/ddsc/src/dds__entity.h
+++ b/src/core/ddsc/src/dds__entity.h
@@ -204,10 +204,10 @@ dds_return_t dds_entity_pin_for_delete (dds_entity_t hdl, bool explicit, bool fr
 DDS_EXPORT void dds_entity_unpin (dds_entity *e);
 
 /** @component generic_entity */
-dds_return_t dds_entity_lock (dds_entity_t hdl, dds_entity_kind_t kind, dds_entity **eptr);
+DDS_EXPORT dds_return_t dds_entity_lock (dds_entity_t hdl, dds_entity_kind_t kind, dds_entity **eptr);
 
 /** @component generic_entity */
-void dds_entity_unlock (dds_entity *e);
+DDS_EXPORT void dds_entity_unlock (dds_entity *e);
 
 /** @component generic_entity */
 dds_return_t dds_entity_observer_register (

--- a/src/core/ddsc/src/dds_participant.c
+++ b/src/core/ddsc/src/dds_participant.c
@@ -183,6 +183,8 @@ err_dds_init:
   return ret;
 }
 
+DDSRT_STATIC_ASSERT (DDS_PARTICIPANT_FLAGS_NO_DISCOVERY == (RTPS_PF_NO_BUILTIN_READERS | RTPS_PF_NO_BUILTIN_WRITERS | RTPS_PF_NO_PRIVILEGED_PP));
+
 dds_entity_t dds_create_participant_guid (const dds_domainid_t domain, const dds_qos_t *qos, const dds_listener_t *listener, uint32_t flags, const dds_guid_t *guid)
 {
   return create_participant_flags_guid (domain, qos, listener, flags, guid);

--- a/src/core/ddsc/src/dds_participant.c
+++ b/src/core/ddsc/src/dds_participant.c
@@ -20,6 +20,7 @@
 #include "dds/ddsi/ddsi_plist.h"
 #include "dds/ddsi/ddsi_domaingv.h"
 #include "dds/ddsi/ddsi_entity_index.h"
+#include "dds/ddsc/dds_internal_api.h"
 #include "dds/version.h"
 #include "dds__init.h"
 #include "dds__domain.h"

--- a/src/core/ddsc/tests/liveliness.c
+++ b/src/core/ddsc/tests/liveliness.c
@@ -83,8 +83,9 @@ static ddsi_seqno_t get_pmd_seqno(dds_entity_t participant)
   CU_ASSERT_EQUAL_FATAL(dds_entity_pin(participant, &pp_entity), 0);
   ddsi_thread_state_awake(ddsi_lookup_thread_state(), &pp_entity->m_domain->gv);
   pp = ddsi_entidx_lookup_participant_guid(pp_entity->m_domain->gv.entity_index, &pp_entity->m_guid);
-  wr = ddsi_get_builtin_writer (pp, DDSI_ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_WRITER);
+  dds_return_t ret = ddsi_get_builtin_writer (pp, DDSI_ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_WRITER, &wr);
   CU_ASSERT_FATAL(wr != NULL);
+  CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
   seqno = wr->seq;
   ddsi_thread_state_asleep(ddsi_lookup_thread_state());
   dds_entity_unpin(pp_entity);

--- a/src/core/ddsc/tests/xtypes_common.c
+++ b/src/core/ddsc/tests/xtypes_common.c
@@ -75,10 +75,11 @@ void test_proxy_rd_create (struct ddsi_domaingv *gv, const char *topic_name, DDS
   CU_ASSERT_FATAL (rc);
 
   ddsi_xqos_mergein_missing (&plist->qos, &ddsi_default_qos_reader, ~(uint64_t)0);
+  struct ddsi_proxy_reader *proxy_reader;
 #ifdef DDS_HAS_SSM
-  rc = ddsi_new_proxy_reader (gv, pp_guid, rd_guid, as, plist, ddsrt_time_wallclock (), 1, 0);
+  rc = ddsi_new_proxy_reader (&proxy_reader, gv, pp_guid, rd_guid, as, plist, ddsrt_time_wallclock (), 1, 0);
 #else
-  rc = ddsi_new_proxy_reader (gv, pp_guid, rd_guid, as, plist, ddsrt_time_wallclock (), 1);
+  rc = ddsi_new_proxy_reader (&proxy_reader, gv, pp_guid, rd_guid, as, plist, ddsrt_time_wallclock (), 1);
 #endif
   CU_ASSERT_EQUAL_FATAL (rc, exp_ret);
   ddsi_plist_fini (plist);

--- a/src/core/ddsc/tests/xtypes_common.c
+++ b/src/core/ddsc/tests/xtypes_common.c
@@ -71,7 +71,8 @@ void test_proxy_rd_create (struct ddsi_domaingv *gv, const char *topic_name, DDS
   struct ddsi_addrset *as = ddsi_new_addrset ();
   ddsi_add_locator_to_addrset (gv, as, &gv->loc_default_uc);
   ddsi_ref_addrset (as); // increase refc to 2, new_proxy_participant does not add a ref
-  int rc = ddsi_new_proxy_participant (gv, pp_guid, 0, NULL, as, as, plist, DDS_INFINITY, DDSI_VENDORID_ECLIPSE, 0, ddsrt_time_wallclock (), 1);
+  struct ddsi_proxy_participant *proxy_participant;
+  int rc = ddsi_new_proxy_participant (&proxy_participant, gv, pp_guid, 0, NULL, as, as, plist, DDS_INFINITY, DDSI_VENDORID_ECLIPSE, 0, ddsrt_time_wallclock (), 1);
   CU_ASSERT_FATAL (rc);
 
   ddsi_xqos_mergein_missing (&plist->qos, &ddsi_default_qos_reader, ~(uint64_t)0);

--- a/src/core/ddsi/defconfig.c
+++ b/src/core/ddsi/defconfig.c
@@ -101,8 +101,8 @@ void ddsi_config_init_default (struct ddsi_config *cfg)
 }
 /* generated from ddsi_config.h[007a7968df8cbc42a122109bd139ac85bab0f6c9] */
 /* generated from ddsi__cfgunits.h[bd22f0c0ed210501d0ecd3b07c992eca549ef5aa] */
-/* generated from ddsi__cfgelems.h[607a8f573eb5d87d6f93b1d9bce2947f29da56dc] */
-/* generated from ddsi_config.c[d4ef67f90737b1bf8ae94ad932774fa015e3a2cf] */
+/* generated from ddsi__cfgelems.h[194217161977869610495a7889bbc1e6bc976ce1] */
+/* generated from ddsi_config.c[8c7ad90526d135063496f4a55e4e5992fa7bc72a] */
 /* generated from _confgen.h[e32eabfc35e9f3a7dcb63b19ed148c0d17c6e5fc] */
 /* generated from _confgen.c[237308acd53897a34e8c643e16e05a61d73ffd65] */
 /* generated from generate_rnc.c[b50e4b7ab1d04b2bc1d361a0811247c337b74934] */

--- a/src/core/ddsi/include/dds/ddsi/ddsi_addrset.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_addrset.h
@@ -21,6 +21,7 @@ extern "C" {
 #endif
 
 struct ddsi_addrset;
+struct ddsi_domaingv;
 
 typedef void (*ddsi_addrset_forall_fun_t) (const ddsi_xlocator_t *loc, void *arg);
 
@@ -31,6 +32,21 @@ bool ddsi_addrset_empty (const struct ddsi_addrset *as)
 /** @component locators */
 void ddsi_addrset_forall (struct ddsi_addrset *as, ddsi_addrset_forall_fun_t f, void *arg)
   ddsrt_nonnull ((1,2));
+
+/** @component locators */
+DDS_EXPORT struct ddsi_addrset *ddsi_ref_addrset (struct ddsi_addrset *as);
+
+/** @component locators */
+DDS_EXPORT void ddsi_unref_addrset (struct ddsi_addrset *as);
+
+/** @component locators */
+DDS_EXPORT struct ddsi_addrset *ddsi_new_addrset (void)
+  ddsrt_attribute_warn_unused_result;
+
+/** @component locators */
+DDS_EXPORT void ddsi_add_locator_to_addrset (const struct ddsi_domaingv *gv, struct ddsi_addrset *as, const ddsi_locator_t *loc)
+  ddsrt_nonnull_all;
+
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsi/include/dds/ddsi/ddsi_endpoint.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_endpoint.h
@@ -190,7 +190,10 @@ struct ddsi_local_orphan_writer *ddsi_new_local_orphan_writer (struct ddsi_domai
 void ddsi_delete_local_orphan_writer (struct ddsi_local_orphan_writer *wr);
 
 /** @component ddsi_endpoint */
-dds_return_t ddsi_new_writer (struct ddsi_writer **wr_out, struct ddsi_guid *wrguid, const struct ddsi_guid *group_guid, struct ddsi_participant *pp, const char *topic_name, const struct ddsi_sertype *type, const struct dds_qos *xqos, struct ddsi_whc * whc, ddsi_status_cb_t status_cb, void *status_cb_arg, struct ddsi_psmx_locators_set *psmx_locators);
+dds_return_t ddsi_generate_writer_guid (struct ddsi_guid *wrguid, struct ddsi_participant *participant, const struct ddsi_sertype *sertype);
+
+/** @component ddsi_endpoint */
+dds_return_t ddsi_new_writer (struct ddsi_writer **wr_out, const struct ddsi_guid *guid, const struct ddsi_guid *group_guid, struct ddsi_participant *pp, const char *topic_name, const struct ddsi_sertype *type, const struct dds_qos *xqos, struct ddsi_whc *whc, ddsi_status_cb_t status_cb, void *status_entity, struct ddsi_psmx_locators_set *psmx_locators);
 
 /** @component ddsi_endpoint */
 void ddsi_update_writer_qos (struct ddsi_writer *wr, const struct dds_qos *xqos);
@@ -217,7 +220,10 @@ struct ddsi_reader *ddsi_writer_first_in_sync_reader (struct ddsi_entity_index *
 struct ddsi_reader *ddsi_writer_next_in_sync_reader (struct ddsi_entity_index *entity_index, ddsrt_avl_iter_t *it);
 
 /** @component ddsi_endpoint */
-dds_return_t ddsi_new_reader (struct ddsi_reader **rd_out, struct ddsi_guid *rdguid, const struct ddsi_guid *group_guid, struct ddsi_participant *pp, const char *topic_name, const struct ddsi_sertype *type, const struct dds_qos *xqos, struct ddsi_rhc * rhc, ddsi_status_cb_t status_cb, void *status_cb_arg, struct ddsi_psmx_locators_set *psmx_locators);
+dds_return_t ddsi_generate_reader_guid (struct ddsi_guid *rdguid, struct ddsi_participant *participant, const struct ddsi_sertype *sertype);
+
+/** @component ddsi_endpoint */
+dds_return_t ddsi_new_reader (struct ddsi_reader **rd_out, const struct ddsi_guid *guid, const struct ddsi_guid *group_guid, struct ddsi_participant *pp, const char *topic_name, const struct ddsi_sertype *type, const struct dds_qos *xqos, struct ddsi_rhc *rhc, ddsi_status_cb_t status_cb, void * status_entity, struct ddsi_psmx_locators_set *psmx_locators);
 
 /** @component ddsi_endpoint */
 void ddsi_update_reader_qos (struct ddsi_reader *rd, const struct dds_qos *xqos);

--- a/src/core/ddsi/include/dds/ddsi/ddsi_endpoint.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_endpoint.h
@@ -196,7 +196,10 @@ dds_return_t ddsi_new_writer (struct ddsi_writer **wr_out, struct ddsi_guid *wrg
 void ddsi_update_writer_qos (struct ddsi_writer *wr, const struct dds_qos *xqos);
 
 /** @component ddsi_endpoint */
-void ddsi_make_writer_info(struct ddsi_writer_info *wrinfo, const struct ddsi_entity_common *e, const struct dds_qos *xqos, uint32_t statusinfo);
+void ddsi_make_writer_info (struct ddsi_writer_info *wrinfo, const struct ddsi_entity_common *e, const struct dds_qos *xqos, uint32_t statusinfo);
+
+/** @component ddsi_endpoint */
+void ddsi_make_writer_info_params (struct ddsi_writer_info *wrinfo, const ddsi_guid_t *wr_guid, int32_t ownership_strength, bool autodispose_unregistered_instances, uint64_t iid, uint32_t statusinfo, dds_duration_t lifespan_duration);
 
 /** @component ddsi_endpoint */
 dds_return_t ddsi_writer_wait_for_acks (struct ddsi_writer *wr, const ddsi_guid_t *rdguid, dds_time_t abstimeout);

--- a/src/core/ddsi/include/dds/ddsi/ddsi_entity_index.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_entity_index.h
@@ -64,7 +64,7 @@ void *ddsi_entidx_lookup_guid (const struct ddsi_entity_index *ei, const struct 
 struct ddsi_participant *ddsi_entidx_lookup_participant_guid (const struct ddsi_entity_index *ei, const struct ddsi_guid *guid) ddsrt_nonnull_all;
 
 /** @component entity_index */
-struct ddsi_writer *ddsi_entidx_lookup_writer_guid (const struct ddsi_entity_index *ei, const struct ddsi_guid *guid) ddsrt_nonnull_all;
+DDS_EXPORT struct ddsi_writer *ddsi_entidx_lookup_writer_guid (const struct ddsi_entity_index *ei, const struct ddsi_guid *guid) ddsrt_nonnull_all;
 
 /** @component entity_index */
 struct ddsi_reader *ddsi_entidx_lookup_reader_guid (const struct ddsi_entity_index *ei, const struct ddsi_guid *guid) ddsrt_nonnull_all;

--- a/src/core/ddsi/include/dds/ddsi/ddsi_guid.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_guid.h
@@ -32,10 +32,10 @@ typedef struct ddsi_guid {
 } ddsi_guid_t;
 
 /** @component misc */
-ddsi_guid_t ddsi_hton_guid (ddsi_guid_t g);
+DDS_EXPORT ddsi_guid_t ddsi_hton_guid (ddsi_guid_t g);
 
 /** @component misc */
-ddsi_guid_t ddsi_ntoh_guid (ddsi_guid_t g);
+DDS_EXPORT ddsi_guid_t ddsi_ntoh_guid (ddsi_guid_t g);
 
 /** @component misc */
 ddsi_guid_prefix_t ddsi_hton_guid_prefix (ddsi_guid_prefix_t p);

--- a/src/core/ddsi/include/dds/ddsi/ddsi_participant.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_participant.h
@@ -26,6 +26,28 @@
 extern "C" {
 #endif
 
+/* Set this flag in new_participant to prevent the creation SPDP, SEDP
+   and PMD readers for that participant.  It doesn't really need it,
+   they all share the information anyway.  But you do need it once. */
+#define RTPS_PF_NO_BUILTIN_READERS 1u
+/* Set this flag to prevent the creation of SPDP, SEDP and PMD
+   writers.  It will then rely on the "privileged participant", which
+   must exist at the time of creation.  It creates a reference to that
+   "privileged participant" to ensure it won't disappear too early. */
+#define RTPS_PF_NO_BUILTIN_WRITERS 2u
+/* Set this flag to mark the participant as the "privileged
+   participant", there can only be one of these.  The privileged
+   participant MUST have all builtin readers and writers. */
+#define RTPS_PF_PRIVILEGED_PP 4u
+/* Set this flag to mark the participant as is_ddsi2_pp. */
+#define RTPS_PF_IS_DDSI2_PP 8u
+/* Set this flag to mark the participant as an local entity only. */
+#define RTPS_PF_ONLY_LOCAL 16u
+/* Set this flag to mark that no privileged participant should be used
+   for the built-in readers and writers. Can be used with NO_BUILTIN_READER and
+   NO_BUILTIN_WRITER flag to avoid any communication for built-in topics. */
+#define RTPS_PF_NO_PRIVILEGED_PP 32u
+
 struct ddsi_avail_entityid_set {
   struct ddsi_inverse_uint32_set x;
 };
@@ -42,6 +64,7 @@ struct ddsi_participant
   struct ddsi_entity_common e;
   uint32_t bes; /* built-in endpoint set */
   unsigned is_ddsi2_pp: 1; /* true for the "federation leader", the ddsi2 participant itself in OSPL; FIXME: probably should use this for broker mode as well ... */
+  uint32_t flags; /* flags used when creating this participant */
   struct ddsi_plist *plist; /* settings/QoS for this participant */
   struct ddsi_xevent *spdp_xevent; /* timed event for periodically publishing SPDP */
   struct ddsi_xevent *pmd_update_xevent; /* timed event for periodically publishing ParticipantMessageData */

--- a/src/core/ddsi/include/dds/ddsi/ddsi_participant.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_participant.h
@@ -62,12 +62,19 @@ struct ddsi_participant
 };
 
 /**
- * @brief Create a new participant in the domain
+ * @brief Generates a new participant GUID
+ *
+ * @param[out] ppguid  The generated participant GUID
+ * @param[in] gv  Domain globals
+ */
+void ddsi_generate_participant_guid (ddsi_guid_t *ppguid, struct ddsi_domaingv *gv);
+
+/**
+ * @brief Create a new participant with a specified GUID
  * @component ddsi_participant
  *
- * @param[out] ppguid
- *               On successful return: the GUID of the new participant;
- *               Undefined on error.
+ * @param[in] ppguid  The GUID for the new participant
+ * @param[in]  gv  Domain globals
  * @param[in]  flags
  *               Zero or more of:
  *               - RTPS_PF_NO_BUILTIN_READERS   do not create discovery readers in new ppant
@@ -75,21 +82,16 @@ struct ddsi_participant
  *               - RTPS_PF_PRIVILEGED_PP        FIXME: figure out how to describe this ...
  *               - RTPS_PF_IS_DDSI2_PP          FIXME: OSPL holdover - there is no DDSI2E here
  *               - RTPS_PF_ONLY_LOCAL           FIXME: not used, it seems
- * @param[in]  plist
- *               Parameters/QoS for this participant
+ * @param[in]  plist  Parameters/QoS for this participant
  *
  * @returns A dds_return_t indicating success or failure.
  *
  * @retval DDS_RETCODE_OK
- *               Success, there is now a local participant with the GUID stored in
- *               *ppguid
- * @retval DDS_RETCODE_OUT_OF_RESOURCES
- *               Failed to allocate a new GUID (note: currently this will always
- *               happen after 2**24-1 successful calls to new_participant ...).
+ *               Success
  * @retval DDS_RETCODE_OUT_OF_RESOURCES
  *               The configured maximum number of participants has been reached.
 */
-dds_return_t ddsi_new_participant (struct ddsi_guid *ppguid, struct ddsi_domaingv *gv, unsigned flags, const struct ddsi_plist *plist);
+dds_return_t ddsi_new_participant (ddsi_guid_t *ppguid, struct ddsi_domaingv *gv, unsigned flags, const struct ddsi_plist *plist);
 
 /**
  * @component ddsi_participant

--- a/src/core/ddsi/include/dds/ddsi/ddsi_plist.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_plist.h
@@ -160,7 +160,7 @@ typedef struct ddsi_plist {
  *
  * @param[out] dest  plist_t to be initialized.
  */
-void ddsi_plist_init_empty (ddsi_plist_t *dest);
+DDS_EXPORT void ddsi_plist_init_empty (ddsi_plist_t *dest);
 
 /**
  * @brief Free memory owned by "ps"
@@ -174,7 +174,7 @@ void ddsi_plist_init_empty (ddsi_plist_t *dest);
  *
  * @param[in] ps   ddsi_plist_t for which to free memory
  */
-void ddsi_plist_fini (ddsi_plist_t *ps);
+DDS_EXPORT void ddsi_plist_fini (ddsi_plist_t *ps);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsi/include/dds/ddsi/ddsi_portmapping.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_portmapping.h
@@ -19,6 +19,13 @@
 extern "C" {
 #endif
 
+enum ddsi_port {
+  DDSI_PORT_MULTI_DISC,
+  DDSI_PORT_MULTI_DATA,
+  DDSI_PORT_UNI_DISC,
+  DDSI_PORT_UNI_DATA
+};
+
 struct ddsi_portmapping {
   uint32_t base;
   uint32_t dg;
@@ -28,6 +35,9 @@ struct ddsi_portmapping {
   uint32_t d2;
   uint32_t d3;
 };
+
+/** @component port_mapping */
+DDS_EXPORT bool ddsi_get_port_int (uint32_t *port, const struct ddsi_portmapping *map, enum ddsi_port which, uint32_t domain_id, int32_t participant_index, char *str_if_overflow, size_t strsize);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsi/include/dds/ddsi/ddsi_proxy_endpoint.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_proxy_endpoint.h
@@ -101,6 +101,48 @@ struct ddsi_proxy_reader {
   ddsi_filter_fn_t filter;
 };
 
+
+/**
+ * @brief To create a new proxy writer
+ * @component ddsi_proxy_endpoint
+ *
+ * @param proxy_writer  out parameter for the created proxy writer
+ * @param gv        domain globals
+ * @param ppguid    the proxy participant is determined from the GUID and must exist
+ * @param guid      guid for the proxy writer
+ * @param as        address set
+ * @param plist     parameter list
+ * @param dqueue    receive queue
+ * @param evq       event queue
+ * @param timestamp timestamp to be used as creation time for the proxy writer
+ * @param seq       sequence number
+ * @returns 0 on success
+ */
+DDS_EXPORT int ddsi_new_proxy_writer (struct ddsi_proxy_writer **proxy_writer, struct ddsi_domaingv *gv, const struct ddsi_guid *ppguid, const struct ddsi_guid *guid, struct ddsi_addrset *as, const struct ddsi_plist *plist, struct ddsi_dqueue *dqueue, struct ddsi_xeventq *evq, ddsrt_wctime_t timestamp, ddsi_seqno_t seq);
+
+
+/**
+ * @brief To create a new proxy reader
+ * @component ddsi_proxy_endpoint
+ *
+ * @param proxy_reader  out parameter for the created proxy reader
+ * @param gv            domain globals
+ * @param ppguid        the proxy participant is determined from the GUID and must exist
+ * @param guid          guid for the proxy reader
+ * @param as            address set
+ * @param plist         parameter list
+ * @param timestamp     timestamp to be used as creation time for the proxy reader
+ * @param seq           sequence number
+ * @param favours_ssm   indicates if the proxy reader favors ssm
+ * @return int
+ */
+DDS_EXPORT int ddsi_new_proxy_reader (struct ddsi_proxy_reader **proxy_reader, struct ddsi_domaingv *gv, const struct ddsi_guid *ppguid, const struct ddsi_guid *guid, struct ddsi_addrset *as, const struct ddsi_plist *plist, ddsrt_wctime_t timestamp, ddsi_seqno_t seq
+
+#ifdef DDS_HAS_SSM
+, int favours_ssm
+#endif
+);
+
 #if defined (__cplusplus)
 }
 #endif

--- a/src/core/ddsi/include/dds/ddsi/ddsi_proxy_participant.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_proxy_participant.h
@@ -68,6 +68,9 @@ struct ddsi_proxy_participant
 extern const ddsrt_avl_treedef_t ddsi_proxypp_proxytp_treedef;
 #endif
 
+/** @component ddsi_proxy_participant */
+DDS_EXPORT bool ddsi_new_proxy_participant (struct ddsi_proxy_participant **proxy_participant, struct ddsi_domaingv *gv, const struct ddsi_guid *guid, uint32_t bes, const struct ddsi_guid *privileged_pp_guid, struct ddsi_addrset *as_default, struct ddsi_addrset *as_meta, const struct ddsi_plist *plist, dds_duration_t tlease_dur, ddsi_vendorid_t vendor, unsigned custom_flags, ddsrt_wctime_t timestamp, ddsi_seqno_t seq);
+
 #if defined (__cplusplus)
 }
 #endif

--- a/src/core/ddsi/include/dds/ddsi/ddsi_thread.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_thread.h
@@ -187,7 +187,7 @@ inline bool ddsi_thread_is_asleep (void)
 }
 
 /** @component thread_support */
-inline void ddsi_thread_state_asleep (struct ddsi_thread_state *thrst)
+DDS_INLINE_EXPORT inline void ddsi_thread_state_asleep (struct ddsi_thread_state *thrst)
 {
   ddsi_vtime_t vt = ddsrt_atomic_ld32 (&thrst->vtime);
   assert (ddsi_vtime_awake_p (vt));
@@ -202,7 +202,7 @@ inline void ddsi_thread_state_asleep (struct ddsi_thread_state *thrst)
 }
 
 /** @component thread_support */
-inline void ddsi_thread_state_awake (struct ddsi_thread_state *thrst, const struct ddsi_domaingv *gv)
+DDS_INLINE_EXPORT inline void ddsi_thread_state_awake (struct ddsi_thread_state *thrst, const struct ddsi_domaingv *gv)
 {
   ddsi_vtime_t vt = ddsrt_atomic_ld32 (&thrst->vtime);
   assert ((vt & DDSI_VTIME_NEST_MASK) < DDSI_VTIME_NEST_MASK);

--- a/src/core/ddsi/include/dds/ddsi/ddsi_tkmap.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_tkmap.h
@@ -48,10 +48,10 @@ struct ddsi_tkmap_instance * ddsi_tkmap_find(struct ddsi_tkmap *map, struct ddsi
 struct ddsi_tkmap_instance * ddsi_tkmap_find_by_id (struct ddsi_tkmap *map, uint64_t iid);
 
 /** @component key_instance_map */
-struct ddsi_tkmap_instance * ddsi_tkmap_lookup_instance_ref (struct ddsi_tkmap *map, struct ddsi_serdata * sd);
+DDS_EXPORT struct ddsi_tkmap_instance * ddsi_tkmap_lookup_instance_ref (struct ddsi_tkmap *map, struct ddsi_serdata * sd);
 
 /** @component key_instance_map */
-void ddsi_tkmap_instance_unref (struct ddsi_tkmap *map, struct ddsi_tkmap_instance *tk);
+DDS_EXPORT void ddsi_tkmap_instance_unref (struct ddsi_tkmap *map, struct ddsi_tkmap_instance *tk);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsi/include/dds/ddsi/ddsi_tran.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_tran.h
@@ -44,7 +44,7 @@ struct ddsi_tran_qos;
 char *ddsi_xlocator_to_string (char *dst, size_t sizeof_dst, const ddsi_xlocator_t *loc);
 
 /** @component locators */
-char *ddsi_locator_to_string (char *dst, size_t sizeof_dst, const ddsi_locator_t *loc);
+DDS_EXPORT char *ddsi_locator_to_string (char *dst, size_t sizeof_dst, const ddsi_locator_t *loc);
 
 /** @component locators */
 char *ddsi_xlocator_to_string_no_port (char *dst, size_t sizeof_dst, const ddsi_xlocator_t *loc);

--- a/src/core/ddsi/include/dds/ddsi/ddsi_transmit.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_transmit.h
@@ -35,7 +35,7 @@ struct ddsi_thread_state;
  * @param tk        key-instance map instance
  * @return int
  */
-int ddsi_write_sample_gc (struct ddsi_thread_state * const thrst, struct ddsi_xpack *xp, struct ddsi_writer *wr, struct ddsi_serdata *serdata, struct ddsi_tkmap_instance *tk);
+DDS_EXPORT int ddsi_write_sample_gc (struct ddsi_thread_state * const thrst, struct ddsi_xpack *xp, struct ddsi_writer *wr, struct ddsi_serdata *serdata, struct ddsi_tkmap_instance *tk);
 
 /**
  * @component outgoing_rtps

--- a/src/core/ddsi/include/dds/ddsi/ddsi_typelib.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_typelib.h
@@ -95,10 +95,13 @@ DDS_EXPORT const char * ddsi_typemap_get_type_name (const ddsi_typemap_t *typema
 dds_return_t ddsi_type_ref_local (struct ddsi_domaingv *gv, struct ddsi_type **type, const struct ddsi_sertype *sertype, ddsi_typeid_kind_t kind);
 
 /** @component type_system */
-void ddsi_type_ref (struct ddsi_domaingv *gv, struct ddsi_type **type, const struct ddsi_type *src);
+DDS_EXPORT dds_return_t ddsi_type_add (struct ddsi_domaingv *gv, struct ddsi_type **type_minimal, struct ddsi_type **type_complete, const ddsi_typeinfo_t *type_info, const ddsi_typemap_t *type_map);
 
 /** @component type_system */
-void ddsi_type_unref (struct ddsi_domaingv *gv, struct ddsi_type *type);
+DDS_EXPORT void ddsi_type_ref (struct ddsi_domaingv *gv, struct ddsi_type **type, const struct ddsi_type *src);
+
+/** @component type_system */
+DDS_EXPORT void ddsi_type_unref (struct ddsi_domaingv *gv, struct ddsi_type *type);
 
 /** @component type_system */
 void ddsi_type_unref_sertype (struct ddsi_domaingv *gv, const struct ddsi_sertype *sertype);

--- a/src/core/ddsi/include/dds/ddsi/ddsi_typelib.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_typelib.h
@@ -89,6 +89,9 @@ DDS_EXPORT void ddsi_typemap_fini (ddsi_typemap_t *typemap);
 DDS_EXPORT bool ddsi_typemap_equal (const ddsi_typemap_t *a, const ddsi_typemap_t *b);
 
 /** @component type_system */
+DDS_EXPORT const char * ddsi_typemap_get_type_name (const ddsi_typemap_t *typemap, const ddsi_typeid_t *type_id);
+
+/** @component type_system */
 dds_return_t ddsi_type_ref_local (struct ddsi_domaingv *gv, struct ddsi_type **type, const struct ddsi_sertype *sertype, ddsi_typeid_kind_t kind);
 
 /** @component type_system */

--- a/src/core/ddsi/include/dds/ddsi/ddsi_xmsg.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_xmsg.h
@@ -23,13 +23,13 @@ struct ddsi_domaingv;
 struct ddsi_xpack;
 
 /** @component rtps_msg */
-struct ddsi_xpack * ddsi_xpack_new (struct ddsi_domaingv *gv, bool async_mode);
+DDS_EXPORT struct ddsi_xpack * ddsi_xpack_new (struct ddsi_domaingv *gv, bool async_mode);
 
 /** @component rtps_msg */
-void ddsi_xpack_free (struct ddsi_xpack *xp);
+DDS_EXPORT void ddsi_xpack_free (struct ddsi_xpack *xp);
 
 /** @component rtps_msg */
-void ddsi_xpack_send (struct ddsi_xpack *xp, bool immediately /* unused */);
+DDS_EXPORT void ddsi_xpack_send (struct ddsi_xpack *xp, bool immediately /* unused */);
 
 /** @component rtps_msg */
 void ddsi_xpack_sendq_init (struct ddsi_domaingv *gv);

--- a/src/core/ddsi/include/dds/ddsi/ddsi_xqos.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_xqos.h
@@ -384,7 +384,7 @@ void ddsi_xqos_mergein_missing (dds_qos_t *a, const dds_qos_t *b, uint64_t mask)
  *
  * @returns Bitmask of differences
  */
-uint64_t ddsi_xqos_delta (const dds_qos_t *a, const dds_qos_t *b, uint64_t mask);
+DDS_EXPORT uint64_t ddsi_xqos_delta (const dds_qos_t *a, const dds_qos_t *b, uint64_t mask);
 
 /**
  * @brief Add a property 'name' to the properties of "xqos" if it does not exists

--- a/src/core/ddsi/src/ddsi__addrset.h
+++ b/src/core/ddsi/src/ddsi__addrset.h
@@ -35,20 +35,6 @@ struct ddsi_addrset {
 typedef ssize_t (*ddsi_addrset_forone_fun_t) (const ddsi_xlocator_t *loc, void *arg);
 
 /** @component locators */
-struct ddsi_addrset *ddsi_new_addrset (void)
-  ddsrt_attribute_warn_unused_result;
-
-/** @component locators */
-struct ddsi_addrset *ddsi_ref_addrset (struct ddsi_addrset *as);
-
-/** @component locators */
-void ddsi_unref_addrset (struct ddsi_addrset *as);
-
-/** @component locators */
-void ddsi_add_locator_to_addrset (const struct ddsi_domaingv *gv, struct ddsi_addrset *as, const ddsi_locator_t *loc)
-  ddsrt_nonnull_all;
-
-/** @component locators */
 void ddsi_add_xlocator_to_addrset (const struct ddsi_domaingv *gv, struct ddsi_addrset *as, const ddsi_xlocator_t *loc)
   ddsrt_nonnull_all;
 

--- a/src/core/ddsi/src/ddsi__cfgelems.h
+++ b/src/core/ddsi/src/ddsi__cfgelems.h
@@ -2013,6 +2013,10 @@ static struct cfgelem tracing_cfgelems[] = {
       "<li><i>plist</i>: tracing of discovery parameter list interpretation</li>\n"
       "<li><i>content</i>: tracing of sample contents</li>\n"
       "<li><i>malformed</i>: dump malformed full packet as warning</li>\n"
+      "<li><i>user</i>: all user-defined tracing categories</li>\n"
+      "<li><i>user1</i>: user-defined tracing category 1</li>\n"
+      "<li><i>user2</i>: user-defined tracing category 2</li>\n"
+      "<li><i>user3</i>: user-defined tracing category 3</li>\n"
       "</ul>\n"
       "<p>In addition, there is the keyword <i>trace</i> that enables: "
       "<i>fatal</i>, <i>error</i>, <i>warning</i>, <i>info</i>, <i>config</i>, "
@@ -2026,7 +2030,7 @@ static struct cfgelem tracing_cfgelems[] = {
     VALUES(
       "fatal","error","warning","info","config","discovery","data","radmin",
       "timing","traffic","topic","tcp","plist","whc","throttle","rhc",
-      "content","malformed","trace"
+      "content","malformed","trace","user","user1","user2","user3"
     )),
   ENUM("Verbosity", NULL, 1, "none",
     NOMEMBER,

--- a/src/core/ddsi/src/ddsi__discovery_addrset.h
+++ b/src/core/ddsi/src/ddsi__discovery_addrset.h
@@ -25,7 +25,7 @@ typedef struct ddsi_interface_set {
 
 /** @brief Initializes an interface set to all-false
  * @component discovery
- * 
+ *
  * @param[out] intfs interface set to initialize */
 void ddsi_interface_set_init (ddsi_interface_set_t *intfs)
   ddsrt_nonnull_all;
@@ -35,7 +35,7 @@ void ddsi_interface_set_init (ddsi_interface_set_t *intfs)
  *
  * @param[in] gv domain
  * @return true iff multicast locators are to be included */
-bool ddsi_include_multicast_locator_in_discovery (const struct ddsi_domaingv *gv)
+DDS_EXPORT bool ddsi_include_multicast_locator_in_discovery (const struct ddsi_domaingv *gv)
   ddsrt_nonnull_all;
 
 /** @brief Constructs a new address set from uni- and multicast locators received in SPDP or SEDP

--- a/src/core/ddsi/src/ddsi__endpoint.h
+++ b/src/core/ddsi/src/ddsi__endpoint.h
@@ -60,9 +60,6 @@ int ddsi_is_keyed_endpoint_entityid (ddsi_entityid_t id);
 int ddsi_is_builtin_volatile_endpoint (ddsi_entityid_t id);
 
 /** @component ddsi_endpoint */
-dds_return_t ddsi_new_writer_guid (struct ddsi_writer **wr_out, const struct ddsi_guid *guid, const struct ddsi_guid *group_guid, struct ddsi_participant *pp, const char *topic_name, const struct ddsi_sertype *type, const struct dds_qos *xqos, struct ddsi_whc *whc, ddsi_status_cb_t status_cb, void *status_entity, struct ddsi_psmx_locators_set *psmx_locators);
-
-/** @component ddsi_endpoint */
 int ddsi_is_writer_entityid (ddsi_entityid_t id);
 
 /** @component ddsi_endpoint */
@@ -97,9 +94,6 @@ void ddsi_writer_set_alive_may_unlock (struct ddsi_writer *wr, bool notify);
 
 /** @component ddsi_endpoint */
 int ddsi_writer_set_notalive (struct ddsi_writer *wr, bool notify);
-
-/** @component ddsi_endpoint */
-dds_return_t ddsi_new_reader_guid (struct ddsi_reader **rd_out, const struct ddsi_guid *guid, const struct ddsi_guid *group_guid, struct ddsi_participant *pp, const char *topic_name, const struct ddsi_sertype *type, const struct dds_qos *xqos, struct ddsi_rhc *rhc, ddsi_status_cb_t status_cb, void * status_entity, struct ddsi_psmx_locators_set *psmx_locators);
 
 /** @component ddsi_endpoint */
 int ddsi_is_reader_entityid (ddsi_entityid_t id);

--- a/src/core/ddsi/src/ddsi__ipaddr.h
+++ b/src/core/ddsi/src/ddsi__ipaddr.h
@@ -31,7 +31,7 @@ int ddsi_ipaddr_compare (const struct sockaddr *const sa1, const struct sockaddr
 char *ddsi_ipaddr_to_string (char *dst, size_t sizeof_dst, const ddsi_locator_t *loc, int with_port, const struct ddsi_network_interface *interf);
 
 /** @component ip_address */
-void ddsi_ipaddr_to_loc (ddsi_locator_t *dst, const struct sockaddr *src, int32_t kind);
+DDS_EXPORT void ddsi_ipaddr_to_loc (ddsi_locator_t *dst, const struct sockaddr *src, int32_t kind);
 
 /** @component ip_address */
 void ddsi_ipaddr_from_loc (struct sockaddr_storage *dst, const ddsi_locator_t *src);

--- a/src/core/ddsi/src/ddsi__participant.h
+++ b/src/core/ddsi/src/ddsi__participant.h
@@ -49,24 +49,6 @@ struct ddsi_deleted_participants_admin {
   int64_t delay;
 };
 
-/* Set this flag in new_participant to prevent the creation SPDP, SEDP
-   and PMD readers for that participant.  It doesn't really need it,
-   they all share the information anyway.  But you do need it once. */
-#define RTPS_PF_NO_BUILTIN_READERS 1u
-/* Set this flag to prevent the creation of SPDP, SEDP and PMD
-   writers.  It will then rely on the "privileged participant", which
-   must exist at the time of creation.  It creates a reference to that
-   "privileged participant" to ensure it won't disappear too early. */
-#define RTPS_PF_NO_BUILTIN_WRITERS 2u
-/* Set this flag to mark the participant as the "privileged
-   participant", there can only be one of these.  The privileged
-   participant MUST have all builtin readers and writers. */
-#define RTPS_PF_PRIVILEGED_PP 4u
-  /* Set this flag to mark the participant as is_ddsi2_pp. */
-#define RTPS_PF_IS_DDSI2_PP 8u
-  /* Set this flag to mark the participant as an local entity only. */
-#define RTPS_PF_ONLY_LOCAL 16u
-
 /** @component ddsi_participant */
 void ddsi_participant_add_wr_lease_locked (struct ddsi_participant * pp, const struct ddsi_writer * wr);
 
@@ -121,13 +103,14 @@ dds_duration_t ddsi_participant_get_pmd_interval (struct ddsi_participant *pp);
  * @component ddsi_participant
  * @brief To obtain the builtin writer to be used for publishing SPDP, SEDP, PMD stuff for
  * PP and its endpoints, given the entityid. If PP has its own writer, use it; else use the
- * privileged participant.
+ * privileged participant, unless the NO_PRIVILEGED_PP flag is set.
  *
  * @param[in] pp The participant
  * @param[in] entityid The entity ID of the writer
- * @returns The built-in writer
+ * @param[out] bwr The built-in writer
+ * @returns Return code indicating success or failure
  */
-struct ddsi_writer *ddsi_get_builtin_writer (const struct ddsi_participant *pp, unsigned entityid);
+dds_return_t ddsi_get_builtin_writer (const struct ddsi_participant *pp, unsigned entityid, struct ddsi_writer **bwr);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsi/src/ddsi__portmapping.h
+++ b/src/core/ddsi/src/ddsi__portmapping.h
@@ -20,13 +20,6 @@
 extern "C" {
 #endif
 
-enum ddsi_port {
-  DDSI_PORT_MULTI_DISC,
-  DDSI_PORT_MULTI_DATA,
-  DDSI_PORT_UNI_DISC,
-  DDSI_PORT_UNI_DATA
-};
-
 struct ddsi_config;
 
 /** @component port_mapping */
@@ -34,9 +27,6 @@ bool ddsi_valid_portmapping (const struct ddsi_config *config, int32_t participa
 
 /** @component port_mapping */
 uint32_t ddsi_get_port (const struct ddsi_config *config, enum ddsi_port which, int32_t participant_index);
-
-/** @component port_mapping */
-bool ddsi_get_port_int (uint32_t *port, const struct ddsi_portmapping *map, enum ddsi_port which, uint32_t domain_id, int32_t participant_index, char *str_if_overflow, size_t strsize);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsi/src/ddsi__portmapping.h
+++ b/src/core/ddsi/src/ddsi__portmapping.h
@@ -35,6 +35,9 @@ bool ddsi_valid_portmapping (const struct ddsi_config *config, int32_t participa
 /** @component port_mapping */
 uint32_t ddsi_get_port (const struct ddsi_config *config, enum ddsi_port which, int32_t participant_index);
 
+/** @component port_mapping */
+bool ddsi_get_port_int (uint32_t *port, const struct ddsi_portmapping *map, enum ddsi_port which, uint32_t domain_id, int32_t participant_index, char *str_if_overflow, size_t strsize);
+
 #if defined (__cplusplus)
 }
 #endif

--- a/src/core/ddsi/src/ddsi__proxy_endpoint.h
+++ b/src/core/ddsi/src/ddsi__proxy_endpoint.h
@@ -55,44 +55,6 @@ void ddsi_send_entityid_to_pwr (struct ddsi_proxy_writer *pwr, const ddsi_guid_t
 void ddsi_send_entityid_to_prd (struct ddsi_proxy_reader *prd, const ddsi_guid_t *guid);
 
 /**
- * @brief To create a new proxy writer
- * @component ddsi_proxy_endpoint
- *
- * @param gv        domain globals
- * @param ppguid    the proxy participant is determined from the GUID and must exist
- * @param guid      guid for the proxy writer
- * @param as        address set
- * @param plist     parameter list
- * @param dqueue    receive queue
- * @param evq       event queue
- * @param timestamp timestamp to be used as creation time for the proxy writer
- * @param seq       sequence number
- * @returns 0 on success
- */
-int ddsi_new_proxy_writer (struct ddsi_domaingv *gv, const struct ddsi_guid *ppguid, const struct ddsi_guid *guid, struct ddsi_addrset *as, const struct ddsi_plist *plist, struct ddsi_dqueue *dqueue, struct ddsi_xeventq *evq, ddsrt_wctime_t timestamp, ddsi_seqno_t seq);
-
-
-/**
- * @brief To create a new proxy reader
- * @component ddsi_proxy_endpoint
- *
- * @param gv            domain globals
- * @param ppguid        the proxy participant is determined from the GUID and must exist
- * @param guid          guid for the proxy reader
- * @param as            address set
- * @param plist         parameter list
- * @param timestamp     timestamp to be used as creation time for the proxy reader
- * @param seq           sequence number
- * @param favours_ssm   indicates if the proxy reader favors ssm
- * @return int
- */
-int ddsi_new_proxy_reader (struct ddsi_domaingv *gv, const struct ddsi_guid *ppguid, const struct ddsi_guid *guid, struct ddsi_addrset *as, const struct ddsi_plist *plist, ddsrt_wctime_t timestamp, ddsi_seqno_t seq
-#ifdef DDS_HAS_SSM
-, int favours_ssm
-#endif
-);
-
-/**
  * @brief Delete a proxy writer
  * @component ddsi_proxy_endpoint
  *

--- a/src/core/ddsi/src/ddsi__proxy_participant.h
+++ b/src/core/ddsi/src/ddsi__proxy_participant.h
@@ -75,9 +75,6 @@ void ddsi_proxy_participant_remove_pwr_lease_locked (struct ddsi_proxy_participa
 
 
 /** @component ddsi_proxy_participant */
-bool ddsi_new_proxy_participant (struct ddsi_domaingv *gv, const struct ddsi_guid *guid, uint32_t bes, const struct ddsi_guid *privileged_pp_guid, struct ddsi_addrset *as_default, struct ddsi_addrset *as_meta, const struct ddsi_plist *plist, dds_duration_t tlease_dur, ddsi_vendorid_t vendor, unsigned custom_flags, ddsrt_wctime_t timestamp, ddsi_seqno_t seq);
-
-/** @component ddsi_proxy_participant */
 int ddsi_delete_proxy_participant_by_guid (struct ddsi_domaingv *gv, const struct ddsi_guid *guid, ddsrt_wctime_t timestamp, int isimplicit);
 
 #if defined (__cplusplus)

--- a/src/core/ddsi/src/ddsi__typewrap.h
+++ b/src/core/ddsi/src/ddsi__typewrap.h
@@ -47,6 +47,8 @@ dds_return_t ddsi_typeobj_get_hash_id (const struct DDS_XTypes_TypeObject *type_
 /** @component xtypes_wrapper */
 void ddsi_typeobj_get_hash_id_impl (const struct DDS_XTypes_TypeObject *type_obj, struct DDS_XTypes_TypeIdentifier *type_id);
 
+/** @component xtypes_wrapper */
+const char *ddsi_typeobj_get_type_name_impl (const struct DDS_XTypes_TypeObject *type_obj);
 
 /** @component xtypes_wrapper */
 dds_return_t ddsi_xt_type_init (struct ddsi_domaingv *gv, struct xt_type *xt, const ddsi_typeid_t *ti, const ddsi_typeobj_t *to);

--- a/src/core/ddsi/src/ddsi__xt_impl.h
+++ b/src/core/ddsi/src/ddsi__xt_impl.h
@@ -15,6 +15,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <string.h>
 #include "dds/ddsrt/avl.h"
 #include "dds/ddsrt/misc.h"
 #include "dds/ddsi/ddsi_xt_typeinfo.h"

--- a/src/core/ddsi/src/ddsi_config.c
+++ b/src/core/ddsi/src/ddsi_config.c
@@ -1007,10 +1007,10 @@ GENERIC_ENUM_CTYPE (shm_loglevel, enum ddsi_shm_loglevel)
 
 /* "trace" is special: it enables (nearly) everything */
 static const char *tracemask_names[] = {
-  "fatal", "error", "warning", "info", "config", "discovery", "data", "radmin", "timing", "traffic", "topic", "tcp", "plist", "whc", "throttle", "rhc", "content", "malformed", "trace", NULL
+  "fatal", "error", "warning", "info", "config", "discovery", "data", "radmin", "timing", "traffic", "topic", "tcp", "plist", "whc", "throttle", "rhc", "content", "malformed", "user1", "user2", "user3", "user", "trace", NULL
 };
 static const uint32_t tracemask_codes[] = {
-  DDS_LC_FATAL, DDS_LC_ERROR, DDS_LC_WARNING, DDS_LC_INFO, DDS_LC_CONFIG, DDS_LC_DISCOVERY, DDS_LC_DATA, DDS_LC_RADMIN, DDS_LC_TIMING, DDS_LC_TRAFFIC, DDS_LC_TOPIC, DDS_LC_TCP, DDS_LC_PLIST, DDS_LC_WHC, DDS_LC_THROTTLE, DDS_LC_RHC, DDS_LC_CONTENT, DDS_LC_MALFORMED, DDS_LC_ALL
+  DDS_LC_FATAL, DDS_LC_ERROR, DDS_LC_WARNING, DDS_LC_INFO, DDS_LC_CONFIG, DDS_LC_DISCOVERY, DDS_LC_DATA, DDS_LC_RADMIN, DDS_LC_TIMING, DDS_LC_TRAFFIC, DDS_LC_TOPIC, DDS_LC_TCP, DDS_LC_PLIST, DDS_LC_WHC, DDS_LC_THROTTLE, DDS_LC_RHC, DDS_LC_CONTENT, DDS_LC_MALFORMED, DDS_LC_USER1, DDS_LC_USER2, DDS_LC_USER3, DDS_LC_USER, DDS_LC_ALL
 };
 
 static enum update_result uf_tracemask (struct ddsi_cfgst *cfgst, UNUSED_ARG (void *parent), UNUSED_ARG (struct cfgelem const * const cfgelem), UNUSED_ARG (int first), const char *value)

--- a/src/core/ddsi/src/ddsi_discovery.c
+++ b/src/core/ddsi/src/ddsi_discovery.c
@@ -76,6 +76,7 @@ struct ddsi_proxy_participant *ddsi_implicitly_create_proxypp (struct ddsi_domai
 {
   ddsi_guid_t privguid;
   ddsi_plist_t pp_plist;
+  struct ddsi_proxy_participant *proxy_participant;
 
   if (memcmp (&ppguid->prefix, src_guid_prefix, sizeof (ppguid->prefix)) == 0)
     /* if the writer is owned by the participant itself, we're not interested */
@@ -109,7 +110,7 @@ struct ddsi_proxy_participant *ddsi_implicitly_create_proxypp (struct ddsi_domai
        doing anything about (1).  That means we fall back to the legacy mode of locally generating
        GIDs but leaving the system id unchanged if the remote is OSPL.  */
     actual_vendorid = (datap->present & PP_VENDORID) ?  datap->vendorid : vendorid;
-    (void) ddsi_new_proxy_participant (gv, ppguid, 0, &privguid, ddsi_new_addrset(), ddsi_new_addrset(), &pp_plist, DDS_INFINITY, actual_vendorid, DDSI_CF_IMPLICITLY_CREATED_PROXYPP, timestamp, seq);
+    (void) ddsi_new_proxy_participant (&proxy_participant, gv, ppguid, 0, &privguid, ddsi_new_addrset(), ddsi_new_addrset(), &pp_plist, DDS_INFINITY, actual_vendorid, DDSI_CF_IMPLICITLY_CREATED_PROXYPP, timestamp, seq);
   }
   else if (ppguid->prefix.u[0] == src_guid_prefix->u[0] && ddsi_vendor_is_eclipse_or_opensplice (vendorid))
   {
@@ -143,7 +144,7 @@ struct ddsi_proxy_participant *ddsi_implicitly_create_proxypp (struct ddsi_domai
       ddsrt_mutex_unlock (&privpp->e.lock);
 
       pp_plist.adlink_participant_version_info.flags &= ~DDSI_ADLINK_FL_PARTICIPANT_IS_DDSI2;
-      (void) ddsi_new_proxy_participant (gv, ppguid, 0, &privguid, as_default, as_meta, &pp_plist, DDS_INFINITY, vendorid, DDSI_CF_IMPLICITLY_CREATED_PROXYPP | DDSI_CF_PROXYPP_NO_SPDP, timestamp, seq);
+      (void) ddsi_new_proxy_participant (&proxy_participant, gv, ppguid, 0, &privguid, as_default, as_meta, &pp_plist, DDS_INFINITY, vendorid, DDSI_CF_IMPLICITLY_CREATED_PROXYPP | DDSI_CF_PROXYPP_NO_SPDP, timestamp, seq);
     }
   }
 

--- a/src/core/ddsi/src/ddsi_discovery.c
+++ b/src/core/ddsi/src/ddsi_discovery.c
@@ -65,8 +65,9 @@
 
 struct ddsi_writer *ddsi_get_sedp_writer (const struct ddsi_participant *pp, unsigned entityid)
 {
-  struct ddsi_writer *sedp_wr = ddsi_get_builtin_writer (pp, entityid);
-  if (sedp_wr == NULL)
+  struct ddsi_writer *sedp_wr;
+  dds_return_t ret = ddsi_get_builtin_writer (pp, entityid, &sedp_wr);
+  if (ret != DDS_RETCODE_OK)
     DDS_FATAL ("sedp_write_writer: no SEDP builtin writer %x for "PGUIDFMT"\n", entityid, PGUID (pp->e.guid));
   return sedp_wr;
 }

--- a/src/core/ddsi/src/ddsi_discovery.c
+++ b/src/core/ddsi/src/ddsi_discovery.c
@@ -143,7 +143,7 @@ struct ddsi_proxy_participant *ddsi_implicitly_create_proxypp (struct ddsi_domai
       ddsrt_mutex_unlock (&privpp->e.lock);
 
       pp_plist.adlink_participant_version_info.flags &= ~DDSI_ADLINK_FL_PARTICIPANT_IS_DDSI2;
-      ddsi_new_proxy_participant (gv, ppguid, 0, &privguid, as_default, as_meta, &pp_plist, DDS_INFINITY, vendorid, DDSI_CF_IMPLICITLY_CREATED_PROXYPP | DDSI_CF_PROXYPP_NO_SPDP, timestamp, seq);
+      (void) ddsi_new_proxy_participant (gv, ppguid, 0, &privguid, as_default, as_meta, &pp_plist, DDS_INFINITY, vendorid, DDSI_CF_IMPLICITLY_CREATED_PROXYPP | DDSI_CF_PROXYPP_NO_SPDP, timestamp, seq);
     }
   }
 

--- a/src/core/ddsi/src/ddsi_discovery_endpoint.c
+++ b/src/core/ddsi/src/ddsi_discovery_endpoint.c
@@ -562,9 +562,10 @@ void ddsi_handle_sedp_alive_endpoint (const struct ddsi_receiver_state *rst, dds
         ddsi_update_proxy_writer (pwr, seq, as, xqos, timestamp);
       else
       {
+        struct ddsi_proxy_writer *proxy_writer;
         /* not supposed to get here for built-in ones, so can determine the channel based on the transport priority */
         assert (!ddsi_is_builtin_entityid (datap->endpoint_guid.entityid, vendorid));
-        ddsi_new_proxy_writer (gv, &ppguid, &datap->endpoint_guid, as, datap, gv->user_dqueue, gv->xevents, timestamp, seq);
+        ddsi_new_proxy_writer (&proxy_writer, gv, &ppguid, &datap->endpoint_guid, as, datap, gv->user_dqueue, gv->xevents, timestamp, seq);
       }
     }
     else
@@ -573,10 +574,11 @@ void ddsi_handle_sedp_alive_endpoint (const struct ddsi_receiver_state *rst, dds
         ddsi_update_proxy_reader (prd, seq, as, xqos, timestamp);
       else
       {
+        struct ddsi_proxy_reader *proxy_reader;
 #ifdef DDS_HAS_SSM
-        ddsi_new_proxy_reader (gv, &ppguid, &datap->endpoint_guid, as, datap, timestamp, seq, ssm);
+        ddsi_new_proxy_reader (&proxy_reader, gv, &ppguid, &datap->endpoint_guid, as, datap, timestamp, seq, ssm);
 #else
-        ddsi_new_proxy_reader (gv, &ppguid, &datap->endpoint_guid, as, datap, timestamp, seq);
+        ddsi_new_proxy_reader (&proxy_reader, gv, &ppguid, &datap->endpoint_guid, as, datap, timestamp, seq);
 #endif
       }
     }

--- a/src/core/ddsi/src/ddsi_discovery_endpoint.c
+++ b/src/core/ddsi/src/ddsi_discovery_endpoint.c
@@ -263,30 +263,32 @@ static int sedp_write_endpoint_impl
 
 int ddsi_sedp_write_writer (struct ddsi_writer *wr)
 {
-  if ((!ddsi_is_builtin_entityid(wr->e.guid.entityid, DDSI_VENDORID_ECLIPSE)) && (!wr->e.onlylocal))
-  {
-    unsigned entityid = ddsi_determine_publication_writer(wr);
-    struct ddsi_writer *sedp_wr = ddsi_get_sedp_writer (wr->c.pp, entityid);
-    ddsi_security_info_t *security = NULL;
+  if (ddsi_is_builtin_entityid (wr->e.guid.entityid, DDSI_VENDORID_ECLIPSE) || wr->e.onlylocal)
+    return 0;
+
+  unsigned entityid = ddsi_determine_publication_writer (wr);
+  struct ddsi_writer *sedp_wr = ddsi_get_sedp_writer (wr->c.pp, entityid);
+  if (sedp_wr == NULL)
+    return 0;
+
 #ifdef DDS_HAS_SSM
-    struct ddsi_addrset *as = wr->ssm_as;
+  struct ddsi_addrset *as = wr->ssm_as;
 #else
-    struct ddsi_addrset *as = NULL;
+  struct ddsi_addrset *as = NULL;
 #endif
+
+  ddsi_security_info_t *security = NULL;
 #ifdef DDS_HAS_SECURITY
-    ddsi_security_info_t tmp;
-    if (ddsi_omg_get_writer_security_info (wr, &tmp))
-    {
-      security = &tmp;
-    }
+  ddsi_security_info_t tmp;
+  if (ddsi_omg_get_writer_security_info (wr, &tmp))
+    security = &tmp;
 #endif
+
 #ifdef DDS_HAS_TYPELIB
-    return sedp_write_endpoint_impl (sedp_wr, 1, &wr->e.guid, &wr->c, wr->xqos, as, security, wr->type);
+  return sedp_write_endpoint_impl (sedp_wr, 1, &wr->e.guid, &wr->c, wr->xqos, as, security, wr->type);
 #else
-    return sedp_write_endpoint_impl (sedp_wr, 1, &wr->e.guid, &wr->c, wr->xqos, as, security);
+  return sedp_write_endpoint_impl (sedp_wr, 1, &wr->e.guid, &wr->c, wr->xqos, as, security);
 #endif
-  }
-  return 0;
 }
 
 int ddsi_sedp_write_reader (struct ddsi_reader *rd)
@@ -294,8 +296,11 @@ int ddsi_sedp_write_reader (struct ddsi_reader *rd)
   if (ddsi_is_builtin_entityid (rd->e.guid.entityid, DDSI_VENDORID_ECLIPSE) || rd->e.onlylocal)
     return 0;
 
-  unsigned entityid = ddsi_determine_subscription_writer(rd);
+  unsigned entityid = ddsi_determine_subscription_writer (rd);
   struct ddsi_writer *sedp_wr = ddsi_get_sedp_writer (rd->c.pp, entityid);
+  if (sedp_wr == NULL)
+    return 0;
+
   ddsi_security_info_t *security = NULL;
   struct ddsi_addrset *as = NULL;
 #ifdef DDS_HAS_NETWORK_PARTITIONS
@@ -333,32 +338,36 @@ int ddsi_sedp_write_reader (struct ddsi_reader *rd)
 
 int ddsi_sedp_dispose_unregister_writer (struct ddsi_writer *wr)
 {
-  if ((!ddsi_is_builtin_entityid(wr->e.guid.entityid, DDSI_VENDORID_ECLIPSE)) && (!wr->e.onlylocal))
-  {
-    unsigned entityid = ddsi_determine_publication_writer(wr);
-    struct ddsi_writer *sedp_wr = ddsi_get_sedp_writer (wr->c.pp, entityid);
+  if (ddsi_is_builtin_entityid (wr->e.guid.entityid, DDSI_VENDORID_ECLIPSE) || wr->e.onlylocal)
+    return 0;
+
+  unsigned entityid = ddsi_determine_publication_writer (wr);
+  struct ddsi_writer *sedp_wr = ddsi_get_sedp_writer (wr->c.pp, entityid);
+  if (sedp_wr == NULL)
+    return 0;
+
 #ifdef DDS_HAS_TYPELIB
-    return sedp_write_endpoint_impl (sedp_wr, 0, &wr->e.guid, NULL, NULL, NULL, NULL, NULL);
+  return sedp_write_endpoint_impl (sedp_wr, 0, &wr->e.guid, NULL, NULL, NULL, NULL, NULL);
 #else
-    return sedp_write_endpoint_impl (sedp_wr, 0, &wr->e.guid, NULL, NULL, NULL, NULL);
+  return sedp_write_endpoint_impl (sedp_wr, 0, &wr->e.guid, NULL, NULL, NULL, NULL);
 #endif
-  }
-  return 0;
 }
 
 int ddsi_sedp_dispose_unregister_reader (struct ddsi_reader *rd)
 {
-  if ((!ddsi_is_builtin_entityid(rd->e.guid.entityid, DDSI_VENDORID_ECLIPSE)) && (!rd->e.onlylocal))
-  {
-    unsigned entityid = ddsi_determine_subscription_writer(rd);
-    struct ddsi_writer *sedp_wr = ddsi_get_sedp_writer (rd->c.pp, entityid);
+  if (ddsi_is_builtin_entityid (rd->e.guid.entityid, DDSI_VENDORID_ECLIPSE) || rd->e.onlylocal)
+    return 0;
+
+  unsigned entityid = ddsi_determine_subscription_writer (rd);
+  struct ddsi_writer *sedp_wr = ddsi_get_sedp_writer (rd->c.pp, entityid);
+  if (sedp_wr == NULL)
+    return 0;
+
 #ifdef DDS_HAS_TYPELIB
-    return sedp_write_endpoint_impl (sedp_wr, 0, &rd->e.guid, NULL, NULL, NULL, NULL, NULL);
+  return sedp_write_endpoint_impl (sedp_wr, 0, &rd->e.guid, NULL, NULL, NULL, NULL, NULL);
 #else
-    return sedp_write_endpoint_impl (sedp_wr, 0, &rd->e.guid, NULL, NULL, NULL, NULL);
+  return sedp_write_endpoint_impl (sedp_wr, 0, &rd->e.guid, NULL, NULL, NULL, NULL);
 #endif
-  }
-  return 0;
 }
 
 static const char *durability_to_string (dds_durability_kind_t k)

--- a/src/core/ddsi/src/ddsi_discovery_spdp.c
+++ b/src/core/ddsi/src/ddsi_discovery_spdp.c
@@ -853,7 +853,8 @@ static int handle_spdp_alive (const struct ddsi_receiver_state *rst, ddsi_seqno_
 
   maybe_add_pp_as_meta_to_as_disc (gv, as_meta);
 
-  if (!ddsi_new_proxy_participant (gv, &datap->participant_guid, builtin_endpoint_set, &privileged_pp_guid, as_default, as_meta, datap, lease_duration, rst->vendor, custom_flags, timestamp, seq))
+  struct ddsi_proxy_participant *proxy_participant;
+  if (!ddsi_new_proxy_participant (&proxy_participant, gv, &datap->participant_guid, builtin_endpoint_set, &privileged_pp_guid, as_default, as_meta, datap, lease_duration, rst->vendor, custom_flags, timestamp, seq))
   {
     /* If no proxy participant was created, don't respond */
     return 0;

--- a/src/core/ddsi/src/ddsi_participant.c
+++ b/src/core/ddsi/src/ddsi_participant.c
@@ -771,7 +771,7 @@ void ddsi_unref_participant (struct ddsi_participant *pp, const struct ddsi_guid
   }
 }
 
-static dds_return_t new_participant_guid (ddsi_guid_t *ppguid, struct ddsi_domaingv *gv, unsigned flags, const ddsi_plist_t *plist)
+dds_return_t ddsi_new_participant (ddsi_guid_t *ppguid, struct ddsi_domaingv *gv, unsigned flags, const ddsi_plist_t *plist)
 {
   struct ddsi_participant *pp;
   ddsi_guid_t subguid, group_guid;
@@ -1013,17 +1013,17 @@ new_pp_err:
   return ret;
 }
 
-dds_return_t ddsi_new_participant (ddsi_guid_t *p_ppguid, struct ddsi_domaingv *gv, unsigned flags, const ddsi_plist_t *plist)
+void ddsi_generate_participant_guid (ddsi_guid_t *ppguid, struct ddsi_domaingv *gv)
 {
   union { uint64_t u64; uint32_t u32[2]; } u;
   u.u32[0] = gv->ppguid_base.prefix.u[1];
   u.u32[1] = gv->ppguid_base.prefix.u[2];
   u.u64 += ddsi_iid_gen ();
-  p_ppguid->prefix.u[0] = gv->ppguid_base.prefix.u[0];
-  p_ppguid->prefix.u[1] = u.u32[0];
-  p_ppguid->prefix.u[2] = u.u32[1];
-  p_ppguid->entityid.u = DDSI_ENTITYID_PARTICIPANT;
-  return new_participant_guid (p_ppguid, gv, flags, plist);
+
+  ppguid->prefix.u[0] = gv->ppguid_base.prefix.u[0];
+  ppguid->prefix.u[1] = u.u32[0];
+  ppguid->prefix.u[2] = u.u32[1];
+  ppguid->entityid.u = DDSI_ENTITYID_PARTICIPANT;
 }
 
 void ddsi_update_participant_plist (struct ddsi_participant *pp, const ddsi_plist_t *plist)

--- a/src/core/ddsi/src/ddsi_participant.c
+++ b/src/core/ddsi/src/ddsi_participant.c
@@ -198,7 +198,7 @@ static void add_security_builtin_endpoints (struct ddsi_participant *pp, ddsi_gu
 
     subguid->entityid = ddsi_to_entityid (DDSI_ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_WRITER);
     wrinfo = dds_whc_make_wrinfo (NULL, &gv->builtin_endpoint_xqos_wr);
-    ddsi_new_writer_guid (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_PARTICIPANT_SECURE_NAME, gv->spdp_secure_type, &gv->builtin_endpoint_xqos_wr, dds_whc_new(gv, wrinfo), NULL, NULL, NULL);
+    ddsi_new_writer (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_PARTICIPANT_SECURE_NAME, gv->spdp_secure_type, &gv->builtin_endpoint_xqos_wr, dds_whc_new(gv, wrinfo), NULL, NULL, NULL);
     dds_whc_free_wrinfo (wrinfo);
     /* But we need the as_disc address set for SPDP, because we need to
        send it to everyone regardless of the existence of readers. */
@@ -207,28 +207,28 @@ static void add_security_builtin_endpoints (struct ddsi_participant *pp, ddsi_gu
 
     subguid->entityid = ddsi_to_entityid (DDSI_ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_MESSAGE_WRITER);
     wrinfo = dds_whc_make_wrinfo (NULL, &gv->builtin_stateless_xqos_wr);
-    ddsi_new_writer_guid (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_PARTICIPANT_STATELESS_MESSAGE_NAME, gv->pgm_stateless_type, &gv->builtin_stateless_xqos_wr, dds_whc_new(gv, wrinfo), NULL, NULL, NULL);
+    ddsi_new_writer (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_PARTICIPANT_STATELESS_MESSAGE_NAME, gv->pgm_stateless_type, &gv->builtin_stateless_xqos_wr, dds_whc_new(gv, wrinfo), NULL, NULL, NULL);
     dds_whc_free_wrinfo (wrinfo);
     pp->bes |= DDSI_BUILTIN_ENDPOINT_PARTICIPANT_STATELESS_MESSAGE_ANNOUNCER;
 
     subguid->entityid = ddsi_to_entityid (DDSI_ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER);
     wrinfo = dds_whc_make_wrinfo (NULL, &gv->builtin_secure_volatile_xqos_wr);
-    ddsi_new_writer_guid (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_PARTICIPANT_VOLATILE_MESSAGE_SECURE_NAME, gv->pgm_volatile_type, &gv->builtin_secure_volatile_xqos_wr, dds_whc_new(gv, wrinfo), NULL, NULL, NULL);
+    ddsi_new_writer (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_PARTICIPANT_VOLATILE_MESSAGE_SECURE_NAME, gv->pgm_volatile_type, &gv->builtin_secure_volatile_xqos_wr, dds_whc_new(gv, wrinfo), NULL, NULL, NULL);
     dds_whc_free_wrinfo (wrinfo);
     pp->bes |= DDSI_BUILTIN_ENDPOINT_PARTICIPANT_VOLATILE_SECURE_ANNOUNCER;
 
     wrinfo = dds_whc_make_wrinfo (NULL, &gv->builtin_endpoint_xqos_wr);
 
     subguid->entityid = ddsi_to_entityid (DDSI_ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER);
-    ddsi_new_writer_guid (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_PARTICIPANT_MESSAGE_SECURE_NAME, gv->pmd_secure_type, &gv->builtin_endpoint_xqos_wr, dds_whc_new(gv, wrinfo), NULL, NULL, NULL);
+    ddsi_new_writer (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_PARTICIPANT_MESSAGE_SECURE_NAME, gv->pmd_secure_type, &gv->builtin_endpoint_xqos_wr, dds_whc_new(gv, wrinfo), NULL, NULL, NULL);
     pp->bes |= DDSI_BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_SECURE_ANNOUNCER;
 
     subguid->entityid = ddsi_to_entityid (DDSI_ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER);
-    ddsi_new_writer_guid (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_PUBLICATION_SECURE_NAME, gv->sedp_writer_secure_type, &gv->builtin_endpoint_xqos_wr, dds_whc_new(gv, wrinfo), NULL, NULL, NULL);
+    ddsi_new_writer (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_PUBLICATION_SECURE_NAME, gv->sedp_writer_secure_type, &gv->builtin_endpoint_xqos_wr, dds_whc_new(gv, wrinfo), NULL, NULL, NULL);
     pp->bes |= DDSI_BUILTIN_ENDPOINT_PUBLICATION_MESSAGE_SECURE_ANNOUNCER;
 
     subguid->entityid = ddsi_to_entityid (DDSI_ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER);
-    ddsi_new_writer_guid (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_SUBSCRIPTION_SECURE_NAME, gv->sedp_reader_secure_type, &gv->builtin_endpoint_xqos_wr, dds_whc_new(gv, wrinfo), NULL, NULL, NULL);
+    ddsi_new_writer (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_SUBSCRIPTION_SECURE_NAME, gv->sedp_reader_secure_type, &gv->builtin_endpoint_xqos_wr, dds_whc_new(gv, wrinfo), NULL, NULL, NULL);
     pp->bes |= DDSI_BUILTIN_ENDPOINT_SUBSCRIPTION_MESSAGE_SECURE_ANNOUNCER;
 
     dds_whc_free_wrinfo (wrinfo);
@@ -237,11 +237,11 @@ static void add_security_builtin_endpoints (struct ddsi_participant *pp, ddsi_gu
   if (add_readers)
   {
     subguid->entityid = ddsi_to_entityid (DDSI_ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER);
-    ddsi_new_reader_guid (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_SUBSCRIPTION_SECURE_NAME, gv->sedp_reader_secure_type, &gv->builtin_endpoint_xqos_rd, NULL, NULL, NULL, NULL);
+    ddsi_new_reader (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_SUBSCRIPTION_SECURE_NAME, gv->sedp_reader_secure_type, &gv->builtin_endpoint_xqos_rd, NULL, NULL, NULL, NULL);
     pp->bes |= DDSI_BUILTIN_ENDPOINT_SUBSCRIPTION_MESSAGE_SECURE_DETECTOR;
 
     subguid->entityid = ddsi_to_entityid (DDSI_ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_READER);
-    ddsi_new_reader_guid (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_PUBLICATION_SECURE_NAME, gv->sedp_writer_secure_type, &gv->builtin_endpoint_xqos_rd, NULL, NULL, NULL, NULL);
+    ddsi_new_reader (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_PUBLICATION_SECURE_NAME, gv->sedp_writer_secure_type, &gv->builtin_endpoint_xqos_rd, NULL, NULL, NULL, NULL);
     pp->bes |= DDSI_BUILTIN_ENDPOINT_PUBLICATION_MESSAGE_SECURE_DETECTOR;
   }
 
@@ -250,19 +250,19 @@ static void add_security_builtin_endpoints (struct ddsi_participant *pp, ddsi_gu
    * besmode flag setting, because all participant do require authentication.
    */
   subguid->entityid = ddsi_to_entityid (DDSI_ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_READER);
-  ddsi_new_reader_guid (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_PARTICIPANT_SECURE_NAME, gv->spdp_secure_type, &gv->builtin_endpoint_xqos_rd, NULL, NULL, NULL, NULL);
+  ddsi_new_reader (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_PARTICIPANT_SECURE_NAME, gv->spdp_secure_type, &gv->builtin_endpoint_xqos_rd, NULL, NULL, NULL, NULL);
   pp->bes |= DDSI_DISC_BUILTIN_ENDPOINT_PARTICIPANT_SECURE_DETECTOR;
 
   subguid->entityid = ddsi_to_entityid (DDSI_ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_READER);
-  ddsi_new_reader_guid (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_PARTICIPANT_VOLATILE_MESSAGE_SECURE_NAME, gv->pgm_volatile_type, &gv->builtin_secure_volatile_xqos_rd, NULL, NULL, NULL, NULL);
+  ddsi_new_reader (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_PARTICIPANT_VOLATILE_MESSAGE_SECURE_NAME, gv->pgm_volatile_type, &gv->builtin_secure_volatile_xqos_rd, NULL, NULL, NULL, NULL);
   pp->bes |= DDSI_BUILTIN_ENDPOINT_PARTICIPANT_VOLATILE_SECURE_DETECTOR;
 
   subguid->entityid = ddsi_to_entityid (DDSI_ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_MESSAGE_READER);
-  ddsi_new_reader_guid (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_PARTICIPANT_STATELESS_MESSAGE_NAME, gv->pgm_stateless_type, &gv->builtin_stateless_xqos_rd, NULL, NULL, NULL, NULL);
+  ddsi_new_reader (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_PARTICIPANT_STATELESS_MESSAGE_NAME, gv->pgm_stateless_type, &gv->builtin_stateless_xqos_rd, NULL, NULL, NULL, NULL);
   pp->bes |= DDSI_BUILTIN_ENDPOINT_PARTICIPANT_STATELESS_MESSAGE_DETECTOR;
 
   subguid->entityid = ddsi_to_entityid (DDSI_ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER);
-  ddsi_new_reader_guid (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_PARTICIPANT_MESSAGE_SECURE_NAME, gv->pmd_secure_type, &gv->builtin_endpoint_xqos_rd, NULL, NULL, NULL, NULL);
+  ddsi_new_reader (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_PARTICIPANT_MESSAGE_SECURE_NAME, gv->pmd_secure_type, &gv->builtin_endpoint_xqos_rd, NULL, NULL, NULL, NULL);
   pp->bes |= DDSI_BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_SECURE_DETECTOR;
 }
 
@@ -312,16 +312,16 @@ static void add_builtin_endpoints (struct ddsi_participant *pp, ddsi_guid_t *sub
 
     /* SEDP writers: */
     subguid->entityid = ddsi_to_entityid (DDSI_ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_WRITER);
-    ddsi_new_writer_guid (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_SUBSCRIPTION_NAME, gv->sedp_reader_type, &gv->builtin_endpoint_xqos_wr, dds_whc_new(gv, wrinfo_tl), NULL, NULL, NULL);
+    ddsi_new_writer (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_SUBSCRIPTION_NAME, gv->sedp_reader_type, &gv->builtin_endpoint_xqos_wr, dds_whc_new(gv, wrinfo_tl), NULL, NULL, NULL);
     pp->bes |= DDSI_DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_ANNOUNCER;
 
     subguid->entityid = ddsi_to_entityid (DDSI_ENTITYID_SEDP_BUILTIN_PUBLICATIONS_WRITER);
-    ddsi_new_writer_guid (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_PUBLICATION_NAME, gv->sedp_writer_type, &gv->builtin_endpoint_xqos_wr, dds_whc_new(gv, wrinfo_tl), NULL, NULL, NULL);
+    ddsi_new_writer (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_PUBLICATION_NAME, gv->sedp_writer_type, &gv->builtin_endpoint_xqos_wr, dds_whc_new(gv, wrinfo_tl), NULL, NULL, NULL);
     pp->bes |= DDSI_DISC_BUILTIN_ENDPOINT_PUBLICATION_ANNOUNCER;
 
     /* PMD writer: */
     subguid->entityid = ddsi_to_entityid (DDSI_ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_WRITER);
-    ddsi_new_writer_guid (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_PARTICIPANT_MESSAGE_NAME, gv->pmd_type, &gv->builtin_endpoint_xqos_wr, dds_whc_new(gv, wrinfo_tl), NULL, NULL, NULL);
+    ddsi_new_writer (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_PARTICIPANT_MESSAGE_NAME, gv->pmd_type, &gv->builtin_endpoint_xqos_wr, dds_whc_new(gv, wrinfo_tl), NULL, NULL, NULL);
     pp->bes |= DDSI_BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_WRITER;
 
 #ifdef DDS_HAS_TOPIC_DISCOVERY
@@ -329,7 +329,7 @@ static void add_builtin_endpoints (struct ddsi_participant *pp, ddsi_guid_t *sub
     {
       /* SEDP topic writer: */
       subguid->entityid = ddsi_to_entityid (DDSI_ENTITYID_SEDP_BUILTIN_TOPIC_WRITER);
-      ddsi_new_writer_guid (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_TOPIC_NAME, gv->sedp_topic_type, &gv->builtin_endpoint_xqos_wr, dds_whc_new(gv, wrinfo_tl), NULL, NULL, NULL);
+      ddsi_new_writer (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_TOPIC_NAME, gv->sedp_topic_type, &gv->builtin_endpoint_xqos_wr, dds_whc_new(gv, wrinfo_tl), NULL, NULL, NULL);
       pp->bes |= DDSI_DISC_BUILTIN_ENDPOINT_TOPICS_ANNOUNCER;
     }
 #endif
@@ -339,11 +339,11 @@ static void add_builtin_endpoints (struct ddsi_participant *pp, ddsi_guid_t *sub
     struct ddsi_writer *wr_tl_req, *wr_tl_reply;
 
     subguid->entityid = ddsi_to_entityid (DDSI_ENTITYID_TL_SVC_BUILTIN_REQUEST_WRITER);
-    ddsi_new_writer_guid (&wr_tl_req, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_TYPELOOKUP_REQUEST_NAME, gv->tl_svc_request_type, &gv->builtin_volatile_xqos_wr, dds_whc_new(gv, wrinfo_vol), NULL, NULL, NULL);
+    ddsi_new_writer (&wr_tl_req, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_TYPELOOKUP_REQUEST_NAME, gv->tl_svc_request_type, &gv->builtin_volatile_xqos_wr, dds_whc_new(gv, wrinfo_vol), NULL, NULL, NULL);
     pp->bes |= DDSI_BUILTIN_ENDPOINT_TL_SVC_REQUEST_DATA_WRITER;
 
     subguid->entityid = ddsi_to_entityid (DDSI_ENTITYID_TL_SVC_BUILTIN_REPLY_WRITER);
-    ddsi_new_writer_guid (&wr_tl_reply, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_TYPELOOKUP_REPLY_NAME, gv->tl_svc_reply_type, &gv->builtin_volatile_xqos_wr, dds_whc_new(gv, wrinfo_vol), NULL, NULL, NULL);
+    ddsi_new_writer (&wr_tl_reply, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_TYPELOOKUP_REPLY_NAME, gv->tl_svc_reply_type, &gv->builtin_volatile_xqos_wr, dds_whc_new(gv, wrinfo_vol), NULL, NULL, NULL);
     pp->bes |= DDSI_BUILTIN_ENDPOINT_TL_SVC_REPLY_DATA_WRITER;
 
     /* The built-in type lookup writers are keep-all writers, because the topic is keyless (using DDS-RPC request
@@ -364,21 +364,21 @@ static void add_builtin_endpoints (struct ddsi_participant *pp, ddsi_guid_t *sub
   {
     /* SPDP reader: */
     subguid->entityid = ddsi_to_entityid (DDSI_ENTITYID_SPDP_BUILTIN_PARTICIPANT_READER);
-    ddsi_new_reader_guid (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_PARTICIPANT_NAME, gv->spdp_type, &gv->spdp_endpoint_xqos, NULL, NULL, NULL, NULL);
+    ddsi_new_reader (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_PARTICIPANT_NAME, gv->spdp_type, &gv->spdp_endpoint_xqos, NULL, NULL, NULL, NULL);
     pp->bes |= DDSI_DISC_BUILTIN_ENDPOINT_PARTICIPANT_DETECTOR;
 
     /* SEDP readers: */
     subguid->entityid = ddsi_to_entityid (DDSI_ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_READER);
-    ddsi_new_reader_guid (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_SUBSCRIPTION_NAME, gv->sedp_reader_type, &gv->builtin_endpoint_xqos_rd, NULL, NULL, NULL, NULL);
+    ddsi_new_reader (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_SUBSCRIPTION_NAME, gv->sedp_reader_type, &gv->builtin_endpoint_xqos_rd, NULL, NULL, NULL, NULL);
     pp->bes |= DDSI_DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_DETECTOR;
 
     subguid->entityid = ddsi_to_entityid (DDSI_ENTITYID_SEDP_BUILTIN_PUBLICATIONS_READER);
-    ddsi_new_reader_guid (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_PUBLICATION_NAME, gv->sedp_writer_type, &gv->builtin_endpoint_xqos_rd, NULL, NULL, NULL, NULL);
+    ddsi_new_reader (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_PUBLICATION_NAME, gv->sedp_writer_type, &gv->builtin_endpoint_xqos_rd, NULL, NULL, NULL, NULL);
     pp->bes |= DDSI_DISC_BUILTIN_ENDPOINT_PUBLICATION_DETECTOR;
 
     /* PMD reader: */
     subguid->entityid = ddsi_to_entityid (DDSI_ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_READER);
-    ddsi_new_reader_guid (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_PARTICIPANT_MESSAGE_NAME, gv->pmd_type, &gv->builtin_endpoint_xqos_rd, NULL, NULL, NULL, NULL);
+    ddsi_new_reader (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_PARTICIPANT_MESSAGE_NAME, gv->pmd_type, &gv->builtin_endpoint_xqos_rd, NULL, NULL, NULL, NULL);
     pp->bes |= DDSI_BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_READER;
 
 #ifdef DDS_HAS_TOPIC_DISCOVERY
@@ -386,18 +386,18 @@ static void add_builtin_endpoints (struct ddsi_participant *pp, ddsi_guid_t *sub
     {
       /* SEDP topic reader: */
       subguid->entityid = ddsi_to_entityid (DDSI_ENTITYID_SEDP_BUILTIN_TOPIC_READER);
-      ddsi_new_reader_guid (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_TOPIC_NAME, gv->sedp_topic_type, &gv->builtin_endpoint_xqos_rd, NULL, NULL, NULL, NULL);
+      ddsi_new_reader (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_TOPIC_NAME, gv->sedp_topic_type, &gv->builtin_endpoint_xqos_rd, NULL, NULL, NULL, NULL);
       pp->bes |= DDSI_DISC_BUILTIN_ENDPOINT_TOPICS_DETECTOR;
     }
 #endif
 #ifdef DDS_HAS_TYPE_DISCOVERY
     /* TypeLookup readers: */
     subguid->entityid = ddsi_to_entityid (DDSI_ENTITYID_TL_SVC_BUILTIN_REQUEST_READER);
-    ddsi_new_reader_guid (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_TYPELOOKUP_REQUEST_NAME, gv->tl_svc_request_type, &gv->builtin_volatile_xqos_rd, NULL, NULL, NULL, NULL);
+    ddsi_new_reader (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_TYPELOOKUP_REQUEST_NAME, gv->tl_svc_request_type, &gv->builtin_volatile_xqos_rd, NULL, NULL, NULL, NULL);
     pp->bes |= DDSI_BUILTIN_ENDPOINT_TL_SVC_REQUEST_DATA_READER;
 
     subguid->entityid = ddsi_to_entityid (DDSI_ENTITYID_TL_SVC_BUILTIN_REPLY_READER);
-    ddsi_new_reader_guid (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_TYPELOOKUP_REPLY_NAME, gv->tl_svc_reply_type, &gv->builtin_volatile_xqos_rd, NULL, NULL, NULL, NULL);
+    ddsi_new_reader (NULL, subguid, group_guid, pp, DDS_BUILTIN_TOPIC_TYPELOOKUP_REPLY_NAME, gv->tl_svc_reply_type, &gv->builtin_volatile_xqos_rd, NULL, NULL, NULL, NULL);
     pp->bes |= DDSI_BUILTIN_ENDPOINT_TL_SVC_REPLY_DATA_READER;
 #endif
   }
@@ -906,7 +906,7 @@ dds_return_t ddsi_new_participant (ddsi_guid_t *ppguid, struct ddsi_domaingv *gv
   {
     subguid.entityid = ddsi_to_entityid (DDSI_ENTITYID_SPDP_BUILTIN_PARTICIPANT_WRITER);
     wrinfo = dds_whc_make_wrinfo (NULL, &gv->spdp_endpoint_xqos);
-    ddsi_new_writer_guid (NULL, &subguid, &group_guid, pp, DDS_BUILTIN_TOPIC_PARTICIPANT_NAME, gv->spdp_type, &gv->spdp_endpoint_xqos, dds_whc_new(gv, wrinfo), NULL, NULL, NULL);
+    ddsi_new_writer (NULL, &subguid, &group_guid, pp, DDS_BUILTIN_TOPIC_PARTICIPANT_NAME, gv->spdp_type, &gv->spdp_endpoint_xqos, dds_whc_new(gv, wrinfo), NULL, NULL, NULL);
     dds_whc_free_wrinfo (wrinfo);
     /* But we need the as_disc address set for SPDP, because we need to
        send it to everyone regardless of the existence of readers. */

--- a/src/core/ddsi/src/ddsi_pmd.c
+++ b/src/core/ddsi/src/ddsi_pmd.c
@@ -63,22 +63,23 @@ void ddsi_write_pmd_message (struct ddsi_thread_state * const thrst, struct ddsi
   struct ddsi_serdata *serdata;
   struct ddsi_tkmap_instance *tk;
 
-  if ((wr = ddsi_get_builtin_writer (pp, DDSI_ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_WRITER)) == NULL)
+  if (ddsi_get_builtin_writer (pp, DDSI_ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_WRITER, &wr) != DDS_RETCODE_OK)
   {
     GVTRACE ("ddsi_write_pmd_message ("PGUIDFMT") - builtin pmd writer not found\n", PGUID (pp->e.guid));
-    return;
   }
+  else if (wr != NULL)
+  {
+    pmd.participantGuidPrefix = pp->e.guid.prefix;
+    pmd.kind = pmd_kind;
+    pmd.value.length = (uint32_t) sizeof (data);
+    pmd.value.value = data;
+    serdata = ddsi_serdata_from_sample (gv->pmd_type, SDK_DATA, &pmd);
+    serdata->timestamp = ddsrt_time_wallclock ();
 
-  pmd.participantGuidPrefix = pp->e.guid.prefix;
-  pmd.kind = pmd_kind;
-  pmd.value.length = (uint32_t) sizeof (data);
-  pmd.value.value = data;
-  serdata = ddsi_serdata_from_sample (gv->pmd_type, SDK_DATA, &pmd);
-  serdata->timestamp = ddsrt_time_wallclock ();
-
-  tk = ddsi_tkmap_lookup_instance_ref (gv->m_tkmap, serdata);
-  ddsi_write_sample_nogc (thrst, xp, wr, serdata, tk);
-  ddsi_tkmap_instance_unref (gv->m_tkmap, tk);
+    tk = ddsi_tkmap_lookup_instance_ref (gv->m_tkmap, serdata);
+    ddsi_write_sample_nogc (thrst, xp, wr, serdata, tk);
+    ddsi_tkmap_instance_unref (gv->m_tkmap, tk);
+  }
 #undef PMD_DATA_LENGTH
 }
 

--- a/src/core/ddsi/src/ddsi_portmapping.c
+++ b/src/core/ddsi/src/ddsi_portmapping.c
@@ -18,7 +18,7 @@
 // for a static assert on DDSI_TRAN_RANDOM_PORT_NUMBER
 #include "ddsi__tran.h"
 
-static bool get_port_int (uint32_t *port, const struct ddsi_portmapping *map, enum ddsi_port which, uint32_t domain_id, int32_t participant_index, char *str_if_overflow, size_t strsize)
+bool ddsi_get_port_int (uint32_t *port, const struct ddsi_portmapping *map, enum ddsi_port which, uint32_t domain_id, int32_t participant_index, char *str_if_overflow, size_t strsize)
 {
   uint32_t off = UINT32_MAX, ppidx = UINT32_MAX;
 
@@ -109,7 +109,7 @@ bool ddsi_valid_portmapping (const struct ddsi_config *config, int32_t participa
   int n = snprintf (msg, msgsize, "port number(s) of out range:");
   size_t pos = (n >= 0 && (size_t) n <= msgsize) ? (size_t) n : msgsize;
   do {
-    if (!get_port_int (&dummy_port, &config->ports, which, config->extDomainId.value, participant_index, str, sizeof (str)))
+    if (!ddsi_get_port_int (&dummy_port, &config->ports, which, config->extDomainId.value, participant_index, str, sizeof (str)))
     {
       n = snprintf (msg + pos, msgsize - pos, "%s %s %s", ok ? "" : ",", portname (which), str);
       if (n >= 0 && (size_t) n <= msgsize - pos)
@@ -125,7 +125,7 @@ uint32_t ddsi_get_port (const struct ddsi_config *config, enum ddsi_port which, 
   /* Not supposed to come here if port mapping is invalid */
   uint32_t port;
   char str[32];
-  bool ok = get_port_int (&port, &config->ports, which, config->extDomainId.value, participant_index, str, sizeof (str));
+  bool ok = ddsi_get_port_int (&port, &config->ports, which, config->extDomainId.value, participant_index, str, sizeof (str));
   assert (ok);
   (void) ok;
   return port;

--- a/src/core/ddsi/src/ddsi_proxy_endpoint.c
+++ b/src/core/ddsi/src/ddsi_proxy_endpoint.c
@@ -227,7 +227,7 @@ static enum ddsi_reorder_mode get_proxy_writer_reorder_mode(const ddsi_entityid_
   return DDSI_REORDER_MODE_MONOTONICALLY_INCREASING;
 }
 
-int ddsi_new_proxy_writer (struct ddsi_domaingv *gv, const struct ddsi_guid *ppguid, const struct ddsi_guid *guid, struct ddsi_addrset *as, const ddsi_plist_t *plist, struct ddsi_dqueue *dqueue, struct ddsi_xeventq *evq, ddsrt_wctime_t timestamp, ddsi_seqno_t seq)
+int ddsi_new_proxy_writer (struct ddsi_proxy_writer **proxy_writer, struct ddsi_domaingv *gv, const struct ddsi_guid *ppguid, const struct ddsi_guid *guid, struct ddsi_addrset *as, const ddsi_plist_t *plist, struct ddsi_dqueue *dqueue, struct ddsi_xeventq *evq, ddsrt_wctime_t timestamp, ddsi_seqno_t seq)
 {
   struct ddsi_proxy_participant *proxypp;
   struct ddsi_proxy_writer *pwr;
@@ -236,6 +236,7 @@ int ddsi_new_proxy_writer (struct ddsi_domaingv *gv, const struct ddsi_guid *ppg
   enum ddsi_reorder_mode reorder_mode;
   int ret;
 
+  assert (proxy_writer);
   assert (ddsi_is_writer_entityid (guid->entityid));
   assert (ddsi_entidx_lookup_proxy_writer_guid (gv->entity_index, guid) == NULL);
 
@@ -349,6 +350,7 @@ int ddsi_new_proxy_writer (struct ddsi_domaingv *gv, const struct ddsi_guid *ppg
   pwr->local_matching_inprogress = 0;
   ddsrt_mutex_unlock (&pwr->e.lock);
 
+  *proxy_writer = pwr;
   return 0;
 }
 
@@ -569,7 +571,7 @@ int ddsi_proxy_writer_set_notalive (struct ddsi_proxy_writer *pwr, bool notify)
 
 /* PROXY-READER ----------------------------------------------------- */
 
-int ddsi_new_proxy_reader (struct ddsi_domaingv *gv, const struct ddsi_guid *ppguid, const struct ddsi_guid *guid, struct ddsi_addrset *as, const ddsi_plist_t *plist, ddsrt_wctime_t timestamp, ddsi_seqno_t seq
+int ddsi_new_proxy_reader (struct ddsi_proxy_reader **proxy_reader, struct ddsi_domaingv *gv, const struct ddsi_guid *ppguid, const struct ddsi_guid *guid, struct ddsi_addrset *as, const ddsi_plist_t *plist, ddsrt_wctime_t timestamp, ddsi_seqno_t seq
 #ifdef DDS_HAS_SSM
 , int favours_ssm
 #endif
@@ -580,6 +582,7 @@ int ddsi_new_proxy_reader (struct ddsi_domaingv *gv, const struct ddsi_guid *ppg
   ddsrt_mtime_t tnow = ddsrt_time_monotonic ();
   int ret;
 
+  assert (proxy_reader);
   assert (!ddsi_is_writer_entityid (guid->entityid));
   assert (ddsi_entidx_lookup_proxy_reader_guid (gv->entity_index, guid) == NULL);
 
@@ -627,6 +630,7 @@ int ddsi_new_proxy_reader (struct ddsi_domaingv *gv, const struct ddsi_guid *ppg
   ddsrt_mutex_unlock (&prd->e.lock);
 
   ddsi_match_proxy_reader_with_writers (prd, tnow);
+  *proxy_reader = prd;
   return DDS_RETCODE_OK;
 }
 

--- a/src/core/ddsi/src/ddsi_proxy_participant.c
+++ b/src/core/ddsi/src/ddsi_proxy_participant.c
@@ -115,14 +115,18 @@ static void create_proxy_builtin_endpoint_impl (struct ddsi_domaingv *gv, ddsrt_
   plist->qos.topic_name = dds_string_dup (topic_name);
   plist->qos.present |= DDSI_QP_TOPIC_NAME;
   if (ddsi_is_writer_entityid (ep_guid->entityid))
-    ddsi_new_proxy_writer (gv, ppguid, ep_guid, proxypp->as_meta, plist, gv->builtins_dqueue, gv->xevents, timestamp, 0);
+  {
+    struct ddsi_proxy_writer *proxy_writer;
+    ddsi_new_proxy_writer (&proxy_writer, gv, ppguid, ep_guid, proxypp->as_meta, plist, gv->builtins_dqueue, gv->xevents, timestamp, 0);
+  }
   else
   {
+    struct ddsi_proxy_reader *proxy_reader;
 #ifdef DDS_HAS_SSM
     const int ssm = ddsi_addrset_contains_ssm (gv, proxypp->as_meta);
-    ddsi_new_proxy_reader (gv, ppguid, ep_guid, proxypp->as_meta, plist, timestamp, 0, ssm);
+    ddsi_new_proxy_reader (&proxy_reader, gv, ppguid, ep_guid, proxypp->as_meta, plist, timestamp, 0, ssm);
 #else
-    ddsi_new_proxy_reader (gv, ppguid, ep_guid, proxypp->as_meta, plist, timestamp, 0);
+    ddsi_new_proxy_reader (&proxy_reader, gv, ppguid, ep_guid, proxypp->as_meta, plist, timestamp, 0);
 #endif
   }
 }

--- a/src/core/ddsi/src/ddsi_proxy_participant.c
+++ b/src/core/ddsi/src/ddsi_proxy_participant.c
@@ -329,7 +329,7 @@ static void free_proxy_participant (struct ddsi_proxy_participant *proxypp)
   ddsrt_free (proxypp);
 }
 
-bool ddsi_new_proxy_participant (struct ddsi_domaingv *gv, const struct ddsi_guid *ppguid, uint32_t bes, const struct ddsi_guid *privileged_pp_guid, struct ddsi_addrset *as_default, struct ddsi_addrset *as_meta, const ddsi_plist_t *plist, dds_duration_t tlease_dur, ddsi_vendorid_t vendor, unsigned custom_flags, ddsrt_wctime_t timestamp, ddsi_seqno_t seq)
+bool ddsi_new_proxy_participant (struct ddsi_proxy_participant **proxy_participant, struct ddsi_domaingv *gv, const struct ddsi_guid *ppguid, uint32_t bes, const struct ddsi_guid *privileged_pp_guid, struct ddsi_addrset *as_default, struct ddsi_addrset *as_meta, const ddsi_plist_t *plist, dds_duration_t tlease_dur, ddsi_vendorid_t vendor, unsigned custom_flags, ddsrt_wctime_t timestamp, ddsi_seqno_t seq)
 {
   /* No locking => iff all participants use unique guids, and sedp
      runs on a single thread, it can't go wrong. FIXME, maybe? The
@@ -343,6 +343,7 @@ bool ddsi_new_proxy_participant (struct ddsi_domaingv *gv, const struct ddsi_gui
   assert (ppguid->entityid.u == DDSI_ENTITYID_PARTICIPANT);
   assert (ddsi_entidx_lookup_proxy_participant_guid (gv->entity_index, ppguid) == NULL);
   assert (privileged_pp_guid == NULL || privileged_pp_guid->entityid.u == DDSI_ENTITYID_PARTICIPANT);
+  assert (proxy_participant);
 
   ddsi_prune_deleted_participant_guids (gv->deleted_participants, ddsrt_time_monotonic ());
 
@@ -477,6 +478,7 @@ bool ddsi_new_proxy_participant (struct ddsi_domaingv *gv, const struct ddsi_gui
     ddsi_proxy_participant_create_handshakes (gv, proxypp);
   }
 #endif
+  *proxy_participant = proxypp;
   return true;
 }
 

--- a/src/core/ddsi/src/ddsi_security_exchange.c
+++ b/src/core/ddsi/src/ddsi_security_exchange.c
@@ -42,7 +42,7 @@ bool ddsi_write_auth_handshake_message(const struct ddsi_participant *pp, const 
   ddsi_guid_t prd_guid;
   bool result = false;
 
-  if ((wr = ddsi_get_builtin_writer (pp, DDSI_ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_MESSAGE_WRITER)) == NULL) {
+  if (ddsi_get_builtin_writer (pp, DDSI_ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_MESSAGE_WRITER, &wr) != DDS_RETCODE_OK || wr == NULL) {
     GVTRACE ("write_handshake("PGUIDFMT") - builtin stateless message writer not found", PGUID (pp->e.guid));
     return false;
   }
@@ -152,7 +152,7 @@ static bool write_crypto_exchange_message(const struct ddsi_participant *pp, con
   ddsi_seqno_t seq;
   int r;
 
-  if ((wr = ddsi_get_builtin_writer (pp, DDSI_ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER)) == NULL)
+  if (ddsi_get_builtin_writer (pp, DDSI_ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER, &wr) != DDS_RETCODE_OK || wr == NULL)
   {
     GVLOG (DDS_LC_DISCOVERY, "write_crypto_exchange_message("PGUIDFMT") - builtin volatile secure writer not found\n", PGUID (pp->e.guid));
     return false;

--- a/src/core/ddsi/src/ddsi_typelib.c
+++ b/src/core/ddsi/src/ddsi_typelib.c
@@ -206,6 +206,14 @@ const struct DDS_XTypes_TypeObject * ddsi_typemap_typeobj (const ddsi_typemap_t 
   return NULL;
 }
 
+const char * ddsi_typemap_get_type_name (const ddsi_typemap_t *typemap, const ddsi_typeid_t *type_id)
+{
+  const struct DDS_XTypes_TypeObject *type_obj = ddsi_typemap_typeobj (typemap, &type_id->x);
+  if (type_obj == NULL)
+    return NULL;
+  return ddsi_typeobj_get_type_name_impl (type_obj);
+}
+
 ddsi_typemap_t *ddsi_typemap_deser (const unsigned char *data, uint32_t sz)
 {
   unsigned char *data_ne;

--- a/src/core/ddsi/src/ddsi_typelookup.c
+++ b/src/core/ddsi/src/ddsi_typelookup.c
@@ -59,7 +59,7 @@ static struct ddsi_writer *get_typelookup_writer (const struct ddsi_domaingv *gv
   while (wr == NULL && (pp = ddsi_entidx_enum_participant_next (&est)) != NULL)
   {
     if (participant_builtin_writers_ready (pp))
-      wr = ddsi_get_builtin_writer (pp, wr_eid);
+      (void) ddsi_get_builtin_writer (pp, wr_eid, &wr);
   }
   ddsi_entidx_enum_participant_fini (&est);
   ddsi_thread_state_asleep (ddsi_lookup_thread_state ());

--- a/src/core/ddsi/src/ddsi_typewrap.c
+++ b/src/core/ddsi/src/ddsi_typewrap.c
@@ -445,6 +445,30 @@ dds_return_t ddsi_typeobj_get_hash_id (const struct DDS_XTypes_TypeObject *type_
   return DDS_RETCODE_OK;
 }
 
+const char *ddsi_typeobj_get_type_name_impl (const struct DDS_XTypes_TypeObject *type_obj)
+{
+  if (type_obj->_d != DDS_XTypes_EK_COMPLETE)
+    return NULL;
+
+  switch (type_obj->_u.complete._d)
+  {
+    case DDS_XTypes_TK_ALIAS:
+      return type_obj->_u.complete._u.alias_type.header.detail.type_name;
+    case DDS_XTypes_TK_STRUCTURE:
+      return type_obj->_u.complete._u.struct_type.header.detail.type_name;
+    case DDS_XTypes_TK_UNION:
+      return type_obj->_u.complete._u.union_type.header.detail.type_name;
+    case DDS_XTypes_TK_BITSET:
+      return type_obj->_u.complete._u.bitset_type.header.detail.type_name;
+    case DDS_XTypes_TK_ENUM:
+      return type_obj->_u.complete._u.enumerated_type.header.detail.type_name;
+    case DDS_XTypes_TK_BITMASK:
+      return type_obj->_u.complete._u.bitmask_type.header.detail.type_name;
+    default:
+      return NULL;
+  }
+}
+
 void ddsi_typeobj_fini_impl (struct DDS_XTypes_TypeObject *typeobj)
 {
   dds_stream_free_sample (typeobj, &dds_cdrstream_default_allocator, DDS_XTypes_TypeObject_desc.m_ops);

--- a/src/core/ddsi/tests/plist_leasedur.c
+++ b/src/core/ddsi/tests/plist_leasedur.c
@@ -368,6 +368,7 @@ static void ddsi_plist_leasedur_new_proxyrd_impl (bool include_lease_duration)
   plist.qos.liveliness.kind = DDS_LIVELINESS_AUTOMATIC;
   plist.qos.liveliness.lease_duration = DDS_SECS (10);
   ddsi_thread_state_awake (thrst, &gv);
+  ddsi_generate_participant_guid (&ppguid, &gv);
   dds_return_t ret = ddsi_new_participant (&ppguid, &gv, RTPS_PF_PRIVILEGED_PP | RTPS_PF_IS_DDSI2_PP, &plist);
   ddsi_thread_state_asleep (thrst);
   CU_ASSERT_FATAL (ret >= 0);

--- a/src/core/ddsi/tests/pmd_message.c
+++ b/src/core/ddsi/tests/pmd_message.c
@@ -227,6 +227,7 @@ static void create_fake_proxy_participant (void)
   ddsi_plist_init_empty (&plist);
   ddsi_xqos_mergein_missing (&plist.qos, &gv.default_local_xqos_pp, ~(uint64_t)0);
   ddsi_thread_state_awake (thrst, &gv);
+  ddsi_generate_participant_guid (&ppguid, &gv);
   dds_return_t ret = ddsi_new_participant (&ppguid, &gv, RTPS_PF_IS_DDSI2_PP | RTPS_PF_PRIVILEGED_PP, &plist);
   ddsi_thread_state_asleep (thrst);
   ddsi_plist_fini (&plist);

--- a/src/core/ddsi/tests/wraddrset.c
+++ b/src/core/ddsi/tests/wraddrset.c
@@ -145,6 +145,7 @@ static void ddsi_wraddrset_some_cases (int casenumber, int cost, bool wr_psmx, c
 
   setup_and_start ();
   ddsi_thread_state_awake (ddsi_lookup_thread_state(), &gv);
+  ddsi_generate_participant_guid (&wrppguid, &gv);
   ddsi_new_participant (&wrppguid, &gv, RTPS_PF_PRIVILEGED_PP | RTPS_PF_IS_DDSI2_PP, &plist_pp[0]);
 
   const struct ddsi_sertype st = {

--- a/src/core/ddsi/tests/wraddrset.c
+++ b/src/core/ddsi/tests/wraddrset.c
@@ -176,6 +176,9 @@ static void ddsi_wraddrset_some_cases (int casenumber, int cost, bool wr_psmx, c
       .free = whc_free
     }
   };
+  dds_return_t ret = ddsi_generate_writer_guid (&wrguid, pp, &st);
+  assert (ret == DDS_RETCODE_OK);
+  (void) ret;
   ddsi_new_writer (&wr, &wrguid, NULL, pp, "Q", &st, &ddsi_default_qos_writer, &whc, NULL, NULL, wr_psmx ? &psmx_locs : NULL);
   assert (ddsi_entidx_lookup_writer_guid (gv.entity_index, &wrguid));
 

--- a/src/core/ddsi/tests/wraddrset.c
+++ b/src/core/ddsi/tests/wraddrset.c
@@ -199,11 +199,12 @@ static void ddsi_wraddrset_some_cases (int casenumber, int cost, bool wr_psmx, c
         .entityid = { .u = DDSI_ENTITYID_PARTICIPANT }
       };
       struct ddsi_addrset *proxypp_as = ddsi_new_addrset ();
+      struct ddsi_proxy_participant *proxy_participant;
       ddsi_locator_t loc = ucloc[i]; loc.port = 1000 + (unsigned) j;
       ddsi_add_locator_to_addrset (&gv, proxypp_as, &loc);
       ddsi_add_locator_to_addrset (&gv, proxypp_as, &mcloc);
-      ddsi_new_proxy_participant (&gv, &rdppguid[i][j], 0, NULL, proxypp_as, ddsi_ref_addrset (proxypp_as), &plist_pp[i], DDS_INFINITY, DDSI_VENDORID_ECLIPSE, 0, ddsrt_time_wallclock (), 1);
-      assert (ddsi_entidx_lookup_proxy_participant_guid (gv.entity_index, &rdppguid[i][j]));
+      ddsi_new_proxy_participant (&proxy_participant, &gv, &rdppguid[i][j], 0, NULL, proxypp_as, ddsi_ref_addrset (proxypp_as), &plist_pp[i], DDS_INFINITY, DDSI_VENDORID_ECLIPSE, 0, ddsrt_time_wallclock (), 1);
+      assert (proxy_participant != NULL);
 
       const ddsi_guid_t rdguid = {
         .prefix = rdppguid[i][j].prefix,

--- a/src/core/ddsi/tests/wraddrset.c
+++ b/src/core/ddsi/tests/wraddrset.c
@@ -224,12 +224,13 @@ static void ddsi_wraddrset_some_cases (int casenumber, int cost, bool wr_psmx, c
         // something else
         ddsi_add_xlocator_to_addrset (&gv, rd_as, &(ddsi_xlocator_t){ .conn = &fake_conn, .c = psmxloc[i] });
       }
+      struct ddsi_proxy_reader *proxy_reader;
 #if DDS_HAS_SSM
-      ddsi_new_proxy_reader (&gv, &rdppguid[i][j], &rdguid, rd_as, &plist_rd, ddsrt_time_wallclock (), 1, false);
+      ddsi_new_proxy_reader (&proxy_reader, &gv, &rdppguid[i][j], &rdguid, rd_as, &plist_rd, ddsrt_time_wallclock (), 1, false);
 #else
-      ddsi_new_proxy_reader (&gv, &rdppguid[i][j], &rdguid, rd_as, &plist_rd, ddsrt_time_wallclock (), 1);
+      ddsi_new_proxy_reader (&proxy_reader, &gv, &rdppguid[i][j], &rdguid, rd_as, &plist_rd, ddsrt_time_wallclock (), 1);
 #endif
-      assert (ddsi_entidx_lookup_proxy_reader_guid (gv.entity_index, &rdguid));
+      assert (proxy_reader);
       ddsi_unref_addrset (rd_as);
     }
   }

--- a/src/core/xtests/symbol_export/CMakeLists.txt
+++ b/src/core/xtests/symbol_export/CMakeLists.txt
@@ -17,6 +17,7 @@ target_include_directories(symbol_export_test PRIVATE
     "$<BUILD_INTERFACE:$<TARGET_PROPERTY:ddsrt,INTERFACE_INCLUDE_DIRECTORIES>>"
     "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src/include/>"
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../ddsc/src>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../ddsi/src>"
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../ddsi/include>"
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../cdr/include>")
 

--- a/src/core/xtests/symbol_export/symbol_export.c
+++ b/src/core/xtests/symbol_export/symbol_export.c
@@ -522,6 +522,7 @@ int main (int argc, char **argv)
   dds_loaned_sample_ref (ptr);
   dds_loaned_sample_unref (ptr);
   dds_reader_store_loaned_sample (1, ptr);
+  dds_reader_store_loaned_sample_wr_metadata (0, ptr, 0, 0, 0);
 
 #ifdef DDS_HAS_SECURITY
   // dds_security_timed_cb.h

--- a/src/core/xtests/symbol_export/symbol_export.c
+++ b/src/core/xtests/symbol_export/symbol_export.c
@@ -56,6 +56,7 @@
 #include "dds/ddsi/ddsi_typelib.h"
 #include "dds/ddsi/ddsi_typebuilder.h"
 #endif
+#include "dds/ddsi/ddsi_proxy_participant.h"
 #include "dds/ddsi/ddsi_proxy_endpoint.h"
 
 #ifdef DDS_HAS_SECURITY
@@ -749,6 +750,9 @@ int main (int argc, char **argv)
 #else
   ddsi_new_proxy_reader (ptr, ptr2, ptr3, ptr4, ptr5, ptr6, ddsrt_time_wallclock(), 0);
 #endif
+
+  // ddsi/ddsi_proxy_participant.h
+  ddsi_new_proxy_participant (ptr, ptr2, ptr3, 0, ptr5, ptr6, ptr7, ptr8, 0, (ddsi_vendorid_t) { 0 }, 0, ddsrt_time_wallclock (), 0);
 
   // ddsrt/atomics.h
   ddsrt_atomic_ld32 (ptr);

--- a/src/core/xtests/symbol_export/symbol_export.c
+++ b/src/core/xtests/symbol_export/symbol_export.c
@@ -145,6 +145,7 @@ int main (int argc, char **argv)
   dds_get_listener (1, ptr);
   dds_set_listener (1, ptr);
   dds_create_participant (0, ptr, ptr);
+  dds_create_participant_guid (1, ptr, ptr2, 0, ptr3);
   dds_create_domain (0, ptr);
   dds_create_domain_with_rawconfig (0, ptr);
   dds_get_parent (1);

--- a/src/core/xtests/symbol_export/symbol_export.c
+++ b/src/core/xtests/symbol_export/symbol_export.c
@@ -37,6 +37,7 @@
 #include "dds/ddsrt/xmlparser.h"
 #include "dds/ddsrt/io.h"
 #include "dds/ddsrt/ifaddrs.h"
+#include "dds/ddsrt/sockets.h"
 #if DDSRT_HAVE_FILESYSTEM
 #include "dds/ddsrt/filesystem.h"
 #endif
@@ -58,6 +59,17 @@
 #endif
 #include "dds/ddsi/ddsi_proxy_participant.h"
 #include "dds/ddsi/ddsi_proxy_endpoint.h"
+#include "dds/ddsi/ddsi_plist.h"
+#include "dds/ddsi/ddsi_xmsg.h"
+#include "dds/ddsi/ddsi_guid.h"
+#include "dds/ddsi/ddsi_tkmap.h"
+#include "dds/ddsi/ddsi_transmit.h"
+#include "dds/ddsi/ddsi_entity_index.h"
+#include "dds/ddsi/ddsi_addrset.h"
+#include "dds/ddsi/ddsi_tran.h"
+#include "dds/ddsi/ddsi_portmapping.h"
+#include "ddsi__ipaddr.h"
+#include "ddsi__discovery_addrset.h"
 
 #ifdef DDS_HAS_SECURITY
 #include "dds/security/core/dds_security_serialize.h"
@@ -78,7 +90,8 @@
 
 #include "dds/cdr/dds_cdrstream.h"
 
-#include "dds__write.h" // dds_write_impl, dds_writecdr_impl
+#include "dds__write.h"
+#include "dds__entity.h"
 
 DDSRT_WARNING_DEPRECATED_OFF
 DDSRT_WARNING_GNUC_OFF (unused-result)
@@ -716,6 +729,9 @@ int main (int argc, char **argv)
   ddsi_typemap_get_type_name (ptr, ptr2);
   ddsi_type_lookup (ptr, ptr);
   ddsi_type_compare (ptr, ptr);
+  ddsi_type_ref (ptr, ptr2, ptr3);
+  ddsi_type_unref (ptr, ptr2);
+  ddsi_type_add (ptr, ptr2, ptr3, ptr4, ptr5);
 
   ddsi_make_typeid_str (ptr, ptr);
 #endif
@@ -729,6 +745,8 @@ int main (int argc, char **argv)
   // ddsi/ddsi_thread.h
   ddsi_lookup_thread_state ();
   ddsi_lookup_thread_state_real ();
+  ddsi_thread_state_asleep (ptr);
+  ddsi_thread_state_awake (ptr, ptr2);
 
   // ddsi/ddsi_gc.h
   ddsi_gcreq_new (ptr, ptr);
@@ -753,6 +771,51 @@ int main (int argc, char **argv)
 
   // ddsi/ddsi_proxy_participant.h
   ddsi_new_proxy_participant (ptr, ptr2, ptr3, 0, ptr5, ptr6, ptr7, ptr8, 0, (ddsi_vendorid_t) { 0 }, 0, ddsrt_time_wallclock (), 0);
+
+  // ddsi/ddsi_plist.h
+  ddsi_plist_init_empty (ptr);
+  ddsi_plist_fini (ptr);
+
+  // ddsi/ddsi_xqos.h
+  ddsi_xqos_delta (ptr, ptr2, 0);
+
+  // ddsi/ddsi_xmsg.h
+  (void) ddsi_xpack_new (ptr, false);
+  ddsi_xpack_free (ptr);
+  ddsi_xpack_send (ptr, false);
+
+  // ddsi/ddsi_guid.h
+  ddsi_hton_guid ((ddsi_guid_t) { 0 });
+  ddsi_ntoh_guid ((ddsi_guid_t) { 0 });
+
+  // ddsi/ddsi_tkmap.h
+  (void) ddsi_tkmap_lookup_instance_ref (ptr, ptr2);
+  ddsi_tkmap_instance_unref (ptr, ptr2);
+
+  // ddsi/ddsi_transmit.h
+  ddsi_write_sample_gc (ptr, ptr2, ptr3, ptr4, ptr5);
+
+  // ddsi/ddsi_entity_index.h
+  (void) ddsi_entidx_lookup_writer_guid (ptr, ptr2);
+
+  // ddsi/ddsi_addrset.h
+  (void) ddsi_ref_addrset (ptr);
+  ddsi_unref_addrset (ptr);
+  (void) ddsi_new_addrset ();
+  ddsi_add_locator_to_addrset (ptr, ptr2, ptr3);
+
+  // ddsi/ddsi_tran.h
+  (void) ddsi_locator_to_string (ptr, 0, ptr2);
+
+  // ddsi/ddsi_portmapping.h
+  ddsi_get_port_int (ptr, ptr2, 0, 0, 0, ptr3, 0);
+
+  // ddsi__ipaddr.h
+  ddsi_ipaddr_to_loc (ptr, ptr2, 0);
+
+  // ddsi__discovery_addrset.h
+  ddsi_include_multicast_locator_in_discovery (ptr);
+
 
   // ddsrt/atomics.h
   ddsrt_atomic_ld32 (ptr);
@@ -1028,6 +1091,7 @@ int main (int argc, char **argv)
   // ddsrt/log.h
   dds_log (0, ptr, 0, ptr, " ");
   dds_set_log_mask (0); // ROS 2 rmw_cyclonedds_cpp needs this, probably erroneously
+  dds_get_log_mask ();
 
   // ddsrt/sockets.h
 #if DDSRT_HAVE_GETHOSTNAME
@@ -1092,9 +1156,16 @@ int main (int argc, char **argv)
   ddsrt_getifaddrs (ptr, ptr);
   ddsrt_freeifaddrs (ptr);
 
+  // ddsrt/sockets.h
+  ddsrt_sockaddrfromstr (0, ptr, ptr2);
+
   // dds__write.h
   dds_write_impl (ptr, ptr, 0, (dds_write_action) 0);
   dds_writecdr_impl (ptr, ptr, ptr, false);
+
+  // dds__entity.h
+  dds_entity_pin (0, ptr);
+  dds_entity_unpin (ptr);
 
   return 0;
 }

--- a/src/core/xtests/symbol_export/symbol_export.c
+++ b/src/core/xtests/symbol_export/symbol_export.c
@@ -711,6 +711,7 @@ int main (int argc, char **argv)
   ddsi_typemap_deser (ptr, 0);
   ddsi_typemap_fini (ptr);
   ddsi_typemap_equal (ptr, ptr);
+  ddsi_typemap_get_type_name (ptr, ptr2);
   ddsi_type_lookup (ptr, ptr);
   ddsi_type_compare (ptr, ptr);
 

--- a/src/core/xtests/symbol_export/symbol_export.c
+++ b/src/core/xtests/symbol_export/symbol_export.c
@@ -56,6 +56,7 @@
 #include "dds/ddsi/ddsi_typelib.h"
 #include "dds/ddsi/ddsi_typebuilder.h"
 #endif
+#include "dds/ddsi/ddsi_proxy_endpoint.h"
 
 #ifdef DDS_HAS_SECURITY
 #include "dds/security/core/dds_security_serialize.h"
@@ -117,7 +118,7 @@ int main (int argc, char **argv)
 {
   (void) argc;
   (void) argv;
-  void *ptr = &ptr, *ptr2 = &ptr2, *ptr3 = &ptr3, *ptr4 = &ptr4;
+  void *ptr = &ptr, *ptr2 = &ptr2, *ptr3 = &ptr3, *ptr4 = &ptr4, *ptr5 = &ptr5, *ptr6 = &ptr6, *ptr7 = &ptr7, *ptr8 = &ptr8;
 
   /* The functions shouldn't actually be called, just included here so that
      the linker resolves the symbols. An early return (with unreachable code
@@ -739,6 +740,14 @@ int main (int argc, char **argv)
   // ddsi/ddsi_typebuilder.h
   ddsi_topic_descriptor_from_type (ptr, ptr2, ptr3);
   ddsi_topic_descriptor_fini (ptr);
+#endif
+
+  // ddsi/ddsi_proxy_endpoint.h
+  ddsi_new_proxy_writer (ptr, ptr2, ptr3, ptr4, ptr5, ptr6, ptr7, ptr8, ddsrt_time_wallclock(), 0);
+#ifdef DDS_HAS_SSM
+  ddsi_new_proxy_reader (ptr, ptr2, ptr3, ptr4, ptr5, ptr6, ddsrt_time_wallclock(), 0, 0);
+#else
+  ddsi_new_proxy_reader (ptr, ptr2, ptr3, ptr4, ptr5, ptr6, ddsrt_time_wallclock(), 0);
 #endif
 
   // ddsrt/atomics.h

--- a/src/core/xtests/symbol_export/symbol_export.c
+++ b/src/core/xtests/symbol_export/symbol_export.c
@@ -1166,6 +1166,8 @@ int main (int argc, char **argv)
   // dds__entity.h
   dds_entity_pin (0, ptr);
   dds_entity_unpin (ptr);
+  dds_entity_lock (0, 0, ptr);
+  dds_entity_unlock (ptr);
 
   return 0;
 }

--- a/src/core/xtests/symbol_export/symbol_export.c
+++ b/src/core/xtests/symbol_export/symbol_export.c
@@ -171,9 +171,11 @@ int main (int argc, char **argv)
   dds_resume (1);
   dds_wait_for_acks (1, 0);
   dds_create_reader (1, 1, ptr, ptr);
+  dds_create_reader_guid (1, 1, ptr, ptr2, ptr3);
   dds_create_reader_rhc (1, 1, ptr, ptr, ptr);
   dds_reader_wait_for_historical_data (1, 0);
   dds_create_writer (1, 1, ptr, ptr);
+  dds_create_writer_guid (1, 1, ptr, ptr2, ptr3);
   dds_register_instance (1, ptr, ptr);
   dds_unregister_instance (1, ptr);
   dds_unregister_instance_ih (1, 1);

--- a/src/ddsrt/include/dds/ddsrt/log.h
+++ b/src/ddsrt/include/dds/ddsrt/log.h
@@ -151,14 +151,14 @@ typedef struct ddsrt_log_cfg {
   } u;
 } ddsrt_log_cfg_t;
 
-extern uint32_t *const dds_log_mask;
+DDS_EXPORT extern uint32_t *const dds_log_mask;
 
 /**
  * @brief Get currently enabled log and trace categories.
  *
  * @returns A uint32_t with enabled categories set.
  */
-inline uint32_t
+DDS_INLINE_EXPORT inline uint32_t
 dds_get_log_mask(void)
 {
     return *dds_log_mask;

--- a/src/ddsrt/include/dds/ddsrt/log.h
+++ b/src/ddsrt/include/dds/ddsrt/log.h
@@ -82,12 +82,18 @@ extern "C" {
 #define DDS_LC_SYSDEF (524288u)
 /** Debug/trace messages related to qos provider. */
 #define DDS_LC_QOSPROV (1048576u)
+/** Reserved for user defined log categories (e.g. user application that uses Cyclone logger) */
+#define DDS_LC_USER1 (1u << 29)
+#define DDS_LC_USER2 (1u << 30)
+#define DDS_LC_USER3 (1u << 31)
+#define DDS_LC_USER (DDS_LC_USER1 | DDS_LC_USER2 | DDS_LC_USER3)
+
 /** All common trace categories. */
 #define DDS_LC_ALL \
     (DDS_LC_FATAL | DDS_LC_ERROR | DDS_LC_WARNING | DDS_LC_INFO | \
      DDS_LC_CONFIG | DDS_LC_DISCOVERY | DDS_LC_DATA | DDS_LC_TRACE | \
      DDS_LC_TIMING | DDS_LC_TRAFFIC | DDS_LC_TCP | DDS_LC_THROTTLE | \
-     DDS_LC_CONTENT)
+     DDS_LC_CONTENT | DDS_LC_USER)
 /** @}*/
 
 #define DDS_LOG_MASK \

--- a/src/ddsrt/include/dds/ddsrt/sockets.h
+++ b/src/ddsrt/include/dds/ddsrt/sockets.h
@@ -495,7 +495,7 @@ ddsrt_nonnull_all;
  *
  * See @ref ddsrt_sockaddrtostr
  */
-dds_return_t
+DDS_EXPORT dds_return_t
 ddsrt_sockaddrfromstr(
   int af, const char *str, void *sa);
 

--- a/src/security/core/tests/common/test_utils.c
+++ b/src/security/core/tests/common/test_utils.c
@@ -633,8 +633,8 @@ DDS_Security_DatawriterCryptoHandle get_builtin_writer_crypto_handle(dds_entity_
   ddsi_thread_state_awake(ddsi_lookup_thread_state(), &pp_entity->m_domain->gv);
   pp = ddsi_entidx_lookup_participant_guid(pp_entity->m_domain->gv.entity_index, &pp_entity->m_guid);
   dds_return_t ret = ddsi_get_builtin_writer (pp, entityid, &wr);
-  CU_ASSERT_FATAL(ret, DDS_RETCODE_OK);
-  CU_ASSERT_EQUAL_FATAL(wr != NULL);
+  CU_ASSERT_EQUAL_FATAL(ret, DDS_RETCODE_OK);
+  CU_ASSERT_FATAL(wr != NULL);
   crypto_handle = wr->sec_attr->crypto_handle;
   ddsi_thread_state_asleep(ddsi_lookup_thread_state());
   dds_entity_unpin(pp_entity);

--- a/src/security/core/tests/common/test_utils.c
+++ b/src/security/core/tests/common/test_utils.c
@@ -632,8 +632,9 @@ DDS_Security_DatawriterCryptoHandle get_builtin_writer_crypto_handle(dds_entity_
   CU_ASSERT_EQUAL_FATAL(dds_entity_pin(participant, &pp_entity), 0);
   ddsi_thread_state_awake(ddsi_lookup_thread_state(), &pp_entity->m_domain->gv);
   pp = ddsi_entidx_lookup_participant_guid(pp_entity->m_domain->gv.entity_index, &pp_entity->m_guid);
-  wr = ddsi_get_builtin_writer (pp, entityid);
-  CU_ASSERT_FATAL(wr != NULL);
+  dds_return_t ret = ddsi_get_builtin_writer (pp, entityid, &wr);
+  CU_ASSERT_FATAL(ret, DDS_RETCODE_OK);
+  CU_ASSERT_EQUAL_FATAL(wr != NULL);
   crypto_handle = wr->sec_attr->crypto_handle;
   ddsi_thread_state_asleep(ddsi_lookup_thread_state());
   dds_entity_unpin(pp_entity);


### PR DESCRIPTION
The changes in this PR make it possible to disable the participant and endpoint discovery when creating a new DDS participant, by passing the `DDS_PARTICIPANT_FLAGS_NO_DISCOVERY` flag. Additionally, some other minor changes are included, including exporting some additional internal functions that are useful in specific applications. 