### PR TITLE
Skip optionals completely when deserializing a key

### DIFF
--- a/src/core/cdr/src/dds_cdrstream.c
+++ b/src/core/cdr/src/dds_cdrstream.c
@@ -1837,12 +1837,13 @@ static inline const uint32_t *stream_skip_member (uint32_t insn, char * __restri
 static inline const uint32_t *dds_stream_read_adr (uint32_t insn, dds_istream_t * __restrict is, char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, bool is_mutable_member, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
 {
   void *addr = data + ops[1];
-  if (!stream_is_member_present (insn, is, is_mutable_member))
-    return stream_skip_member (insn, data, addr, allocator, ops, sample_state);
 
   const bool is_key = (insn & DDS_OP_FLAG_KEY);
   if (cdr_kind == CDR_KIND_KEY && !is_key)
     return dds_stream_skip_adr (insn, ops);
+
+  if (!stream_is_member_present (insn, is, is_mutable_member))
+    return stream_skip_member (insn, data, addr, allocator, ops, sample_state);
 
   if (op_type_external (insn))
     dds_stream_alloc_external (ops, insn, &addr, allocator, &sample_state);
@@ -4300,15 +4301,16 @@ static const uint32_t *prtf_uni (char * __restrict *buf, size_t *bufsize, dds_is
 
 static const uint32_t * dds_stream_print_adr (char * __restrict *buf, size_t * __restrict bufsize, uint32_t insn, dds_istream_t * __restrict is, const uint32_t * __restrict ops, bool is_mutable_member, enum cdr_data_kind cdr_kind)
 {
+  const bool is_key = (insn & DDS_OP_FLAG_KEY);
+  if (cdr_kind == CDR_KIND_KEY && !is_key)
+    return dds_stream_skip_adr (insn, ops);
+
   if (!stream_is_member_present (insn, is, is_mutable_member))
   {
     (void) prtf (buf, bufsize, "NULL");
     return dds_stream_skip_adr (insn, ops);
   }
 
-  const bool is_key = (insn & DDS_OP_FLAG_KEY);
-  if (cdr_kind == CDR_KIND_KEY && !is_key)
-    return dds_stream_skip_adr (insn, ops);
   switch (DDS_OP_TYPE (insn))
   {
     case DDS_OP_VAL_BLN: case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY:

--- a/src/core/cdr/src/dds_cdrstream.c
+++ b/src/core/cdr/src/dds_cdrstream.c
@@ -2870,6 +2870,10 @@ static const uint32_t *normalize_uni (char * __restrict data, uint32_t * __restr
 static const uint32_t *stream_normalize_adr (uint32_t insn, char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t * __restrict ops, bool is_mutable_member, enum cdr_data_kind cdr_kind) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
 static const uint32_t *stream_normalize_adr (uint32_t insn, char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t * __restrict ops, bool is_mutable_member, enum cdr_data_kind cdr_kind)
 {
+  const bool is_key = (insn & DDS_OP_FLAG_KEY);
+  if (cdr_kind == CDR_KIND_KEY && !is_key)
+    return dds_stream_skip_adr (insn, ops);
+
   if (op_type_optional (insn))
   {
     bool present = true;
@@ -2881,10 +2885,6 @@ static const uint32_t *stream_normalize_adr (uint32_t insn, char * __restrict da
     if (!present)
       return dds_stream_skip_adr (insn, ops);
   }
-
-  const bool is_key = (insn & DDS_OP_FLAG_KEY);
-  if (cdr_kind == CDR_KIND_KEY && !is_key)
-    return dds_stream_skip_adr (insn, ops);
 
   switch (DDS_OP_TYPE (insn))
   {


### PR DESCRIPTION
The serialized key only contains the key fields and when deserializing a key one must skip everything else.  The deserialization (and printing) code incorrectly read the boolean indicating presence of an optional field in cases like:

    struct S {
      @optional long x;
      @key long y;
    };

This commit fixes it by first checking whether a key is being deserialized, skipping the checks for the presence of an optional field if it is.  (Note that optional fields can not be key fields.)