### PR TITLE
feat: add compile commands for cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@
 cmake_minimum_required(VERSION 3.16)
 # C++ is only for Iceoryx plugin
 project(CycloneDDS VERSION 0.11.0 LANGUAGES C CXX)
+set(CMAKE_EXPORT_COMPILE_COMMANDS true)
 
 # Set a default build type if none was specified
 set(default_build_type "RelWithDebInfo")

--- a/compile_commands.json
+++ b/compile_commands.json
@@ -1,0 +1,1 @@
+build/compile_commands.json


### PR DESCRIPTION
This PR add CMAKE_EXPORT_COMPILE_COMMANDS for cmake so that it will generate `compile_commands.json`.
It will help vscode extension or language server to parse code and headers correctly.

Hope it helps!