### PR TITLE
Guard short RTPS messages in the DDSI security scan

### DIFF
--- a/src/core/ddsi/src/ddsi_security_omg.c
+++ b/src/core/ddsi/src/ddsi_security_omg.c
@@ -3677,9 +3677,11 @@ bool ddsi_security_decode_sec_prefix (const struct ddsi_receiver_state *rst, uns
   return result;
 }
 
-static ddsi_rtps_msg_state_t check_rtps_message_is_secure (struct ddsi_domaingv *gv, ddsi_rtps_header_t *hdr, const unsigned char *buff, bool isstream, struct ddsi_proxy_participant **proxypp)
+static ddsi_rtps_msg_state_t check_rtps_message_is_secure (struct ddsi_domaingv *gv, ddsi_rtps_header_t *hdr, const unsigned char *buff, size_t sz, bool isstream, struct ddsi_proxy_participant **proxypp)
 {
   const uint32_t offset = DDSI_RTPS_MESSAGE_HEADER_SIZE + (isstream ? sizeof (ddsi_rtps_msg_len_t) : 0);
+  if (sz < offset + DDSI_RTPS_SUBMESSAGE_HEADER_SIZE)
+    return DDSI_RTPS_MSG_STATE_PLAIN;
   const ddsi_rtps_submessage_header_t *submsg = (const ddsi_rtps_submessage_header_t *) (buff + offset);
   if (submsg->submessageId != DDSI_RTPS_SMID_SRTPS_PREFIX)
     return DDSI_RTPS_MSG_STATE_PLAIN;
@@ -3773,7 +3775,7 @@ ddsi_security_decode_rtps_message (
   struct ddsi_proxy_participant *proxypp;
   ddsi_rtps_msg_state_t ret;
   ddsi_thread_state_awake_fixed_domain (thrst);
-  ret = check_rtps_message_is_secure (gv, *hdr, *buff, isstream, &proxypp);
+  ret = check_rtps_message_is_secure (gv, *hdr, *buff, *sz, isstream, &proxypp);
   if (ret == DDSI_RTPS_MSG_STATE_ENCODED)
     ret = decode_rtps_message_awake (rmsg, hdr, buff, sz, rbpool, isstream, proxypp);
   ddsi_thread_state_asleep (thrst);


### PR DESCRIPTION
# Fix #2402: Guard short RTPS messages in the DDSI security scan

## Problem

`check_rtps_message_is_secure()` reads the first RTPS submessage header before
checking that the received buffer is long enough to contain one.

The upstream length check in `handle_rtps_message()` only guarantees
`sz >= DDSI_RTPS_MESSAGE_HEADER_SIZE` (20 bytes). For a packet containing
exactly the RTPS header and no submessage, `offset == sz`, so the security scan
can read one byte past the valid received data from the receive-buffer pool.

This is the robustness defect reported in #2402: Valgrind reports
`Conditional jump or move depends on uninitialised value(s)`, and the packet can
be mis-classified as an encoded RTPS message from an unknown participant.

This is not a security vulnerability, but it should be handled cleanly.

## Fix

`check_rtps_message_is_secure()` is `static` and has a single caller,
`ddsi_security_decode_rtps_message()`, where the message length is already
available. This PR passes the length into the helper and returns
`DDSI_RTPS_MSG_STATE_PLAIN` before dereferencing the submessage header when the
buffer is too short to contain one.

The guard checks for the full `DDSI_RTPS_SUBMESSAGE_HEADER_SIZE`, not only the
`submessageId` byte, because the encoded path treats the data as a complete
submessage header.

No public headers change; only the static helper signature and its one call site
are touched.

## Verification

Tested with `-DENABLE_SECURITY=ON` on Ubuntu 24.04 aarch64.

| Check | Result |
|-------|--------|
| Security-enabled build | Pass |
| `ctest -R secure_communication` | Pass, 5/5 |
| `secure_communication` under Valgrind | Pass, 0 errors |
| Isolated before/after Valgrind repro | Unfixed reports the uninitialised conditional jump; fixed is clean |

Fixes #2402