### PR TITLE
Simplify data_type_properties

### DIFF
--- a/src/core/cdr/src/dds_cdrstream.c
+++ b/src/core/cdr/src/dds_cdrstream.c
@@ -852,38 +852,23 @@ static const uint32_t *dds_stream_get_ops_info_seq (const uint32_t *ops, uint32_
   const enum dds_stream_typecode subtype = DDS_OP_SUBTYPE (insn);
   switch (subtype)
   {
-    case DDS_OP_VAL_BLN: case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY:
+    case DDS_OP_VAL_BLN: case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY: case DDS_OP_VAL_WCHAR:
       ops += 2 + bound_op;
       break;
-    case DDS_OP_VAL_STR:
+    case DDS_OP_VAL_STR: case DDS_OP_VAL_WSTR:
+      info->data_types &= ~DDS_DATA_TYPE_IS_MEMCPY_SAFE;
       ops += 2 + bound_op;
-      info->data_types |= DDS_DATA_TYPE_CONTAINS_STRING;
       break;
-    case DDS_OP_VAL_BST:
+    case DDS_OP_VAL_BST: case DDS_OP_VAL_BWSTR: case DDS_OP_VAL_ENU:
       ops += 3 + bound_op;
-      info->data_types |= DDS_DATA_TYPE_CONTAINS_BSTRING;
-      break;
-    case DDS_OP_VAL_WSTR:
-      ops += 2 + bound_op;
-      info->data_types |= DDS_DATA_TYPE_CONTAINS_WSTRING;
-      break;
-    case DDS_OP_VAL_BWSTR:
-      ops += 3 + bound_op;
-      info->data_types |= DDS_DATA_TYPE_CONTAINS_BWSTRING;
-      break;
-    case DDS_OP_VAL_WCHAR:
-      ops += 2 + bound_op;
-      info->data_types |= DDS_DATA_TYPE_CONTAINS_WCHAR;
-      break;
-    case DDS_OP_VAL_ENU:
-      ops += 3 + bound_op;
-      info->data_types |= DDS_DATA_TYPE_CONTAINS_ENUM;
       break;
     case DDS_OP_VAL_BMK:
       ops += 4 + bound_op;
-      info->data_types |= DDS_DATA_TYPE_CONTAINS_BITMASK;
       break;
-    case DDS_OP_VAL_SEQ: case DDS_OP_VAL_BSQ: case DDS_OP_VAL_ARR: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU: {
+    case DDS_OP_VAL_SEQ: case DDS_OP_VAL_BSQ:
+      info->data_types &= ~DDS_DATA_TYPE_IS_MEMCPY_SAFE;
+      /* fall through */
+    case DDS_OP_VAL_ARR: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU: {
       const uint32_t jmp = DDS_OP_ADR_JMP (ops[3 + bound_op]);
       uint32_t const * const jsr_ops = ops + DDS_OP_ADR_JSR (ops[3 + bound_op]);
       if (ops + 4 + bound_op > info->ops_end)
@@ -909,38 +894,23 @@ static const uint32_t *dds_stream_get_ops_info_arr (const uint32_t *ops, uint32_
   const enum dds_stream_typecode subtype = DDS_OP_SUBTYPE (insn);
   switch (subtype)
   {
-    case DDS_OP_VAL_BLN: case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY:
+    case DDS_OP_VAL_BLN: case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY: case DDS_OP_VAL_WCHAR:
       ops += 3;
       break;
-    case DDS_OP_VAL_STR:
+    case DDS_OP_VAL_STR: case DDS_OP_VAL_WSTR:
+      info->data_types &= ~DDS_DATA_TYPE_IS_MEMCPY_SAFE;
       ops += 3;
-      info->data_types |= DDS_DATA_TYPE_CONTAINS_STRING;
-      break;
-    case DDS_OP_VAL_WSTR:
-      ops += 3;
-      info->data_types |= DDS_DATA_TYPE_CONTAINS_WSTRING;
-      break;
-    case DDS_OP_VAL_WCHAR:
-      ops += 3;
-      info->data_types |= DDS_DATA_TYPE_CONTAINS_WCHAR;
       break;
     case DDS_OP_VAL_ENU:
       ops += 4;
-      info->data_types |= DDS_DATA_TYPE_CONTAINS_ENUM;
       break;
-    case DDS_OP_VAL_BST:
+    case DDS_OP_VAL_BST: case DDS_OP_VAL_BWSTR: case DDS_OP_VAL_BMK:
       ops += 5;
-      info->data_types |= DDS_DATA_TYPE_CONTAINS_BSTRING;
       break;
-    case DDS_OP_VAL_BWSTR:
-      ops += 5;
-      info->data_types |= DDS_DATA_TYPE_CONTAINS_BWSTRING;
-      break;
-    case DDS_OP_VAL_BMK:
-      ops += 5;
-      info->data_types |= DDS_DATA_TYPE_CONTAINS_BITMASK;
-      break;
-    case DDS_OP_VAL_SEQ: case DDS_OP_VAL_BSQ: case DDS_OP_VAL_ARR: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU: {
+    case DDS_OP_VAL_SEQ: case DDS_OP_VAL_BSQ:
+      info->data_types &= ~DDS_DATA_TYPE_IS_MEMCPY_SAFE;
+      /* fall through */
+    case DDS_OP_VAL_ARR: case DDS_OP_VAL_UNI: case DDS_OP_VAL_STU: {
       const uint32_t jmp = DDS_OP_ADR_JMP (ops[3]);
       const uint32_t *jsr_ops = ops + DDS_OP_ADR_JSR (ops[3]);
       if (ops + 5 > info->ops_end)
@@ -963,38 +933,26 @@ static const uint32_t *dds_stream_get_ops_info_arr (const uint32_t *ops, uint32_
 ddsrt_nonnull_all
 static const uint32_t *dds_stream_get_ops_info_uni (const uint32_t *ops, uint32_t nestc, struct dds_cdrstream_ops_info *info, bool in_recursive)
 {
-  enum dds_stream_typecode disc_type = DDS_OP_SUBTYPE (ops[0]);
-  if (disc_type == DDS_OP_VAL_ENU)
-    info->data_types |= DDS_DATA_TYPE_CONTAINS_ENUM;
-
   const uint32_t numcases = ops[2];
   const uint32_t *jeq_op = ops + DDS_OP_ADR_JSR (ops[3]);
   for (uint32_t i = 0; i < numcases; i++)
   {
     const enum dds_stream_typecode valtype = DDS_JEQ_TYPE (jeq_op[0]);
-    if (op_type_external (jeq_op[0]) && valtype != DDS_OP_VAL_STR && valtype != DDS_OP_VAL_WSTR)
-      info->data_types |= DDS_DATA_TYPE_CONTAINS_EXTERNAL;
+    if (op_type_external (jeq_op[0]) || op_type_optional (jeq_op[0]))
+      info->data_types &= ~DDS_DATA_TYPE_IS_MEMCPY_SAFE;
     switch (valtype)
     {
       case DDS_OP_VAL_BLN: case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY:
+      case DDS_OP_VAL_WCHAR: case DDS_OP_VAL_ENU:
         break;
-      case DDS_OP_VAL_STR:
-        info->data_types |= DDS_DATA_TYPE_CONTAINS_STRING;
+      case DDS_OP_VAL_STR: case DDS_OP_VAL_WSTR:
+        info->data_types &= ~DDS_DATA_TYPE_IS_MEMCPY_SAFE;
         break;
-      case DDS_OP_VAL_WSTR:
-        info->data_types |= DDS_DATA_TYPE_CONTAINS_WSTRING;
-        break;
-      case DDS_OP_VAL_WCHAR:
-        info->data_types |= DDS_DATA_TYPE_CONTAINS_WCHAR;
-        break;
-      case DDS_OP_VAL_ENU:
-        info->data_types |= DDS_DATA_TYPE_CONTAINS_ENUM;
-        break;
-      case DDS_OP_VAL_STU:
-        info->data_types |= DDS_DATA_TYPE_CONTAINS_STRUCT;
-        /* fall-through */
-      case DDS_OP_VAL_BST: case DDS_OP_VAL_BWSTR:
-      case DDS_OP_VAL_SEQ: case DDS_OP_VAL_BSQ: case DDS_OP_VAL_ARR: case DDS_OP_VAL_UNI: case DDS_OP_VAL_BMK: {
+      case DDS_OP_VAL_SEQ: case DDS_OP_VAL_BSQ:
+        info->data_types &= ~DDS_DATA_TYPE_IS_MEMCPY_SAFE;
+        /* fall through */
+      case DDS_OP_VAL_STU: case DDS_OP_VAL_BST: case DDS_OP_VAL_BWSTR:
+      case DDS_OP_VAL_ARR: case DDS_OP_VAL_UNI: case DDS_OP_VAL_BMK: {
         bool recursive = DDS_OP_ADR_JSR (jeq_op[0]) <= 0;
         if (!in_recursive)
           dds_stream_get_ops_info1 (jeq_op + DDS_OP_ADR_JSR (jeq_op[0]), nestc + (valtype == DDS_OP_VAL_UNI || valtype == DDS_OP_VAL_STU ? 1 : 0), info, false, recursive);
@@ -1056,68 +1014,40 @@ static void dds_stream_get_ops_info1 (const uint32_t *ops, uint32_t nestc, struc
     {
       case DDS_OP_ADR: {
         if (info->toplevel_op == NULL)
-        {
           info->toplevel_op = ops;
-          if (DDS_OP_TYPE (insn) != DDS_OP_VAL_UNI)
-            info->data_types |= DDS_DATA_TYPE_CONTAINS_STRUCT;
-        }
         if ((insn & DDS_OP_FLAG_KEY) && nestc == 0)
           info->data_types |= DDS_DATA_TYPE_CONTAINS_KEY;
+        if (op_type_external (insn) || op_type_optional (insn))
+          info->data_types &= ~DDS_DATA_TYPE_IS_MEMCPY_SAFE;
         if (op_type_optional (insn))
         {
-          info->data_types |= DDS_DATA_TYPE_CONTAINS_OPTIONAL;
+          info->data_types |= DDS_DATA_TYPE_DEFAULTS_TO_XCDR2;
           in_xcdr1_delimited_scope = true;
         }
-        if (op_type_external (insn) && DDS_OP_TYPE (insn) != DDS_OP_VAL_STR && DDS_OP_TYPE (insn) != DDS_OP_VAL_WSTR)
-          info->data_types |= DDS_DATA_TYPE_CONTAINS_EXTERNAL;
         switch (DDS_OP_TYPE (insn))
         {
-          case DDS_OP_VAL_BLN: case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY:
+          case DDS_OP_VAL_BLN: case DDS_OP_VAL_1BY: case DDS_OP_VAL_2BY: case DDS_OP_VAL_4BY: case DDS_OP_VAL_8BY: case DDS_OP_VAL_WCHAR:
             ops += 2;
             break;
-          case DDS_OP_VAL_STR:
+          case DDS_OP_VAL_STR: case DDS_OP_VAL_WSTR:
+            info->data_types &= ~DDS_DATA_TYPE_IS_MEMCPY_SAFE;
             ops += 2;
-            info->data_types |= DDS_DATA_TYPE_CONTAINS_STRING;
             break;
-          case DDS_OP_VAL_WSTR:
-            ops += 2;
-            info->data_types |= DDS_DATA_TYPE_CONTAINS_WSTRING;
-            break;
-          case DDS_OP_VAL_WCHAR:
-            ops += 2;
-            info->data_types |= DDS_DATA_TYPE_CONTAINS_WCHAR;
-            break;
-          case DDS_OP_VAL_BST:
+          case DDS_OP_VAL_BST: case DDS_OP_VAL_BWSTR: case DDS_OP_VAL_ENU:
             ops += 3;
-            info->data_types |= DDS_DATA_TYPE_CONTAINS_BSTRING;
-            break;
-          case DDS_OP_VAL_BWSTR:
-            ops += 3;
-            info->data_types |= DDS_DATA_TYPE_CONTAINS_BWSTRING;
-            break;
-          case DDS_OP_VAL_ENU:
-            ops += 3;
-            info->data_types |= DDS_DATA_TYPE_CONTAINS_ENUM;
             break;
           case DDS_OP_VAL_BMK:
             ops += 4;
-            info->data_types |= DDS_DATA_TYPE_CONTAINS_BITMASK;
             break;
-          case DDS_OP_VAL_SEQ:
-            info->data_types |= DDS_DATA_TYPE_CONTAINS_SEQUENCE;
-            ops = dds_stream_get_ops_info_seq (ops, insn, nestc, info, in_recursive);
-            break;
-          case DDS_OP_VAL_BSQ:
-            info->data_types |= DDS_DATA_TYPE_CONTAINS_BSEQUENCE;
+          case DDS_OP_VAL_SEQ: case DDS_OP_VAL_BSQ:
+            info->data_types &= ~DDS_DATA_TYPE_IS_MEMCPY_SAFE;
             ops = dds_stream_get_ops_info_seq (ops, insn, nestc, info, in_recursive);
             break;
           case DDS_OP_VAL_ARR:
-            info->data_types |= DDS_DATA_TYPE_CONTAINS_ARRAY;
             ops = dds_stream_get_ops_info_arr (ops, insn, nestc, info, in_recursive);
             break;
           case DDS_OP_VAL_UNI:
             ops = dds_stream_get_ops_info_uni (ops, nestc, info, in_recursive);
-            info->data_types |= DDS_DATA_TYPE_CONTAINS_UNION;
             break;
           case DDS_OP_VAL_EXT: {
             if (!op_type_optional (insn))
@@ -1148,14 +1078,14 @@ static void dds_stream_get_ops_info1 (const uint32_t *ops, uint32_t nestc, struc
         break;
       }
       case DDS_OP_DLC: {
-        info->data_types |= DDS_DATA_TYPE_CONTAINS_APPENDABLE;
+        info->data_types |= DDS_DATA_TYPE_DEFAULTS_TO_XCDR2;
         if (!in_xcdr1_delimited_scope)
           info->min_xcdrv = DDSI_RTPS_CDR_ENC_VERSION_2;
         ops++;
         break;
       }
       case DDS_OP_PLC: {
-        info->data_types |= DDS_DATA_TYPE_CONTAINS_MUTABLE;
+        info->data_types |= DDS_DATA_TYPE_DEFAULTS_TO_XCDR2;
         ops = dds_stream_get_ops_info_pl (ops, nestc, info, in_xcdr1_delimited_scope, in_recursive);
         break;
       }
@@ -1185,7 +1115,7 @@ static void dds_stream_get_ops_info (const uint32_t *ops, struct dds_cdrstream_o
   info->ops_end = ops;
   info->min_xcdrv = DDSI_RTPS_CDR_ENC_VERSION_1;
   info->nesting_max = 0;
-  info->data_types = 0ull;
+  info->data_types = DDS_DATA_TYPE_IS_MEMCPY_SAFE;
   dds_stream_get_ops_info1 (ops, 0, info, true, false);
 }
 
@@ -6477,27 +6407,12 @@ uint32_t dds_stream_type_nesting_depth (const uint32_t *ops)
   return info.nesting_max;
 }
 
-static bool data_type_contains_indirections (dds_data_type_properties_t props)
-{
-  return props & (DDS_DATA_TYPE_CONTAINS_OPTIONAL
-                  | DDS_DATA_TYPE_CONTAINS_STRING
-                  | DDS_DATA_TYPE_CONTAINS_WSTRING
-                  | DDS_DATA_TYPE_CONTAINS_SEQUENCE
-                  | DDS_DATA_TYPE_CONTAINS_BSEQUENCE
-                  | DDS_DATA_TYPE_CONTAINS_EXTERNAL);
-}
-
 dds_data_type_properties_t dds_stream_data_types (const uint32_t *ops)
 {
   struct dds_cdrstream_ops_info info;
   dds_stream_get_ops_info (ops, &info);
-  if (!data_type_contains_indirections (info.data_types))
-    info.data_types |= DDS_DATA_TYPE_IS_MEMCPY_SAFE;
   return info.data_types;
 }
-
-
-
 
 // Calculate key size
 

--- a/src/core/ddsc/include/dds/ddsc/dds_data_type_properties.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_data_type_properties.h
@@ -19,26 +19,35 @@ extern "C" {
 
 /**
  * @brief Flags that are used to indicate the types used in a data type
+ *
+ * Bits 0 .. 16 are kinda reserved for presence of a variety of types, but its really not worth the bother.
+ * The old names are left in for backwards source compatibility with other sertype implementations.
+ * Eventually they can be reused, if necessary.
  */
-#define DDS_DATA_TYPE_CONTAINS_UNION              (0x1ull << 0)
-#define DDS_DATA_TYPE_CONTAINS_BITMASK            (0x1ull << 1)
-#define DDS_DATA_TYPE_CONTAINS_ENUM               (0x1ull << 2)
-#define DDS_DATA_TYPE_CONTAINS_STRUCT             (0x1ull << 3)
-#define DDS_DATA_TYPE_CONTAINS_STRING             (0x1ull << 4)
-#define DDS_DATA_TYPE_CONTAINS_BSTRING            (0x1ull << 5)
-#define DDS_DATA_TYPE_CONTAINS_WSTRING            (0x1ull << 6)
-#define DDS_DATA_TYPE_CONTAINS_SEQUENCE           (0x1ull << 7)
-#define DDS_DATA_TYPE_CONTAINS_BSEQUENCE          (0x1ull << 8)
-#define DDS_DATA_TYPE_CONTAINS_ARRAY              (0x1ull << 9)
+#define DDS_DATA_TYPE_CONTAINS_UNION              (0ull)
+#define DDS_DATA_TYPE_CONTAINS_BITMASK            (0ull)
+#define DDS_DATA_TYPE_CONTAINS_ENUM               (0ull)
+#define DDS_DATA_TYPE_CONTAINS_STRUCT             (0ull)
+#define DDS_DATA_TYPE_CONTAINS_STRING             (0ull)
+#define DDS_DATA_TYPE_CONTAINS_BSTRING            (0ull)
+#define DDS_DATA_TYPE_CONTAINS_WSTRING            (0ull)
+#define DDS_DATA_TYPE_CONTAINS_SEQUENCE           (0ull)
+#define DDS_DATA_TYPE_CONTAINS_BSEQUENCE          (0ull)
+#define DDS_DATA_TYPE_CONTAINS_ARRAY              (0ull)
 #define DDS_DATA_TYPE_CONTAINS_OPTIONAL           (0x1ull << 10)
-#define DDS_DATA_TYPE_CONTAINS_EXTERNAL           (0x1ull << 11)
-#define DDS_DATA_TYPE_CONTAINS_KEY                (0x1ull << 12)
-#define DDS_DATA_TYPE_CONTAINS_BWSTRING           (0x1ull << 13)
-#define DDS_DATA_TYPE_CONTAINS_WCHAR              (0x1ull << 14)
+#define DDS_DATA_TYPE_CONTAINS_EXTERNAL           (0ull)
+#define DDS_DATA_TYPE_CONTAINS_BWSTRING           (0ull)
+#define DDS_DATA_TYPE_CONTAINS_WCHAR              (0ull)
 #define DDS_DATA_TYPE_CONTAINS_APPENDABLE         (0x1ull << 15)
 #define DDS_DATA_TYPE_CONTAINS_MUTABLE            (0x1ull << 16)
 
+// Bits 10, 15 and 16 used to be optional, appendable and mutable, respectively: and if some of these
+// were set, the default was XCDR2. Now we set only bit 10, but check for any of the 3 bits.
+#define DDS_DATA_TYPE_DEFAULTS_TO_XCDR2           (DDS_DATA_TYPE_CONTAINS_OPTIONAL)
+#define DDS_DATA_TYPE_DEFAULTS_TO_XCDR2_MASK      (DDS_DATA_TYPE_CONTAINS_OPTIONAL | DDS_DATA_TYPE_CONTAINS_APPENDABLE | DDS_DATA_TYPE_CONTAINS_MUTABLE)
+#define DDS_DATA_TYPE_CONTAINS_KEY                (0x1ull << 12)
 #define DDS_DATA_TYPE_IS_MEMCPY_SAFE              (0x1ull << 63)
+
 
 typedef uint64_t dds_data_type_properties_t;
 

--- a/src/core/ddsc/src/dds_qos.c
+++ b/src/core/ddsc/src/dds_qos.c
@@ -871,7 +871,7 @@ dds_return_t dds_ensure_valid_data_representation (dds_qos_t *qos, uint32_t allo
   assert (entitykind == DDS_KIND_TOPIC || entitykind == DDS_KIND_READER || entitykind == DDS_KIND_WRITER);
   const bool allow1 = allowed_data_representations & DDS_DATA_REPRESENTATION_FLAG_XCDR1;
   const bool allow2 = allowed_data_representations & DDS_DATA_REPRESENTATION_FLAG_XCDR2;
-  const bool prefer2 = data_type_props & (DDS_DATA_TYPE_CONTAINS_OPTIONAL | DDS_DATA_TYPE_CONTAINS_APPENDABLE | DDS_DATA_TYPE_CONTAINS_MUTABLE);
+  const bool prefer2 = data_type_props & DDS_DATA_TYPE_DEFAULTS_TO_XCDR2_MASK;
 
   if ((qos->present & DDSI_QP_DATA_REPRESENTATION) && qos->data_representation.value.n > 0)
   {

--- a/src/core/ddsc/tests/cdrstream.c
+++ b/src/core/ddsc/tests/cdrstream.c
@@ -1233,25 +1233,25 @@ CU_Test (ddsc_cdrstream, data_type_info)
     const dds_topic_descriptor_t *desc;
     uint64_t data_types;
   } tests[] = {
-    { D(dti_struct),   DDS_DATA_TYPE_CONTAINS_STRUCT | DDS_DATA_TYPE_IS_MEMCPY_SAFE },
-    { D(dti_string),   DDS_DATA_TYPE_CONTAINS_STRUCT | DDS_DATA_TYPE_CONTAINS_STRING },
-    { D(dti_bstring),  DDS_DATA_TYPE_CONTAINS_STRUCT | DDS_DATA_TYPE_CONTAINS_BSTRING | DDS_DATA_TYPE_IS_MEMCPY_SAFE },
-    { D(dti_seq),      DDS_DATA_TYPE_CONTAINS_STRUCT | DDS_DATA_TYPE_CONTAINS_SEQUENCE },
-    { D(dti_bseq),     DDS_DATA_TYPE_CONTAINS_STRUCT | DDS_DATA_TYPE_CONTAINS_BSEQUENCE },
-    { D(dti_seq_str),  DDS_DATA_TYPE_CONTAINS_STRUCT | DDS_DATA_TYPE_CONTAINS_SEQUENCE | DDS_DATA_TYPE_CONTAINS_STRING },
-    { D(dti_arr),      DDS_DATA_TYPE_CONTAINS_STRUCT | DDS_DATA_TYPE_CONTAINS_ARRAY | DDS_DATA_TYPE_IS_MEMCPY_SAFE },
-    { D(dti_arr_bstr), DDS_DATA_TYPE_CONTAINS_STRUCT | DDS_DATA_TYPE_CONTAINS_ARRAY | DDS_DATA_TYPE_CONTAINS_BSTRING | DDS_DATA_TYPE_IS_MEMCPY_SAFE },
-    { D(dti_opt),      DDS_DATA_TYPE_CONTAINS_STRUCT | DDS_DATA_TYPE_CONTAINS_OPTIONAL | DDS_DATA_TYPE_CONTAINS_EXTERNAL },
-    { D(dti_ext),      DDS_DATA_TYPE_CONTAINS_STRUCT | DDS_DATA_TYPE_CONTAINS_EXTERNAL },
-    { D(dti_struct_key),          DDS_DATA_TYPE_CONTAINS_STRUCT | DDS_DATA_TYPE_CONTAINS_KEY | DDS_DATA_TYPE_IS_MEMCPY_SAFE },
-    { D(dti_struct_nested_key),   DDS_DATA_TYPE_CONTAINS_STRUCT | DDS_DATA_TYPE_CONTAINS_KEY | DDS_DATA_TYPE_IS_MEMCPY_SAFE },
-    { D(dti_struct_nested_nokey), DDS_DATA_TYPE_CONTAINS_STRUCT | DDS_DATA_TYPE_IS_MEMCPY_SAFE },
-    { D(dti_union),    DDS_DATA_TYPE_CONTAINS_UNION | DDS_DATA_TYPE_IS_MEMCPY_SAFE },
-    { D(dti_union_string),  DDS_DATA_TYPE_CONTAINS_UNION | DDS_DATA_TYPE_CONTAINS_STRING },
-    { D(dti_union_enum),    DDS_DATA_TYPE_CONTAINS_UNION | DDS_DATA_TYPE_CONTAINS_ENUM | DDS_DATA_TYPE_IS_MEMCPY_SAFE },
-    { D(dti_union_seq),     DDS_DATA_TYPE_CONTAINS_UNION | DDS_DATA_TYPE_CONTAINS_SEQUENCE },
-    { D(dti_union_arr),     DDS_DATA_TYPE_CONTAINS_UNION | DDS_DATA_TYPE_CONTAINS_ARRAY | DDS_DATA_TYPE_IS_MEMCPY_SAFE },
-    { D(dti_union_struct),  DDS_DATA_TYPE_CONTAINS_UNION | DDS_DATA_TYPE_CONTAINS_STRUCT | DDS_DATA_TYPE_IS_MEMCPY_SAFE }
+    { D(dti_struct),   DDS_DATA_TYPE_IS_MEMCPY_SAFE },
+    { D(dti_string),   0 },
+    { D(dti_bstring),  DDS_DATA_TYPE_IS_MEMCPY_SAFE },
+    { D(dti_seq),      0 },
+    { D(dti_bseq),     0 },
+    { D(dti_seq_str),  0 },
+    { D(dti_arr),      DDS_DATA_TYPE_IS_MEMCPY_SAFE },
+    { D(dti_arr_bstr), DDS_DATA_TYPE_IS_MEMCPY_SAFE },
+    { D(dti_opt),      DDS_DATA_TYPE_DEFAULTS_TO_XCDR2 },
+    { D(dti_ext),      0 },
+    { D(dti_struct_key),          DDS_DATA_TYPE_CONTAINS_KEY | DDS_DATA_TYPE_IS_MEMCPY_SAFE },
+    { D(dti_struct_nested_key),   DDS_DATA_TYPE_CONTAINS_KEY | DDS_DATA_TYPE_IS_MEMCPY_SAFE },
+    { D(dti_struct_nested_nokey), DDS_DATA_TYPE_IS_MEMCPY_SAFE },
+    { D(dti_union),    DDS_DATA_TYPE_IS_MEMCPY_SAFE },
+    { D(dti_union_string),  0 },
+    { D(dti_union_enum),    DDS_DATA_TYPE_IS_MEMCPY_SAFE },
+    { D(dti_union_seq),     0 },
+    { D(dti_union_arr),     DDS_DATA_TYPE_IS_MEMCPY_SAFE },
+    { D(dti_union_struct),  DDS_DATA_TYPE_IS_MEMCPY_SAFE }
   };
 
   for (uint32_t i = 0; i < sizeof (tests) / sizeof (tests[0]); i++)


### PR DESCRIPTION
No real value is in knowing that a type (transitively) contains, e.g., an array. When such details are relevant, it is almost invariably necessary to know a lot more and the full type definition needs to be inspected.

What is relevant is to know whether the type contains key fields or contains pointers (if not, it can be memcpy'd). What is also relevant is whether the type meets the restrictions of pre-XTypes DDS.

This removes all the useless flags while retaining (source & binary) backwards compatibility, except for the presumed non-existent code that really rely on the bits that for presence of integers, bools, strings, &c.