### PR TITLE
make index increment in  dds_read_collect_sample conditional

### DIFF
--- a/src/core/ddsc/src/dds_read.c
+++ b/src/core/ddsc/src/dds_read.c
@@ -51,7 +51,7 @@ dds_return_t dds_read_collect_sample (void *varg, const dds_sample_info_t *si, c
     ddsi_sertype_zero_sample (st, arg->ptrs[arg->next_idx]);
     ok = ddsi_serdata_untyped_to_sample (st, sd, arg->ptrs[arg->next_idx], NULL, NULL);
   }
-  arg->next_idx++;
+  arg->next_idx += (uint32_t)ok; // Only increment on success.
   return ok ? DDS_RETCODE_OK : DDS_RETCODE_ERROR;
 }
 


### PR DESCRIPTION
This fixes the behavior of `dds_read_collect_sample_loan()`. In the error case where it failed `dds_read_collect_sample()`, the index must not be incremented. The point of the NULL assignment in the below error path, is to undo the damage by the earlier `arg->ptrs[arg->next_idx] = ls->sample_ptr;`.
https://github.com/eclipse-cyclonedds/cyclonedds/blob/a35247d61a3a8fcd97856fc214955b979ee64f56/src/core/ddsc/src/dds_read.c#L99-L110
