### PR TITLE
mingw-w64 + improve ddsrt_recvmsg interface

### DIFF
--- a/src/core/ddsi/src/ddsi_udp.c
+++ b/src/core/ddsi/src/ddsi_udp.c
@@ -49,6 +49,9 @@ DDSRT_STATIC_ASSERT (DDSI_LOCATOR_UDPv4MCGEN_INDEX_MASK_BITS <= 32 - UDP_MC_ADDR
 #  endif
 #endif
 #ifndef PACKET_DESTINATION_INFO
+#  if defined (__MINGW32__) && !defined (CMSG_SPACE)
+#    define PACKET_DESTINATION_INFO 0
+#  endif
 #  if defined CMSG_SPACE && (defined IP_PKTINFO || (DDSRT_HAVE_IPV6 && defined IPV6_PKTINFO))
 #    define PACKET_DESTINATION_INFO 1
 #  else

--- a/src/ddsrt/include/dds/ddsrt/hopscotch.h
+++ b/src/ddsrt/include/dds/ddsrt/hopscotch.h
@@ -215,18 +215,11 @@ struct ddsrt_chh_bucket;
  * @brief Embedded data version of @ref ddsrt_hh_iter.
  * @see ddsrt_chh_iter_first
  */
-#if ! ddsrt_has_feature_thread_sanitizer
 struct ddsrt_chh_iter {
   struct ddsrt_chh_bucket *bs;
   uint32_t size;
   uint32_t cursor;
 };
-#else
-struct ddsrt_chh_iter {
-  struct ddsrt_chh *chh;
-  struct ddsrt_hh_iter it;
-};
-#endif
 
 /**
  * @brief Concurrent version of @ref ddsrt_hh_new

--- a/src/ddsrt/include/dds/ddsrt/sockets.h
+++ b/src/ddsrt/include/dds/ddsrt/sockets.h
@@ -280,7 +280,7 @@ ddsrt_recv(
  * @param[in] sockext the socket
  * @param[out] msg the message received
  * @param[in] flags flags for special options
- * @param[out] rcvd number of bytes received
+ * @param[out] rcvd number of bytes received (>= 0 if return == OK, undefined if return != OK)
  * @return a DDS_RETCODE (OK, ERROR, TRY_AGAIN, BAD_PARAMETER, NO_CONNECTION, INTERRUPTED, OUT_OF_RESOURCES, ILLEGAL_OPERATION)
  *
  * See @ref ddsrt_sendmsg


### PR DESCRIPTION
This takes the change for `PACKET_DESTINATION_INFO` from #2045 and bundles it with an improvement to the interface of `ddsrt_recvmsg`.

Closes #2027