### PR TITLE
typebuilder: free correct entries in key descriptor cleanup

### DIFF
--- a/src/core/ddsi/src/ddsi_typebuilder.c
+++ b/src/core/ddsi/src/ddsi_typebuilder.c
@@ -1726,7 +1726,7 @@ static dds_return_t typebuilder_get_keys_build_descriptor (const struct typebuil
     if (!(*key_desc)[k].m_name)
     {
       for (uint32_t i = 0; i < k; i++)
-        ddsrt_free ((char *) (*key_desc)[k].m_name); // cast const away, inherited from ye olden days
+        ddsrt_free ((char *) (*key_desc)[i].m_name); // cast const away, inherited from ye olden days
       ddsrt_free (*key_desc);
       return DDS_RETCODE_OUT_OF_RESOURCES;
     }


### PR DESCRIPTION
## Bug

In `typebuilder_get_keys_build_descriptor()` (src/core/ddsi/src/ddsi_typebuilder.c:1713) the error-cleanup loop that runs when `typebuilder_get_keys_make_name()` returns NULL uses the wrong array index:

```c
for (uint32_t k = 0; k < tbd->n_keys; k++)
{
  ...
  (*key_desc)[k] = (struct dds_key_descriptor) {
    .m_name = typebuilder_get_keys_make_name (key),
    ...
  };
  if (!(*key_desc)[k].m_name)
  {
    for (uint32_t i = 0; i < k; i++)
      ddsrt_free ((char *) (*key_desc)[k].m_name); // <-- BUG: indexes [k], not [i]
    ddsrt_free (*key_desc);
    return DDS_RETCODE_OUT_OF_RESOURCES;
  }
}
```

Inside the cleanup the loop iterates `i = 0..k-1` but each iteration frees `(*key_desc)[k].m_name`, i.e. the entry whose allocation just failed and which the surrounding `if` just established to be NULL. So the loop calls `ddsrt_free(NULL)` `k` times (no-op) and the previously-allocated name strings at indices `0..k-1` are never released.

This is a paired alloc/free correctness defect on the out-of-memory path of the topic-descriptor build that runs whenever a type descriptor is constructed from `ddsi_type` (e.g. via `ddsi_topic_descriptor_from_type()` called from `dds_topic.c`).

## Reproduction

A minimal reproducer that mirrors the loop and counts live string allocations after an injected allocation failure at `k = 2` (with `N_OK = 2`, `n_keys = 3`):

```
variant=buggy rc=-1 live_strings_after_error=2 (expect 0)
variant=fixed rc=-1 live_strings_after_error=0 (expect 0)
```

The buggy variant leaks the two `key_0`/`key_1` name strings; the fixed variant releases them and reports zero live strings.

## Fix

The fix is a single-character correction: index the cleanup with the loop variable `i` (the iterator over the already-initialised entries) rather than `k` (the failing entry, which is NULL):

```c
for (uint32_t i = 0; i < k; i++)
  ddsrt_free ((char *) (*key_desc)[i].m_name);
```

The change is confined to the function that performs the (mis-)allocation, so the fix lives in the same callee that owns the leaked memory; no callers are affected.

## Build

`libddsc.dylib` builds cleanly with the patch applied (CMake default configuration, `cmake --build . --target ddsc`).