### PR TITLE
Export sysdef parser functions

### DIFF
--- a/src/core/ddsc/src/dds__sysdef_parser.h
+++ b/src/core/ddsc/src/dds__sysdef_parser.h
@@ -12,6 +12,7 @@
 
 #include "dds/ddsrt/log.h"
 #include "dds/ddsrt/retcode.h"
+#include "dds/export.h"
 
 #if defined (__cplusplus)
 extern "C" {
@@ -85,7 +86,7 @@ struct dds_sysdef_type_metadata_admin;
 *
 * @return a DDS return code
 */
-dds_return_t dds_sysdef_init_sysdef (FILE *fp, struct dds_sysdef_system **sysdef, uint32_t lib_scope);
+DDS_EXPORT_INTERNAL_FUNCTION dds_return_t dds_sysdef_init_sysdef (FILE *fp, struct dds_sysdef_system **sysdef, uint32_t lib_scope);
 
 /**
 * @brief Initialize System definition from `xml` string.
@@ -100,7 +101,7 @@ dds_return_t dds_sysdef_init_sysdef (FILE *fp, struct dds_sysdef_system **sysdef
 *
 * @return a DDS return code
 */
-dds_return_t dds_sysdef_init_sysdef_str (const char *raw, struct dds_sysdef_system **sysdef, uint32_t lib_scope);
+DDS_EXPORT_INTERNAL_FUNCTION dds_return_t dds_sysdef_init_sysdef_str (const char *raw, struct dds_sysdef_system **sysdef, uint32_t lib_scope);
 
 /**
 * @brief Finalize System definition.
@@ -112,7 +113,7 @@ dds_return_t dds_sysdef_init_sysdef_str (const char *raw, struct dds_sysdef_syst
 * @param[in] sysdef - Pointer to dds_sysdef_system structure.
 *
 */
-void dds_sysdef_fini_sysdef (struct dds_sysdef_system *sysdef);
+DDS_EXPORT_INTERNAL_FUNCTION void dds_sysdef_fini_sysdef (struct dds_sysdef_system *sysdef);
 
 /**
 * @brief Initialize System definition for data types.
@@ -126,7 +127,7 @@ void dds_sysdef_fini_sysdef (struct dds_sysdef_system *sysdef);
 *
 * @return a DDS return code
 */
-dds_return_t dds_sysdef_init_data_types (FILE *fp, struct dds_sysdef_type_metadata_admin **type_meta_data);
+DDS_EXPORT_INTERNAL_FUNCTION dds_return_t dds_sysdef_init_data_types (FILE *fp, struct dds_sysdef_type_metadata_admin **type_meta_data);
 
 /**
 * @brief Finalize System definition for data types.
@@ -138,7 +139,7 @@ dds_return_t dds_sysdef_init_data_types (FILE *fp, struct dds_sysdef_type_metada
 * @param[in,out] type_meta_data - Pointer dds_sysdef_type_metadata_admin structure.
 *
 */
-void dds_sysdef_fini_data_types (struct dds_sysdef_type_metadata_admin *type_meta_data);
+DDS_EXPORT_INTERNAL_FUNCTION void dds_sysdef_fini_data_types (struct dds_sysdef_type_metadata_admin *type_meta_data);
 
 #if defined (__cplusplus)
 }

--- a/src/core/xtests/symbol_export/symbol_export.c
+++ b/src/core/xtests/symbol_export/symbol_export.c
@@ -92,6 +92,7 @@
 
 #include "dds__write.h"
 #include "dds__entity.h"
+#include "dds__sysdef_parser.h"
 
 DDSRT_WARNING_DEPRECATED_OFF
 DDSRT_WARNING_GNUC_OFF (unused-result)
@@ -1168,6 +1169,13 @@ int main (int argc, char **argv)
   dds_entity_unpin (ptr);
   dds_entity_lock (0, 0, ptr);
   dds_entity_unlock (ptr);
+
+  // dds__sysdef_parser.h
+  dds_sysdef_init_sysdef (ptr, ptr2, 0);
+  dds_sysdef_init_sysdef_str (ptr, ptr2, 0);
+  dds_sysdef_fini_sysdef (ptr);
+  dds_sysdef_init_data_types (ptr, ptr2);
+  dds_sysdef_fini_data_types (ptr);
 
   return 0;
 }


### PR DESCRIPTION
Adding export macros to the system definition parser initialization and finalize functions.