### PR TITLE
Fix serdata size in serdata_default_from_psmx

### DIFF
--- a/src/core/ddsc/src/dds_serdata_default.c
+++ b/src/core/ddsc/src/dds_serdata_default.c
@@ -913,7 +913,8 @@ static struct ddsi_serdata * serdata_default_from_psmx (const struct ddsi_sertyp
   else
     return NULL;
 
-  struct dds_serdata_default *d = serdata_default_new_size (tp, kind, md->sample_size, xcdr_version);
+  const uint32_t pad = ddsrt_fromBE2u (md->cdr_options) & DDS_CDR_HDR_PADDING_MASK;
+  struct dds_serdata_default *d = serdata_default_new_size (tp, kind, md->sample_size + pad, xcdr_version);
   d->c.statusinfo = md->statusinfo;
   d->c.timestamp.v = md->timestamp;
   if (md->cdr_identifier == DDSI_RTPS_SAMPLE_NATIVE)


### PR DESCRIPTION
The size of a serdata should include the padding bytes. This fix adds these padding bytes from the PSMX meta-data in the call to serdata_default_new_size when receiving data from PSMX.