### PR TITLE
Fix HelloWorld key steps heading

### DIFF
--- a/docs/manual/getting_started/helloworld/helloworld_key_steps.rst
+++ b/docs/manual/getting_started/helloworld/helloworld_key_steps.rst
@@ -4,8 +4,8 @@
 
 .. _key_steps:
 
-HelloWorld keys steps
-=====================
+HelloWorld key steps
+====================
 
 The **Hello World!** example has a minimal 'data layer' with a data
 model made of one data type ``Msg`` that represents keyed messages.


### PR DESCRIPTION
The tab colors reported in #1992 were addressed by 8b412988, but the title typo called out in the same issue is still present in the live docs.

This changes “HelloWorld keys steps” to “HelloWorld key steps” and updates the reStructuredText underline to match.

Testing:
- Built the full manual with sphinx-build using docs/requirements.txt
- Confirmed the generated title and h1 use the corrected heading

The full build succeeds. It still emits documentation warnings that are unrelated to this change.

AI assistance: I used OpenAI Codex to inspect the issue history, make this edit, and run the documented verification.

Fixes #1992