### PR TITLE
Remove code for dependencies between participants

### DIFF
--- a/docs/manual/config/config_file_reference.rst
+++ b/docs/manual/config/config_file_reference.rst
@@ -922,17 +922,15 @@ The default value is: ``3 s``
 //CycloneDDS/Domain/Internal/BuiltinEndpointSet
 -----------------------------------------------
 
-One of: full, writers, minimal
+One of: full, writers
 
 This element controls which participants will have which built-in endpoints for the discovery and liveliness protocols. Valid values are:
  * full: all participants have all endpoints;
 
  * writers: all participants have the writers, but just one has the readers;
 
- * minimal: only one participant has built-in endpoints.
 
-
-The default is writers, as this is thought to be compliant and reasonably efficient. Minimal may or may not be compliant but is most efficient, and full is inefficient but certain to be compliant.
+The default is writers, as this is thought to be compliant and reasonably efficient. Full is inefficient but certain to be compliant.
 
 The default value is: ``writers``
 
@@ -2768,9 +2766,9 @@ The categorisation of tracing output is incomplete and hence most of the verbosi
 The default value is: ``none``
 
 ..
-   generated from ddsi_config.h[fd22386b5a5456d010458848b862bbe2be02b3e4] 
-   generated from ddsi_config.c[ea1079220b5c907e79b1f20fe97de87874d360fd] 
-   generated from ddsi__cfgelems.h[94e38d76830ce8487ad67cb37df5366c1b079c12] 
+   generated from ddsi_config.h[d7db98ce697e409412ec7fb0b900e10261a66c44] 
+   generated from ddsi_config.c[184d7299baad5acc9b96884de77770aac009a11a] 
+   generated from ddsi__cfgelems.h[741151ccf40cab43638e8c32cac3a4b9c3e73566] 
    generated from cfgunits.h[05f093223fce107d24dd157ebaafa351dc9df752] 
    generated from _confgen.h[fd29634526c05c3237dbc3f785030fe022eb7875] 
    generated from _confgen.c[0d833a6f2c98902f1249e63aed03a6164f0791d6] 

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -624,16 +624,14 @@ The default value is: `3 s`
 
 
 #### //CycloneDDS/Domain/Internal/BuiltinEndpointSet
-One of: full, writers, minimal
+One of: full, writers
 
 This element controls which participants will have which built-in endpoints for the discovery and liveliness protocols. Valid values are:
  * full: all participants have all endpoints;
 
  * writers: all participants have the writers, but just one has the readers;
 
- * minimal: only one participant has built-in endpoints.
-
-The default is writers, as this is thought to be compliant and reasonably efficient. Minimal may or may not be compliant but is most efficient, and full is inefficient but certain to be compliant.
+The default is writers, as this is thought to be compliant and reasonably efficient. Full is inefficient but certain to be compliant.
 
 The default value is: `writers`
 
@@ -1942,9 +1940,9 @@ While none prevents any message from being written to a DDSI2 log file.
 The categorisation of tracing output is incomplete and hence most of the verbosity levels and categories are not of much use in the current release. This is an ongoing process and here we describe the target situation rather than the current situation. Currently, the most useful verbosity levels are config, fine and finest.
 
 The default value is: `none`
-<!--- generated from ddsi_config.h[fd22386b5a5456d010458848b862bbe2be02b3e4] -->
-<!--- generated from ddsi_config.c[ea1079220b5c907e79b1f20fe97de87874d360fd] -->
-<!--- generated from ddsi__cfgelems.h[94e38d76830ce8487ad67cb37df5366c1b079c12] -->
+<!--- generated from ddsi_config.h[d7db98ce697e409412ec7fb0b900e10261a66c44] -->
+<!--- generated from ddsi_config.c[184d7299baad5acc9b96884de77770aac009a11a] -->
+<!--- generated from ddsi__cfgelems.h[741151ccf40cab43638e8c32cac3a4b9c3e73566] -->
 <!--- generated from cfgunits.h[05f093223fce107d24dd157ebaafa351dc9df752] -->
 <!--- generated from _confgen.h[fd29634526c05c3237dbc3f785030fe022eb7875] -->
 <!--- generated from _confgen.c[0d833a6f2c98902f1249e63aed03a6164f0791d6] -->

--- a/etc/cyclonedds.rnc
+++ b/etc/cyclonedds.rnc
@@ -444,12 +444,11 @@ CycloneDDS configuration""" ] ]
         & [ a:documentation [ xml:lang="en" """
 <p>This element controls which participants will have which built-in endpoints for the discovery and liveliness protocols. Valid values are:</p>
 <ul><li><i>full</i>: all participants have all endpoints;</li>
-<li><i>writers</i>: all participants have the writers, but just one has the readers;</li>
-<li><i>minimal</i>: only one participant has built-in endpoints.</li></ul>
-<p>The default is <i>writers</i>, as this is thought to be compliant and reasonably efficient. <i>Minimal</i> may or may not be compliant but is most efficient, and <i>full</i> is inefficient but certain to be compliant.</p>
+<li><i>writers</i>: all participants have the writers, but just one has the readers;</li></ul>
+<p>The default is <i>writers</i>, as this is thought to be compliant and reasonably efficient. <i>Full</i> is inefficient but certain to be compliant.</p>
 <p>The default value is: <code>writers</code></p>""" ] ]
         element BuiltinEndpointSet {
-          ("full"|"writers"|"minimal")
+          ("full"|"writers")
         }?
         & [ a:documentation [ xml:lang="en" """
 <p>Setting for controlling the size of transmitting bursts.</p>""" ] ]
@@ -1348,9 +1347,9 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==<br>
   memsize = xsd:token { pattern = "0|(\d+(\.\d*)?([Ee][\-+]?\d+)?|\.\d+([Ee][\-+]?\d+)?) *([kMG]i?)?B" }
   maybe_memsize = xsd:token { pattern = "default|0|(\d+(\.\d*)?([Ee][\-+]?\d+)?|\.\d+([Ee][\-+]?\d+)?) *([kMG]i?)?B" }
 }
-# generated from ddsi_config.h[fd22386b5a5456d010458848b862bbe2be02b3e4] 
-# generated from ddsi_config.c[ea1079220b5c907e79b1f20fe97de87874d360fd] 
-# generated from ddsi__cfgelems.h[94e38d76830ce8487ad67cb37df5366c1b079c12] 
+# generated from ddsi_config.h[d7db98ce697e409412ec7fb0b900e10261a66c44] 
+# generated from ddsi_config.c[184d7299baad5acc9b96884de77770aac009a11a] 
+# generated from ddsi__cfgelems.h[741151ccf40cab43638e8c32cac3a4b9c3e73566] 
 # generated from cfgunits.h[05f093223fce107d24dd157ebaafa351dc9df752] 
 # generated from _confgen.h[fd29634526c05c3237dbc3f785030fe022eb7875] 
 # generated from _confgen.c[0d833a6f2c98902f1249e63aed03a6164f0791d6] 

--- a/etc/cyclonedds.xsd
+++ b/etc/cyclonedds.xsd
@@ -719,16 +719,14 @@ CycloneDDS configuration</xs:documentation>
       <xs:documentation>
 &lt;p&gt;This element controls which participants will have which built-in endpoints for the discovery and liveliness protocols. Valid values are:&lt;/p&gt;
 &lt;ul&gt;&lt;li&gt;&lt;i&gt;full&lt;/i&gt;: all participants have all endpoints;&lt;/li&gt;
-&lt;li&gt;&lt;i&gt;writers&lt;/i&gt;: all participants have the writers, but just one has the readers;&lt;/li&gt;
-&lt;li&gt;&lt;i&gt;minimal&lt;/i&gt;: only one participant has built-in endpoints.&lt;/li&gt;&lt;/ul&gt;
-&lt;p&gt;The default is &lt;i&gt;writers&lt;/i&gt;, as this is thought to be compliant and reasonably efficient. &lt;i&gt;Minimal&lt;/i&gt; may or may not be compliant but is most efficient, and &lt;i&gt;full&lt;/i&gt; is inefficient but certain to be compliant.&lt;/p&gt;
+&lt;li&gt;&lt;i&gt;writers&lt;/i&gt;: all participants have the writers, but just one has the readers;&lt;/li&gt;&lt;/ul&gt;
+&lt;p&gt;The default is &lt;i&gt;writers&lt;/i&gt;, as this is thought to be compliant and reasonably efficient. &lt;i&gt;Full&lt;/i&gt; is inefficient but certain to be compliant.&lt;/p&gt;
 &lt;p&gt;The default value is: &lt;code&gt;writers&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
     <xs:simpleType>
       <xs:restriction base="xs:token">
         <xs:enumeration value="full"/>
         <xs:enumeration value="writers"/>
-        <xs:enumeration value="minimal"/>
       </xs:restriction>
     </xs:simpleType>
   </xs:element>
@@ -2027,9 +2025,9 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
     </xs:restriction>
   </xs:simpleType>
 </xs:schema>
-<!--- generated from ddsi_config.h[fd22386b5a5456d010458848b862bbe2be02b3e4] -->
-<!--- generated from ddsi_config.c[ea1079220b5c907e79b1f20fe97de87874d360fd] -->
-<!--- generated from ddsi__cfgelems.h[94e38d76830ce8487ad67cb37df5366c1b079c12] -->
+<!--- generated from ddsi_config.h[d7db98ce697e409412ec7fb0b900e10261a66c44] -->
+<!--- generated from ddsi_config.c[184d7299baad5acc9b96884de77770aac009a11a] -->
+<!--- generated from ddsi__cfgelems.h[741151ccf40cab43638e8c32cac3a4b9c3e73566] -->
 <!--- generated from cfgunits.h[05f093223fce107d24dd157ebaafa351dc9df752] -->
 <!--- generated from _confgen.h[fd29634526c05c3237dbc3f785030fe022eb7875] -->
 <!--- generated from _confgen.c[0d833a6f2c98902f1249e63aed03a6164f0791d6] -->

--- a/src/core/ddsc/include/dds/ddsc/dds_internal_api.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_internal_api.h
@@ -24,7 +24,7 @@ extern "C" {
 
 // Magic numbers match the set of internal flags we want to use but do not want to expose in the API.
 // The implementation contains static assert to ensure this is kept in sync.
-#define DDS_PARTICIPANT_FLAGS_NO_DISCOVERY (1u | 2u | 32u)
+#define DDS_PARTICIPANT_FLAGS_NO_DISCOVERY (1u | 2u)
 
 /**
  * @ingroup internal

--- a/src/core/ddsc/src/dds_participant.c
+++ b/src/core/ddsc/src/dds_participant.c
@@ -180,7 +180,7 @@ err_dds_init:
   return ret;
 }
 
-DDSRT_STATIC_ASSERT (DDS_PARTICIPANT_FLAGS_NO_DISCOVERY == (RTPS_PF_NO_BUILTIN_READERS | RTPS_PF_NO_BUILTIN_WRITERS | RTPS_PF_NO_PRIVILEGED_PP));
+DDSRT_STATIC_ASSERT (DDS_PARTICIPANT_FLAGS_NO_DISCOVERY == (RTPS_PF_NO_BUILTIN_READERS | RTPS_PF_NO_BUILTIN_WRITERS));
 
 dds_entity_t dds_create_participant_guid (const dds_domainid_t domain, const dds_qos_t *qos, const dds_listener_t *listener, uint32_t flags, const dds_guid_t *guid)
 {

--- a/src/core/ddsc/tests/xtypes_common.c
+++ b/src/core/ddsc/tests/xtypes_common.c
@@ -72,7 +72,7 @@ void test_proxy_rd_create (struct ddsi_domaingv *gv, const char *topic_name, DDS
   ddsi_add_locator_to_addrset (gv, as, &gv->loc_default_uc);
   ddsi_ref_addrset (as); // increase refc to 2, new_proxy_participant does not add a ref
   struct ddsi_proxy_participant *proxy_participant;
-  int rc = ddsi_new_proxy_participant (&proxy_participant, gv, pp_guid, 0, NULL, as, as, plist, DDS_INFINITY, DDSI_VENDORID_ECLIPSE, 0, ddsrt_time_wallclock (), 1);
+  int rc = ddsi_new_proxy_participant (&proxy_participant, gv, pp_guid, 0, as, as, plist, DDS_INFINITY, DDSI_VENDORID_ECLIPSE, ddsrt_time_wallclock (), 1);
   CU_ASSERT_FATAL (rc);
 
   ddsi_xqos_mergein_missing (&plist->qos, &ddsi_default_qos_reader, ~(uint64_t)0);

--- a/src/core/ddsi/defconfig.c
+++ b/src/core/ddsi/defconfig.c
@@ -103,9 +103,9 @@ void ddsi_config_init_default (struct ddsi_config *cfg)
   cfg->ssl_min_version.minor = 3;
 #endif /* DDS_HAS_TCP_TLS */
 }
-/* generated from ddsi_config.h[fd22386b5a5456d010458848b862bbe2be02b3e4] */
-/* generated from ddsi_config.c[ea1079220b5c907e79b1f20fe97de87874d360fd] */
-/* generated from ddsi__cfgelems.h[94e38d76830ce8487ad67cb37df5366c1b079c12] */
+/* generated from ddsi_config.h[d7db98ce697e409412ec7fb0b900e10261a66c44] */
+/* generated from ddsi_config.c[184d7299baad5acc9b96884de77770aac009a11a] */
+/* generated from ddsi__cfgelems.h[741151ccf40cab43638e8c32cac3a4b9c3e73566] */
 /* generated from cfgunits.h[05f093223fce107d24dd157ebaafa351dc9df752] */
 /* generated from _confgen.h[fd29634526c05c3237dbc3f785030fe022eb7875] */
 /* generated from _confgen.c[0d833a6f2c98902f1249e63aed03a6164f0791d6] */

--- a/src/core/ddsi/include/dds/ddsi/ddsi_config.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_config.h
@@ -39,8 +39,7 @@ enum ddsi_standards_conformance {
 
 enum ddsi_besmode {
   DDSI_BESMODE_FULL,
-  DDSI_BESMODE_WRITERS,
-  DDSI_BESMODE_MINIMAL
+  DDSI_BESMODE_WRITERS
 };
 
 enum ddsi_retransmit_merging {

--- a/src/core/ddsi/include/dds/ddsi/ddsi_domaingv.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_domaingv.h
@@ -166,18 +166,10 @@ struct ddsi_domaingv {
   ddsrt_cond_t participant_set_cond;
   uint32_t nparticipants;
 
-  /* For participants without (some) built-in writers, we fall back to
-     this participant, which is the first one created with all
-     built-in writers present.  It MUST be created before any in need
-     of it pops up! */
-  struct ddsi_participant *privileged_pp;
-  ddsrt_mutex_t privileged_pp_lock;
-
   /* For tracking (recently) deleted participants */
   struct ddsi_deleted_participants_admin *deleted_participants;
 
-  /* GUID to be used in next call to new_participant; also protected
-     by privileged_pp_lock */
+  /* GUID to be used in next call to new_participant */
   struct ddsi_guid ppguid_base;
 
   /* number of selected interfaces. */

--- a/src/core/ddsi/include/dds/ddsi/ddsi_participant.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_participant.h
@@ -31,22 +31,8 @@ extern "C" {
    they all share the information anyway.  But you do need it once. */
 #define RTPS_PF_NO_BUILTIN_READERS 1u
 /* Set this flag to prevent the creation of SPDP, SEDP and PMD
-   writers.  It will then rely on the "privileged participant", which
-   must exist at the time of creation.  It creates a reference to that
-   "privileged participant" to ensure it won't disappear too early. */
+   writers.  This prevents the discovery data from being published. */
 #define RTPS_PF_NO_BUILTIN_WRITERS 2u
-/* Set this flag to mark the participant as the "privileged
-   participant", there can only be one of these.  The privileged
-   participant MUST have all builtin readers and writers. */
-#define RTPS_PF_PRIVILEGED_PP 4u
-/* Set this flag to mark the participant as is_ddsi2_pp. */
-#define RTPS_PF_IS_DDSI2_PP 8u
-/* Set this flag to mark the participant as an local entity only. */
-#define RTPS_PF_ONLY_LOCAL 16u
-/* Set this flag to mark that no privileged participant should be used
-   for the built-in readers and writers. Can be used with NO_BUILTIN_READER and
-   NO_BUILTIN_WRITER flag to avoid any communication for built-in topics. */
-#define RTPS_PF_NO_PRIVILEGED_PP 32u
 
 struct ddsi_avail_entityid_set {
   struct ddsi_inverse_uint32_set x;
@@ -63,7 +49,6 @@ struct ddsi_participant
 {
   struct ddsi_entity_common e;
   uint32_t bes; /* built-in endpoint set */
-  unsigned is_ddsi2_pp: 1; /* true for the "federation leader", the ddsi2 participant itself in OSPL; FIXME: probably should use this for broker mode as well ... */
   uint32_t flags; /* flags used when creating this participant */
   struct ddsi_plist *plist; /* settings/QoS for this participant */
   struct ddsi_serdata *spdp_serdata; /* SPDP message: we no longer have a writer for it */
@@ -103,9 +88,6 @@ void ddsi_generate_participant_guid (ddsi_guid_t *ppguid, struct ddsi_domaingv *
  *               Zero or more of:
  *               - RTPS_PF_NO_BUILTIN_READERS   do not create discovery readers in new ppant
  *               - RTPS_PF_NO_BUILTIN_WRITERS   do not create discvoery writers in new ppant
- *               - RTPS_PF_PRIVILEGED_PP        FIXME: figure out how to describe this ...
- *               - RTPS_PF_IS_DDSI2_PP          FIXME: OSPL holdover - there is no DDSI2E here
- *               - RTPS_PF_ONLY_LOCAL           FIXME: not used, it seems
  * @param[in]  plist  Parameters/QoS for this participant
  *
  * @returns A dds_return_t indicating success or failure.

--- a/src/core/ddsi/include/dds/ddsi/ddsi_proxy_participant.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_proxy_participant.h
@@ -35,7 +35,6 @@ struct ddsi_proxy_participant
   uint32_t refc; /* number of proxy endpoints (both user & built-in; not groups, they don't have a life of their own) */
   ddsi_vendorid_t vendor; /* vendor code from discovery */
   unsigned bes; /* built-in endpoint set */
-  ddsi_guid_t privileged_pp_guid; /* if this PP depends on another PP for its SEDP writing */
   struct ddsi_plist *plist; /* settings/QoS for this participant */
   ddsrt_atomic_voidp_t minl_auto; /* clone of min(leaseheap_auto) */
   ddsrt_fibheap_t leaseheap_auto; /* keeps leases for this proxypp and leases for pwrs (with liveliness automatic) */
@@ -50,13 +49,8 @@ struct ddsi_proxy_participant
 #endif
   ddsi_seqno_t seq; /* sequence number of most recent SPDP message */
   uint32_t receive_buffer_size; /* assumed size of receive buffer, used to limit bursts involving this proxypp */
-  unsigned implicitly_created : 1; /* participants are implicitly created for Cloud/Fog discovered endpoints */
-  unsigned is_ddsi2_pp: 1; /* if this is the federation-leader on the remote node */
-  unsigned minimal_bes_mode: 1;
   unsigned lease_expired: 1;
   unsigned deleting: 1;
-  unsigned proxypp_have_spdp: 1;
-  unsigned owns_lease: 1;
   unsigned redundant_networking: 1; /* 1 iff requests receiving data on all advertised interfaces */
 #ifdef DDS_HAS_SECURITY
   ddsi_security_info_t security_info;
@@ -69,7 +63,7 @@ extern const ddsrt_avl_treedef_t ddsi_proxypp_proxytp_treedef;
 #endif
 
 /** @component ddsi_proxy_participant */
-DDS_EXPORT bool ddsi_new_proxy_participant (struct ddsi_proxy_participant **proxy_participant, struct ddsi_domaingv *gv, const struct ddsi_guid *guid, uint32_t bes, const struct ddsi_guid *privileged_pp_guid, struct ddsi_addrset *as_default, struct ddsi_addrset *as_meta, const struct ddsi_plist *plist, dds_duration_t tlease_dur, ddsi_vendorid_t vendor, unsigned custom_flags, ddsrt_wctime_t timestamp, ddsi_seqno_t seq);
+DDS_EXPORT bool ddsi_new_proxy_participant (struct ddsi_proxy_participant **proxy_participant, struct ddsi_domaingv *gv, const struct ddsi_guid *guid, uint32_t bes, struct ddsi_addrset *as_default, struct ddsi_addrset *as_meta, const struct ddsi_plist *plist, dds_duration_t tlease_dur, ddsi_vendorid_t vendor, ddsrt_wctime_t timestamp, ddsi_seqno_t seq);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsi/src/ddsi__cfgelems.h
+++ b/src/core/ddsi/src/ddsi__cfgelems.h
@@ -1262,14 +1262,11 @@ static struct cfgelem internal_cfgelems[] = {
       "are:</p>\n"
       "<ul><li><i>full</i>: all participants have all endpoints;</li>\n"
       "<li><i>writers</i>: "
-      "all participants have the writers, but just one has the readers;</li>\n"
-      "<li><i>minimal</i>: "
-      "only one participant has built-in endpoints.</li></ul>\n"
+      "all participants have the writers, but just one has the readers;</li></ul>\n"
       "<p>The default is <i>writers</i>, as this is thought to be compliant "
-      "and reasonably efficient. <i>Minimal</i> may or may not be compliant "
-      "but is most efficient, and <i>full</i> is inefficient but certain to "
+      "and reasonably efficient. <i>Full</i> is inefficient but certain to "
       "be compliant.</p>"),
-    VALUES("full","writers","minimal")),
+    VALUES("full","writers")),
   BOOL("MeasureHbToAckLatency", NULL, 1, "false",
     MEMBER(meas_hb_to_ack_latency),
     FUNCTIONS(0, uf_boolean, 0, pf_boolean),

--- a/src/core/ddsi/src/ddsi__discovery.h
+++ b/src/core/ddsi/src/ddsi__discovery.h
@@ -40,7 +40,7 @@ struct ddsi_writer *ddsi_get_sedp_writer (const struct ddsi_participant *pp, uns
   ddsrt_nonnull_all;
 
 /** @component discovery */
-struct ddsi_proxy_participant *ddsi_implicitly_create_proxypp (struct ddsi_domaingv *gv, const ddsi_guid_t *ppguid, ddsi_plist_t *datap /* note: potentially modifies datap */, const ddsi_guid_prefix_t *src_guid_prefix, ddsi_vendorid_t vendorid, ddsrt_wctime_t timestamp, ddsi_seqno_t seq)
+struct ddsi_proxy_participant *ddsi_implicitly_create_proxypp (struct ddsi_domaingv *gv, const ddsi_guid_t *ppguid, ddsi_plist_t *datap /* note: potentially modifies datap */, ddsi_vendorid_t vendorid, ddsrt_wctime_t timestamp, ddsi_seqno_t seq)
   ddsrt_nonnull_all;
 
 /** @component discovery */
@@ -48,9 +48,7 @@ bool ddsi_check_sedp_kind_and_guid (ddsi_sedp_kind_t sedp_kind, const ddsi_guid_
   ddsrt_nonnull_all;
 
 /** @component discovery */
-bool ddsi_handle_sedp_checks (struct ddsi_domaingv * const gv, ddsi_sedp_kind_t sedp_kind, ddsi_guid_t *entity_guid, ddsi_plist_t *datap,
-    const ddsi_guid_prefix_t *src_guid_prefix, ddsi_vendorid_t vendorid, ddsrt_wctime_t timestamp,
-    struct ddsi_proxy_participant **proxypp, ddsi_guid_t *ppguid)
+bool ddsi_handle_sedp_checks (struct ddsi_domaingv * const gv, ddsi_sedp_kind_t sedp_kind, ddsi_guid_t *entity_guid, ddsi_plist_t *datap, ddsi_vendorid_t vendorid, struct ddsi_proxy_participant **proxypp, ddsi_guid_t *ppguid)
   ddsrt_nonnull_all;
 
 /** @component discovery */

--- a/src/core/ddsi/src/ddsi__discovery_endpoint.h
+++ b/src/core/ddsi/src/ddsi__discovery_endpoint.h
@@ -49,7 +49,7 @@ int ddsi_sedp_dispose_unregister_writer (struct ddsi_writer *wr) ddsrt_nonnull_a
 int ddsi_sedp_dispose_unregister_reader (struct ddsi_reader *rd) ddsrt_nonnull_all;
 
 /** @component discovery */
-void ddsi_handle_sedp_alive_endpoint (const struct ddsi_receiver_state *rst, ddsi_seqno_t seq, ddsi_plist_t *datap /* note: potentially modifies datap */, ddsi_sedp_kind_t sedp_kind, const ddsi_guid_prefix_t *src_guid_prefix, ddsi_vendorid_t vendorid, ddsrt_wctime_t timestamp)
+void ddsi_handle_sedp_alive_endpoint (const struct ddsi_receiver_state *rst, ddsi_seqno_t seq, ddsi_plist_t *datap /* note: potentially modifies datap */, ddsi_sedp_kind_t sedp_kind, ddsi_vendorid_t vendorid, ddsrt_wctime_t timestamp)
   ddsrt_nonnull_all;
 
 /** @component discovery */

--- a/src/core/ddsi/src/ddsi__discovery_topic.h
+++ b/src/core/ddsi/src/ddsi__discovery_topic.h
@@ -34,7 +34,7 @@ struct ddsi_receiver_state;
 int ddsi_sedp_write_topic (struct ddsi_topic *tp, bool alive) ddsrt_nonnull_all;
 
 /** @component discovery */
-void ddsi_handle_sedp_alive_topic (const struct ddsi_receiver_state *rst, ddsi_seqno_t seq, ddsi_plist_t *datap /* note: potentially modifies datap */, const ddsi_guid_prefix_t *src_guid_prefix, ddsi_vendorid_t vendorid, ddsrt_wctime_t timestamp)
+void ddsi_handle_sedp_alive_topic (const struct ddsi_receiver_state *rst, ddsi_seqno_t seq, ddsi_plist_t *datap /* note: potentially modifies datap */, ddsi_vendorid_t vendorid, ddsrt_wctime_t timestamp)
   ddsrt_nonnull_all;
 
 /** @component discovery */

--- a/src/core/ddsi/src/ddsi__participant.h
+++ b/src/core/ddsi/src/ddsi__participant.h
@@ -101,13 +101,16 @@ dds_duration_t ddsi_participant_get_pmd_interval (struct ddsi_participant *pp);
 /**
  * @component ddsi_participant
  * @brief To obtain the builtin writer to be used for publishing SPDP, SEDP, PMD stuff for
- * PP and its endpoints, given the entityid. If PP has its own writer, use it; else use the
- * privileged participant, unless the NO_PRIVILEGED_PP flag is set.
+ * PP and its endpoints, given the entityid.
  *
  * @param[in] pp The participant
  * @param[in] entityid The entity ID of the writer
  * @param[out] bwr The built-in writer
  * @returns Return code indicating success or failure
+ * @retval `DDS_RETCODE_OK` and `bwr` != NULL writer to use
+ * @retval `DDS_RETCODE_OK` and `bwr` == NULL no data needs to be written
+ * @retval `DDS_RETCODE_PRECONDITION_NOT_MET` data should be written but participant does not have a writer
+ * @retval `DDS_RETCODE_BAD_PARAMETER` entityid is invalid
  */
 dds_return_t ddsi_get_builtin_writer (const struct ddsi_participant *pp, unsigned entityid, struct ddsi_writer **bwr);
 

--- a/src/core/ddsi/src/ddsi__proxy_participant.h
+++ b/src/core/ddsi/src/ddsi__proxy_participant.h
@@ -31,23 +31,8 @@ struct ddsi_addrset;
 struct ddsi_proxy_endpoint_common;
 struct ddsi_proxy_writer;
 
-/* Set when this proxy participant is created implicitly and has to be deleted upon disappearance
-   of its last endpoint.  FIXME: Currently there is a potential race with adding a new endpoint
-   in parallel to deleting the last remaining one. The endpoint will then be created, added to the
-   proxy participant and then both are deleted. With the current single-threaded discovery
-   this can only happen when it is all triggered by lease expiry. */
-#define DDSI_CF_IMPLICITLY_CREATED_PROXYPP          (1 << 0)
-/* Set when this proxy participant is a DDSI2 participant, to help Cloud figure out whom to send
-   discovery data when used in conjunction with the networking bridge */
-#define DDSI_CF_PARTICIPANT_IS_DDSI2                (1 << 1)
-/* Set when this proxy participant is not to be announced on the built-in topics yet */
-#define DDSI_CF_PROXYPP_NO_SPDP                     (1 << 2)
-
 /** @component ddsi_proxy_participant */
 int ddsi_update_proxy_participant_plist_locked (struct ddsi_proxy_participant *proxypp, ddsi_seqno_t seq, const struct ddsi_plist *datap, ddsrt_wctime_t timestamp);
-
-/** @component ddsi_proxy_participant */
-void ddsi_proxy_participant_reassign_lease (struct ddsi_proxy_participant *proxypp, struct ddsi_lease *newlease);
 
 /** @component ddsi_proxy_participant */
 void ddsi_purge_proxy_participants (struct ddsi_domaingv *gv, const ddsi_xlocator_t *loc);

--- a/src/core/ddsi/src/ddsi_config.c
+++ b/src/core/ddsi/src/ddsi_config.c
@@ -979,8 +979,8 @@ static const char *en_boolean_default_vs[] = { "default", "false", "true", NULL 
 static const enum ddsi_boolean_default en_boolean_default_ms[] = { DDSI_BOOLDEF_DEFAULT, DDSI_BOOLDEF_FALSE, DDSI_BOOLDEF_TRUE, 0 };
 GENERIC_ENUM_CTYPE (boolean_default, enum ddsi_boolean_default)
 
-static const char *en_besmode_vs[] = { "full", "writers", "minimal", NULL };
-static const enum ddsi_besmode en_besmode_ms[] = { DDSI_BESMODE_FULL, DDSI_BESMODE_WRITERS, DDSI_BESMODE_MINIMAL, 0 };
+static const char *en_besmode_vs[] = { "full", "writers", NULL };
+static const enum ddsi_besmode en_besmode_ms[] = { DDSI_BESMODE_FULL, DDSI_BESMODE_WRITERS, 0 };
 GENERIC_ENUM_CTYPE (besmode, enum ddsi_besmode)
 
 static const char *en_retransmit_merging_vs[] = { "never", "adaptive", "always", NULL };

--- a/src/core/ddsi/src/ddsi_debmon.c
+++ b/src/core/ddsi/src/ddsi_debmon.c
@@ -413,13 +413,6 @@ static void print_writer_seq (struct st *st, void *varg)
       cpfobj (st, print_writer, &(struct print_writer_arg){ .p = arg->p, .w = w });
 }
 
-static void print_participant_flags (struct st *st, void *vp)
-{
-  struct ddsi_participant * const p = vp;
-  if (p->is_ddsi2_pp)
-    cpfstr (st, "ddsi2");
-}
-
 static void print_participant (struct st *st, void *vp)
 {
   struct ddsi_participant *p = vp;
@@ -427,7 +420,6 @@ static void print_participant (struct st *st, void *vp)
   ddsrt_mutex_lock (&p->e.lock);
   cpfkguid (st, "guid", &p->e.guid);
   cpfkstr (st, "name", (p->plist->qos.present & DDSI_QP_ENTITY_NAME) ? p->plist->qos.entity_name : "");
-  cpfkseq (st, "flags", print_participant_flags, p);
   ddsrt_mutex_unlock (&p->e.lock);
 
   {
@@ -570,12 +562,6 @@ static void print_proxy_writer_seq (struct st *st, void *varg)
 static void print_proxy_participant_flags (struct st *st, void *vp)
 {
   struct ddsi_proxy_participant * const p = vp;
-  if (p->implicitly_created)
-    cpfstr (st, "implicitly_created");
-  if (p->is_ddsi2_pp)
-    cpfstr (st, "ddsi2");
-  if (p->minimal_bes_mode)
-    cpfstr (st, "minimal_bes_mode");
   if (p->redundant_networking)
     cpfstr (st, "redundant_networking");
 }

--- a/src/core/ddsi/src/ddsi_discovery.c
+++ b/src/core/ddsi/src/ddsi_discovery.c
@@ -72,87 +72,6 @@ struct ddsi_writer *ddsi_get_sedp_writer (const struct ddsi_participant *pp, uns
   return sedp_wr;
 }
 
-struct ddsi_proxy_participant *ddsi_implicitly_create_proxypp (struct ddsi_domaingv *gv, const ddsi_guid_t *ppguid, ddsi_plist_t *datap /* note: potentially modifies datap */, const ddsi_guid_prefix_t *src_guid_prefix, ddsi_vendorid_t vendorid, ddsrt_wctime_t timestamp, ddsi_seqno_t seq)
-{
-  ddsi_guid_t privguid;
-  ddsi_plist_t pp_plist;
-  struct ddsi_proxy_participant *proxy_participant;
-
-  if (memcmp (&ppguid->prefix, src_guid_prefix, sizeof (ppguid->prefix)) == 0)
-    /* if the writer is owned by the participant itself, we're not interested */
-    return NULL;
-
-  privguid.prefix = *src_guid_prefix;
-  privguid.entityid = ddsi_to_entityid (DDSI_ENTITYID_PARTICIPANT);
-  ddsi_plist_init_empty(&pp_plist);
-
-  if (ddsi_vendor_is_cloud (vendorid))
-  {
-    ddsi_vendorid_t actual_vendorid;
-    /* Some endpoint that we discovered through the DS, but then it must have at least some locators */
-    GVTRACE (" from-DS %"PRIx32":%"PRIx32":%"PRIx32":%"PRIx32, PGUID (privguid));
-    /* avoid "no address" case, so we never create the proxy participant for nothing (FIXME: rework some of this) */
-    if (!(datap->present & (PP_UNICAST_LOCATOR | PP_MULTICAST_LOCATOR)))
-    {
-      GVTRACE (" data locator absent\n");
-      goto err;
-    }
-    GVTRACE (" new-proxypp "PGUIDFMT"\n", PGUID (*ppguid));
-    /* We need to handle any source of entities, but we really want to try to keep the GIDs (and
-       certainly the systemId component) unchanged for OSPL.  The new proxy participant will take
-       the GID from the GUID if it is from a "modern" OSPL that advertises it includes all GIDs in
-       the endpoint discovery; else if it is OSPL it will take at the systemId and fake the rest.
-       However, (1) Cloud filters out the GIDs from the discovery, and (2) DDSI2 deliberately
-       doesn't include the GID for internally generated endpoints (such as the fictitious transient
-       data readers) to signal that these are internal and have no GID (and not including a GID if
-       there is none is quite a reasonable approach).  Point (2) means we have no reliable way of
-       determining whether GIDs are included based on the first endpoint, and so there is no point
-       doing anything about (1).  That means we fall back to the legacy mode of locally generating
-       GIDs but leaving the system id unchanged if the remote is OSPL.  */
-    actual_vendorid = (datap->present & PP_VENDORID) ?  datap->vendorid : vendorid;
-    (void) ddsi_new_proxy_participant (&proxy_participant, gv, ppguid, 0, &privguid, ddsi_new_addrset(), ddsi_new_addrset(), &pp_plist, DDS_INFINITY, actual_vendorid, DDSI_CF_IMPLICITLY_CREATED_PROXYPP, timestamp, seq);
-  }
-  else if (ppguid->prefix.u[0] == src_guid_prefix->u[0] && ddsi_vendor_is_eclipse_or_opensplice (vendorid))
-  {
-    /* FIXME: requires address sets to be those of ddsi2, no built-in
-       readers or writers, only if remote ddsi2 is provably running
-       with a minimal built-in endpoint set */
-    struct ddsi_proxy_participant *privpp;
-    if ((privpp = ddsi_entidx_lookup_proxy_participant_guid (gv->entity_index, &privguid)) == NULL) {
-      GVTRACE (" unknown-src-proxypp?\n");
-      goto err;
-    } else if (!privpp->is_ddsi2_pp) {
-      GVTRACE (" src-proxypp-not-ddsi2?\n");
-      goto err;
-    } else if (!privpp->minimal_bes_mode) {
-      GVTRACE (" src-ddsi2-not-minimal-bes-mode?\n");
-      goto err;
-    } else {
-      struct ddsi_addrset *as_default, *as_meta;
-      ddsi_plist_t tmp_plist;
-      GVTRACE (" from-ddsi2 "PGUIDFMT, PGUID (privguid));
-      ddsi_plist_init_empty (&pp_plist);
-
-      ddsrt_mutex_lock (&privpp->e.lock);
-      as_default = ddsi_ref_addrset(privpp->as_default);
-      as_meta = ddsi_ref_addrset(privpp->as_meta);
-      /* copy just what we need */
-      tmp_plist = *privpp->plist;
-      tmp_plist.present = PP_PARTICIPANT_GUID | PP_ADLINK_PARTICIPANT_VERSION_INFO;
-      tmp_plist.participant_guid = *ppguid;
-      ddsi_plist_mergein_missing (&pp_plist, &tmp_plist, ~(uint64_t)0, ~(uint64_t)0);
-      ddsrt_mutex_unlock (&privpp->e.lock);
-
-      pp_plist.adlink_participant_version_info.flags &= ~DDSI_ADLINK_FL_PARTICIPANT_IS_DDSI2;
-      (void) ddsi_new_proxy_participant (&proxy_participant, gv, ppguid, 0, &privguid, as_default, as_meta, &pp_plist, DDS_INFINITY, vendorid, DDSI_CF_IMPLICITLY_CREATED_PROXYPP | DDSI_CF_PROXYPP_NO_SPDP, timestamp, seq);
-    }
-  }
-
- err:
-  ddsi_plist_fini (&pp_plist);
-  return ddsi_entidx_lookup_proxy_participant_guid (gv->entity_index, ppguid);
-}
-
 bool ddsi_check_sedp_kind_and_guid (ddsi_sedp_kind_t sedp_kind, const ddsi_guid_t *entity_guid)
 {
   switch (sedp_kind)
@@ -168,9 +87,7 @@ bool ddsi_check_sedp_kind_and_guid (ddsi_sedp_kind_t sedp_kind, const ddsi_guid_
   return false;
 }
 
-bool ddsi_handle_sedp_checks (struct ddsi_domaingv * const gv, ddsi_sedp_kind_t sedp_kind, ddsi_guid_t *entity_guid, ddsi_plist_t *datap,
-    const ddsi_guid_prefix_t *src_guid_prefix, ddsi_vendorid_t vendorid, ddsrt_wctime_t timestamp,
-    struct ddsi_proxy_participant **proxypp, ddsi_guid_t *ppguid)
+bool ddsi_handle_sedp_checks (struct ddsi_domaingv * const gv, ddsi_sedp_kind_t sedp_kind, ddsi_guid_t *entity_guid, ddsi_plist_t *datap, ddsi_vendorid_t vendorid, struct ddsi_proxy_participant **proxypp, ddsi_guid_t *ppguid)
 {
 #define E(msg, lbl) do { GVLOGDISC (msg); return false; } while (0)
   if (!ddsi_check_sedp_kind_and_guid (sedp_kind, entity_guid))
@@ -191,13 +108,7 @@ bool ddsi_handle_sedp_checks (struct ddsi_domaingv * const gv, ddsi_sedp_kind_t 
   if (!(datap->qos.present & DDSI_QP_TYPE_NAME))
     E (" no typename?\n", err);
   if ((*proxypp = ddsi_entidx_lookup_proxy_participant_guid (gv->entity_index, ppguid)) == NULL)
-  {
-    GVLOGDISC (" unknown-proxypp");
-    if ((*proxypp = ddsi_implicitly_create_proxypp (gv, ppguid, datap, src_guid_prefix, vendorid, timestamp, 0)) == NULL)
-      E ("?\n", err);
-    /* Repeat regular SEDP trace for convenience */
-    GVLOGDISC ("SEDP ST0 "PGUIDFMT" (cont)", PGUID (*entity_guid));
-  }
+    E (" unknown-proxypp", err);
   return true;
 #undef E
 }
@@ -216,12 +127,12 @@ static void ddsi_handle_sedp (const struct ddsi_receiver_state *rst, ddsi_seqno_
         {
           case SEDP_KIND_TOPIC:
 #ifdef DDS_HAS_TOPIC_DISCOVERY
-            ddsi_handle_sedp_alive_topic (rst, seq, &decoded_data, &rst->src_guid_prefix, rst->vendor, serdata->timestamp);
+            ddsi_handle_sedp_alive_topic (rst, seq, &decoded_data, rst->vendor, serdata->timestamp);
 #endif
             break;
           case SEDP_KIND_READER:
           case SEDP_KIND_WRITER:
-            ddsi_handle_sedp_alive_endpoint (rst, seq, &decoded_data, sedp_kind, &rst->src_guid_prefix, rst->vendor, serdata->timestamp);
+            ddsi_handle_sedp_alive_endpoint (rst, seq, &decoded_data, sedp_kind, rst->vendor, serdata->timestamp);
             break;
         }
         break;

--- a/src/core/ddsi/src/ddsi_discovery_topic.c
+++ b/src/core/ddsi/src/ddsi_discovery_topic.c
@@ -91,7 +91,7 @@ static const char *durability_to_string (dds_durability_kind_t k)
   return "undefined-durability";
 }
 
-void ddsi_handle_sedp_alive_topic (const struct ddsi_receiver_state *rst, ddsi_seqno_t seq, ddsi_plist_t *datap /* note: potentially modifies datap */, const ddsi_guid_prefix_t *src_guid_prefix, ddsi_vendorid_t vendorid, ddsrt_wctime_t timestamp)
+void ddsi_handle_sedp_alive_topic (const struct ddsi_receiver_state *rst, ddsi_seqno_t seq, ddsi_plist_t *datap /* note: potentially modifies datap */, ddsi_vendorid_t vendorid, ddsrt_wctime_t timestamp)
 {
   struct ddsi_domaingv * const gv = rst->gv;
   struct ddsi_proxy_participant *proxypp;
@@ -104,7 +104,7 @@ void ddsi_handle_sedp_alive_topic (const struct ddsi_receiver_state *rst, ddsi_s
   assert (datap->present & PP_CYCLONE_TOPIC_GUID);
   GVLOGDISC (" "PGUIDFMT, PGUID (datap->topic_guid));
 
-  if (!ddsi_handle_sedp_checks (gv, SEDP_KIND_TOPIC, &datap->topic_guid, datap, src_guid_prefix, vendorid, timestamp, &proxypp, &ppguid))
+  if (!ddsi_handle_sedp_checks (gv, SEDP_KIND_TOPIC, &datap->topic_guid, datap, vendorid, &proxypp, &ppguid))
     return;
 
   xqos = &datap->qos;

--- a/src/core/ddsi/tests/plist_leasedur.c
+++ b/src/core/ddsi/tests/plist_leasedur.c
@@ -369,7 +369,7 @@ static void ddsi_plist_leasedur_new_proxyrd_impl (bool include_lease_duration)
   plist.qos.liveliness.lease_duration = DDS_SECS (10);
   ddsi_thread_state_awake (thrst, &gv);
   ddsi_generate_participant_guid (&ppguid, &gv);
-  dds_return_t ret = ddsi_new_participant (&ppguid, &gv, RTPS_PF_PRIVILEGED_PP | RTPS_PF_IS_DDSI2_PP, &plist);
+  dds_return_t ret = ddsi_new_participant (&ppguid, &gv, 0, &plist);
   ddsi_thread_state_asleep (thrst);
   CU_ASSERT_FATAL (ret >= 0);
   ddsi_plist_fini (&plist);

--- a/src/core/ddsi/tests/pmd_message.c
+++ b/src/core/ddsi/tests/pmd_message.c
@@ -228,7 +228,7 @@ static void create_fake_proxy_participant (void)
   ddsi_xqos_mergein_missing (&plist.qos, &gv.default_local_xqos_pp, ~(uint64_t)0);
   ddsi_thread_state_awake (thrst, &gv);
   ddsi_generate_participant_guid (&ppguid, &gv);
-  dds_return_t ret = ddsi_new_participant (&ppguid, &gv, RTPS_PF_IS_DDSI2_PP | RTPS_PF_PRIVILEGED_PP, &plist);
+  dds_return_t ret = ddsi_new_participant (&ppguid, &gv, 0, &plist);
   ddsi_thread_state_asleep (thrst);
   ddsi_plist_fini (&plist);
   CU_ASSERT_FATAL (ret == 0);

--- a/src/core/ddsi/tests/wraddrset.c
+++ b/src/core/ddsi/tests/wraddrset.c
@@ -146,7 +146,7 @@ static void ddsi_wraddrset_some_cases (int casenumber, int cost, bool wr_psmx, c
   setup_and_start ();
   ddsi_thread_state_awake (ddsi_lookup_thread_state(), &gv);
   ddsi_generate_participant_guid (&wrppguid, &gv);
-  ddsi_new_participant (&wrppguid, &gv, RTPS_PF_PRIVILEGED_PP | RTPS_PF_IS_DDSI2_PP, &plist_pp[0]);
+  ddsi_new_participant (&wrppguid, &gv, 0, &plist_pp[0]);
 
   const struct ddsi_sertype st = {
     .ops = &(struct ddsi_sertype_ops){ .free = sertype_free },
@@ -203,7 +203,7 @@ static void ddsi_wraddrset_some_cases (int casenumber, int cost, bool wr_psmx, c
       ddsi_locator_t loc = ucloc[i]; loc.port = 1000 + (unsigned) j;
       ddsi_add_locator_to_addrset (&gv, proxypp_as, &loc);
       ddsi_add_locator_to_addrset (&gv, proxypp_as, &mcloc);
-      ddsi_new_proxy_participant (&proxy_participant, &gv, &rdppguid[i][j], 0, NULL, proxypp_as, ddsi_ref_addrset (proxypp_as), &plist_pp[i], DDS_INFINITY, DDSI_VENDORID_ECLIPSE, 0, ddsrt_time_wallclock (), 1);
+      ddsi_new_proxy_participant (&proxy_participant, &gv, &rdppguid[i][j], 0, proxypp_as, ddsi_ref_addrset (proxypp_as), &plist_pp[i], DDS_INFINITY, DDSI_VENDORID_ECLIPSE, ddsrt_time_wallclock (), 1);
       assert (proxy_participant != NULL);
 
       const ddsi_guid_t rdguid = {

--- a/src/core/xtests/symbol_export/symbol_export.c
+++ b/src/core/xtests/symbol_export/symbol_export.c
@@ -773,7 +773,7 @@ int main (int argc, char **argv)
 #endif
 
   // ddsi/ddsi_proxy_participant.h
-  ddsi_new_proxy_participant (ptr, ptr2, ptr3, 0, ptr5, ptr6, ptr7, ptr8, 0, (ddsi_vendorid_t) { 0 }, 0, ddsrt_time_wallclock (), 0);
+  ddsi_new_proxy_participant (ptr, ptr2, ptr3, 0, ptr5, ptr6, ptr7, 0, (ddsi_vendorid_t) { 0 }, ddsrt_time_wallclock(), 0);
 
   // ddsi/ddsi_plist.h
   ddsi_plist_init_empty (ptr);


### PR DESCRIPTION
The code base inherited (from OpenSplice) some features to handle participants dependent on another participant, for example a participant for which all discovery and application data is handle by a gateway process.  This is a useful feature in principle, but it hasn't been used or tested in Cyclone in years and it now turns out to cause incorrect handling of the writer liveliness in combination with, of all implementations, OpenSplice.

This removes that (now broken) support because cleaning up, fixing the code and adding tests is too big a project at this time, and all the old code visible in the history.