### PR TITLE
`fix`:`ddsc`: allow sysdef read `uri` fmt.

### DIFF
--- a/src/core/ddsc/src/dds_qos_provider.c
+++ b/src/core/ddsc/src/dds_qos_provider.c
@@ -32,19 +32,20 @@ static dds_return_t read_sysdef (const char *path, struct dds_sysdef_system **sy
     ret = dds_sysdef_init_sysdef_str(path, sysdef, SYSDEF_SCOPE_QOS_LIB);
   } else {
     FILE *fp;
-  DDSRT_WARNING_MSVC_OFF(4996)
-    if ((fp = fopen (path, "r")) == NULL)
+    const char *cursor = path;
+    const char uri_prefix[] = "file://";
+    if (!strncmp (cursor, uri_prefix, sizeof(uri_prefix)-1U))
+      cursor = path + (sizeof(uri_prefix)-1U);
+    DDSRT_WARNING_MSVC_OFF(4996)
+    if ((fp = fopen (cursor, "r")) == NULL)
     {
-      if (strncmp (path, "file://", 7) != 0 || (fp = fopen (path + 7, "r")) == NULL)
-      {
-        SYSDEF_ERROR ("Error reading system definition: can't read from path '%s'\n", path);
-        ret = DDS_RETCODE_BAD_PARAMETER;
-      }
+      SYSDEF_ERROR ("Error reading system definition: can't read from path '%s'\n", path);
+      ret = DDS_RETCODE_BAD_PARAMETER;
     }
+    DDSRT_WARNING_MSVC_ON(4996)
     if (ret == DDS_RETCODE_OK) {
       ret = dds_sysdef_init_sysdef (fp, sysdef, SYSDEF_SCOPE_QOS_LIB);
       (void)fclose(fp);
-  DDSRT_WARNING_MSVC_ON(4996)
     }
   }
 


### PR DESCRIPTION
by analogy with configuration path read, let user to specify `uri` format path to system-definition file.
resolve the issue:
- https://github.com/eclipse-cyclonedds/cyclonedds-cxx/issues/549