### PR TITLE
Default to accepting SPDP received over loopback

### DIFF
--- a/docs/manual/config/config_file_reference.rst
+++ b/docs/manual/config/config_file_reference.rst
@@ -188,7 +188,7 @@ The default value is: ``lax``
 //CycloneDDS/Domain/Discovery
 =============================
 
-Children: :ref:`DSGracePeriod<//CycloneDDS/Domain/Discovery/DSGracePeriod>`, :ref:`DefaultMulticastAddress<//CycloneDDS/Domain/Discovery/DefaultMulticastAddress>`, :ref:`DiscoveredLocatorPruneDelay<//CycloneDDS/Domain/Discovery/DiscoveredLocatorPruneDelay>`, :ref:`EnableTopicDiscoveryEndpoints<//CycloneDDS/Domain/Discovery/EnableTopicDiscoveryEndpoints>`, :ref:`ExternalDomainId<//CycloneDDS/Domain/Discovery/ExternalDomainId>`, :ref:`InitialLocatorPruneDelay<//CycloneDDS/Domain/Discovery/InitialLocatorPruneDelay>`, :ref:`LeaseDuration<//CycloneDDS/Domain/Discovery/LeaseDuration>`, :ref:`MaxAutoParticipantIndex<//CycloneDDS/Domain/Discovery/MaxAutoParticipantIndex>`, :ref:`ParticipantIndex<//CycloneDDS/Domain/Discovery/ParticipantIndex>`, :ref:`Peers<//CycloneDDS/Domain/Discovery/Peers>`, :ref:`Ports<//CycloneDDS/Domain/Discovery/Ports>`, :ref:`SPDPInterval<//CycloneDDS/Domain/Discovery/SPDPInterval>`, :ref:`SPDPMulticastAddress<//CycloneDDS/Domain/Discovery/SPDPMulticastAddress>`, :ref:`Tag<//CycloneDDS/Domain/Discovery/Tag>`
+Children: :ref:`DSGracePeriod<//CycloneDDS/Domain/Discovery/DSGracePeriod>`, :ref:`DefaultMulticastAddress<//CycloneDDS/Domain/Discovery/DefaultMulticastAddress>`, :ref:`DiscoveredLocatorPruneDelay<//CycloneDDS/Domain/Discovery/DiscoveredLocatorPruneDelay>`, :ref:`EnableTopicDiscoveryEndpoints<//CycloneDDS/Domain/Discovery/EnableTopicDiscoveryEndpoints>`, :ref:`ExternalDomainId<//CycloneDDS/Domain/Discovery/ExternalDomainId>`, :ref:`InitialLocatorPruneDelay<//CycloneDDS/Domain/Discovery/InitialLocatorPruneDelay>`, :ref:`InterfaceFiltering<//CycloneDDS/Domain/Discovery/InterfaceFiltering>`, :ref:`LeaseDuration<//CycloneDDS/Domain/Discovery/LeaseDuration>`, :ref:`MaxAutoParticipantIndex<//CycloneDDS/Domain/Discovery/MaxAutoParticipantIndex>`, :ref:`ParticipantIndex<//CycloneDDS/Domain/Discovery/ParticipantIndex>`, :ref:`Peers<//CycloneDDS/Domain/Discovery/Peers>`, :ref:`Ports<//CycloneDDS/Domain/Discovery/Ports>`, :ref:`SPDPInterval<//CycloneDDS/Domain/Discovery/SPDPInterval>`, :ref:`SPDPMulticastAddress<//CycloneDDS/Domain/Discovery/SPDPMulticastAddress>`, :ref:`Tag<//CycloneDDS/Domain/Discovery/Tag>`
 
 The Discovery element allows you to specify various parameters related to the discovery of peers.
 
@@ -269,6 +269,27 @@ This element specifies the default time for configured peer locators are initial
 Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.
 
 The default value is: ``30s``
+
+
+.. _`//CycloneDDS/Domain/Discovery/InterfaceFiltering`:
+
+//CycloneDDS/Domain/Discovery/InterfaceFiltering
+------------------------------------------------
+
+One of: off, strict, normal
+
+This element decides how strictly the participant discovery filters 
+on reception interface (requires extended packet info to be enabled, see 
+Internal/ExtendedPacketInfo:
+ * off: no filtering
+
+ * normal: only the configured interfaces and loopback
+
+ * strict: only the configured interfaces
+
+
+
+The default value is: ``normal``
 
 
 .. _`//CycloneDDS/Domain/Discovery/LeaseDuration`:
@@ -2997,14 +3018,14 @@ The categorisation of tracing output is incomplete and hence most of the verbosi
 The default value is: ``none``
 
 ..
-   generated from ddsi_config.h[296c449e5f567df1dad1ac3d0db7c8f079ee9cc3]
-   generated from ddsi_config.c[898d7e396b2d99b164e14562b1fa6c33910f2cc7]
-   generated from ddsi__cfgelems.h[0224b00c31124b7d7148a6cb4bf179561fbba4e7]
+   generated from ddsi_config.h[f91973dc418c2652cde7f01c7f643d93abe523b9]
+   generated from ddsi_config.c[7da74c5d75c9ed5b87f7260a8dc487f57b34eba2]
+   generated from ddsi__cfgelems.h[e6bc98ae723fac5cfac16b3793ae64c655e7a90f]
    generated from cfgunits.h[05f093223fce107d24dd157ebaafa351dc9df752]
-   generated from _confgen.h[bb9a0fc6ef1f7f7c46790ee00132e340e5fff36d]
+   generated from _confgen.h[e0b7a072621df43c0e7419d52359ddf4b98b202f]
    generated from _confgen.c[500178f92fc0791a8de2234cea5b277820e6b40b]
    generated from generate_rnc.c[b50e4b7ab1d04b2bc1d361a0811247c337b74934]
    generated from generate_md.c[789b92e422631684352909cfb8bf43f6ceb16a01]
    generated from generate_rst.c[3c4b523fbb57c8e4a7e247379d06a8021ccc21c4]
    generated from generate_xsd.c[9bb91084fff7495aee9c025db3108549a0141957]
-   generated from generate_defconfig.c[02afff6935d72b7f04dc64c8a649b09f9f6143ac]
+   generated from generate_defconfig.c[ab6586fcd43cc01814507db687575914686943dc]

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -119,7 +119,7 @@ The default value is: `lax`
 
 
 ### //CycloneDDS/Domain/Discovery
-Children: [DSGracePeriod](#cycloneddsdomaindiscoverydsgraceperiod), [DefaultMulticastAddress](#cycloneddsdomaindiscoverydefaultmulticastaddress), [DiscoveredLocatorPruneDelay](#cycloneddsdomaindiscoverydiscoveredlocatorprunedelay), [EnableTopicDiscoveryEndpoints](#cycloneddsdomaindiscoveryenabletopicdiscoveryendpoints), [ExternalDomainId](#cycloneddsdomaindiscoveryexternaldomainid), [InitialLocatorPruneDelay](#cycloneddsdomaindiscoveryinitiallocatorprunedelay), [LeaseDuration](#cycloneddsdomaindiscoveryleaseduration), [MaxAutoParticipantIndex](#cycloneddsdomaindiscoverymaxautoparticipantindex), [ParticipantIndex](#cycloneddsdomaindiscoveryparticipantindex), [Peers](#cycloneddsdomaindiscoverypeers), [Ports](#cycloneddsdomaindiscoveryports), [SPDPInterval](#cycloneddsdomaindiscoveryspdpinterval), [SPDPMulticastAddress](#cycloneddsdomaindiscoveryspdpmulticastaddress), [Tag](#cycloneddsdomaindiscoverytag)
+Children: [DSGracePeriod](#cycloneddsdomaindiscoverydsgraceperiod), [DefaultMulticastAddress](#cycloneddsdomaindiscoverydefaultmulticastaddress), [DiscoveredLocatorPruneDelay](#cycloneddsdomaindiscoverydiscoveredlocatorprunedelay), [EnableTopicDiscoveryEndpoints](#cycloneddsdomaindiscoveryenabletopicdiscoveryendpoints), [ExternalDomainId](#cycloneddsdomaindiscoveryexternaldomainid), [InitialLocatorPruneDelay](#cycloneddsdomaindiscoveryinitiallocatorprunedelay), [InterfaceFiltering](#cycloneddsdomaindiscoveryinterfacefiltering), [LeaseDuration](#cycloneddsdomaindiscoveryleaseduration), [MaxAutoParticipantIndex](#cycloneddsdomaindiscoverymaxautoparticipantindex), [ParticipantIndex](#cycloneddsdomaindiscoveryparticipantindex), [Peers](#cycloneddsdomaindiscoverypeers), [Ports](#cycloneddsdomaindiscoveryports), [SPDPInterval](#cycloneddsdomaindiscoveryspdpinterval), [SPDPMulticastAddress](#cycloneddsdomaindiscoveryspdpmulticastaddress), [Tag](#cycloneddsdomaindiscoverytag)
 
 The Discovery element allows you to specify various parameters related to the discovery of peers.
 
@@ -176,6 +176,22 @@ This element specifies the default time for configured peer locators are initial
 Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.
 
 The default value is: `30s`
+
+
+#### //CycloneDDS/Domain/Discovery/InterfaceFiltering
+One of: off, strict, normal
+
+This element decides how strictly the participant discovery filters 
+on reception interface (requires extended packet info to be enabled, see 
+Internal/ExtendedPacketInfo:
+ * off: no filtering
+
+ * normal: only the configured interfaces and loopback
+
+ * strict: only the configured interfaces
+
+
+The default value is: `normal`
 
 
 #### //CycloneDDS/Domain/Discovery/LeaseDuration
@@ -2095,14 +2111,14 @@ While none prevents any message from being written to a DDSI2 log file.
 The categorisation of tracing output is incomplete and hence most of the verbosity levels and categories are not of much use in the current release. This is an ongoing process and here we describe the target situation rather than the current situation. Currently, the most useful verbosity levels are config, fine and finest.
 
 The default value is: `none`
-<!--- generated from ddsi_config.h[296c449e5f567df1dad1ac3d0db7c8f079ee9cc3] -->
-<!--- generated from ddsi_config.c[898d7e396b2d99b164e14562b1fa6c33910f2cc7] -->
-<!--- generated from ddsi__cfgelems.h[0224b00c31124b7d7148a6cb4bf179561fbba4e7] -->
+<!--- generated from ddsi_config.h[f91973dc418c2652cde7f01c7f643d93abe523b9] -->
+<!--- generated from ddsi_config.c[7da74c5d75c9ed5b87f7260a8dc487f57b34eba2] -->
+<!--- generated from ddsi__cfgelems.h[e6bc98ae723fac5cfac16b3793ae64c655e7a90f] -->
 <!--- generated from cfgunits.h[05f093223fce107d24dd157ebaafa351dc9df752] -->
-<!--- generated from _confgen.h[bb9a0fc6ef1f7f7c46790ee00132e340e5fff36d] -->
+<!--- generated from _confgen.h[e0b7a072621df43c0e7419d52359ddf4b98b202f] -->
 <!--- generated from _confgen.c[500178f92fc0791a8de2234cea5b277820e6b40b] -->
 <!--- generated from generate_rnc.c[b50e4b7ab1d04b2bc1d361a0811247c337b74934] -->
 <!--- generated from generate_md.c[789b92e422631684352909cfb8bf43f6ceb16a01] -->
 <!--- generated from generate_rst.c[3c4b523fbb57c8e4a7e247379d06a8021ccc21c4] -->
 <!--- generated from generate_xsd.c[9bb91084fff7495aee9c025db3108549a0141957] -->
-<!--- generated from generate_defconfig.c[02afff6935d72b7f04dc64c8a649b09f9f6143ac] -->
+<!--- generated from generate_defconfig.c[ab6586fcd43cc01814507db687575914686943dc] -->

--- a/etc/cyclonedds.rnc
+++ b/etc/cyclonedds.rnc
@@ -126,6 +126,18 @@ CycloneDDS configuration""" ] ]
           duration_inf
         }?
         & [ a:documentation [ xml:lang="en" """
+<p>This element decides how strictly the participant discovery filters 
+on reception interface (requires extended packet info to be enabled, see 
+Internal/ExtendedPacketInfo:</p>
+<ul><li><i>off</i>: no filtering</li>
+<li><i>normal</i>: only the configured interfaces and loopback</li>
+<li><i>strict</i>: only the configured interfaces</li></ul>
+
+<p>The default value is: <code>normal</code></p>""" ] ]
+        element InterfaceFiltering {
+          ("off"|"strict"|"normal")
+        }?
+        & [ a:documentation [ xml:lang="en" """
 <p>This setting controls the default participant lease duration.<p>
 <p>The unit must be specified explicitly. Recognised units: ns, us, ms, s, min, hr, day.</p>
 <p>The default value is: <code>10 s</code></p>""" ] ]
@@ -1458,14 +1470,14 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==<br>
   memsize = xsd:token { pattern = "0|(\d+(\.\d*)?([Ee][\-+]?\d+)?|\.\d+([Ee][\-+]?\d+)?) *([kMG]i?)?B" }
   maybe_memsize = xsd:token { pattern = "default|0|(\d+(\.\d*)?([Ee][\-+]?\d+)?|\.\d+([Ee][\-+]?\d+)?) *([kMG]i?)?B" }
 }
-# generated from ddsi_config.h[296c449e5f567df1dad1ac3d0db7c8f079ee9cc3]
-# generated from ddsi_config.c[898d7e396b2d99b164e14562b1fa6c33910f2cc7]
-# generated from ddsi__cfgelems.h[0224b00c31124b7d7148a6cb4bf179561fbba4e7]
+# generated from ddsi_config.h[f91973dc418c2652cde7f01c7f643d93abe523b9]
+# generated from ddsi_config.c[7da74c5d75c9ed5b87f7260a8dc487f57b34eba2]
+# generated from ddsi__cfgelems.h[e6bc98ae723fac5cfac16b3793ae64c655e7a90f]
 # generated from cfgunits.h[05f093223fce107d24dd157ebaafa351dc9df752]
-# generated from _confgen.h[bb9a0fc6ef1f7f7c46790ee00132e340e5fff36d]
+# generated from _confgen.h[e0b7a072621df43c0e7419d52359ddf4b98b202f]
 # generated from _confgen.c[500178f92fc0791a8de2234cea5b277820e6b40b]
 # generated from generate_rnc.c[b50e4b7ab1d04b2bc1d361a0811247c337b74934]
 # generated from generate_md.c[789b92e422631684352909cfb8bf43f6ceb16a01]
 # generated from generate_rst.c[3c4b523fbb57c8e4a7e247379d06a8021ccc21c4]
 # generated from generate_xsd.c[9bb91084fff7495aee9c025db3108549a0141957]
-# generated from generate_defconfig.c[02afff6935d72b7f04dc64c8a649b09f9f6143ac]
+# generated from generate_defconfig.c[ab6586fcd43cc01814507db687575914686943dc]

--- a/etc/cyclonedds.xsd
+++ b/etc/cyclonedds.xsd
@@ -164,6 +164,7 @@ CycloneDDS configuration</xs:documentation>
         <xs:element minOccurs="0" ref="config:EnableTopicDiscoveryEndpoints"/>
         <xs:element minOccurs="0" ref="config:ExternalDomainId"/>
         <xs:element minOccurs="0" ref="config:InitialLocatorPruneDelay"/>
+        <xs:element minOccurs="0" ref="config:InterfaceFiltering"/>
         <xs:element minOccurs="0" ref="config:LeaseDuration"/>
         <xs:element minOccurs="0" ref="config:MaxAutoParticipantIndex"/>
         <xs:element minOccurs="0" ref="config:ParticipantIndex"/>
@@ -219,6 +220,26 @@ CycloneDDS configuration</xs:documentation>
 &lt;p&gt;Valid values are finite durations with an explicit unit or the keyword 'inf' for infinity. Recognised units: ns, us, ms, s, min, hr, day.&lt;/p&gt;
 &lt;p&gt;The default value is: &lt;code&gt;30s&lt;/code&gt;&lt;/p&gt;</xs:documentation>
     </xs:annotation>
+  </xs:element>
+  <xs:element name="InterfaceFiltering">
+    <xs:annotation>
+      <xs:documentation>
+&lt;p&gt;This element decides how strictly the participant discovery filters 
+on reception interface (requires extended packet info to be enabled, see 
+Internal/ExtendedPacketInfo:&lt;/p&gt;
+&lt;ul&gt;&lt;li&gt;&lt;i&gt;off&lt;/i&gt;: no filtering&lt;/li&gt;
+&lt;li&gt;&lt;i&gt;normal&lt;/i&gt;: only the configured interfaces and loopback&lt;/li&gt;
+&lt;li&gt;&lt;i&gt;strict&lt;/i&gt;: only the configured interfaces&lt;/li&gt;&lt;/ul&gt;
+
+&lt;p&gt;The default value is: &lt;code&gt;normal&lt;/code&gt;&lt;/p&gt;</xs:documentation>
+    </xs:annotation>
+    <xs:simpleType>
+      <xs:restriction base="xs:token">
+        <xs:enumeration value="off"/>
+        <xs:enumeration value="strict"/>
+        <xs:enumeration value="normal"/>
+      </xs:restriction>
+    </xs:simpleType>
   </xs:element>
   <xs:element name="LeaseDuration" type="config:duration">
     <xs:annotation>
@@ -2137,14 +2158,14 @@ MIIEpAIBAAKCAQEA3HIh...AOBaaqSV37XBUJg==&lt;br&gt;
     </xs:restriction>
   </xs:simpleType>
 </xs:schema>
-<!--- generated from ddsi_config.h[296c449e5f567df1dad1ac3d0db7c8f079ee9cc3] -->
-<!--- generated from ddsi_config.c[898d7e396b2d99b164e14562b1fa6c33910f2cc7] -->
-<!--- generated from ddsi__cfgelems.h[0224b00c31124b7d7148a6cb4bf179561fbba4e7] -->
+<!--- generated from ddsi_config.h[f91973dc418c2652cde7f01c7f643d93abe523b9] -->
+<!--- generated from ddsi_config.c[7da74c5d75c9ed5b87f7260a8dc487f57b34eba2] -->
+<!--- generated from ddsi__cfgelems.h[e6bc98ae723fac5cfac16b3793ae64c655e7a90f] -->
 <!--- generated from cfgunits.h[05f093223fce107d24dd157ebaafa351dc9df752] -->
-<!--- generated from _confgen.h[bb9a0fc6ef1f7f7c46790ee00132e340e5fff36d] -->
+<!--- generated from _confgen.h[e0b7a072621df43c0e7419d52359ddf4b98b202f] -->
 <!--- generated from _confgen.c[500178f92fc0791a8de2234cea5b277820e6b40b] -->
 <!--- generated from generate_rnc.c[b50e4b7ab1d04b2bc1d361a0811247c337b74934] -->
 <!--- generated from generate_md.c[789b92e422631684352909cfb8bf43f6ceb16a01] -->
 <!--- generated from generate_rst.c[3c4b523fbb57c8e4a7e247379d06a8021ccc21c4] -->
 <!--- generated from generate_xsd.c[9bb91084fff7495aee9c025db3108549a0141957] -->
-<!--- generated from generate_defconfig.c[02afff6935d72b7f04dc64c8a649b09f9f6143ac] -->
+<!--- generated from generate_defconfig.c[ab6586fcd43cc01814507db687575914686943dc] -->

--- a/src/core/ddsi/defconfig.c
+++ b/src/core/ddsi/defconfig.c
@@ -53,6 +53,7 @@ void ddsi_config_init_default (struct ddsi_config *cfg)
 #ifdef DDS_HAS_TOPIC_DISCOVERY
 #endif /* DDS_HAS_TOPIC_DISCOVERY */
   cfg->lease_duration = INT64_C (10000000000);
+  cfg->interface_filtering = INT32_C (1);
   cfg->tracefile = "cyclonedds.log";
   cfg->pcap_file = "";
   cfg->delivery_queue_maxsamples = UINT32_C (256);
@@ -108,14 +109,14 @@ void ddsi_config_init_default (struct ddsi_config *cfg)
   cfg->ssl_min_version.minor = 3;
 #endif /* DDS_HAS_TCP_TLS */
 }
-/* generated from ddsi_config.h[296c449e5f567df1dad1ac3d0db7c8f079ee9cc3] */
-/* generated from ddsi_config.c[898d7e396b2d99b164e14562b1fa6c33910f2cc7] */
-/* generated from ddsi__cfgelems.h[0224b00c31124b7d7148a6cb4bf179561fbba4e7] */
+/* generated from ddsi_config.h[f91973dc418c2652cde7f01c7f643d93abe523b9] */
+/* generated from ddsi_config.c[7da74c5d75c9ed5b87f7260a8dc487f57b34eba2] */
+/* generated from ddsi__cfgelems.h[e6bc98ae723fac5cfac16b3793ae64c655e7a90f] */
 /* generated from cfgunits.h[05f093223fce107d24dd157ebaafa351dc9df752] */
-/* generated from _confgen.h[bb9a0fc6ef1f7f7c46790ee00132e340e5fff36d] */
+/* generated from _confgen.h[e0b7a072621df43c0e7419d52359ddf4b98b202f] */
 /* generated from _confgen.c[500178f92fc0791a8de2234cea5b277820e6b40b] */
 /* generated from generate_rnc.c[b50e4b7ab1d04b2bc1d361a0811247c337b74934] */
 /* generated from generate_md.c[789b92e422631684352909cfb8bf43f6ceb16a01] */
 /* generated from generate_rst.c[3c4b523fbb57c8e4a7e247379d06a8021ccc21c4] */
 /* generated from generate_xsd.c[9bb91084fff7495aee9c025db3108549a0141957] */
-/* generated from generate_defconfig.c[02afff6935d72b7f04dc64c8a649b09f9f6143ac] */
+/* generated from generate_defconfig.c[ab6586fcd43cc01814507db687575914686943dc] */

--- a/src/core/ddsi/include/dds/ddsi/ddsi_config.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_config.h
@@ -188,6 +188,12 @@ enum ddsi_many_sockets_mode {
   DDSI_MSM_MANY_UNICAST
 };
 
+enum ddsi_interface_filtering {
+  DDSI_INTERFACE_FILTERING_OFF,
+  DDSI_INTERFACE_FILTERING_NORMAL,
+  DDSI_INTERFACE_FILTERING_STRICT
+};
+
 #ifdef DDS_HAS_SECURITY
 struct ddsi_plugin_library_properties {
   char *library_path;
@@ -437,6 +443,7 @@ struct ddsi_config
   int generate_keyhash;
   uint32_t max_sample_size;
   enum ddsi_boolean_default extended_packet_info;
+  enum ddsi_interface_filtering interface_filtering;
 
   /* compability options */
   enum ddsi_standards_conformance standards_conformance;

--- a/src/core/ddsi/include/dds/ddsi/ddsi_domaingv.h
+++ b/src/core/ddsi/include/dds/ddsi/ddsi_domaingv.h
@@ -183,6 +183,10 @@ struct ddsi_domaingv {
   /* whether we're using a link-local address (and therefore
      only listening to multicasts on that interface) */
   int using_link_local_intf;
+  /* The interface index of the loopback interface for implementing interface filtering
+     mode "normal". There may be multiple loopback interfaces, but it seems overkill to
+     support that. */
+  uint32_t loopback_if_index;
 
   /* Addressing: actual own (preferred) IP address, IP address
      advertised in discovery messages (so that an external IP address on

--- a/src/core/ddsi/src/ddsi__cfgelems.h
+++ b/src/core/ddsi/src/ddsi__cfgelems.h
@@ -2231,6 +2231,17 @@ static struct cfgelem discovery_cfgelems[] = {
     DESCRIPTION(
       "<p>This setting controls the default participant lease duration.<p>"),
     UNIT("duration")),
+  ENUM("InterfaceFiltering", NULL, 1, "normal",
+    MEMBER(interface_filtering),
+    FUNCTIONS(0, uf_interface_filtering, 0, pf_interface_filtering),
+    DESCRIPTION(
+      "<p>This element decides how strictly the participant discovery filters \n"
+      "on reception interface (requires extended packet info to be enabled, see \n"
+      "Internal/ExtendedPacketInfo:</p>\n"
+      "<ul><li><i>off</i>: no filtering</li>\n"
+      "<li><i>normal</i>: only the configured interfaces and loopback</li>\n"
+      "<li><i>strict</i>: only the configured interfaces</li></ul>\n"),
+    VALUES("off","strict","normal")),
   END_MARKER
 };
 

--- a/src/core/ddsi/src/ddsi_config.c
+++ b/src/core/ddsi/src/ddsi_config.c
@@ -198,6 +198,7 @@ DUPF(maybe_int32);
 DUPF(domainId);
 DUPF(transport_selector);
 DUPF(many_sockets_mode);
+DUPF(interface_filtering);
 DU(deaf_mute);
 #ifdef DDS_HAS_TCP_TLS
 DUPF(min_tls_version);
@@ -1118,6 +1119,10 @@ static const char *tracemask_names[] = {
 static const uint32_t tracemask_codes[] = {
   DDS_LC_FATAL, DDS_LC_ERROR, DDS_LC_WARNING, DDS_LC_INFO, DDS_LC_CONFIG, DDS_LC_DISCOVERY, DDS_LC_DATA, DDS_LC_RADMIN, DDS_LC_TIMING, DDS_LC_TRAFFIC, DDS_LC_TOPIC, DDS_LC_TCP, DDS_LC_PLIST, DDS_LC_WHC, DDS_LC_THROTTLE, DDS_LC_RHC, DDS_LC_CONTENT, DDS_LC_MALFORMED, DDS_LC_TYPELIB, DDS_LC_USER1, DDS_LC_USER2, DDS_LC_USER3, DDS_LC_USER, DDS_LC_ALL
 };
+
+static const char *en_interface_filtering_vs[] = { "off", "normal", "strict", NULL };
+static const enum ddsi_interface_filtering en_interface_filtering_ms[] = { DDSI_INTERFACE_FILTERING_OFF, DDSI_INTERFACE_FILTERING_NORMAL, DDSI_INTERFACE_FILTERING_STRICT, 0 };
+GENERIC_ENUM_CTYPE (interface_filtering, enum ddsi_interface_filtering)
 
 static enum update_result uf_tracemask (struct ddsi_cfgst *cfgst, UNUSED_ARG (void *parent), UNUSED_ARG (struct cfgelem const * const cfgelem), UNUSED_ARG (int first), const char *value)
 {

--- a/src/core/ddsi/src/ddsi_discovery_spdp.c
+++ b/src/core/ddsi/src/ddsi_discovery_spdp.c
@@ -367,7 +367,7 @@ static enum find_internal_interface_index_result find_internal_interface_index (
 
 static enum find_internal_interface_index_result find_internal_interface_index (const struct ddsi_domaingv *gv, uint32_t nwstack_if_index, int *internal_if_index)
 {
-  if (nwstack_if_index == 0)
+  if (nwstack_if_index == 0 || gv->config.interface_filtering == DDSI_INTERFACE_FILTERING_OFF)
     return FIIIR_NO_INFO;
   for (int i = 0; i < gv->n_interfaces; i++)
   {
@@ -376,6 +376,12 @@ static enum find_internal_interface_index_result find_internal_interface_index (
       *internal_if_index = i;
       return FIIIR_MATCH;
     }
+  }
+  if (gv->config.interface_filtering == DDSI_INTERFACE_FILTERING_NORMAL &&
+      nwstack_if_index == gv->loopback_if_index)
+  {
+    // not matched against one of ours, but we accept it nonetheless */
+    return FIIIR_NO_INFO;
   }
   return FIIIR_NO_MATCH;
 }

--- a/src/core/ddsi/src/ddsi_nwinterfaces.c
+++ b/src/core/ddsi/src/ddsi_nwinterfaces.c
@@ -529,6 +529,14 @@ int ddsi_gather_network_interfaces (struct ddsi_domaingv *gv)
     assert (maxq_list[i] < n_interfaces);
 #endif
 
+  gv->loopback_if_index = 0;
+  for (size_t i = 0; i < n_interfaces; i++) {
+    if (interfaces[i].loopback) {
+      gv->loopback_if_index = interfaces[i].if_index;
+      break;
+    }
+  }
+
   bool ok = true;
   gv->n_interfaces = 0;
 

--- a/src/core/ddsi/src/ddsi_nwinterfaces.c
+++ b/src/core/ddsi/src/ddsi_nwinterfaces.c
@@ -191,7 +191,7 @@ static enum maybe_add_interface_result maybe_add_interface (struct ddsi_domaingv
   if (ddsi_locator_from_sockaddr (gv->m_factory, &dst->loc, ifa->addr) < 0)
     return MAI_IGNORED;
   ddsi_locator_to_string_no_port(addrbuf, sizeof(addrbuf), &dst->loc);
-  GVLOG (DDS_LC_CONFIG, " %s(", addrbuf);
+  GVLOG (DDS_LC_CONFIG, " %s@%"PRIu32"(", addrbuf, ifa->index);
 
   bool link_local = false;
   bool loopback = false;

--- a/src/tools/_confgen/_confgen.h
+++ b/src/tools/_confgen/_confgen.h
@@ -54,6 +54,7 @@ void gendef_pf_transport_selector (FILE *fp, void *parent, struct cfgelem const 
 void gendef_pf_many_sockets_mode (FILE *fp, void *parent, struct cfgelem const * const cfgelem);
 void gendef_pf_standards_conformance (FILE *fp, void *parent, struct cfgelem const * const cfgelem);
 void gendef_pf_shm_loglevel (FILE *fp, void *parent, struct cfgelem const * const cfgelem);
+void gendef_pf_interface_filtering (FILE *fp, void *parent, struct cfgelem const * const cfgelem);
 void gendef_pf_uint32_array (FILE *out, void *parent, struct cfgelem const * const cfgelem);
 void gendef_pf_vendorid_list (FILE *fp, void *parent, struct cfgelem const * const cfgelem);
 

--- a/src/tools/_confgen/generate_defconfig.c
+++ b/src/tools/_confgen/generate_defconfig.c
@@ -200,6 +200,9 @@ void gendef_pf_standards_conformance (FILE *out, void *parent, struct cfgelem co
 void gendef_pf_shm_loglevel (FILE *out, void *parent, struct cfgelem const * const cfgelem) {
   gendef_pf_int (out, parent, cfgelem);
 }
+void gendef_pf_interface_filtering (FILE *out, void *parent, struct cfgelem const * const cfgelem) {
+  gendef_pf_int (out, parent, cfgelem);
+}
 void gendef_pf_uint32_array (FILE *out, void *parent, struct cfgelem const * const cfgelem) {
   (void) out;
   struct ddsi_config_uint32_array const * const p = cfg_address (parent, cfgelem);


### PR DESCRIPTION
On macOS, a unicast to (say) the Ethernet interface's configured IP address is delivered to the process as received over the Ethernet interface, but on Linux it is delivered as received over the loopback interface. This causes the discovery packets from participants on the same machine to be dropped if only the Ethernet interface is configured. That is almost never the desired behaviour.