### PR TITLE
Remove `restrict` (for the most part)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "VxWorks")
 endif()
 
 if(${CMAKE_C_COMPILER_ID} STREQUAL "SunPro")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m64 -xc99 -D__restrict=restrict -D__deprecated__=")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m64 -xc99 -D__deprecated__=")
   set(CMAKE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} -m64")
 elseif(CMAKE_SYSTEM_NAME STREQUAL "SunOS")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m64")

--- a/docs/manual/doxygen.conf.in
+++ b/docs/manual/doxygen.conf.in
@@ -21,7 +21,7 @@ GENERATE_HTML          = NO
 GENERATE_LATEX         = NO
 GENERATE_XML           = YES
 MACRO_EXPANSION        = YES
-PREDEFINED             = __restrict= __attribute__= __declspec(x)= DDS_EXPORT= DDS_DEPRECATED_EXPORT= DDSRT_STATIC_ASSERT(x)= DOXYGEN_SHOULD_SKIP_THIS=1 DDS_HAS_TOPIC_DISCOVERY=1 DDS_HAS_TYPELIB=1 DDS_HAS_TYPE_DISCOVERY=1 ddsrt_attribute_warn_unused_result= ddsrt_attribute_malloc= ddsrt_nonnull(x)= ddsrt_attribute_no_sanitize(x)=
+PREDEFINED             = restrict= __attribute__= __declspec(x)= DDS_EXPORT= DDS_DEPRECATED_EXPORT= DDSRT_STATIC_ASSERT(x)= DOXYGEN_SHOULD_SKIP_THIS=1 DDS_HAS_TOPIC_DISCOVERY=1 DDS_HAS_TYPELIB=1 DDS_HAS_TYPE_DISCOVERY=1 ddsrt_attribute_warn_unused_result= ddsrt_attribute_malloc= ddsrt_nonnull(x)= ddsrt_attribute_no_sanitize(x)=
 CLASS_GRAPH            = TEXT
 ALIASES               += "component=\noop"
 ALIASES               += "notincomponent=\noop"

--- a/src/core/cdr/include/dds/cdr/dds_cdrstream.h
+++ b/src/core/cdr/include/dds/cdr/dds_cdrstream.h
@@ -124,31 +124,31 @@ DDSRT_STATIC_ASSERT (offsetof (dds_ostreamLE_t, x) == 0);
 DDSRT_STATIC_ASSERT (offsetof (dds_ostreamBE_t, x) == 0);
 
 /** @component cdr_serializer */
-uint32_t dds_cdr_alignto4_clear_and_resize (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, uint32_t xcdr_version);
+uint32_t dds_cdr_alignto4_clear_and_resize (dds_ostream_t *os, const struct dds_cdrstream_allocator *allocator, uint32_t xcdr_version);
 
 /** @component cdr_serializer */
-DDS_EXPORT void dds_istream_init (dds_istream_t * __restrict is, uint32_t size, const void * __restrict input, uint32_t xcdr_version);
+DDS_EXPORT void dds_istream_init (dds_istream_t *is, uint32_t size, const void *input, uint32_t xcdr_version);
 
 /** @component cdr_serializer */
-DDS_EXPORT void dds_istream_fini (dds_istream_t * __restrict is);
+DDS_EXPORT void dds_istream_fini (dds_istream_t *is);
 
 /** @component cdr_serializer */
-DDS_EXPORT void dds_ostream_init (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, uint32_t size, uint32_t xcdr_version);
+DDS_EXPORT void dds_ostream_init (dds_ostream_t *os, const struct dds_cdrstream_allocator *allocator, uint32_t size, uint32_t xcdr_version);
 
 /** @component cdr_serializer */
-DDS_EXPORT void dds_ostream_fini (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator);
+DDS_EXPORT void dds_ostream_fini (dds_ostream_t *os, const struct dds_cdrstream_allocator *allocator);
 
 /** @component cdr_serializer */
-DDS_EXPORT void dds_ostreamLE_init (dds_ostreamLE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, uint32_t size, uint32_t xcdr_version);
+DDS_EXPORT void dds_ostreamLE_init (dds_ostreamLE_t *os, const struct dds_cdrstream_allocator *allocator, uint32_t size, uint32_t xcdr_version);
 
 /** @component cdr_serializer */
-DDS_EXPORT void dds_ostreamLE_fini (dds_ostreamLE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator);
+DDS_EXPORT void dds_ostreamLE_fini (dds_ostreamLE_t *os, const struct dds_cdrstream_allocator *allocator);
 
 /** @component cdr_serializer */
-DDS_EXPORT void dds_ostreamBE_init (dds_ostreamBE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, uint32_t size, uint32_t xcdr_version);
+DDS_EXPORT void dds_ostreamBE_init (dds_ostreamBE_t *os, const struct dds_cdrstream_allocator *allocator, uint32_t size, uint32_t xcdr_version);
 
 /** @component cdr_serializer */
-DDS_EXPORT void dds_ostreamBE_fini (dds_ostreamBE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator);
+DDS_EXPORT void dds_ostreamBE_fini (dds_ostreamBE_t *os, const struct dds_cdrstream_allocator *allocator);
 
 /** @component cdr_serializer */
 dds_ostream_t dds_ostream_from_buffer(void *buffer, size_t size, uint16_t write_encoding_version);
@@ -166,116 +166,116 @@ dds_ostream_t dds_ostream_from_buffer(void *buffer, size_t size, uint16_t write_
  * @param actual_size   is set to the actual size of the data (*actual_size <= size) on successful return
  * @returns             True iff validation and normalization succeeded
  */
-DDS_EXPORT bool dds_stream_normalize (void * __restrict data, uint32_t size, bool bswap, uint32_t xcdr_version, const struct dds_cdrstream_desc * __restrict desc, bool just_key, uint32_t * __restrict actual_size)
+DDS_EXPORT bool dds_stream_normalize (void *data, uint32_t size, bool bswap, uint32_t xcdr_version, const struct dds_cdrstream_desc *desc, bool just_key, uint32_t *actual_size)
   ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
 
 /** @component cdr_serializer */
-DDS_EXPORT const uint32_t *dds_stream_normalize_data (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t * __restrict ops)
+DDS_EXPORT const uint32_t *dds_stream_normalize_data (char *data, uint32_t *off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t *ops)
   ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
 
 /** @component cdr_serializer */
-DDS_EXPORT const uint32_t *dds_stream_write (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict data, const uint32_t * __restrict ops)
+DDS_EXPORT const uint32_t *dds_stream_write (dds_ostream_t *os, const struct dds_cdrstream_allocator *allocator, const char *data, const uint32_t *ops)
   ddsrt_attribute_warn_unused_result;
 
 /** @component cdr_serializer */
-DDS_EXPORT const uint32_t *dds_stream_writeLE (dds_ostreamLE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict data, const uint32_t * __restrict ops)
+DDS_EXPORT const uint32_t *dds_stream_writeLE (dds_ostreamLE_t *os, const struct dds_cdrstream_allocator *allocator, const char *data, const uint32_t *ops)
   ddsrt_attribute_warn_unused_result;
 
 /** @component cdr_serializer */
-DDS_EXPORT const uint32_t *dds_stream_writeBE (dds_ostreamBE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict data, const uint32_t * __restrict ops)
+DDS_EXPORT const uint32_t *dds_stream_writeBE (dds_ostreamBE_t *os, const struct dds_cdrstream_allocator *allocator, const char *data, const uint32_t *ops)
   ddsrt_attribute_warn_unused_result;
 
 /** @component cdr_serializer */
-DDS_EXPORT const uint32_t * dds_stream_write_with_byte_order (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict data, const uint32_t * __restrict ops, enum ddsrt_byte_order_selector bo)
+DDS_EXPORT const uint32_t * dds_stream_write_with_byte_order (dds_ostream_t *os, const struct dds_cdrstream_allocator *allocator, const char *data, const uint32_t *ops, enum ddsrt_byte_order_selector bo)
   ddsrt_attribute_warn_unused_result;
 
 /** @component cdr_serializer */
-DDS_EXPORT bool dds_stream_write_sample (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const void * __restrict data, const struct dds_cdrstream_desc * __restrict desc)
+DDS_EXPORT bool dds_stream_write_sample (dds_ostream_t *os, const struct dds_cdrstream_allocator *allocator, const void *data, const struct dds_cdrstream_desc *desc)
   ddsrt_attribute_warn_unused_result;
 
 /** @component cdr_serializer */
-DDS_EXPORT bool dds_stream_write_sampleLE (dds_ostreamLE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const void * __restrict data, const struct dds_cdrstream_desc * __restrict desc)
+DDS_EXPORT bool dds_stream_write_sampleLE (dds_ostreamLE_t *os, const struct dds_cdrstream_allocator *allocator, const void *data, const struct dds_cdrstream_desc *desc)
   ddsrt_attribute_warn_unused_result;
 
 /** @component cdr_serializer */
-DDS_EXPORT bool dds_stream_write_sampleBE (dds_ostreamBE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const void * __restrict data, const struct dds_cdrstream_desc * __restrict desc)
+DDS_EXPORT bool dds_stream_write_sampleBE (dds_ostreamBE_t *os, const struct dds_cdrstream_allocator *allocator, const void *data, const struct dds_cdrstream_desc *desc)
   ddsrt_attribute_warn_unused_result;
 
 /** @component cdr_serializer */
-DDS_EXPORT void dds_stream_read_sample (dds_istream_t * __restrict is, void * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const struct dds_cdrstream_desc * __restrict desc);
+DDS_EXPORT void dds_stream_read_sample (dds_istream_t *is, void *data, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc *desc);
 
 /** @component cdr_serializer */
-DDS_EXPORT void dds_stream_free_sample (void * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops);
+DDS_EXPORT void dds_stream_free_sample (void *data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops);
 
 /** @component cdr_serializer */
-DDS_EXPORT uint32_t dds_stream_countops (const uint32_t * __restrict ops, uint32_t nkeys, const dds_key_descriptor_t * __restrict keys);
+DDS_EXPORT uint32_t dds_stream_countops (const uint32_t *ops, uint32_t nkeys, const dds_key_descriptor_t *keys);
 
 /** @component cdr_serializer */
-size_t dds_stream_check_optimize (const struct dds_cdrstream_desc * __restrict desc, uint32_t xcdr_version);
+size_t dds_stream_check_optimize (const struct dds_cdrstream_desc *desc, uint32_t xcdr_version);
 
 /** @component cdr_serializer */
-bool dds_stream_write_key (dds_ostream_t * __restrict os, enum dds_cdr_key_serialization_kind ser_kind, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict sample, const struct dds_cdrstream_desc * __restrict desc)
+bool dds_stream_write_key (dds_ostream_t *os, enum dds_cdr_key_serialization_kind ser_kind, const struct dds_cdrstream_allocator *allocator, const char *sample, const struct dds_cdrstream_desc *desc)
   ddsrt_attribute_warn_unused_result;
 
 /** @component cdr_serializer */
-bool dds_stream_write_keyBE (dds_ostreamBE_t * __restrict os, enum dds_cdr_key_serialization_kind ser_kind, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict sample, const struct dds_cdrstream_desc * __restrict desc)
+bool dds_stream_write_keyBE (dds_ostreamBE_t *os, enum dds_cdr_key_serialization_kind ser_kind, const struct dds_cdrstream_allocator *allocator, const char *sample, const struct dds_cdrstream_desc *desc)
   ddsrt_attribute_warn_unused_result;
 
 /** @component cdr_serializer */
-DDS_EXPORT bool dds_stream_extract_key_from_data (dds_istream_t * __restrict is, dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const struct dds_cdrstream_desc * __restrict desc)
+DDS_EXPORT bool dds_stream_extract_key_from_data (dds_istream_t *is, dds_ostream_t *os, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc *desc)
   ddsrt_attribute_warn_unused_result;
 
 /** @component cdr_serializer */
-DDS_EXPORT void dds_stream_extract_key_from_key (dds_istream_t * __restrict is, dds_ostream_t * __restrict os, enum dds_cdr_key_serialization_kind ser_kind, const struct dds_cdrstream_allocator * __restrict allocator, const struct dds_cdrstream_desc * __restrict desc);
+DDS_EXPORT void dds_stream_extract_key_from_key (dds_istream_t *is, dds_ostream_t *os, enum dds_cdr_key_serialization_kind ser_kind, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc *desc);
 
 /** @component cdr_serializer */
-DDS_EXPORT bool dds_stream_extract_keyBE_from_data (dds_istream_t * __restrict is, dds_ostreamBE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const struct dds_cdrstream_desc * __restrict desc)
+DDS_EXPORT bool dds_stream_extract_keyBE_from_data (dds_istream_t *is, dds_ostreamBE_t *os, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc *desc)
   ddsrt_attribute_warn_unused_result;
 
 /** @component cdr_serializer */
-DDS_EXPORT void dds_stream_extract_keyBE_from_key (dds_istream_t * __restrict is, dds_ostreamBE_t * __restrict os, enum dds_cdr_key_serialization_kind ser_kind, const struct dds_cdrstream_allocator * __restrict allocator, const struct dds_cdrstream_desc * __restrict desc);
+DDS_EXPORT void dds_stream_extract_keyBE_from_key (dds_istream_t *is, dds_ostreamBE_t *os, enum dds_cdr_key_serialization_kind ser_kind, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc *desc);
 
 /** @component cdr_serializer */
-DDS_EXPORT const uint32_t *dds_stream_read (dds_istream_t * __restrict is, char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops);
+DDS_EXPORT const uint32_t *dds_stream_read (dds_istream_t *is, char *data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops);
 
 /** @component cdr_serializer */
-DDS_EXPORT void dds_stream_read_key (dds_istream_t * __restrict is, char * __restrict sample, const struct dds_cdrstream_allocator * __restrict allocator, const struct dds_cdrstream_desc * __restrict desc);
+DDS_EXPORT void dds_stream_read_key (dds_istream_t *is, char *sample, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc *desc);
 
 /** @component cdr_serializer */
-DDS_EXPORT size_t dds_stream_print_key (dds_istream_t * __restrict is, const struct dds_cdrstream_desc * __restrict desc, char * __restrict buf, size_t size);
+DDS_EXPORT size_t dds_stream_print_key (dds_istream_t *is, const struct dds_cdrstream_desc *desc, char *buf, size_t size);
 
 /** @component cdr_serializer */
-DDS_EXPORT size_t dds_stream_print_sample (dds_istream_t * __restrict is, const struct dds_cdrstream_desc * __restrict desc, char * __restrict buf, size_t size);
+DDS_EXPORT size_t dds_stream_print_sample (dds_istream_t *is, const struct dds_cdrstream_desc *desc, char *buf, size_t size);
 
 /** @component cdr_serializer */
-DDS_EXPORT size_t dds_stream_getsize_sample (const char * __restrict data, const struct dds_cdrstream_desc * __restrict desc, uint32_t xcdr_version)
+DDS_EXPORT size_t dds_stream_getsize_sample (const char *data, const struct dds_cdrstream_desc *desc, uint32_t xcdr_version)
   ddsrt_nonnull_all;
 
 /** @component cdr_serializer */
-DDS_EXPORT size_t dds_stream_getsize_key (enum dds_cdr_key_serialization_kind ser_kind, const char * __restrict sample, const struct dds_cdrstream_desc * __restrict desc, uint32_t xcdr_version)
+DDS_EXPORT size_t dds_stream_getsize_key (enum dds_cdr_key_serialization_kind ser_kind, const char *sample, const struct dds_cdrstream_desc *desc, uint32_t xcdr_version)
   ddsrt_nonnull_all;
 
 /** @component cdr_serializer */
-uint16_t dds_stream_minimum_xcdr_version (const uint32_t * __restrict ops);
+uint16_t dds_stream_minimum_xcdr_version (const uint32_t *ops);
 
 /** @component cdr_serializer */
-uint32_t dds_stream_type_nesting_depth (const uint32_t * __restrict ops);
+uint32_t dds_stream_type_nesting_depth (const uint32_t *ops);
 
 /** @component cdr_serializer */
 uint32_t dds_stream_key_flags (struct dds_cdrstream_desc *desc, uint32_t *keysz_xcdrv1, uint32_t *keysz_xcdrv2);
 
 /** @component cdr_serializer */
-bool dds_stream_extensibility (const uint32_t * __restrict ops, enum dds_cdr_type_extensibility *ext);
+bool dds_stream_extensibility (const uint32_t *ops, enum dds_cdr_type_extensibility *ext);
 
 /** @component cdr_serializer */
-dds_data_type_properties_t dds_stream_data_types (const uint32_t * __restrict ops);
+dds_data_type_properties_t dds_stream_data_types (const uint32_t *ops);
 
 /** @component cdr_serializer */
-DDS_EXPORT void dds_cdrstream_desc_init (struct dds_cdrstream_desc *desc, const struct dds_cdrstream_allocator * __restrict allocator,
+DDS_EXPORT void dds_cdrstream_desc_init (struct dds_cdrstream_desc *desc, const struct dds_cdrstream_allocator *allocator,
     uint32_t size, uint32_t align, uint32_t flagset, const uint32_t *ops, const dds_key_descriptor_t *keys, uint32_t nkeys);
 
 /** @component cdr_serializer */
-DDS_EXPORT void dds_cdrstream_desc_fini (struct dds_cdrstream_desc *desc, const struct dds_cdrstream_allocator * __restrict allocator);
+DDS_EXPORT void dds_cdrstream_desc_fini (struct dds_cdrstream_desc *desc, const struct dds_cdrstream_allocator *allocator);
 
 /** @component cdr_serializer */
 DDS_EXPORT void dds_cdrstream_desc_from_topic_desc (struct dds_cdrstream_desc *desc, const dds_topic_descriptor_t *topic_desc);

--- a/src/core/cdr/src/dds_cdrstream.c
+++ b/src/core/cdr/src/dds_cdrstream.c
@@ -138,25 +138,25 @@ struct dds_cdrstream_ops_info {
   dds_data_type_properties_t data_types;
 };
 
-static const uint32_t *dds_stream_skip_adr (uint32_t insn, const uint32_t * __restrict ops);
-static const uint32_t *dds_stream_skip_default (char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, enum sample_data_state sample_state);
-static const uint32_t *dds_stream_extract_key_from_data1 (dds_istream_t * __restrict is, dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator,
-  const uint32_t * const __restrict op0, const uint32_t * __restrict ops, bool mutable_member, bool mutable_member_or_parent,
-  uint32_t n_keys, uint32_t * __restrict keys_remaining);
+static const uint32_t *dds_stream_skip_adr (uint32_t insn, const uint32_t *ops);
+static const uint32_t *dds_stream_skip_default (char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, enum sample_data_state sample_state);
+static const uint32_t *dds_stream_extract_key_from_data1 (dds_istream_t *is, dds_ostream_t *os, const struct dds_cdrstream_allocator *allocator,
+  const uint32_t * const op0, const uint32_t *ops, bool mutable_member, bool mutable_member_or_parent,
+  uint32_t n_keys, uint32_t * restrict keys_remaining);
 #if DDSRT_ENDIAN == DDSRT_LITTLE_ENDIAN
-static const uint32_t *dds_stream_extract_keyBE_from_data1 (dds_istream_t * __restrict is, dds_ostreamBE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator,
-  const uint32_t * const __restrict op0, const uint32_t * __restrict ops, bool mutable_member, bool mutable_member_or_parent,
-  uint32_t n_keys, uint32_t * __restrict keys_remaining);
+static const uint32_t *dds_stream_extract_keyBE_from_data1 (dds_istream_t *is, dds_ostreamBE_t *os, const struct dds_cdrstream_allocator *allocator,
+  const uint32_t * const op0, const uint32_t *ops, bool mutable_member, bool mutable_member_or_parent,
+  uint32_t n_keys, uint32_t * restrict keys_remaining);
 #endif
-static const uint32_t *stream_normalize_data_impl (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t * __restrict ops, bool is_mutable_member, enum cdr_data_kind cdr_kind) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
-static const uint32_t *dds_stream_read_impl (dds_istream_t * __restrict is, char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, bool is_mutable_member, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state);
-static const uint32_t *stream_free_sample_adr (uint32_t insn, void * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops);
-static const uint32_t *dds_stream_skip_adr_default (uint32_t insn, char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, enum sample_data_state sample_state);
-static const uint32_t *dds_stream_key_size (const uint32_t * __restrict ops, struct key_props *k);
-static const uint32_t *dds_stream_free_sample_uni (char * __restrict discaddr, char * __restrict baseaddr, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, uint32_t insn);
+static const uint32_t *stream_normalize_data_impl (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t *ops, bool is_mutable_member, enum cdr_data_kind cdr_kind) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+static const uint32_t *dds_stream_read_impl (dds_istream_t *is, char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, bool is_mutable_member, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state);
+static const uint32_t *stream_free_sample_adr (uint32_t insn, void * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops);
+static const uint32_t *dds_stream_skip_adr_default (uint32_t insn, char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, enum sample_data_state sample_state);
+static const uint32_t *dds_stream_key_size (const uint32_t *ops, struct key_props *k);
+static const uint32_t *dds_stream_free_sample_uni (char * restrict discaddr, char * restrict baseaddr, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, uint32_t insn);
 
-static const uint32_t *dds_stream_write_implLE (dds_ostreamLE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict data, const uint32_t * __restrict ops, bool is_mutable_member, enum cdr_data_kind cdr_kind);
-static const uint32_t *dds_stream_write_implBE (dds_ostreamBE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict data, const uint32_t * __restrict ops, bool is_mutable_member, enum cdr_data_kind cdr_kind);
+static const uint32_t *dds_stream_write_implLE (dds_ostreamLE_t *os, const struct dds_cdrstream_allocator *allocator, const char *data, const uint32_t *ops, bool is_mutable_member, enum cdr_data_kind cdr_kind);
+static const uint32_t *dds_stream_write_implBE (dds_ostreamBE_t *os, const struct dds_cdrstream_allocator *allocator, const char *data, const uint32_t *ops, bool is_mutable_member, enum cdr_data_kind cdr_kind);
 
 #ifndef NDEBUG
 typedef struct align { uint32_t a; } align_t;
@@ -179,7 +179,7 @@ static inline align_t dds_cdr_get_align (uint32_t xcdr_version, uint32_t size)
 #undef MK_ALIGN
 }
 
-static void dds_ostream_grow (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, uint32_t size)
+static void dds_ostream_grow (dds_ostream_t *os, const struct dds_cdrstream_allocator *allocator, uint32_t size)
 {
   uint32_t needed = size + os->m_index;
 
@@ -202,13 +202,13 @@ dds_ostream_t dds_ostream_from_buffer(void *buffer, size_t size, uint16_t write_
   return os;
 }
 
-static void dds_cdr_resize (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, uint32_t l)
+static void dds_cdr_resize (dds_ostream_t *os, const struct dds_cdrstream_allocator *allocator, uint32_t l)
 {
   if (os->m_size < l + os->m_index)
     dds_ostream_grow (os, allocator, l);
 }
 
-void dds_istream_init (dds_istream_t * __restrict is, uint32_t size, const void * __restrict input, uint32_t xcdr_version)
+void dds_istream_init (dds_istream_t *is, uint32_t size, const void *input, uint32_t xcdr_version)
 {
   is->m_buffer = input;
   is->m_size = size;
@@ -216,7 +216,7 @@ void dds_istream_init (dds_istream_t * __restrict is, uint32_t size, const void 
   is->m_xcdr_version = xcdr_version;
 }
 
-void dds_ostream_init (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, uint32_t size, uint32_t xcdr_version)
+void dds_ostream_init (dds_ostream_t *os, const struct dds_cdrstream_allocator *allocator, uint32_t size, uint32_t xcdr_version)
 {
   os->m_buffer = NULL;
   os->m_size = 0;
@@ -225,44 +225,44 @@ void dds_ostream_init (dds_ostream_t * __restrict os, const struct dds_cdrstream
   dds_cdr_resize (os, allocator, size);
 }
 
-void dds_ostreamLE_init (dds_ostreamLE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, uint32_t size, uint32_t xcdr_version)
+void dds_ostreamLE_init (dds_ostreamLE_t *os, const struct dds_cdrstream_allocator *allocator, uint32_t size, uint32_t xcdr_version)
 {
   dds_ostream_init (&os->x, allocator, size, xcdr_version);
 }
 
-void dds_ostreamBE_init (dds_ostreamBE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, uint32_t size, uint32_t xcdr_version)
+void dds_ostreamBE_init (dds_ostreamBE_t *os, const struct dds_cdrstream_allocator *allocator, uint32_t size, uint32_t xcdr_version)
 {
   dds_ostream_init (&os->x, allocator, size, xcdr_version);
 }
 
-void dds_istream_fini (dds_istream_t * __restrict is)
+void dds_istream_fini (dds_istream_t *is)
 {
   (void) is;
 }
 
-void dds_ostream_fini (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator)
+void dds_ostream_fini (dds_ostream_t *os, const struct dds_cdrstream_allocator *allocator)
 {
   if (os->m_size)
     allocator->free (os->m_buffer);
 }
 
-void dds_ostreamLE_fini (dds_ostreamLE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator)
+void dds_ostreamLE_fini (dds_ostreamLE_t *os, const struct dds_cdrstream_allocator *allocator)
 {
   dds_ostream_fini (&os->x, allocator);
 }
 
-void dds_ostreamBE_fini (dds_ostreamBE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator)
+void dds_ostreamBE_fini (dds_ostreamBE_t *os, const struct dds_cdrstream_allocator *allocator)
 {
   dds_ostream_fini (&os->x, allocator);
 }
 
-static void dds_cdr_alignto (dds_istream_t * __restrict is, align_t a)
+static void dds_cdr_alignto (dds_istream_t *is, align_t a)
 {
   is->m_index = (is->m_index + ALIGN(a) - 1) & ~(ALIGN(a) - 1);
   assert (is->m_index < is->m_size);
 }
 
-static uint32_t dds_cdr_alignto_clear_and_resize (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, align_t a, uint32_t extra)
+static uint32_t dds_cdr_alignto_clear_and_resize (dds_ostream_t *os, const struct dds_cdrstream_allocator *allocator, align_t a, uint32_t extra)
 {
   const uint32_t m = os->m_index % ALIGN(a);
   if (m == 0)
@@ -281,18 +281,18 @@ static uint32_t dds_cdr_alignto_clear_and_resize (dds_ostream_t * __restrict os,
 }
 
 #if DDSRT_ENDIAN == DDSRT_LITTLE_ENDIAN
-static uint32_t dds_cdr_alignto_clear_and_resizeBE (dds_ostreamBE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, align_t a, uint32_t extra)
+static uint32_t dds_cdr_alignto_clear_and_resizeBE (dds_ostreamBE_t *os, const struct dds_cdrstream_allocator *allocator, align_t a, uint32_t extra)
 {
   return dds_cdr_alignto_clear_and_resize (&os->x, allocator, a, extra);
 }
 #endif
 
-uint32_t dds_cdr_alignto4_clear_and_resize (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, uint32_t xcdr_version)
+uint32_t dds_cdr_alignto4_clear_and_resize (dds_ostream_t *os, const struct dds_cdrstream_allocator *allocator, uint32_t xcdr_version)
 {
   return dds_cdr_alignto_clear_and_resize (os, allocator, dds_cdr_get_align (xcdr_version, 4), 0);
 }
 
-static uint8_t dds_is_get1 (dds_istream_t * __restrict is)
+static uint8_t dds_is_get1 (dds_istream_t *is)
 {
   assert (is->m_index < is->m_size);
   uint8_t v = *(is->m_buffer + is->m_index);
@@ -300,7 +300,7 @@ static uint8_t dds_is_get1 (dds_istream_t * __restrict is)
   return v;
 }
 
-static uint16_t dds_is_get2 (dds_istream_t * __restrict is)
+static uint16_t dds_is_get2 (dds_istream_t *is)
 {
   dds_cdr_alignto (is, dds_cdr_get_align (is->m_xcdr_version, 2));
   uint16_t v = * ((uint16_t *) (is->m_buffer + is->m_index));
@@ -308,7 +308,7 @@ static uint16_t dds_is_get2 (dds_istream_t * __restrict is)
   return v;
 }
 
-static uint32_t dds_is_get4 (dds_istream_t * __restrict is)
+static uint32_t dds_is_get4 (dds_istream_t *is)
 {
   dds_cdr_alignto (is, dds_cdr_get_align (is->m_xcdr_version, 4));
   uint32_t v = * ((uint32_t *) (is->m_buffer + is->m_index));
@@ -316,14 +316,14 @@ static uint32_t dds_is_get4 (dds_istream_t * __restrict is)
   return v;
 }
 
-static uint32_t dds_is_peek4 (dds_istream_t * __restrict is)
+static uint32_t dds_is_peek4 (dds_istream_t *is)
 {
   dds_cdr_alignto (is, dds_cdr_get_align (is->m_xcdr_version, 4));
   uint32_t v = * ((uint32_t *) (is->m_buffer + is->m_index));
   return v;
 }
 
-static uint64_t dds_is_get8 (dds_istream_t * __restrict is)
+static uint64_t dds_is_get8 (dds_istream_t *is)
 {
   dds_cdr_alignto (is, dds_cdr_get_align (is->m_xcdr_version, 8));
   size_t off_low = (DDSRT_ENDIAN == DDSRT_LITTLE_ENDIAN) ? 0 : 4, off_high = 4 - off_low;
@@ -334,35 +334,35 @@ static uint64_t dds_is_get8 (dds_istream_t * __restrict is)
   return v;
 }
 
-static void dds_is_get_bytes (dds_istream_t * __restrict is, void * __restrict b, uint32_t num, uint32_t elem_size)
+static void dds_is_get_bytes (dds_istream_t *is, void * restrict b, uint32_t num, uint32_t elem_size)
 {
   dds_cdr_alignto (is, dds_cdr_get_align (is->m_xcdr_version, elem_size));
   memcpy (b, is->m_buffer + is->m_index, num * elem_size);
   is->m_index += num * elem_size;
 }
 
-static void dds_os_put1 (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, uint8_t v)
+static void dds_os_put1 (dds_ostream_t *os, const struct dds_cdrstream_allocator *allocator, uint8_t v)
 {
   dds_cdr_resize (os, allocator, 1);
   *((uint8_t *) (os->m_buffer + os->m_index)) = v;
   os->m_index += 1;
 }
 
-static void dds_os_put2 (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, uint16_t v)
+static void dds_os_put2 (dds_ostream_t *os, const struct dds_cdrstream_allocator *allocator, uint16_t v)
 {
   dds_cdr_alignto_clear_and_resize (os, allocator, dds_cdr_get_align (os->m_xcdr_version, 2), 2);
   *((uint16_t *) (os->m_buffer + os->m_index)) = v;
   os->m_index += 2;
 }
 
-static void dds_os_put4 (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, uint32_t v)
+static void dds_os_put4 (dds_ostream_t *os, const struct dds_cdrstream_allocator *allocator, uint32_t v)
 {
   dds_cdr_alignto_clear_and_resize (os, allocator, dds_cdr_get_align (os->m_xcdr_version, 4), 4);
   *((uint32_t *) (os->m_buffer + os->m_index)) = v;
   os->m_index += 4;
 }
 
-static void dds_os_put8 (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, uint64_t v)
+static void dds_os_put8 (dds_ostream_t *os, const struct dds_cdrstream_allocator *allocator, uint64_t v)
 {
   dds_cdr_alignto_clear_and_resize (os, allocator, dds_cdr_get_align (os->m_xcdr_version, 8), 8);
   size_t off_low = (DDSRT_ENDIAN == DDSRT_LITTLE_ENDIAN) ? 0 : 4, off_high = 4 - off_low;
@@ -371,35 +371,35 @@ static void dds_os_put8 (dds_ostream_t * __restrict os, const struct dds_cdrstre
   os->m_index += 8;
 }
 
-static uint32_t dds_os_reserve4 (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator)
+static uint32_t dds_os_reserve4 (dds_ostream_t *os, const struct dds_cdrstream_allocator *allocator)
 {
   dds_cdr_alignto_clear_and_resize (os, allocator, dds_cdr_get_align (os->m_xcdr_version, 4), 4);
   os->m_index += 4;
   return os->m_index;
 }
 
-static uint32_t dds_os_reserve8 (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator)
+static uint32_t dds_os_reserve8 (dds_ostream_t *os, const struct dds_cdrstream_allocator *allocator)
 {
   dds_cdr_alignto_clear_and_resize (os, allocator, dds_cdr_get_align (os->m_xcdr_version, 8), 8);
   os->m_index += 8;
   return os->m_index;
 }
 
-static void dds_os_put1LE (dds_ostreamLE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, uint8_t v)  { dds_os_put1 (&os->x, allocator, v); }
-static void dds_os_put2LE (dds_ostreamLE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, uint16_t v) { dds_os_put2 (&os->x, allocator, ddsrt_toLE2u (v)); }
-static void dds_os_put4LE (dds_ostreamLE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, uint32_t v) { dds_os_put4 (&os->x, allocator, ddsrt_toLE4u (v)); }
-static void dds_os_put8LE (dds_ostreamLE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, uint64_t v) { dds_os_put8 (&os->x, allocator, ddsrt_toLE8u (v)); }
-static uint32_t dds_os_reserve4LE (dds_ostreamLE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator) { return dds_os_reserve4 (&os->x, allocator); }
-static uint32_t dds_os_reserve8LE (dds_ostreamLE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator) { return dds_os_reserve8 (&os->x, allocator); }
+static void dds_os_put1LE (dds_ostreamLE_t *os, const struct dds_cdrstream_allocator *allocator, uint8_t v)  { dds_os_put1 (&os->x, allocator, v); }
+static void dds_os_put2LE (dds_ostreamLE_t *os, const struct dds_cdrstream_allocator *allocator, uint16_t v) { dds_os_put2 (&os->x, allocator, ddsrt_toLE2u (v)); }
+static void dds_os_put4LE (dds_ostreamLE_t *os, const struct dds_cdrstream_allocator *allocator, uint32_t v) { dds_os_put4 (&os->x, allocator, ddsrt_toLE4u (v)); }
+static void dds_os_put8LE (dds_ostreamLE_t *os, const struct dds_cdrstream_allocator *allocator, uint64_t v) { dds_os_put8 (&os->x, allocator, ddsrt_toLE8u (v)); }
+static uint32_t dds_os_reserve4LE (dds_ostreamLE_t *os, const struct dds_cdrstream_allocator *allocator) { return dds_os_reserve4 (&os->x, allocator); }
+static uint32_t dds_os_reserve8LE (dds_ostreamLE_t *os, const struct dds_cdrstream_allocator *allocator) { return dds_os_reserve8 (&os->x, allocator); }
 
-static void dds_os_put1BE (dds_ostreamBE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, uint8_t v)  { dds_os_put1 (&os->x, allocator, v); }
-static void dds_os_put2BE (dds_ostreamBE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, uint16_t v) { dds_os_put2 (&os->x, allocator, ddsrt_toBE2u (v)); }
-static void dds_os_put4BE (dds_ostreamBE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, uint32_t v) { dds_os_put4 (&os->x, allocator, ddsrt_toBE4u (v)); }
-static void dds_os_put8BE (dds_ostreamBE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, uint64_t v) { dds_os_put8 (&os->x, allocator, ddsrt_toBE8u (v)); }
-static uint32_t dds_os_reserve4BE (dds_ostreamBE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator) { return dds_os_reserve4 (&os->x, allocator); }
-static uint32_t dds_os_reserve8BE (dds_ostreamBE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator) { return dds_os_reserve8 (&os->x, allocator); }
+static void dds_os_put1BE (dds_ostreamBE_t *os, const struct dds_cdrstream_allocator *allocator, uint8_t v)  { dds_os_put1 (&os->x, allocator, v); }
+static void dds_os_put2BE (dds_ostreamBE_t *os, const struct dds_cdrstream_allocator *allocator, uint16_t v) { dds_os_put2 (&os->x, allocator, ddsrt_toBE2u (v)); }
+static void dds_os_put4BE (dds_ostreamBE_t *os, const struct dds_cdrstream_allocator *allocator, uint32_t v) { dds_os_put4 (&os->x, allocator, ddsrt_toBE4u (v)); }
+static void dds_os_put8BE (dds_ostreamBE_t *os, const struct dds_cdrstream_allocator *allocator, uint64_t v) { dds_os_put8 (&os->x, allocator, ddsrt_toBE8u (v)); }
+static uint32_t dds_os_reserve4BE (dds_ostreamBE_t *os, const struct dds_cdrstream_allocator *allocator) { return dds_os_reserve4 (&os->x, allocator); }
+static uint32_t dds_os_reserve8BE (dds_ostreamBE_t *os, const struct dds_cdrstream_allocator *allocator) { return dds_os_reserve8 (&os->x, allocator); }
 
-static void dds_stream_swap (void * __restrict vbuf, uint32_t size, uint32_t num)
+static void dds_stream_swap (void *vbuf, uint32_t size, uint32_t num)
 {
   assert (size == 1 || size == 2 || size == 4 || size == 8);
   switch (size)
@@ -436,14 +436,14 @@ static void dds_stream_swap (void * __restrict vbuf, uint32_t size, uint32_t num
   }
 }
 
-static void dds_os_put_bytes (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const void * __restrict b, uint32_t l)
+static void dds_os_put_bytes (dds_ostream_t *os, const struct dds_cdrstream_allocator *allocator, const void *b, uint32_t l)
 {
   dds_cdr_resize (os, allocator, l);
   memcpy (os->m_buffer + os->m_index, b, l);
   os->m_index += l;
 }
 
-static void dds_os_put_bytes_aligned (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const void * __restrict data, uint32_t num, uint32_t elem_sz, align_t cdr_align, void **dst)
+static void dds_os_put_bytes_aligned (dds_ostream_t *os, const struct dds_cdrstream_allocator *allocator, const void *data, uint32_t num, uint32_t elem_sz, align_t cdr_align, void **dst)
 {
   const uint32_t sz = num * elem_sz;
   dds_cdr_alignto_clear_and_resize (os, allocator, cdr_align, sz);
@@ -484,7 +484,7 @@ static uint32_t get_primitive_size (enum dds_stream_typecode type)
     abort ();
 }
 
-static uint32_t get_collection_elem_size (uint32_t insn, const uint32_t * __restrict ops)
+static uint32_t get_collection_elem_size (uint32_t insn, const uint32_t *ops)
 {
   switch (DDS_OP_SUBTYPE (insn))
   {
@@ -512,7 +512,7 @@ static uint32_t get_collection_elem_size (uint32_t insn, const uint32_t * __rest
   return 0u;
 }
 
-static uint32_t get_adr_type_size (uint32_t insn, const uint32_t * __restrict ops)
+static uint32_t get_adr_type_size (uint32_t insn, const uint32_t *ops)
 {
   uint32_t sz = 0;
   switch (DDS_OP_TYPE (insn))
@@ -563,7 +563,7 @@ static uint32_t get_adr_type_size (uint32_t insn, const uint32_t * __restrict op
   return sz;
 }
 
-static uint32_t get_jeq4_type_size (const enum dds_stream_typecode valtype, const uint32_t * __restrict jeq_op)
+static uint32_t get_jeq4_type_size (const enum dds_stream_typecode valtype, const uint32_t *jeq_op)
 {
   uint32_t sz = 0;
   switch (valtype)
@@ -645,7 +645,7 @@ static inline bool check_optimize_impl (uint32_t xcdr_version, const uint32_t *o
   return true;
 }
 
-static uint32_t dds_stream_check_optimize1 (const struct dds_cdrstream_desc * __restrict desc, uint32_t xcdr_version, const uint32_t *ops, uint32_t off, uint32_t member_offs)
+static uint32_t dds_stream_check_optimize1 (const struct dds_cdrstream_desc *desc, uint32_t xcdr_version, const uint32_t *ops, uint32_t off, uint32_t member_offs)
 {
   uint32_t insn;
   while ((insn = *ops) != DDS_OP_RTS)
@@ -729,7 +729,7 @@ static uint32_t dds_stream_check_optimize1 (const struct dds_cdrstream_desc * __
 #undef ALLOW_ENUM
 }
 
-size_t dds_stream_check_optimize (const struct dds_cdrstream_desc * __restrict desc, uint32_t xcdr_version)
+size_t dds_stream_check_optimize (const struct dds_cdrstream_desc *desc, uint32_t xcdr_version)
 {
   size_t opt_size = dds_stream_check_optimize1 (desc, xcdr_version, desc->ops.ops, 0, 0);
   // off < desc can occur if desc->size includes "trailing" padding
@@ -737,9 +737,9 @@ size_t dds_stream_check_optimize (const struct dds_cdrstream_desc * __restrict d
   return opt_size;
 }
 
-static void dds_stream_get_ops_info1 (const uint32_t * __restrict ops, uint32_t nestc, struct dds_cdrstream_ops_info *info);
+static void dds_stream_get_ops_info1 (const uint32_t *ops, uint32_t nestc, struct dds_cdrstream_ops_info *info);
 
-static const uint32_t *dds_stream_get_ops_info_seq (const uint32_t * __restrict ops, uint32_t insn, uint32_t nestc, struct dds_cdrstream_ops_info *info)
+static const uint32_t *dds_stream_get_ops_info_seq (const uint32_t *ops, uint32_t insn, uint32_t nestc, struct dds_cdrstream_ops_info *info)
 {
   uint32_t bound_op = seq_is_bounded (DDS_OP_TYPE (insn)) ? 1 : 0;
   const enum dds_stream_typecode subtype = DDS_OP_SUBTYPE (insn);
@@ -795,7 +795,7 @@ static const uint32_t *dds_stream_get_ops_info_seq (const uint32_t * __restrict 
   return ops;
 }
 
-static const uint32_t *dds_stream_get_ops_info_arr (const uint32_t * __restrict ops, uint32_t insn, uint32_t nestc, struct dds_cdrstream_ops_info *info)
+static const uint32_t *dds_stream_get_ops_info_arr (const uint32_t *ops, uint32_t insn, uint32_t nestc, struct dds_cdrstream_ops_info *info)
 {
   const enum dds_stream_typecode subtype = DDS_OP_SUBTYPE (insn);
   switch (subtype)
@@ -850,7 +850,7 @@ static const uint32_t *dds_stream_get_ops_info_arr (const uint32_t * __restrict 
   return ops;
 }
 
-static const uint32_t *dds_stream_get_ops_info_uni (const uint32_t * __restrict ops, uint32_t nestc, struct dds_cdrstream_ops_info *info)
+static const uint32_t *dds_stream_get_ops_info_uni (const uint32_t *ops, uint32_t nestc, struct dds_cdrstream_ops_info *info)
 {
   enum dds_stream_typecode disc_type = DDS_OP_SUBTYPE (ops[0]);
   if (disc_type == DDS_OP_VAL_ENU)
@@ -901,7 +901,7 @@ static const uint32_t *dds_stream_get_ops_info_uni (const uint32_t * __restrict 
   return ops;
 }
 
-static const uint32_t *dds_stream_get_ops_info_pl (const uint32_t * __restrict ops, uint32_t nestc, struct dds_cdrstream_ops_info *info)
+static const uint32_t *dds_stream_get_ops_info_pl (const uint32_t *ops, uint32_t nestc, struct dds_cdrstream_ops_info *info)
 {
   uint32_t insn;
   assert (ops[0] == DDS_OP_PLC);
@@ -930,7 +930,7 @@ static const uint32_t *dds_stream_get_ops_info_pl (const uint32_t * __restrict o
   return ops;
 }
 
-static void dds_stream_get_ops_info1 (const uint32_t * __restrict ops, uint32_t nestc, struct dds_cdrstream_ops_info *info)
+static void dds_stream_get_ops_info1 (const uint32_t *ops, uint32_t nestc, struct dds_cdrstream_ops_info *info)
 {
   uint32_t insn;
   if (info->nesting_max < nestc)
@@ -1045,7 +1045,7 @@ static void dds_stream_get_ops_info1 (const uint32_t * __restrict ops, uint32_t 
     info->ops_end = ops;
 }
 
-static void dds_stream_countops_keyoffset (const uint32_t * __restrict ops, const dds_key_descriptor_t * __restrict key, const uint32_t ** __restrict ops_end)
+static void dds_stream_countops_keyoffset (const uint32_t *ops, const dds_key_descriptor_t *key, const uint32_t **ops_end)
 {
   assert (key);
   assert (*ops_end);
@@ -1056,7 +1056,7 @@ static void dds_stream_countops_keyoffset (const uint32_t * __restrict ops, cons
   }
 }
 
-static void dds_stream_get_ops_info (const uint32_t * __restrict ops, struct dds_cdrstream_ops_info *info)
+static void dds_stream_get_ops_info (const uint32_t *ops, struct dds_cdrstream_ops_info *info)
 {
   info->toplevel_op = NULL;
   info->ops_end = ops;
@@ -1066,7 +1066,7 @@ static void dds_stream_get_ops_info (const uint32_t * __restrict ops, struct dds
   dds_stream_get_ops_info1 (ops, 0, info);
 }
 
-static char *dds_stream_reuse_string_bound (dds_istream_t * __restrict is, char * __restrict str, const uint32_t size)
+static char *dds_stream_reuse_string_bound (dds_istream_t *is, char * restrict str, const uint32_t size)
 {
   const uint32_t length = dds_is_get4 (is);
   const void *src = is->m_buffer + is->m_index;
@@ -1080,7 +1080,7 @@ static char *dds_stream_reuse_string_bound (dds_istream_t * __restrict is, char 
   return str;
 }
 
-static char *dds_stream_reuse_string (dds_istream_t * __restrict is, char * __restrict str, const struct dds_cdrstream_allocator * __restrict allocator, enum sample_data_state sample_state)
+static char *dds_stream_reuse_string (dds_istream_t *is, char * restrict str, const struct dds_cdrstream_allocator *allocator, enum sample_data_state sample_state)
 {
   const uint32_t length = dds_is_get4 (is);
   const void *src = is->m_buffer + is->m_index;
@@ -1096,7 +1096,7 @@ static char *dds_stream_reuse_string (dds_istream_t * __restrict is, char * __re
   return str;
 }
 
-static char *dds_stream_reuse_string_empty (char * __restrict str, const struct dds_cdrstream_allocator * __restrict allocator, enum sample_data_state sample_state)
+static char *dds_stream_reuse_string_empty (char * restrict str, const struct dds_cdrstream_allocator *allocator, enum sample_data_state sample_state)
 {
   if (sample_state == SAMPLE_DATA_INITIALIZED && str != NULL)
   {
@@ -1122,7 +1122,7 @@ static size_t wstring_utf16_len (const wchar_t *str)
   return n;
 }
 
-static void wstring_from_utf16 (wchar_t *dst, size_t dstlen, const uint16_t *src, size_t srclen)
+static void wstring_from_utf16 (wchar_t * restrict dst, size_t dstlen, const uint16_t *src, size_t srclen)
 {
   // src, srclen without terminating 0
   // dst, dstlen including terminating 0
@@ -1158,7 +1158,7 @@ static void wstring_from_utf16 (wchar_t *dst, size_t dstlen, const uint16_t *src
   }
 }
 
-static wchar_t *dds_stream_reuse_wstring_bound (dds_istream_t * __restrict is, wchar_t * __restrict str, const uint32_t size)
+static wchar_t *dds_stream_reuse_wstring_bound (dds_istream_t *is, wchar_t * restrict str, const uint32_t size)
 {
   const uint32_t cdrsize = dds_is_get4 (is);
   const uint16_t *src = (const uint16_t *) (is->m_buffer + is->m_index);
@@ -1167,7 +1167,7 @@ static wchar_t *dds_stream_reuse_wstring_bound (dds_istream_t * __restrict is, w
   return str;
 }
 
-static wchar_t *dds_stream_reuse_wstring (dds_istream_t * __restrict is, wchar_t * __restrict str, const struct dds_cdrstream_allocator * __restrict allocator, enum sample_data_state sample_state)
+static wchar_t *dds_stream_reuse_wstring (dds_istream_t *is, wchar_t * restrict str, const struct dds_cdrstream_allocator *allocator, enum sample_data_state sample_state)
 {
   const uint32_t cdrsize = dds_is_get4 (is);
   const uint16_t *src = (const uint16_t *) (is->m_buffer + is->m_index);
@@ -1184,7 +1184,7 @@ static wchar_t *dds_stream_reuse_wstring (dds_istream_t * __restrict is, wchar_t
   return str;
 }
 
-static wchar_t *dds_stream_reuse_wstring_empty (wchar_t * __restrict str, const struct dds_cdrstream_allocator * __restrict allocator, enum sample_data_state sample_state)
+static wchar_t *dds_stream_reuse_wstring_empty (wchar_t * restrict str, const struct dds_cdrstream_allocator *allocator, enum sample_data_state sample_state)
 {
   if (sample_state == SAMPLE_DATA_INITIALIZED && str != NULL)
   {
@@ -1197,19 +1197,19 @@ static wchar_t *dds_stream_reuse_wstring_empty (wchar_t * __restrict str, const 
   return str;
 }
 
-static void dds_stream_skip_forward (dds_istream_t * __restrict is, uint32_t len, const uint32_t elem_size)
+static void dds_stream_skip_forward (dds_istream_t *is, uint32_t len, const uint32_t elem_size)
 {
   if (elem_size && len)
     is->m_index += len * elem_size;
 }
 
-static void dds_stream_skip_string (dds_istream_t * __restrict is)
+static void dds_stream_skip_string (dds_istream_t *is)
 {
   const uint32_t length = dds_is_get4 (is);
   dds_stream_skip_forward (is, length, 1);
 }
 
-static void dds_stream_skip_wstring (dds_istream_t * __restrict is)
+static void dds_stream_skip_wstring (dds_istream_t *is)
 {
   const uint32_t length = dds_is_get4 (is);
   dds_stream_skip_forward (is, length, 1);
@@ -1226,7 +1226,7 @@ static bool insn_key_ok_p (uint32_t insn)
 }
 #endif
 
-static uint32_t read_union_discriminant (dds_istream_t * __restrict is, uint32_t insn)
+static uint32_t read_union_discriminant (dds_istream_t *is, uint32_t insn)
 {
   enum dds_stream_typecode type = DDS_OP_SUBTYPE (insn);
   assert (is_primitive_or_enum_type (type));
@@ -1250,7 +1250,7 @@ static uint32_t read_union_discriminant (dds_istream_t * __restrict is, uint32_t
   return 0;
 }
 
-static const uint32_t *find_union_case (const uint32_t * __restrict union_ops, uint32_t disc)
+static const uint32_t *find_union_case (const uint32_t *union_ops, uint32_t disc)
 {
   assert (DDS_OP_TYPE (*union_ops) == DDS_OP_VAL_UNI);
   const bool has_default = *union_ops & DDS_OP_FLAG_DEF;
@@ -1281,7 +1281,7 @@ static const uint32_t *find_union_case (const uint32_t * __restrict union_ops, u
   return (ci < numcases) ? jeq_op : NULL;
 }
 
-static const uint32_t *skip_sequence_insns (uint32_t insn, const uint32_t * __restrict ops)
+static const uint32_t *skip_sequence_insns (uint32_t insn, const uint32_t *ops)
 {
   uint32_t bound_op = seq_is_bounded (DDS_OP_TYPE (insn)) ? 1 : 0;
   switch (DDS_OP_SUBTYPE (insn))
@@ -1305,7 +1305,7 @@ static const uint32_t *skip_sequence_insns (uint32_t insn, const uint32_t * __re
   return NULL;
 }
 
-static const uint32_t *skip_array_insns (uint32_t insn, const uint32_t * __restrict ops)
+static const uint32_t *skip_array_insns (uint32_t insn, const uint32_t *ops)
 {
   assert (DDS_OP_TYPE (insn) == DDS_OP_VAL_ARR);
   switch (DDS_OP_SUBTYPE (insn))
@@ -1329,7 +1329,7 @@ static const uint32_t *skip_array_insns (uint32_t insn, const uint32_t * __restr
   return NULL;
 }
 
-static const uint32_t *skip_array_default (uint32_t insn, char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, enum sample_data_state sample_state)
+static const uint32_t *skip_array_default (uint32_t insn, char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, enum sample_data_state sample_state)
 {
   const enum dds_stream_typecode subtype = DDS_OP_SUBTYPE (insn);
   const uint32_t num = ops[2];
@@ -1387,7 +1387,7 @@ static const uint32_t *skip_array_default (uint32_t insn, char * __restrict data
   return NULL;
 }
 
-static inline uint32_t const * stream_union_switch_case (uint32_t insn, uint32_t disc, char * __restrict discaddr, char * __restrict baseaddr, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, enum sample_data_state *sample_state)
+static inline uint32_t const * stream_union_switch_case (uint32_t insn, uint32_t disc, char * restrict discaddr, char * restrict baseaddr, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, enum sample_data_state *sample_state)
 {
   /* Switching union cases causes big trouble if some cases have sequences or strings,
      and other cases have other things mapped to those addresses.  So, pretend to be
@@ -1411,7 +1411,7 @@ static inline uint32_t const * stream_union_switch_case (uint32_t insn, uint32_t
   return find_union_case (ops, disc);
 }
 
-static void dds_stream_union_member_alloc_external (uint32_t const * const jeq_op, const enum dds_stream_typecode valtype, void ** valaddr, const struct dds_cdrstream_allocator * __restrict allocator, enum sample_data_state *sample_state)
+static void dds_stream_union_member_alloc_external (uint32_t const * const jeq_op, const enum dds_stream_typecode valtype, void ** valaddr, const struct dds_cdrstream_allocator *allocator, enum sample_data_state *sample_state)
 {
   assert (DDS_OP (jeq_op[0]) == DDS_OP_JEQ4);
   if (*sample_state != SAMPLE_DATA_INITIALIZED || *((char **) *valaddr) == NULL)
@@ -1423,7 +1423,7 @@ static void dds_stream_union_member_alloc_external (uint32_t const * const jeq_o
   *valaddr = *((char **) *valaddr);
 }
 
-static const uint32_t * skip_union_default (uint32_t insn, char * __restrict discaddr, char * __restrict baseaddr, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, enum sample_data_state sample_state)
+static const uint32_t * skip_union_default (uint32_t insn, char * restrict discaddr, char * restrict baseaddr, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, enum sample_data_state sample_state)
 {
   const uint32_t disc = 0;
   uint32_t const * const jeq_op = stream_union_switch_case (insn, disc, discaddr, baseaddr, allocator, ops, &sample_state);
@@ -1513,7 +1513,7 @@ static uint32_t get_length_code_arr (const enum dds_stream_typecode subtype)
   return 0u;
 }
 
-static uint32_t get_length_code (const uint32_t * __restrict ops)
+static uint32_t get_length_code (const uint32_t *ops)
 {
   const uint32_t insn = *ops;
   assert (insn != DDS_OP_RTS);
@@ -1559,7 +1559,7 @@ static uint32_t get_length_code (const uint32_t * __restrict ops)
   return 0;
 }
 
-static bool is_member_present (const char * __restrict data, const uint32_t * __restrict ops)
+static bool is_member_present (const char *data, const uint32_t *ops)
 {
   uint32_t insn;
   while ((insn = *ops) != DDS_OP_RTS)
@@ -1589,11 +1589,11 @@ static bool is_member_present (const char * __restrict data, const uint32_t * __
 }
 
 #if DDSRT_ENDIAN == DDSRT_LITTLE_ENDIAN
-static inline void dds_stream_to_BE_insitu (void * __restrict vbuf, uint32_t size, uint32_t num)
+static inline void dds_stream_to_BE_insitu (void *vbuf, uint32_t size, uint32_t num)
 {
   dds_stream_swap (vbuf, size, num);
 }
-static inline void dds_stream_to_LE_insitu (void * __restrict vbuf, uint32_t size, uint32_t num)
+static inline void dds_stream_to_LE_insitu (void *vbuf, uint32_t size, uint32_t num)
 {
   (void) vbuf;
   (void) size;
@@ -1601,13 +1601,13 @@ static inline void dds_stream_to_LE_insitu (void * __restrict vbuf, uint32_t siz
 }
 #define dds_stream_to__insitu dds_stream_to_LE_insitu
 #else /* if DDSRT_ENDIAN == DDSRT_LITTLE_ENDIAN */
-static inline void dds_stream_to_BE_insitu (void * __restrict vbuf, uint32_t size, uint32_t num)
+static inline void dds_stream_to_BE_insitu (void *vbuf, uint32_t size, uint32_t num)
 {
   (void) vbuf;
   (void) size;
   (void) num;
 }
-static inline void dds_stream_to_LE_insitu (void * __restrict vbuf, uint32_t size, uint32_t num)
+static inline void dds_stream_to_LE_insitu (void *vbuf, uint32_t size, uint32_t num)
 {
   dds_stream_swap (vbuf, size, num);
 }
@@ -1642,7 +1642,7 @@ static inline void dds_stream_to_LE_insitu (void * __restrict vbuf, uint32_t siz
 
 #if DDSRT_ENDIAN == DDSRT_LITTLE_ENDIAN
 
-bool dds_stream_write_sample (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const void * __restrict data, const struct dds_cdrstream_desc * __restrict desc)
+bool dds_stream_write_sample (dds_ostream_t *os, const struct dds_cdrstream_allocator *allocator, const void *data, const struct dds_cdrstream_desc *desc)
 {
   STREAM_SIZE_CHECK_INIT;
   const bool res = dds_stream_write_sampleLE ((dds_ostreamLE_t *) os, allocator, data, desc);
@@ -1650,7 +1650,7 @@ bool dds_stream_write_sample (dds_ostream_t * __restrict os, const struct dds_cd
   return res;
 }
 
-bool dds_stream_write_sampleLE (dds_ostreamLE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const void * __restrict data, const struct dds_cdrstream_desc * __restrict desc)
+bool dds_stream_write_sampleLE (dds_ostreamLE_t *os, const struct dds_cdrstream_allocator *allocator, const void *data, const struct dds_cdrstream_desc *desc)
 {
   STREAM_SIZE_CHECK_INIT;
   const size_t opt_size = os->x.m_xcdr_version == DDSI_RTPS_CDR_ENC_VERSION_1 ? desc->opt_size_xcdr1 : desc->opt_size_xcdr2;
@@ -1665,7 +1665,7 @@ bool dds_stream_write_sampleLE (dds_ostreamLE_t * __restrict os, const struct dd
   return res;
 }
 
-bool dds_stream_write_sampleBE (dds_ostreamBE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const void * __restrict data, const struct dds_cdrstream_desc * __restrict desc)
+bool dds_stream_write_sampleBE (dds_ostreamBE_t *os, const struct dds_cdrstream_allocator *allocator, const void *data, const struct dds_cdrstream_desc *desc)
 {
   STREAM_SIZE_CHECK_INIT;
   const bool res = (dds_stream_writeBE (os, allocator, data, desc->ops.ops) != NULL);
@@ -1675,7 +1675,7 @@ bool dds_stream_write_sampleBE (dds_ostreamBE_t * __restrict os, const struct dd
 
 #else /* if DDSRT_ENDIAN == DDSRT_LITTLE_ENDIAN */
 
-bool dds_stream_write_sample (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const void * __restrict data, const struct dds_cdrstream_desc * __restrict desc)
+bool dds_stream_write_sample (dds_ostream_t *os, const struct dds_cdrstream_allocator *allocator, const void *data, const struct dds_cdrstream_desc *desc)
 {
   STREAM_SIZE_CHECK_INIT;
   const bool res = dds_stream_write_sampleBE ((dds_ostreamBE_t *) os, allocator, data, desc);
@@ -1683,7 +1683,7 @@ bool dds_stream_write_sample (dds_ostream_t * __restrict os, const struct dds_cd
   return res;
 }
 
-bool dds_stream_write_sampleLE (dds_ostreamLE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const void * __restrict data, const struct dds_cdrstream_desc * __restrict desc)
+bool dds_stream_write_sampleLE (dds_ostreamLE_t *os, const struct dds_cdrstream_allocator *allocator, const void *data, const struct dds_cdrstream_desc *desc)
 {
   STREAM_SIZE_CHECK_INIT;
   const bool res = (dds_stream_writeLE (os, allocator, data, desc->ops.ops) != NULL);
@@ -1691,7 +1691,7 @@ bool dds_stream_write_sampleLE (dds_ostreamLE_t * __restrict os, const struct dd
   return res;
 }
 
-bool dds_stream_write_sampleBE (dds_ostreamBE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const void * __restrict data, const struct dds_cdrstream_desc * __restrict desc)
+bool dds_stream_write_sampleBE (dds_ostreamBE_t *os, const struct dds_cdrstream_allocator *allocator, const void *data, const struct dds_cdrstream_desc *desc)
 {
   STREAM_SIZE_CHECK_INIT;
   const size_t opt_size = os->x.m_xcdr_version == DDSI_RTPS_CDR_ENC_VERSION_1 ? desc->opt_size_xcdr1 : desc->opt_size_xcdr2;
@@ -1711,7 +1711,7 @@ bool dds_stream_write_sampleBE (dds_ostreamBE_t * __restrict os, const struct dd
 #undef STREAM_SIZE_CHECK
 #undef STREAM_SIZE_CHECK_INIT
 
-const uint32_t * dds_stream_write_with_byte_order (dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict data, const uint32_t * __restrict ops, enum ddsrt_byte_order_selector bo)
+const uint32_t * dds_stream_write_with_byte_order (dds_ostream_t *os, const struct dds_cdrstream_allocator *allocator, const char *data, const uint32_t *ops, enum ddsrt_byte_order_selector bo)
 {
   if (bo == DDSRT_BOSEL_LE)
     return dds_stream_writeLE ((dds_ostreamLE_t *) os, allocator, data, ops);
@@ -1728,9 +1728,9 @@ struct getsize_state {
   const uint32_t xcdr_version;
 };
 
-static const uint32_t *dds_stream_getsize_impl (struct getsize_state * __restrict st, const char * __restrict data, const uint32_t * __restrict ops, bool is_mutable_member);
+static const uint32_t *dds_stream_getsize_impl (struct getsize_state *st, const char *data, const uint32_t *ops, bool is_mutable_member);
 
-static inline void getsize_reserve (struct getsize_state * __restrict st, uint32_t elemsz)
+static inline void getsize_reserve (struct getsize_state *st, uint32_t elemsz)
 {
   // elemsz is also alignment
   assert (elemsz == 1 || elemsz == 2 || elemsz == 4 || elemsz == 8);
@@ -1739,7 +1739,7 @@ static inline void getsize_reserve (struct getsize_state * __restrict st, uint32
   st->pos = ((st->pos + a) & ~a) + elemsz;
 }
 
-static inline void getsize_reserve_many (struct getsize_state * __restrict st, uint32_t elemsz, uint32_t n)
+static inline void getsize_reserve_many (struct getsize_state *st, uint32_t elemsz, uint32_t n)
 {
   // elemsz is also alignment
   assert (elemsz == 1 || elemsz == 2 || elemsz == 4 || elemsz == 8);
@@ -1748,21 +1748,21 @@ static inline void getsize_reserve_many (struct getsize_state * __restrict st, u
   st->pos = ((st->pos + a) & ~a) + n * elemsz;
 }
 
-static void dds_stream_getsize_string (struct getsize_state * __restrict st, const char * __restrict val)
+static void dds_stream_getsize_string (struct getsize_state *st, const char *val)
 {
   uint32_t size = val ? (uint32_t) strlen (val) + 1 : 1; // string includes '\0'
   getsize_reserve (st, 4);
   getsize_reserve_many (st, 1, size);
 }
 
-static void dds_stream_getsize_wstring (struct getsize_state * __restrict st, const wchar_t * __restrict val)
+static void dds_stream_getsize_wstring (struct getsize_state *st, const wchar_t *val)
 {
   uint32_t size = val ? (uint32_t) wstring_utf16_len (val) : 0; // wstring does not include a terminator
   getsize_reserve (st, 4);
   getsize_reserve_many (st, 2, size);
 }
 
-static const uint32_t *dds_stream_getsize_seq (struct getsize_state * __restrict st, const char * __restrict addr, const uint32_t * __restrict ops, uint32_t insn)
+static const uint32_t *dds_stream_getsize_seq (struct getsize_state *st, const char *addr, const uint32_t *ops, uint32_t insn)
 {
   const dds_sequence_t * const seq = (const dds_sequence_t *) addr;
   uint32_t xcdrv = st->xcdr_version;
@@ -1859,7 +1859,7 @@ static const uint32_t *dds_stream_getsize_seq (struct getsize_state * __restrict
   return ops;
 }
 
-static const uint32_t *dds_stream_getsize_arr (struct getsize_state * __restrict st, const char * __restrict addr, const uint32_t * __restrict ops, uint32_t insn)
+static const uint32_t *dds_stream_getsize_arr (struct getsize_state *st, const char *addr, const uint32_t *ops, uint32_t insn)
 {
   const enum dds_stream_typecode subtype = DDS_OP_SUBTYPE (insn);
   uint32_t xcdrv = st->xcdr_version;
@@ -1935,7 +1935,7 @@ static const uint32_t *dds_stream_getsize_arr (struct getsize_state * __restrict
   return ops;
 }
 
-static bool dds_stream_getsize_union_discriminant (struct getsize_state * __restrict st, uint32_t insn, const void * __restrict addr, uint32_t *disc)
+static bool dds_stream_getsize_union_discriminant (struct getsize_state *st, uint32_t insn, const void *addr, uint32_t *disc)
 {
   assert (disc);
   enum dds_stream_typecode type = DDS_OP_SUBTYPE (insn);
@@ -1968,7 +1968,7 @@ static bool dds_stream_getsize_union_discriminant (struct getsize_state * __rest
   return true;
 }
 
-static const uint32_t *dds_stream_getsize_uni (struct getsize_state * __restrict st, const char * __restrict discaddr, const char * __restrict baseaddr, const uint32_t * __restrict ops, uint32_t insn)
+static const uint32_t *dds_stream_getsize_uni (struct getsize_state *st, const char *discaddr, const char *baseaddr, const uint32_t *ops, uint32_t insn)
 {
   uint32_t disc;
   if (!dds_stream_getsize_union_discriminant (st, insn, discaddr, &disc))
@@ -2016,7 +2016,7 @@ static const uint32_t *dds_stream_getsize_uni (struct getsize_state * __restrict
   return ops;
 }
 
-static const uint32_t *dds_stream_getsize_adr (uint32_t insn, struct getsize_state * __restrict st, const char * __restrict data, const uint32_t * __restrict ops, bool is_mutable_member)
+static const uint32_t *dds_stream_getsize_adr (uint32_t insn, struct getsize_state *st, const char *data, const uint32_t *ops, bool is_mutable_member)
 {
   const void *addr = data + ops[1];
   if (op_type_external (insn) || op_type_optional (insn) || DDS_OP_TYPE (insn) == DDS_OP_VAL_STR || DDS_OP_TYPE (insn) == DDS_OP_VAL_WSTR)
@@ -2076,7 +2076,7 @@ static const uint32_t *dds_stream_getsize_adr (uint32_t insn, struct getsize_sta
   return ops;
 }
 
-static const uint32_t *dds_stream_getsize_delimited (struct getsize_state * __restrict st, const char * __restrict data, const uint32_t * __restrict ops)
+static const uint32_t *dds_stream_getsize_delimited (struct getsize_state *st, const char *data, const uint32_t *ops)
 {
   getsize_reserve (st, 4);
   if (!(ops = dds_stream_getsize_impl (st, data, ops + 1, false)))
@@ -2084,7 +2084,7 @@ static const uint32_t *dds_stream_getsize_delimited (struct getsize_state * __re
   return ops;
 }
 
-static bool dds_stream_getsize_pl_member (struct getsize_state * __restrict st, const char * __restrict data, const uint32_t * __restrict ops)
+static bool dds_stream_getsize_pl_member (struct getsize_state *st, const char *data, const uint32_t *ops)
 {
   /* get flags from first member op */
   uint32_t flags = DDS_OP_FLAGS (ops[0]);
@@ -2102,7 +2102,7 @@ static bool dds_stream_getsize_pl_member (struct getsize_state * __restrict st, 
   return true;
 }
 
-static const uint32_t *dds_stream_getsize_pl_memberlist (struct getsize_state * __restrict st, const char * __restrict data, const uint32_t * __restrict ops)
+static const uint32_t *dds_stream_getsize_pl_memberlist (struct getsize_state *st, const char *data, const uint32_t *ops)
 {
   uint32_t insn;
   while (ops && (insn = *ops) != DDS_OP_RTS)
@@ -2135,7 +2135,7 @@ static const uint32_t *dds_stream_getsize_pl_memberlist (struct getsize_state * 
   return ops;
 }
 
-static const uint32_t *dds_stream_getsize_pl (struct getsize_state * __restrict st, const char * __restrict data, const uint32_t * __restrict ops)
+static const uint32_t *dds_stream_getsize_pl (struct getsize_state *st, const char *data, const uint32_t *ops)
 {
   /* skip PLC op */
   ops++;
@@ -2145,7 +2145,7 @@ static const uint32_t *dds_stream_getsize_pl (struct getsize_state * __restrict 
   return dds_stream_getsize_pl_memberlist (st, data, ops);
 }
 
-static const uint32_t *dds_stream_getsize_impl (struct getsize_state * __restrict st, const char * __restrict data, const uint32_t * __restrict ops, bool is_mutable_member)
+static const uint32_t *dds_stream_getsize_impl (struct getsize_state *st, const char *data, const uint32_t *ops, bool is_mutable_member)
 {
   uint32_t insn;
   while (ops && (insn = *ops) != DDS_OP_RTS)
@@ -2176,7 +2176,7 @@ static const uint32_t *dds_stream_getsize_impl (struct getsize_state * __restric
   return ops;
 }
 
-static size_t dds_stream_getsize_sample_impl (const char * __restrict data, const uint32_t * __restrict ops, uint32_t xcdr_version)
+static size_t dds_stream_getsize_sample_impl (const char *data, const uint32_t *ops, uint32_t xcdr_version)
 {
   struct getsize_state st = {
     .pos = 0,
@@ -2189,12 +2189,12 @@ static size_t dds_stream_getsize_sample_impl (const char * __restrict data, cons
 }
 
 
-size_t dds_stream_getsize_sample (const char * __restrict data, const struct dds_cdrstream_desc * __restrict desc, uint32_t xcdr_version)
+size_t dds_stream_getsize_sample (const char *data, const struct dds_cdrstream_desc *desc, uint32_t xcdr_version)
 {
   return dds_stream_getsize_sample_impl (data, desc->ops.ops, xcdr_version);
 }
 
-static void dds_stream_getsize_key_impl (struct getsize_state * __restrict st, const uint32_t *ops, const void *src, uint16_t key_offset_count, const uint32_t * key_offset_insn)
+static void dds_stream_getsize_key_impl (struct getsize_state *st, const uint32_t *ops, const void *src, uint16_t key_offset_count, const uint32_t * key_offset_insn)
 {
   uint32_t insn = *ops;
   assert (DDS_OP (insn) == DDS_OP_ADR);
@@ -2256,7 +2256,7 @@ static void dds_stream_getsize_key_impl (struct getsize_state * __restrict st, c
   }
 }
 
-size_t dds_stream_getsize_key (enum dds_cdr_key_serialization_kind ser_kind, const char * __restrict sample, const struct dds_cdrstream_desc * __restrict desc, uint32_t xcdr_version)
+size_t dds_stream_getsize_key (enum dds_cdr_key_serialization_kind ser_kind, const char *sample, const struct dds_cdrstream_desc *desc, uint32_t xcdr_version)
 {
   struct getsize_state st = {
     .pos = 0,
@@ -2301,7 +2301,7 @@ size_t dds_stream_getsize_key (enum dds_cdr_key_serialization_kind ser_kind, con
   return st.pos;
 }
 
-static void malloc_sequence_buffer (dds_sequence_t * __restrict seq, const struct dds_cdrstream_allocator * __restrict allocator, uint32_t num, uint32_t elem_size)
+static void malloc_sequence_buffer (dds_sequence_t *seq, const struct dds_cdrstream_allocator *allocator, uint32_t num, uint32_t elem_size)
 {
   const uint32_t size = num * elem_size;
   seq->_buffer = allocator->malloc (size);
@@ -2309,7 +2309,7 @@ static void malloc_sequence_buffer (dds_sequence_t * __restrict seq, const struc
   seq->_maximum = num;
 }
 
-static void grow_sequence_buffer_initialize (dds_sequence_t * __restrict seq, const struct dds_cdrstream_allocator * __restrict allocator, uint32_t num, uint32_t elem_size)
+static void grow_sequence_buffer_initialize (dds_sequence_t *seq, const struct dds_cdrstream_allocator *allocator, uint32_t num, uint32_t elem_size)
 {
   // valid input for seq:
   //  (_maximum == 0 && _buffer == NULL)
@@ -2337,7 +2337,7 @@ static void grow_sequence_buffer_initialize (dds_sequence_t * __restrict seq, co
  * can avoid by using its buffers in a slightly different way, and the additional memcpy/memset
  * on realloc, but those operations are usually cheaper than trying to free the sample.
  */
-static void adjust_sequence_buffer_initialize (dds_sequence_t * __restrict seq, const struct dds_cdrstream_allocator * __restrict allocator, uint32_t num, uint32_t elem_size, enum sample_data_state *sample_state)
+static void adjust_sequence_buffer_initialize (dds_sequence_t *seq, const struct dds_cdrstream_allocator *allocator, uint32_t num, uint32_t elem_size, enum sample_data_state *sample_state)
 {
   // If num == 0, dds_stream_read_seq short-circuits
   assert (num > 0);
@@ -2363,7 +2363,7 @@ static void adjust_sequence_buffer_initialize (dds_sequence_t * __restrict seq, 
   }
 }
 
-static void adjust_sequence_buffer (dds_sequence_t * __restrict seq, const struct dds_cdrstream_allocator * __restrict allocator, uint32_t num, uint32_t elem_size, enum sample_data_state *sample_state)
+static void adjust_sequence_buffer (dds_sequence_t *seq, const struct dds_cdrstream_allocator *allocator, uint32_t num, uint32_t elem_size, enum sample_data_state *sample_state)
 {
   // Reduced version of adjust_sequence_buffer_initialize that avoids
   // memsetting when we know it won't matter, e.g. a sequence of ints
@@ -2385,12 +2385,12 @@ static void adjust_sequence_buffer (dds_sequence_t * __restrict seq, const struc
   }
 }
 
-static bool stream_is_member_present (uint32_t insn, dds_istream_t * __restrict is, bool is_mutable_member)
+static bool stream_is_member_present (uint32_t insn, dds_istream_t *is, bool is_mutable_member)
 {
   return !op_type_optional (insn) || is_mutable_member || dds_is_get1 (is);
 }
 
-static const uint32_t *initialize_and_skip_sequence (dds_sequence_t *seq, uint32_t insn, const uint32_t * __restrict ops, enum sample_data_state sample_state)
+static const uint32_t *initialize_and_skip_sequence (dds_sequence_t *seq, uint32_t insn, const uint32_t *ops, enum sample_data_state sample_state)
 {
   if (sample_state == SAMPLE_DATA_UNINITIALIZED)
   {
@@ -2402,7 +2402,7 @@ static const uint32_t *initialize_and_skip_sequence (dds_sequence_t *seq, uint32
   return skip_sequence_insns (insn, ops);
 }
 
-static const uint32_t *dds_stream_read_seq (dds_istream_t * __restrict is, char * __restrict addr, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, uint32_t insn, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
+static const uint32_t *dds_stream_read_seq (dds_istream_t *is, char * restrict addr, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, uint32_t insn, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
 {
   dds_sequence_t * const seq = (dds_sequence_t *) addr;
   const enum dds_stream_typecode subtype = DDS_OP_SUBTYPE (insn);
@@ -2531,7 +2531,7 @@ static const uint32_t *dds_stream_read_seq (dds_istream_t * __restrict is, char 
   return NULL;
 }
 
-static const uint32_t *dds_stream_read_arr (dds_istream_t * __restrict is, char * __restrict addr, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, uint32_t insn, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
+static const uint32_t *dds_stream_read_arr (dds_istream_t *is, char * restrict addr, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, uint32_t insn, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
 {
   const enum dds_stream_typecode subtype = DDS_OP_SUBTYPE (insn);
   if (is_dheader_needed (subtype, is->m_xcdr_version))
@@ -2618,7 +2618,7 @@ static const uint32_t *dds_stream_read_arr (dds_istream_t * __restrict is, char 
   return NULL;
 }
 
-static const uint32_t *dds_stream_read_uni (dds_istream_t * __restrict is, char * __restrict discaddr, char * __restrict baseaddr, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, uint32_t insn, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
+static const uint32_t *dds_stream_read_uni (dds_istream_t *is, char * restrict discaddr, char * restrict baseaddr, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, uint32_t insn, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
 {
   const uint32_t disc = read_union_discriminant (is, insn);
   uint32_t const * const jeq_op = stream_union_switch_case (insn, disc, discaddr, baseaddr, allocator, ops, &sample_state);
@@ -2670,7 +2670,7 @@ static const uint32_t *dds_stream_read_uni (dds_istream_t * __restrict is, char 
   return ops;
 }
 
-static void dds_stream_alloc_external (const uint32_t * __restrict ops, uint32_t insn, void ** addr, const struct dds_cdrstream_allocator * __restrict allocator, enum sample_data_state * sample_state)
+static void dds_stream_alloc_external (const uint32_t *ops, uint32_t insn, void ** addr, const struct dds_cdrstream_allocator *allocator, enum sample_data_state * sample_state)
 {
   uint32_t sz = get_adr_type_size (insn, ops);
   if (*sample_state != SAMPLE_DATA_INITIALIZED || *((char **) *addr) == NULL)
@@ -2681,7 +2681,7 @@ static void dds_stream_alloc_external (const uint32_t * __restrict ops, uint32_t
   *addr = *((char **) *addr);
 }
 
-static inline const uint32_t *stream_skip_member (uint32_t insn, char * __restrict data, void *addr, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, enum sample_data_state sample_state)
+static inline const uint32_t *stream_skip_member (uint32_t insn, char * restrict data, void * restrict addr, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, enum sample_data_state sample_state)
 {
   if (sample_state == SAMPLE_DATA_INITIALIZED)
     return stream_free_sample_adr (insn, data, allocator, ops);
@@ -2690,7 +2690,7 @@ static inline const uint32_t *stream_skip_member (uint32_t insn, char * __restri
   return dds_stream_skip_adr (insn, ops);
 }
 
-static inline const uint32_t *dds_stream_read_adr (uint32_t insn, dds_istream_t * __restrict is, char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, bool is_mutable_member, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
+static inline const uint32_t *dds_stream_read_adr (uint32_t insn, dds_istream_t *is, char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, bool is_mutable_member, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
 {
   void *addr = data + ops[1];
 
@@ -2759,7 +2759,7 @@ static inline const uint32_t *dds_stream_read_adr (uint32_t insn, dds_istream_t 
   return ops;
 }
 
-static const uint32_t *dds_stream_skip_adr (uint32_t insn, const uint32_t * __restrict ops)
+static const uint32_t *dds_stream_skip_adr (uint32_t insn, const uint32_t *ops)
 {
   switch (DDS_OP_TYPE (insn))
   {
@@ -2793,7 +2793,7 @@ static const uint32_t *dds_stream_skip_adr (uint32_t insn, const uint32_t * __re
   return NULL;
 }
 
-static const uint32_t *dds_stream_skip_adr_default (uint32_t insn, char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, enum sample_data_state sample_state)
+static const uint32_t *dds_stream_skip_adr_default (uint32_t insn, char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, enum sample_data_state sample_state)
 {
   void *addr = data + ops[1];
   /* FIXME: currently only implicit default values are used, this code should be
@@ -2852,12 +2852,12 @@ static const uint32_t *dds_stream_skip_adr_default (uint32_t insn, char * __rest
   return NULL;
 }
 
-static const uint32_t *dds_stream_skip_delimited_default (char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, enum sample_data_state sample_state)
+static const uint32_t *dds_stream_skip_delimited_default (char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, enum sample_data_state sample_state)
 {
   return dds_stream_skip_default (data, allocator, ++ops, sample_state);
 }
 
-static void dds_stream_skip_pl_member_default (char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, enum sample_data_state sample_state)
+static void dds_stream_skip_pl_member_default (char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, enum sample_data_state sample_state)
 {
   uint32_t insn;
   while ((insn = *ops) != DDS_OP_RTS)
@@ -2880,7 +2880,7 @@ static void dds_stream_skip_pl_member_default (char * __restrict data, const str
   }
 }
 
-static const uint32_t *dds_stream_skip_pl_memberlist_default (char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, enum sample_data_state sample_state)
+static const uint32_t *dds_stream_skip_pl_memberlist_default (char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, enum sample_data_state sample_state)
 {
   uint32_t insn;
   while (ops && (insn = *ops) != DDS_OP_RTS)
@@ -2911,13 +2911,13 @@ static const uint32_t *dds_stream_skip_pl_memberlist_default (char * __restrict 
   return ops;
 }
 
-static const uint32_t *dds_stream_skip_pl_default (char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, enum sample_data_state sample_state)
+static const uint32_t *dds_stream_skip_pl_default (char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, enum sample_data_state sample_state)
 {
   /* skip PLC op */
   return dds_stream_skip_pl_memberlist_default (data, allocator, ++ops, sample_state);
 }
 
-static const uint32_t *dds_stream_skip_default (char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, enum sample_data_state sample_state)
+static const uint32_t *dds_stream_skip_default (char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, enum sample_data_state sample_state)
 {
   uint32_t insn;
   while ((insn = *ops) != DDS_OP_RTS)
@@ -2947,7 +2947,7 @@ static const uint32_t *dds_stream_skip_default (char * __restrict data, const st
   return ops;
 }
 
-static const uint32_t *dds_stream_read_delimited (dds_istream_t * __restrict is, char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
+static const uint32_t *dds_stream_read_delimited (dds_istream_t *is, char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
 {
   uint32_t delimited_sz = dds_is_get4 (is), delimited_offs = is->m_index, insn;
   ops++;
@@ -2977,7 +2977,7 @@ static const uint32_t *dds_stream_read_delimited (dds_istream_t * __restrict is,
   return ops;
 }
 
-static bool dds_stream_read_pl_member (dds_istream_t * __restrict is, char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, uint32_t m_id, const uint32_t * __restrict ops, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
+static bool dds_stream_read_pl_member (dds_istream_t *is, char * restrict data, const struct dds_cdrstream_allocator *allocator, uint32_t m_id, const uint32_t *ops, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
 {
   uint32_t insn, ops_csr = 0;
   bool found = false;
@@ -3006,7 +3006,7 @@ static bool dds_stream_read_pl_member (dds_istream_t * __restrict is, char * __r
   return found;
 }
 
-static const uint32_t *dds_stream_read_pl (dds_istream_t * __restrict is, char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
+static const uint32_t *dds_stream_read_pl (dds_istream_t *is, char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
 {
   /* skip PLC op */
   ops++;
@@ -3058,7 +3058,7 @@ static const uint32_t *dds_stream_read_pl (dds_istream_t * __restrict is, char *
   return ops;
 }
 
-static const uint32_t *dds_stream_read_impl (dds_istream_t * __restrict is, char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, bool is_mutable_member, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
+static const uint32_t *dds_stream_read_impl (dds_istream_t *is, char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, bool is_mutable_member, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
 {
   uint32_t insn;
   while ((insn = *ops) != DDS_OP_RTS)
@@ -3088,7 +3088,7 @@ static const uint32_t *dds_stream_read_impl (dds_istream_t * __restrict is, char
   return ops;
 }
 
-const uint32_t *dds_stream_read (dds_istream_t * __restrict is, char * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops)
+const uint32_t *dds_stream_read (dds_istream_t *is, char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops)
 {
   return dds_stream_read_impl (is, data, allocator, ops, false, CDR_KIND_DATA, SAMPLE_DATA_INITIALIZED);
 }
@@ -3146,8 +3146,8 @@ static bool normalize_uint8 (uint32_t *off, uint32_t size)
   return true;
 }
 
-static bool normalize_uint16 (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
-static bool normalize_uint16 (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap)
+static bool normalize_uint16 (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+static bool normalize_uint16 (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap)
 {
   if ((*off = check_align_prim (*off, size, 1, 1)) == UINT32_MAX)
     return false;
@@ -3157,8 +3157,8 @@ static bool normalize_uint16 (char * __restrict data, uint32_t * __restrict off,
   return true;
 }
 
-static bool normalize_uint32 (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
-static bool normalize_uint32 (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap)
+static bool normalize_uint32 (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+static bool normalize_uint32 (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap)
 {
   if ((*off = check_align_prim (*off, size, 2, 2)) == UINT32_MAX)
     return false;
@@ -3168,8 +3168,8 @@ static bool normalize_uint32 (char * __restrict data, uint32_t * __restrict off,
   return true;
 }
 
-static bool normalize_uint64 (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t xcdr_version) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
-static bool normalize_uint64 (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t xcdr_version)
+static bool normalize_uint64 (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t xcdr_version) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+static bool normalize_uint64 (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t xcdr_version)
 {
   if ((*off = check_align_prim (*off, size, xcdr_version == DDSI_RTPS_CDR_ENC_VERSION_2 ? 2 : 3, 3)) == UINT32_MAX)
     return false;
@@ -3183,8 +3183,8 @@ static bool normalize_uint64 (char * __restrict data, uint32_t * __restrict off,
   return true;
 }
 
-static bool normalize_bool (char * __restrict data, uint32_t * __restrict off, uint32_t size) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
-static bool normalize_bool (char * __restrict data, uint32_t * __restrict off, uint32_t size)
+static bool normalize_bool (char * restrict data, uint32_t * restrict off, uint32_t size) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+static bool normalize_bool (char * restrict data, uint32_t * restrict off, uint32_t size)
 {
   if (*off == size)
     return normalize_error_bool ();
@@ -3195,8 +3195,8 @@ static bool normalize_bool (char * __restrict data, uint32_t * __restrict off, u
   return true;
 }
 
-static bool read_and_normalize_bool (bool * __restrict val, char * __restrict data, uint32_t * __restrict off, uint32_t size) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
-static bool read_and_normalize_bool (bool * __restrict val, char * __restrict data, uint32_t * __restrict off, uint32_t size)
+static bool read_and_normalize_bool (bool * restrict val, char * restrict data, uint32_t * restrict off, uint32_t size) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+static bool read_and_normalize_bool (bool * restrict val, char * restrict data, uint32_t * restrict off, uint32_t size)
 {
   if (*off == size)
     return normalize_error_bool ();
@@ -3208,8 +3208,8 @@ static bool read_and_normalize_bool (bool * __restrict val, char * __restrict da
   return true;
 }
 
-static inline bool read_and_normalize_uint8 (uint8_t * __restrict val, char * __restrict data, uint32_t * __restrict off, uint32_t size) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
-static inline bool read_and_normalize_uint8 (uint8_t * __restrict val, char * __restrict data, uint32_t * __restrict off, uint32_t size)
+static inline bool read_and_normalize_uint8 (uint8_t * restrict val, char * restrict data, uint32_t * restrict off, uint32_t size) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+static inline bool read_and_normalize_uint8 (uint8_t * restrict val, char * restrict data, uint32_t * restrict off, uint32_t size)
 {
   if ((*off = check_align_prim (*off, size, 0, 0)) == UINT32_MAX)
     return false;
@@ -3218,8 +3218,8 @@ static inline bool read_and_normalize_uint8 (uint8_t * __restrict val, char * __
   return true;
 }
 
-static inline bool read_and_normalize_uint16 (uint16_t * __restrict val, char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
-static inline bool read_and_normalize_uint16 (uint16_t * __restrict val, char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap)
+static inline bool read_and_normalize_uint16 (uint16_t * restrict val, char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+static inline bool read_and_normalize_uint16 (uint16_t * restrict val, char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap)
 {
   if ((*off = check_align_prim (*off, size, 1, 1)) == UINT32_MAX)
     return false;
@@ -3230,8 +3230,8 @@ static inline bool read_and_normalize_uint16 (uint16_t * __restrict val, char * 
   return true;
 }
 
-static inline bool read_and_normalize_uint32 (uint32_t * __restrict val, char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
-static inline bool read_and_normalize_uint32 (uint32_t * __restrict val, char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap)
+static inline bool read_and_normalize_uint32 (uint32_t * restrict val, char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+static inline bool read_and_normalize_uint32 (uint32_t * restrict val, char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap)
 {
   if ((*off = check_align_prim (*off, size, 2, 2)) == UINT32_MAX)
     return false;
@@ -3242,8 +3242,8 @@ static inline bool read_and_normalize_uint32 (uint32_t * __restrict val, char * 
   return true;
 }
 
-static inline bool read_and_normalize_uint64 (uint64_t * __restrict val, char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t xcdr_version) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
-static inline bool read_and_normalize_uint64 (uint64_t * __restrict val, char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t xcdr_version)
+static inline bool read_and_normalize_uint64 (uint64_t * restrict val, char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t xcdr_version) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+static inline bool read_and_normalize_uint64 (uint64_t * restrict val, char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t xcdr_version)
 {
   if ((*off = check_align_prim (*off, size, xcdr_version == DDSI_RTPS_CDR_ENC_VERSION_2 ? 2 : 3, 3)) == UINT32_MAX)
     return false;
@@ -3261,8 +3261,8 @@ static inline bool read_and_normalize_uint64 (uint64_t * __restrict val, char * 
   return true;
 }
 
-static bool peek_and_normalize_uint32 (uint32_t * __restrict val, char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
-static bool peek_and_normalize_uint32 (uint32_t * __restrict val, char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap)
+static bool peek_and_normalize_uint32 (uint32_t * restrict val, char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+static bool peek_and_normalize_uint32 (uint32_t * restrict val, char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap)
 {
   if ((*off = check_align_prim (*off, size, 2, 2)) == UINT32_MAX)
     return false;
@@ -3273,8 +3273,8 @@ static bool peek_and_normalize_uint32 (uint32_t * __restrict val, char * __restr
   return true;
 }
 
-static bool read_normalize_enum (uint32_t * __restrict val, char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t insn, uint32_t max) ddsrt_attribute_warn_unused_result ddsrt_nonnull((1,2,3));
-static bool read_normalize_enum (uint32_t * __restrict val, char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t insn, uint32_t max)
+static bool read_normalize_enum (uint32_t * restrict val, char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t insn, uint32_t max) ddsrt_attribute_warn_unused_result ddsrt_nonnull((1,2,3));
+static bool read_normalize_enum (uint32_t * restrict val, char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t insn, uint32_t max)
 {
   switch (DDS_OP_TYPE_SZ (insn))
   {
@@ -3304,15 +3304,15 @@ static bool read_normalize_enum (uint32_t * __restrict val, char * __restrict da
   return true;
 }
 
-static bool normalize_enum (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t insn, uint32_t max) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
-static bool normalize_enum (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t insn, uint32_t max)
+static bool normalize_enum (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t insn, uint32_t max) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+static bool normalize_enum (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t insn, uint32_t max)
 {
   uint32_t val;
   return read_normalize_enum (&val, data, off, size, bswap, insn, max);
 }
 
-static bool read_normalize_bitmask (uint64_t * __restrict val, char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, uint32_t insn, uint32_t bits_h, uint32_t bits_l) ddsrt_attribute_warn_unused_result ddsrt_nonnull((1,2,3));
-static bool read_normalize_bitmask (uint64_t * __restrict val, char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, uint32_t insn, uint32_t bits_h, uint32_t bits_l)
+static bool read_normalize_bitmask (uint64_t * restrict val, char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, uint32_t insn, uint32_t bits_h, uint32_t bits_l) ddsrt_attribute_warn_unused_result ddsrt_nonnull((1,2,3));
+static bool read_normalize_bitmask (uint64_t * restrict val, char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, uint32_t insn, uint32_t bits_h, uint32_t bits_l)
 {
   switch (DDS_OP_TYPE_SZ (insn))
   {
@@ -3349,15 +3349,15 @@ static bool read_normalize_bitmask (uint64_t * __restrict val, char * __restrict
   return true;
 }
 
-static bool normalize_bitmask (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, uint32_t insn, uint32_t bits_h, uint32_t bits_l) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
-static bool normalize_bitmask (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, uint32_t insn, uint32_t bits_h, uint32_t bits_l)
+static bool normalize_bitmask (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, uint32_t insn, uint32_t bits_h, uint32_t bits_l) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+static bool normalize_bitmask (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, uint32_t insn, uint32_t bits_h, uint32_t bits_l)
 {
   uint64_t val;
   return read_normalize_bitmask (&val, data, off, size, bswap, xcdr_version, insn, bits_h, bits_l);
 }
 
-static bool normalize_string (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, size_t maxsz) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
-static bool normalize_string (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, size_t maxsz)
+static bool normalize_string (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, size_t maxsz) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+static bool normalize_string (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, size_t maxsz)
 {
   // maxsz = character count, includes terminating '\0' that is in-memory and on the wire
   uint32_t sz;
@@ -3371,8 +3371,8 @@ static bool normalize_string (char * __restrict data, uint32_t * __restrict off,
   return true;
 }
 
-static inline bool normalize_wchar (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
-static inline bool normalize_wchar (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap)
+static inline bool normalize_wchar (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+static inline bool normalize_wchar (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap)
 {
   if ((*off = check_align_prim (*off, size, 1, 1)) == UINT32_MAX)
     return false;
@@ -3386,8 +3386,8 @@ static inline bool normalize_wchar (char * __restrict data, uint32_t * __restric
   return true;
 }
 
-static bool normalize_wstring (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, size_t maxsz) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
-static bool normalize_wstring (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, size_t maxsz)
+static bool normalize_wstring (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, size_t maxsz) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+static bool normalize_wstring (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, size_t maxsz)
 {
   // maxsz = character count, includes terminating L'\0' that is in-memory
   // CDR stream contains number of bytes (so must be even), excluding termating L'\0'
@@ -3427,8 +3427,8 @@ static bool normalize_wstring (char * __restrict data, uint32_t * __restrict off
   return true;
 }
 
-static bool normalize_boolarray (char * __restrict data, uint32_t * __restrict off, uint32_t size, uint32_t num) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
-static bool normalize_boolarray (char * __restrict data, uint32_t * __restrict off, uint32_t size, uint32_t num)
+static bool normalize_boolarray (char * restrict data, uint32_t * restrict off, uint32_t size, uint32_t num) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+static bool normalize_boolarray (char * restrict data, uint32_t * restrict off, uint32_t size, uint32_t num)
 {
   if ((*off = check_align_prim_many (*off, size, 0, 0, num)) == UINT32_MAX)
     return false;
@@ -3440,8 +3440,8 @@ static bool normalize_boolarray (char * __restrict data, uint32_t * __restrict o
   return true;
 }
 
-static bool normalize_primarray (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t num, enum dds_stream_typecode type, uint32_t xcdr_version) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
-static bool normalize_primarray (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t num, enum dds_stream_typecode type, uint32_t xcdr_version)
+static bool normalize_primarray (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t num, enum dds_stream_typecode type, uint32_t xcdr_version) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+static bool normalize_primarray (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t num, enum dds_stream_typecode type, uint32_t xcdr_version)
 {
   switch (type)
   {
@@ -3478,8 +3478,8 @@ static bool normalize_primarray (char * __restrict data, uint32_t * __restrict o
   return false;
 }
 
-static bool normalize_enumarray (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t enum_sz, uint32_t num, uint32_t max) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
-static bool normalize_enumarray (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t enum_sz, uint32_t num, uint32_t max)
+static bool normalize_enumarray (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t enum_sz, uint32_t num, uint32_t max) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+static bool normalize_enumarray (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t enum_sz, uint32_t num, uint32_t max)
 {
   switch (enum_sz)
   {
@@ -3519,8 +3519,8 @@ static bool normalize_enumarray (char * __restrict data, uint32_t * __restrict o
   return true;
 }
 
-static bool normalize_bitmaskarray (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, uint32_t insn, uint32_t num, uint32_t bits_h, uint32_t bits_l) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
-static bool normalize_bitmaskarray (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, uint32_t insn, uint32_t num, uint32_t bits_h, uint32_t bits_l)
+static bool normalize_bitmaskarray (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, uint32_t insn, uint32_t num, uint32_t bits_h, uint32_t bits_l) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+static bool normalize_bitmaskarray (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, uint32_t insn, uint32_t num, uint32_t bits_h, uint32_t bits_l)
 {
   switch (DDS_OP_TYPE_SZ (insn))
   {
@@ -3576,8 +3576,8 @@ static bool normalize_bitmaskarray (char * __restrict data, uint32_t * __restric
   return true;
 }
 
-static bool read_and_normalize_collection_dheader (bool * __restrict has_dheader, uint32_t * __restrict size1, char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, const enum dds_stream_typecode subtype, uint32_t xcdr_version) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
-static bool read_and_normalize_collection_dheader (bool * __restrict has_dheader, uint32_t * __restrict size1, char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, const enum dds_stream_typecode subtype, uint32_t xcdr_version)
+static bool read_and_normalize_collection_dheader (bool * restrict has_dheader, uint32_t * restrict size1, char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, const enum dds_stream_typecode subtype, uint32_t xcdr_version) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+static bool read_and_normalize_collection_dheader (bool * restrict has_dheader, uint32_t * restrict size1, char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, const enum dds_stream_typecode subtype, uint32_t xcdr_version)
 {
   if (is_dheader_needed (subtype, xcdr_version))
   {
@@ -3597,8 +3597,8 @@ static bool read_and_normalize_collection_dheader (bool * __restrict has_dheader
   }
 }
 
-static const uint32_t *normalize_seq (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t * __restrict ops, uint32_t insn, enum cdr_data_kind cdr_kind) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
-static const uint32_t *normalize_seq (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t * __restrict ops, uint32_t insn, enum cdr_data_kind cdr_kind)
+static const uint32_t *normalize_seq (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t *ops, uint32_t insn, enum cdr_data_kind cdr_kind) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+static const uint32_t *normalize_seq (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t *ops, uint32_t insn, enum cdr_data_kind cdr_kind)
 {
   const enum dds_stream_typecode subtype = DDS_OP_SUBTYPE (insn);
   uint32_t bound_op = seq_is_bounded (DDS_OP_TYPE (insn)) ? 1 : 0;
@@ -3682,8 +3682,8 @@ static const uint32_t *normalize_seq (char * __restrict data, uint32_t * __restr
   return ops;
 }
 
-static const uint32_t *normalize_arr (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t * __restrict ops, uint32_t insn, enum cdr_data_kind cdr_kind) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
-static const uint32_t *normalize_arr (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t * __restrict ops, uint32_t insn, enum cdr_data_kind cdr_kind)
+static const uint32_t *normalize_arr (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t *ops, uint32_t insn, enum cdr_data_kind cdr_kind) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+static const uint32_t *normalize_arr (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t *ops, uint32_t insn, enum cdr_data_kind cdr_kind)
 {
   const enum dds_stream_typecode subtype = DDS_OP_SUBTYPE (insn);
   bool has_dheader;
@@ -3755,8 +3755,8 @@ static const uint32_t *normalize_arr (char * __restrict data, uint32_t * __restr
   return ops;
 }
 
-static bool normalize_uni_disc (uint32_t * __restrict val, char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t insn, const uint32_t * __restrict ops) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
-static bool normalize_uni_disc (uint32_t * __restrict val, char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t insn, const uint32_t * __restrict ops)
+static bool normalize_uni_disc (uint32_t * restrict val, char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t insn, const uint32_t *ops) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+static bool normalize_uni_disc (uint32_t * restrict val, char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t insn, const uint32_t *ops)
 {
   switch (DDS_OP_SUBTYPE (insn))
   {
@@ -3797,8 +3797,8 @@ static bool normalize_uni_disc (uint32_t * __restrict val, char * __restrict dat
   return false;
 }
 
-static const uint32_t *normalize_uni (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t * __restrict ops, uint32_t insn, enum cdr_data_kind cdr_kind) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
-static const uint32_t *normalize_uni (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t * __restrict ops, uint32_t insn, enum cdr_data_kind cdr_kind)
+static const uint32_t *normalize_uni (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t *ops, uint32_t insn, enum cdr_data_kind cdr_kind) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+static const uint32_t *normalize_uni (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t *ops, uint32_t insn, enum cdr_data_kind cdr_kind)
 {
   uint32_t disc;
   if (!normalize_uni_disc (&disc, data, off, size, bswap, insn, ops))
@@ -3831,8 +3831,8 @@ static const uint32_t *normalize_uni (char * __restrict data, uint32_t * __restr
   return ops;
 }
 
-static const uint32_t *stream_normalize_adr (uint32_t insn, char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t * __restrict ops, bool is_mutable_member, enum cdr_data_kind cdr_kind) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
-static const uint32_t *stream_normalize_adr (uint32_t insn, char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t * __restrict ops, bool is_mutable_member, enum cdr_data_kind cdr_kind)
+static const uint32_t *stream_normalize_adr (uint32_t insn, char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t *ops, bool is_mutable_member, enum cdr_data_kind cdr_kind) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+static const uint32_t *stream_normalize_adr (uint32_t insn, char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t *ops, bool is_mutable_member, enum cdr_data_kind cdr_kind)
 {
   const bool is_key = (insn & DDS_OP_FLAG_KEY);
   if (cdr_kind == CDR_KIND_KEY && !is_key)
@@ -3887,8 +3887,8 @@ static const uint32_t *stream_normalize_adr (uint32_t insn, char * __restrict da
   return ops;
 }
 
-static const uint32_t *stream_normalize_delimited (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t * __restrict ops, enum cdr_data_kind cdr_kind) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
-static const uint32_t *stream_normalize_delimited (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t * __restrict ops, enum cdr_data_kind cdr_kind)
+static const uint32_t *stream_normalize_delimited (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t *ops, enum cdr_data_kind cdr_kind) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+static const uint32_t *stream_normalize_delimited (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t *ops, enum cdr_data_kind cdr_kind)
 {
   uint32_t delimited_sz;
   if (!read_and_normalize_uint32 (&delimited_sz, data, off, size, bswap))
@@ -3948,8 +3948,8 @@ enum normalize_pl_member_result {
   NPMR_ERROR // found the data, but normalization failed
 };
 
-static enum normalize_pl_member_result dds_stream_normalize_pl_member (char * __restrict data, uint32_t m_id, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t * __restrict ops, enum cdr_data_kind cdr_kind) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
-static enum normalize_pl_member_result dds_stream_normalize_pl_member (char * __restrict data, uint32_t m_id, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t * __restrict ops, enum cdr_data_kind cdr_kind)
+static enum normalize_pl_member_result dds_stream_normalize_pl_member (char * restrict data, uint32_t m_id, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t *ops, enum cdr_data_kind cdr_kind) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+static enum normalize_pl_member_result dds_stream_normalize_pl_member (char * restrict data, uint32_t m_id, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t *ops, enum cdr_data_kind cdr_kind)
 {
   uint32_t insn, ops_csr = 0;
   enum normalize_pl_member_result result = NPMR_NOT_FOUND;
@@ -3977,8 +3977,8 @@ static enum normalize_pl_member_result dds_stream_normalize_pl_member (char * __
   return result;
 }
 
-static const uint32_t *stream_normalize_pl (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t * __restrict ops, enum cdr_data_kind cdr_kind) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
-static const uint32_t *stream_normalize_pl (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t * __restrict ops, enum cdr_data_kind cdr_kind)
+static const uint32_t *stream_normalize_pl (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t *ops, enum cdr_data_kind cdr_kind) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+static const uint32_t *stream_normalize_pl (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t *ops, enum cdr_data_kind cdr_kind)
 {
   /* skip PLC op */
   ops++;
@@ -4066,8 +4066,8 @@ static const uint32_t *stream_normalize_pl (char * __restrict data, uint32_t * _
   return ops;
 }
 
-static const uint32_t *stream_normalize_data_impl (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t * __restrict ops, bool is_mutable_member, enum cdr_data_kind cdr_kind) ddsrt_attribute_warn_unused_result ddsrt_nonnull ((1, 2, 6));
-static const uint32_t *stream_normalize_data_impl (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t * __restrict ops, bool is_mutable_member, enum cdr_data_kind cdr_kind)
+static const uint32_t *stream_normalize_data_impl (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t *ops, bool is_mutable_member, enum cdr_data_kind cdr_kind) ddsrt_attribute_warn_unused_result ddsrt_nonnull ((1, 2, 6));
+static const uint32_t *stream_normalize_data_impl (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t *ops, bool is_mutable_member, enum cdr_data_kind cdr_kind)
 {
   uint32_t insn;
   while ((insn = *ops) != DDS_OP_RTS)
@@ -4108,13 +4108,13 @@ static const uint32_t *stream_normalize_data_impl (char * __restrict data, uint3
   return ops;
 }
 
-const uint32_t *dds_stream_normalize_data (char * __restrict data, uint32_t * __restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t * __restrict ops)
+const uint32_t *dds_stream_normalize_data (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t *ops)
 {
   return stream_normalize_data_impl (data, off, size, bswap, xcdr_version, ops, false, CDR_KIND_DATA);
 }
 
-static bool stream_normalize_key_impl (void * __restrict data, uint32_t size, uint32_t *offs, bool bswap, uint32_t xcdr_version, const uint32_t * __restrict ops, uint16_t key_offset_count, const uint32_t * key_offset_insn) ddsrt_attribute_warn_unused_result ddsrt_nonnull ((1, 3, 6));
-static bool stream_normalize_key_impl (void * __restrict data, uint32_t size, uint32_t *offs, bool bswap, uint32_t xcdr_version, const uint32_t * __restrict ops, uint16_t key_offset_count, const uint32_t * key_offset_insn)
+static bool stream_normalize_key_impl (void * restrict data, uint32_t size, uint32_t *offs, bool bswap, uint32_t xcdr_version, const uint32_t *ops, uint16_t key_offset_count, const uint32_t * key_offset_insn) ddsrt_attribute_warn_unused_result ddsrt_nonnull ((1, 3, 6));
+static bool stream_normalize_key_impl (void * restrict data, uint32_t size, uint32_t *offs, bool bswap, uint32_t xcdr_version, const uint32_t *ops, uint16_t key_offset_count, const uint32_t * key_offset_insn)
 {
   uint32_t insn = ops[0];
   assert (insn_key_ok_p (insn));
@@ -4147,8 +4147,8 @@ static bool stream_normalize_key_impl (void * __restrict data, uint32_t size, ui
   return true;
 }
 
-static bool stream_normalize_key (void * __restrict data, uint32_t size, bool bswap, uint32_t xcdr_version, const struct dds_cdrstream_desc * __restrict desc, uint32_t *actual_size) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
-static bool stream_normalize_key (void * __restrict data, uint32_t size, bool bswap, uint32_t xcdr_version, const struct dds_cdrstream_desc * __restrict desc, uint32_t *actual_size)
+static bool stream_normalize_key (void * restrict data, uint32_t size, bool bswap, uint32_t xcdr_version, const struct dds_cdrstream_desc *desc, uint32_t *actual_size) ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+static bool stream_normalize_key (void * restrict data, uint32_t size, bool bswap, uint32_t xcdr_version, const struct dds_cdrstream_desc *desc, uint32_t *actual_size)
 {
   uint32_t offs = 0;
 
@@ -4190,7 +4190,7 @@ static bool stream_normalize_key (void * __restrict data, uint32_t size, bool bs
   return true;
 }
 
-bool dds_stream_normalize (void * __restrict data, uint32_t size, bool bswap, uint32_t xcdr_version, const struct dds_cdrstream_desc * __restrict desc, bool just_key, uint32_t * __restrict actual_size)
+bool dds_stream_normalize (void *data, uint32_t size, bool bswap, uint32_t xcdr_version, const struct dds_cdrstream_desc *desc, bool just_key, uint32_t *actual_size)
 {
   uint32_t off = 0;
   if (size > CDR_SIZE_MAX)
@@ -4212,7 +4212,7 @@ bool dds_stream_normalize (void * __restrict data, uint32_t size, bool bswap, ui
  **
  *******************************************************************************************/
 
-static const uint32_t *dds_stream_free_sample_seq (char * __restrict addr, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, uint32_t insn)
+static const uint32_t *dds_stream_free_sample_seq (char * restrict addr, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, uint32_t insn)
 {
   dds_sequence_t * const seq = (dds_sequence_t *) addr;
   uint32_t num = (seq->_buffer == NULL) ? 0 : (seq->_maximum > seq->_length) ? seq->_maximum : seq->_length;
@@ -4277,7 +4277,7 @@ static const uint32_t *dds_stream_free_sample_seq (char * __restrict addr, const
   return ops;
 }
 
-static const uint32_t *dds_stream_free_sample_arr (char * __restrict addr, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, uint32_t insn)
+static const uint32_t *dds_stream_free_sample_arr (char * restrict addr, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, uint32_t insn)
 {
   ops += 2;
   const enum dds_stream_typecode subtype = DDS_OP_SUBTYPE (insn);
@@ -4319,7 +4319,7 @@ static const uint32_t *dds_stream_free_sample_arr (char * __restrict addr, const
   return ops;
 }
 
-static const uint32_t *dds_stream_free_sample_uni (char * __restrict discaddr, char * __restrict baseaddr, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, uint32_t insn)
+static const uint32_t *dds_stream_free_sample_uni (char * restrict discaddr, char * restrict baseaddr, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, uint32_t insn)
 {
   uint32_t disc = 0;
   switch (DDS_OP_SUBTYPE (insn))
@@ -4375,7 +4375,7 @@ no_ext_member:
   return ops;
 }
 
-static const uint32_t *dds_stream_free_sample_pl (char * __restrict addr, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops)
+static const uint32_t *dds_stream_free_sample_pl (char * restrict addr, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops)
 {
   uint32_t insn;
   assert (ops[0] == DDS_OP_PLC);
@@ -4402,7 +4402,7 @@ static const uint32_t *dds_stream_free_sample_pl (char * __restrict addr, const 
   return ops;
 }
 
-static const uint32_t *stream_free_sample_adr_nonexternal (uint32_t insn, void * __restrict addr, void * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops)
+static const uint32_t *stream_free_sample_adr_nonexternal (uint32_t insn, void * restrict addr, void * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops)
 {
   assert (DDS_OP (insn) == DDS_OP_ADR);
 
@@ -4441,7 +4441,7 @@ static const uint32_t *stream_free_sample_adr_nonexternal (uint32_t insn, void *
   return ops;
 }
 
-static const uint32_t *stream_free_sample_adr (uint32_t insn, void * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops)
+static const uint32_t *stream_free_sample_adr (uint32_t insn, void * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops)
 {
   assert (DDS_OP (insn) == DDS_OP_ADR);
   if (!op_type_external (insn))
@@ -4467,7 +4467,7 @@ static const uint32_t *stream_free_sample_adr (uint32_t insn, void * __restrict 
   return ops;
 }
 
-void dds_stream_free_sample (void * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops)
+void dds_stream_free_sample (void *data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops)
 {
   uint32_t insn;
   while ((insn = *ops) != DDS_OP_RTS)
@@ -4502,7 +4502,7 @@ void dds_stream_free_sample (void * __restrict data, const struct dds_cdrstream_
  **
  *******************************************************************************************/
 
-static void dds_stream_extract_key_from_key_prim_op (dds_istream_t * __restrict is, dds_ostream_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, uint16_t key_offset_count, const uint32_t * key_offset_insn)
+static void dds_stream_extract_key_from_key_prim_op (dds_istream_t *is, dds_ostream_t *os, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, uint16_t key_offset_count, const uint32_t * key_offset_insn)
 {
   const uint32_t insn = *ops;
   assert ((insn & DDS_OP_FLAG_KEY) && ((DDS_OP (insn)) == DDS_OP_ADR));
@@ -4575,7 +4575,7 @@ static void dds_stream_extract_key_from_key_prim_op (dds_istream_t * __restrict 
 }
 
 #if DDSRT_ENDIAN == DDSRT_LITTLE_ENDIAN
-static void dds_stream_swap_copy (void * __restrict vdst, const void * __restrict vsrc, uint32_t size, uint32_t num)
+static void dds_stream_swap_copy (void * restrict vdst, const void *vsrc, uint32_t size, uint32_t num)
 {
   assert (size == 1 || size == 2 || size == 4 || size == 8);
   switch (size)
@@ -4610,7 +4610,7 @@ static void dds_stream_swap_copy (void * __restrict vdst, const void * __restric
   }
 }
 
-static void dds_stream_extract_keyBE_from_key_prim_op (dds_istream_t * __restrict is, dds_ostreamBE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, uint16_t key_offset_count, const uint32_t * key_offset_insn)
+static void dds_stream_extract_keyBE_from_key_prim_op (dds_istream_t *is, dds_ostreamBE_t *os, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, uint16_t key_offset_count, const uint32_t * key_offset_insn)
 {
   const uint32_t insn = *ops;
   assert ((insn & DDS_OP_FLAG_KEY) && ((DDS_OP (insn)) == DDS_OP_ADR));
@@ -4686,7 +4686,7 @@ static void dds_stream_extract_keyBE_from_key_prim_op (dds_istream_t * __restric
 }
 #endif
 
-static void dds_stream_extract_key_from_data_skip_subtype (dds_istream_t * __restrict is, uint32_t num, uint32_t insn, enum dds_stream_typecode subtype, const uint32_t * __restrict subops)
+static void dds_stream_extract_key_from_data_skip_subtype (dds_istream_t *is, uint32_t num, uint32_t insn, enum dds_stream_typecode subtype, const uint32_t *subops)
 {
   assert (subops != NULL || DDS_OP (insn) == DDS_OP_ADR);
   switch (subtype)
@@ -4729,7 +4729,7 @@ static void dds_stream_extract_key_from_data_skip_subtype (dds_istream_t * __res
   }
 }
 
-static const uint32_t *dds_stream_extract_key_from_data_skip_array (dds_istream_t * __restrict is, const uint32_t * __restrict ops)
+static const uint32_t *dds_stream_extract_key_from_data_skip_array (dds_istream_t *is, const uint32_t *ops)
 {
   const uint32_t insn = *ops;
   assert (DDS_OP_TYPE (insn) == DDS_OP_VAL_ARR);
@@ -4749,7 +4749,7 @@ static const uint32_t *dds_stream_extract_key_from_data_skip_array (dds_istream_
   return skip_array_insns (insn, ops);
 }
 
-static const uint32_t *dds_stream_extract_key_from_data_skip_sequence (dds_istream_t * __restrict is, const uint32_t * __restrict ops)
+static const uint32_t *dds_stream_extract_key_from_data_skip_sequence (dds_istream_t *is, const uint32_t *ops)
 {
   const uint32_t insn = *ops;
   uint32_t bound_op = seq_is_bounded (DDS_OP_TYPE (insn)) ? 1 : 0;
@@ -4775,7 +4775,7 @@ static const uint32_t *dds_stream_extract_key_from_data_skip_sequence (dds_istre
   return skip_sequence_insns (insn, ops);
 }
 
-static const uint32_t *dds_stream_extract_key_from_data_skip_union (dds_istream_t * __restrict is, const uint32_t * __restrict ops)
+static const uint32_t *dds_stream_extract_key_from_data_skip_union (dds_istream_t *is, const uint32_t *ops)
 {
   const uint32_t insn = *ops;
   assert (DDS_OP_TYPE (insn) == DDS_OP_VAL_UNI);
@@ -4786,7 +4786,7 @@ static const uint32_t *dds_stream_extract_key_from_data_skip_union (dds_istream_
   return ops + DDS_OP_ADR_JMP (ops[3]);
 }
 
-static const uint32_t *dds_stream_extract_key_from_data_skip_adr (dds_istream_t * __restrict is, const uint32_t * __restrict ops, enum dds_stream_typecode type)
+static const uint32_t *dds_stream_extract_key_from_data_skip_adr (dds_istream_t *is, const uint32_t *ops, enum dds_stream_typecode type)
 {
   switch (type)
   {
@@ -4827,7 +4827,7 @@ static const uint32_t *dds_stream_extract_key_from_data_skip_adr (dds_istream_t 
  **
  *******************************************************************************************/
 
-void dds_stream_read_sample (dds_istream_t * __restrict is, void * __restrict data, const struct dds_cdrstream_allocator * __restrict allocator, const struct dds_cdrstream_desc * __restrict desc)
+void dds_stream_read_sample (dds_istream_t *is, void *data, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc *desc)
 {
   size_t opt_size = is->m_xcdr_version == DDSI_RTPS_CDR_ENC_VERSION_1 ? desc->opt_size_xcdr1 : desc->opt_size_xcdr2;
   if (opt_size)
@@ -4843,7 +4843,7 @@ void dds_stream_read_sample (dds_istream_t * __restrict is, void * __restrict da
   }
 }
 
-static void dds_stream_read_key_impl (dds_istream_t * __restrict is, char * __restrict sample, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, uint16_t key_offset_count, const uint32_t * key_offset_insn, enum sample_data_state sample_state)
+static void dds_stream_read_key_impl (dds_istream_t *is, char *sample, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, uint16_t key_offset_count, const uint32_t * key_offset_insn, enum sample_data_state sample_state)
 {
   void *dst = sample + ops[1];
   uint32_t insn = ops[0];
@@ -4931,7 +4931,7 @@ static void dds_stream_read_key_impl (dds_istream_t * __restrict is, char * __re
   }
 }
 
-void dds_stream_read_key (dds_istream_t * __restrict is, char * __restrict sample, const struct dds_cdrstream_allocator * __restrict allocator, const struct dds_cdrstream_desc * __restrict desc)
+void dds_stream_read_key (dds_istream_t *is, char *sample, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc *desc)
 {
   if (desc->flagset & (DDS_TOPIC_KEY_APPENDABLE | DDS_TOPIC_KEY_MUTABLE))
   {
@@ -4968,7 +4968,7 @@ void dds_stream_read_key (dds_istream_t * __restrict is, char * __restrict sampl
 
 /* Used in dds_stream_write_key for writing keys in native endianness, so no
    swap is needed in that case and this function is a no-op */
-static inline void dds_stream_swap_if_needed_insitu (void * __restrict vbuf, uint32_t size, uint32_t num)
+static inline void dds_stream_swap_if_needed_insitu (void *vbuf, uint32_t size, uint32_t num)
 {
   (void) vbuf;
   (void) size;
@@ -4982,7 +4982,7 @@ static inline void dds_stream_swap_if_needed_insitu (void * __restrict vbuf, uin
 
 #if DDSRT_ENDIAN == DDSRT_LITTLE_ENDIAN
 
-static void dds_stream_swap_if_needed_insituBE (void * __restrict vbuf, uint32_t size, uint32_t num)
+static void dds_stream_swap_if_needed_insituBE (void *vbuf, uint32_t size, uint32_t num)
 {
   dds_stream_swap (vbuf, size, num);
 }
@@ -4994,17 +4994,17 @@ static void dds_stream_swap_if_needed_insituBE (void * __restrict vbuf, uint32_t
 
 #else /* if DDSRT_ENDIAN == DDSRT_LITTLE_ENDIAN */
 
-void dds_stream_write_keyBE (dds_ostreamBE_t * __restrict os, enum dds_cdr_key_serialization_kind ser_kind, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict sample, const struct dds_cdrstream_desc * __restrict desc)
+void dds_stream_write_keyBE (dds_ostreamBE_t *os, enum dds_cdr_key_serialization_kind ser_kind, const struct dds_cdrstream_allocator *allocator, const char *sample, const struct dds_cdrstream_desc *desc)
 {
   dds_stream_write_key (&os->x, ser_kind, allocator, sample, desc);
 }
 
-bool dds_stream_extract_keyBE_from_data (dds_istream_t * __restrict is, dds_ostreamBE_t * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const struct dds_cdrstream_desc * __restrict desc)
+bool dds_stream_extract_keyBE_from_data (dds_istream_t *is, dds_ostreamBE_t *os, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc *desc)
 {
   return dds_stream_extract_key_from_data (is, &os->x, allocator, desc);
 }
 
-void dds_stream_extract_keyBE_from_key (dds_istream_t * __restrict is, dds_ostreamBE_t * __restrict os, enum dds_cdr_key_serialization_kind ser_kind, const struct dds_cdrstream_allocator * __restrict allocator, const struct dds_cdrstream_desc * __restrict desc)
+void dds_stream_extract_keyBE_from_key (dds_istream_t *is, dds_ostreamBE_t *os, enum dds_cdr_key_serialization_kind ser_kind, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc *desc)
 {
   dds_stream_extract_key_from_key (is, &os->x, ser_kind, allocator, desc);
 }
@@ -5018,10 +5018,10 @@ void dds_stream_extract_keyBE_from_key (dds_istream_t * __restrict is, dds_ostre
  *******************************************************************************************/
 
 /* Returns true if buffer not yet exhausted, false otherwise */
-static bool prtf (char * __restrict *buf, size_t * __restrict bufsize, const char *fmt, ...)
+static bool prtf (char **buf, size_t *bufsize, const char *fmt, ...)
   ddsrt_attribute_format_printf(3, 4);
 
-static bool prtf (char * __restrict *buf, size_t * __restrict bufsize, const char *fmt, ...)
+static bool prtf (char **buf, size_t *bufsize, const char *fmt, ...)
 {
   va_list ap;
   if (*bufsize == 0)
@@ -5048,7 +5048,7 @@ static bool prtf (char * __restrict *buf, size_t * __restrict bufsize, const cha
   }
 }
 
-static bool prtf_str (char * __restrict *buf, size_t * __restrict bufsize, dds_istream_t * __restrict is)
+static bool prtf_str (char **buf, size_t *bufsize, dds_istream_t *is)
 {
   size_t sz = dds_is_get4 (is);
   bool ret = prtf (buf, bufsize, "\"%s\"", is->m_buffer + is->m_index);
@@ -5056,7 +5056,7 @@ static bool prtf_str (char * __restrict *buf, size_t * __restrict bufsize, dds_i
   return ret;
 }
 
-static bool prtf_utf32 (char * __restrict *buf, size_t * __restrict bufsize, uint32_t utf32)
+static bool prtf_utf32 (char **buf, size_t *bufsize, uint32_t utf32)
 {
   unsigned char utf8[5], lead;
   int len;
@@ -5073,7 +5073,7 @@ static bool prtf_utf32 (char * __restrict *buf, size_t * __restrict bufsize, uin
   return prtf (buf, bufsize, "%s", utf8);
 }
 
-static bool prtf_wstr (char * __restrict *buf, size_t * __restrict bufsize, dds_istream_t * __restrict is)
+static bool prtf_wstr (char **buf, size_t *bufsize, dds_istream_t *is)
 {
   size_t sz = dds_is_get4 (is);
   bool ret = prtf (buf, bufsize, "\"");
@@ -5104,7 +5104,7 @@ static size_t isprint_runlen (const unsigned char *s, size_t n)
   return m;
 }
 
-static bool prtf_enum_bitmask (char * __restrict *buf, size_t * __restrict bufsize, dds_istream_t * __restrict is, uint32_t flags)
+static bool prtf_enum_bitmask (char **buf, size_t *bufsize, dds_istream_t *is, uint32_t flags)
 {
   switch (DDS_OP_FLAGS_SZ (flags))
   {
@@ -5130,7 +5130,7 @@ static bool prtf_enum_bitmask (char * __restrict *buf, size_t * __restrict bufsi
   return false;
 }
 
-static bool prtf_simple (char * __restrict *buf, size_t * __restrict bufsize, dds_istream_t * __restrict is, enum dds_stream_typecode type, uint32_t flags)
+static bool prtf_simple (char **buf, size_t *bufsize, dds_istream_t *is, enum dds_stream_typecode type, uint32_t flags)
 {
   switch (type)
   {
@@ -5184,7 +5184,7 @@ static bool prtf_simple (char * __restrict *buf, size_t * __restrict bufsize, dd
   return false;
 }
 
-static bool prtf_simple_array (char * __restrict *buf, size_t * __restrict bufsize, dds_istream_t * __restrict is, uint32_t num, enum dds_stream_typecode type, uint32_t flags)
+static bool prtf_simple_array (char **buf, size_t *bufsize, dds_istream_t *is, uint32_t num, enum dds_stream_typecode type, uint32_t flags)
 {
   bool cont = prtf (buf, bufsize, "{");
   switch (type)
@@ -5243,9 +5243,9 @@ static bool prtf_simple_array (char * __restrict *buf, size_t * __restrict bufsi
   return prtf (buf, bufsize, "}");
 }
 
-static const uint32_t *dds_stream_print_sample1 (char * __restrict *buf, size_t * __restrict bufsize, dds_istream_t * __restrict is, const uint32_t * __restrict ops, bool add_braces, bool is_mutable_member, enum cdr_data_kind cdr_kind);
+static const uint32_t *dds_stream_print_sample1 (char **buf, size_t *bufsize, dds_istream_t *is, const uint32_t *ops, bool add_braces, bool is_mutable_member, enum cdr_data_kind cdr_kind);
 
-static const uint32_t *prtf_seq (char * __restrict *buf, size_t *bufsize, dds_istream_t * __restrict is, const uint32_t * __restrict ops, uint32_t insn, enum cdr_data_kind cdr_kind)
+static const uint32_t *prtf_seq (char **buf, size_t *bufsize, dds_istream_t *is, const uint32_t *ops, uint32_t insn, enum cdr_data_kind cdr_kind)
 {
   const enum dds_stream_typecode subtype = DDS_OP_SUBTYPE (insn);
   uint32_t bound_op = seq_is_bounded (DDS_OP_TYPE (insn)) ? 1 : 0;
@@ -5295,7 +5295,7 @@ static const uint32_t *prtf_seq (char * __restrict *buf, size_t *bufsize, dds_is
   return NULL;
 }
 
-static const uint32_t *prtf_arr (char * __restrict *buf, size_t *bufsize, dds_istream_t * __restrict is, const uint32_t * __restrict ops, uint32_t insn, enum cdr_data_kind cdr_kind)
+static const uint32_t *prtf_arr (char **buf, size_t *bufsize, dds_istream_t *is, const uint32_t *ops, uint32_t insn, enum cdr_data_kind cdr_kind)
 {
   const enum dds_stream_typecode subtype = DDS_OP_SUBTYPE (insn);
   if (is_dheader_needed (subtype, is->m_xcdr_version))
@@ -5334,7 +5334,7 @@ static const uint32_t *prtf_arr (char * __restrict *buf, size_t *bufsize, dds_is
   return NULL;
 }
 
-static const uint32_t *prtf_uni (char * __restrict *buf, size_t *bufsize, dds_istream_t * __restrict is, const uint32_t * __restrict ops, uint32_t insn, enum cdr_data_kind cdr_kind)
+static const uint32_t *prtf_uni (char **buf, size_t *bufsize, dds_istream_t *is, const uint32_t *ops, uint32_t insn, enum cdr_data_kind cdr_kind)
 {
   const uint32_t disc = read_union_discriminant (is, insn);
   uint32_t const * const jeq_op = find_union_case (ops, disc);
@@ -5361,7 +5361,7 @@ static const uint32_t *prtf_uni (char * __restrict *buf, size_t *bufsize, dds_is
   return ops;
 }
 
-static const uint32_t * dds_stream_print_adr (char * __restrict *buf, size_t * __restrict bufsize, uint32_t insn, dds_istream_t * __restrict is, const uint32_t * __restrict ops, bool is_mutable_member, enum cdr_data_kind cdr_kind)
+static const uint32_t * dds_stream_print_adr (char **buf, size_t *bufsize, uint32_t insn, dds_istream_t *is, const uint32_t *ops, bool is_mutable_member, enum cdr_data_kind cdr_kind)
 {
   const bool is_key = (insn & DDS_OP_FLAG_KEY);
   if (cdr_kind == CDR_KIND_KEY && !is_key)
@@ -5413,7 +5413,7 @@ static const uint32_t * dds_stream_print_adr (char * __restrict *buf, size_t * _
   return ops;
 }
 
-static const uint32_t *prtf_delimited (char * __restrict *buf, size_t *bufsize, dds_istream_t * __restrict is, const uint32_t * __restrict ops, enum cdr_data_kind cdr_kind)
+static const uint32_t *prtf_delimited (char **buf, size_t *bufsize, dds_istream_t *is, const uint32_t *ops, enum cdr_data_kind cdr_kind)
 {
   uint32_t delimited_sz = dds_is_get4 (is), delimited_offs = is->m_index, insn;
   bool needs_comma = false;
@@ -5449,7 +5449,7 @@ static const uint32_t *prtf_delimited (char * __restrict *buf, size_t *bufsize, 
   return ops;
 }
 
-static bool prtf_plm (char * __restrict *buf, size_t *bufsize, dds_istream_t * __restrict is, uint32_t m_id, const uint32_t * __restrict ops, enum cdr_data_kind cdr_kind)
+static bool prtf_plm (char **buf, size_t *bufsize, dds_istream_t *is, uint32_t m_id, const uint32_t *ops, enum cdr_data_kind cdr_kind)
 {
   uint32_t insn, ops_csr = 0;
   bool found = false;
@@ -5475,7 +5475,7 @@ static bool prtf_plm (char * __restrict *buf, size_t *bufsize, dds_istream_t * _
   return found;
 }
 
-static const uint32_t *prtf_pl (char * __restrict *buf, size_t *bufsize, dds_istream_t * __restrict is, const uint32_t * __restrict ops, enum cdr_data_kind cdr_kind)
+static const uint32_t *prtf_pl (char **buf, size_t *bufsize, dds_istream_t *is, const uint32_t *ops, enum cdr_data_kind cdr_kind)
 {
   /* skip PLC op */
   ops++;
@@ -5525,7 +5525,7 @@ static const uint32_t *prtf_pl (char * __restrict *buf, size_t *bufsize, dds_ist
   return ops;
 }
 
-static const uint32_t * dds_stream_print_sample1 (char * __restrict *buf, size_t * __restrict bufsize, dds_istream_t * __restrict is, const uint32_t * __restrict ops, bool add_braces, bool is_mutable_member, enum cdr_data_kind cdr_kind)
+static const uint32_t * dds_stream_print_sample1 (char **buf, size_t *bufsize, dds_istream_t *is, const uint32_t *ops, bool add_braces, bool is_mutable_member, enum cdr_data_kind cdr_kind)
 {
   uint32_t insn;
   bool cont = true;
@@ -5564,13 +5564,13 @@ static const uint32_t * dds_stream_print_sample1 (char * __restrict *buf, size_t
   return ops;
 }
 
-size_t dds_stream_print_sample (dds_istream_t * __restrict is, const struct dds_cdrstream_desc * __restrict desc, char * __restrict buf, size_t size)
+size_t dds_stream_print_sample (dds_istream_t *is, const struct dds_cdrstream_desc *desc, char *buf, size_t size)
 {
   (void) dds_stream_print_sample1 (&buf, &size, is, desc->ops.ops, true, false, CDR_KIND_DATA);
   return size;
 }
 
-size_t dds_stream_print_key (dds_istream_t * __restrict is, const struct dds_cdrstream_desc * __restrict desc, char * __restrict buf, size_t size)
+size_t dds_stream_print_key (dds_istream_t *is, const struct dds_cdrstream_desc *desc, char *buf, size_t size)
 {
   (void) prtf (&buf, &size, ":k:{");
   (void) dds_stream_print_sample1 (&buf, &size, is, desc->ops.ops, true, false, CDR_KIND_KEY);
@@ -5578,7 +5578,7 @@ size_t dds_stream_print_key (dds_istream_t * __restrict is, const struct dds_cdr
   return size;
 }
 
-uint32_t dds_stream_countops (const uint32_t * __restrict ops, uint32_t nkeys, const dds_key_descriptor_t * __restrict keys)
+uint32_t dds_stream_countops (const uint32_t *ops, uint32_t nkeys, const dds_key_descriptor_t *keys)
 {
   struct dds_cdrstream_ops_info info;
   dds_stream_get_ops_info (ops, &info);
@@ -5589,7 +5589,7 @@ uint32_t dds_stream_countops (const uint32_t * __restrict ops, uint32_t nkeys, c
 
 /* Gets the (minimum) extensibility of the types used for this topic, and returns the XCDR
    version that is required for (de)serializing the type for this topic descriptor */
-uint16_t dds_stream_minimum_xcdr_version (const uint32_t * __restrict ops)
+uint16_t dds_stream_minimum_xcdr_version (const uint32_t *ops)
 {
   struct dds_cdrstream_ops_info info;
   dds_stream_get_ops_info (ops, &info);
@@ -5597,7 +5597,7 @@ uint16_t dds_stream_minimum_xcdr_version (const uint32_t * __restrict ops)
 }
 
 /* Gets the extensibility of the top-level type for a topic, by inspecting the serializer ops */
-bool dds_stream_extensibility (const uint32_t * __restrict ops, enum dds_cdr_type_extensibility *ext)
+bool dds_stream_extensibility (const uint32_t *ops, enum dds_cdr_type_extensibility *ext)
 {
   uint32_t insn;
 
@@ -5627,7 +5627,7 @@ bool dds_stream_extensibility (const uint32_t * __restrict ops, enum dds_cdr_typ
   return false;
 }
 
-uint32_t dds_stream_type_nesting_depth (const uint32_t * __restrict ops)
+uint32_t dds_stream_type_nesting_depth (const uint32_t *ops)
 {
   struct dds_cdrstream_ops_info info;
   dds_stream_get_ops_info (ops, &info);
@@ -5644,7 +5644,7 @@ static bool data_type_contains_indirections (dds_data_type_properties_t props)
                   | DDS_DATA_TYPE_CONTAINS_EXTERNAL);
 }
 
-dds_data_type_properties_t dds_stream_data_types (const uint32_t * __restrict ops)
+dds_data_type_properties_t dds_stream_data_types (const uint32_t *ops)
 {
   struct dds_cdrstream_ops_info info;
   dds_stream_get_ops_info (ops, &info);
@@ -5695,7 +5695,7 @@ static void set_key_size_unbounded (struct key_props *k)
   k->sz_xcdrv2 = DDS_FIXED_KEY_MAX_SIZE + 1;
 }
 
-static const uint32_t *dds_stream_key_size_arr (const uint32_t * __restrict ops, uint32_t insn, struct key_props *k)
+static const uint32_t *dds_stream_key_size_arr (const uint32_t *ops, uint32_t insn, struct key_props *k)
 {
   const enum dds_stream_typecode subtype = DDS_OP_SUBTYPE (insn);
   uint32_t bound = ops[2];
@@ -5758,7 +5758,7 @@ static const uint32_t *dds_stream_key_size_arr (const uint32_t * __restrict ops,
   return NULL;
 }
 
-static const uint32_t *dds_stream_key_size_adr (const uint32_t * __restrict ops, uint32_t insn, struct key_props *k)
+static const uint32_t *dds_stream_key_size_adr (const uint32_t *ops, uint32_t insn, struct key_props *k)
 {
   if (!(insn & DDS_OP_FLAG_KEY))
     return dds_stream_skip_adr (insn, ops);
@@ -5833,7 +5833,7 @@ static const uint32_t *dds_stream_key_size_adr (const uint32_t * __restrict ops,
   return ops;
 }
 
-static const uint32_t *dds_stream_key_size_delimited (const uint32_t * __restrict ops, struct key_props *k)
+static const uint32_t *dds_stream_key_size_delimited (const uint32_t *ops, struct key_props *k)
 {
   // DLC op
   ops++;
@@ -5864,7 +5864,7 @@ static const uint32_t *dds_stream_key_size_delimited (const uint32_t * __restric
   return ops;
 }
 
-static bool dds_stream_key_size_pl_member (const uint32_t * __restrict ops, struct key_props *k)
+static bool dds_stream_key_size_pl_member (const uint32_t *ops, struct key_props *k)
 {
   uint32_t flags = DDS_OP_FLAGS (ops[0]);
   bool is_key = flags & (DDS_OP_FLAG_MU | DDS_OP_FLAG_KEY);
@@ -5879,7 +5879,7 @@ static bool dds_stream_key_size_pl_member (const uint32_t * __restrict ops, stru
   return dds_stream_key_size (ops, k);
 }
 
-static const uint32_t *dds_stream_key_size_pl_memberlist (const uint32_t * __restrict ops, struct key_props *k)
+static const uint32_t *dds_stream_key_size_pl_memberlist (const uint32_t *ops, struct key_props *k)
 {
   uint32_t insn;
   while (ops && (insn = *ops) != DDS_OP_RTS)
@@ -5912,7 +5912,7 @@ static const uint32_t *dds_stream_key_size_pl_memberlist (const uint32_t * __res
   return ops;
 }
 
-static const uint32_t *dds_stream_key_size_pl (const uint32_t * __restrict ops, struct key_props *k)
+static const uint32_t *dds_stream_key_size_pl (const uint32_t *ops, struct key_props *k)
 {
   // skip PLC op
   ops++;
@@ -5924,7 +5924,7 @@ static const uint32_t *dds_stream_key_size_pl (const uint32_t * __restrict ops, 
   return dds_stream_key_size_pl_memberlist (ops, k);
 }
 
-static void dds_stream_key_size_prim_op (const uint32_t * __restrict ops, uint16_t key_offset_count, const uint32_t * key_offset_insn, struct key_props *k)
+static void dds_stream_key_size_prim_op (const uint32_t *ops, uint16_t key_offset_count, const uint32_t * key_offset_insn, struct key_props *k)
 {
   const uint32_t insn = *ops;
   assert ((insn & DDS_OP_FLAG_KEY) && ((DDS_OP (insn)) == DDS_OP_ADR));
@@ -5975,7 +5975,7 @@ static void dds_stream_key_size_keyhash (struct dds_cdrstream_desc *desc, struct
   }
 }
 
-static const uint32_t *dds_stream_key_size (const uint32_t * __restrict ops, struct key_props *k)
+static const uint32_t *dds_stream_key_size (const uint32_t *ops, struct key_props *k)
 {
   uint32_t insn;
   while ((insn = *ops) != DDS_OP_RTS)
@@ -6053,7 +6053,7 @@ static int key_cmp_idx (const void *va, const void *vb)
   return 0;
 }
 
-static void copy_desc_keys (dds_cdrstream_desc_key_t **dst, const struct dds_cdrstream_allocator * __restrict allocator, const dds_key_descriptor_t *keys, uint32_t nkeys)
+static void copy_desc_keys (dds_cdrstream_desc_key_t **dst, const struct dds_cdrstream_allocator *allocator, const dds_key_descriptor_t *keys, uint32_t nkeys)
 {
   if (nkeys > 0)
   {
@@ -6070,7 +6070,7 @@ static void copy_desc_keys (dds_cdrstream_desc_key_t **dst, const struct dds_cdr
   }
 }
 
-void dds_cdrstream_desc_init (struct dds_cdrstream_desc *desc, const struct dds_cdrstream_allocator * __restrict allocator,
+void dds_cdrstream_desc_init (struct dds_cdrstream_desc *desc, const struct dds_cdrstream_allocator *allocator,
     uint32_t size, uint32_t align, uint32_t flagset, const uint32_t *ops, const dds_key_descriptor_t *keys, uint32_t nkeys)
 {
   desc->size = size;
@@ -6094,7 +6094,7 @@ void dds_cdrstream_desc_init (struct dds_cdrstream_desc *desc, const struct dds_
   desc->flagset |= dds_stream_key_flags (desc, NULL, NULL);
 }
 
-void dds_cdrstream_desc_fini (struct dds_cdrstream_desc *desc, const struct dds_cdrstream_allocator * __restrict allocator)
+void dds_cdrstream_desc_fini (struct dds_cdrstream_desc *desc, const struct dds_cdrstream_allocator *allocator)
 {
   if (desc->keys.nkeys > 0)
   {

--- a/src/core/cdr/src/dds_cdrstream_keys.part.h
+++ b/src/core/cdr/src/dds_cdrstream_keys.part.h
@@ -9,7 +9,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 ddsrt_attribute_warn_unused_result
-static bool dds_stream_write_keyBO_impl (DDS_OSTREAM_T * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t *ops, const void *src, uint16_t key_offset_count, const uint32_t * key_offset_insn)
+static bool dds_stream_write_keyBO_impl (DDS_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, const void *src, uint16_t key_offset_count, const uint32_t * key_offset_insn)
 {
   uint32_t insn = *ops;
   assert (DDS_OP (insn) == DDS_OP_ADR);
@@ -104,7 +104,7 @@ static bool dds_stream_write_keyBO_impl (DDS_OSTREAM_T * __restrict os, const st
   return true;
 }
 
-bool dds_stream_write_keyBO (DDS_OSTREAM_T * __restrict os, enum dds_cdr_key_serialization_kind ser_kind, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict sample, const struct dds_cdrstream_desc * __restrict desc)
+bool dds_stream_write_keyBO (DDS_OSTREAM_T *os, enum dds_cdr_key_serialization_kind ser_kind, const struct dds_cdrstream_allocator *allocator, const char *sample, const struct dds_cdrstream_desc *desc)
 {
 #ifndef NDEBUG
   const size_t check_start_index = ((dds_ostream_t *)os)->m_index;
@@ -153,8 +153,8 @@ bool dds_stream_write_keyBO (DDS_OSTREAM_T * __restrict os, enum dds_cdr_key_ser
   return true;
 }
 
-static const uint32_t *dds_stream_extract_keyBO_from_data_adr (uint32_t insn, dds_istream_t * __restrict is, DDS_OSTREAM_T * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator,
-  const uint32_t * const __restrict op0, const uint32_t * __restrict ops, bool mutable_member, bool mutable_member_or_parent, uint32_t n_keys, uint32_t * __restrict keys_remaining)
+static const uint32_t *dds_stream_extract_keyBO_from_data_adr (uint32_t insn, dds_istream_t *is, DDS_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator,
+  const uint32_t * const op0, const uint32_t *ops, bool mutable_member, bool mutable_member_or_parent, uint32_t n_keys, uint32_t * restrict keys_remaining)
 {
   assert (insn == *ops);
   assert (DDS_OP (insn) == DDS_OP_ADR);
@@ -196,8 +196,8 @@ static const uint32_t *dds_stream_extract_keyBO_from_data_adr (uint32_t insn, dd
   return ops;
 }
 
-static const uint32_t *dds_stream_extract_keyBO_from_data_delimited (dds_istream_t * __restrict is, DDS_OSTREAM_T * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator,
-  const uint32_t * const __restrict op0, const uint32_t * __restrict ops, bool mutable_member_or_parent, uint32_t n_keys, uint32_t * __restrict keys_remaining)
+static const uint32_t *dds_stream_extract_keyBO_from_data_delimited (dds_istream_t *is, DDS_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator,
+  const uint32_t * const op0, const uint32_t *ops, bool mutable_member_or_parent, uint32_t n_keys, uint32_t * restrict keys_remaining)
 {
   uint32_t delimited_sz_is = dds_is_get4 (is), delimited_offs_is = is->m_index, insn;
 
@@ -243,8 +243,8 @@ static const uint32_t *dds_stream_extract_keyBO_from_data_delimited (dds_istream
   return ops;
 }
 
-static bool dds_stream_extract_keyBO_from_data_pl_member (dds_istream_t * __restrict is, DDS_OSTREAM_T * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, uint32_t m_id,
-  const uint32_t * const __restrict op0, const uint32_t * __restrict ops, uint32_t n_keys, uint32_t * __restrict keys_remaining)
+static bool dds_stream_extract_keyBO_from_data_pl_member (dds_istream_t *is, DDS_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator, uint32_t m_id,
+  const uint32_t * const op0, const uint32_t *ops, uint32_t n_keys, uint32_t * restrict keys_remaining)
 {
   uint32_t insn, ops_csr = 0;
   bool found = false;
@@ -287,8 +287,8 @@ static bool dds_stream_extract_keyBO_from_data_pl_member (dds_istream_t * __rest
   return found;
 }
 
-static const uint32_t *dds_stream_extract_keyBO_from_data_pl (dds_istream_t * __restrict is, DDS_OSTREAM_T * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator,
-  const uint32_t * const __restrict op0, const uint32_t * __restrict ops, uint32_t n_keys, uint32_t * __restrict keys_remaining)
+static const uint32_t *dds_stream_extract_keyBO_from_data_pl (dds_istream_t *is, DDS_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator,
+  const uint32_t * const op0, const uint32_t *ops, uint32_t n_keys, uint32_t * restrict keys_remaining)
 {
   /* skip PLC op */
   ops++;
@@ -348,9 +348,9 @@ static const uint32_t *dds_stream_extract_keyBO_from_data_pl (dds_istream_t * __
   return ops;
 }
 
-static const uint32_t *dds_stream_extract_keyBO_from_data1 (dds_istream_t * __restrict is, DDS_OSTREAM_T * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator,
-  const uint32_t * const __restrict op0, const uint32_t * __restrict ops, bool mutable_member, bool mutable_member_or_parent,
-  uint32_t n_keys, uint32_t * __restrict keys_remaining)
+static const uint32_t *dds_stream_extract_keyBO_from_data1 (dds_istream_t *is, DDS_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator,
+  const uint32_t * const op0, const uint32_t *ops, bool mutable_member, bool mutable_member_or_parent,
+  uint32_t n_keys, uint32_t * restrict keys_remaining)
 {
   uint32_t insn;
   while ((insn = *ops) != DDS_OP_RTS)
@@ -378,7 +378,7 @@ static const uint32_t *dds_stream_extract_keyBO_from_data1 (dds_istream_t * __re
   return ops;
 }
 
-bool dds_stream_extract_keyBO_from_data (dds_istream_t * __restrict is, DDS_OSTREAM_T * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const struct dds_cdrstream_desc * __restrict desc)
+bool dds_stream_extract_keyBO_from_data (dds_istream_t *is, DDS_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc *desc)
 {
   bool ret = true;
   uint32_t keys_remaining = desc->keys.nkeys;
@@ -413,8 +413,8 @@ bool dds_stream_extract_keyBO_from_data (dds_istream_t * __restrict is, DDS_OSTR
   return ret;
 }
 
-static void dds_stream_extract_keyBO_from_key_impl (dds_istream_t * __restrict is, DDS_OSTREAM_T * __restrict os, enum dds_cdr_key_serialization_kind ser_kind,
-    const struct dds_cdrstream_allocator * __restrict allocator, const struct dds_cdrstream_desc * __restrict desc)
+static void dds_stream_extract_keyBO_from_key_impl (dds_istream_t *is, DDS_OSTREAM_T *os, enum dds_cdr_key_serialization_kind ser_kind,
+    const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc *desc)
 {
   /* The type or any subtype has non-final extensibility, so read a key sample
      and write the key-only CDR for this sample */
@@ -435,8 +435,8 @@ static void dds_stream_extract_keyBO_from_key_impl (dds_istream_t * __restrict i
   allocator->free (sample);
 }
 
-static void dds_stream_extract_keyBO_from_key_optimized (dds_istream_t * __restrict is, DDS_OSTREAM_T * __restrict os,
-    const struct dds_cdrstream_allocator * __restrict allocator, const struct dds_cdrstream_desc * __restrict desc)
+static void dds_stream_extract_keyBO_from_key_optimized (dds_istream_t *is, DDS_OSTREAM_T *os,
+    const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc *desc)
 {
   for (uint32_t i = 0; i < desc->keys.nkeys; i++)
   {
@@ -464,8 +464,8 @@ static void dds_stream_extract_keyBO_from_key_optimized (dds_istream_t * __restr
    representation (native endianess). The former is not used regularly by Cyclone, and the latter is only used when receiving a key sample,
    e.g. a dispose. For this reason, we use a (performance wise) sub-optimal approach of going through the entire CDR for every key field.
    Optimizations is possible but would result in more complex code. */
-void dds_stream_extract_keyBO_from_key (dds_istream_t * __restrict is, DDS_OSTREAM_T * __restrict os, enum dds_cdr_key_serialization_kind ser_kind,
-    const struct dds_cdrstream_allocator * __restrict allocator, const struct dds_cdrstream_desc * __restrict desc)
+void dds_stream_extract_keyBO_from_key (dds_istream_t *is, DDS_OSTREAM_T *os, enum dds_cdr_key_serialization_kind ser_kind,
+    const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc *desc)
 {
   assert (ser_kind == DDS_CDR_KEY_SERIALIZATION_SAMPLE || ser_kind == DDS_CDR_KEY_SERIALIZATION_KEYHASH);
 

--- a/src/core/cdr/src/dds_cdrstream_write.part.h
+++ b/src/core/cdr/src/dds_cdrstream_write.part.h
@@ -8,15 +8,15 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
-static const uint32_t *dds_stream_write_implBO (DDS_OSTREAM_T * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict data, const uint32_t * __restrict ops, bool is_mutable_member, enum cdr_data_kind cdr_kind);
+static const uint32_t *dds_stream_write_implBO (DDS_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator, const char *data, const uint32_t *ops, bool is_mutable_member, enum cdr_data_kind cdr_kind);
 
-static inline bool dds_stream_write_bool_valueBO (DDS_OSTREAM_T * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const uint8_t val)
+static inline bool dds_stream_write_bool_valueBO (DDS_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator, const uint8_t val)
 {
   dds_os_put1BO (os, allocator, val != 0);
   return true;
 }
 
-static bool dds_stream_write_enum_valueBO (DDS_OSTREAM_T * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, uint32_t insn, uint32_t val, uint32_t max)
+static bool dds_stream_write_enum_valueBO (DDS_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator, uint32_t insn, uint32_t val, uint32_t max)
 {
   if (val > max)
     return false;
@@ -37,7 +37,7 @@ static bool dds_stream_write_enum_valueBO (DDS_OSTREAM_T * __restrict os, const 
   return true;
 }
 
-static bool dds_stream_write_bitmask_valueBO (DDS_OSTREAM_T * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, uint32_t insn, const void * __restrict addr, uint32_t bits_h, uint32_t bits_l)
+static bool dds_stream_write_bitmask_valueBO (DDS_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator, uint32_t insn, const void *addr, uint32_t bits_h, uint32_t bits_l)
 {
   switch (DDS_OP_TYPE_SZ (insn))
   {
@@ -75,7 +75,7 @@ static bool dds_stream_write_bitmask_valueBO (DDS_OSTREAM_T * __restrict os, con
   return true;
 }
 
-static void dds_stream_write_stringBO (DDS_OSTREAM_T * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict val)
+static void dds_stream_write_stringBO (DDS_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator, const char *val)
 {
   uint32_t size = val ? (uint32_t) strlen (val) + 1 : 1;
   dds_os_put4BO (os, allocator, size);
@@ -85,7 +85,7 @@ static void dds_stream_write_stringBO (DDS_OSTREAM_T * __restrict os, const stru
     dds_os_put1BO (os, allocator, 0);
 }
 
-static void dds_stream_write_wstringBO (DDS_OSTREAM_T * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const wchar_t * __restrict val)
+static void dds_stream_write_wstringBO (DDS_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator, const wchar_t *val)
 {
   if (val == NULL)
     dds_os_put4BO (os, allocator, 0);
@@ -117,7 +117,7 @@ static void dds_stream_write_wstringBO (DDS_OSTREAM_T * __restrict os, const str
 }
 
 ddsrt_attribute_warn_unused_result
-static bool dds_stream_write_wcharBO (DDS_OSTREAM_T * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const wchar_t val)
+static bool dds_stream_write_wcharBO (DDS_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator, const wchar_t val)
 {
   // surrogates are forbidden
   if ((uint32_t) val >= 0xd800 && (uint32_t) val < 0xe000)
@@ -128,7 +128,7 @@ static bool dds_stream_write_wcharBO (DDS_OSTREAM_T * __restrict os, const struc
   return true;
 }
 
-static bool dds_stream_write_bool_arrBO (DDS_OSTREAM_T * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const uint8_t * __restrict addr, uint32_t num)
+static bool dds_stream_write_bool_arrBO (DDS_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator, const uint8_t *addr, uint32_t num)
 {
   for (uint32_t i = 0; i < num; i++)
   {
@@ -138,7 +138,7 @@ static bool dds_stream_write_bool_arrBO (DDS_OSTREAM_T * __restrict os, const st
   return true;
 }
 
-static bool dds_stream_write_enum_arrBO (DDS_OSTREAM_T * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, uint32_t insn, const uint32_t * __restrict addr, uint32_t num, uint32_t max)
+static bool dds_stream_write_enum_arrBO (DDS_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator, uint32_t insn, const uint32_t *addr, uint32_t num, uint32_t max)
 {
   switch (DDS_OP_TYPE_SZ (insn))
   {
@@ -172,7 +172,7 @@ static bool dds_stream_write_enum_arrBO (DDS_OSTREAM_T * __restrict os, const st
   return true;
 }
 
-static bool dds_stream_write_bitmask_arrBO (DDS_OSTREAM_T * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, uint32_t insn, const void * __restrict addr, uint32_t num, uint32_t bits_h, uint32_t bits_l)
+static bool dds_stream_write_bitmask_arrBO (DDS_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator, uint32_t insn, const void *addr, uint32_t num, uint32_t bits_h, uint32_t bits_l)
 {
   switch (DDS_OP_TYPE_SZ (insn))
   {
@@ -222,7 +222,7 @@ static bool dds_stream_write_bitmask_arrBO (DDS_OSTREAM_T * __restrict os, const
   return true;
 }
 
-static const uint32_t *dds_stream_write_seqBO (DDS_OSTREAM_T * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict addr, const uint32_t * __restrict ops, uint32_t insn, enum cdr_data_kind cdr_kind)
+static const uint32_t *dds_stream_write_seqBO (DDS_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator, const char *addr, const uint32_t *ops, uint32_t insn, enum cdr_data_kind cdr_kind)
 {
   const dds_sequence_t * const seq = (const dds_sequence_t *) addr;
   uint32_t offs = 0, xcdrv = ((struct dds_ostream *)os)->m_xcdr_version;
@@ -346,7 +346,7 @@ static const uint32_t *dds_stream_write_seqBO (DDS_OSTREAM_T * __restrict os, co
   return ops;
 }
 
-static const uint32_t *dds_stream_write_arrBO (DDS_OSTREAM_T * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict addr, const uint32_t * __restrict ops, uint32_t insn, enum cdr_data_kind cdr_kind)
+static const uint32_t *dds_stream_write_arrBO (DDS_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator, const char *addr, const uint32_t *ops, uint32_t insn, enum cdr_data_kind cdr_kind)
 {
   const enum dds_stream_typecode subtype = DDS_OP_SUBTYPE (insn);
   uint32_t offs = 0, xcdrv = ((struct dds_ostream *)os)->m_xcdr_version;
@@ -444,7 +444,7 @@ static const uint32_t *dds_stream_write_arrBO (DDS_OSTREAM_T * __restrict os, co
   return ops;
 }
 
-static bool dds_stream_write_union_discriminantBO (DDS_OSTREAM_T * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const uint32_t * __restrict ops, uint32_t insn, const void * __restrict addr, uint32_t *disc)
+static bool dds_stream_write_union_discriminantBO (DDS_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, uint32_t insn, const void *addr, uint32_t *disc)
 {
   assert (disc);
   enum dds_stream_typecode type = DDS_OP_SUBTYPE (insn);
@@ -479,7 +479,7 @@ static bool dds_stream_write_union_discriminantBO (DDS_OSTREAM_T * __restrict os
   return true;
 }
 
-static const uint32_t *dds_stream_write_uniBO (DDS_OSTREAM_T * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict discaddr, const char * __restrict baseaddr, const uint32_t * __restrict ops, uint32_t insn, enum cdr_data_kind cdr_kind)
+static const uint32_t *dds_stream_write_uniBO (DDS_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator, const char *discaddr, const char *baseaddr, const uint32_t *ops, uint32_t insn, enum cdr_data_kind cdr_kind)
 {
   uint32_t disc;
   if (!dds_stream_write_union_discriminantBO (os, allocator, ops, insn, discaddr, &disc))
@@ -536,7 +536,7 @@ static const uint32_t *dds_stream_write_uniBO (DDS_OSTREAM_T * __restrict os, co
   return ops;
 }
 
-static const uint32_t *dds_stream_write_adrBO (uint32_t insn, DDS_OSTREAM_T * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict data, const uint32_t * __restrict ops, bool is_mutable_member, enum cdr_data_kind cdr_kind)
+static const uint32_t *dds_stream_write_adrBO (uint32_t insn, DDS_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator, const char *data, const uint32_t *ops, bool is_mutable_member, enum cdr_data_kind cdr_kind)
 {
   const void *addr = data + ops[1];
   if (op_type_external (insn) || op_type_optional (insn) || DDS_OP_TYPE (insn) == DDS_OP_VAL_STR || DDS_OP_TYPE (insn) == DDS_OP_VAL_WSTR)
@@ -612,7 +612,7 @@ static const uint32_t *dds_stream_write_adrBO (uint32_t insn, DDS_OSTREAM_T * __
   return ops;
 }
 
-static const uint32_t *dds_stream_write_delimitedBO (DDS_OSTREAM_T * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict data, const uint32_t * __restrict ops, enum cdr_data_kind cdr_kind)
+static const uint32_t *dds_stream_write_delimitedBO (DDS_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator, const char *data, const uint32_t *ops, enum cdr_data_kind cdr_kind)
 {
   uint32_t offs = dds_os_reserve4BO (os, allocator);
   if (!(ops = dds_stream_write_implBO (os, allocator, data, ops + 1, false, cdr_kind)))
@@ -623,7 +623,7 @@ static const uint32_t *dds_stream_write_delimitedBO (DDS_OSTREAM_T * __restrict 
   return ops;
 }
 
-static bool dds_stream_write_pl_memberBO (uint32_t mid, DDS_OSTREAM_T * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict data, const uint32_t * __restrict ops, enum cdr_data_kind cdr_kind)
+static bool dds_stream_write_pl_memberBO (uint32_t mid, DDS_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator, const char *data, const uint32_t *ops, enum cdr_data_kind cdr_kind)
 {
   assert (!(mid & ~EMHEADER_MEMBERID_MASK));
 
@@ -655,7 +655,7 @@ static bool dds_stream_write_pl_memberBO (uint32_t mid, DDS_OSTREAM_T * __restri
   return true;
 }
 
-static const uint32_t *dds_stream_write_pl_memberlistBO (DDS_OSTREAM_T * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict data, const uint32_t * __restrict ops, enum cdr_data_kind cdr_kind)
+static const uint32_t *dds_stream_write_pl_memberlistBO (DDS_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator, const char *data, const uint32_t *ops, enum cdr_data_kind cdr_kind)
 {
   uint32_t insn;
   while (ops && (insn = *ops) != DDS_OP_RTS)
@@ -689,7 +689,7 @@ static const uint32_t *dds_stream_write_pl_memberlistBO (DDS_OSTREAM_T * __restr
   return ops;
 }
 
-static const uint32_t *dds_stream_write_plBO (DDS_OSTREAM_T * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict data, const uint32_t * __restrict ops, enum cdr_data_kind cdr_kind)
+static const uint32_t *dds_stream_write_plBO (DDS_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator, const char *data, const uint32_t *ops, enum cdr_data_kind cdr_kind)
 {
   /* skip PLC op */
   ops++;
@@ -706,7 +706,7 @@ static const uint32_t *dds_stream_write_plBO (DDS_OSTREAM_T * __restrict os, con
   return ops;
 }
 
-static const uint32_t *dds_stream_write_implBO (DDS_OSTREAM_T * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict data, const uint32_t * __restrict ops, bool is_mutable_member, enum cdr_data_kind cdr_kind)
+static const uint32_t *dds_stream_write_implBO (DDS_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator, const char *data, const uint32_t *ops, bool is_mutable_member, enum cdr_data_kind cdr_kind)
 {
   uint32_t insn;
   while (ops && (insn = *ops) != DDS_OP_RTS)
@@ -737,7 +737,7 @@ static const uint32_t *dds_stream_write_implBO (DDS_OSTREAM_T * __restrict os, c
   return ops;
 }
 
-const uint32_t *dds_stream_writeBO (DDS_OSTREAM_T * __restrict os, const struct dds_cdrstream_allocator * __restrict allocator, const char * __restrict data, const uint32_t * __restrict ops)
+const uint32_t *dds_stream_writeBO (DDS_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator, const char *data, const uint32_t *ops)
 {
   return dds_stream_write_implBO (os, allocator, data, ops, false, CDR_KIND_DATA);
 }

--- a/src/core/ddsc/include/dds/dds.h
+++ b/src/core/ddsc/include/dds/dds.h
@@ -25,10 +25,6 @@
  * @defgroup deprecated (Deprecated functionality)
  */
 
-#if defined (__cplusplus)
-#define restrict
-#endif
-
 #include "dds/export.h"
 #include "dds/features.h"
 

--- a/src/core/ddsc/include/dds/ddsc/dds_public_listener.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_public_listener.h
@@ -78,7 +78,7 @@ DDS_EXPORT dds_listener_t* dds_create_listener(void* arg);
  *
  * @param[in] listener pointer to the listener struct to delete
  */
-DDS_EXPORT void dds_delete_listener (dds_listener_t * __restrict listener);
+DDS_EXPORT void dds_delete_listener (dds_listener_t *listener);
 
 /**
  * @ingroup listener
@@ -87,7 +87,7 @@ DDS_EXPORT void dds_delete_listener (dds_listener_t * __restrict listener);
  *
  * @param[in,out] listener pointer to the listener struct to reset
  */
-DDS_EXPORT void dds_reset_listener (dds_listener_t * __restrict listener);
+DDS_EXPORT void dds_reset_listener (dds_listener_t *listener);
 
 /**
  * @ingroup listener
@@ -97,7 +97,7 @@ DDS_EXPORT void dds_reset_listener (dds_listener_t * __restrict listener);
  * @param[in,out] dst The pointer to the destination listener structure, where the content is to copied
  * @param[in] src The pointer to the source listener structure to be copied
  */
-DDS_EXPORT void dds_copy_listener (dds_listener_t * __restrict dst, const dds_listener_t * __restrict src);
+DDS_EXPORT void dds_copy_listener (dds_listener_t *dst, const dds_listener_t *src);
 
 /**
  * @ingroup listener
@@ -110,7 +110,7 @@ DDS_EXPORT void dds_copy_listener (dds_listener_t * __restrict dst, const dds_li
  * @param[in,out] dst The pointer to the destination listener structure, where the content is merged
  * @param[in] src The pointer to the source listener structure to be copied
  */
-DDS_EXPORT void dds_merge_listener (dds_listener_t * __restrict dst, const dds_listener_t * __restrict src);
+DDS_EXPORT void dds_merge_listener (dds_listener_t *dst, const dds_listener_t *src);
 
 /************************************************************************************************
  *  Setters
@@ -134,7 +134,7 @@ DDS_EXPORT void dds_merge_listener (dds_listener_t * __restrict dst, const dds_l
  * @retval DDS_RETCODE_OK success
  * @retval DDS_RETCODE_BAD_PARAMETER listener is a null pointer
  */
-DDS_EXPORT dds_return_t dds_lset_data_available_arg (dds_listener_t * __restrict listener, dds_on_data_available_fn callback, void *arg, bool reset_on_invoke);
+DDS_EXPORT dds_return_t dds_lset_data_available_arg (dds_listener_t *listener, dds_on_data_available_fn callback, void *arg, bool reset_on_invoke);
 
 /**
  * @ingroup listener_setters
@@ -149,7 +149,7 @@ DDS_EXPORT dds_return_t dds_lset_data_available_arg (dds_listener_t * __restrict
  * @retval DDS_RETCODE_OK success
  * @retval DDS_RETCODE_BAD_PARAMETER listener is a null pointer
  */
-DDS_EXPORT dds_return_t dds_lset_data_on_readers_arg (dds_listener_t * __restrict listener, dds_on_data_on_readers_fn callback, void *arg, bool reset_on_invoke);
+DDS_EXPORT dds_return_t dds_lset_data_on_readers_arg (dds_listener_t *listener, dds_on_data_on_readers_fn callback, void *arg, bool reset_on_invoke);
 
 /**
  * @ingroup listener_setters
@@ -164,7 +164,7 @@ DDS_EXPORT dds_return_t dds_lset_data_on_readers_arg (dds_listener_t * __restric
  * @retval DDS_RETCODE_OK success
  * @retval DDS_RETCODE_BAD_PARAMETER listener is a null pointer
  */
-DDS_EXPORT dds_return_t dds_lset_inconsistent_topic_arg (dds_listener_t * __restrict listener, dds_on_inconsistent_topic_fn callback, void *arg, bool reset_on_invoke);
+DDS_EXPORT dds_return_t dds_lset_inconsistent_topic_arg (dds_listener_t *listener, dds_on_inconsistent_topic_fn callback, void *arg, bool reset_on_invoke);
 
 /**
  * @ingroup listener_setters
@@ -179,7 +179,7 @@ DDS_EXPORT dds_return_t dds_lset_inconsistent_topic_arg (dds_listener_t * __rest
  * @retval DDS_RETCODE_OK success
  * @retval DDS_RETCODE_BAD_PARAMETER listener is a null pointer
  */
-DDS_EXPORT dds_return_t dds_lset_liveliness_changed_arg (dds_listener_t * __restrict listener, dds_on_liveliness_changed_fn callback, void *arg, bool reset_on_invoke);
+DDS_EXPORT dds_return_t dds_lset_liveliness_changed_arg (dds_listener_t *listener, dds_on_liveliness_changed_fn callback, void *arg, bool reset_on_invoke);
 
 /**
  * @ingroup listener_setters
@@ -194,7 +194,7 @@ DDS_EXPORT dds_return_t dds_lset_liveliness_changed_arg (dds_listener_t * __rest
  * @retval DDS_RETCODE_OK success
  * @retval DDS_RETCODE_BAD_PARAMETER listener is a null pointer
  */
-DDS_EXPORT dds_return_t dds_lset_liveliness_lost_arg (dds_listener_t * __restrict listener, dds_on_liveliness_lost_fn callback, void *arg, bool reset_on_invoke);
+DDS_EXPORT dds_return_t dds_lset_liveliness_lost_arg (dds_listener_t *listener, dds_on_liveliness_lost_fn callback, void *arg, bool reset_on_invoke);
 
 /**
  * @ingroup listener_setters
@@ -209,7 +209,7 @@ DDS_EXPORT dds_return_t dds_lset_liveliness_lost_arg (dds_listener_t * __restric
  * @retval DDS_RETCODE_OK success
  * @retval DDS_RETCODE_BAD_PARAMETER listener is a null pointer
  */
-DDS_EXPORT dds_return_t dds_lset_offered_deadline_missed_arg (dds_listener_t * __restrict listener, dds_on_offered_deadline_missed_fn callback, void *arg, bool reset_on_invoke);
+DDS_EXPORT dds_return_t dds_lset_offered_deadline_missed_arg (dds_listener_t *listener, dds_on_offered_deadline_missed_fn callback, void *arg, bool reset_on_invoke);
 
 /**
  * @ingroup listener_setters
@@ -224,7 +224,7 @@ DDS_EXPORT dds_return_t dds_lset_offered_deadline_missed_arg (dds_listener_t * _
  * @retval DDS_RETCODE_OK success
  * @retval DDS_RETCODE_BAD_PARAMETER listener is a null pointer
  */
-DDS_EXPORT dds_return_t dds_lset_offered_incompatible_qos_arg (dds_listener_t * __restrict listener, dds_on_offered_incompatible_qos_fn callback, void *arg, bool reset_on_invoke);
+DDS_EXPORT dds_return_t dds_lset_offered_incompatible_qos_arg (dds_listener_t *listener, dds_on_offered_incompatible_qos_fn callback, void *arg, bool reset_on_invoke);
 
 /**
  * @ingroup listener_setters
@@ -239,7 +239,7 @@ DDS_EXPORT dds_return_t dds_lset_offered_incompatible_qos_arg (dds_listener_t * 
  * @retval DDS_RETCODE_OK success
  * @retval DDS_RETCODE_BAD_PARAMETER listener is a null pointer
  */
-DDS_EXPORT dds_return_t dds_lset_publication_matched_arg (dds_listener_t * __restrict listener, dds_on_publication_matched_fn callback, void *arg, bool reset_on_invoke);
+DDS_EXPORT dds_return_t dds_lset_publication_matched_arg (dds_listener_t *listener, dds_on_publication_matched_fn callback, void *arg, bool reset_on_invoke);
 
 /**
  * @ingroup listener_setters
@@ -254,7 +254,7 @@ DDS_EXPORT dds_return_t dds_lset_publication_matched_arg (dds_listener_t * __res
  * @retval DDS_RETCODE_OK success
  * @retval DDS_RETCODE_BAD_PARAMETER listener is a null pointer
  */
-DDS_EXPORT dds_return_t dds_lset_requested_deadline_missed_arg (dds_listener_t * __restrict listener, dds_on_requested_deadline_missed_fn callback, void *arg, bool reset_on_invoke);
+DDS_EXPORT dds_return_t dds_lset_requested_deadline_missed_arg (dds_listener_t *listener, dds_on_requested_deadline_missed_fn callback, void *arg, bool reset_on_invoke);
 
 /**
  * @ingroup listener_setters
@@ -269,7 +269,7 @@ DDS_EXPORT dds_return_t dds_lset_requested_deadline_missed_arg (dds_listener_t *
  * @retval DDS_RETCODE_OK success
  * @retval DDS_RETCODE_BAD_PARAMETER listener is a null pointer
  */
-DDS_EXPORT dds_return_t dds_lset_requested_incompatible_qos_arg (dds_listener_t * __restrict listener, dds_on_requested_incompatible_qos_fn callback, void *arg, bool reset_on_invoke);
+DDS_EXPORT dds_return_t dds_lset_requested_incompatible_qos_arg (dds_listener_t *listener, dds_on_requested_incompatible_qos_fn callback, void *arg, bool reset_on_invoke);
 
 /**
  * @ingroup listener_setters
@@ -284,7 +284,7 @@ DDS_EXPORT dds_return_t dds_lset_requested_incompatible_qos_arg (dds_listener_t 
  * @retval DDS_RETCODE_OK success
  * @retval DDS_RETCODE_BAD_PARAMETER listener is a null pointer
  */
-DDS_EXPORT dds_return_t dds_lset_sample_lost_arg (dds_listener_t * __restrict listener, dds_on_sample_lost_fn callback, void *arg, bool reset_on_invoke);
+DDS_EXPORT dds_return_t dds_lset_sample_lost_arg (dds_listener_t *listener, dds_on_sample_lost_fn callback, void *arg, bool reset_on_invoke);
 
 /**
  * @ingroup listener_setters
@@ -299,7 +299,7 @@ DDS_EXPORT dds_return_t dds_lset_sample_lost_arg (dds_listener_t * __restrict li
  * @retval DDS_RETCODE_OK success
  * @retval DDS_RETCODE_BAD_PARAMETER listener is a null pointer
  */
-DDS_EXPORT dds_return_t dds_lset_sample_rejected_arg (dds_listener_t * __restrict listener, dds_on_sample_rejected_fn callback, void *arg, bool reset_on_invoke);
+DDS_EXPORT dds_return_t dds_lset_sample_rejected_arg (dds_listener_t *listener, dds_on_sample_rejected_fn callback, void *arg, bool reset_on_invoke);
 
 /**
  * @ingroup listener_setters
@@ -314,7 +314,7 @@ DDS_EXPORT dds_return_t dds_lset_sample_rejected_arg (dds_listener_t * __restric
  * @retval DDS_RETCODE_OK success
  * @retval DDS_RETCODE_BAD_PARAMETER listener is a null pointer
  */
-DDS_EXPORT dds_return_t dds_lset_subscription_matched_arg (dds_listener_t * __restrict listener, dds_on_subscription_matched_fn callback, void *arg, bool reset_on_invoke);
+DDS_EXPORT dds_return_t dds_lset_subscription_matched_arg (dds_listener_t *listener, dds_on_subscription_matched_fn callback, void *arg, bool reset_on_invoke);
 
 /**
  * @ingroup listener_setters
@@ -327,7 +327,7 @@ DDS_EXPORT dds_return_t dds_lset_subscription_matched_arg (dds_listener_t * __re
  * @param[in,out] listener listener structure to update
  * @param[in] callback the callback to set or a null pointer
  */
-DDS_EXPORT void dds_lset_inconsistent_topic (dds_listener_t * __restrict listener, dds_on_inconsistent_topic_fn callback);
+DDS_EXPORT void dds_lset_inconsistent_topic (dds_listener_t *listener, dds_on_inconsistent_topic_fn callback);
 
 /**
  * @ingroup listener_setters
@@ -340,7 +340,7 @@ DDS_EXPORT void dds_lset_inconsistent_topic (dds_listener_t * __restrict listene
  * @param[in,out] listener listener structure to update
  * @param[in] callback the callback to set or a null pointer
  */
-DDS_EXPORT void dds_lset_liveliness_lost (dds_listener_t * __restrict listener, dds_on_liveliness_lost_fn callback);
+DDS_EXPORT void dds_lset_liveliness_lost (dds_listener_t *listener, dds_on_liveliness_lost_fn callback);
 
 /**
  * @ingroup listener_setters
@@ -353,7 +353,7 @@ DDS_EXPORT void dds_lset_liveliness_lost (dds_listener_t * __restrict listener, 
  * @param[in,out] listener listener structure to update
  * @param[in] callback the callback to set or a null pointer
  */
-DDS_EXPORT void dds_lset_offered_deadline_missed (dds_listener_t * __restrict listener, dds_on_offered_deadline_missed_fn callback);
+DDS_EXPORT void dds_lset_offered_deadline_missed (dds_listener_t *listener, dds_on_offered_deadline_missed_fn callback);
 
 /**
  * @ingroup listener_setters
@@ -366,7 +366,7 @@ DDS_EXPORT void dds_lset_offered_deadline_missed (dds_listener_t * __restrict li
  * @param[in,out] listener listener structure to update
  * @param[in] callback the callback to set or a null pointer
  */
-DDS_EXPORT void dds_lset_offered_incompatible_qos (dds_listener_t * __restrict listener, dds_on_offered_incompatible_qos_fn callback);
+DDS_EXPORT void dds_lset_offered_incompatible_qos (dds_listener_t *listener, dds_on_offered_incompatible_qos_fn callback);
 
 /**
  * @ingroup listener_setters
@@ -379,7 +379,7 @@ DDS_EXPORT void dds_lset_offered_incompatible_qos (dds_listener_t * __restrict l
  * @param[in,out] listener listener structure to update
  * @param[in] callback the callback to set or a null pointer
  */
-DDS_EXPORT void dds_lset_data_on_readers (dds_listener_t * __restrict listener, dds_on_data_on_readers_fn callback);
+DDS_EXPORT void dds_lset_data_on_readers (dds_listener_t *listener, dds_on_data_on_readers_fn callback);
 
 /**
  * @ingroup listener_setters
@@ -392,7 +392,7 @@ DDS_EXPORT void dds_lset_data_on_readers (dds_listener_t * __restrict listener, 
  * @param[in,out] listener listener structure to update
  * @param[in] callback the callback to set or a null pointer
  */
-DDS_EXPORT void dds_lset_sample_lost (dds_listener_t * __restrict listener, dds_on_sample_lost_fn callback);
+DDS_EXPORT void dds_lset_sample_lost (dds_listener_t *listener, dds_on_sample_lost_fn callback);
 
 /**
  * @ingroup listener_setters
@@ -405,7 +405,7 @@ DDS_EXPORT void dds_lset_sample_lost (dds_listener_t * __restrict listener, dds_
  * @param[in,out] listener listener structure to update
  * @param[in] callback the callback to set or a null pointer
  */
-DDS_EXPORT void dds_lset_data_available (dds_listener_t * __restrict listener, dds_on_data_available_fn callback);
+DDS_EXPORT void dds_lset_data_available (dds_listener_t *listener, dds_on_data_available_fn callback);
 
 /**
  * @ingroup listener_setters
@@ -418,7 +418,7 @@ DDS_EXPORT void dds_lset_data_available (dds_listener_t * __restrict listener, d
  * @param[in,out] listener listener structure to update
  * @param[in] callback the callback to set or a null pointer
  */
-DDS_EXPORT void dds_lset_sample_rejected (dds_listener_t * __restrict listener, dds_on_sample_rejected_fn callback);
+DDS_EXPORT void dds_lset_sample_rejected (dds_listener_t *listener, dds_on_sample_rejected_fn callback);
 
 /**
  * @ingroup listener_setters
@@ -431,7 +431,7 @@ DDS_EXPORT void dds_lset_sample_rejected (dds_listener_t * __restrict listener, 
  * @param[in,out] listener listener structure to update
  * @param[in] callback the callback to set or a null pointer
  */
-DDS_EXPORT void dds_lset_liveliness_changed (dds_listener_t * __restrict listener, dds_on_liveliness_changed_fn callback);
+DDS_EXPORT void dds_lset_liveliness_changed (dds_listener_t *listener, dds_on_liveliness_changed_fn callback);
 
 /**
  * @ingroup listener_setters
@@ -444,7 +444,7 @@ DDS_EXPORT void dds_lset_liveliness_changed (dds_listener_t * __restrict listene
  * @param[in,out] listener listener structure to update
  * @param[in] callback the callback to set or a null pointer
  */
-DDS_EXPORT void dds_lset_requested_deadline_missed (dds_listener_t * __restrict listener, dds_on_requested_deadline_missed_fn callback);
+DDS_EXPORT void dds_lset_requested_deadline_missed (dds_listener_t *listener, dds_on_requested_deadline_missed_fn callback);
 
 /**
  * @ingroup listener_setters
@@ -457,7 +457,7 @@ DDS_EXPORT void dds_lset_requested_deadline_missed (dds_listener_t * __restrict 
  * @param[in,out] listener listener structure to update
  * @param[in] callback the callback to set or a null pointer
  */
-DDS_EXPORT void dds_lset_requested_incompatible_qos (dds_listener_t * __restrict listener, dds_on_requested_incompatible_qos_fn callback);
+DDS_EXPORT void dds_lset_requested_incompatible_qos (dds_listener_t *listener, dds_on_requested_incompatible_qos_fn callback);
 
 /**
  * @ingroup listener_setters
@@ -470,7 +470,7 @@ DDS_EXPORT void dds_lset_requested_incompatible_qos (dds_listener_t * __restrict
  * @param[in,out] listener listener structure to update
  * @param[in] callback the callback to set or a null pointer
  */
-DDS_EXPORT void dds_lset_publication_matched (dds_listener_t * __restrict listener, dds_on_publication_matched_fn callback);
+DDS_EXPORT void dds_lset_publication_matched (dds_listener_t *listener, dds_on_publication_matched_fn callback);
 
 /**
  * @ingroup listener_setters
@@ -483,7 +483,7 @@ DDS_EXPORT void dds_lset_publication_matched (dds_listener_t * __restrict listen
  * @param[in,out] listener listener structure to update
  * @param[in] callback the callback to set or a null pointer
  */
-DDS_EXPORT void dds_lset_subscription_matched (dds_listener_t * __restrict listener, dds_on_subscription_matched_fn callback);
+DDS_EXPORT void dds_lset_subscription_matched (dds_listener_t *listener, dds_on_subscription_matched_fn callback);
 
 
 /************************************************************************************************
@@ -508,7 +508,7 @@ DDS_EXPORT void dds_lset_subscription_matched (dds_listener_t * __restrict liste
  * @retval DDS_RETCODE_OK if successful
  * @retval DDS_RETCODE_BAD_PARAMETER listener is a null pointer
  */
-DDS_EXPORT dds_return_t dds_lget_data_available_arg (const dds_listener_t * __restrict listener, dds_on_data_available_fn *callback, void **arg, bool *reset_on_invoke);
+DDS_EXPORT dds_return_t dds_lget_data_available_arg (const dds_listener_t *listener, dds_on_data_available_fn *callback, void **arg, bool *reset_on_invoke);
 
 /**
  * @ingroup listener_getters
@@ -523,7 +523,7 @@ DDS_EXPORT dds_return_t dds_lget_data_available_arg (const dds_listener_t * __re
  * @retval DDS_RETCODE_OK if successful
  * @retval DDS_RETCODE_BAD_PARAMETER listener is a null pointer
  */
-DDS_EXPORT dds_return_t dds_lget_data_on_readers_arg (const dds_listener_t * __restrict listener, dds_on_data_on_readers_fn *callback, void **arg, bool *reset_on_invoke);
+DDS_EXPORT dds_return_t dds_lget_data_on_readers_arg (const dds_listener_t *listener, dds_on_data_on_readers_fn *callback, void **arg, bool *reset_on_invoke);
 
 /**
  * @ingroup listener_getters
@@ -538,7 +538,7 @@ DDS_EXPORT dds_return_t dds_lget_data_on_readers_arg (const dds_listener_t * __r
  * @retval DDS_RETCODE_OK if successful
  * @retval DDS_RETCODE_BAD_PARAMETER listener is a null pointer
  */
-DDS_EXPORT dds_return_t dds_lget_inconsistent_topic_arg (const dds_listener_t * __restrict listener, dds_on_inconsistent_topic_fn *callback, void **arg, bool *reset_on_invoke);
+DDS_EXPORT dds_return_t dds_lget_inconsistent_topic_arg (const dds_listener_t *listener, dds_on_inconsistent_topic_fn *callback, void **arg, bool *reset_on_invoke);
 
 /**
  * @ingroup listener_getters
@@ -553,7 +553,7 @@ DDS_EXPORT dds_return_t dds_lget_inconsistent_topic_arg (const dds_listener_t * 
  * @retval DDS_RETCODE_OK if successful
  * @retval DDS_RETCODE_BAD_PARAMETER listener is a null pointer
  */
-DDS_EXPORT dds_return_t dds_lget_liveliness_changed_arg (const dds_listener_t * __restrict listener, dds_on_liveliness_changed_fn *callback, void **arg, bool *reset_on_invoke);
+DDS_EXPORT dds_return_t dds_lget_liveliness_changed_arg (const dds_listener_t *listener, dds_on_liveliness_changed_fn *callback, void **arg, bool *reset_on_invoke);
 
 /**
  * @ingroup listener_getters
@@ -568,7 +568,7 @@ DDS_EXPORT dds_return_t dds_lget_liveliness_changed_arg (const dds_listener_t * 
  * @retval DDS_RETCODE_OK if successful
  * @retval DDS_RETCODE_BAD_PARAMETER listener is a null pointer
  */
-DDS_EXPORT dds_return_t dds_lget_liveliness_lost_arg (const dds_listener_t * __restrict listener, dds_on_liveliness_lost_fn *callback, void **arg, bool *reset_on_invoke);
+DDS_EXPORT dds_return_t dds_lget_liveliness_lost_arg (const dds_listener_t *listener, dds_on_liveliness_lost_fn *callback, void **arg, bool *reset_on_invoke);
 
 /**
  * @ingroup listener_getters
@@ -583,7 +583,7 @@ DDS_EXPORT dds_return_t dds_lget_liveliness_lost_arg (const dds_listener_t * __r
  * @retval DDS_RETCODE_OK if successful
  * @retval DDS_RETCODE_BAD_PARAMETER listener is a null pointer
  */
-DDS_EXPORT dds_return_t dds_lget_offered_deadline_missed_arg (const dds_listener_t * __restrict listener, dds_on_offered_deadline_missed_fn *callback, void **arg, bool *reset_on_invoke);
+DDS_EXPORT dds_return_t dds_lget_offered_deadline_missed_arg (const dds_listener_t *listener, dds_on_offered_deadline_missed_fn *callback, void **arg, bool *reset_on_invoke);
 
 /**
  * @ingroup listener_getters
@@ -598,7 +598,7 @@ DDS_EXPORT dds_return_t dds_lget_offered_deadline_missed_arg (const dds_listener
  * @retval DDS_RETCODE_OK if successful
  * @retval DDS_RETCODE_BAD_PARAMETER listener is a null pointer
  */
-DDS_EXPORT dds_return_t dds_lget_offered_incompatible_qos_arg (const dds_listener_t * __restrict listener, dds_on_offered_incompatible_qos_fn *callback, void **arg, bool *reset_on_invoke);
+DDS_EXPORT dds_return_t dds_lget_offered_incompatible_qos_arg (const dds_listener_t *listener, dds_on_offered_incompatible_qos_fn *callback, void **arg, bool *reset_on_invoke);
 
 /**
  * @ingroup listener_getters
@@ -613,7 +613,7 @@ DDS_EXPORT dds_return_t dds_lget_offered_incompatible_qos_arg (const dds_listene
  * @retval DDS_RETCODE_OK if successful
  * @retval DDS_RETCODE_BAD_PARAMETER listener is a null pointer
  */
-DDS_EXPORT dds_return_t dds_lget_publication_matched_arg (const dds_listener_t * __restrict listener, dds_on_publication_matched_fn *callback, void **arg, bool *reset_on_invoke);
+DDS_EXPORT dds_return_t dds_lget_publication_matched_arg (const dds_listener_t *listener, dds_on_publication_matched_fn *callback, void **arg, bool *reset_on_invoke);
 
 /**
  * @ingroup listener_getters
@@ -628,7 +628,7 @@ DDS_EXPORT dds_return_t dds_lget_publication_matched_arg (const dds_listener_t *
  * @retval DDS_RETCODE_OK if successful
  * @retval DDS_RETCODE_BAD_PARAMETER listener is a null pointer
  */
-DDS_EXPORT dds_return_t dds_lget_requested_deadline_missed_arg (const dds_listener_t * __restrict listener, dds_on_requested_deadline_missed_fn *callback, void **arg, bool *reset_on_invoke);
+DDS_EXPORT dds_return_t dds_lget_requested_deadline_missed_arg (const dds_listener_t *listener, dds_on_requested_deadline_missed_fn *callback, void **arg, bool *reset_on_invoke);
 
 /**
  * @ingroup listener_getters
@@ -643,7 +643,7 @@ DDS_EXPORT dds_return_t dds_lget_requested_deadline_missed_arg (const dds_listen
  * @retval DDS_RETCODE_OK if successful
  * @retval DDS_RETCODE_BAD_PARAMETER listener is a null pointer
  */
-DDS_EXPORT dds_return_t dds_lget_requested_incompatible_qos_arg (const dds_listener_t * __restrict listener, dds_on_requested_incompatible_qos_fn *callback, void **arg, bool *reset_on_invoke);
+DDS_EXPORT dds_return_t dds_lget_requested_incompatible_qos_arg (const dds_listener_t *listener, dds_on_requested_incompatible_qos_fn *callback, void **arg, bool *reset_on_invoke);
 
 /**
  * @ingroup listener_getters
@@ -658,7 +658,7 @@ DDS_EXPORT dds_return_t dds_lget_requested_incompatible_qos_arg (const dds_liste
  * @retval DDS_RETCODE_OK if successful
  * @retval DDS_RETCODE_BAD_PARAMETER listener is a null pointer
  */
-DDS_EXPORT dds_return_t dds_lget_sample_lost_arg (const dds_listener_t * __restrict listener, dds_on_sample_lost_fn *callback, void **arg, bool *reset_on_invoke);
+DDS_EXPORT dds_return_t dds_lget_sample_lost_arg (const dds_listener_t *listener, dds_on_sample_lost_fn *callback, void **arg, bool *reset_on_invoke);
 
 /**
  * @ingroup listener_getters
@@ -673,7 +673,7 @@ DDS_EXPORT dds_return_t dds_lget_sample_lost_arg (const dds_listener_t * __restr
  * @retval DDS_RETCODE_OK if successful
  * @retval DDS_RETCODE_BAD_PARAMETER listener is a null pointer
  */
-DDS_EXPORT dds_return_t dds_lget_sample_rejected_arg (const dds_listener_t * __restrict listener, dds_on_sample_rejected_fn *callback, void **arg, bool *reset_on_invoke);
+DDS_EXPORT dds_return_t dds_lget_sample_rejected_arg (const dds_listener_t *listener, dds_on_sample_rejected_fn *callback, void **arg, bool *reset_on_invoke);
 
 /**
  * @ingroup listener_getters
@@ -688,7 +688,7 @@ DDS_EXPORT dds_return_t dds_lget_sample_rejected_arg (const dds_listener_t * __r
  * @retval DDS_RETCODE_OK if successful
  * @retval DDS_RETCODE_BAD_PARAMETER listener is a null pointer
  */
-DDS_EXPORT dds_return_t dds_lget_subscription_matched_arg (const dds_listener_t * __restrict listener, dds_on_subscription_matched_fn *callback, void **arg, bool *reset_on_invoke);
+DDS_EXPORT dds_return_t dds_lget_subscription_matched_arg (const dds_listener_t *listener, dds_on_subscription_matched_fn *callback, void **arg, bool *reset_on_invoke);
 
 /**
  * @ingroup listener_getters
@@ -700,7 +700,7 @@ DDS_EXPORT dds_return_t dds_lget_subscription_matched_arg (const dds_listener_t 
  * @param[in] listener The pointer to the listener structure, where the callback will be retrieved from
  * @param[out] callback Callback function; may be a null pointer
  */
-DDS_EXPORT void dds_lget_inconsistent_topic (const dds_listener_t * __restrict listener, dds_on_inconsistent_topic_fn *callback);
+DDS_EXPORT void dds_lget_inconsistent_topic (const dds_listener_t *listener, dds_on_inconsistent_topic_fn *callback);
 
 /**
  * @ingroup listener_getters
@@ -712,7 +712,7 @@ DDS_EXPORT void dds_lget_inconsistent_topic (const dds_listener_t * __restrict l
  * @param[in] listener The pointer to the listener structure, where the callback will be retrieved from
  * @param[out] callback Callback function; may be a null pointer
  */
-DDS_EXPORT void dds_lget_liveliness_lost (const dds_listener_t * __restrict listener, dds_on_liveliness_lost_fn *callback);
+DDS_EXPORT void dds_lget_liveliness_lost (const dds_listener_t *listener, dds_on_liveliness_lost_fn *callback);
 
 /**
  * @ingroup listener_getters
@@ -724,7 +724,7 @@ DDS_EXPORT void dds_lget_liveliness_lost (const dds_listener_t * __restrict list
  * @param[in] listener The pointer to the listener structure, where the callback will be retrieved from
  * @param[out] callback Callback function; may be a null pointer
  */
-DDS_EXPORT void dds_lget_offered_deadline_missed (const dds_listener_t * __restrict listener, dds_on_offered_deadline_missed_fn *callback);
+DDS_EXPORT void dds_lget_offered_deadline_missed (const dds_listener_t *listener, dds_on_offered_deadline_missed_fn *callback);
 
 /**
  * @ingroup listener_getters
@@ -736,7 +736,7 @@ DDS_EXPORT void dds_lget_offered_deadline_missed (const dds_listener_t * __restr
  * @param[in] listener The pointer to the listener structure, where the callback will be retrieved from
  * @param[out] callback Callback function; may be a null pointer
  */
-DDS_EXPORT void dds_lget_offered_incompatible_qos (const dds_listener_t * __restrict listener, dds_on_offered_incompatible_qos_fn *callback);
+DDS_EXPORT void dds_lget_offered_incompatible_qos (const dds_listener_t *listener, dds_on_offered_incompatible_qos_fn *callback);
 
 /**
  * @ingroup listener_getters
@@ -748,7 +748,7 @@ DDS_EXPORT void dds_lget_offered_incompatible_qos (const dds_listener_t * __rest
  * @param[in] listener The pointer to the listener structure, where the callback will be retrieved from
  * @param[out] callback Callback function; may be a null pointer
  */
-DDS_EXPORT void dds_lget_data_on_readers (const dds_listener_t * __restrict listener, dds_on_data_on_readers_fn *callback);
+DDS_EXPORT void dds_lget_data_on_readers (const dds_listener_t *listener, dds_on_data_on_readers_fn *callback);
 
 /**
  * @ingroup listener_getters
@@ -760,7 +760,7 @@ DDS_EXPORT void dds_lget_data_on_readers (const dds_listener_t * __restrict list
  * @param[in] listener The pointer to the listener structure, where the callback will be retrieved from
  * @param[out] callback Callback function; may be a null pointer
  */
-DDS_EXPORT void dds_lget_sample_lost (const dds_listener_t *__restrict listener, dds_on_sample_lost_fn *callback);
+DDS_EXPORT void dds_lget_sample_lost (const dds_listener_t *listener, dds_on_sample_lost_fn *callback);
 
 /**
  * @ingroup listener_getters
@@ -772,7 +772,7 @@ DDS_EXPORT void dds_lget_sample_lost (const dds_listener_t *__restrict listener,
  * @param[in] listener The pointer to the listener structure, where the callback will be retrieved from
  * @param[out] callback Callback function; may be a null pointer
  */
-DDS_EXPORT void dds_lget_data_available (const dds_listener_t *__restrict listener, dds_on_data_available_fn *callback);
+DDS_EXPORT void dds_lget_data_available (const dds_listener_t *listener, dds_on_data_available_fn *callback);
 
 /**
  * @ingroup listener_getters
@@ -784,7 +784,7 @@ DDS_EXPORT void dds_lget_data_available (const dds_listener_t *__restrict listen
  * @param[in] listener The pointer to the listener structure, where the callback will be retrieved from
  * @param[out] callback Callback function; may be a null pointer
  */
-DDS_EXPORT void dds_lget_sample_rejected (const dds_listener_t  *__restrict listener, dds_on_sample_rejected_fn *callback);
+DDS_EXPORT void dds_lget_sample_rejected (const dds_listener_t *listener, dds_on_sample_rejected_fn *callback);
 
 /**
  * @ingroup listener_getters
@@ -796,7 +796,7 @@ DDS_EXPORT void dds_lget_sample_rejected (const dds_listener_t  *__restrict list
  * @param[in] listener The pointer to the listener structure, where the callback will be retrieved from
  * @param[out] callback Callback function; may be a null pointer
  */
-DDS_EXPORT void dds_lget_liveliness_changed (const dds_listener_t * __restrict listener, dds_on_liveliness_changed_fn *callback);
+DDS_EXPORT void dds_lget_liveliness_changed (const dds_listener_t *listener, dds_on_liveliness_changed_fn *callback);
 
 /**
  * @ingroup listener_getters
@@ -808,7 +808,7 @@ DDS_EXPORT void dds_lget_liveliness_changed (const dds_listener_t * __restrict l
  * @param[in] listener The pointer to the listener structure, where the callback will be retrieved from
  * @param[out] callback Callback function; may be a null pointer
  */
-DDS_EXPORT void dds_lget_requested_deadline_missed (const dds_listener_t * __restrict listener, dds_on_requested_deadline_missed_fn *callback);
+DDS_EXPORT void dds_lget_requested_deadline_missed (const dds_listener_t *listener, dds_on_requested_deadline_missed_fn *callback);
 
 /**
  * @ingroup listener_getters
@@ -820,7 +820,7 @@ DDS_EXPORT void dds_lget_requested_deadline_missed (const dds_listener_t * __res
  * @param[in] listener The pointer to the listener structure, where the callback will be retrieved from
  * @param[out] callback Callback function; may be a null pointer
  */
-DDS_EXPORT void dds_lget_requested_incompatible_qos (const dds_listener_t * __restrict listener, dds_on_requested_incompatible_qos_fn *callback);
+DDS_EXPORT void dds_lget_requested_incompatible_qos (const dds_listener_t *listener, dds_on_requested_incompatible_qos_fn *callback);
 
 /**
  * @ingroup listener_getters
@@ -832,7 +832,7 @@ DDS_EXPORT void dds_lget_requested_incompatible_qos (const dds_listener_t * __re
  * @param[in] listener The pointer to the listener structure, where the callback will be retrieved from
  * @param[out] callback Callback function; may be a null pointer
  */
-DDS_EXPORT void dds_lget_publication_matched (const dds_listener_t * __restrict listener, dds_on_publication_matched_fn *callback);
+DDS_EXPORT void dds_lget_publication_matched (const dds_listener_t *listener, dds_on_publication_matched_fn *callback);
 
 /**
  * @ingroup listener_getters
@@ -844,7 +844,7 @@ DDS_EXPORT void dds_lget_publication_matched (const dds_listener_t * __restrict 
  * @param[in] listener The pointer to the listener structure, where the callback will be retrieved from
  * @param[out] callback Callback function; may be a null pointer
  */
-DDS_EXPORT void dds_lget_subscription_matched (const dds_listener_t * __restrict listener, dds_on_subscription_matched_fn *callback);
+DDS_EXPORT void dds_lget_subscription_matched (const dds_listener_t *listener, dds_on_subscription_matched_fn *callback);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsc/include/dds/ddsc/dds_public_qos.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_public_qos.h
@@ -52,7 +52,7 @@ dds_qos_t * dds_create_qos (void);
  * @param[in] qos - Pointer to dds_qos_t structure
  */
 DDS_EXPORT void
-dds_delete_qos (dds_qos_t * __restrict qos);
+dds_delete_qos (dds_qos_t *qos);
 
 /**
  * @ingroup qos
@@ -62,7 +62,7 @@ dds_delete_qos (dds_qos_t * __restrict qos);
  * @param[in,out] qos - Pointer to the dds_qos_t structure
  */
 DDS_EXPORT void
-dds_reset_qos(dds_qos_t * __restrict qos);
+dds_reset_qos(dds_qos_t *qos);
 
 /**
  * @ingroup qos
@@ -75,7 +75,7 @@ dds_reset_qos(dds_qos_t * __restrict qos);
  * @returns - Return-code indicating success or failure
  */
 DDS_EXPORT dds_return_t
-dds_copy_qos (dds_qos_t * __restrict dst, const dds_qos_t * __restrict src);
+dds_copy_qos (dds_qos_t *dst, const dds_qos_t *src);
 
 /**
  * @ingroup qos
@@ -88,7 +88,7 @@ dds_copy_qos (dds_qos_t * __restrict dst, const dds_qos_t * __restrict src);
  * @param[in] src - Pointer to the source qos structure
  */
 DDS_EXPORT void
-dds_merge_qos (dds_qos_t * __restrict dst, const dds_qos_t * __restrict src);
+dds_merge_qos (dds_qos_t *dst, const dds_qos_t *src);
 
 /**
  * @ingroup qos
@@ -101,7 +101,7 @@ dds_merge_qos (dds_qos_t * __restrict dst, const dds_qos_t * __restrict src);
  * @returns whether the two qos structures contain the same set of QoS-policies
  */
 DDS_EXPORT bool
-dds_qos_equal (const dds_qos_t * __restrict a, const dds_qos_t * __restrict b);
+dds_qos_equal (const dds_qos_t *a, const dds_qos_t *b);
 
 /**
  * @defgroup qos_setters (Qos Setters)
@@ -120,8 +120,8 @@ dds_qos_equal (const dds_qos_t * __restrict a, const dds_qos_t * __restrict b);
  */
 DDS_EXPORT void
 dds_qset_userdata (
-  dds_qos_t * __restrict qos,
-  const void * __restrict value,
+  dds_qos_t *qos,
+  const void *value,
   size_t sz);
 
 /**
@@ -135,8 +135,8 @@ dds_qset_userdata (
  */
 DDS_EXPORT void
 dds_qset_topicdata (
-  dds_qos_t * __restrict qos,
-  const void * __restrict value,
+  dds_qos_t *qos,
+  const void *value,
   size_t sz);
 
 /**
@@ -150,8 +150,8 @@ dds_qset_topicdata (
  */
 DDS_EXPORT void
 dds_qset_groupdata (
-  dds_qos_t * __restrict qos,
-  const void * __restrict value,
+  dds_qos_t *qos,
+  const void *value,
   size_t sz);
 
 /**
@@ -163,7 +163,7 @@ dds_qset_groupdata (
  * @param[in] kind - Durability kind value
  */
 DDS_EXPORT void
-dds_qset_durability (dds_qos_t * __restrict qos, dds_durability_kind_t kind);
+dds_qset_durability (dds_qos_t *qos, dds_durability_kind_t kind);
 
 /**
  * @ingroup qos_setters
@@ -178,7 +178,7 @@ dds_qset_durability (dds_qos_t * __restrict qos, dds_durability_kind_t kind);
  */
 DDS_EXPORT void
 dds_qset_history (
-  dds_qos_t * __restrict qos,
+  dds_qos_t *qos,
   dds_history_kind_t kind,
   int32_t depth);
 
@@ -194,7 +194,7 @@ dds_qset_history (
  */
 DDS_EXPORT void
 dds_qset_resource_limits (
-  dds_qos_t * __restrict qos,
+  dds_qos_t *qos,
   int32_t max_samples,
   int32_t max_instances,
   int32_t max_samples_per_instance);
@@ -211,7 +211,7 @@ dds_qset_resource_limits (
  */
 DDS_EXPORT void
 dds_qset_presentation (
-  dds_qos_t * __restrict qos,
+  dds_qos_t *qos,
   dds_presentation_access_scope_kind_t access_scope,
   bool coherent_access,
   bool ordered_access);
@@ -226,7 +226,7 @@ dds_qset_presentation (
  */
 DDS_EXPORT void
 dds_qset_lifespan (
-  dds_qos_t * __restrict qos,
+  dds_qos_t *qos,
   dds_duration_t lifespan);
 
 /**
@@ -239,7 +239,7 @@ dds_qset_lifespan (
  */
 DDS_EXPORT void
 dds_qset_deadline (
-  dds_qos_t * __restrict qos,
+  dds_qos_t *qos,
   dds_duration_t deadline);
 
 /**
@@ -252,7 +252,7 @@ dds_qset_deadline (
  */
 DDS_EXPORT void
 dds_qset_latency_budget (
-  dds_qos_t * __restrict qos,
+  dds_qos_t *qos,
   dds_duration_t duration);
 
 /**
@@ -265,7 +265,7 @@ dds_qset_latency_budget (
  */
 DDS_EXPORT void
 dds_qset_ownership (
-  dds_qos_t * __restrict qos,
+  dds_qos_t *qos,
   dds_ownership_kind_t kind);
 
 /**
@@ -277,7 +277,7 @@ dds_qset_ownership (
  * @param[in] value - Ownership strength value
  */
 DDS_EXPORT void
-dds_qset_ownership_strength (dds_qos_t * __restrict qos, int32_t value);
+dds_qset_ownership_strength (dds_qos_t *qos, int32_t value);
 
 /**
  * @ingroup qos_setters
@@ -290,7 +290,7 @@ dds_qset_ownership_strength (dds_qos_t * __restrict qos, int32_t value);
  */
 DDS_EXPORT void
 dds_qset_liveliness (
-  dds_qos_t * __restrict qos,
+  dds_qos_t *qos,
   dds_liveliness_kind_t kind,
   dds_duration_t lease_duration);
 
@@ -304,7 +304,7 @@ dds_qset_liveliness (
  */
 DDS_EXPORT void
 dds_qset_time_based_filter (
-  dds_qos_t * __restrict qos,
+  dds_qos_t *qos,
   dds_duration_t minimum_separation);
 
 /**
@@ -318,9 +318,9 @@ dds_qset_time_based_filter (
  */
 DDS_EXPORT void
 dds_qset_partition (
-  dds_qos_t * __restrict qos,
+  dds_qos_t *qos,
   uint32_t n,
-  const char ** __restrict ps);
+  const char **ps);
 
 /**
  * @ingroup qos_setters
@@ -333,8 +333,8 @@ dds_qset_partition (
  */
 DDS_EXPORT void
 dds_qset_partition1 (
-  dds_qos_t * __restrict qos,
-  const char * __restrict name);
+  dds_qos_t *qos,
+  const char *name);
 
 /**
  * @ingroup qos_setters
@@ -347,7 +347,7 @@ dds_qset_partition1 (
  */
 DDS_EXPORT void
 dds_qset_reliability (
-  dds_qos_t * __restrict qos,
+  dds_qos_t *qos,
   dds_reliability_kind_t kind,
   dds_duration_t max_blocking_time);
 
@@ -360,7 +360,7 @@ dds_qset_reliability (
  * @param[in] value - Priority value
  */
 DDS_EXPORT void
-dds_qset_transport_priority (dds_qos_t * __restrict qos, int32_t value);
+dds_qset_transport_priority (dds_qos_t *qos, int32_t value);
 
 /**
  * @ingroup qos_setters
@@ -372,7 +372,7 @@ dds_qset_transport_priority (dds_qos_t * __restrict qos, int32_t value);
  */
 DDS_EXPORT void
 dds_qset_destination_order (
-  dds_qos_t * __restrict qos,
+  dds_qos_t *qos,
   dds_destination_order_kind_t kind);
 
 /**
@@ -384,7 +384,7 @@ dds_qset_destination_order (
  * @param[in] autodispose - Automatic disposal of unregistered instances
  */
 DDS_EXPORT void
-dds_qset_writer_data_lifecycle (dds_qos_t * __restrict qos, bool autodispose);
+dds_qset_writer_data_lifecycle (dds_qos_t *qos, bool autodispose);
 
 /**
  * @ingroup qos_setters
@@ -397,7 +397,7 @@ dds_qset_writer_data_lifecycle (dds_qos_t * __restrict qos, bool autodispose);
  */
 DDS_EXPORT void
 dds_qset_reader_data_lifecycle (
-  dds_qos_t * __restrict qos,
+  dds_qos_t *qos,
   dds_duration_t autopurge_nowriter_samples_delay,
   dds_duration_t autopurge_disposed_samples_delay);
 
@@ -424,7 +424,7 @@ dds_qset_reader_data_lifecycle (
  * @param[in] batch_updates - Whether writes should be batched
  */
 DDS_EXPORT void
-dds_qset_writer_batching (dds_qos_t * __restrict qos, bool batch_updates);
+dds_qset_writer_batching (dds_qos_t *qos, bool batch_updates);
 
 /**
  * @ingroup qos_setters
@@ -441,7 +441,7 @@ dds_qset_writer_batching (dds_qos_t * __restrict qos, bool batch_updates);
  */
 DDS_EXPORT void
 dds_qset_durability_service (
-  dds_qos_t * __restrict qos,
+  dds_qos_t *qos,
   dds_duration_t service_cleanup_delay,
   dds_history_kind_t history_kind,
   int32_t history_depth,
@@ -459,7 +459,7 @@ dds_qset_durability_service (
  */
 DDS_EXPORT void
 dds_qset_ignorelocal (
-  dds_qos_t * __restrict qos,
+  dds_qos_t *qos,
   dds_ignorelocal_kind_t ignore);
 
 /**
@@ -478,7 +478,7 @@ dds_qset_ignorelocal (
  */
 DDS_EXPORT void
 dds_qset_prop (
-  dds_qos_t * __restrict qos,
+  dds_qos_t *qos,
   const char * name,
   const char * value);
 
@@ -495,7 +495,7 @@ dds_qset_prop (
  */
 DDS_EXPORT void
 dds_qunset_prop (
-  dds_qos_t * __restrict qos,
+  dds_qos_t *qos,
   const char * name);
 
 /**
@@ -515,7 +515,7 @@ dds_qunset_prop (
  */
 DDS_EXPORT void
 dds_qset_bprop (
-  dds_qos_t * __restrict qos,
+  dds_qos_t *qos,
   const char * name,
   const void * value,
   const size_t sz);
@@ -533,7 +533,7 @@ dds_qset_bprop (
  */
 DDS_EXPORT void
 dds_qunset_bprop (
-  dds_qos_t * __restrict qos,
+  dds_qos_t *qos,
   const char * name);
 
 /**
@@ -551,7 +551,7 @@ dds_qunset_bprop (
  */
 DDS_EXPORT void
 dds_qset_type_consistency (
-  dds_qos_t * __restrict qos,
+  dds_qos_t *qos,
   dds_type_consistency_kind_t kind,
   bool ignore_sequence_bounds,
   bool ignore_string_bounds,
@@ -570,7 +570,7 @@ dds_qset_type_consistency (
  */
 DDS_EXPORT void
 dds_qset_data_representation (
-  dds_qos_t * __restrict qos,
+  dds_qos_t *qos,
   uint32_t n,
   const dds_data_representation_id_t *values);
 
@@ -588,7 +588,7 @@ dds_qset_data_representation (
  */
 DDS_EXPORT void
 dds_qset_entity_name (
-  dds_qos_t * __restrict qos,
+  dds_qos_t *qos,
   const char * name);
 
 /**
@@ -602,7 +602,7 @@ dds_qset_entity_name (
  */
 DDS_EXPORT void
 dds_qset_psmx_instances (
-  dds_qos_t * __restrict qos,
+  dds_qos_t *qos,
   uint32_t n,
   const char **values);
 
@@ -624,7 +624,7 @@ dds_qset_psmx_instances (
  *
  * @returns - false iff any of the arguments is invalid or the qos is not present in the qos object
  */
-DDS_EXPORT bool dds_qget_userdata (const dds_qos_t * __restrict qos, void **value, size_t *sz);
+DDS_EXPORT bool dds_qget_userdata (const dds_qos_t *qos, void **value, size_t *sz);
 
 /**
  * @ingroup qos_getters
@@ -637,7 +637,7 @@ DDS_EXPORT bool dds_qget_userdata (const dds_qos_t * __restrict qos, void **valu
  *
  * @returns - false iff any of the arguments is invalid or the qos is not present in the qos object
 */
-DDS_EXPORT bool dds_qget_topicdata (const dds_qos_t * __restrict qos, void **value, size_t *sz);
+DDS_EXPORT bool dds_qget_topicdata (const dds_qos_t *qos, void **value, size_t *sz);
 
 /**
  * @ingroup qos_getters
@@ -650,7 +650,7 @@ DDS_EXPORT bool dds_qget_topicdata (const dds_qos_t * __restrict qos, void **val
  *
  * @returns - false iff any of the arguments is invalid or the qos is not present in the qos object
  */
-DDS_EXPORT bool dds_qget_groupdata (const dds_qos_t * __restrict qos, void **value, size_t *sz);
+DDS_EXPORT bool dds_qget_groupdata (const dds_qos_t *qos, void **value, size_t *sz);
 
 /**
  * @ingroup qos_getters
@@ -662,7 +662,7 @@ DDS_EXPORT bool dds_qget_groupdata (const dds_qos_t * __restrict qos, void **val
  *
  * @returns - false iff any of the arguments is invalid or the qos is not present in the qos object
  */
-DDS_EXPORT bool dds_qget_durability (const dds_qos_t * __restrict qos, dds_durability_kind_t *kind);
+DDS_EXPORT bool dds_qget_durability (const dds_qos_t *qos, dds_durability_kind_t *kind);
 
 /**
  * @ingroup qos_getters
@@ -675,7 +675,7 @@ DDS_EXPORT bool dds_qget_durability (const dds_qos_t * __restrict qos, dds_durab
  *
  * @returns - false iff any of the arguments is invalid or the qos is not present in the qos object
  */
-DDS_EXPORT bool dds_qget_history (const dds_qos_t * __restrict qos, dds_history_kind_t *kind, int32_t *depth);
+DDS_EXPORT bool dds_qget_history (const dds_qos_t *qos, dds_history_kind_t *kind, int32_t *depth);
 
 /**
  * @ingroup qos_getters
@@ -691,7 +691,7 @@ DDS_EXPORT bool dds_qget_history (const dds_qos_t * __restrict qos, dds_history_
  */
 DDS_EXPORT bool
 dds_qget_resource_limits (
-  const dds_qos_t * __restrict qos,
+  const dds_qos_t *qos,
   int32_t *max_samples,
   int32_t *max_instances,
   int32_t *max_samples_per_instance);
@@ -710,7 +710,7 @@ dds_qget_resource_limits (
  */
 DDS_EXPORT bool
 dds_qget_presentation (
-  const dds_qos_t * __restrict qos,
+  const dds_qos_t *qos,
   dds_presentation_access_scope_kind_t *access_scope,
   bool *coherent_access,
   bool *ordered_access);
@@ -727,7 +727,7 @@ dds_qget_presentation (
  */
 DDS_EXPORT bool
 dds_qget_lifespan (
-  const dds_qos_t * __restrict qos,
+  const dds_qos_t *qos,
   dds_duration_t *lifespan);
 
 /**
@@ -742,7 +742,7 @@ dds_qget_lifespan (
  */
 DDS_EXPORT bool
 dds_qget_deadline (
-  const dds_qos_t * __restrict qos,
+  const dds_qos_t *qos,
   dds_duration_t *deadline);
 
 /**
@@ -757,7 +757,7 @@ dds_qget_deadline (
  */
 DDS_EXPORT bool
 dds_qget_latency_budget (
-  const dds_qos_t * __restrict qos,
+  const dds_qos_t *qos,
   dds_duration_t *duration);
 
 /**
@@ -772,7 +772,7 @@ dds_qget_latency_budget (
  */
 DDS_EXPORT bool
 dds_qget_ownership (
-  const dds_qos_t * __restrict qos,
+  const dds_qos_t *qos,
   dds_ownership_kind_t *kind);
 
 /**
@@ -787,7 +787,7 @@ dds_qget_ownership (
  */
 DDS_EXPORT bool
 dds_qget_ownership_strength (
-  const dds_qos_t * __restrict qos,
+  const dds_qos_t *qos,
   int32_t *value);
 
 /**
@@ -803,7 +803,7 @@ dds_qget_ownership_strength (
  */
 DDS_EXPORT bool
 dds_qget_liveliness (
-  const dds_qos_t * __restrict qos,
+  const dds_qos_t *qos,
   dds_liveliness_kind_t *kind,
   dds_duration_t *lease_duration);
 
@@ -819,7 +819,7 @@ dds_qget_liveliness (
  */
 DDS_EXPORT bool
 dds_qget_time_based_filter (
-  const dds_qos_t * __restrict qos,
+  const dds_qos_t *qos,
   dds_duration_t *minimum_separation);
 
 /**
@@ -835,7 +835,7 @@ dds_qget_time_based_filter (
  */
 DDS_EXPORT bool
 dds_qget_partition (
-  const dds_qos_t * __restrict qos,
+  const dds_qos_t *qos,
   uint32_t *n,
   char ***ps);
 
@@ -852,7 +852,7 @@ dds_qget_partition (
  */
 DDS_EXPORT bool
 dds_qget_reliability (
-  const dds_qos_t * __restrict qos,
+  const dds_qos_t *qos,
   dds_reliability_kind_t *kind,
   dds_duration_t *max_blocking_time);
 
@@ -868,7 +868,7 @@ dds_qget_reliability (
  */
 DDS_EXPORT bool
 dds_qget_transport_priority (
-  const dds_qos_t * __restrict qos,
+  const dds_qos_t *qos,
   int32_t *value);
 
 /**
@@ -883,7 +883,7 @@ dds_qget_transport_priority (
  */
 DDS_EXPORT bool
 dds_qget_destination_order (
-  const dds_qos_t * __restrict qos,
+  const dds_qos_t *qos,
   dds_destination_order_kind_t *kind);
 
 /**
@@ -898,7 +898,7 @@ dds_qget_destination_order (
  */
 DDS_EXPORT bool
 dds_qget_writer_data_lifecycle (
-  const dds_qos_t * __restrict qos,
+  const dds_qos_t *qos,
   bool *autodispose);
 
 /**
@@ -914,7 +914,7 @@ dds_qget_writer_data_lifecycle (
  */
 DDS_EXPORT bool
 dds_qget_reader_data_lifecycle (
-  const dds_qos_t * __restrict qos,
+  const dds_qos_t *qos,
   dds_duration_t *autopurge_nowriter_samples_delay,
   dds_duration_t *autopurge_disposed_samples_delay);
 
@@ -930,7 +930,7 @@ dds_qget_reader_data_lifecycle (
  */
 DDS_EXPORT bool
 dds_qget_writer_batching (
-  const dds_qos_t * __restrict qos,
+  const dds_qos_t *qos,
   bool *batch_updates);
 
 /**
@@ -950,7 +950,7 @@ dds_qget_writer_batching (
  */
 DDS_EXPORT bool
 dds_qget_durability_service (
-  const dds_qos_t * __restrict qos,
+  const dds_qos_t *qos,
   dds_duration_t *service_cleanup_delay,
   dds_history_kind_t *history_kind,
   int32_t *history_depth,
@@ -970,7 +970,7 @@ dds_qget_durability_service (
  */
 DDS_EXPORT bool
 dds_qget_ignorelocal (
-  const dds_qos_t * __restrict qos,
+  const dds_qos_t *qos,
   dds_ignorelocal_kind_t *ignore);
 
 /**
@@ -986,7 +986,7 @@ dds_qget_ignorelocal (
  */
 DDS_EXPORT bool
 dds_qget_propnames (
-  const dds_qos_t * __restrict qos,
+  const dds_qos_t *qos,
   uint32_t * n,
   char *** names);
 
@@ -1006,7 +1006,7 @@ dds_qget_propnames (
  */
 DDS_EXPORT bool
 dds_qget_prop (
-  const dds_qos_t * __restrict qos,
+  const dds_qos_t *qos,
   const char * name,
   char ** value);
 
@@ -1023,7 +1023,7 @@ dds_qget_prop (
  */
 DDS_EXPORT bool
 dds_qget_bpropnames (
-  const dds_qos_t * __restrict qos,
+  const dds_qos_t *qos,
   uint32_t * n,
   char *** names);
 
@@ -1044,7 +1044,7 @@ dds_qget_bpropnames (
  */
 DDS_EXPORT bool
 dds_qget_bprop (
-  const dds_qos_t * __restrict qos,
+  const dds_qos_t *qos,
   const char * name,
   void ** value,
   size_t * sz);
@@ -1066,7 +1066,7 @@ dds_qget_bprop (
  */
 DDS_EXPORT bool
 dds_qget_type_consistency (
-  const dds_qos_t * __restrict qos,
+  const dds_qos_t *qos,
   dds_type_consistency_kind_t *kind,
   bool *ignore_sequence_bounds,
   bool *ignore_string_bounds,
@@ -1093,7 +1093,7 @@ dds_qget_type_consistency (
  */
 DDS_EXPORT bool
 dds_qget_data_representation (
-  const dds_qos_t * __restrict qos,
+  const dds_qos_t *qos,
   uint32_t *n,
   dds_data_representation_id_t **values);
 
@@ -1108,7 +1108,7 @@ dds_qget_data_representation (
  * @returns - false iff any of the arguments is invalid or the qos is not present in the qos object
  *            or if a buffer to store the name could not be allocated.
  */
-DDS_EXPORT bool dds_qget_entity_name (const dds_qos_t * __restrict qos, char **name);
+DDS_EXPORT bool dds_qget_entity_name (const dds_qos_t *qos, char **name);
 
 
 /**
@@ -1123,7 +1123,7 @@ DDS_EXPORT bool dds_qget_entity_name (const dds_qos_t * __restrict qos, char **n
  */
 DDS_EXPORT bool
 dds_qget_psmx_instances (
-  const dds_qos_t * __restrict qos,
+  const dds_qos_t *qos,
   uint32_t *n_out,
   char ***values);
 

--- a/src/core/ddsc/include/dds/ddsc/dds_rhc.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_rhc.h
@@ -63,17 +63,17 @@ DDS_INLINE_EXPORT inline dds_return_t dds_rhc_associate (struct dds_rhc *rhc, st
 }
 
 /** @component rhc */
-DDS_INLINE_EXPORT inline bool dds_rhc_store (struct dds_rhc * __restrict rhc, const struct ddsi_writer_info * __restrict wr_info, struct ddsi_serdata * __restrict sample, struct ddsi_tkmap_instance * __restrict tk) {
+DDS_INLINE_EXPORT inline bool dds_rhc_store (struct dds_rhc *rhc, const struct ddsi_writer_info *wr_info, struct ddsi_serdata *sample, struct ddsi_tkmap_instance *tk) {
   return rhc->common.ops->rhc_ops.store (&rhc->common.rhc, wr_info, sample, tk);
 }
 
 /** @component rhc */
-DDS_INLINE_EXPORT inline void dds_rhc_unregister_wr (struct dds_rhc * __restrict rhc, const struct ddsi_writer_info * __restrict wr_info) {
+DDS_INLINE_EXPORT inline void dds_rhc_unregister_wr (struct dds_rhc *rhc, const struct ddsi_writer_info *wr_info) {
   rhc->common.ops->rhc_ops.unregister_wr (&rhc->common.rhc, wr_info);
 }
 
 /** @component rhc */
-DDS_INLINE_EXPORT inline void dds_rhc_relinquish_ownership (struct dds_rhc * __restrict rhc, const uint64_t wr_iid) {
+DDS_INLINE_EXPORT inline void dds_rhc_relinquish_ownership (struct dds_rhc *rhc, const uint64_t wr_iid) {
   rhc->common.ops->rhc_ops.relinquish_ownership (&rhc->common.rhc, wr_iid);
 }
 

--- a/src/core/ddsc/src/dds__listener.h
+++ b/src/core/ddsc/src/dds__listener.h
@@ -19,10 +19,10 @@ extern "C" {
 #endif
 
 /** @component entity_listener */
-void dds_override_inherited_listener (dds_listener_t * __restrict dst, const dds_listener_t * __restrict src);
+void dds_override_inherited_listener (dds_listener_t *dst, const dds_listener_t *src);
 
 /** @component entity_listener */
-void dds_inherit_listener (dds_listener_t * __restrict dst, const dds_listener_t * __restrict src);
+void dds_inherit_listener (dds_listener_t *dst, const dds_listener_t *src);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsc/src/dds_listener.c
+++ b/src/core/ddsc/src/dds_listener.c
@@ -33,11 +33,11 @@ dds_listener_t *dds_create_listener (void* arg)
   return l;
 }
 
-void dds_delete_listener (dds_listener_t * __restrict listener)
+void dds_delete_listener (dds_listener_t *listener)
 {
   dds_free (listener);
 }
-void dds_reset_listener (dds_listener_t * __restrict listener)
+void dds_reset_listener (dds_listener_t *listener)
 {
   if (listener)
   {
@@ -60,7 +60,7 @@ void dds_reset_listener (dds_listener_t * __restrict listener)
   }
 }
 
-void dds_copy_listener (dds_listener_t * __restrict dst, const dds_listener_t * __restrict src)
+void dds_copy_listener (dds_listener_t *dst, const dds_listener_t *src)
 {
   if (dst && src)
     *dst = *src;
@@ -89,7 +89,7 @@ static uint32_t combine_reset_on_invoke (const dds_listener_t *dst, const dds_li
   return copy_bits (dst->reset_on_invoke, src->reset_on_invoke, status);
 }
 
-static void dds_combine_listener (bool (*op) (uint32_t inherited, void (*dst)(void), void (*src)(void)), dds_listener_t * __restrict dst, const dds_listener_t * __restrict src)
+static void dds_combine_listener (bool (*op) (uint32_t inherited, void (*dst)(void), void (*src)(void)), dds_listener_t *dst, const dds_listener_t *src)
 {
 #define C(NAME_, name_) do { \
     if (op (dst->inherited & DDS_##NAME_##_STATUS, (void (*)(void)) dst->on_##name_, (void (*)(void)) src->on_##name_)){ \
@@ -115,19 +115,19 @@ static void dds_combine_listener (bool (*op) (uint32_t inherited, void (*dst)(vo
 #undef C
 }
 
-void dds_override_inherited_listener (dds_listener_t * __restrict dst, const dds_listener_t * __restrict src)
+void dds_override_inherited_listener (dds_listener_t *dst, const dds_listener_t *src)
 {
   if (dst && src)
     dds_combine_listener (dds_combine_listener_override_inherited, dst, src);
 }
 
-void dds_inherit_listener (dds_listener_t * __restrict dst, const dds_listener_t * __restrict src)
+void dds_inherit_listener (dds_listener_t *dst, const dds_listener_t *src)
 {
   if (dst && src)
     dds_combine_listener (dds_combine_listener_merge, dst, src);
 }
 
-void dds_merge_listener (dds_listener_t * __restrict dst, const dds_listener_t * __restrict src)
+void dds_merge_listener (dds_listener_t *dst, const dds_listener_t *src)
 {
   if (dst && src)
   {
@@ -138,7 +138,7 @@ void dds_merge_listener (dds_listener_t * __restrict dst, const dds_listener_t *
 }
 
 #define DDS_SET_LISTENER_ARG(NAME_, name_) \
-  dds_return_t dds_lset_##name_##_arg (dds_listener_t * __restrict listener, dds_on_##name_##_fn callback, void *arg, bool reset_on_invoke) \
+  dds_return_t dds_lset_##name_##_arg (dds_listener_t *listener, dds_on_##name_##_fn callback, void *arg, bool reset_on_invoke) \
   { \
     if (listener == NULL) \
       return DDS_RETCODE_BAD_PARAMETER; \
@@ -163,7 +163,7 @@ DDS_SET_LISTENER_ARG (SUBSCRIPTION_MATCHED, subscription_matched)
 #undef DDS_SET_LISTENER_ARG
 
 #define DDS_SET_LISTENER(NAME_, name_) \
-  void dds_lset_##name_ (dds_listener_t * __restrict listener, dds_on_##name_##_fn callback) { \
+  void dds_lset_##name_ (dds_listener_t *listener, dds_on_##name_##_fn callback) { \
     if (listener) \
       (void) dds_lset_##name_##_arg (listener, callback, listener->on_##name_##_arg, true); \
   }
@@ -183,7 +183,7 @@ DDS_SET_LISTENER (SUBSCRIPTION_MATCHED, subscription_matched)
 #undef DDS_SET_LISTENER
 
 #define DDS_GET_LISTENER_ARG(NAME_, name_) \
-  dds_return_t dds_lget_##name_##_arg (const dds_listener_t * __restrict listener, dds_on_##name_##_fn *callback, void **arg, bool *reset_on_invoke) \
+  dds_return_t dds_lget_##name_##_arg (const dds_listener_t *listener, dds_on_##name_##_fn *callback, void **arg, bool *reset_on_invoke) \
   { \
     if (listener == NULL) \
       return DDS_RETCODE_BAD_PARAMETER; \
@@ -211,7 +211,7 @@ DDS_GET_LISTENER_ARG (SUBSCRIPTION_MATCHED, subscription_matched)
 #undef DDS_GET_LISTENER_ARG
 
 #define DDS_GET_LISTENER(name_) \
-  void dds_lget_##name_ (const dds_listener_t * __restrict listener, dds_on_##name_##_fn *callback) { \
+  void dds_lget_##name_ (const dds_listener_t *listener, dds_on_##name_##_fn *callback) { \
     (void) dds_lget_##name_##_arg (listener, callback, NULL, NULL); \
   }
 DDS_GET_LISTENER (data_available)

--- a/src/core/ddsc/src/dds_qos.c
+++ b/src/core/ddsc/src/dds_qos.c
@@ -23,7 +23,7 @@
 #include "dds__topic.h"
 #include "dds__psmx.h"
 
-static void dds_qos_data_copy_in (ddsi_octetseq_t *data, const void * __restrict value, size_t sz, bool overwrite)
+static void dds_qos_data_copy_in (ddsi_octetseq_t *data, const void *value, size_t sz, bool overwrite)
 {
   if (overwrite && data->value)
     ddsrt_free (data->value);
@@ -61,7 +61,7 @@ dds_qos_t *dds_create_qos (void)
   return qos;
 }
 
-void dds_reset_qos (dds_qos_t * __restrict qos)
+void dds_reset_qos (dds_qos_t *qos)
 {
   if (qos)
   {
@@ -70,7 +70,7 @@ void dds_reset_qos (dds_qos_t * __restrict qos)
   }
 }
 
-void dds_delete_qos (dds_qos_t * __restrict qos)
+void dds_delete_qos (dds_qos_t *qos)
 {
   if (qos)
   {
@@ -79,7 +79,7 @@ void dds_delete_qos (dds_qos_t * __restrict qos)
   }
 }
 
-dds_return_t dds_copy_qos (dds_qos_t * __restrict dst, const dds_qos_t * __restrict src)
+dds_return_t dds_copy_qos (dds_qos_t *dst, const dds_qos_t *src)
 {
   if (src == NULL || dst == NULL)
     return DDS_RETCODE_BAD_PARAMETER;
@@ -87,14 +87,14 @@ dds_return_t dds_copy_qos (dds_qos_t * __restrict dst, const dds_qos_t * __restr
   return DDS_RETCODE_OK;
 }
 
-void dds_merge_qos (dds_qos_t * __restrict dst, const dds_qos_t * __restrict src)
+void dds_merge_qos (dds_qos_t *dst, const dds_qos_t *src)
 {
   /* Copy qos from source to destination unless already set */
   if (src != NULL && dst != NULL)
     ddsi_xqos_mergein_missing (dst, src, ~(uint64_t)0);
 }
 
-bool dds_qos_equal (const dds_qos_t * __restrict a, const dds_qos_t * __restrict b)
+bool dds_qos_equal (const dds_qos_t *a, const dds_qos_t *b)
 {
   /* FIXME: a bit of a hack - and I am not so sure I like accepting null pointers here anyway */
   if (a == NULL && b == NULL)
@@ -105,7 +105,7 @@ bool dds_qos_equal (const dds_qos_t * __restrict a, const dds_qos_t * __restrict
     return ddsi_xqos_delta (a, b, ~(DDSI_QP_TYPE_INFORMATION)) == 0;
 }
 
-void dds_qset_userdata (dds_qos_t * __restrict qos, const void * __restrict value, size_t sz)
+void dds_qset_userdata (dds_qos_t *qos, const void *value, size_t sz)
 {
   if (qos == NULL || (sz > 0 && value == NULL))
     return;
@@ -113,7 +113,7 @@ void dds_qset_userdata (dds_qos_t * __restrict qos, const void * __restrict valu
   qos->present |= DDSI_QP_USER_DATA;
 }
 
-void dds_qset_topicdata (dds_qos_t * __restrict qos, const void * __restrict value, size_t sz)
+void dds_qset_topicdata (dds_qos_t *qos, const void *value, size_t sz)
 {
   if (qos == NULL || (sz > 0 && value == NULL))
     return;
@@ -121,7 +121,7 @@ void dds_qset_topicdata (dds_qos_t * __restrict qos, const void * __restrict val
   qos->present |= DDSI_QP_TOPIC_DATA;
 }
 
-void dds_qset_groupdata (dds_qos_t * __restrict qos, const void * __restrict value, size_t sz)
+void dds_qset_groupdata (dds_qos_t *qos, const void *value, size_t sz)
 {
   if (qos == NULL || (sz > 0 && value == NULL))
     return;
@@ -129,7 +129,7 @@ void dds_qset_groupdata (dds_qos_t * __restrict qos, const void * __restrict val
   qos->present |= DDSI_QP_GROUP_DATA;
 }
 
-void dds_qset_durability (dds_qos_t * __restrict qos, dds_durability_kind_t kind)
+void dds_qset_durability (dds_qos_t *qos, dds_durability_kind_t kind)
 {
   if (qos == NULL)
     return;
@@ -137,7 +137,7 @@ void dds_qset_durability (dds_qos_t * __restrict qos, dds_durability_kind_t kind
   qos->present |= DDSI_QP_DURABILITY;
 }
 
-void dds_qset_history (dds_qos_t * __restrict qos, dds_history_kind_t kind, int32_t depth)
+void dds_qset_history (dds_qos_t *qos, dds_history_kind_t kind, int32_t depth)
 {
   if (qos == NULL)
     return;
@@ -146,7 +146,7 @@ void dds_qset_history (dds_qos_t * __restrict qos, dds_history_kind_t kind, int3
   qos->present |= DDSI_QP_HISTORY;
 }
 
-void dds_qset_resource_limits (dds_qos_t * __restrict qos, int32_t max_samples, int32_t max_instances, int32_t max_samples_per_instance)
+void dds_qset_resource_limits (dds_qos_t *qos, int32_t max_samples, int32_t max_instances, int32_t max_samples_per_instance)
 {
   if (qos == NULL)
     return;
@@ -156,7 +156,7 @@ void dds_qset_resource_limits (dds_qos_t * __restrict qos, int32_t max_samples, 
   qos->present |= DDSI_QP_RESOURCE_LIMITS;
 }
 
-void dds_qset_presentation (dds_qos_t * __restrict qos, dds_presentation_access_scope_kind_t access_scope, bool coherent_access, bool ordered_access)
+void dds_qset_presentation (dds_qos_t *qos, dds_presentation_access_scope_kind_t access_scope, bool coherent_access, bool ordered_access)
 {
   if (qos == NULL)
     return;
@@ -166,7 +166,7 @@ void dds_qset_presentation (dds_qos_t * __restrict qos, dds_presentation_access_
   qos->present |= DDSI_QP_PRESENTATION;
 }
 
-void dds_qset_lifespan (dds_qos_t * __restrict qos, dds_duration_t lifespan)
+void dds_qset_lifespan (dds_qos_t *qos, dds_duration_t lifespan)
 {
   if (qos == NULL)
     return;
@@ -174,7 +174,7 @@ void dds_qset_lifespan (dds_qos_t * __restrict qos, dds_duration_t lifespan)
   qos->present |= DDSI_QP_LIFESPAN;
 }
 
-void dds_qset_deadline (dds_qos_t * __restrict qos, dds_duration_t deadline)
+void dds_qset_deadline (dds_qos_t *qos, dds_duration_t deadline)
 {
   if (qos == NULL)
     return;
@@ -182,7 +182,7 @@ void dds_qset_deadline (dds_qos_t * __restrict qos, dds_duration_t deadline)
   qos->present |= DDSI_QP_DEADLINE;
 }
 
-void dds_qset_latency_budget (dds_qos_t * __restrict qos, dds_duration_t duration)
+void dds_qset_latency_budget (dds_qos_t *qos, dds_duration_t duration)
 {
   if (qos == NULL)
     return;
@@ -190,7 +190,7 @@ void dds_qset_latency_budget (dds_qos_t * __restrict qos, dds_duration_t duratio
   qos->present |= DDSI_QP_LATENCY_BUDGET;
 }
 
-void dds_qset_ownership (dds_qos_t * __restrict qos, dds_ownership_kind_t kind)
+void dds_qset_ownership (dds_qos_t *qos, dds_ownership_kind_t kind)
 {
   if (qos == NULL)
     return;
@@ -198,7 +198,7 @@ void dds_qset_ownership (dds_qos_t * __restrict qos, dds_ownership_kind_t kind)
   qos->present |= DDSI_QP_OWNERSHIP;
 }
 
-void dds_qset_ownership_strength (dds_qos_t * __restrict qos, int32_t value)
+void dds_qset_ownership_strength (dds_qos_t *qos, int32_t value)
 {
   if (qos == NULL)
     return;
@@ -206,7 +206,7 @@ void dds_qset_ownership_strength (dds_qos_t * __restrict qos, int32_t value)
   qos->present |= DDSI_QP_OWNERSHIP_STRENGTH;
 }
 
-void dds_qset_liveliness (dds_qos_t * __restrict qos, dds_liveliness_kind_t kind, dds_duration_t lease_duration)
+void dds_qset_liveliness (dds_qos_t *qos, dds_liveliness_kind_t kind, dds_duration_t lease_duration)
 {
   if (qos == NULL)
     return;
@@ -215,7 +215,7 @@ void dds_qset_liveliness (dds_qos_t * __restrict qos, dds_liveliness_kind_t kind
   qos->present |= DDSI_QP_LIVELINESS;
 }
 
-void dds_qset_time_based_filter (dds_qos_t * __restrict qos, dds_duration_t minimum_separation)
+void dds_qset_time_based_filter (dds_qos_t *qos, dds_duration_t minimum_separation)
 {
   if (qos == NULL)
     return;
@@ -223,7 +223,7 @@ void dds_qset_time_based_filter (dds_qos_t * __restrict qos, dds_duration_t mini
   qos->present |= DDSI_QP_TIME_BASED_FILTER;
 }
 
-void dds_qset_partition (dds_qos_t * __restrict qos, uint32_t n, const char ** __restrict ps)
+void dds_qset_partition (dds_qos_t *qos, uint32_t n, const char **ps)
 {
   if (qos == NULL || (n > 0 && ps == NULL))
     return;
@@ -245,7 +245,7 @@ void dds_qset_partition (dds_qos_t * __restrict qos, uint32_t n, const char ** _
   qos->present |= DDSI_QP_PARTITION;
 }
 
-void dds_qset_partition1 (dds_qos_t * __restrict qos, const char * __restrict name)
+void dds_qset_partition1 (dds_qos_t *qos, const char *name)
 {
   if (name == NULL)
     dds_qset_partition (qos, 0, NULL);
@@ -253,7 +253,7 @@ void dds_qset_partition1 (dds_qos_t * __restrict qos, const char * __restrict na
     dds_qset_partition (qos, 1, (const char **) &name);
 }
 
-void dds_qset_reliability (dds_qos_t * __restrict qos, dds_reliability_kind_t kind, dds_duration_t max_blocking_time)
+void dds_qset_reliability (dds_qos_t *qos, dds_reliability_kind_t kind, dds_duration_t max_blocking_time)
 {
   if (qos == NULL)
     return;
@@ -262,7 +262,7 @@ void dds_qset_reliability (dds_qos_t * __restrict qos, dds_reliability_kind_t ki
   qos->present |= DDSI_QP_RELIABILITY;
 }
 
-void dds_qset_transport_priority (dds_qos_t * __restrict qos, int32_t value)
+void dds_qset_transport_priority (dds_qos_t *qos, int32_t value)
 {
   if (qos == NULL)
     return;
@@ -270,7 +270,7 @@ void dds_qset_transport_priority (dds_qos_t * __restrict qos, int32_t value)
   qos->present |= DDSI_QP_TRANSPORT_PRIORITY;
 }
 
-void dds_qset_destination_order (dds_qos_t * __restrict qos, dds_destination_order_kind_t kind)
+void dds_qset_destination_order (dds_qos_t *qos, dds_destination_order_kind_t kind)
 {
   if (qos == NULL)
     return;
@@ -278,7 +278,7 @@ void dds_qset_destination_order (dds_qos_t * __restrict qos, dds_destination_ord
   qos->present |= DDSI_QP_DESTINATION_ORDER;
 }
 
-void dds_qset_writer_data_lifecycle (dds_qos_t * __restrict qos, bool autodispose)
+void dds_qset_writer_data_lifecycle (dds_qos_t *qos, bool autodispose)
 {
   if (qos == NULL)
     return;
@@ -286,7 +286,7 @@ void dds_qset_writer_data_lifecycle (dds_qos_t * __restrict qos, bool autodispos
   qos->present |= DDSI_QP_ADLINK_WRITER_DATA_LIFECYCLE;
 }
 
-void dds_qset_reader_data_lifecycle (dds_qos_t * __restrict qos, dds_duration_t autopurge_nowriter_samples_delay, dds_duration_t autopurge_disposed_samples_delay)
+void dds_qset_reader_data_lifecycle (dds_qos_t *qos, dds_duration_t autopurge_nowriter_samples_delay, dds_duration_t autopurge_disposed_samples_delay)
 {
   if (qos == NULL)
     return;
@@ -295,7 +295,7 @@ void dds_qset_reader_data_lifecycle (dds_qos_t * __restrict qos, dds_duration_t 
   qos->present |= DDSI_QP_ADLINK_READER_DATA_LIFECYCLE;
 }
 
-void dds_qset_writer_batching (dds_qos_t * __restrict qos, bool batch_updates)
+void dds_qset_writer_batching (dds_qos_t *qos, bool batch_updates)
 {
   if (qos == NULL)
     return;
@@ -303,7 +303,7 @@ void dds_qset_writer_batching (dds_qos_t * __restrict qos, bool batch_updates)
   qos->present |= DDSI_QP_CYCLONE_WRITER_BATCHING;
 }
 
-void dds_qset_durability_service (dds_qos_t * __restrict qos, dds_duration_t service_cleanup_delay, dds_history_kind_t history_kind, int32_t history_depth, int32_t max_samples, int32_t max_instances, int32_t max_samples_per_instance)
+void dds_qset_durability_service (dds_qos_t *qos, dds_duration_t service_cleanup_delay, dds_history_kind_t history_kind, int32_t history_depth, int32_t max_samples, int32_t max_instances, int32_t max_samples_per_instance)
 {
   if (qos == NULL)
     return;
@@ -316,7 +316,7 @@ void dds_qset_durability_service (dds_qos_t * __restrict qos, dds_duration_t ser
   qos->present |= DDSI_QP_DURABILITY_SERVICE;
 }
 
-void dds_qset_ignorelocal (dds_qos_t * __restrict qos, dds_ignorelocal_kind_t ignore)
+void dds_qset_ignorelocal (dds_qos_t *qos, dds_ignorelocal_kind_t ignore)
 {
   if (qos == NULL)
     return;
@@ -355,7 +355,7 @@ DDS_QPROP_GET_INDEX (prop, value)
 DDS_QPROP_GET_INDEX (bprop, binary_value)
 
 #define DDS_QUNSET_PROP(prop_type_, prop_field_, value_field_) \
-void dds_qunset_##prop_type_ (dds_qos_t * __restrict qos, const char * name) \
+void dds_qunset_##prop_type_ (dds_qos_t *qos, const char * name) \
 { \
   uint32_t i; \
   if (qos == NULL || !(qos->present & DDSI_QP_PROPERTY_LIST) || qos->property.prop_field_.n == 0 || name == NULL) \
@@ -383,7 +383,7 @@ void dds_qunset_##prop_type_ (dds_qos_t * __restrict qos, const char * name) \
 DDS_QUNSET_PROP (prop, value, value)
 DDS_QUNSET_PROP (bprop, binary_value, value.value)
 
-void dds_qset_prop (dds_qos_t * __restrict qos, const char * name, const char * value)
+void dds_qset_prop (dds_qos_t *qos, const char * name, const char * value)
 {
   uint32_t i;
   if (qos == NULL || name == NULL || value == NULL)
@@ -407,7 +407,7 @@ void dds_qset_prop (dds_qos_t * __restrict qos, const char * name, const char * 
   }
 }
 
-void dds_qset_bprop (dds_qos_t * __restrict qos, const char * name, const void * value, const size_t sz)
+void dds_qset_bprop (dds_qos_t *qos, const char * name, const void * value, const size_t sz)
 {
   uint32_t i;
   if (qos == NULL || name == NULL || (value == NULL && sz > 0))
@@ -430,7 +430,7 @@ void dds_qset_bprop (dds_qos_t * __restrict qos, const char * name, const void *
   }
 }
 
-void dds_qset_entity_name (dds_qos_t * __restrict qos, const char * name)
+void dds_qset_entity_name (dds_qos_t *qos, const char * name)
 {
   if (qos == NULL || name == NULL)
     return;
@@ -440,7 +440,7 @@ void dds_qset_entity_name (dds_qos_t * __restrict qos, const char * name)
   qos->present |= DDSI_QP_ENTITY_NAME;
 }
 
-void dds_qset_type_consistency (dds_qos_t * __restrict qos, dds_type_consistency_kind_t kind,
+void dds_qset_type_consistency (dds_qos_t *qos, dds_type_consistency_kind_t kind,
   bool ignore_sequence_bounds, bool ignore_string_bounds, bool ignore_member_names, bool prevent_type_widening, bool force_type_validation)
 {
   if (qos == NULL)
@@ -454,7 +454,7 @@ void dds_qset_type_consistency (dds_qos_t * __restrict qos, dds_type_consistency
   qos->present |= DDSI_QP_TYPE_CONSISTENCY_ENFORCEMENT;
 }
 
-void dds_qset_data_representation (dds_qos_t * __restrict qos, uint32_t n, const dds_data_representation_id_t *values)
+void dds_qset_data_representation (dds_qos_t *qos, uint32_t n, const dds_data_representation_id_t *values)
 {
   if (qos == NULL || (n && !values))
     return;
@@ -482,7 +482,7 @@ void dds_qset_data_representation (dds_qos_t * __restrict qos, uint32_t n, const
   qos->present |= DDSI_QP_DATA_REPRESENTATION;
 }
 
-void dds_qset_psmx_instances (dds_qos_t * __restrict qos, uint32_t n, const char **values)
+void dds_qset_psmx_instances (dds_qos_t *qos, uint32_t n, const char **values)
 {
   if (qos == NULL || (n > 0 && values == NULL) || n > DDS_MAX_PSMX_INSTANCES)
     return;
@@ -518,28 +518,28 @@ void dds_qset_psmx_instances (dds_qos_t * __restrict qos, uint32_t n, const char
   qos->present |= DDSI_QP_PSMX;
 }
 
-bool dds_qget_userdata (const dds_qos_t * __restrict qos, void **value, size_t *sz)
+bool dds_qget_userdata (const dds_qos_t *qos, void **value, size_t *sz)
 {
   if (qos == NULL || !(qos->present & DDSI_QP_USER_DATA))
     return false;
   return dds_qos_data_copy_out (&qos->user_data, value, sz);
 }
 
-bool dds_qget_topicdata (const dds_qos_t * __restrict qos, void **value, size_t *sz)
+bool dds_qget_topicdata (const dds_qos_t *qos, void **value, size_t *sz)
 {
   if (qos == NULL || !(qos->present & DDSI_QP_TOPIC_DATA))
     return false;
   return dds_qos_data_copy_out (&qos->topic_data, value, sz);
 }
 
-bool dds_qget_groupdata (const dds_qos_t * __restrict qos, void **value, size_t *sz)
+bool dds_qget_groupdata (const dds_qos_t *qos, void **value, size_t *sz)
 {
   if (qos == NULL || !(qos->present & DDSI_QP_GROUP_DATA))
     return false;
   return dds_qos_data_copy_out (&qos->group_data, value, sz);
 }
 
-bool dds_qget_durability (const dds_qos_t * __restrict qos, dds_durability_kind_t *kind)
+bool dds_qget_durability (const dds_qos_t *qos, dds_durability_kind_t *kind)
 {
   if (qos == NULL || !(qos->present & DDSI_QP_DURABILITY))
     return false;
@@ -548,7 +548,7 @@ bool dds_qget_durability (const dds_qos_t * __restrict qos, dds_durability_kind_
   return true;
 }
 
-bool dds_qget_history (const dds_qos_t * __restrict qos, dds_history_kind_t *kind, int32_t *depth)
+bool dds_qget_history (const dds_qos_t *qos, dds_history_kind_t *kind, int32_t *depth)
 {
   if (qos == NULL || !(qos->present & DDSI_QP_HISTORY))
     return false;
@@ -559,7 +559,7 @@ bool dds_qget_history (const dds_qos_t * __restrict qos, dds_history_kind_t *kin
   return true;
 }
 
-bool dds_qget_resource_limits (const dds_qos_t * __restrict qos, int32_t *max_samples, int32_t *max_instances, int32_t *max_samples_per_instance)
+bool dds_qget_resource_limits (const dds_qos_t *qos, int32_t *max_samples, int32_t *max_instances, int32_t *max_samples_per_instance)
 {
   if (qos == NULL || !(qos->present & DDSI_QP_RESOURCE_LIMITS))
     return false;
@@ -572,7 +572,7 @@ bool dds_qget_resource_limits (const dds_qos_t * __restrict qos, int32_t *max_sa
   return true;
 }
 
-bool dds_qget_presentation (const dds_qos_t * __restrict qos, dds_presentation_access_scope_kind_t *access_scope, bool *coherent_access, bool *ordered_access)
+bool dds_qget_presentation (const dds_qos_t *qos, dds_presentation_access_scope_kind_t *access_scope, bool *coherent_access, bool *ordered_access)
 {
   if (qos == NULL || !(qos->present & DDSI_QP_PRESENTATION))
     return false;
@@ -585,7 +585,7 @@ bool dds_qget_presentation (const dds_qos_t * __restrict qos, dds_presentation_a
   return true;
 }
 
-bool dds_qget_lifespan (const dds_qos_t * __restrict qos, dds_duration_t *lifespan)
+bool dds_qget_lifespan (const dds_qos_t *qos, dds_duration_t *lifespan)
 {
   if (qos == NULL || !(qos->present & DDSI_QP_LIFESPAN))
     return false;
@@ -594,7 +594,7 @@ bool dds_qget_lifespan (const dds_qos_t * __restrict qos, dds_duration_t *lifesp
   return true;
 }
 
-bool dds_qget_deadline (const dds_qos_t * __restrict qos, dds_duration_t *deadline)
+bool dds_qget_deadline (const dds_qos_t *qos, dds_duration_t *deadline)
 {
   if (qos == NULL || !(qos->present & DDSI_QP_DEADLINE))
     return false;
@@ -603,7 +603,7 @@ bool dds_qget_deadline (const dds_qos_t * __restrict qos, dds_duration_t *deadli
   return true;
 }
 
-bool dds_qget_latency_budget (const dds_qos_t * __restrict qos, dds_duration_t *duration)
+bool dds_qget_latency_budget (const dds_qos_t *qos, dds_duration_t *duration)
 {
   if (qos == NULL || !(qos->present & DDSI_QP_LATENCY_BUDGET))
     return false;
@@ -612,7 +612,7 @@ bool dds_qget_latency_budget (const dds_qos_t * __restrict qos, dds_duration_t *
   return true;
 }
 
-bool dds_qget_ownership (const dds_qos_t * __restrict qos, dds_ownership_kind_t *kind)
+bool dds_qget_ownership (const dds_qos_t *qos, dds_ownership_kind_t *kind)
 {
   if (qos == NULL || !(qos->present & DDSI_QP_OWNERSHIP))
     return false;
@@ -621,7 +621,7 @@ bool dds_qget_ownership (const dds_qos_t * __restrict qos, dds_ownership_kind_t 
   return true;
 }
 
-bool dds_qget_ownership_strength (const dds_qos_t * __restrict qos, int32_t *value)
+bool dds_qget_ownership_strength (const dds_qos_t *qos, int32_t *value)
 {
   if (qos == NULL || !(qos->present & DDSI_QP_OWNERSHIP_STRENGTH))
     return false;
@@ -630,7 +630,7 @@ bool dds_qget_ownership_strength (const dds_qos_t * __restrict qos, int32_t *val
   return true;
 }
 
-bool dds_qget_liveliness (const dds_qos_t * __restrict qos, dds_liveliness_kind_t *kind, dds_duration_t *lease_duration)
+bool dds_qget_liveliness (const dds_qos_t *qos, dds_liveliness_kind_t *kind, dds_duration_t *lease_duration)
 {
   if (qos == NULL || !(qos->present & DDSI_QP_LIVELINESS))
     return false;
@@ -641,7 +641,7 @@ bool dds_qget_liveliness (const dds_qos_t * __restrict qos, dds_liveliness_kind_
   return true;
 }
 
-bool dds_qget_time_based_filter (const dds_qos_t * __restrict qos, dds_duration_t *minimum_separation)
+bool dds_qget_time_based_filter (const dds_qos_t *qos, dds_duration_t *minimum_separation)
 {
   if (qos == NULL || !(qos->present & DDSI_QP_TIME_BASED_FILTER))
     return false;
@@ -650,7 +650,7 @@ bool dds_qget_time_based_filter (const dds_qos_t * __restrict qos, dds_duration_
   return true;
 }
 
-bool dds_qget_partition (const dds_qos_t * __restrict qos, uint32_t *n, char ***ps)
+bool dds_qget_partition (const dds_qos_t *qos, uint32_t *n, char ***ps)
 {
   if (qos == NULL || !(qos->present & DDSI_QP_PARTITION))
     return false;
@@ -672,7 +672,7 @@ bool dds_qget_partition (const dds_qos_t * __restrict qos, uint32_t *n, char ***
   return true;
 }
 
-bool dds_qget_reliability (const dds_qos_t * __restrict qos, dds_reliability_kind_t *kind, dds_duration_t *max_blocking_time)
+bool dds_qget_reliability (const dds_qos_t *qos, dds_reliability_kind_t *kind, dds_duration_t *max_blocking_time)
 {
   if (qos == NULL || !(qos->present & DDSI_QP_RELIABILITY))
     return false;
@@ -683,7 +683,7 @@ bool dds_qget_reliability (const dds_qos_t * __restrict qos, dds_reliability_kin
   return true;
 }
 
-bool dds_qget_transport_priority (const dds_qos_t * __restrict qos, int32_t *value)
+bool dds_qget_transport_priority (const dds_qos_t *qos, int32_t *value)
 {
   if (qos == NULL || !(qos->present & DDSI_QP_TRANSPORT_PRIORITY))
     return false;
@@ -692,7 +692,7 @@ bool dds_qget_transport_priority (const dds_qos_t * __restrict qos, int32_t *val
   return true;
 }
 
-bool dds_qget_destination_order (const dds_qos_t * __restrict qos, dds_destination_order_kind_t *kind)
+bool dds_qget_destination_order (const dds_qos_t *qos, dds_destination_order_kind_t *kind)
 {
   if (qos == NULL || !(qos->present & DDSI_QP_DESTINATION_ORDER))
     return false;
@@ -701,7 +701,7 @@ bool dds_qget_destination_order (const dds_qos_t * __restrict qos, dds_destinati
   return true;
 }
 
-bool dds_qget_writer_data_lifecycle (const dds_qos_t * __restrict qos, bool *autodispose)
+bool dds_qget_writer_data_lifecycle (const dds_qos_t *qos, bool *autodispose)
 {
   if (qos == NULL || !(qos->present & DDSI_QP_ADLINK_WRITER_DATA_LIFECYCLE))
     return false;
@@ -710,7 +710,7 @@ bool dds_qget_writer_data_lifecycle (const dds_qos_t * __restrict qos, bool *aut
   return true;
 }
 
-bool dds_qget_reader_data_lifecycle (const dds_qos_t * __restrict qos, dds_duration_t *autopurge_nowriter_samples_delay, dds_duration_t *autopurge_disposed_samples_delay)
+bool dds_qget_reader_data_lifecycle (const dds_qos_t *qos, dds_duration_t *autopurge_nowriter_samples_delay, dds_duration_t *autopurge_disposed_samples_delay)
 {
   if (qos == NULL || !(qos->present & DDSI_QP_ADLINK_READER_DATA_LIFECYCLE))
     return false;
@@ -721,7 +721,7 @@ bool dds_qget_reader_data_lifecycle (const dds_qos_t * __restrict qos, dds_durat
   return true;
 }
 
-bool dds_qget_writer_batching (const dds_qos_t * __restrict qos, bool *batch_updates)
+bool dds_qget_writer_batching (const dds_qos_t *qos, bool *batch_updates)
 {
   if (qos == NULL || !(qos->present & DDSI_QP_CYCLONE_WRITER_BATCHING))
     return false;
@@ -730,7 +730,7 @@ bool dds_qget_writer_batching (const dds_qos_t * __restrict qos, bool *batch_upd
   return true;
 }
 
-bool dds_qget_durability_service (const dds_qos_t * __restrict qos, dds_duration_t *service_cleanup_delay, dds_history_kind_t *history_kind, int32_t *history_depth, int32_t *max_samples, int32_t *max_instances, int32_t *max_samples_per_instance)
+bool dds_qget_durability_service (const dds_qos_t *qos, dds_duration_t *service_cleanup_delay, dds_history_kind_t *history_kind, int32_t *history_depth, int32_t *max_samples, int32_t *max_instances, int32_t *max_samples_per_instance)
 {
   if (qos == NULL || !(qos->present & DDSI_QP_DURABILITY_SERVICE))
     return false;
@@ -749,7 +749,7 @@ bool dds_qget_durability_service (const dds_qos_t * __restrict qos, dds_duration
   return true;
 }
 
-bool dds_qget_ignorelocal (const dds_qos_t * __restrict qos, dds_ignorelocal_kind_t *ignore)
+bool dds_qget_ignorelocal (const dds_qos_t *qos, dds_ignorelocal_kind_t *ignore)
 {
   if (qos == NULL || !(qos->present & DDSI_QP_CYCLONE_IGNORELOCAL))
     return false;
@@ -759,7 +759,7 @@ bool dds_qget_ignorelocal (const dds_qos_t * __restrict qos, dds_ignorelocal_kin
 }
 
 #define DDS_QGET_PROPNAMES(prop_type_, prop_field_) \
-bool dds_qget_##prop_type_##names (const dds_qos_t * __restrict qos, uint32_t * n, char *** names) \
+bool dds_qget_##prop_type_##names (const dds_qos_t *qos, uint32_t * n, char *** names) \
 { \
   bool props; \
   if (qos == NULL || (n == NULL && names == NULL)) \
@@ -783,7 +783,7 @@ bool dds_qget_##prop_type_##names (const dds_qos_t * __restrict qos, uint32_t * 
 DDS_QGET_PROPNAMES (prop, value)
 DDS_QGET_PROPNAMES (bprop, binary_value)
 
-bool dds_qget_prop (const dds_qos_t * __restrict qos, const char * name, char ** value)
+bool dds_qget_prop (const dds_qos_t *qos, const char * name, char ** value)
 {
   uint32_t i;
   bool found;
@@ -797,7 +797,7 @@ bool dds_qget_prop (const dds_qos_t * __restrict qos, const char * name, char **
   return found;
 }
 
-bool dds_qget_bprop (const dds_qos_t * __restrict qos, const char * name, void ** value, size_t * sz)
+bool dds_qget_bprop (const dds_qos_t *qos, const char * name, void ** value, size_t * sz)
 {
   uint32_t i;
   bool found;
@@ -821,7 +821,7 @@ bool dds_qget_bprop (const dds_qos_t * __restrict qos, const char * name, void *
   return found;
 }
 
-bool dds_qget_type_consistency (const dds_qos_t * __restrict qos, dds_type_consistency_kind_t *kind,
+bool dds_qget_type_consistency (const dds_qos_t *qos, dds_type_consistency_kind_t *kind,
   bool *ignore_sequence_bounds, bool *ignore_string_bounds, bool *ignore_member_names, bool *prevent_type_widening, bool *force_type_validation)
 {
   if (qos == NULL || !(qos->present & DDSI_QP_TYPE_CONSISTENCY_ENFORCEMENT))
@@ -841,7 +841,7 @@ bool dds_qget_type_consistency (const dds_qos_t * __restrict qos, dds_type_consi
   return true;
 }
 
-bool dds_qget_data_representation (const dds_qos_t * __restrict qos, uint32_t *n, dds_data_representation_id_t **values)
+bool dds_qget_data_representation (const dds_qos_t *qos, uint32_t *n, dds_data_representation_id_t **values)
 {
   if (qos == NULL || !(qos->present & DDSI_QP_DATA_REPRESENTATION))
     return false;
@@ -908,7 +908,7 @@ dds_return_t dds_ensure_valid_data_representation (dds_qos_t *qos, uint32_t allo
 }
 
 
-bool dds_qget_psmx_instances (const dds_qos_t * __restrict qos, uint32_t *n_out, char ***values)
+bool dds_qget_psmx_instances (const dds_qos_t *qos, uint32_t *n_out, char ***values)
 {
   if (qos == NULL || !(qos->present & DDSI_QP_PSMX) || n_out == NULL)
     return false;
@@ -994,7 +994,7 @@ bool dds_qos_has_psmx_instances (const dds_qos_t *qos, const char *psmx_instance
   return found;
 }
 
-bool dds_qget_entity_name (const dds_qos_t * __restrict qos, char **name)
+bool dds_qget_entity_name (const dds_qos_t *qos, char **name)
 {
   if (qos == NULL || name == NULL || !(qos->present & DDSI_QP_ENTITY_NAME))
     return false;

--- a/src/core/ddsc/src/dds_reader.c
+++ b/src/core/ddsc/src/dds_reader.c
@@ -244,7 +244,7 @@ void dds_reader_data_available_cb (struct dds_reader *rd)
   ddsrt_mutex_unlock (&rd->m_entity.m_observers_lock);
 }
 
-static void update_requested_deadline_missed (struct dds_requested_deadline_missed_status * __restrict st, const ddsi_status_cb_data_t *data)
+static void update_requested_deadline_missed (struct dds_requested_deadline_missed_status *st, const ddsi_status_cb_data_t *data)
 {
   st->last_instance_handle = data->handle;
   uint64_t tmp = (uint64_t)data->extra + (uint64_t)st->total_count;
@@ -258,21 +258,21 @@ static void update_requested_deadline_missed (struct dds_requested_deadline_miss
   st->total_count_change = tmp2 > INT32_MAX ? INT32_MAX : tmp2 < INT32_MIN ? INT32_MIN : (int32_t)tmp2;
 }
 
-static void update_requested_incompatible_qos (struct dds_requested_incompatible_qos_status * __restrict st, const ddsi_status_cb_data_t *data)
+static void update_requested_incompatible_qos (struct dds_requested_incompatible_qos_status *st, const ddsi_status_cb_data_t *data)
 {
   st->last_policy_id = data->extra;
   st->total_count++;
   st->total_count_change++;
 }
 
-static void update_sample_lost (struct dds_sample_lost_status * __restrict st, const ddsi_status_cb_data_t *data)
+static void update_sample_lost (struct dds_sample_lost_status *st, const ddsi_status_cb_data_t *data)
 {
   (void) data;
   st->total_count++;
   st->total_count_change++;
 }
 
-static void update_sample_rejected (struct dds_sample_rejected_status * __restrict st, const ddsi_status_cb_data_t *data)
+static void update_sample_rejected (struct dds_sample_rejected_status *st, const ddsi_status_cb_data_t *data)
 {
   st->last_reason = data->extra;
   st->last_instance_handle = data->handle;
@@ -280,7 +280,7 @@ static void update_sample_rejected (struct dds_sample_rejected_status * __restri
   st->total_count_change++;
 }
 
-static void update_liveliness_changed (struct dds_liveliness_changed_status * __restrict st, const ddsi_status_cb_data_t *data)
+static void update_liveliness_changed (struct dds_liveliness_changed_status *st, const ddsi_status_cb_data_t *data)
 {
   DDSRT_STATIC_ASSERT ((uint32_t) DDSI_LIVELINESS_CHANGED_ADD_ALIVE == 0 &&
                        DDSI_LIVELINESS_CHANGED_ADD_ALIVE < DDSI_LIVELINESS_CHANGED_ADD_NOT_ALIVE &&
@@ -324,7 +324,7 @@ static void update_liveliness_changed (struct dds_liveliness_changed_status * __
   }
 }
 
-static void update_subscription_matched (struct dds_subscription_matched_status * __restrict st, const ddsi_status_cb_data_t *data)
+static void update_subscription_matched (struct dds_subscription_matched_status *st, const ddsi_status_cb_data_t *data)
 {
   st->last_publication_handle = data->handle;
   if (data->add) {

--- a/src/core/ddsc/src/dds_rhc.c
+++ b/src/core/ddsc/src/dds_rhc.c
@@ -15,9 +15,9 @@
 #include "dds__loaned_sample.h"
 
 DDS_EXPORT extern inline dds_return_t dds_rhc_associate (struct dds_rhc *rhc, struct dds_reader *reader, const struct ddsi_sertype *type, struct ddsi_tkmap *tkmap);
-DDS_EXPORT extern inline bool dds_rhc_store (struct dds_rhc * __restrict rhc, const struct ddsi_writer_info * __restrict wr_info, struct ddsi_serdata * __restrict sample, struct ddsi_tkmap_instance * __restrict tk);
-DDS_EXPORT extern inline void dds_rhc_unregister_wr (struct dds_rhc * __restrict rhc, const struct ddsi_writer_info * __restrict wr_info);
-DDS_EXPORT extern inline void dds_rhc_relinquish_ownership (struct dds_rhc * __restrict rhc, const uint64_t wr_iid);
+DDS_EXPORT extern inline bool dds_rhc_store (struct dds_rhc *rhc, const struct ddsi_writer_info *wr_info, struct ddsi_serdata *sample, struct ddsi_tkmap_instance *tk);
+DDS_EXPORT extern inline void dds_rhc_unregister_wr (struct dds_rhc *rhc, const struct ddsi_writer_info *wr_info);
+DDS_EXPORT extern inline void dds_rhc_relinquish_ownership (struct dds_rhc *rhc, const uint64_t wr_iid);
 DDS_EXPORT extern inline void dds_rhc_set_qos (struct dds_rhc *rhc, const struct dds_qos *qos);
 DDS_EXPORT extern inline void dds_rhc_free (struct dds_rhc *rhc);
 DDS_EXPORT extern inline int32_t dds_rhc_peek (struct dds_rhc *rhc, int32_t max_samples, uint32_t mask, dds_instance_handle_t handle, struct dds_readcond *cond, dds_read_with_collector_fn_t collect_sample, void *collect_sample_arg);

--- a/src/core/ddsc/src/dds_serdata_default.c
+++ b/src/core/ddsc/src/dds_serdata_default.c
@@ -338,7 +338,7 @@ static bool gen_serdata_key_from_sample (const struct dds_sertype_default *type,
   return gen_serdata_key (type, kh, GSKIK_SAMPLE, (void *) sample);
 }
 
-static bool gen_serdata_key_from_cdr (dds_istream_t * __restrict is, struct dds_serdata_default_key * __restrict kh, const struct dds_sertype_default * __restrict type, const bool just_key)
+static bool gen_serdata_key_from_cdr (dds_istream_t *is, struct dds_serdata_default_key *kh, const struct dds_sertype_default *type, const bool just_key)
 {
   return gen_serdata_key (type, kh, just_key ? GSKIK_CDRKEY : GSKIK_CDRSAMPLE, is);
 }
@@ -514,7 +514,7 @@ static struct ddsi_serdata *serdata_default_from_keyhash_cdr_nokey (const struct
   return fix_serdata_default_nokey(d, tp->c.serdata_basehash);
 }
 
-static void istream_from_serdata_default (dds_istream_t * __restrict s, const struct dds_serdata_default * __restrict d)
+static void istream_from_serdata_default (dds_istream_t *s, const struct dds_serdata_default *d)
 {
   if (d->c.loan != NULL &&
       (d->c.loan->metadata->sample_state == DDS_LOANED_SAMPLE_STATE_SERIALIZED_KEY ||
@@ -538,7 +538,7 @@ static void istream_from_serdata_default (dds_istream_t * __restrict s, const st
   s->m_xcdr_version = ddsi_sertype_enc_id_xcdr_version (d->hdr.identifier);
 }
 
-static void ostream_from_serdata_default (dds_ostream_t * __restrict s, const struct dds_serdata_default * __restrict d)
+static void ostream_from_serdata_default (dds_ostream_t *s, const struct dds_serdata_default *d)
 {
   s->m_buffer = (unsigned char *) d;
   s->m_index = (uint32_t) offsetof (struct dds_serdata_default, data);
@@ -551,7 +551,7 @@ static void ostream_from_serdata_default (dds_ostream_t * __restrict s, const st
   s->m_xcdr_version = ddsi_sertype_enc_id_xcdr_version (d->hdr.identifier);
 }
 
-static void ostream_add_to_serdata_default (dds_ostream_t * __restrict s, struct dds_serdata_default ** __restrict d)
+static void ostream_add_to_serdata_default (dds_ostream_t *s, struct dds_serdata_default **d)
 {
   /* DDSI requires 4 byte alignment */
   const uint32_t pad = dds_cdr_alignto4_clear_and_resize (s, &dds_cdrstream_default_allocator, s->m_xcdr_version);

--- a/src/core/ddsc/src/dds_writer.c
+++ b/src/core/ddsc/src/dds_writer.c
@@ -53,7 +53,7 @@ static dds_return_t dds_writer_status_validate (uint32_t mask)
   return (mask & ~DDS_WRITER_STATUS_MASK) ? DDS_RETCODE_BAD_PARAMETER : DDS_RETCODE_OK;
 }
 
-static void update_offered_deadline_missed (struct dds_offered_deadline_missed_status * __restrict st, const ddsi_status_cb_data_t *data)
+static void update_offered_deadline_missed (struct dds_offered_deadline_missed_status *st, const ddsi_status_cb_data_t *data)
 {
   st->last_instance_handle = data->handle;
   uint64_t tmp = (uint64_t)data->extra + (uint64_t)st->total_count;
@@ -67,21 +67,21 @@ static void update_offered_deadline_missed (struct dds_offered_deadline_missed_s
   st->total_count_change = tmp2 > INT32_MAX ? INT32_MAX : tmp2 < INT32_MIN ? INT32_MIN : (int32_t)tmp2;
 }
 
-static void update_offered_incompatible_qos (struct dds_offered_incompatible_qos_status * __restrict st, const ddsi_status_cb_data_t *data)
+static void update_offered_incompatible_qos (struct dds_offered_incompatible_qos_status *st, const ddsi_status_cb_data_t *data)
 {
   st->last_policy_id = data->extra;
   st->total_count++;
   st->total_count_change++;
 }
 
-static void update_liveliness_lost (struct dds_liveliness_lost_status * __restrict st, const ddsi_status_cb_data_t *data)
+static void update_liveliness_lost (struct dds_liveliness_lost_status *st, const ddsi_status_cb_data_t *data)
 {
   (void) data;
   st->total_count++;
   st->total_count_change++;
 }
 
-static void update_publication_matched (struct dds_publication_matched_status * __restrict st, const ddsi_status_cb_data_t *data)
+static void update_publication_matched (struct dds_publication_matched_status *st, const ddsi_status_cb_data_t *data)
 {
   st->last_subscription_handle = data->handle;
   if (data->add) {

--- a/src/core/ddsc/tests/data_avail_stress.c
+++ b/src/core/ddsc/tests/data_avail_stress.c
@@ -54,7 +54,7 @@ struct listener_arg {
 
 static void data_avail (dds_entity_t rd, void *varg)
 {
-  struct listener_arg * const __restrict arg = varg;
+  struct listener_arg * const arg = varg;
   dds_return_t rc;
   Space_Type1 sample;
   void *sampleptr = &sample;

--- a/src/core/ddsc/tests/test_oneliner.c
+++ b/src/core/ddsc/tests/test_oneliner.c
@@ -664,7 +664,7 @@ static bool qos_liveliness (struct oneliner_lex *l, dds_qos_t *q)
   return true;
 }
 
-static bool qos_simple_duration (struct oneliner_lex *l, dds_qos_t *q, void (*set) (dds_qos_t * __restrict q, dds_duration_t dur))
+static bool qos_simple_duration (struct oneliner_lex *l, dds_qos_t *q, void (*set) (dds_qos_t *q, dds_duration_t dur))
 {
   static const struct kvarg k = { "", 0, 0, .arg = read_kvarg_dur };
   int v;

--- a/src/core/ddsc/tests/userdata.c
+++ b/src/core/ddsc/tests/userdata.c
@@ -233,8 +233,8 @@ static uint32_t rw_thread (void *varg)
   static const char *exp_rwud[] = {
     "a", "bc", "def", "",
   };
-  bool (*qget) (const dds_qos_t * __restrict qos, void **value, size_t *sz) = 0;
-  void (*qset) (dds_qos_t * __restrict qos, const void *value, size_t sz) = 0;
+  bool (*qget) (const dds_qos_t *qos, void **value, size_t *sz) = 0;
+  void (*qset) (dds_qos_t *qos, const void *value, size_t sz) = 0;
 
   dds_entity_t dp, tp, ep, grp, rdep, qent = 0, ws;
   dds_return_t rc;

--- a/src/core/ddsi/include/dds/ddsi/ddsi_deliver_locally.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_deliver_locally.h
@@ -51,7 +51,7 @@ struct ddsi_deliver_locally_ops {
 };
 
 /** @component local_delivery */
-dds_return_t ddsi_deliver_locally_allinsync (struct ddsi_domaingv *gv, struct ddsi_entity_common *source_entity, bool source_entity_locked, struct ddsi_local_reader_ary *fastpath_rdary, const struct ddsi_writer_info *wrinfo, const struct ddsi_deliver_locally_ops * __restrict ops, void *vsourceinfo);
+dds_return_t ddsi_deliver_locally_allinsync (struct ddsi_domaingv *gv, struct ddsi_entity_common *source_entity, bool source_entity_locked, struct ddsi_local_reader_ary *fastpath_rdary, const struct ddsi_writer_info *wrinfo, const struct ddsi_deliver_locally_ops *ops, void *vsourceinfo);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsi/include/dds/ddsi/ddsi_rhc.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_rhc.h
@@ -42,9 +42,9 @@ struct ddsi_writer_info
 };
 
 typedef void (*ddsi_rhc_free_t) (struct ddsi_rhc *rhc);
-typedef bool (*ddsi_rhc_store_t) (struct ddsi_rhc * __restrict rhc, const struct ddsi_writer_info * __restrict wrinfo, struct ddsi_serdata * __restrict sample, struct ddsi_tkmap_instance * __restrict tk);
-typedef void (*ddsi_rhc_unregister_wr_t) (struct ddsi_rhc * __restrict rhc, const struct ddsi_writer_info * __restrict wrinfo);
-typedef void (*ddsi_rhc_relinquish_ownership_t) (struct ddsi_rhc * __restrict rhc, const uint64_t wr_iid);
+typedef bool (*ddsi_rhc_store_t) (struct ddsi_rhc *rhc, const struct ddsi_writer_info *wrinfo, struct ddsi_serdata *sample, struct ddsi_tkmap_instance *tk);
+typedef void (*ddsi_rhc_unregister_wr_t) (struct ddsi_rhc *rhc, const struct ddsi_writer_info *wrinfo);
+typedef void (*ddsi_rhc_relinquish_ownership_t) (struct ddsi_rhc *rhc, const uint64_t wr_iid);
 typedef void (*ddsi_rhc_set_qos_t) (struct ddsi_rhc *rhc, const struct dds_qos *qos);
 
 struct ddsi_rhc_ops {
@@ -60,7 +60,7 @@ struct ddsi_rhc {
 };
 
 /** @component rhc_if */
-inline bool ddsi_rhc_store (struct ddsi_rhc * __restrict rhc, const struct ddsi_writer_info * __restrict wrinfo, struct ddsi_serdata * __restrict sample, struct ddsi_tkmap_instance * __restrict tk) {
+inline bool ddsi_rhc_store (struct ddsi_rhc *rhc, const struct ddsi_writer_info *wrinfo, struct ddsi_serdata *sample, struct ddsi_tkmap_instance *tk) {
   return rhc->ops->store (rhc, wrinfo, sample, tk);
 }
 

--- a/src/core/ddsi/include/dds/ddsi/ddsi_statistics.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_statistics.h
@@ -21,10 +21,10 @@ struct ddsi_reader;
 struct ddsi_writer;
 
 /** @component ddsi_statistics */
-void ddsi_get_writer_stats (struct ddsi_writer *wr, uint64_t * __restrict rexmit_bytes, uint32_t * __restrict throttle_count, uint64_t * __restrict time_throttled, uint64_t * __restrict time_retransmit);
+void ddsi_get_writer_stats (struct ddsi_writer *wr, uint64_t *rexmit_bytes, uint32_t *throttle_count, uint64_t *time_throttled, uint64_t *time_retransmit);
 
 /** @component ddsi_statistics */
-void ddsi_get_reader_stats (struct ddsi_reader *rd, uint64_t * __restrict discarded_bytes);
+void ddsi_get_reader_stats (struct ddsi_reader *rd, uint64_t *discarded_bytes);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsi/src/ddsi__deliver_locally.h
+++ b/src/core/ddsi/src/ddsi__deliver_locally.h
@@ -30,7 +30,7 @@ struct ddsi_deliver_locally_ops;
 
 /** @component local_delivery */
 dds_return_t ddsi_deliver_locally_one (struct ddsi_domaingv *gv, struct ddsi_entity_common *source_entity, bool source_entity_locked, const ddsi_guid_t *rdguid,
-    const struct ddsi_writer_info *wrinfo, const struct ddsi_deliver_locally_ops * __restrict ops, void *vsourceinfo);
+    const struct ddsi_writer_info *wrinfo, const struct ddsi_deliver_locally_ops *ops, void *vsourceinfo);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsi/src/ddsi__plist.h
+++ b/src/core/ddsi/src/ddsi__plist.h
@@ -343,7 +343,7 @@ void ddsi_plist_addtomsg_bo (struct ddsi_xmsg *m, const ddsi_plist_t *ps, uint64
  *
  * @returns number of bytes written to buf, excluding a terminating 0.
  */
-size_t ddsi_plist_print (char * __restrict buf, size_t bufsize, const ddsi_plist_t *plist);
+size_t ddsi_plist_print (char *buf, size_t bufsize, const ddsi_plist_t *plist);
 
 struct ddsi_rsample_info;
 

--- a/src/core/ddsi/src/ddsi__plist_generic.h
+++ b/src/core/ddsi/src/ddsi__plist_generic.h
@@ -47,37 +47,37 @@ enum ddsi_pserop {
 } ddsrt_attribute_packed;
 
 /** @component parameter_list */
-void ddsi_plist_fini_generic (void * __restrict dst, const enum ddsi_pserop *desc, bool aliased);
+void ddsi_plist_fini_generic (void * restrict dst, const enum ddsi_pserop *desc, bool aliased);
 
 /** @component parameter_list */
-void ddsi_plist_ser_generic_size_embeddable (size_t *dstoff, const void *src, size_t srcoff, const enum ddsi_pserop * __restrict desc);
+void ddsi_plist_ser_generic_size_embeddable (size_t *dstoff, const void *src, size_t srcoff, const enum ddsi_pserop *desc);
 
 /** @component parameter_list */
-dds_return_t ddsi_plist_deser_generic (void * __restrict dst, const void * __restrict src, size_t srcsize, bool bswap, const enum ddsi_pserop * __restrict desc);
+dds_return_t ddsi_plist_deser_generic (void * restrict dst, const void *src, size_t srcsize, bool bswap, const enum ddsi_pserop *desc);
 
 /** @component parameter_list */
-dds_return_t ddsi_plist_deser_generic_srcoff (void * __restrict dst, const void * __restrict src, size_t srcsize, size_t *srcoff, bool bswap, const enum ddsi_pserop * __restrict desc);
+dds_return_t ddsi_plist_deser_generic_srcoff (void * restrict dst, const void *src, size_t srcsize, size_t * restrict srcoff, bool bswap, const enum ddsi_pserop *desc);
 
 /** @component parameter_list */
-dds_return_t ddsi_plist_ser_generic_embeddable (char * const data, size_t *dstoff, const void *src, size_t srcoff, const enum ddsi_pserop * __restrict desc, enum ddsrt_byte_order_selector bo);
+dds_return_t ddsi_plist_ser_generic_embeddable (char * const data, size_t * restrict dstoff, const void *src, size_t srcoff, const enum ddsi_pserop *desc, enum ddsrt_byte_order_selector bo);
 
 /** @component parameter_list */
-dds_return_t ddsi_plist_ser_generic (void **dst, size_t *dstsize, const void *src, const enum ddsi_pserop * __restrict desc);
+dds_return_t ddsi_plist_ser_generic (void **dst, size_t *dstsize, const void *src, const enum ddsi_pserop *desc);
 
 /** @component parameter_list */
-dds_return_t ddsi_plist_ser_generic_be (void **dst, size_t *dstsize, const void *src, const enum ddsi_pserop * __restrict desc);
+dds_return_t ddsi_plist_ser_generic_be (void **dst, size_t *dstsize, const void *src, const enum ddsi_pserop *desc);
 
 /** @component parameter_list */
-dds_return_t ddsi_plist_unalias_generic (void * __restrict dst, const enum ddsi_pserop * __restrict desc);
+dds_return_t ddsi_plist_unalias_generic (void * restrict dst, const enum ddsi_pserop *desc);
 
 /** @component parameter_list */
-bool ddsi_plist_equal_generic (const void *srcx, const void *srcy, const enum ddsi_pserop * __restrict desc);
+bool ddsi_plist_equal_generic (const void *srcx, const void *srcy, const enum ddsi_pserop *desc);
 
 /** @component parameter_list */
-size_t ddsi_plist_memsize_generic (const enum ddsi_pserop * __restrict desc);
+size_t ddsi_plist_memsize_generic (const enum ddsi_pserop *desc);
 
 /** @component parameter_list */
-size_t ddsi_plist_print_generic (char * __restrict buf, size_t bufsize, const void * __restrict src, const enum ddsi_pserop * __restrict desc);
+size_t ddsi_plist_print_generic (char * restrict buf, size_t bufsize, const void *src, const enum ddsi_pserop *desc);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsi/src/ddsi__rhc.h
+++ b/src/core/ddsi/src/ddsi__rhc.h
@@ -29,12 +29,12 @@ extern "C" {
 struct dds_qos;
 
 /** @component rhc_if */
-inline void ddsi_rhc_unregister_wr (struct ddsi_rhc * __restrict rhc, const struct ddsi_writer_info * __restrict wrinfo) {
+inline void ddsi_rhc_unregister_wr (struct ddsi_rhc *rhc, const struct ddsi_writer_info *wrinfo) {
   rhc->ops->unregister_wr (rhc, wrinfo);
 }
 
 /** @component rhc_if */
-inline void ddsi_rhc_relinquish_ownership (struct ddsi_rhc * __restrict rhc, const uint64_t wr_iid) {
+inline void ddsi_rhc_relinquish_ownership (struct ddsi_rhc *rhc, const uint64_t wr_iid) {
   rhc->ops->relinquish_ownership (rhc, wr_iid);
 }
 

--- a/src/core/ddsi/src/ddsi__xqos.h
+++ b/src/core/ddsi/src/ddsi__xqos.h
@@ -94,7 +94,7 @@ void ddsi_xqos_log (uint32_t cat, const struct ddsrt_log_cfg *logcfg, const dds_
  *
  * @returns number of bytes written to buf, excluding a terminating 0.
  */
-size_t ddsi_xqos_print (char * __restrict buf, size_t bufsize, const dds_qos_t *xqos);
+size_t ddsi_xqos_print (char *buf, size_t bufsize, const dds_qos_t *xqos);
 
 /**
  * @brief Check if "xqos" includes properties with a name starting with "nameprefix"

--- a/src/core/ddsi/src/ddsi_deliver_locally.c
+++ b/src/core/ddsi/src/ddsi_deliver_locally.c
@@ -67,7 +67,7 @@ static void free_sample_after_store (struct ddsi_domaingv *gv, struct ddsi_serda
   }
 }
 
-static void type_sample_cache_init (struct type_sample_cache * __restrict tsc)
+static void type_sample_cache_init (struct type_sample_cache *tsc)
 {
   tsc->n = 0;
   ddsrt_avl_init (&tsc_large_td, &tsc->overflow);
@@ -81,7 +81,7 @@ static void free_large_entry (void *vnode, void *varg)
   ddsrt_free (e);
 }
 
-static void type_sample_cache_fini (struct type_sample_cache * __restrict tsc, struct ddsi_domaingv *gv)
+static void type_sample_cache_fini (struct type_sample_cache *tsc, struct ddsi_domaingv *gv)
 {
   for (uint32_t i = 0; i < tsc->n && i < TYPE_SAMPLE_CACHE_SIZE; i++)
     if (tsc->types[i] && tsc->samples[i].tk)
@@ -90,7 +90,7 @@ static void type_sample_cache_fini (struct type_sample_cache * __restrict tsc, s
   ddsrt_avl_free_arg (&tsc_large_td, &tsc->overflow, free_large_entry, gv);
 }
 
-static bool type_sample_cache_lookup (struct ddsi_serdata ** __restrict sample, struct ddsi_tkmap_instance ** __restrict tk, struct type_sample_cache * __restrict tsc, const struct ddsi_sertype *type)
+static bool type_sample_cache_lookup (struct ddsi_serdata **sample, struct ddsi_tkmap_instance **tk, struct type_sample_cache *tsc, const struct ddsi_sertype *type)
 {
   /* linear scan of an array of pointers should be pretty fast */
   for (uint32_t i = 0; i < tsc->n && i < TYPE_SAMPLE_CACHE_SIZE; i++)
@@ -113,7 +113,7 @@ static bool type_sample_cache_lookup (struct ddsi_serdata ** __restrict sample, 
   return false;
 }
 
-static void type_sample_cache_store (struct type_sample_cache * __restrict tsc, const struct ddsi_sertype *type, struct ddsi_serdata *sample, struct ddsi_tkmap_instance *tk)
+static void type_sample_cache_store (struct type_sample_cache *tsc, const struct ddsi_sertype *type, struct ddsi_serdata *sample, struct ddsi_tkmap_instance *tk)
 {
   if (tsc->n < TYPE_SAMPLE_CACHE_SIZE)
   {
@@ -132,7 +132,7 @@ static void type_sample_cache_store (struct type_sample_cache * __restrict tsc, 
   tsc->n++;
 }
 
-dds_return_t ddsi_deliver_locally_one (struct ddsi_domaingv *gv, struct ddsi_entity_common *source_entity, bool source_entity_locked, const ddsi_guid_t *rdguid, const struct ddsi_writer_info *wrinfo, const struct ddsi_deliver_locally_ops * __restrict ops, void *vsourceinfo)
+dds_return_t ddsi_deliver_locally_one (struct ddsi_domaingv *gv, struct ddsi_entity_common *source_entity, bool source_entity_locked, const ddsi_guid_t *rdguid, const struct ddsi_writer_info *wrinfo, const struct ddsi_deliver_locally_ops *ops, void *vsourceinfo)
 {
   struct ddsi_reader *rd = ddsi_entidx_lookup_reader_guid (gv->entity_index, rdguid);
   if (rd == NULL)
@@ -165,7 +165,7 @@ dds_return_t ddsi_deliver_locally_one (struct ddsi_domaingv *gv, struct ddsi_ent
   return DDS_RETCODE_OK;
 }
 
-static dds_return_t deliver_locally_slowpath (struct ddsi_domaingv *gv, struct ddsi_entity_common *source_entity, bool source_entity_locked, const struct ddsi_writer_info *wrinfo, const struct ddsi_deliver_locally_ops * __restrict ops, void *vsourceinfo)
+static dds_return_t deliver_locally_slowpath (struct ddsi_domaingv *gv, struct ddsi_entity_common *source_entity, bool source_entity_locked, const struct ddsi_writer_info *wrinfo, const struct ddsi_deliver_locally_ops *ops, void *vsourceinfo)
 {
   /* When deleting, pwr is no longer accessible via the hash
      tables, and consequently, a reader may be deleted without
@@ -209,7 +209,7 @@ static dds_return_t deliver_locally_slowpath (struct ddsi_domaingv *gv, struct d
   return DDS_RETCODE_OK;
 }
 
-static dds_return_t deliver_locally_fastpath (struct ddsi_domaingv *gv, struct ddsi_entity_common *source_entity, bool source_entity_locked, struct ddsi_local_reader_ary *fastpath_rdary, const struct ddsi_writer_info *wrinfo, const struct ddsi_deliver_locally_ops * __restrict ops, void *vsourceinfo)
+static dds_return_t deliver_locally_fastpath (struct ddsi_domaingv *gv, struct ddsi_entity_common *source_entity, bool source_entity_locked, struct ddsi_local_reader_ary *fastpath_rdary, const struct ddsi_writer_info *wrinfo, const struct ddsi_deliver_locally_ops *ops, void *vsourceinfo)
 {
   struct ddsi_reader ** const rdary = fastpath_rdary->rdary;
   uint32_t i = 0;
@@ -243,7 +243,7 @@ static dds_return_t deliver_locally_fastpath (struct ddsi_domaingv *gv, struct d
   return DDS_RETCODE_OK;
 }
 
-dds_return_t ddsi_deliver_locally_allinsync (struct ddsi_domaingv *gv, struct ddsi_entity_common *source_entity, bool source_entity_locked, struct ddsi_local_reader_ary *fastpath_rdary, const struct ddsi_writer_info *wrinfo, const struct ddsi_deliver_locally_ops * __restrict ops, void *vsourceinfo)
+dds_return_t ddsi_deliver_locally_allinsync (struct ddsi_domaingv *gv, struct ddsi_entity_common *source_entity, bool source_entity_locked, struct ddsi_local_reader_ary *fastpath_rdary, const struct ddsi_writer_info *wrinfo, const struct ddsi_deliver_locally_ops *ops, void *vsourceinfo)
 {
   dds_return_t rc;
   /* FIXME: Retry loop for re-delivery of rejected reliable samples is a bad hack

--- a/src/core/ddsi/src/ddsi_plist.c
+++ b/src/core/ddsi/src/ddsi_plist.c
@@ -120,16 +120,16 @@ struct piddesc {
        will fit */
     const enum ddsi_pserop desc[12];
     struct {
-      dds_return_t (*deser) (void * __restrict dst, struct flagset *flagset, uint64_t flag, const struct dd * __restrict dd, struct ddsi_domaingv const * const gv);
+      dds_return_t (*deser) (void * restrict dst, struct flagset *flagset, uint64_t flag, const struct dd *dd, struct ddsi_domaingv const * const gv);
       dds_return_t (*ser) (struct ddsi_xmsg *xmsg, ddsi_parameterid_t pid, const void *src, size_t srcoff, enum ddsrt_byte_order_selector bo, enum ddsi_plist_context_kind context_kind);
-      dds_return_t (*unalias) (void * __restrict dst, size_t * __restrict dstoff, bool gen_seq_aliased);
-      dds_return_t (*fini) (void * __restrict dst, size_t * __restrict dstoff, struct flagset *flagset, uint64_t flag);
+      dds_return_t (*unalias) (void * restrict dst, size_t * restrict dstoff, bool gen_seq_aliased);
+      dds_return_t (*fini) (void * restrict dst, size_t * restrict dstoff, struct flagset *flagset, uint64_t flag);
       dds_return_t (*valid) (const void *src, size_t srcoff);
       bool (*equal) (const void *srcx, const void *srcy, size_t srcoff);
-      bool (*print) (char * __restrict *buf, size_t * __restrict bufsize, const void *src, size_t srcoff);
+      bool (*print) (char * restrict *buf, size_t * restrict bufsize, const void *src, size_t srcoff);
     } f;
   } op;
-  dds_return_t (*deser_validate_xform) (void * __restrict dst, const struct dd * __restrict dd);
+  dds_return_t (*deser_validate_xform) (void * restrict dst, const struct dd *dd);
 };
 
 enum do_locator_result {
@@ -147,13 +147,13 @@ static enum do_locator_result do_locator (ddsi_locators_t *ls, uint64_t present,
 static dds_return_t final_validation_qos (const dds_qos_t *dest, ddsi_protocol_version_t protocol_version, ddsi_vendorid_t vendorid, bool *dursvc_accepted_allzero, bool strict);
 static int partitions_equal (const void *srca, const void *srcb, size_t off);
 static dds_return_t ddsi_xqos_valid_strictness (const struct ddsrt_log_cfg *logcfg, const dds_qos_t *xqos, bool strict);
-static dds_return_t unalias_generic (void * __restrict dst, size_t * __restrict dstoff, bool gen_seq_aliased, const enum ddsi_pserop * __restrict desc);
-static dds_return_t deser_generic (void * __restrict dst, struct flagset *flagset, uint64_t flag, const struct dd * __restrict dd, const enum ddsi_pserop * __restrict desc);
-static dds_return_t ser_generic (struct ddsi_xmsg *xmsg, ddsi_parameterid_t pid, const void *src, size_t srcoff, const enum ddsi_pserop * __restrict desc, enum ddsrt_byte_order_selector bo);
-static bool equal_generic (const void *srcx, const void *srcy, size_t srcoff, const enum ddsi_pserop * __restrict desc);
-static dds_return_t fini_generic (void * __restrict dst, size_t * __restrict dstoff, struct flagset *flagset, uint64_t flag, const enum ddsi_pserop * __restrict desc);
-static dds_return_t valid_generic (const void *src, size_t srcoff, const enum ddsi_pserop * __restrict desc);
-static bool print_generic (char * __restrict *buf, size_t * __restrict bufsize, const void *src, size_t srcoff, const enum ddsi_pserop * __restrict desc);
+static dds_return_t unalias_generic (void * restrict dst, size_t * restrict dstoff, bool gen_seq_aliased, const enum ddsi_pserop *desc);
+static dds_return_t deser_generic (void * restrict dst, struct flagset *flagset, uint64_t flag, const struct dd *dd, const enum ddsi_pserop *desc);
+static dds_return_t ser_generic (struct ddsi_xmsg *xmsg, ddsi_parameterid_t pid, const void *src, size_t srcoff, const enum ddsi_pserop *desc, enum ddsrt_byte_order_selector bo);
+static bool equal_generic (const void *srcx, const void *srcy, size_t srcoff, const enum ddsi_pserop *desc);
+static dds_return_t fini_generic (void * restrict dst, size_t * restrict dstoff, struct flagset *flagset, uint64_t flag, const enum ddsi_pserop *desc);
+static dds_return_t valid_generic (const void *src, size_t srcoff, const enum ddsi_pserop *desc);
+static bool print_generic (char * restrict *buf, size_t * restrict bufsize, const void *src, size_t srcoff, const enum ddsi_pserop *desc);
 
 static size_t pserop_seralign(enum ddsi_pserop op)
 {
@@ -211,19 +211,19 @@ static size_t align8(const size_t off)
   return alignN(off, 8);
 }
 
-static void *deser_generic_dst (void * __restrict dst, size_t *dstoff, const size_t align)
+static void *deser_generic_dst (void * restrict dst, size_t * restrict dstoff, const size_t align)
 {
   *dstoff = alignN(*dstoff, align);
   return (char *) dst + *dstoff;
 }
 
-static const void *deser_generic_src (const void * __restrict src, size_t *srcoff, const size_t align)
+static const void *deser_generic_src (const void * restrict src, size_t * restrict srcoff, const size_t align)
 {
   *srcoff = alignN(*srcoff, align);
   return (const char *) src + *srcoff;
 }
 
-static void *ser_generic_aligned (char * __restrict p, size_t * __restrict off, const size_t align)
+static void *ser_generic_aligned (char * restrict p, size_t * restrict off, const size_t align)
 {
   const size_t off1 = alignN(*off, align);
   size_t pad = off1 - *off;
@@ -234,22 +234,22 @@ static void *ser_generic_aligned (char * __restrict p, size_t * __restrict off, 
   return dst;
 }
 
-static void *ser_generic_align2(char * __restrict p, size_t * __restrict off)
+static void *ser_generic_align2(char * restrict p, size_t * restrict off)
 {
   return ser_generic_aligned(p, off, 2);
 }
 
-static void *ser_generic_align4(char * __restrict p, size_t * __restrict off)
+static void *ser_generic_align4(char * restrict p, size_t * restrict off)
 {
   return ser_generic_aligned(p, off, 4);
 }
 
-static void *ser_generic_align8(char * __restrict p, size_t * __restrict off)
+static void *ser_generic_align8(char * restrict p, size_t * restrict off)
 {
   return ser_generic_aligned(p, off, 8);
 }
 
-static dds_return_t deser_uint16 (uint16_t *dst, const struct dd * __restrict dd, size_t * __restrict off)
+static dds_return_t deser_uint16 (uint16_t * restrict dst, const struct dd *dd, size_t * restrict off)
 {
   size_t off1 = (*off + 1) & ~(size_t)1;
   uint16_t tmp;
@@ -263,7 +263,7 @@ static dds_return_t deser_uint16 (uint16_t *dst, const struct dd * __restrict dd
   return 0;
 }
 
-static dds_return_t deser_uint32 (uint32_t *dst, const struct dd * __restrict dd, size_t * __restrict off)
+static dds_return_t deser_uint32 (uint32_t * restrict dst, const struct dd *dd, size_t * restrict off)
 {
   size_t off1 = (*off + 3) & ~(size_t)3;
   uint32_t tmp;
@@ -277,7 +277,7 @@ static dds_return_t deser_uint32 (uint32_t *dst, const struct dd * __restrict dd
   return 0;
 }
 
-static dds_return_t deser_int16 (int16_t *dst, const struct dd * __restrict dd, size_t * __restrict off)
+static dds_return_t deser_int16 (int16_t * restrict dst, const struct dd *dd, size_t * restrict off)
 {
   size_t off1 = (*off + 1) & ~(size_t)1;
   int16_t tmp;
@@ -291,7 +291,7 @@ static dds_return_t deser_int16 (int16_t *dst, const struct dd * __restrict dd, 
   return 0;
 }
 
-static dds_return_t deser_int64 (int64_t *dst, const struct dd * __restrict dd, size_t * __restrict off)
+static dds_return_t deser_int64 (int64_t * restrict dst, const struct dd *dd, size_t * restrict off)
 {
   size_t off1 = (*off + 7) & ~(size_t)7;
   int64_t tmp;
@@ -306,10 +306,10 @@ static dds_return_t deser_int64 (int64_t *dst, const struct dd * __restrict dd, 
 }
 
 /* Returns true if buffer not yet exhausted, false otherwise */
-static bool prtf (char * __restrict *buf, size_t * __restrict bufsize, const char *fmt, ...)
+static bool prtf (char * restrict *buf, size_t * restrict bufsize, const char *fmt, ...)
   ddsrt_attribute_format_printf(3, 4);
 
-static bool prtf (char * __restrict *buf, size_t * __restrict bufsize, const char *fmt, ...)
+static bool prtf (char * restrict *buf, size_t * restrict bufsize, const char *fmt, ...)
 {
   va_list ap;
   if (*bufsize == 0)
@@ -336,7 +336,7 @@ static bool prtf (char * __restrict *buf, size_t * __restrict bufsize, const cha
   }
 }
 
-static dds_return_t deser_reliability (void * __restrict dst, struct flagset *flagset, uint64_t flag, const struct dd * __restrict dd, struct ddsi_domaingv const * const gv)
+static dds_return_t deser_reliability (void * restrict dst, struct flagset *flagset, uint64_t flag, const struct dd *dd, struct ddsi_domaingv const * const gv)
 {
   DDSRT_STATIC_ASSERT (DDS_EXTERNAL_RELIABILITY_BEST_EFFORT == 1 && DDS_EXTERNAL_RELIABILITY_RELIABLE == 2 &&
                        DDS_RELIABILITY_BEST_EFFORT == 0 && DDS_RELIABILITY_RELIABLE == 1);
@@ -389,13 +389,13 @@ static bool equal_reliability (const void *srcx, const void *srcy, size_t srcoff
   return x->kind == y->kind && x->max_blocking_time == y->max_blocking_time;
 }
 
-static bool print_reliability (char * __restrict *buf, size_t * __restrict bufsize, const void *src, size_t srcoff)
+static bool print_reliability (char * restrict *buf, size_t * restrict bufsize, const void *src, size_t srcoff)
 {
   dds_reliability_qospolicy_t const * const x = deser_generic_src (src, &srcoff, plist_alignof (dds_reliability_qospolicy_t));
   return prtf (buf, bufsize, "%d:%"PRId64, (int) x->kind, x->max_blocking_time);
 }
 
-static dds_return_t deser_statusinfo (void * __restrict dst, struct flagset *flagset, uint64_t flag, const struct dd * __restrict dd, struct ddsi_domaingv const * const gv)
+static dds_return_t deser_statusinfo (void * restrict dst, struct flagset *flagset, uint64_t flag, const struct dd *dd, struct ddsi_domaingv const * const gv)
 {
   size_t srcoff = 0, dstoff = 0;
   uint32_t * const x = deser_generic_dst (dst, &dstoff, plist_alignof (dds_reliability_qospolicy_t));
@@ -420,13 +420,13 @@ static dds_return_t ser_statusinfo (struct ddsi_xmsg *xmsg, ddsi_parameterid_t p
   return 0;
 }
 
-static bool print_statusinfo (char * __restrict *buf, size_t * __restrict bufsize, const void *src, size_t srcoff)
+static bool print_statusinfo (char * restrict *buf, size_t * restrict bufsize, const void *src, size_t srcoff)
 {
   uint32_t const * const x = deser_generic_src (src, &srcoff, plist_alignof (uint32_t));
   return prtf (buf, bufsize, "%"PRIx32, *x);
 }
 
-static dds_return_t deser_locator (void * __restrict dst, struct flagset *flagset, uint64_t flag, const struct dd * __restrict dd, struct ddsi_domaingv const * const gv)
+static dds_return_t deser_locator (void * restrict dst, struct flagset *flagset, uint64_t flag, const struct dd *dd, struct ddsi_domaingv const * const gv)
 {
   size_t srcoff = 0, dstoff = 0;
   ddsi_locators_t * const x = deser_generic_dst (dst, &dstoff, plist_alignof (ddsi_locators_t));
@@ -468,7 +468,7 @@ static dds_return_t ser_locator (struct ddsi_xmsg *xmsg, ddsi_parameterid_t pid,
   return 0;
 }
 
-static dds_return_t unalias_locator (void * __restrict dst, size_t * __restrict dstoff, bool gen_seq_aliased)
+static dds_return_t unalias_locator (void * restrict dst, size_t * restrict dstoff, bool gen_seq_aliased)
 {
   ddsi_locators_t * const x = deser_generic_dst (dst, dstoff, plist_alignof (ddsi_locators_t));
   ddsi_locators_t newlocs = { .n = x->n, .first = NULL, .last = NULL };
@@ -487,7 +487,7 @@ static dds_return_t unalias_locator (void * __restrict dst, size_t * __restrict 
   return 0;
 }
 
-static dds_return_t fini_locator (void * __restrict dst, size_t * __restrict dstoff, struct flagset *flagset, uint64_t flag)
+static dds_return_t fini_locator (void * restrict dst, size_t * restrict dstoff, struct flagset *flagset, uint64_t flag)
 {
   ddsi_locators_t * const x = deser_generic_dst (dst, dstoff, plist_alignof (ddsi_locators_t));
   if (!(*flagset->aliased & flag))
@@ -502,7 +502,7 @@ static dds_return_t fini_locator (void * __restrict dst, size_t * __restrict dst
   return 0;
 }
 
-static const enum ddsi_pserop* pserop_advance (const enum ddsi_pserop * __restrict desc)
+static const enum ddsi_pserop* pserop_advance (const enum ddsi_pserop *desc)
 {
   /* Should not start on an end. */
   assert(*desc != XSTOP);
@@ -524,7 +524,7 @@ static const enum ddsi_pserop* pserop_advance (const enum ddsi_pserop * __restri
   return (desc + 1);
 }
 
-static bool print_locator (char * __restrict *buf, size_t * __restrict bufsize, const void *src, size_t srcoff)
+static bool print_locator (char * restrict *buf, size_t * restrict bufsize, const void *src, size_t srcoff)
 {
   ddsi_locators_t const * const x = deser_generic_src (src, &srcoff, plist_alignof (ddsi_locators_t));
   const char *sep = "";
@@ -539,7 +539,7 @@ static bool print_locator (char * __restrict *buf, size_t * __restrict bufsize, 
   return prtf (buf, bufsize, "}");
 }
 
-static dds_return_t deser_type_consistency (void * __restrict dst, struct flagset *flagset, uint64_t flag, const struct dd * __restrict dd, struct ddsi_domaingv const * const gv)
+static dds_return_t deser_type_consistency (void * restrict dst, struct flagset *flagset, uint64_t flag, const struct dd *dd, struct ddsi_domaingv const * const gv)
 {
   DDSRT_STATIC_ASSERT (DDS_TYPE_CONSISTENCY_DISALLOW_TYPE_COERCION == 0 && DDS_TYPE_CONSISTENCY_ALLOW_TYPE_COERCION == 1);
   size_t srcoff = 0, dstoff = 0;
@@ -624,7 +624,7 @@ static bool equal_type_consistency (const void *srcx, const void *srcy, size_t s
     && x->force_type_validation == y->force_type_validation;
 }
 
-static bool print_type_consistency (char * __restrict *buf, size_t * __restrict bufsize, const void *src, size_t srcoff)
+static bool print_type_consistency (char * restrict *buf, size_t * restrict bufsize, const void *src, size_t srcoff)
 {
   dds_type_consistency_enforcement_qospolicy_t const * const x = deser_generic_src (src, &srcoff, plist_alignof (dds_type_consistency_enforcement_qospolicy_t));
   return prtf (buf, bufsize, "%d:%d%d%d%d%d", (int) x->kind, x->ignore_sequence_bounds, x->ignore_string_bounds, x->ignore_member_names, x->prevent_type_widening, x->force_type_validation);
@@ -644,7 +644,7 @@ static dds_return_t validate_liveliness_kind (uint32_t kind)
   return DDS_RETCODE_BAD_PARAMETER;
 }
 
-static dds_return_t deser_liveliness (void * __restrict dst, struct flagset *flagset, uint64_t flag, const struct dd * __restrict dd, struct ddsi_domaingv const * const gv)
+static dds_return_t deser_liveliness (void * restrict dst, struct flagset *flagset, uint64_t flag, const struct dd *dd, struct ddsi_domaingv const * const gv)
 {
   (void) flag; (void) gv;
   size_t srcoff = 0, dstoff = 0;
@@ -719,14 +719,14 @@ static bool equal_liveliness (const void *srcx, const void *srcy, size_t srcoff)
   return equal_generic (srcx, srcy, srcoff, desc_liveliness);
 }
 
-static bool print_liveliness (char * __restrict *buf, size_t * __restrict bufsize, const void *src, size_t srcoff)
+static bool print_liveliness (char * restrict *buf, size_t * restrict bufsize, const void *src, size_t srcoff)
 {
   return print_generic (buf, bufsize, src, srcoff, desc_liveliness);
 }
 
 static const enum ddsi_pserop desc_data_representation[] =  { XQ, Xs, XSTOP, XSTOP };
 
-static dds_return_t deser_data_representation (void * __restrict dst, struct flagset *flagset, uint64_t flag, const struct dd * __restrict dd, struct ddsi_domaingv const * const gv)
+static dds_return_t deser_data_representation (void * restrict dst, struct flagset *flagset, uint64_t flag, const struct dd *dd, struct ddsi_domaingv const * const gv)
 {
   size_t srcoff = 0, dstoff = 0;
   dds_data_representation_qospolicy_t * const x = deser_generic_dst (dst, &dstoff, plist_alignof (dds_data_representation_qospolicy_t));
@@ -771,17 +771,17 @@ static bool equal_data_representation (const void *srcx, const void *srcy, size_
   return equal_generic (srcx, srcy, srcoff, desc_data_representation);
 }
 
-static dds_return_t unalias_data_representation (void * __restrict dst, size_t * __restrict dstoff, bool gen_seq_aliased)
+static dds_return_t unalias_data_representation (void * restrict dst, size_t * restrict dstoff, bool gen_seq_aliased)
 {
   return unalias_generic (dst, dstoff, gen_seq_aliased, desc_data_representation);
 }
 
-static dds_return_t fini_data_representation (void * __restrict dst, size_t * __restrict dstoff, struct flagset *flagset, uint64_t flag)
+static dds_return_t fini_data_representation (void * restrict dst, size_t * restrict dstoff, struct flagset *flagset, uint64_t flag)
 {
   return fini_generic (dst, dstoff, flagset, flag, desc_data_representation);
 }
 
-static bool print_data_representation (char * __restrict *buf, size_t * __restrict bufsize, const void *src, size_t srcoff)
+static bool print_data_representation (char * restrict *buf, size_t * restrict bufsize, const void *src, size_t srcoff)
 {
   dds_data_representation_qospolicy_t const * const x = deser_generic_src (src, &srcoff, plist_alignof (dds_data_representation_qospolicy_t));
   prtf (buf, bufsize, "%"PRIu32"(", x->value.n);
@@ -796,7 +796,7 @@ static bool print_data_representation (char * __restrict *buf, size_t * __restri
 
 #ifdef DDS_HAS_TYPELIB
 
-static dds_return_t deser_type_information (void * __restrict dst, struct flagset *flagset, uint64_t flag, const struct dd * __restrict dd, struct ddsi_domaingv const * const gv)
+static dds_return_t deser_type_information (void * restrict dst, struct flagset *flagset, uint64_t flag, const struct dd *dd, struct ddsi_domaingv const * const gv)
 {
   (void) gv;
   size_t dstoff = 0;
@@ -853,7 +853,7 @@ static bool equal_type_information (const void *srcx, const void *srcy, size_t s
   return ddsi_typeinfo_equal (*x, *y, DDSI_TYPE_INCLUDE_DEPS);
 }
 
-static dds_return_t unalias_type_information (void * __restrict dst, size_t * __restrict dstoff, bool gen_seq_aliased)
+static dds_return_t unalias_type_information (void * restrict dst, size_t * restrict dstoff, bool gen_seq_aliased)
 {
   ddsi_typeinfo_t const * * x = deser_generic_dst (dst, dstoff, plist_alignof (ddsi_typeinfo_t *));
   ddsi_typeinfo_t * new_type_info = ddsi_typeinfo_dup (*x);
@@ -863,7 +863,7 @@ static dds_return_t unalias_type_information (void * __restrict dst, size_t * __
   return 0;
 }
 
-static dds_return_t fini_type_information (void * __restrict dst, size_t * __restrict dstoff, struct flagset *flagset, uint64_t flag)
+static dds_return_t fini_type_information (void * restrict dst, size_t * restrict dstoff, struct flagset *flagset, uint64_t flag)
 {
   ddsi_typeinfo_t const * const * x = deser_generic_src (dst, dstoff, plist_alignof (ddsi_typeinfo_t *));
   if ((*flagset->present & flag) && !(*flagset->aliased & flag))
@@ -874,7 +874,7 @@ static dds_return_t fini_type_information (void * __restrict dst, size_t * __res
   return 0;
 }
 
-static bool print_type_information (char * __restrict *buf, size_t * __restrict bufsize, const void *src, size_t srcoff)
+static bool print_type_information (char * restrict *buf, size_t * restrict bufsize, const void *src, size_t srcoff)
 {
   ddsi_typeinfo_t const * const * x = deser_generic_src (src, &srcoff, plist_alignof (ddsi_typeinfo_t *));
   struct ddsi_typeid_str tpstrm, tpstrc;
@@ -894,7 +894,7 @@ static bool print_type_information (char * __restrict *buf, size_t * __restrict 
 // stand in for the actual type.
 enum xe3_prototype { XE3_PROTO_0, XE3_PROTO_1, XE3_PROTO_2, XE3_PROTO_3 };
 
-static size_t ser_generic_srcsize (const enum ddsi_pserop * __restrict desc)
+static size_t ser_generic_srcsize (const enum ddsi_pserop *desc)
 {
   size_t srcoff = 0, srcalign = 0;
 #define SIMPLE(basecase_, type_) do {                          \
@@ -931,12 +931,12 @@ static size_t ser_generic_srcsize (const enum ddsi_pserop * __restrict desc)
 #undef SIMPLE
 }
 
-size_t ddsi_plist_memsize_generic (const enum ddsi_pserop * __restrict desc)
+size_t ddsi_plist_memsize_generic (const enum ddsi_pserop *desc)
 {
   return ser_generic_srcsize (desc);
 }
 
-static bool fini_generic_embeddable (void * __restrict dst, size_t * __restrict dstoff, const enum ddsi_pserop *desc, const enum ddsi_pserop * const desc_end, bool aliased)
+static bool fini_generic_embeddable (void * restrict dst, size_t * restrict dstoff, const enum ddsi_pserop *desc, const enum ddsi_pserop * const desc_end, bool aliased)
 {
   bool freed = false;
 #define COMPLEX(basecase_, type_, cleanup_unaliased_, cleanup_always_) do { \
@@ -1014,7 +1014,7 @@ static size_t pserop_memalign (enum ddsi_pserop op)
   return 0;
 }
 
-static dds_return_t deser_generic_r (void * __restrict dst, size_t * __restrict dstoff, struct flagset *flagset, uint64_t flag, const struct dd * __restrict dd, size_t * __restrict srcoff, const enum ddsi_pserop * __restrict desc)
+static dds_return_t deser_generic_r (void * restrict dst, size_t * restrict dstoff, struct flagset *flagset, uint64_t flag, const struct dd *dd, size_t * restrict srcoff, const enum ddsi_pserop *desc)
 {
   enum ddsi_pserop const * const desc_in = desc;
   size_t dstoff_in = *dstoff;
@@ -1205,7 +1205,7 @@ fail:
   return DDS_RETCODE_BAD_PARAMETER;
 }
 
-static dds_return_t deser_generic (void * __restrict dst, struct flagset *flagset, uint64_t flag, const struct dd * __restrict dd, const enum ddsi_pserop * __restrict desc)
+static dds_return_t deser_generic (void * restrict dst, struct flagset *flagset, uint64_t flag, const struct dd *dd, const enum ddsi_pserop *desc)
 {
   size_t srcoff = 0, dstoff = 0;
   dds_return_t ret;
@@ -1218,7 +1218,7 @@ static dds_return_t deser_generic (void * __restrict dst, struct flagset *flagse
   return ret;
 }
 
-dds_return_t ddsi_plist_deser_generic_srcoff (void * __restrict dst, const void * __restrict src, size_t srcsize, size_t *srcoff, bool bswap, const enum ddsi_pserop * __restrict desc)
+dds_return_t ddsi_plist_deser_generic_srcoff (void * restrict dst, const void * restrict src, size_t srcsize, size_t * restrict srcoff, bool bswap, const enum ddsi_pserop *desc)
 {
   struct dd dd = {
     .buf = src,
@@ -1234,13 +1234,13 @@ dds_return_t ddsi_plist_deser_generic_srcoff (void * __restrict dst, const void 
   return deser_generic_r (dst, &dstoff, &fs, 1, &dd, srcoff, desc);
 }
 
-dds_return_t ddsi_plist_deser_generic (void * __restrict dst, const void * __restrict src, size_t srcsize, bool bswap, const enum ddsi_pserop * __restrict desc)
+dds_return_t ddsi_plist_deser_generic (void * restrict dst, const void * restrict src, size_t srcsize, bool bswap, const enum ddsi_pserop *desc)
 {
   size_t srcoff = 0;
   return ddsi_plist_deser_generic_srcoff (dst, src, srcsize, &srcoff, bswap, desc);
 }
 
-void ddsi_plist_ser_generic_size_embeddable (size_t *dstoff, const void *src, size_t srcoff, const enum ddsi_pserop * __restrict desc)
+void ddsi_plist_ser_generic_size_embeddable (size_t * restrict dstoff, const void *src, size_t srcoff, const enum ddsi_pserop *desc)
 {
 #define COMPLEX(basecase_, type_, dstoff_update_) do {                        \
     type_ const *x = deser_generic_src (src, &srcoff, plist_alignof (type_)); \
@@ -1288,14 +1288,14 @@ void ddsi_plist_ser_generic_size_embeddable (size_t *dstoff, const void *src, si
 #undef COMPLEX
 }
 
-static size_t ser_generic_size (const void *src, size_t srcoff, const enum ddsi_pserop * __restrict desc)
+static size_t ser_generic_size (const void *src, size_t srcoff, const enum ddsi_pserop *desc)
 {
   size_t dstoff = 0;
   ddsi_plist_ser_generic_size_embeddable (&dstoff, src, srcoff, desc);
   return dstoff;
 }
 
-static uint32_t ser_generic_count (const ddsi_octetseq_t *src, size_t elem_size, const enum ddsi_pserop * __restrict desc)
+static uint32_t ser_generic_count (const ddsi_octetseq_t *src, size_t elem_size, const enum ddsi_pserop *desc)
 {
   /* This whole thing exists solely for dealing with the vile "propagate" boolean, which must come first in an
      element, or one can't deserialize it at all.  Therefore, if desc doesn't start with XbPROP, all "length"
@@ -1310,7 +1310,7 @@ static uint32_t ser_generic_count (const ddsi_octetseq_t *src, size_t elem_size,
   return count;
 }
 
-dds_return_t ddsi_plist_ser_generic_embeddable (char * const data, size_t *dstoff, const void *src, size_t srcoff, const enum ddsi_pserop * __restrict desc, enum ddsrt_byte_order_selector bo)
+dds_return_t ddsi_plist_ser_generic_embeddable (char * const data, size_t * restrict dstoff, const void *src, size_t srcoff, const enum ddsi_pserop *desc, enum ddsrt_byte_order_selector bo)
 {
   while (true)
   {
@@ -1461,14 +1461,14 @@ dds_return_t ddsi_plist_ser_generic_embeddable (char * const data, size_t *dstof
 
 
 
-static dds_return_t ser_generic (struct ddsi_xmsg *xmsg, ddsi_parameterid_t pid, const void *src, size_t srcoff, const enum ddsi_pserop * __restrict desc, enum ddsrt_byte_order_selector bo)
+static dds_return_t ser_generic (struct ddsi_xmsg *xmsg, ddsi_parameterid_t pid, const void *src, size_t srcoff, const enum ddsi_pserop *desc, enum ddsrt_byte_order_selector bo)
 {
   char * const data = ddsi_xmsg_addpar_bo (xmsg, pid, ser_generic_size (src, srcoff, desc), bo);
   size_t dstoff = 0;
   return ddsi_plist_ser_generic_embeddable (data, &dstoff, src, srcoff, desc, bo);
 }
 
-dds_return_t ddsi_plist_ser_generic (void **dst, size_t *dstsize, const void *src, const enum ddsi_pserop * __restrict desc)
+dds_return_t ddsi_plist_ser_generic (void **dst, size_t *dstsize, const void *src, const enum ddsi_pserop *desc)
 {
   const size_t srcoff = 0;
   size_t dstoff = 0;
@@ -1481,7 +1481,7 @@ dds_return_t ddsi_plist_ser_generic (void **dst, size_t *dstsize, const void *sr
   return ret;
 }
 
-dds_return_t ddsi_plist_ser_generic_be (void **dst, size_t *dstsize, const void *src, const enum ddsi_pserop * __restrict desc)
+dds_return_t ddsi_plist_ser_generic_be (void **dst, size_t *dstsize, const void *src, const enum ddsi_pserop *desc)
 {
   const size_t srcoff = 0;
   size_t dstoff = 0;
@@ -1494,7 +1494,7 @@ dds_return_t ddsi_plist_ser_generic_be (void **dst, size_t *dstsize, const void 
   return ret;
 }
 
-static dds_return_t unalias_generic (void * __restrict dst, size_t * __restrict dstoff, bool gen_seq_aliased, const enum ddsi_pserop * __restrict desc)
+static dds_return_t unalias_generic (void * restrict dst, size_t * restrict dstoff, bool gen_seq_aliased, const enum ddsi_pserop *desc)
 {
 #define COMPLEX(basecase_, type_, ...) do {                            \
     type_ *x = deser_generic_dst (dst, dstoff, plist_alignof (type_)); \
@@ -1550,13 +1550,13 @@ static dds_return_t unalias_generic (void * __restrict dst, size_t * __restrict 
 #undef COMPLEX
 }
 
-dds_return_t ddsi_plist_unalias_generic (void * __restrict dst, const enum ddsi_pserop * __restrict desc)
+dds_return_t ddsi_plist_unalias_generic (void * restrict dst, const enum ddsi_pserop *desc)
 {
   size_t dstoff = 0;
   return unalias_generic (dst, &dstoff, false, desc);
 }
 
-static bool unalias_generic_required (const enum ddsi_pserop * __restrict desc)
+static bool unalias_generic_required (const enum ddsi_pserop *desc)
 {
   while (*desc != XSTOP)
   {
@@ -1571,25 +1571,25 @@ static bool unalias_generic_required (const enum ddsi_pserop * __restrict desc)
   return false;
 }
 
-static bool fini_generic_required (const enum ddsi_pserop * __restrict desc)
+static bool fini_generic_required (const enum ddsi_pserop *desc)
 {
   /* the two happen to be the same */
   return unalias_generic_required (desc);
 }
 
-static dds_return_t fini_generic (void * __restrict dst, size_t * __restrict dstoff, struct flagset *flagset, uint64_t flag, const enum ddsi_pserop * __restrict desc)
+static dds_return_t fini_generic (void * restrict dst, size_t * restrict dstoff, struct flagset *flagset, uint64_t flag, const enum ddsi_pserop *desc)
 {
   (void)fini_generic_embeddable (dst, dstoff, desc, NULL, *flagset->aliased & flag);
   return 0;
 }
 
-void ddsi_plist_fini_generic (void * __restrict dst, const enum ddsi_pserop *desc, bool aliased)
+void ddsi_plist_fini_generic (void * restrict dst, const enum ddsi_pserop *desc, bool aliased)
 {
   size_t dstoff = 0;
   (void)fini_generic_embeddable (dst, &dstoff, desc, NULL, aliased);
 }
 
-static dds_return_t valid_generic (const void *src, size_t srcoff, const enum ddsi_pserop * __restrict desc)
+static dds_return_t valid_generic (const void *src, size_t srcoff, const enum ddsi_pserop *desc)
 {
 #define COMPLEX(basecase_, type_, cond_stmts_) do {                           \
     type_ const *x = deser_generic_src (src, &srcoff, plist_alignof (type_)); \
@@ -1639,7 +1639,7 @@ static dds_return_t valid_generic (const void *src, size_t srcoff, const enum dd
 #undef COMPLEX
 }
 
-static bool equal_generic (const void *srcx, const void *srcy, size_t srcoff, const enum ddsi_pserop * __restrict desc)
+static bool equal_generic (const void *srcx, const void *srcy, size_t srcoff, const enum ddsi_pserop *desc)
 {
 #define COMPLEX(basecase_, type_, cond_stmts_) do {                            \
     type_ const *x = deser_generic_src (srcx, &srcoff, plist_alignof (type_)); \
@@ -1703,7 +1703,7 @@ static bool equal_generic (const void *srcx, const void *srcy, size_t srcoff, co
 #undef COMPLEX
 }
 
-bool ddsi_plist_equal_generic (const void *srcx, const void *srcy, const enum ddsi_pserop * __restrict desc)
+bool ddsi_plist_equal_generic (const void *srcx, const void *srcy, const enum ddsi_pserop *desc)
 {
   return equal_generic (srcx, srcy, 0, desc);
 }
@@ -1716,7 +1716,7 @@ static uint32_t isprint_runlen (uint32_t n, const unsigned char *xs)
   return m;
 }
 
-static bool prtf_octetseq (char * __restrict *buf, size_t * __restrict bufsize, uint32_t n, const unsigned char *xs)
+static bool prtf_octetseq (char * restrict *buf, size_t * restrict bufsize, uint32_t n, const unsigned char *xs)
 {
   /* Truncate octet sequences: 100 is arbitrary but experience suggests it is
      usually enough, and truncating it helps a lot when printing handshake
@@ -1752,7 +1752,7 @@ static bool prtf_octetseq (char * __restrict *buf, size_t * __restrict bufsize, 
   return trunc ? prtf (buf, bufsize, "...") : true;
 }
 
-static bool print_generic1 (char * __restrict *buf, size_t * __restrict bufsize, const void *src, size_t srcoff, const enum ddsi_pserop * __restrict desc, const char *sep)
+static bool print_generic1 (char * restrict *buf, size_t * restrict bufsize, const void *src, size_t srcoff, const enum ddsi_pserop *desc, const char *sep)
 {
   while (true)
   {
@@ -1909,7 +1909,7 @@ static bool print_generic1 (char * __restrict *buf, size_t * __restrict bufsize,
   }
 }
 
-static bool print_generic (char * __restrict *buf, size_t * __restrict bufsize, const void *src, size_t srcoff, const enum ddsi_pserop * __restrict desc)
+static bool print_generic (char * restrict *buf, size_t * restrict bufsize, const void *src, size_t srcoff, const enum ddsi_pserop *desc)
 {
   return print_generic1 (buf, bufsize, src, srcoff, desc, "");
 }
@@ -1930,26 +1930,26 @@ static int protocol_version_is_newer (ddsi_protocol_version_t pv)
   return (pv.major < DDSI_RTPS_MAJOR) ? 0 : (pv.major > DDSI_RTPS_MAJOR) ? 1 : (pv.minor > DDSI_RTPS_MINOR);
 }
 
-static dds_return_t dvx_durability_service (void * __restrict dst, const struct dd * __restrict dd)
+static dds_return_t dvx_durability_service (void * restrict dst, const struct dd *dd)
 {
   /* Accept all zero durability because of CoreDX, final_validation is more strict */
   (void) dd;
   return validate_durability_service_qospolicy_acceptzero (dst, true);
 }
 
-static dds_return_t dvx_history (void * __restrict dst, const struct dd * __restrict dd)
+static dds_return_t dvx_history (void * restrict dst, const struct dd *dd)
 {
   (void) dd;
   return validate_history_qospolicy (dst);
 }
 
-static dds_return_t dvx_resource_limits (void * __restrict dst, const struct dd * __restrict dd)
+static dds_return_t dvx_resource_limits (void * restrict dst, const struct dd *dd)
 {
   (void) dd;
   return validate_resource_limits_qospolicy (dst);
 }
 
-static dds_return_t dvx_participant_guid (void * __restrict dst, const struct dd * __restrict dd)
+static dds_return_t dvx_participant_guid (void * restrict dst, const struct dd *dd)
 {
   const ddsi_guid_t *g = dst;
   (void) dd;
@@ -1959,7 +1959,7 @@ static dds_return_t dvx_participant_guid (void * __restrict dst, const struct dd
     return (g->entityid.u == DDSI_ENTITYID_PARTICIPANT) ? 0 : DDS_RETCODE_BAD_PARAMETER;
 }
 
-static dds_return_t dvx_group_guid (void * __restrict dst, const struct dd * __restrict dd)
+static dds_return_t dvx_group_guid (void * restrict dst, const struct dd *dd)
 {
   const ddsi_guid_t *g = dst;
   (void) dd;
@@ -1969,7 +1969,7 @@ static dds_return_t dvx_group_guid (void * __restrict dst, const struct dd * __r
     return (g->entityid.u != 0) ? 0 : DDS_RETCODE_BAD_PARAMETER;
 }
 
-static dds_return_t dvx_endpoint_guid (void * __restrict dst, const struct dd * __restrict dd)
+static dds_return_t dvx_endpoint_guid (void * restrict dst, const struct dd *dd)
 {
   ddsi_guid_t *g = dst;
   if (g->prefix.u[0] == 0 && g->prefix.u[1] == 0 && g->prefix.u[2] == 0)
@@ -1987,7 +1987,7 @@ static dds_return_t dvx_endpoint_guid (void * __restrict dst, const struct dd * 
 }
 
 #ifdef DDSRT_HAVE_SSM
-static dds_return_t dvx_reader_favours_ssm (void * __restrict dst, const struct dd * __restrict dd)
+static dds_return_t dvx_reader_favours_ssm (void * restrict dst, const struct dd *dd)
 {
   uint32_t * const favours_ssm = dst;
   (void) dd;
@@ -2361,7 +2361,7 @@ void ddsi_plist_init_tables (void)
   ddsrt_once (&table_init_control, ddsi_plist_init_tables_real);
 }
 
-static void plist_or_xqos_fini (void * __restrict dst, size_t shift, uint64_t pmask, uint64_t qmask)
+static void plist_or_xqos_fini (void * restrict dst, size_t shift, uint64_t pmask, uint64_t qmask)
 {
   /* shift == 0: plist, shift > 0: just qos */
   struct flagset pfs, qfs;
@@ -2406,7 +2406,7 @@ static void plist_or_xqos_fini (void * __restrict dst, size_t shift, uint64_t pm
   }
 }
 
-static void plist_or_xqos_unalias (void * __restrict dst, size_t shift)
+static void plist_or_xqos_unalias (void * restrict dst, size_t shift)
 {
   /* shift == 0: plist, shift > 0: just qos */
   struct flagset pfs, qfs;
@@ -2449,7 +2449,7 @@ static void plist_or_xqos_unalias (void * __restrict dst, size_t shift)
   assert (*qfs.aliased == 0);
 }
 
-static void plist_or_xqos_mergein_missing (void * __restrict dst, const void * __restrict src, size_t shift, uint64_t pmask, uint64_t qmask)
+static void plist_or_xqos_mergein_missing (void * restrict dst, const void *src, size_t shift, uint64_t pmask, uint64_t qmask)
 {
   /* shift == 0: plist, shift > 0: just qos */
   struct flagset pfs_src, qfs_src;
@@ -2519,7 +2519,7 @@ static void plist_or_xqos_mergein_missing (void * __restrict dst, const void * _
   assert ((*qfs_dst.aliased & ~ aliased_dst_inq) == 0);
 }
 
-static void plist_or_xqos_addtomsg (struct ddsi_xmsg *xmsg, const void * __restrict src, size_t shift, uint64_t pwanted, uint64_t qwanted, enum ddsrt_byte_order_selector bo, enum ddsi_plist_context_kind context_kind)
+static void plist_or_xqos_addtomsg (struct ddsi_xmsg *xmsg, const void *src, size_t shift, uint64_t pwanted, uint64_t qwanted, enum ddsrt_byte_order_selector bo, enum ddsi_plist_context_kind context_kind)
 {
   /* shift == 0: plist, shift > 0: just qos */
   uint64_t pw, qw;
@@ -3991,7 +3991,7 @@ void ddsi_plist_addtomsg (struct ddsi_xmsg *m, const ddsi_plist_t *ps, uint64_t 
 
 /*************************/
 
-static void plist_or_xqos_print (char * __restrict *buf, size_t * __restrict bufsize, const void * __restrict src, size_t shift, uint64_t pwanted, uint64_t qwanted)
+static void plist_or_xqos_print (char * restrict *buf, size_t * restrict bufsize, const void *src, size_t shift, uint64_t pwanted, uint64_t qwanted)
 {
   /* shift == 0: plist, shift > 0: just qos */
   const char *sep = "";
@@ -4046,7 +4046,7 @@ static void plist_or_xqos_print (char * __restrict *buf, size_t * __restrict buf
   }
 }
 
-static void plist_or_xqos_log (uint32_t cat, const struct ddsrt_log_cfg *logcfg, const void * __restrict src, size_t shift, uint64_t pwanted, uint64_t qwanted)
+static void plist_or_xqos_log (uint32_t cat, const struct ddsrt_log_cfg *logcfg, const void *src, size_t shift, uint64_t pwanted, uint64_t qwanted)
 {
   if (logcfg->c.mask & cat)
   {
@@ -4057,7 +4057,7 @@ static void plist_or_xqos_log (uint32_t cat, const struct ddsrt_log_cfg *logcfg,
   }
 }
 
-size_t ddsi_xqos_print (char * __restrict buf, size_t bufsize, const dds_qos_t *xqos)
+size_t ddsi_xqos_print (char *buf, size_t bufsize, const dds_qos_t *xqos)
 {
   const size_t bufsize_in = bufsize;
   (void) prtf (&buf, &bufsize, "{");
@@ -4066,7 +4066,7 @@ size_t ddsi_xqos_print (char * __restrict buf, size_t bufsize, const dds_qos_t *
   return bufsize_in - bufsize;
 }
 
-size_t ddsi_plist_print (char * __restrict buf, size_t bufsize, const ddsi_plist_t *plist)
+size_t ddsi_plist_print (char *buf, size_t bufsize, const ddsi_plist_t *plist)
 {
   const size_t bufsize_in = bufsize;
   (void) prtf (&buf, &bufsize, "{");
@@ -4085,7 +4085,7 @@ void ddsi_plist_log (uint32_t cat, const struct ddsrt_log_cfg *logcfg, const dds
   plist_or_xqos_log (cat, logcfg, plist, 0, ~(uint64_t)0, ~(uint64_t)0);
 }
 
-size_t ddsi_plist_print_generic (char * __restrict buf, size_t bufsize, const void * __restrict src, const enum ddsi_pserop * __restrict desc)
+size_t ddsi_plist_print_generic (char *buf, size_t bufsize, const void *src, const enum ddsi_pserop *desc)
 {
   const size_t bufsize_in = bufsize;
   (void) print_generic (&buf, &bufsize, src, 0, desc);

--- a/src/core/ddsi/src/ddsi_receive.c
+++ b/src/core/ddsi/src/ddsi_receive.c
@@ -1998,13 +1998,13 @@ static struct ddsi_serdata *remote_make_sample (struct ddsi_tkmap_instance **tk,
 {
   /* hopefully the compiler figures out that these are just aliases and doesn't reload them
      unnecessarily from memory */
-  const struct remote_sourceinfo * __restrict si = vsourceinfo;
-  const struct ddsi_rsample_info * __restrict sampleinfo = si->sampleinfo;
-  const struct ddsi_rdata * __restrict fragchain = si->fragchain;
+  const struct remote_sourceinfo *si = vsourceinfo;
+  const struct ddsi_rsample_info *sampleinfo = si->sampleinfo;
+  const struct ddsi_rdata *fragchain = si->fragchain;
   const uint32_t statusinfo = si->statusinfo;
   const unsigned char data_smhdr_flags = si->data_smhdr_flags;
   const ddsrt_wctime_t tstamp = si->tstamp;
-  const ddsi_plist_t * __restrict qos = si->qos;
+  const ddsi_plist_t *qos = si->qos;
   const char *failmsg = NULL;
   struct ddsi_serdata *sample = NULL;
 

--- a/src/core/ddsi/src/ddsi_rhc.c
+++ b/src/core/ddsi/src/ddsi_rhc.c
@@ -11,7 +11,7 @@
 #include "ddsi__rhc.h"
 
 extern inline void ddsi_rhc_free (struct ddsi_rhc *rhc);
-extern inline bool ddsi_rhc_store (struct ddsi_rhc * __restrict rhc, const struct ddsi_writer_info * __restrict wrinfo, struct ddsi_serdata * __restrict sample, struct ddsi_tkmap_instance * __restrict tk);
-extern inline void ddsi_rhc_unregister_wr (struct ddsi_rhc * __restrict rhc, const struct ddsi_writer_info * __restrict wrinfo);
-extern inline void ddsi_rhc_relinquish_ownership (struct ddsi_rhc * __restrict rhc, const uint64_t wr_iid);
+extern inline bool ddsi_rhc_store (struct ddsi_rhc *rhc, const struct ddsi_writer_info *wrinfo, struct ddsi_serdata *sample, struct ddsi_tkmap_instance *tk);
+extern inline void ddsi_rhc_unregister_wr (struct ddsi_rhc *rhc, const struct ddsi_writer_info *wrinfo);
+extern inline void ddsi_rhc_relinquish_ownership (struct ddsi_rhc *rhc, const uint64_t wr_iid);
 extern inline void ddsi_rhc_set_qos (struct ddsi_rhc *rhc, const struct dds_qos *qos);

--- a/src/core/ddsi/src/ddsi_serdata_cdr.c
+++ b/src/core/ddsi/src/ddsi_serdata_cdr.c
@@ -197,7 +197,7 @@ static struct ddsi_serdata *serdata_cdr_from_ser (const struct ddsi_sertype *tpc
   return fix_serdata_cdr (d, tpcmn->serdata_basehash);
 }
 
-static void istream_from_serdata_cdr (dds_istream_t * __restrict s, const struct ddsi_serdata_cdr * __restrict d)
+static void istream_from_serdata_cdr (dds_istream_t *s, const struct ddsi_serdata_cdr *d)
 {
   s->m_buffer = (const unsigned char *) d;
   s->m_index = (uint32_t) offsetof (struct ddsi_serdata_cdr, data);
@@ -210,7 +210,7 @@ static void istream_from_serdata_cdr (dds_istream_t * __restrict s, const struct
   s->m_xcdr_version = ddsi_sertype_enc_id_xcdr_version (d->hdr.identifier);
 }
 
-static void ostream_from_serdata_cdr (dds_ostream_t * __restrict s, const struct ddsi_serdata_cdr * __restrict d)
+static void ostream_from_serdata_cdr (dds_ostream_t *s, const struct ddsi_serdata_cdr *d)
 {
   s->m_buffer = (unsigned char *) d;
   s->m_index = (uint32_t) offsetof (struct ddsi_serdata_cdr, data);
@@ -223,7 +223,7 @@ static void ostream_from_serdata_cdr (dds_ostream_t * __restrict s, const struct
   s->m_xcdr_version = ddsi_sertype_enc_id_xcdr_version (d->hdr.identifier);
 }
 
-static void ostream_add_to_serdata_cdr (dds_ostream_t * __restrict s, struct ddsi_serdata_cdr ** __restrict d)
+static void ostream_add_to_serdata_cdr (dds_ostream_t *s, struct ddsi_serdata_cdr **d)
 {
   /* DDSI requires 4 byte alignment */
   const uint32_t pad = dds_cdr_alignto4_clear_and_resize (s, &dds_cdrstream_default_allocator, s->m_xcdr_version);

--- a/src/core/ddsi/src/ddsi_statistics.c
+++ b/src/core/ddsi/src/ddsi_statistics.c
@@ -19,7 +19,7 @@
 #include "ddsi__radmin.h"
 #include "ddsi__proxy_endpoint.h"
 
-void ddsi_get_writer_stats (struct ddsi_writer *wr, uint64_t * __restrict rexmit_bytes, uint32_t * __restrict throttle_count, uint64_t * __restrict time_throttled, uint64_t * __restrict time_retransmit)
+void ddsi_get_writer_stats (struct ddsi_writer *wr, uint64_t *rexmit_bytes, uint32_t *throttle_count, uint64_t *time_throttled, uint64_t *time_retransmit)
 {
   ddsrt_mutex_lock (&wr->e.lock);
   *rexmit_bytes = wr->rexmit_bytes;
@@ -29,7 +29,7 @@ void ddsi_get_writer_stats (struct ddsi_writer *wr, uint64_t * __restrict rexmit
   ddsrt_mutex_unlock (&wr->e.lock);
 }
 
-void ddsi_get_reader_stats (struct ddsi_reader *rd, uint64_t * __restrict discarded_bytes)
+void ddsi_get_reader_stats (struct ddsi_reader *rd, uint64_t *discarded_bytes)
 {
   struct ddsi_rd_pwr_match *m;
   ddsi_guid_t pwrguid;

--- a/src/ddsrt/include/dds/ddsrt/hopscotch.h
+++ b/src/ddsrt/include/dds/ddsrt/hopscotch.h
@@ -104,7 +104,7 @@ DDS_EXPORT struct ddsrt_hh *ddsrt_hh_new (uint32_t init_size, ddsrt_hh_hash_fn h
  * @param[in,out] hh the hash table to destroy
  * @see ddsrt_hh_new
  */
-DDS_EXPORT void ddsrt_hh_free (struct ddsrt_hh * __restrict hh) ddsrt_nonnull_all;
+DDS_EXPORT void ddsrt_hh_free (struct ddsrt_hh *hh) ddsrt_nonnull_all;
 
 /**
  * @brief Lookup an element in the hash table.
@@ -117,7 +117,7 @@ DDS_EXPORT void ddsrt_hh_free (struct ddsrt_hh * __restrict hh) ddsrt_nonnull_al
  * @param[in] keyobject is the object with which to do the lookup
  * @return pointer to the matching element, NULL if failed
  */
-DDS_EXPORT void *ddsrt_hh_lookup (const struct ddsrt_hh * __restrict rt, const void * __restrict keyobject) ddsrt_nonnull_all;
+DDS_EXPORT void *ddsrt_hh_lookup (const struct ddsrt_hh *rt, const void *keyobject) ddsrt_nonnull_all;
 
 /**
  * @brief Add an element to the hash table.
@@ -130,7 +130,7 @@ DDS_EXPORT void *ddsrt_hh_lookup (const struct ddsrt_hh * __restrict rt, const v
  * @return false iff key already present
  * @see ddsrt_hh_remove
  */
-DDS_EXPORT bool ddsrt_hh_add (struct ddsrt_hh * __restrict rt, void * __restrict data) ddsrt_nonnull_all;
+DDS_EXPORT bool ddsrt_hh_add (struct ddsrt_hh *rt, void *data) ddsrt_nonnull_all;
 
 /**
  * @brief Remove an element from the hash table.
@@ -144,7 +144,7 @@ DDS_EXPORT bool ddsrt_hh_add (struct ddsrt_hh * __restrict rt, void * __restrict
  * @return false iff key not present
  * @see ddsrt_hh_add
  */
-DDS_EXPORT bool ddsrt_hh_remove (struct ddsrt_hh * __restrict rt, const void * __restrict keyobject) ddsrt_nonnull_all;
+DDS_EXPORT bool ddsrt_hh_remove (struct ddsrt_hh *rt, const void *keyobject) ddsrt_nonnull_all;
 
 /**
  * @brief Like @ref ddsrt_hh_add, but without returning success/failure result.
@@ -155,7 +155,7 @@ DDS_EXPORT bool ddsrt_hh_remove (struct ddsrt_hh * __restrict rt, const void * _
  * @param[in] data user data to add
  * @see ddsrt_hh_remove
  */
-DDS_EXPORT void ddsrt_hh_add_absent (struct ddsrt_hh * __restrict rt, void * __restrict data) ddsrt_nonnull_all;
+DDS_EXPORT void ddsrt_hh_add_absent (struct ddsrt_hh *rt, void *data) ddsrt_nonnull_all;
 
 /**
  * @brief Like @ref ddsrt_hh_remove, but without returning success/failure result.
@@ -166,7 +166,7 @@ DDS_EXPORT void ddsrt_hh_add_absent (struct ddsrt_hh * __restrict rt, void * __r
  * @param[in] keyobject user data to remove
  * @see ddsrt_hh_add_absent
  */
-DDS_EXPORT void ddsrt_hh_remove_present (struct ddsrt_hh * __restrict rt, void * __restrict keyobject) ddsrt_nonnull_all;
+DDS_EXPORT void ddsrt_hh_remove_present (struct ddsrt_hh *rt, void *keyobject) ddsrt_nonnull_all;
 
 /**
  * @brief Walk the hash table and apply a user defined function to each node.
@@ -180,7 +180,7 @@ DDS_EXPORT void ddsrt_hh_remove_present (struct ddsrt_hh * __restrict rt, void *
  * @param[in] f_arg extra argument for walk function
  * @see ddsrt_hh_iter_next
  */
-DDS_EXPORT void ddsrt_hh_enum (struct ddsrt_hh * __restrict rt, void (*f) (void *a, void *f_arg), void *f_arg) ddsrt_nonnull ((1, 2));
+DDS_EXPORT void ddsrt_hh_enum (struct ddsrt_hh *rt, void (*f) (void *a, void *f_arg), void *f_arg) ddsrt_nonnull ((1, 2));
 
 /**
  * @brief Initialize the iterator and get the first element.
@@ -190,7 +190,7 @@ DDS_EXPORT void ddsrt_hh_enum (struct ddsrt_hh * __restrict rt, void (*f) (void 
  * @return pointer to first element
  * @see ddsrt_hh_iter_next
  */
-DDS_EXPORT void *ddsrt_hh_iter_first (struct ddsrt_hh * __restrict rt, struct ddsrt_hh_iter * __restrict iter) ddsrt_nonnull_all;
+DDS_EXPORT void *ddsrt_hh_iter_first (struct ddsrt_hh *rt, struct ddsrt_hh_iter *iter) ddsrt_nonnull_all;
 
 /**
  * @brief Use the iterator to get the next element
@@ -200,7 +200,7 @@ DDS_EXPORT void *ddsrt_hh_iter_first (struct ddsrt_hh * __restrict rt, struct dd
  * @see ddsrt_hh_iter_first
  * @see ddsrt_hh_enum
  */
-DDS_EXPORT void *ddsrt_hh_iter_next (struct ddsrt_hh_iter * __restrict iter) ddsrt_nonnull_all;
+DDS_EXPORT void *ddsrt_hh_iter_next (struct ddsrt_hh_iter *iter) ddsrt_nonnull_all;
 
 /* Concurrent version */
 /**
@@ -240,7 +240,7 @@ struct ddsrt_chh *ddsrt_chh_new (uint32_t init_size, ddsrt_hh_hash_fn hash, ddsr
  * @param[in,out] hh the hash table to destroy
  * @see ddsrt_chh_new
  */
-void ddsrt_chh_free (struct ddsrt_chh * __restrict hh);
+void ddsrt_chh_free (struct ddsrt_chh *hh);
 
 /**
  * @brief Concurrent version of @ref ddsrt_hh_lookup
@@ -256,7 +256,7 @@ void ddsrt_chh_free (struct ddsrt_chh * __restrict hh);
  * @param[in] keyobject is the object with which to do the lookup
  * @return pointer to the matching element, NULL if failed
  */
-void *ddsrt_chh_lookup (struct ddsrt_chh * __restrict rt, const void * __restrict keyobject);
+void *ddsrt_chh_lookup (struct ddsrt_chh *rt, const void *keyobject);
 
 /**
  * @brief Concurrent version of @ref ddsrt_hh_add
@@ -266,7 +266,7 @@ void *ddsrt_chh_lookup (struct ddsrt_chh * __restrict rt, const void * __restric
  * @return false iff key already present
  * @see ddsrt_chh_remove
  */
-bool ddsrt_chh_add (struct ddsrt_chh * __restrict rt, void * __restrict data);
+bool ddsrt_chh_add (struct ddsrt_chh *rt, void *data);
 
 /**
  * @brief Concurrent version of @ref ddsrt_hh_remove
@@ -279,7 +279,7 @@ bool ddsrt_chh_add (struct ddsrt_chh * __restrict rt, void * __restrict data);
  * @return false iff key not present
  * @see ddsrt_chh_add
  */
-bool ddsrt_chh_remove (struct ddsrt_chh * __restrict rt, const void * __restrict keyobject);
+bool ddsrt_chh_remove (struct ddsrt_chh *rt, const void *keyobject);
 
 /**
  * @brief Concurrent version of @ref ddsrt_hh_enum
@@ -295,7 +295,7 @@ bool ddsrt_chh_remove (struct ddsrt_chh * __restrict rt, const void * __restrict
  * @param[in] f_arg extra argument for walk function
  * @see ddsrt_chh_iter_next
  */
-void ddsrt_chh_enum_unsafe (struct ddsrt_chh * __restrict rt, void (*f) (void *a, void *f_arg), void *f_arg); /* may delete a */
+void ddsrt_chh_enum_unsafe (struct ddsrt_chh *rt, void (*f) (void *a, void *f_arg), void *f_arg); /* may delete a */
 
 /**
  * @brief Concurrent version of @ref ddsrt_hh_iter_first
@@ -305,7 +305,7 @@ void ddsrt_chh_enum_unsafe (struct ddsrt_chh * __restrict rt, void (*f) (void *a
  * @return pointer to first element
  * @see ddsrt_chh_iter_next
  */
-void *ddsrt_chh_iter_first (struct ddsrt_chh * __restrict rt, struct ddsrt_chh_iter *it);
+void *ddsrt_chh_iter_first (struct ddsrt_chh *rt, struct ddsrt_chh_iter *it);
 
 /**
  * @brief Concurrent version of @ref ddsrt_hh_iter_next
@@ -360,7 +360,7 @@ struct ddsrt_ehh *ddsrt_ehh_new (size_t elemsz, uint32_t init_size, ddsrt_hh_has
  * @param[in,out] hh the hash table to destroy
  * @see ddsrt_ehh_new
  */
-void ddsrt_ehh_free (struct ddsrt_ehh * __restrict hh);
+void ddsrt_ehh_free (struct ddsrt_ehh *hh);
 
 /**
  * @brief Embedded data version of @ref ddsrt_hh_lookup
@@ -369,7 +369,7 @@ void ddsrt_ehh_free (struct ddsrt_ehh * __restrict hh);
  * @param[in] keyobject is the object with which to do the lookup
  * @return pointer to the matching element, NULL if failed
  */
-void *ddsrt_ehh_lookup (const struct ddsrt_ehh * __restrict rt, const void * __restrict keyobject);
+void *ddsrt_ehh_lookup (const struct ddsrt_ehh *rt, const void *keyobject);
 
 /**
  * @brief Embedded data version of @ref ddsrt_hh_add
@@ -381,7 +381,7 @@ void *ddsrt_ehh_lookup (const struct ddsrt_ehh * __restrict rt, const void * __r
  * @return false iff key already present
  * @see ddsrt_ehh_remove
  */
-bool ddsrt_ehh_add (struct ddsrt_ehh * __restrict rt, const void * __restrict data);
+bool ddsrt_ehh_add (struct ddsrt_ehh *rt, const void *data);
 
 /**
  * @brief Embedded data version of @ref ddsrt_hh_remove
@@ -393,7 +393,7 @@ bool ddsrt_ehh_add (struct ddsrt_ehh * __restrict rt, const void * __restrict da
  * @return false iff key not present
  * @see ddsrt_ehh_add
  */
-bool ddsrt_ehh_remove (struct ddsrt_ehh * __restrict rt, const void * __restrict keyobject);
+bool ddsrt_ehh_remove (struct ddsrt_ehh *rt, const void *keyobject);
 
 /**
  * @brief Embedded data version of @ref ddsrt_hh_enum
@@ -403,7 +403,7 @@ bool ddsrt_ehh_remove (struct ddsrt_ehh * __restrict rt, const void * __restrict
  * @param[in] f_arg extra argument for walk function
  * @see ddsrt_ehh_iter_next
  */
-void ddsrt_ehh_enum (struct ddsrt_ehh * __restrict rt, void (*f) (void *a, void *f_arg), void *f_arg); /* may delete a */
+void ddsrt_ehh_enum (struct ddsrt_ehh *rt, void (*f) (void *a, void *f_arg), void *f_arg); /* may delete a */
 
 /**
  * @brief Embedded data version of @ref ddsrt_hh_iter_first
@@ -413,7 +413,7 @@ void ddsrt_ehh_enum (struct ddsrt_ehh * __restrict rt, void (*f) (void *a, void 
  * @return pointer to first element
  * @see ddsrt_ehh_iter_next
  */
-void *ddsrt_ehh_iter_first (struct ddsrt_ehh * __restrict rt, struct ddsrt_ehh_iter * __restrict iter); /* may delete nodes */
+void *ddsrt_ehh_iter_first (struct ddsrt_ehh *rt, struct ddsrt_ehh_iter *iter); /* may delete nodes */
 
 /**
  * @brief Embedded data version of @ref ddsrt_hh_iter_next
@@ -423,7 +423,7 @@ void *ddsrt_ehh_iter_first (struct ddsrt_ehh * __restrict rt, struct ddsrt_ehh_i
  * @see ddsrt_ehh_iter_first
  * @see ddsrt_ehh_enum
  */
-void *ddsrt_ehh_iter_next (struct ddsrt_ehh_iter * __restrict iter);
+void *ddsrt_ehh_iter_next (struct ddsrt_ehh_iter *iter);
 
 #if defined (__cplusplus)
 }

--- a/src/ddsrt/include/dds/ddsrt/rusage.h
+++ b/src/ddsrt/include/dds/ddsrt/rusage.h
@@ -73,7 +73,7 @@ DDS_EXPORT dds_return_t ddsrt_getrusage(enum ddsrt_getrusage_who who, ddsrt_rusa
  * @retval DDS_RETCODE_ERROR
  *             An unidentified error occurred.
  */
-DDS_EXPORT dds_return_t ddsrt_getrusage_anythread (ddsrt_thread_list_id_t tid, ddsrt_rusage_t * __restrict usage);
+DDS_EXPORT dds_return_t ddsrt_getrusage_anythread (ddsrt_thread_list_id_t tid, ddsrt_rusage_t *usage);
 #endif
 
 #if defined (__cplusplus)

--- a/src/ddsrt/include/dds/ddsrt/sockets.h
+++ b/src/ddsrt/include/dds/ddsrt/sockets.h
@@ -449,7 +449,7 @@ ddsrt_sockaddr_get_port(
  */
 bool
 ddsrt_sockaddr_isunspecified(
-  const struct sockaddr *__restrict sa) ddsrt_nonnull_all;
+  const struct sockaddr *sa) ddsrt_nonnull_all;
 
 /**
  * @brief Check if the given address is a loopback address.
@@ -460,7 +460,7 @@ ddsrt_sockaddr_isunspecified(
  */
 bool
 ddsrt_sockaddr_isloopback(
-  const struct sockaddr *__restrict sa) ddsrt_nonnull_all;
+  const struct sockaddr *sa) ddsrt_nonnull_all;
 
 /**
  * @brief Check if given socket IP addresses reside in the same subnet.

--- a/src/ddsrt/include/dds/ddsrt/string.h
+++ b/src/ddsrt/include/dds/ddsrt/string.h
@@ -143,8 +143,8 @@ ddsrt_attribute_malloc;
  */
 DDS_EXPORT size_t
 ddsrt_strlcpy(
-  char * __restrict dest,
-  const char * __restrict src,
+  char *dest,
+  const char *src,
   size_t size)
 ddsrt_nonnull((1,2));
 
@@ -166,8 +166,8 @@ ddsrt_nonnull((1,2));
  */
 DDS_EXPORT size_t
 ddsrt_strlcat(
-  char * __restrict dest,
-  const char * __restrict src,
+  char *dest,
+  const char *src,
   size_t size)
 ddsrt_nonnull((1,2));
 

--- a/src/ddsrt/include/dds/ddsrt/threads.h
+++ b/src/ddsrt/include/dds/ddsrt/threads.h
@@ -184,7 +184,7 @@ ddsrt_thread_join(
  */
 DDS_EXPORT size_t
 ddsrt_thread_getname(
-  char *__restrict name,
+  char *name,
   size_t size);
 
 /**
@@ -198,7 +198,7 @@ ddsrt_thread_getname(
 #if DDSRT_HAVE_THREAD_SETNAME
 DDS_EXPORT void
 ddsrt_thread_setname(
-  const char *__restrict name);
+  const char *name);
 #endif
 
 #if DDSRT_HAVE_THREAD_LIST
@@ -220,7 +220,7 @@ ddsrt_thread_setname(
  * @retval DDS_RETCODE_UNSUPPORTED
  *             Not supported on the platform
  */
-DDS_EXPORT dds_return_t ddsrt_thread_list (ddsrt_thread_list_id_t * __restrict tids, size_t size);
+DDS_EXPORT dds_return_t ddsrt_thread_list (ddsrt_thread_list_id_t *tids, size_t size);
 
 /**
  * @brief Get the name of the specified thread (in the calling process)
@@ -245,7 +245,7 @@ DDS_EXPORT dds_return_t ddsrt_thread_list (ddsrt_thread_list_id_t * __restrict t
  * @retval DDS_RETCODE_UNSUPPORTED
  *             Not supported on the platform
  */
-DDS_EXPORT dds_return_t ddsrt_thread_getname_anythread (ddsrt_thread_list_id_t tid, char *__restrict name, size_t size);
+DDS_EXPORT dds_return_t ddsrt_thread_getname_anythread (ddsrt_thread_list_id_t tid, char *name, size_t size);
 #endif
 
 /**

--- a/src/ddsrt/include/dds/ddsrt/time.h
+++ b/src/ddsrt/include/dds/ddsrt/time.h
@@ -276,7 +276,7 @@ ddsrt_duration_to_msecs_ceil(dds_duration_t reltime)
  * @param[out]  sec   Seconds part
  * @param[out]  usec  Microseconds part
  */
-DDS_EXPORT void ddsrt_mtime_to_sec_usec (int32_t * __restrict sec, int32_t * __restrict usec, ddsrt_mtime_t t);
+DDS_EXPORT void ddsrt_mtime_to_sec_usec (int32_t *sec, int32_t *usec, ddsrt_mtime_t t);
 
 /**
  * @brief Convert wall-clock time seconds & microseconds
@@ -285,7 +285,7 @@ DDS_EXPORT void ddsrt_mtime_to_sec_usec (int32_t * __restrict sec, int32_t * __r
  * @param[out]  sec   Seconds part
  * @param[out]  usec  Microseconds part
  */
-DDS_EXPORT void ddsrt_wctime_to_sec_usec (int32_t * __restrict sec, int32_t * __restrict usec, ddsrt_wctime_t t);
+DDS_EXPORT void ddsrt_wctime_to_sec_usec (int32_t *sec, int32_t *usec, ddsrt_wctime_t t);
 
 /**
  * @brief Convert elapsed time seconds & microseconds
@@ -294,7 +294,7 @@ DDS_EXPORT void ddsrt_wctime_to_sec_usec (int32_t * __restrict sec, int32_t * __
  * @param[out]  sec   Seconds part
  * @param[out]  usec  Microseconds part
  */
-DDS_EXPORT void ddsrt_etime_to_sec_usec (int32_t * __restrict sec, int32_t * __restrict usec, ddsrt_etime_t t);
+DDS_EXPORT void ddsrt_etime_to_sec_usec (int32_t *sec, int32_t *usec, ddsrt_etime_t t);
 
 #if defined(__cplusplus)
 }

--- a/src/ddsrt/src/hopscotch.c
+++ b/src/ddsrt/src/hopscotch.c
@@ -71,7 +71,7 @@ struct ddsrt_hh *ddsrt_hh_new (uint32_t init_size, ddsrt_hh_hash_fn hash, ddsrt_
   return hh;
 }
 
-void ddsrt_hh_free (struct ddsrt_hh * __restrict hh)
+void ddsrt_hh_free (struct ddsrt_hh *hh)
 {
   ddsrt_hh_fini (hh);
   ddsrt_free (hh);
@@ -93,7 +93,7 @@ static void *ddsrt_hh_lookup_internal (const struct ddsrt_hh *rt, const uint32_t
   return NULL;
 }
 
-void *ddsrt_hh_lookup (const struct ddsrt_hh * __restrict rt, const void * __restrict keyobject)
+void *ddsrt_hh_lookup (const struct ddsrt_hh *rt, const void *keyobject)
 {
   const uint32_t hash = rt->hash (keyobject);
   const uint32_t idxmask = rt->size - 1;
@@ -182,7 +182,7 @@ static void ddsrt_hh_resize (struct ddsrt_hh *rt)
   }
 }
 
-bool ddsrt_hh_add (struct ddsrt_hh * __restrict rt, void * __restrict data)
+bool ddsrt_hh_add (struct ddsrt_hh *rt, void *data)
 {
   const uint32_t hash = rt->hash (data);
   const uint32_t idxmask = rt->size - 1;
@@ -216,7 +216,7 @@ bool ddsrt_hh_add (struct ddsrt_hh * __restrict rt, void * __restrict data)
   return ddsrt_hh_add (rt, data);
 }
 
-bool ddsrt_hh_remove (struct ddsrt_hh * __restrict rt, const void * __restrict keyobject)
+bool ddsrt_hh_remove (struct ddsrt_hh *rt, const void *keyobject)
 {
   const uint32_t hash = rt->hash (keyobject);
   const uint32_t idxmask = rt->size - 1;
@@ -238,21 +238,21 @@ bool ddsrt_hh_remove (struct ddsrt_hh * __restrict rt, const void * __restrict k
   return false;
 }
 
-void ddsrt_hh_add_absent (struct ddsrt_hh * __restrict rt, void * __restrict data)
+void ddsrt_hh_add_absent (struct ddsrt_hh *rt, void *data)
 {
   const int x = ddsrt_hh_add (rt, data);
   assert (x);
   (void) x;
 }
 
-void ddsrt_hh_remove_present (struct ddsrt_hh * __restrict rt, void * __restrict keyobject)
+void ddsrt_hh_remove_present (struct ddsrt_hh *rt, void *keyobject)
 {
   const int x = ddsrt_hh_remove (rt, keyobject);
   assert (x);
   (void) x;
 }
 
-void ddsrt_hh_enum (struct ddsrt_hh * __restrict rt, void (*f) (void *a, void *f_arg), void *f_arg)
+void ddsrt_hh_enum (struct ddsrt_hh *rt, void (*f) (void *a, void *f_arg), void *f_arg)
 {
   uint32_t i;
   for (i = 0; i < rt->size; i++) {
@@ -263,14 +263,14 @@ void ddsrt_hh_enum (struct ddsrt_hh * __restrict rt, void (*f) (void *a, void *f
   }
 }
 
-void *ddsrt_hh_iter_first (struct ddsrt_hh * __restrict rt, struct ddsrt_hh_iter * __restrict iter)
+void *ddsrt_hh_iter_first (struct ddsrt_hh *rt, struct ddsrt_hh_iter *iter)
 {
   iter->hh = rt;
   iter->cursor = 0;
   return ddsrt_hh_iter_next (iter);
 }
 
-void *ddsrt_hh_iter_next (struct ddsrt_hh_iter * __restrict iter)
+void *ddsrt_hh_iter_next (struct ddsrt_hh_iter *iter)
 {
   struct ddsrt_hh *rt = iter->hh;
   while (iter->cursor < rt->size) {
@@ -361,7 +361,7 @@ struct ddsrt_chh *ddsrt_chh_new (uint32_t init_size, ddsrt_hh_hash_fn hash, ddsr
     }
 }
 
-void ddsrt_chh_free (struct ddsrt_chh * __restrict hh)
+void ddsrt_chh_free (struct ddsrt_chh *hh)
 {
     ddsrt_chh_fini (hh);
     ddsrt_free (hh);
@@ -411,7 +411,7 @@ static void *ddsrt_chh_lookup_internal (struct ddsrt_chh_bucket_array const * co
         ddsrt_atomic_st32 (var__, (expr_));                                  \
     } while (0)
 
-void *ddsrt_chh_lookup (struct ddsrt_chh * __restrict rt, const void * __restrict keyobject)
+void *ddsrt_chh_lookup (struct ddsrt_chh *rt, const void *keyobject)
 {
     struct ddsrt_chh_bucket_array const * const bsary = ddsrt_atomic_ldvoidp (&rt->buckets);
     const uint32_t hash = rt->hash (keyobject);
@@ -502,7 +502,7 @@ static void ddsrt_chh_resize (struct ddsrt_chh *rt)
     rt->gc_buckets (bsary0, rt->gc_buckets_arg);
 }
 
-static bool ddsrt_chh_add_locked (struct ddsrt_chh * __restrict rt, const void * __restrict data)
+static bool ddsrt_chh_add_locked (struct ddsrt_chh *rt, const void *data)
 {
     const uint32_t hash = rt->hash (data);
     uint32_t size;
@@ -548,7 +548,7 @@ static bool ddsrt_chh_add_locked (struct ddsrt_chh * __restrict rt, const void *
     return ddsrt_chh_add_locked (rt, data);
 }
 
-bool ddsrt_chh_add (struct ddsrt_chh * __restrict rt, void * __restrict data)
+bool ddsrt_chh_add (struct ddsrt_chh *rt, void *data)
 {
     ddsrt_mutex_lock (&rt->change_lock);
     const bool ret = ddsrt_chh_add_locked (rt, data);
@@ -556,7 +556,7 @@ bool ddsrt_chh_add (struct ddsrt_chh * __restrict rt, void * __restrict data)
     return ret;
 }
 
-bool ddsrt_chh_remove (struct ddsrt_chh * __restrict rt, const void * __restrict keyobject)
+bool ddsrt_chh_remove (struct ddsrt_chh *rt, const void *keyobject)
 {
     const uint32_t hash = rt->hash (keyobject);
     ddsrt_mutex_lock (&rt->change_lock);
@@ -588,7 +588,7 @@ bool ddsrt_chh_remove (struct ddsrt_chh * __restrict rt, const void * __restrict
     return false;
 }
 
-void ddsrt_chh_enum_unsafe (struct ddsrt_chh * __restrict rt, void (*f) (void *a, void *f_arg), void *f_arg)
+void ddsrt_chh_enum_unsafe (struct ddsrt_chh *rt, void (*f) (void *a, void *f_arg), void *f_arg)
 {
     struct ddsrt_chh_bucket_array * const bsary = ddsrt_atomic_ldvoidp (&rt->buckets);
     struct ddsrt_chh_bucket * const bs = bsary->bs;
@@ -614,7 +614,7 @@ void *ddsrt_chh_iter_next (struct ddsrt_chh_iter *it)
   return NULL;
 }
 
-void *ddsrt_chh_iter_first (struct ddsrt_chh * __restrict rt, struct ddsrt_chh_iter *it)
+void *ddsrt_chh_iter_first (struct ddsrt_chh *rt, struct ddsrt_chh_iter *it)
 {
   struct ddsrt_chh_bucket_array * const bsary = ddsrt_atomic_ldvoidp (&rt->buckets);
   it->bs = bsary->bs;
@@ -672,7 +672,7 @@ struct ddsrt_ehh *ddsrt_ehh_new (size_t elemsz, uint32_t init_size, ddsrt_hh_has
     return hh;
 }
 
-void ddsrt_ehh_free (struct ddsrt_ehh * __restrict hh)
+void ddsrt_ehh_free (struct ddsrt_ehh *hh)
 {
     ddsrt_ehh_fini (hh);
     ddsrt_free (hh);
@@ -704,7 +704,7 @@ static void *ddsrt_ehh_lookup_internal (const struct ddsrt_ehh *rt, uint32_t buc
     return NULL;
 }
 
-void *ddsrt_ehh_lookup (const struct ddsrt_ehh * __restrict rt, const void * __restrict keyobject)
+void *ddsrt_ehh_lookup (const struct ddsrt_ehh *rt, const void *keyobject)
 {
     const uint32_t hash = rt->hash (keyobject);
     const uint32_t idxmask = rt->size - 1;
@@ -782,7 +782,7 @@ static void ddsrt_ehh_resize (struct ddsrt_ehh *rt)
     rt->buckets = bs1;
 }
 
-bool ddsrt_ehh_add (struct ddsrt_ehh * __restrict rt, const void * __restrict data)
+bool ddsrt_ehh_add (struct ddsrt_ehh *rt, const void *data)
 {
     const uint32_t hash = rt->hash (data);
     const uint32_t idxmask = rt->size - 1;
@@ -822,7 +822,7 @@ bool ddsrt_ehh_add (struct ddsrt_ehh * __restrict rt, const void * __restrict da
     return ddsrt_ehh_add (rt, data);
 }
 
-bool ddsrt_ehh_remove (struct ddsrt_ehh * __restrict rt, const void * __restrict keyobject)
+bool ddsrt_ehh_remove (struct ddsrt_ehh *rt, const void *keyobject)
 {
     const uint32_t hash = rt->hash (keyobject);
     const uint32_t idxmask = rt->size - 1;
@@ -848,7 +848,7 @@ bool ddsrt_ehh_remove (struct ddsrt_ehh * __restrict rt, const void * __restrict
     return false;
 }
 
-void ddsrt_ehh_enum (struct ddsrt_ehh * __restrict rt, void (*f) (void *a, void *f_arg), void *f_arg)
+void ddsrt_ehh_enum (struct ddsrt_ehh *rt, void (*f) (void *a, void *f_arg), void *f_arg)
 {
     uint32_t i;
     for (i = 0; i < rt->size; i++) {
@@ -859,14 +859,14 @@ void ddsrt_ehh_enum (struct ddsrt_ehh * __restrict rt, void (*f) (void *a, void 
     }
 }
 
-void *ddsrt_ehh_iter_first (struct ddsrt_ehh * __restrict rt, struct ddsrt_ehh_iter * __restrict iter)
+void *ddsrt_ehh_iter_first (struct ddsrt_ehh *rt, struct ddsrt_ehh_iter *iter)
 {
     iter->hh = rt;
     iter->cursor = 0;
     return ddsrt_ehh_iter_next (iter);
 }
 
-void *ddsrt_ehh_iter_next (struct ddsrt_ehh_iter * __restrict iter)
+void *ddsrt_ehh_iter_next (struct ddsrt_ehh_iter *iter)
 {
     struct ddsrt_ehh *rt = iter->hh;
     while (iter->cursor < rt->size) {

--- a/src/ddsrt/src/rusage/freertos/rusage.c
+++ b/src/ddsrt/src/rusage/freertos/rusage.c
@@ -81,7 +81,7 @@ rusage_thread(ddsrt_thread_list_id_t tid, ddsrt_rusage_t *usage)
 static
 #endif
 dds_return_t
-ddsrt_getrusage_anythread(ddsrt_thread_list_id_t tid, ddsrt_rusage_t *__restrict usage)
+ddsrt_getrusage_anythread(ddsrt_thread_list_id_t tid, ddsrt_rusage_t *usage)
 {
   assert(usage != NULL);
   return rusage_thread(tid, usage);

--- a/src/ddsrt/src/rusage/posix/rusage.c
+++ b/src/ddsrt/src/rusage/posix/rusage.c
@@ -23,7 +23,7 @@
 dds_return_t
 ddsrt_getrusage_anythread (
   ddsrt_thread_list_id_t tid,
-  ddsrt_rusage_t * __restrict usage)
+  ddsrt_rusage_t *usage)
 {
   /* Linux' man pages happily state that the second field is the process/task name
      in parentheses, and that %s is the correct scanf conversion.  As it turns out
@@ -176,7 +176,7 @@ ddsrt_getrusage (enum ddsrt_getrusage_who who, ddsrt_rusage_t *usage)
 dds_return_t
 ddsrt_getrusage_anythread (
   ddsrt_thread_list_id_t tid,
-  ddsrt_rusage_t * __restrict usage)
+  ddsrt_rusage_t *usage)
 {
   mach_msg_type_number_t cnt;
   thread_basic_info_data_t info;

--- a/src/ddsrt/src/rusage/windows/rusage.c
+++ b/src/ddsrt/src/rusage/windows/rusage.c
@@ -24,7 +24,7 @@ filetime_to_time (const FILETIME *ft)
 }
 
 dds_return_t
-ddsrt_getrusage_anythread (ddsrt_thread_list_id_t tid, ddsrt_rusage_t * __restrict usage)
+ddsrt_getrusage_anythread (ddsrt_thread_list_id_t tid, ddsrt_rusage_t *usage)
 {
     FILETIME stime, utime, ctime, etime;
 

--- a/src/ddsrt/src/sockets.c
+++ b/src/ddsrt/src/sockets.c
@@ -108,7 +108,7 @@ uint16_t ddsrt_sockaddr_get_port(const struct sockaddr *const sa)
 }
 
 bool
-ddsrt_sockaddr_isunspecified(const struct sockaddr *__restrict sa)
+ddsrt_sockaddr_isunspecified(const struct sockaddr *sa)
 {
   assert(sa != NULL);
 
@@ -125,7 +125,7 @@ ddsrt_sockaddr_isunspecified(const struct sockaddr *__restrict sa)
 }
 
 bool
-ddsrt_sockaddr_isloopback(const struct sockaddr *__restrict sa)
+ddsrt_sockaddr_isloopback(const struct sockaddr *sa)
 {
   assert(sa != NULL);
 

--- a/src/ddsrt/src/string.c
+++ b/src/ddsrt/src/string.c
@@ -82,8 +82,8 @@ ddsrt_strsep(char **stringp, const char *delim)
 
 size_t
 ddsrt_strlcpy(
-  char * __restrict dest,
-  const char * __restrict src,
+  char *dest,
+  const char *src,
   size_t size)
 {
   size_t srclen = 0;
@@ -112,8 +112,8 @@ ddsrt_strlcpy(
          0 or 1. */
 size_t
 ddsrt_strlcat(
-  char * __restrict dest,
-  const char * __restrict src,
+  char *dest,
+  const char *src,
   size_t size)
 {
   size_t destlen, srclen;

--- a/src/ddsrt/src/threads/freertos/threads.c
+++ b/src/ddsrt/src/threads/freertos/threads.c
@@ -103,7 +103,7 @@ bool ddsrt_thread_equal(ddsrt_thread_t a, ddsrt_thread_t b)
 }
 
 size_t
-ddsrt_thread_getname(char *__restrict name, size_t size)
+ddsrt_thread_getname(char *name, size_t size)
 {
   char *ptr;
 

--- a/src/ddsrt/src/threads/posix/threads.c
+++ b/src/ddsrt/src/threads/posix/threads.c
@@ -81,7 +81,7 @@ int _open(const char *name, int mode) { return -1; }
 #endif
 
 size_t
-ddsrt_thread_getname(char * __restrict name, size_t size)
+ddsrt_thread_getname(char *name, size_t size)
 {
 #ifdef MAXTHREADNAMESIZE
   char buf[MAXTHREADNAMESIZE + 1] = "";
@@ -145,7 +145,7 @@ ddsrt_thread_getname(char * __restrict name, size_t size)
 }
 
 void
-ddsrt_thread_setname(const char *__restrict name)
+ddsrt_thread_setname(const char *name)
 {
   assert(name != NULL);
 
@@ -543,7 +543,7 @@ ddsrt_thread_join(ddsrt_thread_t thread, uint32_t *thread_result)
 #if defined __linux
 dds_return_t
 ddsrt_thread_list (
-  ddsrt_thread_list_id_t * __restrict tids,
+  ddsrt_thread_list_id_t *tids,
   size_t size)
 {
   DIR *dir;
@@ -574,7 +574,7 @@ ddsrt_thread_list (
 dds_return_t
 ddsrt_thread_getname_anythread (
   ddsrt_thread_list_id_t tid,
-  char *__restrict name,
+  char *name,
   size_t size)
 {
   char file[100];
@@ -608,7 +608,7 @@ DDSRT_STATIC_ASSERT (sizeof (ddsrt_thread_list_id_t) == sizeof (mach_port_t));
 
 dds_return_t
 ddsrt_thread_list (
-  ddsrt_thread_list_id_t * __restrict tids,
+  ddsrt_thread_list_id_t *tids,
   size_t size)
 {
   thread_act_array_t tasks;
@@ -624,7 +624,7 @@ ddsrt_thread_list (
 dds_return_t
 ddsrt_thread_getname_anythread (
   ddsrt_thread_list_id_t tid,
-  char *__restrict name,
+  char *name,
   size_t size)
 {
   if (size > 0)

--- a/src/ddsrt/src/threads/windows/threads.c
+++ b/src/ddsrt/src/threads/windows/threads.c
@@ -249,7 +249,7 @@ static ddsrt_thread_local char thread_name[16] = "";
 
 size_t
 ddsrt_thread_getname(
-  char *__restrict str,
+  char *str,
   size_t size)
 {
   size_t cnt;
@@ -290,7 +290,7 @@ typedef struct tagTHREADNAME_INFO
 
 void
 ddsrt_thread_setname(
-  const char *__restrict name)
+  const char *name)
 {
   assert (name != NULL);
   getset_threaddescription_addresses ();
@@ -332,7 +332,7 @@ ddsrt_thread_setname(
 
 dds_return_t
 ddsrt_thread_list (
-  ddsrt_thread_list_id_t * __restrict tids,
+  ddsrt_thread_list_id_t *tids,
   size_t size)
 {
   HANDLE hThreadSnap;
@@ -370,7 +370,7 @@ ddsrt_thread_list (
 dds_return_t
 ddsrt_thread_getname_anythread (
   ddsrt_thread_list_id_t tid,
-  char * __restrict name,
+  char *name,
   size_t size)
 {
   getset_threaddescription_addresses ();

--- a/src/ddsrt/src/time.c
+++ b/src/ddsrt/src/time.c
@@ -73,23 +73,23 @@ ddsrt_ctime(dds_time_t abstime, char *str, size_t size)
   return ddsrt_strlcpy(str, buf, size);
 }
 
-static void time_to_sec_usec (int32_t * __restrict sec, int32_t * __restrict usec, int64_t t)
+static void time_to_sec_usec (int32_t *sec, int32_t *usec, int64_t t)
 {
   *sec = (int32_t) (t / DDS_NSECS_IN_SEC);
   *usec = (int32_t) (t % DDS_NSECS_IN_SEC) / 1000;
 }
 
-void ddsrt_mtime_to_sec_usec (int32_t * __restrict sec, int32_t * __restrict usec, ddsrt_mtime_t t)
+void ddsrt_mtime_to_sec_usec (int32_t *sec, int32_t *usec, ddsrt_mtime_t t)
 {
   time_to_sec_usec (sec, usec, t.v);
 }
 
-void ddsrt_wctime_to_sec_usec (int32_t * __restrict sec, int32_t * __restrict usec, ddsrt_wctime_t t)
+void ddsrt_wctime_to_sec_usec (int32_t *sec, int32_t *usec, ddsrt_wctime_t t)
 {
   time_to_sec_usec (sec, usec, t.v);
 }
 
-void ddsrt_etime_to_sec_usec (int32_t * __restrict sec, int32_t * __restrict usec, ddsrt_etime_t t)
+void ddsrt_etime_to_sec_usec (int32_t *sec, int32_t *usec, ddsrt_etime_t t)
 {
   time_to_sec_usec (sec, usec, t.v);
 }

--- a/src/ddsrt/tests/hopscotch.c
+++ b/src/ddsrt/tests/hopscotch.c
@@ -247,7 +247,7 @@ struct chhtest_thread_arg {
 
 static uint32_t chhtest_thread (void *varg)
 {
-  struct chhtest_thread_arg * const __restrict arg = varg;
+  struct chhtest_thread_arg * const arg = varg;
   uint32_t ** ksptrs;
   uint32_t n = 0;
 

--- a/src/idl/include/idl/string.h
+++ b/src/idl/include/idl/string.h
@@ -40,7 +40,7 @@ IDL_EXPORT char *idl_strdup(const char *str);
 
 IDL_EXPORT char *idl_strndup(const char *str, size_t len);
 
-IDL_EXPORT size_t idl_strlcpy(char * __restrict dest, const char * __restrict src, size_t size);
+IDL_EXPORT size_t idl_strlcpy(char *dest, const char *src, size_t size);
 
 IDL_EXPORT int idl_snprintf(char *str, size_t size, const char *fmt, ...)
 idl_attribute_format_printf(3, 4);

--- a/src/idl/src/string.c
+++ b/src/idl/src/string.c
@@ -142,7 +142,7 @@ char *idl_strndup(const char *str, size_t len)
   return s;
 }
 
-size_t idl_strlcpy(char * __restrict dest, const char * __restrict src, size_t size)
+size_t idl_strlcpy(char *dest, const char *src, size_t size)
 {
   size_t srclen;
 


### PR DESCRIPTION
A lot of "restricts" were sprinkled throughout the code, for the most part completely unnecessary because it didn't even involve performance-sensitive code. C++ does not have the "restrict" keyword, and the work-around for that was #defining it away, which breaks C++ code using "restrict" as an identifier. In short, a bit of a mess.

This removes the vast majority, including in particular all in the API and thus eliminating any need for a C++-specific workaround. The only cases that remain are in the (de)serializers because:

* they are performance-sensitive
* they read/write through "char *" pointers that are allowed to alias anything
* a cursory inspection of the output of gcc suggests it does affects the code

This PR sits on top of #2124, mainly because of laziness. The two PRs are not entirely independent (because of the serializer), but this PR can easily be changed to apply to master if this one gets the green light but the other one does not (yet?). The changes exclusive to this PR are all in a single commit, so it is pretty easy to review the restrict part without having to wade through unrelated changes.

Fixes #2140 