### PR TITLE
security add support for pkcs11

### DIFF
--- a/src/security/builtin_plugins/access_control/src/access_control_utils.h
+++ b/src/security/builtin_plugins/access_control/src/access_control_utils.h
@@ -15,6 +15,12 @@
 #include "dds/security/export.h"
 #include "dds/security/dds_security_api.h"
 #include "dds/security/openssl_support.h"
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+#include <openssl/engine.h>
+#else
+#include <openssl/provider.h>
+#endif
+#include <openssl/store.h>
 
 #define DDS_ACCESS_CONTROL_PLUGIN_CONTEXT "Access Control"
 

--- a/src/security/builtin_plugins/authentication/src/auth_utils.c
+++ b/src/security/builtin_plugins/authentication/src/auth_utils.c
@@ -127,67 +127,66 @@ DDS_Security_ValidationResult_t get_subject_name_DER_encoded(const X509 *cert, u
 
 static DDS_Security_ValidationResult_t check_key(EVP_PKEY *key, const char *key_type, bool isPrivate, DDS_Security_SecurityException *ex)
 {
-    DDSRT_UNUSED_ARG(key_type);
+  DDSRT_UNUSED_ARG(key_type);
 
-    if (EVP_PKEY_id(key) == EVP_PKEY_RSA)
+  if (EVP_PKEY_id(key) == EVP_PKEY_RSA)
+  {
+    if (isPrivate)
     {
-        if (isPrivate)
-        {
-            RSA *rsaKey = EVP_PKEY_get1_RSA(key);
-            const bool fail = (rsaKey && RSA_check_key(rsaKey) != 1);
-            RSA_free(rsaKey);
-            if (fail)
-            {
-                DDS_Security_Exception_set_with_openssl_error(ex, DDS_AUTH_PLUGIN_CONTEXT, DDS_SECURITY_ERR_UNDEFINED_CODE, DDS_SECURITY_VALIDATION_FAILED, "RSA key not correct : ");
-                return DDS_SECURITY_VALIDATION_FAILED;
-            }
-        }
+      const RSA *rsaKey = EVP_PKEY_get0_RSA(key);
+      const bool fail = (rsaKey && (RSA_check_key(rsaKey) != 1) && RSA_get0_p(rsaKey));
+      if (fail)
+      {
+        DDS_Security_Exception_set_with_openssl_error(ex, DDS_AUTH_PLUGIN_CONTEXT, DDS_SECURITY_ERR_UNDEFINED_CODE, DDS_SECURITY_VALIDATION_FAILED, "RSA key not correct : ");
+        return DDS_SECURITY_VALIDATION_FAILED;
+      }
     }
-    else
+  }
+  else
+  {
+    assert(EVP_PKEY_id(key) == EVP_PKEY_EC);
+    EC_KEY *ecKey = EVP_PKEY_get1_EC_KEY(key);
+    const bool fail = (ecKey && EC_KEY_check_key(ecKey) != 1);
+    EC_KEY_free(ecKey);
+    if (fail)
     {
-        assert(EVP_PKEY_id(key) == EVP_PKEY_EC);
-        EC_KEY *ecKey = EVP_PKEY_get1_EC_KEY(key);
-        const bool fail = (ecKey && EC_KEY_check_key(ecKey) != 1);
-        EC_KEY_free(ecKey);
-        if (fail)
-        {
-            DDS_Security_Exception_set(ex, DDS_AUTH_PLUGIN_CONTEXT, DDS_SECURITY_ERR_UNDEFINED_CODE, DDS_SECURITY_VALIDATION_FAILED, "EC key not correct : ");
-            return DDS_SECURITY_VALIDATION_FAILED;
-        }
+      DDS_Security_Exception_set(ex, DDS_AUTH_PLUGIN_CONTEXT, DDS_SECURITY_ERR_UNDEFINED_CODE, DDS_SECURITY_VALIDATION_FAILED, "EC key not correct : ");
+      return DDS_SECURITY_VALIDATION_FAILED;
     }
-    return DDS_SECURITY_VALIDATION_OK;
+  }
+  return DDS_SECURITY_VALIDATION_OK;
 }
 
 #else
 
 static DDS_Security_ValidationResult_t check_key(EVP_PKEY *key, const char *key_type, int isPrivate, DDS_Security_SecurityException *ex)
 {
-    DDS_Security_ValidationResult_t result = DDS_SECURITY_VALIDATION_OK;
-    EVP_PKEY_CTX *ctx = NULL;
+  DDS_Security_ValidationResult_t result = DDS_SECURITY_VALIDATION_OK;
+  EVP_PKEY_CTX *ctx = NULL;
 
-    if ((ctx = EVP_PKEY_CTX_new_from_pkey(NULL, key, NULL)) == NULL)
+  if ((ctx = EVP_PKEY_CTX_new_from_pkey(NULL, key, NULL)) == NULL)
+  {
+    DDS_Security_Exception_set(ex, DDS_AUTH_PLUGIN_CONTEXT, DDS_SECURITY_ERR_UNDEFINED_CODE, DDS_SECURITY_VALIDATION_FAILED, "EVP_PKEY_CTX_new_from_pkey(%s) failed : ", key_type);
+    return DDS_SECURITY_VALIDATION_FAILED;
+  }
+  if (isPrivate)
+  {
+    if (EVP_PKEY_private_check(ctx) != 1)
     {
-        DDS_Security_Exception_set(ex, DDS_AUTH_PLUGIN_CONTEXT, DDS_SECURITY_ERR_UNDEFINED_CODE, DDS_SECURITY_VALIDATION_FAILED, "EVP_PKEY_CTX_new_from_pkey(%s) failed : ", key_type);
-        return DDS_SECURITY_VALIDATION_FAILED;
+      DDS_Security_Exception_set(ex, DDS_AUTH_PLUGIN_CONTEXT, DDS_SECURITY_ERR_UNDEFINED_CODE, DDS_SECURITY_VALIDATION_FAILED, "%s key not correct : ", key_type);
+      result = DDS_SECURITY_VALIDATION_FAILED  ;
     }
-    if (isPrivate)
+  }
+  else
+  {
+    if (EVP_PKEY_public_check(ctx) != 1)
     {
-        if (EVP_PKEY_private_check(ctx) != 1)
-        {
-            DDS_Security_Exception_set(ex, DDS_AUTH_PLUGIN_CONTEXT, DDS_SECURITY_ERR_UNDEFINED_CODE, DDS_SECURITY_VALIDATION_FAILED, "%s key not correct : ", key_type);
-            result = DDS_SECURITY_VALIDATION_FAILED  ;
-        }
+      DDS_Security_Exception_set(ex, DDS_AUTH_PLUGIN_CONTEXT, DDS_SECURITY_ERR_UNDEFINED_CODE, DDS_SECURITY_VALIDATION_FAILED, "%s key not correct : ", key_type);
+      result = DDS_SECURITY_VALIDATION_FAILED  ;
     }
-    else
-    {
-        if (EVP_PKEY_public_check(ctx) != 1)
-        {
-            DDS_Security_Exception_set(ex, DDS_AUTH_PLUGIN_CONTEXT, DDS_SECURITY_ERR_UNDEFINED_CODE, DDS_SECURITY_VALIDATION_FAILED, "%s key not correct : ", key_type);
-            result = DDS_SECURITY_VALIDATION_FAILED  ;
-        }
-    }
-    EVP_PKEY_CTX_free(ctx);
-    return result;
+  }
+  EVP_PKEY_CTX_free(ctx);
+  return result;
 }
 
 #endif
@@ -427,6 +426,233 @@ static DDS_Security_ValidationResult_t load_private_key_from_file(const char *fi
   }
 }
 
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+static DDS_Security_ValidationResult_t load_X509_certificate_from_pkcs11(const char *uri, X509 **x509Cert, DDS_Security_SecurityException *ex)
+{
+  ENGINE *engine;
+  struct {
+    const char *cert_id;
+    X509 *cert;
+  } parms;
+
+  if (!(engine = ENGINE_by_id("pkcs11"))) {
+    DDS_Security_Exception_set(ex, DDS_AUTH_PLUGIN_CONTEXT, DDS_SECURITY_ERR_UNDEFINED_CODE, DDS_SECURITY_VALIDATION_FAILED, "Failed to find pkcs11 engine");
+    return DDS_SECURITY_VALIDATION_FAILED;
+  }
+
+  parms.cert_id = uri;
+  parms.cert = NULL;
+  if (!ENGINE_ctrl_cmd(engine, "LOAD_CERT_CTRL", 0, &parms, NULL, 1))
+  {
+    DDS_Security_Exception_set_with_openssl_error(ex, DDS_AUTH_PLUGIN_CONTEXT, DDS_SECURITY_ERR_UNDEFINED_CODE, DDS_SECURITY_VALIDATION_FAILED, "Failed to get certificate from pkcs11 engine: ");
+    goto err_or_ok;
+  }
+  *x509Cert = parms.cert;
+
+err_or_ok:
+  ENGINE_free(engine);
+  return (parms.cert ? DDS_SECURITY_VALIDATION_OK : DDS_SECURITY_VALIDATION_FAILED);
+}
+
+static DDS_Security_ValidationResult_t load_private_key_from_pkcs11(const char *uri, const char *password, EVP_PKEY **privateKey, DDS_Security_SecurityException *ex)
+{
+  ENGINE *engine;
+
+  if (!(engine = ENGINE_by_id("pkcs11")))
+  {
+    DDS_Security_Exception_set(ex, DDS_AUTH_PLUGIN_CONTEXT, DDS_SECURITY_ERR_UNDEFINED_CODE, DDS_SECURITY_VALIDATION_FAILED, "Failed to find pkcs11 engine");
+    return DDS_SECURITY_VALIDATION_FAILED;
+  }
+
+  if (!(*privateKey = ENGINE_load_private_key(engine, uri, NULL, NULL)))
+  {
+    DDS_Security_Exception_set(ex, DDS_AUTH_PLUGIN_CONTEXT, DDS_SECURITY_ERR_UNDEFINED_CODE, DDS_SECURITY_VALIDATION_FAILED, "Failed to find private key");
+    ENGINE_free(engine);
+    return DDS_SECURITY_VALIDATION_FAILED;
+  }
+  ENGINE_free(engine);
+  return DDS_SECURITY_VALIDATION_OK;
+}
+
+static DDS_Security_ValidationResult_t load_X509_crl_from_pkcs11(const char *uri, X509_CRL **x509CRL, DDS_Security_SecurityException *ex)
+{
+  ENGINE *engine;
+  struct {
+    const char *crl_id;
+    X509_CRL *crl;
+  } parms;
+
+  if (!(engine = ENGINE_by_id("pkcs11"))) {
+    DDS_Security_Exception_set(ex, DDS_AUTH_PLUGIN_CONTEXT, DDS_SECURITY_ERR_UNDEFINED_CODE, DDS_SECURITY_VALIDATION_FAILED, "Failed to find pkcs11 engine");
+    return DDS_SECURITY_VALIDATION_FAILED;
+  }
+
+  parms.crl_id = uri;
+  parms.crl = NULL;
+  if (!ENGINE_ctrl_cmd(engine, "LOAD_CERT_CRL", 0, &parms, NULL, 1))
+  {
+    DDS_Security_Exception_set_with_openssl_error(ex, DDS_AUTH_PLUGIN_CONTEXT, DDS_SECURITY_ERR_UNDEFINED_CODE, DDS_SECURITY_VALIDATION_FAILED, "Failed to get CRL from pkcs11 engine: ");
+    goto err_or_ok;
+  }
+  *x509CRL = parms.crl;
+
+err_or_ok:
+  ENGINE_free(engine);
+  return (parms.crl ? DDS_SECURITY_VALIDATION_OK : DDS_SECURITY_VALIDATION_FAILED);
+}
+#else
+static DDS_Security_ValidationResult_t load_X509_certificate_from_pkcs11(const char *uri, X509 **x509Cert, load_callback_func pkcs11_loader, void *cb_arg, DDS_Security_SecurityException *ex)
+{
+  OSSL_STORE_CTX *store_ctx = NULL;
+  OSSL_STORE_INFO *store_info = NULL;
+  X509 *cert = NULL;
+  assert(uri);
+  assert(x509Cert);
+  assert(pkcs11_loader);
+  assert(cb_arg);
+
+  if (!pkcs11_loader(cb_arg))
+  {
+    DDS_Security_Exception_set(ex, DDS_AUTH_PLUGIN_CONTEXT, DDS_SECURITY_ERR_UNDEFINED_CODE, DDS_SECURITY_VALIDATION_FAILED, "Failed to load pkcs11 provider");
+    return DDS_SECURITY_VALIDATION_FAILED;
+  }
+
+  if (!(store_ctx = OSSL_STORE_open(uri, NULL, NULL, NULL, NULL)))
+  {
+    DDS_Security_Exception_set_with_openssl_error(ex, DDS_AUTH_PLUGIN_CONTEXT, DDS_SECURITY_ERR_UNDEFINED_CODE, DDS_SECURITY_VALIDATION_FAILED, "Failed to open OSSL_STORE: ");
+    return DDS_SECURITY_VALIDATION_FAILED;
+  }
+
+  while (!cert)
+  {
+    if ((store_info = OSSL_STORE_load(store_ctx)))
+    {
+        if (OSSL_STORE_INFO_get_type(store_info) == OSSL_STORE_INFO_CERT)
+          *x509Cert = cert = OSSL_STORE_INFO_get1_CERT(store_info);
+        OSSL_STORE_INFO_free(store_info);
+    }
+    else if (OSSL_STORE_error(store_ctx))
+    {
+      DDS_Security_Exception_set_with_openssl_error(ex, DDS_AUTH_PLUGIN_CONTEXT, DDS_SECURITY_ERR_UNDEFINED_CODE, DDS_SECURITY_VALIDATION_FAILED, "Failed to load OSSL_STORE: ");
+      break;
+    }
+    else
+    {
+      DDS_Security_Exception_set(ex, DDS_AUTH_PLUGIN_CONTEXT, DDS_SECURITY_ERR_UNDEFINED_CODE, DDS_SECURITY_VALIDATION_FAILED, "Failed to find certificate: ");
+      break;
+    }
+  }
+  OSSL_STORE_close(store_ctx);
+
+  return (cert ? DDS_SECURITY_VALIDATION_OK : DDS_SECURITY_VALIDATION_FAILED);
+}
+
+static DDS_Security_ValidationResult_t load_private_key_from_pkcs11(const char *uri, const char *password, EVP_PKEY **privateKey, load_callback_func pkcs11_loader, void *cb_arg, DDS_Security_SecurityException *ex)
+{
+  OSSL_STORE_CTX *store_ctx = NULL;
+  OSSL_STORE_INFO *store_info = NULL;
+  EVP_PKEY *pkey = NULL;
+  char *uri_pw = NULL;
+  assert(uri);
+  assert(privateKey);
+  assert(pkcs11_loader);
+  assert(cb_arg);
+
+  if (!pkcs11_loader(cb_arg))
+  {
+    DDS_Security_Exception_set(ex, DDS_AUTH_PLUGIN_CONTEXT, DDS_SECURITY_ERR_UNDEFINED_CODE, DDS_SECURITY_VALIDATION_FAILED, "Failed to load pkcs11 provider");
+    return DDS_SECURITY_VALIDATION_FAILED;
+  }
+
+  if (password)
+  {
+    const char *pin_str = "?pin_value=";
+    size_t len = strlen(uri) + strlen(password) + strlen(pin_str) + 1;
+    uri_pw = ddsrt_malloc(len);
+    snprintf(uri_pw, len, "%s%s%s", uri, pin_str, password);
+  }
+
+  if (!(store_ctx = OSSL_STORE_open((uri_pw ? uri_pw : uri), NULL, NULL, NULL, NULL)))
+  {
+    DDS_Security_Exception_set_with_openssl_error(ex, DDS_AUTH_PLUGIN_CONTEXT, DDS_SECURITY_ERR_UNDEFINED_CODE, DDS_SECURITY_VALIDATION_FAILED, "Failed to open OSSL_STORE: ");
+    ddsrt_free(uri_pw);
+    return DDS_SECURITY_VALIDATION_FAILED;
+  }
+  ddsrt_free(uri_pw);
+
+  while (!pkey)
+  {
+    if ((store_info = OSSL_STORE_load(store_ctx)))
+    {
+      if (OSSL_STORE_INFO_get_type(store_info) == OSSL_STORE_INFO_PKEY)
+        *privateKey = pkey = OSSL_STORE_INFO_get1_PKEY(store_info);
+      OSSL_STORE_INFO_free(store_info);
+    }
+    else if (OSSL_STORE_error(store_ctx))
+    {
+      DDS_Security_Exception_set_with_openssl_error(ex, DDS_AUTH_PLUGIN_CONTEXT, DDS_SECURITY_ERR_UNDEFINED_CODE, DDS_SECURITY_VALIDATION_FAILED, "Failed to load OSSL_STORE: ");
+      break;
+    }
+    else
+    {
+      DDS_Security_Exception_set(ex, DDS_AUTH_PLUGIN_CONTEXT, DDS_SECURITY_ERR_UNDEFINED_CODE, DDS_SECURITY_VALIDATION_FAILED, "Failed to find private key");
+      break;
+    }
+  }
+  OSSL_STORE_close(store_ctx);
+
+  return (pkey ? DDS_SECURITY_VALIDATION_OK : DDS_SECURITY_VALIDATION_FAILED);
+}
+
+static DDS_Security_ValidationResult_t load_X509_crl_from_pkcs11(const char *uri, X509_CRL **x509CRL, load_callback_func pkcs11_loader, void *cb_arg, DDS_Security_SecurityException *ex)
+{
+  OSSL_STORE_CTX *store_ctx = NULL;
+  OSSL_STORE_INFO *store_info = NULL;
+  X509_CRL *crl = NULL;
+  assert(uri);
+  assert(crl);
+  assert(pkcs11_loader);
+  assert(cb_arg);
+
+  if (!pkcs11_loader(cb_arg))
+  {
+    DDS_Security_Exception_set(ex, DDS_AUTH_PLUGIN_CONTEXT, DDS_SECURITY_ERR_UNDEFINED_CODE, DDS_SECURITY_VALIDATION_FAILED, "Failed to load pkcs11 provider");
+    return DDS_SECURITY_VALIDATION_FAILED;
+  }
+
+  if (!(store_ctx = OSSL_STORE_open(uri, NULL, NULL, NULL, NULL)))
+  {
+    DDS_Security_Exception_set_with_openssl_error(ex, DDS_AUTH_PLUGIN_CONTEXT, DDS_SECURITY_ERR_UNDEFINED_CODE, DDS_SECURITY_VALIDATION_FAILED, "Failed to open OSSL_STORE: ");
+    return DDS_SECURITY_VALIDATION_FAILED;
+  }
+
+  while (!crl)
+  {
+    if ((store_info = OSSL_STORE_load(store_ctx)))
+    {
+        if (OSSL_STORE_INFO_get_type(store_info) == OSSL_STORE_INFO_CRL)
+          *x509CRL = crl = OSSL_STORE_INFO_get1_CRL(store_info);
+        OSSL_STORE_INFO_free(store_info);
+    }
+    else if (OSSL_STORE_error(store_ctx))
+    {
+      DDS_Security_Exception_set_with_openssl_error(ex, DDS_AUTH_PLUGIN_CONTEXT, DDS_SECURITY_ERR_UNDEFINED_CODE, DDS_SECURITY_VALIDATION_FAILED, "Failed to open OSSL_STORE: ");
+      break;
+    }
+    else
+    {
+      DDS_Security_Exception_set(ex, DDS_AUTH_PLUGIN_CONTEXT, DDS_SECURITY_ERR_UNDEFINED_CODE, DDS_SECURITY_VALIDATION_FAILED, "Failed to find CRL: ");
+      break;
+    }
+  }
+  OSSL_STORE_close(store_ctx);
+
+  return (crl ? DDS_SECURITY_VALIDATION_OK : DDS_SECURITY_VALIDATION_FAILED);
+}
+#endif
+
+
+
 /*
  * Gets the URI string (as referred in DDS Security spec) and returns the URI type
  * data: data part of the URI. Typically It contains different format according to URI type.
@@ -462,7 +688,7 @@ static AuthConfItemPrefix_t get_conf_item_type(const char *str, char **data)
   return AUTH_CONF_ITEM_PREFIX_UNKNOWN;
 }
 
-DDS_Security_ValidationResult_t load_X509_certificate(const char *data, X509 **x509Cert, DDS_Security_SecurityException *ex)
+DDS_Security_ValidationResult_t load_X509_certificate(const char *data, X509 **x509Cert, load_callback_func cb, void *cb_arg, DDS_Security_SecurityException *ex)
 {
   DDS_Security_ValidationResult_t result;
   char *contents = NULL;
@@ -478,8 +704,7 @@ DDS_Security_ValidationResult_t load_X509_certificate(const char *data, X509 **x
     result = load_X509_certificate_from_data(contents, (int)strlen(contents), x509Cert, ex);
     break;
   case AUTH_CONF_ITEM_PREFIX_PKCS11:
-    result = DDS_SECURITY_VALIDATION_FAILED;
-    DDS_Security_Exception_set(ex, DDS_AUTH_PLUGIN_CONTEXT, DDS_SECURITY_ERR_UNDEFINED_CODE, (int)result, "Certificate pkcs11 format currently not supported:\n%s", data);
+    result = load_X509_certificate_from_pkcs11(data, x509Cert, cb, cb_arg, ex);
     break;
   default:
     result = DDS_SECURITY_VALIDATION_FAILED;
@@ -500,7 +725,7 @@ DDS_Security_ValidationResult_t load_X509_certificate(const char *data, X509 **x
   return result;
 }
 
-DDS_Security_ValidationResult_t load_X509_private_key(const char *data, const char *password, EVP_PKEY **privateKey, DDS_Security_SecurityException *ex)
+DDS_Security_ValidationResult_t load_X509_private_key(const char *data, const char *password, EVP_PKEY **privateKey, load_callback_func cb, void *cb_arg, DDS_Security_SecurityException *ex)
 {
   DDS_Security_ValidationResult_t result;
   char *contents = NULL;
@@ -516,8 +741,7 @@ DDS_Security_ValidationResult_t load_X509_private_key(const char *data, const ch
     result = load_private_key_from_data(contents, password, privateKey, ex);
     break;
   case AUTH_CONF_ITEM_PREFIX_PKCS11:
-    result = DDS_SECURITY_VALIDATION_FAILED;
-    DDS_Security_Exception_set(ex, DDS_AUTH_PLUGIN_CONTEXT, DDS_SECURITY_ERR_UNDEFINED_CODE, (int)result, "PrivateKey pkcs11 format currently not supported:\n%s", data);
+    result = load_private_key_from_pkcs11(data, password, privateKey, cb, cb_arg, ex);
     break;
   default:
     result = DDS_SECURITY_VALIDATION_FAILED;
@@ -583,7 +807,7 @@ static DDS_Security_ValidationResult_t load_CRL_from_data(const char *data, X509
   return DDS_SECURITY_VALIDATION_OK;
 }
 
-DDS_Security_ValidationResult_t load_X509_CRL(const char *data, X509_CRL **crl, DDS_Security_SecurityException *ex)
+DDS_Security_ValidationResult_t load_X509_CRL(const char *data, X509_CRL **crl, load_callback_func cb, void *cb_arg, DDS_Security_SecurityException *ex)
 {
   DDS_Security_ValidationResult_t result;
   char *contents = NULL;
@@ -597,6 +821,9 @@ DDS_Security_ValidationResult_t load_X509_CRL(const char *data, X509_CRL **crl, 
     break;
   case AUTH_CONF_ITEM_PREFIX_DATA:
     result = load_CRL_from_data(contents, crl, ex);
+    break;
+  case AUTH_CONF_ITEM_PREFIX_PKCS11:
+    result = load_X509_crl_from_pkcs11(data, crl, cb, cb_arg, ex);
     break;
   default:
     result = DDS_SECURITY_VALIDATION_FAILED;

--- a/src/security/builtin_plugins/authentication/src/auth_utils.h
+++ b/src/security/builtin_plugins/authentication/src/auth_utils.h
@@ -17,6 +17,12 @@
 #endif
 #include <openssl/x509.h>
 #include <openssl/evp.h>
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+#include <openssl/engine.h>
+#else
+#include <openssl/provider.h>
+#endif
+#include <openssl/store.h>
 
 #include "dds/security/dds_security_api.h"
 #include "dds/ddsrt/time.h"
@@ -55,20 +61,22 @@ dds_time_t get_certificate_expiry(const X509 *cert);
  */
 DDS_Security_ValidationResult_t get_subject_name_DER_encoded(const X509 *cert, unsigned char **buffer, size_t *size, DDS_Security_SecurityException *ex);
 
+typedef bool (*load_callback_func)(void *arg);
+
 /* Load a X509 certificate for the provided data (PEM format) */
 DDS_Security_ValidationResult_t load_X509_certificate_from_data(const char *data, int len, X509 **x509Cert, DDS_Security_SecurityException *ex);
 
 /* Load a X509 certificate for the provided data (certificate uri) */
-DDS_Security_ValidationResult_t load_X509_certificate(const char *data, X509 **x509Cert, DDS_Security_SecurityException *ex);
+DDS_Security_ValidationResult_t load_X509_certificate(const char *data, X509 **x509Cert, load_callback_func cb, void *cb_arg, DDS_Security_SecurityException *ex);
 
 /* Load a X509 certificate for the provided file */
 DDS_Security_ValidationResult_t load_X509_certificate_from_file(const char *filename, X509 **x509Cert, DDS_Security_SecurityException *ex);
 
 /* Load a Private Key for the provided data (private key uri) */
-DDS_Security_ValidationResult_t load_X509_private_key(const char *data, const char *password, EVP_PKEY **privateKey, DDS_Security_SecurityException *ex);
+DDS_Security_ValidationResult_t load_X509_private_key(const char *data, const char *password, EVP_PKEY **privateKey, load_callback_func cb, void *cb_arg, DDS_Security_SecurityException *ex);
 
 /* Load a Certificate Revocation List (CRL) for the provided data (CRL uri) */
-DDS_Security_ValidationResult_t load_X509_CRL(const char *data, X509_CRL **crl, DDS_Security_SecurityException *ex);
+DDS_Security_ValidationResult_t load_X509_CRL(const char *data, X509_CRL **crl, load_callback_func cb, void *cb_arg, DDS_Security_SecurityException *ex);
 
 /* Validate an identity certificate against the identityCA
  * The provided identity certificate is checked if it is

--- a/src/security/builtin_plugins/authentication/src/authentication.c
+++ b/src/security/builtin_plugins/authentication/src/authentication.c
@@ -659,6 +659,7 @@ static DDS_Security_ValidationResult_t get_adjusted_participant_guid(X509 *cert,
 #if OPENSSL_VERSION_NUMBER < 0x30000000L
 static bool load_pkcs11_provider(void *arg)
 {
+  dds_security_authentication_impl *auth = arg;
   const char *pkcs11 = "pkcs11";
   bool result = true;
 

--- a/src/security/builtin_plugins/authentication/src/authentication.c
+++ b/src/security/builtin_plugins/authentication/src/authentication.c
@@ -151,6 +151,11 @@ typedef struct dds_security_authentication_impl
   const dds_security_authentication_listener *listener;
   X509Seq trustedCAList;
   bool include_optional;
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+  ENGINE *engine;
+#else
+  OSSL_PROVIDER *pkcs11Provider;
+#endif
 } dds_security_authentication_impl;
 
 /* data type for timer dispatcher */
@@ -650,6 +655,44 @@ static DDS_Security_ValidationResult_t get_adjusted_participant_guid(X509 *cert,
 }
 #undef ADJUSTED_GUID_PREFIX_FLAG
 
+
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+static bool load_pkcs11_provider(void *arg)
+{
+  const char *pkcs11 = "pkcs11";
+  bool result = true;
+
+  ddsrt_mutex_lock(&auth->lock);
+  if (!auth->engine)
+  {
+    if (!(auth->engine = ENGINE_by_id(pkcs11)))
+      result = false;
+    else if (!ENGINE_init(auth->engine))
+    {
+      ENGINE_free(auth->engine);
+      auth->engine = NULL;
+      result = false;
+    }
+  }
+  ddsrt_mutex_unlock(&auth->lock);
+  return result;
+}
+#else
+static bool load_pkcs11_provider(void *arg)
+{
+  dds_security_authentication_impl *auth = arg;
+  const char *pkcs11 = "pkcs11";
+
+  if (OSSL_PROVIDER_available(NULL, pkcs11))
+    return true;
+
+  ddsrt_mutex_lock(&auth->lock);
+  auth->pkcs11Provider = OSSL_PROVIDER_try_load(NULL, pkcs11, 1);
+  ddsrt_mutex_unlock(&auth->lock);
+  return (auth->pkcs11Provider != NULL);
+}
+#endif
+
 DDS_Security_ValidationResult_t validate_local_identity(dds_security_authentication *instance, DDS_Security_IdentityHandle *local_identity_handle,
     DDS_Security_GUID_t *adjusted_participant_guid, const DDS_Security_DomainId domain_id, const DDS_Security_Qos *participant_qos,
     const DDS_Security_GUID_t *candidate_participant_guid, DDS_Security_SecurityException *ex)
@@ -697,13 +740,13 @@ DDS_Security_ValidationResult_t validate_local_identity(dds_security_authenticat
 
   crlPEM = DDS_Security_Property_get_value(&participant_qos->property.value, ORG_ECLIPSE_CYCLONEDDS_SEC_AUTH_CRL);
 
-  if (load_X509_certificate(identityCaPEM, &identityCA, ex) != DDS_SECURITY_VALIDATION_OK)
+  if (load_X509_certificate(identityCaPEM, &identityCA, load_pkcs11_provider, implementation, ex) != DDS_SECURITY_VALIDATION_OK)
     goto err_inv_identity_ca;
 
   /* check for CA if listed in trusted CA files */
   if (implementation->trustedCAList.length > 0)
   {
-    if (crlPEM)
+    if (crlPEM && strlen(crlPEM) > 0)
     {
       // FIXME: When a CRL is specified, we assume that it is associated with the "own_ca".  However, when
       // a list of CAs is presented that assumption may not hold.  Resolve this ambiguity for now by just
@@ -735,15 +778,15 @@ DDS_Security_ValidationResult_t validate_local_identity(dds_security_authenticat
       goto err_identity_ca_not_trusted;
     }
   }
-  if (load_X509_certificate(identityCertPEM, &identityCert, ex) != DDS_SECURITY_VALIDATION_OK)
+  if (load_X509_certificate(identityCertPEM, &identityCert, load_pkcs11_provider, implementation, ex) != DDS_SECURITY_VALIDATION_OK)
     goto err_inv_identity_cert;
 
-  if (load_X509_private_key(privateKeyPEM, password, &privateKey, ex) != DDS_SECURITY_VALIDATION_OK)
+  if (load_X509_private_key(privateKeyPEM, password, &privateKey, load_pkcs11_provider, implementation, ex) != DDS_SECURITY_VALIDATION_OK)
     goto err_inv_private_key;
 
   if (crlPEM && strlen(crlPEM) > 0)
   {
-    if (load_X509_CRL(crlPEM, &crl, ex) != DDS_SECURITY_VALIDATION_OK)
+    if (load_X509_CRL(crlPEM, &crl, load_pkcs11_provider, implementation, ex) != DDS_SECURITY_VALIDATION_OK)
     {
       goto err_inv_crl;
     }
@@ -2269,7 +2312,13 @@ int32_t init_authentication(const char *argument, void **context, struct ddsi_do
   authentication->remoteGuidHash = ddsrt_hh_new(32, remote_guid_hash, remote_guid_equal);
   memset(&authentication->trustedCAList, 0, sizeof(X509Seq));
   authentication->include_optional = gv->handshake_include_optional;
-
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+  OpenSSL_add_all_algorithms();
+  ENGINE_load_builtin_engines();
+  authentication->engine = NULL;
+#else
+  authentication->pkcs11Provider = NULL;
+#endif
   dds_openssl_init ();
   *context = authentication;
   return 0;
@@ -2292,6 +2341,17 @@ int32_t finalize_authentication(void *instance)
       ddsrt_hh_free(authentication->objectHash);
     }
     free_ca_list_contents(&(authentication->trustedCAList));
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+
+    if (authentication->engine)
+    {
+      ENGINE_finish(authentication->engine);
+      ENGINE_free(authentication->engine);
+    }
+#else
+    if (authentication->pkcs11Provider)
+      OSSL_PROVIDER_unload(authentication->pkcs11Provider);
+#endif
     ddsrt_mutex_unlock(&authentication->lock);
     ddsrt_mutex_destroy(&authentication->lock);
     ddsrt_free((dds_security_authentication_impl *)instance);

--- a/src/security/builtin_plugins/authentication/src/authentication.c
+++ b/src/security/builtin_plugins/authentication/src/authentication.c
@@ -683,14 +683,16 @@ static bool load_pkcs11_provider(void *arg)
 {
   dds_security_authentication_impl *auth = arg;
   const char *pkcs11 = "pkcs11";
+  bool result;
 
   if (OSSL_PROVIDER_available(NULL, pkcs11))
     return true;
 
   ddsrt_mutex_lock(&auth->lock);
   auth->pkcs11Provider = OSSL_PROVIDER_try_load(NULL, pkcs11, 1);
+  result = (auth->pkcs11Provider != NULL);
   ddsrt_mutex_unlock(&auth->lock);
-  return (auth->pkcs11Provider != NULL);
+  return result;
 }
 #endif
 

--- a/src/security/core/tests/CMakeLists.txt
+++ b/src/security/core/tests/CMakeLists.txt
@@ -106,6 +106,14 @@ if(ENABLE_SSL AND OPENSSL_FOUND)
   add_wrapper(authentication dds_security_auth)
   add_wrapper(cryptography dds_security_crypto)
 
+  FIND_PROGRAM(PKCS11_TOOL_CMD pkcs11-tool)
+  FIND_PROGRAM(SOFTHSM_UTIL_CMD softhsm2-util)
+  if (PKCS11_TOOL_CMD AND SOFTHSM_UTIL_CMD)
+    set(PKCS11_TEST_FILE "pkcs11.c")
+  else()
+    set(PKCS11_TEST_FILE "")
+  endif()
+
   list(APPEND security_core_test_sources
     "common/security_config_test_utils.c"
     "common/test_utils.c"
@@ -119,6 +127,7 @@ if(ENABLE_SSL AND OPENSSL_FOUND)
     "handshake.c"
     "plugin_loading.c"
     "secure_communication.c"
+    ${PKCS11_TEST_FILE}
     ${CYCLONEDDS_OPENSSL_APPLINK})
   # applink.c triggers the dreaded This function or variable may be unsafe
   if(NOT "${CYCLONEDDS_OPENSSL_APPLINK}" STREQUAL "")

--- a/src/security/core/tests/common/cert_utils.c
+++ b/src/security/core/tests/common/cert_utils.c
@@ -160,7 +160,7 @@ char * generate_pkcs11_private_key(const char *token, const char *name, uint32_t
 {
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
   const char template[] = "pkcs11:token=%s;object=%s;id=%u?pin-value=%s";
-  size_t len = sizeof (template) + strlen (token) + strlen (name) + 8 + strlen (pin);
+  size_t len = sizeof (template) + strlen (token) + strlen (name) + 10 + strlen (pin);
   char *uri = malloc (len);
   snprintf(uri, len, template, token, name, id, pin);
   EVP_PKEY *pkey = NULL;

--- a/src/security/core/tests/common/cert_utils.c
+++ b/src/security/core/tests/common/cert_utils.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "dds/ddsrt/misc.h"
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/string.h"
 #include "dds/security/openssl_support.h"
@@ -195,12 +196,17 @@ char * generate_pkcs11_private_key(const char *token, const char *name, uint32_t
   printf("PRIV_KEY_URI=%s\n", uri);
   return uri;
 #else
-  return NULL
+  DDSRT_UNUSED_ARG(token);
+  DDSRT_UNUSED_ARG(name);
+  DDSRT_UNUSED_ARG(id);
+  DDSRT_UNUSED_ARG(pin);
+  return NULL;
 #endif
 }
 
 EVP_PKEY * get_priv_key_pkcs11(const char *uri)
 {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
   OSSL_STORE_CTX *store_ctx = NULL;
   OSSL_STORE_INFO *store_info = NULL;
   EVP_PKEY *pkey = NULL;
@@ -230,10 +236,15 @@ EVP_PKEY * get_priv_key_pkcs11(const char *uri)
   OSSL_STORE_close(store_ctx);
 
   return pkey;
+#else
+  DDSRT_UNUSED_ARG(uri);
+  return NULL;
+#endif
 }
 
 X509 * get_certificate_pkcs11(const char *uri)
 {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
   OSSL_STORE_CTX *store_ctx = NULL;
   OSSL_STORE_INFO *store_info = NULL;
   X509 *cert = NULL;
@@ -263,19 +274,42 @@ X509 * get_certificate_pkcs11(const char *uri)
   OSSL_STORE_close(store_ctx);
 
   return cert;
+#else
+  DDSRT_UNUSED_ARG(uri);
+  return NULL;
+#endif
 }
 
 char * generate_ca_pkcs11(const char *ca_name, const char * ca_priv_key_uri, int not_valid_before, int not_valid_after)
 {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
   EVP_PKEY *ca_priv_key = get_priv_key_pkcs11(ca_priv_key_uri);
   return generate_ca_internal(ca_name, ca_priv_key, not_valid_before, not_valid_after);
+#else
+  DDSRT_UNUSED_ARG(ca_name);
+  DDSRT_UNUSED_ARG(ca_priv_key_uri);
+  DDSRT_UNUSED_ARG(not_valid_before);
+  DDSRT_UNUSED_ARG(not_valid_after);
+  return NULL;
+#endif
 }
 
 char * generate_identity_pkcs11(const char * ca_cert_str, const char * ca_priv_key_uri, const char * name, const char * priv_key_uri, int not_valid_before, int not_valid_after, char ** subject)
 {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
   EVP_PKEY *ca_key_pkey = get_priv_key_pkcs11 (ca_priv_key_uri);
   EVP_PKEY *id_pkey = get_priv_key_pkcs11 (priv_key_uri);
   return generate_identity_internal(ca_cert_str, ca_key_pkey, name, id_pkey, not_valid_before, not_valid_after, subject);
+#else
+  DDSRT_UNUSED_ARG(ca_cert_str);
+  DDSRT_UNUSED_ARG(ca_priv_key_uri);
+  DDSRT_UNUSED_ARG(name);
+  DDSRT_UNUSED_ARG(priv_key_uri);
+  DDSRT_UNUSED_ARG(not_valid_before);
+  DDSRT_UNUSED_ARG(not_valid_after);
+  DDSRT_UNUSED_ARG(subject);
+  return NULL;
+#endif
 }
 
 

--- a/src/security/core/tests/common/cert_utils.c
+++ b/src/security/core/tests/common/cert_utils.c
@@ -75,10 +75,8 @@ static X509 * get_cert(const char * cert_str)
   return cert;
 }
 
-char * generate_ca(const char *ca_name, const char * ca_priv_key_str, int not_valid_before, int not_valid_after)
+static char * generate_ca_internal(const char *ca_name, EVP_PKEY *ca_priv_key, int not_valid_before, int not_valid_after)
 {
-  EVP_PKEY *ca_priv_key = get_priv_key (ca_priv_key_str);
-
   char * email = malloc (MAX_EMAIL);
   snprintf(email, MAX_EMAIL, "%s@%s" , ca_name, EMAIL_HOST);
   X509 * ca_cert = get_x509 (not_valid_before, not_valid_after, ca_name, email);
@@ -95,11 +93,15 @@ char * generate_ca(const char *ca_name, const char * ca_priv_key_str, int not_va
   return output;
 }
 
-char * generate_identity(const char * ca_cert_str, const char * ca_priv_key_str, const char * name, const char * priv_key_str, int not_valid_before, int not_valid_after, char ** subject)
+char * generate_ca(const char *ca_name, const char * ca_priv_key_str, int not_valid_before, int not_valid_after)
+{
+  EVP_PKEY *ca_priv_key = get_priv_key (ca_priv_key_str);
+  return generate_ca_internal(ca_name, ca_priv_key, not_valid_before, not_valid_after);
+}
+
+static char * generate_identity_internal(const char * ca_cert_str, EVP_PKEY * ca_key_pkey, const char * name, EVP_PKEY * id_pkey, int not_valid_before, int not_valid_after, char ** subject)
 {
   X509 *ca_cert = get_cert (ca_cert_str);
-  EVP_PKEY *ca_key_pkey = get_priv_key (ca_priv_key_str);
-  EVP_PKEY *id_pkey = get_priv_key (priv_key_str);
   EVP_PKEY *ca_cert_pkey = X509_get_pubkey (ca_cert);
   X509_REQ *csr =  X509_REQ_new ();
   X509_REQ_set_pubkey (csr, id_pkey);
@@ -134,3 +136,146 @@ char * generate_identity(const char * ca_cert_str, const char * ca_priv_key_str,
 
   return output;
 }
+
+char * generate_identity(const char * ca_cert_str, const char * ca_priv_key_str, const char * name, const char * priv_key_str, int not_valid_before, int not_valid_after, char ** subject)
+{
+  EVP_PKEY *ca_key_pkey = get_priv_key (ca_priv_key_str);
+  EVP_PKEY *id_pkey = get_priv_key (priv_key_str);
+  return generate_identity_internal(ca_cert_str, ca_key_pkey, name, id_pkey, not_valid_before, not_valid_after, subject);
+}
+
+bool check_pkcs11_provider(void)
+{
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+  if (OSSL_PROVIDER_available(NULL, "pkcs11"))
+    return true;
+  else if (OSSL_PROVIDER_try_load(NULL, "pkcs11", 1))
+    return true;
+#endif
+  return false;
+}
+
+char * generate_pkcs11_private_key(const char *token, const char *name, uint32_t id, const char *pin)
+{
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+  const char template[] = "pkcs11:token=%s;object=%s;id=%u?pin-value=%s";
+  size_t len = sizeof (template) + strlen (token) + strlen (name) + 8 + strlen (pin);
+  char *uri = malloc (len);
+  snprintf(uri, len, template, token, name, id, pin);
+  EVP_PKEY *pkey = NULL;
+
+  /* Create keygen context using PKCS#11 URI */
+  EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new_from_name(NULL, "EC", "provider=pkcs11");
+  CU_ASSERT_FATAL (ctx != NULL);
+
+  if (EVP_PKEY_keygen_init(ctx) <= 0)
+  {
+    ERR_print_errors_fp (stderr);
+    CU_ASSERT_FATAL (false);
+  }
+
+  OSSL_PARAM params[3];
+  params[0] = OSSL_PARAM_construct_utf8_string("ec_paramgen_curve", "P-256", 0);
+  params[1] = OSSL_PARAM_construct_utf8_string("pkcs11_uri", uri, 0);
+  params[2] = OSSL_PARAM_construct_end();
+
+  if (EVP_PKEY_CTX_set_params(ctx, params) <= 0)
+  {
+    ERR_print_errors_fp (stderr);
+    CU_ASSERT_FATAL (false);
+  }
+
+  /* Generate the key */
+  if (EVP_PKEY_generate(ctx, &pkey) <= 0)
+  {
+    ERR_print_errors_fp (stderr);
+    CU_ASSERT_FATAL (false);
+  }
+  EVP_PKEY_free(pkey);
+  printf("PRIV_KEY_URI=%s\n", uri);
+  return uri;
+#else
+  return NULL
+#endif
+}
+
+EVP_PKEY * get_priv_key_pkcs11(const char *uri)
+{
+  OSSL_STORE_CTX *store_ctx = NULL;
+  OSSL_STORE_INFO *store_info = NULL;
+  EVP_PKEY *pkey = NULL;
+
+  if (!(store_ctx = OSSL_STORE_open(uri, NULL, NULL, NULL, NULL)))
+  {
+    ERR_print_errors_fp (stderr);
+    CU_ASSERT_FATAL (false);
+  }
+
+  while (!pkey)
+  {
+    if ((store_info = OSSL_STORE_load(store_ctx)))
+    {
+      if (OSSL_STORE_INFO_get_type(store_info) == OSSL_STORE_INFO_PKEY)
+        pkey = OSSL_STORE_INFO_get1_PKEY(store_info);
+      OSSL_STORE_INFO_free(store_info);
+    }
+    else if (OSSL_STORE_error(store_ctx))
+    {
+      ERR_print_errors_fp (stderr);
+      CU_ASSERT_FATAL (false);
+    }
+    else
+      CU_ASSERT_FATAL (false);
+  }
+  OSSL_STORE_close(store_ctx);
+
+  return pkey;
+}
+
+X509 * get_certificate_pkcs11(const char *uri)
+{
+  OSSL_STORE_CTX *store_ctx = NULL;
+  OSSL_STORE_INFO *store_info = NULL;
+  X509 *cert = NULL;
+
+  if (!(store_ctx = OSSL_STORE_open(uri, NULL, NULL, NULL, NULL)))
+  {
+    ERR_print_errors_fp (stderr);
+    CU_ASSERT_FATAL (false);
+  }
+
+  while (!cert)
+  {
+    if ((store_info = OSSL_STORE_load(store_ctx)))
+    {
+      if (OSSL_STORE_INFO_get_type(store_info) == OSSL_STORE_INFO_CERT)
+        cert = OSSL_STORE_INFO_get1_CERT(store_info);
+      OSSL_STORE_INFO_free(store_info);
+    }
+    else if (OSSL_STORE_error(store_ctx))
+    {
+      ERR_print_errors_fp (stderr);
+      CU_ASSERT_FATAL (false);
+    }
+    else
+      CU_ASSERT_FATAL (false);
+  }
+  OSSL_STORE_close(store_ctx);
+
+  return cert;
+}
+
+char * generate_ca_pkcs11(const char *ca_name, const char * ca_priv_key_uri, int not_valid_before, int not_valid_after)
+{
+  EVP_PKEY *ca_priv_key = get_priv_key_pkcs11(ca_priv_key_uri);
+  return generate_ca_internal(ca_name, ca_priv_key, not_valid_before, not_valid_after);
+}
+
+char * generate_identity_pkcs11(const char * ca_cert_str, const char * ca_priv_key_uri, const char * name, const char * priv_key_uri, int not_valid_before, int not_valid_after, char ** subject)
+{
+  EVP_PKEY *ca_key_pkey = get_priv_key_pkcs11 (ca_priv_key_uri);
+  EVP_PKEY *id_pkey = get_priv_key_pkcs11 (priv_key_uri);
+  return generate_identity_internal(ca_cert_str, ca_key_pkey, name, id_pkey, not_valid_before, not_valid_after, subject);
+}
+
+

--- a/src/security/core/tests/common/cert_utils.h
+++ b/src/security/core/tests/common/cert_utils.h
@@ -12,8 +12,15 @@
 #define SECURITY_CORE_TEST_CERT_UTILS_H_
 
 #include <stdlib.h>
+#include "dds/security/openssl_support.h"
 
 char * generate_ca(const char *ca_name, const char * ca_priv_key_str, int not_valid_before, int not_valid_after);
 char * generate_identity(const char * ca_cert_str, const char * ca_priv_key_str, const char * name, const char * priv_key_str, int not_valid_before, int not_valid_after, char ** subject);
+char * generate_pkcs11_private_key(const char *token, const char *name, uint32_t id, const char *pin);
+char * generate_ca_pkcs11(const char *ca_name, const char * ca_priv_key_uri, int not_valid_before, int not_valid_after);
+char * generate_identity_pkcs11(const char * ca_cert_str, const char * ca_priv_key_uri, const char * name, const char * priv_key_uri, int not_valid_before, int not_valid_after, char ** subject);
+EVP_PKEY * get_priv_key_pkcs11(const char *uri);
+X509 * get_certificate_pkcs11(const char *uri);
+bool check_pkcs11_provider(void);
 
 #endif /* SECURITY_CORE_TEST_CERT_UTILS_H_ */

--- a/src/security/core/tests/common/security_config_test_utils.h
+++ b/src/security/core/tests/common/security_config_test_utils.h
@@ -37,4 +37,10 @@ char * get_permissions_grant (const char * grant_name, const char * subject_name
 char * get_permissions_default_grant (const char * grant_name, const char * subject_name, const char * topic_name);
 char * get_permissions_config (char * grants[], size_t ngrants, bool add_prefix);
 
+typedef char * (smime_sign_function)(const char *config, void *args);
+
+char * get_governance_config_ex (bool allow_unauth_pp, bool enable_join_ac, DDS_Security_ProtectionKind discovery_protection_kind, DDS_Security_ProtectionKind liveliness_protection_kind,
+    DDS_Security_ProtectionKind rtps_protection_kind, const char * topic_rules, smime_sign_function signer, void *signer_arg, bool add_prefix);
+char * get_permissions_config_ex(char * grants[], size_t ngrants, smime_sign_function signer, void *signer_arg, bool add_prefix);
+
 #endif /* SECURITY_CORE_TEST_SECURITY_CONFIG_TEST_UTILS_H_ */

--- a/src/security/openssl/include/dds/security/openssl_support.h
+++ b/src/security/openssl/include/dds/security/openssl_support.h
@@ -30,6 +30,8 @@
 #include <openssl/ec.h>
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 #include <openssl/core_names.h>
+#include <openssl/provider.h>
+#include <openssl/store.h>
 #endif
 #include <openssl/err.h>
 #include <openssl/evp.h>


### PR DESCRIPTION
For DDS security added support to have the private key's and the certificates stored in a hsm using the openssl pkcs11 provider