### PR TITLE
Fix ACKNACK event mishandling of AANR_SILENT_NACK

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/ddsi_xevent.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_xevent.h
@@ -55,7 +55,7 @@ void ddsi_delete_xevent (struct ddsi_xevent *ev)
 int ddsi_resched_xevent_if_earlier (struct ddsi_xevent *ev, ddsrt_mtime_t tsched)
   ddsrt_nonnull_all;
 
-/** @brief returns whether or not the event is scheduled
+/** @brief returns whether or not the event is scheduled or pending deletion
  * @component timed_events
  *
  * @remark: may be called from inside the event handler
@@ -63,7 +63,7 @@ int ddsi_resched_xevent_if_earlier (struct ddsi_xevent *ev, ddsrt_mtime_t tsched
  * @param[in] ev the event for which to check whether it is scheduled
  *
  * @retval 0 not scheduled
- * @retval 1 scheduled
+ * @retval 1 scheduled or pending deletion
  */
 int ddsi_xevent_is_scheduled (struct ddsi_xevent *ev)
   ddsrt_nonnull_all;

--- a/src/core/ddsi/src/ddsi_xevent.c
+++ b/src/core/ddsi/src/ddsi_xevent.c
@@ -350,7 +350,8 @@ int ddsi_xevent_is_scheduled (struct ddsi_xevent *ev)
   struct ddsi_xeventq *evq = ev->evq;
   int is_scheduled;
   ddsrt_mutex_lock (&evq->lock);
-  is_scheduled = (ev->tsched.v != TSCHED_DELETE && ev->tsched.v != DDS_NEVER);
+  // Also considers it scheduled if it is about to be deleted
+  is_scheduled = (ev->tsched.v != DDS_NEVER);
   ddsrt_mutex_unlock (&evq->lock);
   return is_scheduled;
 }


### PR DESCRIPTION
This case is supposed to not send anything at all, only rescheduling the event to send a NACK when we are willing to do that.  The early out was missing, causing a (pure) ACK to be generated and a failing assertion in the code updating the state of last ACK sent because it was supposed to be unreachable.

In a release build it should not cause more damage than a sometimes sending ACK where sending nothing was intended; in a debug build it would instead crash.

(Why did I not spot this *before* merging #2033 ... 😢)