### PR TITLE
Allow empty structs in type validator

### DIFF
--- a/src/core/ddsc/tests/dynamic_type.c
+++ b/src/core/ddsc/tests/dynamic_type.c
@@ -566,20 +566,21 @@ CU_Test (ddsc_dynamic_type, no_members, .init = dynamic_type_init, .fini = dynam
   // Struct without members
   dds_dynamic_type_t dstruct = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_STRUCTURE, .name = "t" });
   ret = dds_dynamic_type_register (&dstruct, &type_info);
-  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_BAD_PARAMETER);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
+  dds_free_typeinfo (type_info);
   dds_dynamic_type_unref (&dstruct);
 
   // Struct with basetype without members
   dds_dynamic_type_t dbasestruct = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_STRUCTURE, .name = "b" });
   dstruct = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_STRUCTURE, .name = "t", .base_type = DDS_DYNAMIC_TYPE_SPEC (dbasestruct) });
-  CU_ASSERT_EQUAL_FATAL (dstruct.ret, DDS_RETCODE_BAD_PARAMETER);
-  dds_dynamic_type_unref (&dbasestruct);
+  CU_ASSERT_EQUAL_FATAL (dstruct.ret, DDS_RETCODE_OK);
+  dds_dynamic_type_unref (&dstruct);
 
   // Struct with substruct without members
   dds_dynamic_type_t dsubstruct = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_STRUCTURE, .name = "s" });
   dstruct = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_STRUCTURE, .name = "t" });
   ret = dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER(dsubstruct, "m1"));
-  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_BAD_PARAMETER);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
   dds_dynamic_type_unref (&dstruct);
 
   // Union without members

--- a/src/core/ddsi/src/ddsi_typewrap.c
+++ b/src/core/ddsi/src/ddsi_typewrap.c
@@ -620,9 +620,8 @@ static dds_return_t xt_valid_struct_member_ids (struct ddsi_domaingv *gv, const 
     cnt += t1->_u.structure.members.length;
   if (cnt == 0 && !t->_u.structure.base_type)
   {
-    GVTRACE ("struct has no members\n");
-    ret = DDS_RETCODE_BAD_PARAMETER;
-    goto failed;
+    ret = DDS_RETCODE_OK;
+    goto empty;
   }
 
   DDS_XTypes_MemberId *ids = ddsrt_malloc (cnt * sizeof (*ids));
@@ -653,6 +652,7 @@ static dds_return_t xt_valid_struct_member_ids (struct ddsi_domaingv *gv, const 
 failed_duplicate:
   ddsrt_free (ids);
 failed:
+empty:
   return ret;
 }
 


### PR DESCRIPTION
This allows empty structs in the type validator. Structs can be defined in IDL with any number of members, including 0 (which is also used in the XTypes Type Object data types). The IDL compiler C backend handles empty struct correctly, by not creating a C struct for the type, because C does not allow empty structs. But the type validator was incorrectly rejecting type meta-data for an empty struct, which is changed in this PR.

Empty unions are still not allowed in the validator, because there seems to be little practical value in supporting them (however the spec is not clear at this point).

Fixes #2091 