### PR TITLE
Always have a NACK scheduled if data is missing

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/ddsi_xevent.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_xevent.h
@@ -55,6 +55,19 @@ void ddsi_delete_xevent (struct ddsi_xevent *ev)
 int ddsi_resched_xevent_if_earlier (struct ddsi_xevent *ev, ddsrt_mtime_t tsched)
   ddsrt_nonnull_all;
 
+/** @brief returns whether or not the event is scheduled
+ * @component timed_events
+ *
+ * @remark: may be called from inside the event handler
+ *
+ * @param[in] ev the event for which to check whether it is scheduled
+ *
+ * @retval 0 not scheduled
+ * @retval 1 scheduled
+ */
+int ddsi_xevent_is_scheduled (struct ddsi_xevent *ev)
+  ddsrt_nonnull_all;
+
 /** @brief creates a new event object on the given event queue for invoking `cb` in the
  *   future on the thread handling this queue
  * @component timed_events

--- a/src/core/ddsi/src/ddsi__acknack.h
+++ b/src/core/ddsi/src/ddsi__acknack.h
@@ -27,7 +27,8 @@ struct ddsi_pwr_rd_match;
 struct ddsi_proxy_writer;
 
 enum ddsi_add_acknack_result {
-  AANR_SUPPRESSED_ACK,  //!< sending nothing: too short a time since the last ACK
+  AANR_SILENT_ACK,      //!< sending nothing: too short a time since the last ACK
+  AANR_SILENT_NACK,     //!< sending nothing, even though there are things to NACK
   AANR_ACK,             //!< sending an ACK and there's nothing to NACK
   AANR_SUPPRESSED_NACK, //!< sending an ACK even though there are things to NACK
   AANR_NACK,            //!< sending a NACK, possibly also a NACKFRAG
@@ -53,7 +54,7 @@ struct ddsi_add_acknack_info {
 
 
 /** @component incoming_rtps */
-void ddsi_sched_acknack_if_needed (struct ddsi_xevent *ev, struct ddsi_proxy_writer *pwr, struct ddsi_pwr_rd_match *rwn, ddsrt_mtime_t tnow, bool avoid_suppressed_nack);
+void ddsi_sched_acknack_if_needed (struct ddsi_xevent *ev, struct ddsi_proxy_writer *pwr, struct ddsi_pwr_rd_match *rwn, ddsrt_mtime_t tnow);
 
 struct ddsi_acknack_xevent_cb_arg {
   ddsi_guid_t pwr_guid;

--- a/src/core/ddsi/src/ddsi__radmin.h
+++ b/src/core/ddsi/src/ddsi__radmin.h
@@ -198,8 +198,14 @@ void ddsi_reorder_drop_upto (struct ddsi_reorder *reorder, ddsi_seqno_t maxp1); 
 /** @component receive_buffers */
 int ddsi_reorder_wantsample (const struct ddsi_reorder *reorder, ddsi_seqno_t seq);
 
+enum ddsi_reorder_nackmap_result {
+  DDSI_REORDER_NACKMAP_ACK,            //!< Nothing to ACK, bitmap length = 0
+  DDSI_REORDER_NACKMAP_NACK,           //!< Some bits set in bitmap, bitmap length \> 0
+  DDSI_REORDER_NACKMAP_SUPPRESSED_NACK //!< No bits set in bitmap even though there are things to NACK, bitmap length \> 0
+};
+
 /** @component receive_buffers */
-unsigned ddsi_reorder_nackmap (const struct ddsi_reorder *reorder, ddsi_seqno_t base, ddsi_seqno_t maxseq, struct ddsi_sequence_number_set_header *map, uint32_t *mapbits, uint32_t maxsz, int notail);
+enum ddsi_reorder_nackmap_result ddsi_reorder_nackmap (const struct ddsi_reorder *reorder, ddsi_seqno_t base, ddsi_seqno_t maxseq, struct ddsi_sequence_number_set_header *map, uint32_t *mapbits, uint32_t maxsz, int notail);
 
 /** @component receive_buffers */
 ddsi_seqno_t ddsi_reorder_next_seq (const struct ddsi_reorder *reorder);

--- a/src/core/ddsi/src/ddsi_receive.c
+++ b/src/core/ddsi/src/ddsi_receive.c
@@ -1227,7 +1227,7 @@ static void handle_Heartbeat_helper (struct ddsi_pwr_rd_match * const wn, struct
   if (arg->directed_heartbeat)
     wn->directed_heartbeat = 1;
 
-  ddsi_sched_acknack_if_needed (wn->acknack_xevent, pwr, wn, arg->tnow_mt, true);
+  ddsi_sched_acknack_if_needed (wn->acknack_xevent, pwr, wn, arg->tnow_mt);
 }
 
 static int handle_Heartbeat (struct ddsi_receiver_state *rst, ddsrt_etime_t tnow, struct ddsi_rmsg *rmsg, const ddsi_rtps_heartbeat_t *msg, ddsrt_wctime_t timestamp, ddsi_rtps_submessage_kind_t prev_smid)

--- a/src/core/ddsi/src/ddsi_xevent.c
+++ b/src/core/ddsi/src/ddsi_xevent.c
@@ -345,6 +345,16 @@ int ddsi_resched_xevent_if_earlier (struct ddsi_xevent *ev, ddsrt_mtime_t tsched
   return is_resched;
 }
 
+int ddsi_xevent_is_scheduled (struct ddsi_xevent *ev)
+{
+  struct ddsi_xeventq *evq = ev->evq;
+  int is_scheduled;
+  ddsrt_mutex_lock (&evq->lock);
+  is_scheduled = (ev->tsched.v != TSCHED_DELETE && ev->tsched.v != DDS_NEVER);
+  ddsrt_mutex_unlock (&evq->lock);
+  return is_scheduled;
+}
+
 #ifndef NDEBUG
 bool ddsi_delete_xevent_pending (struct ddsi_xevent *ev)
 {


### PR DESCRIPTION
The spec says that readers may only send an ACKNACK message in response to a HEARTBEAT, but there is no guarantee that a writer will actually send that HEARTBEAT for historical data and in case of reconnecting after an asymmetric disconnection.

The sensible thing to do is to not sit idle as a reader, but always eventually send an ACKNACK if data is known to be missing (or if no HEARTBEAT has been received yet). This has been a design choice in this stack since the very beginning, but it turns out that there is a case where the ACKNACK event doesn't get rescheduled even though data is missing because what would ordinarily have been a NACK gets generated as an ACK, and then potentially never sent out.

This changes the ACKNACK generation logic to always distinguish the case where a NACK would have been generated if only circumstances allowed it, then ensures that the event is always scheduled if a NACK is generated or would have been generated.