### PR TITLE
Change default for PSMX-IOX keyed topics option

### DIFF
--- a/src/psmx_iox/src/psmx_iox_impl.cpp
+++ b/src/psmx_iox/src/psmx_iox_impl.cpp
@@ -708,11 +708,11 @@ dds_return_t iox_create_psmx(struct dds_psmx **psmx, dds_psmx_instance_id_t inst
     return DDS_RETCODE_ERROR;
 
   auto opt_keyed_topics = get_config_option_value(config, "KEYED_TOPICS", true);
-  bool keyed_topics = false;
+  bool keyed_topics = true;
   if (opt_keyed_topics.has_value()) {
-    if (opt_keyed_topics.value() == "true")
-      keyed_topics = true;
-    else if (opt_keyed_topics.value() != "false")
+    if (opt_keyed_topics.value() == "false")
+      keyed_topics = false;
+    else if (opt_keyed_topics.value() != "true")
       return DDS_RETCODE_ERROR;
   }
 


### PR DESCRIPTION
This changes the default of the `KEYED_TOPICS` option in the Iceoryx PSMX plugin to `true`, aligning it with the pre-PSMX behavior in Cyclone 0.10.x. Despite limitations in key support within the Iceoryx integration, enabling this option by default seems a reasonable choice.