### PR TITLE
Fix build for earlier macOS versions

### DIFF
--- a/src/core/ddsi/src/ddsi_udp.c
+++ b/src/core/ddsi/src/ddsi_udp.c
@@ -12,6 +12,10 @@
 #define __APPLE_USE_RFC_3542
 #define _GNU_SOURCE
 
+#ifdef __APPLE__
+#include <AvailabilityMacros.h>
+#endif
+
 #include <assert.h>
 #include <string.h>
 #include "dds/ddsrt/atomics.h"
@@ -500,7 +504,9 @@ static dds_return_t set_mc_options_transmit_ipv6 (struct ddsi_domaingv const * c
 
 static dds_return_t set_mc_options_transmit_ipv4_if (struct ddsi_domaingv const * const gv, struct ddsi_network_interface const * const intf, ddsrt_socket_t sock)
 {
-#if (defined(__linux) || defined(__APPLE__)) && !LWIP_SOCKET
+/* ip_mreqn is available on macOS 10.7+ */
+#if ((defined(__APPLE__) && defined(MAC_OS_X_VERSION_10_7) && (MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_7)) \
+  || defined(__linux)) && !LWIP_SOCKET
   if (gv->config.use_multicast_if_mreqn)
   {
     struct ip_mreqn mreqn;

--- a/src/ddsrt/src/threads/posix/threads.c
+++ b/src/ddsrt/src/threads/posix/threads.c
@@ -49,6 +49,7 @@ typedef struct {
 #include <mach/task.h>
 #include <mach/task_info.h>
 #include <mach/vm_map.h>
+#include <AvailabilityMacros.h>
 #elif defined(__sun)
 #define MAXTHREADNAMESIZE (31)
 #elif defined(__FreeBSD__)
@@ -455,9 +456,9 @@ ddsrt_gettid(void)
 #elif defined(__FreeBSD__) && (__FreeBSD__ >= 9)
   /* FreeBSD >= 9.0 */
   tid = pthread_getthreadid_np();
-#elif defined(__APPLE__) && !(defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && \
-                                      __MAC_OS_X_VERSION_MIN_REQUIRED < 1060)
-  /* macOS >= 10.6 */
+#elif defined(__APPLE__) && !defined(__POWERPC__) && \
+  !(defined(MAC_OS_X_VERSION_MIN_REQUIRED) && MAC_OS_X_VERSION_MIN_REQUIRED < 1060)
+  /* macOS >= 10.6, but for ppc this symbol is unavailable */
   pthread_threadid_np(NULL, &tid);
 #elif defined(__VXWORKS__)
   tid = taskIdSelf();

--- a/src/ddsrt/src/threads/posix/threads.c
+++ b/src/ddsrt/src/threads/posix/threads.c
@@ -50,6 +50,9 @@ typedef struct {
 #include <mach/task_info.h>
 #include <mach/vm_map.h>
 #include <AvailabilityMacros.h>
+#ifndef MAXTHREADNAMESIZE
+#define MAXTHREADNAMESIZE (64)
+#endif /* MAXTHREADNAMESIZE */
 #elif defined(__sun)
 #define MAXTHREADNAMESIZE (31)
 #elif defined(__FreeBSD__)

--- a/src/security/builtin_plugins/cryptographic/src/crypto_transform.c
+++ b/src/security/builtin_plugins/cryptographic/src/crypto_transform.c
@@ -331,7 +331,7 @@ static bool read_submsg_header (tainted_input_buffer_t *input, uint8_t smid, dds
   // silly C can't deal with assignment to *submsg_view in any way because of endp
   // memcpy to the rescue!
   // coverity[store_writes_const_field]
-  memcpy (submsg_view, &(tainted_input_buffer_t){ .ptr = input->ptr, .endp = input->ptr + hdr->octetsToNextHeader }, sizeof (*submsg_view));
+  memcpy (submsg_view, (&(tainted_input_buffer_t){ .ptr = input->ptr, .endp = input->ptr + hdr->octetsToNextHeader }), sizeof (*submsg_view));
   input->ptr += hdr->octetsToNextHeader;
   return true;
 }


### PR DESCRIPTION
@eboasson These are necessary, but insufficient. At the moment 0.10.5 still fails further at linking, while the master fails earlier: https://github.com/eclipse-cyclonedds/cyclonedds/issues/2019

`MAXTHREADNAMESIZE` is defined in `Libc` internal header. Since the code uses it unconditionally, it should be defined to something. For w/e reason the value from `Libc` is inaccessible, and it also fails on CI on x86_64 up to 10.10: https://build.macports.org/builders/ports-10.10_x86_64-builder/builds/271089/steps/install-port/logs/stdio

Then up to 10.12 there is a failure due to wrong number of arguments in `memcpy`: https://build.macports.org/builders/ports-10.12_x86_64-builder/builds/275235/steps/install-port/logs/stdio
(This is a known issue, Apple changed the declaration for `memcpy`.)

Unfortunately, I have no idea at the moment why linking fails with undefined `_dds_stream_extract_keyBE_from_key`.