### PR TITLE
Dynsub better json

### DIFF
--- a/examples/dynsub/dynsub.h
+++ b/examples/dynsub/dynsub.h
@@ -34,13 +34,6 @@ struct type_hashid_map {
   int lineno;
 };
 
-struct context {
-  bool valid_data;
-  bool key;
-  size_t offset;
-  size_t maxalign;
-};
-
 struct ppc {
   bool bol;
   int indent;

--- a/examples/dynsub/variouspub.c
+++ b/examples/dynsub/variouspub.c
@@ -99,6 +99,14 @@ static void *samples_d[] = {
   NULL
 };
 
+static void *samples_e[] = {
+  &(E){ 0, {{0},{0}}, 456 },
+  &(E){ 0, {{0},{._length=1, ._maximum=1, ._buffer=&(U){34,"aap","noot",56}}}, 456},
+  &(E){ 0, {{0},{._length=1, ._maximum=1, ._buffer=&(U){78,"aap","zus",56}}}, 456},
+  &(E){ 0, {{0},{._length=1, ._maximum=1, ._buffer=&(U){78,"wim","zus",90}}}, 456},
+  NULL
+};
+
 static struct tpentry {
   const char *name;
   const dds_topic_descriptor_t *descr;
@@ -110,6 +118,7 @@ static struct tpentry {
   { "C", &C_desc, samples_c, offsetof (C, b.a.count) },
   { "M1::O", &M1_O_desc, samples_M1_O, SIZE_MAX },
   { "D", &D_desc, samples_d, offsetof (D, count) },
+  { "E", &E_desc, samples_e, offsetof (E, a) },
   { NULL, NULL, NULL, 0 }
 };
 

--- a/examples/dynsub/variouspub_types.idl
+++ b/examples/dynsub/variouspub_types.idl
@@ -33,3 +33,16 @@ struct D {
   wchar wc;
   unsigned long count;
 };
+
+struct U {
+  uint32 w;
+  @key string x;
+  string y;
+  @key uint32 z;
+};
+
+struct E {
+  uint32 a;
+  @key sequence<U> b[2];
+  @key uint32 c;
+};


### PR DESCRIPTION
Dynsub would print an extra comma before the first field in the output when printing an invalid sample of a type where the first key field was preceded by a non-key field.