### PR TITLE
Fix appendable and sparse enum handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ gen.*
 build/
 build-*/
 *~
+*#*
 .zed
 .cache
 **/.DS_Store
@@ -18,5 +19,5 @@ compile_commands.json
 fuzz/fuzz_sample_deser/fuzz_sample.idl
 fuzz/fuzz_sample_deser/fuzz_sample_deser_seed_corpus/**
 fuzz/fuzz_sample_deser/fuzz_samples.h
-libprotobuf-mutator/**
-LPM/**
+libprotobuf-mutator/
+LPM/

--- a/cmake/Modules/Generate.cmake
+++ b/cmake/Modules/Generate.cmake
@@ -182,7 +182,17 @@ function(IDLC_GENERATE_GENERIC)
     set(_dir ${CMAKE_CURRENT_BINARY_DIR})
   endif()
 
-  list(APPEND IDLC_ARGS "-o${_dir}")
+  # Keep generated source mtimes stable only for the in-tree shared build,
+  # where rebuilding idlc from core would otherwise force test IDL rebuilds.
+  # Static builds consume some generated files as ordinary sources, so use
+  # direct outputs there as for application builds.
+  if(CMAKE_PROJECT_NAME STREQUAL "CycloneDDS" AND BUILD_IDLC AND BUILD_SHARED_LIBS)
+    set(_stable_idlc_outputs ON)
+  else()
+    set(_stable_idlc_outputs OFF)
+    list(APPEND IDLC_ARGS "-o${_dir}")
+  endif()
+
   set(_target ${IDLC_TARGET})
   foreach(_file ${IDLC_FILES})
     get_filename_component(_path ${_file} ABSOLUTE)
@@ -194,6 +204,7 @@ function(IDLC_GENERATE_GENERIC)
     set(IDLC_SUFFIXES ".c" ".h")
   endif()
   set(_outputs "")
+  set(_stamps "")
   foreach(_file ${_files})
     get_filename_component(_name ${_file} NAME_WLE)
     get_filename_component(_name_ext ${_file} NAME)
@@ -209,24 +220,69 @@ function(IDLC_GENERATE_GENERIC)
       string(REGEX REPLACE "[\\/]$" "" _mid_dir_path "${_mid_dir_path}")
     endif()
 
+    if(_stable_idlc_outputs)
+      # Keep generated source mtimes stable when idlc output is unchanged.
+      string(MD5 _file_hash "${_file}")
+      set(_tmp_dir "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${_target}_idlc/${_name}-${_file_hash}")
+      set(_stamp "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${_target}_idlc/${_name}-${_file_hash}.stamp")
+    endif()
+
     set(_file_outputs "")
+    if(_stable_idlc_outputs)
+      set(_copy_commands "")
+      set(_make_dir_commands "")
+    endif()
     foreach(_suffix ${IDLC_SUFFIXES})
       if(IDLC_BASE_DIR)
-        list(APPEND _file_outputs "${_dir}/${_mid_dir_path}/${_name}${_suffix}")
+        set(_output "${_dir}/${_mid_dir_path}/${_name}${_suffix}")
+        if(_stable_idlc_outputs)
+          set(_tmp_output "${_tmp_dir}/${_mid_dir_path}/${_name}${_suffix}")
+        endif()
       else()
-        list(APPEND _file_outputs "${_dir}/${_name}${_suffix}")
+        set(_output "${_dir}/${_name}${_suffix}")
+        if(_stable_idlc_outputs)
+          set(_tmp_output "${_tmp_dir}/${_name}${_suffix}")
+        endif()
+      endif()
+      list(APPEND _file_outputs "${_output}")
+      if(_stable_idlc_outputs)
+        get_filename_component(_output_dir "${_output}" DIRECTORY)
+        list(APPEND _make_dir_commands
+          COMMAND "${CMAKE_COMMAND}" -E make_directory "${_output_dir}")
+        list(APPEND _copy_commands
+          COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${_tmp_output}" "${_output}")
       endif()
     endforeach()
 
     list(APPEND _outputs ${_file_outputs})
-    add_custom_command(
-      OUTPUT   ${_file_outputs}
-      COMMAND  ${_idlc_executable}
-      ARGS     ${_language} ${IDLC_ARGS} ${IDLC_INCLUDE_DIRS} ${_file}
-      DEPENDS  ${_files} ${_depends})
+    if(_stable_idlc_outputs)
+      list(APPEND _stamps "${_stamp}")
+      add_custom_command(
+        OUTPUT   "${_stamp}"
+        BYPRODUCTS ${_file_outputs}
+        COMMAND  "${CMAKE_COMMAND}" -E remove_directory "${_tmp_dir}"
+        COMMAND  "${CMAKE_COMMAND}" -E make_directory "${_tmp_dir}"
+        COMMAND  ${_idlc_executable}
+        ARGS     ${_language} ${IDLC_ARGS} "-o${_tmp_dir}" ${IDLC_INCLUDE_DIRS} ${_file}
+        ${_make_dir_commands}
+        ${_copy_commands}
+        COMMAND  "${CMAKE_COMMAND}" -E touch "${_stamp}"
+        DEPENDS  ${_files} ${_depends}
+        VERBATIM)
+    else()
+      add_custom_command(
+        OUTPUT   ${_file_outputs}
+        COMMAND  ${_idlc_executable}
+        ARGS     ${_language} ${IDLC_ARGS} ${IDLC_INCLUDE_DIRS} ${_file}
+        DEPENDS  ${_files} ${_depends})
+    endif()
   endforeach()
 
-  add_custom_target("${_target}_generate" DEPENDS "${_outputs}")
+  if(_stable_idlc_outputs)
+    add_custom_target("${_target}_generate" DEPENDS "${_stamps}")
+  else()
+    add_custom_target("${_target}_generate" DEPENDS "${_outputs}")
+  endif()
   if(${CMAKE_GENERATOR} MATCHES "Xcode")
     set_target_properties("${_target}_generate" PROPERTIES XCODE_GENERATE_SCHEME NO)
   endif()

--- a/examples/dynsub/dyntypelib.c
+++ b/examples/dynsub/dyntypelib.c
@@ -508,6 +508,7 @@ static dds_return_t make_union (const struct make_context *ctxt, struct dyntype 
   // We require the discriminator type at the time of creating the union, so go look for it
   const struct elem *discriminator_elem = NULL;
   bool discriminator_is_key = false;
+  enum dds_dynamic_type_try_construct discriminator_try_construct = DDS_DYNAMIC_MEMBER_TRY_CONSTRUCT_DISCARD;
   dds_dynamic_type_spec_t discts = DDS_DYNAMIC_TYPE_SPEC_PRIM (DDS_DYNAMIC_BOOLEAN);
   {
     bool discts_set = false;
@@ -528,6 +529,8 @@ static dds_return_t make_union (const struct make_context *ctxt, struct dyntype 
         else
           return dtl_set_error (err, elem, "disciminator key attribute has invalid value: %s\n", keystr);
       }
+      if ((rc = get_try_construct (c, "tryConstruct", &discriminator_try_construct, err)) != 0)
+        return rc;
       break;
     }
     if (!discts_set)
@@ -547,6 +550,8 @@ static dds_return_t make_union (const struct make_context *ctxt, struct dyntype 
     return rc;
   if ((rc = dds_dynamic_member_set_key (t->dtype, 0, discriminator_is_key)) != 0)
     return dtl_set_error (err, elem, "failed to set key attribute for union type: %s\n", dds_strretcode (rc));
+  if ((rc = dds_dynamic_member_set_try_construct (t->dtype, 0, discriminator_try_construct)) != 0)
+    return dtl_set_error (err, discriminator_elem, "failed to set try_construct attribute for union discriminator: %s\n", dds_strretcode (rc));
 
   for (const struct elem *c = elem->children; c; c = c->next)
   {

--- a/examples/dynsub/xmltype.c
+++ b/examples/dynsub/xmltype.c
@@ -248,6 +248,11 @@ int main (int argc, char **argv)
 
       dds_qos_t *tpqos = dds_create_qos ();
       dds_qset_reliability (tpqos, DDS_RELIABILITY_RELIABLE, DDS_SECS (1));
+      if (xcdrv != 0) {
+        const dds_data_representation_id_t datarep =
+          (xcdrv == 1) ? DDS_DATA_REPRESENTATION_XCDR1 : DDS_DATA_REPRESENTATION_XCDR2;
+        dds_qset_data_representation (tpqos, 1, &datarep);
+      }
       dds_qos_t *epqos = dds_create_qos ();
       dds_qset_type_consistency (
               epqos, DDS_TYPE_CONSISTENCY_ALLOW_TYPE_COERCION,
@@ -256,11 +261,6 @@ int main (int argc, char **argv)
               (tce >> 2) & 1,
               (tce >> 1) & 1,
               tce & 1);
-      if (xcdrv != 0) {
-        const dds_data_representation_id_t datarep =
-          (xcdrv == 1) ? DDS_DATA_REPRESENTATION_XCDR1 : DDS_DATA_REPRESENTATION_XCDR2;
-        dds_qset_data_representation (epqos, 1, &datarep);
-      }
       if (partition) {
         dds_qset_partition1 (epqos, partition);
       }

--- a/src/core/cdr/include/dds/cdr/dds_cdrstream.h
+++ b/src/core/cdr/include/dds/cdr/dds_cdrstream.h
@@ -156,12 +156,23 @@ typedef struct dds_cdrstream_desc_op_seq {
 
 struct dds_cdrstream_desc_mid_table {
   struct ddsrt_hh *table;
+  struct ddsrt_hh *enum_value_sets;
   const uint32_t * op0;
+  bool has_special_defaults;
+};
+
+struct dds_cdrstream_desc_enum_value_set {
+  uint32_t setid;
+  uint32_t default_value;
+  uint32_t nvalues;
+  uint32_t max;
+  uint32_t *values;
 };
 
 struct dds_cdrstream_desc_mid {
   uint32_t adr_offs;
   uint32_t mid;
+  const struct dds_cdrstream_desc_enum_value_set *enum_value_set;
 };
 
 struct dds_cdrstream_desc {

--- a/src/core/cdr/include/dds/cdr/dds_cdrstream.h
+++ b/src/core/cdr/include/dds/cdr/dds_cdrstream.h
@@ -735,6 +735,16 @@ enum dds_cdr_enc_version dds_stream_minimum_xcdr_version (const uint32_t *ops)
   ddsrt_nonnull_all;
 
 /**
+ * @brief Determine the data representations supported by stream operations.
+ * @component cdr_serializer
+ *
+ * @param ops  marshalling metadata to inspect
+ * @returns    bitmask of DDS_DATA_REPRESENTATION_FLAG_XCDR1/XCDR2
+ */
+uint32_t dds_stream_allowed_data_representations (const uint32_t *ops)
+  ddsrt_nonnull_all;
+
+/**
  * @brief Determine the maximum type nesting depth in stream operations.
  * @component cdr_serializer
  *

--- a/src/core/cdr/include/dds/cdr/dds_cdrstream.h
+++ b/src/core/cdr/include/dds/cdr/dds_cdrstream.h
@@ -21,8 +21,6 @@
 extern "C" {
 #endif
 
-#define DDS_CDRSTREAM_MAX_NESTING_DEPTH 32  /* maximum level of nesting for key extraction */
-
 /*
   Encoding version to be used for serialization. Encoding version 1
   represents the XCDR1 format as defined in the DDS XTypes specification,
@@ -732,16 +730,6 @@ DDS_EXPORT size_t dds_stream_getsize_key (const char *sample, const struct dds_c
  * @returns    bitmask of DDS_DATA_REPRESENTATION_FLAG_XCDR1/XCDR2
  */
 uint32_t dds_stream_supported_data_representations (const uint32_t *ops)
-  ddsrt_nonnull_all;
-
-/**
- * @brief Determine the maximum type nesting depth in stream operations.
- * @component cdr_serializer
- *
- * @param ops  marshalling metadata to inspect
- * @returns    maximum nested aggregate depth
- */
-uint32_t dds_stream_type_nesting_depth (const uint32_t *ops)
   ddsrt_nonnull_all;
 
 /**

--- a/src/core/cdr/include/dds/cdr/dds_cdrstream.h
+++ b/src/core/cdr/include/dds/cdr/dds_cdrstream.h
@@ -725,23 +725,13 @@ DDS_EXPORT size_t dds_stream_getsize_key (const char *sample, const struct dds_c
   ddsrt_nonnull_all ddsrt_attribute_warn_unused_result;
 
 /**
- * @brief Determine the minimum XCDR version required by stream operations.
- * @component cdr_serializer
- *
- * @param ops  marshalling metadata to inspect
- * @returns    minimum required XCDR version
- */
-enum dds_cdr_enc_version dds_stream_minimum_xcdr_version (const uint32_t *ops)
-  ddsrt_nonnull_all;
-
-/**
  * @brief Determine the data representations supported by stream operations.
  * @component cdr_serializer
  *
  * @param ops  marshalling metadata to inspect
  * @returns    bitmask of DDS_DATA_REPRESENTATION_FLAG_XCDR1/XCDR2
  */
-uint32_t dds_stream_allowed_data_representations (const uint32_t *ops)
+uint32_t dds_stream_supported_data_representations (const uint32_t *ops)
   ddsrt_nonnull_all;
 
 /**

--- a/src/core/cdr/src/dds_cdrstream.c
+++ b/src/core/cdr/src/dds_cdrstream.c
@@ -238,6 +238,15 @@ static bool dds_stream_enum_value_set (const struct dds_cdrstream_desc_mid_table
 static bool dds_stream_enum_value_valid (const struct dds_cdrstream_desc_enum_value_set *set, uint32_t max, uint32_t val)
   ddsrt_attribute_warn_unused_result;
 
+static uint32_t dds_stream_enum_value_image (const uint32_t *op, uint32_t val)
+  ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+
+static uint32_t dds_stream_enum_value_from_image (const uint32_t *op, uint32_t image)
+  ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+
+static bool dds_stream_enum_value_image_from_memory (const uint32_t *op, uint32_t val, uint32_t *image)
+  ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+
 static enum tryconstruct tryconstruct_mode (uint32_t insn, bool for_subtype)
   ddsrt_attribute_warn_unused_result;
 
@@ -1687,8 +1696,10 @@ static inline uint32_t const * stream_union_switch_case (uint32_t insn, uint64_t
       *((uint16_t *) discaddr) = (uint16_t) disc;
       break;
     case DDS_SOP_VAL_4BY:
-    case DDS_SOP_VAL_ENU:
       *((uint32_t *) discaddr) = (uint32_t) disc;
+      break;
+    case DDS_SOP_VAL_ENU:
+      *((uint32_t *) discaddr) = dds_stream_enum_value_from_image (&insn, (uint32_t) disc);
       break;
     case DDS_SOP_VAL_8BY:
       *((uint64_t *) discaddr) = (uint64_t) disc;
@@ -1726,7 +1737,7 @@ ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
 static uint64_t union_default_discriminant (const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *ops, const uint32_t insn)
 {
   if (DDS_OP_SUBTYPE (insn) == DDS_SOP_VAL_ENU)
-    return dds_stream_enum_default_value (mid_table, ops, ops[4]);
+    return dds_stream_enum_value_image (ops, dds_stream_enum_default_value (mid_table, ops, ops[4]));
   return 0;
 }
 
@@ -2328,8 +2339,8 @@ static const uint32_t *dds_stream_getsize_arr (struct getsize_state *st, const c
   return ops;
 }
 
-ddsrt_nonnull_all
-static void dds_stream_getsize_union_discriminant (struct getsize_state *st, uint32_t insn, const void *addr, uint64_t *disc)
+ddsrt_nonnull_all ddsrt_attribute_warn_unused_result
+static bool dds_stream_getsize_union_discriminant (struct getsize_state *st, uint32_t insn, const void *addr, uint64_t *disc)
 {
   enum dds_stream_typecode type = DDS_OP_SUBTYPE (insn);
   assert (is_primitive_or_enum_or_bitmask_type (type));
@@ -2355,10 +2366,14 @@ static void dds_stream_getsize_union_discriminant (struct getsize_state *st, uin
       *disc = *((const uint64_t *) addr);
       getsize_reserve (st, 8);
       break;
-    case DDS_SOP_VAL_ENU:
-      *disc = *((const uint32_t *) addr);
+    case DDS_SOP_VAL_ENU: {
+      uint32_t image = 0;
+      if (!dds_stream_enum_value_image_from_memory (&insn, *((const uint32_t *) addr), &image))
+        return false;
+      *disc = image;
       getsize_reserve (st, DDS_OP_TYPE_SZ (insn));
       break;
+    }
     case DDS_SOP_VAL_BMK:
       switch (DDS_OP_TYPE_SZ (insn))
       {
@@ -2372,12 +2387,15 @@ static void dds_stream_getsize_union_discriminant (struct getsize_state *st, uin
     default:
       abort ();
   }
+  return true;
 }
 
+ddsrt_attribute_warn_unused_result
 static const uint32_t *dds_stream_getsize_uni (struct getsize_state *st, const char *discaddr, const char *baseaddr, const uint32_t *ops, uint32_t insn)
 {
   uint64_t disc;
-  dds_stream_getsize_union_discriminant (st, insn, discaddr, &disc);
+  if (!dds_stream_getsize_union_discriminant (st, insn, discaddr, &disc))
+    return NULL;
   uint32_t const * const jeq_op = find_union_case (ops, disc);
   ops += DDS_OP_ADR_JMP (ops[3]);
   if (jeq_op)
@@ -3068,11 +3086,11 @@ static const uint32_t *dds_stream_read_seq (dds_istream_t *is, char * restrict a
       {
         case 1:
           for (uint32_t i = 0; i < seq->_length; i++)
-            ((uint32_t *) seq->_buffer)[i] = dds_is_get1 (is);
+            ((uint32_t *) seq->_buffer)[i] = dds_stream_enum_value_from_image (&insn, dds_is_get1 (is));
           break;
         case 2:
           for (uint32_t i = 0; i < seq->_length; i++)
-            ((uint32_t *) seq->_buffer)[i] = dds_is_get2 (is);
+            ((uint32_t *) seq->_buffer)[i] = dds_stream_enum_value_from_image (&insn, dds_is_get2 (is));
           break;
         case 4:
           dds_is_get_bytes (is, seq->_buffer, seq->_length, elem_size);
@@ -3183,11 +3201,11 @@ static const uint32_t *dds_stream_read_arr (dds_istream_t *is, char * restrict a
       {
         case 1:
           for (uint32_t i = 0; i < num; i++)
-             ((uint32_t *) addr)[i] = dds_is_get1 (is);
+             ((uint32_t *) addr)[i] = dds_stream_enum_value_from_image (&insn, dds_is_get1 (is));
           break;
         case 2:
           for (uint32_t i = 0; i < num; i++)
-             ((uint32_t *) addr)[i] = dds_is_get2 (is);
+             ((uint32_t *) addr)[i] = dds_stream_enum_value_from_image (&insn, dds_is_get2 (is));
           break;
         case 4:
           dds_is_get_bytes (is, addr, num, 4);
@@ -3269,8 +3287,8 @@ static const uint32_t *dds_stream_read_uni (dds_istream_t *is, char * restrict d
       case DDS_SOP_VAL_ENU:
         switch (DDS_OP_TYPE_SZ (jeq_op[0]))
         {
-          case 1: *((uint32_t *) valaddr) = dds_is_get1 (is); break;
-          case 2: *((uint32_t *) valaddr) = dds_is_get2 (is); break;
+          case 1: *((uint32_t *) valaddr) = dds_stream_enum_value_from_image (jeq_op, dds_is_get1 (is)); break;
+          case 2: *((uint32_t *) valaddr) = dds_stream_enum_value_from_image (jeq_op, dds_is_get2 (is)); break;
           case 4: *((uint32_t *) valaddr) = dds_is_get4 (is); break;
           default: abort ();
         }
@@ -3375,8 +3393,8 @@ static inline const uint32_t *dds_stream_read_adr (uint32_t insn, dds_istream_t 
     case DDS_SOP_VAL_ENU: {
       switch (DDS_OP_TYPE_SZ (insn))
       {
-        case 1: *((uint32_t *) addr) = dds_is_get1 (&is1); break;
-        case 2: *((uint32_t *) addr) = dds_is_get2 (&is1); break;
+        case 1: *((uint32_t *) addr) = dds_stream_enum_value_from_image (ops, dds_is_get1 (&is1)); break;
+        case 2: *((uint32_t *) addr) = dds_stream_enum_value_from_image (ops, dds_is_get2 (&is1)); break;
         case 4: *((uint32_t *) addr) = dds_is_get4 (&is1); break;
         default: abort ();
       }
@@ -4087,11 +4105,65 @@ static uint32_t dds_stream_enum_default_value (const struct dds_cdrstream_desc_m
 
 static bool dds_stream_enum_value_valid (const struct dds_cdrstream_desc_enum_value_set *set, const uint32_t max, const uint32_t val)
 {
+  /* val is already the unsigned holder image. This keeps enum discriminator
+     selection independent of signed extension for 8/16-bit enum holders. */
   if (set == NULL)
     return val <= max;
   if (val > set->max)
     return false;
   return uint32_set_contains (set->values, set->nvalues, val);
+}
+
+static uint32_t dds_stream_enum_value_image (const uint32_t *op, uint32_t val)
+{
+  switch (DDS_OP_TYPE_SZ (*op))
+  {
+    case 1: return (uint8_t) val;
+    case 2: return (uint16_t) val;
+    case 4: return val;
+    default: abort ();
+  }
+}
+
+static uint32_t dds_stream_enum_value_from_image (const uint32_t *op, uint32_t image)
+{
+  /* CDR carries the unsigned holder image. Application memory stores the
+     semantic signed Int32 value, so narrow images with the sign bit set become
+     their signed enum literal value after validation/normalization. */
+  switch (DDS_OP_TYPE_SZ (*op))
+  {
+    case 1: return (uint32_t) (int32_t) (int8_t) (uint8_t) image;
+    case 2: return (uint32_t) (int32_t) (int16_t) (uint16_t) image;
+    case 4: return image;
+    default: abort ();
+  }
+}
+
+static bool dds_stream_enum_value_image_from_memory (const uint32_t *op, uint32_t val, uint32_t *image)
+{
+  /* Application memory stores the semantic signed Int32 enum value. Validate
+     that it is canonical for the CDR holder before comparing holder images, so
+     e.g. semantic -1 (0xffffffff) is accepted but invalid +255 is not an alias
+     for an 8-bit enum literal with holder image 0xff. */
+  const int32_t s_val = (int32_t) val;
+  switch (DDS_OP_TYPE_SZ (*op))
+  {
+    case 1:
+      if (s_val < INT8_MIN || s_val > INT8_MAX)
+        return false;
+      *image = (uint8_t) val;
+      return true;
+    case 2:
+      if (s_val < INT16_MIN || s_val > INT16_MAX)
+        return false;
+      *image = (uint16_t) val;
+      return true;
+    case 4:
+      *image = val;
+      return true;
+    default:
+      abort ();
+  }
 }
 
 static void normalize_store_uint_value (unsigned char * restrict const data, const uint32_t sz, const uint64_t val)
@@ -4135,7 +4207,7 @@ static enum dds_stream_normalize_result read_normalize_enum_tryconstruct (struct
       const uint32_t sz = DDS_OP_TYPE_SZ (insn);
       const uint32_t default_value = set ? set->default_value : 0;
       normalize_store_uint_value (post_data - sz, sz, default_value);
-      *val = default_value;
+      *val = dds_stream_enum_value_image (op, default_value);
       return normalize_success ();
     }
   }
@@ -5849,8 +5921,10 @@ static const uint32_t *dds_stream_free_sample_uni (char * restrict discaddr, cha
       disc = *((uint16_t *) discaddr);
       break;
     case DDS_SOP_VAL_4BY:
-    case DDS_SOP_VAL_ENU:
       disc = *((uint32_t *) discaddr);
+      break;
+    case DDS_SOP_VAL_ENU:
+      disc = dds_stream_enum_value_image (&insn, *((uint32_t *) discaddr));
       break;
     case DDS_SOP_VAL_BMK:
       switch (DDS_OP_TYPE_SZ (insn))
@@ -6492,8 +6566,8 @@ static void dds_stream_read_key_impl (dds_istream_t *is, char *sample, const str
     case DDS_SOP_VAL_ENU:
       switch (DDS_OP_TYPE_SZ (insn))
       {
-        case 1: *((uint32_t *) dst) = dds_is_get1 (is); break;
-        case 2: *((uint32_t *) dst) = dds_is_get2 (is); break;
+        case 1: *((uint32_t *) dst) = dds_stream_enum_value_from_image (&insn, dds_is_get1 (is)); break;
+        case 2: *((uint32_t *) dst) = dds_stream_enum_value_from_image (&insn, dds_is_get2 (is)); break;
         case 4: *((uint32_t *) dst) = dds_is_get4 (is); break;
         default: assert (0);
       }
@@ -6528,11 +6602,11 @@ static void dds_stream_read_key_impl (dds_istream_t *is, char *sample, const str
           {
             case 1:
               for (uint32_t i = 0; i < num; i++)
-                ((uint32_t *) dst)[i] = dds_is_get1 (is);
+                ((uint32_t *) dst)[i] = dds_stream_enum_value_from_image (&insn, dds_is_get1 (is));
               break;
             case 2:
               for (uint32_t i = 0; i < num; i++)
-                ((uint32_t *) dst)[i] = dds_is_get2 (is);
+                ((uint32_t *) dst)[i] = dds_stream_enum_value_from_image (&insn, dds_is_get2 (is));
               break;
             case 4:
               dds_is_get_bytes (is, dst, num, 4);

--- a/src/core/cdr/src/dds_cdrstream.c
+++ b/src/core/cdr/src/dds_cdrstream.c
@@ -208,7 +208,7 @@ static const struct dds_cdrstream_desc_mid_table static_empty_mid_table = { .tab
 static const uint32_t *dds_stream_skip_adr_insns (uint32_t insn, const uint32_t *ops)
   ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
 
-static const uint32_t *dds_stream_skip_insns_default (char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, enum sample_data_state sample_state)
+static const uint32_t *dds_stream_skip_insns_default (char * restrict data, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *ops, enum sample_data_state sample_state)
   ddsrt_nonnull_all;
 
 static const uint32_t *dds_stream_extract_key_from_data1 (dds_istream_t *is, restrict_ostream_t *os, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc_mid_table *mid_table,
@@ -227,13 +227,16 @@ static enum dds_stream_normalize_result stream_normalize_adr_impl (struct normal
 static enum dds_stream_normalize_result stream_normalize_data_impl (struct normalize_state const * restrict const st, uint32_t * restrict const off, const uint32_t **ops, bool is_mutable_member)
   ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
 
-static const uint32_t *dds_stream_read_impl (dds_istream_t *is, char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, bool is_mutable_member, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
+static const uint32_t *dds_stream_read_impl (dds_istream_t *is, char * restrict data, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *ops, bool is_mutable_member, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
   ddsrt_nonnull_all;
+
+static uint32_t dds_stream_enum_default_value (const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *op, uint32_t max)
+  ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
 
 static const uint32_t *stream_free_sample_adr (uint32_t insn, void * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops)
   ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
 
-static const uint32_t *dds_stream_skip_adr_insns_default (uint32_t insn, char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, enum sample_data_state sample_state)
+static const uint32_t *dds_stream_skip_adr_insns_default (uint32_t insn, char * restrict data, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *ops, enum sample_data_state sample_state)
   ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
 
 static const uint32_t *dds_stream_key_size (const uint32_t *ops, struct key_props *k)
@@ -1560,7 +1563,7 @@ static const uint32_t *skip_array_insns (const uint32_t *ops)
 }
 
 ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
-static const uint32_t *skip_array_insns_default (uint32_t insn, char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, enum sample_data_state sample_state)
+static const uint32_t *skip_array_insns_default (uint32_t insn, char * restrict data, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *ops, enum sample_data_state sample_state)
 {
   const enum dds_stream_typecode subtype = DDS_OP_SUBTYPE (insn);
   const uint32_t num = ops[2];
@@ -1571,10 +1574,20 @@ static const uint32_t *skip_array_insns_default (uint32_t insn, char * restrict 
       memset (data, 0, num * elem_size);
       return ops + 3;
     }
-    case DDS_SOP_VAL_ENU: case DDS_SOP_VAL_BMK: {
+    case DDS_SOP_VAL_ENU: {
+      const uint32_t default_value = dds_stream_enum_default_value (mid_table, ops, ops[3]);
+      uint32_t *xs = (uint32_t *) data;
+      if (default_value == 0)
+        memset (xs, 0, num * sizeof (*xs));
+      else
+        for (uint32_t i = 0; i < num; i++)
+          xs[i] = default_value;
+      return ops + 4;
+    }
+    case DDS_SOP_VAL_BMK: {
       const uint32_t elem_size = DDS_OP_TYPE_SZ (insn);
       memset (data, 0, num * elem_size);
-      return ops + 4 + (subtype == DDS_SOP_VAL_BMK ? 1 : 0);
+      return ops + 5;
     }
     case DDS_SOP_VAL_STR: {
       char **ptr = (char **) data;
@@ -1607,7 +1620,7 @@ static const uint32_t *skip_array_insns_default (uint32_t insn, char * restrict 
       const uint32_t jmp = DDS_OP_ADR_JMP (ops[3]);
       const uint32_t elem_size = ops[4];
       for (uint32_t i = 0; i < num; i++)
-        (void) dds_stream_skip_insns_default (data + i * elem_size, allocator, jsr_ops, sample_state);
+        (void) dds_stream_skip_insns_default (data + i * elem_size, allocator, mid_table, jsr_ops, sample_state);
       return ops + (jmp ? jmp : 5);
     }
     case DDS_SOP_VAL_EXT: {
@@ -1678,9 +1691,16 @@ static void dds_stream_union_member_alloc_external (uint32_t const * const jeq_o
 }
 
 ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
-static const uint32_t * skip_union_insns_default (uint32_t insn, char * restrict discaddr, char * restrict baseaddr, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, enum sample_data_state sample_state)
+static uint64_t union_default_discriminant (const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *ops, const uint32_t insn)
 {
-  const uint64_t disc = 0; // FIXME: this probably needs to change when @default_literal is supported
+  if (DDS_OP_SUBTYPE (insn) == DDS_SOP_VAL_ENU)
+    return dds_stream_enum_default_value (mid_table, ops, ops[4]);
+  return 0;
+}
+
+static const uint32_t * skip_union_insns_default (uint32_t insn, char * restrict discaddr, char * restrict baseaddr, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *ops, enum sample_data_state sample_state)
+{
+  const uint64_t disc = union_default_discriminant (mid_table, ops, insn);
   uint32_t const * const jeq_op = stream_union_switch_case (insn, disc, discaddr, baseaddr, allocator, ops, &sample_state);
   ops += DDS_OP_ADR_JMP (ops[3]);
   if (jeq_op)
@@ -1695,14 +1715,15 @@ static const uint32_t * skip_union_insns_default (uint32_t insn, char * restrict
     {
       case DDS_SOP_VAL_BLN: case DDS_SOP_VAL_1BY: *((uint8_t *) valaddr) = 0; break;
       case DDS_SOP_VAL_2BY: *((uint16_t *) valaddr) = 0; break;
-      case DDS_SOP_VAL_4BY: case DDS_SOP_VAL_ENU: *((uint32_t *) valaddr) = 0; break;
+      case DDS_SOP_VAL_4BY: *((uint32_t *) valaddr) = 0; break;
+      case DDS_SOP_VAL_ENU: *((uint32_t *) valaddr) = dds_stream_enum_default_value (mid_table, jeq_op, jeq_op[3]); break;
       case DDS_SOP_VAL_8BY: *((uint64_t *) valaddr) = 0; break;
       case DDS_SOP_VAL_16BY: memset (valaddr, 0, 16); break;
       case DDS_SOP_VAL_STR: *(char **) valaddr = dds_stream_reuse_string_empty (*((char **) valaddr), allocator, sample_state); break;
       case DDS_SOP_VAL_WSTR: *(wchar_t **) valaddr = dds_stream_reuse_wstring_empty (*((wchar_t **) valaddr), allocator, sample_state); break;
       case DDS_SOP_VAL_WCHAR: *((wchar_t *) valaddr) = L'\0'; break;
       case DDS_SOP_VAL_BST: case DDS_SOP_VAL_BWSTR: case DDS_SOP_VAL_SEQ: case DDS_SOP_VAL_BSQ: case DDS_SOP_VAL_ARR: case DDS_SOP_VAL_UNI: case DDS_SOP_VAL_STU: case DDS_SOP_VAL_BMK:
-        (void) dds_stream_skip_insns_default (valaddr, allocator, jeq_op + DDS_OP_ADR_JSR (jeq_op[0]), sample_state);
+        (void) dds_stream_skip_insns_default (valaddr, allocator, mid_table, jeq_op + DDS_OP_ADR_JSR (jeq_op[0]), sample_state);
         break;
       case DDS_SOP_VAL_EXT: {
         abort (); /* not supported */
@@ -1852,9 +1873,9 @@ static bool find_member_id (const struct dds_cdrstream_desc_mid_table *mid_table
     return false;
   struct dds_cdrstream_desc_mid tmpl = { .adr_offs = (uint32_t) (adr_op - mid_table->op0) };
   const struct dds_cdrstream_desc_mid *m = ddsrt_hh_lookup (mid_table->table, &tmpl);
-  if (m != NULL)
+  if (m != NULL && m->mid != UINT32_MAX)
     *mid = m->mid;
-  return m != NULL;
+  return m != NULL && m->mid != UINT32_MAX;
 }
 
 #if DDSRT_ENDIAN == DDSRT_LITTLE_ENDIAN
@@ -2950,7 +2971,7 @@ static const uint32_t *dds_stream_read_skip_adr (dds_istream_t *is, const uint32
 }
 
 ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
-static const uint32_t *dds_stream_read_seq (dds_istream_t *is, char * restrict addr, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, uint32_t insn, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
+static const uint32_t *dds_stream_read_seq (dds_istream_t *is, char * restrict addr, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *ops, uint32_t insn, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
 {
   dds_sequence_t * const seq = (dds_sequence_t *) addr;
   const enum dds_stream_typecode subtype = DDS_OP_SUBTYPE (insn);
@@ -3090,7 +3111,7 @@ static const uint32_t *dds_stream_read_seq (dds_istream_t *is, char * restrict a
       seq->_length = (num <= seq->_maximum) ? num : seq->_maximum;
       char *ptr = (char *) seq->_buffer;
       for (uint32_t i = 0; i < num; i++)
-        (void) dds_stream_read_impl (is, ptr + i * elem_size, allocator, jsr_ops, false, cdr_kind, sample_state);
+        (void) dds_stream_read_impl (is, ptr + i * elem_size, allocator, mid_table, jsr_ops, false, cdr_kind, sample_state);
       for (uint32_t i = num; i < num_cdr; i++)
         (void) dds_stream_read_skip_adr (is, jsr_ops, cdr_kind);
       return ops + (jmp ? jmp : (4 + bound_op)); /* FIXME: why would jmp be 0? */
@@ -3104,7 +3125,7 @@ static const uint32_t *dds_stream_read_seq (dds_istream_t *is, char * restrict a
 }
 
 ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
-static const uint32_t *dds_stream_read_arr (dds_istream_t *is, char * restrict addr, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, uint32_t insn, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
+static const uint32_t *dds_stream_read_arr (dds_istream_t *is, char * restrict addr, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *ops, uint32_t insn, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
 {
   const enum dds_stream_typecode subtype = DDS_OP_SUBTYPE (insn);
   if (is_dheader_needed (subtype, is->m_xcdr_version))
@@ -3180,7 +3201,7 @@ static const uint32_t *dds_stream_read_arr (dds_istream_t *is, char * restrict a
       const uint32_t jmp = DDS_OP_ADR_JMP (ops[3]);
       const uint32_t elem_size = ops[4];
       for (uint32_t i = 0; i < num; i++)
-        (void) dds_stream_read_impl (is, addr + i * elem_size, allocator, jsr_ops, false, cdr_kind, sample_state);
+        (void) dds_stream_read_impl (is, addr + i * elem_size, allocator, mid_table, jsr_ops, false, cdr_kind, sample_state);
       return ops + (jmp ? jmp : 5);
     }
     case DDS_SOP_VAL_EXT: {
@@ -3192,7 +3213,7 @@ static const uint32_t *dds_stream_read_arr (dds_istream_t *is, char * restrict a
 }
 
 ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
-static const uint32_t *dds_stream_read_uni (dds_istream_t *is, char * restrict discaddr, char * restrict baseaddr, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, uint32_t insn, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
+static const uint32_t *dds_stream_read_uni (dds_istream_t *is, char * restrict discaddr, char * restrict baseaddr, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *ops, uint32_t insn, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
 {
   const uint64_t disc = read_union_discriminant (is, insn);
   uint32_t const * const jeq_op = stream_union_switch_case (insn, disc, discaddr, baseaddr, allocator, ops, &sample_state);
@@ -3229,11 +3250,11 @@ static const uint32_t *dds_stream_read_uni (dds_istream_t *is, char * restrict d
         *(wchar_t **) valaddr = dds_stream_reuse_wstring (is, *((wchar_t **) valaddr), allocator, sample_state);
         break;
       case DDS_SOP_VAL_BST: case DDS_SOP_VAL_BWSTR: case DDS_SOP_VAL_SEQ: case DDS_SOP_VAL_BSQ: case DDS_SOP_VAL_ARR: case DDS_SOP_VAL_BMK:
-        (void) dds_stream_read_impl (is, valaddr, allocator, jeq_op + DDS_OP_ADR_JSR (jeq_op[0]), false, cdr_kind, sample_state);
+        (void) dds_stream_read_impl (is, valaddr, allocator, mid_table, jeq_op + DDS_OP_ADR_JSR (jeq_op[0]), false, cdr_kind, sample_state);
         break;
       case DDS_SOP_VAL_UNI: case DDS_SOP_VAL_STU: {
         const uint32_t *jsr_ops = jeq_op + DDS_OP_ADR_JSR (jeq_op[0]);
-        (void) dds_stream_read_impl (is, valaddr, allocator, jsr_ops, false, cdr_kind, sample_state);
+        (void) dds_stream_read_impl (is, valaddr, allocator, mid_table, jsr_ops, false, cdr_kind, sample_state);
         break;
       }
       case DDS_SOP_VAL_EXT: {
@@ -3268,7 +3289,7 @@ static inline const uint32_t *stream_skip_member_insns (uint32_t insn, char * re
 }
 
 ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
-static inline const uint32_t *dds_stream_read_adr (uint32_t insn, dds_istream_t *is, char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, bool is_mutable_member, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
+static inline const uint32_t *dds_stream_read_adr (uint32_t insn, dds_istream_t *is, char * restrict data, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *ops, bool is_mutable_member, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
 {
   void *addr = data + ops[1];
 
@@ -3316,9 +3337,9 @@ static inline const uint32_t *dds_stream_read_adr (uint32_t insn, dds_istream_t 
     case DDS_SOP_VAL_WSTR: *((wchar_t **) addr) = dds_stream_reuse_wstring (&is1, *((wchar_t **) addr), allocator, sample_state); ops += 2; break;
     case DDS_SOP_VAL_BST: (void) dds_stream_reuse_string_bound (&is1, (char *) addr, ops[2]); ops += 3; break;
     case DDS_SOP_VAL_BWSTR: (void) dds_stream_reuse_wstring_bound (&is1, (wchar_t *) addr, ops[2]); ops += 3; break;
-    case DDS_SOP_VAL_SEQ: case DDS_SOP_VAL_BSQ: ops = dds_stream_read_seq (&is1, addr, allocator, ops, insn, cdr_kind, sample_state); break;
-    case DDS_SOP_VAL_ARR: ops = dds_stream_read_arr (&is1, addr, allocator, ops, insn, cdr_kind, sample_state); break;
-    case DDS_SOP_VAL_UNI: ops = dds_stream_read_uni (&is1, addr, data, allocator, ops, insn, cdr_kind, sample_state); break;
+    case DDS_SOP_VAL_SEQ: case DDS_SOP_VAL_BSQ: ops = dds_stream_read_seq (&is1, addr, allocator, mid_table, ops, insn, cdr_kind, sample_state); break;
+    case DDS_SOP_VAL_ARR: ops = dds_stream_read_arr (&is1, addr, allocator, mid_table, ops, insn, cdr_kind, sample_state); break;
+    case DDS_SOP_VAL_UNI: ops = dds_stream_read_uni (&is1, addr, data, allocator, mid_table, ops, insn, cdr_kind, sample_state); break;
     case DDS_SOP_VAL_ENU: {
       switch (DDS_OP_TYPE_SZ (insn))
       {
@@ -3351,7 +3372,7 @@ static inline const uint32_t *dds_stream_read_adr (uint32_t insn, dds_istream_t 
       if (op_type_base (insn) && jsr_ops[0] == DDS_OP_DLC)
         jsr_ops++;
 
-      (void) dds_stream_read_impl (&is1, addr, allocator, jsr_ops, false, cdr_kind, sample_state);
+      (void) dds_stream_read_impl (&is1, addr, allocator, mid_table, jsr_ops, false, cdr_kind, sample_state);
       ops += jmp ? jmp : 3;
       break;
     }
@@ -3402,7 +3423,7 @@ static const uint32_t *dds_stream_skip_adr_insns (uint32_t insn, const uint32_t 
 }
 
 ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
-static const uint32_t *dds_stream_skip_adr_insns_default (uint32_t insn, char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, enum sample_data_state sample_state)
+static const uint32_t *dds_stream_skip_adr_insns_default (uint32_t insn, char * restrict data, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *ops, enum sample_data_state sample_state)
 {
   void *addr = data + ops[1];
   /* FIXME: currently only implicit default values are used, this code should be
@@ -3427,7 +3448,7 @@ static const uint32_t *dds_stream_skip_adr_insns_default (uint32_t insn, char * 
     case DDS_SOP_VAL_WSTR: *(wchar_t **) addr = dds_stream_reuse_wstring_empty (*(wchar_t **) addr, allocator, sample_state); return ops + 2;
     case DDS_SOP_VAL_BST: ((char *) addr)[0] = '\0'; return ops + 3;
     case DDS_SOP_VAL_BWSTR: ((wchar_t *) addr)[0] = L'\0'; return ops + 3;
-    case DDS_SOP_VAL_ENU: *(uint32_t *) addr = 0; return ops + 3;
+    case DDS_SOP_VAL_ENU: *(uint32_t *) addr = dds_stream_enum_default_value (mid_table, ops, ops[2]); return ops + 3;
     case DDS_SOP_VAL_BMK: {
       switch (DDS_OP_TYPE_SZ (insn))
       {
@@ -3443,15 +3464,15 @@ static const uint32_t *dds_stream_skip_adr_insns_default (uint32_t insn, char * 
       return initialize_and_skip_sequence_insns (seq, ops, sample_state);
     }
     case DDS_SOP_VAL_ARR: {
-      return skip_array_insns_default (insn, addr, allocator, ops, sample_state);
+      return skip_array_insns_default (insn, addr, allocator, mid_table, ops, sample_state);
     }
     case DDS_SOP_VAL_UNI: {
-      return skip_union_insns_default (insn, addr, data, allocator, ops, sample_state);
+      return skip_union_insns_default (insn, addr, data, allocator, mid_table, ops, sample_state);
     }
     case DDS_SOP_VAL_EXT: {
       const uint32_t *jsr_ops = ops + DDS_OP_ADR_JSR (ops[2]);
       const uint32_t jmp = DDS_OP_ADR_JMP (ops[2]);
-      (void) dds_stream_skip_insns_default (addr, allocator, jsr_ops, sample_state);
+      (void) dds_stream_skip_insns_default (addr, allocator, mid_table, jsr_ops, sample_state);
       return ops + (jmp ? jmp : 3);
     }
     case DDS_SOP_VAL_STU: {
@@ -3464,13 +3485,13 @@ static const uint32_t *dds_stream_skip_adr_insns_default (uint32_t insn, char * 
 }
 
 ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
-static const uint32_t *dds_stream_skip_delimited_insns_default (char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, enum sample_data_state sample_state)
+static const uint32_t *dds_stream_skip_delimited_insns_default (char * restrict data, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *ops, enum sample_data_state sample_state)
 {
-  return dds_stream_skip_insns_default (data, allocator, ++ops, sample_state);
+  return dds_stream_skip_insns_default (data, allocator, mid_table, ++ops, sample_state);
 }
 
 ddsrt_nonnull_all
-static void dds_stream_skip_pl_member_insns_default (char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, enum sample_data_state sample_state)
+static void dds_stream_skip_pl_member_insns_default (char * restrict data, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *ops, enum sample_data_state sample_state)
 {
   uint32_t insn;
   while ((insn = *ops) != DDS_OP_RTS)
@@ -3478,11 +3499,11 @@ static void dds_stream_skip_pl_member_insns_default (char * restrict data, const
     switch (DDS_OP (insn))
     {
       case DDS_SOP_ADR: {
-        ops = dds_stream_skip_insns_default (data, allocator, ops, sample_state);
+        ops = dds_stream_skip_insns_default (data, allocator, mid_table, ops, sample_state);
         break;
       }
       case DDS_SOP_JSR:
-        dds_stream_skip_pl_member_insns_default (data, allocator, ops + DDS_OP_JUMP (insn), sample_state);
+        dds_stream_skip_pl_member_insns_default (data, allocator, mid_table, ops + DDS_OP_JUMP (insn), sample_state);
         ops++;
         break;
       case DDS_SOP_RTS: case DDS_SOP_JEQ: case DDS_SOP_JEQ4: case DDS_SOP_KOF:
@@ -3494,7 +3515,7 @@ static void dds_stream_skip_pl_member_insns_default (char * restrict data, const
 }
 
 ddsrt_nonnull_all
-static const uint32_t *dds_stream_skip_pl_memberlist_insns_default (char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops0, enum sample_data_state sample_state)
+static const uint32_t *dds_stream_skip_pl_memberlist_insns_default (char * restrict data, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *ops0, enum sample_data_state sample_state)
 {
   const uint32_t *ops = ops0;
   uint32_t insn;
@@ -3509,11 +3530,11 @@ static const uint32_t *dds_stream_skip_pl_memberlist_insns_default (char * restr
         {
           assert (plm_ops[0] == DDS_OP_PLC);
           plm_ops++; /* skip PLC op to go to first PLM for the base type */
-          (void) dds_stream_skip_pl_memberlist_insns_default (data, allocator, plm_ops, sample_state);
+          (void) dds_stream_skip_pl_memberlist_insns_default (data, allocator, mid_table, plm_ops, sample_state);
         }
         else
         {
-          dds_stream_skip_pl_member_insns_default (data, allocator, plm_ops, sample_state);
+          dds_stream_skip_pl_member_insns_default (data, allocator, mid_table, plm_ops, sample_state);
         }
         ops += 2;
         break;
@@ -3527,14 +3548,14 @@ static const uint32_t *dds_stream_skip_pl_memberlist_insns_default (char * restr
 }
 
 ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
-static const uint32_t *dds_stream_skip_pl_insns_default (char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, enum sample_data_state sample_state)
+static const uint32_t *dds_stream_skip_pl_insns_default (char * restrict data, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *ops, enum sample_data_state sample_state)
 {
   /* skip PLC op */
-  return dds_stream_skip_pl_memberlist_insns_default (data, allocator, ++ops, sample_state);
+  return dds_stream_skip_pl_memberlist_insns_default (data, allocator, mid_table, ++ops, sample_state);
 }
 
 ddsrt_nonnull_all
-static const uint32_t *dds_stream_skip_insns_default (char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, enum sample_data_state sample_state)
+static const uint32_t *dds_stream_skip_insns_default (char * restrict data, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *ops, enum sample_data_state sample_state)
 {
   uint32_t insn;
   while ((insn = *ops) != DDS_OP_RTS)
@@ -3542,11 +3563,11 @@ static const uint32_t *dds_stream_skip_insns_default (char * restrict data, cons
     switch (DDS_OP (insn))
     {
       case DDS_SOP_ADR: {
-        ops = dds_stream_skip_adr_insns_default (insn, data, allocator, ops, sample_state);
+        ops = dds_stream_skip_adr_insns_default (insn, data, allocator, mid_table, ops, sample_state);
         break;
       }
       case DDS_SOP_JSR: {
-        (void) dds_stream_skip_insns_default (data, allocator, ops + DDS_OP_JUMP (insn), sample_state);
+        (void) dds_stream_skip_insns_default (data, allocator, mid_table, ops + DDS_OP_JUMP (insn), sample_state);
         ops++;
         break;
       }
@@ -3554,10 +3575,10 @@ static const uint32_t *dds_stream_skip_insns_default (char * restrict data, cons
         abort ();
         break;
       case DDS_SOP_DLC:
-        ops = dds_stream_skip_delimited_insns_default (data, allocator, ops, sample_state);
+        ops = dds_stream_skip_delimited_insns_default (data, allocator, mid_table, ops, sample_state);
         break;
       case DDS_SOP_PLC:
-        ops = dds_stream_skip_pl_insns_default (data, allocator, ops, sample_state);
+        ops = dds_stream_skip_pl_insns_default (data, allocator, mid_table, ops, sample_state);
         break;
     }
   }
@@ -3565,7 +3586,7 @@ static const uint32_t *dds_stream_skip_insns_default (char * restrict data, cons
 }
 
 ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
-static const uint32_t *dds_stream_read_delimited (dds_istream_t *is, char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
+static const uint32_t *dds_stream_read_delimited (dds_istream_t *is, char * restrict data, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *ops, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
 {
   uint32_t delimited_offs = is->m_index, insn, delimited_sz = is->m_size - is->m_index;
   ops++; // skip DLC op
@@ -3575,11 +3596,11 @@ static const uint32_t *dds_stream_read_delimited (dds_istream_t *is, char * rest
     {
       case DDS_SOP_ADR: {
         /* skip fields that are not in serialized data for appendable type */
-        ops = (is->m_index - delimited_offs < delimited_sz) ? dds_stream_read_adr (insn, is, data, allocator, ops, false, cdr_kind, sample_state) : dds_stream_skip_adr_insns_default (insn, data, allocator, ops, sample_state);
+        ops = (is->m_index - delimited_offs < delimited_sz) ? dds_stream_read_adr (insn, is, data, allocator, mid_table, ops, false, cdr_kind, sample_state) : dds_stream_skip_adr_insns_default (insn, data, allocator, mid_table, ops, sample_state);
         break;
       }
       case DDS_SOP_JSR: {
-        (void) dds_stream_read_impl (is, data, allocator, ops + DDS_OP_JUMP (insn), false, cdr_kind, sample_state);
+        (void) dds_stream_read_impl (is, data, allocator, mid_table, ops + DDS_OP_JUMP (insn), false, cdr_kind, sample_state);
         ops++;
         break;
       }
@@ -3596,7 +3617,7 @@ static const uint32_t *dds_stream_read_delimited (dds_istream_t *is, char * rest
 }
 
 ddsrt_nonnull_all
-static bool dds_stream_read_pl_member (dds_istream_t *is, char * restrict data, const struct dds_cdrstream_allocator *allocator, uint32_t m_id, const uint32_t *ops, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
+static bool dds_stream_read_pl_member (dds_istream_t *is, char * restrict data, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc_mid_table *mid_table, uint32_t m_id, const uint32_t *ops, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
 {
   uint32_t insn, ops_csr = 0;
   bool found = false;
@@ -3612,11 +3633,11 @@ static bool dds_stream_read_pl_member (dds_istream_t *is, char * restrict data, 
     {
       assert (DDS_OP (plm_ops[0]) == DDS_OP_PLC);
       plm_ops++; /* skip PLC to go to first PLM from base type */
-      found = dds_stream_read_pl_member (is, data, allocator, m_id, plm_ops, cdr_kind, sample_state);
+      found = dds_stream_read_pl_member (is, data, allocator, mid_table, m_id, plm_ops, cdr_kind, sample_state);
     }
     else if (ops[ops_csr + 1] == m_id)
     {
-      (void) dds_stream_read_impl (is, data, allocator, plm_ops, true, cdr_kind, sample_state);
+      (void) dds_stream_read_impl (is, data, allocator, mid_table, plm_ops, true, cdr_kind, sample_state);
       found = true;
       break;
     }
@@ -3626,14 +3647,14 @@ static bool dds_stream_read_pl_member (dds_istream_t *is, char * restrict data, 
 }
 
 ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
-static const uint32_t *dds_stream_read_xcdr1_pl (dds_istream_t *is, char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
+static const uint32_t *dds_stream_read_xcdr1_pl (dds_istream_t *is, char * restrict data, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *ops, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
 {
   /* skip PLC op */
   ops++;
 
   /* default-initialize all members
       FIXME: optimize so that only members not in received data are initialized */
-  dds_stream_skip_pl_memberlist_insns_default (data, allocator, ops, sample_state);
+  dds_stream_skip_pl_memberlist_insns_default (data, allocator, mid_table, ops, sample_state);
 
   uint32_t param_mid, param_len;
   while (stream_read_xcdr1_paramheader (is, &param_mid, &param_len))
@@ -3646,7 +3667,7 @@ static const uint32_t *dds_stream_read_xcdr1_pl (dds_istream_t *is, char * restr
     is1.m_size = param_len;
 
     // find member and deserialize
-    (void) dds_stream_read_pl_member (&is1, data, allocator, param_mid, ops, cdr_kind, sample_state);
+    (void) dds_stream_read_pl_member (&is1, data, allocator, mid_table, param_mid, ops, cdr_kind, sample_state);
 
     // forward index in CDR by param_len if found, and also in case member not known
     is->m_index += param_len;
@@ -3660,14 +3681,14 @@ static const uint32_t *dds_stream_read_xcdr1_pl (dds_istream_t *is, char * restr
 }
 
 ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
-static const uint32_t *dds_stream_read_xcdr2_pl (dds_istream_t *is, char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
+static const uint32_t *dds_stream_read_xcdr2_pl (dds_istream_t *is, char * restrict data, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *ops, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
 {
   /* skip PLC op */
   ops++;
 
   /* default-initialize all members
       FIXME: optimize so that only members not in received data are initialized */
-  dds_stream_skip_pl_memberlist_insns_default (data, allocator, ops, sample_state);
+  dds_stream_skip_pl_memberlist_insns_default (data, allocator, mid_table, ops, sample_state);
 
   /* read DHEADER */
   uint32_t pl_sz = dds_is_get4 (is), pl_offs = is->m_index;
@@ -3701,7 +3722,7 @@ static const uint32_t *dds_stream_read_xcdr2_pl (dds_istream_t *is, char * restr
     const uint32_t next_off = is->m_index + msz + ((lc >= LENGTH_CODE_ALSO_NEXTINT) ? 4 : 0);
 #endif
     /* find member and deserialize */
-    if (!dds_stream_read_pl_member (is, data, allocator, m_id, ops, cdr_kind, sample_state))
+    if (!dds_stream_read_pl_member (is, data, allocator, mid_table, m_id, ops, cdr_kind, sample_state))
     {
       is->m_index += msz;
       if (lc >= LENGTH_CODE_ALSO_NEXTINT)
@@ -3717,7 +3738,7 @@ static const uint32_t *dds_stream_read_xcdr2_pl (dds_istream_t *is, char * restr
   return ops;
 }
 
-static const uint32_t *dds_stream_read_impl (dds_istream_t *is, char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, bool is_mutable_member, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
+static const uint32_t *dds_stream_read_impl (dds_istream_t *is, char * restrict data, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *ops, bool is_mutable_member, enum cdr_data_kind cdr_kind, enum sample_data_state sample_state)
 {
   uint32_t insn;
   while ((insn = *ops) != DDS_OP_RTS)
@@ -3725,10 +3746,10 @@ static const uint32_t *dds_stream_read_impl (dds_istream_t *is, char * restrict 
     switch (DDS_OP (insn))
     {
       case DDS_SOP_ADR:
-        ops = dds_stream_read_adr (insn, is, data, allocator, ops, is_mutable_member, cdr_kind, sample_state);
+        ops = dds_stream_read_adr (insn, is, data, allocator, mid_table, ops, is_mutable_member, cdr_kind, sample_state);
         break;
       case DDS_SOP_JSR:
-        (void) dds_stream_read_impl (is, data, allocator, ops + DDS_OP_JUMP (insn), is_mutable_member, cdr_kind, sample_state);
+        (void) dds_stream_read_impl (is, data, allocator, mid_table, ops + DDS_OP_JUMP (insn), is_mutable_member, cdr_kind, sample_state);
         ops++;
         break;
       case DDS_SOP_RTS: case DDS_SOP_JEQ: case DDS_SOP_JEQ4: case DDS_SOP_KOF: case DDS_SOP_PLM: case DDS_SOP_MID:
@@ -3744,16 +3765,16 @@ static const uint32_t *dds_stream_read_impl (dds_istream_t *is, char * restrict 
 
           is->m_index += delimited_sz;
         }
-        ops = dds_stream_read_delimited (&is1, data, allocator, ops, cdr_kind, sample_state);
+        ops = dds_stream_read_delimited (&is1, data, allocator, mid_table, ops, cdr_kind, sample_state);
         if (is->m_xcdr_version == DDSI_RTPS_CDR_ENC_VERSION_1)
           is->m_index = is1.m_index;
         break;
       }
       case DDS_SOP_PLC:
         if (is->m_xcdr_version == DDSI_RTPS_CDR_ENC_VERSION_2)
-          ops = dds_stream_read_xcdr2_pl (is, data, allocator, ops, cdr_kind, sample_state);
+          ops = dds_stream_read_xcdr2_pl (is, data, allocator, mid_table, ops, cdr_kind, sample_state);
         else
-          ops = dds_stream_read_xcdr1_pl (is, data, allocator, ops, cdr_kind, sample_state);
+          ops = dds_stream_read_xcdr1_pl (is, data, allocator, mid_table, ops, cdr_kind, sample_state);
         break;
     }
   }
@@ -3762,7 +3783,7 @@ static const uint32_t *dds_stream_read_impl (dds_istream_t *is, char * restrict 
 
 const uint32_t *dds_stream_read (dds_istream_t *is, char * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops)
 {
-  return dds_stream_read_impl (is, data, allocator, ops, false, CDR_KIND_DATA, SAMPLE_DATA_INITIALIZED);
+  return dds_stream_read_impl (is, data, allocator, &static_empty_mid_table, ops, false, CDR_KIND_DATA, SAMPLE_DATA_INITIALIZED);
 }
 
 /*******************************************************************************************
@@ -3990,10 +4011,89 @@ static bool peek_and_normalize_uint32 (struct normalize_state const * const st, 
   return true;
 }
 
-ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
-static enum dds_stream_normalize_result read_normalize_enum_tryconstruct (const uint32_t insn, const uint32_t max, unsigned char * restrict const post_data, const bool for_subtype, uint32_t * const val)
+static bool uint32_set_contains (const uint32_t *xs, uint32_t n, uint32_t x)
 {
-  if (*val <= max)
+  uint32_t a = 0, b = n;
+  while (a < b)
+  {
+    const uint32_t m = a + (b - a) / 2;
+    const uint32_t y = xs[m];
+    if (y < x)
+      a = m + 1;
+    else
+      b = m;
+  }
+  return a < n && xs[a] == x;
+}
+
+static bool dds_stream_enum_value_set (const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *op, const uint32_t max, const struct dds_cdrstream_desc_enum_value_set **set)
+{
+  *set = NULL;
+  if (max != UINT32_MAX || mid_table->enum_value_sets == NULL)
+    return true;
+  if (mid_table->table == NULL || mid_table->op0 == NULL)
+    return false;
+  struct dds_cdrstream_desc_mid tmpl = { .adr_offs = (uint32_t) (op - mid_table->op0) };
+  const struct dds_cdrstream_desc_mid *m = ddsrt_hh_lookup (mid_table->table, &tmpl);
+  if (m == NULL || m->enum_value_set == NULL)
+    return false;
+  *set = m->enum_value_set;
+  return true;
+}
+
+static enum dds_stream_normalize_result normalize_enum_value_set (struct normalize_state const * const st, const uint32_t *op, const uint32_t max, const struct dds_cdrstream_desc_enum_value_set **set)
+{
+  return dds_stream_enum_value_set (st->mid_table, op, max, set) ? normalize_success () : normalize_error ();
+}
+
+static uint32_t dds_stream_enum_default_value (const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *op, const uint32_t max)
+{
+  if (!mid_table->has_special_defaults)
+    return 0;
+  const struct dds_cdrstream_desc_enum_value_set *set;
+  if (!dds_stream_enum_value_set (mid_table, op, max, &set))
+    abort ();
+  return set ? set->default_value : 0;
+}
+
+static bool normalize_enum_value_valid (const struct dds_cdrstream_desc_enum_value_set *set, const uint32_t max, const uint32_t val)
+{
+  if (set == NULL)
+    return val <= max;
+  if (val > set->max)
+    return false;
+  return uint32_set_contains (set->values, set->nvalues, val);
+}
+
+static void normalize_store_uint_value (unsigned char * restrict const data, const uint32_t sz, const uint64_t val)
+{
+  switch (sz)
+  {
+    case 1:
+      *((uint8_t *) data) = (uint8_t) val;
+      break;
+    case 2:
+      *((uint16_t *) data) = (uint16_t) val;
+      break;
+    case 4:
+      *((uint32_t *) data) = (uint32_t) val;
+      break;
+    case 8:
+      *((uint64_t *) data) = val;
+      break;
+    default:
+      abort ();
+  }
+}
+
+ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
+static enum dds_stream_normalize_result read_normalize_enum_tryconstruct (struct normalize_state const * const st, const uint32_t *op, const uint32_t insn, const uint32_t max, unsigned char * restrict const post_data, const bool for_subtype, uint32_t * const val)
+{
+  const struct dds_cdrstream_desc_enum_value_set *set;
+  enum dds_stream_normalize_result res;
+  if ((res = normalize_enum_value_set (st, op, max, &set)) != DDS_STREAM_NORMALIZE_SUCCESS)
+    return res;
+  if (normalize_enum_value_valid (set, max, *val))
     return normalize_success ();
   // note: can't use normalize_from_tryconstruct becasue we're also reading the value
   switch (tryconstruct_mode (insn, for_subtype))
@@ -4003,10 +4103,10 @@ static enum dds_stream_normalize_result read_normalize_enum_tryconstruct (const 
     case TC_DISCARD:
       return normalize_discard ();
     case TC_TRIM: case TC_USE_DEFAULT: {
-      // FIXME: deal with no consecutive enum values one day
       const uint32_t sz = DDS_OP_TYPE_SZ (insn);
-      memset (post_data - sz, 0, sz);
-      *val = 0;
+      const uint32_t default_value = set ? set->default_value : 0;
+      normalize_store_uint_value (post_data - sz, sz, default_value);
+      *val = default_value;
       return normalize_success ();
     }
   }
@@ -4014,8 +4114,9 @@ static enum dds_stream_normalize_result read_normalize_enum_tryconstruct (const 
 }
 
 ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
-static enum dds_stream_normalize_result read_normalize_enum (struct normalize_state const * const st, uint32_t * restrict const off, const uint32_t insn, const uint32_t max, const bool for_subtype, uint32_t * restrict const val)
+static enum dds_stream_normalize_result read_normalize_enum (struct normalize_state const * const st, uint32_t * restrict const off, const uint32_t *op, const uint32_t max, const bool for_subtype, uint32_t * restrict const val)
 {
+  const uint32_t insn = *op;
   switch (DDS_OP_TYPE_SZ (insn))
   {
     case 1: {
@@ -4043,14 +4144,14 @@ static enum dds_stream_normalize_result read_normalize_enum (struct normalize_st
       assert (0);
       return normalize_error ();
   }
-  return read_normalize_enum_tryconstruct (insn, max, st->data + *off, for_subtype, val);
+  return read_normalize_enum_tryconstruct (st, op, insn, max, st->data + *off, for_subtype, val);
 }
 
 ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
-static enum dds_stream_normalize_result normalize_enum (struct normalize_state const * const st, uint32_t * restrict const off, const uint32_t insn, const uint32_t max, const bool for_subtype)
+static enum dds_stream_normalize_result normalize_enum (struct normalize_state const * const st, uint32_t * restrict const off, const uint32_t *op, const uint32_t max, const bool for_subtype)
 {
   uint32_t val;
-  return read_normalize_enum (st, off, insn, max, for_subtype, &val);
+  return read_normalize_enum (st, off, op, max, for_subtype, &val);
 }
 
 ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
@@ -4067,7 +4168,7 @@ static enum dds_stream_normalize_result read_normalize_bitmask_tryconstruct (con
       return normalize_discard ();
     case TC_TRIM: case TC_USE_DEFAULT: {
       const uint32_t sz = DDS_OP_TYPE_SZ (insn);
-      memset (post_data - sz, 0, sz);
+      normalize_store_uint_value (post_data - sz, sz, 0);
       *val = 0;
       return normalize_success ();
     }
@@ -4076,8 +4177,9 @@ static enum dds_stream_normalize_result read_normalize_bitmask_tryconstruct (con
 }
 
 ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
-static enum dds_stream_normalize_result read_normalize_bitmask (struct normalize_state const * const st, uint32_t * restrict const off, const uint32_t insn, const uint64_t bits, const bool for_subtype, uint64_t * restrict const val)
+static enum dds_stream_normalize_result read_normalize_bitmask (struct normalize_state const * const st, uint32_t * restrict const off, const uint32_t *op, const uint64_t bits, const bool for_subtype, uint64_t * restrict const val)
 {
+  const uint32_t insn = *op;
   switch (DDS_OP_TYPE_SZ (insn))
   {
     case 1: {
@@ -4116,10 +4218,10 @@ static enum dds_stream_normalize_result read_normalize_bitmask (struct normalize
 }
 
 ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
-static enum dds_stream_normalize_result normalize_bitmask (struct normalize_state const * const st, uint32_t * restrict const off, const uint32_t insn, const uint64_t bits, const bool for_subtype)
+static enum dds_stream_normalize_result normalize_bitmask (struct normalize_state const * const st, uint32_t * restrict const off, const uint32_t *op, const uint64_t bits, const bool for_subtype)
 {
   uint64_t val;
-  return read_normalize_bitmask (st, off, insn, bits, for_subtype, &val);
+  return read_normalize_bitmask (st, off, op, bits, for_subtype, &val);
 }
 
 ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
@@ -4289,8 +4391,13 @@ static enum dds_stream_normalize_result normalize_primarray (struct normalize_st
 }
 
 ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
-static enum dds_stream_normalize_result normalize_enumarray (struct normalize_state const * const st, uint32_t * restrict const off, const uint32_t enum_sz, const uint32_t num, const uint32_t max, const enum tryconstruct tc)
+static enum dds_stream_normalize_result normalize_enumarray (struct normalize_state const * const st, uint32_t * restrict const off, const uint32_t *op, const uint32_t enum_sz, const uint32_t num, const uint32_t max, const enum tryconstruct tc)
 {
+  const struct dds_cdrstream_desc_enum_value_set *set;
+  enum dds_stream_normalize_result res;
+  if ((res = normalize_enum_value_set (st, op, max, &set)) != DDS_STREAM_NORMALIZE_SUCCESS)
+    return res;
+  const uint32_t default_value = set ? set->default_value : 0;
   switch (enum_sz)
   {
     case 1: {
@@ -4298,11 +4405,11 @@ static enum dds_stream_normalize_result normalize_enumarray (struct normalize_st
         return normalize_error ();
       uint8_t * const xs = (uint8_t *) (st->data + *off);
       for (uint32_t i = 0; i < num; i++) {
-        if (xs[i] > max) {
+        if (!normalize_enum_value_valid (set, max, xs[i])) {
           if (tc == TC_REJECT || tc == TC_DISCARD)
             return normalize_from_tryconstruct (tc);
           else
-            xs[i] = 0;
+            xs[i] = (uint8_t) default_value;
         }
       }
       *off += num;
@@ -4314,11 +4421,11 @@ static enum dds_stream_normalize_result normalize_enumarray (struct normalize_st
       dds_stream_maybe_swap16 (st, off, num);
       uint16_t * const xs = (uint16_t *) (st->data + *off);
       for (uint32_t i = 0; i < num; i++) {
-        if (xs[i] > max) {
+        if (!normalize_enum_value_valid (set, max, xs[i])) {
           if (tc == TC_REJECT || tc == TC_DISCARD)
             return normalize_from_tryconstruct (tc);
           else
-            xs[i] = 0;
+            xs[i] = (uint16_t) default_value;
         }
       }
       *off += 2 * num;
@@ -4330,11 +4437,11 @@ static enum dds_stream_normalize_result normalize_enumarray (struct normalize_st
       dds_stream_maybe_swap32 (st, off, num);
       uint32_t * const xs = (uint32_t *) (st->data + *off);
       for (uint32_t i = 0; i < num; i++) {
-        if (xs[i] > max) {
+        if (!normalize_enum_value_valid (set, max, xs[i])) {
           if (tc == TC_REJECT || tc == TC_DISCARD)
             return normalize_from_tryconstruct (tc);
           else
-            xs[i] = 0;
+            xs[i] = default_value;
         }
       }
       *off += 4 * num;
@@ -4497,10 +4604,11 @@ static enum dds_stream_normalize_result normalize_seq_arr_body (struct normalize
       break;
     case DDS_SOP_VAL_ENU: {
       const enum tryconstruct tc = tryconstruct_mode (**ops, true);
+      const uint32_t *enum_op = *ops;
       const uint32_t sz = DDS_OP_TYPE_SZ (**ops);
       const uint32_t max = (*ops)[2 + x0];
       *ops += 3 + x0;
-      if ((res = normalize_enumarray (st1, off, sz, num, max, tc)) != DDS_STREAM_NORMALIZE_SUCCESS)
+      if ((res = normalize_enumarray (st1, off, enum_op, sz, num, max, tc)) != DDS_STREAM_NORMALIZE_SUCCESS)
         return res;
       break;
     }
@@ -4677,7 +4785,7 @@ static enum dds_stream_normalize_result read_normalize_uni_disc (struct normaliz
     }
     case DDS_SOP_VAL_ENU: {
       uint32_t val32;
-      if ((res = read_normalize_enum (st, off, *ops, ops[4], true, &val32)) != DDS_STREAM_NORMALIZE_SUCCESS)
+      if ((res = read_normalize_enum (st, off, ops, ops[4], true, &val32)) != DDS_STREAM_NORMALIZE_SUCCESS)
         return res;
       *val = val32;
       return normalize_success ();
@@ -4685,7 +4793,7 @@ static enum dds_stream_normalize_result read_normalize_uni_disc (struct normaliz
     case DDS_SOP_VAL_BMK: {
       const uint64_t bits = bitmask_bits_hl (ops[4], ops[5]);
       uint64_t val64;
-      if ((res = read_normalize_bitmask (st, off, *ops, bits, true, &val64)) != DDS_STREAM_NORMALIZE_SUCCESS)
+      if ((res = read_normalize_bitmask (st, off, ops, bits, true, &val64)) != DDS_STREAM_NORMALIZE_SUCCESS)
         return res;
       *val = val64;
       return normalize_success ();
@@ -4751,7 +4859,7 @@ static enum dds_stream_normalize_result normalize_uni (struct normalize_state co
       return normalize_wstring (st, off, SIZE_MAX, TC_REJECT);
     case DDS_SOP_VAL_ENU: {
       const uint32_t max = jeq_op[3];
-      return normalize_enum (st, off, jeq_op[0], max, false);
+      return normalize_enum (st, off, jeq_op, max, false);
     }
     case DDS_SOP_VAL_BST: case DDS_SOP_VAL_BWSTR:
     case DDS_SOP_VAL_SEQ: case DDS_SOP_VAL_BSQ: case DDS_SOP_VAL_ARR:
@@ -4978,16 +5086,16 @@ static enum dds_stream_normalize_result stream_normalize_adr_impl (struct normal
       return normalize_uni (st, off, ops);
     }
     case DDS_SOP_VAL_ENU: {
-      const uint32_t insn = **ops;
+      const uint32_t *op = *ops;
       const uint32_t max = (*ops)[2];
       *ops += 3;
-      return normalize_enum (st, off, insn, max, false);
+      return normalize_enum (st, off, op, max, false);
     }
     case DDS_SOP_VAL_BMK: {
-      const uint32_t insn = **ops;
+      const uint32_t *op = *ops;
       const uint64_t bits = bitmask_bits_hl ((*ops)[2], (*ops)[3]);
       *ops += 4;
-      return normalize_bitmask (st, off, insn, bits, false);
+      return normalize_bitmask (st, off, op, bits, false);
     }
     case DDS_SOP_VAL_EXT: {
       const uint32_t jmp = DDS_OP_ADR_JMP ((*ops)[2]);
@@ -5465,8 +5573,8 @@ static enum dds_stream_normalize_result stream_normalize_key_impl (struct normal
     case DDS_SOP_VAL_1BY: if (!normalize_uint8 (st, offs)) return normalize_error (); break;
     case DDS_SOP_VAL_2BY: if (!normalize_uint16 (st, offs)) return normalize_error (); break;
     case DDS_SOP_VAL_4BY: if (!normalize_uint32 (st, offs)) return normalize_error (); break;
-    case DDS_SOP_VAL_ENU: if (!normalize_enum (st, offs, insn, ops[2], false)) return normalize_error (); break;
-    case DDS_SOP_VAL_BMK: if (!normalize_bitmask (st, offs, insn, bitmask_bits_hl (ops[2], ops[3]), false)) return normalize_error (); break;
+    case DDS_SOP_VAL_ENU: if ((res = normalize_enum (st, offs, ops, ops[2], false)) != DDS_STREAM_NORMALIZE_SUCCESS) return res; break;
+    case DDS_SOP_VAL_BMK: if ((res = normalize_bitmask (st, offs, ops, bitmask_bits_hl (ops[2], ops[3]), false)) != DDS_STREAM_NORMALIZE_SUCCESS) return res; break;
     case DDS_SOP_VAL_8BY: if (!normalize_uint64 (st, offs)) return normalize_error (); break;
     case DDS_SOP_VAL_16BY: if (!normalize_uint128 (st, offs)) return normalize_error (); break;
     case DDS_SOP_VAL_STR: if ((res = normalize_string (st, offs, SIZE_MAX, TC_REJECT)) != DDS_STREAM_NORMALIZE_SUCCESS) return res; break;
@@ -6319,7 +6427,7 @@ void dds_stream_read_sample (dds_istream_t *is, void *data, const struct dds_cdr
   }
   else
   {
-    (void) dds_stream_read_impl (is, data, allocator, desc->ops.ops, false, CDR_KIND_DATA, SAMPLE_DATA_INITIALIZED);
+    (void) dds_stream_read_impl (is, data, allocator, &desc->member_ids, desc->ops.ops, false, CDR_KIND_DATA, SAMPLE_DATA_INITIALIZED);
   }
 }
 
@@ -6418,7 +6526,7 @@ void dds_stream_read_key (dds_istream_t *is, char *sample, const struct dds_cdrs
   {
     /* For types with key fields in aggregated types with appendable or mutable
        extensibility, use the regular read functions to read the key fields */
-    (void) dds_stream_read_impl (is, sample, allocator, desc->ops.ops, false, CDR_KIND_KEY, SAMPLE_DATA_INITIALIZED);
+    (void) dds_stream_read_impl (is, sample, allocator, &desc->member_ids, desc->ops.ops, false, CDR_KIND_KEY, SAMPLE_DATA_INITIALIZED);
   }
   else
   {
@@ -7755,21 +7863,120 @@ static bool mid_equal (const void *va, const void *vb)
   return a->adr_offs == b->adr_offs;
 }
 
-static const uint32_t *dds_stream_get_memberid_table (const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, struct ddsrt_hh **table)
+static uint32_t enum_value_set_hash (const void *va)
 {
-  if (*table == NULL)
-    *table = ddsrt_hh_new (1, mid_hash, mid_equal);
+  const struct dds_cdrstream_desc_enum_value_set *s = va;
+  return ddsrt_mh3 (&s->setid, sizeof (s->setid), 0);
+}
+
+static bool enum_value_set_equal (const void *va, const void *vb)
+{
+  const struct dds_cdrstream_desc_enum_value_set *a = va;
+  const struct dds_cdrstream_desc_enum_value_set *b = vb;
+  return a->setid == b->setid;
+}
+
+static struct dds_cdrstream_desc_mid *dds_stream_get_op_meta (const struct dds_cdrstream_allocator *allocator, struct dds_cdrstream_desc_mid_table *table, uint32_t op_offs)
+{
+  if (table->table == NULL)
+    table->table = ddsrt_hh_new (1, mid_hash, mid_equal);
+  struct dds_cdrstream_desc_mid tmpl = { .adr_offs = op_offs };
+  struct dds_cdrstream_desc_mid *m = ddsrt_hh_lookup (table->table, &tmpl);
+  if (m == NULL)
+  {
+    m = allocator->malloc (sizeof (*m));
+    memset (m, 0, sizeof (*m));
+    m->adr_offs = op_offs;
+    m->mid = UINT32_MAX;
+    if (!ddsrt_hh_add (table->table, m))
+    {
+      allocator->free (m);
+      m = ddsrt_hh_lookup (table->table, &tmpl);
+      assert (m != NULL);
+    }
+  }
+  return m;
+}
+
+static const uint32_t *dds_stream_get_memberid_table (const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, struct dds_cdrstream_desc_mid_table *table)
+{
   uint32_t insn;
   while ((insn = *ops) != DDS_OP_RTS)
   {
     switch (DDS_OP (insn))
     {
-      case DDS_SOP_MID: {
-        struct dds_cdrstream_desc_mid *m = allocator->malloc (sizeof (*m));
-        m->adr_offs = (uint32_t) (insn & DDS_MID_OFFSET_MASK);
+      case DDS_OP_MID: {
+        struct dds_cdrstream_desc_mid *m = dds_stream_get_op_meta (allocator, table, (uint32_t) (insn & DDS_MID_OFFSET_MASK));
         m->mid = ops[1];
-        if (!ddsrt_hh_add (*table, m))
-          allocator->free (m);
+        ops += 2;
+        break;
+      }
+      default:
+        abort ();
+    }
+  }
+  return ++ops;
+}
+
+static const uint32_t *dds_stream_get_enum_value_sets (const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, struct dds_cdrstream_desc_mid_table *table)
+{
+  if (table->enum_value_sets == NULL)
+    table->enum_value_sets = ddsrt_hh_new (1, enum_value_set_hash, enum_value_set_equal);
+  uint32_t insn;
+  while ((insn = *ops) != DDS_OP_RTS)
+  {
+    switch (insn & DDS_OP_MASK)
+    {
+      case DDS_OP_EVS: {
+        const uint32_t setid = (uint32_t) (insn & DDS_MID_OFFSET_MASK);
+        const uint32_t default_value = ops[1];
+        const uint32_t nvalues = ops[2];
+        if (default_value != 0)
+          table->has_special_defaults = true;
+        struct dds_cdrstream_desc_enum_value_set *s = allocator->malloc (sizeof (*s));
+        s->setid = setid;
+        s->default_value = default_value;
+        s->nvalues = nvalues;
+        s->max = 0;
+        s->values = nvalues ? allocator->malloc (nvalues * sizeof (*s->values)) : NULL;
+        for (uint32_t n = 0; n < nvalues; n++)
+        {
+          s->values[n] = ops[3 + n];
+          assert (n == 0 || s->values[n - 1] < s->values[n]);
+        }
+        s->max = nvalues ? s->values[nvalues - 1] : 0;
+        if (!ddsrt_hh_add (table->enum_value_sets, s))
+        {
+          if (s->values != NULL)
+            allocator->free (s->values);
+          allocator->free (s);
+        }
+        ops += 3 + nvalues;
+        break;
+      }
+      default:
+        abort ();
+    }
+  }
+  return ++ops;
+}
+
+static const uint32_t *dds_stream_get_enum_value_maps (const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, struct dds_cdrstream_desc_mid_table *table)
+{
+  if (table->enum_value_sets == NULL)
+    abort ();
+  uint32_t insn;
+  while ((insn = *ops) != DDS_OP_RTS)
+  {
+    switch (insn & DDS_OP_MASK)
+    {
+      case DDS_OP_EVM: {
+        const uint32_t setid = ops[1];
+        struct dds_cdrstream_desc_enum_value_set tmpl = { .setid = setid };
+        const struct dds_cdrstream_desc_enum_value_set *s = ddsrt_hh_lookup (table->enum_value_sets, &tmpl);
+        assert (s != NULL);
+        struct dds_cdrstream_desc_mid *m = dds_stream_get_op_meta (allocator, table, (uint32_t) (insn & DDS_MID_OFFSET_MASK));
+        m->enum_value_set = s;
         ops += 2;
         break;
       }
@@ -7785,6 +7992,8 @@ void dds_cdrstream_desc_init_with_nops (struct dds_cdrstream_desc *desc, const s
 {
   desc->size = size;
   desc->align = align;
+  desc->opt_size_xcdr1 = 0;
+  desc->opt_size_xcdr2 = 0;
 
   /* Copy keys from topic descriptor, which are ordered by member-id (scoped to their containing
      type. Additionally a copy of the key list in definition order is stored. */
@@ -7808,18 +8017,29 @@ void dds_cdrstream_desc_init_with_nops (struct dds_cdrstream_desc *desc, const s
      provided nops value has the actual number of instructions, and we'll read the additional
      ops up to this actual number of opcodes. */
   desc->member_ids.table = NULL;
+  desc->member_ids.enum_value_sets = NULL;
+  desc->member_ids.op0 = NULL;
+  desc->member_ids.has_special_defaults = false;
   if (counted_ops < nops)
   {
     const uint32_t *aop = desc->ops.ops + counted_ops;
+    desc->member_ids.op0 = desc->ops.ops;
     while (aop < desc->ops.ops + desc->ops.nops)
     {
-      switch (DDS_OP (*aop))
+      switch (*aop & DDS_OP_MASK)
       {
-        case DDS_SOP_MID:
+        case DDS_OP_MID:
           /* Read the member ID table from the ops and store it in a hash table
             (member IDs for non-mutable types, used in XCDR1 member header) */
-          desc->member_ids.op0 = desc->ops.ops;
-          aop = dds_stream_get_memberid_table (allocator, aop, &desc->member_ids.table);
+          aop = dds_stream_get_memberid_table (allocator, aop, &desc->member_ids);
+          break;
+
+        case DDS_OP_EVS:
+          aop = dds_stream_get_enum_value_sets (allocator, aop, &desc->member_ids);
+          break;
+
+        case DDS_OP_EVM:
+          aop = dds_stream_get_enum_value_maps (allocator, aop, &desc->member_ids);
           break;
 
         default:
@@ -7847,6 +8067,15 @@ static void free_member_id (void *vinfo, void *varg)
   allocator->free (vinfo);
 }
 
+static void free_enum_value_set (void *vinfo, void *varg)
+{
+  const struct dds_cdrstream_allocator *allocator = (const struct dds_cdrstream_allocator *) varg;
+  struct dds_cdrstream_desc_enum_value_set *s = vinfo;
+  if (s->values != NULL)
+    allocator->free (s->values);
+  allocator->free (s);
+}
+
 void dds_cdrstream_desc_fini (struct dds_cdrstream_desc *desc, const struct dds_cdrstream_allocator *allocator)
 {
   if (desc->keys.nkeys > 0)
@@ -7860,6 +8089,11 @@ void dds_cdrstream_desc_fini (struct dds_cdrstream_desc *desc, const struct dds_
   {
     ddsrt_hh_enum (desc->member_ids.table, free_member_id, (void *) allocator);
     ddsrt_hh_free (desc->member_ids.table);
+  }
+  if (desc->member_ids.enum_value_sets != NULL)
+  {
+    ddsrt_hh_enum (desc->member_ids.enum_value_sets, free_enum_value_set, (void *) allocator);
+    ddsrt_hh_free (desc->member_ids.enum_value_sets);
   }
   allocator->free (desc->ops.ops);
 }

--- a/src/core/cdr/src/dds_cdrstream.c
+++ b/src/core/cdr/src/dds_cdrstream.c
@@ -177,6 +177,7 @@ struct dds_cdrstream_ops_info {
   enum dds_cdr_enc_version min_xcdrv;
   uint32_t nesting_max;
   dds_data_type_properties_t data_types;
+  uint32_t allowed_data_representations;
 };
 
 enum tryconstruct {
@@ -232,6 +233,9 @@ static const uint32_t *dds_stream_read_impl (dds_istream_t *is, char * restrict 
 
 static uint32_t dds_stream_enum_default_value (const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *op, uint32_t max)
   ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+
+static enum tryconstruct tryconstruct_mode (uint32_t insn, bool for_subtype)
+  ddsrt_attribute_warn_unused_result;
 
 static const uint32_t *stream_free_sample_adr (uint32_t insn, void * restrict data, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops)
   ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
@@ -960,8 +964,12 @@ size_t dds_stream_check_optimize (const struct dds_cdrstream_desc *desc, enum dd
   return opt_size;
 }
 
+#define XCDR1_REP DDS_DATA_REPRESENTATION_FLAG_XCDR1
+#define XCDR2_REP DDS_DATA_REPRESENTATION_FLAG_XCDR2
+#define XCDR12_REP (XCDR1_REP | XCDR2_REP)
+
 ddsrt_nonnull_all
-static void dds_stream_get_ops_info1 (const uint32_t *ops, uint32_t nestc, struct dds_cdrstream_ops_info *info, bool in_xcdr1_delimited_scope, bool in_recursive);
+static void dds_stream_get_ops_info1 (const uint32_t *ops, uint32_t nestc, struct dds_cdrstream_ops_info *info, bool in_xcdr1_delimited_scope, uint32_t value_bound_xcdrv, uint32_t tail_bound_xcdrv, bool in_recursive);
 
 ddsrt_nonnull_all
 static const uint32_t *dds_stream_get_ops_info_seq (const uint32_t *ops, uint32_t insn, uint32_t nestc, struct dds_cdrstream_ops_info *info, bool in_recursive)
@@ -993,7 +1001,7 @@ static const uint32_t *dds_stream_get_ops_info_seq (const uint32_t *ops, uint32_
         info->ops_end = ops + 4 + bound_op;
       bool recursive = DDS_OP_ADR_JSR (ops[3 + bound_op]) <= 0;
       if (!in_recursive)
-        dds_stream_get_ops_info1 (jsr_ops, nestc + (subtype == DDS_SOP_VAL_UNI || subtype == DDS_SOP_VAL_STU ? 1 : 0), info, false, recursive);
+        dds_stream_get_ops_info1 (jsr_ops, nestc + (subtype == DDS_SOP_VAL_UNI || subtype == DDS_SOP_VAL_STU ? 1 : 0), info, false, 0, 0, recursive);
       ops += (jmp ? jmp : (4 + bound_op)); /* FIXME: why would jmp be 0? */
       break;
     }
@@ -1035,7 +1043,7 @@ static const uint32_t *dds_stream_get_ops_info_arr (const uint32_t *ops, uint32_
         info->ops_end = ops + 5;
       bool recursive = DDS_OP_ADR_JSR (ops[3]) <= 0;
       if (!in_recursive)
-        dds_stream_get_ops_info1 (jsr_ops, nestc + (subtype == DDS_SOP_VAL_UNI || subtype == DDS_SOP_VAL_STU ? 1 : 0), info, false, recursive);
+        dds_stream_get_ops_info1 (jsr_ops, nestc + (subtype == DDS_SOP_VAL_UNI || subtype == DDS_SOP_VAL_STU ? 1 : 0), info, false, 0, 0, recursive);
       ops += (jmp ? jmp : 5);
       break;
     }
@@ -1049,8 +1057,21 @@ static const uint32_t *dds_stream_get_ops_info_arr (const uint32_t *ops, uint32_
 }
 
 ddsrt_nonnull_all
-static const uint32_t *dds_stream_get_ops_info_uni (const uint32_t *ops, uint32_t nestc, struct dds_cdrstream_ops_info *info, bool in_recursive)
+static const uint32_t *dds_stream_get_ops_info_uni (const uint32_t *ops, uint32_t nestc, struct dds_cdrstream_ops_info *info, uint32_t value_bound_xcdrv, uint32_t tail_bound_xcdrv, bool at_tail, bool in_recursive)
 {
+  const uint32_t union_bound_xcdrv = value_bound_xcdrv | (at_tail ? tail_bound_xcdrv : 0u);
+  const enum dds_stream_typecode disc_type = DDS_OP_SUBTYPE (*ops);
+  const enum tryconstruct disc_tc = tryconstruct_mode (*ops, true);
+  if ((disc_type == DDS_SOP_VAL_ENU || disc_type == DDS_SOP_VAL_BMK) && (disc_tc == TC_USE_DEFAULT || disc_tc == TC_TRIM))
+  {
+    info->allowed_data_representations &= union_bound_xcdrv;
+    if (!(info->allowed_data_representations & XCDR1_REP))
+    {
+      info->data_types |= DDS_DATA_TYPE_DEFAULTS_TO_XCDR2;
+      info->min_xcdrv = DDSI_RTPS_CDR_ENC_VERSION_2;
+    }
+  }
+
   const uint32_t numcases = ops[2];
   const uint32_t *jeq_op = ops + DDS_OP_ADR_JSR (ops[3]);
   for (uint32_t i = 0; i < numcases; i++)
@@ -1073,7 +1094,7 @@ static const uint32_t *dds_stream_get_ops_info_uni (const uint32_t *ops, uint32_
       case DDS_SOP_VAL_ARR: case DDS_SOP_VAL_UNI: case DDS_SOP_VAL_BMK: {
         bool recursive = DDS_OP_ADR_JSR (jeq_op[0]) <= 0;
         if (!in_recursive)
-          dds_stream_get_ops_info1 (jeq_op + DDS_OP_ADR_JSR (jeq_op[0]), nestc + (valtype == DDS_SOP_VAL_UNI || valtype == DDS_SOP_VAL_STU ? 1 : 0), info, false, recursive);
+          dds_stream_get_ops_info1 (jeq_op + DDS_OP_ADR_JSR (jeq_op[0]), nestc + (valtype == DDS_SOP_VAL_UNI || valtype == DDS_SOP_VAL_STU ? 1 : 0), info, false, 0, union_bound_xcdrv, recursive);
         break;
       }
       case DDS_SOP_VAL_EXT:
@@ -1106,7 +1127,7 @@ static const uint32_t *dds_stream_get_ops_info_pl (const uint32_t *ops, uint32_t
         if (flags & DDS_OP_FLAG_BASE)
           (void) dds_stream_get_ops_info_pl (plm_ops, nestc, info, in_xcdr1_delimited_scope, in_recursive);
         else if (!in_recursive)
-          dds_stream_get_ops_info1 (plm_ops, nestc, info, in_xcdr1_delimited_scope, in_recursive);
+          dds_stream_get_ops_info1 (plm_ops, nestc, info, in_xcdr1_delimited_scope, 0, XCDR12_REP, in_recursive);
         ops += 2;
         break;
       }
@@ -1121,7 +1142,7 @@ static const uint32_t *dds_stream_get_ops_info_pl (const uint32_t *ops, uint32_t
 }
 
 ddsrt_nonnull_all
-static void dds_stream_get_ops_info1 (const uint32_t *ops, uint32_t nestc, struct dds_cdrstream_ops_info *info, bool in_xcdr1_delimited_scope, bool in_recursive)
+static void dds_stream_get_ops_info1 (const uint32_t *ops, uint32_t nestc, struct dds_cdrstream_ops_info *info, bool in_xcdr1_delimited_scope, uint32_t value_bound_xcdrv, uint32_t tail_bound_xcdrv, bool in_recursive)
 {
   uint32_t insn;
   if (info->nesting_max < nestc)
@@ -1137,6 +1158,7 @@ static void dds_stream_get_ops_info1 (const uint32_t *ops, uint32_t nestc, struc
           info->data_types |= DDS_DATA_TYPE_CONTAINS_KEY;
         if (op_type_external (insn) || op_type_optional (insn))
           info->data_types &= ~DDS_DATA_TYPE_IS_MEMCPY_SAFE;
+        const uint32_t adr_value_bound_xcdrv = value_bound_xcdrv | (op_type_optional (insn) ? XCDR1_REP : 0u);
         if (op_type_optional (insn))
         {
           info->data_types |= DDS_DATA_TYPE_DEFAULTS_TO_XCDR2;
@@ -1164,18 +1186,24 @@ static void dds_stream_get_ops_info1 (const uint32_t *ops, uint32_t nestc, struc
           case DDS_SOP_VAL_ARR:
             ops = dds_stream_get_ops_info_arr (ops, insn, nestc, info, in_recursive);
             break;
-          case DDS_SOP_VAL_UNI:
-            ops = dds_stream_get_ops_info_uni (ops, nestc, info, in_recursive);
+          case DDS_SOP_VAL_UNI: {
+            const uint32_t jmp = DDS_OP_ADR_JMP (ops[3]);
+            const bool at_tail = *(ops + (jmp ? jmp : 4)) == DDS_OP_RTS;
+            ops = dds_stream_get_ops_info_uni (ops, nestc, info, adr_value_bound_xcdrv, tail_bound_xcdrv, at_tail, in_recursive);
             break;
+          }
           case DDS_SOP_VAL_EXT: {
             if (!op_type_optional (insn))
               in_xcdr1_delimited_scope = false;
             const uint32_t *jsr_ops = ops + DDS_OP_ADR_JSR (ops[2]);
             const uint32_t jmp = DDS_OP_ADR_JMP (ops[2]);
+            const uint32_t *next_ops = ops + (jmp ? jmp : 3);
+            const bool at_tail = *next_ops == DDS_OP_RTS;
+            const uint32_t ext_tail_bound_xcdrv = adr_value_bound_xcdrv | (at_tail ? tail_bound_xcdrv : 0u);
             bool recursive = DDS_OP_ADR_JSR (ops[2]) <= 0;
             if (!in_recursive)
-              dds_stream_get_ops_info1 (jsr_ops, nestc + 1, info, in_xcdr1_delimited_scope, recursive);
-            ops += jmp ? jmp : 3;
+              dds_stream_get_ops_info1 (jsr_ops, nestc + 1, info, in_xcdr1_delimited_scope, 0, ext_tail_bound_xcdrv, recursive);
+            ops = next_ops;
             break;
           }
           case DDS_SOP_VAL_STU:
@@ -1186,8 +1214,10 @@ static void dds_stream_get_ops_info1 (const uint32_t *ops, uint32_t nestc, struc
       }
       case DDS_SOP_JSR: {
         bool recursive = DDS_OP_JUMP (insn) <= 0;
+        const bool at_tail = ops[1] == DDS_OP_RTS;
+        const uint32_t jsr_tail_bound_xcdrv = at_tail ? (value_bound_xcdrv | tail_bound_xcdrv) : 0u;
         if (!in_recursive)
-          dds_stream_get_ops_info1 (ops + DDS_OP_JUMP (insn), nestc, info, in_xcdr1_delimited_scope, recursive);
+          dds_stream_get_ops_info1 (ops + DDS_OP_JUMP (insn), nestc, info, in_xcdr1_delimited_scope, 0, jsr_tail_bound_xcdrv, recursive);
         ops++;
         break;
       }
@@ -1199,6 +1229,8 @@ static void dds_stream_get_ops_info1 (const uint32_t *ops, uint32_t nestc, struc
         info->data_types |= DDS_DATA_TYPE_DEFAULTS_TO_XCDR2;
         if (!in_xcdr1_delimited_scope)
           info->min_xcdrv = DDSI_RTPS_CDR_ENC_VERSION_2;
+        tail_bound_xcdrv = XCDR2_REP | ((tail_bound_xcdrv | value_bound_xcdrv) & XCDR1_REP);
+        value_bound_xcdrv = 0u;
         ops++;
         break;
       }
@@ -1234,7 +1266,8 @@ static void dds_stream_get_ops_info (const uint32_t *ops, struct dds_cdrstream_o
   info->min_xcdrv = DDSI_RTPS_CDR_ENC_VERSION_1;
   info->nesting_max = 0;
   info->data_types = DDS_DATA_TYPE_IS_MEMCPY_SAFE;
-  dds_stream_get_ops_info1 (ops, 0, info, true, false);
+  info->allowed_data_representations = XCDR12_REP;
+  dds_stream_get_ops_info1 (ops, 0, info, true, 0, XCDR12_REP, false);
 }
 
 ddsrt_nonnull_all
@@ -3717,18 +3750,15 @@ static const uint32_t *dds_stream_read_xcdr2_pl (dds_istream_t *is, char * restr
         break;
     }
 
-#ifndef NDEBUG
     /* next field starts here (length embedded in member does not include it's own 4 bytes): */
     const uint32_t next_off = is->m_index + msz + ((lc >= LENGTH_CODE_ALSO_NEXTINT) ? 4 : 0);
-#endif
+    dds_istream_t is1 = *is;
+    is1.m_size = next_off;
+
     /* find member and deserialize */
-    if (!dds_stream_read_pl_member (is, data, allocator, mid_table, m_id, ops, cdr_kind, sample_state))
-    {
-      is->m_index += msz;
-      if (lc >= LENGTH_CODE_ALSO_NEXTINT)
-        is->m_index += 4; /* length embedded in member does not include it's own 4 bytes */
-    }
-    assert (next_off == is->m_index);
+    if (dds_stream_read_pl_member (&is1, data, allocator, mid_table, m_id, ops, cdr_kind, sample_state))
+      assert (next_off == is1.m_index);
+    is->m_index = next_off;
   }
 
   /* skip all PLM-memberid pairs */
@@ -4745,7 +4775,6 @@ static enum dds_stream_normalize_result normalize_arr (struct normalize_state co
 ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
 static enum dds_stream_normalize_result read_normalize_uni_disc (struct normalize_state const * const st, uint32_t * restrict const off, uint32_t const * const ops, uint64_t * restrict val)
 {
-  enum dds_stream_normalize_result res;
   switch (DDS_OP_SUBTYPE (*ops))
   {
     case DDS_SOP_VAL_BLN: {
@@ -4757,46 +4786,60 @@ static enum dds_stream_normalize_result read_normalize_uni_disc (struct normaliz
     }
     case DDS_SOP_VAL_1BY: {
       uint8_t val8;
-      if ((res = read_and_normalize_uint8 (st, off, &val8)) != DDS_STREAM_NORMALIZE_SUCCESS)
-        return res;
+      if (!read_and_normalize_uint8 (st, off, &val8))
+        return normalize_error ();
       *val = val8;
       return normalize_success ();
     }
     case DDS_SOP_VAL_2BY: {
       uint16_t val16;
-      if ((res = read_and_normalize_uint16 (st, off, &val16)) != DDS_STREAM_NORMALIZE_SUCCESS)
-        return res;
+      if (!read_and_normalize_uint16 (st, off, &val16))
+        return normalize_error ();
       *val = val16;
       return normalize_success ();
     }
     case DDS_SOP_VAL_4BY: {
       uint32_t val32;
-      if ((res = read_and_normalize_uint32 (st, off, &val32)) != DDS_STREAM_NORMALIZE_SUCCESS)
-        return res;
+      if (!read_and_normalize_uint32 (st, off, &val32))
+        return normalize_error ();
       *val = val32;
       return normalize_success ();
     }
     case DDS_SOP_VAL_8BY: {
       uint64_t val64;
-      if ((res = read_and_normalize_uint64 (st, off, &val64)) != DDS_STREAM_NORMALIZE_SUCCESS)
-        return res;
+      if (!read_and_normalize_uint64 (st, off, &val64))
+        return normalize_error ();
       *val = val64;
       return normalize_success ();
     }
     case DDS_SOP_VAL_ENU: {
       uint32_t val32;
-      if ((res = read_normalize_enum (st, off, ops, ops[4], true, &val32)) != DDS_STREAM_NORMALIZE_SUCCESS)
-        return res;
-      *val = val32;
-      return normalize_success ();
+      switch (read_normalize_enum (st, off, ops, ops[4], true, &val32))
+      {
+        case DDS_STREAM_NORMALIZE_SUCCESS:
+          *val = val32;
+          return normalize_success ();
+        case DDS_STREAM_NORMALIZE_DISCARD:
+          return normalize_discard ();
+        case DDS_STREAM_NORMALIZE_ERROR:
+          return normalize_error ();
+      }
+      return normalize_error ();
     }
     case DDS_SOP_VAL_BMK: {
-      const uint64_t bits = bitmask_bits_hl (ops[4], ops[5]);
       uint64_t val64;
-      if ((res = read_normalize_bitmask (st, off, ops, bits, true, &val64)) != DDS_STREAM_NORMALIZE_SUCCESS)
-        return res;
-      *val = val64;
-      return normalize_success ();
+      const uint64_t bits = bitmask_bits_hl (ops[4], ops[5]);
+      switch (read_normalize_bitmask (st, off, ops, bits, true, &val64))
+      {
+        case DDS_STREAM_NORMALIZE_SUCCESS:
+          *val = val64;
+          return normalize_success ();
+        case DDS_STREAM_NORMALIZE_DISCARD:
+          return normalize_discard ();
+        case DDS_STREAM_NORMALIZE_ERROR:
+          return normalize_error ();
+      }
+      return normalize_error ();
     }
     default:
       abort ();
@@ -4808,11 +4851,9 @@ ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
 static enum dds_stream_normalize_result normalize_uni (struct normalize_state const * const st, uint32_t * restrict const off, uint32_t const * * const ops)
 {
   uint64_t disc = 0;
-  {
-    enum dds_stream_normalize_result res;
-    if ((res = read_normalize_uni_disc (st, off, *ops, &disc)) != DDS_STREAM_NORMALIZE_SUCCESS)
-      return res;
-  }
+  const enum dds_stream_normalize_result discres = read_normalize_uni_disc (st, off, *ops, &disc);
+  if (discres != DDS_STREAM_NORMALIZE_SUCCESS)
+    return discres;
   uint32_t const * const jeq_op = find_union_case (*ops, disc);
   *ops += DDS_OP_ADR_JMP ((*ops)[3]);
   if (!jeq_op) {
@@ -7295,7 +7336,18 @@ enum dds_cdr_enc_version dds_stream_minimum_xcdr_version (const uint32_t *ops)
 {
   struct dds_cdrstream_ops_info info;
   dds_stream_get_ops_info (ops, &info);
+  if (!(info.allowed_data_representations & DDS_DATA_REPRESENTATION_FLAG_XCDR1))
+    return DDSI_RTPS_CDR_ENC_VERSION_2;
   return info.min_xcdrv;
+}
+
+uint32_t dds_stream_allowed_data_representations (const uint32_t *ops)
+{
+  struct dds_cdrstream_ops_info info;
+  dds_stream_get_ops_info (ops, &info);
+  if (info.min_xcdrv == DDSI_RTPS_CDR_ENC_VERSION_2)
+    info.allowed_data_representations &= ~DDS_DATA_REPRESENTATION_FLAG_XCDR1;
+  return info.allowed_data_representations;
 }
 
 /* Gets the extensibility of the top-level type for a topic, by inspecting the serializer ops */

--- a/src/core/cdr/src/dds_cdrstream.c
+++ b/src/core/cdr/src/dds_cdrstream.c
@@ -145,7 +145,7 @@ typedef struct restrict_ostreamLE {
 struct key_props {
   uint32_t sz_xcdrv1;
   uint32_t sz_xcdrv2;
-  enum dds_cdr_enc_version min_xcdrv;
+  uint32_t supported_data_representations;
   bool is_appendable;
   bool is_mutable;
   bool is_sequence;
@@ -174,10 +174,9 @@ enum sample_data_state {
 struct dds_cdrstream_ops_info {
   const uint32_t *toplevel_op;
   const uint32_t *ops_end;
-  enum dds_cdr_enc_version min_xcdrv;
   uint32_t nesting_max;
   dds_data_type_properties_t data_types;
-  uint32_t allowed_data_representations;
+  uint32_t supported_data_representations;
 };
 
 enum tryconstruct {
@@ -1064,12 +1063,9 @@ static const uint32_t *dds_stream_get_ops_info_uni (const uint32_t *ops, uint32_
   const enum tryconstruct disc_tc = tryconstruct_mode (*ops, true);
   if ((disc_type == DDS_SOP_VAL_ENU || disc_type == DDS_SOP_VAL_BMK) && (disc_tc == TC_USE_DEFAULT || disc_tc == TC_TRIM))
   {
-    info->allowed_data_representations &= union_bound_xcdrv;
-    if (!(info->allowed_data_representations & XCDR1_REP))
-    {
+    info->supported_data_representations &= union_bound_xcdrv;
+    if (!(info->supported_data_representations & XCDR1_REP))
       info->data_types |= DDS_DATA_TYPE_DEFAULTS_TO_XCDR2;
-      info->min_xcdrv = DDSI_RTPS_CDR_ENC_VERSION_2;
-    }
   }
 
   const uint32_t numcases = ops[2];
@@ -1228,7 +1224,7 @@ static void dds_stream_get_ops_info1 (const uint32_t *ops, uint32_t nestc, struc
       case DDS_SOP_DLC: {
         info->data_types |= DDS_DATA_TYPE_DEFAULTS_TO_XCDR2;
         if (!in_xcdr1_delimited_scope)
-          info->min_xcdrv = DDSI_RTPS_CDR_ENC_VERSION_2;
+          info->supported_data_representations &= ~XCDR1_REP;
         tail_bound_xcdrv = XCDR2_REP | ((tail_bound_xcdrv | value_bound_xcdrv) & XCDR1_REP);
         value_bound_xcdrv = 0u;
         ops++;
@@ -1263,10 +1259,9 @@ static void dds_stream_get_ops_info (const uint32_t *ops, struct dds_cdrstream_o
 {
   info->toplevel_op = NULL;
   info->ops_end = ops;
-  info->min_xcdrv = DDSI_RTPS_CDR_ENC_VERSION_1;
   info->nesting_max = 0;
   info->data_types = DDS_DATA_TYPE_IS_MEMCPY_SAFE;
-  info->allowed_data_representations = XCDR12_REP;
+  info->supported_data_representations = XCDR12_REP;
   dds_stream_get_ops_info1 (ops, 0, info, true, 0, XCDR12_REP, false);
 }
 
@@ -7330,24 +7325,11 @@ uint32_t dds_stream_countops (const uint32_t *ops, uint32_t nkeys, const dds_key
   return (uint32_t) (info.ops_end - ops);
 }
 
-/* Gets the (minimum) extensibility of the types used for this topic, and returns the XCDR
-   version that is required for (de)serializing the type for this topic descriptor */
-enum dds_cdr_enc_version dds_stream_minimum_xcdr_version (const uint32_t *ops)
+uint32_t dds_stream_supported_data_representations (const uint32_t *ops)
 {
   struct dds_cdrstream_ops_info info;
   dds_stream_get_ops_info (ops, &info);
-  if (!(info.allowed_data_representations & DDS_DATA_REPRESENTATION_FLAG_XCDR1))
-    return DDSI_RTPS_CDR_ENC_VERSION_2;
-  return info.min_xcdrv;
-}
-
-uint32_t dds_stream_allowed_data_representations (const uint32_t *ops)
-{
-  struct dds_cdrstream_ops_info info;
-  dds_stream_get_ops_info (ops, &info);
-  if (info.min_xcdrv == DDSI_RTPS_CDR_ENC_VERSION_2)
-    info.allowed_data_representations &= ~DDS_DATA_REPRESENTATION_FLAG_XCDR1;
-  return info.allowed_data_representations;
+  return info.supported_data_representations;
 }
 
 /* Gets the extensibility of the top-level type for a topic, by inspecting the serializer ops */
@@ -7422,16 +7404,21 @@ static void add_to_key_size_xcdrv2 (struct key_props *k, uint32_t field_size, ui
   k->sz_xcdrv2 = add_to_key_size_impl (k->sz_xcdrv2, field_size, field_dims, field_align, XCDR2_MAX_ALIGN);
 }
 
+static bool key_props_supports_xcdr1 (const struct key_props *k)
+{
+  return (k->supported_data_representations & XCDR1_REP) != 0;
+}
+
 static void add_to_key_size (struct key_props *k, uint32_t field_size, uint32_t field_dims, uint32_t field_align)
 {
-  if (k->min_xcdrv == DDSI_RTPS_CDR_ENC_VERSION_1)
+  if (key_props_supports_xcdr1 (k))
     add_to_key_size_xcdrv1 (k, field_size, field_dims, field_align);
   add_to_key_size_xcdrv2 (k, field_size, field_dims, field_align);
 }
 
 static void set_key_size_unbounded (struct key_props *k)
 {
-  if (k->min_xcdrv == DDSI_RTPS_CDR_ENC_VERSION_1)
+  if (key_props_supports_xcdr1 (k))
     k->sz_xcdrv1 = DDS_FIXED_KEY_MAX_SIZE + 1;
   k->sz_xcdrv2 = DDS_FIXED_KEY_MAX_SIZE + 1;
 }
@@ -7439,7 +7426,7 @@ static void set_key_size_unbounded (struct key_props *k)
 #ifndef NDEBUG
 static bool key_size_is_unbounded (const struct key_props *k)
 {
-  return (k->min_xcdrv == DDSI_RTPS_CDR_ENC_VERSION_1) ?
+  return key_props_supports_xcdr1 (k) ?
       (k->sz_xcdrv1 == DDS_FIXED_KEY_MAX_SIZE + 1) : (k->sz_xcdrv2 == DDS_FIXED_KEY_MAX_SIZE + 1);
 }
 #endif
@@ -7840,10 +7827,10 @@ uint32_t dds_stream_key_flags (struct dds_cdrstream_desc *desc, uint32_t *keysz_
   {
     {
       struct key_props key_properties = { 0 };
-      key_properties.min_xcdrv = dds_stream_minimum_xcdr_version (desc->ops.ops);
+      key_properties.supported_data_representations = dds_stream_supported_data_representations (desc->ops.ops);
       (void) dds_stream_key_size (desc->ops.ops, &key_properties);
 
-      if (key_properties.min_xcdrv == DDSI_RTPS_CDR_ENC_VERSION_1 && key_properties.sz_xcdrv1 <= DDS_FIXED_KEY_MAX_SIZE)
+      if (key_props_supports_xcdr1 (&key_properties) && key_properties.sz_xcdrv1 <= DDS_FIXED_KEY_MAX_SIZE)
         key_flags |= DDS_TOPIC_FIXED_KEY;
       if (key_properties.sz_xcdrv2 <= DDS_FIXED_KEY_MAX_SIZE)
         key_flags |= DDS_TOPIC_FIXED_KEY_XCDR2;
@@ -7858,7 +7845,7 @@ uint32_t dds_stream_key_flags (struct dds_cdrstream_desc *desc, uint32_t *keysz_
         key_flags |= DDS_TOPIC_KEY_ARRAY_NONPRIM;
 
       if (keysz_xcdrv1 != NULL)
-        *keysz_xcdrv1 = key_properties.min_xcdrv == DDSI_RTPS_CDR_ENC_VERSION_1 ? key_properties.sz_xcdrv1 : 0;
+        *keysz_xcdrv1 = key_props_supports_xcdr1 (&key_properties) ? key_properties.sz_xcdrv1 : 0;
       if (keysz_xcdrv2 != NULL)
         *keysz_xcdrv2 = key_properties.sz_xcdrv2;
     }

--- a/src/core/cdr/src/dds_cdrstream.c
+++ b/src/core/cdr/src/dds_cdrstream.c
@@ -232,6 +232,12 @@ static const uint32_t *dds_stream_read_impl (dds_istream_t *is, char * restrict 
 static uint32_t dds_stream_enum_default_value (const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *op, uint32_t max)
   ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
 
+static bool dds_stream_enum_value_set (const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *op, uint32_t max, const struct dds_cdrstream_desc_enum_value_set **set)
+  ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+
+static bool dds_stream_enum_value_valid (const struct dds_cdrstream_desc_enum_value_set *set, uint32_t max, uint32_t val)
+  ddsrt_attribute_warn_unused_result;
+
 static enum tryconstruct tryconstruct_mode (uint32_t insn, bool for_subtype)
   ddsrt_attribute_warn_unused_result;
 
@@ -956,6 +962,8 @@ static uint32_t dds_stream_check_optimize1 (const struct dds_cdrstream_desc *des
 ddsrt_nonnull_all
 size_t dds_stream_check_optimize (const struct dds_cdrstream_desc *desc, enum dds_cdr_enc_version xcdr_version)
 {
+  if (desc->member_ids.enum_value_sets != NULL)
+    return 0;
   size_t opt_size = dds_stream_check_optimize1 (desc, xcdr_version, desc->ops.ops, 0, 0);
   // off < desc can occur if desc->size includes "trailing" padding
   assert (opt_size <= desc->size);
@@ -4077,7 +4085,7 @@ static uint32_t dds_stream_enum_default_value (const struct dds_cdrstream_desc_m
   return set ? set->default_value : 0;
 }
 
-static bool normalize_enum_value_valid (const struct dds_cdrstream_desc_enum_value_set *set, const uint32_t max, const uint32_t val)
+static bool dds_stream_enum_value_valid (const struct dds_cdrstream_desc_enum_value_set *set, const uint32_t max, const uint32_t val)
 {
   if (set == NULL)
     return val <= max;
@@ -4114,7 +4122,7 @@ static enum dds_stream_normalize_result read_normalize_enum_tryconstruct (struct
   enum dds_stream_normalize_result res;
   if ((res = normalize_enum_value_set (st, op, max, &set)) != DDS_STREAM_NORMALIZE_SUCCESS)
     return res;
-  if (normalize_enum_value_valid (set, max, *val))
+  if (dds_stream_enum_value_valid (set, max, *val))
     return normalize_success ();
   // note: can't use normalize_from_tryconstruct becasue we're also reading the value
   switch (tryconstruct_mode (insn, for_subtype))
@@ -4426,7 +4434,7 @@ static enum dds_stream_normalize_result normalize_enumarray (struct normalize_st
         return normalize_error ();
       uint8_t * const xs = (uint8_t *) (st->data + *off);
       for (uint32_t i = 0; i < num; i++) {
-        if (!normalize_enum_value_valid (set, max, xs[i])) {
+        if (!dds_stream_enum_value_valid (set, max, xs[i])) {
           if (tc == TC_REJECT || tc == TC_DISCARD)
             return normalize_from_tryconstruct (tc);
           else
@@ -4442,7 +4450,7 @@ static enum dds_stream_normalize_result normalize_enumarray (struct normalize_st
       dds_stream_maybe_swap16 (st, off, num);
       uint16_t * const xs = (uint16_t *) (st->data + *off);
       for (uint32_t i = 0; i < num; i++) {
-        if (!normalize_enum_value_valid (set, max, xs[i])) {
+        if (!dds_stream_enum_value_valid (set, max, xs[i])) {
           if (tc == TC_REJECT || tc == TC_DISCARD)
             return normalize_from_tryconstruct (tc);
           else
@@ -4458,7 +4466,7 @@ static enum dds_stream_normalize_result normalize_enumarray (struct normalize_st
       dds_stream_maybe_swap32 (st, off, num);
       uint32_t * const xs = (uint32_t *) (st->data + *off);
       for (uint32_t i = 0; i < num; i++) {
-        if (!normalize_enum_value_valid (set, max, xs[i])) {
+        if (!dds_stream_enum_value_valid (set, max, xs[i])) {
           if (tc == TC_REJECT || tc == TC_DISCARD)
             return normalize_from_tryconstruct (tc);
           else

--- a/src/core/cdr/src/dds_cdrstream.c
+++ b/src/core/cdr/src/dds_cdrstream.c
@@ -174,7 +174,6 @@ enum sample_data_state {
 struct dds_cdrstream_ops_info {
   const uint32_t *toplevel_op;
   const uint32_t *ops_end;
-  uint32_t nesting_max;
   dds_data_type_properties_t data_types;
   uint32_t supported_data_representations;
 };
@@ -968,10 +967,10 @@ size_t dds_stream_check_optimize (const struct dds_cdrstream_desc *desc, enum dd
 #define XCDR12_REP (XCDR1_REP | XCDR2_REP)
 
 ddsrt_nonnull_all
-static void dds_stream_get_ops_info1 (const uint32_t *ops, uint32_t nestc, struct dds_cdrstream_ops_info *info, bool in_xcdr1_delimited_scope, uint32_t value_bound_xcdrv, uint32_t tail_bound_xcdrv, bool in_recursive);
+static void dds_stream_get_ops_info1 (const uint32_t *ops, bool top_level_key_scope, struct dds_cdrstream_ops_info *info, bool in_xcdr1_delimited_scope, uint32_t value_bound_xcdrv, uint32_t tail_bound_xcdrv, bool in_recursive);
 
 ddsrt_nonnull_all
-static const uint32_t *dds_stream_get_ops_info_seq (const uint32_t *ops, uint32_t insn, uint32_t nestc, struct dds_cdrstream_ops_info *info, bool in_recursive)
+static const uint32_t *dds_stream_get_ops_info_seq (const uint32_t *ops, uint32_t insn, bool top_level_key_scope, struct dds_cdrstream_ops_info *info, bool in_recursive)
 {
   uint32_t bound_op = seq_is_bounded (DDS_OP_TYPE (insn)) ? 1 : 0;
   const enum dds_stream_typecode subtype = DDS_OP_SUBTYPE (insn);
@@ -1000,7 +999,7 @@ static const uint32_t *dds_stream_get_ops_info_seq (const uint32_t *ops, uint32_
         info->ops_end = ops + 4 + bound_op;
       bool recursive = DDS_OP_ADR_JSR (ops[3 + bound_op]) <= 0;
       if (!in_recursive)
-        dds_stream_get_ops_info1 (jsr_ops, nestc + (subtype == DDS_SOP_VAL_UNI || subtype == DDS_SOP_VAL_STU ? 1 : 0), info, false, 0, 0, recursive);
+        dds_stream_get_ops_info1 (jsr_ops, top_level_key_scope && !(subtype == DDS_SOP_VAL_UNI || subtype == DDS_SOP_VAL_STU), info, false, 0, 0, recursive);
       ops += (jmp ? jmp : (4 + bound_op)); /* FIXME: why would jmp be 0? */
       break;
     }
@@ -1014,7 +1013,7 @@ static const uint32_t *dds_stream_get_ops_info_seq (const uint32_t *ops, uint32_
 }
 
 ddsrt_nonnull_all
-static const uint32_t *dds_stream_get_ops_info_arr (const uint32_t *ops, uint32_t insn, uint32_t nestc, struct dds_cdrstream_ops_info *info, bool in_recursive)
+static const uint32_t *dds_stream_get_ops_info_arr (const uint32_t *ops, uint32_t insn, bool top_level_key_scope, struct dds_cdrstream_ops_info *info, bool in_recursive)
 {
   const enum dds_stream_typecode subtype = DDS_OP_SUBTYPE (insn);
   switch (subtype)
@@ -1042,7 +1041,7 @@ static const uint32_t *dds_stream_get_ops_info_arr (const uint32_t *ops, uint32_
         info->ops_end = ops + 5;
       bool recursive = DDS_OP_ADR_JSR (ops[3]) <= 0;
       if (!in_recursive)
-        dds_stream_get_ops_info1 (jsr_ops, nestc + (subtype == DDS_SOP_VAL_UNI || subtype == DDS_SOP_VAL_STU ? 1 : 0), info, false, 0, 0, recursive);
+        dds_stream_get_ops_info1 (jsr_ops, top_level_key_scope && !(subtype == DDS_SOP_VAL_UNI || subtype == DDS_SOP_VAL_STU), info, false, 0, 0, recursive);
       ops += (jmp ? jmp : 5);
       break;
     }
@@ -1056,7 +1055,7 @@ static const uint32_t *dds_stream_get_ops_info_arr (const uint32_t *ops, uint32_
 }
 
 ddsrt_nonnull_all
-static const uint32_t *dds_stream_get_ops_info_uni (const uint32_t *ops, uint32_t nestc, struct dds_cdrstream_ops_info *info, uint32_t value_bound_xcdrv, uint32_t tail_bound_xcdrv, bool at_tail, bool in_recursive)
+static const uint32_t *dds_stream_get_ops_info_uni (const uint32_t *ops, bool top_level_key_scope, struct dds_cdrstream_ops_info *info, uint32_t value_bound_xcdrv, uint32_t tail_bound_xcdrv, bool at_tail, bool in_recursive)
 {
   const uint32_t union_bound_xcdrv = value_bound_xcdrv | (at_tail ? tail_bound_xcdrv : 0u);
   const enum dds_stream_typecode disc_type = DDS_OP_SUBTYPE (*ops);
@@ -1090,7 +1089,7 @@ static const uint32_t *dds_stream_get_ops_info_uni (const uint32_t *ops, uint32_
       case DDS_SOP_VAL_ARR: case DDS_SOP_VAL_UNI: case DDS_SOP_VAL_BMK: {
         bool recursive = DDS_OP_ADR_JSR (jeq_op[0]) <= 0;
         if (!in_recursive)
-          dds_stream_get_ops_info1 (jeq_op + DDS_OP_ADR_JSR (jeq_op[0]), nestc + (valtype == DDS_SOP_VAL_UNI || valtype == DDS_SOP_VAL_STU ? 1 : 0), info, false, 0, union_bound_xcdrv, recursive);
+          dds_stream_get_ops_info1 (jeq_op + DDS_OP_ADR_JSR (jeq_op[0]), top_level_key_scope && !(valtype == DDS_SOP_VAL_UNI || valtype == DDS_SOP_VAL_STU), info, false, 0, union_bound_xcdrv, recursive);
         break;
       }
       case DDS_SOP_VAL_EXT:
@@ -1108,7 +1107,7 @@ static const uint32_t *dds_stream_get_ops_info_uni (const uint32_t *ops, uint32_
 }
 
 ddsrt_nonnull_all
-static const uint32_t *dds_stream_get_ops_info_pl (const uint32_t *ops, uint32_t nestc, struct dds_cdrstream_ops_info *info, bool in_xcdr1_delimited_scope, bool in_recursive)
+static const uint32_t *dds_stream_get_ops_info_pl (const uint32_t *ops, bool top_level_key_scope, struct dds_cdrstream_ops_info *info, bool in_xcdr1_delimited_scope, bool in_recursive)
 {
   uint32_t insn;
   assert (ops[0] == DDS_OP_PLC);
@@ -1121,9 +1120,9 @@ static const uint32_t *dds_stream_get_ops_info_pl (const uint32_t *ops, uint32_t
         uint32_t flags = DDS_PLM_FLAGS (insn);
         const uint32_t *plm_ops = ops + DDS_OP_ADR_PLM (insn);
         if (flags & DDS_OP_FLAG_BASE)
-          (void) dds_stream_get_ops_info_pl (plm_ops, nestc, info, in_xcdr1_delimited_scope, in_recursive);
+          (void) dds_stream_get_ops_info_pl (plm_ops, top_level_key_scope, info, in_xcdr1_delimited_scope, in_recursive);
         else if (!in_recursive)
-          dds_stream_get_ops_info1 (plm_ops, nestc, info, in_xcdr1_delimited_scope, 0, XCDR12_REP, in_recursive);
+          dds_stream_get_ops_info1 (plm_ops, top_level_key_scope, info, in_xcdr1_delimited_scope, 0, XCDR12_REP, in_recursive);
         ops += 2;
         break;
       }
@@ -1138,11 +1137,9 @@ static const uint32_t *dds_stream_get_ops_info_pl (const uint32_t *ops, uint32_t
 }
 
 ddsrt_nonnull_all
-static void dds_stream_get_ops_info1 (const uint32_t *ops, uint32_t nestc, struct dds_cdrstream_ops_info *info, bool in_xcdr1_delimited_scope, uint32_t value_bound_xcdrv, uint32_t tail_bound_xcdrv, bool in_recursive)
+static void dds_stream_get_ops_info1 (const uint32_t *ops, bool top_level_key_scope, struct dds_cdrstream_ops_info *info, bool in_xcdr1_delimited_scope, uint32_t value_bound_xcdrv, uint32_t tail_bound_xcdrv, bool in_recursive)
 {
   uint32_t insn;
-  if (info->nesting_max < nestc)
-    info->nesting_max = nestc;
   while ((insn = *ops) != DDS_OP_RTS)
   {
     switch (DDS_OP (insn))
@@ -1150,7 +1147,7 @@ static void dds_stream_get_ops_info1 (const uint32_t *ops, uint32_t nestc, struc
       case DDS_SOP_ADR: {
         if (info->toplevel_op == NULL)
           info->toplevel_op = ops;
-        if ((insn & DDS_OP_FLAG_KEY) && nestc == 0)
+        if ((insn & DDS_OP_FLAG_KEY) && top_level_key_scope)
           info->data_types |= DDS_DATA_TYPE_CONTAINS_KEY;
         if (op_type_external (insn) || op_type_optional (insn))
           info->data_types &= ~DDS_DATA_TYPE_IS_MEMCPY_SAFE;
@@ -1177,15 +1174,15 @@ static void dds_stream_get_ops_info1 (const uint32_t *ops, uint32_t nestc, struc
             break;
           case DDS_SOP_VAL_SEQ: case DDS_SOP_VAL_BSQ:
             info->data_types &= ~DDS_DATA_TYPE_IS_MEMCPY_SAFE;
-            ops = dds_stream_get_ops_info_seq (ops, insn, nestc, info, in_recursive);
+            ops = dds_stream_get_ops_info_seq (ops, insn, top_level_key_scope, info, in_recursive);
             break;
           case DDS_SOP_VAL_ARR:
-            ops = dds_stream_get_ops_info_arr (ops, insn, nestc, info, in_recursive);
+            ops = dds_stream_get_ops_info_arr (ops, insn, top_level_key_scope, info, in_recursive);
             break;
           case DDS_SOP_VAL_UNI: {
             const uint32_t jmp = DDS_OP_ADR_JMP (ops[3]);
             const bool at_tail = *(ops + (jmp ? jmp : 4)) == DDS_OP_RTS;
-            ops = dds_stream_get_ops_info_uni (ops, nestc, info, adr_value_bound_xcdrv, tail_bound_xcdrv, at_tail, in_recursive);
+            ops = dds_stream_get_ops_info_uni (ops, top_level_key_scope, info, adr_value_bound_xcdrv, tail_bound_xcdrv, at_tail, in_recursive);
             break;
           }
           case DDS_SOP_VAL_EXT: {
@@ -1198,7 +1195,7 @@ static void dds_stream_get_ops_info1 (const uint32_t *ops, uint32_t nestc, struc
             const uint32_t ext_tail_bound_xcdrv = adr_value_bound_xcdrv | (at_tail ? tail_bound_xcdrv : 0u);
             bool recursive = DDS_OP_ADR_JSR (ops[2]) <= 0;
             if (!in_recursive)
-              dds_stream_get_ops_info1 (jsr_ops, nestc + 1, info, in_xcdr1_delimited_scope, 0, ext_tail_bound_xcdrv, recursive);
+              dds_stream_get_ops_info1 (jsr_ops, false, info, in_xcdr1_delimited_scope, 0, ext_tail_bound_xcdrv, recursive);
             ops = next_ops;
             break;
           }
@@ -1213,7 +1210,7 @@ static void dds_stream_get_ops_info1 (const uint32_t *ops, uint32_t nestc, struc
         const bool at_tail = ops[1] == DDS_OP_RTS;
         const uint32_t jsr_tail_bound_xcdrv = at_tail ? (value_bound_xcdrv | tail_bound_xcdrv) : 0u;
         if (!in_recursive)
-          dds_stream_get_ops_info1 (ops + DDS_OP_JUMP (insn), nestc, info, in_xcdr1_delimited_scope, 0, jsr_tail_bound_xcdrv, recursive);
+          dds_stream_get_ops_info1 (ops + DDS_OP_JUMP (insn), top_level_key_scope, info, in_xcdr1_delimited_scope, 0, jsr_tail_bound_xcdrv, recursive);
         ops++;
         break;
       }
@@ -1232,7 +1229,7 @@ static void dds_stream_get_ops_info1 (const uint32_t *ops, uint32_t nestc, struc
       }
       case DDS_SOP_PLC: {
         info->data_types |= DDS_DATA_TYPE_DEFAULTS_TO_XCDR2;
-        ops = dds_stream_get_ops_info_pl (ops, nestc, info, in_xcdr1_delimited_scope, in_recursive);
+        ops = dds_stream_get_ops_info_pl (ops, top_level_key_scope, info, in_xcdr1_delimited_scope, in_recursive);
         break;
       }
     }
@@ -1259,10 +1256,9 @@ static void dds_stream_get_ops_info (const uint32_t *ops, struct dds_cdrstream_o
 {
   info->toplevel_op = NULL;
   info->ops_end = ops;
-  info->nesting_max = 0;
   info->data_types = DDS_DATA_TYPE_IS_MEMCPY_SAFE;
   info->supported_data_representations = XCDR12_REP;
-  dds_stream_get_ops_info1 (ops, 0, info, true, 0, XCDR12_REP, false);
+  dds_stream_get_ops_info1 (ops, true, info, true, 0, XCDR12_REP, false);
 }
 
 ddsrt_nonnull_all
@@ -7363,13 +7359,6 @@ bool dds_stream_extensibility (const uint32_t *ops, enum dds_cdr_type_extensibil
   /* A final empty aggregate has no ADR/DLC/PLC instruction before RTS. */
   *ext = DDS_CDR_TYPE_EXT_FINAL;
   return true;
-}
-
-uint32_t dds_stream_type_nesting_depth (const uint32_t *ops)
-{
-  struct dds_cdrstream_ops_info info;
-  dds_stream_get_ops_info (ops, &info);
-  return info.nesting_max;
 }
 
 dds_data_type_properties_t dds_stream_data_types (const uint32_t *ops)

--- a/src/core/cdr/src/dds_cdrstream_keys.part.h
+++ b/src/core/cdr/src/dds_cdrstream_keys.part.h
@@ -31,7 +31,7 @@ static bool dds_stream_write_keyBO_impl (RESTRICT_OSTREAM_T *os, const struct dd
     case DDS_SOP_VAL_8BY: dds_os_put8BO (os, allocator, *((uint64_t *) addr)); break;
     case DDS_SOP_VAL_16BY: dds_os_put16BO (os, allocator, *((ddsrt_uint128_t *) addr)); break;
     case DDS_SOP_VAL_ENU:
-      if (!dds_stream_write_enum_valueBO (os, allocator, insn, *((uint32_t *) addr), ops[2]))
+      if (!dds_stream_write_enum_valueBO (os, allocator, mid_table, ops, *((uint32_t *) addr), ops[2]))
         return false;
       break;
     case DDS_SOP_VAL_BMK:
@@ -86,10 +86,14 @@ static bool dds_stream_write_keyBO_impl (RESTRICT_OSTREAM_T *os, const struct dd
 ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
 static bool dds_stream_write_keyBO_restrict (RESTRICT_OSTREAM_T *os, enum dds_cdr_key_serialization_kind ser_kind, const struct dds_cdrstream_allocator *allocator, const char *sample, const struct dds_cdrstream_desc *desc)
 {
-  if (desc->flagset & (DDS_TOPIC_KEY_APPENDABLE | DDS_TOPIC_KEY_MUTABLE | DDS_TOPIC_KEY_SEQUENCE | DDS_TOPIC_KEY_ARRAY_NONPRIM) && ser_kind == DDS_CDR_KEY_SERIALIZATION_SAMPLE)
+  const bool use_regular_sample_key_writer =
+    (desc->flagset & (DDS_TOPIC_KEY_APPENDABLE | DDS_TOPIC_KEY_MUTABLE | DDS_TOPIC_KEY_SEQUENCE | DDS_TOPIC_KEY_ARRAY_NONPRIM)) ||
+    desc->member_ids.enum_value_sets != NULL;
+  if (use_regular_sample_key_writer && ser_kind == DDS_CDR_KEY_SERIALIZATION_SAMPLE)
   {
     /* For types with key fields in aggregated types with appendable or mutable
-       extensibility, write the key CDR using the regular write functions */
+       extensibility or with enum value tables, write the key CDR using the
+       regular write functions. */
     if (dds_stream_write_implBO (os, allocator, &desc->member_ids, sample, desc->ops.ops, false, CDR_KIND_KEY) == NULL)
       return false;
   }
@@ -283,13 +287,17 @@ static bool dds_stream_extract_keyBO_from_data_restrict (dds_istream_t *is, REST
   if (keys_remaining == 0)
     return ret;
 
-  if (desc->flagset & (DDS_TOPIC_KEY_APPENDABLE | DDS_TOPIC_KEY_MUTABLE | DDS_TOPIC_KEY_SEQUENCE | DDS_TOPIC_KEY_ARRAY_NONPRIM))
+  const bool use_regular_key_extraction =
+    (desc->flagset & (DDS_TOPIC_KEY_APPENDABLE | DDS_TOPIC_KEY_MUTABLE | DDS_TOPIC_KEY_SEQUENCE | DDS_TOPIC_KEY_ARRAY_NONPRIM)) ||
+    desc->member_ids.enum_value_sets != NULL;
+  if (use_regular_key_extraction)
   {
     /* In case key members exist in top-level type or any subtype has non-final extensibility,
-       read the full sample and use the write function to get the key CDR for this sample */
+       or enum value tables are present, read the full sample and use the write function
+       to get the key CDR for this sample. */
     void *sample = allocator->malloc (desc->size);
     memset (sample, 0, desc->size);
-    (void) dds_stream_read (is, sample, allocator, desc->ops.ops);
+    (void) dds_stream_read_impl (is, sample, allocator, &desc->member_ids, desc->ops.ops, false, CDR_KIND_DATA, SAMPLE_DATA_INITIALIZED);
     if (!dds_stream_write_keyBO_restrict (os, DDS_CDR_KEY_SERIALIZATION_SAMPLE, allocator, sample, desc))
     {
       // can't happen given normalized input (and it has to be normalized, else dds_stream_read may not be used)
@@ -373,12 +381,16 @@ void dds_stream_extract_keyBO_from_key (dds_istream_t *is, DDS_OSTREAM_T *os, en
 
   /* This assumes that the key fields in the input CDR are in definition order.
      In case any key field is in an appendable or mutable type, or in case a serialized
-     key for a keyhash is required (in member-id order), extract and write the key
-     in two steps. Otherwise, extract the output CDR in a single step. */
+     key for a keyhash is required (in member-id order), or when enum value tables
+     are present, extract and write the key in two steps. Otherwise, extract the
+     output CDR in a single step. */
   RESTRICT_OSTREAM_T ros;
   memcpy (&ros, os, sizeof (*os));
   ros.x.m_align_off = 0;
-  if ((desc->flagset & (DDS_TOPIC_KEY_APPENDABLE | DDS_TOPIC_KEY_MUTABLE | DDS_TOPIC_KEY_SEQUENCE | DDS_TOPIC_KEY_ARRAY_NONPRIM)) || ser_kind == DDS_CDR_KEY_SERIALIZATION_KEYHASH)
+  const bool use_regular_key_extraction =
+    (desc->flagset & (DDS_TOPIC_KEY_APPENDABLE | DDS_TOPIC_KEY_MUTABLE | DDS_TOPIC_KEY_SEQUENCE | DDS_TOPIC_KEY_ARRAY_NONPRIM)) ||
+    desc->member_ids.enum_value_sets != NULL;
+  if (use_regular_key_extraction || ser_kind == DDS_CDR_KEY_SERIALIZATION_KEYHASH)
     dds_stream_extract_keyBO_from_key_impl (is, &ros, ser_kind, allocator, desc);
   else
     dds_stream_extract_keyBO_from_key_optimized (is, &ros, allocator, desc);

--- a/src/core/cdr/src/dds_cdrstream_keys.part.h
+++ b/src/core/cdr/src/dds_cdrstream_keys.part.h
@@ -328,7 +328,7 @@ static void dds_stream_extract_keyBO_from_key_impl (dds_istream_t *is, RESTRICT_
      and write the key-only CDR for this sample */
   void *sample = allocator->malloc (desc->size);
   memset (sample, 0, desc->size);
-  (void) dds_stream_read_impl (is, sample, allocator, desc->ops.ops, false, CDR_KIND_KEY, SAMPLE_DATA_INITIALIZED);
+  (void) dds_stream_read_impl (is, sample, allocator, &desc->member_ids, desc->ops.ops, false, CDR_KIND_KEY, SAMPLE_DATA_INITIALIZED);
   if (!dds_stream_write_keyBO_restrict (os, ser_kind, allocator, sample, desc))
   {
     // input must have been proven correct (using normalize), so write can't run into invalid data

--- a/src/core/cdr/src/dds_cdrstream_write.part.h
+++ b/src/core/cdr/src/dds_cdrstream_write.part.h
@@ -16,10 +16,12 @@ static inline bool dds_stream_write_bool_valueBO (RESTRICT_OSTREAM_T *os, const 
   return true;
 }
 
-static bool dds_stream_write_enum_valueBO (RESTRICT_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator, uint32_t insn, uint32_t val, uint32_t max)
+static bool dds_stream_write_enum_valueBO (RESTRICT_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *op, uint32_t val, uint32_t max)
 {
-  if (val > max)
+  const struct dds_cdrstream_desc_enum_value_set *set;
+  if (!dds_stream_enum_value_set (mid_table, op, max, &set) || !dds_stream_enum_value_valid (set, max, val))
     return write_error_bool ();
+  const uint32_t insn = *op;
   switch (DDS_OP_TYPE_SZ (insn))
   {
     case 1:
@@ -167,14 +169,18 @@ static bool dds_stream_write_bool_arrBO (RESTRICT_OSTREAM_T *os, const struct dd
   return true;
 }
 
-static bool dds_stream_write_enum_arrBO (RESTRICT_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator, uint32_t insn, const uint32_t *addr, uint32_t num, uint32_t max)
+static bool dds_stream_write_enum_arrBO (RESTRICT_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *op, const uint32_t *addr, uint32_t num, uint32_t max)
 {
+  const struct dds_cdrstream_desc_enum_value_set *set;
+  if (!dds_stream_enum_value_set (mid_table, op, max, &set))
+    return write_error_bool ();
+  const uint32_t insn = *op;
   switch (DDS_OP_TYPE_SZ (insn))
   {
     case 1:
       for (uint32_t i = 0; i < num; i++)
       {
-        if (addr[i] > max)
+        if (!dds_stream_enum_value_valid (set, max, addr[i]))
           return write_error_bool ();
         dds_os_put1BO (os, allocator, (uint8_t) addr[i]);
       }
@@ -182,7 +188,7 @@ static bool dds_stream_write_enum_arrBO (RESTRICT_OSTREAM_T *os, const struct dd
     case 2:
       for (uint32_t i = 0; i < num; i++)
       {
-        if (addr[i] > max)
+        if (!dds_stream_enum_value_valid (set, max, addr[i]))
           return write_error_bool ();
         dds_os_put2BO (os, allocator, (uint16_t) addr[i]);
       }
@@ -190,7 +196,7 @@ static bool dds_stream_write_enum_arrBO (RESTRICT_OSTREAM_T *os, const struct dd
     case 4:
       for (uint32_t i = 0; i < num; i++)
       {
-        if (addr[i] > max)
+        if (!dds_stream_enum_value_valid (set, max, addr[i]))
           return write_error_bool ();
         dds_os_put4BO (os, allocator, addr[i]);
       }
@@ -303,7 +309,7 @@ static const uint32_t *dds_stream_write_seqBO (RESTRICT_OSTREAM_T *os, const str
         break;
       }
       case DDS_SOP_VAL_ENU:
-        if (!dds_stream_write_enum_arrBO (os, allocator, insn, (const uint32_t *) seq->_buffer, num, ops[2 + bound_op]))
+        if (!dds_stream_write_enum_arrBO (os, allocator, mid_table, ops, (const uint32_t *) seq->_buffer, num, ops[2 + bound_op]))
           return NULL;
         ops += 3 + bound_op;
         break;
@@ -408,7 +414,7 @@ static const uint32_t *dds_stream_write_arrBO (RESTRICT_OSTREAM_T *os, const str
       break;
     }
     case DDS_SOP_VAL_ENU:
-      if (!dds_stream_write_enum_arrBO (os, allocator, insn, (const uint32_t *) addr, num, ops[3]))
+      if (!dds_stream_write_enum_arrBO (os, allocator, mid_table, ops, (const uint32_t *) addr, num, ops[3]))
         return NULL;
       ops += 4;
       break;
@@ -482,7 +488,7 @@ static const uint32_t *dds_stream_write_arrBO (RESTRICT_OSTREAM_T *os, const str
 }
 
 ddsrt_nonnull_all
-static bool dds_stream_write_union_discriminantBO (RESTRICT_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator, const uint32_t *ops, uint32_t insn, const void *addr, uint64_t *disc)
+static bool dds_stream_write_union_discriminantBO (RESTRICT_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *ops, uint32_t insn, const void *addr, uint64_t *disc)
 {
   enum dds_stream_typecode type = DDS_OP_SUBTYPE (insn);
   assert (is_primitive_or_enum_or_bitmask_type (type));
@@ -511,7 +517,7 @@ static bool dds_stream_write_union_discriminantBO (RESTRICT_OSTREAM_T *os, const
       break;
     case DDS_SOP_VAL_ENU:
       *disc = *((const uint32_t *) addr);
-      if (!dds_stream_write_enum_valueBO (os, allocator, insn, (uint32_t) *disc, ops[4]))
+      if (!dds_stream_write_enum_valueBO (os, allocator, mid_table, ops, (uint32_t) *disc, ops[4]))
         return false;
       break;
     case DDS_SOP_VAL_BMK:
@@ -534,7 +540,7 @@ static bool dds_stream_write_union_discriminantBO (RESTRICT_OSTREAM_T *os, const
 static const uint32_t *dds_stream_write_uniBO (RESTRICT_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc_mid_table *mid_table, const char *discaddr, const char *baseaddr, const uint32_t *ops, uint32_t insn, enum cdr_data_kind cdr_kind)
 {
   uint64_t disc;
-  if (!dds_stream_write_union_discriminantBO (os, allocator, ops, insn, discaddr, &disc))
+  if (!dds_stream_write_union_discriminantBO (os, allocator, mid_table, ops, insn, discaddr, &disc))
     return NULL;
   uint32_t const * const jeq_op = find_union_case (ops, disc);
   ops += DDS_OP_ADR_JMP (ops[3]);
@@ -566,7 +572,7 @@ static const uint32_t *dds_stream_write_uniBO (RESTRICT_OSTREAM_T *os, const str
       case DDS_SOP_VAL_8BY: dds_os_put8BO (os, allocator, *(const uint64_t *) valaddr); break;
       case DDS_SOP_VAL_16BY: dds_os_put16BO (os, allocator, *(const ddsrt_uint128_t *) valaddr); break;
       case DDS_SOP_VAL_ENU:
-        if (!dds_stream_write_enum_valueBO (os, allocator, jeq_op[0], *((const uint32_t *) valaddr), jeq_op[3]))
+        if (!dds_stream_write_enum_valueBO (os, allocator, mid_table, jeq_op, *((const uint32_t *) valaddr), jeq_op[3]))
           return NULL;
         break;
       case DDS_SOP_VAL_STR:
@@ -697,7 +703,7 @@ static const uint32_t *dds_stream_write_adrBO (uint32_t insn, RESTRICT_OSTREAM_T
     case DDS_SOP_VAL_8BY: dds_os_put8BO (os, allocator, *((const uint64_t *) addr)); ops += 2; break;
     case DDS_SOP_VAL_16BY: dds_os_put16BO (os, allocator, *((const ddsrt_uint128_t *) addr)); ops += 2; break;
     case DDS_SOP_VAL_ENU:
-      if (!dds_stream_write_enum_valueBO (os, allocator, insn, *((const uint32_t *) addr), ops[2]))
+      if (!dds_stream_write_enum_valueBO (os, allocator, mid_table, ops, *((const uint32_t *) addr), ops[2]))
         return NULL;
       ops += 3;
       break;
@@ -799,7 +805,7 @@ static bool dds_stream_write_xcdr1_pl_memberBO (RESTRICT_OSTREAM_T *os, const st
   return true;
 }
 
-static bool dds_stream_write_xcdr2_pl_memberBO (RESTRICT_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator, uint32_t mid, const char *data, const uint32_t *ops, enum cdr_data_kind cdr_kind)
+static bool dds_stream_write_xcdr2_pl_memberBO (RESTRICT_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator, uint32_t mid, const struct dds_cdrstream_desc_mid_table *mid_table, const char *data, const uint32_t *ops, enum cdr_data_kind cdr_kind)
 {
   assert (!(mid & ~EMHEADER_MEMBERID_MASK));
 
@@ -816,7 +822,7 @@ static bool dds_stream_write_xcdr2_pl_memberBO (RESTRICT_OSTREAM_T *os, const st
   uint32_t lc = get_length_code (ops);
   assert (lc <= LENGTH_CODE_ALSO_NEXTINT8);
   uint32_t data_offs = (lc != LENGTH_CODE_NEXTINT) ? dds_os_reserve4BO (os, allocator) : dds_os_reserve8BO (os, allocator);
-  if (!(dds_stream_write_implBO (os, allocator, &static_empty_mid_table, data, ops, true, cdr_kind)))
+  if (!(dds_stream_write_implBO (os, allocator, mid_table, data, ops, true, cdr_kind)))
     return false;
 
   /* add emheader with data length code and flags and optionally the serialized size of the data */
@@ -855,7 +861,7 @@ static const uint32_t *dds_stream_write_pl_memberlistBO (RESTRICT_OSTREAM_T *os,
           uint32_t member_id = ops[1];
           if (os->x.m_xcdr_version == DDSI_RTPS_CDR_ENC_VERSION_2)
           {
-            if (!dds_stream_write_xcdr2_pl_memberBO (os, allocator, member_id, data, plm_ops, cdr_kind))
+            if (!dds_stream_write_xcdr2_pl_memberBO (os, allocator, member_id, mid_table, data, plm_ops, cdr_kind))
               return NULL;
           }
           else

--- a/src/core/cdr/src/dds_cdrstream_write.part.h
+++ b/src/core/cdr/src/dds_cdrstream_write.part.h
@@ -19,19 +19,22 @@ static inline bool dds_stream_write_bool_valueBO (RESTRICT_OSTREAM_T *os, const 
 static bool dds_stream_write_enum_valueBO (RESTRICT_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *op, uint32_t val, uint32_t max)
 {
   const struct dds_cdrstream_desc_enum_value_set *set;
-  if (!dds_stream_enum_value_set (mid_table, op, max, &set) || !dds_stream_enum_value_valid (set, max, val))
+  uint32_t image;
+  if (!dds_stream_enum_value_image_from_memory (op, val, &image))
+    return write_error_bool ();
+  if (!dds_stream_enum_value_set (mid_table, op, max, &set) || !dds_stream_enum_value_valid (set, max, image))
     return write_error_bool ();
   const uint32_t insn = *op;
   switch (DDS_OP_TYPE_SZ (insn))
   {
     case 1:
-      dds_os_put1BO (os, allocator, (uint8_t) val);
+      dds_os_put1BO (os, allocator, (uint8_t) image);
       break;
     case 2:
-      dds_os_put2BO (os, allocator, (uint16_t) val);
+      dds_os_put2BO (os, allocator, (uint16_t) image);
       break;
     case 4:
-      dds_os_put4BO (os, allocator, val);
+      dds_os_put4BO (os, allocator, image);
       break;
     default:
       abort ();
@@ -180,25 +183,34 @@ static bool dds_stream_write_enum_arrBO (RESTRICT_OSTREAM_T *os, const struct dd
     case 1:
       for (uint32_t i = 0; i < num; i++)
       {
-        if (!dds_stream_enum_value_valid (set, max, addr[i]))
+        uint32_t image;
+        if (!dds_stream_enum_value_image_from_memory (op, addr[i], &image))
           return write_error_bool ();
-        dds_os_put1BO (os, allocator, (uint8_t) addr[i]);
+        if (!dds_stream_enum_value_valid (set, max, image))
+          return write_error_bool ();
+        dds_os_put1BO (os, allocator, (uint8_t) image);
       }
       break;
     case 2:
       for (uint32_t i = 0; i < num; i++)
       {
-        if (!dds_stream_enum_value_valid (set, max, addr[i]))
+        uint32_t image;
+        if (!dds_stream_enum_value_image_from_memory (op, addr[i], &image))
           return write_error_bool ();
-        dds_os_put2BO (os, allocator, (uint16_t) addr[i]);
+        if (!dds_stream_enum_value_valid (set, max, image))
+          return write_error_bool ();
+        dds_os_put2BO (os, allocator, (uint16_t) image);
       }
       break;
     case 4:
       for (uint32_t i = 0; i < num; i++)
       {
-        if (!dds_stream_enum_value_valid (set, max, addr[i]))
+        uint32_t image;
+        if (!dds_stream_enum_value_image_from_memory (op, addr[i], &image))
           return write_error_bool ();
-        dds_os_put4BO (os, allocator, addr[i]);
+        if (!dds_stream_enum_value_valid (set, max, image))
+          return write_error_bool ();
+        dds_os_put4BO (os, allocator, image);
       }
       break;
     default:
@@ -487,7 +499,7 @@ static const uint32_t *dds_stream_write_arrBO (RESTRICT_OSTREAM_T *os, const str
   return ops;
 }
 
-ddsrt_nonnull_all
+ddsrt_nonnull_all ddsrt_attribute_warn_unused_result
 static bool dds_stream_write_union_discriminantBO (RESTRICT_OSTREAM_T *os, const struct dds_cdrstream_allocator *allocator, const struct dds_cdrstream_desc_mid_table *mid_table, const uint32_t *ops, uint32_t insn, const void *addr, uint64_t *disc)
 {
   enum dds_stream_typecode type = DDS_OP_SUBTYPE (insn);
@@ -515,12 +527,17 @@ static bool dds_stream_write_union_discriminantBO (RESTRICT_OSTREAM_T *os, const
       *disc = *((const uint64_t *) addr);
       dds_os_put8BO (os, allocator, *disc);
       break;
-    case DDS_SOP_VAL_ENU:
-      *disc = *((const uint32_t *) addr);
-      if (!dds_stream_write_enum_valueBO (os, allocator, mid_table, ops, (uint32_t) *disc, ops[4]))
+    case DDS_SOP_VAL_ENU: {
+      const uint32_t val = *((const uint32_t *) addr);
+      uint32_t image;
+      if (!dds_stream_enum_value_image_from_memory (ops, val, &image))
+        return false;
+      *disc = image;
+      if (!dds_stream_write_enum_valueBO (os, allocator, mid_table, ops, val, ops[4]))
         return false;
       break;
-    case DDS_SOP_VAL_BMK:
+    }
+    case DDS_SOP_VAL_BMK: {
       switch (DDS_OP_TYPE_SZ (insn))
       {
         case 1: *disc = *((const uint8_t *) addr); break;
@@ -531,6 +548,7 @@ static bool dds_stream_write_union_discriminantBO (RESTRICT_OSTREAM_T *os, const
       if (!dds_stream_write_bitmask_valueBO (os, allocator, insn, disc, bitmask_bits_hl (ops[4], ops[5])))
         return false;
       break;
+    }
     default:
       abort ();
   }

--- a/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
@@ -408,7 +408,9 @@ enum dds_stream_opcode {
 /**
  * Trailing metadata records, not part of the serialization VM instruction set:
  *   [EVS, 0, set-id] [default value] [nvalues] [value-0] ... [value-n-1]
- *       where values are sorted in ascending order
+ *       where default value is the semantic signed Int32 enum value bit
+ *       pattern for memory/defaulting, and values are unsigned CDR holder
+ *       images sorted in ascending order for membership tests
  *   [EVM, 0, elem-insn] [set-id]
  */
 

--- a/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
@@ -220,6 +220,8 @@ extern "C" {
 #define DDS_OP_KOF  (0x07 << 24)
 #define DDS_OP_JEQ4 (0x08 << 24)
 #define DDS_OP_MID  (0x09 << 24)
+#define DDS_OP_EVS  (0x0a << 24)
+#define DDS_OP_EVM  (0x0b << 24)
 
 /**
  * @ingroup serialization
@@ -402,6 +404,13 @@ enum dds_stream_opcode {
    */
   DDS_SOP_MID = DDS_OP_MID
 };
+
+/**
+ * Trailing metadata records, not part of the serialization VM instruction set:
+ *   [EVS, 0, set-id] [default value] [nvalues] [value-0] ... [value-n-1]
+ *       where values are sorted in ascending order
+ *   [EVM, 0, elem-insn] [set-id]
+ */
 
 #define DDS_OP_VAL_1BY   (0x01)
 #define DDS_OP_VAL_2BY   (0x02)

--- a/src/core/ddsc/include/dds/ddsc/dds_public_dynamic_type.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_public_dynamic_type.h
@@ -272,9 +272,9 @@ enum dds_dynamic_type_enum_value_kind {
 /**
  * @ingroup dynamic_type
  *
- * Dynamic Enumeration type literal value kind and value. Can be set to NEXT_AVAIL to indicate
- * that the current max value + 1 should be used for this member, or an explicit value can be
- * provided.
+ * Dynamic Enumeration type literal value kind and value. Explicit values are signed XTypes
+ * enum literal values. Can be set to NEXT_AVAIL to indicate that the current max value + 1
+ * should be used for this member, or an explicit value can be provided.
  */
 typedef struct dds_dynamic_enum_literal_value {
   enum dds_dynamic_type_enum_value_kind value_kind;

--- a/src/core/ddsc/src/dds__serdata_default.h
+++ b/src/core/ddsc/src/dds__serdata_default.h
@@ -147,7 +147,7 @@ struct dds_serdatapool * dds_serdatapool_new (void);
 void dds_serdatapool_free (struct dds_serdatapool * pool);
 
 /** @component typesupport_c */
-dds_return_t dds_sertype_default_init (const struct dds_domain *domain, struct dds_sertype_default *st, const dds_topic_descriptor_t *desc, enum dds_cdr_enc_version min_xcdrv, dds_data_representation_id_t data_representation);
+dds_return_t dds_sertype_default_init (const struct dds_domain *domain, struct dds_sertype_default *st, const dds_topic_descriptor_t *desc, dds_data_representation_id_t data_representation);
 
 #if defined (__cplusplus)
 }

--- a/src/core/ddsc/src/dds_sertype_default.c
+++ b/src/core/ddsc/src/dds_sertype_default.c
@@ -296,7 +296,7 @@ const struct ddsi_sertype_ops dds_sertype_ops_default = {
   .serialize_into = sertype_default_serialize_into
 };
 
-dds_return_t dds_sertype_default_init (const struct dds_domain *domain, struct dds_sertype_default *st, const dds_topic_descriptor_t *desc, enum dds_cdr_enc_version min_xcdrv, dds_data_representation_id_t data_representation)
+dds_return_t dds_sertype_default_init (const struct dds_domain *domain, struct dds_sertype_default *st, const dds_topic_descriptor_t *desc, dds_data_representation_id_t data_representation)
 {
   const struct ddsi_domaingv *gv = &domain->gv;
   const struct ddsi_serdata_ops *serdata_ops;
@@ -322,9 +322,8 @@ dds_return_t dds_sertype_default_init (const struct dds_domain *domain, struct d
 
   uint32_t allowed_data_representation = desc->m_flagset & DDS_TOPIC_RESTRICT_DATA_REPRESENTATION ?
       desc->restrict_data_representation : DDS_DATA_REPRESENTATION_RESTRICT_DEFAULT;
-  allowed_data_representation &= dds_stream_allowed_data_representations (desc->m_ops);
-  if (min_xcdrv == DDSI_RTPS_CDR_ENC_VERSION_2)
-    allowed_data_representation &= ~DDS_DATA_REPRESENTATION_FLAG_XCDR1;
+  const uint32_t supported_data_representations = dds_stream_supported_data_representations (desc->m_ops);
+  allowed_data_representation &= supported_data_representations;
 
   ddsi_sertype_init_props (&st->c, desc->m_typename, &dds_sertype_ops_default, serdata_ops, desc->m_size, dds_stream_data_types (desc->m_ops), allowed_data_representation, 0);
   st->encoding_format = ddsi_sertype_extensibility_enc_format (type_ext);
@@ -335,7 +334,7 @@ dds_return_t dds_sertype_default_init (const struct dds_domain *domain, struct d
 
   dds_cdrstream_desc_init_with_nops (&st->type, &dds_cdrstream_default_allocator, desc->m_size, desc->m_align, desc->m_flagset, desc->m_ops, desc->m_nops, desc->m_keys, desc->m_nkeys);
 
-  if (min_xcdrv == DDSI_RTPS_CDR_ENC_VERSION_2 && dds_stream_type_nesting_depth (desc->m_ops) > DDS_CDRSTREAM_MAX_NESTING_DEPTH)
+  if (!(supported_data_representations & DDS_DATA_REPRESENTATION_FLAG_XCDR1) && dds_stream_type_nesting_depth (desc->m_ops) > DDS_CDRSTREAM_MAX_NESTING_DEPTH)
   {
     ddsi_sertype_unref (&st->c);
     GVTRACE ("Serializer ops for type %s has unsupported nesting depth (max %u)\n", desc->m_typename, DDS_CDRSTREAM_MAX_NESTING_DEPTH);

--- a/src/core/ddsc/src/dds_sertype_default.c
+++ b/src/core/ddsc/src/dds_sertype_default.c
@@ -334,13 +334,6 @@ dds_return_t dds_sertype_default_init (const struct dds_domain *domain, struct d
 
   dds_cdrstream_desc_init_with_nops (&st->type, &dds_cdrstream_default_allocator, desc->m_size, desc->m_align, desc->m_flagset, desc->m_ops, desc->m_nops, desc->m_keys, desc->m_nkeys);
 
-  if (!(supported_data_representations & DDS_DATA_REPRESENTATION_FLAG_XCDR1) && dds_stream_type_nesting_depth (desc->m_ops) > DDS_CDRSTREAM_MAX_NESTING_DEPTH)
-  {
-    ddsi_sertype_unref (&st->c);
-    GVTRACE ("Serializer ops for type %s has unsupported nesting depth (max %u)\n", desc->m_typename, DDS_CDRSTREAM_MAX_NESTING_DEPTH);
-    return DDS_RETCODE_BAD_PARAMETER;
-  }
-
   if (desc->m_flagset & DDS_TOPIC_XTYPES_METADATA)
   {
     if (desc->type_information.sz == 0 || desc->type_information.data == NULL

--- a/src/core/ddsc/src/dds_sertype_default.c
+++ b/src/core/ddsc/src/dds_sertype_default.c
@@ -322,6 +322,7 @@ dds_return_t dds_sertype_default_init (const struct dds_domain *domain, struct d
 
   uint32_t allowed_data_representation = desc->m_flagset & DDS_TOPIC_RESTRICT_DATA_REPRESENTATION ?
       desc->restrict_data_representation : DDS_DATA_REPRESENTATION_RESTRICT_DEFAULT;
+  allowed_data_representation &= dds_stream_allowed_data_representations (desc->m_ops);
   if (min_xcdrv == DDSI_RTPS_CDR_ENC_VERSION_2)
     allowed_data_representation &= ~DDS_DATA_REPRESENTATION_FLAG_XCDR1;
 

--- a/src/core/ddsc/src/dds_topic.c
+++ b/src/core/ddsc/src/dds_topic.c
@@ -674,10 +674,7 @@ dds_entity_t dds_create_topic (dds_entity_t participant, const dds_topic_descrip
      QoS object. */
   uint32_t allowed_repr = descriptor->m_flagset & DDS_TOPIC_RESTRICT_DATA_REPRESENTATION ?
       descriptor->restrict_data_representation : DDS_DATA_REPRESENTATION_RESTRICT_DEFAULT;
-  allowed_repr &= dds_stream_allowed_data_representations (descriptor->m_ops);
-  enum dds_cdr_enc_version min_xcdrv = dds_stream_minimum_xcdr_version (descriptor->m_ops);
-  if (min_xcdrv == DDSI_RTPS_CDR_ENC_VERSION_2)
-    allowed_repr &= ~DDS_DATA_REPRESENTATION_FLAG_XCDR1;
+  allowed_repr &= dds_stream_supported_data_representations (descriptor->m_ops);
   if ((ret = dds_ensure_valid_data_representation (tpqos, allowed_repr, dds_stream_data_types (descriptor->m_ops), DDS_KIND_TOPIC)) != DDS_RETCODE_OK)
     goto err_data_repr;
 
@@ -685,7 +682,7 @@ dds_entity_t dds_create_topic (dds_entity_t participant, const dds_topic_descrip
   dds_data_representation_id_t data_representation = tpqos->data_representation.value.ids[0];
 
   struct dds_sertype_default *st = ddsrt_malloc (sizeof (*st));
-  if ((ret = dds_sertype_default_init (ppent->m_domain, st, descriptor, min_xcdrv, data_representation)) < 0)
+  if ((ret = dds_sertype_default_init (ppent->m_domain, st, descriptor, data_representation)) < 0)
   {
     ddsrt_free (st);
     goto err_st_init;

--- a/src/core/ddsc/src/dds_topic.c
+++ b/src/core/ddsc/src/dds_topic.c
@@ -674,6 +674,7 @@ dds_entity_t dds_create_topic (dds_entity_t participant, const dds_topic_descrip
      QoS object. */
   uint32_t allowed_repr = descriptor->m_flagset & DDS_TOPIC_RESTRICT_DATA_REPRESENTATION ?
       descriptor->restrict_data_representation : DDS_DATA_REPRESENTATION_RESTRICT_DEFAULT;
+  allowed_repr &= dds_stream_allowed_data_representations (descriptor->m_ops);
   enum dds_cdr_enc_version min_xcdrv = dds_stream_minimum_xcdr_version (descriptor->m_ops);
   if (min_xcdrv == DDSI_RTPS_CDR_ENC_VERSION_2)
     allowed_repr &= ~DDS_DATA_REPRESENTATION_FLAG_XCDR1;

--- a/src/core/ddsc/tests/CMakeLists.txt
+++ b/src/core/ddsc/tests/CMakeLists.txt
@@ -40,7 +40,7 @@ idlc_generate(TARGET Array100 FILES Array100.idl WARNINGS no-implicit-extensibil
 idlc_generate(TARGET DynamicData FILES DynamicData.idl WARNINGS no-implicit-extensibility)
 if(ENABLE_TYPELIB)
   idlc_generate(TARGET SertypeData FILES SertypeData.idl)
-  idlc_generate(TARGET XSpace FILES XSpace.idl XSpaceEnum.idl XSpaceMustUnderstand.idl XSpaceTypeConsistencyEnforcement.idl WARNINGS no-implicit-extensibility no-inherit-appendable)
+  idlc_generate(TARGET XSpace FILES XSpace.idl XSpaceEnum.idl XSpaceEnumUnion.idl XSpaceMustUnderstand.idl XSpaceTypeConsistencyEnforcement.idl WARNINGS no-implicit-extensibility no-inherit-appendable)
   idlc_generate(TARGET XSpaceNoTypeInfo FILES XSpaceNoTypeInfo.idl NO_TYPE_INFO WARNINGS no-implicit-extensibility)
   idlc_generate(TARGET TypeBuilderTypes FILES TypeBuilderTypes.idl WARNINGS no-implicit-extensibility no-inherit-appendable)
   idlc_generate(TARGET DynamicTypeTypes FILES DynamicTypeTypes.idl)

--- a/src/core/ddsc/tests/CdrStreamTryconstruct.idl
+++ b/src/core/ddsc/tests/CdrStreamTryconstruct.idl
@@ -72,4 +72,22 @@ module CdrStreamTryconstruct {
     @try_construct(USE_DEFAULT) sequence<@try_construct(USE_DEFAULT) sequence<unsigned long, 3>, 3> f9;
     string f10;
   };
+
+  @final @bit_bound(8) bitmask bmf {
+    BMF0,
+    BMF1
+  };
+
+  @appendable @bit_bound(8) bitmask bma {
+    BMA0,
+    BMA1
+  };
+
+  @final struct t8 {
+    @try_construct(DISCARD) bmf f1;
+    @try_construct(USE_DEFAULT) bmf f2;
+    @try_construct(DISCARD) bma f3;
+    @try_construct(USE_DEFAULT) bma f4;
+    string f5;
+  };
 };

--- a/src/core/ddsc/tests/TypeBuilderTypes.idl
+++ b/src/core/ddsc/tests/TypeBuilderTypes.idl
@@ -693,8 +693,8 @@ module TypeBuilderTypes {
   @bit_bound(16)
   enum en59 {
     EN59_0,
-    @value(65000) EN59_65000,
-    EN59_65001
+    @value(-32000) EN59_NEG32000,
+    EN59_NEG31999
   };
 
   @mutable

--- a/src/core/ddsc/tests/TypeBuilderTypes.idl
+++ b/src/core/ddsc/tests/TypeBuilderTypes.idl
@@ -689,4 +689,97 @@ module TypeBuilderTypes {
     @id(1) @must_understand sequence<sequence<long> > f1;
     @id(2) @must_understand sequence<long> f2[2];
   };
+
+  @bit_bound(16)
+  enum en59 {
+    EN59_0,
+    @value(65000) EN59_65000,
+    EN59_65001
+  };
+
+  @mutable
+  struct t59 {
+    @id(1) long before;
+    @id(2) en59 scalar;
+    @id(3) long between;
+    @id(4) en59 arr[2];
+    @id(5) sequence<en59, 2> seq;
+    @id(6) long after;
+  };
+
+  @nested @mutable
+  struct t60_base {
+    @id(1) long base_member;
+  };
+
+  @mutable
+  struct t60 : t60_base {
+    @id(2) en59 scalar;
+    @id(3) long after;
+  };
+
+  /* enum value metadata for a nested sequence element */
+  enum en61 {
+    @value(1) EN61_1,
+    @default_literal
+    EN61_2,
+    EN61_3,
+    EN61_4,
+    @value(6) EN61_6,
+    EN61_7,
+    EN61_8,
+    @value(14) EN61_14,
+    EN61_15,
+    EN61_16,
+    EN61_17,
+    EN61_18,
+    EN61_19
+  };
+
+  typedef sequence<sequence<en61>, 10> t61_seq_en;
+
+  typedef sequence<sequence<long, 6> > t61_seq_long;
+
+  typedef char t61_char_arr[2];
+
+  @appendable
+  struct t61 {
+    @key
+    float f1;
+    sequence<t61_char_arr, 17> f2;
+    t61_seq_long f3[3][1];
+    string f4[1][2];
+    long f5;
+    sequence<octet, 12> f6;
+    @optional
+    t61_seq_en f7;
+  };
+
+  /* enum value metadata for a union case sequence element */
+  enum en62 {
+    EN62_1,
+    @default_literal
+    EN62_2,
+    EN62_3,
+    @value(6) EN62_6,
+    EN62_7
+  };
+
+  @nested
+  union t62_union switch(long) {
+    case 1:
+      sequence<long> f1;
+    case 2:
+      string f2;
+    case 3:
+      sequence<en62> f3;
+    case 4:
+      string<16> f4;
+    default:
+      string<24> f5;
+  };
+
+  struct t62 {
+    sequence<t62_union, 8> f1;
+  };
 };

--- a/src/core/ddsc/tests/XSpaceEnum.idl
+++ b/src/core/ddsc/tests/XSpaceEnum.idl
@@ -44,3 +44,29 @@ module XSpaceEnumLabel {
   @final struct wr1_5 { enum_f_label f1; };
   @final struct wr2_5 { enum_a_label f1; };
 };
+
+module XSpaceBitmask {
+  @final @bit_bound(8) bitmask bm_f { BMF0, BMF1 };
+  @appendable @bit_bound(8) bitmask bm_a { BMA0, BMA1 };
+
+  @final @bit_bound(8) bitmask bm_f_plus { BMFP0, BMFP1, BMFP2 };
+  @appendable @bit_bound(8) bitmask bm_a_plus { BMAP0, BMAP1, BMAP2 };
+
+  @final @bit_bound(8) bitmask bm_f_min { BMFM0 };
+  @appendable @bit_bound(8) bitmask bm_a_min { BMAM0 };
+
+  @final @bit_bound(16) bitmask bm_f_wide { BMFW0, BMFW1 };
+  @appendable @bit_bound(16) bitmask bm_a_wide { BMAW0, BMAW1 };
+
+  @final struct rd_f { bm_f f1; };
+  @final struct rd_a { bm_a f1; };
+
+  @final struct wr_f { bm_f f1; };
+  @final struct wr_a { bm_a f1; };
+  @final struct wr_f_plus { bm_f_plus f1; };
+  @final struct wr_a_plus { bm_a_plus f1; };
+  @final struct wr_f_min { bm_f_min f1; };
+  @final struct wr_a_min { bm_a_min f1; };
+  @final struct wr_f_wide { bm_f_wide f1; };
+  @final struct wr_a_wide { bm_a_wide f1; };
+};

--- a/src/core/ddsc/tests/XSpaceEnumUnion.idl
+++ b/src/core/ddsc/tests/XSpaceEnumUnion.idl
@@ -1,0 +1,81 @@
+// Copyright(c) 2006 to 2026 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+module XSpaceEnumUnionRd {
+  @appendable enum e { A, B };
+  @bit_bound(8) bitmask bm { B0, B1 };
+
+  @appendable union explicit_default_string switch (@try_construct(USE_DEFAULT) e) {
+    case A: @id(0) long a;
+    default: @id(20) string s;
+  };
+
+  @appendable union explicit_long switch (@try_construct(USE_DEFAULT) e) {
+    case A: @id(0) long a;
+    case B: @id(1) long b;
+  };
+
+  @appendable union bitmask_uint_default_long switch (@try_construct(USE_DEFAULT) bm) {
+    case 0: @id(0) long z;
+    case B0: @id(1) long a;
+  };
+};
+
+module XSpaceEnumUnionWr {
+  @appendable enum e { A, B, C };
+  @bit_bound(8) bitmask bm { B0, B1, B2 };
+
+  @appendable union extra_explicit_long switch (e) {
+    case A: @id(0) long a;
+    case C: @id(10) long c;
+  };
+
+  @appendable union extra_explicit_string switch (e) {
+    case A: @id(0) long a;
+    case C: @id(10) string c;
+  };
+
+  @appendable union extra_implicit_none switch (e) {
+    case A: @id(0) long a;
+  };
+
+  @appendable union extra_default_long switch (e) {
+    case A: @id(0) long a;
+    default: @id(10) long x;
+  };
+
+  @appendable union extra_default_string switch (e) {
+    case A: @id(0) long a;
+    case B: @id(1) long b;
+    default: @id(10) string x;
+  };
+
+  @appendable union uint8_default_long switch (uint8) {
+    case 0: @id(0) long z;
+    case 1: @id(1) long a;
+    default: @id(10) long x;
+  };
+
+  @appendable union uint8_default_string switch (uint8) {
+    case 0: @id(0) long z;
+    case 1: @id(1) long a;
+    default: @id(10) string x;
+  };
+
+  @appendable union bitmask_implicit_none switch (bm) {
+    case 0: @id(0) long z;
+    case B0: @id(1) long a;
+  };
+
+  @appendable union uint8_implicit_none switch (uint8) {
+    case 0: @id(0) long z;
+    case 1: @id(1) long a;
+  };
+};

--- a/src/core/ddsc/tests/cdrstream.c
+++ b/src/core/ddsc/tests/cdrstream.c
@@ -1798,10 +1798,11 @@ typedef struct CdrStreamEnumMeta {
   uint32_t e;
 } CdrStreamEnumMeta;
 
-#define CDRSTREAM_ENUM_META_INSN (DDS_OP_ADR | DDS_OP_TYPE_ENU | DDS_OP_FLAG_TYPE_TC_DEF | (2u << DDS_OP_FLAG_SZ_SHIFT))
+#define CDRSTREAM_ENUM_META_INSN32 (DDS_OP_ADR | DDS_OP_TYPE_ENU | DDS_OP_FLAG_TYPE_TC_DEF | (2u << DDS_OP_FLAG_SZ_SHIFT))
+#define CDRSTREAM_ENUM_META_INSN8 (DDS_OP_ADR | DDS_OP_TYPE_ENU | DDS_OP_FLAG_TYPE_TC_DEF | (0u << DDS_OP_FLAG_SZ_SHIFT))
 
 static const uint32_t CdrStreamEnumMeta_ops[] = {
-  CDRSTREAM_ENUM_META_INSN, offsetof (CdrStreamEnumMeta, e), UINT32_MAX,
+  CDRSTREAM_ENUM_META_INSN32, offsetof (CdrStreamEnumMeta, e), UINT32_MAX,
   DDS_OP_RTS,
   DDS_OP_EVS | 0u, 3u, 3u, 1u, 3u, UINT32_MAX,
   DDS_OP_RTS,
@@ -1810,7 +1811,7 @@ static const uint32_t CdrStreamEnumMeta_ops[] = {
 };
 
 static const uint32_t CdrStreamEnumMetaKey_ops[] = {
-  CDRSTREAM_ENUM_META_INSN | DDS_OP_FLAG_KEY, offsetof (CdrStreamEnumMeta, e), UINT32_MAX,
+  CDRSTREAM_ENUM_META_INSN32 | DDS_OP_FLAG_KEY, offsetof (CdrStreamEnumMeta, e), UINT32_MAX,
   DDS_OP_RTS,
   DDS_OP_EVS | 0u, 3u, 3u, 1u, 3u, UINT32_MAX,
   DDS_OP_RTS,
@@ -1832,7 +1833,25 @@ static const uint32_t CdrStreamEnumMetaReject_ops[] = {
 };
 
 static const uint32_t CdrStreamEnumMetaOld_ops[] = {
-  CDRSTREAM_ENUM_META_INSN, offsetof (CdrStreamEnumMeta, e), UINT32_MAX,
+  CDRSTREAM_ENUM_META_INSN32, offsetof (CdrStreamEnumMeta, e), UINT32_MAX,
+  DDS_OP_RTS
+};
+
+static const uint32_t CdrStreamEnumMeta8_ops[] = {
+  CDRSTREAM_ENUM_META_INSN8, offsetof (CdrStreamEnumMeta, e), UINT32_MAX,
+  DDS_OP_RTS,
+  DDS_OP_EVS | 0u, UINT32_MAX, 1u, 0xffu,
+  DDS_OP_RTS,
+  DDS_OP_EVM | 0u, 0u,
+  DDS_OP_RTS
+};
+
+static const uint32_t CdrStreamEnumMeta8Key_ops[] = {
+  CDRSTREAM_ENUM_META_INSN8 | DDS_OP_FLAG_KEY, offsetof (CdrStreamEnumMeta, e), UINT32_MAX,
+  DDS_OP_RTS,
+  DDS_OP_EVS | 0u, UINT32_MAX, 1u, 0xffu,
+  DDS_OP_RTS,
+  DDS_OP_EVM | 0u, 0u,
   DDS_OP_RTS
 };
 
@@ -1864,7 +1883,7 @@ typedef struct CdrStreamEnumUnionDefaultMeta {
 static const uint32_t CdrStreamEnumAppendableDefaultMeta_ops[] = {
   DDS_OP_DLC,
   DDS_OP_ADR | DDS_OP_TYPE_4BY, offsetof (CdrStreamEnumAppendableDefaultMeta, a),
-  CDRSTREAM_ENUM_META_INSN, offsetof (CdrStreamEnumAppendableDefaultMeta, e), UINT32_MAX,
+  CDRSTREAM_ENUM_META_INSN32, offsetof (CdrStreamEnumAppendableDefaultMeta, e), UINT32_MAX,
   DDS_OP_RTS,
   DDS_OP_EVS | 0u, 3u, 3u, 1u, 3u, UINT32_MAX,
   DDS_OP_RTS,
@@ -1874,7 +1893,7 @@ static const uint32_t CdrStreamEnumAppendableDefaultMeta_ops[] = {
 
 static const uint32_t CdrStreamEnumAppendableDefaultMetaKey_ops[] = {
   DDS_OP_DLC,
-  CDRSTREAM_ENUM_META_INSN | DDS_OP_FLAG_KEY, offsetof (CdrStreamEnumMeta, e), UINT32_MAX,
+  CDRSTREAM_ENUM_META_INSN32 | DDS_OP_FLAG_KEY, offsetof (CdrStreamEnumMeta, e), UINT32_MAX,
   DDS_OP_RTS,
   DDS_OP_KOF | 1u, 1u,
   DDS_OP_EVS | 0u, 3u, 3u, 1u, 3u, UINT32_MAX,
@@ -1901,7 +1920,7 @@ static const uint32_t CdrStreamEnumMutableDefaultMeta_ops[] = {
   DDS_OP_PLC,
   DDS_OP_PLM | 3u, 7u,
   DDS_OP_RTS,
-  CDRSTREAM_ENUM_META_INSN, offsetof (CdrStreamEnumMeta, e), UINT32_MAX,
+  CDRSTREAM_ENUM_META_INSN32, offsetof (CdrStreamEnumMeta, e), UINT32_MAX,
   DDS_OP_RTS,
   DDS_OP_EVS | 0u, 3u, 3u, 1u, 3u, UINT32_MAX,
   DDS_OP_RTS,
@@ -1913,7 +1932,7 @@ static const uint32_t CdrStreamEnumMutableDefaultMetaKey_ops[] = {
   DDS_OP_PLC,
   DDS_OP_PLM | 3u, 7u,
   DDS_OP_RTS,
-  CDRSTREAM_ENUM_META_INSN | DDS_OP_FLAG_KEY, offsetof (CdrStreamEnumMeta, e), UINT32_MAX,
+  CDRSTREAM_ENUM_META_INSN32 | DDS_OP_FLAG_KEY, offsetof (CdrStreamEnumMeta, e), UINT32_MAX,
   DDS_OP_RTS,
   DDS_OP_KOF | 1u, 4u,
   DDS_OP_EVS | 0u, 3u, 3u, 1u, 3u, UINT32_MAX,
@@ -1932,6 +1951,18 @@ static const uint32_t CdrStreamEnumUnionAppendableDefaultMeta_ops[] = {
   DDS_OP_JEQ4 | DDS_OP_TYPE_ENU | DDS_OP_FLAG_TYPE_TC_DEF | (2u << DDS_OP_FLAG_SZ_SHIFT), 3u, offsetof (CdrStreamEnumUnionDefaultMeta, u.e), UINT32_MAX,
   DDS_OP_RTS,
   DDS_OP_EVS | 0u, 3u, 3u, 1u, 3u, UINT32_MAX,
+  DDS_OP_RTS,
+  DDS_OP_EVM | 1u, 0u,
+  DDS_OP_EVM | 6u, 0u,
+  DDS_OP_RTS
+};
+
+static const uint32_t CdrStreamEnumUnionAppendableNegativeDefaultMeta_ops[] = {
+  DDS_OP_DLC,
+  DDS_OP_ADR | DDS_OP_TYPE_UNI | DDS_OP_SUBTYPE_ENU | DDS_OP_FLAG_SUBTYPE_TC_DEF | (0u << DDS_OP_FLAG_SZ_SHIFT), offsetof (CdrStreamEnumUnionDefaultMeta, d), 1u, (9u << 16u) + 5u, UINT32_MAX,
+  DDS_OP_JEQ4 | DDS_OP_TYPE_ENU | DDS_OP_FLAG_TYPE_TC_DEF | (0u << DDS_OP_FLAG_SZ_SHIFT), 0xffu, offsetof (CdrStreamEnumUnionDefaultMeta, u.e), UINT32_MAX,
+  DDS_OP_RTS,
+  DDS_OP_EVS | 0u, UINT32_MAX, 1u, 0xffu,
   DDS_OP_RTS,
   DDS_OP_EVM | 1u, 0u,
   DDS_OP_EVM | 6u, 0u,
@@ -2159,6 +2190,90 @@ CU_Test (ddsc_cdrstream, write_enum_value_metadata)
   CU_ASSERT_FATAL (!ret);
 
   dds_ostreamBE_fini (&osbe, &dds_cdrstream_default_allocator);
+  dds_cdrstream_desc_fini (&desc, &dds_cdrstream_default_allocator);
+}
+
+CU_Test (ddsc_cdrstream, write_enum_value_metadata_8bit_signed)
+{
+  struct dds_cdrstream_desc desc;
+  dds_cdrstream_desc_init_with_nops (&desc, &dds_cdrstream_default_allocator, sizeof (CdrStreamEnumMeta), dds_alignof (CdrStreamEnumMeta), 0, CdrStreamEnumMeta8_ops, sizeof (CdrStreamEnumMeta8_ops) / sizeof (CdrStreamEnumMeta8_ops[0]), NULL, 0);
+
+  dds_ostream_t os;
+  dds_ostream_init (&os, &dds_cdrstream_default_allocator, 0, DDSI_RTPS_CDR_ENC_VERSION_2);
+
+  CdrStreamEnumMeta sample = { .e = UINT32_MAX };
+  bool ret = dds_stream_write_sample (&os, &dds_cdrstream_default_allocator, &sample, &desc);
+  const uint8_t expected[] = { 0xffu };
+  CU_ASSERT_FATAL (ret);
+  CU_ASSERT_MEMEQ_FATAL (os.m_buffer, os.m_index, expected, sizeof (expected));
+
+  os.m_index = 0;
+  sample.e = 0xffu;
+  ret = dds_stream_write_sample (&os, &dds_cdrstream_default_allocator, &sample, &desc);
+  CU_ASSERT_FATAL (!ret);
+
+  dds_ostream_fini (&os, &dds_cdrstream_default_allocator);
+
+  dds_ostreamBE_t osbe;
+  dds_ostreamBE_init (&osbe, &dds_cdrstream_default_allocator, 0, DDSI_RTPS_CDR_ENC_VERSION_2);
+
+  sample.e = UINT32_MAX;
+  ret = dds_stream_write_sampleBE (&osbe, &dds_cdrstream_default_allocator, &sample, &desc);
+  CU_ASSERT_FATAL (ret);
+  CU_ASSERT_MEMEQ_FATAL (osbe.x.m_buffer, osbe.x.m_index, expected, sizeof (expected));
+
+  osbe.x.m_index = 0;
+  sample.e = 0xffu;
+  ret = dds_stream_write_sampleBE (&osbe, &dds_cdrstream_default_allocator, &sample, &desc);
+  CU_ASSERT_FATAL (!ret);
+
+  dds_ostreamBE_fini (&osbe, &dds_cdrstream_default_allocator);
+  dds_cdrstream_desc_fini (&desc, &dds_cdrstream_default_allocator);
+}
+
+CU_Test (ddsc_cdrstream, read_enum_value_metadata_8bit_signed)
+{
+  struct dds_cdrstream_desc desc;
+  dds_cdrstream_desc_init_with_nops (&desc, &dds_cdrstream_default_allocator, sizeof (CdrStreamEnumMeta), dds_alignof (CdrStreamEnumMeta), 0, CdrStreamEnumMeta8_ops, sizeof (CdrStreamEnumMeta8_ops) / sizeof (CdrStreamEnumMeta8_ops[0]), NULL, 0);
+
+  ALIGNED_CDR_BUFFER_INIT (cdr, 0xffu);
+  CdrStreamEnumMeta sample = { .e = 0u };
+  dds_istream_t is;
+  dds_istream_init (&is, sizeof (cdr.data), cdr.data, DDSI_RTPS_CDR_ENC_VERSION_2);
+  dds_stream_read_sample (&is, &sample, &dds_cdrstream_default_allocator, &desc);
+
+  CU_ASSERT_EQ_FATAL (is.m_index, sizeof (cdr.data));
+  CU_ASSERT_EQ_FATAL (sample.e, UINT32_MAX);
+
+  dds_cdrstream_desc_fini (&desc, &dds_cdrstream_default_allocator);
+}
+
+CU_Test (ddsc_cdrstream, extract_enum_key_metadata_8bit_signed)
+{
+  struct dds_cdrstream_desc desc;
+  dds_cdrstream_desc_init_with_nops (&desc, &dds_cdrstream_default_allocator, sizeof (CdrStreamEnumMeta), dds_alignof (CdrStreamEnumMeta), 0, CdrStreamEnumMeta8Key_ops, sizeof (CdrStreamEnumMeta8Key_ops) / sizeof (CdrStreamEnumMeta8Key_ops[0]), CdrStreamEnumMeta_keys, 1);
+
+  ALIGNED_CDR_BUFFER_INIT (cdr, 0xffu);
+  const uint8_t expected[] = { 0xffu };
+  dds_istream_t is;
+  dds_ostream_t os;
+  dds_istream_init (&is, sizeof (cdr.data), cdr.data, DDSI_RTPS_CDR_ENC_VERSION_2);
+  dds_ostream_init (&os, &dds_cdrstream_default_allocator, 0, DDSI_RTPS_CDR_ENC_VERSION_2);
+  bool ret = dds_stream_extract_key_from_data (&is, &os, &dds_cdrstream_default_allocator, &desc);
+  CU_ASSERT_FATAL (ret);
+  CU_ASSERT_EQ_FATAL (is.m_index, sizeof (cdr.data));
+  CU_ASSERT_MEMEQ_FATAL (os.m_buffer, os.m_index, expected, sizeof (expected));
+  dds_ostream_fini (&os, &dds_cdrstream_default_allocator);
+
+  dds_ostreamBE_t osbe;
+  dds_istream_init (&is, sizeof (cdr.data), cdr.data, DDSI_RTPS_CDR_ENC_VERSION_2);
+  dds_ostreamBE_init (&osbe, &dds_cdrstream_default_allocator, 0, DDSI_RTPS_CDR_ENC_VERSION_2);
+  ret = dds_stream_extract_keyBE_from_data (&is, &osbe, &dds_cdrstream_default_allocator, &desc);
+  CU_ASSERT_FATAL (ret);
+  CU_ASSERT_EQ_FATAL (is.m_index, sizeof (cdr.data));
+  CU_ASSERT_MEMEQ_FATAL (osbe.x.m_buffer, osbe.x.m_index, expected, sizeof (expected));
+  dds_ostreamBE_fini (&osbe, &dds_cdrstream_default_allocator);
+
   dds_cdrstream_desc_fini (&desc, &dds_cdrstream_default_allocator);
 }
 
@@ -2519,6 +2634,32 @@ CU_Test (ddsc_cdrstream, normalize_read_union_discriminator_use_default)
   CU_ASSERT_EQ_FATAL (is.m_index, sizeof (final_cdr));
   CU_ASSERT_EQ_FATAL (sample.d, 3u);
   CU_ASSERT_EQ_FATAL (sample.u.e, 1u);
+
+  dds_cdrstream_desc_fini (&desc, &dds_cdrstream_default_allocator);
+}
+
+CU_Test (ddsc_cdrstream, normalize_read_union_negative_enum_discriminator_use_default)
+{
+  struct dds_cdrstream_desc desc;
+  dds_cdrstream_desc_init_with_nops (&desc, &dds_cdrstream_default_allocator, sizeof (CdrStreamEnumUnionDefaultMeta), dds_alignof (CdrStreamEnumUnionDefaultMeta), 0, CdrStreamEnumUnionAppendableNegativeDefaultMeta_ops, sizeof (CdrStreamEnumUnionAppendableNegativeDefaultMeta_ops) / sizeof (CdrStreamEnumUnionAppendableNegativeDefaultMeta_ops[0]), NULL, 0);
+  CU_ASSERT_FATAL (desc.member_ids.has_special_defaults);
+
+  ALIGNED_CDR_BUFFER_INIT (cdr, SER_DHEADER (2u), 0x00u, 0x00u);
+  uint32_t actual_size = 0;
+  enum dds_stream_normalize_result ret = dds_stream_normalize (cdr.data, sizeof (cdr.data), false, DDSI_RTPS_CDR_ENC_VERSION_2, &desc, false, &actual_size);
+  CU_ASSERT_EQ_FATAL (ret, DDS_STREAM_NORMALIZE_SUCCESS);
+  CU_ASSERT_EQ_FATAL (actual_size, sizeof (cdr.data));
+  CU_ASSERT_EQ_FATAL (cdr.data[4], 0xffu);
+  CU_ASSERT_EQ_FATAL (cdr.data[5], 0xffu);
+
+  CdrStreamEnumUnionDefaultMeta sample = { .d = 1u, .u = { .e = 99u } };
+  dds_istream_t is;
+  dds_istream_init (&is, sizeof (cdr.data), cdr.data, DDSI_RTPS_CDR_ENC_VERSION_2);
+  dds_stream_read_sample (&is, &sample, &dds_cdrstream_default_allocator, &desc);
+
+  CU_ASSERT_EQ_FATAL (is.m_index, sizeof (cdr.data));
+  CU_ASSERT_EQ_FATAL (sample.d, UINT32_MAX);
+  CU_ASSERT_EQ_FATAL (sample.u.e, UINT32_MAX);
 
   dds_cdrstream_desc_fini (&desc, &dds_cdrstream_default_allocator);
 }

--- a/src/core/ddsc/tests/cdrstream.c
+++ b/src/core/ddsc/tests/cdrstream.c
@@ -3616,6 +3616,13 @@ static bool eq_CdrStreamTryconstruct_t6 (const void *va, const void *vb)
   return eq_CdrStreamTryconstruct_t456 (va, vb);
 }
 
+static bool eq_CdrStreamTryconstruct_t8 (const void *va, const void *vb)
+{
+  const CdrStreamTryconstruct_t8 *a = va;
+  const CdrStreamTryconstruct_t8 *b = vb;
+  return a->f1 == b->f1 && a->f2 == b->f2 && a->f3 == b->f3 && a->f4 == b->f4 && strcmp (a->f5, b->f5) == 0;
+}
+
 #define D(n) (&CdrStreamTryconstruct_##n##_desc), eq_CdrStreamTryconstruct_##n
 #define X(n, ...) (&(CdrStreamTryconstruct_##n){ __VA_ARGS__ })
 #define X_ERROR ((const void *) 1)
@@ -3719,6 +3726,12 @@ CU_Test (ddsc_cdrstream, tryconstruct)
     { D(t6), X(t6, CSEQ0, CSEQ0, CSEQ0, CSEQ0, CSEQ0, "6j"), // f5 w oversize str beyond bound
       CDR(DHDR(32,0), DHDR(32,0), DHDR(32,0), DHDR(32,0), DHDR(32,4, STR('a'),PAD2,STR('b'),PAD2,STR('c'),PAD2,STR('a','b','c','d')),
           PAD3, STR('6','j')) },
+    // t8 (bitmask try-construct)
+    { D(t8), X(t8, 1,2,1,2,"8a"), CDR(8,1, 8,2, 8,1, 8,2, STR('8','a')) },
+    { D(t8), X_DISCARD, CDR(8,4, 8,2, 8,1, 8,2, STR('8','b')) }, // final bitmask f1 -> discard
+    { D(t8), X(t8, 1,0,1,2,"8c"), CDR(8,1, 8,4, 8,1, 8,2, STR('8','c')) }, // final bitmask f2 -> use_default
+    { D(t8), X_DISCARD, CDR(8,1, 8,2, 8,4, 8,2, STR('8','d')) }, // appendable bitmask f3 -> discard
+    { D(t8), X(t8, 1,2,1,0,"8e"), CDR(8,1, 8,2, 8,1, 8,4, STR('8','e')) }, // appendable bitmask f4 -> use_default
   };
 
   for (uint32_t i = 0; i < sizeof (tests) / sizeof (tests[0]); i++)

--- a/src/core/ddsc/tests/cdrstream.c
+++ b/src/core/ddsc/tests/cdrstream.c
@@ -90,6 +90,9 @@
 #define COMMA() ,
 #define SERSIZE(...) ((DDSRT_FOREACH_PAIR_WRAP (FIRST, PLUS, __VA_ARGS__)) / 8)
 #define CDR(...) SERSIZE(__VA_ARGS__), (uint8_t[]){ DDSRT_FOREACH_PAIR_WRAP (MAKE_SER, COMMA, __VA_ARGS__) }
+#define ALIGNED_CDR_BUFFER(name_, size_) struct { uint32_t align; uint8_t data[size_]; } name_
+#define ALIGNED_CDR_BUFFER_INIT(name_, ...) \
+  ALIGNED_CDR_BUFFER (name_, sizeof ((uint8_t[]){ __VA_ARGS__ })) = { 0u, { __VA_ARGS__ } }
 
 #define PHDR(pid,plen) 16,(pid),16,(plen)
 #define PHDR_EXT(pid,plen) PHDR(DDS_XCDR1_PL_SHORT_PID_EXTENDED | DDS_XCDR1_PL_SHORT_FLAG_MU, 8), 32,(pid), 32,(plen)
@@ -1869,6 +1872,21 @@ static const uint32_t CdrStreamEnumAppendableDefaultMeta_ops[] = {
   DDS_OP_RTS
 };
 
+static const uint32_t CdrStreamEnumAppendableDefaultMetaKey_ops[] = {
+  DDS_OP_DLC,
+  CDRSTREAM_ENUM_META_INSN | DDS_OP_FLAG_KEY, offsetof (CdrStreamEnumMeta, e), UINT32_MAX,
+  DDS_OP_RTS,
+  DDS_OP_KOF | 1u, 1u,
+  DDS_OP_EVS | 0u, 3u, 3u, 1u, 3u, UINT32_MAX,
+  DDS_OP_RTS,
+  DDS_OP_EVM | 1u, 0u,
+  DDS_OP_RTS
+};
+
+static const dds_key_descriptor_t CdrStreamEnumAppendableDefaultMetaKey_keys[] = {
+  { .m_name = "e", .m_offset = 5u, .m_idx = 0u }
+};
+
 static const uint32_t CdrStreamEnumArrayAppendableDefaultMeta_ops[] = {
   DDS_OP_DLC,
   DDS_OP_ADR | DDS_OP_TYPE_ARR | DDS_OP_SUBTYPE_ENU | DDS_OP_FLAG_SUBTYPE_TC_DEF | (2u << DDS_OP_FLAG_SZ_SHIFT), offsetof (CdrStreamEnumArrayMeta, e), 3u, UINT32_MAX,
@@ -1889,6 +1907,23 @@ static const uint32_t CdrStreamEnumMutableDefaultMeta_ops[] = {
   DDS_OP_RTS,
   DDS_OP_EVM | 4u, 0u,
   DDS_OP_RTS
+};
+
+static const uint32_t CdrStreamEnumMutableDefaultMetaKey_ops[] = {
+  DDS_OP_PLC,
+  DDS_OP_PLM | 3u, 7u,
+  DDS_OP_RTS,
+  CDRSTREAM_ENUM_META_INSN | DDS_OP_FLAG_KEY, offsetof (CdrStreamEnumMeta, e), UINT32_MAX,
+  DDS_OP_RTS,
+  DDS_OP_KOF | 1u, 4u,
+  DDS_OP_EVS | 0u, 3u, 3u, 1u, 3u, UINT32_MAX,
+  DDS_OP_RTS,
+  DDS_OP_EVM | 4u, 0u,
+  DDS_OP_RTS
+};
+
+static const dds_key_descriptor_t CdrStreamEnumMutableDefaultMetaKey_keys[] = {
+  { .m_name = "e", .m_offset = 8u, .m_idx = 0u }
 };
 
 static const uint32_t CdrStreamEnumUnionAppendableDefaultMeta_ops[] = {
@@ -2075,6 +2110,282 @@ CU_Test (ddsc_cdrstream, check_normalize_generated_enum_value_metadata)
   ret = dds_stream_normalize (invalid_union_field, sizeof (invalid_union_field), false, DDSI_RTPS_CDR_ENC_VERSION_2, &desc, false, &actual_size);
   CU_ASSERT_EQ_FATAL (ret, DDS_STREAM_NORMALIZE_ERROR);
 
+  dds_cdrstream_desc_fini (&desc, &dds_cdrstream_default_allocator);
+}
+
+CU_Test (ddsc_cdrstream, write_enum_value_metadata)
+{
+  struct dds_cdrstream_desc desc;
+  dds_cdrstream_desc_init_with_nops (&desc, &dds_cdrstream_default_allocator, sizeof (CdrStreamEnumMeta), dds_alignof (CdrStreamEnumMeta), 0, CdrStreamEnumMeta_ops, sizeof (CdrStreamEnumMeta_ops) / sizeof (CdrStreamEnumMeta_ops[0]), NULL, 0);
+
+  CU_ASSERT_EQ_FATAL (dds_stream_check_optimize (&desc, XCDR1), 0u);
+  CU_ASSERT_EQ_FATAL (dds_stream_check_optimize (&desc, XCDR2), 0u);
+
+  dds_ostream_t os;
+  dds_ostream_init (&os, &dds_cdrstream_default_allocator, 0, DDSI_RTPS_CDR_ENC_VERSION_2);
+
+  CdrStreamEnumMeta sample = { .e = 3u };
+  bool ret = dds_stream_write_sample (&os, &dds_cdrstream_default_allocator, &sample, &desc);
+  const uint8_t expected_3[] = { SER32 (3u) };
+  CU_ASSERT_FATAL (ret);
+  CU_ASSERT_MEMEQ_FATAL (os.m_buffer, os.m_index, expected_3, sizeof (expected_3));
+
+  os.m_index = 0;
+  sample.e = UINT32_MAX;
+  ret = dds_stream_write_sample (&os, &dds_cdrstream_default_allocator, &sample, &desc);
+  const uint8_t expected_max[] = { SER32 (UINT32_MAX) };
+  CU_ASSERT_FATAL (ret);
+  CU_ASSERT_MEMEQ_FATAL (os.m_buffer, os.m_index, expected_max, sizeof (expected_max));
+
+  os.m_index = 0;
+  sample.e = 2u;
+  ret = dds_stream_write_sample (&os, &dds_cdrstream_default_allocator, &sample, &desc);
+  CU_ASSERT_FATAL (!ret);
+
+  dds_ostream_fini (&os, &dds_cdrstream_default_allocator);
+
+  dds_ostreamBE_t osbe;
+  dds_ostreamBE_init (&osbe, &dds_cdrstream_default_allocator, 0, DDSI_RTPS_CDR_ENC_VERSION_2);
+
+  sample.e = 3u;
+  ret = dds_stream_write_sampleBE (&osbe, &dds_cdrstream_default_allocator, &sample, &desc);
+  const uint8_t expected_3_be[] = { SER32BE (3u) };
+  CU_ASSERT_FATAL (ret);
+  CU_ASSERT_MEMEQ_FATAL (osbe.x.m_buffer, osbe.x.m_index, expected_3_be, sizeof (expected_3_be));
+
+  osbe.x.m_index = 0;
+  sample.e = 2u;
+  ret = dds_stream_write_sampleBE (&osbe, &dds_cdrstream_default_allocator, &sample, &desc);
+  CU_ASSERT_FATAL (!ret);
+
+  dds_ostreamBE_fini (&osbe, &dds_cdrstream_default_allocator);
+  dds_cdrstream_desc_fini (&desc, &dds_cdrstream_default_allocator);
+}
+
+CU_Test (ddsc_cdrstream, write_enum_mutable_value_metadata)
+{
+  struct dds_cdrstream_desc desc;
+  dds_cdrstream_desc_init_with_nops (&desc, &dds_cdrstream_default_allocator, sizeof (CdrStreamEnumMeta), dds_alignof (CdrStreamEnumMeta), 0, CdrStreamEnumMutableDefaultMeta_ops, sizeof (CdrStreamEnumMutableDefaultMeta_ops) / sizeof (CdrStreamEnumMutableDefaultMeta_ops[0]), NULL, 0);
+
+  dds_ostream_t os;
+  dds_ostream_init (&os, &dds_cdrstream_default_allocator, 0, DDSI_RTPS_CDR_ENC_VERSION_2);
+
+  CdrStreamEnumMeta sample = { .e = 3u };
+  bool ret = dds_stream_write_sample (&os, &dds_cdrstream_default_allocator, &sample, &desc);
+  const uint8_t expected[] = { SER_DHEADER (8u), SER_EMHEADER (0, 2, 7), SER32 (3u) };
+  CU_ASSERT_FATAL (ret);
+  CU_ASSERT_MEMEQ_FATAL (os.m_buffer, os.m_index, expected, sizeof (expected));
+
+  os.m_index = 0;
+  sample.e = 2u;
+  ret = dds_stream_write_sample (&os, &dds_cdrstream_default_allocator, &sample, &desc);
+  CU_ASSERT_FATAL (!ret);
+  dds_ostream_fini (&os, &dds_cdrstream_default_allocator);
+
+  dds_ostreamBE_t osbe;
+  dds_ostreamBE_init (&osbe, &dds_cdrstream_default_allocator, 0, DDSI_RTPS_CDR_ENC_VERSION_2);
+
+  sample.e = 3u;
+  ret = dds_stream_write_sampleBE (&osbe, &dds_cdrstream_default_allocator, &sample, &desc);
+  const uint8_t expected_be[] = { SER_DHEADERBE (8u), SER32BE ((2u << 28) | 7u), SER32BE (3u) };
+  CU_ASSERT_FATAL (ret);
+  CU_ASSERT_MEMEQ_FATAL (osbe.x.m_buffer, osbe.x.m_index, expected_be, sizeof (expected_be));
+
+  osbe.x.m_index = 0;
+  sample.e = 2u;
+  ret = dds_stream_write_sampleBE (&osbe, &dds_cdrstream_default_allocator, &sample, &desc);
+  CU_ASSERT_FATAL (!ret);
+
+  dds_ostreamBE_fini (&osbe, &dds_cdrstream_default_allocator);
+  dds_cdrstream_desc_fini (&desc, &dds_cdrstream_default_allocator);
+}
+
+CU_Test (ddsc_cdrstream, write_enum_value_metadata_old_descriptor)
+{
+  struct dds_cdrstream_desc desc;
+  dds_cdrstream_desc_init_with_nops (&desc, &dds_cdrstream_default_allocator, sizeof (CdrStreamEnumMeta), dds_alignof (CdrStreamEnumMeta), 0, CdrStreamEnumMetaOld_ops, sizeof (CdrStreamEnumMetaOld_ops) / sizeof (CdrStreamEnumMetaOld_ops[0]), NULL, 0);
+
+  dds_ostream_t os;
+  dds_ostream_init (&os, &dds_cdrstream_default_allocator, 0, DDSI_RTPS_CDR_ENC_VERSION_2);
+
+  CdrStreamEnumMeta sample = { .e = 2u };
+  const bool ret = dds_stream_write_sample (&os, &dds_cdrstream_default_allocator, &sample, &desc);
+  const uint8_t expected[] = { SER32 (2u) };
+  CU_ASSERT_FATAL (ret);
+  CU_ASSERT_MEMEQ_FATAL (os.m_buffer, os.m_index, expected, sizeof (expected));
+
+  dds_ostream_fini (&os, &dds_cdrstream_default_allocator);
+  dds_cdrstream_desc_fini (&desc, &dds_cdrstream_default_allocator);
+}
+
+CU_Test (ddsc_cdrstream, write_enum_array_value_metadata)
+{
+  struct dds_cdrstream_desc desc;
+  dds_cdrstream_desc_init_with_nops (&desc, &dds_cdrstream_default_allocator, sizeof (CdrStreamEnumArrayMeta), dds_alignof (CdrStreamEnumArrayMeta), 0, CdrStreamEnumArrayMeta_ops, sizeof (CdrStreamEnumArrayMeta_ops) / sizeof (CdrStreamEnumArrayMeta_ops[0]), NULL, 0);
+
+  dds_ostream_t os;
+  dds_ostream_init (&os, &dds_cdrstream_default_allocator, 0, DDSI_RTPS_CDR_ENC_VERSION_2);
+
+  CdrStreamEnumArrayMeta sample = { .e = { 1u, 3u, UINT32_MAX } };
+  bool ret = dds_stream_write_sample (&os, &dds_cdrstream_default_allocator, &sample, &desc);
+  const uint8_t expected[] = { SER_DHEADER (12u), SER32 (1u), SER32 (3u), SER32 (UINT32_MAX) };
+  CU_ASSERT_FATAL (ret);
+  CU_ASSERT_MEMEQ_FATAL (os.m_buffer, os.m_index, expected, sizeof (expected));
+
+  os.m_index = 0;
+  sample = (CdrStreamEnumArrayMeta) { .e = { 1u, 2u, 3u } };
+  ret = dds_stream_write_sample (&os, &dds_cdrstream_default_allocator, &sample, &desc);
+  CU_ASSERT_FATAL (!ret);
+
+  dds_ostream_fini (&os, &dds_cdrstream_default_allocator);
+  dds_cdrstream_desc_fini (&desc, &dds_cdrstream_default_allocator);
+}
+
+CU_Test (ddsc_cdrstream, write_enum_key_value_metadata)
+{
+  struct dds_cdrstream_desc desc;
+  dds_cdrstream_desc_init_with_nops (&desc, &dds_cdrstream_default_allocator, sizeof (CdrStreamEnumMeta), dds_alignof (CdrStreamEnumMeta), 0, CdrStreamEnumMetaKey_ops, sizeof (CdrStreamEnumMetaKey_ops) / sizeof (CdrStreamEnumMetaKey_ops[0]), CdrStreamEnumMeta_keys, 1);
+
+  dds_ostream_t os;
+  dds_ostream_init (&os, &dds_cdrstream_default_allocator, 0, DDSI_RTPS_CDR_ENC_VERSION_2);
+
+  CdrStreamEnumMeta sample = { .e = 3u };
+  bool ret = dds_stream_write_key (&os, DDS_CDR_KEY_SERIALIZATION_SAMPLE, &dds_cdrstream_default_allocator, (const char *) &sample, &desc);
+  const uint8_t expected[] = { SER32 (3u) };
+  CU_ASSERT_FATAL (ret);
+  CU_ASSERT_MEMEQ_FATAL (os.m_buffer, os.m_index, expected, sizeof (expected));
+
+  dds_istream_t is;
+  dds_ostream_t osk;
+  dds_istream_init (&is, os.m_index, os.m_buffer, os.m_xcdr_version);
+  dds_ostream_init (&osk, &dds_cdrstream_default_allocator, 0, DDSI_RTPS_CDR_ENC_VERSION_2);
+  ret = dds_stream_extract_key_from_data (&is, &osk, &dds_cdrstream_default_allocator, &desc);
+  CU_ASSERT_FATAL (ret);
+  CU_ASSERT_EQ_FATAL (is.m_index, is.m_size);
+  CU_ASSERT_MEMEQ_FATAL (osk.m_buffer, osk.m_index, expected, sizeof (expected));
+  dds_ostream_fini (&osk, &dds_cdrstream_default_allocator);
+
+  dds_istream_init (&is, os.m_index, os.m_buffer, os.m_xcdr_version);
+  dds_ostream_init (&osk, &dds_cdrstream_default_allocator, 0, DDSI_RTPS_CDR_ENC_VERSION_2);
+  dds_stream_extract_key_from_key (&is, &osk, DDS_CDR_KEY_SERIALIZATION_SAMPLE, &dds_cdrstream_default_allocator, &desc);
+  CU_ASSERT_EQ_FATAL (is.m_index, is.m_size);
+  CU_ASSERT_MEMEQ_FATAL (osk.m_buffer, osk.m_index, expected, sizeof (expected));
+  dds_ostream_fini (&osk, &dds_cdrstream_default_allocator);
+
+  os.m_index = 0;
+  sample.e = 2u;
+  ret = dds_stream_write_key (&os, DDS_CDR_KEY_SERIALIZATION_SAMPLE, &dds_cdrstream_default_allocator, (const char *) &sample, &desc);
+  CU_ASSERT_FATAL (!ret);
+
+  dds_ostream_fini (&os, &dds_cdrstream_default_allocator);
+
+  dds_ostreamBE_t osbe;
+  dds_ostreamBE_init (&osbe, &dds_cdrstream_default_allocator, 0, DDSI_RTPS_CDR_ENC_VERSION_2);
+
+  sample.e = 3u;
+  ret = dds_stream_write_keyBE (&osbe, DDS_CDR_KEY_SERIALIZATION_SAMPLE, &dds_cdrstream_default_allocator, (const char *) &sample, &desc);
+  const uint8_t expected_be[] = { SER32BE (3u) };
+  CU_ASSERT_FATAL (ret);
+  CU_ASSERT_MEMEQ_FATAL (osbe.x.m_buffer, osbe.x.m_index, expected_be, sizeof (expected_be));
+
+  osbe.x.m_index = 0;
+  sample.e = 2u;
+  ret = dds_stream_write_keyBE (&osbe, DDS_CDR_KEY_SERIALIZATION_SAMPLE, &dds_cdrstream_default_allocator, (const char *) &sample, &desc);
+  CU_ASSERT_FATAL (!ret);
+
+  dds_ostreamBE_fini (&osbe, &dds_cdrstream_default_allocator);
+  dds_cdrstream_desc_fini (&desc, &dds_cdrstream_default_allocator);
+}
+
+CU_Test (ddsc_cdrstream, extract_enum_key_default_metadata)
+{
+  const ALIGNED_CDR_BUFFER_INIT (appendable_default_key_cdr, SER_DHEADER (0u));
+  const ALIGNED_CDR_BUFFER_INIT (mutable_default_key_cdr, SER_DHEADER (0u));
+  struct test_cdr_data {
+    const uint8_t *data;
+    size_t size;
+  };
+  const struct {
+    const uint32_t *ops;
+    const dds_key_descriptor_t *keys;
+    struct test_cdr_data cdr;
+    struct test_cdr_data expected;
+    struct test_cdr_data expected_be;
+    size_t nops;
+  } tests[] = {
+    {
+      .ops = CdrStreamEnumAppendableDefaultMetaKey_ops,
+      .keys = CdrStreamEnumAppendableDefaultMetaKey_keys,
+      .cdr = { appendable_default_key_cdr.data, sizeof (appendable_default_key_cdr.data) },
+      .expected = { (const uint8_t[]) { SER_DHEADER (4u), SER32 (3u) }, 8u },
+      .expected_be = { (const uint8_t[]) { SER_DHEADERBE (4u), SER32BE (3u) }, 8u },
+      .nops = sizeof (CdrStreamEnumAppendableDefaultMetaKey_ops) / sizeof (CdrStreamEnumAppendableDefaultMetaKey_ops[0])
+    },
+    {
+      .ops = CdrStreamEnumMutableDefaultMetaKey_ops,
+      .keys = CdrStreamEnumMutableDefaultMetaKey_keys,
+      .cdr = { mutable_default_key_cdr.data, sizeof (mutable_default_key_cdr.data) },
+      .expected = { (const uint8_t[]) { SER_DHEADER (8u), SER_EMHEADER (0, 2, 7), SER32 (3u) }, 12u },
+      .expected_be = { (const uint8_t[]) { SER_DHEADERBE (8u), SER32BE ((2u << 28) | 7u), SER32BE (3u) }, 12u },
+      .nops = sizeof (CdrStreamEnumMutableDefaultMetaKey_ops) / sizeof (CdrStreamEnumMutableDefaultMetaKey_ops[0])
+    }
+  };
+
+  for (uint32_t i = 0; i < sizeof (tests) / sizeof (tests[0]); i++)
+  {
+    struct dds_cdrstream_desc desc;
+    const uint32_t cdrsize = (uint32_t) tests[i].cdr.size;
+    dds_cdrstream_desc_init_with_nops (&desc, &dds_cdrstream_default_allocator, sizeof (CdrStreamEnumMeta), dds_alignof (CdrStreamEnumMeta), 0, tests[i].ops, (uint32_t) tests[i].nops, tests[i].keys, 1);
+    CU_ASSERT_FATAL (desc.member_ids.has_special_defaults);
+
+    dds_istream_t is;
+    dds_ostream_t os;
+    dds_istream_init (&is, cdrsize, tests[i].cdr.data, DDSI_RTPS_CDR_ENC_VERSION_2);
+    dds_ostream_init (&os, &dds_cdrstream_default_allocator, 0, DDSI_RTPS_CDR_ENC_VERSION_2);
+    bool ret = dds_stream_extract_key_from_data (&is, &os, &dds_cdrstream_default_allocator, &desc);
+    CU_ASSERT_FATAL (ret);
+    CU_ASSERT_EQ_FATAL (is.m_index, is.m_size);
+    CU_ASSERT_MEMEQ_FATAL (os.m_buffer, os.m_index, tests[i].expected.data, tests[i].expected.size);
+    dds_ostream_fini (&os, &dds_cdrstream_default_allocator);
+
+    dds_ostreamBE_t osbe;
+    dds_istream_init (&is, cdrsize, tests[i].cdr.data, DDSI_RTPS_CDR_ENC_VERSION_2);
+    dds_ostreamBE_init (&osbe, &dds_cdrstream_default_allocator, 0, DDSI_RTPS_CDR_ENC_VERSION_2);
+    ret = dds_stream_extract_keyBE_from_data (&is, &osbe, &dds_cdrstream_default_allocator, &desc);
+    CU_ASSERT_FATAL (ret);
+    CU_ASSERT_EQ_FATAL (is.m_index, is.m_size);
+    CU_ASSERT_MEMEQ_FATAL (osbe.x.m_buffer, osbe.x.m_index, tests[i].expected_be.data, tests[i].expected_be.size);
+    dds_ostreamBE_fini (&osbe, &dds_cdrstream_default_allocator);
+
+    dds_cdrstream_desc_fini (&desc, &dds_cdrstream_default_allocator);
+  }
+}
+
+CU_Test (ddsc_cdrstream, write_enum_union_value_metadata)
+{
+  struct dds_cdrstream_desc desc;
+  dds_cdrstream_desc_init_with_nops (&desc, &dds_cdrstream_default_allocator, sizeof (CdrStreamEnumUnionDefaultMeta), dds_alignof (CdrStreamEnumUnionDefaultMeta), 0, CdrStreamEnumUnionAppendableDefaultMeta_ops, sizeof (CdrStreamEnumUnionAppendableDefaultMeta_ops) / sizeof (CdrStreamEnumUnionAppendableDefaultMeta_ops[0]), NULL, 0);
+
+  dds_ostream_t os;
+  dds_ostream_init (&os, &dds_cdrstream_default_allocator, 0, DDSI_RTPS_CDR_ENC_VERSION_2);
+
+  CdrStreamEnumUnionDefaultMeta sample = { .d = 3u, .u = { .e = 3u } };
+  bool ret = dds_stream_write_sample (&os, &dds_cdrstream_default_allocator, &sample, &desc);
+  const uint8_t expected[] = { SER_DHEADER (8u), SER32 (3u), SER32 (3u) };
+  CU_ASSERT_FATAL (ret);
+  CU_ASSERT_MEMEQ_FATAL (os.m_buffer, os.m_index, expected, sizeof (expected));
+
+  os.m_index = 0;
+  sample = (CdrStreamEnumUnionDefaultMeta) { .d = 2u, .u = { .e = 3u } };
+  ret = dds_stream_write_sample (&os, &dds_cdrstream_default_allocator, &sample, &desc);
+  CU_ASSERT_FATAL (!ret);
+
+  os.m_index = 0;
+  sample = (CdrStreamEnumUnionDefaultMeta) { .d = 3u, .u = { .e = 2u } };
+  ret = dds_stream_write_sample (&os, &dds_cdrstream_default_allocator, &sample, &desc);
+  CU_ASSERT_FATAL (!ret);
+
+  dds_ostream_fini (&os, &dds_cdrstream_default_allocator);
   dds_cdrstream_desc_fini (&desc, &dds_cdrstream_default_allocator);
 }
 

--- a/src/core/ddsc/tests/cdrstream.c
+++ b/src/core/ddsc/tests/cdrstream.c
@@ -1790,6 +1790,294 @@ CU_Test (ddsc_cdrstream, check_normalize_boolean)
 }
 #undef D
 
+typedef struct CdrStreamEnumMeta {
+  uint32_t e;
+} CdrStreamEnumMeta;
+
+#define CDRSTREAM_ENUM_META_INSN (DDS_OP_ADR | DDS_OP_TYPE_ENU | DDS_OP_FLAG_TYPE_TC_DEF | (2u << DDS_OP_FLAG_SZ_SHIFT))
+
+static const uint32_t CdrStreamEnumMeta_ops[] = {
+  CDRSTREAM_ENUM_META_INSN, offsetof (CdrStreamEnumMeta, e), UINT32_MAX,
+  DDS_OP_RTS,
+  DDS_OP_EVS | 0u, 3u, 3u, 1u, 3u, UINT32_MAX,
+  DDS_OP_RTS,
+  DDS_OP_EVM | 0u, 0u,
+  DDS_OP_RTS
+};
+
+static const uint32_t CdrStreamEnumMetaKey_ops[] = {
+  CDRSTREAM_ENUM_META_INSN | DDS_OP_FLAG_KEY, offsetof (CdrStreamEnumMeta, e), UINT32_MAX,
+  DDS_OP_RTS,
+  DDS_OP_EVS | 0u, 3u, 3u, 1u, 3u, UINT32_MAX,
+  DDS_OP_RTS,
+  DDS_OP_EVM | 0u, 0u,
+  DDS_OP_RTS
+};
+
+static const dds_key_descriptor_t CdrStreamEnumMeta_keys[] = {
+  { .m_name = "e", .m_offset = 0u, .m_idx = 0u }
+};
+
+static const uint32_t CdrStreamEnumMetaReject_ops[] = {
+  DDS_OP_ADR | DDS_OP_TYPE_ENU | DDS_OP_FLAG_TYPE_TC_DEF | DDS_OP_FLAG_TYPE_TC_TRIM | (2u << DDS_OP_FLAG_SZ_SHIFT), offsetof (CdrStreamEnumMeta, e), UINT32_MAX,
+  DDS_OP_RTS,
+  DDS_OP_EVS | 0u, 3u, 3u, 1u, 3u, UINT32_MAX,
+  DDS_OP_RTS,
+  DDS_OP_EVM | 0u, 0u,
+  DDS_OP_RTS
+};
+
+static const uint32_t CdrStreamEnumMetaOld_ops[] = {
+  CDRSTREAM_ENUM_META_INSN, offsetof (CdrStreamEnumMeta, e), UINT32_MAX,
+  DDS_OP_RTS
+};
+
+typedef struct CdrStreamEnumArrayMeta {
+  uint32_t e[3];
+} CdrStreamEnumArrayMeta;
+
+static const uint32_t CdrStreamEnumArrayMeta_ops[] = {
+  DDS_OP_ADR | DDS_OP_TYPE_ARR | DDS_OP_SUBTYPE_ENU | DDS_OP_FLAG_SUBTYPE_TC_DEF | (2u << DDS_OP_FLAG_SZ_SHIFT), offsetof (CdrStreamEnumArrayMeta, e), 3u, UINT32_MAX,
+  DDS_OP_RTS,
+  DDS_OP_EVS | 0u, 3u, 3u, 1u, 3u, UINT32_MAX,
+  DDS_OP_RTS,
+  DDS_OP_EVM | 0u, 0u,
+  DDS_OP_RTS
+};
+
+typedef struct CdrStreamEnumAppendableDefaultMeta {
+  uint32_t a;
+  uint32_t e;
+} CdrStreamEnumAppendableDefaultMeta;
+
+typedef struct CdrStreamEnumUnionDefaultMeta {
+  uint32_t d;
+  union {
+    uint32_t e;
+  } u;
+} CdrStreamEnumUnionDefaultMeta;
+
+static const uint32_t CdrStreamEnumAppendableDefaultMeta_ops[] = {
+  DDS_OP_DLC,
+  DDS_OP_ADR | DDS_OP_TYPE_4BY, offsetof (CdrStreamEnumAppendableDefaultMeta, a),
+  CDRSTREAM_ENUM_META_INSN, offsetof (CdrStreamEnumAppendableDefaultMeta, e), UINT32_MAX,
+  DDS_OP_RTS,
+  DDS_OP_EVS | 0u, 3u, 3u, 1u, 3u, UINT32_MAX,
+  DDS_OP_RTS,
+  DDS_OP_EVM | 3u, 0u,
+  DDS_OP_RTS
+};
+
+static const uint32_t CdrStreamEnumArrayAppendableDefaultMeta_ops[] = {
+  DDS_OP_DLC,
+  DDS_OP_ADR | DDS_OP_TYPE_ARR | DDS_OP_SUBTYPE_ENU | DDS_OP_FLAG_SUBTYPE_TC_DEF | (2u << DDS_OP_FLAG_SZ_SHIFT), offsetof (CdrStreamEnumArrayMeta, e), 3u, UINT32_MAX,
+  DDS_OP_RTS,
+  DDS_OP_EVS | 0u, 3u, 3u, 1u, 3u, UINT32_MAX,
+  DDS_OP_RTS,
+  DDS_OP_EVM | 1u, 0u,
+  DDS_OP_RTS
+};
+
+static const uint32_t CdrStreamEnumMutableDefaultMeta_ops[] = {
+  DDS_OP_PLC,
+  DDS_OP_PLM | 3u, 7u,
+  DDS_OP_RTS,
+  CDRSTREAM_ENUM_META_INSN, offsetof (CdrStreamEnumMeta, e), UINT32_MAX,
+  DDS_OP_RTS,
+  DDS_OP_EVS | 0u, 3u, 3u, 1u, 3u, UINT32_MAX,
+  DDS_OP_RTS,
+  DDS_OP_EVM | 4u, 0u,
+  DDS_OP_RTS
+};
+
+static const uint32_t CdrStreamEnumUnionAppendableDefaultMeta_ops[] = {
+  DDS_OP_DLC,
+  DDS_OP_ADR | DDS_OP_TYPE_UNI | DDS_OP_SUBTYPE_ENU | DDS_OP_FLAG_SUBTYPE_TC_DEF | (2u << DDS_OP_FLAG_SZ_SHIFT), offsetof (CdrStreamEnumUnionDefaultMeta, d), 1u, (9u << 16u) + 5u, UINT32_MAX,
+  DDS_OP_JEQ4 | DDS_OP_TYPE_ENU | DDS_OP_FLAG_TYPE_TC_DEF | (2u << DDS_OP_FLAG_SZ_SHIFT), 3u, offsetof (CdrStreamEnumUnionDefaultMeta, u.e), UINT32_MAX,
+  DDS_OP_RTS,
+  DDS_OP_EVS | 0u, 3u, 3u, 1u, 3u, UINT32_MAX,
+  DDS_OP_RTS,
+  DDS_OP_EVM | 1u, 0u,
+  DDS_OP_EVM | 6u, 0u,
+  DDS_OP_RTS
+};
+
+CU_Test (ddsc_cdrstream, check_normalize_enum_value_metadata)
+{
+  struct dds_cdrstream_desc desc;
+  dds_cdrstream_desc_init_with_nops (&desc, &dds_cdrstream_default_allocator, sizeof (CdrStreamEnumMeta), dds_alignof (CdrStreamEnumMeta), 0, CdrStreamEnumMeta_ops, sizeof (CdrStreamEnumMeta_ops) / sizeof (CdrStreamEnumMeta_ops[0]), NULL, 0);
+
+  uint32_t actual_size = 0;
+  uint32_t cdr = 2u;
+  enum dds_stream_normalize_result ret = dds_stream_normalize (&cdr, sizeof (cdr), false, DDSI_RTPS_CDR_ENC_VERSION_2, &desc, false, &actual_size);
+  CU_ASSERT_EQ_FATAL (ret, DDS_STREAM_NORMALIZE_SUCCESS);
+  CU_ASSERT_EQ_FATAL (actual_size, sizeof (cdr));
+  CU_ASSERT_EQ_FATAL (cdr, 3u);
+
+  cdr = UINT32_MAX;
+  ret = dds_stream_normalize (&cdr, sizeof (cdr), false, DDSI_RTPS_CDR_ENC_VERSION_2, &desc, false, &actual_size);
+  CU_ASSERT_EQ_FATAL (ret, DDS_STREAM_NORMALIZE_SUCCESS);
+  CU_ASSERT_EQ_FATAL (cdr, UINT32_MAX);
+
+  cdr = ddsrt_bswap4u (2u);
+  ret = dds_stream_normalize (&cdr, sizeof (cdr), true, DDSI_RTPS_CDR_ENC_VERSION_2, &desc, false, &actual_size);
+  CU_ASSERT_EQ_FATAL (ret, DDS_STREAM_NORMALIZE_SUCCESS);
+  CU_ASSERT_EQ_FATAL (cdr, 3u);
+
+  dds_cdrstream_desc_fini (&desc, &dds_cdrstream_default_allocator);
+
+  dds_cdrstream_desc_init_with_nops (&desc, &dds_cdrstream_default_allocator, sizeof (CdrStreamEnumMeta), dds_alignof (CdrStreamEnumMeta), 0, CdrStreamEnumMetaKey_ops, sizeof (CdrStreamEnumMetaKey_ops) / sizeof (CdrStreamEnumMetaKey_ops[0]), CdrStreamEnumMeta_keys, 1);
+  cdr = UINT32_MAX;
+  ret = dds_stream_normalize (&cdr, sizeof (cdr), false, DDSI_RTPS_CDR_ENC_VERSION_2, &desc, true, &actual_size);
+  CU_ASSERT_EQ_FATAL (ret, DDS_STREAM_NORMALIZE_SUCCESS);
+  CU_ASSERT_EQ_FATAL (actual_size, sizeof (cdr));
+  CU_ASSERT_EQ_FATAL (cdr, UINT32_MAX);
+
+  dds_cdrstream_desc_fini (&desc, &dds_cdrstream_default_allocator);
+}
+
+CU_Test (ddsc_cdrstream, check_normalize_enum_value_metadata_reject)
+{
+  struct dds_cdrstream_desc desc;
+  dds_cdrstream_desc_init_with_nops (&desc, &dds_cdrstream_default_allocator, sizeof (CdrStreamEnumMeta), dds_alignof (CdrStreamEnumMeta), 0, CdrStreamEnumMetaReject_ops, sizeof (CdrStreamEnumMetaReject_ops) / sizeof (CdrStreamEnumMetaReject_ops[0]), NULL, 0);
+
+  uint32_t actual_size = 0;
+  uint32_t cdr = 2u;
+  const enum dds_stream_normalize_result ret = dds_stream_normalize (&cdr, sizeof (cdr), false, DDSI_RTPS_CDR_ENC_VERSION_2, &desc, false, &actual_size);
+  CU_ASSERT_EQ_FATAL (ret, DDS_STREAM_NORMALIZE_ERROR);
+
+  dds_cdrstream_desc_fini (&desc, &dds_cdrstream_default_allocator);
+}
+
+CU_Test (ddsc_cdrstream, check_normalize_enum_value_metadata_old_descriptor)
+{
+  struct dds_cdrstream_desc desc;
+  dds_cdrstream_desc_init_with_nops (&desc, &dds_cdrstream_default_allocator, sizeof (CdrStreamEnumMeta), dds_alignof (CdrStreamEnumMeta), 0, CdrStreamEnumMetaOld_ops, sizeof (CdrStreamEnumMetaOld_ops) / sizeof (CdrStreamEnumMetaOld_ops[0]), NULL, 0);
+
+  uint32_t actual_size = 0;
+  uint32_t cdr = 2u;
+  const enum dds_stream_normalize_result ret = dds_stream_normalize (&cdr, sizeof (cdr), false, DDSI_RTPS_CDR_ENC_VERSION_2, &desc, false, &actual_size);
+  CU_ASSERT_EQ_FATAL (ret, DDS_STREAM_NORMALIZE_SUCCESS);
+  CU_ASSERT_EQ_FATAL (cdr, 2u);
+
+  dds_cdrstream_desc_fini (&desc, &dds_cdrstream_default_allocator);
+}
+
+CU_Test (ddsc_cdrstream, check_normalize_enum_array_value_metadata)
+{
+  struct dds_cdrstream_desc desc;
+  dds_cdrstream_desc_init_with_nops (&desc, &dds_cdrstream_default_allocator, sizeof (CdrStreamEnumArrayMeta), dds_alignof (CdrStreamEnumArrayMeta), 0, CdrStreamEnumArrayMeta_ops, sizeof (CdrStreamEnumArrayMeta_ops) / sizeof (CdrStreamEnumArrayMeta_ops[0]), NULL, 0);
+
+  uint32_t actual_size = 0;
+  uint32_t cdr[] = { 12u, 1u, 2u, UINT32_MAX };
+  const enum dds_stream_normalize_result ret = dds_stream_normalize (cdr, sizeof (cdr), false, DDSI_RTPS_CDR_ENC_VERSION_2, &desc, false, &actual_size);
+  CU_ASSERT_EQ_FATAL (ret, DDS_STREAM_NORMALIZE_SUCCESS);
+  CU_ASSERT_EQ_FATAL (actual_size, sizeof (cdr));
+  CU_ASSERT_EQ_FATAL (cdr[1], 1u);
+  CU_ASSERT_EQ_FATAL (cdr[2], 3u);
+  CU_ASSERT_EQ_FATAL (cdr[3], UINT32_MAX);
+
+  dds_cdrstream_desc_fini (&desc, &dds_cdrstream_default_allocator);
+}
+
+CU_Test (ddsc_cdrstream, check_normalize_generated_enum_value_metadata)
+{
+  struct dds_cdrstream_desc desc;
+  dds_cdrstream_desc_from_topic_desc (&desc, &TestIdl_MsgUnion_desc);
+
+  uint32_t actual_size = 0;
+  uint32_t valid[] = { TestIdl_KIND1_1, TestIdl_KIND2_10, TestIdl_KIND3_1, TestIdl_KIND2_6 };
+  enum dds_stream_normalize_result ret = dds_stream_normalize (valid, sizeof (valid), false, DDSI_RTPS_CDR_ENC_VERSION_2, &desc, false, &actual_size);
+  CU_ASSERT_EQ_FATAL (ret, DDS_STREAM_NORMALIZE_SUCCESS);
+  CU_ASSERT_EQ_FATAL (actual_size, sizeof (valid));
+
+  uint32_t invalid_field[] = { TestIdl_KIND1_1, 2u, TestIdl_KIND3_1, TestIdl_KIND2_6 };
+  ret = dds_stream_normalize (invalid_field, sizeof (invalid_field), false, DDSI_RTPS_CDR_ENC_VERSION_2, &desc, false, &actual_size);
+  CU_ASSERT_EQ_FATAL (ret, DDS_STREAM_NORMALIZE_ERROR);
+
+  uint32_t invalid_union_field[] = { TestIdl_KIND1_1, TestIdl_KIND2_10, TestIdl_KIND3_1, 2u };
+  ret = dds_stream_normalize (invalid_union_field, sizeof (invalid_union_field), false, DDSI_RTPS_CDR_ENC_VERSION_2, &desc, false, &actual_size);
+  CU_ASSERT_EQ_FATAL (ret, DDS_STREAM_NORMALIZE_ERROR);
+
+  dds_cdrstream_desc_fini (&desc, &dds_cdrstream_default_allocator);
+}
+
+CU_Test (ddsc_cdrstream, read_appendable_enum_default_metadata)
+{
+  struct dds_cdrstream_desc desc;
+  dds_cdrstream_desc_init_with_nops (&desc, &dds_cdrstream_default_allocator, sizeof (CdrStreamEnumAppendableDefaultMeta), dds_alignof (CdrStreamEnumAppendableDefaultMeta), 0, CdrStreamEnumAppendableDefaultMeta_ops, sizeof (CdrStreamEnumAppendableDefaultMeta_ops) / sizeof (CdrStreamEnumAppendableDefaultMeta_ops[0]), NULL, 0);
+  CU_ASSERT_FATAL (desc.member_ids.has_special_defaults);
+
+  uint32_t cdr[] = { 4u, 11u };
+  CdrStreamEnumAppendableDefaultMeta sample = { .a = 0xaaau, .e = 99u };
+  dds_istream_t is;
+  dds_istream_init (&is, sizeof (cdr), cdr, DDSI_RTPS_CDR_ENC_VERSION_2);
+  dds_stream_read_sample (&is, &sample, &dds_cdrstream_default_allocator, &desc);
+
+  CU_ASSERT_EQ_FATAL (is.m_index, sizeof (cdr));
+  CU_ASSERT_EQ_FATAL (sample.a, 11u);
+  CU_ASSERT_EQ_FATAL (sample.e, 3u);
+
+  dds_cdrstream_desc_fini (&desc, &dds_cdrstream_default_allocator);
+}
+
+CU_Test (ddsc_cdrstream, read_appendable_enum_array_default_metadata)
+{
+  struct dds_cdrstream_desc desc;
+  dds_cdrstream_desc_init_with_nops (&desc, &dds_cdrstream_default_allocator, sizeof (CdrStreamEnumArrayMeta), dds_alignof (CdrStreamEnumArrayMeta), 0, CdrStreamEnumArrayAppendableDefaultMeta_ops, sizeof (CdrStreamEnumArrayAppendableDefaultMeta_ops) / sizeof (CdrStreamEnumArrayAppendableDefaultMeta_ops[0]), NULL, 0);
+  CU_ASSERT_FATAL (desc.member_ids.has_special_defaults);
+
+  uint32_t cdr[] = { 0u };
+  CdrStreamEnumArrayMeta sample = { .e = { 99u, 99u, 99u } };
+  dds_istream_t is;
+  dds_istream_init (&is, sizeof (cdr), cdr, DDSI_RTPS_CDR_ENC_VERSION_2);
+  dds_stream_read_sample (&is, &sample, &dds_cdrstream_default_allocator, &desc);
+
+  CU_ASSERT_EQ_FATAL (is.m_index, sizeof (cdr));
+  CU_ASSERT_EQ_FATAL (sample.e[0], 3u);
+  CU_ASSERT_EQ_FATAL (sample.e[1], 3u);
+  CU_ASSERT_EQ_FATAL (sample.e[2], 3u);
+
+  dds_cdrstream_desc_fini (&desc, &dds_cdrstream_default_allocator);
+}
+
+CU_Test (ddsc_cdrstream, read_mutable_enum_default_metadata)
+{
+  struct dds_cdrstream_desc desc;
+  dds_cdrstream_desc_init_with_nops (&desc, &dds_cdrstream_default_allocator, sizeof (CdrStreamEnumMeta), dds_alignof (CdrStreamEnumMeta), 0, CdrStreamEnumMutableDefaultMeta_ops, sizeof (CdrStreamEnumMutableDefaultMeta_ops) / sizeof (CdrStreamEnumMutableDefaultMeta_ops[0]), NULL, 0);
+  CU_ASSERT_FATAL (desc.member_ids.has_special_defaults);
+
+  uint32_t cdr[] = { 0u };
+  CdrStreamEnumMeta sample = { .e = 99u };
+  dds_istream_t is;
+  dds_istream_init (&is, sizeof (cdr), cdr, DDSI_RTPS_CDR_ENC_VERSION_2);
+  dds_stream_read_sample (&is, &sample, &dds_cdrstream_default_allocator, &desc);
+
+  CU_ASSERT_EQ_FATAL (is.m_index, sizeof (cdr));
+  CU_ASSERT_EQ_FATAL (sample.e, 3u);
+
+  dds_cdrstream_desc_fini (&desc, &dds_cdrstream_default_allocator);
+}
+
+CU_Test (ddsc_cdrstream, read_appendable_enum_union_default_metadata)
+{
+  struct dds_cdrstream_desc desc;
+  dds_cdrstream_desc_init_with_nops (&desc, &dds_cdrstream_default_allocator, sizeof (CdrStreamEnumUnionDefaultMeta), dds_alignof (CdrStreamEnumUnionDefaultMeta), 0, CdrStreamEnumUnionAppendableDefaultMeta_ops, sizeof (CdrStreamEnumUnionAppendableDefaultMeta_ops) / sizeof (CdrStreamEnumUnionAppendableDefaultMeta_ops[0]), NULL, 0);
+  CU_ASSERT_FATAL (desc.member_ids.has_special_defaults);
+
+  uint32_t cdr[] = { 0u };
+  CdrStreamEnumUnionDefaultMeta sample = { .d = 1u, .u = { .e = 99u } };
+  dds_istream_t is;
+  dds_istream_init (&is, sizeof (cdr), cdr, DDSI_RTPS_CDR_ENC_VERSION_2);
+  dds_stream_read_sample (&is, &sample, &dds_cdrstream_default_allocator, &desc);
+
+  CU_ASSERT_EQ_FATAL (is.m_index, sizeof (cdr));
+  CU_ASSERT_EQ_FATAL (sample.d, 3u);
+  CU_ASSERT_EQ_FATAL (sample.u.e, 3u);
+
+  dds_cdrstream_desc_fini (&desc, &dds_cdrstream_default_allocator);
+}
+
 
 #define D(n) (&CdrStreamChecking_ ## n ## _desc)
 CU_Test (ddsc_cdrstream, check_sequence_alloc)

--- a/src/core/ddsc/tests/cdrstream.c
+++ b/src/core/ddsc/tests/cdrstream.c
@@ -1107,8 +1107,8 @@ CU_Test (ddsc_cdrstream, appendable_mutable, .init = cdrstream_init, .fini = cdr
 
         struct dds_cdrstream_desc desc_wr;
         dds_cdrstream_desc_from_topic_desc (&desc_wr, topic_desc_wr);
-        enum dds_cdr_enc_version min_xcdrv_wr = dds_stream_minimum_xcdr_version (desc_wr.ops.ops);
-        CU_ASSERT (x == 0 || min_xcdrv_wr == DDSI_RTPS_CDR_ENC_VERSION_1);
+        const uint32_t supported_representations_wr = dds_stream_supported_data_representations (desc_wr.ops.ops);
+        CU_ASSERT (x == 0 || (supported_representations_wr & DDS_DATA_REPRESENTATION_FLAG_XCDR1));
 
         void * msg_wr = t ? tests[i].i2 () : tests[i].i1 ();
         bool ret = dds_stream_write_sample (&os, &dds_cdrstream_default_allocator, msg_wr, &desc_wr);
@@ -1123,8 +1123,8 @@ CU_Test (ddsc_cdrstream, appendable_mutable, .init = cdrstream_init, .fini = cdr
 
         struct dds_cdrstream_desc desc_rd;
         dds_cdrstream_desc_from_topic_desc (&desc_rd, topic_desc_rd);
-        enum dds_cdr_enc_version min_xcdrv_rd = dds_stream_minimum_xcdr_version (desc_wr.ops.ops);
-        CU_ASSERT (x == 0 || min_xcdrv_rd == DDSI_RTPS_CDR_ENC_VERSION_1);
+        const uint32_t supported_representations_rd = dds_stream_supported_data_representations (desc_rd.ops.ops);
+        CU_ASSERT (x == 0 || (supported_representations_rd & DDS_DATA_REPRESENTATION_FLAG_XCDR1));
 
         uint32_t act_size;
         void *cdr_copy = ddsrt_memdup (os.m_buffer, os.m_index);
@@ -1163,40 +1163,41 @@ CU_Test (ddsc_cdrstream, appendable_mutable, .init = cdrstream_init, .fini = cdr
 #undef F
 
 #define D(n) (&MinXcdrVersion_ ## n ## _desc)
-CU_Test (ddsc_cdrstream, min_xcdr_version)
+CU_Test (ddsc_cdrstream, supported_data_representations)
 {
+  enum { XCDR12_REP = DDS_DATA_REPRESENTATION_FLAG_XCDR1 | DDS_DATA_REPRESENTATION_FLAG_XCDR2 };
   static const struct {
     const dds_topic_descriptor_t *desc;
-    uint16_t min_xcdrv;
+    uint32_t supported_representations;
   } tests[] = {
-    { D(t), XCDR1 },
-    { D(t_nested), XCDR1 },
-    { D(t_inherit), XCDR1 },
-    { D(t_opt), XCDR1 },
-    { D(t_ext), XCDR1 },
-    { D(t_append), XCDR1 },
-    { D(t_append_u), XCDR1 },
-    { D(t_append_nested), XCDR2 },
-    { D(t_append_nested_opt), XCDR1 },
-    { D(t_u_nested_append), XCDR2 },
-    { D(t_append_nested_u), XCDR2 },
-    { D(t_append_opt), XCDR1 },
-    { D(t_append_opt_u), XCDR1 },
-    { D(t_append_seq), XCDR2 },
-    { D(t_append_bseq), XCDR2 },
-    { D(t_append_arr), XCDR2 },
-    { D(t_mut), XCDR1 },
-    { D(t_nested_mut), XCDR1 },
-    { D(t_nested_opt), XCDR1 }
+    { D(t), XCDR12_REP },
+    { D(t_nested), XCDR12_REP },
+    { D(t_inherit), XCDR12_REP },
+    { D(t_opt), XCDR12_REP },
+    { D(t_ext), XCDR12_REP },
+    { D(t_append), XCDR12_REP },
+    { D(t_append_u), XCDR12_REP },
+    { D(t_append_nested), DDS_DATA_REPRESENTATION_FLAG_XCDR2 },
+    { D(t_append_nested_opt), XCDR12_REP },
+    { D(t_u_nested_append), DDS_DATA_REPRESENTATION_FLAG_XCDR2 },
+    { D(t_append_nested_u), DDS_DATA_REPRESENTATION_FLAG_XCDR2 },
+    { D(t_append_opt), XCDR12_REP },
+    { D(t_append_opt_u), XCDR12_REP },
+    { D(t_append_seq), DDS_DATA_REPRESENTATION_FLAG_XCDR2 },
+    { D(t_append_bseq), DDS_DATA_REPRESENTATION_FLAG_XCDR2 },
+    { D(t_append_arr), DDS_DATA_REPRESENTATION_FLAG_XCDR2 },
+    { D(t_mut), XCDR12_REP },
+    { D(t_nested_mut), XCDR12_REP },
+    { D(t_nested_opt), XCDR12_REP }
   };
 
   for (uint32_t i = 0; i < sizeof (tests) / sizeof (tests[0]); i++)
   {
     tprintf("running test for desc: %s\n", tests[i].desc->m_typename);
     cdrstream_init ();
-    CU_ASSERT_EQ_FATAL (dds_stream_minimum_xcdr_version (tests[i].desc->m_ops), tests[i].min_xcdrv);
+    CU_ASSERT_EQ_FATAL (dds_stream_supported_data_representations (tests[i].desc->m_ops), tests[i].supported_representations);
 
-    entity_init (tests[i].desc, DDS_DATA_REPRESENTATION_XCDR1, tests[i].min_xcdrv != XCDR1);
+    entity_init (tests[i].desc, DDS_DATA_REPRESENTATION_XCDR1, !(tests[i].supported_representations & DDS_DATA_REPRESENTATION_FLAG_XCDR1));
     entity_init (tests[i].desc, DDS_DATA_REPRESENTATION_XCDR2, false);
     cdrstream_fini ();
   }
@@ -2156,13 +2157,12 @@ CU_Test (ddsc_cdrstream, read_appendable_enum_union_default_metadata)
 CU_Test (ddsc_cdrstream, union_discriminator_use_default_data_representations)
 {
   const uint32_t xcdr12 = DDS_DATA_REPRESENTATION_FLAG_XCDR1 | DDS_DATA_REPRESENTATION_FLAG_XCDR2;
-  CU_ASSERT_EQ_FATAL (dds_stream_allowed_data_representations (CdrStreamEnumUnionFinalDiscUseDefaultMeta_ops), xcdr12);
-  CU_ASSERT_EQ_FATAL (dds_stream_allowed_data_representations (CdrStreamFinalStructUnionLastDiscUseDefaultMeta_ops), xcdr12);
-  CU_ASSERT_EQ_FATAL (dds_stream_allowed_data_representations (CdrStreamFinalStructUnionThenMemberDiscUseDefaultMeta_ops), 0u);
-  CU_ASSERT_EQ_FATAL (dds_stream_allowed_data_representations (CdrStreamEnumUnionAppendableDefaultMeta_ops), xcdr12);
-  CU_ASSERT_EQ_FATAL (dds_stream_allowed_data_representations (CdrStreamAppendableStructUnionLastDiscUseDefaultMeta_ops), xcdr12);
-  CU_ASSERT_EQ_FATAL (dds_stream_allowed_data_representations (CdrStreamAppendableStructUnionThenMemberDiscUseDefaultMeta_ops), 0u);
-  CU_ASSERT_EQ_FATAL (dds_stream_minimum_xcdr_version (CdrStreamEnumUnionAppendableDefaultMeta_ops), XCDR1);
+  CU_ASSERT_EQ_FATAL (dds_stream_supported_data_representations (CdrStreamEnumUnionFinalDiscUseDefaultMeta_ops), xcdr12);
+  CU_ASSERT_EQ_FATAL (dds_stream_supported_data_representations (CdrStreamFinalStructUnionLastDiscUseDefaultMeta_ops), xcdr12);
+  CU_ASSERT_EQ_FATAL (dds_stream_supported_data_representations (CdrStreamFinalStructUnionThenMemberDiscUseDefaultMeta_ops), 0u);
+  CU_ASSERT_EQ_FATAL (dds_stream_supported_data_representations (CdrStreamEnumUnionAppendableDefaultMeta_ops), xcdr12);
+  CU_ASSERT_EQ_FATAL (dds_stream_supported_data_representations (CdrStreamAppendableStructUnionLastDiscUseDefaultMeta_ops), xcdr12);
+  CU_ASSERT_EQ_FATAL (dds_stream_supported_data_representations (CdrStreamAppendableStructUnionThenMemberDiscUseDefaultMeta_ops), 0u);
 }
 
 CU_Test (ddsc_cdrstream, normalize_read_union_discriminator_use_default)

--- a/src/core/ddsc/tests/cdrstream.c
+++ b/src/core/ddsc/tests/cdrstream.c
@@ -1902,6 +1902,81 @@ static const uint32_t CdrStreamEnumUnionAppendableDefaultMeta_ops[] = {
   DDS_OP_RTS
 };
 
+static const uint32_t CdrStreamEnumUnionFinalDiscUseDefaultMeta_ops[] = {
+  DDS_OP_ADR | DDS_OP_TYPE_UNI | DDS_OP_SUBTYPE_ENU | DDS_OP_FLAG_SUBTYPE_TC_DEF | (2u << DDS_OP_FLAG_SZ_SHIFT), offsetof (CdrStreamEnumUnionDefaultMeta, d), 1u, (9u << 16u) + 5u, UINT32_MAX,
+  DDS_OP_JEQ4 | DDS_OP_TYPE_ENU | DDS_OP_FLAG_TYPE_TC_DEF | (2u << DDS_OP_FLAG_SZ_SHIFT), 3u, offsetof (CdrStreamEnumUnionDefaultMeta, u.e), UINT32_MAX,
+  DDS_OP_RTS,
+  DDS_OP_EVS | 0u, 3u, 3u, 1u, 3u, UINT32_MAX,
+  DDS_OP_RTS,
+  DDS_OP_EVM | 0u, 0u,
+  DDS_OP_EVM | 5u, 0u,
+  DDS_OP_RTS
+};
+
+typedef struct CdrStreamEnumUnionStructMeta {
+  uint32_t before;
+  CdrStreamEnumUnionDefaultMeta u;
+  uint32_t after;
+} CdrStreamEnumUnionStructMeta;
+
+static const uint32_t CdrStreamFinalStructUnionLastDiscUseDefaultMeta_ops[] = {
+  DDS_OP_ADR | DDS_OP_TYPE_4BY, offsetof (CdrStreamEnumUnionStructMeta, before),
+  DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (CdrStreamEnumUnionStructMeta, u), (3u << 16u) + 4u,
+  DDS_OP_RTS,
+  DDS_OP_ADR | DDS_OP_TYPE_UNI | DDS_OP_SUBTYPE_ENU | DDS_OP_FLAG_SUBTYPE_TC_DEF | (2u << DDS_OP_FLAG_SZ_SHIFT), offsetof (CdrStreamEnumUnionDefaultMeta, d), 1u, (9u << 16u) + 5u, UINT32_MAX,
+  DDS_OP_JEQ4 | DDS_OP_TYPE_ENU | DDS_OP_FLAG_TYPE_TC_DEF | (2u << DDS_OP_FLAG_SZ_SHIFT), 3u, offsetof (CdrStreamEnumUnionDefaultMeta, u.e), UINT32_MAX,
+  DDS_OP_RTS,
+  DDS_OP_EVS | 0u, 3u, 3u, 1u, 3u, UINT32_MAX,
+  DDS_OP_RTS,
+  DDS_OP_EVM | 6u, 0u,
+  DDS_OP_EVM | 11u, 0u,
+  DDS_OP_RTS
+};
+
+static const uint32_t CdrStreamFinalStructUnionThenMemberDiscUseDefaultMeta_ops[] = {
+  DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (CdrStreamEnumUnionStructMeta, u), (3u << 16u) + 6u,
+  DDS_OP_ADR | DDS_OP_TYPE_4BY, offsetof (CdrStreamEnumUnionStructMeta, after),
+  DDS_OP_RTS,
+  DDS_OP_ADR | DDS_OP_TYPE_UNI | DDS_OP_SUBTYPE_ENU | DDS_OP_FLAG_SUBTYPE_TC_DEF | (2u << DDS_OP_FLAG_SZ_SHIFT), offsetof (CdrStreamEnumUnionDefaultMeta, d), 1u, (9u << 16u) + 5u, UINT32_MAX,
+  DDS_OP_JEQ4 | DDS_OP_TYPE_ENU | DDS_OP_FLAG_TYPE_TC_DEF | (2u << DDS_OP_FLAG_SZ_SHIFT), 3u, offsetof (CdrStreamEnumUnionDefaultMeta, u.e), UINT32_MAX,
+  DDS_OP_RTS,
+  DDS_OP_EVS | 0u, 3u, 3u, 1u, 3u, UINT32_MAX,
+  DDS_OP_RTS,
+  DDS_OP_EVM | 6u, 0u,
+  DDS_OP_EVM | 11u, 0u,
+  DDS_OP_RTS
+};
+
+static const uint32_t CdrStreamAppendableStructUnionLastDiscUseDefaultMeta_ops[] = {
+  DDS_OP_DLC,
+  DDS_OP_ADR | DDS_OP_TYPE_4BY, offsetof (CdrStreamEnumUnionStructMeta, before),
+  DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (CdrStreamEnumUnionStructMeta, u), (3u << 16u) + 4u,
+  DDS_OP_RTS,
+  DDS_OP_ADR | DDS_OP_TYPE_UNI | DDS_OP_SUBTYPE_ENU | DDS_OP_FLAG_SUBTYPE_TC_DEF | (2u << DDS_OP_FLAG_SZ_SHIFT), offsetof (CdrStreamEnumUnionDefaultMeta, d), 1u, (9u << 16u) + 5u, UINT32_MAX,
+  DDS_OP_JEQ4 | DDS_OP_TYPE_ENU | DDS_OP_FLAG_TYPE_TC_DEF | (2u << DDS_OP_FLAG_SZ_SHIFT), 3u, offsetof (CdrStreamEnumUnionDefaultMeta, u.e), UINT32_MAX,
+  DDS_OP_RTS,
+  DDS_OP_EVS | 0u, 3u, 3u, 1u, 3u, UINT32_MAX,
+  DDS_OP_RTS,
+  DDS_OP_EVM | 7u, 0u,
+  DDS_OP_EVM | 12u, 0u,
+  DDS_OP_RTS
+};
+
+static const uint32_t CdrStreamAppendableStructUnionThenMemberDiscUseDefaultMeta_ops[] = {
+  DDS_OP_DLC,
+  DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (CdrStreamEnumUnionStructMeta, u), (3u << 16u) + 6u,
+  DDS_OP_ADR | DDS_OP_TYPE_4BY, offsetof (CdrStreamEnumUnionStructMeta, after),
+  DDS_OP_RTS,
+  DDS_OP_ADR | DDS_OP_TYPE_UNI | DDS_OP_SUBTYPE_ENU | DDS_OP_FLAG_SUBTYPE_TC_DEF | (2u << DDS_OP_FLAG_SZ_SHIFT), offsetof (CdrStreamEnumUnionDefaultMeta, d), 1u, (9u << 16u) + 5u, UINT32_MAX,
+  DDS_OP_JEQ4 | DDS_OP_TYPE_ENU | DDS_OP_FLAG_TYPE_TC_DEF | (2u << DDS_OP_FLAG_SZ_SHIFT), 3u, offsetof (CdrStreamEnumUnionDefaultMeta, u.e), UINT32_MAX,
+  DDS_OP_RTS,
+  DDS_OP_EVS | 0u, 3u, 3u, 1u, 3u, UINT32_MAX,
+  DDS_OP_RTS,
+  DDS_OP_EVM | 7u, 0u,
+  DDS_OP_EVM | 12u, 0u,
+  DDS_OP_RTS
+};
+
 CU_Test (ddsc_cdrstream, check_normalize_enum_value_metadata)
 {
   struct dds_cdrstream_desc desc;
@@ -2078,6 +2153,64 @@ CU_Test (ddsc_cdrstream, read_appendable_enum_union_default_metadata)
   dds_cdrstream_desc_fini (&desc, &dds_cdrstream_default_allocator);
 }
 
+CU_Test (ddsc_cdrstream, union_discriminator_use_default_data_representations)
+{
+  const uint32_t xcdr12 = DDS_DATA_REPRESENTATION_FLAG_XCDR1 | DDS_DATA_REPRESENTATION_FLAG_XCDR2;
+  CU_ASSERT_EQ_FATAL (dds_stream_allowed_data_representations (CdrStreamEnumUnionFinalDiscUseDefaultMeta_ops), xcdr12);
+  CU_ASSERT_EQ_FATAL (dds_stream_allowed_data_representations (CdrStreamFinalStructUnionLastDiscUseDefaultMeta_ops), xcdr12);
+  CU_ASSERT_EQ_FATAL (dds_stream_allowed_data_representations (CdrStreamFinalStructUnionThenMemberDiscUseDefaultMeta_ops), 0u);
+  CU_ASSERT_EQ_FATAL (dds_stream_allowed_data_representations (CdrStreamEnumUnionAppendableDefaultMeta_ops), xcdr12);
+  CU_ASSERT_EQ_FATAL (dds_stream_allowed_data_representations (CdrStreamAppendableStructUnionLastDiscUseDefaultMeta_ops), xcdr12);
+  CU_ASSERT_EQ_FATAL (dds_stream_allowed_data_representations (CdrStreamAppendableStructUnionThenMemberDiscUseDefaultMeta_ops), 0u);
+  CU_ASSERT_EQ_FATAL (dds_stream_minimum_xcdr_version (CdrStreamEnumUnionAppendableDefaultMeta_ops), XCDR1);
+}
+
+CU_Test (ddsc_cdrstream, normalize_read_union_discriminator_use_default)
+{
+  struct dds_cdrstream_desc desc;
+  dds_cdrstream_desc_init_with_nops (&desc, &dds_cdrstream_default_allocator, sizeof (CdrStreamEnumUnionDefaultMeta), dds_alignof (CdrStreamEnumUnionDefaultMeta), 0, CdrStreamEnumUnionAppendableDefaultMeta_ops, sizeof (CdrStreamEnumUnionAppendableDefaultMeta_ops) / sizeof (CdrStreamEnumUnionAppendableDefaultMeta_ops[0]), NULL, 0);
+  CU_ASSERT_FATAL (desc.member_ids.has_special_defaults);
+
+  uint32_t cdr[] = { 8u, 2u, 1u };
+  uint32_t actual_size = 0;
+  enum dds_stream_normalize_result ret = dds_stream_normalize (cdr, sizeof (cdr), false, DDSI_RTPS_CDR_ENC_VERSION_2, &desc, false, &actual_size);
+  CU_ASSERT_EQ_FATAL (ret, DDS_STREAM_NORMALIZE_SUCCESS);
+  CU_ASSERT_EQ_FATAL (actual_size, sizeof (cdr));
+  CU_ASSERT_EQ_FATAL (cdr[1], 3u);
+  CU_ASSERT_EQ_FATAL (cdr[2], 1u);
+
+  CdrStreamEnumUnionDefaultMeta sample = { .d = 1u, .u = { .e = 99u } };
+  dds_istream_t is;
+  dds_istream_init (&is, sizeof (cdr), cdr, DDSI_RTPS_CDR_ENC_VERSION_2);
+  dds_stream_read_sample (&is, &sample, &dds_cdrstream_default_allocator, &desc);
+
+  CU_ASSERT_EQ_FATAL (is.m_index, sizeof (cdr));
+  CU_ASSERT_EQ_FATAL (sample.d, 3u);
+  CU_ASSERT_EQ_FATAL (sample.u.e, 1u);
+
+  dds_cdrstream_desc_fini (&desc, &dds_cdrstream_default_allocator);
+
+  dds_cdrstream_desc_init_with_nops (&desc, &dds_cdrstream_default_allocator, sizeof (CdrStreamEnumUnionDefaultMeta), dds_alignof (CdrStreamEnumUnionDefaultMeta), 0, CdrStreamEnumUnionFinalDiscUseDefaultMeta_ops, sizeof (CdrStreamEnumUnionFinalDiscUseDefaultMeta_ops) / sizeof (CdrStreamEnumUnionFinalDiscUseDefaultMeta_ops[0]), NULL, 0);
+  CU_ASSERT_FATAL (desc.member_ids.has_special_defaults);
+
+  uint32_t final_cdr[] = { 2u, 1u };
+  actual_size = 0;
+  ret = dds_stream_normalize (final_cdr, sizeof (final_cdr), false, DDSI_RTPS_CDR_ENC_VERSION_1, &desc, false, &actual_size);
+  CU_ASSERT_EQ_FATAL (ret, DDS_STREAM_NORMALIZE_SUCCESS);
+  CU_ASSERT_EQ_FATAL (actual_size, sizeof (final_cdr));
+  CU_ASSERT_EQ_FATAL (final_cdr[0], 3u);
+  CU_ASSERT_EQ_FATAL (final_cdr[1], 1u);
+
+  sample = (CdrStreamEnumUnionDefaultMeta) { .d = 1u, .u = { .e = 99u } };
+  dds_istream_init (&is, sizeof (final_cdr), final_cdr, DDSI_RTPS_CDR_ENC_VERSION_1);
+  dds_stream_read_sample (&is, &sample, &dds_cdrstream_default_allocator, &desc);
+
+  CU_ASSERT_EQ_FATAL (is.m_index, sizeof (final_cdr));
+  CU_ASSERT_EQ_FATAL (sample.d, 3u);
+  CU_ASSERT_EQ_FATAL (sample.u.e, 1u);
+
+  dds_cdrstream_desc_fini (&desc, &dds_cdrstream_default_allocator);
+}
 
 #define D(n) (&CdrStreamChecking_ ## n ## _desc)
 CU_Test (ddsc_cdrstream, check_sequence_alloc)

--- a/src/core/ddsc/tests/dynamic_type.c
+++ b/src/core/ddsc/tests/dynamic_type.c
@@ -388,15 +388,15 @@ CU_Test (ddsc_dynamic_type, bitmask_field_invalid, .init = dynamic_type_init, .f
 CU_Test (ddsc_dynamic_type, enum_type, .init = dynamic_type_init, .fini = dynamic_type_fini)
 {
   dds_dynamic_type_t denum = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_ENUMERATION, .name = "e" });
-  dds_return_t ret = dds_dynamic_type_set_bit_bound (&denum, 31);
+  dds_return_t ret = dds_dynamic_type_set_bit_bound (&denum, 32);
   CU_ASSERT_EQ_FATAL (ret, DDS_RETCODE_OK);
   dds_dynamic_type_add_enum_literal (&denum, "e_auto0", DDS_DYNAMIC_ENUM_LITERAL_VALUE_AUTO, false);
   dds_dynamic_type_add_enum_literal (&denum, "e_auto1", DDS_DYNAMIC_ENUM_LITERAL_VALUE_AUTO, true);
-  dds_dynamic_type_add_enum_literal (&denum, "e_31", DDS_DYNAMIC_ENUM_LITERAL_VALUE ((1u << 31) - 1), false);
+  dds_dynamic_type_add_enum_literal (&denum, "e_min", DDS_DYNAMIC_ENUM_LITERAL_VALUE (INT32_MIN), false);
   dds_dynamic_type_add_enum_literal (&denum, "e_2", DDS_DYNAMIC_ENUM_LITERAL_VALUE (2), false);
 
   struct ddsi_type *type = get_ddsi_type (&denum);
-  CU_ASSERT_EQ_FATAL (type->xt._u.bitmask.bit_bound, 31);
+  CU_ASSERT_EQ_FATAL (type->xt._u.enum_type.bit_bound, 32);
   CU_ASSERT_EQ_FATAL (type->xt._u.enum_type.literals.length, 4);
 
   CU_ASSERT_EQ_FATAL (type->xt._u.enum_type.literals.seq[0].value, 0);
@@ -405,12 +405,62 @@ CU_Test (ddsc_dynamic_type, enum_type, .init = dynamic_type_init, .fini = dynami
   CU_ASSERT_EQ_FATAL (type->xt._u.enum_type.literals.seq[1].value, 1);
   CU_ASSERT_NEQ_FATAL (type->xt._u.enum_type.literals.seq[1].flags & DDS_XTypes_IS_DEFAULT, 0);
 
-  CU_ASSERT_EQ_FATAL (type->xt._u.enum_type.literals.seq[2].value, (1u << 31) - 1);
+  CU_ASSERT_EQ_FATAL (type->xt._u.enum_type.literals.seq[2].value, INT32_MIN);
   CU_ASSERT_FATAL (!(type->xt._u.enum_type.literals.seq[2].flags & DDS_XTypes_IS_DEFAULT));
 
   CU_ASSERT_EQ_FATAL (type->xt._u.enum_type.literals.seq[3].value, 2);
   CU_ASSERT_FATAL (!(type->xt._u.enum_type.literals.seq[3].flags & DDS_XTypes_IS_DEFAULT));
 
+  dds_dynamic_type_unref (&denum);
+}
+
+CU_Test (ddsc_dynamic_type, enum_literal_auto_after_negative, .init = dynamic_type_init, .fini = dynamic_type_fini)
+{
+  dds_dynamic_type_t denum = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_ENUMERATION, .name = "e" });
+  dds_return_t ret = dds_dynamic_type_set_bit_bound (&denum, 3);
+  CU_ASSERT_EQ_FATAL (ret, DDS_RETCODE_OK);
+  ret = dds_dynamic_type_add_enum_literal (&denum, "e_min", DDS_DYNAMIC_ENUM_LITERAL_VALUE (-4), false);
+  CU_ASSERT_EQ_FATAL (ret, DDS_RETCODE_OK);
+  ret = dds_dynamic_type_add_enum_literal (&denum, "e_auto", DDS_DYNAMIC_ENUM_LITERAL_VALUE_AUTO, false);
+  CU_ASSERT_EQ_FATAL (ret, DDS_RETCODE_OK);
+
+  struct ddsi_type *type = get_ddsi_type (&denum);
+  CU_ASSERT_EQ_FATAL (type->xt._u.enum_type.literals.length, 2);
+  CU_ASSERT_EQ_FATAL (type->xt._u.enum_type.literals.seq[0].value, -4);
+  CU_ASSERT_EQ_FATAL (type->xt._u.enum_type.literals.seq[1].value, -3);
+
+  dds_dynamic_type_unref (&denum);
+}
+
+CU_Test (ddsc_dynamic_type, enum_bit_bound_one, .init = dynamic_type_init, .fini = dynamic_type_fini)
+{
+  dds_dynamic_type_t denum = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_ENUMERATION, .name = "e" });
+  dds_return_t ret = dds_dynamic_type_set_bit_bound (&denum, 1);
+  CU_ASSERT_EQ_FATAL (ret, DDS_RETCODE_OK);
+  ret = dds_dynamic_type_add_enum_literal (&denum, "e_neg1", DDS_DYNAMIC_ENUM_LITERAL_VALUE (-1), false);
+  CU_ASSERT_EQ_FATAL (ret, DDS_RETCODE_OK);
+  ret = dds_dynamic_type_add_enum_literal (&denum, "e_auto0", DDS_DYNAMIC_ENUM_LITERAL_VALUE_AUTO, false);
+  CU_ASSERT_EQ_FATAL (ret, DDS_RETCODE_OK);
+
+  struct ddsi_type *type = get_ddsi_type (&denum);
+  CU_ASSERT_EQ_FATAL (type->xt._u.enum_type.bit_bound, 1);
+  CU_ASSERT_EQ_FATAL (type->xt._u.enum_type.literals.length, 2);
+  CU_ASSERT_EQ_FATAL (type->xt._u.enum_type.literals.seq[0].value, -1);
+  CU_ASSERT_EQ_FATAL (type->xt._u.enum_type.literals.seq[1].value, 0);
+  dds_dynamic_type_unref (&denum);
+
+  denum = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_ENUMERATION, .name = "e" });
+  dds_dynamic_type_set_bit_bound (&denum, 1);
+  ret = dds_dynamic_type_add_enum_literal (&denum, "e1", DDS_DYNAMIC_ENUM_LITERAL_VALUE (1), false);
+  CU_ASSERT_EQ_FATAL (ret, DDS_RETCODE_BAD_PARAMETER);
+  dds_dynamic_type_unref (&denum);
+
+  denum = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_ENUMERATION, .name = "e" });
+  dds_dynamic_type_set_bit_bound (&denum, 1);
+  ret = dds_dynamic_type_add_enum_literal (&denum, "e_auto0", DDS_DYNAMIC_ENUM_LITERAL_VALUE_AUTO, false);
+  CU_ASSERT_EQ_FATAL (ret, DDS_RETCODE_OK);
+  ret = dds_dynamic_type_add_enum_literal (&denum, "e_auto1", DDS_DYNAMIC_ENUM_LITERAL_VALUE_AUTO, false);
+  CU_ASSERT_EQ_FATAL (ret, DDS_RETCODE_BAD_PARAMETER);
   dds_dynamic_type_unref (&denum);
 }
 
@@ -452,6 +502,18 @@ CU_Test (ddsc_dynamic_type, enum_literal_invalid, .init = dynamic_type_init, .fi
   dds_dynamic_type_set_bit_bound (&denum, 2);
   ret = dds_dynamic_type_add_enum_literal (&denum, "e1", DDS_DYNAMIC_ENUM_LITERAL_VALUE (4), false);
   CU_ASSERT_EQ_FATAL (ret, DDS_RETCODE_BAD_PARAMETER);
+  dds_dynamic_type_unref (&denum);
+
+  denum = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_ENUMERATION, .name = "e" });
+  dds_dynamic_type_set_bit_bound (&denum, 2);
+  ret = dds_dynamic_type_add_enum_literal (&denum, "e1", DDS_DYNAMIC_ENUM_LITERAL_VALUE (2), false);
+  CU_ASSERT_EQ_FATAL (ret, DDS_RETCODE_BAD_PARAMETER);
+  dds_dynamic_type_unref (&denum);
+
+  denum = dds_dynamic_type_create (participant, (dds_dynamic_type_descriptor_t) { .kind = DDS_DYNAMIC_ENUMERATION, .name = "e" });
+  dds_dynamic_type_set_bit_bound (&denum, 2);
+  ret = dds_dynamic_type_add_enum_literal (&denum, "e_min", DDS_DYNAMIC_ENUM_LITERAL_VALUE (-2), false);
+  CU_ASSERT_EQ (ret, DDS_RETCODE_OK);
   dds_dynamic_type_unref (&denum);
 }
 

--- a/src/core/ddsc/tests/dynamic_type.c
+++ b/src/core/ddsc/tests/dynamic_type.c
@@ -549,9 +549,13 @@ CU_Test (ddsc_dynamic_type, union_member_prop, .init = dynamic_type_init, .fini 
   // Because of the set_hashid, from this point the member has a different id
   ret = dds_dynamic_member_set_external (&dunion, ddsi_dynamic_type_member_hashid ("m2_name"), true);
   CU_ASSERT_EQ_FATAL (ret, DDS_RETCODE_OK);
+  ret = dds_dynamic_member_set_try_construct (&dunion, 0, DDS_DYNAMIC_MEMBER_TRY_CONSTRUCT_USE_DEFAULT);
+  CU_ASSERT_EQ_FATAL (ret, DDS_RETCODE_OK);
 
   struct ddsi_type *type = get_ddsi_type (&dunion);
   CU_ASSERT_EQ_FATAL (type->xt._u.union_type.members.length, 3);
+  CU_ASSERT_EQ_FATAL (type->xt._u.union_type.disc_flags & (DDS_XTypes_TRY_CONSTRUCT1 | DDS_XTypes_TRY_CONSTRUCT2), DDS_XTypes_TRY_CONSTRUCT_USE_DEFAULT);
+  CU_ASSERT_NEQ_FATAL (type->xt._u.union_type.disc_flags & DDS_XTypes_IS_MUST_UNDERSTAND, 0);
 
   CU_ASSERT_EQ_FATAL (type->xt._u.union_type.members.seq[0].id, ddsi_dynamic_type_member_hashid ("m1"));
   CU_ASSERT_FATAL (!(type->xt._u.union_type.members.seq[0].flags & DDS_XTypes_IS_EXTERNAL));

--- a/src/core/ddsc/tests/serdata_keys.c
+++ b/src/core/ddsc/tests/serdata_keys.c
@@ -1437,12 +1437,14 @@ CU_Test(ddsc_serdata, key_serialization)
   for (uint32_t test_index = 0; test_index < sizeof (tests) / sizeof (tests[0]); test_index++)
   {
     dds_entity_t participant = create_pp (0);
+    const uint32_t supported_representations = dds_stream_supported_data_representations (tests[test_index].desc->m_ops);
+    CU_ASSERT_NEQ_FATAL (supported_representations, 0u);
 
     for (uint32_t dr = 0; dr < sizeof (data_repr) / sizeof (data_repr[0]); dr++)
     {
+      const uint32_t representation_flag = data_repr[dr] == DDS_DATA_REPRESENTATION_XCDR1 ? DDS_DATA_REPRESENTATION_FLAG_XCDR1 : DDS_DATA_REPRESENTATION_FLAG_XCDR2;
       tprintf ("\ntest type %s (XCDRv%u)\n", tests[test_index].desc->m_typename, dr + 1);
-      if (dds_stream_minimum_xcdr_version (tests[test_index].desc->m_ops) == DDSI_RTPS_CDR_ENC_VERSION_2
-          && data_repr[dr] != DDS_DATA_REPRESENTATION_XCDR2)
+      if (!(supported_representations & representation_flag))
       {
         tprintf ("xcdrv not supported\n");
         continue;

--- a/src/core/ddsc/tests/typebuilder.c
+++ b/src/core/ddsc/tests/typebuilder.c
@@ -142,7 +142,7 @@ CU_TheoryDataPoints (ddsc_typebuilder, topic_desc) = {
                  &D(t33), &D(t34), &D(t35), &D(t36), &D(t37), &D(t38), /* TODO &D(t39), */
                  &D(t40), &D(t41), &D(t42), &D(t43), &D(t44), &D(t45), &D(t46), &D(t47),
                  &D(t48), &D(t49), &D(t50), &D(t51), &D(t52), &D(t53), &D(t54), &D(t55),
-                 &D(t56), &D(t57), &D(t58) ),
+                 &D(t56), &D(t57), &D(t58), &D(t59), &D(t60), &D(t61), &D(t62) ),
 };
 #undef D
 
@@ -193,7 +193,7 @@ CU_Theory((const dds_topic_descriptor_t *desc), ddsc_typebuilder, topic_desc, .i
   uint32_t ops_cnt = dds_stream_countops (desc->m_ops, desc->m_nkeys, desc->m_keys);
   tprintf ("ops count: %u (%u)\n", ops_cnt_gen, ops_cnt);
   CU_ASSERT_EQ_FATAL (ops_cnt_gen, ops_cnt);
-  for (uint32_t n = 0; n < ops_cnt; n++)
+  for (uint32_t n = 0; n < desc->m_nops; n++)
   {
     if (desc->m_ops[n] != generated_desc->m_ops[n])
     {

--- a/src/core/ddsc/tests/typewrap.c
+++ b/src/core/ddsc/tests/typewrap.c
@@ -1595,17 +1595,17 @@ CU_Test (ddsc_typewrap, invalid_enum_typeobject, .init = typewrap_init, .fini = 
       sizeof (duplicate_name_run) / sizeof (duplicate_name_run[0]), DDS_RETCODE_BAD_PARAMETER);
 
   const struct enum_literal too_large_two_bits[] = {
-    { "TwoBitsMin", 0 },
-    { "TwoBitsMax", 3 },
-    { "TwoBitsTooLarge", 4 }
+    { "TwoBitsMin", -2 },
+    { "TwoBitsMax", 1 },
+    { "TwoBitsTooLarge", 2 }
   };
   check_enum_typeobject ("TooLargeForTwoBits", 2, too_large_two_bits,
       sizeof (too_large_two_bits) / sizeof (too_large_two_bits[0]), DDS_RETCODE_BAD_PARAMETER);
 
   const struct enum_literal too_large_eight_bits[] = {
-    { "EightBitsMin", 0 },
-    { "EightBitsMax", 255 },
-    { "EightBitsTooLarge", 256 }
+    { "EightBitsMin", -128 },
+    { "EightBitsMax", 127 },
+    { "EightBitsTooLarge", 128 }
   };
   check_enum_typeobject ("TooLargeForEightBits", 8, too_large_eight_bits,
       sizeof (too_large_eight_bits) / sizeof (too_large_eight_bits[0]), DDS_RETCODE_BAD_PARAMETER);
@@ -1617,7 +1617,7 @@ CU_Test (ddsc_typewrap, invalid_enum_typeobject, .init = typewrap_init, .fini = 
     { "NegativeMid", 0 }
   };
   check_enum_typeobject ("NegativeValues", 1, negative_values,
-      sizeof (negative_values) / sizeof (negative_values[0]), DDS_RETCODE_BAD_PARAMETER);
+      sizeof (negative_values) / sizeof (negative_values[0]), DDS_RETCODE_OK);
 }
 
 CU_Test (ddsc_typewrap, invalid_bitmask_typeobject, .init = typewrap_init, .fini = typewrap_fini)

--- a/src/core/ddsc/tests/xtypes_assignability.c
+++ b/src/core/ddsc/tests/xtypes_assignability.c
@@ -41,6 +41,7 @@
 
 #include "XSpace.h"
 #include "XSpaceEnum.h"
+#include "XSpaceEnumUnion.h"
 #include "XSpaceMustUnderstand.h"
 #include "XSpaceTypeConsistencyEnforcement.h"
 #include "XSpaceNoTypeInfo.h"
@@ -664,3 +665,69 @@ CU_Theory ((const dds_topic_descriptor_t *rd_desc, const dds_topic_descriptor_t 
 }
 
 #undef DB
+
+/* Union discriminator enum defaulting test cases */
+static void sample_init_enum_union_extra_explicit_long (void *ptr)
+{
+  XSpaceEnumUnionWr_extra_explicit_long *sample = (XSpaceEnumUnionWr_extra_explicit_long *) ptr;
+  sample->_d = XSpaceEnumUnionWr_C;
+  sample->_u.c = 42;
+}
+
+static void sample_check_enum_union_extra_explicit_long (void *wrptr, void *rdptr)
+{
+  XSpaceEnumUnionWr_extra_explicit_long *wr_sample = (XSpaceEnumUnionWr_extra_explicit_long *) wrptr;
+  XSpaceEnumUnionRd_explicit_default_string *rd_sample = (XSpaceEnumUnionRd_explicit_default_string *) rdptr;
+  CU_ASSERT_EQ_FATAL (wr_sample->_d, XSpaceEnumUnionWr_C);
+  CU_ASSERT_EQ_FATAL (rd_sample->_d, XSpaceEnumUnionRd_A);
+  CU_ASSERT_EQ_FATAL (rd_sample->_u.a, wr_sample->_u.c);
+}
+
+static void sample_init_enum_union_extra_default_long (void *ptr)
+{
+  XSpaceEnumUnionWr_extra_default_long *sample = (XSpaceEnumUnionWr_extra_default_long *) ptr;
+  sample->_d = XSpaceEnumUnionWr_C;
+  sample->_u.x = 73;
+}
+
+static void sample_check_enum_union_extra_default_long (void *wrptr, void *rdptr)
+{
+  XSpaceEnumUnionWr_extra_default_long *wr_sample = (XSpaceEnumUnionWr_extra_default_long *) wrptr;
+  XSpaceEnumUnionRd_explicit_long *rd_sample = (XSpaceEnumUnionRd_explicit_long *) rdptr;
+  CU_ASSERT_EQ_FATAL (wr_sample->_d, XSpaceEnumUnionWr_C);
+  CU_ASSERT_EQ_FATAL (rd_sample->_d, XSpaceEnumUnionRd_A);
+  CU_ASSERT_EQ_FATAL (rd_sample->_u.a, wr_sample->_u.x);
+}
+
+static void sample_init_bitmask_uint8_default_long (void *ptr)
+{
+  XSpaceEnumUnionWr_uint8_default_long *sample = (XSpaceEnumUnionWr_uint8_default_long *) ptr;
+  sample->_d = 4;
+  sample->_u.x = 91;
+}
+
+static void sample_check_bitmask_uint8_default_long (void *wrptr, void *rdptr)
+{
+  XSpaceEnumUnionWr_uint8_default_long *wr_sample = (XSpaceEnumUnionWr_uint8_default_long *) wrptr;
+  XSpaceEnumUnionRd_bitmask_uint_default_long *rd_sample = (XSpaceEnumUnionRd_bitmask_uint_default_long *) rdptr;
+  CU_ASSERT_EQ_FATAL (wr_sample->_d, 4);
+  CU_ASSERT_EQ_FATAL (rd_sample->_d, 0);
+  CU_ASSERT_EQ_FATAL (rd_sample->_u.z, wr_sample->_u.x);
+}
+
+CU_Test (ddsc_xtypes_assignability, enum_union_discriminator_try_construct_default, .init = xtypes_assignability_init, .fini = xtypes_assignability_fini)
+{
+  do_test (&XSpaceEnumUnionRd_explicit_default_string_desc, NULL, &XSpaceEnumUnionWr_extra_explicit_long_desc, NULL, true, sample_init_enum_union_extra_explicit_long, true, sample_check_enum_union_extra_explicit_long);
+  do_test (&XSpaceEnumUnionRd_explicit_long_desc, NULL, &XSpaceEnumUnionWr_extra_default_long_desc, NULL, true, sample_init_enum_union_extra_default_long, true, sample_check_enum_union_extra_default_long);
+  do_test (&XSpaceEnumUnionRd_explicit_default_string_desc, NULL, &XSpaceEnumUnionWr_extra_explicit_string_desc, NULL, false, 0, false, 0);
+  do_test (&XSpaceEnumUnionRd_explicit_long_desc, NULL, &XSpaceEnumUnionWr_extra_default_string_desc, NULL, false, 0, false, 0);
+  do_test (&XSpaceEnumUnionRd_explicit_long_desc, NULL, &XSpaceEnumUnionWr_extra_implicit_none_desc, NULL, false, 0, false, 0);
+}
+
+CU_Test (ddsc_xtypes_assignability, bitmask_uint_union_discriminator_try_construct_default, .init = xtypes_assignability_init, .fini = xtypes_assignability_fini)
+{
+  do_test (&XSpaceEnumUnionRd_bitmask_uint_default_long_desc, NULL, &XSpaceEnumUnionWr_uint8_default_long_desc, NULL, true, sample_init_bitmask_uint8_default_long, true, sample_check_bitmask_uint8_default_long);
+  do_test (&XSpaceEnumUnionRd_bitmask_uint_default_long_desc, NULL, &XSpaceEnumUnionWr_uint8_default_string_desc, NULL, false, 0, false, 0);
+  do_test (&XSpaceEnumUnionRd_bitmask_uint_default_long_desc, NULL, &XSpaceEnumUnionWr_bitmask_implicit_none_desc, NULL, false, 0, false, 0);
+  do_test (&XSpaceEnumUnionRd_bitmask_uint_default_long_desc, NULL, &XSpaceEnumUnionWr_uint8_implicit_none_desc, NULL, false, 0, false, 0);
+}

--- a/src/core/ddsc/tests/xtypes_assignability.c
+++ b/src/core/ddsc/tests/xtypes_assignability.c
@@ -647,3 +647,20 @@ CU_Theory ((const dds_topic_descriptor_t *rd_desc, const dds_topic_descriptor_t 
 #undef DM
 #undef DL
 #undef I
+
+/* Bitmask extensibility test cases */
+#define DB(n) XSpaceBitmask_ ## n ## _desc
+CU_TheoryDataPoints (ddsc_xtypes_assignability, bitmask_extensibility) = {
+  CU_DataPoints (const dds_topic_descriptor_t *, &DB(rd_f),     &DB(rd_f),          &DB(rd_f),         &DB(rd_f),        &DB(rd_f),        &DB(rd_a),     &DB(rd_a),          &DB(rd_a),         &DB(rd_a),        &DB(rd_a)        ),
+  CU_DataPoints (const dds_topic_descriptor_t *, &DB(wr_f),     &DB(wr_f_plus),     &DB(wr_f_min),     &DB(wr_a_plus),   &DB(wr_f_wide),   &DB(wr_a),     &DB(wr_a_plus),     &DB(wr_a_min),     &DB(wr_f_plus),   &DB(wr_a_wide)   ),
+  CU_DataPoints (bool,                          true,          true,              true,             true,             false,            true,          true,              true,             true,             false            )
+};
+
+CU_Theory ((const dds_topic_descriptor_t *rd_desc, const dds_topic_descriptor_t *wr_desc, bool assignable),
+    ddsc_xtypes_assignability, bitmask_extensibility, .init = xtypes_assignability_init, .fini = xtypes_assignability_fini)
+{
+  tprintf ("Running test xtypes_bitmask: %s %s\n", wr_desc->m_typename, rd_desc->m_typename);
+  do_test (rd_desc, NULL, wr_desc, NULL, assignable, 0, false, 0);
+}
+
+#undef DB

--- a/src/core/ddsi/src/ddsi_dynamic_type.c
+++ b/src/core/ddsi/src/ddsi_dynamic_type.c
@@ -870,37 +870,49 @@ dds_return_t ddsi_dynamic_type_add_union_member (struct ddsi_type *type, struct 
   return DDS_RETCODE_OK;
 }
 
+static int32_t dynamic_type_enum_value_min (uint16_t bit_bound)
+{
+  return (bit_bound >= 32) ? INT32_MIN : -(int32_t) (UINT32_C (1) << (bit_bound - 1));
+}
+
+static int32_t dynamic_type_enum_value_max (uint16_t bit_bound)
+{
+  return (bit_bound >= 32) ? INT32_MAX : (int32_t) ((UINT32_C (1) << (bit_bound - 1)) - 1);
+}
+
 dds_return_t ddsi_dynamic_type_add_enum_literal (struct ddsi_type *type, struct ddsi_dynamic_type_enum_literal_param params)
 {
   assert (type->state == DDSI_TYPE_CONSTRUCTING);
   assert (type->xt._d == DDS_XTypes_TK_ENUM);
 
-  /* Get maximum value for a literal in this enum. Type object has long type
-     to store the literal value, so limited to int32_max */
+  /* Dynamic enum literals are semantic signed Int32 values. Range checks use
+     @bit_bound; cdrstream image conversion happens later in typebuilder. */
   assert (type->xt._u.enum_type.bit_bound <= 32);
-  uint32_t max_literal_value = (uint32_t) (1ull << (uint64_t) type->xt._u.enum_type.bit_bound) - 1;
-  if (max_literal_value > INT32_MAX)
-    max_literal_value = INT32_MAX;
+  const int32_t min_literal_value = dynamic_type_enum_value_min (type->xt._u.enum_type.bit_bound);
+  const int32_t max_literal_value = dynamic_type_enum_value_max (type->xt._u.enum_type.bit_bound);
 
-  if (type->xt._u.enum_type.literals.length >= max_literal_value)
+  if (type->xt._u.enum_type.literals.length == UINT32_MAX)
     return DDS_RETCODE_BAD_PARAMETER;
 
   int32_t literal_value = 0;
   if (params.is_auto_value)
   {
-    for (uint32_t n = 0; n < type->xt._u.enum_type.literals.length; n++)
+    if (type->xt._u.enum_type.literals.length > 0)
     {
-      if (type->xt._u.enum_type.literals.seq[n].value >= (int32_t) literal_value)
+      int32_t max_value = type->xt._u.enum_type.literals.seq[0].value;
+      for (uint32_t n = 1; n < type->xt._u.enum_type.literals.length; n++)
       {
-        if (type->xt._u.enum_type.literals.seq[n].value == (int32_t) max_literal_value)
-          return DDS_RETCODE_BAD_PARAMETER;
-        literal_value = type->xt._u.enum_type.literals.seq[n].value + 1;
+        if (type->xt._u.enum_type.literals.seq[n].value > max_value)
+          max_value = type->xt._u.enum_type.literals.seq[n].value;
       }
+      if (max_value == max_literal_value)
+        return DDS_RETCODE_BAD_PARAMETER;
+      literal_value = max_value + 1;
     }
   }
   else
   {
-    if ((uint32_t) params.value > max_literal_value)
+    if (params.value < min_literal_value || params.value > max_literal_value)
       return DDS_RETCODE_BAD_PARAMETER;
     for (uint32_t n = 0; n < type->xt._u.enum_type.literals.length; n++)
       if (type->xt._u.enum_type.literals.seq[n].value == params.value)

--- a/src/core/ddsi/src/ddsi_dynamic_type.c
+++ b/src/core/ddsi/src/ddsi_dynamic_type.c
@@ -1167,7 +1167,12 @@ dds_return_t ddsi_dynamic_type_member_set_try_construct (struct ddsi_type *type,
   else
   {
     if ((ret = find_union_member (type, member_id, &member_index)) == DDS_RETCODE_OK)
-      set_try_construct (&type->xt._u.union_type.members.seq[member_index].flags, try_construct);
+    {
+      uint16_t * const flags = (member_index == UINT32_MAX)
+        ? &type->xt._u.union_type.disc_flags
+        : &type->xt._u.union_type.members.seq[member_index].flags;
+      set_try_construct (flags, try_construct);
+    }
   }
   return ret;
 }

--- a/src/core/ddsi/src/ddsi_sertype_cdr.c
+++ b/src/core/ddsi/src/ddsi_sertype_cdr.c
@@ -157,13 +157,6 @@ dds_return_t ddsi_sertype_cdr_init (const struct ddsi_domaingv *gv, struct ddsi_
 
   dds_cdrstream_desc_init_with_nops (&st->type, &dds_cdrstream_default_allocator, desc->m_size, desc->m_align, desc->m_flagset, desc->m_ops, desc->m_nops, desc->m_keys, desc->m_nkeys);
 
-  if (dds_stream_type_nesting_depth (desc->m_ops) > DDS_CDRSTREAM_MAX_NESTING_DEPTH)
-  {
-    ddsi_sertype_unref (&st->c);
-    GVTRACE ("Serializer ops for type %s has unsupported nesting depth (max %u)\n", desc->m_typename, DDS_CDRSTREAM_MAX_NESTING_DEPTH);
-    return DDS_RETCODE_BAD_PARAMETER;
-  }
-
   st->type.opt_size_xcdr2 = dds_stream_check_optimize (&st->type, DDSI_RTPS_CDR_ENC_VERSION_2);
   if (st->type.opt_size_xcdr2 > 0)
     GVTRACE ("Marshalling XCDR2 for type: %s is %soptimised\n", st->c.type_name, st->type.opt_size_xcdr2 ? "" : "not ");

--- a/src/core/ddsi/src/ddsi_typebuilder.c
+++ b/src/core/ddsi/src/ddsi_typebuilder.c
@@ -643,10 +643,9 @@ static dds_return_t typebuilder_add_type (struct typebuilder_data *tbd, uint32_t
       tb_type->args.bitmask_args.bits_l = (uint32_t) (bits & 0xffffffffu);
       tb_type->args.bitmask_args.bits_h = (uint32_t) (bits >> 32);
       tb_type->args.bitmask_args.bit_bound = type->xt._u.bitmask.bit_bound;
-      if (type->xt._u.bitmask.flags & DDS_XTypes_IS_FINAL)
-        tb_type->args.bitmask_args.tc = TYPEBUILDER_TC_REJECT;
-      else
-        tb_type->args.bitmask_args.tc = tc;
+      /* Unlike enum, a bitmask can be assignable from an unsigned integer, so
+         final bitmasks must preserve the declared try-construct mode. */
+      tb_type->args.bitmask_args.tc = tc;
       if (type->xt._u.bitmask.bit_bound > 32)
       {
         *align = ALGN (uint64_t, is_ext);

--- a/src/core/ddsi/src/ddsi_typebuilder.c
+++ b/src/core/ddsi/src/ddsi_typebuilder.c
@@ -40,12 +40,15 @@
   if ((ret = set_op (ops, (idx), (val))) != DDS_RETCODE_OK) \
     return ret;
 
+struct typebuilder_data;
+
 struct typebuilder_ops
 {
   uint32_t *ops;
   uint32_t index;
   uint32_t maximum;
   uint32_t n_ops;
+  struct typebuilder_data *tbd;
 };
 
 struct typebuilder_type;
@@ -92,7 +95,12 @@ struct typebuilder_type
     struct {
       uint32_t bit_bound;
       uint32_t max;
+      uint32_t default_value;
+      uint32_t nvalues;
+      uint32_t *values;
       enum typebuilder_try_construct tc;
+      bool needs_value_metadata;
+      const struct ddsi_type *type;
     } enum_args;
     struct {
       uint32_t bit_bound;
@@ -212,6 +220,14 @@ struct typebuilder_key
   struct typebuilder_key_path *path;
 };
 
+struct typebuilder_enum_use
+{
+  const struct ddsi_type *type;
+  const struct typebuilder_type *tb_type;
+  uint32_t insn_offs;
+  struct typebuilder_enum_use *next;
+};
+
 #define NOARG
 DDSI_LIST_TYPES_TMPL(typebuilder_dep_types, struct typebuilder_aggregated_type *, NOARG, 32)
 #undef NOARG
@@ -224,6 +240,7 @@ struct typebuilder_data
   struct typebuilder_dep_types dep_types;
   uint32_t n_keys;
   struct typebuilder_key *keys;
+  struct typebuilder_enum_use *enum_uses;
   bool fixed_size;
 };
 
@@ -274,6 +291,9 @@ static void typebuilder_type_fini (struct typebuilder_type *tb_type)
         ddsrt_free (tb_type->args.collection_args.element_type.type);
       }
       break;
+    case DDS_OP_VAL_ENU:
+      ddsrt_free (tb_type->args.enum_args.values);
+      break;
     default:
       break;
   }
@@ -294,6 +314,7 @@ static void typebuilder_struct_fini (struct typebuilder_struct *tb_struct)
 
 static void typebuilder_union_fini (struct typebuilder_union *tb_union)
 {
+  typebuilder_type_fini (&tb_union->disc_type);
   if (tb_union->cases)
   {
     for (uint32_t n = 0; n < tb_union->n_cases; n++)
@@ -339,6 +360,13 @@ static void typebuilder_data_free (struct typebuilder_data *tbd)
     ddsrt_free (tb_aggrtype);
   }
   typebuilder_dep_types_free (&tbd->dep_types);
+
+  while (tbd->enum_uses)
+  {
+    struct typebuilder_enum_use *next = tbd->enum_uses->next;
+    ddsrt_free (tbd->enum_uses);
+    tbd->enum_uses = next;
+  }
 
   for (uint32_t n = 0; n < tbd->n_keys; n++)
   {
@@ -456,6 +484,18 @@ static enum typebuilder_try_construct get_tc (uint16_t flags)
   return TYPEBUILDER_TC_REJECT;
 }
 
+static int uint32_cmp (const void *va, const void *vb)
+{
+  const uint32_t a = *((const uint32_t *) va);
+  const uint32_t b = *((const uint32_t *) vb);
+  return (a > b) - (a < b);
+}
+
+static bool typebuilder_enum_needs_value_metadata (uint32_t max, uint32_t nvalues, uint32_t default_value)
+{
+  return nvalues == 0 || default_value != 0 || max != nvalues - 1;
+}
+
 static dds_return_t typebuilder_add_type (struct typebuilder_data *tbd, uint32_t *size, uint32_t *align, struct typebuilder_type *tb_type, const struct ddsi_type *type, bool is_ext, bool use_ext_type, enum typebuilder_try_construct tc)
 {
   assert (tbd);
@@ -542,15 +582,34 @@ static dds_return_t typebuilder_add_type (struct typebuilder_data *tbd, uint32_t
     }
     case DDS_XTypes_TK_ENUM: {
       uint32_t max = 0;
+      uint32_t default_value = 0;
+      const uint32_t nvalues = type->xt._u.enum_type.literals.length;
+      uint32_t *values = nvalues ? ddsrt_calloc (nvalues, sizeof (*values)) : NULL;
+      if (nvalues && values == NULL)
+      {
+        ret = DDS_RETCODE_OUT_OF_RESOURCES;
+        break;
+      }
       for (uint32_t n = 0; n < type->xt._u.enum_type.literals.length; n++)
       {
         assert (type->xt._u.enum_type.literals.seq[n].value >= 0);
-        if ((uint32_t) type->xt._u.enum_type.literals.seq[n].value > max)
-          max = (uint32_t) type->xt._u.enum_type.literals.seq[n].value;
+        const uint32_t value = (uint32_t) type->xt._u.enum_type.literals.seq[n].value;
+        values[n] = value;
+        if (value > max)
+          max = value;
+        if (n == 0 || (type->xt._u.enum_type.literals.seq[n].flags & DDS_XTypes_IS_DEFAULT))
+          default_value = value;
       }
+      if (nvalues > 1)
+        qsort (values, nvalues, sizeof (*values), uint32_cmp);
       tb_type->type_code = DDS_OP_VAL_ENU;
       tb_type->args.enum_args.max = max;
+      tb_type->args.enum_args.default_value = default_value;
+      tb_type->args.enum_args.nvalues = nvalues;
+      tb_type->args.enum_args.values = values;
       tb_type->args.enum_args.bit_bound = type->xt._u.enum_type.bit_bound;
+      tb_type->args.enum_args.needs_value_metadata = typebuilder_enum_needs_value_metadata (max, nvalues, default_value);
+      tb_type->args.enum_args.type = type;
       if (type->xt._u.enum_type.flags & DDS_XTypes_IS_FINAL)
         tb_type->args.enum_args.tc = TYPEBUILDER_TC_REJECT;
       else
@@ -964,6 +1023,35 @@ static void or_op (struct typebuilder_ops *ops, uint32_t index, uint32_t value)
   ops->ops[index] |= value;
 }
 
+static uint32_t typebuilder_enum_descriptor_max (const struct typebuilder_type *tb_type)
+{
+  return tb_type->args.enum_args.needs_value_metadata ? UINT32_MAX : tb_type->args.enum_args.max;
+}
+
+static dds_return_t typebuilder_add_enum_use (struct typebuilder_ops *ops, const struct typebuilder_type *tb_type, uint32_t insn_offs)
+{
+  if (tb_type->type_code != DDS_OP_VAL_ENU || !tb_type->args.enum_args.needs_value_metadata)
+    return DDS_RETCODE_OK;
+
+  struct typebuilder_enum_use *use = ddsrt_calloc (1, sizeof (*use));
+  if (use == NULL)
+    return DDS_RETCODE_OUT_OF_RESOURCES;
+  use->type = tb_type->args.enum_args.type;
+  use->tb_type = tb_type;
+  use->insn_offs = insn_offs;
+
+  if (ops->tbd->enum_uses == NULL)
+    ops->tbd->enum_uses = use;
+  else
+  {
+    struct typebuilder_enum_use *last = ops->tbd->enum_uses;
+    while (last->next)
+      last = last->next;
+    last->next = use;
+  }
+  return DDS_RETCODE_OK;
+}
+
 static uint32_t get_type_flags (const struct typebuilder_type *tb_type, bool for_subtype)
 {
   uint32_t flags = 0;
@@ -1016,9 +1104,11 @@ static dds_return_t get_ops_type (struct typebuilder_type *tb_type, uint32_t fla
       break;
     case DDS_OP_VAL_ENU:
       flags |= get_type_flags (tb_type, false);
+      if ((ret = typebuilder_add_enum_use (ops, tb_type, ops->index)) != DDS_RETCODE_OK)
+        goto err;
       PUSH_OP ((uint32_t) DDS_OP_ADR | type_code_to_op_type (tb_type->type_code) | flags);
       PUSH_ARG (member_offset);
-      PUSH_ARG (tb_type->args.enum_args.max);
+      PUSH_ARG (typebuilder_enum_descriptor_max (tb_type));
       break;
     case DDS_OP_VAL_BMK:
       flags |= get_type_flags (tb_type, false);
@@ -1059,7 +1149,9 @@ static dds_return_t get_ops_type (struct typebuilder_type *tb_type, uint32_t fla
         case DDS_OP_VAL_16BY:
           break;
         case DDS_OP_VAL_ENU:
-          PUSH_ARG (element_type->args.enum_args.max);
+          if ((ret = typebuilder_add_enum_use (ops, element_type, adr_index)) != DDS_RETCODE_OK)
+            goto err;
+          PUSH_ARG (typebuilder_enum_descriptor_max (element_type));
           break;
         case DDS_OP_VAL_BMK:
           PUSH_ARG (element_type->args.bitmask_args.bits_h);
@@ -1117,7 +1209,9 @@ static dds_return_t get_ops_type (struct typebuilder_type *tb_type, uint32_t fla
         case DDS_OP_VAL_16BY:
           break;
         case DDS_OP_VAL_ENU:
-          PUSH_ARG (element_type->args.enum_args.max);
+          if ((ret = typebuilder_add_enum_use (ops, element_type, adr_index)) != DDS_RETCODE_OK)
+            goto err;
+          PUSH_ARG (typebuilder_enum_descriptor_max (element_type));
           break;
         case DDS_OP_VAL_BMK:
           PUSH_ARG (element_type->args.bitmask_args.bits_h);
@@ -1236,10 +1330,12 @@ static dds_return_t get_ops_union_case (struct typebuilder_type *tb_type, uint32
       break;
     case DDS_OP_VAL_ENU:
       flags |= get_type_flags (tb_type, false);
+      if ((ret = typebuilder_add_enum_use (ops, tb_type, ops->index)) != DDS_RETCODE_OK)
+        break;
       PUSH_OP ((uint32_t) DDS_OP_JEQ4 | type_code_to_op_type (tb_type->type_code) | flags);
       PUSH_ARG (disc_value);
       PUSH_ARG (offset);
-      PUSH_ARG (tb_type->args.enum_args.max);
+      PUSH_ARG (typebuilder_enum_descriptor_max (tb_type));
       break;
     case DDS_OP_VAL_STR:
     case DDS_OP_VAL_WSTR:
@@ -1340,13 +1436,15 @@ static dds_return_t get_ops_union (const struct typebuilder_union *tb_union, uin
     flags |= tb_union->cases[c].is_default ? DDS_OP_FLAG_DEF : 0u;
 
   uint32_t next_insn_offs = ops->index;
+  if (tb_union->disc_type.type_code == DDS_OP_VAL_ENU && (ret = typebuilder_add_enum_use (ops, &tb_union->disc_type, ops->index)) != DDS_RETCODE_OK)
+    return ret;
   PUSH_OP ((uint32_t) DDS_OP_ADR | (uint32_t) DDS_OP_TYPE_UNI | (uint32_t) (tb_union->disc_type.type_code << 8) | flags);
   PUSH_ARG (0u);
   PUSH_ARG (tb_union->n_cases);
   uint32_t next_insn_idx = ops->index;
   if (tb_union->disc_type.type_code == DDS_OP_VAL_ENU) {
     PUSH_ARG (5u);
-    PUSH_ARG (tb_union->disc_type.args.enum_args.max);
+    PUSH_ARG (typebuilder_enum_descriptor_max (&tb_union->disc_type));
   } else if (tb_union->disc_type.type_code == DDS_OP_VAL_BMK) {
     PUSH_ARG (6u);
     PUSH_ARG (tb_union->disc_type.args.bitmask_args.bits_h);
@@ -1992,6 +2090,93 @@ err:
   return ret;
 }
 
+struct typebuilder_enum_value_set_id
+{
+  const struct ddsi_type *type;
+  const struct typebuilder_type *tb_type;
+  uint32_t setid;
+  struct typebuilder_enum_value_set_id *next;
+};
+
+static struct typebuilder_enum_value_set_id *find_enum_value_set_id (struct typebuilder_enum_value_set_id *sets, const struct ddsi_type *type)
+{
+  while (sets)
+  {
+    if (sets->type == type)
+      return sets;
+    sets = sets->next;
+  }
+  return NULL;
+}
+
+static void free_enum_value_set_ids (struct typebuilder_enum_value_set_id *sets)
+{
+  while (sets)
+  {
+    struct typebuilder_enum_value_set_id *next = sets->next;
+    ddsrt_free (sets);
+    sets = next;
+  }
+}
+
+static dds_return_t emit_enum_value_set (struct typebuilder_ops *ops, const struct typebuilder_type *tb_type, uint32_t setid)
+{
+  dds_return_t ret;
+  assert (setid <= UINT16_MAX);
+  PUSH_OP (DDS_OP_EVS | setid);
+  PUSH_ARG (tb_type->args.enum_args.default_value);
+  PUSH_ARG (tb_type->args.enum_args.nvalues);
+  for (uint32_t n = 0; n < tb_type->args.enum_args.nvalues; n++)
+    PUSH_ARG (tb_type->args.enum_args.values[n]);
+  return DDS_RETCODE_OK;
+}
+
+static dds_return_t typebuilder_add_enum_value_metadata (struct typebuilder_data *tbd, struct typebuilder_ops *ops)
+{
+  dds_return_t ret;
+  struct typebuilder_enum_value_set_id *sets = NULL;
+  uint32_t nsets = 0;
+
+  for (const struct typebuilder_enum_use *use = tbd->enum_uses; use; use = use->next)
+  {
+    if (find_enum_value_set_id (sets, use->type) == NULL)
+    {
+      struct typebuilder_enum_value_set_id *set = ddsrt_calloc (1, sizeof (*set));
+      if (set == NULL)
+      {
+        free_enum_value_set_ids (sets);
+        return DDS_RETCODE_OUT_OF_RESOURCES;
+      }
+      set->type = use->type;
+      set->tb_type = use->tb_type;
+      set->setid = nsets++;
+      set->next = sets;
+      sets = set;
+      if ((ret = emit_enum_value_set (ops, set->tb_type, set->setid)) != DDS_RETCODE_OK)
+      {
+        free_enum_value_set_ids (sets);
+        return ret;
+      }
+    }
+  }
+  if (sets != NULL)
+    PUSH_OP (DDS_OP_RTS);
+
+  for (const struct typebuilder_enum_use *use = tbd->enum_uses; use; use = use->next)
+  {
+    struct typebuilder_enum_value_set_id *set = find_enum_value_set_id (sets, use->type);
+    assert (set != NULL);
+    assert (use->insn_offs <= UINT16_MAX);
+    PUSH_OP (DDS_OP_EVM | use->insn_offs);
+    PUSH_ARG (set->setid);
+  }
+  if (sets != NULL)
+    PUSH_OP (DDS_OP_RTS);
+
+  free_enum_value_set_ids (sets);
+  return DDS_RETCODE_OK;
+}
+
 static dds_return_t typebuilder_add_mid_table (struct typebuilder_data *tbd, struct typebuilder_ops *ops)
 {
   dds_return_t ret;
@@ -2012,7 +2197,7 @@ static dds_return_t typebuilder_add_mid_table (struct typebuilder_data *tbd, str
     va = van;
   }
 
-  return ret;
+  return typebuilder_add_enum_value_metadata (tbd, ops);
 }
 
 
@@ -2021,7 +2206,7 @@ static dds_return_t get_topic_descriptor (dds_topic_descriptor_t *desc, struct t
   dds_return_t ret;
   unsigned char *typeinfo_data = NULL, *typemap_data = NULL;
   uint32_t typeinfo_sz, typemap_sz;
-  struct typebuilder_ops ops = { NULL, 0, 0, 0 };
+  struct typebuilder_ops ops = { NULL, 0, 0, 0, tbd };
 
   if ((ret = ddsi_type_get_typeinfo_ser (tbd->gv, tbd->type, &typeinfo_data, &typeinfo_sz)) != DDS_RETCODE_OK)
     goto err;

--- a/src/core/ddsi/src/ddsi_typebuilder.c
+++ b/src/core/ddsi/src/ddsi_typebuilder.c
@@ -168,6 +168,12 @@ static uint32_t union_case_label_to_disc_value (const struct typebuilder_type *d
       return (uint8_t) label;
     case DDS_OP_VAL_2BY:
       return (uint16_t) label;
+    case DDS_OP_VAL_ENU:
+      if (disc_type->args.enum_args.bit_bound <= 8)
+        return (uint8_t) label;
+      if (disc_type->args.enum_args.bit_bound <= 16)
+        return (uint16_t) label;
+      return (uint32_t) label;
     default:
       return (uint32_t) label;
   }
@@ -491,9 +497,18 @@ static int uint32_cmp (const void *va, const void *vb)
   return (a > b) - (a < b);
 }
 
-static bool typebuilder_enum_needs_value_metadata (uint32_t max, uint32_t nvalues, uint32_t default_value)
+static uint32_t typebuilder_enum_value_image (uint32_t bit_bound, int32_t value)
 {
-  return nvalues == 0 || default_value != 0 || max != nvalues - 1;
+  if (bit_bound <= 8)
+    return (uint8_t) value;
+  if (bit_bound <= 16)
+    return (uint16_t) value;
+  return (uint32_t) value;
+}
+
+static bool typebuilder_enum_needs_value_metadata (int32_t max, uint32_t nvalues, int32_t default_value)
+{
+  return nvalues == 0 || default_value != 0 || max < 0 || (uint32_t) max != nvalues - 1;
 }
 
 static dds_return_t typebuilder_add_type (struct typebuilder_data *tbd, uint32_t *size, uint32_t *align, struct typebuilder_type *tb_type, const struct ddsi_type *type, bool is_ext, bool use_ext_type, enum typebuilder_try_construct tc)
@@ -581,8 +596,11 @@ static dds_return_t typebuilder_add_type (struct typebuilder_data *tbd, uint32_t
       break;
     }
     case DDS_XTypes_TK_ENUM: {
-      uint32_t max = 0;
-      uint32_t default_value = 0;
+      /* Keep signed literal semantics until descriptor emission. The descriptor's
+         value table uses holder images because cdrstream reads narrow enums as
+         unsigned bytes/words. */
+      int32_t max = INT32_MIN;
+      int32_t default_value = 0;
       const uint32_t nvalues = type->xt._u.enum_type.literals.length;
       uint32_t *values = nvalues ? ddsrt_calloc (nvalues, sizeof (*values)) : NULL;
       if (nvalues && values == NULL)
@@ -592,9 +610,8 @@ static dds_return_t typebuilder_add_type (struct typebuilder_data *tbd, uint32_t
       }
       for (uint32_t n = 0; n < type->xt._u.enum_type.literals.length; n++)
       {
-        assert (type->xt._u.enum_type.literals.seq[n].value >= 0);
-        const uint32_t value = (uint32_t) type->xt._u.enum_type.literals.seq[n].value;
-        values[n] = value;
+        const int32_t value = type->xt._u.enum_type.literals.seq[n].value;
+        values[n] = typebuilder_enum_value_image (type->xt._u.enum_type.bit_bound, value);
         if (value > max)
           max = value;
         if (n == 0 || (type->xt._u.enum_type.literals.seq[n].flags & DDS_XTypes_IS_DEFAULT))
@@ -603,8 +620,8 @@ static dds_return_t typebuilder_add_type (struct typebuilder_data *tbd, uint32_t
       if (nvalues > 1)
         qsort (values, nvalues, sizeof (*values), uint32_cmp);
       tb_type->type_code = DDS_OP_VAL_ENU;
-      tb_type->args.enum_args.max = max;
-      tb_type->args.enum_args.default_value = default_value;
+      tb_type->args.enum_args.max = (uint32_t) max;
+      tb_type->args.enum_args.default_value = (uint32_t) default_value;
       tb_type->args.enum_args.nvalues = nvalues;
       tb_type->args.enum_args.values = values;
       tb_type->args.enum_args.bit_bound = type->xt._u.enum_type.bit_bound;
@@ -2123,6 +2140,8 @@ static dds_return_t emit_enum_value_set (struct typebuilder_ops *ops, const stru
 {
   dds_return_t ret;
   assert (setid <= UINT16_MAX);
+  /* EVS default_value is the semantic int32 bit pattern for memory/defaulting.
+     EVS values are unsigned CDR holder images for membership tests. */
   PUSH_OP (DDS_OP_EVS | setid);
   PUSH_ARG (tb_type->args.enum_args.default_value);
   PUSH_ARG (tb_type->args.enum_args.nvalues);

--- a/src/core/ddsi/src/ddsi_typebuilder.c
+++ b/src/core/ddsi/src/ddsi_typebuilder.c
@@ -1892,8 +1892,10 @@ static dds_return_t add_memberids_struct (struct typebuilder_data *tbd, struct t
     struct typebuilder_struct_member *member = &tb_struct->members[n];
     if (member->is_optional && !is_mutable_struct)
     {
-      PUSH_OP (DDS_OP_MID);
-      PUSH_ARG (member->insn_offs);
+      const uint32_t insn_offs = member->parent->insn_offs + member->insn_offs;
+      assert (insn_offs <= DDS_KOF_OFFSET_MASK);
+      PUSH_OP (DDS_OP_MID | insn_offs);
+      PUSH_ARG (member->member_id);
     }
     switch (member->type.type_code)
     {

--- a/src/core/ddsi/src/ddsi_typewrap.c
+++ b/src/core/ddsi/src/ddsi_typewrap.c
@@ -993,6 +993,16 @@ struct xt_union_label_range {
   uint64_t max;
 };
 
+static int32_t xt_enum_value_min (DDS_XTypes_BitBound bit_bound)
+{
+  return (bit_bound >= 32) ? INT32_MIN : -(int32_t) (UINT32_C (1) << (bit_bound - 1));
+}
+
+static int32_t xt_enum_value_max (DDS_XTypes_BitBound bit_bound)
+{
+  return (bit_bound >= 32) ? INT32_MAX : (int32_t) ((UINT32_C (1) << (bit_bound - 1)) - 1);
+}
+
 static dds_return_t xt_union_label_range (const struct xt_type *disc_type, struct xt_union_label_range *range)
 {
   if (ddsi_xt_missing_definition (disc_type))
@@ -1036,9 +1046,11 @@ static dds_return_t xt_union_label_range (const struct xt_type *disc_type, struc
       range->min = 0; range->max = UINT64_MAX;
       break;
     case DDS_XTypes_TK_ENUM: {
-      // Enum values are signed 32-bit integers in type objects, so the maximum value is INT32_MAX
+      /* Validation operates on XTypes semantic values. The unsigned holder-image
+         form is only a cdrstream descriptor detail. */
       const DDS_XTypes_BitBound bit_bound = dt->_u.enum_type.bit_bound;
-      range->min = 0; range->max = (bit_bound >= 31) ? INT32_MAX : ((1u << bit_bound) - 1);
+      range->min = xt_enum_value_min (bit_bound);
+      range->max = (uint64_t) xt_enum_value_max (bit_bound);
       break;
     }
     case DDS_XTypes_TK_BITMASK: {
@@ -1252,7 +1264,8 @@ static dds_return_t xt_valid_enum_values (struct ddsi_domaingv *gv, const struct
 {
   assert (ddsi_xt_has_definition (t) && t->_d == DDS_XTypes_TK_ENUM);
   dds_return_t ret = DDS_RETCODE_OK;
-  const int32_t max = (t->_u.enum_type.bit_bound >= 31) ? INT32_MAX : (int32_t) ((1u << t->_u.enum_type.bit_bound) - 1);
+  const int32_t min = xt_enum_value_min (t->_u.enum_type.bit_bound);
+  const int32_t max = xt_enum_value_max (t->_u.enum_type.bit_bound);
 
   uint32_t cnt = t->_u.enum_type.literals.length;
   if (cnt == 0)
@@ -1280,7 +1293,7 @@ static dds_return_t xt_valid_enum_values (struct ddsi_domaingv *gv, const struct
   for (uint32_t n = 0; n < cnt; n++)
   {
     const int32_t value = t->_u.enum_type.literals.seq[n].value;
-    if (value < 0 || value > max)
+    if (value < min || value > max)
     {
       GVTRACE ("enum value %"PRId32" cannot be represented by bit_bound %"PRIu16"\n", value, t->_u.enum_type.bit_bound);
       ret = DDS_RETCODE_BAD_PARAMETER;

--- a/src/core/ddsi/src/ddsi_typewrap.c
+++ b/src/core/ddsi/src/ddsi_typewrap.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <limits.h>
+#include "dds/ddsrt/attributes.h"
 #include "dds/features.h"
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsrt/hopscotch.h"
@@ -3436,6 +3437,244 @@ static bool xt_union_labels_match (const struct DDS_XTypes_UnionCaseLabelSeq *ls
 }
 
 ddsrt_nonnull_all
+static bool xt_union_label_seq_contains (const struct DDS_XTypes_UnionCaseLabelSeq *ls, int32_t label)
+{
+  /* UnionCaseLabelSeq is ordered by value (as noted in typeobject idl) */
+  uint32_t a = 0, b = ls->_length;
+  while (a < b)
+  {
+    const uint32_t m = a + (b - a) / 2;
+    const int32_t y = ls->_buffer[m];
+    if (y < label)
+      a = m + 1;
+    else
+      b = m;
+  }
+  return a < ls->_length && ls->_buffer[a] == label;
+}
+
+ddsrt_nonnull_all
+static const struct xt_union_member *xt_union_default_member (const struct xt_type *t)
+{
+  assert (t->_d == DDS_XTypes_TK_UNION);
+  for (uint32_t n = 0; n < t->_u.union_type.members.length; n++)
+    if (t->_u.union_type.members.seq[n].flags & DDS_XTypes_IS_DEFAULT)
+      return &t->_u.union_type.members.seq[n];
+  return NULL;
+}
+
+ddsrt_nonnull_all
+static const struct xt_union_member *xt_union_explicit_member_for_label (const struct xt_type *t, int32_t label)
+{
+  assert (t->_d == DDS_XTypes_TK_UNION);
+  for (uint32_t n = 0; n < t->_u.union_type.members.length; n++)
+    if (xt_union_label_seq_contains (&t->_u.union_type.members.seq[n].label_seq, label))
+      return &t->_u.union_type.members.seq[n];
+  return NULL;
+}
+
+ddsrt_nonnull ((1))
+static const struct xt_union_member *xt_union_selected_member (const struct xt_type *t, const struct xt_union_member *def_m, int32_t label)
+{
+  const struct xt_union_member *m = xt_union_explicit_member_for_label (t, label);
+  return m ? m : def_m;
+}
+
+ddsrt_nonnull_all
+static int32_t xt_enum_default_value (const struct xt_type *t)
+{
+  assert (t->_d == DDS_XTypes_TK_ENUM);
+  assert (t->_u.enum_type.literals.length > 0);
+  for (uint32_t i = 0; i < t->_u.enum_type.literals.length; i++)
+    if (t->_u.enum_type.literals.seq[i].flags & DDS_XTypes_IS_DEFAULT)
+      return t->_u.enum_type.literals.seq[i].value;
+  return t->_u.enum_type.literals.seq[0].value;
+}
+
+static bool xt_try_construct_is_use_default (uint16_t flags)
+{
+  const uint16_t tc = DDS_XTypes_TRY_CONSTRUCT1 | DDS_XTypes_TRY_CONSTRUCT2;
+  return (flags & tc) == DDS_XTypes_TRY_CONSTRUCT_USE_DEFAULT;
+}
+
+struct xt_union_assignability_ctx {
+  const struct xt_type *t1, *t2;
+  const struct xt_type *t1_disc, *t2_disc;
+  const struct xt_union_member *t1_def_m, *t2_def_m;
+  const struct xt_union_member *t1_disc_def_m;
+  int32_t t1_disc_def_v;
+  bool t1_disc_use_def;
+};
+
+ddsrt_nonnull_all
+static bool xt_union_disc_value_valid (const struct xt_type *disc_type, int32_t label)
+{
+  switch (disc_type->_d)
+  {
+    case DDS_XTypes_TK_ENUM:
+      return xt_union_label_in_enum (disc_type, label);
+    case DDS_XTypes_TK_BITMASK:
+      return (((uint64_t) (uint32_t) label) & ~xt_union_label_bitmask_allowed_mask (disc_type)) == 0;
+    default:
+      return true;
+  }
+}
+
+static bool xt_type_is_uint (const struct xt_type *t)
+{
+  switch (t->_d)
+  {
+    case DDS_XTypes_TK_UINT8:
+    case DDS_XTypes_TK_UINT16:
+    case DDS_XTypes_TK_UINT32:
+    case DDS_XTypes_TK_UINT64:
+      return true;
+    default:
+      return false;
+  }
+}
+
+ddsrt_nonnull_all
+static uint64_t xt_uint_max (const struct xt_type *t)
+{
+  switch (t->_d)
+  {
+    case DDS_XTypes_TK_UINT8:
+      return UINT8_MAX;
+    case DDS_XTypes_TK_UINT16:
+      return UINT16_MAX;
+    case DDS_XTypes_TK_UINT32:
+      return UINT32_MAX;
+    case DDS_XTypes_TK_UINT64:
+      return UINT64_MAX;
+    default:
+      abort ();
+  }
+}
+
+static uint32_t xt_popcount64 (uint64_t x)
+{
+  uint32_t n = 0;
+  while (x != 0)
+  {
+    n += (uint32_t) (x & 1u);
+    x >>= 1;
+  }
+  return n;
+}
+
+static uint64_t xt_disc_value_count_from_bit_count (uint32_t bits)
+{
+  return (bits >= 64) ? UINT64_MAX : (UINT64_C (1) << bits);
+}
+
+ddsrt_nonnull_all
+static int32_t xt_union_disc_default_value (const struct xt_type *disc_type)
+{
+  if (disc_type->_d == DDS_XTypes_TK_ENUM)
+    return xt_enum_default_value (disc_type);
+  return 0;
+}
+
+ddsrt_nonnull_all
+static const struct xt_union_member *xt_union_selected_reader_member (const struct xt_union_assignability_ctx *uctx, int32_t label)
+{
+  if (uctx->t1_disc_use_def && !xt_union_disc_value_valid (uctx->t1_disc, label))
+    label = uctx->t1_disc_def_v;
+  if (label == uctx->t1_disc_def_v)
+    return uctx->t1_disc_def_m;
+  return xt_union_selected_member (uctx->t1, uctx->t1_def_m, label);
+}
+
+ddsrt_nonnull_all
+static uint64_t xt_union_writer_invalid_disc_value_count (const struct xt_union_assignability_ctx *uctx)
+{
+  /* Strong discriminator assignability is normally same-kind here, but bitmask is
+     special: xt_is_assignable_from_bitmask also accepts the matching unsigned integer
+     type (XTypes is such a mess ...)  A uint writer can produce values with bits outside
+     the reader bitmask, so those values follow the reader discriminator's
+     @try_construct(DEFAULT) path.  A uint reader, conversely, can represent all values
+     produced by a strongly-assignable bitmask writer. */
+  switch (uctx->t1_disc->_d)
+  {
+    case DDS_XTypes_TK_ENUM: {
+      uint64_t count = 0;
+      for (uint32_t n = 0; n < uctx->t2_disc->_u.enum_type.literals.length; n++)
+      {
+        const int32_t label = uctx->t2_disc->_u.enum_type.literals.seq[n].value;
+        if (!xt_union_label_in_enum (uctx->t1_disc, label))
+          count++;
+      }
+      return count;
+    }
+    case DDS_XTypes_TK_BITMASK: {
+      const uint64_t t1_mask = xt_union_label_bitmask_allowed_mask (uctx->t1_disc);
+      if (uctx->t2_disc->_d == DDS_XTypes_TK_BITMASK)
+      {
+        const uint64_t t2_mask = xt_union_label_bitmask_allowed_mask (uctx->t2_disc);
+        if ((t2_mask & ~t1_mask) == 0)
+          return 0;
+        const uint64_t all_t2_values = xt_disc_value_count_from_bit_count (xt_popcount64 (t2_mask));
+        const uint64_t valid_t1_values = xt_disc_value_count_from_bit_count (xt_popcount64 (t2_mask & t1_mask));
+        return (all_t2_values > valid_t1_values) ? (all_t2_values - valid_t1_values) : UINT64_MAX;
+      }
+      if (xt_type_is_uint (uctx->t2_disc))
+      {
+        const uint64_t t2_mask = xt_uint_max (uctx->t2_disc);
+        if ((t2_mask & ~t1_mask) == 0)
+          return 0;
+        const uint64_t all_t2_values = (t2_mask == UINT64_MAX) ? UINT64_MAX : t2_mask + 1;
+        const uint64_t valid_t1_values = xt_disc_value_count_from_bit_count (xt_popcount64 (t2_mask & t1_mask));
+        return (all_t2_values > valid_t1_values) ? (all_t2_values - valid_t1_values) : UINT64_MAX;
+      }
+      return 0;
+    }
+    default:
+      return 0;
+  }
+}
+
+ddsrt_nonnull ((1))
+static uint32_t xt_union_writer_explicit_invalid_disc_label_count (const struct xt_union_assignability_ctx *uctx)
+{
+  uint32_t count = 0;
+  for (uint32_t i2 = 0; i2 < uctx->t2->_u.union_type.members.length; i2++)
+  {
+    const struct xt_union_member *m2 = &uctx->t2->_u.union_type.members.seq[i2];
+    for (uint32_t l2 = 0; l2 < m2->label_seq._length; l2++)
+      if (!xt_union_disc_value_valid (uctx->t1_disc, m2->label_seq._buffer[l2]))
+        count++;
+  }
+  return count;
+}
+
+ddsrt_nonnull_all
+static bool xt_union_writer_unlabeled_invalid_disc_values_assignable (struct ddsi_domaingv *gv, struct xt_assignability_context *context, const struct xt_union_assignability_ctx *uctx, const dds_type_consistency_enforcement_qospolicy_t *tce, struct ddsi_non_assignability_reason *reason)
+{
+  /* This is for discriminator values that are valid for the writer, invalid for
+     the reader, and have no explicit writer case label.  The per-label loop
+     above never sees them, but the reader may still normalize the discriminator
+     to its default value and then expect a selected member payload. */
+  const uint64_t invalid_count = xt_union_writer_invalid_disc_value_count (uctx);
+  if (invalid_count <= xt_union_writer_explicit_invalid_disc_label_count (uctx))
+    return true;
+
+  const struct xt_union_member *m1 = uctx->t1_disc_def_m;
+  if (!uctx->t2_def_m)
+  {
+    if (!m1)
+      return true;
+    return xt_non_assignable (reason, DDSI_NONASSIGN_MISSING_CASE, uctx->t1, uctx->t2, m1->id);
+  }
+
+  if (!m1)
+    return xt_non_assignable (reason, DDSI_NONASSIGN_MISSING_CASE, uctx->t1, uctx->t2, uctx->t2_def_m->id);
+
+  const struct xt_type *m2t = ddsi_xt_unalias (&uctx->t2_def_m->type->xt);
+  return xt_is_assignable_from_impl (gv, context, ddsi_xt_unalias (&m1->type->xt), m2t, tce, reason);
+}
+
+ddsrt_nonnull_all
 static bool xt_is_assignable_from_enum (const struct xt_type *t1, const struct xt_type *t2, struct ddsi_non_assignability_reason *reason)
 {
   assert (t1->_d == DDS_XTypes_TK_ENUM);
@@ -3471,14 +3710,30 @@ static bool xt_is_assignable_from_enum (const struct xt_type *t1, const struct x
 ddsrt_nonnull_all
 static bool xt_is_assignable_from_union (struct ddsi_domaingv *gv, struct xt_assignability_context *context, const struct xt_type *t1, const struct xt_type *t2, const dds_type_consistency_enforcement_qospolicy_t *tce, struct ddsi_non_assignability_reason *reason)
 {
-  /* Note: T1 is the type of the writer, T2 is the type of the writer. These impractical names
-     are used because this is reader the definition of assignability in the specification. */
+  /* Note: T1 is the reader type, T2 is the writer type. These impractical names
+     are used because they follow the definition of assignability in the specification. */
   assert (t1->_d == DDS_XTypes_TK_UNION);
   assert (t2->_d == DDS_XTypes_TK_UNION);
   if (xt_get_extensibility (t1) != xt_get_extensibility (t2))
     return xt_non_assignable (reason, DDSI_NONASSIGN_DIFFERENT_EXTENSIBILITY, t1, t2, 0);
-  if (!xt_is_strongly_assignable_from (gv, context, ddsi_xt_unalias (&t1->_u.union_type.disc_type->xt), ddsi_xt_unalias (&t2->_u.union_type.disc_type->xt), tce, reason))
+  const struct xt_type *t1_disc = ddsi_xt_unalias (&t1->_u.union_type.disc_type->xt);
+  const struct xt_type *t2_disc = ddsi_xt_unalias (&t2->_u.union_type.disc_type->xt);
+  if (!xt_is_strongly_assignable_from (gv, context, t1_disc, t2_disc, tce, reason))
     return false;
+  const int32_t t1_disc_def_v = xt_union_disc_default_value (t1_disc);
+  const struct xt_union_member *t1_def_m = xt_union_default_member (t1);
+  const struct xt_union_member *t2_def_m = xt_union_default_member (t2);
+  const struct xt_union_assignability_ctx uctx = {
+    .t1 = t1,
+    .t2 = t2,
+    .t1_disc = t1_disc,
+    .t2_disc = t2_disc,
+    .t1_def_m = t1_def_m,
+    .t2_def_m = t2_def_m,
+    .t1_disc_def_m = xt_union_selected_member (t1, t1_def_m, t1_disc_def_v),
+    .t1_disc_def_v = t1_disc_def_v,
+    .t1_disc_use_def = xt_try_construct_is_use_default (t1->_u.union_type.disc_flags)
+  };
 
   /* Rule: Either the discriminators of both T1 and T2 are keys or neither are keys. */
   if ((t1->_u.union_type.disc_flags & DDS_XTypes_IS_KEY) != (t2->_u.union_type.disc_flags & DDS_XTypes_IS_KEY))
@@ -3497,7 +3752,6 @@ static bool xt_is_assignable_from_union (struct ddsi_domaingv *gv, struct xt_ass
     struct xt_union_member *m1 = &t1->_u.union_type.members.seq[i1];
     const struct xt_type *m1t = ddsi_xt_unalias (&m1->type->xt);
     bool m2_id_match = false, m2_labels_match = true, t1_selects_t2_member = false;
-    struct xt_union_member *def_m2 = NULL;
     /* Rule: Any members in T1 and T2 that have the same name also have the same ID and any members
        with the same ID also have the same name. */
     if (!tce->ignore_member_names)
@@ -3532,15 +3786,13 @@ static bool xt_is_assignable_from_union (struct ddsi_domaingv *gv, struct xt_ass
         m2_labels_match = false;
       if (xt_union_label_selects (&m1->label_seq, &m2->label_seq))
         t1_selects_t2_member = true;
-      if (m2->flags & DDS_XTypes_IS_DEFAULT)
-        def_m2 = m2;
     } /* loop T2 members */
 
     /* Rule: If any non-default labels in T1 that select the default member in T2, the type of the member in T1 is
       assignable from the type of the T2 default member. */
-    if (!(m1->flags & DDS_XTypes_IS_DEFAULT) && !t1_selects_t2_member && def_m2)
+    if (!(m1->flags & DDS_XTypes_IS_DEFAULT) && !t1_selects_t2_member && uctx.t2_def_m)
     {
-      if (!xt_is_assignable_from_impl (gv, context, m1t, ddsi_xt_unalias (&def_m2->type->xt), tce, reason))
+      if (!xt_is_assignable_from_impl (gv, context, m1t, ddsi_xt_unalias (&uctx.t2_def_m->type->xt), tce, reason))
         return false;
     }
 
@@ -3553,27 +3805,30 @@ static bool xt_is_assignable_from_union (struct ddsi_domaingv *gv, struct xt_ass
   } /* loop T1 members */
 
   /* Rule: For all non-default labels in T2 that select some member in T1 (including selecting the member in T1’s
-    default label), the type of the selected member in T1 is assignable from the type of the T2 member. */
+    default label), the type of the selected member in T1 is assignable from the type of the T2 member.  When
+    a T2 discriminator value is invalid in T1 and the T1 discriminator has @try_construct(DEFAULT), the selected
+    T1 member is the one selected by T1's discriminator default value. */
   for (uint32_t i2 = 0; i2 < i2_max; i2++)
   {
-    // FIXME: integrate this in the loop above to get better performance
     struct xt_union_member *m2 = &t2->_u.union_type.members.seq[i2];
     if (m2->flags & DDS_XTypes_IS_DEFAULT)
       continue;
-    struct xt_union_member *def_m1 = NULL, *sel_m1 = NULL;
-    for (uint32_t i1 = i2; i1 < i1_max + i2; i1++)
+    const struct xt_type *m2t = ddsi_xt_unalias (&m2->type->xt);
+    for (uint32_t l2 = 0; l2 < m2->label_seq._length; l2++)
     {
-      struct xt_union_member *m1 = &t1->_u.union_type.members.seq[i1 % i1_max];
-      if (xt_union_label_selects (&m2->label_seq, &m1->label_seq))
-        sel_m1 = m1;
-      if (m1->flags & DDS_XTypes_IS_DEFAULT)
-        def_m1 = m1;
+      const struct xt_union_member *m1 = xt_union_selected_reader_member (&uctx, m2->label_seq._buffer[l2]);
+      if (m1 && !xt_is_assignable_from_impl (gv, context, ddsi_xt_unalias (&m1->type->xt), m2t, tce, reason))
+        return false;
+      if (!m1 && tce->prevent_type_widening)
+        return xt_non_assignable (reason, DDSI_NONASSIGN_MISSING_CASE, t1, t2, m2->id);
     }
-    if ((sel_m1 || def_m1) && !xt_is_assignable_from_impl (gv, context, ddsi_xt_unalias (sel_m1 ? &sel_m1->type->xt : &def_m1->type->xt), ddsi_xt_unalias(&m2->type->xt), tce, reason))
-      return false;
-    if (!sel_m1 && tce->prevent_type_widening)
-      return xt_non_assignable (reason, DDSI_NONASSIGN_MISSING_CASE, t1, t2, m2->id);
   }
+
+  /* Discriminator values that are valid in T2 but invalid in T1 may have no explicit writer case labels.  They
+    need a separate check when the reader discriminator defaults, because the reader may then expect a selected
+    member payload that the writer did not serialize. */
+  if (uctx.t1_disc_use_def && !xt_union_writer_unlabeled_invalid_disc_values_assignable (gv, context, &uctx, tce, reason))
+    return false;
 
   /* Rule: [extensibility is final], otherwise, they have at least one common label other than the default label. */
   if (!any_match)

--- a/src/idl/include/idl/tree.h
+++ b/src/idl/include/idl/tree.h
@@ -448,10 +448,9 @@ struct idl_enumerator {
   idl_node_t node;
   struct idl_name *name;
   /* metadata */
-  /* an enumeration must contain no more than 2^32 enumerators and must be
-     mapped to a native data type capable of representing a maximally-sized
-     enumeration */
-  IDL_ANNOTATABLE(uint32_t) value;
+  /* XTypes models enum literal values as signed Int32. CDR serialization may
+     later compare an unsigned holder image, but the IDL tree keeps semantics. */
+  IDL_ANNOTATABLE(int32_t) value;
 };
 
 typedef struct idl_enum idl_enum_t;

--- a/src/idl/src/annotation.c
+++ b/src/idl/src/annotation.c
@@ -204,7 +204,7 @@ annotate_value(
 {
   idl_type_t type;
   const idl_const_expr_t *const_expr;
-  uint32_t value;
+  int32_t value;
 
   assert(annotation_appl);
   assert(annotation_appl->parameters);
@@ -220,19 +220,19 @@ annotate_value(
   if (type == IDL_OCTET || (type & IDL_INTEGER_TYPE)) {
     idl_intval_t intval = idl_intval(const_expr);
 
-    if ((intval.type & IDL_UNSIGNED) && intval.value.ullng > UINT32_MAX) {
+    if ((intval.type & IDL_UNSIGNED) && intval.value.ullng > INT32_MAX) {
       idl_error(pstate, idl_location(annotation_appl),
         "@value(%" PRIu64 ") cannot be applied to '%s' element",
         intval.value.ullng, idl_construct(node));
       return IDL_RETCODE_SEMANTIC_ERROR;
-    } else if (!(intval.type & IDL_UNSIGNED) && intval.value.llng < 0) {
+    } else if (!(intval.type & IDL_UNSIGNED) && (intval.value.llng < INT32_MIN || intval.value.llng > INT32_MAX)) {
       idl_error(pstate, idl_location(annotation_appl),
         "@value(%" PRId64 ") cannot be applied to '%s' element",
         intval.value.llng, idl_construct(node));
       return IDL_RETCODE_SEMANTIC_ERROR;
     }
 
-    value = (uint32_t)intval.value.ullng;
+    value = (intval.type & IDL_UNSIGNED) ? (int32_t) intval.value.ullng : (int32_t) intval.value.llng;
   } else {
     idl_error(pstate, idl_location(annotation_appl),
       "@value with %s cannot be applied to '%s' element",

--- a/src/idl/src/descriptor_type_meta.c
+++ b/src/idl/src/descriptor_type_meta.c
@@ -1436,8 +1436,9 @@ emit_enumerator (
   memset (&c, 0, sizeof (c));
 
   const idl_enumerator_t *enumerator = (idl_enumerator_t *) node;
-  assert (enumerator->value.value <= INT32_MAX);
-  m.common.value = c.common.value = (int32_t) enumerator->value.value;
+  /* TypeObject stores the semantic signed literal value. Do not apply the
+     CDR holder-image conversion here. */
+  m.common.value = c.common.value = enumerator->value.value;
   get_namehash (m.detail.name_hash, idl_identifier (enumerator));
   m.common.flags = c.common.flags = get_enum_literal_flags (_enum, enumerator);
   if ((ret = get_complete_member_detail (node, &c.detail)) < 0)

--- a/src/idl/src/processor.c
+++ b/src/idl/src/processor.c
@@ -428,11 +428,13 @@ check_bitbound(
   } else if (idl_is_enum(node)) {
     const idl_enum_t *_enum = node;
     const idl_enumerator_t *_e = NULL;
-    uint64_t max = (UINT64_C(0x1) << _enum->bit_bound.value);
+    const int32_t min = (_enum->bit_bound.value >= 32) ? INT32_MIN : -(int32_t) (UINT32_C(1) << (_enum->bit_bound.value - 1));
+    const int32_t max = (_enum->bit_bound.value >= 32) ? INT32_MAX : (int32_t) ((UINT32_C(1) << (_enum->bit_bound.value - 1)) - 1);
     IDL_FOREACH(_e, _enum->enumerators) {
-      if (_e->value.value >= max) {
+      if (_e->value.value < min || _e->value.value > max) {
         idl_error(pstate, idl_location(_e),
-          "Enumerator overflow for value '%s' (%u), max allowed value is %" PRIu64 " (bit_bound %hu)", idl_identifier(_e), _e->value.value, max-1, _enum->bit_bound.value);
+          "Enumerator overflow for value '%s' (%" PRId32 "), allowed range is %" PRId32 "..%" PRId32 " (bit_bound %hu)",
+          idl_identifier(_e), _e->value.value, min, max, _enum->bit_bound.value);
         return IDL_RETCODE_OUT_OF_RANGE;
       }
     }

--- a/src/idl/src/tree.c
+++ b/src/idl/src/tree.c
@@ -2831,7 +2831,6 @@ int64_t idl_case_label_intvalue(const void *ptr)
     return literal->value.uint8;
   } else if (type == IDL_ENUM) {
     idl_enumerator_t *enumerator = node->const_expr;
-    assert(enumerator->value.value <= INT32_MAX);
     return enumerator->value.value;
   } else if (type == IDL_BITMASK) {
     // FIXME: should allow (or require?) symbolic values
@@ -2864,8 +2863,8 @@ uint32_t idl_enum_max_value(const void *ptr)
   assert(idl_mask(node) & IDL_ENUM);
   uint32_t max = 0;
   for (idl_enumerator_t *e = node->enumerators; e; e = idl_next(e)) {
-    if (e->value.value > max)
-      max = e->value.value;
+    if (e->value.value > 0 && (uint32_t) e->value.value > max)
+      max = (uint32_t) e->value.value;
   }
   return max;
 }
@@ -2918,7 +2917,7 @@ idl_create_enum(
   static const struct methods methods = {
     delete_enum, iterate_enum, describe_enum };
   static const enum idl_declaration_kind kind = IDL_SPECIFIER_DECLARATION;
-  uint32_t value = UINT32_MAX;
+  int32_t value = -1;
 
   if ((ret = create_node(pstate, size, mask, location, &methods, &node)))
     goto err_alloc;
@@ -2937,10 +2936,10 @@ idl_create_enum(
       //implicit value derived
 
       //check for possible wraparound
-      if (value == UINT32_MAX && idl_previous(e1)) {
+      if (value == INT32_MAX && idl_previous(e1)) {
         idl_error(pstate, idl_location(e1),
-          "Implicit value of enumerator '%s' will wrap around due to previous value being UINT32_MAX (%u).",
-          e1->name->identifier, UINT32_MAX);
+          "Implicit value of enumerator '%s' will wrap around due to previous value being INT32_MAX (%" PRId32 ").",
+          e1->name->identifier, INT32_MAX);
         ret = IDL_RETCODE_OUT_OF_RANGE;
         goto err_wraparound;
       }

--- a/src/idl/tests/annotation.c
+++ b/src/idl/tests/annotation.c
@@ -792,8 +792,8 @@ CU_Test(idl_annotation, autoid_module)
 
 #define S(ann) ann " struct s { char c; };"
 #define U(ann) ann " union u switch(short) { case 1: char c; };"
-#define BM(ann) ann " bitmask bm { bm0, bm1; };"
-#define E(ann) ann " enum e { enum0, enum1; };"
+#define BM(ann) ann " bitmask bm { bm0, bm1 };"
+#define E(ann) ann " enum e { enum0, enum1 };"
 CU_Test(idl_annotation, extensibility)
 {
   static const struct {
@@ -814,12 +814,10 @@ CU_Test(idl_annotation, extensibility)
     { IDL_STRUCT, S("@mutable @data_representation(XCDR1)"), IDL_MUTABLE, IDL_RETCODE_OK },
     { IDL_UNION, U("@mutable @data_representation(XCDR1)"), IDL_MUTABLE, IDL_RETCODE_SEMANTIC_ERROR },
 
-    /* FIXME: extensibility on bitmask and enum not supported yet
-        (both can be final or appendable, not mutable */
-    { IDL_BITMASK, BM("@appendable"), 0, IDL_RETCODE_SYNTAX_ERROR },
-    { IDL_BITMASK, BM("@mutable"), 0, IDL_RETCODE_SYNTAX_ERROR },
-    { IDL_ENUM, E("@appendable"), 0, IDL_RETCODE_SYNTAX_ERROR },
-    { IDL_ENUM, E("@mutable"), 0, IDL_RETCODE_SYNTAX_ERROR },
+    { IDL_BITMASK, BM("@appendable"), IDL_APPENDABLE, IDL_RETCODE_OK },
+    { IDL_BITMASK, BM("@mutable"), 0, IDL_RETCODE_SEMANTIC_ERROR },
+    { IDL_ENUM, E("@appendable"), IDL_APPENDABLE, IDL_RETCODE_OK },
+    { IDL_ENUM, E("@mutable"), 0, IDL_RETCODE_SEMANTIC_ERROR },
   };
   static const size_t n = sizeof(tests)/sizeof(tests[0]);
 
@@ -846,6 +844,20 @@ CU_Test(idl_annotation, extensibility)
           CU_ASSERT_NEQ_FATAL (u, NULL);
           CU_ASSERT_FATAL (idl_is_union(u));
           CU_ASSERT_EQ (u->extensibility.value, tests[i].ext);
+          break;
+        }
+        case IDL_BITMASK: {
+          idl_bitmask_t *bm = (idl_bitmask_t *)pstate->root;
+          CU_ASSERT_NEQ_FATAL (bm, NULL);
+          CU_ASSERT_FATAL (idl_is_bitmask(bm));
+          CU_ASSERT_EQ (bm->extensibility.value, tests[i].ext);
+          break;
+        }
+        case IDL_ENUM: {
+          idl_enum_t *e = (idl_enum_t *)pstate->root;
+          CU_ASSERT_NEQ_FATAL (e, NULL);
+          CU_ASSERT_FATAL (idl_is_enum(e));
+          CU_ASSERT_EQ (e->extensibility.value, tests[i].ext);
           break;
         }
         default:

--- a/src/idl/tests/annotation.c
+++ b/src/idl/tests/annotation.c
@@ -191,7 +191,7 @@ CU_Test(idl_annotation, idl_default)
 typedef struct enum_default_test {
   const char *str;
   idl_retcode_t ret;
-  uint32_t default_index;
+  int32_t default_index;
   const char *default_name;
   uint32_t default_mask;
 } enum_default_test_t;
@@ -990,15 +990,17 @@ CU_Test(idl_annotation, bit_bound)
     { E("21"), true, 21 },
     { E("32"), true, 32 },
     { "enum MyEnum { ENUM1 };", true, 32 },
-    { "@bit_bound(1) enum MyEnum { ENUM1, ENUM2 };", true, 1 },
-    { "@bit_bound(3) enum MyEnum { ENUM1, @value (7) ENUM2 };", true, 3 },
+    { "@bit_bound(1) enum MyEnum { @value (-1) ENUM1, ENUM2 };", true, 1 },
+    { "@bit_bound(3) enum MyEnum { @value (-4) ENUM1, @value (3) ENUM2 };", true, 3 },
     /* invalid */
     { BM("0"), false, 0 },
     { BM("65"), false, 0 },
     { E("0"), false, 0 },
     { E("33"), false, 0 },
     { "@bit_bound(1) bitmask MyBitMask { flag0, flag1 };", false, 0 },
-    { "@bit_bound(1) enum MyEnum { ENUM1, ENUM2, ENUM3 };", false, 0 },
+    { "@bit_bound(1) enum MyEnum { ENUM1, ENUM2 };", false, 0 },
+    { "@bit_bound(3) enum MyEnum { ENUM1, @value (7) ENUM2 };", false, 0 },
+    { "@bit_bound(2) enum MyEnum { ENUM1, @value (2) ENUM2 };", false, 0 },
     { "@bit_bound(2) enum MyEnum { ENUM1, @value (4) ENUM2 };", false, 0 },
   };
   static const size_t n = sizeof(tests)/sizeof(tests[0]);

--- a/src/idl/tests/parser.c
+++ b/src/idl/tests/parser.c
@@ -423,14 +423,16 @@ CU_Test(idl_parser, bit_bound_validation)
       {"@bit_bound(2) bitmask bm { @position(1) flag0 };", true},
       {"@bit_bound(2) bitmask bm { @position(1) flag0, flag1 };", false},
       {"@bit_bound(2) bitmask bm { @position(0) flag0, flag1 };", true},
-      //enums have an implicit bit bound of 32
-      {"enum e { @value(4294967295) e_0, e_1 };", false},
-      {"enum e { @value(4294967294) e_0, e_1 };", true},
-      {"enum e { e_0, @value(4294967295) e_1 };", true},
-      //enums with an explicitly set bit bound
+      //enums have signed literal values and an implicit bit bound of 32
+      {"enum e { @value(2147483647) e_0, e_1 };", false},
+      {"enum e { @value(-2147483647 - 1) e_0, e_1 };", true},
+      {"enum e { e_0, @value(2147483647) e_1 };", true},
+      //enums with an explicitly set bit bound use the corresponding signed range
       {"@bit_bound(2) enum e { @value(3) e_0, e_1 };", false},
-      {"@bit_bound(2) enum e { @value(2) e_0, e_1 };", true},
-      {"@bit_bound(2) enum e { e_0, @value(3) e_1 };", true},
+      {"@bit_bound(2) enum e { @value(2) e_0, e_1 };", false},
+      {"@bit_bound(2) enum e { e_0, @value(3) e_1 };", false},
+      {"@bit_bound(2) enum e { @value(-2) e_0, e_1 };", true},
+      {"@bit_bound(2) enum e { @value(-1) e_0, e_1 };", true},
     };
 
   for (size_t i = 0; i < sizeof(tests)/sizeof(tests[0]); i++)

--- a/src/tools/idlc/src/libidlc/libidlc__descriptor.c
+++ b/src/tools/idlc/src/libidlc/libidlc__descriptor.c
@@ -575,10 +575,13 @@ static void set_try_construct (uint32_t *flags, const idl_type_spec_t *type_spec
         return;
       break;
     case IDL_ENUM:
-    case IDL_BITMASK:
-      // @final enum/bitmask gets marked as "reject", @appendable gets marked as
+      // @final enum gets marked as "reject", @appendable gets marked as
       // discard/use_default
       final_check = true;
+      break;
+    case IDL_BITMASK:
+      // A bitmask can be assignable from an unsigned integer, so even a @final
+      // bitmask must keep the declared try-construct mode.
       break;
     default:
       return;
@@ -1873,10 +1876,9 @@ emit_bitmask(
 {
   (void)revisit;
   (void)path;
+  (void)pstate;
+  (void)node;
   (void)user_data;
-  const idl_bitmask_t *bitmask = (const idl_bitmask_t *)node;
-  if (bitmask->extensibility.annotation && bitmask->extensibility.value != IDL_FINAL)
-    idl_warning(pstate, IDL_WARN_UNSUPPORTED_ANNOTATIONS, idl_location(node), "Extensibility appendable and mutable for bitmask type are not yet supported in the C generator, the extensibility will not be used");
   return IDL_RETCODE_OK;
 }
 

--- a/src/tools/idlc/src/libidlc/libidlc__descriptor.c
+++ b/src/tools/idlc/src/libidlc/libidlc__descriptor.c
@@ -758,9 +758,34 @@ shift_plm_list_offsets(struct constructed_type *ctype)
   }
 }
 
+static void
+shift_enum_metadata_offsets(struct descriptor *descriptor, const struct constructed_type *ctype, uint32_t offset, uint32_t shift)
+{
+  assert(offset <= INT16_MAX);
+  assert(shift <= INT16_MAX);
+  for (struct constructed_type_enummeta *em = descriptor->enum_metadata; em; em = em->next) {
+    if (em->ctype == ctype && em->rel_offs >= 0 && (uint32_t) em->rel_offs >= offset) {
+      assert(em->rel_offs <= INT16_MAX - (int16_t) shift);
+      em->rel_offs = (int16_t) (em->rel_offs + (int16_t) shift);
+    }
+  }
+}
+
+static void
+shift_enum_metadata_for_insert(
+  struct descriptor *descriptor,
+  const struct constructed_type *ctype,
+  const struct instructions *instructions,
+  uint32_t offset)
+{
+  if (offset < instructions->count)
+    shift_enum_metadata_offsets(descriptor, ctype, offset, 1);
+}
+
 static idl_retcode_t
 add_mutable_member_offset(
   const idl_pstate_t *pstate,
+  struct descriptor *descriptor,
   struct constructed_type *ctype,
   uint32_t id)
 {
@@ -774,10 +799,12 @@ add_mutable_member_offset(
       - ctype->pl_offset /* offset of first op after PLC */
       + 2 /* skip this JEQ and member id */
       + 1 /* skip RTS (of the PLC list) */);
+  const uint32_t insert_offset = ctype->pl_offset;
   if ((ret = stash_mutable_member_offset(pstate, &ctype->instructions, ctype->pl_offset++, opcode, addr_offs)) ||
       (ret = stash_single(pstate, &ctype->instructions, ctype->pl_offset++, id)))
     return ret;
 
+  shift_enum_metadata_offsets(descriptor, ctype, insert_offset, 2);
   shift_plm_list_offsets(ctype);
 
   return IDL_RETCODE_OK;
@@ -786,15 +813,18 @@ add_mutable_member_offset(
 static idl_retcode_t
 add_mutable_member_base(
   const idl_pstate_t *pstate,
+  struct descriptor *descriptor,
   struct constructed_type *ctype,
   const struct constructed_type *base_ctype)
 {
   idl_retcode_t ret;
   assert(idl_is_extensible(ctype->node, IDL_MUTABLE));
+  const uint32_t insert_offset = ctype->pl_offset;
   if ((ret = stash_base_members_offset(pstate, &ctype->instructions, ctype->pl_offset++, base_ctype->node)))
     return ret;
   if ((ret = stash_single(pstate, &ctype->instructions, ctype->pl_offset++, 0u)))
     return ret;
+  shift_enum_metadata_offsets(descriptor, ctype, insert_offset, 2);
   shift_plm_list_offsets(ctype);
   return IDL_RETCODE_OK;
 }
@@ -845,6 +875,186 @@ close_member_id_table(
   struct descriptor *descriptor)
 {
   return stash_opcode(pstate, &descriptor->member_ids, nop, DDS_OP_RTS, 0u);
+}
+
+static uint32_t idl_enum_default_value (const idl_enum_t *_enum)
+{
+  assert (_enum);
+  assert (_enum->default_enumerator);
+  return _enum->default_enumerator->value.value;
+}
+
+static bool idl_enum_needs_value_metadata (const idl_enum_t *_enum)
+{
+  uint32_t expected = 0;
+  for (const idl_enumerator_t *e = _enum->enumerators; e; e = idl_next (e), expected++)
+    if (e->value.value != expected)
+      return true;
+  return idl_enum_default_value (_enum) != 0;
+}
+
+static idl_retcode_t add_enum_metadata_use (const idl_pstate_t *pstate, struct descriptor *descriptor, const struct constructed_type *ctype, uint32_t rel_offs, const idl_type_spec_t *type_spec)
+{
+  const idl_enum_t *_enum = (const idl_enum_t *) type_spec;
+  assert (idl_is_enum (_enum));
+  if (!idl_enum_needs_value_metadata (_enum))
+    return IDL_RETCODE_OK;
+  assert (rel_offs <= INT16_MAX);
+  for (struct constructed_type_enummeta *em = descriptor->enum_metadata; em; em = em->next)
+    if (em->ctype == ctype && em->rel_offs == (int16_t) rel_offs)
+      return IDL_RETCODE_OK;
+  struct constructed_type_enummeta *em = idl_calloc (1, sizeof (*em));
+  if (em == NULL)
+    return IDL_RETCODE_NO_MEMORY;
+  em->ctype = ctype;
+  em->rel_offs = (int16_t) rel_offs;
+  em->type = _enum;
+  if (descriptor->enum_metadata == NULL)
+    descriptor->enum_metadata = em;
+  else
+  {
+    struct constructed_type_enummeta *last = descriptor->enum_metadata;
+    while (last->next)
+      last = last->next;
+    last->next = em;
+  }
+  (void) pstate;
+  return IDL_RETCODE_OK;
+}
+
+static idl_retcode_t stash_enum_max (const idl_pstate_t *pstate, struct descriptor *descriptor, struct constructed_type *ctype, struct instructions *instructions, uint32_t index, uint32_t rel_offs, const idl_type_spec_t *type_spec)
+{
+  const idl_enum_t *_enum = (const idl_enum_t *) type_spec;
+  assert (idl_is_enum (_enum));
+  idl_retcode_t ret;
+  if ((ret = add_enum_metadata_use (pstate, descriptor, ctype, rel_offs, type_spec)) < 0)
+    return ret;
+  return stash_single (pstate, instructions, index, idl_enum_needs_value_metadata (_enum) ? UINT32_MAX : idl_enum_max_value (_enum));
+}
+
+struct enum_value_set_id {
+  const idl_enum_t *type;
+  uint32_t setid;
+  struct enum_value_set_id *next;
+};
+
+static struct enum_value_set_id *find_enum_value_set_id (struct enum_value_set_id *sets, const idl_enum_t *type)
+{
+  while (sets)
+  {
+    if (sets->type == type)
+      return sets;
+    sets = sets->next;
+  }
+  return NULL;
+}
+
+static void free_enum_value_set_ids (struct enum_value_set_id *sets)
+{
+  while (sets)
+  {
+    struct enum_value_set_id *next = sets->next;
+    idl_free (sets);
+    sets = next;
+  }
+}
+
+static int uint32_cmp (const void *va, const void *vb)
+{
+  const uint32_t a = *((const uint32_t *) va);
+  const uint32_t b = *((const uint32_t *) vb);
+  return (a > b) - (a < b);
+}
+
+static idl_retcode_t emit_enum_value_set (const idl_pstate_t *pstate, struct descriptor *descriptor, const idl_enum_t *_enum, uint32_t setid)
+{
+  idl_retcode_t ret;
+  uint32_t nvalues = 0;
+  for (const idl_enumerator_t *e = _enum->enumerators; e; e = idl_next (e))
+    nvalues++;
+  uint32_t *values = nvalues ? idl_malloc (nvalues * sizeof (*values)) : NULL;
+  if (nvalues && values == NULL)
+    return IDL_RETCODE_NO_MEMORY;
+  uint32_t idx = 0;
+  for (const idl_enumerator_t *e = _enum->enumerators; e; e = idl_next (e))
+    values[idx++] = e->value.value;
+  if (nvalues > 1)
+    qsort (values, nvalues, sizeof (*values), uint32_cmp);
+  assert (setid <= UINT16_MAX);
+  if ((ret = stash_opcode (pstate, &descriptor->member_ids, nop, DDS_OP_EVS | setid, 0u)) < 0 ||
+      (ret = stash_single (pstate, &descriptor->member_ids, nop, idl_enum_default_value (_enum))) < 0 ||
+      (ret = stash_single (pstate, &descriptor->member_ids, nop, nvalues)) < 0)
+  {
+    idl_free (values);
+    return ret;
+  }
+  for (idx = 0; idx < nvalues; idx++)
+    if ((ret = stash_single (pstate, &descriptor->member_ids, nop, values[idx])) < 0)
+    {
+      idl_free (values);
+      return ret;
+    }
+  idl_free (values);
+  return IDL_RETCODE_OK;
+}
+
+static idl_retcode_t add_enum_metadata_entries (const idl_pstate_t *pstate, struct descriptor *descriptor)
+{
+  idl_retcode_t ret;
+  struct enum_value_set_id *sets = NULL;
+  uint32_t nsets = 0;
+
+  for (const struct constructed_type_enummeta *em = descriptor->enum_metadata; em; em = em->next)
+  {
+    if (find_enum_value_set_id (sets, em->type) == NULL)
+    {
+      struct enum_value_set_id *set = idl_calloc (1, sizeof (*set));
+      if (set == NULL)
+      {
+        free_enum_value_set_ids (sets);
+        return IDL_RETCODE_NO_MEMORY;
+      }
+      set->type = em->type;
+      set->setid = nsets++;
+      set->next = sets;
+      sets = set;
+      if ((ret = emit_enum_value_set (pstate, descriptor, em->type, set->setid)) < 0)
+      {
+        free_enum_value_set_ids (sets);
+        return ret;
+      }
+    }
+  }
+  if (sets != NULL && (ret = stash_opcode (pstate, &descriptor->member_ids, nop, DDS_OP_RTS, 0u)) < 0)
+  {
+    free_enum_value_set_ids (sets);
+    return ret;
+  }
+
+  for (const struct constructed_type_enummeta *em = descriptor->enum_metadata; em; em = em->next)
+  {
+    struct enum_value_set_id *set = find_enum_value_set_id (sets, em->type);
+    assert (set != NULL);
+    assert (em->ctype->offset <= INT32_MAX);
+    assert (em->ctype->offset < (uint32_t) (INT32_MAX - em->rel_offs));
+    const int32_t offs = (int32_t) em->ctype->offset + em->rel_offs;
+    assert (offs >= 0);
+    assert (offs <= UINT16_MAX);
+    if ((ret = stash_opcode (pstate, &descriptor->member_ids, nop, DDS_OP_EVM | (uint32_t) offs, 0u)) < 0 ||
+        (ret = stash_single (pstate, &descriptor->member_ids, nop, set->setid)) < 0)
+    {
+      free_enum_value_set_ids (sets);
+      return ret;
+    }
+  }
+  if (sets != NULL && (ret = stash_opcode (pstate, &descriptor->member_ids, nop, DDS_OP_RTS, 0u)) < 0)
+  {
+    free_enum_value_set_ids (sets);
+    return ret;
+  }
+
+  free_enum_value_set_ids (sets);
+  return IDL_RETCODE_OK;
 }
 
 
@@ -935,6 +1145,7 @@ emit_case(
       off = stype->offset + 2 + union_discr_extra + (stype->label * 4);
 
       bool has_size = false;
+      const uint32_t case_op_off = off;
       if (case_type == INLINE || case_type == IN_UNION) {
         uint32_t label_opcode = opcode;
         /* update offset to first instruction for in-union cases */
@@ -947,20 +1158,25 @@ emit_case(
           has_size = idl_is_array(type_spec) || idl_is_sequence(type_spec);
         }
         /* generate union case opcode */
+        shift_enum_metadata_for_insert(descriptor, ctype, &ctype->instructions, off);
         if ((ret = stash_opcode(pstate, &ctype->instructions, off++, label_opcode, 0u)))
           return ret;
       } else { /* EXTERNAL */
         assert(off <= INT16_MAX);
         if (idl_is_external(node))
           has_size = true;
-        stash_jeq_offset(pstate, &ctype->instructions, off, type_spec, opcode, (int16_t)off);
+        shift_enum_metadata_for_insert(descriptor, ctype, &ctype->instructions, off);
+        if ((ret = stash_jeq_offset(pstate, &ctype->instructions, off, type_spec, opcode, (int16_t)off)))
+          return ret;
         off++;
       }
+      shift_enum_metadata_for_insert(descriptor, ctype, &ctype->instructions, off);
       /* generate union case discriminator, use 0 for default case */
       if ((ret = stash_case_label32(pstate, &ctype->instructions, off++, idl_is_default_case_label(label) || idl_is_implicit_default_case_label(label) ? 0 : label->const_expr)))
         return ret;
       /* generate union case member (address) offset; use offset 0 for empty types,
          as these members are not generated and no offset can be calculated */
+      shift_enum_metadata_for_insert(descriptor, ctype, &ctype->instructions, off);
       if ((ret = stash_offset(pstate, &ctype->instructions, off++, idl_is_empty(type_spec) ? NULL : stype->fields)))
         return ret;
       /* For @external union members include the size of the member to allow the
@@ -969,13 +1185,16 @@ emit_case(
          instruction with parameters remains 4. */
       if (has_size) {
         assert (case_type != INLINE);
+        shift_enum_metadata_for_insert(descriptor, ctype, &ctype->instructions, off);
         if ((ret = stash_member_size(pstate, &ctype->instructions, off++, node, true)))
           return ret;
       } else if (idl_is_enum(type_spec) && case_type == INLINE) {
         // only add max for inline ENU, not for IN_UNION array of enum
-        if ((ret = stash_single(pstate, &ctype->instructions, off++, idl_enum_max_value(type_spec))))
+        shift_enum_metadata_for_insert(descriptor, ctype, &ctype->instructions, off);
+        if ((ret = stash_enum_max(pstate, descriptor, ctype, &ctype->instructions, off++, case_op_off, type_spec)))
           return ret;
       } else {
+        shift_enum_metadata_for_insert(descriptor, ctype, &ctype->instructions, off);
         if ((ret = stash_single(pstate, &ctype->instructions, off++, 0)))
           return ret;
       }
@@ -1033,12 +1252,13 @@ emit_switch_type_spec(
   }
   if (idl_is_default_case(idl_parent(union_spec->default_case)) && !idl_is_implicit_default_case(idl_parent(union_spec->default_case)))
     opcode |= DDS_OP_FLAG_DEF;
+  const uint32_t disc_op_off = ctype->instructions.count;
   if ((ret = stash_opcode(pstate, &ctype->instructions, nop, opcode, order)))
     return ret;
   if ((ret = stash_offset(pstate, &ctype->instructions, nop, field)))
     return ret;
   if (idl_is_enum(type_spec)) {
-    if ((ret = stash_single(pstate, &ctype->instructions, nop, idl_enum_max_value(type_spec))))
+    if ((ret = stash_enum_max(pstate, descriptor, ctype, &ctype->instructions, nop, disc_op_off, type_spec)))
       return ret;
   } else if (idl_is_bitmask(type_spec)) {
     if ((ret = stash_bitmask_bits(pstate, &ctype->instructions, nop, (const idl_bitmask_t *)(type_spec))))
@@ -1068,6 +1288,7 @@ emit_union(
     ctype = stype->ctype;
     assert(stype->label <= stype->labels);
     cnt = (ctype->instructions.count - stype->offset) + 2;
+    shift_enum_metadata_for_insert(descriptor, ctype, &ctype->instructions, stype->offset + 2);
     if ((ret = stash_single(pstate, &ctype->instructions, stype->offset + 2, stype->label)))  // not stype->labels, as labels with empty declarator type will be left out
       return ret;
     uint32_t enum_bitmask_extra = 0;
@@ -1075,6 +1296,7 @@ emit_union(
       enum_bitmask_extra = 1;
     else if (idl_is_bitmask(idl_type_spec(union_spec->switch_type_spec)))
       enum_bitmask_extra = 2;
+    shift_enum_metadata_for_insert(descriptor, ctype, &ctype->instructions, stype->offset + 3);
     if ((ret = stash_couple(pstate, &ctype->instructions, stype->offset + 3, (uint16_t)cnt, (uint16_t)(4u + enum_bitmask_extra))))
       return ret;
     if ((ret = stash_opcode(pstate, &ctype->instructions, nop, DDS_OP_RTS, 0u)))
@@ -1159,7 +1381,7 @@ emit_inherit_spec(
     assert(base_ctype);
 
     if (idl_is_extensible(ctype->node, IDL_MUTABLE)) {
-      if ((ret = add_mutable_member_base(pstate, ctype, base_ctype)))
+      if ((ret = add_mutable_member_base(pstate, descriptor, ctype, base_ctype)))
         return ret;
     } else {
       // final and appendable structs
@@ -1216,6 +1438,8 @@ emit_struct(
     uint32_t off = idl_is_extensible(node, IDL_MUTABLE) ? ctype->pl_offset : nop;
     if ((ret = stash_opcode(pstate, &ctype->instructions, off, DDS_OP_RTS, 0u)))
       return ret;
+    if (idl_is_extensible(node, IDL_MUTABLE))
+      shift_enum_metadata_offsets(descriptor, ctype, off, 1);
     pop_type(descriptor);
   } else {
     if (find_ctype(descriptor, node))
@@ -1291,6 +1515,7 @@ emit_sequence(
     uint16_t bound_op = idl_is_bounded(node) ? 1 : 0;
     off = stype->offset;
     cnt = ctype->instructions.count;
+    shift_enum_metadata_offsets(descriptor, ctype, off + 2u + bound_op, 2u);
     /* generate data field [elem-size] */
     if ((ret = stash_member_size(pstate, &ctype->instructions, off + 2 + bound_op, node, false)))
       return ret;
@@ -1401,7 +1626,7 @@ emit_sequence(
         return ret;
     }
     if (idl_is_enum(type_spec)) {
-      if ((ret = stash_single(pstate, &ctype->instructions, nop, idl_enum_max_value(type_spec))))
+      if ((ret = stash_enum_max(pstate, descriptor, ctype, &ctype->instructions, nop, off, type_spec)))
         return ret;
     } else if (idl_is_bitmask(type_spec)) {
       if ((ret = stash_bitmask_bits(pstate, &ctype->instructions, nop, (const idl_bitmask_t *)(type_spec))))
@@ -1469,6 +1694,7 @@ emit_array(
     uint32_t off, cnt;
     off = stype->offset;
     cnt = ctype->instructions.count;
+    shift_enum_metadata_offsets(descriptor, ctype, off + 3u, 2u);
     /* generate data field [next-insn, elem-insn] */
     if (idl_is_struct(type_spec) || idl_is_union(type_spec)) {
       assert(cnt <= INT16_MAX);
@@ -1567,7 +1793,7 @@ emit_array(
       return ret;
 
     if (idl_is_enum(type_spec)) {
-      if ((ret = stash_single(pstate, &ctype->instructions, nop, idl_enum_max_value(type_spec))))
+      if ((ret = stash_enum_max(pstate, descriptor, ctype, &ctype->instructions, nop, off, type_spec)))
         return ret;
     } else if (idl_is_bitmask(type_spec)) {
       if ((ret = stash_bitmask_bits(pstate, &ctype->instructions, nop, (const idl_bitmask_t *)(type_spec))))
@@ -1647,19 +1873,8 @@ emit_enum(
   (void)revisit;
   (void)path;
   (void)user_data;
-  const idl_enum_t *_enum = (const idl_enum_t *)node;
-  uint32_t value = 0, value_c = 0;
-  if (_enum->default_enumerator && idl_mask(_enum->default_enumerator) == IDL_DEFAULT_ENUMERATOR)
-    idl_warning(pstate, IDL_WARN_UNSUPPORTED_ANNOTATIONS, idl_location(node), "The @default_literal annotation is not supported yet in the C generator and will not be used");
-  for (idl_enumerator_t *e1 = _enum->enumerators; e1; e1 = idl_next(e1), value++) {
-    if (e1->value.annotation)
-      value = e1->value.value;
-    if (value != value_c++) {
-      idl_warning(pstate, IDL_WARN_ENUM_CONSECUTIVE, idl_location(e1),
-        "Warning: values for literals of this enumerator are not consecutive or not starting from zero. The serializer currently does not support checking for valid values for incoming and outgoing data for enums using non-consecutive literal values.");
-      break;
-    }
-  }
+  (void)pstate;
+  (void)node;
   return IDL_RETCODE_OK;
 }
 
@@ -1685,7 +1900,7 @@ emit_declarator(
   /* delegate array type specifiers or declarators */
   if (idl_is_array(node) || idl_is_array(type_spec)) {
     if (!revisit && mutable_aggr_type_member) {
-      if ((ret = add_mutable_member_offset(pstate, ctype, ((idl_declarator_t *)node)->id.value)))
+      if ((ret = add_mutable_member_offset(pstate, descriptor, ctype, ((idl_declarator_t *)node)->id.value)))
         return ret;
     }
 
@@ -1715,7 +1930,7 @@ emit_declarator(
     uint32_t order = 0;
     struct field *field = NULL;
 
-    if (mutable_aggr_type_member && (ret = add_mutable_member_offset(pstate, ctype, ((idl_declarator_t *)node)->id.value)))
+    if (mutable_aggr_type_member && (ret = add_mutable_member_offset(pstate, descriptor, ctype, ((idl_declarator_t *)node)->id.value)))
       return ret;
 
     if (!idl_is_alias(node) && idl_is_struct(stype->node)) {
@@ -1789,7 +2004,7 @@ emit_declarator(
       if ((ret = stash_single(pstate, &ctype->instructions, nop, idl_bound(type_spec)+1)))
         return ret;
     } else if (idl_is_enum(type_spec)) {
-      if ((ret = stash_single(pstate, &ctype->instructions, nop, idl_enum_max_value(type_spec))))
+      if ((ret = stash_enum_max(pstate, descriptor, ctype, &ctype->instructions, nop, (uint32_t) addr_offs, type_spec)))
         return ret;
     } else if (idl_is_bitmask(type_spec)) {
       if ((ret = stash_bitmask_bits(pstate, &ctype->instructions, nop, (const idl_bitmask_t *)(type_spec))))
@@ -1822,11 +2037,11 @@ static int print_opcode(FILE *fp, const struct instruction *inst)
   char buf[32];
   const char *vec[20];
   size_t len = 0;
-  enum dds_stream_opcode opcode;
+  uint32_t opcode;
 
   assert(inst->type == OPCODE);
 
-  opcode = DDS_OP(inst->data.opcode.code);
+  opcode = inst->data.opcode.code & DDS_OP_MASK;
 
   switch (opcode) {
     case DDS_OP_DLC:
@@ -1851,6 +2066,12 @@ static int print_opcode(FILE *fp, const struct instruction *inst)
       break;
     case DDS_OP_MID:
       vec[len++] = "DDS_OP_MID";
+      break;
+    case DDS_OP_EVS:
+      vec[len++] = "DDS_OP_EVS";
+      break;
+    case DDS_OP_EVM:
+      vec[len++] = "DDS_OP_EVM";
       break;
     default:
       assert(opcode == DDS_OP_ADR);
@@ -1907,6 +2128,9 @@ static int print_opcode(FILE *fp, const struct instruction *inst)
   } else if (opcode == DDS_OP_MID) {
     /* lower 16 bits contain an offset */
     idl_snprintf(buf, sizeof(buf), " | %u", (uint16_t) DDS_OP_JUMP (inst->data.member_id.addr_offs));
+    vec[len++] = buf;
+  } else if (opcode == DDS_OP_EVS || opcode == DDS_OP_EVM) {
+    idl_snprintf(buf, sizeof(buf), " | %u", (uint16_t) DDS_OP_JUMP (inst->data.opcode.code));
     vec[len++] = buf;
   } else if (opcode == DDS_OP_JEQ4) {
     enum dds_stream_typecode type = DDS_OP_TYPE(inst->data.opcode.code);
@@ -2180,10 +2404,15 @@ static int print_opcodes(FILE *fp, const struct descriptor *descriptor, uint32_t
         break;
       }
       case OPCODE:
-        opcode = DDS_OP(inst->data.opcode.code);
-        assert (opcode == DDS_OP_RTS);
+        opcode = inst->data.opcode.code & DDS_OP_MASK;
         if (fputs(sep, fp) < 0 || print_opcode(fp, inst) < 0)
           return -1;
+        if (opcode == DDS_OP_EVS && op + 2 < descriptor->member_ids.count && descriptor->member_ids.table[op + 2].type == SINGLE)
+          brk = op + 3 + descriptor->member_ids.table[op + 2].data.single;
+        else if (opcode == DDS_OP_EVM)
+          brk = op + 2;
+        else if (opcode == DDS_OP_RTS)
+          brk = op + 1;
         break;
       default:
         return -1;
@@ -2209,10 +2438,15 @@ static int print_opcodes(FILE *fp, const struct descriptor *descriptor, uint32_t
           return -1;
         break;
       case OPCODE:
-        opcode = DDS_OP(inst->data.opcode.code);
-        assert (opcode == DDS_OP_RTS);
+        opcode = inst->data.opcode.code & DDS_OP_MASK;
         if (fputs(sep, fp) < 0 || print_opcode(fp, inst) < 0)
           return -1;
+        if (opcode == DDS_OP_EVS && op + 2 < descriptor->member_ids.count && descriptor->member_ids.table[op + 2].type == SINGLE)
+          brk = op + 3 + descriptor->member_ids.table[op + 2].data.single;
+        else if (opcode == DDS_OP_EVM)
+          brk = op + 2;
+        else if (opcode == DDS_OP_RTS)
+          brk = op + 1;
         break;
       default:
         return -1;
@@ -2599,6 +2833,16 @@ err_type:
 static void free_ctype_memberids(struct constructed_type_memberid *mids)
 {
   struct constructed_type_memberid *tmp = mids, *tmp1;
+  while (tmp) {
+    tmp1 = tmp;
+    tmp = tmp->next;
+    idl_free (tmp1);
+  }
+}
+
+static void free_ctype_enummetas(struct constructed_type_enummeta *ems)
+{
+  struct constructed_type_enummeta *tmp = ems, *tmp1;
   while (tmp) {
     tmp1 = tmp;
     tmp = tmp->next;
@@ -3038,6 +3282,7 @@ descriptor_fini(struct descriptor *descriptor)
     ctype = ctype1;
   }
   instructions_fini(&descriptor->key_offsets);
+  free_ctype_enummetas(descriptor->enum_metadata);
   descriptor_keys_free(descriptor->keys, descriptor->n_keys);
   idl_free (descriptor->key_offsets.table);
   idl_free (descriptor->member_ids.table);
@@ -3114,6 +3359,10 @@ generate_descriptor_impl(
     if ((ret = close_member_id_table (pstate, descriptor)) < 0)
       goto err;
   }
+  if ((ret = add_enum_metadata_entries (pstate, descriptor)) < 0)
+    goto err;
+  free_ctype_enummetas (descriptor->enum_metadata);
+  descriptor->enum_metadata = NULL;
   struct visited_ctype *vc = visited_ctypes.next;
   while (vc != NULL)
   {

--- a/src/tools/idlc/src/libidlc/libidlc__descriptor.c
+++ b/src/tools/idlc/src/libidlc/libidlc__descriptor.c
@@ -406,18 +406,34 @@ err_type:
   return IDL_RETCODE_NO_MEMORY;
 }
 
+static uint32_t idl_enum_value_image (uint32_t bit_bound, int32_t value)
+{
+  /* XTypes enum literals are signed Int32 values. The cdrstream descriptor
+     stores valid enum values as the unsigned image of the CDR holder selected
+     by @bit_bound, so narrow negative values compare without sign-extension. */
+  if (bit_bound <= 8)
+    return (uint8_t) value;
+  if (bit_bound <= 16)
+    return (uint16_t) value;
+  return (uint32_t) value;
+}
+
 static idl_retcode_t
 stash_case_label32(
-  const idl_pstate_t *pstate, struct instructions *instructions, uint32_t index, const idl_const_expr_t *const_expr)
+  const idl_pstate_t *pstate, struct instructions *instructions, uint32_t index, const idl_type_spec_t *disc_type, const idl_const_expr_t *const_expr)
 {
-  // discrimiant value and case labels are always read as unsigned integer by the deserializer
+  // discriminator value and case labels are always read as unsigned integer by the deserializer
   int cnt = 0;
   struct instruction inst = { CONSTANT, { .constant = { NULL } } };
   char **strp = &inst.data.constant.value;
 
-  if (idl_is_enumerator(const_expr)) {
-    cnt = IDL_PRINT(strp, print_type, const_expr);
-  } else if (const_expr) {
+  if (!const_expr) {
+    /* Default case labels use the NULL constant value, printed as 0. */
+  } else if (idl_is_enumerator(const_expr)) {
+    assert (idl_is_enum (disc_type));
+    const idl_enumerator_t *e = (const idl_enumerator_t *) const_expr;
+    cnt = idl_asprintf (strp, "%" PRIu32, idl_enum_value_image (idl_bound (disc_type), e->value.value));
+  } else {
     const idl_literal_t *literal = const_expr;
 
     switch (idl_type(const_expr)) {
@@ -881,12 +897,12 @@ static uint32_t idl_enum_default_value (const idl_enum_t *_enum)
 {
   assert (_enum);
   assert (_enum->default_enumerator);
-  return _enum->default_enumerator->value.value;
+  return (uint32_t) _enum->default_enumerator->value.value;
 }
 
 static bool idl_enum_needs_value_metadata (const idl_enum_t *_enum)
 {
-  uint32_t expected = 0;
+  int64_t expected = 0;
   for (const idl_enumerator_t *e = _enum->enumerators; e; e = idl_next (e), expected++)
     if (e->value.value != expected)
       return true;
@@ -977,10 +993,12 @@ static idl_retcode_t emit_enum_value_set (const idl_pstate_t *pstate, struct des
     return IDL_RETCODE_NO_MEMORY;
   uint32_t idx = 0;
   for (const idl_enumerator_t *e = _enum->enumerators; e; e = idl_next (e))
-    values[idx++] = e->value.value;
+    values[idx++] = idl_enum_value_image (_enum->bit_bound.value, e->value.value);
   if (nvalues > 1)
     qsort (values, nvalues, sizeof (*values), uint32_cmp);
   assert (setid <= UINT16_MAX);
+  /* EVS default_value is the semantic int32 bit pattern for memory/defaulting.
+     EVS values are unsigned CDR holder images for membership tests. */
   if ((ret = stash_opcode (pstate, &descriptor->member_ids, nop, DDS_OP_EVS | setid, 0u)) < 0 ||
       (ret = stash_single (pstate, &descriptor->member_ids, nop, idl_enum_default_value (_enum))) < 0 ||
       (ret = stash_single (pstate, &descriptor->member_ids, nop, nvalues)) < 0)
@@ -1172,7 +1190,7 @@ emit_case(
       }
       shift_enum_metadata_for_insert(descriptor, ctype, &ctype->instructions, off);
       /* generate union case discriminator, use 0 for default case */
-      if ((ret = stash_case_label32(pstate, &ctype->instructions, off++, idl_is_default_case_label(label) || idl_is_implicit_default_case_label(label) ? 0 : label->const_expr)))
+      if ((ret = stash_case_label32(pstate, &ctype->instructions, off++, idl_type_spec(union_spec->switch_type_spec), idl_is_default_case_label(label) || idl_is_implicit_default_case_label(label) ? 0 : label->const_expr)))
         return ret;
       /* generate union case member (address) offset; use offset 0 for empty types,
          as these members are not generated and no offset can be calculated */

--- a/src/tools/idlc/src/libidlc/libidlc__descriptor.h
+++ b/src/tools/idlc/src/libidlc/libidlc__descriptor.h
@@ -131,6 +131,13 @@ struct constructed_type_memberid {
   const char *member; /**< Name of the member */
 };
 
+struct constructed_type_enummeta {
+  const struct constructed_type *ctype; /**< Reference to constructed type that contains this enum use */
+  struct constructed_type_enummeta *next; /**< Next item in linked-list */
+  int16_t rel_offs; /**< Relative offset from the ctype's offset */
+  const idl_enum_t *type; /**< Enum type needing value metadata */
+};
+
 struct field {
   struct field *previous;
   const void *node;
@@ -164,6 +171,7 @@ struct descriptor {
   struct constructed_type *constructed_types;
   struct instructions key_offsets;
   struct instructions member_ids;
+  struct constructed_type_enummeta *enum_metadata;
 };
 
 void

--- a/src/tools/idlc/src/libidlc/libidlc__types.c
+++ b/src/tools/idlc/src/libidlc/libidlc__types.c
@@ -526,7 +526,8 @@ emit_enum(
   char *name = NULL, *type = NULL;
   const char *fmt, *sep = "";
   const idl_enumerator_t *enumerator;
-  uint32_t skip = 0, value = 0;
+  int64_t skip = 0;
+  int32_t value = 0;
 
   (void)pstate;
   (void)revisit;
@@ -545,11 +546,11 @@ emit_enum(
     if (value == skip)
       fmt = "%s  %s";
     else
-      fmt = "%s  %s = %" PRIu32;
+      fmt = "%s  %s = %" PRId32;
     if (idl_fprintf(gen->header.handle, fmt, sep, name, value) < 0)
       return IDL_RETCODE_NO_MEMORY;
     sep = ",\n";
-    skip = value + 1;
+    skip = (int64_t) value + 1;
   }
 
   fmt = "\n} %1$s;\n\n"

--- a/src/tools/idlc/tests/descriptor.c
+++ b/src/tools/idlc/tests/descriptor.c
@@ -180,6 +180,86 @@ CU_Test(idlc_descriptor, default_extensibility)
 #undef S
 #undef U
 
+static const struct instruction *instruction_at_absolute_offset (const struct descriptor *descriptor, uint32_t offs)
+{
+  for (const struct constructed_type *ctype = descriptor->constructed_types; ctype; ctype = ctype->next)
+  {
+    if (offs >= ctype->offset && offs < ctype->offset + ctype->instructions.count)
+      return &ctype->instructions.table[offs - ctype->offset];
+  }
+  return NULL;
+}
+
+static bool instruction_uses_enum_value_metadata (const struct instruction *inst)
+{
+  if (inst == NULL || inst->type != OPCODE)
+    return false;
+
+  const uint32_t op = inst->data.opcode.code;
+  switch (DDS_OP (op))
+  {
+    case DDS_OP_ADR:
+      switch (DDS_OP_TYPE (op))
+      {
+        case DDS_OP_VAL_ENU:
+          return true;
+        case DDS_OP_VAL_UNI:
+          return DDS_OP_SUBTYPE (op) == DDS_OP_VAL_ENU;
+        case DDS_OP_VAL_SEQ:
+        case DDS_OP_VAL_BSQ:
+        case DDS_OP_VAL_ARR:
+          return DDS_OP_SUBTYPE (op) == DDS_OP_VAL_ENU;
+        default:
+          return false;
+      }
+    case DDS_OP_JEQ4:
+      return DDS_OP_TYPE (op) == DDS_OP_VAL_ENU;
+    default:
+      return false;
+  }
+}
+
+CU_Test(idlc_descriptor, enum_value_metadata_union_case_sequence)
+{
+  idl_retcode_t ret;
+  idl_pstate_t *pstate = NULL;
+  struct descriptor descriptor;
+  uint32_t flags = IDL_FLAG_EXTENDED_DATA_TYPES |
+                   IDL_FLAG_ANONYMOUS_TYPES |
+                   IDL_FLAG_ANNOTATIONS;
+  const char *idl =
+    "enum e { A, @default_literal B, @value(4) C }; "
+    "@nested union u switch(long) { "
+    "case 1: sequence<long> a; "
+    "case 2: sequence<e> b; "
+    "case 3: string c; "
+    "default: string d; "
+    "}; "
+    "@topic struct s { sequence<u, 4> us; };";
+
+  ret = idl_create_pstate (flags, NULL, &pstate);
+  CU_ASSERT_EQ_FATAL (ret, IDL_RETCODE_OK);
+  memset (&descriptor, 0, sizeof (descriptor));
+  ret = generate_test_descriptor (pstate, idl, &descriptor);
+  CU_ASSERT_EQ_FATAL (ret, IDL_RETCODE_OK);
+
+  uint32_t evm_count = 0;
+  for (uint32_t n = 0; n + 1 < descriptor.member_ids.count; n++)
+  {
+    const struct instruction *evm = &descriptor.member_ids.table[n];
+    if (evm->type != OPCODE || DDS_OP (evm->data.opcode.code) != DDS_OP_EVM)
+      continue;
+
+    const uint32_t offs = evm->data.opcode.code & DDS_MID_OFFSET_MASK;
+    CU_ASSERT_FATAL (instruction_uses_enum_value_metadata (instruction_at_absolute_offset (&descriptor, offs)));
+    evm_count++;
+  }
+  CU_ASSERT_EQ_FATAL (evm_count, 1);
+
+  descriptor_fini (&descriptor);
+  idl_delete_pstate (pstate);
+}
+
 CU_Test(idlc_descriptor, key_valid_types)
 {
   static const struct {

--- a/src/tools/idlc/tests/descriptor.c
+++ b/src/tools/idlc/tests/descriptor.c
@@ -310,6 +310,50 @@ CU_Test(idlc_descriptor, key_valid_types)
   }
 }
 
+CU_Test(idlc_descriptor, enum_bit_bound_one)
+{
+  idl_pstate_t *pstate = NULL;
+  struct descriptor descriptor;
+  uint32_t flags = IDL_FLAG_EXTENDED_DATA_TYPES |
+                   IDL_FLAG_ANONYMOUS_TYPES |
+                   IDL_FLAG_ANNOTATIONS;
+
+  idl_retcode_t ret = idl_create_pstate (flags, NULL, &pstate);
+  CU_ASSERT_EQ_FATAL (ret, IDL_RETCODE_OK);
+  memset (&descriptor, 0, sizeof (descriptor));
+  ret = generate_test_descriptor (pstate, "@bit_bound(1) enum e { @value(-1) E_NEG1, E_0 }; @topic struct test { e f; };", &descriptor);
+  CU_ASSERT_EQ_FATAL (ret, IDL_RETCODE_OK);
+
+  bool saw_evs = false;
+  for (uint32_t n = 0; n + 4 < descriptor.member_ids.count; n++)
+  {
+    const struct instruction *inst = &descriptor.member_ids.table[n];
+    if (inst->type != OPCODE || DDS_OP (inst->data.opcode.code) != DDS_OP_EVS)
+      continue;
+    CU_ASSERT_EQ_FATAL (descriptor.member_ids.table[n + 1].type, SINGLE);
+    CU_ASSERT_EQ_FATAL (descriptor.member_ids.table[n + 2].type, SINGLE);
+    CU_ASSERT_EQ_FATAL (descriptor.member_ids.table[n + 3].type, SINGLE);
+    CU_ASSERT_EQ_FATAL (descriptor.member_ids.table[n + 4].type, SINGLE);
+    CU_ASSERT_EQ_FATAL (descriptor.member_ids.table[n + 1].data.single, UINT32_MAX);
+    CU_ASSERT_EQ_FATAL (descriptor.member_ids.table[n + 2].data.single, 2);
+    CU_ASSERT_EQ_FATAL (descriptor.member_ids.table[n + 3].data.single, 0);
+    CU_ASSERT_EQ_FATAL (descriptor.member_ids.table[n + 4].data.single, 0xff);
+    saw_evs = true;
+    break;
+  }
+  CU_ASSERT_FATAL (saw_evs);
+  descriptor_fini (&descriptor);
+  idl_delete_pstate (pstate);
+
+  pstate = NULL;
+  ret = idl_create_pstate (flags, NULL, &pstate);
+  CU_ASSERT_EQ_FATAL (ret, IDL_RETCODE_OK);
+  memset (&descriptor, 0, sizeof (descriptor));
+  ret = generate_test_descriptor (pstate, "@bit_bound(1) enum e { E_0, E_1 }; @topic struct test { e f; };", &descriptor);
+  CU_ASSERT_EQ_FATAL (ret, IDL_RETCODE_OUT_OF_RANGE);
+  idl_delete_pstate (pstate);
+}
+
 #define TEST_MAX_KEYS 10
 CU_Test(idlc_descriptor, keys_inheritance)
 {
@@ -378,4 +422,3 @@ CU_Test(idlc_descriptor, keys_inheritance)
   }
 }
 #undef TEST_MAX_KEYS
-

--- a/src/tools/idlc/xtests/main.c
+++ b/src/tools/idlc/xtests/main.c
@@ -81,10 +81,20 @@ int main(int argc, char **argv)
   init_desc (&cdrstream_desc);
 
   enum byte_order { LE, BE } test_bo[2] = { LE, BE };
-  uint16_t min_xcdrv = dds_stream_minimum_xcdr_version (cdrstream_desc.ops.ops);
-
-  for (uint32_t xcdrv = min_xcdrv; xcdrv <= DDSI_RTPS_CDR_ENC_VERSION_2; xcdrv++)
+  const uint32_t supported_representations = dds_stream_supported_data_representations (cdrstream_desc.ops.ops);
+  if (supported_representations == 0)
   {
+    printf("type supports no data representations\n");
+    dds_cdrstream_desc_fini (&cdrstream_desc, &dds_cdrstream_default_allocator);
+    return 1;
+  }
+
+  for (uint32_t xcdrv = DDSI_RTPS_CDR_ENC_VERSION_1; xcdrv <= DDSI_RTPS_CDR_ENC_VERSION_2; xcdrv++)
+  {
+    const uint32_t representation_flag = (xcdrv == DDSI_RTPS_CDR_ENC_VERSION_1) ? DDS_DATA_REPRESENTATION_FLAG_XCDR1 : DDS_DATA_REPRESENTATION_FLAG_XCDR2;
+    if (!(supported_representations & representation_flag))
+      continue;
+
     for (size_t b = 0; b < sizeof (test_bo) / sizeof (test_bo[0]); b++)
     {
       enum byte_order bo = test_bo[b];

--- a/src/tools/idlc/xtests/test_enum.idl
+++ b/src/tools/idlc/xtests/test_enum.idl
@@ -16,7 +16,7 @@ enum e { E_0, E_1, E_2, E_3, E_4 };
 enum e8 { E8_0, E8_1, E8_2, E8_3 };
 
 @bit_bound(16)
-enum e16 { E16_0, @value(65000) E16_65000, E16_65001 };
+enum e16 { E16_0, @value(-32000) E16_NEG32000, E16_NEG31999 };
 
 typedef sequence<e> seq_e;
 typedef e td_e;
@@ -77,30 +77,30 @@ void init_sample (void *s)
   test_enum *s1 = (test_enum *) s;
   s1->f1 = E_1;
   s1->f2 = E8_2;
-  s1->f3 = E16_65000;
+  s1->f3 = E16_NEG32000;
   SEQA(s1->f4, 1)
   s1->f4._buffer[0] = E_2;
   SEQA(s1->f5, 2)
   s1->f5._buffer[0] = E8_2;
   s1->f5._buffer[1] = E8_3;
   SEQA(s1->f6, 3)
-  s1->f6._buffer[0] = E16_65000;
+  s1->f6._buffer[0] = E16_NEG32000;
   s1->f6._buffer[1] = E16_0;
-  s1->f6._buffer[2] = E16_65001;
+  s1->f6._buffer[2] = E16_NEG31999;
   for (uint32_t n = 0; n < 99; n++)
     s1->f7[n] = n % 5;
   for (uint32_t n = 0; n < 98; n++)
-    s1->f8[n] = n % 2 ? E16_0 : E16_65000;
+    s1->f8[n] = n % 2 ? E16_0 : E16_NEG32000;
   SEQA(s1->f9, 1)
   s1->f9._buffer[0] = E_4;
   s1->f10 = E_3;
   for (uint32_t n = 0; n < 97; n++)
     s1->f11[n] = n % 4;
   s1->f12._d = E8_2;
-  EXTA(s1->f12._u.f2, E16_65001);
+  EXTA(s1->f12._u.f2, E16_NEG31999);
   EXTA(s1->s.f13, E8_2);
   s1->s.f14 = NULL;
-  EXTA(s1->s.f15, E16_65001);
+  EXTA(s1->s.f15, E16_NEG31999);
   s1->s.f16 = NULL;
 }
 
@@ -111,26 +111,26 @@ int cmp_sample (const void *sa, const void *sb)
 
   CMP (a, b, f1, E_1);
   CMP (a, b, f2, E8_2);
-  CMP (a, b, f3, E16_65000);
+  CMP (a, b, f3, E16_NEG32000);
   CMP (a, b, f4._buffer[0], E_2);
   CMP (a, b, f5._buffer[0], E8_2);
   CMP (a, b, f5._buffer[1], E8_3);
-  CMP (a, b, f6._buffer[0], E16_65000);
+  CMP (a, b, f6._buffer[0], E16_NEG32000);
   CMP (a, b, f6._buffer[1], E16_0);
-  CMP (a, b, f6._buffer[2], E16_65001);
+  CMP (a, b, f6._buffer[2], E16_NEG31999);
   for (uint32_t n = 0; n < 99; n++)
     CMP (a, b, f7[n], n % 5);
   for (uint32_t n = 0; n < 98; n++)
-    CMP (a, b, f8[n], n % 2 ? E16_0 : E16_65000);
+    CMP (a, b, f8[n], n % 2 ? E16_0 : E16_NEG32000);
   CMP (a, b, f9._buffer[0], E_4);
   CMP (a, b, f10, E_3);
   for (uint32_t n = 0; n < 97; n++)
     CMP (a, b, f11[n], n % 4);
   CMP (a, b, f12._d, E8_2);
-  CMPEXT (a, b, f12._u.f2, E16_65001);
+  CMPEXT (a, b, f12._u.f2, E16_NEG31999);
   CMPEXT (a, b, s.f13, E8_2);
   CMP (a, b, s.f14, NULL);
-  CMPEXT (a, b, s.f15, E16_65001);
+  CMPEXT (a, b, s.f15, E16_NEG31999);
   CMP (a, b, s.f16, NULL);
   return 0;
 }
@@ -141,9 +141,9 @@ int cmp_key (const void *sa, const void *sb)
   test_enum *b = (test_enum *) sb;
   CMP (a, b, f1, E_1);
   CMP (a, b, f2, E8_2);
-  CMP (a, b, f3, E16_65000);
+  CMP (a, b, f3, E16_NEG32000);
   for (uint32_t n = 0; n < 98; n++)
-    CMP (a, b, f8[n], n % 2 ? E16_0 : E16_65000);
+    CMP (a, b, f8[n], n % 2 ? E16_0 : E16_NEG32000);
   for (uint32_t n = 0; n < 97; n++)
     CMP (a, b, f11[n], n % 4);
   CMPEXT (a, b, s.f13, E8_2);


### PR DESCRIPTION
This addresses some issues in the handling of types that use sparse enums, enum defaults, bitmasks and union discriminators.

**Notable changes**

- This changes the mapping of enums to integers from unsigned to signed to match the XTypes specification. Pre-XTypes, the values were unsigned but one couldn't specify the mapping and so there'd be no difference for the first 2^31 enum symbols. The change really only affects IDL that maps enum symbols to values ≥2^31, hopefully no-one relied on that ...
- Sparse enum values are now represented explicitly in topic descriptors. This allows Cyclone DDS to validate enum domains correctly when enum literals use explicit `@value(...)`, non-zero defaults, narrow enum bounds, or negative XTypes enum values.
- `@default_literal` now works.
- Enum and bitmask union discriminators with `try_construct(use_default)` are normalized and read more accurately, including cases where assignability maps a writer discriminator to a reader default.
- Final and appendable bitmasks are handled better in XTypes assignability. Bitmask assignability is now based on bit bounds rather than only on declared flag sets.
- `xmltype` now sets data representation on the topic QoS, avoiding incompatible topic redefinition when testing assignable reader/writer types.

**Other unrelated fixes**

- Fix the encoding of the member-id for `@optional` fields in XCDR1 in the code generator for dynamic types.
- Deeply nested stream descriptors are no longer rejected by the obsolete 32-level nesting check.
- Cyclone’s own build preserves unchanged IDLC-generated outputs, reducing unnecessary rebuild churn after relinking IDLC.

**Notes**

- The C++ binding's IDL backend needs a (trivial) update to avoid compiler warnings on sign conversions (https://github.com/eclipse-cyclonedds/cyclonedds-cxx/pull/579).

Partially implements #2361 
Fixes #2095
Fixes #2354
Fixes #1926
