### PR TITLE
Type info in built-in topics for local entities

### DIFF
--- a/src/core/ddsi/src/ddsi__entity.h
+++ b/src/core/ddsi/src/ddsi__entity.h
@@ -66,7 +66,7 @@ int ddsi_is_builtin_entityid (ddsi_entityid_t id, ddsi_vendorid_t vendorid);
 bool ddsi_update_qos_locked (struct ddsi_entity_common *e, dds_qos_t *ent_qos, const dds_qos_t *xqos, ddsrt_wctime_t timestamp);
 
 /** @component ddsi_generic_entity */
-int ddsi_set_topic_type_name (dds_qos_t *xqos, const char * topic_name, const char * type_name);
+int ddsi_set_xqos_topic_and_type (dds_qos_t *xqos, const char * topic_name, const struct ddsi_sertype * type);
 
 /** @component ddsi_generic_entity */
 int ddsi_compare_entityid (const void *a, const void *b);

--- a/src/core/ddsi/src/ddsi_discovery_endpoint.c
+++ b/src/core/ddsi/src/ddsi_discovery_endpoint.c
@@ -118,11 +118,7 @@ static int sedp_write_endpoint_impl
 (
    struct ddsi_writer *wr, int alive, const ddsi_guid_t *guid,
    const struct ddsi_endpoint_common *epcommon,
-   const dds_qos_t *xqos, struct ddsi_addrset *as, ddsi_security_info_t *security
-#ifdef DDS_HAS_TYPELIB
-   , const struct ddsi_sertype *sertype
-#endif
-)
+   const dds_qos_t *xqos, struct ddsi_addrset *as, ddsi_security_info_t *security)
 {
   struct ddsi_domaingv * const gv = wr->e.gv;
   const dds_qos_t *defqos = NULL;
@@ -247,12 +243,6 @@ static int sedp_write_endpoint_impl
       for (uint32_t i = 0; i < epcommon->psmx_locators.length; i++)
         add_psmx_locator_to_ps (&epcommon->psmx_locators.locators[i], &arg);
     }
-
-#ifdef DDS_HAS_TYPELIB
-    assert (sertype);
-    if ((ps.qos.type_information = ddsi_sertype_typeinfo (sertype)))
-      ps.qos.present |= DDSI_QP_TYPE_INFORMATION;
-#endif
   }
 
   if (xqos)
@@ -283,11 +273,7 @@ int ddsi_sedp_write_writer (struct ddsi_writer *wr)
     security = &tmp;
 #endif
 
-#ifdef DDS_HAS_TYPELIB
-  return sedp_write_endpoint_impl (sedp_wr, 1, &wr->e.guid, &wr->c, wr->xqos, as, security, wr->type);
-#else
   return sedp_write_endpoint_impl (sedp_wr, 1, &wr->e.guid, &wr->c, wr->xqos, as, security);
-#endif
 }
 
 int ddsi_sedp_write_reader (struct ddsi_reader *rd)
@@ -326,11 +312,7 @@ int ddsi_sedp_write_reader (struct ddsi_reader *rd)
     security = &tmp;
   }
 #endif
-#ifdef DDS_HAS_TYPELIB
-  const int ret = sedp_write_endpoint_impl (sedp_wr, 1, &rd->e.guid, &rd->c, rd->xqos, as, security, rd->type);
-#else
   const int ret = sedp_write_endpoint_impl (sedp_wr, 1, &rd->e.guid, &rd->c, rd->xqos, as, security);
-#endif
   ddsi_unref_addrset (as);
   return ret;
 }
@@ -345,11 +327,7 @@ int ddsi_sedp_dispose_unregister_writer (struct ddsi_writer *wr)
   if (sedp_wr == NULL)
     return 0;
 
-#ifdef DDS_HAS_TYPELIB
-  return sedp_write_endpoint_impl (sedp_wr, 0, &wr->e.guid, NULL, NULL, NULL, NULL, NULL);
-#else
   return sedp_write_endpoint_impl (sedp_wr, 0, &wr->e.guid, NULL, NULL, NULL, NULL);
-#endif
 }
 
 int ddsi_sedp_dispose_unregister_reader (struct ddsi_reader *rd)
@@ -362,11 +340,7 @@ int ddsi_sedp_dispose_unregister_reader (struct ddsi_reader *rd)
   if (sedp_wr == NULL)
     return 0;
 
-#ifdef DDS_HAS_TYPELIB
-  return sedp_write_endpoint_impl (sedp_wr, 0, &rd->e.guid, NULL, NULL, NULL, NULL, NULL);
-#else
   return sedp_write_endpoint_impl (sedp_wr, 0, &rd->e.guid, NULL, NULL, NULL, NULL);
-#endif
 }
 
 static const char *durability_to_string (dds_durability_kind_t k)

--- a/src/core/ddsi/src/ddsi_discovery_topic.c
+++ b/src/core/ddsi/src/ddsi_discovery_topic.c
@@ -30,7 +30,7 @@
 #include "ddsi__xqos.h"
 #include "ddsi__typelib.h"
 
-static int ddsi_sedp_write_topic_impl (struct ddsi_writer *wr, int alive, const ddsi_guid_t *guid, const dds_qos_t *xqos, ddsi_typeinfo_t *type_info)
+static int ddsi_sedp_write_topic_impl (struct ddsi_writer *wr, int alive, const ddsi_guid_t *guid, const dds_qos_t *xqos)
 {
   struct ddsi_domaingv * const gv = wr->e.gv;
   const dds_qos_t *defqos = &ddsi_default_qos_topic;
@@ -48,12 +48,6 @@ static int ddsi_sedp_write_topic_impl (struct ddsi_writer *wr, int alive, const 
   uint64_t qosdiff = ddsi_xqos_delta (xqos, defqos, ~(uint64_t)0);
   if (gv->config.explicitly_publish_qos_set_to_default)
     qosdiff |= ~DDSI_QP_UNRECOGNIZED_INCOMPATIBLE_MASK;
-
-  if (type_info)
-  {
-    ps.qos.type_information = type_info;
-    ps.qos.present |= DDSI_QP_TYPE_INFORMATION;
-  }
   if (xqos)
     ddsi_xqos_mergein_missing (&ps.qos, xqos, qosdiff);
   return ddsi_write_and_fini_plist (wr, &ps, alive);
@@ -74,7 +68,7 @@ int ddsi_sedp_write_topic (struct ddsi_topic *tp, bool alive)
   int ret = 0;
   ddsrt_mutex_lock (&tp->e.qos_lock);
   // the allocation type info object is freed with the plist
-  ret = ddsi_sedp_write_topic_impl (sedp_wr, alive, &tp->e.guid, tp->definition->xqos, ddsi_type_pair_get_typeinfo (tp->e.gv, tp->definition->type_pair));
+  ret = ddsi_sedp_write_topic_impl (sedp_wr, alive, &tp->e.guid, tp->definition->xqos);
   ddsrt_mutex_unlock (&tp->e.qos_lock);
   return ret;
 }

--- a/src/core/ddsi/src/ddsi_endpoint.c
+++ b/src/core/ddsi/src/ddsi_endpoint.c
@@ -831,7 +831,7 @@ static void ddsi_new_writer_guid_common_init (struct ddsi_writer *wr, const char
   ddsi_xqos_copy (wr->xqos, xqos);
   ddsi_xqos_mergein_missing (wr->xqos, &ddsi_default_qos_writer, ~(uint64_t)0);
   assert (wr->xqos->aliased == 0);
-  ddsi_set_topic_type_name (wr->xqos, topic_name, type->type_name);
+  ddsi_set_xqos_topic_and_type (wr->xqos, topic_name, type);
 
   ELOGDISC (wr, "WRITER "PGUIDFMT" QOS={", PGUID (wr->e.guid));
   ddsi_xqos_log (DDS_LC_DISCOVERY, &gv->logconfig, wr->xqos);
@@ -1497,7 +1497,7 @@ dds_return_t ddsi_new_reader (struct ddsi_reader **rd_out, const struct ddsi_gui
   ddsi_xqos_copy (rd->xqos, xqos);
   ddsi_xqos_mergein_missing (rd->xqos, &ddsi_default_qos_reader, ~(uint64_t)0);
   assert (rd->xqos->aliased == 0);
-  ddsi_set_topic_type_name (rd->xqos, topic_name, type->type_name);
+  ddsi_set_xqos_topic_and_type (rd->xqos, topic_name, type);
 
   if (rd->e.gv->logconfig.c.mask & DDS_LC_DISCOVERY)
   {

--- a/src/core/ddsi/src/ddsi_entity.c
+++ b/src/core/ddsi/src/ddsi_entity.c
@@ -19,6 +19,7 @@
 #include "dds/ddsi/ddsi_domaingv.h"
 #include "dds/ddsi/ddsi_tkmap.h"
 #include "dds/ddsi/ddsi_iid.h"
+#include "dds/ddsi/ddsi_typelib.h"
 #include "ddsi__entity.h"
 #include "ddsi__participant.h"
 #include "ddsi__entity_index.h"
@@ -169,18 +170,29 @@ uint64_t ddsi_get_entity_instanceid (const struct ddsi_domaingv *gv, const struc
   return iid;
 }
 
-int ddsi_set_topic_type_name (dds_qos_t *xqos, const char * topic_name, const char * type_name)
+int ddsi_set_xqos_topic_and_type (dds_qos_t *xqos, const char * topic_name, const struct ddsi_sertype * type)
 {
   if (!(xqos->present & DDSI_QP_TYPE_NAME))
   {
     xqos->present |= DDSI_QP_TYPE_NAME;
-    xqos->type_name = ddsrt_strdup (type_name);
+    xqos->type_name = ddsrt_strdup (type->type_name);
   }
   if (!(xqos->present & DDSI_QP_TOPIC_NAME))
   {
     xqos->present |= DDSI_QP_TOPIC_NAME;
     xqos->topic_name = ddsrt_strdup (topic_name);
   }
+#ifdef DDS_HAS_TYPELIB
+  if (!(xqos->present & DDSI_QP_TYPE_INFORMATION))
+  {
+    ddsi_typeinfo_t * const type_info = ddsi_sertype_typeinfo (type);
+    if (type_info)
+    {
+      xqos->type_information = type_info;
+      xqos->present |= DDSI_QP_TYPE_INFORMATION;
+    }
+  }
+#endif
   return 0;
 }
 

--- a/src/core/ddsi/src/ddsi_topic.c
+++ b/src/core/ddsi/src/ddsi_topic.c
@@ -104,7 +104,7 @@ dds_return_t ddsi_new_topic (struct ddsi_topic **tp_out, struct ddsi_guid *tpgui
   tp_qos->present |= DDSI_QP_TYPE_INFORMATION;
   tp_qos->type_information = ddsi_sertype_typeinfo (sertype);
   assert (tp_qos->type_information);
-  ddsi_set_topic_type_name (tp_qos, topic_name, sertype->type_name);
+  ddsi_set_xqos_topic_and_type (tp_qos, topic_name, sertype);
 
   if (gv->logconfig.c.mask & DDS_LC_DISCOVERY)
   {

--- a/src/core/ddsi/src/ddsi_topic.c
+++ b/src/core/ddsi/src/ddsi_topic.c
@@ -101,10 +101,8 @@ dds_return_t ddsi_new_topic (struct ddsi_topic **tp_out, struct ddsi_guid *tpgui
   assert (tp_qos->aliased == 0);
 
   /* Set topic name, type name and type information in qos */
-  tp_qos->present |= DDSI_QP_TYPE_INFORMATION;
-  tp_qos->type_information = ddsi_sertype_typeinfo (sertype);
-  assert (tp_qos->type_information);
   ddsi_set_xqos_topic_and_type (tp_qos, topic_name, sertype);
+  assert ((tp_qos->present & DDSI_QP_TYPE_INFORMATION) && tp_qos->type_information);
 
   if (gv->logconfig.c.mask & DDS_LC_DISCOVERY)
   {


### PR DESCRIPTION
The data used for generating the built-in topic sample for a local entity did not include the type information, and as a consequence a process looking at its own entities would see "no type information available" in this data.