### PR TITLE
fix off-by-one error in returning loans

### DIFF
--- a/src/core/ddsc/include/dds/dds.h
+++ b/src/core/ddsc/include/dds/dds.h
@@ -3096,7 +3096,7 @@ dds_waitset_wait_until(
  * The `buf` parameter is used as follows:
  * - If `buf[0]` on entry is a null pointer:
  *   - on return `buf[0]` .. `buf[k-1]` will point to middleware-owned memory (a.k.a. loans); and
- *   - `buf[k]` will be a null pointer if `0 <= k < bufsz-1`; and
+ *   - `buf[k]` will be a null pointer if `0 <= k < bufsz`; and
  *   - `0 <= k <= maxs` is the number of samples read (a.k.a. the return value).
  *
  * - If `buf[0]` on entry is an outstanding sample loan (i.e., resulting from a previous call to, e.g., read), then:
@@ -3327,7 +3327,7 @@ dds_peek_next(
  * The `buf` parameter is used as follows:
  * - If `buf[0]` on entry is a null pointer:
  *   - on return `buf[0]` .. `buf[k-1]` will point to middleware-owned memory (a.k.a. loans); and
- *   - `buf[k]` will be a null pointer if `0 <= k < bufsz-1`; and
+ *   - `buf[k]` will be a null pointer if `0 <= k < bufsz`; and
  *   - `0 <= k <= maxs` is the number of samples read (a.k.a. the return value).
  *
  * - If `buf[0]` on entry is an outstanding sample loan (i.e., resulting from a previous call to, e.g., read), then:
@@ -3726,7 +3726,7 @@ dds_read_next_wl(
  * The `buf` parameter is used as follows:
  * - If `buf[0]` on entry is a null pointer:
  *   - on return `buf[0]` .. `buf[k-1]` will point to middleware-owned memory (a.k.a. loans); and
- *   - `buf[k]` will be a null pointer if `0 <= k < bufsz-1`; and
+ *   - `buf[k]` will be a null pointer if `0 <= k < bufsz`; and
  *   - `0 <= k <= maxs` is the number of samples read (a.k.a. the return value).
  *
  * - If `buf[0]` on entry is an outstanding sample loan (i.e., resulting from a previous call to, e.g., read), then:

--- a/src/core/ddsc/src/dds_loaned_sample.c
+++ b/src/core/ddsc/src/dds_loaned_sample.c
@@ -104,8 +104,7 @@ dds_loaned_sample_t *dds_loan_pool_find_and_remove_loan (dds_loan_pool_t *pool, 
     {
       dds_loaned_sample_t * const ls = pool->samples[i];
       assert (pool->n_samples > 0);
-      if (i < --pool->n_samples)
-        pool->samples[i] = pool->samples[pool->n_samples];
+      pool->samples[i] = pool->samples[--pool->n_samples];
       pool->samples[pool->n_samples] = NULL;
       return ls;
     }

--- a/src/core/ddsc/src/dds_read.c
+++ b/src/core/ddsc/src/dds_read.c
@@ -250,7 +250,7 @@ static dds_return_t dds_read_impl (enum dds_read_impl_common_oper oper, dds_enti
   // If use_loan, make sure the `buf` is either fully initialized or ends on a null pointer
   // so the various paths returning loans know when to stop.  (If no data returned and using
   // loans, buf[0] is a null pointer, no point in updating it again.)
-  if (use_loan && ret > 0 && (size_t) ret < bufsz - 1)
+  if (use_loan && ret > 0 && (size_t) ret < bufsz)
     buf[ret] = NULL;
 
   // Drop any remaining cached samples.  We have to be prepared to drop *some* because of the


### PR DESCRIPTION
This fixes the following problem: Cyclone's mechanisms for returning loans fail after receiving exactly (bufsz - 1) samples

It also adds a regression test.