### PR TITLE
Fix IDLC line number for newline at end of buffer

### DIFF
--- a/src/idl/src/scanner.c
+++ b/src/idl/src/scanner.c
@@ -595,6 +595,8 @@ scan(idl_pstate_t *pstate, idl_lexeme_t *lex)
     } else if ((cnt = have_newline(pstate, cur)) > 0) {
       lim = cur + cnt;
       code = '\n';
+    } else if (cnt < 0) {
+      return IDL_RETCODE_NEED_REFILL;
     } else if ((cnt = have_space(pstate, cur)) > 0) {
       /* skip space characters, except newline */
       lim = cur + cnt;


### PR DESCRIPTION
If the newline is at the very end of the input buffer, have_newline returns a negative value to signal the need to refill, but the scanner ends up treating as a single character that then gets skipped over somewhere without incrementing the line number.

This propagates the need to refill instead.