### PR TITLE
Oneliner deaf/mute and read improvements

### DIFF
--- a/src/core/ddsc/tests/asymdisconnect.c
+++ b/src/core/ddsc/tests/asymdisconnect.c
@@ -36,7 +36,7 @@ CU_Test (ddsc_asymdisconnect, reader_keeps_nacking)
     // - this really is just a little devil dropping some packets
     "  setflags(r) w'"
     // restoring hearing triggers discovery
-    "  hearing! P"
+    "  normal! P"
     // r should see w' again
     // - r will send a pre-emptive ACKNACK, w' will respond with heartbeat
     // - r will then send ACKNACKs requesting retransmit, w' forgets to send the data
@@ -58,7 +58,7 @@ CU_Test (ddsc_asymdisconnect, reader_keeps_nacking)
     "  setflags() w'"
     // without the fix and with flags cleared, disconnecting and reconnecting fixes it:
     //   sleep 2 !?!da take{} r // so no data!
-    //   deaf! P ?sm r hearing! P ?sm r // dis-/reconnect
+    //   deaf! P ?sm r normal! P ?sm r // dis-/reconnect
     //   ?da r take{(1,0,0)} r
     // with fix present:
     "  ?da r take{(1,0,0)} r"

--- a/src/core/ddsc/tests/listener.c
+++ b/src/core/ddsc/tests/listener.c
@@ -309,22 +309,22 @@ CU_Test (ddsc_listener, matched)
   dotest ("sm da r pm w' ?sm r ?pm w' ;" // matched reader/writer pair
           " wr w' 1   ; ?da r take{(1,0,0)} r ?ack w' ;" // wait-for-acks => writer drops data
           " deaf! P   ; ?sm(1,0,0,-1,w') r ?da r take{d1} r ; wr w' 2 ;" // write lost on "wire"
-          " hearing! P; ?sm(2,1,1,1,w') r  ?da r sleep 0.3 take{(2,0,0)} r ; ?!pm");
+          " normal! P; ?sm(2,1,1,1,w') r  ?da r sleep 0.3 take{(2,0,0)} r ; ?!pm");
   dotest ("sm da r pm w' ; ?sm r ?pm w' ;"
           " r'' ?pm w' deaf! P'' ;" // with second reader: reader is deaf so won't ACK
           " wr w' 1   ; ?da r take{(1,0,0)} r ?ack(r) w' ;" // wait for ack from r' (not r'')
           " deaf! P   ; ?sm(1,0,0,-1,w') r ?da r take{d1} r ; wr w' 2 ;" // write lost on "wire"
-          " hearing! P; ?sm(2,1,1,1,w') r  ?da r sleep 0.3 take{(2,0,0)} r ; ?!pm");
+          " normal! P; ?sm(2,1,1,1,w') r  ?da r sleep 0.3 take{(2,0,0)} r ; ?!pm");
   // same without taking the "dispose" after disconnect
   // sample 1 will be delivered anew
   dotest ("sm da r pm w' ; ?sm r ?pm w' ; wr w' 1 ; ?da r take{(1,0,0)} r ;"
           " deaf! P ; ?sm(1,0,0,-1,w') r ?da r ; wr w' 2 ;"
-          " hearing! P ; ?sm(2,1,1,1,w') r ?da r sleep 0.3 take{d1,(2,0,0)} r ; ?!pm");
+          " normal! P ; ?sm(2,1,1,1,w') r ?da r sleep 0.3 take{d1,(2,0,0)} r ; ?!pm");
 
   // if a volatile writer loses the reader temporarily, the data won't show up
   dotest ("sm da r pm w' ; ?sm r ?pm w' ; wr w' 1 ; ?da r read{(1,0,0)} r ;"
           " deaf! P' ; ?!sm ?!da ?pm(1,0,0,-1,r) w' ; wr w' 2 ;"
-          " hearing! P' ; ?!sm ?pm(2,1,1,1,r) w' ?!da ; wr w' 3 ;"
+          " normal! P' ; ?!sm ?pm(2,1,1,1,r) w' ?!da ; wr w' 3 ;"
           " ?da r sleep 0.3 read{s(1,0,0),f(3,0,0)} r");
   // if a transient-local writer loses the reader temporarily, what data
   // has been published during the disconnect must still show up; delete
@@ -335,13 +335,13 @@ CU_Test (ddsc_listener, matched)
   dotest ("sm da r(d=tl) pm w'(d=tl,h=1,ds=0/1) ; ?sm r ?pm w' ;"
           " wr w' 1 ; ?da r read{(1,0,0)} r ;"
           " deaf! P' ; ?pm(1,0,0,-1,r) w' ; wr w' 2 wr w' 2 ;"
-          " hearing! P' ; ?pm(2,1,1,1,r) w' ; wr w' 3 ;"
+          " normal! P' ; ?pm(2,1,1,1,r) w' ; wr w' 3 ;"
           " ?da(2) r read{s(1,0,0),f(2,0,0),f(3,0,0)} r ;"
           " -w' ?sm r ?da r read(3,3) r");
   dotest ("sm da r(d=tl) pm w'(d=tl,h=1,ds=0/all) ; ?sm r ?pm w' ;"
           " wr w' 1 ; ?da r read{(1,0,0)} r ;"
           " deaf! P' ; ?pm(1,0,0,-1,r) w' ; wr w' 2 wr w' 2 ;"
-          " hearing! P' ; ?pm(2,1,1,1,r) w' ; wr w' 3 ;"
+          " normal! P' ; ?pm(2,1,1,1,r) w' ; wr w' 3 ;"
           " ?da(3) r read{s(1,0,0),f(2,0,0),f(2,0,0),f(3,0,0)} r ;"
           " -w' ?sm r ?da r read(4,3) r");
 }
@@ -410,7 +410,7 @@ CU_Test (ddsc_listener, data_available)
   // the invalid sample has the source time stamp of the latest update -- one wonders whether that is wise?
   dotest ("da r(d=tl) ?pm w'(d=tl,ad=n) ; wr w' (1,2,3)@1.1 ?da r read{fan(1,2,3)w'} r ;"
           " deaf! P ; ?da r read{suo(1,2,3)w'@1.1,fuo1w'@1.1} r ;"
-          " hearing! P ; ?da r read{sao(1,2,3)w'@1.1,fao1w'@1.1} r");
+          " normal! P ; ?da r read{sao(1,2,3)w'@1.1,fao1w'@1.1} r");
 }
 
 CU_Test (ddsc_listener, data_available_delete_writer)

--- a/src/core/ddsc/tests/oneliner.c
+++ b/src/core/ddsc/tests/oneliner.c
@@ -37,7 +37,7 @@ int main (int argc, char **argv)
   }
   else
   {
-    /* read from stdin, # starts a comment, any line with an indent no greater
+    /* read from stdin, # starts a comment unless preceded by a non-space, any line with an indent no greater
        than the current test's indent starts a new test, i.e.,
          # this is a comment
          r wr w 1
@@ -68,6 +68,8 @@ int main (int argc, char **argv)
       }
 
       char *cmt = strchr (buf, '#');
+      while (cmt && cmt > buf && !isspace ((unsigned char) cmt[-1]))
+        cmt = strchr (cmt + 1, '#');
       if (cmt)
         *cmt = 0;
 

--- a/src/core/ddsc/tests/test_oneliner.c
+++ b/src/core/ddsc/tests/test_oneliner.c
@@ -2063,6 +2063,9 @@ static void dosleep (struct oneliner_ctx *ctx)
 {
   if (nexttok_dur (&ctx->l, NULL, true) != TOK_DURATION)
     error (ctx, "sleep: invalid duration");
+  mprintf (ctx, "sleep: %d.%03ds\n",
+           (int) (ctx->l.v.d / DDS_NSECS_IN_SEC),
+           (int) (((ctx->l.v.d + DDS_NSECS_IN_MSEC - 1) / DDS_NSECS_IN_MSEC) % 1000));
   dds_sleepfor (ctx->l.v.d);
 }
 

--- a/src/core/ddsc/tests/test_oneliner.c
+++ b/src/core/ddsc/tests/test_oneliner.c
@@ -1424,11 +1424,20 @@ static void doreadlike (struct oneliner_ctx *ctx, const char *name, dds_return_t
       mprintf (ctx, "%s", wrname.n);
       print_timestamp (ctx, si[i].source_timestamp);
       if (!doreadlike_matchstep (&si[i], s, exp, nexp, ellipsis, &tomatch, &cursor, &lastih, &matchidx[i]))
+      {
+        mprintf (ctx, "[unexpected]");
         matchok = false;
+      }
+      else
+      {
+        mprintf (ctx, "[#%d]", matchidx[i]);
+      }
     }
     mprintf (ctx, "}:");
+#if 0 // printing cursor is more confusing then helpful
     for (int i = 0; i < n; i++)
       mprintf (ctx, " %d", matchidx[i]);
+#endif
   }
   if (ws)
   {
@@ -1443,12 +1452,17 @@ static void doreadlike (struct oneliner_ctx *ctx, const char *name, dds_return_t
     mprintf (ctx, " (samples missing)");
     matchok = false;
   }
-  mprintf (ctx, " valid %d %d invalid %d %d", count[1], exp_nvalid, count[0], exp_ninvalid);
   if (exp_nvalid >= 0 && (count[1] != exp_nvalid))
+  {
+    mprintf (ctx, " %d valid samples instead of expected %d", count[1], exp_nvalid);
     matchok = false;
+  }
   if (exp_ninvalid >= 0 && (count[0] != exp_ninvalid))
+  {
+    mprintf (ctx, " %d invalid samples instead of expected %d", count[0], exp_ninvalid);
     matchok = false;
-  mprintf (ctx, "\n");
+  }
+  mprintf (ctx, " %s\n", matchok ? "ok" : "fail");
   if (!matchok)
     testfail (ctx, "%s%s: mismatch between actual and expected set\n", name, namesuf);
 #undef MAXN

--- a/src/core/ddsc/tests/test_oneliner.c
+++ b/src/core/ddsc/tests/test_oneliner.c
@@ -2200,7 +2200,6 @@ static void dispatchcmd (struct oneliner_ctx *ctx)
     { "mute",       domute },
     { "deafmute",   dodeafmute },
     { "normal",     donormal },
-    { "hearing",    donormal }, // backwards compat
     { "sleep",      dosleep },
     { "setflags",   dosetflags },
   };

--- a/src/core/ddsc/tests/test_oneliner.h
+++ b/src/core/ddsc/tests/test_oneliner.h
@@ -89,8 +89,8 @@
  *                       In the third form, the exact result set is given by the sample
  *                       Si, which is a comma-separated list of samples:
  *
- *                         [STATE]K[ENTITY-NAME][@DT]
- *                         [STATE](K,X,Y)[ENTITY-NAME][@DT]
+ *                         [STATE]K[ENTITY-NAME][@DT][#dD][#uU]
+ *                         [STATE](K,X,Y)[ENTITY-NAME][@DT][#dD][#uU]
  *
  *                       Suffixing READ-LIKE with an exclamation mark in this third form
  *                       makes it wait until all specified data has been received (with
@@ -109,7 +109,9 @@
  *                       publication_handle.  Not specifying a writer means any writer is
  *                       ok.  DT is the timestamp in the same manner as the write-like
  *                       operations.  Not specifying a timestamp means any timestamp is
- *                       ok.
+ *                       ok.  #dD specifies that the "disposed generation count must" be
+ *                       D, similarly, #uU specifies that the "no writers generation
+ *                       count" must be U.
  *
  *                       If the expected set ends up with "..." there may be other samples
  *                       in the result as well.

--- a/src/core/ddsc/tests/test_oneliner.h
+++ b/src/core/ddsc/tests/test_oneliner.h
@@ -164,17 +164,17 @@
  *
  *                       Delay program execution for D s (D is a floating-point number)
  *
- *               | deaf ENTITY-NAME
- *               | deaf! ENTITY-NAME
- *               | hearing ENTITY-NAME
- *               | hearing! ENTITY-NAME
+ *               | normal[!] ENTITY-NAME
+ *               | deaf[!] ENTITY-NAME
+ *               | mute[!] ENTITY-NAME
+ *               | deafmute[!] ENTITY-NAME
  *
- *                       Makes the domain wherein the specified entity exists deaf,
- *                       respectively restoring hearing.  The entity must be either P or
- *                       P' and both must exist.  The ones suffixed with "!" play use
- *                       some tricks to speed up lease expiry and reconnection (like
- *                       forcibly deleting a proxy participant or triggering the publication
- *                       of SPDP packets).
+ *                       Makes the domain wherein the specified entity exists communicate
+ *                       normally, deaf, mute or both deaf and mute.  respectively
+ *                       restoring hearing.  The entity must be a participant.  If
+ *                       suffixed with "!", use some tricks to speed up lease expiry and
+ *                       reconnection (like forcibly deleting a proxy participant or
+ *                       triggering the publication of SPDP packets).
  *
  *               | setflags(FLAGS) ENTITY-NAME
  *

--- a/src/core/ddsi/src/ddsi_spdp_schedule.c
+++ b/src/core/ddsi/src/ddsi_spdp_schedule.c
@@ -810,7 +810,7 @@ static void ddsi_spdp_handle_live_locators_xevent_cb (struct ddsi_domaingv *gv, 
 bool ddsi_spdp_force_republish (struct spdp_admin *adm, const struct ddsi_participant *pp, const struct ddsi_proxy_reader *prd)
 {
   // Used for: initial publication, QoS update, dispose+unregister, faster rediscovery in
-  // oneliner in implementation of "hearing!"
+  // oneliner in implementation of "normal!"
   //
   // It seems there's no need to update the scheduled next publication for any of these cases.
   //


### PR DESCRIPTION
This improves `oneliner` by:
* Adding support for `mute` and `deafmute` modes. One specifies the desired mode (so `deaf` followed by `mute` ends up as mute, not as deaf-mute). Normal communication is re-established using `normal`, `hearing` is no longer recognized. (Things may change again in the future, it is only an unstable test/debug/quick hack tool after all.)
* Printing more sensible output for `read` and `take`.
* Supporting disposed and no-writers generation counts in `read` and `take`.
* Printing `sleep` operations
* Consistently using entity names instead of handles in the output

The disposed and no-writers generation counts rely on `#` in the sample info specification. The executable wrapper now requires comments to be at the beginning of the line or to be preceded by a whitespace character.