### PR TITLE
Add restrict qualifier to serializer output buffer

### DIFF
--- a/src/core/cdr/src/dds_cdrstream_keys.part.h
+++ b/src/core/cdr/src/dds_cdrstream_keys.part.h
@@ -421,12 +421,7 @@ static void dds_stream_extract_keyBO_from_key_impl (dds_istream_t *is, DDS_OSTRE
   void *sample = allocator->malloc (desc->size);
   memset (sample, 0, desc->size);
   (void) dds_stream_read_impl (is, sample, allocator, desc->ops.ops, false, CDR_KIND_KEY, SAMPLE_DATA_INITIALIZED);
-  bool ok;
-  if (ser_kind == DDS_CDR_KEY_SERIALIZATION_KEYHASH)
-    ok = dds_stream_write_keyBE ((dds_ostreamBE_t *) os, ser_kind, allocator, sample, desc);
-  else
-    ok = dds_stream_write_keyBO (os, ser_kind, allocator, sample, desc);
-  if (!ok)
+  if (!dds_stream_write_keyBO (os, ser_kind, allocator, sample, desc))
   {
     // input must have been proven correct (using normalize), so write can't run into invalid data
     abort ();

--- a/src/core/ddsc/tests/test_common.c
+++ b/src/core/ddsc/tests/test_common.c
@@ -80,16 +80,16 @@ void no_sync_reader_writer (dds_entity_t participant_rd, dds_entity_t reader, dd
   sync_reader_writer_impl (participant_rd, reader, participant_wr, writer, false, timeout);
 }
 
-void xcdr2_ser (const void *obj, const dds_topic_descriptor_t *topic_desc, dds_ostream_t *os)
+void xcdr2_ser (const void *obj, const dds_topic_descriptor_t *topic_desc, dds_ostreamLE_t *os)
 {
   struct dds_cdrstream_desc desc;
   dds_cdrstream_desc_from_topic_desc (&desc, topic_desc);
 
-  os->m_buffer = NULL;
-  os->m_index = 0;
-  os->m_size = 0;
-  os->m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2;
-  bool ret = dds_stream_write_sampleLE ((dds_ostreamLE_t *) os, &dds_cdrstream_default_allocator, obj, &desc);
+  os->x.m_buffer = NULL;
+  os->x.m_index = 0;
+  os->x.m_size = 0;
+  os->x.m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2;
+  bool ret = dds_stream_write_sampleLE (os, &dds_cdrstream_default_allocator, obj, &desc);
   dds_cdrstream_desc_fini (&desc, &dds_cdrstream_default_allocator);
   CU_ASSERT_FATAL (ret);
 }

--- a/src/core/ddsc/tests/test_common.h
+++ b/src/core/ddsc/tests/test_common.h
@@ -24,7 +24,7 @@
 #include "Space.h"
 #include "RoundTrip.h"
 
-void xcdr2_ser (const void *obj, const dds_topic_descriptor_t *desc, dds_ostream_t *os);
+void xcdr2_ser (const void *obj, const dds_topic_descriptor_t *desc, dds_ostreamLE_t *os);
 void xcdr2_deser (const unsigned char *buf, uint32_t sz, void **obj, const dds_topic_descriptor_t *desc);
 
 #endif /* _TEST_COMMON_H_ */

--- a/src/core/ddsc/tests/typebuilder.c
+++ b/src/core/ddsc/tests/typebuilder.c
@@ -86,18 +86,18 @@ static bool ti_to_pairs_equal (dds_sequence_DDS_XTypes_TypeIdentifierTypeObjectP
     if (!to_b)
       return false;
 
-    dds_ostream_t to_a_ser = { NULL, 0, 0, DDSI_RTPS_CDR_ENC_VERSION_2 };
+    dds_ostreamLE_t to_a_ser = { .x = { NULL, 0, 0, DDSI_RTPS_CDR_ENC_VERSION_2 } };
     xcdr2_ser (&a->_buffer[n].type_object, &DDS_XTypes_TypeObject_desc, &to_a_ser);
-    dds_ostream_t to_b_ser = { NULL, 0, 0, DDSI_RTPS_CDR_ENC_VERSION_2 };
+    dds_ostreamLE_t to_b_ser = { .x = { NULL, 0, 0, DDSI_RTPS_CDR_ENC_VERSION_2 } };
     xcdr2_ser (to_b, &DDS_XTypes_TypeObject_desc, &to_b_ser);
 
-    if (to_a_ser.m_index != to_b_ser.m_index)
+    if (to_a_ser.x.m_index != to_b_ser.x.m_index)
       return false;
-    if (memcmp (to_a_ser.m_buffer, to_b_ser.m_buffer, to_a_ser.m_index))
+    if (memcmp (to_a_ser.x.m_buffer, to_b_ser.x.m_buffer, to_a_ser.x.m_index))
       return false;
 
-    dds_ostream_fini (&to_a_ser, &dds_cdrstream_default_allocator);
-    dds_ostream_fini (&to_b_ser, &dds_cdrstream_default_allocator);
+    dds_ostreamLE_fini (&to_a_ser, &dds_cdrstream_default_allocator);
+    dds_ostreamLE_fini (&to_b_ser, &dds_cdrstream_default_allocator);
   }
   return true;
 }

--- a/src/core/ddsc/tests/xtypes_common.c
+++ b/src/core/ddsc/tests/xtypes_common.c
@@ -29,10 +29,10 @@
 
 void typeinfo_ser (struct dds_type_meta_ser *ser, DDS_XTypes_TypeInformation *ti)
 {
-  dds_ostream_t os = { .m_buffer = NULL, .m_index = 0, .m_size = 0, .m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2 };
+  dds_ostreamLE_t os = { .x = { .m_buffer = NULL, .m_index = 0, .m_size = 0, .m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2 } };
   xcdr2_ser (ti, &DDS_XTypes_TypeInformation_desc, &os);
-  ser->data = os.m_buffer;
-  ser->sz = os.m_index;
+  ser->data = os.x.m_buffer;
+  ser->sz = os.x.m_index;
 }
 
 void typeinfo_deser (DDS_XTypes_TypeInformation **ti, const struct dds_type_meta_ser *ser)
@@ -42,10 +42,10 @@ void typeinfo_deser (DDS_XTypes_TypeInformation **ti, const struct dds_type_meta
 
 void typemap_ser (struct dds_type_meta_ser *ser, DDS_XTypes_TypeMapping *tmap)
 {
-  dds_ostream_t os = { .m_buffer = NULL, .m_index = 0, .m_size = 0, .m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2 };
+  dds_ostreamLE_t os = { .x = { .m_buffer = NULL, .m_index = 0, .m_size = 0, .m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2 } };
   xcdr2_ser (tmap, &DDS_XTypes_TypeMapping_desc, &os);
-  ser->data = os.m_buffer;
-  ser->sz = os.m_index;
+  ser->data = os.x.m_buffer;
+  ser->sz = os.x.m_index;
 }
 
 void typemap_deser (DDS_XTypes_TypeMapping **tmap, const struct dds_type_meta_ser *ser)

--- a/src/core/ddsi/src/ddsi_typelib.c
+++ b/src/core/ddsi/src/ddsi_typelib.c
@@ -811,25 +811,24 @@ err:
   return ret;
 }
 
-static dds_return_t xcdr2_ser (const void *obj, const struct dds_cdrstream_desc *desc, dds_ostream_t *os)
+static dds_return_t xcdr2_ser (const void *obj, const struct dds_cdrstream_desc *desc, dds_ostreamLE_t *os)
 {
-  os->m_buffer = NULL;
-  os->m_index = 0;
-  os->m_size = 0;
-  os->m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2;
-  dds_return_t ret = dds_stream_write_sampleLE ((dds_ostreamLE_t *) os, &dds_cdrstream_default_allocator, obj, desc) ? DDS_RETCODE_OK : DDS_RETCODE_BAD_PARAMETER;
-  return ret;
+  os->x.m_buffer = NULL;
+  os->x.m_index = 0;
+  os->x.m_size = 0;
+  os->x.m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2;
+  return dds_stream_write_sampleLE (os, &dds_cdrstream_default_allocator, obj, desc) ? DDS_RETCODE_OK : DDS_RETCODE_BAD_PARAMETER;
 }
 
 static dds_return_t get_typeid_with_size (DDS_XTypes_TypeIdentifierWithSize *typeid_with_size, const DDS_XTypes_TypeIdentifier *ti, const DDS_XTypes_TypeObject *to)
 {
   dds_return_t ret;
-  dds_ostream_t os;
+  dds_ostreamLE_t os;
   ddsi_typeid_copy_impl (&typeid_with_size->type_id, ti);
   if ((ret = xcdr2_ser (to, &DDS_XTypes_TypeObject_cdrstream_desc, &os)) < 0)
     return ret;
-  typeid_with_size->typeobject_serialized_size = os.m_index;
-  dds_ostream_fini (&os, &dds_cdrstream_default_allocator);
+  typeid_with_size->typeobject_serialized_size = os.x.m_index;
+  dds_ostreamLE_fini (&os, &dds_cdrstream_default_allocator);
   return DDS_RETCODE_OK;
 }
 
@@ -1070,7 +1069,7 @@ dds_return_t ddsi_type_get_typeinfo_locked (struct ddsi_domaingv *gv, struct dds
 dds_return_t ddsi_type_get_typeinfo_ser (struct ddsi_domaingv *gv, const struct ddsi_type *type_c, unsigned char **data, uint32_t *sz)
 {
   dds_return_t ret;
-  dds_ostream_t os = { NULL, 0, 0, DDSI_RTPS_CDR_ENC_VERSION_2 };
+  dds_ostreamLE_t os = { .x = { NULL, 0, 0, DDSI_RTPS_CDR_ENC_VERSION_2 } };
   struct ddsi_typeinfo type_info;
   struct ddsi_type *type_m;
 
@@ -1092,8 +1091,8 @@ dds_return_t ddsi_type_get_typeinfo_ser (struct ddsi_domaingv *gv, const struct 
 
   if ((ret = xcdr2_ser (&type_info.x, &DDS_XTypes_TypeInformation_cdrstream_desc, &os)) != DDS_RETCODE_OK)
     goto err_ser;
-  *data = os.m_buffer;
-  *sz = os.m_index;
+  *data = os.x.m_buffer;
+  *sz = os.x.m_index;
 
 err_ser:
   ddsi_typeinfo_fini (&type_info);
@@ -1211,7 +1210,7 @@ err:
 dds_return_t ddsi_type_get_typemap_ser (struct ddsi_domaingv *gv, const struct ddsi_type *type, unsigned char **data, uint32_t *sz)
 {
   dds_return_t ret;
-  dds_ostream_t os = { NULL, 0, 0, DDSI_RTPS_CDR_ENC_VERSION_2 };
+  dds_ostreamLE_t os = { .x = { NULL, 0, 0, DDSI_RTPS_CDR_ENC_VERSION_2 } };
   struct ddsi_typemap type_map;
 
   ddsrt_mutex_lock (&gv->typelib_lock);
@@ -1225,8 +1224,8 @@ dds_return_t ddsi_type_get_typemap_ser (struct ddsi_domaingv *gv, const struct d
   if (ret != DDS_RETCODE_OK)
     goto err;
 
-  *data = os.m_buffer;
-  *sz = os.m_index;
+  *data = os.x.m_buffer;
+  *sz = os.x.m_index;
 err:
   return ret;
 }

--- a/src/core/ddsi/src/ddsi_typewrap.c
+++ b/src/core/ddsi/src/ddsi_typewrap.c
@@ -352,14 +352,14 @@ int ddsi_typeid_compare (const ddsi_typeid_t *a, const ddsi_typeid_t *b)
 
 void ddsi_typeid_ser (const ddsi_typeid_t *type_id, unsigned char **buf, uint32_t *sz)
 {
-  dds_ostream_t os = { .m_buffer = NULL, .m_index = 0, .m_size = 0, .m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2 };
-  if (!dds_stream_writeLE ((dds_ostreamLE_t *) &os, &dds_cdrstream_default_allocator, (const void *) type_id, DDS_XTypes_TypeIdentifier_desc.m_ops))
+  dds_ostreamLE_t os = { .x = { .m_buffer = NULL, .m_index = 0, .m_size = 0, .m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2 } };
+  if (!dds_stream_writeLE (&os, &dds_cdrstream_default_allocator, (const void *) type_id, DDS_XTypes_TypeIdentifier_desc.m_ops))
   {
     // input is always valid
     abort ();
   }
-  *buf = os.m_buffer;
-  *sz = os.m_index;
+  *buf = os.x.m_buffer;
+  *sz = os.x.m_index;
 }
 
 void ddsi_typeid_fini_impl (struct DDS_XTypes_TypeIdentifier *type_id)
@@ -428,8 +428,8 @@ void ddsi_typeobj_get_hash_id_impl (const struct DDS_XTypes_TypeObject *type_obj
   assert (type_obj);
   assert (type_id);
   assert (type_obj->_d == DDS_XTypes_EK_MINIMAL || type_obj->_d == DDS_XTypes_EK_COMPLETE);
-  dds_ostream_t os = { .m_buffer = NULL, .m_index = 0, .m_size = 0, .m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2 };
-  if (!dds_stream_writeLE ((dds_ostreamLE_t *) &os, &dds_cdrstream_default_allocator, (const void *) type_obj, DDS_XTypes_TypeObject_desc.m_ops))
+  dds_ostreamLE_t os = { .x = { .m_buffer = NULL, .m_index = 0, .m_size = 0, .m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2 } };
+  if (!dds_stream_writeLE (&os, &dds_cdrstream_default_allocator, (const void *) type_obj, DDS_XTypes_TypeObject_desc.m_ops))
   {
     // input type object is always valid
     abort ();
@@ -438,11 +438,11 @@ void ddsi_typeobj_get_hash_id_impl (const struct DDS_XTypes_TypeObject *type_obj
   char buf[16];
   ddsrt_md5_state_t md5st;
   ddsrt_md5_init (&md5st);
-  ddsrt_md5_append (&md5st, (ddsrt_md5_byte_t *) os.m_buffer, os.m_index);
+  ddsrt_md5_append (&md5st, (ddsrt_md5_byte_t *) os.x.m_buffer, os.x.m_index);
   ddsrt_md5_finish (&md5st, (ddsrt_md5_byte_t *) buf);
   type_id->_d = type_obj->_d;
   memcpy (type_id->_u.equivalence_hash, buf, sizeof(DDS_XTypes_EquivalenceHash));
-  dds_ostream_fini (&os, &dds_cdrstream_default_allocator);
+  dds_ostreamLE_fini (&os, &dds_cdrstream_default_allocator);
 }
 
 dds_return_t ddsi_typeobj_get_hash_id (const struct DDS_XTypes_TypeObject *type_obj, ddsi_typeid_t *type_id)

--- a/src/idl/src/descriptor_type_meta.c
+++ b/src/idl/src/descriptor_type_meta.c
@@ -96,14 +96,14 @@ static idl_retcode_t
 xcdr2_ser (
   const void *obj,
   const struct dds_cdrstream_desc *desc,
-  dds_ostream_t *os)
+  dds_ostreamLE_t *os)
 {
   // serialize as XCDR2 LE
-  os->m_buffer = NULL;
-  os->m_index = 0;
-  os->m_size = 0;
-  os->m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2;
-  dds_return_t ret = dds_stream_write_sampleLE ((dds_ostreamLE_t *) os, &idlc_cdrstream_default_allocator, obj, desc) ? IDL_RETCODE_OK : IDL_RETCODE_BAD_PARAMETER;
+  os->x.m_buffer = NULL;
+  os->x.m_index = 0;
+  os->x.m_size = 0;
+  os->x.m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2;
+  dds_return_t ret = dds_stream_write_sampleLE (os, &idlc_cdrstream_default_allocator, obj, desc) ? IDL_RETCODE_OK : IDL_RETCODE_BAD_PARAMETER;
   return ret;
 }
 
@@ -343,7 +343,7 @@ get_plain_typeid (const idl_pstate_t *pstate, struct descriptor_type_meta *dtm, 
 idl_retcode_t
 get_type_hash (DDS_XTypes_EquivalenceHash hash, const DDS_XTypes_TypeObject *to)
 {
-  dds_ostream_t os;
+  dds_ostreamLE_t os;
   idl_retcode_t ret;
   if ((ret = xcdr2_ser (to, &DDS_XTypes_TypeObject_cdrstream_desc, &os)) < 0)
     return ret;
@@ -352,10 +352,10 @@ get_type_hash (DDS_XTypes_EquivalenceHash hash, const DDS_XTypes_TypeObject *to)
   char buf[16];
   idl_md5_state_t md5st;
   idl_md5_init (&md5st);
-  idl_md5_append (&md5st, (idl_md5_byte_t *) os.m_buffer, os.m_index);
+  idl_md5_append (&md5st, (idl_md5_byte_t *) os.x.m_buffer, os.x.m_index);
   idl_md5_finish (&md5st, (idl_md5_byte_t *) buf);
   memcpy (hash, buf, sizeof(DDS_XTypes_EquivalenceHash));
-  dds_ostream_fini (&os, &idlc_cdrstream_default_allocator);
+  dds_ostreamLE_fini (&os, &idlc_cdrstream_default_allocator);
   return IDL_RETCODE_OK;
 }
 
@@ -1585,11 +1585,11 @@ get_typeid_with_size (
   assert (ti);
   assert (to);
   memcpy (&typeid_with_size->type_id, ti, sizeof (typeid_with_size->type_id));
-  dds_ostream_t os;
+  dds_ostreamLE_t os;
   if ((ret = xcdr2_ser (to, &DDS_XTypes_TypeObject_cdrstream_desc, &os)) < 0)
     return ret;
-  typeid_with_size->typeobject_serialized_size = os.m_index;
-  dds_ostream_fini (&os, &idlc_cdrstream_default_allocator);
+  typeid_with_size->typeobject_serialized_size = os.x.m_index;
+  dds_ostreamLE_fini (&os, &idlc_cdrstream_default_allocator);
   return IDL_RETCODE_OK;
 }
 
@@ -1728,8 +1728,8 @@ generate_type_meta_ser_impl (
   const idl_pstate_t *pstate,
   const idl_node_t *node,
   struct DDS_XTypes_TypeInformation *type_information,
-  dds_ostream_t *os_typeinfo,
-  dds_ostream_t *os_typemap)
+  dds_ostreamLE_t *os_typeinfo,
+  dds_ostreamLE_t *os_typemap)
 {
   idl_retcode_t ret;
   struct descriptor_type_meta dtm;
@@ -1821,8 +1821,8 @@ print_type_meta_ser (
   const idl_node_t *node)
 {
   struct DDS_XTypes_TypeInformation type_information;
-  dds_ostream_t os_typeinfo;
-  dds_ostream_t os_typemap;
+  dds_ostreamLE_t os_typeinfo;
+  dds_ostreamLE_t os_typemap;
   char *type_name;
   idl_retcode_t rc;
 
@@ -1834,13 +1834,13 @@ print_type_meta_ser (
 
   if ((rc = print_typeinformation_comment (fp, &type_information)) != IDL_RETCODE_OK)
     goto err_print;
-  print_ser_data (fp, "TYPE_INFO_CDR", type_name, os_typeinfo.m_buffer, os_typeinfo.m_index);
-  print_ser_data (fp, "TYPE_MAP_CDR", type_name, os_typemap.m_buffer, os_typemap.m_index);
+  print_ser_data (fp, "TYPE_INFO_CDR", type_name, os_typeinfo.x.m_buffer, os_typeinfo.x.m_index);
+  print_ser_data (fp, "TYPE_MAP_CDR", type_name, os_typemap.x.m_buffer, os_typemap.x.m_index);
 
 err_print:
   xtypes_typeinfo_fini (&type_information);
-  dds_ostream_fini (&os_typeinfo, &idlc_cdrstream_default_allocator);
-  dds_ostream_fini (&os_typemap, &idlc_cdrstream_default_allocator);
+  dds_ostreamLE_fini (&os_typeinfo, &idlc_cdrstream_default_allocator);
+  dds_ostreamLE_fini (&os_typemap, &idlc_cdrstream_default_allocator);
   return rc;
 }
 
@@ -1851,8 +1851,8 @@ generate_type_meta_ser (
   idl_typeinfo_typemap_t *result)
 {
   struct DDS_XTypes_TypeInformation type_information;
-  dds_ostream_t os_typeinfo;
-  dds_ostream_t os_typemap;
+  dds_ostreamLE_t os_typeinfo;
+  dds_ostreamLE_t os_typemap;
   idl_retcode_t rc;
 
   if ((rc = generate_type_meta_ser_impl (state, node, &type_information, &os_typeinfo, &os_typemap)))
@@ -1860,24 +1860,24 @@ generate_type_meta_ser (
 
   result->typeinfo = NULL;
   result->typemap = NULL;
-  result->typeinfo_size = os_typeinfo.m_index;
-  result->typemap_size = os_typemap.m_index;
+  result->typeinfo_size = os_typeinfo.x.m_index;
+  result->typemap_size = os_typemap.x.m_index;
   if ((result->typeinfo = idl_malloc (result->typeinfo_size)) == NULL) {
     rc = IDL_RETCODE_NO_MEMORY;
     goto err_nomem;
   }
-  memcpy (result->typeinfo, os_typeinfo.m_buffer, result->typeinfo_size);
+  memcpy (result->typeinfo, os_typeinfo.x.m_buffer, result->typeinfo_size);
   if ((result->typemap = idl_malloc (result->typemap_size)) == NULL) {
     idl_free (result->typeinfo);
     rc = IDL_RETCODE_NO_MEMORY;
     goto err_nomem;
   }
-  memcpy (result->typemap, os_typemap.m_buffer, result->typemap_size);
+  memcpy (result->typemap, os_typemap.x.m_buffer, result->typemap_size);
 
 err_nomem:
   xtypes_typeinfo_fini (&type_information);
-  dds_ostream_fini (&os_typeinfo, &idlc_cdrstream_default_allocator);
-  dds_ostream_fini (&os_typemap, &idlc_cdrstream_default_allocator);
+  dds_ostreamLE_fini (&os_typeinfo, &idlc_cdrstream_default_allocator);
+  dds_ostreamLE_fini (&os_typemap, &idlc_cdrstream_default_allocator);
   return rc;
 }
 

--- a/src/tools/idlc/tests/type_meta.c
+++ b/src/tools/idlc/tests/type_meta.c
@@ -99,13 +99,13 @@ CU_Test(idlc_type_meta, union_max_label_value)
 }
 
 
-static void xcdr2_ser (const void *obj, const struct dds_cdrstream_desc *desc, dds_ostream_t *os)
+static void xcdr2_ser (const void *obj, const struct dds_cdrstream_desc *desc, dds_ostreamLE_t *os)
 {
-  os->m_buffer = NULL;
-  os->m_index = 0;
-  os->m_size = 0;
-  os->m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2;
-  bool ret = dds_stream_write_sampleLE ((dds_ostreamLE_t *) os, &dds_cdrstream_default_allocator, obj, desc);
+  os->x.m_buffer = NULL;
+  os->x.m_index = 0;
+  os->x.m_size = 0;
+  os->x.m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_2;
+  bool ret = dds_stream_write_sampleLE (os, &dds_cdrstream_default_allocator, obj, desc);
   CU_ASSERT_FATAL (ret);
 }
 
@@ -845,35 +845,35 @@ CU_Test(idlc_type_meta, type_obj_serdes)
       printf ("test type %s %s\n", type_name ? type_name : "<anonymous>", ddsi_make_typeid_str_impl (&tidstr, tm->ti_complete));
 
       // serialize the generated type object
-      dds_ostream_t os;
+      dds_ostreamLE_t os;
       xcdr2_ser (tm->to_complete, &DDS_XTypes_TypeObject_cdrstream_desc, &os);
 
       if (tm->node == descriptor.topic)
       {
-        dds_ostream_t os_test;
+        dds_ostreamLE_t os_test;
         // serializer the reference type object
         DDS_XTypes_TypeObject *to_test = tests[i].get_typeobj_fn();
         xcdr2_ser (to_test, &DDS_XTypes_TypeObject_cdrstream_desc, &os_test);
 
         // compare serialized blobs
-        CU_ASSERT_EQUAL_FATAL (os.m_index, os_test.m_index);
-        assert (os.m_index == os_test.m_index);
-        int cmp = memcmp (os.m_buffer, os_test.m_buffer, os.m_index);
+        CU_ASSERT_EQUAL_FATAL (os.x.m_index, os_test.x.m_index);
+        assert (os.x.m_index == os_test.x.m_index);
+        int cmp = memcmp (os.x.m_buffer, os_test.x.m_buffer, os.x.m_index);
         CU_ASSERT_EQUAL_FATAL (cmp, 0);
 
         dds_stream_free_sample (to_test, &dds_cdrstream_default_allocator, DDS_XTypes_TypeObject_desc.m_ops);
         free (to_test);
-        dds_ostream_fini (&os_test, &dds_cdrstream_default_allocator);
+        dds_ostreamLE_fini (&os_test, &dds_cdrstream_default_allocator);
       }
 
       // test that generated type object can be serialized
       DDS_XTypes_TypeObject *to;
-      xcdr2_deser (os.m_buffer, os.m_index, (void **)&to, &DDS_XTypes_TypeObject_cdrstream_desc);
+      xcdr2_deser (os.x.m_buffer, os.x.m_index, (void **)&to, &DDS_XTypes_TypeObject_cdrstream_desc);
 
       // cleanup
       dds_stream_free_sample (to, &dds_cdrstream_default_allocator, DDS_XTypes_TypeObject_desc.m_ops);
       free (to);
-      dds_ostream_fini (&os, &dds_cdrstream_default_allocator);
+      dds_ostreamLE_fini (&os, &dds_cdrstream_default_allocator);
     }
 
     descriptor_type_meta_fini (&dtm);


### PR DESCRIPTION
... and two unrelated and very minor details.

Thinking about the use of `restrict` while cleaning it up in #2145, it seemed sensible to also mark the output buffer of the serializer as `restrict`. Clearly things will go horribly wrong if it aliases any of the inputs of the serializer, it is one of those essentially untyped buffers and so clearly a case where qualifying it may avoid some reloads of things after storing data in it. I don't really think it is very likely, but ok.

Those restrictions don't apply to the caller's use of the buffer before or after. So `dds_ostream_t` shouldn't be changed ... This solves this by casting a pointer to a `dds_ostream_t` to a pointer of the (new type) `restrict_ostream_t` at the entry points of the serializer. All other casts between the `ostream` variants (and there were quite a few) have been eliminated.

Just the elimination of the multitude of casts was worth the effort. If objections are raised to the use of the `restrict` qualifier for this buffer, then it makes sense to drop just that single `restrict` keyword that this PR adds and keep all the other changes. (Perhaps with the `restrict_ostream_t` renamed, too 🙂)