### PR TITLE
Macos rpath fix

### DIFF
--- a/src/tools/idlc/CMakeLists.txt
+++ b/src/tools/idlc/CMakeLists.txt
@@ -47,6 +47,21 @@ target_include_directories(
 
 add_executable(${PROJECT_NAME}::idlc ALIAS idlc)
 
+if(APPLE)
+  set(IDLC_EXTRA_RPATHS
+    "/Users/roberthall/ros2_rolling/install/iceoryx_posh/lib"
+    "/Users/roberthall/ros2_rolling/install/iceoryx_binding_c/lib"
+    "/Users/roberthall/ros2_rolling/install/iceoryx_hoofs/lib"
+    "${CMAKE_BINARY_DIR}/cyclonedds/lib"
+  )
+  set_target_properties(idlc PROPERTIES
+    INSTALL_RPATH "${IDLC_EXTRA_RPATHS}"
+    BUILD_RPATH "${IDLC_EXTRA_RPATHS}"
+    BUILD_WITH_INSTALL_RPATH FALSE
+    MACOSX_RPATH ON
+  )
+endif()
+
 install(
   DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/idlc"
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"


### PR DESCRIPTION
## Summary

This change adds MacOS-specific `INSTALL_RPATH` and `BUILD_RPATH` settings for the `idlc` binary to ensure dependent dynamic libraries such as:

- `libiceoryx_posh.dylib`
- `libiceoryx_binding_c.dylib`
- `libiceoryx_hoofs.dylib`

can be located at both **build** and **runtime** when used with `ros2_rolling` and `colcon build`.

Key points:

- Fix resolves runtime aborts from `idlc` during the CycloneDDS build process
- Targets **MacOS only** (`if(APPLE)`)
- Ensures `MACOSX_RPATH` is correctly set
- Verified working on MacOS x86_64 (12.7.6 Monterey) with System Integrity Protection (SIP) enabled

## Checklist

- [x] My code builds and works on at least one target platform (MacOS x86_64)
- [ ] I have added tests to cover my changes (N/A - build system change only)
- [ ] I have updated the documentation (N/A)
- [ ] I have added a changelog entry for my changes
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
- [x] I have set the correct target branch (`releases/0.10.x`)
- [ ] I have updated all relevant GitHub workflows if necessary (N/A)

## Testing

- Built with `colcon build --symlink-install`
- Part of a functional ROS 2 Rolling workspace using the `ros2.repos` meta file
- Confirmed that `idlc` executes without errors when invoked by CMake
- Apple SIP enabled throughout testing

## Related Issues

- Closes: **TBD**
- Improves platform compatibility for MacOS users using ROS 2 with CycloneDDS tooling

