### PR TITLE
Some improvements to `xmltype`

### DIFF
--- a/examples/dynsub/dyntypelib.c
+++ b/examples/dynsub/dyntypelib.c
@@ -579,6 +579,7 @@ static dds_return_t make_enum (const struct make_context *ctxt, const struct ele
       return dtl_set_error (err, elem, "set_bit_bound failed: %s\n", dds_strretcode (rc));
   }
 
+  bool have_deflit = false;
   for (const struct elem *m = elem->children; m; m = m->next)
   {
     if (strcmp (m->name, "enumerator") != 0)
@@ -594,8 +595,25 @@ static dds_return_t make_enum (const struct make_context *ctxt, const struct ele
     int pos;
     if (sscanf (valuestr, "%"SCNd32"%n", &value, &pos) != 1 || valuestr[pos] != 0)
       return dtl_set_error (err, m, "value not a plain integer %s\n", valuestr);
+    const char *deflitstr = getattr (m, "defaultLiteral");
+    bool deflit = false;
+    if (deflitstr != NULL)
+    {
+      if (strcmp (deflitstr, "true") == 0)
+        deflit = true;
+      else if (strcmp (deflitstr, "false") == 0)
+        deflit = false;
+      else
+        return dtl_set_error (err, m, "defaultLiteral %s not valid\n", deflitstr);
+    }
+    if (deflit)
+    {
+      if (have_deflit)
+        return dtl_set_error (err, m, "multiple default literals\n");
+      have_deflit = true;
+    }
 
-    rc = dds_dynamic_type_add_enum_literal (denum, mname, DDS_DYNAMIC_ENUM_LITERAL_VALUE(value), false);
+    rc = dds_dynamic_type_add_enum_literal (denum, mname, DDS_DYNAMIC_ENUM_LITERAL_VALUE(value), deflit);
     if (rc != DDS_RETCODE_OK)
       return dtl_set_error (err, m, "add_enum_literal failed: %s\n",  dds_strretcode (rc));
   }

--- a/examples/dynsub/print_sample.c
+++ b/examples/dynsub/print_sample.c
@@ -305,14 +305,17 @@ static void print_sample1_to (struct type_cache *tc, const unsigned char *sample
       struct typeinfo templ = { .key = { .key = (uintptr_t) typeobj } }, *info = type_cache_lookup (tc, &templ);
       const DDS_XTypes_CompleteEnumeratedType *t = &typeobj->_u.enumerated_type;
       const int *p = align (sample, c, info->align, info->size);
-      if (c->needs_comma) fputc (',', stdout);
-      if (label) printf ("\"%s\":", label);
-      for (uint32_t l = 0; l < t->literal_seq._length; l++)
+      if (c->key || c->valid_data)
       {
-        if (t->literal_seq._buffer[l].common.value == *p)
-          printf ("\"%s\"", t->literal_seq._buffer[l].detail.name);
+        if (c->needs_comma) fputc (',', stdout);
+        if (label) printf ("\"%s\":", label);
+        for (uint32_t l = 0; l < t->literal_seq._length; l++)
+        {
+          if (t->literal_seq._buffer[l].common.value == *p)
+            printf ("\"%s\"", t->literal_seq._buffer[l].detail.name);
+        }
+        c->needs_comma = true;
       }
-      c->needs_comma = true;
       break;
     }
     case DDS_XTypes_TK_UNION: {

--- a/examples/dynsub/print_type.c
+++ b/examples/dynsub/print_type.c
@@ -52,13 +52,26 @@ static void ppc_print_equivhash (struct ppc *ppc, const DDS_XTypes_EquivalenceHa
              (unsigned) id[12], (unsigned) id[13]);
 }
 
-static void ppc_print_memberflags (struct ppc *ppc, DDS_XTypes_MemberFlag flag)
+static void ppc_print_memberflags (struct ppc *ppc, DDS_XTypes_MemberFlag flag, const char *name, bool has_tc)
 {
+  const char *tcstr = "TRY_CONSTRUCT(INVALID)";
   const char *sep = "";
-  ppc_print (ppc, "memberflags={");
+  ppc_print (ppc, "%sflags={", name);
+  if (has_tc)
+  {
+    switch (flag & (DDS_XTypes_TRY_CONSTRUCT1 | DDS_XTypes_TRY_CONSTRUCT2))
+    {
+      case DDS_XTypes_TRY_CONSTRUCT1: tcstr = "DISCARD"; break;
+      case DDS_XTypes_TRY_CONSTRUCT2: tcstr = "USE_DEFAULT"; break;
+      case DDS_XTypes_TRY_CONSTRUCT1 | DDS_XTypes_TRY_CONSTRUCT2: tcstr = "TRIM"; break;
+    }
+    ppc_print (ppc, "%s", tcstr);
+    flag &= (uint16_t)~(DDS_XTypes_TRY_CONSTRUCT1 | DDS_XTypes_TRY_CONSTRUCT2);
+    sep = ",";
+  }
 #define PF(flagname) do { \
     if (flag & DDS_XTypes_##flagname) { \
-      ppc_print (ppc, "%s%s", sep, #flagname); \
+      ppc_print (ppc, "%s%s", sep, #flagname);   \
       flag &= (uint16_t)~DDS_XTypes_##flagname; \
       sep = ","; \
     } \
@@ -70,6 +83,7 @@ static void ppc_print_memberflags (struct ppc *ppc, DDS_XTypes_MemberFlag flag)
   PF(IS_MUST_UNDERSTAND);
   PF(IS_KEY);
   PF(IS_DEFAULT);
+#undef PF
   if (flag)
     ppc_print (ppc, "%s0x%"PRIx16, sep, flag);
   ppc_print (ppc, "}");
@@ -91,6 +105,7 @@ static void ppc_print_typeflags (struct ppc *ppc, DDS_XTypes_TypeFlag flag)
   PF(IS_MUTABLE);
   PF(IS_NESTED);
   PF(IS_AUTOID_HASH);
+#undef PF
   if (flag)
     ppc_print (ppc, "%s0x%"PRIx16, sep, flag);
   ppc_print (ppc, "}");
@@ -286,7 +301,7 @@ void ppc_print_ti (struct type_cache *tc, struct ppc *ppc, const DDS_XTypes_Type
         default: ppc_print (ppc, "%02"PRIx8, header->equiv_kind);
       }
       ppc_print (ppc, " ");
-      ppc_print_memberflags (ppc, header->element_flags);
+      ppc_print_memberflags (ppc, header->element_flags, "element", true);
       ppc_print (ppc, "\n");
       ppc_indent (ppc);
       ppc_print_ti (tc, ppc, et);
@@ -318,7 +333,7 @@ void ppc_print_ti (struct type_cache *tc, struct ppc *ppc, const DDS_XTypes_Type
         default: ppc_print (ppc, "%02"PRIx8, header->equiv_kind);
       }
       ppc_print (ppc, " ");
-      ppc_print_memberflags (ppc, header->element_flags);
+      ppc_print_memberflags (ppc, header->element_flags, "element", true);
       ppc_print (ppc, "\n");
       ppc_indent (ppc);
       ppc_print_ti (tc, ppc, et);
@@ -379,7 +394,7 @@ void ppc_print_to (struct type_cache *tc, struct ppc *ppc, const DDS_XTypes_Comp
       ppc_indent (ppc);
       ppc_print_builtin_member_annots (ppc, x->body.ann_builtin);
       ppc_print_annots (ppc, x->body.ann_custom);
-      ppc_print_memberflags (ppc, x->body.common.related_flags);
+      ppc_print_memberflags (ppc, x->body.common.related_flags, "related_", false);
       ppc_print (ppc, "\n");
       ppc_print_ti (tc, ppc, &x->body.common.related_type);
       ppc_outdent (ppc);
@@ -396,7 +411,7 @@ void ppc_print_to (struct type_cache *tc, struct ppc *ppc, const DDS_XTypes_Comp
       {
         const DDS_XTypes_CompleteEnumeratedLiteral *l = &x->literal_seq._buffer[i];
         ppc_print (ppc, "%s = %"PRId32" ", l->detail.name, l->common.value);
-        ppc_print_memberflags (ppc, l->common.flags);
+        ppc_print_memberflags (ppc, l->common.flags, "member", false);
         ppc_print_memberdetail_sans_name (ppc, &l->detail);
         ppc_print (ppc, "\n");
       }
@@ -414,7 +429,7 @@ void ppc_print_to (struct type_cache *tc, struct ppc *ppc, const DDS_XTypes_Comp
       {
         const DDS_XTypes_CompleteBitflag *l = &x->flag_seq._buffer[i];
         ppc_print (ppc, "%s = %"PRIu32" ", l->detail.name, l->common.position);
-        ppc_print_memberflags (ppc, l->common.flags);
+        ppc_print_memberflags (ppc, l->common.flags, "member", false);
         ppc_print_memberdetail_sans_name (ppc, &l->detail);
         ppc_print (ppc, "\n");
       }
@@ -425,7 +440,7 @@ void ppc_print_to (struct type_cache *tc, struct ppc *ppc, const DDS_XTypes_Comp
       const DDS_XTypes_CompleteSequenceType *x = &typeobj->_u.sequence_type;
       ppc_print (ppc, "SEQUENCE bound=%"PRIu32" ", x->header.common.bound);
       ppc_print_typeflags (ppc, x->collection_flag);
-      ppc_print_memberflags (ppc, x->element.common.element_flags);
+      ppc_print_memberflags (ppc, x->element.common.element_flags, "element", true);
       ppc_print_typedetail (ppc, x->header.detail);
       ppc_print (ppc, "\n");
       ppc_indent (ppc);
@@ -453,7 +468,7 @@ void ppc_print_to (struct type_cache *tc, struct ppc *ppc, const DDS_XTypes_Comp
         const DDS_XTypes_CompleteStructMember *m = &t->member_seq._buffer[i];
         ppc_print (ppc, "name=%s ", m->detail.name);
         ppc_print (ppc, "memberid=0x%"PRIx32" ", m->common.member_id);
-        ppc_print_memberflags (ppc, m->common.member_flags);
+        ppc_print_memberflags (ppc, m->common.member_flags, "member", true);
         ppc_print (ppc, "\n");
         ppc_indent (ppc);
         ppc_print_memberdetail_sans_name (ppc, &m->detail);
@@ -474,7 +489,7 @@ void ppc_print_to (struct type_cache *tc, struct ppc *ppc, const DDS_XTypes_Comp
       ppc_print (ppc, "discriminator=");
       ppc_indent (ppc);
       const DDS_XTypes_CompleteDiscriminatorMember *disc = &t->discriminator;
-      ppc_print_memberflags (ppc, disc->common.member_flags);
+      ppc_print_memberflags (ppc, disc->common.member_flags, "member", true);
       ppc_print (ppc, " ");
       ppc_print_ti (tc, ppc, &disc->common.type_id);
       ppc_print_builtin_type_annots (ppc, disc->ann_builtin);
@@ -490,7 +505,7 @@ void ppc_print_to (struct type_cache *tc, struct ppc *ppc, const DDS_XTypes_Comp
         ppc_indent (ppc);
         ppc_print (ppc, "name=%s ", m->detail.name);
         ppc_print (ppc, "memberid=0x%"PRIx32" ", m->common.member_id);
-        ppc_print_memberflags (ppc, m->common.member_flags);
+        ppc_print_memberflags (ppc, m->common.member_flags, "member", true);
         ppc_print (ppc, "\n");
         ppc_indent (ppc);
         ppc_print_memberdetail_sans_name (ppc, &m->detail);
@@ -520,7 +535,7 @@ void ppc_print_to_min (struct type_cache *tc, struct ppc *ppc, const DDS_XTypes_
       ppc_print_typeflags (ppc, x->alias_flags);
       ppc_print (ppc, "\n");
       ppc_indent (ppc);
-      ppc_print_memberflags (ppc, x->body.common.related_flags);
+      ppc_print_memberflags (ppc, x->body.common.related_flags, "related_", false);
       ppc_print (ppc, "\n");
       ppc_print_ti (tc, ppc, &x->body.common.related_type);
       ppc_outdent (ppc);
@@ -536,7 +551,7 @@ void ppc_print_to_min (struct type_cache *tc, struct ppc *ppc, const DDS_XTypes_
       {
         const DDS_XTypes_MinimalEnumeratedLiteral *l = &x->literal_seq._buffer[i];
         ppc_print (ppc, "%02"PRIx8"%02"PRIx8"%02"PRIx8"%02"PRIx8" = %"PRId32" ", l->detail.name_hash[0], l->detail.name_hash[1], l->detail.name_hash[2], l->detail.name_hash[3], l->common.value);
-        ppc_print_memberflags (ppc, l->common.flags);
+        ppc_print_memberflags (ppc, l->common.flags, "member", false);
         ppc_print (ppc, "\n");
       }
       ppc_outdent (ppc);
@@ -552,7 +567,7 @@ void ppc_print_to_min (struct type_cache *tc, struct ppc *ppc, const DDS_XTypes_
       {
         const DDS_XTypes_MinimalBitflag *l = &x->flag_seq._buffer[i];
         ppc_print (ppc, "%02"PRIx8"%02"PRIx8"%02"PRIx8"%02"PRIx8" = %"PRId32" ", l->detail.name_hash[0], l->detail.name_hash[1], l->detail.name_hash[2], l->detail.name_hash[3], l->common.position);
-        ppc_print_memberflags (ppc, l->common.flags);
+        ppc_print_memberflags (ppc, l->common.flags, "member", false);
         ppc_print (ppc, "\n");
       }
       ppc_outdent (ppc);
@@ -562,7 +577,7 @@ void ppc_print_to_min (struct type_cache *tc, struct ppc *ppc, const DDS_XTypes_
       const DDS_XTypes_MinimalSequenceType *x = &typeobj->_u.sequence_type;
       ppc_print (ppc, "SEQUENCE bound=%"PRIu32" ", x->header.common.bound);
       ppc_print_typeflags (ppc, x->collection_flag);
-      ppc_print_memberflags (ppc, x->element.common.element_flags);
+      ppc_print_memberflags (ppc, x->element.common.element_flags, "element", true);
       ppc_print (ppc, "\n");
       ppc_indent (ppc);
       ppc_print_ti (tc, ppc, &x->element.common.type);
@@ -587,7 +602,7 @@ void ppc_print_to_min (struct type_cache *tc, struct ppc *ppc, const DDS_XTypes_
         const DDS_XTypes_MinimalStructMember *m = &t->member_seq._buffer[i];
         ppc_print (ppc, "name_hash=%02"PRIx8"%02"PRIx8"%02"PRIx8"%02"PRIx8" ", m->detail.name_hash[0], m->detail.name_hash[1], m->detail.name_hash[2], m->detail.name_hash[3]);
         ppc_print (ppc, "memberid=0x%"PRIx32" ", m->common.member_id);
-        ppc_print_memberflags (ppc, m->common.member_flags);
+        ppc_print_memberflags (ppc, m->common.member_flags, "member", true);
         ppc_print (ppc, "\n");
         ppc_indent (ppc);
         ppc_print_ti (tc, ppc, &m->common.member_type_id);
@@ -605,7 +620,7 @@ void ppc_print_to_min (struct type_cache *tc, struct ppc *ppc, const DDS_XTypes_
       ppc_print (ppc, "discriminator=");
       ppc_indent (ppc);
       const DDS_XTypes_MinimalDiscriminatorMember *disc = &t->discriminator;
-      ppc_print_memberflags (ppc, disc->common.member_flags);
+      ppc_print_memberflags (ppc, disc->common.member_flags, "member", true);
       ppc_print (ppc, " ");
       ppc_print_ti (tc, ppc, &disc->common.type_id);
       ppc_outdent (ppc);
@@ -619,7 +634,7 @@ void ppc_print_to_min (struct type_cache *tc, struct ppc *ppc, const DDS_XTypes_
         ppc_indent (ppc);
         ppc_print (ppc, "name_hash=%02"PRIx8"%02"PRIx8"%02"PRIx8"%02"PRIx8" ", m->detail.name_hash[0], m->detail.name_hash[1], m->detail.name_hash[2], m->detail.name_hash[3]);
         ppc_print (ppc, "memberid=0x%"PRIx32" ", m->common.member_id);
-        ppc_print_memberflags (ppc, m->common.member_flags);
+        ppc_print_memberflags (ppc, m->common.member_flags, "member", true);
         ppc_print (ppc, "\n");
         ppc_indent (ppc);
         ppc_print_ti (tc, ppc, &m->common.type_id);

--- a/examples/dynsub/scan_sample.c
+++ b/examples/dynsub/scan_sample.c
@@ -383,6 +383,159 @@ static const DDS_XTypes_CompleteStructMember *find_struct_member (struct dyntype
   return find_struct_member1 (dtl, m_base, obj, &off, t, name);
 }
 
+static const DDS_XTypes_CompleteUnionMember *find_union_member (DDS_XTypes_CompleteUnionType const * const t, const char *name)
+{
+  for (uint32_t i = 0; i < t->member_seq._length; i++)
+  {
+    const DDS_XTypes_CompleteUnionMember *m = &t->member_seq._buffer[i];
+    if (strcmp (name, m->detail.name) == 0)
+      return m;
+  }
+  return NULL;
+}
+
+static size_t union_data_offset (struct dyntypelib *dtl, DDS_XTypes_CompleteUnionType const * const t)
+{
+  const size_t disc_size = dtl_get_typeid_size (dtl, &t->discriminator.common.type_id);
+  size_t data_off = disc_size;
+  for (uint32_t i = 0; i < t->member_seq._length; i++)
+  {
+    DDS_XTypes_CompleteUnionMember const * const m = &t->member_seq._buffer[i];
+    size_t a;
+    if (m->common.member_flags & (DDS_XTypes_IS_OPTIONAL | DDS_XTypes_IS_EXTERNAL))
+      a = _Alignof (char *);
+    else
+      a = dtl_get_typeid_align (dtl, &m->common.type_id);
+    if (a > data_off)
+      data_off = a;
+  }
+  return data_off;
+}
+
+static bool scan_union (struct dyntypelib *dtl, unsigned char *obj, DDS_XTypes_CompleteUnionType const * const t, struct elem const * const elem, bool ignore_unknown_members, struct dyntypelib_error *err)
+{
+  const size_t disc_size = dtl_get_typeid_size (dtl, &t->discriminator.common.type_id);
+  struct elem const * disc_elem = NULL;
+  struct elem const * data_elem = NULL;
+  for (struct elem const *e = elem->children; e; e = e->next)
+  {
+    if (strcmp (e->name, "discriminator") == 0)
+    {
+      if (disc_elem)
+        return (dtl_set_error (err, e, "union: multiple discriminator children\n") == DDS_RETCODE_OK);
+      disc_elem = e;
+    }
+    else
+    {
+      if (data_elem)
+        return (dtl_set_error (err, e, "union: multiple data children\n") == DDS_RETCODE_OK);
+      data_elem = e;
+    }
+  }
+  if (disc_elem == NULL && data_elem == NULL)
+    return (dtl_set_error (err, elem, "union: discriminator and data missing\n") == DDS_RETCODE_OK);
+
+  DDS_XTypes_CompleteUnionMember const *data_member = NULL;
+  if (data_elem)
+  {
+    data_member = find_union_member (t, data_elem->name);
+    if (data_member == NULL)
+      return (dtl_set_error (err, data_elem, "union: unknown data element\n") == DDS_RETCODE_OK);
+  }
+
+  // If discriminant given, convert and store it; if not, store the label value associated
+  // with the member that we did get (but only if there's exactly one label value).
+  //
+  // If either path succeeded, we have the numerical value of the discriminant in the
+  // struct we are scanning into and we can extract it and check it against the specified
+  // case.
+  if (disc_elem)
+  {
+    if (!scan_sample1_ti (dtl, obj, &t->discriminator.common.type_id, disc_elem, false, false, err))
+      return false;
+  }
+  else
+  {
+    assert (data_elem != NULL);
+
+    if (data_member->common.label_seq._length != 1)
+      return (dtl_set_error (err, data_elem, "union: no discriminant, ambiguous label for data element\n") == DDS_RETCODE_OK);
+
+    const int32_t dv = data_member->common.label_seq._buffer[0];
+    switch (t->discriminator.common.type_id._d)
+    {
+      case DDS_XTypes_TK_INT8:  *((int8_t *) obj) = (int8_t) dv; break;
+      case DDS_XTypes_TK_INT16: *((int16_t *) obj) = (int16_t) dv; break;
+      case DDS_XTypes_TK_INT32: *((int32_t *) obj) = dv; break;
+      case DDS_XTypes_TK_INT64: *((int64_t *) obj) = dv; break;
+      default:
+        switch (disc_size)
+        {
+          case 1: *((uint8_t *) obj) = (uint8_t) dv; break;
+          case 2: *((uint16_t *) obj) = (uint16_t) dv; break;
+          case 4: *((uint32_t *) obj) = (uint32_t) dv; break;
+          case 8: *((uint64_t *) obj) = (uint32_t) dv; break;
+          default: abort ();
+        }
+        break;
+    }
+  }
+
+  // Extract discriminant value
+  uint64_t disc_value = 0;
+  switch (t->discriminator.common.type_id._d)
+  {
+    case DDS_XTypes_TK_INT8:  disc_value = (uint64_t) *((int8_t *) obj); break;
+    case DDS_XTypes_TK_INT16: disc_value = (uint64_t) *((int16_t *) obj); break;
+    case DDS_XTypes_TK_INT32: disc_value = (uint64_t) *((int32_t *) obj); break;
+    case DDS_XTypes_TK_INT64: disc_value = (uint64_t) *((int64_t *) obj); break;
+    default:
+      switch (disc_size)
+      {
+        case 1: disc_value = *((uint8_t *) obj); break;
+        case 2: disc_value = *((uint16_t *) obj); break;
+        case 4: disc_value = *((uint32_t *) obj); break;
+        case 8: disc_value = *((uint64_t *) obj); break;
+        default: abort ();
+      }
+      break;
+  }
+
+  // Scan member if present
+  if (data_elem == NULL)
+  {
+    for (uint32_t i = 0; i < t->member_seq._length; i++)
+    {
+      DDS_XTypes_CompleteUnionMember const * const m = &t->member_seq._buffer[i];
+      if (m->common.member_flags & DDS_XTypes_IS_DEFAULT)
+        return (dtl_set_error (err, elem, "union value required") == DDS_RETCODE_OK);
+      for (uint32_t j = 0; j < m->common.label_seq._length; j++)
+        if (disc_value == (uint64_t) ((uint32_t) m->common.label_seq._buffer[j]))
+          return (dtl_set_error (err, elem, "union value required") == DDS_RETCODE_OK);
+    }
+    return true;
+  }
+  else
+  {
+    if (!(data_member->common.member_flags & DDS_XTypes_IS_DEFAULT))
+    {
+      uint32_t labelidx;
+      for (labelidx = 0; labelidx < data_member->common.label_seq._length; labelidx++)
+      {
+        // FIXME: it looks like label_seq holds 32-bit ints in type obj. If so, how are
+        // 64-bit discriminators supposed to be supported?
+        if (disc_value == (uint64_t) ((uint32_t) data_member->common.label_seq._buffer[labelidx]))
+          break;
+      }
+      if (labelidx == data_member->common.label_seq._length)
+        return (dtl_set_error (err, elem, "case labels do not include discriminator") == DDS_RETCODE_OK);
+    }
+    const bool case_is_opt_or_ext = data_member->common.member_flags & (DDS_XTypes_IS_OPTIONAL | DDS_XTypes_IS_EXTERNAL);
+    const size_t data_off = union_data_offset (dtl, t);
+    return scan_sample1_ti (dtl, obj + data_off, &data_member->common.type_id, data_elem, case_is_opt_or_ext, ignore_unknown_members, err);
+  }
+}
+
 static bool scan_sample1_to (struct dyntypelib *dtl, unsigned char *obj, DDS_XTypes_CompleteTypeObject const * const typeobj, struct elem const * const elem, const bool is_opt_or_ext, const bool ignore_unknown_members, struct dyntypelib_error *err)
 {
   if (is_opt_or_ext && !dtl_is_unbounded_string_to (typeobj))
@@ -476,73 +629,7 @@ static bool scan_sample1_to (struct dyntypelib *dtl, unsigned char *obj, DDS_XTy
     }
 
     case DDS_XTypes_TK_UNION: {
-      const DDS_XTypes_CompleteUnionType *t = &typeobj->_u.union_type;
-      uint64_t disc_value = 0;
-      // discriminator is always at offset 0
-      if (elem->children == NULL ||
-          strcmp (elem->children->name, "discriminator") != 0 ||
-          elem->children->next == NULL || elem->children->next->next != NULL)
-      {
-        return (dtl_set_error (err, elem, "union: expected first child 'discriminator' and second child matching union case\n") == DDS_RETCODE_OK);
-      }
-      if (!scan_sample1_ti (dtl, obj, &t->discriminator.common.type_id, elem->children, false, false, err))
-        return false;
-      const size_t disc_size = dtl_get_typeid_size (dtl, &t->discriminator.common.type_id);
-      switch (t->discriminator.common.type_id._d)
-      {
-        case DDS_XTypes_TK_INT8:  disc_value = (uint64_t) *((int8_t *) obj); break;
-        case DDS_XTypes_TK_INT16: disc_value = (uint64_t) *((int16_t *) obj); break;
-        case DDS_XTypes_TK_INT32: disc_value = (uint64_t) *((int32_t *) obj); break;
-        case DDS_XTypes_TK_INT64: disc_value = (uint64_t) *((int64_t *) obj); break;
-        default:
-          switch (disc_size)
-          {
-            case 1: disc_value = *((uint8_t *) obj); break;
-            case 2: disc_value = *((uint16_t *) obj); break;
-            case 4: disc_value = *((uint32_t *) obj); break;
-            case 8: disc_value = *((uint64_t *) obj); break;
-            default: abort ();
-          }
-          break;
-      }
-      size_t data_off = disc_size;
-      for (uint32_t i = 0; i < t->member_seq._length; i++)
-      {
-        // FIXME: shouldn't need to recompute this every time
-        DDS_XTypes_CompleteUnionMember const * const m = &t->member_seq._buffer[i];
-        size_t a;
-        if (m->common.member_flags & (DDS_XTypes_IS_OPTIONAL | DDS_XTypes_IS_EXTERNAL))
-          a = _Alignof (char *);
-        else
-          a = dtl_get_typeid_align (dtl, &m->common.type_id);
-        if (a > data_off)
-          data_off = a;
-      }
-      uint32_t memberidx;
-      for (memberidx = 0; memberidx < t->member_seq._length; memberidx++)
-      {
-        DDS_XTypes_CompleteUnionMember const * const m = &t->member_seq._buffer[memberidx];
-        if (strcmp (m->detail.name, elem->children->next->name) == 0)
-          break;
-      }
-      if (memberidx == t->member_seq._length)
-        return (dtl_set_error (err, elem, "union case not found") == DDS_RETCODE_OK);
-      DDS_XTypes_CompleteUnionMember const * const m = &t->member_seq._buffer[memberidx];
-      if (!(m->common.member_flags & DDS_XTypes_IS_DEFAULT))
-      {
-        uint32_t labelidx;
-        for (labelidx = 0; labelidx < m->common.label_seq._length; labelidx++)
-        {
-          // FIXME: it looks like label_seq holds 32-bit ints in type obj. If so, how are
-          // 64-bit discriminators supposed to be supported?
-          if (disc_value == (uint64_t) m->common.label_seq._buffer[labelidx])
-            break;
-        }
-        if (labelidx == m->common.label_seq._length)
-          return (dtl_set_error (err, elem, "case labels do not include discriminator") == DDS_RETCODE_OK);
-      }
-      const bool case_is_opt_or_ext = m->common.member_flags & (DDS_XTypes_IS_OPTIONAL | DDS_XTypes_IS_EXTERNAL);
-      return scan_sample1_ti (dtl, obj + data_off, &m->common.type_id, elem->children->next, case_is_opt_or_ext, ignore_unknown_members, err);
+      return scan_union (dtl, obj, &typeobj->_u.union_type, elem, ignore_unknown_members, err);
     }
   }
 

--- a/examples/dynsub/xmltype.c
+++ b/examples/dynsub/xmltype.c
@@ -120,6 +120,7 @@ OPTIONS:\n\
                 - ignore member names\n\
                 - prevent type widening\n\
                 - force type validation\n\
+-x 0|1|2       force default (0) or XCDR version N\n\
 -i ID          use domain ID\n\
 -P P           use partition instead of default\n\
 -R             use binary data without input validation\n\
@@ -137,8 +138,9 @@ int main (int argc, char **argv)
   bool skip_normalize_for_bin = false;
   const char *partition = NULL;
   const char *topicname = "T";
+  int xcdrv = 0;
   dds_domainid_t domainid = DDS_DOMAIN_DEFAULT;
-  while ((opt = getopt (argc, argv, "c:i:P:RT:")) != EOF)
+  while ((opt = getopt (argc, argv, "c:i:P:RT:x:")) != EOF)
   {
     switch (opt)
     {
@@ -162,6 +164,13 @@ int main (int argc, char **argv)
         break;
       case 'T':
         topicname = optarg;
+        break;
+      case 'x':
+        xcdrv = atoi (optarg);
+        if (xcdrv < 0 || xcdrv > 2) {
+          fprintf (stderr, "%s: %s is not a valid setting for XCDR version\n", argv[0], optarg);
+          exit (2);
+        }
         break;
       default:
         usage (argv[0]);
@@ -221,8 +230,14 @@ int main (int argc, char **argv)
               (tce >> 2) & 1,
               (tce >> 1) & 1,
               tce & 1);
-      if (partition)
+      if (xcdrv != 0) {
+        const dds_data_representation_id_t datarep =
+          (xcdrv == 1) ? DDS_DATA_REPRESENTATION_XCDR1 : DDS_DATA_REPRESENTATION_XCDR2;
+        dds_qset_data_representation (epqos, 1, &datarep);
+      }
+      if (partition) {
         dds_qset_partition1 (epqos, partition);
+      }
 
       if (wrtype) {
         rc = dds_create_topic_descriptor (DDS_FIND_SCOPE_LOCAL_DOMAIN, dp, wrtype->typeinfo, 0, &wrdescriptor);

--- a/examples/dynsub/xmltype.c
+++ b/examples/dynsub/xmltype.c
@@ -86,6 +86,8 @@ static bool doread (struct dyntypelib *dtl, const dds_entity_t ws, const dds_ent
   dds_sample_info_t si;
   while ((rc = dds_take (rd, &ptr, &si, 1, 1)) == 1)
   {
+    if (!si.valid_data)
+      printf ("[invalid] ");
     dtl_print_sample (dtl, si.valid_data, ptr, &typeobj->_u.complete);
     dds_return_loan (rd, &ptr, 1);
   }


### PR DESCRIPTION
* Improves the conversion of unions from XML to samples: discriminator value is no longer required, and neither is the value if the specified discriminator value doesn't have a value
* It now recognises the `defaultLiteral` attribute (the deserializer doesn't handle it correctly, but at least it is now being set correctly)
* Readable printing of `try_construct` in the type, instead of `TRY_CONSTRUCT1` and `TRY_CONSTRUCT2` flags
* Output of an invalid sample doesn't print an enum value if it isn't a key
* Prepend `[invalid]` to output lines involving invalid samples, to avoid confusion
* Adds a command-line option to set the data representation