### PR TITLE
fix minor typos in documentation

### DIFF
--- a/docs/manual/config/config_file_reference.rst
+++ b/docs/manual/config/config_file_reference.rst
@@ -1412,7 +1412,7 @@ The default value is: ``false``
 
 Number-with-unit
 
-Maximum pseudo-random delay in milliseconds between discovering aremote participant and responding to it.
+Maximum pseudo-random delay in milliseconds between discovering a remote participant and responding to it.
 
 The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.
 

--- a/docs/manual/config/discovery-behavior.rst
+++ b/docs/manual/config/discovery-behavior.rst
@@ -137,7 +137,7 @@ When the WHC contains at least ``high`` bytes in unacknowledged samples, it stal
 writer until the number of bytes in unacknowledged samples drops below the value set in: 
 :ref:`Internal/Watermarks/WhcLow <//CycloneDDS/Domain/Internal/Watermarks/WhcLow>`.
 
-Based on the transmit pressure and receive re-ransmit requests, the value of ``high`` is 
+Based on the transmit pressure and receive re-transmit requests, the value of ``high`` is
 dynamically adjusted between:
 - :ref:`Internal/Watermarks/WhcLow <//CycloneDDS/Domain/Internal/Watermarks/WhcLow>`
 - :ref:`Internal/Watermarks/WhcHigh <//CycloneDDS/Domain/Internal/Watermarks/WhcHigh>`

--- a/src/idl/src/scanner.c
+++ b/src/idl/src/scanner.c
@@ -486,7 +486,7 @@ scan_identifier(idl_pstate_t *pstate, const char *cur, const char **lim, bool al
 /* grammer for IDL (>=4.0) is incorrect (or at least ambiguous). blanks,
    horizontal and vertical tabs, newlines, form feeds, and comments
    (collective, "white space") are ignored except as they serve to separate
-   tokens. the specification does not clearly pstate if white space may occur
+   tokens. the specification does not clearly state if white space may occur
    between "::" and adjacent identifiers to form a "scoped_name". the same is
    true for the "annotation_appl". in C++ "::" is an operator and white space
    is therefore allowed, in IDL it is not. this did not use to be a problem,


### PR DESCRIPTION
Files touched:
* docs/manual/config/config_file_reference.rst
* docs/manual/config/discovery-behavior.rst
* src/idl/src/scanner.c