### PR TITLE
Contribute to documentation for IDL formatting.

### DIFF
--- a/docs/manual/_static/css/helpers.css
+++ b/docs/manual/_static/css/helpers.css
@@ -74,3 +74,8 @@ dl:not(.c):not(.cpp):not(.py):not(.simple) > dd {
     /* Don't indent top-level code */
     margin-inline-start: 0;
 }
+
+/* Sphinx tabs extension style adjustments */
+.sphinx-tabs-panel {
+    background: rgba(36, 36, 41, 0.0);
+}

--- a/docs/manual/about_dds/eclipse_cyclone_dds.rst
+++ b/docs/manual/about_dds/eclipse_cyclone_dds.rst
@@ -27,7 +27,6 @@
    waitset
    status
    performance
-   idl
    ddsi_concepts
    contributing
 

--- a/docs/manual/external-links.part.rst
+++ b/docs/manual/external-links.part.rst
@@ -200,3 +200,7 @@
 .. |url::omg_xml_1.0| raw:: html
 
     <a href="https://www.omg.org/spec/DDS-XML/1.0/" target="_blank">DDS Consolidated XML Syntax</a>
+
+.. |url::omg_idl_4.2| raw:: html
+
+    <a href="https://www.omg.org/spec/IDL/4.2/" target="_blank">OMG IDL 4.2</a>

--- a/docs/manual/idl/about.rst
+++ b/docs/manual/idl/about.rst
@@ -1,16 +1,17 @@
-.. index:: IDL
+.. include:: ../external-links.part.rst
 
 .. _idl_bm:
 
-===
-IDL
-===
+###################################
+IDL (Interface Definition Language)
+###################################
 
 .. toctree::
    :maxdepth: 1
    :hidden:
 
-   idl_compilers
+   compiler
+   syntax
 
 IDL is a language to defined data types and interfaces that are platform and language 
 agnostic. There are tools that have been developed to then consume that IDL and emit 
@@ -73,3 +74,4 @@ For example, the following IDL code:
             message: str
 
 See also: :ref:`helloworld_idl`.
+

--- a/docs/manual/idl/compiler.rst
+++ b/docs/manual/idl/compiler.rst
@@ -4,7 +4,7 @@
 
 .. _idl_compiler:
 
-IDL compiler
+IDL Compiler
 ============
 
 The |var-project-short| IDL compiler translates module names into namespaces 

--- a/docs/manual/idl/syntax.rst
+++ b/docs/manual/idl/syntax.rst
@@ -1,0 +1,262 @@
+.. include:: ../external-links.part.rst
+
+.. index:: IDL; syntax format
+
+.. _idl_syntax:
+
+##########
+IDL Syntax
+##########
+
+|var-project| follows the |url::omg_idl_4.2| specification for its IDL syntax.
+
+.. _idl_comment_syntax:
+
+**************
+Comment Syntax
+**************
+
+IDL supports single-line and multi-line comments in a similar fashion to C/C++.
+
+Single-line comments start with `//` and continue to the end of the line.
+
+Multi-line comments are enclosed in `/*` and `*/`.
+
+.. code-block:: shell
+
+  // This is a single-line comment
+  /* This is a multi-line comment
+    that spans multiple lines */
+
+
+.. _idl_include_file:
+
+********************
+Including Other IDLs
+********************
+
+You can include other IDL files using the `#include` directive. This allows you to reuse type definitions across multiple IDL files.
+
+.. code-block:: shell
+
+   #include "OtherFile.idl"
+
+.. _idl_primitive_types:
+
+***************
+Primitive Types
+***************
+
+The table below shows the primitive types supported by the IDL compiler for both C/C++ and Python. Some aliases are defined, but only for primitive types
+
+.. list-table::
+  :align: left
+  :header-rows: 1
+  :widths: 20 20 20 40
+
+  * - IDL Type
+    - Aliases
+    - C/C++11 Types
+    - Description
+  * - ``boolean``
+    - ``n/a``
+    - ``bool``
+    - Boolean type, true or false
+  * - ``char``
+    - ``n/a``
+    - ``char``
+    - 8-bit character
+  * - ``octet``
+    - ``uint8``
+    - ``uint8_t``
+    - 8-bit unsigned integer
+  * - ``short``
+    - ``int16``
+    - ``int16_t``
+    - 16-bit unsigned integer
+  * - ``unsigned short``
+    - ``uint16``
+    - ``uint16_t``
+    - 16-bit unsigned integer
+  * - ``long``
+    - ``int32``
+    - ``int32_t``
+    - 32-bit signed integer
+  * - ``unsigned long``
+    - ``uint32``
+    - ``uint32_t``
+    - 32-bit unsigned integer
+  * - ``long long``
+    - ``int64``
+    - ``int64_t``
+    - 64-bit signed integer
+  * - ``unsigned long long``
+    - ``uint64``
+    - ``uint64_t``
+    - 64-bit unsigned integer
+  * - ``float``
+    - ``n/a``
+    - ``float``
+    - 32-bit floating point number
+  * - ``double``
+    - ``n/a``
+    - ``double``
+    - 64-bit floating point number
+  * - ``string``
+    - ``n/a``
+    - ``std::string``
+    - UTF-8 encoded string
+
+.. _idl_arrays:
+
+******
+Arrays
+******
+
+Arrays in IDL are defined using the syntax `type name[size]`, where `type` is the element type, `name` is the name of the variable, and `size` is the number of elements. For dynamically sized arrarys, see :ref:`idl_sequences`.
+
+.. list-table::
+  :align: left
+  :header-rows: 1
+  :widths: 50 50
+
+  * - IDL Type
+    - C/C++11 Types
+  * - ``char a[5]``
+    - ``std::array<char, 5> a``
+  * - ``octet a[5]``
+    - ``std::array<uint8_t, 5> a``
+  * - ``short a[5]``
+    - ``std::array<int16_t, 5> a``
+  * - ``unsigned short a[5]``
+    - ``std::array<uint16_t, 5> a``
+  * - ``long a[5]``
+    - ``std::array<int32_t, 5> a``
+  * - ``unsigned long a[5]``
+    - ``std::array<uint32_t, 5> a``
+  * - ``long long a[5]``
+    - ``std::array<int64_t, 5> a``
+  * - ``unsigned long long a[5]``
+    - ``std::array<uint64_t, 5> a``
+  * - ``float a[5]``
+    - ``std::array<float, 5> a``
+  * - ``double a[5]``
+    - ``std::array<double, 5> a``
+
+.. _idl_sequences:
+
+*********
+Sequences
+*********
+
+Sequences in IDL are mapped to an `std::vector` like structure. They can grow and shrink dynamically, and their size is not fixed at compile time.
+
+.. list-table::
+  :align: left
+  :header-rows: 1
+  :widths: 50 50
+
+  * - IDL Type
+    - C/C++11 Types
+  * - ``boolean``
+    - ``bool``
+  * - ``sequence<char>``
+    - ``std::vector<char>``
+  * - ``sequence<octet>``
+    - ``std::vector<uint8_t>``
+  * - ``sequence<short>``
+    - ``std::vector<int16_t>``
+  * - ``sequence<unsigned short>``
+    - ``std::vector<uint16_t>``
+  * - ``sequence<long>``
+    - ``std::vector<int32_t>``
+  * - ``sequence<unsigned long>``
+    - ``std::vector<uint32_t>``
+  * - ``sequence<long long>``
+    - ``std::vector<int64_t>``
+  * - ``sequence<unsigned long long>``
+    - ``std::vector<uint64_t>``
+  * - ``sequence<float>``
+    - ``std::vector<float>``
+  * - ``sequence<double>``
+    - ``std::vector<double>``
+
+.. _idl_maps:
+
+****
+Maps
+****
+
+Maps in IDL are defined using the `map<key_type, value_type>` syntax, where `key_type` is the type of the keys and `value_type` is the type of the values. They are typically implemented as a `std::map` in C++.
+
+.. list-table::
+  :align: left
+  :header-rows: 1
+  :widths: 50 50
+
+  * - IDL Type
+    - C/C++11 Types
+  * - ``map<char, long>``
+    - ``std::map<char, int64_t>``
+
+.. _idl_enumerations:
+
+************
+Enumerations
+************
+
+Enumerations are typically used to define a set of named constants. In IDL, it is defined using the `enum` keyword followed by the name and a list of enumerators, and is mapped directly to a C++ enum.
+
+The following IDL definition:
+
+.. code-block:: shell
+
+  enum Color
+  {
+    RED,
+    YELLOW,
+    @value(3)
+    BLUE
+  };
+
+Would be converted to the following C++ code:
+
+.. code-block:: C++
+
+  enum class Color
+  {
+    RED,
+    YELLOW,
+    BLUE = 3
+  };
+
+.. _idl_bitmasks:
+
+********
+Bitmasks
+********
+
+Bitmasks in IDL are a special kind of enumeration defined using the `bitmask` keyword followed by the name and the underlying type. They are typically used to represent a set of flags in binary form.
+
+For example, the following IDL definition:
+
+.. code-block:: shell
+
+  @bit_bound(8)
+  bitmask MyFlags : unsigned long
+  {
+    FLAG_ONE = 0x1,
+    FLAG_TWO = 0x2,
+    FLAG_THREE = 0x4
+  };
+
+Would be converted to the following C++ code:
+
+.. code-block:: C++
+
+  enum class MyFlags : uint32_t
+  {
+    FLAG_ONE = 0x1,
+    FLAG_TWO = 0x2,
+    FLAG_THREE = 0x4
+  };

--- a/docs/manual/index.rst
+++ b/docs/manual/index.rst
@@ -20,6 +20,7 @@
    :maxdepth: 1
 
    about_dds/eclipse_cyclone_dds
+   idl/about
    installation/installation
    getting_started/index
    config/index


### PR DESCRIPTION
Hi, long-time user, but first time contributor, hopefully not the last!

I'm proposing to add two changes, let me know what you think!


## Fix colors for tab extension to match light/dark/darkest mode
Fixes coloring when tabs are used, specifically when a code block is in place. For dark/darkest modes, the tab background would remain white while the text would change. This commit fixes this by making the background of the tabs transparent, hence taking the normal background. To deliniate between inside the tab and outside the tab, the border is defined to a color that stands out enough. See verification details below for more.

### Verification Evidence:

Before: https://cyclonedds.io/docs/cyclonedds/latest/about_dds/idl.html

After:
<img width="1758" height="632" alt="image" src="https://github.com/user-attachments/assets/3e16c2b5-74a1-4d26-bccd-ce068ab9dfc8" />

<img width="1816" height="876" alt="image" src="https://github.com/user-attachments/assets/923645bf-d2c7-4ea3-81a0-57114a94c110" />

<img width="1826" height="784" alt="image" src="https://github.com/user-attachments/assets/41c60a4b-1c1a-4cef-9b17-1a80117c1731" />


## Add additional documentation for IDL syntax

I've added documentation for the formatting of IDL. I also moved IDL documentation to it's own top-level section, since I feel like it is important enough (and somewhat separate from DDS) to be side by side but have its own section. I could also be convinced otherwise though.

### Verification Evidence:
<img width="3512" height="9762" alt="image" src="https://github.com/user-attachments/assets/9cc9961c-f5b1-4ae0-88b8-22c426c9d743" />

