### PR TITLE
implement custom idlpy location

### DIFF
--- a/src/tools/idlc/include/idlc/generator.h
+++ b/src/tools/idlc/include/idlc/generator.h
@@ -43,7 +43,7 @@ struct idlc_generator_plugin {
   idlc_generate_t generate;
 };
 
-int idlc_load_generator(idlc_generator_plugin_t *plugin, const char *lang);
+int idlc_load_generator(idlc_generator_plugin_t *plugin, const char *lang, const char *idlpy_overwrite);
 void idlc_unload_generator(idlc_generator_plugin_t *plugin);
 
 #endif /* IDLC_GENERATOR_H */

--- a/src/tools/idlc/src/idlc/generator.c
+++ b/src/tools/idlc/src/idlc/generator.c
@@ -146,7 +146,7 @@ static int run_library_locator(const char *command, char **out_output) {
   return -1;
 }
 
-int idlc_load_generator(idlc_generator_plugin_t *plugin, const char *lang)
+int idlc_load_generator(idlc_generator_plugin_t *plugin, const char *lang, const char *idlpy_overwrite)
 {
   char buf[64], *file = NULL;
   const char *path;
@@ -164,10 +164,14 @@ int idlc_load_generator(idlc_generator_plugin_t *plugin, const char *lang)
         correct idlpy library.
    */
   if (idl_strcasecmp(lang, "py") == 0) {
-    if (run_library_locator("python3 -m cyclonedds.__idlc__", &file) != 0) {
-      return -1;
+    if (idlpy_overwrite != NULL && strlen(idlpy_overwrite) > 0) {
+      path = idlpy_overwrite;
+    } else {
+      if (run_library_locator("python3 -m cyclonedds.__idlc__", &file) != 0) {
+        return -1;
+      }
+      path = (const char*) file;
     }
-    path = (const char*) file;
   }
 
   /* figure out if user passed library or language */


### PR DESCRIPTION
Previously the `_idlpy` could only be loaded from a location returned by `python3` program.

This PR adds a command-line option `-y <path>` to use a custom `_idlpy` lib.

This is needed when you want to use idlc python without any pip package installation.
For example `CycloneDDS-Insight` needs this because there idlc should use the binaries inside the App.

@eboasson can you have a look at this PR? 😊