### PR TITLE
Fix use-after-free in `ddsi_local_reader_ary_insert`

### DIFF
--- a/src/core/ddsc/tests/CMakeLists.txt
+++ b/src/core/ddsc/tests/CMakeLists.txt
@@ -73,6 +73,7 @@ set(ddsc_test_sources
     "qos_set_match.c"
     "querycondition.c"
     "guardcondition.c"
+    "matchstress.c"
     "readcollect.c"
     "readcondition.c"
     "reader.c"
@@ -269,7 +270,7 @@ if(BUILD_SHARED_LIBS)
 else()
   list(APPEND psmx_includes
     "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src/ddsrt/include>"
-    "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src/core/include>" 
+    "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src/core/include>"
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../ddsc/include>"
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../../ddsrt/include>")
   add_library(psmx_cdds OBJECT ${psmx_cdds_sources} psmx_cdds_data.c)

--- a/src/core/ddsc/tests/matchstress.c
+++ b/src/core/ddsc/tests/matchstress.c
@@ -1,0 +1,95 @@
+// Copyright(c) 2025 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+#include <stdio.h>
+
+#include "dds/dds.h"
+#include "dds/ddsrt/threads.h"
+#include "test_common.h"
+#include "build_options.h"
+
+struct create_reader_thread_arg {
+  dds_entity_t dp;
+  dds_entity_t tp;
+  dds_listener_t *listener;
+};
+
+static void on_pub_matched (dds_entity_t wr, const dds_publication_matched_status_t st, void *arg)
+{
+  (void) wr; (void) st; (void) arg;
+}
+
+static void on_sub_matched (dds_entity_t rd, const dds_subscription_matched_status_t st, void *arg)
+{
+  (void) rd; (void) st; (void) arg;
+}
+
+static uint32_t create_reader_thread (void *varg)
+{
+  struct create_reader_thread_arg *arg = varg;
+  const dds_entity_t rd = dds_create_reader (arg->dp, arg->tp, NULL, arg->listener);
+  if (rd < 0)
+    return __LINE__;
+  if (dds_set_listener (rd, NULL) != 0)
+    return __LINE__;
+  if (dds_delete (rd) != 0)
+    return __LINE__;
+  return 0;
+}
+
+static void do_ddsc_match_stress_single_writer_many_readers (void)
+{
+  const dds_entity_t dp = dds_create_participant (0, NULL, NULL);
+  CU_ASSERT_FATAL (dp > 0);
+  char topicname[100];
+  create_unique_topic_name ("ddsc_match_stress_single_writer_many_readers", topicname, sizeof (topicname));
+  const dds_entity_t tp = dds_create_topic (dp, &Space_Type1_desc, topicname, NULL, NULL);
+  CU_ASSERT_FATAL (tp > 0);
+  dds_listener_t *listener = dds_create_listener (NULL);
+  dds_lset_publication_matched (listener, on_pub_matched);
+  dds_lset_subscription_matched (listener, on_sub_matched);
+  const dds_entity_t wr = dds_create_writer (dp, tp, NULL, listener);
+  CU_ASSERT_FATAL (wr > 0);
+  ddsrt_threadattr_t tattr;
+  ddsrt_threadattr_init (&tattr);
+  ddsrt_thread_t tids[100];
+  struct create_reader_thread_arg crtarg = { .dp = dp, .tp = tp, .listener = listener };
+  dds_return_t rc;
+  for (size_t i = 0; i < sizeof (tids) / sizeof (tids[0]); i++)
+  {
+    char threadname[100];
+    snprintf (threadname, sizeof (threadname), "thr%zu", i);
+    rc = ddsrt_thread_create (&tids[i], threadname, &tattr, create_reader_thread, &crtarg);
+    CU_ASSERT_FATAL (rc == 0);
+  }
+  rc = dds_set_listener (wr, NULL);
+  CU_ASSERT_FATAL (rc == 0);
+  rc = dds_delete (wr);
+  CU_ASSERT_FATAL (rc == 0);
+  for (size_t i = 0; i < sizeof (tids) / sizeof (tids[0]); i++)
+  {
+    uint32_t res;
+    rc = ddsrt_thread_join (tids[i], &res);
+    CU_ASSERT_FATAL (rc == 0);
+    CU_ASSERT_FATAL (res == 0);
+  }
+  dds_delete_listener (listener);
+  rc = dds_delete (dp);
+  CU_ASSERT_FATAL (rc == 0);
+}
+
+CU_Test(ddsc_match_stress, single_writer_many_readers)
+{
+  // Needs many runs to hit the rare race condition that used to trigger
+  //
+  // 10 is not nearly enough, 1000 seems to be getting there on macOS on an M1
+  for (int i = 0; i < 10; i++)
+    do_ddsc_match_stress_single_writer_many_readers ();
+}

--- a/src/core/ddsi/src/ddsi_init.c
+++ b/src/core/ddsi/src/ddsi_init.c
@@ -990,7 +990,7 @@ void ddsi_set_deafmute (struct ddsi_domaingv *gv, bool deaf, bool mute, int64_t 
   {
     ddsrt_mtime_t when = ddsrt_mtime_add_duration (ddsrt_time_monotonic (), reset_after);
     GVTRACE (" reset after %"PRId64".%09u ns", reset_after / DDS_NSECS_IN_SEC, (unsigned) (reset_after % DDS_NSECS_IN_SEC));
-    ddsi_qxev_callback (gv->xevents, when, reset_deaf_mute, NULL, 0, true);
+    ddsi_qxev_callback (gv->xevents, when, reset_deaf_mute, NULL, 0, false);
   }
   GVLOGDISC ("\n");
 }


### PR DESCRIPTION
When deleting a writer, it is first removed from the hash table, and only later
freed. When deleting a reader, it needs to be removed from the writer's array of reader
pointers, but the writer can no longer be found when it has been removed from said hash
table. This causes a dangling reader pointer to be left in the array.

If another reader is getting matched to the writer in parallel to this, it potentially
dereferences readers in this array to check the type pointer, to keep readers with the
same type together. This can result in a use-after-free.

For example:

reader 1 gets created, starts matching, locates writer W, thread is descheduled
writer W is deleted, gets removed from hash table, freeing is deferred
reader 2 is deleted, can't find W, leaves dangling pointer in reader ary
reader 1 matching continues, compares reader 1's type pointer with (what used to be)
  reader 2's type pointer found in the array

There is already a "valid" flag for the reader array, which gets reset once: when it is
removed from the hash table (all under the writer lock). Adding a reader to the array
needs to be skipped when the array is no longer valid.