### PR TITLE
Consistently set in_file to a malloc'd pointer

### DIFF
--- a/src/tools/idlpp/src/main.c
+++ b/src/tools/idlpp/src/main.c
@@ -391,7 +391,8 @@ int     main
 #endif
         }
     } else {
-        in_file = stdin_name;
+        in_file = xmalloc( strlen( stdin_name) + 1);
+        strcpy( in_file, stdin_name);
     }
     /* Open output file, "-" means stdout.  */
     if (out_file != NULL && ! str_eq( out_file, "-")) {
@@ -435,11 +436,6 @@ int     main
 
 fatal_error_exit:
 #if MCPP_LIB
-    /* Free malloced memory */
-    if (mcpp_debug & MACRO_CALL) {
-        if (in_file != stdin_name)
-            free( in_file);
-    }
     clear_filelist();
     clear_symtable();
 #endif
@@ -452,7 +448,7 @@ fatal_error_exit:
         fclose( fp_err);
     clean_system();
     if (in_file != NULL)
-      free(in_file);
+        free( in_file);
 
     if (mcpp_debug & MEMORY)
         print_heap();

--- a/src/tools/idlpp/src/system.c
+++ b/src/tools/idlpp/src/system.c
@@ -1406,9 +1406,11 @@ Version:
     /* Normalize the path-list  */
     if (*in_pp && ! str_eq( *in_pp, "-")) {
         char *  tmp = norm_path( null, *in_pp, FALSE, FALSE);
-        if (tmp)                        /* The file exists          */
+        if (tmp) {                       /* The file exists          */
+            free(*in_pp);
             *in_pp = tmp;
             /* Else mcpp_main() will diagnose *in_pp and exit   */
+        }
     }
     if (! (mcpp_debug & MACRO_CALL)) {
         /* -K option alters behavior of -v option   */
@@ -2224,7 +2226,8 @@ static char *   set_files(
 #if SYS_FAMILY == SYS_WIN
         cp = bsl2sl( cp);
 #endif
-        *in_pp = cp;
+        *in_pp = xmalloc( strlen(cp) + 1);  /* Need a new buffer    */
+        strcpy( *in_pp, cp);
     }
     if (mcpp_optind < argc && argv[ mcpp_optind][ 0] != '-'
             && *out_pp == NULL) {


### PR DESCRIPTION
In some cases, the input file would point to a string constant (stdin name), in some cases to a command-line argument, and in some (probably most in reality) to malloc'd address.  This changes the code to always assign it to a malloc'd string.