### PR TITLE
Type validation improvements and assignability fixes

### DIFF
--- a/src/core/ddsc/tests/CMakeLists.txt
+++ b/src/core/ddsc/tests/CMakeLists.txt
@@ -137,6 +137,7 @@ if(ENABLE_TYPELIB)
     "data_representation.c"
     "typebuilder.c"
     "dynamic_type.c"
+    "typewrap.c"
   )
 endif()
 

--- a/src/core/ddsc/tests/typewrap.c
+++ b/src/core/ddsc/tests/typewrap.c
@@ -192,6 +192,7 @@ static void check_struct_typeobject (
 
 static void check_union_typeobject (
     const char *name,
+    uint8_t discriminator_type,
     const struct union_member *members,
     uint32_t n_members,
     dds_return_t expected_ret)
@@ -221,7 +222,7 @@ static void check_union_typeobject (
         .discriminator = {
           .common = {
             .member_flags = DDS_XTypes_TRY_CONSTRUCT1,
-            .type_id = { ._d = DDS_XTypes_TK_INT32 }
+            .type_id = { ._d = discriminator_type }
           }
         },
         .member_seq = {
@@ -237,6 +238,272 @@ static void check_union_typeobject (
       sizeof (typeobj._u.complete._u.union_type.header.detail.type_name));
 
   check_typeobject (&typeobj, expected_ret);
+}
+
+static void check_union_discriminator_typeobject (
+    const char *name,
+    const struct DDS_XTypes_TypeIdentifier *discriminator_type,
+    const struct union_member *members,
+    uint32_t n_members,
+    dds_return_t expected_ret)
+{
+  int32_t label_buf[5] = {0};
+  struct DDS_XTypes_CompleteUnionMember member_buf[5] = {0};
+  CU_ASSERT_LEQ_FATAL (n_members, sizeof (member_buf) / sizeof (member_buf[0]));
+  for (uint32_t n = 0; n < n_members; n++)
+  {
+    label_buf[n] = members[n].label;
+    member_buf[n].common.member_id = members[n].id;
+    member_buf[n].common.member_flags = DDS_XTypes_TRY_CONSTRUCT1;
+    member_buf[n].common.type_id._d = DDS_XTypes_TK_INT32;
+    member_buf[n].common.label_seq._maximum = 1;
+    member_buf[n].common.label_seq._length = 1;
+    member_buf[n].common.label_seq._buffer = &label_buf[n];
+    member_buf[n].common.label_seq._release = false;
+    ddsrt_strlcpy (member_buf[n].detail.name, members[n].name, sizeof (member_buf[n].detail.name));
+  }
+
+  struct DDS_XTypes_TypeObject typeobj = {
+    ._d = DDS_XTypes_EK_COMPLETE,
+    ._u.complete = {
+      ._d = DDS_XTypes_TK_UNION,
+      ._u.union_type = {
+        .union_flags = DDS_XTypes_IS_FINAL,
+        .discriminator = {
+          .common = {
+            .member_flags = DDS_XTypes_TRY_CONSTRUCT1,
+            .type_id = *discriminator_type
+          }
+        },
+        .member_seq = {
+          ._maximum = n_members,
+          ._length = n_members,
+          ._buffer = member_buf,
+          ._release = false
+        }
+      }
+    }
+  };
+  ddsrt_strlcpy (typeobj._u.complete._u.union_type.header.detail.type_name, name,
+      sizeof (typeobj._u.complete._u.union_type.header.detail.type_name));
+
+  check_typeobject (&typeobj, expected_ret);
+}
+
+static void check_union_enum_typeobject (
+    const char *name,
+    const char *enum_name,
+    uint16_t bit_bound,
+    const struct enum_literal *literals,
+    uint32_t n_literals,
+    const struct union_member *members,
+    uint32_t n_members,
+    dds_return_t expected_ret)
+{
+  struct DDS_XTypes_CompleteEnumeratedLiteral literal_buf[5] = {0};
+  CU_ASSERT_LEQ_FATAL (n_literals, sizeof (literal_buf) / sizeof (literal_buf[0]));
+  for (uint32_t n = 0; n < n_literals; n++)
+  {
+    literal_buf[n].common.value = literals[n].value;
+    ddsrt_strlcpy (literal_buf[n].detail.name, literals[n].name, sizeof (literal_buf[n].detail.name));
+  }
+
+  struct DDS_XTypes_TypeObject enum_typeobj = {
+    ._d = DDS_XTypes_EK_COMPLETE,
+    ._u.complete = {
+      ._d = DDS_XTypes_TK_ENUM,
+      ._u.enumerated_type = {
+        .enum_flags = DDS_XTypes_IS_FINAL,
+        .header = { .common = { .bit_bound = bit_bound } },
+        .literal_seq = {
+          ._maximum = n_literals,
+          ._length = n_literals,
+          ._buffer = literal_buf,
+          ._release = false
+        }
+      }
+    }
+  };
+  ddsrt_strlcpy (enum_typeobj._u.complete._u.enumerated_type.header.detail.type_name, enum_name,
+      sizeof (enum_typeobj._u.complete._u.enumerated_type.header.detail.type_name));
+
+  ddsi_typeid_t enum_typeid;
+  dds_return_t ret = ddsi_typeobj_get_hash_id (&enum_typeobj, &enum_typeid);
+  CU_ASSERT_EQ_FATAL (ret, DDS_RETCODE_OK);
+
+  int32_t label_buf[5] = {0};
+  struct DDS_XTypes_CompleteUnionMember member_buf[5] = {0};
+  CU_ASSERT_LEQ_FATAL (n_members, sizeof (member_buf) / sizeof (member_buf[0]));
+  for (uint32_t n = 0; n < n_members; n++)
+  {
+    label_buf[n] = members[n].label;
+    member_buf[n].common.member_id = members[n].id;
+    member_buf[n].common.member_flags = DDS_XTypes_TRY_CONSTRUCT1;
+    member_buf[n].common.type_id._d = DDS_XTypes_TK_INT32;
+    member_buf[n].common.label_seq._maximum = 1;
+    member_buf[n].common.label_seq._length = 1;
+    member_buf[n].common.label_seq._buffer = &label_buf[n];
+    member_buf[n].common.label_seq._release = false;
+    ddsrt_strlcpy (member_buf[n].detail.name, members[n].name, sizeof (member_buf[n].detail.name));
+  }
+
+  struct DDS_XTypes_TypeObject typeobj = {
+    ._d = DDS_XTypes_EK_COMPLETE,
+    ._u.complete = {
+      ._d = DDS_XTypes_TK_UNION,
+      ._u.union_type = {
+        .union_flags = DDS_XTypes_IS_FINAL,
+        .discriminator = {
+          .common = {
+            .member_flags = DDS_XTypes_TRY_CONSTRUCT1,
+            .type_id = enum_typeid.x
+          }
+        },
+        .member_seq = {
+          ._maximum = n_members,
+          ._length = n_members,
+          ._buffer = member_buf,
+          ._release = false
+        }
+      }
+    }
+  };
+  ddsrt_strlcpy (typeobj._u.complete._u.union_type.header.detail.type_name, name,
+      sizeof (typeobj._u.complete._u.union_type.header.detail.type_name));
+
+  ddsi_typeid_t typeid;
+  ret = ddsi_typeobj_get_hash_id (&typeobj, &typeid);
+  CU_ASSERT_EQ_FATAL (ret, DDS_RETCODE_OK);
+
+  struct ddsi_domaingv *gv = get_domaingv (participant);
+  struct ddsi_type *enum_type = NULL, *type = NULL;
+  ddsrt_mutex_lock (&gv->typelib_lock);
+  ret = ddsi_type_ref_id_locked (gv, &enum_type, &enum_typeid);
+  CU_ASSERT_EQ (ret, DDS_RETCODE_OK);
+  if (ret == DDS_RETCODE_OK)
+  {
+    ret = ddsi_type_add_typeobj (gv, enum_type, &enum_typeobj);
+    CU_ASSERT_EQ (ret, DDS_RETCODE_OK);
+  }
+
+  ret = ddsi_type_ref_id_locked (gv, &type, &typeid);
+  CU_ASSERT_EQ (ret, DDS_RETCODE_OK);
+  if (ret == DDS_RETCODE_OK)
+  {
+    ret = ddsi_type_add_typeobj (gv, type, &typeobj);
+    CU_ASSERT_EQ (ret, expected_ret);
+  }
+  ddsi_type_unref_locked (gv, type);
+  ddsi_type_unref_locked (gv, enum_type);
+  ddsrt_mutex_unlock (&gv->typelib_lock);
+}
+
+static void check_union_bitmask_typeobject (
+    const char *name,
+    const char *bitmask_name,
+    uint16_t bit_bound,
+    const struct bitflag *bitflags,
+    uint32_t n_bitflags,
+    const struct union_member *members,
+    uint32_t n_members,
+    dds_return_t expected_ret)
+{
+  struct DDS_XTypes_CompleteBitflag bitflag_buf[5] = {0};
+  CU_ASSERT_LEQ_FATAL (n_bitflags, sizeof (bitflag_buf) / sizeof (bitflag_buf[0]));
+  for (uint32_t n = 0; n < n_bitflags; n++)
+  {
+    bitflag_buf[n].common.position = bitflags[n].position;
+    ddsrt_strlcpy (bitflag_buf[n].detail.name, bitflags[n].name, sizeof (bitflag_buf[n].detail.name));
+  }
+
+  struct DDS_XTypes_TypeObject bitmask_typeobj = {
+    ._d = DDS_XTypes_EK_COMPLETE,
+    ._u.complete = {
+      ._d = DDS_XTypes_TK_BITMASK,
+      ._u.bitmask_type = {
+        .bitmask_flags = DDS_XTypes_IS_FINAL,
+        .header = { .common = { .bit_bound = bit_bound } },
+        .flag_seq = {
+          ._maximum = n_bitflags,
+          ._length = n_bitflags,
+          ._buffer = bitflag_buf,
+          ._release = false
+        }
+      }
+    }
+  };
+  ddsrt_strlcpy (bitmask_typeobj._u.complete._u.bitmask_type.header.detail.type_name, bitmask_name,
+      sizeof (bitmask_typeobj._u.complete._u.bitmask_type.header.detail.type_name));
+
+  ddsi_typeid_t bitmask_typeid;
+  dds_return_t ret = ddsi_typeobj_get_hash_id (&bitmask_typeobj, &bitmask_typeid);
+  CU_ASSERT_EQ_FATAL (ret, DDS_RETCODE_OK);
+
+  int32_t label_buf[5] = {0};
+  struct DDS_XTypes_CompleteUnionMember member_buf[5] = {0};
+  CU_ASSERT_LEQ_FATAL (n_members, sizeof (member_buf) / sizeof (member_buf[0]));
+  for (uint32_t n = 0; n < n_members; n++)
+  {
+    label_buf[n] = members[n].label;
+    member_buf[n].common.member_id = members[n].id;
+    member_buf[n].common.member_flags = DDS_XTypes_TRY_CONSTRUCT1;
+    member_buf[n].common.type_id._d = DDS_XTypes_TK_INT32;
+    member_buf[n].common.label_seq._maximum = 1;
+    member_buf[n].common.label_seq._length = 1;
+    member_buf[n].common.label_seq._buffer = &label_buf[n];
+    member_buf[n].common.label_seq._release = false;
+    ddsrt_strlcpy (member_buf[n].detail.name, members[n].name, sizeof (member_buf[n].detail.name));
+  }
+
+  struct DDS_XTypes_TypeObject typeobj = {
+    ._d = DDS_XTypes_EK_COMPLETE,
+    ._u.complete = {
+      ._d = DDS_XTypes_TK_UNION,
+      ._u.union_type = {
+        .union_flags = DDS_XTypes_IS_FINAL,
+        .discriminator = {
+          .common = {
+            .member_flags = DDS_XTypes_TRY_CONSTRUCT1,
+            .type_id = bitmask_typeid.x
+          }
+        },
+        .member_seq = {
+          ._maximum = n_members,
+          ._length = n_members,
+          ._buffer = member_buf,
+          ._release = false
+        }
+      }
+    }
+  };
+  ddsrt_strlcpy (typeobj._u.complete._u.union_type.header.detail.type_name, name,
+      sizeof (typeobj._u.complete._u.union_type.header.detail.type_name));
+
+  ddsi_typeid_t typeid;
+  ret = ddsi_typeobj_get_hash_id (&typeobj, &typeid);
+  CU_ASSERT_EQ_FATAL (ret, DDS_RETCODE_OK);
+
+  struct ddsi_domaingv *gv = get_domaingv (participant);
+  struct ddsi_type *bitmask_type = NULL, *type = NULL;
+  ddsrt_mutex_lock (&gv->typelib_lock);
+  ret = ddsi_type_ref_id_locked (gv, &bitmask_type, &bitmask_typeid);
+  CU_ASSERT_EQ (ret, DDS_RETCODE_OK);
+  if (ret == DDS_RETCODE_OK)
+  {
+    ret = ddsi_type_add_typeobj (gv, bitmask_type, &bitmask_typeobj);
+    CU_ASSERT_EQ (ret, DDS_RETCODE_OK);
+  }
+
+  ret = ddsi_type_ref_id_locked (gv, &type, &typeid);
+  CU_ASSERT_EQ (ret, DDS_RETCODE_OK);
+  if (ret == DDS_RETCODE_OK)
+  {
+    ret = ddsi_type_add_typeobj (gv, type, &typeobj);
+    CU_ASSERT_EQ (ret, expected_ret);
+  }
+  ddsi_type_unref_locked (gv, type);
+  ddsi_type_unref_locked (gv, bitmask_type);
+  ddsrt_mutex_unlock (&gv->typelib_lock);
 }
 
 CU_Test (ddsc_typewrap, invalid_enum_typeobject, .init = typewrap_init, .fini = typewrap_fini)
@@ -457,7 +724,7 @@ CU_Test (ddsc_typewrap, invalid_union_typeobject, .init = typewrap_init, .fini =
     { "duplicate_adjacent_b", 1, 2 },
     { "duplicate_adjacent_c", 2, 3 }
   };
-  check_union_typeobject ("DuplicateAdjacentUnionMember", duplicate_adjacent,
+  check_union_typeobject ("DuplicateAdjacentUnionMember", DDS_XTypes_TK_INT32, duplicate_adjacent,
       sizeof (duplicate_adjacent) / sizeof (duplicate_adjacent[0]), DDS_RETCODE_BAD_PARAMETER);
 
   const struct union_member duplicate_unsorted[] = {
@@ -466,7 +733,7 @@ CU_Test (ddsc_typewrap, invalid_union_typeobject, .init = typewrap_init, .fini =
     { "duplicate_unsorted_c", 5, 3 },
     { "duplicate_unsorted_d", 2, 4 }
   };
-  check_union_typeobject ("DuplicateUnsortedUnionMember", duplicate_unsorted,
+  check_union_typeobject ("DuplicateUnsortedUnionMember", DDS_XTypes_TK_INT32, duplicate_unsorted,
       sizeof (duplicate_unsorted) / sizeof (duplicate_unsorted[0]), DDS_RETCODE_BAD_PARAMETER);
 
   const struct union_member duplicate_run[] = {
@@ -476,14 +743,112 @@ CU_Test (ddsc_typewrap, invalid_union_typeobject, .init = typewrap_init, .fini =
     { "duplicate_run_d", 5, 4 },
     { "duplicate_run_e", 2, 5 }
   };
-  check_union_typeobject ("DuplicateRunUnionMember", duplicate_run,
+  check_union_typeobject ("DuplicateRunUnionMember", DDS_XTypes_TK_INT32, duplicate_run,
       sizeof (duplicate_run) / sizeof (duplicate_run[0]), DDS_RETCODE_BAD_PARAMETER);
+
+  const struct union_member overlapping_labels[] = {
+    { "overlapping_label_a", 1, 1 },
+    { "overlapping_label_b", 2, 1 },
+    { "overlapping_label_c", 3, 3 }
+  };
+  check_union_typeobject ("OverlappingUnionLabels", DDS_XTypes_TK_INT32, overlapping_labels,
+      sizeof (overlapping_labels) / sizeof (overlapping_labels[0]), DDS_RETCODE_BAD_PARAMETER);
+
+  const struct union_member label_outside_discriminator_range[] = {
+    { "label_range_a", 1, INT8_MIN },
+    { "label_range_b", 2, INT8_MAX },
+    { "label_range_c", 3, (int32_t) INT8_MAX + 1 }
+  };
+  check_union_typeobject ("LabelOutsideDiscriminatorRange", DDS_XTypes_TK_INT8, label_outside_discriminator_range,
+      sizeof (label_outside_discriminator_range) / sizeof (label_outside_discriminator_range[0]), DDS_RETCODE_BAD_PARAMETER);
+
+  const struct enum_literal sparse_enum[] = {
+    { "sparse_a", 1 },
+    { "sparse_b", 3 },
+    { "sparse_c", 7 }
+  };
+  const struct union_member valid_enum_labels[] = {
+    { "valid_enum_a", 1, 1 },
+    { "valid_enum_b", 2, 3 },
+    { "valid_enum_c", 3, 7 }
+  };
+  check_union_enum_typeobject ("ValidEnumDiscriminatorLabels", "ValidEnumDiscriminator", 4, sparse_enum,
+      sizeof (sparse_enum) / sizeof (sparse_enum[0]), valid_enum_labels,
+      sizeof (valid_enum_labels) / sizeof (valid_enum_labels[0]), DDS_RETCODE_OK);
+
+  const struct union_member undefined_enum_label[] = {
+    { "undefined_enum_a", 1, 1 },
+    { "undefined_enum_b", 2, 2 },
+    { "undefined_enum_c", 3, 7 }
+  };
+  check_union_enum_typeobject ("UndefinedEnumDiscriminatorLabel", "UndefinedEnumDiscriminator", 4, sparse_enum,
+      sizeof (sparse_enum) / sizeof (sparse_enum[0]), undefined_enum_label,
+      sizeof (undefined_enum_label) / sizeof (undefined_enum_label[0]), DDS_RETCODE_BAD_PARAMETER);
+
+  const struct bitflag sparse_bitmask[] = {
+    { "sparse_bit_a", 0 },
+    { "sparse_bit_b", 2 },
+    { "sparse_bit_c", 4 }
+  };
+  const struct union_member valid_bitmask_labels[] = {
+    { "valid_bitmask_a", 1, 1 },
+    { "valid_bitmask_b", 2, 4 },
+    { "valid_bitmask_c", 3, 17 }
+  };
+  check_union_bitmask_typeobject ("ValidBitmaskDiscriminatorLabels", "ValidBitmaskDiscriminator", 5, sparse_bitmask,
+      sizeof (sparse_bitmask) / sizeof (sparse_bitmask[0]), valid_bitmask_labels,
+      sizeof (valid_bitmask_labels) / sizeof (valid_bitmask_labels[0]), DDS_RETCODE_OK);
+
+  const struct union_member undefined_bitmask_bit[] = {
+    { "undefined_bitmask_a", 1, 1 },
+    { "undefined_bitmask_b", 2, 2 },
+    { "undefined_bitmask_c", 3, 16 }
+  };
+  check_union_bitmask_typeobject ("UndefinedBitmaskDiscriminatorBit", "UndefinedBitmaskDiscriminator", 5, sparse_bitmask,
+      sizeof (sparse_bitmask) / sizeof (sparse_bitmask[0]), undefined_bitmask_bit,
+      sizeof (undefined_bitmask_bit) / sizeof (undefined_bitmask_bit[0]), DDS_RETCODE_BAD_PARAMETER);
+
+  const struct bitflag high_bitmask[] = {
+    { "high_bit_a", 0 },
+    { "high_bit_b", 31 }
+  };
+  const struct union_member high_bitmask_labels[] = {
+    { "high_bitmask_a", 1, 1 },
+    { "high_bitmask_b", 2, INT32_MIN }
+  };
+  check_union_bitmask_typeobject ("HighBitmaskDiscriminatorLabels", "HighBitmaskDiscriminator", 32, high_bitmask,
+      sizeof (high_bitmask) / sizeof (high_bitmask[0]), high_bitmask_labels,
+      sizeof (high_bitmask_labels) / sizeof (high_bitmask_labels[0]), DDS_RETCODE_OK);
+
+  const struct DDS_XTypes_TypeIdentifier unresolved_enum_discriminator = {
+    ._d = DDS_XTypes_EK_COMPLETE,
+    ._u.equivalence_hash = { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 }
+  };
+  const struct union_member unresolved_enum_labels[] = {
+    { "unresolved_enum_a", 1, 1 },
+    { "unresolved_enum_b", 2, 2 },
+    { "unresolved_enum_c", 3, 7 }
+  };
+  check_union_discriminator_typeobject ("UnresolvedEnumDiscriminatorLabels", &unresolved_enum_discriminator,
+      unresolved_enum_labels, sizeof (unresolved_enum_labels) / sizeof (unresolved_enum_labels[0]), DDS_RETCODE_OK);
+
+  const struct DDS_XTypes_TypeIdentifier unresolved_bitmask_discriminator = {
+    ._d = DDS_XTypes_EK_COMPLETE,
+    ._u.equivalence_hash = { 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 }
+  };
+  const struct union_member unresolved_bitmask_labels[] = {
+    { "unresolved_bitmask_a", 1, 1 },
+    { "unresolved_bitmask_b", 2, 2 },
+    { "unresolved_bitmask_c", 3, INT32_MIN }
+  };
+  check_union_discriminator_typeobject ("UnresolvedBitmaskDiscriminatorLabels", &unresolved_bitmask_discriminator,
+      unresolved_bitmask_labels, sizeof (unresolved_bitmask_labels) / sizeof (unresolved_bitmask_labels[0]), DDS_RETCODE_OK);
 
   const struct union_member valid_member_ids[] = {
     { "valid_first", 1, 1 },
     { "valid_middle", 12, 2 },
     { "valid_last", 27, 3 }
   };
-  check_union_typeobject ("ValidUnionMemberIds", valid_member_ids,
+  check_union_typeobject ("ValidUnionMemberIds", DDS_XTypes_TK_INT32, valid_member_ids,
       sizeof (valid_member_ids) / sizeof (valid_member_ids[0]), DDS_RETCODE_OK);
 }

--- a/src/core/ddsc/tests/typewrap.c
+++ b/src/core/ddsc/tests/typewrap.c
@@ -13,6 +13,7 @@
 #include "dds/ddsrt/string.h"
 #include "dds/ddsi/ddsi_domaingv.h"
 #include "ddsi__dynamic_type.h"
+#include "ddsi__typelib.h"
 #include "ddsi__typewrap.h"
 #include "ddsi__xt_impl.h"
 #include "test_util.h"
@@ -44,6 +45,39 @@ struct bitflag {
   const char *name;
   uint16_t position;
 };
+
+struct struct_member {
+  const char *name;
+  uint32_t id;
+};
+
+struct union_member {
+  const char *name;
+  uint32_t id;
+  int32_t label;
+};
+
+static void check_typeobject (
+    const struct DDS_XTypes_TypeObject *typeobj,
+    dds_return_t expected_ret)
+{
+  ddsi_typeid_t typeid;
+  dds_return_t ret = ddsi_typeobj_get_hash_id (typeobj, &typeid);
+  CU_ASSERT_EQ_FATAL (ret, DDS_RETCODE_OK);
+
+  struct ddsi_domaingv *gv = get_domaingv (participant);
+  struct ddsi_type *type = NULL;
+  ddsrt_mutex_lock (&gv->typelib_lock);
+  ret = ddsi_type_ref_id_locked (gv, &type, &typeid);
+  CU_ASSERT_EQ (ret, DDS_RETCODE_OK);
+  if (ret == DDS_RETCODE_OK)
+  {
+    ret = ddsi_type_add_typeobj (gv, type, typeobj);
+    CU_ASSERT_EQ (ret, expected_ret);
+    ddsi_type_unref_locked (gv, type);
+  }
+  ddsrt_mutex_unlock (&gv->typelib_lock);
+}
 
 static void check_enum_typeobject (
     const char *name,
@@ -79,17 +113,7 @@ static void check_enum_typeobject (
   ddsrt_strlcpy (typeobj._u.complete._u.enumerated_type.header.detail.type_name, name,
       sizeof (typeobj._u.complete._u.enumerated_type.header.detail.type_name));
 
-  ddsi_typeid_t typeid;
-  dds_return_t ret = ddsi_typeobj_get_hash_id (&typeobj, &typeid);
-  CU_ASSERT_EQ_FATAL (ret, DDS_RETCODE_OK);
-
-  struct ddsi_domaingv *gv = get_domaingv (participant);
-  struct xt_type xt = {0};
-  ret = ddsi_xt_type_init (gv, &xt, &typeid, (const ddsi_typeobj_t *) &typeobj);
-  CU_ASSERT_EQ_FATAL (ret, expected_ret);
-
-  if (ret == DDS_RETCODE_OK)
-    ddsi_xt_type_fini (gv, &xt, true);
+  check_typeobject (&typeobj, expected_ret);
 }
 
 static void check_bitmask_typeobject (
@@ -126,17 +150,93 @@ static void check_bitmask_typeobject (
   ddsrt_strlcpy (typeobj._u.complete._u.bitmask_type.header.detail.type_name, name,
       sizeof (typeobj._u.complete._u.bitmask_type.header.detail.type_name));
 
-  ddsi_typeid_t typeid;
-  dds_return_t ret = ddsi_typeobj_get_hash_id (&typeobj, &typeid);
-  CU_ASSERT_EQ_FATAL (ret, DDS_RETCODE_OK);
+  check_typeobject (&typeobj, expected_ret);
+}
 
-  struct ddsi_domaingv *gv = get_domaingv (participant);
-  struct xt_type xt = {0};
-  ret = ddsi_xt_type_init (gv, &xt, &typeid, (const ddsi_typeobj_t *) &typeobj);
-  CU_ASSERT_EQ_FATAL (ret, expected_ret);
+static void check_struct_typeobject (
+    const char *name,
+    const struct struct_member *members,
+    uint32_t n_members,
+    dds_return_t expected_ret)
+{
+  struct DDS_XTypes_CompleteStructMember member_buf[5] = {0};
+  CU_ASSERT_LEQ_FATAL (n_members, sizeof (member_buf) / sizeof (member_buf[0]));
+  for (uint32_t n = 0; n < n_members; n++)
+  {
+    member_buf[n].common.member_id = members[n].id;
+    member_buf[n].common.member_flags = DDS_XTypes_TRY_CONSTRUCT1;
+    member_buf[n].common.member_type_id._d = DDS_XTypes_TK_INT32;
+    ddsrt_strlcpy (member_buf[n].detail.name, members[n].name, sizeof (member_buf[n].detail.name));
+  }
 
-  if (ret == DDS_RETCODE_OK)
-    ddsi_xt_type_fini (gv, &xt, true);
+  struct DDS_XTypes_TypeObject typeobj = {
+    ._d = DDS_XTypes_EK_COMPLETE,
+    ._u.complete = {
+      ._d = DDS_XTypes_TK_STRUCTURE,
+      ._u.struct_type = {
+        .struct_flags = DDS_XTypes_IS_FINAL,
+        .member_seq = {
+          ._maximum = n_members,
+          ._length = n_members,
+          ._buffer = member_buf,
+          ._release = false
+        }
+      }
+    }
+  };
+  ddsrt_strlcpy (typeobj._u.complete._u.struct_type.header.detail.type_name, name,
+      sizeof (typeobj._u.complete._u.struct_type.header.detail.type_name));
+
+  check_typeobject (&typeobj, expected_ret);
+}
+
+static void check_union_typeobject (
+    const char *name,
+    const struct union_member *members,
+    uint32_t n_members,
+    dds_return_t expected_ret)
+{
+  int32_t label_buf[5] = {0};
+  struct DDS_XTypes_CompleteUnionMember member_buf[5] = {0};
+  CU_ASSERT_LEQ_FATAL (n_members, sizeof (member_buf) / sizeof (member_buf[0]));
+  for (uint32_t n = 0; n < n_members; n++)
+  {
+    label_buf[n] = members[n].label;
+    member_buf[n].common.member_id = members[n].id;
+    member_buf[n].common.member_flags = DDS_XTypes_TRY_CONSTRUCT1;
+    member_buf[n].common.type_id._d = DDS_XTypes_TK_INT32;
+    member_buf[n].common.label_seq._maximum = 1;
+    member_buf[n].common.label_seq._length = 1;
+    member_buf[n].common.label_seq._buffer = &label_buf[n];
+    member_buf[n].common.label_seq._release = false;
+    ddsrt_strlcpy (member_buf[n].detail.name, members[n].name, sizeof (member_buf[n].detail.name));
+  }
+
+  struct DDS_XTypes_TypeObject typeobj = {
+    ._d = DDS_XTypes_EK_COMPLETE,
+    ._u.complete = {
+      ._d = DDS_XTypes_TK_UNION,
+      ._u.union_type = {
+        .union_flags = DDS_XTypes_IS_FINAL,
+        .discriminator = {
+          .common = {
+            .member_flags = DDS_XTypes_TRY_CONSTRUCT1,
+            .type_id = { ._d = DDS_XTypes_TK_INT32 }
+          }
+        },
+        .member_seq = {
+          ._maximum = n_members,
+          ._length = n_members,
+          ._buffer = member_buf,
+          ._release = false
+        }
+      }
+    }
+  };
+  ddsrt_strlcpy (typeobj._u.complete._u.union_type.header.detail.type_name, name,
+      sizeof (typeobj._u.complete._u.union_type.header.detail.type_name));
+
+  check_typeobject (&typeobj, expected_ret);
 }
 
 CU_Test (ddsc_typewrap, invalid_enum_typeobject, .init = typewrap_init, .fini = typewrap_fini)
@@ -310,4 +410,80 @@ CU_Test (ddsc_typewrap, invalid_bitmask_typeobject, .init = typewrap_init, .fini
   };
   check_bitmask_typeobject ("ValidSixtyFourBitBitmask", 64, valid_positions,
       sizeof (valid_positions) / sizeof (valid_positions[0]), DDS_RETCODE_OK);
+}
+
+CU_Test (ddsc_typewrap, invalid_struct_typeobject, .init = typewrap_init, .fini = typewrap_fini)
+{
+  const struct struct_member duplicate_adjacent[] = {
+    { "duplicate_adjacent_a", 1 },
+    { "duplicate_adjacent_b", 1 },
+    { "duplicate_adjacent_c", 2 }
+  };
+  check_struct_typeobject ("DuplicateAdjacentStructMember", duplicate_adjacent,
+      sizeof (duplicate_adjacent) / sizeof (duplicate_adjacent[0]), DDS_RETCODE_BAD_PARAMETER);
+
+  const struct struct_member duplicate_unsorted[] = {
+    { "duplicate_unsorted_a", 7 },
+    { "duplicate_unsorted_b", 2 },
+    { "duplicate_unsorted_c", 5 },
+    { "duplicate_unsorted_d", 2 }
+  };
+  check_struct_typeobject ("DuplicateUnsortedStructMember", duplicate_unsorted,
+      sizeof (duplicate_unsorted) / sizeof (duplicate_unsorted[0]), DDS_RETCODE_BAD_PARAMETER);
+
+  const struct struct_member duplicate_run[] = {
+    { "duplicate_run_a", 6 },
+    { "duplicate_run_b", 2 },
+    { "duplicate_run_c", 2 },
+    { "duplicate_run_d", 5 },
+    { "duplicate_run_e", 2 }
+  };
+  check_struct_typeobject ("DuplicateRunStructMember", duplicate_run,
+      sizeof (duplicate_run) / sizeof (duplicate_run[0]), DDS_RETCODE_BAD_PARAMETER);
+
+  const struct struct_member valid_member_ids[] = {
+    { "valid_first", 1 },
+    { "valid_middle", 12 },
+    { "valid_last", 27 }
+  };
+  check_struct_typeobject ("ValidStructMemberIds", valid_member_ids,
+      sizeof (valid_member_ids) / sizeof (valid_member_ids[0]), DDS_RETCODE_OK);
+}
+
+CU_Test (ddsc_typewrap, invalid_union_typeobject, .init = typewrap_init, .fini = typewrap_fini)
+{
+  const struct union_member duplicate_adjacent[] = {
+    { "duplicate_adjacent_a", 1, 1 },
+    { "duplicate_adjacent_b", 1, 2 },
+    { "duplicate_adjacent_c", 2, 3 }
+  };
+  check_union_typeobject ("DuplicateAdjacentUnionMember", duplicate_adjacent,
+      sizeof (duplicate_adjacent) / sizeof (duplicate_adjacent[0]), DDS_RETCODE_BAD_PARAMETER);
+
+  const struct union_member duplicate_unsorted[] = {
+    { "duplicate_unsorted_a", 7, 1 },
+    { "duplicate_unsorted_b", 2, 2 },
+    { "duplicate_unsorted_c", 5, 3 },
+    { "duplicate_unsorted_d", 2, 4 }
+  };
+  check_union_typeobject ("DuplicateUnsortedUnionMember", duplicate_unsorted,
+      sizeof (duplicate_unsorted) / sizeof (duplicate_unsorted[0]), DDS_RETCODE_BAD_PARAMETER);
+
+  const struct union_member duplicate_run[] = {
+    { "duplicate_run_a", 6, 1 },
+    { "duplicate_run_b", 2, 2 },
+    { "duplicate_run_c", 2, 3 },
+    { "duplicate_run_d", 5, 4 },
+    { "duplicate_run_e", 2, 5 }
+  };
+  check_union_typeobject ("DuplicateRunUnionMember", duplicate_run,
+      sizeof (duplicate_run) / sizeof (duplicate_run[0]), DDS_RETCODE_BAD_PARAMETER);
+
+  const struct union_member valid_member_ids[] = {
+    { "valid_first", 1, 1 },
+    { "valid_middle", 12, 2 },
+    { "valid_last", 27, 3 }
+  };
+  check_union_typeobject ("ValidUnionMemberIds", valid_member_ids,
+      sizeof (valid_member_ids) / sizeof (valid_member_ids[0]), DDS_RETCODE_OK);
 }

--- a/src/core/ddsc/tests/typewrap.c
+++ b/src/core/ddsc/tests/typewrap.c
@@ -1,0 +1,313 @@
+// Copyright(c) 2026 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+#include "CUnit/Theory.h"
+#include "dds/dds.h"
+#include "dds/ddsrt/string.h"
+#include "dds/ddsi/ddsi_domaingv.h"
+#include "ddsi__dynamic_type.h"
+#include "ddsi__typewrap.h"
+#include "ddsi__xt_impl.h"
+#include "test_util.h"
+
+static dds_entity_t domain = 0, participant = 0;
+
+static void typewrap_init (void)
+{
+  domain = dds_create_domain (0, NULL);
+  CU_ASSERT_GEQ_FATAL (domain, 0);
+  participant = dds_create_participant (0, NULL, NULL);
+  CU_ASSERT_GEQ_FATAL (participant, 0);
+}
+
+static void typewrap_fini (void)
+{
+  dds_return_t ret = dds_delete (participant);
+  CU_ASSERT_EQ_FATAL (ret, DDS_RETCODE_OK);
+  ret = dds_delete (domain);
+  CU_ASSERT_EQ_FATAL (ret, DDS_RETCODE_OK);
+}
+
+struct enum_literal {
+  const char *name;
+  int32_t value;
+};
+
+struct bitflag {
+  const char *name;
+  uint16_t position;
+};
+
+static void check_enum_typeobject (
+    const char *name,
+    uint16_t bit_bound,
+    const struct enum_literal *literals,
+    uint32_t n_literals,
+    dds_return_t expected_ret)
+{
+  struct DDS_XTypes_CompleteEnumeratedLiteral literal_buf[5] = {0};
+  CU_ASSERT_LEQ_FATAL (n_literals, sizeof (literal_buf) / sizeof (literal_buf[0]));
+  for (uint32_t n = 0; n < n_literals; n++)
+  {
+    literal_buf[n].common.value = literals[n].value;
+    ddsrt_strlcpy (literal_buf[n].detail.name, literals[n].name, sizeof (literal_buf[n].detail.name));
+  }
+
+  struct DDS_XTypes_TypeObject typeobj = {
+    ._d = DDS_XTypes_EK_COMPLETE,
+    ._u.complete = {
+      ._d = DDS_XTypes_TK_ENUM,
+      ._u.enumerated_type = {
+        .enum_flags = DDS_XTypes_IS_FINAL,
+        .header = { .common = { .bit_bound = bit_bound } },
+        .literal_seq = {
+          ._maximum = n_literals,
+          ._length = n_literals,
+          ._buffer = literal_buf,
+          ._release = false
+        }
+      }
+    }
+  };
+  ddsrt_strlcpy (typeobj._u.complete._u.enumerated_type.header.detail.type_name, name,
+      sizeof (typeobj._u.complete._u.enumerated_type.header.detail.type_name));
+
+  ddsi_typeid_t typeid;
+  dds_return_t ret = ddsi_typeobj_get_hash_id (&typeobj, &typeid);
+  CU_ASSERT_EQ_FATAL (ret, DDS_RETCODE_OK);
+
+  struct ddsi_domaingv *gv = get_domaingv (participant);
+  struct xt_type xt = {0};
+  ret = ddsi_xt_type_init (gv, &xt, &typeid, (const ddsi_typeobj_t *) &typeobj);
+  CU_ASSERT_EQ_FATAL (ret, expected_ret);
+
+  if (ret == DDS_RETCODE_OK)
+    ddsi_xt_type_fini (gv, &xt, true);
+}
+
+static void check_bitmask_typeobject (
+    const char *name,
+    uint16_t bit_bound,
+    const struct bitflag *bitflags,
+    uint32_t n_bitflags,
+    dds_return_t expected_ret)
+{
+  struct DDS_XTypes_CompleteBitflag bitflag_buf[5] = {0};
+  CU_ASSERT_LEQ_FATAL (n_bitflags, sizeof (bitflag_buf) / sizeof (bitflag_buf[0]));
+  for (uint32_t n = 0; n < n_bitflags; n++)
+  {
+    bitflag_buf[n].common.position = bitflags[n].position;
+    ddsrt_strlcpy (bitflag_buf[n].detail.name, bitflags[n].name, sizeof (bitflag_buf[n].detail.name));
+  }
+
+  struct DDS_XTypes_TypeObject typeobj = {
+    ._d = DDS_XTypes_EK_COMPLETE,
+    ._u.complete = {
+      ._d = DDS_XTypes_TK_BITMASK,
+      ._u.bitmask_type = {
+        .bitmask_flags = DDS_XTypes_IS_FINAL,
+        .header = { .common = { .bit_bound = bit_bound } },
+        .flag_seq = {
+          ._maximum = n_bitflags,
+          ._length = n_bitflags,
+          ._buffer = bitflag_buf,
+          ._release = false
+        }
+      }
+    }
+  };
+  ddsrt_strlcpy (typeobj._u.complete._u.bitmask_type.header.detail.type_name, name,
+      sizeof (typeobj._u.complete._u.bitmask_type.header.detail.type_name));
+
+  ddsi_typeid_t typeid;
+  dds_return_t ret = ddsi_typeobj_get_hash_id (&typeobj, &typeid);
+  CU_ASSERT_EQ_FATAL (ret, DDS_RETCODE_OK);
+
+  struct ddsi_domaingv *gv = get_domaingv (participant);
+  struct xt_type xt = {0};
+  ret = ddsi_xt_type_init (gv, &xt, &typeid, (const ddsi_typeobj_t *) &typeobj);
+  CU_ASSERT_EQ_FATAL (ret, expected_ret);
+
+  if (ret == DDS_RETCODE_OK)
+    ddsi_xt_type_fini (gv, &xt, true);
+}
+
+CU_Test (ddsc_typewrap, invalid_enum_typeobject, .init = typewrap_init, .fini = typewrap_fini)
+{
+  const struct enum_literal duplicate_adjacent[] = {
+    { "DuplicateAdjacentA", 1 },
+    { "DuplicateAdjacentB", 1 },
+    { "DuplicateAdjacentC", 2 }
+  };
+  check_enum_typeobject ("DuplicateAdjacent", 4, duplicate_adjacent,
+      sizeof (duplicate_adjacent) / sizeof (duplicate_adjacent[0]), DDS_RETCODE_BAD_PARAMETER);
+
+  const struct enum_literal duplicate_unsorted[] = {
+    { "DuplicateUnsortedA", 0 },
+    { "DuplicateUnsortedB", 3 },
+    { "DuplicateUnsortedC", 12 },
+    { "DuplicateUnsortedD", 3 }
+  };
+  check_enum_typeobject ("DuplicateUnsorted", 5, duplicate_unsorted,
+      sizeof (duplicate_unsorted) / sizeof (duplicate_unsorted[0]), DDS_RETCODE_BAD_PARAMETER);
+
+  const struct enum_literal duplicate_at_min[] = {
+    { "DuplicateAtMinA", 7 },
+    { "DuplicateAtMinB", 0 },
+    { "DuplicateAtMinC", 5 },
+    { "DuplicateAtMinD", 0 }
+  };
+  check_enum_typeobject ("DuplicateAtMinAfterSort", 4, duplicate_at_min,
+      sizeof (duplicate_at_min) / sizeof (duplicate_at_min[0]), DDS_RETCODE_BAD_PARAMETER);
+
+  const struct enum_literal duplicate_at_max[] = {
+    { "DuplicateAtMaxA", 0 },
+    { "DuplicateAtMaxB", 7 },
+    { "DuplicateAtMaxC", 1 },
+    { "DuplicateAtMaxD", 7 }
+  };
+  check_enum_typeobject ("DuplicateAtMaxAfterSort", 4, duplicate_at_max,
+      sizeof (duplicate_at_max) / sizeof (duplicate_at_max[0]), DDS_RETCODE_BAD_PARAMETER);
+
+  const struct enum_literal duplicate_run[] = {
+    { "DuplicateRunA", 6 },
+    { "DuplicateRunB", 2 },
+    { "DuplicateRunC", 2 },
+    { "DuplicateRunD", 1 },
+    { "DuplicateRunE", 2 }
+  };
+  check_enum_typeobject ("DuplicateRunAfterSort", 4, duplicate_run,
+      sizeof (duplicate_run) / sizeof (duplicate_run[0]), DDS_RETCODE_BAD_PARAMETER);
+
+  const struct enum_literal duplicate_name_adjacent[] = {
+    { "DuplicateNameAdjacentA", 0 },
+    { "DuplicateNameAdjacentA", 1 },
+    { "DuplicateNameAdjacentC", 2 }
+  };
+  check_enum_typeobject ("DuplicateNameAdjacent", 4, duplicate_name_adjacent,
+      sizeof (duplicate_name_adjacent) / sizeof (duplicate_name_adjacent[0]), DDS_RETCODE_BAD_PARAMETER);
+
+  const struct enum_literal duplicate_name_unsorted[] = {
+    { "DuplicateNameUnsortedA", 3 },
+    { "DuplicateNameUnsortedB", 1 },
+    { "DuplicateNameUnsortedA", 2 },
+    { "DuplicateNameUnsortedD", 4 }
+  };
+  check_enum_typeobject ("DuplicateNameUnsorted", 4, duplicate_name_unsorted,
+      sizeof (duplicate_name_unsorted) / sizeof (duplicate_name_unsorted[0]), DDS_RETCODE_BAD_PARAMETER);
+
+  const struct enum_literal duplicate_name_run[] = {
+    { "DuplicateNameRunA", 5 },
+    { "DuplicateNameRunB", 3 },
+    { "DuplicateNameRunB", 0 },
+    { "DuplicateNameRunD", 2 },
+    { "DuplicateNameRunB", 4 }
+  };
+  check_enum_typeobject ("DuplicateNameRun", 4, duplicate_name_run,
+      sizeof (duplicate_name_run) / sizeof (duplicate_name_run[0]), DDS_RETCODE_BAD_PARAMETER);
+
+  const struct enum_literal too_large_two_bits[] = {
+    { "TwoBitsMin", 0 },
+    { "TwoBitsMax", 3 },
+    { "TwoBitsTooLarge", 4 }
+  };
+  check_enum_typeobject ("TooLargeForTwoBits", 2, too_large_two_bits,
+      sizeof (too_large_two_bits) / sizeof (too_large_two_bits[0]), DDS_RETCODE_BAD_PARAMETER);
+
+  const struct enum_literal too_large_eight_bits[] = {
+    { "EightBitsMin", 0 },
+    { "EightBitsMax", 255 },
+    { "EightBitsTooLarge", 256 }
+  };
+  check_enum_typeobject ("TooLargeForEightBits", 8, too_large_eight_bits,
+      sizeof (too_large_eight_bits) / sizeof (too_large_eight_bits[0]), DDS_RETCODE_BAD_PARAMETER);
+
+  check_enum_typeobject ("NoSymbols", 8, NULL, 0, DDS_RETCODE_BAD_PARAMETER);
+
+  const struct enum_literal negative_values[] = {
+    { "NegativeMin", -1 },
+    { "NegativeMid", 0 }
+  };
+  check_enum_typeobject ("NegativeValues", 1, negative_values,
+      sizeof (negative_values) / sizeof (negative_values[0]), DDS_RETCODE_BAD_PARAMETER);
+}
+
+CU_Test (ddsc_typewrap, invalid_bitmask_typeobject, .init = typewrap_init, .fini = typewrap_fini)
+{
+  const struct bitflag duplicate_adjacent[] = {
+    { "DuplicateAdjacentA", 1 },
+    { "DuplicateAdjacentB", 1 },
+    { "DuplicateAdjacentC", 2 }
+  };
+  check_bitmask_typeobject ("DuplicateAdjacentBitflag", 8, duplicate_adjacent,
+      sizeof (duplicate_adjacent) / sizeof (duplicate_adjacent[0]), DDS_RETCODE_BAD_PARAMETER);
+
+  const struct bitflag duplicate_unsorted[] = {
+    { "DuplicateUnsortedA", 7 },
+    { "DuplicateUnsortedB", 2 },
+    { "DuplicateUnsortedC", 5 },
+    { "DuplicateUnsortedD", 2 }
+  };
+  check_bitmask_typeobject ("DuplicateUnsortedBitflag", 8, duplicate_unsorted,
+      sizeof (duplicate_unsorted) / sizeof (duplicate_unsorted[0]), DDS_RETCODE_BAD_PARAMETER);
+
+  const struct bitflag duplicate_run[] = {
+    { "DuplicateRunA", 6 },
+    { "DuplicateRunB", 2 },
+    { "DuplicateRunC", 2 },
+    { "DuplicateRunD", 5 },
+    { "DuplicateRunE", 2 }
+  };
+  check_bitmask_typeobject ("DuplicateRunBitflag", 8, duplicate_run,
+      sizeof (duplicate_run) / sizeof (duplicate_run[0]), DDS_RETCODE_BAD_PARAMETER);
+
+  const struct bitflag duplicate_name_adjacent[] = {
+    { "DuplicateNameAdjacentA", 0 },
+    { "DuplicateNameAdjacentA", 1 },
+    { "DuplicateNameAdjacentC", 2 }
+  };
+  check_bitmask_typeobject ("DuplicateNameAdjacentBitflag", 8, duplicate_name_adjacent,
+      sizeof (duplicate_name_adjacent) / sizeof (duplicate_name_adjacent[0]), DDS_RETCODE_BAD_PARAMETER);
+
+  const struct bitflag duplicate_name_unsorted[] = {
+    { "DuplicateNameUnsortedA", 0 },
+    { "DuplicateNameUnsortedB", 2 },
+    { "DuplicateNameUnsortedA", 4 },
+    { "DuplicateNameUnsortedD", 6 }
+  };
+  check_bitmask_typeobject ("DuplicateNameUnsortedBitflag", 8, duplicate_name_unsorted,
+      sizeof (duplicate_name_unsorted) / sizeof (duplicate_name_unsorted[0]), DDS_RETCODE_BAD_PARAMETER);
+
+  const struct bitflag too_large_eight_bits[] = {
+    { "EightBitsFirst", 0 },
+    { "EightBitsLast", 7 },
+    { "EightBitsTooLarge", 8 }
+  };
+  check_bitmask_typeobject ("TooLargeForEightBitBitmask", 8, too_large_eight_bits,
+      sizeof (too_large_eight_bits) / sizeof (too_large_eight_bits[0]), DDS_RETCODE_BAD_PARAMETER);
+
+  const struct bitflag too_large_sixty_four_bits[] = {
+    { "SixtyFourBitsFirst", 0 },
+    { "SixtyFourBitsLast", 63 },
+    { "SixtyFourBitsTooLarge", 64 }
+  };
+  check_bitmask_typeobject ("TooLargeForSixtyFourBitBitmask", 64, too_large_sixty_four_bits,
+      sizeof (too_large_sixty_four_bits) / sizeof (too_large_sixty_four_bits[0]), DDS_RETCODE_BAD_PARAMETER);
+
+  check_bitmask_typeobject ("NoBitflags", 8, NULL, 0, DDS_RETCODE_BAD_PARAMETER);
+
+  const struct bitflag valid_positions[] = {
+    { "ValidFirst", 0 },
+    { "ValidMiddle", 31 },
+    { "ValidLast", 63 }
+  };
+  check_bitmask_typeobject ("ValidSixtyFourBitBitmask", 64, valid_positions,
+      sizeof (valid_positions) / sizeof (valid_positions[0]), DDS_RETCODE_OK);
+}

--- a/src/core/ddsc/tests/xtypes_assignability.c
+++ b/src/core/ddsc/tests/xtypes_assignability.c
@@ -483,6 +483,11 @@ CU_Theory ((const dds_topic_descriptor_t *rd_desc, const dds_topic_descriptor_t 
 #define DDS_TD_T const dds_topic_descriptor_t *
 #define DDS_TCE_T dds_type_consistency_kind_t
 
+/* Note: for most of these cases the pattern is that t_1 is the reader type and t_N with N
+   > 1 the writer type. However, for type-widening it is inverted. The reason is that the
+   implementation of the assignability check and of this test case followed the naming in
+   the specification, but that meaning in the specification of T1 and T2 is effectively
+   reversed in the section describing type-widening. Yay. */
 CU_TheoryDataPoints (ddsc_xtypes_assignability, type_consistency_enforcement) = {
   CU_DataPoints (const char *,
                             "wr seq bound > rd seq bound, but ignore_seq_bounds",
@@ -507,8 +512,8 @@ CU_TheoryDataPoints (ddsc_xtypes_assignability, type_consistency_enforcement) = 
                                                                                                                                                                                                        "widen mutable type, prevent_type_widening",
                                                                                                                                                                                                                 "widen union type, !prevent_type_widening",
                                                                                                                                                                                                                          "widen union type, prevent_type_widening"),
-  CU_DataPoints (DDS_TD_T,  D(t1_1), D(t1_1), D(t1_1), D(t1_3), D(t1_1), D(t1_1), D(t2_1), D(t2_1), D(t2_1), D(t2_3), D(t3_1), D(t3_1), D(t4_1), D(t4_1), D(t5_1), D(t5_1), D(t5_1), D(t5_1), D(t6_1), D(t6_1), D(t7_1), D(t7_1)    ),
-  CU_DataPoints (DDS_TD_T,  D(t1_2), D(t1_2), D(t1_3), D(t1_1), D(t1_1), D(t1_3), D(t2_2), D(t2_2), D(t2_3), D(t2_1), D(t3_2), D(t3_2), D(t4_2), D(t4_2), D(t5_2), D(t5_2), D(t5_3), D(t5_4), D(t6_2), D(t6_2), D(t7_2), D(t7_2)    ),
+  CU_DataPoints (DDS_TD_T,  D(t1_1), D(t1_1), D(t1_1), D(t1_3), D(t1_1), D(t1_1), D(t2_1), D(t2_1), D(t2_1), D(t2_3), D(t3_1), D(t3_1), D(t4_1), D(t4_1), D(t5_2), D(t5_2), D(t5_3), D(t5_4), D(t6_2), D(t6_2), D(t7_2), D(t7_2)    ),
+  CU_DataPoints (DDS_TD_T,  D(t1_2), D(t1_2), D(t1_3), D(t1_1), D(t1_1), D(t1_3), D(t2_2), D(t2_2), D(t2_3), D(t2_1), D(t3_2), D(t3_2), D(t4_2), D(t4_2), D(t5_1), D(t5_1), D(t5_1), D(t5_1), D(t6_1), D(t6_1), D(t7_1), D(t7_1)    ),
 
   CU_DataPoints (DDS_TCE_T, ALLOW  , ALLOW  , ALLOW  , ALLOW  , DISALW , DISALW , ALLOW  , ALLOW  , ALLOW  , ALLOW  , ALLOW  , ALLOW  , ALLOW  , ALLOW  , ALLOW  , ALLOW  , ALLOW  , ALLOW  , ALLOW  , ALLOW  , ALLOW  , ALLOW      ),  // allow/disallow type coercion
   CU_DataPoints (bool,      DF     , DF     , DF     , DF     , DF     , DF     , DF     , DF     , DF     , DF     , DF     , DF     , DF     , DF     , false  , true   , true   , true   , false  , true   , false  , true       ),  // prevent_type_widening
@@ -539,6 +544,46 @@ CU_Theory ((const char *test, const dds_topic_descriptor_t *rd_desc, const dds_t
 #undef DF
 #undef DDS_TD_T
 #undef DDS_TCE_T
+
+#define D(n) (&XSpaceTypeConsistencyEnforcement_ ## n ## _desc)
+CU_Test (ddsc_xtypes_assignability, type_widening, .init = xtypes_assignability_init, .fini = xtypes_assignability_fini)
+{
+  static const struct {
+    const dds_topic_descriptor_t *rd_desc;
+    const dds_topic_descriptor_t *wr_desc;
+    bool assignable[2]; /* !prevent type widening, p t w */
+  } tests[] = {
+    // same struct type (not really interesting)
+    { D (t5_1), D (t5_1), { true, true } },
+    { D (t5_2), D (t5_2), { true, true } },
+    { D (t5_3), D (t5_3), { true, true } },
+    { D (t5_4), D (t5_4), { true, true } },
+    { D (t6_1), D (t6_1), { true, true } },
+    { D (t6_2), D (t6_2), { true, true } },
+    // read narrow, write wide: all ok
+    { D (t5_1), D (t5_2), { true, true } },
+    { D (t5_1), D (t5_3), { true, true } },
+    { D (t5_1), D (t5_4), { true, true } },
+    { D (t6_1), D (t6_2), { true, true } },
+    // read wide, write narrow: not all ok
+    { D (t5_2), D (t5_1), { true, false } },
+    { D (t5_3), D (t5_1), { true, false } },
+    { D (t5_4), D (t5_1), { true, true } },
+    { D (t6_2), D (t6_1), { true, false } }
+  };
+  for (size_t i = 0; i < sizeof (tests) / sizeof (tests[0]); i++)
+  {
+    for (int ptw = 0; ptw <= 1; ptw++)
+    {
+      tprintf ("Running test type_widening: rd %s wr %s ptw %d\n", tests[i].rd_desc->m_typename, tests[i].wr_desc->m_typename, ptw);
+      dds_qos_t *qos = dds_create_qos ();
+      dds_qset_type_consistency (qos, DDS_TYPE_CONSISTENCY_ALLOW_TYPE_COERCION, true, true, false, (ptw != 0), false);
+      do_test (tests[i].rd_desc, qos, tests[i].wr_desc, NULL, tests[i].assignable[ptw], 0, false, 0);
+      dds_delete_qos (qos);
+    }
+  }
+}
+#undef D
 
 /* Type consistency enforcement policy test case for force_type_validation */
 CU_Test (ddsc_xtypes_assignability, type_consistency_enforcement_force_validation, .init = xtypes_assignability_init, .fini = xtypes_assignability_fini)

--- a/src/core/ddsi/src/ddsi_typewrap.c
+++ b/src/core/ddsi/src/ddsi_typewrap.c
@@ -10,6 +10,7 @@
 
 #include <string.h>
 #include <stdlib.h>
+#include <limits.h>
 #include "dds/features.h"
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/md5.h"
@@ -737,10 +738,16 @@ static int xt_enum_value_cmp (const void *va, const void *vb)
   return (*m1 == *m2) ? 0 : (*m1 < *m2) ? -1 : 1;
 }
 
+static int xt_namehash_cmp (const void *va, const void *vb)
+{
+  return memcmp (va, vb, sizeof (DDS_XTypes_NameHash));
+}
+
 static dds_return_t xt_valid_enum_values (struct ddsi_domaingv *gv, const struct xt_type *t)
 {
   assert (ddsi_xt_is_resolved (t) && t->_d == DDS_XTypes_TK_ENUM);
   dds_return_t ret = DDS_RETCODE_OK;
+  const int32_t max = (t->_u.enum_type.bit_bound >= 31) ? INT32_MAX : (int32_t) ((1u << t->_u.enum_type.bit_bound) - 1);
 
   uint32_t cnt = t->_u.enum_type.literals.length;
   if (cnt == 0)
@@ -757,10 +764,28 @@ static dds_return_t xt_valid_enum_values (struct ddsi_domaingv *gv, const struct
     ret = DDS_RETCODE_OUT_OF_RESOURCES;
     goto failed;
   }
+  DDS_XTypes_NameHash *name_hashes = ddsrt_malloc (cnt * sizeof (*name_hashes));
+  if (name_hashes == NULL)
+  {
+    GVTRACE ("out-of-memory while checking enum literal names\n");
+    ret = DDS_RETCODE_OUT_OF_RESOURCES;
+    goto failed_values;
+  }
 
   for (uint32_t n = 0; n < cnt; n++)
+  {
+    const int32_t value = t->_u.enum_type.literals.seq[n].value;
+    if (value < 0 || value > max)
+    {
+      GVTRACE ("enum value %"PRId32" cannot be represented by bit_bound %"PRIu16"\n", value, t->_u.enum_type.bit_bound);
+      ret = DDS_RETCODE_BAD_PARAMETER;
+      goto failed_duplicate;
+    }
     values[n] = t->_u.enum_type.literals.seq[n].value;
+    memcpy (name_hashes[n], t->_u.enum_type.literals.seq[n].detail.name_hash, sizeof (name_hashes[n]));
+  }
   qsort (values, cnt, sizeof (*values), xt_enum_value_cmp);
+  qsort (name_hashes, cnt, sizeof (*name_hashes), xt_namehash_cmp);
   for (uint32_t n = 0; n < cnt - 1; n++)
   {
     if (values[n] == values[n + 1])
@@ -769,9 +794,17 @@ static dds_return_t xt_valid_enum_values (struct ddsi_domaingv *gv, const struct
       ret = DDS_RETCODE_BAD_PARAMETER;
       goto failed_duplicate;
     }
+    if (memcmp (name_hashes[n], name_hashes[n + 1], sizeof (name_hashes[n])) == 0)
+    {
+      GVTRACE ("duplicate enum literal name hash\n");
+      ret = DDS_RETCODE_BAD_PARAMETER;
+      goto failed_duplicate;
+    }
   }
 
 failed_duplicate:
+  ddsrt_free (name_hashes);
+failed_values:
   ddsrt_free (values);
 failed:
   return ret;
@@ -802,10 +835,28 @@ static dds_return_t xt_valid_bitmask_positions (struct ddsi_domaingv *gv, const 
     ret = DDS_RETCODE_OUT_OF_RESOURCES;
     goto failed;
   }
+  DDS_XTypes_NameHash *name_hashes = ddsrt_malloc (cnt * sizeof (*name_hashes));
+  if (name_hashes == NULL)
+  {
+    GVTRACE ("out-of-memory while checking bitmask flag names\n");
+    ret = DDS_RETCODE_OUT_OF_RESOURCES;
+    goto failed_positions;
+  }
 
   for (uint32_t n = 0; n < cnt; n++)
+  {
+    if (t->_u.bitmask.bitflags.seq[n].position >= t->_u.bitmask.bit_bound)
+    {
+      GVTRACE ("bitmask position %"PRIu16" cannot be represented by bit_bound %"PRIu16"\n",
+          t->_u.bitmask.bitflags.seq[n].position, t->_u.bitmask.bit_bound);
+      ret = DDS_RETCODE_BAD_PARAMETER;
+      goto failed_duplicate;
+    }
     positions[n] = t->_u.bitmask.bitflags.seq[n].position;
+    memcpy (name_hashes[n], t->_u.bitmask.bitflags.seq[n].detail.name_hash, sizeof (name_hashes[n]));
+  }
   qsort (positions, cnt, sizeof (*positions), xt_bitmask_position_cmp);
+  qsort (name_hashes, cnt, sizeof (*name_hashes), xt_namehash_cmp);
   for (uint32_t n = 0; n < cnt - 1; n++)
   {
     if (positions[n] == positions[n + 1])
@@ -814,9 +865,17 @@ static dds_return_t xt_valid_bitmask_positions (struct ddsi_domaingv *gv, const 
       ret = DDS_RETCODE_BAD_PARAMETER;
       goto failed_duplicate;
     }
+    if (memcmp (name_hashes[n], name_hashes[n + 1], sizeof (name_hashes[n])) == 0)
+    {
+      GVTRACE ("duplicate bitmask flag name hash\n");
+      ret = DDS_RETCODE_BAD_PARAMETER;
+      goto failed_duplicate;
+    }
   }
 
 failed_duplicate:
+  ddsrt_free (name_hashes);
+failed_positions:
   ddsrt_free (positions);
 failed:
   return ret;
@@ -1048,21 +1107,21 @@ static dds_return_t xt_validate_impl (struct ddsi_domaingv *gv, const struct xt_
       break;
     }
     case DDS_XTypes_TK_ENUM:
+      if (t->_u.enum_type.bit_bound == 0 || t->_u.enum_type.bit_bound > 32)
+        return DDS_RETCODE_BAD_PARAMETER;
       if ((ret = xt_valid_type_flags (gv, t->_u.enum_type.flags, t->_d))
           || (ret = xt_valid_enum_values (gv, t)))
         return ret;
-      if (t->_u.enum_type.bit_bound > 32)
-        return DDS_RETCODE_BAD_PARAMETER;
       for (uint32_t n = 0; n < t->_u.enum_type.literals.length; n++)
         if ((ret = xt_valid_member_flags (gv, t->_u.enum_type.literals.seq[n].flags, MEMBER_FLAG_ENUM_LITERAL, in_key)))
           return ret;
       break;
     case DDS_XTypes_TK_BITMASK:
+      if (t->_u.bitmask.bit_bound == 0 || t->_u.bitmask.bit_bound > 64)
+        return DDS_RETCODE_BAD_PARAMETER;
       if ((ret = xt_valid_type_flags (gv, t->_u.bitmask.flags, t->_d))
           || (ret = xt_valid_bitmask_positions (gv, t)))
         return ret;
-      if (t->_u.bitmask.bit_bound > 64)
-        return DDS_RETCODE_BAD_PARAMETER;
       for (uint32_t n = 0; n < t->_u.bitmask.bitflags.length; n++)
         if ((ret = xt_valid_member_flags (gv, t->_u.bitmask.bitflags.seq[n].flags, MEMBER_FLAG_BIT_FLAG, in_key)))
           return ret;

--- a/src/core/ddsi/src/ddsi_typewrap.c
+++ b/src/core/ddsi/src/ddsi_typewrap.c
@@ -2738,6 +2738,8 @@ static bool xt_is_assignable_from_enum (const struct xt_type *t1, const struct x
 ddsrt_nonnull_all
 static bool xt_is_assignable_from_union (struct ddsi_domaingv *gv, const struct xt_type *t1, const struct xt_type *t2, const dds_type_consistency_enforcement_qospolicy_t *tce, struct ddsi_non_assignability_reason *reason)
 {
+  /* Note: T1 is the type of the writer, T2 is the type of the writer. These impractical names
+     are used because this is reader the definition of assignability in the specification. */
   assert (t1->_d == DDS_XTypes_TK_UNION);
   assert (t2->_d == DDS_XTypes_TK_UNION);
   if (xt_get_extensibility (t1) != xt_get_extensibility (t2))
@@ -2783,9 +2785,7 @@ static bool xt_is_assignable_from_union (struct ddsi_domaingv *gv, const struct 
       struct xt_union_member *m2 = &t2->_u.union_type.members.seq[i2 % i2_max];
       const struct xt_type *m2t = ddsi_xt_unalias (&m2->type->xt);
       if (m1->id == m2->id)
-      {
         m2_id_match = true;
-      }
 
       /* Rule: If T1 and T2 both have default labels, the type associated with T1 default member is assignable from
           the type associated with T2 default member. */
@@ -3053,10 +3053,10 @@ static bool xt_is_assignable_from_struct (struct ddsi_domaingv *gv, const struct
         - if T1 is appendable, then members with the same member_index have the same member ID, the same setting for the
           optional attribute and the T1 member type is strongly assignable from the T2 member type
         - if T1 is final, then they meet the same condition as for T1 being appendable and ... (see below) */
-    struct xt_struct_member *m2 = &te2->_u.structure.members.seq[i1];
+    struct xt_struct_member *m2 = (i1 < i2_max) ? &te2->_u.structure.members.seq[i1] : NULL;
     if ((xt_get_extensibility (te1) == DDS_XTypes_IS_APPENDABLE && i1 < i2_max) || xt_get_extensibility (te1) == DDS_XTypes_IS_FINAL)
     {
-      if (i1 >= i2_max) {
+      if (m2 == NULL) {
         xt_non_assignable (reason, DDSI_NONASSIGN_NUMBER_OF_MEMBERS, t1, t2, 0);
         goto struct_failed;
       } else if (m1->id != m2->id) {
@@ -3070,9 +3070,9 @@ static bool xt_is_assignable_from_struct (struct ddsi_domaingv *gv, const struct
       }
     }
     /* if T1 is final, or prevent type-widening is set: ... [continued] in addition T1 and T2 have the same set of member IDs */
-    if ((xt_get_extensibility (te1) == DDS_XTypes_IS_FINAL || (tce->prevent_type_widening && !(m2->flags & DDS_XTypes_IS_OPTIONAL))) && !match)
+    if ((xt_get_extensibility (te1) == DDS_XTypes_IS_FINAL || (tce->prevent_type_widening && !(m1->flags & DDS_XTypes_IS_OPTIONAL))) && !match)
     {
-      xt_non_assignable (reason, DDSI_NONASSIGN_NUMBER_OF_MEMBERS, t1, t2, m2->id);
+      xt_non_assignable (reason, DDSI_NONASSIGN_NUMBER_OF_MEMBERS, t1, t2, m1->id);
       goto struct_failed;
     }
   } /* for members in T1 */
@@ -3089,8 +3089,7 @@ static bool xt_is_assignable_from_struct (struct ddsi_domaingv *gv, const struct
     bool match = false;
     if ((!(m2->flags & DDS_XTypes_IS_OPTIONAL) && (m2->flags & DDS_XTypes_IS_MUST_UNDERSTAND))
         || (m2->flags & DDS_XTypes_IS_KEY)
-        || xt_get_extensibility (te1) == DDS_XTypes_IS_FINAL
-        || (tce->prevent_type_widening && !(m2->flags & DDS_XTypes_IS_OPTIONAL)))
+        || xt_get_extensibility (te1) == DDS_XTypes_IS_FINAL)
     {
       for (uint32_t i1 = i2; !match && i1 < i1_max + i2; i1++)
         match = (te1->_u.structure.members.seq[i1 % i1_max].id == m2->id);

--- a/src/core/ddsi/src/ddsi_typewrap.c
+++ b/src/core/ddsi/src/ddsi_typewrap.c
@@ -646,6 +646,94 @@ static int xt_member_id_cmp (const void *va, const void *vb)
   return (*m1 == *m2) ? 0 : (*m1 < *m2) ? -1 : 1;
 }
 
+static int xt_union_label_cmp (const void *va, const void *vb)
+{
+  const int32_t *l1 = va, *l2 = vb;
+  return (*l1 == *l2) ? 0 : (*l1 < *l2) ? -1 : 1;
+}
+
+struct xt_union_label_range {
+  int64_t min;
+  uint64_t max;
+};
+
+static dds_return_t xt_union_label_range (const struct xt_type *disc_type, struct xt_union_label_range *range)
+{
+  if (ddsi_xt_is_unresolved (disc_type))
+  {
+    range->min = INT64_MIN;
+    range->max = UINT64_MAX;
+    return DDS_RETCODE_OK;
+  }
+
+  const struct xt_type *dt = ddsi_xt_unalias (disc_type);
+  switch (dt->_d)
+  {
+    case DDS_XTypes_TK_BOOLEAN:
+      range->min = 0; range->max = 1;
+      break;
+    case DDS_XTypes_TK_BYTE:
+    case DDS_XTypes_TK_CHAR8:
+    case DDS_XTypes_TK_UINT8:
+      range->min = 0; range->max = UINT8_MAX;
+      break;
+    case DDS_XTypes_TK_CHAR16:
+    case DDS_XTypes_TK_UINT16:
+      range->min = 0; range->max = UINT16_MAX;
+      break;
+    case DDS_XTypes_TK_INT8:
+      range->min = INT8_MIN; range->max = INT8_MAX;
+      break;
+    case DDS_XTypes_TK_INT16:
+      range->min = INT16_MIN; range->max = INT16_MAX;
+      break;
+    case DDS_XTypes_TK_INT32:
+      range->min = INT32_MIN; range->max = INT32_MAX;
+      break;
+    case DDS_XTypes_TK_INT64:
+      range->min = INT64_MIN; range->max = INT64_MAX;
+      break;
+    case DDS_XTypes_TK_UINT32:
+      range->min = 0; range->max = UINT32_MAX;
+      break;
+    case DDS_XTypes_TK_UINT64:
+      range->min = 0; range->max = UINT64_MAX;
+      break;
+    case DDS_XTypes_TK_ENUM: {
+      // Enum values are signed 32-bit integers in type objects, so the maximum value is INT32_MAX
+      const DDS_XTypes_BitBound bit_bound = dt->_u.enum_type.bit_bound;
+      range->min = 0; range->max = (bit_bound >= 31) ? INT32_MAX : ((1u << bit_bound) - 1);
+      break;
+    }
+    case DDS_XTypes_TK_BITMASK: {
+      const DDS_XTypes_BitBound bit_bound = dt->_u.bitmask.bit_bound;
+      range->min = INT64_MIN; range->max = (bit_bound >= 64) ? UINT64_MAX : (((uint64_t)1 << bit_bound) - 1);
+      break;
+    }
+    default:
+      return DDS_RETCODE_UNSUPPORTED;
+  }
+  return DDS_RETCODE_OK;
+}
+
+static bool xt_union_label_in_enum (const struct xt_type *disc_type, int32_t label)
+{
+  assert (ddsi_xt_is_resolved (disc_type) && disc_type->_d == DDS_XTypes_TK_ENUM);
+  for (uint32_t n = 0; n < disc_type->_u.enum_type.literals.length; n++)
+    if (label == disc_type->_u.enum_type.literals.seq[n].value)
+      return true;
+  return false;
+}
+
+static uint64_t xt_union_label_bitmask_allowed_mask (const struct xt_type *disc_type)
+{
+  assert (ddsi_xt_is_resolved (disc_type) && disc_type->_d == DDS_XTypes_TK_BITMASK);
+  uint64_t mask = 0;
+  for (uint32_t n = 0; n < disc_type->_u.bitmask.bitflags.length; n++)
+    mask |= (uint64_t)1 << disc_type->_u.bitmask.bitflags.seq[n].position;
+  return mask;
+}
+
 static dds_return_t xt_valid_struct_member_ids (struct ddsi_domaingv *gv, const struct xt_type *t)
 {
   assert (ddsi_xt_is_resolved (t) && t->_d == DDS_XTypes_TK_STRUCTURE);
@@ -729,6 +817,81 @@ static dds_return_t xt_valid_union_member_ids (struct ddsi_domaingv *gv, const s
 failed_duplicate:
   ddsrt_free (ids);
 failed:
+  return ret;
+}
+
+static dds_return_t xt_valid_union_case_labels (struct ddsi_domaingv *gv, const struct xt_type *t)
+{
+  assert (ddsi_xt_is_resolved (t) && t->_d == DDS_XTypes_TK_UNION);
+  dds_return_t ret = DDS_RETCODE_OK;
+
+  uint32_t cnt = 0;
+  for (uint32_t n = 0; n < t->_u.union_type.members.length; n++)
+    cnt += t->_u.union_type.members.seq[n].label_seq._length;
+  if (cnt == 0)
+    goto empty;
+
+  int32_t *labels = ddsrt_malloc (cnt * sizeof (*labels));
+  if (labels == NULL)
+  {
+    GVTRACE ("out-of-memory while checking union case labels\n");
+    ret = DDS_RETCODE_OUT_OF_RESOURCES;
+    goto failed;
+  }
+
+  const struct xt_type *disc_type = &t->_u.union_type.disc_type->xt;
+  const struct xt_type *disc_type_resolved = ddsi_xt_is_unresolved (disc_type) ? NULL : ddsi_xt_unalias (disc_type);
+  struct xt_union_label_range range = { 0, 0 };
+  if ((ret = xt_union_label_range (disc_type, &range)) != DDS_RETCODE_OK)
+    goto failed_labels;
+  uint64_t bitmask_allowed_mask = 0;
+  if (disc_type_resolved && disc_type_resolved->_d == DDS_XTypes_TK_BITMASK)
+    bitmask_allowed_mask = xt_union_label_bitmask_allowed_mask (disc_type_resolved);
+
+  uint32_t cnt1 = 0;
+  for (uint32_t n = 0; n < t->_u.union_type.members.length; n++)
+  {
+    const DDS_XTypes_UnionCaseLabelSeq *labels1 = &t->_u.union_type.members.seq[n].label_seq;
+    for (uint32_t m = 0; m < labels1->_length; m++)
+    {
+      const int32_t label = labels1->_buffer[m];
+      if (label < range.min || (label >= 0 && (uint64_t) label > range.max))
+      {
+        GVTRACE ("union case label %"PRId32" outside discriminator range\n", label);
+        ret = DDS_RETCODE_BAD_PARAMETER;
+        goto failed_labels;
+      }
+      if (disc_type_resolved && disc_type_resolved->_d == DDS_XTypes_TK_ENUM && !xt_union_label_in_enum (disc_type_resolved, label))
+      {
+        GVTRACE ("union case label %"PRId32" not present in enum discriminator\n", label);
+        ret = DDS_RETCODE_BAD_PARAMETER;
+        goto failed_labels;
+      }
+      if (disc_type_resolved && disc_type_resolved->_d == DDS_XTypes_TK_BITMASK && (((uint64_t) (uint32_t) label) & ~bitmask_allowed_mask) != 0)
+      {
+        GVTRACE ("union case label %"PRId32" sets bits not present in bitmask discriminator\n", label);
+        ret = DDS_RETCODE_BAD_PARAMETER;
+        goto failed_labels;
+      }
+      labels[cnt1++] = labels1->_buffer[m];
+    }
+  }
+  qsort (labels, cnt, sizeof (*labels), xt_union_label_cmp);
+  for (uint32_t n = 1; n < cnt; n++)
+  {
+    if (labels[n] == labels[n - 1])
+    {
+      GVTRACE ("duplicate union case label %"PRId32"\n", labels[n]);
+      ret = DDS_RETCODE_BAD_PARAMETER;
+      goto failed_duplicate;
+    }
+  }
+
+failed_duplicate:
+failed_labels:
+  ddsrt_free (labels);
+failed:
+empty:
   return ret;
 }
 
@@ -1083,6 +1246,7 @@ static dds_return_t xt_validate_impl (struct ddsi_domaingv *gv, const struct xt_
     case DDS_XTypes_TK_UNION: {
       if (((ret = xt_valid_union_disc_type (gv, t)))
           || (ret = xt_valid_union_member_ids (gv, t))
+          || (ret = xt_valid_union_case_labels (gv, t))
           || (ret = xt_valid_type_flags (gv, t->_u.union_type.flags, t->_d))
           || (ret = xt_valid_member_flags (gv, t->_u.union_type.disc_flags, MEMBER_FLAG_UNION_DISC, in_key)))
         return ret;


### PR DESCRIPTION
* Assignability check if "prevent type widening" is selected: this had the two types reversed
* Validation of literals/member names are unique
* Validation of union case labels