### PR TITLE
Fix of enum warnings for MSVC 2022 ROS2 windows rolling build

### DIFF
--- a/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
@@ -384,25 +384,24 @@ enum dds_stream_typecode {
 /**
  * @ingroup serialization
  * @brief primary type code for DDS_OP_ADR, DDS_OP_JEQ
- * Convinience pre-bitshifted values.
+ * Convenience pre-bitshifted values, defined as macros to allow
+ * bitwise OR with dds_stream_opcode without enum type mixing warnings.
  */
-enum dds_stream_typecode_primary {
-  DDS_OP_TYPE_1BY = DDS_OP_VAL_1BY << 16, /**< one byte simple type (char, octet) */
-  DDS_OP_TYPE_2BY = DDS_OP_VAL_2BY << 16, /**< two byte simple type ((unsigned) short) */
-  DDS_OP_TYPE_4BY = DDS_OP_VAL_4BY << 16, /**< four byte simple type ((unsigned) long, float) */
-  DDS_OP_TYPE_8BY = DDS_OP_VAL_8BY << 16, /**< eight byte simple type ((unsigned) long long, double) */
-  DDS_OP_TYPE_STR = DDS_OP_VAL_STR << 16, /**< string */
-  DDS_OP_TYPE_BST = DDS_OP_VAL_BST << 16, /**< bounded string */
-  DDS_OP_TYPE_SEQ = DDS_OP_VAL_SEQ << 16, /**< sequence */
-  DDS_OP_TYPE_ARR = DDS_OP_VAL_ARR << 16, /**< array */
-  DDS_OP_TYPE_UNI = DDS_OP_VAL_UNI << 16, /**< union */
-  DDS_OP_TYPE_STU = DDS_OP_VAL_STU << 16, /**< struct */
-  DDS_OP_TYPE_BSQ = DDS_OP_VAL_BSQ << 16, /**< bounded sequence */
-  DDS_OP_TYPE_ENU = DDS_OP_VAL_ENU << 16, /**< enumerated value (long) */
-  DDS_OP_TYPE_EXT = DDS_OP_VAL_EXT << 16, /**< field with external definition */
-  DDS_OP_TYPE_BLN = DDS_OP_VAL_BLN << 16, /**< boolean */
-  DDS_OP_TYPE_BMK = DDS_OP_VAL_BMK << 16  /**< bitmask */
-};
+#define DDS_OP_TYPE_1BY (DDS_OP_VAL_1BY << 16) /**< one byte simple type (char, octet) */
+#define DDS_OP_TYPE_2BY (DDS_OP_VAL_2BY << 16) /**< two byte simple type ((unsigned) short) */
+#define DDS_OP_TYPE_4BY (DDS_OP_VAL_4BY << 16) /**< four byte simple type ((unsigned) long, float) */
+#define DDS_OP_TYPE_8BY (DDS_OP_VAL_8BY << 16) /**< eight byte simple type ((unsigned) long long, double) */
+#define DDS_OP_TYPE_STR (DDS_OP_VAL_STR << 16) /**< string */
+#define DDS_OP_TYPE_BST (DDS_OP_VAL_BST << 16) /**< bounded string */
+#define DDS_OP_TYPE_SEQ (DDS_OP_VAL_SEQ << 16) /**< sequence */
+#define DDS_OP_TYPE_ARR (DDS_OP_VAL_ARR << 16) /**< array */
+#define DDS_OP_TYPE_UNI (DDS_OP_VAL_UNI << 16) /**< union */
+#define DDS_OP_TYPE_STU (DDS_OP_VAL_STU << 16) /**< struct */
+#define DDS_OP_TYPE_BSQ (DDS_OP_VAL_BSQ << 16) /**< bounded sequence */
+#define DDS_OP_TYPE_ENU (DDS_OP_VAL_ENU << 16) /**< enumerated value (long) */
+#define DDS_OP_TYPE_EXT (DDS_OP_VAL_EXT << 16) /**< field with external definition */
+#define DDS_OP_TYPE_BLN (DDS_OP_VAL_BLN << 16) /**< boolean */
+#define DDS_OP_TYPE_BMK (DDS_OP_VAL_BMK << 16) /**< bitmask */
 
 /**
  * @anchor DDS_OP_FLAG_EXT
@@ -422,24 +421,23 @@ enum dds_stream_typecode_primary {
  * @brief sub-type code
  *  - encodes element type for DDS_OP_TYPE_{SEQ,ARR},
  *  - discriminant type for DDS_OP_TYPE_UNI
- * Convinience pre-bitshifted values.
+ * Convenience pre-bitshifted values, defined as macros to allow
+ * bitwise OR with dds_stream_opcode without enum type mixing warnings.
  */
-enum dds_stream_typecode_subtype {
-  DDS_OP_SUBTYPE_1BY = DDS_OP_VAL_1BY << 8, /**< one byte simple type (char, octet) */
-  DDS_OP_SUBTYPE_2BY = DDS_OP_VAL_2BY << 8, /**< two byte simple type ((unsigned) short) */
-  DDS_OP_SUBTYPE_4BY = DDS_OP_VAL_4BY << 8, /**< four byte simple type ((unsigned) long, float) */
-  DDS_OP_SUBTYPE_8BY = DDS_OP_VAL_8BY << 8, /**< eight byte simple type ((unsigned) long long, double) */
-  DDS_OP_SUBTYPE_STR = DDS_OP_VAL_STR << 8, /**< string */
-  DDS_OP_SUBTYPE_BST = DDS_OP_VAL_BST << 8, /**< bounded string */
-  DDS_OP_SUBTYPE_SEQ = DDS_OP_VAL_SEQ << 8, /**< sequence */
-  DDS_OP_SUBTYPE_ARR = DDS_OP_VAL_ARR << 8, /**< array */
-  DDS_OP_SUBTYPE_UNI = DDS_OP_VAL_UNI << 8, /**< union */
-  DDS_OP_SUBTYPE_STU = DDS_OP_VAL_STU << 8, /**< struct */
-  DDS_OP_SUBTYPE_BSQ = DDS_OP_VAL_BSQ << 8, /**< bounded sequence */
-  DDS_OP_SUBTYPE_ENU = DDS_OP_VAL_ENU << 8, /**< enumerated value (long) */
-  DDS_OP_SUBTYPE_BLN = DDS_OP_VAL_BLN << 8, /**< boolean */
-  DDS_OP_SUBTYPE_BMK = DDS_OP_VAL_BMK << 8  /**< bitmask */
-};
+#define DDS_OP_SUBTYPE_1BY (DDS_OP_VAL_1BY << 8) /**< one byte simple type (char, octet) */
+#define DDS_OP_SUBTYPE_2BY (DDS_OP_VAL_2BY << 8) /**< two byte simple type ((unsigned) short) */
+#define DDS_OP_SUBTYPE_4BY (DDS_OP_VAL_4BY << 8) /**< four byte simple type ((unsigned) long, float) */
+#define DDS_OP_SUBTYPE_8BY (DDS_OP_VAL_8BY << 8) /**< eight byte simple type ((unsigned) long long, double) */
+#define DDS_OP_SUBTYPE_STR (DDS_OP_VAL_STR << 8) /**< string */
+#define DDS_OP_SUBTYPE_BST (DDS_OP_VAL_BST << 8) /**< bounded string */
+#define DDS_OP_SUBTYPE_SEQ (DDS_OP_VAL_SEQ << 8) /**< sequence */
+#define DDS_OP_SUBTYPE_ARR (DDS_OP_VAL_ARR << 8) /**< array */
+#define DDS_OP_SUBTYPE_UNI (DDS_OP_VAL_UNI << 8) /**< union */
+#define DDS_OP_SUBTYPE_STU (DDS_OP_VAL_STU << 8) /**< struct */
+#define DDS_OP_SUBTYPE_BSQ (DDS_OP_VAL_BSQ << 8) /**< bounded sequence */
+#define DDS_OP_SUBTYPE_ENU (DDS_OP_VAL_ENU << 8) /**< enumerated value (long) */
+#define DDS_OP_SUBTYPE_BLN (DDS_OP_VAL_BLN << 8) /**< boolean */
+#define DDS_OP_SUBTYPE_BMK (DDS_OP_VAL_BMK << 8) /**< bitmask */
 
 /**
  * @anchor DDS_OP_FLAG_KEY

--- a/src/idl/include/idl/visit.h
+++ b/src/idl/include/idl/visit.h
@@ -65,30 +65,25 @@ typedef idl_retcode_t(*idl_visitor_callback_t)(
    instruct the visitor to recurse, iterate and/or revisit by signalling the
    inverse */
 
-typedef enum idl_visit_recurse idl_visit_recurse_t;
-enum idl_visit_recurse {
-  IDL_VISIT_RECURSE_BY_DEFAULT = 0,
-  IDL_VISIT_RECURSE = (1<<0), /**< Recurse into subtree(s) */
-  IDL_VISIT_DONT_RECURSE = (1<<1) /**< Do not recurse into subtree(s) */
-};
+/* Visit flags defined as macros to allow bitwise OR without enum type mixing warnings */
+typedef int idl_visit_recurse_t;
+#define IDL_VISIT_RECURSE_BY_DEFAULT (0)
+#define IDL_VISIT_RECURSE (1<<0) /**< Recurse into subtree(s) */
+#define IDL_VISIT_DONT_RECURSE (1<<1) /**< Do not recurse into subtree(s) */
 
 /* FIXME: it now applies to the next level. instead, it should apply to the
         current level. in which case IDL_VISIT_ITERATE instructs the
         visitor to continue, IDL_VISIT_DONT_ITERATE does the inverse!
 */
-typedef enum idl_visit_iterate idl_visit_iterate_t;
-enum idl_visit_iterate {
-  IDL_VISIT_ITERATE_BY_DEFAULT = 0,
-  IDL_VISIT_ITERATE = (1<<2), /**< Iterate over subtree(s) */
-  IDL_VISIT_DONT_ITERATE = (1<<3) /**< Do not iterate over subtree(s) */
-};
+typedef int idl_visit_iterate_t;
+#define IDL_VISIT_ITERATE_BY_DEFAULT (0)
+#define IDL_VISIT_ITERATE (1<<2) /**< Iterate over subtree(s) */
+#define IDL_VISIT_DONT_ITERATE (1<<3) /**< Do not iterate over subtree(s) */
 
-typedef enum idl_visit_revisit idl_visit_revisit_t;
-enum idl_visit_revisit {
-  IDL_VISIT_DONT_REVISIT_BY_DEFAULT = 0,
-  IDL_VISIT_REVISIT = (1<<4), /**< Revisit node(s) on exit */
-  IDL_VISIT_DONT_REVISIT = (1<<5) /**< Do not revisit node(s) on exit */
-};
+typedef int idl_visit_revisit_t;
+#define IDL_VISIT_DONT_REVISIT_BY_DEFAULT (0)
+#define IDL_VISIT_REVISIT (1<<4) /**< Revisit node(s) on exit */
+#define IDL_VISIT_DONT_REVISIT (1<<5) /**< Do not revisit node(s) on exit */
 
 /** Visit associated type specifier (callback signal) */
 #define IDL_VISIT_TYPE_SPEC (1<<6)


### PR DESCRIPTION
Hi! 

This PR is fixing the enum comparison warnings for MSVC 2022 builds for ROS2 on windows (warning[ C5286 C5287](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warnings-c5200-through-c5399)). Cyclone-dds 0.10.x was resulting in over 1500 warnings (See this on the ros2 ci: https://ci.ros2.org/job/test_ci_windows/687/)

With this patch in place, the warnings were resolved (see this test build on [ros2 ci](https://ci.ros2.org/job/test_ci_windows/693/)).

I'll leave this in **draft** so that you and the ROS PMC can discuss if this change is desired. An alternative would be to fix this all by all local cmake suppressions of these warnings, but that was a wack-a-mole that required that suppression in a lot of cmake. This was a patch that required the least amount of code change but perhaps not something to be desired. 

Related to https://github.com/ros2/ci/issues/832#issuecomment-3786789226

Just let me know what you think.