### PR TITLE
feature/implement-PID_PRODUCT_VERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@
 #
 cmake_minimum_required(VERSION 3.16)
 # C++ is only for Iceoryx plugin
-project(CycloneDDS VERSION 0.11.0 LANGUAGES C CXX)
+project(CycloneDDS VERSION 0.11.0.0 LANGUAGES C CXX)
 
 # Set a default build type if none was specified
 set(default_build_type "RelWithDebInfo")

--- a/src/core/ddsi/include/dds/ddsi/ddsi_plist.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_plist.h
@@ -109,6 +109,7 @@ typedef struct ddsi_plist {
 
   ddsi_protocol_version_t protocol_version;
   ddsi_vendorid_t vendorid;
+  ddsi_product_version_t product_version;
   ddsi_locators_t unicast_locators;
   ddsi_locators_t multicast_locators;
   ddsi_locators_t default_unicast_locators;

--- a/src/core/ddsi/include/dds/ddsi/ddsi_protocol.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_protocol.h
@@ -59,6 +59,13 @@ typedef struct {
   uint8_t id[2];
 } ddsi_vendorid_t;
 
+typedef struct {
+  uint8_t major;
+  uint8_t minor;
+  uint8_t release;
+  uint8_t revision;
+} ddsi_product_version_t;
+
 typedef struct ddsi_protocolid {
   uint8_t id[4];
 } ddsi_protocolid_t;

--- a/src/core/ddsi/src/ddsi__plist.h
+++ b/src/core/ddsi/src/ddsi__plist.h
@@ -70,6 +70,7 @@ struct ddsi_xmsg;
 #define PP_CYCLONE_RECEIVE_BUFFER_SIZE          ((uint64_t)1 << 38)
 #define PP_CYCLONE_TOPIC_GUID                   ((uint64_t)1 << 39)
 #define PP_CYCLONE_REQUESTS_KEYHASH             ((uint64_t)1 << 40)
+#define PP_PRODUCT_VERSION                      ((uint64_t)1 << 41)
 
 /* Set for unrecognized parameters that are in the reserved space or
    in our own vendor-specific space that have the

--- a/src/core/ddsi/src/ddsi__protocol.h
+++ b/src/core/ddsi/src/ddsi__protocol.h
@@ -264,6 +264,7 @@ typedef union ddsi_rtps_submessage {
 #define DDSI_PID_TRANSPORT_PRIORITY                  0x49u
 #define DDSI_PID_PROTOCOL_VERSION                    0x15u
 #define DDSI_PID_VENDORID                            0x16u
+#define DDSI_PID_PRODUCT_VERSION                     0x8000u
 #define DDSI_PID_UNICAST_LOCATOR                     0x2fu
 #define DDSI_PID_MULTICAST_LOCATOR                   0x30u
 #define DDSI_PID_MULTICAST_IPADDRESS                 0x11u

--- a/src/core/ddsi/src/ddsi_discovery_endpoint.c
+++ b/src/core/ddsi/src/ddsi_discovery_endpoint.c
@@ -160,10 +160,14 @@ static int sedp_write_endpoint_impl
   else
   {
     assert (xqos != NULL);
-    ps.present |= PP_PROTOCOL_VERSION | PP_VENDORID;
+    ps.present |= PP_PROTOCOL_VERSION | PP_VENDORID | PP_PRODUCT_VERSION;
     ps.protocol_version.major = DDSI_RTPS_MAJOR;
     ps.protocol_version.minor = DDSI_RTPS_MINOR;
     ps.vendorid = DDSI_VENDORID_ECLIPSE;
+    ps.product_version.major = DDS_VERSION_MAJOR;
+    ps.product_version.minor = DDS_VERSION_MINOR;
+    ps.product_version.release = DDS_VERSION_PATCH;
+    ps.product_version.revision = DDS_VERSION_TWEAK;
 
     assert (epcommon != NULL);
 

--- a/src/core/ddsi/src/ddsi_discovery_spdp.c
+++ b/src/core/ddsi/src/ddsi_discovery_spdp.c
@@ -81,13 +81,17 @@ void ddsi_get_participant_builtin_topic_data (const struct ddsi_participant *pp,
 
   ddsi_plist_init_empty (dst);
   dst->present |= PP_PARTICIPANT_GUID | PP_BUILTIN_ENDPOINT_SET |
-    PP_PROTOCOL_VERSION | PP_VENDORID | PP_DOMAIN_ID;
+    PP_PROTOCOL_VERSION | PP_VENDORID | PP_DOMAIN_ID | PP_PRODUCT_VERSION;
   dst->participant_guid = pp->e.guid;
   dst->builtin_endpoint_set = pp->bes;
   dst->protocol_version.major = DDSI_RTPS_MAJOR;
   dst->protocol_version.minor = DDSI_RTPS_MINOR;
   dst->vendorid = DDSI_VENDORID_ECLIPSE;
   dst->domain_id = gv->config.extDomainId.value;
+  dst->product_version.major = DDS_VERSION_MAJOR;
+  dst->product_version.minor = DDS_VERSION_MINOR;
+  dst->product_version.release = DDS_VERSION_PATCH;
+  dst->product_version.revision = DDS_VERSION_TWEAK;
   /* Be sure not to send a DOMAIN_TAG when it is the default (an empty)
      string: it is an "incompatible-if-unrecognized" parameter, and so
      implementations that don't understand the parameter will refuse to

--- a/src/core/ddsi/src/ddsi_discovery_topic.c
+++ b/src/core/ddsi/src/ddsi_discovery_topic.c
@@ -13,6 +13,7 @@
 #include <string.h>
 #include <stdlib.h>
 
+#include "dds/version.h"
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/log.h"
 #include "dds/ddsi/ddsi_domaingv.h"
@@ -41,10 +42,14 @@ static int ddsi_sedp_write_topic_impl (struct ddsi_writer *wr, int alive, const 
   ps.topic_guid = *guid;
 
   assert (xqos != NULL);
-  ps.present |= PP_PROTOCOL_VERSION | PP_VENDORID;
+  ps.present |= PP_PROTOCOL_VERSION | PP_VENDORID | PP_PRODUCT_VERSION;
   ps.protocol_version.major = DDSI_RTPS_MAJOR;
   ps.protocol_version.minor = DDSI_RTPS_MINOR;
   ps.vendorid = DDSI_VENDORID_ECLIPSE;
+  ps.product_version.major = DDS_VERSION_MAJOR;
+  ps.product_version.minor = DDS_VERSION_MINOR;
+  ps.product_version.release = DDS_VERSION_PATCH;
+  ps.product_version.revision = DDS_VERSION_TWEAK;
 
   uint64_t qosdiff = ddsi_xqos_delta (xqos, defqos, ~(uint64_t)0);
   if (gv->config.explicitly_publish_qos_set_to_default)

--- a/src/core/ddsi/src/ddsi_plist.c
+++ b/src/core/ddsi/src/ddsi_plist.c
@@ -2049,6 +2049,7 @@ static const struct piddesc piddesc_omg[] = {
 #endif
   PP  (PROTOCOL_VERSION,                    protocol_version, Xox2),
   PP  (VENDORID,                            vendorid, Xox2),
+  PP  (PRODUCT_VERSION,                     product_version, Xox2),
   PP  (EXPECTS_INLINE_QOS,                  expects_inline_qos, Xb),
   PP  (PARTICIPANT_MANUAL_LIVELINESS_COUNT, participant_manual_liveliness_count, Xi),
   PP  (PARTICIPANT_BUILTIN_ENDPOINTS,       participant_builtin_endpoints, Xu),

--- a/src/security/core/src/dds_security_serialize.c
+++ b/src/security/core/src/dds_security_serialize.c
@@ -49,6 +49,7 @@
 #define PID_TRANSPORT_PRIORITY                  0x49u
 #define PID_PROTOCOL_VERSION                    0x15u
 #define PID_VENDORID                            0x16u
+#define PID_PRODUCT_VERSION                     0x8000u
 #define PID_UNICAST_LOCATOR                     0x2fu
 #define PID_MULTICAST_LOCATOR                   0x30u
 #define PID_MULTICAST_IPADDRESS                 0x11u


### PR DESCRIPTION
This PR implements `PID_PRODUCT_VERSION` to be able to see the version on wireshark.

@eboasson could you have a look?