### PR TITLE
Fix some issues with inheritance

### DIFF
--- a/src/core/ddsc/tests/TypeBuilderTypes.idl
+++ b/src/core/ddsc/tests/TypeBuilderTypes.idl
@@ -476,4 +476,19 @@ module TypeBuilderTypes {
   @nested struct t44_n2 { sequence<long> n2_1; };
   @nested struct t44_n1 { sequence<sequence<t44_n2> > n1_1[3]; };
   struct t44 { t44_n1 t1; @key t44_n1 t2; };
+
+  // not @nested: also used for inheritance test
+  @final struct t45_n2 { @id(2) @key short n2_1; @id(1) @key short n2_2; };
+  @final struct t45_n1 : t45_n2 { @id(11) long n1_1; };
+  @final struct t45 : t45_n1 { @id(21) long t1; };
+
+  // not @nested: also used for inheritance test
+  @appendable struct t46_n2 { @id(2) @key short n2_1; @id(1) @key short n2_2; };
+  @appendable struct t46_n1 : t46_n2 { @id(11) long n1_1; };
+  @appendable struct t46 : t46_n1 { @id(21) long t1; };
+
+  // not @nested: also used for inheritance test
+  @mutable struct t47_n2 { @id(2) @key short n2_1; @id(1) @key short n2_2; };
+  @mutable struct t47_n1 : t47_n2 { @id(11) long n1_1; };
+  @mutable struct t47 : t47_n1 { @id(21) long t1; };
 };

--- a/src/core/ddsc/tests/typebuilder.c
+++ b/src/core/ddsc/tests/typebuilder.c
@@ -138,7 +138,7 @@ CU_TheoryDataPoints (ddsc_typebuilder, topic_desc) = {
                                                  &D(t17), &D(t18), &D(t19), &D(t20), &D(t21), &D(t22), &D(t23), &D(t24),
                                                  &D(t25), &D(t26), &D(t27), &D(t28), &D(t29), &D(t30), &D(t31), &D(t32),
                                                  &D(t33), &D(t34), &D(t35), &D(t36), &D(t37), &D(t38), /* TODO &D(t39), */
-                                                 &D(t40), &D(t41), &D(t42), &D(t43), &D(t44) ),
+                                                 &D(t40), &D(t41), &D(t42), &D(t43), &D(t44), &D(t45), &D(t46), &D(t47) ),
 };
 #undef D
 
@@ -251,4 +251,3 @@ CU_Test(ddsc_typebuilder, invalid_toplevel, .init = typebuilder_init, .fini = ty
   ddsrt_free (generated_desc);
   topic_type_unref (topic, type);
 }
-

--- a/src/core/ddsi/src/ddsi_typebuilder.c
+++ b/src/core/ddsi/src/ddsi_typebuilder.c
@@ -1579,7 +1579,8 @@ static dds_return_t typebuilder_get_keys_push_ops (struct typebuilder_data *tbd,
           n_key_offs++;
           break;
         case KEY_PATH_PART_INHERIT:
-          if ((ret = push_op_arg (ops, 0u)) != DDS_RETCODE_OK)
+          // we get for @final and @appendable types, for appendable we need to skip the DLC instruction
+          if ((ret = push_op_arg (ops, (tbd->toplevel_type.extensibility == DDS_XTypes_IS_FINAL) ? 0u : 1u)) != DDS_RETCODE_OK)
             goto err;
           inherit_mutable = false;
           n_key_offs++;


### PR DESCRIPTION
Assignability check failing with multi-level inheritance

Key offsets not computed correctly by "type builder" for appendable types i.c.w. inheritance