### PR TITLE
Add threads list, getrusage and netstat support for QNX

### DIFF
--- a/src/ddsrt/CMakeLists.txt
+++ b/src/ddsrt/CMakeLists.txt
@@ -315,23 +315,28 @@ else()
 
     if(CMAKE_SYSTEM MATCHES "Linux")
       set(DDSRT_HAVE_NETSTAT TRUE)
+      set(DDSRT_HAVE_RUSAGE TRUE)
       list(APPEND sources
         "${source_dir}/src/netstat/linux/netstat.c"
+        "${source_dir}/src/rusage/posix/rusage.c"
         "${source_dir}/src/time/posix/time.c")
     elseif(CMAKE_SYSTEM MATCHES "Darwin")
       set(DDSRT_HAVE_NETSTAT TRUE)
+      set(DDSRT_HAVE_RUSAGE TRUE)
       list(APPEND sources
         "${source_dir}/src/netstat/darwin/netstat.c"
+        "${source_dir}/src/rusage/posix/rusage.c"
         "${source_dir}/src/time/darwin/time.c")
+    elseif(CMAKE_SYSTEM MATCHES "QNX")
+      set(DDSRT_HAVE_NETSTAT TRUE)
+      set(DDSRT_HAVE_RUSAGE TRUE)
+      list(APPEND sources
+        "${source_dir}/src/netstat/qnx/netstat.c"
+        "${source_dir}/src/rusage/posix/rusage.c"
+        "${source_dir}/src/time/posix/time.c")
     else()
       list(APPEND sources
         "${source_dir}/src/time/posix/time.c")
-    endif()
-
-    if(CMAKE_SYSTEM MATCHES "Darwin|Linux")
-      set(DDSRT_HAVE_RUSAGE TRUE)
-      list(APPEND sources
-        "${source_dir}/src/rusage/posix/rusage.c")
     endif()
 
     check_library_exists(c clock_gettime "" HAVE_CLOCK_GETTIME)

--- a/src/ddsrt/include/dds/ddsrt/threads/posix.h
+++ b/src/ddsrt/include/dds/ddsrt/threads/posix.h
@@ -14,7 +14,7 @@
 #include <pthread.h>
 
 #define DDSRT_HAVE_THREAD_SETNAME (1)
-#if defined (__linux) || defined (__APPLE__)
+#if defined (__linux) || defined (__APPLE__) || defined (__QNXNTO__)
 #define DDSRT_HAVE_THREAD_LIST (1)
 #else
 #define DDSRT_HAVE_THREAD_LIST (0)
@@ -51,6 +51,11 @@ typedef TASK_ID ddsrt_tid_t;
 #   define PRIdTID "d" /* typedef int TASK_ID */
 # endif
 /* __VXWORKS__ */
+#elif __QNXNTO__
+typedef int ddsrt_tid_t;
+#define PRIdTID "d"
+typedef int ddsrt_thread_list_id_t;
+/* __QNXNTO__ */
 #else
 typedef uintptr_t ddsrt_tid_t;
 #define PRIdTID PRIuPTR

--- a/src/ddsrt/src/netstat/qnx/netstat.c
+++ b/src/ddsrt/src/netstat/qnx/netstat.c
@@ -1,0 +1,76 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+
+#include <devctl.h>
+#include <sys/ioctl.h>
+#include <sys/dcmd_io-net.h>
+#include <net/if.h>
+#include <net/ifdrvcom.h>
+
+#include <dds/ddsrt/heap.h>
+#include <dds/ddsrt/string.h>
+#include <dds/ddsrt/netstat.h>
+#include <dds/ddsrt/log.h>
+
+struct ddsrt_netstat_control {
+  char *name;
+};
+
+dds_return_t ddsrt_netstat_get (struct ddsrt_netstat_control *control, struct ddsrt_netstat *stats)
+{
+  struct drvcom_stats dstats;
+  nic_stats_t *ifstats;
+  int s;
+
+  if ((s = socket(AF_INET, SOCK_DGRAM, 0)) == -1) {
+    return DDS_RETCODE_ERROR;
+  }
+
+  (void)strncpy(dstats.dcom_cmd.ifdc_name, control->name, IFNAMSIZ);
+  dstats.dcom_cmd.ifdc_cmd = DRVCOM_STATS;
+  dstats.dcom_cmd.ifdc_len = sizeof(*ifstats);
+  ifstats = &dstats.dcom_stats;
+
+  if (devctl(s, SIOCGDRVCOM, &dstats, sizeof(dstats), 0) != EOK) {
+    DDS_ERROR("devctl() failed for SIOCGDRVCOM for if '%s': %s\n", 
+      dstats.dcom_cmd.ifdc_name, strerror(errno));
+    close(s);
+    return DDS_RETCODE_ERROR;
+  }
+  stats->ipkt = ifstats->rxed_ok;
+  stats->opkt = ifstats->txed_ok;
+  stats->ibytes = ifstats->octets_rxed_ok;
+  stats->obytes = ifstats->octets_txed_ok;
+  
+  close(s);
+  return DDS_RETCODE_OK;
+}
+
+
+dds_return_t ddsrt_netstat_new (struct ddsrt_netstat_control **control, const char *device)
+{
+  struct ddsrt_netstat_control *c = ddsrt_malloc (sizeof (*c));
+  struct ddsrt_netstat dummy;
+  c->name = ddsrt_strdup (device);
+  if (ddsrt_netstat_get (c, &dummy) != DDS_RETCODE_OK)
+  {
+    ddsrt_free (c->name);
+    ddsrt_free (c);
+    *control = NULL;
+    return DDS_RETCODE_ERROR;
+  }
+  else
+  {
+    *control = c;
+    return DDS_RETCODE_OK;
+  }
+}
+
+dds_return_t ddsrt_netstat_free (struct ddsrt_netstat_control *control)
+{
+  ddsrt_free (control->name);
+  ddsrt_free (control);
+  return DDS_RETCODE_OK;
+}

--- a/src/ddsrt/src/threads/posix/threads.c
+++ b/src/ddsrt/src/threads/posix/threads.c
@@ -67,7 +67,9 @@ typedef struct {
 #define MAXTHREADNAMESIZE (VX_TASK_NAME_LENGTH)
 #elif defined(__QNXNTO__)
 #include <pthread.h>
+#include <fcntl.h>
 #include <sys/neutrino.h>
+#include <sys/procfs.h>
 #define MAXTHREADNAMESIZE (_NTO_THREAD_NAME_MAX - 1)
 #elif defined(__ZEPHYR__) && defined(CONFIG_THREAD_NAME)
 /* CONFIG_THREAD_MAX_NAME_LEN indicates the max name length,
@@ -604,6 +606,91 @@ ddsrt_thread_getname_anythread (
   assert (size == 0 || namelen < size);
   if (size > 0)
     name[namelen] = 0;
+  return DDS_RETCODE_OK;
+}
+#elif defined __QNXNTO__
+dds_return_t
+ddsrt_thread_list (
+  ddsrt_thread_list_id_t *tids,
+  size_t size)
+{
+  char path[32];
+  int fd;
+  int pos;
+  procfs_info procinfo;
+  int numthreads;
+  pos = snprintf(path, sizeof(path), "/proc/%d/as", getpid());
+  if (pos < 0 || pos >= (int)sizeof(path)) {
+    return DDS_RETCODE_ERROR;
+  }
+  if ((fd = open(path, O_RDONLY)) == -1) {
+    return DDS_RETCODE_NOT_FOUND;
+  }
+  memset(&procinfo, 0, sizeof(procinfo));
+  if (devctl(fd, DCMD_PROC_INFO, &procinfo, sizeof(procinfo), 0) != EOK) {
+    DDS_ERROR("devctl() failed for DCMD_PROC_INFO on pid %d: %s\n", 
+      getpid(), strerror(errno));
+    close(fd);
+    return DDS_RETCODE_ERROR;
+  }
+  /* In QNX, thread IDs for each process start at 1 and increment sequentially,
+     IDs of terminated threads are not reused */
+  int tid = 1;
+  int n;
+  for (n=0; n < procinfo.num_threads; n++) {
+    if ((size_t)n < size) {
+      tids[n] = (ddsrt_thread_list_id_t)tid;
+      tid++;
+    } else {
+      break;
+    }
+  }
+  close(fd);
+  return (n == 0) ? DDS_RETCODE_ERROR : n;
+}
+
+dds_return_t
+ddsrt_thread_getname_anythread (
+  ddsrt_thread_list_id_t tid,
+  char *name,
+  size_t size)
+{
+  char path[100];
+  int fd;
+  int pos;
+  procfs_threadctl tidinfo;
+  struct _thread_name *tn;
+  pos = snprintf(path, sizeof(path), "/proc/%d/as", getpid());
+  if (pos < 0 || pos >= (int)sizeof(path)) {
+    return DDS_RETCODE_ERROR;
+  }
+  if ((fd = open(path, O_RDONLY)) == -1) {
+    return DDS_RETCODE_NOT_FOUND;
+  }
+  memset(&tidinfo, 0, sizeof(tidinfo));
+  tidinfo.tid = tid;
+  tidinfo.cmd = _NTO_TCTL_NAME;
+  tn = (struct _thread_name*)&tidinfo.data;
+  tn->name_buf_len = sizeof(tidinfo.data) - sizeof(*tn);
+  if (tn->name_buf_len < size) {
+    close(fd);
+    return DDS_RETCODE_NOT_ENOUGH_SPACE;
+  }
+  tn->new_name_len = -1; /* get the current name */
+  if (devctl(fd, DCMD_PROC_THREADCTL, &tidinfo, sizeof(tidinfo), 0) != EOK) {
+    DDS_ERROR("devctl() failed for DCMD_PROC_THREADCTL on pid %d and tid %d: %s\n",
+      getpid(), tid, strerror(errno));
+    close(fd);
+    return DDS_RETCODE_ERROR;
+  }
+  if (tidinfo.tid != tid) {
+    /* Requested thread has terminated, devctl() returned info for a different thread */
+    close(fd);
+    return DDS_RETCODE_NOT_FOUND;
+  }
+  strncpy(name, tn->name_buf, size - 1);
+  name[size - 1] = '\0';
+  close(fd);
   return DDS_RETCODE_OK;
 }
 #elif defined __APPLE__


### PR DESCRIPTION
This adds some platform-specific bits and pieces for getting metrics out of the QNX OS (used by ddsperf).