### PR TITLE
Fix permissions example XML in the DDS Security documentation

### DIFF
--- a/docs/manual/_static/example_permissions.xml
+++ b/docs/manual/_static/example_permissions.xml
@@ -3,7 +3,7 @@
      xsi:noNamespaceSchemaLocation="https://www.omg.org/spec/DDS-SECURITY/20170901/omg_shared_ca_permissions.xsd">
   <permissions>
     <grant name="default_permissions">
-      <subject_name>emailAddress=alice@cycloneddssecurity.adlinktech.com,CN=Alice Example,O=Example Organization,OU=Organizational Unit Name,L=Locality Name,ST=OV,C=NL</subject_name>
+      <subject_name>emailAddress=alice@example.com,CN=Alice Example,O=Example Organization,OU=Organizational Unit Name,L=Locality Name,ST=OV,C=NL</subject_name>
       <validity>
         <!-- Format is CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] in GMT -->
         <not_before>2020-01-01T01:00:00</not_before>

--- a/docs/manual/_static/security_by_config.xml
+++ b/docs/manual/_static/security_by_config.xml
@@ -1,19 +1,21 @@
-<Domain id="any">
-  <DDSSecurity>
-    <Authentication>
-      <Library initFunction="init_authentication" finalizeFunction="finalize_authentication" path="dds_security_auth"/>
-      <IdentityCA>file:/path/to/example_id_ca_cert.pem</IdentityCA>
-      <IdentityCertificate>file:/path/to/example_alice_cert.pem</IdentityCertificate>
-      <PrivateKey>file:/path/to/example_alice_priv_key.pem</PrivateKey>
-    </Authentication>
-    <Cryptographic>
-      <Library initFunction="init_crypto" finalizeFunction="finalize_crypto" path="dds_security_crypto"/>
-    </Cryptographic>
-    <AccessControl>
-      <Library initFunction="init_access_control" finalizeFunction="finalize_access_control" path="dds_security_ac"/>
-      <PermissionsCA>file:/path/to/example_perm_ca_cert.pem</PermissionsCA>
-      <Governance>file:/path/to/example_governance.p7s</Governance>
-      <Permissions>file:/path/to/example_permissions.p7s</Permissions>
-    </AccessControl>
-  </DDSSecurity>
-</Domain>
+<CycloneDDS>
+  <Domain id="any">
+    <Security>
+      <Authentication>
+        <Library initFunction="init_authentication" finalizeFunction="finalize_authentication" path="dds_security_auth"/>
+        <IdentityCA>file:/path/to/example_id_ca_cert.pem</IdentityCA>
+        <IdentityCertificate>file:/path/to/example_alice_cert.pem</IdentityCertificate>
+        <PrivateKey>file:/path/to/example_alice_priv_key.pem</PrivateKey>
+      </Authentication>
+      <Cryptographic>
+        <Library initFunction="init_crypto" finalizeFunction="finalize_crypto" path="dds_security_crypto"/>
+      </Cryptographic>
+      <AccessControl>
+        <Library initFunction="init_access_control" finalizeFunction="finalize_access_control" path="dds_security_ac"/>
+        <PermissionsCA>file:/path/to/example_perm_ca_cert.pem</PermissionsCA>
+        <Governance>file:/path/to/example_governance.p7s</Governance>
+        <Permissions>file:/path/to/example_permissions.p7s</Permissions>
+      </AccessControl>
+    </Security>
+  </Domain>
+</CycloneDDS>

--- a/docs/manual/security/example_configuration.rst
+++ b/docs/manual/security/example_configuration.rst
@@ -12,11 +12,11 @@
 Example DDS security configuration
 **********************************
 
-This section shows an example |var-project-short| configuration for DDS Security. 
+This section shows an example |var-project-short| configuration for DDS Security.
 
 The steps for configuring DDS Security are:
 
-#. :ref:`create_certificate_authority` 
+#. :ref:`create_certificate_authority`
 #. :ref:`create_identity_certificate`
 #. :ref:`create_governance_document`
 #. :ref:`create_permissions_document`
@@ -45,9 +45,9 @@ To generate the CA for identity management (authentication):
 
    .. code-block:: console
 
-     openssl req -x509 -key example_id_ca_priv_key.pem -out example_id_ca_cert.pem -days 3650 -subj "/C=NL/ST=OV/L=Locality Name/OU=Example OU/O=Example ID CA Organization/CN=Example ID CA/emailAddress=authority@cycloneddssecurity.zettascale.com"
+     openssl req -x509 -key example_id_ca_priv_key.pem -out example_id_ca_cert.pem -days 3650 -subj "/C=NL/ST=OV/L=Locality Name/OU=Example OU/O=Example ID CA Organization/CN=Example ID CA/emailAddress=authority@example.com"
 
-#. Create the private key of the permissions CA (used for signing the AccessControl 
+#. Create the private key of the permissions CA (used for signing the AccessControl
    configuration files):
 
    .. code-block:: console
@@ -58,7 +58,7 @@ To generate the CA for identity management (authentication):
 
    .. code-block:: console
 
-     openssl req -x509 -key example_perm_ca_priv_key.pem -out example_perm_ca_cert.pem -days 3650 -subj "/C=NL/ST=OV/L=Locality Name/OU=Example OU/O=Example CA Organization/CN=Example Permissions CA/emailAddress=authority@cycloneddssecurity.zettascale.com"
+     openssl req -x509 -key example_perm_ca_priv_key.pem -out example_perm_ca_cert.pem -days 3650 -subj "/C=NL/ST=OV/L=Locality Name/OU=Example OU/O=Example CA Organization/CN=Example Permissions CA/emailAddress=authority@example.com"
 
 .. index:: Identity certificate; Creating
 
@@ -70,7 +70,7 @@ Create an identity certificate
 
 Create an identity certificate (signed by the CA), and the private key corresponding to an identity named *Alice*.
 
-.. note:: 
+.. note::
   These steps need to be repeated for each identity in the system.
 
 To create a private key and an identity certificate for an identity named *Alice*:
@@ -85,7 +85,7 @@ To create a private key and an identity certificate for an identity named *Alice
 
    .. code-block:: console
 
-     openssl req -new -key example_alice_priv_key.pem -out example_alice.csr -subj "/C=NL/ST=OV/L=Locality Name/OU=Organizational Unit Name/O=Example Organization/CN=Alice Example/emailAddress=alice@cycloneddssecurity.zettascale.com"
+     openssl req -new -key example_alice_priv_key.pem -out example_alice.csr -subj "/C=NL/ST=OV/L=Locality Name/OU=Organizational Unit Name/O=Example Organization/CN=Alice Example/emailAddress=alice@example.com"
 
 #. Create *Alice's* **identity certificate**:
 
@@ -95,13 +95,13 @@ To create a private key and an identity certificate for an identity named *Alice
 
 #. In the DDS Security authentication configuration:
 
-   - Use *Alice's* private key (example_alice_priv_key.pem) file for the 
-     :ref:`PrivateKey <//CycloneDDS/Domain/Security/Authentication/PrivateKey>` setting. 
+   - Use *Alice's* private key (example_alice_priv_key.pem) file for the
+     :ref:`PrivateKey <//CycloneDDS/Domain/Security/Authentication/PrivateKey>` setting.
 
    - Use *Alice's* identity certificate (example_alice_cert.pem) file for the
-     :ref:`IdentityCertificate <//CycloneDDS/Domain/Security/Authentication/IdentityCertificate>` setting. 
- 
-   - Use the certificate of the CA used for signing this identity (example_id_ca_cert.pem), 
+     :ref:`IdentityCertificate <//CycloneDDS/Domain/Security/Authentication/IdentityCertificate>` setting.
+
+   - Use the certificate of the CA used for signing this identity (example_id_ca_cert.pem),
      for the :ref:`IdentityCA <//CycloneDDS/Domain/Security/Authentication/IdentityCA>` setting.
 
 .. index:: Governance document; Creating
@@ -118,7 +118,7 @@ The following shows an example of a governance document that uses *signing for s
     :linenos:
     :language: xml
 
-The governance document must be signed by the :ref:`permissions CA <create_certificate_authority>`. 
+The governance document must be signed by the :ref:`permissions CA <create_certificate_authority>`.
 
 To sign the governance document:
 
@@ -157,7 +157,7 @@ This document also needs to be signed by the :ref:`permissions CA <create_certif
 Set the security properties in participant QoS
 ==============================================
 
-The following code fragment shows how to set the security properties to a QoS object, and 
+The following code fragment shows how to set the security properties to a QoS object, and
 use this QoS when creating a participant:
 
 .. literalinclude:: ../_static/security_by_qos.c
@@ -187,7 +187,7 @@ variable to this config file:
 
   export CYCLONEDDS_URI=/path/to/secure_config.xml
 
-.. note:: 
+.. note::
   This example configuration uses the attribute ``id=any`` for the ``domain`` element, any participant
   that is created (which implicitly creates a domain) in an application using this configuration gets
   these security settings.

--- a/docs/manual/security/public_key_infrastructure.rst
+++ b/docs/manual/security/public_key_infrastructure.rst
@@ -1,4 +1,4 @@
-.. index:: 
+.. index::
    single: DDS security; Public-key infrastructure
    single: Security; Public-key infrastructure
    single: Public-key infrastructure
@@ -18,15 +18,15 @@ maintains a trustworthy networking environment.
 
 **Public key cryptography**
 
-Each user has a key pair, generated during the initial certificate deployment process. 
+Each user has a key pair, generated during the initial certificate deployment process.
 It consists of:
 
 - A public key, which is shared.
-- A private key, which is not shared. 
+- A private key, which is not shared.
 
 Data is encrypted with the user's public key and decrypted with their private key.
 
-Digital signatures are also generated using public key cryptography (used for non-repudiation, 
+Digital signatures are also generated using public key cryptography (used for non-repudiation,
 authentication and data integrity).
 
 .. _identity_certificate:
@@ -38,9 +38,9 @@ includes:
 
 - Information about the key.
 - Information about the identity of its owner (called the subject).
-- The digital signature of an entity that has verified the certificate's contents (called the issuer). 
+- The digital signature of an entity that has verified the certificate's contents (called the issuer).
 
-If the signature is valid, and the software examining the certificate trusts the issuer, 
+If the signature is valid, and the software examining the certificate trusts the issuer,
 then it can use that key to communicate securely with the certificate's subject.
 
 .. _certificate_authority:
@@ -63,10 +63,10 @@ organization (OU), state (ST) and country (C).
 
 **Subject name**
 
-This is also knows as the distinguished name. It is the string representation of the certificate 
+This is also knows as the distinguished name. It is the string representation of the certificate
 subject. For example:
 
- emailAddress=alice\@zettascale.ist,CN=Alice,OU=IST,O=ADLink,ST=OV,C=NL
+ emailAddress=alice\@example.com,CN=Alice,OU=IST,O=ADLink,ST=OV,C=NL
 
 .. index:: Access control
 
@@ -85,8 +85,8 @@ be verified if it is really issued by ID CA.
 
 Access Control is configured with governance and permissions documents:
 
-- A governance document defines the security behavior of domains and topics. 
-- A permissions document contains the permissions of the domain participant (topics, readers and 
+- A governance document defines the security behavior of domains and topics.
+- A permissions document contains the permissions of the domain participant (topics, readers and
   writers), and binds them to an identity certificate by subject name (distinguished name).
 
 Governance documents and Permissions documents are signed by **Permission CA**. Signed documents also
@@ -98,16 +98,16 @@ Diffie-Hellman key exchange. This shared key is used for encrypting/decrypting d
 
 During the handshake:
 
-- Alice checks Bob's certificate and Bob's Permissions document to see whether they are really 
+- Alice checks Bob's certificate and Bob's Permissions document to see whether they are really
   issued by the ID CA certificate and Permissions CA Certificate that **she** has.
 
-- Bob checks Alice's certificate and Alice's Permissions document to see whether they are really 
+- Bob checks Alice's certificate and Alice's Permissions document to see whether they are really
   issued by the ID CA certificate and Permissions CA that **he** has.
 
 .. needs a better description:
 
-Permissions documents can contain permissions for several identities. To establish a binding between an 
-identity and its permissions, the subject name of an identity certificate can appear multiple times in 
+Permissions documents can contain permissions for several identities. To establish a binding between an
+identity and its permissions, the subject name of an identity certificate can appear multiple times in
 a permissions document.
 
 There are several ways to set up the certificates and signed configuration files to be used with


### PR DESCRIPTION
Fixes the `subject_name` in the permissions example XML in the DDS Security documentation, so that it matches the subject name used for the identity. Also updates the configuration XML used in the example. 