### PR TITLE
Reset the allocation functions to the default if `NULL` is provided

### DIFF
--- a/src/ddsrt/include/dds/ddsrt/heap.h
+++ b/src/ddsrt/include/dds/ddsrt/heap.h
@@ -37,6 +37,9 @@ typedef struct ddsrt_allocation_ops {
 ///
 /// Set the functions to malloc, calloc, realloc, and free memory. By default
 /// the functions of `stdlib` will be used.
+///
+/// Setting any of the function pointers in the `custom_ops` to NULL will reset
+/// that corresponding allocation function to the default.
 DDS_EXPORT void
 ddsrt_set_allocator(
   ddsrt_allocation_ops_t custom_ops);

--- a/src/ddsrt/src/heap/posix/heap.c
+++ b/src/ddsrt/src/heap/posix/heap.c
@@ -24,6 +24,10 @@ void
 ddsrt_set_allocator(
   ddsrt_allocation_ops_t custom_ops)
 {
+  if (custom_ops.malloc == NULL) { custom_ops.malloc = malloc; }
+  if (custom_ops.calloc == NULL) { custom_ops.calloc = calloc; }
+  if (custom_ops.realloc == NULL) { custom_ops.realloc = realloc; }
+  if (custom_ops.free == NULL) { custom_ops.free = free; }
   ddsrt_allocator = custom_ops;
 }
 


### PR DESCRIPTION
I needed a way to reset the allocation functions in some tests I was writing. I have some workarounds, but I thought it might just be better to bake it in as expected behavior in `ddsrt_set_allocator`.