### PR TITLE
Add check for nested optional members in key

### DIFF
--- a/src/core/ddsc/tests/dynamic_type.c
+++ b/src/core/ddsc/tests/dynamic_type.c
@@ -416,10 +416,9 @@ CU_Test (ddsc_dynamic_type, struct_member_prop, .init = dynamic_type_init, .fini
   dds_dynamic_type_set_autoid (&dstruct, DDS_DYNAMIC_TYPE_AUTOID_HASH);
   dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER_PRIM(DDS_DYNAMIC_UINT16, "m1"));
   dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER_PRIM(DDS_DYNAMIC_UINT16, "m2"));
+  dds_dynamic_type_add_member (&dstruct, DDS_DYNAMIC_MEMBER_PRIM(DDS_DYNAMIC_UINT16, "m3"));
 
   dds_return_t ret = dds_dynamic_member_set_key (&dstruct, ddsi_dynamic_type_member_hashid ("m2"), true);
-  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
-  ret = dds_dynamic_member_set_optional (&dstruct, ddsi_dynamic_type_member_hashid ("m2"), true);
   CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
   ret = dds_dynamic_member_set_external (&dstruct, ddsi_dynamic_type_member_hashid ("m2"), true);
   CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
@@ -429,8 +428,12 @@ CU_Test (ddsc_dynamic_type, struct_member_prop, .init = dynamic_type_init, .fini
   ret = dds_dynamic_member_set_must_understand (&dstruct, ddsi_dynamic_type_member_hashid ("m2_name"), true);
   CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
 
+  // Optional and key can't be set to the same member
+  ret = dds_dynamic_member_set_optional (&dstruct, ddsi_dynamic_type_member_hashid ("m3"), true);
+  CU_ASSERT_EQUAL_FATAL (ret, DDS_RETCODE_OK);
+
   struct ddsi_type *type = get_ddsi_type (&dstruct);
-  CU_ASSERT_EQUAL_FATAL (type->xt._u.structure.members.length, 2);
+  CU_ASSERT_EQUAL_FATAL (type->xt._u.structure.members.length, 3);
 
   CU_ASSERT_EQUAL_FATAL (type->xt._u.structure.members.seq[0].id, ddsi_dynamic_type_member_hashid ("m1"));
   CU_ASSERT_FATAL (!(type->xt._u.structure.members.seq[0].flags & DDS_XTypes_IS_KEY));
@@ -440,9 +443,15 @@ CU_Test (ddsc_dynamic_type, struct_member_prop, .init = dynamic_type_init, .fini
 
   CU_ASSERT_EQUAL_FATAL (type->xt._u.structure.members.seq[1].id, ddsi_dynamic_type_member_hashid ("m2_name"));
   CU_ASSERT_FATAL (type->xt._u.structure.members.seq[1].flags & DDS_XTypes_IS_KEY);
-  CU_ASSERT_FATAL (type->xt._u.structure.members.seq[1].flags & DDS_XTypes_IS_OPTIONAL);
+  CU_ASSERT_FATAL (!(type->xt._u.structure.members.seq[1].flags & DDS_XTypes_IS_OPTIONAL));
   CU_ASSERT_FATAL (type->xt._u.structure.members.seq[1].flags & DDS_XTypes_IS_EXTERNAL);
   CU_ASSERT_FATAL (type->xt._u.structure.members.seq[1].flags & DDS_XTypes_IS_MUST_UNDERSTAND);
+
+  CU_ASSERT_EQUAL_FATAL (type->xt._u.structure.members.seq[2].id, ddsi_dynamic_type_member_hashid ("m3"));
+  CU_ASSERT_FATAL (!(type->xt._u.structure.members.seq[2].flags & DDS_XTypes_IS_KEY));
+  CU_ASSERT_FATAL (type->xt._u.structure.members.seq[2].flags & DDS_XTypes_IS_OPTIONAL);
+  CU_ASSERT_FATAL (!(type->xt._u.structure.members.seq[2].flags & DDS_XTypes_IS_EXTERNAL));
+  CU_ASSERT_FATAL (!(type->xt._u.structure.members.seq[2].flags & DDS_XTypes_IS_MUST_UNDERSTAND));
 
   dds_dynamic_type_unref (&dstruct);
 }

--- a/src/idl/src/tree.c
+++ b/src/idl/src/tree.c
@@ -3700,7 +3700,14 @@ static bool no_specific_key(const void *node)
 {
   /* @key(FALSE) is equivalent to missing @key(?) */
   if (idl_mask(node) & IDL_STRUCT) {
-    const idl_member_t *member = ((const idl_struct_t *)node)->members;
+    const idl_struct_t *_struct = (const idl_struct_t *)node;
+    if (_struct->inherit_spec)
+    {
+      if (!no_specific_key(_struct->inherit_spec->base))
+        return false;
+    }
+
+    const idl_member_t *member = _struct->members;
     for (; member; member = idl_next(member)) {
       if (member->key.value)
         return false;

--- a/src/tools/idlc/src/libidlc/libidlc__descriptor.c
+++ b/src/tools/idlc/src/libidlc/libidlc__descriptor.c
@@ -2119,6 +2119,11 @@ static idl_retcode_t get_ctype_keys(const idl_pstate_t *pstate, struct descripto
           if (parent_is_key && !ctype->has_key_member)
             inst->data.opcode.code |= DDS_OP_FLAG_KEY;
           if (inst->data.opcode.code & DDS_OP_FLAG_KEY) {
+            if (inst->data.opcode.code & DDS_OP_FLAG_OPT) {
+              idl_error (pstate, ctype->node, "A member that is part of a key (possibly nested inside a struct) cannot be optional");
+              ret = IDL_RETCODE_SYNTAX_ERROR;
+              goto err;
+            }
             if ((ret = get_ctype_keys_adr(pstate, descriptor, offs, base_type_ops_offs, inst, ctype, n_keys, &ctype_keys)) != IDL_RETCODE_OK)
               goto err;
           }


### PR DESCRIPTION
Optional members as part of a key in a data type are not allowed. A check for optional members in nested types was missing, and is introduced in this commit. The checks is added in the IDL compiler and in the runtime type meta-data validator.

Fixes #2151