### PR TITLE
Add setting for controlling thread affinity

### DIFF
--- a/docs/manual/config/config_file_reference.rst
+++ b/docs/manual/config/config_file_reference.rst
@@ -2520,9 +2520,21 @@ The default value is: ``<empty>``
 //CycloneDDS/Domain/Threads/Thread/Scheduling
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Children: :ref:`Class<//CycloneDDS/Domain/Threads/Thread/Scheduling/Class>`, :ref:`Priority<//CycloneDDS/Domain/Threads/Thread/Scheduling/Priority>`
+Children: :ref:`Affinity<//CycloneDDS/Domain/Threads/Thread/Scheduling/Affinity>`, :ref:`Class<//CycloneDDS/Domain/Threads/Thread/Scheduling/Class>`, :ref:`Priority<//CycloneDDS/Domain/Threads/Thread/Scheduling/Priority>`
 
 This element configures the scheduling properties of the thread.
+
+
+.. _`//CycloneDDS/Domain/Threads/Thread/Scheduling/Affinity`:
+
+//CycloneDDS/Domain/Threads/Thread/Scheduling/Affinity
+""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+Text
+
+This element specifies the thread affinity using a string of comma-separated unsigned 32-bit integers. The notional meaning of the string is that it lists the IDs of the CPU cores to use, but some platforms may use a different mapping. Ignored if unsupported by the platform.
+
+The default value is: ``<empty>``
 
 
 .. _`//CycloneDDS/Domain/Threads/Thread/Scheduling/Class`:
@@ -2704,14 +2716,14 @@ The categorisation of tracing output is incomplete and hence most of the verbosi
 The default value is: ``none``
 
 ..
-   generated from ddsi_config.h[83ad19f1a665710b0c82b3ac6b861e6c8e83913f] 
+   generated from ddsi_config.h[e6e75c7c07b3b91a92715063cfd8abdd0fbd8b08] 
    generated from ddsi__cfgunits.h[bd22f0c0ed210501d0ecd3b07c992eca549ef5aa] 
-   generated from ddsi__cfgelems.h[194217161977869610495a7889bbc1e6bc976ce1] 
-   generated from ddsi_config.c[a439a20e32fe327db26f2f10028d0056e46c1a0b] 
-   generated from _confgen.h[e32eabfc35e9f3a7dcb63b19ed148c0d17c6e5fc] 
+   generated from ddsi__cfgelems.h[69679834d0a592a339803ed27e3966adc900d592] 
+   generated from ddsi_config.c[8d7ef0ae962a47cb2138de27ac0f6751e3393c66] 
+   generated from _confgen.h[9554f1d72645c0b8bb66ffbfbc3c0fb664fc1a43] 
    generated from _confgen.c[237308acd53897a34e8c643e16e05a61d73ffd65] 
    generated from generate_rnc.c[b50e4b7ab1d04b2bc1d361a0811247c337b74934] 
    generated from generate_md.c[789b92e422631684352909cfb8bf43f6ceb16a01] 
    generated from generate_rst.c[3c4b523fbb57c8e4a7e247379d06a8021ccc21c4] 
    generated from generate_xsd.c[6b6818d7f17a35d56c376c04ec1410427f34c0f0] 
-   generated from generate_defconfig.c[63ca9d8ae2f1ce2e761c9d4c0510a45eb062d830] 
+   generated from generate_defconfig.c[631cafee70a6f9480e0267db8ffe883d806f5f70] 

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -1754,9 +1754,17 @@ The default value is: `<empty>`
 
 
 ##### //CycloneDDS/Domain/Threads/Thread/Scheduling
-Children: [Class](#cycloneddsdomainthreadsthreadschedulingclass), [Priority](#cycloneddsdomainthreadsthreadschedulingpriority)
+Children: [Affinity](#cycloneddsdomainthreadsthreadschedulingaffinity), [Class](#cycloneddsdomainthreadsthreadschedulingclass), [Priority](#cycloneddsdomainthreadsthreadschedulingpriority)
 
 This element configures the scheduling properties of the thread.
+
+
+###### //CycloneDDS/Domain/Threads/Thread/Scheduling/Affinity
+Text
+
+This element specifies the thread affinity using a string of comma-separated unsigned 32-bit integers. The notional meaning of the string is that it lists the IDs of the CPU cores to use, but some platforms may use a different mapping. Ignored if unsupported by the platform.
+
+The default value is: `<empty>`
 
 
 ###### //CycloneDDS/Domain/Threads/Thread/Scheduling/Class
@@ -1898,14 +1906,14 @@ While none prevents any message from being written to a DDSI2 log file.
 The categorisation of tracing output is incomplete and hence most of the verbosity levels and categories are not of much use in the current release. This is an ongoing process and here we describe the target situation rather than the current situation. Currently, the most useful verbosity levels are config, fine and finest.
 
 The default value is: `none`
-<!--- generated from ddsi_config.h[83ad19f1a665710b0c82b3ac6b861e6c8e83913f] -->
+<!--- generated from ddsi_config.h[e6e75c7c07b3b91a92715063cfd8abdd0fbd8b08] -->
 <!--- generated from ddsi__cfgunits.h[bd22f0c0ed210501d0ecd3b07c992eca549ef5aa] -->
-<!--- generated from ddsi__cfgelems.h[194217161977869610495a7889bbc1e6bc976ce1] -->
-<!--- generated from ddsi_config.c[a439a20e32fe327db26f2f10028d0056e46c1a0b] -->
-<!--- generated from _confgen.h[e32eabfc35e9f3a7dcb63b19ed148c0d17c6e5fc] -->
+<!--- generated from ddsi__cfgelems.h[69679834d0a592a339803ed27e3966adc900d592] -->
+<!--- generated from ddsi_config.c[8d7ef0ae962a47cb2138de27ac0f6751e3393c66] -->
+<!--- generated from _confgen.h[9554f1d72645c0b8bb66ffbfbc3c0fb664fc1a43] -->
 <!--- generated from _confgen.c[237308acd53897a34e8c643e16e05a61d73ffd65] -->
 <!--- generated from generate_rnc.c[b50e4b7ab1d04b2bc1d361a0811247c337b74934] -->
 <!--- generated from generate_md.c[789b92e422631684352909cfb8bf43f6ceb16a01] -->
 <!--- generated from generate_rst.c[3c4b523fbb57c8e4a7e247379d06a8021ccc21c4] -->
 <!--- generated from generate_xsd.c[6b6818d7f17a35d56c376c04ec1410427f34c0f0] -->
-<!--- generated from generate_defconfig.c[63ca9d8ae2f1ce2e761c9d4c0510a45eb062d830] -->
+<!--- generated from generate_defconfig.c[631cafee70a6f9480e0267db8ffe883d806f5f70] -->

--- a/etc/cyclonedds.rnc
+++ b/etc/cyclonedds.rnc
@@ -1215,6 +1215,12 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==<br>
 <p>This element configures the scheduling properties of the thread.</p>""" ] ]
           element Scheduling {
             [ a:documentation [ xml:lang="en" """
+<p>This element specifies the thread affinity using a string of comma-separated unsigned 32-bit integers. The notional meaning of the string is that it lists the IDs of the CPU cores to use, but some platforms may use a different mapping. Ignored if unsupported by the platform.</p>
+<p>The default value is: <code>&lt;empty&gt;</code></p>""" ] ]
+            element Affinity {
+              text
+            }?
+            & [ a:documentation [ xml:lang="en" """
 <p>This element specifies the thread scheduling class (<i>realtime</i>, <i>timeshare</i> or <i>default</i>). The user may need special privileges from the underlying operating system to be able to assign some of the privileged scheduling classes.</p>
 <p>The default value is: <code>default</code></p>""" ] ]
             element Class {
@@ -1313,14 +1319,14 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==<br>
   duration_inf = xsd:token { pattern = "inf|0|(\d+(\.\d*)?([Ee][\-+]?\d+)?|\.\d+([Ee][\-+]?\d+)?) *([num]?s|min|hr|day)" }
   memsize = xsd:token { pattern = "0|(\d+(\.\d*)?([Ee][\-+]?\d+)?|\.\d+([Ee][\-+]?\d+)?) *([kMG]i?)?B" }
 }
-# generated from ddsi_config.h[83ad19f1a665710b0c82b3ac6b861e6c8e83913f] 
+# generated from ddsi_config.h[e6e75c7c07b3b91a92715063cfd8abdd0fbd8b08] 
 # generated from ddsi__cfgunits.h[bd22f0c0ed210501d0ecd3b07c992eca549ef5aa] 
-# generated from ddsi__cfgelems.h[194217161977869610495a7889bbc1e6bc976ce1] 
-# generated from ddsi_config.c[a439a20e32fe327db26f2f10028d0056e46c1a0b] 
-# generated from _confgen.h[e32eabfc35e9f3a7dcb63b19ed148c0d17c6e5fc] 
+# generated from ddsi__cfgelems.h[69679834d0a592a339803ed27e3966adc900d592] 
+# generated from ddsi_config.c[8d7ef0ae962a47cb2138de27ac0f6751e3393c66] 
+# generated from _confgen.h[9554f1d72645c0b8bb66ffbfbc3c0fb664fc1a43] 
 # generated from _confgen.c[237308acd53897a34e8c643e16e05a61d73ffd65] 
 # generated from generate_rnc.c[b50e4b7ab1d04b2bc1d361a0811247c337b74934] 
 # generated from generate_md.c[789b92e422631684352909cfb8bf43f6ceb16a01] 
 # generated from generate_rst.c[3c4b523fbb57c8e4a7e247379d06a8021ccc21c4] 
 # generated from generate_xsd.c[6b6818d7f17a35d56c376c04ec1410427f34c0f0] 
-# generated from generate_defconfig.c[63ca9d8ae2f1ce2e761c9d4c0510a45eb062d830] 
+# generated from generate_defconfig.c[631cafee70a6f9480e0267db8ffe883d806f5f70] 

--- a/etc/cyclonedds.xsd
+++ b/etc/cyclonedds.xsd
@@ -1813,10 +1813,18 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
     </xs:annotation>
     <xs:complexType>
       <xs:all>
+        <xs:element minOccurs="0" ref="config:Affinity"/>
         <xs:element minOccurs="0" ref="config:Class"/>
         <xs:element minOccurs="0" ref="config:Priority"/>
       </xs:all>
     </xs:complexType>
+  </xs:element>
+  <xs:element name="Affinity" type="xs:string">
+    <xs:annotation>
+      <xs:documentation>
+&lt;p&gt;This element specifies the thread affinity using a string of comma-separated unsigned 32-bit integers. The notional meaning of the string is that it lists the IDs of the CPU cores to use, but some platforms may use a different mapping. Ignored if unsupported by the platform.&lt;/p&gt;
+&lt;p&gt;The default value is: &lt;code&gt;&amp;lt;empty&amp;gt;&lt;/code&gt;&lt;/p&gt;</xs:documentation>
+    </xs:annotation>
   </xs:element>
   <xs:element name="Class">
     <xs:annotation>
@@ -1971,14 +1979,14 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
     </xs:restriction>
   </xs:simpleType>
 </xs:schema>
-<!--- generated from ddsi_config.h[83ad19f1a665710b0c82b3ac6b861e6c8e83913f] -->
+<!--- generated from ddsi_config.h[e6e75c7c07b3b91a92715063cfd8abdd0fbd8b08] -->
 <!--- generated from ddsi__cfgunits.h[bd22f0c0ed210501d0ecd3b07c992eca549ef5aa] -->
-<!--- generated from ddsi__cfgelems.h[194217161977869610495a7889bbc1e6bc976ce1] -->
-<!--- generated from ddsi_config.c[a439a20e32fe327db26f2f10028d0056e46c1a0b] -->
-<!--- generated from _confgen.h[e32eabfc35e9f3a7dcb63b19ed148c0d17c6e5fc] -->
+<!--- generated from ddsi__cfgelems.h[69679834d0a592a339803ed27e3966adc900d592] -->
+<!--- generated from ddsi_config.c[8d7ef0ae962a47cb2138de27ac0f6751e3393c66] -->
+<!--- generated from _confgen.h[9554f1d72645c0b8bb66ffbfbc3c0fb664fc1a43] -->
 <!--- generated from _confgen.c[237308acd53897a34e8c643e16e05a61d73ffd65] -->
 <!--- generated from generate_rnc.c[b50e4b7ab1d04b2bc1d361a0811247c337b74934] -->
 <!--- generated from generate_md.c[789b92e422631684352909cfb8bf43f6ceb16a01] -->
 <!--- generated from generate_rst.c[3c4b523fbb57c8e4a7e247379d06a8021ccc21c4] -->
 <!--- generated from generate_xsd.c[6b6818d7f17a35d56c376c04ec1410427f34c0f0] -->
-<!--- generated from generate_defconfig.c[63ca9d8ae2f1ce2e761c9d4c0510a45eb062d830] -->
+<!--- generated from generate_defconfig.c[631cafee70a6f9480e0267db8ffe883d806f5f70] -->

--- a/src/core/ddsi/defconfig.c
+++ b/src/core/ddsi/defconfig.c
@@ -99,14 +99,14 @@ void ddsi_config_init_default (struct ddsi_config *cfg)
   cfg->ssl_min_version.minor = 3;
 #endif /* DDS_HAS_TCP_TLS */
 }
-/* generated from ddsi_config.h[83ad19f1a665710b0c82b3ac6b861e6c8e83913f] */
+/* generated from ddsi_config.h[e6e75c7c07b3b91a92715063cfd8abdd0fbd8b08] */
 /* generated from ddsi__cfgunits.h[bd22f0c0ed210501d0ecd3b07c992eca549ef5aa] */
-/* generated from ddsi__cfgelems.h[194217161977869610495a7889bbc1e6bc976ce1] */
-/* generated from ddsi_config.c[a439a20e32fe327db26f2f10028d0056e46c1a0b] */
-/* generated from _confgen.h[e32eabfc35e9f3a7dcb63b19ed148c0d17c6e5fc] */
+/* generated from ddsi__cfgelems.h[69679834d0a592a339803ed27e3966adc900d592] */
+/* generated from ddsi_config.c[8d7ef0ae962a47cb2138de27ac0f6751e3393c66] */
+/* generated from _confgen.h[9554f1d72645c0b8bb66ffbfbc3c0fb664fc1a43] */
 /* generated from _confgen.c[237308acd53897a34e8c643e16e05a61d73ffd65] */
 /* generated from generate_rnc.c[b50e4b7ab1d04b2bc1d361a0811247c337b74934] */
 /* generated from generate_md.c[789b92e422631684352909cfb8bf43f6ceb16a01] */
 /* generated from generate_rst.c[3c4b523fbb57c8e4a7e247379d06a8021ccc21c4] */
 /* generated from generate_xsd.c[6b6818d7f17a35d56c376c04ec1410427f34c0f0] */
-/* generated from generate_defconfig.c[63ca9d8ae2f1ce2e761c9d4c0510a45eb062d830] */
+/* generated from generate_defconfig.c[631cafee70a6f9480e0267db8ffe883d806f5f70] */

--- a/src/core/ddsi/include/dds/ddsi/ddsi_config.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_config.h
@@ -120,12 +120,18 @@ struct ddsi_config_maybe_duration {
   dds_duration_t value;
 };
 
+struct ddsi_config_uint32_array {
+  uint32_t n;
+  uint32_t *xs;
+};
+
 struct ddsi_config_thread_properties_listelem {
   struct ddsi_config_thread_properties_listelem *next;
   char *name;
   ddsrt_sched_t sched_class;
   struct ddsi_config_maybe_int32 schedule_priority;
   struct ddsi_config_maybe_uint32 stack_size;
+  struct ddsi_config_uint32_array affinity;
 };
 
 struct ddsi_config_peer_listelem

--- a/src/core/ddsi/src/ddsi__cfgelems.h
+++ b/src/core/ddsi/src/ddsi__cfgelems.h
@@ -846,6 +846,16 @@ static struct cfgelem thread_properties_sched_cfgelems[] = {
       "special privileges from the underlying operating system to be able to "
       "assign some of the privileged priorities.</p>"
     )),
+  STRING("Affinity", NULL, 1, "",
+    MEMBEROF(ddsi_config_thread_properties_listelem, affinity),
+    FUNCTIONS(0, uf_uint32_array, ff_uint32_array, pf_uint32_array),
+    DESCRIPTION(
+      "<p>This element specifies the thread affinity using a string of "
+      "comma-separated unsigned 32-bit integers. The notional meaning "
+      "of the string is that it lists the IDs of the CPU cores to use, "
+      "but some platforms may use a different mapping. Ignored if "
+      "unsupported by the platform.</p>"
+    )),
   END_MARKER
 };
 

--- a/src/core/ddsi/src/ddsi_thread.c
+++ b/src/core/ddsi/src/ddsi_thread.c
@@ -334,6 +334,8 @@ static dds_return_t create_thread_int (struct ddsi_thread_state **ts1_out, const
     tattr.schedClass = tprops->sched_class; /* explicit default value in the enum */
     if (!tprops->stack_size.isdefault)
       tattr.stackSize = tprops->stack_size.value;
+    tattr.schedAffinityN = tprops->affinity.n;
+    tattr.schedAffinitySet = tprops->affinity.xs;
   }
   if (gv)
   {

--- a/src/ddsrt/include/dds/ddsrt/threads.h
+++ b/src/ddsrt/include/dds/ddsrt/threads.h
@@ -68,6 +68,9 @@ typedef struct {
   ddsrt_sched_t schedClass;
   /** Specifies the thread priority */
   int32_t schedPriority;
+  /** Specifies thread affinity, N = 0, Set = NULL or N > 0 and Set[0..N-1] contains N CPU ids */
+  uint32_t schedAffinityN;
+  uint32_t *schedAffinitySet;
   /** Specifies the thread stack size */
   uint32_t stackSize;
 } ddsrt_threadattr_t;

--- a/src/ddsrt/src/threads.c
+++ b/src/ddsrt/src/threads.c
@@ -11,6 +11,7 @@
 #include <assert.h>
 
 #include "dds/ddsrt/threads.h"
+#include "dds/ddsrt/heap.h"
 
 void
 ddsrt_threadattr_init (
@@ -19,5 +20,7 @@ ddsrt_threadattr_init (
   assert(attr != NULL);
   attr->schedClass = DDSRT_SCHED_DEFAULT;
   attr->schedPriority = 0;
+  attr->schedAffinityN = 0;
+  attr->schedAffinitySet = NULL;
   attr->stackSize = 0;
 }

--- a/src/tools/_confgen/_confgen.h
+++ b/src/tools/_confgen/_confgen.h
@@ -53,6 +53,7 @@ void gendef_pf_transport_selector (FILE *fp, void *parent, struct cfgelem const 
 void gendef_pf_many_sockets_mode (FILE *fp, void *parent, struct cfgelem const * const cfgelem);
 void gendef_pf_standards_conformance (FILE *fp, void *parent, struct cfgelem const * const cfgelem);
 void gendef_pf_shm_loglevel (FILE *fp, void *parent, struct cfgelem const * const cfgelem);
+void gendef_pf_uint32_array (FILE *out, void *parent, struct cfgelem const * const cfgelem);
 
 struct cfgunit {
   const char *name;

--- a/src/tools/_confgen/generate_defconfig.c
+++ b/src/tools/_confgen/generate_defconfig.c
@@ -193,6 +193,14 @@ void gendef_pf_standards_conformance (FILE *out, void *parent, struct cfgelem co
 void gendef_pf_shm_loglevel (FILE *out, void *parent, struct cfgelem const * const cfgelem) {
   gendef_pf_int (out, parent, cfgelem);
 }
+void gendef_pf_uint32_array (FILE *out, void *parent, struct cfgelem const * const cfgelem) {
+  (void) out;
+  struct ddsi_config_uint32_array const * const p = cfg_address (parent, cfgelem);
+  if (p->n != 0) {
+    fprintf (stderr, "generate_defconfig internal error: non-empty uint32_array not handled\n");
+    abort ();
+  }
+}
 
 static void gen_defaults (FILE *out, void *parent, struct cfgelem const * const cfgelem)
 {


### PR DESCRIPTION
This adds a Thread/Scheduling/Affinity option, which is a list of unsigned 32-bit
integers indicating in some manner what CPUs to bind the thread to. Silently ignored on
platforms that do not support it (or where Cyclone doesn't provide support for it yet).

Currently only on Linux, where it is interpreted as a list of CPU ids.