### PR TITLE
Export functions to get PSMX loan

### DIFF
--- a/src/core/ddsc/src/dds__psmx.h
+++ b/src/core/ddsc/src/dds__psmx.h
@@ -73,4 +73,16 @@ void dds_psmx_locators_set_free (struct ddsi_psmx_locators_set *psmx_locators_se
 dds_loaned_sample_t * dds_psmx_endpoint_request_loan (struct dds_psmx_endpoint *psmx_endpoint, uint32_t sz)
   ddsrt_nonnull_all ddsrt_attribute_warn_unused_result;
 
+
+/**
+ * @brief Sets the writer info parameters in a loaned sample
+ *
+ * @param loan The loaned sample to set the parameters for
+ * @param wr_guid Writer GUID
+ * @param timestamp Timestamp
+ * @param statusinfo Statusinfo value
+ */
+void dds_psmx_set_loan_writeinfo (struct dds_loaned_sample *loan, const ddsi_guid_t *wr_guid, dds_time_t timestamp, uint32_t statusinfo)
+  ddsrt_nonnull_all;
+
 #endif // DDS__PSMX_H

--- a/src/core/ddsc/src/dds__writer.h
+++ b/src/core/ddsc/src/dds__writer.h
@@ -11,6 +11,7 @@
 #ifndef DDS__WRITER_H
 #define DDS__WRITER_H
 
+#include "dds/ddsi/ddsi_serdata.h"
 #include "dds__entity.h"
 
 #if defined (__cplusplus)
@@ -33,14 +34,24 @@ void dds_writer_status_cb (void *entity, const struct ddsi_status_cb_data * data
 void dds_writer_invoke_cbs_for_pending_events(struct dds_entity *e, uint32_t status);
 
 /** @component writer */
-dds_return_t dds_return_writer_loan (dds_writer *wr, void **samples_ptr, int32_t n_samples) ddsrt_nonnull_all;
-
-/** @component writer */
 dds_return_t dds__ddsi_writer_wait_for_acks (struct dds_writer *wr, ddsi_guid_t *rdguid, dds_time_t abstimeout);
 
 /** @component writer */
 dds_return_t dds_request_writer_loan (dds_writer *wr, enum dds_writer_loan_type loan_type, uint32_t sz, void **sample)
   ddsrt_nonnull_all;
+
+/** @component writer */
+dds_return_t dds_return_writer_loan (dds_writer *wr, void **samples_ptr, int32_t n_samples) ddsrt_nonnull_all;
+
+/** @component writer */
+DDS_EXPORT_INTERNAL_FUNCTION
+struct dds_loaned_sample * dds_writer_psmx_loan_raw (const struct dds_writer *wr, const void *data, enum ddsi_serdata_kind sdkind, dds_time_t timestamp, uint32_t statusinfo)
+  ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+
+/** @component writer */
+DDS_EXPORT_INTERNAL_FUNCTION
+struct dds_loaned_sample * dds_writer_psmx_loan_from_serdata (const struct dds_writer *wr, const struct ddsi_serdata *sd)
+  ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsc/src/dds_psmx.c
+++ b/src/core/ddsc/src/dds_psmx.c
@@ -552,3 +552,12 @@ dds_return_t dds_request_loan_of_size (dds_entity_t writer, size_t size, void **
   dds_entity_unpin (e);
   return ret;
 }
+
+void dds_psmx_set_loan_writeinfo (struct dds_loaned_sample *loan, const ddsi_guid_t *wr_guid, dds_time_t timestamp, uint32_t statusinfo)
+{
+  assert (loan->metadata->sample_state != DDS_LOANED_SAMPLE_STATE_UNITIALIZED);
+  struct dds_psmx_metadata *md = loan->metadata;
+  memcpy (&md->guid, wr_guid, sizeof (md->guid));
+  md->timestamp = timestamp;
+  md->statusinfo = statusinfo;
+}

--- a/src/core/xtests/symbol_export/symbol_export.c
+++ b/src/core/xtests/symbol_export/symbol_export.c
@@ -91,6 +91,7 @@
 #include "dds/cdr/dds_cdrstream.h"
 
 #include "dds__write.h"
+#include "dds__writer.h"
 #include "dds__entity.h"
 #include "dds__sysdef_parser.h"
 
@@ -1166,6 +1167,10 @@ int main (int argc, char **argv)
   // dds__write.h
   dds_write_impl (ptr, ptr, 0, (dds_write_action) 0);
   dds_writecdr_impl (ptr, ptr, ptr, false);
+
+  // dds__writer.h
+  dds_writer_psmx_loan_raw (ptr, ptr2, 0, 0, 0);
+  dds_writer_psmx_loan_from_serdata (ptr, ptr2);
 
   // dds__entity.h
   dds_entity_pin (0, ptr);


### PR DESCRIPTION
This exports the functions to get a PSMX loan from a serdata or a raw sample, which can be useful for specific scenarios.