### PR TITLE
Fix `dds_get_guid` to return unsupported error for topics

### DIFF
--- a/src/core/ddsc/src/dds_entity.c
+++ b/src/core/ddsc/src/dds_entity.c
@@ -1286,7 +1286,6 @@ dds_return_t dds_get_guid (dds_entity_t entity, dds_guid_t *guid)
     case DDS_KIND_PARTICIPANT:
     case DDS_KIND_READER:
     case DDS_KIND_WRITER:
-    case DDS_KIND_TOPIC:
       *guid = dds_guid_from_ddsi_guid (e->m_guid);
       ret = DDS_RETCODE_OK;
       break;


### PR DESCRIPTION
An absolutely tiny fix `dds_get_guid`. Currently it always returns `GUID_UNKNOWN` for topics but as the docs say this operation should only be supported on participants, readers, and writers.