### PR TITLE
Do not change type in typelib making key holder

### DIFF
--- a/src/core/ddsi/src/ddsi_typewrap.c
+++ b/src/core/ddsi/src/ddsi_typewrap.c
@@ -2161,7 +2161,7 @@ static struct xt_type *xt_type_keyholder (struct ddsi_domaingv *gv, const struct
       {
         /* Rule: If T is a structure with no key members, then KeyHolder(T) adds a key designator to each member. */
         for (uint32_t i = 0; i < t->_u.structure.members.length; i++)
-          t->_u.structure.members.seq[i].flags |= DDS_XTypes_IS_KEY;
+          tkh->_u.structure.members.seq[i].flags |= DDS_XTypes_IS_KEY;
       }
       return tkh;
     }


### PR DESCRIPTION
Type assignability for structs can require constructing a key holder type, which in turn involves marking all fields as key fields for a struct that has no key fields defined, e.g., when:

    struct Inner {
      long a, b;
    };
    struct Outer {
      @key Inner k;
    };

the key holder type will constructing a type where "a" and "b" are annotated as keys.  The code for doing this incorrectly modified the input type already in the library, rather than setting the flag on the new key holder type.

Obviously, silently changing the type in the library is bad.  It was observed because the change affects the type identifier (without changing where the type is in the index) and the mismatch got flagged while processing a type lookup reply.