### PR TITLE
Fix OSS-Fuzz crash in vnet_write and address some coverity issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,10 @@ build/
 **/.DS_Store
 compile_commands.json
 .clangd
+
+# building the fuzzers creates these files:
+fuzz/fuzz_sample_deser/fuzz_sample.idl
+fuzz/fuzz_sample_deser/fuzz_sample_deser_seed_corpus/**
+fuzz/fuzz_sample_deser/fuzz_samples.h
+libprotobuf-mutator/**
+LPM/**

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build/
 .cache
 **/.DS_Store
 compile_commands.json
+.clangd

--- a/examples/dynsub/dyntypelib.c
+++ b/examples/dynsub/dyntypelib.c
@@ -388,7 +388,7 @@ static dds_return_t set_extensibility (const struct make_context *ctxt, dds_dyna
       rc = dds_dynamic_type_set_extensibility (dtype, DDS_DYNAMIC_TYPE_EXT_MUTABLE);
     else
       return dtl_set_error (err, elem, "unknown extensibility %s\n", ext);
-  } else 
+  } else
   {
     rc = dds_dynamic_type_set_extensibility (dtype, ctxt->dtl->default_extensibility);
   }
@@ -515,11 +515,13 @@ static dds_return_t make_union (const struct make_context *ctxt, const struct el
         labs[nlabs++] = (int32_t) strtol (valstr, &endptr, 0);
         if (*endptr)
         {
-          if (strcmp(getattr(discriminator_elem, "type"), "nonBasic") != 0)
-            return dtl_set_error (err, m, "junk at end of value\n");
+          if (getattr(discriminator_elem, "type") == NULL ||
+              strcmp(getattr(discriminator_elem, "type"), "nonBasic") != 0 ||
+              getattr(discriminator_elem, "nonBasicTypeName") == NULL)
+            return dtl_set_error (err, m, "junk at end of value / non enum type for discriminator\n");
           struct dyntype* d_enum = lookup_type(ctxt, ns, getattr(discriminator_elem, "nonBasicTypeName"));
-          if (d_enum->typeobj->_u.complete._d != DDS_XTypes_TK_ENUM)
-            return dtl_set_error (err, m, "Non eunm type for literal values\n");
+          if (d_enum == NULL || d_enum->typeobj->_u.complete._d != DDS_XTypes_TK_ENUM)
+            return dtl_set_error (err, m, "Non enum type for literal values\n");
           const DDS_XTypes_CompleteEnumeratedType *c_enum = &d_enum->typeobj->_u.complete._u.enumerated_type;
           bool enum_contains_value = false;
           for (uint32_t i = 0; i < c_enum->literal_seq._length; i++)

--- a/examples/dynsub/scan_sample.c
+++ b/examples/dynsub/scan_sample.c
@@ -468,7 +468,7 @@ static bool scan_sample1_to (struct dyntypelib *dtl, unsigned char *obj, DDS_XTy
         *((uint64_t *) obj) = v;
       else if (t->header.common.bit_bound > 16)
         *((uint32_t *) obj) = (uint32_t) v;
-      else if (t->header.common.bit_bound > 16)
+      else if (t->header.common.bit_bound > 8)
         *((uint16_t *) obj) = (uint16_t) v;
       else
         *((uint8_t *) obj) = (uint8_t) v;

--- a/examples/dynsub/size_and_align.c
+++ b/examples/dynsub/size_and_align.c
@@ -160,8 +160,10 @@ void *dtl_advance_string_ti (unsigned char *base, size_t *off, const DDS_XTypes_
 void *dtl_advance_ti (struct dyntypelib *dtl, unsigned char *base, size_t *off, const DDS_XTypes_TypeIdentifier *typeid, bool is_opt_or_ext)
 {
   // Advancing over an @optional or @external always means advancing over a pointer
-  if (is_opt_or_ext)
+  if (is_opt_or_ext) {
+    // coverity[suspicious_sizeof:FALSE]
     return dtl_align (base, off, _Alignof (void *), sizeof (void *));
+  }
 
   void *p = dtl_advance_simple (base, off, typeid->_d);
   if (p != NULL)
@@ -216,8 +218,10 @@ void *dtl_advance_ti (struct dyntypelib *dtl, unsigned char *base, size_t *off, 
 void *dtl_advance_to (struct dyntypelib *dtl, unsigned char *base, size_t *off, const DDS_XTypes_CompleteTypeObject *typeobj, bool is_opt_or_ext)
 {
   // Advancing over an @optional or @external always means advancing over a pointer
-  if (is_opt_or_ext)
+  if (is_opt_or_ext) {
+    // coverity[suspicious_sizeof:FALSE]
     return dtl_align (base, off, _Alignof (void *), sizeof (void *));
+  }
 
   void *p = dtl_advance_simple (base, off, typeobj->_d);
   if (p != NULL)
@@ -311,4 +315,3 @@ size_t dtl_get_typeobj_size (struct dyntypelib *dtl, DDS_XTypes_CompleteTypeObje
 {
   return get_typeid_typeobj_size (dtl, typeobj->_d, typeobj);
 }
-

--- a/fuzz/fuzz_handshake/CMakeLists.txt
+++ b/fuzz/fuzz_handshake/CMakeLists.txt
@@ -22,6 +22,7 @@ set(protobuf_DIR "${PROTOBUF_ROOT}/lib/cmake/protobuf")
 # ...sometime in the future these two statements should suffice:
 set(Protobuf_USE_STATIC_LIBS ON)
 find_package(protobuf REQUIRED CONFIG)
+find_package(OpenSSL REQUIRED)
 
 add_library(fuzz_handshake_harness fuzz_handshake_harness.c)
 target_include_directories(
@@ -39,6 +40,7 @@ target_include_directories(
   "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src/security/core/tests>"
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../src/security/api/include>"
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../install/include>")
+target_link_libraries(fuzz_handshake_harness PRIVATE OpenSSL::SSL)
 
 add_executable(fuzz_handshake fuzz_handshake.cc)
 protobuf_generate(TARGET fuzz_handshake LANGUAGE cpp PROTOS "${CMAKE_CURRENT_SOURCE_DIR}/fuzz_handshake.proto")
@@ -50,8 +52,6 @@ target_include_directories(
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../install/include>"
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/>")
 
-
-find_package(OpenSSL REQUIRED)
 target_link_libraries(fuzz_handshake
     fuzz_handshake_harness
     ${CMAKE_BINARY_DIR}/../LPM/src/libfuzzer/libprotobuf-mutator-libfuzzer.a

--- a/fuzz/fuzz_handshake/patch_abseil_randen_copts.cmake
+++ b/fuzz/fuzz_handshake/patch_abseil_randen_copts.cmake
@@ -1,0 +1,15 @@
+if(NOT DEFINED PROTOBUF_SOURCE_DIR)
+  message(FATAL_ERROR "PROTOBUF_SOURCE_DIR is not set")
+endif()
+
+set(abseil_copts "${PROTOBUF_SOURCE_DIR}/third_party/abseil-cpp/absl/copts/AbseilConfigureCopts.cmake")
+if(NOT EXISTS "${abseil_copts}")
+  message(FATAL_ERROR "Cannot find ${abseil_copts}")
+endif()
+
+file(READ "${abseil_copts}" contents)
+string(REPLACE
+  [=[list(APPEND ABSL_RANDOM_RANDEN_COPTS "-Xarch_${_arch}" "${_flag}")]=]
+  [=[list(APPEND ABSL_RANDOM_RANDEN_COPTS "SHELL:-Xarch_${_arch} ${_flag}")]=]
+  contents "${contents}")
+file(WRITE "${abseil_copts}" "${contents}")

--- a/fuzz/fuzz_handshake/patch_lpm.py
+++ b/fuzz/fuzz_handshake/patch_lpm.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+import shutil
+import sys
+
+
+def replace_once(text, old, new, path):
+    if new in text:
+        return text
+    if old not in text:
+        raise SystemExit(f"cannot find expected text in {path}")
+    return text.replace(old, new, 1)
+
+
+def main():
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: patch_lpm.py LIBPROTOBUF_MUTATOR_DIR")
+
+    lpm_source = Path(sys.argv[1])
+    lpm_cmake = lpm_source / "CMakeLists.txt"
+    protobuf_cmake = lpm_source / "cmake" / "external" / "protobuf.cmake"
+    if not lpm_cmake.exists():
+        raise SystemExit(f"cannot find {lpm_cmake}")
+    if not protobuf_cmake.exists():
+        raise SystemExit(f"cannot find {protobuf_cmake}")
+
+    patch_script = Path(__file__).with_name("patch_abseil_randen_copts.cmake")
+    copied_patch_script = protobuf_cmake.with_name("patch_abseil_randen_copts.cmake")
+    shutil.copyfile(patch_script, copied_patch_script)
+
+    text = protobuf_cmake.read_text()
+    text = replace_once(
+        text,
+        "include_directories(${PROTOBUF_INCLUDE_DIRS})\n"
+        "include_directories(${CMAKE_CURRENT_BINARY_DIR})",
+        "include_directories(BEFORE ${PROTOBUF_INCLUDE_DIRS})\n"
+        "include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR})",
+        protobuf_cmake,
+    )
+    text = replace_once(
+        text,
+        '    UPDATE_COMMAND ""\n',
+        '    UPDATE_COMMAND ""\n'
+        '    PATCH_COMMAND ${CMAKE_COMMAND} -DPROTOBUF_SOURCE_DIR=<SOURCE_DIR> -P ${CMAKE_CURRENT_LIST_DIR}/patch_abseil_randen_copts.cmake\n',
+        protobuf_cmake,
+    )
+    text = replace_once(
+        text,
+        "        -Dprotobuf_BUILD_TESTS=OFF\n",
+        "        -Dprotobuf_BUILD_TESTS=OFF\n"
+        "        -Dprotobuf_WITH_ZLIB=OFF\n",
+        protobuf_cmake,
+    )
+    protobuf_cmake.write_text(text)
+
+    text = lpm_cmake.read_text()
+    text = text.replace("include_directories(${LIBLZMA_INCLUDE_DIRS})\n", "")
+    text = text.replace("include_directories(${ZLIB_INCLUDE_DIRS})\n", "")
+    lpm_cmake.write_text(text)
+
+
+if __name__ == "__main__":
+    main()

--- a/fuzz/local.sh
+++ b/fuzz/local.sh
@@ -21,17 +21,35 @@ fi
 
 set -ex
 
+if [ -z "${CC:-}" ] && [ -x /opt/homebrew/opt/llvm/bin/clang ] ; then
+    export CC=/opt/homebrew/opt/llvm/bin/clang
+else
+    export CC="${CC:-clang}"
+fi
+if [ -z "${CXX:-}" ] && [ -x /opt/homebrew/opt/llvm/bin/clang++ ] ; then
+    export CXX=/opt/homebrew/opt/llvm/bin/clang++
+else
+    export CXX="${CXX:-clang++}"
+fi
+if [ -z "${LIB_FUZZING_ENGINE:-}" ] && [ -f /usr/lib/llvm-18/lib/libFuzzer.a ] ; then
+    export LIB_FUZZING_ENGINE=/usr/lib/llvm-18/lib/libFuzzer.a
+else
+    export LIB_FUZZING_ENGINE="${LIB_FUZZING_ENGINE:-}"
+fi
+
 # hopefully Cyclone will never gain a "libprotobuf-mutator" or "LPM" subdirectory so that
 # we can keep populate it to match oss-fuzz here and not have to deal with
 # absl/utf8_range/protobuf horrors any more than this
 if [ ! -d ../LPM ] ; then
     [ ! -d ../libprotobuf-mutator ] && \
          git clone --depth 1 https://github.com/google/libprotobuf-mutator.git ../libprotobuf-mutator
+    python3 ../fuzz/fuzz_handshake/patch_lpm.py ../libprotobuf-mutator
     mkdir ../LPM
     (cd ../LPM && \
          cmake ../libprotobuf-mutator -GNinja \
                -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON \
                -DLIB_PROTO_MUTATOR_TESTING=OFF \
+               -DLIB_PROTO_MUTATOR_EXAMPLES=OFF \
                -DCMAKE_BUILD_TYPE=Release && \
          ninja)
 fi
@@ -41,13 +59,35 @@ export LD_LIBRARY_PATH="$CYCLONEDDS_HOME/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH
 export PATH="$CYCLONEDDS_HOME/lib:$PATH"
 export PYTHONPATH="$CYCLONEDDS_PYTHON/tests/support_modules${PYTHONPATH:+:$PYTHONPATH}"
 
+if [ -z "${PYTHON:-}" ] ; then
+    for p in \
+        "$CYCLONEDDS_PYTHON/venv.3.14/bin/python" \
+        "$CYCLONEDDS_PYTHON/venv.3.13/bin/python" \
+        "$CYCLONEDDS_PYTHON/venv.3.12/bin/python" \
+        "$CYCLONEDDS_PYTHON/venv.3.11/bin/python" \
+        "$CYCLONEDDS_PYTHON/venv.3.10/bin/python" \
+        "$CYCLONEDDS_PYTHON/venv/bin/python" \
+        python3.14 python3.13 python3.12 python3.11 python3.10 python3 ; do
+        if command -v "$p" >/dev/null 2>&1 ; then
+            PYTHON=$p
+            break
+        fi
+    done
+fi
+if [ -z "${PYTHON:-}" ] ; then
+    echo "Need Python 3.10 or newer" 2>&1
+    exit 1
+fi
+"$PYTHON" - <<'PY'
+import sys
+if sys.version_info < (3, 10):
+    raise SystemExit("need Python 3.10 or newer")
+PY
+export PATH="$(dirname "$PYTHON"):$PATH"
+
 # Use current git HEAD hash as seed
 [ -z "$SEED" ] && SEED=$(git ls-remote https://github.com/eclipse-cyclonedds/cyclonedds HEAD |cut -f1)
-python3 "../fuzz/fuzz_sample_deser/generate_idl.py" $SEED "../fuzz/fuzz_sample_deser"
-
-export CC=clang
-export CXX=clang++
-export LIB_FUZZING_ENGINE=/usr/lib/llvm-18/lib/libFuzzer.a
+"$PYTHON" "../fuzz/fuzz_sample_deser/generate_idl.py" $SEED "../fuzz/fuzz_sample_deser"
 
 cmake -G Ninja \
       -DSANITIZER=address,undefined,fuzzer \

--- a/src/core/cdr/src/dds_cdrstream.c
+++ b/src/core/cdr/src/dds_cdrstream.c
@@ -1471,7 +1471,7 @@ static uint64_t read_union_discriminant (dds_istream_t *is, uint32_t insn)
     case DDS_SOP_VAL_BMK:
       return read_varsized_as_uint64 (is, insn);
     default:
-      return 0;
+      break;
   }
   abort ();
   return 0;

--- a/src/core/ddsc/tests/cdrstream.c
+++ b/src/core/ddsc/tests/cdrstream.c
@@ -3001,7 +3001,7 @@ CU_Test (ddsc_cdrstream, tryconstruct_nested_seq)
       for (uint32_t n0 = 1; n0 <= 4; n0++)
       {
         const uint32_t n0cmp = (n0 <= 3) ? n0 : (tc0 == TRIM) ? 3 : 0;
-        for (uint32_t n1 = 4; n1 <= 4; n1++)
+        for (uint32_t n1 = 0; n1 <= 4; n1++)
         {
           const uint32_t n1cmp = (n1 <= 3) ? n1 : (tc1 == TRIM) ? 3 : 0;
           struct CdrStreamTryconstruct_t7 a;

--- a/src/core/ddsc/tests/reader.c
+++ b/src/core/ddsc/tests/reader.c
@@ -3228,7 +3228,7 @@ static bool test_long_2_eq_2 (const void *vsample)
   return (sample->long_2 == 2);
 }
 
-static void do_readtake_sample_rank (const char *opname_past_tense, dds_return_t (*op) (dds_entity_t reader_or_condition, void **buf, dds_sample_info_t *si, size_t bufsz, uint32_t maxs, uint32_t mask))
+static void do_readtake_sample_rank (const char *opname_past_tense, dds_return_t (*op) (dds_entity_t reader_or_condition, void **buf, dds_sample_info_t *si, size_t bufsz, uint32_t maxs, uint32_t mask), bool verbose)
 {
   const dds_entity_t dp = dds_create_participant (0, NULL, NULL);
   CU_ASSERT_GT_FATAL (dp, 0);
@@ -3250,17 +3250,23 @@ static void do_readtake_sample_rank (const char *opname_past_tense, dds_return_t
   while (nsamp[3] == 0)
   {
     int totsamp = 0;
-    tprintf ("samples/instance: ");
+    if (verbose)
+      tprintf ("samples/instance: ");
     for (int i = 0; nsamp[i] > 0; i++) {
       totsamp += nsamp[i];
-      printf (" %d", nsamp[i]);
+      if (verbose)
+        printf (" %d", nsamp[i]);
     }
-    printf ("\n");
-    fflush (stdout);
+    if (verbose)
+    {
+      printf ("\n");
+      fflush (stdout);
+    }
 
     for (int skip_even_long_2 = 0; skip_even_long_2 <= 1; skip_even_long_2++)
     {
-      tprintf ("  skip_even_long_2 %d\n", skip_even_long_2);
+      if (verbose)
+        tprintf ("  skip_even_long_2 %d\n", skip_even_long_2);
       int totsamp_after_maybe_skipping_even = 0;
       if (!skip_even_long_2)
         totsamp_after_maybe_skipping_even = totsamp;
@@ -3339,11 +3345,14 @@ static void do_readtake_sample_rank (const char *opname_past_tense, dds_return_t
 
         assert (rdlimit < (int) (sizeof (xs) / sizeof (xs[0])));
         int n = (int) op (rd, buf, si, (size_t) rdlimit, (uint32_t) rdlimit, (skip_even_long_2 ? DDS_NOT_READ_SAMPLE_STATE : 0));
-        tprintf ("  -- %s %d (<= %d), ranks:", opname_past_tense, n, rdlimit);
-        for (int i = 0; i < n; i++)
-          printf (" %"PRIu32, si[i].sample_rank);
-        printf ("\n");
-        fflush (stdout);
+        if (verbose)
+        {
+          tprintf ("  -- %s %d (<= %d), ranks:", opname_past_tense, n, rdlimit);
+          for (int i = 0; i < n; i++)
+            printf (" %"PRIu32, si[i].sample_rank);
+          printf ("\n");
+          fflush (stdout);
+        }
         CU_ASSERT_NEQ_FATAL (n == ((rdlimit <= totsamp_after_maybe_skipping_even) ? rdlimit : totsamp_after_maybe_skipping_even), 0);
 
         {
@@ -3387,12 +3396,12 @@ static void do_readtake_sample_rank (const char *opname_past_tense, dds_return_t
 
 CU_Test (ddsc_read, sample_rank)
 {
-  do_readtake_sample_rank ("read", dds_read_mask);
+  do_readtake_sample_rank ("read", dds_read_mask, false);
 }
 
 CU_Test (ddsc_take, sample_rank)
 {
-  do_readtake_sample_rank ("took", dds_take_mask);
+  do_readtake_sample_rank ("took", dds_take_mask, false);
 }
 
 static void ddsc_peek_setup (dds_entity_t *dp, dds_entity_t *rd, dds_instance_handle_t *ih)

--- a/src/core/ddsi/src/ddsi_plist.c
+++ b/src/core/ddsi/src/ddsi_plist.c
@@ -1161,7 +1161,7 @@ static dds_return_t deser_generic_r (void * restrict dst, size_t * restrict dsto
         if (deser_uint32 (&x->length, dd, srcoff) < 0 || x->length > dd->bufsz - *srcoff)
           goto fail;
         const size_t elem_size = ser_generic_srcsize (desc + 1);
-        if (x->length > UINT32_MAX / elem_size)
+        if (elem_size != 0 && x->length > UINT32_MAX / elem_size)
           goto fail;
         if (x->length == 0)
           x->value = NULL;

--- a/src/core/ddsi/src/ddsi_vnet.c
+++ b/src/core/ddsi/src/ddsi_vnet.c
@@ -71,7 +71,8 @@ static dds_return_t ddsi_vnet_conn_write (struct ddsi_tran_conn * conn_cmn, cons
   ddsrt_iov_len_t n = 0;
   for (size_t i = 0; i < msgfrags->niov; i++)
     n += msgfrags->iov[i].iov_len;
-  *bytes_written = n;
+  if (bytes_written)
+    *bytes_written = n;
   return DDS_RETCODE_OK;
 }
 

--- a/src/security/core/src/dds_security_serialize.c
+++ b/src/security/core/src/dds_security_serialize.c
@@ -9,6 +9,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 #include <assert.h>
+#include <stdint.h>
 #include <string.h>
 #include "dds/ddsrt/bswap.h"
 #include "dds/ddsrt/heap.h"
@@ -604,6 +605,14 @@ DDS_Security_Deserialize_OctetSeq(
 }
 
 static int
+DDS_Security_Deserialize_seq_alloc_size_ok(
+     uint32_t length,
+     size_t elem_size)
+{
+    return elem_size == 0 || length <= UINT32_MAX / elem_size;
+}
+
+static int
 DDS_Security_Deserialize_Property(
      DDS_Security_Deserializer dser,
      DDS_Security_Property_t *property)
@@ -638,6 +647,9 @@ DDS_Security_Deserialize_PropertySeq(
     if (length > dser->remain / minpropsize) {
         return 0;
     }
+    if (!DDS_Security_Deserialize_seq_alloc_size_ok(length, sizeof(*seq->_buffer))) {
+        return 0;
+    }
     DDS_Security_PropertySeq_deinit(seq);
     seq->_length = seq->_maximum = length;
     seq->_buffer = (seq->_length == 0) ? NULL : DDS_Security_PropertySeq_allocbuf(seq->_length);
@@ -662,6 +674,9 @@ DDS_Security_Deserialize_BinaryPropertySeq(
         return 0;
     }
     if (length > dser->remain / minpropsize) {
+        return 0;
+    }
+    if (!DDS_Security_Deserialize_seq_alloc_size_ok(length, sizeof(*seq->_buffer))) {
         return 0;
     }
     DDS_Security_BinaryPropertySeq_deinit(seq);


### PR DESCRIPTION
The crash is limited to the fuzzing test itself.

The coverity issues are mostly unimportant, the only real bug is in the handling of 16-bit bitmasks in the `xmltype` "example", so also relatively benign.