### PR TITLE
Check for sync delivery for filtered proxy writers

### DIFF
--- a/src/core/ddsi/src/ddsi_receive.c
+++ b/src/core/ddsi/src/ddsi_receive.c
@@ -1352,7 +1352,12 @@ static int handle_Heartbeat (struct ddsi_receiver_state *rst, ddsrt_etime_t tnow
             // use the advertised first sequence number in the WHC
             struct ddsi_reorder *ro = wn->u.not_in_sync.reorder;
             if ((res = ddsi_reorder_gap (&sc, ro, gap, 1, firstseq, &refc_adjust)) > 0)
-              ddsi_dqueue_enqueue1 (pwr->dqueue, &wn->rd_guid, &sc, res);
+            {
+              if (pwr->deliver_synchronously)
+                deliver_user_data_synchronously (&sc, &wn->rd_guid);
+              else
+                ddsi_dqueue_enqueue1 (pwr->dqueue, &wn->rd_guid, &sc, res);
+            }
             if (ddsi_from_seqno (msg->lastSN) > wn->last_seq)
             {
               wn->last_seq = ddsi_from_seqno (msg->lastSN);


### PR DESCRIPTION
Creating a proxy writer with the "filtered" flag set is not currently possible via the API and the only ones that are created are built-in ones.  Since all built-in ones are using the asynchronous path anyway the absence of a synchronous path is not actually a bug, but the undocumented deviation of the pattern is.

Not deviating from the patter is the better option here, especially because it is constitutes a significant fraction of performing content filtering at the writer and so its use is likely to be extended.

Fixes #2018 