### PR TITLE
Fix ddsi_xpack_send blocking on full send queue

### DIFF
--- a/src/core/ddsi/src/ddsi_xmsg.c
+++ b/src/core/ddsi/src/ddsi_xmsg.c
@@ -1345,10 +1345,10 @@ void ddsi_xpack_send (struct ddsi_xpack *xp, bool immediately)
     ddsi_xpack_reinit (xp);
     xp1->sendq_next = NULL;
     ddsrt_mutex_lock (&gv->sendq_lock);
+    while (gv->sendq_length >= SENDQ_MAX)
+      ddsrt_cond_wait (&gv->sendq_cond, &gv->sendq_lock);
     if (immediately || gv->sendq_length == 0)
       ddsrt_cond_broadcast (&gv->sendq_cond);
-    if (gv->sendq_length >= SENDQ_MAX)
-      ddsrt_cond_wait (&gv->sendq_cond, &gv->sendq_lock);
     if (gv->sendq_head)
       gv->sendq_tail->sendq_next = xp1;
     else


### PR DESCRIPTION
When enqueuing an element and calling cond_broadcast all inside the lock, it doesn't really matter when exactly cond_broadcast is called, so while doing that before enqueuing the packet may look odd, it is not wrong in itself.

However, if one wants to wait until the queue is no longer overfull and does so by calling cond_wait _after_ the potential call to cond_broadcast but before the actual enqueuing of the data, it means the cond_broadcast is no longer atomic with the update of the queue: cond_wait(cv,lk) is effectively an atomic unlock(lk)+wait(cv) followed by lock(lk).

It makes sense to wait before enqueuing, but then the wait operation should precede the broadcast.

Furthermore cond_wait can suffer from spurious wakeups - they seem to be really rare, and if so, they are harmless in this case. Still, it seems wiser to not proceed if there is no space in the queue.