### PR TITLE
dds_stream_normalize_data input must be writable

### DIFF
--- a/src/core/ddsi/src/ddsi_plist.c
+++ b/src/core/ddsi/src/ddsi_plist.c
@@ -804,10 +804,7 @@ static dds_return_t deser_type_information (void * __restrict dst, struct flagse
   unsigned char *buf;
   dds_return_t ret = 0;
 
-  if (dd->bswap)
-    buf = ddsrt_memdup (dd->buf, dd->bufsz);
-  else
-    buf = (unsigned char *) dd->buf;
+  buf = ddsrt_memdup (dd->buf, dd->bufsz);
   if (!dds_stream_normalize_data ((char *) buf, &srcoff, (uint32_t) dd->bufsz, dd->bswap, DDSI_RTPS_CDR_ENC_VERSION_2, DDS_XTypes_TypeInformation_desc.m_ops))
   {
     ret = DDS_RETCODE_BAD_PARAMETER;
@@ -820,8 +817,7 @@ static dds_return_t deser_type_information (void * __restrict dst, struct flagse
   dds_stream_read (&is, (void *) *x, &dds_cdrstream_default_allocator, DDS_XTypes_TypeInformation_desc.m_ops);
   *flagset->present |= flag;
 err_normalize:
-  if (dd->bswap)
-    ddsrt_free (buf);
+  ddsrt_free (buf);
   return ret;
 }
 

--- a/src/core/ddsi/src/ddsi_typelib.c
+++ b/src/core/ddsi/src/ddsi_typelib.c
@@ -86,7 +86,7 @@ ddsi_typeinfo_t * ddsi_typeinfo_dup (const ddsi_typeinfo_t *src)
 
 ddsi_typeinfo_t *ddsi_typeinfo_deser (const unsigned char *data, uint32_t sz)
 {
-  unsigned char *data_ne;
+  unsigned char *data_norm;
   uint32_t srcoff = 0;
 
   if (sz == 0 || data == NULL)
@@ -96,22 +96,17 @@ ddsi_typeinfo_t *ddsi_typeinfo_deser (const unsigned char *data, uint32_t sz)
   DDSRT_WARNING_MSVC_OFF(6326)
   bool bswap = (DDSRT_ENDIAN != DDSRT_LITTLE_ENDIAN);
   DDSRT_WARNING_MSVC_ON(6326)
-  if (bswap)
-    data_ne = ddsrt_memdup (data, sz);
-  else
-    data_ne = (unsigned char *) data;
-  if (!dds_stream_normalize_data ((char *) data_ne, &srcoff, sz, bswap, DDSI_RTPS_CDR_ENC_VERSION_2, DDS_XTypes_TypeInformation_desc.m_ops))
+  data_norm = ddsrt_memdup (data, sz);
+  if (!dds_stream_normalize_data ((char *) data_norm, &srcoff, sz, bswap, DDSI_RTPS_CDR_ENC_VERSION_2, DDS_XTypes_TypeInformation_desc.m_ops))
   {
-    if (bswap)
-      ddsrt_free (data_ne);
+    ddsrt_free (data_norm);
     return NULL;
   }
 
-  dds_istream_t is = { .m_buffer = data_ne, .m_index = 0, .m_size = sz, .m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2 };
+  dds_istream_t is = { .m_buffer = data_norm, .m_index = 0, .m_size = sz, .m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2 };
   ddsi_typeinfo_t *typeinfo = ddsrt_calloc (1, sizeof (*typeinfo));
   dds_stream_read (&is, (void *) typeinfo, &dds_cdrstream_default_allocator, DDS_XTypes_TypeInformation_desc.m_ops);
-  if (bswap)
-    ddsrt_free (data_ne);
+  ddsrt_free (data_norm);
   return typeinfo;
 }
 
@@ -216,7 +211,7 @@ const char * ddsi_typemap_get_type_name (const ddsi_typemap_t *typemap, const dd
 
 ddsi_typemap_t *ddsi_typemap_deser (const unsigned char *data, uint32_t sz)
 {
-  unsigned char *data_ne;
+  unsigned char *data_norm;
   uint32_t srcoff = 0;
 
   if (sz == 0 || data == NULL)
@@ -225,22 +220,17 @@ ddsi_typemap_t *ddsi_typemap_deser (const unsigned char *data, uint32_t sz)
   DDSRT_WARNING_MSVC_OFF(6326)
   bool bswap = (DDSRT_ENDIAN != DDSRT_LITTLE_ENDIAN);
   DDSRT_WARNING_MSVC_ON(6326)
-  if (bswap)
-    data_ne = ddsrt_memdup (data, sz);
-  else
-    data_ne = (unsigned char *) data;
-  if (!dds_stream_normalize_data ((char *) data_ne, &srcoff, sz, bswap, DDSI_RTPS_CDR_ENC_VERSION_2, DDS_XTypes_TypeMapping_desc.m_ops))
+  data_norm = ddsrt_memdup (data, sz);
+  if (!dds_stream_normalize_data ((char *) data_norm, &srcoff, sz, bswap, DDSI_RTPS_CDR_ENC_VERSION_2, DDS_XTypes_TypeMapping_desc.m_ops))
   {
-    if (bswap)
-      ddsrt_free (data_ne);
+    ddsrt_free (data_norm);
     return NULL;
   }
 
-  dds_istream_t is = { .m_buffer = data_ne, .m_index = 0, .m_size = sz, .m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2 };
+  dds_istream_t is = { .m_buffer = data_norm, .m_index = 0, .m_size = sz, .m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2 };
   ddsi_typemap_t *typemap = ddsrt_calloc (1, sizeof (*typemap));
   dds_stream_read (&is, (void *) typemap, &dds_cdrstream_default_allocator, DDS_XTypes_TypeMapping_desc.m_ops);
-  if (bswap)
-    ddsrt_free (data_ne);
+  ddsrt_free (data_norm);
   return typemap;
 }
 


### PR DESCRIPTION
With the change of interpreting != 0 in CDR as true for a boolean, a call to dds_stream_normalize_data may now also modify the input when the endianness is native, if only for badly formed CDR. (See commit 615d5aae0004340dc5013fef6218276d51667e64)

For untrusted inputs we therefore no longer have the luxury of casting away the constness if we know there is no need to byteswap the input.

In regular operation, the only const inputs are those coming from IDLC and so, at least in principle, trustworthy. All untrustworthy stuff is dynamically allocated and not truly const. Where we do run into this is in fuzzing.