### PR TITLE
Improve performance of publishing complex types over PSMX only

### DIFF
--- a/src/core/cdr/include/dds/cdr/dds_cdrstream.h
+++ b/src/core/cdr/include/dds/cdr/dds_cdrstream.h
@@ -205,19 +205,23 @@ DDS_EXPORT uint32_t dds_stream_countops (const uint32_t * __restrict ops, uint32
 size_t dds_stream_check_optimize (const struct dds_cdrstream_desc * __restrict desc, uint32_t xcdr_version);
 
 /** @component cdr_serializer */
-void dds_stream_write_key (dds_ostream_t * __restrict os, enum dds_cdr_key_serialization_kind ser_kind, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict sample, const struct dds_cdrstream_desc * __restrict desc);
+bool dds_stream_write_key (dds_ostream_t * __restrict os, enum dds_cdr_key_serialization_kind ser_kind, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict sample, const struct dds_cdrstream_desc * __restrict desc)
+  ddsrt_attribute_warn_unused_result;
 
 /** @component cdr_serializer */
-void dds_stream_write_keyBE (dds_ostreamBE_t * __restrict os, enum dds_cdr_key_serialization_kind ser_kind, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict sample, const struct dds_cdrstream_desc * __restrict desc);
+bool dds_stream_write_keyBE (dds_ostreamBE_t * __restrict os, enum dds_cdr_key_serialization_kind ser_kind, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict sample, const struct dds_cdrstream_desc * __restrict desc)
+  ddsrt_attribute_warn_unused_result;
 
 /** @component cdr_serializer */
-DDS_EXPORT bool dds_stream_extract_key_from_data (dds_istream_t * __restrict is, dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const struct dds_cdrstream_desc * __restrict desc);
+DDS_EXPORT bool dds_stream_extract_key_from_data (dds_istream_t * __restrict is, dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const struct dds_cdrstream_desc * __restrict desc)
+  ddsrt_attribute_warn_unused_result;
 
 /** @component cdr_serializer */
 DDS_EXPORT void dds_stream_extract_key_from_key (dds_istream_t * __restrict is, dds_ostream_t * __restrict os, enum dds_cdr_key_serialization_kind ser_kind, const struct dds_cdrstream_allocator * __restrict allocator, const struct dds_cdrstream_desc * __restrict desc);
 
 /** @component cdr_serializer */
-DDS_EXPORT bool dds_stream_extract_keyBE_from_data (dds_istream_t * __restrict is, dds_ostreamBE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const struct dds_cdrstream_desc * __restrict desc);
+DDS_EXPORT bool dds_stream_extract_keyBE_from_data (dds_istream_t * __restrict is, dds_ostreamBE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const struct dds_cdrstream_desc * __restrict desc)
+  ddsrt_attribute_warn_unused_result;
 
 /** @component cdr_serializer */
 DDS_EXPORT void dds_stream_extract_keyBE_from_key (dds_istream_t * __restrict is, dds_ostreamBE_t * __restrict os, enum dds_cdr_key_serialization_kind ser_kind, const struct dds_cdrstream_allocator * __restrict allocator, const struct dds_cdrstream_desc * __restrict desc);

--- a/src/core/cdr/include/dds/cdr/dds_cdrstream.h
+++ b/src/core/cdr/include/dds/cdr/dds_cdrstream.h
@@ -166,31 +166,40 @@ dds_ostream_t dds_ostream_from_buffer(void *buffer, size_t size, uint16_t write_
  * @param actual_size   is set to the actual size of the data (*actual_size <= size) on successful return
  * @returns             True iff validation and normalization succeeded
  */
-DDS_EXPORT bool dds_stream_normalize (void * __restrict data, uint32_t size, bool bswap, uint32_t xcdr_version, const struct dds_cdrstream_desc * __restrict desc, bool just_key, uint32_t * __restrict actual_size) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+DDS_EXPORT bool dds_stream_normalize (void * __restrict data, uint32_t size, bool bswap, uint32_t xcdr_version, const struct dds_cdrstream_desc * __restrict desc, bool just_key, uint32_t * __restrict actual_size)
+  ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
 
 /** @component cdr_serializer */
-DDS_EXPORT const uint32_t *dds_stream_normalize_data (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t * __restrict ops) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+DDS_EXPORT const uint32_t *dds_stream_normalize_data (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t * __restrict ops)
+  ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
 
 /** @component cdr_serializer */
-DDS_EXPORT const uint32_t *dds_stream_write (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict data, const uint32_t * __restrict ops);
+DDS_EXPORT const uint32_t *dds_stream_write (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict data, const uint32_t * __restrict ops)
+  ddsrt_attribute_warn_unused_result;
 
 /** @component cdr_serializer */
-DDS_EXPORT const uint32_t *dds_stream_writeLE (dds_ostreamLE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict data, const uint32_t * __restrict ops);
+DDS_EXPORT const uint32_t *dds_stream_writeLE (dds_ostreamLE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict data, const uint32_t * __restrict ops)
+  ddsrt_attribute_warn_unused_result;
 
 /** @component cdr_serializer */
-DDS_EXPORT const uint32_t *dds_stream_writeBE (dds_ostreamBE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict data, const uint32_t * __restrict ops);
+DDS_EXPORT const uint32_t *dds_stream_writeBE (dds_ostreamBE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict data, const uint32_t * __restrict ops)
+  ddsrt_attribute_warn_unused_result;
 
 /** @component cdr_serializer */
-DDS_EXPORT const uint32_t * dds_stream_write_with_byte_order (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict data, const uint32_t * __restrict ops, enum ddsrt_byte_order_selector bo);
+DDS_EXPORT const uint32_t * dds_stream_write_with_byte_order (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict data, const uint32_t * __restrict ops, enum ddsrt_byte_order_selector bo)
+  ddsrt_attribute_warn_unused_result;
 
 /** @component cdr_serializer */
-DDS_EXPORT bool dds_stream_write_sample (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const void * __restrict data, const struct dds_cdrstream_desc * __restrict desc);
+DDS_EXPORT bool dds_stream_write_sample (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const void * __restrict data, const struct dds_cdrstream_desc * __restrict desc)
+  ddsrt_attribute_warn_unused_result;
 
 /** @component cdr_serializer */
-DDS_EXPORT bool dds_stream_write_sampleLE (dds_ostreamLE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const void * __restrict data, const struct dds_cdrstream_desc * __restrict desc);
+DDS_EXPORT bool dds_stream_write_sampleLE (dds_ostreamLE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const void * __restrict data, const struct dds_cdrstream_desc * __restrict desc)
+  ddsrt_attribute_warn_unused_result;
 
 /** @component cdr_serializer */
-DDS_EXPORT bool dds_stream_write_sampleBE (dds_ostreamBE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const void * __restrict data, const struct dds_cdrstream_desc * __restrict desc);
+DDS_EXPORT bool dds_stream_write_sampleBE (dds_ostreamBE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const void * __restrict data, const struct dds_cdrstream_desc * __restrict desc)
+  ddsrt_attribute_warn_unused_result;
 
 /** @component cdr_serializer */
 DDS_EXPORT void dds_stream_read_sample (dds_istream_t * __restrict is, void * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const struct dds_cdrstream_desc * __restrict desc);

--- a/src/core/cdr/include/dds/cdr/dds_cdrstream.h
+++ b/src/core/cdr/include/dds/cdr/dds_cdrstream.h
@@ -235,6 +235,14 @@ DDS_EXPORT size_t dds_stream_print_key (dds_istream_t * __restrict is, const str
 DDS_EXPORT size_t dds_stream_print_sample (dds_istream_t * __restrict is, const struct dds_cdrstream_desc * __restrict desc, char * __restrict buf, size_t size);
 
 /** @component cdr_serializer */
+DDS_EXPORT size_t dds_stream_getsize_sample (const char * __restrict data, const struct dds_cdrstream_desc * __restrict desc, uint32_t xcdr_version)
+  ddsrt_nonnull_all;
+
+/** @component cdr_serializer */
+DDS_EXPORT size_t dds_stream_getsize_key (enum dds_cdr_key_serialization_kind ser_kind, const char * __restrict sample, const struct dds_cdrstream_desc * __restrict desc, uint32_t xcdr_version)
+  ddsrt_nonnull_all;
+
+/** @component cdr_serializer */
 uint16_t dds_stream_minimum_xcdr_version (const uint32_t * __restrict ops);
 
 /** @component cdr_serializer */

--- a/src/core/cdr/src/dds_cdrstream.c
+++ b/src/core/cdr/src/dds_cdrstream.c
@@ -2333,8 +2333,8 @@ static bool normalize_bool (char * __restrict data, uint32_t * __restrict off, u
   if (*off == size)
     return normalize_error_bool ();
   uint8_t b = *((uint8_t *) (data + *off));
-  if (b > 1)
-    return normalize_error_bool ();
+  if (b > 1) // correct the representation of true
+    *((uint8_t *) (data + *off)) = 1;
   (*off)++;
   return true;
 }
@@ -2345,8 +2345,8 @@ static bool read_and_normalize_bool (bool * __restrict val, char * __restrict da
   if (*off == size)
     return normalize_error_bool ();
   uint8_t b = *((uint8_t *) (data + *off));
-  if (b > 1)
-    return normalize_error_bool ();
+  if (b > 1) // correct the representation of true
+    *((uint8_t *) (data + *off)) = 1;
   *val = b;
   (*off)++;
   return true;

--- a/src/core/cdr/src/dds_cdrstream.c
+++ b/src/core/cdr/src/dds_cdrstream.c
@@ -3080,6 +3080,19 @@ static bool normalize_string (char * __restrict data, uint32_t * __restrict off,
   return true;
 }
 
+static bool normalize_boolarray (char * __restrict data, uint32_t * __restrict off, uint32_t size, uint32_t num) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+static bool normalize_boolarray (char * __restrict data, uint32_t * __restrict off, uint32_t size, uint32_t num)
+{
+  if ((*off = check_align_prim_many (*off, size, 0, 0, num)) == UINT32_MAX)
+    return false;
+  uint8_t * const xs = (uint8_t *) (data + *off);
+  for (uint32_t i = 0; i < num; i++)
+    if (xs[i] > 1)
+      xs[i] = 1;
+  *off += num;
+  return true;
+}
+
 static bool normalize_primarray (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t num, enum dds_stream_typecode type, uint32_t xcdr_version) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
 static bool normalize_primarray (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t num, enum dds_stream_typecode type, uint32_t xcdr_version)
 {
@@ -3319,7 +3332,7 @@ static const uint32_t *normalize_arr (char * __restrict data, uint32_t * __restr
   switch (subtype)
   {
     case DDS_OP_VAL_BLN:
-      if (!normalize_enumarray (data, off, size1, bswap, 1, num, 1))
+      if (!normalize_boolarray (data, off, size1, num))
         return NULL;
       ops += 3;
       break;

--- a/src/core/cdr/src/dds_cdrstream.c
+++ b/src/core/cdr/src/dds_cdrstream.c
@@ -630,7 +630,10 @@ static uint32_t dds_stream_check_optimize1 (const struct dds_cdrstream_desc * __
 
     switch (DDS_OP_TYPE (insn))
     {
-      case DDS_OP_VAL_BLN: case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY:
+      case DDS_OP_VAL_BLN:
+        // rejecting "memcpy" if there's a boolean, because we want to guarantee true comes out as 1, not something != 0
+        return 0;
+      case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY:
         if (!check_optimize_impl (xcdr_version, ops, get_primitive_size (DDS_OP_TYPE (insn)), 1, &off, member_offs))
           return 0;
         ops += 2;
@@ -648,7 +651,10 @@ static uint32_t dds_stream_check_optimize1 (const struct dds_cdrstream_desc * __
       case DDS_OP_VAL_ARR:
         switch (DDS_OP_SUBTYPE (insn))
         {
-          case DDS_OP_VAL_BLN: case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY:
+          case DDS_OP_VAL_BLN:
+            // rejecting "memcpy" if there's a boolean, because we want to guarantee true comes out as 1, not something != 0
+            return 0;
+          case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY:
             if (!check_optimize_impl (xcdr_version, ops, get_primitive_size (DDS_OP_SUBTYPE (insn)), ops[2], &off, member_offs))
               return 0;
             ops += 3;

--- a/src/core/cdr/src/dds_cdrstream.c
+++ b/src/core/cdr/src/dds_cdrstream.c
@@ -1857,10 +1857,8 @@ static const uint32_t *dds_stream_getsize_delimited (struct getsize_state * __re
   return ops;
 }
 
-static bool dds_stream_getsize_pl_member (uint32_t mid, struct getsize_state * __restrict st, const char * __restrict data, const uint32_t * __restrict ops)
+static bool dds_stream_getsize_pl_member (struct getsize_state * __restrict st, const char * __restrict data, const uint32_t * __restrict ops)
 {
-  assert (!(mid & ~EMHEADER_MEMBERID_MASK));
-
   /* get flags from first member op */
   uint32_t flags = DDS_OP_FLAGS (ops[0]);
   bool is_key = flags & (DDS_OP_FLAG_MU | DDS_OP_FLAG_KEY);
@@ -1896,8 +1894,7 @@ static const uint32_t *dds_stream_getsize_pl_memberlist (struct getsize_state * 
         }
         else if (is_member_present (data, plm_ops))
         {
-          uint32_t member_id = ops[1];
-          if (!dds_stream_getsize_pl_member (member_id, st, data, plm_ops))
+          if (!dds_stream_getsize_pl_member (st, data, plm_ops))
             return NULL;
         }
         ops += 2;

--- a/src/core/cdr/src/dds_cdrstream.c
+++ b/src/core/cdr/src/dds_cdrstream.c
@@ -1974,9 +1974,9 @@ static void dds_stream_getsize_key_impl (struct getsize_state * __restrict st, c
   assert (insn_key_ok_p (insn));
   void *addr = (char *) src + ops[1];
 
-  if (op_type_external (insn))
+  if (op_type_external (insn) || DDS_OP_TYPE (insn) == DDS_OP_VAL_STR)
   {
-    addr = *((char **) addr);
+    addr = *(char **) addr;
     if (addr == NULL && DDS_OP_TYPE (insn) != DDS_OP_VAL_STR)
       return;
   }
@@ -1990,7 +1990,7 @@ static void dds_stream_getsize_key_impl (struct getsize_state * __restrict st, c
     case DDS_OP_VAL_8BY: getsize_reserve (st, 8); break;
     case DDS_OP_VAL_ENU:
     case DDS_OP_VAL_BMK: getsize_reserve (st, DDS_OP_TYPE_SZ (insn)); break;
-    case DDS_OP_VAL_STR: dds_stream_getsize_string (st, *(char **) addr); break;
+    case DDS_OP_VAL_STR: dds_stream_getsize_string (st, addr); break;
     case DDS_OP_VAL_BST: dds_stream_getsize_string (st, addr); break;
     case DDS_OP_VAL_ARR: {
       const uint32_t num = ops[2];

--- a/src/core/cdr/src/dds_cdrstream_keys.part.h
+++ b/src/core/cdr/src/dds_cdrstream_keys.part.h
@@ -85,6 +85,9 @@ static void dds_stream_write_keyBO_impl (DDS_OSTREAM_T * __restrict os, const st
 
 void dds_stream_write_keyBO (DDS_OSTREAM_T * __restrict os, enum dds_cdr_key_serialization_kind ser_kind, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict sample, const struct dds_cdrstream_desc * __restrict desc)
 {
+#ifndef NDEBUG
+  const size_t check_start_index = ((dds_ostream_t *)os)->m_index;
+#endif
   if (desc->flagset & (DDS_TOPIC_KEY_APPENDABLE | DDS_TOPIC_KEY_MUTABLE) && ser_kind == DDS_CDR_KEY_SERIALIZATION_SAMPLE)
   {
     /* For types with key fields in aggregated types with appendable or mutable
@@ -119,6 +122,10 @@ void dds_stream_write_keyBO (DDS_OSTREAM_T * __restrict os, enum dds_cdr_key_ser
       }
     }
   }
+#ifndef NDEBUG
+  const size_t check_size = dds_stream_getsize_key (ser_kind, sample, desc, ((dds_ostream_t *)os)->m_xcdr_version);
+  assert (check_size == ((dds_ostream_t *)os)->m_index - check_start_index);
+#endif
 }
 
 static const uint32_t *dds_stream_extract_keyBO_from_data_adr (uint32_t insn, dds_istream_t * __restrict is, DDS_OSTREAM_T * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator,

--- a/src/core/cdr/src/dds_cdrstream_keys.part.h
+++ b/src/core/cdr/src/dds_cdrstream_keys.part.h
@@ -25,7 +25,7 @@ static void dds_stream_write_keyBO_impl (DDS_OSTREAM_T * __restrict os, const st
 
   switch (DDS_OP_TYPE (insn))
   {
-    case DDS_OP_VAL_BLN:
+    case DDS_OP_VAL_BLN: dds_os_put1BO (os, allocator, *((uint8_t *) addr) != 0); break;
     case DDS_OP_VAL_1BY: dds_os_put1BO (os, allocator, *((uint8_t *) addr)); break;
     case DDS_OP_VAL_2BY: dds_os_put2BO (os, allocator, *((uint16_t *) addr)); break;
     case DDS_OP_VAL_4BY: dds_os_put4BO (os, allocator, *((uint32_t *) addr)); break;
@@ -42,7 +42,11 @@ static void dds_stream_write_keyBO_impl (DDS_OSTREAM_T * __restrict os, const st
       const uint32_t num = ops[2];
       switch (DDS_OP_SUBTYPE (insn))
       {
-        case DDS_OP_VAL_BLN: case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY: {
+        case DDS_OP_VAL_BLN:
+          if (!dds_stream_write_bool_arrBO (os, allocator, addr, num))
+            return false;
+          break;
+        case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY: {
           const uint32_t elem_size = get_primitive_size (DDS_OP_SUBTYPE (insn));
           const align_t cdr_align = dds_cdr_get_align (((struct dds_ostream *)os)->m_xcdr_version, elem_size);
           dds_cdr_alignto_clear_and_resizeBO (os, allocator, cdr_align, num * elem_size);

--- a/src/core/cdr/src/dds_cdrstream_keys.part.h
+++ b/src/core/cdr/src/dds_cdrstream_keys.part.h
@@ -16,8 +16,12 @@ static void dds_stream_write_keyBO_impl (DDS_OSTREAM_T * __restrict os, const st
   assert (insn_key_ok_p (insn));
   void *addr = (char *) src + ops[1];
 
-  if (op_type_external (insn))
-    addr = *((char **) addr);
+  if (op_type_external (insn) || DDS_OP_TYPE (insn) == DDS_OP_VAL_STR)
+  {
+    addr = *(char **) addr;
+    if (addr == NULL && DDS_OP_TYPE (insn) != DDS_OP_VAL_STR)
+      return;
+  }
 
   switch (DDS_OP_TYPE (insn))
   {
@@ -32,7 +36,7 @@ static void dds_stream_write_keyBO_impl (DDS_OSTREAM_T * __restrict os, const st
     case DDS_OP_VAL_BMK:
       (void) dds_stream_write_bitmask_valueBO (os, allocator, insn, addr, ops[2], ops[3]);
       break;
-    case DDS_OP_VAL_STR: dds_stream_write_stringBO (os, allocator, *(char **) addr); break;
+    case DDS_OP_VAL_STR: dds_stream_write_stringBO (os, allocator, addr); break;
     case DDS_OP_VAL_BST: dds_stream_write_stringBO (os, allocator, addr); break;
     case DDS_OP_VAL_ARR: {
       const uint32_t num = ops[2];

--- a/src/core/cdr/src/dds_cdrstream_write.part.h
+++ b/src/core/cdr/src/dds_cdrstream_write.part.h
@@ -197,10 +197,7 @@ static const uint32_t *dds_stream_write_seqBO (DDS_OSTREAM_T * __restrict os, co
 
   const uint32_t num = seq->_length;
   if (bound && num > bound)
-  {
-    dds_ostreamBO_fini (os, allocator);
     return NULL;
-  }
 
   dds_os_put4BO (os, allocator, num);
 

--- a/src/core/cdr/src/dds_cdrstream_write.part.h
+++ b/src/core/cdr/src/dds_cdrstream_write.part.h
@@ -12,9 +12,7 @@ static const uint32_t *dds_stream_write_implBO (DDS_OSTREAM_T * __restrict os, c
 
 static inline bool dds_stream_write_bool_valueBO (DDS_OSTREAM_T * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const uint8_t val)
 {
-  if (val > 1)
-    return false;
-  dds_os_put1BO (os, allocator, val);
+  dds_os_put1BO (os, allocator, val != 0);
   return true;
 }
 
@@ -366,7 +364,7 @@ static bool dds_stream_write_union_discriminantBO (DDS_OSTREAM_T * __restrict os
   switch (type)
   {
     case DDS_OP_VAL_BLN:
-      *disc = *((const uint8_t *) addr);
+      *disc = *((const uint8_t *) addr) != 0;
       if (!dds_stream_write_bool_valueBO (os, allocator, (uint8_t) *disc))
         return false;
       break;

--- a/src/core/ddsc/src/dds_sertype_default.c
+++ b/src/core/ddsc/src/dds_sertype_default.c
@@ -222,16 +222,6 @@ static dds_return_t sertype_default_get_serialized_size (const struct ddsi_serty
   else
     *size = dds_stream_getsize_sample (sample, &tp->type, tp->write_encoding_version);
   *enc_identifier = ddsi_sertype_get_native_enc_identifier (tp->write_encoding_version, tp->encoding_format);
-#ifndef NDEBUG
-  struct ddsi_serdata *serdata = ddsi_serdata_from_sample (tpcmn, sdkind, sample);
-  if (serdata == NULL)
-    return DDS_RETCODE_BAD_PARAMETER;
-  struct dds_cdr_header hdr;
-  ddsi_serdata_to_ser (serdata, 0, sizeof (struct dds_cdr_header), &hdr);
-  assert (*size == ddsi_serdata_size (serdata) - sizeof (struct dds_cdr_header) - ddsrt_fromBE2u (hdr.options));
-  assert (*enc_identifier = hdr.identifier);
-  ddsi_serdata_unref (serdata);
-#endif
   return DDS_RETCODE_OK;
 }
 

--- a/src/core/ddsc/src/dds_sertype_default.c
+++ b/src/core/ddsc/src/dds_sertype_default.c
@@ -236,14 +236,9 @@ static bool sertype_default_serialize_into (const struct ddsi_sertype *tpcmn, en
     .m_xcdr_version = tp->write_encoding_version
   };
   if (sdkind == SDK_KEY)
-  {
-    dds_stream_write_key (&os, DDS_CDR_KEY_SERIALIZATION_SAMPLE, &no_allocator, sample, &tp->type);
-    return true;
-  }
+    return dds_stream_write_key (&os, DDS_CDR_KEY_SERIALIZATION_SAMPLE, &no_allocator, sample, &tp->type);
   else
-  {
     return dds_stream_write_sample (&os, &no_allocator, sample, &tp->type);
-  }
 }
 
 const struct ddsi_sertype_ops dds_sertype_ops_default = {

--- a/src/core/ddsc/tests/CMakeLists.txt
+++ b/src/core/ddsc/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ idlc_generate(TARGET CdrStreamOptimize FILES CdrStreamOptimize.idl WARNINGS no-i
 idlc_generate(TARGET CdrStreamSkipDefault FILES CdrStreamSkipDefault.idl)
 idlc_generate(TARGET CdrStreamKeySize FILES CdrStreamKeySize.idl)
 idlc_generate(TARGET CdrStreamKeyExt FILES CdrStreamKeyExt.idl)
+idlc_generate(TARGET CdrStreamChecking FILES CdrStreamChecking.idl)
 idlc_generate(TARGET SerdataData FILES SerdataData.idl)
 idlc_generate(TARGET PsmxDataModels FILES PsmxDataModels.idl WARNINGS no-implicit-extensibility)
 idlc_generate(TARGET CdrStreamDataTypeInfo FILES CdrStreamDataTypeInfo.idl WARNINGS no-implicit-extensibility)
@@ -214,6 +215,7 @@ target_link_libraries(cunit_ddsc PRIVATE
   CdrStreamOptimize
   CdrStreamSkipDefault
   CdrStreamDataTypeInfo
+  CdrStreamChecking
   PsmxDataModels
   psmx_dummy
   DynamicData

--- a/src/core/ddsc/tests/CdrStreamChecking.idl
+++ b/src/core/ddsc/tests/CdrStreamChecking.idl
@@ -1,0 +1,50 @@
+// Copyright(c) 2024 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+module CdrStreamChecking {
+  // sequence length, null pointer for non-empty sequence
+  @final struct t1 { sequence<octet, 1> f1; };
+
+  // out-of-bound enum
+  @final enum en2 { E2_1 };
+  @final struct t2 { en2 f1; };
+
+  // out-of-bound bitmask
+  @final bitmask bm3 { B3_1 };
+  @final struct t3 { bm3 f1; };
+
+  // null pointers (only first rejects a null pointer: Cyclone accepts strings to be null)
+  @final struct t4 { @external octet f1; };
+  @final struct t4a { @external @optional octet f1; };
+  @final struct t4b { @external string f1; };
+
+  // external union member: may not be null, unless it is a string
+  @nested @final union u5 switch (long) {
+    case 0: @external octet c0;
+    case 1: @external string c1;
+  };
+  @final struct t5 { u5 f1; };
+
+  // boolean: accept anything, but must turn into 0 or 1
+  // use t6x for constructing sample
+  @final struct t6 { boolean f1; };
+  @final struct t6x { octet f1; };
+
+  // union over boolean: must correctly map !=0 to case true
+  // use t7x for constructing sample
+  @nested @final union u7 switch (boolean) {
+    case true: octet c1;
+  };
+  @final struct t7 { u7 f1; };
+  @nested @final union u7x switch (octet) {
+    case 1: octet c1;
+  };
+  @final struct t7x { u7x f1; };
+};

--- a/src/core/ddsc/tests/CdrStreamChecking.idl
+++ b/src/core/ddsc/tests/CdrStreamChecking.idl
@@ -14,16 +14,16 @@ module CdrStreamChecking {
 
   // out-of-bound enum
   @final enum en2 { E2_1 };
-  @final struct t2 { en2 f1; };
+  @final struct t2 { @key en2 f1; };
 
   // out-of-bound bitmask
   @final bitmask bm3 { B3_1 };
-  @final struct t3 { bm3 f1; };
+  @final struct t3 { @key bm3 f1; };
 
   // null pointers (only first rejects a null pointer: Cyclone accepts strings to be null)
-  @final struct t4 { @external octet f1; };
+  @final struct t4 { @key @external octet f1; };
   @final struct t4a { @external @optional octet f1; };
-  @final struct t4b { @external string f1; };
+  @final struct t4b { @key @external string f1; };
 
   // external union member: may not be null, unless it is a string
   @nested @final union u5 switch (long) {
@@ -34,7 +34,7 @@ module CdrStreamChecking {
 
   // boolean: accept anything, but must turn into 0 or 1
   // use t6x for constructing sample
-  @final struct t6 { boolean f1; };
+  @final struct t6 { @key boolean f1; };
   @final struct t6x { octet f1; };
 
   // union over boolean: must correctly map !=0 to case true
@@ -47,4 +47,9 @@ module CdrStreamChecking {
     case 1: octet c1;
   };
   @final struct t7x { u7x f1; };
+
+  // boolean array: accept anything, but must turn into 0 or 1
+  // use t8x for constructing sample
+  @final struct t8 { @key boolean f1[2]; };
+  @final struct t8x { octet f1[2]; };
 };

--- a/src/core/ddsc/tests/CdrStreamOptimize.idl
+++ b/src/core/ddsc/tests/CdrStreamOptimize.idl
@@ -26,8 +26,10 @@ module CdrStreamOptimize {
   @final struct t5 { n5 f1; };
   @final struct t5a { n5 f1[3]; };
 
+  // with octet: optimizable, with boolean: not anymore because boolean
   enum en6 { E6_1, E6_2 };
-  @final struct t6 { boolean f1; en6 f2; octet f3; short f5; long f6; };
+  @final struct t6 { octet f1; en6 f2; octet f3; short f5; long f6; };
+  @final struct t6a { boolean f1; en6 f2; octet f3; short f5; long f6; };
 
   @nested @final struct n7 { octet f1; short f2; };
   @final struct t7 { octet f1; n7 f2; short f3; };
@@ -41,7 +43,8 @@ module CdrStreamOptimize {
   enum en10 { E10_1, E10_2 };
   @final struct t10 { en10 f1[3]; };
 
-  @final struct t11 { long f1[100]; long f2; float f3; char f4; boolean f5; };
+  @final struct t11 { long f1[100]; long f2; float f3; char f4; octet f5; };
+  @final struct t11a { long f1[100]; long f2; float f3; char f4; boolean f5; };
 
   bitmask bm12 { BM12_0, BM12_1 };
   @final struct t12 { bm12 f1; };
@@ -85,4 +88,12 @@ module CdrStreamOptimize {
 
   @nested @final struct b27 { long b1; };
   @final struct t27 : b27 { long long f1; };
+
+  @final struct t28 { boolean f1[2]; };
+
+  @nested @final struct b29 { long b1; };
+  @final struct t29 : b29 { boolean f1; };
+
+  @nested @final struct b30 { boolean b1; };
+  @final struct t30 : b30 { long f1; };
 };

--- a/src/core/ddsc/tests/Space.idl
+++ b/src/core/ddsc/tests/Space.idl
@@ -43,4 +43,19 @@ module Space {
     @key
     string              s;
   };
+
+  enum invalid_data_enum {
+    IDE0
+  };
+
+  bitmask invalid_data_bitmask {
+    IDB0
+  };
+
+  struct invalid_data {
+    sequence<octet, 1> o1;
+    invalid_data_enum e1;
+    invalid_data_bitmask bm1;
+    @external octet exto;
+  };
 };

--- a/src/core/ddsc/tests/Space.idl
+++ b/src/core/ddsc/tests/Space.idl
@@ -54,8 +54,8 @@ module Space {
 
   struct invalid_data {
     sequence<octet, 1> o1;
-    invalid_data_enum e1;
-    invalid_data_bitmask bm1;
-    @external octet exto;
+    @key invalid_data_enum e1;
+    @key invalid_data_bitmask bm1;
+    @key @external octet exto;
   };
 };

--- a/src/core/ddsc/tests/cdrstream.c
+++ b/src/core/ddsc/tests/cdrstream.c
@@ -1867,11 +1867,13 @@ CU_Test (ddsc_cdrstream, check_optimize)
     { D(t5),    16,    0, "XCDR2 uses 4 byte alignment for 64 bits types" },
     { D(t5a),    0,    0, "array of non-primitive type is currently not optimized (FIXME: could be optimized for XCDR1?)" },
     { D(t6),    16,   16, "CDR and memory have equal alignment" },
+    { D(t6a),    0,    0, "CDR and memory have equal alignment but boolean prevents optimization" },
     { D(t7),     0,    0, "field f2 is 1-byte aligned in CDR (because of 1-byte type in nested type), but 2-byte in memory" },
     { D(t8),     0,    0, "type of f2 is appendable" },
     { D(t9),     3,    0, "bitmask (bit bound 8) array (dheader in v2)" },
     { D(t10),   12,    0, "enum (bit bound 32) array (dheader in v2)" },
     { D(t11),  410,  410, "final type with array" },
+    { D(t11a),   0,    0, "final type with array but boolean prevents optimization" },
     { D(t12),    4,    4, "32 bits bitmask" },
     { D(t13),    1,    1, "8 bit bitmask" },
     { D(t14),    8,    8, "64 bits bitmask" },
@@ -1888,6 +1890,9 @@ CU_Test (ddsc_cdrstream, check_optimize)
     { D(t25),    0,    0, "union type currently not optimized" },
     { D(t26),    0,    0, "union type member currently not optimized" },
     { D(t27),   16,    0, "inheritance, base members before derived type members, xcdr2 has 4 byte alignment for long long" },
+    { D(t28),    0,    0, "array of booleans" },
+    { D(t29),    0,    0, "boolean in extended struct" },
+    { D(t30),    0,    0, "boolean in base struct" }
   };
 
   for (uint32_t i = 0; i < sizeof (tests) / sizeof (tests[0]); i++)

--- a/src/core/ddsc/tests/psmx.c
+++ b/src/core/ddsc/tests/psmx.c
@@ -1421,7 +1421,8 @@ static void deepcopy_sample_contents (const dds_topic_descriptor_t *tpdesc, void
   dds_cdrstream_desc_from_topic_desc (&desc, tpdesc);
   struct dds_ostream os;
   dds_ostream_init (&os, &dds_cdrstream_default_allocator, 0, DDSI_RTPS_CDR_ENC_VERSION_2);
-  dds_stream_write_sample (&os, &dds_cdrstream_default_allocator, input, &desc);
+  if (!dds_stream_write_sample (&os, &dds_cdrstream_default_allocator, input, &desc))
+    abort ();
   struct dds_istream is;
   dds_istream_init (&is, os.m_index, os.m_buffer, os.m_xcdr_version);
   memset (output, 0, desc.size);
@@ -1461,8 +1462,10 @@ static bool data_equal (const dds_topic_descriptor_t *tpdesc, const void *a, con
   }
   else
   {
-    dds_stream_write_sample (&osa, &dds_cdrstream_default_allocator, a, &desc);
-    dds_stream_write_sample (&osb, &dds_cdrstream_default_allocator, b, &desc);
+    if (!dds_stream_write_sample (&osa, &dds_cdrstream_default_allocator, a, &desc))
+      abort ();
+    if (!dds_stream_write_sample (&osb, &dds_cdrstream_default_allocator, b, &desc))
+      abort ();
   }
   const bool eq = (osa.m_index == osb.m_index) && memcmp (osa.m_buffer, osb.m_buffer, osa.m_index) == 0;
   dds_ostream_fini (&osa, &dds_cdrstream_default_allocator);

--- a/src/core/ddsc/tests/psmx.c
+++ b/src/core/ddsc/tests/psmx.c
@@ -1454,8 +1454,10 @@ static bool data_equal (const dds_topic_descriptor_t *tpdesc, const void *a, con
   dds_ostream_init (&osb, &dds_cdrstream_default_allocator, 0, DDSI_RTPS_CDR_ENC_VERSION_2);
   if (justkey)
   {
-    dds_stream_write_key (&osa, DDS_CDR_KEY_SERIALIZATION_SAMPLE, &dds_cdrstream_default_allocator, a, &desc);
-    dds_stream_write_key (&osb, DDS_CDR_KEY_SERIALIZATION_SAMPLE, &dds_cdrstream_default_allocator, b, &desc);
+    if (!dds_stream_write_key (&osa, DDS_CDR_KEY_SERIALIZATION_SAMPLE, &dds_cdrstream_default_allocator, a, &desc))
+      abort ();
+    if (!dds_stream_write_key (&osb, DDS_CDR_KEY_SERIALIZATION_SAMPLE, &dds_cdrstream_default_allocator, b, &desc))
+      abort ();
   }
   else
   {

--- a/src/core/ddsc/tests/write.c
+++ b/src/core/ddsc/tests/write.c
@@ -14,6 +14,7 @@
 #include "RoundTrip.h"
 #include "Space.h"
 #include "test_oneliner.h"
+#include "test_util.h"
 
 #include "dds/dds.h"
 #include "dds/ddsrt/io.h"
@@ -36,7 +37,9 @@ setup(void)
 {
     participant = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL, NULL);
     CU_ASSERT_FATAL(participant > 0);
-    topic = dds_create_topic(participant, &RoundTripModule_DataType_desc, "RoundTrip", NULL, NULL);
+    char topicname[100];
+    create_unique_topic_name ("RoundTrip", topicname, sizeof (topicname));
+    topic = dds_create_topic(participant, &RoundTripModule_DataType_desc, topicname, NULL, NULL);
     CU_ASSERT_FATAL(topic > 0);
     publisher = dds_create_publisher(participant, NULL, NULL);
     CU_ASSERT_FATAL(publisher > 0);
@@ -149,7 +152,9 @@ CU_Test(ddsc_write, simpletypes)
 
     par = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL, NULL);
     CU_ASSERT_FATAL(par > 0);
-    top = dds_create_topic(par, &Space_simpletypes_desc, "SimpleTypes", NULL, NULL);
+    char topicname[100];
+    create_unique_topic_name ("RoundTrip", topicname, sizeof (topicname));
+    top = dds_create_topic(par, &Space_simpletypes_desc, topicname, NULL, NULL);
     CU_ASSERT_FATAL(top > 0);
     wri = dds_create_writer(par, top, NULL, NULL);
     CU_ASSERT_FATAL(wri > 0);

--- a/src/core/ddsc/tests/write.c
+++ b/src/core/ddsc/tests/write.c
@@ -169,34 +169,34 @@ CU_Test(ddsc_write, simpletypes)
 
 CU_Test(ddsc_write, invalid_data)
 {
+    const struct { Space_invalid_data x; bool invalidkey; } tests[] = {
+        {
+            .x = { .o1={._length=2, ._buffer=(uint8_t[]){1,2}}, .e1=(Space_invalid_data_enum)0, .bm1=0, .exto=&(uint8_t){0} },
+            .invalidkey = false
+        },
+        {
+            .x = { .o1={._length=1, ._buffer=NULL}, .e1=(Space_invalid_data_enum)0, .bm1=0, .exto=&(uint8_t){0} },
+            .invalidkey = false
+        },
+        {
+            .x = { .o1={._length=1, ._buffer=(uint8_t[]){1}}, .e1=(Space_invalid_data_enum)1, .bm1=0, .exto=&(uint8_t){0} },
+            .invalidkey = true
+        },
+        {
+            .x = { .o1 = {._length=1, ._buffer=(uint8_t[]){1}}, .e1=(Space_invalid_data_enum)0, .bm1=2, .exto=&(uint8_t){0} },
+            .invalidkey = true
+        },
+        {
+            .x = { .o1={._length=1, ._buffer=(uint8_t[]){1}}, .e1=(Space_invalid_data_enum)0, .bm1=0, .exto=NULL },
+            .invalidkey = true
+        },
+        {
+            .x = { .o1={._length=1, ._buffer=(uint8_t[]){1}}, .e1=(Space_invalid_data_enum)0, .bm1=0, .exto=NULL },
+            .invalidkey = true
+        }
+    };
     dds_return_t status;
     dds_entity_t par, top, wri;
-    Space_invalid_data st_data[] = {
-      { .o1 = { ._length = 2, ._buffer = (uint8_t[]){1,2} },
-        .e1 = (Space_invalid_data_enum) 0,
-        .bm1 = 0,
-        .exto = &(uint8_t){0} },
-      { .o1 = { ._length = 1, ._buffer = NULL },
-        .e1 = (Space_invalid_data_enum) 0,
-        .bm1 = 0,
-        .exto = &(uint8_t){0} },
-      { .o1 = { ._length = 1, ._buffer = (uint8_t[]){1} },
-        .e1 = (Space_invalid_data_enum) 1,
-        .bm1 = 0,
-        .exto = &(uint8_t){0} },
-      { .o1 = { ._length = 1, ._buffer = (uint8_t[]){1} },
-        .e1 = (Space_invalid_data_enum) 0,
-        .bm1 = 2,
-        .exto = &(uint8_t){0} },
-      { .o1 = { ._length = 1, ._buffer = (uint8_t[]){1} },
-        .e1 = (Space_invalid_data_enum) 0,
-        .bm1 = 0,
-        .exto = NULL },
-      { .o1 = { ._length = 1, ._buffer = (uint8_t[]){1} },
-        .e1 = (Space_invalid_data_enum) 0,
-        .bm1 = 0,
-        .exto = NULL },
-    };
 
     par = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL, NULL);
     CU_ASSERT_FATAL(par > 0);
@@ -207,10 +207,16 @@ CU_Test(ddsc_write, invalid_data)
     wri = dds_create_writer(par, top, NULL, NULL);
     CU_ASSERT_FATAL(wri > 0);
 
-    for (size_t i = 0; i < sizeof (st_data) / sizeof (st_data[0]); i++)
+    for (size_t i = 0; i < sizeof (tests) / sizeof (tests[0]); i++)
     {
-        status = dds_write(wri, &st_data[i]);
+        status = dds_write(wri, &tests[i].x);
         CU_ASSERT_EQUAL_FATAL(status, DDS_RETCODE_BAD_PARAMETER);
+
+        if (tests[i].invalidkey)
+        {
+            status = dds_dispose(wri, &tests[i].x);
+            CU_ASSERT_EQUAL_FATAL(status, DDS_RETCODE_BAD_PARAMETER);
+        }
     }
 
     dds_delete(wri);

--- a/src/core/ddsi/include/dds/ddsi/ddsi_serdata.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_serdata.h
@@ -25,12 +25,6 @@ extern "C" {
 struct ddsi_rdata;
 struct dds_loaned_sample;
 
-enum ddsi_serdata_kind {
-  SDK_EMPTY,
-  SDK_KEY,
-  SDK_DATA
-};
-
 struct ddsi_serdata {
   const struct ddsi_serdata_ops *ops; /* cached from type->serdata_ops */
   uint32_t hash;

--- a/src/core/ddsi/include/dds/ddsi/ddsi_sertype.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_sertype.h
@@ -107,19 +107,14 @@ typedef void (*ddsi_sertype_free_samples_t) (const struct ddsi_sertype *d, void 
 /* Gets the type identifier of the requested kind (minimal or complete) for this sertype */
 typedef ddsi_typeid_t * (*ddsi_sertype_typeid_t) (const struct ddsi_sertype *tp, ddsi_typeid_kind_t kind);
 
-/* Compute the serialized size based on the sertype information and the sample */
-// Note: size_t maximum is reserved as error value
-typedef size_t (*ddsi_sertype_get_serialized_size_t)(
-    const struct ddsi_sertype *d, const void *sample);
+/* Compute the (unpadded) size of the CDR based on the sertype information and the sample (plus used encoding) */
+typedef dds_return_t (*ddsi_sertype_get_serialized_size_t) (const struct ddsi_sertype *tp, const void *sample, size_t *size, uint16_t *enc_identifier);
 
 /* Serialize into a destination buffer */
 // Note that we assume the destination buffer is large enough (we do not necessarily check)
 // The required size can be obtained with ddsi_sertype_get_serialized_size_t
 // Returns true if the serialization succeeds, false otherwise.
-typedef bool (*ddsi_sertype_serialize_into_t)(const struct ddsi_sertype *d,
-                                              const void *sample,
-                                              void *dst_buffer,
-                                              size_t dst_size);
+typedef bool (*ddsi_sertype_serialize_into_t)(const struct ddsi_sertype *d, const void *sample, void *dst_buffer, size_t dst_size);
 
 /* Gets the type map for this sertype */
 typedef ddsi_typemap_t * (*ddsi_sertype_typemap_t) (const struct ddsi_sertype *tp);
@@ -283,8 +278,8 @@ DDS_INLINE_EXPORT inline struct ddsi_sertype * ddsi_sertype_derive_sertype (cons
 }
 
 /** @component typesupport_if */
-DDS_INLINE_EXPORT inline size_t ddsi_sertype_get_serialized_size(const struct ddsi_sertype *tp, const void *sample) {
-  return tp->ops->get_serialized_size(tp, sample);
+DDS_INLINE_EXPORT inline dds_return_t ddsi_sertype_get_serialized_size(const struct ddsi_sertype *tp, const void *sample, size_t *size, uint16_t *enc_identifier) {
+  return tp->ops->get_serialized_size(tp, sample, size, enc_identifier);
 }
 
 /** @component typesupport_if */

--- a/src/core/ddsi/include/dds/ddsi/ddsi_sertype.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_sertype.h
@@ -114,13 +114,13 @@ typedef void (*ddsi_sertype_free_samples_t) (const struct ddsi_sertype *d, void 
 typedef ddsi_typeid_t * (*ddsi_sertype_typeid_t) (const struct ddsi_sertype *tp, ddsi_typeid_kind_t kind);
 
 /* Compute the (unpadded) size of the CDR based on the sertype information and the sample (plus used encoding) */
-typedef dds_return_t (*ddsi_sertype_get_serialized_size_t) (const struct ddsi_sertype *tp, const void *sample, size_t *size, uint16_t *enc_identifier);
+typedef dds_return_t (*ddsi_sertype_get_serialized_size_t) (const struct ddsi_sertype *tp, enum ddsi_serdata_kind sdkind, const void *sample, size_t *size, uint16_t *enc_identifier);
 
 /* Serialize into a destination buffer */
 // Note that we assume the destination buffer is large enough (we do not necessarily check)
 // The required size can be obtained with ddsi_sertype_get_serialized_size_t
 // Returns true if the serialization succeeds, false otherwise.
-typedef bool (*ddsi_sertype_serialize_into_t)(const struct ddsi_sertype *d, const void *sample, void *dst_buffer, size_t dst_size);
+typedef bool (*ddsi_sertype_serialize_into_t)(const struct ddsi_sertype *d, enum ddsi_serdata_kind sdkind, const void *sample, void *dst_buffer, size_t dst_size);
 
 /* Gets the type map for this sertype */
 typedef ddsi_typemap_t * (*ddsi_sertype_typemap_t) (const struct ddsi_sertype *tp);
@@ -284,13 +284,13 @@ DDS_INLINE_EXPORT inline struct ddsi_sertype * ddsi_sertype_derive_sertype (cons
 }
 
 /** @component typesupport_if */
-DDS_INLINE_EXPORT inline dds_return_t ddsi_sertype_get_serialized_size(const struct ddsi_sertype *tp, const void *sample, size_t *size, uint16_t *enc_identifier) {
-  return tp->ops->get_serialized_size(tp, sample, size, enc_identifier);
+DDS_INLINE_EXPORT inline dds_return_t ddsi_sertype_get_serialized_size(const struct ddsi_sertype *tp, enum ddsi_serdata_kind sdkind, const void *sample, size_t *size, uint16_t *enc_identifier) {
+  return tp->ops->get_serialized_size(tp, sdkind, sample, size, enc_identifier);
 }
 
 /** @component typesupport_if */
-DDS_INLINE_EXPORT inline bool ddsi_sertype_serialize_into(const struct ddsi_sertype *tp, const void *sample, void *dst_buffer, size_t dst_size) {
-  return tp->ops->serialize_into(tp, sample, dst_buffer, dst_size);
+DDS_INLINE_EXPORT inline bool ddsi_sertype_serialize_into(const struct ddsi_sertype *tp, enum ddsi_serdata_kind sdkind, const void *sample, void *dst_buffer, size_t dst_size) {
+  return tp->ops->serialize_into(tp, sdkind, sample, dst_buffer, dst_size);
 }
 
 #if defined (__cplusplus)

--- a/src/core/ddsi/include/dds/ddsi/ddsi_sertype.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_sertype.h
@@ -32,6 +32,12 @@ struct ddsi_domaingv;
 struct ddsi_typeid;
 struct ddsi_type_pair;
 
+enum ddsi_serdata_kind {
+  SDK_EMPTY,
+  SDK_KEY,
+  SDK_DATA
+};
+
 #define DDSI_SERTYPE_REGISTERING 0x40000000u // set prior to setting gv
 #define DDSI_SERTYPE_REGISTERED  0x80000000u // set after setting gv
 #define DDSI_SERTYPE_REFC_MASK   0x0fffffffu

--- a/src/core/ddsi/src/ddsi_sertype.c
+++ b/src/core/ddsi/src/ddsi_sertype.c
@@ -309,5 +309,5 @@ DDS_EXPORT extern inline ddsi_typemap_t * ddsi_sertype_typemap (const struct dds
 DDS_EXPORT extern inline ddsi_typeinfo_t * ddsi_sertype_typeinfo (const struct ddsi_sertype *tp);
 DDS_EXPORT extern inline struct ddsi_sertype * ddsi_sertype_derive_sertype (const struct ddsi_sertype *base_sertype, dds_data_representation_id_t data_representation, dds_type_consistency_enforcement_qospolicy_t tce_qos);
 
-DDS_EXPORT extern inline size_t ddsi_sertype_get_serialized_size(const struct ddsi_sertype *tp, const void *sample);
+DDS_EXPORT extern inline dds_return_t ddsi_sertype_get_serialized_size(const struct ddsi_sertype *tp, const void *sample, size_t *size, uint16_t *enc_identifier);
 DDS_EXPORT extern inline bool ddsi_sertype_serialize_into(const struct ddsi_sertype *tp, const void *sample, void *dst_buffer, size_t dst_size);

--- a/src/core/ddsi/src/ddsi_sertype.c
+++ b/src/core/ddsi/src/ddsi_sertype.c
@@ -309,5 +309,5 @@ DDS_EXPORT extern inline ddsi_typemap_t * ddsi_sertype_typemap (const struct dds
 DDS_EXPORT extern inline ddsi_typeinfo_t * ddsi_sertype_typeinfo (const struct ddsi_sertype *tp);
 DDS_EXPORT extern inline struct ddsi_sertype * ddsi_sertype_derive_sertype (const struct ddsi_sertype *base_sertype, dds_data_representation_id_t data_representation, dds_type_consistency_enforcement_qospolicy_t tce_qos);
 
-DDS_EXPORT extern inline dds_return_t ddsi_sertype_get_serialized_size(const struct ddsi_sertype *tp, const void *sample, size_t *size, uint16_t *enc_identifier);
-DDS_EXPORT extern inline bool ddsi_sertype_serialize_into(const struct ddsi_sertype *tp, const void *sample, void *dst_buffer, size_t dst_size);
+DDS_EXPORT extern inline dds_return_t ddsi_sertype_get_serialized_size(const struct ddsi_sertype *tp, enum ddsi_serdata_kind sdkind, const void *sample, size_t *size, uint16_t *enc_identifier);
+DDS_EXPORT extern inline bool ddsi_sertype_serialize_into(const struct ddsi_sertype *tp, enum ddsi_serdata_kind sdkind, const void *sample, void *dst_buffer, size_t dst_size);

--- a/src/core/ddsi/src/ddsi_typelib.c
+++ b/src/core/ddsi/src/ddsi_typelib.c
@@ -269,9 +269,16 @@ static bool ti_to_pairs_equal (const dds_sequence_DDS_XTypes_TypeIdentifierTypeO
     {
       dds_ostream_t to_a_ser = { NULL, 0, 0, DDSI_RTPS_CDR_ENC_VERSION_2 };
       dds_ostream_t to_b_ser = { NULL, 0, 0, DDSI_RTPS_CDR_ENC_VERSION_2 };
-      dds_stream_write_sample (&to_a_ser, &dds_cdrstream_default_allocator, &a->_buffer[n].type_object, &DDS_XTypes_TypeObject_cdrstream_desc);
-      dds_stream_write_sample (&to_b_ser, &dds_cdrstream_default_allocator, to_b, &DDS_XTypes_TypeObject_cdrstream_desc);
-      equal = (to_a_ser.m_index == to_b_ser.m_index) && memcmp (to_a_ser.m_buffer, to_b_ser.m_buffer, to_a_ser.m_index) == 0;
+      if (dds_stream_write_sample (&to_a_ser, &dds_cdrstream_default_allocator, &a->_buffer[n].type_object, &DDS_XTypes_TypeObject_cdrstream_desc) &&
+          dds_stream_write_sample (&to_b_ser, &dds_cdrstream_default_allocator, to_b, &DDS_XTypes_TypeObject_cdrstream_desc))
+      {
+        equal = (to_a_ser.m_index == to_b_ser.m_index) && memcmp (to_a_ser.m_buffer, to_b_ser.m_buffer, to_a_ser.m_index) == 0;
+      }
+      else
+      {
+        // type objects should always be valid, so serialization should succeed
+        abort ();
+      }
       dds_ostream_fini (&to_a_ser, &dds_cdrstream_default_allocator);
       dds_ostream_fini (&to_b_ser, &dds_cdrstream_default_allocator);
     }

--- a/src/core/ddsi/src/ddsi_typewrap.c
+++ b/src/core/ddsi/src/ddsi_typewrap.c
@@ -353,7 +353,11 @@ int ddsi_typeid_compare (const ddsi_typeid_t *a, const ddsi_typeid_t *b)
 void ddsi_typeid_ser (const ddsi_typeid_t *type_id, unsigned char **buf, uint32_t *sz)
 {
   dds_ostream_t os = { .m_buffer = NULL, .m_index = 0, .m_size = 0, .m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2 };
-  dds_stream_writeLE ((dds_ostreamLE_t *) &os, &dds_cdrstream_default_allocator, (const void *) type_id, DDS_XTypes_TypeIdentifier_desc.m_ops);
+  if (!dds_stream_writeLE ((dds_ostreamLE_t *) &os, &dds_cdrstream_default_allocator, (const void *) type_id, DDS_XTypes_TypeIdentifier_desc.m_ops))
+  {
+    // input is always valid
+    abort ();
+  }
   *buf = os.m_buffer;
   *sz = os.m_index;
 }
@@ -425,7 +429,11 @@ void ddsi_typeobj_get_hash_id_impl (const struct DDS_XTypes_TypeObject *type_obj
   assert (type_id);
   assert (type_obj->_d == DDS_XTypes_EK_MINIMAL || type_obj->_d == DDS_XTypes_EK_COMPLETE);
   dds_ostream_t os = { .m_buffer = NULL, .m_index = 0, .m_size = 0, .m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2 };
-  dds_stream_writeLE ((dds_ostreamLE_t *) &os, &dds_cdrstream_default_allocator, (const void *) type_obj, DDS_XTypes_TypeObject_desc.m_ops);
+  if (!dds_stream_writeLE ((dds_ostreamLE_t *) &os, &dds_cdrstream_default_allocator, (const void *) type_obj, DDS_XTypes_TypeObject_desc.m_ops))
+  {
+    // input type object is always valid
+    abort ();
+  }
 
   char buf[16];
   ddsrt_md5_state_t md5st;

--- a/src/core/xtests/symbol_export/symbol_export.c
+++ b/src/core/xtests/symbol_export/symbol_export.c
@@ -674,7 +674,7 @@ int main (int argc, char **argv)
   ddsi_sertype_typemap (ptr);
   ddsi_sertype_typeinfo (ptr);
   ddsi_sertype_derive_sertype (ptr, 0, tce);
-  ddsi_sertype_get_serialized_size (ptr, ptr);
+  ddsi_sertype_get_serialized_size (ptr, ptr, ptr, ptr);
   ddsi_sertype_serialize_into (ptr, ptr, ptr, 0);
 
   // ddsi_serdata.h

--- a/src/core/xtests/symbol_export/symbol_export.c
+++ b/src/core/xtests/symbol_export/symbol_export.c
@@ -509,6 +509,9 @@ int main (int argc, char **argv)
   dds_stream_write_sampleLE (ptr, ptr2, ptr3, ptr4);
   dds_stream_write_sampleBE (ptr, ptr2, ptr3, ptr4);
 
+  dds_stream_getsize_sample (ptr, ptr, 0);
+  dds_stream_getsize_key (0, ptr, ptr, 0);
+
   dds_stream_read (ptr, ptr2, ptr3, ptr4);
   dds_stream_read_key (ptr, ptr2, ptr3, ptr4);
 

--- a/src/core/xtests/symbol_export/symbol_export.c
+++ b/src/core/xtests/symbol_export/symbol_export.c
@@ -674,8 +674,8 @@ int main (int argc, char **argv)
   ddsi_sertype_typemap (ptr);
   ddsi_sertype_typeinfo (ptr);
   ddsi_sertype_derive_sertype (ptr, 0, tce);
-  ddsi_sertype_get_serialized_size (ptr, ptr, ptr, ptr);
-  ddsi_sertype_serialize_into (ptr, ptr, ptr, 0);
+  ddsi_sertype_get_serialized_size (ptr, SDK_DATA, ptr, ptr, ptr);
+  ddsi_sertype_serialize_into (ptr, SDK_DATA, ptr, ptr, 0);
 
   // ddsi_serdata.h
   ddsi_serdata_init (ptr, ptr, 0);

--- a/src/tools/idlc/xtests/main.c
+++ b/src/tools/idlc/xtests/main.c
@@ -154,7 +154,11 @@ int main(int argc, char **argv)
 
       // write key
       dds_ostream_t os_wr_key = { NULL, 0, 0, DDSI_RTPS_CDR_ENC_VERSION_2 };
-      dds_stream_write_key (&os_wr_key, DDS_CDR_KEY_SERIALIZATION_SAMPLE, &dds_cdrstream_default_allocator, msg_wr, &cdrstream_desc);
+      if (!dds_stream_write_key (&os_wr_key, DDS_CDR_KEY_SERIALIZATION_SAMPLE, &dds_cdrstream_default_allocator, msg_wr, &cdrstream_desc))
+      {
+        printf("write key failed\n");
+        return 1;
+      }
 
       // extract key from key
       dds_istream_t is_key_from_key = { os_wr_key.m_buffer, os_wr_key.m_size, 0, DDSI_RTPS_CDR_ENC_VERSION_2 };


### PR DESCRIPTION
It used to be that publishing "complex" types — anything requiring serialization, really — would always construct a serdata, then optionally copy the CDR into shared memory. We already know if we'll need both or will only need the shared memory copy, and so we can quite easily remove a copy. This gives rise to the new `dds_write_impl_serialize_into_loan`.

Then the question is one of implementation. The sertype already defined functions for this, but they could not handle key-only data and `sertype_default` implementation was horrible (serialize, look at the size, free the result). This has gave rise to `dds_stream_getsize_sample` and `dds_stream_getsize_key`.

That required testing, that made me find some cases where invalid data was not reject correctly in the write path, then I was fiddling with the serializer and so decided to also make the boolean handling a bit friendlier to inputs where `true` is encoded as a non-`0` byte, instead of only accepting `1`. (See #2068, this should fix that.)

This is quite difficult to test, but the paths do get hit in the PSMX tests and the serializer calls check against the length of the serialized data against the length computed by the `getsize` functions. The Python binding "fuzzer" test will be extended by a PR on the Python binding that also performs these checks on the types/data used there, which increases the coverage to a reasonable level. (Tested locally with some 1000 types.)