### PR TITLE
Reduce dds_waitset_wait_impl() time complexity by avoinding to iterate over all attached entities

### DIFF
--- a/src/core/ddsc/src/dds_waitset.c
+++ b/src/core/ddsc/src/dds_waitset.c
@@ -64,8 +64,9 @@ static dds_return_t dds_waitset_wait_impl (dds_entity_t waitset, dds_attach_t *x
 
   /* Move any previously but no longer triggering entities back to the observed list */
   ddsrt_mutex_lock (&ws->wait_lock);
+  size_t previous_ntriggered = ws->ntriggered;
   ws->ntriggered = 0;
-  for (size_t i = 0; i < ws->nentities; i++)
+  for (size_t i = 0; i < previous_ntriggered; i++)
   {
     if (is_triggered (ws->entities[i].entity))
     {


### PR DESCRIPTION
First, I'm not really familiar with the waitset implementation, so apologies if the suggestion is incorrect.

When moving the previously but no longer triggering entities back to the observed list, the implementation is currently iterating over all the waitset entities.
It seems to me that the iteration could be done only over the previous `ws->ntriggered` entities.
This improves time complexity, as I would expect ntriggered to be typically a low number, while the total amount of conditions can be much larger.