### PR TITLE
Turn off PACKET_DESTINATION_INFO for mingw-w64.

### DIFF
--- a/src/core/ddsi/src/ddsi_udp.c
+++ b/src/core/ddsi/src/ddsi_udp.c
@@ -49,6 +49,9 @@ DDSRT_STATIC_ASSERT (DDSI_LOCATOR_UDPv4MCGEN_INDEX_MASK_BITS <= 32 - UDP_MC_ADDR
 #  endif
 #endif
 #ifndef PACKET_DESTINATION_INFO
+#  if defined (__MINGW32__) && !defined (CMSG_SPACE)
+#    define PACKET_DESTINATION_INFO 0
+#  endif
 #  if defined CMSG_SPACE && (defined IP_PKTINFO || (DDSRT_HAVE_IPV6 && defined IPV6_PKTINFO))
 #    define PACKET_DESTINATION_INFO 1
 #  else

--- a/src/ddsrt/src/sockets/windows/socket.c
+++ b/src/ddsrt/src/sockets/windows/socket.c
@@ -570,6 +570,7 @@ ddsrt_recvmsg(
     if (sockext->wsarecvmsg (sockext->sock, &wsamsg, &n, NULL, 0) != 0)
     {
       int err = WSAGetLastError();
+      *rcvd = (ssize_t) n;
       return recv_error_to_retcode(err);
     }
     else


### PR DESCRIPTION
The CMSG_* macros used in CycloneDDS are not provided by mingw-w64-gcc (only WSA*). Set the number of bytes received also for nonzero return from wsarecvmsg. Closes #2027