### PR TITLE
Avoid BIO_new_fp: avoid coupling of openssl/stdlib

### DIFF
--- a/src/security/builtin_plugins/tests/listeners_authentication/src/listeners_authentication_utests.c
+++ b/src/security/builtin_plugins/tests/listeners_authentication/src/listeners_authentication_utests.c
@@ -292,11 +292,13 @@ get_certificate_expiry(
             dds_duration_t delta = DDS_SECS(((dds_duration_t)seconds + ((dds_duration_t)days * secs_per_day)));
             expiry = dds_time() + delta;
             {
-                BIO *b;
-                b = BIO_new_fp(stdout, BIO_NOCLOSE);
+                BIO *b = BIO_new(BIO_s_mem());
                 BIO_printf(b, "[asn1time] ");
                 ASN1_TIME_print(b, ans1);
                 BIO_printf(b, "\n");
+                BUF_MEM *bptr;
+                BIO_get_mem_ptr(b, &bptr);
+                fwrite(bptr->data, 1, bptr->length, stdout);
                 BIO_free(b);
             }
         }


### PR DESCRIPTION
Suddenly a Win32RelWithDebInfo CI run started failing with a stack buffer overflow exception in BIO_new_fp, immediately after Microsoft updated Visual Studio Enterprise in the Azure image from 17.14.36616.10 to 17.14.36623.8.

I'm guessing the definition of struct FILE changed in the standard library included in that Visual Studio version, but that the OpenSSL library didn't get recompiled.

Avoiding BIO_new_fp altogether and relying on a memory-based BIO eliminates the problem. We only use it for printing the expiry time of a generated certificate in a single test, so it is not like this can have a significant impact.