### PR TITLE
OSS-Fuzz: Fix build for CXX17 requirements

### DIFF
--- a/fuzz/fuzz_config_init/CMakeLists.txt
+++ b/fuzz/fuzz_config_init/CMakeLists.txt
@@ -10,7 +10,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
 
-project(fuzz_config_init LANGUAGES C)
+project(fuzz_config_init LANGUAGES C CXX)
 cmake_minimum_required(VERSION 3.5)
 
 if(NOT TARGET CycloneDDS::ddsc)

--- a/fuzz/fuzz_handle_rtps_message/CMakeLists.txt
+++ b/fuzz/fuzz_handle_rtps_message/CMakeLists.txt
@@ -10,7 +10,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
 
-project(fuzz_handle_rtps_message LANGUAGES C)
+project(fuzz_handle_rtps_message LANGUAGES C CXX)
 cmake_minimum_required(VERSION 3.5)
 
 if(NOT TARGET CycloneDDS::ddsc)

--- a/fuzz/fuzz_handshake/prepare.sh
+++ b/fuzz/fuzz_handshake/prepare.sh
@@ -5,6 +5,8 @@ prepare_fuzz_handshake() {
     apt-get -y install ninja-build liblzma-dev libz-dev libtool
     rm -rf libprotobuf-mutator LPM
     git clone --depth 1 https://github.com/google/libprotobuf-mutator.git
+    # Build LPM's bundled protobuf/abseil at C++17, required by protobuf v29.x
+    sed -i "s@CMAKE_CXX_STANDARD=14@CMAKE_CXX_STANDARD=17@" libprotobuf-mutator/cmake/external/protobuf.cmake
     mkdir LPM && cd LPM
     cmake ../libprotobuf-mutator -GNinja \
         -DCMAKE_BUILD_TYPE=Release \

--- a/fuzz/fuzz_sample_deser/CMakeLists.txt
+++ b/fuzz/fuzz_sample_deser/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(fuzz_sample_deser LANGUAGES C)
+project(fuzz_sample_deser LANGUAGES C CXX)
 
 if(NOT TARGET CycloneDDS::ddsc)
   # Find the CycloneDDS package.

--- a/fuzz/fuzz_security_deser/CMakeLists.txt
+++ b/fuzz/fuzz_security_deser/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(fuzz_security_deser LANGUAGES C)
+project(fuzz_security_deser LANGUAGES C CXX)
 cmake_minimum_required(VERSION 3.5)
 
 if(NOT TARGET CycloneDDS::ddsc)

--- a/fuzz/fuzz_type_object/CMakeLists.txt
+++ b/fuzz/fuzz_type_object/CMakeLists.txt
@@ -10,7 +10,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
 
-project(fuzz_type_object LANGUAGES C)
+project(fuzz_type_object LANGUAGES C CXX)
 cmake_minimum_required(VERSION 3.5)
 
 if(NOT TARGET CycloneDDS::ddsc)


### PR DESCRIPTION
This PR fixes the build configuration for the fuzzers to accommodate the CXX17 requirements.