### PR TITLE
Replace call to strdup by call to ddsrt_strdup.

### DIFF
--- a/examples/dynsub/xmltype.c
+++ b/examples/dynsub/xmltype.c
@@ -42,7 +42,7 @@ static void exitfmt (const char *fmt, ...)
 
 static bool lookup_type_pair (struct dyntypelib *dtl, const char *names, struct dyntype **wrtype, struct dyntype **rdtype)
 {
-  char *wtname = strdup (names);
+  char *wtname = ddsrt_strdup (names);
   if (wtname == NULL)
     return false;
   char *rtname = strchr (wtname, '/');


### PR DESCRIPTION
strdup is part of POSIX but hasn't been part of the standard C lib until C23. A simple way to improve code portability of the dynsub example  is to replace stdup by ddsrt_strdup.