### PR TITLE
Support "prevent type widening"

### DIFF
--- a/.azure/templates/build-test.yml
+++ b/.azure/templates/build-test.yml
@@ -94,6 +94,7 @@ steps:
   - bash: |
       python -m pip install gcovr --user --upgrade
     name: install_gcovr
+    condition: eq(variables['coverage'], 'on')
   - bash: |
       set -e -x
       sudo apt install libacl1-dev libncurses5-dev pkg-config

--- a/src/core/cdr/include/dds/cdr/dds_cdrstream.h
+++ b/src/core/cdr/include/dds/cdr/dds_cdrstream.h
@@ -858,8 +858,10 @@ dds_data_type_properties_t dds_stream_data_types (const uint32_t *ops)
  * @param nops       number of operation words supplied
  * @param keys       key descriptors, or NULL when @p nkeys is zero
  * @param nkeys      number of key descriptors
+ * @returns          DDS_RETCODE_OK when @p desc was initialized; DDS_RETCODE_BAD_PARAMETER
+ *                   when the stream descriptor cannot be supported
  */
-DDS_EXPORT void dds_cdrstream_desc_init_with_nops (struct dds_cdrstream_desc *desc, const struct dds_cdrstream_allocator *allocator,
+DDS_EXPORT dds_return_t dds_cdrstream_desc_init_with_nops (struct dds_cdrstream_desc *desc, const struct dds_cdrstream_allocator *allocator,
     uint32_t size, uint32_t align, uint32_t flagset, const uint32_t *ops, uint32_t nops, const dds_key_descriptor_t *keys, uint32_t nkeys)
   ddsrt_nonnull ((1, 2, 6));
 
@@ -883,8 +885,10 @@ DDS_EXPORT void dds_cdrstream_desc_init_with_nops (struct dds_cdrstream_desc *de
  * @param ops        marshalling metadata to copy
  * @param keys       key descriptors, or NULL when @p nkeys is zero
  * @param nkeys      number of key descriptors
+ * @returns          DDS_RETCODE_OK when @p desc was initialized; DDS_RETCODE_BAD_PARAMETER
+ *                   when the stream descriptor cannot be supported
  */
-DDS_EXPORT void dds_cdrstream_desc_init (struct dds_cdrstream_desc *desc, const struct dds_cdrstream_allocator *allocator,
+DDS_EXPORT dds_return_t dds_cdrstream_desc_init (struct dds_cdrstream_desc *desc, const struct dds_cdrstream_allocator *allocator,
     uint32_t size, uint32_t align, uint32_t flagset, const uint32_t *ops, const dds_key_descriptor_t *keys, uint32_t nkeys)
   ddsrt_nonnull ((1, 2, 6));
 
@@ -911,8 +915,10 @@ DDS_EXPORT void dds_cdrstream_desc_fini (struct dds_cdrstream_desc *desc, const 
  *
  * @param desc        descriptor to initialize
  * @param topic_desc  topic descriptor containing serialization metadata
+ * @returns           DDS_RETCODE_OK when @p desc was initialized; DDS_RETCODE_BAD_PARAMETER
+ *                    when the stream descriptor cannot be supported
  */
-DDS_EXPORT void dds_cdrstream_desc_from_topic_desc (struct dds_cdrstream_desc *desc, const dds_topic_descriptor_t *topic_desc)
+DDS_EXPORT dds_return_t dds_cdrstream_desc_from_topic_desc (struct dds_cdrstream_desc *desc, const dds_topic_descriptor_t *topic_desc)
   ddsrt_nonnull_all;
 
 

--- a/src/core/cdr/include/dds/cdr/dds_cdrstream.h
+++ b/src/core/cdr/include/dds/cdr/dds_cdrstream.h
@@ -107,6 +107,15 @@ enum dds_stream_normalize_result {
   DDS_STREAM_NORMALIZE_DISCARD  ///< Sample is well-formed but must be discarded by try-construct handling.
 };
 
+/**
+ * @brief Options controlling serialized CDR normalization.
+ * @component cdr_serializer
+ */
+enum dds_stream_normalize_flags {
+  DDS_STREAM_NORMALIZE_FLAG_NONE = 0u,
+  DDS_STREAM_NORMALIZE_FLAG_PREVENT_TYPE_WIDENING = 1u << 0
+};
+
 typedef struct dds_istream {
   const unsigned char *m_buffer;
   uint32_t m_size;          /* Buffer size */
@@ -359,6 +368,16 @@ DDS_EXPORT enum dds_stream_normalize_result dds_stream_normalize (void *data, ui
   ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
 
 /**
+ * @brief Normalize and validate CDR data with normalization options.
+ * @component cdr_serializer
+ *
+ * This is equivalent to @ref dds_stream_normalize, except that @p flags
+ * controls additional validation rules.
+ */
+DDS_EXPORT enum dds_stream_normalize_result dds_stream_normalize_with_flags (void *data, uint32_t size, bool bswap, enum dds_cdr_enc_version xcdr_version, const struct dds_cdrstream_desc *desc, bool just_key, uint32_t flags, uint32_t *actual_size)
+  ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+
+/**
  * @brief Normalize and validate an XCDR2 data fragment.
  * @component cdr_serializer
  *
@@ -401,6 +420,17 @@ DDS_EXPORT enum dds_stream_normalize_result dds_stream_normalize_xcdr2_data (cha
  *                      when validation failed or normalization could not be completed.
  */
 DDS_EXPORT enum dds_stream_normalize_result dds_stream_normalize_to_istream (dds_istream_t *is, void *data, uint32_t size, bool bswap, enum dds_cdr_enc_version xcdr_version, const struct dds_cdrstream_desc *desc, bool just_key, uint32_t *actual_size)
+  ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
+
+/**
+ * @brief Normalize CDR data with normalization options and initialize a trusted
+ *        input stream on success.
+ * @component cdr_serializer
+ *
+ * This is equivalent to @ref dds_stream_normalize_to_istream, except
+ * that @p flags controls additional validation rules.
+ */
+DDS_EXPORT enum dds_stream_normalize_result dds_stream_normalize_to_istream_with_flags (dds_istream_t *is, void *data, uint32_t size, bool bswap, enum dds_cdr_enc_version xcdr_version, const struct dds_cdrstream_desc *desc, bool just_key, uint32_t flags, uint32_t *actual_size)
   ddsrt_attribute_warn_unused_result ddsrt_nonnull_all;
 
 /**

--- a/src/core/cdr/src/dds_cdrstream.c
+++ b/src/core/cdr/src/dds_cdrstream.c
@@ -5813,10 +5813,14 @@ static enum dds_stream_normalize_result stream_normalize_delimited_impl (struct 
   struct normalize_state st1 = shorten_normalize_state (st, *off + delimited_sz);
   assert (st1.size <= st->size);
 
+  const uint32_t *dlc_ops = *ops;
+  const uint16_t required_prefix = DDS_OP_DLC_REQUIRED_PREFIX (*dlc_ops);
+  const uint32_t *required_end = dlc_ops + required_prefix;
   (*ops)++; /* skip DLC op */
   uint32_t insn;
-  while ((insn = **ops) != DDS_OP_RTS && *off < st1.size)
+  while ((insn = **ops) != DDS_OP_RTS && (*off < st1.size || (required_prefix && *ops < required_end)))
   {
+    const uint32_t *ops0 = *ops;
     switch (DDS_OP (insn))
     {
       case DDS_SOP_ADR:
@@ -5836,6 +5840,8 @@ static enum dds_stream_normalize_result stream_normalize_delimited_impl (struct 
         abort ();
         break;
     }
+    if (*ops == ops0)
+      return normalize_error ();
   }
 
   if (insn != DDS_OP_RTS)
@@ -5844,6 +5850,8 @@ static enum dds_stream_normalize_result stream_normalize_delimited_impl (struct 
     if (!type_widening_allowed)
       return NULL;
 #endif
+    if (required_prefix && *ops < required_end)
+      return normalize_error ();
     /* skip fields that are not in serialized data for appendable type */
     while ((insn = **ops) != DDS_OP_RTS)
       *ops = dds_stream_skip_adr_insns (insn, *ops);

--- a/src/core/cdr/src/dds_cdrstream.c
+++ b/src/core/cdr/src/dds_cdrstream.c
@@ -894,6 +894,11 @@ static inline bool op_type_base (const uint32_t insn)
   return (opflags & DDS_OP_FLAG_BASE);
 }
 
+static inline bool op_is_dlc (const uint32_t insn)
+{
+  return DDS_OP (insn) == DDS_OP_DLC;
+}
+
 static inline bool op_is_union_adr (const uint32_t insn)
 {
   return DDS_OP (insn) == DDS_OP_ADR && DDS_OP_TYPE (insn) == DDS_SOP_VAL_UNI;
@@ -2685,7 +2690,7 @@ static const uint32_t *dds_stream_getsize_adr (uint32_t insn, struct getsize_sta
 
       /* skip DLC instruction for base type, so that the DHEADER is not
           serialized for base types */
-      if (op_type_base (insn) && jsr_ops[0] == DDS_OP_DLC)
+      if (op_type_base (insn) && op_is_dlc (jsr_ops[0]))
         jsr_ops++;
 
       /* don't forward is_mutable_member, subtype can have other extensibility */
@@ -3695,7 +3700,7 @@ static inline const uint32_t *dds_stream_read_adr (uint32_t insn, dds_istream_t 
 
       /* skip DLC instruction for base type, handle as if it is final because the base type's
          members follow the derived types members without an extra DHEADER */
-      if (op_type_base (insn) && jsr_ops[0] == DDS_OP_DLC)
+      if (op_type_base (insn) && op_is_dlc (jsr_ops[0]))
         jsr_ops++;
 
       (void) dds_stream_read_impl (&is1, addr, allocator, mid_table, jsr_ops, false, cdr_kind, sample_state);
@@ -5711,7 +5716,7 @@ static enum dds_stream_normalize_result stream_normalize_adr_impl (struct normal
       {
         const uint32_t *jsr_ops = *ops + DDS_OP_ADR_JSR ((*ops)[2]);
         /* skip DLC instruction for base type, the base type members are not preceded by a DHEADER */
-        if (op_type_base (**ops) && jsr_ops[0] == DDS_OP_DLC)
+        if (op_type_base (**ops) && op_is_dlc (jsr_ops[0]))
           jsr_ops++;
         *ops += jmp ? jmp : 3;
         return stream_normalize_data_impl (st, off, &jsr_ops, false);
@@ -5723,7 +5728,7 @@ static enum dds_stream_normalize_result stream_normalize_adr_impl (struct normal
         const struct normalize_state st1 = nested_normalize_state (st);
         const uint32_t *jsr_ops = *ops + DDS_OP_ADR_JSR ((*ops)[2]);
         /* skip DLC instruction for base type, the base type members are not preceded by a DHEADER */
-        if (op_type_base (**ops) && jsr_ops[0] == DDS_OP_DLC)
+        if (op_type_base (**ops) && op_is_dlc (jsr_ops[0]))
           jsr_ops++;
         *ops += jmp ? jmp : 3;
         return stream_normalize_data_impl (&st1, off, &jsr_ops, false);
@@ -7764,7 +7769,7 @@ static const uint32_t * dds_stream_print_adr (char **buf, size_t *bufsize, uint3
       const uint32_t *jsr_ops = ops + DDS_OP_ADR_JSR (ops[2]);
       const uint32_t jmp = DDS_OP_ADR_JMP (ops[2]);
       /* skip DLC instruction for base type, DHEADER is not in the data for base types */
-      if (op_type_base (insn) && jsr_ops[0] == DDS_OP_DLC)
+      if (op_type_base (insn) && op_is_dlc (jsr_ops[0]))
         jsr_ops++;
       if (dds_stream_print_sample1 (buf, bufsize, &is1, jsr_ops, true, false, cdr_kind) == NULL)
         return NULL;
@@ -8325,7 +8330,7 @@ static const uint32_t *dds_stream_key_size_adr (const uint32_t *ops, uint32_t in
 
       /* skip DLC instruction for base type, handle as if it is final because the base type's
          members follow the derived types members without an extra DHEADER */
-      if (op_type_base (insn) && jsr_ops[0] == DDS_OP_DLC)
+      if (op_type_base (insn) && op_is_dlc (jsr_ops[0]))
         jsr_ops++;
 
       (void) dds_stream_key_size (jsr_ops, k);

--- a/src/core/cdr/src/dds_cdrstream.c
+++ b/src/core/cdr/src/dds_cdrstream.c
@@ -186,6 +186,7 @@ struct dds_cdrstream_ops_info {
   dds_data_type_properties_t data_types;
   uint32_t supported_data_representations;
   uint32_t descriptor_flags;
+  bool mutable_member_counts_within_limit;
 };
 
 enum tryconstruct {
@@ -196,6 +197,8 @@ enum tryconstruct {
 };
 
 #define NORMALIZE_MAX_DEPTH 100   // max nesting for recursive types in normalize (also limits TypeObject nesting)
+#define MUTABLE_MEMBER_LIMIT 512
+#define MUTABLE_MEMBER_MASK_WORDS ((MUTABLE_MEMBER_LIMIT + 31) / 32)
 
 struct normalize_state {
   unsigned char * restrict data;  // payload
@@ -1172,6 +1175,49 @@ static const uint32_t *dds_stream_get_ops_info_uni (const uint32_t *ops, bool to
   return ops;
 }
 
+static void dds_stream_get_ops_info_count_mutable_member (struct dds_cdrstream_ops_info *info, uint32_t *mutable_member_count)
+{
+  if (*mutable_member_count == MUTABLE_MEMBER_LIMIT)
+    info->mutable_member_counts_within_limit = false;
+  else
+    (*mutable_member_count)++;
+}
+
+ddsrt_nonnull_all
+static const uint32_t *dds_stream_get_ops_info_plc_members (const uint32_t *ops, bool top_level_key_scope, struct dds_cdrstream_ops_info *info, bool in_xcdr1_delimited_scope, uint32_t value_bound_xcdrv, uint32_t tail_bound_xcdrv, bool in_recursive, uint32_t *mutable_member_count)
+{
+  uint32_t insn;
+  while ((insn = *ops) != DDS_OP_RTS)
+  {
+    switch (DDS_OP (insn))
+    {
+      case DDS_SOP_PLM: {
+        uint32_t flags = DDS_PLM_FLAGS (insn);
+        const uint32_t *plm_ops = ops + DDS_OP_ADR_PLM (insn);
+        if (flags & DDS_OP_FLAG_BASE)
+        {
+          assert (DDS_OP (plm_ops[0]) == DDS_OP_PLC);
+          (void) dds_stream_get_ops_info_plc_members (plm_ops + 1, top_level_key_scope, info, in_xcdr1_delimited_scope, value_bound_xcdrv, tail_bound_xcdrv, in_recursive, mutable_member_count);
+        }
+        else
+        {
+          dds_stream_get_ops_info_count_mutable_member (info, mutable_member_count);
+          if (!in_recursive)
+            dds_stream_get_ops_info1 (plm_ops, top_level_key_scope, info, in_xcdr1_delimited_scope, 0, XCDR12_REP, in_recursive);
+        }
+        ops += 2;
+        break;
+      }
+      default:
+        abort (); /* only list of (PLM, member-id) supported */
+        break;
+    }
+  }
+  if (ops > info->ops_end)
+    info->ops_end = ops;
+  return ops;
+}
+
 ddsrt_nonnull_all
 static const uint32_t *dds_stream_get_ops_info_plc (const uint32_t *ops, bool top_level_key_scope, struct dds_cdrstream_ops_info *info, bool in_xcdr1_delimited_scope, uint32_t value_bound_xcdrv, uint32_t tail_bound_xcdrv, bool in_recursive)
 {
@@ -1187,32 +1233,8 @@ static const uint32_t *dds_stream_get_ops_info_plc (const uint32_t *ops, bool to
     return dds_stream_get_ops_info_uni (ops, top_level_key_scope, info, value_bound_xcdrv, tail_bound_xcdrv, at_tail, in_recursive, true);
   }
 
-  uint32_t insn;
-  while ((insn = *ops) != DDS_OP_RTS)
-  {
-    switch (DDS_OP (insn))
-    {
-      case DDS_SOP_PLM: {
-        uint32_t flags = DDS_PLM_FLAGS (insn);
-        const uint32_t *plm_ops = ops + DDS_OP_ADR_PLM (insn);
-        if (flags & DDS_OP_FLAG_BASE)
-        {
-          assert (DDS_OP (plm_ops[0]) == DDS_OP_PLC);
-          (void) dds_stream_get_ops_info_plc (plm_ops + 1, top_level_key_scope, info, in_xcdr1_delimited_scope, value_bound_xcdrv, tail_bound_xcdrv, in_recursive);
-        }
-        else if (!in_recursive)
-          dds_stream_get_ops_info1 (plm_ops, top_level_key_scope, info, in_xcdr1_delimited_scope, 0, XCDR12_REP, in_recursive);
-        ops += 2;
-        break;
-      }
-      default:
-        abort (); /* only list of (PLM, member-id) supported */
-        break;
-    }
-  }
-  if (ops > info->ops_end)
-    info->ops_end = ops;
-  return ops;
+  uint32_t mutable_member_count = 0;
+  return dds_stream_get_ops_info_plc_members (ops, top_level_key_scope, info, in_xcdr1_delimited_scope, value_bound_xcdrv, tail_bound_xcdrv, in_recursive, &mutable_member_count);
 }
 
 ddsrt_nonnull_all
@@ -1342,8 +1364,18 @@ static void dds_stream_get_ops_info (const uint32_t *ops, struct dds_cdrstream_o
   info->data_types = DDS_DATA_TYPE_IS_MEMCPY_SAFE;
   info->supported_data_representations = XCDR12_REP;
   info->descriptor_flags = DDS_TOPIC_FIXED_SIZE;
+  info->mutable_member_counts_within_limit = true;
   dds_stream_get_ops_info1 (ops, true, info, true, 0, XCDR12_REP, false);
 }
+
+#ifndef NDEBUG
+static bool dds_stream_mutable_member_counts_within_limit (const uint32_t *ops)
+{
+  struct dds_cdrstream_ops_info info;
+  dds_stream_get_ops_info (ops, &info);
+  return info.mutable_member_counts_within_limit;
+}
+#endif
 
 ddsrt_nonnull_all
 static char *dds_stream_reuse_string_bound (dds_istream_t *is, char * restrict str, const uint32_t size)
@@ -5882,8 +5914,59 @@ enum normalize_pl_member_result {
   NPMR_ERROR // found the data, but normalization failed
 };
 
+static inline void mutable_member_mask_set (uint32_t mask[MUTABLE_MEMBER_MASK_WORDS], uint32_t slot)
+{
+  mask[slot / 32] |= 1u << (slot % 32);
+}
+
+static inline void mutable_member_mask_clear (uint32_t mask[MUTABLE_MEMBER_MASK_WORDS], uint32_t slot)
+{
+  mask[slot / 32] &= ~(1u << (slot % 32));
+}
+
+static bool mutable_member_mask_nonzero (const uint32_t mask[MUTABLE_MEMBER_MASK_WORDS])
+{
+  for (uint32_t n = 0; n < MUTABLE_MEMBER_MASK_WORDS; n++)
+  {
+    if (mask[n] != 0)
+      return true;
+  }
+  return false;
+}
+
+static bool mutable_member_is_required (uint32_t insn)
+{
+  return (insn & DDS_OP_FLAG_KEY) || ((insn & DDS_OP_FLAG_MU) && !op_type_optional (insn));
+}
+
+static bool dds_stream_pl_required_mask (const uint32_t *ops, uint32_t *slot, uint32_t missing[MUTABLE_MEMBER_MASK_WORDS])
+{
+  uint32_t insn, ops_csr = 0;
+  while ((insn = ops[ops_csr]) != DDS_OP_RTS)
+  {
+    assert (DDS_OP (insn) == DDS_OP_PLM);
+    const uint32_t *plm_ops = ops + ops_csr + DDS_OP_ADR_PLM (insn);
+    if (DDS_PLM_FLAGS (insn) & DDS_OP_FLAG_BASE)
+    {
+      assert (DDS_OP (plm_ops[0]) == DDS_OP_PLC);
+      if (!dds_stream_pl_required_mask (plm_ops + 1, slot, missing))
+        return false;
+    }
+    else
+    {
+      if (*slot >= MUTABLE_MEMBER_LIMIT)
+        return false;
+      if (mutable_member_is_required (*plm_ops))
+        mutable_member_mask_set (missing, *slot);
+      (*slot)++;
+    }
+    ops_csr += 2;
+  }
+  return true;
+}
+
 ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
-static enum normalize_pl_member_result dds_stream_normalize_pl_member (struct normalize_state const * const st, uint32_t * restrict const off, const uint32_t m_id, const uint32_t *ops)
+static enum normalize_pl_member_result dds_stream_normalize_pl_member (struct normalize_state const * const st, uint32_t * restrict const off, const uint32_t m_id, const uint32_t *ops, uint32_t *slot, uint32_t missing[MUTABLE_MEMBER_MASK_WORDS])
 {
   uint32_t insn, ops_csr = 0;
   enum normalize_pl_member_result result = NPMR_NOT_FOUND;
@@ -5896,18 +5979,33 @@ static enum normalize_pl_member_result dds_stream_normalize_pl_member (struct no
     {
       assert (DDS_OP (plm_ops[0]) == DDS_OP_PLC);
       plm_ops++; /* skip PLC to go to first PLM from base type */
-      result = dds_stream_normalize_pl_member (st, off, m_id, plm_ops);
+      result = dds_stream_normalize_pl_member (st, off, m_id, plm_ops, slot, missing);
     }
     else if (ops[ops_csr + 1] == m_id)
     {
+      if (*slot >= MUTABLE_MEMBER_LIMIT)
+        return NPMR_ERROR;
+      const uint32_t matched_slot = *slot;
       enum dds_stream_normalize_result nres = stream_normalize_data_impl (st, off, &plm_ops, true);
       switch (nres)
       {
-        case DDS_STREAM_NORMALIZE_SUCCESS: result = NPMR_FOUND; break;
-        case DDS_STREAM_NORMALIZE_DISCARD: result = NPMR_DISCARD; break;
+        case DDS_STREAM_NORMALIZE_SUCCESS:
+          mutable_member_mask_clear (missing, matched_slot);
+          result = NPMR_FOUND;
+          break;
+        case DDS_STREAM_NORMALIZE_DISCARD:
+          mutable_member_mask_clear (missing, matched_slot);
+          result = NPMR_DISCARD;
+          break;
         case DDS_STREAM_NORMALIZE_ERROR: result = NPMR_ERROR; break;
       }
       break;
+    }
+    else
+    {
+      if (*slot >= MUTABLE_MEMBER_LIMIT)
+        return NPMR_ERROR;
+      (*slot)++;
     }
     ops_csr += 2;
   }
@@ -5918,6 +6016,11 @@ static enum normalize_pl_member_result dds_stream_normalize_pl_member (struct no
 ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
 static enum dds_stream_normalize_result stream_normalize_xcdr1_pl (struct normalize_state const * const st, uint32_t * restrict const off, uint32_t const * * const ops)
 {
+  uint32_t missing[MUTABLE_MEMBER_MASK_WORDS] = { 0 };
+  uint32_t required_slot = 0;
+  if (!dds_stream_pl_required_mask (*ops, &required_slot, missing))
+    return normalize_error ();
+
   bool paramlist_end = false;
   do
   {
@@ -5949,7 +6052,8 @@ static enum dds_stream_normalize_result stream_normalize_xcdr1_pl (struct normal
         // don't allow member values that exceed its declared size
         const struct normalize_state st1 = offset_and_shorten_normalize_state (st, input_offset, param_length);
         uint32_t off1 = 0;
-        switch (dds_stream_normalize_pl_member (&st1, &off1, phdr_mid, *ops))
+        uint32_t slot = 0;
+        switch (dds_stream_normalize_pl_member (&st1, &off1, phdr_mid, *ops, &slot, missing))
         {
           case NPMR_NOT_FOUND: // FIXME: can now fix this FIXME!
             /* FIXME: the caller should be able to differentiate between a sample that
@@ -5986,6 +6090,9 @@ static enum dds_stream_normalize_result stream_normalize_xcdr1_pl (struct normal
   }
   while (!paramlist_end);
 
+  if (mutable_member_mask_nonzero (missing))
+    return normalize_error ();
+
   /* skip all PLM-memberid pairs */
   while (**ops != DDS_OP_RTS)
     *ops += 2;
@@ -5997,6 +6104,11 @@ static enum dds_stream_normalize_result stream_normalize_xcdr1_pl (struct normal
 ddsrt_attribute_warn_unused_result ddsrt_nonnull_all
 static enum dds_stream_normalize_result stream_normalize_xcdr2_pl (struct normalize_state const * const st, uint32_t * restrict const off, uint32_t const * * const ops)
 {
+  uint32_t missing[MUTABLE_MEMBER_MASK_WORDS] = { 0 };
+  uint32_t required_slot = 0;
+  if (!dds_stream_pl_required_mask (*ops, &required_slot, missing))
+    return normalize_error ();
+
   /* normalize DHEADER */
   uint32_t pl_sz;
   if (!read_and_normalize_uint32 (st, off, &pl_sz))
@@ -6052,7 +6164,8 @@ static enum dds_stream_normalize_result stream_normalize_xcdr2_pl (struct normal
       return normalize_error ();
     // don't allow member values that exceed its declared size
     const struct normalize_state st2 = shorten_normalize_state (&st1, *off + msz);
-    switch (dds_stream_normalize_pl_member (&st2, off, m_id, *ops))
+    uint32_t slot = 0;
+    switch (dds_stream_normalize_pl_member (&st2, off, m_id, *ops, &slot, missing))
     {
       case NPMR_NOT_FOUND:
         /* FIXME: the caller should be able to differentiate between a sample that
@@ -6079,6 +6192,9 @@ static enum dds_stream_normalize_result stream_normalize_xcdr2_pl (struct normal
         return normalize_error ();
     }
   }
+
+  if (mutable_member_mask_nonzero (missing))
+    return normalize_error ();
 
   /* skip all PLM-memberid pairs */
   while (**ops != DDS_OP_RTS)
@@ -6160,6 +6276,7 @@ static enum dds_stream_normalize_result stream_normalize_data_impl (struct norma
 
 enum dds_stream_normalize_result dds_stream_normalize_xcdr2_data (char * restrict data, uint32_t * restrict off, uint32_t size, bool bswap, const uint32_t *ops)
 {
+  assert (dds_stream_mutable_member_counts_within_limit (ops));
   const struct dds_cdrstream_desc_mid_table empty_mid_table = { .table = (struct ddsrt_hh *) &ddsrt_hh_empty, .op0 = ops };
   const uint32_t *tmp_ops = ops;
   const struct normalize_state st = {
@@ -8028,13 +8145,18 @@ size_t dds_stream_print_key (dds_istream_t *is, const struct dds_cdrstream_desc 
   return size;
 }
 
+static uint32_t dds_stream_countops_info (const uint32_t *ops, uint32_t nkeys, const dds_key_descriptor_t *keys, struct dds_cdrstream_ops_info *info)
+{
+  dds_stream_get_ops_info (ops, info);
+  for (uint32_t n = 0; n < nkeys; n++)
+    dds_stream_countops_keyoffset (ops, &keys[n], &info->ops_end);
+  return (uint32_t) (info->ops_end - ops);
+}
+
 uint32_t dds_stream_countops (const uint32_t *ops, uint32_t nkeys, const dds_key_descriptor_t *keys)
 {
   struct dds_cdrstream_ops_info info;
-  dds_stream_get_ops_info (ops, &info);
-  for (uint32_t n = 0; n < nkeys; n++)
-    dds_stream_countops_keyoffset (ops, &keys[n], &info.ops_end);
-  return (uint32_t) (info.ops_end - ops);
+  return dds_stream_countops_info (ops, nkeys, keys, &info);
 }
 
 uint32_t dds_stream_supported_data_representations (const uint32_t *ops)
@@ -8542,24 +8664,28 @@ static const uint32_t *dds_stream_key_size (const uint32_t *ops, struct key_prop
   return ops;
 }
 
-uint32_t dds_stream_descriptor_flags (struct dds_cdrstream_desc *desc, uint32_t flagset, uint32_t *keysz_xcdrv1,
-    uint32_t *keysz_xcdrv2)
+static uint32_t dds_stream_descriptor_flags_impl (struct dds_cdrstream_desc *desc, uint32_t flagset, uint32_t *keysz_xcdrv1,
+    uint32_t *keysz_xcdrv2, const struct dds_cdrstream_ops_info *ops_info)
 {
   if (keysz_xcdrv1 != NULL)
     *keysz_xcdrv1 = 0;
   if (keysz_xcdrv2 != NULL)
     *keysz_xcdrv2 = 0;
 
-  struct dds_cdrstream_ops_info info;
-  dds_stream_get_ops_info (desc->ops.ops, &info);
+  struct dds_cdrstream_ops_info info_store;
+  if (ops_info == NULL)
+  {
+    dds_stream_get_ops_info (desc->ops.ops, &info_store);
+    ops_info = &info_store;
+  }
 
   uint32_t descriptor_flags = flagset & DDS_CDR_DESCRIPTOR_PRESERVED_FLAGS;
-  descriptor_flags |= info.descriptor_flags & DDS_TOPIC_FIXED_SIZE;
+  descriptor_flags |= ops_info->descriptor_flags & DDS_TOPIC_FIXED_SIZE;
 
   if (desc->keys.nkeys > 0)
   {
     struct key_props key_properties = { 0 };
-    key_properties.supported_data_representations = info.supported_data_representations;
+    key_properties.supported_data_representations = ops_info->supported_data_representations;
     (void) dds_stream_key_size (desc->ops.ops, &key_properties);
 
     if (keysz_xcdrv1 != NULL)
@@ -8591,6 +8717,12 @@ uint32_t dds_stream_descriptor_flags (struct dds_cdrstream_desc *desc, uint32_t 
   }
 
   return descriptor_flags;
+}
+
+uint32_t dds_stream_descriptor_flags (struct dds_cdrstream_desc *desc, uint32_t flagset, uint32_t *keysz_xcdrv1,
+    uint32_t *keysz_xcdrv2)
+{
+  return dds_stream_descriptor_flags_impl (desc, flagset, keysz_xcdrv1, keysz_xcdrv2, NULL);
 }
 
 static int key_cmp_idx (const void *va, const void *vb)
@@ -8756,7 +8888,7 @@ static const uint32_t *dds_stream_get_enum_value_maps (const struct dds_cdrstrea
   return ++ops;
 }
 
-void dds_cdrstream_desc_init_with_nops (struct dds_cdrstream_desc *desc, const struct dds_cdrstream_allocator *allocator,
+dds_return_t dds_cdrstream_desc_init_with_nops (struct dds_cdrstream_desc *desc, const struct dds_cdrstream_allocator *allocator,
     uint32_t size, uint32_t align, uint32_t flagset, const uint32_t *ops, uint32_t nops, const dds_key_descriptor_t *keys, uint32_t nkeys)
 {
   desc->size = size;
@@ -8773,7 +8905,17 @@ void dds_cdrstream_desc_init_with_nops (struct dds_cdrstream_desc *desc, const s
     qsort (desc->keys.keys_definition_order, nkeys, sizeof (*desc->keys.keys_definition_order), key_cmp_idx);
 
   /* Get the actual number of ops, excluding the member ID table ops */
-  uint32_t counted_ops = dds_stream_countops (ops, nkeys, keys);
+  struct dds_cdrstream_ops_info ops_info;
+  uint32_t counted_ops = dds_stream_countops_info (ops, nkeys, keys, &ops_info);
+  if (!ops_info.mutable_member_counts_within_limit)
+  {
+    if (desc->keys.keys != NULL)
+      allocator->free (desc->keys.keys);
+    if (desc->keys.keys_definition_order != NULL)
+      allocator->free (desc->keys.keys_definition_order);
+    memset (desc, 0, sizeof (*desc));
+    return DDS_RETCODE_BAD_PARAMETER;
+  }
   desc->ops.nops = (counted_ops < nops) ? nops : counted_ops;
 
   /* Copy all ops, including the member ID table (if present) */
@@ -8820,13 +8962,14 @@ void dds_cdrstream_desc_init_with_nops (struct dds_cdrstream_desc *desc, const s
 
   /* Get the flagset from the descriptor, except for flags that are calculated
      using the CDR stream serializer. */
-  desc->flagset = dds_stream_descriptor_flags (desc, flagset, NULL, NULL);
+  desc->flagset = dds_stream_descriptor_flags_impl (desc, flagset, NULL, NULL, &ops_info);
+  return DDS_RETCODE_OK;
 }
 
-void dds_cdrstream_desc_init (struct dds_cdrstream_desc *desc, const struct dds_cdrstream_allocator *allocator,
+dds_return_t dds_cdrstream_desc_init (struct dds_cdrstream_desc *desc, const struct dds_cdrstream_allocator *allocator,
     uint32_t size, uint32_t align, uint32_t flagset, const uint32_t *ops, const dds_key_descriptor_t *keys, uint32_t nkeys)
 {
-  dds_cdrstream_desc_init_with_nops (desc, allocator, size, align, flagset, ops, 0, keys, nkeys);
+  return dds_cdrstream_desc_init_with_nops (desc, allocator, size, align, flagset, ops, 0, keys, nkeys);
 }
 
 static void free_member_id (void *vinfo, void *varg)

--- a/src/core/cdr/src/dds_cdrstream.c
+++ b/src/core/cdr/src/dds_cdrstream.c
@@ -209,6 +209,7 @@ struct normalize_state {
   uint32_t max_align_lg2;         // lg2 of max align in stream (3 for XCDR1, 2 for XCDR2)
   enum dds_cdr_enc_version xcdr_version; // CDR version (XCDR1 or XCDR2)
   enum cdr_data_kind cdr_kind;    // key or data
+  uint32_t normalize_flags;
   const struct dds_cdrstream_desc_mid_table *mid_table;
 #ifndef NDEBUG
   const void *stack_witness;
@@ -5878,10 +5879,8 @@ static enum dds_stream_normalize_result stream_normalize_delimited_impl (struct 
 
   if (insn != DDS_OP_RTS)
   {
-#if 0 // FIXME: need to deal with type coercion flags
-    if (!type_widening_allowed)
-      return NULL;
-#endif
+    if (st->normalize_flags & DDS_STREAM_NORMALIZE_FLAG_PREVENT_TYPE_WIDENING)
+      return normalize_error ();
     if (required_prefix && *ops < required_end)
       return normalize_error ();
     /* skip fields that are not in serialized data for appendable type */
@@ -5934,12 +5933,15 @@ static bool mutable_member_mask_nonzero (const uint32_t mask[MUTABLE_MEMBER_MASK
   return false;
 }
 
-static bool mutable_member_is_required (uint32_t insn)
+static bool mutable_member_is_required (uint32_t insn, uint32_t normalize_flags)
 {
-  return (insn & DDS_OP_FLAG_KEY) || ((insn & DDS_OP_FLAG_MU) && !op_type_optional (insn));
+  if (normalize_flags & DDS_STREAM_NORMALIZE_FLAG_PREVENT_TYPE_WIDENING)
+    return (insn & DDS_OP_FLAG_KEY) || !op_type_optional (insn);
+  else
+    return (insn & DDS_OP_FLAG_KEY) || ((insn & DDS_OP_FLAG_MU) && !op_type_optional (insn));
 }
 
-static bool dds_stream_pl_required_mask (const uint32_t *ops, uint32_t *slot, uint32_t missing[MUTABLE_MEMBER_MASK_WORDS])
+static bool dds_stream_pl_required_mask (const uint32_t *ops, uint32_t *slot, uint32_t missing[MUTABLE_MEMBER_MASK_WORDS], uint32_t normalize_flags)
 {
   uint32_t insn, ops_csr = 0;
   while ((insn = ops[ops_csr]) != DDS_OP_RTS)
@@ -5949,14 +5951,14 @@ static bool dds_stream_pl_required_mask (const uint32_t *ops, uint32_t *slot, ui
     if (DDS_PLM_FLAGS (insn) & DDS_OP_FLAG_BASE)
     {
       assert (DDS_OP (plm_ops[0]) == DDS_OP_PLC);
-      if (!dds_stream_pl_required_mask (plm_ops + 1, slot, missing))
+      if (!dds_stream_pl_required_mask (plm_ops + 1, slot, missing, normalize_flags))
         return false;
     }
     else
     {
       if (*slot >= MUTABLE_MEMBER_LIMIT)
         return false;
-      if (mutable_member_is_required (*plm_ops))
+      if (mutable_member_is_required (*plm_ops, normalize_flags))
         mutable_member_mask_set (missing, *slot);
       (*slot)++;
     }
@@ -6018,7 +6020,7 @@ static enum dds_stream_normalize_result stream_normalize_xcdr1_pl (struct normal
 {
   uint32_t missing[MUTABLE_MEMBER_MASK_WORDS] = { 0 };
   uint32_t required_slot = 0;
-  if (!dds_stream_pl_required_mask (*ops, &required_slot, missing))
+  if (!dds_stream_pl_required_mask (*ops, &required_slot, missing, st->normalize_flags))
     return normalize_error ();
 
   bool paramlist_end = false;
@@ -6106,7 +6108,7 @@ static enum dds_stream_normalize_result stream_normalize_xcdr2_pl (struct normal
 {
   uint32_t missing[MUTABLE_MEMBER_MASK_WORDS] = { 0 };
   uint32_t required_slot = 0;
-  if (!dds_stream_pl_required_mask (*ops, &required_slot, missing))
+  if (!dds_stream_pl_required_mask (*ops, &required_slot, missing, st->normalize_flags))
     return normalize_error ();
 
   /* normalize DHEADER */
@@ -6377,7 +6379,7 @@ static enum dds_stream_normalize_result stream_normalize_key (struct normalize_s
   return normalize_success ();
 }
 
-enum dds_stream_normalize_result dds_stream_normalize (void *data, uint32_t size, bool bswap, enum dds_cdr_enc_version xcdr_version, const struct dds_cdrstream_desc *desc, bool just_key, uint32_t *actual_size)
+enum dds_stream_normalize_result dds_stream_normalize_with_flags (void *data, uint32_t size, bool bswap, enum dds_cdr_enc_version xcdr_version, const struct dds_cdrstream_desc *desc, bool just_key, uint32_t flags, uint32_t *actual_size)
 {
   if (size > CDR_SIZE_MAX)
     return normalize_error ();
@@ -6390,6 +6392,7 @@ enum dds_stream_normalize_result dds_stream_normalize (void *data, uint32_t size
     .max_align_lg2 = (xcdr_version == DDSI_RTPS_CDR_ENC_VERSION_1) ? 3 : 2,
     .xcdr_version = xcdr_version,
     .cdr_kind = just_key ? CDR_KIND_KEY : CDR_KIND_DATA,
+    .normalize_flags = flags,
     .mid_table = &desc->member_ids
 #ifndef NDEBUG
   , .stack_witness = &st
@@ -6418,10 +6421,15 @@ enum dds_stream_normalize_result dds_stream_normalize (void *data, uint32_t size
   }
 }
 
-enum dds_stream_normalize_result dds_stream_normalize_to_istream (dds_istream_t *is, void *data, uint32_t size, bool bswap, enum dds_cdr_enc_version xcdr_version, const struct dds_cdrstream_desc *desc, bool just_key, uint32_t *actual_size)
+enum dds_stream_normalize_result dds_stream_normalize (void *data, uint32_t size, bool bswap, enum dds_cdr_enc_version xcdr_version, const struct dds_cdrstream_desc *desc, bool just_key, uint32_t *actual_size)
+{
+  return dds_stream_normalize_with_flags (data, size, bswap, xcdr_version, desc, just_key, DDS_STREAM_NORMALIZE_FLAG_NONE, actual_size);
+}
+
+enum dds_stream_normalize_result dds_stream_normalize_to_istream_with_flags (dds_istream_t *is, void *data, uint32_t size, bool bswap, enum dds_cdr_enc_version xcdr_version, const struct dds_cdrstream_desc *desc, bool just_key, uint32_t flags, uint32_t *actual_size)
 {
   const enum dds_stream_normalize_result res =
-    dds_stream_normalize (data, size, bswap, xcdr_version, desc, just_key, actual_size);
+    dds_stream_normalize_with_flags (data, size, bswap, xcdr_version, desc, just_key, flags, actual_size);
   if (res == DDS_STREAM_NORMALIZE_SUCCESS)
     dds_istream_init_well_formed (is, *actual_size, data, xcdr_version);
   else
@@ -6430,6 +6438,11 @@ enum dds_stream_normalize_result dds_stream_normalize_to_istream (dds_istream_t 
     dds_istream_reset_empty (is, xcdr_version);
   }
   return res;
+}
+
+enum dds_stream_normalize_result dds_stream_normalize_to_istream (dds_istream_t *is, void *data, uint32_t size, bool bswap, enum dds_cdr_enc_version xcdr_version, const struct dds_cdrstream_desc *desc, bool just_key, uint32_t *actual_size)
+{
+  return dds_stream_normalize_to_istream_with_flags (is, data, size, bswap, xcdr_version, desc, just_key, DDS_STREAM_NORMALIZE_FLAG_NONE, actual_size);
 }
 
 enum dds_stream_normalize_result dds_stream_normalize_xcdr2_data_to_istream (dds_istream_t *is, char *data, uint32_t *off, uint32_t size, bool bswap, const uint32_t *ops)

--- a/src/core/cdr/src/dds_cdrstream_keys.part.h
+++ b/src/core/cdr/src/dds_cdrstream_keys.part.h
@@ -181,7 +181,7 @@ static const uint32_t *dds_stream_extract_keyBO_from_data_adr (uint32_t insn, dd
 
     /* skip DLC instruction for base type, handle as if it is final because the base type's
         members follow the derived types members without an extra DHEADER */
-    if (op_type_base (insn) && jsr_ops[0] == DDS_OP_DLC)
+    if (op_type_base (insn) && op_is_dlc (jsr_ops[0]))
       jsr_ops++;
 
     /* only in case the ADR|EXT has the key flag set, pass the actual ostream, otherwise skip the EXT type by passing NULL for ostream */

--- a/src/core/cdr/src/dds_cdrstream_write.part.h
+++ b/src/core/cdr/src/dds_cdrstream_write.part.h
@@ -861,7 +861,7 @@ static const uint32_t *dds_stream_write_adrBO (uint32_t insn, RESTRICT_OSTREAM_T
 
       /* skip DLC instruction for base type, so that the DHEADER is not
           serialized for base types */
-      if (op_type_base (insn) && jsr_ops[0] == DDS_OP_DLC)
+      if (op_type_base (insn) && op_is_dlc (jsr_ops[0]))
         jsr_ops++;
 
       /* don't forward is_mutable_member, subtype can have other extensibility */

--- a/src/core/ddsc/include/dds/ddsc/dds_internal_api.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_internal_api.h
@@ -36,7 +36,7 @@ extern "C" {
  * @param[in] topic_desc The source topic descriptor
  *
 */
-DDS_EXPORT void
+DDS_EXPORT dds_return_t
 dds_cdrstream_desc_from_topic_desc (struct dds_cdrstream_desc *desc, const dds_topic_descriptor_t *topic_desc);
 
 /**

--- a/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
+++ b/src/core/ddsc/include/dds/ddsc/dds_opcodes.h
@@ -170,6 +170,18 @@ extern "C" {
 #define DDS_OP_LENGTH(o)      ((uint16_t) ((o) & DDS_OP_JMP_MASK))
 
 /**
+ * @anchor DDS_OP_DLC_REQUIRED_PREFIX
+ * @ingroup serialization
+ * @brief Extract the offset past the required appendable prefix
+ *
+ * For DLC instructions, this is an unsigned offset from the DLC instruction to
+ * the first instruction past the required prefix in the delimited scope. This
+ * prefix covers the first member, if any, and all key or non-optional
+ * must-understand members. A value of 0 means there is no required prefix.
+ */
+#define DDS_OP_DLC_REQUIRED_PREFIX(o) ((uint16_t) ((o) & DDS_OP_JMP_MASK))
+
+/**
  * @anchor DDS_OP_JUMP
  * @ingroup serialization
  * @brief Extract the JUMP from a uint32
@@ -357,8 +369,14 @@ enum dds_stream_opcode {
   */
   DDS_SOP_JEQ = DDS_OP_JEQ,
 
-  /** XCDR2 delimited CDR (inserts DHEADER before type)
-    [DLC, 0, 0]
+  /** delimited CDR (inserts DHEADER before type for XCDR2)
+    [DLC, 0, e]
+     where
+       e = (unsigned 16 bits) offset to first instruction past the required
+           prefix in the delimited scope, from the start of the DLC instruction.
+           The prefix covers the first member, if any, and all key or
+           non-optional must-understand members. A value of 0 means there is no
+           required prefix.
   */
   DDS_SOP_DLC = DDS_OP_DLC,
 

--- a/src/core/ddsc/src/dds__serdata_default.h
+++ b/src/core/ddsc/src/dds__serdata_default.h
@@ -126,6 +126,7 @@ struct dds_sertype_default {
   struct ddsi_sertype c;
   enum dds_cdr_enc_format encoding_format; /* DDSI_RTPS_CDR_ENC_FORMAT_(PLAIN|DELIMITED|PL) - CDR encoding format for the top-level type in this sertype */
   enum dds_cdr_enc_version xcdr_version; /* DDSI_RTPS_CDR_ENC_VERSION_(1|2) - CDR encoding version used for writing data using this sertype */
+  uint32_t normalize_flags;
   struct dds_serdatapool *serpool;
   struct dds_cdrstream_desc type;
   struct dds_sertype_default_cdr_data typeinfo_ser;

--- a/src/core/ddsc/src/dds__types.h
+++ b/src/core/ddsc/src/dds__types.h
@@ -400,6 +400,7 @@ typedef struct dds_reader {
   struct dds_entity m_entity;
   struct dds_endpoint m_endpoint;
   struct dds_topic *m_topic; /* refc'd, constant, lock(rd) -> lock(tp) allowed */
+  struct ddsi_sertype *m_stype; /* refc'd, constant, borrowed by the RHC */
   struct dds_rhc *m_rhc; /* aliases m_rd->rhc with a wider interface, FIXME: but m_rd owns it for resource management */
   struct ddsi_reader *m_rd;
   struct dds_loan_pool *m_loans; /* administration of outstanding loans */

--- a/src/core/ddsc/src/dds_reader.c
+++ b/src/core/ddsc/src/dds_reader.c
@@ -83,6 +83,7 @@ static dds_return_t dds_reader_delete (dds_entity *e)
   dds_loan_pool_free (rd->m_heap_loan_cache);
   dds_loan_pool_free (rd->m_loans);
   dds_endpoint_remove_psmx_endpoints (&rd->m_endpoint);
+  ddsi_sertype_unref (rd->m_stype);
 
   dds_entity_drop_ref (&rd->m_topic->m_entity);
   return ret;
@@ -618,7 +619,13 @@ static dds_entity_t dds_create_reader_int (dds_entity_t participant_or_subscribe
   ddsrt_atomic_or32 (&rd->m_entity.m_status.m_status_and_mask, DDS_DATA_ON_READERS_STATUS << SAM_ENABLED_SHIFT);
   rd->m_sample_rejected_status.last_reason = DDS_NOT_REJECTED;
   rd->m_topic = tp;
-  rd->m_rhc = rhc ? rhc : dds_rhc_default_new (gv, tp->m_stype, rd->m_entity.m_qos);
+  rd->m_stype = ddsi_sertype_derive_sertype (tp->m_stype, rqos->data_representation.value.ids[0],
+    rqos->present & DDSI_QP_TYPE_CONSISTENCY_ENFORCEMENT
+      ? rqos->type_consistency : ddsi_default_qos_reader.type_consistency);
+  if (!rd->m_stype)
+    rd->m_stype = tp->m_stype;
+  ddsi_sertype_ref (rd->m_stype);
+  rd->m_rhc = rhc ? rhc : dds_rhc_default_new (gv, rd->m_stype, rd->m_entity.m_qos);
   rc = dds_loan_pool_create (&rd->m_loans, 0);
   assert (rc == DDS_RETCODE_OK); // FIXME: can be out of resources
   rc = dds_loan_pool_create (&rd->m_heap_loan_cache, 0);
@@ -645,7 +652,7 @@ static dds_entity_t dds_create_reader_int (dds_entity_t participant_or_subscribe
     rd->m_entity.m_guid = dds_guid_to_ddsi_guid (*guid);
   else
   {
-    rc = ddsi_generate_reader_guid (&rd->m_entity.m_guid, pp, tp->m_stype);
+    rc = ddsi_generate_reader_guid (&rd->m_entity.m_guid, pp, rd->m_stype);
     if (rc != DDS_RETCODE_OK)
     {
       ddsi_thread_state_asleep (ddsi_lookup_thread_state ());
@@ -655,9 +662,7 @@ static dds_entity_t dds_create_reader_int (dds_entity_t participant_or_subscribe
 
   struct ddsi_psmx_locators_set *vl_set = dds_get_psmx_locators_set (rqos, &rd->m_entity.m_domain->psmx_instances);
 
-  /* Reader gets the sertype from the topic, as the serdata functions the reader uses are
-     not specific for a data representation (the representation can be retrieved from the cdr header) */
-  rc = ddsi_new_reader (&rd->m_rd, &rd->m_entity.m_guid, NULL, pp, tp->m_name, tp->m_stype, rqos, &rd->m_rhc->common.rhc, dds_reader_status_cb, rd, vl_set);
+  rc = ddsi_new_reader (&rd->m_rd, &rd->m_entity.m_guid, NULL, pp, tp->m_name, rd->m_stype, rqos, &rd->m_rhc->common.rhc, dds_reader_status_cb, rd, vl_set);
   if (rc != DDS_RETCODE_OK)
   {
     /* FIXME: can be out-of-resources at the very least; would leak allocated entity id */

--- a/src/core/ddsc/src/dds_serdata_default.c
+++ b/src/core/ddsc/src/dds_serdata_default.c
@@ -405,7 +405,8 @@ static enum from_ser_result serdata_default_from_ser_common (const struct ddsi_s
   if (d->pos < pad)
     nres = DDS_STREAM_NORMALIZE_ERROR;
   else
-    nres = dds_stream_normalize_to_istream (&is, d->data, d->pos - pad, needs_bswap, xcdr_version, &tp->type, kind == SDK_KEY, &actual_size);
+    nres = dds_stream_normalize_to_istream_with_flags (&is, d->data, d->pos - pad, needs_bswap, xcdr_version,
+      &tp->type, kind == SDK_KEY, tp->normalize_flags, &actual_size);
   switch (nres)
   {
     case DDS_STREAM_NORMALIZE_SUCCESS:
@@ -468,7 +469,8 @@ static enum from_ser_result serdata_default_from_ser_iov_common (const struct dd
   if (d->pos < pad)
     nres = DDS_STREAM_NORMALIZE_ERROR;
   else
-    nres = dds_stream_normalize_to_istream (&is, d->data, d->pos - pad, needs_bswap, xcdr_version, &tp->type, kind == SDK_KEY, &actual_size);
+    nres = dds_stream_normalize_to_istream_with_flags (&is, d->data, d->pos - pad, needs_bswap, xcdr_version,
+      &tp->type, kind == SDK_KEY, tp->normalize_flags, &actual_size);
   switch (nres)
   {
     case DDS_STREAM_NORMALIZE_SUCCESS:
@@ -1026,7 +1028,8 @@ static struct ddsi_serdata * serdata_default_from_psmx (const struct ddsi_sertyp
       dds_istream_t is;
       const enum dds_stream_normalize_result nres = (md->sample_size < pad)
         ? DDS_STREAM_NORMALIZE_ERROR
-        : dds_stream_normalize_to_istream (&is, d->data, md->sample_size - pad, false, xcdr_version, &tp->type, just_key, &actual_size);
+        : dds_stream_normalize_to_istream_with_flags (&is, d->data, md->sample_size - pad, false, xcdr_version,
+          &tp->type, just_key, tp->normalize_flags, &actual_size);
       switch (nres)
       {
         case DDS_STREAM_NORMALIZE_SUCCESS:

--- a/src/core/ddsc/src/dds_sertype_default.c
+++ b/src/core/ddsc/src/dds_sertype_default.c
@@ -325,14 +325,16 @@ dds_return_t dds_sertype_default_init (const struct dds_domain *domain, struct d
   const uint32_t supported_data_representations = dds_stream_supported_data_representations (desc->m_ops);
   allowed_data_representation &= supported_data_representations;
 
+  dds_return_t ret = dds_cdrstream_desc_init_with_nops (&st->type, &dds_cdrstream_default_allocator, desc->m_size, desc->m_align, desc->m_flagset, desc->m_ops, desc->m_nops, desc->m_keys, desc->m_nkeys);
+  if (ret != DDS_RETCODE_OK)
+    return ret;
+
   ddsi_sertype_init_props (&st->c, desc->m_typename, &dds_sertype_ops_default, serdata_ops, desc->m_size, dds_stream_data_types (desc->m_ops), allowed_data_representation, 0);
   st->encoding_format = ddsi_sertype_extensibility_enc_format (type_ext);
   /* Store the encoding version used for writing data using this sertype. When reading data,
      the encoding version from the encapsulation header in the CDR is used */
   st->xcdr_version = data_representation == DDS_DATA_REPRESENTATION_XCDR1 ? DDSI_RTPS_CDR_ENC_VERSION_1 : DDSI_RTPS_CDR_ENC_VERSION_2;
   st->serpool = domain->serpool;
-
-  dds_cdrstream_desc_init_with_nops (&st->type, &dds_cdrstream_default_allocator, desc->m_size, desc->m_align, desc->m_flagset, desc->m_ops, desc->m_nops, desc->m_keys, desc->m_nkeys);
 
   if (desc->m_flagset & DDS_TOPIC_XTYPES_METADATA)
   {

--- a/src/core/ddsc/src/dds_sertype_default.c
+++ b/src/core/ddsc/src/dds_sertype_default.c
@@ -34,6 +34,8 @@ static bool sertype_default_equal (const struct ddsi_sertype *acmn, const struct
   const struct dds_sertype_default *b = (struct dds_sertype_default *) bcmn;
   if (a->encoding_format != b->encoding_format)
     return false;
+  if (a->normalize_flags != b->normalize_flags)
+    return false;
   if (a->type.size != b->type.size)
     return false;
   if (a->type.align != b->type.align)
@@ -129,6 +131,7 @@ static uint32_t sertype_default_hash (const struct ddsi_sertype *tpcmn)
   ddsrt_md5_init (&md5st);
   ddsrt_md5_append (&md5st, (ddsrt_md5_byte_t *) tp->c.type_name, (uint32_t) strlen (tp->c.type_name));
   ddsrt_md5_append (&md5st, (ddsrt_md5_byte_t *) &tp->encoding_format, sizeof (tp->encoding_format));
+  ddsrt_md5_append (&md5st, (ddsrt_md5_byte_t *) &tp->normalize_flags, sizeof (tp->normalize_flags));
   ddsrt_md5_append (&md5st, (ddsrt_md5_byte_t *) &tp->type.size, sizeof (tp->type.size));
   ddsrt_md5_append (&md5st, (ddsrt_md5_byte_t *) &tp->type.align, sizeof (tp->type.align));
   ddsrt_md5_append (&md5st, (ddsrt_md5_byte_t *) &tp->type.flagset, sizeof (tp->type.flagset));
@@ -216,11 +219,10 @@ static struct ddsi_sertype * sertype_default_derive_sertype (const struct ddsi_s
   const struct dds_sertype_default *base_sertype_default = (const struct dds_sertype_default *) base_sertype;
   struct dds_sertype_default *derived_sertype = NULL;
   const struct ddsi_serdata_ops *required_ops;
+  const uint32_t required_normalize_flags = tce_qos.prevent_type_widening
+    ? DDS_STREAM_NORMALIZE_FLAG_PREVENT_TYPE_WIDENING : DDS_STREAM_NORMALIZE_FLAG_NONE;
 
   assert (base_sertype);
-
-  // FIXME: implement using options from the type consistency enforcement qos policy in (de)serializer
-  (void) tce_qos;
 
   if (data_representation == DDS_DATA_REPRESENTATION_XCDR1)
     required_ops = base_sertype->has_key ? &dds_serdata_ops_cdr : &dds_serdata_ops_cdr_nokey;
@@ -229,7 +231,8 @@ static struct ddsi_sertype * sertype_default_derive_sertype (const struct ddsi_s
   else
     abort ();
 
-  if (base_sertype->serdata_ops == required_ops)
+  if (base_sertype->serdata_ops == required_ops &&
+      base_sertype_default->normalize_flags == required_normalize_flags)
     derived_sertype = (struct dds_sertype_default *) base_sertype_default;
   else
   {
@@ -238,6 +241,7 @@ static struct ddsi_sertype * sertype_default_derive_sertype (const struct ddsi_s
     ddsrt_atomic_st32 (&derived_sertype->c.flags_refc, refc & ~DDSI_SERTYPE_REFC_MASK);
     derived_sertype->c.base_sertype = ddsi_sertype_ref (base_sertype);
     derived_sertype->c.serdata_ops = required_ops;
+    derived_sertype->normalize_flags = required_normalize_flags;
     derived_sertype->xcdr_version = data_representation == DDS_DATA_REPRESENTATION_XCDR1 ? DDSI_RTPS_CDR_ENC_VERSION_1 : DDSI_RTPS_CDR_ENC_VERSION_2;
   }
 
@@ -334,6 +338,7 @@ dds_return_t dds_sertype_default_init (const struct dds_domain *domain, struct d
   /* Store the encoding version used for writing data using this sertype. When reading data,
      the encoding version from the encapsulation header in the CDR is used */
   st->xcdr_version = data_representation == DDS_DATA_REPRESENTATION_XCDR1 ? DDSI_RTPS_CDR_ENC_VERSION_1 : DDSI_RTPS_CDR_ENC_VERSION_2;
+  st->normalize_flags = DDS_STREAM_NORMALIZE_FLAG_NONE;
   st->serpool = domain->serpool;
 
   if (desc->m_flagset & DDS_TOPIC_XTYPES_METADATA)

--- a/src/core/ddsc/src/dds_topic.c
+++ b/src/core/ddsc/src/dds_topic.c
@@ -1165,9 +1165,9 @@ dds_return_t dds_delete_topic_descriptor (dds_topic_descriptor_t *descriptor)
 
 #endif /* DDS_HAS_TYPELIB */
 
-void dds_cdrstream_desc_from_topic_desc (struct dds_cdrstream_desc *desc, const dds_topic_descriptor_t *topic_desc)
+dds_return_t dds_cdrstream_desc_from_topic_desc (struct dds_cdrstream_desc *desc, const dds_topic_descriptor_t *topic_desc)
 {
   memset (desc, 0, sizeof (*desc));
-  dds_cdrstream_desc_init_with_nops (desc, &dds_cdrstream_default_allocator, topic_desc->m_size, topic_desc->m_align, topic_desc->m_flagset,
+  return dds_cdrstream_desc_init_with_nops (desc, &dds_cdrstream_default_allocator, topic_desc->m_size, topic_desc->m_align, topic_desc->m_flagset,
       topic_desc->m_ops, topic_desc->m_nops, topic_desc->m_keys, topic_desc->m_nkeys);
 }

--- a/src/core/ddsc/tests/CdrStreamParamHeader.idl
+++ b/src/core/ddsc/tests/CdrStreamParamHeader.idl
@@ -105,4 +105,22 @@ module CdrStreamMutable {
     @id(1) uint32 f1;
     @id(2) sequence<uint32> f2;
   };
+
+  @mutable
+  struct key_tail {
+    @id(1) uint32 f1;
+    @id(2) @key uint32 f2;
+  };
+
+  @mutable
+  struct mu_tail {
+    @id(1) uint32 f1;
+    @id(2) @must_understand uint32 f2;
+  };
+
+  @mutable
+  struct optional_mu_tail {
+    @id(1) uint32 f1;
+    @id(2) @optional @must_understand uint32 f2;
+  };
 };

--- a/src/core/ddsc/tests/CdrStreamParamHeader.idl
+++ b/src/core/ddsc/tests/CdrStreamParamHeader.idl
@@ -47,6 +47,40 @@ module CdrStreamAppendable {
   };
 
   @appendable
+  struct a1_key {
+    @key long m1;
+  };
+
+  @appendable
+  struct narrow {
+    long m1;
+  };
+
+  @appendable
+  struct wide {
+    long m1;
+    long m2;
+  };
+
+  @appendable
+  struct key_tail {
+    long m1;
+    @key long m2;
+  };
+
+  @appendable
+  struct mu_tail {
+    long m1;
+    @must_understand long m2;
+  };
+
+  @appendable
+  struct optional_mu_tail {
+    long m1;
+    @optional @must_understand long m2;
+  };
+
+  @appendable
   struct a2 {
     long m1;
     @optional long m2;

--- a/src/core/ddsc/tests/cdrstream.c
+++ b/src/core/ddsc/tests/cdrstream.c
@@ -4025,6 +4025,76 @@ CU_Test (ddsc_cdrstream, check_xcdr1_mutable_zero_length_member_normalize)
   dds_cdrstream_desc_fini (&desc, &dds_cdrstream_default_allocator);
 }
 
+CU_Test (ddsc_cdrstream, check_mutable_required_members_normalize)
+{
+  const struct {
+    const char *name;
+    const dds_topic_descriptor_t *topic_desc;
+    enum dds_cdr_enc_version xcdr_version;
+    enum dds_stream_normalize_result result;
+    uint32_t cdrsize;
+    const uint8_t *cdr;
+  } tests[] = {
+    { "key-xcdr1-empty", &CdrStreamMutable_key_tail_desc, XCDR1, DDS_STREAM_NORMALIZE_ERROR, CDR(PHDR(DDS_XCDR1_PL_SHORT_PID_LIST_END, 0)) },
+    { "key-xcdr1-f1-only", &CdrStreamMutable_key_tail_desc, XCDR1, DDS_STREAM_NORMALIZE_ERROR, CDR(PHDR(1, 4), 32, 7, PHDR(DDS_XCDR1_PL_SHORT_PID_LIST_END, 0)) },
+    { "key-xcdr1-f2-present", &CdrStreamMutable_key_tail_desc, XCDR1, DDS_STREAM_NORMALIZE_SUCCESS, CDR(PHDR(2, 4), 32, 9, PHDR(DDS_XCDR1_PL_SHORT_PID_LIST_END, 0)) },
+    { "mu-xcdr1-empty", &CdrStreamMutable_mu_tail_desc, XCDR1, DDS_STREAM_NORMALIZE_ERROR, CDR(PHDR(DDS_XCDR1_PL_SHORT_PID_LIST_END, 0)) },
+    { "mu-xcdr1-f1-only", &CdrStreamMutable_mu_tail_desc, XCDR1, DDS_STREAM_NORMALIZE_ERROR, CDR(PHDR(1, 4), 32, 7, PHDR(DDS_XCDR1_PL_SHORT_PID_LIST_END, 0)) },
+    { "mu-xcdr1-f2-present", &CdrStreamMutable_mu_tail_desc, XCDR1, DDS_STREAM_NORMALIZE_SUCCESS, CDR(PHDR(2, 4), 32, 9, PHDR(DDS_XCDR1_PL_SHORT_PID_LIST_END, 0)) },
+    { "optional-mu-xcdr1-empty", &CdrStreamMutable_optional_mu_tail_desc, XCDR1, DDS_STREAM_NORMALIZE_SUCCESS, CDR(PHDR(DDS_XCDR1_PL_SHORT_PID_LIST_END, 0)) },
+    { "optional-mu-xcdr1-f1-only", &CdrStreamMutable_optional_mu_tail_desc, XCDR1, DDS_STREAM_NORMALIZE_SUCCESS, CDR(PHDR(1, 4), 32, 7, PHDR(DDS_XCDR1_PL_SHORT_PID_LIST_END, 0)) },
+
+    { "key-xcdr2-empty", &CdrStreamMutable_key_tail_desc, XCDR2, DDS_STREAM_NORMALIZE_ERROR, CDR(32, 0) },
+    { "key-xcdr2-f1-only", &CdrStreamMutable_key_tail_desc, XCDR2, DDS_STREAM_NORMALIZE_ERROR, CDR(DHDR(32, 0x20000001, 32, 7)) },
+    { "key-xcdr2-f2-present", &CdrStreamMutable_key_tail_desc, XCDR2, DDS_STREAM_NORMALIZE_SUCCESS, CDR(DHDR(32, 0x20000002, 32, 9)) },
+    { "mu-xcdr2-empty", &CdrStreamMutable_mu_tail_desc, XCDR2, DDS_STREAM_NORMALIZE_ERROR, CDR(32, 0) },
+    { "mu-xcdr2-f1-only", &CdrStreamMutable_mu_tail_desc, XCDR2, DDS_STREAM_NORMALIZE_ERROR, CDR(DHDR(32, 0x20000001, 32, 7)) },
+    { "mu-xcdr2-f2-present", &CdrStreamMutable_mu_tail_desc, XCDR2, DDS_STREAM_NORMALIZE_SUCCESS, CDR(DHDR(32, 0x20000002, 32, 9)) },
+    { "optional-mu-xcdr2-empty", &CdrStreamMutable_optional_mu_tail_desc, XCDR2, DDS_STREAM_NORMALIZE_SUCCESS, CDR(32, 0) },
+    { "optional-mu-xcdr2-f1-only", &CdrStreamMutable_optional_mu_tail_desc, XCDR2, DDS_STREAM_NORMALIZE_SUCCESS, CDR(DHDR(32, 0x20000001, 32, 7)) }
+  };
+
+  for (uint32_t i = 0; i < sizeof (tests) / sizeof (tests[0]); i++)
+  {
+    tprintf ("running test %s\n", tests[i].name);
+    struct dds_cdrstream_desc desc;
+    CU_ASSERT_EQ_FATAL (dds_cdrstream_desc_from_topic_desc (&desc, tests[i].topic_desc), DDS_RETCODE_OK);
+    uint32_t actual_size = 0;
+    void *cdr = ddsrt_memdup (tests[i].cdr, tests[i].cdrsize);
+    const enum dds_stream_normalize_result norm_res = dds_stream_normalize (cdr, tests[i].cdrsize, false, tests[i].xcdr_version, &desc, false, &actual_size);
+    CU_ASSERT_EQ_FATAL (norm_res, tests[i].result);
+    if (norm_res == DDS_STREAM_NORMALIZE_SUCCESS)
+      CU_ASSERT_EQ_FATAL (actual_size, tests[i].cdrsize);
+    ddsrt_free (cdr);
+    dds_cdrstream_desc_fini (&desc, &dds_cdrstream_default_allocator);
+  }
+}
+
+CU_Test (ddsc_cdrstream, check_mutable_member_limit_descriptor_init)
+{
+  const uint32_t nmembers = 513;
+  const uint32_t member_ops = 1 + 2 * nmembers + 1;
+  const uint32_t nops = member_ops + 3 * nmembers;
+  uint32_t *ops = ddsrt_calloc (nops, sizeof (*ops));
+  ops[0] = DDS_OP_PLC;
+  for (uint32_t n = 0; n < nmembers; n++)
+  {
+    const uint32_t plm_idx = 1 + 2 * n;
+    const uint32_t adr_idx = member_ops + 3 * n;
+    ops[plm_idx] = DDS_OP_PLM | (adr_idx - plm_idx);
+    ops[2 + 2 * n] = n;
+    ops[adr_idx] = DDS_OP_ADR | DDS_OP_TYPE_4BY;
+    ops[adr_idx + 1] = 0;
+    ops[adr_idx + 2] = DDS_OP_RTS;
+  }
+  ops[member_ops - 1] = DDS_OP_RTS;
+
+  struct dds_cdrstream_desc desc;
+  const dds_return_t ret = dds_cdrstream_desc_init_with_nops (&desc, &dds_cdrstream_default_allocator, 0, 1, 0, ops, nops, NULL, 0);
+  CU_ASSERT_EQ_FATAL (ret, DDS_RETCODE_BAD_PARAMETER);
+  ddsrt_free (ops);
+}
+
 
 CU_Test (ddsc_cdrstream, check_wstring_normalize)
 {
@@ -4067,7 +4137,7 @@ static void run_test_normalize (
     enum dds_cdr_enc_version xcdr_version, bool valid, uint32_t *act_size)
 {
   struct dds_cdrstream_desc desc;
-  dds_cdrstream_desc_from_topic_desc (&desc, tdesc);
+  CU_ASSERT_EQ_FATAL (dds_cdrstream_desc_from_topic_desc (&desc, tdesc), DDS_RETCODE_OK);
   assert (desc.ops.ops);
   uint8_t empty = 0;
   void *cdr_copy = cdrsize ? ddsrt_memdup (cdr, cdrsize) : &empty;

--- a/src/core/ddsc/tests/cdrstream.c
+++ b/src/core/ddsc/tests/cdrstream.c
@@ -4070,6 +4070,50 @@ CU_Test (ddsc_cdrstream, check_mutable_required_members_normalize)
   }
 }
 
+CU_Test (ddsc_cdrstream, check_mutable_prevent_type_widening_normalize)
+{
+  const struct {
+    const char *name;
+    const dds_topic_descriptor_t *topic_desc;
+    enum dds_cdr_enc_version xcdr_version;
+    enum dds_stream_normalize_result normal_result;
+    enum dds_stream_normalize_result strict_result;
+    uint32_t cdrsize;
+    const uint8_t *cdr;
+  } tests[] = {
+    { "xcdr1-empty", &CdrStreamMutable_t1_desc, XCDR1, DDS_STREAM_NORMALIZE_SUCCESS, DDS_STREAM_NORMALIZE_ERROR, CDR(PHDR(DDS_XCDR1_PL_SHORT_PID_LIST_END, 0)) },
+    { "xcdr1-f1-only", &CdrStreamMutable_t1_desc, XCDR1, DDS_STREAM_NORMALIZE_SUCCESS, DDS_STREAM_NORMALIZE_ERROR, CDR(PHDR(1, 4), 32, 7, PHDR(DDS_XCDR1_PL_SHORT_PID_LIST_END, 0)) },
+    { "xcdr1-complete", &CdrStreamMutable_t1_desc, XCDR1, DDS_STREAM_NORMALIZE_SUCCESS, DDS_STREAM_NORMALIZE_SUCCESS, CDR(PHDR(1, 4), 32, 7, PHDR(2, 4), 32, 0, PHDR(DDS_XCDR1_PL_SHORT_PID_LIST_END, 0)) },
+    { "xcdr1-optional-tail-missing", &CdrStreamMutable_optional_mu_tail_desc, XCDR1, DDS_STREAM_NORMALIZE_SUCCESS, DDS_STREAM_NORMALIZE_SUCCESS, CDR(PHDR(1, 4), 32, 7, PHDR(DDS_XCDR1_PL_SHORT_PID_LIST_END, 0)) },
+
+    { "xcdr2-empty", &CdrStreamMutable_t1_desc, XCDR2, DDS_STREAM_NORMALIZE_SUCCESS, DDS_STREAM_NORMALIZE_ERROR, CDR(32, 0) },
+    { "xcdr2-f1-only", &CdrStreamMutable_t1_desc, XCDR2, DDS_STREAM_NORMALIZE_SUCCESS, DDS_STREAM_NORMALIZE_ERROR, CDR(DHDR(32, 0x20000001, 32, 7)) },
+    { "xcdr2-complete", &CdrStreamMutable_t1_desc, XCDR2, DDS_STREAM_NORMALIZE_SUCCESS, DDS_STREAM_NORMALIZE_SUCCESS, CDR(DHDR(32, 0x20000001, 32, 7, 32, 0x60000002, 32, 0)) },
+    { "xcdr2-optional-tail-missing", &CdrStreamMutable_optional_mu_tail_desc, XCDR2, DDS_STREAM_NORMALIZE_SUCCESS, DDS_STREAM_NORMALIZE_SUCCESS, CDR(DHDR(32, 0x20000001, 32, 7)) }
+  };
+
+  for (uint32_t i = 0; i < sizeof (tests) / sizeof (tests[0]); i++)
+  {
+    tprintf ("running test %s\n", tests[i].name);
+    struct dds_cdrstream_desc desc;
+    CU_ASSERT_EQ_FATAL (dds_cdrstream_desc_from_topic_desc (&desc, tests[i].topic_desc), DDS_RETCODE_OK);
+
+    uint32_t actual_size = 0;
+    void *cdr = ddsrt_memdup (tests[i].cdr, tests[i].cdrsize);
+    enum dds_stream_normalize_result norm_res = dds_stream_normalize (cdr, tests[i].cdrsize, false, tests[i].xcdr_version, &desc, false, &actual_size);
+    CU_ASSERT_EQ_FATAL (norm_res, tests[i].normal_result);
+    ddsrt_free (cdr);
+
+    actual_size = 0;
+    cdr = ddsrt_memdup (tests[i].cdr, tests[i].cdrsize);
+    norm_res = dds_stream_normalize_with_flags (cdr, tests[i].cdrsize, false, tests[i].xcdr_version, &desc, false, DDS_STREAM_NORMALIZE_FLAG_PREVENT_TYPE_WIDENING, &actual_size);
+    CU_ASSERT_EQ_FATAL (norm_res, tests[i].strict_result);
+    ddsrt_free (cdr);
+
+    dds_cdrstream_desc_fini (&desc, &dds_cdrstream_default_allocator);
+  }
+}
+
 CU_Test (ddsc_cdrstream, check_mutable_member_limit_descriptor_init)
 {
   const uint32_t nmembers = 513;
@@ -4134,7 +4178,7 @@ CU_Test (ddsc_cdrstream, check_wstring_normalize)
 
 static void run_test_normalize (
     const dds_topic_descriptor_t *tdesc, const uint8_t *cdr, uint32_t cdrsize,
-    enum dds_cdr_enc_version xcdr_version, bool valid, uint32_t *act_size)
+    enum dds_cdr_enc_version xcdr_version, bool valid, uint32_t flags, uint32_t *act_size)
 {
   struct dds_cdrstream_desc desc;
   CU_ASSERT_EQ_FATAL (dds_cdrstream_desc_from_topic_desc (&desc, tdesc), DDS_RETCODE_OK);
@@ -4142,7 +4186,7 @@ static void run_test_normalize (
   uint8_t empty = 0;
   void *cdr_copy = cdrsize ? ddsrt_memdup (cdr, cdrsize) : &empty;
   const enum dds_stream_normalize_result norm_res =
-    dds_stream_normalize (cdr_copy, cdrsize, false, xcdr_version, &desc, false, act_size);
+    dds_stream_normalize_with_flags (cdr_copy, cdrsize, false, xcdr_version, &desc, false, flags, act_size);
   const bool res = norm_res == DDS_STREAM_NORMALIZE_SUCCESS;
   CU_ASSERT_EQ_FATAL (res, valid);
   if (cdrsize)
@@ -4152,12 +4196,12 @@ static void run_test_normalize (
 
 static void run_test_xcdr1_normalize (const dds_topic_descriptor_t *tdesc, const uint8_t *cdr, uint32_t cdrsize, bool valid, uint32_t *act_size)
 {
-  run_test_normalize (tdesc, cdr, cdrsize, DDSI_RTPS_CDR_ENC_VERSION_1, valid, act_size);
+  run_test_normalize (tdesc, cdr, cdrsize, DDSI_RTPS_CDR_ENC_VERSION_1, valid, DDS_STREAM_NORMALIZE_FLAG_NONE, act_size);
 }
 
 static void run_test_xcdr2_normalize (const dds_topic_descriptor_t *tdesc, const uint8_t *cdr, uint32_t cdrsize, bool valid, uint32_t *act_size)
 {
-  run_test_normalize (tdesc, cdr, cdrsize, DDSI_RTPS_CDR_ENC_VERSION_2, valid, act_size);
+  run_test_normalize (tdesc, cdr, cdrsize, DDSI_RTPS_CDR_ENC_VERSION_2, valid, DDS_STREAM_NORMALIZE_FLAG_NONE, act_size);
 }
 
 #define D(n) (&CdrStreamParamHeader_ ## n ## _desc)
@@ -4297,6 +4341,36 @@ CU_Test (ddsc_cdrstream, check_xcdr2_appendable_normalize)
     run_test_xcdr2_normalize (tests[i].desc, tests[i].cdr, tests[i].cdrsize, tests[i].normalize_valid, &act_size);
     if (tests[i].normalize_valid)
       CU_ASSERT_EQ_FATAL (tests[i].cdrsize, act_size);
+  }
+}
+#undef D
+
+#define D(n) (&CdrStreamAppendable_ ## n ## _desc)
+CU_Test (ddsc_cdrstream, check_appendable_prevent_type_widening_normalize)
+{
+  const struct {
+    const char *name;
+    const dds_topic_descriptor_t *desc;
+    enum dds_cdr_enc_version xcdr_version;
+    bool normal_valid;
+    bool strict_valid;
+    uint32_t cdrsize;
+    const uint8_t *cdr;
+  } tests[] = {
+    { "xcdr1-wide-missing-tail", D(wide), XCDR1, true, false, CDR(32,1) },
+    { "xcdr1-wide-complete", D(wide), XCDR1, true, true, CDR(32,1, 32,2) },
+    { "xcdr1-optional-missing", D(a2), XCDR1, true, false, CDR(32,1) },
+    { "xcdr1-optional-absent", D(a2), XCDR1, true, true, CDR(32,1, PHDR(1, 0)) },
+    { "xcdr2-wide-missing-tail", D(wide), XCDR2, true, false, CDR(DHDR(32,1)) },
+    { "xcdr2-wide-complete", D(wide), XCDR2, true, true, CDR(DHDR(32,1, 32,2)) }
+  };
+
+  for (uint32_t i = 0; i < sizeof (tests) / sizeof (tests[0]); i++)
+  {
+    uint32_t act_size;
+    tprintf ("running test %s for type %s\n", tests[i].name, tests[i].desc->m_typename);
+    run_test_normalize (tests[i].desc, tests[i].cdr, tests[i].cdrsize, tests[i].xcdr_version, tests[i].normal_valid, DDS_STREAM_NORMALIZE_FLAG_NONE, &act_size);
+    run_test_normalize (tests[i].desc, tests[i].cdr, tests[i].cdrsize, tests[i].xcdr_version, tests[i].strict_valid, DDS_STREAM_NORMALIZE_FLAG_PREVENT_TYPE_WIDENING, &act_size);
   }
 }
 #undef D

--- a/src/core/ddsc/tests/cdrstream.c
+++ b/src/core/ddsc/tests/cdrstream.c
@@ -4062,19 +4062,32 @@ CU_Test (ddsc_cdrstream, check_wstring_normalize)
   }
 }
 
-static void run_test_xcdr1_normalize (const dds_topic_descriptor_t *tdesc, const uint8_t *cdr, uint32_t cdrsize, bool valid, uint32_t *act_size)
+static void run_test_normalize (
+    const dds_topic_descriptor_t *tdesc, const uint8_t *cdr, uint32_t cdrsize,
+    enum dds_cdr_enc_version xcdr_version, bool valid, uint32_t *act_size)
 {
   struct dds_cdrstream_desc desc;
   dds_cdrstream_desc_from_topic_desc (&desc, tdesc);
   assert (desc.ops.ops);
-  dds_ostream_t os;
-  dds_ostream_init (&os, &dds_cdrstream_default_allocator, 0, DDSI_RTPS_CDR_ENC_VERSION_1);
-  void *cdr_copy = ddsrt_memdup (cdr, cdrsize);
-  const enum dds_stream_normalize_result norm_res = dds_stream_normalize (cdr_copy, cdrsize, false, DDSI_RTPS_CDR_ENC_VERSION_1, &desc, false, act_size);
+  uint8_t empty = 0;
+  void *cdr_copy = cdrsize ? ddsrt_memdup (cdr, cdrsize) : &empty;
+  const enum dds_stream_normalize_result norm_res =
+    dds_stream_normalize (cdr_copy, cdrsize, false, xcdr_version, &desc, false, act_size);
   const bool res = norm_res == DDS_STREAM_NORMALIZE_SUCCESS;
   CU_ASSERT_EQ_FATAL (res, valid);
-  ddsrt_free (cdr_copy);
+  if (cdrsize)
+    ddsrt_free (cdr_copy);
   dds_cdrstream_desc_fini (&desc, &dds_cdrstream_default_allocator);
+}
+
+static void run_test_xcdr1_normalize (const dds_topic_descriptor_t *tdesc, const uint8_t *cdr, uint32_t cdrsize, bool valid, uint32_t *act_size)
+{
+  run_test_normalize (tdesc, cdr, cdrsize, DDSI_RTPS_CDR_ENC_VERSION_1, valid, act_size);
+}
+
+static void run_test_xcdr2_normalize (const dds_topic_descriptor_t *tdesc, const uint8_t *cdr, uint32_t cdrsize, bool valid, uint32_t *act_size)
+{
+  run_test_normalize (tdesc, cdr, cdrsize, DDSI_RTPS_CDR_ENC_VERSION_2, valid, act_size);
 }
 
 #define D(n) (&CdrStreamParamHeader_ ## n ## _desc)
@@ -4127,6 +4140,7 @@ CU_Test (ddsc_cdrstream, check_xcdr1_param_normalize)
 #define D(n) (&CdrStreamAppendable_ ## n ## _desc)
 CU_Test (ddsc_cdrstream, check_xcdr1_appendable_normalize)
 {
+  static const uint8_t empty_cdr[] = { 0 };
   const struct {
     const dds_topic_descriptor_t *desc;
     bool normalize_valid;
@@ -4137,6 +4151,17 @@ CU_Test (ddsc_cdrstream, check_xcdr1_appendable_normalize)
     { D(a1), true, 0,  CDR(32,1, 32,2) },         // valid
     { D(a1), true, 0,  CDR(32,1, 32,2, 32,3) },   // valid, 1 extra member in CDR
     { D(a1), true, 0,  CDR(32,1) },               // valid, 1 member missing in CDR
+    { D(a1), false, 0, 0, empty_cdr },             // invalid, no members consumed
+    { D(a1_key), true, 0, CDR(32,1) },             // valid, keyed member present
+    { D(a1_key), false, 0, 0, empty_cdr },         // invalid, no keyed member consumed
+    { D(narrow), true, 0, CDR(32,1) },             // valid, narrow type
+    { D(wide), true, 0, CDR(32,1) },               // valid, narrow type widened to wide
+    { D(key_tail), false, 0, CDR(32,1) },           // invalid, key member missing in CDR
+    { D(key_tail), true, 0, CDR(32,1, 32,2) },      // valid, key member present
+    { D(mu_tail), false, 0, CDR(32,1) },            // invalid, non-optional must-understand member missing in CDR
+    { D(mu_tail), true, 0, CDR(32,1, 32,2) },       // valid, must-understand member present
+    { D(optional_mu_tail), false, 0, 0, empty_cdr }, // invalid, no members consumed
+    { D(optional_mu_tail), true, 0, CDR(32,1) },    // valid, optional must-understand member missing in CDR
 
     { D(f1), true,  0, CDR(32,1, 32,2) },         // valid
     { D(f1), true,  4, CDR(32,1, 32,2, 32,3) },   // too much data in CDR, normalize succeeds, but actual size differs from CDR size
@@ -4164,6 +4189,44 @@ CU_Test (ddsc_cdrstream, check_xcdr1_appendable_normalize)
     run_test_xcdr1_normalize (tests[i].desc, tests[i].cdr, tests[i].cdrsize, tests[i].normalize_valid, &act_size);
     if (tests[i].normalize_valid)
       CU_ASSERT_EQ_FATAL (tests[i].cdrsize, (uint32_t) ((int32_t) act_size + tests[i].dsize));
+  }
+}
+#undef D
+
+#define D(n) (&CdrStreamAppendable_ ## n ## _desc)
+CU_Test (ddsc_cdrstream, check_xcdr2_appendable_normalize)
+{
+  static const uint8_t empty_cdr[] = { 0 };
+  const struct {
+    const dds_topic_descriptor_t *desc;
+    bool normalize_valid;
+    uint32_t cdrsize;
+    const uint8_t *cdr;
+  } tests[] = {
+    { D(a1), false, 0, empty_cdr },                   // invalid, missing DHEADER
+    { D(a1), false, CDR(32,0) },                      // invalid, zero DHEADER and no members consumed
+    { D(a1_key), false, CDR(32,0) },                  // invalid, zero DHEADER and no keyed member consumed
+    { D(a1_key), true, CDR(DHDR(32,1)) },             // valid, keyed member present
+    { D(narrow), true, CDR(DHDR(32,1)) },             // valid, narrow type
+    { D(wide), true, CDR(DHDR(32,1)) },               // valid, narrow type widened to wide
+    { D(key_tail), false, CDR(DHDR(32,1)) },           // invalid, key member missing in CDR
+    { D(key_tail), true, CDR(DHDR(32,1, 32,2)) },      // valid, key member present
+    { D(mu_tail), false, CDR(DHDR(32,1)) },            // invalid, non-optional must-understand member missing in CDR
+    { D(mu_tail), true, CDR(DHDR(32,1, 32,2)) },       // valid, must-understand member present
+    { D(optional_mu_tail), false, CDR(32,0) },         // invalid, zero DHEADER and no members consumed
+    { D(optional_mu_tail), true, CDR(DHDR(32,1)) },    // valid, optional must-understand member missing in CDR
+    { D(a1), true, CDR(DHDR(32,1)) },                 // valid, 1 member missing in CDR
+    { D(a1), true, CDR(DHDR(32,1, 32,2)) },           // valid
+    { D(a1), true, CDR(DHDR(32,1, 32,2, 32,3)) }      // valid, 1 extra member in CDR
+  };
+
+  for (uint32_t i = 0; i < sizeof (tests) / sizeof (tests[0]); i++)
+  {
+    uint32_t act_size;
+    tprintf("running test %"PRIu32" for type %s\n", i, tests[i].desc->m_typename);
+    run_test_xcdr2_normalize (tests[i].desc, tests[i].cdr, tests[i].cdrsize, tests[i].normalize_valid, &act_size);
+    if (tests[i].normalize_valid)
+      CU_ASSERT_EQ_FATAL (tests[i].cdrsize, act_size);
   }
 }
 #undef D

--- a/src/core/ddsi/src/ddsi_sertype_cdr.c
+++ b/src/core/ddsi/src/ddsi_sertype_cdr.c
@@ -151,11 +151,12 @@ dds_return_t ddsi_sertype_cdr_init (const struct ddsi_domaingv *gv, struct ddsi_
   if (!dds_stream_extensibility (desc->m_ops, &type_ext))
     return DDS_RETCODE_BAD_PARAMETER;
 
+  dds_return_t ret = dds_cdrstream_desc_init_with_nops (&st->type, &dds_cdrstream_default_allocator, desc->m_size, desc->m_align, desc->m_flagset, desc->m_ops, desc->m_nops, desc->m_keys, desc->m_nkeys);
+  if (ret != DDS_RETCODE_OK)
+    return ret;
+
   ddsi_sertype_init_props (&st->c, desc->m_typename, &ddsi_sertype_ops_cdr, &ddsi_serdata_ops_cdr, desc->m_size, dds_stream_data_types (desc->m_ops), DDS_DATA_REPRESENTATION_FLAG_XCDR2, 0);
-
   st->encoding_format = ddsi_sertype_extensibility_enc_format (type_ext);
-
-  dds_cdrstream_desc_init_with_nops (&st->type, &dds_cdrstream_default_allocator, desc->m_size, desc->m_align, desc->m_flagset, desc->m_ops, desc->m_nops, desc->m_keys, desc->m_nkeys);
 
   st->type.opt_size_xcdr2 = dds_stream_check_optimize (&st->type, DDSI_RTPS_CDR_ENC_VERSION_2);
   if (st->type.opt_size_xcdr2 > 0)

--- a/src/core/ddsi/src/ddsi_typebuilder.c
+++ b/src/core/ddsi/src/ddsi_typebuilder.c
@@ -273,6 +273,7 @@ DDSI_LIST_CODE_TMPL(static, typebuilder_dep_types, struct typebuilder_aggregated
 static dds_return_t typebuilder_add_aggrtype (struct typebuilder_data *tbd, struct typebuilder_aggregated_type *tb_aggrtype, const struct ddsi_type *type);
 static dds_return_t typebuilder_add_type (struct typebuilder_data *tbd, uint32_t *size, uint32_t *align, struct typebuilder_type *tb_type, const struct ddsi_type *type, bool is_ext, bool use_ext_type, enum typebuilder_try_construct tc);
 static dds_return_t resolve_ops_offsets_aggrtype (const struct typebuilder_aggregated_type *tb_aggrtype, struct typebuilder_ops *ops, struct visited_aggrtype *visited_aggrtypes);
+static dds_return_t typebuilder_set_dlc_required_prefixes (struct typebuilder_data *tbd, struct typebuilder_ops *ops);
 static dds_return_t get_keys_aggrtype (struct typebuilder_data *tbd, struct typebuilder_key_path *path, const struct typebuilder_aggregated_type *tb_aggrtype, bool parent_key);
 static void set_implicit_keys_aggrtype (struct typebuilder_aggregated_type *tb_aggrtype, bool is_toplevel, bool parent_is_key, struct visited_implicit_keys *visited_implicit_keys);
 
@@ -1667,6 +1668,152 @@ static dds_return_t typebuilder_resolve_ops_offsets (const struct typebuilder_da
   return resolve_ops_offsets_aggrtype (&tbd->toplevel_type, ops, NULL);
 }
 
+static uint32_t typebuilder_skip_sequence_insns (const uint32_t *ops)
+{
+  const uint32_t bound_op = DDS_OP_TYPE (*ops) == DDS_SOP_VAL_BSQ ? 1 : 0;
+  switch (DDS_OP_SUBTYPE (*ops))
+  {
+    case DDS_SOP_VAL_BLN: case DDS_SOP_VAL_1BY: case DDS_SOP_VAL_2BY: case DDS_SOP_VAL_4BY: case DDS_SOP_VAL_8BY:
+    case DDS_SOP_VAL_STR: case DDS_SOP_VAL_WSTR: case DDS_SOP_VAL_WCHAR: case DDS_SOP_VAL_16BY:
+      return 2 + bound_op;
+    case DDS_SOP_VAL_BST: case DDS_SOP_VAL_BWSTR: case DDS_SOP_VAL_ENU:
+      return 3 + bound_op;
+    case DDS_SOP_VAL_BMK:
+      return 4 + bound_op;
+    case DDS_SOP_VAL_SEQ: case DDS_SOP_VAL_BSQ: case DDS_SOP_VAL_ARR: case DDS_SOP_VAL_UNI: case DDS_SOP_VAL_STU: {
+      const uint32_t jmp = DDS_OP_ADR_JMP (ops[3 + bound_op]);
+      return jmp ? jmp : 4 + bound_op;
+    }
+    case DDS_SOP_VAL_EXT:
+      abort ();
+      break;
+  }
+  return 0;
+}
+
+static uint32_t typebuilder_skip_array_insns (const uint32_t *ops)
+{
+  assert (DDS_OP_TYPE (*ops) == DDS_SOP_VAL_ARR);
+  switch (DDS_OP_SUBTYPE (*ops))
+  {
+    case DDS_SOP_VAL_BLN: case DDS_SOP_VAL_1BY: case DDS_SOP_VAL_2BY: case DDS_SOP_VAL_4BY: case DDS_SOP_VAL_8BY:
+    case DDS_SOP_VAL_STR: case DDS_SOP_VAL_WSTR: case DDS_SOP_VAL_WCHAR: case DDS_SOP_VAL_16BY:
+      return 3;
+    case DDS_SOP_VAL_ENU:
+      return 4;
+    case DDS_SOP_VAL_BST: case DDS_SOP_VAL_BWSTR: case DDS_SOP_VAL_BMK:
+      return 5;
+    case DDS_SOP_VAL_SEQ: case DDS_SOP_VAL_BSQ: case DDS_SOP_VAL_ARR: case DDS_SOP_VAL_UNI: case DDS_SOP_VAL_STU: {
+      const uint32_t jmp = DDS_OP_ADR_JMP (ops[3]);
+      return jmp ? jmp : 5;
+    }
+    case DDS_SOP_VAL_EXT:
+      abort ();
+      break;
+  }
+  return 0;
+}
+
+static uint32_t typebuilder_skip_adr_insns (const uint32_t *ops)
+{
+  assert (DDS_OP (ops[0]) == DDS_OP_ADR);
+  switch (DDS_OP_TYPE (ops[0]))
+  {
+    case DDS_SOP_VAL_BLN: case DDS_SOP_VAL_1BY: case DDS_SOP_VAL_2BY: case DDS_SOP_VAL_4BY: case DDS_SOP_VAL_8BY:
+    case DDS_SOP_VAL_STR: case DDS_SOP_VAL_WSTR: case DDS_SOP_VAL_WCHAR: case DDS_SOP_VAL_16BY:
+      return 2;
+    case DDS_SOP_VAL_BST:
+    case DDS_SOP_VAL_BWSTR:
+    case DDS_SOP_VAL_ENU:
+      return 3;
+    case DDS_SOP_VAL_BMK:
+      return 4;
+    case DDS_SOP_VAL_SEQ:
+    case DDS_SOP_VAL_BSQ:
+      return typebuilder_skip_sequence_insns (ops);
+    case DDS_SOP_VAL_ARR:
+      return typebuilder_skip_array_insns (ops);
+    case DDS_SOP_VAL_UNI: {
+      const uint32_t jmp = DDS_OP_ADR_JMP (ops[3]);
+      return jmp ? jmp : 4;
+    }
+    case DDS_SOP_VAL_EXT: {
+      const uint32_t jmp = DDS_OP_ADR_JMP (ops[2]);
+      return jmp ? jmp : 3;
+    }
+    case DDS_SOP_VAL_STU:
+      abort ();
+      break;
+  }
+  return 0;
+}
+
+static dds_return_t typebuilder_set_dlc_required_prefix_aggrtype (struct typebuilder_aggregated_type *tb_aggrtype, struct typebuilder_ops *ops)
+{
+  dds_return_t ret;
+  if (tb_aggrtype->extensibility != DDS_XTypes_IS_APPENDABLE)
+    return DDS_RETCODE_OK;
+
+  const uint32_t parent_insn_offs = tb_aggrtype->insn_offs;
+  assert (DDS_OP (ops->ops[parent_insn_offs]) == DDS_OP_DLC);
+
+  uint32_t required_prefix = 0;
+  bool seen_member = false;
+  switch (tb_aggrtype->kind)
+  {
+    case DDS_XTypes_TK_STRUCTURE: {
+      const struct typebuilder_struct *tb_struct = &tb_aggrtype->detail._struct;
+      if (tb_aggrtype->base_type)
+      {
+        struct typebuilder_aggregated_type *base_aggrtype = tb_aggrtype->base_type->args.external_type_args.external_type.type;
+        assert (base_aggrtype);
+        if ((ret = typebuilder_set_dlc_required_prefix_aggrtype (base_aggrtype, ops)) != DDS_RETCODE_OK)
+          return ret;
+        const uint32_t adr_insn_offs = parent_insn_offs + 1;
+        required_prefix = adr_insn_offs + typebuilder_skip_adr_insns (&ops->ops[adr_insn_offs]) - parent_insn_offs;
+        seen_member = true;
+      }
+      for (uint32_t m = 0; m < tb_struct->n_members; m++)
+      {
+        const struct typebuilder_struct_member *mem = &tb_struct->members[m];
+        const uint32_t adr_insn_offs = parent_insn_offs + mem->insn_offs;
+        const uint32_t next_insn_offs = adr_insn_offs + typebuilder_skip_adr_insns (&ops->ops[adr_insn_offs]);
+        if (!seen_member || mem->is_key || (mem->is_must_understand && !mem->is_optional))
+          required_prefix = next_insn_offs - parent_insn_offs;
+        seen_member = true;
+      }
+      break;
+    }
+    case DDS_XTypes_TK_UNION: {
+      const struct typebuilder_union *tb_union = &tb_aggrtype->detail._union;
+      const uint32_t adr_insn_offs = parent_insn_offs + tb_union->disc_insn_offs;
+      required_prefix = adr_insn_offs + typebuilder_skip_adr_insns (&ops->ops[adr_insn_offs]) - parent_insn_offs;
+      break;
+    }
+    default:
+      abort ();
+  }
+
+  assert (required_prefix <= UINT16_MAX);
+  if (required_prefix > UINT16_MAX)
+    return DDS_RETCODE_BAD_PARAMETER;
+  ops->ops[parent_insn_offs] = DDS_OP_DLC | required_prefix;
+  return DDS_RETCODE_OK;
+}
+
+static dds_return_t typebuilder_set_dlc_required_prefixes (struct typebuilder_data *tbd, struct typebuilder_ops *ops)
+{
+  dds_return_t ret;
+  if ((ret = typebuilder_set_dlc_required_prefix_aggrtype (&tbd->toplevel_type, ops)) != DDS_RETCODE_OK)
+    return ret;
+
+  struct typebuilder_dep_types_iter it;
+  for (struct typebuilder_aggregated_type *tb_aggrtype = typebuilder_dep_types_iter_first (&tbd->dep_types, &it); tb_aggrtype; tb_aggrtype = typebuilder_dep_types_iter_next (&it))
+    if ((ret = typebuilder_set_dlc_required_prefix_aggrtype (tb_aggrtype, ops)) != DDS_RETCODE_OK)
+      return ret;
+  return DDS_RETCODE_OK;
+}
+
 static void path_free (struct typebuilder_key_path *path)
 {
   ddsrt_free (path->parts);
@@ -2298,7 +2445,8 @@ static dds_return_t get_topic_descriptor (dds_topic_descriptor_t *desc, struct t
     goto err;
 
   if ((ret = typebuilder_get_ops (tbd, &ops)) != DDS_RETCODE_OK
-      || (ret = typebuilder_resolve_ops_offsets (tbd, &ops)) != DDS_RETCODE_OK)
+      || (ret = typebuilder_resolve_ops_offsets (tbd, &ops)) != DDS_RETCODE_OK
+      || (ret = typebuilder_set_dlc_required_prefixes (tbd, &ops)) != DDS_RETCODE_OK)
     goto err;
 
   struct dds_key_descriptor *key_desc = NULL;

--- a/src/core/ddsi/src/ddsi_xt_typeinfo.c
+++ b/src/core/ddsi/src/ddsi_xt_typeinfo.c
@@ -87,7 +87,7 @@ static const uint32_t DDS_XTypes_TypeIdentifier_ops [] =
   DDS_OP_RTS,
 
   /* StronglyConnectedComponentId */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_StronglyConnectedComponentId, sc_component_id), (3u << 16u) + 8u /* TypeObjectHashId */,
   DDS_OP_ADR | DDS_OP_TYPE_4BY | DDS_OP_FLAG_SGN, offsetof (DDS_XTypes_StronglyConnectedComponentId, scc_length),
   DDS_OP_ADR | DDS_OP_TYPE_4BY | DDS_OP_FLAG_SGN, offsetof (DDS_XTypes_StronglyConnectedComponentId, scc_index),
@@ -142,7 +142,7 @@ __pragma(warning(disable: 5287))
 static const uint32_t DDS_XTypes_TypeObject_ops [] =
 {
   /* TypeObject */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 13,
   DDS_OP_ADR | DDS_OP_FLAG_MU | DDS_OP_TYPE_UNI | DDS_OP_SUBTYPE_1BY, offsetof (DDS_XTypes_TypeObject, _d), 2u, (12u << 16u) + 4u,
   DDS_OP_JEQ4 | DDS_OP_TYPE_UNI | 9 /* CompleteTypeObject */, 242, offsetof (DDS_XTypes_TypeObject, _u.complete), 0u,
   DDS_OP_JEQ4 | DDS_OP_TYPE_UNI | 738 /* MinimalTypeObject */, 241, offsetof (DDS_XTypes_TypeObject, _u.minimal), 0u,
@@ -170,7 +170,7 @@ static const uint32_t DDS_XTypes_TypeObject_ops [] =
   DDS_OP_RTS,
 
   /* CompleteAliasHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteAliasHeader, detail), (3u << 16u) + 4u /* CompleteTypeDetail */,
   DDS_OP_RTS,
 
@@ -181,7 +181,7 @@ static const uint32_t DDS_XTypes_TypeObject_ops [] =
   DDS_OP_RTS,
 
   /* AppliedBuiltinTypeAnnotations */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 5,
   DDS_OP_ADR | DDS_OP_FLAG_OPT | DDS_OP_FLAG_EXT | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_AppliedBuiltinTypeAnnotations, verbatim), (4u << 16u) + 5u /* AppliedVerbatimAnnotation */, sizeof (DDS_XTypes_AppliedVerbatimAnnotation),
   DDS_OP_RTS,
 
@@ -192,7 +192,7 @@ static const uint32_t DDS_XTypes_TypeObject_ops [] =
   DDS_OP_RTS,
 
   /* AppliedAnnotation */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_AppliedAnnotation, annotation_typeid), (3u << 16u) + 8u /* TypeIdentifier */,
   DDS_OP_ADR | DDS_OP_FLAG_OPT | DDS_OP_FLAG_EXT | DDS_OP_TYPE_SEQ | DDS_OP_SUBTYPE_STU, offsetof (DDS_XTypes_AppliedAnnotation, param_seq), sizeof (DDS_XTypes_AppliedAnnotationParameter), (4u << 16u) + 181u /* AppliedAnnotationParameter */,
   DDS_OP_RTS,
@@ -270,7 +270,7 @@ static const uint32_t DDS_XTypes_TypeObject_ops [] =
   DDS_OP_RTS,
 
   /* StronglyConnectedComponentId */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_StronglyConnectedComponentId, sc_component_id), (3u << 16u) + 8u /* TypeObjectHashId */,
   DDS_OP_ADR | DDS_OP_TYPE_4BY | DDS_OP_FLAG_SGN, offsetof (DDS_XTypes_StronglyConnectedComponentId, scc_length),
   DDS_OP_ADR | DDS_OP_TYPE_4BY | DDS_OP_FLAG_SGN, offsetof (DDS_XTypes_StronglyConnectedComponentId, scc_index),
@@ -285,7 +285,7 @@ static const uint32_t DDS_XTypes_TypeObject_ops [] =
   DDS_OP_RTS,
 
   /* AppliedAnnotationParameter */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_ARR | DDS_OP_SUBTYPE_1BY, offsetof (DDS_XTypes_AppliedAnnotationParameter, paramname_hash), 4u,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_AppliedAnnotationParameter, value), (3u << 16u) + 4u /* AnnotationParameterValue */,
   DDS_OP_RTS,
@@ -317,7 +317,7 @@ static const uint32_t DDS_XTypes_TypeObject_ops [] =
   DDS_OP_RTS,
 
   /* CompleteAliasBody */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteAliasBody, common), (3u << 16u) + 12u /* CommonAliasBody */,
   DDS_OP_ADR | DDS_OP_FLAG_OPT | DDS_OP_FLAG_EXT | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteAliasBody, ann_builtin), (4u << 16u) + 17u /* AppliedBuiltinMemberAnnotations */, sizeof (DDS_XTypes_AppliedBuiltinMemberAnnotations),
   DDS_OP_ADR | DDS_OP_FLAG_OPT | DDS_OP_FLAG_EXT | DDS_OP_TYPE_SEQ | DDS_OP_SUBTYPE_STU, offsetof (DDS_XTypes_CompleteAliasBody, ann_custom), sizeof (DDS_XTypes_AppliedAnnotation), (4u << 16u) + 65260u /* AppliedAnnotation */,
@@ -329,7 +329,7 @@ static const uint32_t DDS_XTypes_TypeObject_ops [] =
   DDS_OP_RTS,
 
   /* AppliedBuiltinMemberAnnotations */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 3,
   DDS_OP_ADR | DDS_OP_FLAG_OPT | DDS_OP_TYPE_STR, offsetof (DDS_XTypes_AppliedBuiltinMemberAnnotations, unit),
   DDS_OP_ADR | DDS_OP_FLAG_OPT | DDS_OP_FLAG_EXT | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_AppliedBuiltinMemberAnnotations, min), (4u << 16u) + 65437u /* AnnotationParameterValue */, sizeof (DDS_XTypes_AnnotationParameterValue),
   DDS_OP_ADR | DDS_OP_FLAG_OPT | DDS_OP_FLAG_EXT | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_AppliedBuiltinMemberAnnotations, max), (4u << 16u) + 65433u /* AnnotationParameterValue */, sizeof (DDS_XTypes_AnnotationParameterValue),
@@ -343,12 +343,12 @@ static const uint32_t DDS_XTypes_TypeObject_ops [] =
   DDS_OP_RTS,
 
   /* CompleteAnnotationHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_BST, offsetof (DDS_XTypes_CompleteAnnotationHeader, annotation_name), 257u,
   DDS_OP_RTS,
 
   /* CompleteAnnotationParameter */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteAnnotationParameter, common), (3u << 16u) + 10u /* CommonAnnotationParameter */,
   DDS_OP_ADR | DDS_OP_TYPE_BST, offsetof (DDS_XTypes_CompleteAnnotationParameter, name), 257u,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteAnnotationParameter, default_value), (3u << 16u) + 65402u /* AnnotationParameterValue */,
@@ -366,13 +366,13 @@ static const uint32_t DDS_XTypes_TypeObject_ops [] =
   DDS_OP_RTS,
 
   /* CompleteStructHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteStructHeader, base_type), (3u << 16u) + 65193u /* TypeIdentifier */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteStructHeader, detail), (3u << 16u) + 65154u /* CompleteTypeDetail */,
   DDS_OP_RTS,
 
   /* CompleteStructMember */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteStructMember, common), (3u << 16u) + 7u /* CommonStructMember */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteStructMember, detail), (3u << 16u) + 14u /* CompleteMemberDetail */,
   DDS_OP_RTS,
@@ -397,12 +397,12 @@ static const uint32_t DDS_XTypes_TypeObject_ops [] =
   DDS_OP_RTS,
 
   /* CompleteUnionHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteUnionHeader, detail), (3u << 16u) + 65104u /* CompleteTypeDetail */,
   DDS_OP_RTS,
 
   /* CompleteDiscriminatorMember */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteDiscriminatorMember, common), (3u << 16u) + 12u /* CommonDiscriminatorMember */,
   DDS_OP_ADR | DDS_OP_FLAG_OPT | DDS_OP_FLAG_EXT | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteDiscriminatorMember, ann_builtin), (4u << 16u) + 65108u /* AppliedBuiltinTypeAnnotations */, sizeof (DDS_XTypes_AppliedBuiltinTypeAnnotations),
   DDS_OP_ADR | DDS_OP_FLAG_OPT | DDS_OP_FLAG_EXT | DDS_OP_TYPE_SEQ | DDS_OP_SUBTYPE_STU, offsetof (DDS_XTypes_CompleteDiscriminatorMember, ann_custom), sizeof (DDS_XTypes_AppliedAnnotation), (4u << 16u) + 65119u /* AppliedAnnotation */,
@@ -414,7 +414,7 @@ static const uint32_t DDS_XTypes_TypeObject_ops [] =
   DDS_OP_RTS,
 
   /* CompleteUnionMember */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteUnionMember, common), (3u << 16u) + 7u /* CommonUnionMember */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteUnionMember, detail), (3u << 16u) + 65479u /* CompleteMemberDetail */,
   DDS_OP_RTS,
@@ -427,19 +427,19 @@ static const uint32_t DDS_XTypes_TypeObject_ops [] =
   DDS_OP_RTS,
 
   /* CompleteBitsetType */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 5,
   DDS_OP_ADR | DDS_OP_TYPE_BMK | (1 << DDS_OP_FLAG_SZ_SHIFT), offsetof (DDS_XTypes_CompleteBitsetType, bitset_flags), 0u, 31u,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteBitsetType, header), (3u << 16u) + 8u /* CompleteBitsetHeader */,
   DDS_OP_ADR | DDS_OP_TYPE_SEQ | DDS_OP_SUBTYPE_STU, offsetof (DDS_XTypes_CompleteBitsetType, field_seq), sizeof (DDS_XTypes_CompleteBitfield), (4u << 16u) + 10u /* CompleteBitfield */,
   DDS_OP_RTS,
 
   /* CompleteBitsetHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteBitsetHeader, detail), (3u << 16u) + 65045u /* CompleteTypeDetail */,
   DDS_OP_RTS,
 
   /* CompleteBitfield */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteBitfield, common), (3u << 16u) + 7u /* CommonBitfield */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteBitfield, detail), (3u << 16u) + 65441u /* CompleteMemberDetail */,
   DDS_OP_RTS,
@@ -458,7 +458,7 @@ static const uint32_t DDS_XTypes_TypeObject_ops [] =
   DDS_OP_RTS,
 
   /* CompleteCollectionHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteCollectionHeader, common), (3u << 16u) + 8u /* CommonCollectionHeader */,
   DDS_OP_ADR | DDS_OP_FLAG_OPT | DDS_OP_FLAG_EXT | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteCollectionHeader, detail), (4u << 16u) + 65007u /* CompleteTypeDetail */, sizeof (DDS_XTypes_CompleteTypeDetail),
   DDS_OP_RTS,
@@ -468,7 +468,7 @@ static const uint32_t DDS_XTypes_TypeObject_ops [] =
   DDS_OP_RTS,
 
   /* CompleteCollectionElement */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteCollectionElement, common), (3u << 16u) + 7u /* CommonCollectionElement */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteCollectionElement, detail), (3u << 16u) + 12u /* CompleteElementDetail */,
   DDS_OP_RTS,
@@ -484,14 +484,14 @@ static const uint32_t DDS_XTypes_TypeObject_ops [] =
   DDS_OP_RTS,
 
   /* CompleteArrayType */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 5,
   DDS_OP_ADR | DDS_OP_TYPE_BMK | (1 << DDS_OP_FLAG_SZ_SHIFT), offsetof (DDS_XTypes_CompleteArrayType, collection_flag), 0u, 31u,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteArrayType, header), (3u << 16u) + 7u /* CompleteArrayHeader */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteArrayType, element), (3u << 16u) + 65503u /* CompleteCollectionElement */,
   DDS_OP_RTS,
 
   /* CompleteArrayHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteArrayHeader, common), (3u << 16u) + 7u /* CommonArrayHeader */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteArrayHeader, detail), (3u << 16u) + 64958u /* CompleteTypeDetail */,
   DDS_OP_RTS,
@@ -514,7 +514,7 @@ static const uint32_t DDS_XTypes_TypeObject_ops [] =
   DDS_OP_RTS,
 
   /* CompleteEnumeratedHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteEnumeratedHeader, common), (3u << 16u) + 7u /* CommonEnumeratedHeader */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteEnumeratedHeader, detail), (3u << 16u) + 64921u /* CompleteTypeDetail */,
   DDS_OP_RTS,
@@ -524,26 +524,26 @@ static const uint32_t DDS_XTypes_TypeObject_ops [] =
   DDS_OP_RTS,
 
   /* CompleteEnumeratedLiteral */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteEnumeratedLiteral, common), (3u << 16u) + 7u /* CommonEnumeratedLiteral */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteEnumeratedLiteral, detail), (3u << 16u) + 65314u /* CompleteMemberDetail */,
   DDS_OP_RTS,
 
   /* CommonEnumeratedLiteral */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 3,
   DDS_OP_ADR | DDS_OP_TYPE_4BY | DDS_OP_FLAG_SGN, offsetof (DDS_XTypes_CommonEnumeratedLiteral, value),
   DDS_OP_ADR | DDS_OP_TYPE_BMK | (1 << DDS_OP_FLAG_SZ_SHIFT), offsetof (DDS_XTypes_CommonEnumeratedLiteral, flags), 0u, 127u,
   DDS_OP_RTS,
 
   /* CompleteBitmaskType */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 5,
   DDS_OP_ADR | DDS_OP_TYPE_BMK | (1 << DDS_OP_FLAG_SZ_SHIFT), offsetof (DDS_XTypes_CompleteBitmaskType, bitmask_flags), 0u, 31u,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteBitmaskType, header), (3u << 16u) + 65504u /* CompleteEnumeratedHeader */,
   DDS_OP_ADR | DDS_OP_TYPE_SEQ | DDS_OP_SUBTYPE_STU, offsetof (DDS_XTypes_CompleteBitmaskType, flag_seq), sizeof (DDS_XTypes_CompleteBitflag), (4u << 16u) + 5u /* CompleteBitflag */,
   DDS_OP_RTS,
 
   /* CompleteBitflag */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteBitflag, common), (3u << 16u) + 7u /* CommonBitflag */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteBitflag, detail), (3u << 16u) + 65285u /* CompleteMemberDetail */,
   DDS_OP_RTS,
@@ -583,7 +583,7 @@ static const uint32_t DDS_XTypes_TypeObject_ops [] =
   DDS_OP_RTS,
 
   /* MinimalAliasBody */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalAliasBody, common), (3u << 16u) + 65113u /* CommonAliasBody */,
   DDS_OP_RTS,
 
@@ -598,7 +598,7 @@ static const uint32_t DDS_XTypes_TypeObject_ops [] =
   DDS_OP_RTS,
 
   /* MinimalAnnotationParameter */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalAnnotationParameter, common), (3u << 16u) + 65144u /* CommonAnnotationParameter */,
   DDS_OP_ADR | DDS_OP_TYPE_ARR | DDS_OP_SUBTYPE_1BY, offsetof (DDS_XTypes_MinimalAnnotationParameter, name_hash), 4u,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalAnnotationParameter, default_value), (3u << 16u) + 65000u /* AnnotationParameterValue */,
@@ -611,7 +611,7 @@ static const uint32_t DDS_XTypes_TypeObject_ops [] =
   DDS_OP_RTS,
 
   /* MinimalStructHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalStructHeader, base_type), (3u << 16u) + 64799u /* TypeIdentifier */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, 0u, (3u << 16u) + 4u /* MinimalTypeDetail */,
   DDS_OP_RTS,
@@ -620,7 +620,7 @@ static const uint32_t DDS_XTypes_TypeObject_ops [] =
   DDS_OP_RTS,
 
   /* MinimalStructMember */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalStructMember, common), (3u << 16u) + 65148u /* CommonStructMember */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalStructMember, detail), (3u << 16u) + 4u /* MinimalMemberDetail */,
   DDS_OP_RTS,
@@ -637,23 +637,23 @@ static const uint32_t DDS_XTypes_TypeObject_ops [] =
   DDS_OP_RTS,
 
   /* MinimalUnionHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, 0u, (3u << 16u) + 65507u /* MinimalTypeDetail */,
   DDS_OP_RTS,
 
   /* MinimalDiscriminatorMember */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalDiscriminatorMember, common), (3u << 16u) + 65171u /* CommonDiscriminatorMember */,
   DDS_OP_RTS,
 
   /* MinimalUnionMember */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalUnionMember, common), (3u << 16u) + 65182u /* CommonUnionMember */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalUnionMember, detail), (3u << 16u) + 65503u /* MinimalMemberDetail */,
   DDS_OP_RTS,
 
   /* MinimalBitsetType */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 5,
   DDS_OP_ADR | DDS_OP_TYPE_BMK | (1 << DDS_OP_FLAG_SZ_SHIFT), offsetof (DDS_XTypes_MinimalBitsetType, bitset_flags), 0u, 31u,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, 0u, (3u << 16u) + 8u /* MinimalBitsetHeader */,
   DDS_OP_ADR | DDS_OP_TYPE_SEQ | DDS_OP_SUBTYPE_STU, offsetof (DDS_XTypes_MinimalBitsetType, field_seq), sizeof (DDS_XTypes_MinimalBitfield), (4u << 16u) + 7u /* MinimalBitfield */,
@@ -664,7 +664,7 @@ static const uint32_t DDS_XTypes_TypeObject_ops [] =
   DDS_OP_RTS,
 
   /* MinimalBitfield */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalBitfield, common), (3u << 16u) + 65197u /* CommonBitfield */,
   DDS_OP_ADR | DDS_OP_TYPE_ARR | DDS_OP_SUBTYPE_1BY, offsetof (DDS_XTypes_MinimalBitfield, name_hash), 4u,
   DDS_OP_RTS,
@@ -676,12 +676,12 @@ static const uint32_t DDS_XTypes_TypeObject_ops [] =
   DDS_OP_RTS,
 
   /* MinimalCollectionHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalCollectionHeader, common), (3u << 16u) + 65209u /* CommonCollectionHeader */,
   DDS_OP_RTS,
 
   /* MinimalCollectionElement */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalCollectionElement, common), (3u << 16u) + 65215u /* CommonCollectionElement */,
   DDS_OP_RTS,
 
@@ -692,7 +692,7 @@ static const uint32_t DDS_XTypes_TypeObject_ops [] =
   DDS_OP_RTS,
 
   /* MinimalArrayHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalArrayHeader, common), (3u << 16u) + 65236u /* CommonArrayHeader */,
   DDS_OP_RTS,
 
@@ -710,25 +710,25 @@ static const uint32_t DDS_XTypes_TypeObject_ops [] =
   DDS_OP_RTS,
 
   /* MinimalEnumeratedHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalEnumeratedHeader, common), (3u << 16u) + 65242u /* CommonEnumeratedHeader */,
   DDS_OP_RTS,
 
   /* MinimalEnumeratedLiteral */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalEnumeratedLiteral, common), (3u << 16u) + 65248u /* CommonEnumeratedLiteral */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalEnumeratedLiteral, detail), (3u << 16u) + 65404u /* MinimalMemberDetail */,
   DDS_OP_RTS,
 
   /* MinimalBitmaskType */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 5,
   DDS_OP_ADR | DDS_OP_TYPE_BMK | (1 << DDS_OP_FLAG_SZ_SHIFT), offsetof (DDS_XTypes_MinimalBitmaskType, bitmask_flags), 0u, 31u,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalBitmaskType, header), (3u << 16u) + 65518u /* MinimalEnumeratedHeader */,
   DDS_OP_ADR | DDS_OP_TYPE_SEQ | DDS_OP_SUBTYPE_STU, offsetof (DDS_XTypes_MinimalBitmaskType, flag_seq), sizeof (DDS_XTypes_MinimalBitflag), (4u << 16u) + 5u /* MinimalBitflag */,
   DDS_OP_RTS,
 
   /* MinimalBitflag */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalBitflag, common), (3u << 16u) + 65256u /* CommonBitflag */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalBitflag, detail), (3u << 16u) + 65383u /* MinimalMemberDetail */,
   DDS_OP_RTS,
@@ -808,14 +808,14 @@ static const uint32_t DDS_XTypes_TypeInformation_ops [] =
   DDS_OP_RTS,
 
   /* TypeIdentifierWithDependencies */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_TypeIdentifierWithDependencies, typeid_with_size), (3u << 16u) + 10u /* TypeIdentifierWithSize */,
   DDS_OP_ADR | DDS_OP_TYPE_4BY | DDS_OP_FLAG_SGN, offsetof (DDS_XTypes_TypeIdentifierWithDependencies, dependent_typeid_count),
   DDS_OP_ADR | DDS_OP_TYPE_SEQ | DDS_OP_SUBTYPE_STU, offsetof (DDS_XTypes_TypeIdentifierWithDependencies, dependent_typeids), sizeof (DDS_XTypes_TypeIdentifierWithSize), (4u << 16u) + 5u /* TypeIdentifierWithSize */,
   DDS_OP_RTS,
 
   /* TypeIdentifierWithSize */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_TypeIdentifierWithSize, type_id), (3u << 16u) + 6u /* TypeIdentifier */,
   DDS_OP_ADR | DDS_OP_TYPE_4BY, offsetof (DDS_XTypes_TypeIdentifierWithSize, typeobject_serialized_size),
   DDS_OP_RTS,
@@ -893,7 +893,7 @@ static const uint32_t DDS_XTypes_TypeInformation_ops [] =
   DDS_OP_RTS,
 
   /* StronglyConnectedComponentId */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_StronglyConnectedComponentId, sc_component_id), (3u << 16u) + 8u /* TypeObjectHashId */,
   DDS_OP_ADR | DDS_OP_TYPE_4BY | DDS_OP_FLAG_SGN, offsetof (DDS_XTypes_StronglyConnectedComponentId, scc_length),
   DDS_OP_ADR | DDS_OP_TYPE_4BY | DDS_OP_FLAG_SGN, offsetof (DDS_XTypes_StronglyConnectedComponentId, scc_index),

--- a/src/core/ddsi/src/ddsi_xt_typelookup.c
+++ b/src/core/ddsi/src/ddsi_xt_typelookup.c
@@ -45,7 +45,7 @@ static const uint32_t DDS_Builtin_TypeLookup_Request_ops [] =
   DDS_OP_RTS,
 
   /* TypeLookup_Call */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 13,
   DDS_OP_ADR | DDS_OP_FLAG_MU | DDS_OP_TYPE_UNI | DDS_OP_SUBTYPE_4BY | DDS_OP_FLAG_SGN, offsetof (DDS_Builtin_TypeLookup_Call, _d), 2u, (12u << 16u) + 4u,
   DDS_OP_JEQ4 | DDS_OP_TYPE_STU | 9 /* TypeLookup_getTypes_In */, 25318099, offsetof (DDS_Builtin_TypeLookup_Call, _u.getTypes), 0u,
   DDS_OP_JEQ4 | DDS_OP_TYPE_STU | 190 /* TypeLookup_getTypeDependencies_In */, 95091505, offsetof (DDS_Builtin_TypeLookup_Call, _u.getTypeDependencies), 0u,
@@ -131,7 +131,7 @@ static const uint32_t DDS_Builtin_TypeLookup_Request_ops [] =
   DDS_OP_RTS,
 
   /* StronglyConnectedComponentId */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_StronglyConnectedComponentId, sc_component_id), (3u << 16u) + 8u /* TypeObjectHashId */,
   DDS_OP_ADR | DDS_OP_TYPE_4BY | DDS_OP_FLAG_SGN, offsetof (DDS_XTypes_StronglyConnectedComponentId, scc_length),
   DDS_OP_ADR | DDS_OP_TYPE_4BY | DDS_OP_FLAG_SGN, offsetof (DDS_XTypes_StronglyConnectedComponentId, scc_index),
@@ -226,14 +226,14 @@ static const uint32_t DDS_Builtin_TypeLookup_Reply_ops [] =
   DDS_OP_RTS,
 
   /* TypeLookup_Return */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 13,
   DDS_OP_ADR | DDS_OP_FLAG_MU | DDS_OP_TYPE_UNI | DDS_OP_SUBTYPE_4BY | DDS_OP_FLAG_SGN, offsetof (DDS_Builtin_TypeLookup_Return, _d), 2u, (12u << 16u) + 4u,
   DDS_OP_JEQ4 | DDS_OP_TYPE_UNI | 9 /* TypeLookup_getTypes_Result */, 25318099, offsetof (DDS_Builtin_TypeLookup_Return, _u.getType), 0u,
   DDS_OP_JEQ4 | DDS_OP_TYPE_UNI | 1072 /* TypeLookup_getTypeDependencies_Result */, 95091505, offsetof (DDS_Builtin_TypeLookup_Return, _u.getTypeDependencies), 0u,
   DDS_OP_RTS,
 
   /* TypeLookup_getTypes_Result */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 9,
   DDS_OP_ADR | DDS_OP_FLAG_MU | DDS_OP_TYPE_UNI | DDS_OP_SUBTYPE_4BY | DDS_OP_FLAG_SGN, offsetof (DDS_Builtin_TypeLookup_getTypes_Result, _d), 1u, (8u << 16u) + 4u,
   DDS_OP_JEQ4 | DDS_OP_TYPE_STU | 5 /* TypeLookup_getTypes_Out */, 0, offsetof (DDS_Builtin_TypeLookup_getTypes_Result, _u.result), 0u,
   DDS_OP_RTS,
@@ -326,7 +326,7 @@ static const uint32_t DDS_Builtin_TypeLookup_Reply_ops [] =
   DDS_OP_RTS,
 
   /* StronglyConnectedComponentId */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_StronglyConnectedComponentId, sc_component_id), (3u << 16u) + 8u /* TypeObjectHashId */,
   DDS_OP_ADR | DDS_OP_TYPE_4BY | DDS_OP_FLAG_SGN, offsetof (DDS_XTypes_StronglyConnectedComponentId, scc_length),
   DDS_OP_ADR | DDS_OP_TYPE_4BY | DDS_OP_FLAG_SGN, offsetof (DDS_XTypes_StronglyConnectedComponentId, scc_index),
@@ -341,7 +341,7 @@ static const uint32_t DDS_Builtin_TypeLookup_Reply_ops [] =
   DDS_OP_RTS,
 
   /* TypeObject */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 13,
   DDS_OP_ADR | DDS_OP_FLAG_MU | DDS_OP_TYPE_UNI | DDS_OP_SUBTYPE_1BY, offsetof (DDS_XTypes_TypeObject, _d), 2u, (12u << 16u) + 4u,
   DDS_OP_JEQ4 | DDS_OP_TYPE_UNI | 9 /* CompleteTypeObject */, 242, offsetof (DDS_XTypes_TypeObject, _u.complete), 0u,
   DDS_OP_JEQ4 | DDS_OP_TYPE_UNI | 562 /* MinimalTypeObject */, 241, offsetof (DDS_XTypes_TypeObject, _u.minimal), 0u,
@@ -369,7 +369,7 @@ static const uint32_t DDS_Builtin_TypeLookup_Reply_ops [] =
   DDS_OP_RTS,
 
   /* CompleteAliasHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteAliasHeader, detail), (3u << 16u) + 4u /* CompleteTypeDetail */,
   DDS_OP_RTS,
 
@@ -380,7 +380,7 @@ static const uint32_t DDS_Builtin_TypeLookup_Reply_ops [] =
   DDS_OP_RTS,
 
   /* AppliedBuiltinTypeAnnotations */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 5,
   DDS_OP_ADR | DDS_OP_FLAG_OPT | DDS_OP_FLAG_EXT | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_AppliedBuiltinTypeAnnotations, verbatim), (4u << 16u) + 5u /* AppliedVerbatimAnnotation */, sizeof (DDS_XTypes_AppliedVerbatimAnnotation),
   DDS_OP_RTS,
 
@@ -391,13 +391,13 @@ static const uint32_t DDS_Builtin_TypeLookup_Reply_ops [] =
   DDS_OP_RTS,
 
   /* AppliedAnnotation */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_AppliedAnnotation, annotation_typeid), (3u << 16u) + 65253u /* TypeIdentifier */,
   DDS_OP_ADR | DDS_OP_FLAG_OPT | DDS_OP_FLAG_EXT | DDS_OP_TYPE_SEQ | DDS_OP_SUBTYPE_STU, offsetof (DDS_XTypes_AppliedAnnotation, param_seq), sizeof (DDS_XTypes_AppliedAnnotationParameter), (4u << 16u) + 5u /* AppliedAnnotationParameter */,
   DDS_OP_RTS,
 
   /* AppliedAnnotationParameter */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_ARR | DDS_OP_SUBTYPE_1BY, offsetof (DDS_XTypes_AppliedAnnotationParameter, paramname_hash), 4u,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_AppliedAnnotationParameter, value), (3u << 16u) + 4u /* AnnotationParameterValue */,
   DDS_OP_RTS,
@@ -429,7 +429,7 @@ static const uint32_t DDS_Builtin_TypeLookup_Reply_ops [] =
   DDS_OP_RTS,
 
   /* CompleteAliasBody */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteAliasBody, common), (3u << 16u) + 12u /* CommonAliasBody */,
   DDS_OP_ADR | DDS_OP_FLAG_OPT | DDS_OP_FLAG_EXT | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteAliasBody, ann_builtin), (4u << 16u) + 17u /* AppliedBuiltinMemberAnnotations */, sizeof (DDS_XTypes_AppliedBuiltinMemberAnnotations),
   DDS_OP_ADR | DDS_OP_FLAG_OPT | DDS_OP_FLAG_EXT | DDS_OP_TYPE_SEQ | DDS_OP_SUBTYPE_STU, offsetof (DDS_XTypes_CompleteAliasBody, ann_custom), sizeof (DDS_XTypes_AppliedAnnotation), (4u << 16u) + 65436u /* AppliedAnnotation */,
@@ -441,7 +441,7 @@ static const uint32_t DDS_Builtin_TypeLookup_Reply_ops [] =
   DDS_OP_RTS,
 
   /* AppliedBuiltinMemberAnnotations */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 3,
   DDS_OP_ADR | DDS_OP_FLAG_OPT | DDS_OP_TYPE_STR, offsetof (DDS_XTypes_AppliedBuiltinMemberAnnotations, unit),
   DDS_OP_ADR | DDS_OP_FLAG_OPT | DDS_OP_FLAG_EXT | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_AppliedBuiltinMemberAnnotations, min), (4u << 16u) + 65437u /* AnnotationParameterValue */, sizeof (DDS_XTypes_AnnotationParameterValue),
   DDS_OP_ADR | DDS_OP_FLAG_OPT | DDS_OP_FLAG_EXT | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_AppliedBuiltinMemberAnnotations, max), (4u << 16u) + 65433u /* AnnotationParameterValue */, sizeof (DDS_XTypes_AnnotationParameterValue),
@@ -455,12 +455,12 @@ static const uint32_t DDS_Builtin_TypeLookup_Reply_ops [] =
   DDS_OP_RTS,
 
   /* CompleteAnnotationHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_BST, offsetof (DDS_XTypes_CompleteAnnotationHeader, annotation_name), 257u,
   DDS_OP_RTS,
 
   /* CompleteAnnotationParameter */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteAnnotationParameter, common), (3u << 16u) + 10u /* CommonAnnotationParameter */,
   DDS_OP_ADR | DDS_OP_TYPE_BST, offsetof (DDS_XTypes_CompleteAnnotationParameter, name), 257u,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteAnnotationParameter, default_value), (3u << 16u) + 65402u /* AnnotationParameterValue */,
@@ -478,13 +478,13 @@ static const uint32_t DDS_Builtin_TypeLookup_Reply_ops [] =
   DDS_OP_RTS,
 
   /* CompleteStructHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteStructHeader, base_type), (3u << 16u) + 65078u /* TypeIdentifier */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteStructHeader, detail), (3u << 16u) + 65330u /* CompleteTypeDetail */,
   DDS_OP_RTS,
 
   /* CompleteStructMember */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteStructMember, common), (3u << 16u) + 7u /* CommonStructMember */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteStructMember, detail), (3u << 16u) + 14u /* CompleteMemberDetail */,
   DDS_OP_RTS,
@@ -509,12 +509,12 @@ static const uint32_t DDS_Builtin_TypeLookup_Reply_ops [] =
   DDS_OP_RTS,
 
   /* CompleteUnionHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteUnionHeader, detail), (3u << 16u) + 65280u /* CompleteTypeDetail */,
   DDS_OP_RTS,
 
   /* CompleteDiscriminatorMember */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteDiscriminatorMember, common), (3u << 16u) + 12u /* CommonDiscriminatorMember */,
   DDS_OP_ADR | DDS_OP_FLAG_OPT | DDS_OP_FLAG_EXT | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteDiscriminatorMember, ann_builtin), (4u << 16u) + 65284u /* AppliedBuiltinTypeAnnotations */, sizeof (DDS_XTypes_AppliedBuiltinTypeAnnotations),
   DDS_OP_ADR | DDS_OP_FLAG_OPT | DDS_OP_FLAG_EXT | DDS_OP_TYPE_SEQ | DDS_OP_SUBTYPE_STU, offsetof (DDS_XTypes_CompleteDiscriminatorMember, ann_custom), sizeof (DDS_XTypes_AppliedAnnotation), (4u << 16u) + 65295u /* AppliedAnnotation */,
@@ -526,7 +526,7 @@ static const uint32_t DDS_Builtin_TypeLookup_Reply_ops [] =
   DDS_OP_RTS,
 
   /* CompleteUnionMember */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteUnionMember, common), (3u << 16u) + 7u /* CommonUnionMember */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteUnionMember, detail), (3u << 16u) + 65479u /* CompleteMemberDetail */,
   DDS_OP_RTS,
@@ -539,19 +539,19 @@ static const uint32_t DDS_Builtin_TypeLookup_Reply_ops [] =
   DDS_OP_RTS,
 
   /* CompleteBitsetType */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 5,
   DDS_OP_ADR | DDS_OP_TYPE_BMK | (1 << DDS_OP_FLAG_SZ_SHIFT), offsetof (DDS_XTypes_CompleteBitsetType, bitset_flags), 0u, 31u,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteBitsetType, header), (3u << 16u) + 8u /* CompleteBitsetHeader */,
   DDS_OP_ADR | DDS_OP_TYPE_SEQ | DDS_OP_SUBTYPE_STU, offsetof (DDS_XTypes_CompleteBitsetType, field_seq), sizeof (DDS_XTypes_CompleteBitfield), (4u << 16u) + 10u /* CompleteBitfield */,
   DDS_OP_RTS,
 
   /* CompleteBitsetHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteBitsetHeader, detail), (3u << 16u) + 65221u /* CompleteTypeDetail */,
   DDS_OP_RTS,
 
   /* CompleteBitfield */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteBitfield, common), (3u << 16u) + 7u /* CommonBitfield */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteBitfield, detail), (3u << 16u) + 65441u /* CompleteMemberDetail */,
   DDS_OP_RTS,
@@ -570,7 +570,7 @@ static const uint32_t DDS_Builtin_TypeLookup_Reply_ops [] =
   DDS_OP_RTS,
 
   /* CompleteCollectionHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteCollectionHeader, common), (3u << 16u) + 8u /* CommonCollectionHeader */,
   DDS_OP_ADR | DDS_OP_FLAG_OPT | DDS_OP_FLAG_EXT | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteCollectionHeader, detail), (4u << 16u) + 65183u /* CompleteTypeDetail */, sizeof (DDS_XTypes_CompleteTypeDetail),
   DDS_OP_RTS,
@@ -580,7 +580,7 @@ static const uint32_t DDS_Builtin_TypeLookup_Reply_ops [] =
   DDS_OP_RTS,
 
   /* CompleteCollectionElement */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteCollectionElement, common), (3u << 16u) + 7u /* CommonCollectionElement */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteCollectionElement, detail), (3u << 16u) + 12u /* CompleteElementDetail */,
   DDS_OP_RTS,
@@ -596,14 +596,14 @@ static const uint32_t DDS_Builtin_TypeLookup_Reply_ops [] =
   DDS_OP_RTS,
 
   /* CompleteArrayType */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 5,
   DDS_OP_ADR | DDS_OP_TYPE_BMK | (1 << DDS_OP_FLAG_SZ_SHIFT), offsetof (DDS_XTypes_CompleteArrayType, collection_flag), 0u, 31u,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteArrayType, header), (3u << 16u) + 7u /* CompleteArrayHeader */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteArrayType, element), (3u << 16u) + 65503u /* CompleteCollectionElement */,
   DDS_OP_RTS,
 
   /* CompleteArrayHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteArrayHeader, common), (3u << 16u) + 7u /* CommonArrayHeader */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteArrayHeader, detail), (3u << 16u) + 65134u /* CompleteTypeDetail */,
   DDS_OP_RTS,
@@ -626,7 +626,7 @@ static const uint32_t DDS_Builtin_TypeLookup_Reply_ops [] =
   DDS_OP_RTS,
 
   /* CompleteEnumeratedHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteEnumeratedHeader, common), (3u << 16u) + 7u /* CommonEnumeratedHeader */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteEnumeratedHeader, detail), (3u << 16u) + 65097u /* CompleteTypeDetail */,
   DDS_OP_RTS,
@@ -636,26 +636,26 @@ static const uint32_t DDS_Builtin_TypeLookup_Reply_ops [] =
   DDS_OP_RTS,
 
   /* CompleteEnumeratedLiteral */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteEnumeratedLiteral, common), (3u << 16u) + 7u /* CommonEnumeratedLiteral */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteEnumeratedLiteral, detail), (3u << 16u) + 65314u /* CompleteMemberDetail */,
   DDS_OP_RTS,
 
   /* CommonEnumeratedLiteral */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 3,
   DDS_OP_ADR | DDS_OP_TYPE_4BY | DDS_OP_FLAG_SGN, offsetof (DDS_XTypes_CommonEnumeratedLiteral, value),
   DDS_OP_ADR | DDS_OP_TYPE_BMK | (1 << DDS_OP_FLAG_SZ_SHIFT), offsetof (DDS_XTypes_CommonEnumeratedLiteral, flags), 0u, 127u,
   DDS_OP_RTS,
 
   /* CompleteBitmaskType */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 5,
   DDS_OP_ADR | DDS_OP_TYPE_BMK | (1 << DDS_OP_FLAG_SZ_SHIFT), offsetof (DDS_XTypes_CompleteBitmaskType, bitmask_flags), 0u, 31u,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteBitmaskType, header), (3u << 16u) + 65504u /* CompleteEnumeratedHeader */,
   DDS_OP_ADR | DDS_OP_TYPE_SEQ | DDS_OP_SUBTYPE_STU, offsetof (DDS_XTypes_CompleteBitmaskType, flag_seq), sizeof (DDS_XTypes_CompleteBitflag), (4u << 16u) + 5u /* CompleteBitflag */,
   DDS_OP_RTS,
 
   /* CompleteBitflag */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteBitflag, common), (3u << 16u) + 7u /* CommonBitflag */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteBitflag, detail), (3u << 16u) + 65285u /* CompleteMemberDetail */,
   DDS_OP_RTS,
@@ -695,7 +695,7 @@ static const uint32_t DDS_Builtin_TypeLookup_Reply_ops [] =
   DDS_OP_RTS,
 
   /* MinimalAliasBody */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalAliasBody, common), (3u << 16u) + 65113u /* CommonAliasBody */,
   DDS_OP_RTS,
 
@@ -710,7 +710,7 @@ static const uint32_t DDS_Builtin_TypeLookup_Reply_ops [] =
   DDS_OP_RTS,
 
   /* MinimalAnnotationParameter */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalAnnotationParameter, common), (3u << 16u) + 65144u /* CommonAnnotationParameter */,
   DDS_OP_ADR | DDS_OP_TYPE_ARR | DDS_OP_SUBTYPE_1BY, offsetof (DDS_XTypes_MinimalAnnotationParameter, name_hash), 4u,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalAnnotationParameter, default_value), (3u << 16u) + 65000u /* AnnotationParameterValue */,
@@ -723,7 +723,7 @@ static const uint32_t DDS_Builtin_TypeLookup_Reply_ops [] =
   DDS_OP_RTS,
 
   /* MinimalStructHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalStructHeader, base_type), (3u << 16u) + 64684u /* TypeIdentifier */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, 0u, (3u << 16u) + 4u /* MinimalTypeDetail */,
   DDS_OP_RTS,
@@ -732,7 +732,7 @@ static const uint32_t DDS_Builtin_TypeLookup_Reply_ops [] =
   DDS_OP_RTS,
 
   /* MinimalStructMember */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalStructMember, common), (3u << 16u) + 65148u /* CommonStructMember */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalStructMember, detail), (3u << 16u) + 4u /* MinimalMemberDetail */,
   DDS_OP_RTS,
@@ -749,23 +749,23 @@ static const uint32_t DDS_Builtin_TypeLookup_Reply_ops [] =
   DDS_OP_RTS,
 
   /* MinimalUnionHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, 0u, (3u << 16u) + 65507u /* MinimalTypeDetail */,
   DDS_OP_RTS,
 
   /* MinimalDiscriminatorMember */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalDiscriminatorMember, common), (3u << 16u) + 65171u /* CommonDiscriminatorMember */,
   DDS_OP_RTS,
 
   /* MinimalUnionMember */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalUnionMember, common), (3u << 16u) + 65182u /* CommonUnionMember */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalUnionMember, detail), (3u << 16u) + 65503u /* MinimalMemberDetail */,
   DDS_OP_RTS,
 
   /* MinimalBitsetType */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 5,
   DDS_OP_ADR | DDS_OP_TYPE_BMK | (1 << DDS_OP_FLAG_SZ_SHIFT), offsetof (DDS_XTypes_MinimalBitsetType, bitset_flags), 0u, 31u,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, 0u, (3u << 16u) + 8u /* MinimalBitsetHeader */,
   DDS_OP_ADR | DDS_OP_TYPE_SEQ | DDS_OP_SUBTYPE_STU, offsetof (DDS_XTypes_MinimalBitsetType, field_seq), sizeof (DDS_XTypes_MinimalBitfield), (4u << 16u) + 7u /* MinimalBitfield */,
@@ -776,7 +776,7 @@ static const uint32_t DDS_Builtin_TypeLookup_Reply_ops [] =
   DDS_OP_RTS,
 
   /* MinimalBitfield */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalBitfield, common), (3u << 16u) + 65197u /* CommonBitfield */,
   DDS_OP_ADR | DDS_OP_TYPE_ARR | DDS_OP_SUBTYPE_1BY, offsetof (DDS_XTypes_MinimalBitfield, name_hash), 4u,
   DDS_OP_RTS,
@@ -788,12 +788,12 @@ static const uint32_t DDS_Builtin_TypeLookup_Reply_ops [] =
   DDS_OP_RTS,
 
   /* MinimalCollectionHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalCollectionHeader, common), (3u << 16u) + 65209u /* CommonCollectionHeader */,
   DDS_OP_RTS,
 
   /* MinimalCollectionElement */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalCollectionElement, common), (3u << 16u) + 65215u /* CommonCollectionElement */,
   DDS_OP_RTS,
 
@@ -804,7 +804,7 @@ static const uint32_t DDS_Builtin_TypeLookup_Reply_ops [] =
   DDS_OP_RTS,
 
   /* MinimalArrayHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalArrayHeader, common), (3u << 16u) + 65236u /* CommonArrayHeader */,
   DDS_OP_RTS,
 
@@ -822,25 +822,25 @@ static const uint32_t DDS_Builtin_TypeLookup_Reply_ops [] =
   DDS_OP_RTS,
 
   /* MinimalEnumeratedHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalEnumeratedHeader, common), (3u << 16u) + 65242u /* CommonEnumeratedHeader */,
   DDS_OP_RTS,
 
   /* MinimalEnumeratedLiteral */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalEnumeratedLiteral, common), (3u << 16u) + 65248u /* CommonEnumeratedLiteral */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalEnumeratedLiteral, detail), (3u << 16u) + 65404u /* MinimalMemberDetail */,
   DDS_OP_RTS,
 
   /* MinimalBitmaskType */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 5,
   DDS_OP_ADR | DDS_OP_TYPE_BMK | (1 << DDS_OP_FLAG_SZ_SHIFT), offsetof (DDS_XTypes_MinimalBitmaskType, bitmask_flags), 0u, 31u,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalBitmaskType, header), (3u << 16u) + 65518u /* MinimalEnumeratedHeader */,
   DDS_OP_ADR | DDS_OP_TYPE_SEQ | DDS_OP_SUBTYPE_STU, offsetof (DDS_XTypes_MinimalBitmaskType, flag_seq), sizeof (DDS_XTypes_MinimalBitflag), (4u << 16u) + 5u /* MinimalBitflag */,
   DDS_OP_RTS,
 
   /* MinimalBitflag */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalBitflag, common), (3u << 16u) + 65256u /* CommonBitflag */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalBitflag, detail), (3u << 16u) + 65383u /* MinimalMemberDetail */,
   DDS_OP_RTS,
@@ -855,7 +855,7 @@ static const uint32_t DDS_Builtin_TypeLookup_Reply_ops [] =
   DDS_OP_RTS,
 
   /* TypeLookup_getTypeDependencies_Result */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 9,
   DDS_OP_ADR | DDS_OP_FLAG_MU | DDS_OP_TYPE_UNI | DDS_OP_SUBTYPE_4BY | DDS_OP_FLAG_SGN, offsetof (DDS_Builtin_TypeLookup_getTypeDependencies_Result, _d), 1u, (8u << 16u) + 4u,
   DDS_OP_JEQ4 | DDS_OP_TYPE_STU | 5 /* TypeLookup_getTypeDependencies_Out */, 0, offsetof (DDS_Builtin_TypeLookup_getTypeDependencies_Result, _u.result), 0u,
   DDS_OP_RTS,
@@ -871,7 +871,7 @@ static const uint32_t DDS_Builtin_TypeLookup_Reply_ops [] =
   DDS_OP_RTS,
 
   /* TypeIdentifierWithSize */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_TypeIdentifierWithSize, type_id), (3u << 16u) + 64476u /* TypeIdentifier */,
   DDS_OP_ADR | DDS_OP_TYPE_4BY, offsetof (DDS_XTypes_TypeIdentifierWithSize, typeobject_serialized_size),
   DDS_OP_RTS,

--- a/src/core/ddsi/src/ddsi_xt_typemap.c
+++ b/src/core/ddsi/src/ddsi_xt_typemap.c
@@ -98,7 +98,7 @@ static const uint32_t DDS_XTypes_TypeMapping_ops [] =
   DDS_OP_RTS,
 
   /* StronglyConnectedComponentId */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_StronglyConnectedComponentId, sc_component_id), (3u << 16u) + 8u /* TypeObjectHashId */,
   DDS_OP_ADR | DDS_OP_TYPE_4BY | DDS_OP_FLAG_SGN, offsetof (DDS_XTypes_StronglyConnectedComponentId, scc_length),
   DDS_OP_ADR | DDS_OP_TYPE_4BY | DDS_OP_FLAG_SGN, offsetof (DDS_XTypes_StronglyConnectedComponentId, scc_index),
@@ -113,7 +113,7 @@ static const uint32_t DDS_XTypes_TypeMapping_ops [] =
   DDS_OP_RTS,
 
   /* TypeObject */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 13,
   DDS_OP_ADR | DDS_OP_FLAG_MU | DDS_OP_TYPE_UNI | DDS_OP_SUBTYPE_1BY, offsetof (DDS_XTypes_TypeObject, _d), 2u, (12u << 16u) + 4u,
   DDS_OP_JEQ4 | DDS_OP_TYPE_UNI | 9 /* CompleteTypeObject */, 242, offsetof (DDS_XTypes_TypeObject, _u.complete), 0u,
   DDS_OP_JEQ4 | DDS_OP_TYPE_UNI | 562 /* MinimalTypeObject */, 241, offsetof (DDS_XTypes_TypeObject, _u.minimal), 0u,
@@ -141,7 +141,7 @@ static const uint32_t DDS_XTypes_TypeMapping_ops [] =
   DDS_OP_RTS,
 
   /* CompleteAliasHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteAliasHeader, detail), (3u << 16u) + 4u /* CompleteTypeDetail */,
   DDS_OP_RTS,
 
@@ -152,7 +152,7 @@ static const uint32_t DDS_XTypes_TypeMapping_ops [] =
   DDS_OP_RTS,
 
   /* AppliedBuiltinTypeAnnotations */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 5,
   DDS_OP_ADR | DDS_OP_FLAG_OPT | DDS_OP_FLAG_EXT | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_AppliedBuiltinTypeAnnotations, verbatim), (4u << 16u) + 5u /* AppliedVerbatimAnnotation */, sizeof (DDS_XTypes_AppliedVerbatimAnnotation),
   DDS_OP_RTS,
 
@@ -163,13 +163,13 @@ static const uint32_t DDS_XTypes_TypeMapping_ops [] =
   DDS_OP_RTS,
 
   /* AppliedAnnotation */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_AppliedAnnotation, annotation_typeid), (3u << 16u) + 65253u /* TypeIdentifier */,
   DDS_OP_ADR | DDS_OP_FLAG_OPT | DDS_OP_FLAG_EXT | DDS_OP_TYPE_SEQ | DDS_OP_SUBTYPE_STU, offsetof (DDS_XTypes_AppliedAnnotation, param_seq), sizeof (DDS_XTypes_AppliedAnnotationParameter), (4u << 16u) + 5u /* AppliedAnnotationParameter */,
   DDS_OP_RTS,
 
   /* AppliedAnnotationParameter */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_ARR | DDS_OP_SUBTYPE_1BY, offsetof (DDS_XTypes_AppliedAnnotationParameter, paramname_hash), 4u,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_AppliedAnnotationParameter, value), (3u << 16u) + 4u /* AnnotationParameterValue */,
   DDS_OP_RTS,
@@ -201,7 +201,7 @@ static const uint32_t DDS_XTypes_TypeMapping_ops [] =
   DDS_OP_RTS,
 
   /* CompleteAliasBody */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteAliasBody, common), (3u << 16u) + 12u /* CommonAliasBody */,
   DDS_OP_ADR | DDS_OP_FLAG_OPT | DDS_OP_FLAG_EXT | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteAliasBody, ann_builtin), (4u << 16u) + 17u /* AppliedBuiltinMemberAnnotations */, sizeof (DDS_XTypes_AppliedBuiltinMemberAnnotations),
   DDS_OP_ADR | DDS_OP_FLAG_OPT | DDS_OP_FLAG_EXT | DDS_OP_TYPE_SEQ | DDS_OP_SUBTYPE_STU, offsetof (DDS_XTypes_CompleteAliasBody, ann_custom), sizeof (DDS_XTypes_AppliedAnnotation), (4u << 16u) + 65436u /* AppliedAnnotation */,
@@ -213,7 +213,7 @@ static const uint32_t DDS_XTypes_TypeMapping_ops [] =
   DDS_OP_RTS,
 
   /* AppliedBuiltinMemberAnnotations */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 3,
   DDS_OP_ADR | DDS_OP_FLAG_OPT | DDS_OP_TYPE_STR, offsetof (DDS_XTypes_AppliedBuiltinMemberAnnotations, unit),
   DDS_OP_ADR | DDS_OP_FLAG_OPT | DDS_OP_FLAG_EXT | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_AppliedBuiltinMemberAnnotations, min), (4u << 16u) + 65437u /* AnnotationParameterValue */, sizeof (DDS_XTypes_AnnotationParameterValue),
   DDS_OP_ADR | DDS_OP_FLAG_OPT | DDS_OP_FLAG_EXT | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_AppliedBuiltinMemberAnnotations, max), (4u << 16u) + 65433u /* AnnotationParameterValue */, sizeof (DDS_XTypes_AnnotationParameterValue),
@@ -227,12 +227,12 @@ static const uint32_t DDS_XTypes_TypeMapping_ops [] =
   DDS_OP_RTS,
 
   /* CompleteAnnotationHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_BST, offsetof (DDS_XTypes_CompleteAnnotationHeader, annotation_name), 257u,
   DDS_OP_RTS,
 
   /* CompleteAnnotationParameter */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteAnnotationParameter, common), (3u << 16u) + 10u /* CommonAnnotationParameter */,
   DDS_OP_ADR | DDS_OP_TYPE_BST, offsetof (DDS_XTypes_CompleteAnnotationParameter, name), 257u,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteAnnotationParameter, default_value), (3u << 16u) + 65402u /* AnnotationParameterValue */,
@@ -250,13 +250,13 @@ static const uint32_t DDS_XTypes_TypeMapping_ops [] =
   DDS_OP_RTS,
 
   /* CompleteStructHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteStructHeader, base_type), (3u << 16u) + 65078u /* TypeIdentifier */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteStructHeader, detail), (3u << 16u) + 65330u /* CompleteTypeDetail */,
   DDS_OP_RTS,
 
   /* CompleteStructMember */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteStructMember, common), (3u << 16u) + 7u /* CommonStructMember */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteStructMember, detail), (3u << 16u) + 14u /* CompleteMemberDetail */,
   DDS_OP_RTS,
@@ -281,12 +281,12 @@ static const uint32_t DDS_XTypes_TypeMapping_ops [] =
   DDS_OP_RTS,
 
   /* CompleteUnionHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteUnionHeader, detail), (3u << 16u) + 65280u /* CompleteTypeDetail */,
   DDS_OP_RTS,
 
   /* CompleteDiscriminatorMember */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteDiscriminatorMember, common), (3u << 16u) + 12u /* CommonDiscriminatorMember */,
   DDS_OP_ADR | DDS_OP_FLAG_OPT | DDS_OP_FLAG_EXT | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteDiscriminatorMember, ann_builtin), (4u << 16u) + 65284u /* AppliedBuiltinTypeAnnotations */, sizeof (DDS_XTypes_AppliedBuiltinTypeAnnotations),
   DDS_OP_ADR | DDS_OP_FLAG_OPT | DDS_OP_FLAG_EXT | DDS_OP_TYPE_SEQ | DDS_OP_SUBTYPE_STU, offsetof (DDS_XTypes_CompleteDiscriminatorMember, ann_custom), sizeof (DDS_XTypes_AppliedAnnotation), (4u << 16u) + 65295u /* AppliedAnnotation */,
@@ -298,7 +298,7 @@ static const uint32_t DDS_XTypes_TypeMapping_ops [] =
   DDS_OP_RTS,
 
   /* CompleteUnionMember */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteUnionMember, common), (3u << 16u) + 7u /* CommonUnionMember */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteUnionMember, detail), (3u << 16u) + 65479u /* CompleteMemberDetail */,
   DDS_OP_RTS,
@@ -311,19 +311,19 @@ static const uint32_t DDS_XTypes_TypeMapping_ops [] =
   DDS_OP_RTS,
 
   /* CompleteBitsetType */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 5,
   DDS_OP_ADR | DDS_OP_TYPE_BMK | (1 << DDS_OP_FLAG_SZ_SHIFT), offsetof (DDS_XTypes_CompleteBitsetType, bitset_flags), 0u, 31u,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteBitsetType, header), (3u << 16u) + 8u /* CompleteBitsetHeader */,
   DDS_OP_ADR | DDS_OP_TYPE_SEQ | DDS_OP_SUBTYPE_STU, offsetof (DDS_XTypes_CompleteBitsetType, field_seq), sizeof (DDS_XTypes_CompleteBitfield), (4u << 16u) + 10u /* CompleteBitfield */,
   DDS_OP_RTS,
 
   /* CompleteBitsetHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteBitsetHeader, detail), (3u << 16u) + 65221u /* CompleteTypeDetail */,
   DDS_OP_RTS,
 
   /* CompleteBitfield */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteBitfield, common), (3u << 16u) + 7u /* CommonBitfield */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteBitfield, detail), (3u << 16u) + 65441u /* CompleteMemberDetail */,
   DDS_OP_RTS,
@@ -342,7 +342,7 @@ static const uint32_t DDS_XTypes_TypeMapping_ops [] =
   DDS_OP_RTS,
 
   /* CompleteCollectionHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteCollectionHeader, common), (3u << 16u) + 8u /* CommonCollectionHeader */,
   DDS_OP_ADR | DDS_OP_FLAG_OPT | DDS_OP_FLAG_EXT | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteCollectionHeader, detail), (4u << 16u) + 65183u /* CompleteTypeDetail */, sizeof (DDS_XTypes_CompleteTypeDetail),
   DDS_OP_RTS,
@@ -352,7 +352,7 @@ static const uint32_t DDS_XTypes_TypeMapping_ops [] =
   DDS_OP_RTS,
 
   /* CompleteCollectionElement */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteCollectionElement, common), (3u << 16u) + 7u /* CommonCollectionElement */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteCollectionElement, detail), (3u << 16u) + 12u /* CompleteElementDetail */,
   DDS_OP_RTS,
@@ -368,14 +368,14 @@ static const uint32_t DDS_XTypes_TypeMapping_ops [] =
   DDS_OP_RTS,
 
   /* CompleteArrayType */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 5,
   DDS_OP_ADR | DDS_OP_TYPE_BMK | (1 << DDS_OP_FLAG_SZ_SHIFT), offsetof (DDS_XTypes_CompleteArrayType, collection_flag), 0u, 31u,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteArrayType, header), (3u << 16u) + 7u /* CompleteArrayHeader */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteArrayType, element), (3u << 16u) + 65503u /* CompleteCollectionElement */,
   DDS_OP_RTS,
 
   /* CompleteArrayHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteArrayHeader, common), (3u << 16u) + 7u /* CommonArrayHeader */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteArrayHeader, detail), (3u << 16u) + 65134u /* CompleteTypeDetail */,
   DDS_OP_RTS,
@@ -398,7 +398,7 @@ static const uint32_t DDS_XTypes_TypeMapping_ops [] =
   DDS_OP_RTS,
 
   /* CompleteEnumeratedHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteEnumeratedHeader, common), (3u << 16u) + 7u /* CommonEnumeratedHeader */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteEnumeratedHeader, detail), (3u << 16u) + 65097u /* CompleteTypeDetail */,
   DDS_OP_RTS,
@@ -408,26 +408,26 @@ static const uint32_t DDS_XTypes_TypeMapping_ops [] =
   DDS_OP_RTS,
 
   /* CompleteEnumeratedLiteral */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteEnumeratedLiteral, common), (3u << 16u) + 7u /* CommonEnumeratedLiteral */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteEnumeratedLiteral, detail), (3u << 16u) + 65314u /* CompleteMemberDetail */,
   DDS_OP_RTS,
 
   /* CommonEnumeratedLiteral */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 3,
   DDS_OP_ADR | DDS_OP_TYPE_4BY | DDS_OP_FLAG_SGN, offsetof (DDS_XTypes_CommonEnumeratedLiteral, value),
   DDS_OP_ADR | DDS_OP_TYPE_BMK | (1 << DDS_OP_FLAG_SZ_SHIFT), offsetof (DDS_XTypes_CommonEnumeratedLiteral, flags), 0u, 127u,
   DDS_OP_RTS,
 
   /* CompleteBitmaskType */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 5,
   DDS_OP_ADR | DDS_OP_TYPE_BMK | (1 << DDS_OP_FLAG_SZ_SHIFT), offsetof (DDS_XTypes_CompleteBitmaskType, bitmask_flags), 0u, 31u,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteBitmaskType, header), (3u << 16u) + 65504u /* CompleteEnumeratedHeader */,
   DDS_OP_ADR | DDS_OP_TYPE_SEQ | DDS_OP_SUBTYPE_STU, offsetof (DDS_XTypes_CompleteBitmaskType, flag_seq), sizeof (DDS_XTypes_CompleteBitflag), (4u << 16u) + 5u /* CompleteBitflag */,
   DDS_OP_RTS,
 
   /* CompleteBitflag */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteBitflag, common), (3u << 16u) + 7u /* CommonBitflag */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_CompleteBitflag, detail), (3u << 16u) + 65285u /* CompleteMemberDetail */,
   DDS_OP_RTS,
@@ -467,7 +467,7 @@ static const uint32_t DDS_XTypes_TypeMapping_ops [] =
   DDS_OP_RTS,
 
   /* MinimalAliasBody */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalAliasBody, common), (3u << 16u) + 65113u /* CommonAliasBody */,
   DDS_OP_RTS,
 
@@ -482,7 +482,7 @@ static const uint32_t DDS_XTypes_TypeMapping_ops [] =
   DDS_OP_RTS,
 
   /* MinimalAnnotationParameter */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalAnnotationParameter, common), (3u << 16u) + 65144u /* CommonAnnotationParameter */,
   DDS_OP_ADR | DDS_OP_TYPE_ARR | DDS_OP_SUBTYPE_1BY, offsetof (DDS_XTypes_MinimalAnnotationParameter, name_hash), 4u,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalAnnotationParameter, default_value), (3u << 16u) + 65000u /* AnnotationParameterValue */,
@@ -495,7 +495,7 @@ static const uint32_t DDS_XTypes_TypeMapping_ops [] =
   DDS_OP_RTS,
 
   /* MinimalStructHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalStructHeader, base_type), (3u << 16u) + 64684u /* TypeIdentifier */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, 0u, (3u << 16u) + 4u /* MinimalTypeDetail */,
   DDS_OP_RTS,
@@ -504,7 +504,7 @@ static const uint32_t DDS_XTypes_TypeMapping_ops [] =
   DDS_OP_RTS,
 
   /* MinimalStructMember */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalStructMember, common), (3u << 16u) + 65148u /* CommonStructMember */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalStructMember, detail), (3u << 16u) + 4u /* MinimalMemberDetail */,
   DDS_OP_RTS,
@@ -521,23 +521,23 @@ static const uint32_t DDS_XTypes_TypeMapping_ops [] =
   DDS_OP_RTS,
 
   /* MinimalUnionHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, 0u, (3u << 16u) + 65507u /* MinimalTypeDetail */,
   DDS_OP_RTS,
 
   /* MinimalDiscriminatorMember */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalDiscriminatorMember, common), (3u << 16u) + 65171u /* CommonDiscriminatorMember */,
   DDS_OP_RTS,
 
   /* MinimalUnionMember */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalUnionMember, common), (3u << 16u) + 65182u /* CommonUnionMember */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalUnionMember, detail), (3u << 16u) + 65503u /* MinimalMemberDetail */,
   DDS_OP_RTS,
 
   /* MinimalBitsetType */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 5,
   DDS_OP_ADR | DDS_OP_TYPE_BMK | (1 << DDS_OP_FLAG_SZ_SHIFT), offsetof (DDS_XTypes_MinimalBitsetType, bitset_flags), 0u, 31u,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, 0u, (3u << 16u) + 8u /* MinimalBitsetHeader */,
   DDS_OP_ADR | DDS_OP_TYPE_SEQ | DDS_OP_SUBTYPE_STU, offsetof (DDS_XTypes_MinimalBitsetType, field_seq), sizeof (DDS_XTypes_MinimalBitfield), (4u << 16u) + 7u /* MinimalBitfield */,
@@ -548,7 +548,7 @@ static const uint32_t DDS_XTypes_TypeMapping_ops [] =
   DDS_OP_RTS,
 
   /* MinimalBitfield */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalBitfield, common), (3u << 16u) + 65197u /* CommonBitfield */,
   DDS_OP_ADR | DDS_OP_TYPE_ARR | DDS_OP_SUBTYPE_1BY, offsetof (DDS_XTypes_MinimalBitfield, name_hash), 4u,
   DDS_OP_RTS,
@@ -560,12 +560,12 @@ static const uint32_t DDS_XTypes_TypeMapping_ops [] =
   DDS_OP_RTS,
 
   /* MinimalCollectionHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalCollectionHeader, common), (3u << 16u) + 65209u /* CommonCollectionHeader */,
   DDS_OP_RTS,
 
   /* MinimalCollectionElement */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalCollectionElement, common), (3u << 16u) + 65215u /* CommonCollectionElement */,
   DDS_OP_RTS,
 
@@ -576,7 +576,7 @@ static const uint32_t DDS_XTypes_TypeMapping_ops [] =
   DDS_OP_RTS,
 
   /* MinimalArrayHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalArrayHeader, common), (3u << 16u) + 65236u /* CommonArrayHeader */,
   DDS_OP_RTS,
 
@@ -594,25 +594,25 @@ static const uint32_t DDS_XTypes_TypeMapping_ops [] =
   DDS_OP_RTS,
 
   /* MinimalEnumeratedHeader */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalEnumeratedHeader, common), (3u << 16u) + 65242u /* CommonEnumeratedHeader */,
   DDS_OP_RTS,
 
   /* MinimalEnumeratedLiteral */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalEnumeratedLiteral, common), (3u << 16u) + 65248u /* CommonEnumeratedLiteral */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalEnumeratedLiteral, detail), (3u << 16u) + 65404u /* MinimalMemberDetail */,
   DDS_OP_RTS,
 
   /* MinimalBitmaskType */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 5,
   DDS_OP_ADR | DDS_OP_TYPE_BMK | (1 << DDS_OP_FLAG_SZ_SHIFT), offsetof (DDS_XTypes_MinimalBitmaskType, bitmask_flags), 0u, 31u,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalBitmaskType, header), (3u << 16u) + 65518u /* MinimalEnumeratedHeader */,
   DDS_OP_ADR | DDS_OP_TYPE_SEQ | DDS_OP_SUBTYPE_STU, offsetof (DDS_XTypes_MinimalBitmaskType, flag_seq), sizeof (DDS_XTypes_MinimalBitflag), (4u << 16u) + 5u /* MinimalBitflag */,
   DDS_OP_RTS,
 
   /* MinimalBitflag */
-  DDS_OP_DLC,
+  DDS_OP_DLC | 4,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalBitflag, common), (3u << 16u) + 65256u /* CommonBitflag */,
   DDS_OP_ADR | DDS_OP_TYPE_EXT, offsetof (DDS_XTypes_MinimalBitflag, detail), (3u << 16u) + 65383u /* MinimalMemberDetail */,
   DDS_OP_RTS,

--- a/src/core/xtests/symbol_export/symbol_export.c
+++ b/src/core/xtests/symbol_export/symbol_export.c
@@ -503,7 +503,6 @@ int main (int argc, char **argv)
   dds_lookup_statistic (ptr, ptr);
 
   // dds_cdrstream.h
-  bool ret_cdrs;
   dds_istream_init_well_formed (ptr, 0, ptr2, 0);
   dds_istream_init (ptr, 0, ptr2, 0);
   dds_istream_fini (ptr);
@@ -514,10 +513,11 @@ int main (int argc, char **argv)
   dds_ostreamBE_init (ptr, ptr2, 0, 0);
   dds_ostreamBE_fini (ptr, ptr2);
 
-  ret_cdrs = dds_stream_normalize (ptr, 0, 0, 0, ptr2, 0, ptr3);
-  (void) ret_cdrs;
+  (void) dds_stream_normalize (ptr, 0, 0, 0, ptr2, 0, ptr3);
+  (void) dds_stream_normalize_with_flags (ptr, 0, 0, 0, ptr2, 0, 0, ptr3);
   (void) dds_stream_normalize_xcdr2_data (ptr, ptr2, 0, 0, ptr3);
   (void) dds_stream_normalize_to_istream (ptr, ptr2, 0, 0, 0, ptr3, 0, ptr4);
+  (void) dds_stream_normalize_to_istream_with_flags (ptr, ptr2, 0, 0, 0, ptr3, 0, 0, ptr4);
   (void) dds_stream_normalize_xcdr2_data_to_istream (ptr, ptr2, ptr3, 0, 0, ptr4);
 
   dds_stream_write (ptr, ptr2, ptr3, ptr4);

--- a/src/idl/src/annotation.c
+++ b/src/idl/src/annotation.c
@@ -356,10 +356,6 @@ annotate_key(
         idl_error(pstate, idl_location(annotation_appl),
           "@key cannot be set to true on optional members");
         return IDL_RETCODE_SEMANTIC_ERROR;
-      } else if (mem->must_understand.annotation && !mem->must_understand.value) {
-        idl_error(pstate, idl_location(annotation_appl),
-          "@key cannot be set to true on members with must_understand set to false");
-        return IDL_RETCODE_SEMANTIC_ERROR;
       }
     }
     mem->key.annotation = annotation_appl;
@@ -505,10 +501,6 @@ annotate_must_understand(
   if (!idl_is_member(node)) {
     idl_error(pstate, idl_location(annotation_appl),
       "@must_understand can only be assigned to members");
-    return IDL_RETCODE_SEMANTIC_ERROR;
-  }else if (!must_understand && mem->key.value) {
-    idl_error(pstate, idl_location(annotation_appl),
-      "@must_understand can not be set to false on key members");
     return IDL_RETCODE_SEMANTIC_ERROR;
   }
 

--- a/src/idl/src/descriptor_type_meta.c
+++ b/src/idl/src/descriptor_type_meta.c
@@ -488,15 +488,7 @@ get_struct_member_flags(const idl_member_t *member)
     flags |= DDS_XTypes_IS_KEY;
   if (member->optional.value)
     flags |= DDS_XTypes_IS_OPTIONAL;
-  // XTypes spec 7.2.2.4.4.4.8: Key members shall always have their 'must understand' attribute set to true
-  //
-  // but ... this is not how all implementors read it, and RTI can't deal with 'must understand' on incoming
-  // mutable data where it didn't expect it ... and so while this should read
-  //
-  //   member->must_understand.value || member->key.value
-  //
-  // we have to leave out the key part.  This allows for some abuse in the absence of type discovery, but
-  // not much worse than there would be anyway.
+  // Key and must-understand are independent member flags.
   if (member->must_understand.value)
     flags |= DDS_XTypes_IS_MUST_UNDERSTAND;
   return flags;

--- a/src/idl/src/processor.c
+++ b/src/idl/src/processor.c
@@ -374,36 +374,6 @@ static idl_retcode_t validate_forwards(idl_pstate_t *pstate, void *root)
   return IDL_RETCODE_OK;
 }
 
-static idl_retcode_t validate_must_understand(idl_pstate_t *pstate, void *root)
-{
-  for (void *node = root; node; node = idl_next(node))
-  {
-    if (idl_mask(node) == IDL_MODULE) {
-      idl_retcode_t ret;
-      if ((ret = validate_must_understand(pstate, ((idl_module_t *)node)->definitions)))
-        return ret;
-    } else if (idl_mask(node) == IDL_STRUCT) {
-      idl_member_t *member;
-      IDL_FOREACH(member, ((idl_struct_t *)node)->members) {
-        /* Because the delimited-CDR data representation does not have a flag for
-        must understand defined in the XTypes specification, the reader has no means to find
-        out if, in case data is received after the data for members that are known to the reader,
-        the additional members have the must-understand flag set (and the sample should be
-        discarded). Note that this only applies to optional must-understand members, because
-        non-optional must-understand members should exist in both types for the the types
-        to be assignable. For this reason, using the @must_understand annotation on appendable
-        types is currently not supported.  */
-        if (idl_is_must_understand(&member->node) && !idl_is_extensible(node, IDL_MUTABLE)) {
-          idl_error(pstate, idl_location(member),
-            "@must_understand can only be set to true on members of a mutable type");
-          return IDL_RETCODE_SEMANTIC_ERROR;
-        }
-      }
-    }
-  }
-  return IDL_RETCODE_OK;
-}
-
 static idl_retcode_t
 check_bitbound(
   const idl_pstate_t *pstate,
@@ -588,8 +558,6 @@ grammar:
   if ((ret = set_type_extensibility(pstate)) != IDL_RETCODE_OK)
     goto err;
   if ((ret = validate_forwards(pstate, pstate->root)))
-    goto err;
-  if ((ret = validate_must_understand(pstate, pstate->root)))
     goto err;
   if ((ret = validate_bitbound(pstate)))
     goto err;

--- a/src/idl/tests/annotation.c
+++ b/src/idl/tests/annotation.c
@@ -318,7 +318,7 @@ CU_Test(idl_annotation, key)
      "};", IDL_RETCODE_SEMANTIC_ERROR, {false}, {false}},
     {"@mutable struct s {\n"
      "  @must_understand(FALSE) @key char c;\n"
-     "};", IDL_RETCODE_SEMANTIC_ERROR, {false}, {false}},
+     "};", IDL_RETCODE_OK, {true}, {true}},
     {"struct s {\n"
      "  @optional @key char c;\n"
      "};", IDL_RETCODE_SEMANTIC_ERROR, {false}, {false}},
@@ -1182,11 +1182,12 @@ CU_Test(idl_annotation, must_understand)
 {
   mu_test_t tests[] = {
     {"@mutable struct s { char c; @must_understand char d; @must_understand(false) char e; @key @must_understand(true) char f; };", IDL_RETCODE_OK, {false, true, false, true}, {false, true, true, true} },
-    {"@final struct s { @must_understand char c;  };", IDL_RETCODE_SEMANTIC_ERROR, {false}, {false} },
+    {"@final struct s { @must_understand char c;  };", IDL_RETCODE_OK, {true}, {true} },
     {"@final struct s { @must_understand(false) char c;  };", IDL_RETCODE_OK, {false}, {true} },
-    {"@appendable struct s { @must_understand char c;  };", IDL_RETCODE_SEMANTIC_ERROR, {false}, {false} },
+    {"@appendable struct s { @must_understand char c;  };", IDL_RETCODE_OK, {true}, {true} },
     {"@appendable struct s { @must_understand(false) char c;  };", IDL_RETCODE_OK, {false}, {true} },
-    {"struct s { @key @must_understand(false) char c;  };", IDL_RETCODE_SEMANTIC_ERROR, {false}, {false} },
+    {"struct s { @key @must_understand(false) char c;  };", IDL_RETCODE_OK, {false}, {true} },
+    {"struct s { @must_understand(false) @key char c;  };", IDL_RETCODE_OK, {false}, {true} },
     {"@must_understand struct s { char b; char c; };", IDL_RETCODE_SEMANTIC_ERROR, {false}, {false} },
     {"@must_understand module m { struct s { char b; char c; }; }; ", IDL_RETCODE_SEMANTIC_ERROR, {false}, {false} },
     {"union u switch(long) { case 0: @must_understand char c; default: string s; };", IDL_RETCODE_SEMANTIC_ERROR, {false}, {false} },

--- a/src/tools/dyntypelib/disassemble.c
+++ b/src/tools/dyntypelib/disassemble.c
@@ -451,9 +451,14 @@ static void print_decoded_op (const uint32_t *ops, uint32_t nops, uint32_t idx, 
   switch (op)
   {
     case DDS_SOP_RTS:
-    case DDS_SOP_DLC:
     case DDS_SOP_PLC:
       break;
+    case DDS_SOP_DLC: {
+      const uint16_t required_prefix = DDS_OP_DLC_REQUIRED_PREFIX (insn);
+      if (required_prefix != 0)
+        printf (" required-prefix=%"PRIu16, required_prefix);
+      break;
+    }
     case DDS_SOP_ADR:
       print_adr (ops, idx);
       break;

--- a/src/tools/idlc/src/libidlc/libidlc__descriptor.c
+++ b/src/tools/idlc/src/libidlc/libidlc__descriptor.c
@@ -738,6 +738,201 @@ find_ctype(const struct descriptor *descriptor, const void *node)
   return ctype;
 }
 
+static idl_retcode_t set_ctype_dlc_required_prefix (const struct descriptor *descriptor, struct constructed_type *ctype);
+
+static uint32_t
+instruction_high_arg (const struct instruction *inst)
+{
+  switch (inst->type) {
+    case COUPLE:
+      return inst->data.couple.high;
+    case ELEM_OFFSET:
+      return inst->data.inst_offset.inst.high;
+    default:
+      abort ();
+  }
+}
+
+static uint32_t
+skip_sequence_instructions (const struct instructions *instructions, uint32_t offs)
+{
+  const uint32_t insn = instructions->table[offs].data.opcode.code;
+  const uint32_t bound_op = DDS_OP_TYPE (insn) == DDS_SOP_VAL_BSQ ? 1 : 0;
+  switch (DDS_OP_SUBTYPE (insn))
+  {
+    case DDS_SOP_VAL_BLN: case DDS_SOP_VAL_1BY: case DDS_SOP_VAL_2BY: case DDS_SOP_VAL_4BY: case DDS_SOP_VAL_8BY:
+    case DDS_SOP_VAL_STR: case DDS_SOP_VAL_WSTR: case DDS_SOP_VAL_WCHAR: case DDS_SOP_VAL_16BY:
+      return offs + 2 + bound_op;
+    case DDS_SOP_VAL_BST: case DDS_SOP_VAL_BWSTR: case DDS_SOP_VAL_ENU:
+      return offs + 3 + bound_op;
+    case DDS_SOP_VAL_BMK:
+      return offs + 4 + bound_op;
+    case DDS_SOP_VAL_SEQ: case DDS_SOP_VAL_BSQ: case DDS_SOP_VAL_ARR: case DDS_SOP_VAL_UNI: case DDS_SOP_VAL_STU: {
+      const uint32_t jmp = instruction_high_arg (&instructions->table[offs + 3 + bound_op]);
+      return offs + (jmp ? jmp : 4 + bound_op);
+    }
+    case DDS_SOP_VAL_EXT:
+      abort ();
+      break;
+  }
+  return 0;
+}
+
+static uint32_t
+skip_array_instructions (const struct instructions *instructions, uint32_t offs)
+{
+  const uint32_t insn = instructions->table[offs].data.opcode.code;
+  assert (DDS_OP_TYPE (insn) == DDS_SOP_VAL_ARR);
+  switch (DDS_OP_SUBTYPE (insn))
+  {
+    case DDS_SOP_VAL_BLN: case DDS_SOP_VAL_1BY: case DDS_SOP_VAL_2BY: case DDS_SOP_VAL_4BY: case DDS_SOP_VAL_8BY:
+    case DDS_SOP_VAL_STR: case DDS_SOP_VAL_WSTR: case DDS_SOP_VAL_WCHAR: case DDS_SOP_VAL_16BY:
+      return offs + 3;
+    case DDS_SOP_VAL_ENU:
+      return offs + 4;
+    case DDS_SOP_VAL_BST: case DDS_SOP_VAL_BWSTR: case DDS_SOP_VAL_BMK:
+      return offs + 5;
+    case DDS_SOP_VAL_SEQ: case DDS_SOP_VAL_BSQ: case DDS_SOP_VAL_ARR: case DDS_SOP_VAL_UNI: case DDS_SOP_VAL_STU: {
+      const uint32_t jmp = instruction_high_arg (&instructions->table[offs + 3]);
+      return offs + (jmp ? jmp : 5);
+    }
+    case DDS_SOP_VAL_EXT:
+      abort ();
+      break;
+  }
+  return 0;
+}
+
+static uint32_t
+skip_adr_instructions (const struct instructions *instructions, uint32_t offs)
+{
+  const uint32_t insn = instructions->table[offs].data.opcode.code;
+  assert (DDS_OP (insn) == DDS_OP_ADR);
+  switch (DDS_OP_TYPE (insn))
+  {
+    case DDS_SOP_VAL_BLN: case DDS_SOP_VAL_1BY: case DDS_SOP_VAL_2BY: case DDS_SOP_VAL_4BY: case DDS_SOP_VAL_8BY:
+    case DDS_SOP_VAL_STR: case DDS_SOP_VAL_WSTR: case DDS_SOP_VAL_WCHAR: case DDS_SOP_VAL_16BY:
+      return offs + 2;
+    case DDS_SOP_VAL_BST:
+    case DDS_SOP_VAL_BWSTR:
+    case DDS_SOP_VAL_ENU:
+      return offs + 3;
+    case DDS_SOP_VAL_BMK:
+      return offs + 4;
+    case DDS_SOP_VAL_SEQ:
+    case DDS_SOP_VAL_BSQ:
+      return skip_sequence_instructions (instructions, offs);
+    case DDS_SOP_VAL_ARR:
+      return skip_array_instructions (instructions, offs);
+    case DDS_SOP_VAL_UNI: {
+      const uint32_t jmp = instruction_high_arg (&instructions->table[offs + 3]);
+      return offs + (jmp ? jmp : 4);
+    }
+    case DDS_SOP_VAL_EXT: {
+      const uint32_t jmp = instruction_high_arg (&instructions->table[offs + 2]);
+      return offs + (jmp ? jmp : 3);
+    }
+    case DDS_SOP_VAL_STU:
+      abort ();
+      break;
+  }
+  return 0;
+}
+
+static bool
+ctype_dlc_has_required_prefix (const struct constructed_type *ctype)
+{
+  if (ctype->instructions.count == 0 || ctype->instructions.table[0].type != OPCODE)
+    return false;
+  const uint32_t insn = ctype->instructions.table[0].data.opcode.code;
+  return DDS_OP (insn) == DDS_OP_DLC && DDS_OP_DLC_REQUIRED_PREFIX (insn) != 0;
+}
+
+static idl_retcode_t
+appendable_member_is_required (const struct descriptor *descriptor, struct constructed_type *ctype, uint32_t offs, uint32_t insn, bool *required)
+{
+  if ((insn & DDS_OP_FLAG_KEY) || ((insn & DDS_OP_FLAG_MU) && !(insn & DDS_OP_FLAG_OPT)))
+  {
+    *required = true;
+    return IDL_RETCODE_OK;
+  }
+
+  if ((insn & DDS_OP_FLAG_BASE) && DDS_OP_TYPE (insn) == DDS_SOP_VAL_EXT)
+  {
+    assert (ctype->instructions.table[offs + 2].type == ELEM_OFFSET);
+    struct constructed_type *base_ctype = find_ctype (descriptor, ctype->instructions.table[offs + 2].data.inst_offset.node);
+    assert (base_ctype);
+    idl_retcode_t ret;
+    if ((ret = set_ctype_dlc_required_prefix (descriptor, base_ctype)) != IDL_RETCODE_OK)
+      return ret;
+    *required = ctype_dlc_has_required_prefix (base_ctype);
+    return IDL_RETCODE_OK;
+  }
+
+  *required = false;
+  return IDL_RETCODE_OK;
+}
+
+static idl_retcode_t
+set_ctype_dlc_required_prefix (const struct descriptor *descriptor, struct constructed_type *ctype)
+{
+  if (ctype->instructions.count == 0 || ctype->instructions.table[0].type != OPCODE)
+    return IDL_RETCODE_OK;
+
+  struct instruction *dlc = &ctype->instructions.table[0];
+  if (DDS_OP (dlc->data.opcode.code) != DDS_OP_DLC)
+    return IDL_RETCODE_OK;
+
+  bool seen_member = false;
+  uint32_t required_prefix = 0;
+  for (uint32_t offs = 1; offs < ctype->instructions.count; )
+  {
+    struct instruction *inst = &ctype->instructions.table[offs];
+    if (inst->type != OPCODE)
+      abort ();
+
+    const uint32_t insn = inst->data.opcode.code;
+    switch (DDS_OP (insn))
+    {
+      case DDS_SOP_ADR: {
+        const uint32_t next_offs = skip_adr_instructions (&ctype->instructions, offs);
+        bool required;
+        idl_retcode_t ret;
+        if (!seen_member)
+          required = true;
+        else if ((ret = appendable_member_is_required (descriptor, ctype, offs, insn, &required)) != IDL_RETCODE_OK)
+          return ret;
+        if (required)
+          required_prefix = next_offs;
+        seen_member = true;
+        offs = next_offs;
+        break;
+      }
+      case DDS_SOP_JSR:
+        offs++;
+        break;
+      case DDS_SOP_RTS:
+        dlc->data.opcode.code = DDS_OP_DLC | required_prefix;
+        return IDL_RETCODE_OK;
+      case DDS_SOP_JEQ: case DDS_SOP_JEQ4: case DDS_SOP_KOF: case DDS_SOP_DLC: case DDS_SOP_PLC: case DDS_SOP_PLM: case DDS_SOP_MID:
+        abort ();
+        break;
+    }
+  }
+  abort ();
+  return IDL_RETCODE_BAD_PARAMETER;
+}
+
+static idl_retcode_t
+set_dlc_required_prefixes (const struct descriptor *descriptor)
+{
+  idl_retcode_t ret;
+  for (struct constructed_type *ctype = descriptor->constructed_types; ctype; ctype = ctype->next)
+    if ((ret = set_ctype_dlc_required_prefix (descriptor, ctype)) != IDL_RETCODE_OK)
+      return ret;
+  return IDL_RETCODE_OK;
+}
+
 static idl_retcode_t
 add_ctype(struct descriptor *descriptor, const idl_scope_t *scope, const void *node, struct constructed_type **ctype)
 {
@@ -2082,6 +2277,10 @@ static int print_opcode(FILE *fp, const struct instruction *inst)
   switch (opcode) {
     case DDS_OP_DLC:
       vec[len++] = "DDS_OP_DLC";
+      if (DDS_OP_DLC_REQUIRED_PREFIX (inst->data.opcode.code) != 0) {
+        idl_snprintf(buf, sizeof(buf), " | %u", DDS_OP_DLC_REQUIRED_PREFIX (inst->data.opcode.code));
+        vec[len++] = buf;
+      }
       break;
     case DDS_OP_PLC:
       vec[len++] = "DDS_OP_PLC";
@@ -3364,6 +3563,8 @@ generate_descriptor_impl(
     goto err;
   }
   if ((ret = resolve_offsets(descriptor)) < 0)
+    goto err;
+  if ((ret = set_dlc_required_prefixes(descriptor)) < 0)
     goto err;
 
   struct constructed_type_key *ctype_keys;

--- a/src/tools/idlc/tests/descriptor.c
+++ b/src/tools/idlc/tests/descriptor.c
@@ -165,10 +165,11 @@ CU_Test(idlc_descriptor, default_extensibility)
     const bool is_union = idl_is_union (descriptor.constructed_types->node);
     switch (tests[i].exp_ext) {
       case IDL_FINAL:
-        CU_ASSERT_FATAL (instr1 != DDS_OP_DLC && instr1 != DDS_OP_PLC);
+        CU_ASSERT_FATAL (DDS_OP (instr1) != DDS_OP_DLC && DDS_OP (instr1) != DDS_OP_PLC);
         break;
       case IDL_APPENDABLE:
-        CU_ASSERT_EQ_FATAL (instr1, DDS_OP_DLC);
+        CU_ASSERT_EQ_FATAL (DDS_OP (instr1), DDS_OP_DLC);
+        CU_ASSERT_FATAL (DDS_OP_DLC_REQUIRED_PREFIX (instr1) != 0);
         break;
       case IDL_MUTABLE:
         CU_ASSERT_EQ_FATAL (instr1, DDS_OP_PLC);

--- a/src/tools/idlc/xtests/main.c
+++ b/src/tools/idlc/xtests/main.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 #include "dds/ddsrt/endian.h"
 #include "dds/ddsrt/heap.h"
 #include "dds/ddsi/ddsi_serdata.h"
@@ -31,7 +32,7 @@ static void free_sample (void *s)
 static void init_desc (struct dds_cdrstream_desc *cdrstream_desc)
 {
   memset (cdrstream_desc, 0, sizeof (*cdrstream_desc));
-  dds_cdrstream_desc_init_with_nops (cdrstream_desc, &dds_cdrstream_default_allocator, desc->m_size, desc->m_align, desc->m_flagset, desc->m_ops, desc->m_nops, desc->m_keys, desc->m_nkeys);
+  assert (dds_cdrstream_desc_init_with_nops (cdrstream_desc, &dds_cdrstream_default_allocator, desc->m_size, desc->m_align, desc->m_flagset, desc->m_ops, desc->m_nops, desc->m_keys, desc->m_nkeys) == DDS_RETCODE_OK);
 }
 
 static void print_raw_cdr (dds_ostream_t *os)

--- a/src/tools/xmltype/xmltype.c
+++ b/src/tools/xmltype/xmltype.c
@@ -35,7 +35,11 @@ static enum dtl_sample_format output_format = DTL_SAMPLE_FORMAT_JSON;
 static void print_generated_descriptor (const char *role, const dds_topic_descriptor_t *topic_desc)
 {
   struct dds_cdrstream_desc cdr_desc;
-  dds_cdrstream_desc_from_topic_desc (&cdr_desc, topic_desc);
+  if (dds_cdrstream_desc_from_topic_desc (&cdr_desc, topic_desc) != DDS_RETCODE_OK)
+  {
+    fprintf (stderr, "invalid generated descriptor for %s type %s\n", role, topic_desc->m_typename);
+    exit (1);
+  }
   printf ("%s descriptor typename=%s ", role, topic_desc->m_typename);
   dtl_print_cdrstream_descriptor (&cdr_desc);
   dds_cdrstream_desc_fini (&cdr_desc, &dds_cdrstream_default_allocator);


### PR DESCRIPTION
This tightens checking of appendable and mutable XTypes data, especially around required members and the `prevent_type_widening` type consistency setting. The main user-visible effect is that Cyclone DDS now more accurately rejects serialized data that is incomplete for the reader’s type when the type requires those members to be present, while still preserving the normal permissive type-widening behavior where XTypes allows it.

**Changes**

- Enforce required-member presence during normalization for appendable data.
- Enforce required-member presence during normalization for mutable data.
- Treat key members and non-optional `@must_understand` members as required.
- Honor the reader’s `prevent_type_widening` type consistency setting during CDR normalization.
- Preserve permissive behavior for compatible widening when `prevent_type_widening` is not enabled.
- Add descriptor metadata so appendable types record the required prefix of a delimited scope.
- Extend descriptor disassembly so the required-prefix metadata is visible when inspecting generated serializer instructions.
- Add focused XCDR1 and XCDR2 regression tests for appendable, mutable,

Generated type-support descriptors should be regenerated so appendable metadata contains the required-prefix information used by the new validation logic.