### PR TITLE
ddsi_time_t.seconds should be uint32_t

### DIFF
--- a/src/core/ddsi/src/ddsi__time.h
+++ b/src/core/ddsi/src/ddsi__time.h
@@ -21,11 +21,11 @@ extern "C" {
 #endif
 
 typedef struct {
-  int32_t seconds;
+  uint32_t seconds;
   uint32_t fraction;
 } ddsi_time_t;
-#define DDSI_TIME_INFINITE ((ddsi_time_t) { INT32_MAX, UINT32_MAX })
-#define DDSI_TIME_INVALID ((ddsi_time_t) { -1, UINT32_MAX })
+#define DDSI_TIME_INFINITE ((ddsi_time_t) { UINT32_MAX, UINT32_MAX - 1 })
+#define DDSI_TIME_INVALID ((ddsi_time_t) { UINT32_MAX, UINT32_MAX })
 
 typedef ddsi_time_t ddsi_duration_t;
 

--- a/src/core/ddsi/src/ddsi_plist.c
+++ b/src/core/ddsi/src/ddsi_plist.c
@@ -349,7 +349,7 @@ static dds_return_t deser_reliability (void * restrict dst, struct flagset *flag
     return DDS_RETCODE_BAD_PARAMETER;
   if (kind < 1 || kind > 2)
     return DDS_RETCODE_BAD_PARAMETER;
-  mbt.seconds = (int32_t) mbtsec;
+  mbt.seconds = mbtsec;
   mbt.fraction = mbtfrac;
   if (validate_external_duration (&mbt) < 0)
     return DDS_RETCODE_BAD_PARAMETER;
@@ -2693,9 +2693,11 @@ static dds_return_t validate_external_duration (const ddsi_duration_t *d)
 {
   /* Accepted are zero, positive, infinite or invalid as defined in
      the DDS 2.1 spec, table 9.4. */
-  if (d->seconds >= 0)
+  if (d->seconds == 0 && d->fraction == 0)
     return 0;
-  else if (d->seconds == -1 && d->fraction == UINT32_MAX)
+  else if (d->seconds == UINT32_MAX && d->fraction == UINT32_MAX)
+    return 0;
+  else if (d->seconds == UINT32_MAX && d->fraction == UINT32_MAX - 1)
     return 0;
   else
     return DDS_RETCODE_BAD_PARAMETER;

--- a/src/core/ddsi/src/ddsi_receive.c
+++ b/src/core/ddsi/src/ddsi_receive.c
@@ -247,7 +247,7 @@ static enum validation_result validate_InfoTS (ddsi_rtps_info_ts_t *msg, size_t 
   {
     if (byteswap)
     {
-      msg->time.seconds = ddsrt_bswap4 (msg->time.seconds);
+      msg->time.seconds = ddsrt_bswap4u (msg->time.seconds);
       msg->time.fraction = ddsrt_bswap4u (msg->time.fraction);
     }
     return ddsi_is_valid_timestamp (msg->time) ? VR_ACCEPT : VR_MALFORMED;

--- a/src/core/ddsi/src/ddsi_time.c
+++ b/src/core/ddsi/src/ddsi_time.c
@@ -29,7 +29,7 @@ static ddsi_time_t to_ddsi_time (int64_t t)
        of the inverse is correctly rounded anyway, so it shouldn't ever matter. */
     ddsi_time_t x;
     int ns = (int) (t % DDS_NSECS_IN_SEC);
-    x.seconds = (int) (t / DDS_NSECS_IN_SEC);
+    x.seconds = (uint32_t) (t / DDS_NSECS_IN_SEC);
     x.fraction = (unsigned) (((DDS_NSECS_IN_SEC-1) + ((int64_t) ns << 32)) / DDS_NSECS_IN_SEC);
     return x;
   }


### PR DESCRIPTION
ref DDSI-RTPS 9.3.2.1 IDL Definitions 
``` idl
struct Time_t {
  unsigned long seconds; // time in seconds
  unsigned long fraction; // time in sec/2^32
};
```