### PR TITLE
Add support for building under `aarch64` for Windows

### DIFF
--- a/src/core/ddsi/src/ddsi_sysdeps.c
+++ b/src/core/ddsi/src/ddsi_sysdeps.c
@@ -120,6 +120,14 @@ static DWORD init_stackframe (STACKFRAME64 *frame, const CONTEXT *context)
   frame->AddrStack.Offset = context->IntSp;
   frame->AddrStack.Mode = AddrModeFlat;
   return IMAGE_FILE_MACHINE_IA64;
+#elif _M_ARM64
+  frame->AddrPC.Offset = context->Pc;
+  frame->AddrPC.Mode = AddrModeFlat;
+  frame->AddrFrame.Offset = context->Fp;
+  frame->AddrFrame.Mode = AddrModeFlat;
+  frame->AddrStack.Offset = context->Sp;
+  frame->AddrStack.Mode = AddrModeFlat;
+  return IMAGE_FILE_MACHINE_ARM64;
 #else
 #error "Unsupported machine type for windows stacktrace support"
 #endif


### PR DESCRIPTION
I was setting up the builds with a vendored Cyclone C lib for the Rust API and noticed that Cyclone DDS doesn't currently build under the `aarch64-msvc` target. I didn't add a new OS in the matrix for the `azure-pipelines.yml` but I guess it would be pretty easy (just specifying the correct image from the set of images supported on Azure).