### PR TITLE
Some fixes for edge cases

### DIFF
--- a/src/core/ddsc/src/dds__entity.h
+++ b/src/core/ddsc/src/dds__entity.h
@@ -95,10 +95,10 @@ inline dds_entity_kind_t dds_entity_kind (const dds_entity *e) {
 }
 
 /** @component generic_entity */
-void dds_entity_observers_signal (dds_entity *observed, uint32_t status);
+void dds_entity_observers_signal (dds_entity *observed);
 
 /** @component generic_entity */
-void dds_entity_status_signal (dds_entity *e, uint32_t status);
+void dds_entity_status_signal (dds_entity *e);
 
 union dds_status_union {
   dds_inconsistent_topic_status_t inconsistent_topic;
@@ -166,7 +166,7 @@ union dds_status_union {
     else                                                                \
       signal = status_cb_##name_##_invoke (e);                          \
     if (signal)                                                         \
-      dds_entity_observers_signal (&e->m_entity, DDS_##NAME_##_STATUS); \
+      dds_entity_observers_signal (&e->m_entity);                       \
   }
 
 /** @component generic_entity */

--- a/src/core/ddsc/src/dds__readcond.h
+++ b/src/core/ddsc/src/dds__readcond.h
@@ -18,7 +18,7 @@ extern "C" {
 #endif
 
 /** @component data_query */
-dds_readcond * dds_create_readcond_impl (dds_reader *rd, dds_entity_kind_t kind, uint32_t mask, dds_querycondition_filter_fn filter);
+dds_return_t dds_create_readcond_impl (dds_readcond **rdcond_out, dds_reader *rd, dds_entity_kind_t kind, uint32_t mask, dds_querycondition_filter_fn filter);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsc/src/dds__types.h
+++ b/src/core/ddsc/src/dds__types.h
@@ -122,7 +122,7 @@ typedef struct dds_entity_deriver {
 } dds_entity_deriver;
 
 struct dds_waitset;
-typedef void (*dds_entity_callback_t) (struct dds_waitset *observer, dds_entity_t observed, uint32_t status);
+typedef void (*dds_entity_callback_t) (struct dds_waitset *observer, dds_entity_t observed);
 typedef bool (*dds_entity_attach_callback_t) (struct dds_waitset *observer, struct dds_entity *observed, void *attach_arg);
 typedef void (*dds_entity_delete_callback_t) (struct dds_waitset *observer, dds_entity_t observed);
 

--- a/src/core/ddsc/src/dds_entity.c
+++ b/src/core/ddsc/src/dds_entity.c
@@ -1173,6 +1173,7 @@ dds_return_t dds_set_status_mask (dds_entity_t entity, uint32_t mask)
       assert (!(old & DDS_DATA_ON_READERS_STATUS) || dds_entity_kind (e) != DDS_KIND_READER);
       new = (mask << SAM_ENABLED_SHIFT) | (old & SAM_STATUS_MASK);
     } while (!ddsrt_atomic_cas32 (&e->m_status.m_status_and_mask, old, new));
+    dds_entity_observers_signal (e, new & SAM_STATUS_MASK);
     ddsrt_mutex_unlock (&e->m_observers_lock);
   }
   dds_entity_unlock (e);

--- a/src/core/ddsc/src/dds_entity.c
+++ b/src/core/ddsc/src/dds_entity.c
@@ -1173,7 +1173,7 @@ dds_return_t dds_set_status_mask (dds_entity_t entity, uint32_t mask)
       assert (!(old & DDS_DATA_ON_READERS_STATUS) || dds_entity_kind (e) != DDS_KIND_READER);
       new = (mask << SAM_ENABLED_SHIFT) | (old & SAM_STATUS_MASK);
     } while (!ddsrt_atomic_cas32 (&e->m_status.m_status_and_mask, old, new));
-    dds_entity_observers_signal (e, new & SAM_STATUS_MASK);
+    dds_entity_observers_signal (e);
     ddsrt_mutex_unlock (&e->m_observers_lock);
   }
   dds_entity_unlock (e);
@@ -1440,10 +1440,10 @@ dds_return_t dds_entity_observer_unregister (dds_entity *observed, dds_waitset *
   return rc;
 }
 
-void dds_entity_observers_signal (dds_entity *observed, uint32_t status)
+void dds_entity_observers_signal (dds_entity *observed)
 {
   for (dds_entity_observer *idx = observed->m_observers; idx; idx = idx->m_next)
-    idx->m_cb (idx->m_observer, observed->m_hdllink.hdl, status);
+    idx->m_cb (idx->m_observer, observed->m_hdllink.hdl);
 }
 
 static void dds_entity_observers_signal_delete (dds_entity *observed)
@@ -1460,10 +1460,10 @@ static void dds_entity_observers_signal_delete (dds_entity *observed)
   observed->m_observers = NULL;
 }
 
-void dds_entity_status_signal (dds_entity *e, uint32_t status)
+void dds_entity_status_signal (dds_entity *e)
 {
   ddsrt_mutex_lock (&e->m_observers_lock);
-  dds_entity_observers_signal (e, status);
+  dds_entity_observers_signal (e);
   ddsrt_mutex_unlock (&e->m_observers_lock);
 }
 

--- a/src/core/ddsc/src/dds_guardcond.c
+++ b/src/core/ddsc/src/dds_guardcond.c
@@ -90,7 +90,7 @@ dds_return_t dds_set_guardcondition (dds_entity_t guardcond, bool triggered)
       oldst = ddsrt_atomic_ld32 (&e->m_status.m_trigger);
     } while (!ddsrt_atomic_cas32 (&e->m_status.m_trigger, oldst, triggered));
     if (oldst == 0 && triggered != 0)
-      dds_entity_observers_signal (e, triggered);
+      dds_entity_observers_signal (e);
     ddsrt_mutex_unlock (&e->m_observers_lock);
     dds_guardcond_unlock (gcond);
     return DDS_RETCODE_OK;

--- a/src/core/ddsc/src/dds_querycond.c
+++ b/src/core/ddsc/src/dds_querycond.c
@@ -20,19 +20,22 @@
 
 dds_entity_t dds_create_querycondition (dds_entity_t reader, uint32_t mask, dds_querycondition_filter_fn filter)
 {
+  dds_reader *rd;
+  dds_readcond *cond;
   dds_return_t rc;
-  dds_reader *r;
 
-  if ((rc = dds_reader_lock (reader, &r)) != DDS_RETCODE_OK)
+  if ((rc = dds_reader_lock (reader, &rd)) != DDS_RETCODE_OK)
     return rc;
+  else if ((rc = dds_create_readcond_impl (&cond, rd, DDS_KIND_COND_QUERY, mask, filter)) != DDS_RETCODE_OK)
+  {
+    dds_reader_unlock (rd);
+    return rc;
+  }
   else
   {
-    dds_entity_t hdl;
-    dds_readcond *cond = dds_create_readcond_impl (r, DDS_KIND_COND_QUERY, mask, filter);
-    assert (cond);
-    hdl = cond->m_entity.m_hdllink.hdl;
+    dds_entity_t const hdl = cond->m_entity.m_hdllink.hdl;
     dds_entity_init_complete (&cond->m_entity);
-    dds_reader_unlock (r);
+    dds_reader_unlock (rd);
     return hdl;
   }
 }

--- a/src/core/ddsc/src/dds_reader.c
+++ b/src/core/ddsc/src/dds_reader.c
@@ -76,14 +76,14 @@ static dds_return_t dds_reader_delete (dds_entity *e)
   dds_return_t ret = DDS_RETCODE_OK;
   dds_reader * const rd = (dds_reader *) e;
 
-  dds_endpoint_remove_psmx_endpoints (&rd->m_endpoint);
-
   ddsi_thread_state_awake (ddsi_lookup_thread_state (), &e->m_domain->gv);
   dds_rhc_free (rd->m_rhc);
   ddsi_thread_state_asleep (ddsi_lookup_thread_state ());
 
   dds_loan_pool_free (rd->m_heap_loan_cache);
   dds_loan_pool_free (rd->m_loans);
+  dds_endpoint_remove_psmx_endpoints (&rd->m_endpoint);
+
   dds_entity_drop_ref (&rd->m_topic->m_entity);
   return ret;
 }

--- a/src/core/ddsc/src/dds_reader.c
+++ b/src/core/ddsc/src/dds_reader.c
@@ -175,14 +175,14 @@ static void data_avail_cb_trigger_waitsets (dds_entity *rd, uint32_t signal)
     ddsrt_mutex_lock (&sub->m_observers_lock);
     const uint32_t sm = ddsrt_atomic_ld32 (&sub->m_status.m_status_and_mask);
     if ((sm & (sm >> SAM_ENABLED_SHIFT)) & DDS_DATA_ON_READERS_STATUS)
-      dds_entity_observers_signal (sub, DDS_DATA_ON_READERS_STATUS);
+      dds_entity_observers_signal (sub);
     ddsrt_mutex_unlock (&sub->m_observers_lock);
   }
   if (signal & DDS_DATA_AVAILABLE_STATUS)
   {
     const uint32_t sm = ddsrt_atomic_ld32 (&rd->m_status.m_status_and_mask);
     if ((sm & (sm >> SAM_ENABLED_SHIFT)) & DDS_DATA_AVAILABLE_STATUS)
-      dds_entity_observers_signal (rd, DDS_DATA_AVAILABLE_STATUS);
+      dds_entity_observers_signal (rd);
   }
 }
 

--- a/src/core/ddsc/src/dds_rhc_default.c
+++ b/src/core/ddsc/src/dds_rhc_default.c
@@ -2540,7 +2540,7 @@ static bool dds_rhc_default_add_readcondition (struct dds_rhc *rhc_common, dds_r
   if (trigger)
   {
     ddsrt_atomic_st32 (&cond->m_entity.m_status.m_trigger, trigger);
-    dds_entity_status_signal (&cond->m_entity, DDS_DATA_AVAILABLE_STATUS);
+    dds_entity_status_signal (&cond->m_entity);
   }
 
   TRACE ("add_readcondition(%p, %"PRIx32", %"PRIx32", %"PRIx32") => %p qminv %"PRIx32" ; rhc %"PRIu32" conds\n",
@@ -2770,7 +2770,7 @@ static bool update_conditions_locked (struct dds_rhc_default *rhc, bool called_f
 
     if (trigger)
     {
-      dds_entity_status_signal (&iter->m_entity, DDS_DATA_AVAILABLE_STATUS);
+      dds_entity_status_signal (&iter->m_entity);
     }
     TRACE ("\n");
     iter = iter->m_next;

--- a/src/core/ddsc/src/dds_waitset.c
+++ b/src/core/ddsc/src/dds_waitset.c
@@ -219,10 +219,8 @@ dds_return_t dds_waitset_get_entities (dds_entity_t waitset, dds_entity_t *entit
 }
 
 /* This is called when the observed entity signals a status change. */
-static void dds_waitset_observer (struct dds_waitset *ws, dds_entity_t observed, uint32_t status)
+static void dds_waitset_observer (struct dds_waitset *ws, dds_entity_t observed)
 {
-  (void) status;
-
   ddsrt_mutex_lock (&ws->wait_lock);
   /* Move observed entity to triggered list. */
   size_t i;
@@ -413,7 +411,7 @@ dds_return_t dds_waitset_set_trigger (dds_entity_t waitset, bool trigger)
       oldst = ddsrt_atomic_ld32 (&ent->m_status.m_trigger);
     } while (!ddsrt_atomic_cas32 (&ent->m_status.m_trigger, oldst, trigger));
     if (oldst == 0 && trigger != 0)
-      dds_entity_observers_signal (ent, trigger);
+      dds_entity_observers_signal (ent);
     ddsrt_mutex_unlock (&ent->m_observers_lock);
     dds_entity_unpin (ent);
     return DDS_RETCODE_OK;

--- a/src/core/ddsc/tests/querycondition.c
+++ b/src/core/ddsc/tests/querycondition.c
@@ -262,10 +262,29 @@ CU_Theory((dds_entity_t *rdr), ddsc_querycondition_create, non_readers, .init=qu
     cond = dds_create_querycondition(*rdr, mask, filter_mod2);
     CU_ASSERT_EQUAL_FATAL(cond, DDS_RETCODE_ILLEGAL_OPERATION);
 }
-/*************************************************************************************************/
 
+CU_Test(ddsc_querycondition_create, many, .init=querycondition_init, .fini=querycondition_fini)
+{
+    // Current implementation maintains a 32-bits wide bitmask for tracking the query conditions
+    // matched by a sample.  So let's try to create 33 query conditions. We expect it to fail at
+    // the last one and not to crash.
+    dds_entity_t conds[33];
+    dds_return_t ret;
 
+    for (int i = 0; i < 32; i++)
+    {
+      conds[i] = dds_create_querycondition(g_reader, 0, filter_mod2);
+      CU_ASSERT_FATAL(conds[i] > 0);
+    }
+    conds[32] = dds_create_querycondition(g_reader, 0, filter_mod2);
+    CU_ASSERT_FATAL(conds[32] < 0);
 
+    // If we delete one, we should be able to create another one
+    ret = dds_delete (conds[0]);
+    CU_ASSERT_FATAL (ret == 0);
+    conds[32] = dds_create_querycondition(g_reader, 0, filter_mod2);
+    CU_ASSERT_FATAL(conds[32] > 0);
+}
 
 
 /**************************************************************************************************

--- a/src/ddsrt/src/threads/freertos/threads.c
+++ b/src/ddsrt/src/threads/freertos/threads.c
@@ -379,6 +379,11 @@ ddsrt_thread_create(
   {
     return DDS_RETCODE_BAD_PARAMETER;
   }
+  /* Didn't implement setting thread affinity on FreeRTOS yet */
+  if (attr->schedAffinityN > 0)
+  {
+    return DDS_RETCODE_ERROR;
+  }
 
   /* Stack size is quietly increased to match at least the minimum. */
   if (attr->stackSize > size) {

--- a/src/ddsrt/src/threads/posix/threads.c
+++ b/src/ddsrt/src/threads/posix/threads.c
@@ -412,10 +412,10 @@ ddsrt_thread_create (
     }
 #endif
   }
-  
-#if defined (__linux) && !defined(__ANDROID__)
+
   if (tattr.schedAffinityN > 0)
   {
+#if defined (__linux) && !defined(__ANDROID__)
     cpu_set_t cpuset;
     CPU_ZERO (&cpuset);
     for (uint32_t i = 0; i < tattr.schedAffinityN; i++)
@@ -432,8 +432,11 @@ ddsrt_thread_create (
       DDS_ERROR("ddsrt_thread_create(%s): pthread_attr_setinheritsched(EXPLICIT) failed with error %d\n", name, result);
       goto err;
     }
-  }
+#else
+    /* Didn't implement setting thread affinity for this platform yet */
+    goto err;
 #endif
+  }
 
   /* Construct context structure & start thread */
   ctx = ddsrt_malloc (sizeof (thread_context_t));

--- a/src/ddsrt/src/threads/windows/threads.c
+++ b/src/ddsrt/src/threads/windows/threads.c
@@ -117,6 +117,12 @@ ddsrt_thread_create(
   assert(attr != NULL);
   assert(start_routine != NULL);
 
+  if (attr->schedAffinityN > 0)
+  {
+    /* Didn't implement setting thread affinity on Windows yet */
+    return DDS_RETCODE_ERROR;
+  }
+
   if ((ctx = ddsrt_malloc(sizeof(*ctx))) == NULL ||
       (ctx->name = ddsrt_strdup(name)) == NULL)
     return DDS_RETCODE_OUT_OF_RESOURCES;


### PR DESCRIPTION
This PR contains fixes for the following problems:
* deleting a reader with outstanding PSMX loans
* waitset_wait not getting unblocked by set_status_mask
* a crash when trying to create the 33rd query condition on a reader
* silently ignoring thread scheduling affinity settings