### PR TITLE
Some testing / µCUnit improvements

### DIFF
--- a/.azure/templates/build-test.yml
+++ b/.azure/templates/build-test.yml
@@ -180,7 +180,7 @@ steps:
       set -e -x
       cd build
       UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 \
-        ctest --repeat after-timeout:3 -j --output-on-failure -T test -E '^CUnit_ddsrt_random_default_random$' -C ${BUILD_TYPE}
+        ctest --repeat after-timeout:3 -j --output-on-failure -T test -E '^ddsrt_random_default_random$' -C ${BUILD_TYPE}
     condition: ne(variables['testing'], 'off')
     name: test
     displayName: Test

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -263,7 +263,7 @@ jobs:
       - if: ${{ matrix.config.testing != false}}
         run: |
           set -e -x
-          ctest --repeat after-timeout:3 --test-dir ./build -j --output-on-failure -T test -E '^CUnit_ddsrt_random_default_random$' -C ${{ matrix.config.build_type || 'Release' }}
+          ctest --repeat after-timeout:3 --test-dir ./build -j --output-on-failure -T test -E '^ddsrt_random_default_random$' -C ${{ matrix.config.build_type || 'Release' }}
         shell: bash
         env:
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -119,7 +119,7 @@ jobs:
         name: install
       - run: |
           set -e -x
-          ctest --repeat after-timeout:3 --test-dir ./build -j --output-on-failure -T test -E '^CUnit_ddsrt_random_default_random$' -C ${{ matrix.config.build_type || 'Release' }}
+          ctest --repeat after-timeout:3 --test-dir ./build -j --output-on-failure -T test -E '^ddsrt_random_default_random$' -C ${{ matrix.config.build_type || 'Release' }}
         shell: bash
         env:
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -142,7 +142,7 @@ jobs:
       - if: ${{ matrix.config.testing != false}}
         run: |
           set -e -x
-          ctest --repeat after-timeout:3 --test-dir ./build -j --output-on-failure -T test -E '^CUnit_ddsrt_random_default_random$' -C ${{ matrix.config.build_type || 'Release' }}
+          ctest --repeat after-timeout:3 --test-dir ./build -j --output-on-failure -T test -E '^ddsrt_random_default_random$' -C ${{ matrix.config.build_type || 'Release' }}
         shell: bash
         env:
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1

--- a/cmake/Modules/CUnit.cmake
+++ b/cmake/Modules/CUnit.cmake
@@ -292,7 +292,7 @@ function(add_cunit_executable TARGET)
 
         set(decls "${decls}\nCU_TestDecl(${suite}, ${test});")
         set(defns "${defns}\nADD_TEST(${suite}, ${test}, ${enable});")
-        set(ctest "CUnit_${suite}_${test}")
+        set(ctest "${suite}_${test}")
 
         add_test(
           NAME ${ctest}
@@ -322,7 +322,7 @@ function(add_cunit_executable TARGET)
 
   add_executable(
     ${TARGET} "${CMAKE_CURRENT_BINARY_DIR}/${TARGET}.c" ${sources})
-  target_link_libraries(${TARGET} PRIVATE CycloneDDS::ucunit ddsrt-internal)
+  target_link_libraries(${TARGET} PRIVATE CycloneDDS::ucunit)
   if(MSVC)
     target_compile_definitions(${TARGET} PRIVATE _CRT_SECURE_NO_WARNINGS)
   endif()

--- a/cmake/Modules/CUnit.cmake
+++ b/cmake/Modules/CUnit.cmake
@@ -322,7 +322,7 @@ function(add_cunit_executable TARGET)
 
   add_executable(
     ${TARGET} "${CMAKE_CURRENT_BINARY_DIR}/${TARGET}.c" ${sources})
-  target_link_libraries(${TARGET} PRIVATE CycloneDDS::ucunit)
+  target_link_libraries(${TARGET} PRIVATE CycloneDDS::ucunit ddsrt-internal)
   if(MSVC)
     target_compile_definitions(${TARGET} PRIVATE _CRT_SECURE_NO_WARNINGS)
   endif()

--- a/cmake/Modules/CUnit/src/main.c.in
+++ b/cmake/Modules/CUnit/src/main.c.in
@@ -10,6 +10,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
 #include <stdio.h>
+#include <stdbool.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -19,55 +21,25 @@
 #include <CUnit/Basic.h>
 #include <CUnit/Automated.h>
 #include "CUnit/Test.h"
+#include "dds/ddsrt/regex.h"
 
 static struct {
     bool print_help;
     CU_ErrorAction error_action;
     const char *suite;
     const char *test;
+    const char *regex;
 } opts = {
     false,
     CUEA_FAIL,
     "*",
-    "*"
+    "*",
+    NULL
 };
 
-static int patmatch(const char *pat, const char *str)
-{
-    while (*pat) {
-        if (*pat == '?') {
-            /* any character will do */
-            if (*str++ == 0) {
-                return 0;
-            }
-            pat++;
-        } else if (*pat == '*') {
-            /* collapse a sequence of wildcards, requiring as many
-               characters in str as there are ?s in the sequence */
-            while (*pat == '*' || *pat == '?') {
-                if (*pat == '?' && *str++ == 0) {
-                    return 0;
-                }
-                pat++;
-            }
-            /* try matching on all positions where str matches pat */
-            while (*str) {
-                if (*str == *pat && patmatch(pat+1, str+1)) {
-                    return 1;
-                }
-                str++;
-            }
-            return *pat == 0;
-        } else {
-            /* only an exact match */
-            if (*str++ != *pat++) {
-                return 0;
-            }
-        }
-    }
-
-    return *str == 0;
-}
+static ddsrt_regex_t suite_regex = DDSRT_REGEX_INITIALIZER;
+static ddsrt_regex_t test_regex = DDSRT_REGEX_INITIALIZER;
+static ddsrt_regex_t name_regex = DDSRT_REGEX_INITIALIZER;
 
 static void usage(const char *name)
 {
@@ -82,8 +54,9 @@ static void help(const char *name)
     printf("Possible options:\n");
     printf("  -f           fail fast: abort on failed fatal assert\n");
     printf("  -h           display this help and exit\n");
-    printf("  -s PATTERN   run only tests in suites matching pattern\n");
-    printf("  -t PATTERN   run only test matching pattern\n");
+    printf("  -s PATTERN   run only tests in suites matching wildcard pattern\n");
+    printf("  -t PATTERN   run only tests matching wildcard pattern\n");
+    printf("  -r REGEX     run only tests with suite_test name matching unanchored regular expression\n");
     printf("\n");
     printf("Exit codes:\n");
     printf("  %-2d  Successful termination\n", EXIT_SUCCESS);
@@ -104,18 +77,27 @@ static int parse_options(int argc, char *argv[])
             case 'f':
                 opts.error_action = CUEA_ABORT;
                 break;
+            case 'r':
+                if ((i+1) < argc) {
+                    opts.regex = argv[++i];
+                    break;
+                }
+                err = 1;
+                break;
             case 's':
                 if ((i+1) < argc) {
                     opts.suite = argv[++i];
                     break;
                 }
-                /* FALLS THROUGH */
+                err = 1;
+                break;
             case 't':
                 if ((i+1) < argc) {
                     opts.test = argv[++i];
                     break;
                 }
-                /* FALLS THROUGH */
+                err = 1;
+                break;
             default:
                 err = 1;
                 break;
@@ -123,6 +105,121 @@ static int parse_options(int argc, char *argv[])
     }
 
     return err;
+}
+
+static bool is_regex_metachar(char ch)
+{
+    switch (ch) {
+        case '.':
+        case '^':
+        case '$':
+        case '[':
+        case ']':
+        case '(':
+        case ')':
+        case '|':
+        case '*':
+        case '+':
+        case '?':
+        case '\\':
+            return true;
+        default:
+            return false;
+    }
+}
+
+static char *wildcard_to_regex(const char *pattern)
+{
+    size_t len = 3;
+    char *regex;
+    char *p;
+
+    for (const char *s = pattern; *s != '\0'; s++) {
+        size_t add = 1;
+        if (*s == '*') {
+            add = 2;
+        } else if (*s != '?' && is_regex_metachar(*s)) {
+            add = 2;
+        }
+        if (len > SIZE_MAX - add) {
+            return NULL;
+        }
+        len += add;
+    }
+
+    regex = malloc(len);
+    if (regex == NULL) {
+        return NULL;
+    }
+
+    p = regex;
+    *p++ = '^';
+    for (const char *s = pattern; *s != '\0'; s++) {
+        if (*s == '*') {
+            *p++ = '.';
+            *p++ = '*';
+        } else if (*s == '?') {
+            *p++ = '.';
+        } else {
+            if (is_regex_metachar(*s)) {
+                *p++ = '\\';
+            }
+            *p++ = *s;
+        }
+    }
+    *p++ = '$';
+    *p = '\0';
+
+    return regex;
+}
+
+static int compile_filter(ddsrt_regex_t *regex, const char *name, const char *pattern)
+{
+    dds_return_t rc = ddsrt_regex_compile(regex, pattern);
+    if (rc != DDS_RETCODE_OK) {
+        fprintf(stderr, "Invalid %s regular expression: %s\n", name, pattern);
+        return 1;
+    }
+    return 0;
+}
+
+static int compile_wildcard_filter(ddsrt_regex_t *regex, const char *name, const char *pattern)
+{
+    char *regex_pattern = wildcard_to_regex(pattern);
+    int ret;
+
+    if (regex_pattern == NULL) {
+        fprintf(stderr, "Out of memory compiling %s pattern: %s\n", name, pattern);
+        return 1;
+    }
+
+    ret = compile_filter(regex, name, regex_pattern);
+    free(regex_pattern);
+    return ret;
+}
+
+static int compile_filters(void)
+{
+    if (compile_wildcard_filter(&suite_regex, "suite", opts.suite) != 0) {
+        return 1;
+    }
+    if (compile_wildcard_filter(&test_regex, "test", opts.test) != 0) {
+        ddsrt_regex_fini(&suite_regex);
+        return 1;
+    }
+    if (opts.regex != NULL && compile_filter(&name_regex, "suite_test", opts.regex) != 0) {
+        ddsrt_regex_fini(&test_regex);
+        ddsrt_regex_fini(&suite_regex);
+        return 1;
+    }
+    return 0;
+}
+
+static void fini_filters(void)
+{
+    ddsrt_regex_fini(&name_regex);
+    ddsrt_regex_fini(&test_regex);
+    ddsrt_regex_fini(&suite_regex);
 }
 
 static void
@@ -136,7 +233,7 @@ add_suite(
     pSuite = CU_get_suite(suite);
     if (pSuite == NULL) {
         pSuite = CU_add_suite(suite, pInitFunc, pCleanFunc);
-        CU_set_suite_active(pSuite, patmatch(opts.suite, suite));
+        CU_set_suite_active(pSuite, ddsrt_regex_match(&suite_regex, suite));
     }
 }
 
@@ -147,6 +244,7 @@ static void
 add_test(
     const char *suite,
     const char *test,
+    const char *name,
     CU_TestFunc pTestFunc,
     bool enable)
 {
@@ -155,11 +253,14 @@ add_test(
 
     pSuite = CU_get_suite(suite);
     pTest = CU_add_test(pSuite, test, pTestFunc);
-    CU_set_test_active(pTest, enable && patmatch(opts.test, test));
+    CU_set_test_active(pTest,
+        enable &&
+        ddsrt_regex_match(&test_regex, test) &&
+        (opts.regex == NULL || ddsrt_regex_search(&name_regex, name)));
 }
 
 #define ADD_TEST(suite, test, enable) \
-  add_test(#suite, #test, CU_TestProxyName(suite, test), enable)
+  add_test(#suite, #test, #suite "_" #test, CU_TestProxyName(suite, test), enable)
 
 /* CMake will expand the macro below to declare generated functions. */
 @decls@
@@ -174,8 +275,11 @@ int main(int argc, char *argv[])
     } else if (opts.print_help) {
         help(argv[0]);
         return ret;
+    } else if (compile_filters() != 0) {
+        return EX_USAGE;
     } else if (CU_initialize_registry() != CUE_SUCCESS) {
         fprintf(stderr, "CU_initialize_registry: %s\n", CU_get_error_msg());
+        fini_filters();
         return EX_SOFTWARE;
     }
 
@@ -192,7 +296,7 @@ int main(int argc, char *argv[])
     }
 
     CU_cleanup_registry();
+    fini_filters();
 
     return ret;
 }
-

--- a/src/core/ddsc/tests/CMakeLists.txt
+++ b/src/core/ddsc/tests/CMakeLists.txt
@@ -223,31 +223,31 @@ if(ENABLE_TYPELIB)
 endif()
 
 # Setup environment for config-tests
-get_test_property(CUnit_ddsc_config_simple_udp ENVIRONMENT CUnit_ddsc_config_simple_udp_env)
+get_test_property(ddsc_config_simple_udp ENVIRONMENT ddsc_config_simple_udp_env)
 if(ENABLE_FAKEUDP)
-  set(CUnit_ddsc_config_simple_udp_file "${CMAKE_CURRENT_LIST_DIR}/config_simple_fakeudp.xml")
+  set(ddsc_config_simple_udp_file "${CMAKE_CURRENT_LIST_DIR}/config_simple_fakeudp.xml")
 else()
-  set(CUnit_ddsc_config_simple_udp_file "${CMAKE_CURRENT_LIST_DIR}/config_simple_udp.xml")
+  set(ddsc_config_simple_udp_file "${CMAKE_CURRENT_LIST_DIR}/config_simple_udp.xml")
 endif()
-set(CUnit_ddsc_config_simple_udp_uri "file://${CUnit_ddsc_config_simple_udp_file}")
-set(CUnit_ddsc_config_simple_udp_max_participants "0")
-set(CUnit_ddsc_config_simple_udp_env "CYCLONEDDS_URI=${CUnit_ddsc_config_simple_udp_uri};MAX_PARTICIPANTS=${CUnit_ddsc_config_simple_udp_max_participants};${CUnit_ddsc_config_simple_udp_env}")
+set(ddsc_config_simple_udp_uri "file://${ddsc_config_simple_udp_file}")
+set(ddsc_config_simple_udp_max_participants "0")
+set(ddsc_config_simple_udp_env "CYCLONEDDS_URI=${ddsc_config_simple_udp_uri};MAX_PARTICIPANTS=${ddsc_config_simple_udp_max_participants};${ddsc_config_simple_udp_env}")
 set_tests_properties(
-  CUnit_ddsc_config_simple_udp
+  ddsc_config_simple_udp
   PROPERTIES
-    REQUIRED_FILES ${CUnit_ddsc_config_simple_udp_file}
-    ENVIRONMENT "${CUnit_ddsc_config_simple_udp_env}")
+    REQUIRED_FILES ${ddsc_config_simple_udp_file}
+    ENVIRONMENT "${ddsc_config_simple_udp_env}")
 
 # Setup environment for sysdef-test
-get_test_property(CUnit_ddsc_qos_provider_read_sysdef ENVIRONMENT CUnit_ddsc_qos_provider_read_sysdef_env)
-set(CUnit_ddsc_qos_provider_read_sysdef_file "${CMAKE_CURRENT_LIST_DIR}/sysdef_qos_library.xml")
-set(CUnit_ddsc_qos_provider_read_sysdef_uri "file://${CUnit_ddsc_qos_provider_read_sysdef_file}")
-set(CUnit_ddsc_qos_provider_read_sysdef_env "CYCLONEDDS_SYSDEF_URI=${CUnit_ddsc_qos_provider_read_sysdef_uri};${CUnit_ddsc_qos_provider_read_sysdef_env}")
+get_test_property(ddsc_qos_provider_read_sysdef ENVIRONMENT ddsc_qos_provider_read_sysdef_env)
+set(ddsc_qos_provider_read_sysdef_file "${CMAKE_CURRENT_LIST_DIR}/sysdef_qos_library.xml")
+set(ddsc_qos_provider_read_sysdef_uri "file://${ddsc_qos_provider_read_sysdef_file}")
+set(ddsc_qos_provider_read_sysdef_env "CYCLONEDDS_SYSDEF_URI=${ddsc_qos_provider_read_sysdef_uri};${ddsc_qos_provider_read_sysdef_env}")
 set_tests_properties(
-  CUnit_ddsc_qos_provider_read_sysdef
+  ddsc_qos_provider_read_sysdef
   PROPERTIES
-    REQUIRED_FILES ${CUnit_ddsc_qos_provider_read_sysdef_file}
-    ENVIRONMENT "${CUnit_ddsc_qos_provider_read_sysdef_env}")
+    REQUIRED_FILES ${ddsc_qos_provider_read_sysdef_file}
+    ENVIRONMENT "${ddsc_qos_provider_read_sysdef_env}")
 
 configure_file("deadline_update.h.in" "deadline_update.h")
 configure_file("build_options.h.in" "build_options.h")
@@ -260,7 +260,7 @@ configure_file("config_env.h.in" "config_env.h" @ONLY)
 # communication and the deadline tests with their tight timing         #
 ########################################################################
 foreach(t async_one_unrel_sample relwr_unrelrd_network)
-  set_tests_properties(CUnit_ddsc_write_${t} PROPERTIES RUN_SERIAL TRUE)
+  set_tests_properties(ddsc_write_${t} PROPERTIES RUN_SERIAL TRUE)
 endforeach()
 if(ENABLE_DEADLINE_MISSED)
   foreach(t
@@ -268,7 +268,7 @@ if(ENABLE_DEADLINE_MISSED)
       instances
       update
       writer_types)
-    set_tests_properties(CUnit_ddsc_deadline_${t} PROPERTIES RUN_SERIAL TRUE)
+    set_tests_properties(ddsc_deadline_${t} PROPERTIES RUN_SERIAL TRUE)
   endforeach()
 endif()
 
@@ -357,13 +357,13 @@ endif()
 ################################################################################
 
 get_property(test_names DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY TESTS)
-list(FILTER test_names INCLUDE REGEX "^CUnit_ddsc_psmx_[A-Za-z_0-9]+$")
+list(FILTER test_names INCLUDE REGEX "^ddsc_psmx_[A-Za-z_0-9]+$")
 
 # Iceoryx2
 if(ENABLE_ICEORYX2 AND NOT DEFINED ENV{COLCON})
   if(BUILD_SHARED_LIBS)
     foreach(fullname ${test_names})
-      string(REGEX REPLACE "^CUnit_ddsc_psmx_(.*)" "\\1" shortname "${fullname}")
+      string(REGEX REPLACE "^ddsc_psmx_(.*)" "\\1" shortname "${fullname}")
       add_test(NAME ${fullname}_iox2 COMMAND cunit_ddsc -s ddsc_psmx -t ${shortname})
       set_tests_properties(${fullname}_iox2 PROPERTIES ENVIRONMENT "CDDS_PSMX_NAME=iox2;LD_LIBRARY_PATH=$<TARGET_FILE_DIR:psmx_iox2>:$ENV{LD_LIBRARY_PATH}")
     endforeach()
@@ -422,7 +422,7 @@ kill -0 `cat ctest_fixture_iox_roudi.pid`")
   # Iceoryx in a static build (because I don't know how to delete tests!)
   if(BUILD_SHARED_LIBS)
     foreach(fullname ${test_names})
-      string(REGEX REPLACE "^CUnit_ddsc_psmx_(.*)" "\\1" shortname "${fullname}")
+      string(REGEX REPLACE "^ddsc_psmx_(.*)" "\\1" shortname "${fullname}")
       add_test(NAME ${fullname}_iox COMMAND cunit_ddsc -s ddsc_psmx -t ${shortname})
       set_tests_properties(${fullname}_iox PROPERTIES FIXTURES_REQUIRED iox)
       set_tests_properties(${fullname}_iox PROPERTIES RESOURCE_LOCK iox_lock)

--- a/src/core/ddsc/tests/config_env.h.in
+++ b/src/core/ddsc/tests/config_env.h.in
@@ -11,8 +11,8 @@
 #ifndef CONFIG_ENV_H
 #define CONFIG_ENV_H
 
-#define CONFIG_ENV_SIMPLE_UDP           "@CUnit_ddsc_config_simple_udp_uri@"
-#define CONFIG_ENV_MAX_PARTICIPANTS     "@CUnit_ddsc_config_simple_udp_max_participants@"
-#define CONFIG_ENV_READ_SYSDEF          "@CUnit_ddsc_qos_provider_read_sysdef_uri@"
+#define CONFIG_ENV_SIMPLE_UDP           "@ddsc_config_simple_udp_uri@"
+#define CONFIG_ENV_MAX_PARTICIPANTS     "@ddsc_config_simple_udp_max_participants@"
+#define CONFIG_ENV_READ_SYSDEF          "@ddsc_qos_provider_read_sysdef_uri@"
 
 #endif /* CONFIG_ENV_H */

--- a/src/core/ddsc/tests/domain_torture.c
+++ b/src/core/ddsc/tests/domain_torture.c
@@ -82,21 +82,6 @@ static void participant_creation_torture(void)
 }
 
 
-/*
- * There are some issues when completely init/deinit the
- * library in a torturing way. We really just want to
- * check the domain creation/deletion. So, disable this
- * test for now.
- */
-CU_Test (ddsc_domain, torture_implicit, .disabled=true)
-{
-  /* No explicit domain creation, just start creating and
-   * deleting participants (that'll create and delete the
-   * domain implicitly) in a torturing manner. */
-  participant_creation_torture();
-}
-
-
 CU_Test (ddsc_domain, torture_explicit)
 {
   dds_return_t rc;

--- a/src/core/ddsc/tests/test_common.c
+++ b/src/core/ddsc/tests/test_common.c
@@ -62,7 +62,7 @@ static void sync_reader_writer_impl (dds_entity_t participant_rd, dds_entity_t r
 void sync_reader_writer (dds_entity_t participant_rd, dds_entity_t reader, dds_entity_t participant_wr, dds_entity_t writer)
 {
   // Timing out after 1s would seem to be reasonable, but in reality seems to result in CI flakiness
-  // for some tests (e.g., CUnit_ddsc_xtypes_basic at the time of this comment).  A hypothesis is
+  // for some tests (e.g., ddsc_xtypes_basic at the time of this comment).  A hypothesis is
   // that some of the tests that happen to run in parallel cause so much load and network traffic
   // that there is the occasional bit of packet loss, and if that affects discovery packets, it could
   // plausibly make it take longer than 1s.

--- a/src/core/xtests/symbol_export/symbol_export.c
+++ b/src/core/xtests/symbol_export/symbol_export.c
@@ -28,6 +28,7 @@
 #include "dds/ddsrt/avl.h"
 #include "dds/ddsrt/fibheap.h"
 #include "dds/ddsrt/random.h"
+#include "dds/ddsrt/regex.h"
 #include "dds/ddsrt/retcode.h"
 #include "dds/ddsrt/log.h"
 #include "dds/ddsrt/machineid.h"
@@ -1044,6 +1045,13 @@ int main (int argc, char **argv)
 
   // ddsrt/random.h
   ddsrt_random ();
+
+  // ddsrt/regex.h
+  ddsrt_regex_compile (ptr, ptr);
+  ddsrt_regex_compile_with_storage (ptr, ptr, ptr, 0);
+  ddsrt_regex_match (ptr, ptr);
+  ddsrt_regex_search (ptr, ptr);
+  ddsrt_regex_fini (ptr);
 
   // ddsrt/avl.h
   ddsrt_avl_treedef_init (ptr, 0, 0, ptr, ptr, 0);

--- a/src/ddsrt/CMakeLists.txt
+++ b/src/ddsrt/CMakeLists.txt
@@ -75,6 +75,7 @@ set(headers
   "${source_dir}/src/threads_priv.h"
   "${source_dir}/include/dds/ddsrt/cdtors.h"
   "${source_dir}/include/dds/ddsrt/random.h"
+  "${source_dir}/include/dds/ddsrt/regex.h"
   "${source_dir}/include/dds/ddsrt/align.h")
 
 set(sources
@@ -103,6 +104,7 @@ set(sources
   "${source_dir}/src/ifaddrs.c"
   "${source_dir}/src/cdtors.c"
   "${source_dir}/src/random.c"
+  "${source_dir}/src/regex.c"
   "${source_dir}/src/time.c")
 
 # Not every target offers the same set of features. For embedded targets the

--- a/src/ddsrt/include/dds/ddsrt/regex.h
+++ b/src/ddsrt/include/dds/ddsrt/regex.h
@@ -1,0 +1,138 @@
+// Copyright(c) 2026 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+/**
+ * @file regex.h
+ * @brief Small regular expression matcher.
+ */
+#ifndef DDSRT_REGEX_H
+#define DDSRT_REGEX_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "dds/export.h"
+#include "dds/ddsrt/attributes.h"
+#include "dds/ddsrt/retcode.h"
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+#define DDSRT_REGEX_CLASS_BYTES 32
+
+typedef enum ddsrt_regex_opcode {
+  DDSRT_REGEX_OP_UNUSED,
+  DDSRT_REGEX_OP_CHAR,
+  DDSRT_REGEX_OP_ANY,
+  DDSRT_REGEX_OP_CLASS,
+  DDSRT_REGEX_OP_SPLIT,
+  DDSRT_REGEX_OP_JUMP,
+  DDSRT_REGEX_OP_BOL,
+  DDSRT_REGEX_OP_EOL,
+  DDSRT_REGEX_OP_MATCH
+} ddsrt_regex_opcode_t;
+
+typedef struct ddsrt_regex_state {
+  ddsrt_regex_opcode_t op;
+  int out1;
+  int out2;
+  unsigned char ch;
+  bool invert_class;
+  unsigned char cls[DDSRT_REGEX_CLASS_BYTES];
+} ddsrt_regex_state_t;
+
+typedef struct ddsrt_regex {
+  ddsrt_regex_state_t *states;
+  size_t nstates;
+  size_t maxstates;
+  int start;
+  bool owns_states;
+} ddsrt_regex_t;
+
+#define DDSRT_REGEX_INITIALIZER { NULL, 0u, 0u, -1, false }
+
+/**
+ * @brief Compile a regular expression.
+ *
+ * Supported syntax is deliberately small: literals, escaping with `\`, `.`,
+ * `^`, `$`, character classes with ranges and `^` negation, grouping with
+ * parentheses, alternation with `|`, and the `*`, `+` and `?` postfix
+ * operators. Matching is byte-oriented and does not implement Unicode
+ * character semantics.
+ *
+ * @param[out] regex  Compiled regular expression. It must be finalized with
+ *                    @ref ddsrt_regex_fini after a successful call.
+ * @param[in] pattern Null-terminated pattern string.
+ *
+ * @returns @ref DDS_RETCODE_OK on success, @ref DDS_RETCODE_BAD_PARAMETER for
+ *          invalid input or syntax, or @ref DDS_RETCODE_OUT_OF_RESOURCES.
+ */
+DDS_EXPORT dds_return_t
+ddsrt_regex_compile(
+  ddsrt_regex_t *regex,
+  const char *pattern);
+
+/**
+ * @brief Compile a regular expression into caller-provided storage.
+ *
+ * This avoids allocation while compiling. The @ref ddsrt_regex_match and
+ * @ref ddsrt_regex_search functions allocate temporary matching workspace.
+ * A storage array of `2 * strlen(pattern) + 2` states is sufficient for any
+ * valid pattern.
+ *
+ * @param[out] regex    Compiled regular expression. It may be finalized with
+ *                      @ref ddsrt_regex_fini, but the state storage remains
+ *                      owned by the caller.
+ * @param[in] pattern   Null-terminated pattern string.
+ * @param[in] states    Caller-provided state storage.
+ * @param[in] nstates   Number of states in @p states.
+ *
+ * @returns @ref DDS_RETCODE_OK on success, @ref DDS_RETCODE_BAD_PARAMETER for
+ *          invalid input or syntax, or @ref DDS_RETCODE_NOT_ENOUGH_SPACE.
+ */
+DDS_EXPORT dds_return_t
+ddsrt_regex_compile_with_storage(
+  ddsrt_regex_t *regex,
+  const char *pattern,
+  ddsrt_regex_state_t *states,
+  size_t nstates);
+
+/**
+ * @brief Finalize a compiled regular expression.
+ */
+DDS_EXPORT void
+ddsrt_regex_fini(
+  ddsrt_regex_t *regex)
+ddsrt_nonnull_all;
+
+/**
+ * @brief Match a regular expression against an entire string.
+ */
+DDS_EXPORT bool
+ddsrt_regex_match(
+  const ddsrt_regex_t *regex,
+  const char *str)
+ddsrt_nonnull_all;
+
+/**
+ * @brief Search for a regular expression match in a string.
+ */
+DDS_EXPORT bool
+ddsrt_regex_search(
+  const ddsrt_regex_t *regex,
+  const char *str)
+ddsrt_nonnull_all;
+
+#if defined (__cplusplus)
+}
+#endif
+
+#endif /* DDSRT_REGEX_H */

--- a/src/ddsrt/src/regex.c
+++ b/src/ddsrt/src/regex.c
@@ -1,0 +1,749 @@
+// Copyright(c) 2026 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+#include <assert.h>
+#include <limits.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/regex.h"
+
+#define PATCH_NONE (-1)
+
+struct regex_parser {
+  ddsrt_regex_t *regex;
+  const char *pat;
+  dds_return_t rc;
+};
+
+struct regex_frag {
+  int start;
+  int outs;
+};
+
+struct regex_match_workspace {
+  int *cur;
+  int *next;
+  int *stack;
+  unsigned char *cur_seen;
+  unsigned char *next_seen;
+};
+
+static int
+patch_ref(
+  int state,
+  int out)
+{
+  assert(state >= 0);
+  assert(out == 0 || out == 1);
+  return 2 * state + out;
+}
+
+static int *
+patch_field(
+  ddsrt_regex_t *regex,
+  int ref)
+{
+  ddsrt_regex_state_t *st;
+
+  assert(ref >= 0);
+  st = &regex->states[ref / 2];
+  return (ref & 1) ? &st->out2 : &st->out1;
+}
+
+static int
+patch_list1(
+  ddsrt_regex_t *regex,
+  int ref)
+{
+  *patch_field(regex, ref) = PATCH_NONE;
+  return ref;
+}
+
+static int
+patch_append(
+  ddsrt_regex_t *regex,
+  int a,
+  int b)
+{
+  int ref;
+
+  if (a == PATCH_NONE)
+    return b;
+  if (b == PATCH_NONE)
+    return a;
+
+  ref = a;
+  while (*patch_field(regex, ref) != PATCH_NONE)
+    ref = *patch_field(regex, ref);
+  *patch_field(regex, ref) = b;
+  return a;
+}
+
+static void
+patch(
+  ddsrt_regex_t *regex,
+  int list,
+  int target)
+{
+  while (list != PATCH_NONE) {
+    int *field = patch_field(regex, list);
+    int next = *field;
+    *field = target;
+    list = next;
+  }
+}
+
+static void
+set_error(
+  struct regex_parser *p,
+  dds_return_t rc)
+{
+  if (p->rc == DDS_RETCODE_OK)
+    p->rc = rc;
+}
+
+static int
+emit_state(
+  struct regex_parser *p,
+  ddsrt_regex_opcode_t op)
+{
+  ddsrt_regex_t *regex = p->regex;
+  ddsrt_regex_state_t *st;
+  size_t idx;
+
+  if (regex->nstates >= regex->maxstates) {
+    set_error(p, DDS_RETCODE_NOT_ENOUGH_SPACE);
+    return -1;
+  }
+
+  idx = regex->nstates++;
+  assert(idx <= (size_t) INT_MAX / 2);
+  st = &regex->states[idx];
+  memset(st, 0, sizeof(*st));
+  st->op = op;
+  st->out1 = -1;
+  st->out2 = -1;
+  return (int) idx;
+}
+
+static struct regex_frag
+make_empty(
+  struct regex_parser *p)
+{
+  struct regex_frag frag = { -1, PATCH_NONE };
+  int jump = emit_state(p, DDSRT_REGEX_OP_JUMP);
+
+  if (jump >= 0) {
+    frag.start = jump;
+    frag.outs = patch_list1(p->regex, patch_ref(jump, 0));
+  }
+  return frag;
+}
+
+static void
+class_set(
+  unsigned char *cls,
+  unsigned char ch)
+{
+  cls[ch >> 3] = (unsigned char) (cls[ch >> 3] | (1u << (ch & 7)));
+}
+
+static bool
+class_get(
+  const unsigned char *cls,
+  unsigned char ch)
+{
+  return (cls[ch >> 3] & (1u << (ch & 7))) != 0;
+}
+
+static unsigned char
+decode_escape(
+  unsigned char ch)
+{
+  switch (ch) {
+    case 'n':
+      return '\n';
+    case 'r':
+      return '\r';
+    case 't':
+      return '\t';
+    default:
+      return ch;
+  }
+}
+
+static bool parse_alt(struct regex_parser *p, struct regex_frag *frag);
+
+static bool
+parse_class_char(
+  struct regex_parser *p,
+  unsigned char *ch)
+{
+  if (*p->pat == '\0') {
+    set_error(p, DDS_RETCODE_BAD_PARAMETER);
+    return false;
+  } else if (*p->pat == '\\') {
+    p->pat++;
+    if (*p->pat == '\0') {
+      set_error(p, DDS_RETCODE_BAD_PARAMETER);
+      return false;
+    }
+    *ch = decode_escape((unsigned char) *p->pat++);
+  } else {
+    *ch = (unsigned char) *p->pat++;
+  }
+  return true;
+}
+
+static bool
+parse_class(
+  struct regex_parser *p,
+  struct regex_frag *frag)
+{
+  int state;
+  bool first = true;
+  ddsrt_regex_state_t *st;
+
+  state = emit_state(p, DDSRT_REGEX_OP_CLASS);
+  if (state < 0)
+    return false;
+  st = &p->regex->states[state];
+
+  if (*p->pat == '^') {
+    st->invert_class = true;
+    p->pat++;
+  }
+
+  for (;;) {
+    unsigned char lo, hi;
+
+    if (*p->pat == '\0') {
+      set_error(p, DDS_RETCODE_BAD_PARAMETER);
+      return false;
+    }
+    if (*p->pat == ']' && !first) {
+      p->pat++;
+      break;
+    }
+
+    if (!parse_class_char(p, &lo))
+      return false;
+    first = false;
+
+    if (*p->pat == '-' && p->pat[1] != '\0' && p->pat[1] != ']') {
+      p->pat++;
+      if (!parse_class_char(p, &hi))
+        return false;
+      if (lo > hi) {
+        set_error(p, DDS_RETCODE_BAD_PARAMETER);
+        return false;
+      }
+      for (unsigned c = lo; c <= hi; c++)
+        class_set(st->cls, (unsigned char) c);
+    } else {
+      class_set(st->cls, lo);
+    }
+  }
+
+  frag->start = state;
+  frag->outs = patch_list1(p->regex, patch_ref(state, 0));
+  return true;
+}
+
+static bool
+is_atom_start(
+  char ch)
+{
+  switch (ch) {
+    case '\0':
+    case ')':
+    case '|':
+    case '*':
+    case '+':
+    case '?':
+      return false;
+    default:
+      return true;
+  }
+}
+
+static bool
+parse_atom(
+  struct regex_parser *p,
+  struct regex_frag *frag)
+{
+  int state;
+
+  switch (*p->pat) {
+    case '(':
+      p->pat++;
+      if (!parse_alt(p, frag))
+        return false;
+      if (*p->pat != ')') {
+        set_error(p, DDS_RETCODE_BAD_PARAMETER);
+        return false;
+      }
+      p->pat++;
+      return true;
+    case '[':
+      p->pat++;
+      return parse_class(p, frag);
+    case '.':
+      p->pat++;
+      state = emit_state(p, DDSRT_REGEX_OP_ANY);
+      break;
+    case '^':
+      p->pat++;
+      state = emit_state(p, DDSRT_REGEX_OP_BOL);
+      break;
+    case '$':
+      p->pat++;
+      state = emit_state(p, DDSRT_REGEX_OP_EOL);
+      break;
+    case '\\':
+      p->pat++;
+      if (*p->pat == '\0') {
+        set_error(p, DDS_RETCODE_BAD_PARAMETER);
+        return false;
+      }
+      state = emit_state(p, DDSRT_REGEX_OP_CHAR);
+      if (state >= 0)
+        p->regex->states[state].ch = decode_escape((unsigned char) *p->pat++);
+      break;
+    default:
+      if (!is_atom_start(*p->pat)) {
+        set_error(p, DDS_RETCODE_BAD_PARAMETER);
+        return false;
+      }
+      state = emit_state(p, DDSRT_REGEX_OP_CHAR);
+      if (state >= 0)
+        p->regex->states[state].ch = (unsigned char) *p->pat++;
+      break;
+  }
+
+  if (state < 0)
+    return false;
+  frag->start = state;
+  frag->outs = patch_list1(p->regex, patch_ref(state, 0));
+  return true;
+}
+
+static bool
+parse_repeat(
+  struct regex_parser *p,
+  struct regex_frag *frag)
+{
+  if (!parse_atom(p, frag))
+    return false;
+
+  switch (*p->pat) {
+    case '*': {
+      int split;
+      p->pat++;
+      split = emit_state(p, DDSRT_REGEX_OP_SPLIT);
+      if (split < 0)
+        return false;
+      p->regex->states[split].out1 = frag->start;
+      patch(p->regex, frag->outs, split);
+      frag->start = split;
+      frag->outs = patch_list1(p->regex, patch_ref(split, 1));
+      break;
+    }
+    case '+': {
+      int split;
+      p->pat++;
+      split = emit_state(p, DDSRT_REGEX_OP_SPLIT);
+      if (split < 0)
+        return false;
+      p->regex->states[split].out1 = frag->start;
+      patch(p->regex, frag->outs, split);
+      frag->outs = patch_list1(p->regex, patch_ref(split, 1));
+      break;
+    }
+    case '?': {
+      int split;
+      int split_out;
+      p->pat++;
+      split = emit_state(p, DDSRT_REGEX_OP_SPLIT);
+      if (split < 0)
+        return false;
+      p->regex->states[split].out1 = frag->start;
+      split_out = patch_list1(p->regex, patch_ref(split, 1));
+      frag->start = split;
+      frag->outs = patch_append(p->regex, frag->outs, split_out);
+      break;
+    }
+    default:
+      break;
+  }
+
+  if (*p->pat == '*' || *p->pat == '+' || *p->pat == '?') {
+    set_error(p, DDS_RETCODE_BAD_PARAMETER);
+    return false;
+  }
+  return true;
+}
+
+static bool
+parse_concat(
+  struct regex_parser *p,
+  struct regex_frag *frag)
+{
+  bool have_frag = false;
+
+  while (is_atom_start(*p->pat)) {
+    struct regex_frag next;
+
+    if (!parse_repeat(p, &next))
+      return false;
+
+    if (!have_frag) {
+      *frag = next;
+      have_frag = true;
+    } else {
+      patch(p->regex, frag->outs, next.start);
+      frag->outs = next.outs;
+    }
+  }
+
+  if (!have_frag)
+    *frag = make_empty(p);
+  return p->rc == DDS_RETCODE_OK;
+}
+
+static bool
+parse_alt(
+  struct regex_parser *p,
+  struct regex_frag *frag)
+{
+  if (!parse_concat(p, frag))
+    return false;
+
+  while (*p->pat == '|') {
+    struct regex_frag rhs;
+    int split;
+
+    p->pat++;
+    if (!parse_concat(p, &rhs))
+      return false;
+
+    split = emit_state(p, DDSRT_REGEX_OP_SPLIT);
+    if (split < 0)
+      return false;
+    p->regex->states[split].out1 = frag->start;
+    p->regex->states[split].out2 = rhs.start;
+    frag->start = split;
+    frag->outs = patch_append(p->regex, frag->outs, rhs.outs);
+  }
+
+  return true;
+}
+
+dds_return_t
+ddsrt_regex_compile_with_storage(
+  ddsrt_regex_t *regex,
+  const char *pattern,
+  ddsrt_regex_state_t *states,
+  size_t nstates)
+{
+  struct regex_parser p;
+  struct regex_frag frag;
+  int match;
+
+  if (regex == NULL || pattern == NULL || states == NULL || nstates == 0)
+    return DDS_RETCODE_BAD_PARAMETER;
+  if (nstates > (size_t) INT_MAX / 2)
+    return DDS_RETCODE_BAD_PARAMETER;
+
+  regex->states = states;
+  regex->nstates = 0;
+  regex->maxstates = nstates;
+  regex->start = -1;
+  regex->owns_states = false;
+
+  p.regex = regex;
+  p.pat = pattern;
+  p.rc = DDS_RETCODE_OK;
+
+  if (!parse_alt(&p, &frag)) {
+    regex->nstates = 0;
+    return p.rc;
+  }
+  if (*p.pat != '\0') {
+    regex->nstates = 0;
+    return DDS_RETCODE_BAD_PARAMETER;
+  }
+
+  match = emit_state(&p, DDSRT_REGEX_OP_MATCH);
+  if (match < 0) {
+    regex->nstates = 0;
+    return p.rc;
+  }
+  patch(regex, frag.outs, match);
+  regex->start = frag.start;
+  return DDS_RETCODE_OK;
+}
+
+dds_return_t
+ddsrt_regex_compile(
+  ddsrt_regex_t *regex,
+  const char *pattern)
+{
+  ddsrt_regex_state_t *states;
+  dds_return_t rc;
+  size_t len;
+  size_t nstates;
+
+  if (regex == NULL || pattern == NULL)
+    return DDS_RETCODE_BAD_PARAMETER;
+
+  len = strlen(pattern);
+  if (len > (((size_t) INT_MAX / 2) - 2u) / 2u)
+    return DDS_RETCODE_OUT_OF_RESOURCES;
+  nstates = 2u * len + 2u;
+  if (nstates > SIZE_MAX / sizeof(*states))
+    return DDS_RETCODE_OUT_OF_RESOURCES;
+  states = ddsrt_malloc_s(nstates * sizeof(*states));
+  if (states == NULL)
+    return DDS_RETCODE_OUT_OF_RESOURCES;
+
+  rc = ddsrt_regex_compile_with_storage(regex, pattern, states, nstates);
+  if (rc == DDS_RETCODE_OK) {
+    regex->owns_states = true;
+  } else {
+    ddsrt_free(states);
+    regex->states = NULL;
+    regex->maxstates = 0;
+    regex->start = -1;
+  }
+  return rc;
+}
+
+void
+ddsrt_regex_fini(
+  ddsrt_regex_t *regex)
+{
+  if (regex->owns_states)
+    ddsrt_free(regex->states);
+  regex->states = NULL;
+  regex->nstates = 0;
+  regex->maxstates = 0;
+  regex->start = -1;
+  regex->owns_states = false;
+}
+
+static void
+add_state(
+  const ddsrt_regex_t *regex,
+  int *list,
+  size_t *nlist,
+  int *stack,
+  unsigned char *seen,
+  int stateidx,
+  size_t pos,
+  size_t len,
+  bool *matched)
+{
+  size_t nstack = 0;
+
+  if (stateidx < 0)
+    return;
+#define PUSH_STATE(idx_) do { \
+    const int idx__ = (idx_); \
+    if (idx__ >= 0) { \
+      assert((size_t) idx__ < regex->nstates); \
+      if (!seen[idx__]) { \
+        assert(nstack < regex->nstates); \
+        seen[idx__] = 1; \
+        stack[nstack++] = idx__; \
+      } \
+    } \
+  } while (0)
+
+  PUSH_STATE(stateidx);
+
+  while (nstack > 0) {
+    const ddsrt_regex_state_t *st;
+    int idx = stack[--nstack];
+
+    assert(idx >= 0);
+    assert((size_t) idx < regex->nstates);
+    st = &regex->states[idx];
+
+    switch (st->op) {
+      case DDSRT_REGEX_OP_SPLIT:
+        PUSH_STATE(st->out1);
+        PUSH_STATE(st->out2);
+        break;
+      case DDSRT_REGEX_OP_JUMP:
+        PUSH_STATE(st->out1);
+        break;
+      case DDSRT_REGEX_OP_BOL:
+        if (pos == 0)
+          PUSH_STATE(st->out1);
+        break;
+      case DDSRT_REGEX_OP_EOL:
+        if (pos == len)
+          PUSH_STATE(st->out1);
+        break;
+      case DDSRT_REGEX_OP_MATCH:
+        *matched = true;
+        break;
+      case DDSRT_REGEX_OP_CHAR:
+      case DDSRT_REGEX_OP_ANY:
+      case DDSRT_REGEX_OP_CLASS:
+        list[(*nlist)++] = idx;
+        break;
+      case DDSRT_REGEX_OP_UNUSED:
+        break;
+    }
+  }
+
+#undef PUSH_STATE
+}
+
+static bool
+state_matches(
+  const ddsrt_regex_state_t *st,
+  unsigned char ch)
+{
+  switch (st->op) {
+    case DDSRT_REGEX_OP_CHAR:
+      return st->ch == ch;
+    case DDSRT_REGEX_OP_ANY:
+      return true;
+    case DDSRT_REGEX_OP_CLASS: {
+      bool in_class = class_get(st->cls, ch);
+      return st->invert_class ? !in_class : in_class;
+    }
+    default:
+      return false;
+  }
+}
+
+static bool
+match_from(
+  const ddsrt_regex_t *regex,
+  const char *str,
+  size_t len,
+  size_t start,
+  bool full,
+  struct regex_match_workspace *ws)
+{
+  int *cur = ws->cur;
+  int *next = ws->next;
+  unsigned char *cur_seen = ws->cur_seen;
+  unsigned char *next_seen = ws->next_seen;
+  size_t ncur = 0;
+  bool matched = false;
+
+  memset(cur_seen, 0, regex->nstates);
+  add_state(regex, cur, &ncur, ws->stack, cur_seen, regex->start, start, len, &matched);
+  if (matched && (!full || start == len))
+    return true;
+
+  for (size_t pos = start; pos < len && ncur > 0; pos++) {
+    size_t nnext = 0;
+    bool next_matched = false;
+    unsigned char ch = (unsigned char) str[pos];
+
+    memset(next_seen, 0, regex->nstates);
+    for (size_t i = 0; i < ncur; i++) {
+      const ddsrt_regex_state_t *st = &regex->states[cur[i]];
+      if (state_matches(st, ch))
+        add_state(regex, next, &nnext, ws->stack, next_seen, st->out1, pos + 1, len, &next_matched);
+    }
+
+    if (next_matched && (!full || pos + 1 == len))
+      return true;
+
+    {
+      int *tmp_list = cur;
+      unsigned char *tmp_seen = cur_seen;
+      cur = next;
+      next = tmp_list;
+      cur_seen = next_seen;
+      next_seen = tmp_seen;
+      ncur = nnext;
+    }
+  }
+
+  return false;
+}
+
+static void
+alloc_workspace(
+  struct regex_match_workspace *ws,
+  size_t nstates)
+{
+  ws->cur = ddsrt_malloc(nstates * sizeof(*ws->cur));
+  ws->next = ddsrt_malloc(nstates * sizeof(*ws->next));
+  ws->stack = ddsrt_malloc(nstates * sizeof(*ws->stack));
+  ws->cur_seen = ddsrt_malloc(nstates);
+  ws->next_seen = ddsrt_malloc(nstates);
+}
+
+static void
+free_workspace(
+  struct regex_match_workspace *ws)
+{
+  ddsrt_free(ws->next_seen);
+  ddsrt_free(ws->cur_seen);
+  ddsrt_free(ws->stack);
+  ddsrt_free(ws->next);
+  ddsrt_free(ws->cur);
+}
+
+bool
+ddsrt_regex_match(
+  const ddsrt_regex_t *regex,
+  const char *str)
+{
+  struct regex_match_workspace ws;
+  bool result;
+
+  assert(regex != NULL);
+  assert(str != NULL);
+  assert(regex->states != NULL);
+  assert(regex->start >= 0);
+
+  alloc_workspace(&ws, regex->nstates);
+  result = match_from(regex, str, strlen(str), 0, true, &ws);
+  free_workspace(&ws);
+  return result;
+}
+
+bool
+ddsrt_regex_search(
+  const ddsrt_regex_t *regex,
+  const char *str)
+{
+  struct regex_match_workspace ws;
+  size_t len;
+  bool result = false;
+
+  assert(regex != NULL);
+  assert(str != NULL);
+  assert(regex->states != NULL);
+  assert(regex->start >= 0);
+
+  len = strlen(str);
+  alloc_workspace(&ws, regex->nstates);
+  for (size_t start = 0; start <= len; start++) {
+    if (match_from(regex, str, len, start, false, &ws)) {
+      result = true;
+      break;
+    }
+  }
+  free_workspace(&ws);
+  return result;
+}

--- a/src/ddsrt/tests/CMakeLists.txt
+++ b/src/ddsrt/tests/CMakeLists.txt
@@ -88,6 +88,7 @@ if(HAVE_DYNLIB)
 endif()
 
 add_cunit_executable(cunit_ddsrt ${sources})
+target_link_libraries(cunit_ddsrt PRIVATE ddsrt-internal)
 
 # Ensure the directory containing the test library for the dlopen tests is in
 # PATH/LD_LIBRARY_PATH (macOS is fine by virtue of rpath) so that the tests that do not
@@ -101,7 +102,7 @@ if(HAVE_DYNLIB)
     string(REPLACE ":" ";" libtest ${libtest})
     list(GET libtest 0 suite)
     list(GET libtest 1 test)
-    set(libtestname "CUnit_${suite}_${test}")
+    set(libtestname "${suite}_${test}")
     if("${CMAKE_HOST_SYSTEM}" MATCHES ".*Windows.*")
       set_property(TEST ${libtestname} APPEND PROPERTY ENVIRONMENT "${test_lib_dir}")
     else()

--- a/src/ddsrt/tests/CMakeLists.txt
+++ b/src/ddsrt/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ set(sources
   mh3.c
   hopscotch.c
   random.c
+  regex.c
   retcode.c
   strlcpy.c
   socket.c
@@ -110,7 +111,5 @@ if(HAVE_DYNLIB)
 endif()
 
 add_coverage(cunit_ddsrt)
-target_link_libraries(
-  cunit_ddsrt PRIVATE ddsrt-internal)
 target_include_directories(
   cunit_ddsrt PRIVATE "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>")

--- a/src/ddsrt/tests/regex.c
+++ b/src/ddsrt/tests/regex.c
@@ -1,0 +1,146 @@
+// Copyright(c) 2026 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+#include "CUnit/Test.h"
+#include "dds/ddsrt/regex.h"
+
+static bool
+regex_match(
+  const char *pattern,
+  const char *str)
+{
+  ddsrt_regex_t regex = DDSRT_REGEX_INITIALIZER;
+  bool result;
+
+  CU_ASSERT_EQ_FATAL(ddsrt_regex_compile(&regex, pattern), DDS_RETCODE_OK);
+  result = ddsrt_regex_match(&regex, str);
+  ddsrt_regex_fini(&regex);
+  return result;
+}
+
+static bool
+regex_search(
+  const char *pattern,
+  const char *str)
+{
+  ddsrt_regex_t regex = DDSRT_REGEX_INITIALIZER;
+  bool result;
+
+  CU_ASSERT_EQ_FATAL(ddsrt_regex_compile(&regex, pattern), DDS_RETCODE_OK);
+  result = ddsrt_regex_search(&regex, str);
+  ddsrt_regex_fini(&regex);
+  return result;
+}
+
+static dds_return_t
+regex_compile(
+  const char *pattern)
+{
+  ddsrt_regex_t regex = DDSRT_REGEX_INITIALIZER;
+  dds_return_t rc = ddsrt_regex_compile(&regex, pattern);
+
+  if (rc == DDS_RETCODE_OK)
+    ddsrt_regex_fini(&regex);
+  return rc;
+}
+
+CU_Test(ddsrt_regex, literal)
+{
+  CU_ASSERT(regex_match("abc", "abc"));
+  CU_ASSERT(!regex_match("abc", "ab"));
+  CU_ASSERT(!regex_match("abc", "abcd"));
+  CU_ASSERT(regex_match("", ""));
+  CU_ASSERT(!regex_match("", "a"));
+  CU_ASSERT(regex_match("a\\.c", "a.c"));
+  CU_ASSERT(!regex_match("a\\.c", "abc"));
+  CU_ASSERT(regex_match("a\\nb", "a\nb"));
+}
+
+CU_Test(ddsrt_regex, alternation_and_grouping)
+{
+  CU_ASSERT(regex_match("a|bc", "a"));
+  CU_ASSERT(regex_match("a|bc", "bc"));
+  CU_ASSERT(!regex_match("a|bc", "b"));
+  CU_ASSERT(regex_match("(ab|cd)e", "abe"));
+  CU_ASSERT(regex_match("(ab|cd)e", "cde"));
+  CU_ASSERT(!regex_match("(ab|cd)e", "ab"));
+  CU_ASSERT(regex_match("a(b|c)d", "abd"));
+  CU_ASSERT(regex_match("a(b|c)d", "acd"));
+  CU_ASSERT(regex_match("(a|)b", "ab"));
+  CU_ASSERT(regex_match("(a|)b", "b"));
+}
+
+CU_Test(ddsrt_regex, repeat)
+{
+  CU_ASSERT(regex_match("ab*c", "ac"));
+  CU_ASSERT(regex_match("ab*c", "abbc"));
+  CU_ASSERT(!regex_match("ab+c", "ac"));
+  CU_ASSERT(regex_match("ab+c", "abc"));
+  CU_ASSERT(regex_match("ab?c", "ac"));
+  CU_ASSERT(regex_match("ab?c", "abc"));
+  CU_ASSERT(!regex_match("ab?c", "abbc"));
+  CU_ASSERT(regex_match("(ab)+", "abab"));
+  CU_ASSERT(regex_match("(ab|c)*", "abcabc"));
+}
+
+CU_Test(ddsrt_regex, any_and_anchors)
+{
+  CU_ASSERT(regex_match("a.c", "abc"));
+  CU_ASSERT(regex_match("a.*c", "axyzc"));
+  CU_ASSERT(regex_match("^abc$", "abc"));
+  CU_ASSERT(!regex_match("^abc$", "xabc"));
+  CU_ASSERT(regex_search("bc", "abcd"));
+  CU_ASSERT(!regex_match("bc", "abcd"));
+  CU_ASSERT(regex_search("^ab", "abcd"));
+  CU_ASSERT(!regex_search("^bc", "abcd"));
+  CU_ASSERT(regex_search("cd$", "abcd"));
+  CU_ASSERT(!regex_search("bc$", "abcd"));
+}
+
+CU_Test(ddsrt_regex, character_classes)
+{
+  CU_ASSERT(regex_match("[a-c]+", "abcba"));
+  CU_ASSERT(!regex_match("[a-c]+", "abcd"));
+  CU_ASSERT(regex_match("[^0-9]+", "abc"));
+  CU_ASSERT(!regex_match("[^0-9]+", "abc1"));
+  CU_ASSERT(regex_match("[-a]+", "-a--"));
+  CU_ASSERT(regex_match("[a-]+", "a--"));
+  CU_ASSERT(regex_match("[]]+", "]]"));
+  CU_ASSERT(regex_match("[a\\-c]+", "a-c"));
+}
+
+CU_Test(ddsrt_regex, caller_storage)
+{
+  ddsrt_regex_state_t states[16];
+  ddsrt_regex_t regex = DDSRT_REGEX_INITIALIZER;
+
+  CU_ASSERT_EQ_FATAL(
+    ddsrt_regex_compile_with_storage(&regex, "(ab|cd)+", states, sizeof(states) / sizeof(states[0])),
+    DDS_RETCODE_OK);
+  CU_ASSERT(ddsrt_regex_match(&regex, "abcd"));
+  CU_ASSERT(!ddsrt_regex_match(&regex, "abce"));
+  ddsrt_regex_fini(&regex);
+}
+
+CU_Test(ddsrt_regex, invalid_syntax)
+{
+  ddsrt_regex_state_t states[1];
+  ddsrt_regex_t regex = DDSRT_REGEX_INITIALIZER;
+
+  CU_ASSERT_EQ(regex_compile("("), DDS_RETCODE_BAD_PARAMETER);
+  CU_ASSERT_EQ(regex_compile("a)"), DDS_RETCODE_BAD_PARAMETER);
+  CU_ASSERT_EQ(regex_compile("[abc"), DDS_RETCODE_BAD_PARAMETER);
+  CU_ASSERT_EQ(regex_compile("[z-a]"), DDS_RETCODE_BAD_PARAMETER);
+  CU_ASSERT_EQ(regex_compile("a**"), DDS_RETCODE_BAD_PARAMETER);
+  CU_ASSERT_EQ(regex_compile("\\"), DDS_RETCODE_BAD_PARAMETER);
+  CU_ASSERT_EQ(
+    ddsrt_regex_compile_with_storage(&regex, "a", states, sizeof(states) / sizeof(states[0])),
+    DDS_RETCODE_NOT_ENOUGH_SPACE);
+}

--- a/src/security/builtin_plugins/tests/CMakeLists.txt
+++ b/src/security/builtin_plugins/tests/CMakeLists.txt
@@ -91,6 +91,6 @@ if(CMAKE_GENERATOR MATCHES "Visual Studio")
   set_target_properties(cunit_security_plugins PROPERTIES LINK_FLAGS "/ignore:4099")
 endif()
 
-set(CUnit_builtin_plugins_tests_dir "${CMAKE_CURRENT_LIST_DIR}")
-set(CUnit_build_dir "${CMAKE_CURRENT_BINARY_DIR}")
+set(security_builtin_plugins_tests_dir "${CMAKE_CURRENT_LIST_DIR}")
+set(security_builtin_plugins_build_dir "${CMAKE_CURRENT_BINARY_DIR}")
 configure_file("config_env.h.in" "config_env.h")

--- a/src/security/builtin_plugins/tests/config_env.h.in
+++ b/src/security/builtin_plugins/tests/config_env.h.in
@@ -12,7 +12,7 @@
 #ifndef CONFIG_ENV_H
 #define CONFIG_ENV_H
 
-#define CONFIG_ENV_TESTS_DIR           "@CUnit_builtin_plugins_tests_dir@"
-#define CONFIG_ENV_BUILD_DIR           "@CUnit_build_dir@"
+#define CONFIG_ENV_TESTS_DIR           "@security_builtin_plugins_tests_dir@"
+#define CONFIG_ENV_BUILD_DIR           "@security_builtin_plugins_build_dir@"
 
 #endif /* CONFIG_ENV_H */


### PR DESCRIPTION
This PR adds support for selecting tests in the µCunit runners using regex matching:
```sh
cunit_ddsc -r 'type(builder|wrap).*union'
```
  
The argument to `-r` is an unanchored regular expression over the generated `suite_test` name, which is especially useful for copy-pasting CTest output and for selecting related tests across suites.

Anyone with local scripts, CI filters, or `ctest` `-R`/`-E` expressions that refer to generated CUnit test names must drop the `CUnit_` prefix. For example: `ctest -R '^CUnit_ddsc_typebuilder_'` needs to be changed into: `ctest -R '^ddsc_typebuilder_'`.

The PR also removes a disabled implicit-domain torture test that has been disabled since forever and doesn't really add much value anyway.