### PR TITLE
Fixed memory leak in idl preprocessor

### DIFF
--- a/src/tools/idlpp/src/internal.H
+++ b/src/tools/idlpp/src/internal.H
@@ -507,6 +507,7 @@ extern int      (* mcpp_fprintf)( MCPP_OUTDEST od, const char * format, ...)
         MCPP_ATTRIBUTE_FORMAT_PRINTF(2, 3);
 
 /* system.c */
+extern void     clean_system(void);
 extern void     do_options( int argc, char ** argv, char ** in_pp
         , char ** out_pp);
                 /* Process command line args    */

--- a/src/tools/idlpp/src/main.c
+++ b/src/tools/idlpp/src/main.c
@@ -450,6 +450,9 @@ fatal_error_exit:
         fclose( fp_out);
     if (fp_err && fp_err != stderr)
         fclose( fp_err);
+    clean_system();
+    if (in_file != NULL)
+      free(in_file);
 
     if (mcpp_debug & MEMORY)
         print_heap();

--- a/src/tools/idlpp/src/system.c
+++ b/src/tools/idlpp/src/system.c
@@ -3293,6 +3293,7 @@ found_name:
     if (open_include( filename, (delim == '"'), next)) {
         /* 'fname' should not be free()ed, it is used as file->         */
         /*      real_fname and has been registered into fnamelist[]     */
+        free( filename);
         return  TRUE;
     }
 
@@ -3612,6 +3613,7 @@ search:
         put_depend( fullname);          /* Output dependency line   */
 
 true:
+    free( fullname);
     return  TRUE;
 false:
     free( fullname);
@@ -5086,3 +5088,8 @@ void    clear_filelist( void)
 }
 #endif
 
+void clean_system(void)
+{
+  if (sharp_filename != NULL)
+    free(sharp_filename);
+}

--- a/src/tools/idlpp/src/system.c
+++ b/src/tools/idlpp/src/system.c
@@ -3680,7 +3680,7 @@ static const char *     set_fname(
     fnamelen = strlen( filename);
     for (fnamep = fnamelist; fnamep < fname_end; fnamep++) {
         if (fnamep->len == fnamelen && str_case_eq( fnamep->name, filename))
-            return  filename;           /* Already registered       */
+            return  fnamep->name;           /* Already registered       */
     }
     fname_end->name = xmalloc( fnamelen + 1);
     filename = strcpy( (char *)fname_end->name, filename);

--- a/src/tools/idlpp/src/system.c
+++ b/src/tools/idlpp/src/system.c
@@ -3291,8 +3291,6 @@ found_name:
     }
 #endif
     if (open_include( filename, (delim == '"'), next)) {
-        /* 'fname' should not be free()ed, it is used as file->         */
-        /*      real_fname and has been registered into fnamelist[]     */
         free( filename);
         return  TRUE;
     }


### PR DESCRIPTION
This leak was caused by not freeing the strings generated when resolving paths
To reproduce this leak: parse an idl file which includes another idl file