### PR TITLE
resolve qos_lib scope profiles reference

### DIFF
--- a/src/core/ddsc/src/dds_sysdef_parser.c
+++ b/src/core/ddsc/src/dds_sysdef_parser.c
@@ -879,11 +879,43 @@ static int split_ref (const char *ref, char **lib, char **local_name)
     return *type != NULL ? SD_PARSE_RESULT_OK : SD_PARSE_RESULT_INVALID_REF; \
   }
 
-RESOLVE_REF_FNDEF(qos_profile, qos, qos_profiles)
 RESOLVE_REF_FNDEF(domain, domain, domains)
 RESOLVE_REF_FNDEF(participant, participant, participants)
 RESOLVE_REF_FNDEF(node, node, nodes)
 RESOLVE_REF_FNDEF(application, application, applications)
+
+static int proc_attr_resolve_qos_profile_ref (struct parse_sysdef_state * const pstate, const char *type_ref, struct dds_sysdef_qos_profile **qos_profile)
+{
+  char *lib_name, *local_name;
+  if (*qos_profile != NULL)
+    return SD_PARSE_RESULT_DUPLICATE;
+
+  struct dds_sysdef_qos_lib *lib = NULL;
+  if (split_ref (type_ref, &lib_name, &local_name) != SD_PARSE_RESULT_OK)
+  {
+    if (pstate->current->parent != NULL &&
+        pstate->current->parent->kind == ELEMENT_KIND_QOS_LIB) {
+      lib = (struct dds_sysdef_qos_lib *) pstate->current->parent;
+    } else if (pstate->current->parent != NULL &&
+        pstate->current->parent->parent != NULL &&
+        pstate->current->parent->kind == ELEMENT_KIND_QOS_PROFILE) {
+      lib = (struct dds_sysdef_qos_lib *) pstate->current->parent->parent;
+    } else {
+      return SD_PARSE_RESULT_ERR;
+    }
+    lib_name = ddsrt_strdup(lib->name);
+    local_name = ddsrt_strdup(type_ref);
+  } else {
+    _RESOLVE_LIB (qos, lib_name, lib);
+  }
+
+  if (lib != NULL)
+    _RESOLVE_ENTITY(lib, qos_profile, qos_profiles, local_name, *qos_profile);
+  ddsrt_free (lib_name);
+  ddsrt_free (local_name);
+
+  return *qos_profile != NULL ? SD_PARSE_RESULT_OK : SD_PARSE_RESULT_INVALID_REF;
+}
 
 enum resolve_endpoint_kind {
   RESOLVE_ENDPOINT_READER,
@@ -1077,7 +1109,8 @@ static int proc_attr (void *varg, UNUSED_ARG (uintptr_t eleminfo), const char *n
   struct parse_sysdef_state * const pstate = varg;
   bool attr_processed = false;
 
-  if (ddsrt_strcasecmp(name, "xmlns") == 0 || ddsrt_strcasecmp(name, "xmlns:xsi") == 0 ||ddsrt_strcasecmp(name, "xsi:schemaLocation") == 0)
+  if (ddsrt_strcasecmp(name, "xmlns") == 0 || ddsrt_strcasecmp(name, "xmlns:xsi") == 0 ||
+      ddsrt_strcasecmp(name, "xsi:schemaLocation") == 0 || ddsrt_strcasecmp(name, "xsi:noNamespaceSchemaLocation") == 0)
     return 0;
 
   int ret = SD_PARSE_RESULT_OK;

--- a/src/core/ddsc/src/dds_sysdef_parser.c
+++ b/src/core/ddsc/src/dds_sysdef_parser.c
@@ -893,16 +893,15 @@ static int proc_attr_resolve_qos_profile_ref (struct parse_sysdef_state * const 
   struct dds_sysdef_qos_lib *lib = NULL;
   if (split_ref (type_ref, &lib_name, &local_name) != SD_PARSE_RESULT_OK)
   {
-    if (pstate->current->parent != NULL &&
-        pstate->current->parent->kind == ELEMENT_KIND_QOS_LIB) {
-      lib = (struct dds_sysdef_qos_lib *) pstate->current->parent;
-    } else if (pstate->current->parent != NULL &&
-        pstate->current->parent->parent != NULL &&
-        pstate->current->parent->kind == ELEMENT_KIND_QOS_PROFILE) {
-      lib = (struct dds_sysdef_qos_lib *) pstate->current->parent->parent;
-    } else {
+    struct xml_element *cur = pstate->current->parent;
+    while (cur != NULL && cur->kind != ELEMENT_KIND_QOS_LIB)
+      cur = cur->parent;
+
+    if (cur != NULL)
+      lib = (struct dds_sysdef_qos_lib *) cur;
+    else
       return SD_PARSE_RESULT_ERR;
-    }
+
     lib_name = ddsrt_strdup(lib->name);
     local_name = ddsrt_strdup(type_ref);
   } else {

--- a/src/core/ddsc/tests/sysdef_parser.c
+++ b/src/core/ddsc/tests/sysdef_parser.c
@@ -18,7 +18,7 @@
 
 static const char sysdef_all_constructs[] =
 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-"<dds xmlns=\"http://www.omg.org/spec/DDS-XML\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"unused\">"
+"<dds xmlns=\"http://www.omg.org/spec/DDS-XML\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"unused\" xsi:noNamespaceSchemaLocation=\"unused\">"
 "  <types>"
 "    <external_type_ref name=\"Msg\"/>"
 "    <external_type_ref name=\"OtherMsg\"/>"

--- a/src/core/ddsc/tests/sysdef_parser.c
+++ b/src/core/ddsc/tests/sysdef_parser.c
@@ -50,13 +50,17 @@ static const char sysdef_all_constructs[] =
 "        <writer_batching><batch_updates>false</batch_updates></writer_batching>"
 "        <user_data/>"
 "      </datawriter_qos>"
+"      <datawriter_qos>"
+"        <writer_data_lifecycle><autodispose_unregistered_instances>false</autodispose_unregistered_instances></writer_data_lifecycle>"
+"      </datawriter_qos>"
 "      <publisher_qos name=\"PublisherDefaults\"><group_data><value>REVG</value></group_data><partition><name><element>Alpha</element><element>Beta</element></name></partition><presentation><access_scope>GROUP_PRESENTATION_QOS</access_scope><coherent_access>true</coherent_access><ordered_access>false</ordered_access></presentation><entity_factory><autoenable_created_entities>true</autoenable_created_entities></entity_factory></publisher_qos>"
 "      <subscriber_qos name=\"SubscriberDefaults\"><group_data/></subscriber_qos>"
 "      <topic_qos name=\"TopicDefaults\"><topic_data><value>R0hJ</value></topic_data><durability><kind>VOLATILE_DURABILITY_QOS</kind></durability></topic_qos>"
 "      <domain_participant_qos name=\"ParticipantDefaults\"><user_data><value>SlNM</value></user_data><entity_factory><autoenable_created_entities>false</autoenable_created_entities></entity_factory></domain_participant_qos>"
 "    </qos_profile>"
-"    <qos_profile name=\"DerivedProfile\" base_name=\"QosLib::BaseProfile\">"
+"    <qos_profile name=\"DerivedProfile\" base_name=\"BaseProfile\">"
 "      <domainparticipant_qos base_name=\"QosLib::BaseProfile\"/>"
+"      <datawriter_qos base_name=\"BaseProfile\"/>"
 "    </qos_profile>"
 "  </qos_library>"
 "  <domain_library name=\"DomainLib\">"
@@ -260,6 +264,8 @@ CU_Test (ddsc_sysdef_parser, all_constructs_values)
   CU_ASSERT_EQ (derived_profile->base_profile, base_profile);
   const struct dds_sysdef_qos *derived_participant_qos = find_qos (derived_profile, DDS_SYSDEF_PARTICIPANT_QOS, NULL);
   CU_ASSERT_EQ (derived_participant_qos->base_profile, base_profile);
+  const struct dds_sysdef_qos *derived_datawriter_qos = find_qos (derived_profile, DDS_SYSDEF_WRITER_QOS, NULL);
+  CU_ASSERT_EQ (derived_datawriter_qos->base_profile, base_profile);
   CU_ASSERT_EQ (derived_profile->xmlnode.next, NULL);
 
   const struct dds_sysdef_domain_lib *domain_lib = sysdef->domain_libs;


### PR DESCRIPTION
This changes allow to resolve not only `<qos_lib>::<qos_profile>` ref. within `base_name`, but `<qos_profile>`. Thus `base_name` ref. on `<qos_profile>` will be resolved with profile current `qos_lib`. Such kind of reference allowed only with use inside of `qos_lib` and `qos_profile` scope. All other cases treat as parse error.

> [!NOTE]
> this pull request may resolve topics highlighted by the issue <https://github.com/eclipse-cyclonedds/cyclonedds/issues/2413>