### PR TITLE
Fix signal mask not restored when pthread_create fails

### DIFF
--- a/src/ddsrt/src/threads/posix/threads.c
+++ b/src/ddsrt/src/threads/posix/threads.c
@@ -471,6 +471,9 @@ ddsrt_thread_create (
   return DDS_RETCODE_OK;
 
 err_create:
+#if !defined(__ZEPHYR__)
+  sigprocmask (SIG_SETMASK, &oset, NULL);
+#endif
   ddsrt_free (ctx->name);
   ddsrt_free (ctx);
 err:


### PR DESCRIPTION
When ddsrt_thread_create blocks signals via sigprocmask(SIG_BLOCK) before pthread_create, and pthread_create fails, the original signal mask is never restored. This leaves the calling thread with signals blocked indefinitely.

The fix adds sigprocmask(SIG_SETMASK, &oset, NULL) at the err_create label, matching the restoration on the success path.

Fixes: #2423