### PR TITLE
Add incorrectly deleted dds_remove_psmx_ functions

### DIFF
--- a/src/core/ddsc/include/dds/ddsc/dds_psmx.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_psmx.h
@@ -630,11 +630,35 @@ DDS_DEPRECATED_EXPORT dds_return_t dds_add_psmx_topic_to_list (struct dds_psmx_t
  *
  * does nothing, exists for backwards compatibility only
  *
+ * @param[in] psmx_topic       ignored
+ * @param[in,out] list         ignored
+ * @return `DDS_RETCODE_OK`
+ */
+DDS_DEPRECATED_EXPORT dds_return_t dds_remove_psmx_topic_from_list (struct dds_psmx_topic *psmx_topic, void **list);
+
+/**
+ * @brief nop
+ * @ingroup psmx
+ *
+ * does nothing, exists for backwards compatibility only
+ *
  * @param[in] psmx_endpoint    ignored
  * @param[in,out] list         ignored
  * @return `DDS_RETCODE_OK`
  */
 DDS_DEPRECATED_EXPORT dds_return_t dds_add_psmx_endpoint_to_list (struct dds_psmx_endpoint *psmx_endpoint, void **list);
+
+/**
+ * @brief nop
+ * @ingroup psmx
+ *
+ * does nothing, exists for backwards compatibility only
+ *
+ * @param[in] psmx_endpoint    ignored
+ * @param[in,out] list         ignored
+ * @return `DDS_RETCODE_OK`
+ */
+DDS_DEPRECATED_EXPORT dds_return_t dds_remove_psmx_endpoint_from_list (struct dds_psmx_endpoint *psmx_endpoint, void **list);
 
 /**
  * @brief initialization function for PSMX instance (interface version 0)

--- a/src/core/ddsc/src/dds_psmx.c
+++ b/src/core/ddsc/src/dds_psmx.c
@@ -83,7 +83,21 @@ dds_return_t dds_add_psmx_topic_to_list (struct dds_psmx_topic *psmx_topic, void
   return DDS_RETCODE_OK;
 }
 
+dds_return_t dds_remove_psmx_topic_from_list (struct dds_psmx_topic *psmx_topic, void **list)
+{
+  // deprecated, kept for compatibility with older PSMX Plugin sources
+  (void) psmx_topic; (void) list;
+  return DDS_RETCODE_OK;
+}
+
 dds_return_t dds_add_psmx_endpoint_to_list (struct dds_psmx_endpoint *psmx_endpoint, void **list)
+{
+  // deprecated, kept for compatibility with older PSMX Plugin sources
+  (void) psmx_endpoint; (void) list;
+  return DDS_RETCODE_OK;
+}
+
+dds_return_t dds_remove_psmx_endpoint_from_list (struct dds_psmx_endpoint *psmx_endpoint, void **list)
 {
   // deprecated, kept for compatibility with older PSMX Plugin sources
   (void) psmx_endpoint; (void) list;

--- a/src/core/xtests/symbol_export/symbol_export.c
+++ b/src/core/xtests/symbol_export/symbol_export.c
@@ -533,6 +533,8 @@ int main (int argc, char **argv)
   // dds_psmx.h
   dds_add_psmx_endpoint_to_list (ptr, ptr2);
   dds_add_psmx_topic_to_list (ptr, ptr2);
+  dds_remove_psmx_endpoint_from_list (ptr, ptr2);
+  dds_remove_psmx_topic_from_list (ptr, ptr2);
   dds_psmx_init_generic (ptr);
   dds_psmx_cleanup_generic (ptr);
   dds_psmx_topic_init_generic (ptr, ptr2, ptr3, ptr4, ptr, 0);


### PR DESCRIPTION
These two were deleted in commit d57c242bf8aac16e7d21276931af6ae3f0e383a9 when cleaning up the PSMX interface. That work was meant to be backwards compatible, but these two functions were accidentally removed because all call-sites in the repository had been removed.