### PR TITLE
Never set PKTINFO if packet info not supported

### DIFF
--- a/docs/manual/config/config_file_reference.rst
+++ b/docs/manual/config/config_file_reference.rst
@@ -1249,9 +1249,9 @@ The default value is: ``<empty>``
 
 Boolean
 
-Whether to enable the IP\_PKTINFO on UDP sockets to get hold of the packet destination address and interface on which it was received. This allows for better filtering on discovery packets, but comes at a small performance penalty.
+Whether to enable the IP\_PKTINFO on UDP sockets to get hold of the packet destination address and interface on which it was received. This allows for better filtering on discovery packets, but comes at a small performance penalty. Enabled by default if supported.
 
-The default value is: ``true``
+The default value is: ``default``
 
 
 .. _`//CycloneDDS/Domain/Internal/GenerateKeyhash`:
@@ -2959,9 +2959,9 @@ The categorisation of tracing output is incomplete and hence most of the verbosi
 The default value is: ``none``
 
 ..
-   generated from ddsi_config.h[a96f2afb055d694037710e101e4431ceee2c7c94] 
+   generated from ddsi_config.h[94ad20bdb44ea1f393ba906865b1da591bbe1b57] 
    generated from ddsi_config.c[9fb9ace4394a1b7d50f4e0fa3905bbba2a183e36] 
-   generated from ddsi__cfgelems.h[5137766e3f48f57c05c3745cc2a2380bf7af82cc] 
+   generated from ddsi__cfgelems.h[6e57a9213340839aeac89e7417646451cc5bb706] 
    generated from cfgunits.h[05f093223fce107d24dd157ebaafa351dc9df752] 
    generated from _confgen.h[bb9a0fc6ef1f7f7c46790ee00132e340e5fff36d] 
    generated from _confgen.c[0d833a6f2c98902f1249e63aed03a6164f0791d6] 

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -846,9 +846,9 @@ The default value is: `<empty>`
 #### //CycloneDDS/Domain/Internal/ExtendedPacketInfo
 Boolean
 
-Whether to enable the IP\_PKTINFO on UDP sockets to get hold of the packet destination address and interface on which it was received. This allows for better filtering on discovery packets, but comes at a small performance penalty.
+Whether to enable the IP\_PKTINFO on UDP sockets to get hold of the packet destination address and interface on which it was received. This allows for better filtering on discovery packets, but comes at a small performance penalty. Enabled by default if supported.
 
-The default value is: `true`
+The default value is: `default`
 
 
 #### //CycloneDDS/Domain/Internal/GenerateKeyhash
@@ -2069,9 +2069,9 @@ While none prevents any message from being written to a DDSI2 log file.
 The categorisation of tracing output is incomplete and hence most of the verbosity levels and categories are not of much use in the current release. This is an ongoing process and here we describe the target situation rather than the current situation. Currently, the most useful verbosity levels are config, fine and finest.
 
 The default value is: `none`
-<!--- generated from ddsi_config.h[a96f2afb055d694037710e101e4431ceee2c7c94] -->
+<!--- generated from ddsi_config.h[94ad20bdb44ea1f393ba906865b1da591bbe1b57] -->
 <!--- generated from ddsi_config.c[9fb9ace4394a1b7d50f4e0fa3905bbba2a183e36] -->
-<!--- generated from ddsi__cfgelems.h[5137766e3f48f57c05c3745cc2a2380bf7af82cc] -->
+<!--- generated from ddsi__cfgelems.h[6e57a9213340839aeac89e7417646451cc5bb706] -->
 <!--- generated from cfgunits.h[05f093223fce107d24dd157ebaafa351dc9df752] -->
 <!--- generated from _confgen.h[bb9a0fc6ef1f7f7c46790ee00132e340e5fff36d] -->
 <!--- generated from _confgen.c[0d833a6f2c98902f1249e63aed03a6164f0791d6] -->

--- a/etc/cyclonedds.rnc
+++ b/etc/cyclonedds.rnc
@@ -600,8 +600,8 @@ CycloneDDS configuration""" ] ]
           xsd:token { pattern = "((whc|rhc|xevent|all)(,(whc|rhc|xevent|all))*)|" }
         }?
         & [ a:documentation [ xml:lang="en" """
-<p>Whether to enable the IP_PKTINFO on UDP sockets to get hold of the packet destination address and interface on which it was received. This allows for better filtering on discovery packets, but comes at a small performance penalty.</p>
-<p>The default value is: <code>true</code></p>""" ] ]
+<p>Whether to enable the IP_PKTINFO on UDP sockets to get hold of the packet destination address and interface on which it was received. This allows for better filtering on discovery packets, but comes at a small performance penalty. Enabled by default if supported.</p>
+<p>The default value is: <code>default</code></p>""" ] ]
         element ExtendedPacketInfo {
           xsd:boolean
         }?
@@ -1439,9 +1439,9 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==<br>
   memsize = xsd:token { pattern = "0|(\d+(\.\d*)?([Ee][\-+]?\d+)?|\.\d+([Ee][\-+]?\d+)?) *([kMG]i?)?B" }
   maybe_memsize = xsd:token { pattern = "default|0|(\d+(\.\d*)?([Ee][\-+]?\d+)?|\.\d+([Ee][\-+]?\d+)?) *([kMG]i?)?B" }
 }
-# generated from ddsi_config.h[a96f2afb055d694037710e101e4431ceee2c7c94] 
+# generated from ddsi_config.h[94ad20bdb44ea1f393ba906865b1da591bbe1b57] 
 # generated from ddsi_config.c[9fb9ace4394a1b7d50f4e0fa3905bbba2a183e36] 
-# generated from ddsi__cfgelems.h[5137766e3f48f57c05c3745cc2a2380bf7af82cc] 
+# generated from ddsi__cfgelems.h[6e57a9213340839aeac89e7417646451cc5bb706] 
 # generated from cfgunits.h[05f093223fce107d24dd157ebaafa351dc9df752] 
 # generated from _confgen.h[bb9a0fc6ef1f7f7c46790ee00132e340e5fff36d] 
 # generated from _confgen.c[0d833a6f2c98902f1249e63aed03a6164f0791d6] 

--- a/etc/cyclonedds.xsd
+++ b/etc/cyclonedds.xsd
@@ -910,8 +910,8 @@ CycloneDDS configuration</xs:documentation>
   <xs:element name="ExtendedPacketInfo" type="xs:boolean">
     <xs:annotation>
       <xs:documentation>
-&lt;p&gt;Whether to enable the IP_PKTINFO on UDP sockets to get hold of the packet destination address and interface on which it was received. This allows for better filtering on discovery packets, but comes at a small performance penalty.&lt;/p&gt;
-&lt;p&gt;The default value is: &lt;code&gt;true&lt;/code&gt;&lt;/p&gt;</xs:documentation>
+&lt;p&gt;Whether to enable the IP_PKTINFO on UDP sockets to get hold of the packet destination address and interface on which it was received. This allows for better filtering on discovery packets, but comes at a small performance penalty. Enabled by default if supported.&lt;/p&gt;
+&lt;p&gt;The default value is: &lt;code&gt;default&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="GenerateKeyhash" type="xs:boolean">
@@ -2122,9 +2122,9 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
     </xs:restriction>
   </xs:simpleType>
 </xs:schema>
-<!--- generated from ddsi_config.h[a96f2afb055d694037710e101e4431ceee2c7c94] -->
+<!--- generated from ddsi_config.h[94ad20bdb44ea1f393ba906865b1da591bbe1b57] -->
 <!--- generated from ddsi_config.c[9fb9ace4394a1b7d50f4e0fa3905bbba2a183e36] -->
-<!--- generated from ddsi__cfgelems.h[5137766e3f48f57c05c3745cc2a2380bf7af82cc] -->
+<!--- generated from ddsi__cfgelems.h[6e57a9213340839aeac89e7417646451cc5bb706] -->
 <!--- generated from cfgunits.h[05f093223fce107d24dd157ebaafa351dc9df752] -->
 <!--- generated from _confgen.h[bb9a0fc6ef1f7f7c46790ee00132e340e5fff36d] -->
 <!--- generated from _confgen.c[0d833a6f2c98902f1249e63aed03a6164f0791d6] -->

--- a/src/core/ddsi/defconfig.c
+++ b/src/core/ddsi/defconfig.c
@@ -92,7 +92,6 @@ void ddsi_config_init_default (struct ddsi_config *cfg)
   cfg->max_rexmit_burst_size = UINT32_C (1048576);
   cfg->init_transmit_extra_pct = UINT32_C (4294967295);
   cfg->max_frags_in_rexmit_of_sample = UINT32_C (1);
-  cfg->extended_packet_info = INT32_C (1);
   cfg->tcp_nodelay = INT32_C (1);
   cfg->tcp_port = INT32_C (-1);
   cfg->tcp_read_timeout = INT64_C (2000000000);
@@ -108,9 +107,9 @@ void ddsi_config_init_default (struct ddsi_config *cfg)
   cfg->ssl_min_version.minor = 3;
 #endif /* DDS_HAS_TCP_TLS */
 }
-/* generated from ddsi_config.h[a96f2afb055d694037710e101e4431ceee2c7c94] */
+/* generated from ddsi_config.h[94ad20bdb44ea1f393ba906865b1da591bbe1b57] */
 /* generated from ddsi_config.c[9fb9ace4394a1b7d50f4e0fa3905bbba2a183e36] */
-/* generated from ddsi__cfgelems.h[5137766e3f48f57c05c3745cc2a2380bf7af82cc] */
+/* generated from ddsi__cfgelems.h[6e57a9213340839aeac89e7417646451cc5bb706] */
 /* generated from cfgunits.h[05f093223fce107d24dd157ebaafa351dc9df752] */
 /* generated from _confgen.h[bb9a0fc6ef1f7f7c46790ee00132e340e5fff36d] */
 /* generated from _confgen.c[0d833a6f2c98902f1249e63aed03a6164f0791d6] */

--- a/src/core/ddsi/include/dds/ddsi/ddsi_config.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_config.h
@@ -420,7 +420,7 @@ struct ddsi_config
   int retry_on_reject_besteffort;
   int generate_keyhash;
   uint32_t max_sample_size;
-  int extended_packet_info;
+  enum ddsi_boolean_default extended_packet_info;
 
   /* compability options */
   enum ddsi_standards_conformance standards_conformance;

--- a/src/core/ddsi/src/ddsi__cfgelems.h
+++ b/src/core/ddsi/src/ddsi__cfgelems.h
@@ -1742,14 +1742,14 @@ static struct cfgelem internal_cfgelems[] = {
     NOMEMBER,
     NOFUNCTIONS,
     DESCRIPTION("<p>Setting for controlling the size of transmitting bursts.</p>")),
-  BOOL("ExtendedPacketInfo", NULL, 1, "true",
+  BOOL("ExtendedPacketInfo", NULL, 1, "default",
     MEMBER(extended_packet_info),
-    FUNCTIONS(0, uf_boolean, 0, pf_boolean),
+    FUNCTIONS(0, uf_boolean_default, 0, pf_boolean_default),
     DESCRIPTION(
       "<p>Whether to enable the IP_PKTINFO on UDP sockets to get hold of the packet "
       "destination address and interface on which it was received. This allows "
       "for better filtering on discovery packets, but comes at a small performance "
-      "penalty.</p>")),
+      "penalty. Enabled by default if supported.</p>")),
   LIST("EnableExpensiveChecks", NULL, 1, "",
     MEMBER(enabled_xchecks),
     FUNCTIONS(0, uf_xcheck, 0, pf_xcheck),

--- a/src/core/ddsi/src/ddsi_udp.c
+++ b/src/core/ddsi/src/ddsi_udp.c
@@ -408,6 +408,7 @@ static dds_return_t set_dont_route (struct ddsi_domaingv const * const gv, ddsrt
   return rc;
 }
 
+#if PACKET_DESTINATION_INFO
  // Perhaps not all platforms support this, so only log errors on setting in the trace
 static dds_return_t setsockopt_pktinfo (struct ddsi_domaingv const * const gv, ddsrt_socket_t socket, bool ipv6)
 {
@@ -440,6 +441,7 @@ static dds_return_t setsockopt_pktinfo (struct ddsi_domaingv const * const gv, d
 #endif
   return rc;
 }
+#endif // PACKET_DESTINATION_INFO
 
 static dds_return_t set_socket_buffer (struct ddsi_domaingv const * const gv, ddsrt_socket_t sock, int32_t socket_option, const char *socket_option_name, const char *name, const struct ddsi_config_socket_buf_size *config, uint32_t default_min_size)
 {
@@ -692,12 +694,20 @@ static dds_return_t ddsi_udp_create_conn (struct ddsi_tran_conn **conn_out, stru
   if (gv->config.dontRoute && set_dont_route (gv, sock, ipv6) != DDS_RETCODE_OK)
     goto fail_w_socket;
 
+#if PACKET_DESTINATION_INFO
   // IP_PKTINFO on socket so we get to know the destination address and the interface
   // on which the packet was received.  If it doesn't work, we don't mind: it simply
   // means there is slightly less information available for making sense of addresses
   // or deciding whether multicast SPDP packet really is to be processed
-  if (gv->config.extended_packet_info)
+  if (gv->config.extended_packet_info != DDSI_BOOLDEF_FALSE)
     (void) setsockopt_pktinfo (gv, sock, ipv6);
+#else
+  if (gv->config.extended_packet_info == DDSI_BOOLDEF_TRUE)
+  {
+    GVERROR ("ddsi_udp_create_conn: ExtendedPacketInfo enabled in configuration but not supported\n");
+    goto fail_w_socket;
+  }
+#endif
 
   if ((rc = ddsrt_bind (sock, &socketname.a, ddsrt_sockaddr_get_size (&socketname.a))) != DDS_RETCODE_OK)
   {


### PR DESCRIPTION
The IP_PKTINFO / IPV6_PKTINFO socket option was set if defined and the ExtendedPacketInfo configuration setting was true, even when the PACKET_DESTINATION_INFO macro in the UDP support code was false. This means it is requesting packet information without providing a buffer, which on some platforms results in the MSG_CTRUNC flag getting set.

This avoids setting the PKTINFO socket option and graciously fails if the configuration option is set to true but the platform doesn't support it.

Fixes #2359  
Thanks @caiming100
