### PR TITLE
Update protocol version to DDSI 2.5

### DIFF
--- a/docs/manual/config/config_file_reference.rst
+++ b/docs/manual/config/config_file_reference.rst
@@ -44,7 +44,7 @@ The default value is: ``any``
 //CycloneDDS/Domain/Compatibility
 =================================
 
-Children: :ref:`AssumeRtiHasPmdEndpoints<//CycloneDDS/Domain/Compatibility/AssumeRtiHasPmdEndpoints>`, :ref:`ExplicitlyPublishQosSetToDefault<//CycloneDDS/Domain/Compatibility/ExplicitlyPublishQosSetToDefault>`, :ref:`ManySocketsMode<//CycloneDDS/Domain/Compatibility/ManySocketsMode>`, :ref:`StandardsConformance<//CycloneDDS/Domain/Compatibility/StandardsConformance>`
+Children: :ref:`AssumeRtiHasPmdEndpoints<//CycloneDDS/Domain/Compatibility/AssumeRtiHasPmdEndpoints>`, :ref:`ExplicitlyPublishQosSetToDefault<//CycloneDDS/Domain/Compatibility/ExplicitlyPublishQosSetToDefault>`, :ref:`ManySocketsMode<//CycloneDDS/Domain/Compatibility/ManySocketsMode>`, :ref:`ProtocolVersion<//CycloneDDS/Domain/Compatibility/ProtocolVersion>`, :ref:`StandardsConformance<//CycloneDDS/Domain/Compatibility/StandardsConformance>`
 
 The Compatibility element allows you to specify various settings related to compatibility with standards and with other DDSI implementations.
 
@@ -87,6 +87,18 @@ This option specifies whether a network socket will be created for each domain p
 Disabling it slightly improves performance and reduces network traffic somewhat. It also causes the set of port numbers needed by Cyclone DDS to become predictable, which may be useful for firewall and NAT configuration.
 
 The default value is: ``single``
+
+
+.. _`//CycloneDDS/Domain/Compatibility/ProtocolVersion`:
+
+//CycloneDDS/Domain/Compatibility/ProtocolVersion
+-------------------------------------------------
+
+Text
+
+This option allows configuring the advertised protocol version.  Valid values are "2.1" and "2.5"
+
+The default value is: ``2.5``
 
 
 .. _`//CycloneDDS/Domain/Compatibility/StandardsConformance`:
@@ -2756,14 +2768,14 @@ The categorisation of tracing output is incomplete and hence most of the verbosi
 The default value is: ``none``
 
 ..
-   generated from ddsi_config.h[42220b1353d36847608f616190face87a0a09548] 
-   generated from ddsi_config.c[1a21a7dc4b1a8552fe5ee879fc24c8172b79a478] 
-   generated from ddsi__cfgelems.h[6ecb019e4cc1bb37a145d8a7d72b3fa3a7f40d62] 
+   generated from ddsi_config.h[fd22386b5a5456d010458848b862bbe2be02b3e4] 
+   generated from ddsi_config.c[ea1079220b5c907e79b1f20fe97de87874d360fd] 
+   generated from ddsi__cfgelems.h[94e38d76830ce8487ad67cb37df5366c1b079c12] 
    generated from cfgunits.h[05f093223fce107d24dd157ebaafa351dc9df752] 
-   generated from _confgen.h[9554f1d72645c0b8bb66ffbfbc3c0fb664fc1a43] 
+   generated from _confgen.h[fd29634526c05c3237dbc3f785030fe022eb7875] 
    generated from _confgen.c[0d833a6f2c98902f1249e63aed03a6164f0791d6] 
    generated from generate_rnc.c[b50e4b7ab1d04b2bc1d361a0811247c337b74934] 
    generated from generate_md.c[789b92e422631684352909cfb8bf43f6ceb16a01] 
    generated from generate_rst.c[3c4b523fbb57c8e4a7e247379d06a8021ccc21c4] 
    generated from generate_xsd.c[6b6818d7f17a35d56c376c04ec1410427f34c0f0] 
-   generated from generate_defconfig.c[631cafee70a6f9480e0267db8ffe883d806f5f70] 
+   generated from generate_defconfig.c[ba599ccf70b6f1929c08a597a6c555ff2375e458] 

--- a/docs/manual/config/config_file_reference.rst
+++ b/docs/manual/config/config_file_reference.rst
@@ -2756,7 +2756,7 @@ The categorisation of tracing output is incomplete and hence most of the verbosi
 The default value is: ``none``
 
 ..
-   generated from ddsi_config.h[c4ccfda527ef98e906da3de8bd1e6d1afb456e99] 
+   generated from ddsi_config.h[42220b1353d36847608f616190face87a0a09548] 
    generated from ddsi_config.c[1a21a7dc4b1a8552fe5ee879fc24c8172b79a478] 
    generated from ddsi__cfgelems.h[6ecb019e4cc1bb37a145d8a7d72b3fa3a7f40d62] 
    generated from cfgunits.h[05f093223fce107d24dd157ebaafa351dc9df752] 

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -20,7 +20,7 @@ The default value is: `any`
 
 
 ### //CycloneDDS/Domain/Compatibility
-Children: [AssumeRtiHasPmdEndpoints](#cycloneddsdomaincompatibilityassumertihaspmdendpoints), [ExplicitlyPublishQosSetToDefault](#cycloneddsdomaincompatibilityexplicitlypublishqossettodefault), [ManySocketsMode](#cycloneddsdomaincompatibilitymanysocketsmode), [StandardsConformance](#cycloneddsdomaincompatibilitystandardsconformance)
+Children: [AssumeRtiHasPmdEndpoints](#cycloneddsdomaincompatibilityassumertihaspmdendpoints), [ExplicitlyPublishQosSetToDefault](#cycloneddsdomaincompatibilityexplicitlypublishqossettodefault), [ManySocketsMode](#cycloneddsdomaincompatibilitymanysocketsmode), [ProtocolVersion](#cycloneddsdomaincompatibilityprotocolversion), [StandardsConformance](#cycloneddsdomaincompatibilitystandardsconformance)
 
 The Compatibility element allows you to specify various settings related to compatibility with standards and with other DDSI implementations.
 
@@ -51,6 +51,14 @@ This option specifies whether a network socket will be created for each domain p
 Disabling it slightly improves performance and reduces network traffic somewhat. It also causes the set of port numbers needed by Cyclone DDS to become predictable, which may be useful for firewall and NAT configuration.
 
 The default value is: `single`
+
+
+#### //CycloneDDS/Domain/Compatibility/ProtocolVersion
+Text
+
+This option allows configuring the advertised protocol version.  Valid values are "2.1" and "2.5"
+
+The default value is: `2.5`
 
 
 #### //CycloneDDS/Domain/Compatibility/StandardsConformance
@@ -1934,14 +1942,14 @@ While none prevents any message from being written to a DDSI2 log file.
 The categorisation of tracing output is incomplete and hence most of the verbosity levels and categories are not of much use in the current release. This is an ongoing process and here we describe the target situation rather than the current situation. Currently, the most useful verbosity levels are config, fine and finest.
 
 The default value is: `none`
-<!--- generated from ddsi_config.h[42220b1353d36847608f616190face87a0a09548] -->
-<!--- generated from ddsi_config.c[1a21a7dc4b1a8552fe5ee879fc24c8172b79a478] -->
-<!--- generated from ddsi__cfgelems.h[6ecb019e4cc1bb37a145d8a7d72b3fa3a7f40d62] -->
+<!--- generated from ddsi_config.h[fd22386b5a5456d010458848b862bbe2be02b3e4] -->
+<!--- generated from ddsi_config.c[ea1079220b5c907e79b1f20fe97de87874d360fd] -->
+<!--- generated from ddsi__cfgelems.h[94e38d76830ce8487ad67cb37df5366c1b079c12] -->
 <!--- generated from cfgunits.h[05f093223fce107d24dd157ebaafa351dc9df752] -->
-<!--- generated from _confgen.h[9554f1d72645c0b8bb66ffbfbc3c0fb664fc1a43] -->
+<!--- generated from _confgen.h[fd29634526c05c3237dbc3f785030fe022eb7875] -->
 <!--- generated from _confgen.c[0d833a6f2c98902f1249e63aed03a6164f0791d6] -->
 <!--- generated from generate_rnc.c[b50e4b7ab1d04b2bc1d361a0811247c337b74934] -->
 <!--- generated from generate_md.c[789b92e422631684352909cfb8bf43f6ceb16a01] -->
 <!--- generated from generate_rst.c[3c4b523fbb57c8e4a7e247379d06a8021ccc21c4] -->
 <!--- generated from generate_xsd.c[6b6818d7f17a35d56c376c04ec1410427f34c0f0] -->
-<!--- generated from generate_defconfig.c[631cafee70a6f9480e0267db8ffe883d806f5f70] -->
+<!--- generated from generate_defconfig.c[ba599ccf70b6f1929c08a597a6c555ff2375e458] -->

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -1934,7 +1934,7 @@ While none prevents any message from being written to a DDSI2 log file.
 The categorisation of tracing output is incomplete and hence most of the verbosity levels and categories are not of much use in the current release. This is an ongoing process and here we describe the target situation rather than the current situation. Currently, the most useful verbosity levels are config, fine and finest.
 
 The default value is: `none`
-<!--- generated from ddsi_config.h[c4ccfda527ef98e906da3de8bd1e6d1afb456e99] -->
+<!--- generated from ddsi_config.h[42220b1353d36847608f616190face87a0a09548] -->
 <!--- generated from ddsi_config.c[1a21a7dc4b1a8552fe5ee879fc24c8172b79a478] -->
 <!--- generated from ddsi__cfgelems.h[6ecb019e4cc1bb37a145d8a7d72b3fa3a7f40d62] -->
 <!--- generated from cfgunits.h[05f093223fce107d24dd157ebaafa351dc9df752] -->

--- a/etc/cyclonedds.rnc
+++ b/etc/cyclonedds.rnc
@@ -1342,7 +1342,7 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==<br>
   memsize = xsd:token { pattern = "0|(\d+(\.\d*)?([Ee][\-+]?\d+)?|\.\d+([Ee][\-+]?\d+)?) *([kMG]i?)?B" }
   maybe_memsize = xsd:token { pattern = "default|0|(\d+(\.\d*)?([Ee][\-+]?\d+)?|\.\d+([Ee][\-+]?\d+)?) *([kMG]i?)?B" }
 }
-# generated from ddsi_config.h[c4ccfda527ef98e906da3de8bd1e6d1afb456e99] 
+# generated from ddsi_config.h[42220b1353d36847608f616190face87a0a09548] 
 # generated from ddsi_config.c[1a21a7dc4b1a8552fe5ee879fc24c8172b79a478] 
 # generated from ddsi__cfgelems.h[6ecb019e4cc1bb37a145d8a7d72b3fa3a7f40d62] 
 # generated from cfgunits.h[05f093223fce107d24dd157ebaafa351dc9df752] 

--- a/etc/cyclonedds.rnc
+++ b/etc/cyclonedds.rnc
@@ -38,6 +38,12 @@ CycloneDDS configuration""" ] ]
           ("false"|"true"|"single"|"none"|"many")
         }?
         & [ a:documentation [ xml:lang="en" """
+<p>This option allows configuring the advertised protocol version.  Valid values are "2.1" and "2.5"</p>
+<p>The default value is: <code>2.5</code></p>""" ] ]
+        element ProtocolVersion {
+          text
+        }?
+        & [ a:documentation [ xml:lang="en" """
 <p>This element sets the level of standards conformance of this instance of the Cyclone DDS Service. Stricter conformance typically means less interoperability with other implementations. Currently, three modes are defined:</p>
 <ul><li><i>pedantic</i>: very strictly conform to the specification, ultimately for compliance testing, but currently of little value because it adheres even to what will most likely turn out to be editing errors in the DDSI standard. Arguably, as long as no errata have been published, the current text is in effect, and that is what pedantic currently does.</li>
 <li><i>strict</i>: a relatively less strict view of the standard than does pedantic: it follows the established behaviour where the standard is obviously in error.</li>
@@ -1342,14 +1348,14 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==<br>
   memsize = xsd:token { pattern = "0|(\d+(\.\d*)?([Ee][\-+]?\d+)?|\.\d+([Ee][\-+]?\d+)?) *([kMG]i?)?B" }
   maybe_memsize = xsd:token { pattern = "default|0|(\d+(\.\d*)?([Ee][\-+]?\d+)?|\.\d+([Ee][\-+]?\d+)?) *([kMG]i?)?B" }
 }
-# generated from ddsi_config.h[42220b1353d36847608f616190face87a0a09548] 
-# generated from ddsi_config.c[1a21a7dc4b1a8552fe5ee879fc24c8172b79a478] 
-# generated from ddsi__cfgelems.h[6ecb019e4cc1bb37a145d8a7d72b3fa3a7f40d62] 
+# generated from ddsi_config.h[fd22386b5a5456d010458848b862bbe2be02b3e4] 
+# generated from ddsi_config.c[ea1079220b5c907e79b1f20fe97de87874d360fd] 
+# generated from ddsi__cfgelems.h[94e38d76830ce8487ad67cb37df5366c1b079c12] 
 # generated from cfgunits.h[05f093223fce107d24dd157ebaafa351dc9df752] 
-# generated from _confgen.h[9554f1d72645c0b8bb66ffbfbc3c0fb664fc1a43] 
+# generated from _confgen.h[fd29634526c05c3237dbc3f785030fe022eb7875] 
 # generated from _confgen.c[0d833a6f2c98902f1249e63aed03a6164f0791d6] 
 # generated from generate_rnc.c[b50e4b7ab1d04b2bc1d361a0811247c337b74934] 
 # generated from generate_md.c[789b92e422631684352909cfb8bf43f6ceb16a01] 
 # generated from generate_rst.c[3c4b523fbb57c8e4a7e247379d06a8021ccc21c4] 
 # generated from generate_xsd.c[6b6818d7f17a35d56c376c04ec1410427f34c0f0] 
-# generated from generate_defconfig.c[631cafee70a6f9480e0267db8ffe883d806f5f70] 
+# generated from generate_defconfig.c[ba599ccf70b6f1929c08a597a6c555ff2375e458] 

--- a/etc/cyclonedds.xsd
+++ b/etc/cyclonedds.xsd
@@ -50,6 +50,7 @@ CycloneDDS configuration</xs:documentation>
         <xs:element minOccurs="0" ref="config:AssumeRtiHasPmdEndpoints"/>
         <xs:element minOccurs="0" ref="config:ExplicitlyPublishQosSetToDefault"/>
         <xs:element minOccurs="0" ref="config:ManySocketsMode"/>
+        <xs:element minOccurs="0" ref="config:ProtocolVersion"/>
         <xs:element minOccurs="0" ref="config:StandardsConformance"/>
       </xs:all>
     </xs:complexType>
@@ -85,6 +86,13 @@ CycloneDDS configuration</xs:documentation>
         <xs:enumeration value="many"/>
       </xs:restriction>
     </xs:simpleType>
+  </xs:element>
+  <xs:element name="ProtocolVersion" type="xs:string">
+    <xs:annotation>
+      <xs:documentation>
+&lt;p&gt;This option allows configuring the advertised protocol version.  Valid values are "2.1" and "2.5"&lt;/p&gt;
+&lt;p&gt;The default value is: &lt;code&gt;2.5&lt;/code&gt;&lt;/p&gt;</xs:documentation>
+    </xs:annotation>
   </xs:element>
   <xs:element name="StandardsConformance">
     <xs:annotation>
@@ -2019,14 +2027,14 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
     </xs:restriction>
   </xs:simpleType>
 </xs:schema>
-<!--- generated from ddsi_config.h[42220b1353d36847608f616190face87a0a09548] -->
-<!--- generated from ddsi_config.c[1a21a7dc4b1a8552fe5ee879fc24c8172b79a478] -->
-<!--- generated from ddsi__cfgelems.h[6ecb019e4cc1bb37a145d8a7d72b3fa3a7f40d62] -->
+<!--- generated from ddsi_config.h[fd22386b5a5456d010458848b862bbe2be02b3e4] -->
+<!--- generated from ddsi_config.c[ea1079220b5c907e79b1f20fe97de87874d360fd] -->
+<!--- generated from ddsi__cfgelems.h[94e38d76830ce8487ad67cb37df5366c1b079c12] -->
 <!--- generated from cfgunits.h[05f093223fce107d24dd157ebaafa351dc9df752] -->
-<!--- generated from _confgen.h[9554f1d72645c0b8bb66ffbfbc3c0fb664fc1a43] -->
+<!--- generated from _confgen.h[fd29634526c05c3237dbc3f785030fe022eb7875] -->
 <!--- generated from _confgen.c[0d833a6f2c98902f1249e63aed03a6164f0791d6] -->
 <!--- generated from generate_rnc.c[b50e4b7ab1d04b2bc1d361a0811247c337b74934] -->
 <!--- generated from generate_md.c[789b92e422631684352909cfb8bf43f6ceb16a01] -->
 <!--- generated from generate_rst.c[3c4b523fbb57c8e4a7e247379d06a8021ccc21c4] -->
 <!--- generated from generate_xsd.c[6b6818d7f17a35d56c376c04ec1410427f34c0f0] -->
-<!--- generated from generate_defconfig.c[631cafee70a6f9480e0267db8ffe883d806f5f70] -->
+<!--- generated from generate_defconfig.c[ba599ccf70b6f1929c08a597a6c555ff2375e458] -->

--- a/etc/cyclonedds.xsd
+++ b/etc/cyclonedds.xsd
@@ -2019,7 +2019,7 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
     </xs:restriction>
   </xs:simpleType>
 </xs:schema>
-<!--- generated from ddsi_config.h[c4ccfda527ef98e906da3de8bd1e6d1afb456e99] -->
+<!--- generated from ddsi_config.h[42220b1353d36847608f616190face87a0a09548] -->
 <!--- generated from ddsi_config.c[1a21a7dc4b1a8552fe5ee879fc24c8172b79a478] -->
 <!--- generated from ddsi__cfgelems.h[6ecb019e4cc1bb37a145d8a7d72b3fa3a7f40d62] -->
 <!--- generated from cfgunits.h[05f093223fce107d24dd157ebaafa351dc9df752] -->

--- a/src/core/ddsc/src/dds__types.h
+++ b/src/core/ddsc/src/dds__types.h
@@ -423,6 +423,7 @@ typedef struct dds_writer {
   struct ddsi_whc *m_whc; /* FIXME: ownership still with underlying DDSI writer (cos of DDSI built-in writers )*/
   bool whc_batch; /* FIXME: channels + latency budget */
   struct dds_loan_pool *m_loans; /* administration of associated loans */
+  ddsi_protocol_version_t protocol_version; /* copy of configured protocol version */
 
   /* Status metrics */
 

--- a/src/core/ddsc/src/dds__write.h
+++ b/src/core/ddsc/src/dds__write.h
@@ -48,6 +48,13 @@ dds_return_t dds_writecdr_local_orphan_impl (struct ddsi_local_orphan_writer *lo
 /** @component write_data */
 void dds_write_flush_impl (dds_writer *wr);
 
+inline bool dds_source_timestamp_is_valid_ddsi_time (dds_time_t timestamp) {
+  // infinity as a source timestamp makes no sense so we disallow it
+  // invalid is useful because of dds_forwardcdr i.c.w. inputs with invalid/missing source timestamps
+  // negative timestamps have always been disallowed by Cyclone and are unrepresentable in DDSI 2.3 and later
+  return (timestamp >= 0 && timestamp <= INT64_C (4294967295999999999)) || (timestamp == DDS_TIME_INVALID);
+}
+
 #if defined (__cplusplus)
 }
 #endif

--- a/src/core/ddsc/src/dds__write.h
+++ b/src/core/ddsc/src/dds__write.h
@@ -48,11 +48,15 @@ dds_return_t dds_writecdr_local_orphan_impl (struct ddsi_local_orphan_writer *lo
 /** @component write_data */
 void dds_write_flush_impl (dds_writer *wr);
 
-inline bool dds_source_timestamp_is_valid_ddsi_time (dds_time_t timestamp) {
+inline bool dds_source_timestamp_is_valid_ddsi_time (dds_time_t timestamp, ddsi_protocol_version_t protover) {
   // infinity as a source timestamp makes no sense so we disallow it
   // invalid is useful because of dds_forwardcdr i.c.w. inputs with invalid/missing source timestamps
   // negative timestamps have always been disallowed by Cyclone and are unrepresentable in DDSI 2.3 and later
-  return (timestamp >= 0 && timestamp <= INT64_C (4294967295999999999)) || (timestamp == DDS_TIME_INVALID);
+  assert (protover.major == 2);
+  if (protover.minor > 2)
+    return (timestamp >= 0 && timestamp <= INT64_C (4294967295999999999)) || (timestamp == DDS_TIME_INVALID);
+  else
+    return (timestamp >= 0 && timestamp <= INT64_C (2147483647999999999)) || (timestamp == DDS_TIME_INVALID);
 }
 
 #if defined (__cplusplus)

--- a/src/core/ddsc/src/dds_instance.c
+++ b/src/core/ddsc/src/dds_instance.c
@@ -107,7 +107,7 @@ dds_return_t dds_unregister_instance_ts (dds_entity_t writer, const void *data, 
   dds_write_action action = DDS_WR_ACTION_UNREGISTER;
   dds_writer *wr;
 
-  if (data == NULL || timestamp < 0)
+  if (data == NULL)
     return DDS_RETCODE_BAD_PARAMETER;
 
   if ((ret = dds_writer_lock (writer, &wr)) != DDS_RETCODE_OK)
@@ -136,9 +136,6 @@ dds_return_t dds_unregister_instance_ih_ts (dds_entity_t writer, dds_instance_ha
   dds_write_action action = DDS_WR_ACTION_UNREGISTER;
   dds_writer *wr;
   struct ddsi_tkmap_instance *tk;
-
-  if (timestamp < 0)
-    return DDS_RETCODE_BAD_PARAMETER;
 
   if ((ret = dds_writer_lock (writer, &wr)) != DDS_RETCODE_OK)
     return ret;
@@ -178,7 +175,7 @@ dds_return_t dds_writedispose_ts (dds_entity_t writer, const void *data, dds_tim
   dds_return_t ret;
   dds_writer *wr;
 
-  if (data == NULL || timestamp < 0)
+  if (data == NULL)
     return DDS_RETCODE_BAD_PARAMETER;
 
   if ((ret = dds_writer_lock (writer, &wr)) != DDS_RETCODE_OK)
@@ -209,7 +206,7 @@ dds_return_t dds_dispose_ts (dds_entity_t writer, const void *data, dds_time_t t
   dds_return_t ret;
   dds_writer *wr;
 
-  if (data == NULL || timestamp < 0)
+  if (data == NULL)
     return DDS_RETCODE_BAD_PARAMETER;
 
   if ((ret = dds_writer_lock (writer, &wr)) != DDS_RETCODE_OK)
@@ -227,9 +224,6 @@ dds_return_t dds_dispose_ih_ts (dds_entity_t writer, dds_instance_handle_t handl
 {
   dds_return_t ret;
   dds_writer *wr;
-
-  if (timestamp < 0)
-    return DDS_RETCODE_BAD_PARAMETER;
 
   if ((ret = dds_writer_lock (writer, &wr)) != DDS_RETCODE_OK)
     return ret;

--- a/src/core/ddsc/src/dds_write.c
+++ b/src/core/ddsc/src/dds_write.c
@@ -32,6 +32,8 @@
 #include "dds__psmx.h"
 #include "dds__guid.h"
 
+extern inline bool dds_source_timestamp_is_valid_ddsi_time (dds_time_t timestamp);
+
 struct ddsi_serdata_plain { struct ddsi_serdata p; };
 struct ddsi_serdata_any   { struct ddsi_serdata a; };
 
@@ -158,7 +160,7 @@ dds_return_t dds_write_ts (dds_entity_t writer, const void *data, dds_time_t tim
   dds_return_t ret;
   dds_writer *wr;
 
-  if (data == NULL || timestamp < 0)
+  if (data == NULL)
     return DDS_RETCODE_BAD_PARAMETER;
 
   if ((ret = dds_writer_lock (writer, &wr)) != DDS_RETCODE_OK)
@@ -464,6 +466,12 @@ static dds_return_t dds_writecdr_impl_common (struct dds_writer *wr, struct ddsi
   // let refc(din) be r, so upon returning it must be r-1
   struct ddsi_thread_state * const thrst = ddsi_lookup_thread_state ();
   dds_return_t ret;
+
+  if (!dds_source_timestamp_is_valid_ddsi_time (din->a.timestamp.v))
+  {
+    ddsi_serdata_unref (&din->a);
+    return DDS_RETCODE_BAD_PARAMETER;
+  }
 
   // Cases:
   //    din    correct      psmx?   loan?
@@ -804,7 +812,9 @@ dds_return_t dds_write_impl (dds_writer *wr, const void *data, dds_time_t timest
   const uint32_t statusinfo =
     (((action & DDS_WR_DISPOSE_BIT) ? DDSI_STATUSINFO_DISPOSE : 0) |
      ((action & DDS_WR_UNREGISTER_BIT) ? DDSI_STATUSINFO_UNREGISTER : 0));
-  int ret = DDS_RETCODE_OK;
+
+  if (!dds_source_timestamp_is_valid_ddsi_time (timestamp))
+    return DDS_RETCODE_BAD_PARAMETER;
 
   if (!evaluate_topic_filter (wr, data, sdkind))
     return DDS_RETCODE_OK;
@@ -852,6 +862,7 @@ dds_return_t dds_write_impl (dds_writer *wr, const void *data, dds_time_t timest
   // other form (serialized PSMX loan and/or serdata), but those don't allow for cheap extraction
   // of the key.  So it can't be freed by "dds_write_impl_psmxloan_serdata".
   struct dds_loaned_sample *loan_to_be_freed;
+  dds_return_t ret = DDS_RETCODE_OK;
   if ((ret = dds_write_impl_psmxloan_serdata (wr, data, sdkind, timestamp, statusinfo, &psmx_loan, &serdata, &loan_to_be_freed)) == DDS_RETCODE_OK)
   {
     assert (psmx_loan != NULL || serdata != NULL);
@@ -924,7 +935,7 @@ dds_return_t dds_write_impl (dds_writer *wr, const void *data, dds_time_t timest
         ret = dds_write_impl_deliver_via_ddsi (thrst, wr, serdata);
       ddsi_serdata_unref (serdata);
     }
-    
+
     if (loan_to_be_freed)
       dds_loaned_sample_unref (loan_to_be_freed);
   }

--- a/src/core/ddsc/src/dds_write.c
+++ b/src/core/ddsc/src/dds_write.c
@@ -32,7 +32,7 @@
 #include "dds__psmx.h"
 #include "dds__guid.h"
 
-extern inline bool dds_source_timestamp_is_valid_ddsi_time (dds_time_t timestamp);
+extern inline bool dds_source_timestamp_is_valid_ddsi_time (dds_time_t timestamp, ddsi_protocol_version_t protover);
 
 struct ddsi_serdata_plain { struct ddsi_serdata p; };
 struct ddsi_serdata_any   { struct ddsi_serdata a; };
@@ -467,7 +467,7 @@ static dds_return_t dds_writecdr_impl_common (struct dds_writer *wr, struct ddsi
   struct ddsi_thread_state * const thrst = ddsi_lookup_thread_state ();
   dds_return_t ret;
 
-  if (!dds_source_timestamp_is_valid_ddsi_time (din->a.timestamp.v))
+  if (!dds_source_timestamp_is_valid_ddsi_time (din->a.timestamp.v, wr->protocol_version))
   {
     ddsi_serdata_unref (&din->a);
     return DDS_RETCODE_BAD_PARAMETER;
@@ -813,7 +813,7 @@ dds_return_t dds_write_impl (dds_writer *wr, const void *data, dds_time_t timest
     (((action & DDS_WR_DISPOSE_BIT) ? DDSI_STATUSINFO_DISPOSE : 0) |
      ((action & DDS_WR_UNREGISTER_BIT) ? DDSI_STATUSINFO_UNREGISTER : 0));
 
-  if (!dds_source_timestamp_is_valid_ddsi_time (timestamp))
+  if (!dds_source_timestamp_is_valid_ddsi_time (timestamp, wr->protocol_version))
     return DDS_RETCODE_BAD_PARAMETER;
 
   if (!evaluate_topic_filter (wr, data, sdkind))

--- a/src/core/ddsc/src/dds_writer.c
+++ b/src/core/ddsc/src/dds_writer.c
@@ -418,6 +418,7 @@ static dds_entity_t dds_create_writer_int (dds_entity_t participant_or_publisher
   // and then disable it for a specific writer.  Should somebody runs into a problem because of this
   // we can have another look.
   wr->whc_batch = wqos->writer_batching.batch_updates || gv->config.whc_batch;
+  wr->protocol_version = gv->config.protocol_version;
 
   if ((rc = dds_endpoint_add_psmx_endpoint (&wr->m_endpoint, wqos, &tp->m_ktopic->psmx_topics, DDS_PSMX_ENDPOINT_TYPE_WRITER)) != DDS_RETCODE_OK)
     goto err_pipe_open;

--- a/src/core/ddsc/tests/test_oneliner.c
+++ b/src/core/ddsc/tests/test_oneliner.c
@@ -791,6 +791,16 @@ static bool qos_partition (struct oneliner_lex *l, dds_qos_t *q)
   return true;
 }
 
+static bool qos_userdata (struct oneliner_lex *l, dds_qos_t *q)
+{
+  const char *p = l->inp;
+  while (*p != 0 && *p != ',' && *p != ')')
+    p++;
+  dds_qset_userdata (q, l->inp, (size_t) (p - l->inp));
+  l->inp = p;
+  return true;
+}
+
 static const struct {
   char *abbrev;
   size_t n;
@@ -812,7 +822,8 @@ static const struct {
   { "ds", 2, qos_durability_service, DDS_DURABILITYSERVICE_QOS_POLICY_ID },
   { "ad", 2, qos_autodispose_unregistered_instances, DDS_WRITERDATALIFECYCLE_QOS_POLICY_ID },
   { "wb", 2, qos_writer_batching, DDS_INVALID_QOS_POLICY_ID },
-  { "part", 4, qos_partition, DDS_PARTITION_QOS_POLICY_ID }
+  { "part", 4, qos_partition, DDS_PARTITION_QOS_POLICY_ID },
+  { "ud", 2, qos_userdata, DDS_USERDATA_QOS_POLICY_ID }
 };
 
 static bool setqos (struct oneliner_lex *l, dds_qos_t *q)

--- a/src/core/ddsc/tests/test_oneliner.c
+++ b/src/core/ddsc/tests/test_oneliner.c
@@ -389,16 +389,17 @@ static int nexttok_dur (struct oneliner_lex *l, union oneliner_tokval *v, bool e
   else if (l->inp[0] == '@' || (expecting_duration && (lookingatnum (l) || lookingatinf (l))))
   {
     const int ists = (l->inp[0] == '@');
+    const int isabs = (ists && l->inp[1] == '=');
     char *endp;
-    if (!ists && strncmp (l->inp + ists, "inf", 3) == 0 && !issymchar (l->inp[ists + 3]))
+    if (!ists && strncmp (l->inp + ists + isabs, "inf", 3) == 0 && !issymchar (l->inp[ists + 3]))
     {
-      l->inp += ists + 3;
+      l->inp += ists + isabs + 3;
       l->v.d = DDS_INFINITY;
     }
     else
     {
       double d;
-      if (ddsrt_strtod (l->inp + ists, &endp, &d) != DDS_RETCODE_OK)
+      if (ddsrt_strtod (l->inp + ists + isabs, &endp, &d) != DDS_RETCODE_OK)
         return false;
       if (!ists && d < 0)
         return false;
@@ -408,7 +409,7 @@ static int nexttok_dur (struct oneliner_lex *l, union oneliner_tokval *v, bool e
         l->v.d = (int64_t) (d * 1e9 + 0.5);
       else
         l->v.d = -(int64_t) (-d * 1e9 + 0.5);
-      if (ists)
+      if (ists && !isabs)
         l->v.d += l->tref;
       l->inp = endp;
     }

--- a/src/core/ddsc/tests/test_oneliner.c
+++ b/src/core/ddsc/tests/test_oneliner.c
@@ -928,6 +928,20 @@ static void make_participant (struct oneliner_ctx *ctx, int ent, dds_qos_t *qos,
     ddsrt_free (conf);
     conf = conf1;
   }
+  void *udata;
+  size_t udatasz;
+  if (dds_qget_userdata (qos, &udata, &udatasz))
+  {
+    // user data is always 0 terminated in output of qget, terminating 0 is not included
+    // in size -- so we can pretend it is just a string
+    static const char *fmt = "%s,<Compatibility><ProtocolVersion>%s</ProtocolVersion></Compatibility>";
+    size_t newsize = strlen (fmt) - 4 + strlen (conf) + udatasz + 1;
+    char *conf1 = ddsrt_malloc (newsize);
+    (void) snprintf (conf1, newsize, fmt, conf, udata);
+    ddsrt_free (conf);
+    conf = conf1;
+    dds_free (udata);
+  }
   entname_t name;
   dds_entity_t bisub;
   mprintf (ctx, "create domain %"PRIu32, domid);

--- a/src/core/ddsi/CMakeLists.txt
+++ b/src/core/ddsi/CMakeLists.txt
@@ -117,6 +117,7 @@ set(hdrs_ddsi
   ddsi_proxy_participant.h
   ddsi_topic.h
   ddsi_endpoint.h
+  ddsi_protocol_version.h
   ddsi_proxy_endpoint.h
   ddsi_gc.h
   ddsi_pmd.h

--- a/src/core/ddsi/defconfig.c
+++ b/src/core/ddsi/defconfig.c
@@ -101,7 +101,7 @@ void ddsi_config_init_default (struct ddsi_config *cfg)
   cfg->ssl_min_version.minor = 3;
 #endif /* DDS_HAS_TCP_TLS */
 }
-/* generated from ddsi_config.h[c4ccfda527ef98e906da3de8bd1e6d1afb456e99] */
+/* generated from ddsi_config.h[42220b1353d36847608f616190face87a0a09548] */
 /* generated from ddsi_config.c[1a21a7dc4b1a8552fe5ee879fc24c8172b79a478] */
 /* generated from ddsi__cfgelems.h[6ecb019e4cc1bb37a145d8a7d72b3fa3a7f40d62] */
 /* generated from cfgunits.h[05f093223fce107d24dd157ebaafa351dc9df752] */

--- a/src/core/ddsi/defconfig.c
+++ b/src/core/ddsi/defconfig.c
@@ -27,6 +27,8 @@ void ddsi_config_init_default (struct ddsi_config *cfg)
   cfg->rmsg_chunk_size = UINT32_C (131072);
   cfg->standards_conformance = INT32_C (2);
   cfg->many_sockets_mode = INT32_C (1);
+  cfg->protocol_version.major = 2;
+  cfg->protocol_version.minor = 5;
   cfg->domainTag = "";
   cfg->extDomainId.isdefault = 1;
   cfg->ds_grace_period = INT64_C (30000000000);
@@ -101,14 +103,14 @@ void ddsi_config_init_default (struct ddsi_config *cfg)
   cfg->ssl_min_version.minor = 3;
 #endif /* DDS_HAS_TCP_TLS */
 }
-/* generated from ddsi_config.h[42220b1353d36847608f616190face87a0a09548] */
-/* generated from ddsi_config.c[1a21a7dc4b1a8552fe5ee879fc24c8172b79a478] */
-/* generated from ddsi__cfgelems.h[6ecb019e4cc1bb37a145d8a7d72b3fa3a7f40d62] */
+/* generated from ddsi_config.h[fd22386b5a5456d010458848b862bbe2be02b3e4] */
+/* generated from ddsi_config.c[ea1079220b5c907e79b1f20fe97de87874d360fd] */
+/* generated from ddsi__cfgelems.h[94e38d76830ce8487ad67cb37df5366c1b079c12] */
 /* generated from cfgunits.h[05f093223fce107d24dd157ebaafa351dc9df752] */
-/* generated from _confgen.h[9554f1d72645c0b8bb66ffbfbc3c0fb664fc1a43] */
+/* generated from _confgen.h[fd29634526c05c3237dbc3f785030fe022eb7875] */
 /* generated from _confgen.c[0d833a6f2c98902f1249e63aed03a6164f0791d6] */
 /* generated from generate_rnc.c[b50e4b7ab1d04b2bc1d361a0811247c337b74934] */
 /* generated from generate_md.c[789b92e422631684352909cfb8bf43f6ceb16a01] */
 /* generated from generate_rst.c[3c4b523fbb57c8e4a7e247379d06a8021ccc21c4] */
 /* generated from generate_xsd.c[6b6818d7f17a35d56c376c04ec1410427f34c0f0] */
-/* generated from generate_defconfig.c[631cafee70a6f9480e0267db8ffe883d806f5f70] */
+/* generated from generate_defconfig.c[ba599ccf70b6f1929c08a597a6c555ff2375e458] */

--- a/src/core/ddsi/include/dds/ddsi/ddsi_config.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_config.h
@@ -417,6 +417,7 @@ struct ddsi_config
   int explicitly_publish_qos_set_to_default;
   enum ddsi_many_sockets_mode many_sockets_mode;
   int assume_rti_has_pmd_endpoints;
+  ddsi_protocol_version_t protocol_version;
 
   struct ddsi_portmapping ports;
 

--- a/src/core/ddsi/include/dds/ddsi/ddsi_config.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_config.h
@@ -18,6 +18,7 @@
 #include "dds/ddsrt/sched.h"
 #include "dds/ddsrt/random.h"
 #include "dds/ddsi/ddsi_portmapping.h"
+#include "dds/ddsi/ddsi_protocol_version.h"
 #include "dds/ddsi/ddsi_locator.h"
 #include "dds/ddsi/ddsi_xqos.h"
 

--- a/src/core/ddsi/include/dds/ddsi/ddsi_protocol.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_protocol.h
@@ -16,6 +16,7 @@
 #include "dds/ddsi/ddsi_feature_check.h"
 #include "dds/ddsi/ddsi_locator.h"
 #include "dds/ddsi/ddsi_guid.h"
+#include "dds/ddsi/ddsi_protocol_version.h"
 
 #if defined (__cplusplus)
 extern "C" {
@@ -42,10 +43,6 @@ extern "C" {
 #define DDSI_LOCATOR_UDPv4MCGEN_INDEX_MASK_BITS 12
 
 typedef uint32_t ddsi_count_t;
-
-typedef struct ddsi_protocol_version {
-  uint8_t major, minor;
-} ddsi_protocol_version_t;
 
 typedef uint64_t ddsi_seqno_t;
 #define DDSI_MAX_SEQ_NUMBER INT64_MAX

--- a/src/core/ddsi/include/dds/ddsi/ddsi_protocol_version.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_protocol_version.h
@@ -1,0 +1,34 @@
+// Copyright(c) 2025 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+#ifndef DDSI_PROTOCOL_VERSION_H
+#define DDSI_PROTOCOL_VERSION_H
+
+#include <stdint.h>
+#include "dds/export.h"
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+typedef struct ddsi_protocol_version {
+  uint8_t major, minor;
+} ddsi_protocol_version_t;
+
+/* This implements DDSI 2.5, accepts 2.1 and later */
+#define DDSI_RTPS_MAJOR 2
+#define DDSI_RTPS_MINOR 5
+#define DDSI_RTPS_MINOR_MINIMUM 1
+
+#if defined (__cplusplus)
+}
+#endif
+
+#endif

--- a/src/core/ddsi/include/dds/ddsi/ddsi_protocol_version.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_protocol_version.h
@@ -24,7 +24,7 @@ typedef struct ddsi_protocol_version {
 
 /* This implements DDSI 2.5, accepts 2.1 and later */
 #define DDSI_RTPS_MAJOR 2
-#define DDSI_RTPS_MINOR 5
+#define DDSI_RTPS_MINOR_LATEST 5
 #define DDSI_RTPS_MINOR_MINIMUM 1
 
 #if defined (__cplusplus)

--- a/src/core/ddsi/src/ddsi__cfgelems.h
+++ b/src/core/ddsi/src/ddsi__cfgelems.h
@@ -975,6 +975,13 @@ static struct cfgelem compatibility_cfgelems[] = {
       "the liveliness protocol are present in RTI participants even when not "
       "properly advertised by the participant discovery protocol.</p>"
     )),
+  STRING("ProtocolVersion", NULL, 1, "2.5",
+    MEMBER(protocol_version),
+    FUNCTIONS(0, uf_protocol_version, 0, pf_protocol_version),
+    DESCRIPTION(
+      "<p>This option allows configuring the advertised protocol version.  Valid "
+      "values are \"2.1\" and \"2.5\"</p>"
+    )),
   END_MARKER
 };
 

--- a/src/core/ddsi/src/ddsi__protocol.h
+++ b/src/core/ddsi/src/ddsi__protocol.h
@@ -59,9 +59,9 @@ extern "C" {
 
 #define DDSI_BES_MASK_NON_SECURITY 0xf000ffffu
 
-/* Only one specific version is grokked */
+/* Oldest version we are willing to work with is DDSI 2.1, this implements DDSI 2.5. */
 #define DDSI_RTPS_MAJOR 2
-#define DDSI_RTPS_MINOR 1
+#define DDSI_RTPS_MINOR 5
 #define DDSI_RTPS_MINOR_MINIMUM 1
 
 #if DDSRT_ENDIAN == DDSRT_LITTLE_ENDIAN

--- a/src/core/ddsi/src/ddsi__protocol.h
+++ b/src/core/ddsi/src/ddsi__protocol.h
@@ -59,11 +59,6 @@ extern "C" {
 
 #define DDSI_BES_MASK_NON_SECURITY 0xf000ffffu
 
-/* Oldest version we are willing to work with is DDSI 2.1, this implements DDSI 2.5. */
-#define DDSI_RTPS_MAJOR 2
-#define DDSI_RTPS_MINOR 5
-#define DDSI_RTPS_MINOR_MINIMUM 1
-
 #if DDSRT_ENDIAN == DDSRT_LITTLE_ENDIAN
 #define DDSI_PROTOCOLID_AS_UINT32 (((uint32_t)'R' << 0) | ((uint32_t)'T' << 8) | ((uint32_t)'P' << 16) | ((uint32_t)'S' << 24))
 #elif DDSRT_ENDIAN == DDSRT_BIG_ENDIAN

--- a/src/core/ddsi/src/ddsi__time.h
+++ b/src/core/ddsi/src/ddsi__time.h
@@ -21,11 +21,11 @@ extern "C" {
 #endif
 
 typedef struct {
-  int32_t seconds;
+  uint32_t seconds;
   uint32_t fraction;
 } ddsi_time_t;
-#define DDSI_TIME_INFINITE ((ddsi_time_t) { INT32_MAX, UINT32_MAX })
-#define DDSI_TIME_INVALID ((ddsi_time_t) { -1, UINT32_MAX })
+#define DDSI_TIME_INFINITE ((ddsi_time_t) { UINT32_MAX, UINT32_MAX - 1 })
+#define DDSI_TIME_INVALID ((ddsi_time_t) { UINT32_MAX, UINT32_MAX })
 
 typedef ddsi_time_t ddsi_duration_t;
 

--- a/src/core/ddsi/src/ddsi__time.h
+++ b/src/core/ddsi/src/ddsi__time.h
@@ -20,6 +20,22 @@
 extern "C" {
 #endif
 
+// DDSI 2.2 and earlier have signed seconds
+typedef struct {
+  int32_t seconds;
+  uint32_t fraction;
+} ddsi_time22_t;
+#define DDSI_TIME22_INFINITE ((ddsi_time22_t) { INT32_MAX, UINT32_MAX })
+#define DDSI_TIME22_INVALID ((ddsi_time22_t) { -1, UINT32_MAX })
+
+// DDSI 2.3 and later have unsigned seconds
+//
+// The CDR representation for TIME_INVALID is the same as that for TIME22_INVALID,
+// so we can allow writing data with the source timestamp set to invalid without
+// breaking compatibility.  This is useful because some DDS implementations do not
+// provide a source timestamp when the destination order QoS is set to "by reception
+// timestamp", which Cyclone turns into an "invalid timestamp", which one would then
+// assume to be valid input to "dds_forwardcdr".
 typedef struct {
   uint32_t seconds;
   uint32_t fraction;
@@ -27,7 +43,7 @@ typedef struct {
 #define DDSI_TIME_INFINITE ((ddsi_time_t) { UINT32_MAX, UINT32_MAX - 1 })
 #define DDSI_TIME_INVALID ((ddsi_time_t) { UINT32_MAX, UINT32_MAX })
 
-typedef ddsi_time_t ddsi_duration_t;
+typedef ddsi_time22_t ddsi_duration_t;
 
 /** @component time_utils */
 bool ddsi_is_valid_timestamp (ddsi_time_t t);
@@ -36,7 +52,16 @@ bool ddsi_is_valid_timestamp (ddsi_time_t t);
 ddsi_time_t ddsi_wctime_to_ddsi_time (ddsrt_wctime_t t);
 
 /** @component time_utils */
+ddsi_time22_t ddsi_wctime_to_ddsi_time22 (ddsrt_wctime_t t);
+
+/** @component time_utils */
 ddsrt_wctime_t ddsi_wctime_from_ddsi_time (ddsi_time_t x);
+
+/** @component time_utils */
+bool ddsi_is_valid_timestamp22 (ddsi_time22_t t);
+
+/** @component time_utils */
+ddsrt_wctime_t ddsi_wctime_from_ddsi_time22 (ddsi_time22_t x);
 
 /** @component time_utils */
 ddsi_duration_t ddsi_duration_from_dds (dds_duration_t t);

--- a/src/core/ddsi/src/ddsi__time.h
+++ b/src/core/ddsi/src/ddsi__time.h
@@ -25,8 +25,12 @@ typedef struct {
   int32_t seconds;
   uint32_t fraction;
 } ddsi_time22_t;
-#define DDSI_TIME22_INFINITE ((ddsi_time22_t) { INT32_MAX, UINT32_MAX })
-#define DDSI_TIME22_INVALID ((ddsi_time22_t) { -1, UINT32_MAX })
+#define DDSI_TIME22_INFINITE_SECONDS INT32_MAX
+#define DDSI_TIME22_INFINITE_FRACTION UINT32_MAX
+#define DDSI_TIME22_INFINITE ((ddsi_time22_t) { DDSI_TIME22_INFINITE_SECONDS, DDSI_TIME22_INFINITE_FRACTION })
+#define DDSI_TIME22_INVALID_SECONDS (-1)
+#define DDSI_TIME22_INVALID_FRACTION UINT32_MAX
+#define DDSI_TIME22_INVALID ((ddsi_time22_t) { DDSI_TIME22_INVALID_SECONDS, DDSI_TIME22_INVALID_FRACTION })
 
 // DDSI 2.3 and later have unsigned seconds
 //
@@ -40,10 +44,25 @@ typedef struct {
   uint32_t seconds;
   uint32_t fraction;
 } ddsi_time_t;
-#define DDSI_TIME_INFINITE ((ddsi_time_t) { UINT32_MAX, UINT32_MAX - 1 })
-#define DDSI_TIME_INVALID ((ddsi_time_t) { UINT32_MAX, UINT32_MAX })
+#define DDSI_TIME_INFINITE_SECONDS UINT32_MAX
+#define DDSI_TIME_INFINITE_FRACTION (UINT32_MAX - 1)
+#define DDSI_TIME_INVALID_SECONDS UINT32_MAX
+#define DDSI_TIME_INVALID_FRACTION UINT32_MAX
+#define DDSI_TIME_INFINITE ((ddsi_time_t) { DDSI_TIME_INFINITE_SECONDS, DDSI_TIME_INFINITE_FRACTION })
+#define DDSI_TIME_INVALID ((ddsi_time_t) { DDSI_TIME_INVALID_SECONDS, DDSI_TIME_INVALID_FRACTION })
 
-typedef ddsi_time22_t ddsi_duration_t;
+typedef struct {
+  int32_t seconds;
+  uint32_t fraction;
+} ddsi_duration_t;
+// duration "invalid" doesn't exist in the spec, we have it for convenience in sharing
+// code between time22 and duration
+#define DDSI_DURATION_INFINITE_SECONDS INT32_MAX
+#define DDSI_DURATION_INFINITE_FRACTION UINT32_MAX
+#define DDSI_DURATION_INVALID_SECONDS (-1)
+#define DDSI_DURATION_INVALID_FRACTION UINT32_MAX
+#define DDSI_DURATION_INFINITE ((ddsi_duration_t) { DDSI_DURATION_INFINITE_SECONDS, DDSI_DURATION_INFINITE_FRACTION })
+#define DDSI_DURATION_INVALID ((ddsi_duration_t) { DDSI_DURATION_INVALID_SECONDS, DDSI_DURATION_INVALID_FRACTION })
 
 /** @component time_utils */
 bool ddsi_is_valid_timestamp (ddsi_time_t t);

--- a/src/core/ddsi/src/ddsi__xmsg.h
+++ b/src/core/ddsi/src/ddsi__xmsg.h
@@ -47,7 +47,7 @@ enum ddsi_xmsg_kind {
 };
 
 /** @component rtps_submsg */
-struct ddsi_xmsgpool *ddsi_xmsgpool_new (void)
+struct ddsi_xmsgpool *ddsi_xmsgpool_new (ddsi_protocol_version_t protocol_version)
   ddsrt_attribute_warn_unused_result;
 
 /** @component rtps_submsg */

--- a/src/core/ddsi/src/ddsi_config.c
+++ b/src/core/ddsi/src/ddsi_config.c
@@ -147,6 +147,7 @@ DUPF(networkAddresses);
 DU(ipv4);
 DUPF(allow_multicast);
 DUPF(boolean);
+DUPF(protocol_version);
 DU(boolean_default);
 PF(boolean_default);
 DUPF(string);
@@ -1105,6 +1106,29 @@ static void pf_min_tls_version (struct ddsi_cfgst *cfgst, void *parent, struct c
   cfg_logelem (cfgst, sources, "%d.%d", p->major, p->minor);
 }
 #endif
+
+static enum update_result uf_protocol_version (struct ddsi_cfgst *cfgst, void *parent, struct cfgelem const * const cfgelem, UNUSED_ARG (int first), const char *value)
+{
+  static const char *vs[] = {
+    "2.1", "2.5", NULL
+  };
+  static const ddsi_protocol_version_t ms[] = {
+    {2,1}, {2,5}, {0,0}
+  };
+  const int idx = list_index (vs, value);
+  ddsi_protocol_version_t * const elem = cfg_address (cfgst, parent, cfgelem);
+  assert (sizeof (vs) / sizeof (*vs) == sizeof (ms) / sizeof (*ms));
+  if (idx < 0)
+    return cfg_error(cfgst, "'%s': undefined value", value);
+  *elem = ms[idx];
+  return URES_SUCCESS;
+}
+
+static void pf_protocol_version (struct ddsi_cfgst *cfgst, void *parent, struct cfgelem const * const cfgelem, uint32_t sources)
+{
+  ddsi_protocol_version_t * const p = cfg_address (cfgst, parent, cfgelem);
+  cfg_logelem (cfgst, sources, "%d.%d", p->major, p->minor);
+}
 
 static enum update_result uf_string (struct ddsi_cfgst *cfgst, void *parent, struct cfgelem const * const cfgelem, UNUSED_ARG (int first), const char *value)
 {

--- a/src/core/ddsi/src/ddsi_discovery_endpoint.c
+++ b/src/core/ddsi/src/ddsi_discovery_endpoint.c
@@ -161,8 +161,7 @@ static int sedp_write_endpoint_impl
   {
     assert (xqos != NULL);
     ps.present |= PP_PROTOCOL_VERSION | PP_VENDORID;
-    ps.protocol_version.major = DDSI_RTPS_MAJOR;
-    ps.protocol_version.minor = DDSI_RTPS_MINOR;
+    ps.protocol_version = gv->config.protocol_version;
     ps.vendorid = DDSI_VENDORID_ECLIPSE;
 
     assert (epcommon != NULL);

--- a/src/core/ddsi/src/ddsi_discovery_spdp.c
+++ b/src/core/ddsi/src/ddsi_discovery_spdp.c
@@ -84,8 +84,7 @@ void ddsi_get_participant_builtin_topic_data (const struct ddsi_participant *pp,
     PP_PROTOCOL_VERSION | PP_VENDORID | PP_DOMAIN_ID;
   dst->participant_guid = pp->e.guid;
   dst->builtin_endpoint_set = pp->bes;
-  dst->protocol_version.major = DDSI_RTPS_MAJOR;
-  dst->protocol_version.minor = DDSI_RTPS_MINOR;
+  dst->protocol_version = gv->config.protocol_version;
   dst->vendorid = DDSI_VENDORID_ECLIPSE;
   dst->domain_id = gv->config.extDomainId.value;
   /* Be sure not to send a DOMAIN_TAG when it is the default (an empty)

--- a/src/core/ddsi/src/ddsi_discovery_topic.c
+++ b/src/core/ddsi/src/ddsi_discovery_topic.c
@@ -42,8 +42,7 @@ static int ddsi_sedp_write_topic_impl (struct ddsi_writer *wr, int alive, const 
 
   assert (xqos != NULL);
   ps.present |= PP_PROTOCOL_VERSION | PP_VENDORID;
-  ps.protocol_version.major = DDSI_RTPS_MAJOR;
-  ps.protocol_version.minor = DDSI_RTPS_MINOR;
+  ps.protocol_version = gv->config.protocol_version;
   ps.vendorid = DDSI_VENDORID_ECLIPSE;
 
   uint64_t qosdiff = ddsi_xqos_delta (xqos, defqos, ~(uint64_t)0);

--- a/src/core/ddsi/src/ddsi_init.c
+++ b/src/core/ddsi/src/ddsi_init.c
@@ -1298,7 +1298,7 @@ int ddsi_init (struct ddsi_domaingv *gv, struct ddsi_psmx_instance_locators *psm
 #endif
   }
 
-  gv->xmsgpool = ddsi_xmsgpool_new ();
+  gv->xmsgpool = ddsi_xmsgpool_new (gv->config.protocol_version);
 
   // copy default participant plist into one that is used for this domain's participants
   // a plain copy is safe because it doesn't alias anything

--- a/src/core/ddsi/src/ddsi_plist.c
+++ b/src/core/ddsi/src/ddsi_plist.c
@@ -349,7 +349,7 @@ static dds_return_t deser_reliability (void * restrict dst, struct flagset *flag
     return DDS_RETCODE_BAD_PARAMETER;
   if (kind < 1 || kind > 2)
     return DDS_RETCODE_BAD_PARAMETER;
-  mbt.seconds = mbtsec;
+  mbt.seconds = (int32_t) mbtsec;
   mbt.fraction = mbtfrac;
   if (validate_external_duration (&mbt) < 0)
     return DDS_RETCODE_BAD_PARAMETER;
@@ -2693,11 +2693,9 @@ static dds_return_t validate_external_duration (const ddsi_duration_t *d)
 {
   /* Accepted are zero, positive, infinite or invalid as defined in
      the DDS 2.1 spec, table 9.4. */
-  if (d->seconds == 0 && d->fraction == 0)
+  if (d->seconds >= 0)
     return 0;
-  else if (d->seconds == UINT32_MAX && d->fraction == UINT32_MAX)
-    return 0;
-  else if (d->seconds == UINT32_MAX && d->fraction == UINT32_MAX - 1)
+  else if (d->seconds == -1 && d->fraction == UINT32_MAX)
     return 0;
   else
     return DDS_RETCODE_BAD_PARAMETER;

--- a/src/core/ddsi/src/ddsi_plist.c
+++ b/src/core/ddsi/src/ddsi_plist.c
@@ -2691,11 +2691,8 @@ void ddsi_plist_delta (uint64_t *pdelta, uint64_t *qdelta, const ddsi_plist_t *x
 
 static dds_return_t validate_external_duration (const ddsi_duration_t *d)
 {
-  /* Accepted are zero, positive, infinite or invalid as defined in
-     the DDS 2.1 spec, table 9.4. */
+  /* Accepted are zero, positive, infinite (= INT32_MAX.UINT32_MAX) */
   if (d->seconds >= 0)
-    return 0;
-  else if (d->seconds == -1 && d->fraction == UINT32_MAX)
     return 0;
   else
     return DDS_RETCODE_BAD_PARAMETER;

--- a/src/core/ddsi/src/ddsi_plist.c
+++ b/src/core/ddsi/src/ddsi_plist.c
@@ -1927,7 +1927,7 @@ static bool print_generic (char * restrict *buf, size_t * restrict bufsize, cons
 
 static int protocol_version_is_newer (ddsi_protocol_version_t pv)
 {
-  return (pv.major < DDSI_RTPS_MAJOR) ? 0 : (pv.major > DDSI_RTPS_MAJOR) ? 1 : (pv.minor > DDSI_RTPS_MINOR);
+  return (pv.major < DDSI_RTPS_MAJOR) ? 0 : (pv.major > DDSI_RTPS_MAJOR) ? 1 : (pv.minor > DDSI_RTPS_MINOR_LATEST);
 }
 
 static dds_return_t dvx_durability_service (void * restrict dst, const struct dd *dd)
@@ -2609,7 +2609,7 @@ static dds_return_t ddsi_xqos_valid_strictness (const struct ddsrt_log_cfg *logc
       }
     }
   }
-  if ((ret = final_validation_qos (xqos, (ddsi_protocol_version_t) { DDSI_RTPS_MAJOR, DDSI_RTPS_MINOR }, DDSI_VENDORID_ECLIPSE, NULL, strict)) < 0)
+  if ((ret = final_validation_qos (xqos, (ddsi_protocol_version_t) { DDSI_RTPS_MAJOR, DDSI_RTPS_MINOR_LATEST }, DDSI_VENDORID_ECLIPSE, NULL, strict)) < 0)
   {
     DDS_CLOG (DDS_LC_PLIST, logcfg, "ddsi_xqos_valid: final validation failed\n");
   }

--- a/src/core/ddsi/src/ddsi_plist.c
+++ b/src/core/ddsi/src/ddsi_plist.c
@@ -349,7 +349,7 @@ static dds_return_t deser_reliability (void * restrict dst, struct flagset *flag
     return DDS_RETCODE_BAD_PARAMETER;
   if (kind < 1 || kind > 2)
     return DDS_RETCODE_BAD_PARAMETER;
-  mbt.seconds = (int32_t) mbtsec;
+  mbt.seconds = mbtsec;
   mbt.fraction = mbtfrac;
   if (validate_external_duration (&mbt) < 0)
     return DDS_RETCODE_BAD_PARAMETER;
@@ -2693,9 +2693,11 @@ static dds_return_t validate_external_duration (const ddsi_duration_t *d)
 {
   /* Accepted are zero, positive, infinite or invalid as defined in
      the DDS 2.1 spec, table 9.4. */
-  if (d->seconds >= 0)
+  if (d->seconds == 0 && d->fraction == 0)
     return 0;
-  else if (d->seconds == -1 && d->fraction == UINT32_MAX)
+  else if (d->seconds == UINT32_MAX && d->fraction == UINT32_MAX)
+    return 0;
+  else if (d->seconds == UINT32_MAX && d->fraction == UINT32_MAX - 1)
     return 0;
   else
     return DDS_RETCODE_BAD_PARAMETER;

--- a/src/core/ddsi/src/ddsi_receive.c
+++ b/src/core/ddsi/src/ddsi_receive.c
@@ -247,7 +247,7 @@ static enum validation_result validate_InfoTS (ddsi_rtps_info_ts_t *msg, size_t 
   {
     if (byteswap)
     {
-      msg->time.seconds = ddsrt_bswap4 (msg->time.seconds);
+      msg->time.seconds = ddsrt_bswap4u (msg->time.seconds);
       msg->time.fraction = ddsrt_bswap4u (msg->time.fraction);
     }
     return ddsi_is_valid_timestamp (msg->time) ? VR_ACCEPT : VR_MALFORMED;

--- a/src/core/ddsi/src/ddsi_receive.c
+++ b/src/core/ddsi/src/ddsi_receive.c
@@ -250,7 +250,7 @@ static enum validation_result validate_InfoTS (const struct ddsi_receiver_state 
       msg->time.seconds = ddsrt_bswap4u (msg->time.seconds);
       msg->time.fraction = ddsrt_bswap4u (msg->time.fraction);
     }
-    if (rst->protocol_version.major * 256 + rst->protocol_version.minor >= 0x203)
+    if (rst->gv->config.protocol_version.minor >= 0x3 && rst->protocol_version.major * 256 + rst->protocol_version.minor >= 0x203)
       return ddsi_is_valid_timestamp (msg->time) ? VR_ACCEPT : VR_MALFORMED;
     else
     {
@@ -1765,7 +1765,7 @@ static int handle_InfoTS (const struct ddsi_receiver_state *rst, const ddsi_rtps
   }
   else
   {
-    if (rst->protocol_version.major * 256 + rst->protocol_version.minor >= 0x203)
+    if (rst->gv->config.protocol_version.minor >= 0x3 && rst->protocol_version.major * 256 + rst->protocol_version.minor >= 0x203)
       *timestamp = ddsi_wctime_from_ddsi_time (msg->time);
     else
     {
@@ -3261,6 +3261,7 @@ static int handle_submsg_sequence
 static void handle_rtps_message (struct ddsi_thread_state * const thrst, struct ddsi_domaingv *gv, struct ddsi_tran_conn * conn, const ddsi_guid_prefix_t *guidprefix, struct ddsi_rbufpool *rbpool, struct ddsi_rmsg *rmsg, size_t sz, unsigned char *msg, const struct ddsi_network_packet_info *pktinfo)
 {
   ddsi_rtps_header_t *hdr = (ddsi_rtps_header_t *) msg;
+  assert (gv->config.protocol_version.major == DDSI_RTPS_MAJOR);
   assert (ddsi_thread_is_asleep ());
   if (sz < DDSI_RTPS_MESSAGE_HEADER_SIZE || *(uint32_t *)msg != DDSI_PROTOCOLID_AS_UINT32)
   {

--- a/src/core/ddsi/src/ddsi_serdata_plist.c
+++ b/src/core/ddsi/src/ddsi_serdata_plist.c
@@ -66,7 +66,7 @@ static struct ddsi_serdata_plist *serdata_plist_new (const struct ddsi_sertype_p
   // these should be overruled by the one creating the serdata
   d->vendorid = DDSI_VENDORID_UNKNOWN;
   d->protoversion.major = DDSI_RTPS_MAJOR;
-  d->protoversion.minor = DDSI_RTPS_MINOR;
+  d->protoversion.minor = DDSI_RTPS_MINOR_LATEST;
   const uint16_t *hdrsrc = cdr_header;
   d->identifier = hdrsrc[0];
   d->options = hdrsrc[1];

--- a/src/core/ddsi/src/ddsi_time.c
+++ b/src/core/ddsi/src/ddsi_time.c
@@ -11,20 +11,21 @@
 #include <assert.h>
 
 #include "dds/ddsrt/time.h"
+#include "dds/ddsrt/static_assert.h"
 #include "ddsi__time.h"
 
 bool ddsi_is_valid_timestamp (ddsi_time_t t)
 {
   // all bit patterns are valid DDSI Timestamps (including "invalid"!), but we reject infinity
   // because it is not a point in time
-  return !(t.seconds == DDSI_TIME_INFINITE.seconds && t.fraction == DDSI_TIME_INFINITE.fraction);
+  return !(t.seconds == DDSI_TIME_INFINITE_SECONDS && t.fraction == DDSI_TIME_INFINITE_FRACTION);
 }
 
 bool ddsi_is_valid_timestamp22 (ddsi_time22_t t)
 {
   // all bit patterns are valid DDSI Timestamps (including "invalid"!), but we reject infinity
   // because it is not a point in time
-  return !(t.seconds == DDSI_TIME22_INFINITE.seconds && t.fraction == DDSI_TIME22_INFINITE.fraction);
+  return !(t.seconds == DDSI_TIME22_INFINITE_SECONDS && t.fraction == DDSI_TIME22_INFINITE_FRACTION);
 }
 
 static ddsi_time_t to_ddsi_time (int64_t t)
@@ -45,21 +46,26 @@ static ddsi_time_t to_ddsi_time (int64_t t)
   }
 }
 
-static ddsi_time22_t to_ddsi_time22 (int64_t t)
+static void to_ddsi_time22_duration (int32_t * restrict seconds, uint32_t * restrict fraction, int64_t t)
 {
   assert (t >= 0 || t == DDS_TIME_INVALID);
   if (t == DDS_NEVER)
-    return DDSI_TIME22_INFINITE;
+  {
+    DDSRT_STATIC_ASSERT(DDSI_TIME22_INVALID_SECONDS == DDSI_DURATION_INVALID_SECONDS &&
+                        DDSI_TIME22_INVALID_FRACTION == DDSI_DURATION_INVALID_FRACTION &&
+                        DDSI_TIME22_INFINITE_SECONDS == DDSI_DURATION_INFINITE_SECONDS &&
+                        DDSI_TIME22_INFINITE_FRACTION == DDSI_DURATION_INFINITE_FRACTION);
+    *seconds = DDSI_TIME22_INFINITE_SECONDS;
+    *fraction = DDSI_TIME22_INFINITE_FRACTION;
+  }
   else
   {
     /* ceiling(ns * 2^32/10^9) -- can't change the ceiling to round-to-nearest
        because that would break backwards compatibility, but round-to-nearest
        of the inverse is correctly rounded anyway, so it shouldn't ever matter. */
-    ddsi_time22_t x;
     int ns = (int) (t % DDS_NSECS_IN_SEC);
-    x.seconds = (int) (t / DDS_NSECS_IN_SEC);
-    x.fraction = (unsigned) (((DDS_NSECS_IN_SEC-1) + ((int64_t) ns << 32)) / DDS_NSECS_IN_SEC);
-    return x;
+    *seconds = (int) (t / DDS_NSECS_IN_SEC);
+    *fraction = (unsigned) (((DDS_NSECS_IN_SEC-1) + ((int64_t) ns << 32)) / DDS_NSECS_IN_SEC);
   }
 }
 
@@ -70,14 +76,16 @@ ddsi_time_t ddsi_wctime_to_ddsi_time (ddsrt_wctime_t t)
 
 ddsi_time22_t ddsi_wctime_to_ddsi_time22 (ddsrt_wctime_t t)
 {
-  return to_ddsi_time22 (t.v);
+  ddsi_time22_t out;
+  to_ddsi_time22_duration (&out.seconds, &out.fraction, t.v);
+  return out;
 }
 
 static int64_t from_ddsi_time (ddsi_time_t x)
 {
-  if (x.seconds == DDSI_TIME_INVALID.seconds && x.fraction == DDSI_TIME_INVALID.fraction)
+  if (x.seconds == DDSI_TIME_INVALID_SECONDS && x.fraction == DDSI_TIME_INVALID_FRACTION)
     return INT64_MIN;
-  if (x.seconds == DDSI_TIME_INFINITE.seconds && x.fraction == DDSI_TIME_INFINITE.fraction)
+  if (x.seconds == DDSI_TIME_INFINITE_SECONDS && x.fraction == DDSI_TIME_INFINITE_FRACTION)
     return DDS_NEVER;
   else
   {
@@ -92,31 +100,39 @@ ddsrt_wctime_t ddsi_wctime_from_ddsi_time (ddsi_time_t x)
   return (ddsrt_wctime_t) { from_ddsi_time (x) };
 }
 
-static int64_t from_ddsi_time22 (ddsi_time22_t x)
+static int64_t from_ddsi_time22_duration (int32_t seconds, uint32_t fraction)
 {
-  if (x.seconds == DDSI_TIME22_INVALID.seconds && x.fraction == DDSI_TIME22_INVALID.fraction)
+  // DURATION_INVALID doesn't really exist
+  DDSRT_STATIC_ASSERT(DDSI_TIME22_INVALID_SECONDS == DDSI_DURATION_INVALID_SECONDS &&
+                      DDSI_TIME22_INVALID_FRACTION == DDSI_DURATION_INVALID_FRACTION &&
+                      DDSI_TIME22_INFINITE_SECONDS == DDSI_DURATION_INFINITE_SECONDS &&
+                      DDSI_TIME22_INFINITE_FRACTION == DDSI_DURATION_INFINITE_FRACTION);
+  if (seconds == DDSI_TIME22_INVALID_SECONDS && fraction == DDSI_TIME22_INVALID_FRACTION)
     return INT64_MIN;
-  if (x.seconds == DDSI_TIME22_INFINITE.seconds && x.fraction == DDSI_TIME22_INFINITE.fraction)
+  if (seconds == DDSI_TIME22_INFINITE_SECONDS && fraction == DDSI_TIME22_INFINITE_FRACTION)
     return DDS_NEVER;
   else
   {
     /* Round-to-nearest conversion of DDSI time fraction to nanoseconds */
-    int ns = (int) (((int64_t) 2147483648u + (int64_t) x.fraction * DDS_NSECS_IN_SEC) >> 32);
-    return x.seconds * DDS_NSECS_IN_SEC + ns;
+    int ns = (int) (((int64_t) 2147483648u + (int64_t) fraction * DDS_NSECS_IN_SEC) >> 32);
+    return seconds * DDS_NSECS_IN_SEC + ns;
   }
 }
 
 ddsrt_wctime_t ddsi_wctime_from_ddsi_time22 (ddsi_time22_t x)
 {
-  return (ddsrt_wctime_t) { from_ddsi_time22 (x) };
+  return (ddsrt_wctime_t) { from_ddsi_time22_duration (x.seconds, x.fraction) };
 }
 
 ddsi_duration_t ddsi_duration_from_dds (dds_duration_t x)
 {
-  return to_ddsi_time22 (x);
+  ddsi_duration_t out;
+  assert (x >= 0);
+  to_ddsi_time22_duration (&out.seconds, &out.fraction, x);
+  return out;
 }
 
 dds_duration_t ddsi_duration_to_dds (ddsi_duration_t x)
 {
-  return from_ddsi_time22 (x);
+  return from_ddsi_time22_duration (x.seconds, x.fraction);
 }

--- a/src/core/ddsi/src/ddsi_time.c
+++ b/src/core/ddsi/src/ddsi_time.c
@@ -15,7 +15,9 @@
 
 bool ddsi_is_valid_timestamp (ddsi_time_t t)
 {
-  return t.seconds != DDSI_TIME_INVALID.seconds && t.fraction != DDSI_TIME_INVALID.fraction;
+  // all bit patterns are valid DDSI Timestamps (including "invalid"!), but we reject infinity
+  // because it is not a point in time
+  return !(t.seconds == DDSI_TIME_INFINITE.seconds && t.fraction == DDSI_TIME_INFINITE.fraction);
 }
 
 static ddsi_time_t to_ddsi_time (int64_t t)

--- a/src/core/ddsi/src/ddsi_time.c
+++ b/src/core/ddsi/src/ddsi_time.c
@@ -29,7 +29,7 @@ static ddsi_time_t to_ddsi_time (int64_t t)
        of the inverse is correctly rounded anyway, so it shouldn't ever matter. */
     ddsi_time_t x;
     int ns = (int) (t % DDS_NSECS_IN_SEC);
-    x.seconds = (int) (t / DDS_NSECS_IN_SEC);
+    x.seconds = (uint32_t) (t / DDS_NSECS_IN_SEC);
     x.fraction = (unsigned) (((DDS_NSECS_IN_SEC-1) + ((int64_t) ns << 32)) / DDS_NSECS_IN_SEC);
     return x;
   }

--- a/src/core/ddsi/tests/plist.c
+++ b/src/core/ddsi/tests/plist.c
@@ -346,7 +346,7 @@ CU_Test (ddsi_plist, locator_lists_reject)
           case REJ_GARBAGE:  plist_rej[12] = 1; break;
         }
         const ddsi_plist_src_t src = {
-          .protocol_version = { DDSI_RTPS_MAJOR, DDSI_RTPS_MINOR },
+          .protocol_version = gv.config.protocol_version,
           .vendorid = DDSI_VENDORID_ECLIPSE,
           .encoding = DDSI_RTPS_PL_CDR_BE,
           .buf = plist_rej,
@@ -436,7 +436,7 @@ CU_Test (ddsi_plist, locator_lists_accept)
         HDR(DDSI_PID_SENTINEL, 0)
       };
       const ddsi_plist_src_t src = {
-        .protocol_version = { DDSI_RTPS_MAJOR, DDSI_RTPS_MINOR },
+        .protocol_version = gv.config.protocol_version,
         .vendorid = DDSI_VENDORID_ECLIPSE,
         .encoding = DDSI_RTPS_PL_CDR_BE,
         .buf = plist_ok,

--- a/src/core/ddsi/tests/plist_leasedur.c
+++ b/src/core/ddsi/tests/plist_leasedur.c
@@ -262,7 +262,7 @@ static void ddsi_plist_leasedur_new_proxypp_impl (bool include_lease_duration)
 
   // not static nor const: we need to patch in the port number
   unsigned char pkt_header[] = {
-    'R', 'T', 'P', 'S', DDSI_RTPS_MAJOR, DDSI_RTPS_MINOR,
+    'R', 'T', 'P', 'S', gv.config.protocol_version.major, gv.config.protocol_version.minor,
     // vendor id: major 1 is a given
     1, DDSI_VENDORID_MINOR_ECLIPSE,
     // GUID prefix: first two bytes ordinarily have vendor id, so 7,7 is
@@ -281,7 +281,7 @@ static void ddsi_plist_leasedur_new_proxypp_impl (bool include_lease_duration)
     HDR (DDSI_PID_PARTICIPANT_GUID, 16),
       TEST_GUIDPREFIX_BYTES, SER32BE (DDSI_ENTITYID_PARTICIPANT),
     HDR (DDSI_PID_BUILTIN_ENDPOINT_SET, 4),         SER32BE (DDSI_DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_ANNOUNCER),
-    HDR (DDSI_PID_PROTOCOL_VERSION, 4),             DDSI_RTPS_MAJOR, DDSI_RTPS_MINOR, 0,0,
+    HDR (DDSI_PID_PROTOCOL_VERSION, 4),             gv.config.protocol_version.major, gv.config.protocol_version.minor, 0,0,
     HDR (DDSI_PID_VENDORID, 4),                     1, DDSI_VENDORID_MINOR_ECLIPSE, 0,0,
     HDR (DDSI_PID_DEFAULT_UNICAST_LOCATOR, 24),     UDPLOCATOR (127,0,0,1, port),
     HDR (DDSI_PID_METATRAFFIC_UNICAST_LOCATOR, 24), UDPLOCATOR (127,0,0,1, port)
@@ -376,7 +376,7 @@ static void ddsi_plist_leasedur_new_proxyrd_impl (bool include_lease_duration)
 
   // not static nor const: we need to patch in the port number
   const unsigned char pkt_p0[] = {
-    'R', 'T', 'P', 'S', DDSI_RTPS_MAJOR, DDSI_RTPS_MINOR,
+    'R', 'T', 'P', 'S', gv.config.protocol_version.major, gv.config.protocol_version.minor,
     // vendor id: major 1 is a given
     1, DDSI_VENDORID_MINOR_ECLIPSE,
     // GUID prefix: first two bytes ordinarily have vendor id, so 7,7 is

--- a/src/core/ddsi/tests/pmd_message.c
+++ b/src/core/ddsi/tests/pmd_message.c
@@ -163,7 +163,7 @@ static void create_fake_proxy_participant (void)
 
   // not static nor const: we need to patch in the port number
   unsigned char spdp_pkt[] = {
-    'R', 'T', 'P', 'S', DDSI_RTPS_MAJOR, DDSI_RTPS_MINOR,
+    'R', 'T', 'P', 'S', gv.config.protocol_version.major, gv.config.protocol_version.minor,
     // vendor id: major 1 is a given
     1, DDSI_VENDORID_MINOR_ECLIPSE,
     // GUID prefix: first two bytes ordinarily have vendor id, so 7,7 is
@@ -183,7 +183,7 @@ static void create_fake_proxy_participant (void)
       TEST_GUIDPREFIX_BYTES, SER32BE (DDSI_ENTITYID_PARTICIPANT),
     HDR (DDSI_PID_BUILTIN_ENDPOINT_SET, 4),
     SER32BE (DDSI_DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_ANNOUNCER | DDSI_BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_WRITER),
-    HDR (DDSI_PID_PROTOCOL_VERSION, 4),             DDSI_RTPS_MAJOR, DDSI_RTPS_MINOR, 0,0,
+    HDR (DDSI_PID_PROTOCOL_VERSION, 4),             gv.config.protocol_version.major, gv.config.protocol_version.minor, 0,0,
     HDR (DDSI_PID_VENDORID, 4),                     1, DDSI_VENDORID_MINOR_ECLIPSE, 0,0,
     HDR (DDSI_PID_DEFAULT_UNICAST_LOCATOR, 24),     UDPLOCATOR (127,0,0,1, port),
     HDR (DDSI_PID_METATRAFFIC_UNICAST_LOCATOR, 24), UDPLOCATOR (127,0,0,1, port),
@@ -244,7 +244,7 @@ static void send_pmd_message (uint32_t seqlo, uint16_t encoding, uint16_t option
 
   // not static nor const: we need to patch in the port number
   unsigned char pmd_pkt[] = {
-    'R', 'T', 'P', 'S', DDSI_RTPS_MAJOR, DDSI_RTPS_MINOR,
+    'R', 'T', 'P', 'S', gv.config.protocol_version.major, gv.config.protocol_version.minor,
     // vendor id: major 1 is a given
     1, DDSI_VENDORID_MINOR_ECLIPSE,
     // GUID prefix: first two bytes ordinarily have vendor id, so 7,7 is

--- a/src/tools/_confgen/_confgen.h
+++ b/src/tools/_confgen/_confgen.h
@@ -45,6 +45,7 @@ void gendef_pf_participantIndex (FILE *fp, void *parent, struct cfgelem const * 
 void gendef_pf_boolean (FILE *fp, void *parent, struct cfgelem const * const cfgelem);
 void gendef_pf_boolean_default (FILE *fp, void *parent, struct cfgelem const * const cfgelem);
 void gendef_pf_besmode (FILE *fp, void *parent, struct cfgelem const * const cfgelem);
+void gendef_pf_protocol_version (FILE *out, void *parent, struct cfgelem const * const cfgelem);
 void gendef_pf_retransmit_merging (FILE *fp, void *parent, struct cfgelem const * const cfgelem);
 void gendef_pf_sched_class (FILE *fp, void *parent, struct cfgelem const * const cfgelem);
 void gendef_pf_entity_naming_mode (FILE *fp, void *parent, struct cfgelem const * const cfgelem);

--- a/src/tools/_confgen/generate_defconfig.c
+++ b/src/tools/_confgen/generate_defconfig.c
@@ -168,6 +168,13 @@ void gendef_pf_boolean_default (FILE *out, void *parent, struct cfgelem const * 
 void gendef_pf_besmode (FILE *out, void *parent, struct cfgelem const * const cfgelem) {
   gendef_pf_int (out, parent, cfgelem);
 }
+void gendef_pf_protocol_version (FILE *out, void *parent, struct cfgelem const * const cfgelem) {
+  ddsi_protocol_version_t * const p = cfg_address (parent, cfgelem);
+  fprintf (out, "\
+  cfg->%s.major = %d;\n\
+  cfg->%s.minor = %d;\n",
+             cfgelem->membername, p->major, cfgelem->membername, p->minor);
+}
 void gendef_pf_retransmit_merging (FILE *out, void *parent, struct cfgelem const * const cfgelem) {
   gendef_pf_int (out, parent, cfgelem);
 }


### PR DESCRIPTION
This builds on #2180 with thanks to @binbowang1987 for doing the initial bit of updating the time representation. This furthermore add changes to:

* validation of the InfoTimestamp submessage — it was broken, but I think also wrong
* make the advertised protocol version configurable
* adds some stuff to "oneliner" to make it easy to configure the protocol version

