### PR TITLE
Fix inherited composite key (and some others I ran into)

### DIFF
--- a/examples/dynsub/dynsub.c
+++ b/examples/dynsub/dynsub.c
@@ -80,7 +80,7 @@ static dds_return_t get_topic_and_typeobj (const char *topic_name, dds_duration_
       // as an approximation of the topic QoS.
       if ((*topic = dds_find_topic (DDS_FIND_SCOPE_GLOBAL, participant, ep->topic_name, typeinfo, DDS_SECS (2))) < 0)
       {
-        fprintf (stderr, "dds_find_topic: %s ... continuing on the assumptions that topic discovery is disabled\n", dds_strretcode (*topic));
+        fprintf (stderr, "dds_find_topic: %s ... continuing on the assumption that topic discovery is disabled\n", dds_strretcode (*topic));
         dds_topic_descriptor_t *descriptor;
         if ((ret = dds_create_topic_descriptor(DDS_FIND_SCOPE_GLOBAL, participant, typeinfo, DDS_SECS (10), &descriptor)) < 0)
         {

--- a/src/core/ddsi/src/ddsi__typewrap.h
+++ b/src/core/ddsi/src/ddsi__typewrap.h
@@ -88,8 +88,10 @@ enum ddsi_non_assignability_code {
 
 struct ddsi_non_assignability_reason {
   enum ddsi_non_assignability_code code;
-  const struct xt_type *t1;
-  const struct xt_type *t2;
+  DDS_XTypes_TypeIdentifier t1_id;
+  DDS_XTypes_TypeIdentifier t2_id;
+  uint8_t t1_typekind;
+  uint8_t t2_typekind;
   uint32_t id;
 };
 

--- a/src/core/ddsi/src/ddsi_acknack.c
+++ b/src/core/ddsi/src/ddsi_acknack.c
@@ -554,16 +554,18 @@ static struct ddsi_xmsg *make_preemptive_acknack (struct ddsi_xevent *ev, struct
     (ddsi_count_t *) ((char *) an + offsetof (ddsi_rtps_acknack_t, bits) + DDSI_SEQUENCE_NUMBER_SET_BITS_SIZE (0));
   *countp = 0;
   ddsi_xmsg_submsg_setnext (msg, sm_marker);
+
+  // print before security gets to it: it can delete the message
+  // numbits is always 0 here, so need to print the bitmap
+  ETRACE (pwr, "acknack "PGUIDFMT" -> "PGUIDFMT": #%"PRIu32":%"PRId64"/%"PRIu32":\n",
+          PGUID (rwn->rd_guid), PGUID (pwr->e.guid), *countp,
+          ddsi_from_seqno (an->readerSNState.bitmap_base), an->readerSNState.numbits);
+
   ddsi_security_encode_datareader_submsg (msg, sm_marker, pwr, &rwn->rd_guid);
 
   rwn->t_last_ack = tnow;
   const dds_duration_t new_intv = preemptive_acknack_interval (rwn);
   (void) ddsi_resched_xevent_if_earlier (ev, ddsrt_mtime_add_duration (rwn->t_last_ack, new_intv));
-
-  // numbits is always 0 here, so need to print the bitmap
-  ETRACE (pwr, "acknack "PGUIDFMT" -> "PGUIDFMT": #%"PRIu32":%"PRId64"/%"PRIu32":\n",
-          PGUID (rwn->rd_guid), PGUID (pwr->e.guid), *countp,
-          ddsi_from_seqno (an->readerSNState.bitmap_base), an->readerSNState.numbits);
   return msg;
 }
 

--- a/src/core/ddsi/src/ddsi_typebuilder.c
+++ b/src/core/ddsi/src/ddsi_typebuilder.c
@@ -1500,15 +1500,19 @@ static int key_id_cmp (const void *va, const void *vb)
   for (uint32_t n = 0; n < (*a)->path->n_parts; n++)
   {
     assert (n < (*b)->path->n_parts);
-    if ((*a)->path->parts[n].kind == KEY_PATH_PART_INHERIT_MUTABLE)
+    switch ((*a)->path->parts[n].kind)
     {
-      /* a derived type cannot add keys, so all keys must have an INHERIT_MUTABLE
-         kind part at this index */
-      assert ((*b)->path->parts[n].kind == KEY_PATH_PART_INHERIT_MUTABLE);
-      continue;
+      case KEY_PATH_PART_INHERIT:
+      case KEY_PATH_PART_INHERIT_MUTABLE:
+        /* a derived type cannot add keys, so all keys must have an INHERIT_MUTABLE
+           kind part at this index */
+        assert ((*b)->path->parts[n].kind == (*a)->path->parts[n].kind);
+        break;
+      case KEY_PATH_PART_REGULAR:
+        if ((*a)->path->parts[n].member->member_id != (*b)->path->parts[n].member->member_id)
+          return (*a)->path->parts[n].member->member_id < (*b)->path->parts[n].member->member_id ? -1 : 1;
+        break;
     }
-    if ((*a)->path->parts[n].member->member_id != (*b)->path->parts[n].member->member_id)
-      return (*a)->path->parts[n].member->member_id < (*b)->path->parts[n].member->member_id ? -1 : 1;
   }
   assert ((*a)->path->n_parts == (*b)->path->n_parts);
   return 0;

--- a/src/core/ddsi/src/ddsi_typelib.c
+++ b/src/core/ddsi/src/ddsi_typelib.c
@@ -1423,10 +1423,10 @@ bool ddsi_is_assignable_from (struct ddsi_domaingv *gv, const struct ddsi_type_p
     GVLOG (lc_cat, "assignability check failed: rd type %s wr type %s, t1=%s (%s) t2=%s (%s) id %"PRIu32": %s\n",
            ddsi_make_typeid_str (&trdstr, &rd_xt->id),
            ddsi_make_typeid_str (&twrstr, &wr_xt->id),
-           reason.t1 ? ddsi_make_typeid_str (&t1str, &reason.t1->id) : "(none)",
-           reason.t1 ? ddsi_typekind_descr (reason.t1->_d) : "",
-           reason.t2 ? ddsi_make_typeid_str (&t2str, &reason.t2->id) : "(none)",
-           reason.t2 ? ddsi_typekind_descr (reason.t2->_d) : "",
+           reason.t1_typekind ? ddsi_make_typeid_str_impl (&t1str, &reason.t1_id) : "(none)",
+           reason.t1_typekind ? ddsi_typekind_descr (reason.t1_typekind) : "",
+           reason.t2_typekind ? ddsi_make_typeid_str_impl (&t2str, &reason.t2_id) : "(none)",
+           reason.t2_typekind ? ddsi_typekind_descr (reason.t2_typekind) : "",
            reason.id, ddsi_non_assignability_code_str (reason.code));
   }
   return assignable;

--- a/src/core/ddsi/src/ddsi_typewrap.c
+++ b/src/core/ddsi/src/ddsi_typewrap.c
@@ -640,9 +640,9 @@ static dds_return_t xt_valid_struct_member_ids (struct ddsi_domaingv *gv, const 
       ids[--cnt1] = t1->_u.structure.members.seq[n].id;
   }
   qsort (ids, cnt, sizeof (*ids), xt_member_id_cmp);
-  for (uint32_t n = 0; n < cnt - 1; n++)
+  for (uint32_t n = 1; n < cnt; n++)
   {
-    if (ids[n] == ids[n + 1])
+    if (ids[n] == ids[n - 1])
     {
       GVTRACE ("duplicate member id %"PRIu32" in struct\n", ids[n]);
       ret = DDS_RETCODE_BAD_PARAMETER;

--- a/src/core/ddsi/src/ddsi_typewrap.c
+++ b/src/core/ddsi/src/ddsi_typewrap.c
@@ -2066,8 +2066,13 @@ static bool xt_non_assignable (struct ddsi_non_assignability_reason *reason, enu
 {
   reason->code = code;
   reason->id = id;
-  reason->t1 = t1;
-  reason->t2 = t2;
+  reason->t1_id = t1->id.x;
+  reason->t1_typekind = t1->_d;
+  if (t2)
+  {
+    reason->t2_id = t2->id.x;
+    reason->t2_typekind = t2->_d;
+  }
   return false;
 }
 
@@ -2914,6 +2919,8 @@ static ddsi_typeid_kind_t ddsi_typeid_kind_impl (const struct DDS_XTypes_TypeIde
 bool ddsi_xt_is_assignable_from (struct ddsi_domaingv *gv, const struct xt_type *rd_xt, const struct xt_type *wr_xt, const dds_type_consistency_enforcement_qospolicy_t *tce, struct ddsi_non_assignability_reason *reason)
 {
   reason->code = DDSI_NONASSIGN_ASSIGNABLE;
+  reason->t1_typekind = 0;
+  reason->t2_typekind = 0;
   if (xt_is_assignable_from_impl (gv, rd_xt, wr_xt, tce, reason))
     return true;
   if (reason->code == DDSI_NONASSIGN_ASSIGNABLE)


### PR DESCRIPTION
* use-after-free in tracing an outgoing pre-emptive ACKNACK message if security decides to drop the message
* a harmless typo in the output of `dynsub` that today annoyed me too much 🙂 
* a potential use-after-free in my new non-assignability reason printer (bummer, well, it was caught quickly)
* a crash on validating an empty struct with an unresolved base type

and, last but not least: the crash for an inherited composite key in a (non-mutable) type.

Fixes https://github.com/eclipse-cyclonedds/cyclonedds-python/issues/257