### PR TITLE
Allow typedefs to struct/union as topic-type

### DIFF
--- a/src/core/ddsc/tests/TypeBuilderTypes.idl
+++ b/src/core/ddsc/tests/TypeBuilderTypes.idl
@@ -491,4 +491,9 @@ module TypeBuilderTypes {
   @mutable struct t47_n2 { @id(2) @key short n2_1; @id(1) @key short n2_2; };
   @mutable struct t47_n1 : t47_n2 { @id(11) long n1_1; };
   @mutable struct t47 : t47_n1 { @id(21) long t1; };
+
+  // used for testing constructing a topic from a typedef
+  @nested struct t48_n1 { long n1; };
+  typedef t48_n1 t48_a1;
+  struct t48 { t48_a1 t1; };
 };

--- a/src/core/ddsi/src/ddsi_typebuilder.c
+++ b/src/core/ddsi/src/ddsi_typebuilder.c
@@ -1820,7 +1820,8 @@ dds_return_t ddsi_topic_descriptor_from_type (struct ddsi_domaingv *gv, dds_topi
     goto err;
   }
 
-  if ((ret = typebuilder_add_aggrtype (tbd, &tbd->toplevel_type, type)) != DDS_RETCODE_OK)
+  const struct ddsi_type * unaliased_type = type_unalias (type);
+  if ((ret = typebuilder_add_aggrtype (tbd, &tbd->toplevel_type, unaliased_type)) != DDS_RETCODE_OK)
     goto err;
   set_implicit_keys_aggrtype (&tbd->toplevel_type, true, false);
   if ((ret = get_topic_descriptor (desc, tbd)) != DDS_RETCODE_OK)

--- a/src/core/ddsi/src/ddsi_typelib.c
+++ b/src/core/ddsi/src/ddsi_typelib.c
@@ -658,9 +658,12 @@ static bool valid_top_level_type (const struct ddsi_type *type)
     return false;
   if (type->xt.kind != DDSI_TYPEID_KIND_COMPLETE && type->xt.kind != DDSI_TYPEID_KIND_MINIMAL)
     return false;
-  if (ddsi_xt_is_resolved (&type->xt) && type->xt._d != DDS_XTypes_TK_STRUCTURE && type->xt._d != DDS_XTypes_TK_UNION)
-    return false;
-  return true;
+  if (!ddsi_xt_is_resolved (&type->xt))
+    return true;
+  const struct ddsi_type *unaliased_type = type;
+  while (unaliased_type->xt._d == DDS_XTypes_TK_ALIAS)
+    unaliased_type = unaliased_type->xt._u.alias.related_type;
+  return (unaliased_type->xt._d == DDS_XTypes_TK_STRUCTURE || unaliased_type->xt._d == DDS_XTypes_TK_UNION);
 }
 
 static dds_return_t type_add_ref_impl (struct ddsi_domaingv *gv, struct ddsi_type **type, const ddsi_typeinfo_t *type_info, const ddsi_typemap_t *type_map, ddsi_typeid_kind_t kind)

--- a/src/core/ddsi/src/ddsi_typelib.c
+++ b/src/core/ddsi/src/ddsi_typelib.c
@@ -658,12 +658,9 @@ static bool valid_top_level_type (const struct ddsi_type *type)
     return false;
   if (type->xt.kind != DDSI_TYPEID_KIND_COMPLETE && type->xt.kind != DDSI_TYPEID_KIND_MINIMAL)
     return false;
-  if (!ddsi_xt_is_resolved (&type->xt))
-    return true;
-  const struct ddsi_type *unaliased_type = type;
-  while (unaliased_type->xt._d == DDS_XTypes_TK_ALIAS)
-    unaliased_type = unaliased_type->xt._u.alias.related_type;
-  return (unaliased_type->xt._d == DDS_XTypes_TK_STRUCTURE || unaliased_type->xt._d == DDS_XTypes_TK_UNION);
+  while (ddsi_xt_is_resolved (&type->xt) && type->xt._d == DDS_XTypes_TK_ALIAS)
+    type = type->xt._u.alias.related_type;
+  return (ddsi_xt_is_unresolved (&type->xt) || type->xt._d == DDS_XTypes_TK_STRUCTURE || type->xt._d == DDS_XTypes_TK_UNION);
 }
 
 static dds_return_t type_add_ref_impl (struct ddsi_domaingv *gv, struct ddsi_type **type, const ddsi_typeinfo_t *type_info, const ddsi_typemap_t *type_map, ddsi_typeid_kind_t kind)


### PR DESCRIPTION
The XTypes 1.3 spec seems to pretty clearly state that a top-level type must be a structure or a union type:

  7.6.2 Types that may be associated with a DDS Topic

  The only types that may be associated with a DDS Topic are the Aggregated Types defined
  in 7.2.2.4.4, that is, Structure types (7.2.2.4.4.2) and Union types (7.2.2.4.4.3). The
  reason is that these are the only types that support defining key members and can
  therefore be used to model Topics that contain multiple data-instances.

One can reasonably conclude that this forbids a typedef to a struct/union as the topic type. On the other hand, the argument given doesn't apply to typedefs. Moreover, the spec says about typedefs:

  7.2.2.4.2 Alias Types

  Alias types introduce an additional name for another type.

and in Table 6 (same section):

  Alternative name for another type.

  An alias type—also referred to as a typedef from its representation in IDL, C, and
  elsewhere—applies an additional name to an already-existing type. Such an alternative
  name can be helpful for suggesting particular uses and semantics to human readers,
  making it easier to repeat complex type names for human writers, and simplifying certain
  language bindings.

  As in the C and C++ programming languages, an alias/typedef does not introduce a
  distinct type. It merely provides an alternative name by which to refer to the same
  type.

Which says it is the same type under a different name, and so arguably a typedef to a struct/union should be allowed.

Common sense says that it makes the most sense to allow it.