### PR TITLE
Fix build when ENABLE_QOS_PROVIDER=OFF

### DIFF
--- a/src/core/ddsc/CMakeLists.txt
+++ b/src/core/ddsc/CMakeLists.txt
@@ -90,11 +90,14 @@ prepend(hdrs_private_ddsc "${CMAKE_CURRENT_LIST_DIR}/src/"
   dds__heap_loan.h
   dds__psmx.h
   dds__sysdef_model.h
-  dds__sysdef_parser.h
-  dds__sysdef_validation.h
-  dds__qos_provider.h
   dds__guid.h
 )
+if(ENABLE_QOS_PROVIDER)
+  list(APPEND hdrs_private_ddsc
+    "${CMAKE_CURRENT_LIST_DIR}/src/dds__sysdef_parser.h"
+    "${CMAKE_CURRENT_LIST_DIR}/src/dds__sysdef_validation.h"
+    "${CMAKE_CURRENT_LIST_DIR}/src/dds__qos_provider.h")
+endif()
 
 prepend(hdrs_public_ddsc "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>/dds/"
   dds.h

--- a/src/core/xtests/symbol_export/symbol_export.c
+++ b/src/core/xtests/symbol_export/symbol_export.c
@@ -1246,6 +1246,7 @@ int main (int argc, char **argv)
   dds_entity_lock (0, 0, ptr);
   dds_entity_unlock (ptr);
 
+#ifdef DDS_HAS_QOS_PROVIDER
   // dds__sysdef_parser.h
   dds_sysdef_init_sysdef (ptr, ptr2, 0);
   dds_sysdef_init_sysdef_str (ptr, ptr2, 0);
@@ -1253,6 +1254,7 @@ int main (int argc, char **argv)
   dds_sysdef_init_data_types (ptr, ptr2);
   dds_sysdef_init_data_types_str (ptr, ptr2);
   dds_sysdef_fini_data_types (ptr);
+#endif
 
   // deprecated functions from v0.1
   dds_fail_set (0);


### PR DESCRIPTION
Currently building with -DENABLE_QOS_PROVIDER=NO fails:

```
[271/291] Linking C executable bin/symbol_export_test
FAILED: [code=1] bin/symbol_export_test 
: && /usr/bin/cc -O2 -g -DNDEBUG -Wl,--dependency-file=src/core/xtests/symbol_export/CMakeFiles/symbol_export_test.dir/link.d src/core/xtests/symbol_export/CMakeFiles/symbol_export_test.dir/symbol_export.c.o -o bin/symbol_export_test  -Wl,-rpath,/home/ultra/build/cyclonedds/lib  lib/libddsc.so.11.0.1 && :
/usr/bin/x86_64-linux-gnu-ld.bfd: src/core/xtests/symbol_export/CMakeFiles/symbol_export_test.dir/symbol_export.c.o: in function `main':
/home/ultra/src/cyclonedds/src/core/xtests/symbol_export/symbol_export.c:1250:(.text.startup+0x34e3): undefined reference to `dds_sysdef_init_sysdef'
/usr/bin/x86_64-linux-gnu-ld.bfd: /home/ultra/src/cyclonedds/src/core/xtests/symbol_export/symbol_export.c:1251:(.text.startup+0x34f4): undefined reference to `dds_sysdef_init_sysdef_str'
/usr/bin/x86_64-linux-gnu-ld.bfd: /home/ultra/src/cyclonedds/src/core/xtests/symbol_export/symbol_export.c:1252:(.text.startup+0x34fe): undefined reference to `dds_sysdef_fini_sysdef'
/usr/bin/x86_64-linux-gnu-ld.bfd: /home/ultra/src/cyclonedds/src/core/xtests/symbol_export/symbol_export.c:1253:(.text.startup+0x350d): undefined reference to `dds_sysdef_init_data_types'
/usr/bin/x86_64-linux-gnu-ld.bfd: /home/ultra/src/cyclonedds/src/core/xtests/symbol_export/symbol_export.c:1254:(.text.startup+0x351c): undefined reference to `dds_sysdef_init_data_types_str'
/usr/bin/x86_64-linux-gnu-ld.bfd: /home/ultra/src/cyclonedds/src/core/xtests/symbol_export/symbol_export.c:1255:(.text.startup+0x3526): undefined reference to `dds_sysdef_fini_data_types'
collect2: error: ld returned 1 exit status
[277/291] Building C object src/tools/...dir/src/libidlc/libidlc__descriptor.c.o
ninja: build stopped: subcommand failed.
```