### PR TITLE
Fix order of dimensions for typedef of array of bounded string.

### DIFF
--- a/src/tools/idlc/src/libidlc/libidlc__types.c
+++ b/src/tools/idlc/src/libidlc/libidlc__types.c
@@ -463,7 +463,6 @@ emit_typedef(
   void *user_data)
 {
   struct generator *gen = user_data;
-  char dims[32] = "";
   const char *fmt, *star = "";
   char *name = NULL, *type = NULL;
   const idl_declarator_t *declarator;
@@ -474,10 +473,15 @@ emit_typedef(
   /* typedef of sequence requires a little magic */
   if (idl_is_sequence(type_spec))
     return emit_sequence_typedef(pstate, revisit, path, node, user_data);
-  if (idl_is_xstring(type_spec) && idl_is_bounded(type_spec))
-    idl_snprintf(dims, sizeof(dims), "[%" PRIu32 "]", idl_bound(type_spec)+1);
-  else if (idl_is_xstring(type_spec))
-    star = "*";
+
+  bool is_bounded_string = false;
+  if ( idl_is_xstring(type_spec) ) {
+    if ( idl_is_bounded(type_spec) ) {
+      is_bounded_string = true;
+    } else {
+      star = "*";
+    }
+  }
 
   const char *type_prefix = get_type_prefix(type_spec);
 
@@ -487,14 +491,18 @@ emit_typedef(
   for (; declarator; declarator = idl_next(declarator)) {
     if (IDL_PRINTA(&name, print_type, declarator) < 0)
       return IDL_RETCODE_NO_MEMORY;
-    fmt = "typedef %1$s%2$s %3$s%4$s%5$s";
-    if (idl_fprintf(gen->header.handle, fmt, type_prefix, type, star, name, dims) < 0)
+    fmt = "typedef %1$s%2$s %3$s%4$s";
+    if (idl_fprintf(gen->header.handle, fmt, type_prefix, type, star, name) < 0)
       return IDL_RETCODE_NO_MEMORY;
     literal = declarator->const_expr;
     for (; literal; literal = idl_next(literal)) {
       fmt = "[%" PRIu32 "]";
       if (idl_fprintf(gen->header.handle, fmt, literal->value.uint32) < 0)
         return IDL_RETCODE_NO_MEMORY;
+    }
+    if ( is_bounded_string ) {
+      // The string bound must come after the array dimensions.
+      idl_fprintf(gen->header.handle, "[%" PRIu32 "]", idl_bound(type_spec)+1);
     }
     fmt = ";\n\n"
           "#define %1$s__alloc() \\\n"

--- a/src/tools/idlc/xtests/CMakeLists.txt
+++ b/src/tools/idlc/xtests/CMakeLists.txt
@@ -27,6 +27,7 @@ set(_sources
   test_union_member_types_r.idl
   test_union_r.idl
   test_bounded_seq.idl
+  test_bounded_str.idl
   test_enum.idl
   test_bool.idl
   test_bitmask.idl

--- a/src/tools/idlc/xtests/test_bounded_str.idl
+++ b/src/tools/idlc/xtests/test_bounded_str.idl
@@ -1,0 +1,101 @@
+// Copyright(c) 2021 to 2022 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+#if defined(__IDLC__)
+
+module test_module
+{
+  typedef string<128> str_t;
+  typedef string<128> str_arr_t[1][2][3];
+
+  @final
+  struct test_bounded_str {
+    string<128> f1;
+    str_t f2;
+    string<128> f3[1][2][3];
+    str_t f4[1][2][3];
+    str_arr_t f5;
+    str_arr_t f6[4];
+  };
+};
+
+#else
+
+#include <string.h>
+#include "dds/ddsrt/heap.h"
+#include "test_bounded_str.h"
+#include "common.h"
+
+const dds_topic_descriptor_t *desc = &test_module_test_bounded_str_desc;
+
+#include <stdio.h>
+
+void init_sample (void *s)
+{
+  test_module_test_bounded_str *s1 = (test_module_test_bounded_str *) s;
+  STRCPY (s1->f1, STR128);
+  STRCPY (s1->f2, STR128);
+
+  for (int i = 0; i < 1; i++)
+    for (int j = 0; j < 2; j++)
+      for (int k = 0; k < 3; k++)
+        STRCPY (s1->f3[i][j][k], STR128);
+
+  for (int i = 0; i < 1; i++)
+    for (int j = 0; j < 2; j++)
+      for (int k = 0; k < 3; k++)
+        STRCPY (s1->f4[i][j][k], STR128);
+
+  for (int i = 0; i < 1; i++)
+    for (int j = 0; j < 2; j++)
+      for (int k = 0; k < 3; k++)
+        STRCPY (s1->f5[i][j][k], STR128);
+
+  for (int n = 0; n < 4; n++)
+    for (int i = 0; i < 1; i++)
+      for (int j = 0; j < 2; j++)
+        for (int k = 0; k < 3; k++)
+          STRCPY (s1->f6[n][i][j][k], STR128);
+}
+
+int cmp_sample (const void *sa, const void *sb)
+{
+  test_module_test_bounded_str *a = (test_module_test_bounded_str *) sa;
+  test_module_test_bounded_str *b = (test_module_test_bounded_str *) sb;
+  CMPSTR (a, b, f1, STR128);
+  CMPSTR (a, b, f2, STR128);
+
+  for (int i = 0; i < 1; i++)
+    for (int j = 0; j < 2; j++)
+      for (int k = 0; k < 3; k++)
+        CMPSTR (a, b, f3[i][j][k], STR128);
+
+  for (int i = 0; i < 1; i++)
+    for (int j = 0; j < 2; j++)
+      for (int k = 0; k < 3; k++)
+        CMPSTR (a, b, f4[i][j][k], STR128);
+
+  for (int i = 0; i < 1; i++)
+    for (int j = 0; j < 2; j++)
+      for (int k = 0; k < 3; k++)
+        CMPSTR (a, b, f5[i][j][k], STR128);
+
+  for (int n = 0; n < 4; n++)
+    for (int i = 0; i < 1; i++)
+      for (int j = 0; j < 2; j++)
+        for (int k = 0; k < 3; k++)
+          CMPSTR (a, b, f6[n][i][j][k], STR128);
+
+  return 0;
+}
+
+NO_KEY_CMP
+
+#endif


### PR DESCRIPTION
An array of bounded string was mapped incorrectly from IDL to C in the sense that it put the dimensions of the array and the string bound in the wrong order, i.e.

```idl
typedef string<16>  str_arr[3];
```
becomes
```c
typedef char Space_str_arr[17][3];
```
when it should be
```c
typedef char Space_str_arr[3][17];
```