### PR TITLE
add option to set realtime priority to iceorix notification thread (linux only)

### DIFF
--- a/src/psmx_iox/CMakeLists.txt
+++ b/src/psmx_iox/CMakeLists.txt
@@ -18,7 +18,9 @@ set(psmx_iox_sources
   src/psmx_iox_impl.cpp
   include/psmx_iox_impl.hpp
   src/machineid.cpp
-  src/machineid.hpp)
+  src/machineid.hpp
+  src/scheduling.hpp
+  src/scheduling.cpp)
 
 if(BUILD_SHARED_LIBS)
   add_library(psmx_iox SHARED ${psmx_iox_sources})

--- a/src/psmx_iox/src/psmx_iox_impl.cpp
+++ b/src/psmx_iox/src/psmx_iox_impl.cpp
@@ -32,6 +32,7 @@
 
 #include "psmx_iox_impl.hpp"
 #include "machineid.hpp"
+#include "scheduling.hpp"
 
 #define ERROR_PREFIX "=== [ICEORYX] "
 
@@ -93,7 +94,7 @@ static bool is_wildcard_partition(const char *str)
 
 struct iox_psmx : public dds_psmx_t
 {
-  iox_psmx(dds_psmx_instance_id_t identifier, const std::string& service_name, const dds_psmx_node_identifier_t& node_id, bool support_keyed_topics, bool allow_nondisc_wr, int prio, uint64_t affinity);
+  iox_psmx(dds_psmx_instance_id_t identifier, const std::string& service_name, const dds_psmx_node_identifier_t& node_id, bool support_keyed_topics, bool allow_nondisc_wr, sched::sched_info sched_info);
   ~iox_psmx();
   bool _support_keyed_topics;
   bool _allow_nondisc_wr;
@@ -101,12 +102,13 @@ struct iox_psmx : public dds_psmx_t
   std::unique_ptr<iox::popo::Listener> _listener;  //the listener needs to be created after iox runtime has been initialized
   dds_psmx_node_identifier_t _node_id = { 0 };
   std::shared_ptr<iox::popo::UntypedPublisher> _node_id_publisher;
-  int thread_prio;
-  uint64_t thread_affinity;
-  bool set_thread_attr;
+  sched::sched_info _sched_info;
 };
 
-iox_psmx::iox_psmx(dds_psmx_instance_id_t identifier, const std::string& service_name, const dds_psmx_node_identifier_t& node_id, bool support_keyed_topics, bool allow_nondisc_wr, int prio, uint64_t affinity) :
+// Whether Iceoryx listener thread(s) need to set the priority
+static thread_local bool sched_info_set = false;
+
+iox_psmx::iox_psmx(dds_psmx_instance_id_t identifier, const std::string& service_name, const dds_psmx_node_identifier_t& node_id, bool support_keyed_topics, bool allow_nondisc_wr, sched::sched_info sched_info) :
   dds_psmx_t {
     .ops = psmx_ops,
     .instance_name = dds_string_dup ("CycloneDDS-IOX-PSMX"),
@@ -118,7 +120,8 @@ iox_psmx::iox_psmx(dds_psmx_instance_id_t identifier, const std::string& service
   _support_keyed_topics{support_keyed_topics},
   _allow_nondisc_wr{allow_nondisc_wr},
   _service_name{iox::capro::IdString_t(iox::cxx::TruncateToCapacity, service_name)},
-  _listener{}
+  _listener{},
+  _sched_info{sched_info}
 {
   uint64_t instance_hash = (uint64_t) ddsrt_random() << 32 | ddsrt_random();
   char iox_runtime_name[64];
@@ -127,9 +130,6 @@ iox_psmx::iox_psmx(dds_psmx_instance_id_t identifier, const std::string& service
   _listener = std::unique_ptr<iox::popo::Listener>(new iox::popo::Listener());
 
   _node_id = node_id;
-  thread_prio = prio;
-  thread_affinity = affinity;
-  set_thread_attr = (prio != 0);
   dds_psmx_init_generic(this);
 }
 
@@ -547,76 +547,19 @@ static dds_loaned_sample_t * iox_take(struct dds_psmx_endpoint * psmx_endpoint)
   return loaned_sample;
 }
 
-static dds_return_t set_thread_priority(ddsrt_thread_t thread, int priority)
-{
-#if defined(__linux)
-  int r;
-  struct sched_param param;
-  param.sched_priority = priority;
-
-  if ((priority < sched_get_priority_min(SCHED_FIFO)) || (priority > sched_get_priority_max(SCHED_FIFO)))
-  {
-    std::cerr << ERROR_PREFIX "failed to set thread priority: "<< priority <<" is out of acceptable range" << std::endl;
-    return DDS_RETCODE_ERROR;
-  }
-
-	if ((r = pthread_setschedparam(thread.v, SCHED_FIFO, &param)) != 0)
-	{
-	  std::cerr << ERROR_PREFIX "set thread priority failed with error " << r << std::endl;
-    return DDS_RETCODE_ERROR;
-	}
-#elif
-	DDSRT_UNUSED_ARG(thread);
-  DDSRT_UNUSED_ARG(priority);
-#endif
-  return DDS_RETCODE_OK;
-}
-
-static dds_return_t set_thread_affinity(ddsrt_thread_t thread, uint64_t affinity)
-{
-#if defined(__linux)
-  int r;
-  cpu_set_t cpuset;
-  long np = sysconf(_SC_NPROCESSORS_CONF);
-
-  if (affinity == 0)
-    return DDS_RETCODE_OK;
-
-  CPU_ZERO(&cpuset);
-  for (int i = 0; i < np; i++)
-  {
-    if (affinity & (1<<i))
-      CPU_SET(i, &cpuset);
-  }
-
-  if ((r = pthread_setaffinity_np(thread.v, sizeof(cpuset), &cpuset)) != 0)
-  {
-    std::cerr << ERROR_PREFIX "set thread affinity failed with error " << r << std::endl;
-    return DDS_RETCODE_ERROR;
-  }
-#elif defined(_WIN32)
-  DDSRT_UNUSED_ARG(thread);
-  DDSRT_UNUSED_ARG(affinity);
-#endif
-
-  return DDS_RETCODE_OK;
-}
-
 static void on_incoming_data_callback(iox::popo::UntypedSubscriber * subscriber, iox_psmx_endpoint * psmx_endpoint)
 {
-  psmx_endpoint->lock.lock();
-
   assert(psmx_endpoint->psmx_topic);
   assert(psmx_endpoint->psmx_topic->psmx_instance);
   struct iox_psmx *psmx = static_cast<struct iox_psmx *>(psmx_endpoint->psmx_topic->psmx_instance);
 
-  if (psmx->set_thread_attr)
-  {
-    (void)set_thread_priority(ddsrt_thread_self(), psmx->thread_prio);
-    (void)set_thread_affinity(ddsrt_thread_self(), psmx->thread_affinity);
-    psmx->set_thread_attr = false;
+  if (!sched_info_set) {
+    sched_info_set = true;
+    if (!sched_info_apply(psmx->_sched_info))
+      std::cerr << ERROR_PREFIX "failed to apply scheduling settings" << std::endl;
   }
 
+  psmx_endpoint->lock.lock();
   while (subscriber->hasData())
   {
     subscriber->take().and_then([psmx_endpoint](auto& sample) {
@@ -679,7 +622,7 @@ static void iox_loaned_sample_free(dds_loaned_sample_t *loan)
 static std::optional<std::string> get_config_option_value(const char *conf, const char *option_name, bool tolower = false)
 {
   char *copy = dds_string_dup (conf), *cursor = copy, *tok;
-  while ((tok = ddsrt_strsep (&cursor, ",/|;")) != nullptr)
+  while ((tok = ddsrt_strsep (&cursor, ";")) != nullptr)
   {
     if (strlen(tok) == 0)
       continue;
@@ -732,36 +675,6 @@ static std::optional<dds_psmx_node_identifier_t> to_node_identifier(const std::s
   return id;
 }
 
-static std::optional<uint64_t> to_affinity(const std::string& str)
-{
-  uint64_t bits = 0;
-  char *copy = dds_string_dup (str.c_str()), *cursor = copy, *tok;
-
-  while ((tok = ddsrt_strsep (&cursor, ":")) != nullptr)
-  {
-    int v,e;
-    if (strlen(tok) == 0)
-      continue;
-    char *f = ddsrt_strsep(&tok, "-");
-    v = atoi(f);
-    if (v > 0 && v <= 64) {
-      bits |= 1 << (v-1);
-    } else {
-      return std::nullopt;
-    }
-    if (tok != nullptr) {
-      e = atoi(tok);
-      if (e > v && e <= 64) {
-        int i;
-        for (i = v+1; i <= e; ++i) {
-          bits |= 1 << (i-1);
-        }
-      }
-    }
-  }
-  return bits;
-}
-
 dds_return_t iox_create_psmx(struct dds_psmx **psmx, dds_psmx_instance_id_t instance_id, const char *config)
 {
   assert(psmx);
@@ -812,20 +725,22 @@ dds_return_t iox_create_psmx(struct dds_psmx **psmx, dds_psmx_instance_id_t inst
       return DDS_RETCODE_ERROR;
   }
 
-  int thread_prio = 0;
-  auto opt_thread_prio = get_config_option_value(config, "SCHED_PRIO");
-  if (opt_thread_prio.has_value()) {
-    thread_prio = std::stoi(opt_thread_prio.value());
+  iox_psmx::sched::sched_info si;
+  auto opt_sched_prio = get_config_option_value(config, "PRIORITY");
+  if (opt_sched_prio.has_value()) {
+    if (!iox_psmx::sched::sched_info_setpriority (si, opt_sched_prio.value())) {
+      std::cerr << ERROR_PREFIX "invalid value for PRIORITY" << std::endl;
+      return DDS_RETCODE_ERROR;
+    }
+  }
+  auto opt_sched_affinity = get_config_option_value(config, "AFFINITY");
+  if (opt_sched_affinity.has_value()) {
+    if (!iox_psmx::sched::sched_info_setaffinity (si, opt_sched_affinity.value())) {
+      std::cerr << ERROR_PREFIX "invalid value for AFFINITY" << std::endl;
+      return DDS_RETCODE_ERROR;
+    }
   }
 
-  uint64_t thread_affinity = 0;
-  std::optional<uint64_t> affinity = std::nullopt;
-  auto opt_thread_affinity = get_config_option_value(config, "AFFINITY");
-  if (opt_thread_affinity.has_value())
-    affinity = to_affinity(opt_thread_affinity.value());
-  if (affinity.has_value())
-    thread_affinity = affinity.value();
-
-  *psmx = new iox_psmx::iox_psmx(instance_id, service_name, node_id.value(), keyed_topics, allow_nondisc_wr, thread_prio, thread_affinity);
+  *psmx = new iox_psmx::iox_psmx(instance_id, service_name, node_id.value(), keyed_topics, allow_nondisc_wr, si);
   return *psmx ? DDS_RETCODE_OK :  DDS_RETCODE_ERROR;
 }

--- a/src/psmx_iox/src/scheduling.cpp
+++ b/src/psmx_iox/src/scheduling.cpp
@@ -1,0 +1,190 @@
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+#include <cstring>
+#include <memory>
+#include <functional>
+
+#include <stddef.h>
+#include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/string.h"
+
+#include "scheduling.hpp"
+
+namespace iox_psmx { namespace sched {
+
+#if defined(__linux) || defined(__APPLE__)
+static bool valid_priority(prioclass_t cl, int prio)
+{
+  return (prio >= sched_get_priority_min(cl) && prio <= sched_get_priority_max(cl));
+}
+#elif defined(_WIN32)
+static bool valid_priority(prioclass_t cl, int prio)
+{
+  switch (prio)
+  {
+    case THREAD_PRIORITY_ABOVE_NORMAL:
+    case THREAD_PRIORITY_BELOW_NORMAL:
+    case THREAD_PRIORITY_HIGHEST:
+    case THREAD_PRIORITY_IDLE:
+    case THREAD_PRIORITY_LOWEST:
+    case THREAD_PRIORITY_NORMAL:
+    case THREAD_PRIORITY_TIME_CRITICAL:
+      return true;
+    case -7: case -6: case -5: case -4: case -3:
+    case 3: case 4: case 5: case 6:
+      return (cl == REALTIME_PRIORITY_CLASS);
+    default:
+      return false;
+  }
+}
+#else
+static bool valid_priority(prioclass_t cl, int prio)
+{
+  static_cast<void>(cl);
+  static_cast<void>(prio);
+  return false;
+}
+#endif
+
+bool sched_info_setpriority(sched_info& si, const std::string& x)
+{
+  size_t priostart = x.find(':');
+  prioclass_t cl;
+#if defined(__linux) || defined(__APPLE_)
+  // The reason to raise the priority of the Iceoryx listener thread is to get the latencies
+  // down, so some a real-time scheduling class seems the most reasonable default
+  cl = SCHED_FIFO;
+#elif defined(_WIN32)
+  cl = GetPriorityClass(GetCurrentProcess());
+#else
+  cl = 0;
+#endif
+  if (priostart == x.npos)
+    priostart = 0;
+  else
+  {
+    std::string cstr = x.substr(0, priostart);
+    std::transform(cstr.begin(), cstr.end(), cstr.begin(), [](unsigned char c){ return std::toupper(c); });
+#if defined(__linux) || defined(__APPLE_)
+    if (cstr == "OTHER")         cl = SCHED_OTHER;
+    else if (cstr == "FIFO")     cl = SCHED_FIFO;
+    else if (cstr == "RT")       cl = SCHED_RR;
+    else return false;
+#else
+    return false;
+#endif
+    ++priostart;
+  }
+  int prio;
+  try {
+    prio = std::stoi(x.substr(priostart));
+  } catch (std::exception()) {
+    return false;
+  }
+  if (!valid_priority(cl, prio))
+    return false;
+  si.prio = class_prio{cl, prio};
+  return true;
+}
+
+static bool cpuset_set(cpuset_t& set, int id)
+{
+#if defined(__linux)
+  if (id < 0 || id >= CPU_SETSIZE)
+    return false;
+  CPU_SET(id, &set.x);
+  return true;
+#elif defined(_WIN32)
+  if (id < 0 || id >= CHAR_BIT * sizeof (uintptr_t))
+    return false;
+  set.mask |= (uintptr_t)1 << id;
+  return true;
+#else
+  static_cast<void>(set);
+  static_cast<void>(id);
+  return false;
+#endif
+}
+
+bool sched_info_setaffinity(sched_info& si, const std::string& x)
+{
+  cpuset_t cpuset;
+  std::unique_ptr<char, std::function<void(void *)>> copy{ddsrt_strdup(x.c_str()), ddsrt_free};
+  char *cursor = copy.get(), *tok;
+  while ((tok = ddsrt_strsep(&cursor, ",")) != nullptr)
+  {
+    int v, e, pos;
+    if (sscanf(tok, "%d-%d%n", &v, &e, &pos) == 2) {
+      // skip
+    } else if (sscanf(tok, "%d%n", &v, &pos) == 1) {
+      e = v;
+    } else {
+      return false;
+    }
+    if (e < v || tok[pos] != 0) {
+      return false;
+    }
+    for (int i = v; i <= e; i++) {
+      if (!cpuset_set(cpuset, v))
+        return false;
+    }
+  }
+  si.affinity = cpuset;
+  return true;
+}
+
+static bool set_thread_priority(const class_prio& cp)
+{
+#if defined(__linux) || defined(__APPLE__)
+  struct sched_param param;
+  memset(static_cast<void *>(&param), 0, sizeof(param));
+  param.sched_priority = cp.priority;
+  if (pthread_setschedparam(pthread_self(), cp.schedclass, &param) == 0)
+    return true;
+#elif defined(_WIN32)
+  if (SetThreadPriority(GetCurrentThread(), cp.priority))
+    return true;
+#else
+  static_cast<void>(cp);
+#endif
+  return false;
+}
+
+static bool set_thread_affinity(const cpuset_t& affinity)
+{
+#if defined(__linux)
+  if (pthread_setaffinity_np(pthread_self(), sizeof(affinity.x), &affinity.x) == 0)
+    return true;
+#elif defined(_WIN32)
+  if (SetThreadAffinityMask(GetCurrentThread(), affinity.mask))
+    return true;
+#else
+  static_cast<void>(affinity);
+#endif
+  return false;
+}
+
+bool sched_info_apply(const sched_info& si)
+{
+  if (si.prio.has_value()) {
+    if (!set_thread_priority(si.prio.value()))
+      return false;
+  }
+  if (si.affinity.has_value()) {
+    if (!set_thread_affinity(si.affinity.value()))
+      return false;
+  }
+  return true;
+}
+
+} } // namespace

--- a/src/psmx_iox/src/scheduling.hpp
+++ b/src/psmx_iox/src/scheduling.hpp
@@ -1,0 +1,59 @@
+// Copyright(c) 2024 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+#ifndef SCHEDULING_HPP
+#define SCHEDULING_HPP
+
+#include <cstdint>
+#include <array>
+#include <optional>
+
+#if defined(__linux) || defined(__APPLE__)
+#include <pthread.h>
+#include <sched.h>
+#endif
+
+namespace iox_psmx { namespace sched {
+
+struct cpuset_t {
+#if defined(__linux)
+  cpuset_t() { CPU_ZERO (&x); }
+  cpu_set_t x;
+#elif defined(_WIN32)
+  cpuset_t() : mask(0) { }
+  uintptr_t mask;
+#endif
+};
+
+#if defined(__linux) || defined(__APPLE__)
+typedef int prioclass_t;
+#elif defined(_WIN32)
+typedef uint32_t prioclass_t;
+#else
+typedef int prioclass_t; // so we have something
+#endif
+
+struct class_prio {
+  prioclass_t schedclass;
+  int priority;
+};
+
+struct sched_info {
+  std::optional<class_prio> prio;
+  std::optional<cpuset_t> affinity;
+};
+
+bool sched_info_setpriority(sched_info& si, const std::string& x);
+bool sched_info_setaffinity(sched_info& si, const std::string& x);
+bool sched_info_apply(const sched_info& x);
+
+} };
+
+#endif /* SCHEDULING_HPP */


### PR DESCRIPTION
An option to set the realtime priority and the affinity to the psmx-iox notification thread is added. Currently this is implemented for linux only.