### PR TITLE
align `serdata` within a context only

### DIFF
--- a/src/core/ddsc/src/dds_write.c
+++ b/src/core/ddsc/src/dds_write.c
@@ -642,15 +642,13 @@ static struct dds_loaned_sample *dds_write_impl_serialize_into_loan (const struc
   uint16_t enc_identifier;
   if (ddsi_sertype_get_serialized_size (sertype, sdkind, data, &loan_size_unpadded, &enc_identifier) != 0)
     return NULL;
-  const uint32_t pad_mask = 3u;
-  const uint32_t loan_size_padded = ((uint32_t) loan_size_unpadded + pad_mask) & ~pad_mask;
-  struct dds_loaned_sample * const loan = dds_writer_request_psmx_loan (wr, loan_size_padded);
+  struct dds_loaned_sample * const loan = dds_writer_request_psmx_loan (wr, (uint32_t)loan_size_unpadded);
   if (loan == NULL)
     return NULL;
   struct dds_psmx_metadata * const md = loan->metadata;
   md->sample_state = (sdkind == SDK_KEY) ? DDS_LOANED_SAMPLE_STATE_SERIALIZED_KEY : DDS_LOANED_SAMPLE_STATE_SERIALIZED_DATA;
   md->cdr_identifier = enc_identifier;
-  md->cdr_options = ddsrt_toBE2u ((uint16_t) (loan_size_padded - loan_size_unpadded));
+  md->cdr_options = 0;
   ddsi_sertype_serialize_into (sertype, sdkind, data, loan->sample_ptr, loan_size_unpadded);
   dds_psmx_set_loan_writeinfo (loan, &wr->m_entity.m_guid, timestamp, statusinfo);
   return loan;

--- a/src/core/ddsc/tests/serdata_keys.c
+++ b/src/core/ddsc/tests/serdata_keys.c
@@ -378,10 +378,12 @@ static const unsigned char *serdata_default_keybuf (const struct dds_serdata_def
   return (d->key.buftype == KEYBUFTYPE_STATIC) ? d->key.u.stbuf : d->key.u.dynbuf;
 }
 
+#if 0
 static size_t alignN(const size_t off, const size_t align)
 {
   return (off + align - 1) & ~(align - 1);
 }
+#endif
 
 static void print_check_cdr (const struct dds_serdata_default *sd, const unsigned char *exp_cdr, size_t exp_cdr_sz)
 {
@@ -1467,7 +1469,7 @@ CU_Test(ddsc_serdata, key_serialization)
         struct dds_serdata_default *sd = (struct dds_serdata_default *) ddsi_serdata_from_sample (sertype, SDK_DATA, sample);
         CU_ASSERT_NEQ_FATAL (sd, NULL);
 
-        size_t exp_sz_aligned = alignN (tests[test_index].xcdrv[dr].data_sz, 4);
+        size_t exp_sz_aligned = tests[test_index].xcdrv[dr].data_sz;
         tprintf ("Data: ");
         print_check_cdr (sd, tests[test_index].xcdrv[dr].data, exp_sz_aligned);
         CU_ASSERT_EQ (exp_sz_aligned, sd->pos);
@@ -1486,7 +1488,7 @@ CU_Test(ddsc_serdata, key_serialization)
 
         size_t exp_sz = tests[test_index].xcdrv[dr].key_sz;
         const unsigned char *exp_data = tests[test_index].xcdrv[dr].key;
-        size_t exp_sz_aligned = alignN (exp_sz, 4);
+        size_t exp_sz_aligned = exp_sz;
         tprintf ("Key: ");
         print_check_cdr (sd, exp_data, exp_sz_aligned);
         CU_ASSERT_EQ (exp_sz_aligned, sd->pos);

--- a/src/core/ddsi/src/ddsi__xmsg.h
+++ b/src/core/ddsi/src/ddsi__xmsg.h
@@ -264,6 +264,10 @@ void ddsi_xmsg_submsg_setnext (struct ddsi_xmsg *msg, struct ddsi_xmsg_marker ma
   ddsrt_nonnull_all;
 
 /** @component rtps_submsg */
+void ddsi_xmsg_submsg_setlast (struct ddsi_xmsg *msg, struct ddsi_xmsg_marker marker)
+  ddsrt_nonnull_all;
+
+/** @component rtps_submsg */
 void ddsi_xmsg_submsg_init (struct ddsi_xmsg *msg, struct ddsi_xmsg_marker marker, ddsi_rtps_submessage_kind_t smkind)
   ddsrt_nonnull_all;
 

--- a/src/core/ddsi/src/ddsi_serdata_pserop.c
+++ b/src/core/ddsi/src/ddsi_serdata_pserop.c
@@ -221,8 +221,7 @@ static struct ddsi_serdata *serdata_pserop_from_sample (const struct ddsi_sertyp
     size_t size;
     if (ddsi_plist_ser_generic (&data, &size, sample, (kind == SDK_DATA) ? tp->ops : tp->ops_key) < 0)
       return NULL;
-    const size_t size4 = (size + 3) & ~(size_t)3;
-    if ((d = serdata_pserop_new (tp, kind, size4, &header)) == NULL)
+    if ((d = serdata_pserop_new (tp, kind, size, &header)) == NULL)
     {
       ddsrt_free (data);
       return NULL;
@@ -230,7 +229,6 @@ static struct ddsi_serdata *serdata_pserop_from_sample (const struct ddsi_sertyp
     assert (tp->ops_key == NULL || (size >= 16 && tp->memsize >= 16));
     assert (d->data != NULL); // clang static analyzer
     memcpy (d->data, data, size);
-    memset (d->data + size, 0, size4 - size);
     d->pos = (uint32_t) size;
     ddsrt_free (data); // FIXME: shouldn't allocate twice & copy
     // FIXME: and then this silly thing deserialises it immediately again -- perhaps it should be a bit lazier

--- a/src/core/ddsi/src/ddsi_transmit.c
+++ b/src/core/ddsi/src/ddsi_transmit.c
@@ -120,7 +120,7 @@ static dds_return_t ddsi_create_fragment_message_simple (struct ddsi_writer *wr,
 #else
   ddsi_xmsg_serdata (*pmsg, serdata, 0, ddsi_serdata_size (serdata), wr);
 #endif
-  ddsi_xmsg_submsg_setnext (*pmsg, sm_marker);
+  ddsi_xmsg_submsg_setlast (*pmsg, sm_marker);
   return 0;
 }
 
@@ -269,7 +269,7 @@ dds_return_t ddsi_create_fragment_message (struct ddsi_writer *wr, ddsi_seqno_t 
   }
 
   ddsi_xmsg_serdata (*pmsg, serdata, fragstart, fraglen, wr);
-  ddsi_xmsg_submsg_setnext (*pmsg, sm_marker);
+  ddsi_xmsg_submsg_setlast (*pmsg, sm_marker);
 #if 0
   GVTRACE ("queue data%s "PGUIDFMT" #%"PRId64"/%"PRIu32"[%"PRIu32"..%"PRIu32")\n",
            fragging ? "frag" : "", PGUID (wr->e.guid),


### PR DESCRIPTION
There is no requirement for serdata to be aligned by itself, but alignment is required in context of serialized payload usage within submessage (only exception is data as latest submessage or datafrag, in that cases no of any alignment needed). Thus alignment removed from serdata itself and provided when required. Additionally alignment of `loan` reduced also.