### PR TITLE
Fix key extraction for array-of-struct-with-array

### DIFF
--- a/src/core/cdr/src/dds_cdrstream.c
+++ b/src/core/cdr/src/dds_cdrstream.c
@@ -6634,7 +6634,8 @@ static const uint32_t *dds_stream_key_size_adr (const uint32_t *ops, uint32_t in
       break;
     case DDS_OP_VAL_ARR: {
       const enum dds_stream_typecode subtype = DDS_OP_SUBTYPE (insn);
-      k->is_array_nonprim = !(is_primitive_or_enum_type (subtype) || subtype == DDS_OP_VAL_BMK);
+      if (!(is_primitive_or_enum_type (subtype) || subtype == DDS_OP_VAL_BMK))
+        k->is_array_nonprim = true;
       ops = dds_stream_key_size_arr_bseq (ops, insn, k);
       break;
     }

--- a/src/core/ddsc/tests/CMakeLists.txt
+++ b/src/core/ddsc/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ idlc_generate(TARGET CdrStreamOptimize FILES CdrStreamOptimize.idl WARNINGS no-i
 idlc_generate(TARGET CdrStreamSkipDefault FILES CdrStreamSkipDefault.idl)
 idlc_generate(TARGET CdrStreamKeySize FILES CdrStreamKeySize.idl)
 idlc_generate(TARGET CdrStreamKeyExt FILES CdrStreamKeyExt.idl)
+idlc_generate(TARGET CdrStreamKeyFlags FILES CdrStreamKeyFlags.idl)
 idlc_generate(TARGET CdrStreamChecking FILES CdrStreamChecking.idl)
 idlc_generate(TARGET CdrStreamWstring FILES CdrStreamWstring.idl)
 idlc_generate(TARGET CdrStreamParamHeader FILES CdrStreamParamHeader.idl)
@@ -194,6 +195,7 @@ target_link_libraries(cunit_ddsc PRIVATE
   Array100
   CdrStreamKeySize
   CdrStreamKeyExt
+  CdrStreamKeyFlags
   SerdataData
   ddsc
 )

--- a/src/core/ddsc/tests/CdrStreamKeyFlags.idl
+++ b/src/core/ddsc/tests/CdrStreamKeyFlags.idl
@@ -1,0 +1,14 @@
+// Copyright(c) 2025 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+module CdrStreamKeyFlags {
+  @final struct nested1 { @key octet a[3]; };
+  @final struct t1 { @key nested1 b[3][3]; };
+};

--- a/src/core/ddsc/tests/cdrstream.c
+++ b/src/core/ddsc/tests/cdrstream.c
@@ -30,6 +30,7 @@
 #include "CdrStreamSkipDefault.h"
 #include "CdrStreamKeySize.h"
 #include "CdrStreamKeyExt.h"
+#include "CdrStreamKeyFlags.h"
 #include "CdrStreamDataTypeInfo.h"
 #include "CdrStreamChecking.h"
 #include "CdrStreamWstring.h"
@@ -1539,6 +1540,27 @@ CU_Test(ddsc_cdrstream, key_flags_ext)
     uint32_t key_flags = dds_stream_key_flags (&desc, NULL, NULL);
     CU_ASSERT_EQ_FATAL ((key_flags & DDS_TOPIC_KEY_APPENDABLE) != 0, tests[i].key_appendable);
     CU_ASSERT_EQ_FATAL ((key_flags & DDS_TOPIC_KEY_MUTABLE) != 0, tests[i].key_mutable);
+    dds_cdrstream_desc_fini (&desc, &dds_cdrstream_default_allocator);
+  }
+}
+#undef D
+
+#define D(n) (&CdrStreamKeyFlags_ ## n ## _desc)
+CU_Test(ddsc_cdrstream, key_flags_various)
+{
+  static const struct {
+    const dds_topic_descriptor_t *desc;
+    bool key_array_non_prim;
+  } tests[] = {
+    { D(t1), true },
+  };
+
+  for (size_t i = 0; i < sizeof (tests) / sizeof (tests[0]); i++) {
+    printf ("running test for type: %s\n", tests[i].desc->m_typename);
+    struct dds_cdrstream_desc desc;
+    dds_cdrstream_desc_from_topic_desc (&desc, tests[i].desc);
+    uint32_t key_flags = dds_stream_key_flags (&desc, NULL, NULL);
+    CU_ASSERT_EQ_FATAL ((key_flags & DDS_TOPIC_KEY_ARRAY_NONPRIM) != 0, tests[i].key_array_non_prim);
     dds_cdrstream_desc_fini (&desc, &dds_cdrstream_default_allocator);
   }
 }


### PR DESCRIPTION
The "type contains key of array of non-primitive type" flag could be set by one key field, and then cleared by a second key field that is an array of primitives. If this is the only thing requiring the slow path in "extract_key_from_data", it aborts on encountering an array of unexpected type.