### PR TITLE
Fix take_next_instance for invalid samples

### DIFF
--- a/src/core/ddsc/src/dds_rhc_default.c
+++ b/src/core/ddsc/src/dds_rhc_default.c
@@ -2115,19 +2115,30 @@ static struct rhc_instance *next_nonempty_instance_by_id(const struct readtake_w
     //otherwise the application won't be able to get the next instance handle
 
     //Make sure instance view state matches, otherwise it's as if the instance is empty
-    if((qmask_of_inst(current_instance) & state->qminv) != 0) continue; 
+    if(inst_is_empty(current_instance) || (qmask_of_inst(current_instance) & state->qminv) != 0) continue; 
 
     //check for readable valid samples
     bool unmasked_sample_exists = false;
-    struct rhc_sample *sample = current_instance->latest->next, * const end1 = sample;
-    do {
-      if ((qmask_of_sample (sample) & state->qminv) == 0 && (state->qcmask == 0 || (sample->conds & state->qcmask)))
+    if(current_instance->latest != NULL)
+    {
+      struct rhc_sample *sample = current_instance->latest->next, * const end1 = sample;
+      do 
       {
-        unmasked_sample_exists = true;
-        break;
-      }
-      sample = sample->next;
-    } while (sample != end1);
+        if ((qmask_of_sample (sample) & state->qminv) == 0 && (state->qcmask == 0 || (sample->conds & state->qcmask)))
+        {
+          unmasked_sample_exists = true;
+          break;
+        }
+        sample = sample->next;
+      } while (sample != end1);
+    }
+
+    if (current_instance->inv_exists &&
+        (qmask_of_invsample (current_instance) & state->qminv) == 0 &&
+        (state->qcmask == 0 || (current_instance->conds & state->qcmask) != 0))
+    {
+      unmasked_sample_exists = true;
+    }
 
     if(!unmasked_sample_exists) continue;
 

--- a/src/core/ddsc/tests/take_next_instance.c
+++ b/src/core/ddsc/tests/take_next_instance.c
@@ -912,7 +912,7 @@ CU_Test(ddsc_read_next_instance, querycondition, .init=take_next_instance_init, 
 
     CU_ASSERT_EQ_FATAL(ret, 0);
     CU_ASSERT_EQ_FATAL(cnt, expected_cnt);
-    CU_ASSERT_EQ_FATAL(cntinv, 1);
+    CU_ASSERT_EQ_FATAL(cntinv, 2);
 
     /* All samples should still be available. */
     ret = samples_cnt();
@@ -1400,7 +1400,7 @@ CU_Test(ddsc_peek_next_instance, querycondition, .init=take_next_instance_init, 
 
     CU_ASSERT_EQ_FATAL(ret, 0);
     CU_ASSERT_EQ_FATAL(cnt, expected_cnt);
-    CU_ASSERT_EQ_FATAL(cntinv, 1);
+    CU_ASSERT_EQ_FATAL(cntinv, 2);
 
     /* All samples should still be available. */
     ret = samples_cnt();


### PR DESCRIPTION
Take next_nonempty_instance_by_id was ignoring invalid samples when checking if an instance is empty