### PR TITLE
Handle deleting proxypp during new proxy endpoint

### DIFF
--- a/src/core/ddsi/include/dds/ddsi/ddsi_proxy_endpoint.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_proxy_endpoint.h
@@ -119,7 +119,7 @@ struct ddsi_proxy_reader {
  * @param seq       sequence number
  * @returns 0 on success
  */
-DDS_EXPORT int ddsi_new_proxy_writer (struct ddsi_proxy_writer **proxy_writer, struct ddsi_domaingv *gv, const struct ddsi_guid *ppguid, const struct ddsi_guid *guid, struct ddsi_addrset *as, const struct ddsi_plist *plist, struct ddsi_dqueue *dqueue, struct ddsi_xeventq *evq, ddsrt_wctime_t timestamp, ddsi_seqno_t seq);
+DDS_EXPORT dds_return_t ddsi_new_proxy_writer (struct ddsi_proxy_writer **proxy_writer, struct ddsi_domaingv *gv, const struct ddsi_guid *ppguid, const struct ddsi_guid *guid, struct ddsi_addrset *as, const struct ddsi_plist *plist, struct ddsi_dqueue *dqueue, struct ddsi_xeventq *evq, ddsrt_wctime_t timestamp, ddsi_seqno_t seq);
 
 /**
  * @brief To create a new proxy reader
@@ -136,7 +136,7 @@ DDS_EXPORT int ddsi_new_proxy_writer (struct ddsi_proxy_writer **proxy_writer, s
  * @param favours_ssm   indicates if the proxy reader favors ssm
  * @return int
  */
-DDS_EXPORT int ddsi_new_proxy_reader (struct ddsi_proxy_reader **proxy_reader, struct ddsi_domaingv *gv, const struct ddsi_guid *ppguid, const struct ddsi_guid *guid, struct ddsi_addrset *as, const struct ddsi_plist *plist, ddsrt_wctime_t timestamp, ddsi_seqno_t seq
+DDS_EXPORT dds_return_t ddsi_new_proxy_reader (struct ddsi_proxy_reader **proxy_reader, struct ddsi_domaingv *gv, const struct ddsi_guid *ppguid, const struct ddsi_guid *guid, struct ddsi_addrset *as, const struct ddsi_plist *plist, ddsrt_wctime_t timestamp, ddsi_seqno_t seq
 #ifdef DDSRT_HAVE_SSM
 , int favours_ssm
 #endif

--- a/src/core/ddsi/src/ddsi__proxy_participant.h
+++ b/src/core/ddsi/src/ddsi__proxy_participant.h
@@ -38,10 +38,16 @@ int ddsi_update_proxy_participant_plist_locked (struct ddsi_proxy_participant *p
 void ddsi_purge_proxy_participants (struct ddsi_domaingv *gv, const ddsi_xlocator_t *loc);
 
 /** @component ddsi_proxy_participant */
-int ddsi_ref_proxy_participant (struct ddsi_proxy_participant *proxypp, struct ddsi_proxy_endpoint_common *c);
+dds_return_t ddsi_ref_proxy_participant_begin (struct ddsi_proxy_participant *proxypp, struct ddsi_proxy_endpoint_common *c)
+  ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
 
 /** @component ddsi_proxy_participant */
-void ddsi_unref_proxy_participant (struct ddsi_proxy_participant *proxypp, struct ddsi_proxy_endpoint_common *c);
+dds_return_t ddsi_ref_proxy_participant_complete (struct ddsi_proxy_participant *proxypp)
+  ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+
+/** @component ddsi_proxy_participant */
+void ddsi_unref_proxy_participant (struct ddsi_proxy_participant *proxypp, struct ddsi_proxy_endpoint_common *c)
+  ddsrt_nonnull ((1));
 
 /** @component ddsi_proxy_participant */
 void ddsi_proxy_participant_add_pwr_lease_locked (struct ddsi_proxy_participant * proxypp, const struct ddsi_proxy_writer * pwr);


### PR DESCRIPTION
This fixes two symptoms seen rarely on CI, triggered by some test code:

* oneliner "P P' sleep 0.6 deaf! P" crashes on termination with

    Assertion failed: (ddsrt_fibheap_min (&lease_fhdef, &gv->leaseheap) == NULL),
      function ddsi_lease_management_term, file ddsi_lease.c, line 71

* oneliner "P P' sleep 0.6 deaf! P deaf! P'" hangs on the second "deaf!" while waiting for the domain 1 to remove the proxy participant for P from the table with recently deleted participant GUIDs (in test_oneliner.c, function wait_for_cleanup)

The first of those can theoretically happen in application code as well if proxy participant lease expiry happens at just the right time while the discovery thread is creating a new proxy entity for it. The likelihood of that is, of course, rather low: the reception of the discovery message triggering the creation of the new endpoint also renewed the lease, and so the discovery thread would have to be delayed by a fair bit while the lease would have to be unusually short. But it is still possible.

new_proxy_{reader,writer} checks whether the proxy participant is still accessible via the hash table and if it is not being deleted yet. If both conditions apply, it adds an entry to the list of endpoints and increments the proxy participant's reference count. Only once the proxy endpoint is fully initialized does it add it to the hash table.

On the other hand, ddsi_delete_participant_by_guid removes the proxy participant from the hash table, marks it as deleted, collects all the endpoint GUIDs and then deletes the endpoints by looking up the GUID and triggering deletion. So if it runs between the two steps in creating a proxy endpoint mentioned above, it won't trigger deletion of the endpoint being created.

After that, there is nothing triggering the deletion of the proxy endpoint anymore (an application one could possibly still beleted, as it is still in the hash table, but that requires receiving a dispose message, so there is still no guarantee). A built-in one will certainly remain (but is only susceptible to the problem when triggered by oneliner, not by lease expiration).

Thus, the final stage of the proxy participant cleanup doesn't occur, it remains in the "deleted participants" table and its lease remains on the books.

This addresses the problem by making sure the work ddsi_delete_proxy_participant_by_guid tried to do is completed by ddsi_new_proxy_{reader,writer}.