### PR TITLE
Fix RHC registering instance for rejected sample

### DIFF
--- a/src/core/ddsc/src/dds_rhc_default.c
+++ b/src/core/ddsc/src/dds_rhc_default.c
@@ -1140,6 +1140,8 @@ static void dds_rhc_register (struct dds_rhc_default *rhc, struct rhc_instance *
     inst->wr_iid = wr_iid;
     if (sample_accepted)
       inst->wr_iid_islive = 1;
+    else
+      lwregs_add (&rhc->registrations, inst->iid, wr_iid);
     inst->wrcount++;
     inst->no_writers_gen++;
     inst->autodispose = autodispose;
@@ -1173,7 +1175,7 @@ static void dds_rhc_register (struct dds_rhc_default *rhc, struct rhc_instance *
         inst->autodispose = 1;
       TRACE ("new2iidnull");
     }
-    else
+    else if (sample_accepted)
     {
       bool x = lwregs_delete (&rhc->registrations, inst->iid, wr_iid);
       assert (x);


### PR DESCRIPTION
The RHC registers a writer for an instance even when the sample is rejected (e.g., because of a too old source timestamp when the destination order QoS is set to "by source timestamp"). If there are no registered writers for that instance, it constructs an inconsistent state for the instance because it doesn't mark the writer id in the instance as "live" and neither does it add it to the set of registrations in the RHC.

The consequence is that on the next sample, the writer can re-register, at which point the live writer count is 2 even though there is only a single writer. This is most easily observable after an unregister for that writer: the instance then remains alive.


Reported-by: Michel van den Hoek <michel.vandenhoek@zettascale.tech>