### PR TITLE
Use interface with highest priority for ACKs and retransmits

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/ddsi_proxy_endpoint.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_proxy_endpoint.h
@@ -37,6 +37,7 @@ struct ddsi_proxy_endpoint_common
   struct ddsi_proxy_endpoint_common *prev_ep; /* prev / -- this is in arbitrary ordering */
   struct dds_qos *xqos; /* proxy endpoint QoS lives here; FIXME: local ones should have it moved to common as well */
   struct ddsi_addrset *as; /* address set to use for communicating with this endpoint */
+  ddsi_xlocator_t loc_uc; /* preferred address for sending unicast */
   ddsi_guid_t group_guid; /* 0:0:0:0 if not available */
   ddsi_vendorid_t vendor; /* cached from proxypp->vendor */
   ddsi_seqno_t seq; /* sequence number of most recent SEDP message */

--- a/src/core/ddsi/src/ddsi__addrset.h
+++ b/src/core/ddsi/src/ddsi__addrset.h
@@ -92,10 +92,6 @@ bool ddsi_addrset_any_mc (const struct ddsi_addrset *as, ddsi_xlocator_t *dst)
   ddsrt_nonnull_all;
 
 /** @component locators */
-void ddsi_addrset_any_uc_else_mc_nofail (const struct ddsi_addrset *as, ddsi_xlocator_t *dst)
-  ddsrt_nonnull_all;
-
-/** @component locators */
 bool ddsi_addrset_contains_non_psmx_uc (const struct ddsi_addrset *as)
   ddsrt_nonnull_all;
 

--- a/src/core/ddsi/src/ddsi_xmsg.c
+++ b/src/core/ddsi/src/ddsi_xmsg.c
@@ -723,11 +723,7 @@ void ddsi_xmsg_setdst_prd (struct ddsi_xmsg *m, const struct ddsi_proxy_reader *
   // only accepting endpoints that have an address
   assert (m->dstmode == NN_XMSG_DST_UNSET);
   if (!prd->redundant_networking)
-  {
-    ddsi_xlocator_t loc;
-    ddsi_addrset_any_uc (prd->c.as, &loc);
-    ddsi_xmsg_setdst1 (prd->e.gv, m, &prd->e.guid.prefix, &loc);
-  }
+    ddsi_xmsg_setdst1 (prd->e.gv, m, &prd->e.guid.prefix, &prd->c.loc_uc);
   else
   {
     // FIXME: maybe I should work on the merging instead ...
@@ -744,11 +740,7 @@ void ddsi_xmsg_setdst_pwr (struct ddsi_xmsg *m, const struct ddsi_proxy_writer *
   // only accepting endpoints that have an address
   assert (m->dstmode == NN_XMSG_DST_UNSET);
   if (!pwr->redundant_networking)
-  {
-    ddsi_xlocator_t loc;
-    ddsi_addrset_any_uc (pwr->c.as, &loc);
-    ddsi_xmsg_setdst1 (pwr->e.gv, m, &pwr->e.guid.prefix, &loc);
-  }
+    ddsi_xmsg_setdst1 (pwr->e.gv, m, &pwr->e.guid.prefix, &pwr->c.loc_uc);
   else
   {
     // FIXME: maybe I should work on the merging instead ...


### PR DESCRIPTION
This changes Cyclone to use the network interface with the highest priority for sending
ACKs, unicast heartbeats and (unicast) retransmit messages, rather than the network
interface that happens to be picked by "ddsi_addrset_any_uc".

It has the side benefit that copying the locator out of the proxy entity is cheaper than
extracting an address from the proxy entity's address set.