### PR TITLE
Add support for mutable types in XCDR1

### DIFF
--- a/src/core/cdr/include/dds/cdr/dds_cdrstream.h
+++ b/src/core/cdr/include/dds/cdr/dds_cdrstream.h
@@ -51,13 +51,19 @@ payload in order to reach the next 4-byte aligned offset. */
 #define DDS_XCDR1_PL_SHORT_PID_EXT_LEN      0x8u           // Value of the param header length field in case of extended PL encoding
 #define DDS_XCDR1_PL_SHORT_FLAG_IMPL_EXT    0x8000u        // Flag for implementation specific interpretation of the parameter (not implemented)
 #define DDS_XCDR1_PL_SHORT_FLAG_MU          0x4000u        // Flag to indicate the parameter is must-understand in short PL header
-#define DDS_XCDR1_PL_SHORT_PID_MASK         0x3fffu        // Mask for the member ID in the short PL header
+
+// Mask for the member ID in the short PL header; we don't use implementation-defined parameter ids (except
+// in discovery data, but that's handled elsewhere anyway) and including this bit in the mask means we
+// automatically treat them as unrecognised ids
+#define DDS_XCDR1_PL_SHORT_PID_MASK         (0x3fffu | DDS_XCDR1_PL_SHORT_FLAG_IMPL_EXT)
 
 #define DDS_XCDR1_PL_LONG_FLAG_IMPL_EXT     0x80000000u    // Flag used for RTPS discovery data types
 #define DDS_XCDR1_PL_LONG_FLAG_MU           0x40000000u    // Flag to indicate the parameter is must-understand in extended PL header
 #define DDS_XCDR1_PL_LONG_UNSPECIFIED1      0x20000000u    // For future extension
 #define DDS_XCDR1_PL_LONG_UNSPECIFIED2      0x10000000u    // For future extension
-#define DDS_XCDR1_PL_LONG_MID_MASK          0x0fffffffu    // Mask for the member ID in the long PL header
+
+// Mask for the member ID in the long PL header
+#define DDS_XCDR1_PL_LONG_MID_MASK          (0x0fffffffu | DDS_XCDR1_PL_LONG_FLAG_IMPL_EXT)
 
 
 #define DDS_CDR_CALCULATED_FLAGS (DDS_TOPIC_FIXED_KEY | DDS_TOPIC_FIXED_KEY_XCDR2 | DDS_TOPIC_FIXED_KEY_XCDR2_KEYHASH | DDS_TOPIC_KEY_APPENDABLE | DDS_TOPIC_KEY_MUTABLE | DDS_TOPIC_KEY_SEQUENCE | DDS_TOPIC_KEY_ARRAY_NONPRIM)

--- a/src/core/cdr/include/dds/cdr/dds_cdrstream.h
+++ b/src/core/cdr/include/dds/cdr/dds_cdrstream.h
@@ -49,8 +49,8 @@ payload in order to reach the next 4-byte aligned offset. */
 #define DDS_XCDR1_PL_SHORT_PID_EXTENDED     0x3f01u        // Indicates the extended (long) PL encoding is used
 #define DDS_XCDR1_PL_SHORT_PID_LIST_END     0x3f02u        // Indicates the end of the parameter list data structure
 #define DDS_XCDR1_PL_SHORT_PID_EXT_LEN      0x8u           // Value of the param header length field in case of extended PL encoding
-#define DDS_XCDR1_PL_SHORT_FLAG_IMPL_EXT    0x4000u        // Flag for implementation specific interpretation of the parameter (not implemented)
-#define DDS_XCDR1_PL_SHORT_FLAG_MU          0x2000u        // Flag to indicate the parameter is must-understand in short PL header
+#define DDS_XCDR1_PL_SHORT_FLAG_IMPL_EXT    0x8000u        // Flag for implementation specific interpretation of the parameter (not implemented)
+#define DDS_XCDR1_PL_SHORT_FLAG_MU          0x4000u        // Flag to indicate the parameter is must-understand in short PL header
 #define DDS_XCDR1_PL_SHORT_PID_MASK         0x3fffu        // Mask for the member ID in the short PL header
 
 #define DDS_XCDR1_PL_LONG_FLAG_IMPL_EXT     0x80000000u    // Flag used for RTPS discovery data types

--- a/src/core/cdr/src/dds_cdrstream.c
+++ b/src/core/cdr/src/dds_cdrstream.c
@@ -4311,8 +4311,16 @@ static enum normalize_xcdr1_paramheader_result stream_read_normalize_xcdr1_param
     // Check length and must understand in short param header
     if (slen != DDS_XCDR1_PL_SHORT_PID_EXT_LEN)
       return NPHR1_ERROR;
+    // XTypes 1.3 note immediately following table 34:
+    //
+    // When writing data, implementations of this specification shall set the
+    // FLAG_MUST_UNDERSTAND bit as described in Table 34. When reading data,
+    // implementations of this specification shall be robust to any setting of
+    // the FLAG_MUST_UNDERSTAND bit and accept the parameter nevertheless.
+#if 0
     if (!(phdr & DDS_XCDR1_PL_SHORT_FLAG_MU))
       return NPHR1_ERROR;
+#endif
 
     // Read and check the extended parameter ID
     uint32_t pid;

--- a/src/core/cdr/src/dds_cdrstream.c
+++ b/src/core/cdr/src/dds_cdrstream.c
@@ -2209,7 +2209,7 @@ static const uint32_t *dds_stream_getsize_adr (uint32_t insn, struct getsize_sta
   bool alignment_offset_by_4 = false;
   if (op_type_optional (insn) && !is_mutable_member)
   {
-    bool present = op_type_optional (insn) ? (addr != NULL) : true;
+    bool present = (addr != NULL);
     if (st->xcdr_version != DDSI_RTPS_CDR_ENC_VERSION_1)
       getsize_reserve (st, 1);
     else

--- a/src/core/cdr/src/dds_cdrstream.c
+++ b/src/core/cdr/src/dds_cdrstream.c
@@ -116,9 +116,13 @@ typedef struct restrict_ostreamLE {
 #define dds_stream_writeBO                                  NAME_BYTE_ORDER(dds_stream_write)
 #define dds_stream_write_implBO                             NAME_BYTE_ORDER(dds_stream_write_impl)
 #define dds_stream_write_xcdr1_paramheaderBO                NAME_BYTE_ORDER(dds_stream_write_xcdr1_paramheader)
+#define dds_stream_write_xcdr1_paramheader_closeBO          NAME_BYTE_ORDER(dds_stream_write_xcdr1_paramheader_closeBO)
+#define dds_stream_write_xcdr1_param_list_endBO             NAME_BYTE_ORDER(dds_stream_write_xcdr1_param_list_end)
 #define dds_stream_write_adrBO                              NAME_BYTE_ORDER(dds_stream_write_adr)
+#define dds_stream_write_xcdr1_plBO                         NAME_BYTE_ORDER(dds_stream_write_xcdr1_pl)
 #define dds_stream_write_xcdr2_plBO                         NAME_BYTE_ORDER(dds_stream_write_xcdr2_pl)
-#define dds_stream_write_xcdr2_pl_memberlistBO              NAME_BYTE_ORDER(dds_stream_write_xcdr2_pl_memberlist)
+#define dds_stream_write_pl_memberlistBO                    NAME_BYTE_ORDER(dds_stream_write_pl_memberlist)
+#define dds_stream_write_xcdr1_pl_memberBO                  NAME_BYTE_ORDER(dds_stream_write_xcdr1_pl_member)
 #define dds_stream_write_xcdr2_pl_memberBO                  NAME_BYTE_ORDER(dds_stream_write_xcdr2_pl_member)
 #define dds_stream_write_delimitedBO                        NAME_BYTE_ORDER(dds_stream_write_delimited)
 #define dds_stream_write_keyBO                              NAME_BYTE_ORDER(dds_stream_write_key)
@@ -130,9 +134,7 @@ typedef struct restrict_ostreamLE {
 #define dds_stream_extract_keyBO_from_data1                 NAME2_BYTE_ORDER(dds_stream_extract_key, _from_data1)
 #define dds_stream_extract_keyBO_from_data_adr              NAME2_BYTE_ORDER(dds_stream_extract_key, _from_data_adr)
 #define dds_stream_extract_keyBO_from_key_prim_op           NAME2_BYTE_ORDER(dds_stream_extract_key, _from_key_prim_op)
-#define dds_stream_extract_keyBO_from_data_delimited        NAME2_BYTE_ORDER(dds_stream_extract_key, _from_data_delimited)
-#define dds_stream_extract_keyBO_from_data_xcdr2_pl         NAME2_BYTE_ORDER(dds_stream_extract_key, _from_data_xcdr2_pl)
-#define dds_stream_extract_keyBO_from_data_xcdr2_pl_member  NAME2_BYTE_ORDER(dds_stream_extract_key, _from_data_xcdr2_pl_member)
+#define dds_stream_extract_keyBO_from_data_skip_delimited   NAME2_BYTE_ORDER(dds_stream_extract_key, _from_data_skip_delimited)
 #define dds_stream_extract_keyBO_from_key_impl              NAME2_BYTE_ORDER(dds_stream_extract_key, _from_key_impl)
 #define dds_stream_extract_keyBO_from_key_optimized         NAME2_BYTE_ORDER(dds_stream_extract_key, _from_key_optimized)
 #define dds_stream_extract_keyBO_from_key                   NAME2_BYTE_ORDER(dds_stream_extract_key, _from_key)
@@ -183,13 +185,13 @@ static const uint32_t *dds_stream_skip_default (char * restrict data, const stru
   ddsrt_nonnull_all;
 
 static const uint32_t *dds_stream_extract_key_from_data1 (dds_istream_t *is, restrict_ostream_t *os, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc_mid_table *mid_table,
-  const uint32_t *ops, bool mutable_member, bool mutable_member_or_parent, uint32_t n_keys, uint32_t * restrict keys_remaining)
-  ddsrt_nonnull ((1, 3, 4, 5, 9));
+  const uint32_t *ops, bool mutable_member, uint32_t n_keys, uint32_t * restrict keys_remaining)
+  ddsrt_nonnull ((1, 3, 4, 5, 8));
 
 #if DDSRT_ENDIAN == DDSRT_LITTLE_ENDIAN
 static const uint32_t *dds_stream_extract_keyBE_from_data1 (dds_istream_t *is, restrict_ostreamBE_t *os, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc_mid_table *mid_table,
-  const uint32_t *ops, bool mutable_member, bool mutable_member_or_parent, uint32_t n_keys, uint32_t * restrict keys_remaining)
-  ddsrt_nonnull ((1, 3, 4, 5, 9));
+  const uint32_t *ops, bool mutable_member, uint32_t n_keys, uint32_t * restrict keys_remaining)
+  ddsrt_nonnull ((1, 3, 4, 5, 8));
 #endif
 
 static const uint32_t *stream_normalize_data_impl (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *ops, bool is_mutable_member, enum cdr_data_kind cdr_kind)
@@ -211,10 +213,10 @@ static const uint32_t *dds_stream_free_sample_uni (char * restrict discaddr, cha
   ddsrt_nonnull_all;
 
 static const uint32_t *dds_stream_write_implLE (restrict_ostreamLE_t *os, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc_mid_table *mid_table, const char *data, const uint32_t *ops, bool is_mutable_member, enum cdr_data_kind cdr_kind)
-  ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+  ddsrt_attribute_warn_unused_result ddsrt_nonnull ((1, 2, 3, 4, 5));
 
 static const uint32_t *dds_stream_write_implBE (restrict_ostreamBE_t *os, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc_mid_table *mid_table, const char *data, const uint32_t *ops, bool is_mutable_member, enum cdr_data_kind cdr_kind)
-  ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+  ddsrt_attribute_warn_unused_result ddsrt_nonnull ((1, 2, 3, 4, 5));
 
 #ifndef NDEBUG
 typedef struct align { uint32_t a; } align_t;
@@ -1009,7 +1011,7 @@ static const uint32_t *dds_stream_get_ops_info_uni (const uint32_t *ops, uint32_
 }
 
 ddsrt_nonnull_all
-static const uint32_t *dds_stream_get_ops_info_xcdr2_pl (const uint32_t *ops, uint32_t nestc, struct dds_cdrstream_ops_info *info, bool in_xcdr1_delimited_scope)
+static const uint32_t *dds_stream_get_ops_info_pl (const uint32_t *ops, uint32_t nestc, struct dds_cdrstream_ops_info *info, bool in_xcdr1_delimited_scope)
 {
   uint32_t insn;
   assert (ops[0] == DDS_OP_PLC);
@@ -1022,7 +1024,7 @@ static const uint32_t *dds_stream_get_ops_info_xcdr2_pl (const uint32_t *ops, ui
         uint32_t flags = DDS_PLM_FLAGS (insn);
         const uint32_t *plm_ops = ops + DDS_OP_ADR_PLM (insn);
         if (flags & DDS_OP_FLAG_BASE)
-          (void) dds_stream_get_ops_info_xcdr2_pl (plm_ops, nestc, info, in_xcdr1_delimited_scope);
+          (void) dds_stream_get_ops_info_pl (plm_ops, nestc, info, in_xcdr1_delimited_scope);
         else
           dds_stream_get_ops_info1 (plm_ops, nestc, info, in_xcdr1_delimited_scope);
         ops += 2;
@@ -1148,8 +1150,7 @@ static void dds_stream_get_ops_info1 (const uint32_t *ops, uint32_t nestc, struc
       }
       case DDS_OP_PLC: {
         info->data_types |= DDS_DATA_TYPE_CONTAINS_MUTABLE;
-        info->min_xcdrv = DDSI_RTPS_CDR_ENC_VERSION_2;
-        ops = dds_stream_get_ops_info_xcdr2_pl (ops, nestc, info, in_xcdr1_delimited_scope);
+        ops = dds_stream_get_ops_info_pl (ops, nestc, info, in_xcdr1_delimited_scope);
         break;
       }
     }
@@ -2200,23 +2201,21 @@ static const uint32_t *dds_stream_getsize_adr (uint32_t insn, struct getsize_sta
     return dds_stream_skip_adr (insn, ops);
 
   bool alignment_offset_by_4 = false;
-  if (op_type_optional (insn))
+  if (op_type_optional (insn) && !is_mutable_member)
   {
-    if (!is_mutable_member)
+    bool present = op_type_optional (insn) ? (addr != NULL) : true;
+    if (st->xcdr_version != DDSI_RTPS_CDR_ENC_VERSION_1)
+      getsize_reserve (st, 1);
+    else
     {
-      if (st->xcdr_version != DDSI_RTPS_CDR_ENC_VERSION_1)
-        getsize_reserve (st, 1);
-      else
+      getsize_reserve_many (st, 4, 3);
+      if (present && ((st->pos - st->align_off) % 8) != 0)
       {
-        getsize_reserve_many (st, 4, 3);
-        if (addr && ((st->pos - st->align_off) % 8) != 0)
-        {
-          st->align_off += 4;
-          alignment_offset_by_4 = true;
-        }
+        st->align_off += 4;
+        alignment_offset_by_4 = true;
       }
     }
-    if (!addr)
+    if (!present)
     {
       if (alignment_offset_by_4)
         st->align_off -= 4;
@@ -2273,6 +2272,32 @@ static const uint32_t *dds_stream_getsize_delimited (struct getsize_state *st, c
   return ops;
 }
 
+static bool dds_stream_getsize_xcdr1_pl_member (struct getsize_state *st, const char *data, const uint32_t *ops)
+{
+  /* get flags from first member op */
+  uint32_t flags = DDS_OP_FLAGS (ops[0]);
+  bool is_key = flags & (DDS_OP_FLAG_MU | DDS_OP_FLAG_KEY);
+
+  if (st->cdr_kind == CDR_KIND_KEY && !is_key)
+    return true;
+
+  bool alignment_offset_by_4 = false;
+  getsize_reserve_many (st, 4, 3);
+  if (((st->pos - st->align_off) % 8) != 0)
+  {
+    st->align_off += 4;
+    alignment_offset_by_4 = true;
+  }
+
+  if (!(dds_stream_getsize_impl (st, data, ops, true)))
+    return false;
+
+  if (alignment_offset_by_4)
+    st->align_off -= 4;
+
+  return true;
+}
+
 static bool dds_stream_getsize_xcdr2_pl_member (struct getsize_state *st, const char *data, const uint32_t *ops)
 {
   /* get flags from first member op */
@@ -2291,7 +2316,7 @@ static bool dds_stream_getsize_xcdr2_pl_member (struct getsize_state *st, const 
   return true;
 }
 
-static const uint32_t *dds_stream_getsize_xcdr2_pl_memberlist (struct getsize_state *st, const char *data, const uint32_t *ops)
+static const uint32_t *dds_stream_getsize_pl_memberlist (struct getsize_state *st, const char *data, const uint32_t *ops)
 {
   uint32_t insn;
   while (ops && (insn = *ops) != DDS_OP_RTS)
@@ -2305,13 +2330,21 @@ static const uint32_t *dds_stream_getsize_xcdr2_pl_memberlist (struct getsize_st
         {
           assert (plm_ops[0] == DDS_OP_PLC);
           plm_ops++; /* skip PLC op to go to first PLM for the base type */
-          if (!dds_stream_getsize_xcdr2_pl_memberlist (st, data, plm_ops))
+          if (!dds_stream_getsize_pl_memberlist (st, data, plm_ops))
             return NULL;
         }
         else if (is_member_present (data, plm_ops))
         {
-          if (!dds_stream_getsize_xcdr2_pl_member (st, data, plm_ops))
-            return NULL;
+          if (st->xcdr_version == DDSI_RTPS_CDR_ENC_VERSION_2)
+          {
+            if (!dds_stream_getsize_xcdr2_pl_member (st, data, plm_ops))
+              return NULL;
+          }
+          else
+          {
+            if (!dds_stream_getsize_xcdr1_pl_member (st, data, plm_ops))
+              return NULL;
+          }
         }
         ops += 2;
         break;
@@ -2324,6 +2357,20 @@ static const uint32_t *dds_stream_getsize_xcdr2_pl_memberlist (struct getsize_st
   return ops;
 }
 
+static const uint32_t *dds_stream_getsize_xcdr1_pl (struct getsize_state *st, const char *data, const uint32_t *ops)
+{
+  /* skip PLC op */
+  ops++;
+
+  /* members, including members from base types */
+  ops = dds_stream_getsize_pl_memberlist (st, data, ops);
+
+  /* list-end parameter (4-byte aligned) */
+  getsize_reserve (st, 4);
+
+  return ops;
+}
+
 static const uint32_t *dds_stream_getsize_xcdr2_pl (struct getsize_state *st, const char *data, const uint32_t *ops)
 {
   /* skip PLC op */
@@ -2331,7 +2378,7 @@ static const uint32_t *dds_stream_getsize_xcdr2_pl (struct getsize_state *st, co
   /* alloc space for dheader */
   getsize_reserve (st, 4);
   /* members, including members from base types */
-  return dds_stream_getsize_xcdr2_pl_memberlist (st, data, ops);
+  return dds_stream_getsize_pl_memberlist (st, data, ops);
 }
 
 static const uint32_t *dds_stream_getsize_impl (struct getsize_state *st, const char *data, const uint32_t *ops0, bool is_mutable_member)
@@ -2360,8 +2407,10 @@ static const uint32_t *dds_stream_getsize_impl (struct getsize_state *st, const 
           ops = dds_stream_getsize_impl (st, data, ops + 1, false);
         break;
       case DDS_OP_PLC:
-        assert (st->xcdr_version == DDSI_RTPS_CDR_ENC_VERSION_2);
-        ops = dds_stream_getsize_xcdr2_pl (st, data, ops);
+        if (st->xcdr_version == DDSI_RTPS_CDR_ENC_VERSION_2)
+          ops = dds_stream_getsize_xcdr2_pl (st, data, ops);
+        else
+          ops = dds_stream_getsize_xcdr1_pl (st, data, ops);
         break;
     }
   }
@@ -2589,26 +2638,43 @@ static void adjust_sequence_buffer (dds_sequence_t *seq, const struct dds_cdrstr
   }
 }
 
+static void stream_read_xcdr1_paramheader (dds_istream_t *is, uint32_t *param_mid, uint32_t *param_len, bool *paramlist_end)
+{
+  assert (param_len);
+  dds_cdr_alignto (is, dds_cdr_get_align (is->m_xcdr_version, 4));
+  uint16_t phdr = dds_is_get2 (is);
+  uint16_t slen = dds_is_get2 (is);
+  if ((phdr & DDS_XCDR1_PL_SHORT_PID_MASK) == DDS_XCDR1_PL_SHORT_PID_LIST_END)
+  {
+    if (paramlist_end)
+      *paramlist_end = true;
+  }
+  else if ((phdr & DDS_XCDR1_PL_SHORT_PID_MASK) == DDS_XCDR1_PL_SHORT_PID_EXTENDED)
+  {
+    uint32_t ehdr = dds_is_get4 (is);
+    if (param_mid)
+      *param_mid = ehdr & DDS_XCDR1_PL_LONG_MID_MASK;
+    *param_len = dds_is_get4 (is);
+    if (paramlist_end)
+      *paramlist_end = false;
+  }
+  else
+  {
+    if (param_mid)
+      *param_mid = (phdr & DDS_XCDR1_PL_SHORT_PID_MASK);
+    *param_len = (uint32_t) slen;
+    if (paramlist_end)
+      *paramlist_end = false;
+  }
+}
+
 ddsrt_nonnull_all
 static bool stream_is_member_present (dds_istream_t *is, uint32_t *param_len)
 {
   if (is->m_xcdr_version == DDSI_RTPS_CDR_ENC_VERSION_1)
   {
-    dds_cdr_alignto (is, dds_cdr_get_align (is->m_xcdr_version, 4));
-    uint16_t phdr = dds_is_get2 (is);
-    uint16_t slen = dds_is_get2 (is);
-    uint32_t plen;
-    if ((phdr & DDS_XCDR1_PL_SHORT_PID_MASK) == DDS_XCDR1_PL_SHORT_PID_EXTENDED)
-    {
-      (void) dds_is_get4 (is); /* skip param ID (is checked in normalize) */
-      plen = dds_is_get4 (is);
-    }
-    else
-    {
-      plen = (uint32_t) slen;
-    }
-    *param_len = plen;
-    return plen > 0;
+    stream_read_xcdr1_paramheader (is, NULL, param_len, NULL);
+    return *param_len > 0;
   }
   else
   {
@@ -3124,7 +3190,7 @@ static const uint32_t *dds_stream_skip_delimited_default (char * restrict data, 
 }
 
 ddsrt_nonnull_all
-static void dds_stream_skip_xcdr2_pl_member_default (char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, enum sample_data_state sample_state)
+static void dds_stream_skip_pl_member_default (char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, enum sample_data_state sample_state)
 {
   uint32_t insn;
   while ((insn = *ops) != DDS_OP_RTS)
@@ -3136,7 +3202,7 @@ static void dds_stream_skip_xcdr2_pl_member_default (char * restrict data, const
         break;
       }
       case DDS_OP_JSR:
-        dds_stream_skip_xcdr2_pl_member_default (data, allocator, ops + DDS_OP_JUMP (insn), sample_state);
+        dds_stream_skip_pl_member_default (data, allocator, ops + DDS_OP_JUMP (insn), sample_state);
         ops++;
         break;
       case DDS_OP_RTS: case DDS_OP_JEQ: case DDS_OP_JEQ4: case DDS_OP_KOF:
@@ -3148,7 +3214,7 @@ static void dds_stream_skip_xcdr2_pl_member_default (char * restrict data, const
 }
 
 ddsrt_nonnull_all
-static const uint32_t *dds_stream_skip_xcdr2_pl_memberlist_default (char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops0, enum sample_data_state sample_state)
+static const uint32_t *dds_stream_skip_pl_memberlist_default (char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops0, enum sample_data_state sample_state)
 {
   const uint32_t *ops = ops0;
   uint32_t insn;
@@ -3163,11 +3229,11 @@ static const uint32_t *dds_stream_skip_xcdr2_pl_memberlist_default (char * restr
         {
           assert (plm_ops[0] == DDS_OP_PLC);
           plm_ops++; /* skip PLC op to go to first PLM for the base type */
-          (void) dds_stream_skip_xcdr2_pl_memberlist_default (data, allocator, plm_ops, sample_state);
+          (void) dds_stream_skip_pl_memberlist_default (data, allocator, plm_ops, sample_state);
         }
         else
         {
-          dds_stream_skip_xcdr2_pl_member_default (data, allocator, plm_ops, sample_state);
+          dds_stream_skip_pl_member_default (data, allocator, plm_ops, sample_state);
         }
         ops += 2;
         break;
@@ -3181,10 +3247,10 @@ static const uint32_t *dds_stream_skip_xcdr2_pl_memberlist_default (char * restr
 }
 
 ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
-static const uint32_t *dds_stream_skip_xcdr2_pl_default (char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, enum sample_data_state sample_state)
+static const uint32_t *dds_stream_skip_pl_default (char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, enum sample_data_state sample_state)
 {
   /* skip PLC op */
-  return dds_stream_skip_xcdr2_pl_memberlist_default (data, allocator, ++ops, sample_state);
+  return dds_stream_skip_pl_memberlist_default (data, allocator, ++ops, sample_state);
 }
 
 ddsrt_nonnull_all
@@ -3211,7 +3277,7 @@ static const uint32_t *dds_stream_skip_default (char * restrict data, const stru
         ops = dds_stream_skip_delimited_default (data, allocator, ops, sample_state);
         break;
       case DDS_OP_PLC:
-        ops = dds_stream_skip_xcdr2_pl_default (data, allocator, ops, sample_state);
+        ops = dds_stream_skip_pl_default (data, allocator, ops, sample_state);
         break;
     }
   }
@@ -3249,8 +3315,8 @@ static const uint32_t *dds_stream_read_delimited (dds_istream_t *is, char * rest
   return ops;
 }
 
-ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
-static bool dds_stream_read_xcdr2_pl_member (dds_istream_t *is, char * restrict data, const struct dds_cdrstream_allocator *allocator, uint32_t m_id, const uint32_t *ops, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
+ddsrt_nonnull_all
+static bool dds_stream_read_pl_member (dds_istream_t *is, char * restrict data, const struct dds_cdrstream_allocator *allocator, uint32_t m_id, const uint32_t *ops, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
 {
   uint32_t insn, ops_csr = 0;
   bool found = false;
@@ -3266,7 +3332,7 @@ static bool dds_stream_read_xcdr2_pl_member (dds_istream_t *is, char * restrict 
     {
       assert (DDS_OP (plm_ops[0]) == DDS_OP_PLC);
       plm_ops++; /* skip PLC to go to first PLM from base type */
-      found = dds_stream_read_xcdr2_pl_member (is, data, allocator, m_id, plm_ops, cdr_kind, sample_state);
+      found = dds_stream_read_pl_member (is, data, allocator, m_id, plm_ops, cdr_kind, sample_state);
     }
     else if (ops[ops_csr + 1] == m_id)
     {
@@ -3280,6 +3346,46 @@ static bool dds_stream_read_xcdr2_pl_member (dds_istream_t *is, char * restrict 
 }
 
 ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
+static const uint32_t *dds_stream_read_xcdr1_pl (dds_istream_t *is, char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
+{
+  /* skip PLC op */
+  ops++;
+
+  /* default-initialize all members
+      FIXME: optimize so that only members not in received data are initialized */
+  dds_stream_skip_pl_memberlist_default (data, allocator, ops, sample_state);
+
+  bool paramlist_end;
+  do
+  {
+    uint32_t param_mid, param_len;
+    stream_read_xcdr1_paramheader (is, &param_mid, &param_len, &paramlist_end);
+    if (!paramlist_end)
+    {
+      // Move buffer in temporary istream `is1` to start of parameter value and
+      // set size to param length, so that alignment is reset to 0
+      dds_istream_t is1 = *is;
+      is1.m_buffer += is1.m_index;
+      is1.m_index = 0;
+      is1.m_size = param_len;
+
+      // find member and deserialize
+      (void) dds_stream_read_pl_member (&is1, data, allocator, param_mid, ops, cdr_kind, sample_state);
+
+      // forward index in CDR by param_len if found, and also in case member not known
+      is->m_index += param_len;
+    }
+  }
+  while (!paramlist_end);
+
+  /* skip all PLM-memberid pairs */
+  while (ops[0] != DDS_OP_RTS)
+    ops += 2;
+
+  return ops;
+}
+
+ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
 static const uint32_t *dds_stream_read_xcdr2_pl (dds_istream_t *is, char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
 {
   /* skip PLC op */
@@ -3287,7 +3393,7 @@ static const uint32_t *dds_stream_read_xcdr2_pl (dds_istream_t *is, char * restr
 
   /* default-initialize all members
       FIXME: optimize so that only members not in received data are initialized */
-  dds_stream_skip_xcdr2_pl_memberlist_default (data, allocator, ops, sample_state);
+  dds_stream_skip_pl_memberlist_default (data, allocator, ops, sample_state);
 
   /* read DHEADER */
   uint32_t pl_sz = dds_is_get4 (is), pl_offs = is->m_index;
@@ -3321,7 +3427,7 @@ static const uint32_t *dds_stream_read_xcdr2_pl (dds_istream_t *is, char * restr
     const uint32_t next_off = is->m_index + msz + ((lc >= LENGTH_CODE_ALSO_NEXTINT) ? 4 : 0);
 #endif
     /* find member and deserialize */
-    if (!dds_stream_read_xcdr2_pl_member (is, data, allocator, m_id, ops, cdr_kind, sample_state))
+    if (!dds_stream_read_pl_member (is, data, allocator, m_id, ops, cdr_kind, sample_state))
     {
       is->m_index += msz;
       if (lc >= LENGTH_CODE_ALSO_NEXTINT)
@@ -3370,8 +3476,10 @@ static const uint32_t *dds_stream_read_impl (dds_istream_t *is, char * restrict 
         break;
       }
       case DDS_OP_PLC:
-        assert (is->m_xcdr_version == DDSI_RTPS_CDR_ENC_VERSION_2);
-        ops = dds_stream_read_xcdr2_pl (is, data, allocator, ops, cdr_kind, sample_state);
+        if (is->m_xcdr_version == DDSI_RTPS_CDR_ENC_VERSION_2)
+          ops = dds_stream_read_xcdr2_pl (is, data, allocator, ops, cdr_kind, sample_state);
+        else
+          ops = dds_stream_read_xcdr1_pl (is, data, allocator, ops, cdr_kind, sample_state);
         break;
     }
   }
@@ -4121,18 +4229,49 @@ static const uint32_t *normalize_uni (char * restrict data, uint32_t * restrict 
   return ops;
 }
 
+
+// Alignment rules madness: XCDR1 serialization of optionals/mutable shifts
+// reference position, so int64/float64 alignment is no longer always at
+// multiple of 8:
+//
+//    Member of mutable aggregated type (structure, union), version 1 encoding
+//    using short PL encoding when both M.id <= 2^14 and M.value.ssize <= 2^16
+//    (24) XCDR[1] << {M : MMEMBER} =
+//        XCDR
+//        << ALIGN(4)
+//        << { FLAG_I + FLAG_M + M.id : UInt16 }
+//        << { M.value.ssize : UInt16 }
+//        << PUSH( ORIGIN=0 )
+//        << { M.value : M.value.type }
+//
+//    Member of mutable aggregated type (structure, union), version 1 encoding
+//    using long PL encoding
+//    (25) XCDR[1] << {M : MMEMBER} =
+//        XCDR
+//        << ALIGN(4)
+//        << { FLAG_I + FLAG_M + PID_EXTENDED : UInt16 }
+//        << { slength=8 : UInt16 }
+//        << { M.id : UInt32 }
+//        << { M.value.ssize : UInt32 }
+//        << PUSH( ORIGIN=0 )
+//        << { M.value : M.value.type }
+//
+// (with a presumed-missing POP(ORIGIN) at the end of both)
+
+
 enum normalize_xcdr1_paramheader_result {
   NPHR1_NOT_FOUND,   // unknown memberid, param_length and must_understand set
   NPHR1_NOT_PRESENT, // known memberid, param_length = 0, must_understand set
   NPHR1_PRESENT,     // known memberid, param_length != 0, must_understand set
+  NPHR1_LIST_END,    // list-end found
   NPHR1_ERROR        // normalization failed; param_length and must_understand undefined
 };
 
 ddsrt_nonnull_all
-static enum normalize_xcdr1_paramheader_result stream_read_normalize_xcdr1_paramheader (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t *param_length, bool *must_understand, const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *adr_op)
+static enum normalize_xcdr1_paramheader_result stream_read_normalize_xcdr1_paramheader (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t *param_length, bool *must_understand, uint32_t *phdr_mid)
 {
   uint16_t phdr, slen;
-  uint32_t phdr_mid, plen;
+  uint32_t plen;
 
   if ((*off = check_align_prim (*off, size, 2, 2)) == UINT32_MAX)
     return NPHR1_ERROR;
@@ -4156,7 +4295,7 @@ static enum normalize_xcdr1_paramheader_result stream_read_normalize_xcdr1_param
       return NPHR1_ERROR;
     if (pid & DDS_XCDR1_PL_LONG_FLAG_IMPL_EXT)
       return NPHR1_ERROR;
-    phdr_mid = pid & DDS_XCDR1_PL_LONG_MID_MASK;
+    *phdr_mid = pid & DDS_XCDR1_PL_LONG_MID_MASK;
     *must_understand = (pid & DDS_XCDR1_PL_LONG_FLAG_MU);
 
     // Read the extended parameter length
@@ -4185,20 +4324,39 @@ static enum normalize_xcdr1_paramheader_result stream_read_normalize_xcdr1_param
 
     uint32_t pid = (phdr & DDS_XCDR1_PL_SHORT_PID_MASK);
     if (pid == DDS_XCDR1_PL_SHORT_PID_LIST_END)
-      return NPHR1_ERROR;
+      return NPHR1_LIST_END;
     if (pid >= 0x3F04 && pid <= 0x3FFF) // reserved value
       return NPHR1_NOT_FOUND;
-    phdr_mid = pid;
+    *phdr_mid = pid;
   }
-
-  uint32_t adr_mid;
-  if (!find_member_id (mid_table, adr_op, &adr_mid))
-    return NPHR1_NOT_FOUND;
-  if (adr_mid != phdr_mid)
-    return NPHR1_ERROR;
 
   return plen > 0 ? NPHR1_PRESENT : NPHR1_NOT_PRESENT;
 }
+
+
+ddsrt_nonnull_all
+static enum normalize_xcdr1_paramheader_result stream_read_normalize_xcdr1_paramheader_optional (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t *param_length, bool *must_understand, const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *adr_op)
+{
+  uint32_t adr_mid, phdr_mid;
+  enum normalize_xcdr1_paramheader_result res = stream_read_normalize_xcdr1_paramheader (data, off, size, bswap, param_length, must_understand, &phdr_mid);
+  switch (res)
+  {
+    case NPHR1_ERROR:
+    case NPHR1_LIST_END:
+    case NPHR1_NOT_FOUND:
+      break;
+
+    case NPHR1_PRESENT:
+    case NPHR1_NOT_PRESENT:
+      if (!find_member_id (mid_table, adr_op, &adr_mid))
+        res = NPHR1_NOT_FOUND;
+      else if (adr_mid != phdr_mid)
+        res = NPHR1_ERROR;
+      break;
+  }
+  return res;
+}
+
 
 ddsrt_nonnull_all
 static const uint32_t *stream_normalize_adr_impl (uint32_t insn, char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *ops, enum cdr_data_kind cdr_kind)
@@ -4261,13 +4419,14 @@ static const uint32_t *stream_normalize_adr (uint32_t insn, char * restrict data
     else
       return stream_normalize_adr_impl (insn, data, off, size, bswap, xcdr_version, mid_table, ops, cdr_kind);
   }
-  else // xcdr_version == DDSI_RTPS_CDR_ENC_VERSION_1
+  else // optional member in xcdr version 1
   {
     uint32_t param_length = 0;
     bool must_understand = false;
-    switch (stream_read_normalize_xcdr1_paramheader (data, off, size, bswap, &param_length, &must_understand, mid_table, ops))
+    switch (stream_read_normalize_xcdr1_paramheader_optional (data, off, size, bswap, &param_length, &must_understand, mid_table, ops))
     {
       case NPHR1_ERROR:
+      case NPHR1_LIST_END:
         return normalize_error_ops ();
       case NPHR1_NOT_FOUND:
         if (must_understand) // must_understand and unknown means we have to reject the input
@@ -4278,33 +4437,7 @@ static const uint32_t *stream_normalize_adr (uint32_t insn, char * restrict data
         ops = dds_stream_skip_adr (insn, ops);
         break;
       case NPHR1_PRESENT: {
-        // alignment rules madness: XCDR1 serialization of optionals/mutable shifts
-        // reference position, so int64/float64 alignment is no longer always at
-        // multiple of 8:
-        //
-        //    Member of mutable aggregated type (structure, union), version 1 encoding
-        //    using short PL encoding when both M.id <= 2^14 and M.value.ssize <= 2^16
-        //    (24) XCDR[1] << {M : MMEMBER} =
-        //        XCDR
-        //        << ALIGN(4)
-        //        << { FLAG_I + FLAG_M + M.id : UInt16 }
-        //        << { M.value.ssize : UInt16 }
-        //        << PUSH( ORIGIN=0 )
-        //        << { M.value : M.value.type }
-        //
-        //    Member of mutable aggregated type (structure, union), version 1 encoding
-        //    using long PL encoding
-        //    (25) XCDR[1] << {M : MMEMBER} =
-        //        XCDR
-        //        << ALIGN(4)
-        //        << { FLAG_I + FLAG_M + PID_EXTENDED : UInt16 }
-        //        << { slength=8 : UInt16 }
-        //        << { M.id : UInt32 }
-        //        << { M.value.ssize : UInt32 }
-        //        << PUSH( ORIGIN=0 )
-        //        << { M.value : M.value.type }
-        //
-        // (with a presumed-missing POP(ORIGIN) at the end of both)
+        // see remark on XCDR1 parameter alignment rules above
         const uint32_t input_offset = *off;
         uint32_t off1 = 0;
         if ((ops = stream_normalize_adr_impl (insn, data + input_offset, &off1, param_length, bswap, xcdr_version, mid_table, ops, cdr_kind)) == NULL)
@@ -4380,18 +4513,18 @@ static const uint32_t *stream_normalize_delimited (char * restrict data, uint32_
   return stream_normalize_delimited_impl (data, off, size, delimited_sz, bswap, xcdr_version, mid_table, ops, cdr_kind);
 }
 
-enum normalize_xcdr2_pl_member_result {
-  NPMR2_NOT_FOUND,
-  NPMR2_FOUND,
-  NPMR2_ERROR // found the data, but normalization failed
+enum normalize_pl_member_result {
+  NPMR_NOT_FOUND,
+  NPMR_FOUND,
+  NPMR_ERROR // found the data, but normalization failed
 };
 
 ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
-static enum normalize_xcdr2_pl_member_result dds_stream_normalize_xcdr2_pl_member (char * restrict data, uint32_t m_id, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *ops, enum cdr_data_kind cdr_kind)
+static enum normalize_pl_member_result dds_stream_normalize_pl_member (char * restrict data, uint32_t m_id, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *ops, enum cdr_data_kind cdr_kind)
 {
   uint32_t insn, ops_csr = 0;
-  enum normalize_xcdr2_pl_member_result result = NPMR2_NOT_FOUND;
-  while (result == NPMR2_NOT_FOUND && (insn = ops[ops_csr]) != DDS_OP_RTS)
+  enum normalize_pl_member_result result = NPMR_NOT_FOUND;
+  while (result == NPMR_NOT_FOUND && (insn = ops[ops_csr]) != DDS_OP_RTS)
   {
     assert (DDS_OP (insn) == DDS_OP_PLM);
     uint32_t flags = DDS_PLM_FLAGS (insn);
@@ -4400,14 +4533,14 @@ static enum normalize_xcdr2_pl_member_result dds_stream_normalize_xcdr2_pl_membe
     {
       assert (DDS_OP (plm_ops[0]) == DDS_OP_PLC);
       plm_ops++; /* skip PLC to go to first PLM from base type */
-      result = dds_stream_normalize_xcdr2_pl_member (data, m_id, off, size, bswap, xcdr_version, mid_table, plm_ops, cdr_kind);
+      result = dds_stream_normalize_pl_member (data, m_id, off, size, bswap, xcdr_version, mid_table, plm_ops, cdr_kind);
     }
     else if (ops[ops_csr + 1] == m_id)
     {
       if (stream_normalize_data_impl (data, off, size, bswap, xcdr_version, mid_table, plm_ops, true, cdr_kind))
-        result = NPMR2_FOUND;
+        result = NPMR_FOUND;
       else
-        result = NPMR2_ERROR;
+        result = NPMR_ERROR;
       break;
     }
     ops_csr += 2;
@@ -4415,8 +4548,76 @@ static enum normalize_xcdr2_pl_member_result dds_stream_normalize_xcdr2_pl_membe
   return result;
 }
 
+
 ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
-static const uint32_t *stream_normalize_xcdr2_pl (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *ops, enum cdr_data_kind cdr_kind)
+static const uint32_t *stream_normalize_xcdr1_pl (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *ops, enum cdr_data_kind cdr_kind)
+{
+  /* skip PLC op */
+  ops++;
+
+  bool paramlist_end = false;
+  do
+  {
+    uint32_t phdr_mid;
+    uint32_t param_length = 0;
+    bool must_understand = false;
+    switch (stream_read_normalize_xcdr1_paramheader (data, off, size, bswap, &param_length, &must_understand, &phdr_mid))
+    {
+      case NPHR1_ERROR:
+        return normalize_error_ops ();
+      case NPHR1_LIST_END:
+        paramlist_end = true;
+        break;
+      case NPHR1_NOT_FOUND:
+      case NPHR1_NOT_PRESENT:
+        if (must_understand) // must_understand and unknown means we have to reject the input
+          return normalize_error_ops ();
+        *off += param_length;
+        break;
+      case NPHR1_PRESENT: {
+        // see remark on XCDR1 parameter alignment rules above
+        const uint32_t input_offset = *off;
+
+        // reject if fewer than msz bytes remain in declared size of the parameter list
+        if (param_length > size - *off)
+          return normalize_error_ops ();
+        // don't allow member values that exceed its declared size
+        uint32_t off1 = 0;
+        switch (dds_stream_normalize_pl_member (data + input_offset, phdr_mid, &off1, param_length, bswap, xcdr_version, mid_table, ops, cdr_kind))
+        {
+          case NPMR_NOT_FOUND:
+            /* FIXME: the caller should be able to differentiate between a sample that
+              is dropped because of an unknown member that has the must-understand flag
+              and a sample that is dropped because the data is invalid. This requires
+              changes in the cdrstream interface, but also in the serdata interface to
+              pass the return value to ddsi_receive. */
+            if (must_understand)
+              return normalize_error_ops ();
+            break;
+          case NPMR_FOUND:
+            if (off1 != param_length)
+              return normalize_error_ops ();
+            break;
+          case NPMR_ERROR:
+            return NULL;
+        }
+        *off += param_length;
+        break;
+      }
+    }
+  }
+  while (!paramlist_end);
+
+  /* skip all PLM-memberid pairs */
+  while (ops[0] != DDS_OP_RTS)
+    ops += 2;
+
+  return ops;
+}
+
+
+ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
+static const uint32_t *stream_normalize_xcdr2_pl (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, uint32_t xcdr_version, const uint32_t *ops, enum cdr_data_kind cdr_kind)
 {
   /* skip PLC op */
   ops++;
@@ -4476,9 +4677,9 @@ static const uint32_t *stream_normalize_xcdr2_pl (char * restrict data, uint32_t
       return normalize_error_ops ();
     // don't allow member values that exceed its declared size
     const uint32_t size2 = *off + msz;
-    switch (dds_stream_normalize_xcdr2_pl_member (data, m_id, off, size2, bswap, xcdr_version, mid_table, ops, cdr_kind))
+    switch (dds_stream_normalize_pl_member (data, m_id, off, size2, bswap, xcdr_version, &static_empty_mid_table, ops, cdr_kind))
     {
-      case NPMR2_NOT_FOUND:
+      case NPMR_NOT_FOUND:
         /* FIXME: the caller should be able to differentiate between a sample that
            is dropped because of an unknown member that has the must-understand flag
            and a sample that is dropped because the data is invalid. This requires
@@ -4488,7 +4689,7 @@ static const uint32_t *stream_normalize_xcdr2_pl (char * restrict data, uint32_t
           return normalize_error_ops ();
         *off = size2;
         break;
-      case NPMR2_FOUND:
+      case NPMR_FOUND:
         /* XCDR2 final can't be changed, appendable is delimited, mutable always runs
            to the end and so no padding at the end of a parameter is ever needed.
 
@@ -4496,7 +4697,7 @@ static const uint32_t *stream_normalize_xcdr2_pl (char * restrict data, uint32_t
         if (*off != size2)
           return normalize_error_ops ();
         break;
-      case NPMR2_ERROR:
+      case NPMR_ERROR:
         return NULL;
     }
   }
@@ -4546,10 +4747,16 @@ static const uint32_t *stream_normalize_data_impl (char * restrict data, uint32_
         break;
       }
       case DDS_OP_PLC: {
-        if (xcdr_version != DDSI_RTPS_CDR_ENC_VERSION_2)
-          return normalize_error_ops ();
-        if ((ops = stream_normalize_xcdr2_pl (data, off, size, bswap, xcdr_version, mid_table, ops, cdr_kind)) == NULL)
-          return NULL;
+        if (xcdr_version == DDSI_RTPS_CDR_ENC_VERSION_2)
+        {
+          if ((ops = stream_normalize_xcdr2_pl (data, off, size, bswap, xcdr_version, ops, cdr_kind)) == NULL)
+            return NULL;
+        }
+        else
+        {
+          if ((ops = stream_normalize_xcdr1_pl (data, off, size, bswap, xcdr_version, mid_table, ops, cdr_kind)) == NULL)
+            return NULL;
+        }
         break;
       }
     }
@@ -5138,6 +5345,7 @@ static void dds_stream_extract_keyBE_from_key_prim_op (dds_istream_t *is, restri
 }
 #endif
 
+ddsrt_nonnull ((1))
 static void dds_stream_extract_key_from_data_skip_subtype (dds_istream_t *is, uint32_t num, uint32_t insn, enum dds_stream_typecode subtype, const uint32_t *subops)
 {
   assert (subops != NULL || DDS_OP (insn) == DDS_OP_ADR);
@@ -5171,7 +5379,7 @@ static void dds_stream_extract_key_from_data_skip_subtype (dds_istream_t *is, ui
     case DDS_OP_VAL_SEQ: case DDS_OP_VAL_BSQ: case DDS_OP_VAL_ARR: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU: {
       uint32_t remain = UINT32_MAX;
       for (uint32_t i = 0; i < num; i++)
-        dds_stream_extract_key_from_data1 (is, NULL, &dds_cdrstream_default_allocator, &static_empty_mid_table, subops, false, false, remain, &remain);
+        dds_stream_extract_key_from_data1 (is, NULL, &dds_cdrstream_default_allocator, &static_empty_mid_table, subops, false, remain, &remain);
       break;
     }
     case DDS_OP_VAL_EXT: {
@@ -5181,6 +5389,7 @@ static void dds_stream_extract_key_from_data_skip_subtype (dds_istream_t *is, ui
   }
 }
 
+ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
 static const uint32_t *dds_stream_extract_key_from_data_skip_array (dds_istream_t *is, const uint32_t *ops)
 {
   const uint32_t insn = *ops;
@@ -5201,6 +5410,7 @@ static const uint32_t *dds_stream_extract_key_from_data_skip_array (dds_istream_
   return skip_array_insns (insn, ops);
 }
 
+ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
 static const uint32_t *dds_stream_extract_key_from_data_skip_sequence (dds_istream_t *is, const uint32_t *ops)
 {
   const uint32_t insn = *ops;
@@ -5227,6 +5437,7 @@ static const uint32_t *dds_stream_extract_key_from_data_skip_sequence (dds_istre
   return skip_sequence_insns (insn, ops);
 }
 
+ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
 static const uint32_t *dds_stream_extract_key_from_data_skip_union (dds_istream_t *is, const uint32_t *ops)
 {
   const uint32_t insn = *ops;
@@ -5238,6 +5449,42 @@ static const uint32_t *dds_stream_extract_key_from_data_skip_union (dds_istream_
   return ops + DDS_OP_ADR_JMP (ops[3]);
 }
 
+ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
+static const uint32_t *dds_stream_extract_key_from_data_skip_pl (dds_istream_t *is, const uint32_t *ops)
+{
+  /* skip PLC op */
+  ops++;
+
+  if (is->m_xcdr_version == DDSI_RTPS_CDR_ENC_VERSION_1)
+  {
+    bool paramlist_end;
+    do
+    {
+      uint32_t param_mid, param_len;
+      stream_read_xcdr1_paramheader (is, &param_mid, &param_len, &paramlist_end);
+      if (!paramlist_end)
+      {
+        // forward index in CDR by param_len
+        is->m_index += param_len;
+      }
+    }
+    while (!paramlist_end);
+  }
+  else
+  {
+    /* read DHEADER and skip bytes in input */
+    uint32_t pl_sz = dds_is_get4 (is);
+    is->m_index += pl_sz;
+  }
+
+  /* skip all PLM-memberid pairs */
+  while (ops[0] != DDS_OP_RTS)
+    ops += 2;
+
+  return ops;
+}
+
+ddsrt_attribute_warn_unused_result ddsrt_nonnull ((1, 2))
 static const uint32_t *dds_stream_extract_key_from_data_skip_adr (dds_istream_t *is, const uint32_t *ops, enum dds_stream_typecode type)
 {
   switch (type)
@@ -5917,7 +6164,7 @@ static const uint32_t *prtf_delimited (char **buf, size_t *bufsize, dds_istream_
   return prtf_delimited_impl (buf, bufsize, delimited_sz, is, ops, cdr_kind);
 }
 
-static bool prtf_xcdr2_plm (char **buf, size_t *bufsize, dds_istream_t *is, uint32_t m_id, const uint32_t *ops, enum cdr_data_kind cdr_kind)
+static bool prtf_plm (char **buf, size_t *bufsize, dds_istream_t *is, uint32_t m_id, const uint32_t *ops, enum cdr_data_kind cdr_kind)
 {
   uint32_t insn, ops_csr = 0;
   bool found = false;
@@ -5930,7 +6177,7 @@ static bool prtf_xcdr2_plm (char **buf, size_t *bufsize, dds_istream_t *is, uint
     {
       assert (DDS_OP (plm_ops[0]) == DDS_OP_PLC);
       plm_ops++; /* skip PLC to go to first PLM from base type */
-      found = prtf_xcdr2_plm (buf, bufsize, is, m_id, plm_ops, cdr_kind);
+      found = prtf_plm (buf, bufsize, is, m_id, plm_ops, cdr_kind);
     }
     else if (ops[ops_csr + 1] == m_id)
     {
@@ -5941,6 +6188,39 @@ static bool prtf_xcdr2_plm (char **buf, size_t *bufsize, dds_istream_t *is, uint
     ops_csr += 2;
   }
   return found;
+}
+
+static const uint32_t *prtf_xcdr1_pl (char **buf, size_t *bufsize, dds_istream_t *is, const uint32_t *ops, enum cdr_data_kind cdr_kind)
+{
+  /* skip PLC op */
+  ops++;
+
+  bool paramlist_end;
+  do
+  {
+    uint32_t param_mid, param_len;
+    stream_read_xcdr1_paramheader (is, &param_mid, &param_len, &paramlist_end);
+    if (!paramlist_end)
+    {
+      // Move buffer in temporary istream `is1` to start of parameter value and
+      // set size to param length, so that alignment is reset to 0
+      dds_istream_t is1 = *is;
+      is1.m_buffer += is1.m_index;
+      is1.m_index = 0;
+      is1.m_size = param_len;
+
+      /* find member and deserialize; skip if not found */
+      (void) prtf_plm (buf, bufsize, &is1, param_mid, ops, cdr_kind);
+      is->m_index += param_len;
+    }
+  }
+  while (!paramlist_end);
+
+  /* skip all PLM-memberid pairs */
+  while (ops[0] != DDS_OP_RTS)
+    ops += 2;
+
+  return ops;
 }
 
 static const uint32_t *prtf_xcdr2_pl (char **buf, size_t *bufsize, dds_istream_t *is, const uint32_t *ops, enum cdr_data_kind cdr_kind)
@@ -5982,7 +6262,7 @@ static const uint32_t *prtf_xcdr2_pl (char **buf, size_t *bufsize, dds_istream_t
     const uint32_t next_off = is->m_index + msz + ((lc >= LENGTH_CODE_ALSO_NEXTINT) ? 4 : 0);
 #endif
     /* find member and deserialize */
-    if (!prtf_xcdr2_plm (buf, bufsize, is, m_id, ops, cdr_kind))
+    if (!prtf_plm (buf, bufsize, is, m_id, ops, cdr_kind))
     {
       is->m_index += msz;
       if (lc >= LENGTH_CODE_ALSO_NEXTINT)
@@ -6029,8 +6309,10 @@ static const uint32_t * dds_stream_print_sample1 (char **buf, size_t *bufsize, d
           ops = prtf_delimited_impl (buf, bufsize, is->m_size, is, ops, cdr_kind);
         break;
       case DDS_OP_PLC:
-        assert (is->m_xcdr_version == DDSI_RTPS_CDR_ENC_VERSION_2);
-        ops = prtf_xcdr2_pl (buf, bufsize, is, ops, cdr_kind);
+        if (is->m_xcdr_version == DDSI_RTPS_CDR_ENC_VERSION_2)
+          ops = prtf_xcdr2_pl (buf, bufsize, is, ops, cdr_kind);
+        else
+          ops = prtf_xcdr1_pl (buf, bufsize, is, ops, cdr_kind);
         break;
     }
   }
@@ -6411,22 +6693,31 @@ static const uint32_t *dds_stream_key_size_delimited (const uint32_t *ops, struc
   return ops;
 }
 
-static bool dds_stream_key_size_xcdr2_pl_member (const uint32_t *ops, struct key_props *k)
+static bool dds_stream_key_size_pl_member (const uint32_t *ops, struct key_props *k)
 {
   uint32_t flags = DDS_OP_FLAGS (ops[0]);
   bool is_key = flags & (DDS_OP_FLAG_MU | DDS_OP_FLAG_KEY);
   if (!is_key)
     return true;
 
+  // XCDR1 parameter header (extended) - as long as we don't write the short
+  // header, there is no need to take the alignment rules for PL-XCDR1 into
+  // account, because the extended header followed by the key value and the
+  // parameter list-end don't fit into 16 bytes, and the key size will be
+  // set to DDS_FIXED_KEY_MAX_SIZE
+  add_to_key_size_xcdrv1 (k, 4, 3, 4);
+
+  // XCDR2 member header
   uint32_t lc = get_length_code (ops);
   assert (lc <= LENGTH_CODE_ALSO_NEXTINT8);
-  add_to_key_size (k, 4, 1, 4);
+  add_to_key_size_xcdrv2 (k, 4, 1, 4);
   if (lc == LENGTH_CODE_NEXTINT)
-    add_to_key_size (k, 4, 1, 4);
+    add_to_key_size_xcdrv2 (k, 4, 1, 4);
+
   return dds_stream_key_size (ops, k);
 }
 
-static const uint32_t *dds_stream_key_size_xcdr2_pl_memberlist (const uint32_t *ops, struct key_props *k)
+static const uint32_t *dds_stream_key_size_pl_memberlist (const uint32_t *ops, struct key_props *k)
 {
   uint32_t insn;
   while (ops && (insn = *ops) != DDS_OP_RTS)
@@ -6440,12 +6731,12 @@ static const uint32_t *dds_stream_key_size_xcdr2_pl_memberlist (const uint32_t *
         {
           assert (plm_ops[0] == DDS_OP_PLC);
           plm_ops++; /* skip PLC op to go to first PLM for the base type */
-          if (!dds_stream_key_size_xcdr2_pl_memberlist (plm_ops, k))
+          if (!dds_stream_key_size_pl_memberlist (plm_ops, k))
             return NULL;
         }
         else
         {
-          if (!dds_stream_key_size_xcdr2_pl_member (plm_ops, k))
+          if (!dds_stream_key_size_pl_member (plm_ops, k))
             return NULL;
         }
         ops += 2;
@@ -6459,16 +6750,21 @@ static const uint32_t *dds_stream_key_size_xcdr2_pl_memberlist (const uint32_t *
   return ops;
 }
 
-static const uint32_t *dds_stream_key_size_xcdr2_pl (const uint32_t *ops, struct key_props *k)
+static const uint32_t *dds_stream_key_size_pl (const uint32_t *ops, struct key_props *k)
 {
   // skip PLC op
   ops++;
 
-  // add dheader size
-  add_to_key_size (k, 4, 1, 4);
+  // add dheader size for XCDR2
+  add_to_key_size_xcdrv2 (k, 4, 1, 4);
 
   // add members
-  return dds_stream_key_size_xcdr2_pl_memberlist (ops, k);
+  ops = dds_stream_key_size_pl_memberlist (ops, k);
+
+  // add parameter-list end for XCDR1
+  add_to_key_size_xcdrv1 (k, 4, 1, 4);
+
+  return ops;
 }
 
 static void dds_stream_key_size_prim_op (const uint32_t *ops, uint16_t key_offset_count, const uint32_t * key_offset_insn, struct key_props *k)
@@ -6545,7 +6841,7 @@ static const uint32_t *dds_stream_key_size (const uint32_t *ops, struct key_prop
         break;
       case DDS_OP_PLC:
         k->is_mutable = true;
-        ops = dds_stream_key_size_xcdr2_pl (ops, k);
+        ops = dds_stream_key_size_pl (ops, k);
         break;
     }
   }

--- a/src/core/cdr/src/dds_cdrstream.c
+++ b/src/core/cdr/src/dds_cdrstream.c
@@ -4326,8 +4326,6 @@ static enum normalize_xcdr1_paramheader_result stream_read_normalize_xcdr1_param
     uint32_t pid;
     if (!read_and_normalize_uint32 (&pid, data, off, size, bswap))
       return NPHR1_ERROR;
-    if (pid & DDS_XCDR1_PL_LONG_FLAG_IMPL_EXT)
-      return NPHR1_ERROR;
     *phdr_mid = pid & DDS_XCDR1_PL_LONG_MID_MASK;
     *must_understand = (pid & DDS_XCDR1_PL_LONG_FLAG_MU);
 

--- a/src/core/cdr/src/dds_cdrstream_write.part.h
+++ b/src/core/cdr/src/dds_cdrstream_write.part.h
@@ -43,28 +43,28 @@ static bool dds_stream_write_bitmask_valueBO (RESTRICT_OSTREAM_T *os, const stru
   {
     case 1: {
       const uint8_t *ptr = (const uint8_t *) addr;
-      if (!bitmask_value_valid (*ptr, bits_h, bits_l))
+      if (!bitmask_value_valid (0, *ptr, bits_h, bits_l))
         return false;
       dds_os_put1BO (os, allocator, *ptr);
       break;
     }
     case 2: {
       const uint16_t *ptr = (const uint16_t *) addr;
-      if (!bitmask_value_valid (*ptr, bits_h, bits_l))
+      if (!bitmask_value_valid (0, *ptr, bits_h, bits_l))
         return false;
       dds_os_put2BO (os, allocator, *ptr);
       break;
     }
     case 4: {
       const uint32_t *ptr = (const uint32_t *) addr;
-      if (!bitmask_value_valid (*ptr, bits_h, bits_l))
+      if (!bitmask_value_valid (0, *ptr, bits_h, bits_l))
         return false;
       dds_os_put4BO (os, allocator, *ptr);
       break;
     }
     case 8: {
       const uint64_t *ptr = (const uint64_t *) addr;
-      if (!bitmask_value_valid (*ptr, bits_h, bits_l))
+      if (!bitmask_value_valid ((uint32_t) (*ptr >> 32), (uint32_t) *ptr, bits_h, bits_l))
         return false;
       dds_os_put8BO (os, allocator, *ptr);
       break;
@@ -179,7 +179,7 @@ static bool dds_stream_write_bitmask_arrBO (RESTRICT_OSTREAM_T *os, const struct
       const uint8_t *ptr = (const uint8_t *) addr;
       for (uint32_t i = 0; i < num; i++)
       {
-        if (!bitmask_value_valid (ptr[i], bits_h, bits_l))
+        if (!bitmask_value_valid (0, ptr[i], bits_h, bits_l))
           return false;
         dds_os_put1BO (os, allocator, ptr[i]);
       }
@@ -189,7 +189,7 @@ static bool dds_stream_write_bitmask_arrBO (RESTRICT_OSTREAM_T *os, const struct
       const uint16_t *ptr = (const uint16_t *) addr;
       for (uint32_t i = 0; i < num; i++)
       {
-        if (!bitmask_value_valid (ptr[i], bits_h, bits_l))
+        if (!bitmask_value_valid (0, ptr[i], bits_h, bits_l))
           return false;
         dds_os_put2BO (os, allocator, ptr[i]);
       }
@@ -199,7 +199,7 @@ static bool dds_stream_write_bitmask_arrBO (RESTRICT_OSTREAM_T *os, const struct
       const uint32_t *ptr = (const uint32_t *) addr;
       for (uint32_t i = 0; i < num; i++)
       {
-        if (!bitmask_value_valid (ptr[i], bits_h, bits_l))
+        if (!bitmask_value_valid (0, ptr[i], bits_h, bits_l))
           return false;
         dds_os_put4BO (os, allocator, ptr[i]);
       }
@@ -209,7 +209,7 @@ static bool dds_stream_write_bitmask_arrBO (RESTRICT_OSTREAM_T *os, const struct
       const uint64_t *ptr = (const uint64_t *) addr;
       for (uint32_t i = 0; i < num; i++)
       {
-        if (!bitmask_value_valid (ptr[i], bits_h, bits_l))
+        if (!bitmask_value_valid ((uint32_t) (ptr[i] >> 32), (uint32_t) ptr[i], bits_h, bits_l))
           return false;
         dds_os_put8BO (os, allocator, ptr[i]);
       }

--- a/src/core/cdr/src/dds_cdrstream_write.part.h
+++ b/src/core/cdr/src/dds_cdrstream_write.part.h
@@ -563,7 +563,8 @@ static void dds_stream_write_xcdr1_paramheaderBO (RESTRICT_OSTREAM_T *os, const 
 
 static void dds_stream_write_xcdr1_param_list_endBO (RESTRICT_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator)
 {
-  uint16_t phdr = DDS_XCDR1_PL_SHORT_PID_LIST_END;
+  // XTypes 1.3 table 34: must understand should be set in generated CDR
+  uint16_t phdr = DDS_XCDR1_PL_SHORT_FLAG_MU | DDS_XCDR1_PL_SHORT_PID_LIST_END;
   uint16_t slen = 0;
 
   dds_cdr_alignto_clear_and_resize_base (&os->x, allocator, dds_cdr_get_align (os->x.m_xcdr_version, 4), 4);

--- a/src/core/cdr/test/mem_ser.h
+++ b/src/core/cdr/test/mem_ser.h
@@ -77,4 +77,7 @@
 #define SER_EMHEADER(mu,lc,mid) SER32(((mu) ? (1u << 31) : 0) + ((uint32_t) (lc) << 28) + ((uint32_t) (mid) & 0x0fffffff))
 #define SER_NEXTINT(l) SER32(l)
 
+#define SER_PHDR_EXT(mu,len,mid) SER16(DDS_XCDR1_PL_SHORT_PID_EXTENDED), SER16(8), SER32(((mu) ? DDS_XCDR1_PL_LONG_FLAG_MU : 0) + ((uint32_t) (mid) & DDS_XCDR1_PL_LONG_MID_MASK)), SER32(len)
+#define SER_PHDR_END() SER16(DDS_XCDR1_PL_SHORT_PID_LIST_END), SER16(0)
+
 #endif /* DDSI_TEST_MEM_SER_H */

--- a/src/core/cdr/test/mem_ser.h
+++ b/src/core/cdr/test/mem_ser.h
@@ -77,7 +77,7 @@
 #define SER_EMHEADER(mu,lc,mid) SER32(((mu) ? (1u << 31) : 0) + ((uint32_t) (lc) << 28) + ((uint32_t) (mid) & 0x0fffffff))
 #define SER_NEXTINT(l) SER32(l)
 
-#define SER_PHDR_EXT(mu,len,mid) SER16(DDS_XCDR1_PL_SHORT_PID_EXTENDED), SER16(8), SER32(((mu) ? DDS_XCDR1_PL_LONG_FLAG_MU : 0) + ((uint32_t) (mid) & DDS_XCDR1_PL_LONG_MID_MASK)), SER32(len)
-#define SER_PHDR_END() SER16(DDS_XCDR1_PL_SHORT_PID_LIST_END), SER16(0)
+#define SER_PHDR_EXT(mu,len,mid) SER16(DDS_XCDR1_PL_SHORT_PID_EXTENDED | DDS_XCDR1_PL_SHORT_FLAG_MU), SER16(8), SER32(((mu) ? DDS_XCDR1_PL_LONG_FLAG_MU : 0) + ((uint32_t) (mid) & DDS_XCDR1_PL_LONG_MID_MASK)), SER32(len)
+#define SER_PHDR_END() SER16(DDS_XCDR1_PL_SHORT_PID_LIST_END | DDS_XCDR1_PL_SHORT_FLAG_MU), SER16(0)
 
 #endif /* DDSI_TEST_MEM_SER_H */

--- a/src/core/ddsc/src/dds_serdata_default.c
+++ b/src/core/ddsc/src/dds_serdata_default.c
@@ -228,7 +228,8 @@ static struct dds_serdata_default *serdata_default_new (const struct dds_sertype
 
 static inline bool is_valid_xcdr1_id (unsigned short cdr_identifier)
 {
-  return (cdr_identifier == DDSI_RTPS_CDR_LE || cdr_identifier == DDSI_RTPS_CDR_BE);
+  return (cdr_identifier == DDSI_RTPS_CDR_LE || cdr_identifier == DDSI_RTPS_CDR_BE
+    || cdr_identifier == DDSI_RTPS_PL_CDR_LE || cdr_identifier == DDSI_RTPS_PL_CDR_BE);
 }
 
 static inline bool is_valid_xcdr2_id (unsigned short cdr_identifier)

--- a/src/core/ddsc/tests/SerdataData.idl
+++ b/src/core/ddsc/tests/SerdataData.idl
@@ -87,6 +87,20 @@ struct SerdataKeyOrderFinalNestedMutable {
     @id(1) @key SerdataKeyOrderMutable z;
 };
 
+@final
+struct SerdataKeyOrderFinalNestedNonKeyMutable {
+    @id(3) @key uint8 x;
+    @id(2) uint8 y;
+    @id(1) SerdataKeyOrderMutable z;
+};
+
+@final
+struct SerdataKeyOrderFinalNestedNonKeyAppendable {
+    @id(3) @key uint8 x;
+    @id(2) uint8 y;
+    @optional @id(1) SerdataKeyOrderAppendable z;
+};
+
 @appendable
 struct SerdataKeyOrderAppendableNestedMutable {
     @id(3) @key uint8 x;

--- a/src/core/ddsc/tests/cdrstream.c
+++ b/src/core/ddsc/tests/cdrstream.c
@@ -2159,7 +2159,7 @@ CU_Test (ddsc_cdrstream, check_xcdr1_param_normalize)
     { D(t2), false, CDR(PHDR(321, 0),            PHDR(124, 0) ) },             // invalid, incorrect member id
     { D(t2), true,  CDR(PHDR(321, 1), 8,1, PAD3, PHDR_EXT(123, 4), 32,1 ) },   // valid, short/extended header, present
     { D(t2), true,  CDR(PHDR_EXT(321, 0),        PHDR_EXT(123, 0) ) },         // valid, extended header, not-present
-    { D(t2), false, CDR(PHDR(321, 0),            PHDR(DDS_XCDR1_PL_SHORT_FLAG_IMPL_EXT & DDS_XCDR1_PL_SHORT_PID_EXTENDED, 8), 32,123, 32,4, 32,1) },   // invalid extended header: impl_ext flag set
+    { D(t2), false, CDR(PHDR(321, 0),            PHDR(DDS_XCDR1_PL_SHORT_FLAG_IMPL_EXT | DDS_XCDR1_PL_SHORT_PID_EXTENDED, 8), 32,123, 32,4, 32,1) },   // invalid extended header: impl_ext flag set
 
     { D(t3), true,  CDR(PHDR(10, 1), 8,1, PAD3, PHDR(99, 9), 32,5, 8,'a', 8,'b', 8,'c', 8,'d', 8,'\0', PAD3, PHDR(100, 8), 64,1) },          // valid, present
     { D(t3), true,  CDR(PHDR_EXT(10, 1), 8,1, PAD3, PHDR_EXT(99, 9), 32,5, 8,'a', 8,'b', 8,'c', 8,'d', 8,'\0', PAD3, PHDR(100, 8), 64,1) },  // valid, short/extended header, present

--- a/src/core/ddsc/tests/cdrstream.c
+++ b/src/core/ddsc/tests/cdrstream.c
@@ -1744,7 +1744,7 @@ CU_Test (ddsc_cdrstream, check_normalize_boolean)
 #define XCDR2 DDSI_RTPS_CDR_ENC_VERSION_2
 
 #define PHDR(pid,plen) 16,(pid),16,(plen)
-#define PHDR_EXT(pid,plen) PHDR(DDS_XCDR1_PL_SHORT_PID_EXTENDED, 8), 32,(pid), 32,(plen)
+#define PHDR_EXT(pid,plen) PHDR(DDS_XCDR1_PL_SHORT_PID_EXTENDED | DDS_XCDR1_PL_SHORT_FLAG_MU, 8), 32,(pid), 32,(plen)
 
 struct test_cdr_params {
   const dds_topic_descriptor_t *desc;
@@ -2147,7 +2147,8 @@ CU_Test (ddsc_cdrstream, check_xcdr1_param_normalize)
     { D(t1), true,  CDR(PHDR(0, 0)) },         // valid, not present
 
     { D(t1), false, CDR(PHDR(DDS_XCDR1_PL_SHORT_PID_EXTENDED, 6), 32,0, 32,4, 32,1) },   // extended header: incorrect slen for extended header (should be 8)
-    { D(t1), false, CDR(PHDR(~DDS_XCDR1_PL_SHORT_FLAG_MU & DDS_XCDR1_PL_SHORT_PID_EXTENDED, 8), 32,0, 32,4, 32,1) },   // extended header: MU flag missing
+    { D(t1), true, CDR(PHDR(DDS_XCDR1_PL_SHORT_PID_EXTENDED, 8), 32,0, 32,4, 32,1) },   // extended header: MU flag missing
+    { D(t1), true, CDR(PHDR(DDS_XCDR1_PL_SHORT_FLAG_MU | DDS_XCDR1_PL_SHORT_PID_EXTENDED, 8), 32,0, 32,4, 32,1) },   // extended header: MU flag present
     { D(t1), false, CDR(PHDR_EXT(1, 4), 32,1) },   // extended header: incorrect member id
     { D(t1), false, CDR(PHDR_EXT(1, 2), 16,1) },   // extended header: incorrect member length
     { D(t1), true,  CDR(PHDR_EXT(0, 4), 32,1) },   // extended header: valid, present

--- a/src/core/ddsc/tests/data_representation.c
+++ b/src/core/ddsc/tests/data_representation.c
@@ -395,24 +395,24 @@ CU_Test(ddsc_data_representation, data_type_props, .init = data_representation_i
     { &DESC(TypeAppendable),       { X2,   true, X2 },   { X1,   true,  X1 },  { X2,   true,  X2 } },
     { &DESC(TypeAppendable),       { X2,   true, X2 },   { X2_1, true,  X2_1 },{ X2_1, true,  X2 } },
 
-    { &DESC(TypeMutable),          { X_,   true,  X2 },  { X_,   true,  X2 },  { X_,   true,  X2 } },
-    { &DESC(TypeMutable),          { X2_1, false, X_ },  { X_,   false, X_ },  { X_,   false, X_ } },
+    { &DESC(TypeMutable),          { X_,   true,  X2_1 },{ X_,   true,  X2_1 },{ X_,   true,  X2 } },
+    { &DESC(TypeMutable),          { X2_1, true,  X2_1 },{ X_,   true,  X2_1 },{ X_,   true,  X2 } },
     { &DESC(TypeMutable),          { X2,   true,  X2 },  { X_,   true,  X2 },  { X_,   true,  X2 } },
 
     { &DESC(TypeNestedAppendable), { X_,   true,  X2 },  { X_,   true,  X2 },  { X_,   true,  X2 } },
     { &DESC(TypeNestedAppendable), { X2_1, false, X_ },  { X_,   false, X_ },  { X_,   false, X_ } },
     { &DESC(TypeNestedAppendable), { X2,   true,  X2 },  { X_,   true,  X2 },  { X_,   true,  X2 } },
 
-    { &DESC(TypeNestedMutable),    { X_,   true,  X2 },  { X_,   true,  X2 },  { X_,   true,  X2 } },
-    { &DESC(TypeNestedMutable),    { X2_1, false, X_ },  { X_,   false, X_ },  { X_,   false, X_ } },
+    { &DESC(TypeNestedMutable),    { X_,   true,  X2_1 },{ X_,   true,  X2_1 },{ X_,   true,  X2 } },
+    { &DESC(TypeNestedMutable),    { X2_1, true,  X2_1 },{ X_,   true,  X2_1 },{ X_,   true,  X2 } },
     { &DESC(TypeNestedMutable),    { X2,   true,  X2 },  { X_,   true,  X2 },  { X_,   true,  X2 } },
 
-    { &DESC(TypeNestedMutableArr), { X_,   true,  X2 },  { X_,   true,  X2 },  { X_,   true,  X2 } },
-    { &DESC(TypeNestedMutableArr), { X1,   false, X_ },  { X_,   false, X_ },  { X_,   false, X_ } },
-    { &DESC(TypeNestedMutableSeq), { X_,   true,  X2 },  { X_,   true,  X2 },  { X_,   true,  X2 } },
-    { &DESC(TypeNestedMutableSeq), { X1,   false, X_ },  { X_,   false, X_ },  { X_,   false, X_ } },
-    { &DESC(TypeNestedMutableUni), { X_,   true,  X2 },  { X_,   true,  X2 },  { X_,   true,  X2 } },
-    { &DESC(TypeNestedMutableUni), { X1,   false, X_ },  { X_,   false, X_ },  { X_,   false, X_ } }
+    { &DESC(TypeNestedMutableArr), { X_,   true,  X2_1 },{ X_,   true,  X2_1 },{ X_,   true,  X2 } },
+    { &DESC(TypeNestedMutableArr), { X1,   true,  X1 },  { X_,   true,  X1 },  { X_,   true,  X1 } },
+    { &DESC(TypeNestedMutableSeq), { X_,   true,  X2_1 },{ X_,   true,  X2_1 },{ X_,   true,  X2 } },
+    { &DESC(TypeNestedMutableSeq), { X1,   true,  X1 },  { X_,   true,  X1 },  { X_,   true,  X1 } },
+    { &DESC(TypeNestedMutableUni), { X_,   true,  X2_1 },{ X_,   true,  X2_1 },{ X_,   true,  X2 } },
+    { &DESC(TypeNestedMutableUni), { X1,   true,  X1 },  { X_,   true,  X1 },  { X_,   true,  X1 } }
   };
 #undef X_
 #undef X1

--- a/src/core/ddsi/src/ddsi_sertype.c
+++ b/src/core/ddsi/src/ddsi_sertype.c
@@ -271,6 +271,7 @@ uint32_t ddsi_sertype_enc_id_xcdr_version (uint16_t cdr_identifier)
   switch (cdr_identifier)
   {
     case DDSI_RTPS_CDR_LE: case DDSI_RTPS_CDR_BE:
+    case DDSI_RTPS_PL_CDR_LE: case DDSI_RTPS_PL_CDR_BE:
       return DDSI_RTPS_CDR_ENC_VERSION_1;
     case DDSI_RTPS_CDR2_LE: case DDSI_RTPS_CDR2_BE:
     case DDSI_RTPS_D_CDR2_LE: case DDSI_RTPS_D_CDR2_BE:
@@ -290,6 +291,7 @@ uint32_t ddsi_sertype_enc_id_enc_format (uint16_t cdr_identifier)
       return DDSI_RTPS_CDR_ENC_FORMAT_PLAIN;
     case DDSI_RTPS_D_CDR2_LE: case DDSI_RTPS_D_CDR2_BE:
       return DDSI_RTPS_CDR_ENC_FORMAT_DELIMITED;
+    case DDSI_RTPS_PL_CDR_LE: case DDSI_RTPS_PL_CDR_BE:
     case DDSI_RTPS_PL_CDR2_LE: case DDSI_RTPS_PL_CDR2_BE:
       return DDSI_RTPS_CDR_ENC_FORMAT_PL;
     default:

--- a/src/tools/idlc/xtests/main.c
+++ b/src/tools/idlc/xtests/main.c
@@ -45,11 +45,11 @@ static void print_raw_cdr (dds_ostream_t *os)
   printf("\n");
 }
 
-int rd_cmp_print_key (dds_ostream_t *os, const void *msg_wr, struct dds_cdrstream_desc *cdrstream_desc)
+int rd_cmp_print_key (dds_ostream_t *os, const void *msg_wr, struct dds_cdrstream_desc *cdrstream_desc, uint32_t xcdrv)
 {
   int res;
   char buf[99999];
-  dds_istream_t is = { os->m_buffer, os->m_size, 0, DDSI_RTPS_CDR_ENC_VERSION_2 };
+  dds_istream_t is = { os->m_buffer, os->m_size, 0, xcdrv };
 
   // read
   void *msg_rd = ddsrt_calloc (1, desc->m_size);
@@ -80,102 +80,108 @@ int main(int argc, char **argv)
   struct dds_cdrstream_desc cdrstream_desc;
   init_desc (&cdrstream_desc);
 
-  enum { LE, BE } tests[2] = { LE, BE };
-  for (size_t i = 0; i < sizeof (tests) / sizeof (tests[0]); i++)
+  enum byte_order { LE, BE } test_bo[2] = { LE, BE };
+  uint16_t min_xcdrv = dds_stream_minimum_xcdr_version (cdrstream_desc.ops.ops);
+
+  for (uint32_t xcdrv = min_xcdrv; xcdrv <= DDSI_RTPS_CDR_ENC_VERSION_2; xcdrv++)
   {
-    char buf[99999];
-
-    // init data
-    void *msg_wr = ddsrt_malloc (desc->m_size);
-    memset (msg_wr, 0xdd, desc->m_size);
-    init_sample(msg_wr);
-
-    // write data
-    printf("cdr write %s\n", tests[i] == BE ? "BE" : "LE");
-    dds_ostream_t os = { NULL, 0, 0, DDSI_RTPS_CDR_ENC_VERSION_2 };
-    bool ret;
-    if (tests[i] == BE)
-      ret = dds_stream_write_sampleBE ((dds_ostreamBE_t *)(&os), &dds_cdrstream_default_allocator, msg_wr, &cdrstream_desc);
-    else
-      ret = dds_stream_write_sampleLE ((dds_ostreamLE_t *)(&os), &dds_cdrstream_default_allocator, msg_wr, &cdrstream_desc);
-    if (!ret)
+    for (size_t b = 0; b < sizeof (test_bo) / sizeof (test_bo[0]); b++)
     {
-      printf("cdr write failed\n");
-      return 1;
-    }
-    printf("sample data cdr:\n");
-    print_raw_cdr (&os);
+      enum byte_order bo = test_bo[b];
+      char buf[99999];
 
-    dds_istream_t is = { os.m_buffer, os.m_size, 0, DDSI_RTPS_CDR_ENC_VERSION_2 };
+      // init data
+      void *msg_wr = ddsrt_malloc (desc->m_size);
+      memset (msg_wr, 0xdd, desc->m_size);
+      init_sample(msg_wr);
 
-    // normalize sample
-    uint32_t actual_size = 0;
-    bool swap = (DDSRT_ENDIAN == DDSRT_LITTLE_ENDIAN) ? (tests[i] == BE) : (tests[i] == LE);
-    printf("cdr normalize (%sswap)\n", swap ? "" : "no ");
-    if (!dds_stream_normalize ((void *)is.m_buffer, os.m_index, swap, DDSI_RTPS_CDR_ENC_VERSION_2, &cdrstream_desc, false, &actual_size))
-    {
-      printf("cdr normalize failed\n");
-      return 1;
-    }
-    if (actual_size != os.m_index)
-    {
-      printf("cdr normalize size invalid (actual: %u, expected: %u)\n", actual_size, os.m_index);
-      return 1;
-    }
-
-    // read data and check for expected result
-    printf("cdr read data\n");
-    void *msg_rd = ddsrt_calloc (1, desc->m_size);
-    dds_stream_read_sample (&is, msg_rd, &dds_cdrstream_default_allocator, &cdrstream_desc);
-    res = cmp_sample(msg_wr, msg_rd);
-    printf("data compare result: %d\n", res);
-
-    // print sample
-    is.m_index = 0;
-    (void) dds_stream_print_sample (&is, &cdrstream_desc, buf, sizeof (buf));
-    printf("sample: %s\n", buf);
-
-    if (res == 0 && cdrstream_desc.keys.nkeys > 0)
-    {
-      // extract key from data
-      is.m_index = 0;
-      dds_ostream_t os_key_from_data = { NULL, 0, 0, DDSI_RTPS_CDR_ENC_VERSION_2 };
-      if (!dds_stream_extract_key_from_data (&is, &os_key_from_data, &dds_cdrstream_default_allocator, &cdrstream_desc))
+      // write data
+      printf("cdr write XCDR%u/%s\n", xcdrv, bo == BE ? "BE" : "LE");
+      dds_ostream_t os = { NULL, 0, 0, xcdrv };
+      bool ret;
+      if (bo == BE)
+        ret = dds_stream_write_sampleBE ((dds_ostreamBE_t *)(&os), &dds_cdrstream_default_allocator, msg_wr, &cdrstream_desc);
+      else
+        ret = dds_stream_write_sampleLE ((dds_ostreamLE_t *)(&os), &dds_cdrstream_default_allocator, msg_wr, &cdrstream_desc);
+      if (!ret)
       {
-        printf("extract key from data failed\n");
+        printf("cdr write failed\n");
         return 1;
       }
-      printf("key cdr:\n");
-      print_raw_cdr (&os_key_from_data);
+      printf("sample data cdr:\n");
+      print_raw_cdr (&os);
 
-      res = rd_cmp_print_key (&os_key_from_data, msg_wr, &cdrstream_desc);
+      dds_istream_t is = { os.m_buffer, os.m_size, 0, xcdrv };
+
+      // normalize sample
+      uint32_t actual_size = 0;
+      bool swap = (DDSRT_ENDIAN == DDSRT_LITTLE_ENDIAN) ? (bo == BE) : (bo == LE);
+      printf("cdr normalize (%sswap)\n", swap ? "" : "no ");
+      if (!dds_stream_normalize ((void *)is.m_buffer, os.m_index, swap, xcdrv, &cdrstream_desc, false, &actual_size))
+      {
+        printf("cdr normalize failed\n");
+        return 1;
+      }
+      if (actual_size != os.m_index)
+      {
+        printf("cdr normalize size invalid (actual: %u, expected: %u)\n", actual_size, os.m_index);
+        return 1;
+      }
+
+      // read data and check for expected result
+      printf("cdr read data\n");
+      void *msg_rd = ddsrt_calloc (1, desc->m_size);
+      dds_stream_read_sample (&is, msg_rd, &dds_cdrstream_default_allocator, &cdrstream_desc);
+      res = cmp_sample(msg_wr, msg_rd);
+      printf("data compare result: %d\n", res);
+
+      // print sample
+      is.m_index = 0;
+      (void) dds_stream_print_sample (&is, &cdrstream_desc, buf, sizeof (buf));
+      printf("sample: %s\n", buf);
+
+      if (res == 0 && cdrstream_desc.keys.nkeys > 0)
+      {
+        // extract key from data
+        is.m_index = 0;
+        dds_ostream_t os_key_from_data = { NULL, 0, 0, xcdrv };
+        if (!dds_stream_extract_key_from_data (&is, &os_key_from_data, &dds_cdrstream_default_allocator, &cdrstream_desc))
+        {
+          printf("extract key from data failed\n");
+          return 1;
+        }
+        printf("key cdr:\n");
+        print_raw_cdr (&os_key_from_data);
+
+        res = rd_cmp_print_key (&os_key_from_data, msg_wr, &cdrstream_desc, xcdrv);
+        if (res != 0)
+          break;
+
+        // write key
+        dds_ostream_t os_wr_key = { NULL, 0, 0, xcdrv };
+        if (!dds_stream_write_key (&os_wr_key, DDS_CDR_KEY_SERIALIZATION_SAMPLE, &dds_cdrstream_default_allocator, msg_wr, &cdrstream_desc))
+        {
+          printf("write key failed\n");
+          return 1;
+        }
+
+        // extract key from key
+        dds_istream_t is_key_from_key = { os_wr_key.m_buffer, os_wr_key.m_size, 0, xcdrv };
+        dds_ostream_t os_key_from_key = { NULL, 0, 0, xcdrv };
+        dds_stream_extract_key_from_key (&is_key_from_key, &os_key_from_key, DDS_CDR_KEY_SERIALIZATION_SAMPLE, &dds_cdrstream_default_allocator, &cdrstream_desc);
+        res = rd_cmp_print_key (&os_key_from_key, msg_wr, &cdrstream_desc, xcdrv);
+
+        dds_ostream_fini (&os_key_from_data, &dds_cdrstream_default_allocator);
+        dds_ostream_fini (&os_key_from_key, &dds_cdrstream_default_allocator);
+        dds_ostream_fini (&os_wr_key, &dds_cdrstream_default_allocator);
+      }
+
+      dds_ostream_fini (&os, &dds_cdrstream_default_allocator);
+      free_sample(msg_wr);
+      free_sample(msg_rd);
       if (res != 0)
         break;
-
-      // write key
-      dds_ostream_t os_wr_key = { NULL, 0, 0, DDSI_RTPS_CDR_ENC_VERSION_2 };
-      if (!dds_stream_write_key (&os_wr_key, DDS_CDR_KEY_SERIALIZATION_SAMPLE, &dds_cdrstream_default_allocator, msg_wr, &cdrstream_desc))
-      {
-        printf("write key failed\n");
-        return 1;
-      }
-
-      // extract key from key
-      dds_istream_t is_key_from_key = { os_wr_key.m_buffer, os_wr_key.m_size, 0, DDSI_RTPS_CDR_ENC_VERSION_2 };
-      dds_ostream_t os_key_from_key = { NULL, 0, 0, DDSI_RTPS_CDR_ENC_VERSION_2 };
-      dds_stream_extract_key_from_key (&is_key_from_key, &os_key_from_key, DDS_CDR_KEY_SERIALIZATION_SAMPLE, &dds_cdrstream_default_allocator, &cdrstream_desc);
-      res = rd_cmp_print_key (&os_key_from_key, msg_wr, &cdrstream_desc);
-
-      dds_ostream_fini (&os_key_from_data, &dds_cdrstream_default_allocator);
-      dds_ostream_fini (&os_key_from_key, &dds_cdrstream_default_allocator);
-      dds_ostream_fini (&os_wr_key, &dds_cdrstream_default_allocator);
     }
-
-    dds_ostream_fini (&os, &dds_cdrstream_default_allocator);
-    free_sample(msg_wr);
-    free_sample(msg_rd);
-    if (res != 0)
-      break;
   }
 
   dds_cdrstream_desc_fini (&cdrstream_desc, &dds_cdrstream_default_allocator);


### PR DESCRIPTION
This adds support for XCDR1 (de)serialization of mutable types in the CDR stream serializer and also includes a few related changes:

- The serialization order for the CDR used to calculate the keyhash for an XCDR1 endpoint now always uses the member IDs (if present)
- The extract_key_from_data functions for the optimized path are simplified, because a type with keys in appendable or mutable nested types will be handled in the non-optimized path
- The IDLC xtests are updated so that these also do a run with XCDR1
- Update cdrstream `get_ops_info` so that appendable or mutable aggregated types used in recursion are correctly detected

Some of the CI builds fail on the `idlc_test_bitmask` test with a "load of misaligned address for type 'uint64_t'", which may be a result of the XCDR1 alignment rules for parameter payload? (but I don't really understand why this error is not triggered for XCDR2, which also has max 4-byte alignment..)

**Note that this PR includes the commits of #2259** 