### PR TITLE
Update cmake minimum version  to  3.21

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.21)
 # C++ is only for Iceoryx plugin
 project(CycloneDDS VERSION 0.11.0 LANGUAGES C CXX)
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ In order to build Cyclone DDS you need a Linux, Mac or Windows 10 machine (or, w
 
   * C compiler (most commonly GCC on Linux, Visual Studio on Windows, Xcode on macOS);
   * Optionally GIT version control system;
-  * [CMake](https://cmake.org/download/), version 3.16 or later;
+  * [CMake](https://cmake.org/download/), version 3.21 or later;
   * Optionally [OpenSSL](https://www.openssl.org/), we recommend a fully patched and supported version but 1.1.1 will still work;
   * Optionally [Eclipse Iceoryx](https://iceoryx.io) version 2.0 for shared memory and zero-copy support;
   * Optionally [Bison](https://www.gnu.org/software/bison/) parser generator. A cached source is checked into the repository.


### PR DESCRIPTION
Dependency to C_STANDARD 23 was introduced in PR [#2300](https://github.com/eclipse-cyclonedds/cyclonedds/pull/2300)

C_STANDARD 23 was added in cmake 3.21 and cause the following error on older cmake:

C_STANDARD is set to invalid value '23'
