### PR TITLE
Fix thread-local storage section name under Windows

### DIFF
--- a/src/ddsrt/src/cdtors.c
+++ b/src/ddsrt/src/cdtors.c
@@ -195,17 +195,17 @@ DDSRT_WARNING_CLANG_ON(missing-prototypes)
 // logic isn't exactly as trivial as for example determining the endianness of
 // a platform, so keeping this close to the implementation is probably wise.
 #if __MINGW32__
-  PIMAGE_TLS_CALLBACK __crt_xl_tls_callback__ __attribute__ ((section(".CRT$XLZ"))) = ddsrt_cdtor;
+  PIMAGE_TLS_CALLBACK __crt_xl_tls_callback__ __attribute__ ((section(".CRT$XLY"))) = ddsrt_cdtor;
 #elif _WIN64
   #pragma comment (linker, "/INCLUDE:_tls_used")
   #pragma comment (linker, "/INCLUDE:tls_callback_func")
-  #pragma const_seg(".CRT$XLZ")
+  #pragma const_seg(".CRT$XLY")
   EXTERN_C const PIMAGE_TLS_CALLBACK tls_callback_func = ddsrt_cdtor;
   #pragma const_seg()
 #else
   #pragma comment (linker, "/INCLUDE:__tls_used")
   #pragma comment (linker, "/INCLUDE:_tls_callback_func")
-  #pragma data_seg(".CRT$XLZ")
+  #pragma data_seg(".CRT$XLY")
   EXTERN_C PIMAGE_TLS_CALLBACK tls_callback_func = ddsrt_cdtor;
   #pragma data_seg()
  #endif

--- a/src/ddsrt/src/cdtors.c
+++ b/src/ddsrt/src/cdtors.c
@@ -184,7 +184,24 @@ DDSRT_WARNING_CLANG_ON(missing-prototypes)
 // are executed when a thread (or program) attaches or detaches. In contrast to
 // DllMain, a TLS initializer is also executed when the library is linked
 // statically. TLS initializers are always executed before DllMain (both when
-// the library is attached and detached). See http://www.nynaeve.net/?p=190,
+// the library is attached and detached).
+//
+// The Windows C Runtime (CRT) has startup code which gets linked in alongside your
+// application. Its initialization and startup code get called before your application
+// code and it provides the ability to hook-in callbacks to be called as part of the
+// initialization process.
+// 
+// This is configured through specially named sections between .CRT$XLA till .CRT$XLZ
+// (where XLA and XLZ represent the sentinel values for the region). You can configure
+// your callbacks to execute on thread initialization by attaching your function to
+// .CRT$XLB to .CRT$XLY inclusive. The functions associated with these sections will
+// be called in alphabetical order from B till Y.
+//
+// WARN: BE CAREFUL NOT TO SPECIFY YOUR FUNCTION CALLBACKS AGAINST XLA nor XLZ! Only
+// configure them from XLB till XLY!
+// 
+// See https://web.archive.org/web/20251109192547/http://www.nynaeve.net/?p=190
+// and https://learn.microsoft.com/en-us/cpp/c-runtime-library/crt-initialization?view=msvc-170/
 // for a detailed explanation on TLS initializers. Boost and/or POSIX Threads
 // for Windows code bases may also form good sources of information on this
 // subject.

--- a/src/idl/src/string.c
+++ b/src/idl/src/string.c
@@ -423,17 +423,17 @@ _Pragma("GCC diagnostic pop")
 #endif
 
 #if defined __MINGW32__
-  PIMAGE_TLS_CALLBACK __crt_xl_tls_callback__ __attribute__ ((section(".CRT$XLZ"))) = idl_cdtor;
+  PIMAGE_TLS_CALLBACK __crt_xl_tls_callback__ __attribute__ ((section(".CRT$XLY"))) = idl_cdtor;
 #elif defined _WIN64
   #pragma comment (linker, "/INCLUDE:_tls_used")
   #pragma comment (linker, "/INCLUDE:tls_callback_func")
-  #pragma const_seg(".CRT$XLZ")
+  #pragma const_seg(".CRT$XLY")
   EXTERN_C const PIMAGE_TLS_CALLBACK tls_callback_func = idl_cdtor;
   #pragma const_seg()
 #else
   #pragma comment (linker, "/INCLUDE:__tls_used")
   #pragma comment (linker, "/INCLUDE:_tls_callback_func")
-  #pragma data_seg(".CRT$XLZ")
+  #pragma data_seg(".CRT$XLY")
   EXTERN_C PIMAGE_TLS_CALLBACK tls_callback_func = idl_cdtor;
   #pragma data_seg()
 #endif /* _WIN32 */


### PR DESCRIPTION
I ran into some issues with the `TLS_OUT_OF_INDEXES` when vendoring Cyclone for the Rust API. This seems to happen when doing a static build of Cyclone for Windows in `debug`.

According to https://web.archive.org/web/20251116170835/http://www.nynaeve.net/?p=183 (which the original TLS comments that we have in Cyclone reference):

> The C runtime uses this quirk of the compiler to create an array of
> null terminated function pointers to TLS callbacks (with the pointer
> stored in the ".CRT$XLZ" section being the null terminator).

I'm not 100% sure whether the XLZ section is just the null terminator or is also executed, but correcting the section name fixes this assert on static Windows builds (under debug):

```c
dds_return_t ddsrt_thread_cleanup_push(void (*routine)(void *), void *arg)
{
...
  assert(cleanup != TLS_OUT_OF_INDEXES);
```

The `cleanup` var was not being initialized by `ddsrt_thread_init` without this fix.